### PR TITLE
fix(skills): honor Codex agents/openai.yaml invocation policy

### DIFF
--- a/src/skills/loading/codex-invocation-policy.test.ts
+++ b/src/skills/loading/codex-invocation-policy.test.ts
@@ -1,0 +1,69 @@
+// Tests for the Codex `agents/openai.yaml` sidecar reader.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { readCodexImplicitInvocationDisabled } from "./codex-invocation-policy.js";
+
+describe("readCodexImplicitInvocationDisabled", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  let root: string;
+
+  beforeEach(() => {
+    root = tempDirs.make("codex-sidecar-");
+  });
+
+  function writeSidecar(skillName: string, content: string | null) {
+    const skillDir = join(root, skillName);
+    mkdirSync(join(skillDir, "agents"), { recursive: true });
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---\nname: ${skillName}\ndescription: ${skillName}\n---\n`,
+    );
+    if (content !== null) {
+      writeFileSync(join(skillDir, "agents", "openai.yaml"), content);
+    }
+    return skillDir;
+  }
+
+  it("returns false when no sidecar is present", () => {
+    const dir = writeSidecar("no-sidecar", null);
+    expect(readCodexImplicitInvocationDisabled(dir)).toBe(false);
+  });
+
+  it("returns true when policy.allow_implicit_invocation is false", () => {
+    const dir = writeSidecar("explicit-only", "policy:\n  allow_implicit_invocation: false\n");
+    expect(readCodexImplicitInvocationDisabled(dir)).toBe(true);
+  });
+
+  it("returns false when policy.allow_implicit_invocation is true", () => {
+    const dir = writeSidecar("implicit-ok", "policy:\n  allow_implicit_invocation: true\n");
+    expect(readCodexImplicitInvocationDisabled(dir)).toBe(false);
+  });
+
+  it("returns false when the sidecar omits the policy key", () => {
+    const dir = writeSidecar("no-policy", "interface:\n  display_name: No Policy\n");
+    expect(readCodexImplicitInvocationDisabled(dir)).toBe(false);
+  });
+
+  it("honors the policy alongside an interface block (real-world shape)", () => {
+    const dir = writeSidecar(
+      "full-sidecar",
+      "interface:\n  display_name: Full\npolicy:\n  allow_implicit_invocation: false\n",
+    );
+    expect(readCodexImplicitInvocationDisabled(dir)).toBe(true);
+  });
+
+  it("returns false on unparseable YAML (never restricts on malformed input)", () => {
+    const dir = writeSidecar(
+      "malformed",
+      "policy: [unclosed\n  allow_implicit_invocation: false\n",
+    );
+    expect(readCodexImplicitInvocationDisabled(dir)).toBe(false);
+  });
+
+  it("returns false when allow_implicit_invocation is a non-boolean value", () => {
+    const dir = writeSidecar("string-val", 'policy:\n  allow_implicit_invocation: "false"\n');
+    expect(readCodexImplicitInvocationDisabled(dir)).toBe(false);
+  });
+});

--- a/src/skills/loading/codex-invocation-policy.ts
+++ b/src/skills/loading/codex-invocation-policy.ts
@@ -1,0 +1,69 @@
+// Reads Codex's per-skill `agents/openai.yaml` sidecar to derive whether
+// implicit (model) invocation is disabled for a skill.
+//
+// Codex stores invocation policy in this sidecar (`policy.allow_implicit_invocation`),
+// separate from the SKILL.md frontmatter field `disable-model-invocation` that
+// OpenClaw reads. The core Agent Skills specification defines neither field;
+// both are client-specific extensions. OpenClaw discovers the same shared
+// Agent Skills roots as Codex (`~/.agents/skills`, `.agents/skills`), so when a
+// skill author marks a workflow explicit-only via the Codex sidecar, OpenClaw
+// must honor it too -- otherwise the same on-disk skill is implicit-invocable in
+// one client and explicit-only in the other.
+//
+// The sidecar is read through the same root-scoped boundary helper used for
+// SKILL.md so a symlinked sidecar cannot escape the skill root. Only an explicit
+// `policy.allow_implicit_invocation: false` disables invocation; an absent sidecar,
+// a missing policy key, or an unparseable file leaves behavior unchanged (returns
+// false), so malformed input can never restrict a skill that would otherwise load.
+import { closeSync, existsSync, realpathSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { openRootFileSync, readFileDescriptorBoundedSync } from "../../infra/boundary-file-read.js";
+
+/** Cap sidecar reads: a metadata YAML file is tiny in practice. */
+const CODEX_SIDECAR_MAX_BYTES = 65_536;
+
+/** Path of the sidecar relative to the skill directory. */
+const CODEX_SIDECAR_RELATIVE_PATH = join("agents", "openai.yaml");
+
+/**
+ * Returns whether Codex's `agents/openai.yaml` sidecar disables implicit
+ * (model) invocation for the skill at `skillDir`. See module docs for the
+ * conservative default (false) on absent/malformed input.
+ */
+export function readCodexImplicitInvocationDisabled(skillDir: string): boolean {
+  const sidecarPath = resolve(skillDir, CODEX_SIDECAR_RELATIVE_PATH);
+  // Cheap stat gates the realpath + bounded open behind the sidecar actually
+  // existing; openRootFileSync re-validates, so the race is harmless.
+  if (!existsSync(sidecarPath)) {
+    return false;
+  }
+  let rootRealPath: string;
+  try {
+    rootRealPath = realpathSync(skillDir);
+  } catch {
+    return false;
+  }
+  const opened = openRootFileSync({
+    absolutePath: sidecarPath,
+    rootPath: rootRealPath,
+    rootRealPath,
+    boundaryLabel: "skill root",
+    maxBytes: CODEX_SIDECAR_MAX_BYTES,
+  });
+  if (!opened.ok) {
+    return false;
+  }
+  try {
+    const buffer = readFileDescriptorBoundedSync(opened.fd, CODEX_SIDECAR_MAX_BYTES);
+    const parsed = parseYaml(buffer.toString("utf8")) as
+      | { policy?: { allow_implicit_invocation?: unknown } }
+      | null
+      | undefined;
+    return parsed?.policy?.allow_implicit_invocation === false;
+  } catch {
+    return false;
+  } finally {
+    closeSync(opened.fd);
+  }
+}

--- a/src/skills/loading/frontmatter.test.ts
+++ b/src/skills/loading/frontmatter.test.ts
@@ -21,6 +21,21 @@ describe("resolveSkillInvocationPolicy", () => {
     expect(policy.userInvocable).toBe(false);
     expect(policy.disableModelInvocation).toBe(true);
   });
+
+  it("honors a Codex sidecar disable even when frontmatter allows invocation", () => {
+    const policy = resolveSkillInvocationPolicy({ "disable-model-invocation": "false" }, true);
+    expect(policy.disableModelInvocation).toBe(true);
+  });
+
+  it("keeps invocation enabled when neither declaration disables it", () => {
+    const policy = resolveSkillInvocationPolicy({}, false);
+    expect(policy.disableModelInvocation).toBe(false);
+  });
+
+  it("frontmatter disable still applies when the sidecar allows invocation", () => {
+    const policy = resolveSkillInvocationPolicy({ "disable-model-invocation": "true" }, false);
+    expect(policy.disableModelInvocation).toBe(true);
+  });
 });
 
 describe("parseFrontmatter", () => {

--- a/src/skills/loading/frontmatter.ts
+++ b/src/skills/loading/frontmatter.ts
@@ -214,13 +214,18 @@ export function resolveOpenClawMetadata(
 
 export function resolveSkillInvocationPolicy(
   frontmatter: ParsedSkillFrontmatter,
+  codexImplicitDisabled = false,
 ): SkillInvocationPolicy {
   return {
     userInvocable: parseFrontmatterBool(getFrontmatterString(frontmatter, "user-invocable"), true),
-    disableModelInvocation: parseFrontmatterBool(
-      getFrontmatterString(frontmatter, "disable-model-invocation"),
-      false,
-    ),
+    // A skill is hidden from implicit model context when either declaration
+    // disables it: the SKILL.md `disable-model-invocation` field or Codex's
+    // `agents/openai.yaml` -> `policy.allow_implicit_invocation: false`. The
+    // latter is resolved by the caller via readCodexImplicitInvocationDisabled
+    // so this helper stays free of filesystem I/O.
+    disableModelInvocation:
+      parseFrontmatterBool(getFrontmatterString(frontmatter, "disable-model-invocation"), false) ||
+      codexImplicitDisabled,
   };
 }
 

--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { openRootFileSync } from "../../infra/boundary-file-read.js";
 import type { ParsedSkillFrontmatter } from "../types.js";
+import { readCodexImplicitInvocationDisabled } from "./codex-invocation-policy.js";
 import { parseFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
 import { createSyntheticSourceInfo, type Skill } from "./skill-contract.js";
 import { computeSkillPromptVersion } from "./skill-version.js";
@@ -72,7 +73,10 @@ function loadSingleSkillDirectory(params: {
   if (!name || !description) {
     return null;
   }
-  const invocation = resolveSkillInvocationPolicy(frontmatter);
+  const invocation = resolveSkillInvocationPolicy(
+    frontmatter,
+    readCodexImplicitInvocationDisabled(params.skillDir),
+  );
   const filePath = path.resolve(skillFilePath);
   const baseDir = path.resolve(params.skillDir);
 

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -8,6 +8,7 @@ import { addIgnoreRules, toPosixPath, type IgnoreMatcher } from "../../shared/ig
 // Session skill helpers resolve skills attached to a session and its transcript state.
 import { expandTildePath } from "../../shared/tilde-path.js";
 import { getArchivedSkillFiles } from "../workshop/curator.js";
+import { readCodexImplicitInvocationDisabled } from "./codex-invocation-policy.js";
 import { parseFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
 import { formatSkillsForPrompt as formatSkillContractForPrompt } from "./skill-contract.js";
 import { computeSkillPromptVersion } from "./skill-version.js";
@@ -216,8 +217,11 @@ function loadSkillFromFile(
   try {
     const rawContent = readFileSync(filePath, "utf-8");
     const frontmatter = parseFrontmatter(rawContent);
-    const invocation = resolveSkillInvocationPolicy(frontmatter);
     const skillDir = dirname(filePath);
+    const invocation = resolveSkillInvocationPolicy(
+      frontmatter,
+      readCodexImplicitInvocationDisabled(skillDir),
+    );
     const parentDirName = basename(skillDir);
 
     // Validate description

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -36,6 +36,7 @@ import type {
 import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION } from "../types.js";
 import { getArchivedSkillFiles } from "../workshop/curator.js";
 import { resolveBundledSkillsDir } from "./bundled-dir.js";
+import { readCodexImplicitInvocationDisabled } from "./codex-invocation-policy.js";
 import {
   hasUnavailableSkillSecretOwners,
   isSkillSecretOwnerUnavailable,
@@ -1286,7 +1287,10 @@ function loadSkillEntries(
           maxBytes: limits.maxSkillFileBytes,
         }) ??
         ({} as ParsedSkillFrontmatter);
-      const invocation = resolveSkillInvocationPolicy(frontmatter);
+      const invocation = resolveSkillInvocationPolicy(
+        frontmatter,
+        readCodexImplicitInvocationDisabled(skill.baseDir),
+      );
       const entry: SkillEntry = {
         skill,
         frontmatter,


### PR DESCRIPTION
Fixes #115337

## What Problem This Solves

OpenClaw discovers skills from the same shared Agent Skills roots as Codex (`~/.agents/skills`, `.agents/skills`), but it derives invocation policy only from the SKILL.md `disable-model-invocation` frontmatter field and ignores Codex's per-skill `agents/openai.yaml` -> `policy.allow_implicit_invocation`. So a skill an author marks explicit-only for Codex is still exposed to the model for implicit invocation when OpenClaw loads the same on-disk installation. The repo's own bundled `openclaw-test-performance` skill ships `allow_implicit_invocation: false` with no `disable-model-invocation`, so it is currently mis-exposed.

## Why This Change Was Made

The core Agent Skills specification defines neither field; both are client-specific extensions that now meet on the same shared skill installation. Rather than require authors to maintain two equivalent declarations, OpenClaw honors the Codex sidecar the same way it already reads SKILL.md frontmatter.

- New `readCodexImplicitInvocationDisabled(skillDir)` reads the colocated `<skill>/agents/openai.yaml` sidecar through the same root-scoped boundary helper (`openRootFileSync` + `readFileDescriptorBoundedSync`) used for SKILL.md, so a symlinked sidecar cannot escape the skill root and reads are byte-bounded.
- Only an explicit `policy.allow_implicit_invocation: false` disables invocation. An absent sidecar, a missing policy key, a non-boolean value, or an unparseable file leaves behavior unchanged (returns `false`), so malformed input can never restrict a skill that would otherwise load.
- `resolveSkillInvocationPolicy(frontmatter, codexImplicitDisabled = false)` ORs the two declarations: a skill is hidden from implicit model context when **either** declaration disables it. The merge lives in the shared helper, so every consumer of `invocation.disableModelInvocation` (session loader, local loader, workspace `includeInAvailableSkillsPrompt`) picks it up. The helper stays free of filesystem I/O; only the new module reads disk.
- Remote (node-hosted) skills are intentionally out of scope: they have no local sidecar and `resolveSkillInvocationPolicy` is called there with the default.

## User Impact

A shared `~/.agents/skills` installation now behaves consistently across Codex and OpenClaw: a workflow an author marked explicit-only (`allow_implicit_invocation: false`) is excluded from the model's available-skills prompt in both clients, while remaining invocable via explicit `/skill:name`. Skills without the sidecar, or with `allow_implicit_invocation: true`, are unaffected.

## Evidence

- `node scripts/run-vitest.mjs src/skills/loading/codex-invocation-policy.test.ts` - 7/7 passed
- `node scripts/run-vitest.mjs src/skills/loading/frontmatter.test.ts` - passed (incl. new merge cases)
- `node scripts/run-vitest.mjs src/skills/loading/session.test.ts` - passed
- `node scripts/run-vitest.mjs src/skills/loading/workspace-load.test.ts` - passed
- `oxlint src/skills/loading/**` - passed (no findings)
- `oxfmt --check` on all changed files - passed
- `tsgo -p tsconfig.core.json` - passed

Real behavior proof at exact PR head `893df76e42b6520b73941684e08004fe0c992909`. The proof loads the **real** local skill loader (`loadSkillsFromDirSafe`) and the **real** prompt formatter (`formatSkillsForPrompt`, the public API that assembles the model's available-skills prompt) from source, against a temp skill carrying `agents/openai.yaml`:

```text
[before fix, clean upstream/main c193ffd554642c4b5b2e0e11b1c12dbb6348c66b]
case: explicit-only via Codex sidecar (allow_implicit_invocation: false)
  disableModelInvocation: false (expected true)   <- BUG: explicit-only skill treated as implicit-invocable
  appears in prompt     : true                      <- BUG: exposed to the model
  ok                    : NO
RESULT: MISMATCH

[after fix, PR head 893df76e42b6520b73941684e08004fe0c992909]  pnpm exec tsx scripts/proof/skills-codex-invocation-policy.mjs
case: explicit-only via Codex sidecar (allow_implicit_invocation: false)
  disableModelInvocation: true (expected true)
  appears in prompt     : false
  ok                    : YES
case: implicit-allowed via Codex sidecar (allow_implicit_invocation: true)
  disableModelInvocation: false (expected false)
  appears in prompt     : true
  ok                    : YES
case: no sidecar (OpenClaw default behavior)
  disableModelInvocation: false (expected false)
  appears in prompt     : true
  ok                    : YES
case: sidecar present but policy key absent
  disableModelInvocation: false (expected false)
  appears in prompt     : true
  ok                    : YES
case: malformed sidecar (unparseable YAML)
  disableModelInvocation: false (expected false)
  appears in prompt     : true
  ok                    : YES
RESULT: ALL CASES MATCH EXPECTATION
```

Notes on what was not tested locally: two pre-existing Windows-only flakes are unrelated to this change and were verified to fail identically on clean `upstream/main` -- `compact-format.test.ts` (`~/` path compaction on Windows HOME) and `agents-directory.test.ts` (`EBUSY` on `openclaw.sqlite-shm` during teardown). Both are environmental and do not reproduce on Linux CI.

AI-assisted: Claude


