### PR TITLE
refactor(meetings): consolidate runtime facades

### DIFF
--- a/extensions/teams-meetings/src/runtime-probes.test.ts
+++ b/extensions/teams-meetings/src/runtime-probes.test.ts
@@ -1,13 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { teamsMeetingsConfig } from "./config.js";
-import {
-  testTeamsMeetingListening,
-  testTeamsMeetingSpeech,
-  type TeamsMeetingsProbeContext,
-} from "./runtime-probes.js";
+import { testTeamsMeetingListening, testTeamsMeetingSpeech } from "./runtime-probes.js";
 import type { TeamsMeetingsSession } from "./transports/types.js";
 
 const resolveTeamsMeetingsConfig = teamsMeetingsConfig.resolveConfig;
+type TeamsMeetingsProbeContext = Parameters<typeof testTeamsMeetingSpeech>[0];
 
 const URL = "https://teams.microsoft.com/l/meetup-join/19%3ameeting_probe%40thread.v2/0";
 

--- a/extensions/teams-meetings/src/runtime-probes.ts
+++ b/extensions/teams-meetings/src/runtime-probes.ts
@@ -3,11 +3,8 @@ import type { TeamsMeetingsConfig, TeamsMeetingsMode, TeamsMeetingsTransport } f
 import type {
   TeamsMeetingsChromeHealth,
   TeamsMeetingsJoinRequest,
-  TeamsMeetingsPluginTypes,
   TeamsMeetingsSession,
 } from "./transports/types.js";
-
-export type TeamsMeetingsProbeContext = TeamsMeetingsPluginTypes["ProbeContext"];
 
 const probes = MeetingPlatformAdapter.createRuntimeProbes<
   TeamsMeetingsConfig,

--- a/extensions/teams-meetings/src/runtime-setup.ts
+++ b/extensions/teams-meetings/src/runtime-setup.ts
@@ -1,167 +1,29 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import {
-  addMeetingSetupCheck,
-  createMeetingSetupStatus,
-  MeetingPlatformAdapter,
-  resolveMeetingBrowserNodeInfo,
-  type MeetingSetupStatus,
-} from "openclaw/plugin-sdk/meeting-runtime";
-import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
-import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { TeamsMeetingsConfig, TeamsMeetingsMode, TeamsMeetingsTransport } from "./config.js";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
+import type { TeamsMeetingsConfig, TeamsMeetingsMode } from "./config.js";
 import { assertBlackHole2chAvailable } from "./transports/chrome.js";
 import { TEAMS_MEETINGS_BROWSER_NODE_ADAPTER } from "./transports/teams-meetings-platform-constants.js";
 
-function audioCommands(config: TeamsMeetingsConfig): string[] {
-  return uniqueStrings(
-    [
-      config.chrome.audioInputCommand[0],
-      config.chrome.audioOutputCommand[0],
-      config.chrome.bargeInInputCommand?.[0],
-    ].filter((value): value is string => Boolean(value?.trim())),
-  );
-}
-
-async function commandExists(runtime: PluginRuntime, command: string): Promise<boolean> {
-  const result = await runtime.system.runCommandWithTimeout(
-    ["/bin/sh", "-lc", 'command -v "$1" >/dev/null 2>&1', "sh", command],
-    { timeoutMs: 5_000 },
-  );
-  return result.code === 0;
-}
-
-export async function getTeamsMeetingsSetupStatus(params: {
-  config: TeamsMeetingsConfig;
-  fullConfig: OpenClawConfig;
-  runtime: PluginRuntime;
-  options?: { mode?: TeamsMeetingsMode; transport?: TeamsMeetingsTransport };
-}): Promise<MeetingSetupStatus> {
-  const mode = params.options?.mode ?? params.config.defaultMode;
-  const transport =
-    params.options?.transport ?? (params.config.chromeNode.node ? "chrome-node" : "chrome");
-  const talkBack = MeetingPlatformAdapter.isTalkBackMode(mode);
-  let status = createMeetingSetupStatus([
-    {
-      id: "chrome-profile",
-      ok: true,
-      message: params.config.chrome.browserProfile
-        ? `Chrome node profile configured: ${params.config.chrome.browserProfile}`
-        : "Local Chrome uses the configured OpenClaw browser profile",
-    },
-    {
-      id: "guest-join",
-      ok: Boolean(
-        params.config.chrome.guestName &&
-        params.config.chrome.autoJoin &&
-        params.config.chrome.reuseExistingTab,
-      ),
-      message:
-        params.config.chrome.guestName &&
-        params.config.chrome.autoJoin &&
-        params.config.chrome.reuseExistingTab
-          ? "Guest name, auto-join, and tab reuse are configured"
-          : "Set chrome.guestName, chrome.autoJoin, and chrome.reuseExistingTab for unattended guest joins",
-    },
-    {
-      id: "captions",
-      ok: true,
-      message:
-        mode === "transcribe"
-          ? "Teams caption scraping is disabled pending live selector validation; transcript snapshots are empty"
-          : "Caption scraping is not used by talk-back modes",
-    },
-  ]);
-
-  if (transport === "chrome-node") {
-    try {
-      const node = await resolveMeetingBrowserNodeInfo({
-        runtime: params.runtime,
-        requestedNode: params.config.chromeNode.node,
-        adapter: TEAMS_MEETINGS_BROWSER_NODE_ADAPTER,
-      });
-      status = addMeetingSetupCheck(status, {
-        id: "chrome-node-connected",
-        ok: true,
-        message: `Connected Teams meeting node ready: ${node.displayName ?? node.remoteIp ?? node.nodeId}`,
-      });
-      if (talkBack) {
-        if (!node.nodeId) {
-          throw new Error("Connected Microsoft Teams meetings node did not include a node id.");
-        }
-        await params.runtime.nodes.invoke({
-          nodeId: node.nodeId,
-          command: TEAMS_MEETINGS_BROWSER_NODE_ADAPTER.nodeCommandName,
-          params: {
-            action: "setup",
-            audioInputCommand: params.config.chrome.audioInputCommand,
-            audioOutputCommand: params.config.chrome.audioOutputCommand,
-            ...(params.config.chrome.bargeInInputCommand
-              ? { bargeInInputCommand: params.config.chrome.bargeInInputCommand }
-              : {}),
-          },
-          timeoutMs: 12_000,
-        });
-        status = addMeetingSetupCheck(status, {
-          id: "chrome-node-audio-prerequisites",
-          ok: true,
-          message: "Remote macOS, BlackHole 2ch, and SoX prerequisites are ready",
-        });
-      }
-    } catch (error) {
-      const connected = status.checks.some(
-        (check) => check.id === "chrome-node-connected" && check.ok,
-      );
-      status = addMeetingSetupCheck(status, {
-        id: connected ? "chrome-node-audio-prerequisites" : "chrome-node-connected",
-        ok: false,
-        message: formatErrorMessage(error),
-      });
-    }
-  }
-
-  if (!talkBack) {
-    return status;
-  }
-  status = addMeetingSetupCheck(status, {
-    id: "audio-bridge",
-    ok:
-      params.config.chrome.audioInputCommand.length > 0 &&
-      params.config.chrome.audioOutputCommand.length > 0,
-    message: `SoX command-pair audio bridge configured (${params.config.chrome.audioFormat})`,
-  });
-  if (transport === "chrome-node") {
-    return status;
-  }
-  try {
-    await assertBlackHole2chAvailable({
-      runtime: params.runtime,
-      timeoutMs: Math.min(params.config.chrome.joinTimeoutMs, 10_000),
-    });
-    status = addMeetingSetupCheck(status, {
-      id: "chrome-local-audio-device",
-      ok: true,
-      message: "BlackHole 2ch audio device found",
-    });
-  } catch (error) {
-    status = addMeetingSetupCheck(status, {
-      id: "chrome-local-audio-device",
-      ok: false,
-      message: formatErrorMessage(error),
-    });
-  }
-  const missing: string[] = [];
-  for (const command of audioCommands(params.config)) {
-    if (!(await commandExists(params.runtime, command).catch(() => false))) {
-      missing.push(command);
-    }
-  }
-  return addMeetingSetupCheck(status, {
-    id: "chrome-local-audio-commands",
-    ok: missing.length === 0,
-    message:
-      missing.length === 0
-        ? "Configured Chrome audio commands are available"
-        : `Chrome audio commands missing: ${missing.join(", ")}`,
-  });
-}
+export const getTeamsMeetingsSetupStatus = MeetingPlatformAdapter.createRuntimeSetup<
+  TeamsMeetingsConfig,
+  TeamsMeetingsMode
+>({
+  assertAudioDeviceAvailable: assertBlackHole2chAvailable,
+  captionsMessage: (mode) =>
+    mode === "transcribe"
+      ? "Teams caption scraping is disabled pending live selector validation; transcript snapshots are empty"
+      : "Caption scraping is not used by talk-back modes",
+  connectedNodeMessage: (node) => `Connected Teams meeting node ready: ${node}`,
+  guestJoinCheck: (config) => {
+    const ok = Boolean(
+      config.chrome.guestName && config.chrome.autoJoin && config.chrome.reuseExistingTab,
+    );
+    return {
+      ok,
+      message: ok
+        ? "Guest name, auto-join, and tab reuse are configured"
+        : "Set chrome.guestName, chrome.autoJoin, and chrome.reuseExistingTab for unattended guest joins",
+    };
+  },
+  missingNodeIdMessage: "Connected Microsoft Teams meetings node did not include a node id.",
+  nodeAdapter: TEAMS_MEETINGS_BROWSER_NODE_ADAPTER,
+});

