### PR TITLE
fix(reply): honor the configured default agent for authenticated auto-replies

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
@@ -151,4 +151,94 @@ describe("runPreflightCompactionIfNeeded stale totalTokens gating", () => {
 
     expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    {
+      name: "the configured roster default for an embedded provider",
+      runAgentId: undefined,
+      expectedAgentId: "ops",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      expectsCompaction: true,
+    },
+    {
+      name: "the explicitly prepared agent for an embedded provider",
+      runAgentId: "worker",
+      expectedAgentId: "worker",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      expectsCompaction: true,
+    },
+    {
+      name: "the configured roster default before provider runtime selection",
+      runAgentId: undefined,
+      expectedAgentId: "ops",
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      expectsCompaction: false,
+    },
+    {
+      name: "the explicitly prepared agent before provider runtime selection",
+      runAgentId: "worker",
+      expectedAgentId: "worker",
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      expectsCompaction: false,
+    },
+  ])(
+    "resolves an unscoped session key with $name",
+    async ({ runAgentId, expectedAgentId, provider, model, expectsCompaction }) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      const storePath = path.join(rootDir, "sessions.json");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(2_000) } })}\n`,
+        "utf8",
+      );
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        sessionFile,
+        updatedAt: Date.now(),
+        totalTokens: 200_000,
+        totalTokensFresh: true,
+      };
+      await writeTestSessionStore(storePath, "main", sessionEntry);
+
+      const result = await runPreflightCompactionIfNeeded({
+        cfg: {
+          agents: {
+            list: [{ id: "ops", default: true }, { id: "worker" }],
+            defaults: { compaction: { memoryFlush: {} } },
+          },
+        },
+        followupRun: createTestFollowupRun({
+          agentId: runAgentId,
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "main",
+          provider,
+          model,
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100_000,
+        sessionEntry,
+        sessionStore: { main: sessionEntry },
+        sessionKey: "main",
+        storePath,
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+      });
+
+      expect(result).toBe(sessionEntry);
+      if (expectsCompaction) {
+        expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sessionTarget: expect.objectContaining({ agentId: expectedAgentId }),
+          }),
+        );
+      } else {
+        expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+      }
+    },
+  );
 });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -7,6 +7,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
 import { estimateMessagesTokens } from "../../agents/compaction.js";
@@ -295,7 +296,7 @@ function resolveFollowupAgentRuntimeId(params: FollowupRuntimeParams): string {
     cfg: params.cfg,
     provider: params.followupRun.run.provider,
     modelId: params.followupRun.run.model,
-    agentId: params.followupRun.run.agentId,
+    agentId: params.followupRun.run.agentId ?? resolveDefaultAgentId(params.cfg),
     sessionKey:
       params.runtimePolicySessionKey ??
       params.sessionKey ??
@@ -802,13 +803,10 @@ export async function runPreflightCompactionIfNeeded(params: {
   if (!compactionSessionKey) {
     return entry ?? params.sessionEntry;
   }
-  const keyAgentId = resolveAgentIdFromSessionKey(
-    compactionSessionKey,
-    params.followupRun.run.agentId,
-  );
+  const configuredAgentId = params.followupRun.run.agentId ?? resolveDefaultAgentId(params.cfg);
   const compactionAgentId = isUnscopedSessionKeySentinel(compactionSessionKey)
-    ? (params.followupRun.run.agentId ?? keyAgentId ?? "main")
-    : (keyAgentId ?? params.followupRun.run.agentId ?? "main");
+    ? configuredAgentId
+    : resolveAgentIdFromSessionKey(compactionSessionKey, configuredAgentId);
   const compactionStorePath = resolveSessionStorePathForScope({
     agentId: compactionAgentId,
     sessionKey: compactionSessionKey,

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 import {
   formatEmbeddedAgentQueueFailureSummary,
   queueEmbeddedAgentMessageWithOutcomeAsync,
@@ -426,6 +427,7 @@ export async function runReplyAgent(
     originatingAccountId: followupRun.originatingAccountId,
     agentAccountId: followupRun.run.agentAccountId,
   });
+  followupRun.run.agentId ??= resolveDefaultAgentId(followupRun.run.config);
 
   const replyToChannel = resolveOriginMessageProvider({
     originatingChannel: sessionCtx.OriginatingChannel,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   applySessionEntryLifecycleMutation,
@@ -1080,6 +1081,109 @@ describe("runReplyAgent heartbeat followup guard", () => {
 });
 
 describe("runReplyAgent pending final delivery capture", () => {
+  it("delivers an authenticated channel reply through the configured default agent", async () => {
+    const config = {
+      agents: {
+        list: [{ id: "ops", default: true }, { id: "worker" }],
+        defaults: { compaction: { memoryFlush: {} } },
+      },
+    };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+    const storePath = join(
+      tempDirs.make("openclaw-custom-default-agent-"),
+      "agents",
+      "ops",
+      "sessions",
+      "sessions.json",
+    );
+    await replaceSessionEntry(
+      { agentId: "ops", defaultAgentId: "ops", sessionKey: "main", storePath },
+      sessionEntry,
+    );
+    const sessionCtx = {
+      Provider: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "channel:24680",
+      MessageSid: "custom-default-source-message",
+      SenderId: "sender-42",
+      SenderName: "Ada",
+    } as const;
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "custom default agent reply" }],
+      meta: {},
+    });
+    const { followupRun, run, sourceTurnId } = createMinimalRun({
+      sessionCtx,
+      runOverrides: {
+        agentId: undefined,
+        config,
+        messageProvider: "discord",
+      },
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      storePath,
+    });
+    if (!sourceTurnId) {
+      throw new Error("test channel source turn id required");
+    }
+    followupRun.userTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
+      input: {
+        text: "custom default agent request",
+        idempotencyKey: sourceTurnId,
+        sender: { id: "sender-42", name: "Ada" },
+      },
+      target: {
+        agentId: "ops",
+        config,
+        cwd: "/tmp",
+        sessionEntry,
+        sessionId: "session",
+        sessionKey: "main",
+        sessionStore,
+        storePath,
+      },
+    });
+
+    setRuntimeConfigSnapshot(config, config);
+    try {
+      await expect(run()).resolves.toEqual(
+        expect.objectContaining({ text: "custom default agent reply" }),
+      );
+
+      expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
+      expect(
+        await loadTranscriptEvents({
+          agentId: "ops",
+          sessionId: "session",
+          sessionKey: "main",
+          storePath,
+        }),
+      ).toContainEqual(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            role: "user",
+            content: "custom default agent request",
+          }),
+        }),
+      );
+      expect(await readStoredMainSession(storePath)).toMatchObject({
+        pendingFinalDelivery: {
+          kind: "replayable",
+          text: "custom default agent reply",
+          context: { channel: "discord", to: "channel:24680" },
+        },
+        restartRecoveryTerminalRunIds: [sourceTurnId],
+      });
+    } finally {
+      clearRuntimeConfigSnapshot();
+    }
+  });
+
   it("does not persist message-tool-only final replies for heartbeat replay", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users whose configured default agent is not `main` could lose an authenticated channel reply when a legacy or unscoped session has no prepared agent ID.

## Why This Change Was Made

Resolve the configured default from the active runtime configuration before reply admission, and consistently carry the prepared owner into runtime selection, compaction, transcript persistence, and restart recovery. Explicit agent IDs and provider-owned native compaction remain unchanged.

## User Impact

Authenticated channel messages are handled by the configured default agent, stored in that agent SQLite session, and retain the visible final reply and replayable recovery state.

## Evidence

- Fail-first authenticated Discord end-to-end test: unpatched code rejects the turn with `Session key does not contain an agent id; resolve it with the configured default agent`; patched code returns the visible reply and persists the user transcript and replayable final under the actual `ops` agent SQLite session.
- Repaired-current-main final head: 382 of 382 focused auto-reply, routing, provider failure, recovery, and delivery regressions passed.
- Exact final-commit full changed-file gate passed: production and test type-checking, zero-warning lint, formatting, plugin and SDK ownership, dead exports, database-first storage, and security guards.
- Independent Codex extra-high-effort review: no actionable findings.
- Remote proof: https://github.com/openclaw/openclaw/actions/runs/30429958521
- Baseline disclosure: on original base `5f43fa021ece2d845e2543755a0cb72d519d58d2`, the complete existing end-to-end file already contained 16 unrelated failures, covering provider fallback and old canonical-storage expectations. This pull request proves the exact new authenticated custom-default regression and does not claim to fix #80700.
- AI-assisted.