### PR TITLE
fix(zalo): stop provider startup after gateway shutdown

### DIFF
--- a/extensions/zalo/src/channel.pre-aborted.integration.test.ts
+++ b/extensions/zalo/src/channel.pre-aborted.integration.test.ts
@@ -1,0 +1,113 @@
+// Zalo tests cover the configured gateway lifecycle through the real HTTP client.
+import { createServer, type Server } from "node:http";
+import {
+  createEmptyPluginRegistry,
+  createStartAccountContext,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveZaloAccount } from "./accounts.js";
+import { zaloPlugin } from "./channel.js";
+import { setZaloRuntime, type OpenClawConfig, type PluginRuntime } from "./runtime-api.js";
+
+const originalZaloApiUrl = process.env.ZALO_API_URL;
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback Zalo API address");
+  }
+  return `http://127.0.0.1:${String(address.port)}`;
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function requireStartAccount() {
+  const startAccount = zaloPlugin.gateway?.startAccount;
+  if (!startAccount) {
+    throw new Error("expected Zalo gateway startAccount");
+  }
+  return startAccount;
+}
+
+describe("configured Zalo gateway with a pre-aborted lifecycle", () => {
+  let server: Server;
+  let apiMethods: string[];
+
+  beforeEach(async () => {
+    apiMethods = [];
+    server = createServer((request, response) => {
+      const method = request.url?.match(/\/bot[^/]+\/([^/?]+)/u)?.[1] ?? "unknown";
+      apiMethods.push(method);
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: true,
+          result:
+            method === "getMe"
+              ? {
+                  id: "loopback-bot",
+                  account_name: "Loopback proof bot",
+                  account_type: "BOT",
+                  can_join_groups: false,
+                }
+              : { url: "" },
+        }),
+      );
+    });
+    process.env.ZALO_API_URL = await listen(server);
+    setZaloRuntime({} as PluginRuntime);
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  afterEach(async () => {
+    if (originalZaloApiUrl === undefined) {
+      delete process.env.ZALO_API_URL;
+    } else {
+      process.env.ZALO_API_URL = originalZaloApiUrl;
+    }
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    await close(server);
+  });
+
+  it.each([
+    { mode: "polling", channel: { botToken: "test-bot-token" } },
+    {
+      mode: "webhook",
+      channel: {
+        botToken: "test-bot-token",
+        webhookUrl: "https://example.invalid/hooks/zalo",
+        webhookSecret: "test-webhook-secret",
+      },
+    },
+  ] as const)("performs only the account probe in $mode mode", async ({ channel }) => {
+    const cfg = { channels: { zalo: channel } } as OpenClawConfig;
+    const account = resolveZaloAccount({ cfg });
+    const abort = new AbortController();
+    abort.abort();
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    await requireStartAccount()(
+      createStartAccountContext({
+        account,
+        cfg,
+        abortSignal: abort.signal,
+      }),
+    );
+
+    expect(apiMethods).toEqual(["getMe"]);
+    expect(registry.httpRoutes).toHaveLength(0);
+  });
+});

--- a/extensions/zalo/src/monitor.lifecycle.test.ts
+++ b/extensions/zalo/src/monitor.lifecycle.test.ts
@@ -265,4 +265,53 @@ describe("monitorZaloProvider lifecycle", () => {
     expect(registry.httpRoutes).toHaveLength(0);
     expect(runtime.log).toHaveBeenCalledWith("[default] Zalo provider stopped mode=webhook");
   });
