### PR TITLE
refactor: unify session cost rollup scans

### DIFF
--- a/src/infra/session-cost-usage-aggregation.ts
+++ b/src/infra/session-cost-usage-aggregation.ts
@@ -352,6 +352,38 @@ function scanRecordsIntoRollup(params: {
   return { countedRecords, parsedRecords };
 }
 
+function createUsageRollupScan(params: {
+  pricingFingerprint: string;
+  appendOnly: boolean;
+  previous?: UsageCostStoredRollup;
+  resolveCost: UsageCostResolver;
+}) {
+  const previous = params.appendOnly ? params.previous?.entry : undefined;
+  const rollup = previous
+    ? cloneSessionUsageRollupData(previous.rollup)
+    : createSessionUsageRollupData();
+  let countedRecords = 0;
+  let parsedRecords = 0;
+  return {
+    addRecords(records: Iterable<Record<string, unknown>>): void {
+      const counts = scanRecordsIntoRollup({ records, rollup, resolveCost: params.resolveCost });
+      countedRecords += counts.countedRecords;
+      parsedRecords += counts.parsedRecords;
+    },
+    finish(checkpoint: UsageCostJsonlCheckpoint | UsageCostSqliteCheckpoint): UsageCostRollupEntry {
+      return {
+        version: USAGE_COST_ROLLUP_VERSION,
+        pricingFingerprint: params.pricingFingerprint,
+        checkpoint,
+        scannedAt: Date.now(),
+        parsedRecords: (previous?.parsedRecords ?? 0) + parsedRecords,
+        countedRecords: (previous?.countedRecords ?? 0) + countedRecords,
+        rollup,
+      };
+    },
+  };
+}
+
 async function scanJsonlUsageRollup(params: {
   file: UsageCostTranscriptFile;
   previous?: UsageCostStoredRollup;
@@ -375,25 +407,12 @@ async function scanJsonlUsageRollup(params: {
     identityMatches && previousAnchor === previousCheckpoint?.anchorHash && params.previous,
   );
   const startOffset = appendOnly ? (previousCheckpoint?.parsedOffset ?? 0) : 0;
-  const rollup =
-    appendOnly && params.previous
-      ? cloneSessionUsageRollupData(params.previous.entry.rollup)
-      : createSessionUsageRollupData();
-  let countedRecords = 0;
-  let parsedRecords = 0;
+  const scan = createUsageRollupScan({ ...params, appendOnly });
   const processedOffset = await scanJsonlRange({
     filePath: params.file.filePath,
     startOffset,
     endOffset: params.file.size,
-    onRecord: (record) => {
-      const entry = parseUsageCostTranscriptEntry(record, params.resolveCost);
-      if (!entry) {
-        return;
-      }
-      const counted = appendParsedEntryToRollup(rollup, entry);
-      countedRecords += counted.countedRecord ? 1 : 0;
-      parsedRecords += counted.parsedRecord ? 1 : 0;
-    },
+    onRecord: (record) => scan.addRecords([record]),
   });
   const postStats = await fs.promises.stat(params.file.filePath);
   if (
@@ -407,24 +426,15 @@ async function scanJsonlUsageRollup(params: {
   if (!anchorHash) {
     throw new Error(`transcript checkpoint unavailable: ${params.file.filePath}`);
   }
-  return {
-    version: USAGE_COST_ROLLUP_VERSION,
-    pricingFingerprint: params.pricingFingerprint,
-    checkpoint: {
-      kind: "jsonl",
-      parsedOffset: processedOffset,
-      observedSize: params.file.size,
-      observedMtimeMs: params.file.mtimeMs,
-      device: params.file.device ?? 0,
-      inode: params.file.inode ?? 0,
-      anchorHash,
-    },
-    scannedAt: Date.now(),
-    parsedRecords: (appendOnly ? (params.previous?.entry.parsedRecords ?? 0) : 0) + parsedRecords,
-    countedRecords:
-      (appendOnly ? (params.previous?.entry.countedRecords ?? 0) : 0) + countedRecords,
-    rollup,
-  };
+  return scan.finish({
+    kind: "jsonl",
+    parsedOffset: processedOffset,
+    observedSize: params.file.size,
+    observedMtimeMs: params.file.mtimeMs,
+    device: params.file.device ?? 0,
+    inode: params.file.inode ?? 0,
+    anchorHash,
+  });
 }
 
 function selectIncrementalSqliteRecords(
@@ -521,15 +531,8 @@ async function scanSqliteUsageRollup(params: {
           ? [event as Record<string, unknown>]
           : [],
       );
-  const rollup =
-    appendOnly && params.previous
-      ? cloneSessionUsageRollupData(params.previous.entry.rollup)
-      : createSessionUsageRollupData();
-  const counts = scanRecordsIntoRollup({
-    records: allRecords,
-    rollup,
-    resolveCost: params.resolveCost,
-  });
+  const scan = createUsageRollupScan({ ...params, appendOnly });
+  scan.addRecords(allRecords);
   const postFile = await resolveUsageCostTranscriptFile(params.file.filePath);
   if (!postFile || (postFile.maxSeq ?? 0) < maxSeq || (postFile.eventCount ?? 0) < eventCount) {
     throw new Error(`SQLite transcript changed while scanning: ${params.file.filePath}`);
@@ -544,25 +547,15 @@ async function scanSqliteUsageRollup(params: {
   const visibleLeafId = appendOnly
     ? incremental?.visibleLeafId
     : (scanSessionTranscriptTree(allRows.map((row) => row.event)).leafId ?? undefined);
-  return {
-    version: USAGE_COST_ROLLUP_VERSION,
-    pricingFingerprint: params.pricingFingerprint,
-    checkpoint: {
-      kind: "sqlite",
-      maxSeq,
-      eventCount,
-      size: params.file.size,
-      mtimeMs: params.file.mtimeMs,
-      anchorHash: snapshotAnchorHash,
-      ...(visibleLeafId ? { visibleLeafId } : {}),
-    },
-    scannedAt: Date.now(),
-    parsedRecords:
-      (appendOnly ? (params.previous?.entry.parsedRecords ?? 0) : 0) + counts.parsedRecords,
-    countedRecords:
-      (appendOnly ? (params.previous?.entry.countedRecords ?? 0) : 0) + counts.countedRecords,
-    rollup,
-  };
+  return scan.finish({
+    kind: "sqlite",
+    maxSeq,
+    eventCount,
+    size: params.file.size,
+    mtimeMs: params.file.mtimeMs,
+    anchorHash: snapshotAnchorHash,
+    ...(visibleLeafId ? { visibleLeafId } : {}),
+  });
 }
 
 async function scanUsageFileForRollup(params: {


### PR DESCRIPTION
## What Problem This Solves

JSONL and SQLite session-cost scans separately owned the same rollup initialization, record accumulation, previous-count carry-forward, and final cache-entry construction. That duplicated the most important accounting invariant across the two transcript formats.

## Why This Change Was Made

This AI-assisted refactor introduces one scan accumulator with `addRecords` and `finish` operations. JSONL now routes each streamed record through the existing `scanRecordsIntoRollup` parser, while SQLite adds its selected batch through the same path; each format still owns its distinct identity and checkpoint validation. The three resolver wrappers remain because they have 13 production call sites across aggregation, reporting, and cache runtime.

## User Impact

No user-visible behavior changes. Cached session-cost totals, append-only carry-forward, transcript identity checks, and JSONL/SQLite checkpoint shapes remain unchanged.

## Evidence

- Numstat: production `+54/-61` (net `-7`); tests `+0/-0`. Current main had less duplicated epilogue code than the older lane snapshot, so this does not claim the original `-60..-90` estimate.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs session-cost-usage` — 4 files, 66 tests passed before and after rebase.
- `node scripts/check-changed.mjs -- src/infra/session-cost-usage-aggregation.ts src/agents/code-mode-runtime.ts` — passed on Blacksmith Testbox ([run 30432409695](https://github.com/openclaw/openclaw/actions/runs/30432409695)), including format, Knip, core prod/test typecheck, lint, database-first storage, and import cycles.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high` — clean, no accepted/actionable findings.
- Shared scan ownership is visible at `src/infra/session-cost-usage-aggregation.ts:355`; JSONL ingestion uses it at `src/infra/session-cost-usage-aggregation.ts:410`; SQLite uses it later in the same module.
- Final self-review re-read both format scanners, append-only selection, callers, cache writers, projection/reporting consumers, and tests. It confirmed format-specific identity/checkpoint checks remain explicit and found no additional actionable issue.
