### PR TITLE
fix: recovered sessions report and route the primary model

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -8,7 +8,6 @@ import type { SessionEntry } from "../config/sessions.js";
 import { withEnv } from "../test-utils/env.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
-  hasLegacyAutoFallbackWithoutOrigin,
   markAutoFallbackPrimaryProbe,
   hasConfiguredModelFallbacks,
   resolveAgentConfig,
@@ -617,36 +616,6 @@ describe("resolveAgentConfig", () => {
         probeState: new Map(),
       }),
     ).toBeUndefined();
-  });
-
-  it("identifies legacy auto fallback overrides without origin metadata", () => {
-    expect(
-      hasLegacyAutoFallbackWithoutOrigin({
-        modelOverrideSource: "auto",
-        modelOverrideFallbackOriginProvider: "anthropic",
-        modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
-      }),
-    ).toBe(false);
-    expect(
-      hasLegacyAutoFallbackWithoutOrigin({
-        modelOverrideSource: "auto",
-        modelOverrideFallbackOriginProvider: " ",
-        modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
-      }),
-    ).toBe(true);
-    expect(
-      hasLegacyAutoFallbackWithoutOrigin({
-        modelOverrideSource: "auto",
-        modelOverrideFallbackOriginProvider: "anthropic",
-      }),
-    ).toBe(true);
-    expect(
-      hasLegacyAutoFallbackWithoutOrigin({
-        modelOverrideSource: "user",
-      }),
-    ).toBe(false);
-    expect(hasLegacyAutoFallbackWithoutOrigin({})).toBe(false);
-    expect(hasLegacyAutoFallbackWithoutOrigin(undefined)).toBe(false);
   });
 
   it("recognizes recovered auto fallback provenance without a source marker", () => {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveSessionAuthProfileOverrideSource } from "../config/sessions/auth-profile-override-provenance.js";
 import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
-export { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
+export {
+  hasLegacyAutoFallbackWithoutOrigin,
+  hasSessionAutoModelFallbackProvenance,
+} from "../config/sessions/model-override-provenance.js";
 import {
   lowercasePreservingWhitespace,
   normalizeLowercaseStringOrEmpty,
@@ -104,25 +107,6 @@ export type AutoFallbackPrimaryProbe = {
   fallbackAuthProfileId?: string;
   fallbackAuthProfileIdSource?: "auto" | "user";
 };
-
-/** Detects old auto-fallback session entries that lack primary-origin metadata. */
-export function hasLegacyAutoFallbackWithoutOrigin(
-  entry:
-    | Pick<
-        SessionEntry,
-        | "modelOverrideSource"
-        | "modelOverrideFallbackOriginProvider"
-        | "modelOverrideFallbackOriginModel"
-      >
-    | null
-    | undefined,
-): boolean {
-  return (
-    entry?.modelOverrideSource === "auto" &&
-    (!normalizeOptionalString(entry.modelOverrideFallbackOriginProvider) ||
-      !normalizeOptionalString(entry.modelOverrideFallbackOriginModel))
-  );
-}
 
 export function resolveAutoFallbackPrimaryProbe(params: {
   entry:

--- a/src/agents/session-model-ref.test.ts
+++ b/src/agents/session-model-ref.test.ts
@@ -37,6 +37,40 @@ describe("resolveSessionModelRef", () => {
     expect(resolved).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
   });
 
+  test("ignores legacy auto fallback overrides during agent admission", () => {
+    const resolved = resolveSessionModelRef(
+      modelConfig("openai/gpt-5.6-sol"),
+      {
+        providerOverride: "anthropic",
+        modelOverride: "claude-sonnet-4-6",
+        modelOverrideSource: "auto",
+        modelProvider: "openai",
+        model: "gpt-5.6-sol",
+      },
+      "main",
+    );
+
+    expect(resolved).toEqual({ provider: "openai", model: "gpt-5.6-sol" });
+  });
+
+  test("preserves an active auto fallback with complete origin provenance", () => {
+    const resolved = resolveSessionModelRef(
+      modelConfig("openai/gpt-5.6-sol"),
+      {
+        providerOverride: "anthropic",
+        modelOverride: "claude-sonnet-4-6",
+        modelOverrideSource: "auto",
+        modelOverrideFallbackOriginProvider: "openai",
+        modelOverrideFallbackOriginModel: "gpt-5.6-sol",
+        modelProvider: "openai",
+        model: "gpt-5.6-sol",
+      },
+      "main",
+    );
+
+    expect(resolved).toEqual({ provider: "anthropic", model: "claude-sonnet-4-6" });
+  });
+
   test("preserves runtime identity for legacy callers without an agent id", () => {
     const resolved = resolveSessionModelRef(modelConfig("anthropic/claude-opus-4-6"), {
       modelProvider: "openai",

--- a/src/agents/session-model-ref.ts
+++ b/src/agents/session-model-ref.ts
@@ -1,5 +1,6 @@
 // Resolves persisted session model metadata without loading Gateway projections.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { hasLegacyAutoFallbackWithoutOrigin } from "../config/sessions/model-override-provenance.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
@@ -14,7 +15,16 @@ import {
 
 type SessionModelEntry =
   | SessionEntry
-  | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">;
+  | Pick<
+      SessionEntry,
+      | "model"
+      | "modelProvider"
+      | "modelOverride"
+      | "providerOverride"
+      | "modelOverrideSource"
+      | "modelOverrideFallbackOriginProvider"
+      | "modelOverrideFallbackOriginModel"
+    >;
 
 export function resolveSessionModelRef(
   cfg: OpenClawConfig,
@@ -22,9 +32,13 @@ export function resolveSessionModelRef(
   agentId?: string,
   options?: { allowPluginNormalization?: boolean },
 ): { provider: string; model: string } {
+  // Originless automatic pins predate trustworthy fallback provenance.
+  // Current writers persist complete origins, so these records cannot
+  // represent an active fallback and must not override current selection.
+  const ignoreStoredOverride = hasLegacyAutoFallbackWithoutOrigin(entry);
   const normalizedOverride = normalizeStoredOverrideModel({
-    providerOverride: entry?.providerOverride,
-    modelOverride: entry?.modelOverride,
+    providerOverride: ignoreStoredOverride ? undefined : entry?.providerOverride,
+    modelOverride: ignoreStoredOverride ? undefined : entry?.modelOverride,
   });
   if (normalizedOverride.providerOverride && normalizedOverride.modelOverride) {
     return resolvePersistedSelectedModelRef({

--- a/src/commands/sessions-display-model.ts
+++ b/src/commands/sessions-display-model.ts
@@ -12,6 +12,7 @@ import {
   type CliProviderClassifier,
 } from "../agents/model-selection.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
+import { hasLegacyAutoFallbackWithoutOrigin } from "../config/sessions/model-override-provenance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 type SessionDisplayModelRow = {
@@ -20,6 +21,9 @@ type SessionDisplayModelRow = {
   modelProvider?: string;
   modelOverride?: string;
   providerOverride?: string;
+  modelOverrideSource?: "user" | "auto";
+  modelOverrideFallbackOriginProvider?: string;
+  modelOverrideFallbackOriginModel?: string;
 };
 
 type SessionDisplayDefaults = {
@@ -145,9 +149,12 @@ export function resolveSessionDisplayModelRef(
 ): SessionDisplayModelRef {
   const agentId = row.key.startsWith("agent:") ? row.key.split(":")[1] : undefined;
   const defaultRef = resolveDefaultModelRef(cfg, agentId);
+  // Execution ignores originless automatic pins, so operator listings must
+  // not resurrect them ahead of the live runtime model.
+  const ignoreStoredOverride = hasLegacyAutoFallbackWithoutOrigin(row);
   const normalizedOverride = normalizeStoredOverrideModel({
-    providerOverride: row.providerOverride,
-    modelOverride: row.modelOverride,
+    providerOverride: ignoreStoredOverride ? undefined : row.providerOverride,
+    modelOverride: ignoreStoredOverride ? undefined : row.modelOverride,
   });
 
   if (normalizedOverride.modelOverride) {

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -47,6 +47,9 @@ export type SessionDisplayRow = {
   modelProvider?: string;
   providerOverride?: string;
   modelOverride?: string;
+  modelOverrideSource?: SessionEntry["modelOverrideSource"];
+  modelOverrideFallbackOriginProvider?: string;
+  modelOverrideFallbackOriginModel?: string;
   contextTokens?: number;
   runtimePolicySessionKey?: string;
 };
@@ -93,6 +96,9 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
     modelProvider: entry?.modelProvider,
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
+    modelOverrideSource: entry?.modelOverrideSource,
+    modelOverrideFallbackOriginProvider: entry?.modelOverrideFallbackOriginProvider,
+    modelOverrideFallbackOriginModel: entry?.modelOverrideFallbackOriginModel,
     contextTokens: entry?.contextTokens,
   };
 }

--- a/src/commands/sessions.model-resolution.test.ts
+++ b/src/commands/sessions.model-resolution.test.ts
@@ -99,6 +99,36 @@ describe("sessionsCommand model resolution", () => {
     expect(model).toBe("gpt-5.4");
   });
 
+  it("ignores legacy auto fallback overrides after the runtime returns to primary", async () => {
+    const model = await resolveSubagentModel(
+      {
+        providerOverride: "anthropic",
+        modelOverride: "claude-sonnet-4-6",
+        modelOverrideSource: "auto",
+        modelProvider: "openai",
+        model: "gpt-5.6-sol",
+      },
+      "subagent-legacy-auto-fallback",
+    );
+    expect(model).toBe("gpt-5.6-sol");
+  });
+
+  it("preserves an active auto fallback with complete origin provenance", async () => {
+    const model = await resolveSubagentModel(
+      {
+        providerOverride: "anthropic",
+        modelOverride: "claude-sonnet-4-6",
+        modelOverrideSource: "auto",
+        modelOverrideFallbackOriginProvider: "openai",
+        modelOverrideFallbackOriginModel: "gpt-5.6-sol",
+        modelProvider: "openai",
+        model: "gpt-5.6-sol",
+      },
+      "subagent-active-auto-fallback",
+    );
+    expect(model).toBe("claude-sonnet-4-6");
+  });
+
   it("separates Claude CLI runtime from canonical model provider in JSON output", async () => {
     setMockSessionsConfig(() => ({
       agents: {

--- a/src/commands/status.summary.runtime.test.ts
+++ b/src/commands/status.summary.runtime.test.ts
@@ -376,6 +376,56 @@ describe("statusSummaryRuntime.resolveSessionModelRef", () => {
     });
   });
 
+  it("ignores legacy auto fallback overrides after the runtime returns to primary", () => {
+    expect(
+      statusSummaryRuntime.resolveSessionModelRef(
+        {
+          agents: {
+            defaults: {
+              model: { primary: "openai/gpt-5.6-sol" },
+            },
+          },
+        } as never,
+        {
+          providerOverride: "anthropic",
+          modelOverride: "claude-sonnet-4-6",
+          modelOverrideSource: "auto",
+          modelProvider: "openai",
+          model: "gpt-5.6-sol",
+        },
+      ),
+    ).toEqual({
+      provider: "openai",
+      model: "gpt-5.6-sol",
+    });
+  });
+
+  it("preserves an active auto fallback with complete origin provenance", () => {
+    expect(
+      statusSummaryRuntime.resolveSessionModelRef(
+        {
+          agents: {
+            defaults: {
+              model: { primary: "openai/gpt-5.6-sol" },
+            },
+          },
+        } as never,
+        {
+          providerOverride: "anthropic",
+          modelOverride: "claude-sonnet-4-6",
+          modelOverrideSource: "auto",
+          modelOverrideFallbackOriginProvider: "openai",
+          modelOverrideFallbackOriginModel: "gpt-5.6-sol",
+          modelProvider: "openai",
+          model: "gpt-5.6-sol",
+        },
+      ),
+    ).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+  });
+
   it("falls back to configured defaults when persisted session model fields are malformed", () => {
     expect(
       statusSummaryRuntime.resolveSessionModelRef(cfg, {

--- a/src/config/sessions/model-override-provenance.test.ts
+++ b/src/config/sessions/model-override-provenance.test.ts
@@ -1,5 +1,55 @@
 import { describe, expect, it } from "vitest";
-import { hasSessionActiveAutoModelFallback } from "./model-override-provenance.js";
+import {
+  hasLegacyAutoFallbackWithoutOrigin,
+  hasSessionActiveAutoModelFallback,
+} from "./model-override-provenance.js";
+
+describe("hasLegacyAutoFallbackWithoutOrigin", () => {
+  it.each([
+    {
+      name: "origin-backed automatic override",
+      entry: {
+        modelOverrideSource: "auto" as const,
+        modelOverrideFallbackOriginProvider: "anthropic",
+        modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
+      },
+      expected: false,
+    },
+    {
+      name: "blank origin provider",
+      entry: {
+        modelOverrideSource: "auto" as const,
+        modelOverrideFallbackOriginProvider: " ",
+        modelOverrideFallbackOriginModel: "claude-sonnet-4-6",
+      },
+      expected: true,
+    },
+    {
+      name: "missing origin model",
+      entry: {
+        modelOverrideSource: "auto" as const,
+        modelOverrideFallbackOriginProvider: "anthropic",
+      },
+      expected: true,
+    },
+    {
+      name: "user override",
+      entry: { modelOverrideSource: "user" as const },
+      expected: false,
+    },
+    {
+      name: "unmarked override",
+      entry: {},
+      expected: false,
+    },
+  ])("returns $expected for $name", ({ entry, expected }) => {
+    expect(hasLegacyAutoFallbackWithoutOrigin(entry)).toBe(expected);
+  });
+
+  it("returns false for a missing entry", () => {
+    expect(hasLegacyAutoFallbackWithoutOrigin(undefined)).toBe(false);
+  });
+});
 
 describe("hasSessionActiveAutoModelFallback", () => {
   it.each([

--- a/src/config/sessions/model-override-provenance.ts
+++ b/src/config/sessions/model-override-provenance.ts
@@ -2,6 +2,25 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionEntry } from "./types.js";
 
+/** Detects old auto-fallback session entries that lack primary-origin metadata. */
+export function hasLegacyAutoFallbackWithoutOrigin(
+  entry:
+    | Pick<
+        SessionEntry,
+        | "modelOverrideSource"
+        | "modelOverrideFallbackOriginProvider"
+        | "modelOverrideFallbackOriginModel"
+      >
+    | null
+    | undefined,
+): boolean {
+  return (
+    entry?.modelOverrideSource === "auto" &&
+    (!normalizeOptionalString(entry.modelOverrideFallbackOriginProvider) ||
+      !normalizeOptionalString(entry.modelOverrideFallbackOriginModel))
+  );
+}
+
 /** Detects model overrides created by automatic fallback provenance. */
 export function hasSessionAutoModelFallbackProvenance(
   entry:

--- a/src/status/summary.runtime.ts
+++ b/src/status/summary.runtime.ts
@@ -15,6 +15,7 @@ import { waitForContextWindowCacheLoad } from "../agents/context.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { parseModelRef, resolvePersistedSelectedModelRef } from "../agents/model-selection.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
+import { hasLegacyAutoFallbackWithoutOrigin } from "../config/sessions/model-override-provenance.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveStoredSessionKeyForAgentStore } from "../gateway/session-store-key.js";
@@ -154,7 +155,16 @@ function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
     | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
+    | Pick<
+        SessionEntry,
+        | "model"
+        | "modelProvider"
+        | "modelOverride"
+        | "providerOverride"
+        | "modelOverrideSource"
+        | "modelOverrideFallbackOriginProvider"
+        | "modelOverrideFallbackOriginModel"
+      >,
   agentId?: string,
 ): { provider: string; model: string } {
   const resolved = resolveConfiguredStatusModelRef({
@@ -164,11 +174,16 @@ function resolveSessionModelRef(
     agentId,
   });
   const defaultProvider = resolved.provider || DEFAULT_PROVIDER;
+  // Legacy auto-fallback pins have no trustworthy origin and are ignored by
+  // execution. Status must not resurrect them ahead of the live runtime model.
+  const ignoreStoredOverride = hasLegacyAutoFallbackWithoutOrigin(entry);
+  const overrideProvider = ignoreStoredOverride ? undefined : entry?.providerOverride;
+  const overrideModel = ignoreStoredOverride ? undefined : entry?.modelOverride;
   const providerlessPersisted =
     resolveProviderlessPersistedStatusModelRef({
       defaultProvider,
-      provider: entry?.providerOverride,
-      model: entry?.modelOverride,
+      provider: overrideProvider,
+      model: overrideModel,
     }) ??
     resolveProviderlessPersistedStatusModelRef({
       defaultProvider,
@@ -184,8 +199,8 @@ function resolveSessionModelRef(
       defaultProvider,
       runtimeProvider: entry?.modelProvider,
       runtimeModel: entry?.model,
-      overrideProvider: entry?.providerOverride,
-      overrideModel: entry?.modelOverride,
+      overrideProvider,
+      overrideModel,
       allowManifestNormalization: false,
       allowPluginNormalization: false,
     }) ?? resolved


### PR DESCRIPTION
Related: #92776

Tracking: https://github.com/thomasmoenco/the-pantheon-hub/issues/2294

AI-assisted contribution. I reviewed the resulting code and understand the changed routing and display behavior.

## What Problem This Solves

Fixes an issue where recovered sessions could still route or report a stale fallback model when their automatic fallback pin came from an older store without primary-origin metadata.

The affected session could be running successfully on its configured primary while `status` and `sessions` still showed the old fallback. Gateway admission could also resolve the stale pin before the agent loop had a chance to clear it.

## Why This Change Was Made

The existing legacy auto-fallback detector now lives with session override provenance and is applied consistently at the canonical session-model admission resolver and both operator-facing model displays.

Only `modelOverrideSource: "auto"` entries missing origin metadata are ignored. Explicit user overrides and automatic fallbacks with complete origin metadata retain their existing behavior. This change does not mutate session state or add a migration.

## User Impact

Recovered sessions continue on the configured primary instead of being routed backward by stale legacy metadata. `openclaw status` and `openclaw sessions` report the live runtime model for the same state.

## Evidence

- Regression-first proof: the new admission, status, and sessions tests each failed by selecting `anthropic/claude-sonnet-4-6` instead of the recovered `openai/gpt-5.6-sol` before the fix.
- `node scripts/run-vitest.mjs src/config/sessions/model-override-provenance.test.ts src/agents/agent-scope.test.ts src/agents/session-model-ref.test.ts src/commands/status.summary.runtime.test.ts src/commands/status.summary.runtime.normalization.test.ts src/commands/status.summary.test.ts src/commands/sessions.model-resolution.test.ts` — 7 files, 113 tests passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` — passed.
- Targeted `scripts/run-oxlint.mjs` and `oxfmt --check` on all 11 changed files — passed.
- `git diff --check` — passed.

The repository's `autoreview` skill was not available in this environment; I performed a manual owner/caller/callee/sibling review instead.


## Exact-head runtime proof (2026-08-09)

- PR head: `742285eeedaae64b1ed8f35f7b44e4a03730790e`; CI merge build: `244173d0e322861c7cc4e3033c967c3fef301f6e`.
- Isolated recovered-session fixture: runtime/config `openai/gpt-5.6-sol`; originless persisted auto-pin `anthropic/claude-sonnet-4-6`; stale auto auth-profile metadata.
- `status` before/after: `selectedModel=openai/gpt-5.6-sol`, `modelSelectionReason=null`.
- `sessions` before: displayed `openai/gpt-5.6-sol` while retaining the seeded legacy pin; after the successful turn: Sol displayed and pin absent.
- Gateway admission: requested/effective `openai/gpt-5.6-sol`, `rerouted=false`; mock provider saw only `POST /v1/responses model=gpt-5.6-sol`.
- Canonical persisted row after success: model/provider/auth automatic override fields all absent.
- Full redacted transcript: https://github.com/openclaw/openclaw/pull/115808#issuecomment-5230887191
- Exact-head CI: 55 jobs passed. The only underlying failure is unrelated current-base plugin-SDK manifest drift: https://github.com/openclaw/openclaw/actions/runs/31306088717/job/93226672730
- No live package root, production state, gateway, or fleet was mutated or restarted.
