### PR TITLE
feat(talk): support GPT-Live over gateway relay

### DIFF
--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -11,12 +11,12 @@ Talk mode covers five runtime shapes:
 - **Native macOS/iOS/Android Talk**: native speech recognition, Gateway chat, and `talk.speak` TTS. Apple Speech recognition on macOS/iOS may use network services; Android behavior depends on the installed speech service. Nodes advertise the `talk` capability and declare which `talk.*` commands they support.
 - **iOS Talk (realtime)**: client-owned WebRTC for OpenAI realtime configs that select `webrtc` transport or omit transport, including framed and frameless transcript/audio events. Explicit `gateway-relay`, `provider-websocket`, and non-OpenAI realtime configs stay on the Gateway-owned relay; non-realtime configs use the native speech loop.
 - **Browser Talk**: `talk.client.create` for client-owned `webrtc`/`provider-websocket` sessions, or `talk.session.create` for Gateway-owned `gateway-relay` sessions. `managed-room` is reserved for Gateway handoff and walkie-talkie rooms.
-- **Android Talk (realtime)**: Android uses Gateway-owned relay realtime when `talk.catalog` reports the realtime group ready and the configured model supports relay; it never opens a client-owned WebRTC session. Browser-only `gpt-live-*` models skip relay, so Android stays on native speech recognition, Gateway chat, and `talk.speak` just as it does when realtime is not ready.
+- **Android Talk (realtime)**: Android uses Gateway-owned relay realtime when `talk.catalog` reports the realtime group ready and the configured model passes the Android client gate; it never opens a client-owned WebRTC session. The Gateway now supports `gpt-live-*` relay sessions, but Android intentionally keeps those models on native speech recognition, Gateway chat, and `talk.speak` until the relay path is proven live from an Android device.
 - **Transcription-only clients**: `talk.session.create({ mode: "transcription", transport: "gateway-relay", brain: "none" })`, then `talk.session.appendAudio`, `talk.session.cancelTurn`, and `talk.session.close` for captions/dictation without an assistant voice response. One-shot uploaded voice notes still use the [media understanding](/nodes/media-understanding) audio path.
 
 Native Talk is a continuous loop: listen for speech, send the transcript to the model through the active session, wait for the response, then speak it via the configured Talk provider (`talk.speak`).
 
-Client-owned realtime Talk normally forwards provider tool calls through `talk.client.toolCall` instead of calling `chat.send` directly. GPT-Live delegates on a Gateway-owned sideband, and the Gateway binds each delegation to the browser connection that owns the Talk session. While a realtime consult is active, clients can call `talk.client.steer` or `talk.session.steer` to classify spoken input as `status`, `steer`, `cancel`, or `followup`; this includes GPT-Live delegations. Accepted steering queues into the active embedded run; rejected steering returns a reason such as `no_active_run`, `not_streaming`, or `compacting`. A newer GPT-Live spoken task also supersedes the running delegation. Gateway-relayed GPT-Live uses the normal relay consult path.
+Client-owned realtime Talk normally forwards provider tool calls through `talk.client.toolCall` instead of calling `chat.send` directly. GPT-Live WebRTC sessions delegate on a Gateway-owned sideband, and the Gateway binds each delegation to the browser or Gateway-relay Talk session that owns it. Backend WebSocket bridges use the normal relay consult path. While a realtime consult is active, clients can call `talk.client.steer` or `talk.session.steer` to classify spoken input as `status`, `steer`, `cancel`, or `followup`; this includes GPT-Live delegations. Accepted steering queues into the active embedded run; rejected steering returns a reason such as `no_active_run`, `not_streaming`, or `compacting`. A newer GPT-Live spoken task also supersedes the running delegation.
 
 Finalized realtime user and assistant utterances are always appended live to the active agent session, so later chat and voice turns share one history. Client-owned transports report their finalized transcripts with stable entry ids; Gateway relay sessions append the same events server-side. Provider sessions also receive the bounded realtime profile context used by Discord voice.
 
@@ -98,24 +98,23 @@ Supported keys: `voice` / `voice_id` / `voiceId`, `model` / `model_id` / `modelI
 }
 ```
 
-OpenAI Talk supports native GPT-Live through `https://api.openai.com/v1/live`.
-Set `talk.realtime.model` to
+OpenAI browser WebRTC and Gateway-relay Talk support native GPT-Live through
+`https://api.openai.com/v1/live`. Set `talk.realtime.model` to
 `gpt-live-1-codex` (recommended) or `gpt-live-1-boulder-alpha`; `gpt-live-1`
-and `gpt-live-1-mini` are not valid on this route. Browser WebRTC prefers a
-ChatGPT OAuth subscription profile and falls back to Platform API-key auth.
-Gateway relay and other backend bridges connect directly over the Frameless
-Bidi WebSocket and require Platform API-key auth, whose `/v1/live` access is
-currently
+and `gpt-live-1-mini` are not valid on this route. Browser and Gateway-relay
+WebRTC prefer a ChatGPT OAuth subscription profile and fall back to Platform
+API-key auth. Other backend bridges connect directly over the Frameless Bidi
+WebSocket and require Platform API-key auth, whose `/v1/live` access is currently
 [waitlist-gated](https://openai.com/form/gpt-live-1-in-the-api/).
 
 The quickest setup is the Control UI: **Settings → Talk**, pick **OpenAI** and
-a `gpt-live-*` model. Choose **WebRTC** for the browser-owned route or
-**Gateway relay** for the server-owned WebSocket route. WebRTC OAuth requires
-an OpenClaw auth profile created with
-`openclaw models auth login --provider openai`; an existing Codex CLI sign-in
-is not read. The WebRTC route also requires the bundled `openai` plugin in full
-registration mode. Its broker allows 8 concurrent sessions per Gateway, a
-30-minute session TTL, and 60-second single-use offer tokens.
+a `gpt-live-*` model. The OAuth prerequisite is an OpenClaw auth profile
+created with `openclaw models auth login --provider openai` — an existing
+Codex CLI sign-in is not read. GPT-Live also requires the bundled `openai`
+plugin registered in full mode; a restrictive `plugins.allow` list fails
+session creation with "OpenAI GPT-Live browser session broker is unavailable".
+Runtime bounds: 8 concurrent sessions per Gateway and a 30-minute session TTL.
+Browser sessions also use 60-second single-use offer tokens.
 
 GPT-Live accepts `alloy`, `ash`, `ballad`, `cedar`, `coral`, `echo`, `marin`,
 `sage`, `shimmer`, and `verse`. A `403 Voice session access denied` response is
@@ -123,12 +122,19 @@ overloaded: an invalid voice returns the same response. The legacy
 `chatgpt.com` backend route also returns `403`; OpenClaw uses the native
 `api.openai.com/v1/live` route instead.
 
-GPT-Live also works through Gateway relay and backend voice bridges, including
-Discord voice and Voice Call/telephony. Those paths keep the
-Platform API key on the Gateway and use one direct provider WebSocket; OpenClaw
-converts telephony G.711 u-law audio to and from GPT-Live's 24 kHz PCM contract.
-The browser WebRTC path remains available for ChatGPT OAuth sessions and keeps
-the OAuth token off the browser.
+| Consumer                    | GPT-Live status                                                         |
+| --------------------------- | ----------------------------------------------------------------------- |
+| Browser Talk                | Supported with client WebRTC and Gateway-owned sideband                 |
+| Gateway-relay Talk          | Supported with Gateway-owned WebRTC and sideband                        |
+| Discord bidirectional voice | Supported with the Platform-key backend WebSocket                       |
+| Voice Call and telephony    | Supported with the Platform-key backend WebSocket                       |
+| iOS client-owned Talk       | Pending                                                                 |
+| Android realtime Talk       | Pending an Android device live-proof flip; Android stays on native Talk |
+
+The Gateway-owned WebRTC route keeps OAuth and Platform credentials away from
+relay clients. Backend WebSocket paths keep the Platform key on the Gateway;
+OpenClaw converts telephony G.711 u-law audio to and from GPT-Live's 24 kHz PCM
+contract.
 
 For GA `gpt-realtime-2.1`, `gpt-realtime-2.1-mini`, and `gpt-realtime-2`
 browser sessions, Platform credentials remain preferred in this order: the
@@ -139,11 +145,12 @@ broker, so the OAuth token never reaches the browser. A configured Platform
 credential that cannot be resolved fails closed instead of silently falling
 through to OAuth.
 
-iOS client-owned WebRTC, Voice Call, Gateway relay, provider WebSocket
+iOS client-owned WebRTC, Voice Call, GA Gateway relay, provider WebSocket
 transports, Discord realtime voice, and Android realtime remain
 Platform-key-only. GA browser Talk keeps the existing client-owned data channel
 and `talk.client.toolCall` loop; only the credential owner and SDP exchange path
-change under OAuth.
+change under OAuth. GPT-Live Gateway relay prefers ChatGPT OAuth and falls back
+to waitlist-enabled Platform access.
 
 | Key                                      | Default                                    | Notes                                                                                                                                                                                                                                                                                   |
 | ---------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -142,28 +142,28 @@ explicit runtime config.
 
 ## OpenClaw feature coverage
 
-| OpenAI capability         | OpenClaw surface                                                                              | Status                                                               |
-| ------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Chat / Responses          | `openai/<model>` model provider                                                               | Yes                                                                  |
-| Codex subscription models | `openai/<model>` with OpenAI OAuth                                                            | Yes                                                                  |
-| Legacy Codex model refs   | old Codex model refs, `codex-cli/<model>`                                                     | Repaired by doctor to `openai/<model>`                               |
-| Codex app-server harness  | Codex-compatible HTTPS route with runtime unset/`auto`, or explicit `agentRuntime.id: codex`  | Yes                                                                  |
-| Server-side web search    | Native OpenAI Responses tool                                                                  | Yes, when web search is enabled and no other provider is pinned      |
-| Images                    | `image_generate`                                                                              | Yes                                                                  |
-| Videos                    | `video_generate`                                                                              | Yes                                                                  |
-| Text-to-speech            | `tts.provider: "openai"` / `tts`                                                              | Yes                                                                  |
-| Batch speech-to-text      | `tools.media.audio` / media understanding                                                     | Yes                                                                  |
-| Streaming speech-to-text  | Voice Call `streaming.provider: "openai"`                                                     | Yes                                                                  |
-| Realtime voice            | Voice Call `realtime.provider: "openai"` / Control UI Talk `talk.realtime.provider: "openai"` | Yes (Platform API key, or ChatGPT OAuth for browser GPT-Live WebRTC) |
-| Embeddings                | memory embedding provider                                                                     | Yes                                                                  |
+| OpenAI capability         | OpenClaw surface                                                                              | Status                                                                   |
+| ------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Chat / Responses          | `openai/<model>` model provider                                                               | Yes                                                                      |
+| Codex subscription models | `openai/<model>` with OpenAI OAuth                                                            | Yes                                                                      |
+| Legacy Codex model refs   | old Codex model refs, `codex-cli/<model>`                                                     | Repaired by doctor to `openai/<model>`                                   |
+| Codex app-server harness  | Codex-compatible HTTPS route with runtime unset/`auto`, or explicit `agentRuntime.id: codex`  | Yes                                                                      |
+| Server-side web search    | Native OpenAI Responses tool                                                                  | Yes, when web search is enabled and no other provider is pinned          |
+| Images                    | `image_generate`                                                                              | Yes                                                                      |
+| Videos                    | `video_generate`                                                                              | Yes                                                                      |
+| Text-to-speech            | `tts.provider: "openai"` / `tts`                                                              | Yes                                                                      |
+| Batch speech-to-text      | `tools.media.audio` / media understanding                                                     | Yes                                                                      |
+| Streaming speech-to-text  | Voice Call `streaming.provider: "openai"`                                                     | Yes                                                                      |
+| Realtime voice            | Voice Call `realtime.provider: "openai"` / Control UI Talk `talk.realtime.provider: "openai"` | Yes (Platform API key; ChatGPT OAuth for browser/Gateway-relay GPT-Live) |
+| Embeddings                | memory embedding provider                                                                     | Yes                                                                      |
 
 <Note>
 GA OpenAI Realtime voice goes through the public **OpenAI Platform Realtime
-API** and requires a Platform API key. GPT-Live browser WebRTC is the exception:
-its native `api.openai.com/v1/live` route prefers a ChatGPT OAuth profile and
-falls back to Platform API-key auth when that account has waitlist-gated access.
-GPT-Live Gateway relay and backend voice bridges use a direct Frameless Bidi
-WebSocket and require Platform API-key auth.
+API** and requires a Platform API key. Browser and Gateway-relay GPT-Live are
+the exceptions: their native `api.openai.com/v1/live` route prefers a ChatGPT
+OAuth profile and falls back to Platform API-key auth when that account has
+waitlist-gated access. Other GPT-Live backend voice bridges use the Frameless
+Bidi WebSocket and require Platform API-key auth.
 
 Platform auth is resolved in this order: configured realtime API key, `openai`
 API-key profile, then `OPENAI_API_KEY`. ChatGPT OAuth does not configure GA
@@ -902,7 +902,7 @@ compatibility fallback when the shared
     | Silence duration                       | `...openai.silenceDurationMs`                                           | `500`                |
     | Prefix padding                         | `...openai.prefixPaddingMs`                                             | `300`                |
     | Reasoning effort                       | `...openai.reasoningEffort`                                             | (unset)              |
-    | Auth                                   | `openai` auth profile, `...openai.apiKey`, or `OPENAI_API_KEY` | Platform API key; ChatGPT OAuth fallback for browser Talk only |
+    | Auth                                   | `openai` auth profile, `...openai.apiKey`, or `OPENAI_API_KEY` | Platform API key; ChatGPT OAuth for browser and Gateway-relay GPT-Live |
 
     Available built-in Realtime voices for `gpt-realtime-2.1`: `alloy`, `ash`,
     `ballad`, `coral`, `echo`, `sage`, `shimmer`, `verse`, `marin`, `cedar`.
@@ -932,18 +932,18 @@ compatibility fallback when the shared
     that cannot be resolved still fails closed; repair or remove that source
     before OAuth fallback can apply.
 
-    This OAuth fallback is browser-only. iOS client-owned WebRTC, Voice Call,
-    Gateway relay, provider WebSocket transports, Discord realtime voice, and
-    other backend Realtime bridges remain Platform-key-only.
+    This GA OAuth fallback is browser-only. iOS client-owned WebRTC, Voice
+    Call, Gateway relay, provider WebSocket transports, Discord realtime voice,
+    and other backend GA Realtime bridges remain Platform-key-only.
 
-    #### GPT-Live Talk
+    #### GPT-Live transport paths
 
-    GPT-Live has two native transport paths. Browser Talk WebRTC uses a ChatGPT
-    OAuth subscription profile (or an enrolled Platform API key) through the
-    Gateway offer broker. Gateway relay and backend voice bridges use the
-    Frameless Bidi `wss://api.openai.com/v1/live?model=...` endpoint directly,
-    with no browser or WebRTC provider connection, and require a Platform API
-    key. The direct wire contract matches public Codex realtime v3.
+    GPT-Live is supported for browser Talk and Gateway-owned `gateway-relay`
+    Talk using ChatGPT OAuth or an enrolled Platform API key. Both paths create
+    a WebRTC call at `/v1/live`; the Gateway relay uses a `werift` peer and keeps
+    media, credentials, and the authenticated sideband on the Gateway. Discord
+    and Voice Call use the Frameless Bidi
+    `wss://api.openai.com/v1/live?model=...` endpoint with Platform API-key auth.
 
     Use `gpt-live-1-codex` (recommended) or
     `gpt-live-1-boulder-alpha`. The values `gpt-live-1` and
@@ -983,9 +983,10 @@ compatibility fallback when the shared
     }
     ```
 
-    For the server-owned WebSocket path, select Gateway relay and configure a
-    Platform API key through `talk.realtime.providers.openai.apiKey`, an
-    `openai` API-key profile, or `OPENAI_API_KEY`:
+    For the Gateway-owned WebRTC path, select Gateway relay. It prefers the
+    OpenClaw ChatGPT OAuth profile and falls back to an enrolled Platform key
+    from `talk.realtime.providers.openai.apiKey`, an `openai` API-key profile,
+    or `OPENAI_API_KEY`:
 
     ```json5
     {
@@ -999,6 +1000,16 @@ compatibility fallback when the shared
     }
     ```
 
+    Browser Talk uses `transport: "webrtc"`.
+
+    | Consumer | GPT-Live status |
+    | --- | --- |
+    | Browser Talk | Supported with client WebRTC and Gateway-owned sideband |
+    | Gateway-relay Talk | Supported with Gateway-owned WebRTC and sideband |
+    | Discord bidirectional voice | Supported with the Platform-key backend WebSocket |
+    | Voice Call and telephony | Supported with the Platform-key backend WebSocket |
+    | iOS client-owned Talk | Pending |
+    | Android realtime Talk | Pending an Android device live-proof flip; Android stays on native Talk |
     <Warning>
     Platform API-key access to `/v1/live` is waitlist-gated and commonly returns
     `400 model_not_found` without enrollment. Use a ChatGPT OAuth profile, or request Platform access with the
@@ -1011,12 +1022,13 @@ compatibility fallback when the shared
     above, then verify that the selected ChatGPT OAuth profile and
     `chatgpt-account-id` belong to the same account.
 
-    The direct WebSocket bridge enables Gateway relay, Discord voice, and Voice
-    Call/telephony. OpenClaw converts G.711 u-law telephony
-    audio to and from GPT-Live's 24 kHz PCM stream. The Gateway routes provider
-    delegations through the configured OpenClaw agent and keeps the Platform
-    API key server-side. The browser WebRTC route remains available for
-    ChatGPT OAuth and never receives the OAuth token.
+    The Gateway-owned WebRTC route routes sideband delegations through the
+    configured OpenClaw agent and keeps OAuth or Platform credentials away from
+    relay clients. The direct WebSocket bridge enables Discord voice and Voice
+    Call/telephony with Platform auth; OpenClaw converts G.711 u-law telephony
+    audio to and from GPT-Live's 24 kHz PCM stream. Android's client-side gate
+    stays closed until the Gateway relay path has live proof from an Android
+    device.
 
     The WebRTC path creates a call on `api.openai.com/v1/live` and joins its
     sideband there. The backend path opens `/v1/live?model=...`, sends a
@@ -1030,6 +1042,7 @@ compatibility fallback when the shared
 
     ```bash
     OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_GPT_LIVE=1 node scripts/test-live.mjs -- extensions/openai/realtime-quicksilver.live.test.ts
