### PR TITLE
fix: expanded disclosures render their content on Apple platforms

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -40227,7 +40227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 735,
+      "line": 737,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift",
       "source": "Image",
       "surface": "apple",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -287,10 +287,12 @@ struct ChatMarkdownRenderSnapshot {
                     preparesReveal: false),
                 isExpanded: disclosure.isExpanded,
                 blocks: disclosure.blocks.map {
+                    // Reveal locations address only top-level blocks. Disclosure content
+                    // uses a nested renderer without reveal state, so render it directly.
                     Self.renderedBlock(
                         $0,
                         isComplete: isComplete,
-                        preparesReveal: preparesReveal)
+                        preparesReveal: false)
                 }))
         case .thematicBreak:
             .thematicBreak

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownRendererTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownRendererTests.swift
@@ -1,0 +1,51 @@
+import Testing
+@testable import OpenClawChatUI
+
+struct ChatMarkdownRendererTests {
+    @Test @MainActor func `streaming disclosure body stays directly renderable`() throws {
+        let snapshot = ChatMarkdownRenderSnapshot(
+            text: """
+            <details>
+            <summary>More detail</summary>
+
+            I'm here to help with questions, projects, and practical tasks.
+
+            - Clear answers
+            - Thoughtful assistance
+
+            ```bash
+            echo "Hello"
+            ```
+
+            </details>
+            """,
+            isComplete: false,
+            preparesReveal: true)
+        guard case let .disclosure(disclosure) = try #require(snapshot.blocks.first) else {
+            Issue.record("expected rendered disclosure")
+            return
+        }
+
+        #expect(String(disclosure.summary.attributed.characters) == "More detail")
+        #expect(disclosure.blocks.count == 2)
+
+        guard case let .prose(prose) = disclosure.blocks[0] else {
+            Issue.record("expected renderable disclosure prose")
+            return
+        }
+        let proseText = String(prose.attributed.characters)
+        #expect(proseText.contains("I'm here to help with questions, projects, and practical tasks."))
+        #expect(proseText.contains("Clear answers"))
+        #expect(proseText.contains("Thoughtful assistance"))
+        #expect(prose.plainText.isEmpty)
+        #expect(prose.prefix.characters.isEmpty)
+        #expect(prose.tail.isEmpty)
+
+        guard case let .code(code) = disclosure.blocks[1] else {
+            Issue.record("expected rendered disclosure code block")
+            return
+        }
+        #expect(code.language == "bash")
+        #expect(code.code == "echo \"Hello\"")
+    }
+}


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

Follow-up to #115641, which is already on main.

## What Problem This Solves

Fixes an issue where a model-authored `<details>` disclosure on Apple platforms rendered its collapsed state correctly but expanded to a completely blank body, causing user-visible content loss on iOS and macOS.

## Why This Change Was Made

Streaming snapshots enable reveal preparation in `ChatMessageViews.swift:1186`, and that flag was propagated into disclosure body prose in `ChatMarkdownRenderer.swift:289`. Prose built in reveal mode expects a reveal driver, but the disclosure's nested renderer in `ChatMarkdownRenderer.swift:355` is constructed without reveal state, so body text was laid out and never drawn. Headings and the disclosure summary already forced reveal preparation off; the body was the inconsistent case.

Disclosure body blocks now render on the direct path with `preparesReveal: false`. Streaming behavior is preserved because only top-level prose participates in word reveal; disclosure content refreshes per snapshot.

## User Impact

Expanding a model-authored disclosure now shows its full body on iOS and macOS instead of a blank area.

## Evidence

- Live iOS Simulator verification against a real gateway with a real GPT-5.6 reply: before the fix, expanding the disclosure showed a blank body. After the fix, it showed the paragraph, both bullets ("Clear answers" and "Thoughtful assistance"), and the syntax-highlighted bash block `echo "Hello"`, matching the web Control UI rendering of the identical message.
- Regression coverage was added at the render layer in `ChatMarkdownRendererTests.swift`. The test fails before the fix and passes after it; segmenter tests passed throughout and could not detect the missing drawing state.
- OpenClawKit: 1,290 Swift Testing tests and 52 XCTest tests passed after rebasing onto current `origin/main`.
- SwiftLint: 0 violations.
- SwiftFormat: clean.
- `git diff --check`: clean.
- Autoreview: Codex `gpt-5.6-sol`, xhigh, branch mode; clean with no accepted findings.
