### PR TITLE
feat(memory): retain recent project scopes per session

### DIFF
--- a/docs/concepts/memory-architecture.md
+++ b/docs/concepts/memory-architecture.md
@@ -264,20 +264,30 @@ cached for the process lifetime; semicolons are escaped so one key cannot become
 multiple list entries, and recall never starts Git once per message.
 
 Project scope changes ranking and automatic injection without partitioning the
-files. Ranked search boosts entries from the active repository, mildly demotes
-entries from another repository, and leaves untagged memory neutral. Trigger
-injection is stricter: a tagged entry is eligible only while its repository is
-active. Each full turn also gets a compact, separately budgeted project-memory
-block built from curated entries for that repository. `USER.md` and standing
-intents remain user-level and are never project-scoped.
+files. Each session keeps up to four recently active repository keys in
+most-recent-first order. Preparing a repository moves its key to the front and
+evicts the least-recent key beyond that cap. This set is ephemeral runtime
+state: it is not persisted or restored, so a new session or process starts with
+an empty set. The current repository identity remains a separate prepared fact
+used for write annotations; new repository-specific memories receive only that
+current key, not the whole active set. Ranked search boosts entries from any
+repository in the active set, mildly demotes entries from another repository,
+and leaves untagged memory neutral. Trigger injection is stricter: a tagged
+entry is eligible only while every project key on that entry is in the active
+set. Each full turn also gets a compact, separately budgeted project-memory
+block built from curated entries for the active repositories. All retained keys
+have the same boost; recency only controls promotion and eviction. `USER.md` and
+standing intents remain user-level and are never project-scoped.
 
 This matters most for a many-repository worker: a build workaround learned in
 one codebase should not silently steer work in another. In one continuous
 repository session, the annotation is mostly invisible; ranking and bootstrap
 refresh preserve the same learned context across compaction and dreaming. A
-session that moves to another repository updates its active identity on the next
-turn, and a sub-agent derives its own identity rather than inheriting its
-parent's. Sessions outside repositories retain the previous global behavior.
+session that moves to another repository keeps both repositories active until
+recency eviction, while a sub-agent derives its own active set rather than
+inheriting its parent's. A session that starts outside a repository retains the
+previous global behavior; leaving a repository does not clear keys already
+active in that session.
 
 The boundary follows the same research result as the rest of recall: selective,
 query-relevant context outperforms indiscriminate history as sessions and

--- a/extensions/active-memory/trigger-recall.test.ts
+++ b/extensions/active-memory/trigger-recall.test.ts
@@ -165,6 +165,19 @@ describe("active-memory trigger recall", () => {
     expect(context).not.toContain("<!--");
   });
 
