### PR TITLE
fix(macos): reap timed-out shell process groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS shell timeouts:** terminate and reap the full subprocess group after bounded TERM-to-KILL escalation, preventing timed-out app helpers and their descendants from surviving in the background.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS shell timeouts:** terminate and reap the full subprocess group after bounded TERM-to-KILL escalation, preventing timed-out app helpers and their descendants from surviving in the background.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/apps/macos/Sources/OpenClaw/ShellExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ShellExecutor.swift
@@ -1,3 +1,5 @@
+import Darwin
+import Dispatch
 import Foundation
 import OpenClawIPC
 import Subprocess
@@ -61,6 +63,60 @@ enum ShellExecutor {
         case timedOut
     }
 
+    private enum DeadlineOutcome: Sendable, Equatable {
+        case exited
+        case timedOut
+    }
+
+    private final class ProcessExitSignal: @unchecked Sendable {
+        private let lock = NSLock()
+        private let source: DispatchSourceProcess
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var finished = false
+
+        init(processIdentifier: pid_t) {
+            self.source = DispatchSource.makeProcessSource(
+                identifier: processIdentifier,
+                eventMask: .exit,
+                queue: .global(qos: .userInitiated))
+            self.source.setEventHandler { [weak self] in
+                self?.finish()
+            }
+            self.source.resume()
+        }
+
+        func wait() async {
+            await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    self.lock.lock()
+                    guard !self.finished else {
+                        self.lock.unlock()
+                        continuation.resume()
+                        return
+                    }
+                    self.continuation = continuation
+                    self.lock.unlock()
+                }
+            } onCancel: {
+                self.finish()
+            }
+        }
+
+        private func finish() {
+            self.lock.lock()
+            guard !self.finished else {
+                self.lock.unlock()
+                return
+            }
+            self.finished = true
+            let continuation = self.continuation
+            self.continuation = nil
+            self.lock.unlock()
+            self.source.cancel()
+            continuation?.resume()
+        }
+    }
+
     private static func environment(from values: [String: String]?) -> Environment {
         guard let values else { return .inherit }
         var converted: [Environment.Key: String] = [:]
@@ -83,29 +139,50 @@ enum ShellExecutor {
         return result.terminationStatus
     }
 
-    private static func execute(
+    private static func runTimedSubprocess(
         configuration: Configuration,
         output: OutputFiles,
-        timeout: Double?) async throws -> RunOutcome
+        timeout: Double) async throws -> RunOutcome
     {
-        guard let timeout, timeout > 0 else {
-            return try await .completed(self.runSubprocess(configuration: configuration, output: output))
-        }
+        let result = try await Subprocess.run(
+            configuration,
+            input: .none,
+            output: output.subprocessStandardOutput,
+            error: output.subprocessStandardError)
+        { execution in
+            let processIdentifier = pid_t(execution.processIdentifier.value)
+            return await withTaskCancellationHandler {
+                let deadline = await withTaskGroup(of: DeadlineOutcome.self) { group in
+                    let exitSignal = ProcessExitSignal(processIdentifier: processIdentifier)
+                    group.addTask {
+                        await exitSignal.wait()
+                        return .exited
+                    }
+                    group.addTask {
+                        do {
+                            try await Task.sleep(for: .seconds(timeout))
+                            return .timedOut
+                        } catch {
+                            return .exited
+                        }
+                    }
+                    defer { group.cancelAll() }
+                    return await group.next() ?? .exited
+                }
 
-        return try await withThrowingTaskGroup(of: RunOutcome.self) { group in
-            group.addTask {
-                try await .completed(self.runSubprocess(configuration: configuration, output: output))
+                guard deadline == .timedOut else { return false }
+                try? execution.send(signal: .terminate, toProcessGroup: true)
+                try? await Task.sleep(for: .milliseconds(100))
+                // The group leader may have exited on TERM. Keep the body alive until
+                // the final group kill so TERM-ignoring descendants cannot escape.
+                try? execution.send(signal: .kill, toProcessGroup: true)
+                return true
+            } onCancel: {
+                // Cancellation can arrive before the timeout race finishes.
+                _ = Darwin.kill(-processIdentifier, SIGKILL)
             }
-            group.addTask {
-                try await Task.sleep(for: .seconds(timeout))
-                return .timedOut
-            }
-
-            // Group scope waits for swift-subprocess cancellation teardown, including
-            // SIGKILL escalation and reaping, before a timeout result reaches callers.
-            defer { group.cancelAll() }
-            return try await group.next() ?? .timedOut
         }
+        return result.closureOutput ? .timedOut : .completed(result.terminationStatus)
     }
 
     static func runDetailed(
@@ -141,9 +218,10 @@ enum ShellExecutor {
         platformOptions.qualityOfService = .userInitiated
         platformOptions.createSession = true
         platformOptions.teardownSequence = [
-            .gracefulShutDown(
+            .send(
+                signal: .kill,
                 toProcessGroup: true,
-                allowedDurationToNextStep: .milliseconds(100)),
+                allowedDurationToNextStep: .zero),
         ]
         let configuration = Configuration(
             .path(.init("/usr/bin/env")),
@@ -153,10 +231,15 @@ enum ShellExecutor {
             platformOptions: platformOptions)
 
         do {
-            let outcome = try await self.execute(
-                configuration: configuration,
-                output: output,
-                timeout: timeout)
+            let outcome = if let timeout, timeout > 0 {
+                try await self.runTimedSubprocess(
+                    configuration: configuration,
+                    output: output,
+                    timeout: timeout)
+            } else {
+                try await RunOutcome.completed(
+                    self.runSubprocess(configuration: configuration, output: output))
+            }
             let captured = output.readAndRemove()
             switch outcome {
             case .timedOut:

--- a/apps/macos/Sources/OpenClaw/ShellExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ShellExecutor.swift
@@ -134,6 +134,7 @@ enum ShellExecutor {
     {
         let result = try await Subprocess.run(
             configuration,
+            input: .standardInput,
             output: output.subprocessStandardOutput,
             error: output.subprocessStandardError)
         return result.terminationStatus
@@ -146,7 +147,7 @@ enum ShellExecutor {
     {
         let result = try await Subprocess.run(
             configuration,
-            input: .none,
+            input: .standardInput,
             output: output.subprocessStandardOutput,
             error: output.subprocessStandardError)
         { execution in

--- a/apps/macos/Sources/OpenClaw/ShellExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ShellExecutor.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OpenClawIPC
+import Subprocess
 
 enum ShellExecutor {
     struct ShellResult: Sendable {
@@ -41,53 +42,70 @@ enum ShellExecutor {
                 String(bytes: stdoutData, encoding: .utf8) ?? "",
                 String(bytes: stderrData, encoding: .utf8) ?? "")
         }
-    }
 
-    private final class CompletionBox: @unchecked Sendable {
-        private let lock = NSLock()
-        private var finished = false
-        private let continuation: CheckedContinuation<ShellResult, Never>
-        private let output: OutputFiles
-
-        init(continuation: CheckedContinuation<ShellResult, Never>, output: OutputFiles) {
-            self.continuation = continuation
-            self.output = output
+        var subprocessStandardOutput: FileDescriptorOutput {
+            .fileDescriptor(
+                .init(rawValue: self.stdout.fileDescriptor),
+                closeAfterSpawningProcess: false)
         }
 
-        func finish(
-            status: Int?,
-            timedOut: Bool,
-            errorMessage: String?,
-            beforeCapture: (@Sendable () -> Void)? = nil)
-        {
-            self.lock.lock()
-            guard !self.finished else {
-                self.lock.unlock()
-                return
+        var subprocessStandardError: FileDescriptorOutput {
+            .fileDescriptor(
+                .init(rawValue: self.stderr.fileDescriptor),
+                closeAfterSpawningProcess: false)
+        }
+    }
+
+    private enum RunOutcome: Sendable {
+        case completed(TerminationStatus)
+        case timedOut
+    }
+
+    private static func environment(from values: [String: String]?) -> Environment {
+        guard let values else { return .inherit }
+        var converted: [Environment.Key: String] = [:]
+        converted.reserveCapacity(values.count)
+        for (key, value) in values {
+            guard let environmentKey = Environment.Key(rawValue: key) else { continue }
+            converted[environmentKey] = value
+        }
+        return .custom(converted)
+    }
+
+    private static func runSubprocess(
+        configuration: Configuration,
+        output: OutputFiles) async throws -> TerminationStatus
+    {
+        let result = try await Subprocess.run(
+            configuration,
+            output: output.subprocessStandardOutput,
+            error: output.subprocessStandardError)
+        return result.terminationStatus
+    }
+
+    private static func execute(
+        configuration: Configuration,
+        output: OutputFiles,
+        timeout: Double?) async throws -> RunOutcome
+    {
+        guard let timeout, timeout > 0 else {
+            return try await .completed(self.runSubprocess(configuration: configuration, output: output))
+        }
+
+        return try await withThrowingTaskGroup(of: RunOutcome.self) { group in
+            group.addTask {
+                try await .completed(self.runSubprocess(configuration: configuration, output: output))
             }
-            self.finished = true
-            self.lock.unlock()
-            beforeCapture?()
-            let captured = self.output.readAndRemove()
-            self.continuation.resume(returning: ShellResult(
-                stdout: captured.stdout,
-                stderr: captured.stderr,
-                exitCode: status,
-                timedOut: timedOut,
-                success: status == 0 && !timedOut && errorMessage == nil,
-                errorMessage: errorMessage ?? status.flatMap { $0 == 0 ? nil : "exit \($0)" }))
-        }
-    }
+            group.addTask {
+                try await Task.sleep(for: .seconds(timeout))
+                return .timedOut
+            }
 
-    private static func completedResult(status: Int, output: OutputFiles) -> ShellResult {
-        let captured = output.readAndRemove()
-        return ShellResult(
-            stdout: captured.stdout,
-            stderr: captured.stderr,
-            exitCode: status,
-            timedOut: false,
-            success: status == 0,
-            errorMessage: status == 0 ? nil : "exit \(status)")
+            // Group scope waits for swift-subprocess cancellation teardown, including
+            // SIGKILL escalation and reaping, before a timeout result reaches callers.
+            defer { group.cancelAll() }
+            return try await group.next() ?? .timedOut
+        }
     }
 
     static func runDetailed(
@@ -106,16 +124,6 @@ enum ShellExecutor {
                 errorMessage: "empty command")
         }
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = command
-        if let cwd {
-            process.currentDirectoryURL = URL(fileURLWithPath: cwd)
-        }
-        if let env {
-            process.environment = env
-        }
-
         let output: OutputFiles
         do {
             output = try OutputFiles()
@@ -128,42 +136,50 @@ enum ShellExecutor {
                 success: false,
                 errorMessage: "failed to capture output: \(error.localizedDescription)")
         }
-        process.standardOutput = output.stdout
-        process.standardError = output.stderr
 
-        if let timeout, timeout > 0 {
-            return await withCheckedContinuation { continuation in
-                let completion = CompletionBox(continuation: continuation, output: output)
-
-                process.terminationHandler = { terminatedProcess in
-                    let status = Int(terminatedProcess.terminationStatus)
-                    completion.finish(status: status, timedOut: false, errorMessage: nil)
-                }
-
-                do {
-                    try process.run()
-                } catch {
-                    completion.finish(
-                        status: nil,
-                        timedOut: false,
-                        errorMessage: "failed to start: \(error.localizedDescription)")
-                    return
-                }
-
-                DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + timeout) {
-                    guard process.isRunning else { return }
-                    // Claim timeout classification before SIGTERM can trigger the termination handler.
-                    completion.finish(
-                        status: nil,
-                        timedOut: true,
-                        errorMessage: "timeout",
-                        beforeCapture: { process.terminate() })
-                }
-            }
-        }
+        var platformOptions = PlatformOptions()
+        platformOptions.qualityOfService = .userInitiated
+        platformOptions.createSession = true
+        platformOptions.teardownSequence = [
+            .gracefulShutDown(
+                toProcessGroup: true,
+                allowedDurationToNextStep: .milliseconds(100)),
+        ]
+        let configuration = Configuration(
+            .path(.init("/usr/bin/env")),
+            arguments: Arguments(command),
+            environment: self.environment(from: env),
+            workingDirectory: cwd.map { .init($0) },
+            platformOptions: platformOptions)
 
         do {
-            try process.run()
+            let outcome = try await self.execute(
+                configuration: configuration,
+                output: output,
+                timeout: timeout)
+            let captured = output.readAndRemove()
+            switch outcome {
+            case .timedOut:
+                return ShellResult(
+                    stdout: captured.stdout,
+                    stderr: captured.stderr,
+                    exitCode: nil,
+                    timedOut: true,
+                    success: false,
+                    errorMessage: "timeout")
+            case let .completed(terminationStatus):
+                let status = switch terminationStatus {
+                case let .exited(code), let .signaled(code):
+                    Int(code)
+                }
+                return ShellResult(
+                    stdout: captured.stdout,
+                    stderr: captured.stderr,
+                    exitCode: status,
+                    timedOut: false,
+                    success: terminationStatus.isSuccess,
+                    errorMessage: terminationStatus.isSuccess ? nil : "exit \(status)")
+            }
         } catch {
             let captured = output.readAndRemove()
             return ShellResult(
@@ -174,9 +190,6 @@ enum ShellExecutor {
                 success: false,
                 errorMessage: "failed to start: \(error.localizedDescription)")
         }
-
-        process.waitUntilExit()
-        return self.completedResult(status: Int(process.terminationStatus), output: output)
     }
 
     static func run(command: [String], cwd: String?, env: [String: String]?, timeout: Double?) async -> Response {

--- a/apps/macos/Tests/OpenClawIPCTests/ShellExecutorTimeoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ShellExecutorTimeoutTests.swift
@@ -1,0 +1,91 @@
+import Darwin
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct ShellExecutorTimeoutTests {
+    @Test func `timeout kills and reaps a TERM-ignoring command`() async throws {
+        let pidFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-shell-timeout-\(UUID().uuidString).pid")
+        defer { try? FileManager.default.removeItem(at: pidFile) }
+
+        let result = await ShellExecutor.runDetailed(
+            command: [
+                "/bin/sh",
+                "-c",
+                "echo $$ > \"$PID_FILE\"; trap '' TERM; while :; do :; done",
+            ],
+            cwd: nil,
+            env: ["PID_FILE": pidFile.path],
+            timeout: 0.1)
+
+        #expect(result.timedOut)
+        let pidString = try String(contentsOf: pidFile, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let pid = try #require(pid_t(pidString))
+        defer {
+            if kill(pid, 0) == 0 {
+                kill(pid, SIGKILL)
+            }
+        }
+        #expect(kill(pid, 0) == -1)
+        #expect(errno == ESRCH)
+    }
+
+    @Test func `timeout terminates TERM-ignoring descendants`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-shell-timeout-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let parentPIDFile = directory.appendingPathComponent("parent.pid")
+        let childPIDFile = directory.appendingPathComponent("child.pid")
+
+        let result = await ShellExecutor.runDetailed(
+            command: [
+                "/bin/sh",
+                "-c",
+                """
+                trap '' TERM
+                /bin/sh -c 'trap "" TERM; echo $$ > "$CHILD_PID_FILE"; while :; do sleep 10; done' &
+                echo $$ > "$PARENT_PID_FILE"
+                while [ ! -s "$CHILD_PID_FILE" ]; do sleep 0.01; done
+                while :; do sleep 10; done
+                """,
+            ],
+            cwd: nil,
+            env: [
+                "PARENT_PID_FILE": parentPIDFile.path,
+                "CHILD_PID_FILE": childPIDFile.path,
+            ],
+            timeout: 0.2)
+
+        #expect(result.timedOut)
+        let parentPID = try self.readPID(from: parentPIDFile)
+        let childPID = try self.readPID(from: childPIDFile)
+        defer {
+            for pid in [parentPID, childPID] where kill(pid, 0) == 0 {
+                kill(pid, SIGKILL)
+            }
+        }
+        #expect(await self.waitUntilGone(parentPID))
+        #expect(await self.waitUntilGone(childPID))
+    }
+
+    private func readPID(from file: URL) throws -> pid_t {
+        let value = try String(contentsOf: file, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return try #require(pid_t(value))
+    }
+
+    private func waitUntilGone(_ pid: pid_t) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(1)
+        while ContinuousClock.now < deadline {
+            errno = 0
+            if kill(pid, 0) == -1, errno == ESRCH {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ShellExecutorTimeoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ShellExecutorTimeoutTests.swift
@@ -45,7 +45,6 @@ struct ShellExecutorTimeoutTests {
                 "/bin/sh",
                 "-c",
                 """
-                trap '' TERM
                 /bin/sh -c 'trap "" TERM; echo $$ > "$CHILD_PID_FILE"; while :; do sleep 10; done' &
                 echo $$ > "$PARENT_PID_FILE"
                 while [ ! -s "$CHILD_PID_FILE" ]; do sleep 0.01; done


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS app helpers that exceeded their timeout could return while the command or one of its descendants was still running, especially when a process ignored SIGTERM. Repeated timeouts could leave background CPU, memory, and file-descriptor users behind.

## Why This Change Was Made

Run shell helpers in an isolated subprocess session, capture output in seekable temporary files, and keep timeout ownership inside the running subprocess body. Timeout teardown now sends TERM to the process group, waits 100 ms, sends KILL to the full group even if the leader already exited, and waits for reaping before returning. Untimed commands and inherited standard input keep their previous behavior.

## User Impact

Timed-out macOS app commands now finish within a bounded teardown path and do not leave TERM-resistant helpers or descendants running in the background. Successful commands, output capture, exit status, and stdin inheritance remain unchanged.

## Evidence

- Before the fix, a TERM-resistant command returned from the timeout path while `kill(pid, 0)` still reported the process alive.
- `swift test --package-path apps/macos --filter ShellExecutorTimeoutTests`: 2 tests passed, including TERM-resistant leader and descendant cases.
- `swift test --package-path apps/macos --filter LowCoverageHelperTests`: 20 tests passed, including timeout, stdout/stderr drain, and inherited-output-handle coverage.
- SwiftFormat 0.62.1 and SwiftLint 0.65.0: clean on touched Swift files.
- Fresh branch autoreview: clean, no accepted/actionable findings.
- Delegated changed gate: https://github.com/openclaw/openclaw/actions/runs/30447453784
