### PR TITLE
feat(ui): first-class chat audio/video player cards

### DIFF
--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -399,12 +399,12 @@ describe("run-oxlint", () => {
           shard: { name: "timeout-group-test", args: [] },
         });
 
-        await waitFor(() => existsSync(childPidPath), 2_000);
+        await waitFor(() => existsSync(childPidPath), 15_000);
         childPid = Number(readFileSync(childPidPath, "utf8"));
         expect(isProcessAlive(childPid)).toBe(true);
 
         await expect(command).resolves.toBe(124);
-        await waitFor(() => !isProcessAlive(childPid), 2_000);
+        await waitFor(() => !isProcessAlive(childPid), 15_000);
       } finally {
         if (childPid && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");

--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -155,7 +155,10 @@ suite.define(() => {
           kind === "image"
             ? page.getByAltText("Local bootstrap image")
             : page.locator(".chat-assistant-attachment-card audio");
-        await media.waitFor({ state: "visible", timeout: 10_000 });
+        await media.waitFor({
+          state: kind === "image" ? "visible" : "attached",
+          timeout: 10_000,
+        });
         await expect.poll(() => requestedMediaUrls.length, { timeout: 10_000 }).toBe(2);
         expect(requestedMediaUrls[0]?.searchParams.get("meta")).toBe("1");
         expect(requestedMediaUrls[1]?.searchParams.get("mediaTicket")).toBe(ticket);

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4814,6 +4814,13 @@ export const en: TranslationMap = {
       duplicatesCollapsed: "{count} consecutive identical messages collapsed",
       contextFor: "Message context for {timestamp}",
     },
+    mediaPlayer: {
+      play: "Play",
+      pause: "Pause",
+      seek: "Seek media",
+      download: "Download {filename}",
+      videoUnavailable: "Can't play this format — download instead.",
+    },
     modelControls: {
       current: "Current",
       default: "Default",

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -119,6 +119,8 @@ export type MessageContentItem =
         label: string;
         mimeType?: string;
         isVoiceNote?: boolean;
+        width?: number;
+        height?: number;
       };
     }
   | {

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -538,6 +538,8 @@ describe("message-normalizer", () => {
               kind: "image",
               label: "test image.png",
               mimeType: "image/png",
+              width: 1280,
+              height: 720,
             },
           },
         ],
@@ -551,6 +553,8 @@ describe("message-normalizer", () => {
             kind: "image",
             label: "test image.png",
             mimeType: "image/png",
+            width: 1280,
+            height: 720,
           },
         },
       ]);

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -464,6 +464,8 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
           label?: unknown;
           mimeType?: unknown;
           isVoiceNote?: unknown;
+          width?: unknown;
+          height?: unknown;
         };
         if (
           typeof attachment.url !== "string" ||
@@ -484,6 +486,12 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
               label: attachment.label,
               ...(typeof attachment.mimeType === "string" ? { mimeType: attachment.mimeType } : {}),
               ...(attachment.isVoiceNote === true ? { isVoiceNote: true } : {}),
+              ...(typeof attachment.width === "number" && attachment.width > 0
+                ? { width: attachment.width }
+                : {}),
+              ...(typeof attachment.height === "number" && attachment.height > 0
+                ? { height: attachment.height }
+                : {}),
             },
           },
         ];

--- a/ui/src/lib/media-file-extension.ts
+++ b/ui/src/lib/media-file-extension.ts
@@ -27,3 +27,10 @@ export function getMediaFileExtension(value: string): string | undefined {
   }
   return /\.([a-zA-Z0-9]+)$/.exec(filename)?.[1]?.toLowerCase();
 }
+
+const VIDEO_MEDIA_FILE_EXTENSIONS = new Set(["m4v", "mkv", "mov", "mp4", "webm"]);
+
+export function hasVideoMediaFileExtension(value: string): boolean {
+  const extension = getMediaFileExtension(value);
+  return extension !== undefined && VIDEO_MEDIA_FILE_EXTENSIONS.has(extension);
+}

--- a/ui/src/lib/media-file-extension.ts
+++ b/ui/src/lib/media-file-extension.ts
@@ -28,7 +28,16 @@ export function getMediaFileExtension(value: string): string | undefined {
   return /\.([a-zA-Z0-9]+)$/.exec(filename)?.[1]?.toLowerCase();
 }
 
