### PR TITLE
fix(mattermost): preserve outbound delivery settlement

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -713,6 +713,62 @@ describe("mattermostPlugin", () => {
       expect(discovery?.schema).toBeUndefined();
     });
 
+    it("prepares supported sends for core-owned durable delivery", async () => {
+      const prepareSendPayload = mattermostPlugin.actions?.prepareSendPayload;
+      if (!prepareSendPayload) {
+        throw new Error("mattermost actions.prepareSendPayload missing");
+      }
+
+      expect(
+        prepareSendPayload({
+          ctx: createMattermostActionContext({
+            params: {
+              to: "channel:CHAN1",
+              message: "report",
+              filePath: "/tmp/workspace/report.md",
+              attachmentText: "native attachment",
+            },
+          }),
+          to: "channel:CHAN1",
+          payload: { text: "report" },
+        }),
+      ).toEqual({
+        text: "report",
+        mediaUrl: "/tmp/workspace/report.md",
+        mediaUrls: ["/tmp/workspace/report.md"],
+        channelData: {
+          mattermost: {
+            attachmentText: "native attachment",
+          },
+        },
+      });
+    });
+
+    it.each([
+      ["buffer attachments", { buffer: "cmVwb3J0" }, "buffer/base64 payloads"],
+      [
+        "multiple attachments",
+        { mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"] },
+        "supports one attachment per message",
+      ],
+    ])("rejects unsupported %s before provider dispatch", async (_label, extraParams, error) => {
+      const prepareSendPayload = mattermostPlugin.actions?.prepareSendPayload;
+      if (!prepareSendPayload) {
+        throw new Error("mattermost actions.prepareSendPayload missing");
+      }
+
+      expect(() =>
+        prepareSendPayload({
+          ctx: createMattermostActionContext({
+            params: { to: "channel:CHAN1", message: "report", ...extraParams },
+          }),
+          to: "channel:CHAN1",
+          payload: { text: "report" },
+        }),
+      ).toThrow(error);
+      expect(sendMessageMattermostMock).not.toHaveBeenCalled();
+    });
+
     it("keeps read opt in when reactions are disabled", () => {
       const cfg: OpenClawConfig = {
         channels: {
@@ -1544,6 +1600,25 @@ describe("mattermostPlugin", () => {
   });
 
   describe("outbound", () => {
+    it("carries provider attachment text through payload delivery", async () => {
+      await requireMattermostSendPayload()({
+        cfg: createMattermostTestConfig(),
+        to: "channel:CHAN1",
+        text: "report",
+        payload: {
+          text: "report",
+          channelData: {
+            mattermost: {
+              attachmentText: "native attachment",
+            },
+          },
+        },
+      });
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "report");
+      expect(options.attachmentText).toBe("native attachment");
+    });
+
     it("renders presentation buttons for normal reply payload delivery", async () => {
       const renderPresentation = requireMattermostRenderPresentation();
       const sendPayload = requireMattermostSendPayload();

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -68,6 +68,7 @@ import {
   resolveMattermostReplyToMode,
   type ResolvedMattermostAccount,
 } from "./mattermost/accounts.js";
+import type { MattermostSendResult } from "./mattermost/send.js";
 import { looksLikeMattermostTargetId, normalizeMattermostMessagingTarget } from "./normalize.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { resolveMattermostOutboundSessionRoute } from "./session-route.js";
@@ -128,11 +129,19 @@ function hasMattermostPresentationNavigation(presentation: MessagePresentation):
   );
 }
 
+function readMattermostPayloadData(payload: {
+  channelData?: Record<string, unknown>;
+}): Record<string, unknown> | undefined {
+  const data = payload.channelData?.mattermost;
+  return data && typeof data === "object" && !Array.isArray(data)
+    ? (data as Record<string, unknown>)
+    : undefined;
+}
+
 function readMattermostPresentationButtons(payload: {
   channelData?: Record<string, unknown>;
 }): Array<unknown> | undefined {
-  const buttons = (payload.channelData?.mattermost as { presentationButtons?: unknown } | undefined)
-    ?.presentationButtons;
+  const buttons = readMattermostPayloadData(payload)?.presentationButtons;
   return Array.isArray(buttons) ? buttons : undefined;
 }
 
@@ -381,6 +390,30 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool: describeMattermostMessageTool,
   extractToolSend: ({ args }) => extractMattermostToolSend(args),
   extractToolSendResult: ({ result, send }) => extractMattermostToolSendResult(result, send),
+  prepareSendPayload: ({ ctx, payload }) => {
+    if (ctx.action !== "send") {
+      return null;
+    }
+    const mediaUrl = resolveMattermostSendAttachmentMedia(ctx.params);
+    const attachmentText =
+      typeof ctx.params.attachmentText === "string" ? ctx.params.attachmentText : undefined;
+    const existingMattermostData = readMattermostPayloadData(payload);
+    return {
+      ...payload,
+      ...(mediaUrl ? { mediaUrl, mediaUrls: [mediaUrl] } : {}),
+      ...(attachmentText !== undefined
+        ? {
+            channelData: {
+              ...payload.channelData,
+              mattermost: {
+                ...existingMattermostData,
+                attachmentText,
+              },
+            },
+          }
+        : {}),
+    };
+  },
   supportsAction: ({ action }) => {
     return action === "send" || action === "react" || action === "read";
   },
@@ -550,17 +583,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       normalizeOptionalString(params.replyTo);
     const resolvedAccountId = accountId || undefined;
 
-    const attachmentMedia = collectMattermostAttachmentMedia(params);
-    if (attachmentMedia.hasUnsupportedAttachmentPayload) {
-      throw new Error(
-        "Mattermost send attachments require media, mediaUrl, path, filePath, fileUrl, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported.",
-      );
-    }
-    if (attachmentMedia.mediaUrls.length > 1) {
-      throw new Error(
-        "Mattermost send supports one attachment per message; split multiple mediaUrls or attachments[] entries into separate sends.",
-      );
-    }
+    const mediaUrl = resolveMattermostSendAttachmentMedia(params);
     const buttons = presentation ? buildMattermostPresentationButtons(presentation) : [];
 
     const result = await (
@@ -571,13 +594,11 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       replyToId,
       buttons: buttons.length > 0 ? buttons : undefined,
       attachmentText: typeof params.attachmentText === "string" ? params.attachmentText : undefined,
-      mediaUrl: attachmentMedia.mediaUrls[0],
+      mediaUrl,
       mediaLocalRoots: mediaLocalRoots ?? mediaAccess?.localRoots,
       mediaReadFile: mediaReadFile ?? mediaAccess?.readFile,
       ...(mediaAccess?.workspaceDir ? { workspaceDir: mediaAccess.workspaceDir } : {}),
-      requireMediaUpload: requiresMattermostMediaUpload(attachmentMedia.mediaUrls[0])
-        ? true
-        : undefined,
+      requireMediaUpload: requiresMattermostMediaUpload(mediaUrl) ? true : undefined,
     });
 
     return {
@@ -725,6 +746,33 @@ function collectMattermostAttachmentMedia(params: Record<string, unknown>): {
   };
 }
 
+function resolveMattermostSendAttachmentMedia(params: Record<string, unknown>): string | undefined {
+  const attachmentMedia = collectMattermostAttachmentMedia(params);
+  if (attachmentMedia.hasUnsupportedAttachmentPayload) {
+    throw new Error(
+      "Mattermost send attachments require media, mediaUrl, path, filePath, fileUrl, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported.",
+    );
+  }
+  if (attachmentMedia.mediaUrls.length > 1) {
+    throw new Error(
+      "Mattermost send supports one attachment per message; split multiple mediaUrls or attachments[] entries into separate sends.",
+    );
+  }
+  return attachmentMedia.mediaUrls[0];
+}
+
+type MattermostOutboundContext = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0];
+
+function createMattermostDeliveryProgressReporter(
+  onDeliveryResult: MattermostOutboundContext["onDeliveryResult"],
+) {
+  return onDeliveryResult
+    ? async (result: MattermostSendResult) => {
+        await onDeliveryResult(attachChannelToResult("mattermost", result));
+      }
+    : undefined;
+}
+
 const mattermostOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: chunkTextForOutbound,
@@ -769,7 +817,9 @@ const mattermostOutbound: ChannelOutboundAdapter = {
   },
   sendPayload: async (ctx) => {
     const buttons = readMattermostPresentationButtons(ctx.payload);
-    if (buttons?.length) {
+    const rawAttachmentText = readMattermostPayloadData(ctx.payload)?.attachmentText;
+    const attachmentText = typeof rawAttachmentText === "string" ? rawAttachmentText : undefined;
+    if (buttons?.length || attachmentText !== undefined) {
       const mediaUrl = resolvePayloadMediaUrls({
         ...ctx.payload,
         mediaUrl: ctx.payload.mediaUrl ?? ctx.mediaUrl,
@@ -787,7 +837,9 @@ const mattermostOutbound: ChannelOutboundAdapter = {
         ...(ctx.mediaAccess?.workspaceDir ? { workspaceDir: ctx.mediaAccess.workspaceDir } : {}),
         requireMediaUpload: requiresMattermostMediaUpload(mediaUrl) ? true : undefined,
         replyToId: ctx.replyToId ?? (ctx.threadId != null ? String(ctx.threadId) : undefined),
-        buttons,
+        buttons: buttons?.length ? buttons : undefined,
+        attachmentText,
+        onDeliveryResult: createMattermostDeliveryProgressReporter(ctx.onDeliveryResult),
       });
       return attachChannelToResult("mattermost", result);
     }
@@ -807,13 +859,14 @@ const mattermostOutbound: ChannelOutboundAdapter = {
   },
   ...createAttachedChannelResultAdapter({
     channel: "mattermost",
-    sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) =>
+    sendText: async ({ cfg, to, text, accountId, replyToId, threadId, onDeliveryResult }) =>
       await (
         await loadMattermostChannelRuntime()
       ).sendMessageMattermost(to, text, {
         cfg,
         accountId: accountId ?? undefined,
         replyToId: replyToId ?? (threadId != null ? String(threadId) : undefined),
+        onDeliveryResult: createMattermostDeliveryProgressReporter(onDeliveryResult),
       }),
     sendMedia: async ({
       cfg,
@@ -826,6 +879,7 @@ const mattermostOutbound: ChannelOutboundAdapter = {
       accountId,
       replyToId,
       threadId,
+      onDeliveryResult,
     }) =>
       await (
         await loadMattermostChannelRuntime()
@@ -838,6 +892,7 @@ const mattermostOutbound: ChannelOutboundAdapter = {
         ...(mediaAccess?.workspaceDir ? { workspaceDir: mediaAccess.workspaceDir } : {}),
         requireMediaUpload: requiresMattermostMediaUpload(mediaUrl) ? true : undefined,
         replyToId: replyToId ?? (threadId != null ? String(threadId) : undefined),
+        onDeliveryResult: createMattermostDeliveryProgressReporter(onDeliveryResult),
       }),
   }),
 };

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.test.ts
@@ -1,0 +1,154 @@
+// Mattermost tests cover native model-picker interaction dispatch ownership.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  authorize: vi.fn(),
+  buildEventPlan: vi.fn(),
+  buildModelsProviderData: vi.fn(),
+  dispatch: vi.fn(),
+  markDeliverySettled: vi.fn(),
+  parseContext: vi.fn(),
+  runDetachedWebhookWork: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/webhook-request-guards", () => ({
+  runDetachedWebhookWork: mocks.runDetachedWebhookWork,
+}));
+
+vi.mock("./model-picker.js", () => ({
+  buildMattermostAllowedModelRefs: () => new Set(["openai/gpt-5.4"]),
+  parseMattermostModelPickerContext: mocks.parseContext,
+  renderMattermostModelsPickerView: () => ({ text: "updated picker", buttons: [] }),
+  renderMattermostProviderPickerView: () => ({ text: "provider picker", buttons: [] }),
+  resolveMattermostModelPickerCurrentModel: () => "openai/gpt-5.4",
+}));
+
+vi.mock("./monitor-auth.js", () => ({
+  authorizeMattermostCommandInvocation: mocks.authorize,
+}));
+
+vi.mock("./monitor-event-plan.js", () => ({
+  buildMattermostEventPlan: mocks.buildEventPlan,
+}));
+
+vi.mock("./runtime-api.js", async () => {
+  const actual = await vi.importActual<typeof import("./runtime-api.js")>("./runtime-api.js");
+  return {
+    ...actual,
+    buildModelsProviderData: mocks.buildModelsProviderData,
+  };
+});
+
+import { createMattermostModelPickerInteractionHandler } from "./monitor-model-picker.js";
+import type { MattermostMonitorContext } from "./monitor-types.js";
+
+describe("Mattermost model-picker interaction dispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.parseContext.mockReturnValue({
+      action: "select",
+      ownerUserId: "user-1",
+      provider: "openai",
+      model: "gpt-5.4",
+      page: 0,
+    });
+    mocks.authorize.mockResolvedValue({
+      ok: true,
+      commandAuthorized: true,
+      channelInfo: { id: "channel-1", team_id: "team-1", type: "O" },
+      kind: "channel",
+      chatType: "channel",
+      channelName: "lifecycle",
+      channelDisplay: "Lifecycle",
+      roomLabel: "#lifecycle",
+    });
+    mocks.buildModelsProviderData.mockResolvedValue({ providers: [{ id: "openai" }] });
+    mocks.buildEventPlan.mockResolvedValue({
+      channelDisplay: "Lifecycle",
+      kind: "channel",
+      roomLabel: "#lifecycle",
+      route: { agentId: "main", dmScope: "per-peer", sessionKey: "agent:main:mm" },
+      thread: { sessionKey: "agent:main:mm", effectiveReplyToId: "root-1" },
+      to: "channel:channel-1",
+      finalizeContext: (context: Record<string, unknown>) => context,
+      createReplyPlan: () => ({
+        deliveryBarrier: {
+          trackDmChannelResolution: vi.fn(),
+          resolveTimeoutPolicy: vi.fn(),
+          markDeliverySettled: mocks.markDeliverySettled,
+        },
+        replyOptions: {},
+        replyPipeline: {},
+        tableMode: "off",
+        textLimit: 4000,
+      }),
+    });
+    mocks.dispatch.mockImplementation(async (params: Record<string, unknown>) => {
+      const dispatcherOptions = params.dispatcherOptions as
+        | { onDeliverySettled?: () => void }
+        | undefined;
+      dispatcherOptions?.onDeliverySettled?.();
+      return {};
+    });
+  });
+
+  it("reserves independent work before ack and observes terminal settlement", async () => {
+    let detachedRun: (() => Promise<void>) | undefined;
+    mocks.runDetachedWebhookWork.mockImplementation((run: () => Promise<void>) => {
+      detachedRun = run;
+      return Promise.resolve();
+    });
+    const updateModelPickerPost = vi.fn(async () => ({}));
+    const monitor = {
+      account: { accountId: "default", config: {} },
+      cfg: {},
+      core: {
+        channel: {
+          commands: { shouldHandleTextCommands: vi.fn(() => true) },
+          inbound: { dispatch: mocks.dispatch },
+          text: { hasControlCommand: vi.fn(() => true) },
+        },
+      },
+      pairing: { readAllowFromStore: vi.fn(async () => []) },
+      resources: {
+        resolveChannelInfo: vi.fn(async () => ({ id: "channel-1", type: "O" })),
+        updateModelPickerPost,
+      },
+      runtime: { error: vi.fn() },
+    } as unknown as MattermostMonitorContext;
+    const handler = createMattermostModelPickerInteractionHandler(monitor);
+
+    const response = await handler({
+      payload: {
+        channel_id: "channel-1",
+        post_id: "picker-post-1",
+        team_id: "team-1",
+        user_id: "user-1",
+      },
+      userName: "tester",
+      context: {},
+      post: { id: "picker-post-1", channel_id: "channel-1", message: "picker" },
+    });
+
+    expect(response).toEqual({});
+    expect(mocks.runDetachedWebhookWork).toHaveBeenCalledOnce();
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+    expect(detachedRun).toBeTypeOf("function");
+
+    await detachedRun?.();
+
+    expect(mocks.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "mattermost",
+        delivery: expect.objectContaining({ observeMessageSent: true }),
+        dispatcherOptions: expect.objectContaining({
+          onDeliverySettled: mocks.markDeliverySettled,
+        }),
+      }),
+    );
+    expect(mocks.markDeliverySettled).toHaveBeenCalledOnce();
+    expect(updateModelPickerPost).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "updated picker" }),
+    );
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.ts
@@ -1,4 +1,5 @@
 // Mattermost plugin module owns native model-picker interactions.
