### PR TITLE
fix(agents): stop false failures for completed grep and shell checks

### DIFF
--- a/src/agents/embedded-agent-subscribe.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.test.ts
@@ -195,8 +195,9 @@ describe("isToolResultError", () => {
     expect(isToolResultError({ details: { status: "blocked" } })).toBe(true);
     expect(isToolResultError({ details: { status: "approval-unavailable" } })).toBe(true);
     expect(isToolResultError({ details: { status: "completed", timedOut: true } })).toBe(true);
-    expect(isToolResultError({ details: { status: "completed", exitCode: 1 } })).toBe(true);
+    expect(isToolResultError({ details: { status: "completed", exitCode: 1 } })).toBe(false);
     expect(isToolResultError({ details: { status: "completed", exitCode: 0 } })).toBe(false);
+    expect(isToolResultError({ details: { exitCode: 1 } })).toBe(true);
     expect(isToolResultError({ details: { ok: true, status: "cancelled" } })).toBe(false);
     expect(isToolResultError({ details: { success: true, status: "canceled" } })).toBe(false);
     expect(isToolResultError({ details: { ok: false, status: "completed" } })).toBe(true);

--- a/src/agents/tool-result-error.test.ts
+++ b/src/agents/tool-result-error.test.ts
@@ -1,8 +1,32 @@
 import { describe, expect, it } from "vitest";
 import {
+  isToolResultError,
   resolveToolExecutionErrorKind,
   resolveToolResultFailureKind,
 } from "./tool-result-error.js";
+
+describe("isToolResultError", () => {
+  it("keeps completed results with nonzero exit codes nonfatal", () => {
+    expect(isToolResultError({ details: { status: "completed", exitCode: 1 } })).toBe(false);
+    expect(isToolResultError({ details: { status: "completed", exitCode: 2 } })).toBe(false);
+    expect(isToolResultError({ details: { status: "completed", exitCode: 0 } })).toBe(false);
+  });
+
+  it("keeps real failures fatal even with a completed status", () => {
+    expect(isToolResultError({ details: { status: "completed", timedOut: true } })).toBe(true);
+    expect(isToolResultError({ details: { status: "completed", error: "spawn failed" } })).toBe(
+      true,
+    );
+    expect(isToolResultError({ details: { ok: false, status: "completed" } })).toBe(true);
+  });
+
+  it("keeps failure statuses and statusless nonzero exits fatal", () => {
+    expect(isToolResultError({ details: { status: "failed", exitCode: 1 } })).toBe(true);
+    expect(isToolResultError({ details: { status: "failed", exitCode: 127 } })).toBe(true);
+    expect(isToolResultError({ details: { status: "killed", exitCode: 137 } })).toBe(true);
+    expect(isToolResultError({ details: { exitCode: 1 } })).toBe(true);
+  });
+});
 
 describe("resolveToolExecutionErrorKind", () => {
   it("recognizes structured timeout identities", () => {
@@ -52,5 +76,14 @@ describe("resolveToolResultFailureKind", () => {
 
     expect(resolveToolResultFailureKind({ details: hostileDetails })).toBeUndefined();
     expect(resolveToolResultFailureKind(hostileResult)).toBeUndefined();
+  });
+
+  it("does not classify completed nonzero exits as failures", () => {
+    expect(
+      resolveToolResultFailureKind({ details: { status: "completed", exitCode: 1 } }),
+    ).toBeUndefined();
+    expect(resolveToolResultFailureKind({ details: { status: "failed", exitCode: 1 } })).toBe(
+      "failed",
+    );
   });
 });

--- a/src/agents/tool-result-error.ts
+++ b/src/agents/tool-result-error.ts
@@ -108,6 +108,9 @@ export function isToolResultError(result: unknown): boolean {
   if (timedOut === true || Boolean(error)) {
     return true;
   }
+  if (normalized === "completed") {
+    return false;
+  }
   const exitCode = details ? readToolErrorField(details, "exitCode") : undefined;
   return typeof exitCode === "number" && Number.isFinite(exitCode) && exitCode !== 0;
 }


### PR DESCRIPTION
Closes #107278.
Supersedes #111574 while preserving its exact reviewed patch and original contributor as a commit co-author.

## What Problem This Solves

Fixes an issue where agents and scheduled jobs reported a normal completed shell check as a failed tool when a command such as a no-match `grep` exited with 1. This produced misleading failure warnings and incorrect terminal diagnostics even though the exec runtime had already correctly marked the command completed.

## Why This Change Was Made

Honor an explicit completed tool status only after existing checks for actual failure statuses, `ok: false`, timeout, and error fields. Keep the legacy nonzero-exit fallback for statusless results. This respects the shared producer contract without hiding shell-dispatch failures, denials, blocked calls, cancellations, timeouts, or genuine runtime errors.

All three changed files are byte-for-byte hunk-equivalent to contributor PR #111574. This maintainer-owned branch was independently reconstructed, rebased onto the repaired current `main`, and committed with original contributor Yuval Dinodia as co-author. It is required because the original fork's otherwise green hosted evidence exceeds the native landing gate's 24-hour freshness limit.

## User Impact

Normal no-match searches and other completed semantic shell exits no longer send false failure warnings or mark cron/agent work as failed. Genuine errors and existing warning protections continue to surface.

## Evidence

- Reproduced the original failure on unpatched `main` using real shell processes.
- Executed a real no-match `grep`, a real stdout-preserving exit 1, and a real exit 2; passed every actual result through production agent tool-start/end handlers. Verified completed status, exact exit codes, successful lifecycle, `isError: false`, preserved output, and no sticky tool failure.
- Verified eight real classification controls: completed-with-timeout, completed-with-error, completed-with-`ok: false`, statusless nonzero, blocked, denied, cancelled, and failed.
- **745 tests passed across 20 touched/sibling test files and eight projects**, including full Codex dynamic-tool/projector, pinned Copilot bridge, gateway/MCP, cron, shell, handler, middleware, CLI, and Code Mode runtime/repair suites.
- Confirmed the repaired main baseline passes actual full-tree production, script, and all-export Knip scans.
- Full remote `pnpm check:changed -- src/agents/tool-result-error.ts src/agents/tool-result-error.test.ts src/agents/embedded-agent-subscribe.tools.test.ts` passed production/test typechecking, format, lint, dead-code, dependency, SDK, plugin-boundary, schema, database, and security gates.
- Fresh independent Codex **xhigh** autoreview returned no accepted/actionable findings.
- Personally inspected upstream Codex `fe01054a28fa4bd04716d9ceadb410f2443a50ce`: `codex-rs/protocol/src/dynamic_tools.rs:45`, `codex-rs/app-server-protocol/src/protocol/event_mapping.rs:38`, and real semantic-exit proof in `codex-rs/core/src/unified_exec/mod_tests.rs:741`.
- Personally inspected exact pinned Copilot SDK `v1.0.7`, `d95cfacc5d3ca13ce8cc9a3ece2746134da5c50c`: `nodejs/src/types.ts:437`, `:516`, and `:571`. Both integrations require explicit success/failure rather than inferring failure from an explicitly completed semantic exit.
- Explicit maintainer decision resolving the original ClawSweeper contract and rank-up concerns: https://github.com/openclaw/openclaw/pull/111574#issuecomment-5114447130.
