### PR TITLE
fix(codex): keep completed answers over audit gaps

### DIFF
--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -442,7 +442,7 @@ export class CodexToolTranscriptProjection {
 
   synthesizeMissingToolResults(params: {
     synthesize: boolean;
-    recordPromptError: boolean;
+    terminalDisposition: "prompt_error" | "tool_error" | "diagnostic_only";
   }): string | undefined {
     if (!params.synthesize) {
       return undefined;
@@ -484,8 +484,11 @@ export class CodexToolTranscriptProjection {
         output: text,
       });
     }
-    if (!params.recordPromptError) {
+    if (params.terminalDisposition === "tool_error") {
       this.recordMissingToolError(missingTranscriptIds, missingTrajectoryIds);
+      return undefined;
+    }
+    if (params.terminalDisposition === "diagnostic_only") {
       return undefined;
     }
     const missingCount = new Set([...missingTranscriptIds, ...missingTrajectoryIds]).size;

--- a/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
@@ -466,12 +466,7 @@ describe("CodexAppServerEventProjector native tool finalization", () => {
 
     expect(readAttemptTerminal(result).promptError).toBeNull();
     expect(readAttemptTerminal(result).promptErrorSource).toBeNull();
-    expect(result.lastToolError).toMatchObject({
-      toolName: "bash",
-      error: expect.stringContaining("without a matching tool.result"),
-      mutatingAction: true,
-    });
-    expect(result.lastToolError?.actionFingerprint).toContain("node scripts/report.js --publish");
+    expect(result.lastToolError).toBeUndefined();
     expect(result.assistantTexts).toEqual([
       "The requested publish command was denied before execution.",
     ]);

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -339,8 +339,13 @@ export class CodexAppServerEventProjector {
     const synthesizedMissingToolResultError =
       this.toolTranscriptProjection.synthesizeMissingToolResults({
         synthesize: legacyFailClosed,
-        recordPromptError:
-          legacyFailClosed && !hasDeliverableAssistantOnCompletedTurn && !this.aborted,
+        // Preserve audit synthesis on every path, but completed answers must not
+        // promote bookkeeping gaps into user-visible terminal failure evidence.
+        terminalDisposition: this.aborted
+          ? "tool_error"
+          : hasDeliverableAssistantOnCompletedTurn
+            ? "diagnostic_only"
+            : "prompt_error",
       });
     if (synthesizedMissingToolResultError) {
       this.synthesizedMissingToolResultError = synthesizedMissingToolResultError;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1943,12 +1943,7 @@ describe("runCodexAppServerAttempt", () => {
     });
     const result = await run;
     expect(readAttemptTerminal(result).promptError).toBeNull();
-    expect(result.lastToolError).toMatchObject({
-      toolName: "bash",
-      error: expect.stringContaining("without a matching tool.result"),
-      mutatingAction: true,
-    });
-    expect(result.lastToolError?.actionFingerprint).toContain("pnpm test extensions/codex");
+    expect(result.lastToolError).toBeUndefined();
     expect(result.assistantTexts).toEqual(["Recovered with final answer after orphan tool call."]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
       "user",


### PR DESCRIPTION
Closes #115489

## What Problem This Solves

Fixes an issue where a completed Codex turn with a real assistant answer could be delivered as a synthetic `⚠️ … failed` tool warning when projector bookkeeping lacked one native tool result. The paid-for answer remained in the transcript but was displaced by terminal failure evidence.

## Why This Change Was Made

Missing native results now use an explicit terminal disposition instead of overloading one boolean:

- `prompt_error` keeps no-answer turns fail-closed;
- `tool_error` retains missing-tool evidence for explicit aborts;
- `diagnostic_only` preserves synthetic transcript and trajectory records without promoting them to `lastToolError` when a completed turn already has deliverable assistant text.

The upstream Codex contract was checked at `openai/codex` commit `d06c7ac055920c7cb140c25ebda3f3db20197b45`, including `codex-rs/app-server/README.md` and the v2 turn/item protocol: terminal truth arrives through authoritative item and `turn/completed` lifecycle events.

## User Impact

Users now receive the completed assistant answer rather than a fallback-only missing-tool warning. Audit consumers still retain the synthesized failed tool result and trajectory record, while genuine no-answer and aborted cases remain visible and fail closed.

AI-assisted: implemented and reviewed with Codex; the full projector, transcript, terminal-error, run-attempt, and upstream lifecycle paths were inspected before landing.

## Evidence

- Before: 2 focused assertions failed because `lastToolError` was populated; 129 adjacent controls passed.
- After: 143 focused projector, terminal-error, and run-attempt tests passed.
- The healthy completed-answer tests still assert the synthetic transcript tool result and trajectory `missing_tool_result`; only terminal presentation is absent.
- Existing abort and whitespace/no-answer tests prove `tool_error` and `prompt_error` behavior remains intact.
- Blacksmith Testbox changed gate: `tbx_01kypq8v0ceqm8easmws4gectg`, Actions run https://github.com/openclaw/openclaw/actions/runs/30444462106 — exit 0. Portal cleanup sync timed out after the successful command; the one-shot lease had already stopped.
- Final Codex autoreview: clean, no accepted/actionable findings; confidence 0.98.
