### PR TITLE
fix(ci): checkout fetch delays fail jobs before validation

### DIFF
--- a/.github/actions/prepare-testbox-shell/action.yml
+++ b/.github/actions/prepare-testbox-shell/action.yml
@@ -1,0 +1,44 @@
+name: Prepare Testbox shell
+description: Pin the checked-out base ref and expose the setup-node toolchain to Testbox.
+
+inputs:
+  base-ref:
+    description: Commit or ref that Testbox should treat as origin/main; defaults to HEAD.
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Pin Testbox base and Node tools
+      shell: bash
+      env:
+        TESTBOX_BASE_REF: ${{ inputs.base-ref }}
+      run: |
+        set -euo pipefail
+
+        base_ref="${TESTBOX_BASE_REF:-HEAD}"
+        if ! base_sha="$(git rev-parse --verify "${base_ref}^{commit}")"; then
+          echo "Testbox base commit is missing from the maintained checkout: $base_ref" >&2
+          exit 1
+        fi
+        git update-ref refs/remotes/origin/main "$base_sha"
+
+        node_bin="$(dirname "$(node -p 'process.execPath')")"
+        link_node_tool() {
+          local tool="$1"
+          local source="$node_bin/$tool"
+          local target="/usr/local/bin/$tool"
+          if [ -e "$target" ] && [ "$(readlink -f "$source")" = "$(readlink -f "$target")" ]; then
+            return
+          fi
+          sudo ln -sf "$source" "$target"
+        }
+        link_node_tool node
+        link_node_tool npm
+        link_node_tool npx
+        link_node_tool corepack
+        sudo tee /usr/local/bin/pnpm >/dev/null <<'PNPM'
+        #!/usr/bin/env bash
+        exec /usr/local/bin/corepack pnpm "$@"
+        PNPM
+        sudo chmod 0755 /usr/local/bin/pnpm

--- a/.github/workflows/ci-build-artifacts-testbox.yml
+++ b/.github/workflows/ci-build-artifacts-testbox.yml
@@ -36,56 +36,10 @@ jobs:
           testbox_id: ${{ inputs.testbox_id }}
 
       - name: Checkout
-        shell: bash
-        env:
-          CHECKOUT_REPO: ${{ github.repository }}
-          CHECKOUT_SHA: ${{ github.sha }}
-          CHECKOUT_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          workdir="$GITHUB_WORKSPACE"
-          if [[ -z "$CHECKOUT_TOKEN" ]]; then
-            echo "checkout token is missing" >&2
-            exit 1
-          fi
-          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
-
-          reset_checkout_dir() {
-            mkdir -p "$workdir"
-            find "$workdir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-          }
-
-          checkout_attempt() {
-            local attempt="$1"
-
-            reset_checkout_dir
-            git init "$workdir" >/dev/null
-            git config --global --add safe.directory "$workdir"
-            git -C "$workdir" remote add origin "https://github.com/${CHECKOUT_REPO}"
-            git -C "$workdir" config gc.auto 0
-
-            timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
-              -c protocol.version=2 \
-              -c "http.extraheader=AUTHORIZATION: basic ${auth_header}" \
-              fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
-              "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
-
-            git -C "$workdir" checkout --force --detach "$CHECKOUT_SHA" || return 1
-            test -f "$workdir/.github/actions/setup-node-env/action.yml" || return 1
-            echo "checkout attempt ${attempt}/5 succeeded"
-          }
-
-          for attempt in 1 2 3 4 5; do
-            if checkout_attempt "$attempt"; then
-              exit 0
-            fi
-            echo "checkout attempt ${attempt}/5 failed"
-            sleep $((attempt * 5))
-          done
-
-          echo "checkout failed after 5 attempts" >&2
-          exit 1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && '2' || '0' }}
+          persist-credentials: false
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -192,34 +146,9 @@ jobs:
           key: ${{ runner.os }}-dist-build-v2-${{ github.sha }}
 
       - name: Prepare Testbox shell
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          timeout --signal=TERM --kill-after=10s 120s git \
-            -c protocol.version=2 \
-            fetch --no-tags --prune --no-recurse-submodules --depth=50 origin \
-            "+refs/heads/main:refs/remotes/origin/main"
-
-          node_bin="$(dirname "$(node -p 'process.execPath')")"
-          link_node_tool() {
-            local tool="$1"
-            local source="$node_bin/$tool"
-            local target="/usr/local/bin/$tool"
-            if [ -e "$target" ] && [ "$(readlink -f "$source")" = "$(readlink -f "$target")" ]; then
-              return
-            fi
-            sudo ln -sf "$source" "$target"
-          }
-          link_node_tool node
-          link_node_tool npm
-          link_node_tool npx
-          link_node_tool corepack
-          sudo tee /usr/local/bin/pnpm >/dev/null <<'PNPM'
-          #!/usr/bin/env bash
-          exec /usr/local/bin/corepack pnpm "$@"
-          PNPM
-          sudo chmod 0755 /usr/local/bin/pnpm
+        uses: ./.github/actions/prepare-testbox-shell
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}
 
       - name: Hydrate Testbox provider env helper
         shell: bash

