### PR TITLE
fix(sessions): deliver agent announcements to direct message sessions

### DIFF
--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -6,7 +6,10 @@
 import { normalizeOptionalStringifiedId } from "@openclaw/normalization-core/string-coerce";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { CallGatewayOptions } from "../../gateway/call.js";
-import { parseThreadSessionSuffix } from "../../sessions/session-key-utils.js";
+import {
+  parseSessionDeliveryRoute,
+  parseThreadSessionSuffix,
+} from "../../sessions/session-key-utils.js";
 import type { GatewaySessionListRow } from "./sessions-helpers.js";
 import type { AnnounceTarget } from "./sessions-send-helpers.js";
 import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
@@ -31,7 +34,12 @@ export async function resolveAnnounceTarget(params: {
   if (fallback) {
     const normalized = normalizeChannelId(fallback.channel);
     const plugin = normalized ? getChannelPlugin(normalized) : null;
-    if (!plugin?.meta?.preferSessionLookupForAnnounceTarget) {
+    const route =
+      parseSessionDeliveryRoute(params.sessionKey) ?? parseSessionDeliveryRoute(params.displayKey);
+    // Stored DM delivery context carries the authoritative account and thread;
+    // use the parsed address only when that exact session has no saved route.
+    const isDirectRoute = route?.peerKind === "direct" || route?.peerKind === "dm";
+    if (!isDirectRoute && !plugin?.meta?.preferSessionLookupForAnnounceTarget) {
       return fallback;
     }
   }

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -2,6 +2,10 @@
 // turn limits for agent-to-agent announce flows.
 import { beforeEach, describe, expect, it } from "vitest";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
 import {
   buildAgentToAgentMessageContext,
@@ -68,6 +72,120 @@ describe("resolveAnnounceTargetFromKey", () => {
     ).toEqual({
       channel: "feishu",
       to: "oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+      threadId: undefined,
+    });
+  });
+
+  it.each([
+    {
+      name: "direct",
+      sessionKey: "agent:main:feishu:direct:ou_recipient",
+      expected: { channel: "feishu", to: "user:ou_recipient", threadId: undefined },
+    },
+    {
+      name: "dm alias",
+      sessionKey: "agent:main:feishu:dm:ou_recipient",
+      expected: { channel: "feishu", to: "user:ou_recipient", threadId: undefined },
+    },
+    {
+      name: "account-scoped direct",
+      sessionKey: "agent:main:feishu:work:direct:ou_recipient",
+      expected: {
+        channel: "feishu",
+        to: "user:ou_recipient",
+        accountId: "work",
+        threadId: undefined,
+      },
+    },
+    {
+      name: "account-scoped dm alias",
+      sessionKey: "agent:main:feishu:work:dm:ou_recipient",
+      expected: {
+        channel: "feishu",
+        to: "user:ou_recipient",
+        accountId: "work",
+        threadId: undefined,
+      },
+    },
+    {
+      name: "thread-scoped direct",
+      sessionKey: "agent:main:feishu:direct:ou_recipient:thread:topic-42",
+      expected: {
+        channel: "feishu",
+        to: "user:ou_recipient",
+        threadId: "topic-42",
+      },
+    },
+    {
+      name: "unregistered channel",
+      sessionKey: "agent:main:wecom:direct:opaque-recipient",
+      expected: {
+        channel: "wecom",
+        to: "user:opaque-recipient",
+        threadId: undefined,
+      },
+    },
+  ])(
+    "resolves $name announce targets without session-list delivery context",
+    ({ sessionKey, expected }) => {
+      expect(resolveAnnounceTargetFromKey(sessionKey)).toEqual(expected);
+    },
+  );
+
+  it("does not reinterpret a nested agent session as an external direct target", () => {
+    expect(
+      resolveAnnounceTargetFromKey("agent:main:agent:other:feishu:direct:ou_recipient"),
+    ).toBeNull();
+  });
+
+  it("keeps a safe user target when a direct delivery resolver returns null", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "feishu",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "feishu" }),
+            messaging: {
+              normalizeTarget: (target: string) => target,
+              resolveDeliveryTarget: () => null,
+            },
+          },
+        },
+      ]),
+    );
+
+    expect(resolveAnnounceTargetFromKey("agent:main:feishu:direct:ou_recipient")).toEqual({
+      channel: "feishu",
+      to: "user:ou_recipient",
+      threadId: undefined,
+    });
+  });
+
+  it("does not let a room delivery resolver convert a direct user into a channel", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "slack" }),
+            messaging: {
+              directTargetStyle: "user-prefixed",
+              targetIdComparison: "lowercase",
+              normalizeTarget: (target: string) => target.toLowerCase(),
+              resolveDeliveryTarget: ({ conversationId }: { conversationId: string }) => ({
+                to: `channel:${conversationId}`,
+              }),
+            },
+          },
+        },
+      ]),
+    );
+
+    expect(resolveAnnounceTargetFromKey("agent:main:slack:direct:U09G2DJ0275")).toEqual({
+      channel: "slack",
+      to: "user:u09g2dj0275",
       threadId: undefined,
     });
   });

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -9,6 +9,7 @@ import {
 } from "../../channels/plugins/index.js";
 import { resolveSessionConversationRef } from "../../channels/plugins/session-conversation.js";
 import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
