### PR TITLE
fix(memory): recover divergent dreaming journals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Memory Core dreaming upgrades:** keep canonical SQLite state and archive divergent retired JSON journals so repeated startup migrations no longer block Gateway readiness. Thanks @brokemac79.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Memory Core dreaming upgrades:** keep canonical SQLite state and archive divergent retired JSON journals so repeated startup migrations no longer block Gateway readiness. Thanks @brokemac79.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -1108,7 +1108,7 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(fs.access(`${eventPath}.migrated`)).resolves.toBeUndefined();
   });
 
-  it("imports persistent legacy dreaming state and ignores transient locks", async () => {
+  it("migrates and recovers persistent legacy dreaming state", async () => {
     const dreamsDir = path.join(workspaceDir, "memory", ".dreams");
     const dailyPath = path.join(dreamsDir, "daily-ingestion.json");
     const sessionPath = path.join(dreamsDir, "session-ingestion.json");
@@ -1256,18 +1256,82 @@ describe("memory-core doctor dreaming migration", () => {
       expect.stringContaining("Retained acknowledged Memory Core phase signals"),
     ]);
 
+    const canonicalDaily = await dreamingTesting.readDailyIngestionState(workspaceDir);
+    const canonicalSession = await dreamingTesting.readSessionIngestionState(workspaceDir);
+    const canonicalRecall = await shortTermTesting.readRecallStore(
+      workspaceDir,
+      "2026-04-05T12:00:00.000Z",
+    );
+    const canonicalPhase = await shortTermTesting.readPhaseSignalStore(
+      workspaceDir,
+      "2026-04-05T13:00:00.000Z",
+    );
+
     const changedDaily = JSON.parse(await fs.readFile(dailyPath, "utf8")) as {
       files: Record<string, { mtimeMs: number }>;
     };
     changedDaily.files["memory/2026-04-05.md"]!.mtimeMs = 999;
-    await fs.writeFile(dailyPath, JSON.stringify(changedDaily), "utf8");
+    const changedDailyContents = JSON.stringify(changedDaily);
+    await fs.writeFile(dailyPath, changedDailyContents, "utf8");
+
+    const changedSession = JSON.parse(await fs.readFile(sessionPath, "utf8")) as {
+      seenMessages: Record<string, string[]>;
+    };
+    changedSession.seenMessages["main/session.jsonl"]!.push("seen-c");
+    const changedSessionContents = JSON.stringify(changedSession);
+    await fs.writeFile(sessionPath, changedSessionContents, "utf8");
+
+    const changedRecall = JSON.parse(await fs.readFile(recallPath, "utf8")) as {
+      entries: Record<string, { recallCount: number }>;
+    };
+    changedRecall.entries["memory:memory/2026-04-05.md:1:1"]!.recallCount = 99;
+    const changedRecallContents = JSON.stringify(changedRecall);
+    await fs.writeFile(recallPath, changedRecallContents, "utf8");
+
+    const changedPhase = JSON.parse(await fs.readFile(phasePath, "utf8")) as {
+      entries: Record<string, { lightHits: number }>;
+    };
+    changedPhase.entries["memory:memory/2026-04-05.md:1:1"]!.lightHits = 99;
+    const changedPhaseContents = JSON.stringify(changedPhase);
+    await fs.writeFile(phasePath, changedPhaseContents, "utf8");
+
     const conflictResult = await migration.migrateLegacyState(migrationParams());
-    expect(conflictResult.changes).toEqual([]);
-    expect(conflictResult.warnings).toEqual([
-      expect.stringContaining("SQLite rows conflict with the legacy source"),
+    expect(conflictResult.changes).toEqual([
+      "Resolved Memory Core daily ingestion legacy conflict by keeping canonical SQLite plugin state",
+      expect.stringContaining("Archived Memory Core daily ingestion conflicting legacy source"),
+      "Resolved Memory Core session ingestion legacy conflict by keeping canonical SQLite plugin state",
+      expect.stringContaining("Archived Memory Core session ingestion conflicting legacy source"),
+      "Resolved Memory Core short-term recall legacy conflict by keeping canonical SQLite plugin state",
+      expect.stringContaining("Archived Memory Core short-term recall conflicting legacy source"),
+      "Resolved Memory Core phase signals legacy conflict by keeping canonical SQLite plugin state",
+      expect.stringContaining("Archived Memory Core phase signals conflicting legacy source"),
     ]);
-    expect(conflictResult.notices).toHaveLength(3);
-    await expect(fs.access(dailyPath)).resolves.toBeUndefined();
+    expect(conflictResult.warnings).toEqual([]);
+    expect(conflictResult.notices).toBeUndefined();
+
+    for (const [sourcePath, archivePath, contents] of [
+      [dailyPath, `${dailyPath}.migrated.3`, changedDailyContents],
+      [sessionPath, `${sessionPath}.migrated.2`, changedSessionContents],
+      [recallPath, `${recallPath}.migrated.2`, changedRecallContents],
+      [phasePath, `${phasePath}.migrated.2`, changedPhaseContents],
+    ] as const) {
+      await expect(fs.access(sourcePath)).rejects.toThrow();
+      await expect(fs.readFile(archivePath, "utf8")).resolves.toBe(contents);
+    }
+
+    expect(await dreamingTesting.readDailyIngestionState(workspaceDir)).toEqual(canonicalDaily);
+    expect(await dreamingTesting.readSessionIngestionState(workspaceDir)).toEqual(canonicalSession);
+    expect(
+      await shortTermTesting.readRecallStore(workspaceDir, "2026-04-05T12:00:00.000Z"),
+    ).toEqual(canonicalRecall);
+    expect(
+      await shortTermTesting.readPhaseSignalStore(workspaceDir, "2026-04-05T13:00:00.000Z"),
+    ).toEqual(canonicalPhase);
+
+    await expect(migration.migrateLegacyState(migrationParams())).resolves.toEqual({
+      changes: [],
+      warnings: [],
+    });
   });
 
   it("leaves invalid legacy JSON in place", async () => {

--- a/extensions/memory-core/src/migration/doctor-dreaming-state.ts
+++ b/extensions/memory-core/src/migration/doctor-dreaming-state.ts
@@ -207,9 +207,17 @@ export const dreamingStateMigration: PluginDoctorStateMigration = {
           );
           continue;
         }
-        warnings.push(
-          `Skipped Memory Core ${source.label} import for ${source.workspaceDir} because SQLite rows conflict with the legacy source; left legacy source in place`,
+        // Each retired journal mirrors the SQLite namespaces used by the runtime.
+        // Keep canonical state active and retain only the divergent rollback source.
+        changes.push(
+          `Resolved Memory Core ${source.label} legacy conflict by keeping canonical SQLite plugin state`,
         );
+        await archiveLegacyStateSource({
+          filePath: source.filePath,
+          label: `Memory Core ${source.label} conflicting legacy source`,
+          changes,
+          warnings,
+        });
         continue;
       }
       let imported: number;

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -478,6 +478,40 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
+  it("checkpoints after a dreaming conflict is archived without a migration warning", async () => {
+    needsStartupMigrationCheckpoint.mockReturnValue(true);
+    autoMigrateLegacyPluginDoctorState.mockResolvedValueOnce({
+      migrated: true,
+      skipped: false,
+      changes: [
+        "Resolved Memory Core session ingestion legacy conflict by keeping canonical SQLite plugin state",
+        "Archived Memory Core session ingestion conflicting legacy source",
+      ],
+      warnings: [],
+    });
+
+    await runDoctorConfigPreflight({
+      migrateLegacyConfig: false,
+      invalidConfigNote: false,
+      requireStartupMigrationCheckpoint: true,
+      skipPristineCoreStateMigrations: true,
+    });
+
+    expect(autoMigrateLegacyPluginDoctorState).toHaveBeenCalledOnce();
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Resolved Memory Core session ingestion legacy conflict by keeping canonical SQLite plugin state",
+      ),
+      "Doctor changes",
+    );
+    expect(note).not.toHaveBeenCalledWith(
+      expect.stringContaining("SQLite rows conflict with the legacy source"),
+      "Doctor warnings",
+    );
+    expect(recordSuccessfulStartupMigrations).toHaveBeenCalledOnce();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+  });
+
   it("maps active payload failures into refreshed plugin quarantine", () => {
     const result = mapStartupPluginQuarantineRefresh({
       cfg: {


### PR DESCRIPTION
Supersedes https://github.com/openclaw/openclaw/pull/111958 with credit to @brokemac79. The original commit is retained through a `Co-authored-by` trailer; the implementation was recreated on current `main` because #113542 moved the migration into its current owner module.

## What Problem This Solves

Fixes an issue where users upgrading from beta.3 could have the Gateway refuse startup forever when canonical Memory Core SQLite rows coexisted with a divergent retired Dreaming JSON journal. Every startup migration repeated the same warning while leaving the retired source active, and startup preflight treats migration warnings as fatal.

## Why This Change Was Made

Canonical SQLite state now wins and the existing migration archive helper retains the divergent JSON source. This applies only to the four retired source classes whose runtime state is fully represented in SQLite: daily ingestion, session ingestion, short-term recall, and phase signals. The daily-ingestion writer and reader replace and reconstruct the complete `dreaming-daily-ingestion` namespace, so it meets the same derived-state bar as the other three.

There is no schema bump, runtime fallback, compatibility shim, or new configuration. Malformed or uncomparable sources still fail closed with a warning.

## User Impact

Affected upgrades recover automatically instead of entering a Gateway restart loop. The exact divergent JSON remains available in the numbered migration archive, canonical SQLite data is unchanged, and the next migration run is clean and idempotent.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-core/doctor-contract-api.test.ts` — 56 tests passed. Covers exact archive bytes, unchanged canonical SQLite state, all four source classes, and a clean second run.
- `node scripts/run-vitest.mjs src/commands/doctor-config-preflight.state-migration.test.ts` — 28 tests passed. Covers readiness checkpointing after the resolved conflict produces changes without the formerly fatal warning.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests '<focused tests>'` — clean, no accepted/actionable findings.
- `git diff --check` — clean.
