### PR TITLE
fix(qa): Matrix E2EE scenarios reject legacy state snapshots

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client-internals.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client-internals.ts
@@ -90,13 +90,5 @@ export async function prepareMatrixQaE2eeStorage(params: {
   await fs.mkdir(storage.accountDir, { mode: 0o700, recursive: true });
   await fs.chmod(storage.rootDir, 0o700);
   await fs.chmod(storage.accountDir, 0o700);
-  await fs
-    .writeFile(storage.idbSnapshotPath, "[]\n", { flag: "wx", mode: 0o600 })
-    .catch((error: unknown) => {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error;
-      }
-    });
-  await fs.chmod(storage.idbSnapshotPath, 0o600);
   return storage;
 }

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts
@@ -1,5 +1,5 @@
 // QA Lab tests cover Matrix E2EE client behavior.
-import { mkdtemp, rm, stat } from "node:fs/promises";
+import { access, mkdtemp, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -81,7 +81,7 @@ describe("matrix qa e2ee client storage", () => {
     }
   });
 
-  it("keeps persisted crypto state private", async () => {
+  it("uses plugin state without creating a legacy IndexedDB snapshot", async () => {
     const outputDir = await mkdtemp(path.join(os.tmpdir(), "matrix-qa-e2ee-storage-"));
     try {
       const storage = await testing.prepareMatrixQaE2eeStorage({
@@ -91,7 +91,7 @@ describe("matrix qa e2ee client storage", () => {
       });
 
       expect((await stat(storage.accountDir)).mode & 0o777).toBe(0o700);
-      expect((await stat(storage.idbSnapshotPath)).mode & 0o777).toBe(0o600);
+      await expect(access(storage.idbSnapshotPath)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       await rm(outputDir, { force: true, recursive: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix E2EE QA scenarios failed during client setup because the harness created a legacy IndexedDB snapshot file that the runtime now rejects pending migration.

## Why This Change Was Made

The QA E2EE client already injects the canonical plugin-state store used for SQLite-backed crypto snapshots. This removes the obsolete JSON sidecar bootstrap while retaining the private account-directory permissions and the path used as the store locator.

## User Impact

Matrix E2EE release-profile scenarios can start against canonical SQLite-backed state instead of failing before execution.

## Evidence

- Blacksmith Testbox `tbx_01kypdbtfjgksj2wfrz5yfafwn`: `pnpm test extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts` — 5 tests passed.
- Updated storage test proves the legacy snapshot path remains absent.
- Autoreview: clean; no accepted or actionable findings.
- `git diff --check` passed.

AI-assisted: yes. Agent transcript omitted unless requested.
