### PR TITLE
fix(mattermost): preserve private-channel conversation origins

### DIFF
--- a/extensions/mattermost/src/mattermost/target-resolution.loopback.test.ts
+++ b/extensions/mattermost/src/mattermost/target-resolution.loopback.test.ts
@@ -86,6 +86,7 @@ describe("Mattermost opaque channel resolution over real HTTP", () => {
           expect(route).toMatchObject({
             peer: { kind: testCase.kind, id: testCase.id },
             chatType: testCase.kind,
+            from: `mattermost:${testCase.kind}:${testCase.id}`,
             to: `channel:${testCase.id}`,
             sessionKey: `agent:main:mattermost:${testCase.kind}:${testCase.id}:thread:loopback-thread`,
           });

--- a/extensions/mattermost/src/session-route.test.ts
+++ b/extensions/mattermost/src/session-route.test.ts
@@ -157,6 +157,7 @@ describe("mattermost session route", () => {
     expect(groupRoute.peer.kind).toBe("group");
     expect(groupRoute.peer.id).toBe("priv123");
     expect(groupRoute.chatType).toBe("group");
+    expect(groupRoute.from).toBe("mattermost:group:priv123");
     expect(groupRoute.baseSessionKey).toBe("agent:main:mattermost:group:priv123");
     // Wire target stays channel:<id>; the group distinction lives in the session key.
     expect(groupRoute.to).toBe("channel:priv123");
@@ -174,6 +175,7 @@ describe("mattermost session route", () => {
     const groupRoute = expectRoute(route);
     expect(groupRoute.peer.kind).toBe("group");
     expect(groupRoute.chatType).toBe("group");
+    expect(groupRoute.from).toBe("mattermost:group:priv123");
     // Outbound now shares the inbound group:<id> namespace instead of forking channel:<id>.
     expect(groupRoute.sessionKey).toBe("agent:main:mattermost:group:priv123:thread:root-post");
     expect(groupRoute.threadId).toBe("root-post");

--- a/extensions/mattermost/src/session-route.ts
+++ b/extensions/mattermost/src/session-route.ts
@@ -78,7 +78,8 @@ export function resolveMattermostOutboundSessionRoute(params: ChannelOutboundSes
       id: rawId,
     },
     chatType: kind,
-    from: isUser ? `mattermost:${rawId}` : `mattermost:channel:${rawId}`,
+    // Origin identity must match inbound; only `to` uses the channel wire address.
+    from: isUser ? `mattermost:${rawId}` : `mattermost:${kind}:${rawId}`,
     // Wire target stays `channel:<id>` for non-DMs: Mattermost posts to the channel
     // id regardless of private/public, and `parseMattermostTarget` only accepts
     // `channel:`/`user:`. The `group` distinction lives in the session key (peer.kind).

--- a/src/gateway/conversation-list.test.ts
+++ b/src/gateway/conversation-list.test.ts
@@ -128,6 +128,65 @@ describe("runGatewayConversationList", () => {
     ]);
   });
 
+  it("keeps a discovered group origin distinct from its channel delivery address", async () => {
+    let discovered: ConversationIdentity[] = [];
+    const channelId = "private-room-123";
+    const resolveOutboundSessionRoute = vi.fn(async () => ({
+      sessionKey: `agent:main:reef:group:${channelId}`,
+      baseSessionKey: `agent:main:reef:group:${channelId}`,
+      peer: { kind: "group" as const, id: channelId },
+      chatType: "group" as const,
+      from: `reef:group:${channelId}`,
+      to: `channel:${channelId}`,
+    }));
+    const deps = {
+      resolveOutboundChannelPlugin: vi.fn(() => ({
+        id: "reef",
+        config: {
+          listAccountIds: () => ["default"],
+          resolveAccount: () => ({ enabled: true, configured: true }),
+          isEnabled: () => true,
+          isConfigured: () => true,
+        },
+        directory: {
+          listPeers: async () => [],
+          listGroups: async () => [
+            { kind: "group" as const, id: `channel:${channelId}`, name: "Private room" },
+          ],
+        },
+      })),
+      resolveOutboundSessionRoute,
+      registerConversationAddresses: vi.fn((_scope, identities) => {
+        discovered = [...identities];
+      }),
+      listConversations: vi.fn(() => []),
+    };
+
+    await runGatewayConversationList(
+      { config: {}, agentId: "main", channel: "reef", limit: 50 },
+      deps as never,
+    );
+
+    expect(resolveOutboundSessionRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: `channel:${channelId}`,
+        resolvedTarget: expect.objectContaining({
+          kind: "group",
+          to: `channel:${channelId}`,
+        }),
+      }),
+    );
+    expect(discovered).toEqual([
+      expect.objectContaining({
+        channel: "reef",
+        kind: "group",
+        peerId: channelId,
+        deliveryTarget: `channel:${channelId}`,
+        nativeChannelId: channelId,
+      }),
+    ]);
+  });
+
   it("merges live directory adapters with config-backed entries", async () => {
     const listPeers = vi.fn(async () => [
       { kind: "user" as const, id: "stale-peer", name: "Stale Peer" },

--- a/src/infra/outbound/outbound-session.integration.test.ts
+++ b/src/infra/outbound/outbound-session.integration.test.ts
@@ -7,9 +7,15 @@ import {
   registerConversationAddresses,
   resolveConversation,
 } from "../../config/sessions/conversation-registry.js";
-import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  loadExactSessionEntry,
+  upsertSessionEntry,
+} from "../../config/sessions/session-accessor.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
-import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
+import {
+  normalizeSessionDeliveryState,
+  sessionDeliveryOrigin,
+} from "../../utils/delivery-context.shared.js";
 import { bindOutboundSessionEntry } from "./outbound-session.js";
 
 describe("outbound session persistence", () => {
@@ -114,6 +120,52 @@ describe("outbound session persistence", () => {
       sessionKey,
       role: "primary",
       target: "reef:peer-agent",
+    });
+  });
+
+  it("persists a group ingress origin without rewriting its native channel target", async () => {
+    const channelId = "private-room-123";
+    const sessionKey = `agent:main:reef:group:${channelId}`;
+    const from = `reef:group:${channelId}`;
+    const to = `channel:${channelId}`;
+    const identity = buildConversationIdentity({
+      channel: "reef",
+      accountId: "default",
+      kind: "group",
+      peerId: from,
+      deliveryTarget: to,
+      nativeChannelId: channelId,
+    });
+    expect(identity).not.toBeNull();
+    registerConversationAddresses({ agentId: "main", storePath }, [identity!], 200);
+
+    await bindOutboundSessionEntry({
+      cfg: { session: { store: storePath } } as OpenClawConfig,
+      channel: "reef",
+      accountId: "default",
+      route: {
+        sessionKey,
+        baseSessionKey: sessionKey,
+        peer: { kind: "group", id: channelId },
+        chatType: "group",
+        from,
+        to,
+      },
+    });
+
+    const persisted = loadExactSessionEntry({ agentId: "main", sessionKey, storePath });
+    expect(sessionDeliveryOrigin(persisted?.entry)).toMatchObject({
+      provider: "reef",
+      accountId: "default",
+      from,
+    });
+    expect(
+      resolveConversation({ agentId: "main", storePath }, identity!.conversationRef),
+    ).toMatchObject({
+      kind: "group",
+      nativeChannelId: channelId,
+      sessionKey,
+      target: to,
     });
   });
 });


### PR DESCRIPTION
Related: #95646, #96645, #95669.

## What Problem This Solves

Fixes an issue where Mattermost private-channel and group-DM replies preserved the correct group session but stored their outbound origin as a public channel. A private inbound message has `From: mattermost:group:<id>`; its outbound route incorrectly reported `mattermost:channel:<id>`. Gateway conversation discovery and durable outbound session metadata consume that origin, so the same private conversation did not retain its authoritative inbound identity.

Public-channel, direct-message, wire-target and session-key behavior must remain unchanged. Conversation references already normalize transport prefixes; this PR does not claim that their hashes fork.

## Why This Change Was Made

Use the already-authoritative owner-local Mattermost peer kind when constructing the outbound `from` origin. Keep `to: channel:<id>` unchanged because both public and private Mattermost channels use the same Bot API transport address.

The original private-origin observation was made by @hansraj316 in #95669; the commit preserves explicit contributor credit. This change builds on the landed authoritative public/private-channel classification in #96645 instead of reviving or counting the closed earlier PR.

## User Impact

Private and group Mattermost conversation origins now match real inbound events, gateway-discovered identities and SQLite-backed outbound session metadata. Public channels, direct messages, thread/session keys and actual REST delivery targets do not change.

No config, plugin SDK, dependency, migration, database schema or core runtime behavior is added.

## Evidence

Real trusted Linux Blacksmith Testbox `tbx_01kypasrprfzejpyn0cw3244w0`; identical checkout and command before and after:

```text
pnpm test \
  extensions/mattermost/src/mattermost/target-resolution.loopback.test.ts \
  extensions/mattermost/src/session-route.test.ts \
  src/gateway/conversation-list.test.ts \
  src/infra/outbound/outbound-session.integration.test.ts
```

Before the one-line owner fix, the production private-channel route failed in three independent real checks:

```text
expected: mattermost:group:priv123
received: mattermost:channel:priv123

real private-channel Bot API loopback:
expected: mattermost:group:bcdefghijklmnopqrstuvwxyza
received: mattermost:channel:bcdefghijklmnopqrstuvwxyza

extension-mattermost: 3 failed, 12 passed
gateway discovery: 5 passed
SQLite-backed outbound persistence: 3 passed
```

After the fix, the same remote lease passed all 23 focused tests, including the authenticated four-request real localhost Mattermost Bot API proof:

```text
GET /api/v4/users/<public-id>      -> 404
GET /api/v4/channels/<public-id>   -> 200, type O
GET /api/v4/users/<private-id>     -> 404
GET /api/v4/channels/<private-id>  -> 200, type P

extension-mattermost: 15 passed
gateway discovery: 5 passed
SQLite-backed outbound persistence: 3 passed
```

The shared gateway and persistence regressions use a generic `reef` channel; core tests do not import or special-case Mattermost plugin internals.

Fresh independent `gpt-5.6-sol` extra-high-effort review: clean; confidence 0.95. Trusted existing formatter: all five files clean. Full remote `pnpm check:changed` passed on the same Blacksmith lease, including core and plugin test typechecking, changed-file lint, formatting, plugin boundaries, database-first guards, import cycles and dependency checks.

AI-assisted; source, owner boundary, inbound event contract, public/direct sibling routes, real Bot API, gateway discovery and real SQLite persistence were personally audited.
