### PR TITLE
fix(codex): classify curated marketplace load failures by sync root

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -782,10 +782,11 @@ describe("startCodexAttemptThread", () => {
       pluginConfig: deadlinePluginConfig,
     });
     await answerInitialize(harness);
-    const pluginList = await waitForRequest(harness, "plugin/list");
-    expect(
-      readHarnessMessages(harness.writes).find((message) => message.id === pluginList.id),
-    ).toMatchObject({ method: "plugin/list", params: {} });
+    // Discovery requests (plugin/installed, and plugin/list only when the
+    // missing-plugin catalog fetch wins the race against the shared deadline)
+    // are deliberately left unanswered; the contract under test is that the
+    // thread still starts, carrying the deny-all apps patch.
+    await waitForRequest(harness, "plugin/installed");
 
     const threadStart = await waitForThreadStart(harness);
     const startMessage = readHarnessMessages(harness.writes).find(

--- a/extensions/codex/src/app-server/plugin-inventory.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.ts
@@ -545,7 +545,12 @@ function marketplaceRef(
   };
 }
 
-/** True for either supported OpenAI curated marketplace wire name. */
+/**
+ * True for either supported OpenAI curated marketplace wire name. Codex also
+ * counts `openai-api-curated` (API-key/Bedrock accounts) as curated, but
+ * OpenClaw's native plugin flows are ChatGPT-account scoped, so that catalog
+ * stays out of discovery and activation until it gets end-to-end support.
+ */
 export function isOpenAiCuratedMarketplace(marketplace: v2.PluginMarketplaceEntry): boolean {
   return (
     marketplace.name === CODEX_PLUGINS_MARKETPLACE_NAME ||

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -523,7 +523,7 @@ describe("buildCodexMigrationProvider", () => {
       ]).marketplaces,
       marketplaceLoadErrors: [
         {
-          marketplacePath: "/marketplaces/broken-custom",
+          marketplacePath: "/marketplaces/broken-custom/.claude-plugin/marketplace.json",
           message: "unrelated custom marketplace is unavailable",
         },
       ],
@@ -564,7 +564,7 @@ describe("buildCodexMigrationProvider", () => {
           marketplaces: [],
           marketplaceLoadErrors: [
             {
-              marketplacePath: "/marketplaces/broken-custom",
+              marketplacePath: "/marketplaces/broken-custom/.agents/plugins/marketplace.json",
               message: "unrelated custom marketplace is unavailable",
             },
           ],
@@ -581,29 +581,34 @@ describe("buildCodexMigrationProvider", () => {
     expect(appServerRequest).toHaveBeenCalledTimes(1);
   });
 
-  it("fails closed when marketplace errors prevent curated source discovery", async () => {
-    const fixture = await createCodexFixture();
-    appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
-      if (method === "plugin/installed") {
-        return {
-          marketplaces: [],
-          marketplaceLoadErrors: [
-            {
-              marketplacePath: "/marketplaces/openai-curated",
-              message: "curated marketplace is unavailable",
-            },
-          ],
-        } satisfies v2.PluginInstalledResponse;
-      }
-      throw new Error(`unexpected request ${method}`);
-    });
+  // Codex reports load failures by manifest file path under the curated sync
+  // root `<codexHome>/.tmp/plugins`; cover both curated manifest variants.
+  it.each([[".agents/plugins/marketplace.json"], [".agents/plugins/api_marketplace.json"]])(
+    "fails closed when the curated %s manifest cannot load",
+    async (manifestRelativePath) => {
+      const fixture = await createCodexFixture();
+      appServerRequest.mockImplementation(async ({ method }: { method: string }) => {
+        if (method === "plugin/installed") {
+          return {
+            marketplaces: [],
+            marketplaceLoadErrors: [
+              {
+                marketplacePath: path.join(fixture.codexHome, ".tmp/plugins", manifestRelativePath),
+                message: "curated marketplace is unavailable",
+              },
+            ],
+          } satisfies v2.PluginInstalledResponse;
+        }
+        throw new Error(`unexpected request ${method}`);
+      });
 
-    const source = await discoverCodexSource({ input: fixture.codexHome });
+      const source = await discoverCodexSource({ input: fixture.codexHome });
 
-    expect(source.pluginDiscoveryError).toBe("curated marketplace is unavailable");
-    expect(source.plugins.some((plugin) => plugin.marketplaceName !== undefined)).toBe(false);
-    expect(sourceAppServerClientScope).toHaveBeenCalledTimes(1);
-  });
+      expect(source.pluginDiscoveryError).toBe("curated marketplace is unavailable");
+      expect(source.plugins.some((plugin) => plugin.marketplaceName !== undefined)).toBe(false);
+      expect(sourceAppServerClientScope).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("does not trust a curated marketplace that reports its own load error", async () => {
     const fixture = await createCodexFixture();
@@ -615,7 +620,10 @@ describe("buildCodexMigrationProvider", () => {
           ]).marketplaces,
           marketplaceLoadErrors: [
             {
-              marketplacePath: "/marketplaces/openai-curated",
+              marketplacePath: path.join(
+                fixture.codexHome,
+                ".tmp/plugins/.agents/plugins/marketplace.json",
+              ),
               message: "curated marketplace was only partially loaded",
             },
           ],

--- a/extensions/codex/src/migration/source.ts
+++ b/extensions/codex/src/migration/source.ts
@@ -1,5 +1,6 @@
 // Codex plugin module implements source behavior.
 import path from "node:path";
+import { isPathInside } from "openclaw/plugin-sdk/security-runtime";
 import {
   defaultCodexAppInventoryCache,
   type CodexAppInventoryRequest,
@@ -120,20 +121,15 @@ async function discoverInstalledCuratedPlugins(
           method: "plugin/installed",
           requestParams: { cwds: [] } satisfies v2.PluginInstalledParams,
         });
-        const curatedMarketplaces = response.marketplaces.filter(isOpenAiCuratedMarketplace);
-        const curatedMarketplacePaths = new Set(
-          curatedMarketplaces.flatMap((marketplace) =>
-            marketplace.path ? [marketplace.path] : [],
-          ),
+        // Codex reports marketplace load failures by manifest file path, and both
+        // curated variants (marketplace.json and api_marketplace.json) sync under
+        // `<codexHome>/.tmp/plugins` while custom marketplaces load from user-owned
+        // roots. Failed manifests never appear in `marketplaces`, so containment in
+        // the curated sync root is the only reliable curated-failure signal.
+        const curatedSyncRoot = path.join(codexHome, ".tmp", "plugins");
+        const curatedMarketplaceErrors = response.marketplaceLoadErrors.filter((error) =>
+          isPathInside(curatedSyncRoot, error.marketplacePath),
         );
-        const curatedMarketplaceErrors = response.marketplaceLoadErrors.filter((error) => {
-          const marketplaceName = path.basename(error.marketplacePath);
-          return (
-            curatedMarketplacePaths.has(error.marketplacePath) ||
-            marketplaceName === CODEX_PLUGINS_MARKETPLACE_NAME ||
-            marketplaceName === `${CODEX_PLUGINS_MARKETPLACE_NAME}-remote`
-          );
-        });
         if (curatedMarketplaceErrors.length > 0) {
           return {
             plugins: [],


### PR DESCRIPTION
## What Problem This Solves

Codex migration's curated-marketplace failure classifier (added in #115075) never matches real Codex output, so a corrupt or unreadable curated marketplace silently reports **zero plugins** instead of a discovery error — the exact silent-loss mode the classification was added to prevent.

The classifier treated a `marketplaceLoadErrors` entry as curated when its `marketplacePath` basename equals `openai-curated`/`openai-curated-remote`, or when the path matches a successfully loaded curated marketplace. Against Codex 0.146.0 both legs are dead:

- Codex reports load errors with the marketplace **manifest file path** (`.agents/plugins/marketplace.json`, `.agents/plugins/api_marketplace.json`, …), so the basename is always a manifest filename, never a marketplace name (`codex-rs/core-plugins/src/marketplace.rs`, `MARKETPLACE_MANIFEST_RELATIVE_PATHS`).
- A manifest either loads or errors, so a failing path can never also appear in `response.marketplaces` — the set-membership leg is unreachable.

## Why This Change Was Made

Classify curated failures by ownership instead of name shape: both curated variants (ChatGPT `marketplace.json` and API-key `api_marketplace.json`) sync under the Codex-managed curated root `<codexHome>/.tmp/plugins` (`codex-rs/core-plugins/src/startup_sync.rs`, `CURATED_PLUGINS_RELATIVE_DIR`), while custom marketplaces load from user-owned roots. A load error whose path lies inside that root is a curated failure; everything else stays an unrelated custom-marketplace failure. Uses the canonical `isPathInside` helper already used by this plugin's migration code.

The tests encoded the invented directory-shaped paths (`/marketplaces/openai-curated`) that made the dead classifier look correct; they now use realistic manifest-file paths, and the fail-closed case covers both curated manifest variants.

Also documents the deliberate `openai-api-curated` exclusion at `isOpenAiCuratedMarketplace` (Codex counts it as curated for API-key/Bedrock accounts; OpenClaw's native plugin flows are ChatGPT-account scoped).

## User Impact

`openclaw migrate` from a Codex home with a corrupt curated marketplace now surfaces `pluginDiscoveryError` ("Codex app-server plugin inventory discovery failed: invalid marketplace file …") instead of silently planning zero native plugins. Unrelated custom-marketplace failures still don't block curated discovery.

## Evidence

- Upstream contract verified in sibling Codex checkout at tag `rust-v0.146.0`: `codex-rs/core-plugins/src/marketplace.rs` (manifest-path errors, load-or-error exclusivity), `codex-rs/core-plugins/src/startup_sync.rs` (curated root `.tmp/plugins`), `codex-rs/core-plugins/src/lib.rs` (`is_openai_curated_marketplace_name`).
- Live proof against the pinned real binary (`codex-cli 0.146.0`): corrupt `<codexHome>/.tmp/plugins/.agents/plugins/marketplace.json` → `plugin/installed` returns `marketplaceLoadErrors[0].marketplacePath` = that manifest file path, and `marketplaces: []`.
- Live A/B through `openclaw migrate plan codex --from <corrupt home>`: old classifier → `warnings: []` (silent loss); this fix → warning `Codex app-server plugin inventory discovery failed: invalid marketplace file …`.
- Focused tests: `node scripts/run-vitest.mjs extensions/codex/src/migration/provider.test.ts` — 57 passed (the two new fail-closed cases fail against the old classifier).
- `node scripts/check-changed.mjs` — green (delegated Testbox run https://github.com/openclaw/openclaw/actions/runs/30446793961).

## CI note

This PR also carries a test-only repair for pre-existing breakage on `main`: `attempt-startup.test.ts` ("continues with a deny-all apps patch when plugin discovery exceeds its shared deadline") asserted a racy intermediate `plugin/list` request. Since #115075, discovery sends `plugin/installed`; `plugin/list` only appears when the missing-plugin catalog fetch wins a race against the shared discovery deadline, so the test is timing-dependent (green on yesterday's CI runners, deterministic-red locally and on today's runners — 3/3 fail at `origin/main` and even at #115075's own green head). The test now asserts the actual contract: the thread still starts and carries the deny-all apps patch. Verified 3/3 green after the fix.
