### PR TITLE
fix(ui): keep custodian startup errors near composer

### DIFF
--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -147,6 +147,57 @@ describeControlUiE2e("Control UI custodian event nudge mocked Gateway E2E", () =
     }
   });
 
+  it("keeps a blocking startup error next to the composer", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(uiProofArtifactDir, { recursive: true });
+    }
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1200, width: 1600 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["openclaw.chat"],
+      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}custodian`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("openclaw.chat");
+      await gateway.rejectDeferred("openclaw.chat", {
+        code: "UNAVAILABLE",
+        message:
+          "OpenClaw requires working inference: No agent model is configured. Run `openclaw onboard` first.",
+        retryable: true,
+      });
+
+      const alert = page.getByRole("alert");
+      await alert.waitFor();
+      const composer = page.locator(".agent-chat__composer-shell");
+      const [alertBox, composerBox] = await Promise.all([
+        alert.boundingBox(),
+        composer.boundingBox(),
+      ]);
+      expect(alertBox).not.toBeNull();
+      expect(composerBox).not.toBeNull();
+
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "04-inference-error.png"),
+        });
+      }
+
+      const verticalGap = composerBox!.y - (alertBox!.y + alertBox!.height);
+      expect(verticalGap).toBeLessThanOrEqual(32);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps event nudges out of sensitive wizard input", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -80,6 +80,26 @@ describe("custodian page", () => {
     expect(connectOption.disabled).toBe(true);
   });
 
+  it("collapses an empty transcript around a blocking startup error", async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "OpenClaw requires working inference: No agent model is configured. Run `openclaw onboard` first.",
+        ),
+      );
+    const { context } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    await waitForFast(() =>
+      expect(page.querySelector(".custodian-surface--empty-error")).not.toBeNull(),
+    );
+    expect(page.querySelector("[role=alert]")?.textContent).toContain(
+      "No agent model is configured",
+    );
+  });
+
   it.each([
     { pathname: "/settings/channels", expectedPage: "channels" },
     { pathname: "/not-an-openclaw-route", expectedPage: undefined },

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -92,8 +92,13 @@ class CustodianSurface extends OpenClawLightDomElement {
   override render() {
     const store = this.store;
     const assistantAvatar = controlUiPublicAssetPath("favicon.svg", this.context.basePath);
+    const emptyError = store.messages.length === 0 && store.error !== null && !store.sending;
     return html`
-      <section class="custodian-surface ${this.compact ? "custodian-surface--panel" : ""}">
+      <section
+        class="custodian-surface ${this.compact ? "custodian-surface--panel" : ""} ${emptyError
+          ? "custodian-surface--empty-error"
+          : ""}"
+      >
         <div class="custodian__messages" aria-live="polite">
           ${!this.onboarding && store.eventNudge && !store.eventNudgePending
             ? eventNudgeState.renderCustodianEventNudge({

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -21,6 +21,11 @@
   min-height: 0;
 }
 
+.custodian-surface--empty-error {
+  grid-template-rows: auto auto auto;
+  align-content: start;
+}
+
 .custodian > openclaw-custodian-surface {
   display: block;
   height: 100%;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Ask OpenClaw users who hit a blocking inference/setup error would see the disabled composer pinned nearly a full viewport below the error banner.

## Why This Change Was Made

The shared custodian surface now switches to content-sized grid rows only when the transcript is empty and a settled error is visible. Normal conversations and the docked panel keep the existing fill-height chat layout.

## User Impact

Blocking startup errors and their composer now stay together near the top of the page instead of leaving a huge empty gap.

## Evidence

- Deterministic Chromium reproduction at 1600×1200: vertical alert-to-composer gap drops from `957.9px` to `32px`.
- `node scripts/run-vitest.mjs ui/src/pages/custodian/custodian-page.test.ts ui/src/components/custodian/custodian-panel.test.ts` — 32 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/custodian-event-nudge.e2e.test.ts` — 5 tests passed.
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox.
- Final autoreview after rebasing onto current `main`: clean, no accepted/actionable findings.
- Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30429218787
