### PR TITLE
fix(gateway): keep Responses replacement streams consistent

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -349,6 +349,175 @@ describe("OpenResponses HTTP API (e2e)", () => {
   );
 
   it.each([
+    { name: "rewritten", replacementText: "final answer" },
+    { name: "shortened", replacementText: "dra" },
+    { name: "cleared", replacementText: "" },
+  ])(
+    "fails an official SDK Responses stream when streamed text is $name",
+    async ({ replacementText }) => {
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming response run ID");
+        }
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: { text: "draft answer", delta: "draft answer" },
+        });
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: { text: replacementText, replace: true, phase: "commentary" },
+        });
+        emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+        return {
+          payloads: [{ text: replacementText }],
+          meta: { agentMeta: { usage: { input: 11, output: 7, total: 18 } } },
+        };
+      }) as never);
+
+      const client = new OpenAI({
+        apiKey: "test",
+        baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+        defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+        maxRetries: 0,
+      });
+      const events = await client.responses.create({
+        model: "openclaw",
+        input: "Reject an incompatible replacement snapshot.",
+        stream: true,
+      });
+
+      const deltas: string[] = [];
+      const failures: Array<{
+        status: string | undefined;
+        code: string | undefined;
+        usage: { input_tokens: number; output_tokens: number; total_tokens: number } | undefined;
+      }> = [];
+      let completionCount = 0;
+      for await (const event of events) {
+        if (event.type === "response.output_text.delta") {
+          deltas.push(event.delta);
+        } else if (event.type === "response.failed") {
+          failures.push({
+            status: event.response.status,
+            code: event.response.error?.code,
+            usage: event.response.usage
+              ? {
+                  input_tokens: event.response.usage.input_tokens,
+                  output_tokens: event.response.usage.output_tokens,
+                  total_tokens: event.response.usage.total_tokens,
+                }
+              : undefined,
+          });
+        } else if (event.type === "response.completed") {
+          completionCount += 1;
+        }
+      }
+
+      expect(deltas).toEqual(["draft answer"]);
+      expect(failures).toEqual([
+        {
+          status: "failed",
+          code: "server_error",
+          usage: { input_tokens: 11, output_tokens: 7, total_tokens: 18 },
+        },
+      ]);
+      expect(completionCount).toBe(0);
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    {
+      name: "a producer replacement snapshot without a delta",
+      previousDelta: undefined,
+      replacementDelta: undefined,
+      expectedDeltas: "final answer",
+    },
+    {
+      name: "a producer replacement snapshot with its own delta",
+      previousDelta: undefined,
+      replacementDelta: "final answer",
+      expectedDeltas: "final answer",
+    },
+    {
+      name: "an append-compatible replacement after streamed partial text",
+      previousDelta: "final ",
+      replacementDelta: "answer",
+      expectedDeltas: "final answer",
+    },
+  ])(
+    "keeps official SDK Responses text consistent for $name",
+    async ({ previousDelta, replacementDelta, expectedDeltas }) => {
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming response run ID");
+        }
+        if (previousDelta) {
+          emitAgentEvent({
+            runId,
+            stream: "assistant",
+            data: { text: previousDelta, delta: previousDelta },
+          });
+        }
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: {
+            text: "final answer",
+            replace: true,
+            phase: "commentary",
+            ...(replacementDelta === undefined ? {} : { delta: replacementDelta }),
+          },
+        });
+        emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+        return { payloads: [{ text: "final answer" }] };
+      }) as never);
+
+      const client = new OpenAI({
+        apiKey: "test",
+        baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+        defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+        maxRetries: 0,
+      });
+      const events = await client.responses.create({
+        model: "openclaw",
+        input: "Stream a replacement snapshot exactly once.",
+        stream: true,
+      });
+
+      const deltas: string[] = [];
+      const doneTexts: string[] = [];
+      const completedTexts: string[] = [];
+      for await (const event of events) {
+        if (event.type === "response.output_text.delta") {
+          deltas.push(event.delta);
+        } else if (event.type === "response.output_text.done") {
+          doneTexts.push(event.text);
+        } else if (event.type === "response.completed") {
+          completedTexts.push(
+            ...event.response.output.flatMap((item) =>
+              item.type === "message"
+                ? item.content.flatMap((part) => (part.type === "output_text" ? [part.text] : []))
+                : [],
+            ),
+          );
+        }
+      }
+
+      expect(deltas.join("")).toBe(expectedDeltas);
+      expect(doneTexts).toEqual(["final answer"]);
+      expect(completedTexts).toEqual(["final answer"]);
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
     { name: "JSON-object output", text: { format: { type: "json_object" } } },
     {
       name: "JSON-schema output",
@@ -1680,6 +1849,81 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(response?.output?.map((item) => item.type)).toEqual(["message", "function_call"]);
     expect(response?.output?.[1]?.name).toBe("get_weather");
   });
