### PR TITLE
fix(mattermost): preserve safe denied-sender group history

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -3,6 +3,10 @@ import {
   formatInboundEnvelope,
   implicitMentionKindWhen,
 } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  resolveChannelContextVisibilityMode,
+  shouldIncludeSupplementalContext,
+} from "openclaw/plugin-sdk/context-visibility-runtime";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -106,6 +110,27 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       senderId;
     const rawPostText = typeof post.message === "string" ? post.message : "";
     const rawText = normalizeOptionalString(rawPostText) ?? "";
+    const { effectiveReplyToId, sessionKey } = thread;
+    const historyKey = resolveMattermostPendingHistoryKey({ kind, sessionKey });
+    const fileIds = uniqueStrings(normalizeTrimmedStringList(post.file_ids ?? []));
+    const nativeMedia = fileIds.map(() => ({}));
+    const pendingBody = formatMattermostPendingMediaText({ body: rawText, media: nativeMedia });
+    const recordPendingHistory = () => {
+      const trimmed = pendingBody.trim();
+      createChannelHistoryWindow({ historyMap: channelHistories }).record({
+        limit: historyLimit,
+        historyKey: historyKey ?? "",
+        entry:
+          historyKey && trimmed
+            ? {
+                sender: senderName,
+                body: trimmed,
+                timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
+                messageId: post.id,
+              }
+            : null,
+      });
+    };
     const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
       cfg,
       surface: "mattermost",
@@ -180,6 +205,21 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
         return;
       }
       if (accessDecision.ingress.reasonCode === "group_policy_not_allowlisted") {
+        // Trigger allowlists do not hide history unless context visibility opts in.
+        // Denied senders must still return before commands, sessions, or replies.
+        if (
+          shouldIncludeSupplementalContext({
+            mode: resolveChannelContextVisibilityMode({
+              cfg,
+              channel: "mattermost",
+              accountId: account.accountId,
+            }),
+            kind: "history",
+            senderAllowed: false,
+          })
+        ) {
+          recordPendingHistory();
+        }
         monitor.logVerboseMessage(
           `mattermost: drop group sender=${senderId} (not in groupAllowFrom)`,
         );
@@ -201,10 +241,6 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       return;
     }
 
-    const { effectiveReplyToId, sessionKey } = thread;
-    const historyKey = resolveMattermostPendingHistoryKey({ kind, sessionKey });
-    const fileIds = uniqueStrings(normalizeTrimmedStringList(post.file_ids ?? []));
-    const nativeMedia = fileIds.map(() => ({}));
     const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, route.agentId);
     const wasMentioned =
       kind !== "direct" &&
@@ -214,24 +250,6 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
           )
         : false) ||
         core.channel.mentions.matchesMentionPatterns(rawText, mentionRegexes));
-    const pendingBody = formatMattermostPendingMediaText({ body: rawText, media: nativeMedia });
-    const recordPendingHistory = () => {
-      const trimmed = pendingBody.trim();
-      createChannelHistoryWindow({ historyMap: channelHistories }).record({
-        limit: historyLimit,
-        historyKey: historyKey ?? "",
-        entry:
-          historyKey && trimmed
-            ? {
-                sender: senderName,
-                body: trimmed,
-                timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
-                messageId: post.id,
-              }
-            : null,
-      });
-    };
-
     const oncharEnabled = account.chatmode === "onchar" && kind !== "direct";
     const oncharPrefixes = oncharEnabled ? resolveOncharPrefixes(account.oncharPrefixes) : [];
     const oncharResult = oncharEnabled

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1,7 +1,10 @@
 // Mattermost tests cover monitor.inbound system event plugin behavior.
+import { once } from "node:events";
+import { createServer } from "node:http";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
 import type { MattermostPost } from "./client.js";
 import type { MattermostEventPayload } from "./monitor-websocket.js";
 import { monitorMattermostProvider } from "./monitor.js";
