### PR TITLE
fix(memory): reconcile derived full-text schemas

### DIFF
--- a/packages/memory-host-sdk/src/host/memory-schema-fts-reconcile.test.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts-reconcile.test.ts
@@ -1,0 +1,237 @@
+// Memory FTS reconciliation keeps derived schemas aligned with canonical data.
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { ensureMemoryIndexSchema } from "./memory-schema.js";
+
+describe("memory FTS schema reconciliation", () => {
+  it("rebuilds body and path indexes when their tokenizer changes", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      expect(
+        ensureMemoryIndexSchema({
+          db,
+          cacheEnabled: false,
+          ftsEnabled: true,
+          ftsTokenizer: "unicode61",
+        }).ftsAvailable,
+      ).toBe(true);
+      db.exec(`
+        INSERT INTO memory_index_sources (path, source, hash, mtime, size)
+        VALUES ('memory/needle.md', 'memory', 'source-hash', 1, 1);
+        INSERT INTO memory_index_chunks
+          (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+        VALUES
+          ('kept', 'memory/needle.md', 'memory', 1, 1, 'chunk-hash', 'model', 'needle body', '[]', 1);
+        INSERT INTO memory_index_chunks_fts
+          (text, id, path, source, model, start_line, end_line)
+        VALUES ('needle body', 'kept', 'memory/needle.md', 'memory', 'model', 1, 1);
+      `);
+
+      expect(
+        ensureMemoryIndexSchema({
+          db,
+          cacheEnabled: false,
+          ftsEnabled: true,
+          ftsTokenizer: "trigram",
+        }).ftsAvailable,
+      ).toBe(true);
+
+      const derivedSchemas = db
+        .prepare(
+          "SELECT name, sql FROM sqlite_schema WHERE type = 'table' AND name IN ('memory_index_chunks_fts', 'memory_index_paths_fts') ORDER BY name",
+        )
+        .all() as Array<{ name: string; sql: string }>;
+      expect(derivedSchemas).toHaveLength(2);
+      expect(
+        derivedSchemas.every((schema) =>
+          schema.sql.includes("tokenize='trigram case_sensitive 0'"),
+        ),
+      ).toBe(true);
+      expect(db.prepare("SELECT id, text FROM memory_index_chunks_fts").all()).toEqual([
+        { id: "kept", text: "needle body" },
+      ]);
+      expect(db.prepare("SELECT path, source FROM memory_index_paths_fts").all()).toEqual([
+        { path: "memory/needle.md", source: "memory" },
+      ]);
+      expect(db.prepare("SELECT id, text FROM memory_index_chunks").all()).toEqual([
+        { id: "kept", text: "needle body" },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("repairs malformed derived tables without changing canonical rows", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+      db.exec(`
+        INSERT INTO memory_index_sources (path, source, hash, mtime, size)
+        VALUES ('memory/kept.md', 'memory', 'source-hash', 1, 1);
+        INSERT INTO memory_index_chunks
+          (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+        VALUES
+          ('kept', 'memory/kept.md', 'memory', 1, 1, 'chunk-hash', 'model', 'kept body', '[]', 1);
+        CREATE VIRTUAL TABLE memory_index_chunks_fts USING fts5(wrong);
+        CREATE VIRTUAL TABLE memory_index_paths_fts USING fts5(wrong);
+        CREATE TRIGGER memory_index_paths_fts_after_insert
+        AFTER INSERT ON memory_index_sources BEGIN SELECT 1; END;
+      `);
+
+      expect(
+        ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: true }).ftsAvailable,
+      ).toBe(true);
+      expect(db.prepare("SELECT id, text FROM memory_index_chunks_fts").all()).toEqual([
+        { id: "kept", text: "kept body" },
+      ]);
+      expect(db.prepare("SELECT path, source FROM memory_index_paths_fts").all()).toEqual([
+        { path: "memory/kept.md", source: "memory" },
+      ]);
+      expect(db.prepare("SELECT id, text FROM memory_index_chunks").all()).toEqual([
+        { id: "kept", text: "kept body" },
+      ]);
+      db.prepare(
+        "INSERT INTO memory_index_sources (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)",
+      ).run("memory/later.md", "memory", "later-hash", 2, 2);
+      expect(db.prepare("SELECT path FROM memory_index_paths_fts ORDER BY path").all()).toEqual([
+        { path: "memory/kept.md" },
+        { path: "memory/later.md" },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each([
+    {
+      name: "indexed metadata columns",
+      definition: "fts5(text, id, path, source, model, start_line, end_line)",
+    },
+    {
+      name: "contentless storage",
+      definition:
+        "fts5(text, id UNINDEXED, path UNINDEXED, source UNINDEXED, model UNINDEXED, start_line UNINDEXED, end_line UNINDEXED, content='')",
+    },
+  ])("repairs body indexes with $name", ({ definition }) => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+      db.exec(`
+        INSERT INTO memory_index_chunks
+          (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+        VALUES
+          ('kept', 'memory/kept.md', 'memory', 1, 1, 'chunk-hash', 'model', 'kept body', '[]', 1);
+        CREATE VIRTUAL TABLE memory_index_chunks_fts USING ${definition};
+      `);
+
+      expect(
+        ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: true }).ftsAvailable,
+      ).toBe(true);
+      expect(db.prepare("SELECT id, text FROM memory_index_chunks_fts").all()).toEqual([
+        { id: "kept", text: "kept body" },
+      ]);
+      expect(
+        db
+          .prepare("SELECT id FROM memory_index_chunks_fts WHERE memory_index_chunks_fts MATCH ?")
+          .all("kept"),
+      ).toEqual([{ id: "kept" }]);
+      expect(
+        db.prepare("SELECT sql FROM sqlite_schema WHERE name = 'memory_index_chunks_fts'").get(),
+      ).toEqual({
+        sql: expect.stringContaining("id UNINDEXED"),
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each(["memory_index_chunks", "MEMORY_INDEX_CHUNKS"])(
+    "never drops canonical chunks for the colliding custom FTS table name %s",
+    (ftsTable) => {
+      const db = new DatabaseSync(":memory:");
+      try {
+        ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+        db.exec(`
+        INSERT INTO memory_index_chunks
+          (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+        VALUES
+          ('kept', 'memory/kept.md', 'memory', 1, 1, 'chunk-hash', 'model', 'kept body', '[]', 1);
+      `);
+
+        expect(
+          ensureMemoryIndexSchema({
+            db,
+            cacheEnabled: false,
+            ftsEnabled: true,
+            ftsTable,
+          }).ftsAvailable,
+        ).toBe(false);
+        expect(db.prepare("SELECT id, text FROM memory_index_chunks").all()).toEqual([
+          { id: "kept", text: "kept body" },
+        ]);
+      } finally {
+        db.close();
+      }
+    },
+  );
+
+  it("never treats FTS-like text in an ordinary custom table as an FTS declaration", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: false });
+      db.exec(`
+        CREATE TABLE custom_memory_fts (
+          description TEXT NOT NULL DEFAULT 'USING fts5(text, id)'
+        );
+        INSERT INTO custom_memory_fts DEFAULT VALUES;
+      `);
+
+      expect(
+        ensureMemoryIndexSchema({
+          db,
+          cacheEnabled: false,
+          ftsEnabled: true,
+          ftsTable: "custom_memory_fts",
+        }).ftsAvailable,
+      ).toBe(false);
+      expect(db.prepare("SELECT description FROM custom_memory_fts").all()).toEqual([
+        { description: "USING fts5(text, id)" },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each(["memory_index_paths_fts", "MEMORY_INDEX_PATHS_FTS"])(
+    "never replaces the reserved path FTS table through the custom body alias %s",
+    (ftsTable) => {
+      const db = new DatabaseSync(":memory:");
+      try {
+        expect(
+          ensureMemoryIndexSchema({ db, cacheEnabled: false, ftsEnabled: true }).ftsAvailable,
+        ).toBe(true);
+        db.prepare(
+          "INSERT INTO memory_index_sources (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)",
+        ).run("memory/kept.md", "memory", "source-hash", 1, 1);
+
+        expect(
+          ensureMemoryIndexSchema({
+            db,
+            cacheEnabled: false,
+            ftsEnabled: true,
+            ftsTable,
+          }).ftsAvailable,
+        ).toBe(false);
+        db.prepare(
+          "INSERT INTO memory_index_sources (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)",
+        ).run("memory/later.md", "memory", "later-hash", 2, 2);
+        expect(db.prepare("SELECT path FROM memory_index_paths_fts ORDER BY path").all()).toEqual([
+          { path: "memory/kept.md" },
+          { path: "memory/later.md" },
+        ]);
+      } finally {
+        db.close();
+      }
+    },
+  );
+});

--- a/packages/memory-host-sdk/src/host/memory-schema-fts.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema-fts.ts
@@ -6,6 +6,94 @@ export const MEMORY_INDEX_CHUNKS_TABLE = "memory_index_chunks";
 export const MEMORY_INDEX_FTS_TABLE = "memory_index_chunks_fts";
 export const MEMORY_INDEX_PATHS_FTS_TABLE = "memory_index_paths_fts";
 
+type FtsTableSchemaStatus = "missing" | "matching" | "mismatched" | "not-fts";
+
+/** Check every persisted FTS column declaration and supported table option. */
+function ftsTableMatchesSchema(params: {
+  db: DatabaseSync;
+  tableName: string;
+  expectedColumns: readonly string[];
+  tokenizeClause: string;
+}): FtsTableSchemaStatus {
+  const table = params.db
+    .prepare("SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = ? COLLATE NOCASE")
+    .get(params.tableName) as { sql?: unknown } | undefined;
+  if (typeof table?.sql !== "string") {
+    return "missing";
+  }
+  const definition =
+    /^\s*CREATE\s+VIRTUAL\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:"[^"]+"|`[^`]+`|\[[^\]]+\]|[^\s(]+)\s+USING\s+fts5\s*\(([\s\S]*)\)\s*$/iu.exec(
+      table.sql,
+    )?.[1];
+  if (definition === undefined) {
+    return "not-fts";
+  }
+
+  const declarations = definition
+    .split(",")
+    .map((declaration) => declaration.trim().replace(/\s+/g, " ").toLowerCase());
+  const expectedDeclarations = params.expectedColumns.map((column, index) =>
+    index === 0 ? column : `${column} unindexed`,
+  );
+  if (
+    declarations.length < expectedDeclarations.length ||
+    expectedDeclarations.some((column, index) => declarations[index] !== column)
+  ) {
+    return "mismatched";
+  }
+
+  // The configured tokenizer is the sole supported FTS option. Accept the
+  // shipped explicit unicode61 spelling, but rebuild contentless/external tables.
+  const options = declarations.slice(expectedDeclarations.length);
+  const tokenizerOption = options[0] ?? "";
+  const tokenizerMatches = params.tokenizeClause.includes("trigram")
+    ? options.length === 1 &&
+      /^tokenize\s*=\s*(['"])trigram case_sensitive 0\1$/u.test(tokenizerOption)
+    : options.length === 0 ||
+      (options.length === 1 && /^tokenize\s*=\s*(['"])unicode61\1$/u.test(tokenizerOption));
+  if (!tokenizerMatches) {
+    return "mismatched";
+  }
+
+  const columns = params.db
+    .prepare("SELECT name FROM pragma_table_info(?) ORDER BY cid")
+    .all(params.tableName) as Array<{ name?: unknown }>;
+  return columns.length === params.expectedColumns.length &&
+    columns.every((column, index) => column.name === params.expectedColumns[index])
+    ? "matching"
+    : "mismatched";
+}
+
+/** Remove only derived FTS state whose persisted schema no longer matches. */
+function dropMismatchedFtsTable(params: {
+  db: DatabaseSync;
+  tableName: string;
+  expectedColumns: readonly string[];
+  tokenizeClause: string;
+}): void {
+  const status = ftsTableMatchesSchema(params);
+  if (status === "missing" || status === "matching") {
+    return;
+  }
+
+  // Deprecated custom names never establish ownership of an existing ordinary
+  // table. Failing closed here prevents a name collision from deleting memories.
+  if (
+    status === "not-fts" &&
+    params.tableName !== MEMORY_INDEX_FTS_TABLE &&
+    params.tableName !== MEMORY_INDEX_PATHS_FTS_TABLE
+  ) {
+    throw new Error(`Memory FTS table "${params.tableName}" collides with a non-FTS table`);
+  }
+
+  // Path triggers target this table; remove them before replacing its schema
+  // so canonical source writes never run against missing derived columns.
+  if (params.tableName === MEMORY_INDEX_PATHS_FTS_TABLE) {
+    dropMemoryPathFtsTriggers(params.db);
+  }
+  params.db.exec(`DROP TABLE ${params.tableName}`);
+}
+
 /** Optional canonical triggers owned by the derived path FTS index. */
 export const MEMORY_PATH_FTS_TRIGGER_DEFINITIONS = [
   {
@@ -56,6 +144,55 @@ export function rebuildMemoryChunkFts(db: DatabaseSync, ftsTable: string): void 
   `);
 }
 
+/** Reconcile and backfill the derived body index in one atomic savepoint. */
+export function ensureMemoryChunkFtsSchema(params: {
+  db: DatabaseSync;
+  ftsTable: string;
+  tokenizeClause: string;
+}): void {
+  // Body and path indexes have incompatible columns and maintenance triggers.
+  // Reject SQLite's case-insensitive path alias before replacing either index.
+  if (params.ftsTable.toLowerCase() === MEMORY_INDEX_PATHS_FTS_TABLE.toLowerCase()) {
+    throw new Error(`Memory body FTS table "${params.ftsTable}" collides with the path FTS index`);
+  }
+
+  params.db.exec("SAVEPOINT ensure_memory_index_chunks_fts");
+  try {
+    dropMismatchedFtsTable({
+      db: params.db,
+      tableName: params.ftsTable,
+      expectedColumns: ["text", "id", "path", "source", "model", "start_line", "end_line"],
+      tokenizeClause: params.tokenizeClause,
+    });
+    params.db.exec(
+      `CREATE VIRTUAL TABLE IF NOT EXISTS ${params.ftsTable} USING fts5(\n` +
+        `  text,\n` +
+        `  id UNINDEXED,\n` +
+        `  path UNINDEXED,\n` +
+        `  source UNINDEXED,\n` +
+        `  model UNINDEXED,\n` +
+        `  start_line UNINDEXED,\n` +
+        `  end_line UNINDEXED\n` +
+        `${params.tokenizeClause});`,
+    );
+    // Empty derived tables are rebuilt from canonical chunks; populated,
+    // matching indexes stay untouched on ordinary schema ensures.
+    params.db.exec(`
+      INSERT INTO ${params.ftsTable} (
+        text, id, path, source, model, start_line, end_line
+      )
+      SELECT text, id, path, source, model, start_line, end_line
+      FROM ${MEMORY_INDEX_CHUNKS_TABLE}
+      WHERE NOT EXISTS (SELECT 1 FROM ${params.ftsTable} LIMIT 1);
+    `);
+    params.db.exec("RELEASE ensure_memory_index_chunks_fts");
+  } catch (err) {
+    params.db.exec("ROLLBACK TO ensure_memory_index_chunks_fts");
+    params.db.exec("RELEASE ensure_memory_index_chunks_fts");
+    throw err;
+  }
+}
+
 export function dropDisabledMemoryFts(db: DatabaseSync, ftsTable: string, enabled: boolean): void {
   if (enabled) {
     return;
@@ -93,6 +230,12 @@ export function ensureMemoryPathFtsSchema(params: {
 }): void {
   params.db.exec("SAVEPOINT ensure_memory_index_paths_fts");
   try {
+    dropMismatchedFtsTable({
+      db: params.db,
+      tableName: MEMORY_INDEX_PATHS_FTS_TABLE,
+      expectedColumns: ["path", "source"],
+      tokenizeClause: params.tokenizeClause,
+    });
     params.db.exec(`
       CREATE VIRTUAL TABLE IF NOT EXISTS ${MEMORY_INDEX_PATHS_FTS_TABLE} USING fts5(
         path,

--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -10,6 +10,7 @@ import {
 import {
   dropDisabledMemoryFts,
   dropMemoryPathFtsTriggers,
+  ensureMemoryChunkFtsSchema,
   ensureMemoryPathFtsSchema,
   ensureMemoryPathFtsTriggers,
   MEMORY_INDEX_CHUNKS_TABLE,
@@ -680,27 +681,7 @@ export function ensureMemoryIndexSchema(params: {
     try {
       const tokenizer = params.ftsTokenizer ?? "unicode61";
       const tokenizeClause = tokenizer === "trigram" ? `, tokenize='trigram case_sensitive 0'` : "";
-      params.db.exec(
-        `CREATE VIRTUAL TABLE IF NOT EXISTS ${ftsTable} USING fts5(\n` +
-          `  text,\n` +
-          `  id UNINDEXED,\n` +
-          `  path UNINDEXED,\n` +
-          `  source UNINDEXED,\n` +
-          `  model UNINDEXED,\n` +
-          `  start_line UNINDEXED,\n` +
-          `  end_line UNINDEXED\n` +
-          `${tokenizeClause});`,
-      );
-      // A migration rebuilds an existing FTS table in its savepoint. If the
-      // table is new, this same empty-table bootstrap covers all canonical rows.
-      params.db.exec(`
-        INSERT INTO ${ftsTable} (
-          text, id, path, source, model, start_line, end_line
-        )
-        SELECT text, id, path, source, model, start_line, end_line
-        FROM ${MEMORY_INDEX_CHUNKS_TABLE}
-        WHERE NOT EXISTS (SELECT 1 FROM ${ftsTable} LIMIT 1);
-      `);
+      ensureMemoryChunkFtsSchema({ db: params.db, ftsTable, tokenizeClause });
       // Deprecated custom FTS tables preserve their body-only contract. The
       // canonical index owns the separate path table and its source triggers.
       if (ftsTable === MEMORY_INDEX_FTS_TABLE) {


### PR DESCRIPTION
Closes #114316

Related contributor investigation: #114319 (thank you @kevin2966n).

## What Problem This Solves

An existing memory SQLite database can retain body or path full-text tables whose tokenizer, indexed columns, storage mode, or trigger contracts no longer match the canonical memory schema. Opening that database can silently return stale or missing search results; unsafe case-insensitive custom aliases can also collide with canonical memory or path tables.

## Why This Change Was Made

Reconcile both derived FTS5 schemas at their existing private memory-host ownership boundary. Rebuild only the mismatched derived indexes from authoritative memory rows inside SQLite savepoints, restore path maintenance triggers, and reject ordinary tables and case-insensitive aliases of canonical body/path state before touching them. Preserve the independently landed FTS enable/disable owner.

No SQLite schema-version bump, configuration option, dependency, runtime migration, or public SDK surface is introduced.

## User Impact

Existing memories stay intact. Unicode/trigram tokenizer changes and malformed, indexed-metadata, or contentless legacy derived indexes regain correct real full-text search. New memory paths keep updating the path index. Colliding custom table names cannot delete or replace user memory or the live path index.

## Evidence

- Real fail-before regression coverage for tokenizer transitions, malformed derived tables, indexed metadata, contentless storage, ordinary FTS-looking tables, case-insensitive canonical-memory aliases, and both spellings of the reserved path FTS alias.
- All 85 relevant SQLite FTS reconciliation, previously landed FTS enable/disable, memory schema, legacy migration, real memory-manager search, and memory-manager database tests pass on Linux/Node 24 Blacksmith Testbox.
- Standalone production-boundary real SQLite proof printed `REAL_SQLITE_FTS_SCHEMA_RECONCILIATION_PASS`: real body/path FTS5 `MATCH`, Unicode-to-trigram rebuild, authoritative-row preservation, repaired malformed/indexed/contentless indexes, restored path-trigger inserts, both case-insensitive canonical/path collision protections, and preservation of an ordinary FTS-like custom table.
- Full remote `CI=1 pnpm check:changed` exited 0, including formatting, core and test typechecking, typed lint, SQLite schema and database-first guards, plugin/SDK boundaries, and runtime import cycles.
- Exact final commit `c9a833a8eeffb2366023e8ebcb234f362a639e76` extra-high-effort autoreview: clean, confidence 0.93.
