### PR TITLE
refactor(openai): make realtime voice lifecycle explicit

### DIFF
--- a/extensions/openai/realtime-quicksilver-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.test.ts
@@ -16,6 +16,7 @@ class FakeSocket extends EventEmitter {
   open(): void {
     this.readyState = 1;
     this.emit("open");
+    this.afterOpen?.(this);
   }
 
   send(payload: string): void {
@@ -54,7 +55,10 @@ class FakeSocket extends EventEmitter {
     this.emit("message", Buffer.from(JSON.stringify(event)), false);
   }
 
-  constructor(private readonly autoStart = true) {
+  constructor(
+    private readonly autoStart = true,
+    private readonly afterOpen?: (socket: FakeSocket) => void,
+  ) {
     super();
   }
 }
@@ -63,9 +67,10 @@ function createHarness(params?: {
   audioFormat?: "pcm16" | "g711_ulaw";
   autoStart?: boolean;
   deferClose?: boolean;
+  afterOpen?: (socket: FakeSocket) => void;
   resolveAuth?: () => Promise<{ type: "api-key"; token: string }>;
 }) {
-  const socket = new FakeSocket(params?.autoStart);
+  const socket = new FakeSocket(params?.autoStart, params?.afterOpen);
   socket.deferClose = params?.deferClose ?? false;
   const connections: Array<{ url: string; options: ClientOptions }> = [];
   const webSocketFactory: OpenAIQuicksilverSocketFactory = (url, options) => {
@@ -164,6 +169,22 @@ describe("OpenAIQuicksilverVoiceBridge", () => {
     expect(harness.onClose).toHaveBeenCalledOnce();
   });
 
+  it("shares an in-flight connection until session readiness", async () => {
+    const harness = createHarness({ autoStart: false });
+    const firstConnect = harness.bridge.connect();
+    const secondConnect = harness.bridge.connect();
+    await vi.waitFor(() => expect(harness.socket.readyState).toBe(1));
+
+    expect(harness.connections).toHaveLength(1);
+    harness.socket.serverEvent({
+      type: "session.started",
+      session: { id: "live-1", expires_at: Math.floor(Date.now() / 1000) + 60 },
+    });
+
+    await Promise.all([firstConnect, secondConnect]);
+    expect(harness.onReady).toHaveBeenCalledOnce();
+  });
+
   it("rejects startup failures without emitting terminal callbacks", async () => {
     const harness = createHarness({ autoStart: false });
     const connecting = harness.bridge.connect();
@@ -178,6 +199,21 @@ describe("OpenAIQuicksilverVoiceBridge", () => {
     expect(harness.onError).not.toHaveBeenCalled();
     expect(harness.onClose).not.toHaveBeenCalled();
     expect(harness.bridge.isConnected()).toBe(false);
+  });
+
+  it("does not reject after explicit close while awaiting session readiness", async () => {
+    const harness = createHarness({ autoStart: false, deferClose: true });
+    const connecting = harness.bridge.connect();
+    await vi.waitFor(() => expect(harness.socket.readyState).toBe(1));
+
+    harness.bridge.close();
+    harness.socket.emit("error", new Error("late startup error"));
+
+    await expect(connecting).resolves.toBeUndefined();
+    expect(harness.onClose).toHaveBeenCalledOnce();
+    expect(harness.onClose).toHaveBeenCalledWith("completed");
+    expect(harness.onError).not.toHaveBeenCalled();
+    harness.socket.finishClose();
   });
 
   it("completes once when closed while authentication is pending", async () => {
@@ -199,6 +235,29 @@ describe("OpenAIQuicksilverVoiceBridge", () => {
     await expect(connecting).resolves.toBeUndefined();
     expect(harness.connections).toHaveLength(0);
     expect(harness.onError).not.toHaveBeenCalled();
+  });
+
+  it("reports a buffered terminal event that follows session readiness", async () => {
+    const harness = createHarness({
+      autoStart: false,
+      afterOpen: (socket) => {
+        socket.serverEvent({
+          type: "session.started",
+          session: { id: "live-1", expires_at: Math.floor(Date.now() / 1000) + 60 },
+        });
+        socket.finishClose();
+      },
+    });
+
+    await harness.bridge.connect();
+
+    expect(harness.onReady).toHaveBeenCalledOnce();
+    expect(harness.onError).toHaveBeenCalledWith(
+      new Error("GPT-Live WebSocket closed during startup"),
+    );
+    expect(harness.onClose).toHaveBeenCalledOnce();
+    expect(harness.onClose).toHaveBeenCalledWith("error");
+    expect(harness.bridge.isConnected()).toBe(false);
   });
 
   it("maps audio, transcripts, and delegations onto the shared bridge contract", async () => {

--- a/extensions/openai/realtime-quicksilver-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.test.ts
@@ -10,6 +10,8 @@ import type {
 class FakeSocket extends EventEmitter {
   readyState = 0;
   readonly sent: string[] = [];
+  closeCalls = 0;
+  deferClose = false;
 
   open(): void {
     this.readyState = 1;
@@ -19,7 +21,7 @@ class FakeSocket extends EventEmitter {
   send(payload: string): void {
     this.sent.push(payload);
     const event = JSON.parse(payload) as { type?: string };
-    if (event.type === "session.update") {
+    if (event.type === "session.update" && this.autoStart) {
       queueMicrotask(() =>
         this.serverEvent({
           type: "session.started",
@@ -33,6 +35,17 @@ class FakeSocket extends EventEmitter {
     if (this.readyState === 3) {
       return;
     }
+    this.closeCalls += 1;
+    if (this.deferClose) {
+      return;
+    }
+    this.finishClose();
+  }
+
+  finishClose(): void {
+    if (this.readyState === 3) {
+      return;
+    }
     this.readyState = 3;
     queueMicrotask(() => this.emit("close"));
   }
@@ -40,10 +53,20 @@ class FakeSocket extends EventEmitter {
   serverEvent(event: unknown): void {
     this.emit("message", Buffer.from(JSON.stringify(event)), false);
   }
+
+  constructor(private readonly autoStart = true) {
+    super();
+  }
 }
 
-function createHarness(params?: { audioFormat?: "pcm16" | "g711_ulaw" }) {
-  const socket = new FakeSocket();
+function createHarness(params?: {
+  audioFormat?: "pcm16" | "g711_ulaw";
+  autoStart?: boolean;
+  deferClose?: boolean;
+  resolveAuth?: () => Promise<{ type: "api-key"; token: string }>;
+}) {
+  const socket = new FakeSocket(params?.autoStart);
+  socket.deferClose = params?.deferClose ?? false;
   const connections: Array<{ url: string; options: ClientOptions }> = [];
   const webSocketFactory: OpenAIQuicksilverSocketFactory = (url, options) => {
     connections.push({ url, options });
@@ -66,7 +89,7 @@ function createHarness(params?: { audioFormat?: "pcm16" | "g711_ulaw" }) {
       params?.audioFormat === "g711_ulaw"
         ? { encoding: "g711_ulaw", sampleRateHz: 8000, channels: 1 }
         : { encoding: "pcm16", sampleRateHz: 24000, channels: 1 },
-    resolveAuth: async () => ({ type: "api-key", token: "test-key" }),
+    resolveAuth: params?.resolveAuth ?? (async () => ({ type: "api-key", token: "test-key" })),
     webSocketFactory,
     onAudio,
     onClearAudio: vi.fn(),
@@ -120,6 +143,62 @@ describe("OpenAIQuicksilverVoiceBridge", () => {
 
     harness.bridge.close();
     await vi.waitFor(() => expect(harness.onClose).toHaveBeenCalledWith("completed"));
+  });
+
+  it("keeps repeated close idempotent while the transport is still open", async () => {
+    const harness = createHarness({ deferClose: true });
+    await harness.bridge.connect();
+
+    harness.bridge.close();
+    harness.bridge.close();
+
+    expect(
+      sentEvents(harness.socket).filter((event) => event.type === "session.close"),
+    ).toHaveLength(1);
+    expect(harness.socket.closeCalls).toBe(1);
+    expect(harness.onClose).toHaveBeenCalledOnce();
+    expect(harness.onClose).toHaveBeenCalledWith("completed");
+
+    harness.socket.finishClose();
+    await Promise.resolve();
+    expect(harness.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("rejects startup failures without emitting terminal callbacks", async () => {
+    const harness = createHarness({ autoStart: false });
+    const connecting = harness.bridge.connect();
+    await vi.waitFor(() => expect(harness.socket.readyState).toBe(1));
+
+    harness.socket.serverEvent({
+      type: "error",
+      error: { message: "invalid live session" },
+    });
+
+    await expect(connecting).rejects.toThrow("invalid live session");
+    expect(harness.onError).not.toHaveBeenCalled();
+    expect(harness.onClose).not.toHaveBeenCalled();
+    expect(harness.bridge.isConnected()).toBe(false);
+  });
+
+  it("completes once when closed while authentication is pending", async () => {
+    let resolveAuth!: (auth: { type: "api-key"; token: string }) => void;
+    const harness = createHarness({
+      resolveAuth: () =>
+        new Promise((resolve) => {
+          resolveAuth = resolve;
+        }),
+    });
+    const connecting = harness.bridge.connect();
+
+    harness.bridge.close();
+    harness.bridge.close();
+    expect(harness.onClose).toHaveBeenCalledOnce();
+    expect(harness.onClose).toHaveBeenCalledWith("completed");
+
+    resolveAuth({ type: "api-key", token: "test-key" });
+    await expect(connecting).resolves.toBeUndefined();
+    expect(harness.connections).toHaveLength(0);
+    expect(harness.onError).not.toHaveBeenCalled();
   });
 
   it("maps audio, transcripts, and delegations onto the shared bridge contract", async () => {

--- a/extensions/openai/realtime-quicksilver-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.ts
@@ -30,6 +30,10 @@ import {
   type OpenAIQuicksilverInboundEvent,
   type OpenAIQuicksilverRequestIds,
 } from "./realtime-quicksilver-wire.js";
+import {
+  OpenAIRealtimeVoiceLifecycle,
+  type OpenAIRealtimeVoiceConnection,
+} from "./realtime-voice-lifecycle.js";
 
 const OPENAI_QUICKSILVER_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
 const OPENAI_QUICKSILVER_READY_TIMEOUT_MS = 15_000;
@@ -80,10 +84,8 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
   readonly handlesInputAudioBargeIn = false;
 
   private socket: OpenAIQuicksilverSocket | undefined;
-  private stopController = new AbortController();
-  private ready = false;
-  private intentionallyClosed = false;
-  private closeNotified = false;
+  private connection: OpenAIRealtimeVoiceConnection | undefined;
+  private readonly lifecycle = new OpenAIRealtimeVoiceLifecycle();
   private pendingAudio: Buffer[] = [];
   private activeDelegations = new Set<string>();
   private readonly flowId = randomUUID();
@@ -96,24 +98,41 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
   constructor(private readonly config: OpenAIQuicksilverVoiceBridgeConfig) {}
 
   async connect(): Promise<void> {
-    if (this.ready) {
+    if (this.lifecycle.isReady()) {
       return;
     }
-    this.intentionallyClosed = false;
-    this.closeNotified = false;
-    if (this.stopController.signal.aborted) {
-      this.stopController = new AbortController();
+    const connection = this.lifecycle.connect();
+    this.connection = connection;
+    let connected: Awaited<ReturnType<typeof connectOpenAIQuicksilverSideband>>;
+    try {
+      const auth = await this.config.resolveAuth();
+      if (!this.lifecycle.isCurrent(connection) || connection.signal.aborted) {
+        return;
+      }
+      const url = buildOpenAIQuicksilverWebSocketUrl(this.config.model);
+      const createSocket = this.config.webSocketFactory ?? this.createSocketFactory();
+      connected = await connectOpenAIQuicksilverSideband({
+        auth,
+        createSocket,
+        requestIds: this.requestIds,
+        signal: connection.signal,
+        url,
+      });
+    } catch (error) {
+      if (
+        !this.lifecycle.isCurrent(connection) ||
+        this.lifecycle.terminalOutcome(connection) === "completed"
+      ) {
+        return;
+      }
+      this.lifecycle.failure(connection);
+      throw error;
     }
-    const auth = await this.config.resolveAuth();
+    if (!this.lifecycle.isCurrent(connection) || connection.signal.aborted) {
+      this.closeSocket("stale connection", connected.socket);
+      return;
+    }
     const url = buildOpenAIQuicksilverWebSocketUrl(this.config.model);
-    const createSocket = this.config.webSocketFactory ?? this.createSocketFactory();
-    const connected = await connectOpenAIQuicksilverSideband({
-      auth,
-      createSocket,
-      requestIds: this.requestIds,
-      signal: this.stopController.signal,
-      url,
-    });
     this.socket = connected.socket;
     captureWsEvent({
       url,
@@ -123,33 +142,58 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
       meta: { provider: "openai", capability: "gpt-live-voice" },
     });
 
+    let reachedReady = false;
     let resolveReady!: () => void;
     let rejectReady!: (error: Error) => void;
+    let readySettled = false;
     const readyPromise = new Promise<void>((resolve, reject) => {
       resolveReady = resolve;
       rejectReady = reject;
     });
-    const readyTimeout = setTimeout(() => {
-      rejectReady(new Error("GPT-Live WebSocket did not emit session.started"));
-      this.closeSocket("session-start timeout");
-    }, OPENAI_QUICKSILVER_READY_TIMEOUT_MS);
-    readyTimeout.unref?.();
     const settleReady = () => {
+      if (readySettled) {
+        return;
+      }
+      readySettled = true;
+      reachedReady = true;
       clearTimeout(readyTimeout);
       resolveReady();
     };
     const failReady = (error: Error) => {
+      if (readySettled) {
+        return;
+      }
+      readySettled = true;
       clearTimeout(readyTimeout);
       rejectReady(error);
     };
+    const failStartup = (error: Error, reason: string) => {
+      if (!this.lifecycle.isCurrent(connection) || reachedReady) {
+        return;
+      }
+      this.lifecycle.failure(connection);
+      failReady(error);
+      this.closeSocket(reason, connected.socket);
+    };
+    const readyTimeout = setTimeout(() => {
+      failStartup(
+        new Error("GPT-Live WebSocket did not emit session.started"),
+        "session-start timeout",
+      );
+    }, OPENAI_QUICKSILVER_READY_TIMEOUT_MS);
+    readyTimeout.unref?.();
 
     connected.socket.on("message", (data: RawData, isBinary: boolean) => {
+      if (!this.lifecycle.isCurrent(connection) || this.socket !== connected.socket) {
+        return;
+      }
       if (isBinary) {
         const error = new Error("GPT-Live WebSocket returned an unexpected binary frame");
-        if (!this.ready) {
-          failReady(error);
+        if (!reachedReady) {
+          failStartup(error, "unexpected binary frame");
+        } else {
+          this.fail(connection, error);
         }
-        this.fail(error);
         return;
       }
       const payload = decodeTextFrame(data);
@@ -163,23 +207,37 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
       });
       const event = parseOpenAIQuicksilverEvent(payload);
       if (event) {
-        this.handleEvent(event, settleReady, failReady);
+        this.handleEvent(event, connection, settleReady, failStartup);
       }
     });
     connected.socket.on("error", (error: Error) => {
-      if (!this.ready) {
-        failReady(error);
+      if (!this.lifecycle.isCurrent(connection) || this.socket !== connected.socket) {
+        return;
       }
-      this.fail(error);
+      if (!reachedReady) {
+        failStartup(error, "startup error");
+      } else {
+        this.fail(connection, error);
+      }
     });
     connected.socket.on("close", () => {
-      const wasReady = this.ready;
-      this.ready = false;
-      this.socket = undefined;
-      if (!wasReady) {
-        failReady(new Error("GPT-Live WebSocket closed before session.started"));
+      if (!this.lifecycle.isCurrent(connection) || this.socket !== connected.socket) {
+        return;
       }
-      this.notifyClose(this.intentionallyClosed ? "completed" : "error");
+      this.socket = undefined;
+      if (!reachedReady) {
+        if (this.lifecycle.terminalOutcome(connection) === "completed") {
+          settleReady();
+          this.notifyClose(connection, "completed");
+          return;
+        }
+        const error = new Error("GPT-Live WebSocket closed before session.started");
+        this.lifecycle.failure(connection);
+        failReady(error);
+        this.lifecycle.close(connection, "error");
+        return;
+      }
+      this.notifyClose(connection, "error");
     });
 
     const terminalEvent = connected.detachBuffer();
@@ -193,7 +251,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
       if (!frame.isBinary) {
         const event = parseOpenAIQuicksilverEvent(decodeTextFrame(frame.data));
         if (event) {
-          this.handleEvent(event, settleReady, failReady);
+          this.handleEvent(event, connection, settleReady, failStartup);
         }
       }
     }
@@ -202,14 +260,13 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
         terminalEvent.kind === "error"
           ? terminalEvent.error
           : new Error("GPT-Live WebSocket closed during startup");
-      failReady(error);
-      this.fail(error);
+      failStartup(error, "startup terminal event");
     }
     await readyPromise;
   }
 
   sendAudio(audio: Buffer): void {
-    if (!this.ready || this.socket?.readyState !== WEBSOCKET_OPEN) {
+    if (!this.lifecycle.isReady() || this.socket?.readyState !== WEBSOCKET_OPEN) {
       if (this.pendingAudio.length < OPENAI_QUICKSILVER_PENDING_AUDIO_CHUNKS) {
         this.pendingAudio.push(audio);
       }
@@ -256,17 +313,19 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
   acknowledgeMark(_markName?: string): void {}
 
   close(): void {
-    this.intentionallyClosed = true;
-    this.stopController.abort(new Error("GPT-Live bridge closed"));
+    const connection = this.connection;
+    if (!connection || !this.lifecycle.cancel()) {
+      return;
+    }
     if (this.socket?.readyState === WEBSOCKET_OPEN) {
       this.sendEvent({ type: "session.close" });
     }
     this.closeSocket("bridge closed");
-    this.ready = false;
+    this.notifyClose(connection, "completed");
   }
 
   isConnected(): boolean {
-    return this.ready && this.socket?.readyState === WEBSOCKET_OPEN;
+    return this.lifecycle.isReady() && this.socket?.readyState === WEBSOCKET_OPEN;
   }
 
   handleBargeIn(): void {
@@ -287,15 +346,15 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
 
   private handleEvent(
     event: OpenAIQuicksilverInboundEvent,
+    connection: OpenAIRealtimeVoiceConnection,
     settleReady: () => void,
-    failReady: (error: Error) => void,
+    failStartup: (error: Error, reason: string) => void,
   ): void {
     if (event.kind === "ignored" || event.kind === "unknown") {
       return;
     }
     if (event.kind === "session-started") {
-      if (!this.ready) {
-        this.ready = true;
+      if (this.lifecycle.ready(connection)) {
         for (const audio of this.pendingAudio.splice(0)) {
           this.sendAudioNow(audio);
         }
@@ -308,7 +367,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     if (event.kind === "audio") {
       const canonical = canonicalizeBase64(event.data);
       if (!canonical) {
-        this.fail(new Error("GPT-Live WebSocket returned malformed base64 audio"));
+        this.fail(connection, new Error("GPT-Live WebSocket returned malformed base64 audio"));
         return;
       }
       const pcm = Buffer.from(canonical, "base64");
@@ -349,14 +408,15 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
       return;
     }
     const error = new Error(event.message);
-    if (!this.ready) {
-      failReady(error);
-      this.closeSocket("session start failed");
+    if (!this.lifecycle.isReady()) {
+      failStartup(error, "session start failed");
+      return;
     }
     this.config.onEvent?.({ direction: "server", type: "error", detail: event.message });
-    this.config.onError?.(error);
     if (event.fatalAuth) {
-      this.closeSocket("authentication failed");
+      this.fail(connection, error, "authentication failed");
+    } else {
+      this.config.onError?.(error);
     }
   }
 
@@ -400,24 +460,34 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     this.socket.send(payload);
   }
 
-  private fail(error: Error): void {
+  private fail(
+    connection: OpenAIRealtimeVoiceConnection,
+    error: Error,
+    reason = "bridge error",
+  ): void {
+    if (!this.lifecycle.failure(connection)) {
+      return;
+    }
     this.config.onError?.(error);
-    this.closeSocket("bridge error");
+    this.closeSocket(reason);
   }
 
-  private closeSocket(reason: string): void {
+  private closeSocket(reason: string, socket = this.socket): void {
     try {
-      this.socket?.close(1000, reason);
+      socket?.close(1000, reason);
     } catch {
       // Closing is best effort once the bridge reaches a terminal state.
     }
   }
 
-  private notifyClose(reason: "completed" | "error"): void {
-    if (this.closeNotified) {
+  private notifyClose(
+    connection: OpenAIRealtimeVoiceConnection,
+    reason: "completed" | "error",
+  ): void {
+    const outcome = this.lifecycle.close(connection, reason);
+    if (!outcome) {
       return;
     }
-    this.closeNotified = true;
-    this.config.onClose?.(reason);
+    this.config.onClose?.(outcome);
   }
 }

--- a/extensions/openai/realtime-quicksilver-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.ts
@@ -162,7 +162,6 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     let resolveReady!: () => void;
     let rejectReady!: (error: Error) => void;
     let readySettled = false;
-    let readyTimeout: ReturnType<typeof setTimeout> | undefined;
     let removeAbortListener = () => {};
     const readyPromise = new Promise<void>((resolve, reject) => {
       resolveReady = resolve;
@@ -203,7 +202,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
       failReady(error);
       this.closeSocket(reason, connected.socket);
     };
-    readyTimeout = setTimeout(() => {
+    const readyTimeout = setTimeout(() => {
       failStartup(
         new Error("GPT-Live WebSocket did not emit session.started"),
         "session-start timeout",
@@ -409,7 +408,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
         },
         (error: unknown) => {
           cleanup();
-          reject(error);
+          reject(error instanceof Error ? error : new Error(String(error)));
         },
       );
     });

--- a/extensions/openai/realtime-quicksilver-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.ts
@@ -85,6 +85,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
 
   private socket: OpenAIQuicksilverSocket | undefined;
   private connection: OpenAIRealtimeVoiceConnection | undefined;
+  private connectPromise: Promise<void> | undefined;
   private readonly lifecycle = new OpenAIRealtimeVoiceLifecycle();
   private pendingAudio: Buffer[] = [];
   private activeDelegations = new Set<string>();
@@ -101,12 +102,27 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     if (this.lifecycle.isReady()) {
       return;
     }
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
     const connection = this.lifecycle.connect();
     this.connection = connection;
+    const connectPromise = this.connectConnection(connection);
+    this.connectPromise = connectPromise;
+    try {
+      await connectPromise;
+    } finally {
+      if (this.connectPromise === connectPromise) {
+        this.connectPromise = undefined;
+      }
+    }
+  }
+
+  private async connectConnection(connection: OpenAIRealtimeVoiceConnection): Promise<void> {
     let connected: Awaited<ReturnType<typeof connectOpenAIQuicksilverSideband>>;
     try {
-      const auth = await this.config.resolveAuth();
-      if (!this.lifecycle.isCurrent(connection) || connection.signal.aborted) {
+      const auth = await this.waitForConnection(this.config.resolveAuth(), connection);
+      if (!auth) {
         return;
       }
       const url = buildOpenAIQuicksilverWebSocketUrl(this.config.model);
@@ -146,17 +162,22 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     let resolveReady!: () => void;
     let rejectReady!: (error: Error) => void;
     let readySettled = false;
+    let readyTimeout: ReturnType<typeof setTimeout> | undefined;
+    let removeAbortListener = () => {};
     const readyPromise = new Promise<void>((resolve, reject) => {
       resolveReady = resolve;
       rejectReady = reject;
     });
-    const settleReady = () => {
+    const settleReady = (providerReady = true) => {
       if (readySettled) {
         return;
       }
       readySettled = true;
-      reachedReady = true;
-      clearTimeout(readyTimeout);
+      reachedReady = providerReady;
+      if (readyTimeout) {
+        clearTimeout(readyTimeout);
+      }
+      removeAbortListener();
       resolveReady();
     };
     const failReady = (error: Error) => {
@@ -164,27 +185,44 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
         return;
       }
       readySettled = true;
-      clearTimeout(readyTimeout);
+      if (readyTimeout) {
+        clearTimeout(readyTimeout);
+      }
+      removeAbortListener();
       rejectReady(error);
     };
     const failStartup = (error: Error, reason: string) => {
-      if (!this.lifecycle.isCurrent(connection) || reachedReady) {
+      if (this.lifecycle.terminalOutcome(connection) === "completed") {
+        settleReady(false);
+        return;
+      }
+      if (!this.lifecycle.acceptsEvents(connection) || reachedReady) {
         return;
       }
       this.lifecycle.failure(connection);
       failReady(error);
       this.closeSocket(reason, connected.socket);
     };
-    const readyTimeout = setTimeout(() => {
+    readyTimeout = setTimeout(() => {
       failStartup(
         new Error("GPT-Live WebSocket did not emit session.started"),
         "session-start timeout",
       );
     }, OPENAI_QUICKSILVER_READY_TIMEOUT_MS);
     readyTimeout.unref?.();
+    const onAbort = () => {
+      if (this.lifecycle.terminalOutcome(connection) === "completed") {
+        settleReady(false);
+      }
+    };
+    connection.signal.addEventListener("abort", onAbort, { once: true });
+    removeAbortListener = () => connection.signal.removeEventListener("abort", onAbort);
+    if (connection.signal.aborted) {
+      onAbort();
+    }
 
     connected.socket.on("message", (data: RawData, isBinary: boolean) => {
-      if (!this.lifecycle.isCurrent(connection) || this.socket !== connected.socket) {
+      if (!this.lifecycle.acceptsEvents(connection) || this.socket !== connected.socket) {
         return;
       }
       if (isBinary) {
@@ -211,7 +249,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
       }
     });
     connected.socket.on("error", (error: Error) => {
-      if (!this.lifecycle.isCurrent(connection) || this.socket !== connected.socket) {
+      if (!this.lifecycle.acceptsEvents(connection) || this.socket !== connected.socket) {
         return;
       }
       if (!reachedReady) {
@@ -260,7 +298,13 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
         terminalEvent.kind === "error"
           ? terminalEvent.error
           : new Error("GPT-Live WebSocket closed during startup");
-      failStartup(error, "startup terminal event");
+      if (reachedReady) {
+        if (this.fail(connection, error, "startup terminal event")) {
+          this.notifyClose(connection, "error");
+        }
+      } else {
+        failStartup(error, "startup terminal event");
+      }
     }
     await readyPromise;
   }
@@ -342,6 +386,33 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
         ...(proxyAgent ? { agent: proxyAgent } : {}),
       });
     };
+  }
+
+  private async waitForConnection<T>(
+    promise: Promise<T>,
+    connection: OpenAIRealtimeVoiceConnection,
+  ): Promise<T | undefined> {
+    if (connection.signal.aborted) {
+      return undefined;
+    }
+    return new Promise<T | undefined>((resolve, reject) => {
+      const onAbort = () => {
+        cleanup();
+        resolve(undefined);
+      };
+      const cleanup = () => connection.signal.removeEventListener("abort", onAbort);
+      connection.signal.addEventListener("abort", onAbort, { once: true });
+      void promise.then(
+        (value) => {
+          cleanup();
+          resolve(value);
+        },
+        (error: unknown) => {
+          cleanup();
+          reject(error);
+        },
+      );
+    });
   }
 
   private handleEvent(
@@ -464,12 +535,13 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     connection: OpenAIRealtimeVoiceConnection,
     error: Error,
     reason = "bridge error",
-  ): void {
+  ): boolean {
     if (!this.lifecycle.failure(connection)) {
-      return;
+      return false;
     }
     this.config.onError?.(error);
     this.closeSocket(reason);
+    return true;
   }
 
   private closeSocket(reason: string, socket = this.socket): void {

--- a/extensions/openai/realtime-voice-lifecycle.test.ts
+++ b/extensions/openai/realtime-voice-lifecycle.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { OpenAIRealtimeVoiceLifecycle } from "./realtime-voice-lifecycle.js";
+
+describe("OpenAIRealtimeVoiceLifecycle", () => {
+  it("moves a connection from connecting to ready", () => {
+    const lifecycle = new OpenAIRealtimeVoiceLifecycle();
+    const connection = lifecycle.connect();
+
+    expect(lifecycle.phase()).toBe("connecting");
+    expect(lifecycle.ready(connection)).toBe(true);
+    expect(lifecycle.phase()).toBe("ready");
+    expect(lifecycle.isReady()).toBe(true);
+    expect(lifecycle.ready(connection)).toBe(false);
+  });
+
+  it("owns retry attempts and resets them only after provider readiness", () => {
+    const lifecycle = new OpenAIRealtimeVoiceLifecycle();
+    const first = lifecycle.connect();
+
+    expect(lifecycle.retry(first, 2)).toMatchObject({ attempt: 1 });
+    const second = lifecycle.reconnect(first);
+    expect(second).toBeDefined();
+    if (!second) {
+      throw new Error("expected a retry connection");
+    }
+
+    expect(lifecycle.retry(second, 2)).toMatchObject({ attempt: 2 });
+    const third = lifecycle.reconnect(second);
+    expect(third).toBeDefined();
+    if (!third) {
+      throw new Error("expected a second retry connection");
+    }
+    expect(lifecycle.retry(third, 2)).toBe("exhausted");
+
+    expect(lifecycle.ready(third)).toBe(true);
+    expect(lifecycle.retry(third, 2)).toMatchObject({ attempt: 1 });
+  });
+
+  it("ignores events from connections replaced by retry or explicit connect", () => {
+    const lifecycle = new OpenAIRealtimeVoiceLifecycle();
+    const first = lifecycle.connect();
+    lifecycle.retry(first, 1);
+    const retry = lifecycle.reconnect(first);
+    expect(retry).toBeDefined();
+    if (!retry) {
+      throw new Error("expected a retry connection");
+    }
+
+    expect(lifecycle.ready(first)).toBe(false);
+    expect(lifecycle.close(first, "error")).toBeUndefined();
+    expect(lifecycle.isCurrent(first)).toBe(false);
+    expect(lifecycle.ready(retry)).toBe(true);
+
+    const replacement = lifecycle.connect();
+    expect(retry.signal.aborted).toBe(true);
+    expect(lifecycle.failure(retry)).toBe(false);
+    expect(lifecycle.ready(replacement)).toBe(true);
+  });
+
+  it("keeps cancellation idempotent and gives it terminal precedence", () => {
+    const lifecycle = new OpenAIRealtimeVoiceLifecycle();
+    const connection = lifecycle.connect();
+
+    expect(lifecycle.cancel()).toBe(true);
+    expect(connection.signal.aborted).toBe(true);
+    expect(lifecycle.cancel()).toBe(false);
+    expect(lifecycle.failure(connection)).toBe(false);
+    expect(lifecycle.close(connection, "error")).toBe("completed");
+    expect(lifecycle.close(connection, "completed")).toBeUndefined();
+  });
+
+  it("keeps failure terminal when cancel and close arrive late", () => {
+    const lifecycle = new OpenAIRealtimeVoiceLifecycle();
+    const connection = lifecycle.connect();
+
+    expect(lifecycle.failure(connection)).toBe(true);
+    expect(lifecycle.cancel()).toBe(false);
+    expect(lifecycle.close(connection, "completed")).toBe("error");
+    expect(lifecycle.close(connection, "error")).toBeUndefined();
+  });
+});

--- a/extensions/openai/realtime-voice-lifecycle.test.ts
+++ b/extensions/openai/realtime-voice-lifecycle.test.ts
@@ -65,6 +65,7 @@ describe("OpenAIRealtimeVoiceLifecycle", () => {
     expect(connection.signal.aborted).toBe(true);
     expect(lifecycle.cancel()).toBe(false);
     expect(lifecycle.failure(connection)).toBe(false);
+    expect(lifecycle.terminalOutcome(connection)).toBe("completed");
     expect(lifecycle.close(connection, "error")).toBe("completed");
     expect(lifecycle.close(connection, "completed")).toBeUndefined();
   });

--- a/extensions/openai/realtime-voice-lifecycle.test.ts
+++ b/extensions/openai/realtime-voice-lifecycle.test.ts
@@ -7,6 +7,7 @@ describe("OpenAIRealtimeVoiceLifecycle", () => {
     const connection = lifecycle.connect();
 
     expect(lifecycle.phase()).toBe("connecting");
+    expect(lifecycle.acceptsEvents(connection)).toBe(true);
     expect(lifecycle.ready(connection)).toBe(true);
     expect(lifecycle.phase()).toBe("ready");
     expect(lifecycle.isReady()).toBe(true);
@@ -63,6 +64,7 @@ describe("OpenAIRealtimeVoiceLifecycle", () => {
 
     expect(lifecycle.cancel()).toBe(true);
     expect(connection.signal.aborted).toBe(true);
+    expect(lifecycle.acceptsEvents(connection)).toBe(false);
     expect(lifecycle.cancel()).toBe(false);
     expect(lifecycle.failure(connection)).toBe(false);
     expect(lifecycle.terminalOutcome(connection)).toBe("completed");

--- a/extensions/openai/realtime-voice-lifecycle.ts
+++ b/extensions/openai/realtime-voice-lifecycle.ts
@@ -116,6 +116,11 @@ export class OpenAIRealtimeVoiceLifecycle {
     return this.currentState(connection) !== undefined;
   }
 
+  acceptsEvents(connection: OpenAIRealtimeVoiceConnection): boolean {
+    const phase = this.currentState(connection)?.phase;
+    return phase === "connecting" || phase === "ready";
+  }
+
   isReady(): boolean {
     return this.state?.phase === "ready";
   }

--- a/extensions/openai/realtime-voice-lifecycle.ts
+++ b/extensions/openai/realtime-voice-lifecycle.ts
@@ -124,6 +124,12 @@ export class OpenAIRealtimeVoiceLifecycle {
     return this.state?.phase;
   }
 
+  terminalOutcome(
+    connection: OpenAIRealtimeVoiceConnection,
+  ): OpenAIRealtimeVoiceTerminalOutcome | undefined {
+    return this.currentState(connection)?.terminalOutcome;
+  }
+
   private createConnection(controller: AbortController): OpenAIRealtimeVoiceConnection {
     return { id: Symbol("openai-realtime-voice-connection"), signal: controller.signal };
   }

--- a/extensions/openai/realtime-voice-lifecycle.ts
+++ b/extensions/openai/realtime-voice-lifecycle.ts
@@ -1,0 +1,136 @@
+export type OpenAIRealtimeVoiceLifecyclePhase = "connecting" | "ready" | "retry-wait" | "terminal";
+
+export type OpenAIRealtimeVoiceTerminalOutcome = "completed" | "error";
+
+export type OpenAIRealtimeVoiceConnection = Readonly<{
+  id: symbol;
+  signal: AbortSignal;
+}>;
+
+type OpenAIRealtimeVoiceLifecycleState = {
+  connection: OpenAIRealtimeVoiceConnection;
+  controller: AbortController;
+  phase: OpenAIRealtimeVoiceLifecyclePhase;
+  retryAttempts: number;
+  terminalOutcome?: OpenAIRealtimeVoiceTerminalOutcome;
+  terminalNotified: boolean;
+};
+
+export class OpenAIRealtimeVoiceLifecycle {
+  private state: OpenAIRealtimeVoiceLifecycleState | undefined;
+
+  connect(): OpenAIRealtimeVoiceConnection {
+    this.state?.controller.abort(new Error("OpenAI realtime voice connection replaced"));
+    const controller = new AbortController();
+    const connection = this.createConnection(controller);
+    this.state = {
+      connection,
+      controller,
+      phase: "connecting",
+      retryAttempts: 0,
+      terminalNotified: false,
+    };
+    return connection;
+  }
+
+  reconnect(connection: OpenAIRealtimeVoiceConnection): OpenAIRealtimeVoiceConnection | undefined {
+    const state = this.currentState(connection);
+    if (!state || state.phase !== "retry-wait" || state.terminalOutcome) {
+      return undefined;
+    }
+    const nextConnection = this.createConnection(state.controller);
+    state.connection = nextConnection;
+    state.phase = "connecting";
+    return nextConnection;
+  }
+
+  ready(connection: OpenAIRealtimeVoiceConnection): boolean {
+    const state = this.currentState(connection);
+    if (!state || state.phase !== "connecting" || state.terminalOutcome) {
+      return false;
+    }
+    state.phase = "ready";
+    state.retryAttempts = 0;
+    return true;
+  }
+
+  retry(
+    connection: OpenAIRealtimeVoiceConnection,
+    maxAttempts: number,
+  ): { attempt: number; signal: AbortSignal } | "exhausted" | undefined {
+    const state = this.currentState(connection);
+    if (!state || state.phase === "retry-wait" || state.terminalOutcome) {
+      return undefined;
+    }
+    if (state.retryAttempts >= maxAttempts) {
+      return "exhausted";
+    }
+    state.retryAttempts += 1;
+    state.phase = "retry-wait";
+    return { attempt: state.retryAttempts, signal: state.controller.signal };
+  }
+
+  cancel(): boolean {
+    const state = this.state;
+    if (!state || state.terminalOutcome) {
+      return false;
+    }
+    state.phase = "terminal";
+    state.terminalOutcome = "completed";
+    state.controller.abort(new Error("OpenAI realtime voice session canceled"));
+    return true;
+  }
+
+  failure(connection: OpenAIRealtimeVoiceConnection): boolean {
+    const state = this.currentState(connection);
+    if (!state || state.terminalOutcome) {
+      return false;
+    }
+    state.phase = "terminal";
+    state.terminalOutcome = "error";
+    state.controller.abort(new Error("OpenAI realtime voice session failed"));
+    return true;
+  }
+
+  close(
+    connection: OpenAIRealtimeVoiceConnection,
+    outcome: OpenAIRealtimeVoiceTerminalOutcome,
+  ): OpenAIRealtimeVoiceTerminalOutcome | undefined {
+    const state = this.currentState(connection);
+    if (!state) {
+      return undefined;
+    }
+    if (!state.terminalOutcome) {
+      state.phase = "terminal";
+      state.terminalOutcome = outcome;
+      state.controller.abort(new Error("OpenAI realtime voice session closed"));
+    }
+    if (state.terminalNotified) {
+      return undefined;
+    }
+    state.terminalNotified = true;
+    return state.terminalOutcome;
+  }
+
+  isCurrent(connection: OpenAIRealtimeVoiceConnection): boolean {
+    return this.currentState(connection) !== undefined;
+  }
+
+  isReady(): boolean {
+    return this.state?.phase === "ready";
+  }
+
+  phase(): OpenAIRealtimeVoiceLifecyclePhase | undefined {
+    return this.state?.phase;
+  }
+
+  private createConnection(controller: AbortController): OpenAIRealtimeVoiceConnection {
+    return { id: Symbol("openai-realtime-voice-connection"), signal: controller.signal };
+  }
+
+  private currentState(
+    connection: OpenAIRealtimeVoiceConnection,
+  ): OpenAIRealtimeVoiceLifecycleState | undefined {
+    return this.state?.connection.id === connection.id ? this.state : undefined;
+  }
+}

--- a/extensions/openai/realtime-voice-lifecycle.ts
+++ b/extensions/openai/realtime-voice-lifecycle.ts
@@ -1,6 +1,6 @@
-export type OpenAIRealtimeVoiceLifecyclePhase = "connecting" | "ready" | "retry-wait" | "terminal";
+type OpenAIRealtimeVoiceLifecyclePhase = "connecting" | "ready" | "retry-wait" | "terminal";
 
-export type OpenAIRealtimeVoiceTerminalOutcome = "completed" | "error";
+type OpenAIRealtimeVoiceTerminalOutcome = "completed" | "error";
 
 export type OpenAIRealtimeVoiceConnection = Readonly<{
   id: symbol;

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -1369,6 +1369,32 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     expect(bridge.isConnected()).toBe(true);
   });
 
+  it("shares an in-flight connection until session readiness", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onReady = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onReady,
+    });
+    const firstConnect = bridge.connect();
+    const secondConnect = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+
+    await Promise.all([firstConnect, secondConnect]);
+    expect(onReady).toHaveBeenCalledOnce();
+    bridge.close();
+  });
+
   it("suppresses auto responses before draining queued initial greeting audio", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const bridgeRef: { current?: RealtimeVoiceBridge } = {};
@@ -1600,11 +1626,12 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
   it("ignores late events from a socket replaced by reconnect", async () => {
     vi.useFakeTimers();
     const provider = buildOpenAIRealtimeVoiceProvider();
+    const onAudio = vi.fn();
     const onClose = vi.fn();
     const onError = vi.fn();
     const bridge = provider.createBridge({
       providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
-      onAudio: vi.fn(),
+      onAudio,
       onClearAudio: vi.fn(),
       onClose,
       onError,
@@ -1622,6 +1649,19 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
 
     firstSocket.readyState = FakeWebSocket.CLOSED;
     firstSocket.emit("close", 1006, Buffer.from("transient drop"));
+    firstSocket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "response.audio.delta",
+          delta: Buffer.from("late audio").toString("base64"),
+        }),
+      ),
+    );
+    firstSocket.emit("error", new Error("late retry-wait failure"));
+    expect(onAudio).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+
     await vi.advanceTimersByTimeAsync(1000);
     const secondSocket = FakeWebSocket.instances[1];
     if (!secondSocket) {

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -1597,6 +1597,122 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     bridge.close();
   });
 
+  it("ignores late events from a socket replaced by reconnect", async () => {
+    vi.useFakeTimers();
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onClose = vi.fn();
+    const onError = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onClose,
+      onError,
+    });
+    const connecting = bridge.connect();
+    const firstSocket = FakeWebSocket.instances[0];
+    if (!firstSocket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    firstSocket.readyState = FakeWebSocket.CLOSED;
+    firstSocket.emit("close", 1006, Buffer.from("transient drop"));
+    await vi.advanceTimersByTimeAsync(1000);
+    const secondSocket = FakeWebSocket.instances[1];
+    if (!secondSocket) {
+      throw new Error("expected bridge to reconnect");
+    }
+    secondSocket.readyState = FakeWebSocket.OPEN;
+    secondSocket.emit("open");
+    secondSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await vi.waitFor(() => expect(bridge.isConnected()).toBe(true));
+
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    firstSocket.emit("error", new Error("late socket failure"));
+    firstSocket.emit("close", 1006, Buffer.from("late socket close"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(bridge.isConnected()).toBe(true);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    bridge.close();
+  });
+
+  it("exhausts retries when sockets open but never become provider-ready", async () => {
+    vi.useFakeTimers();
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onClose = vi.fn();
+    const onError = vi.fn();
+    const onEvent = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onClose,
+      onError,
+      onEvent,
+    });
+    const connecting = bridge.connect();
+    const firstSocket = FakeWebSocket.instances[0];
+    if (!firstSocket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    firstSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    firstSocket.readyState = FakeWebSocket.CLOSED;
+    firstSocket.emit("close", 1006, Buffer.from("transient drop"));
+
+    for (let attempt = 1; attempt <= 5; attempt += 1) {
+      await vi.waitFor(() =>
+        expect(onEvent).toHaveBeenCalledWith({
+          direction: "client",
+          type: "session.reconnect.scheduled",
+          detail: `reason=websocket-close attempt=${attempt} delayMs=${1000 * 2 ** (attempt - 1)}`,
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(1000 * 2 ** (attempt - 1));
+      const retrySocket = FakeWebSocket.instances[attempt];
+      if (!retrySocket) {
+        throw new Error(`expected reconnect socket ${attempt}`);
+      }
+      retrySocket.readyState = FakeWebSocket.OPEN;
+      retrySocket.emit("open");
+      retrySocket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "error",
+            error: { message: `retry startup failure ${attempt}` },
+          }),
+        ),
+      );
+    }
+
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledWith("error"));
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledTimes(5);
+    expect(FakeWebSocket.instances).toHaveLength(6);
+    expect(onEvent).toHaveBeenCalledWith({
+      direction: "client",
+      type: "session.reconnect.exhausted",
+      detail: "reason=websocket-close attempts=5",
+    });
+
+    bridge.close();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
   it("keeps Azure deployment bridges on deployment-compatible session payloads", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const bridge = provider.createBridge({
@@ -2056,10 +2172,12 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     }
 
     bridge.close();
+    bridge.close();
 
     await expect(connecting).resolves.toBeUndefined();
     expect(socket.closed).toBe(true);
     expect(socket.terminated).toBe(false);
+    expect(onClose).toHaveBeenCalledOnce();
     expect(onClose).toHaveBeenCalledWith("completed");
   });
 

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -687,7 +687,6 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       let reachedReady = false;
       let startupFailureClosing = false;
       let activeWs: WebSocket | undefined;
-      let connectTimeout: ReturnType<typeof setTimeout> | undefined;
       let removeAbortListener = () => {};
       const settleResolve = () => {
         if (settled) {
@@ -711,7 +710,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         removeAbortListener();
         reject(error);
       };
-      connectTimeout = setTimeout(() => {
+      const connectTimeout = setTimeout(() => {
         if (
           this.lifecycle.isCurrent(lifecycleConnection) &&
           !reachedReady &&

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -547,6 +547,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
 
   private ws: WebSocket | null = null;
   private connection: OpenAIRealtimeVoiceConnection | undefined;
+  private connectPromise: Promise<void> | undefined;
   private readonly lifecycle = new OpenAIRealtimeVoiceLifecycle();
   private pendingAudio: Buffer[] = [];
   private markQueue: string[] = [];
@@ -579,9 +580,23 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     if (this.terminalError) {
       throw this.terminalError;
     }
+    if (this.lifecycle.isReady()) {
+      return;
+    }
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
     const connection = this.lifecycle.connect();
     this.connection = connection;
-    await this.doConnect(connection);
+    const connectPromise = this.doConnect(connection);
+    this.connectPromise = connectPromise;
+    try {
+      await connectPromise;
+    } finally {
+      if (this.connectPromise === connectPromise) {
+        this.connectPromise = undefined;
+      }
+    }
   }
 
   sendAudio(audio: Buffer): void {
@@ -671,12 +686,18 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       let settled = false;
       let reachedReady = false;
       let startupFailureClosing = false;
+      let activeWs: WebSocket | undefined;
+      let connectTimeout: ReturnType<typeof setTimeout> | undefined;
+      let removeAbortListener = () => {};
       const settleResolve = () => {
         if (settled) {
           return;
         }
         settled = true;
-        clearTimeout(connectTimeout);
+        if (connectTimeout) {
+          clearTimeout(connectTimeout);
+        }
+        removeAbortListener();
         resolve();
       };
       const settleReject = (error: Error) => {
@@ -684,10 +705,13 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           return;
         }
         settled = true;
-        clearTimeout(connectTimeout);
+        if (connectTimeout) {
+          clearTimeout(connectTimeout);
+        }
+        removeAbortListener();
         reject(error);
       };
-      const connectTimeout: ReturnType<typeof setTimeout> = setTimeout(() => {
+      connectTimeout = setTimeout(() => {
         if (
           this.lifecycle.isCurrent(lifecycleConnection) &&
           !reachedReady &&
@@ -695,10 +719,26 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         ) {
           const error = new Error("OpenAI realtime connection timeout");
           startupFailureClosing = true;
-          this.ws?.terminate();
+          activeWs?.terminate();
           settleReject(error);
         }
       }, OpenAIRealtimeVoiceBridge.CONNECT_TIMEOUT_MS);
+      const onAbort = () => {
+        if (activeWs && activeWs.readyState !== WebSocket.CLOSED) {
+          activeWs.close(1000, "connection canceled");
+        }
+        if (this.lifecycle.terminalOutcome(lifecycleConnection) === "completed") {
+          settleResolve();
+          return;
+        }
+        const reason = lifecycleConnection.signal.reason;
+        settleReject(reason instanceof Error ? reason : new Error(String(reason)));
+      };
+      lifecycleConnection.signal.addEventListener("abort", onAbort, { once: true });
+      removeAbortListener = () => lifecycleConnection.signal.removeEventListener("abort", onAbort);
+      if (lifecycleConnection.signal.aborted) {
+        onAbort();
+      }
 
       const openWebSocket = (resolvedConnection: {
         url: string;
@@ -720,10 +760,11 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           maxPayload: OPENAI_VOICE_WS_MAX_PAYLOAD_BYTES,
           ...(proxyAgent ? { agent: proxyAgent } : {}),
         });
+        activeWs = ws;
         this.ws = ws;
 
         const rejectStartup = (error: Error) => {
-          if (!this.lifecycle.isCurrent(lifecycleConnection) || reachedReady) {
+          if (!this.lifecycle.acceptsEvents(lifecycleConnection) || reachedReady) {
             return;
           }
           startupFailureClosing = true;
@@ -734,7 +775,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         };
 
         ws.on("open", () => {
-          if (!this.lifecycle.isCurrent(lifecycleConnection)) {
+          if (!this.lifecycle.acceptsEvents(lifecycleConnection)) {
             ws.close(1000, "stale connection");
             return;
           }
@@ -753,7 +794,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         });
 
         ws.on("message", (data: Buffer) => {
-          if (!this.lifecycle.isCurrent(lifecycleConnection)) {
+          if (!this.lifecycle.acceptsEvents(lifecycleConnection) || this.ws !== ws) {
             return;
           }
           if (settled && !reachedReady) {
@@ -792,7 +833,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         });
 
         ws.on("error", (error) => {
-          if (!this.lifecycle.isCurrent(lifecycleConnection)) {
+          if (!this.lifecycle.acceptsEvents(lifecycleConnection) || this.ws !== ws) {
             return;
           }
           captureWsEvent({

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -52,6 +52,10 @@ import {
   resolveOpenAIChatGptSubscriptionAuth,
 } from "./realtime-quicksilver-session.js";
 import { isOpenAIGptLiveModel } from "./realtime-quicksilver.js";
+import {
+  OpenAIRealtimeVoiceLifecycle,
+  type OpenAIRealtimeVoiceConnection,
+} from "./realtime-voice-lifecycle.js";
 
 type OpenAIRealtimeVoice =
   | "alloy"
@@ -542,10 +546,8 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   readonly supportsToolResultSuppression = true;
 
   private ws: WebSocket | null = null;
-  private connected = false;
-  private sessionConfigured = false;
-  private intentionallyClosed = false;
-  private reconnectAttempts = 0;
+  private connection: OpenAIRealtimeVoiceConnection | undefined;
+  private readonly lifecycle = new OpenAIRealtimeVoiceLifecycle();
   private pendingAudio: Buffer[] = [];
   private markQueue: string[] = [];
   private responseStartTimestamp: number | null = null;
@@ -566,9 +568,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private sessionReadyFired = false;
   private reconnectReason: string | undefined;
   private activeConnectionReason: string | undefined;
-  private reconnectAbortController = new AbortController();
   private terminalError: Error | undefined;
-  private terminalCloseNotified = false;
   private readonly audioFormat: RealtimeVoiceAudioFormat;
 
   constructor(private readonly config: OpenAIRealtimeVoiceBridgeConfig) {
@@ -579,16 +579,13 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     if (this.terminalError) {
       throw this.terminalError;
     }
-    this.intentionallyClosed = false;
-    if (this.reconnectAbortController.signal.aborted) {
-      this.reconnectAbortController = new AbortController();
-    }
-    this.reconnectAttempts = 0;
-    await this.doConnect();
+    const connection = this.lifecycle.connect();
+    this.connection = connection;
+    await this.doConnect(connection);
   }
 
   sendAudio(audio: Buffer): void {
-    if (!this.connected || !this.sessionConfigured || this.ws?.readyState !== WebSocket.OPEN) {
+    if (!this.lifecycle.isReady() || this.ws?.readyState !== WebSocket.OPEN) {
       if (this.pendingAudio.length < 320) {
         this.pendingAudio.push(audio);
       }
@@ -655,25 +652,24 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   close(): void {
-    this.intentionallyClosed = true;
-    // The bridge owns both its active socket and reconnect delay; canceling
-    // both keeps terminal close from retaining callbacks for the full backoff.
-    this.reconnectAbortController.abort();
-    this.connected = false;
-    this.sessionConfigured = false;
-    if (this.ws) {
-      this.ws.close(1000, "Bridge closed");
-      this.ws = null;
+    const connection = this.connection;
+    if (!connection || !this.lifecycle.cancel()) {
+      return;
     }
+    const ws = this.ws;
+    this.ws = null;
+    ws?.close(1000, "Bridge closed");
+    this.notifyClose(connection, "completed");
   }
 
   isConnected(): boolean {
-    return this.connected && this.sessionConfigured;
+    return this.lifecycle.isReady() && this.ws?.readyState === WebSocket.OPEN;
   }
 
-  private async doConnect(): Promise<void> {
+  private async doConnect(lifecycleConnection: OpenAIRealtimeVoiceConnection): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       let settled = false;
+      let reachedReady = false;
       let startupFailureClosing = false;
       const settleResolve = () => {
         if (settled) {
@@ -692,33 +688,44 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         reject(error);
       };
       const connectTimeout: ReturnType<typeof setTimeout> = setTimeout(() => {
-        if (!this.sessionConfigured && !this.intentionallyClosed) {
+        if (
+          this.lifecycle.isCurrent(lifecycleConnection) &&
+          !reachedReady &&
+          this.lifecycle.terminalOutcome(lifecycleConnection) !== "completed"
+        ) {
+          const error = new Error("OpenAI realtime connection timeout");
           startupFailureClosing = true;
           this.ws?.terminate();
-          settleReject(new Error("OpenAI realtime connection timeout"));
+          settleReject(error);
         }
       }, OpenAIRealtimeVoiceBridge.CONNECT_TIMEOUT_MS);
 
-      const openWebSocket = (connection: { url: string; headers: Record<string, string> }) => {
+      const openWebSocket = (resolvedConnection: {
+        url: string;
+        headers: Record<string, string>;
+      }) => {
         if (settled) {
           return;
         }
-        if (this.intentionallyClosed) {
+        if (!this.lifecycle.isCurrent(lifecycleConnection) || lifecycleConnection.signal.aborted) {
           settleResolve();
           return;
         }
-        const url = connection.url;
-        this.connectionUrl = connection.url;
+        const url = resolvedConnection.url;
+        this.connectionUrl = resolvedConnection.url;
         const debugProxy = resolveDebugProxySettings();
         const proxyAgent = createDebugProxyWebSocketAgent(debugProxy);
-        const ws = new WebSocket(connection.url, {
-          headers: connection.headers,
+        const ws = new WebSocket(resolvedConnection.url, {
+          headers: resolvedConnection.headers,
           maxPayload: OPENAI_VOICE_WS_MAX_PAYLOAD_BYTES,
           ...(proxyAgent ? { agent: proxyAgent } : {}),
         });
         this.ws = ws;
 
         const rejectStartup = (error: Error) => {
+          if (!this.lifecycle.isCurrent(lifecycleConnection) || reachedReady) {
+            return;
+          }
           startupFailureClosing = true;
           settleReject(error);
           if (ws.readyState !== WebSocket.CLOSED) {
@@ -727,10 +734,11 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         };
 
         ws.on("open", () => {
+          if (!this.lifecycle.isCurrent(lifecycleConnection)) {
+            ws.close(1000, "stale connection");
+            return;
+          }
           this.resetRealtimeSessionState();
-          this.connected = true;
-          this.sessionConfigured = false;
-          this.reconnectAttempts = 0;
           captureWsEvent({
             url,
             direction: "local",
@@ -745,7 +753,10 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         });
 
         ws.on("message", (data: Buffer) => {
-          if (settled && !this.sessionConfigured) {
+          if (!this.lifecycle.isCurrent(lifecycleConnection)) {
+            return;
+          }
+          if (settled && !reachedReady) {
             return;
           }
           captureWsEvent({
@@ -761,18 +772,19 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           });
           try {
             const event = JSON.parse(data.toString()) as RealtimeEvent;
-            if (event.type === "error" && !this.sessionConfigured) {
+            if (event.type === "error" && !reachedReady) {
               rejectStartup(new Error(readRealtimeErrorDetail(event.error)));
               return;
             }
-            this.handleEvent(event);
+            this.handleEvent(event, lifecycleConnection);
             if (event.type === "session.updated") {
+              reachedReady = this.lifecycle.isReady();
               settleResolve();
             }
           } catch (error) {
             if (error instanceof OpenAIRealtimeMalformedAudioError) {
               settleReject(error);
-              this.failConnection(error, ws);
+              this.failConnection(error, ws, lifecycleConnection);
               return;
             }
             console.error("[openai] realtime event parse failed:", error);
@@ -780,6 +792,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         });
 
         ws.on("error", (error) => {
+          if (!this.lifecycle.isCurrent(lifecycleConnection)) {
+            return;
+          }
           captureWsEvent({
             url,
             direction: "local",
@@ -791,7 +806,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
               capability: "realtime-voice",
             },
           });
-          if (!this.sessionConfigured) {
+          if (!reachedReady) {
             rejectStartup(error instanceof Error ? error : new Error(String(error)));
             return;
           }
@@ -806,41 +821,53 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
             code,
             reasonBuffer,
           });
+          if (!this.lifecycle.isCurrent(lifecycleConnection)) {
+            return;
+          }
+          if (this.ws === ws) {
+            this.ws = null;
+          }
           if (startupFailureClosing) {
-            if (this.ws === ws) {
-              this.connected = false;
-              this.sessionConfigured = false;
-            }
             return;
           }
-          const wasSessionConfigured = this.sessionConfigured;
-          this.connected = false;
-          this.sessionConfigured = false;
           if (this.terminalError) {
-            if (this.ws === ws) {
-              this.ws = null;
-            }
-            this.notifyTerminalClose();
+            this.notifyClose(lifecycleConnection, "error");
             return;
           }
-          if (this.intentionallyClosed) {
+          if (this.lifecycle.terminalOutcome(lifecycleConnection) === "completed") {
             settleResolve();
-            this.config.onClose?.("completed");
+            this.notifyClose(lifecycleConnection, "completed");
             return;
           }
-          if (!wasSessionConfigured && !settled) {
-            settleReject(new Error("OpenAI realtime connection closed before ready"));
+          if (!reachedReady && !settled) {
+            const error = new Error("OpenAI realtime connection closed before ready");
+            settleReject(error);
             return;
           }
           const reason = this.reconnectReason ?? "websocket-close";
           this.reconnectReason = undefined;
-          void this.attemptReconnect(reason);
+          void this.attemptReconnect(reason, lifecycleConnection);
         });
       };
 
-      const connectionOrPromise = this.resolveConnectionParams();
+      let connectionOrPromise:
+        | { url: string; headers: Record<string, string> }
+        | Promise<{ url: string; headers: Record<string, string> }>;
+      try {
+        connectionOrPromise = this.resolveConnectionParams();
+      } catch (error) {
+        settleReject(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
       if (connectionOrPromise instanceof Promise) {
         void connectionOrPromise.then(openWebSocket).catch((error: unknown) => {
+          if (
+            !this.lifecycle.isCurrent(lifecycleConnection) ||
+            this.lifecycle.terminalOutcome(lifecycleConnection) === "completed"
+          ) {
+            settleResolve();
+            return;
+          }
           settleReject(error instanceof Error ? error : new Error(String(error)));
         });
         return;
@@ -944,49 +971,60 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     };
   }
 
-  private async attemptReconnect(reason: string): Promise<void> {
-    if (this.intentionallyClosed) {
+  private async attemptReconnect(
+    reason: string,
+    connection: OpenAIRealtimeVoiceConnection,
+  ): Promise<void> {
+    const retry = this.lifecycle.retry(
+      connection,
+      OpenAIRealtimeVoiceBridge.MAX_RECONNECT_ATTEMPTS,
+    );
+    if (!retry) {
       return;
     }
-    if (this.reconnectAttempts >= OpenAIRealtimeVoiceBridge.MAX_RECONNECT_ATTEMPTS) {
+    if (retry === "exhausted") {
       this.config.onEvent?.({
         direction: "client",
         type: "session.reconnect.exhausted",
-        detail: `reason=${reason} attempts=${this.reconnectAttempts}`,
+        detail: `reason=${reason} attempts=${OpenAIRealtimeVoiceBridge.MAX_RECONNECT_ATTEMPTS}`,
       });
-      this.config.onClose?.("error");
+      this.lifecycle.failure(connection);
+      this.notifyClose(connection, "error");
       return;
     }
-    this.reconnectAttempts += 1;
-    const attempt = this.reconnectAttempts;
+    const attempt = retry.attempt;
     const delay = OpenAIRealtimeVoiceBridge.BASE_RECONNECT_DELAY_MS * 2 ** (attempt - 1);
     this.config.onEvent?.({
       direction: "client",
       type: "session.reconnect.scheduled",
       detail: `reason=${reason} attempt=${attempt} delayMs=${delay}`,
     });
-    const reconnectSignal = this.reconnectAbortController.signal;
     try {
-      await sleepWithAbort(delay, reconnectSignal);
+      await sleepWithAbort(delay, retry.signal);
     } catch (error) {
-      if (!reconnectSignal.aborted) {
+      if (!retry.signal.aborted) {
         throw error;
       }
       return;
     }
-    if (this.intentionallyClosed) {
+    const nextConnection = this.lifecycle.reconnect(connection);
+    if (!nextConnection) {
       return;
     }
+    this.connection = nextConnection;
     try {
-      await this.doConnect();
+      await this.doConnect(nextConnection);
       this.config.onEvent?.({
         direction: "client",
         type: "session.reconnect.ready",
         detail: `reason=${reason} attempt=${attempt}`,
       });
     } catch (error) {
+      if (!this.lifecycle.isCurrent(nextConnection)) {
+        return;
+      }
       this.config.onError?.(error instanceof Error ? error : new Error(String(error)));
-      await this.attemptReconnect(reason);
+      await this.attemptReconnect(reason, nextConnection);
     }
   }
 
@@ -1115,7 +1153,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     return this.audioFormat.encoding === "pcm16" ? "pcm16" : "g711_ulaw";
   }
 
-  private handleEvent(event: RealtimeEvent): void {
+  private handleEvent(event: RealtimeEvent, connection: OpenAIRealtimeVoiceConnection): void {
     const emitServerEvent = () =>
       this.config.onEvent?.({
         direction: "server",
@@ -1146,7 +1184,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         return;
 
       case "session.updated":
-        this.sessionConfigured = true;
+        if (!this.lifecycle.ready(connection)) {
+          return;
+        }
         if (this.activeConnectionReason) {
           this.config.onEvent?.({
             direction: "server",
@@ -1478,15 +1518,16 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     this.deliveredToolCallKeys.clear();
   }
 
-  private failConnection(error: OpenAIRealtimeMalformedAudioError, ws: WebSocket): void {
+  private failConnection(
+    error: OpenAIRealtimeMalformedAudioError,
+    ws: WebSocket,
+    connection: OpenAIRealtimeVoiceConnection,
+  ): void {
     if (this.terminalError) {
       return;
     }
     this.terminalError = error;
-    this.intentionallyClosed = true;
-    this.reconnectAbortController.abort();
-    this.connected = false;
-    this.sessionConfigured = false;
+    this.lifecycle.failure(connection);
     this.resetRealtimeSessionState();
     try {
       this.config.onError?.(error);
@@ -1494,17 +1535,20 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       if (ws.readyState !== WebSocket.CLOSED) {
         ws.close(1002, "Malformed audio payload");
       } else {
-        this.notifyTerminalClose();
+        this.notifyClose(connection, "error");
       }
     }
   }
 
-  private notifyTerminalClose(): void {
-    if (this.terminalCloseNotified) {
+  private notifyClose(
+    connection: OpenAIRealtimeVoiceConnection,
+    outcome: "completed" | "error",
+  ): void {
+    const terminalOutcome = this.lifecycle.close(connection, outcome);
+    if (!terminalOutcome) {
       return;
     }
-    this.terminalCloseNotified = true;
-    this.config.onClose?.("error");
+    this.config.onClose?.(terminalOutcome);
   }
 
   private sendMark(): void {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where OpenAI realtime voice sessions could accept late socket events, refresh retry ownership before provider readiness, or produce inconsistent terminal outcomes across the GA and GPT-Live bridges.

## Why This Change Was Made

Adds one OpenAI-local connection/session lifecycle owner with generation-scoped callbacks, explicit retry accounting, cancellation, and first-terminal-wins behavior. The GA and GPT-Live bridges remain thin protocol adapters; browser brokerage, sideband transport retry, provider configuration, and environment-variable surfaces are unchanged.

## User Impact

Realtime voice behavior remains the same, while cancellation and close are idempotent, reconnect budgets reset only at provider readiness, and stale or late events cannot revive or mutate a replaced session.

## Evidence

- Blacksmith Testbox: 134 focused tests passed across the lifecycle owner, both provider bridges, and GPT-Live session behavior.
- Added coverage for concurrent connect sharing, startup cancellation, buffered terminal events, stale events during retry, retry exhaustion, and terminal precedence.
- Autoreview rerun after fixes: clean, no accepted/actionable findings.
- `pnpm check:changed` first pass completed through format, API, boundary, and package guards and identified two unused type exports; those were fixed. Final reruns were blocked before execution by delegated Testbox file-sync timeouts, so PR CI remains the authoritative full changed-file gate.

