### PR TITLE
fix(memory): declare embeddings API route so OpenAI auth mode is enforced

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts
@@ -1,6 +1,18 @@
 // Memory Host SDK tests cover embeddings remote client behavior.
 import { describe, expect, it, vi } from "vitest";
-import { resolveRemoteEmbeddingBearerClient } from "./embeddings-remote-client.js";
+import {
+  OPENAI_EMBEDDINGS_API,
+  resolveRemoteEmbeddingBearerClient,
+} from "./embeddings-remote-client.js";
+
+const { resolveApiKeyForProviderMock } = vi.hoisted(() => ({
+  resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "sk-resolved", mode: "api-key" })),
+}));
+
+vi.mock("./openclaw-runtime-auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./openclaw-runtime-auth.js")>()),
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
 
 describe("resolveRemoteEmbeddingBearerClient", () => {
   it("uses configured OpenAI provider baseUrl for memory embeddings", async () => {
@@ -53,5 +65,29 @@ describe("resolveRemoteEmbeddingBearerClient", () => {
       version: "2026.3.22",
       "User-Agent": "openclaw/2026.3.22",
     });
+  });
+
+  it("declares the embeddings API route so provider auth mode is enforced", async () => {
+    await resolveRemoteEmbeddingBearerClient({
+      provider: "openai",
+      defaultBaseUrl: "https://api.openai.com/v1",
+      options: {
+        agentDir: "/tmp/openclaw-agent",
+        config: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "http://127.0.0.1:19556/v1",
+              },
+            },
+          },
+        } as never,
+        model: "text-embedding-3-small",
+      },
+    });
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "openai", modelApi: OPENAI_EMBEDDINGS_API }),
+    );
   });
 });

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
@@ -11,6 +11,8 @@ import type { SsrFPolicy } from "./ssrf-policy.js";
 /** Provider id used for remote embedding auth and config lookup. */
 export type RemoteEmbeddingProviderId = string;
 
+export const OPENAI_EMBEDDINGS_API = "openai-embeddings";
+
 /** Attribution headers for native OpenAI embedding calls. */
 function resolveOpenClawAttributionHeaders(): Record<string, string> {
   const version = typeof process !== "undefined" ? process.env.OPENCLAW_VERSION?.trim() : undefined;
@@ -53,6 +55,7 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
           provider: params.provider,
           cfg: params.options.config,
           agentDir: params.options.agentDir,
+          modelApi: OPENAI_EMBEDDINGS_API,
         }),
         params.provider,
       );


### PR DESCRIPTION
Fixes #111985

## What Problem This Solves

Memory embeddings resolve provider auth without declaring which OpenAI API route they are about to use, so the auth-mode guard that keeps ChatGPT subscription credentials off the plain OpenAI Platform REST routes never runs. A ChatGPT OAuth profile is accepted for `/v1/embeddings`, and the access token is sent as the bearer to whatever `models.providers.openai.baseUrl` points at.

`directOpenAIPlatformModelRequiresApiKey` in `src/agents/model-auth-openai.ts:8` only fires when `modelApi` is defined:

```ts
return (
  normalizeProviderId(params.provider) === OPENAI_PROVIDER_ID &&
  params.modelApi !== undefined &&
  normalizeLowercaseStringOrEmpty(params.modelApi) !== OPENAI_CODEX_RESPONSES_API
);
```

`packages/memory-host-sdk/src/host/embeddings-remote-client.ts:54` called `resolveApiKeyForProvider` without one, so both `assertAuthModeAllowedForModel` and the `isAuthModeAllowedForModel` env-credential branch at `src/agents/model-auth-provider.ts:232` short-circuited to allowed:

```
modelApi=openai-completions  mode=oauth -> allowed: false
modelApi=undefined           mode=oauth -> allowed: true
modelApi=undefined           mode=token -> allowed: true
```

Three things widen the blast radius. Memory is on by default and embeddings fire on session start with no memory config at all. The credential was never handed to OpenClaw: `src/agents/cli-credentials.ts:175` deliberately resolves `CODEX_HOME` against the OS home rather than the OpenClaw state dir, so even isolated instances pick up an already-logged-in Codex CLI. And a custom OpenAI-compatible `baseUrl` is a normal configuration.

## Why This Change Was Made