--- a/extensions/teams-meetings/src/runtime.ts
+++ b/extensions/teams-meetings/src/runtime.ts
@@ -1,25 +1,6 @@
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import {
-  createMeetingSession,
-  MeetingPlatformAdapter,
-  MeetingSessionRuntime,
-  type MeetingSessionRuntimeHandles,
-  type MeetingSessionRuntimeJoinContext,
-} from "openclaw/plugin-sdk/meeting-runtime";
-import type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
-import type {
-  TranscriptStartRequest,
-  TranscriptStopRequest,
-} from "openclaw/plugin-sdk/transcripts";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type { TeamsMeetingsConfig, TeamsMeetingsMode, TeamsMeetingsTransport } from "./config.js";
-import {
-  testTeamsMeetingListening,
-  testTeamsMeetingSpeech,
-  type TeamsMeetingsProbeContext,
-} from "./runtime-probes.js";
+import { testTeamsMeetingListening, testTeamsMeetingSpeech } from "./runtime-probes.js";
 import { getTeamsMeetingsSetupStatus } from "./runtime-setup.js";
 import {
   launchTeamsMeetingInChrome,
@@ -29,519 +10,65 @@ import {
   recoverCurrentTeamsMeetingTab,
 } from "./transports/chrome.js";
 import { TEAMS_MEETINGS_PLATFORM_ADAPTER } from "./transports/teams-meetings-platform-adapter.js";
-import type {
-  TeamsMeetingsBrowserTab,
-  TeamsMeetingsChromeHealth,
-  TeamsMeetingsJoinRequest,
-  TeamsMeetingsJoinResult,
-  TeamsMeetingsSession,
-} from "./transports/types.js";
+import type { TeamsMeetingsChromeHealth } from "./transports/types.js";
 
-type ManualActionReason = NonNullable<TeamsMeetingsChromeHealth["manualAction"]>["reason"];
-type SpeechBlockedReason = NonNullable<TeamsMeetingsChromeHealth["speechBlockedReason"]>;
-type SessionRuntime = MeetingSessionRuntime<
-  TeamsMeetingsSession,
-  TeamsMeetingsJoinRequest,
+export const TeamsMeetingsRuntime = MeetingPlatformAdapter.createRuntimeFacade<
+  TeamsMeetingsConfig,
   TeamsMeetingsTransport,
   TeamsMeetingsMode,
   TeamsMeetingsChromeHealth,
-  TeamsMeetingsBrowserTab,
-  ManualActionReason,
-  SpeechBlockedReason
->;
-type JoinContext = MeetingSessionRuntimeJoinContext<
-  TeamsMeetingsSession,
-  TeamsMeetingsTransport,
-  TeamsMeetingsMode,
-  TeamsMeetingsChromeHealth,
-  TeamsMeetingsBrowserTab
->;
-type LaunchResult =
-  | Awaited<ReturnType<typeof launchTeamsMeetingInChrome>>
-  | Awaited<ReturnType<typeof launchTeamsMeetingOnNode>>;
-type AudioBridge = NonNullable<LaunchResult["audioBridge"]>;
-
-function nowIso(): string {
-  return new Date().toISOString();
-}
-
-function resolveTransport(
-  request: TeamsMeetingsJoinRequest,
-  config: TeamsMeetingsConfig,
-): TeamsMeetingsTransport {
-  return request.transport ?? (config.chromeNode.node ? "chrome-node" : "chrome");
-}
-
-function withSessionAgentConfig(config: TeamsMeetingsConfig, agentId: string): TeamsMeetingsConfig {
-  return config.realtime.agentId === agentId
-    ? config
-    : { ...config, realtime: { ...config.realtime, agentId } };
-}
-
-function noteSession(session: TeamsMeetingsSession, note: string): void {
-  session.notes = [...session.notes.filter((item) => item !== note), note];
-}
-
-export class TeamsMeetingsRuntime {
-  readonly #defaultAgentId: string;
-  readonly #sessions: SessionRuntime;
-  readonly #requesterSessionKeys = new Map<string, string>();
-
-  constructor(
-    private readonly params: {
-      config: TeamsMeetingsConfig;
-      fullConfig: OpenClawConfig;
-      runtime: PluginRuntime;
-      logger: RuntimeLogger;
+  {
+    setup: Awaited<ReturnType<typeof getTeamsMeetingsSetupStatus>>;
+    listening: Awaited<ReturnType<typeof testTeamsMeetingListening>>;
+    speech: Awaited<ReturnType<typeof testTeamsMeetingSpeech>>;
+  }
+>({
+  platform: TEAMS_MEETINGS_PLATFORM_ADAPTER,
+  transport: {
+    launchInChrome: launchTeamsMeetingInChrome,
+    launchOnNode: launchTeamsMeetingOnNode,
+    leaveInBrowser: leaveTeamsMeetingInBrowser,
+    readTranscript: readTeamsMeetingTranscript,
+    recoverCurrentTab: recoverCurrentTeamsMeetingTab,
+  },
+  probes: {
+    setupStatus: getTeamsMeetingsSetupStatus,
+    testListening: testTeamsMeetingListening,
+    testSpeech: testTeamsMeetingSpeech,
+  },
+  messages: {
+    durableTranscripts: { providerId: "teams", providerName: "Microsoft Teams" },
+    joined: {
+      local:
+        "Teams guest joined in local Chrome with realtime audio through BlackHole 2ch and SoX.",
+      node: "Teams guest joined in Chrome on the selected node with realtime audio through the node bridge.",
+      transcribe: "Teams guest joined observe-only with live-caption transcript capture.",
+      waiting:
+        "Teams guest join is waiting for the browser to become ready before starting realtime audio.",
     },
-  ) {
-    this.#defaultAgentId = normalizeAgentId(
-      params.config.realtime.agentId ?? resolveDefaultAgentId(params.fullConfig),
-    );
-    this.#sessions = new MeetingSessionRuntime({
-      logger: params.logger,
-      logScope: TEAMS_MEETINGS_PLATFORM_ADAPTER.logScope,
-      formatError: formatErrorMessage,
-      reuseExistingBrowserTab: params.config.chrome.reuseExistingTab,
-      waitForInCallMs: params.config.chrome.waitForInCallMs,
-      joinTimeoutMs: params.config.chrome.joinTimeoutMs,
-      defaultSpeechInstructions: params.config.realtime.introMessage,
-      transientSpeechBlockedReasons: new Set<SpeechBlockedReason>([
-        "not-in-call",
-        "browser-unverified",
-        "teams-microphone-muted",
-      ]),
-      messages: {
-        previousBrowserLeaveFailed:
-          "Could not leave the previous Teams meeting tab before reassignment.",
-        reassignedSessionNote:
-          "Ended before the same Teams meeting tab was reassigned to another agent.",
-        reusedSessionNote: "Reused existing active Microsoft Teams meeting session.",
-        replacementBrowserLeaveFailed:
-          "Could not leave the previous Teams meeting tab before reassignment.",
-        speechBlockedFallback: "Realtime speech blocked until Microsoft Teams is ready.",
-        speech: {
-          audioBridgeUnavailable: "Realtime speech requires an active Chrome audio bridge.",
-          browserUnverified: "Microsoft Teams browser state has not been verified yet.",
-          microphoneMuted: "Turn on the OpenClaw Teams microphone before asking OpenClaw to speak.",
-          microphoneMutedReason: "teams-microphone-muted",
-          notInCall: "Microsoft Teams has not reported that the browser guest is in the call.",
-          notInCallReason: "not-in-call",
-          browserUnverifiedReason: "browser-unverified",
-          audioBridgeUnavailableReason: "audio-bridge-unavailable",
-        },
+    leaveFailed: (error) => `Browser control could not leave the Teams meeting tab: ${error}`,
+    noTrackedTab:
+      "No tracked Teams meeting tab; leave the browser meeting manually if it is still active.",
+    sharedTab: "Kept the shared Teams meeting tab open for another active session.",
+    sessionRuntime: {
+      previousBrowserLeaveFailed:
+        "Could not leave the previous Teams meeting tab before reassignment.",
+      reassignedSessionNote:
+        "Ended before the same Teams meeting tab was reassigned to another agent.",
+      reusedSessionNote: "Reused existing active Microsoft Teams meeting session.",
+      replacementBrowserLeaveFailed:
+        "Could not leave the previous Teams meeting tab before reassignment.",
+      speechBlockedFallback: "Realtime speech blocked until Microsoft Teams is ready.",
+      speech: {
+        audioBridgeUnavailable: "Realtime speech requires an active Chrome audio bridge.",
+        browserUnverified: "Microsoft Teams browser state has not been verified yet.",
+        microphoneMuted: "Turn on the OpenClaw Teams microphone before asking OpenClaw to speak.",
+        microphoneMutedReason: "teams-microphone-muted",
+        notInCall: "Microsoft Teams has not reported that the browser guest is in the call.",
+        notInCallReason: "not-in-call",
+        browserUnverifiedReason: "browser-unverified",
+        audioBridgeUnavailableReason: "audio-bridge-unavailable",
       },
-      resolveJoin: (request) => ({
-        url: TEAMS_MEETINGS_PLATFORM_ADAPTER.urls.validateAndNormalize(request.url),
-        transport: resolveTransport(request, params.config),
-        mode: request.mode ?? params.config.defaultMode,
-        agentId: normalizeAgentId(request.agentId ?? this.#defaultAgentId),
-      }),
-      createSession: ({ request, resolved, createdAt }) => {
-        const session: TeamsMeetingsSession = createMeetingSession({
-          platform: TEAMS_MEETINGS_PLATFORM_ADAPTER,
-          config: params.config,
-          resolved,
-          createdAt,
-        });
-        if (request.requesterSessionKey) {
-          this.#requesterSessionKeys.set(session.id, request.requesterSessionKey);
-        }
-        return session;
-      },
-      resolveSpeechInstructions: (request) =>
-        request.message ?? params.config.realtime.introMessage,
-      isBrowserTransport: () => true,
-      isTalkBackMode: (mode) => MeetingPlatformAdapter.isTalkBackMode(mode),
-      isTranscribeMode: (mode) => mode === "transcribe",
-      sameMeetingUrl: (left, right) =>
-        TEAMS_MEETINGS_PLATFORM_ADAPTER.urls.isSameMeeting(left, right),
-      normalizeMeetingUrlForReuse: (url) =>
-        TEAMS_MEETINGS_PLATFORM_ADAPTER.urls.normalizeForReuse(url),
-      getBrowser: (session) =>
-        session.chrome
-          ? {
-              launched: session.chrome.launched,
-              nodeId: session.chrome.nodeId,
-              tab: session.chrome.browserTab,
-              health: session.chrome.health,
-              hasAudioBridge: Boolean(session.chrome.audioBridge),
-            }
-          : undefined,
-      setBrowserTab: (session, tab) => {
-        if (session.chrome) {
-          session.chrome.browserTab = tab;
-        }
-      },
-      setBrowserHealth: (session, health) => {
-        if (session.chrome) {
-          session.chrome.health = health;
-        }
-      },
-      joinTransport: async ({ request, session, context }) =>
-        await this.#joinTransport(request, session, context),
-      releaseBrowserTab: async (session) => await this.#releaseBrowserTab(session),
-      refreshBrowserHealth: async (session, options) =>
-        await this.#refreshBrowserHealth(session, options),
-      refreshStatus: async (session) =>
-        await this.#sessions.refreshBrowserHealth(session, { force: true, readOnly: true }),
-      refreshReusableSession: async (_session, _request, _resolved) => {},
-      ensureRealtimeBridge: async (session) => await this.#ensureRealtimeBridge(session),
-      captureTranscript: async (session, options) =>
-        await this.#captureTranscript(session, options),
-      speakViaTransport: async () => undefined,
-      durableTranscripts: {
-        config: params.fullConfig.transcripts,
-        providerId: "teams",
-        providerName: "Microsoft Teams",
-      },
-    });
-  }
-
-  list(): TeamsMeetingsSession[] {
-    return this.#sessions.list();
-  }
-
-  async startTranscriptSource(request: TranscriptStartRequest) {
-    return await this.#sessions.startTranscriptSource(request);
-  }
-
-  async stopTranscriptSource(request: TranscriptStopRequest) {
-    return await this.#sessions.stopTranscriptSource(request);
-  }
-
-  ownsSession(agentId: string, sessionId: string): boolean {
-    return this.list().some((session) => session.id === sessionId && session.agentId === agentId);
-  }
-
-  async join(request: TeamsMeetingsJoinRequest): Promise<TeamsMeetingsJoinResult> {
-    try {
-      return await this.#sessions.join(request);
-    } catch (error) {
-      const activeIds = new Set(this.list().map((session) => session.id));
-      for (const sessionId of this.#requesterSessionKeys.keys()) {
-        if (!activeIds.has(sessionId)) {
-          this.#requesterSessionKeys.delete(sessionId);
-        }
-      }
-      throw error;
-    }
-  }
-
-  async leave(sessionId: string) {
-    try {
-      return await this.#sessions.leave(sessionId);
-    } finally {
-      this.#requesterSessionKeys.delete(sessionId);
-    }
-  }
-
-  async status(sessionId?: string) {
-    return await this.#sessions.status(sessionId);
-  }
-
-  async statusForAgent(agentId: string, sessionId?: string) {
-    if (sessionId) {
-      return this.ownsSession(agentId, sessionId)
-        ? await this.#sessions.status(sessionId)
-        : { found: false };
-    }
-    const sessions = this.list().filter((session) => session.agentId === agentId);
-    await Promise.all(sessions.map((session) => this.#sessions.status(session.id)));
-    return { found: true, sessions };
-  }
-
-  async transcript(sessionId: string, options: { sinceIndex?: number } = {}) {
-    return await this.#sessions.transcript(sessionId, options);
-  }
-
-  async speak(sessionId: string, instructions?: string) {
-    return await this.#sessions.speak(sessionId, instructions);
-  }
-
-  async setupStatus(options?: { mode?: TeamsMeetingsMode; transport?: TeamsMeetingsTransport }) {
-    return await getTeamsMeetingsSetupStatus({
-      config: this.params.config,
-      fullConfig: this.params.fullConfig,
-      runtime: this.params.runtime,
-      options,
-    });
-  }
-
-  async testSpeech(request: TeamsMeetingsJoinRequest) {
-    return await testTeamsMeetingSpeech(this.#probeContext(), request);
-  }
-
-  async testListen(request: TeamsMeetingsJoinRequest) {
-    return await testTeamsMeetingListening(this.#probeContext(), request);
-  }
-
-  #probeContext(): TeamsMeetingsProbeContext {
-    return {
-      config: this.params.config,
-      resolveAgentId: (request) => normalizeAgentId(request.agentId ?? this.#defaultAgentId),
-      list: () => this.list(),
-      join: async (request) => await this.join(request),
-      isReusable: (session, resolved) => this.#sessions.isReusableSession(session, resolved),
-      hasHealthHandle: (sessionId) => this.#sessions.hasHealthHandle(sessionId),
-      refreshHealth: (sessionId) => this.#sessions.refreshHealth(sessionId),
-      refreshCaptionHealth: async (session, timeoutMs) =>
-        await this.#refreshBrowserHealth(session, { timeoutMs }),
-    };
-  }
-
-  async #joinTransport(
-    request: TeamsMeetingsJoinRequest,
-    session: TeamsMeetingsSession,
-    context: JoinContext,
-  ): Promise<{ delegatedSpoken?: boolean }> {
-    const config = withSessionAgentConfig(this.params.config, session.agentId);
-    const result: LaunchResult =
-      session.transport === "chrome-node"
-        ? await launchTeamsMeetingOnNode({
-            runtime: this.params.runtime,
-            config,
-            fullConfig: this.params.fullConfig,
-            meetingSessionId: session.id,
-            requesterSessionKey: request.requesterSessionKey,
-            mode: session.mode,
-            url: session.url,
-            logger: this.params.logger,
-          })
-        : await launchTeamsMeetingInChrome({
-            runtime: this.params.runtime,
-            config,
-            fullConfig: this.params.fullConfig,
-            meetingSessionId: session.id,
-            requesterSessionKey: request.requesterSessionKey,
-            mode: session.mode,
-            url: session.url,
-            logger: this.params.logger,
-          });
-    const nodeId = "nodeId" in result ? result.nodeId : undefined;
-    const tab = context.inheritedBrowserTab({
-      session,
-      transport: session.transport,
-      nodeId,
-      meetingUrl: session.url,
-      tab: result.tab,
-    });
-    session.chrome = {
-      audioBackend: "blackhole-2ch",
-      launched: result.launched,
-      nodeId,
-      browserProfile: this.params.config.chrome.browserProfile,
-      browserTab: tab,
-      health: result.browser,
-    };
-    const handles = this.#attachAudioBridge(session, result.audioBridge);
-    if (handles) {
-      context.attachRuntimeHandles(session, handles);
-    }
-    session.notes.push(
-      result.audioBridge
-        ? session.transport === "chrome-node"
-          ? "Teams guest joined in Chrome on the selected node with realtime audio through the node bridge."
-          : "Teams guest joined in local Chrome with realtime audio through BlackHole 2ch and SoX."
-        : session.mode === "transcribe"
-          ? "Teams guest joined observe-only with live-caption transcript capture."
-          : "Teams guest join is waiting for the browser to become ready before starting realtime audio.",
-    );
-    this.#sessions.refreshSpeechReadiness(session);
-    return {};
-  }
-
-  #attachAudioBridge(
-    session: TeamsMeetingsSession,
-    audioBridge: AudioBridge | undefined,
-  ): MeetingSessionRuntimeHandles<TeamsMeetingsChromeHealth> | undefined {
-    if (!session.chrome || !audioBridge) {
-      return undefined;
-    }
-    session.chrome.audioBridge = {
-      type: audioBridge.type,
-      provider: audioBridge.providerId,
-    };
-    return {
-      stop: audioBridge.stop,
-      speak: audioBridge.speak,
-      getHealth: audioBridge.getHealth,
-    };
-  }
-
-  async #ensureRealtimeBridge(
-    session: TeamsMeetingsSession,
-  ): Promise<MeetingSessionRuntimeHandles<TeamsMeetingsChromeHealth> | undefined> {
-    if (
-      !MeetingPlatformAdapter.isTalkBackMode(session.mode) ||
-      session.state !== "active" ||
-      !session.chrome ||
-      session.chrome.audioBridge ||
-      !MeetingPlatformAdapter.isRealtimeRouteReady(session.mode, session.chrome.health)
-    ) {
-      return undefined;
-    }
-    const config = withSessionAgentConfig(this.params.config, session.agentId);
-    const recoveryConfig = {
-      ...config,
-      chrome: { ...config.chrome, launch: false },
-      chromeNode: { node: session.chrome.nodeId ?? config.chromeNode.node },
-    };
-    const result =
-      session.transport === "chrome-node"
-        ? await launchTeamsMeetingOnNode({
-            runtime: this.params.runtime,
-            config: recoveryConfig,
-            fullConfig: this.params.fullConfig,
-            meetingSessionId: session.id,
-            requesterSessionKey: this.#requesterSessionKeys.get(session.id),
-            mode: session.mode,
-            trackedTargetId: session.chrome.browserTab?.targetId,
-            url: session.url,
-            logger: this.params.logger,
-          })
-        : await launchTeamsMeetingInChrome({
-            runtime: this.params.runtime,
-            config: recoveryConfig,
-            fullConfig: this.params.fullConfig,
-            meetingSessionId: session.id,
-            requesterSessionKey: this.#requesterSessionKeys.get(session.id),
-            mode: session.mode,
-            trackedTargetId: session.chrome.browserTab?.targetId,
-            url: session.url,
-            logger: this.params.logger,
-          });
-    if (result.tab) {
-      const currentTab = session.chrome.browserTab;
-      session.chrome.browserTab = {
-        ...result.tab,
-        openedByPlugin:
-          result.tab.targetId === currentTab?.targetId
-            ? currentTab.openedByPlugin
-            : result.tab.openedByPlugin,
-      };
-    }
-    if (result.browser) {
-      session.chrome.health = { ...session.chrome.health, ...result.browser };
-    }
-    session.updatedAt = nowIso();
-    return this.#attachAudioBridge(session, result.audioBridge);
-  }
-
-  async #refreshBrowserHealth(
-    session: TeamsMeetingsSession,
-    options: { readOnly?: boolean; timeoutMs?: number } = {},
-  ): Promise<void> {
-    try {
-      const result = await recoverCurrentTeamsMeetingTab({
-        runtime: this.params.runtime,
-        config: this.params.config,
-        fullConfig: this.params.fullConfig,
-        meetingSessionId: session.id,
-        mode: session.mode,
-        nodeId: session.chrome?.nodeId,
-        readOnly: options.readOnly,
-        trackedMeetingUrl: session.url,
-        trackedTargetId: session.chrome?.browserTab?.targetId,
-        transport: session.transport,
-        timeoutMs: options.timeoutMs,
-        url: session.url,
-      });
-      if (result.found && session.chrome) {
-        if (result.tab?.targetId) {
-          const currentTab = session.chrome.browserTab;
-          session.chrome.browserTab = {
-            targetId: result.tab.targetId,
-            openedByPlugin:
-              result.tab.targetId === currentTab?.targetId ? currentTab.openedByPlugin : false,
-          };
-        }
-        if (result.browser) {
-          session.chrome.health = { ...session.chrome.health, ...result.browser };
-        }
-        session.updatedAt = nowIso();
-      }
-    } catch (error) {
-      this.params.logger.debug?.(
-        `${TEAMS_MEETINGS_PLATFORM_ADAPTER.logScope} browser readiness refresh ignored: ${formatErrorMessage(error)}`,
-      );
-    }
-  }
-
-  async #captureTranscript(session: TeamsMeetingsSession, options: { finalize?: boolean } = {}) {
-    // Recovery permits caption setup but atomically refuses a different live
-    // session owner, so stale sessions read their archived page buffer instead.
-    await this.#sessions.refreshCaptionHealth(session);
-    const tab = session.chrome?.browserTab;
-    if (!tab) {
-      return undefined;
-    }
-    return await readTeamsMeetingTranscript({
-      runtime: this.params.runtime,
-      config: this.params.config,
-      finalize: options.finalize,
-      meetingUrl: session.url,
-      meetingSessionId: session.id,
-      nodeId: session.chrome?.nodeId,
-      tab,
-    });
-  }
-
-  async #releaseBrowserTab(session: TeamsMeetingsSession): Promise<boolean | undefined> {
-    const tab = session.chrome?.browserTab;
-    if (!tab) {
-      noteSession(
-        session,
-        "No tracked Teams meeting tab; leave the browser meeting manually if it is still active.",
-      );
-      session.browserLeft = false;
-      return false;
-    }
-    const shared = this.list().some(
-      (other) =>
-        other.id !== session.id &&
-        other.state === "active" &&
-        other.chrome?.browserTab?.targetId === tab.targetId &&
-        other.chrome?.nodeId === session.chrome?.nodeId,
-    );
-    if (shared) {
-      noteSession(session, "Kept the shared Teams meeting tab open for another active session.");
-      return undefined;
-    }
-    try {
-      const result = await leaveTeamsMeetingInBrowser({
-        runtime: this.params.runtime,
-        config: this.params.config,
-        meetingSessionId: session.id,
-        meetingUrl: session.url,
-        nodeId: session.chrome?.nodeId,
-        tab,
-      });
-      noteSession(session, result.note);
-      if (result.left && session.chrome) {
-        session.chrome.browserTab = undefined;
-        if (session.chrome.health) {
-          session.chrome.health = {
-            ...session.chrome.health,
-            captioning: false,
-            audioInputRouted: false,
-            audioOutputRouted: false,
-            providerConnected: false,
-            realtimeReady: false,
-            audioInputActive: false,
-            audioOutputActive: false,
-          };
-        }
-      }
-      session.browserLeft = result.left;
-      return result.left;
-    } catch (error) {
-      noteSession(
-        session,
-        `Browser control could not leave the Teams meeting tab: ${formatErrorMessage(error)}`,
-      );
-      session.browserLeft = false;
-      return false;
-    }
-  }
-}
+    },
+  },
+});

