### PR TITLE
fix(ai): tool calls fail when an unsupported schema keyword is nested

### DIFF
--- a/packages/ai/src/providers/schema-keyword-strip.test.ts
+++ b/packages/ai/src/providers/schema-keyword-strip.test.ts
@@ -43,4 +43,56 @@ describe("stripUnsupportedSchemaKeywords", () => {
       patternProperties: { "^x-": { type: "array" } },
     });
   });
+
+  it("strips schema dependencies without changing property dependency arrays", () => {
+    const schema = {
+      type: "object",
+      dependencies: {
+        payload: { type: "string", maxLength: 100 },
+        billingAddress: ["creditCard"],
+      },
+    };
+
+    const result = stripUnsupportedSchemaKeywords(schema, new Set(["maxLength"]));
+
+    expect(result).toEqual({
+      type: "object",
+      dependencies: {
+        payload: { type: "string" },
+        billingAddress: ["creditCard"],
+      },
+    });
+  });
+
+  it.each([
+    "additionalItems",
+    "contentSchema",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+  ] as const)("strips unsupported keywords nested under %s", (container) => {
+    const schema = {
+      type: "object",
+      [container]: { type: "string", maxLength: 100 },
+    };
+
+    const result = stripUnsupportedSchemaKeywords(schema, new Set(["maxLength"]));
+
+    expect(result).toEqual({
+      type: "object",
+      [container]: { type: "string" },
+    });
+  });
+
+  it("preserves boolean schemas and non-schema object values", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: true,
+      unevaluatedItems: false,
+      default: { maxLength: 100 },
+      examples: [{ maxLength: 100 }],
+      metadata: { maxLength: 100 },
+    };
+
+    expect(stripUnsupportedSchemaKeywords(schema, new Set(["maxLength"]))).toEqual(schema);
+  });
 });

--- a/packages/ai/src/providers/schema-keyword-strip.test.ts
+++ b/packages/ai/src/providers/schema-keyword-strip.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { stripUnsupportedSchemaKeywords } from "./schema-keyword-strip.js";
+
+describe("stripUnsupportedSchemaKeywords", () => {
+  it("strips unsupported keywords nested under additionalProperties", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: { type: "string", maxLength: 100 },
+    };
+
+    const result = stripUnsupportedSchemaKeywords(schema, new Set(["maxLength"]));
+
+    expect(result).toEqual({
+      type: "object",
+      additionalProperties: { type: "string" },
+    });
+  });
+
+  it("strips unsupported keywords nested under prefixItems", () => {
+    const schema = {
+      type: "array",
+      prefixItems: [{ type: "string", minLength: 2 }],
+    };
+
+    const result = stripUnsupportedSchemaKeywords(schema, new Set(["minLength"]));
+
+    expect(result).toEqual({
+      type: "array",
+      prefixItems: [{ type: "string" }],
+    });
+  });
+
+  it("strips unsupported keywords nested under patternProperties", () => {
+    const schema = {
+      type: "object",
+      patternProperties: { "^x-": { type: "array", maxItems: 3 } },
+    };
+
+    const result = stripUnsupportedSchemaKeywords(schema, new Set(["maxItems"]));
+
+    expect(result).toEqual({
+      type: "object",
+      patternProperties: { "^x-": { type: "array" } },
+    });
+  });
+});

--- a/packages/ai/src/providers/schema-keyword-strip.ts
+++ b/packages/ai/src/providers/schema-keyword-strip.ts
@@ -1,25 +1,30 @@
-/**
- * Containers whose value is a map of property name to schema.
- * Mirrors the keyword sets the caller uses in `agent-tools-parameter-schema.ts`.
- */
+// This helper accepts draft-07 through 2020-12 schemas. Keep the union of
+// schema-bearing keys aligned with the package's dialect-specific walkers.
 const SCHEMA_MAP_KEYS = new Set([
   "$defs",
   "definitions",
   "dependentSchemas",
+  // Draft-07 dependencies mix schemas with property-name arrays. Recursive
+  // stripping leaves the string entries in those arrays unchanged.
+  "dependencies",
   "patternProperties",
   "properties",
 ]);
 
 /** Containers whose value is a single nested schema. */
 const SCHEMA_OBJECT_KEYS = new Set([
+  "additionalItems",
   "additionalProperties",
   "contains",
+  "contentSchema",
   "else",
   "if",
   "items",
   "not",
   "propertyNames",
   "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
 ]);
 
 /** Containers whose value is a list of nested schemas. */

