### PR TITLE
fix(agents): prevent completed background processes from exhausting gateway memory

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -31,6 +31,7 @@ Behavior:
 - When backgrounded (explicit or via `yieldMs` timeout), the tool returns `status: "running"` + `sessionId` and a short output tail.
 - Backgrounded and `yieldMs` runs inherit `tools.exec.timeoutSeconds` unless the call passes an explicit `timeout`.
 - Output stays in memory until the session is polled or cleared.
+- Finished sessions expire after their configured TTL. The registry also retains at most 50 finished sessions and 2,000,000 total output characters, evicting the oldest records first. The newest completed session retains its full output even if it exceeds the aggregate limit.
 - If the `process` tool is disallowed, `exec` runs synchronously and ignores `yieldMs`/`background`.
 - Spawned exec commands receive `OPENCLAW_SHELL=exec` for context-aware shell/profile rules.
 - For long-running work that starts now: start it once and rely on automatic completion wake (when enabled) once the command emits output or fails.
@@ -81,6 +82,7 @@ Actions:
 Notes:
 
 - Only backgrounded sessions are listed/persisted — in memory only, not on disk. Sessions are lost on process restart.
+- Resetting or deleting a session clears only its completed background processes; other sessions, explicit shared scopes, and running processes remain unaffected.
 - A live background session blocks cooperative host suspension and safe Gateway restart until the process owner confirms its actual exit.
 - `process remove` can hide a running session immediately after requesting termination; suspension and restart remain blocked until exit confirmation.
 - Session logs are only saved to chat history if you run `process poll`/`log` and the tool result is recorded.

--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -13,6 +13,7 @@ import {
   deleteSession,
   drainSession,
   getActiveBackgroundExecSessionCount,
+  getFinishedSession,
   listFinishedSessions,
   listRunningSessions,
   markBackgrounded,
@@ -185,6 +186,91 @@ describe("bash process registry", () => {
         totalOutputChars: 0,
       },
     ]);
