### PR TITLE
feat(tui): render plugin transient status

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -290,6 +290,48 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalledTimes(1);
   });
 
+  it("renders sanitized plugin status events without adding chat content", () => {
+    const { chatLog, tui, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-status" },
+    });
+
+    handleAgentEvent({
+      runId: "run-status",
+      stream: "example-plugin.status",
+      data: { text: "◇ Market\u001b[31m   clearing\u0000" },
+    });
+
+    expect(setActivityStatus).toHaveBeenCalledWith("◇ Market clearing");
+    expect(chatLog.addSystem).not.toHaveBeenCalled();
+    expect(chatLog.updateAssistant).not.toHaveBeenCalled();
+    expect(tui.requestRender).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores plugin status events after the owning run is finalized", () => {
+    const { state, tui, setActivityStatus, handleAgentEvent, handleChatEvent } =
+      createHandlersHarness({
+        state: { activeChatRunId: "run-status" },
+      });
+
+    handleChatEvent({
+      runId: "run-status",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+    });
+    setActivityStatus.mockClear();
+    tui.requestRender.mockClear();
+
+    handleAgentEvent({
+      runId: "run-status",
+      stream: "example-plugin.status",
+      data: { text: "late status" },
+    });
+
+    expect(setActivityStatus).not.toHaveBeenCalled();
+    expect(tui.requestRender).not.toHaveBeenCalled();
+  });
+
   it("shows running for a system-injected run that never went through submit", () => {
     const { state, tui, setActivityStatus, handleAgentEvent } = createHandlersHarness({
       state: { activeChatRunId: null },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -61,6 +61,7 @@ type EventHandlerBtwPresenter = {
 };
 
 const MAX_ABORT_DIAGNOSTIC_LENGTH = 160;
+const MAX_PLUGIN_STATUS_LENGTH = 180;
 
 function formatAbortDiagnostic(value: string | undefined): string | undefined {
   const diagnostic = sanitizeRenderableText(value ?? "")
@@ -594,6 +595,22 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const isKnownRun = isActiveRun || isPendingRun || isSessionRun || finalizedRuns.has(evt.runId);
     if (!isKnownRun) {
+      return;
+    }
+    if (evt.stream === "status" || evt.stream.endsWith(".status")) {
+      // Plugins can project transient run state without writing a system/chat
+      // message. Finalized runs cannot replace the terminal idle/error state.
+      if (!(isActiveRun || isPendingRun || isSessionRun)) {
+        return;
+      }
+      const status = sanitizeRenderableText(asString(evt.data?.text, ""))
+        .replace(/\s+/g, " ")
+        .trim();
+      if (!status) {
+        return;
+      }
+      setActivityStatus(truncateUtf16Safe(status, MAX_PLUGIN_STATUS_LENGTH));
+      tui.requestRender();
       return;
     }
     if (evt.stream === "tool") {


### PR DESCRIPTION
Related: #115826

## What Problem This Solves

Resolves a problem where plugins cannot show short-lived provider or workflow progress in the terminal UI without writing durable chat content or imitating a tool call.

## Why This Change Was Made

The TUI now treats a known run's generic plugin-owned `*.status` event as transient activity text. The text is sanitized, whitespace-normalized, capped at 180 UTF-16 code units, and ignored after finalization; it is never appended to the conversation.

This keeps the surface provider-neutral and uses the existing host-enforced plugin event namespace rather than adding a vendor-specific integration.

## User Impact

Terminal users can see honest, ephemeral progress from plugins while their transcript and model context remain unchanged. Plugin authors can use the existing agent-event API instead of inventing a sidecar or misrepresenting status as chat/tool output.

## Evidence

- `./node_modules/.bin/vitest run src/tui/tui-event-handlers.test.ts --reporter=dot`
  - 1 test file passed
  - 161 tests passed
- New regression coverage proves:
  - namespaced status text is sanitized and rendered;
  - no system or assistant chat content is added;
  - late status is ignored after the owning run is finalized.
- A real external plugin using `omnious-rfq-status.status` loaded successfully in two isolated OpenClaw profiles with both `allowPromptInjection` and `allowConversationAccess` disabled.
- `git diff --check`

AI-assisted: yes. I understand the run ownership, sanitization, and finalized-run boundaries in this change. The repository's `autoreview` skill was not available in this environment; I performed a focused manual review and ran the targeted TUI suite.
