### PR TITLE
fix(plugins): forward tool cancellation to hooks

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -97,9 +97,11 @@ positive integer up to 600000 ms. Prefer per-hook overrides for known-slow
 hooks so one plugin does not get a longer budget everywhere.
 
 A timed-out handler promise continues running because hook callbacks do not
-receive a cancellation signal. The hook dispatch can release its Gateway
-admission while that plugin work is still in progress. Plugins that own
-long-running work must provide their own cancellation and shutdown lifecycle.
+receive a timeout-owned cancellation signal. `before_tool_call` receives the
+owning tool call's `ctx.abortSignal`, but hook timeout expiry does not abort it.
+The hook dispatch can release its Gateway admission while that plugin work is
+still in progress. Plugins that own long-running work must provide their own
+cancellation and shutdown lifecycle.
 
 Policy hooks `before_tool_call` and `before_install` use a 15-second default per
 handler. A timeout fails closed: the tool call or installation is rejected
@@ -309,6 +311,9 @@ provider payloads, start the Gateway with `--raw-stream` and
 - optional `event.toolCallId`
 - context fields such as `ctx.agentId`, `ctx.sessionKey`, `ctx.sessionId`,
   `ctx.runId`, `ctx.toolKind`, `ctx.toolInputKind`, and diagnostic `ctx.trace`