+  });
+
+  it("evicts the oldest finished sessions when their count exceeds the retention limit", () => {
+    for (let index = 0; index < 53; index += 1) {
+      const session = createRegistrySession({
+        id: `finished-${index}`,
+        maxOutputChars: 100,
+        pendingMaxOutputChars: 100,
+        backgrounded: true,
+      });
+      addSession(session);
+      appendOutput(session, "stdout", `output-${index}`);
+      markExited(session, 0, null, "completed");
+    }
+
+    expect(listFinishedSessions()).toHaveLength(50);
+    expect(getFinishedSession("finished-0")).toBeUndefined();
+    expect(getFinishedSession("finished-2")).toBeUndefined();
+    expect(getFinishedSession("finished-3")?.aggregated).toBe("output-3");
+    expect(getFinishedSession("finished-52")?.aggregated).toBe("output-52");
+  });
+
+  it("bounds aggregate finished-session output without truncating retained logs", () => {
+    for (let index = 0; index < 11; index += 1) {
+      const session = createRegistrySession({
+        id: `large-finished-${index}`,
+        maxOutputChars: 250_000,
+        pendingMaxOutputChars: 250_000,
+        backgrounded: true,
+      });
+      addSession(session);
+      appendOutput(session, "stdout", String(index).repeat(250_000));
+      markExited(session, 0, null, "completed");
+    }
+
+    expect(listFinishedSessions()).toHaveLength(8);
+    expect(getFinishedSession("large-finished-2")).toBeUndefined();
+    expect(getFinishedSession("large-finished-3")?.aggregated).toBe("3".repeat(250_000));
+    expect(getFinishedSession("large-finished-10")?.aggregated).toBe("10".repeat(125_000));
+  });
+
+  it("releases the aggregate budget when a completed session is explicitly cleared", () => {
+    for (let index = 0; index < 8; index += 1) {
+      const session = createRegistrySession({
+        id: `clear-budget-${index}`,
+        maxOutputChars: 250_000,
+        pendingMaxOutputChars: 250_000,
+        backgrounded: true,
+      });
+      addSession(session);
+      appendOutput(session, "stdout", String(index).repeat(250_000));
+      markExited(session, 0, null, "completed");
+    }
+
+    deleteSession("clear-budget-3");
+
+    const replacement = createRegistrySession({
+      id: "clear-budget-replacement",
+      maxOutputChars: 250_000,
+      pendingMaxOutputChars: 250_000,
+      backgrounded: true,
+    });
+    addSession(replacement);
+    appendOutput(replacement, "stdout", "r".repeat(250_000));
+    markExited(replacement, 0, null, "completed");
+
+    expect(listFinishedSessions()).toHaveLength(8);
+    expect(getFinishedSession("clear-budget-0")?.aggregated).toBe("0".repeat(250_000));
+    expect(getFinishedSession("clear-budget-3")).toBeUndefined();
+    expect(getFinishedSession("clear-budget-replacement")?.aggregated).toBe("r".repeat(250_000));
+  });
+
+  it("retains the complete newest log when it alone exceeds the aggregate budget", () => {
+    const session = createRegistrySession({
+      id: "oversized-finished",
+      maxOutputChars: 2_000_001,
+      pendingMaxOutputChars: 2_000_001,
+      backgrounded: true,
+    });
+    addSession(session);
+    appendOutput(session, "stdout", "x".repeat(2_000_001));
+    markExited(session, 0, null, "completed");
+
+    expect(listFinishedSessions()).toHaveLength(1);
+    expect(getFinishedSession("oversized-finished")?.aggregated).toHaveLength(2_000_001);
   });
 
   it("tracks only live backgrounded sessions", () => {

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -15,6 +15,8 @@ const DEFAULT_JOB_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const MIN_JOB_TTL_MS = 60 * 1000; // 1 minute
 const MAX_JOB_TTL_MS = 3 * 60 * 60 * 1000; // 3 hours
 const DEFAULT_PENDING_OUTPUT_CHARS = 30_000;
+const MAX_FINISHED_SESSION_COUNT = 50;
+const MAX_FINISHED_SESSION_OUTPUT_CHARS = 2_000_000;
 
 function clampTtl(value: number | undefined) {
   if (value === undefined || Number.isNaN(value)) {
@@ -112,6 +114,7 @@ interface FinishedSession {
 const runningSessions = new Map<string, ProcessSession>();
 const finishedSessions = new Map<string, FinishedSession>();
 const activeBackgroundExecSessionIds = new Set<string>();
+let finishedSessionOutputChars = 0;
 
 let sweeper: NodeJS.Timeout | null = null;
 
@@ -142,10 +145,39 @@ export function getFinishedSession(id: string) {
   return finishedSessions.get(id);
 }
 
+function deleteFinishedSession(id: string): boolean {
+  const session = finishedSessions.get(id);
+  if (!session) {
+    return false;
+  }
+  finishedSessions.delete(id);
+  finishedSessionOutputChars -= session.aggregated.length;
+  return true;
+}
+
 /** Removes visible session records without changing live-process activity. */
 export function deleteSession(id: string) {
   runningSessions.delete(id);
-  finishedSessions.delete(id);
+  deleteFinishedSession(id);
+}
+
+/** Removes completed process records belonging to retired session identities. */
+export function clearFinishedSessionsForScopes(scopeKeys: Iterable<string>): void {
+  const retiredScopes = new Set<string>();
+  for (const scopeKey of scopeKeys) {
+    const normalizedScope = scopeKey.trim();
+    if (normalizedScope) {
+      retiredScopes.add(normalizedScope);
+    }
+  }
+  if (retiredScopes.size === 0) {
+    return;
+  }
+  for (const [id, session] of finishedSessions) {
+    if (session.scopeKey && retiredScopes.has(session.scopeKey)) {
+      deleteFinishedSession(id);
+    }
+  }
 }
 
 /** Appends process output while enforcing aggregate and pending-output caps. */
@@ -261,6 +293,9 @@ function moveToFinished(session: ProcessSession, status: ProcessStatus) {
   if (!session.backgrounded) {
     return;
   }
+  // Keep full completed logs; evict older records rather than silently
+  // truncating the process poll/log contract or dropping the newest result.
+  deleteFinishedSession(session.id);
   finishedSessions.set(session.id, {
     id: session.id,
     command: session.command,
@@ -280,6 +315,17 @@ function moveToFinished(session: ProcessSession, status: ProcessStatus) {
     truncated: session.truncated,
     totalOutputChars: session.totalOutputChars,
   });
+  finishedSessionOutputChars += session.aggregated.length;
+  while (
+    finishedSessions.size > MAX_FINISHED_SESSION_COUNT ||
+    (finishedSessions.size > 1 && finishedSessionOutputChars > MAX_FINISHED_SESSION_OUTPUT_CHARS)
+  ) {
+    const oldestSessionId = finishedSessions.keys().next().value;
+    if (oldestSessionId === undefined) {
+      break;
+    }
+    deleteFinishedSession(oldestSessionId);
+  }
 }
 
 /** Returns the last `max` characters of text without adding ellipses. */
@@ -353,6 +399,7 @@ export function listFinishedSessions() {
 function resetProcessRegistryForTests() {
   runningSessions.clear();
   finishedSessions.clear();
+  finishedSessionOutputChars = 0;
   activeBackgroundExecSessionIds.clear();
   stopSweeper();
 }
@@ -376,7 +423,7 @@ function pruneFinishedSessions() {
   const cutoff = Date.now() - jobTtlMs;
   for (const [id, session] of finishedSessions.entries()) {
     if (session.endedAt < cutoff) {
-      finishedSessions.delete(id);
+      deleteFinishedSession(id);
     }
   }
 }

--- a/src/agents/bash-tools.process.finished-retention.test.ts
+++ b/src/agents/bash-tools.process.finished-retention.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Real background-shell proof for bounded completed process retention.
+ */
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  getActiveBackgroundExecSessionCount,
+  listFinishedSessions,
+} from "./bash-process-registry.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
+import { createExecTool } from "./bash-tools.exec-run.js";
+import { createProcessTool } from "./bash-tools.process.js";
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+});
+
+test("real completed background commands retain only the newest fully readable process logs", async () => {
+  const scopeKey = "agent:main:retention-proof";
+  const exec = createExecTool({
+    host: "gateway",
+    security: "full",
+    ask: "off",
+    allowBackground: true,
+    backgroundMs: 0,
+    scopeKey,
+  });
+  const processTool = createProcessTool({ scopeKey });
+  const sessionIds: string[] = [];
+
+  for (let index = 0; index < 53; index += 1) {
+    const result = await exec.execute(`background-retention-${index}`, {
+      command: `node -e "process.stdout.write('retention-${index}')"`,
+      background: true,
+    });
+    const details = result.details as { sessionId?: string; status?: string };
+    expect(details.status).toBe("running");
+    expect(details.sessionId).toEqual(expect.any(String));
+    if (details.sessionId) {
+      sessionIds.push(details.sessionId);
+    }
+  }
+
+  await vi.waitFor(
+    () => {
+      expect(getActiveBackgroundExecSessionCount()).toBe(0);
+    },
+    { timeout: 20_000, interval: 25 },
+  );
+
+  const finishedSessions = listFinishedSessions();
+  expect(finishedSessions).toHaveLength(50);
+  const listed = await processTool.execute("retention-list", { action: "list" });
+  expect((listed.details as { sessions?: unknown[] }).sessions).toHaveLength(50);
+
+  // Real children can exit in a different order than their spawn calls; the
+  // retention contract evicts by completion, not by launch position.
+  const retainedSessionIds = new Set(finishedSessions.map((session) => session.id));
+  const evictedSessionIds = sessionIds.filter((sessionId) => !retainedSessionIds.has(sessionId));
+  expect(evictedSessionIds).toHaveLength(3);
+  const evictedId = evictedSessionIds[0];
+  if (!evictedId) {
+    throw new Error("expected an evicted completed process session");
+  }
+  const evicted = await processTool.execute("retention-evicted-poll", {
+    action: "poll",
+    sessionId: evictedId,
+  });
+  expect(evicted.details).toMatchObject({ status: "failed" });
+  expect(evicted.content[0]).toMatchObject({
+    type: "text",
+    text: expect.stringContaining(`No session found for ${evictedId}`),
+  });
+
+  const newestId = finishedSessions.at(-1)?.id;
+  if (!newestId) {
+    throw new Error("expected the newest completed process session");
+  }
+  const newestIndex = sessionIds.indexOf(newestId);
+  expect(newestIndex).toBeGreaterThanOrEqual(0);
+  const newestLog = await processTool.execute("retention-newest-log", {
+    action: "log",
+    sessionId: newestId,
+  });
+  expect(newestLog.details).toMatchObject({ status: "completed" });
+  expect(newestLog.content[0]).toMatchObject({
+    type: "text",
+    text: `retention-${newestIndex}`,
+  });
+}, 30_000);

--- a/src/gateway/server.sessions.process-cleanup.test.ts
+++ b/src/gateway/server.sessions.process-cleanup.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Gateway lifecycle proof for session-scoped completed process cleanup.
+ */
+import { afterEach, expect, test } from "vitest";
+import {
+  addSession,
+  getFinishedSession,
+  getSession,
+  markExited,
+} from "../agents/bash-process-registry.js";
+import { createProcessSessionFixture } from "../agents/bash-process-registry.test-helpers.js";
+import { resetProcessRegistryForTests } from "../agents/bash-process-registry.test-support.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { writeSessionStore } from "./test-helpers.js";
+import {
+  directSessionReq,
+  sessionStoreEntry,
+  setupGatewaySessionsTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsTestHarness();
+
+afterEach(() => {
+  resetProcessRegistryForTests();
+  closeOpenClawStateDatabaseForTest();
+});
+
+function seedFinishedProcess(id: string, scopeKey: string) {
+  const session = createProcessSessionFixture({ id, backgrounded: true });
+  session.scopeKey = scopeKey;
+  addSession(session);
+  markExited(session, 0, null, "completed");
+}
+
+test("sessions.reset purges finished processes for every retired session identity", async () => {
+  await seedActiveMainSession();
+  seedFinishedProcess("finished-main-alias", "main");
+  seedFinishedProcess("finished-main-canonical", "agent:main:main");
+  seedFinishedProcess("finished-main-id", "sess-main");
+  seedFinishedProcess("finished-other-session", "agent:main:other");
+  seedFinishedProcess("finished-shared-scope", "explicit:shared");
+
+  const running = createProcessSessionFixture({
+    id: "running-main-process",
+    backgrounded: true,
+  });
+  running.scopeKey = "agent:main:main";
+  addSession(running);
+
+  const reset = await directSessionReq("sessions.reset", { key: "main" });
+
+  expect(reset.ok).toBe(true);
+  expect(getFinishedSession("finished-main-alias")).toBeUndefined();
+  expect(getFinishedSession("finished-main-canonical")).toBeUndefined();
+  expect(getFinishedSession("finished-main-id")).toBeUndefined();
+  expect(getFinishedSession("finished-other-session")).toBeDefined();
+  expect(getFinishedSession("finished-shared-scope")).toBeDefined();
+  expect(getSession("running-main-process")).toBe(running);
+});
+
+test("sessions.delete purges only completed processes owned by the deleted session", async () => {
+  await createSessionStoreDir();
+  const requestedKey = "discord:group:retention-proof";
+  const canonicalKey = "agent:main:discord:group:retention-proof";
+  const sessionId = "sess-retention-delete";
+  await writeSessionStore({
+    entries: { [requestedKey]: sessionStoreEntry(sessionId) },
+  });
+  seedFinishedProcess("finished-delete-alias", requestedKey);
+  seedFinishedProcess("finished-delete-canonical", canonicalKey);
+  seedFinishedProcess("finished-delete-id", sessionId);
+  seedFinishedProcess("finished-delete-other", "agent:main:other");
+
+  const deleted = await directSessionReq("sessions.delete", { key: requestedKey });
+
+  expect(deleted.ok).toBe(true);
+  expect(getFinishedSession("finished-delete-alias")).toBeUndefined();
+  expect(getFinishedSession("finished-delete-canonical")).toBeUndefined();
+  expect(getFinishedSession("finished-delete-id")).toBeUndefined();
+  expect(getFinishedSession("finished-delete-other")).toBeDefined();
+});

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -354,9 +354,10 @@ async function ensureSessionRuntimeCleanup(params: {
 }) {
   // Session lifecycle mutation owns this heavy runtime edge; read-only gateway
   // commands such as status must not load the embedded-agent barrel.
-  const [embeddedAgent, mcpTools] = await Promise.all([
+  const [embeddedAgent, mcpTools, { clearFinishedSessionsForScopes }] = await Promise.all([
     import("../agents/embedded-agent.js"),
     import("../agents/agent-bundle-mcp-tools.js"),
+    import("../agents/bash-process-registry.js"),
   ]);
   params.assertCurrent?.();
   const closeTrackedBrowserTabs = async () => {
@@ -381,6 +382,12 @@ async function ensureSessionRuntimeCleanup(params: {
   if (params.sessionId) {
     queueKeys.add(params.sessionId);
   }
+  // Process scopes may use the requested alias, canonical key, or session id.
+  // Clear only completed records so reset/delete cannot erase another scope's
+  // output or hide a background process whose owner has not confirmed exit.
+  const processScopeKeys = new Set(queueKeys);
+  processScopeKeys.add(params.key);
+  clearFinishedSessionsForScopes(processScopeKeys);
   clearSessionResetRuntimeState([...queueKeys], {
     activeReplySessionId: params.sessionId,
   });


### PR DESCRIPTION
Closes #105625

## What Problem This Solves

Fixes an issue where users running many background shell commands could leave an unbounded number of completed processes and their complete logs in Gateway memory. Resetting or deleting a conversation also left its finished command results visible until the retention timer expired.

## Why This Change Was Made

Retain at most 50 completed sessions and 2,000,000 aggregate output characters, evicting the oldest completed records while preserving every retained full process log and the newest result. Session reset and deletion purge only completed results for the retired requested, canonical, and session-id scopes; running commands, unrelated conversations, and intentionally shared scopes remain intact. The process registry is imported only by the existing session-lifecycle cleanup path. No configuration, environment, protocol, database, or security-owner surface is added.

## User Impact

Background-command bursts no longer produce unbounded completed-process memory growth. Users can continue to inspect complete recent command output with process list, poll, and log; resetting or deleting a conversation immediately removes only that conversation's completed command results.

## Evidence

AI-assisted; independently reproduced against main before changing production code and reviewed with `gpt-5.6-sol` at `xhigh` reasoning.

- Before fix: the real exec tool launched 53 actual Node.js child processes and retained all 53 completed results; the expected bound is 50. Actual Gateway `sessions.reset` and `sessions.delete` both retained completed results for the retired requested alias, canonical session key, and session id.
- After fix: Linux Blacksmith Testbox [run 30433732698](https://github.com/openclaw/openclaw/actions/runs/30433732698) completed 93/93 relevant tests across 10 files and three Vitest project shards, including the same 53 actual Node subprocesses, user-visible process `list`/`poll`/`log`, actual Gateway reset/delete, concurrency, lifecycle cleanup, subprocess cancellation, and unrelated/shared/running-session isolation.
- Full remote `pnpm check:changed`: passed, including formatting, documentation, zero-warning lint, core and test typechecks, all three zero-finding unused-export scans, database-first guards, SDK/boundary checks, and runtime cycle checks.
- Fresh structured `gpt-5.6-sol --thinking xhigh` autoreview: no accepted or actionable findings.

Thanks to @aniruddhaadak80 for the original report.