### PR TITLE
fix(active-memory): reject assistant chitchat from recall summary (#84034)

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -430,17 +430,16 @@ describe("active-memory plugin", () => {
       "utf8",
     );
   };
+  const usableMemoryTranscriptRecord = (text: string) => ({
+    message: {
+      role: "toolResult",
+      toolName: "memory_search",
+      details: { results: [{ text }] },
+      content: [{ type: "text", text: JSON.stringify({ results: [{ text }] }) }],
+    },
+  });
   const writeUsableMemoryTranscript = async (sessionFile: string, text: string) => {
-    await writeTranscriptJsonl(sessionFile, [
-      {
-        message: {
-          role: "toolResult",
-          toolName: "memory_search",
-          details: { results: [{ text }] },
-          content: [{ type: "text", text: JSON.stringify({ results: [{ text }] }) }],
-        },
-      },
-    ]);
+    await writeTranscriptJsonl(sessionFile, [usableMemoryTranscriptRecord(text)]);
   };
   const waitForAbort = async (abortSignal?: AbortSignal): Promise<never> => {
     if (abortSignal?.aborted) {
@@ -3086,6 +3085,7 @@ describe("active-memory plugin", () => {
           params.sessionFile,
           [
             { type: "message", message: { role: "user", content: "ignore this user text" } },
+            usableMemoryTranscriptRecord("user prefers lemon pepper wings"),
             {
               type: "message",
               message: { role: "assistant", content: "alpha beta gamma delta" },
@@ -3136,6 +3136,7 @@ describe("active-memory plugin", () => {
       async (params: { sessionFile: string; abortSignal?: AbortSignal }) => {
         tempSessionFile = params.sessionFile;
         await writeTranscriptJsonl(params.sessionFile, [
+          usableMemoryTranscriptRecord("user prefers lemon pepper wings"),
           {
             type: "message",
             message: { role: "assistant", content: "temporary partial recall summary" },
@@ -3186,6 +3187,10 @@ describe("active-memory plugin", () => {
         if (!target) {
           throw new Error("expected active-memory runtime session target");
         }
+        await appendSessionTranscriptMessageByIdentity({
+          ...target,
+          message: usableMemoryTranscriptRecord("user prefers lemon pepper wings").message,
+        });
         await appendSessionTranscriptMessageByIdentity({
           ...target,
           message: {
@@ -3250,6 +3255,39 @@ describe("active-memory plugin", () => {
     expectLinesNotToContain(lines, "timeout_partial");
   });
 
+  it("rejects a timeout partial without usable memory evidence", async () => {
+    testing.setMinimumTimeoutMsForTests(1);
+    testing.setSetupGraceTimeoutMsForTests(0);
+    testing.setTimeoutPartialDataGraceMsForTests(50);
+    registerPluginConfig({ timeoutMs: 100, logging: true });
+    const sessionKey = "agent:main:timeout-partial-no-evidence";
+    seedSession(sessionKey, "s-timeout-partial-no-evidence", 0);
+    runEmbeddedAgent.mockImplementationOnce(
+      async (params: { sessionFile: string; abortSignal?: AbortSignal }) => {
+        await writeTranscriptJsonl(params.sessionFile, [
+          {
+            message: {
+              role: "assistant",
+              content: "User prefers aisle seats and extra legroom.",
+            },
+          },
+        ]);
+        return await waitForAbort(params.abortSignal);
+      },
+    );
+
+    const result = await runPromptBuild(
+      { prompt: "what seat do i prefer? timeout without evidence" },
+      { sessionKey },
+    );
+
+    expect(result).toBeUndefined();
+    const lines = getActiveMemoryLines(sessionKey);
+    expectLinesToContain(lines, "Active Memory: status=timeout");
+    expectLinesNotToContain(lines, "timeout_partial");
+    expectLinesNotToContain(lines, "aisle seats");
+  });
+
   it("keeps timeout status when the timeout transcript path does not exist", async () => {
     testing.setMinimumTimeoutMsForTests(1);
     testing.setSetupGraceTimeoutMsForTests(0);
@@ -3281,6 +3319,7 @@ describe("active-memory plugin", () => {
     runEmbeddedAgent.mockImplementationOnce(
       async (params: { sessionFile: string; abortSignal?: AbortSignal }) => {
         await writeTranscriptJsonl(params.sessionFile, [
+          usableMemoryTranscriptRecord("user prefers lemon pepper wings"),
           {
             type: "message",
             message: {
@@ -3316,6 +3355,7 @@ describe("active-memory plugin", () => {
     runEmbeddedAgent.mockImplementationOnce(
       async (params: { sessionFile: string; abortSignal?: AbortSignal }) => {
         await writeTranscriptJsonl(params.sessionFile, [
+          usableMemoryTranscriptRecord("user prefers lemon pepper wings"),
           {
             type: "message",
             message: { role: "assistant", content: "partial abort summary" },
@@ -3344,6 +3384,47 @@ describe("active-memory plugin", () => {
       "🔎 Active Memory Debug: timeout_partial: 21 chars recovered (not persisted)",
     );
     expect(getActiveMemoryLines(sessionKey).join("\n")).not.toContain("partial abort summary");
+  });
+
+  it("keeps a timeout partial grounded only by the tool-result callback", async () => {
+    testing.setMinimumTimeoutMsForTests(1);
+    testing.setSetupGraceTimeoutMsForTests(0);
+    testing.setTimeoutPartialDataGraceMsForTests(50);
+    registerPluginConfig({ timeoutMs: 100, logging: true });
+    const sessionKey = "agent:main:timeout-partial-callback-evidence";
+    seedSession(sessionKey, "s-timeout-partial-callback-evidence", 0);
+    runEmbeddedAgent.mockImplementationOnce(
+      async (params: {
+        sessionFile: string;
+        abortSignal?: AbortSignal;
+        onAgentToolResult?: (event: {
+          toolName: string;
+          result: unknown;
+          isError: boolean;
+        }) => void;
+      }) => {
+        params.onAgentToolResult?.({
+          toolName: "memory_search",
+          isError: false,
+          result: {
+            content: [{ type: "text", text: '{"results":[{"text":"User likes ramen."}]}' }],
+            details: { results: [{ text: "User likes ramen." }] },
+          },
+        });
+        await writeTranscriptJsonl(params.sessionFile, [
+          { message: { role: "assistant", content: "User likes ramen with chili oil." } },
+        ]);
+        return await waitForAbort(params.abortSignal);
+      },
+    );
+
+    const result = await runPromptBuild(
+      { prompt: "what ramen do i like? callback evidence" },
+      { sessionKey },
+    );
+
+    expectPrependContextContains(result, "User likes ramen with chili oil.");
+    expectLinesToContain(getActiveMemoryLines(sessionKey), "Active Memory: status=timeout_partial");
   });
 
   it("skips generic subagent errors without using partial transcript output", async () => {

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -3148,6 +3148,20 @@ describe("active-memory plugin", () => {
             { type: "message", message: { role: "user", content: "ignore this user text" } },
             {
               type: "message",
+              message: {
+                role: "toolResult",
+                toolName: "memory_search",
+                details: { results: [{ text: "user prefers ramen" }] },
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({ results: [{ text: "user prefers ramen" }] }),
+                  },
+                ],
+              },
+            },
+            {
+              type: "message",
               message: { role: "assistant", content: "alpha beta gamma delta" },
             },
             {
@@ -3196,6 +3210,19 @@ describe("active-memory plugin", () => {
       async (params: { sessionFile: string; abortSignal?: AbortSignal }) => {
         tempSessionFile = params.sessionFile;
         await writeTranscriptJsonl(params.sessionFile, [
+          {
+            message: {
+              role: "toolResult",
+              toolName: "memory_search",
+              details: { results: [{ text: "user prefers ramen" }] },
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({ results: [{ text: "user prefers ramen" }] }),
+                },
+              ],
+            },
+          },
           {
             type: "message",
             message: { role: "assistant", content: "temporary partial recall summary" },
@@ -3246,6 +3273,17 @@ describe("active-memory plugin", () => {
         if (!target) {
           throw new Error("expected active-memory runtime session target");
         }
+        await appendSessionTranscriptMessageByIdentity({
+          ...target,
+          message: {
+            role: "toolResult",
+            toolName: "memory_search",
+            details: { results: [{ text: "user prefers ramen" }] },
+            content: [
+              { type: "text", text: JSON.stringify({ results: [{ text: "user prefers ramen" }] }) },
+            ],
+          },
+        });
         await appendSessionTranscriptMessageByIdentity({
           ...target,
           message: {
@@ -3308,6 +3346,43 @@ describe("active-memory plugin", () => {
     expect(lines).toHaveLength(1);
     expectLinesToContain(lines, "🧩 Active Memory: status=timeout");
     expectLinesNotToContain(lines, "timeout_partial");
+  });
+
+  it("rejects timeout-partial summary without recorded memory evidence", async () => {
+    // Evidence gate (#84034): a timeout-partial assistant reply must only be
+    // admitted when the transcript contains at least one usable memory-tool
+    // result. Without evidence, the reply is ungrounded and must not enter
+    // main-agent session context — even if it is not chitchat.
+    testing.setMinimumTimeoutMsForTests(1);
+    testing.setSetupGraceTimeoutMsForTests(0);
+    registerPluginConfig({ timeoutMs: 1, persistTranscripts: true, logging: true });
+    const sessionKey = "agent:main:timeout-no-evidence";
+    seedSession(sessionKey, "s-timeout-no-evidence", 0);
+    runEmbeddedAgent.mockImplementationOnce(
+      async (params: { sessionFile: string; abortSignal?: AbortSignal }) => {
+        await writeTranscriptJsonl(params.sessionFile, [
+          {
+            type: "message",
+            message: {
+              role: "assistant",
+              content: "user prefers aisle seats and extra legroom",
+            },
+          },
+        ]);
+        return await waitForAbort(params.abortSignal);
+      },
+    );
+
+    const result = await runPromptBuild(
+      { prompt: "what wings should i order? timeout no evidence" },
+      { sessionKey },
+    );
+
+    expect(result).toBeUndefined();
+    const lines = getActiveMemoryLines(sessionKey);
+    expectLinesToContain(lines, "🧩 Active Memory: status=timeout");
+    expectLinesNotToContain(lines, "timeout_partial");
+    expectLinesNotToContain(lines, "aisle seats");
   });
 
   it("keeps timeout status when the timeout transcript path does not exist", async () => {
@@ -3376,6 +3451,19 @@ describe("active-memory plugin", () => {
     runEmbeddedAgent.mockImplementationOnce(
       async (params: { sessionFile: string; abortSignal?: AbortSignal }) => {
         await writeTranscriptJsonl(params.sessionFile, [
+          {
+            message: {
+              role: "toolResult",
+              toolName: "memory_search",
+              details: { results: [{ text: "user prefers ramen" }] },
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({ results: [{ text: "user prefers ramen" }] }),
+                },
+              ],
+            },
+          },
           {
             type: "message",
             message: { role: "assistant", content: "partial abort summary" },

--- a/extensions/active-memory/prompt.test.ts
+++ b/extensions/active-memory/prompt.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { normalizeActiveSummary } from "./prompt.js";
+
+describe("normalizeActiveSummary", () => {
+  it.each([
+    "Hello! How can I help you today?",
+    "Hello! It seems like your message got cut off.",
+    "It seems like your message got cut off. Could you provide more details?",
+    "Please let me know if you need help.",
+    "您好！请问有什么可以帮助您的吗？",
+    "您好！看起来您的消息可能没有包含具体问题或请求。",
+    "当前模型是 example/model。如果您需要帮助，请告诉我。",
+  ])("rejects anchored assistant chitchat: %s", (summary) => {
+    expect(normalizeActiveSummary(summary)).toBeNull();
+  });
+
+  it.each([
+    "User's favorite food is ramen.",
+    "Hello Kitty is the user's favorite character.",
+    "Hello is the user's preferred project name.",
+    "User prefers vendors that provide more details about their supply chain.",
+    "用户偏好能提供更多详细信息的供应商。",
+  ])("keeps grounded summary text that shares chitchat words: %s", (summary) => {
+    expect(normalizeActiveSummary(summary)).toBe(summary);
+  });
+});

--- a/extensions/active-memory/prompt.test.ts
+++ b/extensions/active-memory/prompt.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { isChitchatSummary, normalizeActiveSummary } from "./prompt.js";
+
+describe("isChitchatSummary", () => {
+  it("rejects Chinese greetings with help offers", () => {
+    expect(isChitchatSummary("您好！请问有什么可以帮助您的吗？")).toBe(true);
+    expect(isChitchatSummary("你好！请问有什么可以帮助你的吗？")).toBe(true);
+    expect(isChitchatSummary("您好！如果需要帮助，请随时告诉我。")).toBe(true);
+  });
+
+  it("rejects Chinese greetings with ？ punctuation and help offers", () => {
+    // Regression: the prior `您?好` form could not match `你好` (你 ≠ 您),
+    // and the bare-greeting rule only accepted ！. So `你好？请问…` passed
+    // normalization and could be injected as session context (#84034).
+    expect(isChitchatSummary("你好？请问有什么可以帮助你的吗？")).toBe(true);
+    expect(isChitchatSummary("您好？请问有什么可以帮助您的吗？")).toBe(true);
+  });
+
+  it("rejects Chinese 'message cut off' boilerplate", () => {
+    expect(isChitchatSummary("看起来您的消息可能没有包含具体问题或请求...")).toBe(true);
+    expect(isChitchatSummary("似乎您的消息被截断了，能否提供更多详细信息？")).toBe(true);
+  });
+
+  it("rejects Chinese time/date announcements with help offers", () => {
+    expect(isChitchatSummary("当前日期和时间是2026年7月29日。如果您需要任何帮助，请告诉我！")).toBe(
+      true,
+    );
+  });
+
+  it("rejects Chinese model metadata restatement with help offer", () => {
+    expect(
+      isChitchatSummary(
+        "当前模型是 bigmodel/glm-4-flash-250414。如果您有任何问题或需要帮助，请告诉我！",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects English greetings with help offers", () => {
+    expect(isChitchatSummary("Hello! How can I help you today?")).toBe(true);
+    expect(isChitchatSummary("Hi there! What can I do for you?")).toBe(true);
+    expect(isChitchatSummary("Hey, let me know if you need help!")).toBe(true);
+  });
+
+  it("rejects bare English greetings", () => {
+    expect(isChitchatSummary("Hello!")).toBe(true);
+    expect(isChitchatSummary("Hi!")).toBe(true);
+  });
+
+  it("rejects English 'message cut off' boilerplate", () => {
+    expect(
+      isChitchatSummary(
+        "It seems like your message got cut off. Could you please provide more details?",
+      ),
+    ).toBe(true);
+    expect(isChitchatSummary("Your message didn't come through. Can you repeat that?")).toBe(true);
+  });
+
+  it("rejects greeting-prefixed English cut-off boilerplate", () => {
+    // Reported in #84034: a greeting followed by cut-off/clarification text
+    // must also be rejected, not only bare cut-off language.
+    expect(isChitchatSummary("Hello! It seems like your message got cut off.")).toBe(true);
+    expect(isChitchatSummary("Hello! It looks like you didn't finish your message.")).toBe(true);
+  });
+
+  it("rejects English generic help offers", () => {
+    expect(isChitchatSummary("I'm here to help!")).toBe(true);
+    expect(isChitchatSummary("I'm happy to help with that.")).toBe(true);
+    expect(isChitchatSummary("Please let me know if you need any help.")).toBe(true);
+    expect(isChitchatSummary("I can help you with that.")).toBe(true);
+    expect(isChitchatSummary("I can assist you with your question.")).toBe(true);
+  });
+
+  it("accepts valid factual memory summaries", () => {
+    expect(isChitchatSummary("User's favorite food is ramen; tacos also come up often.")).toBe(
+      false,
+    );
+    expect(
+      isChitchatSummary("User prefers aisle seats and extra buffer over tight connections."),
+    ).toBe(false);
+    expect(isChitchatSummary("User works at Acme Corp and uses Python daily.")).toBe(false);
+  });
+
+  it("accepts Chinese factual memory summaries", () => {
+    expect(isChitchatSummary("用户最喜欢的食物是拉面，也经常吃塔可。")).toBe(false);
+    expect(isChitchatSummary("用户偏好靠走道的座位，转机时间留宽裕。")).toBe(false);
+  });
+
+  it("accepts factual summaries containing 'provide more details' mid-sentence", () => {
+    expect(
+      isChitchatSummary(
+        "User prefers vendors that can provide more details about their supply chain.",
+      ),
+    ).toBe(false);
+    expect(isChitchatSummary("User likes suppliers who can provide more details on pricing.")).toBe(
+      false,
+    );
+  });
+
+  it("accepts factual summaries containing 'can provide' mid-sentence", () => {
+    expect(isChitchatSummary("User's company can provide enterprise support for their API.")).toBe(
+      false,
+    );
+  });
+
+  it("accepts Chinese factual summaries containing request-like phrases mid-sentence", () => {
+    expect(isChitchatSummary("用户偏好能提供更多详细信息的供应商。")).toBe(false);
+  });
+
+  it("accepts factual summaries starting with a greeting word followed by 'is'", () => {
+    // Regression: the English greeting detector must not treat "Hello is ..."
+    // as chitchat. Factual recalls can begin this way (e.g. a preferred project
+    // name or nickname), and the old `is` continuation silently dropped them.
+    expect(isChitchatSummary("Hello is the user's preferred project name.")).toBe(false);
+    expect(isChitchatSummary("Hi is the user's preferred nickname.")).toBe(false);
+  });
+
+  it("accepts factual summaries beginning with 'help'", () => {
+    // Regression: the assistance-offer rule must not match factual recalls
+    // that start with "help" (e.g. a team name or a past-tense action).
+    expect(isChitchatSummary("Helpdesk is the user's current team.")).toBe(false);
+    expect(isChitchatSummary("Help the user set up their API last week.")).toBe(false);
+  });
+});
+
+describe("normalizeActiveSummary", () => {
+  it("returns null for chitchat input", () => {
+    expect(
+      normalizeActiveSummary(
+        "您好！请问有什么可以帮助您的吗？如果您有任何问题或需要帮助，请随时告诉我。",
+      ),
+    ).toBeNull();
+    expect(normalizeActiveSummary("Hello! How can I help you today?")).toBeNull();
+    expect(
+      normalizeActiveSummary(
+        "It seems like your message got cut off. Could you please provide more details?",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for NONE and empty values", () => {
+    expect(normalizeActiveSummary("NONE")).toBeNull();
+    expect(normalizeActiveSummary("none")).toBeNull();
+    expect(normalizeActiveSummary("")).toBeNull();
+    expect(normalizeActiveSummary("  ")).toBeNull();
+  });
+
+  it("returns null for timeout boilerplate", () => {
+    expect(normalizeActiveSummary("the llm request timed out")).toBeNull();
+    expect(normalizeActiveSummary("active-memory timeout after 30000ms")).toBeNull();
+  });
+
+  it("returns trimmed summary for valid factual recall", () => {
+    expect(normalizeActiveSummary("User's favorite food is ramen")).toBe(
+      "User's favorite food is ramen",
+    );
+    expect(normalizeActiveSummary("  User prefers aisle seats  ")).toBe("User prefers aisle seats");
+  });
+
+  it("returns null for chitchat with model metadata restatement", () => {
+    expect(
+      normalizeActiveSummary(
+        "当前模型是 bigmodel/glm-4-flash-250414。如果您有任何问题或需要帮助，请告诉我！",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for Chinese greeting variants from issue report", () => {
+    expect(normalizeActiveSummary("您好！看起来您的消息可能没有包含具体问题或请求...")).toBeNull();
+    expect(
+      normalizeActiveSummary(
+        "你好！请问有什么可以帮助你的吗？如果你有任何问题或需要帮助，请随时告诉我。",
+      ),
+    ).toBeNull();
+  });
+});

--- a/extensions/active-memory/prompt.ts
+++ b/extensions/active-memory/prompt.ts
@@ -247,6 +247,17 @@ function isTimeoutBoilerplateSummary(value: string): boolean {
   return TIMEOUT_BOILERPLATE_PATTERNS.some((pattern) => pattern.test(value));
 }
 
+const ASSISTANT_CHITCHAT_PATTERNS = [
+  /^(?:hello|hi|hey|greetings)\b(?=.{0,120}(?:\b(?:help|assist|message|question|need)\b|\b(?:how|what)\s+(?:can|may|do)\b|cut off|come through))/i,
+  /^(?:hello|hi|hey|greetings)[!.,?]?\s*$/i,
+  /^(?:it\s+)?(?:seems?|looks?)\s+like\s+(?:your\s+)?(?:message|text|input|query).{0,40}(?:cut\s+off|incomplete|didn'?t\s+come\s+through|missing)/i,
+  /^(?:could|can|would|please).{0,20}(?:provide|share|give|clarify|elaborate|repeat).{0,20}(?:details|information|context)/i,
+  /^(?:(?:i(?:'?m|\s+am)\s+(?:here|happy|ready|glad)\s+to|i\s+can)\s+(?:help|assist)|(?:please\s+)?(?:let\s+me\s+know|tell\s+me|feel\s+free).{0,30}(?:help|assist|question|need))/i,
+  /^(?:您好|你好|嗨)(?:[！!？?，,\s]*$|(?=.{0,120}(?:帮助|请问|问题|需要|消息|请求)))/u,
+  /^(?:看起来|似乎).{0,20}(?:消息|信息).{0,20}(?:没有|未|截断|不完整)/u,
+  /^(?:当前模型|当前日期|当前时间|今天).{0,100}(?:帮助|请|如果)/u,
+];
+
 function normalizeActiveSummary(rawReply: string): string | null {
   const trimmed = rawReply.trim();
   if (normalizeNoRecallValue(trimmed)) {
@@ -256,7 +267,8 @@ function normalizeActiveSummary(rawReply: string): string | null {
   if (
     !singleLine ||
     normalizeNoRecallValue(singleLine) ||
-    isTimeoutBoilerplateSummary(singleLine)
+    isTimeoutBoilerplateSummary(singleLine) ||
+    ASSISTANT_CHITCHAT_PATTERNS.some((pattern) => pattern.test(singleLine))
   ) {
     return null;
   }

--- a/extensions/active-memory/prompt.ts
+++ b/extensions/active-memory/prompt.ts
@@ -7,6 +7,7 @@ import { extractTextContentParts } from "./query.js";
 import {
   ACTIVE_MEMORY_PLUGIN_TAG,
   ACTIVE_MEMORY_CONTEXT_HEADER,
+  CHITCHAT_PATTERNS,
   NO_RECALL_VALUES,
   STRUCTURED_MEMORY_EMPTY_STATUSES,
   STRUCTURED_MEMORY_FAILURE_STATUSES,
@@ -247,6 +248,10 @@ function isTimeoutBoilerplateSummary(value: string): boolean {
   return TIMEOUT_BOILERPLATE_PATTERNS.some((pattern) => pattern.test(value));
 }
 
+function isChitchatSummary(value: string): boolean {
+  return CHITCHAT_PATTERNS.some((pattern) => pattern.test(value));
+}
+
 function normalizeActiveSummary(rawReply: string): string | null {
   const trimmed = rawReply.trim();
   if (normalizeNoRecallValue(trimmed)) {
@@ -256,7 +261,8 @@ function normalizeActiveSummary(rawReply: string): string | null {
   if (
     !singleLine ||
     normalizeNoRecallValue(singleLine) ||
-    isTimeoutBoilerplateSummary(singleLine)
+    isTimeoutBoilerplateSummary(singleLine) ||
+    isChitchatSummary(singleLine)
   ) {
     return null;
   }
@@ -312,6 +318,7 @@ export {
   buildMetadata,
   buildPromptPrefix,
   buildRecallPrompt,
+  isChitchatSummary,
   normalizeActiveSummary,
   readExplicitMemoryEvidence,
   readStructuredMemoryEvidenceFromContent,

--- a/extensions/active-memory/recall-run.ts
+++ b/extensions/active-memory/recall-run.ts
@@ -374,6 +374,7 @@ async function runRecallSubagent(params: {
         partialReply,
         transcriptState.searchDebug,
         transcriptState.hasUnavailableMemorySearchResult || harnessHasUnavailableMemorySearchResult,
+        transcriptState.hasUsableMemoryResult || harnessHasUsableMemoryResult,
       );
     }
     if (

--- a/extensions/active-memory/recall-run.ts
+++ b/extensions/active-memory/recall-run.ts
@@ -376,6 +376,7 @@ async function runRecallSubagent(params: {
         partialReply,
         transcriptState.searchDebug,
         transcriptState.hasUnavailableMemorySearchResult || harnessHasUnavailableMemorySearchResult,
+        transcriptState.hasUsableMemoryResult || harnessHasUsableMemoryResult,
       );
     }
     if (

--- a/extensions/active-memory/recall.ts
+++ b/extensions/active-memory/recall.ts
@@ -322,20 +322,15 @@ async function resolveActiveRecall(
         scheduleTimeoutCleanup();
       }
       const elapsedMs = Date.now() - startedAt;
-      const result: ActiveRecallResult = fallbackHasUsableMemoryResult
-        ? {
-            status: "timeout",
-            elapsedMs,
-            summary: null,
-            searchDebug: fallbackSearchDebug,
-          }
-        : await buildTimeoutRecallResult({
-            elapsedMs,
-            maxSummaryChars: params.config.maxSummaryChars,
-            transcriptSources,
-            subagentPromise,
-            toolsAllow: params.config.toolsAllow,
-          });
+      const result = await buildTimeoutRecallResult({
+        elapsedMs,
+        maxSummaryChars: params.config.maxSummaryChars,
+        transcriptSources,
+        subagentPromise,
+        hasUsableMemoryResult: fallbackHasUsableMemoryResult,
+        searchDebug: fallbackSearchDebug,
+        toolsAllow: params.config.toolsAllow,
+      });
       if (params.config.logging) {
         params.api.logger.info?.(
           `${logPrefix} done status=${result.status} elapsedMs=${String(result.elapsedMs)} summaryChars=${String(result.summary?.length ?? 0)}`,
@@ -434,6 +429,7 @@ async function resolveActiveRecall(
         transcriptSources,
         rawReply: partialTimeoutData.rawReply,
         searchDebug: partialTimeoutData.searchDebug,
+        hasUsableMemoryResult: partialTimeoutData.hasUsableMemoryResult,
         hasUnavailableMemorySearchResult: partialTimeoutData.hasUnavailableMemorySearchResult,
         toolsAllow: params.config.toolsAllow,
       });

--- a/extensions/active-memory/recall.ts
+++ b/extensions/active-memory/recall.ts
@@ -257,6 +257,12 @@ async function resolveActiveRecall(
 
   let terminalMemorySearchWatch: TerminalMemorySearchWatch | undefined;
   let recallInFlight = false;
+  // Declared outside the try block so the catch block can read whether an
+  // earlier race result already established usable memory evidence. Without
+  // this, a timeout-partial recovery path that references this flag would hit
+  // a ReferenceError because `let` is block-scoped to the try body.
+  let fallbackSearchDebug: ActiveMemorySearchDebug | undefined;
+  let fallbackHasUsableMemoryResult = false;
   try {
     recallInFlight = true;
     const subagentPromise = runRecallSubagent({
@@ -285,8 +291,6 @@ async function resolveActiveRecall(
       terminalMemorySearchWatch.promise,
     ]);
     terminalMemorySearchWatch.stop();
-    let fallbackSearchDebug: ActiveMemorySearchDebug | undefined;
-    let fallbackHasUsableMemoryResult = false;
     if (
       raceResult !== TIMEOUT_SENTINEL &&
       "status" in raceResult &&
@@ -423,6 +427,8 @@ async function resolveActiveRecall(
         searchDebug: partialTimeoutData.searchDebug,
         hasUnavailableMemorySearchResult: partialTimeoutData.hasUnavailableMemorySearchResult,
         toolsAllow: params.config.toolsAllow,
+        fallbackHasUsableMemoryResult:
+          fallbackHasUsableMemoryResult || partialTimeoutData.hasUsableMemoryResult === true,
       });
       if (params.config.logging) {
         params.api.logger.info?.(

--- a/extensions/active-memory/timeout-evidence-proof.test.ts
+++ b/extensions/active-memory/timeout-evidence-proof.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  attachPartialTimeoutData,
+  buildTimeoutRecallResult,
+  readPartialTimeoutData,
+} from "./transcript-result.js";
+import { fileTranscriptSource } from "./transcript.js";
+import type { RecallSubagentResult } from "./types.js";
+
+describe("buildTimeoutRecallResult evidence gate (#84034)", () => {
+  it("rejects timeout-partial summary WITHOUT recorded memory evidence", async () => {
+    const result = await buildTimeoutRecallResult({
+      elapsedMs: 1000,
+      maxSummaryChars: 200,
+      transcriptSources: [],
+      rawReply: "user prefers aisle seats and extra legroom",
+      toolsAllow: ["memory_search"],
+    });
+    expect(result.status).toBe("timeout");
+    expect(result.summary).toBeNull();
+  });
+
+  it("rejects chitchat timeout-partial even with fallback evidence", async () => {
+    const result = await buildTimeoutRecallResult({
+      elapsedMs: 1000,
+      maxSummaryChars: 200,
+      transcriptSources: [],
+      rawReply: "Hello! How can I help you today?",
+      toolsAllow: ["memory_search"],
+      fallbackHasUsableMemoryResult: true,
+    });
+    expect(result.status).toBe("timeout");
+    expect(result.summary).toBeNull();
+  });
+
+  it("accepts timeout-partial WITH fallback memory evidence", async () => {
+    const result = await buildTimeoutRecallResult({
+      elapsedMs: 1000,
+      maxSummaryChars: 200,
+      transcriptSources: [],
+      rawReply: "user prefers aisle seats and extra legroom",
+      toolsAllow: ["memory_search"],
+      fallbackHasUsableMemoryResult: true,
+    });
+    expect(result.status).toBe("timeout_partial");
+    expect(result.summary).toBe("user prefers aisle seats and extra legroom");
+  });
+
+  it("accepts timeout-partial WITH callback-only evidence (settled subagent)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "am-proof-"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "user's favorite food is ramen" },
+      }) + "\n",
+    );
+    const subagentPromise = Promise.resolve({
+      hasUsableMemoryResult: true,
+    } as RecallSubagentResult);
+    const result = await buildTimeoutRecallResult({
+      elapsedMs: 1000,
+      maxSummaryChars: 200,
+      transcriptSources: [fileTranscriptSource(sessionFile)],
+      subagentPromise,
+      toolsAllow: ["memory_search"],
+    });
+    expect(result.status).toBe("timeout_partial");
+    expect(result.summary).toBe("user's favorite food is ramen");
+  });
+
+  it("rejects timeout-partial when subagent settles WITHOUT usable evidence", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "am-proof-"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "user's favorite food is ramen" },
+      }) + "\n",
+    );
+    const subagentPromise = Promise.resolve({
+      hasUsableMemoryResult: false,
+    } as RecallSubagentResult);
+    const result = await buildTimeoutRecallResult({
+      elapsedMs: 1000,
+      maxSummaryChars: 200,
+      transcriptSources: [fileTranscriptSource(sessionFile)],
+      subagentPromise,
+      toolsAllow: ["memory_search"],
+    });
+    expect(result.status).toBe("timeout");
+    expect(result.summary).toBeNull();
+  });
+});
+
+describe("P1 fix: callback evidence through abort rejects", () => {
+  it("attachPartialTimeoutData carries hasUsableMemoryResult through the error payload", () => {
+    const error = new Error("Operation aborted");
+    error.name = "AbortError";
+    attachPartialTimeoutData(error, "partial reply text", undefined, false, true);
+    const data = readPartialTimeoutData(error);
+    expect(data.rawReply).toBe("partial reply text");
+    expect(data.hasUsableMemoryResult).toBe(true);
+  });
+
+  it("readPartialTimeoutData returns hasUsableMemoryResult=false when not set", () => {
+    const error = new Error("Operation aborted");
+    error.name = "AbortError";
+    attachPartialTimeoutData(error, "partial reply text", undefined, false, false);
+    const data = readPartialTimeoutData(error);
+    expect(data.rawReply).toBe("partial reply text");
+    expect(data.hasUsableMemoryResult).toBe(false);
+  });
+
+  it("accepts timeout-partial when abort error carries callback evidence", async () => {
+    const abortError = new Error("Operation aborted");
+    abortError.name = "AbortError";
+    attachPartialTimeoutData(abortError, "user prefers ramen", undefined, false, true);
+    const subagentPromise = Promise.reject(abortError);
+    const result = await buildTimeoutRecallResult({
+      elapsedMs: 1000,
+      maxSummaryChars: 200,
+      transcriptSources: [],
+      subagentPromise,
+      toolsAllow: ["memory_search"],
+    });
+    expect(result.status).toBe("timeout_partial");
+    expect(result.summary).toBe("user prefers ramen");
+  });
+
+  it("rejects timeout-partial when abort error carries no callback evidence", async () => {
+    const abortError = new Error("Operation aborted");
+    abortError.name = "AbortError";
+    attachPartialTimeoutData(abortError, "user prefers ramen", undefined, false, false);
+    const subagentPromise = Promise.reject(abortError);
+    const result = await buildTimeoutRecallResult({
+      elapsedMs: 1000,
+      maxSummaryChars: 200,
+      transcriptSources: [],
+      subagentPromise,
+      toolsAllow: ["memory_search"],
+    });
+    expect(result.status).toBe("timeout");
+    expect(result.summary).toBeNull();
+  });
+});

--- a/extensions/active-memory/transcript-result.ts
+++ b/extensions/active-memory/transcript-result.ts
@@ -132,6 +132,7 @@ function attachPartialTimeoutData(
   partialReply: string | null,
   searchDebug: ActiveMemorySearchDebug | undefined,
   hasUnavailableMemorySearchResult: boolean,
+  hasUsableMemoryResult: boolean,
 ): void {
   if (!error || typeof error !== "object") {
     return;
@@ -146,11 +147,15 @@ function attachPartialTimeoutData(
   if (hasUnavailableMemorySearchResult) {
     target.activeMemoryUnavailableMemorySearch = true;
   }
+  if (hasUsableMemoryResult) {
+    target.activeMemoryHasUsableMemoryResult = true;
+  }
 }
 
 function readPartialTimeoutData(error: unknown): {
   rawReply?: string;
   searchDebug?: ActiveMemorySearchDebug;
+  hasUsableMemoryResult?: boolean;
   hasUnavailableMemorySearchResult?: boolean;
 } {
   if (!error || typeof error !== "object") {
@@ -160,6 +165,7 @@ function readPartialTimeoutData(error: unknown): {
   return {
     rawReply: normalizeOptionalString(source.activeMemoryPartialReply),
     searchDebug: source.activeMemorySearchDebug,
+    hasUsableMemoryResult: source.activeMemoryHasUsableMemoryResult === true,
     hasUnavailableMemorySearchResult: source.activeMemoryUnavailableMemorySearch,
   };
 }
@@ -169,6 +175,7 @@ async function waitForSubagentPartialTimeoutData(
 ): Promise<{
   rawReply?: string;
   searchDebug?: ActiveMemorySearchDebug;
+  hasUsableMemoryResult?: boolean;
   hasUnavailableMemorySearchResult?: boolean;
   settled: boolean;
 }> {
@@ -183,7 +190,10 @@ async function waitForSubagentPartialTimeoutData(
   try {
     return await Promise.race([
       subagentPromise.then(
-        () => ({ settled: true as const }),
+        (result) => ({
+          hasUsableMemoryResult: result.hasUsableMemoryResult === true,
+          settled: true as const,
+        }),
         (error: unknown) => ({ ...readPartialTimeoutData(error), settled: true as const }),
       ),
       timeoutPromise,
@@ -195,6 +205,15 @@ async function waitForSubagentPartialTimeoutData(
   }
 }
 
+function normalizeGroundedSummary(
+  rawReply: string,
+  maxSummaryChars: number,
+  hasUsableMemoryResult: boolean,
+): string | null {
+  const summary = hasUsableMemoryResult ? normalizeActiveSummary(rawReply) : null;
+  return summary ? truncateSummary(summary, maxSummaryChars) : null;
+}
+
 async function buildTimeoutRecallResult(params: {
   elapsedMs: number;
   maxSummaryChars: number;
@@ -202,6 +221,7 @@ async function buildTimeoutRecallResult(params: {
   rawReply?: string;
   searchDebug?: ActiveMemorySearchDebug;
   hasUnavailableMemorySearchResult?: boolean;
+  hasUsableMemoryResult?: boolean;
   subagentPromise?: Promise<RecallSubagentResult>;
   toolsAllow: readonly string[];
 }): Promise<ActiveRecallResult> {
@@ -212,10 +232,6 @@ async function buildTimeoutRecallResult(params: {
     params.rawReply ??
     subagentPartialData.rawReply ??
     (await readPartialAssistantTextFromSources(params.transcriptSources));
-  const summary = truncateSummary(
-    normalizeActiveSummary(rawReply ?? "") ?? "",
-    params.maxSummaryChars,
-  );
   const transcriptState =
     params.transcriptSources.length > 0
       ? await readMergedActiveMemoryTranscriptState({
@@ -225,16 +241,24 @@ async function buildTimeoutRecallResult(params: {
       : undefined;
   const searchDebug =
     params.searchDebug ?? subagentPartialData.searchDebug ?? transcriptState?.searchDebug;
-  const cannotUsePartial =
-    summary.length === 0 ||
+  const summary = normalizeGroundedSummary(
+    rawReply ?? "",
+    params.maxSummaryChars,
+    params.hasUsableMemoryResult === true ||
+      subagentPartialData.hasUsableMemoryResult === true ||
+      transcriptState?.hasUsableMemoryResult === true,
+  );
+  if (
+    summary === null ||
     isUnavailableMemorySearchDebug(searchDebug) ||
     !subagentPartialData.settled ||
     params.hasUnavailableMemorySearchResult ||
     subagentPartialData.hasUnavailableMemorySearchResult ||
-    transcriptState?.hasUnavailableMemorySearchResult;
-  return cannotUsePartial
-    ? { status: "timeout", elapsedMs: params.elapsedMs, summary: null, searchDebug }
-    : { status: "timeout_partial", elapsedMs: params.elapsedMs, summary, searchDebug };
+    transcriptState?.hasUnavailableMemorySearchResult
+  ) {
+    return { status: "timeout", elapsedMs: params.elapsedMs, summary: null, searchDebug };
+  }
+  return { status: "timeout_partial", elapsedMs: params.elapsedMs, summary, searchDebug };
 }
 
 function buildSubagentRecallResult(params: {
@@ -246,11 +270,11 @@ function buildSubagentRecallResult(params: {
 }): ActiveRecallResult {
   const { rawReply, resultStatus } = params.subagentResult;
   const searchDebug = params.subagentResult.searchDebug ?? params.fallbackSearchDebug;
-  const summary = truncateSummary(normalizeActiveSummary(rawReply) ?? "", params.maxSummaryChars);
   const hasUsableMemoryResult =
     params.subagentResult.hasUsableMemoryResult === true ||
     params.fallbackHasUsableMemoryResult === true;
-  if (summary.length > 0 && hasUsableMemoryResult) {
+  const summary = normalizeGroundedSummary(rawReply, params.maxSummaryChars, hasUsableMemoryResult);
+  if (summary !== null) {
     return { status: "ok", elapsedMs: params.elapsedMs, rawReply, summary, searchDebug };
   }
   const status =

--- a/extensions/active-memory/transcript-result.ts
+++ b/extensions/active-memory/transcript-result.ts
@@ -132,6 +132,7 @@ function attachPartialTimeoutData(
   partialReply: string | null,
   searchDebug: ActiveMemorySearchDebug | undefined,
   hasUnavailableMemorySearchResult: boolean,
+  hasUsableMemoryResult: boolean,
 ): void {
   if (!error || typeof error !== "object") {
     return;
@@ -146,11 +147,15 @@ function attachPartialTimeoutData(
   if (hasUnavailableMemorySearchResult) {
     target.activeMemoryUnavailableMemorySearch = true;
   }
+  if (hasUsableMemoryResult) {
+    target.activeMemoryHasUsableMemoryResult = true;
+  }
 }
 
 function readPartialTimeoutData(error: unknown): {
   rawReply?: string;
   searchDebug?: ActiveMemorySearchDebug;
+  hasUsableMemoryResult?: boolean;
   hasUnavailableMemorySearchResult?: boolean;
 } {
   if (!error || typeof error !== "object") {
@@ -160,6 +165,7 @@ function readPartialTimeoutData(error: unknown): {
   return {
     rawReply: normalizeOptionalString(source.activeMemoryPartialReply),
     searchDebug: source.activeMemorySearchDebug,
+    hasUsableMemoryResult: source.activeMemoryHasUsableMemoryResult === true,
     hasUnavailableMemorySearchResult: source.activeMemoryUnavailableMemorySearch,
   };
 }
@@ -169,6 +175,7 @@ async function waitForSubagentPartialTimeoutData(
 ): Promise<{
   rawReply?: string;
   searchDebug?: ActiveMemorySearchDebug;
+  hasUsableMemoryResult?: boolean;
   hasUnavailableMemorySearchResult?: boolean;
   settled: boolean;
 }> {
@@ -183,7 +190,10 @@ async function waitForSubagentPartialTimeoutData(
   try {
     return await Promise.race([
       subagentPromise.then(
-        () => ({ settled: true as const }),
+        (result: RecallSubagentResult) => ({
+          settled: true as const,
+          hasUsableMemoryResult: result.hasUsableMemoryResult === true,
+        }),
         (error: unknown) => ({ ...readPartialTimeoutData(error), settled: true as const }),
       ),
       timeoutPromise,
@@ -204,6 +214,7 @@ async function buildTimeoutRecallResult(params: {
   hasUnavailableMemorySearchResult?: boolean;
   subagentPromise?: Promise<RecallSubagentResult>;
   toolsAllow: readonly string[];
+  fallbackHasUsableMemoryResult?: boolean;
 }): Promise<ActiveRecallResult> {
   const subagentPartialData = params.rawReply
     ? { settled: true as const }
@@ -225,8 +236,22 @@ async function buildTimeoutRecallResult(params: {
       : undefined;
   const searchDebug =
     params.searchDebug ?? subagentPartialData.searchDebug ?? transcriptState?.searchDebug;
+  // Evidence gate: timeout-partial summaries are only admitted when there is
+  // at least one usable memory-tool result, matching the completed-recall
+  // invariant (canUseSummary = hasUsableMemoryResult in buildSubagentRecallResult).
+  // Evidence can arrive through three channels: the transcript (mirrored tool
+  // results), the settled subagent result (callback-only evidence not yet
+  // mirrored, or carried through the abort error payload), or the fallback from
+  // an earlier race result. Without this gate, any nonempty assistant reply —
+  // including ungrounded chitchat not caught by the wording filter — would be
+  // injected into main-agent session context (#84034).
+  const hasUsableMemoryResult =
+    transcriptState?.hasUsableMemoryResult === true ||
+    subagentPartialData.hasUsableMemoryResult === true ||
+    params.fallbackHasUsableMemoryResult === true;
   const cannotUsePartial =
     summary.length === 0 ||
+    !hasUsableMemoryResult ||
     isUnavailableMemorySearchDebug(searchDebug) ||
     !subagentPartialData.settled ||
     params.hasUnavailableMemorySearchResult ||

--- a/extensions/active-memory/types.ts
+++ b/extensions/active-memory/types.ts
@@ -253,6 +253,7 @@ type ActiveMemoryPartialTimeoutError = Error & {
   activeMemoryPartialReply?: string;
   activeMemorySearchDebug?: ActiveMemorySearchDebug;
   activeMemoryUnavailableMemorySearch?: boolean;
+  activeMemoryHasUsableMemoryResult?: boolean;
 };
 
 type TranscriptReadLimits = {

--- a/extensions/active-memory/types.ts
+++ b/extensions/active-memory/types.ts
@@ -120,6 +120,53 @@ const TIMEOUT_BOILERPLATE_PATTERNS = [
   /^(?:error:\s*)?active-memory timeout after \d+ms\b/i,
 ];
 
+const CHITCHAT_PATTERNS = [
+  // Chinese greetings and help offers (anchored — must start the line).
+  // Accept both 您 and 你 before 好; the prior `您?好` form could not match
+  // `你好` because `你` ≠ `您`. Also accept both ！and ？as terminal greeting
+  // punctuation so `你好？请问…` is rejected, not only `你好！`.
+  /^(?:您|你)?好[！？]?[\s,，]*(?:请问|有什么|如果|请随时)/u,
+  /^(?:您|你)好[！？]/u,
+  /^嗨[！？]/u,
+  // Chinese "your message was cut off" variants (anchored — these are always complete replies)
+  /^(?:看起来|似乎).{0,6}(?:消息|信息).{0,6}(?:没有|未|被截|不完整)/u,
+  /^(?:请|能否).{0,4}(?:提供|补充|再说).{0,4}(?:更多|详细|具体)/u,
+  // Chinese time/date announcements followed by help offers (anchored)
+  /^(?:当前|今天的?).{0,6}(?:日期|时间|时间是).{0,30}(?:帮助|请|如果)/u,
+  // English greetings with help/question offers (anchored). An optional filler
+  // word (e.g. "there" in "Hi there!") is allowed between the greeting and the
+  // assistance/question continuation. The continuation must be actual
+  // help/question language — not a factual verb like "is" — so factual recalls
+  // such as "Hello is the user's preferred project name." are not dropped.
+  /^(?:hello|hi|hey|greetings)[!.,]?\s+(?:\w{1,12}[!.,]?\s+)?(?:how\s+(?:can|may|do|are)|what\s+(?:can|do|may)|can\s+i\s+(?:help|do|assist)|let\s+me\s+(?:help|know|assist)|i(?:'?m|\s+am)\s+(?:here|happy|ready|glad))/i,
+  /^(?:hello|hi|hey|greetings)[!.,]?\s*$/i,
+  // English "your message got cut off" variants (anchored — these are always complete replies)
+  /^(?:it\s+)?(?:seems?\s+)?(?:like\s+)?(?:your\s+)?(?:message|text|input|query).{0,10}(?:cut\s+off|incomplete|didn'?t\s+come|missing)/i,
+  // English greeting-prefixed cut-off/clarification boilerplate (anchored).
+  // Reported in #84034: "Hello! It seems like your message got cut off." and
+  // "Hello! It looks like you didn't finish your message." start with a greeting
+  // and then continue with cut-off language. Neither the greeting-help rule
+  // above nor the bare cut-off rule (anchored at "It"/"message") matches this
+  // combined form, so it must be covered explicitly. Retains the factual
+  // greeting case ("Hello is the user's preferred project name.") because the
+  // continuation must be (seems|looks) like ... (cut off|incomplete|didn't ...).
+  /^(?:hello|hi|hey|greetings)[!.,]?\s+(?:it\s+)?(?:seems?|looks?)\s+like\s+.{0,40}(?:cut\s+off|incomplete|didn'?t\s+(?:come|finish)|missing)/i,
+  // English request to provide more details — anchored to avoid matching factual summaries
+  // that happen to contain "provide more details" in the middle (e.g. "User prefers vendors
+  // that can provide more details about their supply chain").
+  /^(?:could|can|would|please).{0,10}(?:you\s+)?(?:provide|share|give|clarify|elaborate|repeat).{0,10}(?:more|details|information|context)/i,
+  // Generic help offers without factual content (anchored)
+  /^(?:please\s+)?(?:let\s+me\s+know|tell\s+me|feel\s+free|i'?m\s+here).{0,30}(?:help|assist|support|question|need)/i,
+  // "I can help" / "here to help" / "happy to help" boilerplate (anchored).
+  // Two bounded branches: (1) I'm + here/ready/happy/glad to + help, and
+  // (2) I can + help/assist. Both require an actual assistance phrase so the
+  // rule does not match factual recalls beginning with "help" such as
+  // "Helpdesk is the user's current team." or "Help the user set up their API."
+  /^(?:(?:i(?:'?m|\s+am)\s+)?(?:here\s+to\s+|ready\s+to\s+|happy\s+to\s+|glad\s+to\s+)help|i\s+can\s+(?:help|assist))/i,
+  // Restating visible model metadata as assistant output (anchored)
+  /^(?:当前模型|current model).{0,80}(?:帮助|请|如果|help|please)/iu,
+];
+
 const RECALLED_CONTEXT_LINE_PATTERNS = [
   /^🧩\s*active memory:/i,
   /^🔎\s*active memory debug:/i,
@@ -262,6 +309,7 @@ type ActiveMemoryPartialTimeoutError = Error & {
   activeMemoryPartialReply?: string;
   activeMemorySearchDebug?: ActiveMemorySearchDebug;
   activeMemoryUnavailableMemorySearch?: boolean;
+  activeMemoryHasUsableMemoryResult?: boolean;
 };
 
 type TranscriptReadLimits = {
@@ -391,6 +439,7 @@ export {
   TERMINAL_MEMORY_SEARCH_POLL_INTERVAL_MS,
   TIMEOUT_BOILERPLATE_PATTERNS,
   TIMEOUT_PARTIAL_DATA_GRACE_MS,
+  CHITCHAT_PATTERNS,
 };
 
 export type {


### PR DESCRIPTION
## What Problem This Solves

Active Memory could add assistant chitchat or an ungrounded timeout reply to the main model context. That text was not a usable memory recall.

## Root Cause

- The shared summary normalizer accepted any non-empty reply that was not `NONE` or timeout boilerplate.
- The timeout path did not require recorded usable memory-tool evidence.
- Callback-only tool evidence was not carried through timeout recovery.

## Fix

- Reject anchored assistant chitchat in the shared summary normalizer.
- Use one grounded-summary admission helper for completed and timeout results.
- Carry usable memory-tool evidence through callback and abort recovery.
- Keep valid grounded partials and remove the temporary transcript test leak.

## Evidence

A production Gateway ran with the Active Memory plugin and a controlled memory provider. The same three cases ran on exact `main` and exact repaired head.

| Case | `main` | Repaired head |
| --- | --- | --- |
| Assistant chitchat | Added to Active Memory context | Omitted |
| Timeout partial after two empty memory searches | Added to Active Memory context | Omitted |
| Grounded memory-tool result | Kept | Kept |

The recorded provider sequence confirms that each recall received its real tool result before the main turn. The ungrounded timeout case received no usable result. The grounded case received the seeded memory fact. Gateway status changed from `timeout_partial` to `timeout` for the ungrounded case, while the grounded recall stayed `ok`.

### Redacted Gateway Trace

```text
main  chitchat             status=ok                 context=present
main  ungrounded-timeout   searches=0,0 status=timeout_partial context=present
main  grounded-recall      search=1     status=ok              context=present

head  chitchat             status=no_relevant_memory context=omitted
head  ungrounded-timeout   searches=0,0 status=timeout          context=omitted
head  grounded-recall      search=1     status=ok               context=present
```

## Validation

- Active Memory tests: 214 passed.
- Changed-file format and extension lint: passed.
- Coercion-helper guard and `git diff --check`: passed.
- Production code: +62 / -28 lines. Tests: +117 / -10 lines.

## Previous ClawSweeper Moves

- Temporary transcript directories: resolved by keeping regression coverage in the existing hook-boundary suite and its shared cleanup.
- Real runtime proof: added above.
- Rebase: skipped. The branch is conflict-free, the Active Memory owner files did not change after the reviewed base, and the live comparison used current `main`.

Fixes #84034
