### PR TITLE
fix(cron): prevent maintenance from dropping scheduled runs during model setup

### DIFF
--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -252,318 +252,9 @@ export async function prepareCronRunContext(params: {
   const runSessionKey = usesExactRunSession
     ? `${agentSessionKey}:run:${runSessionId}`
     : agentSessionKey;
-  const persistCronSessionRow = async ({
-    storePath,
-    sessionKey,
-    fallbackEntry,
-    resetBoundaryReason,
-    update,
-  }: {
-    storePath: string;
-    sessionKey: string;
-    fallbackEntry: SessionEntry;
-    resetBoundaryReason?: "cron-stale";
-    update: (entry: SessionEntry | undefined) => SessionEntry;
-  }) => {
-    const { applySessionEntryLifecycleMutation, patchSessionEntry } =
-      await loadSessionAccessorRuntime();
-    if (resetBoundaryReason) {
-      await applySessionEntryLifecycleMutation({
-        activeSessionKey: sessionKey,
-        agentId,
-        storePath,
-        upserts: [
-          {
-            sessionKey,
-            resetBoundaryReason,
-            buildEntry: ({ currentEntry }) => update(currentEntry),
-          },
-        ],
-        skipMaintenance: true,
-      });
-      return;
-    }
-    // Guarded replace: the updater sees the freshest persisted row (or
-    // undefined pre-creation) so cron lifecycle claims reject stale owners.
-    await patchSessionEntry(
-      { storePath, sessionKey, agentId },
-      (_entry, context) => update(context.existingEntry),
-      { fallbackEntry, replaceEntry: true },
-    );
-  };
-  const persistSessionEntry = createPersistCronSessionEntry({
-    cronSession,
-    agentSessionKey,
-    persistSessionEntry: persistCronSessionRow,
-  });
-  const withRunSession: WithRunSession = (result) => ({
-    ...result,
-    sessionId: currentRunSessionId(),
-    sessionKey: runSessionKey,
-  });
-  if (!cronSession.sessionEntry.label?.trim() && baseSessionKey.startsWith("cron:")) {
-    const labelSuffix =
-      typeof input.job.name === "string" && input.job.name.trim()
-        ? input.job.name.trim()
-        : input.job.id;
-    cronSession.sessionEntry.label = `Cron: ${labelSuffix}`;
-  }
-
-  const resolvedModelSelection = await resolveCronModelSelection({
-    cfg: runtimeCfg,
-    owner: modelOwner,
-    agentConfigOverride,
-    sessionEntry: cronSession.sessionEntry,
-    payload: input.job.payload,
-    isGmailHook,
-    agentId,
-    agentDir,
-    workspaceDir,
-  });
-  if (!resolvedModelSelection.ok) {
-    return {
-      ok: false,
-      result: withRunSession({
-        status: "error",
-        error: resolvedModelSelection.error,
-        diagnostics: createCronRunDiagnosticsFromError(
-          "cron-preflight",
-          resolvedModelSelection.error,
-        ),
-      }),
-    };
-  }
-  const cfgWithAgentDefaults = resolvedModelSelection.cfgWithAgentDefaults;
-  const thinkingCatalog = modelOwner.modelCatalog.entries;
-  const ownerAgentConfig = resolveAgentConfig(modelOwner.config, modelOwner.agentId);
-  const matchesDefaultFallbackAgentStringModel =
-    typeof ownerAgentConfig?.model === "string" &&
-    resolveAgentModelPrimaryValue(ownerAgentConfig.model) ===
-      resolveAgentModelPrimaryValue(modelOwner.config.agents?.defaults?.model);
-  let provider = resolvedModelSelection.provider;
-  let model = resolvedModelSelection.model;
-  const useSubagentFallbacks = resolvedModelSelection.modelSource === "subagent";
-  const inheritDefaultFallbacksForAgentStringModel =
-    matchesDefaultFallbackAgentStringModel &&
-    (resolvedModelSelection.modelSource === "default" ||
-      resolvedModelSelection.modelSource === "agent");
-
-  const modelPreflightRuntime = await loadCronModelPreflightRuntime();
-  const preflightCandidates = resolveCronPreflightCandidates({
-    cfg: cfgWithAgentDefaults,
-    job: input.job,
-    agentId: modelOwner.agentId,
-    provider,
-    model,
-    useSubagentFallbacks,
-    inheritDefaultFallbacksForAgentStringModel,
-  });
-  let selectedPreflightCandidate: { provider: string; model: string } | undefined;
-  let selectedPreflightCandidateIndex = -1;
-  let firstUnavailablePreflight:
-    | Awaited<ReturnType<typeof modelPreflightRuntime.preflightCronModelProvider>>
-    | undefined;
-  for (const [index, candidate] of preflightCandidates.entries()) {
-    const candidatePreflight = await modelPreflightRuntime.preflightCronModelProvider({
-      cfg: cfgWithAgentDefaults,
-      provider: candidate.provider,
-      model: candidate.model,
-    });
-    if (candidatePreflight.status === "available") {
-      selectedPreflightCandidate = candidate;
-      selectedPreflightCandidateIndex = index;
-      break;
-    }
-    firstUnavailablePreflight ??= candidatePreflight;
-  }
-  if (!selectedPreflightCandidate && firstUnavailablePreflight?.status === "unavailable") {
-    logWarn(`[cron:${input.job.id}] ${firstUnavailablePreflight.reason}`);
-    return {
-      ok: false,
-      result: withRunSession({
-        status: "skipped",
-        error: firstUnavailablePreflight.reason,
-        diagnostics: createCronRunDiagnosticsFromError(
-          "model-preflight",
-          firstUnavailablePreflight.reason,
-          {
-            severity: "warn",
-          },
-        ),
-        provider,
-        model,
-      }),
-    };
-  }
-  const modelFallbacksOverride =
-    selectedPreflightCandidate &&
-    (selectedPreflightCandidate.provider !== provider || selectedPreflightCandidate.model !== model)
-      ? preflightCandidates
-          .slice(selectedPreflightCandidateIndex + 1)
-          .map((candidate) => `${candidate.provider}/${candidate.model}`)
-      : undefined;
-  // When preflight skips the first local candidate, trim the fallback chain so
-  // execution starts at the reachable provider and only falls forward from it.
-  if (selectedPreflightCandidate && modelFallbacksOverride) {
-    if (firstUnavailablePreflight?.status === "unavailable") {
-      logWarn(
-        `[cron:${input.job.id}] ${firstUnavailablePreflight.reason}; continuing with fallback ${selectedPreflightCandidate.provider}/${selectedPreflightCandidate.model}.`,
-      );
-    }
-    provider = selectedPreflightCandidate.provider;
-    model = selectedPreflightCandidate.model;
-  }
-
-  const hooksGmailThinking = isGmailHook
-    ? normalizeThinkLevel(runtimeCfg.hooks?.gmail?.thinking)
-    : undefined;
-  const jobThink = normalizeThinkLevel(
-    (input.job.payload.kind === "agentTurn" ? input.job.payload.thinking : undefined) ?? undefined,
-  );
-  const sessionThink = normalizeThinkLevel(cronSession.sessionEntry.thinkingLevel);
-  const effectiveAgentRuntime = resolveEffectiveAgentRuntime({
-    cfg: cfgWithAgentDefaults,
-    provider,
-    modelId: model,
-    agentId: modelOwner.agentId,
-    sessionKey: agentSessionKey,
-    sessionEntry: cronSession.sessionEntry,
-  });
-  let requestedThinkLevel: ThinkLevel | undefined = jobThink ?? hooksGmailThinking ?? sessionThink;
-  if (!requestedThinkLevel) {
-    requestedThinkLevel = resolveThinkingDefault({
-      cfg: cfgWithAgentDefaults,
-      provider,
-      model,
-      catalog: thinkingCatalog,
-      agentRuntime: effectiveAgentRuntime,
-    });
-  }
-  if (
-    !isThinkingLevelSupported({
-      provider,
-      model,
-      level: requestedThinkLevel,
-      catalog: thinkingCatalog,
-      agentRuntime: effectiveAgentRuntime,
-    })
-  ) {
-    const fallbackThinkLevel = resolveSupportedThinkingLevel({
-      provider,
-      model,
-      level: requestedThinkLevel,
-      catalog: thinkingCatalog,
-      agentRuntime: effectiveAgentRuntime,
-    });
-    if (fallbackThinkLevel !== requestedThinkLevel) {
-      logWarn(
-        `[cron:${input.job.id}] Thinking level "${requestedThinkLevel}" is not supported for ${provider}/${model}; using "${fallbackThinkLevel}" for this candidate.`,
-      );
-    }
-  }
-
-  const explicitTimeoutSeconds =
-    input.job.payload.kind === "agentTurn" ? input.job.payload.timeoutSeconds : undefined;
-  const timeoutMs = resolveAgentTimeoutMs({
-    cfg: cfgWithAgentDefaults,
-    overrideSeconds: explicitTimeoutSeconds,
-  });
-  // Carry the "this run had an explicit per-run timeout" signal forward.
-  // `resolveAgentTimeoutMs` collapses overrideSeconds + the agent default into
-  // one number; the LLM idle watchdog at the embedded-runner attempt loses the
-  // explicit-vs-default distinction without this companion field, which would
-  // otherwise force the implicit 120 s cap whenever the cron payload's
-  // `timeoutSeconds` happens to numerically equal `agents.defaults.timeoutSeconds`.
-  const runTimeoutOverrideMs = resolveCronRunTimeoutOverrideMs(explicitTimeoutSeconds);
-  const agentPayload = input.job.payload.kind === "agentTurn" ? input.job.payload : null;
-  const configuredProvider = cfgWithAgentDefaults.models?.providers?.[provider];
-  const modelApi =
-    findModelInCatalog(thinkingCatalog, provider, model)?.api ??
-    configuredProvider?.models?.find((candidate) => candidate.id === model)?.api ??
-    configuredProvider?.api;
-  const preflightDiagnostics = await createCronToolsAllowPreflightDiagnostics({
-    cfg: cfgWithAgentDefaults,
-    jobId: input.job.id,
-    provider,
-    model,
-    modelApi,
-    agentId: modelOwner.agentId,
-    agentDir: modelOwner.agentDir,
-    sessionKey: agentSessionKey,
-    agentPayload,
-  });
-  const { deliveryPlan, deliveryRequested, resolvedDelivery, sourceDelivery } =
-    await resolveCronDeliveryContext({
-      cfg: cfgWithAgentDefaults,
-      job: input.job,
-      agentId,
-    });
-
-  const { formattedTime, timeLine } = resolveCronStyleNow(runtimeCfg, now);
-  const originalMessage = resolveCronAgentTurnMessage(input);
-  const sourceSessionEntry = sourceSessionKey ? cronSession.store[sourceSessionKey] : undefined;
-  // Current jobs run detached for token hygiene; this bounded tail preserves the
-  // conversation-bound contract without unbounded seeding or transcript continuation.
-  const currentConversationContext =
-    input.job.sessionTarget === "current" && agentPayload && sourceSessionKey && sourceSessionEntry
-      ? await buildCurrentConversationContextBlock({
-          agentId,
-          sourceSessionEntry,
-          sourceSessionKey,
-          storePath: cronSession.storePath,
-        })
-      : undefined;
-  const message = currentConversationContext
-    ? `${currentConversationContext}\n\n${originalMessage}`
-    : originalMessage;
-  const base = `[cron:${input.job.id} ${input.job.name}] ${message}`.trim();
-  const isExternalHook =
-    hookExternalContentSource !== undefined || isExternalHookSession(baseSessionKey);
-  const allowUnsafeExternalContent =
-    agentPayload?.allowUnsafeExternalContent === true ||
-    (isGmailHook && input.cfg.hooks?.gmail?.allowUnsafeExternalContent === true);
-  const shouldWrapExternal = isExternalHook && !allowUnsafeExternalContent;
-  let commandBody: string;
-
-  if (isExternalHook) {
-    const { detectSuspiciousPatterns } = await loadCronExternalContentRuntime();
-    const suspiciousPatterns = detectSuspiciousPatterns(message);
-    if (suspiciousPatterns.length > 0) {
-      logWarn(
-        `[security] Suspicious patterns detected in external hook content ` +
-          `(session=${baseSessionKey}, patterns=${suspiciousPatterns.length}): ${suspiciousPatterns.slice(0, 3).join(", ")}`,
-      );
-    }
-  }
-
-  if (shouldWrapExternal) {
-    const { buildSafeExternalPrompt } = await loadCronExternalContentRuntime();
-    const hookType = mapHookExternalContentSource(hookExternalContentSource ?? "webhook");
-    const safeContent = buildSafeExternalPrompt({
-      content: message,
-      source: hookType,
-      jobName: input.job.name,
-      jobId: input.job.id,
-      timestamp: formattedTime,
-    });
-    commandBody = `${safeContent}\n\n${timeLine}`.trim();
-  } else {
-    commandBody = `${base}\n${timeLine}`.trim();
-  }
-  const messageToolPromptEnabled = canPromptForMessageTool({
-    sourceDelivery,
-    toolsAllow: agentPayload?.toolsAllow,
-  });
-  commandBody = appendCronUnattendedRunPreamble(commandBody, { externalHook: isExternalHook });
-  commandBody = appendCronDeliveryInstruction({
-    commandBody,
-    deliveryRequested,
-    messageToolEnabled: messageToolPromptEnabled,
-    resolvedDeliveryOk: resolvedDelivery.ok,
-    requireExplicitMessageTarget: sourceDelivery.messageTool.requireExplicitTarget,
-  });
-
   const initialSessionEntry = cronSession.initialSessionEntry;
+  // Admission must precede async model preparation so concurrent maintenance
+  // preserves this exact session generation instead of deleting it before claim.
   const sessionWorkAdmission = await beginSessionWorkAdmission({
     scope: cronSession.storePath,
     identities: [
@@ -595,6 +286,325 @@ export async function prepareCronRunContext(params: {
   });
 
   try {
+    const persistCronSessionRow = async ({
+      storePath,
+      sessionKey,
+      fallbackEntry,
+      resetBoundaryReason,
+      update,
+    }: {
+      storePath: string;
+      sessionKey: string;
+      fallbackEntry: SessionEntry;
+      resetBoundaryReason?: "cron-stale";
+      update: (entry: SessionEntry | undefined) => SessionEntry;
+    }) => {
+      const { applySessionEntryLifecycleMutation, patchSessionEntry } =
+        await loadSessionAccessorRuntime();
+      if (resetBoundaryReason) {
+        await applySessionEntryLifecycleMutation({
+          activeSessionKey: sessionKey,
+          agentId,
+          storePath,
+          upserts: [
+            {
+              sessionKey,
+              resetBoundaryReason,
+              buildEntry: ({ currentEntry }) => update(currentEntry),
+            },
+          ],
+          skipMaintenance: true,
+        });
+        return;
+      }
+      // Guarded replace: the updater sees the freshest persisted row (or
+      // undefined pre-creation) so cron lifecycle claims reject stale owners.
+      await patchSessionEntry(
+        { storePath, sessionKey, agentId },
+        (_entry, context) => update(context.existingEntry),
+        { fallbackEntry, replaceEntry: true },
+      );
+    };
+    const persistSessionEntry = createPersistCronSessionEntry({
+      cronSession,
+      agentSessionKey,
+      persistSessionEntry: persistCronSessionRow,
+    });
+    const withRunSession: WithRunSession = (result) => ({
+      ...result,
+      sessionId: currentRunSessionId(),
+      sessionKey: runSessionKey,
+    });
+    if (!cronSession.sessionEntry.label?.trim() && baseSessionKey.startsWith("cron:")) {
+      const labelSuffix =
+        typeof input.job.name === "string" && input.job.name.trim()
+          ? input.job.name.trim()
+          : input.job.id;
+      cronSession.sessionEntry.label = `Cron: ${labelSuffix}`;
+    }
+
+    const resolvedModelSelection = await resolveCronModelSelection({
+      cfg: runtimeCfg,
+      owner: modelOwner,
+      agentConfigOverride,
+      sessionEntry: cronSession.sessionEntry,
+      payload: input.job.payload,
+      isGmailHook,
+      agentId,
+      agentDir,
+      workspaceDir,
+    });
+    if (!resolvedModelSelection.ok) {
+      sessionWorkAdmission.release();
+      return {
+        ok: false,
+        result: withRunSession({
+          status: "error",
+          error: resolvedModelSelection.error,
+          diagnostics: createCronRunDiagnosticsFromError(
+            "cron-preflight",
+            resolvedModelSelection.error,
+          ),
+        }),
+      };
+    }
+    const cfgWithAgentDefaults = resolvedModelSelection.cfgWithAgentDefaults;
+    const thinkingCatalog = modelOwner.modelCatalog.entries;
+    const ownerAgentConfig = resolveAgentConfig(modelOwner.config, modelOwner.agentId);
+    const matchesDefaultFallbackAgentStringModel =
+      typeof ownerAgentConfig?.model === "string" &&
+      resolveAgentModelPrimaryValue(ownerAgentConfig.model) ===
+        resolveAgentModelPrimaryValue(modelOwner.config.agents?.defaults?.model);
+    let provider = resolvedModelSelection.provider;
+    let model = resolvedModelSelection.model;
+    const useSubagentFallbacks = resolvedModelSelection.modelSource === "subagent";
+    const inheritDefaultFallbacksForAgentStringModel =
+      matchesDefaultFallbackAgentStringModel &&
+      (resolvedModelSelection.modelSource === "default" ||
+        resolvedModelSelection.modelSource === "agent");
+
+    const modelPreflightRuntime = await loadCronModelPreflightRuntime();
+    const preflightCandidates = resolveCronPreflightCandidates({
+      cfg: cfgWithAgentDefaults,
+      job: input.job,
+      agentId: modelOwner.agentId,
+      provider,
+      model,
+      useSubagentFallbacks,
+      inheritDefaultFallbacksForAgentStringModel,
+    });
+    let selectedPreflightCandidate: { provider: string; model: string } | undefined;
+    let selectedPreflightCandidateIndex = -1;
+    let firstUnavailablePreflight:
+      | Awaited<ReturnType<typeof modelPreflightRuntime.preflightCronModelProvider>>
+      | undefined;
+    for (const [index, candidate] of preflightCandidates.entries()) {
+      const candidatePreflight = await modelPreflightRuntime.preflightCronModelProvider({
+        cfg: cfgWithAgentDefaults,
+        provider: candidate.provider,
+        model: candidate.model,
+      });
+      if (candidatePreflight.status === "available") {
+        selectedPreflightCandidate = candidate;
+        selectedPreflightCandidateIndex = index;
+        break;
+      }
+      firstUnavailablePreflight ??= candidatePreflight;
+    }
+    if (!selectedPreflightCandidate && firstUnavailablePreflight?.status === "unavailable") {
+      logWarn(`[cron:${input.job.id}] ${firstUnavailablePreflight.reason}`);
+      sessionWorkAdmission.release();
+      return {
+        ok: false,
+        result: withRunSession({
+          status: "skipped",
+          error: firstUnavailablePreflight.reason,
+          diagnostics: createCronRunDiagnosticsFromError(
+            "model-preflight",
+            firstUnavailablePreflight.reason,
+            {
+              severity: "warn",
+            },
+          ),
+          provider,
+          model,
+        }),
+      };
+    }
+    const modelFallbacksOverride =
+      selectedPreflightCandidate &&
+      (selectedPreflightCandidate.provider !== provider ||
+        selectedPreflightCandidate.model !== model)
+        ? preflightCandidates
+            .slice(selectedPreflightCandidateIndex + 1)
+            .map((candidate) => `${candidate.provider}/${candidate.model}`)
+        : undefined;
+    // When preflight skips the first local candidate, trim the fallback chain so
+    // execution starts at the reachable provider and only falls forward from it.
+    if (selectedPreflightCandidate && modelFallbacksOverride) {
+      if (firstUnavailablePreflight?.status === "unavailable") {
+        logWarn(
+          `[cron:${input.job.id}] ${firstUnavailablePreflight.reason}; continuing with fallback ${selectedPreflightCandidate.provider}/${selectedPreflightCandidate.model}.`,
+        );
+      }
+      provider = selectedPreflightCandidate.provider;
+      model = selectedPreflightCandidate.model;
+    }
+
+    const hooksGmailThinking = isGmailHook
+      ? normalizeThinkLevel(runtimeCfg.hooks?.gmail?.thinking)
+      : undefined;
+    const jobThink = normalizeThinkLevel(
+      (input.job.payload.kind === "agentTurn" ? input.job.payload.thinking : undefined) ??
+        undefined,
+    );
+    const sessionThink = normalizeThinkLevel(cronSession.sessionEntry.thinkingLevel);
+    const effectiveAgentRuntime = resolveEffectiveAgentRuntime({
+      cfg: cfgWithAgentDefaults,
+      provider,
+      modelId: model,
+      agentId: modelOwner.agentId,
+      sessionKey: agentSessionKey,
+      sessionEntry: cronSession.sessionEntry,
+    });
+    let requestedThinkLevel: ThinkLevel | undefined =
+      jobThink ?? hooksGmailThinking ?? sessionThink;
+    if (!requestedThinkLevel) {
+      requestedThinkLevel = resolveThinkingDefault({
+        cfg: cfgWithAgentDefaults,
+        provider,
+        model,
+        catalog: thinkingCatalog,
+        agentRuntime: effectiveAgentRuntime,
+      });
+    }
+    if (
+      !isThinkingLevelSupported({
+        provider,
+        model,
+        level: requestedThinkLevel,
+        catalog: thinkingCatalog,
+        agentRuntime: effectiveAgentRuntime,
+      })
+    ) {
+      const fallbackThinkLevel = resolveSupportedThinkingLevel({
+        provider,
+        model,
+        level: requestedThinkLevel,
+        catalog: thinkingCatalog,
+        agentRuntime: effectiveAgentRuntime,
+      });
+      if (fallbackThinkLevel !== requestedThinkLevel) {
+        logWarn(
+          `[cron:${input.job.id}] Thinking level "${requestedThinkLevel}" is not supported for ${provider}/${model}; using "${fallbackThinkLevel}" for this candidate.`,
+        );
+      }
+    }
+
+    const explicitTimeoutSeconds =
+      input.job.payload.kind === "agentTurn" ? input.job.payload.timeoutSeconds : undefined;
+    const timeoutMs = resolveAgentTimeoutMs({
+      cfg: cfgWithAgentDefaults,
+      overrideSeconds: explicitTimeoutSeconds,
+    });
+    // Carry the "this run had an explicit per-run timeout" signal forward.
+    // `resolveAgentTimeoutMs` collapses overrideSeconds + the agent default into
+    // one number; the LLM idle watchdog at the embedded-runner attempt loses the
+    // explicit-vs-default distinction without this companion field, which would
+    // otherwise force the implicit 120 s cap whenever the cron payload's
+    // `timeoutSeconds` happens to numerically equal `agents.defaults.timeoutSeconds`.
+    const runTimeoutOverrideMs = resolveCronRunTimeoutOverrideMs(explicitTimeoutSeconds);
+    const agentPayload = input.job.payload.kind === "agentTurn" ? input.job.payload : null;
+    const configuredProvider = cfgWithAgentDefaults.models?.providers?.[provider];
+    const modelApi =
+      findModelInCatalog(thinkingCatalog, provider, model)?.api ??
+      configuredProvider?.models?.find((candidate) => candidate.id === model)?.api ??
+      configuredProvider?.api;
+    const preflightDiagnostics = await createCronToolsAllowPreflightDiagnostics({
+      cfg: cfgWithAgentDefaults,
+      jobId: input.job.id,
+      provider,
+      model,
+      modelApi,
+      agentId: modelOwner.agentId,
+      agentDir: modelOwner.agentDir,
+      sessionKey: agentSessionKey,
+      agentPayload,
+    });
+    const { deliveryPlan, deliveryRequested, resolvedDelivery, sourceDelivery } =
+      await resolveCronDeliveryContext({
+        cfg: cfgWithAgentDefaults,
+        job: input.job,
+        agentId,
+      });
+
+    const { formattedTime, timeLine } = resolveCronStyleNow(runtimeCfg, now);
+    const originalMessage = resolveCronAgentTurnMessage(input);
+    const sourceSessionEntry = sourceSessionKey ? cronSession.store[sourceSessionKey] : undefined;
+    // Current jobs run detached for token hygiene; this bounded tail preserves the
+    // conversation-bound contract without unbounded seeding or transcript continuation.
+    const currentConversationContext =
+      input.job.sessionTarget === "current" &&
+      agentPayload &&
+      sourceSessionKey &&
+      sourceSessionEntry
+        ? await buildCurrentConversationContextBlock({
+            agentId,
+            sourceSessionEntry,
+            sourceSessionKey,
+            storePath: cronSession.storePath,
+          })
+        : undefined;
+    const message = currentConversationContext
+      ? `${currentConversationContext}\n\n${originalMessage}`
+      : originalMessage;
+    const base = `[cron:${input.job.id} ${input.job.name}] ${message}`.trim();
+    const isExternalHook =
+      hookExternalContentSource !== undefined || isExternalHookSession(baseSessionKey);
+    const allowUnsafeExternalContent =
+      agentPayload?.allowUnsafeExternalContent === true ||
+      (isGmailHook && input.cfg.hooks?.gmail?.allowUnsafeExternalContent === true);
+    const shouldWrapExternal = isExternalHook && !allowUnsafeExternalContent;
+    let commandBody: string;
+
+    if (isExternalHook) {
+      const { detectSuspiciousPatterns } = await loadCronExternalContentRuntime();
+      const suspiciousPatterns = detectSuspiciousPatterns(message);
+      if (suspiciousPatterns.length > 0) {
+        logWarn(
+          `[security] Suspicious patterns detected in external hook content ` +
+            `(session=${baseSessionKey}, patterns=${suspiciousPatterns.length}): ${suspiciousPatterns.slice(0, 3).join(", ")}`,
+        );
+      }
+    }
+
+    if (shouldWrapExternal) {
+      const { buildSafeExternalPrompt } = await loadCronExternalContentRuntime();
+      const hookType = mapHookExternalContentSource(hookExternalContentSource ?? "webhook");
+      const safeContent = buildSafeExternalPrompt({
+        content: message,
+        source: hookType,
+        jobName: input.job.name,
+        jobId: input.job.id,
+        timestamp: formattedTime,
+      });
+      commandBody = `${safeContent}\n\n${timeLine}`.trim();
+    } else {
+      commandBody = `${base}\n${timeLine}`.trim();
+    }
+    const messageToolPromptEnabled = canPromptForMessageTool({
+      sourceDelivery,
+      toolsAllow: agentPayload?.toolsAllow,
+    });
+    commandBody = appendCronUnattendedRunPreamble(commandBody, { externalHook: isExternalHook });
+    commandBody = appendCronDeliveryInstruction({
+      commandBody,
+      deliveryRequested,
+      messageToolEnabled: messageToolPromptEnabled,
+      resolvedDeliveryOk: resolvedDelivery.ok,
+      requireExplicitMessageTarget: sourceDelivery.messageTool.requireExplicitTarget,
+    });
+
     const skillsSnapshot = await resolveCronSkillsSnapshot({
       workspaceDir,
       config: cfgWithAgentDefaults,

--- a/src/cron/isolated-agent/run.session-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.session-lifecycle.test.ts
@@ -53,7 +53,7 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
     mockRunCronFallbackPassthrough();
   });
 
-  it("rejects a session that rotates during async setup", async () => {
+  it("rejects a session that rotates before async setup", async () => {
     const sessionKey = "agent:main:main";
     const initialSessionEntry = makeCronSessionEntry({ sessionId: "session-before-setup" });
     resolveCronSessionMock.mockReturnValue(
@@ -69,19 +69,10 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
       ...initialSessionEntry,
       sessionId: "session-after-setup",
     });
-    const releasePreflight = createDeferred();
-    preflightCronModelProviderMock.mockImplementationOnce(async () => {
-      await releasePreflight.promise;
-      return { status: "available" };
-    });
-
-    const run = runCronIsolatedAgentTurn(makePersistentCronParams(sessionKey));
-    await vi.waitFor(() => expect(preflightCronModelProviderMock).toHaveBeenCalledTimes(1));
-    releasePreflight.resolve();
-
-    await expect(run).rejects.toThrow(
+    await expect(runCronIsolatedAgentTurn(makePersistentCronParams(sessionKey))).rejects.toThrow(
       `Session "${sessionKey}" changed while starting work. Retry.`,
     );
+    expect(preflightCronModelProviderMock).not.toHaveBeenCalled();
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
   });
 
@@ -121,6 +112,81 @@ describe("runCronIsolatedAgentTurn session lifecycle", () => {
 
     await expect(run).resolves.toMatchObject({ status: "ok" });
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("protects the isolated cron session throughout async model preparation", async () => {
+    const sessionKey = "agent:main:cron:test-job";
+    const initialSessionEntry = makeCronSessionEntry({
+      lifecycleRevision: "initial-revision",
+      sessionId: "previous-session",
+    });
+    const sessionEntry = makeCronSessionEntry({ sessionId: "isolated-session" });
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({
+        storePath: inMemoryStorePath,
+        store: { [sessionKey]: { ...initialSessionEntry } },
+        initialSessionEntry,
+        isNewSession: true,
+        sessionEntry,
+      }),
+    );
+    loadSessionEntryMock.mockImplementation((_storePath, currentSessionKey) =>
+      currentSessionKey === sessionKey ? initialSessionEntry : undefined,
+    );
+    const releasePreflight = createDeferred();
+    preflightCronModelProviderMock.mockImplementationOnce(async () => {
+      await releasePreflight.promise;
+      return { status: "available" };
+    });
+
+    const run = runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({
+        agentId: "main",
+        sessionKey: "cron:test-job",
+        job: makeIsolatedAgentJobFixture({
+          sessionTarget: "isolated",
+          delivery: { mode: "none" },
+        }),
+      }),
+    );
+    await vi.waitFor(() => expect(preflightCronModelProviderMock).toHaveBeenCalledTimes(1));
+    const sessionIsProtectedDuringPreflight = isSessionWorkAdmissionActive(inMemoryStorePath, [
+      sessionKey,
+      "previous-session",
+      "isolated-session",
+    ]);
+    releasePreflight.resolve();
+
+    expect(sessionIsProtectedDuringPreflight).toBe(true);
+    await expect(run).resolves.toMatchObject({ status: "ok" });
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    expect(patchSessionEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey }),
+      expect.any(Function),
+      expect.objectContaining({
+        fallbackEntry: expect.objectContaining({ sessionId: "isolated-session" }),
+      }),
+    );
+  });
+
+  it("does not recreate a persistent session deleted during async setup", async () => {
+    const sessionKey = "agent:main:main";
+    const initialSessionEntry = makeCronSessionEntry({ sessionId: "persistent-session" });
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({
+        storePath: inMemoryStorePath,
+        store: { [sessionKey]: { ...initialSessionEntry } },
+        initialSessionEntry,
+        isNewSession: false,
+        sessionEntry: { ...initialSessionEntry },
+      }),
+    );
+    loadSessionEntryMock.mockReturnValue(undefined);
+
+    await expect(runCronIsolatedAgentTurn(makePersistentCronParams(sessionKey))).rejects.toThrow(
+      `Session "${sessionKey}" changed while starting work. Retry.`,
+    );
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
   });
 
   it("interrupts persistent cron work and waits for its lifecycle lease to release", async () => {


### PR DESCRIPTION
Closes #114573

## What Problem This Solves

Fixes an issue where users running isolated scheduled jobs on busy gateways would lose every scheduled run when session maintenance deleted its unprotected cron session during asynchronous model preparation.

## Why This Change Was Made

Claim and protect the exact original session generation immediately after cron session resolution, before asynchronous model selection, provider preflight, delivery preparation, or skill loading. Keep the existing missing-row, archived-session, replacement-owner, and lifecycle-generation fences completely unchanged. Release the early admission on both non-executing model-selection/provider-preflight returns and on preparation exceptions.

This fixes the actual create-to-claim race rather than recreating deleted rows, so an older run cannot resurrect a row after a newer lifecycle owner was removed.

## User Impact

Isolated scheduled runs survive concurrent session maintenance and reach the model instead of repeatedly failing with `CronSessionLifecycleClaimError`. Persistent and user-owned sessions still fail closed on deletion or takeover. Existing model fallback, unavailable-provider skips, detached exact-run state, cleanup, and delivery keep their behavior.

## Evidence

- Reproduced the exact issue against unchanged main on a fresh Blacksmith Testbox: the full isolated cron run aborted at the late admission after the session row vanished; the authoritative guarded persistence path separately rejected the missing row.
- Added a deterministic full isolated-run regression proving the original cron key, original session identity, and exact-run identity are already actively protected while provider preflight is suspended, and proving the embedded run completes.
- Added a fail-closed deletion regression for explicitly bound persistent/user sessions and updated pre-admission rotation proof so stale owners are rejected before model calls.
- Fresh Blacksmith proof: **217/217 tests across 11 files and 3 actual Vitest project shards**, including the complete isolated cron lifecycle, model-provider fallback and skip, session-state generation fencing, hidden run keys, SQLite session-registry maintenance, cap pruning, lifecycle mutation admission, session reaping, scheduler restart recovery, and retry classification.
- Full unsuppressed `pnpm check:changed` on Blacksmith: **passed**; both core and core-test tsgo, changed-file format and lint, production/full-tree/script Knip scans (all zero), SDK and owner-boundary guards, database-first/state-schema guards, and runtime import-cycle guard all passed.
- Fresh independent `gpt-5.6-sol` **xhigh** autoreview: **clean, 0.96**. Its earlier ABA finding against an exploratory recreate-on-missing approach was accepted; this submitted solution preserves the existing generation fences and eliminates that approach.

AI-assisted; source, lifecycle invariants, production owner boundaries, and proof were reviewed against the actual repository.
