### PR TITLE
fix(ui): preserve model names alongside aliases

### DIFF
--- a/ui/src/e2e/model-alias-display.e2e.test.ts
+++ b/ui/src/e2e/model-alias-display.e2e.test.ts
@@ -1,0 +1,172 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+const models = [
+  {
+    id: "claude-opus-4-8",
+    name: "Opus 4.8",
+    alias: "opus",
+    provider: "anthropic",
+  },
+  {
+    id: "claude-sonnet-5",
+    name: "Sonnet 5",
+    alias: "sonnet",
+    provider: "anthropic",
+  },
+  {
+    id: "moonshotai/kimi-k2.5",
+    name: "Kimi K2.5",
+    alias: "Kimi K2.5 (NVIDIA)",
+    provider: "nvidia",
+  },
+];
+
+const proofDir =
+  process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
+    ? path.join(process.cwd(), ".artifacts", "control-ui-e2e", "model-alias-display")
+    : null;
+
+async function createProofContext() {
+  if (proofDir) {
+    await mkdir(proofDir, { recursive: true });
+  }
+  return suite.newBrowserContext({
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport: { height: 900, width: 1280 },
+    ...(proofDir
+      ? {
+          recordVideo: {
+            dir: proofDir,
+            size: { height: 900, width: 1280 },
+          },
+        }
+      : {}),
+  });
+}
+
+suite.define(() => {
+  it("keeps model versions and custom aliases visible in the chat picker", async () => {
+    const context = await createProofContext();
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      models,
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const main = page.getByRole("main");
+      const picker = main.locator('[data-chat-model-select="true"]').first();
+      await picker.waitFor({ state: "visible", timeout: 10_000 });
+      await picker.click();
+      await main.locator('[data-chat-model-provider="anthropic"]').click();
+
+      const opus = main.locator(
+        '[data-chat-model-option="anthropic/claude-opus-4-8"] .chat-controls__model-option-name',
+      );
+      const sonnet = main.locator(
+        '[data-chat-model-option="anthropic/claude-sonnet-5"] .chat-controls__model-option-name',
+      );
+      await expect.poll(() => opus.textContent()).toBe("Opus 4.8 · opus");
+      await expect.poll(() => sonnet.textContent()).toBe("Sonnet 5 · sonnet");
+
+      if (proofDir) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(proofDir, "anthropic-versioned-model-aliases.png"),
+        });
+      }
+
+      await main.locator('[data-chat-model-provider="nvidia"]').click();
+      const nvidia = main.locator(
+        '[data-chat-model-option="nvidia/moonshotai/kimi-k2.5"] .chat-controls__model-option-name',
+      );
+      await expect.poll(() => nvidia.textContent()).toBe("Kimi K2.5 (NVIDIA)");
+      expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
+
+      if (proofDir) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(proofDir, "preserved-nvidia-model-alias.png"),
+        });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("uses the same versioned catalog labels in the Agents model picker", async () => {
+    const context = await createProofContext();
+    const page = await context.newPage();
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-8" },
+          models: {
+            "anthropic/claude-opus-4-8": { alias: "opus" },
+            "anthropic/claude-sonnet-5": { alias: "sonnet" },
+            "nvidia/moonshotai/kimi-k2.5": { alias: "Kimi K2.5 (NVIDIA)" },
+          },
+        },
+        list: [{ id: "main" }],
+      },
+    };
+    const gateway = await installMockGateway(page, {
+      defaultAgentId: "main",
+      models,
+      methodResponses: {
+        "agents.list": {
+          agents: [{ id: "main", identity: { name: "Main" }, name: "Main" }],
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+        },
+        "config.get": {
+          config,
+          sourceConfig: config,
+          hash: "versioned-model-aliases",
+          issues: [],
+          raw: JSON.stringify(config),
+          valid: true,
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/overview`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("agents.list");
+      await gateway.waitForRequest("config.get");
+      const modelRequest = await gateway.waitForRequest("models.list");
+      expect(modelRequest.params).toEqual({ view: "configured" });
+
+      const select = page.locator("select.settings-select").first();
+      await select.waitFor({ state: "visible", timeout: 10_000 });
+      await expect
+        .poll(() => select.locator('option[value="anthropic/claude-opus-4-8"]').textContent())
+        .toContain("Opus 4.8 · opus");
+      await expect
+        .poll(() => select.locator('option[value="anthropic/claude-sonnet-5"]').textContent())
+        .toContain("Sonnet 5 · sonnet");
+      await expect
+        .poll(() => select.locator('option[value="nvidia/moonshotai/kimi-k2.5"]').textContent())
+        .toContain("Kimi K2.5 (NVIDIA)");
+      expect(await gateway.getRequests("config.set")).toHaveLength(0);
+
+      if (proofDir) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(proofDir, "agents-versioned-model-aliases.png"),
+        });
+      }
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -16,7 +16,7 @@ import type {
 } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveAgentAvatarUrl, resolveAssistantTextAvatar } from "../avatar.ts";
-import { buildQualifiedChatModelValue } from "../chat/model-ref.ts";
+import { buildCatalogDisplayLookup, buildChatModelOptionFromLookup } from "../chat/model-ref.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "../string-coerce.ts";
 
 type AgentRosterEntry = {
@@ -548,6 +548,7 @@ export function buildModelOptions(
 ) {
   const seen = new Set<string>();
   const options: ConfiguredModelOption[] = [];
+  const catalogOptions = new Map<string, ConfiguredModelOption>();
   const selectedKey = selected ? normalizeLowercaseStringOrEmpty(selected) : null;
   const addOption = (value: string, label: string) => {
     const key = normalizeLowercaseStringOrEmpty(value);
@@ -558,17 +559,23 @@ export function buildModelOptions(
     options.push({ value, label });
   };
 
-  for (const opt of resolveConfiguredModels(configForm)) {
-    addOption(opt.value, opt.label);
+  if (catalog) {
+    const displayLookup = buildCatalogDisplayLookup(catalog);
+    for (const entry of catalog) {
+      const option = buildChatModelOptionFromLookup(entry, displayLookup);
+      catalogOptions.set(normalizeLowercaseStringOrEmpty(option.value), option);
+    }
   }
 
-  if (catalog) {
-    for (const entry of catalog) {
-      const provider = entry.provider?.trim();
-      const value = buildQualifiedChatModelValue(entry.id, provider);
-      const label = provider ? `${entry.id} · ${provider}` : entry.id;
-      addOption(value, label);
-    }
+  for (const opt of resolveConfiguredModels(configForm)) {
+    // Configured options keep their order and fallback aliases; an authoritative
+    // catalog match must still expose the same model identity as the chat picker.
+    const catalogOption = catalogOptions.get(normalizeLowercaseStringOrEmpty(opt.value));
+    addOption(opt.value, catalogOption?.label ?? opt.label);
+  }
+
+  for (const option of catalogOptions.values()) {
+    addOption(option.value, option.label);
   }
 
   if (current && !seen.has(normalizeLowercaseStringOrEmpty(current))) {

--- a/ui/src/lib/chat/model-ref.test.ts
+++ b/ui/src/lib/chat/model-ref.test.ts
@@ -53,6 +53,39 @@ describe("chat-model-ref helpers", () => {
     );
   });
 
+  it.each([
+    {
+      id: "claude-opus-4-8",
+      name: "Opus 4.8",
+      alias: "opus",
+      expected: "Opus 4.8 · opus",
+    },
+    {
+      id: "claude-sonnet-5",
+      name: "Sonnet 5",
+      alias: "sonnet",
+      expected: "Sonnet 5 · sonnet",
+    },
+    {
+      id: "claude-sonnet-5",
+      name: "Sonnet 5",
+      alias: "My preferred model",
+      expected: "Sonnet 5 · My preferred model",
+    },
+  ])(
+    "keeps the canonical model name visible beside the $alias selection alias",
+    ({ id, name, alias, expected }) => {
+      const entry = { id, name, alias, provider: "anthropic" };
+      const lookup = buildCatalogDisplayLookup([entry]);
+
+      expect(buildChatModelOptionFromLookup(entry, lookup)).toEqual({
+        value: `anthropic/${id}`,
+        label: expected,
+      });
+      expect(formatCatalogChatModelDisplayFromLookup(`anthropic/${id}`, lookup)).toBe(expected);
+    },
+  );
+
   it("disambiguates duplicate names by provider and model id", () => {
     const duplicateProviders = createModelCatalog(
       { id: "claude-sonnet", name: "Claude Sonnet", provider: "anthropic" },

--- a/ui/src/lib/chat/model-ref.ts
+++ b/ui/src/lib/chat/model-ref.ts
@@ -197,7 +197,17 @@ function formatRawCatalogLabel(entry: ModelCatalogEntry): string {
 }
 
 function resolveCatalogDisplayName(entry: ModelCatalogEntry): string {
-  return entry.alias?.trim() || entry.name.trim();
+  const name = entry.name.trim();
+  const alias = entry.alias?.trim();
+  if (!name || !alias) {
+    return name || alias || "";
+  }
+  if (alias.toLowerCase() === name.toLowerCase()) {
+    return name;
+  }
+  // Aliases are selectable metadata, not a replacement for model identity.
+  // Preserve richer custom labels only when they already contain the full name.
+  return alias.toLowerCase().includes(name.toLowerCase()) ? alias : `${name} · ${alias}`;
 }
 
 function createQualifiedCatalogKey(entry: ModelCatalogEntry): string {

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -558,6 +558,49 @@ describe("chat-model-select-state", () => {
     ]);
   });
 
+  it("keeps versioned catalog names visible for configured family aliases", () => {
+    const state = createChatModelState({
+      chatModelCatalog: createModelCatalog(
+        {
+          id: "claude-opus-4-8",
+          alias: "opus",
+          name: "Opus 4.8",
+          provider: "anthropic",
+        },
+        {
+          id: "claude-sonnet-5",
+          alias: "sonnet",
+          name: "Sonnet 5",
+          provider: "anthropic",
+        },
+        {
+          id: "moonshotai/kimi-k2.5",
+          alias: "Kimi K2.5 (NVIDIA)",
+          name: "Kimi K2.5",
+          provider: "nvidia",
+        },
+      ),
+      sessionsResult: createSessionsListResult({
+        model: "claude-opus-4-8",
+        modelProvider: "anthropic",
+        defaultsModel: "claude-opus-4-8",
+        defaultsProvider: "anthropic",
+      }),
+    });
+
+    const resolved = resolveChatModelSelectState(state);
+
+    expect(resolved.defaultLabel).toBe("Default (Opus 4.8 · opus)");
+    expect(resolved.options).toEqual([
+      { value: "anthropic/claude-opus-4-8", label: "Opus 4.8 · opus" },
+      { value: "anthropic/claude-sonnet-5", label: "Sonnet 5 · sonnet" },
+      {
+        value: "nvidia/moonshotai/kimi-k2.5",
+        label: "Kimi K2.5 (NVIDIA)",
+      },
+    ]);
+  });
+
   it("uses the active agent model for the default label", () => {
     const state = createChatModelState({
       agentDefaultModel: "anthropic/claude-opus-4-5",

--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -5,10 +5,12 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   AgentsFilesListResult,
   AgentsListResult,
+  ModelCatalogEntry,
   ToolsEffectiveResult,
 } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { AgentsPanel } from "../../lib/agents/panels.ts";
+import * as chatModels from "../chat/models.ts";
 import type { AgentsRouteData } from "./route.ts";
 import "./agents-page.ts";
 
@@ -27,6 +29,8 @@ type TestAgentsPage = HTMLElement & {
   readonly agentsPanel: AgentsPanel;
   toolsEffectiveLoading: boolean;
   toolsEffectiveResult: ToolsEffectiveResult | null;
+  chatModelCatalog: ModelCatalogEntry[];
+  chatModelCatalogRequest: unknown;
   requestGeneration: number;
   routeDataInitialized: boolean;
   subscriptions: {
@@ -37,6 +41,7 @@ type TestAgentsPage = HTMLElement & {
   willUpdate: (changed: Map<PropertyKey, unknown>) => void;
   applyGatewaySnapshot: (snapshot: ApplicationGatewaySnapshot, sourceChanged: boolean) => void;
   ensureAgentIdentities: () => void;
+  loadActivePanelData: () => void;
   loadEffectiveToolsForAgent: (agentId: string) => void;
   loadAgentFiles: (agentId: string, force?: boolean) => Promise<void>;
 };
@@ -134,6 +139,139 @@ function pageContext(
 }
 
 describe("AgentsPage gateway lifecycle", () => {
+  it("loads the configured model catalog once for the overview model picker", async () => {
+    const models = [
+      {
+        id: "claude-opus-4-8",
+        name: "Opus 4.8",
+        alias: "opus",
+        provider: "anthropic",
+      },
+    ];
+    const request = vi.fn(async () => ({ models }));
+    const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
+    page.routeData = { panel: "overview" } as AgentsRouteData;
+    page.client = { request } as unknown as GatewayBrowserClient;
+    page.connected = true;
+    page.agentsSelectedId = "main";
+
+    page.loadActivePanelData();
+    page.loadActivePanelData();
+
+    await vi.waitFor(() => expect(page.chatModelCatalog).toEqual(models));
+    expect(request).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledWith("models.list", { view: "configured" });
+  });
+
+  it("rejects an old-client model catalog after the Gateway client changes", async () => {
+    const oldModels = [{ id: "old", name: "Old Model", alias: "opus", provider: "anthropic" }];
+    const nextModels = [{ id: "new", name: "Opus 4.8", alias: "opus", provider: "anthropic" }];
+    const oldResult = deferred<{ models: ModelCatalogEntry[] }>();
+    const oldRequest = vi.fn(() => oldResult.promise);
+    const nextRequest = vi.fn(async () => ({ models: nextModels }));
+    const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
+    page.routeData = { panel: "overview" } as AgentsRouteData;
+    page.client = { request: oldRequest } as unknown as GatewayBrowserClient;
+    page.connected = true;
+    page.agentsSelectedId = "main";
+
+    page.loadActivePanelData();
+    page.requestGeneration += 1;
+    page.client = { request: nextRequest } as unknown as GatewayBrowserClient;
+    page.loadActivePanelData();
+
+    await vi.waitFor(() => expect(page.chatModelCatalog).toEqual(nextModels));
+    oldResult.resolve({ models: oldModels });
+    await oldResult.promise;
+    await Promise.resolve();
+
+    expect(page.chatModelCatalog).toEqual(nextModels);
+    expect(oldRequest).toHaveBeenCalledOnce();
+    expect(nextRequest).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes a stale in-flight model catalog after a same-client reconnect", async () => {
+    const oldModels = [{ id: "old", name: "Old Model", alias: "opus", provider: "anthropic" }];
+    const nextModels = [{ id: "new", name: "Opus 4.8", alias: "opus", provider: "anthropic" }];
+    const oldResult = deferred<{ models: ModelCatalogEntry[] }>();
+    const request = vi
+      .fn()
+      .mockReturnValueOnce(oldResult.promise)
+      .mockResolvedValueOnce({ models: nextModels });
+    const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
+    page.routeData = { panel: "overview" } as AgentsRouteData;
+    page.client = { request } as unknown as GatewayBrowserClient;
+    page.connected = true;
+    page.agentsSelectedId = "main";
+
+    page.loadActivePanelData();
+    page.requestGeneration += 1;
+    page.loadActivePanelData();
+
+    await vi.waitFor(() => expect(page.chatModelCatalog).toEqual(nextModels));
+    oldResult.resolve({ models: oldModels });
+    await oldResult.promise;
+    await Promise.resolve();
+
+    expect(page.chatModelCatalog).toEqual(nextModels);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenNthCalledWith(2, "models.list", { view: "configured" });
+  });
+
+  it("refreshes a settled model catalog after a same-client reconnect", async () => {
+    const oldModels = [{ id: "old", name: "Old Model", alias: "opus", provider: "anthropic" }];
+    const nextModels = [{ id: "new", name: "Opus 4.8", alias: "opus", provider: "anthropic" }];
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ models: oldModels })
+      .mockResolvedValueOnce({ models: nextModels });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
+    page.routeData = { panel: "overview" } as AgentsRouteData;
+    page.client = client;
+    page.connected = true;
+    page.agentsSelectedId = "main";
+
+    page.loadActivePanelData();
+    await vi.waitFor(() => expect(page.chatModelCatalog).toEqual(oldModels));
+
+    page.applyGatewaySnapshot(snapshot(client, false), false);
+    expect(page.chatModelCatalog).toEqual([]);
+    page.applyGatewaySnapshot(snapshot(client), false);
+    page.loadActivePanelData();
+
+    await vi.waitFor(() => expect(page.chatModelCatalog).toEqual(nextModels));
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenNthCalledWith(2, "models.list", { view: "configured" });
+  });
+
+  it("handles a model catalog failure and retries without a stale request", async () => {
+    const models = [{ id: "new", name: "Opus 4.8", alias: "opus", provider: "anthropic" }];
+    const loadModels = vi
+      .spyOn(chatModels, "loadModels")
+      .mockRejectedValueOnce(new Error("model catalog unavailable"))
+      .mockResolvedValueOnce(models);
+    const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
+    page.routeData = { panel: "overview" } as AgentsRouteData;
+    page.client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    page.connected = true;
+    page.agentsSelectedId = "main";
+
+    try {
+      page.loadActivePanelData();
+      await vi.waitFor(() => expect(page.chatModelCatalogRequest).toBeNull());
+      expect(page.chatModelCatalog).toEqual([]);
+
+      page.loadActivePanelData();
+      await vi.waitFor(() => expect(page.chatModelCatalog).toEqual(models));
+
+      expect(loadModels).toHaveBeenCalledTimes(2);
+      expect(loadModels).toHaveBeenLastCalledWith(page.client, { refresh: true });
+    } finally {
+      loadModels.mockRestore();
+    }
+  });
+
   it("preserves matching initial route data, then resets it on provider replacement", () => {
     const client = {} as GatewayBrowserClient;
     const currentGateway = gateway(snapshot(client, false));

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -41,6 +41,7 @@ import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
 import { normalizeStringEntries } from "../../lib/string-coerce.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import { loadModels } from "../chat/models.ts";
 import { loadAgentFileContent, saveAgentFile } from "./files.ts";
 import {
   resetIdentityDraft,
@@ -115,6 +116,12 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
   private agentIdentitySource: ApplicationContext["agentIdentity"] | null = null;
   private hasBoundSessions = false;
   private sessionsSource: ApplicationContext["sessions"] | null = null;
+  private chatModelCatalogClient: GatewayBrowserClient | null = null;
+  private chatModelCatalogRefreshRequired = false;
+  private chatModelCatalogRequest: {
+    client: GatewayBrowserClient;
+    generation: number;
+  } | null = null;
   private normalizedLocation = "";
   private readonly subscriptions = new SubscriptionsController(this)
     .effect(
@@ -279,8 +286,12 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
     this.syncGatewayState(snapshot);
     if (forceReset || (!initialBind && clientChanged)) {
       this.resetForClientChange();
+      this.chatModelCatalogRefreshRequired = forceReset && !clientChanged;
     } else if (!initialBind && connectionChanged) {
       this.invalidateTransientRequests();
+      this.chatModelCatalog = [];
+      this.chatModelCatalogClient = null;
+      this.chatModelCatalogRefreshRequired = true;
     }
     this.ensureInitialData();
   }
@@ -343,6 +354,9 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
     this.agentsError = null;
     this.agentsList = null;
     this.agentsSelectedId = null;
+    this.chatModelCatalog = [];
+    this.chatModelCatalogClient = null;
+    this.chatModelCatalogRefreshRequired = false;
     this.resetSelectionState();
     this.cron = createInitialCronState({
       client: this.client,
@@ -512,6 +526,10 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
     if (!agentId) {
       return;
     }
+    if (this.agentsPanel === "overview") {
+      this.ensureModelCatalog();
+      return;
+    }
     if (this.agentsPanel === "files" && this.agentFilesList?.agentId !== agentId) {
       void this.loadAgentFiles(agentId);
       return;
@@ -534,6 +552,43 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
     if (this.agentsPanel === "cron" && !this.cron.cronLoading && !this.cron.cronStatus) {
       void this.refreshCron();
     }
+  }
+
+  private ensureModelCatalog() {
+    const client = this.client;
+    if (!client || !this.connected || this.chatModelCatalogClient === client) {
+      return;
+    }
+    const generation = this.requestGeneration;
+    const previousRequest = this.chatModelCatalogRequest;
+    if (previousRequest?.client === client && previousRequest.generation === generation) {
+      return;
+    }
+    const request = { client, generation };
+    this.chatModelCatalogRequest = request;
+    const refresh = this.chatModelCatalogRefreshRequired || previousRequest?.client === client;
+    this.chatModelCatalogRefreshRequired = false;
+    // A direct overview has no chat metadata. Refresh after reconnect so neither
+    // an in-flight request nor a settled cache can restore stale Gateway models.
+    void loadModels(client, refresh ? { refresh: true } : undefined)
+      .then((models) => {
+        if (this.isCurrentRequest(client, generation)) {
+          this.chatModelCatalog = models;
+          this.chatModelCatalogClient = client;
+        }
+      })
+      .catch(() => {
+        if (this.isCurrentRequest(client, generation)) {
+          this.chatModelCatalog = [];
+          this.chatModelCatalogClient = null;
+          this.chatModelCatalogRefreshRequired = true;
+        }
+      })
+      .finally(() => {
+        if (this.chatModelCatalogRequest === request) {
+          this.chatModelCatalogRequest = null;
+        }
+      });
   }
 
   private async loadAgentsAndCommit() {

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -272,6 +272,73 @@ describe("renderAgents", () => {
     );
   });
 
+  it("shows canonical model names alongside configured aliases in agent options", async () => {
+    const container = document.createElement("div");
+    const configForm = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-8" },
+          models: {
+            "anthropic/claude-opus-4-8": { alias: "opus" },
+            "anthropic/claude-sonnet-5": { alias: "sonnet" },
+            "nvidia/moonshotai/kimi-k2.5": { alias: "Kimi K2.5 (NVIDIA)" },
+            "local/unlisted-model": { alias: "My local model" },
+          },
+        },
+        list: [{ id: "alpha" }, { id: "beta" }],
+      },
+    };
+
+    render(
+      renderAgents(
+        createProps({
+          selectedAgentId: "alpha",
+          config: {
+            form: configForm,
+            loading: false,
+            saving: false,
+            dirty: false,
+          },
+          modelCatalog: [
+            {
+              id: "claude-opus-4-8",
+              alias: "opus",
+              name: "Opus 4.8",
+              provider: "anthropic",
+            },
+            {
+              id: "claude-sonnet-5",
+              alias: "sonnet",
+              name: "Sonnet 5",
+              provider: "anthropic",
+            },
+            {
+              id: "moonshotai/kimi-k2.5",
+              alias: "Kimi K2.5 (NVIDIA)",
+              name: "Kimi K2.5",
+              provider: "nvidia",
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const select = await vi.waitFor(() => {
+      const candidate = container.querySelector<HTMLSelectElement>("select.settings-select");
+      expect(candidate?.value).toBe("anthropic/claude-opus-4-8");
+      return candidate;
+    });
+    const options = new Map(
+      Array.from(select?.options ?? []).map((option) => [option.value, option.textContent?.trim()]),
+    );
+
+    expect(options.get("anthropic/claude-opus-4-8")).toBe("Opus 4.8 · opus");
+    expect(options.get("anthropic/claude-sonnet-5")).toBe("Sonnet 5 · sonnet");
+    expect(options.get("nvidia/moonshotai/kimi-k2.5")).toBe("Kimi K2.5 (NVIDIA)");
+    expect(options.get("local/unlisted-model")).toBe("My local model (local/unlisted-model)");
+  });
+
   it.each([
     { name: "a string primary", model: "openai/gpt-5.4" },
     { name: "an object primary", model: { primary: "openai/gpt-5.4" } },


### PR DESCRIPTION
Closes #111884

## What Problem This Solves

Fixes an issue where users choosing a configured model in Chat or Agent settings would see only a short alias such as `opus` or `sonnet`, hiding the actual model and version. Opening Agent settings directly also never loaded the configured model catalog, so its picker could not recover the full names.

## Why This Change Was Made

Use the Gateway's existing separate canonical model name, alias, and provider metadata as the single display contract for Chat, new-session options, and Agent settings. Keep aliases visible without guessing provider/model families, preserve richer custom labels such as `Kimi K2.5 (NVIDIA)`, provider-qualified values, configured option order, and configured-only fallback aliases. Load the existing configured-view model catalog only for the Agent overview, deduplicate requests, force a fresh request after Gateway reconnect, reject stale client/generation results, and handle catalog-load failures.

## User Impact

Users can distinguish versioned models immediately in both pickers while keeping existing custom aliases, selection values, saved configuration, provider routing, and agent fallback behavior unchanged. Agent model names remain accurate after directly opening settings and reconnecting.

## Evidence

- Fail-first on exact `main`: actual Chromium showed the short `opus` label in both the Chat and Agent pickers; focused unit/rendering tests reproduced hidden canonical names and custom alias behavior.
- Independent xhigh review exposed a settled same-client catalog-cache reconnect bug. Added its fail-first regression, forced a real configured-catalog refresh, covered stale in-flight/old-client responses and handled failure/retry, then obtained a fresh clean xhigh review.
- Real Chromium: **33 passing tests in six E2E suites**, including both issue paths, Opus/Sonnet versions, exact NVIDIA custom label, provider/session model changes, Agent fallback ownership, reconnect, and new-session model/workspace memory.
- **194 passing focused UI, lifecycle, Gateway model-projection/provider-contract, agent selection, and i18n tests.**
- Full remote `pnpm check:changed -- <all 8 changed files>` passed, including core/UI typechecks, formatting, both dead-export scans, i18n verification, dependency/ratchet guards, and complete changed-file lint.
- Testbox timing: `exitCode: 0`; fresh independent `autoreview --mode uncommitted --thinking xhigh`: clean.
