### PR TITLE
fix(nostr): deliver oversized encrypted replies as ordered chunks

### DIFF
--- a/extensions/nostr/src/channel.outbound.test.ts
+++ b/extensions/nostr/src/channel.outbound.test.ts
@@ -126,6 +126,52 @@ describe("nostr outbound cfg threading", () => {
     expect(sanitizeText({ text, payload: { text } })).toBe(expected);
   });
 
+  it.each([
+    {
+      name: "preserves a short reply as one encrypted message",
+      text: "Hello from Nostr.",
+      expectedChunkCount: 1,
+      joinWith: "",
+    },
+    {
+      name: "splits long replies at word boundaries",
+      text: `${"word ".repeat(1_200)}final`,
+      expectedChunkCount: 2,
+      joinWith: " ",
+    },
+    {
+      name: "preserves newline-delimited reply order",
+      text: `${"line\n".repeat(1_200)}final`,
+      expectedChunkCount: 2,
+      joinWith: "\n",
+    },
+    {
+      name: "hard-splits an uninterrupted oversized reply",
+      text: "x".repeat(8_001),
+      expectedChunkCount: 3,
+      joinWith: "",
+    },
+    {
+      name: "preserves Unicode when an odd prefix shifts the chunk boundary",
+      text: `a${"😀".repeat(2_500)}`,
+      expectedChunkCount: 2,
+      joinWith: "",
+    },
+  ])("$name", ({ text, expectedChunkCount, joinWith }) => {
+    const outbound = nostrPlugin.outbound;
+    const textChunkLimit = outbound?.textChunkLimit;
+    expect(textChunkLimit).toBe(4_000);
+    expect(outbound?.chunker).toBeTypeOf("function");
+    if (!outbound?.chunker || textChunkLimit === undefined) {
+      throw new Error("Expected Nostr outbound text chunking");
+    }
+
+    const chunks = outbound.chunker(text, textChunkLimit);
+    expect(chunks).toHaveLength(expectedChunkCount);
+    expect(chunks.every((chunk) => chunk.length <= textChunkLimit)).toBe(true);
+    expect(chunks.join(joinWith)).toBe(text);
+  });
+
   it("converts tables before projecting markdown to Nostr plain text", async () => {
     const { resolveMarkdownTableMode, convertMarkdownTables } = installOutboundRuntime(
       vi.fn((text: string) => (text === "***" ? text : "**Table:** [docs](https://example.com)")),

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -10,7 +10,11 @@ import {
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { sanitizeAssistantVisibleText, stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
+import {
+  chunkTextForOutbound,
+  sanitizeAssistantVisibleText,
+  stripMarkdown,
+} from "openclaw/plugin-sdk/text-chunking";
 import type { ChannelOutboundAdapter, ChannelPlugin } from "./channel-api.js";
 import type { MetricEvent, MetricsSnapshot } from "./metrics.js";
 import { startNostrBus, type NostrBusHandle } from "./nostr-bus.js";
@@ -23,7 +27,7 @@ type NostrGatewayStart = NonNullable<
 >;
 type NostrOutboundAdapter = Pick<
   ChannelOutboundAdapter,
-  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sendText"
+  "chunker" | "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sendText"
 > & {
   sendText: NonNullable<ChannelOutboundAdapter["sendText"]>;
   sanitizeText: NonNullable<ChannelOutboundAdapter["sanitizeText"]>;
@@ -316,6 +320,9 @@ export const nostrPairingTextAdapter = {
 export const nostrOutboundAdapter: NostrOutboundAdapter = {
   deliveryMode: "direct",
   textChunkLimit: 4000,
+  // The outbound planner ignores textChunkLimit unless the adapter also
+  // supplies its chunker, causing oversized encrypted events to be rejected.
+  chunker: chunkTextForOutbound,
   sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   deliveryCapabilities: {
     durableFinal: {


### PR DESCRIPTION
Supersedes: #115485

## What Problem This Solves

Fixes an issue where Nostr recipients receive no reply when a long encrypted direct message exceeds a relay's advertised or enforced WebSocket-message limit. The Nostr channel already declares a 4,000-character outbound limit, but the existing production send planner does not apply a limit unless the channel also supplies its chunker.

## Why This Change Was Made

Connect Nostr's existing outbound limit to the canonical, surrogate-safe Plugin SDK text chunker, following the existing IRC and Microsoft Teams channel contracts. Preserve the recently landed assistant-visible sanitizer, the actual NIP-04 encryption and signature path, recipient tags, relay-confirmed delivery receipts, ordering, existing configuration, plugin boundaries, and short-message behavior.

Relay limits are relay-specific under NIP-11; the 4,000-character channel limit is not claimed to be a universal byte-size guarantee.

## User Impact

Long Nostr replies arrive as ordered, individually signed and encrypted messages instead of disappearing when a relay rejects the oversized event. Ordinary short replies remain one message. Words, newlines, uninterrupted text, and Unicode characters at deliberately misaligned surrogate boundaries remain intact.

## Evidence

- Independently reproduced **five failing regressions on current main**; the ten pre-existing Nostr outbound/privacy tests continued to pass.
- Real before proof on a **12,288-byte size-enforcing loopback Nostr WebSocket relay**: the actual gateway and NIP-04 sender attempted one **36,464-byte** event, received the real negative NIP-01 relay acknowledgement, and produced no delivery receipt.
- Real after proof: **5/5** actual-gateway scenarios use the real core outbound planner, pinned `nostr-tools`, signed kind-4 events, genuine NIP-04 encryption, per-event size enforcement, recipient-side decryption, exact `p` tags, relay-confirmed event receipts, and full message ordering. Scenarios cover short messages, word boundaries, newline boundaries, long uninterrupted text, and an odd-prefix Unicode surrogate boundary.
- Blacksmith Testbox `tbx_01kypjdpj2788r61mdkbm3d62a`: **720 tests passed** across all 265 Nostr tests, the canonical chunker and assistant-visible sanitizer, core outbound planning and delivery, all channel-shape and outbound payload contracts, and the IRC, Microsoft Teams, and LINE sibling paths.
- Full remote `pnpm check:changed`: passed, including production/test typechecking, formatting, lint, plugin/SDK boundaries, database-first storage, dead exports, and import cycles.
- Fresh independent `gpt-5.6-sol` extra-high-effort autoreview: **clean**, confidence **0.88**. Its Unicode-boundary concern was independently disproved against the shared `avoidTrailingHighSurrogateBreak` implementation and explicitly covered by the final odd-prefix regression and real encrypted relay.
- Original two-file solution by @miorbnli in #115485 is preserved with `Co-authored-by: liyuanbin <li.yuanbin1@xydigit.com>`. The original fork PR cannot merge cleanly after the independently landed Nostr privacy fix, so this two-file successor preserves both changes on current main.