+- optional `ctx.abortSignal`, which aborts when the owning tool call is
+  cancelled; handlers should pass it to cancellable I/O and remove any
+  listeners they register
 - optional `ctx.requester`, the host-derived requester that initiated the current
   message run. It can include `channel`, `accountId`, `senderId`,
   `senderIsOwner`, and provider-native `roleIds`. Missing fields are unproven,

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -370,6 +370,7 @@ export function toToolDefinitions(
               ...hookMetadata,
               toolCallId,
               ctx: hookContext,
+              signal,
             });
             if (hookOutcome.blocked) {
               if (hookOutcome.kind === "veto") {
@@ -491,7 +492,7 @@ export function toClientToolDefinitions(
       description: func.description ?? "",
       parameters: func.parameters as ToolDefinition["parameters"],
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
-        const { toolCallId, params } = splitToolExecuteArgs(args);
+        const { toolCallId, params, signal } = splitToolExecuteArgs(args);
         if (onClientToolCall && typeof onClientToolCall !== "function") {
           onClientToolCall.reserve?.(toolCallId, func.name);
         }
@@ -502,6 +503,7 @@ export function toClientToolDefinitions(
             params: initialParamsRecord,
             toolCallId,
             ctx: hookContext,
+            signal,
           });
           if (outcome.blocked) {
             if (onClientToolCall && typeof onClientToolCall !== "function") {

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -779,6 +779,7 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     if (!execTool) {
       throw new Error("missing code-mode exec tool");
     }
+    const abortSignal = new AbortController().signal;
     const wrapped = wrapToolWithAbortSignal(
       wrapToolWithBeforeToolCallHook(execTool, {
         agentId: "main",
@@ -786,7 +787,7 @@ describe("before_tool_call hook deduplication (#15502)", () => {
         sessionId: "session-main",
         runId: "run-main",
       }),
-      new AbortController().signal,
+      abortSignal,
     );
     const [def] = toToolDefinitions([wrapped]);
     if (!def) {
@@ -824,6 +825,7 @@ describe("before_tool_call hook deduplication (#15502)", () => {
         sessionKey: "agent:main:main",
         sessionId: "session-main",
         runId: "run-main",
+        abortSignal,
         toolCallId: "call-wrapped-code-mode-exec",
       },
     );
@@ -1318,6 +1320,66 @@ describe("before_tool_call adapter and client tool integration", () => {
     setActivePluginRegistry(createEmptyPluginRegistry());
     resetClientVoiceConfirmationStateForTest();
     vi.restoreAllMocks();
+  });
+
+  it.each(["wrapped", "adapter"] as const)(
+    "forwards the owning tool-call signal through the %s path",
+    async (pathKind) => {
+      const controller = new AbortController();
+      const seenSignals: Array<AbortSignal | undefined> = [];
+      installBeforeToolCallHook({
+        runBeforeToolCallImpl: async (_event, ctx) => {
+          seenSignals.push((ctx as { abortSignal?: AbortSignal }).abortSignal);
+        },
+      });
+      const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+      const sourceTool = asAgentTool({ name: "read", execute });
+      const tool = pathKind === "wrapped" ? wrapToolWithBeforeToolCallHook(sourceTool) : sourceTool;
+      const definition = expectDefined(toToolDefinitions([tool])[0], `${pathKind} tool definition`);
+
+      await definition.execute(
+        `call-signal-${pathKind}`,
+        { path: "/tmp/input" },
+        controller.signal,
+        undefined,
+        {} as ExtensionContext,
+      );
+
+      expect(seenSignals).toEqual([controller.signal]);
+    },
+  );
+
+  it("forwards the owning tool-call signal to client-tool hooks", async () => {
+    const controller = new AbortController();
+    let seenSignal: AbortSignal | undefined;
+    installBeforeToolCallHook({
+      runBeforeToolCallImpl: async (_event, ctx) => {
+        seenSignal = (ctx as { abortSignal?: AbortSignal }).abortSignal;
+      },
+    });
+    const tool = expectDefined(
+      toClientToolDefinitions([
+        {
+          type: "function",
+          function: {
+            name: "client_tool",
+            description: "Client tool",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ])[0],
+      "client tool definition",
+    );
+
+    await tool.execute(
+      "client-call-signal",
+      {},
+      controller.signal,
+      undefined,
+      {} as ExtensionContext,
+    );
+
+    expect(seenSignal).toBe(controller.signal);
   });
 
   it("passes modified params to client tool callbacks", async () => {

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -1309,6 +1309,42 @@ describe("before_tool_call hook deduplication (#15502)", () => {
 });
 
 describe("before_tool_call adapter and client tool integration", () => {
+  function installAbortBlockingHook() {
+    let markStarted: () => void = () => {};
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let observedAbort = false;
+    installBeforeToolCallHook({
+      runBeforeToolCallImpl: async (_event, ctx) => {
+        const signal = (ctx as { abortSignal?: AbortSignal }).abortSignal;
+        markStarted();
+        if (signal) {
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) {
+              observedAbort = true;
+              resolve();
+              return;
+            }
+            signal.addEventListener(
+              "abort",
+              () => {
+                observedAbort = true;
+                resolve();
+              },
+              { once: true },
+            );
+          });
+        }
+        return { block: true, blockReason: "cancelled by owning tool call" };
+      },
+    });
+    return {
+      started,
+      didObserveAbort: () => observedAbort,
+    };
+  }
+
   beforeEach(() => {
     resetGlobalHookRunner();
     resetDiagnosticSessionStateForTest();
@@ -1323,63 +1359,71 @@ describe("before_tool_call adapter and client tool integration", () => {
   });
 
   it.each(["wrapped", "adapter"] as const)(
-    "forwards the owning tool-call signal through the %s path",
+    "cancels before-tool hook work through the %s path",
     async (pathKind) => {
       const controller = new AbortController();
-      const seenSignals: Array<AbortSignal | undefined> = [];
-      installBeforeToolCallHook({
-        runBeforeToolCallImpl: async (_event, ctx) => {
-          seenSignals.push((ctx as { abortSignal?: AbortSignal }).abortSignal);
-        },
-      });
+      const hook = installAbortBlockingHook();
       const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
       const sourceTool = asAgentTool({ name: "read", execute });
       const tool = pathKind === "wrapped" ? wrapToolWithBeforeToolCallHook(sourceTool) : sourceTool;
       const definition = expectDefined(toToolDefinitions([tool])[0], `${pathKind} tool definition`);
 
-      await definition.execute(
+      const execution = definition.execute(
         `call-signal-${pathKind}`,
         { path: "/tmp/input" },
         controller.signal,
         undefined,
         {} as ExtensionContext,
       );
+      await hook.started;
+      controller.abort(new Error("cancel test"));
+      await execution;
 
-      expect(seenSignals).toEqual([controller.signal]);
+      expect(hook.didObserveAbort()).toBe(true);
+      expect(execute).not.toHaveBeenCalled();
     },
   );
 
-  it("forwards the owning tool-call signal to client-tool hooks", async () => {
+  it("cancels client-tool hook work and releases its reservation", async () => {
     const controller = new AbortController();
-    let seenSignal: AbortSignal | undefined;
-    installBeforeToolCallHook({
-      runBeforeToolCallImpl: async (_event, ctx) => {
-        seenSignal = (ctx as { abortSignal?: AbortSignal }).abortSignal;
-      },
-    });
+    const hook = installAbortBlockingHook();
+    const recorder = {
+      reserve: vi.fn(),
+      complete: vi.fn(),
+      discard: vi.fn(),
+    };
     const tool = expectDefined(
-      toClientToolDefinitions([
-        {
-          type: "function",
-          function: {
-            name: "client_tool",
-            description: "Client tool",
-            parameters: { type: "object", properties: {} },
+      toClientToolDefinitions(
+        [
+          {
+            type: "function",
+            function: {
+              name: "client_tool",
+              description: "Client tool",
+              parameters: { type: "object", properties: {} },
+            },
           },
-        },
-      ])[0],
+        ],
+        recorder,
+      )[0],
       "client tool definition",
     );
 
-    await tool.execute(
+    const execution = tool.execute(
       "client-call-signal",
       {},
       controller.signal,
       undefined,
       {} as ExtensionContext,
     );
+    await hook.started;
+    controller.abort(new Error("cancel test"));
+    await execution;
 
-    expect(seenSignal).toBe(controller.signal);
+    expect(hook.didObserveAbort()).toBe(true);
+    expect(recorder.reserve).toHaveBeenCalledWith("client-call-signal", "client_tool");
+    expect(recorder.discard).toHaveBeenCalledWith("client-call-signal", "client_tool");
+    expect(recorder.complete).not.toHaveBeenCalled();
   });
 
   it("passes modified params to client tool callbacks", async () => {

--- a/src/agents/agent-tools.before-tool-call.policy.ts
+++ b/src/agents/agent-tools.before-tool-call.policy.ts
@@ -251,6 +251,7 @@ export async function runBeforeToolCallHook(args: {
       ...(args.ctx?.sessionKey && { sessionKey: args.ctx.sessionKey }),
       ...(args.ctx?.sessionId && { sessionId: args.ctx.sessionId }),
       ...(args.ctx?.runId && { runId: args.ctx.runId }),
+      ...(args.signal ? { abortSignal: args.signal } : {}),
       ...(args.ctx?.trace && { trace: freezeDiagnosticTraceContext(args.ctx.trace) }),
       ...(args.toolCallId && { toolCallId: args.toolCallId }),
       ...(args.ctx?.channelId && { channelId: args.ctx.channelId }),

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -693,6 +693,8 @@ export type PluginHookToolContext = {
   sessionKey?: string;
   sessionId?: string;
   runId?: string;
+  /** Aborts when the owning tool call is cancelled. Hook timeout expiry does not abort this signal. */
+  abortSignal?: AbortSignal;
   trace?: DiagnosticTraceContext;
   toolName: string;
   /** Host-authoritative discriminator for tools that intentionally share names. */


### PR DESCRIPTION
Related to #105622

## What Problem This Solves

Fixes an issue where asynchronous `before_tool_call` hook work could continue after the owning tool call was cancelled because the existing cancellation signal was not exposed to the hook context.

## Why This Change Was Made

The authoritative tool-call `AbortSignal` is forwarded through wrapped, adapter, policy, and client execution paths as an optional hook-context field. This is deliberately cooperative cancellation only: hook timeout expiry and plugin-owned descendant-process cleanup remain separate work tracked by #105622 and #115450.

## User Impact

Plugin hooks can stop cancellable pre-tool I/O promptly when the owning tool call is aborted. Existing hooks remain compatible because the field is additive and optional.

## Evidence

Exact head: `e528f8cfc6117788fbfd1e0f3520cf4751bc3cba`

- 35 focused `before_tool_call` integration tests passed on the patch-identical maintainer GWT.
- The tests observe actual abort events in wrapped, adapter, and client paths; they also prove the tool body does not run and client reservations are discarded.
- Plugin SDK surface validation, targeted oxlint, docs inventory, and `git diff --check` passed.
- Fresh autoreview reported no actionable findings at 0.94 confidence.
- Exact-head hosted CI is running and remains required before merge.
- Blacksmith Testbox was unavailable because the local client was not authenticated; trusted-source focused proof used the documented local fallback.
- Root `CHANGELOG.md` remains release-owned; release-note context is captured here.
