### PR TITLE
fix(qa): Matrix and Slack scenarios reject allowlist replacements

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
@@ -123,7 +123,11 @@ describe("matrix scenario environment", () => {
     expect(gateway.call).toHaveBeenCalledWith(
       "config.patch",
       expect.objectContaining({
-        replacePaths: ["channels.matrix", "messages"],
+        replacePaths: [
+          "channels.matrix",
+          "channels.matrix.accounts.sut.groupAllowFrom",
+          "messages",
+        ],
       }),
       { timeoutMs: 60_000 },
     );

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
@@ -51,8 +51,15 @@ function readMatrixConfigOverrides(
     : undefined;
 }
 
-function resolveMatrixQaReplacePaths(overrides: MatrixQaConfigOverrides | undefined) {
-  const replacePaths = ["channels.matrix", "messages"];
+function resolveMatrixQaReplacePaths(
+  accountId: string,
+  overrides: MatrixQaConfigOverrides | undefined,
+) {
+  const replacePaths = [
+    "channels.matrix",
+    `channels.matrix.accounts.${accountId}.groupAllowFrom`,
+    "messages",
+  ];
   // Replacing an untouched root drops config.get-omitted runtime policy and can
   // invalidate lifecycle-owned state while the Matrix account is restarting.
   if (overrides?.agentDefaults) {
@@ -219,7 +226,7 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
     const patchResult = await patchGatewayConfig({
       gateway: input.gateway,
       patch: gatewayConfig as Record<string, unknown>,
-      replacePaths: resolveMatrixQaReplacePaths(configOverrides),
+      replacePaths: resolveMatrixQaReplacePaths(params.accountId, configOverrides),
     });
     if (patchResult.noop !== true) {
       await input.waitForConfigRestartSettle({

--- a/extensions/qa-lab/src/live-transports/slack/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/slack/scenario-environment.ts
@@ -6,7 +6,7 @@ import {
   patchLiveQaGatewayConfig,
   readLiveQaGatewayConfig,
 } from "../shared/live-gateway-config.runtime.js";
-import { buildSlackQaConfig } from "./slack-live.config.js";
+import { buildSlackQaConfig, resolveSlackQaReplacePaths } from "./slack-live.config.js";
 import type {
   SlackAuthIdentity,
   SlackObservedMessage,
@@ -75,7 +75,7 @@ export function createSlackQaScenarioEnvironment(params: {
     await patchLiveQaGatewayConfig({
       gateway: input.gateway,
       patch: cfg as Record<string, unknown>,
-      replacePaths: ["agents", "approvals", "channels.slack", "messages", "plugins", "tools"],
+      replacePaths: resolveSlackQaReplacePaths(params.accountId, params.channelId),
       timeoutMs: input.timeoutMs,
       waitForConfigRestartSettle: input.waitForConfigRestartSettle,
     });

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.config.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.config.ts
@@ -51,6 +51,19 @@ export function parseSlackQaCredentialPayload(payload: unknown): SlackQaRuntimeE
   return validateSlackQaRuntimeEnv(runtimeEnv, "Slack credential payload");
 }
 
+export function resolveSlackQaReplacePaths(accountId: string, channelId: string): string[] {
+  return [
+    "agents",
+    "approvals",
+    "channels.slack",
+    `channels.slack.accounts.${accountId}.allowFrom`,
+    `channels.slack.accounts.${accountId}.channels.${channelId}.users`,
+    "messages",
+    "plugins",
+    "tools",
+  ];
+}
+
 export function asPlainRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildSlackQaConfig,
   parseSlackQaCredentialPayload,
+  resolveSlackQaReplacePaths,
   resolveSlackQaRuntimeEnv,
 } from "./slack-live.config.js";
 import { assertSlackCodexApprovalModelSupported } from "./slack-live.contracts.js";
@@ -52,6 +53,7 @@ const testing = {
   resolveCodexFileApprovalTargetPath,
   resolveSlackRateLimitDelayMs: adapterTesting.resolveSlackRateLimitDelayMs,
   resolveSlackQaRuntimeEnv,
+  resolveSlackQaReplacePaths,
   runSlackTableInvalidBlocksFallbackScenario,
   waitForSlackNoReply,
   waitForSlackReaction,
@@ -84,6 +86,19 @@ describe("Slack live QA runtime helpers", () => {
     expect(testing.resolveSlackRateLimitDelayMs({ retryAfter: 10 })).toBe(10_000);
     expect(testing.resolveSlackRateLimitDelayMs({ retryAfter: 0 })).toBeUndefined();
     expect(testing.resolveSlackRateLimitDelayMs(new Error("network failed"))).toBeUndefined();
+  });
+
+  it("authorizes replacement of account and channel allowlists", () => {
+    expect(testing.resolveSlackQaReplacePaths("work", "C123")).toEqual([
+      "agents",
+      "approvals",
+      "channels.slack",
+      "channels.slack.accounts.work.allowFrom",
+      "channels.slack.accounts.work.channels.C123.users",
+      "messages",
+      "plugins",
+      "tools",
+    ]);
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where sequential live QA scenarios failed while replacing intentional allowlists. The observed release-profile run reported 50 Matrix failures for the SUT account `groupAllowFrom` array and one Slack failure for its account and channel allowlists.

## Why This Change Was Made

The Gateway requires `config.patch.replacePaths` to name destructive array replacements at their exact paths; parent objects do not authorize nested arrays. Matrix and Slack now derive those exact paths from the active account and channel IDs while retaining their existing replacement roots.

## User Impact

Matrix and Slack live QA scenarios can replace scenario-owned allowlists between runs instead of failing config preparation.

## Evidence

- Failure evidence: https://github.com/openclaw/openclaw/actions/runs/30424726942
- Blacksmith Testbox focused suite: 46 tests passed across Matrix scenario preparation and Slack runtime helpers.
- Final current-main proof: https://github.com/openclaw/openclaw/actions/runs/30433820290
- Autoreview: clean; no accepted or actionable findings.
- `git diff --check` passed.

AI-assisted: yes. Agent transcript omitted unless requested.