+
+  it.each([
+    { name: "an initial replacement", previousDelta: undefined, replacementDelta: undefined },
+    { name: "a replacement after buffered text", previousDelta: "draft", replacementDelta: "" },
+    {
+      name: "a replacement with an explicit delta",
+      previousDelta: "draft",
+      replacementDelta: "final answer",
+    },
+  ])(
+    "buffers $name until the required client tool is validated",
+    async ({ previousDelta, replacementDelta }) => {
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming response run ID");
+        }
+        if (previousDelta) {
+          emitAgentEvent({
+            runId,
+            stream: "assistant",
+            data: { text: previousDelta, delta: previousDelta },
+          });
+        }
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: {
+            text: "final answer",
+            replace: true,
+            phase: "commentary",
+            ...(replacementDelta === undefined ? {} : { delta: replacementDelta }),
+          },
+        });
+        return {
+          payloads: [{ text: "final answer" }],
+          meta: {
+            stopReason: "tool_calls",
+            pendingToolCalls: [
+              { id: "call_1", name: "get_weather", arguments: '{"city":"Taipei"}' },
+            ],
+          },
+        };
+      }) as never);
+
+      const res = await postResponses(enabledPort, {
+        stream: true,
+        model: "openclaw",
+        input: "check the weather",
+        tools: WEATHER_TOOL,
+        tool_choice: "required",
+      });
+
+      expect(res.status).toBe(200);
+      const events = parseSseEvents(await res.text());
+      const deltas = events
+        .filter((event) => event.event === "response.output_text.delta")
+        .map((event) => (parseSseData(event) as { delta?: string }).delta);
+      expect(deltas).toEqual(["final answer"]);
+
+      const completed = parseSseData(findSseEvent(events, "response.completed")) as {
+        response?: {
+          status?: string;
+          output?: Array<{ type?: string; content?: Array<{ text?: string }> }>;
+        };
+      };
+      expect(completed.response?.status).toBe("incomplete");
+      expect(completed.response?.output?.map((item) => item.type)).toEqual([
+        "message",
+        "function_call",
+      ]);
+      expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
+    },
+  );
 
   it("buffers replaceable assistant events for streaming responses", async () => {
     const port = enabledPort;

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -920,8 +920,10 @@ export async function handleOpenResponsesHttpRequest(
   setSseHeaders(res);
 
   let accumulatedText = "";
+  let streamedAssistantText = "";
   let bufferedReplaceableAssistantContent = "";
   let sawAssistantDelta = false;
+  let unrepresentableAssistantReplacement = false;
   let closed = false;
   let unsubscribe = () => {};
   let stopWatchingDisconnect = () => {};
@@ -1062,29 +1064,35 @@ export async function handleOpenResponsesHttpRequest(
 
       const text = evt.data?.text;
       const replace = evt.data?.replace === true;
-      const hadAssistantDelta = sawAssistantDelta;
       if (replace && typeof text === "string") {
         accumulatedText = text;
-      }
-
-      const content = resolveAssistantStreamDeltaText(evt);
-      if (!content) {
-        if (
-          replace &&
-          typeof text === "string" &&
-          text &&
-          !toolChoiceConstraint &&
-          !hadAssistantDelta
-        ) {
+        if (toolChoiceConstraint) {
+          return;
+        }
+        // Responses deltas can only append. A conflicting replacement must
+        // fail after usage resolves instead of claiming inconsistent success.
+        if (!text.startsWith(streamedAssistantText)) {
+          unrepresentableAssistantReplacement = true;
+          return;
+        }
+        unrepresentableAssistantReplacement = false;
+        const replacementDelta = text.slice(streamedAssistantText.length);
+        if (replacementDelta) {
           sawAssistantDelta = true;
+          streamedAssistantText = text;
           writeSseEvent(res, {
             type: "response.output_text.delta",
             item_id: outputItemId,
             output_index: 0,
             content_index: 0,
-            delta: text,
+            delta: replacementDelta,
           });
         }
+        return;
+      }
+
+      const content = resolveAssistantStreamDeltaText(evt);
+      if (!content) {
         return;
       }
 
@@ -1100,6 +1108,7 @@ export async function handleOpenResponsesHttpRequest(
 
       sawAssistantDelta = true;
       accumulatedText += content;
+      streamedAssistantText += content;
 
       writeSseEvent(res, {
         type: "response.output_text.delta",
@@ -1149,6 +1158,24 @@ export async function handleOpenResponsesHttpRequest(
       });
 
       finalUsage = extractUsageFromResult(result);
+
+      if (unrepresentableAssistantReplacement) {
+        rememberResponseSession();
+        finalizeFailedResponse(
+          createResponseResource({
+            id: responseId,
+            model,
+            status: "failed",
+            output: [],
+            error: {
+              code: "server_error",
+              message: "Assistant output cannot be represented as an append-only response stream.",
+            },
+            usage: finalUsage,
+          }),
+        );
+        return;
+      }
 
       // Check for pending client tool calls BEFORE maybeFinalize() because the
       // lifecycle:end event may already have requested finalization.


### PR DESCRIPTION
Related: #85261

## What Problem This Solves

Fixes an issue where users streaming Gateway `/v1/responses` could receive a doubled final answer when an assistant replacement snapshot also contained text or an explicit delta. Already streamed replacements could also report a successful final answer that did not match the append-only text actually delivered to official OpenAI SDK clients.

## Why This Change Was Made

Keep one authoritative Gateway Responses snapshot and separately track the text already sent. Stream initial replacements exactly once, append only safe replacement suffixes, and hold replacements for `required` or pinned client tools until the actual call has been validated. When a replacement rewrites, shortens, or clears text already visible to the client, finish with one official `response.failed` and preserve the run's actual token usage instead of claiming a contradictory successful completion.

This is the isolated OpenResponses streaming portion identified by Achyut Mukund (@cropsgg) in #85261. The contributor is credited with a real git coauthor trailer. Keep #85261 open: it also contains separate session-history, lazy-module, and auth-test work that this narrow fix does not claim to supersede.

No provider, authentication, configuration, environment, database, plugin, public protocol version, or dependency change.

## User Impact

Real OpenAI Responses clients receive exactly the corrected answer once. Compatible replacements continue to stream their true suffix; impossible post-output rewrites become accurate failed Responses with their original `11/7/18` token accounting. Required tool calls never expose unvalidated or stale replacement text.

## Evidence

Personally inspected the exact pinned `openai@6.48.0` upstream streaming and append-only contracts:

- https://github.com/openai/openai-node/blob/v6.48.0/src/lib/responses/ResponseAccumulator.ts
- https://github.com/openai/openai-node/blob/v6.48.0/src/lib/responses/ResponseStream.ts
- https://github.com/openai/openai-node/blob/v6.48.0/src/resources/responses/responses.ts
- https://github.com/openai/openai-node/blob/v6.48.0/src/core/streaming.ts

Fail-first against unchanged production with a real loopback Gateway and the actual pinned official SDK:

```text
pnpm test src/gateway/openresponses-http.test.ts

FAIL initial replacement snapshot: final answerfinal answer
FAIL explicit replacement delta: final answerfinal answer
47 existing Gateway tests pass
Blacksmith Testbox exitCode=1
```

Final behavior includes actual official-SDK coverage for initial snapshots, explicit deltas, safely appendable replacement suffixes, three impossible rewrite/shorten/clear failure cases with real usage, and three real Gateway required-tool replacement cases.

```text
pnpm test \
  src/gateway/openai-http.test.ts \
  src/gateway/openresponses-http.test.ts \
  src/gateway/openresponses-parity.test.ts \
  src/gateway/openresponses-phase.test.ts \
  src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.filters-final-suppresses-output-without-start-tag.test.ts

Gateway and Responses: 97 passed
Embedded agent stream: 24 passed
Total: 121 passed

pnpm check:changed -- \
  src/gateway/openresponses-http.ts \
  src/gateway/openresponses-http.test.ts

core typecheck, core test typecheck, format, lint, contracts, ownership,
dead-code, database-first, runtime, and security guards: PASS

.agents/skills/autoreview/scripts/autoreview \
  --mode uncommitted --engine codex --model gpt-5.6-sol --thinking xhigh

autoreview clean: no accepted/actionable findings reported
```

AI-assisted; the contributor patch, current main, real producer and Gateway owner paths, pinned upstream SDK, failing real HTTP/SSE behavior, sibling endpoints, token accounting, constrained tools, complete changed-file gate, and independent extra-high-reasoning review were personally verified.
