### PR TITLE
fix(qa): run shared Slack live flows without module setup

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/scenario-environment.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/scenario-environment.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSlackQaScenarioEnvironment } from "./scenario-environment.js";
+
+function createEnvironment() {
+  return createSlackQaScenarioEnvironment({
+    accountId: "work",
+    channelId: "C123456789",
+    driverBotUserId: "U123456789",
+    driverClient: {} as never,
+    sutAppToken: "xapp-test",
+    sutBotToken: "xoxb-test",
+    sutIdentity: { userId: "U987654321" },
+    sutReadClient: {} as never,
+    sutWriteClient: {} as never,
+  });
+}
+
+describe("Slack live scenario environment", () => {
+  it("leaves generic declarative flows to their own config preparation", async () => {
+    const gatewayCall = vi.fn();
+    const { prepareFlow } = createEnvironment();
+
+    await expect(
+      prepareFlow({
+        config: { policyKey: "dmPolicy", policyValue: "disabled" },
+        gateway: { call: gatewayCall } as never,
+        outputDir: "/tmp/slack-output",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        timeoutMs: 60_000,
+        waitForConfigRestartSettle: vi.fn(),
+      }),
+    ).resolves.toBeUndefined();
+    expect(gatewayCall).not.toHaveBeenCalled();
+  });
+
+  it("authorizes the exact Slack account and channel array replacement paths", async () => {
+    const gatewayCall = vi.fn(async (method: string, _params?: unknown) => {
+      if (method === "config.get") {
+        return { config: {}, hash: "config-hash" };
+      }
+      if (method === "config.patch") {
+        return { noop: true };
+      }
+      if (method === "channels.status") {
+        return {
+          channelAccounts: {
+            slack: [
+              {
+                accountId: "work",
+                connected: true,
+                lastConnectedAt: Date.now() - 30_000,
+                restartPending: false,
+                running: true,
+              },
+            ],
+          },
+        };
+      }
+      throw new Error(`unexpected gateway method: ${method}`);
+    });
+    const { prepareFlow } = createEnvironment();
+
+    await prepareFlow({
+      config: { slackScenarioId: "slack-allowlist-block" },
+      gateway: { call: gatewayCall } as never,
+      outputDir: "/tmp/slack-output",
+      primaryModel: "mock-openai/gpt-5.6-luna",
+      timeoutMs: 60_000,
+      waitForConfigRestartSettle: vi.fn(),
+    });
+
+    const patchCall = gatewayCall.mock.calls.find(([method]) => method === "config.patch");
+    if (!patchCall) {
+      throw new Error("config.patch was not called");
+    }
+    expect(patchCall[1]).toMatchObject({
+      replacePaths: expect.arrayContaining([
+        "channels.slack.accounts.work.allowFrom",
+        "channels.slack.accounts.work.channels.C123456789.users",
+      ]),
+    });
+  });
+});

--- a/extensions/qa-lab/src/live-transports/slack/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/slack/scenario-environment.ts
@@ -35,6 +35,19 @@ export type SlackQaScenarioEnvironment = {
   sutWriteClient: WebClient;
 };
 
+function resolveSlackQaReplacePaths(accountId: string, channelId: string): string[] {
+  return [
+    "agents",
+    "approvals",
+    "channels.slack",
+    `channels.slack.accounts.${accountId}.allowFrom`,
+    `channels.slack.accounts.${accountId}.channels.${channelId}.users`,
+    "messages",
+    "plugins",
+    "tools",
+  ];
+}
+
 export function createSlackQaScenarioEnvironment(params: {
   accountId: string;
   channelId: string;
@@ -51,7 +64,7 @@ export function createSlackQaScenarioEnvironment(params: {
   const prepareFlow = async (input: FlowPreparationInput) => {
     const scenarioId = input.config.slackScenarioId;
     if (typeof scenarioId !== "string") {
-      throw new Error("Slack QA module flow requires config.slackScenarioId");
+      return undefined;
     }
     if (!input.primaryModel) {
       throw new Error("Slack QA module flow requires a primary model");
@@ -75,7 +88,7 @@ export function createSlackQaScenarioEnvironment(params: {
     await patchLiveQaGatewayConfig({
       gateway: input.gateway,
       patch: cfg as Record<string, unknown>,
-      replacePaths: ["agents", "approvals", "channels.slack", "messages", "plugins", "tools"],
+      replacePaths: resolveSlackQaReplacePaths(params.accountId, params.channelId),
       timeoutMs: input.timeoutMs,
       waitForConfigRestartSettle: input.waitForConfigRestartSettle,
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA operators running shared Slack live scenarios would see Slack-specific setup fail before scenario execution. It also restores the Slack blocked-sender scenario after protected array replacement became stricter.

## Why This Change Was Made

Slack module preparation now yields to shared declarative flows when no Slack module scenario is selected. Slack module flows explicitly authorize only the exact account allowlist and channel-user array paths they intentionally replace.

## User Impact

No product runtime behavior changes. Maintainers can run generic Slack restart/thread coverage and Slack allowlist coverage through the normal live QA command.

## Evidence

- Baseline on `726d348bbd3`: `slack-restart-resume` failed during preparation because `config.slackScenarioId` was absent.
- Baseline on `726d348bbd3`: `slack-allowlist-block` failed during `config.patch` because the two protected array paths were not named exactly.
- Exact HEAD `a2b752abeb6`: live Slack provider/Gateway runs passed for `slack-allowlist-block`, `slack-restart-resume`, and `thread-follow-up` (3/3).
- Focused Vitest: 47 tests passed across the scenario environment, adapter reconciliation, and Slack live runtime.
- Remote `check:changed`: formatting, extension types, extension test types, lint, boundaries, dead-code scan, and shared guards passed.
- Fresh autoreview: clean, no accepted/actionable findings.

AI-assisted implementation; reviewed and live-validated against the exact commit.