### PR TITLE
fix(codex): suppress missing-tool-result lastToolError when turn has a deliverable answer (#115489)

### DIFF
--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -443,6 +443,7 @@ export class CodexToolTranscriptProjection {
   synthesizeMissingToolResults(params: {
     synthesize: boolean;
     recordPromptError: boolean;
+    suppressLastToolError?: boolean;
   }): string | undefined {
     if (!params.synthesize) {
       return undefined;
@@ -485,7 +486,15 @@ export class CodexToolTranscriptProjection {
       });
     }
     if (!params.recordPromptError) {
-      this.recordMissingToolError(missingTranscriptIds, missingTrajectoryIds);
+      // When the completed turn already produced a deliverable assistant answer,
+      // do not promote the bookkeeping mismatch to lastToolError: the channel
+      // would surface it as a user-visible failure even though a complete answer
+      // exists in the transcript (#115489). Explicit aborts still leave
+      // lastToolError set for diagnostics — suppressLastToolError is only true
+      // when hasDeliverableAssistantOnCompletedTurn is set.
+      if (!params.suppressLastToolError) {
+        this.recordMissingToolError(missingTranscriptIds, missingTrajectoryIds);
+      }
       return undefined;
     }
     const missingCount = new Set([...missingTranscriptIds, ...missingTrajectoryIds]).size;

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -347,6 +347,7 @@ export class CodexAppServerEventProjector {
         synthesize: legacyFailClosed,
         recordPromptError:
           legacyFailClosed && !hasDeliverableAssistantOnCompletedTurn && !this.aborted,
+        suppressLastToolError: hasDeliverableAssistantOnCompletedTurn,
       });
     if (synthesizedMissingToolResultError) {
       this.synthesizedMissingToolResultError = synthesizedMissingToolResultError;


### PR DESCRIPTION
## What Problem This Solves

Fixes openclaw/openclaw#115489

When a Codex turn completes with a real assistant answer but the projector is
missing a tool result for one of its native items (e.g. a command started
through the `exec` tool yields with a cell id and later finishes through `wait`),
the synthesized `missing_tool_result` was promoted to `lastToolError`. The
channel layer treated this as user-visible failure evidence, replacing a
completed answer with `⚠️ 🛠️ … failed` while the answer sat intact in the
transcript.

#104898 fixed the `promptError` half (failure-closed when there is no deliverable
answer). This PR fixes the remaining `!recordPromptError` branch — the turn is
healthy with a completed answer, but the bookkeeping mismatch still surfaces to
the user.

## Evidence

### Before/After Comparison

**BEFORE** — `synthesizeMissingToolResults()` unconditionally calls
`recordMissingToolError()` → `setLastToolError()` when `recordPromptError` is
false, even when the turn already produced a deliverable assistant answer:

```ts
// event-projector-tool-transcript.ts (before fix)
if (!params.recordPromptError) {
  this.recordMissingToolError(missingTranscriptIds, missingTrajectoryIds);
  return undefined;
}
```

**AFTER** — The new `suppressLastToolError` parameter gates
`recordMissingToolError`, passed as `hasDeliverableAssistantOnCompletedTurn`
from the call site, so a completed answer is no longer replaced by a tool-failure
warning:

```ts
// event-projector-tool-transcript.ts (after fix)
if (!params.recordPromptError) {
  if (!params.suppressLastToolError) {
    this.recordMissingToolError(missingTranscriptIds, missingTrajectoryIds);
  }
  return undefined;
}
```

```ts
// event-projector.ts (after fix, call site)
suppressLastToolError: hasDeliverableAssistantOnCompletedTurn,
```

### Fields preserved

- `synthesizeMissingToolResult` promptError path → **unchanged** (fail-closed when no answer)
- `recordMissingToolError` for explicit abort → **unchanged** (diagnostics preserved)
- `suppressLastToolError` for deliverable answer → **skips lastToolError** (answer shown correctly)

### Test results

All existing event-projector tests pass:
- `terminal-errors`: 12/12 passed
- `native-failures`: 9/9 passed
- `commentary`, `native-hooks`, `replay-safety`, `usage`, `progress-echo`: all passed

### Proof tier: L1

This is an internal projector code-path bug. A live reproduction requires a
Codex app-server session triggering the nested exec→wait composition pattern
detailed in the issue, which needs a licensed Codex runtime. Source-level
analysis is provided above; the one-line reproduction command is:

```bash
# Run a Codex task that yields via exec and completes via wait,
# then observe the channel-delivered reply for ⚠️ 🛠️ … failed
```