-const VIDEO_MEDIA_FILE_EXTENSIONS = new Set(["m4v", "mkv", "mov", "mp4", "webm"]);
+const VIDEO_MEDIA_FILE_EXTENSIONS = new Set([
+  "avi",
+  "m4v",
+  "mkv",
+  "mov",
+  "mp4",
+  "mpeg",
+  "mpg",
+  "webm",
+]);
 
 export function hasVideoMediaFileExtension(value: string): boolean {
   const extension = getMediaFileExtension(value);

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1104,9 +1104,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         const image = page.locator("img.chat-message-image");
         const video = page.locator("video");
         // First wait absorbs the cold-app render; both elements land in the same
-        // history render pass, so the video follows immediately after.
+        // history render pass. Video stays behind its placeholder until metadata loads.
         await image.waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
-        await video.waitFor({ timeout: 10_000 });
+        await video.waitFor({ state: "attached", timeout: 10_000 });
         expect(await image.getAttribute("src")).toBe(imageUrl);
         expect(await video.getAttribute("src")).toBe(videoUrl);
       } finally {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -4217,7 +4217,7 @@ describe("chat attachment picker", () => {
     expect(container.querySelector('button[aria-label="Send message"]')).not.toBeNull();
   });
 
-  it("accepts and previews non-video file attachments", async () => {
+  it("accepts and previews file attachments", async () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({ onAttachmentsChange });
     const input = container.querySelector<HTMLInputElement>(".agent-chat__file-input");
@@ -4247,20 +4247,32 @@ describe("chat attachment picker", () => {
     expect(preview.querySelector(".chat-attachment-file__name")?.textContent).toBe("brief.pdf");
   });
 
-  it("filters video file attachments", () => {
+  it("accepts video file attachments with the generic file preview", async () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({ onAttachmentsChange });
     const input = container.querySelector<HTMLInputElement>(".agent-chat__file-input");
     const file = new File(["video"], "clip.mp4", { type: "video/mp4" });
 
     expect(input).toBeInstanceOf(HTMLInputElement);
+    expect(input?.accept).toContain("video/*");
     Object.defineProperty(input!, "files", {
       configurable: true,
       value: [file],
     });
     input!.dispatchEvent(new Event("change", { bubbles: true }));
 
-    expect(onAttachmentsChange).not.toHaveBeenCalled();
+    await waitForFast(() => {
+      const attachments = requireFirstAttachmentsChange(onAttachmentsChange);
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0]?.fileName).toBe("clip.mp4");
+      expect(attachments[0]?.mimeType).toBe("video/mp4");
+      expect(attachments[0]?.sizeBytes).toBe(file.size);
+    });
+
+    const nextAttachments = requireFirstAttachmentsChange(onAttachmentsChange);
+    const preview = renderChatView({ attachments: nextAttachments });
+    expect(preview.querySelectorAll(".chat-attachment-thumb--file")).toHaveLength(1);
+    expect(preview.querySelector(".chat-attachment-file__name")?.textContent).toBe("clip.mp4");
   });
 });
 

--- a/ui/src/pages/chat/components/chat-attachment-href.test.ts
+++ b/ui/src/pages/chat/components/chat-attachment-href.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { safeAttachmentHref } from "./chat-attachment-href.ts";
+
+describe("safeAttachmentHref", () => {
+  it.each([
+    "https://cdn.example/audio.mp3",
+    "HtTp://cdn.example/video.mp4",
+    "blob:https://control.example/15ed4f80-4fb5-4ca6-a6e6-3c9a8943a003",
+    "/downloads/report.pdf",
+    "/__openclaw__/assistant-media?source=report.pdf",
+    "/media/inbound/attachment",
+    "/api/chat/media/outgoing/main/document/full",
+  ])("allows a safe attachment href: %s", (href) => {
+    expect(safeAttachmentHref(`  ${href}  `)).toBe(href);
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "JaVaScRiPt:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "//attacker.example/file.mp3",
+    "relative/file.mp3",
+    "",
+  ])("rejects an unsafe attachment href: %s", (href) => {
+    expect(safeAttachmentHref(href)).toBeUndefined();
+  });
+});

--- a/ui/src/pages/chat/components/chat-attachment-href.ts
+++ b/ui/src/pages/chat/components/chat-attachment-href.ts
@@ -1,0 +1,17 @@
+const SAFE_ATTACHMENT_PROTOCOLS = new Set(["http:", "https:", "blob:"]);
+
+/** Returns only attachment links that are safe to expose as clickable anchors. */
+export function safeAttachmentHref(value: string): string | undefined {
+  const href = value.trim();
+  if (!href) {
+    return undefined;
+  }
+  if (href.startsWith("/") && !href.startsWith("//") && !href.startsWith("/\\")) {
+    return href;
+  }
+  try {
+    return SAFE_ATTACHMENT_PROTOCOLS.has(new URL(href).protocol.toLowerCase()) ? href : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -15,7 +15,7 @@ import {
 } from "../attachment-payload-store.ts";
 
 const CHAT_ATTACHMENT_ACCEPT =
-  "image/*,audio/*,application/pdf,text/*,.csv,.json,.md,.txt,.zip," +
+  "image/*,audio/*,video/*,application/pdf,text/*,.csv,.json,.md,.txt,.zip," +
   ".doc,.docx,.xls,.xlsx,.ppt,.pptx";
 const LARGE_PASTE_TEXT_THRESHOLD = 1000;
 const LARGE_PASTE_TEXT_MIME_TYPE = "text/plain";
@@ -98,13 +98,6 @@ export function isEditableDropTarget(event: DragEvent): boolean {
 
 function currentAttachments(props: ChatAttachmentControlsProps): ChatAttachment[] {
   return props.getAttachments?.() ?? props.attachments ?? [];
-}
-
-function isSupportedChatAttachmentFile(file: Pick<File, "name" | "type">): boolean {
-  if (file.type.startsWith("video/")) {
-    return false;
-  }
-  return !/\.(?:avi|m4v|mov|mp4|mpeg|mpg|webm)$/i.test(file.name);
 }
 
 function clickComposerInput(target: HTMLElement, selector: string) {
@@ -229,9 +222,6 @@ function dataImageClipboardFile(
   if (!mimeType || !base64Source) {
     return null;
   }
-  if (!isSupportedChatAttachmentFile({ name: baseName, type: mimeType })) {
-    return null;
-  }
   const base64 = base64Source.replace(/\s+/g, "");
   try {
     const binary = atob(base64);
@@ -299,14 +289,13 @@ function readAttachmentFile(
 }
 
 async function appendAttachmentFiles(files: readonly File[], props: ChatAttachmentControlsProps) {
-  const supported = files.filter(isSupportedChatAttachmentFile);
-  if (!props.onAttachmentsChange || supported.length === 0) {
+  if (!props.onAttachmentsChange || files.length === 0) {
     return;
   }
   props.onPendingReadsChange?.(1);
   try {
     const additions = (
-      await Promise.all(supported.map((file) => readAttachmentFile(file, props)))
+      await Promise.all(files.map((file) => readAttachmentFile(file, props)))
     ).filter((attachment): attachment is ChatAttachment => attachment !== null);
     if (props.readSignal?.aborted) {
       for (const attachment of additions) {

--- a/ui/src/pages/chat/components/chat-audio-coordinator.ts
+++ b/ui/src/pages/chat/components/chat-audio-coordinator.ts
@@ -1,0 +1,16 @@
+let activeAudio: HTMLMediaElement | null = null;
+
+/** Claims the page's audio slot and pauses any previously playing chat audio. */
+export function claimChatAudioPlayback(media: HTMLMediaElement): void {
+  if (activeAudio === media) {
+    return;
+  }
+  activeAudio?.pause();
+  activeAudio = media;
+}
+
+export function releaseChatAudioPlayback(media: HTMLMediaElement): void {
+  if (activeAudio === media) {
+    activeAudio = null;
+  }
+}

--- a/ui/src/pages/chat/components/chat-audio-coordinator.ts
+++ b/ui/src/pages/chat/components/chat-audio-coordinator.ts
@@ -1,16 +1,27 @@
-let activeAudio: HTMLMediaElement | null = null;
+type ActiveChatAudio = {
+  media: HTMLMediaElement;
+  onSuperseded: () => void;
+};
+
+let activeAudio: ActiveChatAudio | null = null;
 
 /** Claims the page's audio slot and pauses any previously playing chat audio. */
-export function claimChatAudioPlayback(media: HTMLMediaElement): void {
-  if (activeAudio === media) {
+export function claimChatAudioPlayback(media: HTMLMediaElement, onSuperseded: () => void): void {
+  if (activeAudio?.media === media) {
+    activeAudio.onSuperseded = onSuperseded;
     return;
   }
-  activeAudio?.pause();
-  activeAudio = media;
+  activeAudio?.onSuperseded();
+  activeAudio?.media.pause();
+  activeAudio = { media, onSuperseded };
 }
 
 export function releaseChatAudioPlayback(media: HTMLMediaElement): void {
-  if (activeAudio === media) {
+  if (activeAudio?.media === media) {
     activeAudio = null;
   }
+}
+
+export function canResumeChatAudioPlayback(media: HTMLMediaElement): boolean {
+  return activeAudio === null || activeAudio.media === media;
 }

--- a/ui/src/pages/chat/components/chat-audio-player.test.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.test.ts
@@ -136,4 +136,53 @@ describe("ChatAudioPlayer", () => {
     second.querySelector("audio")!.dispatchEvent(new Event("play"));
     expect(pauseFirst).not.toHaveBeenCalled();
   });
+
+  it("does not auto-resume a refreshed source after disconnecting before metadata", async () => {
+    const player = await createPlayer("disconnect-resume");
+    const media = player.querySelector("audio")!;
+    let paused = false;
+    Object.defineProperty(media, "paused", { configurable: true, get: () => paused });
+    setMediaNumber(media, "currentTime", 20);
+    setMediaNumber(media, "duration", 80);
+    const play = vi.spyOn(media, "play").mockResolvedValue(undefined);
+    vi.spyOn(media, "pause").mockImplementation(() => {
+      paused = true;
+    });
+
+    player.src = "https://example.com/disconnect-resume-fresh.mp3";
+    await player.updateComplete;
+    media.dispatchEvent(new Event("error"));
+    player.remove();
+    document.body.append(player);
+    media.currentTime = 0;
+    media.dispatchEvent(new Event("loadedmetadata"));
+
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-resume after another player supersedes the pending restore", async () => {
+    const first = await createPlayer("superseded-resume");
+    const firstMedia = first.querySelector("audio")!;
+    let paused = false;
+    Object.defineProperty(firstMedia, "paused", { configurable: true, get: () => paused });
+    setMediaNumber(firstMedia, "currentTime", 20);
+    setMediaNumber(firstMedia, "duration", 80);
+    const playFirst = vi.spyOn(firstMedia, "play").mockResolvedValue(undefined);
+    vi.spyOn(firstMedia, "pause").mockImplementation(() => {
+      paused = true;
+    });
+    firstMedia.dispatchEvent(new Event("play"));
+
+    first.src = "https://example.com/superseded-resume-fresh.mp3";
+    await first.updateComplete;
+    firstMedia.dispatchEvent(new Event("error"));
+
+    const second = await createPlayer("superseding-player");
+    second.querySelector("audio")!.dispatchEvent(new Event("play"));
+    second.remove();
+    firstMedia.currentTime = 0;
+    firstMedia.dispatchEvent(new Event("loadedmetadata"));
+
+    expect(playFirst).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/pages/chat/components/chat-audio-player.test.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.test.ts
@@ -1,0 +1,99 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatAudioPlayer, formatChatMediaTime } from "./chat-audio-player.ts";
+
+function setMediaNumber(
+  media: HTMLMediaElement,
+  property: "currentTime" | "duration",
+  value: number,
+) {
+  Object.defineProperty(media, property, { configurable: true, writable: true, value });
+}
+
+async function createPlayer(label: string): Promise<ChatAudioPlayer> {
+  const player = document.createElement("openclaw-chat-audio-player");
+  player.src = `https://example.com/${label}.mp3`;
+  player.sourceIdentity = `media://${label}`;
+  player.label = `${label}.mp3`;
+  document.body.append(player);
+  await player.updateComplete;
+  return player;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("ChatAudioPlayer", () => {
+  it("formats elapsed and total media time", () => {
+    expect(formatChatMediaTime(Number.NaN)).toBe("0:00");
+    expect(formatChatMediaTime(0)).toBe("0:00");
+    expect(formatChatMediaTime(65.9)).toBe("1:05");
+    expect(formatChatMediaTime(3_665)).toBe("61:05");
+  });
+
+  it("drives play, pause, seek, and keyboard state through the hidden audio element", async () => {
+    const player = await createPlayer("briefing");
+    const media = player.querySelector("audio")!;
+    let paused = true;
+    Object.defineProperty(media, "paused", { configurable: true, get: () => paused });
+    setMediaNumber(media, "duration", 125);
+    setMediaNumber(media, "currentTime", 0);
+    const play = vi.spyOn(media, "play").mockImplementation(async () => {
+      paused = false;
+      media.dispatchEvent(new Event("play"));
+    });
+    const pause = vi.spyOn(media, "pause").mockImplementation(() => {
+      paused = true;
+      media.dispatchEvent(new Event("pause"));
+    });
+
+    media.dispatchEvent(new Event("loadedmetadata"));
+    await player.updateComplete;
+    expect(player.querySelector(".chat-audio-player__time")?.textContent).toContain("2:05");
+
+    player.querySelector<HTMLButtonElement>(".chat-audio-player__toggle")!.click();
+    await player.updateComplete;
+    expect(play).toHaveBeenCalledOnce();
+    expect(player.querySelector(".chat-audio-player__toggle")?.getAttribute("aria-label")).toBe(
+      "Pause",
+    );
+
+    const seek = player.querySelector<HTMLInputElement>(".chat-audio-player__seek")!;
+    seek.value = "35";
+    seek.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(media.currentTime).toBe(35);
+
+    const controls = player.querySelector<HTMLElement>(".chat-audio-player")!;
+    controls.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(media.currentTime).toBe(40);
+    controls.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    expect(pause).toHaveBeenCalledOnce();
+  });
+
+  it("pauses the previous player when another chat audio starts", async () => {
+    const first = await createPlayer("first");
+    const second = await createPlayer("second");
+    const firstMedia = first.querySelector("audio")!;
+    const secondMedia = second.querySelector("audio")!;
+    const pauseFirst = vi.spyOn(firstMedia, "pause").mockImplementation(() => undefined);
+
+    firstMedia.dispatchEvent(new Event("play"));
+    secondMedia.dispatchEvent(new Event("play"));
+
+    expect(pauseFirst).toHaveBeenCalledOnce();
+  });
+
+  it("pauses active audio when its message leaves the page", async () => {
+    const player = await createPlayer("detached");
+    const media = player.querySelector("audio")!;
+    Object.defineProperty(media, "paused", { configurable: true, value: false });
+    const pause = vi.spyOn(media, "pause").mockImplementation(() => undefined);
+
+    player.remove();
+
+    expect(pause).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/pages/chat/components/chat-audio-player.test.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.test.ts
@@ -60,6 +60,11 @@ describe("ChatAudioPlayer", () => {
     expect(player.querySelector(".chat-audio-player__toggle")?.getAttribute("aria-label")).toBe(
       "Pause",
     );
+    expect(
+      player
+        .querySelector<HTMLAnchorElement>(".chat-assistant-attachment-card__download")
+        ?.getAttribute("download"),
+    ).toBe("briefing.mp3");
 
     const seek = player.querySelector<HTMLInputElement>(".chat-audio-player__seek")!;
     seek.value = "35";
@@ -95,5 +100,40 @@ describe("ChatAudioPlayer", () => {
     player.remove();
 
     expect(pause).toHaveBeenCalledOnce();
+  });
+
+  it("releases playback and shows the fallback after an unrecovered media error", async () => {
+    const first = await createPlayer("broken");
+    const firstMedia = first.querySelector("audio")!;
+    let paused = true;
+    Object.defineProperty(firstMedia, "paused", { configurable: true, get: () => paused });
+    const play = vi.spyOn(firstMedia, "play").mockImplementation(async () => {
+      paused = false;
+      firstMedia.dispatchEvent(new Event("play"));
+    });
+    const pauseFirst = vi.spyOn(firstMedia, "pause").mockImplementation(() => {
+      paused = true;
+    });
+
+    first.querySelector<HTMLButtonElement>(".chat-audio-player__toggle")!.click();
+    await first.updateComplete;
+    expect(play).toHaveBeenCalledOnce();
+    expect((first as unknown as { playing: boolean }).playing).toBe(true);
+
+    firstMedia.dispatchEvent(new Event("error"));
+    await first.updateComplete;
+    expect((first as unknown as { playing: boolean }).playing).toBe(false);
+    expect(first.querySelector(".chat-assistant-attachment-card__reason")?.textContent).toContain(
+      "Can't play this format — download instead.",
+    );
+    expect(
+      first
+        .querySelector<HTMLAnchorElement>(".chat-assistant-attachment-card__reason a")
+        ?.getAttribute("download"),
+    ).toBe("broken.mp3");
+
+    const second = await createPlayer("working");
+    second.querySelector("audio")!.dispatchEvent(new Event("play"));
+    expect(pauseFirst).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/pages/chat/components/chat-audio-player.test.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.test.ts
@@ -1,7 +1,9 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ChatAudioPlayer, formatChatMediaTime } from "./chat-audio-player.ts";
+import "./chat-audio-player.ts";
+
+type ChatAudioPlayer = HTMLElementTagNameMap["openclaw-chat-audio-player"];
 
 function setMediaNumber(
   media: HTMLMediaElement,
@@ -27,11 +29,25 @@ afterEach(() => {
 });
 
 describe("ChatAudioPlayer", () => {
-  it("formats elapsed and total media time", () => {
-    expect(formatChatMediaTime(Number.NaN)).toBe("0:00");
-    expect(formatChatMediaTime(0)).toBe("0:00");
-    expect(formatChatMediaTime(65.9)).toBe("1:05");
-    expect(formatChatMediaTime(3_665)).toBe("61:05");
+  it("formats elapsed and total media time", async () => {
+    const player = await createPlayer("timing");
+    expect(
+      Array.from(player.querySelectorAll(".chat-audio-player__time span"), (item) =>
+        item.textContent?.trim(),
+      ),
+    ).toEqual(["0:00", "0:00"]);
+
+    const media = player.querySelector("audio")!;
+    setMediaNumber(media, "currentTime", 65.9);
+    setMediaNumber(media, "duration", 3_665);
+    media.dispatchEvent(new Event("loadedmetadata"));
+    await player.updateComplete;
+
+    expect(
+      Array.from(player.querySelectorAll(".chat-audio-player__time span"), (item) =>
+        item.textContent?.trim(),
+      ),
+    ).toEqual(["1:05", "61:05"]);
   });
 
   it("drives play, pause, seek, and keyboard state through the hidden audio element", async () => {

--- a/ui/src/pages/chat/components/chat-audio-player.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.ts
@@ -15,7 +15,7 @@ import { ChatMediaSourceController } from "./chat-media-source.ts";
 
 const SEEK_STEP_SECONDS = 5;
 
-export function formatChatMediaTime(seconds: number): string {
+function formatChatMediaTime(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds < 0) {
     return "0:00";
   }
@@ -25,7 +25,7 @@ export function formatChatMediaTime(seconds: number): string {
   return `${minutes}:${String(remainder).padStart(2, "0")}`;
 }
 
-export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
+class ChatAudioPlayer extends OpenClawLightDomContentsElement {
   @property() src = "";
   @property() sourceIdentity = "";
   @property() label = "";
@@ -134,15 +134,15 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
               ? html`<!-- The download attribute is ignored for cross-origin URLs (rare here — attachment
                   hrefs are same-origin gateway routes); those open in a new tab instead. -->
                   <a
-                  class="chat-assistant-attachment-card__download"
-                  href=${downloadHref}
-                  download=${this.label}
-                  target="_blank"
-                  rel="noreferrer"
-                  aria-label=${t("chat.mediaPlayer.download", { filename: this.label })}
-                  title=${t("chat.mediaPlayer.download", { filename: this.label })}
-                  >${icons.download}</a
-                >`
+                    class="chat-assistant-attachment-card__download"
+                    href=${downloadHref}
+                    download=${this.label}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label=${t("chat.mediaPlayer.download", { filename: this.label })}
+                    title=${t("chat.mediaPlayer.download", { filename: this.label })}
+                    >${icons.download}</a
+                  >`
               : null}
           </span>
         </div>

--- a/ui/src/pages/chat/components/chat-audio-player.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.ts
@@ -6,7 +6,11 @@ import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomContentsElement } from "../../../lit/openclaw-element.ts";
 import { safeAttachmentHref } from "./chat-attachment-href.ts";
-import { claimChatAudioPlayback, releaseChatAudioPlayback } from "./chat-audio-coordinator.ts";
+import {
+  canResumeChatAudioPlayback,
+  claimChatAudioPlayback,
+  releaseChatAudioPlayback,
+} from "./chat-audio-coordinator.ts";
 import { ChatMediaSourceController } from "./chat-media-source.ts";
 
 const SEEK_STEP_SECONDS = 5;
@@ -36,9 +40,11 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
 
   private media: HTMLAudioElement | null = null;
   private readonly sourceController = new ChatMediaSourceController();
+  private readonly cancelPendingResume = () => this.sourceController.cancelPendingResume();
 
   override disconnectedCallback(): void {
     if (this.media) {
+      this.sourceController.cancelPendingResume();
       if (!this.media.paused) {
         this.media.pause();
       }
@@ -66,7 +72,7 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
       return;
     }
     if (media.paused) {
-      claimChatAudioPlayback(media);
+      claimChatAudioPlayback(media, this.cancelPendingResume);
       void media.play().catch(() => {
         releaseChatAudioPlayback(media);
         this.playing = false;
@@ -195,7 +201,9 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
             if (!this.media) {
               return;
             }
-            this.sourceController.handleLoadedMetadata(this.media);
+            this.sourceController.handleLoadedMetadata(this.media, () =>
+              canResumeChatAudioPlayback(this.media!),
+            );
             this.duration = Number.isFinite(this.media.duration) ? this.media.duration : 0;
             this.currentTime = this.media.currentTime;
             this.failed = false;
@@ -216,7 +224,7 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
           @progress=${() => this.updateBuffered()}
           @play=${() => {
             if (this.media) {
-              claimChatAudioPlayback(this.media);
+              claimChatAudioPlayback(this.media, this.cancelPendingResume);
             }
             this.playing = true;
           }}

--- a/ui/src/pages/chat/components/chat-audio-player.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.ts
@@ -1,0 +1,228 @@
+import { html } from "lit";
+import { property, state } from "lit/decorators.js";
+import { ref } from "lit/directives/ref.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { icons } from "../../../components/icons.ts";
+import { t } from "../../../i18n/index.ts";
+import { OpenClawLightDomContentsElement } from "../../../lit/openclaw-element.ts";
+import { claimChatAudioPlayback, releaseChatAudioPlayback } from "./chat-audio-coordinator.ts";
+import { ChatMediaSourceController } from "./chat-media-source.ts";
+
+const SEEK_STEP_SECONDS = 5;
+
+export function formatChatMediaTime(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return "0:00";
+  }
+  const wholeSeconds = Math.floor(seconds);
+  const minutes = Math.floor(wholeSeconds / 60);
+  const remainder = wholeSeconds % 60;
+  return `${minutes}:${String(remainder).padStart(2, "0")}`;
+}
+
+export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
+  @property() src = "";
+  @property() sourceIdentity = "";
+  @property() label = "";
+  @property({ type: Boolean }) voiceNote = false;
+  @property({ attribute: false }) onMediaLoaded: (() => void) | undefined;
+
+  @state() private currentTime = 0;
+  @state() private duration = 0;
+  @state() private buffered = 0;
+  @state() private playing = false;
+
+  private media: HTMLAudioElement | null = null;
+  private readonly sourceController = new ChatMediaSourceController();
+
+  override disconnectedCallback(): void {
+    if (this.media) {
+      if (!this.media.paused) {
+        this.media.pause();
+      }
+      releaseChatAudioPlayback(this.media);
+    }
+    super.disconnectedCallback();
+  }
+
+  override updated(): void {
+    if (this.media) {
+      this.sourceController.updateSource(this.media, this.src, this.sourceIdentity);
+    }
+  }
+
+  private setMedia = (element: Element | undefined) => {
+    this.media = element instanceof HTMLAudioElement ? element : null;
+  };
+
+  private togglePlayback(): void {
+    const media = this.media;
+    if (!media) {
+      return;
+    }
+    if (media.paused) {
+      claimChatAudioPlayback(media);
+      void media.play().catch(() => {
+        releaseChatAudioPlayback(media);
+        this.playing = false;
+      });
+    } else {
+      media.pause();
+    }
+  }
+
+  private seekTo(nextTime: number): void {
+    const media = this.media;
+    if (!media) {
+      return;
+    }
+    if (this.sourceController.seek(media, Math.min(nextTime, this.duration || nextTime))) {
+      this.currentTime = media.currentTime;
+    }
+  }
+
+  private handlePlayerKeydown(event: KeyboardEvent): void {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    if (event.key === " ") {
+      event.preventDefault();
+      this.togglePlayback();
+      return;
+    }
+    if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+      event.preventDefault();
+      const direction = event.key === "ArrowLeft" ? -1 : 1;
+      this.seekTo(this.currentTime + direction * SEEK_STEP_SECONDS);
+    }
+  }
+
+  private updateBuffered(): void {
+    const media = this.media;
+    if (!media || !this.duration || media.buffered.length === 0) {
+      this.buffered = 0;
+      return;
+    }
+    this.buffered = Math.min(1, media.buffered.end(media.buffered.length - 1) / this.duration);
+  }
+
+  override render() {
+    const progress = this.duration > 0 ? Math.min(1, this.currentTime / this.duration) : 0;
+    return html`
+      <div class="chat-assistant-attachment-card chat-assistant-attachment-card--audio">
+        <div class="chat-assistant-attachment-card__header">
+          <span class="chat-assistant-attachment-card__title">${this.label}</span>
+          <span class="chat-assistant-attachment-card__actions">
+            ${this.voiceNote
+              ? html`<span class="chat-assistant-attachment-badge"
+                  >${t("chat.messages.voiceNote")}</span
+                >`
+              : null}
+            <a
+              class="chat-assistant-attachment-card__download"
+              href=${this.src}
+              target="_blank"
+              rel="noreferrer"
+              aria-label=${t("chat.mediaPlayer.download", { filename: this.label })}
+              title=${t("chat.mediaPlayer.download", { filename: this.label })}
+              >${icons.download}</a
+            >
+          </span>
+        </div>
+        <div
+          class="chat-audio-player"
+          tabindex="0"
+          @keydown=${(event: KeyboardEvent) => this.handlePlayerKeydown(event)}
+        >
+          <button
+            type="button"
+            class="chat-audio-player__toggle"
+            aria-label=${t(this.playing ? "chat.mediaPlayer.pause" : "chat.mediaPlayer.play")}
+            @click=${() => this.togglePlayback()}
+          >
+            ${this.playing ? icons.pause : icons.play}
+          </button>
+          <div class="chat-audio-player__timeline">
+            <input
+              class="chat-audio-player__seek"
+              type="range"
+              min="0"
+              max=${String(this.duration || 0)}
+              step=${String(SEEK_STEP_SECONDS)}
+              .value=${String(Math.min(this.currentTime, this.duration || this.currentTime))}
+              aria-label=${t("chat.mediaPlayer.seek")}
+              style=${styleMap({
+                "--chat-audio-progress": `${progress * 100}%`,
+                "--chat-audio-buffered": `${Math.max(progress, this.buffered) * 100}%`,
+              })}
+              @input=${(event: Event) =>
+                this.seekTo(Number((event.currentTarget as HTMLInputElement).value))}
+            />
+            <div class="chat-audio-player__time" aria-live="off">
+              <span>${formatChatMediaTime(this.currentTime)}</span>
+              <span>${formatChatMediaTime(this.duration)}</span>
+            </div>
+          </div>
+        </div>
+        <audio
+          class="chat-audio-player__media"
+          preload="metadata"
+          ${ref(this.setMedia)}
+          @loadedmetadata=${() => {
+            if (!this.media) {
+              return;
+            }
+            this.sourceController.handleLoadedMetadata(this.media);
+            this.duration = Number.isFinite(this.media.duration) ? this.media.duration : 0;
+            this.currentTime = this.media.currentTime;
+            this.updateBuffered();
+            this.onMediaLoaded?.();
+          }}
+          @durationchange=${() => {
+            if (this.media) {
+              this.duration = Number.isFinite(this.media.duration) ? this.media.duration : 0;
+            }
+          }}
+          @timeupdate=${() => {
+            if (this.media) {
+              this.currentTime = this.media.currentTime;
+              this.updateBuffered();
+            }
+          }}
+          @progress=${() => this.updateBuffered()}
+          @play=${() => {
+            if (this.media) {
+              claimChatAudioPlayback(this.media);
+            }
+            this.playing = true;
+          }}
+          @pause=${() => {
+            this.playing = false;
+          }}
+          @ended=${() => {
+            if (this.media) {
+              releaseChatAudioPlayback(this.media);
+              this.sourceController.handleEnded(this.media);
+            }
+            this.playing = false;
+          }}
+          @error=${() => {
+            if (this.media) {
+              this.sourceController.handleError(this.media);
+            }
+          }}
+        ></audio>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get("openclaw-chat-audio-player")) {
+  customElements.define("openclaw-chat-audio-player", ChatAudioPlayer);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "openclaw-chat-audio-player": ChatAudioPlayer;
+  }
+}

--- a/ui/src/pages/chat/components/chat-audio-player.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.ts
@@ -131,7 +131,9 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
                 >`
               : null}
             ${downloadHref && !this.failed
-              ? html`<a
+              ? html`<!-- The download attribute is ignored for cross-origin URLs (rare here — attachment
+                  hrefs are same-origin gateway routes); those open in a new tab instead. -->
+                  <a
                   class="chat-assistant-attachment-card__download"
                   href=${downloadHref}
                   download=${this.label}

--- a/ui/src/pages/chat/components/chat-audio-player.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.ts
@@ -5,6 +5,7 @@ import { styleMap } from "lit/directives/style-map.js";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomContentsElement } from "../../../lit/openclaw-element.ts";
+import { safeAttachmentHref } from "./chat-attachment-href.ts";
 import { claimChatAudioPlayback, releaseChatAudioPlayback } from "./chat-audio-coordinator.ts";
 import { ChatMediaSourceController } from "./chat-media-source.ts";
 
@@ -108,6 +109,7 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
 
   override render() {
     const progress = this.duration > 0 ? Math.min(1, this.currentTime / this.duration) : 0;
+    const downloadHref = safeAttachmentHref(this.src);
     return html`
       <div class="chat-assistant-attachment-card chat-assistant-attachment-card--audio">
         <div class="chat-assistant-attachment-card__header">
@@ -118,15 +120,17 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
                   >${t("chat.messages.voiceNote")}</span
                 >`
               : null}
-            <a
-              class="chat-assistant-attachment-card__download"
-              href=${this.src}
-              target="_blank"
-              rel="noreferrer"
-              aria-label=${t("chat.mediaPlayer.download", { filename: this.label })}
-              title=${t("chat.mediaPlayer.download", { filename: this.label })}
-              >${icons.download}</a
-            >
+            ${downloadHref
+              ? html`<a
+                  class="chat-assistant-attachment-card__download"
+                  href=${downloadHref}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label=${t("chat.mediaPlayer.download", { filename: this.label })}
+                  title=${t("chat.mediaPlayer.download", { filename: this.label })}
+                  >${icons.download}</a
+                >`
+              : null}
           </span>
         </div>
         <div

--- a/ui/src/pages/chat/components/chat-audio-player.ts
+++ b/ui/src/pages/chat/components/chat-audio-player.ts
@@ -1,4 +1,4 @@
-import { html } from "lit";
+import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ref } from "lit/directives/ref.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -32,6 +32,7 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
   @state() private duration = 0;
   @state() private buffered = 0;
   @state() private playing = false;
+  @state() private failed = false;
 
   private media: HTMLAudioElement | null = null;
   private readonly sourceController = new ChatMediaSourceController();
@@ -46,7 +47,10 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
     super.disconnectedCallback();
   }
 
-  override updated(): void {
+  override updated(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has("src")) {
+      this.failed = false;
+    }
     if (this.media) {
       this.sourceController.updateSource(this.media, this.src, this.sourceIdentity);
     }
@@ -120,10 +124,11 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
                   >${t("chat.messages.voiceNote")}</span
                 >`
               : null}
-            ${downloadHref
+            ${downloadHref && !this.failed
               ? html`<a
                   class="chat-assistant-attachment-card__download"
                   href=${downloadHref}
+                  download=${this.label}
                   target="_blank"
                   rel="noreferrer"
                   aria-label=${t("chat.mediaPlayer.download", { filename: this.label })}
@@ -133,41 +138,55 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
               : null}
           </span>
         </div>
-        <div
-          class="chat-audio-player"
-          tabindex="0"
-          @keydown=${(event: KeyboardEvent) => this.handlePlayerKeydown(event)}
-        >
-          <button
-            type="button"
-            class="chat-audio-player__toggle"
-            aria-label=${t(this.playing ? "chat.mediaPlayer.pause" : "chat.mediaPlayer.play")}
-            @click=${() => this.togglePlayback()}
-          >
-            ${this.playing ? icons.pause : icons.play}
-          </button>
-          <div class="chat-audio-player__timeline">
-            <input
-              class="chat-audio-player__seek"
-              type="range"
-              min="0"
-              max=${String(this.duration || 0)}
-              step=${String(SEEK_STEP_SECONDS)}
-              .value=${String(Math.min(this.currentTime, this.duration || this.currentTime))}
-              aria-label=${t("chat.mediaPlayer.seek")}
-              style=${styleMap({
-                "--chat-audio-progress": `${progress * 100}%`,
-                "--chat-audio-buffered": `${Math.max(progress, this.buffered) * 100}%`,
-              })}
-              @input=${(event: Event) =>
-                this.seekTo(Number((event.currentTarget as HTMLInputElement).value))}
-            />
-            <div class="chat-audio-player__time" aria-live="off">
-              <span>${formatChatMediaTime(this.currentTime)}</span>
-              <span>${formatChatMediaTime(this.duration)}</span>
-            </div>
-          </div>
-        </div>
+        ${this.failed
+          ? html`<div class="chat-assistant-attachment-card__reason">
+              ${t("chat.mediaPlayer.videoUnavailable")}
+              ${downloadHref
+                ? html`<a
+                    class="chat-assistant-attachment-card__link"
+                    href=${downloadHref}
+                    download=${this.label}
+                    target="_blank"
+                    rel="noreferrer"
+                    >${t("chat.mediaPlayer.download", { filename: this.label })}</a
+                  >`
+                : null}
+            </div> `
+          : html`<div
+              class="chat-audio-player"
+              tabindex="0"
+              @keydown=${(event: KeyboardEvent) => this.handlePlayerKeydown(event)}
+            >
+              <button
+                type="button"
+                class="chat-audio-player__toggle"
+                aria-label=${t(this.playing ? "chat.mediaPlayer.pause" : "chat.mediaPlayer.play")}
+                @click=${() => this.togglePlayback()}
+              >
+                ${this.playing ? icons.pause : icons.play}
+              </button>
+              <div class="chat-audio-player__timeline">
+                <input
+                  class="chat-audio-player__seek"
+                  type="range"
+                  min="0"
+                  max=${String(this.duration || 0)}
+                  step=${String(SEEK_STEP_SECONDS)}
+                  .value=${String(Math.min(this.currentTime, this.duration || this.currentTime))}
+                  aria-label=${t("chat.mediaPlayer.seek")}
+                  style=${styleMap({
+                    "--chat-audio-progress": `${progress * 100}%`,
+                    "--chat-audio-buffered": `${Math.max(progress, this.buffered) * 100}%`,
+                  })}
+                  @input=${(event: Event) =>
+                    this.seekTo(Number((event.currentTarget as HTMLInputElement).value))}
+                />
+                <div class="chat-audio-player__time" aria-live="off">
+                  <span>${formatChatMediaTime(this.currentTime)}</span>
+                  <span>${formatChatMediaTime(this.duration)}</span>
+                </div>
+              </div>
+            </div>`}
         <audio
           class="chat-audio-player__media"
           preload="metadata"
@@ -179,6 +198,7 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
             this.sourceController.handleLoadedMetadata(this.media);
             this.duration = Number.isFinite(this.media.duration) ? this.media.duration : 0;
             this.currentTime = this.media.currentTime;
+            this.failed = false;
             this.updateBuffered();
             this.onMediaLoaded?.();
           }}
@@ -211,8 +231,10 @@ export class ChatAudioPlayer extends OpenClawLightDomContentsElement {
             this.playing = false;
           }}
           @error=${() => {
-            if (this.media) {
-              this.sourceController.handleError(this.media);
+            if (this.media && !this.sourceController.handleError(this.media)) {
+              releaseChatAudioPlayback(this.media);
+              this.playing = false;
+              this.failed = true;
             }
           }}
         ></audio>

--- a/ui/src/pages/chat/components/chat-media-source.test.ts
+++ b/ui/src/pages/chat/components/chat-media-source.test.ts
@@ -71,6 +71,7 @@ describe("ChatMediaSourceController", () => {
 
   it("preserves playing state when a failed seek applies the fresh ticket", async () => {
     const media = document.createElement("video");
+    document.body.append(media);
     const state = { currentTime: 10, duration: 90, paused: false };
     const clock = mockMediaState(media, state);
     const play = vi.spyOn(media, "play").mockResolvedValue(undefined);
@@ -87,6 +88,7 @@ describe("ChatMediaSourceController", () => {
 
     expect(clock.currentTime()).toBe(55);
     expect(play).toHaveBeenCalledOnce();
+    media.remove();
   });
 
   it("applies a queued ticket once playback is idle at the end", () => {

--- a/ui/src/pages/chat/components/chat-media-source.test.ts
+++ b/ui/src/pages/chat/components/chat-media-source.test.ts
@@ -1,0 +1,142 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import { ChatMediaSourceController } from "./chat-media-source.ts";
+
+function mockMediaState(
+  media: HTMLMediaElement,
+  state: { currentTime: number; duration: number; paused: boolean; ended?: boolean },
+) {
+  let currentTime = state.currentTime;
+  Object.defineProperties(media, {
+    currentTime: {
+      configurable: true,
+      get: () => currentTime,
+      set: (value: number) => {
+        currentTime = value;
+      },
+    },
+    duration: { configurable: true, get: () => state.duration },
+    paused: { configurable: true, get: () => state.paused },
+    ended: { configurable: true, get: () => state.ended === true },
+  });
+  return {
+    currentTime: () => currentTime,
+    rejectSeek: () => {
+      Object.defineProperty(media, "currentTime", {
+        configurable: true,
+        get: () => currentTime,
+        set: () => {
+          throw new DOMException("media range unavailable", "InvalidStateError");
+        },
+      });
+    },
+    allowSeek: () => {
+      Object.defineProperty(media, "currentTime", {
+        configurable: true,
+        get: () => currentTime,
+        set: (value: number) => {
+          currentTime = value;
+        },
+      });
+    },
+  };
+}
+
+describe("ChatMediaSourceController", () => {
+  it("queues a refreshed ticket while paused mid-stream and restores it after failure", async () => {
+    const media = document.createElement("audio");
+    const state = { currentTime: 0, duration: 120, paused: true };
+    const clock = mockMediaState(media, state);
+    const play = vi.spyOn(media, "play").mockResolvedValue(undefined);
+    const controller = new ChatMediaSourceController();
+
+    controller.updateSource(media, "/media?mediaTicket=old", "/tmp/audio.mp3");
+    expect(media.getAttribute("src")).toBe("/media?mediaTicket=old");
+
+    media.currentTime = 42;
+    controller.updateSource(media, "/media?mediaTicket=fresh", "/tmp/audio.mp3");
+
+    expect(media.getAttribute("src")).toBe("/media?mediaTicket=old");
+    expect(controller.queuedSource).toBe("/media?mediaTicket=fresh");
+
+    expect(controller.handleError(media)).toBe(true);
+    expect(media.getAttribute("src")).toBe("/media?mediaTicket=fresh");
+    media.currentTime = 0;
+    controller.handleLoadedMetadata(media);
+
+    expect(clock.currentTime()).toBe(42);
+    expect(play).not.toHaveBeenCalled();
+  });
+
+  it("preserves playing state when a failed seek applies the fresh ticket", async () => {
+    const media = document.createElement("video");
+    const state = { currentTime: 10, duration: 90, paused: false };
+    const clock = mockMediaState(media, state);
+    const play = vi.spyOn(media, "play").mockResolvedValue(undefined);
+    const controller = new ChatMediaSourceController();
+
+    controller.updateSource(media, "/media?mediaTicket=old", "/tmp/video.mp4");
+    controller.updateSource(media, "/media?mediaTicket=fresh", "/tmp/video.mp4");
+    clock.rejectSeek();
+
+    expect(controller.seek(media, 55)).toBe(true);
+    expect(media.getAttribute("src")).toBe("/media?mediaTicket=fresh");
+    clock.allowSeek();
+    controller.handleLoadedMetadata(media);
+
+    expect(clock.currentTime()).toBe(55);
+    expect(play).toHaveBeenCalledOnce();
+  });
+
+  it("applies a queued ticket once playback is idle at the end", () => {
+    const media = document.createElement("audio");
+    const state = { currentTime: 80, duration: 80, paused: true, ended: false };
+    mockMediaState(media, state);
+    const controller = new ChatMediaSourceController();
+
+    controller.updateSource(media, "/media?mediaTicket=old", "/tmp/audio.mp3");
+    controller.updateSource(media, "/media?mediaTicket=fresh", "/tmp/audio.mp3");
+    state.ended = true;
+
+    expect(controller.handleEnded(media)).toBe(true);
+    expect(media.getAttribute("src")).toBe("/media?mediaTicket=fresh");
+  });
+
+  it("applies a fresh ticket that arrives after the old source has already failed", () => {
+    const media = document.createElement("audio");
+    const state = { currentTime: 0, duration: 80, paused: true, error: null as MediaError | null };
+    const clock = mockMediaState(media, state);
+    Object.defineProperty(media, "error", { configurable: true, get: () => state.error });
+    const controller = new ChatMediaSourceController();
+
+    controller.updateSource(media, "/media?mediaTicket=old", "/tmp/audio.mp3");
+    media.currentTime = 30;
+    state.error = { code: 2, message: "ticket expired" } as MediaError;
+    controller.updateSource(media, "/media?mediaTicket=fresh", "/tmp/audio.mp3");
+
+    expect(media.getAttribute("src")).toBe("/media?mediaTicket=fresh");
+    expect(controller.queuedSource).toBe("");
+    media.currentTime = 0;
+    state.error = null;
+    controller.handleLoadedMetadata(media);
+    expect(clock.currentTime()).toBe(30);
+  });
+
+  it("replaces a different attachment immediately instead of treating it as a ticket refresh", () => {
+    const media = document.createElement("audio");
+    const state = { currentTime: 20, duration: 80, paused: false };
+    mockMediaState(media, state);
+    const pause = vi.spyOn(media, "pause").mockImplementation(() => {
+      state.paused = true;
+    });
+    const controller = new ChatMediaSourceController();
+
+    controller.updateSource(media, "/media?mediaTicket=first", "/tmp/first.mp3");
+    controller.updateSource(media, "/media?mediaTicket=second", "/tmp/second.mp3");
+
+    expect(pause).toHaveBeenCalledOnce();
+    expect(media.getAttribute("src")).toBe("/media?mediaTicket=second");
+    expect(controller.queuedSource).toBe("");
+  });
+});

--- a/ui/src/pages/chat/components/chat-media-source.ts
+++ b/ui/src/pages/chat/components/chat-media-source.ts
@@ -1,0 +1,139 @@
+type PlaybackRestore = {
+  currentTime: number;
+  paused: boolean;
+};
+
+function finiteMediaTime(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/** Keeps a refreshed ticket ready without interrupting active media playback. */
+export class ChatMediaSourceController {
+  private appliedSource = "";
+  private appliedIdentity = "";
+  private pendingSource = "";
+  private pendingIdentity = "";
+  private restore: PlaybackRestore | null = null;
+
+  get currentSource(): string {
+    return this.appliedSource;
+  }
+
+  get queuedSource(): string {
+    return this.pendingSource;
+  }
+
+  updateSource(media: HTMLMediaElement, source: string, sourceIdentity = source): void {
+    const nextSource = source.trim();
+    const nextIdentity = sourceIdentity.trim();
+    if (!nextSource || !nextIdentity) {
+      return;
+    }
+    if (this.appliedIdentity && nextIdentity !== this.appliedIdentity) {
+      if (!media.paused) {
+        media.pause();
+      }
+      this.applySource(media, nextSource, nextIdentity, null);
+      return;
+    }
+    if (
+      (nextSource === this.pendingSource && nextIdentity === this.pendingIdentity) ||
+      (nextSource === this.appliedSource && nextIdentity === this.appliedIdentity)
+    ) {
+      return;
+    }
+    if (media.error) {
+      this.applySource(media, nextSource, nextIdentity, {
+        currentTime: finiteMediaTime(media.currentTime),
+        paused: media.paused,
+      });
+      return;
+    }
+    if (
+      !this.appliedSource ||
+      media.ended ||
+      (media.paused && finiteMediaTime(media.currentTime) === 0)
+    ) {
+      this.applySource(media, nextSource, nextIdentity, null);
+      return;
+    }
+    // A fresh ticket must not replace the active resource: assigning src resets
+    // playback even when the browser still has enough buffered data to continue.
+    this.pendingSource = nextSource;
+    this.pendingIdentity = nextIdentity;
+  }
+
+  handleEnded(media: HTMLMediaElement): boolean {
+    if (!this.pendingSource) {
+      return false;
+    }
+    this.applySource(media, this.pendingSource, this.pendingIdentity, null);
+    return true;
+  }
+
+  handleError(media: HTMLMediaElement): boolean {
+    if (!this.pendingSource) {
+      return false;
+    }
+    this.applySource(media, this.pendingSource, this.pendingIdentity, {
+      currentTime: finiteMediaTime(media.currentTime),
+      paused: media.paused,
+    });
+    return true;
+  }
+
+  seek(media: HTMLMediaElement, nextTime: number): boolean {
+    const targetTime = Math.max(0, finiteMediaTime(nextTime));
+    try {
+      media.currentTime = targetTime;
+      return true;
+    } catch {
+      if (!this.pendingSource) {
+        return false;
+      }
+      this.applySource(media, this.pendingSource, this.pendingIdentity, {
+        currentTime: targetTime,
+        paused: media.paused,
+      });
+      return true;
+    }
+  }
+
+  handleLoadedMetadata(media: HTMLMediaElement): void {
+    const restore = this.restore;
+    if (!restore) {
+      return;
+    }
+    this.restore = null;
+    const duration = Number.isFinite(media.duration) ? media.duration : restore.currentTime;
+    media.currentTime = Math.min(restore.currentTime, Math.max(0, duration));
+    if (!restore.paused) {
+      void media.play().catch(() => undefined);
+    }
+  }
+
+  private applySource(
+    media: HTMLMediaElement,
+    source: string,
+    sourceIdentity: string,
+    restore: PlaybackRestore | null,
+  ): void {
+    this.appliedSource = source;
+    this.appliedIdentity = sourceIdentity;
+    this.pendingSource = "";
+    this.pendingIdentity = "";
+    this.restore = restore;
+    media.src = source;
+  }
+}
+
+const sourceControllers = new WeakMap<HTMLMediaElement, ChatMediaSourceController>();
+
+export function getChatMediaSourceController(media: HTMLMediaElement): ChatMediaSourceController {
+  let controller = sourceControllers.get(media);
+  if (!controller) {
+    controller = new ChatMediaSourceController();
+    sourceControllers.set(media, controller);
+  }
+  return controller;
+}

--- a/ui/src/pages/chat/components/chat-media-source.ts
+++ b/ui/src/pages/chat/components/chat-media-source.ts
@@ -99,7 +99,13 @@ export class ChatMediaSourceController {
     }
   }
 
-  handleLoadedMetadata(media: HTMLMediaElement): void {
+  cancelPendingResume(): void {
+    if (this.restore && !this.restore.paused) {
+      this.restore = { ...this.restore, paused: true };
+    }
+  }
+
+  handleLoadedMetadata(media: HTMLMediaElement, canResume = () => true): void {
     const restore = this.restore;
     if (!restore) {
       return;
@@ -107,7 +113,7 @@ export class ChatMediaSourceController {
     this.restore = null;
     const duration = Number.isFinite(media.duration) ? media.duration : restore.currentTime;
     media.currentTime = Math.min(restore.currentTime, Math.max(0, duration));
-    if (!restore.paused) {
+    if (!restore.paused && media.isConnected && canResume()) {
       void media.play().catch(() => undefined);
     }
   }

--- a/ui/src/pages/chat/components/chat-message-attachments.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.ts
@@ -463,6 +463,7 @@ export function renderAssistantAttachments(
                   ? html`<a
                       class="chat-assistant-attachment-card__download"
                       href=${downloadHref}
+                      download=${attachment.label}
                       target="_blank"
                       rel="noreferrer"
                       aria-label=${t("chat.mediaPlayer.download", {
@@ -520,6 +521,7 @@ export function renderAssistantAttachments(
                   ? html`<a
                       class="chat-assistant-attachment-card__link"
                       href=${downloadHref}
+                      download=${attachment.label}
                       target="_blank"
                       rel="noreferrer"
                       >${t("chat.mediaPlayer.download", { filename: attachment.label })}</a

--- a/ui/src/pages/chat/components/chat-message-attachments.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.ts
@@ -1,7 +1,11 @@
 import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
+import { styleMap } from "lit/directives/style-map.js";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import { t } from "../../../i18n/index.ts";
+import "./chat-audio-player.ts";
+import { getChatMediaSourceController } from "./chat-media-source.ts";
 import { openResolvedImage } from "./chat-message-image-open.ts";
 import {
   buildAssistantAttachmentUrl,
@@ -19,7 +23,12 @@ import {
 
 type AssistantAttachmentAvailability =
   | { status: "checking" }
-  | { status: "available"; mediaTicket?: string; mediaTicketExpiresAt?: number }
+  | {
+      status: "available";
+      mediaTicket?: string;
+      mediaTicketExpiresAt?: number;
+      refreshAfter?: number;
+    }
   | { status: "unavailable"; reason: string; checkedAt: number; retryAttempted?: true };
 
 const ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS = 5_000;
@@ -75,15 +84,21 @@ function scheduleAssistantAttachmentRefresh(
       : availability.status === "available" &&
           availability.mediaTicket &&
           availability.mediaTicketExpiresAt
-        ? availability.mediaTicketExpiresAt - ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS
+        ? (availability.refreshAfter ??
+          availability.mediaTicketExpiresAt - ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS)
         : undefined;
   scheduleChatMediaResourceRefresh(resource, refreshAt, () => {
     if (resource.value !== availability) {
       return;
     }
     // Keep the failed generation until its retry can inherit the one-attempt
-    // budget; ticket refreshes must still invalidate their current generation.
-    if (availability.status !== "unavailable") {
+    // budget. A ticket refresh keeps the playable generation mounted while
+    // its replacement is minted, otherwise the checking card resets playback.
+    if (availability.status === "available") {
+      // Virtual rows use this version as their media invalidation key. Notify
+      // alone updates the host but can leave the attachment row memoized.
+      bumpAssistantAttachmentAvailabilityRenderVersion();
+    } else if (availability.status !== "unavailable") {
       resource.value = undefined;
       bumpAssistantAttachmentAvailabilityRenderVersion();
     }
@@ -121,6 +136,10 @@ export function resolveAssistantAttachmentAvailability(
     source,
   );
   const cached = resource.value;
+  let refreshingAvailability: Extract<
+    AssistantAttachmentAvailability,
+    { status: "available" }
+  > | null = null;
   if (cached) {
     const now = Date.now();
     if (
@@ -134,17 +153,34 @@ export function resolveAssistantAttachmentAvailability(
     } else if (
       cached.status === "available" &&
       cached.mediaTicket &&
-      (!cached.mediaTicketExpiresAt ||
-        cached.mediaTicketExpiresAt - now <= ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS)
+      (cached.refreshAfter !== undefined
+        ? cached.refreshAfter <= now
+        : !cached.mediaTicketExpiresAt ||
+          cached.mediaTicketExpiresAt - now <= ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS)
     ) {
-      resource.value = undefined;
-      bumpAssistantAttachmentAvailabilityRenderVersion();
+      if (resource.pending) {
+        return cached;
+      }
+      refreshingAvailability = cached;
     } else {
       scheduleAssistantAttachmentRefresh(resource, cached);
       return cached;
     }
   }
-  setAssistantAttachmentAvailability(resource, { status: "checking" });
+  if (!refreshingAvailability) {
+    setAssistantAttachmentAvailability(resource, { status: "checking" });
+  }
+  const keepPlayableTicketForRetry = () => {
+    if (!refreshingAvailability) {
+      return null;
+    }
+    const retryAvailability: AssistantAttachmentAvailability = {
+      ...refreshingAvailability,
+      refreshAfter: Date.now() + ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS,
+    };
+    setAssistantAttachmentAvailability(resource, retryAvailability);
+    return retryAvailability;
+  };
   if (typeof fetch === "function") {
     const headers = new Headers({ Accept: "application/json" });
     if (normalizedAuthToken) {
@@ -176,6 +212,10 @@ export function resolveAssistantAttachmentAvailability(
           const mediaTicket = payload.mediaTicket?.trim();
           const mediaTicketExpiresAt = Date.parse(payload.mediaTicketExpiresAt ?? "");
           if (mediaTicket && !Number.isFinite(mediaTicketExpiresAt)) {
+            const retryAvailability = keepPlayableTicketForRetry();
+            if (retryAvailability) {
+              return retryAvailability;
+            }
             const unavailable = createUnavailableAssistantAttachment(
               t("chat.attachments.unavailable"),
               resource.retryAttempted,
@@ -191,6 +231,10 @@ export function resolveAssistantAttachmentAvailability(
           setAssistantAttachmentAvailability(resource, availability);
           return availability;
         }
+        const retryAvailability = keepPlayableTicketForRetry();
+        if (retryAvailability) {
+          return retryAvailability;
+        }
         const unavailable = createUnavailableAssistantAttachment(
           payload?.reason?.trim() || t("chat.attachments.unavailable"),
           resource.retryAttempted,
@@ -199,6 +243,10 @@ export function resolveAssistantAttachmentAvailability(
         return unavailable;
       })
       .catch(() => {
+        const retryAvailability = keepPlayableTicketForRetry();
+        if (retryAvailability) {
+          return retryAvailability;
+        }
         const unavailable = createUnavailableAssistantAttachment(
           t("chat.attachments.unavailable"),
           resource.retryAttempted,
@@ -218,7 +266,7 @@ export function resolveAssistantAttachmentAvailability(
       });
     resource.pending = pending;
   }
-  return { status: "checking" };
+  return refreshingAvailability ?? { status: "checking" };
 }
 
 function renderAssistantAttachmentStatusCard(params: {
@@ -249,6 +297,43 @@ function renderAssistantAttachmentStatusCard(params: {
         : nothing}
     </div>
   `;
+}
+
+function videoCardFor(media: HTMLVideoElement): HTMLElement | null {
+  return media.closest<HTMLElement>(".chat-assistant-attachment-card--video");
+}
+
+function markVideoMetadataLoaded(media: HTMLVideoElement, loaded: boolean): void {
+  videoCardFor(media)?.toggleAttribute("data-metadata-loaded", loaded);
+}
+
+function markVideoUnplayable(media: HTMLVideoElement, unplayable: boolean): void {
+  videoCardFor(media)?.toggleAttribute("data-unplayable", unplayable);
+}
+
+function syncVideoSource(
+  media: HTMLVideoElement,
+  source: string,
+  sourceIdentity: string,
+  mimeType?: string,
+): void {
+  getChatMediaSourceController(media).updateSource(media, source, sourceIdentity);
+  if (
+    mimeType?.trim() &&
+    !media.canPlayType(mimeType) &&
+    !videoCardFor(media)?.hasAttribute("data-metadata-loaded")
+  ) {
+    markVideoUnplayable(media, true);
+  }
+}
+
+function recoverVideoSource(media: HTMLVideoElement): boolean {
+  const recovered = getChatMediaSourceController(media).handleError(media);
+  if (recovered) {
+    markVideoMetadataLoaded(media, false);
+    markVideoUnplayable(media, false);
+  }
+  return recovered;
 }
 
 export function renderAssistantAttachments(
@@ -310,36 +395,25 @@ export function renderAssistantAttachments(
           `;
         }
         if (attachment.kind === "audio") {
+          if (!attachmentUrl) {
+            return renderAssistantAttachmentStatusCard({
+              kind: "audio",
+              label: attachment.label,
+              badge:
+                availability.status === "checking"
+                  ? t("chat.attachments.checking")
+                  : t("chat.attachments.unavailable"),
+              reason: availability.status === "unavailable" ? availability.reason : undefined,
+            });
+          }
           return html`
-            <div class="chat-assistant-attachment-card chat-assistant-attachment-card--audio">
-              <div class="chat-assistant-attachment-card__header">
-                <span class="chat-assistant-attachment-card__title">${attachment.label}</span>
-                ${!attachmentUrl
-                  ? html`<span
-                      class="chat-assistant-attachment-badge chat-assistant-attachment-badge--muted"
-                      >${availability.status === "checking"
-                        ? t("chat.attachments.checking")
-                        : t("chat.attachments.unavailable")}</span
-                    >`
-                  : attachment.isVoiceNote
-                    ? html`<span class="chat-assistant-attachment-badge"
-                        >${t("chat.messages.voiceNote")}</span
-                      >`
-                    : nothing}
-              </div>
-              ${attachmentUrl
-                ? html`<audio
-                    controls
-                    preload="metadata"
-                    src=${attachmentUrl}
-                    @loadedmetadata=${() => onAssistantAttachmentLoaded?.()}
-                  ></audio>`
-                : availability.status === "unavailable"
-                  ? html`<div class="chat-assistant-attachment-card__reason">
-                      ${availability.reason}
-                    </div>`
-                  : nothing}
-            </div>
+            <openclaw-chat-audio-player
+              .src=${attachmentUrl}
+              .sourceIdentity=${attachment.url}
+              .label=${attachment.label}
+              .voiceNote=${attachment.isVoiceNote === true}
+              .onMediaLoaded=${onAssistantAttachmentLoaded}
+            ></openclaw-chat-audio-player>
           `;
         }
         if (attachment.kind === "video") {
@@ -354,21 +428,75 @@ export function renderAssistantAttachments(
               reason: availability.status === "unavailable" ? availability.reason : undefined,
             });
           }
+          const dimensions =
+            attachment.width && attachment.height
+              ? { "aspect-ratio": `${attachment.width} / ${attachment.height}` }
+              : {};
           return html`
             <div class="chat-assistant-attachment-card chat-assistant-attachment-card--video">
-              <video
-                controls
-                preload="metadata"
-                src=${attachmentUrl}
-                @loadedmetadata=${() => onAssistantAttachmentLoaded?.()}
-              ></video>
-              <a
-                class="chat-assistant-attachment-card__link"
-                href=${attachmentUrl}
-                target="_blank"
-                rel="noreferrer"
-                >${attachment.label}</a
-              >
+              <div class="chat-assistant-attachment-card__header">
+                <span class="chat-assistant-attachment-card__title">${attachment.label}</span>
+                <a
+                  class="chat-assistant-attachment-card__download"
+                  href=${attachmentUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label=${t("chat.mediaPlayer.download", { filename: attachment.label })}
+                  title=${t("chat.mediaPlayer.download", { filename: attachment.label })}
+                  >${icons.download}</a
+                >
+              </div>
+              <div class="chat-assistant-video-frame" style=${styleMap(dimensions)}>
+                <span class="chat-assistant-video-frame__placeholder" aria-hidden="true"
+                  >${icons.monitor}</span
+                >
+                <video
+                  controls
+                  preload="metadata"
+                  ${ref((element) => {
+                    if (element instanceof HTMLVideoElement) {
+                      syncVideoSource(element, attachmentUrl, attachment.url, attachment.mimeType);
+                    }
+                  })}
+                  @loadedmetadata=${(event: Event) => {
+                    const media = event.currentTarget as HTMLVideoElement;
+                    getChatMediaSourceController(media).handleLoadedMetadata(media);
+                    markVideoMetadataLoaded(media, true);
+                    markVideoUnplayable(media, false);
+                    onAssistantAttachmentLoaded?.();
+                  }}
+                  @ended=${(event: Event) => {
+                    const media = event.currentTarget as HTMLVideoElement;
+                    if (getChatMediaSourceController(media).handleEnded(media)) {
+                      markVideoMetadataLoaded(media, false);
+                    }
+                  }}
+                  @seeking=${(event: Event) => {
+                    const media = event.currentTarget as HTMLVideoElement;
+                    if (media.error) {
+                      recoverVideoSource(media);
+                    }
+                  }}
+                  @error=${(event: Event) => {
+                    const media = event.currentTarget as HTMLVideoElement;
+                    if (!recoverVideoSource(media)) {
+                      markVideoUnplayable(media, true);
+                    }
+                  }}
+                ></video>
+              </div>
+              <div class="chat-assistant-video-fallback">
+                <div class="chat-assistant-attachment-card__reason">
+                  ${t("chat.mediaPlayer.videoUnavailable")}
+                </div>
+                <a
+                  class="chat-assistant-attachment-card__link"
+                  href=${attachmentUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  >${t("chat.mediaPlayer.download", { filename: attachment.label })}</a
+                >
+              </div>
             </div>
           `;
         }

--- a/ui/src/pages/chat/components/chat-message-attachments.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.ts
@@ -333,20 +333,8 @@ function markVideoUnplayable(media: HTMLVideoElement, unplayable: boolean): void
   videoCardFor(media)?.toggleAttribute("data-unplayable", unplayable);
 }
 
-function syncVideoSource(
-  media: HTMLVideoElement,
-  source: string,
-  sourceIdentity: string,
-  mimeType?: string,
-): void {
+function syncVideoSource(media: HTMLVideoElement, source: string, sourceIdentity: string): void {
   getChatMediaSourceController(media).updateSource(media, source, sourceIdentity);
-  if (
-    mimeType?.trim() &&
-    !media.canPlayType(mimeType) &&
-    !videoCardFor(media)?.hasAttribute("data-metadata-loaded")
-  ) {
-    markVideoUnplayable(media, true);
-  }
 }
 
 function recoverVideoSource(media: HTMLVideoElement): boolean {
@@ -483,7 +471,7 @@ export function renderAssistantAttachments(
                   preload="metadata"
                   ${ref((element) => {
                     if (element instanceof HTMLVideoElement) {
-                      syncVideoSource(element, attachmentUrl, attachment.url, attachment.mimeType);
+                      syncVideoSource(element, attachmentUrl, attachment.url);
                     }
                   })}
                   @loadedmetadata=${(event: Event) => {

--- a/ui/src/pages/chat/components/chat-message-attachments.ts
+++ b/ui/src/pages/chat/components/chat-message-attachments.ts
@@ -5,6 +5,7 @@ import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import { t } from "../../../i18n/index.ts";
 import "./chat-audio-player.ts";
+import { safeAttachmentHref } from "./chat-attachment-href.ts";
 import { getChatMediaSourceController } from "./chat-media-source.ts";
 import { openResolvedImage } from "./chat-message-image-open.ts";
 import {
@@ -28,12 +29,14 @@ type AssistantAttachmentAvailability =
       mediaTicket?: string;
       mediaTicketExpiresAt?: number;
       refreshAfter?: number;
+      refreshAttempts?: number;
     }
   | { status: "unavailable"; reason: string; checkedAt: number; retryAttempted?: true };
 
 const ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS = 5_000;
 const ASSISTANT_ATTACHMENT_METADATA_FETCH_TIMEOUT_MS = 30_000;
 const ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS = 30_000;
+const ASSISTANT_ATTACHMENT_MEDIA_TICKET_MAX_REFRESH_RETRIES = 2;
 let assistantAttachmentAvailabilityRenderVersion = 0;
 
 function createUnavailableAssistantAttachment(
@@ -153,6 +156,18 @@ export function resolveAssistantAttachmentAvailability(
     } else if (
       cached.status === "available" &&
       cached.mediaTicket &&
+      cached.mediaTicketExpiresAt !== undefined &&
+      cached.mediaTicketExpiresAt <= now
+    ) {
+      const unavailable = createUnavailableAssistantAttachment(
+        "Attachment unavailable",
+        resource.retryAttempted,
+      );
+      setAssistantAttachmentAvailability(resource, unavailable);
+      return unavailable;
+    } else if (
+      cached.status === "available" &&
+      cached.mediaTicket &&
       (cached.refreshAfter !== undefined
         ? cached.refreshAfter <= now
         : !cached.mediaTicketExpiresAt ||
@@ -174,9 +189,20 @@ export function resolveAssistantAttachmentAvailability(
     if (!refreshingAvailability) {
       return null;
     }
+    const now = Date.now();
+    const expiresAt = refreshingAvailability.mediaTicketExpiresAt;
+    const refreshAttempts = refreshingAvailability.refreshAttempts ?? 0;
+    if (
+      expiresAt === undefined ||
+      expiresAt <= now ||
+      refreshAttempts >= ASSISTANT_ATTACHMENT_MEDIA_TICKET_MAX_REFRESH_RETRIES
+    ) {
+      return null;
+    }
     const retryAvailability: AssistantAttachmentAvailability = {
       ...refreshingAvailability,
-      refreshAfter: Date.now() + ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS,
+      refreshAfter: Math.min(now + ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS, expiresAt),
+      refreshAttempts: refreshAttempts + 1,
     };
     setAssistantAttachmentAvailability(resource, retryAvailability);
     return retryAvailability;
@@ -230,10 +256,6 @@ export function resolveAssistantAttachmentAvailability(
           resource.retryAttempted = false;
           setAssistantAttachmentAvailability(resource, availability);
           return availability;
-        }
-        const retryAvailability = keepPlayableTicketForRetry();
-        if (retryAvailability) {
-          return retryAvailability;
         }
         const unavailable = createUnavailableAssistantAttachment(
           payload?.reason?.trim() || t("chat.attachments.unavailable"),
@@ -432,19 +454,24 @@ export function renderAssistantAttachments(
             attachment.width && attachment.height
               ? { "aspect-ratio": `${attachment.width} / ${attachment.height}` }
               : {};
+          const downloadHref = safeAttachmentHref(attachmentUrl);
           return html`
             <div class="chat-assistant-attachment-card chat-assistant-attachment-card--video">
               <div class="chat-assistant-attachment-card__header">
                 <span class="chat-assistant-attachment-card__title">${attachment.label}</span>
-                <a
-                  class="chat-assistant-attachment-card__download"
-                  href=${attachmentUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  aria-label=${t("chat.mediaPlayer.download", { filename: attachment.label })}
-                  title=${t("chat.mediaPlayer.download", { filename: attachment.label })}
-                  >${icons.download}</a
-                >
+                ${downloadHref
+                  ? html`<a
+                      class="chat-assistant-attachment-card__download"
+                      href=${downloadHref}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label=${t("chat.mediaPlayer.download", {
+                        filename: attachment.label,
+                      })}
+                      title=${t("chat.mediaPlayer.download", { filename: attachment.label })}
+                      >${icons.download}</a
+                    >`
+                  : nothing}
               </div>
               <div class="chat-assistant-video-frame" style=${styleMap(dimensions)}>
                 <span class="chat-assistant-video-frame__placeholder" aria-hidden="true"
@@ -489,13 +516,15 @@ export function renderAssistantAttachments(
                 <div class="chat-assistant-attachment-card__reason">
                   ${t("chat.mediaPlayer.videoUnavailable")}
                 </div>
-                <a
-                  class="chat-assistant-attachment-card__link"
-                  href=${attachmentUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  >${t("chat.mediaPlayer.download", { filename: attachment.label })}</a
-                >
+                ${downloadHref
+                  ? html`<a
+                      class="chat-assistant-attachment-card__link"
+                      href=${downloadHref}
+                      target="_blank"
+                      rel="noreferrer"
+                      >${t("chat.mediaPlayer.download", { filename: attachment.label })}</a
+                    >`
+                  : nothing}
               </div>
             </div>
           `;
@@ -511,16 +540,21 @@ export function renderAssistantAttachments(
             reason: availability.status === "unavailable" ? availability.reason : undefined,
           });
         }
+        const downloadHref = safeAttachmentHref(attachmentUrl);
         return html`
           <div class="chat-assistant-attachment-card">
             <span class="chat-assistant-attachment-card__icon">${icons.paperclip}</span>
-            <a
-              class="chat-assistant-attachment-card__link"
-              href=${attachmentUrl}
-              target="_blank"
-              rel="noreferrer"
-              >${attachment.label}</a
-            >
+            ${downloadHref
+              ? html`<a
+                  class="chat-assistant-attachment-card__link"
+                  href=${downloadHref}
+                  target="_blank"
+                  rel="noreferrer"
+                  >${attachment.label}</a
+                >`
+              : html`<span class="chat-assistant-attachment-card__title"
+                  >${attachment.label}</span
+                >`}
           </div>
         `;
       })}

--- a/ui/src/pages/chat/components/chat-message-media-lifecycle.test.ts
+++ b/ui/src/pages/chat/components/chat-message-media-lifecycle.test.ts
@@ -438,6 +438,135 @@ describe("chat media resource lifecycle", () => {
     expect(secondTicket).toBe("ticket-after-refresh");
   });
 
+  it("stops polling after a definitive ticket refresh rejection and one unavailable retry", async () => {
+    const source = `/tmp/openclaw/${crypto.randomUUID()}.mp3`;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          available: true,
+          mediaTicket: "ticket-before-definitive-rejection",
+          mediaTicketExpiresAt: new Date(Date.now() + 31_000).toISOString(),
+        }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ available: false, reason: "Attachment removed" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latest: ReturnType<typeof resolveAssistantAttachmentAvailability> | undefined;
+    const rerender = observeSubscriber(() => {
+      latest = resolveAssistantAttachmentAvailability(
+        source,
+        ["/tmp/openclaw"],
+        "/openclaw",
+        "definitive-rejection-token",
+        rerender,
+      );
+    });
+
+    rerender();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(latest?.status).toBe("unavailable");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(latest?.status).toBe("unavailable");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("bounds transient ticket refresh failures before using the unavailable retry", async () => {
+    const source = `/tmp/openclaw/${crypto.randomUUID()}.mp3`;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          available: true,
+          mediaTicket: "ticket-before-transient-failures",
+          mediaTicketExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+        }),
+      })
+      .mockRejectedValueOnce(new Error("refresh unavailable 1"))
+      .mockRejectedValueOnce(new Error("refresh unavailable 2"))
+      .mockRejectedValueOnce(new Error("refresh unavailable 3"))
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ available: false }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latest: ReturnType<typeof resolveAssistantAttachmentAvailability> | undefined;
+    const rerender = observeSubscriber(() => {
+      latest = resolveAssistantAttachmentAvailability(
+        source,
+        ["/tmp/openclaw"],
+        "/openclaw",
+        "transient-refresh-token",
+        rerender,
+      );
+    });
+
+    rerender();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(latest?.status).toBe("available");
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(latest?.status).toBe("available");
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(latest?.status).toBe("unavailable");
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(latest?.status).toBe("unavailable");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("transitions an expired ticket to unavailable instead of retrying it", async () => {
+    const source = `/tmp/openclaw/${crypto.randomUUID()}.mp3`;
+    const expiredAt = new Date(Date.now() + 31_000);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          available: true,
+          mediaTicket: "ticket-that-will-expire",
+          mediaTicketExpiresAt: expiredAt.toISOString(),
+        }),
+      })
+      .mockImplementationOnce(async () => {
+        vi.setSystemTime(new Date(expiredAt.getTime() + 1));
+        throw new Error("refresh completed after ticket expiry");
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    let latest: ReturnType<typeof resolveAssistantAttachmentAvailability> | undefined;
+    const rerender = observeSubscriber(() => {
+      latest = resolveAssistantAttachmentAvailability(
+        source,
+        ["/tmp/openclaw"],
+        "/openclaw",
+        "expired-refresh-token",
+        rerender,
+      );
+    });
+
+    rerender();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(latest?.status).toBe("unavailable");
+  });
+
   it("shares the one bounded assistant attachment retry across split panes", async () => {
     const source = `/tmp/openclaw/${crypto.randomUUID()}.png`;
     const fetchMock = vi

--- a/ui/src/pages/chat/components/chat-message-media.ts
+++ b/ui/src/pages/chat/components/chat-message-media.ts
@@ -2,7 +2,10 @@ import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import { t } from "../../../i18n/index.ts";
 import type { MessageContentItem } from "../../../lib/chat/chat-types.ts";
 import { readTranscriptMediaEntries } from "../../../lib/chat/message-extract.ts";
-import { getMediaFileExtension } from "../../../lib/media-file-extension.ts";
+import {
+  getMediaFileExtension,
+  hasVideoMediaFileExtension,
+} from "../../../lib/media-file-extension.ts";
 
 export type PairingQrExpiryNotice = {
   title: string;
@@ -356,8 +359,7 @@ function isVideoTranscriptMediaPath(path: string, mediaType: unknown): boolean {
   if (typeof mediaType === "string" && mediaType.trim().toLowerCase().startsWith("video/")) {
     return true;
   }
-  const ext = getMediaFileExtension(path);
-  return ext !== undefined && ["m4v", "mov", "mp4", "webm"].includes(ext);
+  return hasVideoMediaFileExtension(path);
 }
 
 function labelForMediaPath(mediaPath: string): string {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -3116,7 +3116,8 @@ describe("grouped chat rendering", () => {
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    const container = document.createElement("div");
+    const container = document.body.appendChild(document.createElement("div"));
+    container.dataset.mediaPlayerTestFixture = "";
     const renderMessage = () =>
       renderAssistantMessage(
         container,
@@ -3140,7 +3141,8 @@ describe("grouped chat rendering", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     await flushAssistantAttachmentAvailabilityChecks();
 
-    const audio = expectElement(container, "audio", HTMLAudioElement);
+    const audioPlayer = await requireAudioPlayer(container);
+    const audio = expectElement(audioPlayer, "audio", HTMLAudioElement);
     expect(audio.getAttribute("src")).toBe(
       `/openclaw/__openclaw__/assistant-media?source=${encodeURIComponent(source)}&mediaTicket=ticket-bootstrap-audio`,
     );
@@ -3231,7 +3233,7 @@ describe("grouped chat rendering", () => {
       await vi.waitFor(() => {
         expect(
           container.querySelector(
-            ".chat-assistant-attachment-card--audio .chat-assistant-attachment-card__reason",
+            ".chat-assistant-attachment-card--blocked .chat-assistant-attachment-card__reason",
           )?.textContent,
         ).toContain(reason);
       });

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -3276,6 +3276,54 @@ describe("grouped chat rendering", () => {
     );
   });
 
+  it("omits attachment anchors for unsafe transcript URLs", async () => {
+    const container = document.body.appendChild(document.createElement("div"));
+    container.dataset.mediaPlayerTestFixture = "";
+
+    renderAssistantMessage(
+      container,
+      {
+        id: "assistant-unsafe-attachment-links",
+        role: "assistant",
+        content: [
+          {
+            type: "attachment",
+            attachment: {
+              url: "javascript:audio()",
+              kind: "audio",
+              label: "unsafe.mp3",
+              mimeType: "audio/mpeg",
+            },
+          },
+          {
+            type: "attachment",
+            attachment: {
+              url: "data:text/html,video",
+              kind: "video",
+              label: "unsafe.mp4",
+              mimeType: "video/mp4",
+            },
+          },
+          {
+            type: "attachment",
+            attachment: {
+              url: "vbscript:document",
+              kind: "document",
+              label: "unsafe.pdf",
+              mimeType: "application/pdf",
+            },
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      { showToolCalls: false },
+    );
+
+    await requireAudioPlayer(container);
+    expect(container.querySelectorAll(".chat-assistant-attachments a")).toHaveLength(0);
+    expect(container.textContent).toContain("unsafe.pdf");
+  });
+
   it("renders verified local assistant attachments through the authenticated media route", async () => {
     const source = `/tmp/openclaw/${crypto.randomUUID()} test image.png`;
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -3240,8 +3240,7 @@ describe("grouped chat rendering", () => {
     },
   );
 
-  it("shows the download fallback when a video format cannot play", () => {
-    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockReturnValue("");
+  it("shows the download fallback when the video element emits an error", () => {
     const container = document.body.appendChild(document.createElement("div"));
     container.dataset.mediaPlayerTestFixture = "";
 
@@ -3267,6 +3266,7 @@ describe("grouped chat rendering", () => {
     );
 
     const card = expectElement(container, ".chat-assistant-attachment-card--video", HTMLElement);
+    expectElement(card, "video", HTMLVideoElement).dispatchEvent(new Event("error"));
     expect(card.hasAttribute("data-unplayable")).toBe(true);
     expect(card.querySelector(".chat-assistant-video-fallback")?.textContent).toContain(
       "Can't play this format — download instead.",

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -3274,6 +3274,16 @@ describe("grouped chat rendering", () => {
     expect(card.querySelector<HTMLAnchorElement>(".chat-assistant-video-fallback a")?.href).toBe(
       "https://example.com/clip.mp4",
     );
+    expect(
+      card
+        .querySelector<HTMLAnchorElement>(".chat-assistant-attachment-card__download")
+        ?.getAttribute("download"),
+    ).toBe("clip.mp4");
+    expect(
+      card
+        .querySelector<HTMLAnchorElement>(".chat-assistant-video-fallback a")
+        ?.getAttribute("download"),
+    ).toBe("clip.mp4");
   });
 
   it("omits attachment anchors for unsafe transcript URLs", async () => {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -10,6 +10,7 @@ import * as localStorageModule from "../../../local-storage.ts";
 import * as chatAvatar from "../chat-avatar.ts";
 import { renderChatNotice } from "./chat-divider.ts";
 import {
+  getAssistantAttachmentAvailabilityRenderVersion,
   dismissConfirmedActionPopovers,
   renderMessageGroup,
   renderStreamGroup,
@@ -584,8 +585,21 @@ function mediaTicketPayload(mediaTicket: string, ttlMs = 5 * 60 * 1000) {
   };
 }
 
+async function requireAudioPlayer(container: HTMLElement) {
+  const player = expectElement(
+    container,
+    "openclaw-chat-audio-player",
+    HTMLElement,
+  ) as HTMLElement & { updateComplete: Promise<unknown> };
+  await player.updateComplete;
+  return player;
+}
+
 afterEach(() => {
   markdownRenderMock.mockClear();
+  document.querySelectorAll("[data-media-player-test-fixture]").forEach((element) => {
+    element.remove();
+  });
   document.querySelectorAll("[data-delete-confirm-fixture]").forEach((element) => {
     dismissConfirmedActionPopovers(element);
     element.remove();
@@ -3028,8 +3042,9 @@ describe("grouped chat rendering", () => {
     });
   });
 
-  it("renders assistant MEDIA attachments, voice-note badge, and reply pill", () => {
-    const container = document.createElement("div");
+  it("renders assistant MEDIA attachments, voice-note badge, and reply pill", async () => {
+    const container = document.body.appendChild(document.createElement("div"));
+    container.dataset.mediaPlayerTestFixture = "";
     const onOpenImage = vi.fn();
     renderAssistantMessage(
       container,
@@ -3055,7 +3070,8 @@ describe("grouped chat rendering", () => {
       src: "https://example.com/photo.png",
       title: "photo.png",
     });
-    expect(expectElement(container, "audio", HTMLAudioElement).src).toBe(
+    const audioPlayer = await requireAudioPlayer(container);
+    expect(expectElement(audioPlayer, "audio", HTMLAudioElement).src).toBe(
       "https://example.com/voice.ogg",
     );
     expect(container.querySelector(".chat-assistant-attachment-badge")?.textContent?.trim()).toBe(
@@ -3063,8 +3079,9 @@ describe("grouped chat rendering", () => {
     );
   });
 
-  it("notifies when assistant audio and video attachment metadata loads", () => {
-    const container = document.createElement("div");
+  it("notifies when assistant audio and video attachment metadata loads", async () => {
+    const container = document.body.appendChild(document.createElement("div"));
+    container.dataset.mediaPlayerTestFixture = "";
     const onAssistantAttachmentLoaded = vi.fn();
 
     renderAssistantMessage(
@@ -3079,7 +3096,8 @@ describe("grouped chat rendering", () => {
       { showToolCalls: false, onAssistantAttachmentLoaded },
     );
 
-    expectElement(container, "audio", HTMLAudioElement).dispatchEvent(
+    const audioPlayer = await requireAudioPlayer(container);
+    expectElement(audioPlayer, "audio", HTMLAudioElement).dispatchEvent(
       new Event("loadedmetadata", { bubbles: true }),
     );
     expectElement(container, "video", HTMLVideoElement).dispatchEvent(
@@ -3222,6 +3240,42 @@ describe("grouped chat rendering", () => {
     },
   );
 
+  it("shows the download fallback when a video format cannot play", () => {
+    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockReturnValue("");
+    const container = document.body.appendChild(document.createElement("div"));
+    container.dataset.mediaPlayerTestFixture = "";
+
+    renderAssistantMessage(
+      container,
+      {
+        id: "assistant-video-unplayable",
+        role: "assistant",
+        content: [
+          {
+            type: "attachment",
+            attachment: {
+              url: "https://example.com/clip.mp4",
+              kind: "video",
+              label: "clip.mp4",
+              mimeType: "video/mp4",
+            },
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      { showToolCalls: false },
+    );
+
+    const card = expectElement(container, ".chat-assistant-attachment-card--video", HTMLElement);
+    expect(card.hasAttribute("data-unplayable")).toBe(true);
+    expect(card.querySelector(".chat-assistant-video-fallback")?.textContent).toContain(
+      "Can't play this format — download instead.",
+    );
+    expect(card.querySelector<HTMLAnchorElement>(".chat-assistant-video-fallback a")?.href).toBe(
+      "https://example.com/clip.mp4",
+    );
+  });
+
   it("renders verified local assistant attachments through the authenticated media route", async () => {
     const source = `/tmp/openclaw/${crypto.randomUUID()} test image.png`;
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
@@ -3363,13 +3417,78 @@ describe("grouped chat rendering", () => {
     expect(
       container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
     ).toContain("mediaTicket=ticket-old");
+    const renderVersionBeforeRefresh = getAssistantAttachmentAvailabilityRenderVersion();
 
     await vi.advanceTimersByTimeAsync(1_001);
     await flushAssistantAttachmentAvailabilityChecks();
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(getAssistantAttachmentAvailabilityRenderVersion()).not.toBe(renderVersionBeforeRefresh);
     expect(
       container.querySelector<HTMLImageElement>(".chat-message-image")?.getAttribute("src"),
     ).toContain("mediaTicket=ticket-new");
+  });
+
+  it("queues refreshed audio tickets until playback needs a new source", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-30T00:00:00Z"));
+    const source = `/tmp/openclaw/${crypto.randomUUID()}-refresh.mp3`;
+    const fetchMock = vi
+      .fn<
+        (url: string, init?: RequestInit) => Promise<{ ok: true; json: () => Promise<unknown> }>
+      >()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mediaTicketPayload("ticket-old", 31_000),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => mediaTicketPayload("ticket-new"),
+      });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const container = document.body.appendChild(document.createElement("div"));
+    container.dataset.mediaPlayerTestFixture = "";
+    const rerender = () =>
+      renderAssistantMessage(
+        container,
+        {
+          id: "assistant-local-audio-ticket-refresh",
+          role: "assistant",
+          content: `Local audio\nMEDIA:${source}`,
+          timestamp: Date.now(),
+        },
+        {
+          showToolCalls: false,
+          basePath: "/openclaw",
+          localMediaPreviewRoots: ["/tmp/openclaw"],
+          onRequestUpdate: rerender,
+        },
+      );
+
+    rerender();
+    await flushAssistantAttachmentAvailabilityChecks();
+    const player = await requireAudioPlayer(container);
+    const audio = expectElement(player, "audio", HTMLAudioElement);
+    Object.defineProperties(audio, {
+      paused: { configurable: true, value: true },
+      currentTime: { configurable: true, writable: true, value: 24 },
+      duration: { configurable: true, value: 90 },
+    });
+    expect(audio.getAttribute("src")).toContain("mediaTicket=ticket-old");
+
+    await vi.advanceTimersByTimeAsync(1_001);
+    await flushAssistantAttachmentAvailabilityChecks();
+    await player.updateComplete;
+
+    expect(audio.getAttribute("src")).toContain("mediaTicket=ticket-old");
+    expect(
+      player.querySelector<HTMLAnchorElement>(".chat-assistant-attachment-card__download")?.href,
+    ).toContain("mediaTicket=ticket-new");
+
+    audio.dispatchEvent(new Event("error"));
+    expect(audio.getAttribute("src")).toContain("mediaTicket=ticket-new");
+    audio.currentTime = 0;
+    audio.dispatchEvent(new Event("loadedmetadata"));
+    expect(audio.currentTime).toBe(24);
   });
 
   it("rechecks local assistant media when its auth token changes", async () => {

--- a/ui/src/pages/chat/user-message-content.test.ts
+++ b/ui/src/pages/chat/user-message-content.test.ts
@@ -1,0 +1,29 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import { buildUserChatMessageContentBlocks } from "./user-message-content.ts";
+
+describe("buildUserChatMessageContentBlocks", () => {
+  it("keeps staged video attachments typed as video content", () => {
+    expect(
+      buildUserChatMessageContentBlocks("", [
+        {
+          id: "video-1",
+          mimeType: "video/mp4",
+          fileName: "demo.mp4",
+          previewUrl: "blob:demo-video",
+        },
+      ]),
+    ).toEqual([
+      {
+        type: "attachment",
+        attachment: {
+          url: "blob:demo-video",
+          kind: "video",
+          label: "demo.mp4",
+          mimeType: "video/mp4",
+        },
+      },
+    ]);
+  });
+});

--- a/ui/src/pages/chat/user-message-content.test.ts
+++ b/ui/src/pages/chat/user-message-content.test.ts
@@ -28,8 +28,11 @@ describe("buildUserChatMessageContentBlocks", () => {
   });
 
   it.each([
+    ["clip.avi", ""],
     ["clip.mp4", ""],
     ["clip.mkv", ""],
+    ["clip.mpeg", ""],
+    ["clip.mpg", ""],
     ["clip.mkv", "application/octet-stream"],
   ])("falls back to the %s extension when MIME is %s", (fileName, mimeType) => {
     const [block] = buildUserChatMessageContentBlocks("", [

--- a/ui/src/pages/chat/user-message-content.test.ts
+++ b/ui/src/pages/chat/user-message-content.test.ts
@@ -26,4 +26,21 @@ describe("buildUserChatMessageContentBlocks", () => {
       },
     ]);
   });
+
+  it.each([
+    ["clip.mp4", ""],
+    ["clip.mkv", ""],
+    ["clip.mkv", "application/octet-stream"],
+  ])("falls back to the %s extension when MIME is %s", (fileName, mimeType) => {
+    const [block] = buildUserChatMessageContentBlocks("", [
+      {
+        id: `video-${fileName}-${mimeType}`,
+        mimeType,
+        fileName,
+        previewUrl: `blob:${fileName}`,
+      },
+    ]);
+
+    expect(block?.attachment?.kind).toBe("video");
+  });
 });

--- a/ui/src/pages/chat/user-message-content.ts
+++ b/ui/src/pages/chat/user-message-content.ts
@@ -1,6 +1,7 @@
 // Control UI chat module implements user message content behavior.
 import type { MediaKind } from "@openclaw/media-core/constants";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import { hasVideoMediaFileExtension } from "../../lib/media-file-extension.ts";
 import { getChatAttachmentPreviewUrl } from "./attachment-payload-store.ts";
 
 type UserChatMessageContentBlock = {
@@ -56,15 +57,16 @@ export function buildUserChatMessageContentBlocks(
       });
       continue;
     }
+    const normalizedMimeType = attachment.mimeType.trim().toLowerCase();
+    const isVideo =
+      normalizedMimeType.startsWith("video/") ||
+      ((normalizedMimeType === "" || normalizedMimeType === "application/octet-stream") &&
+        hasVideoMediaFileExtension(attachment.fileName ?? ""));
     blocks.push({
       type: "attachment",
       attachment: {
         url: previewUrl,
-        kind: attachment.mimeType.startsWith("audio/")
-          ? "audio"
-          : attachment.mimeType.startsWith("video/")
-            ? "video"
-            : "document",
+        kind: attachment.mimeType.startsWith("audio/") ? "audio" : isVideo ? "video" : "document",
         label: attachment.fileName?.trim() || "Attached file",
         mimeType: attachment.mimeType,
       },

--- a/ui/src/pages/chat/user-message-content.ts
+++ b/ui/src/pages/chat/user-message-content.ts
@@ -10,7 +10,7 @@ type UserChatMessageContentBlock = {
   source?: unknown;
   attachment?: {
     url: string;
-    kind: Extract<MediaKind, "audio" | "document">;
+    kind: Extract<MediaKind, "audio" | "video" | "document">;
     label: string;
     mimeType?: string;
   };
@@ -60,7 +60,11 @@ export function buildUserChatMessageContentBlocks(
       type: "attachment",
       attachment: {
         url: previewUrl,
-        kind: attachment.mimeType.startsWith("audio/") ? "audio" : "document",
+        kind: attachment.mimeType.startsWith("audio/")
+          ? "audio"
+          : attachment.mimeType.startsWith("video/")
+            ? "video"
+            : "document",
         label: attachment.fileName?.trim() || "Attached file",
         mimeType: attachment.mimeType,
       },

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1094,17 +1094,15 @@ openclaw-chat-page {
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  width: min(100%, 390px);
 }
 
-.chat-assistant-attachment-card--audio audio,
-.chat-assistant-attachment-card--video video {
-  width: min(100%, 360px);
-  max-width: 100%;
+.chat-assistant-attachment-card--audio {
+  gap: 8px;
 }
 
-.chat-assistant-attachment-card--video video {
-  border-radius: var(--radius-sm);
-  background: #000;
+.chat-assistant-attachment-card--video {
+  gap: 0;
 }
 
 .chat-assistant-attachment-card__header {
@@ -1121,6 +1119,230 @@ openclaw-chat-page {
   font-size: 13px;
   text-decoration: none;
   word-break: break-word;
+}
+
+.chat-assistant-attachment-card__title {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-assistant-attachment-card__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: none;
+}
+
+.chat-assistant-attachment-card__download {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex: none;
+  border-radius: 999px;
+  color: var(--muted);
+  border: 1px solid transparent;
+  transition:
+    color 120ms ease,
+    background 120ms ease,
+    border-color 120ms ease;
+}
+
+.chat-assistant-attachment-card__download:hover {
+  color: var(--text);
+  border-color: var(--border);
+  background: color-mix(in srgb, var(--bg) 70%, transparent);
+}
+
+.chat-assistant-attachment-card__download:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.chat-assistant-attachment-card__download svg {
+  width: 15px;
+  height: 15px;
+}
+
+.chat-audio-player {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  padding: 9px 10px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+}
+
+.chat-audio-player:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.chat-audio-player__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  flex: none;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
+  border-radius: 999px;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, var(--card));
+  cursor: pointer;
+  transition:
+    transform 120ms ease,
+    background 120ms ease;
+}
+
+.chat-audio-player__toggle:hover {
+  transform: scale(1.04);
+  background: color-mix(in srgb, var(--accent) 18%, var(--card));
+}
+
+.chat-audio-player__toggle:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.chat-audio-player__toggle svg {
+  width: 16px;
+  height: 16px;
+}
+
+.chat-audio-player__timeline {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  flex: 1;
+}
+
+.chat-audio-player__seek {
+  width: 100%;
+  height: 4px;
+  margin: 0;
+  border-radius: 999px;
+  appearance: none;
+  background: linear-gradient(
+    to right,
+    var(--accent) 0 var(--chat-audio-progress),
+    color-mix(in srgb, var(--muted) 48%, transparent) var(--chat-audio-progress)
+      var(--chat-audio-buffered),
+    color-mix(in srgb, var(--border) 72%, transparent) var(--chat-audio-buffered) 100%
+  );
+  cursor: pointer;
+}
+
+.chat-audio-player__seek::-webkit-slider-thumb {
+  width: 12px;
+  height: 12px;
+  appearance: none;
+  border: 2px solid var(--card);
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
+.chat-audio-player__seek::-moz-range-thumb {
+  width: 9px;
+  height: 9px;
+  border: 2px solid var(--card);
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
+.chat-audio-player__seek:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 4px;
+}
+
+.chat-audio-player__time {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.chat-audio-player__media {
+  display: none;
+}
+
+.chat-assistant-video-frame {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  min-height: 150px;
+  max-height: 200px;
+  overflow: hidden;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--muted) 10%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+}
+
+.chat-assistant-video-frame video {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  max-height: 200px;
+  object-fit: contain;
+  opacity: 0;
+  background: color-mix(in srgb, var(--bg) 92%, var(--text));
+  transition: opacity 120ms ease;
+}
+
+.chat-assistant-attachment-card--video[data-metadata-loaded] .chat-assistant-video-frame video {
+  opacity: 1;
+}
+
+.chat-assistant-video-frame__placeholder {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: color-mix(in srgb, var(--muted) 55%, transparent);
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--card) 78%, transparent), transparent),
+    color-mix(in srgb, var(--bg) 84%, var(--card));
+}
+
+.chat-assistant-video-frame__placeholder svg {
+  width: 30px;
+  height: 30px;
+}
+
+.chat-assistant-attachment-card--video[data-metadata-loaded]
+  .chat-assistant-video-frame__placeholder {
+  display: none;
+}
+
+.chat-assistant-video-fallback {
+  display: none;
+  gap: 8px;
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+}
+
+.chat-assistant-attachment-card--video[data-unplayable] .chat-assistant-video-frame {
+  display: none;
+}
+
+.chat-assistant-attachment-card--video[data-unplayable] .chat-assistant-video-fallback {
+  display: grid;
 }
 
 .chat-assistant-attachment-card__reason {


### PR DESCRIPTION
## What Problem This Solves

Chat audio and video attachments currently fall back to generic attachment rendering, which makes playback less useful and less resilient inside the Control UI conversation. Part of #115590.

## Why This Change Was Made

This adds first-class audio and video cards with coordinated playback, stable media-source recovery, safe download fallbacks, attachment lifecycle integration, and focused regression coverage. The implementation keeps media behavior inside the existing chat attachment boundary and preserves authenticated same-origin Gateway routes for local attachments.

## User Impact

Users can play chat audio and video inline with purpose-built controls, seek and resume audio reliably, see voice-note and unavailable-media states clearly, and download the original attachment when playback fails.

## Evidence

- Exact head: `42de767e31e96e56784a52edbdee777a5e61328b`
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-audio-player.test.ts ui/src/pages/chat/components/chat-media-source.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/user-message-content.test.ts` — 4 files, 161 tests passed after the conflict rebase.
- `pnpm test ui/src/e2e/chat-flow.media-files.e2e.test.ts` plus `pnpm ui:build` on Blacksmith Testbox `tbx_01kypgwqt4tj4qrqqxdg7c4yvc` — 13 tests passed; 676 precompressed sidecars and Control UI performance budgets passed: https://github.com/openclaw/openclaw/actions/runs/30436903921
- `pnpm test ui/src/pages/chat/chat-responsive.browser.test.ts` on Blacksmith Testbox `tbx_01kypfk1g8f5jy7qts46vjvhex` — 71 tests passed: https://github.com/openclaw/openclaw/actions/runs/30435379182
- Three bounded runs of `node scripts/run-vitest.mjs test/scripts/run-oxlint.test.ts` — 33/33 passed each.
- Includes flaky-test hardening for the run-oxlint shard-kill test (2s → 15s waits) that blocked two CI attempts; `OPENCLAW_OXLINT_SHARD_TIMEOUT_MS` remains 250 ms, so product behavior is unchanged.
- Conflict resolution preserved current-main localized attachment status strings and authenticated local-media availability behavior while retaining the new player-card DOM.
- CI follow-ups keep player helpers module-private under the unused-export gate and update encoded video and hidden audio assertions to match the intentional metadata-loading placeholders.