--- a/extensions/teams-meetings/src/transports/types.ts
+++ b/extensions/teams-meetings/src/transports/types.ts
@@ -18,7 +18,7 @@ type TeamsMeetingsSpeechBlockedReason =
   | "audio-bridge-unavailable"
   | "teams-microphone-muted";
 
-export type TeamsMeetingsPluginTypes = ReturnType<
+type TeamsMeetingsPluginTypes = ReturnType<
   typeof MeetingPlatformAdapter.pluginTypes<
     TeamsMeetingsConfig,
     TeamsMeetingsTransport,
@@ -30,6 +30,4 @@ export type TeamsMeetingsPluginTypes = ReturnType<
 export type TeamsMeetingsTranscriptSnapshot = TeamsMeetingsPluginTypes["TranscriptSnapshot"];
 export type TeamsMeetingsJoinRequest = TeamsMeetingsPluginTypes["JoinRequest"];
 export type TeamsMeetingsChromeHealth = TeamsMeetingsPluginTypes["ChromeHealth"];
-export type TeamsMeetingsBrowserTab = TeamsMeetingsPluginTypes["BrowserTab"];
 export type TeamsMeetingsSession = TeamsMeetingsPluginTypes["Session"];
-export type TeamsMeetingsJoinResult = TeamsMeetingsPluginTypes["JoinResult"];

--- a/extensions/zoom-meetings/src/runtime-probes.test.ts
+++ b/extensions/zoom-meetings/src/runtime-probes.test.ts
@@ -1,13 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { zoomMeetingsConfig } from "./config.js";
-import {
-  testZoomMeetingListening,
-  testZoomMeetingSpeech,
-  type ZoomMeetingsProbeContext,
-} from "./runtime-probes.js";
+import { testZoomMeetingListening, testZoomMeetingSpeech } from "./runtime-probes.js";
 import type { ZoomMeetingsSession } from "./transports/types.js";
 
 const resolveZoomMeetingsConfig = zoomMeetingsConfig.resolveConfig;
+type ZoomMeetingsProbeContext = Parameters<typeof testZoomMeetingSpeech>[0];
 
 const URL = "https://zoom.us/j/12345678902?pwd=probe";
 

--- a/extensions/zoom-meetings/src/runtime-probes.ts
+++ b/extensions/zoom-meetings/src/runtime-probes.ts
@@ -4,11 +4,8 @@ import { zoomMeetingsInvalidRequest } from "./errors.js";
 import type {
   ZoomMeetingsChromeHealth,
   ZoomMeetingsJoinRequest,
-  ZoomMeetingsPluginTypes,
   ZoomMeetingsSession,
 } from "./transports/types.js";
-
-export type ZoomMeetingsProbeContext = ZoomMeetingsPluginTypes["ProbeContext"];
 
 const probes = MeetingPlatformAdapter.createRuntimeProbes<
   ZoomMeetingsConfig,

--- a/extensions/zoom-meetings/src/runtime-setup.ts
+++ b/extensions/zoom-meetings/src/runtime-setup.ts
@@ -1,165 +1,31 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import {
-  addMeetingSetupCheck,
-  createMeetingSetupStatus,
-  MeetingPlatformAdapter,
-  resolveMeetingBrowserNodeInfo,
-  type MeetingSetupStatus,
-} from "openclaw/plugin-sdk/meeting-runtime";
-import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
-import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { ZoomMeetingsConfig, ZoomMeetingsMode, ZoomMeetingsTransport } from "./config.js";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
+import type { ZoomMeetingsConfig, ZoomMeetingsMode } from "./config.js";
 import { assertBlackHole2chAvailable } from "./transports/chrome.js";
 import { ZOOM_MEETINGS_BROWSER_NODE_ADAPTER } from "./transports/zoom-meetings-platform-constants.js";
 
-function audioCommands(config: ZoomMeetingsConfig): string[] {
-  return uniqueStrings(
-    [
-      config.chrome.audioInputCommand[0],
-      config.chrome.audioOutputCommand[0],
-      config.chrome.bargeInInputCommand?.[0],
-    ].filter((value): value is string => Boolean(value?.trim())),
-  );
-}
-
-async function commandExists(runtime: PluginRuntime, command: string): Promise<boolean> {
-  const result = await runtime.system.runCommandWithTimeout(
-    ["/bin/sh", "-lc", 'command -v "$1" >/dev/null 2>&1', "sh", command],
-    { timeoutMs: 5_000 },
-  );
-  return result.code === 0;
-}
-
-export async function getZoomMeetingsSetupStatus(params: {
-  config: ZoomMeetingsConfig;
-  fullConfig: OpenClawConfig;
-  runtime: PluginRuntime;
-  options?: { mode?: ZoomMeetingsMode; transport?: ZoomMeetingsTransport };
-}): Promise<MeetingSetupStatus> {
-  const mode = params.options?.mode ?? params.config.defaultMode;
-  const transport =
-    params.options?.transport ?? (params.config.chromeNode.node ? "chrome-node" : "chrome");
-  const talkBack = MeetingPlatformAdapter.isTalkBackMode(mode);
-  const guestJoinReady = Boolean(
-    params.config.chrome.guestName &&
-    params.config.chrome.autoJoin &&
-    (params.config.chrome.launch || params.config.chrome.reuseExistingTab),
-  );
-  let status = createMeetingSetupStatus([
-    {
-      id: "chrome-profile",
-      ok: true,
-      message: params.config.chrome.browserProfile
-        ? `Chrome node profile configured: ${params.config.chrome.browserProfile}`
-        : "Local Chrome uses the configured OpenClaw browser profile",
-    },
-    {
-      id: "guest-join",
-      ok: guestJoinReady,
-      message: guestJoinReady
+export const getZoomMeetingsSetupStatus = MeetingPlatformAdapter.createRuntimeSetup<
+  ZoomMeetingsConfig,
+  ZoomMeetingsMode
+>({
+  assertAudioDeviceAvailable: assertBlackHole2chAvailable,
+  captionsMessage: (mode) =>
+    mode === "transcribe"
+      ? "Zoom live-caption capture is enabled and ready"
+      : "Caption scraping is not used by talk-back modes",
+  connectedNodeMessage: (node) => `Connected Zoom meeting node ready: ${node}`,
+  guestJoinCheck: (config) => {
+    const ok = Boolean(
+      config.chrome.guestName &&
+      config.chrome.autoJoin &&
+      (config.chrome.launch || config.chrome.reuseExistingTab),
+    );
+    return {
+      ok,
+      message: ok
         ? "Guest name, auto-join, and a Chrome launch or reuse path are configured"
         : "Set chrome.guestName, chrome.autoJoin, and either chrome.launch or chrome.reuseExistingTab for unattended guest joins",
-    },
-    {
-      id: "captions",
-      ok: true,
-      message:
-        mode === "transcribe"
-          ? "Zoom live-caption capture is enabled and ready"
-          : "Caption scraping is not used by talk-back modes",
-    },
-  ]);
-
-  if (transport === "chrome-node") {
-    try {
-      const node = await resolveMeetingBrowserNodeInfo({
-        runtime: params.runtime,
-        requestedNode: params.config.chromeNode.node,
-        adapter: ZOOM_MEETINGS_BROWSER_NODE_ADAPTER,
-      });
-      status = addMeetingSetupCheck(status, {
-        id: "chrome-node-connected",
-        ok: true,
-        message: `Connected Zoom meeting node ready: ${node.displayName ?? node.remoteIp ?? node.nodeId}`,
-      });
-      if (talkBack) {
-        if (!node.nodeId) {
-          throw new Error("Connected Zoom meetings node did not include a node id.");
-        }
-        await params.runtime.nodes.invoke({
-          nodeId: node.nodeId,
-          command: ZOOM_MEETINGS_BROWSER_NODE_ADAPTER.nodeCommandName,
-          params: {
-            action: "setup",
-            audioInputCommand: params.config.chrome.audioInputCommand,
-            audioOutputCommand: params.config.chrome.audioOutputCommand,
-            ...(params.config.chrome.bargeInInputCommand
-              ? { bargeInInputCommand: params.config.chrome.bargeInInputCommand }
-              : {}),
-          },
-          timeoutMs: 12_000,
-        });
-        status = addMeetingSetupCheck(status, {
-          id: "chrome-node-audio-prerequisites",
-          ok: true,
-          message: "Remote macOS, BlackHole 2ch, and SoX prerequisites are ready",
-        });
-      }
-    } catch (error) {
-      const connected = status.checks.some(
-        (check) => check.id === "chrome-node-connected" && check.ok,
-      );
-      status = addMeetingSetupCheck(status, {
-        id: connected ? "chrome-node-audio-prerequisites" : "chrome-node-connected",
-        ok: false,
-        message: formatErrorMessage(error),
-      });
-    }
-  }
-
-  if (!talkBack) {
-    return status;
-  }
-  status = addMeetingSetupCheck(status, {
-    id: "audio-bridge",
-    ok:
-      params.config.chrome.audioInputCommand.length > 0 &&
-      params.config.chrome.audioOutputCommand.length > 0,
-    message: `SoX command-pair audio bridge configured (${params.config.chrome.audioFormat})`,
-  });
-  if (transport === "chrome-node") {
-    return status;
-  }
-  try {
-    await assertBlackHole2chAvailable({
-      runtime: params.runtime,
-      timeoutMs: Math.min(params.config.chrome.joinTimeoutMs, 10_000),
-    });
-    status = addMeetingSetupCheck(status, {
-      id: "chrome-local-audio-device",
-      ok: true,
-      message: "BlackHole 2ch audio device found",
-    });
-  } catch (error) {
-    status = addMeetingSetupCheck(status, {
-      id: "chrome-local-audio-device",
-      ok: false,
-      message: formatErrorMessage(error),
-    });
-  }
-  const missing: string[] = [];
-  for (const command of audioCommands(params.config)) {
-    if (!(await commandExists(params.runtime, command).catch(() => false))) {
-      missing.push(command);
-    }
-  }
-  return addMeetingSetupCheck(status, {
-    id: "chrome-local-audio-commands",
-    ok: missing.length === 0,
-    message:
-      missing.length === 0
-        ? "Configured Chrome audio commands are available"
-        : `Chrome audio commands missing: ${missing.join(", ")}`,
-  });
-}
+    };
+  },
+  missingNodeIdMessage: "Connected Zoom meetings node did not include a node id.",
+  nodeAdapter: ZOOM_MEETINGS_BROWSER_NODE_ADAPTER,
+});

