### PR TITLE
fix(ui): stabilize tests under three-worker packing

### DIFF
--- a/test/vitest/vitest.ui-isolated-paths.mjs
+++ b/test/vitest/vitest.ui-isolated-paths.mjs
@@ -4,7 +4,9 @@
 export const uiIsolatedTestFiles = [
   "ui/src/app/bootstrap.test.ts",
   "ui/src/app/router-outlet.test.ts",
+  "ui/src/components/resizable-divider.test.ts",
   "ui/src/components/viewer-facepile.test.ts",
+  "ui/src/pages/chat/chat-pane-board.test.ts",
   "ui/src/pages/chat/chat-pane-history.test.ts",
   "ui/src/pages/chat/chat-pane-identity.test.ts",
   "ui/src/pages/chat/chat-pane-lifecycle.test.ts",
@@ -13,6 +15,7 @@ export const uiIsolatedTestFiles = [
   "ui/src/pages/chat/chat-pane.read-marker.test.ts",
   "ui/src/pages/chat/chat-pane.session-discussion.test.ts",
   "ui/src/pages/chat/chat-pane.test.ts",
+  "ui/src/pages/chat/components/chat-thread.measure.test.ts",
   "ui/src/pages/workboard/view.test.ts",
 ];
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI test suite could fail nondeterministically under CI's three-worker packing, attributing shared custom-element/module-registry state to otherwise healthy tests.

## Why This Change Was Made

The non-isolated UI runner resets module imports between files, while the browser custom-element registry preserves constructors. Three tests combined preserved element classes with freshly imported board-provider, media-resource, or i18n singletons. Route those identity-sensitive suites through the existing isolated UI project so each class and its singleton state come from the same module graph.

## User Impact

No product behavior changes. Contributors and maintainers get stable Control UI CI results without rotating false failures in chat media, board authorization, or divider localization tests.

## Evidence

- Linux Node 24 / Blacksmith Testbox `tbx_01kypra2rrhcfews0hvcrghqsj` reproduced the stable-packing failure on run 2: `resizable-divider.test.ts` retained the English label after the test selected Portuguese.
- Eight seeded three-worker file shuffles were recorded during diagnosis.
- Focused isolated lane: 3 files, 39 tests passed.
- Exact shared command repeated six consecutive times: 469 files, 6,736 tests per run, all passed.
- Full package CI shape, `pnpm --dir ui test --maxWorkers 3`: 484 files, 7,010 tests passed.
- `pnpm check:changed`: passed.
- Codex autoreview: no accepted/actionable findings.

AI-assisted: yes. I reviewed the failure mechanism, patch, and proof results.