+import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import type { MattermostPost } from "./client.js";
 import type { MattermostInteractionResponse } from "./interactions.js";
 import {
@@ -82,6 +83,7 @@ export function createMattermostModelPickerInteractionHandler(
       },
       ctxPayload,
       delivery: {
+        observeMessageSent: true,
         // Picker-triggered confirmations should stay immediate.
         deliver: async (payload: ReplyPayload) => {
           const trimmedPayload = {
@@ -248,37 +250,37 @@ export function createMattermostModelPickerInteractionHandler(
       return { ephemeral_text: `That model is no longer available: ${targetModelRef}` };
     }
 
-    void (async () => {
-      try {
-        await runModelPickerCommand({
-          commandText: `/model ${targetModelRef}`,
-          commandAuthorized: auth.commandAuthorized,
-          eventPlan,
-          senderName: params.userName,
-          messageSid: buildMattermostModelPickerSelectMessageSid({
-            postId: params.payload.post_id,
-            provider: pickerState.provider,
-            model: pickerState.model,
-          }),
-        });
-        const currentModel = resolveMattermostModelPickerCurrentModel({
-          cfg,
-          route: modelSessionRoute,
-          data,
-          readConsistency: "latest",
-        });
-        const view = renderMattermostModelsPickerView({
-          ownerUserId: pickerState.ownerUserId,
-          data,
+    // The HTTP response returns before the command finishes. Reserve a new root
+    // while the request is still admitted so session dispatch survives that ack.
+    void runDetachedWebhookWork(async () => {
+      await runModelPickerCommand({
+        commandText: `/model ${targetModelRef}`,
+        commandAuthorized: auth.commandAuthorized,
+        eventPlan,
+        senderName: params.userName,
+        messageSid: buildMattermostModelPickerSelectMessageSid({
+          postId: params.payload.post_id,
           provider: pickerState.provider,
-          page: pickerState.page,
-          currentModel,
-        });
-        await updatePickerPost(view.text, view.buttons);
-      } catch (err) {
-        runtime.error?.(`mattermost model picker select failed: ${String(err)}`);
-      }
-    })();
+          model: pickerState.model,
+        }),
+      });
+      const currentModel = resolveMattermostModelPickerCurrentModel({
+        cfg,
+        route: modelSessionRoute,
+        data,
+        readConsistency: "latest",
+      });
+      const view = renderMattermostModelsPickerView({
+        ownerUserId: pickerState.ownerUserId,
+        data,
+        provider: pickerState.provider,
+        page: pickerState.page,
+        currentModel,
+      });
+      await updatePickerPost(view.text, view.buttons);
+    }).catch((err: unknown) => {
+      runtime.error?.(`mattermost model picker select failed: ${String(err)}`);
+    });
 
     return {};
   };

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -319,7 +319,44 @@ describe("sendMessageMattermost", () => {
     expect(result.receipt.parts).toHaveLength(1);
     expect(result.receipt.parts[0]?.platformMessageId).toBe("post-1");
     expect(result.receipt.parts[0]?.kind).toBe("text");
+    expect(result.content).toBe("hello");
     expect(mockState.loadConfig).not.toHaveBeenCalled();
+  });
+
+  it("reports the provider receipt before post-send bookkeeping can fail", async () => {
+    const events: string[] = [];
+    const onDeliveryResult = vi.fn(() => {
+      events.push("delivery");
+    });
+    mockState.createMattermostPost.mockResolvedValueOnce({
+      id: "post-final",
+      message: "provider-final",
+    });
+    mockState.recordActivity.mockImplementationOnce(() => {
+      events.push("activity");
+      throw new Error("activity store unavailable");
+    });
+
+    await expect(
+      sendMessageMattermost("channel:town-square", "requested text", {
+        cfg: TEST_CFG,
+        onDeliveryResult,
+      }),
+    ).rejects.toThrow("activity store unavailable");
+
+    expect(mockState.createMattermostPost).toHaveBeenCalledTimes(1);
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "post-final",
+        channelId: "town-square",
+        content: "provider-final",
+        receipt: expect.objectContaining({
+          primaryPlatformMessageId: "post-final",
+        }),
+      }),
+    );
+    expect(events).toStrictEqual(["delivery", "activity"]);
   });
 
   it("loads outbound media with trusted local roots before upload", async () => {

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -59,12 +59,15 @@ type MattermostSendOpts = {
   dmRetryOptions?: CreateDmChannelRetryOptions;
   /** Observe the bounded cache-miss DM channel resolution lifecycle. */
   onDmChannelResolution?: (resolution: PromiseLike<unknown>) => void;
+  /** Report the provider-finalized send before later fallible bookkeeping. */
+  onDeliveryResult?: (result: MattermostSendResult) => Promise<void> | void;
 };
 
-type MattermostSendResult = {
+export type MattermostSendResult = {
   messageId: string;
   channelId: string;
   receipt: MessageReceipt;
+  content: string;
 };
 
 const MATTERMOST_BOT_USER_CACHE_MAX_ENTRIES = 64;
@@ -491,10 +494,8 @@ export async function sendMessageMattermost(
     props,
   });
 
-  recordMattermostOutboundActivity(accountId);
   const messageId = post.id ?? "unknown";
-
-  return {
+  const result: MattermostSendResult = {
     messageId,
     channelId,
     receipt: createMattermostSendReceipt({
@@ -507,5 +508,11 @@ export async function sendMessageMattermost(
       }),
       replyToId: opts.replyToId,
     }),
+    content: post.message ?? message,
   };
+  // Core must persist the provider identity before local bookkeeping can fail,
+  // otherwise a durable retry can duplicate an already-visible post.
+  await opts.onDeliveryResult?.(result);
+  recordMattermostOutboundActivity(accountId);
+  return result;
 }

--- a/extensions/mattermost/src/outbound-delivery.test.ts
+++ b/extensions/mattermost/src/outbound-delivery.test.ts
@@ -1,9 +1,14 @@
 // Mattermost tests cover the shared outbound delivery path.
 import { sendDurableMessageBatch } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  addTestHook,
+  createEmptyPluginRegistry,
   createTestRegistry,
+  initializeGlobalHookRunner,
   releasePinnedPluginChannelRegistry,
+  resetGlobalHookRunner,
   setActivePluginRegistry,
+  type PluginHookRegistration,
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -18,16 +23,23 @@ import { mattermostPlugin } from "./channel.js";
 describe("Mattermost outbound delivery", () => {
   beforeEach(() => {
     sendMessageMattermostMock.mockReset();
-    sendMessageMattermostMock.mockResolvedValue({
-      messageId: "post-1",
-      channelId: "channel-1",
+    sendMessageMattermostMock.mockImplementation(async (_to, text, options) => {
+      const result = {
+        messageId: "post-1",
+        channelId: "CHAN1",
+        content: text,
+      };
+      await options?.onDeliveryResult?.(result);
+      return result;
     });
     setActivePluginRegistry(
       createTestRegistry([{ pluginId: "mattermost", plugin: mattermostPlugin, source: "test" }]),
     );
+    resetGlobalHookRunner();
   });
 
   afterEach(() => {
+    resetGlobalHookRunner();
     releasePinnedPluginChannelRegistry();
   });
 
@@ -56,5 +68,60 @@ describe("Mattermost outbound delivery", () => {
       expected,
       expect.objectContaining({ cfg: {} }),
     );
+  });
+
+  it("applies a message rewrite exactly once before the provider post", async () => {
+    const hookRegistry = createEmptyPluginRegistry();
+    const handler = vi.fn().mockResolvedValue({ content: "rewritten once" });
+    addTestHook({
+      registry: hookRegistry,
+      pluginId: "rewrite-policy",
+      hookName: "message_sending",
+      handler: handler as PluginHookRegistration["handler"],
+    });
+    initializeGlobalHookRunner(hookRegistry);
+
+    await sendDurableMessageBatch({
+      cfg: {},
+      channel: "mattermost",
+      to: "channel:CHAN1",
+      payloads: [{ text: "original" }],
+      accountId: "default",
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(sendMessageMattermostMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+      "channel:CHAN1",
+      "rewritten once",
+      expect.objectContaining({
+        accountId: "default",
+        onDeliveryResult: expect.any(Function),
+      }),
+    );
+  });
+
+  it("does not create a provider post when the shared hook cancels", async () => {
+    const hookRegistry = createEmptyPluginRegistry();
+    const handler = vi.fn().mockResolvedValue({ cancel: true });
+    addTestHook({
+      registry: hookRegistry,
+      pluginId: "cancel-policy",
+      hookName: "message_sending",
+      handler: handler as PluginHookRegistration["handler"],
+    });
+    initializeGlobalHookRunner(hookRegistry);
+
+    const result = await sendDurableMessageBatch({
+      cfg: {},
+      channel: "mattermost",
+      to: "channel:CHAN1",
+      payloads: [{ text: "do not send" }],
+      accountId: "default",
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(sendMessageMattermostMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ status: "suppressed", results: [] });
   });
 });


### PR DESCRIPTION
Closes #115827

## What Problem This Solves

Fixes two Mattermost delivery failures:

- native model-picker work could lose its confirmation after the interaction
  HTTP response was acknowledged;
- message-tool sends could create a visible Mattermost post without the shared
  outbound modifier/cancellation path or durable provider receipt ordering.

## Why This Change Was Made

The branch was rewritten to keep only the two owning-boundary repairs.

Model-picker selection reserves independent post-ack Gateway work before
returning the interaction response. Generic Mattermost message-tool sends now
prepare a provider payload for the existing core durable sender, so modifiers,
cancellation, retry state, and terminal observation stay core-owned.
Mattermost reports the provider-finalized post receipt and content before later
fallible local activity bookkeeping.

The rewrite does not migrate generalized inbound, slash-command, interaction,
draft, or reply settlement. It adds no core config, SDK, protocol, storage,
dependency, or migration surface.

## User Impact

Mattermost model-picker confirmations survive the request acknowledgement.
Message-tool rewrites run exactly once, cancellation creates no post, and a
successful provider post is not made retry-ambiguous by later bookkeeping
failure.

## Evidence

- Exact rewritten head: `c7f94d5d4dd2a0872516898c9037ba7cb66945c0`.
- 118 focused Mattermost tests passed across channel actions, model-picker
  dispatch, provider send ordering, and durable outbound delivery.
- Exact-head ephemeral mock-Gateway and mock Mattermost API proof passed:
  - interaction acknowledgement returned before independent dispatch finished;
  - queue work and terminal settlement completed exactly once before picker
    update;
  - the modifier ran once and the provider received one post containing
    `rewritten once`;
  - cancellation produced zero provider posts;
  - provider receipt/content and durable receipt were recorded before a
    simulated bookkeeping failure;
  - the outcome was `partial_failed` with `sentBeforeError: true`, and no
    duplicate post appeared.
- Targeted formatting, lint, and `git diff --check` passed.
- Fresh whole-branch autoreview reported no actionable findings.
- The original branch's disposable real Mattermost run remains reproduction
  evidence for the two defects; the exact rewritten head is additionally
  proven by the isolated Gateway/provider harness above.