--- a/packages/ai/src/providers/schema-keyword-strip.ts
+++ b/packages/ai/src/providers/schema-keyword-strip.ts
@@ -1,3 +1,30 @@
+/**
+ * Containers whose value is a map of property name to schema.
+ * Mirrors the keyword sets the caller uses in `agent-tools-parameter-schema.ts`.
+ */
+const SCHEMA_MAP_KEYS = new Set([
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+]);
+
+/** Containers whose value is a single nested schema. */
+const SCHEMA_OBJECT_KEYS = new Set([
+  "additionalProperties",
+  "contains",
+  "else",
+  "if",
+  "items",
+  "not",
+  "propertyNames",
+  "then",
+]);
+
+/** Containers whose value is a list of nested schemas. */
+const SCHEMA_ARRAY_KEYS = new Set(["allOf", "anyOf", "items", "oneOf", "prefixItems"]);
+
 /** Recursively remove schema keywords unsupported by a target provider/tool surface. */
 export function stripUnsupportedSchemaKeywords(
   schema: unknown,
@@ -17,7 +44,7 @@ export function stripUnsupportedSchemaKeywords(
     }
     // Schema containers hold nested schemas under different shapes. Recurse
     // through each known container while preserving unrelated metadata fields.
-    if (key === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
+    if (SCHEMA_MAP_KEYS.has(key) && value && typeof value === "object" && !Array.isArray(value)) {
       cleaned[key] = Object.fromEntries(
         Object.entries(value as Record<string, unknown>).map(([childKey, childValue]) => [
           childKey,
@@ -26,16 +53,14 @@ export function stripUnsupportedSchemaKeywords(
       );
       continue;
     }
-    if (key === "items" && value && typeof value === "object") {
-      cleaned[key] = Array.isArray(value)
-        ? value.map((entry) => stripUnsupportedSchemaKeywords(entry, unsupportedKeywords))
-        : stripUnsupportedSchemaKeywords(value, unsupportedKeywords);
-      continue;
-    }
-    if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
+    if (SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(value)) {
       cleaned[key] = value.map((entry) =>
         stripUnsupportedSchemaKeywords(entry, unsupportedKeywords),
       );
+      continue;
+    }
+    if (SCHEMA_OBJECT_KEYS.has(key) && value && typeof value === "object") {
+      cleaned[key] = stripUnsupportedSchemaKeywords(value, unsupportedKeywords);
       continue;
     }
     cleaned[key] = value;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users on a model that declares `unsupportedToolSchemaKeywords` would still get their tool calls refused by the provider, because the keyword the model cannot accept was left in the request.

The compatibility layer is meant to make these models usable by removing the offending keywords before the request goes out. It reports success, but the keyword is still there whenever it sits inside a schema container the strip does not walk. From the user's side the model simply fails to call the tool, and the compat setting looks like it does nothing.

Models that configure this today: xAI and Venice (`minContains`, `maxContains`), Fireworks (`not`), and any LM Studio model configured with a keyword list.

## Why This Change Was Made

`stripUnsupportedSchemaKeywords` recursed through five containers — `properties`, `items`, `anyOf`, `oneOf`, `allOf` — and copied every other value through verbatim. JSON Schema has considerably more places a subschema can live, so a keyword nested under any of these survived:

`additionalProperties`, `prefixItems`, `patternProperties`, `contains`, `propertyNames`, `not`, `if` / `then` / `else`, `dependentSchemas`, `$defs`, `definitions`

These are not exotic shapes. `additionalProperties` holding a schema is the ordinary way to describe a dictionary, and it is common in MCP tool definitions.

The full container list was already written down in this function's own caller, `agent-tools-parameter-schema.ts`, as `SCHEMA_MAP_KEYS`, `SCHEMA_OBJECT_KEYS` and `SCHEMA_ARRAY_KEYS` — and again as the `ARRAY_ITEMS_SCHEMA_*` sets in the same file. This change mirrors those sets so the strip walks the same containers the rest of the pipeline already agrees on. The sets are declared locally to avoid a cycle, matching how the file already duplicates them.

Traversal order is map, then array, then object, which preserves the previous dual handling of `items` (array form maps over entries, object form recurses once). Non-schema values such as `additionalProperties: true` are still copied through untouched.

## User Impact

A keyword a model rejects is now removed wherever it appears in the schema, not only in the five containers previously covered, so tool calls that used to be refused by the provider now go out clean. Schemas that do not use the additional containers serialize exactly as before.

## Evidence

### Real runtime proof: what the provider actually receives on the wire

Requested by review — this goes past Vitest output to the bytes leaving the transport.

A local `node:http` server stands in for the provider endpoint: `model.baseUrl` points at `http://127.0.0.1:<port>/v1`, the server parses the real request body, records `tools`, and answers with a real SSE stream. No `fetch` stub and no mocked client — a real socket through `createOpenAICompletionsTransportStreamFn()`, which is the stream function the runtime selects for `api: "openai-completions"` (`transports/provider-transport-stream.ts:85-86`). It needs no provider account.

The model declares `compat.unsupportedToolSchemaKeywords: ["maxLength", "minLength"]`, mirroring the live xAI / Venice records. The tool is an ordinary dictionary shape, with the value schema under `additionalProperties`:

```ts
parameters: {
  type: "object",
  properties: {
    labels: { type: "object", additionalProperties: { type: "string", maxLength: 100 } },
  },
}
```

Only `schema-keyword-strip.ts` differs between the two runs.

| source | `additionalProperties` as received by the provider |
|---|---|
| current `main` | `{"maxLength":100,"type":"string"}` — banned keyword present |
| this PR | `{"type":"string"}` — stripped |

Terminal output, unfixed source first:

```
=== main (unfixed) ===
=== tools payload the provider actually received ===
[{"type":"function","function":{"name":"store_labels","description":"Store a dictionary of labels",
  "parameters":{"properties":{"labels":{"additionalProperties":{"maxLength":100,"type":"string"},
  "type":"object"}},"type":"object"},"strict":false}}]
unsupported keyword present on the wire: true
RESULT: leaked (provider would 400)
```

and with the patch applied:

```
=== HEAD (fixed) ===
=== tools payload the provider actually received ===
[{"type":"function","function":{"name":"store_labels","description":"Store a dictionary of labels",
  "parameters":{"properties":{"labels":{"additionalProperties":{"type":"string"},
  "type":"object"}},"type":"object"},"strict":false}}]
unsupported keyword present on the wire: false
RESULT: stripped
```

The script exits on a boolean computed from the captured payload rather than printing a fixed "PASS", so a regression cannot pass silently.

<details>
<summary>Harness (run with <code>tsx</code>, not committed)</summary>

```ts
const server = createServer((req, res) => {
  const chunks: Buffer[] = [];
  req.on("data", (c: Buffer) => chunks.push(c));
  req.on("end", () => {
    capturedTools = JSON.parse(Buffer.concat(chunks).toString("utf8")).tools;
    res.writeHead(200, { "content-type": "text/event-stream" });
    // ... real SSE chunks + [DONE]
  });
});
await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));

const model = {
  api: "openai-completions",
  baseUrl: `http://127.0.0.1:${port}/v1`,
  compat: { unsupportedToolSchemaKeywords: ["maxLength", "minLength"] },
  // ...
};

const streamFn = createOpenAICompletionsTransportStreamFn();
await streamFn(model, context, { apiKey: "proof-key" }).result();

const leaked = JSON.stringify(capturedTools).includes("maxLength");
process.exit(leaked ? 1 : 0);
```

</details>

### Regression tests

`packages/ai/src/providers/schema-keyword-strip.test.ts` covers three containers that were silently skipped: `additionalProperties`, `prefixItems`, and `patternProperties`. All three fail against the unfixed source, each leaving the unsupported keyword in the output:

```
Test Files  1 failed (1)
     Tests  3 failed (3)
```

The whole provider suite stays green, which covers the tool-schema projection paths that consume this helper:

```
node scripts/run-vitest.mjs run packages/ai/src/providers/

Test Files  29 passed (29)
     Tests  522 passed (522)
```

`oxfmt --check` is clean on both touched files. The exported surface is unchanged, so the public API assertion in `packages/ai/src/package.e2e.test.ts` still holds. The branch is rebased on current `main`.

AI-assisted: written and verified with an AI coding agent; the runtime proof above, the failing-test-first measurement, and the regression run were reviewed by me.