+
+  it("returns immediately without polling startup when abort signal is pre-aborted", async () => {
+    const { monitorZaloProvider } = await import("./monitor.js");
+    const preAborted = new AbortController();
+    preAborted.abort();
+    const runtime = createRuntimeEnv();
+
+    // With a pre-aborted signal the function must return without ever
+    // entering the polling loop (getUpdates never called).
+    await monitorZaloProvider({
+      token: "test-token",
+      account: TEST_ACCOUNT,
+      config: TEST_CONFIG,
+      runtime,
+      abortSignal: preAborted.signal,
+    });
+
+    // getUpdatesMock is a never-resolving promise in polling mode; if the
+    // early return works, this test completes. getUpdates should not be
+    // called because we never entered polling.
+    expect(getUpdatesMock).not.toHaveBeenCalled();
+    // getWebhookInfo should also be skipped — on main the polling path
+    // inspects the webhook before starting the loop, so a pre-aborted
+    // signal that misses the early return would hit getWebhookInfo first.
+    expect(getWebhookInfoMock).not.toHaveBeenCalled();
+    // The early return logs provider init but skips the try/finally block,
+    // so the "stopped" log from the finally block is not emitted.
+  });
+
+  it("returns immediately without webhook registration when abort signal is pre-aborted", async () => {
+    const { monitorZaloProvider } = await import("./monitor.js");
+    const preAborted = new AbortController();
+    preAborted.abort();
+    const runtime = createRuntimeEnv();
+
+    await monitorZaloProvider({
+      token: "test-token",
+      account: TEST_ACCOUNT,
+      config: TEST_CONFIG,
+      runtime,
+      abortSignal: preAborted.signal,
+      useWebhook: true,
+      webhookUrl: "https://example.com/hooks/zalo",
+      webhookSecret: "test-webhook-secret",
+    });
+
+    // setWebhookMock should not be called — we returned before webhook setup.
+    expect(setWebhookMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -867,6 +867,15 @@ export async function monitorZaloProvider(options: ZaloMonitorOptions): Promise<
     }
   };
 
+  if (abortSignal.aborted) {
+    // The signal is already aborted — trigger cleanup in non-webhook mode
+    // and return before acquiring any resources (hosted-media routes,
+    // webhook registration, or polling). This avoids registering cleanup
+    // handlers after stop() has already set stopped=true, which would
+    // skip them in the finally block and leak plugin HTTP routes.
+    stopOnAbort();
+    return;
+  }
   abortSignal.addEventListener("abort", stopOnAbort, { once: true });
 
   runtime.log?.(


### PR DESCRIPTION
Related: #109990

## What Problem This Solves

Fixes an issue where a configured Zalo account could keep starting after its gateway lifecycle had already been canceled. Polling could still inspect or mutate webhooks, and webhook mode could acquire local HTTP routes or change remote webhook registration after shutdown.

## Why This Change Was Made

Preserves and credits @LZY3538's original fix from #109990 while reconstructing its exact three reviewed file blobs on current, repaired main. The Zalo-owned monitor now handles an already-aborted signal before registering its listener and before acquiring any polling, webhook, hosted-media, or HTTP-route resource. No SDK, dependency, configuration, or unrelated plugin behavior changes.

The original contributor fork could not accept the required current-main refresh because the repository-native publisher correctly rejects an unsigned merge and its signed GraphQL fallback cannot preserve merge ancestry. This official, GitHub-signed, expected-head-guarded reconstruction retains the original production fix and regression tests byte-for-byte and includes the contributor's actual `Co-authored-by` trailer.

## User Impact

Zalo polling and webhook accounts now stop immediately and cleanly when gateway shutdown wins the startup race. Already-running accounts retain their existing abort and cleanup behavior.

## Evidence

- Reproduced the real configured-gateway failure on current-main baseline `f466ad0e71b73b3dbb8cce2a29631edd088ee6a7`: both polling and webhook integration cases failed as expected while 26 adjacent controls passed.
- Original @LZY3538 head `14a96a5713d880830ea82a9cfb3ae140b1a44639`: all 123 Zalo tests in 20 files passed on remote Blacksmith.
- Verified each of the three published official blobs is identical to the independently reviewed original-contributor-preserving fix.
- Exact GitHub-signed official head `c0e050bbf275202a3a9eeca86cb9084e33ad7a1b`:
  `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/zalo/src/channel.pre-aborted.integration.test.ts extensions/zalo/src/monitor.lifecycle.test.ts extensions/zalo/src/channel.startup.test.ts`: 3 files, 10 tests passed.
- The integration runs the actual configured Zalo gateway against a real loopback TCP/HTTP server using the production API client; it mocks neither `fetch`, the account monitor, the abort signal, nor the plugin route registry. In both modes only the legitimate `getMe` account probe occurs and zero HTTP routes remain.
- Exact-head Codex `gpt-5.6-sol` autoreview at `xhigh`: clean, no findings, 0.97 correctness; TruffleHog clean.
- `git diff --check`: passed. Current repaired main and workflow sanity fixes are ancestors.
- AI-assisted maintainer reconstruction; original source and contributor credit are preserved in the commit.