### PR TITLE
fix(qa): require exact script producer evidence bundle

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -145,10 +145,9 @@ async function writeScriptProducerEvidence(params: {
   failureReason?: string;
 }) {
   const scenarioArtifactBase = path.join(params.outputDir, params.scenarioId ?? "scenario-script");
-  const runRoot = path.join(scenarioArtifactBase, "run-1");
-  await fs.mkdir(runRoot, { recursive: true });
+  await fs.mkdir(scenarioArtifactBase, { recursive: true });
   await fs.writeFile(
-    path.join(runRoot, "qa-evidence.json"),
+    path.join(scenarioArtifactBase, "qa-evidence.json"),
     `${JSON.stringify(
       {
         kind: "openclaw.qa.evidence-summary",
@@ -191,7 +190,7 @@ async function writeScriptProducerEvidence(params: {
   );
   await fs.writeFile(
     path.join(scenarioArtifactBase, "latest-run.json"),
-    `${JSON.stringify({ qaEvidence: path.join(runRoot, "qa-evidence.json") }, null, 2)}\n`,
+    `${JSON.stringify({ qaEvidence: "qa-evidence.json" }, null, 2)}\n`,
     "utf8",
   );
 }
@@ -538,7 +537,7 @@ describe("qa test file scenario runner", () => {
     { evidence: "stale", expectedFailure: /without writing fresh producer QA evidence/u },
     { evidence: "empty", expectedFailure: /without reporting an executed producer check/u },
     { evidence: "malformed", expectedFailure: /invalid JSON/u },
-    { evidence: "outside", expectedFailure: /inside its scenario output directory/u },
+    { evidence: "alternate-pointer", expectedFailure: /must reference qa-evidence\.json/u },
   ] as const)(
     "fails a successful script with $evidence producer evidence",
     async ({ evidence, expectedFailure }) => {
@@ -550,13 +549,8 @@ describe("qa test file scenario runner", () => {
 
       if (evidence === "stale") {
         await writeScriptProducerEvidence({ outputDir, status: "pass" });
-        const staleEvidencePath = path.join(scenarioOutputDir, "run-1", "qa-evidence.json");
-        await fs.copyFile(staleEvidencePath, evidencePath);
         const staleTimestamp = new Date(Date.now() - 60_000);
-        await Promise.all([
-          fs.utimes(staleEvidencePath, staleTimestamp, staleTimestamp),
-          fs.utimes(evidencePath, staleTimestamp, staleTimestamp),
-        ]);
+        await fs.utimes(evidencePath, staleTimestamp, staleTimestamp);
       }
 
       const result = await runQaTestFileScenarios({
@@ -570,13 +564,6 @@ describe("qa test file scenario runner", () => {
           if (evidence === "stale") {
             await expect(fs.access(latestRunPath)).rejects.toMatchObject({ code: "ENOENT" });
             await expect(fs.access(evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
-            await fs.writeFile(
-              latestRunPath,
-              JSON.stringify({
-                qaEvidence: path.join(scenarioOutputDir, "run-1", "qa-evidence.json"),
-              }),
-              "utf8",
-            );
           } else if (evidence === "empty") {
             await fs.writeFile(
               evidencePath,
@@ -591,22 +578,17 @@ describe("qa test file scenario runner", () => {
             );
           } else if (evidence === "malformed") {
             await fs.writeFile(evidencePath, "{not valid JSON", "utf8");
-          } else if (evidence === "outside") {
-            await writeScriptProducerEvidence({
-              outputDir,
-              scenarioId: "different-script-scenario",
-              status: "pass",
-            });
+          } else if (evidence === "alternate-pointer") {
             await fs.writeFile(
               latestRunPath,
-              JSON.stringify({
-                qaEvidence: path.join(
-                  outputDir,
-                  "different-script-scenario",
-                  "run-1",
-                  "qa-evidence.json",
-                ),
-              }),
+              JSON.stringify({ qaEvidence: "run-1/qa-evidence.json" }),
+              "utf8",
+            );
+          }
+          if (evidence === "empty" || evidence === "malformed") {
+            await fs.writeFile(
+              latestRunPath,
+              JSON.stringify({ qaEvidence: "qa-evidence.json" }),
               "utf8",
             );
           }
@@ -665,7 +647,7 @@ describe("qa test file scenario runner", () => {
         await fs.mkdir(path.join(runRoot, "surfaces", "web-ui"), { recursive: true });
         await fs.writeFile(path.join(runRoot, "surfaces", "web-ui", "screenshot.png"), "png");
         await fs.writeFile(
-          path.join(runRoot, "qa-evidence.json"),
+          path.join(scenarioArtifactBase, "qa-evidence.json"),
           `${JSON.stringify(
             {
               kind: "openclaw.qa.evidence-summary",
@@ -698,7 +680,7 @@ describe("qa test file scenario runner", () => {
                     artifacts: [
                       {
                         kind: "screenshot",
-                        path: "surfaces/web-ui/screenshot.png",
+                        path: "run-1/surfaces/web-ui/screenshot.png",
                         source: "script-producer:web-ui:smoke",
                       },
                     ],
@@ -714,7 +696,7 @@ describe("qa test file scenario runner", () => {
         );
         await fs.writeFile(
           path.join(scenarioArtifactBase, "latest-run.json"),
-          `${JSON.stringify({ qaEvidence: path.join(runRoot, "qa-evidence.json") }, null, 2)}\n`,
+          `${JSON.stringify({ qaEvidence: "qa-evidence.json" }, null, 2)}\n`,
           "utf8",
         );
         return {
@@ -1045,10 +1027,9 @@ describe("qa test file scenario runner", () => {
           "scenario-script-failed",
           "scenario-script",
         );
-        const runRoot = path.join(scenarioArtifactBase, "run-1");
-        await fs.mkdir(runRoot, { recursive: true });
+        await fs.mkdir(scenarioArtifactBase, { recursive: true });
         await fs.writeFile(
-          path.join(runRoot, "qa-evidence.json"),
+          path.join(scenarioArtifactBase, "qa-evidence.json"),
           `${JSON.stringify(
             {
               kind: "openclaw.qa.evidence-summary",
@@ -1097,7 +1078,7 @@ describe("qa test file scenario runner", () => {
         );
         await fs.writeFile(
           path.join(scenarioArtifactBase, "latest-run.json"),
-          `${JSON.stringify({ qaEvidence: path.join(runRoot, "qa-evidence.json") }, null, 2)}\n`,
+          `${JSON.stringify({ qaEvidence: "qa-evidence.json" }, null, 2)}\n`,
           "utf8",
         );
         return {
@@ -1180,10 +1161,9 @@ describe("qa test file scenario runner", () => {
           "scenario-script-producer-fail",
           "scenario-script",
         );
-        const runRoot = path.join(scenarioArtifactBase, "run-1");
-        await fs.mkdir(runRoot, { recursive: true });
+        await fs.mkdir(scenarioArtifactBase, { recursive: true });
         await fs.writeFile(
-          path.join(runRoot, "qa-evidence.json"),
+          path.join(scenarioArtifactBase, "qa-evidence.json"),
           `${JSON.stringify(
             {
               kind: "openclaw.qa.evidence-summary",
@@ -1232,7 +1212,7 @@ describe("qa test file scenario runner", () => {
         );
         await fs.writeFile(
           path.join(scenarioArtifactBase, "latest-run.json"),
-          `${JSON.stringify({ qaEvidence: path.join(runRoot, "qa-evidence.json") }, null, 2)}\n`,
+          `${JSON.stringify({ qaEvidence: "qa-evidence.json" }, null, 2)}\n`,
           "utf8",
         );
         return {
@@ -1394,6 +1374,11 @@ describe("qa test file scenario runner", () => {
           })}\n`,
           "utf8",
         );
+        await fs.writeFile(
+          path.join(scenarioOutputDir, "latest-run.json"),
+          '{"qaEvidence":"qa-evidence.json"}\n',
+          "utf8",
+        );
         return { exitCode: 0, stdout: "script pass\n", stderr: "" };
       },
       env: {
@@ -1464,6 +1449,11 @@ describe("qa test file scenario runner", () => {
               },
             ],
           })}\n`,
+          "utf8",
+        );
+        await fs.writeFile(
+          path.join(scenarioOutputDir, "latest-run.json"),
+          '{"qaEvidence":"qa-evidence.json"}\n',
           "utf8",
         );
         return { exitCode: 0, stdout: "script pass\n", stderr: "" };

--- a/extensions/qa-lab/src/test-file-scenario-script-evidence.ts
+++ b/extensions/qa-lab/src/test-file-scenario-script-evidence.ts
@@ -71,17 +71,6 @@ function normalizeScriptProducerEvidence(params: {
   };
 }
 
-function assertScenarioOwnsEvidencePath(scenarioOutputDir: string, evidencePath: string): void {
-  const relativePath = path.relative(scenarioOutputDir, evidencePath);
-  if (
-    relativePath === ".." ||
-    relativePath.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relativePath)
-  ) {
-    throw new Error("producer evidence must remain inside its scenario output directory");
-  }
-}
-
 export async function readScriptProducerEvidence(params: {
   outputDir: string;
   requireCurrentRunEvidence?: boolean;
@@ -90,16 +79,30 @@ export async function readScriptProducerEvidence(params: {
 }): Promise<{ producerEvidence?: QaEvidenceSummaryJson }> {
   const scenarioOutputDir = path.join(params.outputDir, params.scenario.id);
   const latestRun = await readJsonFileIfExists(path.join(scenarioOutputDir, "latest-run.json"));
-  if (
-    params.requireCurrentRunEvidence === true &&
-    latestRun !== undefined &&
-    (latestRun === null ||
+  if (params.requireCurrentRunEvidence === true) {
+    if (latestRun === undefined) {
+      return {};
+    }
+    if (
+      latestRun === null ||
       typeof latestRun !== "object" ||
       !("qaEvidence" in latestRun) ||
-      typeof latestRun.qaEvidence !== "string" ||
-      latestRun.qaEvidence.trim().length === 0)
-  ) {
-    throw new Error("latest-run.json does not identify a producer evidence bundle");
+      latestRun.qaEvidence !== QA_EVIDENCE_FILENAME
+    ) {
+      throw new Error(`latest-run.json must reference ${QA_EVIDENCE_FILENAME}`);
+    }
+    const evidencePath = path.join(scenarioOutputDir, QA_EVIDENCE_FILENAME);
+    const rawEvidence = await readJsonFileIfExists(evidencePath);
+    if (rawEvidence === undefined) {
+      return {};
+    }
+    return {
+      producerEvidence: normalizeScriptProducerEvidence({
+        evidence: validateQaEvidenceSummaryJson(rawEvidence),
+        evidencePath,
+        repoRoot: params.repoRoot,
+      }),
+    };
   }
   const latestEvidencePath =
     latestRun !== null &&
@@ -117,22 +120,6 @@ export async function readScriptProducerEvidence(params: {
     const evidencePath = path.isAbsolute(candidate)
       ? candidate
       : path.join(scenarioOutputDir, candidate);
-    if (params.requireCurrentRunEvidence === true) {
-      assertScenarioOwnsEvidencePath(scenarioOutputDir, evidencePath);
-      const evidenceStat = await fs.stat(evidencePath).catch((error: unknown) => {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-          return undefined;
-        }
-        throw error;
-      });
-      if (!evidenceStat) {
-        continue;
-      }
-      assertScenarioOwnsEvidencePath(
-        await fs.realpath(scenarioOutputDir),
-        await fs.realpath(evidencePath),
-      );
-    }
     const rawEvidence = await readJsonFileIfExists(evidencePath);
     if (!rawEvidence) {
       continue;


### PR DESCRIPTION
Closes #115758

Related: #115404 landed the broad missing/stale/empty/malformed freshness fix while this PR was open, closing #115758. This rebased PR now contains only the remaining exact two-file bundle tightening. Concurrent #115778 closed unmerged.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Current main invalidates generic script output directories and fails missing, stale, empty, or malformed producer evidence, but its required-evidence reader still accepts alternate pointer targets and an indexless direct fallback that no current generic producer writes.

## Why This Change Was Made

Generic non-Docker scripts now require the exact `createQaScriptEvidenceWriter` commit marker: `latest-run.json` must reference `qa-evidence.json`, and that direct evidence file must exist. This removes alternate required-evidence paths while preserving current main's whole-directory freshness invalidation and status/error handling.

Optional evidence resolution for individually launched Docker scripts remains unchanged, as does the aggregate Docker batch owner.

## User Impact

Generic script scenarios accept only the evidence layout emitted by every current producer, eliminating unused alternate-path behavior without changing Docker or blocked/skipped policy.

## Evidence

- Focused runner proof: `node scripts/run-vitest.mjs extensions/qa-lab/src/test-file-scenario-runner.test.ts` — 1 file, 32 tests passed on the rebased head.
- Changed gate: [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30511890934) timed out syncing before repository execution; the local fallback was stopped when it began unrelated cross-platform dependency reconciliation. Exact-head CI completed with 81 successes, 36 intentional skips, 1 neutral result, and no failures; required [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/30516928811/job/90790435784) passed.
- Fresh post-rebase autoreview against `origin/main`: no accepted/actionable findings; TruffleHog clean.
- [ClawSweeper exact-head review worker](https://github.com/openclaw/clawsweeper/actions/runs/30516837667): no code findings; its later record-commit step failed before replacing the public placeholder. The prior [published review](https://github.com/openclaw/openclaw/pull/115780#issuecomment-5118139433) reached the same result: maintainer confirmation of the exact two-file compatibility boundary remains the merge decision.
- Catalog audit: all 15 current generic script scenarios pass `outputDir` and use `createQaScriptEvidenceWriter`; the 19 Docker scenarios remain under the separate batch owner.
