### PR TITLE
fix(plugin-sdk): restore stream-hook family re-exports on provider-stream-family

### DIFF
--- a/src/plugin-sdk/provider-stream-family.test.ts
+++ b/src/plugin-sdk/provider-stream-family.test.ts
@@ -1,0 +1,34 @@
+// Locks the provider-stream-family subpath contract: it must re-export the full
+// stream-hook family, matching provider-stream. Narrowing it to a subset (#108440)
+// broke external provider plugins published at v2026.7.1 (moonshot, minimax,
+// openrouter) that import their hook constant from this subpath.
+import { describe, expect, it } from "vitest";
+import * as family from "./provider-stream-family.js";
+import * as canonical from "./provider-stream.js";
+
+const STREAM_HOOK_EXPORTS = [
+  "GOOGLE_THINKING_STREAM_HOOKS",
+  "KILOCODE_THINKING_STREAM_HOOKS",
+  "MINIMAX_FAST_MODE_STREAM_HOOKS",
+  "MOONSHOT_THINKING_STREAM_HOOKS",
+  "OPENAI_RESPONSES_STREAM_HOOKS",
+  "OPENROUTER_THINKING_STREAM_HOOKS",
+  "TOOL_STREAM_DEFAULT_ON_HOOKS",
+] as const;
+
+describe("provider-stream-family subpath", () => {
+  it("re-exports every stream-hook family constant with a working wrapStreamFn", () => {
+    for (const name of STREAM_HOOK_EXPORTS) {
+      const hooks = family[name];
+      expect(hooks, name).toBeDefined();
+      expect(hooks.wrapStreamFn, name).toBeTypeOf("function");
+    }
+  });
+
+  it("stays in parity with the canonical provider-stream stream-hook exports", () => {
+    for (const name of STREAM_HOOK_EXPORTS) {
+      // Same underlying object: the family subpath must not drift from provider-stream.
+      expect(family[name], name).toBe(canonical[name]);
+    }
+  });
+});

--- a/src/plugin-sdk/provider-stream-family.ts
+++ b/src/plugin-sdk/provider-stream-family.ts
@@ -12,8 +12,19 @@ export {
   buildProviderStreamFamilyHooks,
   getOpenRouterModelCapabilities,
   loadOpenRouterModelCapabilities,
-  OPENAI_RESPONSES_STREAM_HOOKS,
   resolveOpenAIFastMode,
   resolveOpenAIServiceTier,
   resolveOpenAITextVerbosity,
+} from "./provider-stream.js";
+// Deprecated `*_STREAM_HOOKS` shortcuts stay a shipped contract of this subpath:
+// plugins published at v2026.7.1 import them from here. #108440 kept only
+// OPENAI_RESPONSES and broke moonshot/minimax/openrouter loads on beta core.
+export {
+  GOOGLE_THINKING_STREAM_HOOKS,
+  KILOCODE_THINKING_STREAM_HOOKS,
+  MINIMAX_FAST_MODE_STREAM_HOOKS,
+  MOONSHOT_THINKING_STREAM_HOOKS,
+  OPENAI_RESPONSES_STREAM_HOOKS,
+  OPENROUTER_THINKING_STREAM_HOOKS,
+  TOOL_STREAM_DEFAULT_ON_HOOKS,
 } from "./provider-stream.js";


### PR DESCRIPTION
Closes #115580

## What Problem This Solves

Fixes an issue where operators running a `2026.7.2-beta` gateway see the official Moonshot/Kimi provider plugin fail to load at startup with:

```
SyntaxError: The requested module 'openclaw/plugin-sdk/provider-stream-family'
does not provide an export named 'MOONSHOT_THINKING_STREAM_HOOKS'
```

The plugin never activates, so Moonshot/Kimi models are unavailable on affected builds. This is not Moonshot-specific: the published `@openclaw/minimax` and `@openclaw/openrouter` provider plugins import their own stream-hook constant from the same subpath and fail the same way.

## Why This Change Was Made

The `openclaw/plugin-sdk/provider-stream-family` subpath is a deprecated-but-still-shipped compatibility surface (removal not before `2026-10-01`). #108440 narrowed its barrel from `export * from "./provider-stream.js"` to an explicit list and, in doing so, dropped six of the seven `*_STREAM_HOOKS` family constants — keeping only `OPENAI_RESPONSES_STREAM_HOOKS`. Provider plugins published at `v2026.7.1` (moonshot, minimax, openrouter) import their hook constant from this subpath, so beta core stopped providing an export they still depend on inside its deprecation window.

The fix restores the full `*_STREAM_HOOKS` family superset to the barrel so it stays in parity with the canonical `provider-stream` subpath (which still re-exports all seven), exactly as the issue's own suggested fix describes. Restoring the whole family — rather than patching only `MOONSHOT_THINKING_STREAM_HOOKS` — avoids leaving `minimax`/`openrouter` broken; a one-sided fix would re-break the siblings that share this invariant. A regression test locks the subpath in parity with `provider-stream` so it cannot be silently re-narrowed. Scope is intentionally limited to `provider-stream-family`: it is the only narrowed barrel with a proven published-plugin consumer break (verified against every stream-hook import in the bundled extensions at the `v2026.7.1` tag).

## User Impact

Operators on `2026.7.2-beta.2` … `2026.7.2-beta.5` (and later beta core) can once again load `@openclaw/moonshot-provider`, `@openclaw/minimax`, and `@openclaw/openrouter` at their published `2026.7.1` versions without a startup `SyntaxError` and without hand-patching the installed plugin's `dist/`. Stable `v2026.7.1` was never affected (the narrowing is not in that tag).

## Evidence

- **Root-cause / regression window (git):** the narrowing landed in `dde90a34` (#108440), which is absent from stable `v2026.7.1` and first present in `v2026.7.2-beta.2`. That commit changed the barrel from `export *` to an explicit list keeping only `OPENAI_RESPONSES_STREAM_HOOKS`.
- **Blast radius (git, at `v2026.7.1` tag):** bundled/published plugins import their hook from this exact subpath — moonshot (`MOONSHOT_THINKING_STREAM_HOOKS`), minimax (`MINIMAX_FAST_MODE_STREAM_HOOKS`), openrouter (`OPENROUTER_THINKING_STREAM_HOOKS`); foundry/openai import `OPENAI_RESPONSES_STREAM_HOOKS` and were unaffected.
- **Focused tests:** `src/plugin-sdk/provider-stream-family.test.ts` (new, 2/2) verifies every family hook is re-exported with a working `wrapStreamFn` and stays object-identical to `provider-stream`; `src/plugin-sdk/provider-stream.test.ts` and `src/plugins/compat/registry.test.ts` also pass.
- **Surface budget:** `plugin-sdk:surface:check` passes — `provider-stream-family` is a private-local-only subpath, so restoring deprecated exports there trips no public-surface budget.
