### PR TITLE
fix(agents): forward compaction reconcile through dist re-export shim

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts
@@ -4,8 +4,17 @@
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { updateSessionEntry } from "../config/sessions/session-accessor.js";
 
-/** Persist the highest observed compaction count after a successful subscribed run. */
-export default async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
+/**
+ * Persist the highest observed compaction count after a successful subscribed run.
+ *
+ * Exported as a named binding rather than `default`: the unified dist emits this
+ * lazy runtime as its own chunk, and the stable-name re-export shim rolldown
+ * generates uses `export *`, which per ESM does not forward `default`. Any
+ * dynamic importer would then see `default: undefined` and silently skip
+ * reconciliation. Named exports are forwarded by `export *`, so this keeps the
+ * shim correct without a bundler-side workaround.
+ */
+export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   sessionKey?: string;
   agentId?: string;
   configStore?: string;

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
@@ -13,7 +13,7 @@ import {
   handleCompactionEnd,
   handleCompactionStart,
 } from "./embedded-agent-subscribe.handlers.compaction.js";
-import reconcileSessionStoreCompactionCountAfterSuccess from "./embedded-agent-subscribe.handlers.compaction.runtime.js";
+import { reconcileSessionStoreCompactionCountAfterSuccess } from "./embedded-agent-subscribe.handlers.compaction.runtime.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { makeZeroUsageSnapshot, type AssistantUsageSnapshot } from "./usage.js";
@@ -174,6 +174,18 @@ describe("reconcileSessionStoreCompactionCountAfterSuccess", () => {
 
     expect(nextCount).toBe(3);
     expect(await readCompactionCount(storePath, sessionKey)).toBe(3);
+  });
+
+  it("exposes the reconcile function as a named export so dist re-export shims can forward it", async () => {
+    // The unified dist emits this runtime as its own chunk with a stable-name
+    // re-export shim generated as `export * from "./<hashed>.js"`. Per ESM,
+    // `export *` forwards named bindings but never `default`. Keeping the
+    // reconcile symbol as a named export guarantees the production dynamic
+    // import in embedded-agent-subscribe.handlers.compaction.ts resolves it,
+    // and blocks a silent regression to `export default` that would land the
+    // "reconcile is not a function" WARN on every compaction (issue #115548).
+    const runtimeModule = await import("./embedded-agent-subscribe.handlers.compaction.runtime.js");
+    expect(typeof runtimeModule.reconcileSessionStoreCompactionCountAfterSuccess).toBe("function");
   });
 });
 

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -207,9 +207,8 @@ async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
 }): Promise<number | undefined> {
   // Import the named export: the rolldown-emitted re-export shim uses
   // `export *`, which forwards named bindings but not `default`.
-  const { reconcileSessionStoreCompactionCountAfterSuccess: reconcile } = await import(
-    "./embedded-agent-subscribe.handlers.compaction.runtime.js"
-  );
+  const { reconcileSessionStoreCompactionCountAfterSuccess: reconcile } =
+    await import("./embedded-agent-subscribe.handlers.compaction.runtime.js");
   return reconcile(params);
 }
 

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.ts
@@ -205,8 +205,11 @@ async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   observedCompactionCount: number;
   now?: number;
 }): Promise<number | undefined> {
-  const { default: reconcile } =
-    await import("./embedded-agent-subscribe.handlers.compaction.runtime.js");
+  // Import the named export: the rolldown-emitted re-export shim uses
+  // `export *`, which forwards named bindings but not `default`.
+  const { reconcileSessionStoreCompactionCountAfterSuccess: reconcile } = await import(
+    "./embedded-agent-subscribe.handlers.compaction.runtime.js"
+  );
   return reconcile(params);
 }
 


### PR DESCRIPTION
Closes #115548

## What Problem This Solves

Every successful embedded-agent compaction logs `WARN late compaction count reconcile failed: TypeError: reconcile is not a function`, and the persisted session-store `compactionCount` never advances after embedded compactions. The `memoryFlushCompactionCount === compactionCount` gate then misfires, so pre-compaction memory flushes can duplicate. As reported in #115548 on OpenClaw 2026.6.11.

## Why This Change Was Made

The runtime helper was exported as `export default` and imported with `.default` from the surrounding handler:

```ts
// src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts (before)
export default async function reconcileSessionStoreCompactionCountAfterSuccess(...) { ... }

// src/agents/embedded-agent-subscribe.handlers.compaction.ts (before)
const { default: reconcile } =
  await import("./embedded-agent-subscribe.handlers.compaction.runtime.js");
```

Because this module is a `*.runtime.ts` lazy boundary that is not in `buildCoreDistEntries()` in `tsdown.config.ts`, the unified dist emits it as its own hashed chunk with a stable-name re-export shim of the form:

```js
export * from "./embedded-agent-subscribe.handlers.compaction.runtime-<hash>.js";
```

Per the ESM spec, `export *` re-exports named bindings but **does not** forward `default`. So in the dist, `(await import(...)).default` is `undefined`, `reconcile` is not a function, and every successful compaction hits the WARN path. This exactly matches the reproduction in the issue.

Fix: switch to a named export and update the two call sites. Named exports are forwarded by `export *`, so the generated shim becomes correct without a bundler-side workaround. This follows the repo `AGENTS.md` guidance on canonical paths (no fallback) and on avoiding generic single-word exports (`default`); it also matches how every other `*.runtime.ts` module in this repo exports its symbols.

## User Impact

- Compaction reconciliation now runs successfully in dist builds. The persisted `compactionCount` advances after every embedded compaction, so the `memoryFlushCompactionCount === compactionCount` gate no longer misfires and pre-compaction memory flushes cannot duplicate.
- `WARN late compaction count reconcile failed: TypeError: reconcile is not a function` no longer fires on every successful compaction.
- No behavior change from source checkouts (where the shim was not involved). No config, storage, or public API change.

## Evidence

Files touched:

- `src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts` — `export default` → `export` (named), with an inline block comment explaining why the shim requires named exports (to block silent regressions).
- `src/agents/embedded-agent-subscribe.handlers.compaction.ts` — dynamic import destructures the named export; short comment cites the shim behavior.
- `src/agents/embedded-agent-subscribe.handlers.compaction.test.ts` — static import switched to named; added a focused regression that dynamically imports the runtime module and asserts `runtimeModule.reconcileSessionStoreCompactionCountAfterSuccess` is a function. This is the exact contract the fix restores; if anyone re-introduces `export default`, `export *` in the dist shim will strip it again and this test will fail.

Local validation (Node 24.15.0, macOS):

```
$ node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.compaction.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)

$ node scripts/run-vitest.mjs test/scripts/check-session-accessor-boundary.test.ts
 Test Files  1 passed (1)
      Tests  36 passed (36)

$ git diff --check
(clean)
```

Boundary allow-list for the runtime path (`scripts/check-session-accessor-boundary.mjs`, `test/scripts/check-session-accessor-boundary.test.ts`) is unchanged — only the export shape of the file it points at changed.

## AI-assisted

This PR was drafted with Claude Code. The author reviewed and understands the change; the reasoning above is the same reasoning committed to the code comments.
