### PR TITLE
fix(setup): show Gemini CLI recovery actions

### DIFF
--- a/packages/gateway-protocol/src/schema/openclaw.test.ts
+++ b/packages/gateway-protocol/src/schema/openclaw.test.ts
@@ -99,6 +99,17 @@ describe("OpenClaw setup detection protocol", () => {
           website: "https://ollama.com/download",
         },
       ],
+      unavailableCandidates: [
+        {
+          id: "gemini-cli",
+          brandId: "google-gemini-cli",
+          label: "Gemini CLI",
+          detail: "installed; login status unavailable",
+          reason: "Reconnect through OpenClaw or use a Gemini API key.",
+          authOptionId: "google-gemini-cli",
+          manualProviderId: "gemini-api-key",
+        },
+      ],
       manualProviders: [
         {
           id: "ollama",
@@ -128,6 +139,9 @@ describe("OpenClaw setup detection protocol", () => {
       Value.Check(SystemAgentSetupDetectResultSchema, {
         ...result,
         candidates: result.candidates.map(({ brandId: _brandId, ...candidate }) => candidate),
+        unavailableCandidates: result.unavailableCandidates.map(
+          ({ brandId: _brandId, ...candidate }) => candidate,
+        ),
         manualProviders: result.manualProviders.map(
           ({ brandId: _brandId, ...provider }) => provider,
         ),

--- a/packages/gateway-protocol/src/schema/openclaw.ts
+++ b/packages/gateway-protocol/src/schema/openclaw.ts
@@ -213,9 +213,15 @@ export const SystemAgentSetupDetectResultSchema = closedObject({
     Type.Array(
       closedObject({
         id: NonEmptyString,
+        /** Canonical provider identity for clients with bundled brand artwork. */
+        brandId: Type.Optional(NonEmptyString),
         label: NonEmptyString,
         detail: Type.String(),
         reason: NonEmptyString,
+        authOptionId: Type.Optional(NonEmptyString),
+        manualProviderId: Type.Optional(NonEmptyString),
+        icon: Type.Optional(SetupInferenceHttpsUrl),
+        website: Type.Optional(SetupInferenceHttpsUrl),
       }),
     ),
   ),

--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -187,8 +187,8 @@ describe("detectInferenceBackends", () => {
       "existing-model",
       "codex-cli",
       "openai-api-key",
-      "claude-cli",
       "gemini-cli",
+      "claude-cli",
     ]);
   });
 
@@ -260,7 +260,7 @@ describe("detectInferenceBackends", () => {
     );
   });
 
-  it("gives each logged-out CLI its sign-in remediation", async () => {
+  it("keeps Gemini private-store auth distinct from definitive CLI logouts", async () => {
     const candidates = await detectInferenceBackends({
       env: {},
       platform: "linux",
@@ -274,6 +274,10 @@ describe("detectInferenceBackends", () => {
 
     expect(candidates).toMatchObject([
       {
+        kind: "gemini-cli",
+        detail: "installed; login status unavailable",
+      },
+      {
         kind: "claude-cli",
         detail: "installed, not logged in — run `claude auth login`, then check again",
       },
@@ -281,11 +285,10 @@ describe("detectInferenceBackends", () => {
         kind: "codex-cli",
         detail: "installed, not logged in — run `codex login`, then check again",
       },
-      {
-        kind: "gemini-cli",
-        detail: "installed, not logged in — sign in to Gemini CLI, then check again",
-      },
     ]);
+    expect(
+      candidates.find((candidate) => candidate.kind === "gemini-cli")?.credentials,
+    ).toBeUndefined();
   });
 
   it("recognizes Codex login status across native credential stores", async () => {

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -87,6 +87,12 @@ function describeCliDetail(credentials: boolean | undefined, loginHint: string):
   return "installed";
 }
 
+function describeGeminiCliDetail(credentials: boolean | undefined): string {
+  return credentials === true
+    ? "installed; credentials found"
+    : "installed; login status unavailable";
+}
+
 async function detectCodexLoginState(
   probe: typeof probeLocalCommand,
   command: string,
@@ -260,15 +266,17 @@ export async function detectInferenceBackends(
     });
   }
   if (geminiProbe.found && !geminiProbe.timedOut) {
-    // Gemini CLI stores its OAuth login in a plain file on every platform (no
-    // keychain), so a missing credential file is a definitive logout signal.
-    const credentials = readGemini() !== null;
+    // Current Gemini CLI releases keep primary auth in a private secure store;
+    // oauth_creds.json is only a legacy migration source. Its absence cannot
+    // distinguish logout from a modern login, and probing the secure store can
+    // prompt the user, so only readable legacy credentials are conclusive.
+    const credentials = readGemini() !== null ? true : undefined;
     cliCandidates.push({
       kind: "gemini-cli",
       modelRef: GEMINI_CLI_DEFAULT_MODEL_REF,
       label: "Gemini CLI",
-      detail: describeCliDetail(credentials, "sign in to Gemini CLI"),
-      credentials,
+      detail: describeGeminiCliDetail(credentials),
+      ...(credentials === undefined ? {} : { credentials }),
     });
   }
   // Claude Code and Codex share rank within a credential tier. Randomize before

--- a/src/system-agent/setup-inference-core.ts
+++ b/src/system-agent/setup-inference-core.ts
@@ -74,9 +74,17 @@ export type SetupInferenceCandidate = {
 
 export type SetupInferenceUnavailableCandidate = {
   id: string;
+  /** Canonical provider identity for clients with bundled brand artwork. */
+  brandId?: string;
   label: string;
   detail: string;
   reason: string;
+  /** Provider-owned interactive sign-in that can replace the unavailable route. */
+  authOptionId?: string;
+  /** Provider-owned manual secret route that can replace the unavailable route. */
+  manualProviderId?: string;
+  icon?: string;
+  website?: string;
 };
 
 export type SetupInferenceDetection = {

--- a/src/system-agent/setup-inference-detect.ts
+++ b/src/system-agent/setup-inference-detect.ts
@@ -78,18 +78,8 @@ export async function detectSetupInference(
   }
   const cfg = snapshot.runtimeConfig ?? snapshot.config;
   const detected = await (deps.detectInferenceBackends ?? detectInferenceBackends)({ config: cfg });
-  // Gemini CLI has no hard tool-off mode: wildcard exclusions can be
-  // overridden by admin policy and do not stop discovery or MCP startup.
-  // Keep normal agent support, but never offer it for the setup safety probe.
-  const unavailableCandidates: SetupInferenceUnavailableCandidate[] = detected
-    .filter((candidate) => candidate.kind === "gemini-cli")
-    .map((candidate) => ({
-      id: candidate.kind,
-      label: candidate.label,
-      detail: candidate.detail,
-      reason:
-        "Can't be auto-tested safely here. Use 'Gemini CLI OAuth' or a Gemini API key instead.",
-    }));
+  const unavailableCandidates: SetupInferenceUnavailableCandidate[] = [];
+  const deferredUnavailableCandidates: SetupInferenceUnavailableCandidate[] = [];
   const probe = deps.probeLocalCommand ?? probeLocalCommand;
   const [antigravity, pi, opencode] = await Promise.all([
     probe("agy"),
@@ -97,7 +87,7 @@ export async function detectSetupInference(
     probe("opencode"),
   ]);
   if (antigravity.found && !antigravity.timedOut) {
-    unavailableCandidates.push({
+    deferredUnavailableCandidates.push({
       id: "antigravity-cli",
       label: "Antigravity CLI",
       detail: "installed",
@@ -106,7 +96,7 @@ export async function detectSetupInference(
     });
   }
   if (pi.found && !pi.timedOut) {
-    unavailableCandidates.push({
+    deferredUnavailableCandidates.push({
       id: "pi-cli",
       label: "Pi CLI",
       detail: "installed",
@@ -115,7 +105,7 @@ export async function detectSetupInference(
     });
   }
   if (opencode.found && !opencode.timedOut) {
-    unavailableCandidates.push({
+    deferredUnavailableCandidates.push({
       id: "opencode-cli",
       label: "OpenCode CLI",
       detail: "installed",
@@ -138,6 +128,43 @@ export async function detectSetupInference(
   }).filter(
     (choice) => (deps.enablePluginInConfig ?? enablePluginInConfig)(cfg, choice.pluginId).enabled,
   );
+  const manualProviders = listSetupInferenceManualProviders(authChoices);
+  const authOptions = listSetupInferenceAuthOptions(authChoices);
+  const manualProviderIds = new Set(manualProviders.map((provider) => provider.id));
+  const authOptionIds = new Set(authOptions.map((option) => option.id));
+  // Gemini CLI has no hard tool-off mode: wildcard exclusions can be
+  // overridden by admin policy and do not stop discovery or MCP startup.
+  // Keep normal agent support, but route setup through provider-owned methods
+  // that OpenClaw can verify without inspecting Gemini's private auth store.
+  for (const candidate of detected.filter((entry) => entry.kind === "gemini-cli")) {
+    const providerId = parseRef(candidate.modelRef).provider;
+    const ownerChoice = authChoices.find(
+      (choice) => normalizeProviderId(choice.providerId) === normalizeProviderId(providerId),
+    );
+    const ownerGroup = ownerChoice?.groupId ?? ownerChoice?.providerId ?? providerId;
+    const relatedChoices = authChoices.filter(
+      (choice) => (choice.groupId ?? choice.providerId) === ownerGroup,
+    );
+    const authOptionId = relatedChoices.find((choice) =>
+      authOptionIds.has(choice.choiceId),
+    )?.choiceId;
+    const manualProviderId = relatedChoices.find((choice) =>
+      manualProviderIds.has(choice.choiceId),
+    )?.choiceId;
+    unavailableCandidates.push({
+      id: candidate.kind,
+      brandId: providerId,
+      label: candidate.label,
+      detail: candidate.detail,
+      reason:
+        "OpenClaw cannot confirm whether this private Gemini CLI login works without starting a session that may expose tools. Sign in through OpenClaw or use a Gemini API key to create a connection it can verify.",
+      ...(authOptionId ? { authOptionId } : {}),
+      ...(manualProviderId ? { manualProviderId } : {}),
+      ...(ownerChoice?.icon ? { icon: ownerChoice.icon } : {}),
+      ...(ownerChoice?.website ? { website: ownerChoice.website } : {}),
+    });
+  }
+  unavailableCandidates.push(...deferredUnavailableCandidates);
   const candidates: SetupInferenceCandidate[] = raw.map((candidate) =>
     // Released macOS clients require this field. Keep it false so the wire
     // contract remains decodable without expressing a provider preference.
@@ -231,8 +258,8 @@ export async function detectSetupInference(
   return {
     candidates,
     unavailableCandidates,
-    manualProviders: listSetupInferenceManualProviders(authChoices),
-    authOptions: listSetupInferenceAuthOptions(authChoices),
+    manualProviders,
+    authOptions,
     recommendedInstalls: listRecommendedToolInstalls(),
     workspace,
     ...(configuredModel ? { configuredModel } : {}),

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -523,6 +523,26 @@ describe("detectSetupInference", () => {
       })),
       resolveManifestProviderAuthChoices: () => [
         {
+          pluginId: "google",
+          providerId: "google-gemini-cli",
+          methodId: "oauth",
+          choiceId: "google-gemini-cli",
+          choiceLabel: "Gemini CLI OAuth",
+          groupId: "google",
+          groupLabel: "Google",
+          appGuidedAuth: "oauth",
+        },
+        {
+          pluginId: "google",
+          providerId: "google",
+          methodId: "api-key",
+          choiceId: "gemini-api-key",
+          choiceLabel: "Google Gemini API key",
+          groupId: "google",
+          groupLabel: "Google",
+          appGuidedSecret: true,
+        },
+        {
           pluginId: "local-plugin",
           providerId: "local",
           methodId: "ambient",
@@ -552,7 +572,12 @@ describe("detectSetupInference", () => {
       },
     ]);
     expect(detection.unavailableCandidates).toEqual([
-      expect.objectContaining({ id: "gemini-cli" }),
+      expect.objectContaining({
+        id: "gemini-cli",
+        brandId: "google-gemini-cli",
+        authOptionId: "google-gemini-cli",
+        manualProviderId: "gemini-api-key",
+      }),
       expect.objectContaining({ id: "antigravity-cli" }),
       expect.objectContaining({ id: "pi-cli" }),
       expect.objectContaining({ id: "opencode-cli" }),

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -1,4 +1,6 @@
 // Control UI tests cover guided model setup against a mocked Gateway.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -13,6 +15,7 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -224,6 +227,125 @@ describeControlUiE2e("Control UI Model Setup mocked Gateway E2E", () => {
       await expect
         .poll(async () => page.locator(".model-setup__success").textContent())
         .toContain("provider/verified-model");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("turns an unverifiable Gemini CLI login into direct recovery actions", async () => {
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1000, width: 1440 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "openclaw.setup.detect",
+        "openclaw.setup.auth.start",
+      ],
+      methodResponses: {
+        "openclaw.setup.detect": {
+          candidates: [],
+          unavailableCandidates: [
+            {
+              id: "gemini-cli",
+              brandId: "google-gemini-cli",
+              label: "Gemini CLI",
+              detail: "installed; login status unavailable",
+              reason:
+                "OpenClaw cannot confirm whether this private Gemini CLI login works without starting a session that may expose tools. Sign in through OpenClaw or use a Gemini API key to create a connection it can verify.",
+              authOptionId: "google-gemini-cli",
+              manualProviderId: "gemini-api-key",
+            },
+          ],
+          manualProviders: [
+            {
+              id: "openai-api-key",
+              brandId: "openai",
+              label: "OpenAI API key",
+            },
+            {
+              id: "gemini-api-key",
+              brandId: "google",
+              label: "Google Gemini API key",
+              hint: "Use an AI Studio API key.",
+            },
+          ],
+          authOptions: [
+            {
+              id: "google-gemini-cli",
+              brandId: "google-gemini-cli",
+              label: "Gemini CLI OAuth",
+              groupLabel: "Google",
+              kind: "oauth",
+              featured: true,
+            },
+          ],
+          workspace: "/tmp/openclaw-e2e",
+          setupComplete: false,
+        },
+        "openclaw.setup.auth.start": {
+          sessionId: "gemini-oauth-session",
+          done: false,
+          status: "running",
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/model-setup`);
+      expect(response?.status()).toBe(200);
+      await page.getByRole("heading", { name: "Found, but needs attention" }).waitFor();
+      await page.getByRole("button", { name: "Sign in with Google" }).waitFor();
+      await page.getByRole("button", { name: "Use API key" }).waitFor();
+
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(artifactDir, "after-desktop.png"),
+        });
+        await page.setViewportSize({ height: 844, width: 390 });
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(artifactDir, "after-mobile.png"),
+        });
+        await page.setViewportSize({ height: 1000, width: 1440 });
+      }
+
+      const accessValue = page.locator('.model-setup__manual input[type="password"]');
+      await accessValue.fill("sk-old-provider-secret");
+      await page.getByRole("button", { name: "Use API key" }).click();
+      const provider = page.locator(".model-setup__manual select");
+      await expect.poll(() => provider.inputValue()).toBe("gemini-api-key");
+      await expect.poll(() => accessValue.inputValue()).toBe("");
+      await expect
+        .poll(() => accessValue.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+
+      await accessValue.fill("gemini-secret");
+      await provider.selectOption("openai-api-key");
+      await expect.poll(() => accessValue.inputValue()).toBe("");
+      await page.getByRole("button", { name: "Use API key" }).click();
+
+      const detectCount = (await gateway.getRequests("openclaw.setup.detect")).length;
+      await page
+        .locator('[data-unavailable-candidate="gemini-cli"]')
+        .getByRole("button", { name: "Check again" })
+        .click();
+      await expect
+        .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length)
+        .toBe(detectCount + 1);
+
+      await page.getByRole("button", { name: "Sign in with Google" }).click();
+      const start = await gateway.waitForRequest("openclaw.setup.auth.start");
+      expect(start.params).toMatchObject({ authChoice: "google-gemini-cli" });
     } finally {
       await context.close();
     }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1996,7 +1996,9 @@ export const en: TranslationMap = {
       intro: "No existing AI access was detected. Install one of these tools, then check again.",
     },
     unavailable: {
-      title: "Detected, but not auto-tested",
+      title: "Found, but needs attention",
+      signIn: "Sign in with {provider}",
+      useApiKey: "Use API key",
     },
     signIn: {
       title: "Sign in with a provider",

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -268,6 +268,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     return new Set(
       [
         ...result.candidates,
+        ...(result.unavailableCandidates ?? []),
         ...result.manualProviders,
         ...(result.authOptions ?? []),
         ...(result.recommendedInstalls ?? []),
@@ -461,6 +462,24 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     );
   }
 
+  private selectManualProvider(providerId: string): void {
+    if (providerId !== this.manualProviderId) {
+      this.manualApiKey = "";
+    }
+    this.manualProviderId = providerId;
+    this.manualError = null;
+  }
+
+  private async useManualProvider(providerId: string): Promise<void> {
+    this.selectManualProvider(providerId);
+    await this.updateComplete;
+    const input = this.renderRoot.querySelector<HTMLInputElement>(
+      '.model-setup__manual input[type="password"]',
+    );
+    input?.scrollIntoView?.({ block: "center", behavior: "smooth" });
+    input?.focus();
+  }
+
   private async handleWizardDone(startMethod: ModelSetupWizardStartMethod): Promise<void> {
     const result = await this.detect();
     if (!result) {
@@ -531,10 +550,8 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         this.wizardMode = "prepare";
         void this.wizard.start(option.id, "openclaw.setup.prepare.start");
       },
-      onManualProviderChange: (providerId) => {
-        this.manualProviderId = providerId;
-        this.manualError = null;
-      },
+      onManualProviderChange: (providerId) => this.selectManualProvider(providerId),
+      onUseManualProvider: (providerId) => void this.useManualProvider(providerId),
       onManualApiKeyChange: (apiKey) => {
         this.manualApiKey = apiKey;
         this.manualError = null;

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -24,12 +24,21 @@ const detected: SystemAgentSetupDetectResult = {
   unavailableCandidates: [
     {
       id: "gemini-cli",
+      brandId: "google-gemini-cli",
       label: "Gemini CLI",
-      detail: "Installed",
-      reason: "No active login",
+      detail: "installed; login status unavailable",
+      reason: "OpenClaw could not confirm a usable login.",
+      authOptionId: "google-gemini-cli",
+      manualProviderId: "gemini-api-key",
     },
   ],
   manualProviders: [
+    {
+      id: "gemini-api-key",
+      brandId: "google",
+      label: "Google Gemini API key",
+      hint: "Use an AI Studio API key.",
+    },
     {
       id: "openai",
       brandId: "openai",
@@ -39,6 +48,15 @@ const detected: SystemAgentSetupDetectResult = {
     },
   ],
   authOptions: [
+    {
+      id: "google-gemini-cli",
+      brandId: "google-gemini-cli",
+      label: "Gemini CLI OAuth",
+      groupLabel: "Google",
+      kind: "oauth",
+      featured: true,
+      hint: "Continue with Google.",
+    },
     {
       id: "openai-oauth",
       brandId: "openai",
@@ -97,6 +115,7 @@ function props(overrides: Partial<ModelSetupViewProps> = {}): ModelSetupViewProp
     onStartAuth: vi.fn(),
     onStartPrepare: vi.fn(),
     onManualProviderChange: vi.fn(),
+    onUseManualProvider: vi.fn(),
     onManualApiKeyChange: vi.fn(),
     onManualConnect: vi.fn(),
     onMoreSignInToggle: vi.fn(),
@@ -156,8 +175,8 @@ describe("renderModelSetup", () => {
     expect(text(container)).toContain("Found on this Gateway");
     expect(text(container)).toContain("Codex CLI");
     expect(text(container)).toContain("openai/gpt-5 · Signed in locally");
-    expect(text(container)).toContain("Detected, but not auto-tested");
-    expect(text(container)).toContain("No active login");
+    expect(text(container)).toContain("Found, but needs attention");
+    expect(text(container)).toContain("OpenClaw could not confirm a usable login");
     expect(text(container)).toContain("Sign in with a provider");
     expect(text(container)).toContain("Set up a local model");
     expect(text(container)).toContain("Connect with an API key or token");
@@ -166,6 +185,9 @@ describe("renderModelSetup", () => {
     );
     expect(container.querySelector('input[type="password"]')).not.toBeNull();
     expect(container.querySelector("details")?.open).toBe(false);
+    expect(
+      container.querySelector('[data-unavailable-candidate="gemini-cli"] [data-provider-icon]'),
+    ).not.toBeNull();
     expect(
       container.querySelector('[data-candidate-kind="codex-cli"] [data-provider-icon="codex"]'),
     ).not.toBeNull();
@@ -180,6 +202,29 @@ describe("renderModelSetup", () => {
         ?.textContent,
     ).toContain("O");
     expect(container.querySelectorAll("img")).toHaveLength(0);
+  });
+
+  it("offers direct recovery actions for an unavailable provider", () => {
+    const onStartAuth = vi.fn();
+    const onUseManualProvider = vi.fn();
+    const onDetect = vi.fn();
+    const container = mount(props({ onStartAuth, onUseManualProvider, onDetect }));
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '[data-unavailable-candidate="gemini-cli"] button',
+    );
+
+    expect([...buttons].map((button) => button.textContent?.trim())).toEqual([
+      "Sign in with Google",
+      "Use API key",
+      "Check again",
+    ]);
+    buttons[0]?.click();
+    buttons[1]?.click();
+    buttons[2]?.click();
+
+    expect(onStartAuth).toHaveBeenCalledWith(expect.objectContaining({ id: "google-gemini-cli" }));
+    expect(onUseManualProvider).toHaveBeenCalledWith("gemini-api-key");
+    expect(onDetect).toHaveBeenCalledOnce();
   });
 
   it("derives prepare rows from accepted choice ids and hides usable local candidates", () => {

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -81,6 +81,7 @@ type ModelSetupViewProps = {
   onStartAuth: (option: AuthOption) => void;
   onStartPrepare: (option: ModelSetupPrepareOption) => void;
   onManualProviderChange: (providerId: string) => void;
+  onUseManualProvider: (providerId: string) => void;
   onManualApiKeyChange: (apiKey: string) => void;
   onManualConnect: () => void;
   onMoreSignInToggle: (open: boolean) => void;
@@ -277,7 +278,7 @@ function renderCurrentConnection(props: ModelSetupViewProps, modelRef: string) {
   `;
 }
 
-function renderUnavailable(result: SystemAgentSetupDetectResult) {
+function renderUnavailable(props: ModelSetupViewProps, result: SystemAgentSetupDetectResult) {
   if (!result.unavailableCandidates?.length) {
     return nothing;
   }
@@ -287,16 +288,60 @@ function renderUnavailable(result: SystemAgentSetupDetectResult) {
         <h2>${t("modelSetup.unavailable.title")}</h2>
       </div>
       <div class="model-setup__rows">
-        ${result.unavailableCandidates.map(
-          (candidate) => html`
-            <div class="model-setup__row model-setup__row--info">
-              <div>
-                <div><strong>${candidate.label}</strong> — ${candidate.detail}</div>
-                <div>${candidate.reason}</div>
+        ${result.unavailableCandidates.map((candidate) => {
+          const authOption = (result.authOptions ?? []).find(
+            (option) => option.id === candidate.authOptionId,
+          );
+          const manualProvider = result.manualProviders.find(
+            (provider) => provider.id === candidate.manualProviderId,
+          );
+          return html`
+            <div
+              class="model-setup__row model-setup__row--info"
+              data-unavailable-candidate=${candidate.id}
+            >
+              <div class="model-setup__provider-copy">
+                ${renderProviderIcon(props, candidate)}
+                <div>
+                  <div><strong>${candidate.label}</strong> — ${candidate.detail}</div>
+                  <div class="muted">${candidate.reason}</div>
+                </div>
+              </div>
+              <div class="model-setup__row-actions">
+                ${authOption
+                  ? html`<button
+                      type="button"
+                      class="btn primary"
+                      ?disabled=${props.actionsDisabled}
+                      @click=${() => props.onStartAuth(authOption)}
+                    >
+                      ${t("modelSetup.unavailable.signIn", {
+                        provider: authOption.groupLabel ?? authOption.label,
+                      })}
+                    </button>`
+                  : nothing}
+                ${manualProvider
+                  ? html`<button
+                      type="button"
+                      class="btn"
+                      ?disabled=${props.actionsDisabled}
+                      @click=${() => props.onUseManualProvider(manualProvider.id)}
+                    >
+                      ${t("modelSetup.unavailable.useApiKey")}
+                    </button>`
+                  : nothing}
+                <button
+                  type="button"
+                  class="btn"
+                  ?disabled=${props.actionsDisabled}
+                  @click=${props.onDetect}
+                >
+                  ${t("modelSetup.checkAgain")}
+                </button>
               </div>
             </div>
-          `,
-        )}
+          `;
+        })}
       </div>
     </section>
   `;
@@ -493,8 +538,8 @@ function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectR
   }
   return html`
     ${current} ${renderEmptyState(props, result)} ${renderCandidateRows(props, result)}
-    ${renderUnavailable(result)} ${renderPrepare(props, result)} ${renderSignIn(props, result)}
-    ${renderManual(props, result)}
+    ${renderUnavailable(props, result)} ${renderPrepare(props, result)}
+    ${renderSignIn(props, result)} ${renderManual(props, result)}
   `;
 }
 

--- a/ui/src/styles/model-setup.css
+++ b/ui/src/styles/model-setup.css
@@ -70,6 +70,14 @@
   min-width: 0;
 }
 
+.model-setup__row-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .model-setup__manual-provider select {
   flex: 1;
   min-width: 0;
@@ -234,5 +242,9 @@
   .model-setup__row > .btn,
   .model-setup__success > .btn {
     align-self: flex-start;
+  }
+
+  .model-setup__row-actions {
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
Closes #115834

## What Problem This Solves

Fixes an issue where users with Gemini CLI installed would be told they were logged out and shown a dead-end "not auto-tested" row when current Gemini CLI credentials were stored outside the legacy file OpenClaw inspected.

## Why This Change Was Made

Treats an absent legacy Gemini credential file as an unknown private-store state instead of a confirmed logout. The setup result now carries provider-owned OAuth and API-key recovery targets through the Gateway protocol, and Control UI renders those actions directly while keeping Gemini CLI out of the unsafe setup inference probe.

Changing the selected manual provider also clears any typed credential so a key cannot be submitted to the wrong provider.

## User Impact

Users now see why OpenClaw cannot verify the private Gemini CLI login and can immediately sign in with Google, enter a Gemini API key, or check again. The Models settings route remains selected, and the recovery row works on desktop and mobile.

## Evidence

- Root cause: `oauth_creds.json` is a legacy Gemini CLI migration source; its absence does not prove logout.
- Safety boundary: Gemini CLI remains excluded from setup inference because it has no hard tool-off mode.
- Focused Testbox: 187 unit tests passed.
- Browser Testbox: 4 model-setup E2Es passed, including Google sign-in dispatch, API-key focus, provider-switch credential clearing, and re-detection.
- Full changed-surface gate: formatting, i18n, protocol baseline, dead-code, core/core-test/UI typechecks, all lint shards, import-cycle and runtime guards passed.
- Autoreview: clean after fixing provider-switch credential retention.
- Visual desktop and mobile layouts were validated by the passing model-setup browser E2E; screenshots were retained only as local test artifacts.

Introduced by `2bc50d0656bd` on July 5, 2026, which treated a missing legacy credential file as a definitive logout signal.

Disclosure: this change was prepared with AI-assisted coding and independently verified with focused tests, browser E2E, static gates, and fresh autoreview.