The route is known at the call site, so the call site should declare it. This is the same shape as the already-landed OpenAI audio fix (#90793), which introduced `OPENAI_AUDIO_TRANSCRIPTIONS_API` and passes it as `modelApi` from `src/media-understanding/openai-compatible-audio.ts:47` for exactly this reason.

Loosening the guard instead (treating undefined `modelApi` as "platform route") was rejected: callers that legitimately resolve OpenAI auth without a known route, including the multi-route path in `src/agents/simple-completion-runtime.ts:292`, would start failing closed for valid Codex subscription credentials.

```ts
await resolveApiKeyForProvider({
  provider: params.provider,
  cfg: params.options.config,
  agentDir: params.options.agentDir,
  modelApi: OPENAI_EMBEDDINGS_API,
}),
```

An earlier revision of this PR also declared `OPENAI_IMAGES_API` in the shared OpenAI-compatible image factory. That has been removed, per the ClawSweeper P1 on `src/image-generation/openai-compatible-image-provider.ts`. Two reasons, and the second is the stronger one:

1. Declaring a direct-Images route in the shared factory is the wrong place to enforce it, because credentials are resolved before the configured base URL and transport are known.
2. It could not have helped anything either way. The guard only fires when `normalizeProviderId(provider) === "openai"`, and `normalizeProviderId` is plain lowercasing (`packages/model-catalog-core/src/provider-id.ts:6`). Every in-repo caller of `createOpenAiCompatibleImageGenerationProvider` passes a different id: `litellm`, `deepinfra`, `xai`. The bundled `openai` image provider does not use that factory at all; it is a separate implementation in `extensions/openai/image-generation-provider.ts` that owns its own Codex-Responses OAuth branch. So the declaration was dead code on every real path, and dead code that points at the wrong owner boundary.

This PR is therefore scoped to the embeddings route the issue reports. Other capability call sites that resolve OpenAI auth (media understanding, TTS, image, plugin providers) are out of scope here; each owns its own route knowledge, and none of them is the path in #111985.

The api id follows the existing convention that these values name the wire dialect rather than the vendor: `openai-compatible-audio.ts:47` uses `OPENAI_AUDIO_TRANSCRIPTIONS_API` for every OpenAI-compatible audio provider, not only `openai`.

## User Impact

An operator whose only OpenAI credential is a ChatGPT/Codex login, and who points `models.providers.openai.baseUrl` at any OpenAI-compatible endpoint (the repo's own comments name Requesty), no longer leaks that token to the third party on session start. The embeddings path now fails closed with the same guidance the model path already produces, and memory falls back the way it does for any other missing embeddings credential.

Operators who supply an API key by any documented route (`OPENAI_API_KEY`, `models.providers.openai.apiKey`, `memory.search.remote.apiKey`, or an api-key auth profile) are unaffected. Image generation is untouched by this revision.

## Evidence

Re-run at the current head after rebasing onto `main`.

- Patched head: `67f1f7b9c15eabb8bf505dc1cb9295d92683da30`
- Base `main`: `fb81d03d8ebd` (`fix(commands): restore tool inventory for dynamic models (#119306)`)

Driven through the real production entry point: the bundled OpenAI plugin's memory embedding provider, `createOpenAiEmbeddingProvider` (`extensions/openai/embedding-provider.ts:48`), calling `embedQuery`. No mocks and no stubs. The only substitution is the endpoint the operator configures, which is a local HTTP server that records the `Authorization` header it receives.

Setup, identical across all three runs: an isolated `OPENCLAW_HOME` and `OPENCLAW_STATE_DIR`, a ChatGPT OAuth profile written into the real SQLite auth store through the production `saveAuthProfileStore`, and `models.providers.openai.baseUrl` pointed at `http://127.0.0.1:19556/v1`. Token values are canaries, not real credentials.

The driver is reproduced in full below so this is independently runnable rather than described.

### 1. Before, pristine `main` at `fb81d03d8ebd`, no API key

```console
$ git stash && git log --oneline -1
fb81d03d8eb fix(commands): restore tool inventory for dynamic models (#119306)
$ npx tsx repro-111985.mts
=== OUTCOME ===
embedQuery returned 3 dims
=== REQUESTS THAT REACHED THE CONFIGURED OPENAI ENDPOINT ===
count: 1
  /v1/embeddings  authorization: Bearer CANARY-CHATGPT-OAUTH-ACCESS-TOKEN  oauth-token-leaked: true
```

The subscription token is sent to the configured third-party host and the call succeeds.

### 2. After, this branch, no API key

```console
$ git stash pop && git rev-parse --short HEAD
67f1f7b9c15
$ npx tsx repro-111985.mts
=== OUTCOME ===
threw: No API key found for provider "openai". You are authenticated with OpenAI ChatGPT/Codex OAuth. Use openai/gpt-5.6-sol with the ChatGPT/Codex OAuth profile, or set OPENAI_API_KEY for direct OpenAI API access.
=== REQUESTS THAT REACHED THE CONFIGURED OPENAI ENDPOINT ===
count: 0
```

Zero outbound requests. The failure names the supported alternative rather than dead-ending.

### 3. After, this branch, same OAuth profile plus an API key present

This is the upgrade path for the `merge-risk: compatibility` concern: an operator who currently relies on the OAuth-only path adds a documented API key and keeps working through the same embeddings route.

```console
$ npx tsx repro-111985.mts --with-api-key
=== OUTCOME ===
embedQuery returned 3 dims
=== REQUESTS THAT REACHED THE CONFIGURED OPENAI ENDPOINT ===
count: 1
  /v1/embeddings  authorization: Bearer sk-CANARY-DIRECT-API-KEY  oauth-token-leaked: false
```

The api-key credential is selected over the incompatible OAuth profile, the request goes out, and the OAuth token never appears on the wire.

<details>
<summary>Proof driver (<code>repro-111985.mts</code>, untracked, run from the worktree root)</summary>

```ts
import { mkdtempSync, mkdirSync } from "node:fs";
import { tmpdir } from "node:os";
import { join } from "node:path";
import http from "node:http";

const home = mkdtempSync(join(tmpdir(), "oc-embed-proof-"));
const stateDir = join(home, "state");
mkdirSync(stateDir, { recursive: true });
process.env.OPENCLAW_HOME = home;
process.env.OPENCLAW_STATE_DIR = stateDir;
const withApiKey = process.argv.includes("--with-api-key");
if (withApiKey) {
  process.env.OPENAI_API_KEY = "sk-CANARY-DIRECT-API-KEY";
} else {
  delete process.env.OPENAI_API_KEY;
}

const agentDir = join(home, "agents", "main");
mkdirSync(agentDir, { recursive: true });

const PORT = 19556;
const captured: { path: string; auth: string }[] = [];
const server = http.createServer((req, res) => {
  const auth = String(req.headers.authorization ?? "");
  captured.push({ path: req.url ?? "", auth });
  res.writeHead(200, { "Content-Type": "application/json" });
  res.end(JSON.stringify({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
});
await new Promise<void>((r) => server.listen(PORT, "127.0.0.1", r));

const { saveAuthProfileStore } = await import("./src/agents/auth-profiles/store.js");
saveAuthProfileStore(
  {
    version: 1,
    profiles: {
      "openai-oauth": {
        type: "oauth",
        provider: "openai",
        access: "CANARY-CHATGPT-OAUTH-ACCESS-TOKEN",
        refresh: "CANARY-CHATGPT-OAUTH-REFRESH-TOKEN",
        expires: Date.now() + 60 * 60 * 1000,
      },
    },
  } as never,
  agentDir,
);

const cfg = {
  auth: { order: { openai: ["openai-oauth"] } },
  models: { providers: { openai: { baseUrl: `http://127.0.0.1:${PORT}/v1` } } },
} as never;

const { createOpenAiEmbeddingProvider } = await import(
  "./extensions/openai/embedding-provider.js"
);

let outcome = "";
try {
  const { provider } = await createOpenAiEmbeddingProvider({
    config: cfg,
    agentDir,
    provider: "openai",
    model: "text-embedding-3-small",
  } as never);
  const vector = await provider.embedQuery("proof query for #111985");
  outcome = `embedQuery returned ${Array.isArray(vector) ? `${vector.length} dims` : typeof vector}`;
} catch (error) {
  outcome = `threw: ${(error as Error).message}`;
}

server.close();

console.log("=== OUTCOME ===");
console.log(outcome);
console.log("=== REQUESTS THAT REACHED THE CONFIGURED OPENAI ENDPOINT ===");
console.log(`count: ${captured.length}`);
for (const entry of captured) {
  const leaked = entry.auth.includes("CANARY-CHATGPT-OAUTH");
  console.log(`  ${entry.path}  authorization: ${entry.auth}  oauth-token-leaked: ${leaked}`);
}
process.exit(0);
```

Isolating both `OPENCLAW_HOME` and `OPENCLAW_STATE_DIR` matters: without the second one the auth store resolves to the operator's real `~/.openclaw/agents/main` and can abort on a pending legacy migration.

</details>

### Validation

```console
$ npx vitest run packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

`oxlint` is clean on both changed files. The colocated regression asserts the embeddings client forwards `modelApi`; the guard behavior it unlocks is already covered by `src/agents/model-auth.profiles.test.ts`.

Not covered: no live request to `api.openai.com`, since the capture server stands in for the configured endpoint, and no full build. The driver above is untracked and is not part of this diff.