+  it("honors every project retained in the session active set", () => {
+    const entries = [
+      result({ startLine: 1, triggers: "shared deploy", projectKey: "alpha-key" }),
+      result({ startLine: 2, triggers: "shared deploy", projectKey: "beta-key" }),
+      result({ startLine: 3, triggers: "shared deploy", projectKey: "gamma-key" }),
+    ];
+    expect(
+      selectStrongTriggerMatches("shared deploy", entries, ["beta-key", "alpha-key"]).map(
+        (entry) => entry.startLine,
+      ),
+    ).toEqual([1, 2]);
+  });
+
   it("blocks every oversized entry fragment when its project is inactive", () => {
     const fragments = [
       result({

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1439,7 +1439,7 @@ describe("memory_search corpus labels", () => {
             startLine: 2,
             endLine: 2,
             score: 0.9,
-            snippet: "foreign fact",
+            snippet: "second active fact",
             source: "memory" as const,
             projectKey: "github.com/acme/Beta",
           },
@@ -1452,22 +1452,36 @@ describe("memory_search corpus labels", () => {
             source: "memory" as const,
             projectKey: "github.com/acme/Alpha",
           },
+          {
+            path: "MEMORY.md",
+            startLine: 3,
+            endLine: 3,
+            score: 0.85,
+            snippet: "foreign fact",
+            source: "memory" as const,
+            projectKey: "github.com/acme/Gamma",
+          },
         ],
         opts?.activeProjectKeys,
       );
     });
     const tool = createMemorySearchToolOrThrow({
       config: { memory: { citations: "off" } },
-      activeProjectKeys: ["github.com/acme/Alpha"],
+      activeProjectKeys: ["github.com/acme/Beta", "github.com/acme/Alpha"],
     });
 
     const result = await tool.execute("project-ranked-search", { query: "fact" });
     const details = result.details as { results: Array<{ snippet: string; score: number }> };
 
-    expect(details.results.map((entry) => entry.snippet)).toEqual(["active fact", "foreign fact"]);
-    expect(activeProjectKeys).toEqual(["github.com/acme/Alpha"]);
-    expect(details.results[0]?.score).toBeCloseTo(0.92);
-    expect(details.results[1]?.score).toBeCloseTo(0.81);
+    expect(details.results.map((entry) => entry.snippet)).toEqual([
+      "second active fact",
+      "active fact",
+      "foreign fact",
+    ]);
+    expect(activeProjectKeys).toEqual(["github.com/acme/Beta", "github.com/acme/Alpha"]);
+    expect(details.results[0]?.score).toBeCloseTo(1.035);
+    expect(details.results[1]?.score).toBeCloseTo(0.92);
+    expect(details.results[2]?.score).toBeCloseTo(0.765);
   });
 
   it.each(["sessions", "all"] as const)(

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -46,6 +46,7 @@ import { resolveEmbeddedCompactionTarget } from "./compaction-runtime-context.js
 import { prepareCompactionSessionAgent } from "./compaction-session-agent.js";
 import type { PreparedCompactEmbeddedAgentSessionParams } from "./direct-compaction-preparation.js";
 import { compactEmbeddedAgentSessionDirectOnce } from "./direct-compaction.js";
+import { prepareEmbeddedSessionActiveProjectKeys } from "./session-prompt-state.js";
 import type { EmbeddedAgentCompactResult } from "./types.js";
 
 export type { CompactEmbeddedAgentSessionParams } from "./compact.types.js";
@@ -167,10 +168,15 @@ export async function compactEmbeddedAgentSessionDirect(
         cwd: requestedParams.cwd,
       }) ?? null;
     const projectKey = repoRoot ? await resolveProjectKey(repoRoot) : null;
+    const activeProjectKeys = prepareEmbeddedSessionActiveProjectKeys(
+      requestedParams.sessionId,
+      projectKey,
+    );
     const preparedModelRuntime = Object.freeze({
       ...preparedModelRuntimeOwnerSnapshot,
       repoRoot,
       projectKey,
+      activeProjectKeys,
     });
     // Fallback policy and every attempt consume the same generation as model/auth discovery.
     // A reload may have committed while session targeting was resolved above.

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -905,6 +905,7 @@ describe("resolveModel", () => {
     } as unknown as OpenClawConfig;
     const preparedModelRuntime = {
       agentDir: "/tmp/agent",
+      activeProjectKeys: [],
       config: cfg,
       metadataSnapshot: { plugins: [] } as never,
       modelCatalog: { entries: [], routeVariants: [] },

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -553,9 +553,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       toolNames: effectiveTools.map((tool) => tool.name),
       capabilityToolNames: allowedToolNames,
     });
-    const activeProjectKeys = params.preparedModelRuntime?.projectKey
-      ? [params.preparedModelRuntime.projectKey]
-      : [];
+    const activeProjectKeys = params.preparedModelRuntime?.activeProjectKeys ?? [];
     const buildSystemPromptText = (defaultThinkLevel: ThinkLevel) => {
       const builtSystemPrompt = buildEmbeddedSystemPrompt({
         config: params.config,

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -66,6 +66,7 @@ import { createEmbeddedRunProgressController } from "./run/progress-controller.j
 import { createRecoveryMessageActionTurnCapability } from "./run/recovery-message-action-capability.js";
 import { resolveInitialEmbeddedRunModel } from "./run/runtime-resolution.js";
 import { assertAgentHarnessRunAdmission, backfillSessionKey } from "./run/session-bootstrap.js";
+import { prepareEmbeddedSessionActiveProjectKeys } from "./session-prompt-state.js";
 import type { EmbeddedAgentRunResult } from "./types.js";
 
 const EMPTY_EMBEDDED_AGENT_CONFIG: OpenClawConfig = Object.freeze({});
@@ -234,10 +235,15 @@ async function runEmbeddedAgentInternal(
             cwd: rebound.runParams.cwd,
           }) ?? null;
         const projectKey = repoRoot ? await resolveProjectKey(repoRoot) : null;
+        const activeProjectKeys = prepareEmbeddedSessionActiveProjectKeys(
+          params.sessionId,
+          projectKey,
+        );
         const preparedModelRuntime = Object.freeze({
           ...preparedModelRuntimeOwnerSnapshot,
           repoRoot,
           projectKey,
+          activeProjectKeys,
         });
         const preparedAgentId = workspaceResolution.agentId;
         const resolvedWorkspace = workspaceResolution.workspaceDir;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-assembly.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-assembly.ts
@@ -108,9 +108,7 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
     sessionKey: attempt.sessionKey,
     sessionId: attempt.sessionId,
     workspaceDir: attempt.workspaceDir,
-    activeProjectKeys: attempt.preparedModelRuntime?.projectKey
-      ? [attempt.preparedModelRuntime.projectKey]
-      : [],
+    activeProjectKeys: [...(attempt.preparedModelRuntime?.activeProjectKeys ?? [])],
     modelProviderId: attempt.model.provider,
     modelId: attempt.model.id,
     trigger: attempt.trigger,

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -261,9 +261,7 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
     toolNames: params.effectiveTools.map((tool) => tool.name),
     capabilityToolNames: params.capabilityToolNames,
   });
-  const activeProjectKeys = attempt.preparedModelRuntime?.projectKey
-    ? [attempt.preparedModelRuntime.projectKey]
-    : [];
+  const activeProjectKeys = attempt.preparedModelRuntime?.activeProjectKeys ?? [];
   const projectMemoryBootstrap =
     effectivePromptMode === "full" && activeProjectKeys.length > 0
       ? await prepareProjectMemoryBootstrap({

--- a/src/agents/embedded-agent-runner/session-prompt-state.test.ts
+++ b/src/agents/embedded-agent-runner/session-prompt-state.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearEmbeddedSessionPromptStates,
+  prepareEmbeddedSessionActiveProjectKeys,
+} from "./session-prompt-state.js";
+
+const sessionIds = new Set<string>();
+
+function prepare(sessionId: string, projectKey: string | null): readonly string[] {
+  sessionIds.add(sessionId);
+  return prepareEmbeddedSessionActiveProjectKeys(sessionId, projectKey);
+}
+
+afterEach(() => {
+  clearEmbeddedSessionPromptStates(sessionIds);
+  sessionIds.clear();
+});
+
+describe("embedded session active project keys", () => {
+  it("promotes repeated keys while retaining other recently active projects", () => {
+    expect(prepare("session-lru", "repo-a")).toEqual(["repo-a"]);
+    expect(prepare("session-lru", "repo-b")).toEqual(["repo-b", "repo-a"]);
+    expect(prepare("session-lru", "repo-a")).toEqual(["repo-a", "repo-b"]);
+  });
+
+  it("evicts the least-recent project beyond the four-key cap", () => {
+    for (const key of ["repo-a", "repo-b", "repo-c", "repo-d", "repo-e"]) {
+      prepare("session-cap", key);
+    }
+    expect(prepare("session-cap", null)).toEqual(["repo-e", "repo-d", "repo-c", "repo-b"]);
+  });
+
+  it("keeps single-repository sessions identical and isolated", () => {
+    expect(prepare("session-one", "repo-a")).toEqual(["repo-a"]);
+    expect(prepare("session-one", null)).toEqual(["repo-a"]);
+    expect(prepare("session-two", null)).toEqual([]);
+  });
+});

--- a/src/agents/embedded-agent-runner/session-prompt-state.ts
+++ b/src/agents/embedded-agent-runner/session-prompt-state.ts
@@ -10,11 +10,13 @@ export type ToolResultPromptProjectionState = {
 };
 
 type EmbeddedSessionPromptState = {
+  activeProjectKeys: string[];
   toolResults: ToolResultPromptProjectionState;
   sentUserTurnIds: Set<string>;
 };
 
 const MAX_SESSION_PROMPT_STATES = 64;
+const MAX_ACTIVE_PROJECT_KEYS = 4;
 const SESSION_PROMPT_STATES_KEY = Symbol.for("openclaw.embeddedSessionPromptStates");
 const sessionPromptStates = resolveGlobalSingleton(
   SESSION_PROMPT_STATES_KEY,
@@ -23,6 +25,7 @@ const sessionPromptStates = resolveGlobalSingleton(
 
 function createSessionPromptState(): EmbeddedSessionPromptState {
   return {
+    activeProjectKeys: [],
     toolResults: {
       replacements: new Map<string, AgentMessage>(),
       frozen: new Set<string>(),
@@ -61,6 +64,27 @@ export function getEmbeddedSessionPromptState(sessionId: string): EmbeddedSessio
     sessionPromptStates.delete(oldest);
   }
   return created;
+}
+
+/** Records the prepared repository identity and snapshots this session's LRU active set. */
+export function prepareEmbeddedSessionActiveProjectKeys(
+  sessionId: string,
+  projectKey: string | null,
+): readonly string[] {
+  const state = getEmbeddedSessionPromptState(sessionId);
+  if (projectKey) {
+    const existing = state.activeProjectKeys.indexOf(projectKey);
+    if (existing >= 0) {
+      state.activeProjectKeys.splice(existing, 1);
+    }
+    state.activeProjectKeys.unshift(projectKey);
+    state.activeProjectKeys.length = Math.min(
+      state.activeProjectKeys.length,
+      MAX_ACTIVE_PROJECT_KEYS,
+    );
+  }
+  // Consumers use set membership today; LRU order is retained for a possible future graduated boost.
+  return [...state.activeProjectKeys];
 }
 
 export function clearEmbeddedSessionPromptStates(sessionIds: Iterable<string | undefined>): void {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -220,9 +220,7 @@ export function createOpenClawTools(
     ModelAwareToolContext,
 ): AnyAgentTool[] {
   const resolvedConfig = options?.config;
-  const activeProjectKeys = options?.preparedModelRuntime?.projectKey
-    ? [options.preparedModelRuntime.projectKey]
-    : [];
+  const activeProjectKeys = options?.preparedModelRuntime?.activeProjectKeys ?? [];
   const runtimeSnapshot = getActiveSecretsRuntimeConfigSnapshot();
   const availabilityConfig = selectApplicableRuntimeConfig({
     inputConfig: resolvedConfig,

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -53,6 +53,8 @@ export type PreparedModelRuntimeSnapshot = Readonly<{
   repoRoot?: string | null;
   /** Stable identity derived from repoRoot; null means the run is outside a repository. */
   projectKey?: string | null;
+  /** Session active project set, ordered most-recent first. */
+  activeProjectKeys?: readonly string[];
   config: OpenClawConfig;
   metadataSnapshot: PluginMetadataSnapshot;
   messageToolCatalog?: PreparedMessageToolCatalog;

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -53,8 +53,8 @@ export type PreparedModelRuntimeSnapshot = Readonly<{
   repoRoot?: string | null;
   /** Stable identity derived from repoRoot; null means the run is outside a repository. */
   projectKey?: string | null;
-  /** Session active project set, ordered most-recent first. */
-  activeProjectKeys?: readonly string[];
+  /** Session active project set, ordered most-recent first; empty before run binding. */
+  activeProjectKeys: readonly string[];
   config: OpenClawConfig;
   metadataSnapshot: PluginMetadataSnapshot;
   messageToolCatalog?: PreparedMessageToolCatalog;
@@ -557,6 +557,7 @@ async function buildSnapshot(
   return Object.freeze({
     ...(input.agentId ? { agentId: input.agentId } : {}),
     agentDir: input.agentDir,
+    activeProjectKeys: [],
     ...(input.inheritedAuthDir ? { inheritedAuthDir: input.inheritedAuthDir } : {}),
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     config: input.config,

--- a/src/agents/project-memory-bootstrap.test.ts
+++ b/src/agents/project-memory-bootstrap.test.ts
@@ -66,6 +66,14 @@ describe("project memory bootstrap", () => {
     expect(rendered.length).toBeLessThanOrEqual(2_000);
   });
 
+  it("includes entries from every project retained in the session active set", async () => {
+    const rendered = (
+      await prepareEntries(entries, ["github.com/example/other", "github.com/OpenClaw/OpenClaw"])
+    ).join("\n");
+    expect(rendered).toContain("Use the release helper.");
+    expect(rendered).toContain("Foreign fact.");
+  });
+
   it("never emits a partial entry or exceeds the hard budget", async () => {
     const crowded = Array.from({ length: 10 }, (_, index) => ({
       ...entries[0]!,

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -177,6 +177,7 @@ function setup(entry: SessionEntry = sessionEntry) {
   } = {};
   const preparedModelRuntime = {
     agentDir: "/gateway-agent",
+    activeProjectKeys: [],
     workspaceDir: WORKSPACE,
     config,
     metadataSnapshot: { plugins: [] } as never,


### PR DESCRIPTION
Related: #115438

## What Problem This Solves

Project-scoped memory currently remembers only the latest repository prepared for a session. Sessions that move between a monorepo, sibling checkout, or agent-created worktree therefore stop recalling still-relevant memory from repositories touched earlier in that same session.

## Why This Change Was Made

The prepared runtime now snapshots a session-ephemeral, most-recent-first set of up to four unique project keys. Preparing a repository promotes its key and evicts the least-recent key beyond the cap; bootstrap filtering, trigger recall, memory search, and ranking all consume the same prepared set without rediscovery. The current project key remains separate for write annotations, and there is no SQLite or configuration change.

This change is AI-assisted and was reviewed through the repository autoreview workflow. The final branch review reported no accepted or actionable findings.

## User Impact

Memory recall remains relevant across repository hops within one session. A session that touches repositories A and B can bootstrap, trigger, search, and boost memory from both, while single-repository behavior and the existing 1.15 active / 0.9 foreign ranking multipliers remain unchanged.

## Evidence

- Focused Vitest proof: 115 tests passed across session LRU state, project bootstrap and prompt filtering, trigger recall, plugin context, and production memory-search ranking on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/30434478803.
- Changed checks: formatting, docs, core and test typechecks, lint, dead-code scans, import cycles, database-first guards, and boundary checks passed on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/30434729807.
- Final autoreview: clean, no accepted/actionable findings, 0.94 confidence.
- Final rebase resolved against current `origin/main` with stable patch id `a81278b4fb4125556d5202fde9a7264c62a818d5`.
