### PR TITLE
fix(cron): initialize detached hook run sessions

### DIFF
--- a/src/cron/isolated-agent.session-identity.test.ts
+++ b/src/cron/isolated-agent.session-identity.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as modelThinkingDefault from "../agents/model-thinking-default.js";
+import { SessionManager } from "../agents/sessions/index.js";
 import { upsertSessionEntry } from "../config/sessions/session-accessor.js";
 import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
 import {
@@ -76,6 +77,48 @@ function lastEmbeddedAgentCall(): {
     workspaceDir?: string;
     sessionFile?: string;
   };
+}
+
+function mockEmbeddedTranscriptWrite(
+  storePath: string,
+  content: string,
+  resultMeta?: {
+    sessionId?: string;
+    sessionFile?: string;
+    compactionCount?: number;
+    compactionTokensAfter?: number;
+  },
+): void {
+  runEmbeddedAgentMock.mockImplementationOnce(async (input: Record<string, unknown>) => {
+    const agentId = typeof input.agentId === "string" ? input.agentId : "main";
+    const sessionId = typeof input.sessionId === "string" ? input.sessionId : "";
+    const sessionKey = typeof input.sessionKey === "string" ? input.sessionKey : "";
+    const workspaceDir =
+      typeof input.workspaceDir === "string" ? input.workspaceDir : process.cwd();
+    const manager = SessionManager.open(
+      { agentId, sessionId, sessionKey, storePath },
+      workspaceDir,
+    );
+    manager.appendMessage({ role: "user", content, timestamp: Date.now() });
+    return {
+      payloads: [{ text: "ok" }],
+      meta: {
+        durationMs: 5,
+        agentMeta: {
+          sessionId: resultMeta?.sessionId ?? sessionId,
+          ...(resultMeta?.sessionFile ? { sessionFile: resultMeta.sessionFile } : {}),
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          ...(resultMeta?.compactionCount !== undefined
+            ? { compactionCount: resultMeta.compactionCount }
+            : {}),
+          ...(resultMeta?.compactionTokensAfter !== undefined
+            ? { compactionTokensAfter: resultMeta.compactionTokensAfter }
+            : {}),
+        },
+      },
+    };
+  });
 }
 
 describe("runCronIsolatedAgentTurn session identity", () => {
@@ -178,6 +221,32 @@ describe("runCronIsolatedAgentTurn session identity", () => {
     });
   });
 
+  it.each([
+    ["cron", "cron:job-1"],
+    ["hook", "hook:webhook:request-1"],
+  ])("initializes the exact %s run session before transcript writes", async (_name, sessionKey) => {
+    await useRealCronSessionState();
+    await withTempHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      mockEmbeddedTranscriptWrite(storePath, `${sessionKey} transcript`);
+
+      const { res } = await runCronTurn(home, {
+        jobPayload: {
+          kind: "agentTurn",
+          message: "persist this turn",
+          ...(sessionKey.startsWith("hook:") ? { externalContentSource: "webhook" as const } : {}),
+        },
+        message: "persist this turn",
+        mockTexts: null,
+        sessionKey,
+        storePath,
+      });
+
+      expect(res.status, res.status === "error" ? res.error : undefined).toBe("ok");
+      expect(res.sessionKey).toMatch(/^agent:main:cron:job-1:run:/);
+    });
+  });
+
   it("persists rotated transcript identity for current-bound cron runs", async () => {
     await withTempHome(async (home) => {
       const deps = makeDeps();
@@ -194,20 +263,6 @@ describe("runCronIsolatedAgentTurn session identity", () => {
           systemSent: true,
         },
       });
-      runEmbeddedAgentMock.mockResolvedValueOnce({
-        payloads: [{ text: "ok" }],
-        meta: {
-          durationMs: 5,
-          agentMeta: {
-            sessionId: "bound-session-rotated",
-            sessionFile: rotatedSessionFile,
-            provider: "anthropic",
-            model: "claude-opus-4-6",
-            compactionCount: 1,
-            compactionTokensAfter: 42,
-          },
-        },
-      });
       const currentBoundJob = normalizeCronJobCreate(
         {
           ...makeJob(DEFAULT_AGENT_TURN_PAYLOAD),
@@ -217,6 +272,12 @@ describe("runCronIsolatedAgentTurn session identity", () => {
         { sessionContext: { sessionKey: boundSessionKey } },
       ) as CronJob;
       const executionSessionKey = `agent:main:cron:${currentBoundJob.id}`;
+      mockEmbeddedTranscriptWrite(storePath, "current-bound transcript", {
+        sessionId: "bound-session-rotated",
+        sessionFile: rotatedSessionFile,
+        compactionCount: 1,
+        compactionTokensAfter: 42,
+      });
 
       const res = await runCronIsolatedAgentTurn({
         cfg: makeCfg(home, storePath),

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -248,10 +248,10 @@ export async function prepareCronRunContext(params: {
   }
   const runSessionId = cronSession.sessionEntry.sessionId;
   const currentRunSessionId = () => cronSession.sessionEntry.sessionId ?? runSessionId;
-  const runSessionKey =
-    usesDetachedRunSession || baseSessionKey.startsWith("cron:")
-      ? `${agentSessionKey}:run:${runSessionId}`
-      : agentSessionKey;
+  const usesExactRunSession = usesDetachedRunSession || baseSessionKey.startsWith("cron:");
+  const runSessionKey = usesExactRunSession
+    ? `${agentSessionKey}:run:${runSessionId}`
+    : agentSessionKey;
   const persistCronSessionRow = async ({
     storePath,
     sessionKey,
@@ -663,7 +663,7 @@ export async function prepareCronRunContext(params: {
         ? cronSession.sessionEntry.authProfileOverrideSource
         : undefined,
     };
-    const runContinuationSession = baseSessionKey.startsWith("cron:")
+    const runContinuationSession = usesExactRunSession
       ? createCronRunContinuationSession({
           cronSession,
           runSessionKey,


### PR DESCRIPTION
Related: #100486

## What Problem This Solves

Fixes an issue where detached hook and current-bound cron runs could fail before producing a reply with `Session transcript header was not persisted`.

## Why This Change Was Made

The isolated-run owner already selected an exact per-run session key for detached hook runs, but it initialized the matching continuation row only for `cron:` source keys. This change uses the same exact-run predicate for both key selection and row initialization, so transcript writes always target a persisted SQLite session row.

The repair is intentionally separate from #100486: that PR owns webhook delivery normalization, while this is a current-main cron/session lifecycle defect that also affects current-bound detached runs.

## User Impact

Webhook-triggered agent runs and other detached isolated runs can persist their transcript and complete instead of failing at the first write.

## Evidence

Exact head: `2cf6d8bf40a3d18886113ae8bbbcc486e86844ce`

- Pre-fix reproduction: ordinary cron transcript writes passed; a hook run failed with `Session transcript header was not persisted`.
- `node scripts/run-vitest.mjs src/cron/isolated-agent.session-identity.test.ts src/cron/isolated-agent/run-session-state.test.ts src/cron/isolated-agent.hook-content-wrapping.test.ts src/cron/isolated-agent/run.current-context.test.ts`
  - 4 files, 35 tests passed.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh autoreview found no accepted or actionable findings (confidence 0.96).
