### PR TITLE
fix(line): mark durably accepted webhook deliveries

### DIFF
--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -378,7 +378,7 @@ describe("monitorLineProvider lifecycle", () => {
     await secondMonitor.stop();
   });
 
-  it("redacts structured admission failures from signed HTTP webhook requests", async () => {
+  it("marks only durably admitted signed HTTP webhooks and redacts failures", async () => {
     const runtimeError = vi.fn<(...args: unknown[]) => void>();
     const runtime: RuntimeEnv = {
       log: vi.fn<(...args: unknown[]) => void>(),
@@ -421,6 +421,7 @@ describe("monitorLineProvider lifecycle", () => {
         body: payload,
       });
       expect(rejected.status).toBe(401);
+      expect(rejected.headers.get("x-openclaw-delivery-accepted")).toBeNull();
       expect(await rejected.json()).toEqual({ error: "Invalid signature" });
 
       const bot = createLineBotMock.mock.results[0]?.value;
@@ -429,13 +430,63 @@ describe("monitorLineProvider lifecycle", () => {
       }
       expect(bot.handleWebhook).not.toHaveBeenCalled();
 
+      const verificationPayload = JSON.stringify({ events: [] });
+      const verificationSignature = crypto
+        .createHmac("SHA256", "secret")
+        .update(verificationPayload)
+        .digest("base64");
+      const verification = await fetch(webhookUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-line-signature": verificationSignature,
+        },
+        body: verificationPayload,
+      });
+      expect(verification.status).toBe(200);
+      expect(verification.headers.get("x-openclaw-delivery-accepted")).toBeNull();
+      expect(await verification.json()).toEqual({ status: "ok" });
+      expect(bot.handleWebhook).not.toHaveBeenCalled();
+
+      let releaseAdmission: (() => void) | undefined;
+      bot.handleWebhook.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseAdmission = resolve;
+          }),
+      );
+      const signature = crypto.createHmac("SHA256", "secret").update(payload).digest("base64");
+      let acceptedResponseReceived = false;
+      const acceptedRequest = fetch(webhookUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-line-signature": signature,
+        },
+        body: payload,
+      }).then((response) => {
+        acceptedResponseReceived = true;
+        return response;
+      });
+      await vi.waitFor(() => {
+        expect(bot.handleWebhook).toHaveBeenCalledTimes(1);
+      });
+      expect(acceptedResponseReceived).toBe(false);
+      if (!releaseAdmission) {
+        throw new Error("expected pending LINE durable admission");
+      }
+      releaseAdmission();
+      const accepted = await acceptedRequest;
+      expect(accepted.status).toBe(200);
+      expect(accepted.headers.get("x-openclaw-delivery-accepted")).toBe("durable");
+      expect(await accepted.json()).toEqual({ status: "ok" });
+
       const bearerToken = "test_line_access_token_1234567890";
       bot.handleWebhook.mockRejectedValueOnce({
         code: "LINE_ADMISSION_REJECTED",
         retryAfterMs: 250,
         authorization: `Bearer ${bearerToken}`,
       });
-      const signature = crypto.createHmac("SHA256", "secret").update(payload).digest("base64");
       const response = await fetch(webhookUrl, {
         method: "POST",
         headers: {
@@ -446,8 +497,9 @@ describe("monitorLineProvider lifecycle", () => {
       });
 
       expect(response.status).toBe(500);
+      expect(response.headers.get("x-openclaw-delivery-accepted")).toBeNull();
       expect(await response.json()).toEqual({ error: "Internal server error" });
-      expect(bot.handleWebhook).toHaveBeenCalledTimes(1);
+      expect(bot.handleWebhook).toHaveBeenCalledTimes(2);
       expect(runtimeError).toHaveBeenCalledTimes(1);
       const message = String(runtimeError.mock.calls[0]?.[0]);
       expect(message).toContain("line webhook error:");

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -376,6 +376,8 @@ export async function monitorLineProvider(
           if (body.events && body.events.length > 0) {
             logVerbose(`line: received ${body.events.length} webhook events`);
             await match.target.bot.handleWebhook(body);
+            // Only a committed event is adopted; signed LINE verification pings must stay unmarked.
+            res.setHeader("x-openclaw-delivery-accepted", "durable");
           }
           res.statusCode = 200;
           res.setHeader("Content-Type", "application/json");


### PR DESCRIPTION
Closes #115585
Related: #115586

## What Problem This Solves

Fixes an issue where operators using OpenClaw's documented durable-delivery marker at a reverse proxy would reject every successfully accepted LINE webhook because the production LINE gateway returned a plain 200 after committing the event without the acceptance header.

## Why This Change Was Made

Mark only the production LINE gateway's authenticated, nonempty event response, after `bot.handleWebhook` successfully completes durable admission. Keep LINE's official signed empty-event verification response, invalid signatures, durable-admission failures, response body, and status codes unchanged.

This intentionally lands only the independently reproduced two-file LINE fix. It preserves @edenfunf's original broader five-channel #115586 for separate review, credits its original LINE fix in this commit's `Co-authored-by` trailer, and makes no claim about Google Chat, Zalo, SMS, or Feishu.

## User Impact

Reverse proxies and monitors can recognize durably accepted LINE events through `x-openclaw-delivery-accepted: durable`; verification pings and failures never misrepresent event acceptance.

## Evidence

Official LINE contract: [Messaging API webhook response and signature validation](https://developers.line.biz/en/reference/messaging-api/#webhooks) and [webhook URL verification](https://developers.line.biz/en/docs/messaging-api/verify-webhook-url/). The delivery header is an existing OpenClaw operator contract, not a LINE vendor requirement.

A real loopback `node:http` server running the registered production LINE route and real HMAC-signed `fetch` requests failed on current main with `expected null to be 'durable'`. With the fix, the same HTTP regression confirms delayed durable admission happens before the response and covers signed event success, signed empty-event verification, invalid signatures, and durable-storage failures.

```text
node scripts/run-vitest.mjs --config test/vitest/vitest.extension-line.config.ts extensions/line/src/monitor.lifecycle.test.ts extensions/line/src/webhook-node.test.ts extensions/line/src/webhook-spool.test.ts
Test Files  3 passed (3)
Tests       62 passed (62)

node scripts/run-oxlint.mjs extensions/line/src/monitor.ts extensions/line/src/monitor.lifecycle.test.ts --tsconfig config/tsconfig/oxlint.extensions.json
exit 0

./node_modules/.bin/oxfmt --check extensions/line/src/monitor.ts extensions/line/src/monitor.lifecycle.test.ts
All matched files use the correct format.

.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex --model gpt-5.6-sol --thinking xhigh
Autoreview clean: no accepted/actionable findings.
```

AI-assisted; issue, original contribution, vendor contract, source, real HTTP failure, failure paths, and hosted checks are independently reviewed.