### PR TITLE
fix(docs): unblock CI after the Code Mode heading

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1282,6 +1282,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H1: openclaw agent
   - H2: agent exec
+  - H3: Code Mode model matrix
   - H3: agent exec options
   - H2: Options
   - H2: Examples


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where every pull request that triggers documentation validation fails the required CI gate after the Code Mode model-matrix heading was added to the agent CLI documentation without regenerating the canonical documentation map.

## Why This Change Was Made

Run the repository's existing documentation-map generator on current main. Its only output change is the missing existing `cli/agent.md` heading; no source document, install guidance, generator, configuration, workflow, or runtime is changed.

## User Impact

Documentation pull requests can pass the existing required CI checks again, and agents navigating the generated documentation index can discover the existing Code Mode model-matrix section.

## Evidence

Exact current-main fail-first at `844329284e433eae027b16c0826bf46645fbea26`:

```text
$ node scripts/generate-docs-map.mjs --check
docs:map: docs/docs_map.md is out of date. Run `pnpm docs:map:gen`.
```

Independently compared all 752 generated documentation page sections in memory before making changes; the sole difference was the existing `cli/agent.md` heading `Code Mode model matrix`.

Generated the artifact with the official repository-owned command:

```text
$ node scripts/generate-docs-map.mjs
docs:map: wrote docs/docs_map.md.

$ node scripts/generate-docs-map.mjs --check
docs:map: docs/docs_map.md is up to date.

$ git diff --numstat 844329284e433eae027b16c0826bf46645fbea26 HEAD
1       0       docs/docs_map.md

$ git diff --check 844329284e433eae027b16c0826bf46645fbea26 HEAD
[clean]

$ oxfmt --check docs/docs_map.md
All matched files use the correct format.
```

Related: #115224, #115697.