### PR TITLE
fix(agents): preserve tool-result middleware identity

### DIFF
--- a/src/agents/embedded-agent-runner.extensions.test.ts
+++ b/src/agents/embedded-agent-runner.extensions.test.ts
@@ -14,6 +14,10 @@ import {
   SessionManager,
 } from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  AgentToolResultMiddlewareContext,
+  AgentToolResultMiddlewareEvent,
+} from "../plugins/agent-tool-result-middleware-types.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import {
@@ -33,6 +37,99 @@ afterEach(() => {
 });
 
 describe("buildEmbeddedExtensionFactories", () => {
+  it.each([
+    {
+      label: "normal embedded run",
+      identity: {
+        agentId: "main",
+        sessionId: "session-normal",
+        sessionKey: "agent:main:discord:channel:normal",
+        runId: "run-normal",
+      },
+    },
+    {
+      label: "embedded compaction run",
+      identity: {
+        agentId: "compactor",
+        sessionId: "session-compaction",
+        sessionKey: "agent:compactor:discord:channel:compaction",
+        runId: "run-compaction",
+      },
+    },
+  ])("passes the prepared $label identity to installed result middleware", async ({ identity }) => {
+    const middleware = vi.fn(
+      (event: AgentToolResultMiddlewareEvent, _context: AgentToolResultMiddlewareContext) => ({
+        result: {
+          content: [{ type: "text" as const, text: "middleware-observed" }],
+          details: { observedTool: event.toolName },
+        },
+      }),
+    );
+    const registry = createEmptyPluginRegistry();
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "identity-proof",
+      pluginName: "identity-proof",
+      rawHandler: middleware,
+      handler: middleware,
+      runtimes: ["openclaw"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+
+    const sessionManager = SessionManager.inMemory();
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+      ...identity,
+    });
+    const factory = factories[0];
+    expect(factory).toBeDefined();
+    if (!factory) {
+      throw new Error("Expected embedded tool-result extension factory");
+    }
+
+    const runtime = createExtensionRuntime();
+    const extension = await loadExtensionFromFactory(
+      factory,
+      "/tmp",
+      createEventBus(),
+      runtime,
+      "<middleware-identity-test>",
+    );
+    const runner = new ExtensionRunner(
+      [extension],
+      runtime,
+      "/tmp",
+      sessionManager,
+      ModelRegistry.inMemory(AuthStorage.inMemory()),
+    );
+    const result = await runner.emitToolResult({
+      type: "tool_result",
+      toolName: "read",
+      toolCallId: `${identity.runId}-read`,
+      input: { path: "README.md" },
+      content: [{ type: "text", text: "original tool output" }],
+      details: {},
+      isError: false,
+    });
+
+    expect(middleware).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        toolName: "read",
+        toolCallId: `${identity.runId}-read`,
+        args: { path: "README.md" },
+      }),
+      { runtime: "openclaw", ...identity },
+    );
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: "middleware-observed" }],
+      details: { observedTool: "read" },
+    });
+  });
+
   it("bridges middleware mutations with unique fallback tool call ids", async () => {
     // Middleware invoked from app-server style tool_result events may not have a
     // call id; synthesize stable unique ids for downstream audit/mutation hooks.

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -172,6 +172,10 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
         provider,
         modelId,
         model: effectiveModel,
+        agentId: sessionAgentId,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey ?? sandboxSessionKey,
+        runId,
       });
       const resourceLoader = createEmbeddedAgentResourceLoader({
         cwd: effectiveCwd,

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -52,9 +52,24 @@ function snapshotToolSendReceipt(details: unknown): unknown {
 
 function buildAgentToolResultMiddlewareFactory(
   sessionManager: SessionManager,
-  runId?: string,
+  context: {
+    agentId?: string;
+    sessionId?: string;
+    sessionKey?: string;
+    runId?: string;
+  },
 ): ExtensionFactory {
-  const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" });
+  const { agentId, sessionKey, runId } = context;
+  // Snapshot the prepared session once; tool results must never rediscover
+  // mutable session identity after a later turn has started.
+  const sessionId = context.sessionId ?? sessionManager.getSessionId?.();
+  const runner = createAgentToolResultMiddlewareRunner({
+    runtime: "openclaw",
+    ...(agentId ? { agentId } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(runId ? { runId } : {}),
+  });
   return (agent) => {
     agent.on("tool_result", async (rawEvent: unknown, ctx: { cwd?: string }) => {
       const event = recordFromUnknown(rawEvent) as AgentToolResultEvent;
@@ -178,6 +193,9 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  agentId?: string;
+  sessionId?: string;
+  sessionKey?: string;
   runId?: string;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
@@ -209,6 +227,13 @@ export function buildEmbeddedExtensionFactories(params: {
   if (pruningFactory) {
     factories.push(pruningFactory);
   }
-  factories.push(buildAgentToolResultMiddlewareFactory(params.sessionManager, params.runId));
+  factories.push(
+    buildAgentToolResultMiddlewareFactory(params.sessionManager, {
+      agentId: params.agentId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      runId: params.runId,
+    }),
+  );
   return factories;
 }

--- a/src/agents/embedded-agent-runner/run/attempt-session.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.ts
@@ -80,6 +80,9 @@ export async function prepareEmbeddedAttemptAgentSession(input: {
     provider: attempt.provider,
     modelId: attempt.modelId,
     model: attempt.model,
+    agentId: input.sessionAgentId,
+    sessionId: attempt.sessionId,
+    sessionKey: attempt.sessionKey ?? attempt.sandboxSessionKey,
     runId: attempt.runId,
   });
   const resourceLoader = createEmbeddedAgentResourceLoader({


### PR DESCRIPTION
Closes #106910
Supersedes #107000. Preserves @SebTardif's original design and Git co-author credit.

AI-assisted: yes; the behavior, current owner paths, regression evidence, and exact upstream Codex contracts were independently reviewed.

## What Problem This Solves

Fixes an issue where plugins using installed agent-tool-result middleware could not identify which OpenClaw agent, session, or run executed a tool. Per-session auditing, telemetry, and policy therefore received only `runtime: "openclaw"`, even though the corresponding Codex integration already carries the prepared execution identity.

## Why This Change Was Made

Capture the already prepared agent ID, session ID, session key, and run ID once when building the existing middleware runner. Thread the effective identity through both current owner call sites: ordinary embedded attempts and the current compaction-session execution path. Resolve the session-manager fallback once at factory construction, never in the tool-result hot path.

The original contributor PR #107000 is no longer mergeable against current `main`: compaction factory ownership has moved from its old `compact.ts` call site into `compaction-session-execution.ts`. This maintainer successor carries forward @SebTardif's fix without adding a product proof script, changing Knip configuration, or preserving stale ownership.

## User Impact

Installed plugins receive the same available agent, session, and run identity for OpenClaw tool results that Codex tool-result middleware already receives. Ordinary runs and compaction runs retain their correct prepared owner, and all existing tool-result mutation, error, messaging, safeguard, and cross-runtime behavior is preserved.

## Evidence

- Independently reproduced both normal and compaction identities with a real installed plugin registry, production extension loading, the real `ExtensionRunner`, and an actual `tool_result` event on Blacksmith Testbox `tbx_01kypjr5vcysqs573z8y6660t2`.
- Before: both new end-to-end cases fail because the real middleware receives only `{ runtime: "openclaw" }`; all 13 existing controls pass.
- After: the same installed plugin receives the exact prepared agent, session, session-key, and run identity for both runs and the transformed tool result remains visible.
- Proved the existing Codex sibling and upstream protocol directly at `openai/codex@fe01054a28fa4bd04716d9ceadb410f2443a50ce`: `codex-rs/app-server-protocol/src/protocol/v2/item.rs`, `codex-rs/app-server/src/bespoke_event_handling.rs`, and `codex-rs/protocol/src/dynamic_tools.rs`.
- Passed all 588 tests across 21 exact owner/sibling suites and 8 Vitest shards, covering embedded attempts, compaction, middleware, installed Tokenjuice, and Codex dynamic-tool/native ownership.
- Passed `pnpm check:test-types`, the exact four-file `pnpm check:changed -- ...`, and all three official hard-zero `pnpm deadcode:exports` Knip scans: production exports, full-tree exports, and script exports.
- Fresh `gpt-5.6-sol` structured autoreview at `xhigh`: no accepted or actionable findings.
