### PR TITLE
fix(agents): hide UTF-8 BOMs from file-reading tools

### DIFF
--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -248,6 +248,26 @@ describe("read tool", () => {
     expect(textContent(result)).toBe(bytes.toString("utf8"));
   });
 
+  it("strips one leading UTF-8 BOM without changing embedded markers", async () => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        detectImageMimeType: async () => null,
+        readFile: async () => Buffer.from("\uFEFFimport value\nconst marker = '\uFEFF';"),
+      },
+    });
+
+    const result = await tool.execute(
+      "call-1",
+      { path: "source.ts" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe("import value\nconst marker = '\uFEFF';");
+  });
+
   it("uses an injected backend decoder when declared", async () => {
     const bytes = Buffer.from([0xc4, 0xe3, 0xba, 0xc3]);
     const tool = createReadToolDefinition("/workspace", {

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -408,8 +408,11 @@ export function createReadToolDefinition(
             } else {
               // Read text content.
               const buffer = await ops.readFile(absolutePath);
-              const textContent =
+              const decodedText =
                 ops.decodeText?.({ buffer, absolutePath }) ?? buffer.toString("utf8");
+              const textContent = decodedText.startsWith("\uFEFF")
+                ? decodedText.slice(1)
+                : decodedText;
               const allLines = textContent.split("\n");
               const totalFileLines = allLines.length;
               // Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.


### PR DESCRIPTION
Closes #113828
Supersedes #113829

## What Problem This Solves

Fixes an issue where users reading UTF-8 BOM-prefixed files would expose an invisible leading character to agent models, breaking exact first-line interpretation, especially on Windows and sandboxed or remote file backends.

## Why This Change Was Made

Retain the original contributor's exact two-file fix: normalize exactly one leading U+FEFF only in the decoded, model-visible built-in read-tool result. Preserve custom and Windows decoders, embedded markers, line offsets, byte truncation, binary images, persisted file bytes, Gateway file previews, edit/apply-patch behavior, and Codex's independently inspected byte-preserving filesystem contract.

## User Impact

Agents see the real first source character across local, remote, sandboxed, and Windows-backed reads. Existing files remain byte-for-byte untouched; editing and Gateway preview continue to preserve the original BOM.

## Evidence

Before the fix, a real BOM-prefixed file on current main exposed U+FEFF through the production default filesystem, the actual file-backed fallback decoder, and a file-backed custom decoder:

```text
BASELINE_REAL_DEFAULT_FILESYSTEM=FAILURE_REPRODUCED first=U+FEFF markers=2 rawPrefix=efbbbf
BASELINE_REAL_FILE_BACKED_FALLBACK_DECODER=FAILURE_REPRODUCED first=U+FEFF
BASELINE_REAL_FILE_BACKED_CUSTOM_DECODER=FAILURE_REPRODUCED first=U+FEFF
```

After applying the contributor's byte-identical patch on current main, a trusted Blacksmith Testbox ran the real production tools against real files:

```text
FIXED_REAL_DEFAULT_FILESYSTEM=PASS first=U+0069 embeddedMarkers=1 rawPrefix=efbbbf
FIXED_REAL_FILE_BACKED_FALLBACK_DECODER=PASS
FIXED_REAL_FILE_BACKED_CUSTOM_DECODER=PASS
EXACTLY_ONE_LEADING_BOM_REMOVED=PASS second_marker_preserved
REAL_OFFSET_AND_EMBEDDED_MARKER=PASS
REAL_BYTE_TRUNCATION_BOUNDARY=PASS metadataExcluded=3 logicalBytes=51200
REAL_BINARY_IMAGE_READ_UNCHANGED=PASS
REAL_READ_NEVER_MUTATES_BOM_BYTES=PASS
REAL_EDIT_PRESERVES_ORIGINAL_AND_EMBEDDED_BOM_BYTES=PASS
```

- 476 tests across 21 read, edit, patch, sandbox, Windows, Gateway, upstream-provider and original failing gateway-startup files.
- Fresh current-main core/extensions/root test typechecks and complete two-file changed gate.
- Full production, full-tree and script dead-code scans.
- Fresh independent Codex `gpt-5.6-sol` xhigh review: clean; correctness 0.98.
- Personally verified Codex upstream `fe01054a28fa4bd04716d9ceadb410f2443a50ce`: `codex-rs/app-server-protocol/src/protocol/v2/fs.rs`, `codex-rs/app-server/src/request_processors/fs_processor.rs`, and `codex-rs/protocol/src/dynamic_tools.rs`; raw filesystem reads remain base64-encoded bytes, while dynamic tool output remains separately decoded text.
- Exact contributor patch from #113829 verified hunk-for-hunk; original contributor retained in the commit co-author trailer. The replacement supplies fresh base-repository hosted CI because the original fork's old run failed in unrelated Gateway-startup tests; those exact 57 tests now pass on current main.