--- a/.github/workflows/ci-check-arm-testbox.yml
+++ b/.github/workflows/ci-check-arm-testbox.yml
@@ -51,90 +51,19 @@ jobs:
               ;;
           esac
       - name: Checkout
-        shell: bash
-        env:
-          CHECKOUT_REPO: ${{ github.repository }}
-          CHECKOUT_SHA: ${{ github.sha }}
-          CHECKOUT_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          workdir="$GITHUB_WORKSPACE"
-          if [[ -z "$CHECKOUT_TOKEN" ]]; then
-            echo "checkout token is missing" >&2
-            exit 1
-          fi
-          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
-
-          reset_checkout_dir() {
-            mkdir -p "$workdir"
-            find "$workdir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-          }
-
-          checkout_attempt() {
-            local attempt="$1"
-
-            reset_checkout_dir
-            git init "$workdir" >/dev/null
-            git config --global --add safe.directory "$workdir"
-            git -C "$workdir" remote add origin "https://github.com/${CHECKOUT_REPO}"
-            git -C "$workdir" config gc.auto 0
-
-            timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
-              -c protocol.version=2 \
-              -c "http.extraheader=AUTHORIZATION: basic ${auth_header}" \
-              fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
-              "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
-
-            git -C "$workdir" checkout --force --detach "$CHECKOUT_SHA" || return 1
-            test -f "$workdir/.github/actions/setup-node-env/action.yml" || return 1
-            echo "checkout attempt ${attempt}/5 succeeded"
-          }
-
-          for attempt in 1 2 3 4 5; do
-            if checkout_attempt "$attempt"; then
-              exit 0
-            fi
-            echo "checkout attempt ${attempt}/5 failed"
-            sleep $((attempt * 5))
-          done
-
-          echo "checkout failed after 5 attempts" >&2
-          exit 1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && '2' || '0' }}
+          persist-credentials: false
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
           install-trufflehog: "true"
       - name: Prepare Testbox shell
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          timeout --signal=TERM --kill-after=10s 120s git \
-            -c protocol.version=2 \
-            fetch --no-tags --prune --no-recurse-submodules --depth=50 origin \
-            "+refs/heads/main:refs/remotes/origin/main"
-
-          node_bin="$(dirname "$(node -p 'process.execPath')")"
-          link_node_tool() {
-            local tool="$1"
-            local source="$node_bin/$tool"
-            local target="/usr/local/bin/$tool"
-            if [ -e "$target" ] && [ "$(readlink -f "$source")" = "$(readlink -f "$target")" ]; then
-              return
-            fi
-            sudo ln -sf "$source" "$target"
-          }
-          link_node_tool node
-          link_node_tool npm
-          link_node_tool npx
-          link_node_tool corepack
-          sudo tee /usr/local/bin/pnpm >/dev/null <<'PNPM'
-          #!/usr/bin/env bash
-          exec /usr/local/bin/corepack pnpm "$@"
-          PNPM
-          sudo chmod 0755 /usr/local/bin/pnpm
+        uses: ./.github/actions/prepare-testbox-shell
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}
 
       - name: Hydrate Testbox provider env helper
         shell: bash

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -43,56 +43,10 @@ jobs:
         with:
           testbox_id: ${{ inputs.testbox_id }}
       - name: Checkout
