### PR TITLE
fix(zalo): normalize prefixed Bot API delivery targets

### DIFF
--- a/extensions/zalo/src/channel.target-prefix.integration.test.ts
+++ b/extensions/zalo/src/channel.target-prefix.integration.test.ts
@@ -1,0 +1,149 @@
+// Prove configured Zalo delivery against the actual Bot API HTTP boundary.
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { zaloPlugin } from "./channel.js";
+import type { OpenClawConfig } from "./runtime-api.js";
+
+type RecordedZaloRequest = {
+  body: Record<string, unknown>;
+  method: string;
+};
+
+const originalZaloApiUrl = process.env.ZALO_API_URL;
+const cfg = {
+  channels: {
+    zalo: {
+      accounts: {
+        default: {
+          botToken: "test-bot-token",
+        },
+      },
+    },
+  },
+} as OpenClawConfig;
+
+async function readJsonBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  let body = "";
+  for await (const chunk of request) {
+    body += String(chunk);
+  }
+  return JSON.parse(body) as Record<string, unknown>;
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback Zalo Bot API address");
+  }
+  return `http://127.0.0.1:${String(address.port)}`;
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe("configured Zalo outbound target delivery", () => {
+  let server: Server;
+  let requests: RecordedZaloRequest[];
+
+  beforeEach(async () => {
+    requests = [];
+    server = createServer((request, response) => {
+      void (async () => {
+        const method = request.url?.match(/\/bot[^/]+\/([^/?]+)/u)?.[1] ?? "unknown";
+        const body = await readJsonBody(request);
+        requests.push({ body, method });
+
+        const chatId = typeof body.chat_id === "string" ? body.chat_id : "";
+        const isBareChatId = Boolean(chatId) && !/^(?:zalo|zl|group|user|dm):/iu.test(chatId);
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify(
+            isBareChatId
+              ? {
+                  ok: true,
+                  result: {
+                    message_id: `${method}-delivered`,
+                  },
+                }
+              : {
+                  ok: false,
+                  error_code: 400,
+                  description: "chat_id must be a bare Zalo conversation ID",
+                },
+          ),
+        );
+      })().catch((error: unknown) => {
+        response.writeHead(500, { "content-type": "application/json" });
+        response.end(JSON.stringify({ ok: false, description: String(error) }));
+      });
+    });
+    process.env.ZALO_API_URL = await listen(server);
+  });
+
+  afterEach(async () => {
+    if (originalZaloApiUrl === undefined) {
+      delete process.env.ZALO_API_URL;
+    } else {
+      process.env.ZALO_API_URL = originalZaloApiUrl;
+    }
+    await close(server);
+  });
+
+  it.each([
+    { target: "zalo:group:group-123", peer: "group-123", kind: "text" },
+    { target: "zl:user:direct-456", peer: "direct-456", kind: "text" },
+    { target: "group:group-789", peer: "group-789", kind: "media" },
+    { target: "zalo:dm:direct-987", peer: "direct-987", kind: "media" },
+  ] as const)(
+    "sends $kind to the same bare peer selected by the session route ($target)",
+    async ({ target, peer, kind }) => {
+      const route = await zaloPlugin.messaging?.resolveOutboundSessionRoute?.({
+        cfg,
+        agentId: "main",
+        accountId: "default",
+        target,
+      });
+      expect(route?.peer.id).toBe(peer);
+
+      if (kind === "text") {
+        const sendText = zaloPlugin.outbound?.sendText;
+        if (!sendText) {
+          throw new Error("expected configured Zalo outbound text adapter");
+        }
+        const result = await sendText({ cfg, to: target, text: "proof" });
+        expect(result.messageId).toBe("sendMessage-delivered");
+        expect(requests).toEqual([
+          {
+            method: "sendMessage",
+            body: { chat_id: peer, text: "proof" },
+          },
+        ]);
+        return;
+      }
+
+      const sendMedia = zaloPlugin.outbound?.sendMedia;
+      if (!sendMedia) {
+        throw new Error("expected configured Zalo outbound media adapter");
+      }
+      const mediaUrl = "https://93.184.216.34/proof.png";
+      const result = await sendMedia({ cfg, to: target, text: "proof", mediaUrl });
+      expect(result.messageId).toBe("sendPhoto-delivered");
+      expect(requests).toEqual([
+        {
+          method: "sendPhoto",
+          body: { chat_id: peer, photo: mediaUrl, caption: "proof" },
+        },
+      ]);
+    },
+  );
+});

--- a/extensions/zalo/src/send.test.ts
+++ b/extensions/zalo/src/send.test.ts
@@ -131,6 +131,43 @@ describe("zalo send", () => {
     );
   });
 
