### PR TITLE
fix(memory): exclude annotation carriers from recall text

### DIFF
--- a/extensions/active-memory/trigger-recall.test.ts
+++ b/extensions/active-memory/trigger-recall.test.ts
@@ -146,6 +146,25 @@ describe("active-memory trigger recall", () => {
     expect(context).not.toContain("Global deployment guidance.");
   });
 
+  it("excludes annotation carriers from injected trigger context", () => {
+    const matches = selectStrongTriggerMatches(
+      "Review the alpha deployment",
+      [
+        result({
+          snippet:
+            "Alpha-only deployment guidance. <!-- trigger: alpha deployment --> <!-- importance: 8 --> <!-- project: alpha-key -->",
+          triggers: "alpha deployment",
+          projectKey: "alpha-key",
+        }),
+      ],
+      ["alpha-key"],
+    );
+
+    const context = buildTriggerRecallContext(matches);
+    expect(context).toContain("Alpha-only deployment guidance.");
+    expect(context).not.toContain("<!--");
+  });
+
   it("blocks every oversized entry fragment when its project is inactive", () => {
     const fragments = [
       result({

--- a/extensions/active-memory/trigger-recall.ts
+++ b/extensions/active-memory/trigger-recall.ts
@@ -1,5 +1,8 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  stripMemoryAnnotationCarriers,
+  type MemorySearchResult,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { getActiveMemorySearchManager } from "openclaw/plugin-sdk/memory-host-search";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { buildPromptPrefix } from "./prompt.js";
@@ -119,7 +122,10 @@ export function buildTriggerRecallContext(matches: TriggerRecallMatch[]): string
     return undefined;
   }
   const summary = matches
-    .map((entry) => `- ${entry.snippet.trim()} (Source: ${entry.path}#L${String(entry.startLine)})`)
+    .map(
+      (entry) =>
+        `- ${stripMemoryAnnotationCarriers(entry.snippet).trim()} (Source: ${entry.path}#L${String(entry.startLine)})`,
+    )
     .join("\n");
   return buildPromptPrefix(truncateUtf16Safe(summary, MAX_TRIGGER_CONTEXT_CHARS));
 }

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -39,6 +39,7 @@ afterAll(() => {
 });
 
 let embedBatchCalls = 0;
+let embeddedBatchTexts: string[] = [];
 let embedBatchInputCalls = 0;
 let providerRuntimeBatchCalls: string[][] = [];
 let providerRuntimeBatchGate: Promise<void> | null = null;
@@ -189,6 +190,7 @@ vi.mock("./embeddings.js", () => {
           embedQuery: async (text: string) => embedText(text),
           embedBatch: async (texts: string[]) => {
             embedBatchCalls += 1;
+            embeddedBatchTexts.push(...texts);
             return texts.map(embedText);
           },
           ...(providerId === "gemini" || providerId === "fallback-provider"
@@ -321,6 +323,7 @@ describe("memory index", () => {
     vi.useRealTimers();
     clearRegistry();
     embedBatchCalls = 0;
+    embeddedBatchTexts = [];
     embedBatchInputCalls = 0;
     providerRuntimeBatchCalls = [];
     providerRuntimeBatchGate = null;
@@ -647,7 +650,7 @@ describe("memory index", () => {
       ].join("\n"),
     );
 
-    const manager = await getFreshManager(createCfg({ provider: "none" }));
+    const manager = await getFreshManager(createCfg({}));
     try {
       await manager.sync({ reason: "test", force: true });
       const db = Reflect.get(manager, "db") as DatabaseSync;
@@ -676,21 +679,21 @@ describe("memory index", () => {
       expect(memoryEntries).toHaveLength(3);
       expect(memoryEntries).toMatchObject([
         {
-          text: "- Alpha deploy preference. <!-- trigger: alpha deploy --> <!-- importance: 4 --> <!-- project: alpha-key -->\n  Keep the alpha gateway local.",
+          text: "- Alpha deploy preference.\n  Keep the alpha gateway local.",
           importance: 4,
           triggers: "alpha deploy",
           projectKey: "alpha-key",
           originClass: "agent",
         },
         {
-          text: "- Beta deploy preference. <!-- trigger: beta deploy --> <!-- importance: 9 --> <!-- project: beta-key -->",
+          text: "- Beta deploy preference.",
           importance: 9,
           triggers: "beta deploy",
           projectKey: "beta-key",
           originClass: "agent",
         },
         {
-          text: "- Global deploy preference. <!-- trigger: global defaults --> <!-- importance: 7 -->",
+          text: "- Global deploy preference.",
           importance: 7,
           triggers: "global defaults",
           projectKey: null,
@@ -715,6 +718,28 @@ describe("memory index", () => {
         projectKey: "path:/Users/Alice/Repo; path:/Users/alice/repo",
         originClass: "agent",
       });
+      expect(rows.every((row) => !row.text.includes("<!--"))).toBe(true);
+      expect(embeddedBatchTexts.length).toBeGreaterThan(0);
+      expect(embeddedBatchTexts.every((text) => !text.includes("<!--"))).toBe(true);
+
+      for (const query of ["trigger", "importance", "project"]) {
+        const annotationHits = await manager.search(query, {
+          lexicalOnly: true,
+          maxResults: 20,
+          minScore: 0,
+          sources: ["memory"],
+        });
+        expect(annotationHits).toEqual([]);
+      }
+
+      const bodyHits = await manager.search("Alpha deploy preference", {
+        lexicalOnly: true,
+        maxResults: 10,
+        minScore: 0,
+        sources: ["memory"],
+      });
+      expect(bodyHits[0]?.snippet).toContain("Alpha deploy preference.");
+      expect(bodyHits[0]?.snippet).not.toContain("<!--");
     } finally {
       await manager.close?.();
     }
@@ -881,8 +906,10 @@ describe("memory index", () => {
         .prepare("SELECT value FROM memory_index_meta WHERE key = 'memory_index_meta_v1'")
         .get() as { value: string };
       const currentMeta = JSON.parse(metaRow.value) as MemoryIndexMeta;
-      const legacyMeta: MemoryIndexMeta = { ...currentMeta };
-      delete legacyMeta.chunkingVersion;
+      const legacyMeta: MemoryIndexMeta = {
+        ...currentMeta,
+        chunkingVersion: MEMORY_CHUNKING_VERSION - 1,
+      };
 
       db.prepare("DELETE FROM memory_index_chunks WHERE path = ? AND source = 'memory'").run(
         "MEMORY.md",

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -22,6 +22,7 @@ import {
   remapChunkLines,
   retryTransientMemoryRead,
   runWithConcurrency,
+  stripMemoryAnnotationCarriers,
   type MemoryChunk,
   type MemorySource,
   type MemoryEntryProvenance,
@@ -1126,8 +1127,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     const perEntry =
       options.source === "memory" &&
       (normalizedEntryPath === "MEMORY.md" || normalizedEntryPath === "USER.md");
+    const indexingContent =
+      options.source === "memory" ? stripMemoryAnnotationCarriers(content) : content;
     const baseChunks = filterNonEmptyMemoryChunks(
-      chunkMarkdown(content, {
+      chunkMarkdown(indexingContent, {
         ...this.settings.chunking,
         perEntry,
       }),

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -248,6 +248,30 @@ describe("memory_search unavailable payloads", () => {
     expect(details.results.map((entry) => entry.score)).toEqual([1, 1, 1, 2]);
   });
 
+  it("excludes annotation carriers from surfaced search snippets", async () => {
+    setMemorySearchImpl(async () => [
+      {
+        path: "MEMORY.md",
+        startLine: 1,
+        endLine: 1,
+        score: 1,
+        snippet:
+          "Keep the gateway local. <!-- trigger: gateway setup --> <!-- importance: 9 --> <!-- project: alpha-key -->",
+        source: "memory" as const,
+      },
+    ]);
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+
+    const result = await tool.execute("clean-snippet", { query: "gateway", corpus: "memory" });
+    const details = result.details as { results: Array<{ snippet: string }> };
+    expect(details.results[0]?.snippet).toBe("Keep the gateway local.");
+  });
+
   it("passes the host local-service hook to tool memory managers", async () => {
     const acquireLocalService = vi.fn(async () => undefined);
     const tool = createMemorySearchTool({

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -1,8 +1,9 @@
 // Memory Core plugin module implements tools behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import type {
-  MemoryReadResult,
-  MemorySource,
+import {
+  stripMemoryAnnotationCarriers,
+  type MemoryReadResult,
+  type MemorySource,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   asToolParamsRecord,
@@ -756,7 +757,11 @@ export function createMemorySearchTool(options: {
                   rawResults = rawResults.filter((hit) => hit.source === "memory");
                 }
                 const status = activeMemory.manager.status();
-                const decorated = decorateCitations(rawResults, includeCitations);
+                const payloadResults = rawResults.map((result) => ({
+                  ...result,
+                  snippet: stripMemoryAnnotationCarriers(result.snippet),
+                }));
+                const decorated = decorateCitations(payloadResults, includeCitations);
                 const memoryResults =
                   status.backend === "qmd"
                     ? clampResultsByInjectedChars(

--- a/packages/memory-host-sdk/src/engine-storage.ts
+++ b/packages/memory-host-sdk/src/engine-storage.ts
@@ -17,6 +17,7 @@ export {
   remapChunkLines,
   runWithConcurrency,
   splitCuratedMarkdownEntries,
+  stripMemoryAnnotationCarriers,
   type CuratedMarkdownEntry,
   type CuratedProjectAnnotations,
   type MemoryChunk,

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -15,6 +15,7 @@ import {
   normalizeExtraMemoryPaths,
   remapChunkLines,
   runWithConcurrency,
+  stripMemoryAnnotationCarriers,
 } from "./internal.js";
 import { normalizeMemoryMultimodalSettings, type MemoryMultimodalSettings } from "./multimodal.js";
 
@@ -318,6 +319,25 @@ describe("memory host SDK package internals", () => {
       [5, 6],
       [7, 7],
     ]);
+  });
+
+  it("strips recall annotation carriers while preserving source line positions", () => {
+    const text = [
+      "- Keep the gateway local. <!-- trigger: gateway setup --> <!-- importance: 9 -->",
+      "  <!-- project: github.com/openclaw/openclaw -->",
+      "  Keep this ordinary <!-- note: visible --> comment.",
+    ].join("\n");
+
+    const stripped = stripMemoryAnnotationCarriers(text);
+
+    expect(stripped).toBe(
+      [
+        "- Keep the gateway local.",
+        "",
+        "  Keep this ordinary <!-- note: visible --> comment.",
+      ].join("\n"),
+    );
+    expect(stripped.split("\n")).toHaveLength(text.split("\n").length);
   });
 
   it("keeps promotion headings and markers out of neighboring entries", () => {

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -63,7 +63,7 @@ export type MemoryChunk = {
 };
 
 // Persisted with index metadata so boundary changes rebuild unchanged files.
-export const MEMORY_CHUNKING_VERSION = 1;
+export const MEMORY_CHUNKING_VERSION = 2;
 
 type MultimodalMemoryChunk = {
   chunk: MemoryChunk;
@@ -407,6 +407,19 @@ export type CuratedMarkdownEntry = {
 };
 
 export const INVALID_PROJECT_ANNOTATION_KEY = "!invalid-project-annotation";
+
+// Carrier syntax is line-scoped like recall metadata parsing. Never cross a
+// newline from an unterminated marker into the next entry's valid annotation.
+const MEMORY_ANNOTATION_CARRIER_RE = /<!--\s*(?:trigger|importance|project)\s*:[^\r\n]*?-->/giu;
+
+export function stripMemoryAnnotationCarriers(text: string): string {
+  let stripped = false;
+  const withoutCarriers = text.replace(MEMORY_ANNOTATION_CARRIER_RE, () => {
+    stripped = true;
+    return "";
+  });
+  return stripped ? withoutCarriers.replace(/[ \t]+(?=\r?$)/gmu, "") : text;
+}
 
 export type CuratedProjectAnnotations = {
   annotated: boolean;

--- a/src/agents/project-memory-bootstrap.test.ts
+++ b/src/agents/project-memory-bootstrap.test.ts
@@ -28,7 +28,8 @@ describe("project memory bootstrap", () => {
       startLine: 2,
       endLine: 2,
       score: 0.8,
-      snippet: "Use the release helper. <!-- project: github.com/OpenClaw/OpenClaw -->",
+      snippet:
+        "Use the release helper. <!-- trigger: release helper --> <!-- importance: 8 --> <!-- project: github.com/OpenClaw/OpenClaw -->",
       source: "memory" as const,
       projectKey: "github.com/OpenClaw/OpenClaw",
       importance: 8,
@@ -61,6 +62,7 @@ describe("project memory bootstrap", () => {
     const rendered = lines.join("\n");
     expect(rendered).toContain("Use the release helper.");
     expect(rendered).not.toContain("Foreign fact");
+    expect(rendered).not.toContain("<!--");
     expect(rendered.length).toBeLessThanOrEqual(2_000);
   });
 

--- a/src/agents/project-memory-bootstrap.ts
+++ b/src/agents/project-memory-bootstrap.ts
@@ -2,6 +2,7 @@ import {
   extractProjectKeysFromCuratedEntry,
   normalizeProjectAnnotationKey,
   splitCuratedMarkdownEntries,
+  stripMemoryAnnotationCarriers,
 } from "../../packages/memory-host-sdk/src/engine-storage.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { MemorySearchResult } from "../memory-host-sdk/host/types.js";
@@ -44,13 +45,6 @@ export function filterProjectScopedCuratedContextFiles(params: {
       .join("\n");
     return content === file.content ? file : { path: file.path, content };
   });
-}
-
-function cleanProjectMemorySnippet(value: string): string {
-  return value
-    .replace(/<!--\s*(?:trigger|importance|project)\s*:[\s\S]*?-->/giu, "")
-    .replace(/\s+/gu, " ")
-    .trim();
 }
 
 function truncateEntry(value: string, maxChars: number): string {
@@ -106,7 +100,7 @@ function buildProjectMemoryBootstrap(params: {
   }
   for (const entry of candidates) {
     const snippet = truncateEntry(
-      cleanProjectMemorySnippet(entry.snippet),
+      stripMemoryAnnotationCarriers(entry.snippet).replace(/\s+/gu, " ").trim(),
       PROJECT_MEMORY_ENTRY_MAX_CHARS,
     );
     if (!snippet) {

--- a/src/plugin-sdk/memory-core-host-engine-storage.ts
+++ b/src/plugin-sdk/memory-core-host-engine-storage.ts
@@ -49,6 +49,7 @@ export {
   runWithConcurrency,
   splitCuratedMarkdownEntries,
   statRegularFile,
+  stripMemoryAnnotationCarriers,
 } from "../../packages/memory-host-sdk/src/engine-storage.js";
 
 export type {


### PR DESCRIPTION
## What Problem This Solves

Curated memory annotations such as `<!-- trigger: ... -->`, `<!-- importance: N -->`, and `<!-- project: key -->` were lifted into SQLite columns but also remained in the built-in chunk text. That made FTS match annotation syntax and project-key fragments, polluted embedding inputs, and exposed metadata comments through trigger injection and `memory_search` snippets.

Verification found one requested surface was already partially handled: the project-memory bootstrap digest already removed all three carrier types. Raw bootstrap files were intentionally left unchanged. The real gaps were indexed text, embeddings, FTS, trigger payloads, and surfaced search snippets.

## Why This Change Was Made

A shared memory-host helper now removes only the recognized, line-scoped annotation carriers while preserving raw Markdown and source line positions. Built-in memory text is cleaned before chunking, so chunk hashes, embedding inputs, SQLite chunk text, and FTS all use the same carrier-free form. Trigger recall, the existing project digest, and `memory_search` payloads use the same helper; metadata parsing still reads the raw content, so annotation columns and invalid-annotation fail-close behavior are unchanged.

`MEMORY_CHUNKING_VERSION` advances from 1 to 2 so the cache-class shadow reindex rebuilds existing indexes without a doctor migration, following #115438.

This change is AI-assisted and was reviewed with the repository autoreview workflow.

## User Impact

Memory searches no longer match entries merely because their metadata contains words such as `trigger`, `importance`, or project-key fragments. Embeddings represent the memory body instead of annotation syntax, and model-visible trigger/search/bootstrap-digest text no longer includes the recognized HTML comments. Raw memory files and their lifted metadata remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/internal.test.ts extensions/active-memory/trigger-recall.test.ts src/agents/project-memory-bootstrap.test.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory/index.test.ts` — 189 tests passed on the rebased head.
- Index regressions prove annotation-token FTS queries return no hit, embedding batches receive no carrier text, search snippets are clean, metadata columns still round-trip, and the previous chunking version forces reindex.
- `node scripts/check-changed.mjs -- <12 touched files>` — all formatting, SDK surface/contracts, dead-export, core/extension typecheck, lint, database-first, schema, boundary, and import-cycle gates passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30430014361
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex` — clean, no accepted/actionable findings (0.94 confidence).
