### PR TITLE
fix(cron): deliver explicit failure alerts for best-effort jobs

### DIFF
--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -213,8 +213,9 @@ export function maybeEmitFailureAlert(
     // Suppress failed-run duplicates without disabling global skipped alerts.
     return;
   }
-  const isBestEffort = params.job.delivery?.bestEffort === true;
-  if (isBestEffort) {
+  // Best-effort delivery suppresses inherited alert noise, not an independently
+  // configured job alert that the operator explicitly requested.
+  if (params.job.delivery?.bestEffort === true && !params.job.failureAlert) {
     return;
   }
   const now = params.occurredAtMs ?? state.deps.nowMs();

--- a/src/cron/service/timer.timeout-watchdog.test.ts
+++ b/src/cron/service/timer.timeout-watchdog.test.ts
@@ -708,6 +708,18 @@ describe("cron service timer regressions", () => {
         payload: { kind: "agentTurn", message: "work", timeoutSeconds: 1_200 },
         state: { nextRunAtMs: scheduledAt },
       });
+      cronJob.delivery = {
+        mode: "announce",
+        channel: "telegram",
+        to: "19098680",
+        bestEffort: true,
+      };
+      cronJob.failureAlert = {
+        after: 1,
+        mode: "announce",
+        channel: "telegram",
+        to: "12345",
+      };
       await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
 
       vi.setSystemTime(scheduledAt);
@@ -715,6 +727,7 @@ describe("cron service timer regressions", () => {
       const started = createDeferred<void>();
       let abortObserved = false;
       const cleanupTimedOutAgentRun = vi.fn(async () => {});
+      const sendCronFailureAlert = vi.fn(async () => {});
       const state = createCronServiceState({
         cronEnabled: true,
         storePath: store.storePath,
@@ -723,6 +736,7 @@ describe("cron service timer regressions", () => {
         enqueueSystemEvent: vi.fn(),
         requestHeartbeat: vi.fn(),
         cleanupTimedOutAgentRun,
+        sendCronFailureAlert,
         runIsolatedAgentJob: vi.fn(
           async ({
             abortSignal,
@@ -770,6 +784,14 @@ describe("cron service timer regressions", () => {
       expect(job.state.lastError).toContain("stalled before execution start");
       expect(job.state.lastError).toContain("runtime-plugins");
       expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
+      expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+      expect(sendCronFailureAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: "telegram",
+          to: "12345",
+          text: expect.stringContaining("runtime-plugins"),
+        }),
+      );
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
Closes #89847.

## What Problem This Solves

Fixes an issue where operators who explicitly configure a cron failure alert would receive no notification when an isolated job stalls in `runtime-plugins` and the job's normal result delivery uses `bestEffort: true`.

## Why This Change Was Made

Best-effort result delivery should continue suppressing inherited global failure alerts, but must not override a separately and explicitly configured per-job failure alert. Keep the decision in the cron failure-alert owner, preserve the existing global-alert, target-routing, cooldown, and opt-out contracts, and exercise the existing real scheduler watchdog rather than guessing from the report.

## User Impact

A cron job's explicitly configured Telegram or other channel failure notification now fires after an isolated startup/runtime-plugin stall even when its ordinary announcement is best-effort. Operators who have not configured a job-specific alert keep the existing quiet behavior.

## Evidence

- Reproduced the reported exact `runtime_plugins` stall, `bestEffort: true`, job-specific Telegram alert, and real 60-second cron watchdog against production `onTimer`: before the fix the configured alert callback is called zero times; after the fix it is called exactly once with the configured Telegram target and the `runtime-plugins` error.
- Existing unchanged `src/cron/service.failure-alert.test.ts` independently confirms inherited global alerts remain suppressed for best-effort jobs.
- Fresh trusted Blacksmith Testbox on repaired main: **139 tests passed in all 8 relevant cron suites**, including watchdogs, real service/store startup and replay, completion delivery, Telegram failure-route/account selection, stream triggers, and failure-alert codec.
- Full remote `corepack pnpm check:changed`: **passed**, including all production/full-tree/script Knip dead-export checks, core and test typechecking, formatting, lint, plugin boundaries, SQLite guards, runtime import cycles, and security guards.
- Fresh structured `gpt-5.6-sol` xhigh commit autoreview: clean; no accepted/actionable findings.

This change does not add configuration, change failure-status enums, or attempt to add Telegram topic configuration; those are distinct feature decisions.