### PR TITLE
fix(qa): keep live commands on runnable scenario lanes

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -493,37 +493,17 @@ Required env when `--credential-source env`:
 - `OPENCLAW_QA_TELEGRAM_DRIVER_BOT_TOKEN`
 - `OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN`
 
-The `release` profile selects the maintained Telegram YAML scenarios; `all`
-adds opt-in session, usage, reply-chain, and streaming stress checks. Explicit
-`--scenario` values override the profile.
+The `release` profile selects taxonomy-owned Telegram scenarios that declare
+the channel, use the flow execution kind, and match the requested provider and
+model lane. Explicit `--scenario` values narrow that same selection instead of
+bypassing its constraints. Use `pnpm openclaw qa telegram --list-scenarios
+--provider-mode mock-openai` to print the current selection with regression
+refs. Supplying `--model` applies the same model constraint to listing and
+execution.
 
-- `channel-canary`
-- `channel-mention-gating`
-- `telegram-help-command`
-- `telegram-commands-command`
-- `telegram-tools-compact-command`
-- `telegram-whoami-command`
-- `telegram-status-command`
-- `telegram-repeated-command-authorization`
-- `telegram-other-bot-command-gating`
-- `telegram-context-command`
-- `telegram-current-session-status-tool`
-- `telegram-tool-only-usage-footer`
-- `telegram-reply-chain-exact-marker`
-- `telegram-stream-final-single-message`
-- `telegram-long-final-reuses-preview`
-- `telegram-long-final-three-chunks`
-
-The `release` profile always covers canary, mention gating, native command
-replies, command addressing, and bot-to-bot group replies. `mock-openai`
-also includes the deterministic long-final preview check.
-`telegram-current-session-status-tool` and
-`telegram-tool-only-usage-footer` remain opt-in: the former is only stable
-when threaded directly after canary, and the latter is a real-Telegram proof
-of the `/usage` footer on tool-only replies. Use `pnpm openclaw qa telegram
---list-scenarios --provider-mode mock-openai` to print the current
-default/optional split with regression refs. Use `--profile all` for every
-Telegram live-adapter scenario.
+`telegram-startup-getme-live` is a catalog script producer, not a live-adapter
+flow. Run it through `qa suite --scenario telegram-startup-getme-live`; the
+dedicated `qa telegram` command and `--list-scenarios` intentionally omit it.
 
 Output artifacts:
 
@@ -1007,11 +987,10 @@ WhatsApp YAML scenarios (`qa/scenarios/channels/whatsapp-*.yaml`):
 - Status reactions: `whatsapp-status-reactions`,
   `whatsapp-status-reaction-lifecycle`.
 
-The catalog currently contains 52 scenarios. The `live-frontier` default lane
-is kept small at 8 scenarios for fast smoke coverage. The `mock-openai`
-default lane runs 39 scenarios deterministically through the real WhatsApp
-transport while mocking only model output; approval scenarios and a few
-heavier/blocking checks remain explicit by scenario id.
+WhatsApp defaults are derived from the selected taxonomy profile and lane
+constraints. `mock-openai` runs eligible scenarios deterministically through
+the real WhatsApp transport while mocking only model output; `live-frontier`
+excludes scenarios whose provider or model contract requires the mock lane.
 
 The WhatsApp QA driver observes structured live events (`text`, `media`,
 `location`, `reaction`, and `poll`) and can actively send media, polls,

