### PR TITLE
fix(heartbeat): respect agents.*.heartbeat.session for monitor cron job

### DIFF
--- a/src/cron/heartbeat-monitor.ts
+++ b/src/cron/heartbeat-monitor.ts
@@ -7,7 +7,7 @@ import {
 } from "../infra/heartbeat-runner.js";
 import { resolveHeartbeatPhaseMs } from "../infra/heartbeat-schedule.js";
 import { resolveHeartbeatIntervalMs } from "../infra/heartbeat-summary.js";
-import type { CronJob, CronJobCreate } from "./types.js";
+import type { CronJob, CronJobCreate, CronSessionTarget } from "./types.js";
 
 const HEARTBEAT_DECLARATION_PREFIX = "heartbeat:";
 
@@ -70,7 +70,7 @@ export function resolveHeartbeatMonitorSpecs(
             }),
           },
           payload: { kind: "heartbeat" },
-          sessionTarget: "main",
+          sessionTarget: (agent.heartbeat?.session ?? "main") as CronSessionTarget,
           wakeMode: "next-heartbeat",
         },
       },


### PR DESCRIPTION
## What Problem This Solves

Heartbeat monitor cron jobs are hardcoded to `sessionTarget: "main"` in `src/cron/heartbeat-monitor.ts`. The `agents.defaults.heartbeat.session` and `agents.entries.*.heartbeat.session` configuration fields are ignored when the system-owned cron job is reconciled.

This means users who configure a heartbeat to run in a specific session — for example, a `openclaw-weixin` direct session — still see the heartbeat wake and execute in `agent:main:main`. The only practical workarounds are to route all channel traffic to the main session or to patch the compiled runtime, neither of which is desirable.

## Evidence

### 1. Configured session is ignored at runtime

`agents.entries.main.heartbeat.session` is set to a WeChat direct session:

```bash
$ openclaw config get agents.entries.main.heartbeat
{
  "every": "60m",
  "session": "agent:main:openclaw-weixin:direct:o9cq805vlskx1vwXg2ix5i-_1mza@im.wechat",
  ...
}
```

Yet the heartbeat monitor job still reports `sessionTarget: "main"`:

```bash
$ openclaw cron get heartbeat:main
{
  ...
  "sessionTarget": "main",
  ...
}
```

### 2. Source shows the hardcoded value

`src/cron/heartbeat-monitor.ts` (current `main`):

```ts
input: {
  ...
  payload: { kind: "heartbeat" },
  sessionTarget: "main",   // <-- ignores heartbeat.session config
  wakeMode: "next-heartbeat",
},
```

### 3. Proposed fix

Use the configured session when present, falling back to `"main"`:

```ts
sessionTarget: agent.heartbeat?.session ?? "main",
```

Backwards compatible: users who do not set `agents.*.heartbeat.session` retain the existing `"main"` behavior.

## Validation

- Existing unit tests in `src/gateway/server-cron-heartbeat-jobs.test.ts` still pass; they only assert job existence, schedule, and payload kind, not session target.
- Manual local observation: before the change, `openclaw cron get heartbeat:main` shows `"sessionTarget": "main"` even when config session is set to a WeChat direct session; after the change, the job uses the configured session.
- No behavioral change for default configs (no `session` override).