+import { parseSessionDeliveryRoute } from "../../sessions/session-key-utils.js";
 import { ANNOUNCE_SKIP_TOKEN, REPLY_SKIP_TOKEN } from "./sessions-send-tokens.js";
 export {
   isAnnounceSkip,
@@ -30,7 +31,31 @@ export type AnnounceTarget = {
 export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget | null {
   const parsed = resolveSessionConversationRef(sessionKey);
   if (!parsed) {
-    return null;
+    const directRoute = parseSessionDeliveryRoute(sessionKey);
+    if (!directRoute || (directRoute.peerKind !== "direct" && directRoute.peerKind !== "dm")) {
+      return null;
+    }
+
+    const normalizedChannel =
+      normalizeAnyChannelId(directRoute.channel) ?? normalizeChatChannelId(directRoute.channel);
+    const channel = normalizedChannel ?? directRoute.channel;
+    const messaging = normalizedChannel
+      ? getChannelPlugin(normalizedChannel)?.messaging
+      : undefined;
+    // Session peers are canonical; adapters restore API casing at their boundary.
+    // Channel-style resolvers must not turn an explicit direct user into a room.
+    const resolvedTarget =
+      messaging?.directTargetStyle === "user-prefixed"
+        ? undefined
+        : messaging?.resolveDeliveryTarget?.({ conversationId: directRoute.peerId });
+    const directTarget = `user:${directRoute.peerId}`;
+
+    return {
+      channel,
+      to: resolvedTarget?.to?.trim() || messaging?.normalizeTarget?.(directTarget) || directTarget,
+      ...(directRoute.accountId ? { accountId: directRoute.accountId } : {}),
+      threadId: resolvedTarget?.threadId ?? directRoute.threadId,
+    };
   }
   const normalizedChannel =
     normalizeAnyChannelId(parsed.channel) ?? normalizeChatChannelId(parsed.channel);

--- a/src/gateway/server.sessions-send.direct-announce.test-support.ts
+++ b/src/gateway/server.sessions-send.direct-announce.test-support.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, vi } from "vitest";
+import { testing as agentStepTesting } from "../agents/tools/agent-step.test-support.js";
+import { runSessionsSendA2AFlow } from "../agents/tools/sessions-send-tool.a2a.js";
+import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { setTestPluginRegistry, testState, writeSessionStore } from "./test-helpers.js";
+
+export async function runDirectSessionAnnounceScenario(params: {
+  sessionKey: string;
+  expectedAccountId: string | undefined;
+}): Promise<void> {
+  const { sessionKey, expectedAccountId } = params;
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-direct-announce-"));
+  const sendCalls: Array<{
+    to?: string;
+    text?: string;
+    accountId?: string | null;
+  }> = [];
+  const feishuPlugin = createOutboundTestPlugin({
+    id: "feishu",
+    label: "Feishu",
+    outbound: {
+      deliveryMode: "direct",
+      resolveTarget: ({ to }) =>
+        to?.startsWith("user:")
+          ? { ok: true, to }
+          : { ok: false, error: new Error("expected a direct user target") },
+      sendText: async (ctx) => {
+        sendCalls.push({ to: ctx.to, text: ctx.text, accountId: ctx.accountId });
+        return { channel: "feishu", messageId: "direct-announce-proof" };
+      },
+    },
+    messaging: {
+      normalizeTarget: (raw) => raw,
+      resolveDeliveryTarget: ({ conversationId }) => ({ to: `user:${conversationId}` }),
+    },
+  });
+  setTestPluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "feishu",
+        source: "test",
+        plugin: {
+          ...feishuPlugin,
+          config: {
+            ...feishuPlugin.config,
+            listAccountIds: () => ["default", "work"],
+          },
+        },
+      },
+    ]),
+  );
+
+  testState.sessionStorePath = path.join(dir, "sessions.json");
+  try {
+    await writeSessionStore({
+      entries: {
+        [sessionKey]: {
+          sessionId: `direct-announce-${expectedAccountId ?? "default"}-${sessionKey.includes(":dm:") ? "dm" : "direct"}`,
+          updatedAt: Date.now(),
+        },
+      },
+    });
+    agentStepTesting.setDepsForTest({
+      agentCommandFromIngress: async () => ({
+        payloads: [{ text: "direct announcement delivered", mediaUrl: null }],
+        meta: { durationMs: 1 },
+      }),
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: sessionKey,
+      displayKey: sessionKey,
+      message: "announce to the direct session",
+      announceTimeoutMs: 5_000,
+      maxPingPongTurns: 0,
+      roundOneReply: "agent completed",
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(sendCalls).toHaveLength(1);
+        expect(sendCalls[0]).toMatchObject({
+          to: "user:ou_announce_recipient",
+          text: "direct announcement delivered",
+          ...(expectedAccountId ? { accountId: expectedAccountId } : {}),
+        });
+      },
+      { timeout: 5_000 },
+    );
+  } finally {
+    agentStepTesting.setDepsForTest();
+    testState.sessionStorePath = undefined;
+    await fs.rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  }
+}

