### PR TITLE
fix(memory): prevent phantom memory continuation pages

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -5865,9 +5865,9 @@ describe("QmdMemoryManager", () => {
       const readResult = await manager.readFile({ relPath: result.path });
       expect(readResult).toEqual({
         path: "qmd/sessions-main/session-1.md",
-        text: "# Session session-1\n\nsession canary\n",
+        text: "# Session session-1\n\nsession canary",
         from: 1,
-        lines: 4,
+        lines: 3,
       });
     } finally {
       lstatSpy.mockRestore();

--- a/packages/memory-host-sdk/src/host/read-file-shared.test.ts
+++ b/packages/memory-host-sdk/src/host/read-file-shared.test.ts
@@ -3,6 +3,50 @@ import { describe, expect, it } from "vitest";
 import { buildMemoryReadResult, buildMemoryReadResultFromSlice } from "./read-file-shared.js";
 
 describe("memory read result slicing", () => {
+  it.each([
+    {
+      name: "a terminal newline",
+      content: "one\ntwo\n",
+      requestedLines: 2,
+      text: "one\ntwo",
+      lines: 2,
+    },
+    {
+      name: "an empty file",
+      content: "",
+      requestedLines: 2,
+      text: "",
+      lines: 0,
+    },
+    {
+      name: "one intentional trailing blank line",
+      content: "one\n\n",
+      requestedLines: 2,
+      text: "one\n",
+      lines: 2,
+    },
+    {
+      name: "two intentional trailing blank lines",
+      content: "one\n\n\n",
+      requestedLines: 3,
+      text: "one\n\n",
+      lines: 3,
+    },
+  ])("does not expose a phantom continuation for $name", (fixture) => {
+    expect(
+      buildMemoryReadResult({
+        content: fixture.content,
+        relPath: "memory/test.md",
+        lines: fixture.requestedLines,
+      }),
+    ).toEqual({
+      text: fixture.text,
+      path: "memory/test.md",
+      from: 1,
+      lines: fixture.lines,
+    });
+  });
+
   it("uses default line windows for non-finite from and lines values", () => {
     expect(
       buildMemoryReadResult({

--- a/packages/memory-host-sdk/src/host/read-file-shared.ts
+++ b/packages/memory-host-sdk/src/host/read-file-shared.ts
@@ -113,6 +113,11 @@ export function buildMemoryReadResult(params: {
   suggestReadFallback?: boolean;
 }): MemoryReadResult {
   const fileLines = params.content.split("\n");
+  // A terminal newline closes the preceding line; its split sentinel is not a
+  // readable blank line or a reason to offer another memory page.
+  if (fileLines.at(-1) === "") {
+    fileLines.pop();
+  }
   const start = normalizePositiveInteger(params.from, 1);
   const requestedCount = normalizePositiveInteger(
     params.lines ?? params.defaultLines,


### PR DESCRIPTION
Closes #114313
Related contributor investigation: #114319 (thank you @kevin2966n).

## What Problem This Solves

Memory reads counted the empty split sentinel after a terminal newline as a real source line. Exact-window reads therefore advertised nonexistent continuation pages, and empty files incorrectly reported one readable line.

## Why This Change Was Made

Remove exactly the synthetic terminal split element in the existing private memory-read owner. Preserve intentional trailing blank lines, bounded line and character windows, Unicode-safe truncation, and both native and QMD memory-reader semantics. Update the QMD session-reader integration to assert the corrected real line count. No configuration, SQLite schema, dependency, migration, protocol, or public Plugin SDK changes.

## User Impact

Memory-file pagination stops exactly at the real end of the file. Empty memory files report zero lines, and intentional interior or trailing blank lines remain readable.

## Evidence

- Genuine failing-before proof on fresh main: all four terminal-newline, empty-file, one-blank-line, and two-blank-line regression cases fail before the fix.
- Exact final commit `27cfa63ba53c8e8304b0d673069afeee6cbd6866`: all 186 focused memory-host, native memory reader, and real QMD manager tests pass on Blacksmith Testbox.
- Real runtime proof `REAL_MEMORY_READ_PAGINATION_PASS` exercises all four production-reader boundaries and verifies zero phantom continuation pages.
- Exact-head full `CI=1 pnpm check:changed`: passed, including changed-file formatting, core and extension test typechecks, typed lint, dead-export scans, plugin and SQLite guards, and runtime import cycles.
- Exact-commit extra-high-effort independent autoreview: clean, confidence 0.96.
