### PR TITLE
fix(ci): stabilize logs stderr tail test

### DIFF
--- a/src/cli/logs-cli.runtime.test.ts
+++ b/src/cli/logs-cli.runtime.test.ts
@@ -40,7 +40,7 @@ describe("execFileUtf8Tail", () => {
   it("keeps a bounded stderr tail for failed commands", async () => {
     const result = await execFileUtf8Tail(
       process.execPath,
-      ["-e", "process.stderr.write('😀' + 'x'.repeat(64 * 1024)); process.exit(1)"],
+      ["-e", "require('node:fs').writeSync(2, '😀' + 'x'.repeat(64 * 1024)); process.exit(1)"],
       { maxBytes: 1024 },
     );
     expect(result.code).toBe(1);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the `checks-node-compact-small-7` CI shard could fail
when the stderr-tail fixture exited before Node flushed an asynchronous
`process.stderr.write`. The failure blocked otherwise-green hook pull requests
with a test-only race.

## Why This Change Was Made

The fixture now writes the same UTF-8 payload synchronously to file descriptor
2 before exiting. Production stderr capture and truncation behavior are
unchanged; only the test producer is made deterministic.

## User Impact

No product behavior changes. CI reliably verifies the existing bounded,
UTF-8-safe stderr-tail contract.

## Evidence

- Reproduced the original failure on the current `main` test.
- Focused `src/cli/logs-cli.runtime.test.ts`: 8/8 passed under CI Node 24.18.0.
- `oxfmt --check` and `git diff --check`: passed.
- Fresh commit autoreview: clean, 0.99 confidence.
- Repository oxlint wrapper could not start because the shared linked-worktree
  install currently lacks `tsx`; no dependency reconciliation was performed.
  Exact-head hosted CI remains the authoritative lint gate.
