### PR TITLE
fix(agents): edit rejects a unique match as ambiguous

### DIFF
--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -136,3 +136,31 @@ describe("generateDiffString", () => {
     });
   });
 });
+
+describe("applyEditsToNormalizedContent uniqueness", () => {
+  it("replaces an exactly unique match when trailing whitespace makes a sibling line fuzzy-identical", () => {
+    const content = "foo();  \nfoo();\nbar();\n";
+
+    const result = applyEditsToNormalizedContent(
+      normalizeToLF(content),
+      [{ oldText: "foo();\n", newText: "baz();\n" }],
+      "test.ts",
+    );
+
+    expect(result.newContent).toBe("foo();  \nbaz();\nbar();\n");
+  });
+});
+
+describe("applyEditsToNormalizedContent fuzzy uniqueness", () => {
+  it("still rejects a fuzzy match that is ambiguous once normalization is applied", () => {
+    const content = "foo();  \nfoo();\t\nbar();\n";
+
+    expect(() =>
+      applyEditsToNormalizedContent(
+        normalizeToLF(content),
+        [{ oldText: "foo();\n", newText: "baz();\n" }],
+        "test.ts",
+      ),
+    ).toThrow(/Found 2 occurrences/);
+  });
+});

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -264,6 +264,10 @@ function countOccurrences(content: string, oldText: string): number {
   return fuzzyContent.split(fuzzyOldText).length - 1;
 }
 
+function countExactOccurrences(content: string, oldText: string): number {
+  return content.split(oldText).length - 1;
+}
+
 const EDIT_CANDIDATE_LIMIT = 3;
 const EDIT_CANDIDATE_MAX_LINES = 1000;
 const EDIT_CANDIDATE_MAX_SCAN_CHARS = 128 * 1024;
@@ -490,7 +494,12 @@ export function applyEditsToNormalizedContent(
       throw getNotFoundError(path, i, normalizedEdits.length, normalizedContent, edit.oldText);
     }
 
-    const occurrences = countOccurrences(replacementBaseContent, edit.oldText);
+    // Count in the same space the match was found in. Fuzzy counting collapses
+    // distinctions the exact match relied on, which would reject a genuinely
+    // unique edit as ambiguous.
+    const occurrences = matchResult.usedFuzzyMatch
+      ? countOccurrences(replacementBaseContent, edit.oldText)
+      : countExactOccurrences(replacementBaseContent, edit.oldText);
     if (occurrences > 1) {
       throw getDuplicateError(path, i, normalizedEdits.length, occurrences);
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent using the `edit` tool would have a perfectly unambiguous edit refused with:

```
Found 2 occurrences of the text in <path>. The text must be unique.
Please provide more context to make it unique.
```

even though the text it asked to replace occurs exactly once in the file.

The trigger is ordinary: another line in the file is identical to the target except for characters that only matter to fuzzy matching, such as trailing whitespace, a smart quote, an en-dash, or a non-breaking space. Files that mix straight and curly quotes, or that have stray trailing spaces, hit this routinely.

The practical cost falls on the model. It is told to "provide more context", so it retries with a larger `oldText`, which frequently spans another near-duplicate line and is refused again.

## Why This Change Was Made

`applyEditsToNormalizedContent` locates the edit with `fuzzyFindText`, which is documented to try an exact match first and only fall back to fuzzy matching. The uniqueness gate immediately below it called `countOccurrences`, which unconditionally normalizes both sides before counting.

So the match and the safety check ran in two different string spaces. On the exact path the match was found in raw content, while the count was taken after normalization had folded away exactly the distinctions the match had relied on. Any sibling line that is only fuzzily identical inflated the count, and the edit was rejected as ambiguous.

The fix counts in whichever space the match was actually found in, using `matchResult.usedFuzzyMatch`, which the function already computes and returns. Fuzzy matches keep counting fuzzily, so an edit that really is ambiguous under normalization is still refused. Nothing about matching, normalization, or the error text changes.

## User Impact

Agents can now apply an edit whose target text is genuinely unique, even when the file contains near-duplicate lines differing only in trailing whitespace or Unicode punctuation. Ambiguity protection is unchanged for fuzzy matches, so edits that could land in the wrong place are still refused.

## Evidence

Two tests were added to `src/agents/sessions/tools/edit-diff.test.ts`.

The first pins the fix and is load-bearing. Against the unfixed source it fails with the exact defect:

```
FAIL src/agents/sessions/tools/edit-diff.test.ts
  > applyEditsToNormalizedContent uniqueness
  > replaces an exactly unique match when trailing whitespace makes a sibling line fuzzy-identical
Error: Found 2 occurrences of the text in test.ts. The text must be unique.
 ❯ getDuplicateError src/agents/sessions/tools/edit-diff.ts:428:12
 ❯ applyEditsToNormalizedContent src/agents/sessions/tools/edit-diff.ts:495:13

Test Files  1 failed (1)
     Tests  1 failed | 12 passed (13)
```

The second is the control case: content where the target is ambiguous only under normalization, and where no exact match exists at all. It asserts the duplicate error is still raised, so the change cannot be read as simply weakening the uniqueness gate.

After the fix, both pass along with the existing suite:

```
Test Files  1 passed (1)
     Tests  14 passed (14)
```

`oxfmt --check` is clean on both touched files.

One note on scope: `src/agents/sessions/tools/edit.test.ts` has two pre-existing failures in `renders previews through custom edit operations`. They reproduce identically with this change stashed, so they are unrelated to it and are left alone.

AI-assisted: written and verified with an AI coding agent; the failing-test-first measurement, the control case, and the stashed comparison above were reviewed by me.
