### PR TITLE
fix(doctor): preserve config includes during cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Doctor config includes:** preserve authored `$include` directives during unknown-key cleanup at every config depth, preventing `openclaw doctor --fix` from silently deleting include-owned subtrees.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Doctor config includes:** preserve authored `$include` directives during unknown-key cleanup at every config depth, preventing `openclaw doctor --fix` from silently deleting include-owned subtrees.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/src/commands/doctor-config-analysis.test.ts
+++ b/src/commands/doctor-config-analysis.test.ts
@@ -92,6 +92,63 @@ describe("doctor config analysis helpers", () => {
     });
   });
 
+  it.each([
+    {
+      name: "the config root",
+      config: { $include: "./base.json5", unexpected: true },
+      path: [],
+    },
+    {
+      name: "an agent entry identity",
+      config: {
+        agents: {
+          entries: {
+            main: { identity: { $include: "./main-identity.json5" } },
+          },
+        },
+        unexpected: true,
+      },
+      path: ["agents", "entries", "main", "identity"],
+    },
+    {
+      name: "an agent entry",
+      config: {
+        agents: { entries: { main: { $include: "./main-agent.json5" } } },
+        unexpected: true,
+      },
+      path: ["agents", "entries", "main"],
+    },
+    {
+      name: "agent defaults",
+      config: {
+        agents: { defaults: { $include: "./agent-defaults.json5" } },
+        unexpected: true,
+      },
+      path: ["agents", "defaults"],
+    },
+    {
+      name: "gateway config",
+      config: { gateway: { $include: "./gateway.json5" }, unexpected: true },
+      path: ["gateway"],
+    },
+    {
+      name: "an array entry",
+      config: {
+        plugins: { load: { paths: [{ $include: "./plugin-path.json5" }] } },
+        unexpected: true,
+      },
+      path: ["plugins", "load", "paths", 0],
+    },
+  ])("preserves include syntax at $name while stripping unknown keys", ({ config, path }) => {
+    const result = stripUnknownConfigKeys(config as never);
+
+    expect(result.removed).toContain("unexpected");
+    expect(result.removed).not.toContain(formatConfigPath([...path, "$include"]));
+    expect(resolveConfigPathTarget(result.config, path)).toMatchObject({
+      $include: expect.any(String),
+    });
+  });
+
   describe("stripUnknownConfigKeys during update", () => {
     const originalEnv = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
 

--- a/src/commands/doctor-config-analysis.ts
+++ b/src/commands/doctor-config-analysis.ts
@@ -4,6 +4,7 @@ import { resolvePrimaryStringValue } from "@openclaw/normalization-core/string-c
 import type { ZodIssue } from "zod";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { CONFIG_PATH } from "../config/config.js";
+import { INCLUDE_KEY } from "../config/includes.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { OpenClawSchema } from "../config/zod-schema.js";
@@ -110,6 +111,11 @@ export function stripUnknownConfigKeys(config: OpenClawConfig): {
       issuePath.length === 0 ? undefined : parentKey ? STRIP_PROTECTED_KEYS[parentKey] : undefined;
     for (const key of issue.keys) {
       if (typeof key !== "string" || !(key in record)) {
+        continue;
+      }
+      // $include is authored parser syntax at every object depth, not a schema field.
+      // Doctor validates raw source, so stripping it would destroy include-owned config.
+      if (key === INCLUDE_KEY) {
         continue;
       }
       if (protectedSet?.has(key)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw doctor --fix` could lose any config subtree authored through a nested `$include`. Doctor treated the include directive as an unknown schema key and rewrote shapes such as `agents.entries.main.identity` to an empty object.

## Why This Change Was Made

Unknown-key cleanup now recognizes `$include` as authored parser syntax at every object depth while continuing to remove genuine unknown siblings. The regression matrix covers root, gateway, agent defaults, whole agent entries, nested identity, and array positions rather than special-casing one schema field.

Provenance: the cleanup behavior was introduced by commit 8e33bd86101621d0097213311a9b629d27356296 on 2026-01-20; code author and committer were @steipete. No PR is associated with that commit.

## User Impact

`openclaw doctor --fix` preserves include-owned configuration instead of silently deleting the directive and its effective subtree.

## Evidence

- Before the fix, the focused regression had 5 failures: root, gateway, agent defaults, agent entry, and nested identity includes were removed.
- `node scripts/run-vitest.mjs src/commands/doctor-config-analysis.test.ts` — 33 tests passed.
- Source-blind CLI proof: a temporary config with `agents.entries.main.identity.$include` plus an unknown root key was repaired with `openclaw doctor --fix --non-interactive`; Doctor removed only the unknown key, preserved the include directive, and left the included file unchanged.
- Remote `node scripts/check-changed.mjs -- src/commands/doctor-config-analysis.ts src/commands/doctor-config-analysis.test.ts CHANGELOG.md` — passed on Blacksmith Testbox.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings.

AI-assisted: yes. The author reviewed the code, reproduction, and generated-file proof.
