### PR TITLE
fix(sessions): return direct-agent replies to their active session

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -11,17 +11,27 @@ import { Type } from "typebox";
 import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import type { AgentRouteBinding } from "../../config/types.agents.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { normalizeRouteBindingChannelId } from "../../routing/binding-scope.js";
+import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import {
+  buildAgentMainSessionKey,
   isSubagentSessionKey,
+  normalizeAccountId,
   normalizeAgentId,
   resolveAgentIdFromSessionKey,
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
 import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
-import { isCronRunSessionKey, parseAgentSessionKey } from "../../sessions/session-key-utils.js";
+import { deriveSessionChatTypeFromKey } from "../../sessions/session-chat-type-shared.js";
+import {
+  isCronRunSessionKey,
+  parseAgentSessionKey,
+  parseSessionDeliveryRoute,
+} from "../../sessions/session-key-utils.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import { registerSessionStateWatch } from "../../sessions/session-state-events.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
@@ -593,7 +603,101 @@ export function createSessionsSendTool(opts?: {
       // Normalize sessionKey/sessionId input into a canonical session key.
       const resolvedKey = visibleSession.key;
       const displayKey = visibleSession.displayKey;
-      const requesterSessionKey = opts?.agentSessionKey ? effectiveRequesterKey : undefined;
+      const rawRequesterSessionKey = opts?.agentSessionKey ? effectiveRequesterKey : undefined;
+      const parsedRequesterSessionKey = parseAgentSessionKey(rawRequesterSessionKey);
+      const requesterRouteBindings = cfg.bindings?.filter(
+        (binding): binding is AgentRouteBinding => binding.type !== "acp",
+      );
+      const requesterDeliveryRoute = requesterRouteBindings?.length
+        ? parseSessionDeliveryRoute(rawRequesterSessionKey)
+        : null;
+      const bareRequesterPeerId = parsedRequesterSessionKey?.rest.startsWith("direct:")
+        ? parsedRequesterSessionKey.rest.slice("direct:".length)
+        : parsedRequesterSessionKey?.rest.startsWith("dm:")
+          ? parsedRequesterSessionKey.rest.slice("dm:".length)
+          : undefined;
+      const requesterRouteChannel = requesterDeliveryRoute?.channel ?? opts?.agentChannel;
+      const requesterRoutePeerId = requesterDeliveryRoute?.peerId ?? bareRequesterPeerId;
+      const requesterRoute =
+        requesterRouteBindings?.length && requesterRouteChannel && requesterRoutePeerId
+          ? resolveAgentRoute({
+              cfg,
+              channel: requesterRouteChannel,
+              accountId: requesterDeliveryRoute?.accountId,
+              peer: { kind: "direct", id: requesterRoutePeerId },
+            })
+          : undefined;
+      // Any configured route can transfer this peer to another agent. A key
+      // without enough route facts must never be reassigned to guessed ownership.
+      const hasUnresolvedRequesterRoute = Boolean(
+        requesterRouteBindings?.length &&
+        (!requesterRoute || requesterRoute.agentId !== parsedRequesterSessionKey?.agentId),
+      );
+      // Session keys can discard account, peer casing, team, guild, and roles.
+      // Preserve the authenticated caller whenever any possible binding would
+      // choose another agent or an isolated DM scope using those missing facts.
+      const hasUnsafeRequesterDmBinding = Boolean(
+        requesterRouteBindings?.some((binding) => {
+          const effectiveDmScope = binding.session?.dmScope ?? cfg.session?.dmScope ?? "main";
+          const isForeignAgent =
+            normalizeAgentId(binding.agentId) !== parsedRequesterSessionKey?.agentId;
+          if (!isForeignAgent && effectiveDmScope === "main") {
+            return false;
+          }
+          if (
+            requesterRouteChannel &&
+            normalizeRouteBindingChannelId(binding.match.channel) !==
+              normalizeRouteBindingChannelId(requesterRouteChannel)
+          ) {
+            return false;
+          }
+          const bindingAccountId = binding.match.accountId?.trim();
+          if (
+            requesterDeliveryRoute?.accountId &&
+            bindingAccountId !== "*" &&
+            normalizeAccountId(bindingAccountId) !==
+              normalizeAccountId(requesterDeliveryRoute.accountId)
+          ) {
+            return false;
+          }
+          const peer = binding.match.peer;
+          if (peer) {
+            const peerId = peer.id.trim();
+            if (
+              peer.kind !== "direct" ||
+              (peerId !== "*" &&
+                peerId.toLowerCase() !== requesterRoutePeerId?.trim().toLowerCase())
+            ) {
+              return false;
+            }
+          }
+          return true;
+        }),
+      );
+      const requesterDmScope =
+        requesterRoute && requesterRoute.agentId === parsedRequesterSessionKey?.agentId
+          ? (requesterRoute.dmScope ?? cfg.session?.dmScope ?? "main")
+          : (cfg.session?.dmScope ?? "main");
+      // Normalize legacy DM reply addresses only after exact-key visibility
+      // checks; global/binding-isolated DMs and non-DM owners stay private.
+      const requesterSessionKey = rawRequesterSessionKey;
+      const replyRequesterSessionKey =
+        rawRequesterSessionKey &&
+        parsedRequesterSessionKey &&
+        rawRequesterSessionKey !== resolvedKey &&
+        requesterDmScope === "main" &&
+        !hasUnresolvedRequesterRoute &&
+        !hasUnsafeRequesterDmBinding &&
+        !parsedRequesterSessionKey.rest.startsWith("cron:") &&
+        !parsedRequesterSessionKey.rest.startsWith("hook:") &&
+        !isSubagentSessionKey(rawRequesterSessionKey) &&
+        !parseSessionThreadInfo(rawRequesterSessionKey).threadId &&
+        deriveSessionChatTypeFromKey(rawRequesterSessionKey) === "direct"
+          ? buildAgentMainSessionKey({
+              agentId: parsedRequesterSessionKey.agentId,
+              mainKey,
+            })
+          : rawRequesterSessionKey;
       const timeoutMs =
         finiteSecondsToTimerSafeMilliseconds(timeoutSeconds, {
           floorSeconds: true,
@@ -670,10 +774,10 @@ export function createSessionsSendTool(opts?: {
             const watched =
               watchRequested &&
               !access.expectedSessionId &&
-              requesterSessionKey &&
-              requesterSessionKey !== targetSessionKey
+              replyRequesterSessionKey &&
+              replyRequesterSessionKey !== targetSessionKey
                 ? registerSessionStateWatch({
-                    watcherSessionKey: requesterSessionKey,
+                    watcherSessionKey: replyRequesterSessionKey,
                     targetSessionKey,
                   })
                 : false;
@@ -717,13 +821,13 @@ export function createSessionsSendTool(opts?: {
               : undefined;
 
           const agentMessageContext = buildAgentToAgentMessageContext({
-            requesterSessionKey,
+            requesterSessionKey: replyRequesterSessionKey,
             requesterChannel,
             targetSessionKey: displayKey,
           });
           const inputProvenance = {
             kind: "inter_session" as const,
-            sourceSessionKey: requesterSessionKey,
+            sourceSessionKey: replyRequesterSessionKey,
             sourceChannel: requesterChannel,
             sourceTool: "sessions_send",
           };
@@ -808,7 +912,7 @@ export function createSessionsSendTool(opts?: {
               // Cron runs are isolated jobs; target replies must not become new
               // requester turns, but the target-side announce still runs.
               maxPingPongTurns: isIsolatedCronRequester ? 0 : maxPingPongTurns,
-              requesterSessionKey,
+              requesterSessionKey: replyRequesterSessionKey,
               requesterChannel,
               baseline: flowBaseline,
               roundOneReply,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { ChannelMessagingAdapter } from "../../channels/plugins/types.public.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/io.js";
 import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { extractAssistantText, sanitizeTextContent } from "./chat-history-text.js";
 
@@ -60,7 +61,14 @@ vi.mock("../../plugin-sdk/facade-runtime.js", async () => {
 });
 
 type SessionsToolTestConfig = {
-  session: { scope: "per-sender"; mainKey: string; agentToAgent?: { maxPingPongTurns: number } };
+  agents?: OpenClawConfig["agents"];
+  bindings?: OpenClawConfig["bindings"];
+  session: {
+    scope: "per-sender";
+    mainKey: string;
+    dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
+    agentToAgent?: { maxPingPongTurns: number };
+  };
   tools: {
     agentToAgent: { enabled: boolean };
     sessions?: { visibility: "self" | "tree" | "agent" | "all" };
@@ -247,12 +255,69 @@ function createMainSessionsSendTool() {
   });
 }
 
-async function executeFireAndForgetA2AFrom(requesterSessionKey: string) {
+async function executeFireAndForgetA2AFrom(
+  requesterSessionKey: string,
+  options?: {
+    mainKey?: string;
+    dmScope?: NonNullable<SessionsToolTestConfig["session"]["dmScope"]>;
+    bindingDmScope?: NonNullable<SessionsToolTestConfig["session"]["dmScope"]>;
+    defaultBindingDmScope?: NonNullable<SessionsToolTestConfig["session"]["dmScope"]>;
+    bindingAccountId?: string;
+    bindingAgentId?: string;
+    bindingPeerId?: string;
+    bindingTeamId?: string;
+  },
+) {
   const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
   vi.mocked(runSessionsSendA2AFlow).mockClear();
   const targetSessionKey = "agent:other:discord:group:ops";
   loadConfigMock.mockReturnValue({
-    session: { scope: "per-sender", mainKey: "main" },
+    ...(options?.bindingDmScope ||
+    options?.defaultBindingDmScope ||
+    options?.bindingAccountId ||
+    options?.bindingAgentId
+      ? {
+          ...(options.bindingAgentId
+            ? {
+                agents: {
+                  list: [{ id: "main", default: true }, { id: options.bindingAgentId }],
+                },
+              }
+            : {}),
+          bindings: [
+            ...(options.defaultBindingDmScope
+              ? [
+                  {
+                    type: "route" as const,
+                    agentId: "main",
+                    match: {
+                      channel: requesterSessionKey.includes(":feishu:") ? "feishu" : "telegram",
+                      accountId: "default",
+                      peer: { kind: "direct" as const, id: "peer-1" },
+                    },
+                    session: { dmScope: options.defaultBindingDmScope },
+                  },
+                ]
+              : []),
+            {
+              type: "route",
+              agentId: options.bindingAgentId ?? "main",
+              match: {
+                channel: requesterSessionKey.includes(":feishu:") ? "feishu" : "telegram",
+                accountId: options.bindingAccountId ?? "default",
+                peer: { kind: "direct", id: options.bindingPeerId ?? "peer-1" },
+                ...(options.bindingTeamId ? { teamId: options.bindingTeamId } : {}),
+              },
+              ...(options.bindingDmScope ? { session: { dmScope: options.bindingDmScope } } : {}),
+            },
+          ],
+        }
+      : {}),
+    session: {
+      scope: "per-sender",
+      mainKey: options?.mainKey ?? "main",
+      ...(options?.dmScope ? { dmScope: options.dmScope } : {}),
+    },
     tools: {
       agentToAgent: { enabled: true },
       sessions: { visibility: "all" },
@@ -992,6 +1057,29 @@ describe("sessions_send gating", () => {
     ]);
   });
 
+  it("rejects synchronous sends to the raw legacy direct-message caller", async () => {
+    const requesterSessionKey = "agent:main:feishu:direct:peer-1";
+    callGatewayMock.mockResolvedValueOnce({ key: requesterSessionKey });
+    const tool = createSessionsSendTool({
+      agentSessionKey: requesterSessionKey,
+      agentChannel: "feishu",
+    });
+
+    const result = await tool.execute("call-legacy-direct-self-send", {
+      sessionKey: "current",
+      message: "use this as my reply",
+    });
+
+    expect(requireDetails(result)).toMatchObject({
+      status: "error",
+      error: "sessions_send cannot target the calling session; use your own reply instead",
+      sessionKey: "current",
+    });
+    expect(callGatewayMock.mock.calls).not.toContainEqual([
+      expect.objectContaining({ method: "agent" }),
+    ]);
+  });
+
   it("keeps synchronous distinct-target sends unchanged", async () => {
     const targetSessionKey = "agent:main:other";
     const tool = createSessionsSendTool({
@@ -1177,24 +1265,220 @@ describe("sessions_send gating", () => {
       label: "canonical cron run",
       requesterSessionKey: "agent:main:cron:job:run:abc",
       expected: 0,
+      expectedRequesterSessionKey: "agent:main:cron:job:run:abc",
     },
     {
       label: "normal requester",
       requesterSessionKey: "agent:main:telegram:direct:user",
       expected: 5,
+      expectedRequesterSessionKey: "agent:main:main",
     },
     {
       label: "non-canonical cron-like requester",
       requesterSessionKey: "agent:main:slack:cron:job:run:uuid",
       expected: 5,
+      expectedRequesterSessionKey: "agent:main:slack:cron:job:run:uuid",
     },
   ] as const)(
     "uses the expected ping-pong turns for a $label",
-    async ({ requesterSessionKey, expected }) => {
+    async ({ requesterSessionKey, expected, expectedRequesterSessionKey }) => {
       const flowParams = await executeFireAndForgetA2AFrom(requesterSessionKey);
 
       expect(flowParams.maxPingPongTurns).toBe(expected);
-      expect(flowParams.requesterSessionKey).toBe(requesterSessionKey);
+      expect(flowParams.requesterSessionKey).toBe(expectedRequesterSessionKey);
+    },
+  );
+
+  it.each([
+    { label: "peer", key: "agent:main:direct:peer-1" },
+    { label: "channel", key: "agent:main:feishu:direct:peer-1" },
+    { label: "account", key: "agent:main:feishu:default:direct:peer-1" },
+  ] as const)("preserves a $label DM owned by another routed agent", async ({ key }) => {
+    const flowParams = await executeFireAndForgetA2AFrom(key, {
+      bindingAgentId: "stranger",
+    });
+
+    expect(flowParams.requesterSessionKey).toBe(key);
+  });
+
+  it("fails closed when an erased named account belongs to another agent", async () => {
+    const key = "agent:main:feishu:direct:peer-1";
+    const flowParams = await executeFireAndForgetA2AFrom(key, {
+      bindingAgentId: "stranger",
+      bindingAccountId: "work",
+    });
+
+    expect(flowParams.requesterSessionKey).toBe(key);
+  });
+
+  it("preserves a named-account route that inherits isolated global DM scope", async () => {
+    const key = "agent:main:feishu:direct:peer-1";
+    const flowParams = await executeFireAndForgetA2AFrom(key, {
+      dmScope: "per-peer",
+      defaultBindingDmScope: "main",
+      bindingAccountId: "work",
+    });
+
+    expect(flowParams.requesterSessionKey).toBe(key);
+  });
+
+  it("preserves account-isolated bindings with trimmed wildcard peers", async () => {
+    const key = "agent:main:feishu:direct:peer-1";
+    const flowParams = await executeFireAndForgetA2AFrom(key, {
+      bindingDmScope: "per-peer",
+      bindingAccountId: "work",
+      bindingPeerId: " * ",
+    });
+
+    expect(flowParams.requesterSessionKey).toBe(key);
+  });
+
+  it("preserves isolated peers when the session key loses binding casing", async () => {
+    const key = "agent:main:feishu:direct:peer-1";
+    const flowParams = await executeFireAndForgetA2AFrom(key, {
+      bindingDmScope: "per-peer",
+      bindingPeerId: "PEER-1",
+    });
+
+    expect(flowParams.requesterSessionKey).toBe(key);
+  });
+
+  it("preserves isolated bindings whose team is absent from the session key", async () => {
+    const key = "agent:main:feishu:direct:peer-1";
+    const flowParams = await executeFireAndForgetA2AFrom(key, {
+      bindingDmScope: "per-peer",
+      bindingTeamId: "T123",
+    });
+
+    expect(flowParams.requesterSessionKey).toBe(key);
+  });
+
+  it.each([
+    { label: "peer direct", key: "agent:main:direct:peer-1" },
+    { label: "peer dm", key: "agent:main:dm:peer-1" },
+    { label: "channel direct", key: "agent:main:feishu:direct:peer-1" },
+    { label: "channel dm", key: "agent:main:feishu:dm:peer-1" },
+    { label: "account direct", key: "agent:main:feishu:default:direct:peer-1" },
+    { label: "account dm", key: "agent:main:feishu:default:dm:peer-1" },
+  ] as const)(
+    "routes a legacy $label requester back to its monitored main session",
+    async ({ key }) => {
+      const flowParams = await executeFireAndForgetA2AFrom(key);
+
+      expect(flowParams.requesterSessionKey).toBe(MAIN_AGENT_SESSION_KEY);
+      const agentCall = callGatewayMock.mock.calls.find(
+        ([request]) => (request as { method?: string }).method === "agent",
+      );
+      expect(agentCall?.[0]).toMatchObject({
+        method: "agent",
+        params: {
+          inputProvenance: {
+            kind: "inter_session",
+            sourceSessionKey: MAIN_AGENT_SESSION_KEY,
+            sourceTool: "sessions_send",
+          },
+        },
+      });
+    },
+  );
+
+  it("routes a legacy direct requester to its configured main session key", async () => {
+    const flowParams = await executeFireAndForgetA2AFrom("agent:main:feishu:direct:peer-1", {
+      mainKey: "work",
+    });
+
+    expect(flowParams.requesterSessionKey).toBe("agent:main:work");
+  });
+
+  it.each([
+    { label: "group", key: "agent:main:feishu:group:peer-1" },
+    { label: "group with opaque direct token", key: "agent:main:feishu:group:direct:peer-1" },
+    { label: "group with opaque dm token", key: "agent:main:feishu:group:dm:peer-1" },
+    { label: "channel with opaque direct token", key: "agent:main:channel:direct:peer-1" },
+    { label: "channel with opaque dm token", key: "agent:main:channel:dm:peer-1" },
+    { label: "cron", key: "agent:main:cron:nightly:run:peer-1" },
+    { label: "cron with direct token", key: "agent:main:cron:direct:peer-1" },
+    { label: "hook with direct token", key: "agent:main:hook:direct:peer-1" },
+    { label: "hook with dm token", key: "agent:main:hook:dm:peer-1" },
+    { label: "subagent with direct token", key: "agent:main:subagent:direct:peer-1" },
+    { label: "nested agent owner", key: "agent:main:agent:worker:feishu:direct:peer-1" },
+    {
+      label: "thread-scoped direct conversation",
+      key: "agent:main:feishu:direct:peer-1:thread:reply-root",
+    },
+    {
+      label: "thread-scoped account direct conversation",
+      key: "agent:main:feishu:default:dm:peer-1:thread:reply-root",
+    },
+  ] as const)("preserves the exact $label requester under main DM scope", async ({ key }) => {
+    const flowParams = await executeFireAndForgetA2AFrom(key);
+
+    expect(flowParams.requesterSessionKey).toBe(key);
+  });
+
+  it.each([
+    { dmScope: "per-peer", key: "agent:main:direct:peer-1" },
+    { dmScope: "per-peer", key: "agent:main:dm:peer-1" },
+    { dmScope: "per-channel-peer", key: "agent:main:feishu:direct:peer-1" },
+    { dmScope: "per-channel-peer", key: "agent:main:feishu:dm:peer-1" },
+    {
+      dmScope: "per-account-channel-peer",
+      key: "agent:main:feishu:default:direct:peer-1",
+    },
+    { dmScope: "per-account-channel-peer", key: "agent:main:feishu:default:dm:peer-1" },
+  ] as const)("preserves privacy under $dmScope for $key", async ({ dmScope, key }) => {
+    const flowParams = await executeFireAndForgetA2AFrom(key, { dmScope });
+
+    expect(flowParams.requesterSessionKey).toBe(key);
+  });
+
+  it.each([
+    { bindingDmScope: "per-peer", key: "agent:main:direct:peer-1" },
+    { bindingDmScope: "per-channel-peer", key: "agent:main:feishu:direct:peer-1" },
+    {
+      bindingDmScope: "per-account-channel-peer",
+      key: "agent:main:feishu:default:direct:peer-1",
+    },
+  ] as const)(
+    "preserves a binding-isolated $bindingDmScope DM under global main scope",
+    async ({ bindingDmScope, key }) => {
+      const flowParams = await executeFireAndForgetA2AFrom(key, { bindingDmScope });
+
+      expect(flowParams.requesterSessionKey).toBe(key);
+    },
+  );
+
+  it.each([
+    { dmScope: "per-peer", key: "agent:main:direct:peer-1" },
+    { dmScope: "per-channel-peer", key: "agent:main:feishu:direct:peer-1" },
+    {
+      dmScope: "per-account-channel-peer",
+      key: "agent:main:feishu:default:direct:peer-1",
+    },
+  ] as const)(
+    "honors a main-scope binding overriding global $dmScope",
+    async ({ dmScope, key }) => {
+      const flowParams = await executeFireAndForgetA2AFrom(key, {
+        dmScope,
+        bindingDmScope: "main",
+      });
+
+      expect(flowParams.requesterSessionKey).toBe(MAIN_AGENT_SESSION_KEY);
+    },
+  );
+
+  it.each([
+    { bindingDmScope: "per-peer", key: "agent:main:direct:peer-1" },
+    { bindingDmScope: "per-channel-peer", key: "agent:main:feishu:direct:peer-1" },
+  ] as const)(
+    "fails closed for an account-erased $bindingDmScope DM binding",
+    async ({ bindingDmScope, key }) => {
+      const flowParams = await executeFireAndForgetA2AFrom(key, {
+        bindingDmScope,
+        bindingAccountId: "work",
+      });
+
+      expect(flowParams.requesterSessionKey).toBe(key);
     },
   );
 

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -35,6 +35,7 @@ let envSnapshot: ReturnType<typeof captureEnv>;
 
 type SessionSendTool = ReturnType<typeof createOpenClawTools>[number];
 const SESSION_SEND_E2E_TIMEOUT_MS = 10_000;
+const SESSION_SEND_DM_ROUTING_E2E_TIMEOUT_MS = 30_000;
 let cachedSessionsSendTool: SessionSendTool | null = null;
 
 function getSessionsSendTool(): SessionSendTool {
@@ -619,6 +620,368 @@ describe("sessions_send agent targeting", () => {
         });
         expect(stored?.sessionId).toBe(orionCall?.sessionId);
       } finally {
+        testState.agentsConfig = undefined;
+        testState.sessionStorePath = undefined;
+        await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+      }
+    },
+  );
+});
+
+type DirectMessageRequesterRoutingCase = {
+  label: string;
+  requesterSessionKey: string;
+  dmScope: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
+  bindingDmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
+  defaultBindingDmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
+  bindingAccountId?: string;
+  bindingAgentId?: string;
+  bindingPeerId?: string;
+  bindingTeamId?: string;
+  expectedReplySessionKey: string;
+};
+
+describe("sessions_send direct-message requester routing", () => {
+  it.each<DirectMessageRequesterRoutingCase>([
+    {
+      label: "legacy peer direct route",
+      requesterSessionKey: "agent:main:direct:legacy-peer",
+      dmScope: "main",
+      expectedReplySessionKey: "agent:main:main",
+    },
+    {
+      label: "legacy peer dm route",
+      requesterSessionKey: "agent:main:dm:legacy-peer",
+      dmScope: "main",
+      expectedReplySessionKey: "agent:main:main",
+    },
+    {
+      label: "legacy channel direct route",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer",
+      dmScope: "main",
+      expectedReplySessionKey: "agent:main:main",
+    },
+    {
+      label: "legacy channel dm route",
+      requesterSessionKey: "agent:main:feishu:dm:legacy-peer",
+      dmScope: "main",
+      expectedReplySessionKey: "agent:main:main",
+    },
+    {
+      label: "legacy account direct route",
+      requesterSessionKey: "agent:main:feishu:default:direct:legacy-peer",
+      dmScope: "main",
+      expectedReplySessionKey: "agent:main:main",
+    },
+    {
+      label: "legacy account dm route",
+      requesterSessionKey: "agent:main:feishu:default:dm:legacy-peer",
+      dmScope: "main",
+      expectedReplySessionKey: "agent:main:main",
+    },
+    {
+      label: "isolated peer route",
+      requesterSessionKey: "agent:main:direct:legacy-peer",
+      dmScope: "per-peer",
+      expectedReplySessionKey: "agent:main:direct:legacy-peer",
+    },
+    {
+      label: "isolated channel route",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer",
+      dmScope: "per-channel-peer",
+      expectedReplySessionKey: "agent:main:feishu:direct:legacy-peer",
+    },
+    {
+      label: "isolated account route",
+      requesterSessionKey: "agent:main:feishu:default:direct:legacy-peer",
+      dmScope: "per-account-channel-peer",
+      expectedReplySessionKey: "agent:main:feishu:default:direct:legacy-peer",
+    },
+    {
+      label: "binding-isolated peer route",
+      requesterSessionKey: "agent:main:direct:legacy-peer",
+      dmScope: "main",
+      bindingDmScope: "per-peer",
+      expectedReplySessionKey: "agent:main:direct:legacy-peer",
+    },
+    {
+      label: "binding-isolated channel route",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer",
+      dmScope: "main",
+      bindingDmScope: "per-channel-peer",
+      expectedReplySessionKey: "agent:main:feishu:direct:legacy-peer",
+    },
+    {
+      label: "binding-isolated account route",
+      requesterSessionKey: "agent:main:feishu:default:direct:legacy-peer",
+      dmScope: "main",
+      bindingDmScope: "per-account-channel-peer",
+      expectedReplySessionKey: "agent:main:feishu:default:direct:legacy-peer",
+    },
+    {
+      label: "main binding overriding globally isolated peer route",
+      requesterSessionKey: "agent:main:direct:legacy-peer",
+      dmScope: "per-peer",
+      bindingDmScope: "main",
+      expectedReplySessionKey: "agent:main:main",
+    },
+    {
+      label: "unresolved named-account isolated peer route",
+      requesterSessionKey: "agent:main:direct:legacy-peer",
+      dmScope: "main",
+      bindingDmScope: "per-peer",
+      bindingAccountId: "work",
+      expectedReplySessionKey: "agent:main:direct:legacy-peer",
+    },
+    {
+      label: "unresolved named-account isolated channel route",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer",
+      dmScope: "main",
+      bindingDmScope: "per-channel-peer",
+      bindingAccountId: "work",
+      expectedReplySessionKey: "agent:main:feishu:direct:legacy-peer",
+    },
+    {
+      label: "thread-scoped direct route",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer:thread:reply-root",
+      dmScope: "main",
+      expectedReplySessionKey: "agent:main:feishu:direct:legacy-peer:thread:reply-root",
+    },
+    {
+      label: "direct route owned by another agent",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer",
+      dmScope: "main",
+      bindingAgentId: "stranger",
+      expectedReplySessionKey: "agent:main:feishu:direct:legacy-peer",
+    },
+    {
+      label: "erased named-account route owned by another agent",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer",
+      dmScope: "main",
+      bindingAgentId: "stranger",
+      bindingAccountId: "work",
+      expectedReplySessionKey: "agent:main:feishu:direct:legacy-peer",
+    },
+    {
+      label: "named-account route inheriting globally isolated DM scope",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer",
+      dmScope: "per-peer",
+      defaultBindingDmScope: "main",
+      bindingAccountId: "work",
+      expectedReplySessionKey: "agent:main:feishu:direct:legacy-peer",
+    },
+    {
+      label: "named-account route with a trimmed wildcard peer",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer",
+      dmScope: "main",
+      bindingDmScope: "per-peer",
+      bindingAccountId: "work",
+      bindingPeerId: " * ",
+      expectedReplySessionKey: "agent:main:feishu:direct:legacy-peer",
+    },
+    {
+      label: "isolated route with a case-preserving peer binding",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer",
+      dmScope: "main",
+      bindingDmScope: "per-peer",
+      bindingPeerId: "LEGACY-PEER",
+      expectedReplySessionKey: "agent:main:feishu:direct:legacy-peer",
+    },
+    {
+      label: "isolated route with session-erased team metadata",
+      requesterSessionKey: "agent:main:feishu:direct:legacy-peer",
+      dmScope: "main",
+      bindingDmScope: "per-peer",
+      bindingTeamId: "T123",
+      expectedReplySessionKey: "agent:main:feishu:direct:legacy-peer",
+    },
+    {
+      label: "group route with an opaque direct segment",
+      requesterSessionKey: "agent:main:feishu:group:direct:legacy-peer",
+      dmScope: "main",
+      expectedReplySessionKey: "agent:main:feishu:group:direct:legacy-peer",
+    },
+  ] as const)(
+    "returns a real cross-agent reply to the $label",
+    { timeout: SESSION_SEND_DM_ROUTING_E2E_TIMEOUT_MS },
+    async ({
+      label,
+      requesterSessionKey,
+      dmScope,
+      bindingDmScope,
+      defaultBindingDmScope,
+      bindingAccountId,
+      bindingAgentId,
+      bindingPeerId,
+      bindingTeamId,
+      expectedReplySessionKey,
+    }) => {
+      const configPath = process.env.OPENCLAW_CONFIG_PATH;
+      if (!configPath) {
+        throw new Error("OPENCLAW_CONFIG_PATH missing in gateway test environment");
+      }
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-send-dm-scope-"));
+      // A2A follow-ups outlive tool.execute. Give every real Gateway case its
+      // own agent so a preceding case can never satisfy this case's spy.
+      const targetAgentId = `orion-${label.toLowerCase().replaceAll(" ", "-")}`;
+      const targetSessionKey = `agent:${targetAgentId}:main`;
+      const config: OpenClawConfig = {
+        ...(bindingDmScope || defaultBindingDmScope || bindingAccountId || bindingAgentId
+          ? {
+              bindings: [
+                ...(defaultBindingDmScope
+                  ? [
+                      {
+                        type: "route" as const,
+                        agentId: "main",
+                        match: {
+                          channel: "feishu",
+                          accountId: "default",
+                          peer: { kind: "direct" as const, id: "legacy-peer" },
+                        },
+                        session: { dmScope: defaultBindingDmScope },
+                      },
+                    ]
+                  : []),
+                {
+                  type: "route",
+                  agentId: bindingAgentId ?? "main",
+                  match: {
+                    channel: "feishu",
+                    accountId: bindingAccountId ?? "default",
+                    peer: { kind: "direct", id: bindingPeerId ?? "legacy-peer" },
+                    ...(bindingTeamId ? { teamId: bindingTeamId } : {}),
+                  },
+                  ...(bindingDmScope ? { session: { dmScope: bindingDmScope } } : {}),
+                },
+              ],
+            }
+          : {}),
+        session: { dmScope },
+        tools: {
+          sessions: { visibility: "all" },
+          agentToAgent: { enabled: true },
+        },
+        agents: {
+          list: [
+            { id: "main", default: true },
+            { id: targetAgentId },
+            ...(bindingAgentId ? [{ id: bindingAgentId }] : []),
+          ],
+        },
+      };
+
+      testState.sessionStorePath = path.join(dir, "sessions.json");
+      testState.agentsConfig = config.agents;
+      testState.sessionConfig = config.session;
+      try {
+        await fs.mkdir(path.dirname(configPath), { recursive: true });
+        await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+        await writeSessionStore({
+          entries: {
+            "agent:main:main": { sessionId: "dm-scope-main", updatedAt: Date.now() },
+            [requesterSessionKey]: { sessionId: "dm-scope-legacy", updatedAt: Date.now() },
+            [targetSessionKey]: { sessionId: "dm-scope-orion", updatedAt: Date.now() },
+          },
+        });
+
+        const spy = agentCommand as unknown as Mock<(opts: unknown) => Promise<void>>;
+        spy.mockReset();
+        spy.mockImplementation(async (opts: unknown) =>
+          emitLifecycleAssistantReply({
+            opts,
+            defaultSessionId: `dm-scope-${targetAgentId}`,
+            resolveText: (extraSystemPrompt) => {
+              if (extraSystemPrompt?.includes("Agent-to-agent reply step")) {
+                return "REPLY_SKIP";
+              }
+              if (extraSystemPrompt?.includes("Agent-to-agent announce step")) {
+                return "ANNOUNCE_SKIP";
+              }
+              return "orion received the session message";
+            },
+          }),
+        );
+
+        const tool = createOpenClawTools({
+          agentSessionKey: requesterSessionKey,
+          agentChannel: "feishu",
+          config,
+        }).find((candidate) => candidate.name === "sessions_send");
+        if (!tool) {
+          throw new Error("missing sessions_send tool");
+        }
+
+        const result = await tool.execute("call-dm-scope-routing", {
+          sessionKey: targetSessionKey,
+          message: "deliver to the monitored requester session",
+          timeoutSeconds: 10,
+        });
+        expectSessionsSendDetails(result, {
+          reply: "orion received the session message",
+          sessionKey: targetSessionKey,
+        });
+
+        const runId = (result.details as { runId?: string }).runId;
+        expect(runId).toBeTypeOf("string");
+        const targetCall = spy.mock.calls
+          .map(
+            ([opts]) =>
+              opts as {
+                runId?: string;
+                sessionKey?: string;
+                inputProvenance?: { sourceSessionKey?: string };
+              },
+          )
+          .find((opts) => opts.sessionKey === targetSessionKey && opts.runId === runId);
+        if (!targetCall) {
+          const observedRuns = spy.mock.calls.slice(-6).map(([opts]) => {
+            const call = opts as { runId?: string; sessionKey?: string };
+            return { runId: call.runId, sessionKey: call.sessionKey };
+          });
+          throw new Error(
+            `Target run ${runId} for ${targetSessionKey} was not observed: ${JSON.stringify(observedRuns)}`,
+          );
+        }
+        expect(targetCall?.inputProvenance?.sourceSessionKey).toBe(expectedReplySessionKey);
+
+        await vi.waitFor(
+          () => {
+            expect(
+              spy.mock.calls.some(([opts]) => {
+                const call = opts as {
+                  sessionKey?: string;
+                  extraSystemPrompt?: string;
+                  inputProvenance?: { sourceSessionKey?: string };
+                };
+                return (
+                  call.sessionKey === expectedReplySessionKey &&
+                  call.inputProvenance?.sourceSessionKey === targetSessionKey &&
+                  call.extraSystemPrompt?.includes("Agent-to-agent reply step")
+                );
+              }),
+            ).toBe(true);
+          },
+          { timeout: 10_000, interval: 25 },
+        );
+        if (expectedReplySessionKey !== requesterSessionKey) {
+          expect(
+            spy.mock.calls.some(([opts]) => {
+              const call = opts as {
+                sessionKey?: string;
+                extraSystemPrompt?: string;
+                inputProvenance?: { sourceSessionKey?: string };
+              };
+              return (
+                call.sessionKey === requesterSessionKey &&
+                call.inputProvenance?.sourceSessionKey === targetSessionKey &&
+                call.extraSystemPrompt?.includes("Agent-to-agent reply step")
+              );
+            }),
+          ).toBe(false);
+        }
+      } finally {
+        testState.sessionConfig = undefined;
         testState.agentsConfig = undefined;
         testState.sessionStorePath = undefined;
         await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });


### PR DESCRIPTION
Closes #107399
Related: #107469

## What Problem This Solves

Fixes an issue where users delegating a task from a legacy direct-message session would receive the delegated agent's completion in an unmonitored session instead of their active conversation.

## Why This Change Was Made

Canonicalize only the reply address for structurally valid, unthreaded direct-message and DM session keys when the established route safely resolves to the agent's main session. Preserve the exact authenticated requester identity for visibility, ownership, sandbox, synchronous self-send, and session creation; conservatively preserve account-, peer-, team-, role-, binding-, owner-, and thread-isolated routes.

## User Impact

Delegated cross-agent replies return to the user's active direct conversation, while isolated, foreign-agent, threaded, and group conversations remain separated.

## Evidence

- Fail-first real Gateway evidence: https://github.com/openclaw/openclaw/actions/runs/30430196528
- Clean remote Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30433675273 — 393 passing tests across nine files and five Vitest projects, including all 28 authenticated, device-paired, real-WebSocket Gateway cases.
- Independent fresh gpt-5.6-sol xhigh structured autoreview: clean, with no accepted or actionable findings.
- Local real Gateway regression: all 28 cases pass.
- Source provenance: 65188a7430f (#108354).

Thanks to @ChengKe771 for identifying the issue and proposing #107469. The final maintainer-owned implementation preserves the original contribution through its Co-authored-by commit trailer while additionally protecting structural DM routing, authenticated requester identity, and private binding scopes.