@@ -473,19 +476,26 @@ const testRuntime = (): RuntimeEnv =>
 
 async function emitMattermostChannelPost(
   socket: FakeWebSocket,
-  params: { id: string; message: string; rootId?: string },
+  params: {
+    id: string;
+    message: string;
+    rootId?: string;
+    senderId?: string;
+    senderName?: string;
+  },
 ) {
+  const senderId = params.senderId ?? "user-1";
   await socket.emitMessage({
     event: "posted",
     data: {
       channel_id: "chan-1",
       channel_name: "town-square",
       channel_display_name: "Town Square",
-      sender_name: "alice",
+      sender_name: params.senderName ?? "alice",
       post: JSON.stringify({
         id: params.id,
         channel_id: "chan-1",
-        user_id: "user-1",
+        user_id: senderId,
         message: params.message,
         root_id: params.rootId,
         create_at: 1_714_000_000_000,
@@ -493,7 +503,7 @@ async function emitMattermostChannelPost(
     },
     broadcast: {
       channel_id: "chan-1",
-      user_id: "user-1",
+      user_id: senderId,
     },
   });
 }
@@ -584,6 +594,281 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.OriginatingChannel).toBe("mattermost");
     expect(ctx?.Provider).toBe("mattermost");
   });
+
+  it.each([
+    {
+      name: "default visibility",
+      contextVisibility: undefined,
+      expectedHistory: ["denied second", "denied third"],
+    },
+    {
+      name: "explicit all visibility",
+      contextVisibility: "all",
+      expectedHistory: ["denied second", "denied third"],
+    },
+    {
+      name: "allowlist visibility",
+      contextVisibility: "allowlist",
+      expectedHistory: [],
+    },
+    {
+      name: "allowlist quote visibility",
+      contextVisibility: "allowlist_quote",
+      expectedHistory: [],
+    },
+  ] as const)(
+    "keeps denied group history bounded and policy-safe with $name",
+    async ({ contextVisibility, expectedHistory }) => {
+      const socket = new FakeWebSocket();
+      const abortController = new AbortController();
+      mockState.abortController = abortController;
+      const config: OpenClawConfig = {
+        messages: { groupChat: { historyLimit: 2 } },
+        channels: {
+          ...(contextVisibility ? { defaults: { contextVisibility } } : {}),
+          mattermost: {
+            enabled: true,
+            baseUrl: "https://mattermost.example.com",
+            botToken: "bot-token",
+            chatmode: "onmessage",
+            dmPolicy: "open",
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["allowed-user"],
+          },
+        },
+      };
+      const isControlCommandMessage = vi.fn((text?: string) => text?.trim() === "/reset");
+      const runtimeCore = createRuntimeCore(config, undefined, {
+        isControlCommandMessage,
+        shouldHandleTextCommands: () => true,
+      });
+      mockState.runtimeCore = runtimeCore;
+
+      const monitor = monitorMattermostProvider({
+        config,
+        runtime: testRuntime(),
+        abortSignal: abortController.signal,
+        webSocketFactory: () => socket,
+      });
+
+      await vi.waitFor(() => {
+        expect(socket.openListenerCount).toBeGreaterThan(0);
+      });
+      socket.emitOpen();
+
+      for (const [index, message] of ["/reset", "denied second", "denied third"].entries()) {
+        await emitMattermostChannelPost(socket, {
+          id: `denied-history-${index}`,
+          message,
+          senderId: "denied-user",
+          senderName: "mallory",
+        });
+        expect(mockState.dispatchInboundMessage).not.toHaveBeenCalled();
+        expect(runtimeCore.channel.session.recordInboundSession).not.toHaveBeenCalled();
+        expect(mockState.createReplyDispatcherWithTyping).not.toHaveBeenCalled();
+        expect(mockState.sendMessageMattermost).not.toHaveBeenCalled();
+      }
+
+      await emitMattermostChannelPost(socket, {
+        id: "allowed-history-request",
+        message: "summarize the conversation",
+        senderId: "allowed-user",
+        senderName: "alice",
+      });
+      socket.emitClose(1000);
+      await monitor;
+
+      expect(isControlCommandMessage).toHaveBeenCalledWith("/reset", config);
+      expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(1);
+      expect(runtimeCore.channel.session.recordInboundSession).toHaveBeenCalledTimes(1);
+      expect(mockState.createReplyDispatcherWithTyping).toHaveBeenCalledTimes(1);
+      const ctx = mockState.dispatchInboundMessage.mock.calls.at(0)?.[0].ctx;
+      expect(ctx?.SenderId).toBe("allowed-user");
+      expect(ctx?.BodyForAgent).toBe("summarize the conversation");
+      expect(ctx?.CommandSource).toBeUndefined();
+      expect(ctx?.InboundHistory?.map((entry: { body: string }) => entry.body) ?? []).toEqual(
+        expectedHistory,
+      );
+      expect(ctx?.Body).not.toContain("/reset");
+      for (const history of expectedHistory) {
+        expect(ctx?.Body).toContain(history);
+      }
+      if (expectedHistory.length === 0) {
+        expect(ctx?.Body).not.toContain("denied second");
+        expect(ctx?.Body).not.toContain("denied third");
+      }
+    },
+  );
+
+  it.each([
+    { name: "default visibility", contextVisibility: undefined, expectedHistory: true },
+    { name: "allowlist visibility", contextVisibility: "allowlist", expectedHistory: false },
+  ] as const)(
+    "preserves denied history policy over authenticated Mattermost HTTP and WebSocket with $name",
+    async ({ contextVisibility, expectedHistory }) => {
+      const token = "mattermost-loopback-proof-token";
+      const requests: Array<{ path: string; authorization?: string }> = [];
+      const server = createServer((request, response) => {
+        requests.push({
+          path: request.url ?? "",
+          authorization: request.headers.authorization,
+        });
+        response.setHeader("content-type", "application/json");
+        if (request.headers.authorization !== `Bearer ${token}`) {
+          response.writeHead(401);
+          response.end(JSON.stringify({ message: "unauthorized" }));
+          return;
+        }
+        if (request.url === "/api/v4/users/me") {
+          response.end(JSON.stringify({ id: "bot-user", username: "openclaw", update_at: 1 }));
+          return;
+        }
+        if (request.url === "/api/v4/channels/chan-1") {
+          response.end(
+            JSON.stringify({
+              id: "chan-1",
+              name: "town-square",
+              display_name: "Town Square",
+              team_id: "team-1",
+              type: "O",
+            }),
+          );
+          return;
+        }
+        response.writeHead(404);
+        response.end(JSON.stringify({ message: "unknown loopback endpoint" }));
+      });
+      const websocket = new WebSocketServer({ server, path: "/api/v4/websocket" });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected a Mattermost loopback TCP address");
+      }
+
+      const abortController = new AbortController();
+      mockState.abortController = abortController;
+      const verboseDebug = vi.fn();
+      const baseUrl = `http://127.0.0.1:${address.port}`;
+      const config: OpenClawConfig = {
+        messages: { groupChat: { historyLimit: 2 } },
+        channels: {
+          ...(contextVisibility ? { defaults: { contextVisibility } } : {}),
+          mattermost: {
+            enabled: true,
+            baseUrl,
+            botToken: token,
+            chatmode: "onmessage",
+            dmPolicy: "open",
+            groupPolicy: "allowlist",
+            groupAllowFrom: ["allowed-user"],
+            network: { dangerouslyAllowPrivateNetwork: true },
+          },
+        },
+      };
+      const runtimeCore = createRuntimeCore(config, undefined, { verboseDebug });
+      mockState.runtimeCore = runtimeCore;
+      const actualClient = await vi.importActual<typeof import("./client.js")>("./client.js");
+      mockState.createMattermostClient.mockImplementation(actualClient.createMattermostClient);
+      mockState.fetchMattermostMe.mockImplementation(actualClient.fetchMattermostMe);
+      mockState.resolveChannelInfo.mockImplementation(async (channelId: string) => {
+        const client = mockState.createMattermostClient.mock.results.at(-1)?.value;
+        if (!client) {
+          throw new Error("expected the production Mattermost HTTP client");
+        }
+        return await actualClient.fetchMattermostChannel(client, channelId);
+      });
+
+      const connection = once(websocket, "connection");
+      let monitor: Promise<void> | undefined;
+      try {
+        monitor = monitorMattermostProvider({
+          config,
+          runtime: testRuntime(),
+          abortSignal: abortController.signal,
+        });
+        const [socket] = await connection;
+        const [rawAuthentication] = await once(socket, "message");
+        expect(JSON.parse(String(rawAuthentication))).toMatchObject({
+          action: "authentication_challenge",
+          data: { token },
+        });
+
+        const sendPost = (params: { id: string; message: string; senderId: string }) => {
+          socket.send(
+            JSON.stringify({
+              event: "posted",
+              data: {
+                channel_id: "chan-1",
+                channel_name: "town-square",
+                channel_display_name: "Town Square",
+                sender_name: params.senderId === "allowed-user" ? "alice" : "mallory",
+                post: JSON.stringify({
+                  id: params.id,
+                  channel_id: "chan-1",
+                  user_id: params.senderId,
+                  message: params.message,
+                  create_at: 1_714_000_000_000,
+                }),
+              },
+              broadcast: { channel_id: "chan-1", user_id: params.senderId },
+            }),
+          );
+        };
+
+        for (const [index, message] of ["denied first", "denied second"].entries()) {
+          sendPost({
+            id: `loopback-denied-${index}`,
+            message,
+            senderId: "denied-user",
+          });
+          await vi.waitFor(() => {
+            const drops = verboseDebug.mock.calls.filter(([line]) =>
+              String(line).includes("drop group sender=denied-user"),
+            );
+            expect(drops).toHaveLength(index + 1);
+          });
+          expect(mockState.dispatchInboundMessage).not.toHaveBeenCalled();
+          expect(runtimeCore.channel.session.recordInboundSession).not.toHaveBeenCalled();
+          expect(mockState.sendMessageMattermost).not.toHaveBeenCalled();
+        }
+
+        sendPost({
+          id: "loopback-allowed",
+          message: "summarize the conversation",
+          senderId: "allowed-user",
+        });
+        await vi.waitFor(() => {
+          expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(1);
+        });
+
+        const ctx = mockState.dispatchInboundMessage.mock.calls.at(0)?.[0].ctx;
+        expect(ctx?.SenderId).toBe("allowed-user");
+        expect(ctx?.BodyForAgent).toBe("summarize the conversation");
+        expect(ctx?.InboundHistory?.map((entry: { body: string }) => entry.body) ?? []).toEqual(
+          expectedHistory ? ["denied first", "denied second"] : [],
+        );
+        expect(requests.length).toBeGreaterThanOrEqual(4);
+        expect(requests.every((request) => request.authorization === `Bearer ${token}`)).toBe(true);
+        expect(requests.some((request) => request.path === "/api/v4/users/me")).toBe(true);
+        expect(requests.some((request) => request.path === "/api/v4/channels/chan-1")).toBe(true);
+      } finally {
+        abortController.abort();
+        for (const client of websocket.clients) {
+          client.terminate();
+        }
+        if (monitor) {
+          await monitor;
+        }
+        await new Promise<void>((resolve, reject) => {
+          websocket.close((error) => (error ? reject(error) : resolve()));
+        });
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
 
   it("keeps verbose inbound previews on complete UTF-16 boundaries", async () => {
     const socket = new FakeWebSocket();


### PR DESCRIPTION
Related: #57609
Related: #57607

## What Problem This Solves

Fixes an issue where Mattermost group users asking an allowlisted bot to summarize the conversation would silently lose messages from other group participants. Those participants must never trigger commands, create sessions, send replies, or bypass restrictive context-visibility settings.

## Why This Change Was Made

Preserves and credits Jason Wang’s original Mattermost fix from #57609 while porting it to the current Mattermost ingress owner. The existing context-visibility SDK contract keeps bounded denied-sender history only for the documented default/all mode and omits it completely for allowlist and allowlist_quote. No core, SDK, configuration, default, persistence, or provider behavior changes.

## User Impact

Authorized Mattermost users can summarize the actual bounded group conversation. Denied group senders still cannot invoke commands, start sessions, trigger agent runs, or send visible replies. Existing restrictive context-visibility settings remain fail-closed.

## Evidence

- Red/green: the new default/all regressions fail against unchanged main and pass with the fix; both restrictive modes stay green.
- Full Mattermost plugin suite: 49 test files, 696 passing tests on Blacksmith Testbox.
- Full changed gate: formatting, lint, owner and plugin typechecks, plugin-boundary and SDK-surface guards all pass on Blacksmith Testbox.
- Real authenticated loopback HTTP and WebSocket integration tests exercise production bearer-authenticated Mattermost client requests, authentication challenge, both visibility outcomes, bounded history, denied no-dispatch/no-session/no-reply, and socket/server teardown.
- Fresh xhigh Codex autoreview: clean, no actionable findings. AI-assisted maintainer port; original production commit remains authored by Jason Wang, and the maintainer test commit includes his Co-authored-by trailer.
