### PR TITLE
fix(cron): stop replaying old schedule slots after a cron job is edited

### DIFF
--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -432,6 +432,7 @@ const CronFailureNotificationDeliverySchema = closedObject({
 /** Scheduler-maintained state for the latest run/delivery outcome. */
 export const CronJobStateSchema = closedObject({
   nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+  scheduleActivatedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
   runningAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
   lastRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
   lastRunStatus: Type.Optional(CronRunStatusSchema),

--- a/src/cron/cron-protocol-schema.test.ts
+++ b/src/cron/cron-protocol-schema.test.ts
@@ -40,6 +40,16 @@ describe("cron protocol schema", () => {
     expect(patchStateProperties.streamSourceIdentity).toBeUndefined();
   });
 
+  it("reports schedule activation without accepting it in state patches", () => {
+    const stateProperties = (CronJobStateSchema as SchemaLike).properties ?? {};
+    expect(stateProperties.scheduleActivatedAtMs).toBeDefined();
+
+    const updateProperties = (CronUpdateParamsSchema as SchemaLike).properties ?? {};
+    const patchProperties = (updateProperties.patch as SchemaLike | undefined)?.properties ?? {};
+    const patchState = patchProperties.state as SchemaLike | undefined;
+    expect(patchState?.properties?.scheduleActivatedAtMs).toBeUndefined();
+  });
+
   it("documents that pacing requires at least one bound", () => {
     expect((CronPacingSchema as SchemaLike).description).toContain(
       "at least one of min or max is required",

--- a/src/cron/service.restart-catchup-schedule-change.test.ts
+++ b/src/cron/service.restart-catchup-schedule-change.test.ts
@@ -57,6 +57,17 @@ describe("CronService restart catch-up after a schedule change", () => {
       await editor.update(jobId, {
         schedule: { kind: "cron", expr: "0 21 * * *", tz: "Europe/Istanbul" },
       });
+      const activatedAtMs = Date.parse("2026-07-28T07:18:00.000Z");
+      expect(editor.getJob(jobId)?.state.scheduleActivatedAtMs).toBe(activatedAtMs);
+
+      vi.setSystemTime(new Date("2026-07-28T08:18:00.000Z"));
+      await editor.update(jobId, { name: "renamed daily briefing" });
+      await editor.update(jobId, {
+        schedule: { kind: "cron", expr: "0 21 * * *", tz: "Europe/Istanbul" },
+      });
+      const idempotentlyUpdated = editor.getJob(jobId);
+      expect(idempotentlyUpdated?.state.scheduleActivatedAtMs).toBe(activatedAtMs);
+      expect(idempotentlyUpdated?.updatedAtMs).toBe(Date.parse("2026-07-28T08:18:00.000Z"));
     } finally {
       editor.stop();
     }
@@ -76,6 +87,110 @@ describe("CronService restart catch-up after a schedule change", () => {
       expect(job?.state.nextRunAtMs).toBe(Date.parse("2026-07-28T18:00:00.000Z"));
     } finally {
       restarted.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("runs a genuine missed slot that occurred after schedule activation", async () => {
+    const store = await makeStorePath();
+    const runCommandJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+    const now = Date.parse("2026-07-30T13:18:00.000Z");
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        {
+          id: "restart-post-activation-slot",
+          name: "daily briefing",
+          enabled: true,
+          createdAtMs: Date.parse("2026-07-01T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2026-07-29T08:00:00.000Z"),
+          schedule: { kind: "cron", expr: "0 12 * * *", tz: "UTC" },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "command", argv: ["echo", "FIRED"] },
+          state: {
+            nextRunAtMs: Date.parse("2026-07-31T12:00:00.000Z"),
+            lastRunAtMs: Date.parse("2026-07-28T12:00:00.000Z"),
+            lastStatus: "ok",
+            scheduleActivatedAtMs: Date.parse("2026-07-29T08:00:00.000Z"),
+          },
+        },
+      ],
+    });
+    const service = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      runCommandJob: runCommandJob as never,
+    });
+
+    try {
+      await service.start();
+
+      expect(runCommandJob).toHaveBeenCalledTimes(1);
+      expect(service.getJob("restart-post-activation-slot")?.state.lastRunAtMs).toBe(now);
+    } finally {
+      service.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("preserves one legacy catch-up for an unstamped pre-upgrade job", async () => {
+    const store = await makeStorePath();
+    const runCommandJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+    const now = Date.parse("2026-07-30T13:18:00.000Z");
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        {
+          id: "restart-legacy-unstamped-slot",
+          name: "legacy daily briefing",
+          enabled: true,
+          createdAtMs: Date.parse("2026-07-01T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2026-07-29T08:00:00.000Z"),
+          schedule: { kind: "cron", expr: "0 12 * * *", tz: "UTC" },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "command", argv: ["echo", "FIRED"] },
+          state: {
+            nextRunAtMs: Date.parse("2026-07-31T12:00:00.000Z"),
+            lastRunAtMs: Date.parse("2026-07-28T12:00:00.000Z"),
+            lastStatus: "ok",
+          },
+        },
+      ],
+    });
+    const createService = () =>
+      new CronService({
+        storePath: store.storePath,
+        cronEnabled: true,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+        runCommandJob: runCommandJob as never,
+      });
+
+    const firstRestart = createService();
+    try {
+      await firstRestart.start();
+      expect(runCommandJob).toHaveBeenCalledTimes(1);
+      expect(firstRestart.getJob("restart-legacy-unstamped-slot")?.state.lastRunAtMs).toBe(now);
+    } finally {
+      firstRestart.stop();
+    }
+
+    const secondRestart = createService();
+    try {
+      await secondRestart.start();
+      expect(runCommandJob).toHaveBeenCalledTimes(1);
+    } finally {
+      secondRestart.stop();
       await store.cleanup();
     }
   });

--- a/src/cron/service.restart-catchup-schedule-change.test.ts
+++ b/src/cron/service.restart-catchup-schedule-change.test.ts
@@ -1,0 +1,82 @@
+// Restart catch-up must not resurrect slots that predate a schedule edit.
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite, writeCronStoreSnapshot } from "./service.test-harness.js";
+
+const { logger: noopLogger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-",
+  baseTimeIso: "2026-07-28T07:18:00.000Z",
+});
+
+describe("CronService restart catch-up after a schedule change", () => {
+  it("does not replay a cron slot that predates the new schedule", async () => {
+    // Real report (#91944): a daily 19:00 job edited to 21:00 at 10:18 fired
+    // immediately when the gateway restarted at 13:18. Yesterday's 21:00 slot
+    // never existed under the old schedule, so it is not a missed run.
+    const store = await makeStorePath();
+    const runCommandJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+    const jobId = "restart-pre-activation-slot";
+    const lastRunUnderOldSchedule = Date.parse("2026-07-27T16:00:00.000Z"); // 27 Jul 19:00 +03
+    const createService = () =>
+      new CronService({
+        storePath: store.storePath,
+        cronEnabled: true,
+        log: noopLogger,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+        runCommandJob: runCommandJob as never,
+      });
+
+    vi.setSystemTime(new Date("2026-07-28T07:18:00.000Z")); // 10:18 Europe/Istanbul
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [
+        {
+          id: jobId,
+          name: "daily briefing",
+          enabled: true,
+          createdAtMs: Date.parse("2026-07-01T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2026-07-01T12:00:00.000Z"),
+          schedule: { kind: "cron", expr: "0 19 * * *", tz: "Europe/Istanbul" },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "command", argv: ["echo", "FIRED"] },
+          state: {
+            nextRunAtMs: Date.parse("2026-07-28T16:00:00.000Z"), // 28 Jul 19:00 +03
+            lastRunAtMs: lastRunUnderOldSchedule,
+            lastStatus: "ok",
+          },
+        },
+      ],
+    });
+
+    const editor = createService();
+    try {
+      await editor.start();
+      await editor.update(jobId, {
+        schedule: { kind: "cron", expr: "0 21 * * *", tz: "Europe/Istanbul" },
+      });
+    } finally {
+      editor.stop();
+    }
+    // The edit itself is not a run; catch-up must stay quiet before the restart.
+    expect(runCommandJob).not.toHaveBeenCalled();
+
+    vi.setSystemTime(new Date("2026-07-28T10:18:00.000Z")); // 13:18 Europe/Istanbul
+    const restarted = createService();
+    try {
+      await restarted.start();
+
+      expect(runCommandJob).not.toHaveBeenCalled();
+      const job = (await restarted.list({ includeDisabled: true })).find(
+        (entry) => entry.id === jobId,
+      );
+      expect(job?.state.lastRunAtMs).toBe(lastRunUnderOldSchedule);
+      expect(job?.state.nextRunAtMs).toBe(Date.parse("2026-07-28T18:00:00.000Z"));
+    } finally {
+      restarted.stop();
+      await store.cleanup();
+    }
+  });
+});

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -2,8 +2,8 @@
 import { describe, expect, it } from "vitest";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
 import { projectCronJobThroughStorageCodec } from "../store/row-codec.js";