--- a/extensions/zoom-meetings/src/runtime.ts
+++ b/extensions/zoom-meetings/src/runtime.ts
@@ -1,25 +1,6 @@
-import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import {
-  createMeetingSession,
-  MeetingPlatformAdapter,
-  MeetingSessionRuntime,
-  type MeetingSessionRuntimeHandles,
-  type MeetingSessionRuntimeJoinContext,
-} from "openclaw/plugin-sdk/meeting-runtime";
-import type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
-import type {
-  TranscriptStartRequest,
-  TranscriptStopRequest,
-} from "openclaw/plugin-sdk/transcripts";
+import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type { ZoomMeetingsConfig, ZoomMeetingsMode, ZoomMeetingsTransport } from "./config.js";
-import {
-  testZoomMeetingListening,
-  testZoomMeetingSpeech,
-  type ZoomMeetingsProbeContext,
-} from "./runtime-probes.js";
+import { testZoomMeetingListening, testZoomMeetingSpeech } from "./runtime-probes.js";
 import { getZoomMeetingsSetupStatus } from "./runtime-setup.js";
 import {
   launchZoomMeetingInChrome,
@@ -28,621 +9,159 @@ import {
   readZoomMeetingTranscript,
   recoverCurrentZoomMeetingTab,
 } from "./transports/chrome.js";
-import type {
-  ZoomMeetingsBrowserTab,
-  ZoomMeetingsChromeHealth,
-  ZoomMeetingsJoinRequest,
-  ZoomMeetingsJoinResult,
-  ZoomMeetingsSession,
-} from "./transports/types.js";
+import type { ZoomMeetingsChromeHealth } from "./transports/types.js";
 import { ZOOM_MEETINGS_PLATFORM_ADAPTER } from "./transports/zoom-meetings-platform-adapter.js";
 import { hasSameZoomMeetingJoinCredential } from "./transports/zoom-meetings-urls.js";
 
-type ManualActionReason = NonNullable<ZoomMeetingsChromeHealth["manualAction"]>["reason"];
-type SpeechBlockedReason = NonNullable<ZoomMeetingsChromeHealth["speechBlockedReason"]>;
-type SessionRuntime = MeetingSessionRuntime<
-  ZoomMeetingsSession,
-  ZoomMeetingsJoinRequest,
+export const ZoomMeetingsRuntime = MeetingPlatformAdapter.createRuntimeFacade<
+  ZoomMeetingsConfig,
   ZoomMeetingsTransport,
   ZoomMeetingsMode,
   ZoomMeetingsChromeHealth,
-  ZoomMeetingsBrowserTab,
-  ManualActionReason,
-  SpeechBlockedReason
->;
-type JoinContext = MeetingSessionRuntimeJoinContext<
-  ZoomMeetingsSession,
-  ZoomMeetingsTransport,
-  ZoomMeetingsMode,
-  ZoomMeetingsChromeHealth,
-  ZoomMeetingsBrowserTab
->;
-type LaunchResult =
-  | Awaited<ReturnType<typeof launchZoomMeetingInChrome>>
-  | Awaited<ReturnType<typeof launchZoomMeetingOnNode>>;
-type AudioBridge = NonNullable<LaunchResult["audioBridge"]>;
-
-function nowIso(): string {
-  return new Date().toISOString();
-}
-
-function resolveTransport(
-  request: ZoomMeetingsJoinRequest,
-  config: ZoomMeetingsConfig,
-): ZoomMeetingsTransport {
-  return request.transport ?? (config.chromeNode.node ? "chrome-node" : "chrome");
-}
-
-function withSessionAgentConfig(config: ZoomMeetingsConfig, agentId: string): ZoomMeetingsConfig {
-  return config.realtime.agentId === agentId
-    ? config
-    : { ...config, realtime: { ...config.realtime, agentId } };
-}
-
-function noteSession(session: ZoomMeetingsSession, note: string): void {
-  session.notes = [...session.notes.filter((item) => item !== note), note];
-}
-
-function isAwaitingAdmission(session: ZoomMeetingsSession): boolean {
-  return (
-    session.chrome?.health?.lobbyWaiting === true ||
-    session.chrome?.health?.manualAction?.reason === "zoom-admission-required"
-  );
-}
-
-export class ZoomMeetingsRuntime {
-  readonly #defaultAgentId: string;
-  readonly #sessions: SessionRuntime;
-  readonly #requesterSessionKeys = new Map<string, string>();
-
-  constructor(
-    private readonly params: {
-      config: ZoomMeetingsConfig;
-      fullConfig: OpenClawConfig;
-      runtime: PluginRuntime;
-      logger: RuntimeLogger;
+  {
+    setup: Awaited<ReturnType<typeof getZoomMeetingsSetupStatus>>;
+    listening: Awaited<ReturnType<typeof testZoomMeetingListening>>;
+    speech: Awaited<ReturnType<typeof testZoomMeetingSpeech>>;
+  }
+>({
+  platform: ZOOM_MEETINGS_PLATFORM_ADAPTER,
+  transport: {
+    launchInChrome: launchZoomMeetingInChrome,
+    launchOnNode: launchZoomMeetingOnNode,
+    leaveInBrowser: leaveZoomMeetingInBrowser,
+    readTranscript: readZoomMeetingTranscript,
+    recoverCurrentTab: recoverCurrentZoomMeetingTab,
+  },
+  probes: {
+    setupStatus: getZoomMeetingsSetupStatus,
+    testListening: testZoomMeetingListening,
+    testSpeech: testZoomMeetingSpeech,
+  },
+  hooks: {
+    // Normalize before locking so credential reuse sees the exact launched request.
+    normalizeJoinRequest: (request, context) => {
+      const resolved = context.resolvedJoin(request);
+      return { ...request, agentId: resolved.agentId, url: resolved.url };
     },
-  ) {
-    this.#defaultAgentId = normalizeAgentId(
-      params.config.realtime.agentId ?? resolveDefaultAgentId(params.fullConfig),
-    );
-    this.#sessions = new MeetingSessionRuntime({
-      logger: params.logger,
-      logScope: ZOOM_MEETINGS_PLATFORM_ADAPTER.logScope,
-      formatError: formatErrorMessage,
-      reuseExistingBrowserTab: params.config.chrome.reuseExistingTab,
-      waitForInCallMs: params.config.chrome.waitForInCallMs,
-      joinTimeoutMs: params.config.chrome.joinTimeoutMs,
-      defaultSpeechInstructions: params.config.realtime.introMessage,
-      transientSpeechBlockedReasons: new Set<SpeechBlockedReason>([
-        "not-in-call",
-        "browser-unverified",
-        "zoom-microphone-muted",
-      ]),
-      messages: {
-        previousBrowserLeaveFailed:
-          "Could not leave the previous Zoom meeting tab before reassignment.",
-        reassignedSessionNote:
-          "Ended before the same Zoom meeting tab was reassigned to another agent.",
-        reusedSessionNote: "Reused existing active Zoom meeting session.",
-        replacementBrowserLeaveFailed:
-          "Could not leave the previous Zoom meeting tab before reassignment.",
-        speechBlockedFallback: "Realtime speech blocked until Zoom is ready.",
-        speech: {
-          audioBridgeUnavailable: "Realtime speech requires an active Chrome audio bridge.",
-          browserUnverified: "Zoom browser state has not been verified yet.",
-          microphoneMuted: "Turn on the OpenClaw Zoom microphone before asking OpenClaw to speak.",
-          microphoneMutedReason: "zoom-microphone-muted",
-          notInCall: "Zoom has not reported that the browser guest is in the call.",
-          notInCallReason: "not-in-call",
-          browserUnverifiedReason: "browser-unverified",
-          audioBridgeUnavailableReason: "audio-bridge-unavailable",
-        },
-      },
-      resolveJoin: (request) => ({
-        url: ZOOM_MEETINGS_PLATFORM_ADAPTER.urls.validateAndNormalize(request.url),
-        transport: resolveTransport(request, params.config),
-        mode: request.mode ?? params.config.defaultMode,
-        agentId: normalizeAgentId(request.agentId ?? this.#defaultAgentId),
-      }),
-      createSession: ({ request, resolved, createdAt }) => {
-        const session: ZoomMeetingsSession = createMeetingSession({
-          platform: ZOOM_MEETINGS_PLATFORM_ADAPTER,
-          config: params.config,
-          resolved,
-          createdAt,
-        });
-        if (request.requesterSessionKey) {
-          this.#requesterSessionKeys.set(session.id, request.requesterSessionKey);
-        }
-        return session;
-      },
-      resolveSpeechInstructions: (request) =>
-        request.message ?? params.config.realtime.introMessage,
-      isBrowserTransport: () => true,
-      isTalkBackMode: (mode) => MeetingPlatformAdapter.isTalkBackMode(mode),
-      isTranscribeMode: (mode) => mode === "transcribe",
-      sameMeetingUrl: (left, right) =>
-        ZOOM_MEETINGS_PLATFORM_ADAPTER.urls.isSameMeeting(left, right),
-      normalizeMeetingUrlForReuse: (url) =>
-        ZOOM_MEETINGS_PLATFORM_ADAPTER.urls.normalizeForReuse(url),
-      getBrowser: (session) =>
-        session.chrome
-          ? {
-              launched: session.chrome.launched,
-              nodeId: session.chrome.nodeId,
-              tab: session.chrome.browserTab,
-              health: session.chrome.health,
-              hasAudioBridge: Boolean(
-                session.chrome.audioBridge && session.chrome.health?.bridgeClosed !== true,
-              ),
-            }
-          : undefined,
-      setBrowserTab: (session, tab) => {
-        if (session.chrome) {
-          session.chrome.browserTab = tab;
-        }
-      },
-      setBrowserHealth: (session, health) => {
-        if (session.chrome) {
-          session.chrome.health = health;
-        }
-      },
-      joinTransport: async ({ request, session, context }) =>
-        await this.#joinTransport(request, session, context),
-      releaseBrowserTab: async (session) => await this.#releaseBrowserTab(session),
-      refreshBrowserHealth: async (session, options) =>
-        await this.#refreshBrowserHealth(session, options),
-      refreshStatus: async (session) => {
-        await this.#sessions.refreshBrowserHealth(session, {
-          force: true,
-          readOnly: !isAwaitingAdmission(session),
-        });
-        const confirmedTabMissing = session.chrome?.health?.status === "browser-tab-missing";
-        if (session.state === "active" && confirmedTabMissing) {
-          session.browserLeft = true;
-          await this.#sessions.leave(session.id, { keepBrowserTab: true });
-          this.#requesterSessionKeys.delete(session.id);
-        } else if (session.state === "active" && session.chrome?.health?.meetingEnded === true) {
-          await this.leave(session.id);
-        }
-      },
-      refreshReusableSession: async (session, request) => {
-        await this.#sessions.refreshBrowserHealth(session, {
-          force: true,
-          readOnly: false,
-        });
-        const browser = session.chrome;
-        const health = browser?.health;
-        const staleSession =
-          !browser?.browserTab ||
-          health?.meetingEnded === true ||
-          health?.manualAction?.reason === "zoom-session-conflict" ||
-          health?.manualAction?.reason === "browser-control-unavailable" ||
-          health?.bridgeClosed === true;
-        const replacePendingJoin =
-          health?.inCall !== true &&
-          health?.manualAction?.reason === "zoom-passcode-required" &&
-          !hasSameZoomMeetingJoinCredential(session.url, request.url);
-        if (staleSession || replacePendingJoin) {
-          session.state = "ended";
-          session.updatedAt = nowIso();
-          noteSession(
-            session,
-            replacePendingJoin
-              ? "Ended pending Zoom session after receiving a corrected meeting credential."
-              : "Ended stale Zoom session before opening a replacement.",
-          );
-          this.#requesterSessionKeys.delete(session.id);
-          return {
-            keepBrowserTab:
-              !replacePendingJoin && health?.meetingEnded !== true && health?.bridgeClosed !== true,
-          };
-        }
-        return undefined;
-      },
-      ensureRealtimeBridge: async (session) => await this.#ensureRealtimeBridge(session),
-      captureTranscript: async (session, options) =>
-        await this.#captureTranscript(session, options),
-      speakViaTransport: async () => undefined,
-      durableTranscripts: {
-        config: params.fullConfig.transcripts,
-        providerId: "zoom",
-        providerName: "Zoom",
-      },
-    });
-  }
-
-  list(): ZoomMeetingsSession[] {
-    return this.#sessions.list();
-  }
-
-  async startTranscriptSource(request: TranscriptStartRequest) {
-    return await this.#sessions.startTranscriptSource(request);
-  }
-
-  async stopTranscriptSource(request: TranscriptStopRequest) {
-    return await this.#sessions.stopTranscriptSource(request);
-  }
-
-  ownsSession(agentId: string, sessionId: string): boolean {
-    return this.list().some((session) => session.id === sessionId && session.agentId === agentId);
-  }
-
-  async join(request: ZoomMeetingsJoinRequest): Promise<ZoomMeetingsJoinResult> {
-    try {
-      const url = ZOOM_MEETINGS_PLATFORM_ADAPTER.urls.validateAndNormalize(request.url);
-      const agentId = normalizeAgentId(request.agentId ?? this.#defaultAgentId);
-      return await this.#sessions.join({ ...request, agentId, url });
-    } catch (error) {
-      const activeIds = new Set(this.list().map((session) => session.id));
-      for (const sessionId of this.#requesterSessionKeys.keys()) {
-        if (!activeIds.has(sessionId)) {
-          this.#requesterSessionKeys.delete(sessionId);
-        }
+    // Stateful admission refresh lets the admitted page adopt its existing session.
+    isAwaitingAdmission: (session) =>
+      session.chrome?.health?.lobbyWaiting === true ||
+      session.chrome?.health?.manualAction?.reason === "zoom-admission-required",
+    // Only Zoom treats a missing or host-ended page as terminal during status.
+    afterStatusRefresh: async (session, context) => {
+      const confirmedTabMissing = session.chrome?.health?.status === "browser-tab-missing";
+      if (session.state === "active" && confirmedTabMissing) {
+        session.browserLeft = true;
+        await context.endSession(session.id, { keepBrowserTab: true });
+      } else if (session.state === "active" && session.chrome?.health?.meetingEnded === true) {
+        await context.endSession(session.id);
       }
-      throw error;
-    }
-  }
-
-  async leave(sessionId: string) {
-    try {
-      return await this.#sessions.leave(sessionId);
-    } finally {
-      this.#requesterSessionKeys.delete(sessionId);
-    }
-  }
-
-  async status(sessionId?: string) {
-    return await this.#sessions.status(sessionId);
-  }
-
-  async statusForAgent(agentId: string, sessionId?: string) {
-    if (sessionId) {
-      return this.ownsSession(agentId, sessionId)
-        ? await this.#sessions.status(sessionId)
-        : { found: false };
-    }
-    const sessions = this.list().filter((session) => session.agentId === agentId);
-    await Promise.all(sessions.map((session) => this.#sessions.status(session.id)));
-    return { found: true, sessions };
-  }
-
-  async transcript(sessionId: string, options: { sinceIndex?: number } = {}) {
-    return await this.#sessions.transcript(sessionId, options);
-  }
-
-  async speak(sessionId: string, instructions?: string) {
-    return await this.#sessions.speak(sessionId, instructions);
-  }
-
-  async setupStatus(options?: { mode?: ZoomMeetingsMode; transport?: ZoomMeetingsTransport }) {
-    return await getZoomMeetingsSetupStatus({
-      config: this.params.config,
-      fullConfig: this.params.fullConfig,
-      runtime: this.params.runtime,
-      options,
-    });
-  }
-
-  async testSpeech(request: ZoomMeetingsJoinRequest) {
-    return await testZoomMeetingSpeech(this.#probeContext(), request);
-  }
-
-  async testListen(request: ZoomMeetingsJoinRequest) {
-    return await testZoomMeetingListening(this.#probeContext(), request);
-  }
-
-  #probeContext(): ZoomMeetingsProbeContext {
-    return {
-      config: this.params.config,
-      resolveAgentId: (request) => normalizeAgentId(request.agentId ?? this.#defaultAgentId),
-      list: () => this.list(),
-      join: async (request) => await this.join(request),
-      isReusable: (session, resolved) => this.#sessions.isReusableSession(session, resolved),
-      hasHealthHandle: (sessionId) => this.#sessions.hasHealthHandle(sessionId),
-      refreshHealth: (sessionId) => this.#sessions.refreshHealth(sessionId),
-      refreshCaptionHealth: async (session, timeoutMs) =>
-        await this.#refreshBrowserHealth(session, { timeoutMs }),
-    };
-  }
-
-  async #joinTransport(
-    request: ZoomMeetingsJoinRequest,
-    session: ZoomMeetingsSession,
-    context: JoinContext,
-  ): Promise<{ delegatedSpoken?: boolean }> {
-    const config = withSessionAgentConfig(this.params.config, session.agentId);
-    const result: LaunchResult =
-      session.transport === "chrome-node"
-        ? await launchZoomMeetingOnNode({
-            runtime: this.params.runtime,
-            config,
-            fullConfig: this.params.fullConfig,
-            meetingSessionId: session.id,
-            requesterSessionKey: request.requesterSessionKey,
-            mode: session.mode,
-            url: session.url,
-            logger: this.params.logger,
-          })
-        : await launchZoomMeetingInChrome({
-            runtime: this.params.runtime,
-            config,
-            fullConfig: this.params.fullConfig,
-            meetingSessionId: session.id,
-            requesterSessionKey: request.requesterSessionKey,
-            mode: session.mode,
-            url: session.url,
-            logger: this.params.logger,
-          });
-    const nodeId = "nodeId" in result ? result.nodeId : undefined;
-    const tab = context.inheritedBrowserTab({
-      session,
-      transport: session.transport,
-      nodeId,
-      meetingUrl: session.url,
-      tab: result.tab,
-    });
-    session.chrome = {
-      audioBackend: "blackhole-2ch",
-      launched: result.launched,
-      nodeId,
-      browserProfile: this.params.config.chrome.browserProfile,
-      browserTab: tab,
-      health: result.browser,
-    };
-    if (result.browser?.meetingEnded === true) {
-      throw new Error("The Zoom meeting has already ended.");
-    }
-    const handles = this.#attachAudioBridge(session, result.audioBridge);
-    if (handles) {
-      context.attachRuntimeHandles(session, handles);
-    }
-    session.notes.push(
-      result.audioBridge
-        ? session.transport === "chrome-node"
-          ? "Zoom guest joined in Chrome on the selected node with realtime audio through the node bridge."
-          : "Zoom guest joined in local Chrome with realtime audio through BlackHole 2ch and SoX."
-        : session.mode === "transcribe"
-          ? "Zoom guest joined observe-only with live-caption transcript capture."
-          : "Zoom guest join is waiting for the browser to become ready before starting realtime audio.",
-    );
-    this.#sessions.refreshSpeechReadiness(session);
-    return {};
-  }
-
-  #attachAudioBridge(
-    session: ZoomMeetingsSession,
-    audioBridge: AudioBridge | undefined,
-  ): MeetingSessionRuntimeHandles<ZoomMeetingsChromeHealth> | undefined {
-    if (!session.chrome || !audioBridge) {
-      return undefined;
-    }
-    session.chrome.audioBridge = {
-      type: audioBridge.type,
-      provider: audioBridge.providerId,
-    };
-    session.chrome.health = { ...session.chrome.health, bridgeClosed: false };
-    return {
-      stop: audioBridge.stop,
-      speak: audioBridge.speak,
-      getHealth: audioBridge.getHealth,
-    };
-  }
-
-  async #ensureRealtimeBridge(
-    session: ZoomMeetingsSession,
-  ): Promise<MeetingSessionRuntimeHandles<ZoomMeetingsChromeHealth> | undefined> {
-    const bridgeClosed = session.chrome?.health?.bridgeClosed === true;
-    if (
-      !MeetingPlatformAdapter.isTalkBackMode(session.mode) ||
-      session.state !== "active" ||
-      !session.chrome ||
-      (session.chrome.audioBridge && !bridgeClosed) ||
-      !MeetingPlatformAdapter.isRealtimeRouteReady(session.mode, session.chrome.health)
-    ) {
-      return undefined;
-    }
-    if (bridgeClosed) {
-      session.chrome.audioBridge = undefined;
-    }
-    const config = withSessionAgentConfig(this.params.config, session.agentId);
-    const recoveryConfig = {
-      ...config,
-      chrome: { ...config.chrome, launch: false },
-      chromeNode: { node: session.chrome.nodeId ?? config.chromeNode.node },
-    };
-    const result =
-      session.transport === "chrome-node"
-        ? await launchZoomMeetingOnNode({
-            runtime: this.params.runtime,
-            config: recoveryConfig,
-            fullConfig: this.params.fullConfig,
-            meetingSessionId: session.id,
-            requesterSessionKey: this.#requesterSessionKeys.get(session.id),
-            mode: session.mode,
-            trackedTargetId: session.chrome.browserTab?.targetId,
-            url: session.url,
-            logger: this.params.logger,
-          })
-        : await launchZoomMeetingInChrome({
-            runtime: this.params.runtime,
-            config: recoveryConfig,
-            fullConfig: this.params.fullConfig,
-            meetingSessionId: session.id,
-            requesterSessionKey: this.#requesterSessionKeys.get(session.id),
-            mode: session.mode,
-            trackedTargetId: session.chrome.browserTab?.targetId,
-            url: session.url,
-            logger: this.params.logger,
-          });
-    if (result.tab) {
-      const currentTab = session.chrome.browserTab;
-      session.chrome.browserTab = {
-        ...result.tab,
-        openedByPlugin:
-          result.tab.targetId === currentTab?.targetId
-            ? currentTab.openedByPlugin
-            : result.tab.openedByPlugin,
+    },
+    // Corrected passcodes replace pending joins; safe stale sessions retain their tab.
+    refreshReusableSession: async (session, request, context) => {
+      await context.refreshBrowserHealth(session, { force: true, readOnly: false });
+      const browser = session.chrome;
+      const health = browser?.health;
+      const staleSession =
+        !browser?.browserTab ||
+        health?.meetingEnded === true ||
+        health?.manualAction?.reason === "zoom-session-conflict" ||
+        health?.manualAction?.reason === "browser-control-unavailable" ||
+        health?.bridgeClosed === true;
+      const replacePendingJoin =
+        health?.inCall !== true &&
+        health?.manualAction?.reason === "zoom-passcode-required" &&
+        !hasSameZoomMeetingJoinCredential(session.url, request.url);
+      if (!staleSession && !replacePendingJoin) {
+        return undefined;
+      }
+      session.state = "ended";
+      session.updatedAt = new Date().toISOString();
+      context.noteSession(
+        session,
+        replacePendingJoin
+          ? "Ended pending Zoom session after receiving a corrected meeting credential."
+          : "Ended stale Zoom session before opening a replacement.",
+      );
+      context.deleteRequesterSessionKey(session.id);
+      return {
+        keepBrowserTab:
+          !replacePendingJoin && health?.meetingEnded !== true && health?.bridgeClosed !== true,
       };
-    }
-    if (result.browser) {
-      session.chrome.health = { ...session.chrome.health, ...result.browser };
-    }
-    session.updatedAt = nowIso();
-    return this.#attachAudioBridge(session, result.audioBridge);
-  }
-
-  async #refreshBrowserHealth(
-    session: ZoomMeetingsSession,
-    options: { readOnly?: boolean; timeoutMs?: number } = {},
-  ): Promise<void> {
-    try {
-      const result = await recoverCurrentZoomMeetingTab({
-        runtime: this.params.runtime,
-        config: this.params.config,
-        fullConfig: this.params.fullConfig,
-        meetingSessionId: session.id,
-        mode: session.mode,
-        nodeId: session.chrome?.nodeId,
-        readOnly: options.readOnly,
-        trackedMeetingUrl: session.url,
-        trackedTargetId: session.chrome?.browserTab?.targetId,
-        transport: session.transport,
-        timeoutMs: options.timeoutMs,
-        url: session.url,
-      });
-      if (result.found && session.chrome) {
-        if (result.tab?.targetId) {
-          const currentTab = session.chrome.browserTab;
-          session.chrome.browserTab = {
-            targetId: result.tab.targetId,
-            openedByPlugin:
-              result.tab.targetId === currentTab?.targetId ? currentTab.openedByPlugin : false,
-          };
-        }
-        if (result.browser) {
-          session.chrome.health = { ...session.chrome.health, ...result.browser };
-        }
-        session.updatedAt = nowIso();
-      } else if (session.chrome) {
+    },
+    // A closed Zoom realtime engine is absent so a later speak can rebuild it.
+    isAudioBridgeActive: (session) =>
+      Boolean(session.chrome?.audioBridge && session.chrome.health?.bridgeClosed !== true),
+    afterAudioBridgeAttached: (session) => {
+      if (session.chrome) {
+        session.chrome.health = { ...session.chrome.health, bridgeClosed: false };
+      }
+    },
+    validateLaunchResult: (result) => {
+      if (result.browser?.meetingEnded === true) {
+        throw new Error("The Zoom meeting has already ended.");
+      }
+    },
+    // Missing or unreachable browser state is authoritative for Zoom session reuse;
+    // recording it prevents a dead tab from being reported or reused as active.
+    recordBrowserRecoveryFailure: (session, failure) => {
+      if (!session.chrome) {
+        return;
+      }
+      if (failure.kind === "missing") {
         session.chrome.browserTab = undefined;
         session.browserLeft = true;
-        session.chrome.health = {
-          ...session.chrome.health,
-          inCall: false,
-          micMuted: undefined,
-          captioning: false,
-          audioInputRouted: false,
-          audioOutputRouted: false,
-          manualAction: { reason: "browser-control-unavailable", message: result.message },
-          status: "browser-tab-missing",
-          notes: [
-            ...(session.chrome.health?.notes ?? []).filter((note) => note !== result.message),
-            result.message,
-          ],
-        };
-        session.updatedAt = nowIso();
       }
-    } catch (error) {
-      const message = `Zoom browser readiness refresh failed: ${formatErrorMessage(error)}`;
-      this.params.logger.debug?.(`${ZOOM_MEETINGS_PLATFORM_ADAPTER.logScope} ${message}`);
-      if (session.chrome) {
-        session.chrome.health = {
-          ...session.chrome.health,
-          inCall: false,
-          micMuted: undefined,
-          captioning: false,
-          audioInputRouted: false,
-          audioOutputRouted: false,
-          manualAction: { reason: "browser-control-unavailable", message },
-          status: "browser-control",
-          notes: [
-            ...(session.chrome.health?.notes ?? []).filter((note) => note !== message),
-            message,
-          ],
-        };
-        session.updatedAt = nowIso();
-      }
-    }
-  }
-
-  async #captureTranscript(session: ZoomMeetingsSession, options: { finalize?: boolean } = {}) {
-    // Recovery permits caption setup but atomically refuses a different live
-    // session owner, so stale sessions read their archived page buffer instead.
-    await this.#sessions.refreshCaptionHealth(session);
-    const tab = session.chrome?.browserTab;
-    if (!tab) {
-      return undefined;
-    }
-    return await readZoomMeetingTranscript({
-      runtime: this.params.runtime,
-      config: this.params.config,
-      finalize: options.finalize,
-      meetingUrl: session.url,
-      meetingSessionId: session.id,
-      nodeId: session.chrome?.nodeId,
-      tab,
-    });
-  }
-
-  async #releaseBrowserTab(session: ZoomMeetingsSession): Promise<boolean | undefined> {
-    const tab = session.chrome?.browserTab;
-    if (!tab) {
-      noteSession(
-        session,
-        "No tracked Zoom meeting tab; leave the browser meeting manually if it is still active.",
-      );
-      session.browserLeft = false;
-      return false;
-    }
-    const shared = this.list().some(
-      (other) =>
-        other.id !== session.id &&
-        other.state === "active" &&
-        other.chrome?.browserTab?.targetId === tab.targetId &&
-        other.chrome?.nodeId === session.chrome?.nodeId,
-    );
-    if (shared) {
-      noteSession(session, "Kept the shared Zoom meeting tab open for another active session.");
-      return undefined;
-    }
-    try {
-      const result = await leaveZoomMeetingInBrowser({
-        runtime: this.params.runtime,
-        config: this.params.config,
-        meetingSessionId: session.id,
-        meetingUrl: session.url,
-        nodeId: session.chrome?.nodeId,
-        tab,
-      });
-      noteSession(session, result.note);
-      if (result.left && session.chrome) {
-        session.chrome.browserTab = undefined;
-        if (session.chrome.health) {
-          // MeetingSessionRuntime owns the canonical in-call/manual reset after this
-          // release reports success; this plugin clears only Zoom-specific health.
-          session.chrome.health = {
-            ...session.chrome.health,
-            captioning: false,
-            audioInputRouted: false,
-            audioOutputRouted: false,
-            providerConnected: false,
-            realtimeReady: false,
-            audioInputActive: false,
-            audioOutputActive: false,
-          };
-        }
-      }
-      session.browserLeft = result.left;
-      return result.left;
-    } catch (error) {
-      noteSession(
-        session,
-        `Browser control could not leave the Zoom meeting tab: ${formatErrorMessage(error)}`,
-      );
-      session.browserLeft = false;
-      return false;
-    }
-  }
-}
+      session.chrome.health = {
+        ...session.chrome.health,
+        inCall: false,
+        micMuted: undefined,
+        captioning: false,
+        audioInputRouted: false,
+        audioOutputRouted: false,
+        manualAction: { reason: "browser-control-unavailable", message: failure.message },
+        status: failure.kind === "missing" ? "browser-tab-missing" : "browser-control",
+        notes: [
+          ...(session.chrome.health?.notes ?? []).filter((note) => note !== failure.message),
+          failure.message,
+        ],
+      };
+      session.updatedAt = new Date().toISOString();
+    },
+  },
+  messages: {
+    browserReadinessFailed: (error) => `Zoom browser readiness refresh failed: ${error}`,
+    durableTranscripts: { providerId: "zoom", providerName: "Zoom" },
+    joined: {
+      local: "Zoom guest joined in local Chrome with realtime audio through BlackHole 2ch and SoX.",
+      node: "Zoom guest joined in Chrome on the selected node with realtime audio through the node bridge.",
+      transcribe: "Zoom guest joined observe-only with live-caption transcript capture.",
+      waiting:
+        "Zoom guest join is waiting for the browser to become ready before starting realtime audio.",
+    },
+    leaveFailed: (error) => `Browser control could not leave the Zoom meeting tab: ${error}`,
+    noTrackedTab:
+      "No tracked Zoom meeting tab; leave the browser meeting manually if it is still active.",
+    sharedTab: "Kept the shared Zoom meeting tab open for another active session.",
+    sessionRuntime: {
+      previousBrowserLeaveFailed:
+        "Could not leave the previous Zoom meeting tab before reassignment.",
+      reassignedSessionNote:
+        "Ended before the same Zoom meeting tab was reassigned to another agent.",
+      reusedSessionNote: "Reused existing active Zoom meeting session.",
+      replacementBrowserLeaveFailed:
+        "Could not leave the previous Zoom meeting tab before reassignment.",
+      speechBlockedFallback: "Realtime speech blocked until Zoom is ready.",
+      speech: {
+        audioBridgeUnavailable: "Realtime speech requires an active Chrome audio bridge.",
+        browserUnverified: "Zoom browser state has not been verified yet.",
+        microphoneMuted: "Turn on the OpenClaw Zoom microphone before asking OpenClaw to speak.",
+        microphoneMutedReason: "zoom-microphone-muted",
+        notInCall: "Zoom has not reported that the browser guest is in the call.",
+        notInCallReason: "not-in-call",
+        browserUnverifiedReason: "browser-unverified",
+        audioBridgeUnavailableReason: "audio-bridge-unavailable",
+      },
+    },
+  },
+});

