### PR TITLE
fix(web-fetch): release unread responses after provider fallback

### DIFF
--- a/src/agents/tools/web-fetch.provider-fallback.test.ts
+++ b/src/agents/tools/web-fetch.provider-fallback.test.ts
@@ -1,12 +1,14 @@
 // Provider fallback tests verify web_fetch normalizes third-party fetch output
 // before exposing it to agents or cache entries.
 import { rm } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { wrapExternalContent } from "../../security/external-content.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import { createWebFetchTool } from "./web-fetch.js";
+import * as webGuardedFetch from "./web-guarded-fetch.js";
 
 const { resolveWebFetchDefinitionMock } = vi.hoisted(() => ({
   resolveWebFetchDefinitionMock: vi.fn(),
@@ -358,5 +360,210 @@ describe("web_fetch provider fallback normalization", () => {
     expect(secondDetails.externalContent?.provider).toBe("perplexity-fetch");
     expect(secondDetails.text).toContain("perplexity-fetch fallback body");
     expect(secondDetails.cached).toBeUndefined();
+  });
+
+  it("cancels an unread error response when provider fallback succeeds", async () => {
+    let cancelled = false;
+    global.fetch = withFetchPreconnect(
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              pull(controller) {
+                controller.enqueue(new TextEncoder().encode("unread upstream error"));
+              },
+              cancel() {
+                cancelled = true;
+              },
+            }),
+            { status: 503, headers: { "content-type": "text/plain" } },
+          ),
+      ),
+    );
+    resolveWebFetchDefinitionMock.mockReturnValue({
+      provider: { id: "firecrawl" },
+      definition: {
+        description: "firecrawl",
+        parameters: {},
+        execute: async () => ({
+          text: "provider rescued body",
+          extractor: "custom-provider",
+        }),
+      },
+    });
+
+    const tool = createWebFetchTool({ config: {} as OpenClawConfig, sandboxed: false });
+    const result = await tool?.execute?.("unread-response-fallback", {
+      url: "https://example.com/unread-response-fallback",
+    });
+    const details = result?.details as { text?: string; extractor?: string };
+
+    expect(details.extractor).toBe("custom-provider");
+    expect(details.text).toContain("provider rescued body");
+    expect(cancelled).toBe(true);
+  });
+
+  it("cancels an unread error response when provider fallback throws", async () => {
+    let cancelled = false;
+    global.fetch = withFetchPreconnect(
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              pull(controller) {
+                controller.enqueue(new TextEncoder().encode("unread upstream error"));
+              },
+              cancel() {
+                cancelled = true;
+              },
+            }),
+            { status: 503, headers: { "content-type": "text/plain" } },
+          ),
+      ),
+    );
+    resolveWebFetchDefinitionMock.mockReturnValue({
+      provider: { id: "firecrawl" },
+      definition: {
+        description: "firecrawl",
+        parameters: {},
+        execute: async () => {
+          throw new Error("provider fallback unavailable");
+        },
+      },
+    });
+
+    const tool = createWebFetchTool({ config: {} as OpenClawConfig, sandboxed: false });
+
+    await expect(
+      tool?.execute?.("failed-provider-fallback", {
+        url: "https://example.com/failed-provider-fallback",
+      }),
+    ).rejects.toThrow("provider fallback unavailable");
+    expect(cancelled).toBe(true);
+  });
+
+  it("returns provider fallback without waiting for a stalled body cancellation", async () => {
+    let cancelInvoked = false;
+    global.fetch = withFetchPreconnect(
+      vi.fn(
+        async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              pull(controller) {
+                controller.enqueue(new TextEncoder().encode("unread upstream error"));
+              },
+              cancel() {
+                cancelInvoked = true;
+                return new Promise<void>(() => {});
+              },
+            }),
+            { status: 503, headers: { "content-type": "text/plain" } },
+          ),
+      ),
+    );
+    resolveWebFetchDefinitionMock.mockReturnValue({
+      provider: { id: "firecrawl" },
+      definition: {
+        description: "firecrawl",
+        parameters: {},
+        execute: async () => ({
+          text: "provider rescued body",
+          extractor: "custom-provider",
+        }),
+      },
+    });
+
+    const tool = createWebFetchTool({ config: {} as OpenClawConfig, sandboxed: false });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const result = await Promise.race([
+        tool?.execute?.("stalled-body-cancellation", {
+          url: "https://example.com/stalled-body-cancellation",
+        }),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error("body cancellation blocked fallback")), 1_000);
+        }),
+      ]);
+      const details = result?.details as { text?: string; extractor?: string };
+
+      expect(details.extractor).toBe("custom-provider");
+      expect(details.text).toContain("provider rescued body");
+      expect(cancelInvoked).toBe(true);
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  });
+
+  it("closes a real guarded HTTP response when provider fallback succeeds", async () => {
+    // Allow loopback only inside this proof; production SSRF policy remains unchanged.
+    const fetchWithRealGuard = webGuardedFetch.fetchWithWebToolsNetworkGuard;
+    vi.spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard").mockImplementation((params) =>
+      fetchWithRealGuard({
+        ...params,
+        policy: { ...params.policy, dangerouslyAllowPrivateNetwork: true },
+      }),
+    );
+
+    let upstreamClosed = false;
+    let server: Server | undefined;
+    try {
+      server = createServer((request, response) => {
+        response.writeHead(503, {
+          "content-type": "text/plain; charset=utf-8",
+          "content-length": "1048576",
+        });
+        response.write("unread upstream error\n");
+        const timer = setInterval(() => {
+          response.write("x".repeat(2_048));
+        }, 10);
+        const markClosed = () => {
+          upstreamClosed = true;
+          clearInterval(timer);
+        };
+        request.once("aborted", markClosed);
+        response.once("close", markClosed);
+      });
+      await new Promise<void>((resolve) => {
+        server?.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected a loopback TCP address");
+      }
+
+      resolveWebFetchDefinitionMock.mockReturnValue({
+        provider: { id: "firecrawl" },
+        definition: {
+          description: "firecrawl",
+          parameters: {},
+          execute: async () => ({
+            text: "provider rescued real guarded HTTP",
+            extractor: "custom-provider",
+          }),
+        },
+      });
+      const tool = createWebFetchTool({ config: {} as OpenClawConfig, sandboxed: false });
+      const result = await tool?.execute?.("guarded-http-body-cancellation", {
+        url: `http://127.0.0.1:${address.port}/fallback`,
+      });
+      const details = result?.details as { text?: string; extractor?: string };
+
+      expect(details.extractor).toBe("custom-provider");
+      expect(details.text).toContain("provider rescued real guarded HTTP");
+      await vi.waitFor(() => expect(upstreamClosed).toBe(true), {
+        timeout: 2_000,
+        interval: 10,
+      });
+    } finally {
+      if (server) {
+        const activeServer = server;
+        await new Promise<void>((resolve) => {
+          activeServer.close(() => resolve());
+          activeServer.closeAllConnections();
+        });
+      }
+    }
   });
 });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -816,6 +816,11 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     writeCache(FETCH_CACHE, cacheKey, payload, params.cacheTtlMs);
     return payload;
   } finally {
+    if (!res.bodyUsed) {
+      // Fallbacks and provider failures can abandon the upstream stream. Cancel
+      // without awaiting so a stalled cancellation cannot block guard release.
+      void res.body?.cancel().catch(() => undefined);
+    }
     if (release) {
       await release();
     }


### PR DESCRIPTION
Related: #111332

## What Problem This Solves

Fixes an issue where users relying on a configured web-fetch provider fallback could leak upstream HTTP connections whenever a direct fetch returned an unread error response. A successful fallback returned to the agent while the original response kept streaming; a provider failure leaked the same response while propagating the error.

## Why This Change Was Made

Cancel an upstream response exactly once in the existing guarded-fetch cleanup when its body remains unread. Start cancellation before releasing the network guard without awaiting it, so a noncompliant never-settling stream cannot block a successful fallback. Already-consumed HTML/readability responses, provider selection and cache behavior, original provider errors, and private-network/SSRF policy remain unchanged.

This is a trusted-main, smaller and more complete follow-up to @nocodet888-arch's original #111332. The original contributor is credited as a commit co-author.

## User Impact

Provider fallback no longer leaves HTTP streams or sockets open, including when the provider itself fails. Long-running agents retain bounded HTTP resources without weakening web-fetch SSRF protection or introducing configuration.

## Evidence

- Reproduced all four regressions against trusted current main before the production fix: successful fallback leaked its upstream stream; throwing fallback leaked its stream; non-settling cancellation was not started; and a real production guarded node:http loopback response kept its socket open.
- Red-first Testbox: 4 failed / 5 existing passed.
- After the five-line owner-boundary fix: 184 / 184 tests passed across 10 focused web-fetch, provider, real guarded HTTP, SSRF, visibility, Cloudflare markdown, readability, response output, network guard, and shared-response test files.
- Full `pnpm check:changed` passed on the exact final patch, including formatting, core/core-test typechecks, lint, dead-export, SDK/boundary, and repository guards.
- Independent `gpt-5.6-sol` xhigh autoreview: clean, 0.98 confidence.
- Real HTTP evidence exercises the actual guarded loopback server and observes the abandoned response socket close; private-network access is enabled only within that test, while all 11 production SSRF regressions remain green.
- Remote proof: `blacksmith-testbox`, final command exit 0; lease stopped after proof.
- AI-assisted; reviewed against Undici's documented requirement to consume or cancel response bodies.
