### PR TITLE
fix(ios): keep stop available for staged voice notes

### DIFF
--- a/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
+++ b/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
@@ -167,7 +167,9 @@ struct LocalFixtureChatTransport: OpenClawChatTransport {
             runId: idempotencyKey)
     }
 
-    func abortRun(sessionKey _: String, runId _: String) async throws {}
+    func abortRun(sessionKey: String, runId: String) async throws {
+        await self.store.abortRun(sessionKey: sessionKey, runId: runId)
+    }
 
     func listSessions(
         limit _: Int?,
@@ -255,17 +257,15 @@ struct LocalFixtureChatTransport: OpenClawChatTransport {
         true
     }
 
-    func waitForRunCompletion(
-        runId _: String,
-        timeoutMs _: Int) async -> OpenClawChatRunObservation
-    {
-        .terminal(.completed)
+    /// The held screenshot run resolves only when the real composer aborts it.
+    func waitForRunCompletion(runId: String, timeoutMs _: Int) async -> OpenClawChatRunObservation {
+        await self.store.runObservation(runId: runId)
     }
 
     func events() -> AsyncStream<OpenClawChatTransportEvent> {
         AsyncStream { continuation in
             continuation.yield(.health(ok: true))
-            continuation.finish()
+            self.registerFixtureEventContinuation(continuation)
         }
     }
 
@@ -412,6 +412,16 @@ private actor LocalFixtureChatStore {
                 idempotencyKey: "\(runId):user"))
         let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
         let subject = trimmed.isEmpty ? "that request" : "\"\(trimmed)\""
+        if ScreenshotFixtureMode.holdsInitialChatRun,
+           self.fixture.sessionIDPrefix == "screenshot-fixture",
+           !self.heldInitialRun
+        {
+            self.heldInitialRun = true
+            self.activeRunID = runId
+            return try Self.decode(
+                SendPayload(runId: runId, status: "started"),
+                as: OpenClawChatSendResponse.self)
+        }
         self.messages.append(
             Self.message(
                 role: "assistant",
@@ -423,6 +433,29 @@ private actor LocalFixtureChatStore {
         return try Self.decode(
             SendPayload(runId: runId, status: "ok"),
             as: OpenClawChatSendResponse.self)
+    }
+
+    private var heldInitialRun = false
+    private var activeRunID: String?
+    private var eventContinuation: AsyncStream<OpenClawChatTransportEvent>.Continuation?
+
+    func setEventContinuation(_ continuation: AsyncStream<OpenClawChatTransportEvent>.Continuation) {
+        self.eventContinuation = continuation
+    }
+
+    func runObservation(runId: String) -> OpenClawChatRunObservation {
+        self.activeRunID == runId ? .checkAgain : .terminal(.completed)
+    }
+
+    func abortRun(sessionKey: String, runId: String) {
+        guard self.activeRunID == runId else { return }
+        self.activeRunID = nil
+        self.eventContinuation?.yield(.chat(OpenClawChatEventPayload(
+            runId: runId,
+            sessionKey: sessionKey,
+            state: "aborted",
+            message: nil,
+            errorMessage: nil)))
     }
 
     func sessions() throws -> OpenClawChatSessionsListResponse {
@@ -535,5 +568,25 @@ private actor LocalFixtureChatStore {
         var ok: Bool?
         var key: String
         var sessionId: String?
+    }
+}
+
+extension ScreenshotFixtureMode {
+    static var holdsInitialChatRun: Bool {
+        ProcessInfo.processInfo.arguments.contains("--openclaw-hold-initial-chat-run")
+    }
+}
+
+extension LocalFixtureChatTransport {
+    private func registerFixtureEventContinuation(
+        _ continuation: AsyncStream<OpenClawChatTransportEvent>.Continuation)
+    {
+        guard ScreenshotFixtureMode.holdsInitialChatRun else {
+            continuation.finish()
+            return
+        }
+        Task {
+            await self.store.setEventContinuation(continuation)
+        }
     }
 }

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -506,6 +506,61 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertTrue(self.app?.keyboards.firstMatch.waitForNonExistence(timeout: 3) == true)
     }
 
+    func testVoiceNoteDraftKeepsStopAvailableDuringActiveResponse() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone voice-note composer proof only")
+        self.launchApp(
+            for: ScreenshotTarget(
+                initialTab: "chat",
+                initialDestination: "chat",
+                name: "chat-voice-note-stop-active-response"),
+            additionalArguments: ["--openclaw-hold-initial-chat-run"])
+
+        let app = try XCTUnwrap(self.app)
+        let input = app.textFields["chat-message-input"]
+        XCTAssertTrue(input.waitForExistence(timeout: 8))
+        input.tap()
+        input.typeText("Keep this response running while I record a voice note.")
+
+        let send = app.buttons["chat-send-message"]
+        XCTAssertTrue(send.waitForExistence(timeout: 5))
+        XCTAssertTrue(send.isEnabled)
+        send.tap()
+
+        let stop = app.buttons["Stop response"]
+        XCTAssertTrue(stop.waitForExistence(timeout: 8))
+        XCTAssertTrue(stop.isEnabled)
+
+        let microphone = app.buttons["chat-dictation-control"]
+        XCTAssertTrue(microphone.waitForExistence(timeout: 5))
+        microphone.press(forDuration: 0.8)
+
+        let recordVoiceNote = app.buttons["Record Voice Note"]
+        XCTAssertTrue(recordVoiceNote.waitForExistence(timeout: 5))
+        recordVoiceNote.tap()
+
+        let finishVoiceNote = app.buttons["Finish voice note"]
+        XCTAssertTrue(finishVoiceNote.waitForExistence(timeout: 8))
+        finishVoiceNote.tap()
+
+        let voiceNote = app.staticTexts["Voice note"]
+        XCTAssertTrue(voiceNote.waitForExistence(timeout: 8))
+        XCTAssertTrue(stop.waitForExistence(timeout: 5))
+        XCTAssertTrue(stop.isEnabled)
+        self.attachScreenshot(named: "voice-note-stop-active-response")
+
+        stop.tap()
+        XCTAssertTrue(send.waitForExistence(timeout: 8))
+        self.waitForEnabled(send)
+        XCTAssertTrue(voiceNote.exists)
+        send.tap()
+
+        XCTAssertTrue(voiceNote.waitForNonExistence(timeout: 8))
+        XCTAssertTrue(
+            app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "I can help with"))
+                .firstMatch.waitForExistence(timeout: 8))
+        self.attachScreenshot(named: "voice-note-sent-after-stopping-response")
+    }
+
     func testKeyboardOpenSendFollowsLiveEdge() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone keyboard proof only")
         self.launchApp(for: ScreenshotTarget(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -1230,7 +1230,7 @@ extension OpenClawChatComposer {
 extension OpenClawChatComposer {
     @ViewBuilder
     private var sendButton: some View {
-        if self.viewModel.pendingRunCount > 0, !self.viewModel.hasDraftToSend {
+        if self.viewModel.pendingRunCount > 0, self.shouldShowStopButton {
             Button {
                 self.viewModel.abort()
             } label: {
@@ -1567,6 +1567,13 @@ extension OpenClawChatComposer {
         self.pickerItems = []
     }
     #endif
+
+    /// Preserve text and image draft controls while keeping completed voice notes abortable.
+    private var shouldShowStopButton: Bool {
+        !self.viewModel.hasDraftToSend || self.viewModel.attachments.contains {
+            $0.mimeType == "audio/mp4" && $0.durationSeconds != nil
+        }
+    }
 
     private func sendDraftIfEnabled() {
         guard self.canSendMessage else { return }


### PR DESCRIPTION
Closes #108245

## What Problem This Solves

Fixes an issue where iOS users who finish recording a voice note during an active agent response lose the Stop control and cannot send or recover the staged recording until the running turn completes.

## Why This Change Was Made

Keep the existing Stop response action visible whenever the current client owns an active run, even when the composer already contains a staged voice-note attachment. Extend only the existing local iOS screenshot transport with an explicitly opted-in abortable first-run fixture so the actual application can reproduce the complete active-run, real audio-recorder, abort, preserved-attachment, and send lifecycle.

## User Impact

Users can stop a running response without losing their already recorded voice note, then immediately send that note. The shared composer fix also preserves the existing native macOS stop control; all other fixture and production behavior is unchanged unless the existing UI-test app receives its explicit test-only launch argument.

## Evidence

- Deterministic iPhone simulator before-fix XCUI: initial Stop exists; actual AVAudioRecorder recording starts and finishes; the real composer stages and visibly displays Voice note; Stop disappears and the test fails at the exact reported behavior.
- Identical after-fix XCUI: Stop remains visible and enabled, emits the actual chat aborted transport event, preserves the staged voice recording, restores enabled Send, delivers the voice-note attachment, and receives the fixture assistant reply.
- Five actual iPhone app UI regressions pass, including real voice recording and cancellation, compact composer, keyboard live edge, dark chat presentation, and starter-prompt delivery.
- All 98 focused native iPhone tests pass, including chat transport, history reconciliation, SwiftUI rendering, sidebar, deep links, images, and notifications.
- Fresh independent Codex review at extra-high reasoning effort: clean, no accepted or actionable findings.
- git diff --check passes. Exactly three scoped files; no gateway, provider, configuration, physical microphone, or external service claims.