--- a/extensions/qa-lab/src/live-transports/discord/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/discord/scenario-selection.ts
@@ -3,6 +3,7 @@ import { resolveLiveTransportQaScenarioIds } from "../shared/scenario-selection.
 
 export function resolveDiscordQaScenarioIds(params: {
   profile?: string;
+  primaryModel?: string;
   providerMode?: QaProviderModeInput;
   scenarioIds?: readonly string[];
 }) {

--- a/extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-suite.runtime.test.ts
@@ -27,7 +27,8 @@ describe("live transport suite runtime", () => {
         credentialRole: " ci ",
         sutAccountId: "slack-sut",
       },
-      selectScenarioIds: ({ providerMode, scenarioIds }) => {
+      selectScenarioIds: ({ primaryModel, providerMode, scenarioIds }) => {
+        expect(primaryModel).toBe("openai/gpt-5.5");
         expect(providerMode).toBe("live-frontier");
         expect(scenarioIds).toBeUndefined();
         return ["slack-canary"];

--- a/extensions/qa-lab/src/live-transports/shared/scenario-selection.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/scenario-selection.test.ts
@@ -1,27 +1,91 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { resolveExecutionSelection, resolveProfileScenarios } = vi.hoisted(() => ({
+  resolveExecutionSelection: vi.fn(),
+  resolveProfileScenarios: vi.fn(),
+}));
+
+vi.mock("../../profile-planning.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../profile-planning.js")>();
+  return {
+    ...actual,
+    resolveQaProfileScenarios: (...args: Parameters<typeof actual.resolveQaProfileScenarios>) => {
+      resolveProfileScenarios(...args);
+      return actual.resolveQaProfileScenarios(...args);
+    },
+    resolveQaRunProfileExecutionSelection: (
+      ...args: Parameters<typeof actual.resolveQaRunProfileExecutionSelection>
+    ) => {
+      resolveExecutionSelection(...args);
+      return actual.resolveQaRunProfileExecutionSelection(...args);
+    },
+  };
+});
+
 import { scenarioDeclaresQaChannel } from "../../profile-planning.js";
 import { readQaScenarioPack } from "../../scenario-catalog.js";
-import { resolveCatalogLiveTransportQaScenarioIds } from "./scenario-selection.js";
+import { resolveDiscordQaScenarioIds } from "../discord/scenario-selection.js";
+import { resolveSlackQaScenarioIds } from "../slack/scenario-selection.js";
+import {
+  listTelegramQaScenarios,
+  resolveTelegramQaScenarioIds,
+} from "../telegram/scenario-selection.js";
+import { resolveWhatsAppQaScenarioIds } from "../whatsapp/scenario-selection.js";
+import {
+  resolveCatalogLiveTransportQaScenarioIds,
+  resolveLiveTransportQaScenarioIds,
+} from "./scenario-selection.js";
 
 const MOCK_LANE = {
   providerMode: "mock-openai" as const,
   primaryModel: "mock-openai/gpt-5.6-luna",
 };
 
-describe("catalog live transport QA scenario selection", () => {
-  it.each(["matrix", "telegram"] as const)(
-    "selects declared %s scenarios and preserves an explicit subset",
-    (channelId) => {
-      const scenarioIds = resolveCatalogLiveTransportQaScenarioIds({
-        ...MOCK_LANE,
-        channelId,
-      });
-      const explicitScenarioIds = scenarioIds.slice(0, 2).toReversed();
+describe("live transport QA scenario selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      channelId: "matrix",
+      select: (scenarioIds?: readonly string[]) =>
+        resolveCatalogLiveTransportQaScenarioIds({
+          ...MOCK_LANE,
+          channelId: "matrix",
+          scenarioIds,
+        }),
+    },
+    {
+      channelId: "telegram",
+      select: (scenarioIds?: readonly string[]) =>
+        resolveTelegramQaScenarioIds({ ...MOCK_LANE, scenarioIds }),
+    },
+    {
+      channelId: "discord",
+      select: (scenarioIds?: readonly string[]) =>
+        resolveDiscordQaScenarioIds({ ...MOCK_LANE, scenarioIds }),
+    },
+    {
+      channelId: "slack",
+      select: (scenarioIds?: readonly string[]) =>
+        resolveSlackQaScenarioIds({ ...MOCK_LANE, scenarioIds }),
+    },
+    {
+      channelId: "whatsapp",
+      select: (scenarioIds?: readonly string[]) =>
+        resolveWhatsAppQaScenarioIds({ ...MOCK_LANE, scenarioIds }),
+    },
+  ] as const)(
+    "keeps explicit and implicit singleton eligibility aligned for $channelId",
+    ({ channelId, select }) => {
+      const scenarioIds = select();
+      const singletonScenarioIds = scenarioIds.slice(0, 1);
       const scenarioById = new Map(
         readQaScenarioPack().scenarios.map((scenario) => [scenario.id, scenario] as const),
       );
 
-      expect(scenarioIds.length).toBeGreaterThan(1);
+      expect(singletonScenarioIds).toHaveLength(1);
       expect(
         scenarioIds.every((scenarioId) => {
           const scenario = scenarioById.get(scenarioId);
@@ -30,15 +94,27 @@ describe("catalog live transport QA scenario selection", () => {
           );
         }),
       ).toBe(true);
-      expect(
-        resolveCatalogLiveTransportQaScenarioIds({
-          ...MOCK_LANE,
-          channelId,
-          scenarioIds: explicitScenarioIds,
-        }),
-      ).toEqual(explicitScenarioIds);
+      expect(select(singletonScenarioIds)).toEqual(singletonScenarioIds);
     },
   );
+
+  it("uses the exact requested model for profile selection and listing", () => {
+    const primaryModel = "openai/custom-selection-model";
+
+    resolveLiveTransportQaScenarioIds({
+      channelId: "telegram",
+      primaryModel,
+      providerMode: "mock-openai",
+    });
+    expect(resolveProfileScenarios).toHaveBeenLastCalledWith(
+      expect.objectContaining({ executionKind: "flow", primaryModel }),
+    );
+
+    listTelegramQaScenarios({ primaryModel, providerMode: "mock-openai" });
+    expect(resolveExecutionSelection).toHaveBeenLastCalledWith(
+      expect.objectContaining({ executionKind: "flow", primaryModel }),
+    );
+  });
 
   it.each([
     { channelId: "matrix", scenarioId: "whatsapp-whoami-command", mismatch: "channel=whatsapp" },

--- a/extensions/qa-lab/src/live-transports/shared/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/shared/scenario-selection.ts
@@ -42,14 +42,17 @@ export function resolveCatalogLiveTransportQaScenarioIds(params: {
 export function resolveLiveTransportQaScenarioIds(params: {
   channelId: string;
   profile?: string;
+  primaryModel?: string;
   providerMode: QaProviderModeInput;
   scenarioIds?: readonly string[];
 }) {
   return resolveQaProfileScenarios({
     profile: params.profile?.trim() || "release",
     providerMode: params.providerMode,
+    primaryModel: params.primaryModel,
     channelDriver: "live",
     channel: params.channelId,
+    executionKind: "flow",
     requireDeclaredChannel: true,
     scenarioIds: params.scenarioIds,
   }).scenarios.map((scenario) => scenario.id);
@@ -57,19 +60,22 @@ export function resolveLiveTransportQaScenarioIds(params: {
 
 export function listLiveTransportQaScenarios(params: {
   channelId: string;
+  primaryModel?: string;
   providerMode: QaProviderModeInput;
 }) {
   const defaultIds = new Set(resolveLiveTransportQaScenarioIds(params));
   const providerMode = normalizeQaProviderMode(params.providerMode);
+  const primaryModel = params.primaryModel?.trim() || defaultQaModelForMode(providerMode);
   const eligibleScenarios = readQaScenarioPack().scenarios.filter((scenario) =>
     scenarioDeclaresQaChannel(scenario, params.channelId),
   );
   const scenarios = resolveQaRunProfileExecutionSelection({
     scenarios: eligibleScenarios,
     providerMode,
-    primaryModel: defaultQaModelForMode(providerMode),
+    primaryModel,
     channelDriver: "live",
     channel: params.channelId,
+    executionKind: "flow",
   }).selectedScenarios;
   return scenarios.map((scenario) => {
     return {

--- a/extensions/qa-lab/src/live-transports/slack/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/slack/scenario-selection.ts
@@ -3,6 +3,7 @@ import { resolveLiveTransportQaScenarioIds } from "../shared/scenario-selection.
 
 export function resolveSlackQaScenarioIds(params: {
   profile?: string;
+  primaryModel?: string;
   providerMode?: QaProviderModeInput;
   scenarioIds?: readonly string[];
 }) {

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
@@ -1,14 +1,20 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   createTelegramQaTransportAdapter: vi.fn(),
   listTelegramQaScenarios: vi.fn(),
   printLiveTransportQaArtifacts: vi.fn(),
   resolveTelegramQaRunOptions: vi.fn(
-    (options: { allowFailures?: boolean; providerMode?: string; repoRoot: string }) => ({
+    (options: {
+      allowFailures?: boolean;
+      listScenarios?: boolean;
+      primaryModel?: string;
+      providerMode?: string;
+      repoRoot: string;
+    }) => ({
       ...options,
       allowFailures: options.allowFailures ?? false,
       listScenarios: false,
@@ -39,9 +45,12 @@ vi.mock("./scenario-selection.js", () => ({
   resolveTelegramQaScenarioIds: mocks.resolveTelegramQaScenarioIds,
 }));
 
-import { runQaTelegramSuite } from "./cli.runtime.js";
+import { runQaTelegramCommand, runQaTelegramSuite } from "./cli.runtime.js";
+
+const SUT_COMMAND_ENV = "OPENCLAW_QA_TELEGRAM_SUT_OPENCLAW_COMMAND";
 
 describe("Telegram live QA scenario gate", () => {
+  const originalSutCommand = process.env[SUT_COMMAND_ENV];
   let previousExitCode: typeof process.exitCode;
   let tempRoot: string;
   let summaryPath: string;
@@ -64,6 +73,7 @@ describe("Telegram live QA scenario gate", () => {
     previousExitCode = process.exitCode;
     process.exitCode = undefined;
     vi.clearAllMocks();
+    delete process.env[SUT_COMMAND_ENV];
     tempRoot = mkdtempSync(path.join(tmpdir(), "openclaw-qa-telegram-gate-"));
     summaryPath = path.join(tempRoot, "qa-suite-summary.json");
     mocks.resolveTelegramQaScenarioIds.mockReturnValue(["channel-canary"]);
@@ -76,6 +86,14 @@ describe("Telegram live QA scenario gate", () => {
   afterEach(() => {
     process.exitCode = previousExitCode;
     rmSync(tempRoot, { force: true, recursive: true });
+  });
+
+  afterAll(() => {
+    if (originalSutCommand === undefined) {
+      delete process.env[SUT_COMMAND_ENV];
+    } else {
+      process.env[SUT_COMMAND_ENV] = originalSutCommand;
+    }
   });
 
   it.each(["fail", "skip", "skipped", "timeout"])(
@@ -160,6 +178,48 @@ describe("Telegram live QA scenario gate", () => {
       expect.objectContaining({
         scenarioIds: expect.not.arrayContaining(["telegram-startup-getme-live"]),
       }),
+    );
+  });
+
+  it("lists scenarios against the exact requested model", async () => {
+    mocks.resolveTelegramQaRunOptions.mockReturnValueOnce({
+      allowFailures: false,
+      listScenarios: true,
+      primaryModel: "openai/custom-list-model",
+      providerMode: "live-frontier",
+      repoRoot: process.cwd(),
+    });
+    mocks.listTelegramQaScenarios.mockReturnValue([]);
+
+    await runQaTelegramSuite({
+      listScenarios: true,
+      primaryModel: "openai/custom-list-model",
+      providerMode: "live-frontier",
+      repoRoot: process.cwd(),
+    });
+
+    expect(mocks.listTelegramQaScenarios).toHaveBeenCalledWith({
+      primaryModel: "openai/custom-list-model",
+      providerMode: "live-frontier",
+    });
+  });
+
+  it("selects scenarios against the exact requested model before suite startup", async () => {
+    await runQaTelegramCommand({
+      allowFailures: true,
+      primaryModel: "openai/custom-selection-model",
+      providerMode: "live-frontier",
+      repoRoot: process.cwd(),
+    });
+
+    expect(mocks.resolveTelegramQaScenarioIds).toHaveBeenCalledWith({
+      profile: undefined,
+      primaryModel: "openai/custom-selection-model",
+      providerMode: "live-frontier",
+      scenarioIds: undefined,
+    });
+    expect(mocks.runQaFlowSuiteFromRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryModel: "openai/custom-selection-model" }),
     );
   });
 });

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
@@ -146,7 +146,10 @@ type TelegramQaSuiteOptions = LiveTransportQaCommandOptions & {
 export async function runQaTelegramSuite(opts: TelegramQaSuiteOptions) {
   const runOptions = resolveTelegramQaRunOptions(opts);
   if (runOptions.listScenarios) {
-    for (const scenario of listTelegramQaScenarios(runOptions.providerMode)) {
+    for (const scenario of listTelegramQaScenarios({
+      primaryModel: runOptions.primaryModel,
+      providerMode: runOptions.providerMode,
+    })) {
       const defaultLabel = scenario.defaultEnabled ? "default" : "optional";
       const refs =
         scenario.regressionRefs.length > 0 ? ` refs=${scenario.regressionRefs.join(",")}` : "";
@@ -160,6 +163,7 @@ export async function runQaTelegramSuite(opts: TelegramQaSuiteOptions) {
     ? [...opts.resolvedScenarioIds]
     : resolveTelegramQaScenarioIds({
         profile: opts.profile,
+        primaryModel: runOptions.primaryModel,
         providerMode: runOptions.providerMode,
         scenarioIds: runOptions.scenarioIds,
       });
@@ -213,6 +217,7 @@ export async function runQaTelegramCommand(opts: LiveTransportQaCommandOptions) 
   }
   const resolvedScenarioIds = resolveTelegramQaScenarioIds({
     profile: opts.profile,
+    primaryModel: runOptions.primaryModel,
     providerMode: runOptions.providerMode,
     scenarioIds: runOptions.scenarioIds,
   });

--- a/extensions/qa-lab/src/live-transports/telegram/profiles.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/profiles.test.ts
@@ -3,11 +3,26 @@ import { readQaScenarioPack } from "../../scenario-catalog.js";
 import { listTelegramQaScenarios, resolveTelegramQaScenarioIds } from "./scenario-selection.js";
 
 describe("Telegram QA profiles", () => {
-  it("derives release membership from taxonomy and provider eligibility", () => {
+  it.each(["mock-openai", "live-frontier"] as const)(
+    "keeps the default %s command on flow scenarios",
+    (providerMode) => {
+      const scenarioIds = resolveTelegramQaScenarioIds({ providerMode });
+
+      expect(scenarioIds).toContain("telegram-other-bot-command-gating");
+      expect(scenarioIds).not.toContain("telegram-startup-getme-live");
+      expect(() =>
+        resolveTelegramQaScenarioIds({
+          providerMode,
+          scenarioIds: ["telegram-startup-getme-live"],
+        }),
+      ).toThrow("execution.kind=flow");
+    },
+  );
+
+  it("derives provider-specific release membership from taxonomy", () => {
     const live = resolveTelegramQaScenarioIds({ providerMode: "live-frontier" });
     const mock = resolveTelegramQaScenarioIds({ providerMode: "mock-openai" });
 
-    expect(live).toContain("telegram-other-bot-command-gating");
     expect(live).not.toContain("telegram-long-final-reuses-preview");
     expect(mock).toContain("telegram-long-final-reuses-preview");
     expect(mock).toContain("telegram-assistant-transcript-role-boundary");
@@ -38,7 +53,7 @@ describe("Telegram QA profiles", () => {
         providerMode: "live-frontier",
         scenarioIds: ["telegram-startup-getme-live"],
       }),
-    ).toThrow("Telegram QA flow runner cannot execute non-flow scenario(s)");
+    ).toThrow("execution.kind=flow");
   });
 
   it("rejects unknown profiles and channel-ineligible explicit scenarios", () => {
@@ -54,7 +69,7 @@ describe("Telegram QA profiles", () => {
   });
 
   it("lists catalog-eligible scenarios with provider-specific release defaults", () => {
-    const scenarios = listTelegramQaScenarios("mock-openai");
+    const scenarios = listTelegramQaScenarios({ providerMode: "mock-openai" });
     const defaultIds = new Set(resolveTelegramQaScenarioIds({ providerMode: "mock-openai" }));
     const scenarioById = new Map(
       readQaScenarioPack().scenarios.map((scenario) => [scenario.id, scenario] as const),
@@ -70,7 +85,7 @@ describe("Telegram QA profiles", () => {
     expect(
       scenarios.find(({ id }) => id === "telegram-long-final-three-chunks")?.defaultEnabled,
     ).toBe(true);
-    expect(scenarios.some(({ id }) => id === "telegram-startup-getme-live")).toBe(false);
+    expect(scenarios.map(({ id }) => id)).not.toContain("telegram-startup-getme-live");
     expect(scenarioById.get("telegram-startup-getme-live")?.execution.kind).toBe("script");
   });
 });

--- a/extensions/qa-lab/src/live-transports/telegram/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/scenario-selection.ts
@@ -1,6 +1,5 @@
 import type { QaProviderModeInput } from "../../model-selection.js";
 import {
-  resolveCatalogLiveTransportQaScenarioIds,
   listLiveTransportQaScenarios,
   resolveLiveTransportQaScenarioIds,
 } from "../shared/scenario-selection.js";
@@ -9,41 +8,19 @@ const TELEGRAM_QA_CHANNEL_ID = "telegram";
 
 export function resolveTelegramQaScenarioIds(params: {
   profile?: string;
+  primaryModel?: string;
   providerMode: QaProviderModeInput;
   scenarioIds?: readonly string[];
 }): string[] {
-  const selectedIds = resolveLiveTransportQaScenarioIds({
+  return resolveLiveTransportQaScenarioIds({ channelId: TELEGRAM_QA_CHANNEL_ID, ...params });
+}
+
+export function listTelegramQaScenarios(params: {
+  primaryModel?: string;
+  providerMode: QaProviderModeInput;
+}) {
+  return listLiveTransportQaScenarios({
     channelId: TELEGRAM_QA_CHANNEL_ID,
     ...params,
   });
-  const flowIds = new Set(
-    resolveCatalogLiveTransportQaScenarioIds({
-      channelId: TELEGRAM_QA_CHANNEL_ID,
-      providerMode: params.providerMode,
-    }),
-  );
-  const unsupportedIds = selectedIds.filter((scenarioId) => !flowIds.has(scenarioId));
-  if (params.scenarioIds?.length && unsupportedIds.length > 0) {
-    throw new Error(
-      `Telegram QA flow runner cannot execute non-flow scenario(s): ${unsupportedIds.join(", ")}`,
-    );
-  }
-  const scenarioIds = selectedIds.filter((scenarioId) => flowIds.has(scenarioId));
-  if (scenarioIds.length === 0) {
-    throw new Error("Telegram QA flow selection resolved no scenarios.");
-  }
-  return scenarioIds;
-}
-
-export function listTelegramQaScenarios(providerMode: QaProviderModeInput) {
-  const flowIds = new Set(
-    resolveCatalogLiveTransportQaScenarioIds({
-      channelId: TELEGRAM_QA_CHANNEL_ID,
-      providerMode,
-    }),
-  );
-  return listLiveTransportQaScenarios({
-    channelId: TELEGRAM_QA_CHANNEL_ID,
-    providerMode,
-  }).filter((scenario) => flowIds.has(scenario.id));
 }

--- a/extensions/qa-lab/src/live-transports/whatsapp/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/scenario-selection.ts
@@ -3,6 +3,7 @@ import { resolveLiveTransportQaScenarioIds } from "../shared/scenario-selection.
 
 export function resolveWhatsAppQaScenarioIds(params: {
   profile?: string;
+  primaryModel?: string;
   providerMode: QaProviderModeInput;
   scenarioIds?: readonly string[];
 }) {

--- a/extensions/qa-lab/src/profile-planning.ts
+++ b/extensions/qa-lab/src/profile-planning.ts
@@ -121,12 +121,16 @@ export function resolveQaRunProfileExecutionSelection(params: {
   channel?: string | null;
   defaultChannel?: string;
   claudeCliAuthMode?: QaCliBackendAuthMode;
+  executionKind?: QaSeedScenarioWithSource["execution"]["kind"];
   supportsChannel?: (channel: string) => boolean;
 }): QaRunProfileExecutionSelection {
   const selectedScenarios: QaSeedScenarioWithSource[] = [];
   const excludedScenarios: QaRunProfileExecutionSelection["excludedScenarios"] = [];
   for (const scenario of params.scenarios) {
     const reasons: string[] = [];
+    if (params.executionKind && scenario.execution.kind !== params.executionKind) {
+      reasons.push(`execution.kind=${params.executionKind}`);
+    }
     // qa-channel is the built-in harness channel, so another driver cannot implement it.
     if (scenario.execution.channel === "qa-channel" && params.channelDriver !== "qa-channel") {
       reasons.push("channelDriver=qa-channel");
@@ -185,6 +189,7 @@ export function resolveQaProfileScenarios(params: {
   channelDriver?: QaScorecardChannelDriver;
   channel?: string;
   eligibleChannels?: readonly string[];
+  executionKind?: QaSeedScenarioWithSource["execution"]["kind"];
   requireDeclaredChannel?: boolean;
   scenarioIds?: readonly string[];
 }) {
@@ -230,6 +235,7 @@ export function resolveQaProfileScenarios(params: {
         primaryModel,
         channelDriver,
         channel: channel ?? scenario.execution.channel,
+        executionKind: params.executionKind,
       }).excludedScenarios.flatMap((entry) => entry.reasons),
     );
     return { scenario, reasons: uniqueStrings(reasons) };

--- a/extensions/qa-lab/src/profile-selection.test.ts
+++ b/extensions/qa-lab/src/profile-selection.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { resolveLiveTransportQaScenarioIds } from "./live-transports/shared/scenario-selection.js";
-import { resolveQaProfileScenarios } from "./profile-planning.js";
-import { readQaScenarioPack } from "./scenario-catalog.js";
+import {
+  resolveQaProfileScenarios,
+  resolveQaRunProfileExecutionSelection,
+} from "./profile-planning.js";
+import { readQaScenarioById, readQaScenarioPack } from "./scenario-catalog.js";
 import { readQaScorecardTaxonomyReport } from "./scorecard-taxonomy.js";
 
 describe("taxonomy profile scenario selection", () => {
@@ -63,5 +66,21 @@ describe("taxonomy profile scenario selection", () => {
     expect(liveTelegram).not.toContain("telegram-assistant-transcript-role-boundary");
     expect(mockTelegram).toContain("telegram-assistant-transcript-role-boundary");
     expect(mockTelegram).not.toContain("discord-canary");
+  });
+
+  it("lets flow-only consumers exclude a channel-declared script without changing membership", () => {
+    const scenario = readQaScenarioById("telegram-startup-getme-live");
+    const lane = {
+      scenarios: [scenario],
+      providerMode: "mock-openai" as const,
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      channelDriver: "live" as const,
+      channel: "telegram",
+    };
+
+    expect(resolveQaRunProfileExecutionSelection(lane).selectedScenarios).toEqual([scenario]);
+    expect(
+      resolveQaRunProfileExecutionSelection({ ...lane, executionKind: "flow" }).excludedScenarios,
+    ).toEqual([{ scenario, reasons: ["execution.kind=flow"] }]);
   });
 });

--- a/extensions/qa-lab/src/scenario-lane.test.ts
+++ b/extensions/qa-lab/src/scenario-lane.test.ts
@@ -115,34 +115,40 @@ describe("QA scenario lane matching", () => {
     ]);
   });
 
-  it("keeps provider contracts independent from the selected channel driver", () => {
-    const scenario = makeQaSuiteTestScenario("portable-telegram", {
-      channel: "telegram",
-      config: {
-        requiredProvider: "openai",
-        requiredModel: "gpt-5.6-luna",
-      },
-    });
+  it.each(["crabline", "live"] as const)(
+    "keeps provider, model, and auth contracts independent from the $channelDriver driver",
+    (channelDriver) => {
+      const scenario = makeQaSuiteTestScenario("portable-telegram", {
+        channel: "telegram",
+        config: {
+          requiredProvider: "claude-cli",
+          requiredModel: "claude-sonnet-4-6",
+          authMode: "subscription",
+        },
+      });
 
-    expect(
-      scenarioMatchesQaProviderLane({
-        scenario,
-        providerMode: "live-frontier",
-        primaryModel: "openai/gpt-5.6-luna",
-        channelDriver: "crabline",
-        channel: "telegram",
-      }),
-    ).toBe(true);
-    expect(
-      scenarioMatchesQaProviderLane({
-        scenario,
-        providerMode: "mock-openai",
-        primaryModel: "openai/gpt-5.6-luna",
-        channelDriver: "live",
-        channel: "telegram",
-      }),
-    ).toBe(true);
-  });
+      expect(
+        scenarioMatchesQaProviderLane({
+          scenario,
+          providerMode: "live-frontier",
+          primaryModel: "claude-cli/claude-sonnet-4-6",
+          channelDriver,
+          channel: "telegram",
+          claudeCliAuthMode: "subscription",
+        }),
+      ).toBe(true);
+      expect(
+        describeQaProviderLaneMismatches({
+          scenario,
+          providerMode: "mock-openai",
+          primaryModel: "openai/gpt-5.6-luna",
+          channelDriver,
+          channel: "telegram",
+          claudeCliAuthMode: "api-key",
+        }),
+      ).toEqual(["provider=claude-cli", "model=claude-sonnet-4-6", "authMode=subscription"]);
+    },
+  );
 
   it("enforces an explicit channel driver contract", () => {
     const scenario = makeQaSuiteTestScenario("live-only", {


### PR DESCRIPTION
Closes #115755

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where maintainers running dedicated live-transport QA commands could receive a plan containing an execution kind that the flow host cannot run, while an explicit model could be ignored during scenario selection and Telegram listing.

## Why This Change Was Made

Live-transport profile selection now requests flow scenarios through the canonical profile planner and carries the exact primary model through every channel selector. Telegram selection and listing share that same contract; suite-adapter realization and evidence-driver recording are intentionally unchanged.

## User Impact

Dedicated Matrix, Telegram, Discord, Slack, and WhatsApp QA commands now apply consistent implicit and explicit lane eligibility. Telegram mock and live-frontier defaults omit the separate startup script producer, and `--model` governs both selection and `--list-scenarios` output.

## Evidence

- Focused QA proof: 6 files, 40 tests passed via `node scripts/run-vitest.mjs`.
- Five-channel table proves explicit/implicit singleton parity; Telegram tests prove exact-model selection/listing and script rejection in mock/live modes.
- Membership audit: no current catalog change outside removal of `telegram-startup-getme-live` from both dedicated Telegram defaults; custom-model versus provider-default membership is otherwise unchanged.
- Changed gate passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30434488157
- Fresh Codex autoreview: no accepted/actionable findings; secret scan clean.