-        shell: bash
-        env:
-          CHECKOUT_REPO: ${{ github.repository }}
-          CHECKOUT_SHA: ${{ github.sha }}
-          CHECKOUT_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          workdir="$GITHUB_WORKSPACE"
-          if [[ -z "$CHECKOUT_TOKEN" ]]; then
-            echo "checkout token is missing" >&2
-            exit 1
-          fi
-          auth_header="$(printf 'x-access-token:%s' "$CHECKOUT_TOKEN" | base64 | tr -d '\n')"
-
-          reset_checkout_dir() {
-            mkdir -p "$workdir"
-            find "$workdir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-          }
-
-          checkout_attempt() {
-            local attempt="$1"
-
-            reset_checkout_dir
-            git init "$workdir" >/dev/null
-            git config --global --add safe.directory "$workdir"
-            git -C "$workdir" remote add origin "https://github.com/${CHECKOUT_REPO}"
-            git -C "$workdir" config gc.auto 0
-
-            timeout --signal=TERM --kill-after=10s 120s git -C "$workdir" \
-              -c protocol.version=2 \
-              -c "http.extraheader=AUTHORIZATION: basic ${auth_header}" \
-              fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
-              "+${CHECKOUT_SHA}:refs/remotes/origin/ci-target" || return 1
-
-            git -C "$workdir" checkout --force --detach "$CHECKOUT_SHA" || return 1
-            test -f "$workdir/.github/actions/setup-node-env/action.yml" || return 1
-            echo "checkout attempt ${attempt}/5 succeeded"
-          }
-
-          for attempt in 1 2 3 4 5; do
-            if checkout_attempt "$attempt"; then
-              exit 0
-            fi
-            echo "checkout attempt ${attempt}/5 failed"
-            sleep $((attempt * 5))
-          done
-
-          echo "checkout failed after 5 attempts" >&2
-          exit 1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && '2' || '0' }}
+          persist-credentials: false
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -103,34 +57,9 @@ jobs:
           sticky-disk: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
           use-actions-cache: ${{ github.event_name == 'workflow_dispatch' && 'false' || 'true' }}
       - name: Prepare Testbox shell
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          timeout --signal=TERM --kill-after=10s 120s git \
-            -c protocol.version=2 \
-            fetch --no-tags --prune --no-recurse-submodules --depth=50 origin \
-            "+refs/heads/main:refs/remotes/origin/main"
-
-          node_bin="$(dirname "$(node -p 'process.execPath')")"
-          link_node_tool() {
-            local tool="$1"
-            local source="$node_bin/$tool"
-            local target="/usr/local/bin/$tool"
-            if [ -e "$target" ] && [ "$(readlink -f "$source")" = "$(readlink -f "$target")" ]; then
-              return
-            fi
-            sudo ln -sf "$source" "$target"
-          }
-          link_node_tool node
-          link_node_tool npm
-          link_node_tool npx
-          link_node_tool corepack
-          sudo tee /usr/local/bin/pnpm >/dev/null <<'PNPM'
-          #!/usr/bin/env bash
-          exec /usr/local/bin/corepack pnpm "$@"
-          PNPM
-          sudo chmod 0755 /usr/local/bin/pnpm
+        uses: ./.github/actions/prepare-testbox-shell
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}
 
       - name: Hydrate Testbox provider env helper
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -806,11 +806,20 @@ jobs:
       PRE_COMMIT_HOME: .cache/pre-commit-security-fast
     steps:
       - name: Checkout
+        if: github.event_name != 'workflow_dispatch' || inputs.target_ref == ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      # Manual target validation has a distinct fallback contract: a missing branch/tag
+      # falls back to the workflow SHA, while transport timeouts still fail closed.
+      - name: Checkout manual target
+        if: github.event_name == 'workflow_dispatch' && inputs.target_ref != ''
         env:
           CHECKOUT_REPO: ${{ github.repository }}