--- a/extensions/zoom-meetings/src/transports/types.ts
+++ b/extensions/zoom-meetings/src/transports/types.ts
@@ -20,7 +20,7 @@ type ZoomMeetingsSpeechBlockedReason =
   | "audio-bridge-unavailable"
   | "zoom-microphone-muted";
 
-export type ZoomMeetingsPluginTypes = ReturnType<
+type ZoomMeetingsPluginTypes = ReturnType<
   typeof MeetingPlatformAdapter.pluginTypes<
     ZoomMeetingsConfig,
     ZoomMeetingsTransport,
@@ -33,6 +33,4 @@ export type ZoomMeetingsPluginTypes = ReturnType<
 export type ZoomMeetingsTranscriptSnapshot = ZoomMeetingsPluginTypes["TranscriptSnapshot"];
 export type ZoomMeetingsJoinRequest = ZoomMeetingsPluginTypes["JoinRequest"];
 export type ZoomMeetingsChromeHealth = ZoomMeetingsPluginTypes["ChromeHealth"];
-export type ZoomMeetingsBrowserTab = ZoomMeetingsPluginTypes["BrowserTab"];
 export type ZoomMeetingsSession = ZoomMeetingsPluginTypes["Session"];
-export type ZoomMeetingsJoinResult = ZoomMeetingsPluginTypes["JoinResult"];

