### PR TITLE
fix(ci): validate legacy Matrix QA release targets

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -386,16 +386,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
-      - name: Verify internal Matrix execution sharding support
-        shell: bash
-        run: |
-          set -euo pipefail
-          runtime_source="extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.ts"
-          if [[ ! -f "${runtime_source}" ]] || ! grep -Fq "OPENCLAW_QA_EXECUTION_SHARD" "${runtime_source}"; then
-            echo "Selected target does not support internal post-selection QA sharding; use a target that includes the current QA execution protocol." >&2
-            exit 1
-          fi
-
       - name: Build private QA runtime
         env:
           NODE_OPTIONS: --max-old-space-size=12288
@@ -407,17 +397,26 @@ jobs:
         shell: bash
         env:
           OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
-          OPENCLAW_QA_EXECUTION_SHARD: ${{ format('{0}/5', matrix.shard) }}
         run: |
           set -euo pipefail
 
           output_dir=".artifacts/qa-e2e/matrix-live-shard-${{ matrix.shard }}-of-5-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           mkdir -p "${output_dir}"
 
+          runtime_source="extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.ts"
+          matrix_selection=()
+          if [[ -f "${runtime_source}" ]] && grep -Fq "OPENCLAW_QA_EXECUTION_SHARD" "${runtime_source}"; then
+            export OPENCLAW_QA_EXECUTION_SHARD="${{ matrix.shard }}/5"
+          else
+            legacy_profiles=(transport media e2ee-smoke e2ee-deep e2ee-cli)
+            matrix_selection=(--profile "${legacy_profiles[${{ matrix.shard }} - 1]}")
+          fi
+
           pnpm openclaw qa matrix \
             --repo-root . \
             --output-dir "${output_dir}" \
             --provider-mode mock-openai \
+            "${matrix_selection[@]}" \
             --fast
 
       - name: Upload Matrix QA artifacts

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2632,15 +2632,6 @@ describe("package artifact reuse", () => {
     );
     expect(matrixJob["continue-on-error"]).toBeUndefined();
     expect(matrixJob.strategy?.matrix?.shard).toEqual([1, 2, 3, 4, 5]);
-    expect(
-      workflowStep(matrixJob, "Verify internal Matrix execution sharding support").run,
-    ).toContain('grep -Fq "OPENCLAW_QA_EXECUTION_SHARD"');
-    expect(
-      workflowStep(matrixJob, "Verify internal Matrix execution sharding support").run,
-    ).toContain("does not support internal post-selection QA sharding");
-    expect(workflowStep(matrixJob, "Run Matrix live lane").env).toMatchObject({
-      OPENCLAW_QA_EXECUTION_SHARD: "${{ format('{0}/5', matrix.shard) }}",
-    });
     expect(readWorkflow(QA_LIVE_TRANSPORTS_WORKFLOW).jobs?.run_live_matrix_sharded).toBeUndefined();
     expect(releaseTelegramWorkflow).toContain(
       'echo "Telegram live lane failed on attempt ${attempt}; retrying once..." >&2',
@@ -2648,23 +2639,17 @@ describe("package artifact reuse", () => {
     expect(workflowStep(matrixJob, "Run Matrix live lane").run).not.toContain("for attempt in");
     expect(qaWorkflow).not.toContain("Matrix live lane failed on attempt");
     expect(qaWorkflow).not.toContain("OPENCLAW_QA_MATRIX_CANARY_TIMEOUT_MS");
-    expect(qaWorkflow).not.toContain("legacy_profiles");
-    expect(qaWorkflow).not.toContain("matrix_selection");
     expect(qaWorkflow).not.toContain("--shard <index/total>");
     expect(qaWorkflow).not.toContain("--fail-fast");
   });
 
-  it("keeps Matrix sharding internal to post-selection execution", () => {
+  it("uses legacy Matrix profiles only when a selected target lacks execution sharding", () => {
     const matrixJob = workflowJob(QA_LIVE_TRANSPORTS_WORKFLOW, "run_live_matrix");
     const runStep = workflowStep(matrixJob, "Run Matrix live lane");
-    const run = runStep.run;
 
-    expect(runStep.env).toMatchObject({
-      OPENCLAW_QA_EXECUTION_SHARD: "${{ format('{0}/5', matrix.shard) }}",
-    });
-    expect(run).not.toContain("--shard");
-    expect(run).not.toContain("--profile");
-    expect(run).not.toContain("matrix_selection");
+    expect(runStep.run).toContain("OPENCLAW_QA_EXECUTION_SHARD");
+    expect(runStep.run).toContain("legacy_profiles");
+    expect(runStep.run).toContain("--profile");
     expect(matrixJob.strategy?.matrix?.shard).toEqual([1, 2, 3, 4, 5]);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes a release-validation failure where frozen extended-stable candidates that predate execution-owned Matrix QA sharding fail before running any Matrix scenarios.

## Why This Change Was Made

The trusted release workflow now selects its sharding mechanism from the checked-out target. Targets with the execution-shard protocol keep the current path; older targets use their existing five exhaustive Matrix profiles.

## User Impact

Release operators can validate frozen extended-stable candidates without importing unrelated newer QA runtime code into the candidate.

## Evidence

- Reproduced in [Full Release Validation 30431647967](https://github.com/openclaw/openclaw/actions/runs/30431647967): every Matrix shard stopped at the new protocol guard before suite execution.
- Candidate `f6cdbb87000e0099be40af369c2493ce929e08bd` explicitly supports the legacy `transport`, `media`, `e2ee-smoke`, `e2ee-deep`, and `e2ee-cli` profiles, which its own catalog test documents as exhaustive and disjoint.
- `git diff --check` and focused workflow shell syntax/array-expansion checks passed.
- `autoreview --mode uncommitted` completed with no actionable findings.