-          CHECKOUT_REF: ${{ inputs.target_ref || github.sha }}
+          CHECKOUT_REF: ${{ inputs.target_ref }}
           CHECKOUT_FALLBACK_REF: ${{ github.sha }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           git init "$GITHUB_WORKSPACE"
@@ -843,7 +852,7 @@ jobs:
               echo "::error::checkout fetch for '$CHECKOUT_REF' timed out"
               exit "$fetch_status"
             fi
-            if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ] || [ "$CHECKOUT_REF" = "$CHECKOUT_FALLBACK_REF" ]; then
+            if [ "$CHECKOUT_REF" = "$CHECKOUT_FALLBACK_REF" ]; then
               exit "$fetch_status"
             fi
             echo "::warning::workflow_dispatch target_ref '$CHECKOUT_REF' is unavailable; falling back to head SHA '$CHECKOUT_FALLBACK_REF'"

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -27,34 +27,10 @@ jobs:
     steps:
       - &workflow_sanity_checkout_step
         name: Checkout
-        env:
-          CHECKOUT_REPO: ${{ github.repository }}
-          CHECKOUT_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" config gc.auto 0
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://github.com/${CHECKOUT_REPO}.git"
-          fetch_checkout_ref() {
-            local fetch_status
-            for attempt in 1 2 3; do
-              timeout --signal=TERM --kill-after=10s 30s git -C "$GITHUB_WORKSPACE" \
-                -c protocol.version=2 \
-                fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
-                "+${CHECKOUT_SHA}:refs/remotes/origin/checkout" && return 0
-              fetch_status="$?"
-              if [ "$fetch_status" != "124" ] && [ "$fetch_status" != "137" ]; then
-                return "$fetch_status"
-              fi
-              if [ "$attempt" = "3" ]; then
-                return "$fetch_status"
-              fi
-              echo "::warning::checkout fetch for '$CHECKOUT_SHA' timed out on attempt $attempt; retrying"
-              sleep 5
-            done
-          }
-          fetch_checkout_ref
-          git -C "$GITHUB_WORKSPACE" checkout --detach refs/remotes/origin/checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Fail on tabs in workflow files
         run: |

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3317,9 +3317,6 @@ describe("ci workflow guards", () => {
     const workflowPaths = [
       [".github/workflows/ci.yml", "120s"],
       [".github/workflows/workflow-sanity.yml", "30s"],
-      [".github/workflows/ci-check-testbox.yml", "120s"],
-      [".github/workflows/ci-check-arm-testbox.yml", "120s"],
-      [".github/workflows/ci-build-artifacts-testbox.yml", "120s"],
       [".github/workflows/crabbox-hydrate.yml", "30s"],
     ] as const;
 
@@ -3392,10 +3389,10 @@ describe("ci workflow guards", () => {
     expect(action).toContain("::error title=ensure-base-commit missing base::");
   });
 
-  it("bounds early unauthenticated checkout fetches", () => {
+  it("bounds specialized early checkout fetches", () => {
     const workflow = readCiWorkflow();
 
-    for (const jobName of ["preflight", "security-fast", "skills-python"]) {
+    for (const jobName of ["preflight", "skills-python"]) {
       const checkoutStep = workflow.jobs[jobName].steps.find(
         (step: WorkflowStep) => step.name === "Checkout",
       );
@@ -3407,17 +3404,14 @@ describe("ci workflow guards", () => {
       expect(checkoutStep.run, jobName).toContain("timed out on attempt $attempt; retrying");
       expect(checkoutStep.run, jobName).not.toContain("if timeout --signal=TERM");
       expect(checkoutStep.run, jobName).toContain("-c protocol.version=2");
-      // preflight fetches the head at depth 1 and supplements the parents
-      // blob-less; security-fast keeps depth 2 for its diff-base needs.
-      const expectedDepth = jobName === "security-fast" ? 2 : 1;
       expect(checkoutStep.run, jobName).toContain(
-        `fetch --no-tags --prune --no-recurse-submodules --depth=${expectedDepth} origin`,
+        "fetch --no-tags --prune --no-recurse-submodules --depth=1 origin",
       );
       if (jobName === "preflight") {
         expect(checkoutStep.run, jobName).toContain("--filter=blob:none");
         expect(checkoutStep.run, jobName).toContain("fetch_parent_metadata");
       }
-      if (jobName !== "skills-python") {
+      if (jobName === "preflight") {
         expect(checkoutStep.run, jobName).toContain('if [ "$fetch_status" = "124" ]');
         expect(checkoutStep.run, jobName).toContain("timed out");
       }
@@ -3425,6 +3419,26 @@ describe("ci workflow guards", () => {
         'git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=1',
       );
     }
+  });
+
+  it("uses the maintained authenticated checkout for security-fast", () => {
+    const workflow = readCiWorkflow();
+    const checkoutStep = workflow.jobs["security-fast"].steps.find(
+      (step: WorkflowStep) => step.name === "Checkout",
+    );
+    const manualCheckoutStep = workflow.jobs["security-fast"].steps.find(
+      (step: WorkflowStep) => step.name === "Checkout manual target",
+    );
+
+    expect(checkoutStep.uses).toBe(CHECKOUT_V6);
+    expect(checkoutStep.if).toBe(
+      "github.event_name != 'workflow_dispatch' || inputs.target_ref == ''",
+    );
+    expect(checkoutStep.with).toEqual({ "fetch-depth": 2, "persist-credentials": false });
+    expect(manualCheckoutStep.if).toBe(
+      "github.event_name == 'workflow_dispatch' && inputs.target_ref != ''",
+    );
+    expect(manualCheckoutStep.run).toContain("workflow_dispatch target_ref");
   });
 
   it("refetches an exact manual target when the workflow branch moves", () => {
@@ -3446,7 +3460,7 @@ describe("ci workflow guards", () => {
     expect(finalCheck).toBeGreaterThan(exactFetch);
   });
 
-  it("retries workflow sanity checkout fetch timeouts", () => {
+  it("uses the maintained checkout across workflow sanity jobs", () => {
     const workflow = readWorkflowSanityWorkflow();
 
     for (const jobName of ["no-tabs", "actionlint", "generated-doc-baselines"]) {
@@ -3454,19 +3468,47 @@ describe("ci workflow guards", () => {
         (step: WorkflowStep) => step.name === "Checkout",
       );
 
-      expect(checkoutStep.run, jobName).toContain("fetch_checkout_ref()");
-      expect(checkoutStep.run, jobName).toContain("for attempt in 1 2 3");
-      expect(checkoutStep.run, jobName).toContain(
-        'timeout --signal=TERM --kill-after=10s 30s git -C "$GITHUB_WORKSPACE"',
+      expect(checkoutStep.uses, jobName).toBe(CHECKOUT_V6);
+      expect(checkoutStep.with, jobName).toEqual({
+        "fetch-depth": 1,
+        "persist-credentials": false,
+      });
+    }
+  });
+
+  it("prepares all Testbox checkouts from one maintained owner", () => {
+    const workflowPaths = [
+      ".github/workflows/ci-check-testbox.yml",
+      ".github/workflows/ci-check-arm-testbox.yml",
+      ".github/workflows/ci-build-artifacts-testbox.yml",
+    ];
+
+    for (const workflowPath of workflowPaths) {
+      const workflow = parse(readFileSync(workflowPath, "utf8"));
+      const job = Object.values(workflow.jobs)[0] as { steps: WorkflowStep[] };
+      const checkoutStep = job.steps.find((step) => step.name === "Checkout");
+      const prepareStep = job.steps.find((step) => step.name === "Prepare Testbox shell");
+
+      expect(checkoutStep?.uses, workflowPath).toBe(CHECKOUT_V6);
+      expect(checkoutStep?.with, workflowPath).toEqual({
+        "fetch-depth": "${{ github.event_name == 'pull_request' && '2' || '0' }}",
+        "persist-credentials": false,
+      });
+      expect(prepareStep?.uses, workflowPath).toBe("./.github/actions/prepare-testbox-shell");
+      expect(prepareStep?.with?.["base-ref"], workflowPath).toBe(
+        "${{ github.event.pull_request.base.sha || 'refs/remotes/origin/main' }}",
       );
-      expect(checkoutStep.run, jobName).toContain(
-        'if [ "$fetch_status" != "124" ] && [ "$fetch_status" != "137" ]; then',
-      );
-      expect(checkoutStep.run, jobName).toContain("timed out on attempt $attempt; retrying");
-      expect(checkoutStep.run, jobName).toContain(
-        "fetch --no-tags --prune --no-recurse-submodules --depth=1 origin",
+      expect(JSON.stringify(job.steps), workflowPath).not.toContain(
+        "+refs/heads/main:refs/remotes/origin/main",
       );
     }
+
+    const action = parse(readFileSync(".github/actions/prepare-testbox-shell/action.yml", "utf8"));
+    const run = action.runs.steps[0].run as string;
+    expect(run).toContain('base_ref="${TESTBOX_BASE_REF:-HEAD}"');
+    expect(run).toContain('git rev-parse --verify "${base_ref}^{commit}"');
+    expect(run).toContain('git update-ref refs/remotes/origin/main "$base_sha"');
+    expect(run).not.toContain("git fetch");
   });
 
   it("bounds the workflow sanity tool downloads", () => {


### PR DESCRIPTION
Related: #115589

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where CI jobs could fail before validation when transient Git fetch delays affected a synthetic pull-request merge checkout or a second `origin/main` fetch during Testbox preparation.

## Why This Change Was Made

The affected entry checkouts now use pinned `actions/checkout@v6.0.3`, which owns a bounded maintained fetch retry instead of duplicating shell retry policy in individual workflows. Testbox jobs share one preparation action that pins the base commit already present in the pull-request checkout as `refs/remotes/origin/main`, eliminating the redundant network fetch entirely. The specialized security target checkout remains separate because it has a distinct missing-ref and fail-closed contract.

## User Impact

Contributors and maintainers should see fewer false-negative CI failures before builds, scanners, or workflow validation begin. Product behavior and security scanning policy are unchanged.

## Audit Disposition

- **Checkout/Testbox:** fixed here. The failures shared checkout/fetch ownership, and the Testbox preparation fetch was duplicate policy that could be deleted.
- **TUI PTY:** removed from this PR after rebasing and reevaluating current `main`. #117393 fixes the exact `Session transcript parent entry was not persisted` race at the recorder/reconciliation ownership boundary. Untouched current `main` then passed both audited Gateway cases in 10/10 bounded repetitions, so an additional fixture-settlement patch would be redundant.
- **Docs map:** no change. #115708 remains in history, and #117398 subsequently made `docs/docs_map.md` a publish-time generated artifact; current docs-list validation passes.
- **Security:** checkout reliability only. `security-fast` produced no finding because checkout failed and all scanner steps were skipped; independent security guard and completed CodeQL shards were green.

## Evidence

- Live failure audit:
  - Workflow Sanity [no-tabs](https://github.com/openclaw/openclaw/actions/runs/30430535251/job/90506495056) and [actionlint](https://github.com/openclaw/openclaw/actions/runs/30430535251/job/90506495114), plus CI [security-fast](https://github.com/openclaw/openclaw/actions/runs/30430535698/job/90506497514), timed out fetching the synthetic merge before validation.
  - Testbox [build-artifacts](https://github.com/openclaw/openclaw/actions/runs/30430535315/job/90506495309) and [check](https://github.com/openclaw/openclaw/actions/runs/30430535781/job/90506497056) completed entry checkout, then timed out in the duplicated Testbox-preparation fetch. The artifact build itself passed.
- Focused workflow regression: `test/scripts/ci-workflow-guards.test.ts` passed 95/95 on Blacksmith Testbox.
- Workflow validation: actionlint and zizmor passed; composite-action interpolation guard passed.
- Changed gate: `pnpm check:changed` passed on Blacksmith Testbox `tbx_01kyz129d64s70e82m7f9zshtf` ([run 30707297497](https://github.com/openclaw/openclaw/actions/runs/30707297497)).
- Docs validation: `node scripts/docs-list.js --headings` passed with no docs-map change.
- Current-main TUI disposition: the two original Gateway cases passed 10/10 bounded repetitions on untouched `main` at `83208eb4a96` ([run 30707068029](https://github.com/openclaw/openclaw/actions/runs/30707068029)).
- Fresh whole-branch autoreview: clean, no accepted/actionable findings (0.99 confidence).
- Final rebase: range-diff identical after unrelated mainline commits; no changed CI path overlapped.
- Lease-protected push: remote `main` and the PR head were verified as `8b21c23cc263c6aabf20d99f43d25b525e8cac81` and `41170d528c518b86f784b6cb2d680fa088a7e215` immediately before updating only the PR branch.
- Exact refs: base `8b21c23cc263c6aabf20d99f43d25b525e8cac81`, head `d18dd0dcecc650772705bbb88a29a96b75ac4cc1`, tree `fbf2cba88bb7d26ba6f088e32cd864e90b884584`.
