### PR TITLE
feat(anthropic): support fast mode in Claude CLI

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -128,6 +128,11 @@ Claude Code can drive a Chrome browser through the [Claude in Chrome extension](
 
 The backend also maps OpenClaw `/think` levels to Claude Code's native `--effort` flag: `minimal`/`low` -> `low`, `medium` -> `medium`, and `high`/`xhigh`/`max` pass through directly. This keeps the supported Fable 5 effort levels the same for subscription-backed Claude CLI and API-key routes. `adaptive` removes configured `--effort` flags and supplies no replacement, so Claude Code resolves effective effort from its own environment, settings, and model defaults. Other CLI backends need their owning plugin to declare an equivalent argv mapper before `/think` affects the spawned CLI.
 
+OpenClaw `/fast` settings also map to Claude Code's per-invocation `fastMode`
+setting. Automatic mode is recalculated before every fresh, retry, fallback,
+tool-result, or continuation call, while restricted and `/btw` side-question
+runs keep fast mode off.
+
 Before OpenClaw can use `claude-cli`, Claude Code itself must be logged in on the same host:
 
 ```bash

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -131,7 +131,10 @@ The backend also maps OpenClaw `/think` levels to Claude Code's native `--effort
 OpenClaw `/fast` settings also map to Claude Code's per-invocation `fastMode`
 setting. Automatic mode is recalculated before every fresh, retry, fallback,
 tool-result, or continuation call, while restricted and `/btw` side-question
-runs keep fast mode off.
+runs keep fast mode off. If `--settings` names a file, leave OpenClaw fast mode
+unset or replace the argument with inline JSON; Claude Code accepts only one
+file-or-JSON value, so OpenClaw rejects an authoritative `/fast` override rather
+than silently contradicting the file.
 
 Before OpenClaw can use `claude-cli`, Claude Code itself must be logged in on the same host:
 

--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -272,9 +272,11 @@ side-question argv reliably disables those tools, also set
 `sideQuestionToolMode: "disabled"`; otherwise OpenClaw fails closed when BTW
 requires a no-tools CLI run.
 
-`ctx.fastMode` is the effective boolean for this individual invocation.
-OpenClaw resolves automatic fast-mode cutoffs before calling the hook; the
-backend only needs to map the boolean to its native request or argv contract.
+`ctx.fastMode` is the effective boolean for this individual invocation when
+OpenClaw has a configured fast-mode value; `undefined` means the backend should
+preserve its own default. OpenClaw resolves automatic fast-mode cutoffs before
+calling the hook; the backend only needs to map the boolean to its native
+request or argv contract.
 
 Set `nativeToolMode: "selectable"` only when the backend can disable every
 backend-native tool for an individual run. Restricted runs receive a canonical

--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -272,6 +272,10 @@ side-question argv reliably disables those tools, also set
 `sideQuestionToolMode: "disabled"`; otherwise OpenClaw fails closed when BTW
 requires a no-tools CLI run.
 
+`ctx.fastMode` is the effective boolean for this individual invocation.
+OpenClaw resolves automatic fast-mode cutoffs before calling the hook; the
+backend only needs to map the boolean to its native request or argv contract.
+
 Set `nativeToolMode: "selectable"` only when the backend can disable every
 backend-native tool for an individual run. Restricted runs receive a canonical
 contract: `ctx.toolAvailability.native` is the exact backend-native list and

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -76,6 +76,7 @@ title: "Thinking levels"
 - For `openai/*`, fast mode maps to OpenAI priority processing by sending `service_tier=priority` on supported Responses requests.
 - For Codex-backed `openai/*` / `openai-codex/*` models, fast mode sends the same `service_tier=priority` flag on Codex Responses. Native Codex app-server turns receive the tier only on `turn/start` or thread start/resume, so `auto` cannot retier one already-running app-server turn; it applies to the next model turn OpenClaw starts.
 - For direct public `anthropic/*` requests, including OAuth-authenticated traffic sent to `api.anthropic.com`, fast mode maps to Anthropic service tiers: `/fast on` sets `service_tier=auto`, `/fast off` sets `service_tier=standard_only`.
+- For the `claude-cli` backend, fast mode maps to Claude Code's per-invocation `fastMode` setting. Restricted and `/btw` side-question runs keep fast mode disabled.
 - For `minimax/*` on the Anthropic-compatible path, `/fast on` (or `params.fastMode: true`) rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed`.
 - Explicit Anthropic `serviceTier` / `service_tier` model params override the fast-mode default when both are set. OpenClaw still skips Anthropic service-tier injection for non-Anthropic proxy base URLs.
 - `/status` shows `Fast` when fast mode is enabled and `Fast:auto` when the configured mode is auto.

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -76,7 +76,7 @@ title: "Thinking levels"
 - For `openai/*`, fast mode maps to OpenAI priority processing by sending `service_tier=priority` on supported Responses requests.
 - For Codex-backed `openai/*` / `openai-codex/*` models, fast mode sends the same `service_tier=priority` flag on Codex Responses. Native Codex app-server turns receive the tier only on `turn/start` or thread start/resume, so `auto` cannot retier one already-running app-server turn; it applies to the next model turn OpenClaw starts.
 - For direct public `anthropic/*` requests, including OAuth-authenticated traffic sent to `api.anthropic.com`, fast mode maps to Anthropic service tiers: `/fast on` sets `service_tier=auto`, `/fast off` sets `service_tier=standard_only`.
-- For the `claude-cli` backend, fast mode maps to Claude Code's per-invocation `fastMode` setting. Restricted and `/btw` side-question runs keep fast mode disabled.
+- For the `claude-cli` backend, fast mode maps to Claude Code's per-invocation `fastMode` setting. Restricted and `/btw` side-question runs keep fast mode disabled. File-backed `--settings` arguments are preserved when OpenClaw fast mode is unset; an explicit or configured fast-mode override requires inline JSON settings so the two sources cannot silently disagree.
 - For `minimax/*` on the Anthropic-compatible path, `/fast on` (or `params.fastMode: true`) rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed`.
 - Explicit Anthropic `serviceTier` / `service_tier` model params override the fast-mode default when both are set. OpenClaw still skips Anthropic service-tier injection for non-Anthropic proxy base URLs.
 - `/status` shows `Fast` when fast mode is enabled and `Fast:auto` when the configured mode is auto.

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -211,6 +211,7 @@ describe("resolveClaudeCliExecutionArgs", () => {
         workspaceDir: "/tmp",
         provider: "claude-cli",
         modelId: "claude-opus-4-8",
+        fastMode: true,
         useResume: false,
         baseArgs: [
           "-p",
@@ -274,7 +275,7 @@ describe("resolveClaudeCliExecutionArgs", () => {
       "--setting-sources",
       "",
       "--settings",
-      '{"disableAllHooks":true,"enabledPlugins":{},"autoMemoryEnabled":false,"claudeMdExcludes":["**/CLAUDE.md","**/CLAUDE.local.md","**/.claude/rules/**"]}',
+      '{"disableAllHooks":true,"enabledPlugins":{},"autoMemoryEnabled":false,"fastMode":false,"claudeMdExcludes":["**/CLAUDE.md","**/CLAUDE.local.md","**/.claude/rules/**"]}',
       "--disable-slash-commands",
       "--no-chrome",
       "--strict-mcp-config",
@@ -348,7 +349,7 @@ describe("resolveClaudeCliExecutionArgs", () => {
       "--setting-sources",
       "",
       "--settings",
-      '{"disableAllHooks":true,"enabledPlugins":{},"autoMemoryEnabled":false,"claudeMdExcludes":["**/CLAUDE.md","**/CLAUDE.local.md","**/.claude/rules/**"]}',
+      '{"disableAllHooks":true,"enabledPlugins":{},"autoMemoryEnabled":false,"fastMode":false,"claudeMdExcludes":["**/CLAUDE.md","**/CLAUDE.local.md","**/.claude/rules/**"]}',
       "--disable-slash-commands",
       "--no-chrome",
       "--strict-mcp-config",
@@ -407,7 +408,7 @@ describe("resolveClaudeCliExecutionArgs", () => {
       "--setting-sources",
       "",
       "--settings",
-      '{"disableAllHooks":true,"enabledPlugins":{},"autoMemoryEnabled":false,"claudeMdExcludes":["**/CLAUDE.md","**/CLAUDE.local.md","**/.claude/rules/**"]}',
+      '{"disableAllHooks":true,"enabledPlugins":{},"autoMemoryEnabled":false,"fastMode":false,"claudeMdExcludes":["**/CLAUDE.md","**/CLAUDE.local.md","**/.claude/rules/**"]}',
       "--disable-slash-commands",
       "--no-chrome",
       "--strict-mcp-config",
@@ -492,6 +493,35 @@ describe("resolveClaudeCliExecutionArgs", () => {
     ).toEqual(["-p", "--effort", "max"]);
   });
 
+  it.each([
+    [true, '{"fastMode":true}'],
+    [false, '{"fastMode":false}'],
+  ] as const)("maps fast mode %s to inline Claude settings", (fastMode, settings) => {
+    expect(
+      resolveClaudeCliExecutionArgs({
+        workspaceDir: "/tmp",
+        provider: "claude-cli",
+        modelId: "claude-opus-5",
+        fastMode,
+        useResume: false,
+        baseArgs: ["-p"],
+      }),
+    ).toEqual(["-p", "--settings", settings]);
+  });
+
+  it("merges fast mode into the effective inline settings argument", () => {
+    expect(
+      resolveClaudeCliExecutionArgs({
+        workspaceDir: "/tmp",
+        provider: "claude-cli",
+        modelId: "claude-opus-5",
+        fastMode: true,
+        useResume: false,
+        baseArgs: ["-p", "--settings", '{"hooks":{"PreToolUse":[]}}'],
+      }),
+    ).toEqual(["-p", "--settings", '{"hooks":{"PreToolUse":[]},"fastMode":true}']);
+  });
+
   it("forces isolated no-tool one-shot args for side-question execution", () => {
     expect(
       resolveClaudeCliExecutionArgs({
@@ -499,6 +529,7 @@ describe("resolveClaudeCliExecutionArgs", () => {
         provider: "claude-cli",
         modelId: "claude-opus-4-7",
         thinkingLevel: "max",
+        fastMode: true,
         useResume: true,
         executionMode: "side-question",
         baseArgs: [
@@ -544,6 +575,8 @@ describe("resolveClaudeCliExecutionArgs", () => {
       "1",
       "--permission-mode",
       "default",
+      "--settings",
+      '{"fastMode":false}',
     ]);
   });
 });

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -522,6 +522,37 @@ describe("resolveClaudeCliExecutionArgs", () => {
     ).toEqual(["-p", "--settings", '{"hooks":{"PreToolUse":[]},"fastMode":true}']);
   });
 
+  it.each([
+    ["split", ["-p", "--settings", "/tmp/claude-settings.json"]],
+    ["equals", ["-p", "--settings=/tmp/claude-settings.json"]],
+  ] as const)("preserves file-backed settings in the %s form when fast mode is off", (_, args) => {
+    expect(
+      resolveClaudeCliExecutionArgs({
+        workspaceDir: "/tmp",
+        provider: "claude-cli",
+        modelId: "claude-opus-5",
+        fastMode: false,
+        useResume: false,
+        baseArgs: args,
+      }),
+    ).toEqual(args);
+  });
+
+  it("rejects file-backed settings only when fast mode is on", () => {
+    expect(() =>
+      resolveClaudeCliExecutionArgs({
+        workspaceDir: "/tmp",
+        provider: "claude-cli",
+        modelId: "claude-opus-5",
+        fastMode: true,
+        useResume: false,
+        baseArgs: ["-p", "--settings", "/tmp/claude-settings.json"],
+      }),
+    ).toThrow(
+      "claude-cli fast mode requires inline JSON when --settings is already configured; use inline JSON or disable fast mode",
+    );
+  });
+
   it("forces isolated no-tool one-shot args for side-question execution", () => {
     expect(
       resolveClaudeCliExecutionArgs({

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -525,33 +525,38 @@ describe("resolveClaudeCliExecutionArgs", () => {
   it.each([
     ["split", ["-p", "--settings", "/tmp/claude-settings.json"]],
     ["equals", ["-p", "--settings=/tmp/claude-settings.json"]],
-  ] as const)("preserves file-backed settings in the %s form when fast mode is off", (_, args) => {
-    expect(
-      resolveClaudeCliExecutionArgs({
-        workspaceDir: "/tmp",
-        provider: "claude-cli",
-        modelId: "claude-opus-5",
-        fastMode: false,
-        useResume: false,
-        baseArgs: args,
-      }),
-    ).toEqual(args);
-  });
+  ] as const)(
+    "preserves file-backed settings in the %s form when fast mode is unset",
+    (_, args) => {
+      expect(
+        resolveClaudeCliExecutionArgs({
+          workspaceDir: "/tmp",
+          provider: "claude-cli",
+          modelId: "claude-opus-5",
+          useResume: false,
+          baseArgs: args,
+        }),
+      ).toEqual(args);
+    },
+  );
 
-  it("rejects file-backed settings only when fast mode is on", () => {
-    expect(() =>
-      resolveClaudeCliExecutionArgs({
-        workspaceDir: "/tmp",
-        provider: "claude-cli",
-        modelId: "claude-opus-5",
-        fastMode: true,
-        useResume: false,
-        baseArgs: ["-p", "--settings", "/tmp/claude-settings.json"],
-      }),
-    ).toThrow(
-      "claude-cli fast mode requires inline JSON when --settings is already configured; use inline JSON or disable fast mode",
-    );
-  });
+  it.each([true, false])(
+    "rejects file-backed settings when fast mode has an authoritative %s override",
+    (fastMode) => {
+      expect(() =>
+        resolveClaudeCliExecutionArgs({
+          workspaceDir: "/tmp",
+          provider: "claude-cli",
+          modelId: "claude-opus-5",
+          fastMode,
+          useResume: false,
+          baseArgs: ["-p", "--settings", "/tmp/claude-settings.json"],
+        }),
+      ).toThrow(
+        "claude-cli cannot apply an OpenClaw fast-mode override when --settings names a file; use inline JSON settings or remove the OpenClaw fast-mode override",
+      );
+    },
+  );
 
   it("forces isolated no-tool one-shot args for side-question execution", () => {
     expect(

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -325,11 +325,8 @@ function resolveClaudeFastModeArgs(
       settings = undefined;
     }
     if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
-      if (!fastMode) {
-        return [...args];
-      }
       throw new Error(
-        "claude-cli fast mode requires inline JSON when --settings is already configured; use inline JSON or disable fast mode",
+        "claude-cli cannot apply an OpenClaw fast-mode override when --settings names a file; use inline JSON settings or remove the OpenClaw fast-mode override",
       );
     }
     const normalized = [...args];
@@ -535,18 +532,20 @@ export function resolveClaudeCliExecutionArgs(
         return action satisfies never;
     }
   })();
-  const executionArgs = resolveClaudeFastModeArgs(
-    executionArgsWithoutFastMode,
+  const executionArgsWithRestrictions = context.toolAvailability
+    ? resolveClaudeCliRestrictedExecutionArgs(
+        executionArgsWithoutFastMode,
+        context.toolAvailability,
+      )
+    : executionArgsWithoutFastMode;
+  return resolveClaudeFastModeArgs(
+    executionArgsWithRestrictions,
     context.fastMode === undefined
       ? undefined
       : context.executionMode === "side-question" || context.toolAvailability
         ? false
         : context.fastMode,
   );
-  if (!context.toolAvailability) {
-    return executionArgs;
-  }
-  return resolveClaudeCliRestrictedExecutionArgs(executionArgs, context.toolAvailability);
 }
 
 /** Normalize Claude CLI backend config before registration or execution. */

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -96,7 +96,7 @@ const CLAUDE_NO_TOOLS_VALUE = "";
 const CLAUDE_DENY_MCP_TOOLS_VALUE = "mcp__*";
 const OPENCLAW_MCP_TOOL_PREFIX = "mcp__openclaw__";
 const CLAUDE_RESTRICTED_SETTINGS =
-  '{"disableAllHooks":true,"enabledPlugins":{},"autoMemoryEnabled":false,"claudeMdExcludes":["**/CLAUDE.md","**/CLAUDE.local.md","**/.claude/rules/**"]}';
+  '{"disableAllHooks":true,"enabledPlugins":{},"autoMemoryEnabled":false,"fastMode":false,"claudeMdExcludes":["**/CLAUDE.md","**/CLAUDE.local.md","**/.claude/rules/**"]}';
 
 type ClaudeCliEffort = "low" | "medium" | "high" | "xhigh" | "max";
 type ClaudeCliEffortArgAction =
@@ -292,6 +292,59 @@ function stripClaudeEffortArgs(args: readonly string[]): string[] {
   return normalized;
 }
 
+function resolveClaudeFastModeArgs(
+  args: readonly string[],
+  fastMode: boolean | undefined,
+): string[] {
+  if (fastMode === undefined) {
+    return [...args];
+  }
+  const terminatorIndex = args.indexOf("--");
+  const optionEnd = terminatorIndex < 0 ? args.length : terminatorIndex;
+  let settingsArg:
+    | { index: number; value: string | undefined; valueIndex: number | undefined }
+    | undefined;
+  for (let index = 0; index < optionEnd; index += 1) {
+    const arg = args[index] ?? "";
+    if (arg === CLAUDE_SETTINGS_ARG) {
+      settingsArg = { index, value: args[index + 1], valueIndex: index + 1 };
+      index += 1;
+    } else if (arg.startsWith(`${CLAUDE_SETTINGS_ARG}=`)) {
+      settingsArg = {
+        index,
+        value: arg.slice(`${CLAUDE_SETTINGS_ARG}=`.length),
+        valueIndex: undefined,
+      };
+    }
+  }
+  if (settingsArg) {
+    let settings: unknown;
+    try {
+      settings = JSON.parse(settingsArg.value ?? "");
+    } catch {
+      settings = undefined;
+    }
+    if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
+      throw new Error(
+        "claude-cli fast mode cannot merge a file-backed or malformed --settings value",
+      );
+    }
+    const normalized = [...args];
+    const value = JSON.stringify({ ...(settings as Record<string, unknown>), fastMode });
+    if (settingsArg.valueIndex !== undefined) {
+      normalized[settingsArg.valueIndex] = value;
+    } else {
+      normalized[settingsArg.index] = `${CLAUDE_SETTINGS_ARG}=${value}`;
+    }
+    return normalized;
+  }
+  const settingsArgs = [CLAUDE_SETTINGS_ARG, JSON.stringify({ fastMode })];
+  if (terminatorIndex < 0) {
+    return [...args, ...settingsArgs];
+  }
+  return [...args.slice(0, terminatorIndex), ...settingsArgs, ...args.slice(terminatorIndex)];
+}
+
 const CLAUDE_SIDE_QUESTION_VARIADIC_VALUE_ARGS = new Set([
   CLAUDE_ALLOWED_TOOLS_ARG,
   "--allowed-tools",
@@ -463,7 +516,7 @@ function resolveClaudeCliRestrictedExecutionArgs(
 export function resolveClaudeCliExecutionArgs(
   context: CliBackendResolveExecutionArgsContext,
 ): string[] {
-  const executionArgs = (() => {
+  const executionArgsWithoutFastMode = (() => {
     if (context.executionMode === "side-question") {
       return resolveClaudeCliSideQuestionExecutionArgs(context.baseArgs);
     }
@@ -479,6 +532,14 @@ export function resolveClaudeCliExecutionArgs(
         return action satisfies never;
     }
   })();
+  const executionArgs = resolveClaudeFastModeArgs(
+    executionArgsWithoutFastMode,
+    context.fastMode === undefined
+      ? undefined
+      : context.executionMode === "side-question" || context.toolAvailability
+        ? false
+        : context.fastMode,
+  );
   if (!context.toolAvailability) {
     return executionArgs;
   }

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -325,8 +325,11 @@ function resolveClaudeFastModeArgs(
       settings = undefined;
     }
     if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
+      if (!fastMode) {
+        return [...args];
+      }
       throw new Error(
-        "claude-cli fast mode cannot merge a file-backed or malformed --settings value",
+        "claude-cli fast mode requires inline JSON when --settings is already configured; use inline JSON or disable fast mode",
       );
     }
     const normalized = [...args];

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1216,6 +1216,20 @@ describe("runCliAgent spawn path", () => {
     expect(resolveArgsInput.fastMode).toBe(false);
   });
 
+  it("preserves an unset fast mode for backend argument resolution", async () => {
+    mockSuccessfulCliRun(CLAUDE_OK_JSONL);
+    const resolveExecutionArgs = vi.fn(({ baseArgs }) => baseArgs);
+
+    await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        resolveExecutionArgs,
+      }),
+    );
+
+    const resolveArgsInput = requireRecord(mockCallArg(resolveExecutionArgs), "resolved args");
+    expect(resolveArgsInput.fastMode).toBeUndefined();
+  });
+
   it("preserves exact tool availability through execution-time argument resolution", async () => {
     mockSuccessfulCliRun(CLAUDE_OK_JSONL);
     const toolAvailability: NonNullable<PreparedCliRunContext["params"]["cliToolAvailability"]> = {

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1199,6 +1199,23 @@ describe("runCliAgent spawn path", () => {
     expect(requireArgAfter(input.argv, "--effort")).toBe("high");
   });
 
+  it("passes the elapsed effective fast-mode state to backend argument resolution", async () => {
+    mockSuccessfulCliRun(CLAUDE_OK_JSONL);
+    const resolveExecutionArgs = vi.fn(({ baseArgs }) => baseArgs);
+
+    await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        fastMode: "auto",
+        fastModeStartedAtMs: Date.now() - 6_000,
+        fastModeAutoOnSeconds: 5,
+        resolveExecutionArgs,
+      }),
+    );
+
+    const resolveArgsInput = requireRecord(mockCallArg(resolveExecutionArgs), "resolved args");
+    expect(resolveArgsInput.fastMode).toBe(false);
+  });
+
   it("preserves exact tool availability through execution-time argument resolution", async () => {
     mockSuccessfulCliRun(CLAUDE_OK_JSONL);
     const toolAvailability: NonNullable<PreparedCliRunContext["params"]["cliToolAvailability"]> = {

--- a/src/agents/cli-runner.test-helpers.ts
+++ b/src/agents/cli-runner.test-helpers.ts
@@ -130,6 +130,9 @@ export type PreparedCliRunContextOverrides = {
   mcpDeliveryCapture?: boolean;
   skillsSnapshot?: PreparedCliRunContext["params"]["skillsSnapshot"];
   thinkLevel?: PreparedCliRunContext["params"]["thinkLevel"];
+  fastMode?: PreparedCliRunContext["params"]["fastMode"];
+  fastModeStartedAtMs?: PreparedCliRunContext["params"]["fastModeStartedAtMs"];
+  fastModeAutoOnSeconds?: PreparedCliRunContext["params"]["fastModeAutoOnSeconds"];
   executionMode?: PreparedCliRunContext["params"]["executionMode"];
   cliToolAvailability?: PreparedCliRunContext["params"]["cliToolAvailability"];
   emitCommentaryText?: boolean;
@@ -206,6 +209,9 @@ export function buildPreparedCliRunContext(
       provider,
       model,
       thinkLevel: overrides.thinkLevel,
+      fastMode: overrides.fastMode,
+      fastModeStartedAtMs: overrides.fastModeStartedAtMs,
+      fastModeAutoOnSeconds: overrides.fastModeAutoOnSeconds,
       executionMode: overrides.executionMode,
       cliToolAvailability: overrides.cliToolAvailability,
       emitCommentaryText: overrides.emitCommentaryText,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -212,11 +212,14 @@ export async function executePreparedCliRun(
     : (context.claudeSkillsPluginArgs ?? fallbackClaudeSkillsPlugin?.args ?? []);
   const baseArgsWithSkills =
     claudeSkillsPluginArgs.length > 0 ? [...resolvedArgs, ...claudeSkillsPluginArgs] : resolvedArgs;
-  const fastMode = resolveFastModeForElapsed({
-    mode: params.fastMode,
-    startedAtMs: params.fastModeStartedAtMs ?? context.started,
-    fastAutoOnSeconds: params.fastModeAutoOnSeconds,
-  }).enabled;
+  const fastMode =
+    params.fastMode === undefined
+      ? undefined
+      : resolveFastModeForElapsed({
+          mode: params.fastMode,
+          startedAtMs: params.fastModeStartedAtMs ?? context.started,
+          fastAutoOnSeconds: params.fastModeAutoOnSeconds,
+        }).enabled;
   const resolvedExecutionArgs = context.backendResolved.resolveExecutionArgs?.({
     config: params.config,
     workspaceDir: context.workspaceDir,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -19,6 +19,7 @@ import {
   detectImageReferences,
   hasHydratableMediaImages,
 } from "../embedded-agent-runner/run/images.js";
+import { resolveFastModeForElapsed } from "../fast-mode.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { prepareCliBundleMcpCaptureAttempt } from "./bundle-mcp.js";
 import {
@@ -211,6 +212,11 @@ export async function executePreparedCliRun(
     : (context.claudeSkillsPluginArgs ?? fallbackClaudeSkillsPlugin?.args ?? []);
   const baseArgsWithSkills =
     claudeSkillsPluginArgs.length > 0 ? [...resolvedArgs, ...claudeSkillsPluginArgs] : resolvedArgs;
+  const fastMode = resolveFastModeForElapsed({
+    mode: params.fastMode,
+    startedAtMs: params.fastModeStartedAtMs ?? context.started,
+    fastAutoOnSeconds: params.fastModeAutoOnSeconds,
+  }).enabled;
   const resolvedExecutionArgs = context.backendResolved.resolveExecutionArgs?.({
     config: params.config,
     workspaceDir: context.workspaceDir,
@@ -218,6 +224,7 @@ export async function executePreparedCliRun(
     modelId: context.modelId,
     authProfileId: context.effectiveAuthProfileId,
     thinkingLevel: normalizeCliBackendThinkingLevel(params.thinkLevel),
+    fastMode,
     executionMode: params.executionMode ?? "agent",
     // Node runs project the native subset only: gateway-loopback MCP tools do
     // not exist on the node, and auto-approval must not cross that boundary.

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -4,14 +4,21 @@ import type { FollowupRun } from "./queue.js";
 
 const hoisted = vi.hoisted(() => {
   const resolveEffectiveModelFallbacksMock = vi.fn();
+  const resolveAgentConfigMock = vi.fn();
   const getChannelPluginMock = vi.fn();
   const isReasoningTagProviderMock = vi.fn();
-  return { resolveEffectiveModelFallbacksMock, getChannelPluginMock, isReasoningTagProviderMock };
+  return {
+    resolveEffectiveModelFallbacksMock,
+    resolveAgentConfigMock,
+    getChannelPluginMock,
+    isReasoningTagProviderMock,
+  };
 });
 
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveEffectiveModelFallbacks: (...args: unknown[]) =>
     hoisted.resolveEffectiveModelFallbacksMock(...args),
+  resolveAgentConfig: (...args: unknown[]) => hoisted.resolveAgentConfigMock(...args),
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
@@ -22,8 +29,12 @@ vi.mock("../../utils/provider-utils.js", () => ({
   isReasoningTagProvider: (...args: unknown[]) => hoisted.isReasoningTagProviderMock(...args),
 }));
 
-const { buildThreadingToolContext, buildEmbeddedRunExecutionParams, resolveModelFallbackOptions } =
-  await import("./agent-runner-utils.js");
+const {
+  buildThreadingToolContext,
+  buildEmbeddedRunExecutionParams,
+  resolveModelFallbackOptions,
+  resolveRunFastModeForFallbackCandidate,
+} = await import("./agent-runner-utils.js");
 const { resolveProviderScopedAuthProfile } = await import("./agent-runner-auth-profile.js");
 const { buildEmbeddedRunBaseParams: buildEmbeddedRunBaseParamsCore } =
   await import("./agent-runner-run-params.js");
@@ -66,6 +77,7 @@ function makeRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun["run"
 describe("agent-runner-utils", () => {
   beforeEach(() => {
     hoisted.resolveEffectiveModelFallbacksMock.mockClear();
+    hoisted.resolveAgentConfigMock.mockReset();
     hoisted.getChannelPluginMock.mockReset();
     hoisted.isReasoningTagProviderMock.mockReset();
     hoisted.isReasoningTagProviderMock.mockReturnValue(false);
@@ -124,6 +136,55 @@ describe("agent-runner-utils", () => {
 
     expect(hoisted.resolveEffectiveModelFallbacksMock).not.toHaveBeenCalled();
     expect(resolved.fallbacksOverride).toEqual([]);
+  });
+
+  it("keeps the default fast mode unset for backend-native defaults", () => {
+    const run = makeRun({ fastMode: false });
+
+    expect(
+      resolveRunFastModeForFallbackCandidate({
+        run,
+        config: run.config,
+        provider: "anthropic",
+        model: "claude-opus-5",
+      }).fastMode,
+    ).toBeUndefined();
+  });
+
+  it("keeps an explicit fast-off override authoritative", () => {
+    const run = makeRun({ fastMode: false, fastModeOverride: true });
+
+    expect(
+      resolveRunFastModeForFallbackCandidate({
+        run,
+        config: run.config,
+        provider: "anthropic",
+        model: "claude-opus-5",
+      }).fastMode,
+    ).toBe(false);
+  });
+
+  it("keeps a configured fast-off value authoritative", () => {
+    const run = makeRun({
+      config: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-5": { params: { fastMode: false } },
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      resolveRunFastModeForFallbackCandidate({
+        run,
+        config: run.config,
+        provider: "anthropic",
+        model: "claude-opus-5",
+      }).fastMode,
+    ).toBe(false);
   });
 
   it("passes through missing agentId for helper-based fallback resolution", () => {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -224,7 +224,10 @@ export function resolveRunFastModeForFallbackCandidate(params: {
     };
   }
   return {
-    fastMode: state.mode,
+    // Preserve "not configured" for CLI backends. A backend may already have
+    // its own fast-mode setting, so the OpenClaw default must not become an
+    // authoritative per-invocation `false` override.
+    fastMode: state.source === "default" ? undefined : state.mode,
     fastModeAutoOnSeconds: params.run.fastModeAutoOnSecondsOverride
       ? params.run.fastModeAutoOnSeconds
       : state.fastAutoOnSeconds,

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -165,6 +165,8 @@ export type CliBackendResolveExecutionArgsContext = {
   modelId: string;
   authProfileId?: string;
   thinkingLevel?: CliBackendThinkingLevel;
+  /** Effective fast-mode state for this individual CLI invocation. */
+  fastMode?: boolean;
   executionMode?: CliBackendExecutionMode;
   toolAvailability?: CliBackendToolAvailability;
   useResume: boolean;


### PR DESCRIPTION
Closes #115437

## What Problem This Solves

Resolves a problem where `/fast`, agent fast-mode defaults, and model-level `params.fastMode` were resolved for `claude-cli` runs but never reached the spawned Claude Code process, so enabling fast mode had no effect.

## Why This Change Was Made

The CLI backend hook now receives the effective per-invocation fast-mode boolean, including elapsed `auto` cutoffs. The bundled Anthropic backend maps that value to Claude Code's inline `fastMode` setting, merges existing inline JSON settings instead of replacing them, and explicitly keeps restricted and `/btw` side-question runs off.

The runner preserves an unset OpenClaw fast-mode value as `undefined`, so a backend's own default remains authoritative when OpenClaw has no session, agent, or model setting. Explicit/configured `on` and `off` values remain authoritative. Claude CLI accepts `--settings` as one file-or-JSON value and does not compose repeated flags, so an authoritative OpenClaw override with a file-backed `--settings` argument is rejected with a visible remediation message rather than silently disagreeing with the file or expanding potentially sensitive file contents into process arguments.

## User Impact

Users running supported Claude models through `claude-cli` can use OpenClaw's existing `/fast` controls. Automatic mode is recalculated for each fresh, retry, fallback, tool-result, and continuation invocation, while restricted work avoids premium fast-mode usage.

Existing file-backed Claude settings remain unchanged when OpenClaw fast mode is unset. Users who combine file-backed `--settings` with an explicit or configured OpenClaw fast-mode value must switch that argument to inline JSON or remove the OpenClaw override.

## Evidence

- `extensions/anthropic/cli-shared.test.ts`: 52/52 passed, covering on/off mapping, inline settings merge, unset file-backed settings preservation, authoritative file-backed conflict rejection, restricted settings, and side-question clamping.
- `src/auto-reply/reply/agent-runner-utils.test.ts`: 21/21 passed, including default-unset, explicit-off, and configured-off candidate semantics.
- Focused `src/agents/cli-runner.spawn.test.ts`: 4 passed / 238 skipped across the selected test projects, covering elapsed `auto` cutoff and preservation of `undefined` at the backend hook.
- Core production and root test typechecks passed.
- Plugin SDK API baseline check passed.
- Docs formatting passed across 748 files; docs MDX passed across 764 files.
- `oxlint`, `oxfmt --check`, and `git diff --check` passed for the changed surface.
- Current head `e4cc067a4b6` is cleanly rebased onto main. `git range-diff` reports all three commits patch-identical to the previously reviewed/tested head `bd17f43b373`.
- Eligible-account behavior proof: issue reporter @skadauke tested patch-identical head `bd17f43b373` with Claude CLI 2.1.220 on macOS / Node 24.18.0 after removing their local `fastMode` workaround. Feeding the patched resolver's argv to the real `claude` binary produced `fast_mode_state=on` for OpenClaw fast mode on, `off` for explicit off, and `off` with no injected setting for unset. They also exercised inline merge/override, file-backed remediation, restricted-run clamping, and side-question clamping. Full redacted evidence: https://github.com/openclaw/openclaw/issues/115437#issuecomment-5139295862
- Proof boundary: this was executed resolver/session wiring plus a real eligible Claude CLI process, not a full gateway-to-CLI transcript. The reporter explicitly offered to run an isolated channels-disabled gateway proof if maintainers require that additional end-to-end layer.

## AI Assistance

AI-assisted implementation and review. The patch was iterated against ClawSweeper feedback; eligible-account resolver-to-real-CLI behavior proof is linked above, with the full gateway glue boundary stated explicitly.