### PR TITLE
fix(memory): quarantine writes from tainted agent turns

### DIFF
--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -214,6 +214,7 @@ describe("browser plugin", () => {
     }
 
     expect(tool.name).toBe("browser");
+    expect(tool.resultContentSource).toBe("network");
     expect(tool.description).toContain("action=profiles");
     expect(tool.description).not.toContain('profile="user"');
     expect(tool.outputSchema).toBe(BrowserToolOutputSchema);

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -89,6 +89,7 @@ function createLazyBrowserTool(opts?: {
   return {
     label: "Browser",
     name: "browser",
+    resultContentSource: "network",
     description: describeBrowserTool({ targetDefault, hostHint }),
     parameters: BrowserToolSchema,
     outputSchema: BrowserToolOutputSchema,

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -619,6 +619,10 @@ function blockBrowserNodeGateway(count = 1): () => void {
 }
 
 describe("browser tool output schema", () => {
+  it("marks browser results as network content", () => {
+    expect(createBrowserTool().resultContentSource).toBe("network");
+  });
+
   it("accepts snapshot details", async () => {
     const tool = createBrowserTool();
     const result = await tool.execute?.("call-1", {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -435,6 +435,7 @@ export function createBrowserTool(opts?: {
   return {
     label: "Browser",
     name: "browser",
+    resultContentSource: "network",
     description: describeBrowserTool({ targetDefault, hostHint }),
     parameters: BrowserToolSchema,
     outputSchema: BrowserToolOutputSchema,

--- a/extensions/memory-core/src/dreaming-state.ts
+++ b/extensions/memory-core/src/dreaming-state.ts
@@ -101,6 +101,16 @@ export async function readMemoryCoreWorkspaceEntries(
     .map((entry) => ({ key: entry.value.key, value: entry.value.value }));
 }
 
+export async function readMemoryCoreWorkspaceEntry<T>(
+  params: MemoryCoreWorkspaceParams & { key: string },
+): Promise<T | undefined> {
+  const workspaceKey = memoryCoreWorkspaceStateKey(params.workspaceDir);
+  const entry = await openWorkspaceStore<T>(params.namespace).lookup(
+    memoryCoreWorkspaceEntryKey(params.workspaceDir, params.key),
+  );
+  return entry?.workspaceKey === workspaceKey ? entry.value : undefined;
+}
+
 // Caller owns typed encoding for values written to plugin state.
 export function writeMemoryCoreWorkspaceEntries<T>(
   params: WriteMemoryCoreWorkspaceEntriesParams<T>,
@@ -162,4 +172,14 @@ export async function clearMemoryCoreWorkspaceNamespace(params: {
       await store.delete(entry.key);
     }
   }
+}
+
+export async function deleteMemoryCoreWorkspaceEntry(params: {
+  namespace: string;
+  workspaceDir: string;
+  key: string;
+}): Promise<void> {
+  await openWorkspaceStore(params.namespace).delete(
+    memoryCoreWorkspaceEntryKey(params.workspaceDir, params.key),
+  );
 }

--- a/extensions/memory-core/src/flush-plan.ts
+++ b/extensions/memory-core/src/flush-plan.ts
@@ -185,6 +185,22 @@ export function buildMemoryFlushPlan(
         key: writtenPath,
         value: { fileHash: hash(write.contentAfter), originClass, observedAt: write.observedAt },
       });
+      return async () => {
+        if (existing) {
+          await writeMemoryCoreWorkspaceEntry({
+            namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+            workspaceDir: write.workspaceDir,
+            key: writtenPath,
+            value: existing,
+          });
+          return;
+        }
+        await deleteMemoryCoreWorkspaceEntry({
+          namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+          workspaceDir: write.workspaceDir,
+          key: writtenPath,
+        });
+      };
     },
     clearWriteProvenance: async ({ workspaceDir, relativePath: writtenPath }) => {
       const normalized = normalizeAgentMemoryPath(writtenPath);

--- a/extensions/memory-core/src/flush-plan.ts
+++ b/extensions/memory-core/src/flush-plan.ts
@@ -158,7 +158,7 @@ export function buildMemoryFlushPlan(
     recordWriteProvenance: async (write) => {
       const writtenPath = normalizeAgentMemoryPath(write.relativePath);
       if (!writtenPath) {
-        return;
+        return undefined;
       }
       const hash = (value: string) => createHash("sha256").update(value).digest("hex");
       const existing = await readMemoryCoreWorkspaceEntry<{

--- a/extensions/memory-core/src/flush-plan.ts
+++ b/extensions/memory-core/src/flush-plan.ts
@@ -10,7 +10,8 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import {
   DREAMING_DAILY_PROVENANCE_NAMESPACE,
-  readMemoryCoreWorkspaceEntries,
+  deleteMemoryCoreWorkspaceEntry,
+  readMemoryCoreWorkspaceEntry,
   writeMemoryCoreWorkspaceEntry,
 } from "./dreaming-state.js";
 import { resolveMemoryCoreNowMs } from "./time.js";
@@ -29,6 +30,22 @@ const MEMORY_FLUSH_REQUIRED_HINTS = [
   MEMORY_FLUSH_APPEND_ONLY_HINT,
   MEMORY_FLUSH_READ_ONLY_HINT,
 ];
+
+function normalizeAgentMemoryPath(relativePath: string): string | undefined {
+  const normalized = relativePath.replaceAll("\\", "/").replace(/^\.\//u, "");
+  if (["MEMORY.md", "memory.md", "USER.md"].includes(normalized)) {
+    return normalized;
+  }
+  if (
+    !normalized.startsWith("memory/") ||
+    !normalized.endsWith(".md") ||
+    normalized.startsWith("memory/dreaming/") ||
+    normalized.startsWith("memory/.dreams/")
+  ) {
+    return undefined;
+  }
+  return normalized;
+}
 
 const DEFAULT_MEMORY_FLUSH_PROMPT = [
   "Pre-compaction memory flush.",
@@ -139,17 +156,23 @@ export function buildMemoryFlushPlan(
     systemPrompt: systemPrompt.replaceAll("YYYY-MM-DD", dateStamp),
     relativePath,
     recordWriteProvenance: async (write) => {
+      const writtenPath = normalizeAgentMemoryPath(write.relativePath);
+      if (!writtenPath) {
+        return;
+      }
       const hash = (value: string) => createHash("sha256").update(value).digest("hex");
-      const existing = (
-        await readMemoryCoreWorkspaceEntries<{
-          fileHash: string;
-          originClass: "agent" | "untrusted";
-          observedAt: number;
-        }>({ namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE, workspaceDir: write.workspaceDir })
-      ).find((entry) => entry.key === write.relativePath)?.value;
+      const existing = await readMemoryCoreWorkspaceEntry<{
+        fileHash: string;
+        originClass: "agent" | "untrusted";
+        observedAt: number;
+      }>({
+        namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+        workspaceDir: write.workspaceDir,
+        key: writtenPath,
+      });
       const originClass =
         write.originClass === "agent" &&
-        (!write.contentBefore ||
+        (!existing ||
           (existing?.originClass === "agent" && existing.fileHash === hash(write.contentBefore)))
           ? "agent"
           : "untrusted";
@@ -159,8 +182,19 @@ export function buildMemoryFlushPlan(
       await writeMemoryCoreWorkspaceEntry({
         namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
         workspaceDir: write.workspaceDir,
-        key: write.relativePath,
+        key: writtenPath,
         value: { fileHash: hash(write.contentAfter), originClass, observedAt: write.observedAt },
+      });
+    },
+    clearWriteProvenance: async ({ workspaceDir, relativePath: writtenPath }) => {
+      const normalized = normalizeAgentMemoryPath(writtenPath);
+      if (!normalized) {
+        return;
+      }
+      await deleteMemoryCoreWorkspaceEntry({
+        namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+        workspaceDir,
+        key: normalized,
       });
     },
   };

--- a/extensions/memory-core/src/memory/memory-path-provenance.test.ts
+++ b/extensions/memory-core/src/memory/memory-path-provenance.test.ts
@@ -3,7 +3,14 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  DREAMING_DAILY_PROVENANCE_NAMESPACE,
+  writeMemoryCoreWorkspaceEntry,
+} from "../dreaming-state.js";
+import { createMemoryCoreTestHarness } from "../test-helpers.js";
 import { resolveMemoryPathClassification } from "./memory-path-provenance.js";
+
+createMemoryCoreTestHarness();
 
 describe("memory path provenance", () => {
   it("trusts canonical workspace memory while excluding system and lookalike paths", async () => {
@@ -64,6 +71,26 @@ describe("memory path provenance", () => {
           workspaceDir,
         }),
       ).resolves.toMatchObject({ originClass: "untrusted" });
+    }
+  });
+
+  it("honors sticky untrusted provenance for runtime-written memory files", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-path-runtime-taint-"));
+    try {
+      const absolutePath = path.join(workspaceDir, "MEMORY.md");
+      await fs.writeFile(absolutePath, "network-authored memory", "utf8");
+      await writeMemoryCoreWorkspaceEntry({
+        namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+        workspaceDir,
+        key: "MEMORY.md",
+        value: { originClass: "untrusted" },
+      });
+
+      await expect(
+        resolveMemoryPathClassification({ absolutePath, source: "memory", workspaceDir }),
+      ).resolves.toEqual({ curatedRoot: true, originClass: "untrusted" });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
     }
   });
 });

--- a/extensions/memory-core/src/memory/memory-path-provenance.ts
+++ b/extensions/memory-core/src/memory/memory-path-provenance.ts
@@ -5,6 +5,10 @@ import type {
   MemoryEntryProvenance,
   MemorySource,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import {
+  DREAMING_DAILY_PROVENANCE_NAMESPACE,
+  readMemoryCoreWorkspaceEntry,
+} from "../dreaming-state.js";
 
 type MemoryPathClassification = {
   curatedRoot: boolean;
@@ -50,6 +54,17 @@ export async function resolveMemoryPathClassification(params: {
   }
   const isWorkspaceMemory =
     curatedRoot || (segments[0] === "memory" && segments.at(-1)?.endsWith(".md") === true);
+  const normalizedRelativePath = relativePath.replaceAll(path.sep, "/");
+  const recorded = isWorkspaceMemory
+    ? await readMemoryCoreWorkspaceEntry<{ originClass?: unknown }>({
+        namespace: DREAMING_DAILY_PROVENANCE_NAMESPACE,
+        workspaceDir: params.workspaceDir,
+        key: normalizedRelativePath,
+      })
+    : undefined;
+  if (recorded?.originClass === "untrusted") {
+    return { curatedRoot, originClass: "untrusted" };
+  }
   // Workspace memory Markdown is owner-controlled. Flush-recorded provenance
   // still downgrades machine-written untrusted material during ingestion; the
   // index default must not fail closed the entire workspace.

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -982,6 +982,60 @@ describe("agentLoop tool termination", () => {
     };
   }
 
+  it.each([
+    { source: "network" as const, tainted: true },
+    { source: undefined, tainted: false },
+  ])(
+    "persists $source tool-result taint through the assistant turn",
+    async ({ source, tainted }) => {
+      let turn = 0;
+      const tool: AgentTool = {
+        ...makeTool("fetch", []),
+        ...(source ? { resultContentSource: source } : {}),
+      };
+      const streamFn: StreamFn = () => {
+        turn += 1;
+        const stream = createAssistantMessageEventStream();
+        queueMicrotask(() => {
+          const message =
+            turn === 1
+              ? makeAssistantMessage([
+                  { type: "toolCall", id: "call-fetch", name: tool.name, arguments: {} },
+                ])
+              : makeAssistantMessage([{ type: "text", text: "stored result" }]);
+          stream.push({
+            type: "done",
+            reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+            message,
+          });
+          stream.end();
+        });
+        return stream;
+      };
+
+      const stream = agentLoop(
+        [{ role: "user", content: "fetch", timestamp: 1 }],
+        { systemPrompt: "", messages: [], tools: [tool] },
+        config,
+        undefined,
+        streamFn,
+      );
+      await collectEvents(stream);
+      const messages = await stream.result();
+      const toolResult = messages.find((message) => message.role === "toolResult");
+      const assistant = messages.findLast(
+        (message): message is AssistantMessage => message.role === "assistant",
+      );
+      const metadata = (message: AgentMessage | undefined) =>
+        message ? (message as unknown as Record<string, unknown>)["__openclaw"] : undefined;
+
+      expect(metadata(toolResult)).toEqual(
+        tainted ? { resultContentSource: "network" } : undefined,
+      );
+      expect(metadata(assistant)).toEqual(tainted ? { turnTainted: true } : undefined);
+    },
+  );
+
   it("persists and passes a local turn id when the provider omits one", async () => {
     let turn = 0;
     const toolCall = { type: "toolCall" as const, id: "call_0", name: "exec", arguments: {} };

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -24,6 +24,7 @@ import {
   isTurnHandoffAbort,
   normalizeCoreContextMessages,
 } from "./turn-interruption.js";
+import type { ToolResultContentSource } from "./types.js";
 import type {
   AgentContext,
   AgentEvent,
@@ -280,6 +281,7 @@ async function runLoop(
   let config = initialConfig;
   let firstTurn = true;
   let turnOpen = true;
+  let turnTainted = isActiveTurnTainted(initialContext.messages);
   // Check for steering messages at start (user may have typed while waiting)
   let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
   const stopIfAborted = async (): Promise<boolean> => {
@@ -288,10 +290,13 @@ async function runLoop(
     }
     // Persist an aborted assistant outcome so session post-processing does not
     // compact or continue from the preceding toolUse message.
-    const abortedMessage = createFailureMessage(
-      config.model,
-      signal.reason instanceof Error ? signal.reason : new Error("Agent run aborted"),
-      true,
+    const abortedMessage = withAssistantTurnTaint(
+      createFailureMessage(
+        config.model,
+        signal.reason instanceof Error ? signal.reason : new Error("Agent run aborted"),
+        true,
+      ),
+      turnTainted,
     );
     newMessages.push(abortedMessage);
     if (!turnOpen) {
@@ -329,6 +334,9 @@ async function runLoop(
       // Process pending messages (inject before next assistant response)
       if (pendingMessages.length > 0) {
         for (const message of pendingMessages) {
+          if (message.role === "user") {
+            turnTainted = false;
+          }
           await emit({ type: "message_start", message });
           await emit({ type: "message_end", message });
           currentContext.messages.push(message);
@@ -348,6 +356,7 @@ async function runLoop(
         emit,
         streamFn,
         runtime,
+        turnTainted,
       );
       newMessages.push(message);
 
@@ -374,6 +383,7 @@ async function runLoop(
           emit,
         );
         toolResults.push(...executedToolBatch.messages);
+        turnTainted ||= toolResults.some(toolResultTaintsTurn);
         hasMoreToolCalls = !executedToolBatch.terminate;
 
         for (const result of toolResults) {
@@ -460,6 +470,7 @@ async function streamAssistantResponse(
   emit: AgentEventSink,
   streamFn?: StreamFn,
   runtime?: AgentCoreStreamRuntimeDeps,
+  turnTainted = false,
 ): Promise<AssistantMessage> {
   // Apply context transform if configured (AgentMessage[] → AgentMessage[])
   let messages = context.messages;
@@ -527,8 +538,9 @@ async function streamAssistantResponse(
 
       case "done":
       case "error": {
-        const finalMessage = ensureToolTurnIdentity(
-          removeNonExecutableToolCalls(await response.result()),
+        const finalMessage = withAssistantTurnTaint(
+          ensureToolTurnIdentity(removeNonExecutableToolCalls(await response.result())),
+          turnTainted,
         );
         if (addedPartial) {
           context.messages[context.messages.length - 1] = finalMessage;
@@ -544,8 +556,9 @@ async function streamAssistantResponse(
     }
   }
 
-  const finalMessage = ensureToolTurnIdentity(
-    removeNonExecutableToolCalls(await response.result()),
+  const finalMessage = withAssistantTurnTaint(
+    ensureToolTurnIdentity(removeNonExecutableToolCalls(await response.result())),
+    turnTainted,
   );
   if (addedPartial) {
     context.messages[context.messages.length - 1] = finalMessage;
@@ -679,6 +692,9 @@ async function executeToolCallsSequential(
           executionStarted: false,
           ...(preparation.errorKind ? { errorKind: preparation.errorKind } : {}),
           ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
+          ...(preparation.resultContentSource
+            ? { resultContentSource: preparation.resultContentSource }
+            : {}),
         },
         toolCall.arguments,
         config,
@@ -762,6 +778,9 @@ async function executeToolCallsParallel(
           executionStarted: false,
           ...(preparation.errorKind ? { errorKind: preparation.errorKind } : {}),
           ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
+          ...(preparation.resultContentSource
+            ? { resultContentSource: preparation.resultContentSource }
+            : {}),
         },
         toolCall.arguments,
         config,
@@ -826,6 +845,7 @@ type ImmediateToolCallOutcome = {
   result: AgentToolResult<unknown>;
   isError: boolean;
   errorKind?: "argument-validation";
+  resultContentSource?: ToolResultContentSource;
 };
 
 type ExecutedToolCallOutcome = {
@@ -841,6 +861,7 @@ type FinalizedToolCallOutcome = {
   executionStarted: boolean;
   errorKind?: "argument-validation";
   hideFromChannelProgress?: boolean;
+  resultContentSource?: ToolResultContentSource;
 };
 
 type FinalizedToolCallEntry = FinalizedToolCallOutcome | (() => Promise<FinalizedToolCallOutcome>);
@@ -956,6 +977,7 @@ async function prepareToolCall(
       kind: "immediate",
       result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
       isError: true,
+      ...(tool.resultContentSource ? { resultContentSource: tool.resultContentSource } : {}),
     };
   }
 
@@ -968,6 +990,7 @@ async function prepareToolCall(
       result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
       isError: true,
       errorKind: "argument-validation",
+      ...(tool.resultContentSource ? { resultContentSource: tool.resultContentSource } : {}),
     };
   }
 
@@ -987,6 +1010,7 @@ async function prepareToolCall(
           kind: "immediate",
           result: createErrorToolResult("Operation aborted"),
           isError: true,
+          ...(tool.resultContentSource ? { resultContentSource: tool.resultContentSource } : {}),
         };
       }
       if (beforeResult?.block) {
@@ -994,6 +1018,7 @@ async function prepareToolCall(
           kind: "immediate",
           result: createErrorToolResult(beforeResult.reason || "Tool execution was blocked"),
           isError: true,
+          ...(tool.resultContentSource ? { resultContentSource: tool.resultContentSource } : {}),
         };
       }
     }
@@ -1002,6 +1027,7 @@ async function prepareToolCall(
         kind: "immediate",
         result: createErrorToolResult("Operation aborted"),
         isError: true,
+        ...(tool.resultContentSource ? { resultContentSource: tool.resultContentSource } : {}),
       };
     }
     return {
@@ -1015,6 +1041,7 @@ async function prepareToolCall(
       kind: "immediate",
       result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
       isError: true,
+      ...(tool.resultContentSource ? { resultContentSource: tool.resultContentSource } : {}),
     };
   }
 }
@@ -1129,6 +1156,9 @@ async function finalizeExecutedToolCall(
       isError,
       executionStarted: executed.executionStarted,
       ...(prepared.tool.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
+      ...(prepared.tool.resultContentSource
+        ? { resultContentSource: prepared.tool.resultContentSource }
+        : {}),
     },
     prepared.args,
     config,
@@ -1215,15 +1245,70 @@ async function emitToolExecutionEnd(
 }
 
 function createToolResultMessage(finalized: FinalizedToolCallOutcome): ToolResultMessage {
+  return withToolResultContentSource(
+    {
+      role: "toolResult",
+      toolCallId: finalized.toolCall.id,
+      toolName: finalized.toolCall.name,
+      content: finalized.result.content ?? [],
+      details: finalized.result.details,
+      isError: finalized.isError,
+      timestamp: Date.now(),
+    },
+    finalized.resultContentSource,
+  );
+}
+
+type TurnTaintMetadata = {
+  resultContentSource?: ToolResultContentSource;
+  turnTainted?: true;
+};
+
+function readTurnTaintMetadata(message: AgentMessage): TurnTaintMetadata | undefined {
+  const metadata = (message as unknown as Record<string, unknown>)["__openclaw"];
+  return metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? (metadata as TurnTaintMetadata)
+    : undefined;
+}
+
+function toolResultTaintsTurn(message: ToolResultMessage): boolean {
+  return readTurnTaintMetadata(message)?.resultContentSource === "network";
+}
+
+function isActiveTurnTainted(messages: readonly AgentMessage[]): boolean {
+  for (const message of messages.toReversed()) {
+    if (message.role === "user") {
+      return false;
+    }
+    const metadata = readTurnTaintMetadata(message);
+    if (metadata?.turnTainted === true || metadata?.resultContentSource === "network") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function withAssistantTurnTaint(message: AssistantMessage, tainted: boolean): AssistantMessage {
+  if (!tainted) {
+    return message;
+  }
   return {
-    role: "toolResult",
-    toolCallId: finalized.toolCall.id,
-    toolName: finalized.toolCall.name,
-    content: finalized.result.content ?? [],
-    details: finalized.result.details,
-    isError: finalized.isError,
-    timestamp: Date.now(),
-  };
+    ...message,
+    __openclaw: { ...readTurnTaintMetadata(message), turnTainted: true },
+  } as unknown as AssistantMessage;
+}
+
+function withToolResultContentSource(
+  message: ToolResultMessage,
+  source: ToolResultContentSource | undefined,
+): ToolResultMessage {
+  if (!source) {
+    return message;
+  }
+  return {
+    ...message,
+    __openclaw: { ...readTurnTaintMetadata(message), resultContentSource: source },
+  } as ToolResultMessage;
 }
 
 async function emitToolResultMessage(

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -490,6 +490,9 @@ export interface AgentToolResult<T> {
 /** Callback used by tools to stream partial execution updates. */
 export type AgentToolUpdateCallback<T = unknown> = (partialResult: AgentToolResult<T>) => void;
 
+/** Origin class for tool output that can taint later model-authored content in the same turn. */
+export type ToolResultContentSource = "network";
+
 /** Tool definition used by the agent runtime. */
 export interface AgentTool<
   TParameters extends TSchema = TSchema,
@@ -501,6 +504,8 @@ export interface AgentTool<
   outputSchema?: TSchema;
   /** Preserve lifecycle telemetry without rendering transient channel progress. */
   hideFromChannelProgress?: boolean;
+  /** Tool results contain externally controlled network content. */
+  resultContentSource?: ToolResultContentSource;
   /**
    * Optional compatibility shim for raw tool-call arguments before schema validation.
    * Must return an object that matches `TParameters`.

--- a/packages/memory-host-sdk/src/host/session-files.provenance.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.provenance.test.ts
@@ -55,6 +55,41 @@ describe("session transcript provenance", () => {
     ]);
   });
 
+  it("keeps owner input trusted while downgrading its tool-tainted agent response", async () => {
+    const filePath = await writeTranscript("owner-network-taint.jsonl", [
+      {
+        type: "message",
+        timestamp: "2026-07-01T10:00:00.000Z",
+        message: {
+          role: "user",
+          content: "Research this preference.",
+          __openclaw: { senderIsOwner: true },
+        },
+      },
+      {
+        type: "message",
+        timestamp: "2026-07-01T10:01:00.000Z",
+        message: {
+          role: "toolResult",
+          content: "Attacker-controlled page text.",
+          __openclaw: { resultContentSource: "network" },
+        },
+      },
+      {
+        type: "message",
+        timestamp: "2026-07-01T10:02:00.000Z",
+        message: {
+          role: "assistant",
+          content: "Derived memory candidate.",
+          __openclaw: { turnTainted: true },
+        },
+      },
+    ]);
+
+    const entry = await buildSessionEntry(filePath, { sessionKind: "interactive" });
+    expect(entry?.lineProvenance.map((item) => item.originClass)).toEqual(["owner", "untrusted"]);
+  });
+
   it("excludes a structurally marked recalled turn", async () => {
     const filePath = await writeTranscript("recalled.jsonl", [
       {

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -649,6 +649,14 @@ function classifySessionMessageOrigin(
   turnOrigin: MemoryOriginClass,
 ): MemoryOriginClass {
   if (message.role === "assistant") {
+    const openClawMetadata = message["__openclaw"];
+    if (
+      openClawMetadata &&
+      typeof openClawMetadata === "object" &&
+      (openClawMetadata as { turnTainted?: unknown }).turnTainted === true
+    ) {
+      return "untrusted";
+    }
     return turnOrigin === "owner" ? "agent" : turnOrigin;
   }
   const provenance = message.provenance as { kind?: unknown } | undefined;

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -339,6 +339,7 @@ export function toToolDefinitions(
       name,
       label: tool.label ?? name,
       ...(tool.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
+      ...(tool.resultContentSource ? { resultContentSource: tool.resultContentSource } : {}),
       description: tool.description ?? "",
       parameters: tool.parameters,
       prepareArguments: tool.prepareArguments,

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -638,6 +638,7 @@ export async function recordLoopOutcome(args: {
   toolCallId?: string;
   result?: unknown;
   error?: unknown;
+  resultContentSource?: AnyAgentTool["resultContentSource"];
   toolCallOrdinal?: number;
   terminalPresentation?: string;
 }): Promise<void> {
@@ -684,6 +685,7 @@ export async function recordLoopOutcome(args: {
         toolName: record.toolName,
         argsHash: record.argsHash,
         resultHash: record.resultHash,
+        ...(args.resultContentSource ? { resultContentSource: args.resultContentSource } : {}),
         ...(args.toolCallOrdinal !== undefined ? { toolCallOrdinal: args.toolCallOrdinal } : {}),
         ...(args.terminalPresentation ? { terminalPresentation: args.terminalPresentation } : {}),
       };

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -71,6 +71,7 @@ function asAgentTool(tool: {
   execute: ReturnType<typeof vi.fn>;
   name: string;
   parameters?: object;
+  resultContentSource?: AnyAgentTool["resultContentSource"];
 }): AnyAgentTool {
   return tool as unknown as AnyAgentTool;
 }
@@ -1135,6 +1136,7 @@ describe("before_tool_call hook deduplication (#15502)", () => {
         name: "web_fetch",
         description: "fetch",
         parameters: {},
+        resultContentSource: "network",
         execute: vi.fn().mockResolvedValue({
           content: [],
           details: { status: 200 },
@@ -1161,6 +1163,7 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     expect(onToolOutcome).toHaveBeenCalledWith(
       expect.objectContaining({
         toolName: "web_fetch",
+        resultContentSource: "network",
         terminalPresentation: "Fetched with status 200",
       }),
     );

--- a/src/agents/agent-tools.before-tool-call.types.ts
+++ b/src/agents/agent-tools.before-tool-call.types.ts
@@ -13,12 +13,14 @@ import type {
   PluginHookToolRequesterContext,
 } from "../plugins/types.js";
 import type { SkillSnapshot, SkillTelemetrySource, SkillUsagePath } from "../skills/types.js";
+import type { AgentTool } from "./runtime/index.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 export type ToolOutcomeObservation = {
   toolName: string;
   argsHash: string;
   resultHash: string;
+  resultContentSource?: AgentTool["resultContentSource"];
   /** Monotonic model-call order within the owning embedded run. */
   toolCallOrdinal?: number;
   terminalPresentation?: string;

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -499,6 +499,7 @@ export function wrapToolWithBeforeToolCallHook(
           toolParams: executeParams,
           toolCallId,
           result,
+          resultContentSource: tool.resultContentSource,
           toolCallOrdinal,
           terminalPresentation,
         });
@@ -558,6 +559,7 @@ export function wrapToolWithBeforeToolCallHook(
           toolParams: executeParams,
           toolCallId,
           error: err,
+          resultContentSource: tool.resultContentSource,
           toolCallOrdinal,
         });
         throw err;

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -2112,14 +2112,12 @@ describe("createOpenClawCodingTools", () => {
           "apply_patch",
         ),
       );
-
       await applyPatch("delete-memory", {
         input: "*** Begin Patch\n*** Delete File: memory/recreated.md\n*** End Patch",
       });
       await applyPatch("recreate-memory", {
         input: "*** Begin Patch\n*** Add File: memory/recreated.md\n+recreated\n*** End Patch",
       });
-
       expect(recordedOrigin).toBe("agent");
       await expect(
         fs.readFile(path.join(workspaceDir, "memory/recreated.md"), "utf8"),

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -19,6 +19,11 @@ import {
   resetGlobalHookRunner,
 } from "../plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../plugins/hooks.test-fixtures.js";
+import {
+  clearMemoryPluginState,
+  registerMemoryCapability,
+  type MemoryFlushPlan,
+} from "../plugins/memory-state.js";
 import "./test-helpers/fast-bash-tools.js";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
@@ -197,6 +202,7 @@ describe("createOpenClawCodingTools", () => {
   const testConfig: OpenClawConfig = {};
 
   afterEach(() => {
+    clearMemoryPluginState();
     resetGlobalHookRunner();
   });
 
@@ -2004,6 +2010,114 @@ describe("createOpenClawCodingTools", () => {
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
       await fs.rm(taskCwd, { recursive: true, force: true });
+    }
+  });
+
+  it("records ordinary write, edit, and apply_patch memory provenance from turn taint", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-write-taint-"));
+    const recordWriteProvenance = vi.fn<NonNullable<MemoryFlushPlan["recordWriteProvenance"]>>(
+      async () => {},
+    );
+    registerMemoryCapability("memory-core", {
+      flushPlanResolver: () => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1,
+        reserveTokensFloor: 1,
+        prompt: "flush",
+        systemPrompt: "flush",
+        relativePath: "memory/2026-07-29.md",
+        recordWriteProvenance,
+      }),
+    });
+    let tainted = false;
+    try {
+      const tools = createOpenClawCodingTools({
+        workspaceDir,
+        senderIsOwner: true,
+        isTurnTainted: () => tainted,
+      });
+      const write = requireToolExecute(requireTool(tools, "write"));
+      const edit = requireToolExecute(requireTool(tools, "edit"));
+      const applyPatch = requireToolExecute(requireTool(tools, "apply_patch"));
+
+      await write("write-memory", {
+        path: "memory/2026-07-29.md",
+        content: "owner-requested note\n",
+      });
+      tainted = true;
+      await edit("edit-memory", {
+        path: "memory/2026-07-29.md",
+        edits: [{ oldText: "note", newText: "network-derived note" }],
+      });
+      await applyPatch("patch-memory", {
+        input: [
+          "*** Begin Patch",
+          "*** Add File: memory/project.md",
+          "+network project note",
+          "*** End Patch",
+        ].join("\n"),
+      });
+
+      expect(recordWriteProvenance.mock.calls.map(([entry]) => entry.originClass)).toEqual([
+        "agent",
+        "untrusted",
+        "untrusted",
+      ]);
+      expect(recordWriteProvenance).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          relativePath: "memory/project.md",
+          contentBefore: "",
+          contentAfter: "network project note\n",
+        }),
+      );
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("records sandbox-backed memory writes before mutation", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-sandbox-taint-"));
+    const recordWriteProvenance = vi.fn<NonNullable<MemoryFlushPlan["recordWriteProvenance"]>>(
+      async () => {},
+    );
+    registerMemoryCapability("memory-core", {
+      flushPlanResolver: () => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1,
+        reserveTokensFloor: 1,
+        prompt: "flush",
+        systemPrompt: "flush",
+        relativePath: "memory/2026-07-29.md",
+        recordWriteProvenance,
+      }),
+    });
+    try {
+      const sandbox = createAgentToolsSandboxContext({
+        workspaceDir,
+        fsBridge: createHostSandboxFsBridge(workspaceDir),
+        workspaceAccess: "rw",
+      });
+      const tools = createOpenClawCodingTools({
+        workspaceDir,
+        sandbox,
+        senderIsOwner: true,
+        isTurnTainted: () => true,
+      });
+      await requireToolExecute(requireTool(tools, "write"))("sandbox-memory", {
+        path: "memory/2026-07-29.md",
+        content: "sandbox network note\n",
+      });
+
+      expect(recordWriteProvenance).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relativePath: "memory/2026-07-29.md",
+          originClass: "untrusted",
+          contentBefore: "",
+          contentAfter: "sandbox network note\n",
+        }),
+      );
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
     }
   });
 

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -2088,11 +2088,7 @@ describe("createOpenClawCodingTools", () => {
         systemPrompt: "flush",
         relativePath: "memory/recreated.md",
         recordWriteProvenance: async (entry) => {
-          const previous = recordedOrigin;
           recordedOrigin = entry.originClass;
-          return async () => {
-            recordedOrigin = previous;
-          };
         },
         clearWriteProvenance: async () => {
           recordedOrigin = undefined;
@@ -2119,9 +2115,6 @@ describe("createOpenClawCodingTools", () => {
         input: "*** Begin Patch\n*** Add File: memory/recreated.md\n+recreated\n*** End Patch",
       });
       expect(recordedOrigin).toBe("agent");
-      await expect(
-        fs.readFile(path.join(workspaceDir, "memory/recreated.md"), "utf8"),
-      ).resolves.toBe("recreated\n");
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
@@ -2172,7 +2165,6 @@ describe("createOpenClawCodingTools", () => {
           "apply_patch",
         ),
       );
-
       const deleting = applyPatch("delete-raced-memory", {
         input: "*** Begin Patch\n*** Delete File: memory/raced.md\n*** End Patch",
       });

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -2033,6 +2033,7 @@ describe("createOpenClawCodingTools", () => {
     try {
       const tools = createOpenClawCodingTools({
         workspaceDir,
+        config: { tools: { fs: { workspaceOnly: true } } },
         senderIsOwner: true,
         isTurnTainted: () => tainted,
       });
@@ -2071,6 +2072,125 @@ describe("createOpenClawCodingTools", () => {
         }),
       );
     } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("records agent provenance after an untainted same-turn delete and recreate", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-recreate-"));
+    let recordedOrigin: "agent" | "untrusted" | undefined;
+    registerMemoryCapability("memory-core", {
+      flushPlanResolver: () => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1,
+        reserveTokensFloor: 1,
+        prompt: "flush",
+        systemPrompt: "flush",
+        relativePath: "memory/recreated.md",
+        recordWriteProvenance: async (entry) => {
+          const previous = recordedOrigin;
+          recordedOrigin = entry.originClass;
+          return async () => {
+            recordedOrigin = previous;
+          };
+        },
+        clearWriteProvenance: async () => {
+          recordedOrigin = undefined;
+        },
+      }),
+    });
+    try {
+      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "memory/recreated.md"), "old\n", "utf8");
+      const applyPatch = requireToolExecute(
+        requireTool(
+          createOpenClawCodingTools({
+            workspaceDir,
+            senderIsOwner: true,
+            isTurnTainted: () => false,
+          }),
+          "apply_patch",
+        ),
+      );
+
+      await applyPatch("delete-memory", {
+        input: "*** Begin Patch\n*** Delete File: memory/recreated.md\n*** End Patch",
+      });
+      await applyPatch("recreate-memory", {
+        input: "*** Begin Patch\n*** Add File: memory/recreated.md\n+recreated\n*** End Patch",
+      });
+
+      expect(recordedOrigin).toBe("agent");
+      await expect(
+        fs.readFile(path.join(workspaceDir, "memory/recreated.md"), "utf8"),
+      ).resolves.toBe("recreated\n");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("orders parallel apply_patch delete cleanup before a tainted recreate", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-race-"));
+    let recordedOrigin: "agent" | "untrusted" | undefined;
+    let releaseCleanup!: () => void;
+    let signalCleanupStarted!: () => void;
+    const cleanupRelease = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const cleanupStarted = new Promise<void>((resolve) => {
+      signalCleanupStarted = resolve;
+    });
+    const recordWriteProvenance = vi.fn<NonNullable<MemoryFlushPlan["recordWriteProvenance"]>>(
+      async (entry) => {
+        recordedOrigin = entry.originClass;
+      },
+    );
+    registerMemoryCapability("memory-core", {
+      flushPlanResolver: () => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1,
+        reserveTokensFloor: 1,
+        prompt: "flush",
+        systemPrompt: "flush",
+        relativePath: "memory/raced.md",
+        recordWriteProvenance,
+        clearWriteProvenance: async () => {
+          signalCleanupStarted();
+          await cleanupRelease;
+          recordedOrigin = undefined;
+        },
+      }),
+    });
+    try {
+      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "memory/raced.md"), "old\n", "utf8");
+      const applyPatch = requireToolExecute(
+        requireTool(
+          createOpenClawCodingTools({
+            workspaceDir,
+            senderIsOwner: true,
+            isTurnTainted: () => true,
+          }),
+          "apply_patch",
+        ),
+      );
+
+      const deleting = applyPatch("delete-raced-memory", {
+        input: "*** Begin Patch\n*** Delete File: memory/raced.md\n*** End Patch",
+      });
+      await cleanupStarted;
+      const recreating = applyPatch("recreate-raced-memory", {
+        input: "*** Begin Patch\n*** Add File: memory/raced.md\n+network note\n*** End Patch",
+      });
+      await Promise.resolve();
+      expect(recordWriteProvenance).not.toHaveBeenCalled();
+      releaseCleanup();
+      await Promise.all([deleting, recreating]);
+
+      expect(recordedOrigin).toBe("untrusted");
+      expect(recordWriteProvenance).toHaveBeenCalledOnce();
+    } finally {
+      releaseCleanup();
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
   });

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -1081,7 +1081,10 @@ function createSandboxEditOperations(params: SandboxToolParams) {
 }
 
 function isMissingFileError(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+  return (
+    (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT" ||
+    (error instanceof FsSafeError && error.code === "not-found")
+  );
 }
 
 function withMemoryWriteProvenance<
@@ -1096,6 +1099,10 @@ function withMemoryWriteProvenance<
   return {
     ...operations,
     writeFile: async (absolutePath: string, content: string) => {
+      if (!observer.classifies(absolutePath)) {
+        await operations.writeFile(absolutePath, content);
+        return;
+      }
       const contentBefore = await operations
         .readFile(absolutePath)
         .then((value) => (Buffer.isBuffer(value) ? value.toString("utf8") : value))

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -34,7 +34,10 @@ import {
 } from "./agent-tools.params.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
-import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
+import {
+  type MemoryWriteProvenanceObserver,
+  withMemoryWriteProvenance,
+} from "./memory-write-provenance.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
@@ -1078,50 +1081,6 @@ function createSandboxEditOperations(params: SandboxToolParams) {
     } as const,
     params.memoryWriteProvenance,
   );
-}
-
-function isMissingFileError(error: unknown): boolean {
-  return (
-    (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT" ||
-    (error instanceof FsSafeError && error.code === "not-found")
-  );
-}
-
-function withMemoryWriteProvenance<
-  T extends {
-    readFile: (absolutePath: string) => Promise<Buffer | string>;
-    writeFile: (absolutePath: string, content: string) => Promise<void>;
-  },
->(operations: T, observer: MemoryWriteProvenanceObserver | undefined): T {
-  if (!observer) {
-    return operations;
-  }
-  return {
-    ...operations,
-    writeFile: async (absolutePath: string, content: string) => {
-      if (!observer.classifies(absolutePath)) {
-        await operations.writeFile(absolutePath, content);
-        return;
-      }
-      const contentBefore = await operations
-        .readFile(absolutePath)
-        .then((value) => (Buffer.isBuffer(value) ? value.toString("utf8") : value))
-        .catch((error: unknown) => {
-          if (isMissingFileError(error)) {
-            return "";
-          }
-          throw error;
-        });
-      // Persist the predicted post-write hash first. A provenance failure must
-      // prevent an otherwise untracked memory mutation from becoming trusted.
-      await observer.write({
-        absolutePath,
-        contentBefore,
-        contentAfter: content,
-        commit: () => operations.writeFile(absolutePath, content),
-      });
-    },
-  } as T;
 }
 
 async function assertSandboxFileExists(params: SandboxToolParams, absolutePath: string) {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -34,6 +34,7 @@ import {
 } from "./agent-tools.params.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
+import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
@@ -880,6 +881,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
 type SandboxToolParams = {
   root: string;
   bridge: SandboxFsBridge;
+  memoryWriteProvenance?: MemoryWriteProvenanceObserver;
   modelContextWindowTokens?: number;
   imageSanitization?: ImageSanitizationLimits;
 };
@@ -912,7 +914,13 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
 }
 
 /** Create a host workspace write tool using guarded filesystem operations. */
-export function createHostWorkspaceWriteTool(root: string, options?: { workspaceOnly?: boolean }) {
+export function createHostWorkspaceWriteTool(
+  root: string,
+  options?: {
+    workspaceOnly?: boolean;
+    memoryWriteProvenance?: MemoryWriteProvenanceObserver;
+  },
+) {
   const base = createWriteTool(root, {
     operations: createHostWriteOperations(root, options),
   }) as unknown as AnyAgentTool;
@@ -920,7 +928,13 @@ export function createHostWorkspaceWriteTool(root: string, options?: { workspace
 }
 
 /** Create a host workspace edit tool using guarded filesystem operations. */
-export function createHostWorkspaceEditTool(root: string, options?: { workspaceOnly?: boolean }) {
+export function createHostWorkspaceEditTool(
+  root: string,
+  options?: {
+    workspaceOnly?: boolean;
+    memoryWriteProvenance?: MemoryWriteProvenanceObserver;
+  },
+) {
   const base = createEditTool(root, {
     operations: createHostEditOperations(root, options),
   }) as unknown as AnyAgentTool;
@@ -1036,28 +1050,67 @@ function createSandboxReadOperations(params: SandboxToolParams) {
 }
 
 function createSandboxWriteOperations(params: SandboxToolParams) {
-  return {
-    mkdir: async (dir: string) => {
-      await params.bridge.mkdirp({ filePath: dir, cwd: params.root });
-    },
-    writeFile: async (absolutePath: string, content: string) => {
-      await params.bridge.writeFile({ filePath: absolutePath, cwd: params.root, data: content });
-    },
-    readFile: (absolutePath: string) =>
-      params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
-    statFile: (absolutePath: string) =>
-      params.bridge.stat({ filePath: absolutePath, cwd: params.root }),
-  } as const;
+  return withMemoryWriteProvenance(
+    {
+      mkdir: async (dir: string) => {
+        await params.bridge.mkdirp({ filePath: dir, cwd: params.root });
+      },
+      writeFile: async (absolutePath: string, content: string) => {
+        await params.bridge.writeFile({ filePath: absolutePath, cwd: params.root, data: content });
+      },
+      readFile: (absolutePath: string) =>
+        params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
+      statFile: (absolutePath: string) =>
+        params.bridge.stat({ filePath: absolutePath, cwd: params.root }),
+    } as const,
+    params.memoryWriteProvenance,
+  );
 }
 
 function createSandboxEditOperations(params: SandboxToolParams) {
+  return withMemoryWriteProvenance(
+    {
+      readFile: (absolutePath: string) =>
+        params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
+      writeFile: (absolutePath: string, content: string) =>
+        params.bridge.writeFile({ filePath: absolutePath, cwd: params.root, data: content }),
+      access: (absolutePath: string) => assertSandboxFileExists(params, absolutePath),
+    } as const,
+    params.memoryWriteProvenance,
+  );
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT";
+}
+
+function withMemoryWriteProvenance<
+  T extends {
+    readFile: (absolutePath: string) => Promise<Buffer | string>;
+    writeFile: (absolutePath: string, content: string) => Promise<void>;
+  },
+>(operations: T, observer: MemoryWriteProvenanceObserver | undefined): T {
+  if (!observer) {
+    return operations;
+  }
   return {
-    readFile: (absolutePath: string) =>
-      params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
-    writeFile: (absolutePath: string, content: string) =>
-      params.bridge.writeFile({ filePath: absolutePath, cwd: params.root, data: content }),
-    access: (absolutePath: string) => assertSandboxFileExists(params, absolutePath),
-  } as const;
+    ...operations,
+    writeFile: async (absolutePath: string, content: string) => {
+      const contentBefore = await operations
+        .readFile(absolutePath)
+        .then((value) => (Buffer.isBuffer(value) ? value.toString("utf8") : value))
+        .catch((error: unknown) => {
+          if (isMissingFileError(error)) {
+            return "";
+          }
+          throw error;
+        });
+      // Persist the predicted post-write hash first. A provenance failure must
+      // prevent an otherwise untracked memory mutation from becoming trusted.
+      await observer.recordBeforeWrite({ absolutePath, contentBefore, contentAfter: content });
+      await operations.writeFile(absolutePath, content);
+    },
+  } as T;
 }
 
 async function assertSandboxFileExists(params: SandboxToolParams, absolutePath: string) {
@@ -1117,22 +1170,31 @@ async function writeWorkspaceFile(
   await (await getRoot()).write(relative, content, { mkdir: true });
 }
 
-function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {
+function createHostWriteOperations(
+  root: string,
+  options?: {
+    workspaceOnly?: boolean;
+    memoryWriteProvenance?: MemoryWriteProvenanceObserver;
+  },
+) {
   const workspaceOnly = options?.workspaceOnly ?? false;
 
   if (!workspaceOnly) {
     // When workspaceOnly is false, allow writes anywhere on the host
-    return {
-      mkdir: async (dir: string) => {
-        const resolved = resolveHostPath(dir);
-        await fs.mkdir(resolved, { recursive: true });
-      },
-      writeFile: writeHostFile,
-      readFile: async (absolutePath: string) =>
-        fs.readFile(path.resolve(expandTildeToOsHome(absolutePath))),
-      statFile: (absolutePath: string) =>
-        statHostFile(path.resolve(expandTildeToOsHome(absolutePath))),
-    } as const;
+    return withMemoryWriteProvenance(
+      {
+        mkdir: async (dir: string) => {
+          const resolved = resolveHostPath(dir);
+          await fs.mkdir(resolved, { recursive: true });
+        },
+        writeFile: writeHostFile,
+        readFile: async (absolutePath: string) =>
+          fs.readFile(path.resolve(expandTildeToOsHome(absolutePath))),
+        statFile: (absolutePath: string) =>
+          statHostFile(path.resolve(expandTildeToOsHome(absolutePath))),
+      } as const,
+      options?.memoryWriteProvenance,
+    );
   }
 
   // When workspaceOnly is true, enforce workspace boundary. Resolve the fs-safe
@@ -1141,40 +1203,52 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
   // orphan a rejecting promise as "Unhandled promise rejection: root dir not found".
   let rootPromise: ReturnType<typeof fsRoot> | undefined;
   const getRoot = () => (rootPromise ??= fsRoot(root));
-  return {
-    mkdir: async (dir: string) => {
-      const relative = toRelativeWorkspacePath(root, dir, { allowRoot: true });
-      const resolved = relative ? path.resolve(root, relative) : path.resolve(root);
-      await assertSandboxPath({ filePath: resolved, cwd: root, root });
-      await fs.mkdir(resolved, { recursive: true });
-    },
-    writeFile: (absolutePath: string, content: string) =>
-      writeWorkspaceFile(root, getRoot, absolutePath, content),
-    readFile: async (absolutePath: string) => {
-      const relative = toRelativeWorkspacePath(root, absolutePath);
-      return (await (await getRoot()).read(relative)).buffer;
-    },
-    statFile: async (absolutePath: string) => {
-      const relative = toRelativeWorkspacePath(root, absolutePath);
-      return statHostFile(path.resolve(root, relative));
-    },
-  } as const;
+  return withMemoryWriteProvenance(
+    {
+      mkdir: async (dir: string) => {
+        const relative = toRelativeWorkspacePath(root, dir, { allowRoot: true });
+        const resolved = relative ? path.resolve(root, relative) : path.resolve(root);
+        await assertSandboxPath({ filePath: resolved, cwd: root, root });
+        await fs.mkdir(resolved, { recursive: true });
+      },
+      writeFile: (absolutePath: string, content: string) =>
+        writeWorkspaceFile(root, getRoot, absolutePath, content),
+      readFile: async (absolutePath: string) => {
+        const relative = toRelativeWorkspacePath(root, absolutePath);
+        return (await (await getRoot()).read(relative)).buffer;
+      },
+      statFile: async (absolutePath: string) => {
+        const relative = toRelativeWorkspacePath(root, absolutePath);
+        return statHostFile(path.resolve(root, relative));
+      },
+    } as const,
+    options?.memoryWriteProvenance,
+  );
 }
 
-function createHostEditOperations(root: string, options?: { workspaceOnly?: boolean }) {
+function createHostEditOperations(
+  root: string,
+  options?: {
+    workspaceOnly?: boolean;
+    memoryWriteProvenance?: MemoryWriteProvenanceObserver;
+  },
+) {
   const workspaceOnly = options?.workspaceOnly ?? false;
 
   if (!workspaceOnly) {
     // When workspaceOnly is false, allow edits anywhere on the host
-    return {
-      readFile: async (absolutePath: string) => {
-        return await fs.readFile(resolveHostPath(absolutePath));
-      },
-      writeFile: writeHostFile,
-      access: async (absolutePath: string) => {
-        await fs.access(resolveHostPath(absolutePath));
-      },
-    } as const;
+    return withMemoryWriteProvenance(
+      {
+        readFile: async (absolutePath: string) => {
+          return await fs.readFile(resolveHostPath(absolutePath));
+        },
+        writeFile: writeHostFile,
+        access: async (absolutePath: string) => {
+          await fs.access(resolveHostPath(absolutePath));
+        },
+      } as const,
+      options?.memoryWriteProvenance,
+    );
   }
 
   // When workspaceOnly is true, enforce workspace boundary. Resolve the fs-safe
@@ -1183,42 +1257,45 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
   // orphan a rejecting promise as "Unhandled promise rejection: root dir not found".
   let rootPromise: ReturnType<typeof fsRoot> | undefined;
   const getRoot = () => (rootPromise ??= fsRoot(root));
-  return {
-    readFile: async (absolutePath: string) => {
-      const relative = toRelativeWorkspacePath(root, absolutePath);
-      const safeRead = await (await getRoot()).read(relative);
-      return safeRead.buffer;
-    },
-    writeFile: (absolutePath: string, content: string) =>
-      writeWorkspaceFile(root, getRoot, absolutePath, content),
-    access: async (absolutePath: string) => {
-      let relative: string;
-      try {
-        relative = toRelativeWorkspacePath(root, absolutePath);
-      } catch {
-        // Path escapes workspace root.  Don't throw here – the upstream
-        // library replaces any `access` error with a misleading "File not
-        // found" message.  By returning silently the subsequent `readFile`
-        // call will throw the same "Path escapes workspace root" error
-        // through a code-path that propagates the original message.
-        return;
-      }
-      try {
-        const opened = await (await getRoot()).open(relative);
-        await opened.handle.close().catch(() => {});
-      } catch (error) {
-        if (error instanceof FsSafeError && error.code === "not-found") {
-          throw createFsAccessError("ENOENT", absolutePath);
-        }
-        if (error instanceof FsSafeError && error.code === "outside-workspace") {
-          // Don't throw here – see the comment above about the upstream
-          // library swallowing access errors as "File not found".
+  return withMemoryWriteProvenance(
+    {
+      readFile: async (absolutePath: string) => {
+        const relative = toRelativeWorkspacePath(root, absolutePath);
+        const safeRead = await (await getRoot()).read(relative);
+        return safeRead.buffer;
+      },
+      writeFile: (absolutePath: string, content: string) =>
+        writeWorkspaceFile(root, getRoot, absolutePath, content),
+      access: async (absolutePath: string) => {
+        let relative: string;
+        try {
+          relative = toRelativeWorkspacePath(root, absolutePath);
+        } catch {
+          // Path escapes workspace root.  Don't throw here – the upstream
+          // library replaces any `access` error with a misleading "File not
+          // found" message.  By returning silently the subsequent `readFile`
+          // call will throw the same "Path escapes workspace root" error
+          // through a code-path that propagates the original message.
           return;
         }
-        throw error;
-      }
-    },
-  } as const;
+        try {
+          const opened = await (await getRoot()).open(relative);
+          await opened.handle.close().catch(() => {});
+        } catch (error) {
+          if (error instanceof FsSafeError && error.code === "not-found") {
+            throw createFsAccessError("ENOENT", absolutePath);
+          }
+          if (error instanceof FsSafeError && error.code === "outside-workspace") {
+            // Don't throw here – see the comment above about the upstream
+            // library swallowing access errors as "File not found".
+            return;
+          }
+          throw error;
+        }
+      },
+    } as const,
+    options?.memoryWriteProvenance,
+  );
 }
 
 async function toCanonicalRelativeWorkspacePath(

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -1107,8 +1107,12 @@ function withMemoryWriteProvenance<
         });
       // Persist the predicted post-write hash first. A provenance failure must
       // prevent an otherwise untracked memory mutation from becoming trusted.
-      await observer.recordBeforeWrite({ absolutePath, contentBefore, contentAfter: content });
-      await operations.writeFile(absolutePath, content);
+      await observer.write({
+        absolutePath,
+        contentBefore,
+        contentAfter: content,
+        commit: () => operations.writeFile(absolutePath, content),
+      });
     },
   } as T;
 }

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -22,6 +22,7 @@ import type {
   PluginHookChannelContext,
   PluginHookToolRequesterContext,
 } from "../plugins/hook-types.js";
+import { resolveMemoryFlushPlan } from "../plugins/memory-state.js";
 import { appendRuntimePluginToolGrant } from "../plugins/tool-grant-allowlist.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { GATEWAY_OWNER_ONLY_CORE_TOOLS } from "../security/dangerous-tools.js";
@@ -83,6 +84,7 @@ import {
   filterLocalModelLeanTools,
   resolveLocalModelLeanPreserveToolNames,
 } from "./local-model-lean.js";
+import { createMemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
 import type { ModelAuthMode } from "./model-auth.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import { createOpenClawTools, filterToolsByClientCaps } from "./openclaw-tools.js";
@@ -456,6 +458,8 @@ type OpenClawCodingToolsOptions = {
   toolPolicyAuditLogLevel?: "info" | "debug";
   /** Live observer called after wrapped tool outcomes are recorded. */
   onToolOutcome?: ToolOutcomeObserver;
+  /** Reads the sticky untrusted-content flag for the current user turn. */
+  isTurnTainted?: () => boolean;
   /** Supplies run-global model-call ordering for parallel tool outcomes. */
   allocateToolOutcomeOrdinal?: (toolCallId?: string) => number;
   /** Runtime-only resolved skill paths that the read tool may load under workspaceOnly. */
@@ -605,6 +609,17 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const runtimeRoot = capabilityProfile.workspace.runtimeRoot;
   const codingRoot = sandboxRoot ?? runtimeRoot;
   const memoryFlushWriteRoot = sandboxRoot ?? workspaceRoot;
+  const memoryWriteProvenance = isMemoryFlushRun
+    ? undefined
+    : createMemoryWriteProvenanceObserver({
+        mutationRoot: sandboxRoot ?? workspaceRoot,
+        workspaceDir: workspaceRoot,
+        plan: resolveMemoryFlushPlan({ cfg: options?.config }) ?? {},
+        resolveOriginClass: () =>
+          options?.senderIsOwner === false || options?.isTurnTainted?.() === true
+            ? "untrusted"
+            : "agent",
+      });
   const includeCoreTools = options?.includeCoreTools !== false;
   const toolConstructionPlan = options?.toolConstructionPlan ?? {
     includeBaseCodingTools: includeCoreTools,
@@ -688,7 +703,10 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
         if (sandboxRoot) {
           continue;
         }
-        const wrapped = createHostWorkspaceWriteTool(codingRoot, { workspaceOnly });
+        const wrapped = createHostWorkspaceWriteTool(codingRoot, {
+          workspaceOnly,
+          memoryWriteProvenance,
+        });
         base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, codingRoot) : wrapped);
         continue;
       }
@@ -696,7 +714,10 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
         if (sandboxRoot) {
           continue;
         }
-        const wrapped = createHostWorkspaceEditTool(codingRoot, { workspaceOnly });
+        const wrapped = createHostWorkspaceEditTool(codingRoot, {
+          workspaceOnly,
+          memoryWriteProvenance,
+        });
         base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, codingRoot) : wrapped);
         continue;
       }
@@ -789,6 +810,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
               ? { root: sandboxRoot, bridge: sandboxFsBridge! }
               : undefined,
           workspaceOnly: applyPatchWorkspaceOnly,
+          memoryWriteProvenance,
         });
   options?.recordToolPrepStage?.("shell-tools");
   const ownerOnlyCoreToolDenylist =
@@ -897,22 +919,38 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
         ? [
             workspaceOnly
               ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                  createSandboxedEditTool({
+                    root: sandboxRoot,
+                    bridge: sandboxFsBridge!,
+                    memoryWriteProvenance,
+                  }),
                   sandboxRoot,
                   {
                     containerWorkdir: sandbox.containerWorkdir,
                   },
                 )
-              : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+              : createSandboxedEditTool({
+                  root: sandboxRoot,
+                  bridge: sandboxFsBridge!,
+                  memoryWriteProvenance,
+                }),
             workspaceOnly
               ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                  createSandboxedWriteTool({
+                    root: sandboxRoot,
+                    bridge: sandboxFsBridge!,
+                    memoryWriteProvenance,
+                  }),
                   sandboxRoot,
                   {
                     containerWorkdir: sandbox.containerWorkdir,
                   },
                 )
-              : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+              : createSandboxedWriteTool({
+                  root: sandboxRoot,
+                  bridge: sandboxFsBridge!,
+                  memoryWriteProvenance,
+                }),
           ]
         : []
       : []),

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -609,7 +609,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const runtimeRoot = capabilityProfile.workspace.runtimeRoot;
   const codingRoot = sandboxRoot ?? runtimeRoot;
   const memoryFlushWriteRoot = sandboxRoot ?? workspaceRoot;
-  // Flush runs expose one append-only target and record it after success with inherited taint.
+  // Flush exposes one append-only target; its fallback records inherited taint after success.
   const memoryWriteProvenance = isMemoryFlushRun
     ? undefined
     : createMemoryWriteProvenanceObserver({

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -609,6 +609,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const runtimeRoot = capabilityProfile.workspace.runtimeRoot;
   const codingRoot = sandboxRoot ?? runtimeRoot;
   const memoryFlushWriteRoot = sandboxRoot ?? workspaceRoot;
+  // Flush runs expose one append-only target and record it after success with inherited taint.
   const memoryWriteProvenance = isMemoryFlushRun
     ? undefined
     : createMemoryWriteProvenanceObserver({

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -12,6 +12,7 @@ import { openRootFile, type RootFileOpenResult } from "../infra/boundary-file-re
 import { root as fsRoot } from "../infra/fs-safe.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-guards.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
+import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
 import { toRelativeSandboxPath, resolvePathFromInput } from "./path-policy.js";
 import type { AgentTool } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
@@ -89,6 +90,7 @@ type ApplyPatchOptions = {
   sandbox?: SandboxApplyPatchConfig;
   /** Restrict patch paths to the workspace root (cwd). Default: true. Set false to opt out. */
   workspaceOnly?: boolean;
+  memoryWriteProvenance?: MemoryWriteProvenanceObserver;
   signal?: AbortSignal;
 };
 
@@ -114,7 +116,12 @@ const ApplyPatchToolOutputSchema = Type.Object(
 
 /** Create the agent tool wrapper for applying patch-envelope input. */
 export function createApplyPatchTool(
-  options: { cwd?: string; sandbox?: SandboxApplyPatchConfig; workspaceOnly?: boolean } = {},
+  options: {
+    cwd?: string;
+    sandbox?: SandboxApplyPatchConfig;
+    workspaceOnly?: boolean;
+    memoryWriteProvenance?: MemoryWriteProvenanceObserver;
+  } = {},
 ): AgentTool<typeof applyPatchSchema, ApplyPatchToolDetails> {
   const cwd = options.cwd ?? process.cwd();
   const sandbox = options.sandbox;
@@ -140,6 +147,7 @@ export function createApplyPatchTool(
         cwd,
         sandbox,
         workspaceOnly,
+        memoryWriteProvenance: options.memoryWriteProvenance,
         signal,
       });
 
@@ -287,9 +295,10 @@ type PatchFileOps = {
 };
 
 function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
+  let operations: PatchFileOps;
   if (options.sandbox) {
     const { root, bridge } = options.sandbox;
-    return {
+    operations = {
       readFile: async (filePath) => {
         const buf = await bridge.readFile({ filePath, cwd: root });
         return decodeUtf8File(buf, filePath);
@@ -298,57 +307,86 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
       remove: (filePath) => bridge.remove({ filePath, cwd: root, force: false }),
       mkdirp: (dir) => bridge.mkdirp({ filePath: dir, cwd: root }),
     };
+  } else {
+    const workspaceOnly = options.workspaceOnly !== false;
+    const rootPromise = workspaceOnly ? fsRoot(options.cwd) : undefined;
+    operations = {
+      readFile: async (filePath) => {
+        if (!workspaceOnly) {
+          return decodeUtf8File(await fs.readFile(filePath), filePath);
+        }
+        const opened = await openRootFile({
+          absolutePath: filePath,
+          rootPath: options.cwd,
+          boundaryLabel: "workspace root",
+        });
+        assertBoundaryRead(opened, filePath);
+        try {
+          return decodeUtf8File(syncFs.readFileSync(opened.fd), filePath);
+        } finally {
+          syncFs.closeSync(opened.fd);
+        }
+      },
+      writeFile: async (filePath, content) => {
+        if (!workspaceOnly) {
+          await fs.writeFile(filePath, content, "utf8");
+          return;
+        }
+        const relative = toRelativeSandboxPath(options.cwd, filePath);
+        await (await rootPromise)?.write(relative, content, { encoding: "utf8" });
+      },
+      remove: async (filePath) => {
+        if (!workspaceOnly) {
+          await fs.rm(filePath);
+          return;
+        }
+        const relative = toRelativeSandboxPath(options.cwd, filePath);
+        await (await rootPromise)?.remove(relative);
+      },
+      mkdirp: async (dir) => {
+        if (!workspaceOnly) {
+          await fs.mkdir(dir, { recursive: true });
+          return;
+        }
+        const relative = toRelativeSandboxPath(options.cwd, dir, { allowRoot: true });
+        const root = await rootPromise;
+        if (!root) {
+          return;
+        }
+        if (relative === "" || relative === ".") {
+          await root.ensureRoot();
+          return;
+        }
+        await root.mkdir(relative);
+      },
+    };
   }
-  const workspaceOnly = options.workspaceOnly !== false;
-  const rootPromise = workspaceOnly ? fsRoot(options.cwd) : undefined;
+  const observer = options.memoryWriteProvenance;
+  if (!observer) {
+    return operations;
+  }
+  const isMissing = (error: unknown) =>
+    (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT" ||
+    (error instanceof Error && error.message.includes("(path not found)"));
   return {
-    readFile: async (filePath) => {
-      if (!workspaceOnly) {
-        return decodeUtf8File(await fs.readFile(filePath), filePath);
-      }
-      const opened = await openRootFile({
-        absolutePath: filePath,
-        rootPath: options.cwd,
-        boundaryLabel: "workspace root",
-      });
-      assertBoundaryRead(opened, filePath);
-      try {
-        return decodeUtf8File(syncFs.readFileSync(opened.fd), filePath);
-      } finally {
-        syncFs.closeSync(opened.fd);
-      }
-    },
+    ...operations,
     writeFile: async (filePath, content) => {
-      if (!workspaceOnly) {
-        await fs.writeFile(filePath, content, "utf8");
-        return;
-      }
-      const relative = toRelativeSandboxPath(options.cwd, filePath);
-      await (await rootPromise)?.write(relative, content, { encoding: "utf8" });
+      const contentBefore = await operations.readFile(filePath).catch((error: unknown) => {
+        if (isMissing(error)) {
+          return "";
+        }
+        throw error;
+      });
+      await observer.recordBeforeWrite({
+        absolutePath: filePath,
+        contentBefore,
+        contentAfter: content,
+      });
+      await operations.writeFile(filePath, content);
     },
     remove: async (filePath) => {
-      if (!workspaceOnly) {
-        await fs.rm(filePath);
-        return;
-      }
-      const relative = toRelativeSandboxPath(options.cwd, filePath);
-      await (await rootPromise)?.remove(relative);
-    },
-    mkdirp: async (dir) => {
-      if (!workspaceOnly) {
-        await fs.mkdir(dir, { recursive: true });
-        return;
-      }
-      const relative = toRelativeSandboxPath(options.cwd, dir, { allowRoot: true });
-      const root = await rootPromise;
-      if (!root) {
-        return;
-      }
-      if (relative === "" || relative === ".") {
-        await root.ensureRoot();
-        return;
-      }
-      await root.mkdir(relative);
+      await operations.remove(filePath);
+      await observer.clearAfterDelete(filePath);
     },
   };
 }

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -12,7 +12,10 @@ import { openRootFile, type RootFileOpenResult } from "../infra/boundary-file-re
 import { root as fsRoot } from "../infra/fs-safe.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-guards.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
-import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
+import {
+  type MemoryWriteProvenanceObserver,
+  withMemoryWriteProvenance,
+} from "./memory-write-provenance.js";
 import { toRelativeSandboxPath, resolvePathFromInput } from "./path-policy.js";
 import type { AgentTool } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
@@ -372,38 +375,7 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
       },
     };
   }
-  const observer = options.memoryWriteProvenance;
-  if (!observer) {
-    return operations;
-  }
-  const isMissing = (error: unknown) =>
-    (error as NodeJS.ErrnoException | undefined)?.code === "ENOENT" ||
-    (error instanceof Error && error.message.includes("(path not found)"));
-  return {
-    ...operations,
-    writeFile: async (filePath, content) => {
-      if (!observer.classifies(filePath)) {
-        await operations.writeFile(filePath, content);
-        return;
-      }
-      const contentBefore = await operations.readFile(filePath).catch((error: unknown) => {
-        if (isMissing(error)) {
-          return "";
-        }
-        throw error;
-      });
-      await observer.write({
-        absolutePath: filePath,
-        contentBefore,
-        contentAfter: content,
-        commit: () => operations.writeFile(filePath, content),
-      });
-    },
-    remove: async (filePath) => {
-      await operations.remove(filePath);
-      await observer.clearAfterDelete(filePath);
-    },
-  };
+  return withMemoryWriteProvenance(operations, options.memoryWriteProvenance);
 }
 
 async function ensureDir(filePath: string, ops: PatchFileOps) {

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -377,12 +377,12 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
         }
         throw error;
       });
-      await observer.recordBeforeWrite({
+      await observer.write({
         absolutePath: filePath,
         contentBefore,
         contentAfter: content,
+        commit: () => operations.writeFile(filePath, content),
       });
-      await operations.writeFile(filePath, content);
     },
     remove: async (filePath) => {
       await operations.remove(filePath);

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -17,6 +17,10 @@ import { toRelativeSandboxPath, resolvePathFromInput } from "./path-policy.js";
 import type { AgentTool } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+import {
+  withFileMutationQueue,
+  withFileMutationQueues,
+} from "./sessions/tools/file-mutation-queue.js";
 import { decodeUtf8File } from "./utf8-file.js";
 
 const BEGIN_PATCH_MARKER = "*** Begin Patch";
@@ -187,65 +191,72 @@ async function applyPatch(input: string, options: ApplyPatchOptions): Promise<Ap
 
     if (hunk.kind === "add") {
       const target = await resolvePatchPath(hunk.path, options);
-      await assertPatchParentPath(hunk.path, options);
-      await ensureDir(target.resolved, fileOps);
-      await fileOps.writeFile(target.resolved, hunk.contents);
+      await withFileMutationQueue(target.resolved, async () => {
+        await assertPatchParentPath(hunk.path, options);
+        await ensureDir(target.resolved, fileOps);
+        await fileOps.writeFile(target.resolved, hunk.contents);
+      });
       recordSummary(summary, seen, "added", target.display);
       continue;
     }
 
     if (hunk.kind === "delete") {
       const target = await resolvePatchPath(hunk.path, options, PATH_ALIAS_POLICIES.unlinkTarget);
-      await fileOps.remove(target.resolved);
+      await withFileMutationQueue(target.resolved, () => fileOps.remove(target.resolved));
       recordSummary(summary, seen, "deleted", target.display);
       continue;
     }
 
     const target = await resolvePatchPath(hunk.path, options);
-    const applied = await applyUpdateHunk(target.resolved, hunk.chunks, {
-      readFile: (pathLocal) => fileOps.readFile(pathLocal),
-    });
+    const moveTarget = hunk.movePath ? await resolvePatchPath(hunk.movePath, options) : undefined;
+    await withFileMutationQueues(
+      [target.resolved, ...(moveTarget ? [moveTarget.resolved] : [])],
+      async () => {
+        const applied = await applyUpdateHunk(target.resolved, hunk.chunks, {
+          readFile: (pathLocal) => fileOps.readFile(pathLocal),
+        });
 
-    if (hunk.movePath) {
-      const moveTarget = await resolvePatchPath(hunk.movePath, options);
-      await assertPatchParentPath(hunk.movePath, options);
-      await ensureDir(moveTarget.resolved, fileOps);
-      const moveResolvesToSource =
-        path.resolve(moveTarget.resolved) === path.resolve(target.resolved);
-      const destination = moveResolvesToSource ? target.resolved : moveTarget.resolved;
-      if (moveResolvesToSource) {
+        if (hunk.movePath && moveTarget) {
+          await assertPatchParentPath(hunk.movePath, options);
+          await ensureDir(moveTarget.resolved, fileOps);
+          const moveResolvesToSource =
+            path.resolve(moveTarget.resolved) === path.resolve(target.resolved);
+          const destination = moveResolvesToSource ? target.resolved : moveTarget.resolved;
+          if (moveResolvesToSource) {
+            const existing = await fileOps.readFile(target.resolved);
+            if (normalizeUpdateComparison(existing) === normalizeUpdateComparison(applied)) {
+              noOpPaths.add(target.display);
+            } else {
+              noOpPaths.delete(target.display);
+              await fileOps.writeFile(destination, applied);
+            }
+          } else {
+            noOpPaths.delete(target.display);
+            await fileOps.writeFile(destination, applied);
+          }
+          if (!moveResolvesToSource) {
+            await fileOps.remove(target.resolved);
+          }
+          if (!noOpPaths.has(target.display)) {
+            recordSummary(
+              summary,
+              seen,
+              "modified",
+              moveResolvesToSource ? target.display : moveTarget.display,
+            );
+          }
+          return;
+        }
         const existing = await fileOps.readFile(target.resolved);
         if (normalizeUpdateComparison(existing) === normalizeUpdateComparison(applied)) {
           noOpPaths.add(target.display);
         } else {
           noOpPaths.delete(target.display);
-          await fileOps.writeFile(destination, applied);
+          await fileOps.writeFile(target.resolved, applied);
+          recordSummary(summary, seen, "modified", target.display);
         }
-      } else {
-        noOpPaths.delete(target.display);
-        await fileOps.writeFile(destination, applied);
-      }
-      if (!moveResolvesToSource) {
-        await fileOps.remove(target.resolved);
-      }
-      if (!noOpPaths.has(target.display)) {
-        recordSummary(
-          summary,
-          seen,
-          "modified",
-          moveResolvesToSource ? target.display : moveTarget.display,
-        );
-      }
-    } else {
-      const existing = await fileOps.readFile(target.resolved);
-      if (normalizeUpdateComparison(existing) === normalizeUpdateComparison(applied)) {
-        noOpPaths.add(target.display);
-      } else {
-        noOpPaths.delete(target.display);
-        await fileOps.writeFile(target.resolved, applied);
-        recordSummary(summary, seen, "modified", target.display);
-      }
-    }
+      },
+    );
   }
 
   const noOp = noOpPaths.size > 0 && Object.values(summary).every((paths) => paths.length === 0);
@@ -371,6 +382,10 @@ function resolvePatchFileOps(options: ApplyPatchOptions): PatchFileOps {
   return {
     ...operations,
     writeFile: async (filePath, content) => {
+      if (!observer.classifies(filePath)) {
+        await operations.writeFile(filePath, content);
+        return;
+      }
       const contentBefore = await operations.readFile(filePath).catch((error: unknown) => {
         if (isMissing(error)) {
           return "";

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -50,6 +50,7 @@ import { prepareTerminalWithSettledTurnFinalization } from "./run/settled-turn-f
 import { resolveEmbeddedRunTerminal } from "./run/terminal-resolution.js";
 import { createEmbeddedRunTerminalRetryState } from "./run/terminal-retry-state.js";
 import { resolveEmbeddedRunTerminalTimeout } from "./run/terminal-timeout.js";
+import { createAgentTurnTaintState } from "./run/turn-taint-state.js";
 import type { EmbeddedAgentRunResult, TraceAttempt } from "./types.js";
 import { createUsageAccumulator } from "./usage-accumulator.js";
 
@@ -205,6 +206,7 @@ export async function runPreparedEmbeddedLoop(
   const allocateToolOutcomeOrdinal = (): number => nextToolOutcomeOrdinal++;
   const readAttemptTerminalToolPresentation = (): string | undefined =>
     attemptTerminalToolPresentation.value;
+  const turnTaintState = createAgentTurnTaintState();
   const observeToolOutcome = (observation: ToolOutcomeObservation): void => {
     const observationOrdinal =
       observation.toolCallOrdinal ?? attemptTerminalToolPresentation.ordinal + 1;
@@ -212,6 +214,7 @@ export async function runPreparedEmbeddedLoop(
       attemptTerminalToolPresentation.ordinal = observationOrdinal;
       attemptTerminalToolPresentation.value = observation.terminalPresentation;
     }
+    turnTaintState.observe(observation);
     if (observation.presentationOnly) {
       return;
     }
@@ -330,6 +333,7 @@ export async function runPreparedEmbeddedLoop(
         bootstrapPromptWarningSignaturesSeen,
         resolveRuntimeFallbackReason,
         observeToolOutcome,
+        isTurnTainted: turnTaintState.isTainted,
         allocateToolOutcomeOrdinal,
         getPostCompactionAbortError: () => postCompactionAbortError,
         setPostCompactionAbortController: (controller) => {

--- a/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
@@ -36,6 +36,7 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
   bootstrapPromptWarningSignaturesSeen: string[];
   resolveRuntimeFallbackReason: () => string | null;
   observeToolOutcome: Parameters<typeof dispatchEmbeddedRunAttempt>[0]["control"]["onToolOutcome"];
+  isTurnTainted: () => boolean;
   allocateToolOutcomeOrdinal: Parameters<
     typeof dispatchEmbeddedRunAttempt
   >[0]["control"]["allocateToolOutcomeOrdinal"];
@@ -244,6 +245,7 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
       laneTaskReleaseController,
       noteLaneTaskProgress,
       onToolOutcome: input.observeToolOutcome,
+      isTurnTainted: input.isTurnTainted,
       allocateToolOutcomeOrdinal: input.allocateToolOutcomeOrdinal,
       onToolStreamBoundary: maybeAnnounceFastModeAutoOff,
       onRunProgress: notifyRunProgress,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
@@ -301,6 +301,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
           authProfileStore: attempt.authProfileStore,
           recordToolPrepStage: params.markCoreToolStage,
           onToolOutcome: attempt.onToolOutcome,
+          isTurnTainted: attempt.isTurnTainted,
           allocateToolOutcomeOrdinal: attempt.allocateToolOutcomeOrdinal,
           skillsSnapshot: params.skillsSnapshot,
           skillUsagePaths: params.skillUsagePaths,

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -84,6 +84,7 @@ type AttemptControl = {
   laneTaskReleaseController: AbortController;
   noteLaneTaskProgress: () => void;
   onToolOutcome: ToolOutcomeObserver;
+  isTurnTainted: () => boolean;
   allocateToolOutcomeOrdinal: (toolCallId?: string) => number;
   onToolStreamBoundary: NonNullable<EmbeddedRunAttemptParams["onToolStreamBoundary"]>;
   onRunProgress: NonNullable<EmbeddedRunAttemptParams["onRunProgress"]>;
@@ -287,6 +288,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     agentId: runtime.agentId,
     thinkLevel: runtime.thinkLevel,
     onToolOutcome: control.onToolOutcome,
+    isTurnTainted: control.isTurnTainted,
     allocateToolOutcomeOrdinal: control.allocateToolOutcomeOrdinal,
     onToolStreamBoundary: control.onToolStreamBoundary,
     onRunProgress: control.onRunProgress,

--- a/src/agents/embedded-agent-runner/run/turn-taint-state.test.ts
+++ b/src/agents/embedded-agent-runner/run/turn-taint-state.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { createAgentTurnTaintState } from "./turn-taint-state.js";
+
+describe("agent turn taint state", () => {
+  it("becomes sticky after network content while ignoring presentation updates", () => {
+    const state = createAgentTurnTaintState();
+    expect(state.isTainted()).toBe(false);
+
+    state.observe({
+      toolName: "fake_web_tool",
+      argsHash: "args",
+      resultHash: "result",
+      resultContentSource: "network",
+      presentationOnly: true,
+    });
+    expect(state.isTainted()).toBe(false);
+
+    state.observe({
+      toolName: "fake_web_tool",
+      argsHash: "args",
+      resultHash: "result",
+      resultContentSource: "network",
+    });
+    state.observe({ toolName: "read", argsHash: "next", resultHash: "next" });
+    expect(state.isTainted()).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/turn-taint-state.ts
+++ b/src/agents/embedded-agent-runner/run/turn-taint-state.ts
@@ -1,0 +1,14 @@
+import type { ToolOutcomeObservation } from "../../agent-tools.before-tool-call.js";
+
+/** Sticky current-turn taint shared by retries and runtime-specific tool owners. */
+export function createAgentTurnTaintState() {
+  let tainted = false;
+  return {
+    observe(observation: ToolOutcomeObservation): void {
+      if (!observation.presentationOnly && observation.resultContentSource === "network") {
+        tainted = true;
+      }
+    },
+    isTainted: () => tainted,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -141,6 +141,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   trajectoryRecorder?: EmbeddedRunAttemptTrajectoryRecorder | null;
   /** Live observer called after wrapped tool outcomes are recorded. */
   onToolOutcome?: ToolOutcomeObserver;
+  /** Reads the sticky untrusted-content flag for the current user turn. */
+  isTurnTainted?: () => boolean;
   /** Signals that the attempt's own run-timeout watchdog is active. */
   onAttemptTimeoutArmed?: () => void;
   /** Signals that this attempt's timeout has fired and must unwind promptly. */

--- a/src/agents/memory-write-provenance.test.ts
+++ b/src/agents/memory-write-provenance.test.ts
@@ -5,8 +5,8 @@ describe("memory write provenance", () => {
   it("rolls provenance back when the filesystem write fails", async () => {
     let provenance = "before";
     const observer = createMemoryWriteProvenanceObserver({
-      mutationRoot: "/workspace",
-      workspaceDir: "/workspace",
+      mutationRoot: process.cwd(),
+      workspaceDir: process.cwd(),
       plan: {
         recordWriteProvenance: async () => {
           provenance = "predicted";
@@ -24,7 +24,7 @@ describe("memory write provenance", () => {
 
     await expect(
       observer?.write({
-        absolutePath: "/workspace/memory/2026-07-29.md",
+        absolutePath: `${process.cwd()}/MEMORY.md`,
         contentBefore: "before",
         contentAfter: "after",
         commit,

--- a/src/agents/memory-write-provenance.test.ts
+++ b/src/agents/memory-write-provenance.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
+
+describe("memory write provenance", () => {
+  it("rolls provenance back when the filesystem write fails", async () => {
+    let provenance = "before";
+    const observer = createMemoryWriteProvenanceObserver({
+      mutationRoot: "/workspace",
+      workspaceDir: "/workspace",
+      plan: {
+        recordWriteProvenance: async () => {
+          provenance = "predicted";
+          return async () => {
+            provenance = "before";
+          };
+        },
+      },
+      resolveOriginClass: () => "untrusted",
+      now: () => 1,
+    });
+    const commit = vi.fn(async () => {
+      throw new Error("disk full");
+    });
+
+    await expect(
+      observer?.write({
+        absolutePath: "/workspace/memory/2026-07-29.md",
+        contentBefore: "before",
+        contentAfter: "after",
+        commit,
+      }),
+    ).rejects.toThrow("disk full");
+    expect(provenance).toBe("before");
+    expect(commit).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/memory-write-provenance.ts
+++ b/src/agents/memory-write-provenance.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import { logWarn } from "../logger.js";
 import type { MemoryFlushPlan } from "../plugins/memory-state.js";
@@ -67,7 +68,14 @@ export function withMemoryWriteProvenance<T extends ProvenanceWriteOperations>(
 }
 
 function resolveMemoryRelativePath(root: string, absolutePath: string): string | undefined {
-  const relativePath = path.relative(path.resolve(root), path.resolve(absolutePath));
+  const canonicalPath = (candidate: string) => {
+    try {
+      return realpathSync.native(candidate);
+    } catch {
+      return path.join(realpathSync.native(path.dirname(candidate)), path.basename(candidate));
+    }
+  };
+  const relativePath = path.relative(canonicalPath(root), canonicalPath(absolutePath));
   if (
     !relativePath ||
     path.isAbsolute(relativePath) ||

--- a/src/agents/memory-write-provenance.ts
+++ b/src/agents/memory-write-provenance.ts
@@ -1,11 +1,13 @@
 import path from "node:path";
+import { logWarn } from "../logger.js";
 import type { MemoryFlushPlan } from "../plugins/memory-state.js";
 
 export type MemoryWriteProvenanceObserver = {
-  recordBeforeWrite: (params: {
+  write: (params: {
     absolutePath: string;
     contentBefore: string;
     contentAfter: string;
+    commit: () => Promise<void>;
   }) => Promise<void>;
   clearAfterDelete: (absolutePath: string) => Promise<void>;
 };
@@ -39,12 +41,13 @@ export function createMemoryWriteProvenanceObserver(params: {
   }
   const now = params.now ?? Date.now;
   return {
-    recordBeforeWrite: async ({ absolutePath, contentBefore, contentAfter }) => {
+    write: async ({ absolutePath, contentBefore, contentAfter, commit }) => {
       const relativePath = resolveMemoryRelativePath(params.mutationRoot, absolutePath);
       if (!relativePath) {
+        await commit();
         return;
       }
-      await params.plan.recordWriteProvenance?.({
+      const rollback = await params.plan.recordWriteProvenance?.({
         workspaceDir: params.workspaceDir,
         relativePath,
         contentBefore,
@@ -52,16 +55,35 @@ export function createMemoryWriteProvenanceObserver(params: {
         originClass: params.resolveOriginClass(),
         observedAt: now(),
       });
+      try {
+        await commit();
+      } catch (error) {
+        try {
+          await rollback?.();
+        } catch (rollbackError) {
+          throw new AggregateError(
+            [error, rollbackError],
+            "File write and memory provenance rollback failed",
+          );
+        }
+        throw error;
+      }
     },
     clearAfterDelete: async (absolutePath) => {
       const relativePath = resolveMemoryRelativePath(params.mutationRoot, absolutePath);
       if (!relativePath) {
         return;
       }
-      await params.plan.clearWriteProvenance?.({
-        workspaceDir: params.workspaceDir,
-        relativePath,
-      });
+      try {
+        await params.plan.clearWriteProvenance?.({
+          workspaceDir: params.workspaceDir,
+          relativePath,
+        });
+      } catch (error) {
+        // The file is already gone. Retaining stale quarantine is safer than
+        // reporting the filesystem mutation as failed after it committed.
+        logWarn(`memory provenance cleanup failed for ${relativePath}: ${String(error)}`);
+      }
     },
   };
 }

--- a/src/agents/memory-write-provenance.ts
+++ b/src/agents/memory-write-provenance.ts
@@ -1,0 +1,67 @@
+import path from "node:path";
+import type { MemoryFlushPlan } from "../plugins/memory-state.js";
+
+export type MemoryWriteProvenanceObserver = {
+  recordBeforeWrite: (params: {
+    absolutePath: string;
+    contentBefore: string;
+    contentAfter: string;
+  }) => Promise<void>;
+  clearAfterDelete: (absolutePath: string) => Promise<void>;
+};
+
+function resolveMemoryRelativePath(root: string, absolutePath: string): string | undefined {
+  const relativePath = path.relative(path.resolve(root), path.resolve(absolutePath));
+  if (
+    !relativePath ||
+    path.isAbsolute(relativePath) ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`)
+  ) {
+    return undefined;
+  }
+  const normalized = relativePath.replaceAll(path.sep, "/");
+  if (["MEMORY.md", "memory.md", "USER.md"].includes(normalized)) {
+    return normalized;
+  }
+  return normalized.startsWith("memory/") && normalized.endsWith(".md") ? normalized : undefined;
+}
+
+export function createMemoryWriteProvenanceObserver(params: {
+  mutationRoot: string;
+  workspaceDir: string;
+  plan: Pick<MemoryFlushPlan, "recordWriteProvenance" | "clearWriteProvenance">;
+  resolveOriginClass: () => "agent" | "untrusted";
+  now?: () => number;
+}): MemoryWriteProvenanceObserver | undefined {
+  if (!params.plan.recordWriteProvenance) {
+    return undefined;
+  }
+  const now = params.now ?? Date.now;
+  return {
+    recordBeforeWrite: async ({ absolutePath, contentBefore, contentAfter }) => {
+      const relativePath = resolveMemoryRelativePath(params.mutationRoot, absolutePath);
+      if (!relativePath) {
+        return;
+      }
+      await params.plan.recordWriteProvenance?.({
+        workspaceDir: params.workspaceDir,
+        relativePath,
+        contentBefore,
+        contentAfter,
+        originClass: params.resolveOriginClass(),
+        observedAt: now(),
+      });
+    },
+    clearAfterDelete: async (absolutePath) => {
+      const relativePath = resolveMemoryRelativePath(params.mutationRoot, absolutePath);
+      if (!relativePath) {
+        return;
+      }
+      await params.plan.clearWriteProvenance?.({
+        workspaceDir: params.workspaceDir,
+        relativePath,
+      });
+    },
+  };
+}

--- a/src/agents/memory-write-provenance.ts
+++ b/src/agents/memory-write-provenance.ts
@@ -61,9 +61,9 @@ export function createMemoryWriteProvenanceObserver(params: {
         try {
           await rollback?.();
         } catch (rollbackError) {
-          throw new AggregateError(
-            [error, rollbackError],
-            "File write and memory provenance rollback failed",
+          throw new Error(
+            `File write failed and memory provenance rollback also failed: ${String(error)}`,
+            { cause: rollbackError },
           );
         }
         throw error;

--- a/src/agents/memory-write-provenance.ts
+++ b/src/agents/memory-write-provenance.ts
@@ -3,6 +3,7 @@ import { logWarn } from "../logger.js";
 import type { MemoryFlushPlan } from "../plugins/memory-state.js";
 
 export type MemoryWriteProvenanceObserver = {
+  classifies: (absolutePath: string) => boolean;
   write: (params: {
     absolutePath: string;
     contentBefore: string;
@@ -41,6 +42,8 @@ export function createMemoryWriteProvenanceObserver(params: {
   }
   const now = params.now ?? Date.now;
   return {
+    classifies: (absolutePath) =>
+      resolveMemoryRelativePath(params.mutationRoot, absolutePath) !== undefined,
     write: async ({ absolutePath, contentBefore, contentAfter, commit }) => {
       const relativePath = resolveMemoryRelativePath(params.mutationRoot, absolutePath);
       if (!relativePath) {

--- a/src/agents/memory-write-provenance.ts
+++ b/src/agents/memory-write-provenance.ts
@@ -13,6 +13,59 @@ export type MemoryWriteProvenanceObserver = {
   clearAfterDelete: (absolutePath: string) => Promise<void>;
 };
 
+type ProvenanceWriteOperations = {
+  readFile: (absolutePath: string) => Promise<Buffer | string>;
+  writeFile: (absolutePath: string, content: string) => Promise<void>;
+  remove?: (absolutePath: string) => Promise<void>;
+};
+
+function isMissingFileError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | undefined)?.code;
+  return code === "ENOENT" || code === "not-found" || String(error).includes("(path not found)");
+}
+
+export function withMemoryWriteProvenance<T extends ProvenanceWriteOperations>(
+  operations: T,
+  observer: MemoryWriteProvenanceObserver | undefined,
+): T {
+  if (!observer) {
+    return operations;
+  }
+  const remove = operations.remove;
+  return {
+    ...operations,
+    writeFile: async (absolutePath: string, content: string) => {
+      if (!observer.classifies(absolutePath)) {
+        await operations.writeFile(absolutePath, content);
+        return;
+      }
+      const contentBefore = await operations
+        .readFile(absolutePath)
+        .then((value) => (Buffer.isBuffer(value) ? value.toString("utf8") : value))
+        .catch((error: unknown) => {
+          if (!isMissingFileError(error)) {
+            throw error;
+          }
+          return "";
+        });
+      await observer.write({
+        absolutePath,
+        contentBefore,
+        contentAfter: content,
+        commit: () => operations.writeFile(absolutePath, content),
+      });
+    },
+    ...(remove
+      ? {
+          remove: async (absolutePath: string) => {
+            await remove(absolutePath);
+            await observer.clearAfterDelete(absolutePath);
+          },
+        }
+      : {}),
+  } as T;
+}
+
 function resolveMemoryRelativePath(root: string, absolutePath: string): string | undefined {
   const relativePath = path.relative(path.resolve(root), path.resolve(absolutePath));
   if (

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -34,6 +34,7 @@ import type { Static, TSchema } from "typebox";
 import type { Theme } from "../../modes/interactive/theme/theme.js";
 import type {
   AgentMessage,
+  AgentTool,
   AgentToolResult,
   AgentToolUpdateCallback,
   StreamFn,
@@ -496,6 +497,8 @@ export interface ToolDefinition<
   label: string;
   /** Preserve lifecycle telemetry without rendering transient channel progress. */
   hideFromChannelProgress?: boolean;
+  /** Tool results contain externally controlled network content. */
+  resultContentSource?: AgentTool["resultContentSource"];
   /** Description for LLM */
   description: string;
   /** Optional one-line snippet for the Available tools section in the default system prompt. Custom tools are omitted from that section when this is not provided. */

--- a/src/agents/sessions/tools/file-mutation-queue.ts
+++ b/src/agents/sessions/tools/file-mutation-queue.ts
@@ -5,9 +5,8 @@
  */
 import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
-import { KeyedAsyncQueue } from "../../../plugin-sdk/keyed-async-queue.js";
 
-const fileMutationQueue = new KeyedAsyncQueue();
+const fileMutationTails = new Map<string, Promise<void>>();
 
 function getMutationQueueKey(filePath: string): string {
   const resolvedPath = resolve(filePath);
@@ -23,6 +22,31 @@ function getMutationQueueKey(filePath: string): string {
  * Operations for different files still run in parallel.
  */
 export async function withFileMutationQueue<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
-  const key = getMutationQueueKey(filePath);
-  return await fileMutationQueue.enqueue(key, fn);
+  return await withFileMutationQueues([filePath], fn);
+}
+
+export async function withFileMutationQueues<T>(
+  filePaths: readonly string[],
+  fn: () => Promise<T>,
+): Promise<T> {
+  const keys = [...new Set(filePaths.map(getMutationQueueKey))].toSorted();
+  const current = Promise.all(
+    keys.map((key) => (fileMutationTails.get(key) ?? Promise.resolve()).catch(() => undefined)),
+  ).then(fn);
+  const tail = current.then(
+    () => undefined,
+    () => undefined,
+  );
+  for (const key of keys) {
+    fileMutationTails.set(key, tail);
+  }
+  const cleanup = () => {
+    for (const key of keys) {
+      if (fileMutationTails.get(key) === tail) {
+        fileMutationTails.delete(key);
+      }
+    }
+  };
+  tail.then(cleanup, cleanup);
+  return await current;
 }

--- a/src/agents/sessions/tools/tool-definition-wrapper.test.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.test.ts
@@ -1,0 +1,24 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import type { AgentTool } from "../../runtime/index.js";
+import {
+  createToolDefinitionFromAgentTool,
+  wrapToolDefinition,
+} from "./tool-definition-wrapper.js";
+
+describe("tool definition result content source", () => {
+  it("survives both AgentTool adapter directions", () => {
+    const tool: AgentTool = {
+      name: "network_reader",
+      label: "Network reader",
+      description: "Reads external content",
+      parameters: Type.Object({}),
+      resultContentSource: "network",
+      execute: async () => ({ content: [], details: {} }),
+    };
+
+    const definition = createToolDefinitionFromAgentTool(tool);
+    expect(definition.resultContentSource).toBe("network");
+    expect(wrapToolDefinition(definition).resultContentSource).toBe("network");
+  });
+});

--- a/src/agents/sessions/tools/tool-definition-wrapper.ts
+++ b/src/agents/sessions/tools/tool-definition-wrapper.ts
@@ -20,6 +20,9 @@ export function wrapToolDefinition<
     name: definition.name,
     label: definition.label,
     ...(definition.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
+    ...(definition.resultContentSource
+      ? { resultContentSource: definition.resultContentSource }
+      : {}),
     description: definition.description,
     parameters: definition.parameters,
     ...(definition.outputSchema ? { outputSchema: definition.outputSchema } : {}),
@@ -49,6 +52,7 @@ export function createToolDefinitionFromAgentTool(tool: AgentTool): ToolDefiniti
     name: tool.name,
     label: tool.label,
     ...(tool.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
+    ...(tool.resultContentSource ? { resultContentSource: tool.resultContentSource } : {}),
     description: tool.description,
     parameters: tool.parameters,
     ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -836,6 +836,7 @@ export function createWebFetchTool(options?: {
   const tool: AnyAgentTool = {
     label: "Web Fetch",
     name: "web_fetch",
+    resultContentSource: "network",
     description: "Fetch URL; extract readable markdown/text. Lightweight; no browser automation.",
     parameters: WebFetchSchema,
     outputSchema: WebFetchOutputSchema,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -92,6 +92,7 @@ export function createWebSearchTool(options?: {
   return {
     label: "Web Search",
     name: "web_search",
+    resultContentSource: "network",
     description:
       "Search current web; normalized provider results. Supports freshness and date-range filters (freshness, date_after/date_before) and domain filtering (domain_filter).",
     parameters: WebSearchSchema,

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -119,8 +119,11 @@ afterEach(() => {
 
 describe("web tools defaults", () => {
   it("enables web_fetch by default (non-sandbox)", () => {
-    const tool = createWebFetchTool({ config: {}, sandboxed: false });
-    expect(tool?.name).toBe("web_fetch");
+    const fetchTool = createWebFetchTool({ config: {}, sandboxed: false });
+    const searchTool = createWebSearchTool({ config: {}, sandboxed: false });
+    expect(fetchTool?.name).toBe("web_fetch");
+    expect(fetchTool?.resultContentSource).toBe("network");
+    expect(searchTool?.resultContentSource).toBe("network");
   });
 
   it("disables web_fetch when explicitly disabled", () => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -531,6 +531,12 @@ describe("runMemoryFlushIfNeeded", () => {
           __openclaw: { turnTainted: true },
         },
       },
+      // Force the bounded SQLite tail to lose the turn boundary and taint marker.
+      // A truncated active turn must remain conservatively tainted.
+      ...Array.from({ length: 512 }, (_, index) => ({
+        type: "custom",
+        data: { index },
+      })),
     ]);
     const targetPath = path.join(rootDir, "memory", "2023-11-14.md");
     await fs.mkdir(path.dirname(targetPath), { recursive: true });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -495,6 +495,85 @@ describe("runMemoryFlushIfNeeded", () => {
     );
   });
 
+  it("downgrades an owner-directed flush after a network-tainted embedded turn", async () => {
+    const recordWriteProvenance = vi.fn(async () => {});
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 20_000,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+      recordWriteProvenance,
+    }));
+    const storePath = path.join(rootDir, "tainted-owner-session.json");
+    const sessionKey = "agent:main:main";
+    const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
+    await upsertSessionEntry(scope, { sessionId: "session", updatedAt: 10 });
+    await replaceSqliteTranscriptEvents(scope, [
+      {
+        type: "message",
+        message: { role: "user", content: "Research this", __openclaw: { senderIsOwner: true } },
+      },
+      {
+        type: "message",
+        message: {
+          role: "toolResult",
+          content: "untrusted page",
+          __openclaw: { resultContentSource: "network" },
+        },
+      },
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: "network-derived answer",
+          __openclaw: { turnTainted: true },
+        },
+      },
+    ]);
+    const targetPath = path.join(rootDir, "memory", "2023-11-14.md");
+    await fs.mkdir(path.dirname(targetPath), { recursive: true });
+    runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await fs.writeFile(targetPath, "network-derived memory\n", "utf8");
+      params.onAgentEvent?.({
+        stream: "tool",
+        data: { name: "write", phase: "result", isError: false },
+      });
+      return { payloads: [], meta: {} };
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+    };
+
+    await runMemoryFlushIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        workspaceDir: rootDir,
+        sessionId: "session",
+        sessionKey,
+        senderIsOwner: true,
+      }),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(recordWriteProvenance).toHaveBeenCalledWith(
+      expect.objectContaining({ originClass: "untrusted" }),
+    );
+  });
+
   it("revalidates immutable Ultra for each memory-flush fallback candidate", async () => {
     const storePath = path.join(rootDir, "sessions.json");
     const sessionKey = "main";

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -458,7 +458,10 @@ function readLatestNonzeroUsageFromTranscriptEvents(
   return undefined;
 }
 
-function readActiveTurnTaintFromTranscriptEvents(events: readonly unknown[]): boolean {
+function readActiveTurnTaintFromTranscriptEvents(events: readonly unknown[]): {
+  boundaryFound: boolean;
+  tainted: boolean;
+} {
   const activeEvents = selectSessionTranscriptLeafControlledPath(events) ?? events;
   for (const event of activeEvents.toReversed()) {
     if (!event || typeof event !== "object" || Array.isArray(event)) {
@@ -470,7 +473,7 @@ function readActiveTurnTaintFromTranscriptEvents(events: readonly unknown[]): bo
     }
     const record = message as Record<string, unknown>;
     if (record.role === "user") {
-      return false;
+      return { boundaryFound: true, tainted: false };
     }
     const metadata = record["__openclaw"];
     if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
@@ -478,10 +481,10 @@ function readActiveTurnTaintFromTranscriptEvents(events: readonly unknown[]): bo
     }
     const openClaw = metadata as { resultContentSource?: unknown; turnTainted?: unknown };
     if (openClaw.turnTainted === true || openClaw.resultContentSource === "network") {
-      return true;
+      return { boundaryFound: false, tainted: true };
     }
   }
-  return false;
+  return { boundaryFound: false, tainted: false };
 }
 
 function readSqliteSessionLogSnapshot(
@@ -501,7 +504,9 @@ function readSqliteSessionLogSnapshot(
         });
       }
       if (options.includeTurnTaint) {
-        snapshot.turnTainted = readActiveTurnTaintFromTranscriptEvents(events);
+        const scan = readActiveTurnTaintFromTranscriptEvents(events);
+        snapshot.turnTainted =
+          scan.tainted || (!scan.boundaryFound && events.length >= SQLITE_USAGE_TAIL_MAX_EVENTS);
       }
     }
   } catch {
@@ -630,7 +635,8 @@ async function readFileSessionTurnTaint(logPath: string): Promise<boolean> {
         return [];
       }
     });
-    return readActiveTurnTaintFromTranscriptEvents(events);
+    const scan = readActiveTurnTaintFromTranscriptEvents(events);
+    return scan.tainted || (!scan.boundaryFound && stat.size > size);
   } catch {
     return true;
   } finally {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -458,22 +458,56 @@ function readLatestNonzeroUsageFromTranscriptEvents(
   return undefined;
 }
 
+function readActiveTurnTaintFromTranscriptEvents(events: readonly unknown[]): boolean {
+  const activeEvents = selectSessionTranscriptLeafControlledPath(events) ?? events;
+  for (const event of activeEvents.toReversed()) {
+    if (!event || typeof event !== "object" || Array.isArray(event)) {
+      continue;
+    }
+    const message = (event as { message?: unknown }).message;
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    if (record.role === "user") {
+      return false;
+    }
+    const metadata = record["__openclaw"];
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+      continue;
+    }
+    const openClaw = metadata as { resultContentSource?: unknown; turnTainted?: unknown };
+    if (openClaw.turnTainted === true || openClaw.resultContentSource === "network") {
+      return true;
+    }
+  }
+  return false;
+}
+
 function readSqliteSessionLogSnapshot(
   scope: { agentId?: string; sessionId: string; sessionKey?: string; storePath: string },
-  options: { includeByteSize: boolean; includeUsage: boolean },
+  options: { includeByteSize: boolean; includeTurnTaint?: boolean; includeUsage: boolean },
 ): SessionLogSnapshot {
   const snapshot: SessionLogSnapshot = {};
   try {
     if (options.includeByteSize) {
       snapshot.byteSize = readSessionTranscriptActiveStats(scope).sizeBytes;
     }
-    if (options.includeUsage) {
+    if (options.includeUsage || options.includeTurnTaint) {
       const events = readRecentSessionTranscriptActiveEvents(scope, SQLITE_USAGE_TAIL_MAX_EVENTS);
-      snapshot.usage = deriveTranscriptUsageSnapshot({
-        usage: readLatestNonzeroUsageFromTranscriptEvents(events),
-      });
+      if (options.includeUsage) {
+        snapshot.usage = deriveTranscriptUsageSnapshot({
+          usage: readLatestNonzeroUsageFromTranscriptEvents(events),
+        });
+      }
+      if (options.includeTurnTaint) {
+        snapshot.turnTainted = readActiveTurnTaintFromTranscriptEvents(events);
+      }
     }
   } catch {
+    if (options.includeTurnTaint) {
+      snapshot.turnTainted = true;
+    }
     return snapshot;
   }
   return snapshot;
@@ -481,6 +515,7 @@ function readSqliteSessionLogSnapshot(
 
 type SessionLogSnapshot = {
   byteSize?: number;
+  turnTainted?: boolean;
   usage?: SessionTranscriptUsageSnapshot;
 };
 
@@ -513,6 +548,7 @@ async function readSessionLogSnapshot(params: {
   sessionKey?: string;
   opts?: { agentId?: string; storePath?: string };
   includeByteSize: boolean;
+  includeTurnTaint?: boolean;
   includeUsage: boolean;
 }): Promise<SessionLogSnapshot> {
   const logPath = memoryDeps.resolveSessionLogPath(
@@ -541,12 +577,12 @@ async function readSessionLogSnapshot(params: {
   if (sqliteMarker) {
     return readSqliteSessionLogSnapshot(sqliteMarker, params);
   }
-  return {};
+  return params.includeTurnTaint ? { turnTainted: true } : {};
 }
 
 async function readFileSessionLogSnapshot(
   logPath: string,
-  params: { includeByteSize: boolean; includeUsage: boolean },
+  params: { includeByteSize: boolean; includeTurnTaint?: boolean; includeUsage: boolean },
 ): Promise<SessionLogSnapshot> {
   const snapshot: SessionLogSnapshot = {};
   let usageScan: SessionLogUsageScan | undefined;
@@ -564,12 +600,42 @@ async function readFileSessionLogSnapshot(
     const scannedSize = usageScan?.byteSize;
     if (typeof scannedSize === "number" && Number.isFinite(scannedSize) && scannedSize >= 0) {
       snapshot.byteSize = Math.floor(scannedSize);
-      return snapshot;
+    } else {
+      snapshot.byteSize = await readSessionLogByteSize(logPath);
     }
-    snapshot.byteSize = await readSessionLogByteSize(logPath);
+  }
+
+  if (params.includeTurnTaint) {
+    snapshot.turnTainted = await readFileSessionTurnTaint(logPath);
   }
 
   return snapshot;
+}
+
+async function readFileSessionTurnTaint(logPath: string): Promise<boolean> {
+  const handle = await fs.promises.open(logPath, "r");
+  try {
+    const stat = await handle.stat();
+    const size = Math.min(TRANSCRIPT_TAIL_CHUNK_BYTES, stat.size);
+    const buffer = Buffer.allocUnsafe(size);
+    const { bytesRead } = await handle.read(buffer, 0, size, stat.size - size);
+    const lines = buffer.toString("utf8", 0, bytesRead).split(/\n+/u);
+    if (stat.size > size) {
+      lines.shift();
+    }
+    const events = lines.flatMap((line) => {
+      try {
+        return line.trim() ? [JSON.parse(line) as unknown] : [];
+      } catch {
+        return [];
+      }
+    });
+    return readActiveTurnTaintFromTranscriptEvents(events);
+  } catch {
+    return true;
+  } finally {
+    await handle.close();
+  }
 }
 
 type SessionLogUsageScan = {
@@ -1226,7 +1292,11 @@ export async function runMemoryFlushIfNeeded(params: {
     Number.isFinite(forceFlushTranscriptBytes) &&
     forceFlushTranscriptBytes > 0,
   );
-  const shouldReadSessionLog = shouldReadTranscript || shouldCheckTranscriptSizeForForcedFlush;
+  const shouldReadTurnTaint = Boolean(
+    canAttemptFlush && entry && memoryFlushPlan.recordWriteProvenance,
+  );
+  const shouldReadSessionLog =
+    shouldReadTranscript || shouldCheckTranscriptSizeForForcedFlush || shouldReadTurnTaint;
   const sessionLogSnapshot = shouldReadSessionLog
     ? await readSessionLogSnapshot({
         sessionId: params.followupRun.run.sessionId,
@@ -1234,6 +1304,7 @@ export async function runMemoryFlushIfNeeded(params: {
         sessionKey: params.sessionKey ?? params.followupRun.run.sessionKey,
         opts: { agentId: params.followupRun.run.agentId, storePath: params.storePath },
         includeByteSize: shouldCheckTranscriptSizeForForcedFlush,
+        includeTurnTaint: shouldReadTurnTaint,
         includeUsage: shouldReadTranscript,
       })
     : undefined;
@@ -1515,7 +1586,10 @@ export async function runMemoryFlushIfNeeded(params: {
         relativePath: memoryFlushWritePath,
         contentBefore: memoryFlushContentBefore,
         contentAfter: await readMemoryFlushContent(),
-        originClass: params.followupRun.run.senderIsOwner ? "agent" : "untrusted",
+        originClass:
+          params.followupRun.run.senderIsOwner && sessionLogSnapshot?.turnTainted !== true
+            ? "agent"
+            : "untrusted",
         observedAt: memoryDeps.now(),
       });
     }

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -118,7 +118,7 @@ export type MemoryFlushPlan = {
     contentAfter: string;
     originClass: "agent" | "untrusted";
     observedAt: number;
-  }) => Promise<void>;
+  }) => Promise<(() => Promise<void>) | void>;
   clearWriteProvenance?: (params: { workspaceDir: string; relativePath: string }) => Promise<void>;
 };
 

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -119,6 +119,7 @@ export type MemoryFlushPlan = {
     originClass: "agent" | "untrusted";
     observedAt: number;
   }) => Promise<void>;
+  clearWriteProvenance?: (params: { workspaceDir: string; relativePath: string }) => Promise<void>;
 };
 
 export type MemoryFlushPlanResolver = (params: {


### PR DESCRIPTION
Related: #114819

## What Problem This Solves

Fixes an issue where an agent turn that consumed untrusted network or non-owner content could write attacker-influenced text into memory while the write was still classified as agent-authored and eligible for dreaming.

## Why This Change Was Made

Network-content capability metadata now survives tool adaptation, tool outcomes set a sticky per-turn taint bit, and the embedded transcript owner persists host-only taint metadata on tool results and subsequent assistant messages. Runtime memory writes, edits, and apply-patch mutations record explicit provenance from that turn state; overlapping file mutations share canonical per-file ordering so delete cleanup cannot erase a later write record. The existing owner, agent, untrusted, and system classes remain unchanged, with no schema or configuration surface added.

Scope boundary: transcript owners other than the embedded agent loop do not emit this metadata yet, so absence preserves current untainted behavior. A follow-up PR will add parity for the Codex event projector, CLI backend dispatch mirror, and Copilot attempt journal. Session-level propagation across turns, including later untainted recreation of previously tainted content, remains the existing cross-turn laundering follow-up.

## User Impact

Agent-authored memory created during a tainted turn is classified as untrusted and automatically excluded by the existing dreaming allowlist. Untainted agent writes remain agent-classified, and owner-authored content remains owner-classified even when the turn is tainted.

## Evidence

- Exact-head focused proof: 8 routed Vitest shards, 380 tests passed.
- Parallel apply-patch delete/recreate regression passed eight bounded repeat runs; an overlap-order probe confirmed multi-file reservations prevent later writes from overtaking moves.
- `node scripts/check-changed.mjs -- <41 changed files>` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30438935431
- The final canonical-path delta passed the same changed wrapper locally after Blacksmith allocation hit an HTTP 429; this is the documented trusted-source fallback.
- Final branch autoreview: clean, no accepted/actionable findings, confidence 0.82. Accepted taint-architecture, mutation-ordering, and casing rulings from #114819/#115438 were supplied as review context.
- Known unrelated baseline: `src/agents/apply-patch.test.ts` has one current-main macOS symlink-delete path-alias failure; the other 121 tests in that focused batch passed.

This change is AI-assisted and was reviewed through the repository autoreview workflow. I understand the implementation and its ownership boundaries.