--- a/src/meeting-bot/platform-adapter.ts
+++ b/src/meeting-bot/platform-adapter.ts
@@ -21,7 +21,9 @@ import {
   createMeetingPluginShellEntry,
   createMeetingPluginTypes,
 } from "./plugin-shell.js";
+import { createMeetingRuntimeFacade } from "./runtime-facade.js";
 import { createMeetingRuntimeProbes, resolveMeetingProbeTimeoutMs } from "./runtime-probes.js";
+import { createMeetingRuntimeSetup } from "./runtime-setup.js";
 import type { MeetingBrowserHealth, MeetingTranscriptSnapshot } from "./session-types.js";
 import { createMeetingStatusCallSource } from "./status-call-source.js";
 import { createMeetingStatusPreludeSource } from "./status-prejoin-source.js";
@@ -385,6 +387,8 @@ export const MeetingPlatformAdapter = {
   createPluginNodeHostHandler: createMeetingPluginNodeHostHandler,
   createPluginNodeInvokePolicy: createMeetingPluginNodeInvokePolicy,
   createPluginShellEntry: createMeetingPluginShellEntry,
+  createRuntimeFacade: createMeetingRuntimeFacade,
+  createRuntimeSetup: createMeetingRuntimeSetup,
   pluginTypes: createMeetingPluginTypes,
   registerPluginCli: registerMeetingPluginCli,
   resolveProbeTimeoutMs: resolveMeetingProbeTimeoutMs,

--- a/src/meeting-bot/runtime-facade-types.ts
+++ b/src/meeting-bot/runtime-facade-types.ts
@@ -1,0 +1,305 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginRuntime, RuntimeLogger } from "../plugins/runtime/types.js";
+import type {
+  MeetingBrowserJoinSession,
+  MeetingPlatformRuntimeMetadata,
+} from "./platform-adapter-contract.js";
+import type { MeetingPlatformAdapter } from "./platform-adapter.js";
+import type { MeetingPluginConfig } from "./plugin-config.js";
+import type { MeetingProbeContext } from "./runtime-probes.js";
+import type {
+  MeetingSessionRuntime,
+  MeetingSessionRuntimeHandles,
+  MeetingSessionRuntimeMessages,
+} from "./session-runtime.js";
+import type {
+  MeetingBrowserCandidateTab,
+  MeetingBrowserHealth,
+  MeetingBrowserTab,
+  MeetingPluginChromeHealth,
+  MeetingPluginJoinRequest,
+  MeetingPluginSession,
+  MeetingResolvedJoin,
+  MeetingTranscriptSnapshot,
+} from "./session-types.js";
+
+export type MeetingRuntimeParams<Config extends MeetingPluginConfig> = {
+  config: Config;
+  fullConfig: OpenClawConfig;
+  runtime: PluginRuntime;
+  logger: RuntimeLogger;
+};
+
+type MeetingRuntimePlatform<
+  Mode extends string,
+  Health extends MeetingBrowserHealth,
+> = MeetingPlatformAdapter<
+  MeetingBrowserJoinSession<Mode>,
+  Mode,
+  Health,
+  MeetingTranscriptSnapshot
+> &
+  MeetingPlatformRuntimeMetadata;
+
+export type MeetingRuntimeAudioBridge<Health extends MeetingBrowserHealth> =
+  MeetingSessionRuntimeHandles<Health> & {
+    providerId?: string;
+    type: "command-pair" | "node-command-pair";
+  };
+
+type MeetingRuntimeLaunchResult<Health extends MeetingBrowserHealth> = {
+  launched: boolean;
+  audioBridge?: MeetingRuntimeAudioBridge<Health>;
+  browser?: Health;
+  nodeId?: string;
+  tab?: MeetingBrowserTab;
+};
+
+type MeetingRuntimeLaunchParams<Config extends MeetingPluginConfig, Mode extends string> = {
+  runtime: PluginRuntime;
+  config: Config;
+  fullConfig: OpenClawConfig;
+  meetingSessionId: string;
+  requesterSessionKey?: string;
+  mode: Mode;
+  trackedTargetId?: string;
+  url: string;
+  logger: RuntimeLogger;
+};
+
+type MeetingRuntimeTransport<
+  Config extends MeetingPluginConfig,
+  Mode extends string,
+  Health extends MeetingBrowserHealth,
+> = {
+  launchInChrome(
+    params: MeetingRuntimeLaunchParams<Config, Mode>,
+  ): Promise<MeetingRuntimeLaunchResult<Health>>;
+  launchOnNode(
+    params: MeetingRuntimeLaunchParams<Config, Mode>,
+  ): Promise<MeetingRuntimeLaunchResult<Health> & { nodeId: string }>;
+  leaveInBrowser(params: {
+    runtime: PluginRuntime;
+    config: Config;
+    meetingSessionId: string;
+    meetingUrl: string;
+    nodeId?: string;
+    tab: MeetingBrowserTab;
+  }): Promise<{ left: boolean; note: string }>;
+  readTranscript(params: {
+    runtime: PluginRuntime;
+    config: Config;
+    finalize?: boolean;
+    meetingUrl: string;
+    meetingSessionId: string;
+    nodeId?: string;
+    tab: MeetingBrowserTab;
+  }): Promise<MeetingTranscriptSnapshot>;
+  recoverCurrentTab(params: {
+    runtime: PluginRuntime;
+    config: Config;
+    fullConfig?: OpenClawConfig;
+    meetingSessionId?: string;
+    mode: Mode;
+    nodeId?: string;
+    readOnly?: boolean;
+    trackedMeetingUrl?: string;
+    trackedTargetId?: string;
+    transport: "chrome" | "chrome-node";
+    timeoutMs?: number;
+    url?: string;
+  }): Promise<{
+    browser?: Health;
+    found: boolean;
+    message: string;
+    tab?: MeetingBrowserCandidateTab;
+  }>;
+};
+
+type MeetingRuntimeManualActionReason<Health extends MeetingBrowserHealth> = NonNullable<
+  Health["manualAction"]
+>["reason"];
+export type MeetingRuntimeSpeechBlockedReason<Health extends MeetingBrowserHealth> = NonNullable<
+  Health["speechBlockedReason"]
+>;
+
+export type MeetingRuntimeSession<
+  Transport extends string,
+  Mode extends string,
+  Health extends MeetingBrowserHealth,
+> = MeetingPluginSession<Transport, Mode, Health>;
+export type MeetingRuntimeRequest<
+  Transport extends string,
+  Mode extends string,
+> = MeetingPluginJoinRequest<Transport, Mode>;
+
+export type MeetingRuntimeProbeResults = {
+  setup: unknown;
+  listening: unknown;
+  speech: unknown;
+};
+
+export type MeetingRuntimeOwner<
+  Transport extends "chrome" | "chrome-node",
+  Mode extends string,
+  Health extends MeetingBrowserHealth,
+> = MeetingSessionRuntime<
+  MeetingRuntimeSession<Transport, Mode, Health>,
+  MeetingRuntimeRequest<Transport, Mode>,
+  Transport,
+  Mode,
+  Health,
+  MeetingBrowserTab,
+  MeetingRuntimeManualActionReason<Health>,
+  MeetingRuntimeSpeechBlockedReason<Health>
+>;
+
+type MeetingRuntimeFacadeInstance<
+  Transport extends "chrome" | "chrome-node",
+  Mode extends string,
+  Health extends MeetingPluginChromeHealth<string, string>,
+  Results extends MeetingRuntimeProbeResults,
+> = Pick<
+  MeetingRuntimeOwner<Transport, Mode, Health>,
+  | "join"
+  | "leave"
+  | "speak"
+  | "startTranscriptSource"
+  | "status"
+  | "stopTranscriptSource"
+  | "transcript"
+> & {
+  list(): MeetingRuntimeSession<Transport, Mode, Health>[];
+  ownsSession(agentId: string, sessionId: string): boolean;
+  setupStatus(options?: { mode?: Mode; transport?: Transport }): Promise<Results["setup"]>;
+  statusForAgent(
+    agentId: string,
+    sessionId?: string,
+  ): Promise<{
+    found: boolean;
+    session?: MeetingRuntimeSession<Transport, Mode, Health>;
+    sessions?: MeetingRuntimeSession<Transport, Mode, Health>[];
+  }>;
+  testListen(request: MeetingRuntimeRequest<Transport, Mode>): Promise<Results["listening"]>;
+  testSpeech(request: MeetingRuntimeRequest<Transport, Mode>): Promise<Results["speech"]>;
+};
+
+export type MeetingRuntimeFacadeConstructor<
+  Config extends MeetingPluginConfig,
+  Transport extends "chrome" | "chrome-node",
+  Mode extends string,
+  Health extends MeetingPluginChromeHealth<string, string>,
+  Results extends MeetingRuntimeProbeResults,
+> = new (
+  params: MeetingRuntimeParams<Config>,
+) => MeetingRuntimeFacadeInstance<Transport, Mode, Health, Results>;
+
+export type MeetingRuntimeHookContext<
+  Session extends MeetingPluginSession<Transport, Mode, Health>,
+  Request extends MeetingPluginJoinRequest<Transport, Mode>,
+  Transport extends string,
+  Mode extends string,
+  Health extends MeetingBrowserHealth,
+> = {
+  deleteRequesterSessionKey(sessionId: string): void;
+  endSession(sessionId: string, options?: { keepBrowserTab?: boolean }): Promise<void>;
+  noteSession(session: Session, note: string): void;
+  refreshBrowserHealth(
+    session: Session,
+    options?: { force?: boolean; readOnly?: boolean },
+  ): Promise<void>;
+  resolvedJoin(request: Request): MeetingResolvedJoin<Transport, Mode>;
+};
+
+type MeetingRuntimeHooks<
+  Session extends MeetingPluginSession<Transport, Mode, Health>,
+  Request extends MeetingPluginJoinRequest<Transport, Mode>,
+  Transport extends string,
+  Mode extends string,
+  Health extends MeetingBrowserHealth,
+> = {
+  afterStatusRefresh?(
+    session: Session,
+    context: MeetingRuntimeHookContext<Session, Request, Transport, Mode, Health>,
+  ): Promise<void>;
+  afterAudioBridgeAttached?(session: Session): void;
+  isAudioBridgeActive?(session: Session): boolean;
+  isAwaitingAdmission?(session: Session): boolean;
+  normalizeJoinRequest?(
+    request: Request,
+    context: MeetingRuntimeHookContext<Session, Request, Transport, Mode, Health>,
+  ): Request;
+  recordBrowserRecoveryFailure?(
+    session: Session,
+    failure: { kind: "missing" | "error"; message: string },
+  ): void;
+  refreshReusableSession?(
+    session: Session,
+    request: Request,
+    context: MeetingRuntimeHookContext<Session, Request, Transport, Mode, Health>,
+  ): Promise<{ keepBrowserTab: boolean } | void>;
+  validateLaunchResult?(result: MeetingRuntimeLaunchResult<Health>): void;
+};
+
+type MeetingRuntimeMessages<Health extends MeetingBrowserHealth> = {
+  browserReadinessFailed?(error: string): string;
+  durableTranscripts: { providerId: string; providerName: string };
+  joined: {
+    local: string;
+    node: string;
+    transcribe: string;
+    waiting: string;
+  };
+  leaveFailed(error: string): string;
+  noTrackedTab: string;
+  sessionRuntime: MeetingSessionRuntimeMessages<MeetingRuntimeSpeechBlockedReason<Health>>;
+  sharedTab: string;
+};
+
+type MeetingRuntimeProbeContext<
+  Config extends MeetingPluginConfig & { defaultMode: Mode },
+  Transport extends "chrome" | "chrome-node",
+  Mode extends string,
+  Health extends MeetingPluginChromeHealth<string, string>,
+> = MeetingProbeContext<
+  Config,
+  Mode,
+  Transport,
+  Health,
+  MeetingRuntimeSession<Transport, Mode, Health>,
+  MeetingRuntimeRequest<Transport, Mode>
+>;
+
+export type MeetingRuntimeFacadeOptions<
+  Config extends MeetingPluginConfig & { defaultMode: Mode },
+  Transport extends "chrome" | "chrome-node",
+  Mode extends string,
+  Health extends MeetingPluginChromeHealth<string, string>,
+  Results extends MeetingRuntimeProbeResults,
+> = {
+  hooks?: MeetingRuntimeHooks<
+    MeetingRuntimeSession<Transport, Mode, Health>,
+    MeetingRuntimeRequest<Transport, Mode>,
+    Transport,
+    Mode,
+    Health
+  >;
+  messages: MeetingRuntimeMessages<Health>;
+  platform: MeetingRuntimePlatform<Mode, Health>;
+  probes: {
+    setupStatus(
+      params: MeetingRuntimeParams<Config> & {
+        options?: { mode?: Mode; transport?: Transport };
+      },
+    ): Promise<Results["setup"]>;
+    testListening(
+      context: MeetingRuntimeProbeContext<Config, Transport, Mode, Health>,
+      request: MeetingRuntimeRequest<Transport, Mode>,
+    ): Promise<Results["listening"]>;
+    testSpeech(
+      context: MeetingRuntimeProbeContext<Config, Transport, Mode, Health>,
+      request: MeetingRuntimeRequest<Transport, Mode>,
+    ): Promise<Results["speech"]>;
+  };
+  transport: MeetingRuntimeTransport<Config, Mode, Health>;
+};

