### PR TITLE
fix(whatsapp): audio sent as a voice note can arrive unplayable

### DIFF
--- a/extensions/whatsapp/src/outbound-media-contract.test.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.test.ts
@@ -1,0 +1,19 @@
+// Whatsapp tests cover outbound media canonicalization behavior.
+import { describe, expect, it } from "vitest";
+import { prepareWhatsAppOutboundMedia } from "./outbound-media-contract.js";
+
+describe("prepareWhatsAppOutboundMedia", () => {
+  it("labels ogg audio as a voice note when only the file name reveals the container", async () => {
+    const prepared = await prepareWhatsAppOutboundMedia(
+      {
+        buffer: Buffer.from("fake-opus-bytes"),
+        contentType: "audio/mpeg",
+        fileName: "voice.ogg",
+        kind: "audio",
+      },
+      "https://example.com/download?id=42",
+    );
+
+    expect(prepared.mimetype).toBe("audio/ogg; codecs=opus");
+  });
+});

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -138,7 +138,12 @@ function normalizeWhatsAppLoadedMedia(
 ): CanonicalWhatsAppLoadedMedia {
   const kind = inferWhatsAppMediaKind(media);
   const mimetype =
-    kind === "audio" && isWhatsAppNativeVoiceAudio({ contentType: media.contentType, mediaUrl })
+    kind === "audio" &&
+    isWhatsAppNativeVoiceAudio({
+      contentType: media.contentType,
+      fileName: media.fileName,
+      mediaUrl,
+    })
       ? WHATSAPP_VOICE_MIMETYPE
       : (media.contentType ?? "application/octet-stream");
   const fileName =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending audio to WhatsApp would deliver a voice note the recipient cannot play, when the audio's Opus/Ogg container is identifiable only from the file name rather than from the content type or the URL path.

The message still arrives, and nothing in the logs reports a problem. It is announced as a voice note (`ptt`), but its declared type contradicts the bytes actually sent, and the bytes were never normalized to the format WhatsApp voice notes require.

## Why This Change Was Made

Two decisions in the outbound media path consult the same predicate, `isWhatsAppNativeVoiceAudio`, three dozen lines apart:

- the MIME decision in `normalizeWhatsAppLoadedMedia`
- the "already native, skip transcoding" decision in `prepareWhatsAppOutboundMedia`

Only the second one passed `fileName`. The predicate falls back to the file extension whenever the content type is inconclusive, so dropping `fileName` silently narrows the evidence the first decision gets, and the two calls can reach opposite conclusions about the very same media.

When they disagree, transcoding is skipped because the audio looks native, while the MIME type keeps the caller's original value. The fix passes `fileName` at the first call site so both decisions see the same evidence. This is deliberately the minimal correction: the predicate, the extension fallback, and the transcode path are all unchanged.

## User Impact

Audio whose Opus container is only evident from its file name is now labelled `audio/ogg; codecs=opus`, matching what is actually sent, so recipients get a playable voice note. Audio that genuinely is not native Opus continues to be transcoded exactly as before, and callers that already supply an explicit `audio/ogg` or `audio/opus` content type are unaffected.

## Evidence

Added `extensions/whatsapp/src/outbound-media-contract.test.ts`, covering media that carries `contentType: "audio/mpeg"` with `fileName: "voice.ogg"` behind a URL that reveals no extension. The test needs no ffmpeg and no live WhatsApp session, because the buggy path returns before transcoding.

The test is load-bearing: run against the unfixed source it fails with the exact defect, rather than an incidental error.

Before the fix:

```
FAIL extensions/whatsapp/src/outbound-media-contract.test.ts > prepareWhatsAppOutboundMedia
  > labels ogg audio as a voice note when only the file name reveals the container
AssertionError: expected 'audio/mpeg' to be 'audio/ogg; codecs=opus'
Expected: "audio/ogg; codecs=opus"
Received: "audio/mpeg"

Test Files  1 failed (1)
     Tests  1 failed (1)
```

After the fix:

```
Test Files  1 passed (1)
     Tests  1 passed (1)
```

Existing coverage of the surface stays green, including `deliver-reply.test.ts`, which pins `audio/ogg; codecs=opus` on the voice-note delivery path:

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts \
  extensions/whatsapp/src/auto-reply/deliver-reply.test.ts \
  extensions/whatsapp/src/outbound-media-contract.test.ts

Test Files  2 passed (2)
     Tests  33 passed (33)
```

`oxfmt --check` is clean on both touched files.

AI-assisted: written and verified with an AI coding agent; the analysis, the failing-test-first measurement, and the regression runs above were reviewed by me.