+    OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_GPT_LIVE=1 node scripts/test-live.mjs -- extensions/openai/realtime-quicksilver-gateway-bridge.live.test.ts
     ```
 
     <Note>
@@ -1058,8 +1071,10 @@ compatibility fallback when the shared
     GPT-Live prefers ChatGPT OAuth when both auth modes are configured and
     falls back to Platform API-key access when the account has waitlist-gated
     `/v1/live` access.
-    Gateway relay and Voice Call backend realtime WebSocket bridges require
-    Platform credentials and support both GA and GPT-Live models.
+    GA Gateway relay and Voice Call backend realtime WebSocket bridges require
+    Platform credentials. GPT-Live Gateway relay instead uses Gateway-owned
+    WebRTC, preferring ChatGPT OAuth and falling back to waitlist-enabled
+    Platform access; Voice Call GPT-Live uses the Platform-key backend WebSocket.
     Maintainer live verification is available with
     `OPENAI_API_KEY=... GEMINI_API_KEY=... node --import tsx scripts/dev/realtime-talk-live-smoke.ts`;
     the OpenAI legs verify both the backend WebSocket bridge and the browser

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -73,6 +73,7 @@ export default definePluginEntry({
     api.registerRealtimeVoiceProvider(
       buildOpenAIRealtimeVoiceProvider({
         quicksilverBrowserSessionBroker: quicksilverSession?.broker,
+        logger: api.logger,
       }),
     );
     api.registerSpeechProvider(buildOpenAISpeechProvider());

--- a/extensions/openai/package.json
+++ b/extensions/openai/package.json
@@ -5,6 +5,8 @@
   "description": "OpenClaw OpenAI provider plugins",
   "type": "module",
   "dependencies": {
+    "libopus-wasm": "0.2.0",
+    "werift": "0.24.1",
     "ws": "8.21.1",
     "zod": "4.4.3"
   },

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.live.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.live.test.ts
@@ -1,0 +1,87 @@
+import { readCodexCliCredentialsCached } from "openclaw/plugin-sdk/provider-auth";
+import { describe, expect, it } from "vitest";
+import { resolveCodexAuthIdentity } from "./openai-chatgpt-auth-identity.js";
+import { OpenAIQuicksilverGatewayBridge } from "./realtime-quicksilver-gateway-bridge.js";
+import { resolveOpenAIChatGptSubscriptionAuth } from "./realtime-quicksilver-session.js";
+import type { OpenAIQuicksilverAuth } from "./realtime-quicksilver-wire.js";
+
+const LIVE_ENABLED =
+  process.env.OPENCLAW_LIVE_TEST === "1" && process.env.OPENCLAW_LIVE_GPT_LIVE === "1";
+const describeLive = LIVE_ENABLED ? describe : describe.skip;
+const LIVE_TIMEOUT_MS = 60_000;
+
+async function resolveLiveOAuthProfile(): Promise<
+  Extract<OpenAIQuicksilverAuth, { type: "oauth" }> | undefined
+> {
+  try {
+    const profile = await resolveOpenAIChatGptSubscriptionAuth({});
+    if (profile) {
+      return profile;
+    }
+  } catch (error) {
+    if (!(error instanceof Error) || error.name !== "AuthProfileMigrationRequiredError") {
+      throw error;
+    }
+  }
+  const credential = readCodexCliCredentialsCached({ allowKeychainPrompt: false, ttlMs: 0 });
+  if (!credential) {
+    return undefined;
+  }
+  const accountId =
+    credential.accountId ?? resolveCodexAuthIdentity({ accessToken: credential.access }).accountId;
+  return accountId ? { type: "oauth", token: credential.access, accountId } : undefined;
+}
+
+describeLive("OpenAI GPT-Live gateway WebRTC peer", () => {
+  it(
+    "creates a real call, joins sideband, and receives audio",
+    async ({ skip }) => {
+      const auth = await resolveLiveOAuthProfile();
+      if (!auth) {
+        skip("No ChatGPT OAuth profile is available");
+        return;
+      }
+
+      let ready!: () => void;
+      let audioObserved!: (source: string) => void;
+      let fail!: (error: Error) => void;
+      const readyResult = new Promise<void>((resolve) => {
+        ready = resolve;
+      });
+      const audioResult = new Promise<string>((resolve) => {
+        audioObserved = resolve;
+      });
+      const failureResult = new Promise<never>((_resolve, reject) => {
+        fail = reject;
+      });
+      const bridge = new OpenAIQuicksilverGatewayBridge({
+        providerConfig: {},
+        model: "gpt-live-1-codex",
+        voice: "marin",
+        instructions:
+          "This is a live transport check. Immediately say: OpenClaw gateway relay test OK.",
+        audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
+        onAudio: (audio) => {
+          if (audio.length > 0) {
+            audioObserved("decoded-pcm");
+          }
+        },
+        onClearAudio: () => undefined,
+        onReady: ready,
+        onError: fail,
+        runAgentConsult: async () => ({ text: "The live transport check is complete." }),
+        logger: { debug: () => undefined, warn: () => undefined },
+        resolveAuth: async () => auth,
+      });
+
+      try {
+        await bridge.connect();
+        await expect(Promise.race([readyResult, failureResult])).resolves.toBeUndefined();
+        await expect(Promise.race([audioResult, failureResult])).resolves.toBe("decoded-pcm");
+      } finally {
+        bridge.close();
+      }
+    },
+    LIVE_TIMEOUT_MS,
+  );
+});

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.live.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.live.test.ts
@@ -45,6 +45,7 @@ describeLive("OpenAI GPT-Live gateway WebRTC peer", () => {
       let ready!: () => void;
       let audioObserved!: (source: string) => void;
       let fail!: (error: Error) => void;
+      const eventTypes: string[] = [];
       const readyResult = new Promise<void>((resolve) => {
         ready = resolve;
       });
@@ -52,7 +53,7 @@ describeLive("OpenAI GPT-Live gateway WebRTC peer", () => {
         audioObserved = resolve;
       });
       const failureResult = new Promise<never>((_resolve, reject) => {
-        fail = reject;
+        fail = (error) => reject(new Error(`${error.message}; events=${eventTypes.join(",")}`));
       });
       const bridge = new OpenAIQuicksilverGatewayBridge({
         providerConfig: {},
@@ -67,6 +68,7 @@ describeLive("OpenAI GPT-Live gateway WebRTC peer", () => {
           }
         },
         onClearAudio: () => undefined,
+        onEvent: (event) => eventTypes.push(event.type),
         onReady: ready,
         onError: fail,
         runAgentConsult: async () => ({ text: "The live transport check is complete." }),

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -30,12 +30,17 @@ function createRelayTone(): Buffer {
 
 type TestableAudioPeer = {
   connected: boolean;
+  handleInboundRtp(packet: unknown): void;
   pendingAudio: Buffer;
   sequenceNumber: number;
   timestamp: number;
   sendNextAudioFrame(): void;
   takeNextRelayFrame(): Buffer;
   state: {
+    decoder: {
+      decode(packet: Uint8Array | null, options?: { maxFrameSize?: number }): Int16Array;
+      decodePacketLoss(frameSize?: number): Int16Array;
+    };
     peer: {
       connectionStateChange: {
         execute(state: "closed" | "disconnected"): void;
@@ -48,6 +53,88 @@ type TestableAudioPeer = {
     };
   };
 };
+
+type TestableGatewayBridge = {
+  sideband?: {
+    socket: FakeSocket;
+    requestIds: { realtimeSessionId: string; sessionId: string; threadId: string };
+  };
+  runDelegation(params: {
+    delegationId: string;
+    prompt: string;
+    runAgentConsult: (params: {
+      prompt: string;
+      signal?: AbortSignal;
+    }) => Promise<{ text: string }>;
+    signal: AbortSignal;
+  }): Promise<void>;
+};
+
+function createDelegationBridge(
+  runAgentConsult: (params: { prompt: string; signal?: AbortSignal }) => Promise<{ text: string }>,
+) {
+  const logger = { debug: vi.fn(), warn: vi.fn() };
+  const bridge = new OpenAIQuicksilverGatewayBridge({
+    providerConfig: {},
+    model: "gpt-live-1-codex",
+    voice: "marin",
+    audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
+    onAudio: vi.fn(),
+    onClearAudio: vi.fn(),
+    runAgentConsult,
+    logger,
+    resolveAuth: vi.fn(async () => ({
+      type: "oauth" as const,
+      token: "oauth-token",
+      accountId: "account-1",
+    })),
+  });
+  const socket = new FakeSocket("manual");
+  socket.readyState = 1;
+  const testBridge = bridge as unknown as TestableGatewayBridge;
+  testBridge.sideband = {
+    socket,
+    requestIds: {
+      realtimeSessionId: "realtime-session",
+      sessionId: "session",
+      threadId: "thread",
+    },
+  };
+  return { bridge, logger, socket, testBridge };
+}
+
+async function createInboundAudioHarness(params?: { onRtpPacket?: () => void }) {
+  const { RtpHeader, RtpPacket } = await import("werift");
+  const onAudio = vi.fn();
+  const onError = vi.fn();
+  const peer = await OpenAIQuicksilverAudioPeer.create({
+    callbacks: { onAudio, onError, onRtpPacket: params?.onRtpPacket },
+    iceServers: [],
+  });
+  const testPeer = peer as unknown as TestableAudioPeer;
+  const decodeOrder: Array<number | "plc"> = [];
+  const decode = vi.spyOn(testPeer.state.decoder, "decode").mockImplementation((packet) => {
+    decodeOrder.push(packet?.[0] ?? -1);
+    return new Int16Array(960 * 2);
+  });
+  const decodePacketLoss = vi
+    .spyOn(testPeer.state.decoder, "decodePacketLoss")
+    .mockImplementation(() => {
+      decodeOrder.push("plc");
+      return new Int16Array(960 * 2);
+    });
+  const packet = (sequenceNumber: number, ssrc = 1) =>
+    new RtpPacket(
+      new RtpHeader({
+        payloadType: 111,
+        sequenceNumber,
+        ssrc,
+        timestamp: (sequenceNumber * 960) >>> 0,
+      }),
+      Buffer.from([sequenceNumber & 0xff]),
+    );
+  return { decode, decodeOrder, decodePacketLoss, onAudio, onError, packet, peer, testPeer };
+}
 
 describe("GPT-Live werift audio peer", () => {
   it("creates a full-candidate Opus sendrecv offer without a data channel", async () => {
@@ -63,6 +150,42 @@ describe("GPT-Live werift audio peer", () => {
       expect(offer).toMatch(/^a=candidate:/m);
       expect(offer).toMatch(/^a=end-of-candidates$/m);
       expect(offer).not.toMatch(/^m=application /m);
+    } finally {
+      peer.close();
+    }
+  });
+
+  it("rejects a second SSRC before it can share Opus decoder state", async () => {
+    const { decodeOrder, decodePacketLoss, onError, packet, peer, testPeer } =
+      await createInboundAudioHarness();
+    try {
+      testPeer.handleInboundRtp(packet(10, 1));
+      testPeer.handleInboundRtp(packet(200, 2));
+
+      expect(decodeOrder).toEqual([10]);
+      expect(decodePacketLoss).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "GPT-Live WebRTC audio source changed unexpectedly" }),
+      );
+    } finally {
+      peer.close();
+    }
+  });
+
+  it("fails closed on a large same-SSRC sequence discontinuity", async () => {
+    const { decodeOrder, decodePacketLoss, onError, packet, peer, testPeer } =
+      await createInboundAudioHarness();
+    try {
+      testPeer.handleInboundRtp(packet(40_000));
+      testPeer.handleInboundRtp(packet(10_000));
+
+      expect(decodeOrder).toEqual([40_000 & 0xff]);
+      expect(decodePacketLoss).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "GPT-Live WebRTC RTP sequence changed unexpectedly",
+        }),
+      );
     } finally {
       peer.close();
     }
@@ -99,6 +222,94 @@ describe("GPT-Live werift audio peer", () => {
     } finally {
       encoder.free();
       decoder.free();
+    }
+  });
+
+  it("decodes reordered inbound RTP packets in sequence order", async () => {
+    const { decodeOrder, onAudio, onError, packet, peer, testPeer } =
+      await createInboundAudioHarness();
+    try {
+      testPeer.handleInboundRtp(packet(10));
+      testPeer.handleInboundRtp(packet(12));
+      expect(decodeOrder).toEqual([10]);
+      testPeer.handleInboundRtp(packet(11));
+
+      expect(decodeOrder).toEqual([10, 11, 12]);
+      expect(onAudio).toHaveBeenCalledTimes(3);
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      peer.close();
+    }
+  });
+
+  it("emits an Opus PLC frame for a dropped inbound RTP packet", async () => {
+    const { decodeOrder, decodePacketLoss, onAudio, onError, packet, peer, testPeer } =
+      await createInboundAudioHarness();
+    try {
+      for (const sequenceNumber of [20, 22, 23, 24, 25]) {
+        testPeer.handleInboundRtp(packet(sequenceNumber));
+      }
+
+      expect(decodeOrder).toEqual([20, "plc", 22, 23, 24, 25]);
+      expect(decodePacketLoss).toHaveBeenCalledWith(960);
+      expect(Buffer.concat(onAudio.mock.calls.map(([audio]) => audio))).toHaveLength(6 * 480 * 2);
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      peer.close();
+    }
+  });
+
+  it("flushes a short reordered tail after the 80 ms window", async () => {
+    const { decodeOrder, onError, packet, peer, testPeer } = await createInboundAudioHarness();
+    vi.useFakeTimers();
+    try {
+      for (const sequenceNumber of [40, 42, 43, 44]) {
+        testPeer.handleInboundRtp(packet(sequenceNumber));
+      }
+      await vi.advanceTimersByTimeAsync(79);
+      expect(decodeOrder).toEqual([40]);
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(decodeOrder).toEqual([40, "plc", 42, 43, 44]);
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      peer.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("discards inbound RTP packets that arrive beyond the reorder window", async () => {
+    const { decode, onError, packet, peer, testPeer } = await createInboundAudioHarness();
+    try {
+      for (const sequenceNumber of [30, 32, 33, 34, 35]) {
+        testPeer.handleInboundRtp(packet(sequenceNumber));
+      }
+      const decodedBeforeLatePacket = decode.mock.calls.length;
+      testPeer.handleInboundRtp(packet(31));
+
+      expect(decode).toHaveBeenCalledTimes(decodedBeforeLatePacket);
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      peer.close();
+    }
+  });
+
+  it("reports RTP activity callback failures through the peer error boundary", async () => {
+    const activityError = new Error("activity callback failed");
+    const onRtpPacket = vi.fn(() => {
+      throw activityError;
+    });
+    const { decode, onError, packet, peer, testPeer } = await createInboundAudioHarness({
+      onRtpPacket,
+    });
+    try {
+      testPeer.handleInboundRtp(packet(50));
+
+      expect(onRtpPacket).toHaveBeenCalledOnce();
+      expect(decode).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith(activityError);
+    } finally {
+      peer.close();
     }
   });
 
@@ -327,6 +538,58 @@ describe("GPT-Live gateway relay bridge", () => {
 
     await expect(connection).rejects.toThrow("sideband startup stopped");
     expect(socket.closed).toBe(true);
+  });
+
+  it("does not append failure text when the host cancels a delegation", async () => {
+    const abortError = new Error("The operation was aborted");
+    abortError.name = "AbortError";
+    const runAgentConsult = vi.fn(async () => {
+      throw abortError;
+    });
+    const { bridge, logger, socket, testBridge } = createDelegationBridge(runAgentConsult);
+    try {
+      await testBridge.runDelegation({
+        delegationId: "delegation-cancelled",
+        prompt: "stop this",
+        runAgentConsult,
+        signal: new AbortController().signal,
+      });
+
+      expect(socket.sent).toEqual([]);
+      expect(logger.warn).not.toHaveBeenCalled();
+    } finally {
+      bridge.close();
+    }
+  });
+
+  it("keeps the speakable failure response for genuine delegation errors", async () => {
+    const runAgentConsult = vi.fn(async () => {
+      throw new Error("workspace unavailable");
+    });
+    const { bridge, logger, socket, testBridge } = createDelegationBridge(runAgentConsult);
+    try {
+      await testBridge.runDelegation({
+        delegationId: "delegation-failed",
+        prompt: "do work",
+        runAgentConsult,
+        signal: new AbortController().signal,
+      });
+
+      expect(parseSent(socket)).toContainEqual({
+        type: "delegation.context.append",
+        delegation_item_id: "delegation-failed",
+        channel: "speakable",
+        content: [
+          {
+            type: "input_text",
+            text: "The agent task failed. Tell the user it did not complete and offer to try again.",
+          },
+        ],
+      });
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("workspace unavailable"));
+    } finally {
+      bridge.close();
+    }
   });
 
   it("bounds peer creation and closes a peer that resolves after the deadline", async () => {

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -28,6 +28,26 @@ function createRelayTone(): Buffer {
   return pcm;
 }
 
+type TestableAudioPeer = {
+  connected: boolean;
+  pendingAudio: Buffer;
+  sequenceNumber: number;
+  timestamp: number;
+  sendNextAudioFrame(): void;
+  state: {
+    peer: {
+      connectionStateChange: {
+        execute(state: "closed" | "disconnected"): void;
+      };
+    };
+    transceiver: {
+      sender: {
+        sendRtp(packet: unknown): Promise<void>;
+      };
+    };
+  };
+};
+
 describe("GPT-Live werift audio peer", () => {
   it("creates a full-candidate Opus sendrecv offer without a data channel", async () => {
     const peer = await OpenAIQuicksilverAudioPeer.create({
@@ -79,6 +99,85 @@ describe("GPT-Live werift audio peer", () => {
       encoder.free();
       decoder.free();
     }
+  });
+
+  it("consumes every audio tick while earlier RTP sends remain pending", async () => {
+    const peer = await OpenAIQuicksilverAudioPeer.create({
+      callbacks: { onAudio: vi.fn(), onError: vi.fn() },
+      iceServers: [],
+    });
+    const testPeer = peer as unknown as TestableAudioPeer;
+    const sendRtp = vi
+      .spyOn(testPeer.state.transceiver.sender, "sendRtp")
+      .mockImplementation(async () => await new Promise<void>(() => {}));
+    const frames = [Buffer.alloc(480 * 2, 1), Buffer.alloc(480 * 2, 2), Buffer.alloc(480 * 2, 3)];
+    const initialTimestamp = testPeer.timestamp;
+    const initialSequenceNumber = testPeer.sequenceNumber;
+    try {
+      peer.sendAudio(Buffer.concat(frames));
+      testPeer.connected = true;
+
+      for (let index = 0; index < frames.length; index += 1) {
+        testPeer.sendNextAudioFrame();
+        expect(testPeer.pendingAudio).toEqual(Buffer.concat(frames.slice(index + 1)));
+      }
+
+      expect(sendRtp).toHaveBeenCalledTimes(3);
+      const packets = sendRtp.mock.calls.map(
+        ([packet]) => packet as { header: { sequenceNumber: number; timestamp: number } },
+      );
+      expect(packets.map((packet) => packet.header.timestamp)).toEqual([
+        initialTimestamp,
+        (initialTimestamp + 960) >>> 0,
+        (initialTimestamp + 1_920) >>> 0,
+      ]);
+      expect(packets.map((packet) => packet.header.sequenceNumber)).toEqual([
+        initialSequenceNumber,
+        (initialSequenceNumber + 1) & 0xffff,
+        (initialSequenceNumber + 2) & 0xffff,
+      ]);
+    } finally {
+      peer.close();
+    }
+  });
+
+  it.each(["disconnected", "closed"] as const)(
+    "reports a terminal %s connection state",
+    async (connectionState) => {
+      const onError = vi.fn();
+      const peer = await OpenAIQuicksilverAudioPeer.create({
+        callbacks: { onAudio: vi.fn(), onError },
+        iceServers: [],
+      });
+      try {
+        (peer as unknown as TestableAudioPeer).state.peer.connectionStateChange.execute(
+          connectionState,
+        );
+        expect(onError).toHaveBeenCalledOnce();
+        expect(onError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: `GPT-Live WebRTC media connection ${connectionState}`,
+          }),
+        );
+      } finally {
+        peer.close();
+      }
+    },
+  );
+
+  it("suppresses terminal state callbacks after local close", async () => {
+    const onError = vi.fn();
+    const peer = await OpenAIQuicksilverAudioPeer.create({
+      callbacks: { onAudio: vi.fn(), onError },
+      iceServers: [],
+    });
+    const connectionStateChange = (peer as unknown as TestableAudioPeer).state.peer
+      .connectionStateChange;
+
+    peer.close();
+    connectionStateChange.execute("closed");
+
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it("constructs and offers under Bun without network access", ({ skip }) => {

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -6,6 +6,11 @@ import {
   type OpenAIQuicksilverAudioPeerContract,
 } from "./realtime-quicksilver-peer.runtime.js";
 import {
+  releaseOpenAIQuicksilverSession,
+  reserveOpenAIQuicksilverSession,
+} from "./realtime-quicksilver-session-limit.js";
+import { connectOpenAIQuicksilverSideband } from "./realtime-quicksilver-sideband.js";
+import {
   createCallResponse,
   emitSideband,
   FakeSocket,
@@ -93,9 +98,153 @@ describe("GPT-Live werift audio peer", () => {
     expect(result.stderr).toBe("");
     expect(result.status).toBe(0);
   });
+
+  it("releases the encoder and peer when decoder initialization fails", async () => {
+    const encoder = { free: vi.fn() };
+    vi.doMock("libopus-wasm", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("libopus-wasm")>();
+      return {
+        ...actual,
+        createEncoder: vi.fn(async () => encoder),
+        createDecoder: vi.fn(async () => {
+          throw new Error("decoder init failed");
+        }),
+      };
+    });
+    vi.resetModules();
+    const { RTCPeerConnection } = await import("werift");
+    const closePeer = vi.spyOn(RTCPeerConnection.prototype, "close");
+    try {
+      const { OpenAIQuicksilverAudioPeer: ReloadedPeer } =
+        await import("./realtime-quicksilver-peer.runtime.js");
+      await expect(
+        ReloadedPeer.create({
+          callbacks: { onAudio: vi.fn(), onError: vi.fn() },
+          iceServers: [],
+        }),
+      ).rejects.toThrow("decoder init failed");
+      expect(encoder.free).toHaveBeenCalledOnce();
+      expect(closePeer).toHaveBeenCalled();
+    } finally {
+      closePeer.mockRestore();
+      vi.doUnmock("libopus-wasm");
+      vi.resetModules();
+    }
+  });
+
+  it("releases partial peer resources when codec initialization is aborted", async () => {
+    const encoder = { free: vi.fn() };
+    const decoder = { free: vi.fn() };
+    let resolveDecoder: ((value: typeof decoder) => void) | undefined;
+    const createDecoder = vi.fn(
+      async () =>
+        await new Promise<typeof decoder>((resolve) => {
+          resolveDecoder = resolve;
+        }),
+    );
+    vi.doMock("libopus-wasm", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("libopus-wasm")>();
+      return {
+        ...actual,
+        createEncoder: vi.fn(async () => encoder),
+        createDecoder,
+      };
+    });
+    vi.resetModules();
+    const { RTCPeerConnection } = await import("werift");
+    const closePeer = vi.spyOn(RTCPeerConnection.prototype, "close");
+    const controller = new AbortController();
+    try {
+      const { OpenAIQuicksilverAudioPeer: ReloadedPeer } =
+        await import("./realtime-quicksilver-peer.runtime.js");
+      const creation = ReloadedPeer.create({
+        callbacks: { onAudio: vi.fn(), onError: vi.fn() },
+        iceServers: [],
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(createDecoder).toHaveBeenCalledOnce());
+      controller.abort(new Error("peer startup stopped"));
+      await vi.waitFor(() => expect(closePeer).toHaveBeenCalled());
+      expect(encoder.free).toHaveBeenCalledOnce();
+      resolveDecoder?.(decoder);
+      await expect(creation).rejects.toThrow("peer startup stopped");
+      expect(decoder.free).toHaveBeenCalledOnce();
+      expect(encoder.free).toHaveBeenCalledOnce();
+    } finally {
+      closePeer.mockRestore();
+      vi.doUnmock("libopus-wasm");
+      vi.resetModules();
+    }
+  });
 });
 
 describe("GPT-Live gateway relay bridge", () => {
+  it("closes a sideband that opens in the abort handoff", async () => {
+    const controller = new AbortController();
+    const socket = new FakeSocket("manual");
+    const connection = connectOpenAIQuicksilverSideband({
+      auth: { type: "api-key", token: "platform-key" },
+      createSocket: () => socket,
+      requestIds: {
+        realtimeSessionId: "realtime-session",
+        sessionId: "session",
+        threadId: "thread",
+      },
+      signal: controller.signal,
+      url: "wss://api.openai.com/v1/live/rtc_test",
+    });
+    socket.readyState = 1;
+    socket.emit("open");
+    controller.abort(new Error("sideband startup stopped"));
+
+    await expect(connection).rejects.toThrow("sideband startup stopped");
+    expect(socket.closed).toBe(true);
+  });
+
+  it("bounds peer creation and closes a peer that resolves after the deadline", async () => {
+    let resolvePeer: ((peer: OpenAIQuicksilverAudioPeerContract) => void) | undefined;
+    const peerPromise = new Promise<OpenAIQuicksilverAudioPeerContract>((resolve) => {
+      resolvePeer = resolve;
+    });
+    const closePeer = vi.fn();
+    const bridge = new OpenAIQuicksilverGatewayBridge({
+      providerConfig: {},
+      model: "gpt-live-1-codex",
+      voice: "marin",
+      audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      runAgentConsult: vi.fn(async () => ({ text: "done" })),
+      logger: { debug: vi.fn(), warn: vi.fn() },
+      resolveAuth: vi.fn(async () => ({
+        type: "oauth" as const,
+        token: "oauth-token",
+        accountId: "account-1",
+      })),
+      createPeer: vi.fn(() => peerPromise),
+      connectTimeoutMs: 5,
+    });
+
+    await expect(bridge.connect()).rejects.toMatchObject({ name: "TimeoutError" });
+    const reservationOwners = Array.from({ length: 8 }, () => ({}));
+    try {
+      for (const owner of reservationOwners) {
+        expect(() => reserveOpenAIQuicksilverSession(owner)).not.toThrow();
+      }
+    } finally {
+      for (const owner of reservationOwners) {
+        releaseOpenAIQuicksilverSession(owner);
+      }
+    }
+    resolvePeer?.({
+      createOffer: vi.fn(async () => "v=offer\r\n"),
+      applyAnswer: vi.fn(async () => undefined),
+      sendAudio: vi.fn(),
+      close: closePeer,
+    });
+    await vi.waitFor(() => expect(closePeer).toHaveBeenCalledOnce());
+  });
+
   it("signals, delegates through the injected runner, drops sideband audio, and tears down", async () => {
     let socket: FakeSocket | undefined;
     const applyAnswer = vi.fn(async () => undefined);

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -34,6 +34,7 @@ type TestableAudioPeer = {
   sequenceNumber: number;
   timestamp: number;
   sendNextAudioFrame(): void;
+  takeNextRelayFrame(): Buffer;
   state: {
     peer: {
       connectionStateChange: {
@@ -136,6 +137,34 @@ describe("GPT-Live werift audio peer", () => {
         (initialSequenceNumber + 1) & 0xffff,
         (initialSequenceNumber + 2) & 0xffff,
       ]);
+    } finally {
+      peer.close();
+    }
+  });
+
+  it("consumes and zero-pads a sub-frame audio tail on the next tick", async () => {
+    const peer = await OpenAIQuicksilverAudioPeer.create({
+      callbacks: { onAudio: vi.fn(), onError: vi.fn() },
+      iceServers: [],
+    });
+    const testPeer = peer as unknown as TestableAudioPeer;
+    const tail = Buffer.alloc(200);
+    tail.writeInt16LE(1_234, 0);
+    tail.writeInt16LE(-2_345, 2);
+    const takeNextRelayFrame = testPeer.takeNextRelayFrame.bind(testPeer);
+    let producedFrame: Buffer | undefined;
+    vi.spyOn(testPeer, "takeNextRelayFrame").mockImplementation(() => {
+      producedFrame = takeNextRelayFrame();
+      return producedFrame;
+    });
+    try {
+      peer.sendAudio(tail);
+      testPeer.connected = true;
+      testPeer.sendNextAudioFrame();
+
+      expect(testPeer.pendingAudio).toHaveLength(0);
+      expect(producedFrame?.subarray(0, tail.length)).toEqual(tail);
+      expect(producedFrame?.subarray(tail.length).every((byte) => byte === 0)).toBe(true);
     } finally {
       peer.close();
     }

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -1,0 +1,228 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import { OpenAIQuicksilverGatewayBridge } from "./realtime-quicksilver-gateway-bridge.js";
+import {
+  OpenAIQuicksilverAudioPeer,
+  type OpenAIQuicksilverAudioPeerContract,
+} from "./realtime-quicksilver-peer.runtime.js";
+import {
+  createCallResponse,
+  emitSideband,
+  FakeSocket,
+  parseSent,
+} from "./realtime-quicksilver.test-helpers.js";
+
+function createRelayTone(): Buffer {
+  const pcm = Buffer.alloc(480 * 2);
+  for (let index = 0; index < 480; index += 1) {
+    pcm.writeInt16LE(
+      Math.round(Math.sin((index / 24_000) * 2 * Math.PI * 440) * 12_000),
+      index * 2,
+    );
+  }
+  return pcm;
+}
+
+describe("GPT-Live werift audio peer", () => {
+  it("creates a full-candidate Opus sendrecv offer without a data channel", async () => {
+    const peer = await OpenAIQuicksilverAudioPeer.create({
+      callbacks: { onAudio: vi.fn(), onError: vi.fn() },
+      iceServers: [],
+    });
+    try {
+      const offer = await peer.createOffer();
+      expect(offer).toMatch(/^m=audio .*UDP\/TLS\/RTP\/SAVPF 111$/m);
+      expect(offer).toMatch(/^a=rtpmap:111 OPUS\/48000\/2$/im);
+      expect(offer).toMatch(/^a=sendrecv$/m);
+      expect(offer).toMatch(/^a=candidate:/m);
+      expect(offer).toMatch(/^a=end-of-candidates$/m);
+      expect(offer).not.toMatch(/^m=application /m);
+    } finally {
+      peer.close();
+    }
+  });
+
+  it("keeps raw Opus RTP payload framing and round-trips relay PCM", async () => {
+    const [
+      { Application, createDecoder, createEncoder },
+      { RtpHeader, RtpPacket, dePacketizeRtpPackets },
+    ] = await Promise.all([import("libopus-wasm"), import("werift")]);
+    const encoder = await createEncoder({
+      application: Application.Voip,
+      channels: 2,
+      sampleRate: 48_000,
+      frameSize: 960,
+    });
+    const decoder = await createDecoder({ channels: 2, sampleRate: 48_000 });
+    try {
+      const packet = encoder.encode(OpenAIQuicksilverAudioPeer.convertRelayPcm(createRelayTone()), {
+        frameSize: 960,
+      });
+      const rtp = new RtpPacket(
+        new RtpHeader({ payloadType: 111, sequenceNumber: 7, timestamp: 960 }),
+        Buffer.from(packet),
+      );
+      const depacketized = dePacketizeRtpPackets("opus", [rtp]).data;
+      expect(depacketized).toEqual(Buffer.from(packet));
+      const decoded = decoder.decode(depacketized, { maxFrameSize: 5_760 });
+      const relayPcm = OpenAIQuicksilverAudioPeer.convertQuicksilverPcm(decoded);
+      expect(relayPcm).toHaveLength(480 * 2);
+      expect(
+        Math.max(...Array.from({ length: 480 }, (_, i) => Math.abs(relayPcm.readInt16LE(i * 2)))),
+      ).toBeGreaterThan(1_000);
+    } finally {
+      encoder.free();
+      decoder.free();
+    }
+  });
+
+  it("constructs and offers under Bun without network access", ({ skip }) => {
+    const version = spawnSync("bun", ["--version"], { encoding: "utf8" });
+    if (version.error) {
+      skip("Bun is not installed");
+      return;
+    }
+    const result = spawnSync(
+      "bun",
+      [
+        "--eval",
+        'const { RTCPeerConnection, useOPUS } = await import("werift"); const peer = new RTCPeerConnection({ codecs: { audio: [useOPUS({ payloadType: 111 })], video: [] }, iceServers: [] }); peer.addTransceiver("audio", { direction: "sendrecv" }); const offer = await peer.createOffer(); await peer.setLocalDescription(offer); const sdp = peer.localDescription?.sdp ?? ""; if (!sdp.includes("a=sendrecv") || !sdp.includes("OPUS/48000/2")) throw new Error("invalid offer"); await peer.close();',
+      ],
+      { cwd: process.cwd(), encoding: "utf8", timeout: 30_000 },
+    );
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+  });
+});
+
+describe("GPT-Live gateway relay bridge", () => {
+  it("signals, delegates through the injected runner, drops sideband audio, and tears down", async () => {
+    let socket: FakeSocket | undefined;
+    const applyAnswer = vi.fn(async () => undefined);
+    const closePeer = vi.fn();
+    const createOffer = vi.fn(async () => "v=offer\r\n");
+    const peer: OpenAIQuicksilverAudioPeerContract = {
+      createOffer,
+      applyAnswer,
+      sendAudio: vi.fn(),
+      close: closePeer,
+    };
+    const runAgentConsult = vi.fn(async () => ({ text: "Delegated result" }));
+    const onAudio = vi.fn();
+    const onClearAudio = vi.fn();
+    const onEvent = vi.fn();
+    const onReady = vi.fn();
+    const onClose = vi.fn();
+    const bridge = new OpenAIQuicksilverGatewayBridge({
+      providerConfig: {},
+      model: "gpt-live-1-codex",
+      voice: "marin",
+      instructions: "Speak briefly.",
+      audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
+      onAudio,
+      onClearAudio,
+      onEvent,
+      onReady,
+      onClose,
+      runAgentConsult,
+      logger: { debug: vi.fn(), warn: vi.fn() },
+      resolveAuth: vi.fn(async () => ({
+        type: "oauth" as const,
+        token: "oauth-token",
+        accountId: "account-1",
+      })),
+      createPeer: vi.fn(async () => peer),
+      fetchImpl: vi.fn(async () => createCallResponse("v=answer\r\n", "rtc_bridge")),
+      webSocketFactory: () => {
+        socket = new FakeSocket();
+        return socket;
+      },
+    });
+
+    await bridge.connect();
+    if (!socket) {
+      throw new Error("expected sideband socket");
+    }
+    const connectedSocket = socket;
+    expect(createOffer).toHaveBeenCalledOnce();
+    expect(applyAnswer).toHaveBeenCalledWith("v=answer\r\n");
+    emitSideband(connectedSocket, {
+      type: "session.started",
+      session: { id: "rtc_bridge", expires_at: Math.floor(Date.now() / 1000) + 60 },
+    });
+    expect(onReady).toHaveBeenCalledOnce();
+
+    emitSideband(connectedSocket, { type: "output_audio.delta", delta: "ignored-media-copy" });
+    expect(onEvent).toHaveBeenCalledWith({ direction: "server", type: "output_audio.delta" });
+    expect(onAudio).not.toHaveBeenCalled();
+
+    emitSideband(connectedSocket, { type: "output_audio_buffer.cleared" });
+    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
+
+    emitSideband(connectedSocket, {
+      type: "delegation.created",
+      item: {
+        type: "delegation",
+        target: "client",
+        id: "delegation-1",
+        content: [{ type: "input_text", text: "Check the lights" }],
+      },
+    });
+    await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledOnce());
+    await vi.waitFor(() =>
+      expect(parseSent(connectedSocket)).toContainEqual({
+        type: "delegation.context.append",
+        delegation_item_id: "delegation-1",
+        channel: "speakable",
+        content: [{ type: "input_text", text: "Delegated result" }],
+      }),
+    );
+
+    bridge.close();
+    expect(closePeer).toHaveBeenCalledOnce();
+    expect(connectedSocket.closed).toBe(true);
+    expect(onClose).toHaveBeenCalledWith("completed");
+  });
+
+  it("treats a normal upstream sideband close as completion", async () => {
+    let socket: FakeSocket | undefined;
+    const onClose = vi.fn();
+    const onError = vi.fn();
+    const bridge = new OpenAIQuicksilverGatewayBridge({
+      providerConfig: {},
+      model: "gpt-live-1-codex",
+      voice: "marin",
+      audioFormat: { encoding: "pcm16", sampleRateHz: 24_000, channels: 1 },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onClose,
+      onError,
+      runAgentConsult: vi.fn(async () => ({ text: "done" })),
+      logger: { debug: vi.fn(), warn: vi.fn() },
+      resolveAuth: vi.fn(async () => ({
+        type: "oauth" as const,
+        token: "oauth-token",
+        accountId: "account-1",
+      })),
+      createPeer: vi.fn(async () => ({
+        createOffer: vi.fn(async () => "v=offer\r\n"),
+        applyAnswer: vi.fn(async () => undefined),
+        sendAudio: vi.fn(),
+        close: vi.fn(),
+      })),
+      fetchImpl: vi.fn(async () => createCallResponse("v=answer\r\n", "rtc_close")),
+      webSocketFactory: () => {
+        socket = new FakeSocket();
+        return socket;
+      },
+    });
+
+    await bridge.connect();
+    if (!socket) {
+      throw new Error("expected sideband socket");
+    }
+    socket.close(1000, "complete");
+    expect(onError).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledWith("completed");
+  });
+});

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -1,0 +1,466 @@
+// Gateway-owned GPT-Live WebRTC bridge: werift media peer plus OpenAI sideband control.
+import { randomUUID } from "node:crypto";
+import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
+import type {
+  RealtimeVoiceAgentConsultRunner,
+  RealtimeVoiceBridge,
+  RealtimeVoiceBridgeCreateRequest,
+} from "openclaw/plugin-sdk/realtime-voice";
+import WebSocket, { type RawData } from "ws";
+import {
+  buildOpenAIQuicksilverDelegationPrompt,
+  type OpenAIQuicksilverTranscriptEntry,
+} from "./realtime-quicksilver-instructions.js";
+import type {
+  OpenAIQuicksilverAudioPeerCallbacks,
+  OpenAIQuicksilverAudioPeerContract,
+} from "./realtime-quicksilver-peer.runtime.js";
+import {
+  releaseOpenAIQuicksilverSession,
+  reserveOpenAIQuicksilverSession,
+} from "./realtime-quicksilver-session-limit.js";
+import {
+  connectOpenAIQuicksilverSideband,
+  type OpenAIQuicksilverSocket,
+  type OpenAIQuicksilverSocketFactory,
+} from "./realtime-quicksilver-sideband.js";
+import {
+  boundOpenAIQuicksilverContextItems,
+  buildOpenAIQuicksilverSession,
+  chunkOpenAIQuicksilverAppendText,
+  createOpenAIQuicksilverCall,
+  parseOpenAIQuicksilverEvent,
+  type OpenAIQuicksilverAuth,
+  type OpenAIQuicksilverInboundEvent,
+  type OpenAIQuicksilverRequestIds,
+} from "./realtime-quicksilver-wire.js";
+
+const RELAY_SAMPLE_RATE = 24_000;
+const QUICKSILVER_SESSION_TTL_MS = 30 * 60_000;
+const QUICKSILVER_CONNECT_TIMEOUT_MS = 30_000;
+const WEBSOCKET_OPEN = 1;
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+type OpenAIQuicksilverBridgeConfig = RealtimeVoiceBridgeCreateRequest & {
+  model: string;
+  voice: string;
+  logger: Pick<PluginLogger, "debug" | "warn">;
+  resolveAuth: () => Promise<OpenAIQuicksilverAuth>;
+  createPeer?: (
+    callbacks: OpenAIQuicksilverAudioPeerCallbacks,
+  ) => Promise<OpenAIQuicksilverAudioPeerContract>;
+  fetchImpl?: typeof fetch;
+  webSocketFactory?: OpenAIQuicksilverSocketFactory;
+};
+
+type ActiveSideband = {
+  socket: OpenAIQuicksilverSocket;
+  requestIds: OpenAIQuicksilverRequestIds;
+};
+
+const CONSULT_FAILURE_TEXT =
+  "The agent task failed. Tell the user it did not complete and offer to try again.";
+
+function decodeTextFrame(data: RawData): string {
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString("utf8");
+  }
+  return data.toString("utf8");
+}
+
+function normalizeSidebandCloseReason(reason: Buffer | string | undefined): string {
+  const text = typeof reason === "string" ? reason : (reason?.toString("utf8") ?? "");
+  return text.replaceAll(/\s+/g, " ").trim().slice(0, 180);
+}
+
+function describeSidebandClose(code: number, reason: string): string {
+  return `OpenAI GPT-Live sideband closed (code ${code}${reason ? `: ${reason}` : ""})`;
+}
+
+function sendDelegationAppend(params: {
+  socket: OpenAIQuicksilverSocket;
+  delegationId: string;
+  text: string;
+  channel: "speakable" | "commentary";
+}): void {
+  for (const chunk of chunkOpenAIQuicksilverAppendText(params.text)) {
+    params.socket.send(
+      JSON.stringify({
+        type: "delegation.context.append",
+        delegation_item_id: params.delegationId,
+        channel: params.channel,
+        content: [{ type: "input_text", text: chunk }],
+      }),
+    );
+  }
+}
+
+/** Realtime voice bridge used only when a Gateway relay injects the agent runner. */
+export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
+  readonly supportsToolResultContinuation = false;
+  readonly supportsToolResultSuppression = false;
+
+  private abortController = new AbortController();
+  private activeDelegationId: string | undefined;
+  private connectPromise: Promise<void> | undefined;
+  private consultController: AbortController | undefined;
+  private connected = false;
+  private closed = false;
+  private closeNotified = false;
+  private peer: OpenAIQuicksilverAudioPeerContract | undefined;
+  private ready = false;
+  private sideband: ActiveSideband | undefined;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private transcript: OpenAIQuicksilverTranscriptEntry[] = [];
+  private partialTranscriptRole: "user" | "assistant" | undefined;
+
+  constructor(private readonly config: OpenAIQuicksilverBridgeConfig) {}
+
+  connect(): Promise<void> {
+    if (this.closed) {
+      return Promise.reject(new Error("GPT-Live gateway relay bridge is closed"));
+    }
+    this.connectPromise ??= this.connectInternal();
+    return this.connectPromise;
+  }
+
+  sendAudio(audio: Buffer): void {
+    this.peer?.sendAudio(audio);
+  }
+
+  setMediaTimestamp(_ts: number): void {}
+
+  sendUserMessage(text: string): void {
+    const delegationId = this.activeDelegationId;
+    const socket = this.sideband?.socket;
+    if (!delegationId || !socket || socket.readyState !== WEBSOCKET_OPEN || !text.trim()) {
+      return;
+    }
+    sendDelegationAppend({ socket, delegationId, text: text.trim(), channel: "speakable" });
+  }
+
+  submitToolResult(): void {
+    throw new Error("GPT-Live gateway relay uses provider-owned agent delegations");
+  }
+
+  acknowledgeMark(): void {}
+
+  close(): void {
+    this.teardown("completed");
+  }
+
+  isConnected(): boolean {
+    return this.connected && !this.closed;
+  }
+
+  private async connectInternal(): Promise<void> {
+    if (!this.config.runAgentConsult) {
+      throw new Error("OpenAI GPT-Live gateway relay requires the Gateway agent-consult runtime");
+    }
+    const audioFormat = this.config.audioFormat;
+    if (
+      audioFormat &&
+      (audioFormat.encoding !== "pcm16" ||
+        audioFormat.sampleRateHz !== RELAY_SAMPLE_RATE ||
+        audioFormat.channels !== 1)
+    ) {
+      throw new Error("OpenAI GPT-Live gateway relay requires mono PCM16 audio at 24 kHz");
+    }
+    reserveOpenAIQuicksilverSession(this);
+    const connectSignal = AbortSignal.any([
+      this.abortController.signal,
+      AbortSignal.timeout(QUICKSILVER_CONNECT_TIMEOUT_MS),
+    ]);
+    try {
+      const createPeer =
+        this.config.createPeer ??
+        (async (callbacks: OpenAIQuicksilverAudioPeerCallbacks) => {
+          const { OpenAIQuicksilverAudioPeer } =
+            await import("./realtime-quicksilver-peer.runtime.js");
+          return await OpenAIQuicksilverAudioPeer.create({ callbacks });
+        });
+      this.peer = await createPeer({
+        onAudio: (audio) => this.config.onAudio(audio),
+        onError: (error) => this.fail(error),
+        onRtpPacket: () => this.config.onEvent?.({ direction: "server", type: "output_audio.rtp" }),
+      });
+      const offerSdp = await this.peer.createOffer();
+      const auth = await this.config.resolveAuth();
+      const requestIds = {
+        realtimeSessionId: randomUUID(),
+        sessionId: randomUUID(),
+        threadId: randomUUID(),
+      };
+      const call = await createOpenAIQuicksilverCall({
+        auth,
+        requestIds,
+        sdp: offerSdp,
+        session: buildOpenAIQuicksilverSession({
+          model: this.config.model,
+          instructions: this.config.instructions,
+          voice: this.config.voice,
+        }),
+        signal: connectSignal,
+        fetchImpl: this.config.fetchImpl,
+      });
+      if (call.kind !== "gpt-live") {
+        throw new Error("GPT-Live gateway relay unexpectedly used the GA realtime call shape");
+      }
+      await this.peer.applyAnswer(call.answerSdp);
+      const createSocket =
+        this.config.webSocketFactory ??
+        ((url: string, options: Parameters<OpenAIQuicksilverSocketFactory>[1]) =>
+          new WebSocket(url, options));
+      const connected = await connectOpenAIQuicksilverSideband({
+        auth,
+        createSocket,
+        requestIds,
+        signal: connectSignal,
+        url: call.sidebandUrl,
+      });
+      if (connectSignal.aborted) {
+        connected.socket.close(1000, "session stopped");
+        throw connectSignal.reason;
+      }
+      this.sideband = { socket: connected.socket, requestIds };
+      this.attachSidebandHandlers(connected.socket);
+      const terminalEvent = connected.detachBuffer();
+      this.connected = true;
+      this.scheduleExpiry(QUICKSILVER_SESSION_TTL_MS);
+      for (const frame of connected.bufferedFrames) {
+        this.handleSidebandFrame(frame.data, frame.isBinary);
+      }
+      if (terminalEvent?.kind === "error") {
+        throw terminalEvent.error;
+      }
+      if (terminalEvent?.kind === "close") {
+        const reason = normalizeSidebandCloseReason(terminalEvent.reason);
+        throw new Error(describeSidebandClose(terminalEvent.code, reason));
+      }
+    } catch (error) {
+      this.releaseResources();
+      throw toError(error);
+    }
+  }
+
+  private attachSidebandHandlers(socket: OpenAIQuicksilverSocket): void {
+    socket.on("message", (data, isBinary) => this.handleSidebandFrame(data, isBinary));
+    socket.on("error", (error) => this.fail(error));
+    socket.on("close", (code, rawReason) => {
+      const closeCode = code ?? 1006;
+      const reason = normalizeSidebandCloseReason(rawReason);
+      if (!this.closed) {
+        if (closeCode === 1000) {
+          this.teardown("completed");
+        } else {
+          this.fail(new Error(describeSidebandClose(closeCode, reason)));
+        }
+      }
+    });
+  }
+
+  private handleSidebandFrame(data: RawData, isBinary: boolean): void {
+    if (isBinary) {
+      this.fail(new Error("OpenAI GPT-Live sideband returned an unexpected binary frame"));
+      return;
+    }
+    const payload = decodeTextFrame(data);
+    let eventType: string | undefined;
+    try {
+      const decoded = JSON.parse(payload) as Record<string, unknown>;
+      eventType = typeof decoded.type === "string" ? decoded.type : undefined;
+    } catch {
+      return;
+    }
+    if (eventType) {
+      // Audio belongs to the negotiated RTP track. Sideband audio is observable for proof,
+      // but never delivered twice into the relay sink.
+      this.config.onEvent?.({ direction: "server", type: eventType });
+      if (eventType === "output_audio_buffer.cleared") {
+        this.config.onClearAudio("barge-in");
+      }
+    }
+    const event = parseOpenAIQuicksilverEvent(payload);
+    if (event) {
+      this.handleSidebandEvent(event);
+    }
+  }
+
+  private handleSidebandEvent(event: OpenAIQuicksilverInboundEvent): void {
+    if (event.kind === "ignored") {
+      return;
+    }
+    if (event.kind === "unknown") {
+      this.config.logger.debug?.(`OpenAI GPT-Live ignored sideband event: ${event.eventType}`);
+      return;
+    }
+    if (event.kind === "session-started") {
+      if (event.expiresAt !== undefined) {
+        this.scheduleExpiry(
+          Math.min(QUICKSILVER_SESSION_TTL_MS, Math.max(0, event.expiresAt * 1000 - Date.now())),
+        );
+      }
+      if (!this.ready) {
+        this.ready = true;
+        this.config.onReady?.();
+      }
+      return;
+    }
+    if (event.kind === "transcript-delta" || event.kind === "transcript-done") {
+      this.appendTranscript(event);
+      this.config.onTranscript?.(event.role, event.text, event.kind === "transcript-done");
+      return;
+    }
+    if (event.kind === "error") {
+      const error = new Error(`OpenAI GPT-Live sideband error: ${event.message}`);
+      if (event.fatalAuth) {
+        this.fail(error);
+      } else {
+        this.config.logger.warn(error.message);
+      }
+      return;
+    }
+    this.startDelegation(event.id, event.prompt);
+  }
+
+  private appendTranscript(
+    event: Extract<OpenAIQuicksilverInboundEvent, { kind: "transcript-delta" | "transcript-done" }>,
+  ): void {
+    const last = this.transcript.at(-1);
+    if (event.kind === "transcript-delta") {
+      if (last?.role === event.role && this.partialTranscriptRole === event.role) {
+        last.text += event.text;
+      } else {
+        this.transcript.push({ role: event.role, text: event.text });
+      }
+      this.partialTranscriptRole = event.role;
+    } else {
+      if (last?.role === event.role && this.partialTranscriptRole === event.role) {
+        last.text = event.text;
+      } else {
+        this.transcript.push({ role: event.role, text: event.text });
+      }
+      this.partialTranscriptRole = undefined;
+    }
+    this.transcript = boundOpenAIQuicksilverContextItems(this.transcript);
+  }
+
+  private startDelegation(delegationId: string, input: string): void {
+    const runAgentConsult = this.config.runAgentConsult as RealtimeVoiceAgentConsultRunner;
+    if (!input.trim()) {
+      return;
+    }
+    const transcript = this.transcript;
+    this.transcript = [];
+    this.partialTranscriptRole = undefined;
+    this.consultController?.abort(new Error("GPT-Live delegation superseded"));
+    const controller = new AbortController();
+    this.consultController = controller;
+    this.activeDelegationId = delegationId;
+    const signal = AbortSignal.any([this.abortController.signal, controller.signal]);
+    const prompt = buildOpenAIQuicksilverDelegationPrompt({ input, transcript });
+    void this.runDelegation({ delegationId, prompt, runAgentConsult, signal }).finally(() => {
+      if (this.consultController === controller) {
+        this.consultController = undefined;
+        this.activeDelegationId = undefined;
+      }
+    });
+  }
+
+  private async runDelegation(params: {
+    delegationId: string;
+    prompt: string;
+    runAgentConsult: RealtimeVoiceAgentConsultRunner;
+    signal: AbortSignal;
+  }): Promise<void> {
+    let text: string;
+    try {
+      const result = await params.runAgentConsult({ prompt: params.prompt, signal: params.signal });
+      if (params.signal.aborted) {
+        return;
+      }
+      text = result.text;
+    } catch (error) {
+      if (params.signal.aborted) {
+        return;
+      }
+      this.config.logger.warn(
+        `OpenAI GPT-Live delegation consult failed: ${toError(error).message}`,
+      );
+      text = CONSULT_FAILURE_TEXT;
+    }
+    const socket = this.sideband?.socket;
+    if (!socket || socket.readyState !== WEBSOCKET_OPEN) {
+      return;
+    }
+    sendDelegationAppend({
+      socket,
+      delegationId: params.delegationId,
+      text,
+      channel: "speakable",
+    });
+  }
+
+  private scheduleExpiry(ttlMs: number): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(() => this.teardown("completed"), Math.max(0, ttlMs));
+    this.timer.unref?.();
+  }
+
+  private fail(error: Error): void {
+    if (this.closed) {
+      return;
+    }
+    this.config.onError?.(error);
+    this.teardown("error");
+  }
+
+  private teardown(reason: "completed" | "error"): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.releaseResources();
+    if (!this.closeNotified) {
+      this.closeNotified = true;
+      this.config.onClose?.(reason);
+    }
+  }
+
+  private releaseResources(): void {
+    releaseOpenAIQuicksilverSession(this);
+    this.connected = false;
+    this.abortController.abort(new Error("GPT-Live gateway relay bridge closed"));
+    this.consultController?.abort(new Error("GPT-Live delegation stopped"));
+    this.consultController = undefined;
+    this.activeDelegationId = undefined;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    const socket = this.sideband?.socket;
+    this.sideband = undefined;
+    if (socket?.readyState === WEBSOCKET_OPEN) {
+      try {
+        socket.send(JSON.stringify({ type: "session.close" }));
+      } catch {
+        // The sideband may close between readyState and send.
+      }
+    }
+    try {
+      socket?.close(1000, "session closed");
+    } catch {
+      // Socket teardown follows ownership release and is best effort.
+    }
+    this.peer?.close();
+    this.peer = undefined;
+  }
+}

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -326,6 +326,10 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
       }
       return;
     }
+    if (event.kind === "audio") {
+      // The negotiated RTP track owns audio delivery; sideband audio would duplicate it.
+      return;
+    }
     this.startDelegation(event.id, event.prompt);
   }
 

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -85,12 +85,20 @@ function describeSidebandClose(code: number, reason: string): string {
   return `OpenAI GPT-Live sideband closed (code ${code}${reason ? `: ${reason}` : ""})`;
 }
 
+function connectAbortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error("GPT-Live gateway relay startup stopped", { cause: signal.reason });
+}
+
 function waitForConnectStep<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
-  signal.throwIfAborted();
+  if (signal.aborted) {
+    return Promise.reject(connectAbortError(signal));
+  }
   return new Promise<T>((resolve, reject) => {
     const onAbort = () => {
       signal.removeEventListener("abort", onAbort);
-      reject(signal.reason);
+      reject(connectAbortError(signal));
     };
     signal.addEventListener("abort", onAbort, { once: true });
     promise.then(
@@ -98,9 +106,9 @@ function waitForConnectStep<T>(promise: Promise<T>, signal: AbortSignal): Promis
         signal.removeEventListener("abort", onAbort);
         resolve(value);
       },
-      (error) => {
+      (error: unknown) => {
         signal.removeEventListener("abort", onAbort);
-        reject(error);
+        reject(toError(error));
       },
     );
   });

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -51,9 +51,11 @@ type OpenAIQuicksilverBridgeConfig = RealtimeVoiceBridgeCreateRequest & {
   resolveAuth: () => Promise<OpenAIQuicksilverAuth>;
   createPeer?: (
     callbacks: OpenAIQuicksilverAudioPeerCallbacks,
+    signal: AbortSignal,
   ) => Promise<OpenAIQuicksilverAudioPeerContract>;
   fetchImpl?: typeof fetch;
   webSocketFactory?: OpenAIQuicksilverSocketFactory;
+  connectTimeoutMs?: number;
 };
 
 type ActiveSideband = {
@@ -81,6 +83,27 @@ function normalizeSidebandCloseReason(reason: Buffer | string | undefined): stri
 
 function describeSidebandClose(code: number, reason: string): string {
   return `OpenAI GPT-Live sideband closed (code ${code}${reason ? `: ${reason}` : ""})`;
+}
+
+function waitForConnectStep<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  signal.throwIfAborted();
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
 }
 
 function sendDelegationAppend(params: {
@@ -175,44 +198,62 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
     reserveOpenAIQuicksilverSession(this);
     const connectSignal = AbortSignal.any([
       this.abortController.signal,
-      AbortSignal.timeout(QUICKSILVER_CONNECT_TIMEOUT_MS),
+      AbortSignal.timeout(this.config.connectTimeoutMs ?? QUICKSILVER_CONNECT_TIMEOUT_MS),
     ]);
     try {
       const createPeer =
         this.config.createPeer ??
-        (async (callbacks: OpenAIQuicksilverAudioPeerCallbacks) => {
+        (async (callbacks: OpenAIQuicksilverAudioPeerCallbacks, signal: AbortSignal) => {
           const { OpenAIQuicksilverAudioPeer } =
             await import("./realtime-quicksilver-peer.runtime.js");
-          return await OpenAIQuicksilverAudioPeer.create({ callbacks });
+          return await OpenAIQuicksilverAudioPeer.create({ callbacks, signal });
         });
-      this.peer = await createPeer({
-        onAudio: (audio) => this.config.onAudio(audio),
-        onError: (error) => this.fail(error),
-        onRtpPacket: () => this.config.onEvent?.({ direction: "server", type: "output_audio.rtp" }),
-      });
-      const offerSdp = await this.peer.createOffer();
-      const auth = await this.config.resolveAuth();
+      const peerPromise = createPeer(
+        {
+          onAudio: (audio) => this.config.onAudio(audio),
+          onError: (error) => this.fail(error),
+          onRtpPacket: () =>
+            this.config.onEvent?.({ direction: "server", type: "output_audio.rtp" }),
+        },
+        connectSignal,
+      );
+      // A factory can finish after the deadline. Close that late peer because the
+      // timed-out connect path can no longer adopt or release it synchronously.
+      void peerPromise.then(
+        (peer) => {
+          if (connectSignal.aborted || this.closed) {
+            peer.close();
+          }
+        },
+        () => undefined,
+      );
+      this.peer = await waitForConnectStep(peerPromise, connectSignal);
+      const offerSdp = await waitForConnectStep(this.peer.createOffer(), connectSignal);
+      const auth = await waitForConnectStep(this.config.resolveAuth(), connectSignal);
       const requestIds = {
         realtimeSessionId: randomUUID(),
         sessionId: randomUUID(),
         threadId: randomUUID(),
       };
-      const call = await createOpenAIQuicksilverCall({
-        auth,
-        requestIds,
-        sdp: offerSdp,
-        session: buildOpenAIQuicksilverSession({
-          model: this.config.model,
-          instructions: this.config.instructions,
-          voice: this.config.voice,
+      const call = await waitForConnectStep(
+        createOpenAIQuicksilverCall({
+          auth,
+          requestIds,
+          sdp: offerSdp,
+          session: buildOpenAIQuicksilverSession({
+            model: this.config.model,
+            instructions: this.config.instructions,
+            voice: this.config.voice,
+          }),
+          signal: connectSignal,
+          fetchImpl: this.config.fetchImpl,
         }),
-        signal: connectSignal,
-        fetchImpl: this.config.fetchImpl,
-      });
+        connectSignal,
+      );
       if (call.kind !== "gpt-live") {
         throw new Error("GPT-Live gateway relay unexpectedly used the GA realtime call shape");
       }
-      await this.peer.applyAnswer(call.answerSdp);
+      await waitForConnectStep(this.peer.applyAnswer(call.answerSdp), connectSignal);
       const createSocket =
         this.config.webSocketFactory ??
         ((url: string, options: Parameters<OpenAIQuicksilverSocketFactory>[1]) =>

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -44,6 +44,18 @@ function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+function isAbortLikeError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const value = error as { code?: unknown; message?: unknown; name?: unknown };
+  return (
+    value.name === "AbortError" ||
+    value.code === "ABORT_ERR" ||
+    value.message === "This operation was aborted"
+  );
+}
+
 type OpenAIQuicksilverBridgeConfig = RealtimeVoiceBridgeCreateRequest & {
   model: string;
   voice: string;
@@ -440,7 +452,9 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
       }
       text = result.text;
     } catch (error) {
-      if (params.signal.aborted) {
+      // Host steering aborts the runner's registered chat signal, not this bridge-owned signal.
+      // Abort-shaped rejection is therefore the runner boundary's cancellation marker.
+      if (params.signal.aborted || isAbortLikeError(error)) {
         return;
       }
       this.config.logger.warn(

--- a/extensions/openai/realtime-quicksilver-peer.runtime.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.ts
@@ -77,8 +77,10 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
   static async create(params: {
     callbacks: OpenAIQuicksilverAudioPeerCallbacks;
     iceServers?: Array<{ urls: string | string[]; username?: string; credential?: string }>;
+    signal?: AbortSignal;
   }): Promise<OpenAIQuicksilverAudioPeer> {
     const [werift, libopus] = await Promise.all([import("werift"), import("libopus-wasm")]);
+    params.signal?.throwIfAborted();
     const peer = new werift.RTCPeerConnection({
       codecs: {
         audio: [werift.useOPUS({ payloadType: 111 })],
@@ -87,26 +89,54 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
       ...(params.iceServers ? { iceServers: params.iceServers } : {}),
     });
     const transceiver = peer.addTransceiver("audio", { direction: "sendrecv" });
-    const [encoder, decoder] = await Promise.all([
-      libopus.createEncoder({
+    let encoder: LibopusEncoder | undefined;
+    let decoder: LibopusDecoder | undefined;
+    let encoderFreed = false;
+    let decoderFreed = false;
+    let peerClosed = false;
+    const cleanup = async () => {
+      if (encoder && !encoderFreed) {
+        encoderFreed = true;
+        encoder.free();
+      }
+      if (decoder && !decoderFreed) {
+        decoderFreed = true;
+        decoder.free();
+      }
+      if (!peerClosed) {
+        peerClosed = true;
+        await peer.close().catch(() => undefined);
+      }
+    };
+    const onAbort = () => void cleanup();
+    params.signal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      encoder = await libopus.createEncoder({
         application: libopus.Application.Voip,
         channels: QUICKSILVER_CHANNELS,
         sampleRate: QUICKSILVER_SAMPLE_RATE,
         frameSize: OPUS_FRAME_SAMPLES,
-      }),
-      libopus.createDecoder({
+      });
+      params.signal?.throwIfAborted();
+      decoder = await libopus.createDecoder({
         channels: QUICKSILVER_CHANNELS,
         sampleRate: QUICKSILVER_SAMPLE_RATE,
-      }),
-    ]);
-    return new OpenAIQuicksilverAudioPeer({
-      callbacks: params.callbacks,
-      decoder,
-      encoder,
-      peer,
-      transceiver,
-      werift,
-    });
+      });
+      params.signal?.throwIfAborted();
+      params.signal?.removeEventListener("abort", onAbort);
+      return new OpenAIQuicksilverAudioPeer({
+        callbacks: params.callbacks,
+        decoder,
+        encoder,
+        peer,
+        transceiver,
+        werift,
+      });
+    } catch (error) {
+      params.signal?.removeEventListener("abort", onAbort);
+      await cleanup();
+      throw error;
+    }
   }
 
   static convertRelayPcm(pcm24kMono: Buffer): Int16Array {

--- a/extensions/openai/realtime-quicksilver-peer.runtime.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.ts
@@ -149,7 +149,6 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
 
   private connected = false;
   private closed = false;
-  private mediaSendPending = false;
   private mediaTimer: ReturnType<typeof setInterval> | undefined;
   private pendingAudio = Buffer.alloc(0);
   private sequenceNumber = randomInt(0x1_0000);
@@ -168,11 +167,19 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
   ) {
     state.peer.onTrack.subscribe((track) => this.attachInboundTrack(track));
     state.peer.connectionStateChange.subscribe((connectionState) => {
+      if (this.closed) {
+        return;
+      }
       if (connectionState === "connected") {
         this.connected = true;
         this.startMediaPump();
-      } else if (connectionState === "failed") {
-        this.state.callbacks.onError(new Error("GPT-Live WebRTC media connection failed"));
+      } else if (["failed", "disconnected", "closed"].includes(connectionState)) {
+        this.connected = false;
+        // werift-ice 0.2.2 exits consent polling after setting disconnected
+        // (lib/ice/src/ice.js:289), so recovery requires an explicit ICE restart.
+        this.state.callbacks.onError(
+          new Error(`GPT-Live WebRTC media connection ${connectionState}`),
+        );
       }
     });
   }
@@ -258,7 +265,7 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
   }
 
   private sendNextAudioFrame(): void {
-    if (!this.connected || this.closed || this.mediaSendPending) {
+    if (!this.connected || this.closed) {
       return;
     }
     const hasRelayAudio = this.pendingAudio.length >= RELAY_FRAME_BYTES;
@@ -283,15 +290,11 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
       );
       this.sequenceNumber = (this.sequenceNumber + 1) & 0xffff;
       this.timestamp = (this.timestamp + OPUS_FRAME_SAMPLES) >>> 0;
-      this.mediaSendPending = true;
-      void this.state.transceiver.sender
-        .sendRtp(rtp)
-        .catch((error: unknown) => {
-          this.state.callbacks.onError(toError(error));
-        })
-        .finally(() => {
-          this.mediaSendPending = false;
-        });
+      // werift queues encrypted UDP synchronously before sendRtp yields
+      // (rtpSender.js:538; transport/dtls.js:455), preserving per-tick order.
+      void this.state.transceiver.sender.sendRtp(rtp).catch((error: unknown) => {
+        this.state.callbacks.onError(toError(error));
+      });
     } catch (error) {
       this.state.callbacks.onError(toError(error));
     }

--- a/extensions/openai/realtime-quicksilver-peer.runtime.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.ts
@@ -1,0 +1,269 @@
+// Lazy GPT-Live media runtime: werift peer plus WASM Opus framing and PCM conversion.
+import { randomInt } from "node:crypto";
+import { resamplePcm } from "openclaw/plugin-sdk/realtime-voice";
+
+const QUICKSILVER_SAMPLE_RATE = 48_000;
+const RELAY_SAMPLE_RATE = 24_000;
+const QUICKSILVER_CHANNELS = 2;
+const OPUS_FRAME_SAMPLES = 960;
+const OPUS_FRAME_DURATION_MS = 20;
+const RELAY_FRAME_SAMPLES = 480;
+const RELAY_FRAME_BYTES = RELAY_FRAME_SAMPLES * 2;
+const MAX_PENDING_RELAY_FRAMES = 250;
+
+type WeriftModule = typeof import("werift");
+type LibopusModule = typeof import("libopus-wasm");
+type WeriftPeerConnection = InstanceType<WeriftModule["RTCPeerConnection"]>;
+type WeriftTransceiver = ReturnType<WeriftPeerConnection["addTransceiver"]>;
+type WeriftTrack = Parameters<WeriftPeerConnection["onTrack"]["subscribe"]>[0] extends (
+  track: infer T,
+) => unknown
+  ? T
+  : never;
+type LibopusEncoder = Awaited<ReturnType<LibopusModule["createEncoder"]>>;
+type LibopusDecoder = Awaited<ReturnType<LibopusModule["createDecoder"]>>;
+
+export type OpenAIQuicksilverAudioPeerCallbacks = {
+  onAudio: (audio: Buffer) => void;
+  onError: (error: Error) => void;
+  onRtpPacket?: () => void;
+};
+
+export type OpenAIQuicksilverAudioPeerContract = {
+  createOffer(): Promise<string>;
+  applyAnswer(answerSdp: string): Promise<void>;
+  sendAudio(audio: Buffer): void;
+  close(): void;
+};
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function pcmBufferToInt16(pcm: Buffer): Int16Array {
+  const samples = new Int16Array(Math.floor(pcm.length / 2));
+  for (let index = 0; index < samples.length; index += 1) {
+    samples[index] = pcm.readInt16LE(index * 2);
+  }
+  return samples;
+}
+
+function convertRelayPcmToQuicksilverPcm(pcm24kMono: Buffer): Int16Array {
+  const mono48k = pcmBufferToInt16(
+    resamplePcm(pcm24kMono, RELAY_SAMPLE_RATE, QUICKSILVER_SAMPLE_RATE),
+  );
+  const stereo48k = new Int16Array(mono48k.length * QUICKSILVER_CHANNELS);
+  for (let index = 0; index < mono48k.length; index += 1) {
+    const sample = mono48k[index] ?? 0;
+    stereo48k[index * 2] = sample;
+    stereo48k[index * 2 + 1] = sample;
+  }
+  return stereo48k;
+}
+
+function convertQuicksilverPcmToRelayPcm(pcm48kStereo: Int16Array): Buffer {
+  const frameCount = Math.floor(pcm48kStereo.length / QUICKSILVER_CHANNELS);
+  const mono48k = Buffer.alloc(frameCount * 2);
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    const left = pcm48kStereo[frame * 2] ?? 0;
+    const right = pcm48kStereo[frame * 2 + 1] ?? 0;
+    mono48k.writeInt16LE(Math.round((left + right) / 2), frame * 2);
+  }
+  return resamplePcm(mono48k, QUICKSILVER_SAMPLE_RATE, RELAY_SAMPLE_RATE);
+}
+
+/** Pure-TypeScript WebRTC media peer with a WASM-only Opus codec. */
+export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerContract {
+  static async create(params: {
+    callbacks: OpenAIQuicksilverAudioPeerCallbacks;
+    iceServers?: Array<{ urls: string | string[]; username?: string; credential?: string }>;
+  }): Promise<OpenAIQuicksilverAudioPeer> {
+    const [werift, libopus] = await Promise.all([import("werift"), import("libopus-wasm")]);
+    const peer = new werift.RTCPeerConnection({
+      codecs: {
+        audio: [werift.useOPUS({ payloadType: 111 })],
+        video: [],
+      },
+      ...(params.iceServers ? { iceServers: params.iceServers } : {}),
+    });
+    const transceiver = peer.addTransceiver("audio", { direction: "sendrecv" });
+    const [encoder, decoder] = await Promise.all([
+      libopus.createEncoder({
+        application: libopus.Application.Voip,
+        channels: QUICKSILVER_CHANNELS,
+        sampleRate: QUICKSILVER_SAMPLE_RATE,
+        frameSize: OPUS_FRAME_SAMPLES,
+      }),
+      libopus.createDecoder({
+        channels: QUICKSILVER_CHANNELS,
+        sampleRate: QUICKSILVER_SAMPLE_RATE,
+      }),
+    ]);
+    return new OpenAIQuicksilverAudioPeer({
+      callbacks: params.callbacks,
+      decoder,
+      encoder,
+      peer,
+      transceiver,
+      werift,
+    });
+  }
+
+  static convertRelayPcm(pcm24kMono: Buffer): Int16Array {
+    return convertRelayPcmToQuicksilverPcm(pcm24kMono);
+  }
+
+  static convertQuicksilverPcm(pcm48kStereo: Int16Array): Buffer {
+    return convertQuicksilverPcmToRelayPcm(pcm48kStereo);
+  }
+
+  private connected = false;
+  private closed = false;
+  private mediaSendPending = false;
+  private mediaTimer: ReturnType<typeof setInterval> | undefined;
+  private pendingAudio = Buffer.alloc(0);
+  private sequenceNumber = randomInt(0x1_0000);
+  private subscribedTracks = new Set<string>();
+  private timestamp = randomInt(0x1_0000_0000);
+
+  private constructor(
+    private readonly state: {
+      callbacks: OpenAIQuicksilverAudioPeerCallbacks;
+      decoder: LibopusDecoder;
+      encoder: LibopusEncoder;
+      peer: WeriftPeerConnection;
+      transceiver: WeriftTransceiver;
+      werift: WeriftModule;
+    },
+  ) {
+    state.peer.onTrack.subscribe((track) => this.attachInboundTrack(track));
+    state.peer.connectionStateChange.subscribe((connectionState) => {
+      if (connectionState === "connected") {
+        this.connected = true;
+        this.startMediaPump();
+      } else if (connectionState === "failed") {
+        this.state.callbacks.onError(new Error("GPT-Live WebRTC media connection failed"));
+      }
+    });
+  }
+
+  async createOffer(): Promise<string> {
+    const offer = await this.state.peer.createOffer();
+    await this.state.peer.setLocalDescription(offer);
+    const sdp = this.state.peer.localDescription?.sdp;
+    if (!sdp?.trim()) {
+      throw new Error("werift did not produce a GPT-Live SDP offer");
+    }
+    return sdp;
+  }
+
+  async applyAnswer(answerSdp: string): Promise<void> {
+    await this.state.peer.setRemoteDescription({ type: "answer", sdp: answerSdp });
+    // OpenAI answers may not declare SSRCs. Subscribe to the receiver's stable
+    // default track directly instead of relying only on peer.ontrack demux.
+    this.attachInboundTrack(this.state.transceiver.receiver.track);
+  }
+
+  sendAudio(audio: Buffer): void {
+    if (this.closed || audio.length < 2) {
+      return;
+    }
+    const evenAudio = audio.subarray(0, audio.length - (audio.length % 2));
+    this.pendingAudio =
+      this.pendingAudio.length > 0
+        ? Buffer.concat([this.pendingAudio, evenAudio])
+        : Buffer.from(evenAudio);
+    const maxPendingBytes = RELAY_FRAME_BYTES * MAX_PENDING_RELAY_FRAMES;
+    if (this.pendingAudio.length > maxPendingBytes) {
+      // Keep the newest complete frames. Old microphone audio is less useful than bounded latency.
+      this.pendingAudio = this.pendingAudio.subarray(this.pendingAudio.length - maxPendingBytes);
+    }
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    if (this.mediaTimer) {
+      clearInterval(this.mediaTimer);
+      this.mediaTimer = undefined;
+    }
+    this.pendingAudio = Buffer.alloc(0);
+    this.state.encoder.free();
+    this.state.decoder.free();
+    void this.state.peer.close().catch(() => undefined);
+  }
+
+  private attachInboundTrack(track: WeriftTrack): void {
+    if (track.kind !== "audio" || this.subscribedTracks.has(track.uuid)) {
+      return;
+    }
+    this.subscribedTracks.add(track.uuid);
+    track.onReceiveRtp.subscribe((packet) => {
+      if (this.closed) {
+        return;
+      }
+      try {
+        this.state.callbacks.onRtpPacket?.();
+        const opusPacket = this.state.werift.dePacketizeRtpPackets("opus", [packet]).data;
+        const decoded = this.state.decoder.decode(opusPacket, { maxFrameSize: 5_760 });
+        const relayPcm = convertQuicksilverPcmToRelayPcm(decoded);
+        if (relayPcm.length > 0) {
+          this.state.callbacks.onAudio(relayPcm);
+        }
+      } catch (error) {
+        this.state.callbacks.onError(toError(error));
+      }
+    });
+  }
+
+  private startMediaPump(): void {
+    if (this.mediaTimer || this.closed) {
+      return;
+    }
+    this.sendNextAudioFrame();
+    this.mediaTimer = setInterval(() => this.sendNextAudioFrame(), OPUS_FRAME_DURATION_MS);
+    this.mediaTimer.unref?.();
+  }
+
+  private sendNextAudioFrame(): void {
+    if (!this.connected || this.closed || this.mediaSendPending) {
+      return;
+    }
+    const hasRelayAudio = this.pendingAudio.length >= RELAY_FRAME_BYTES;
+    const frame = hasRelayAudio
+      ? this.pendingAudio.subarray(0, RELAY_FRAME_BYTES)
+      : Buffer.alloc(RELAY_FRAME_BYTES);
+    if (hasRelayAudio) {
+      this.pendingAudio = this.pendingAudio.subarray(RELAY_FRAME_BYTES);
+    }
+    try {
+      const opusPacket = this.state.encoder.encode(convertRelayPcmToQuicksilverPcm(frame), {
+        frameSize: OPUS_FRAME_SAMPLES,
+      });
+      const rtp = new this.state.werift.RtpPacket(
+        new this.state.werift.RtpHeader({
+          marker: false,
+          payloadType: 111,
+          sequenceNumber: this.sequenceNumber,
+          timestamp: this.timestamp,
+        }),
+        Buffer.from(opusPacket),
+      );
+      this.sequenceNumber = (this.sequenceNumber + 1) & 0xffff;
+      this.timestamp = (this.timestamp + OPUS_FRAME_SAMPLES) >>> 0;
+      this.mediaSendPending = true;
+      void this.state.transceiver.sender
+        .sendRtp(rtp)
+        .catch((error: unknown) => {
+          this.state.callbacks.onError(toError(error));
+        })
+        .finally(() => {
+          this.mediaSendPending = false;
+        });
+    } catch (error) {
+      this.state.callbacks.onError(toError(error));
+    }
+  }
+}

--- a/extensions/openai/realtime-quicksilver-peer.runtime.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.ts
@@ -319,7 +319,7 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
         distance: forwardSequenceDistance(expected, sequenceNumber),
       }))
       .filter(({ distance }) => distance < RTP_SEQUENCE_HALF_RANGE)
-      .sort((left, right) => left.distance - right.distance);
+      .toSorted((left, right) => left.distance - right.distance);
     const nearest = pending[0];
     const farthest = pending.at(-1);
     if (!nearest || !farthest || (!force && farthest.distance < INBOUND_REORDER_DEPTH)) {

--- a/extensions/openai/realtime-quicksilver-peer.runtime.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.ts
@@ -268,13 +268,7 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
     if (!this.connected || this.closed) {
       return;
     }
-    const hasRelayAudio = this.pendingAudio.length >= RELAY_FRAME_BYTES;
-    const frame = hasRelayAudio
-      ? this.pendingAudio.subarray(0, RELAY_FRAME_BYTES)
-      : Buffer.alloc(RELAY_FRAME_BYTES);
-    if (hasRelayAudio) {
-      this.pendingAudio = this.pendingAudio.subarray(RELAY_FRAME_BYTES);
-    }
+    const frame = this.takeNextRelayFrame();
     try {
       const opusPacket = this.state.encoder.encode(convertRelayPcmToQuicksilverPcm(frame), {
         frameSize: OPUS_FRAME_SAMPLES,
@@ -298,5 +292,17 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
     } catch (error) {
       this.state.callbacks.onError(toError(error));
     }
+  }
+
+  private takeNextRelayFrame(): Buffer {
+    // Relay ticks are framing boundaries: pad partial PCM now, or its tail survives
+    // silence and is prepended to a later utterance as stale audio.
+    const frame = Buffer.alloc(RELAY_FRAME_BYTES);
+    const queuedBytes = Math.min(this.pendingAudio.length, RELAY_FRAME_BYTES);
+    if (queuedBytes > 0) {
+      this.pendingAudio.copy(frame, 0, 0, queuedBytes);
+      this.pendingAudio = this.pendingAudio.subarray(queuedBytes);
+    }
+    return frame;
   }
 }

--- a/extensions/openai/realtime-quicksilver-peer.runtime.ts
+++ b/extensions/openai/realtime-quicksilver-peer.runtime.ts
@@ -10,11 +10,17 @@ const OPUS_FRAME_DURATION_MS = 20;
 const RELAY_FRAME_SAMPLES = 480;
 const RELAY_FRAME_BYTES = RELAY_FRAME_SAMPLES * 2;
 const MAX_PENDING_RELAY_FRAMES = 250;
+const INBOUND_REORDER_DEPTH = 4;
+// More than two seconds behind cannot be useful 20 ms reordering; fail instead of corrupting Opus state.
+const INBOUND_MAX_LATE_PACKETS = 100;
+const RTP_SEQUENCE_MODULUS = 0x1_0000;
+const RTP_SEQUENCE_HALF_RANGE = RTP_SEQUENCE_MODULUS / 2;
 
 type WeriftModule = typeof import("werift");
 type LibopusModule = typeof import("libopus-wasm");
 type WeriftPeerConnection = InstanceType<WeriftModule["RTCPeerConnection"]>;
 type WeriftTransceiver = ReturnType<WeriftPeerConnection["addTransceiver"]>;
+type WeriftRtpPacket = InstanceType<WeriftModule["RtpPacket"]>;
 type WeriftTrack = Parameters<WeriftPeerConnection["onTrack"]["subscribe"]>[0] extends (
   track: infer T,
 ) => unknown
@@ -22,6 +28,11 @@ type WeriftTrack = Parameters<WeriftPeerConnection["onTrack"]["subscribe"]>[0] e
   : never;
 type LibopusEncoder = Awaited<ReturnType<LibopusModule["createEncoder"]>>;
 type LibopusDecoder = Awaited<ReturnType<LibopusModule["createDecoder"]>>;
+type InboundRtpState = {
+  flushTimer?: ReturnType<typeof setTimeout>;
+  nextSequence?: number;
+  pendingPackets: Map<number, WeriftRtpPacket>;
+};
 
 export type OpenAIQuicksilverAudioPeerCallbacks = {
   onAudio: (audio: Buffer) => void;
@@ -70,6 +81,10 @@ function convertQuicksilverPcmToRelayPcm(pcm48kStereo: Int16Array): Buffer {
     mono48k.writeInt16LE(Math.round((left + right) / 2), frame * 2);
   }
   return resamplePcm(mono48k, QUICKSILVER_SAMPLE_RATE, RELAY_SAMPLE_RATE);
+}
+
+function forwardSequenceDistance(expected: number, sequenceNumber: number): number {
+  return (sequenceNumber - expected + RTP_SEQUENCE_MODULUS) & 0xffff;
 }
 
 /** Pure-TypeScript WebRTC media peer with a WASM-only Opus codec. */
@@ -149,6 +164,8 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
 
   private connected = false;
   private closed = false;
+  private activeInboundSsrc: number | undefined;
+  private inboundRtpState: InboundRtpState = { pendingPackets: new Map() };
   private mediaTimer: ReturnType<typeof setInterval> | undefined;
   private pendingAudio = Buffer.alloc(0);
   private sequenceNumber = randomInt(0x1_0000);
@@ -227,6 +244,7 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
       this.mediaTimer = undefined;
     }
     this.pendingAudio = Buffer.alloc(0);
+    this.resetInboundRtpState();
     this.state.encoder.free();
     this.state.decoder.free();
     void this.state.peer.close().catch(() => undefined);
@@ -237,22 +255,147 @@ export class OpenAIQuicksilverAudioPeer implements OpenAIQuicksilverAudioPeerCon
       return;
     }
     this.subscribedTracks.add(track.uuid);
-    track.onReceiveRtp.subscribe((packet) => {
+    track.onReceiveRtp.subscribe((packet) => this.handleInboundRtp(packet));
+  }
+
+  private handleInboundRtp(packet: WeriftRtpPacket): void {
+    if (this.closed) {
+      return;
+    }
+    try {
+      this.state.callbacks.onRtpPacket?.();
+      const sequenceNumber = packet.header.sequenceNumber;
+      if (this.activeInboundSsrc === undefined) {
+        this.activeInboundSsrc = packet.header.ssrc;
+      } else if (packet.header.ssrc !== this.activeInboundSsrc) {
+        throw new Error("GPT-Live WebRTC audio source changed unexpectedly");
+      }
+      const state = this.inboundRtpState;
+      if (state.nextSequence === undefined) {
+        state.nextSequence = (sequenceNumber + 1) & 0xffff;
+        this.decodeInboundPacket(packet);
+        return;
+      }
+      const distance = forwardSequenceDistance(state.nextSequence, sequenceNumber);
+      if (distance >= RTP_SEQUENCE_HALF_RANGE) {
+        const backwardDistance = forwardSequenceDistance(sequenceNumber, state.nextSequence);
+        if (backwardDistance <= INBOUND_MAX_LATE_PACKETS) {
+          return;
+        }
+        throw new Error("GPT-Live WebRTC RTP sequence changed unexpectedly");
+      }
+      if (state.pendingPackets.has(sequenceNumber)) {
+        return;
+      }
+      if (distance === 0) {
+        state.nextSequence = (state.nextSequence + 1) & 0xffff;
+        this.decodeInboundPacket(packet);
+        this.clearInboundFlushTimer(state);
+        this.drainInboundPackets(state);
+        return;
+      }
+      state.pendingPackets.set(sequenceNumber, packet);
+      this.flushInboundReorderWindow(state);
+      this.scheduleInboundFlush(state);
+    } catch (error) {
+      this.state.callbacks.onError(toError(error));
+    }
+  }
+
+  private resetInboundRtpState(): void {
+    this.clearInboundFlushTimer(this.inboundRtpState);
+    this.inboundRtpState.nextSequence = undefined;
+    this.inboundRtpState.pendingPackets.clear();
+  }
+
+  private flushInboundReorderWindow(state: InboundRtpState, force = false): void {
+    const expected = state.nextSequence;
+    if (expected === undefined || state.pendingPackets.size === 0) {
+      return;
+    }
+    const pending = [...state.pendingPackets.keys()]
+      .map((sequenceNumber) => ({
+        sequenceNumber,
+        distance: forwardSequenceDistance(expected, sequenceNumber),
+      }))
+      .filter(({ distance }) => distance < RTP_SEQUENCE_HALF_RANGE)
+      .sort((left, right) => left.distance - right.distance);
+    const nearest = pending[0];
+    const farthest = pending.at(-1);
+    if (!nearest || !farthest || (!force && farthest.distance < INBOUND_REORDER_DEPTH)) {
+      return;
+    }
+    this.clearInboundFlushTimer(state);
+
+    // Four 20 ms packets cover ordinary Internet reordering. The matching timer
+    // flushes a short final tail; concealment is capped before a large discontinuity resync.
+    const concealCount = Math.min(nearest.distance, INBOUND_REORDER_DEPTH);
+    for (let index = 0; index < concealCount; index += 1) {
+      state.nextSequence = ((state.nextSequence ?? 0) + 1) & 0xffff;
+      this.decodeInboundPacketLoss();
+    }
+    if (nearest.distance > INBOUND_REORDER_DEPTH) {
+      state.nextSequence = nearest.sequenceNumber;
+    }
+    this.drainInboundPackets(state);
+  }
+
+  private drainInboundPackets(state: InboundRtpState): void {
+    while (state.nextSequence !== undefined) {
+      const packet = state.pendingPackets.get(state.nextSequence);
+      if (!packet) {
+        break;
+      }
+      state.pendingPackets.delete(state.nextSequence);
+      state.nextSequence = (state.nextSequence + 1) & 0xffff;
+      this.decodeInboundPacket(packet);
+    }
+    if (state.pendingPackets.size === 0) {
+      this.clearInboundFlushTimer(state);
+    } else {
+      this.scheduleInboundFlush(state);
+    }
+  }
+
+  private scheduleInboundFlush(state: InboundRtpState): void {
+    if (this.closed || state.flushTimer || state.pendingPackets.size === 0) {
+      return;
+    }
+    state.flushTimer = setTimeout(() => {
+      state.flushTimer = undefined;
       if (this.closed) {
         return;
       }
       try {
-        this.state.callbacks.onRtpPacket?.();
-        const opusPacket = this.state.werift.dePacketizeRtpPackets("opus", [packet]).data;
-        const decoded = this.state.decoder.decode(opusPacket, { maxFrameSize: 5_760 });
-        const relayPcm = convertQuicksilverPcmToRelayPcm(decoded);
-        if (relayPcm.length > 0) {
-          this.state.callbacks.onAudio(relayPcm);
-        }
+        this.flushInboundReorderWindow(state, true);
       } catch (error) {
         this.state.callbacks.onError(toError(error));
       }
-    });
+    }, INBOUND_REORDER_DEPTH * OPUS_FRAME_DURATION_MS);
+    state.flushTimer.unref?.();
+  }
+
+  private clearInboundFlushTimer(state: InboundRtpState): void {
+    if (state.flushTimer) {
+      clearTimeout(state.flushTimer);
+      state.flushTimer = undefined;
+    }
+  }
+
+  private decodeInboundPacket(packet: WeriftRtpPacket): void {
+    const opusPacket = this.state.werift.dePacketizeRtpPackets("opus", [packet]).data;
+    this.emitInboundPcm(this.state.decoder.decode(opusPacket, { maxFrameSize: 5_760 }));
+  }
+
+  private decodeInboundPacketLoss(): void {
+    this.emitInboundPcm(this.state.decoder.decodePacketLoss(OPUS_FRAME_SAMPLES));
+  }
+
+  private emitInboundPcm(decoded: Int16Array): void {
+    const relayPcm = convertQuicksilverPcmToRelayPcm(decoded);
+    if (relayPcm.length > 0) {
+      this.state.callbacks.onAudio(relayPcm);
+    }
   }
 
   private startMediaPump(): void {

--- a/extensions/openai/realtime-quicksilver-session-limit.test.ts
+++ b/extensions/openai/realtime-quicksilver-session-limit.test.ts
@@ -1,11 +1,69 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   releaseOpenAIQuicksilverSession,
   reserveOpenAIQuicksilverSession,
 } from "./realtime-quicksilver-session-limit.js";
 
 describe("GPT-Live shared session limit", () => {
-  it("caps browser and relay owners together", () => {
+  it("prunes expired pending offers before reserving a relay session", () => {
+    const owners = Array.from({ length: 9 }, () => Symbol("quicksilver-session"));
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      for (const owner of owners.slice(0, 8)) {
+        reserveOpenAIQuicksilverSession(owner, { expiresAtMs: now + 1 });
+      }
+      vi.mocked(Date.now).mockReturnValue(now + 1);
+      expect(() => reserveOpenAIQuicksilverSession(owners[8])).not.toThrow();
+    } finally {
+      for (const owner of owners) {
+        releaseOpenAIQuicksilverSession(owner);
+      }
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("keeps unexpired pending offers within the shared cap", () => {
+    const owners = Array.from({ length: 9 }, () => Symbol("quicksilver-session"));
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      for (const owner of owners.slice(0, 8)) {
+        reserveOpenAIQuicksilverSession(owner, { expiresAtMs: now + 1 });
+      }
+      expect(() => reserveOpenAIQuicksilverSession(owners[8])).toThrow(
+        "Too many concurrent OpenAI GPT-Live sessions",
+      );
+    } finally {
+      for (const owner of owners) {
+        releaseOpenAIQuicksilverSession(owner);
+      }
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("does not expire established sessions", () => {
+    const owners = Array.from({ length: 9 }, () => Symbol("quicksilver-session"));
+    const now = 1_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      for (const owner of owners.slice(0, 8)) {
+        reserveOpenAIQuicksilverSession(owner, { expiresAtMs: now + 1 });
+        reserveOpenAIQuicksilverSession(owner);
+      }
+      vi.mocked(Date.now).mockReturnValue(now + 60_000);
+      expect(() => reserveOpenAIQuicksilverSession(owners[8])).toThrow(
+        "Too many concurrent OpenAI GPT-Live sessions",
+      );
+    } finally {
+      for (const owner of owners) {
+        releaseOpenAIQuicksilverSession(owner);
+      }
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("releases reservations explicitly", () => {
     const owners = Array.from({ length: 9 }, () => Symbol("quicksilver-session"));
     try {
       for (const owner of owners.slice(0, 8)) {

--- a/extensions/openai/realtime-quicksilver-session-limit.test.ts
+++ b/extensions/openai/realtime-quicksilver-session-limit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  releaseOpenAIQuicksilverSession,
+  reserveOpenAIQuicksilverSession,
+} from "./realtime-quicksilver-session-limit.js";
+
+describe("GPT-Live shared session limit", () => {
+  it("caps browser and relay owners together", () => {
+    const owners = Array.from({ length: 9 }, () => Symbol("quicksilver-session"));
+    try {
+      for (const owner of owners.slice(0, 8)) {
+        reserveOpenAIQuicksilverSession(owner);
+      }
+      expect(() => reserveOpenAIQuicksilverSession(owners[8])).toThrow(
+        "Too many concurrent OpenAI GPT-Live sessions",
+      );
+      releaseOpenAIQuicksilverSession(owners[0]);
+      expect(() => reserveOpenAIQuicksilverSession(owners[8])).not.toThrow();
+    } finally {
+      for (const owner of owners) {
+        releaseOpenAIQuicksilverSession(owner);
+      }
+    }
+  });
+});

--- a/extensions/openai/realtime-quicksilver-session-limit.ts
+++ b/extensions/openai/realtime-quicksilver-session-limit.ts
@@ -1,15 +1,25 @@
 // Shared process-wide cap for browser and Gateway-relay GPT-Live sessions.
 const OPENAI_QUICKSILVER_MAX_SESSIONS = 8;
-const reservations = new Set<unknown>();
+const reservations = new Map<unknown, number | undefined>();
 
-export function reserveOpenAIQuicksilverSession(owner: unknown): void {
+export function reserveOpenAIQuicksilverSession(
+  owner: unknown,
+  opts?: { expiresAtMs?: number },
+): void {
+  const now = Date.now();
+  for (const [reservedOwner, expiresAtMs] of reservations) {
+    if (expiresAtMs !== undefined && expiresAtMs <= now) {
+      reservations.delete(reservedOwner);
+    }
+  }
   if (reservations.has(owner)) {
+    reservations.set(owner, opts?.expiresAtMs);
     return;
   }
   if (reservations.size >= OPENAI_QUICKSILVER_MAX_SESSIONS) {
     throw new Error("Too many concurrent OpenAI GPT-Live sessions; try again in a minute");
   }
-  reservations.add(owner);
+  reservations.set(owner, opts?.expiresAtMs);
 }
 
 export function releaseOpenAIQuicksilverSession(owner: unknown): void {

--- a/extensions/openai/realtime-quicksilver-session-limit.ts
+++ b/extensions/openai/realtime-quicksilver-session-limit.ts
@@ -1,0 +1,17 @@
+// Shared process-wide cap for browser and Gateway-relay GPT-Live sessions.
+const OPENAI_QUICKSILVER_MAX_SESSIONS = 8;
+const reservations = new Set<unknown>();
+
+export function reserveOpenAIQuicksilverSession(owner: unknown): void {
+  if (reservations.has(owner)) {
+    return;
+  }
+  if (reservations.size >= OPENAI_QUICKSILVER_MAX_SESSIONS) {
+    throw new Error("Too many concurrent OpenAI GPT-Live sessions; try again in a minute");
+  }
+  reservations.add(owner);
+}
+
+export function releaseOpenAIQuicksilverSession(owner: unknown): void {
+  reservations.delete(owner);
+}

--- a/extensions/openai/realtime-quicksilver-session.ts
+++ b/extensions/openai/realtime-quicksilver-session.ts
@@ -450,8 +450,8 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       prunePendingOffers();
       const voice = resolveOpenAIQuicksilverVoice(request.voice);
       const token = randomBytes(32).toString("base64url");
-      reserveOpenAIQuicksilverSession(token);
       const expiresAt = Date.now() + OPENAI_QUICKSILVER_PENDING_TTL_MS;
+      reserveOpenAIQuicksilverSession(token, { expiresAtMs: expiresAt });
       pendingOffers.set(token, {
         auth,
         expiresAt,
@@ -615,6 +615,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         partialTranscriptRole: undefined,
       };
       activeSessions.set(token, session);
+      reserveOpenAIQuicksilverSession(token);
       reservationTransferred = true;
       attachSidebandHandlers(session, runAgentConsult);
       const terminalEvent = connected.detachBuffer();

--- a/extensions/openai/realtime-quicksilver-session.ts
+++ b/extensions/openai/realtime-quicksilver-session.ts
@@ -20,6 +20,10 @@ import {
   type OpenAIQuicksilverTranscriptEntry,
 } from "./realtime-quicksilver-instructions.js";
 import {
+  releaseOpenAIQuicksilverSession,
+  reserveOpenAIQuicksilverSession,
+} from "./realtime-quicksilver-session-limit.js";
+import {
   connectOpenAIQuicksilverSideband,
   type OpenAIQuicksilverSocket,
   type OpenAIQuicksilverSocketFactory,
@@ -39,7 +43,7 @@ import {
 import { isOpenAIGptLiveModel } from "./realtime-quicksilver.js";
 export const OPENAI_QUICKSILVER_OFFER_PATH = "/plugins/openai/realtime/calls";
 export const OPENAI_QUICKSILVER_CAPABILITIES = {
-  transports: ["webrtc" as const],
+  transports: ["webrtc" as const, "gateway-relay" as const],
   handlesAgentConsult: true as const,
   supportsToolCalls: false,
   supportsVideoFrames: false,
@@ -47,7 +51,6 @@ export const OPENAI_QUICKSILVER_CAPABILITIES = {
 
 const OPENAI_QUICKSILVER_PENDING_TTL_MS = 60_000;
 const OPENAI_QUICKSILVER_SESSION_TTL_MS = 30 * 60_000;
-const OPENAI_QUICKSILVER_MAX_SESSIONS = 8;
 const OPENAI_QUICKSILVER_MAX_SDP_BYTES = 256 * 1024;
 const OPENAI_QUICKSILVER_UPSTREAM_TIMEOUT_MS = 30_000;
 const WEBSOCKET_OPEN = 1;
@@ -247,6 +250,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
     }
     activeSessions.delete(session.token);
     reservations.delete(session.token);
+    releaseOpenAIQuicksilverSession(session.token);
     clearTimeout(session.timer);
     session.consultController?.abort(new Error("GPT-Live delegation stopped"));
     session.abortController.abort(new Error("GPT-Live session closed"));
@@ -422,6 +426,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       if (offer.expiresAt <= now) {
         pendingOffers.delete(token);
         reservations.delete(token);
+        releaseOpenAIQuicksilverSession(token);
       }
     }
   };
@@ -443,11 +448,9 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         throw new Error("OpenAI GPT-Live requires the Gateway agent-consult runtime");
       }
       prunePendingOffers();
-      if (reservations.size >= OPENAI_QUICKSILVER_MAX_SESSIONS) {
-        throw new Error("Too many concurrent OpenAI GPT-Live sessions; try again in a minute");
-      }
       const voice = resolveOpenAIQuicksilverVoice(request.voice);
       const token = randomBytes(32).toString("base64url");
+      reserveOpenAIQuicksilverSession(token);
       const expiresAt = Date.now() + OPENAI_QUICKSILVER_PENDING_TTL_MS;
       pendingOffers.set(token, {
         auth,
@@ -481,6 +484,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         closeSession(active);
       } else {
         reservations.delete(session.clientSecret);
+        releaseOpenAIQuicksilverSession(session.clientSecret);
       }
     },
   };
@@ -662,6 +666,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       inFlightOffers.delete(token);
       if (!reservationTransferred) {
         reservations.delete(token);
+        releaseOpenAIQuicksilverSession(token);
       }
     }
   };
@@ -686,6 +691,9 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       closeSession(session);
     }
     await Promise.allSettled(inFlightHandlers);
+    for (const token of reservations) {
+      releaseOpenAIQuicksilverSession(token);
+    }
     reservations.clear();
   };
 

--- a/extensions/openai/realtime-quicksilver-sideband.ts
+++ b/extensions/openai/realtime-quicksilver-sideband.ts
@@ -19,17 +19,17 @@ export type OpenAIQuicksilverSocket = {
     listener: (data: RawData, isBinary: boolean) => void,
   ): OpenAIQuicksilverSocket;
   on(event: "error", listener: (error: Error) => void): OpenAIQuicksilverSocket;
-  on(event: "close", listener: () => void): OpenAIQuicksilverSocket;
+  on(event: "close", listener: (code: number, reason: Buffer) => void): OpenAIQuicksilverSocket;
   once(event: "open", listener: () => void): OpenAIQuicksilverSocket;
   once(event: "error", listener: (error: Error) => void): OpenAIQuicksilverSocket;
-  once(event: "close", listener: () => void): OpenAIQuicksilverSocket;
+  once(event: "close", listener: (code: number, reason: Buffer) => void): OpenAIQuicksilverSocket;
   off(event: "open", listener: () => void): OpenAIQuicksilverSocket;
   off(
     event: "message",
     listener: (data: RawData, isBinary: boolean) => void,
   ): OpenAIQuicksilverSocket;
   off(event: "error", listener: (error: Error) => void): OpenAIQuicksilverSocket;
-  off(event: "close", listener: () => void): OpenAIQuicksilverSocket;
+  off(event: "close", listener: (code: number, reason: Buffer) => void): OpenAIQuicksilverSocket;
 };
 
 export type OpenAIQuicksilverSocketFactory = (
@@ -38,7 +38,9 @@ export type OpenAIQuicksilverSocketFactory = (
 ) => OpenAIQuicksilverSocket;
 
 type OpenAIQuicksilverBufferedFrame = { data: RawData; isBinary: boolean };
-type OpenAIQuicksilverTerminalEvent = { kind: "error"; error: Error } | { kind: "close" };
+type OpenAIQuicksilverTerminalEvent =
+  | { kind: "error"; error: Error }
+  | { kind: "close"; code: number; reason: string };
 
 type OpenAIQuicksilverConnectedSideband = {
   socket: OpenAIQuicksilverSocket;
@@ -85,9 +87,13 @@ function waitForSocketOpen(params: {
       }
       finish(error);
     };
-    const onClose = () => {
+    const onClose = (code: number, reason: Buffer) => {
       if (opened) {
-        terminalEvent ??= { kind: "close" };
+        terminalEvent ??= {
+          kind: "close",
+          code: code ?? 1006,
+          reason: reason?.toString("utf8") ?? "",
+        };
         return;
       }
       finish(new Error("GPT-Live sideband closed during startup"));

--- a/extensions/openai/realtime-quicksilver-sideband.ts
+++ b/extensions/openai/realtime-quicksilver-sideband.ts
@@ -175,6 +175,13 @@ export async function connectOpenAIQuicksilverSideband(params: {
     socket.on("message", bufferFrame);
     try {
       const openHandoff = await waitForSocketOpen({ socket, signal: params.signal });
+      if (params.signal.aborted) {
+        socket.off("message", bufferFrame);
+        openHandoff.detachTerminalListeners();
+        socket.on("error", () => {});
+        socket.close(1000, "sideband startup stopped");
+        throw params.signal.reason;
+      }
       return {
         socket,
         bufferedFrames,

--- a/extensions/openai/realtime-quicksilver.test-helpers.ts
+++ b/extensions/openai/realtime-quicksilver.test-helpers.ts
@@ -37,7 +37,7 @@ export class FakeSocket extends EventEmitter {
     this.closeCode = code;
     this.closeReason = reason;
     this.readyState = 3;
-    this.emit("close");
+    this.emit("close", code ?? 1000, Buffer.from(reason ?? ""));
   }
 }
 

--- a/extensions/openai/realtime-quicksilver.test.ts
+++ b/extensions/openai/realtime-quicksilver.test.ts
@@ -1,6 +1,6 @@
 // Openai tests cover GPT-Live (quicksilver) realtime voice gating.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { isOpenAIGptLiveModel } from "./realtime-quicksilver.js";
+import { isOpenAIGptLiveModel, isSupportedOpenAIGptLiveModel } from "./realtime-quicksilver.js";
 import { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 
 const mintSecretMock = vi.hoisted(() => vi.fn());
@@ -27,6 +27,13 @@ describe("openai gpt-live model detection", () => {
     expect(isOpenAIGptLiveModel(undefined)).toBe(false);
     expect(isOpenAIGptLiveModel("gpt-realtime-2.1")).toBe(false);
     expect(isOpenAIGptLiveModel("gpt-liveish")).toBe(false);
+  });
+
+  it("advertises only curated /v1/live models", () => {
+    expect(isSupportedOpenAIGptLiveModel("gpt-live-1-codex")).toBe(true);
+    expect(isSupportedOpenAIGptLiveModel(" GPT-Live-1-Boulder-Alpha ")).toBe(true);
+    expect(isSupportedOpenAIGptLiveModel("gpt-live-1")).toBe(false);
+    expect(isSupportedOpenAIGptLiveModel("gpt-live-1-mini")).toBe(false);
   });
 });
 

--- a/extensions/openai/realtime-quicksilver.test.ts
+++ b/extensions/openai/realtime-quicksilver.test.ts
@@ -54,7 +54,7 @@ describe("openai realtime voice provider gpt-live transport routing", () => {
     });
   });
 
-  it("routes gpt-live models to a backend WebSocket bridge", () => {
+  it("routes gpt-live by the host-owned delegation seam", () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const callbacks = {
       onAudio: vi.fn(),
@@ -66,6 +66,13 @@ describe("openai realtime voice provider gpt-live transport routing", () => {
         providerConfig: { apiKey: "test-key", model: "gpt-live-1-codex" },
       }),
     ).toMatchObject({ supportsToolResultContinuation: true });
+    expect(
+      provider.createBridge({
+        ...callbacks,
+        providerConfig: { apiKey: "test-key", model: "gpt-live-1" },
+        runAgentConsult: vi.fn(async () => ({ text: "done" })),
+      }),
+    ).toMatchObject({ supportsToolResultContinuation: false });
     expect(() =>
       provider.createBridge({
         ...callbacks,

--- a/extensions/openai/realtime-quicksilver.ts
+++ b/extensions/openai/realtime-quicksilver.ts
@@ -1,5 +1,5 @@
-// GPT-Live (OpenAI "quicksilver") routing uses either the ChatGPT OAuth browser
-// WebRTC path or the Platform API-key Frameless Bidi backend WebSocket path.
+// GPT-Live (OpenAI "quicksilver") uses browser or Gateway-owned WebRTC when
+// the host owns delegation, and the Platform-key Frameless Bidi WebSocket elsewhere.
 
 const OPENAI_GPT_LIVE_MODEL_PREFIX = "gpt-live";
 

--- a/extensions/openai/realtime-quicksilver.ts
+++ b/extensions/openai/realtime-quicksilver.ts
@@ -3,6 +3,8 @@
 
 const OPENAI_GPT_LIVE_MODEL_PREFIX = "gpt-live";
 
+export const OPENAI_GPT_LIVE_MODELS = ["gpt-live-1-codex", "gpt-live-1-boulder-alpha"] as const;
+
 export function isOpenAIGptLiveModel(model: string | undefined): boolean {
   if (!model) {
     return false;
@@ -12,4 +14,12 @@ export function isOpenAIGptLiveModel(model: string | undefined): boolean {
     normalized === OPENAI_GPT_LIVE_MODEL_PREFIX ||
     normalized.startsWith(`${OPENAI_GPT_LIVE_MODEL_PREFIX}-`)
   );
+}
+
+export function isSupportedOpenAIGptLiveModel(model: string | undefined): boolean {
+  if (!model) {
+    return false;
+  }
+  const normalized = model.trim().toLowerCase();
+  return OPENAI_GPT_LIVE_MODELS.includes(normalized as (typeof OPENAI_GPT_LIVE_MODELS)[number]);
 }

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -881,6 +881,17 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
       }),
     ).toBe(true);
     expect(
+      readInternalRealtimeVoiceProviderApi(provider).isGatewayRelayConfigured({
+        cfg,
+        providerConfig: {
+          model: "gpt-live-1-mini",
+          azureEndpoint: "https://example.openai.azure.com",
+          azureDeployment: "gpt-live",
+        },
+        agentId: "main",
+      }),
+    ).toBe(false);
+    expect(
       readInternalRealtimeVoiceProviderApi(provider).isBrowserSessionConfigured({
         cfg,
         providerConfig: { model: "gpt-live-1-mini" },

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -13,6 +13,11 @@ function readInternalRealtimeVoiceProviderApi(provider: object) {
       providerConfig: Record<string, unknown>;
       agentId?: string;
     }) => boolean;
+    isGatewayRelayConfigured: (ctx: {
+      cfg?: object;
+      providerConfig: Record<string, unknown>;
+      agentId?: string;
+    }) => boolean;
     resolveBrowserSessionCapabilities: (ctx: {
       cfg?: object;
       providerConfig: Record<string, unknown>;
@@ -373,7 +378,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
         model: "gpt-live-1-mini",
       }),
     ).toMatchObject({
-      transports: ["webrtc"],
+      transports: ["webrtc", "gateway-relay"],
       handlesAgentConsult: true,
       supportsToolCalls: false,
       supportsVideoFrames: false,
@@ -868,6 +873,13 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     expect(provider.isConfigured({ cfg, providerConfig: { model: "gpt-live-1-mini" } })).toBe(
       false,
     );
+    expect(
+      readInternalRealtimeVoiceProviderApi(provider).isGatewayRelayConfigured({
+        cfg,
+        providerConfig: { model: "gpt-live-1-mini" },
+        agentId: "main",
+      }),
+    ).toBe(true);
     expect(
       readInternalRealtimeVoiceProviderApi(provider).isBrowserSessionConfigured({
         cfg,

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -17,7 +17,7 @@ function readInternalRealtimeVoiceProviderApi(provider: object) {
       cfg?: object;
       providerConfig: Record<string, unknown>;
       agentId?: string;
-    }) => boolean;
+    }) => boolean | undefined;
     resolveBrowserSessionCapabilities: (ctx: {
       cfg?: object;
       providerConfig: Record<string, unknown>;
@@ -28,6 +28,21 @@ function readInternalRealtimeVoiceProviderApi(provider: object) {
       supportsVideoFrames?: boolean;
       transports?: string[];
     };
+    resolveGatewayRelayCapabilities: (ctx: {
+      cfg?: object;
+      providerConfig: Record<string, unknown>;
+      model?: string;
+    }) => {
+      handlesAgentConsult?: boolean;
+      supportsToolCalls?: boolean;
+      transports?: string[];
+    };
+    validateGatewayRelayLaunch: (ctx: {
+      cfg?: object;
+      providerConfig: Record<string, unknown>;
+      model?: string;
+      autoRespondToAudio?: boolean;
+    }) => string | undefined;
     cancelBrowserSession: (request: Record<string, unknown>, session: object) => Promise<void>;
   };
 }
@@ -356,7 +371,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     expect(bridge.supportsToolResultSuppression).toBe(true);
   });
 
-  it("uses quicksilver capabilities for a request-model override", () => {
+  it("advertises quicksilver capabilities only for curated /v1/live models", () => {
     const quicksilverBroker = {
       capabilities: {
         transports: ["webrtc" as const],
@@ -375,7 +390,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     expect(
       internalApi.resolveBrowserSessionCapabilities({
         providerConfig: { model: "gpt-realtime-2.1" },
-        model: "gpt-live-1-mini",
+        model: "gpt-live-1-codex",
       }),
     ).toMatchObject({
       transports: ["webrtc", "gateway-relay"],
@@ -383,6 +398,28 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
       supportsToolCalls: false,
       supportsVideoFrames: false,
     });
+    expect(
+      internalApi.resolveGatewayRelayCapabilities({
+        providerConfig: { model: "gpt-realtime-2.1" },
+        model: "gpt-live-1-codex",
+      }),
+    ).toMatchObject({
+      transports: ["webrtc", "gateway-relay"],
+      handlesAgentConsult: true,
+      supportsToolCalls: false,
+    });
+    expect(
+      internalApi.resolveBrowserSessionCapabilities({
+        providerConfig: { model: "gpt-realtime-2.1" },
+        model: "gpt-live-1-mini",
+      }),
+    ).not.toHaveProperty("handlesAgentConsult");
+    expect(
+      internalApi.resolveGatewayRelayCapabilities({
+        providerConfig: { model: "gpt-realtime-2.1" },
+        model: "gpt-live-1-mini",
+      }),
+    ).not.toHaveProperty("handlesAgentConsult");
   });
 
   it("adds OpenClaw attribution headers to native realtime websocket requests", () => {
@@ -829,7 +866,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
-  it("routes gpt-live ChatGPT OAuth sessions through the native quicksilver broker", async () => {
+  it("routes an explicit unlisted gpt-live alias without advertising it as ready", async () => {
     const oauthToken = createTestJwt({
       "https://api.openai.com/auth": { chatgpt_account_id: "account-123" },
     });
@@ -879,7 +916,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
         providerConfig: { model: "gpt-live-1-mini" },
         agentId: "main",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       readInternalRealtimeVoiceProviderApi(provider).isGatewayRelayConfigured({
         cfg,
@@ -897,6 +934,41 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
         providerConfig: { model: "gpt-live-1-mini" },
         agentId: "main",
       }),
+    ).toBe(false);
+    expect(
+      readInternalRealtimeVoiceProviderApi(provider).isGatewayRelayConfigured({
+        cfg,
+        providerConfig: { model: "gpt-realtime-2.1", apiKey: "sk-platform" },
+        agentId: "main",
+      }),
+    ).toBeUndefined();
+    expect(
+      readInternalRealtimeVoiceProviderApi(provider).isGatewayRelayConfigured({
+        cfg,
+        providerConfig: { model: "gpt-live-1-mini", apiKey: "sk-platform" },
+        agentId: "main",
+      }),
+    ).toBe(false);
+    expect(
+      readInternalRealtimeVoiceProviderApi(provider).isBrowserSessionConfigured({
+        cfg,
+        providerConfig: { model: "gpt-live-1-mini", apiKey: "sk-platform" },
+        agentId: "main",
+      }),
+    ).toBe(false);
+    expect(
+      readInternalRealtimeVoiceProviderApi(provider).isGatewayRelayConfigured({
+        cfg,
+        providerConfig: { model: "gpt-live-1-codex" },
+        agentId: "main",
+      }),
+    ).toBe(true);
+    expect(
+      readInternalRealtimeVoiceProviderApi(provider).isBrowserSessionConfigured({
+        cfg,
+        providerConfig: { model: "gpt-live-1-codex" },
+        agentId: "main",
+      }),
     ).toBe(true);
     await provider.createBrowserSession?.(request);
     expect(createBrowserSession).toHaveBeenCalledWith(expect.objectContaining(request), {
@@ -911,6 +983,24 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
         includeExternalCliAuth: false,
       }),
     );
+  });
+
+  it("rejects forced consult routing for prefix-routed gpt-live sessions", () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const internalApi = readInternalRealtimeVoiceProviderApi(provider);
+
+    expect(
+      internalApi.validateGatewayRelayLaunch({
+        providerConfig: { model: "gpt-live-future-alias" },
+        autoRespondToAudio: false,
+      }),
+    ).toContain("cannot use forced agent consult routing");
+    expect(
+      internalApi.validateGatewayRelayLaunch({
+        providerConfig: { model: "gpt-realtime-2.1" },
+        autoRespondToAudio: false,
+      }),
+    ).toBeUndefined();
   });
 
   it("prefers ChatGPT OAuth over Platform auth for gpt-live", async () => {

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -945,6 +945,28 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     expect(
       readInternalRealtimeVoiceProviderApi(provider).isGatewayRelayConfigured({
         cfg,
+        providerConfig: {
+          model: "gpt-realtime-2.1",
+          apiKey: "sk-platform",
+          azureEndpoint: "https://example.openai.azure.com",
+        },
+        agentId: "main",
+      }),
+    ).toBeUndefined();
+    expect(
+      readInternalRealtimeVoiceProviderApi(provider).isGatewayRelayConfigured({
+        cfg,
+        providerConfig: {
+          model: "gpt-live-1-codex",
+          apiKey: "sk-platform",
+          azureEndpoint: "https://example.openai.azure.com",
+        },
+        agentId: "main",
+      }),
+    ).toBe(false);
+    expect(
+      readInternalRealtimeVoiceProviderApi(provider).isGatewayRelayConfigured({
+        cfg,
         providerConfig: { model: "gpt-live-1-mini", apiKey: "sk-platform" },
         agentId: "main",
       }),
@@ -963,6 +985,19 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
         agentId: "main",
       }),
     ).toBe(true);
+    expect(
+      readInternalRealtimeVoiceProviderApi(provider).isGatewayRelayConfigured({
+        cfg,
+        providerConfig: { model: "gpt-live-1-codex" },
+        agentId: "voice-agent",
+      }),
+    ).toBe(true);
+    expect(isProviderAuthProfileConfiguredMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDir: expect.stringContaining("voice-agent"),
+        profileTypes: ["oauth"],
+      }),
+    );
     expect(
       readInternalRealtimeVoiceProviderApi(provider).isBrowserSessionConfigured({
         cfg,

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -480,8 +480,13 @@ async function requireOpenAIRealtimePlatformAuth(params: {
 async function resolveOpenAIQuicksilverBridgeAuth(params: {
   configuredApiKey: string | undefined;
   cfg: RealtimeVoiceBridgeCreateRequest["cfg"] | undefined;
+  agentId?: string;
 }) {
-  const subscriptionAuth = await resolveOpenAIChatGptSubscriptionAuth({ cfg: params.cfg });
+  const subscriptionAuth = await resolveOpenAIChatGptSubscriptionAuth({
+    cfg: params.cfg,
+    agentDir:
+      params.cfg && params.agentId ? resolveAgentDir(params.cfg, params.agentId) : undefined,
+  });
   if (subscriptionAuth) {
     return subscriptionAuth;
   }
@@ -1947,6 +1952,7 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
               resolveOpenAIQuicksilverBridgeAuth({
                 configuredApiKey: config.apiKey,
                 cfg: req.cfg,
+                agentId: req.agentId,
               }),
           });
         }
@@ -2025,6 +2031,8 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
     isGatewayRelayConfigured: ({ cfg, providerConfig, agentId }) => {
       const config = normalizeProviderConfig(providerConfig);
       return (
+        !config.azureEndpoint &&
+        !config.azureDeployment &&
         isOpenAIGptLiveModel(config.model) &&
         hasOpenAIChatGptSubscriptionAuthInput({ cfg, agentId })
       );

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
+import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
 import {
   isProviderAuthProfileConfigured,
   resolveProviderAuthProfileApiKey,
@@ -45,6 +46,7 @@ import {
   trimToUndefined,
 } from "./realtime-provider-shared.js";
 import { OpenAIQuicksilverVoiceBridge } from "./realtime-quicksilver-bridge.js";
+import { OpenAIQuicksilverGatewayBridge } from "./realtime-quicksilver-gateway-bridge.js";
 import { buildOpenAIQuicksilverInstructions } from "./realtime-quicksilver-instructions.js";
 import {
   createOpenAIQuicksilverBrowserSessionBroker,
@@ -473,6 +475,29 @@ async function requireOpenAIRealtimePlatformAuth(params: {
     return resolved;
   }
   throw new Error(OPENAI_REALTIME_PLATFORM_AUTH_REQUIRED);
+}
+
+async function resolveOpenAIQuicksilverBridgeAuth(params: {
+  configuredApiKey: string | undefined;
+  cfg: RealtimeVoiceBridgeCreateRequest["cfg"] | undefined;
+}) {
+  const subscriptionAuth = await resolveOpenAIChatGptSubscriptionAuth({ cfg: params.cfg });
+  if (subscriptionAuth) {
+    return subscriptionAuth;
+  }
+  const platformAuth = await resolveOpenAIRealtimePlatformAuth(params);
+  if (platformAuth.status === "available") {
+    return { type: "api-key" as const, token: platformAuth.value };
+  }
+  if (
+    hasOpenAIRealtimePlatformAuthInput({
+      configuredApiKey: params.configuredApiKey,
+      cfg: params.cfg,
+    })
+  ) {
+    throw new Error(OPENAI_GPT_LIVE_AUTHORED_PLATFORM_AUTH_UNAVAILABLE);
+  }
+  throw new Error(OPENAI_GPT_LIVE_AUTH_REQUIRED);
 }
 
 function hasOpenAIRealtimePlatformAuthInput(params: {
@@ -1693,6 +1718,16 @@ type OpenAIInternalRealtimeVoiceProviderApi = {
     providerConfig: RealtimeVoiceProviderConfig;
     model?: string;
   }) => OpenAIInternalRealtimeVoiceCapabilities;
+  isGatewayRelayConfigured?: (ctx: {
+    cfg?: RealtimeVoiceBrowserSessionCreateRequest["cfg"];
+    providerConfig: RealtimeVoiceProviderConfig;
+    agentId?: string;
+  }) => boolean;
+  resolveGatewayRelayCapabilities?: (ctx: {
+    cfg?: RealtimeVoiceBrowserSessionCreateRequest["cfg"];
+    providerConfig: RealtimeVoiceProviderConfig;
+    model?: string;
+  }) => OpenAIInternalRealtimeVoiceCapabilities;
   cancelBrowserSession?: (
     request: OpenAIInternalRealtimeBrowserSessionCreateRequest,
     session: RealtimeVoiceBrowserSession,
@@ -1864,6 +1899,7 @@ async function cancelOpenAIRealtimeBrowserSession(
 
 export function buildOpenAIRealtimeVoiceProvider(options?: {
   quicksilverBrowserSessionBroker?: OpenAIQuicksilverBrowserSessionBroker;
+  logger?: Pick<PluginLogger, "debug" | "warn">;
 }): RealtimeVoiceProviderPlugin {
   const provider: RealtimeVoiceProviderPlugin = {
     id: "openai",
@@ -1899,6 +1935,20 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
           throw new Error(
             "GPT-Live backend WebSocket sessions do not support Azure endpoints or deployments",
           );
+        }
+        if (req.runAgentConsult) {
+          return new OpenAIQuicksilverGatewayBridge({
+            ...req,
+            model,
+            voice: config.voice ?? "marin",
+            instructions: buildOpenAIQuicksilverInstructions(req.instructions),
+            logger: options?.logger ?? { debug: () => undefined, warn: () => undefined },
+            resolveAuth: () =>
+              resolveOpenAIQuicksilverBridgeAuth({
+                configuredApiKey: config.apiKey,
+                cfg: req.cfg,
+              }),
+          });
         }
         return new OpenAIQuicksilverVoiceBridge({
           ...req,
@@ -1963,6 +2013,23 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
       );
     },
     resolveBrowserSessionCapabilities: ({ providerConfig, model }) => {
+      const config = normalizeProviderConfig(providerConfig);
+      if (isOpenAIGptLiveModel(model ?? config.model)) {
+        return {
+          ...OPENAI_REALTIME_CAPABILITIES,
+          ...OPENAI_QUICKSILVER_CAPABILITIES,
+        };
+      }
+      return OPENAI_REALTIME_CAPABILITIES;
+    },
+    isGatewayRelayConfigured: ({ cfg, providerConfig, agentId }) => {
+      const config = normalizeProviderConfig(providerConfig);
+      return (
+        isOpenAIGptLiveModel(config.model) &&
+        hasOpenAIChatGptSubscriptionAuthInput({ cfg, agentId })
+      );
+    },
+    resolveGatewayRelayCapabilities: ({ providerConfig, model }) => {
       const config = normalizeProviderConfig(providerConfig);
       if (isOpenAIGptLiveModel(model ?? config.model)) {
         return {

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -2046,11 +2046,11 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
     },
     isGatewayRelayConfigured: ({ cfg, providerConfig, agentId }) => {
       const config = normalizeProviderConfig(providerConfig);
-      if (config.azureEndpoint || config.azureDeployment) {
-        return false;
-      }
       if (!isOpenAIGptLiveModel(config.model)) {
         return undefined;
+      }
+      if (config.azureEndpoint || config.azureDeployment) {
+        return false;
       }
       return (
         isSupportedOpenAIGptLiveModel(config.model) &&

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -53,7 +53,11 @@ import {
   OPENAI_QUICKSILVER_CAPABILITIES,
   resolveOpenAIChatGptSubscriptionAuth,
 } from "./realtime-quicksilver-session.js";
-import { isOpenAIGptLiveModel } from "./realtime-quicksilver.js";
+import {
+  isOpenAIGptLiveModel,
+  isSupportedOpenAIGptLiveModel,
+  OPENAI_GPT_LIVE_MODELS,
+} from "./realtime-quicksilver.js";
 import {
   OpenAIRealtimeVoiceLifecycle,
   type OpenAIRealtimeVoiceConnection,
@@ -110,8 +114,7 @@ const OPENAI_REALTIME_MODELS = [
   "gpt-realtime-2.1",
   "gpt-realtime-2.1-mini",
   "gpt-realtime-2",
-  "gpt-live-1-codex",
-  "gpt-live-1-boulder-alpha",
+  ...OPENAI_GPT_LIVE_MODELS,
 ] as const;
 const OPENAI_REALTIME_INPUT_TRANSCRIPTION_MODEL = "gpt-4o-mini-transcribe";
 const OPENAI_REALTIME_CAPABILITIES: RealtimeVoiceProviderCapabilities = {
@@ -1727,12 +1730,18 @@ type OpenAIInternalRealtimeVoiceProviderApi = {
     cfg?: RealtimeVoiceBrowserSessionCreateRequest["cfg"];
     providerConfig: RealtimeVoiceProviderConfig;
     agentId?: string;
-  }) => boolean;
+  }) => boolean | undefined;
   resolveGatewayRelayCapabilities?: (ctx: {
     cfg?: RealtimeVoiceBrowserSessionCreateRequest["cfg"];
     providerConfig: RealtimeVoiceProviderConfig;
     model?: string;
   }) => OpenAIInternalRealtimeVoiceCapabilities;
+  validateGatewayRelayLaunch?: (ctx: {
+    cfg?: RealtimeVoiceBrowserSessionCreateRequest["cfg"];
+    providerConfig: RealtimeVoiceProviderConfig;
+    model?: string;
+    autoRespondToAudio?: boolean;
+  }) => string | undefined;
   cancelBrowserSession?: (
     request: OpenAIInternalRealtimeBrowserSessionCreateRequest,
     session: RealtimeVoiceBrowserSession,
@@ -2004,6 +2013,9 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
       }
       const model = config.model ?? OPENAI_REALTIME_DEFAULT_MODEL;
       if (isOpenAIGptLiveModel(model)) {
+        if (!isSupportedOpenAIGptLiveModel(model)) {
+          return false;
+        }
         return (
           options?.quicksilverBrowserSessionBroker !== undefined &&
           (hasOpenAIRealtimePlatformAuthInput({
@@ -2014,13 +2026,17 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
         );
       }
       return (
-        options?.quicksilverBrowserSessionBroker !== undefined &&
-        hasOpenAIChatGptSubscriptionAuthInput({ cfg, agentId })
+        hasOpenAIRealtimePlatformAuthInput({
+          configuredApiKey: config.apiKey,
+          cfg,
+        }) ||
+        (options?.quicksilverBrowserSessionBroker !== undefined &&
+          hasOpenAIChatGptSubscriptionAuthInput({ cfg, agentId }))
       );
     },
     resolveBrowserSessionCapabilities: ({ providerConfig, model }) => {
       const config = normalizeProviderConfig(providerConfig);
-      if (isOpenAIGptLiveModel(model ?? config.model)) {
+      if (isSupportedOpenAIGptLiveModel(model ?? config.model)) {
         return {
           ...OPENAI_REALTIME_CAPABILITIES,
           ...OPENAI_QUICKSILVER_CAPABILITIES,
@@ -2030,22 +2046,37 @@ export function buildOpenAIRealtimeVoiceProvider(options?: {
     },
     isGatewayRelayConfigured: ({ cfg, providerConfig, agentId }) => {
       const config = normalizeProviderConfig(providerConfig);
+      if (config.azureEndpoint || config.azureDeployment) {
+        return false;
+      }
+      if (!isOpenAIGptLiveModel(config.model)) {
+        return undefined;
+      }
       return (
-        !config.azureEndpoint &&
-        !config.azureDeployment &&
-        isOpenAIGptLiveModel(config.model) &&
-        hasOpenAIChatGptSubscriptionAuthInput({ cfg, agentId })
+        isSupportedOpenAIGptLiveModel(config.model) &&
+        (hasOpenAIRealtimePlatformAuthInput({
+          configuredApiKey: config.apiKey,
+          cfg,
+        }) ||
+          hasOpenAIChatGptSubscriptionAuthInput({ cfg, agentId }))
       );
     },
     resolveGatewayRelayCapabilities: ({ providerConfig, model }) => {
       const config = normalizeProviderConfig(providerConfig);
-      if (isOpenAIGptLiveModel(model ?? config.model)) {
+      if (isSupportedOpenAIGptLiveModel(model ?? config.model)) {
         return {
           ...OPENAI_REALTIME_CAPABILITIES,
           ...OPENAI_QUICKSILVER_CAPABILITIES,
         };
       }
       return OPENAI_REALTIME_CAPABILITIES;
+    },
+    validateGatewayRelayLaunch: ({ providerConfig, model, autoRespondToAudio }) => {
+      const config = normalizeProviderConfig(providerConfig);
+      if (autoRespondToAudio === false && isOpenAIGptLiveModel(model ?? config.model)) {
+        return "GPT-Live gateway-relay sessions cannot use forced agent consult routing; GPT-Live delegates to the agent natively";
+      }
+      return undefined;
     },
     cancelBrowserSession: cancelOpenAIRealtimeBrowserSession,
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ overrides:
   brace-expansion: 5.0.8
   file-type: 22.0.1
   form-data: 4.0.6
-  werift-ice>ip: npm:neoip@3.1.0
+  werift-ice@0.2.2>ip: npm:neoip@3.1.0
   ip-address: 10.3.1
   minimatch: 10.2.5
   path-to-regexp: 8.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1482,6 +1482,12 @@ importers:
 
   extensions/openai:
     dependencies:
+      libopus-wasm:
+        specifier: 0.2.0
+        version: 0.2.0
+      werift:
+        specifier: 0.24.1
+        version: 0.24.1(supports-color@10.2.2)
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -3213,6 +3219,14 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@fidm/asn1@1.0.4':
+    resolution: {integrity: sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ==}
+    engines: {node: '>= 8'}
+
+  '@fidm/x509@1.2.1':
+    resolution: {integrity: sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w==}
+    engines: {node: '>= 8'}
+
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
 
@@ -3676,6 +3690,9 @@ packages:
   '@larksuiteoapi/node-sdk@1.71.1':
     resolution: {integrity: sha512-Z4cZmgWvwiE7tCHqGm+t7DKvbpNRRTH2HqVwcYiOMAwbjIytXSoQqWytsOVu3p+d0fIvrtyIPZok5HOV/VNxxw==}
 
+  '@leichtgewicht/ip-codec@2.0.5':
+    resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
+
   '@lezer/common@1.5.2':
     resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
 
@@ -3834,6 +3851,9 @@ packages:
     resolution: {integrity: sha512-PufhROXKhsC/h6ZKuquPzvNBB1Q9lHHu//vZGfRj3yD+hgtQkEz2YzXZDYC3h0bDN4ej2KtvkDGrsovqrnU0cQ==}
     engines: {node: '>=20'}
 
+  '@minhducsun2002/leb128@1.0.0':
+    resolution: {integrity: sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g==}
+
   '@mistralai/mistralai@2.5.0':
     resolution: {integrity: sha512-S/r6tkiUHblaDJGsb84WS0ePTF2YHVta2EoTi1NJqHNt5mfRRS2uE4v7hCYV134+an+fk6WgG3+aFfinJbQBjQ==}
     peerDependencies:
@@ -3884,6 +3904,10 @@ packages:
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@2.0.1':
     resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
     engines: {node: '>= 20.19.0'}
@@ -3894,6 +3918,10 @@ packages:
 
   '@noble/ed25519@3.1.0':
     resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
@@ -4546,6 +4574,43 @@ packages:
   '@parse5/tools@0.3.0':
     resolution: {integrity: sha512-zxRyTHkqb7WQMV8kTNBKWb1BeOFUKXBXTBWuxg9H9hfvQB3IwP6Iw2U75Ia5eyRxPNltmY7E8YAlz6zWwUnjKg==}
 
+  '@peculiar/asn1-cms@2.8.0':
+    resolution: {integrity: sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==}
+
+  '@peculiar/asn1-csr@2.8.0':
+    resolution: {integrity: sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==}
+
+  '@peculiar/asn1-ecc@2.8.0':
+    resolution: {integrity: sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==}
+
+  '@peculiar/asn1-pfx@2.8.0':
+    resolution: {integrity: sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==}
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    resolution: {integrity: sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==}
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    resolution: {integrity: sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==}
+
+  '@peculiar/asn1-rsa@2.8.0':
+    resolution: {integrity: sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==}
+
+  '@peculiar/asn1-schema@2.8.0':
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    resolution: {integrity: sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==}
+
+  '@peculiar/asn1-x509@2.8.0':
+    resolution: {integrity: sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
+
   '@pierre/diffs@1.2.12':
     resolution: {integrity: sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ==}
     peerDependencies:
@@ -4884,6 +4949,13 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@shinyoshiaki/binary-data@0.6.1':
+    resolution: {integrity: sha512-7HDb/fQAop2bCmvDIzU5+69i+UJaFgIVp99h1VzK1mpg1JwSODOkjbqD7ilTYnqlnadF8C4XjpwpepxDsGY6+w==}
+    engines: {node: '>=6'}
+
+  '@shinyoshiaki/jspack@0.0.6':
+    resolution: {integrity: sha512-SdsNhLjQh4onBlyPrn4ia1Pdx5bXT88G/LIEpOYAjx2u4xeY/m/HB5yHqlkJB1uQR3Zw4R3hBWLj46STRAN0rg==}
+
   '@shoelace-style/animations@1.2.0':
     resolution: {integrity: sha512-avvo1xxkLbv2dgtabdewBbqcJfV0e0zCwFqkPMnHFGbJbBHorRFfMAHh1NG9ymmXn0jW95ibUVH03E1NYXD6Gw==}
 
@@ -5202,6 +5274,12 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/dom-mediacapture-transform@0.1.12':
+    resolution: {integrity: sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==}
+
+  '@types/dom-webcodecs@0.1.13':
+    resolution: {integrity: sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -5579,6 +5657,9 @@ packages:
     resolution: {integrity: sha512-EdGgMx5osY4bNpVN+7dTTT67ZXsFqx/itl4QjGYTKH/Nzm3fqGmWL3E6FjRkVrlWRpiFnRNi+J1lxUJPie4lmg==}
     engines: {node: '>=22.13.0'}
 
+  aes-js@3.1.2:
+    resolution: {integrity: sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -5653,6 +5734,10 @@ packages:
 
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -5819,11 +5904,18 @@ packages:
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -6090,8 +6182,21 @@ packages:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
+
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -6169,6 +6274,10 @@ packages:
 
   discord-api-types@0.38.52:
     resolution: {integrity: sha512-uwe9EKfbjsmgWc2fdFjvDbj+dQqx3lp7wqDCmIha0jInuU+xeQjkCK9tMMn+p7RXfdVQORCInq4cD3U2ymDmyg==}
+
+  dns-packet@5.6.1:
+    resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
+    engines: {node: '>=6'}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -6538,6 +6647,9 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -6775,9 +6887,15 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  int64-buffer@1.1.1:
+    resolution: {integrity: sha512-xp/v0/im2q7n7ISFJXcYsr/aVsUdZKPUZS1uYtoM9I9Cfmm5YuAi7SQts2TrEXwAKIE0wyn3KxJbo35goJgvwQ==}
+
   ip-address@10.3.1:
     resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
+
+  ip@2.0.1:
+    resolution: {integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -6860,11 +6978,18 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
@@ -6887,6 +7012,10 @@ packages:
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
+
+  isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -7227,6 +7356,9 @@ packages:
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
@@ -7374,6 +7506,9 @@ packages:
   media-typer@2.0.0:
     resolution: {integrity: sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==}
     engines: {node: '>=18'}
+
+  mediabunny@1.51.0:
+    resolution: {integrity: sha512-u327374xU8Ho0gCaMII7fUK8t0PnqkabCox1k8uUwvgvGb9o6YQGZEG2Qr4DTe7nTMpzfL7ukgnHDvDROySZ+Q==}
 
   meow@14.1.0:
     resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
@@ -7543,6 +7678,9 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
+  mp4box@0.5.4:
+    resolution: {integrity: sha512-GcCH0fySxBurJtvr0dfhz0IxHZjc1RP+F+I8xw+LIwkU1a+7HJx8NCDiww1I5u4Hz6g4eR1JlGADEGJ9r4lSfA==}
+
   mpg123-decoder@1.0.3:
     resolution: {integrity: sha512-+fjxnWigodWJm3+4pndi+KUg9TBojgn31DPk85zEsim7C6s0X5Ztc/hQYdytXkwuGXH+aB0/aEkG40Emukv6oQ==}
 
@@ -7552,6 +7690,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multicast-dns@7.2.5:
+    resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
+    hasBin: true
 
   music-metadata@11.14.0:
     resolution: {integrity: sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ==}
@@ -7761,6 +7903,10 @@ packages:
         optional: true
       vite-plus:
         optional: true
+
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
@@ -8034,6 +8180,13 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   qified@0.10.1:
     resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
     engines: {node: '>=20'}
@@ -8219,6 +8372,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rx.mini@1.4.0:
+    resolution: {integrity: sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA==}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -8575,6 +8731,9 @@ packages:
   thread-stream@3.2.0:
     resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
 
+  thunky@1.1.0:
+    resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -8689,6 +8848,9 @@ packages:
       unrun:
         optional: true
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -8704,9 +8866,16 @@ packages:
     resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
     engines: {node: '>=18.0.0'}
 
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
+
   tuf-js@6.0.0:
     resolution: {integrity: sha512-zlJVOIO68hmgo1//X4ENEcTGfuOTAtDPi8PsTsG+FyxD85E/ww1ZnwBbWo/yCEExGpI+Kilg7Z3qCdHX2BoJTQ==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -8983,6 +9152,29 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  werift-common@0.0.3:
+    resolution: {integrity: sha512-ma3E4BqKTyZVLhrdfTVs2T1tg9seeUtKMRn5e64LwgrogWa62+3LAUoLBUSl1yPWhgSkXId7GmcHuWDen9IJeQ==}
+    engines: {node: '>=16'}
+
+  werift-dtls@0.5.7:
+    resolution: {integrity: sha512-z2fjbP7fFUFmu/Ky4bCKXzdgPTtmSY1DYi0TUf3GG2zJT4jMQ3TQmGY8y7BSSNGetvL4h3pRZ5un0EcSOWpPog==}
+    engines: {node: '>=16'}
+
+  werift-ice@0.2.2:
+    resolution: {integrity: sha512-td52pHp+JmFnUn5jfDr/SSNO0dMCbknhuPdN1tFp9cfRj5jaktN63qnAdUuZC20QCC3ETWdsOthcm+RalHpFCQ==}
+
+  werift-rtp@0.8.8:
+    resolution: {integrity: sha512-GiYMSdvCyScQaw5bnEsraSoHUVZpjfokJAiLV4R1FsiB06t6XiebPYPpkqB9nYNNKiA8Z/cYWsym7wISq1sYSQ==}
+    engines: {node: '>=10'}
+
+  werift-sctp@0.0.11:
+    resolution: {integrity: sha512-7109yuI5U7NTEHjqjn0A8VeynytkgVaxM6lRr1Ziv0D8bPcaB8A7U/P88M7WaCpWDoELHoXiRUjQycMWStIgjQ==}
+    engines: {node: '>=10'}
+
+  werift@0.24.1:
+    resolution: {integrity: sha512-8Mpf0FWO2pkd9UQyZ0Hb1CcimydlNh8KCvZGD2X/D0ucVY6ubJxX91cndOpTOnPA7wleopop044VSNZeCEwgeA==}
+    engines: {node: '>=16'}
 
   whatsapp-rust-bridge@0.5.4:
     resolution: {integrity: sha512-yYO1qSs0Fe7tGtnxOFHomocUD6IZtoAgmA4oDFyGIRZ67D3QZk3w7swA6XXFXNQngiyrg2k7tul6IrM3eUFh7A==}
@@ -10226,6 +10418,13 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.2.0
 
+  '@fidm/asn1@1.0.4': {}
+
+  '@fidm/x509@1.2.1':
+    dependencies:
+      '@fidm/asn1': 1.0.4
+      tweetnacl: 1.0.3
+
   '@floating-ui/core@1.8.0':
     dependencies:
       '@floating-ui/utils': 0.2.12
@@ -10601,6 +10800,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@leichtgewicht/ip-codec@2.0.5': {}
+
   '@lezer/common@1.5.2': {}
 
   '@lezer/cpp@1.1.6':
@@ -10858,6 +11059,8 @@ snapshots:
       - debug
       - supports-color
 
+  '@minhducsun2002/leb128@1.0.0': {}
+
   '@mistralai/mistralai@2.5.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/semantic-conventions': 1.43.0
@@ -10921,6 +11124,10 @@ snapshots:
 
   '@noble/ciphers@2.2.0': {}
 
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/curves@2.0.1':
     dependencies:
       '@noble/hashes': 2.0.1
@@ -10930,6 +11137,8 @@ snapshots:
       '@noble/hashes': 2.2.0
 
   '@noble/ed25519@3.1.0': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
 
@@ -11430,6 +11639,100 @@ snapshots:
     dependencies:
       parse5: 7.3.0
 
+  '@peculiar/asn1-cms@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pfx': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.8.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-csr': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-pkcs9': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
+
   '@pierre/diffs@1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@pierre/theme': 1.1.0
@@ -11659,6 +11962,13 @@ snapshots:
       '@types/hast': 3.0.5
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@shinyoshiaki/binary-data@0.6.1':
+    dependencies:
+      generate-function: 2.3.1
+      is-plain-object: 2.0.4
+
+  '@shinyoshiaki/jspack@0.0.6': {}
 
   '@shoelace-style/animations@1.2.0': {}
 
@@ -12016,6 +12326,12 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/dom-mediacapture-transform@0.1.12':
+    dependencies:
+      '@types/dom-webcodecs': 0.1.13
+
+  '@types/dom-webcodecs@0.1.13': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -12422,6 +12738,8 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  aes-js@3.1.2: {}
+
   agent-base@6.0.2(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -12494,6 +12812,12 @@ snapshots:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
+
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
 
   assertion-error@2.0.1: {}
 
@@ -12658,9 +12982,16 @@ snapshots:
     dependencies:
       base-x: 5.0.1
 
+  buffer-crc32@1.0.0: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -12918,7 +13249,17 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  date-fns@2.30.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
+
   date-fns@4.4.0: {}
+
+  debug@4.4.0(supports-color@10.2.2):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -12979,6 +13320,10 @@ snapshots:
   dijkstrajs@1.0.3: {}
 
   discord-api-types@0.38.52: {}
+
+  dns-packet@5.6.1:
+    dependencies:
+      '@leichtgewicht/ip-codec': 2.0.5
 
   dom-serializer@2.0.0:
     dependencies:
@@ -13418,6 +13763,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
@@ -13728,7 +14077,11 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  int64-buffer@1.1.1: {}
+
   ip-address@10.3.1: {}
+
+  ip@2.0.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -13820,9 +14173,15 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
+
   is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
+
+  is-property@1.0.2: {}
 
   is-stream@4.0.1: {}
 
@@ -13838,6 +14197,8 @@ snapshots:
 
   isexe@4.0.0:
     optional: true
+
+  isobject@3.0.1: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -14186,6 +14547,8 @@ snapshots:
 
   lodash.truncate@4.4.2: {}
 
+  lodash@4.18.1: {}
+
   log-symbols@7.0.1:
     dependencies:
       is-unicode-supported: 2.1.0
@@ -14431,6 +14794,11 @@ snapshots:
   media-typer@1.1.1: {}
 
   media-typer@2.0.0: {}
+
+  mediabunny@1.51.0:
+    dependencies:
+      '@types/dom-mediacapture-transform': 0.1.12
+      '@types/dom-webcodecs': 0.1.13
 
   meow@14.1.0: {}
 
@@ -14716,6 +15084,8 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
+  mp4box@0.5.4: {}
+
   mpg123-decoder@1.0.3:
     dependencies:
       '@wasm-audio-decoders/common': 9.0.7
@@ -14723,6 +15093,11 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
+
+  multicast-dns@7.2.5:
+    dependencies:
+      dns-packet: 5.6.1
+      thunky: 1.1.0
 
   music-metadata@11.14.0(supports-color@10.2.2):
     dependencies:
@@ -15030,6 +15405,8 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.75.0
       oxlint-tsgolint: 7.0.2001
 
+  p-cancelable@2.1.1: {}
+
   p-finally@1.0.0: {}
 
   p-limit@2.3.0:
@@ -15261,6 +15638,12 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
 
   qified@0.10.1:
     dependencies:
@@ -15513,6 +15896,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rx.mini@1.4.0: {}
 
   safe-buffer@5.1.2: {}
 
@@ -15990,6 +16375,8 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  thunky@1.1.0: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -16077,6 +16464,8 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tslog@4.11.0: {}
@@ -16089,6 +16478,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
+
   tuf-js@6.0.0(supports-color@10.2.2):
     dependencies:
       '@gar/promise-retry': 1.0.3
@@ -16096,6 +16489,8 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  tweetnacl@1.0.3: {}
 
   type-is@2.1.0:
     dependencies:
@@ -16386,6 +16781,69 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
+
+  werift-common@0.0.3(supports-color@10.2.2):
+    dependencies:
+      '@shinyoshiaki/jspack': 0.0.6
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  werift-dtls@0.5.7:
+    dependencies:
+      '@fidm/x509': 1.2.1
+      '@noble/curves': 1.9.7
+      '@peculiar/x509': 1.14.3
+      '@shinyoshiaki/binary-data': 0.6.1
+      date-fns: 2.30.0
+      lodash: 4.18.1
+      rx.mini: 1.4.0
+      tweetnacl: 1.0.3
+
+  werift-ice@0.2.2(supports-color@10.2.2):
+    dependencies:
+      '@shinyoshiaki/jspack': 0.0.6
+      buffer-crc32: 1.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      int64-buffer: 1.1.1
+      ip: 2.0.1
+      lodash: 4.18.1
+      multicast-dns: 7.2.5
+      p-cancelable: 2.1.1
+      rx.mini: 1.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  werift-rtp@0.8.8:
+    dependencies:
+      '@minhducsun2002/leb128': 1.0.0
+      '@shinyoshiaki/jspack': 0.0.6
+      aes-js: 3.1.2
+      buffer: 6.0.3
+      mp4box: 0.5.4
+
+  werift-sctp@0.0.11:
+    dependencies:
+      '@shinyoshiaki/jspack': 0.0.6
+
+  werift@0.24.1(supports-color@10.2.2):
+    dependencies:
+      '@fidm/x509': 1.2.1
+      '@noble/curves': 1.9.7
+      '@peculiar/x509': 1.14.3
+      '@shinyoshiaki/binary-data': 0.6.1
+      buffer: 6.0.3
+      debug: 4.4.0(supports-color@10.2.2)
+      mediabunny: 1.51.0
+      multicast-dns: 7.2.5
+      tweetnacl: 1.0.3
+      werift-common: 0.0.3(supports-color@10.2.2)
+      werift-dtls: 0.5.7
+      werift-ice: 0.2.2(supports-color@10.2.2)
+      werift-rtp: 0.8.8
+      werift-sctp: 0.0.11
+    transitivePeerDependencies:
+      - supports-color
 
   whatsapp-rust-bridge@0.5.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ overrides:
   brace-expansion: 5.0.8
   file-type: 22.0.1
   form-data: 4.0.6
+  werift-ice>ip: npm:neoip@3.1.0
   ip-address: 10.3.1
   minimatch: 10.2.5
   path-to-regexp: 8.4.2
@@ -6894,9 +6895,6 @@ packages:
     resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
-  ip@2.0.1:
-    resolution: {integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==}
-
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -7710,6 +7708,9 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  neoip@3.1.0:
+    resolution: {integrity: sha512-KtkXRRp1XK2BzJpLF7PRHyndphWn/bU5XkQFUJtAdm6rdUenkJZwQDpxifG+Q/7PLpxhc+wdcZiE15L/cZhnXA==}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -14081,8 +14082,6 @@ snapshots:
 
   ip-address@10.3.1: {}
 
-  ip@2.0.1: {}
-
   ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.4.0: {}
@@ -15119,6 +15118,8 @@ snapshots:
   nanoid@5.1.16: {}
 
   negotiator@1.0.0: {}
+
+  neoip@3.1.0: {}
 
   node-addon-api@7.1.1: {}
 
@@ -16806,7 +16807,7 @@ snapshots:
       buffer-crc32: 1.0.0
       debug: 4.4.3(supports-color@10.2.2)
       int64-buffer: 1.1.1
-      ip: 2.0.1
+      ip: neoip@3.1.0
       lodash: 4.18.1
       multicast-dns: 7.2.5
       p-cancelable: 2.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -137,7 +137,7 @@ overrides:
   brace-expansion: 5.0.8
   file-type: 22.0.1
   form-data: 4.0.6
-  "werift-ice>ip": "npm:neoip@3.1.0"
+  "werift-ice@0.2.2>ip": "npm:neoip@3.1.0"
   ip-address: 10.3.1
   minimatch: 10.2.5
   path-to-regexp: 8.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -137,6 +137,7 @@ overrides:
   brace-expansion: 5.0.8
   file-type: 22.0.1
   form-data: 4.0.6
+  "werift-ice>ip": "npm:neoip@3.1.0"
   ip-address: 10.3.1
   minimatch: 10.2.5
   path-to-regexp: 8.4.2

--- a/src/gateway/server-methods/talk-client.ts
+++ b/src/gateway/server-methods/talk-client.ts
@@ -243,6 +243,7 @@ export const talkClientHandlers: GatewayRequestHandlers = {
       }
       const realtimeContext = await resolveTalkRealtimeProviderInstructions({
         config: runtimeConfig,
+        agentId: requestedAgentId,
         configuredInstructions: realtimeConfig.instructions,
         sessionKey: typedParams.sessionKey,
         // Legacy creates can drift to another agent's session at toolCall time, so

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -281,18 +281,18 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
         }
         const runtimeConfig = context.getRuntimeConfig();
         const realtimeConfig = buildTalkRealtimeConfig(runtimeConfig, params.provider);
-        const resolution = resolveConfiguredRealtimeVoiceProvider({
-          configuredProviderId: realtimeConfig.provider,
-          providerConfigs: realtimeConfig.providers,
-          cfg: runtimeConfig,
-          cfgForResolve: runtimeConfig,
-          defaultModel: realtimeConfig.model,
-          surface: "gateway-relay",
-          noRegisteredProviderMessage: "No realtime voice provider registered",
-        });
         const launchOptions = buildRealtimeVoiceLaunchOptions({
           requested: params,
           defaults: realtimeConfig,
+        });
+        const resolution = resolveConfiguredRealtimeVoiceProvider({
+          configuredProviderId: realtimeConfig.provider,
+          providerConfigs: realtimeConfig.providers,
+          providerConfigOverrides: launchOptions.model ? { model: launchOptions.model } : {},
+          cfg: runtimeConfig,
+          defaultModel: realtimeConfig.model,
+          surface: "gateway-relay",
+          noRegisteredProviderMessage: "No realtime voice provider registered",
         });
         const relayLaunch = resolveTalkRealtimeGatewayRelayLaunch({
           ...resolution,

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -16,6 +16,7 @@ import {
   validateTalkSessionSubmitToolResultParams,
   validateTalkSessionTurnParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { buildAgentMainSessionKey } from "../../routing/session-key.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../../talk/agent-run-control-shared.js";
 import { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
@@ -286,7 +287,7 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           cfg: runtimeConfig,
           cfgForResolve: runtimeConfig,
           defaultModel: realtimeConfig.model,
-          surface: "bridge",
+          surface: "gateway-relay",
           noRegisteredProviderMessage: "No realtime voice provider registered",
         });
         const launchOptions = buildRealtimeVoiceLaunchOptions({
@@ -300,12 +301,13 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           requireSessionKeyForProfile: true,
           warn: (message) => context.logGateway.warn(`talk realtime context: ${message}`),
         });
-        if (realtimeContext.requestedSessionKey) {
-          await ensureClientVoiceAgentSessionEntry({
-            agentId: realtimeContext.agentId,
-            sessionKey: realtimeContext.requestedSessionKey,
-          });
-        }
+        const sessionKey =
+          realtimeContext.requestedSessionKey ??
+          buildAgentMainSessionKey({ agentId: realtimeContext.agentId });
+        await ensureClientVoiceAgentSessionEntry({
+          agentId: realtimeContext.agentId,
+          sessionKey,
+        });
         const session = createTalkRealtimeRelaySession({
           context,
           connId,
@@ -315,7 +317,7 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           instructions: buildRealtimeInstructions(realtimeContext.instructions),
           tools: [REALTIME_VOICE_AGENT_CONSULT_TOOL, REALTIME_VOICE_AGENT_CONTROL_TOOL],
           model: launchOptions.model,
-          sessionKey: realtimeContext.requestedSessionKey,
+          sessionKey,
           voice: launchOptions.voice,
           language: normalizeOptionalLowercaseString(params.language),
           forceAgentConsultOnFinalTranscript:

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -1,4 +1,3 @@
-// Talk session methods manage realtime, transcription, handoff, turns, and cleanup.
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -20,6 +19,7 @@ import { buildAgentMainSessionKey } from "../../routing/session-key.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../../talk/agent-run-control-shared.js";
 import { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
+import { resolveTalkSessionAgentId } from "../../talk/agent-target.js";
 import { ensureClientVoiceAgentSessionEntry } from "../../talk/client-voice-session.js";
 import { resolveConfiguredRealtimeVoiceProvider } from "../../talk/provider-resolver.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
@@ -248,7 +248,7 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           token: handoff.token,
           roomId: handoff.roomId,
         });
-        respondOk(respond, {
+        return respondOk(respond, {
           sessionId: handoff.id,
           provider: handoff.provider,
           mode: handoff.mode,
@@ -262,7 +262,6 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           voice: handoff.voice,
           expiresAt: handoff.expiresAt,
         });
-        return;
       }
 
       const connId = client?.connId;
@@ -273,11 +272,10 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
 
       if (mode === "realtime") {
         if (transport !== "gateway-relay" || brain !== "agent-consult") {
-          respondInvalidRequest(
+          return respondInvalidRequest(
             respond,
             `realtime talk.session.create requires transport="gateway-relay" and brain="agent-consult"`,
           );
-          return;
         }
         const runtimeConfig = context.getRuntimeConfig();
         const realtimeConfig = buildTalkRealtimeConfig(runtimeConfig, params.provider);
@@ -285,14 +283,15 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           requested: params,
           defaults: realtimeConfig,
         });
+        const agentId = resolveTalkSessionAgentId(runtimeConfig, params.sessionKey);
         const resolution = resolveConfiguredRealtimeVoiceProvider({
           configuredProviderId: realtimeConfig.provider,
           providerConfigs: realtimeConfig.providers,
           providerConfigOverrides: launchOptions.model ? { model: launchOptions.model } : {},
           cfg: runtimeConfig,
+          agentId,
           defaultModel: realtimeConfig.model,
           surface: "gateway-relay",
-          noRegisteredProviderMessage: "No realtime voice provider registered",
         });
         const relayLaunch = resolveTalkRealtimeGatewayRelayLaunch({
           ...resolution,
@@ -302,11 +301,11 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
         });
         if (relayLaunch.error) {
           // GPT-Live delegates natively; forced transcript consults are a GA-model mode.
-          respondInvalidRequest(respond, relayLaunch.error);
-          return;
+          return respondInvalidRequest(respond, relayLaunch.error);
         }
         const realtimeContext = await resolveTalkRealtimeProviderInstructions({
           config: runtimeConfig,
+          agentId,
           configuredInstructions: realtimeConfig.instructions,
           sessionKey: params.sessionKey,
           requireSessionKeyForProfile: true,
@@ -341,7 +340,6 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
         respondOk(respond, {
           ...session,
           sessionId: session.relaySessionId,
-          // The relay session is the logical voice call; clients need not synthesize it.
           voiceSessionId: session.relaySessionId,
           mode,
           brain,

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -69,8 +69,8 @@ import {
   normalizeTalkSessionTransport,
   resolveConfiguredRealtimeTranscriptionProvider,
   resolveTalkRealtimeProviderInstructions,
+  resolveTalkRealtimeGatewayRelayLaunch,
   talkHandoffErrorCode,
-  withRealtimeBrowserOverrides,
 } from "./talk-shared.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -294,6 +294,17 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           requested: params,
           defaults: realtimeConfig,
         });
+        const relayLaunch = resolveTalkRealtimeGatewayRelayLaunch({
+          ...resolution,
+          cfg: runtimeConfig,
+          launchOptions,
+          consultRouting: realtimeConfig.consultRouting,
+        });
+        if (relayLaunch.error) {
+          // GPT-Live delegates natively; forced transcript consults are a GA-model mode.
+          respondInvalidRequest(respond, relayLaunch.error);
+          return;
+        }
         const realtimeContext = await resolveTalkRealtimeProviderInstructions({
           config: runtimeConfig,
           configuredInstructions: realtimeConfig.instructions,
@@ -313,15 +324,14 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           connId,
           cfg: runtimeConfig,
           provider: resolution.provider,
-          providerConfig: withRealtimeBrowserOverrides(resolution.providerConfig, launchOptions),
+          providerConfig: relayLaunch.providerConfig,
           instructions: buildRealtimeInstructions(realtimeContext.instructions),
           tools: [REALTIME_VOICE_AGENT_CONSULT_TOOL, REALTIME_VOICE_AGENT_CONTROL_TOOL],
           model: launchOptions.model,
           sessionKey,
           voice: launchOptions.voice,
           language: normalizeOptionalLowercaseString(params.language),
-          forceAgentConsultOnFinalTranscript:
-            realtimeConfig.consultRouting === "force-agent-consult",
+          forceAgentConsultOnFinalTranscript: relayLaunch.forceAgentConsultOnFinalTranscript,
         });
         rememberUnifiedTalkSession(session.relaySessionId, {
           kind: "realtime-relay",

--- a/src/gateway/server-methods/talk-shared.ts
+++ b/src/gateway/server-methods/talk-shared.ts
@@ -16,6 +16,7 @@ import {
 import { resolveRealtimeBootstrapContextInstructions } from "../../agents/realtime-bootstrap-context.js";
 import type { TalkRealtimeConfig } from "../../config/types.gateway.js";
 import type { OpenClawConfig } from "../../config/types.js";
+import type { RealtimeVoiceProviderPlugin } from "../../plugins/types.js";
 import {
   getRealtimeTranscriptionProvider,
   listRealtimeTranscriptionProviders,
@@ -24,6 +25,7 @@ import type { RealtimeTranscriptionProviderConfig } from "../../realtime-transcr
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME } from "../../talk/agent-run-control-shared.js";
 import { resolveTalkSessionAgentId, resolveTalkTargetAgentId } from "../../talk/agent-target.js";
+import { resolveInternalRealtimeVoiceGatewayRelayLaunchError } from "../../talk/provider-internal.js";
 import { listRealtimeVoiceProviders } from "../../talk/provider-registry.js";
 import type {
   RealtimeVoiceBrowserSession,
@@ -463,6 +465,28 @@ export function withRealtimeBrowserOverrides(
     overrides.reasoningEffort = reasoningEffort;
   }
   return Object.keys(overrides).length > 0 ? { ...providerConfig, ...overrides } : providerConfig;
+}
+
+export function resolveTalkRealtimeGatewayRelayLaunch(params: {
+  provider: RealtimeVoiceProviderPlugin;
+  providerConfig: RealtimeVoiceProviderConfig;
+  cfg: OpenClawConfig;
+  launchOptions: RealtimeVoiceLaunchOptions;
+  consultRouting?: string;
+}) {
+  const forceAgentConsultOnFinalTranscript = params.consultRouting === "force-agent-consult";
+  const providerConfig = withRealtimeBrowserOverrides(params.providerConfig, params.launchOptions);
+  return {
+    providerConfig,
+    forceAgentConsultOnFinalTranscript,
+    error: resolveInternalRealtimeVoiceGatewayRelayLaunchError({
+      provider: params.provider,
+      cfg: params.cfg,
+      providerConfig,
+      model: params.launchOptions.model,
+      autoRespondToAudio: !forceAgentConsultOnFinalTranscript,
+    }),
+  };
 }
 
 function pickRealtimeVoiceLaunchOptions(

--- a/src/gateway/server-methods/talk-shared.ts
+++ b/src/gateway/server-methods/talk-shared.ts
@@ -438,7 +438,7 @@ export function buildRealtimeVoiceLaunchOptions(params: {
   };
 }
 
-export function withRealtimeBrowserOverrides(
+function withRealtimeBrowserOverrides(
   providerConfig: RealtimeVoiceProviderConfig,
   params: RealtimeVoiceLaunchOptionInput,
 ): RealtimeVoiceProviderConfig {

--- a/src/gateway/server-methods/talk-shared.ts
+++ b/src/gateway/server-methods/talk-shared.ts
@@ -66,6 +66,7 @@ export function normalizeTalkSessionBrain(params: { mode: TalkMode; brain?: stri
 
 export async function resolveTalkRealtimeProviderInstructions(params: {
   config: OpenClawConfig;
+  agentId?: string;
   configuredInstructions?: string;
   sessionKey?: unknown;
   /** Relay sessions bind their agent lazily; injecting a guessed profile would mix agents. */
@@ -76,9 +77,11 @@ export async function resolveTalkRealtimeProviderInstructions(params: {
   const defaultAgentId = resolveTalkTargetAgentId(params.config);
   // Older clients can prefetch without a key. Client-owned creates bind to the
   // default agent immediately, so its workspace profile stays consistent there.
-  const agentId = requestedSessionKey
-    ? resolveTalkSessionAgentId(params.config, requestedSessionKey)
-    : defaultAgentId;
+  const agentId =
+    params.agentId ??
+    (requestedSessionKey
+      ? resolveTalkSessionAgentId(params.config, requestedSessionKey)
+      : defaultAgentId);
   const bootstrapContext =
     params.requireSessionKeyForProfile && !requestedSessionKey
       ? undefined

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -1859,6 +1859,7 @@ describe("talk.session unified handlers", () => {
     mocks.resolveConfiguredRealtimeVoiceProvider.mockImplementationOnce((input) => {
       expect(input).toEqual(
         expect.objectContaining({
+          agentId: "voice-agent",
           providerConfigOverrides: { model: "gpt-live-1-codex" },
           defaultModel: testCase.configuredModel,
           surface: "gateway-relay",
@@ -1891,6 +1892,7 @@ describe("talk.session unified handlers", () => {
         transport: "gateway-relay",
         brain: "agent-consult",
         provider: "openai",
+        sessionKey: "agent:voice-agent:main",
         ...(testCase.requestedModel ? { model: testCase.requestedModel } : {}),
       },
       respond,
@@ -1914,8 +1916,13 @@ describe("talk.session unified handlers", () => {
         provider,
         providerConfig: { model: "gpt-live-1-codex" },
         model: "gpt-live-1-codex",
+        sessionKey: "agent:voice-agent:main",
       }),
     );
+    expect(mocks.ensureClientVoiceAgentSessionEntry).toHaveBeenCalledWith({
+      agentId: "voice-agent",
+      sessionKey: "agent:voice-agent:main",
+    });
     expectRespondOk(respond, { relaySessionId: "relay-effective-model" });
   });
 

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -1838,6 +1838,87 @@ describe("talk.session unified handlers", () => {
     expect(closeRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
   });
 
+  it.each([
+    {
+      label: "request override from a configured GA model",
+      configuredModel: "gpt-realtime-2.1",
+      requestedModel: "gpt-live-1-codex",
+    },
+    {
+      label: "configured supported model without an override",
+      configuredModel: "gpt-live-1-codex",
+      requestedModel: undefined,
+    },
+  ])("resolves relay readiness from the effective model: $label", async (testCase) => {
+    const provider = {
+      id: "openai",
+      label: "OpenAI Realtime",
+      isConfigured: () => false,
+      createBridge: vi.fn(),
+    };
+    mocks.resolveConfiguredRealtimeVoiceProvider.mockImplementationOnce((input) => {
+      expect(input).toEqual(
+        expect.objectContaining({
+          providerConfigOverrides: { model: "gpt-live-1-codex" },
+          defaultModel: testCase.configuredModel,
+          surface: "gateway-relay",
+        }),
+      );
+      return {
+        provider,
+        providerConfig: { model: "gpt-live-1-codex" },
+      } as never;
+    });
+    mocks.createTalkRealtimeRelaySession.mockReturnValueOnce({
+      provider: "openai",
+      transport: "gateway-relay",
+      relaySessionId: "relay-effective-model",
+      audio: {
+        inputEncoding: "pcm16",
+        inputSampleRateHz: 24000,
+        outputEncoding: "pcm16",
+        outputSampleRateHz: 24000,
+      },
+      model: "gpt-live-1-codex",
+      voice: "marin",
+      expiresAt: 1_797_986_400,
+    });
+
+    const respond = vi.fn();
+    await callTalkHandler("talk.session.create", {
+      params: {
+        mode: "realtime",
+        transport: "gateway-relay",
+        brain: "agent-consult",
+        provider: "openai",
+        ...(testCase.requestedModel ? { model: testCase.requestedModel } : {}),
+      },
+      respond,
+      context: {
+        getRuntimeConfig: () =>
+          ({
+            talk: {
+              realtime: {
+                provider: "openai",
+                model: testCase.configuredModel,
+                providers: { openai: {} },
+              },
+            },
+          }) as OpenClawConfig,
+        logGateway: { warn: vi.fn() },
+      },
+    });
+
+    expect(mocks.createTalkRealtimeRelaySession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider,
+        providerConfig: { model: "gpt-live-1-codex" },
+        model: "gpt-live-1-codex",
+      }),
+    );
+    expectRespondOk(respond, { relaySessionId: "relay-effective-model" });
+  });
+
   it("rejects forced consult routing when the provider resolves gpt-live", async () => {
     const provider = {
       id: "openai",

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -46,6 +46,7 @@ const mocks = vi.hoisted(() => ({
   resolveRealtimeVoiceProviderCapabilities: vi.fn(
     ({ provider }: { provider: { capabilities?: unknown } }) => provider.capabilities,
   ),
+  resolveInternalRealtimeVoiceGatewayRelayLaunchError: vi.fn(),
   cancelInternalRealtimeVoiceBrowserSession: vi.fn(async () => undefined),
   createTalkRealtimeRelaySession: vi.fn(),
   sendTalkRealtimeRelayAudio: vi.fn(),
@@ -122,6 +123,8 @@ vi.mock("../../talk/provider-internal.js", async (importOriginal) => {
   return {
     ...actual,
     cancelInternalRealtimeVoiceBrowserSession: mocks.cancelInternalRealtimeVoiceBrowserSession,
+    resolveInternalRealtimeVoiceGatewayRelayLaunchError:
+      mocks.resolveInternalRealtimeVoiceGatewayRelayLaunchError,
   };
 });
 
@@ -1833,6 +1836,61 @@ describe("talk.session unified handlers", () => {
       connId: "conn-1",
     });
     expect(closeRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it("rejects forced consult routing when the provider resolves gpt-live", async () => {
+    const provider = {
+      id: "openai",
+      label: "OpenAI Realtime",
+      isConfigured: () => true,
+      createBridge: vi.fn(),
+    };
+    mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({
+      provider,
+      providerConfig: { model: "gpt-live-1-codex" },
+    });
+    mocks.resolveInternalRealtimeVoiceGatewayRelayLaunchError.mockReturnValueOnce(
+      "GPT-Live gateway-relay sessions cannot use forced agent consult routing; GPT-Live delegates to the agent natively",
+    );
+
+    const respond = vi.fn();
+    await callTalkHandler("talk.session.create", {
+      params: {
+        mode: "realtime",
+        transport: "gateway-relay",
+        brain: "agent-consult",
+        provider: "openai",
+        model: "gpt-live-1-codex",
+      },
+      respond,
+      context: {
+        getRuntimeConfig: () =>
+          ({
+            talk: {
+              realtime: {
+                provider: "openai",
+                providers: { openai: { model: "gpt-live-1-codex" } },
+                consultRouting: "force-agent-consult",
+              },
+            },
+          }) as OpenClawConfig,
+      },
+    });
+
+    expect(mocks.resolveInternalRealtimeVoiceGatewayRelayLaunchError).toHaveBeenCalledWith({
+      provider,
+      cfg: expect.any(Object),
+      providerConfig: { model: "gpt-live-1-codex" },
+      model: "gpt-live-1-codex",
+      autoRespondToAudio: false,
+    });
+    expectRespondError(respond, {
+      code: ErrorCodes.INVALID_REQUEST,
+      message:
+        "GPT-Live gateway-relay sessions cannot use forced agent consult routing; GPT-Live delegates to the agent natively",
+    });
+    expect(mocks.createTalkRealtimeRelaySession).not.toHaveBeenCalled();
+    expect(mocks.ensureClientVoiceAgentSessionEntry).not.toHaveBeenCalled();
   });
 
   it("returns classified talk issue details when realtime relay creation fails", async () => {

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -569,7 +569,7 @@ describe("talk.catalog handler", () => {
     );
   });
 
-  it("uses the bridge surface for gateway-relay catalog resolution", async () => {
+  it("uses the gateway-relay surface for relay catalog resolution", async () => {
     const isConfigured = vi.fn(() => true);
     const provider = {
       id: "relay",
@@ -607,10 +607,10 @@ describe("talk.catalog handler", () => {
     });
 
     expect(mocks.resolveConfiguredRealtimeVoiceProvider).toHaveBeenCalledWith(
-      expect.objectContaining({ surface: "bridge" }),
+      expect.objectContaining({ surface: "gateway-relay" }),
     );
     expect(mocks.resolveRealtimeVoiceProviderCapabilities).toHaveBeenCalledWith(
-      expect.objectContaining({ surface: "bridge" }),
+      expect.objectContaining({ surface: "gateway-relay" }),
     );
     expect(isConfigured).toHaveBeenCalledWith(expect.not.objectContaining({ surface: "bridge" }));
     const catalog = expectRespondOk(respond);
@@ -1671,7 +1671,7 @@ describe("talk.session unified handlers", () => {
       configuredProviderId: "openai",
       providerConfigs: { openai: { apiKey: "openai-key" } },
       defaultModel: "gpt-realtime-default",
-      surface: "bridge",
+      surface: "gateway-relay",
     });
     expect(mocks.ensureClientVoiceAgentSessionEntry).toHaveBeenCalledWith({
       agentId: "main",

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -246,7 +246,7 @@ function buildTalkCatalog(config: OpenClawConfig) {
   const activeTranscriptionProvider = transcriptionSelection.activeProvider;
   const realtimeConfig = buildTalkRealtimeConfig(config);
   const realtimeSurface =
-    realtimeConfig.transport === "gateway-relay" ? "bridge" : "browser-session";
+    realtimeConfig.transport === "gateway-relay" ? "gateway-relay" : "browser-session";
   // Mirror talk.client.create's resolution inputs (agent scope + top-level model
   // override) so catalog readiness matches what session creation will actually do;
   // diverging here previously reported GPT-Live over OAuth as unconfigured.

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -104,13 +104,17 @@ export function createTalkRealtimeRelaySession(
   let failureEmitted = false;
   const relayRef: { current?: RelaySession } = {};
   let consultAgentRuntime: ReturnType<typeof createPluginRuntime>["agent"] | undefined;
+  const relaySessionKey = params.sessionKey?.trim();
+  const relayAgentId = relaySessionKey
+    ? resolveTalkSessionAgentId(params.cfg ?? params.context.getRuntimeConfig(), relaySessionKey)
+    : undefined;
   const runAgentConsult = async ({ prompt, signal }: { prompt: string; signal?: AbortSignal }) => {
     const runtimeConfig = params.cfg ?? params.context.getRuntimeConfig();
-    const sessionKey = params.sessionKey?.trim();
+    const sessionKey = relaySessionKey;
     if (!sessionKey) {
       throw new Error("Realtime gateway-relay agent consult requires a pinned session key");
     }
-    const agentId = resolveTalkSessionAgentId(runtimeConfig, sessionKey);
+    const agentId = relayAgentId ?? resolveTalkSessionAgentId(runtimeConfig, sessionKey);
     consultAgentRuntime ??= createPluginRuntime().agent;
     const talkConfig = normalizeTalkSection(runtimeConfig.talk);
     return await consultRealtimeVoiceAgent({
@@ -160,7 +164,11 @@ export function createTalkRealtimeRelaySession(
   const relayProvider = {
     ...params.provider,
     createBridge: (request: Parameters<typeof params.provider.createBridge>[0]) =>
-      params.provider.createBridge({ ...request, runAgentConsult }),
+      params.provider.createBridge({
+        ...request,
+        ...(relayAgentId ? { agentId: relayAgentId } : {}),
+        runAgentConsult,
+      }),
   };
   const bridge = harness.createBridge({
     provider: relayProvider,

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/number-coercion";
+import { normalizeTalkSection } from "../config/talk.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { consultRealtimeVoiceAgent } from "../talk/agent-consult-runtime.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "../talk/agent-consult-tool.js";
 import { buildRealtimeVoiceAgentCancelProviderResult } from "../talk/agent-run-control-shared.js";
 import {
@@ -11,6 +14,7 @@ import { resolveTalkSessionAgentId } from "../talk/agent-target.js";
 import { REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ } from "../talk/provider-types.js";
 import { createRealtimeVoiceSessionHarness } from "../talk/realtime-session-harness.js";
 import type { TalkEventInput } from "../talk/talk-session-controller.js";
+import { registerChatAbortController } from "./chat-abort.js";
 import {
   buildAlreadyDeliveredToolResult,
   scheduleForcedAgentConsult,
@@ -26,6 +30,7 @@ import {
   closeRelaySession,
   enforceRelaySessionLimits,
   pruneInactiveRelayAgentRuns,
+  registerTalkRealtimeRelayAgentRun,
   steerTalkRealtimeRelayAgentRun,
 } from "./talk-realtime-relay-operations.js";
 import { suppressedToolResultOptions } from "./talk-realtime-relay-provider-results.js";
@@ -98,8 +103,67 @@ export function createTalkRealtimeRelaySession(
   let ready = false;
   let failureEmitted = false;
   const relayRef: { current?: RelaySession } = {};
+  let consultAgentRuntime: ReturnType<typeof createPluginRuntime>["agent"] | undefined;
+  const runAgentConsult = async ({ prompt, signal }: { prompt: string; signal?: AbortSignal }) => {
+    const runtimeConfig = params.cfg ?? params.context.getRuntimeConfig();
+    const sessionKey = params.sessionKey?.trim();
+    if (!sessionKey) {
+      throw new Error("Realtime gateway-relay agent consult requires a pinned session key");
+    }
+    const agentId = resolveTalkSessionAgentId(runtimeConfig, sessionKey);
+    consultAgentRuntime ??= createPluginRuntime().agent;
+    const talkConfig = normalizeTalkSection(runtimeConfig.talk);
+    return await consultRealtimeVoiceAgent({
+      cfg: runtimeConfig,
+      agentRuntime: consultAgentRuntime,
+      logger: params.context.logGateway,
+      agentId,
+      sessionKey,
+      messageProvider: "webchat",
+      lane: "talk",
+      runIdPrefix: "talk-realtime-relay-consult",
+      args: { question: prompt },
+      transcript: [],
+      surface: "a gateway-relay Talk session",
+      userLabel: "User",
+      questionSourceLabel: "user",
+      thinkLevel: talkConfig?.consultThinkingLevel,
+      fastMode: talkConfig?.consultFastMode,
+      abortSignal: signal,
+      onRunStarted: ({ runId, sessionId, timeoutMs }) => {
+        registerTalkRealtimeRelayAgentRun({
+          relaySessionId,
+          connId: params.connId,
+          sessionKey,
+          runId,
+        });
+        const registration = registerChatAbortController({
+          chatAbortControllers: params.context.chatAbortControllers,
+          runId,
+          sessionId,
+          sessionKey,
+          agentId,
+          timeoutMs,
+          ownerConnId: params.connId,
+          controlUiVisible: false,
+          kind: "chat-send",
+        });
+        return {
+          abortSignal: registration.controller.signal,
+          cleanup: registration.cleanup,
+        };
+      },
+    });
+  };
+  // The generic harness should stay transport-neutral. Wrap only this relay provider
+  // invocation so provider-owned delegations cannot acquire the host runner elsewhere.
+  const relayProvider = {
+    ...params.provider,
+    createBridge: (request: Parameters<typeof params.provider.createBridge>[0]) =>
+      params.provider.createBridge({ ...request, runAgentConsult }),
+  };
   const bridge = harness.createBridge({
-    provider: params.provider,
+    provider: relayProvider,
     cfg: params.cfg,
     providerConfig: params.providerConfig,
     audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -92,6 +92,35 @@ describe("talk realtime gateway relay", () => {
     };
   }
 
+  it("injects the host agent runner only into gateway-relay bridge creation", () => {
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    const provider = createIdleRelayProvider();
+    provider.createBridge = (request) => {
+      bridgeRequest = request;
+      return createIdleRelayProvider().createBridge(request);
+    };
+    const session = createTalkRealtimeRelaySession({
+      context: {
+        broadcastToConnIds: vi.fn(),
+        chatAbortControllers: new Map(),
+        getRuntimeConfig: () => ({}),
+        logGateway: { warn: vi.fn() },
+      } as never,
+      connId: "conn-runner",
+      provider,
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+      sessionKey: "agent:main:main",
+    });
+
+    expect(bridgeRequest?.runAgentConsult).toEqual(expect.any(Function));
+    stopTalkRealtimeRelaySession({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-runner",
+    });
+  });
+
   it("appends finalized relay transcripts to the canonical agent session", async () => {
     const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
     const tempDir = await fs.realpath(

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -115,6 +115,7 @@ describe("talk realtime gateway relay", () => {
     });
 
     expect(bridgeRequest?.runAgentConsult).toEqual(expect.any(Function));
+    expect(bridgeRequest?.agentId).toBe("main");
     stopTalkRealtimeRelaySession({
       relaySessionId: session.relaySessionId,
       connId: "conn-runner",

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -4,6 +4,7 @@
 export type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
 export type {
   RealtimeVoiceAudioFormat,
+  RealtimeVoiceAgentConsultRunner,
   RealtimeVoiceBargeInOptions,
   RealtimeVoiceBridge,
   RealtimeVoiceBridgeCallbacks,

--- a/src/talk/provider-internal.ts
+++ b/src/talk/provider-internal.ts
@@ -43,6 +43,16 @@ type InternalRealtimeVoiceProviderApi = {
     /** Effective per-session model after request overrides. */
     model?: string;
   }) => InternalRealtimeVoiceProviderCapabilities;
+  isGatewayRelayConfigured?: (ctx: {
+    cfg?: OpenClawConfig;
+    providerConfig: RealtimeVoiceProviderConfig;
+    agentId?: string;
+  }) => boolean;
+  resolveGatewayRelayCapabilities?: (ctx: {
+    cfg?: OpenClawConfig;
+    providerConfig: RealtimeVoiceProviderConfig;
+    model?: string;
+  }) => InternalRealtimeVoiceProviderCapabilities;
   cancelBrowserSession?: (
     request: InternalRealtimeVoiceBrowserSessionCreateRequest,
     session: RealtimeVoiceBrowserSession,
@@ -90,6 +100,34 @@ export function resolveInternalRealtimeVoiceBrowserSessionCapabilities(params: {
       model: params.model,
     },
   );
+}
+
+export function isInternalRealtimeVoiceGatewayRelayConfigured(params: {
+  provider: RealtimeVoiceProviderPlugin;
+  cfg?: OpenClawConfig;
+  providerConfig: RealtimeVoiceProviderConfig;
+  agentId?: string;
+}): boolean {
+  return (
+    readInternalRealtimeVoiceProviderApi(params.provider)?.isGatewayRelayConfigured?.({
+      cfg: params.cfg,
+      providerConfig: params.providerConfig,
+      agentId: params.agentId,
+    }) === true
+  );
+}
+
+export function resolveInternalRealtimeVoiceGatewayRelayCapabilities(params: {
+  provider: RealtimeVoiceProviderPlugin;
+  cfg?: OpenClawConfig;
+  providerConfig: RealtimeVoiceProviderConfig;
+  model?: string;
+}): InternalRealtimeVoiceProviderCapabilities | undefined {
+  return readInternalRealtimeVoiceProviderApi(params.provider)?.resolveGatewayRelayCapabilities?.({
+    cfg: params.cfg,
+    providerConfig: params.providerConfig,
+    model: params.model,
+  });
 }
 
 export async function cancelInternalRealtimeVoiceBrowserSession(params: {

--- a/src/talk/provider-internal.ts
+++ b/src/talk/provider-internal.ts
@@ -47,12 +47,18 @@ type InternalRealtimeVoiceProviderApi = {
     cfg?: OpenClawConfig;
     providerConfig: RealtimeVoiceProviderConfig;
     agentId?: string;
-  }) => boolean;
+  }) => boolean | undefined;
   resolveGatewayRelayCapabilities?: (ctx: {
     cfg?: OpenClawConfig;
     providerConfig: RealtimeVoiceProviderConfig;
     model?: string;
   }) => InternalRealtimeVoiceProviderCapabilities;
+  validateGatewayRelayLaunch?: (ctx: {
+    cfg?: OpenClawConfig;
+    providerConfig: RealtimeVoiceProviderConfig;
+    model?: string;
+    autoRespondToAudio?: boolean;
+  }) => string | undefined;
   cancelBrowserSession?: (
     request: InternalRealtimeVoiceBrowserSessionCreateRequest,
     session: RealtimeVoiceBrowserSession,
@@ -77,14 +83,12 @@ export function isInternalRealtimeVoiceBrowserSessionConfigured(params: {
   cfg?: OpenClawConfig;
   providerConfig: RealtimeVoiceProviderConfig;
   agentId?: string;
-}): boolean {
-  return (
-    readInternalRealtimeVoiceProviderApi(params.provider)?.isBrowserSessionConfigured({
-      cfg: params.cfg,
-      providerConfig: params.providerConfig,
-      agentId: params.agentId,
-    }) === true
-  );
+}): boolean | undefined {
+  return readInternalRealtimeVoiceProviderApi(params.provider)?.isBrowserSessionConfigured({
+    cfg: params.cfg,
+    providerConfig: params.providerConfig,
+    agentId: params.agentId,
+  });
 }
 
 export function resolveInternalRealtimeVoiceBrowserSessionCapabilities(params: {
@@ -107,14 +111,12 @@ export function isInternalRealtimeVoiceGatewayRelayConfigured(params: {
   cfg?: OpenClawConfig;
   providerConfig: RealtimeVoiceProviderConfig;
   agentId?: string;
-}): boolean {
-  return (
-    readInternalRealtimeVoiceProviderApi(params.provider)?.isGatewayRelayConfigured?.({
-      cfg: params.cfg,
-      providerConfig: params.providerConfig,
-      agentId: params.agentId,
-    }) === true
-  );
+}): boolean | undefined {
+  return readInternalRealtimeVoiceProviderApi(params.provider)?.isGatewayRelayConfigured?.({
+    cfg: params.cfg,
+    providerConfig: params.providerConfig,
+    agentId: params.agentId,
+  });
 }
 
 export function resolveInternalRealtimeVoiceGatewayRelayCapabilities(params: {
@@ -127,6 +129,21 @@ export function resolveInternalRealtimeVoiceGatewayRelayCapabilities(params: {
     cfg: params.cfg,
     providerConfig: params.providerConfig,
     model: params.model,
+  });
+}
+
+export function resolveInternalRealtimeVoiceGatewayRelayLaunchError(params: {
+  provider: RealtimeVoiceProviderPlugin;
+  cfg?: OpenClawConfig;
+  providerConfig: RealtimeVoiceProviderConfig;
+  model?: string;
+  autoRespondToAudio?: boolean;
+}): string | undefined {
+  return readInternalRealtimeVoiceProviderApi(params.provider)?.validateGatewayRelayLaunch?.({
+    cfg: params.cfg,
+    providerConfig: params.providerConfig,
+    model: params.model,
+    autoRespondToAudio: params.autoRespondToAudio,
   });
 }
 

--- a/src/talk/provider-resolver.test.ts
+++ b/src/talk/provider-resolver.test.ts
@@ -19,6 +19,14 @@ function attachInternalRealtimeVoiceProviderApi(
       providerConfig: Record<string, unknown>;
       model?: string;
     }) => object;
+    isGatewayRelayConfigured?: (ctx: {
+      providerConfig: Record<string, unknown>;
+      agentId?: string;
+    }) => boolean;
+    resolveGatewayRelayCapabilities?: (ctx: {
+      providerConfig: Record<string, unknown>;
+      model?: string;
+    }) => object;
   },
 ): void {
   Object.defineProperty(provider, INTERNAL_REALTIME_VOICE_PROVIDER, {
@@ -111,6 +119,36 @@ describe("realtime voice provider resolver", () => {
     expect(isBrowserSessionConfigured).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "voice-agent" }),
     );
+  });
+
+  it("limits internal relay readiness to the gateway-relay surface", () => {
+    const relayOnly: RealtimeVoiceProviderPlugin = {
+      id: "relay-only",
+      label: "Relay only",
+      isConfigured: () => false,
+      createBridge: () => {
+        throw new Error("unused");
+      },
+    };
+    attachInternalRealtimeVoiceProviderApi(relayOnly, {
+      isBrowserSessionConfigured: () => false,
+      isGatewayRelayConfigured: () => true,
+    });
+
+    expect(() =>
+      resolveConfiguredRealtimeVoiceProvider({
+        configuredProviderId: "relay-only",
+        providers: [relayOnly],
+        surface: "bridge",
+      }),
+    ).toThrow('Realtime voice provider "relay-only" is not configured');
+    expect(
+      resolveConfiguredRealtimeVoiceProvider({
+        configuredProviderId: "relay-only",
+        providers: [relayOnly],
+        surface: "gateway-relay",
+      }).provider,
+    ).toBe(relayOnly);
   });
 
   it("applies a default model before provider config resolution", () => {

--- a/src/talk/provider-resolver.test.ts
+++ b/src/talk/provider-resolver.test.ts
@@ -22,7 +22,7 @@ function attachInternalRealtimeVoiceProviderApi(
     isGatewayRelayConfigured?: (ctx: {
       providerConfig: Record<string, unknown>;
       agentId?: string;
-    }) => boolean;
+    }) => boolean | undefined;
     resolveGatewayRelayCapabilities?: (ctx: {
       providerConfig: Record<string, unknown>;
       model?: string;
@@ -149,6 +149,59 @@ describe("realtime voice provider resolver", () => {
         surface: "gateway-relay",
       }).provider,
     ).toBe(relayOnly);
+  });
+
+  it("treats internal surface readiness as authoritative", () => {
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "surface-aware",
+      label: "Surface aware",
+      isConfigured: () => true,
+      createBridge: () => {
+        throw new Error("unused");
+      },
+    };
+    attachInternalRealtimeVoiceProviderApi(provider, {
+      isBrowserSessionConfigured: () => false,
+      isGatewayRelayConfigured: () => false,
+    });
+
+    expect(() =>
+      resolveConfiguredRealtimeVoiceProvider({
+        configuredProviderId: provider.id,
+        providers: [provider],
+        surface: "browser-session",
+      }),
+    ).toThrow('Realtime voice provider "surface-aware" is not configured');
+    expect(() =>
+      resolveConfiguredRealtimeVoiceProvider({
+        configuredProviderId: provider.id,
+        providers: [provider],
+        surface: "gateway-relay",
+      }),
+    ).toThrow('Realtime voice provider "surface-aware" is not configured');
+  });
+
+  it("falls back to public readiness when a surface hook is indeterminate", () => {
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "surface-fallback",
+      label: "Surface fallback",
+      isConfigured: () => true,
+      createBridge: () => {
+        throw new Error("unused");
+      },
+    };
+    attachInternalRealtimeVoiceProviderApi(provider, {
+      isBrowserSessionConfigured: () => false,
+      isGatewayRelayConfigured: () => undefined,
+    });
+
+    expect(
+      resolveConfiguredRealtimeVoiceProvider({
+        configuredProviderId: provider.id,
+        providers: [provider],
+        surface: "gateway-relay",
+      }).provider,
+    ).toBe(provider);
   });
 
   it("applies a default model before provider config resolution", () => {

--- a/src/talk/provider-resolver.ts
+++ b/src/talk/provider-resolver.ts
@@ -73,19 +73,19 @@ export function isRealtimeVoiceProviderConfigured(params: {
   agentId?: string;
   surface?: "browser-session" | "gateway-relay" | "bridge";
 }): boolean {
-  if (
-    params.provider.isConfigured({
-      cfg: params.cfg,
-      providerConfig: params.providerConfig,
-    })
-  ) {
-    return true;
+  const internalConfigured =
+    params.surface === "browser-session"
+      ? isInternalRealtimeVoiceBrowserSessionConfigured(params)
+      : params.surface === "gateway-relay"
+        ? isInternalRealtimeVoiceGatewayRelayConfigured(params)
+        : undefined;
+  if (internalConfigured !== undefined) {
+    return internalConfigured;
   }
-  return (
-    (params.surface === "browser-session" &&
-      isInternalRealtimeVoiceBrowserSessionConfigured(params)) ||
-    (params.surface === "gateway-relay" && isInternalRealtimeVoiceGatewayRelayConfigured(params))
-  );
+  return params.provider.isConfigured({
+    cfg: params.cfg,
+    providerConfig: params.providerConfig,
+  });
 }
 
 /** Resolve the configured realtime voice provider or auto-select the first configured one. */

--- a/src/talk/provider-resolver.ts
+++ b/src/talk/provider-resolver.ts
@@ -9,7 +9,9 @@ import { resolveConfiguredCapabilityProvider } from "../plugin-sdk/provider-sele
 import type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
 import {
   isInternalRealtimeVoiceBrowserSessionConfigured,
+  isInternalRealtimeVoiceGatewayRelayConfigured,
   resolveInternalRealtimeVoiceBrowserSessionCapabilities,
+  resolveInternalRealtimeVoiceGatewayRelayCapabilities,
   type InternalRealtimeVoiceProviderCapabilities,
 } from "./provider-internal.js";
 import { getRealtimeVoiceProvider, listRealtimeVoiceProviders } from "./provider-registry.js";
@@ -37,7 +39,7 @@ export type ResolveConfiguredRealtimeVoiceProviderParams = {
   /** Model injected before provider-specific resolveConfig runs. */
   defaultModel?: string;
   /** Runtime surface being selected. Defaults to the provider bridge path. */
-  surface?: "browser-session" | "bridge";
+  surface?: "browser-session" | "gateway-relay" | "bridge";
   noRegisteredProviderMessage?: string;
 };
 
@@ -47,10 +49,16 @@ export function resolveRealtimeVoiceProviderCapabilities(params: {
   cfg?: OpenClawConfig;
   /** Effective per-session model after request overrides. */
   model?: string;
-  surface?: "browser-session" | "bridge";
+  surface?: "browser-session" | "gateway-relay" | "bridge";
 }): InternalRealtimeVoiceProviderCapabilities | undefined {
   if (params.surface === "browser-session") {
     const internalCapabilities = resolveInternalRealtimeVoiceBrowserSessionCapabilities(params);
+    if (internalCapabilities) {
+      return internalCapabilities;
+    }
+  }
+  if (params.surface === "gateway-relay") {
+    const internalCapabilities = resolveInternalRealtimeVoiceGatewayRelayCapabilities(params);
     if (internalCapabilities) {
       return internalCapabilities;
     }
@@ -63,7 +71,7 @@ export function isRealtimeVoiceProviderConfigured(params: {
   cfg?: OpenClawConfig;
   providerConfig: RealtimeVoiceProviderConfig;
   agentId?: string;
-  surface?: "browser-session" | "bridge";
+  surface?: "browser-session" | "gateway-relay" | "bridge";
 }): boolean {
   if (
     params.provider.isConfigured({
@@ -74,7 +82,9 @@ export function isRealtimeVoiceProviderConfigured(params: {
     return true;
   }
   return (
-    params.surface === "browser-session" && isInternalRealtimeVoiceBrowserSessionConfigured(params)
+    (params.surface === "browser-session" &&
+      isInternalRealtimeVoiceBrowserSessionConfigured(params)) ||
+    (params.surface === "gateway-relay" && isInternalRealtimeVoiceGatewayRelayConfigured(params))
   );
 }
 

--- a/src/talk/provider-types.ts
+++ b/src/talk/provider-types.ts
@@ -106,6 +106,11 @@ export type RealtimeVoiceProviderConfiguredContext = {
   providerConfig: RealtimeVoiceProviderConfig;
 };
 
+export type RealtimeVoiceAgentConsultRunner = (params: {
+  prompt: string;
+  signal?: AbortSignal;
+}) => Promise<{ text: string }>;
+
 export type RealtimeVoiceBridgeCreateRequest = RealtimeVoiceBridgeCallbacks & {
   cfg?: OpenClawConfig;
   providerConfig: RealtimeVoiceProviderConfig;
@@ -115,6 +120,8 @@ export type RealtimeVoiceBridgeCreateRequest = RealtimeVoiceBridgeCallbacks & {
   autoRespondToAudio?: boolean;
   interruptResponseOnInputAudio?: boolean;
   tools?: RealtimeVoiceTool[];
+  /** Host-injected agent delegation runner for provider-owned realtime control channels. */
+  runAgentConsult?: RealtimeVoiceAgentConsultRunner;
 };
 
 export type RealtimeVoiceBrowserSessionCreateRequest = {
@@ -128,8 +135,8 @@ export type RealtimeVoiceBrowserSessionCreateRequest = {
   silenceDurationMs?: number;
   prefixPaddingMs?: number;
   reasoningEffort?: string;
-  /** Host-injected agent delegation runner for provider-owned browser control channels. */
-  runAgentConsult?: (params: { prompt: string; signal?: AbortSignal }) => Promise<{ text: string }>;
+  /** Host-injected agent delegation runner for provider-owned realtime control channels. */
+  runAgentConsult?: RealtimeVoiceAgentConsultRunner;
 };
 
 export type RealtimeVoiceBrowserAudioContract = {

--- a/src/talk/provider-types.ts
+++ b/src/talk/provider-types.ts
@@ -113,6 +113,8 @@ export type RealtimeVoiceAgentConsultRunner = (params: {
 
 export type RealtimeVoiceBridgeCreateRequest = RealtimeVoiceBridgeCallbacks & {
   cfg?: OpenClawConfig;
+  /** Host-selected agent scope for provider auth and agent-owned bridge state. */
+  agentId?: string;
   providerConfig: RealtimeVoiceProviderConfig;
   audioFormat?: RealtimeVoiceAudioFormat;
   instructions?: string;

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -129,6 +129,7 @@ describe("scripts/test-live-shard", () => {
     expect(selectLiveShardFiles("native-live-extensions-openai", allFiles)).toEqual([
       "extensions/openai/openai-provider.live.test.ts",
       "extensions/openai/openai.live.test.ts",
+      "extensions/openai/realtime-quicksilver-gateway-bridge.live.test.ts",
       "extensions/openai/realtime-quicksilver.live.test.ts",
     ]);
     expect(selectLiveShardFiles("native-live-extensions-l-n", allFiles)).toEqual([


### PR DESCRIPTION
Related: #115622

## What Problem This Solves

GPT-Live worked in browser Talk, but clients using the Gateway realtime relay could not establish a GPT-Live media session. The relay also lacked the host-injected agent consultation seam needed for GPT-Live delegations, so enabling the route without that lifecycle would have lost confirmation, steering, and cancellation behavior.

## Why This Change Was Made

This composes with the Platform-key backend WebSocket bridge landed in #115622 and adds the Gateway-owned WebRTC route: a full-candidate werift peer, WASM-only Opus encode/decode, PCM16 mono 24 kHz relay conversion, paced silence while the microphone is idle, direct receiver-level RTP subscription, and OpenAI sideband control. The generic Plugin SDK contract gains a named `RealtimeVoiceAgentConsultRunner`, optional bridge runner injection, and optional agent scope so provider auth is resolved for the selected relay agent.

The negotiated RTP track is the canonical output-audio source. If OpenAI also emits `output_audio.delta` on the sideband, the bridge records the event but drops the duplicate audio payload. Browser and Gateway GPT-Live sessions share the existing eight-session process cap, and startup/teardown now cleanly cover late peers, partial codecs, sockets, timers, and delegations.

This PR was AI-assisted. I reviewed the implementation, ran the repository autoreview workflow to a clean result, and understand the resulting code and lifecycle.

## User Impact

GPT-Live can now be used through browser Talk and the Gateway relay.

| Consumer | GPT-Live status |
| --- | --- |
| Browser Talk | Supported through the existing WebRTC broker |
| Gateway relay | Supported through the new werift WebRTC bridge |
| Discord bidi / Voice Call | Retains the Platform-key backend WebSocket support from #115622 |
| Android relay | Still intentionally gated; the next flip requires live proof from an Android device |

Azure endpoint/deployment configurations remain excluded from the ChatGPT OAuth Gateway-relay route.

## Evidence

- Live OAuth proof on the Gateway peer: `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_GPT_LIVE=1 node scripts/test-live.mjs -- extensions/openai/realtime-gpt-live-gateway-bridge.live.test.ts` passed at the rebased head. The test created the real `/v1/live` call, applied the answer, joined sideband, observed `session.started`, and asserted non-empty decoded PCM from inbound RTP.
- Instrumented diagnosis reached ICE and DTLS connected. Raw RTP / receiver RTP / decoded PCM counters were 55 / 55 / 55 at 5 seconds and 1,274 / 1,274 / 1,274 at 30 seconds. This isolated the original false-negative to track delivery/subscription rather than server audio generation; the production bridge now subscribes directly to the transceiver receiver after applying the answer.
- Focused post-rebase Vitest: 250 tests passed across the OpenAI GPT-Live/provider, Gateway Talk relay/server methods, and provider resolver lanes.
- Exact-head all-project `tsgo` and `pnpm build` passed after reconciling the rebased lockfile. Build verified all 146 public Plugin SDK subpaths and emitted no ineffective-dynamic-import warning.
- Pre-rebase Linux Testbox proof with the final lifecycle fixes: action run 30438861066 passed all-project `tsgo` plus `pnpm build`. The rebased exact-head rerun hit Testbox full-sync dependency metadata skew, so the trusted-source local fallback was used after `pnpm install --prefer-offline`.
- Docs validation passed: 761 MDX files and 6,301 internal links, with zero broken links.
- Plugin SDK API generation and surface check passed. No tracked API-baseline or surface-budget increase was required.
- Production dependency audit passes with no high-or-higher advisories. `werift-ice`'s vulnerable `ip@2.0.1` transitive dependency is replaced by an API-compatible, dependency-scoped `neoip` alias.
- Final full-branch autoreview: clean, no accepted/actionable findings.

Runtime dependencies remain plugin-local:

- `werift@0.24.1`, released 2026-07-24
- `libopus-wasm@0.2.0`, released 2026-06-01
- `neoip@3.1.0`, released 2026-01-23 (scoped replacement for `werift-ice>ip`)

No changelog entry is included; maintainer landing automation owns that step.

