### PR TITLE
fix(browser): abort cancelled CDP handshakes

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.internal.test.ts
@@ -1,15 +1,32 @@
 // Browser tests cover cdp.helpers.internal plugin behavior.
+import { createServer } from "node:http";
+import type { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import { toErrorObject } from "../infra/errors.js";
 import { rawDataToString } from "../infra/ws.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+const sleepWithAbortMock = vi.hoisted(() =>
+  vi.fn<(delayMs: number, signal?: AbortSignal, options?: { ref?: boolean }) => void>(),
+);
 const { registerManagedProxyBrowserCdpBypassMock } = vi.hoisted(() => ({
   registerManagedProxyBrowserCdpBypassMock: vi.fn<(url: string) => (() => void) | undefined>(
     () => undefined,
   ),
 }));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    sleepWithAbort: (...args: Parameters<typeof actual.sleepWithAbort>) => {
+      const pending = actual.sleepWithAbort(...args);
+      sleepWithAbortMock(...args);
+      return pending;
+    },
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
@@ -56,6 +73,7 @@ describe("cdp.helpers internal", () => {
 
   afterEach(async () => {
     fetchWithSsrFGuardMock.mockReset();
+    sleepWithAbortMock.mockClear();
     registerManagedProxyBrowserCdpBypassMock.mockReset();
     registerManagedProxyBrowserCdpBypassMock.mockImplementation(() => undefined);
     if (wss) {
@@ -367,6 +385,116 @@ describe("cdp.helpers internal", () => {
       expect(result.echoed).toBe("Test.afterOpen");
       expect(rejectedHandshakes).toBe(1);
       expect(callbackCount).toBe(1);
+    });
+
+    it("aborts an authenticated 503 handshake retry before opening another socket", async () => {
+      const controller = new AbortController();
+      const expectedAuthorization = `Basic ${Buffer.from("openclaw:cdp-abort-test").toString("base64")}`;
+      let rejectedHandshakes = 0;
+      wss = new WebSocketServer({
+        port: 0,
+        host: "127.0.0.1",
+        verifyClient: (info, callback) => {
+          if (info.req.headers.authorization !== expectedAuthorization) {
+            callback(false, 401, "authentication required");
+            return;
+          }
+          rejectedHandshakes += 1;
+          callback(false, 503, "try later");
+        },
+      });
+      await new Promise<void>((resolve) => {
+        wss?.once("listening", resolve);
+      });
+      const port = (wss.address() as { port: number }).port;
+      const pending = withCdpSocket(
+        `ws://openclaw:cdp-abort-test@127.0.0.1:${port}/devtools/browser/TEST`,
+        async () => "unexpected command",
+        {
+          handshakeRetries: 3,
+          handshakeRetryDelayMs: 2_000,
+          handshakeMaxRetryDelayMs: 2_000,
+          signal: controller.signal,
+        },
+      );
+      await vi.waitFor(() =>
+        expect(sleepWithAbortMock).toHaveBeenCalledWith(expect.any(Number), controller.signal),
+      );
+      controller.abort(new Error("browser request cancelled"));
+
+      await expect(
+        Promise.race([
+          pending,
+          new Promise<never>((_resolve, reject) => {
+            const timeout = setTimeout(
+              () => reject(new Error("CDP cancellation did not stop handshake retry backoff")),
+              300,
+            );
+            timeout.unref?.();
+          }),
+        ]),
+      ).rejects.toThrow("browser request cancelled");
+      expect(rejectedHandshakes).toBe(1);
+    });
+
+    it("closes an authenticated CDP socket when its opening handshake is aborted", async () => {
+      const controller = new AbortController();
+      const server = createServer();
+      const sockets = new Set<Socket>();
+      const expectedAuthorization = `Basic ${Buffer.from("openclaw:cdp-abort-test").toString("base64")}`;
+      let resolveUpgrade: (() => void) | undefined;
+      const upgradeStarted = new Promise<void>((resolve) => {
+        resolveUpgrade = resolve;
+      });
+      server.on("connection", (socket) => {
+        sockets.add(socket);
+        socket.once("end", () => socket.destroy());
+        socket.once("close", () => sockets.delete(socket));
+      });
+      server.on("upgrade", (request, socket) => {
+        if (request.headers.authorization !== expectedAuthorization) {
+          socket.end("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+          return;
+        }
+        // Keep the authenticated TCP socket open without sending an upgrade.
+        socket.resume();
+        resolveUpgrade?.();
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const port = (server.address() as { port: number }).port;
+
+      try {
+        const pending = withCdpSocket(
+          `ws://openclaw:cdp-abort-test@127.0.0.1:${port}/devtools/browser/TEST`,
+          async () => "unexpected command",
+          { handshakeTimeoutMs: 2_000, handshakeRetries: 0, signal: controller.signal },
+        );
+        await upgradeStarted;
+        controller.abort(new Error("browser request cancelled"));
+
+        await expect(
+          Promise.race([
+            pending,
+            new Promise<never>((_resolve, reject) => {
+              const timeout = setTimeout(
+                () => reject(new Error("CDP cancellation did not stop the opening handshake")),
+                300,
+              );
+              timeout.unref?.();
+            }),
+          ]),
+        ).rejects.toThrow("browser request cancelled");
+        await vi.waitFor(() => expect(sockets.size).toBe(0));
+      } finally {
+        for (const socket of sockets) {
+          socket.destroy();
+        }
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
     });
 
     it("does not retry rate-limited websocket handshakes", async () => {

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -7,7 +7,7 @@
 import { createHash } from "node:crypto";
 import { parseBrowserHttpUrl, redactCdpUrl } from "openclaw/plugin-sdk/browser-config";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
-import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import WebSocket from "ws";
 import { isLoopbackHost } from "../gateway/net.js";
@@ -711,6 +711,7 @@ type CdpSocketOptions = {
   handshakeRetries?: number;
   handshakeRetryDelayMs?: number;
   handshakeMaxRetryDelayMs?: number;
+  signal?: AbortSignal;
 };
 
 function normalizeRetryCount(value: number | undefined, fallback: number): number {
@@ -772,8 +773,8 @@ export async function withCdpSocket<T>(
   opts?: CdpSocketOptions,
 ): Promise<T> {
   const maxHandshakeRetries = normalizeRetryCount(opts?.handshakeRetries, 2);
-  let lastHandshakeError: unknown;
-  for (let attempt = 0; attempt <= maxHandshakeRetries; attempt += 1) {
+  for (let attempt = 0; ; attempt += 1) {
+    opts?.signal?.throwIfAborted();
     const ws = openCdpWebSocket(wsUrl, opts);
     const { send, closeWithError } = createCdpSender(ws, opts);
 
@@ -782,24 +783,39 @@ export async function withCdpSocket<T>(
       ws.once("error", (err) => reject(err));
       ws.once("close", () => reject(new Error("CDP socket closed")));
     });
+    // A stalled HTTP upgrade must release its TCP socket on cancellation.
+    const abortHandshake = () => ws.terminate();
+    opts?.signal?.addEventListener("abort", abortHandshake, { once: true });
+    if (opts?.signal?.aborted) {
+      abortHandshake();
+    }
 
     try {
       await openPromise;
     } catch (err) {
-      lastHandshakeError = err;
       // openPromise is only rejected via `ws.once('error', err => reject(err))`
       // or the close event's `new Error(...)`; the former always carries an
       // Error from Node's `ws` library, the latter is already an Error. The
       // non-Error wrap is defensive and structurally unreachable.
       /* c8 ignore next */
       closeWithError(err instanceof Error ? err : new Error(String(err)));
+      // Cancellation on the final attempt must not become a handshake error.
+      opts?.signal?.throwIfAborted();
       if (attempt >= maxHandshakeRetries || !shouldRetryCdpHandshakeError(err)) {
         throw err;
       }
       // Retry only handshake failures. Once CDP commands are flowing, callers
       // own retry semantics because commands may already have side effects.
-      await sleep(computeHandshakeRetryDelayMs(attempt + 1, opts));
+      // Cancelled route requests must not keep retrying Chrome handshakes.
+      await sleepWithAbort(computeHandshakeRetryDelayMs(attempt + 1, opts), opts?.signal).catch(
+        (error: unknown) => {
+          opts?.signal?.throwIfAborted();
+          throw error;
+        },
+      );
       continue;
+    } finally {
+      opts?.signal?.removeEventListener("abort", abortHandshake);
     }
 
     try {
@@ -811,9 +827,4 @@ export async function withCdpSocket<T>(
       ws.close();
     }
   }
-
-  if (lastHandshakeError instanceof Error) {
-    throw lastHandshakeError;
-  }
-  throw new Error("CDP socket failed to open");
 }

--- a/extensions/browser/src/browser/routes/permissions.test.ts
+++ b/extensions/browser/src/browser/routes/permissions.test.ts
@@ -168,6 +168,11 @@ describe("browser permission routes", () => {
       1234,
       undefined,
     );
+    expect(cdpMocks.withCdpSocket).toHaveBeenCalledWith(
+      "ws://127.0.0.1:18800/devtools/browser/test",
+      expect.any(Function),
+      { commandTimeoutMs: 1234, signal: expect.any(AbortSignal) },
+    );
     expect(cdpMocks.send).toHaveBeenCalledWith("Browser.grantPermissions", {
       origin: "https://meet.google.com",
       permissions: ["audioCapture", "videoCapture", "speakerSelection"],

--- a/extensions/browser/src/browser/routes/permissions.ts
+++ b/extensions/browser/src/browser/routes/permissions.ts
@@ -112,7 +112,7 @@ async function grantPermissions(params: {
       });
       unsupportedPermissions = params.optionalPermissions;
     },
-    { commandTimeoutMs: params.timeoutMs },
+    { commandTimeoutMs: params.timeoutMs, signal: params.signal },
   );
   params.signal.throwIfAborted();
   return {


### PR DESCRIPTION
Related: #110286.

## What Problem This Solves

Fixes an issue where users cancelling a browser permission request could remain stuck while Chrome DevTools Protocol handshakes retried or an authenticated WebSocket upgrade never completed. Cancellation now stops promptly without opening another browser socket or leaving the stalled connection behind.

## Why This Change Was Made

Thread the existing per-request abort signal into the browser plugin's existing CDP helper. Use the existing public runtime abortable sleeper for actual handshake retry backoff, terminate an in-progress WebSocket opening handshake on cancellation, remove each attempt's listener, and propagate the caller's original cancellation reason, including on the final no-retry attempt.

Thanks to @chengzhichao-xydt for independently reporting and investigating the retry-backoff problem in #110286. This replacement additionally verifies and repairs the real authenticated hanging WebSocket upgrade, server-side socket cleanup, last-attempt cancellation, original cancellation reasons, and exact timing of the retry-backoff regression.

## User Impact

Browser permission operations cancel promptly when Chrome is unavailable. Authenticated remote CDP connections retain their existing basic-auth headers. Failed upgrades no longer leave a browser-side TCP socket behind, cancellation cannot start another retry, and callers without an abort signal retain the existing retry behavior.

## Evidence

- Reproduced the regression against current main using real loopback WebSocket/HTTP servers rather than simulated issue text.
- Authenticated 503 proof: a real `ws` server checks the HTTP basic-authorization header and rejects the upgrade; the regression waits until the actual production abortable sleeper has started, aborts, verifies the caller's original reason within 300 ms, and proves only one handshake occurs.
- Authenticated stalled-upgrade proof: a real Node HTTP server checks the HTTP basic-authorization header, accepts the upgrade request without responding, tracks real server TCP sockets, aborts the final/no-retry handshake, verifies the caller's original reason within 300 ms, and verifies the socket actually closes.
- Blacksmith Testbox `tbx_01kypfjatwb74ag406b2pjk1nt`: all **204 tests across 9 browser/CDP test files pass**, including transport, retry, ownership, SSRF/proxy and permissions regressions.
- Full changed-file remote gate passes: `CI=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed -- extensions/browser/src/browser/cdp.helpers.internal.test.ts extensions/browser/src/browser/cdp.helpers.ts extensions/browser/src/browser/routes/permissions.test.ts extensions/browser/src/browser/routes/permissions.ts`; format, max-lines, deadcode, both browser typecheck lanes, lint, plugin boundaries, guards and runtime import cycles are clean.
- Fresh isolated Codex review with `--thinking xhigh`: no accepted or actionable findings.
- Exact tested base: `104322c5ccc2b469eec6ee082197537df332bfab`; exact reviewed head: `61ed97659838b63cd448faddda96d55e3fc36355`.
- Upstream contracts personally verified: [Chrome DevTools Browser permissions](https://chromedevtools.github.io/devtools-protocol/tot/Browser/), [Playwright browser context](https://playwright.dev/docs/api/class-browsercontext), [Node abortable timers](https://nodejs.org/api/timers.html), and [the actual ws opening-handshake/terminate implementation](https://github.com/websockets/ws/blob/master/lib/websocket.js).