--- a/src/meeting-bot/runtime-facade-types.ts
+++ b/src/meeting-bot/runtime-facade-types.ts
@@ -2,9 +2,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginRuntime, RuntimeLogger } from "../plugins/runtime/types.js";
 import type {
   MeetingBrowserJoinSession,
+  MeetingPlatformAdapter,
   MeetingPlatformRuntimeMetadata,
 } from "./platform-adapter-contract.js";
-import type { MeetingPlatformAdapter } from "./platform-adapter.js";
 import type { MeetingPluginConfig } from "./plugin-config.js";
 import type { MeetingProbeContext } from "./runtime-probes.js";
 import type {

--- a/src/meeting-bot/runtime-facade.ts
+++ b/src/meeting-bot/runtime-facade.ts
@@ -1,0 +1,519 @@
+import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import type {
+  TranscriptStartRequest,
+  TranscriptStopRequest,
+} from "../transcripts/provider-types.js";
+import { isMeetingRealtimeRouteReady } from "./meeting-modes.js";
+import type { MeetingPluginConfig } from "./plugin-config.js";
+import type {
+  MeetingRuntimeAudioBridge,
+  MeetingRuntimeFacadeConstructor,
+  MeetingRuntimeFacadeOptions,
+  MeetingRuntimeHookContext,
+  MeetingRuntimeOwner,
+  MeetingRuntimeParams,
+  MeetingRuntimeProbeResults,
+  MeetingRuntimeRequest,
+  MeetingRuntimeSession,
+  MeetingRuntimeSpeechBlockedReason,
+} from "./runtime-facade-types.js";
+import type { MeetingProbeContext } from "./runtime-probes.js";
+import { createMeetingSession } from "./session-factory.js";
+import {
+  MeetingSessionRuntime,
+  type MeetingSessionRuntimeHandles,
+  type MeetingSessionRuntimeJoinContext,
+} from "./session-runtime.js";
+import type { MeetingBrowserTab, MeetingPluginChromeHealth } from "./session-types.js";
+
+const nowIso = () => new Date().toISOString();
+
+export function createMeetingRuntimeFacade<
+  Config extends MeetingPluginConfig & { defaultMode: Mode },
+  Transport extends "chrome" | "chrome-node",
+  Mode extends string,
+  Health extends MeetingPluginChromeHealth<string, string>,
+  Results extends MeetingRuntimeProbeResults,
+>(
+  options: MeetingRuntimeFacadeOptions<Config, Transport, Mode, Health, Results>,
+): MeetingRuntimeFacadeConstructor<Config, Transport, Mode, Health, Results> {
+  type Session = MeetingRuntimeSession<Transport, Mode, Health>;
+  type Request = MeetingRuntimeRequest<Transport, Mode>;
+  type SessionRuntime = MeetingRuntimeOwner<Transport, Mode, Health>;
+  type JoinContext = MeetingSessionRuntimeJoinContext<
+    Session,
+    Transport,
+    Mode,
+    Health,
+    MeetingBrowserTab
+  >;
+
+  return class MeetingRuntimeFacade {
+    readonly #defaultAgentId: string;
+    readonly #sessions: SessionRuntime;
+    readonly #requesterSessionKeys = new Map<string, string>();
+
+    constructor(private readonly params: MeetingRuntimeParams<Config>) {
+      this.#defaultAgentId = normalizeAgentId(
+        params.config.realtime.agentId ?? resolveDefaultAgentId(params.fullConfig),
+      );
+      this.#sessions = new MeetingSessionRuntime({
+        logger: params.logger,
+        logScope: options.platform.logScope,
+        formatError: formatErrorMessage,
+        reuseExistingBrowserTab: params.config.chrome.reuseExistingTab,
+        waitForInCallMs: params.config.chrome.waitForInCallMs,
+        joinTimeoutMs: params.config.chrome.joinTimeoutMs,
+        defaultSpeechInstructions: params.config.realtime.introMessage,
+        transientSpeechBlockedReasons: new Set<MeetingRuntimeSpeechBlockedReason<Health>>([
+          "not-in-call",
+          "browser-unverified",
+          options.messages.sessionRuntime.speech.microphoneMutedReason,
+        ] as MeetingRuntimeSpeechBlockedReason<Health>[]),
+        messages: options.messages.sessionRuntime,
+        resolveJoin: (request) => this.#resolveJoin(request),
+        createSession: ({ request, resolved, createdAt }) => {
+          const session = createMeetingSession({
+            platform: options.platform,
+            config: params.config,
+            resolved,
+            createdAt,
+          }) as Session;
+          if (request.requesterSessionKey) {
+            this.#requesterSessionKeys.set(session.id, request.requesterSessionKey);
+          }
+          return session;
+        },
+        resolveSpeechInstructions: (request) =>
+          request.message ?? params.config.realtime.introMessage,
+        isBrowserTransport: () => true,
+        isTalkBackMode: (mode) => mode === "agent" || mode === "bidi",
+        isTranscribeMode: (mode) => mode === "transcribe",
+        sameMeetingUrl: (left, right) => options.platform.urls.isSameMeeting(left, right),
+        normalizeMeetingUrlForReuse: (url) => options.platform.urls.normalizeForReuse(url),
+        getBrowser: (session) =>
+          session.chrome
+            ? {
+                launched: session.chrome.launched,
+                nodeId: session.chrome.nodeId,
+                tab: session.chrome.browserTab,
+                health: session.chrome.health,
+                hasAudioBridge:
+                  options.hooks?.isAudioBridgeActive?.(session) ??
+                  Boolean(session.chrome.audioBridge),
+              }
+            : undefined,
+        setBrowserTab: (session, tab) => {
+          if (session.chrome) {
+            session.chrome.browserTab = tab;
+          }
+        },
+        setBrowserHealth: (session, health) => {
+          if (session.chrome) {
+            session.chrome.health = health;
+          }
+        },
+        joinTransport: async ({ request, session, context }) =>
+          await this.#joinTransport(request, session, context),
+        releaseBrowserTab: async (session) => await this.#releaseBrowserTab(session),
+        refreshBrowserHealth: async (session, refreshOptions) =>
+          await this.#refreshBrowserHealth(session, refreshOptions),
+        refreshStatus: async (session) => await this.#refreshStatus(session),
+        refreshReusableSession: async (session, request) =>
+          await options.hooks?.refreshReusableSession?.(session, request, this.#hookContext()),
+        ensureRealtimeBridge: async (session) => await this.#ensureRealtimeBridge(session),
+        captureTranscript: async (session, captureOptions) =>
+          await this.#captureTranscript(session, captureOptions),
+        speakViaTransport: async () => undefined,
+        durableTranscripts: {
+          config: params.fullConfig.transcripts,
+          ...options.messages.durableTranscripts,
+        },
+      });
+    }
+
+    list(): Session[] {
+      return this.#sessions.list();
+    }
+
+    async startTranscriptSource(request: TranscriptStartRequest) {
+      return await this.#sessions.startTranscriptSource(request);
+    }
+
+    async stopTranscriptSource(request: TranscriptStopRequest) {
+      return await this.#sessions.stopTranscriptSource(request);
+    }
+
+    ownsSession(agentId: string, sessionId: string): boolean {
+      return this.list().some((session) => session.id === sessionId && session.agentId === agentId);
+    }
+
+    async join(request: Request) {
+      try {
+        return await this.#sessions.join(
+          options.hooks?.normalizeJoinRequest?.(request, this.#hookContext()) ?? request,
+        );
+      } catch (error) {
+        const activeIds = new Set(this.list().map((session) => session.id));
+        for (const sessionId of this.#requesterSessionKeys.keys()) {
+          if (!activeIds.has(sessionId)) {
+            this.#requesterSessionKeys.delete(sessionId);
+          }
+        }
+        throw error;
+      }
+    }
+
+    async leave(sessionId: string) {
+      try {
+        return await this.#sessions.leave(sessionId);
+      } finally {
+        this.#requesterSessionKeys.delete(sessionId);
+      }
+    }
+
+    async status(sessionId?: string) {
+      return await this.#sessions.status(sessionId);
+    }
+
+    async statusForAgent(agentId: string, sessionId?: string) {
+      if (sessionId) {
+        return this.ownsSession(agentId, sessionId)
+          ? await this.#sessions.status(sessionId)
+          : { found: false };
+      }
+      const sessions = this.list().filter((session) => session.agentId === agentId);
+      await Promise.all(sessions.map((session) => this.#sessions.status(session.id)));
+      return { found: true, sessions };
+    }
+
+    async transcript(sessionId: string, transcriptOptions: { sinceIndex?: number } = {}) {
+      return await this.#sessions.transcript(sessionId, transcriptOptions);
+    }
+
+    async speak(sessionId: string, instructions?: string) {
+      return await this.#sessions.speak(sessionId, instructions);
+    }
+
+    async setupStatus(setupOptions?: { mode?: Mode; transport?: Transport }) {
+      return await options.probes.setupStatus({ ...this.params, options: setupOptions });
+    }
+
+    async testSpeech(request: Request) {
+      return await options.probes.testSpeech(this.#probeContext(), request);
+    }
+
+    async testListen(request: Request) {
+      return await options.probes.testListening(this.#probeContext(), request);
+    }
+
+    #resolveJoin(request: Request) {
+      return {
+        url: options.platform.urls.validateAndNormalize(request.url),
+        transport:
+          request.transport ??
+          ((this.params.config.chromeNode.node ? "chrome-node" : "chrome") as Transport),
+        mode: request.mode ?? (this.params.config.defaultMode as Mode),
+        agentId: normalizeAgentId(request.agentId ?? this.#defaultAgentId),
+      };
+    }
+
+    #hookContext(): MeetingRuntimeHookContext<Session, Request, Transport, Mode, Health> {
+      return {
+        deleteRequesterSessionKey: (sessionId) => this.#requesterSessionKeys.delete(sessionId),
+        endSession: async (sessionId, leaveOptions) => {
+          await this.#sessions.leave(sessionId, leaveOptions);
+          this.#requesterSessionKeys.delete(sessionId);
+        },
+        noteSession: (session, note) => this.#noteSession(session, note),
+        refreshBrowserHealth: async (session, refreshOptions) =>
+          await this.#sessions.refreshBrowserHealth(session, refreshOptions),
+        resolvedJoin: (request) => this.#resolveJoin(request),
+      };
+    }
+
+    #probeContext(): MeetingProbeContext<Config, Mode, Transport, Health, Session, Request> {
+      return {
+        config: this.params.config,
+        resolveAgentId: (request) => normalizeAgentId(request.agentId ?? this.#defaultAgentId),
+        list: () => this.list(),
+        join: async (request) => await this.join(request),
+        isReusable: (session, resolved) => this.#sessions.isReusableSession(session, resolved),
+        hasHealthHandle: (sessionId) => this.#sessions.hasHealthHandle(sessionId),
+        refreshHealth: (sessionId) => this.#sessions.refreshHealth(sessionId),
+        refreshCaptionHealth: async (session, timeoutMs) =>
+          await this.#refreshBrowserHealth(session, { timeoutMs }),
+      };
+    }
+
+    async #joinTransport(request: Request, session: Session, context: JoinContext) {
+      const config = this.#withSessionAgentConfig(session.agentId);
+      const launchParams = {
+        runtime: this.params.runtime,
+        config,
+        fullConfig: this.params.fullConfig,
+        meetingSessionId: session.id,
+        requesterSessionKey: request.requesterSessionKey,
+        mode: session.mode,
+        url: session.url,
+        logger: this.params.logger,
+      };
+      const result =
+        session.transport === "chrome-node"
+          ? await options.transport.launchOnNode(launchParams)
+          : await options.transport.launchInChrome(launchParams);
+      const nodeId = result.nodeId;
+      const tab = context.inheritedBrowserTab({
+        session,
+        transport: session.transport,
+        nodeId,
+        meetingUrl: session.url,
+        tab: result.tab,
+      });
+      session.chrome = {
+        audioBackend: "blackhole-2ch",
+        launched: result.launched,
+        nodeId,
+        browserProfile: this.params.config.chrome.browserProfile,
+        browserTab: tab,
+        health: result.browser,
+      };
+      options.hooks?.validateLaunchResult?.(result);
+      const handles = this.#attachAudioBridge(session, result.audioBridge);
+      if (handles) {
+        context.attachRuntimeHandles(session, handles);
+      }
+      session.notes.push(
+        result.audioBridge
+          ? session.transport === "chrome-node"
+            ? options.messages.joined.node
+            : options.messages.joined.local
+          : session.mode === "transcribe"
+            ? options.messages.joined.transcribe
+            : options.messages.joined.waiting,
+      );
+      this.#sessions.refreshSpeechReadiness(session);
+      return {};
+    }
+
+    #attachAudioBridge(
+      session: Session,
+      audioBridge: MeetingRuntimeAudioBridge<Health> | undefined,
+    ): MeetingSessionRuntimeHandles<Health> | undefined {
+      if (!session.chrome || !audioBridge) {
+        return undefined;
+      }
+      session.chrome.audioBridge = {
+        type: audioBridge.type,
+        provider: audioBridge.providerId,
+      };
+      options.hooks?.afterAudioBridgeAttached?.(session);
+      return {
+        stop: audioBridge.stop,
+        speak: audioBridge.speak,
+        getHealth: audioBridge.getHealth,
+      };
+    }
+
+    async #ensureRealtimeBridge(
+      session: Session,
+    ): Promise<MeetingSessionRuntimeHandles<Health> | undefined> {
+      const audioBridgeActive =
+        options.hooks?.isAudioBridgeActive?.(session) ?? Boolean(session.chrome?.audioBridge);
+      if (
+        (session.mode !== "agent" && session.mode !== "bidi") ||
+        session.state !== "active" ||
+        !session.chrome ||
+        audioBridgeActive ||
+        !isMeetingRealtimeRouteReady(session.mode, session.chrome.health)
+      ) {
+        return undefined;
+      }
+      if (session.chrome.audioBridge) {
+        session.chrome.audioBridge = undefined;
+      }
+      const config = this.#withSessionAgentConfig(session.agentId);
+      const recoveryConfig = {
+        ...config,
+        chrome: { ...config.chrome, launch: false },
+        chromeNode: { node: session.chrome.nodeId ?? config.chromeNode.node },
+      };
+      const launchParams = {
+        runtime: this.params.runtime,
+        config: recoveryConfig,
+        fullConfig: this.params.fullConfig,
+        meetingSessionId: session.id,
+        requesterSessionKey: this.#requesterSessionKeys.get(session.id),
+        mode: session.mode,
+        trackedTargetId: session.chrome.browserTab?.targetId,
+        url: session.url,
+        logger: this.params.logger,
+      };
+      const result =
+        session.transport === "chrome-node"
+          ? await options.transport.launchOnNode(launchParams)
+          : await options.transport.launchInChrome(launchParams);
+      if (result.tab) {
+        const currentTab = session.chrome.browserTab;
+        session.chrome.browserTab = {
+          ...result.tab,
+          openedByPlugin:
+            result.tab.targetId === currentTab?.targetId
+              ? currentTab.openedByPlugin
+              : result.tab.openedByPlugin,
+        };
+      }
+      if (result.browser) {
+        session.chrome.health = { ...session.chrome.health, ...result.browser };
+      }
+      session.updatedAt = nowIso();
+      return this.#attachAudioBridge(session, result.audioBridge);
+    }
+
+    async #refreshStatus(session: Session): Promise<void> {
+      await this.#sessions.refreshBrowserHealth(session, {
+        force: true,
+        readOnly: !(options.hooks?.isAwaitingAdmission?.(session) ?? false),
+      });
+      await options.hooks?.afterStatusRefresh?.(session, this.#hookContext());
+    }
+
+    async #refreshBrowserHealth(
+      session: Session,
+      refreshOptions: { readOnly?: boolean; timeoutMs?: number } = {},
+    ): Promise<void> {
+      try {
+        const result = await options.transport.recoverCurrentTab({
+          runtime: this.params.runtime,
+          config: this.params.config,
+          fullConfig: this.params.fullConfig,
+          meetingSessionId: session.id,
+          mode: session.mode,
+          nodeId: session.chrome?.nodeId,
+          readOnly: refreshOptions.readOnly,
+          trackedMeetingUrl: session.url,
+          trackedTargetId: session.chrome?.browserTab?.targetId,
+          transport: session.transport,
+          timeoutMs: refreshOptions.timeoutMs,
+          url: session.url,
+        });
+        if (result.found && session.chrome) {
+          if (result.tab?.targetId) {
+            const currentTab = session.chrome.browserTab;
+            session.chrome.browserTab = {
+              targetId: result.tab.targetId,
+              openedByPlugin:
+                result.tab.targetId === currentTab?.targetId ? currentTab.openedByPlugin : false,
+            };
+          }
+          if (result.browser) {
+            session.chrome.health = { ...session.chrome.health, ...result.browser };
+          }
+          session.updatedAt = nowIso();
+        } else if (session.chrome) {
+          options.hooks?.recordBrowserRecoveryFailure?.(session, {
+            kind: "missing",
+            message: result.message,
+          });
+        }
+      } catch (error) {
+        const formattedError = formatErrorMessage(error);
+        const message = options.messages.browserReadinessFailed?.(formattedError) ?? formattedError;
+        if (options.hooks?.recordBrowserRecoveryFailure) {
+          this.params.logger.debug?.(`${options.platform.logScope} ${message}`);
+          options.hooks.recordBrowserRecoveryFailure(session, { kind: "error", message });
+        } else {
+          this.params.logger.debug?.(
+            `${options.platform.logScope} browser readiness refresh ignored: ${formatErrorMessage(error)}`,
+          );
+        }
+      }
+    }
+
+    async #captureTranscript(session: Session, captureOptions: { finalize?: boolean } = {}) {
+      // Recovery permits caption setup but atomically refuses a different live
+      // session owner, so stale sessions read their archived page buffer instead.
+      await this.#sessions.refreshCaptionHealth(session);
+      const tab = session.chrome?.browserTab;
+      if (!tab) {
+        return undefined;
+      }
+      return await options.transport.readTranscript({
+        runtime: this.params.runtime,
+        config: this.params.config,
+        finalize: captureOptions.finalize,
+        meetingUrl: session.url,
+        meetingSessionId: session.id,
+        nodeId: session.chrome?.nodeId,
+        tab,
+      });
+    }
+
+    async #releaseBrowserTab(session: Session): Promise<boolean | undefined> {
+      const tab = session.chrome?.browserTab;
+      if (!tab) {
+        this.#noteSession(session, options.messages.noTrackedTab);
+        session.browserLeft = false;
+        return false;
+      }
+      const shared = this.list().some(
+        (other) =>
+          other.id !== session.id &&
+          other.state === "active" &&
+          other.chrome?.browserTab?.targetId === tab.targetId &&
+          other.chrome?.nodeId === session.chrome?.nodeId,
+      );
+      if (shared) {
+        this.#noteSession(session, options.messages.sharedTab);
+        return undefined;
+      }
+      try {
+        const result = await options.transport.leaveInBrowser({
+          runtime: this.params.runtime,
+          config: this.params.config,
+          meetingSessionId: session.id,
+          meetingUrl: session.url,
+          nodeId: session.chrome?.nodeId,
+          tab,
+        });
+        this.#noteSession(session, result.note);
+        if (result.left && session.chrome) {
+          session.chrome.browserTab = undefined;
+          if (session.chrome.health) {
+            session.chrome.health = {
+              ...session.chrome.health,
+              captioning: false,
+              audioInputRouted: false,
+              audioOutputRouted: false,
+              providerConnected: false,
+              realtimeReady: false,
+              audioInputActive: false,
+              audioOutputActive: false,
+            };
+          }
+        }
+        session.browserLeft = result.left;
+        return result.left;
+      } catch (error) {
+        this.#noteSession(session, options.messages.leaveFailed(formatErrorMessage(error)));
+        session.browserLeft = false;
+        return false;
+      }
+    }
+
+    #withSessionAgentConfig(agentId: string): Config {
+      return this.params.config.realtime.agentId === agentId
+        ? this.params.config
+        : {
+            ...this.params.config,
+            realtime: { ...this.params.config.realtime, agentId },
+          };
+    }
+
+    #noteSession(session: Session, note: string): void {
+      session.notes = [...session.notes.filter((item) => item !== note), note];
+    }
+  };
+}

