### PR TITLE
fix(nostr): keep private tool traces out of encrypted messages

### DIFF
--- a/extensions/nostr/src/channel.inbound.test.ts
+++ b/extensions/nostr/src/channel.inbound.test.ts
@@ -52,11 +52,12 @@ function createRuntimeHarness() {
   const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async ({ dispatcherOptions }) => {
     await dispatcherOptions.deliver({ text: "**Table:** [docs](https://example.com)" });
   });
+  const convertMarkdownTables = vi.fn((text: string) => text);
   const runtime = {
     channel: {
       text: {
         resolveMarkdownTableMode: vi.fn(() => "off"),
-        convertMarkdownTables: vi.fn((text: string) => text),
+        convertMarkdownTables,
       },
       commands: {
         shouldComputeCommandAuthorized: vi.fn(() => true),
@@ -91,6 +92,7 @@ function createRuntimeHarness() {
     runtime,
     recordInboundSession,
     dispatchReplyWithBufferedBlockDispatcher,
+    convertMarkdownTables,
   };
 }
 
@@ -226,5 +228,89 @@ describe("nostr inbound gateway path", () => {
     expect(sendReply).toHaveBeenCalledWith("Table: docs (https://example.com)");
 
     await cleanup.stop();
+  });
+
+  it.each([
+    {
+      name: "strips an internal tool-failure banner",
+      text: "Done.\n⚠️ 🛠️ `search repos (agent)` failed",
+      expected: "Done.",
+    },
+    {
+      name: "strips internal tool-call XML",
+      text: '<tool_call>{"name":"read","arguments":{"path":"private"}}</tool_call>Done.',
+      expected: "Done.",
+    },
+    {
+      name: "strips multiline tool-response scaffolding",
+      text: [
+        "Before",
+        "<function_response>",
+        "private output",
+        "</function_response>",
+        "After",
+      ].join("\n"),
+      expected: "Before\n\nAfter",
+    },
+    {
+      name: "does not send an internal-trace-only reply",
+      text: "⚠️ 🛠️ `search repos (agent)` failed",
+      expected: null,
+    },
+    {
+      name: "preserves ordinary visible prose",
+      text: "The relay has two active subscriptions.",
+      expected: "The relay has two active subscriptions.",
+    },
+  ])("$name before sending an inbound Nostr DM reply", async ({ text, expected }) => {
+    mocks.dispatchInboundDirectDm.mockImplementationOnce(
+      async (params: Parameters<typeof DispatchInboundDirectDm>[0]) => {
+        await params.deliver({ text });
+      },
+    );
+    const { harness, cleanup } = await startGatewayHarness({
+      account: buildResolvedNostrAccount({
+        publicKey: "bot-pubkey",
+        config: { dmPolicy: "allowlist", allowFrom: ["nostr:sender-pubkey"] },
+      }),
+      cfg: {},
+    });
+    const options = mockCallArg(mocks.startNostrBus) as {
+      onMessage: (
+        senderPubkey: string,
+        text: string,
+        reply: (text: string) => Promise<void>,
+        meta: { eventId: string; createdAt: number },
+        lifecycle: NostrIngressLifecycle,
+      ) => Promise<void>;
+    };
+    const sendReply = vi.fn(async (_text: string) => {});
+    const lifecycle: NostrIngressLifecycle = {
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onAbandoned: vi.fn(async () => {}),
+    };
+
+    try {
+      await options.onMessage(
+        "sender-pubkey",
+        "hello from nostr",
+        sendReply,
+        { eventId: "event-123", createdAt: 1_710_000_000 },
+        lifecycle,
+      );
+
+      if (expected === null) {
+        expect(harness.convertMarkdownTables).not.toHaveBeenCalled();
+        expect(sendReply).not.toHaveBeenCalled();
+      } else {
+        expect(harness.convertMarkdownTables).toHaveBeenCalledWith(expected, "off");
+        expect(sendReply).toHaveBeenCalledWith(expected);
+      }
+    } finally {
+      await cleanup.stop();
+    }
   });
 });

--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -85,6 +85,47 @@ describe("nostr outbound cfg threading", () => {
     mocks.startNostrBus.mockReset();
   });
 
