### PR TITLE
fix(whatsapp): send filename-only media as native attachments

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.filename-media.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.filename-media.test.ts
@@ -1,0 +1,190 @@
+// WhatsApp tests prove filename-derived media facts reach native delivery.
+import { describe, expect, it, vi } from "vitest";
+import { createAcceptedWhatsAppSendResult } from "../inbound/send-result.test-helper.js";
+import { createTestWebInboundMessage } from "../inbound/test-message.test-helper.js";
+import type { AdmittedWebInboundMessage } from "../inbound/types.js";
+import { loadWebMedia } from "../media.js";
+import { deliverWebReply } from "./deliver-reply.js";
+
+const hoisted = vi.hoisted(() => ({
+  transcodeAudioBufferToOpus: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/media-runtime")>(
+    "openclaw/plugin-sdk/media-runtime",
+  );
+  return { ...actual, transcodeAudioBufferToOpus: hoisted.transcodeAudioBufferToOpus };
+});
+
+vi.mock("../media.js", () => ({ loadWebMedia: vi.fn() }));
+
+describe("WhatsApp filename-only media delivery", () => {
+  it.each([
+    {
+      fileName: "photo.png",
+      contentType: undefined,
+      payloadKey: "image",
+      mimetype: "image/png",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "clip.mp4",
+      contentType: undefined,
+      payloadKey: "video",
+      mimetype: "video/mp4",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "voice.ogg",
+      contentType: undefined,
+      payloadKey: "audio",
+      mimetype: "audio/ogg; codecs=opus",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "voice.mp3",
+      contentType: undefined,
+      payloadKey: "audio",
+      mimetype: "audio/ogg; codecs=opus",
+      expectedBuffer: "opus-output",
+    },
+    {
+      fileName: "report.pdf",
+      contentType: undefined,
+      payloadKey: "document",
+      mimetype: "application/pdf",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "unknown.bin",
+      contentType: undefined,
+      payloadKey: "document",
+      mimetype: "application/octet-stream",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "photo.png",
+      contentType: "application/octet-stream",
+      payloadKey: "image",
+      mimetype: "image/png",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "clip.mp4",
+      contentType: "application/octet-stream",
+      payloadKey: "video",
+      mimetype: "video/mp4",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "voice.ogg",
+      contentType: "application/octet-stream",
+      payloadKey: "audio",
+      mimetype: "audio/ogg; codecs=opus",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "voice.mp3",
+      contentType: "application/octet-stream",
+      payloadKey: "audio",
+      mimetype: "audio/ogg; codecs=opus",
+      expectedBuffer: "opus-output",
+    },
+    {
+      fileName: "report.pdf",
+      contentType: "application/octet-stream",
+      payloadKey: "document",
+      mimetype: "application/pdf",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "unknown.bin",
+      contentType: "application/octet-stream",
+      payloadKey: "document",
+      mimetype: "application/octet-stream",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "photo.png",
+      contentType: "image/jpeg",
+      payloadKey: "image",
+      mimetype: "image/jpeg",
+      expectedBuffer: "filename-only-media",
+    },
+    {
+      fileName: "photo.png",
+      contentType: "application/pdf",
+      payloadKey: "document",
+      mimetype: "application/pdf",
+      expectedBuffer: "filename-only-media",
+    },
+  ] as const)(
+    "delivers $fileName with $contentType as native $mimetype",
+    async ({ fileName, contentType, payloadKey, mimetype, expectedBuffer }) => {
+      vi.clearAllMocks();
+      hoisted.transcodeAudioBufferToOpus.mockResolvedValue(Buffer.from("opus-output"));
+      vi.mocked(loadWebMedia).mockResolvedValueOnce({
+        buffer: Buffer.from("filename-only-media"),
+        contentType,
+        fileName,
+        kind:
+          contentType === "application/octet-stream" || contentType === "application/pdf"
+            ? "document"
+            : contentType === "image/jpeg"
+              ? "image"
+              : undefined,
+      });
+      const sendMedia = vi
+        .fn<AdmittedWebInboundMessage["platform"]["sendMedia"]>()
+        .mockResolvedValue(createAcceptedWhatsAppSendResult("media", "media-1"));
+      const reply = vi
+        .fn<AdmittedWebInboundMessage["platform"]["reply"]>()
+        .mockResolvedValue(createAcceptedWhatsAppSendResult("text", "text-1"));
+      const msg = createTestWebInboundMessage({
+        event: { id: "msg-1" },
+        payload: { body: "hello" },
+        platform: {
+          chatJid: "15551234567@s.whatsapp.net",
+          recipientJid: "+20000000000",
+          senderJid: "222@s.whatsapp.net",
+          reply,
+          sendMedia,
+        },
+        admission: {
+          accountId: "work",
+          conversation: { kind: "group", id: "+10000000000" },
+          sender: { id: "222@s.whatsapp.net" },
+          senderAccess: { reasonCode: "group_policy_allowed" },
+        },
+      });
+
+      await deliverWebReply({
+        replyResult: { text: "caption", mediaUrl: "https://example.com/download" },
+        msg,
+        maxMediaBytes: 1024 * 1024,
+        textLimit: 200,
+        replyLogger: { info: vi.fn(), warn: vi.fn() },
+        skipLog: true,
+      });
+
+      expect(sendMedia).toHaveBeenCalledOnce();
+      const mediaPayload = sendMedia.mock.calls[0]?.[0];
+      expect(mediaPayload).toMatchObject({
+        [payloadKey]: Buffer.from(expectedBuffer),
+        mimetype,
+      });
+      if (payloadKey === "audio") {
+        expect(mediaPayload).toHaveProperty("ptt", true);
+        expect(reply).toHaveBeenCalledWith("caption", undefined);
+      } else {
+        expect(mediaPayload).toHaveProperty("caption", "caption");
+      }
+      if (payloadKey === "document") {
+        expect(mediaPayload).toHaveProperty("fileName", fileName);
+      } else {
+        expect(mediaPayload).not.toHaveProperty("document");
+      }
+    },
+  );
+});

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -1,7 +1,11 @@
 // Whatsapp plugin module implements outbound media contract behavior.
 import path from "node:path";
 import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