--- a/src/meeting-bot/runtime-setup.ts
+++ b/src/meeting-bot/runtime-setup.ts
@@ -1,0 +1,158 @@
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import type { PluginRuntime } from "../plugins/runtime/types.js";
+import { resolveMeetingBrowserNodeInfo } from "./browser-node.js";
+import { isMeetingTalkBackMode } from "./meeting-modes.js";
+import type { MeetingPluginConfig } from "./plugin-config.js";
+import { addMeetingSetupCheck, createMeetingSetupStatus } from "./setup-checks.js";
+
+type MeetingSetupNodeAdapter = {
+  displayName: string;
+  nodeCommandName: string;
+  nodeConfigPath: string;
+};
+
+type MeetingRuntimeSetupOptions<Config extends MeetingPluginConfig, Mode extends string> = {
+  assertAudioDeviceAvailable(params: { runtime: PluginRuntime; timeoutMs: number }): Promise<void>;
+  captionsMessage(mode: Mode): string;
+  connectedNodeMessage(nodeLabel: string | undefined): string;
+  guestJoinCheck(config: Config): { message: string; ok: boolean };
+  missingNodeIdMessage: string;
+  nodeAdapter: MeetingSetupNodeAdapter;
+};
+
+async function commandExists(runtime: PluginRuntime, command: string): Promise<boolean> {
+  const result = await runtime.system.runCommandWithTimeout(
+    ["/bin/sh", "-lc", 'command -v "$1" >/dev/null 2>&1', "sh", command],
+    { timeoutMs: 5_000 },
+  );
+  return result.code === 0;
+}
+
+export function createMeetingRuntimeSetup<Config extends MeetingPluginConfig, Mode extends string>(
+  options: MeetingRuntimeSetupOptions<Config, Mode>,
+) {
+  return async (params: {
+    config: Config;
+    fullConfig: OpenClawConfig;
+    runtime: PluginRuntime;
+    options?: { mode?: Mode; transport?: "chrome" | "chrome-node" };
+  }) => {
+    const mode = params.options?.mode ?? (params.config.defaultMode as Mode);
+    const transport =
+      params.options?.transport ?? (params.config.chromeNode.node ? "chrome-node" : "chrome");
+    const talkBack = isMeetingTalkBackMode(mode);
+    const guestJoin = options.guestJoinCheck(params.config);
+    let status = createMeetingSetupStatus([
+      {
+        id: "chrome-profile",
+        ok: true,
+        message: params.config.chrome.browserProfile
+          ? `Chrome node profile configured: ${params.config.chrome.browserProfile}`
+          : "Local Chrome uses the configured OpenClaw browser profile",
+      },
+      { id: "guest-join", ...guestJoin },
+      { id: "captions", ok: true, message: options.captionsMessage(mode) },
+    ]);
+
+    if (transport === "chrome-node") {
+      try {
+        const node = await resolveMeetingBrowserNodeInfo({
+          runtime: params.runtime,
+          requestedNode: params.config.chromeNode.node,
+          adapter: options.nodeAdapter,
+        });
+        status = addMeetingSetupCheck(status, {
+          id: "chrome-node-connected",
+          ok: true,
+          message: options.connectedNodeMessage(node.displayName ?? node.remoteIp ?? node.nodeId),
+        });
+        if (talkBack) {
+          if (!node.nodeId) {
+            throw new Error(options.missingNodeIdMessage);
+          }
+          await params.runtime.nodes.invoke({
+            nodeId: node.nodeId,
+            command: options.nodeAdapter.nodeCommandName,
+            params: {
+              action: "setup",
+              audioInputCommand: params.config.chrome.audioInputCommand,
+              audioOutputCommand: params.config.chrome.audioOutputCommand,
+              ...(params.config.chrome.bargeInInputCommand
+                ? { bargeInInputCommand: params.config.chrome.bargeInInputCommand }
+                : {}),
+            },
+            timeoutMs: 12_000,
+          });
+          status = addMeetingSetupCheck(status, {
+            id: "chrome-node-audio-prerequisites",
+            ok: true,
+            message: "Remote macOS, BlackHole 2ch, and SoX prerequisites are ready",
+          });
+        }
+      } catch (error) {
+        const connected = status.checks.some(
+          (check) => check.id === "chrome-node-connected" && check.ok,
+        );
+        status = addMeetingSetupCheck(status, {
+          id: connected ? "chrome-node-audio-prerequisites" : "chrome-node-connected",
+          ok: false,
+          message: formatErrorMessage(error),
+        });
+      }
+    }
+
+    if (!talkBack) {
+      return status;
+    }
+    status = addMeetingSetupCheck(status, {
+      id: "audio-bridge",
+      ok:
+        params.config.chrome.audioInputCommand.length > 0 &&
+        params.config.chrome.audioOutputCommand.length > 0,
+      message: `SoX command-pair audio bridge configured (${params.config.chrome.audioFormat})`,
+    });
+    if (transport === "chrome-node") {
+      return status;
+    }
+    try {
+      await options.assertAudioDeviceAvailable({
+        runtime: params.runtime,
+        timeoutMs: Math.min(params.config.chrome.joinTimeoutMs, 10_000),
+      });
+      status = addMeetingSetupCheck(status, {
+        id: "chrome-local-audio-device",
+        ok: true,
+        message: "BlackHole 2ch audio device found",
+      });
+    } catch (error) {
+      status = addMeetingSetupCheck(status, {
+        id: "chrome-local-audio-device",
+        ok: false,
+        message: formatErrorMessage(error),
+      });
+    }
+    const commands = uniqueStrings(
+      [
+        params.config.chrome.audioInputCommand[0],
+        params.config.chrome.audioOutputCommand[0],
+        params.config.chrome.bargeInInputCommand?.[0],
+      ].filter((value): value is string => Boolean(value?.trim())),
+    );
+    const missing: string[] = [];
+    for (const command of commands) {
+      if (!(await commandExists(params.runtime, command).catch(() => false))) {
+        missing.push(command);
+      }
+    }
+    return addMeetingSetupCheck(status, {
+      id: "chrome-local-audio-commands",
+      ok: missing.length === 0,
+      message:
+        missing.length === 0
+          ? "Configured Chrome audio commands are available"
+          : `Chrome audio commands missing: ${missing.join(", ")}`,
+    });
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

The Teams and Zoom meeting plugins still carried parallel runtime facade and setup implementations after #115707 consolidated their plugin shells. The duplicated lifecycle code made admission, session reuse, browser recovery, realtime bridge recovery, transcript capture, and setup checks easy to drift.

## Why This Change Was Made

This moves the shared lifecycle into `createMeetingRuntimeFacade` and the shared prerequisite checks into `createMeetingRuntimeSetup`, both exposed through the existing `openclaw/plugin-sdk/meeting-runtime` facade. Teams now supplies only transport operations and platform wording. Zoom keeps its behavioral differences as named hooks, including stateful admission refresh, normalized join requests, credential-aware stale-session replacement, terminal status cleanup, browser-recovery state, and closed-bridge recovery.

The extraction preserves the existing owner boundary: `MeetingSessionRuntime` still owns canonical session lifecycle, the platform adapters still own vendor URL/browser contracts, and the plugin modules still own vendor-specific behavior and messages.

## User Impact

No intended behavior change. Teams and Zoom meeting bots retain their existing join, admission, session reuse, status, transcript, speech, browser recovery, and setup behavior with one shared runtime facade. Google Meet remains untouched.

## Evidence

- LOC: production `+1242/-1492` (net `-250`); tests `+4/-10` (net `-6`).
- `node scripts/run-vitest.mjs extensions/teams-meetings extensions/zoom-meetings src/meeting-bot extensions/google-meet` — 64 files passed, 659 tests passed.
- `node scripts/check-changed.mjs -- <14 changed files>` — formatting, SDK API baseline, plugin boundaries, dependency pins, dead exports, core/core-test/extension/extension-test typechecks passed during the hosted runs; findings from intermediate runs (stale exports, declaration shape, max-lines split, and contextual typing) were fixed before push. Exact-head PR CI remains the authoritative broad gate.
- `$AUTOREVIEW --mode uncommitted --stream-engine-output` — accepted findings for Zoom-only status ownership and concrete probe result types were fixed; the repeated stale-tab finding was rejected because `extensions/zoom-meetings/src/runtime.ts:112` explicitly clears `session.chrome.browserTab` in the missing branch.
- Shared facade: `src/meeting-bot/runtime-facade.ts:33`; shared setup: `src/meeting-bot/runtime-setup.ts:33`.
- Thin platform entry points: `extensions/teams-meetings/src/runtime.ts:15`, `extensions/zoom-meetings/src/runtime.ts:16`.
- Zoom behavior hooks: `extensions/zoom-meetings/src/runtime.ts:47` and `extensions/zoom-meetings/src/runtime.ts:61`.