-import type { CronJob } from "../types.js";
-import { applyJobPatch } from "./jobs.js";
+import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
+import { applyJobPatch, createJob } from "./jobs.js";
 
 function makeJob(overrides: Partial<CronJob> = {}): CronJob {
   const now = Date.now();
@@ -86,6 +86,44 @@ describe("applyJobPatch schedule retention", () => {
     applyJobPatch(job, { schedule: next });
 
     expect(job.deleteAfterRun).toBe(false);
+  });
+});
+
+describe("schedule activation ownership", () => {
+  it("ignores caller-supplied activation state during creation", () => {
+    const now = Date.parse("2026-07-30T00:00:00.000Z");
+    const input = {
+      name: "owned activation",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: { scheduleActivatedAtMs: now - 60_000 },
+    } as unknown as CronJobCreate;
+
+    const job = createJob(
+      {
+        deps: {
+          nowMs: () => now,
+          defaultAgentId: "main",
+        },
+      } as never,
+      input,
+    );
+
+    expect(job.state.scheduleActivatedAtMs).toBeUndefined();
+  });
+
+  it("ignores caller-supplied activation state during updates", () => {
+    const job = makeJob({ state: { scheduleActivatedAtMs: 456 } });
+    const patch = {
+      state: { scheduleActivatedAtMs: 123 },
+    } as unknown as CronJobPatch;
+
+    applyJobPatch(job, patch);
+
+    expect(job.state.scheduleActivatedAtMs).toBe(456);
   });
 });
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -24,6 +24,7 @@ import type {
   CronJob,
   CronJobCreate,
   CronJobPatch,
+  CronJobState,
 } from "../types.js";
 import { resolveInitialCronDelivery } from "./initial-delivery.js";
 import {
@@ -172,6 +173,10 @@ export function createJob(
   const ownerAgentId = normalizeOptionalAgentId(input.owner?.agentId);
   const ownerSessionKey = normalizeOptionalString(input.owner?.sessionKey);
   const ownerAccountId = normalizeOptionalAccountId(input.owner?.accountId);
+  const initialState = { ...input.state } as Partial<CronJobState>;
+  // Schedule activation is stamped only by committed scheduling mutations.
+  // Accepting caller state here would let imports spoof restart catch-up ownership.
+  delete initialState.scheduleActivatedAtMs;
   const job: CronJob = {
     id,
     ...(declarationKey ? { declarationKey } : {}),
@@ -205,7 +210,7 @@ export function createJob(
     failureAlert: input.failureAlert,
     ...(input.trigger ? { trigger: structuredClone(input.trigger) } : {}),
     state: {
-      ...input.state,
+      ...initialState,
       ...(schedule.kind === "stream"
         ? { streamSourceIdentity: createCronStreamSourceIdentity() }
         : {}),
@@ -376,7 +381,11 @@ export function applyJobPatch(
         : undefined;
   }
   if (patch.state) {
-    job.state = { ...job.state, ...patch.state };
+    const statePatch = { ...patch.state } as Partial<CronJobState>;
+    // Runtime state patches may report execution progress, but the scheduler
+    // alone owns the boundary that decides whether restart catch-up can run.
+    delete statePatch.scheduleActivatedAtMs;
+    job.state = { ...job.state, ...statePatch };
   }
   if ("agentId" in patch) {
     job.agentId = normalizeOptionalAgentId((patch as { agentId?: unknown }).agentId);

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -115,6 +115,10 @@ function finalizeUpdatedJob(params: {
 
   nextJob.updatedAtMs = now;
   if (schedulingInputsChanged) {
+    // Anchor restart catch-up to the new inputs. Without this, startup replays a
+    // slot the previous schedule never had, because lastRunAtMs still belongs to
+    // the old one and looks perpetually stale against the new slots (#91944).
+    nextJob.state.scheduleActivatedAtMs = now;
     nextJob.state.startupCatchupAtMs = undefined;
     // A paced timestamp is owned by the exact schedule, pacing bounds, and
     // trigger mode that produced it. Configuration changes release both the

--- a/src/cron/service/timer-catchup.ts
+++ b/src/cron/service/timer-catchup.ts
@@ -2,7 +2,6 @@ import { markCronJobActive } from "../active-jobs.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import { normalizeCronRunErrorText } from "./execution-errors.js";
 import {
-  computeJobPreviousRunAtMs,
   DEFAULT_ERROR_BACKOFF_SCHEDULE_MS,
   isJobEnabled,
   recomputeNextRunsForMaintenance,
@@ -35,7 +34,11 @@ import {
   clearUnstartedStartupCatchupReservationMarkers,
   createCompletedCronRunOutcomeDrain,
 } from "./timer-outcome-finalization.js";
-import { collectRunnableJobs, isRunnableJob } from "./timer-runnable.js";
+import {
+  collectRunnableJobs,
+  hasMissedCronSlotSinceLastRun,
+  isRunnableJob,
+} from "./timer-runnable.js";
 import { maybeNotifyIsolatedAgentSetupTimeout } from "./timer-scheduler.js";
 
 function deferPendingBackoffMissedCronSlots(
@@ -61,20 +64,7 @@ function deferPendingBackoffMissedCronSlots(
     if (backoffUntilMs === undefined || nowMs >= backoffUntilMs) {
       continue;
     }
-    let previousRunAtMs: number | undefined;
-    try {
-      previousRunAtMs = computeJobPreviousRunAtMs(job, nowMs);
-    } catch {
-      continue;
-    }
-    const lastRunAtMs = job.state.lastRunAtMs;
-    if (
-      typeof previousRunAtMs !== "number" ||
-      !Number.isFinite(previousRunAtMs) ||
-      typeof lastRunAtMs !== "number" ||
-      !Number.isFinite(lastRunAtMs) ||
-      previousRunAtMs <= lastRunAtMs
-    ) {
+    if (!hasMissedCronSlotSinceLastRun(job, nowMs)) {
       continue;
     }
     if (job.state.nextRunAtMs !== backoffUntilMs) {

--- a/src/cron/service/timer-runnable.ts
+++ b/src/cron/service/timer-runnable.ts
@@ -13,6 +13,40 @@ import {
 import type { CronServiceState } from "./state.js";
 import { isScheduledTerminalOneShotRetry } from "./timer-trigger.js";
 
+/**
+ * Reports whether a cron job's last completed run is older than its previous
+ * effective slot, which is how restart catch-up detects a missed run once
+ * nextRunAtMs has already advanced past it.
+ */
+export function hasMissedCronSlotSinceLastRun(job: CronJob, nowMs: number): boolean {
+  const lastRunAtMs = job.state.lastRunAtMs;
+  // Only replay a "missed slot" when there is concrete run history.
+  if (typeof lastRunAtMs !== "number" || !Number.isFinite(lastRunAtMs)) {
+    return false;
+  }
+  let previousRunAtMs: number | undefined;
+  try {
+    previousRunAtMs = computeJobPreviousRunAtMs(job, nowMs);
+  } catch {
+    return false;
+  }
+  if (
+    typeof previousRunAtMs !== "number" ||
+    !Number.isFinite(previousRunAtMs) ||
+    previousRunAtMs <= lastRunAtMs
+  ) {
+    return false;
+  }
+  // Slots computed from freshly edited scheduling inputs never existed before
+  // those inputs took effect, so they are not missed runs. lastRunAtMs belongs
+  // to the retired schedule and would otherwise stay stale forever (#91944).
+  const activatedAtMs = job.state.scheduleActivatedAtMs;
+  if (typeof activatedAtMs !== "number" || !Number.isFinite(activatedAtMs)) {
+    return true;
+  }
+  return previousRunAtMs > activatedAtMs;
+}
+
 export function isRunnableJob(params: {
   state: CronServiceState;
   job: CronJob;
@@ -86,21 +120,7 @@ export function isRunnableJob(params: {
   if (!params.allowCronMissedRunByLastRun || job.schedule.kind !== "cron") {
     return false;
   }
-  let previousRunAtMs: number | undefined;
-  try {
-    previousRunAtMs = computeJobPreviousRunAtMs(job, nowMs);
-  } catch {
-    return false;
-  }
-  if (typeof previousRunAtMs !== "number" || !Number.isFinite(previousRunAtMs)) {
-    return false;
-  }
-  const lastRunAtMs = job.state.lastRunAtMs;
-  if (typeof lastRunAtMs !== "number" || !Number.isFinite(lastRunAtMs)) {
-    // Only replay a "missed slot" when there is concrete run history.
-    return false;
-  }
-  return previousRunAtMs > lastRunAtMs;
+  return hasMissedCronSlotSinceLastRun(job, nowMs);
 }
 
 function isErrorBackoffPending(_state: CronServiceState, job: CronJob, nowMs: number): boolean {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -360,6 +360,13 @@ type CronScriptPayloadPatch = {
 /** Mutable runtime state persisted beside the immutable cron job spec. */
 export type CronJobState = {
   nextRunAtMs?: number;
+  /**
+   * When the current scheduling inputs took effect. Restart catch-up replays a
+   * missed slot only when the slot is newer than this, because slots computed
+   * from a freshly edited schedule never existed under the old one. Absent on
+   * jobs whose schedule has not changed, where every computed slot is real.
+   */
+  scheduleActivatedAtMs?: number;
   /** Exact startup catch-up slot protected from future-slot repair across restarts. */
   startupCatchupAtMs?: number;
   /** Exact paced completion slot protected from future-slot repair until consumed. */

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -486,7 +486,9 @@ export type CronStoreFile = {
   jobs: CronJob[];
 };
 
-type CronJobStateInput = Partial<Omit<CronJobState, "streamSourceIdentity">>;
+type CronJobStateInput = Partial<
+  Omit<CronJobState, "scheduleActivatedAtMs" | "streamSourceIdentity">
+>;
 
 /** Create input accepted by cron APIs before id/timestamps/state are assigned. */
 export type CronJobCreate = Omit<


### PR DESCRIPTION
Closes #91944

## What Problem This Solves

Fixes an issue where users who edit a recurring cron job's schedule would see that job fire immediately the next time the gateway restarts, instead of only at its new time. A daily job moved from 19:00 to 21:00 fires right after the restart, and then again at 21:00. For scheduled outbound messaging jobs this delivers a message at the wrong time, which is what the linked report describes.

## Why This Change Was Made

Startup catch-up decided a slot was "missed" by computing the previous slot of the *current* schedule and comparing it against `lastRunAtMs`, which still belongs to the schedule that was just replaced. A slot that never existed under the old schedule therefore looked overdue forever.

The scheduler now records when scheduling inputs take effect (`state.scheduleActivatedAtMs`) and replays a missed slot only when that slot is newer than the boundary. The stamp is written in the existing `schedulingInputsChanged` branch of `finalizeUpdatedJob`, the same place that already releases `startupCatchupAtMs`, `pacedNextRunAtMs`, and `forcePreservedNextRunAtMs`, so no new notion of "the schedule changed" was introduced. Jobs with no stamp keep replaying every computed slot, so catch-up behaviour is completely unchanged for jobs whose schedule was never edited.

The missed-slot predicate was duplicated in the runnable check and in the backoff-deferral pass, so both now share one helper and the bound cannot drift between them.

No SQLite schema change and no migration are involved: cron job state persists as JSON in `state_json` and `stateFromRow` already preserves unknown runtime fields, exactly like the existing `startupCatchupAtMs` and `pacedNextRunAtMs` fields.

**Legacy rows are intentionally left alone.** An earlier revision of this PR also backfilled the boundary during `openclaw doctor --fix`, using `updatedAtMs` as the stamp. ClawSweeper correctly rejected that: `updatedAtMs` advances for renames, payload edits, and delivery edits, so a legacy job that genuinely missed a slot and was later edited would have had that real catch-up suppressed after upgrade. Per the review's recommended resolution, that commit is dropped and legacy catch-up semantics are preserved exactly as they are today. The residual gap is narrow and self-healing: a job whose schedule was edited *before* upgrading can still replay once on the first restart after upgrade, after which its `lastRunAtMs` advances and the boundary applies normally. Closing that gap needs a trustworthy activation record rather than an inferred one, so it is deliberately out of scope here.

**Prior art.** This is a port of the approach in #92398 by @amersheeny, which built on #92305 by @fsdwen. #92398 was closed by the stale bot after 27 days of inactivity rather than on technical grounds, and ClawSweeper's review of #91944 asks for a scheduler-owned activation boundary. One deliberate divergence: #92398 also read `?? updatedAtMs` as a runtime fallback for legacy jobs. This PR has no such fallback in the runtime path, for the same reason the doctor backfill was dropped — and concretely, the existing case at `src/cron/service.restart-catchup.test.ts:612` has `updatedAtMs` equal to the missed slot itself, so a runtime fallback would suppress a legitimate catch-up there.

**Scope.** This fixes the restart-replay mechanism that ClawSweeper identified as the canonical root cause for #91944. It does not address that report's separate suggestion about doctor preflight re-reading `jobs.json.migrated` and overwriting SQLite; I could not reproduce that on current `main`.

## User Impact

Editing a cron job's schedule no longer causes a spurious run on the next gateway restart. Jobs whose schedule is never edited behave exactly as before, and nothing rewrites existing persisted job state on upgrade.

## Evidence

### Real gateway restart, before and after

Both runs use the same script against a real gateway on an isolated `OPENCLAW_STATE_DIR` and a free port, driven entirely through the CLI (`cron add`, `cron edit --cron`), with a real command job appending to a file each time it fires. The job really runs on schedule A, schedule B's slot then passes while A is still active, the schedule is edited A→B, and the gateway is stopped and restarted.

**Before — clean `upstream/main` at `c193ffd554`:**

```
  schedule A : '47 16 * * *'   fires at 16:47
  schedule B : '48 16 * * *'   its slot 16:48 passes while A is still active
  edit A->B  : 16:49
  restart    : 16:50

=== RESULT ===
  fires before restart : 1
  fires after restart  : 2
  fired.log:
    2026-07-29T16:47:00+03:00
    2026-07-29T16:50:18+03:00      <-- restart moment, not a scheduled slot
  lastRunAtMs = 2026-07-29T13:50:18.625Z
  FAIL: restart replayed a slot from before the schedule edit
```

**After — this branch:**

```
  schedule A : '37 16 * * *'   fires at 16:37
  schedule B : '38 16 * * *'   its slot 16:38 passes while A is still active
  edit A->B  : 16:39
  restart    : 16:40

=== RESULT ===
  fires before restart : 1
  fires after restart  : 1
  fired.log:
    2026-07-29T16:37:00+03:00
  lastRunAtMs = 2026-07-29T13:37:00.023Z
  nextRunAtMs = 2026-07-30T13:38:00.000Z
  PASS: restart did not replay the pre-edit slot
```

The `16:50:18` line is the reported symptom: the job fires at the moment of the restart rather than at any slot of either schedule.

### Focused tests and checks

`src/cron/service.restart-catchup-schedule-change.test.ts` reproduces the same flow in-process: it seeds the job on the old schedule, starts the service, edits the schedule through `cron.update()`, stops the service, advances the clock, and starts a second service against the same store. It fails on current `main` and passes with this change.

Verified locally on Node 24.18.0:

- `node scripts/run-vitest.mjs src/cron src/commands/doctor/cron` — 168 files, 2056 tests passed
- `pnpm build` — succeeded, no `INEFFECTIVE_DYNAMIC_IMPORT` warnings
- `pnpm check` — 21 of 22 steps green, including the max-lines suppression ratchet, the database-first legacy-store guard, and all three typecheck projects. The one failure is `format`, on `scripts/code-mode-model-matrix.ts`, which this branch does not touch; that file is already unformatted on `main` (`git show upstream/main:scripts/code-mode-model-matrix.ts` fails `oxfmt --check` on its own).

### About the red checks on this PR

The failing shards are `src/tui/tui-pty-local.e2e.test.ts` and `src/cli/help-exit.process.test.ts`, plus `openclaw/ci-gate`, which only aggregates them. Neither test file imports anything under `src/cron/**`, which is the entire surface this branch touches, and checking out clean `upstream/main` at `c193ffd554` and running `node scripts/run-vitest.mjs src/cli/help-exit.process.test.ts` reproduces the identical result there: 4 failed, 48 passed. I left them alone rather than folding unrelated fixes into this PR, but I am happy to rebase onto a greener `main` if a maintainer prefers.