--- a/src/gateway/server.sessions-send.test.ts
+++ b/src/gateway/server.sessions-send.test.ts
@@ -14,6 +14,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { captureEnv } from "../test-utils/env.js";
+import { runDirectSessionAnnounceScenario } from "./server.sessions-send.direct-announce.test-support.js";
 import {
   agentCommand,
   getFreePort,
@@ -187,6 +188,35 @@ describe("sessions_send gateway loopback", () => {
     expect(firstCall?.inputProvenance?.kind).toBe("inter_session");
     expect(firstCall?.inputProvenance?.sourceTool).toBe("sessions_send");
   });
+
+  it.each([
+    {
+      label: "direct",
+      sessionKey: "agent:main:feishu:direct:ou_announce_recipient",
+      expectedAccountId: undefined,
+    },
+    {
+      label: "dm alias",
+      sessionKey: "agent:main:feishu:dm:ou_announce_recipient",
+      expectedAccountId: undefined,
+    },
+    {
+      label: "account-scoped direct",
+      sessionKey: "agent:main:feishu:work:direct:ou_announce_recipient",
+      expectedAccountId: "work",
+    },
+    {
+      label: "account-scoped dm alias",
+      sessionKey: "agent:main:feishu:work:dm:ou_announce_recipient",
+      expectedAccountId: "work",
+    },
+  ])(
+    "delivers a $label session announcement through the authenticated Gateway without stored delivery context",
+    { timeout: SESSION_SEND_DM_ROUTING_E2E_TIMEOUT_MS },
+    async ({ sessionKey, expectedAccountId }) => {
+      await runDirectSessionAnnounceScenario({ sessionKey, expectedAccountId });
+    },
+  );
 
   it(
     "announces through gateway send using external deliveryContext over stale webchat session fields",


### PR DESCRIPTION
Closes #83046
Related: #83048

## What Problem This Solves

Fixes an issue where a completed agent-to-agent announcement silently disappears instead of reaching a direct-message conversation when the session uses a direct or dm key and has no persisted delivery context.

## Why This Change Was Made

Use the canonical structural session delivery parser to recognize direct and dm announcement targets, preserve account and thread identity, and let each channel own its outbound target normalization. Resolve persisted direct-session delivery context first so existing account, thread, and external-route behavior remains authoritative. Respect user-prefixed channel contracts so Slack and Discord direct messages cannot accidentally be delivered to a room.

## User Impact

Agent completion announcements reach direct-message recipients for ordinary, account-scoped, and dm-alias sessions, without breaking existing WhatsApp delivery, private routes, or group announcements.

## Evidence

- Fail-first real paired, token-authenticated Gateway: https://github.com/openclaw/openclaw/actions/runs/30438441120. All four actual direct/dm/account outbound announcement cases fail on current main, as do six structural regression cases, while all 28 existing Gateway cases remain green.
- Final remote Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30439105261. All 407 tests pass across 10 files and six Vitest projects, including 32 real authenticated Gateway cases, all four outbound regressions, preserved WhatsApp account/thread delivery, and the complete real SQLite session/transcript lifecycle.
- Independent gpt-5.6-sol xhigh structured autoreview: clean; confidence 0.98.
- Existing group/channel parser and plugin SDK remain unchanged; format and exact changed-file checks pass.

Thanks to @avatasia for identifying the issue and proposing #83048. The landed change preserves the original contributor through a Co-authored-by trailer.