### PR TITLE
fix(gateway): prevent model owner mismatch after plugin activation

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -359,6 +359,8 @@ const config = {
     // the full-tree companion config still audits their actual consumers.
     "src/commitments/runtime.ts": ["exports"],
     "src/gateway/board-view-ticket.ts": ["exports"],
+    // Focused startup tests consume this explicit seam; production imports only the bootstrap.
+    "src/gateway/server-startup-bootstrap.ts": ["exports"],
     // GatewayBoardProvider and boardExists are constructed/asserted by the
     // focused Control UI provider tests, not by a separate production module.
     "ui/src/lib/board/provider.ts": ["exports"],

--- a/src/gateway/server-startup-bootstrap.test.ts
+++ b/src/gateway/server-startup-bootstrap.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  resetConfigRuntimeState,
+  setAppliedRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { testing } from "./server-startup-bootstrap.js";
+
+const { publishGatewayPluginRuntimeConfigAtStartup } = testing;
+
+afterEach(() => {
+  resetConfigRuntimeState();
+});
+
+describe("Gateway startup runtime config publication", () => {
+  it("replaces the pre-activation snapshot with the exact plugin runtime config", () => {
+    const sourceConfig = {
+      agents: { defaults: { model: "openai/gpt-5.2" } },
+    } as OpenClawConfig;
+    const preActivationConfig = structuredClone(sourceConfig);
+    const pluginRuntimeConfig = {
+      ...preActivationConfig,
+      plugins: {
+        entries: {
+          openai: { enabled: true },
+        },
+      },
+    } as OpenClawConfig;
+    setAppliedRuntimeConfigSnapshot(preActivationConfig, sourceConfig);
+
+    publishGatewayPluginRuntimeConfigAtStartup({
+      runtimeConfig: pluginRuntimeConfig,
+      sourceConfig,
+    });
+
+    expect(getRuntimeConfigSnapshot()).toBe(pluginRuntimeConfig);
+    expect(getRuntimeConfigSourceSnapshot()).toBe(sourceConfig);
+  });
+});

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -61,6 +61,13 @@ type WorkerEnvironmentStartupLoader = () => Promise<
   typeof import("./server-worker-environment-startup.js")
 >;
 
+function publishGatewayPluginRuntimeConfigAtStartup(params: {
+  runtimeConfig: OpenClawConfig;
+  sourceConfig: OpenClawConfig;
+}): void {
+  setAppliedRuntimeConfigSnapshot(params.runtimeConfig, params.sourceConfig);
+}
+
 export async function prepareGatewayServerBootstrap(input: {
   port: number;
   opts: GatewayServerOptions;
@@ -494,6 +501,13 @@ export async function prepareGatewayServerBootstrap(input: {
     runtimePluginsLoaded,
     ambientAutostartSuppressedChannelIds,
   } = pluginBootstrap;
+  // Plugin activation can return a new runtime config object. Publish that exact object before
+  // prepared owners are created so request-time exact-owner lookups cannot see the pre-activation
+  // snapshot and reject the Gateway's own model catalog.
+  publishGatewayPluginRuntimeConfigAtStartup({
+    runtimeConfig: gatewayPluginConfigAtStart,
+    sourceConfig: startupLastGoodSnapshot.sourceConfig,
+  });
   const coreGatewayMethodNames = listCoreGatewayMethodNames();
   setCurrentPluginMetadataSnapshot(pluginLookUpTable, {
     config: startupActivationSourceConfig,
@@ -559,3 +573,7 @@ export async function prepareGatewayServerBootstrap(input: {
     activateRuntimeSecrets,
   };
 }
+
+export const testing = {
+  publishGatewayPluginRuntimeConfigAtStartup,
+};


### PR DESCRIPTION
Related: #115433

## What Problem This Solves

Fixes an issue where users sending a message through a Gateway with runtime-only plugin activation would have the turn fail before model selection with `prepared model catalog owner was not published for the requested config`.

## Why This Change Was Made

Gateway startup now republishes the exact post-plugin-activation config as the active runtime snapshot before downstream prepared owners are created. The persisted source snapshot remains unchanged, and explicit per-request config overrides continue to use exact isolated owners.

## User Impact

Gateway turns can use the model catalog published during startup when plugins were enabled at runtime, including service-account-backed Codex plugin turns.

## Evidence

- Added a focused regression test covering the pre-activation to post-activation runtime snapshot transition and source-snapshot retention.
- `git diff --check` passed.
- Targeted `oxfmt --check` passed.
- Fresh `autoreview --mode uncommitted` returned clean with no accepted/actionable findings (0.97).
- Exact-head hosted CI passed on `56fe70e96de1553656b4aeab9925d9c3d4b108d2`, including `openclaw/ci-gate`, build artifacts, Node test shards, dependency/dead-export checks, and security checks.
- The focused local Vitest command was attempted but the existing linked-worktree dependency tree failed before test collection because its installed `@openclaw/*` workspace package predates `configureFsSafeNative`. No local dependency reconciliation was performed; hosted CI is the authoritative hydrated environment.

## Real behavior proof

- Behavior or issue addressed: Gateway Slack dispatch failed before model selection when the prepared model owner was published from the plugin-activated config but the active runtime snapshot still referenced the pre-activation config.
- Real environment tested: Staging tenant `dxclaw`, with Gateway traffic routed to the remote `clawdx` app-server.
- Exact steps or command run after this patch: Exact-head hosted PR CI on `56fe70e96de1553656b4aeab9925d9c3d4b108d2`, followed by the ordinary Applied image pin/build/rollout workflow and a structured Slack-to-Linear read after the merged artifact is available.
- Evidence after fix: The regression test asserts that the exact plugin runtime config becomes the active snapshot while the canonical source snapshot is retained. All required exact-head hosted CI checks passed. The final immutable staging artifact and structured connector result will be recorded in the follow-up pin PR.
- Observed result after fix: Source review, the focused regression assertion, and exact-head hydrated CI cover the mismatched-owner condition. The current deployed pre-fix artifact still reproduces the startup owner mismatch, which is the reason the merged artifact rollout is required.
- What was not tested: A pre-merge staging build was not used because the supported Applied CLI attempted linked-worktree dependency hydration and Azure authentication was unavailable in the sandbox. Live Slack-to-Linear verification is therefore reserved for the exact merged OpenClaw SHA pinned by the internal build PR.

## AI Assistance

This PR was AI-assisted. I reviewed the implementation and understand the runtime ownership change.
