### PR TITLE
docs(control-ui): document composer capability menu

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -809,7 +809,7 @@ Registry commands do not start the channel bridge. Only `probe` and `doctor --pr
 
 The browser Control UI includes a dedicated MCP settings page at `/settings/mcp`; the previous `/mcp` path remains an alias. The page shows configured server counts, enabled/OAuth/filter summaries, per-server transport rows, enable/disable controls, common CLI commands, and a scoped editor for the `mcp` config section.
 
-For a shorter setup walkthrough covering Settings, CLI, and direct config, see [Connect MCP servers](/tools/mcp).
+For a shorter setup walkthrough covering Settings, the composer path (**+** → **Connectors** → **Add MCP server…**) and its **This session** / **Everywhere** scopes, CLI, and direct config, see [Connect MCP servers](/tools/mcp).
 
 Use the page for operator edits and quick inventory. Use `openclaw mcp doctor --probe` or `openclaw mcp probe` when you need live server proof.
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -10356,6 +10356,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /tools/mcp
 - Headings:
   - H2: Add a server from Settings
+  - H2: Add a server from the composer
   - H2: Add a server from the CLI
   - H2: Configure a server directly
   - H2: Troubleshooting
@@ -10915,6 +10916,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Activity tab
   - H2: Operator terminal
   - H2: Browser panel
+  - H2: Composer capability menu
   - H2: Chat behavior
   - H2: Connection loss and reconnect
   - H2: PWA install and web push

--- a/docs/tools/mcp.md
+++ b/docs/tools/mcp.md
@@ -1,5 +1,5 @@
 ---
-summary: "Connect MCP servers to OpenClaw from Settings, the CLI, or config"
+summary: "Connect MCP servers to OpenClaw from the Control UI, CLI, or config"
 title: "Connect MCP servers"
 read_when:
   - Adding an MCP server for OpenClaw agents
@@ -30,6 +30,12 @@ openclaw mcp doctor <name> --probe
 ```
 
 Saving a definition proves nothing about reachability — the probe does. Note that already-running Gateway or agent processes may need a restart or runtime reload before they pick up the new definition.
+
+## Add a server from the composer
+
+In a Control UI chat, select **+** → **Connectors** → **Add MCP server…**. The dialog uses the same server fields as Settings and requires administrator access.
+
+Choose **This session** for session-only enablement or **Everywhere** for global enablement. Either scope saves a global server definition; session policy is the per-session layer. See [Composer capability menu](/web/control-ui#composer-capability-menu) for the complete scope and tool-access behavior.
 
 ## Add a server from the CLI
 
@@ -106,6 +112,7 @@ Follow the printed authorization URL and rerun with `--code` when prompted.
 
 ## Related
 
+- [Control UI](/web/control-ui#composer-capability-menu)
 - [MCP CLI reference](/cli/mcp)
 - [Manage plugins](/plugins/manage-plugins)
 - [Tool policies](/tools)

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -425,6 +425,21 @@ Two capture modes package page context for the agent:
 
 The macOS app keeps its native link-browser sidebar for links clicked in the dashboard; the browser panel works there too, and is the way to annotate pages on every other platform.
 
+## Composer capability menu
+
+Select **+** beside the chat composer to open attachments and session capabilities in one menu:
+
+- **Skills** enables or disables individual skills for this session.
+- **Connectors** enables or disables configured MCP servers for this session. A **session** tag marks values that differ from the inherited configuration. **Browse connectors** opens the Plugins page on **Discover**.
+- **Web search** enables or disables managed web search plus native OpenAI and Codex search for this session.
+- **Manage plugins** opens the Plugins page.
+
+These controls are sparse session overrides, like the model and thinking settings in the chat header. A capability with no override inherits the current agent or global configuration, and OpenClaw applies the resolved values when the next run materializes its tools and skills. The **N session overrides** pill in the composer footer reopens the menu; select its clear action to remove all capability overrides in one click.
+
+In **Connectors**, administrators can select **Add MCP server…** and choose a scope. **This session** saves the server definition globally but disabled by default, then enables it only for the current session. **Everywhere** saves the definition enabled globally. Transport, authentication, and other server-definition fields are always global. Session policy can override server enablement and deny individual tools through **Tool access**.
+
+Capability toggles stay disabled until the Gateway, session, and runtime config are loaded, and read-only operators cannot change them. Adding a server requires administrator access. See [Connect MCP servers](/tools/mcp) for the Settings, CLI, and config paths.
+
 ## Chat behavior
 
 <AccordionGroup>

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -438,6 +438,8 @@ These controls are sparse session overrides, like the model and thinking setting
 
 In **Connectors**, administrators can select **Add MCP server…** and choose a scope. **This session** saves the server definition globally but disabled by default, then enables it only for the current session. **Everywhere** saves the definition enabled globally. Transport, authentication, and other server-definition fields are always global. Session policy can override server enablement and deny individual tools through **Tool access**.
 
+**Tool access** lists a connector's tools once a run has discovered them. Before that, it explains why the list is empty rather than reporting zero tools: a newly added server has not connected yet, a connected server has not finished listing its tools, or the runtime catalog predates a config change. Sessions that run on the Codex harness keep their MCP connections inside Codex, so their tools do not appear here.
+
 Capability toggles stay disabled until the Gateway, session, and runtime config are loaded, and read-only operators cannot change them. Adding a server requires administrator access. See [Connect MCP servers](/tools/mcp) for the Settings, CLI, and config paths.
 
 ## Chat behavior


### PR DESCRIPTION
Related: #115785
Related: #115800

## What Problem This Solves

The Control UI now has per-session capability controls, but the docs do not explain where to find them, what inherits from agent or global settings, or how session-scoped MCP choices differ from globally stored server configuration.

## Why This Change Was Made

This documents the composer capability menu alongside the existing model and thinking session settings, then adds the composer as a server-setup path in the MCP guide and CLI reference. It covers the behavior landed in #115785 and #115800 plus the in-flight `steipete/composer-connector-management` branch.

This PR must remain a draft and must not be marked ready until the connector-management work lands. That branch does not have a PR at the time this draft was opened. AI-assisted.

## User Impact

Operators can learn how to use per-session Skills, Connectors, Tool access, and Web search overrides, clear those overrides, and choose between session-only or global MCP server enablement without mistaking session policy for session-scoped server configuration.

## Evidence

- `git diff --check`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links` (6,308 internal links, 0 broken)
- `pnpm docs:check-i18n-glossary`
- `pnpm format:docs:check`
- `node scripts/check-changed.mjs` on Blacksmith Testbox: `lanes=docs-only`, exit 0 (https://github.com/openclaw/openclaw/actions/runs/30446165421)
- Codex autoreview: clean, with no accepted or actionable findings
