### PR TITLE
fix(memory): preserve taint across transcript runtimes

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -203,7 +203,7 @@ describe("createCodexDynamicToolBridge", () => {
   it("keeps OpenClaw control-path tools direct while deferring broad tools", () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [
-        createTool({ name: "web_search" }),
+        createTool({ name: "web_search", resultContentSource: "network" }),
         createTool({ name: "message" }),
         createTool({ name: HEARTBEAT_RESPONSE_TOOL_NAME }),
         createTool({ name: "agents_list" }),
@@ -239,6 +239,8 @@ describe("createCodexDynamicToolBridge", () => {
     expectNoNamespace(agentsList);
     expectNoNamespace(sessionsSpawn);
     expectNoNamespace(sessionsYield);
+    expect(bridge.resultContentSourceForTool("web_search")).toBe("network");
+    expect(bridge.resultContentSourceForTool("message")).toBeUndefined();
   });
 
   it("keeps configured direct tools in the initial Codex tool context", () => {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -349,6 +349,7 @@ function hasExplicitNonSourceMessageRoute(
 export type CodexDynamicToolBridge = {
   availableSpecs: CodexDynamicToolSpec[];
   specs: CodexDynamicToolSpec[];
+  resultContentSourceForTool: (toolName: string) => AnyAgentTool["resultContentSource"];
   handleToolCall: (
     params: CodexDynamicToolCallParams,
     options?: {
@@ -544,6 +545,7 @@ export function createCodexDynamicToolBridge(params: {
       loading: params.loading ?? "searchable",
       directToolNames,
     }),
+    resultContentSourceForTool: (toolName) => toolMap.get(toolName)?.tool.resultContentSource,
     telemetry,
     setRemoteWorkspaceFileReader: (reader) => {
       readRemoteWorkspaceFile = reader;

--- a/extensions/codex/src/app-server/event-projector-items.ts
+++ b/extensions/codex/src/app-server/event-projector-items.ts
@@ -176,7 +176,7 @@ export function shouldSynthesizeToolProgressForItem(item: CodexThreadItem): bool
 }
 
 export function shouldRecordNativeToolTranscript(item: CodexThreadItem): boolean {
-  return shouldSynthesizeToolProgressForItem(item) && item.type !== "webSearch";
+  return shouldSynthesizeToolProgressForItem(item);
 }
 
 export function isMutatingNativeToolItem(item: CodexThreadItem): boolean {

--- a/extensions/codex/src/app-server/event-projector-options.ts
+++ b/extensions/codex/src/app-server/event-projector-options.ts
@@ -13,5 +13,6 @@ export type CodexAppServerEventProjectorOptions = {
   remoteWorkspaceRequestTimeoutMs?: number;
   trajectoryRecorder?: CodexTrajectoryRecorder | null;
   onContextCompacted?: () => void;
+  resolveDynamicToolResultContentSource?: (toolName: string) => "network" | undefined;
   upstreamUserText?: string;
 };

--- a/extensions/codex/src/app-server/event-projector-snapshot.ts
+++ b/extensions/codex/src/app-server/event-projector-snapshot.ts
@@ -8,6 +8,30 @@ import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
 import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
 import { promptSnapshot } from "./user-prompt-message.js";
 
+type TurnTaintMetadata = { resultContentSource?: "network"; turnTainted?: true };
+
+function readTurnTaintMetadata(message: AgentMessage): TurnTaintMetadata | undefined {
+  const metadata = (message as unknown as Record<string, unknown>)["__openclaw"];
+  return metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? (metadata as TurnTaintMetadata)
+    : undefined;
+}
+
+function applyStickyTurnTaint(messages: readonly AgentMessage[]): AgentMessage[] {
+  let tainted = false;
+  return messages.map((message) => {
+    if (message.role === "user") {
+      tainted = false;
+      return message;
+    }
+    const metadata = readTurnTaintMetadata(message);
+    tainted ||= metadata?.turnTainted === true || metadata?.resultContentSource === "network";
+    return message.role === "assistant" && tainted
+      ? ({ ...message, __openclaw: { ...metadata, turnTainted: true } } as AgentMessage)
+      : message;
+  });
+}
+
 export function buildCodexMessagesSnapshot(params: {
   runParams: EmbeddedRunAttemptParams;
   turnId: string;
@@ -50,7 +74,7 @@ export function buildCodexMessagesSnapshot(params: {
   if (params.lastAssistant) {
     messages.push(attachCodexMirrorIdentity(params.lastAssistant, `${params.turnId}:assistant`));
   }
-  return messages.map((message) =>
+  return applyStickyTurnTaint(messages).map((message) =>
     projectAgentHarnessTranscriptMessageForDisplay({
       hidden: params.runParams.trigger === "memory",
       message,

--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -68,6 +68,7 @@ export type ToolTranscriptResultInput = {
   text?: string;
   isError: boolean;
   details?: unknown;
+  resultContentSource?: "network";
 };
 
 type ToolProgressRawSignature = { length: number; prefix: string };

--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -163,6 +163,7 @@ export class CodexToolTranscriptProjection {
     success: boolean;
     contentItems: CodexDynamicToolCallOutputContentItem[];
     details?: unknown;
+    resultContentSource?: "network";
   }): void {
     this.recordToolResult({
       id: params.callId,
@@ -170,6 +171,7 @@ export class CodexToolTranscriptProjection {
       text: collectDynamicToolContentText(params.contentItems),
       isError: !params.success,
       details: params.details,
+      ...(params.resultContentSource ? { resultContentSource: params.resultContentSource } : {}),
     });
   }
 
@@ -197,6 +199,7 @@ export class CodexToolTranscriptProjection {
           itemTranscriptResultText(item, this.progress.outputTextByItem),
         isError: isNonSuccessItemStatus(itemStatus(item)),
         details,
+        ...(item.type === "webSearch" ? { resultContentSource: "network" } : {}),
       });
     }
   }
@@ -615,6 +618,9 @@ export class CodexToolTranscriptProjection {
         },
       ],
       ...(params.details !== undefined ? { details: params.details } : {}),
+      ...(params.resultContentSource
+        ? { __openclaw: { resultContentSource: params.resultContentSource } }
+        : {}),
       timestamp: this.nextTranscriptTimestamp(),
     } as unknown as AgentMessage;
   }

--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -157,21 +157,23 @@ export class CodexToolTranscriptProjection {
     });
   }
 
-  recordDynamicToolResult(params: {
-    callId: string;
-    tool: string;
-    success: boolean;
-    contentItems: CodexDynamicToolCallOutputContentItem[];
-    details?: unknown;
-    resultContentSource?: "network";
-  }): void {
+  recordDynamicToolResult(
+    params: {
+      callId: string;
+      tool: string;
+      success: boolean;
+      contentItems: CodexDynamicToolCallOutputContentItem[];
+      details?: unknown;
+    },
+    resultContentSource?: "network",
+  ): void {
     this.recordToolResult({
       id: params.callId,
       name: params.tool,
       text: collectDynamicToolContentText(params.contentItems),
       isError: !params.success,
       details: params.details,
-      ...(params.resultContentSource ? { resultContentSource: params.resultContentSource } : {}),
+      ...(resultContentSource ? { resultContentSource } : {}),
     });
   }
 

--- a/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
@@ -19,7 +19,10 @@ registerCodexEventProjectorTestLifecycle();
 
 describe("CodexAppServerEventProjector dynamic tool projection", () => {
   it("records dynamic OpenClaw tool calls in mirrored transcript snapshots", async () => {
-    const projector = await createProjector();
+    const projector = await createProjector(undefined, {
+      resolveDynamicToolResultContentSource: (toolName) =>
+        toolName === "browser" ? "network" : undefined,
+    });
 
     projector.recordDynamicToolCall({
       callId: "call-browser-1",
@@ -56,6 +59,7 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
     expect(toolResultMessage.toolCallId).toBe("call-browser-1");
     expect(toolResultMessage.toolName).toBe("browser");
     expect(toolResultMessage.isError).toBe(false);
+    expect(toolResultMessage["__openclaw"]).toMatchObject({ resultContentSource: "network" });
     const toolResultContent = requireRecord(
       requireArray(toolResultMessage.content, "tool result content")[0],
       "tool result content item",
@@ -66,6 +70,11 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
     expect(toolResultContent.toolName).toBe("browser");
     expect(toolResultContent.toolCallId).toBe("call-browser-1");
     expect(toolResultContent.content).toBe("opened");
+    expect(
+      requireRecord(result.messagesSnapshot[3], "final assistant")["__openclaw"],
+    ).toMatchObject({
+      turnTainted: true,
+    });
   });
 
   it("retains MCP App preview details in mirrored dynamic tool results", async () => {
@@ -141,7 +150,7 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
     expect(toolResultMessage.details).toEqual(details);
   });
 
-  it("does not mirror Codex-native web searches into transcript snapshots", async () => {
+  it("marks native web-search results and subsequent assistant output as tainted", async () => {
     const projector = await createProjector();
 
     await projector.handleNotification(
@@ -151,28 +160,24 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
           id: "search-observed",
           status: "completed",
           durationMs: 5,
+          query: "hostile result",
         },
       }),
     );
+    await projector.handleNotification(agentMessageDelta("summary"));
 
     const result = projector.buildResult(buildEmptyToolTelemetry());
-
+    const toolResult = requireRecord(result.messagesSnapshot[2], "native web-search result");
+    expect(toolResult).toMatchObject({
+      role: "toolResult",
+      toolName: "web_search",
+      __openclaw: { resultContentSource: "network" },
+    });
     expect(
-      result.messagesSnapshot.some((message) => {
-        const record = message as unknown as Record<string, unknown>;
-        if (record.role === "toolResult") {
-          return true;
-        }
-        const content = Array.isArray(record.content) ? record.content : [];
-        return content.some((entry) => {
-          return (
-            typeof entry === "object" &&
-            entry !== null &&
-            (entry as Record<string, unknown>).type === "toolCall"
-          );
-        });
-      }),
-    ).toBe(false);
+      requireRecord(result.messagesSnapshot[3], "final assistant")["__openclaw"],
+    ).toMatchObject({
+      turnTainted: true,
+    });
   });
 
   it("carries async-started dynamic tool metadata into attempt results", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -475,7 +475,11 @@ export class CodexAppServerEventProjector {
     details?: unknown;
   }): void {
     this.toolProgressProjection.recordDynamicToolResult(params);
-    this.toolTranscriptProjection.recordDynamicToolResult(params);
+    const resultContentSource = this.options.resolveDynamicToolResultContentSource?.(params.tool);
+    this.toolTranscriptProjection.recordDynamicToolResult({
+      ...params,
+      ...(resultContentSource ? { resultContentSource } : {}),
+    });
   }
 
   markTimedOut(): void {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -475,10 +475,8 @@ export class CodexAppServerEventProjector {
     details?: unknown;
   }): void {
     this.toolProgressProjection.recordDynamicToolResult(params);
-    this.toolTranscriptProjection.recordDynamicToolResult(
-      params,
-      this.options.resolveDynamicToolResultContentSource?.(params.tool),
-    );
+    const source = this.options.resolveDynamicToolResultContentSource?.(params.tool);
+    this.toolTranscriptProjection.recordDynamicToolResult(params, source);
   }
 
   markTimedOut(): void {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -475,11 +475,10 @@ export class CodexAppServerEventProjector {
     details?: unknown;
   }): void {
     this.toolProgressProjection.recordDynamicToolResult(params);
-    const resultContentSource = this.options.resolveDynamicToolResultContentSource?.(params.tool);
-    this.toolTranscriptProjection.recordDynamicToolResult({
-      ...params,
-      ...(resultContentSource ? { resultContentSource } : {}),
-    });
+    this.toolTranscriptProjection.recordDynamicToolResult(
+      params,
+      this.options.resolveDynamicToolResultContentSource?.(params.tool),
+    );
   }
 
   markTimedOut(): void {

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -54,7 +54,7 @@ export async function activateCodexAttemptTurn(
     sandboxSessionKey,
     effectiveCwd,
   } = connection;
-  const { dynamicToolParams, computerContextEpoch } = attemptTools;
+  const { dynamicToolParams, computerContextEpoch, toolBridge } = attemptTools;
   const { state, userInputBridgeRef, steeringQueueRef, turnWatches } = turnRuntime;
   const { emitExecutionPhaseOnce, emitLifecycleStart, maybeAnnounceFastModeAutoOff } = lifecycle;
   const { enqueueNotification } = notifications;
@@ -108,6 +108,7 @@ export async function activateCodexAttemptTurn(
           timeoutMs,
         }),
       trajectoryRecorder,
+      resolveDynamicToolResultContentSource: toolBridge.resultContentSourceForTool,
       onNativeToolResultRecorded: maybeAnnounceFastModeAutoOff,
       ...(prepareNativeMcpAppResultDetails ? { prepareNativeMcpAppResultDetails } : {}),
       upstreamUserText: turnState.codexTurnPromptText,

--- a/extensions/copilot/src/attempt-execution.ts
+++ b/extensions/copilot/src/attempt-execution.ts
@@ -2,6 +2,7 @@ import type { Tool as SdkTool } from "@github/copilot-sdk";
 import type {
   AgentHarnessAttemptParams,
   AgentMessage,
+  AnyAgentTool,
   SandboxContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
@@ -250,6 +251,10 @@ export async function runCopilotExecution(context: {
   } = { value: 0 };
   try {
     let sdkTools: SdkTool[] = [];
+    let resultContentSourceByToolName = new Map<
+      string,
+      NonNullable<AnyAgentTool["resultContentSource"]>
+    >();
     if (!settledToolFinalization) {
       try {
         const toolBridge = await createToolBridge({
@@ -288,6 +293,11 @@ export async function runCopilotExecution(context: {
         });
         cleanupToolBridge = toolBridge.cleanup;
         sdkTools = toolBridge.sdkTools;
+        resultContentSourceByToolName = new Map(
+          toolBridge.sourceTools.flatMap((tool) =>
+            tool.resultContentSource ? [[tool.name, tool.resultContentSource] as const] : [],
+          ),
+        );
       } catch (error: unknown) {
         const result = createResult(input, {
           messagesSnapshot: messages,
@@ -438,6 +448,7 @@ export async function runCopilotExecution(context: {
         })),
         modelRef,
         now,
+        resultContentSourceByToolName,
       },
     });
     activeRunHandleRef = registerCopilotActiveRun({

--- a/extensions/copilot/src/attempt-transcript-journal.test.ts
+++ b/extensions/copilot/src/attempt-transcript-journal.test.ts
@@ -515,7 +515,10 @@ describe("Copilot attempt transcript journal", () => {
   });
 
   it("commits a hidden tool turn to SQLite in assistant request order", async () => {
-    const { bridge, journal, recorder, session, target, tempDir } = await createFixture("memory");
+    const { bridge, journal, recorder, session, target, tempDir } = await createFixture(
+      "memory",
+      new Map<string, "network">([["read", "network"]]),
+    );
     await journal.persistInitialUser();
     expect(recorder.markRuntimePersisted).toHaveBeenCalledOnce();
 
@@ -626,7 +629,9 @@ describe("Copilot attempt transcript journal", () => {
       isError: true,
       toolCallId: "call-a",
       content: [{ type: "text", text: "A failed" }],
+      __openclaw: { resultContentSource: "network" },
     });
+    expect(rows[5]?.message).toMatchObject({ __openclaw: { turnTainted: true } });
     expect(journal.snapshot()).toMatchObject({
       assistantTranscriptOwned: true,
       assistantTranscriptIdempotencyKey: "copilot-sdk:sdk-session:assistant-final",
@@ -637,54 +642,6 @@ describe("Copilot attempt transcript journal", () => {
     );
     const files = await fs.readdir(tempDir, { recursive: true });
     expect(files.some((file) => file.endsWith(".jsonl"))).toBe(false);
-  });
-
-  it("persists network-result taint on the result and subsequent assistant", async () => {
-    const { bridge, journal, session, target } = await createFixture(
-      undefined,
-      new Map<string, "network">([["fake_web_tool", "network"]]),
-    );
-    await journal.persistInitialUser();
-    session.emit(event("user.message", "initial-user", { content: "inspect both files" }));
-    session.emit(
-      event("assistant.message", "assistant-tool", {
-        content: "researching",
-        messageId: "assistant-tool",
-        toolRequests: [
-          { arguments: { query: "topic" }, name: "fake_web_tool", toolCallId: "call-web" },
-        ],
-      }),
-    );
-    session.emit(
-      event("tool.execution_start", "start-web", {
-        toolCallId: "call-web",
-        toolName: "fake_web_tool",
-      }),
-    );
-    session.emit(
-      event("tool.execution_complete", "result-web", {
-        result: { content: "untrusted page" },
-        success: true,
-        toolCallId: "call-web",
-      }),
-    );
-    const finalAssistant = event("assistant.message", "assistant-final-tainted", {
-      content: "summary",
-      messageId: "assistant-final-tainted",
-    });
-    session.emit(finalAssistant);
-    bridge.recordSendResult(finalAssistant);
-    await journal.barrier("tainted turn");
-
-    const rows = transcriptMessages(await readSessionTranscriptEvents(target));
-    expect(rows[2]?.message).toMatchObject({
-      role: "toolResult",
-      __openclaw: { resultContentSource: "network" },
-    });
-    expect(rows[3]?.message).toMatchObject({
-      role: "assistant",
-      __openclaw: { turnTainted: true },
-    });
   });
 
   it("groups assistant chunks from one API call before matching tool results", async () => {

--- a/extensions/copilot/src/attempt-transcript-journal.test.ts
+++ b/extensions/copilot/src/attempt-transcript-journal.test.ts
@@ -59,7 +59,10 @@ function event(
   } as SessionEvent;
 }
 
-async function createFixture(trigger?: string) {
+async function createFixture(
+  trigger?: string,
+  resultContentSourceByToolName?: ReadonlyMap<string, "network">,
+) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-copilot-journal-"));
   tempDirs.push(tempDir);
   const target: SessionTranscriptTargetParams = {
@@ -124,6 +127,7 @@ async function createFixture(trigger?: string) {
       journal,
       modelRef: { api: "openai-responses", id: "gpt-5", provider: "github-copilot" },
       now: () => 2,
+      ...(resultContentSourceByToolName ? { resultContentSourceByToolName } : {}),
     },
   });
   return { attempt, bridge, journal, recorder, session, target, tempDir };
@@ -633,6 +637,54 @@ describe("Copilot attempt transcript journal", () => {
     );
     const files = await fs.readdir(tempDir, { recursive: true });
     expect(files.some((file) => file.endsWith(".jsonl"))).toBe(false);
+  });
+
+  it("persists network-result taint on the result and subsequent assistant", async () => {
+    const { bridge, journal, session, target } = await createFixture(
+      undefined,
+      new Map<string, "network">([["fake_web_tool", "network"]]),
+    );
+    await journal.persistInitialUser();
+    session.emit(event("user.message", "initial-user", { content: "inspect both files" }));
+    session.emit(
+      event("assistant.message", "assistant-tool", {
+        content: "researching",
+        messageId: "assistant-tool",
+        toolRequests: [
+          { arguments: { query: "topic" }, name: "fake_web_tool", toolCallId: "call-web" },
+        ],
+      }),
+    );
+    session.emit(
+      event("tool.execution_start", "start-web", {
+        toolCallId: "call-web",
+        toolName: "fake_web_tool",
+      }),
+    );
+    session.emit(
+      event("tool.execution_complete", "result-web", {
+        result: { content: "untrusted page" },
+        success: true,
+        toolCallId: "call-web",
+      }),
+    );
+    const finalAssistant = event("assistant.message", "assistant-final-tainted", {
+      content: "summary",
+      messageId: "assistant-final-tainted",
+    });
+    session.emit(finalAssistant);
+    bridge.recordSendResult(finalAssistant);
+    await journal.barrier("tainted turn");
+
+    const rows = transcriptMessages(await readSessionTranscriptEvents(target));
+    expect(rows[2]?.message).toMatchObject({
+      role: "toolResult",
+      __openclaw: { resultContentSource: "network" },
+    });
+    expect(rows[3]?.message).toMatchObject({
+      role: "assistant",
+      __openclaw: { turnTainted: true },
+    });
   });
 
   it("groups assistant chunks from one API call before matching tool results", async () => {

--- a/extensions/copilot/src/attempt-transcript-journal.ts
+++ b/extensions/copilot/src/attempt-transcript-journal.ts
@@ -25,6 +25,40 @@ type ToolGroup = {
   results: Map<string, PendingWrite>;
 };
 
+type TurnTaintMetadata = { resultContentSource?: "network"; turnTainted?: true };
+
+function readTurnTaintMetadata(message: AgentMessage): TurnTaintMetadata | undefined {
+  const metadata = (message as unknown as Record<string, unknown>)["__openclaw"];
+  return metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? (metadata as TurnTaintMetadata)
+    : undefined;
+}
+
+function isActiveTurnTainted(messages: readonly AgentMessage[]): boolean {
+  for (const message of messages.toReversed()) {
+    if (message.role === "user") {
+      return false;
+    }
+    const metadata = readTurnTaintMetadata(message);
+    if (metadata?.turnTainted === true || metadata?.resultContentSource === "network") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function withAssistantTurnTaint(
+  message: Extract<AgentMessage, { role: "assistant" }>,
+  tainted: boolean,
+) {
+  return tainted
+    ? ({
+        ...message,
+        __openclaw: { ...readTurnTaintMetadata(message), turnTainted: true },
+      } as typeof message)
+    : message;
+}
+
 export type AttemptTranscriptJournal = ReturnType<typeof createAttemptTranscriptJournal>;
 
 export function createAttemptTranscriptJournal(params: {
@@ -40,6 +74,7 @@ export function createAttemptTranscriptJournal(params: {
       message,
     });
   const messagesSnapshot = [...params.messages];
+  let turnTainted = isActiveTurnTainted(messagesSnapshot);
   const snapshotIdempotencyKeys = new Set(
     messagesSnapshot.flatMap((message) => {
       const key = readIdempotencyKey(message);
@@ -128,6 +163,7 @@ export function createAttemptTranscriptJournal(params: {
       replayInvalid = true;
     }
     const idempotencyKey = (message as { idempotencyKey?: string }).idempotencyKey;
+    const taintMetadata = readTurnTaintMetadata(message);
     const toolIdentity =
       message.role === "toolResult"
         ? { toolCallId: message.toolCallId, toolName: message.toolName }
@@ -135,6 +171,9 @@ export function createAttemptTranscriptJournal(params: {
     const prepared = projectDisplay({
       ...hooked,
       ...toolIdentity,
+      ...(taintMetadata
+        ? { __openclaw: { ...readTurnTaintMetadata(hooked), ...taintMetadata } }
+        : {}),
       ...(idempotencyKey ? { idempotencyKey } : {}),
       ...((message as { display?: boolean }).display === false ? { display: false } : {}),
     }) as TranscriptMessage;
@@ -392,6 +431,7 @@ export function createAttemptTranscriptJournal(params: {
         return;
       }
       replayInvalid ||= input.replayIncomplete === true;
+      const message = withAssistantTurnTaint(input.message, turnTainted);
       const key = `copilot-sdk:${params.sdkSessionId}:${input.eventId}`;
       latestAssistantKey = key;
       assistantTranscriptOwned = false;
@@ -402,7 +442,7 @@ export function createAttemptTranscriptJournal(params: {
         }
         const write = {
           eventId: input.eventId,
-          message: { ...input.message, idempotencyKey: key } as TranscriptMessage,
+          message: { ...message, idempotencyKey: key } as TranscriptMessage,
         };
         if (input.toolCallIds.length > 0) {
           pendingTools = {
@@ -429,6 +469,7 @@ export function createAttemptTranscriptJournal(params: {
       if (!claim(input.eventId)) {
         return;
       }
+      turnTainted ||= readTurnTaintMetadata(input.message)?.resultContentSource === "network";
       schedule(async () => {
         const group = pendingTools;
         if (!group || !group.order.includes(input.message.toolCallId)) {

--- a/extensions/copilot/src/event-bridge.ts
+++ b/extensions/copilot/src/event-bridge.ts
@@ -72,6 +72,7 @@ interface EventBridgeOptions {
     journal: AttemptTranscriptJournalProjection;
     modelRef: { api?: string; id: string; provider: string };
     now: () => number;
+    resultContentSourceByToolName?: ReadonlyMap<string, "network">;
   };
 }
 
@@ -370,17 +371,21 @@ export function attachEventBridge(
       const replayIncomplete = Boolean(
         event.data.result?.binaryResultsForLlm?.length || event.data.result?.citableSources?.length,
       );
+      const resolvedToolName =
+        toolName ?? event.data.toolDescription?.name ?? projectedToolName ?? "unknown";
+      const resultContentSource = projection.resultContentSourceByToolName?.get(resolvedToolName);
       projection.journal.recordToolResult({
         eventId: event.id,
         replayIncomplete,
         message: {
           role: "toolResult",
           toolCallId: event.data.toolCallId,
-          toolName: toolName ?? event.data.toolDescription?.name ?? projectedToolName ?? "unknown",
+          toolName: resolvedToolName,
           content: [{ type: "text", text: sanitizeToolDetailText(resultText) }],
           ...(hasOwnKeys(details) ? { details } : {}),
           isError: !event.data.success,
           timestamp: resolveEventTimestamp(event.timestamp, projection.now),
+          ...(resultContentSource ? { __openclaw: { resultContentSource } } : {}),
         },
       });
     }

--- a/src/agents/cli-runner/execute-events.ts
+++ b/src/agents/cli-runner/execute-events.ts
@@ -12,6 +12,7 @@ import { sanitizeToolArgs, sanitizeToolResult } from "../embedded-agent-subscrib
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { resolveCliToolTerminalReason } from "../run-termination.js";
 import type { CliToolTracking } from "./execute-tool-tracking.js";
+import { stripOpenClawMcpToolPrefix } from "./tool-policy.js";
 import type { PreparedCliRunContext } from "./types.js";
 
 type CliToolResult = {
@@ -108,6 +109,9 @@ export function createCliEventHandlers(params: {
     recordToolResult(event);
     params.toolTracking.handleCliToolResult(event);
     if (emitLiveEvents) {
+      const resultContentSource = context.resultContentSourceByToolName?.get(
+        stripOpenClawMcpToolPrefix(event.name),
+      );
       emitAgentEvent({
         runId: runParams.runId,
         stream: "tool",
@@ -117,6 +121,7 @@ export function createCliEventHandlers(params: {
           toolCallId: event.toolCallId,
           isError: event.isError,
           result: sanitizeToolResult(event.result),
+          ...(resultContentSource ? { resultContentSource } : {}),
         },
       });
     }

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1236,6 +1236,50 @@ describe("prepareCliRunContext", () => {
     });
   });
 
+  it("carries projected network-result capability into the prepared CLI context", async () => {
+    setRawCliBackendForPrepareTest({
+      id: "network-tool-cli",
+      pluginId: "network-tool-plugin",
+      bundleMcp: true,
+      bundleMcpMode: "claude-config-file",
+      config: {
+        command: "network-tool-cli",
+        args: ["--print"],
+        output: "text",
+        input: "arg",
+        sessionMode: "none",
+      },
+    });
+    setCliRunnerPrepareTestDeps({
+      getActiveMcpLoopbackRuntime: vi.fn(() => ({
+        port: 31783,
+        ownerToken: "loopback-owner-token",
+        nonOwnerToken: "loopback-non-owner-token",
+      })),
+      resolveMcpLoopbackScopedTools: vi.fn(() => ({
+        agentId: "main",
+        tools: [
+          {
+            name: "fake_web_tool",
+            label: "Fake web tool",
+            description: "Test network content capability",
+            parameters: Type.Object({}, { additionalProperties: false }),
+            resultContentSource: "network" as const,
+            execute: vi.fn(async () => ({ content: [] })),
+          },
+        ],
+      })),
+    });
+
+    const context = await fixture.prepare({
+      provider: "network-tool-cli",
+      model: "test-model",
+      config: createCliBackendConfig({ bundleMcp: true }),
+    });
+
+    expect(context.resultContentSourceByToolName?.get("fake_web_tool")).toBe("network");
+  });
+
   it("lets Gemini CLI preparation override generated MCP system settings auth", async () => {
     const { dir } = fixture.session;
     const profileSystemSettingsPath = path.join(dir, "profile-system-settings.json");

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -904,6 +904,11 @@ export async function prepareCliRunContext(
     };
   }
   const promptTools = bundleMcpEnabled ? projectedTools : [];
+  const resultContentSourceByToolName = new Map(
+    promptTools.flatMap((tool) =>
+      tool.resultContentSource ? [[tool.name, tool.resultContentSource] as const] : [],
+    ),
+  );
   // A restricted selectable tool surface must also bound the MCP bundle:
   // CLI-side --allowedTools is advisory under bypass permission modes, so
   // user/plugin MCP servers must not be merged into the run's config at all.
@@ -1492,6 +1497,7 @@ export async function prepareCliRunContext(
         extraSystemPromptHash,
         messageToolPolicyHash,
         promptToolNamesHash,
+        ...(resultContentSourceByToolName.size > 0 ? { resultContentSourceByToolName } : {}),
         cwdHash,
         ...(mcpDeliveryCaptureEnabled ? { mcpDeliveryCapture: true } : {}),
       };
@@ -1569,6 +1575,7 @@ export async function prepareCliRunContext(
       extraSystemPromptHash,
       messageToolPolicyHash,
       promptToolNamesHash,
+      ...(resultContentSourceByToolName.size > 0 ? { resultContentSourceByToolName } : {}),
       cwdHash,
       ...(mcpDeliveryCaptureEnabled ? { mcpDeliveryCapture: true } : {}),
     };

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -1,4 +1,7 @@
-import type { AgentMessage } from "../../../packages/agent-core/src/types.js";
+import type {
+  AgentMessage,
+  ToolResultContentSource,
+} from "../../../packages/agent-core/src/types.js";
 /**
  * Shared types for preparing and executing CLI-backed agent runs.
  */
@@ -313,6 +316,7 @@ export type PreparedCliRunContext = {
   extraSystemPromptHash?: string;
   messageToolPolicyHash?: string;
   promptToolNamesHash?: string;
+  resultContentSourceByToolName?: ReadonlyMap<string, ToolResultContentSource>;
   cwdHash?: string;
   mcpDeliveryCapture?: true;
 };

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.test.ts
@@ -29,6 +29,7 @@ function recorderParams() {
     prompt: "recall prompt",
     provider: "claude-cli",
     model: "claude-opus-4-8",
+    senderIsOwner: true,
   };
 }
 
@@ -52,6 +53,7 @@ describe("createCliDispatchTranscriptRecorder", () => {
     expect(records[0]?.message).toMatchObject({
       role: "user",
       content: [{ type: "text", text: "recall prompt" }],
+      __openclaw: { senderIsOwner: true },
     });
   });
 
@@ -97,6 +99,28 @@ describe("createCliDispatchTranscriptRecorder", () => {
       role: "assistant",
       content: [{ type: "text", text: "Lemon pepper." }],
       stopReason: "stop",
+    });
+  });
+
+  it("persists network-result taint on the result and subsequent assistant", async () => {
+    const recorder = createCliDispatchTranscriptRecorder(recorderParams());
+    recorder.noteToolEvent({
+      phase: "result",
+      toolName: "fake_web_tool",
+      result: { content: [{ type: "text", text: "untrusted page" }] },
+      isError: false,
+      resultContentSource: "network",
+    });
+    await recorder.finalize("summary");
+
+    const messages = appendedRecords().map((record) => record.message);
+    expect(messages[1]).toMatchObject({
+      role: "toolResult",
+      __openclaw: { resultContentSource: "network" },
+    });
+    expect(messages[2]).toMatchObject({
+      role: "assistant",
+      __openclaw: { turnTainted: true },
     });
   });
 

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch-transcript.ts
@@ -28,6 +28,7 @@ type CliDispatchTranscriptToolEvent = {
   args?: Record<string, unknown>;
   result?: unknown;
   isError?: boolean;
+  resultContentSource?: "network";
 };
 
 type CliDispatchTranscriptRecorder = {
@@ -62,11 +63,13 @@ export function createCliDispatchTranscriptRecorder(params: {
   model?: string;
   cwd?: string;
   config?: OpenClawConfig;
+  senderIsOwner?: boolean;
 }): CliDispatchTranscriptRecorder {
   let tail: Promise<void> = Promise.resolve();
   let lastAssistantText = "";
   let lastWrittenAssistantText = "";
   let finalized = false;
+  let turnTainted = false;
   let toolRecordSequence = 0;
 
   const scope = {
@@ -105,12 +108,24 @@ export function createCliDispatchTranscriptRecorder(params: {
   const buildZeroUsageAssistantMessage = (
     content: AssistantBuildParams["content"],
     stopReason: AssistantBuildParams["stopReason"],
-  ) => buildAssistantMessage({ model, content, stopReason, usage: buildUsageWithNoCost({}) });
+    tainted = turnTainted,
+  ) => {
+    const message = buildAssistantMessage({
+      model,
+      content,
+      stopReason,
+      usage: buildUsageWithNoCost({}),
+    });
+    return tainted ? ({ ...message, __openclaw: { turnTainted: true } } as AgentMessage) : message;
+  };
 
   enqueue(() => ({
     role: "user",
     content: [{ type: "text", text: params.prompt }],
     timestamp: Date.now(),
+    ...(params.senderIsOwner !== undefined
+      ? { __openclaw: { senderIsOwner: params.senderIsOwner } }
+      : {}),
   }));
 
   return {
@@ -122,6 +137,7 @@ export function createCliDispatchTranscriptRecorder(params: {
       const toolCallId =
         event.toolCallId?.trim() || `${params.runId}-tool-${String(toolRecordSequence)}`;
       if (event.phase === "start") {
+        const taintedAtStart = turnTainted;
         enqueue(() =>
           buildZeroUsageAssistantMessage(
             [
@@ -133,10 +149,12 @@ export function createCliDispatchTranscriptRecorder(params: {
               },
             ],
             "toolUse",
+            taintedAtStart,
           ),
         );
         return;
       }
+      turnTainted ||= event.resultContentSource === "network";
       enqueue(() => ({
         role: "toolResult",
         toolCallId,
@@ -145,6 +163,9 @@ export function createCliDispatchTranscriptRecorder(params: {
         details: readToolResultDetails(event.result),
         isError: event.isError === true,
         timestamp: Date.now(),
+        ...(event.resultContentSource
+          ? { __openclaw: { resultContentSource: event.resultContentSource } }
+          : {}),
       }));
     },
     noteAssistantText: (text) => {

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts
@@ -433,6 +433,7 @@ describe("runEmbeddedAgentViaCliBackendIfEligible execution", () => {
           name: "mcp__openclaw__memory_search",
           result: { content: [] },
           isError: false,
+          resultContentSource: "network",
         },
       });
       // Soft tool failures must surface as isError like the native path.
@@ -515,6 +516,7 @@ describe("runEmbeddedAgentViaCliBackendIfEligible execution", () => {
           toolCallId: "call-1",
           result: { content: [] },
           isError: false,
+          resultContentSource: "network",
         },
       });
       return cliRunResult();
@@ -540,7 +542,11 @@ describe("runEmbeddedAgentViaCliBackendIfEligible execution", () => {
       }),
     );
     expect(transcriptRecorder.noteToolEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ phase: "result", toolName: "memory_search" }),
+      expect.objectContaining({
+        phase: "result",
+        toolName: "memory_search",
+        resultContentSource: "network",
+      }),
     );
     expect(transcriptRecorder.finalize).toHaveBeenCalledWith("recall summary");
   });

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
@@ -117,6 +117,7 @@ async function runEmbeddedAgentViaCliBackend(
     model: params.model,
     cwd: params.cwd ?? params.workspaceDir,
     config: params.config,
+    ...(params.senderIsOwner !== undefined ? { senderIsOwner: params.senderIsOwner } : {}),
   });
   // CLI tool results arrive as agent events with transport-prefixed MCP
   // names; strip and normalize so observers and transcript records see the
@@ -152,12 +153,14 @@ async function runEmbeddedAgentViaCliBackend(
       return;
     }
     const isError = evt.data.isError === true || isToolResultError(evt.data.result);
+    const resultContentSource = evt.data.resultContentSource === "network" ? "network" : undefined;
     transcript.noteToolEvent({
       phase,
       toolName,
       toolCallId,
       result: evt.data.result,
       isError,
+      ...(resultContentSource ? { resultContentSource } : {}),
     });
     onAgentToolResult?.({
       toolName,


### PR DESCRIPTION
Related: #115818

## What Problem This Solves

Completes turn-taint transcript parity for runs whose canonical transcript is owned outside the embedded agent loop. Without this follow-up, Codex app-server, CLI-backend dispatch, and Copilot SDK runs could consume network content without persisting the host-only metadata that memory provenance uses to quarantine later assistant-authored writes.

## Why This Change Was Made

Each transcript owner now records `resultContentSource: network` on network-capability tool results and sticky `turnTainted: true` only on subsequent assistant rows. Codex and Copilot derive the capability from their prepared source tool objects, the CLI runner carries a process-local capability map from projected MCP tools into host events, and Codex-native web search uses the typed upstream `webSearch` item class. No tool-name registry, schema, or configuration surface was added.

Cross-turn laundering remains the existing session-level propagation follow-up; this PR completes only the approved turn-scoped transcript-owner parity.

## User Impact

Memory provenance now sees the same taint contract regardless of whether the turn ran through the embedded loop, Codex app-server, CLI backend dispatch, or Copilot. Owner metadata remains preserved, and provider-visible transcript content is unchanged.

## Evidence

- Exact-head focused proof: 4 routed Vitest shards, 305 tests passed across CLI dispatch, CLI preparation, Codex projection/tool mapping, and Copilot journaling.
- `node scripts/check-changed.mjs -- <22 changed files>` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30444852476
- Final branch autoreview: clean, no accepted/actionable findings, confidence 0.94.
- Upstream Codex contract inspected directly at `openai/codex` commit `4c43465133428898aa84f0bfc02c306ed65fb66a`:
  - `codex-rs/app-server-protocol/src/protocol/v2/item.rs:227-371,903-917,1310-1316` — typed `ThreadItem::WebSearch` projection and authoritative `item/completed` envelope.
  - `codex-rs/ext/items/src/web_search.rs:7-22` — web-search item and opaque structured results contract.
  - `codex-rs/app-server/tests/suite/v2/web_search.rs:300-373` — started/completed lifecycle and persisted web-search item proof.
  - `codex-rs/app-server/src/bespoke_event_handling.rs:1428-1452` — completed and raw-response notification emission.

This change is AI-assisted and was reviewed through the repository autoreview workflow. I understand the implementation and its ownership boundaries.