+  it.each([
+    {
+      name: "strips an internal tool-failure banner",
+      text: "Done.\n⚠️ 🛠️ `search repos (agent)` failed",
+      expected: "Done.",
+    },
+    {
+      name: "strips internal tool-call XML",
+      text: '<tool_call>{"name":"read","arguments":{"path":"private"}}</tool_call>Done.',
+      expected: "Done.",
+    },
+    {
+      name: "strips multiline tool-response scaffolding",
+      text: [
+        "Before",
+        "<function_response>",
+        "private output",
+        "</function_response>",
+        "After",
+      ].join("\n"),
+      expected: "Before\n\nAfter",
+    },
+    {
+      name: "suppresses an internal-trace-only reply",
+      text: "⚠️ 🛠️ `search repos (agent)` failed",
+      expected: "",
+    },
+    {
+      name: "preserves ordinary visible prose",
+      text: "The relay has two active subscriptions.",
+      expected: "The relay has two active subscriptions.",
+    },
+  ])("$name through the Nostr outbound sanitizer", ({ text, expected }) => {
+    const sanitizeText = nostrPlugin.outbound?.sanitizeText;
+    expect(sanitizeText).toBeTypeOf("function");
+    if (!sanitizeText) {
+      throw new Error("Expected Nostr outbound assistant-visible text sanitizer");
+    }
+    expect(sanitizeText({ text, payload: { text } })).toBe(expected);
+  });
+
   it("converts tables before projecting markdown to Nostr plain text", async () => {
     const { resolveMarkdownTableMode, convertMarkdownTables } = installOutboundRuntime(
       vi.fn((text: string) => (text === "***" ? text : "**Table:** [docs](https://example.com)")),

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -10,7 +10,7 @@ import {
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
+import { sanitizeAssistantVisibleText, stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
 import type { ChannelOutboundAdapter, ChannelPlugin } from "./channel-api.js";
 import type { MetricEvent, MetricsSnapshot } from "./metrics.js";
 import { startNostrBus, type NostrBusHandle } from "./nostr-bus.js";
@@ -26,6 +26,7 @@ type NostrOutboundAdapter = Pick<
   "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sendText"
 > & {
   sendText: NonNullable<ChannelOutboundAdapter["sendText"]>;
+  sanitizeText: NonNullable<ChannelOutboundAdapter["sanitizeText"]>;
 };
 
 const activeBuses = new Map<string, NostrBusHandle>();
@@ -194,7 +195,10 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
                 payload && typeof payload === "object" && "text" in payload
                   ? ((payload as { text?: string }).text ?? "")
                   : "";
-              if (!outboundText.trim()) {
+              // Inbound DM replies bypass the outbound adapter; sanitize before
+              // Markdown conversion so private tool traces cannot reach a relay.
+              const sanitizedText = sanitizeAssistantVisibleText(outboundText);
+              if (!sanitizedText) {
                 return;
               }
               const tableMode = runtime.channel.text.resolveMarkdownTableMode({
@@ -203,7 +207,7 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
                 accountId: account.accountId,
               });
               const message = stripMarkdown(
-                runtime.channel.text.convertMarkdownTables(outboundText, tableMode),
+                runtime.channel.text.convertMarkdownTables(sanitizedText, tableMode),
               );
               if (message) {
                 await reply(message);
@@ -312,6 +316,7 @@ export const nostrPairingTextAdapter = {
 export const nostrOutboundAdapter: NostrOutboundAdapter = {
   deliveryMode: "direct",
   textChunkLimit: 4000,
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   deliveryCapabilities: {
     durableFinal: {
       text: true,


### PR DESCRIPTION
Related: #90684
Supersedes: #103361

## What Problem This Solves

Fixes an issue where Nostr users receiving encrypted direct messages could see private assistant tool-failure banners, tool-call XML, or raw tool responses instead of only the intended answer. Replies containing only private scaffolding could also be sent as visible noise.

## Why This Change Was Made

Use the existing, canonical assistant-visible text sanitizer at both Nostr delivery boundaries: the normal channel outbound adapter and the inbound direct-message reply callback, which bypasses that adapter. Sanitize before Markdown conversion and suppress empty sanitized replies. Keep provider ownership, existing ingress lifecycle, NIP-04 encryption, relay behavior, account routing, and the Plugin SDK unchanged.

## User Impact

Nostr recipients receive ordinary assistant prose without private internal traces. Trace-only replies are not published to the relay.

## Evidence

- Independently reproduced **9 failures on current main** before applying the fix: 4 direct inbound reply failures and 5 missing outbound-sanitizer contract failures; the same scenarios are green after the change.
- Blacksmith Testbox `tbx_01kypejdm2zjf4vsk580x0dge9`: **554 passing tests** across all Nostr plugin tests, the canonical assistant-visible sanitizer, IRC and LINE sibling delivery, and all 144 channel plugin shape contracts.
- Real loopback Nostr WebSocket relay: **3/3 passing**, exercising signed kind-4 events, real NIP-04 encryption, relay publication, recipient decryption, mixed private tool traces, tool-call XML, and complete suppression of trace-only output.
- Full remote `pnpm check:changed`: **passed**, including extension and extension-test typechecks, lint, formatting, SDK boundaries, database-first guard, zero-dead-export scans, and import-cycle validation.
- Fresh independent `gpt-5.6-sol` extra-high-effort autoreview: **clean**, confidence **0.95**.
- Original Nostr two-path fix by @miorbnli in #103361 is preserved through `Co-authored-by: liyuanbin <li.yuanbin1@xydigit.com>`. This implementation is independently recreated on current main, preserves existing baseline tests, adds the regressions to the current owner test files, and changes only three Nostr-owned files.