+  it("normalizes provider and target-kind prefixes before calling the Bot API", async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      result: { message_id: "z-msg-prefixed" },
+    });
+    sendPhotoMock.mockResolvedValueOnce({
+      ok: true,
+      result: { message_id: "z-photo-prefixed" },
+    });
+
+    await sendMessageZalo("zalo:group:dm-chat-prefixed-text", "hello", {
+      token: "zalo-token",
+    });
+    await sendMessageZalo("zl:user:dm-chat-prefixed-photo", "", {
+      token: "zalo-token",
+      mediaUrl: "https://example.com/photo.jpg",
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      "zalo-token",
+      {
+        chat_id: "dm-chat-prefixed-text",
+        text: "hello",
+      },
+      undefined,
+    );
+    expect(sendPhotoMock).toHaveBeenCalledWith(
+      "zalo-token",
+      {
+        chat_id: "dm-chat-prefixed-photo",
+        photo: "https://example.com/photo.jpg",
+        caption: undefined,
+      },
+      undefined,
+    );
+  });
+
   it("fails fast for missing token or blank photo URLs", async () => {
     const missingToken = await sendMessageZalo("dm-chat-3", "hello", {});
     expectFailedSend(missingToken, "No Zalo bot token configured");

--- a/extensions/zalo/src/send.ts
+++ b/extensions/zalo/src/send.ts
@@ -5,6 +5,7 @@ import {
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { stripChannelTargetPrefix, stripTargetKindPrefix } from "openclaw/plugin-sdk/core";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveZaloAccount } from "./accounts.js";
@@ -119,11 +120,15 @@ function resolveValidatedSendContext(
   if (!token) {
     return { ok: false, error: "No Zalo bot token configured" };
   }
-  const trimmedChatId = chatId?.trim();
+  const trimmedChatId = normalizeZaloSendChatId(chatId);
   if (!trimmedChatId) {
     return { ok: false, error: "No chat_id provided" };
   }
   return { ok: true, chatId: trimmedChatId, token, fetcher };
+}
+
+function normalizeZaloSendChatId(chatId: string): string {
+  return stripTargetKindPrefix(stripChannelTargetPrefix(chatId, "zalo", "zl"));
 }
 
 function resolveSendContextOrFailure(


### PR DESCRIPTION
Related: #106171

## What Problem This Solves

Fixes an issue where Zalo users sending text or a photo to a prefixed direct-message or group target would have delivery rejected by the Zalo Bot API because the transport received the OpenClaw routing prefix as part of `chat_id`.

## Why This Change Was Made

Preserves @lzw112’s original production fix and regression test from #106171: normalize channel and target-kind prefixes at the Zalo plugin’s outbound send boundary before either Bot API send method. Adds actual configured-plugin-to-HTTP-server proof for both direct-message and group aliases, while retaining dotted bare Zalo IDs. No core changes, configuration changes, compatibility shims, or new dependencies.

The provider contract requires the actual conversation `chat_id`, not an OpenClaw routing alias: https://docs.zaloplatforms.com/docs/BOT/apis/sendMessage and https://docs.zaloplatforms.com/docs/BOT/apis/sendPhoto.

The contributor’s original pull request has a stale test conflict and failing lint on its original head, so this successor preserves the original exact normalization fix and regression test on current main and credits the original contributor explicitly through `Co-authored-by: lzw112 <wang.lizhang@xydigit.com>`.

## User Impact

Zalo direct and group conversations can successfully receive text and photos when OpenClaw addresses them as `zalo:group:…`, `zl:user:…`, `group:…`, or `zalo:dm:…`. Outbound receipts and resolved session peers retain their canonical bare conversation IDs.

## Evidence

- Reproduced the actual main-branch failure against a real local TCP/HTTP Bot API endpoint: all four configured-plugin text/photo, direct/group cases failed with `chat_id must be a bare Zalo conversation ID`, while all eight adjacent control tests passed.
- With the fix, all four same real HTTP cases pass through the real configured outbound adapter, lazy runtime import, production Bot API `fetch`, route resolution, API request body, and receipt handling. Neither the outbound adapter nor HTTP fetch is mocked.
- Exact reviewed-tree remote Testbox: `pnpm check:changed` and `pnpm test extensions/zalo/src`; all changed-surface guards, production and test TypeScript lanes, **22 test files and 143 tests passed**. Testbox timing JSON: `exitCode: 0`; https://github.com/openclaw/openclaw/actions/runs/30439105237. Blacksmith’s one-shot lifecycle can mark the backing workflow cancelled after its successful command and clean lease stop; the authoritative Testbox timing JSON and all test output are successful.
- Fresh xhigh branch autoreview: no findings, confidence 0.97.
- AI-assisted maintainer verification; original fix and regression test contributed by @lzw112.