-import { mediaKindFromMime, normalizeMimeType } from "openclaw/plugin-sdk/media-mime";
+import {
+  mediaKindFromMime,
+  mimeTypeFromFilePath,
+  normalizeMimeType,
+} from "openclaw/plugin-sdk/media-mime";
 import type { MediaKind } from "openclaw/plugin-sdk/media-mime";
 import {
   MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS,
@@ -117,16 +121,22 @@ export function normalizeWhatsAppOutboundPayload<T extends WhatsAppOutboundPaylo
 
 function inferWhatsAppMediaKind(
   media: WhatsAppLoadedMediaLike,
+  resolvedContentType?: string,
 ): CanonicalWhatsAppLoadedMedia["kind"] {
+  // Generic binary responses are initially classified as documents; let a
+  // real filename recover their native family instead of preserving that guess.
+  const isGenericDocument =
+    media.kind === "document" &&
+    normalizeMimeType(media.contentType) === "application/octet-stream";
   if (
     media.kind === "image" ||
     media.kind === "audio" ||
     media.kind === "video" ||
-    media.kind === "document"
+    (media.kind === "document" && !isGenericDocument)
   ) {
     return media.kind;
   }
-  const inferredKind = mediaKindFromMime(normalizeMimeType(media.contentType));
+  const inferredKind = mediaKindFromMime(normalizeMimeType(resolvedContentType));
   return !inferredKind || inferredKind === "sticker" || inferredKind === "unknown"
     ? "document"
     : inferredKind;
@@ -136,11 +146,26 @@ function normalizeWhatsAppLoadedMedia(
   media: WhatsAppLoadedMediaLike,
   mediaUrl?: string,
 ): CanonicalWhatsAppLoadedMedia {
-  const kind = inferWhatsAppMediaKind(media);
+  // Infer the kind and native payload MIME from the same filename fact; Baileys
+  // does not replace an explicit application/octet-stream on images or videos.
+  const filenameMimeType = mimeTypeFromFilePath(media.fileName);
+  const normalizedContentType = normalizeMimeType(media.contentType);
+  const resolvedContentType =
+    !normalizedContentType || normalizedContentType === "application/octet-stream"
+      ? (filenameMimeType ?? media.contentType)
+      : media.contentType;
+  const kind = inferWhatsAppMediaKind(media, resolvedContentType);
+  // Match the existing URL/filename voice rule used by the transcode decision;
+  // otherwise native .ogg/.opus uploads carry an inconsistent payload MIME.
   const mimetype =
-    kind === "audio" && isWhatsAppNativeVoiceAudio({ contentType: media.contentType, mediaUrl })
+    kind === "audio" &&
+    isWhatsAppNativeVoiceAudio({
+      contentType: media.contentType,
+      fileName: media.fileName,
+      mediaUrl,
+    })
       ? WHATSAPP_VOICE_MIMETYPE
-      : (media.contentType ?? "application/octet-stream");
+      : (resolvedContentType ?? "application/octet-stream");
   const fileName =
     kind === "document"
       ? resolveWhatsAppDocumentFileName({


### PR DESCRIPTION
Related: #114962

## What Problem This Solves

Fixes an issue where users sending WhatsApp images, videos, voice notes, or PDFs from filename-only or generic-binary media received document attachments, invalid `application/octet-stream` media, or unconverted audio instead of the intended native message.

## Why This Change Was Made

Resolve media family and native MIME from the same WhatsApp-owned filename only when an upstream MIME is absent or generic. Treat `application/octet-stream`'s computed document kind as provisional, while preserving explicitly meaningful MIME types, intentional documents, unknown binary fallback, the existing Ogg/Opus voice contract, and MP3-to-Opus conversion. This is a contributor-preserving, fully verified replacement for #114962; thank you to @MatthewSynthia for identifying the filename-inference bug. The commit retains the original author's `Co-authored-by` trailer.

## User Impact

Filename-only `.png` and `.mp4` arrive as real images and videos with correct MIME; `.ogg` arrives as a native voice note; `.mp3` is transcoded to an Opus voice note; PDFs retain `application/pdf`; unknown binary files remain documents. Explicit declared MIME and intentionally selected document messages remain authoritative.

## Evidence

- Independently reproduced against the actual `deliverWebReply` → `platform.sendMedia` user path on clean current main: 5 native image/video/voice/PDF cases failed before the correction.
- Dedicated 14-case delivery matrix verifies absent and generic MIME headers with real `WebMediaResult` document classification, explicit MIME precedence, unknown document fallback, and correct Baileys-native payloads.
- Personally verified pinned Baileys `7.0.0-rc13` upstream `prepareWAMessageMedia`: it only supplies its media-type default when `mimetype` is absent, so the original partial fix would still preserve an invalid explicit binary MIME.
- Trusted Linux Blacksmith Testbox: `pnpm test extensions/whatsapp/src/auto-reply/deliver-reply.filename-media.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.test.ts extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/media.test.ts extensions/whatsapp/src/inbound/send-api.test.ts extensions/whatsapp/src/channel-outbound.test.ts` — 164/164 passed.
- Trusted Linux full `pnpm check:changed` — passed, including production and test TypeScript, formatting, lint, plugin boundaries, dead exports, media guards, and import cycles.
- Fresh isolated `gpt-5.6-sol` extra-high-effort structured autoreview: clean, no accepted or actionable findings.
