### PR TITLE
fix(cli): keep unknown-command regression reliable on shared runners

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -458,6 +458,9 @@ describe("JSON console style process output", () => {
         await runCliProcess({
           args: ["openclaw-json-console-missing-command", modifier],
           config: loggingConfig,
+          // The fake command cannot belong to a bundled plugin. Avoid cold plugin
+          // discovery so this subprocess measures structured validation, not fleet load.
+          env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
         });
       } catch (error) {
         failure = error as CliProcessFailure;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where unrelated contributor pull requests fail the required small-runner CI gate when the real CLI unknown-command regression needlessly discovers every bundled plugin. The unchanged child is killed at its existing 75-second deadline and falsely reports a null exit code even though the contributor changes do not touch the CLI.

## Why This Change Was Made

Disable bundled-plugin discovery only in the two parameterized subprocesses for an intentionally nonexistent command. A nonexistent command has no bundled owner, and sibling ACP, Gateway, and hooks process fixtures already use the same supported isolation. Preserve the real source CLI invocation, both help/version cases, every exit-code and structured stderr assertion, all existing timeouts, and the complete 52-test process suite. No production, config, workflow, runner, or dependency changes.

## User Impact

Contributor CI validates genuine unknown-command behavior reliably on four-core runners instead of rejecting unrelated fixes because cold plugin discovery exhausted the subprocess deadline.

## Evidence

- Reproduced independently in two consecutive exact-head fork CI jobs 90538263974 and 90543875038: the real unknown-command child receives SIGKILL at 75,069 ms and reports a null exit code.
- Verified the exact current-main test and CI-planner blobs match the failing contributor head; confirmed bundled-plugin disable is the documented owner contract and is already used by sibling real CLI process tests.
- Same Blacksmith Testbox, same four CPUs, same source CLI, same assertions, unchanged baseline: help 52,904 ms; version 26,581 ms.
- Same Testbox and CPU affinity after this three-line test-only fix: help 2,070 ms; version 1,953 ms; both real child exit and JSON error assertions pass.
- Complete four-core CLI process regression: 52 of 52 tests pass in 59.70 seconds; the two cases take 1,362 ms and 1,308 ms in the full suite.
- Independent Codex autoreview at xhigh: clean, no actionable findings.
- git diff --check: passed.
