### PR TITLE
fix(cli): prevent macOS DNS setup from hanging on Homebrew

### DIFF
--- a/src/cli/dns-cli.test.ts
+++ b/src/cli/dns-cli.test.ts
@@ -1,0 +1,108 @@
+// Regression: the dns setup brew-prefix probe must be bounded by a SIGKILL-backed
+// timeout so a hung binary cannot block `openclaw dns setup`, while long-running
+// setup steps (install/restart/sudo writes) stay unbounded.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+const testState = vi.hoisted(() => ({ zonePath: "" }));
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeChildProcessSpawnSync } = await import("openclaw/plugin-sdk/test-node-mocks");
+  return mockNodeChildProcessSpawnSync(spawnSyncMock, () =>
+    vi.importActual<typeof import("node:child_process")>("node:child_process"),
+  );
+});
+
+vi.mock("../infra/widearea-dns.js", async () => {
+  return {
+    getWideAreaZonePath: () => testState.zonePath,
+    normalizeWideAreaDomain: (d: string) => d,
+    resolveWideAreaDiscoveryDomain: () => "openclaw.internal.",
+  };
+});
+
+vi.mock("../infra/tailnet.js", async () => {
+  return {
+    pickPrimaryTailnetIPv4: () => "100.64.0.1",
+    pickPrimaryTailnetIPv6: () => undefined,
+  };
+});
+
+vi.mock("../config/config.js", async () => {
+  return { getRuntimeConfig: () => ({}) };
+});
+
+import { Command } from "commander";
+import { withMockedPlatform } from "../test-utils/vitest-spies.js";
+import { registerDnsCli } from "./dns-cli.js";
+
+function spawnOk(stdout = "") {
+  return { stdout, stderr: "", pid: 1, output: [], status: 0, signal: null };
+}
+
+function isBrewPrefixProbe(call: unknown[]): boolean {
+  const args = call[1] as string[] | undefined;
+  return call[0] === "brew" && args?.[0] === "--prefix";
+}
+
+describe("dns-cli probe bounds", () => {
+  let brewPrefix: string;
+
+  beforeEach(() => {
+    // A real writable temp prefix lets the un-mocked fs writes (Corefile, conf.d,
+    // zone bootstrap) succeed on Linux CI without touching sudo paths.
+    brewPrefix = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-dns-cli-test-"));
+    testState.zonePath = path.join(brewPrefix, "test.zone");
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === "brew" && args?.[0] === "--prefix") {
+        return spawnOk(`${brewPrefix}\n`);
+      }
+      return spawnOk();
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(brewPrefix, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  async function runDnsSetupApply(): Promise<void> {
+    const program = new Command();
+    program.exitOverride();
+    registerDnsCli(program);
+    // The action gates on process.platform; os.platform() is not consulted.
+    await withMockedPlatform("darwin", () =>
+      program.parseAsync([
+        "node",
+        "openclaw",
+        "dns",
+        "setup",
+        "--domain",
+        "openclaw.internal",
+        "--apply",
+      ]),
+    );
+  }
+
+  it("bounds the brew prefix probe with a SIGKILL-backed timeout", async () => {
+    await runDnsSetupApply();
+
+    const probeCall = spawnSyncMock.mock.calls.find(isBrewPrefixProbe);
+    expect(probeCall).toBeDefined();
+    expect(probeCall?.[2]).toMatchObject({ timeout: 15_000, killSignal: "SIGKILL" });
+  });
+
+  it("leaves long-running setup subprocesses unbounded", async () => {
+    await runDnsSetupApply();
+
+    const nonProbeCalls = spawnSyncMock.mock.calls.filter((call) => !isBrewPrefixProbe(call));
+    expect(nonProbeCalls.length).toBeGreaterThan(0);
+    for (const call of nonProbeCalls) {
+      expect(call[2]?.timeout).toBeUndefined();
+    }
+  });
+});

--- a/src/cli/dns-cli.ts
+++ b/src/cli/dns-cli.ts
@@ -15,12 +15,18 @@ import {
 } from "../infra/widearea-dns.js";
 import { defaultRuntime } from "../runtime.js";
 
-type RunOpts = { allowFailure?: boolean; inherit?: boolean };
+type RunOpts = { allowFailure?: boolean; inherit?: boolean; timeoutMs?: number };
 
 function run(cmd: string, args: string[], opts?: RunOpts): string {
   const res = spawnSync(cmd, args, {
     encoding: "utf-8",
     stdio: opts?.inherit ? "inherit" : "pipe",
+    // Timeout stays opt-in: install/restart/sudo-write steps may legitimately run
+    // long, so only fast probes pass a deadline. SIGKILL guarantees a
+    // signal-resistant hung probe still dies at the deadline.
+    ...(opts?.timeoutMs === undefined
+      ? {}
+      : { timeout: opts.timeoutMs, killSignal: "SIGKILL" as const }),
   });
   if (res.error) {
     throw res.error;
@@ -87,7 +93,8 @@ function zoneFileNeedsBootstrap(zonePath: string): boolean {
 }
 
 function detectBrewPrefix(): string {
-  const out = run("brew", ["--prefix"]);
+  // A hung brew shim can block setup indefinitely; bound only this fast probe.
+  const out = run("brew", ["--prefix"], { timeoutMs: 15_000 });
   const prefix = out.trim();
   if (!prefix) {
     throw new Error("failed to resolve Homebrew prefix");


### PR DESCRIPTION
Related: #110671

## What Problem This Solves

Fixes an issue where macOS users running `openclaw dns setup --domain openclaw.internal --apply` would wait indefinitely when `brew --prefix` or a Homebrew shim hangs and ignores `SIGTERM`.

## Why This Change Was Made

Preserves @xydigit-zt's original authored fix from #110671 and applies its exact stable patch (`3e0ad840615f8442160e2cc712a5f7fe986f1cfb`) to current `main`, resolving only the genuine upstream conflict. Only the quick Homebrew-prefix probe receives a 15-second, `SIGKILL`-backed timeout; legitimate Homebrew installs, service restarts, and interactive sudo operations remain unbounded. The commit retains the original contributor as its Git author and records the original commit in its cherry-pick provenance.

## User Impact

macOS DNS setup now fails promptly with the actual Homebrew timeout instead of hanging indefinitely or leaving the signal-resistant probe running. Normal CoreDNS installation and interactive privilege escalation retain their existing behavior.

## Evidence

- Real macOS, actual registered Commander `dns setup --domain openclaw.internal --apply`, and a real executable Homebrew fixture that ignores `SIGTERM`: current `main` remains hung; this exact head returns after the 15-second deadline with `spawnSync brew ETIMEDOUT` and the captured Homebrew process no longer exists (`ESRCH`).
- Current-main Linux Blacksmith Testbox: `pnpm test src/cli/dns-cli.test.ts src/cli/cli-utils.test.ts` — **54 tests passed**, including the bounded probe and unchanged long-running subprocess behavior.
- Same exact patch and Testbox: `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed -- src/cli/dns-cli.ts src/cli/dns-cli.test.ts` — **passed all changed-file, formatting, typecheck, lint, dependency, plugin-boundary, storage, and runtime guards**.
- Fresh structured `gpt-5.6-sol` **xhigh** review of this exact branch: clean, with no accepted or actionable findings.