### PR TITLE
fix(codex): harden app inventory invalidation and targeted publishes

### DIFF
--- a/extensions/codex/src/app-server/app-inventory-cache.test.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.test.ts
@@ -603,6 +603,27 @@ describe("Codex app inventory cache", () => {
     expect(cache.read({ key, request, nowMs: 5, suppressRefresh: true }).state).toBe("fresh");
   });
 
+  it("renews freshness when a targeted refresh re-covers the whole cached scope", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
+    const key = "runtime";
+    const apps = [app("calendar-app")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
+
+    await cache.refreshNow({ key, request, nowMs: 0, targetAppIds: ["calendar-app"] });
+    expect(cache.read({ key, request, nowMs: 1_500, suppressRefresh: true }).state).toBe("stale");
+
+    await cache.refreshNow({
+      key,
+      request,
+      nowMs: 1_500,
+      forceRefetch: true,
+      targetAppIds: ["calendar-app"],
+    });
+    expect(cache.read({ key, request, nowMs: 1_600, suppressRefresh: true }).state).toBe("fresh");
+  });
+
   it("retires stacked scoped invalidations across separate covering refreshes", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
     const key = "runtime";

--- a/extensions/codex/src/app-server/app-inventory-cache.test.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.test.ts
@@ -603,6 +603,39 @@ describe("Codex app inventory cache", () => {
     expect(cache.read({ key, request, nowMs: 5, suppressRefresh: true }).state).toBe("fresh");
   });
 
+  it("replaces an expired union entry on the next single-target refresh", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
+    const key = "runtime";
+    const apps = [app("calendar-app"), app("drive-app")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
+
+    await cache.refreshNow({ key, request, nowMs: 0, targetAppIds: ["calendar-app"] });
+    await cache.refreshNow({
+      key,
+      request,
+      nowMs: 1,
+      forceRefetch: true,
+      targetAppIds: ["drive-app"],
+    });
+    expect(cache.read({ key, request, nowMs: 1_500, suppressRefresh: true }).state).toBe("stale");
+
+    // Past TTL nothing is preserved; the single-target refresh replaces the
+    // union entry and freshness recovers without a complete fetch.
+    await cache.refreshNow({
+      key,
+      request,
+      nowMs: 1_500,
+      forceRefetch: true,
+      targetAppIds: ["calendar-app"],
+    });
+    const read = cache.read({ key, request, nowMs: 1_600, suppressRefresh: true });
+    expect(read.state).toBe("fresh");
+    expect(read.snapshot?.targetAppIds).toEqual(["calendar-app"]);
+    expect(read.snapshot?.apps).toEqual([app("calendar-app")]);
+  });
+
   it("renews freshness when a targeted refresh re-covers the whole cached scope", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
     const key = "runtime";

--- a/extensions/codex/src/app-server/app-inventory-cache.test.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.test.ts
@@ -603,6 +603,37 @@ describe("Codex app inventory cache", () => {
     expect(cache.read({ key, request, nowMs: 5, suppressRefresh: true }).state).toBe("fresh");
   });
 
+  it("retires stacked scoped invalidations across separate covering refreshes", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
+    const key = "runtime";
+    const apps = [app("calendar-app"), app("drive-app")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
+
+    await cache.refreshNow({ key, request, nowMs: 0, targetAppIds: [] });
+    cache.invalidate(key, "calendar plugin installed", 1, ["calendar-app"]);
+    cache.invalidate(key, "drive plugin installed", 2, ["drive-app"]);
+
+    await cache.refreshNow({
+      key,
+      request,
+      nowMs: 3,
+      forceRefetch: true,
+      targetAppIds: ["calendar-app"],
+    });
+    expect(cache.read({ key, request, nowMs: 4, suppressRefresh: true }).state).toBe("stale");
+
+    await cache.refreshNow({
+      key,
+      request,
+      nowMs: 5,
+      forceRefetch: true,
+      targetAppIds: ["drive-app"],
+    });
+    expect(cache.read({ key, request, nowMs: 6, suppressRefresh: true }).state).toBe("fresh");
+  });
+
   it("keeps an unscoped invalidation until a complete refresh", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
     const key = "runtime";

--- a/extensions/codex/src/app-server/app-inventory-cache.test.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.test.ts
@@ -499,6 +499,84 @@ describe("Codex app inventory cache", () => {
     expect(freshRead.state).toBe("fresh");
     expect(freshRead.snapshot?.apps).toEqual([app("fresh-app")]);
   });
+
+  it("discards a pre-invalidation refresh instead of republishing it as fresh", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
+    const key = "runtime";
+    let resolveInstalled: ((response: v2.AppsInstalledResponse) => void) | undefined;
+    const request = vi.fn(async (method, params) => {
+      if (method === "app/installed") {
+        return await new Promise<v2.AppsInstalledResponse>((resolve) => {
+          resolveInstalled = resolve;
+        });
+      }
+      return codexAppInventoryResponse(method, [app("stale-app")], params);
+    });
+
+    const read = cache.read({ key, request, nowMs: 0 });
+    expect(read.state).toBe("missing");
+    expect(read.refreshScheduled).toBe(true);
+
+    cache.invalidate(key, "plugin installed", 1);
+    resolveInstalled?.(codexAppInventoryResponse("app/installed", [app("stale-app")]));
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+
+    const after = cache.read({ key, request, nowMs: 2, suppressRefresh: true });
+    expect(after.state).toBe("missing");
+    expect(after.diagnostic?.message).toBe("plugin installed");
+  });
+
+  it("keeps the complete inventory when a targeted refresh lands on the same runtime", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
+    const key = "runtime";
+    const apps = [app("calendar-app"), app("drive-app")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
+
+    await cache.refreshNow({ key, request, nowMs: 0, targetAppIds: [] });
+    const targeted = await cache.refreshNow({
+      key,
+      request,
+      nowMs: 1,
+      forceRefetch: true,
+      targetAppIds: ["calendar-app"],
+    });
+    expect(targeted.apps).toEqual([app("calendar-app")]);
+    expect(targeted.targetAppIds).toEqual(["calendar-app"]);
+
+    const read = cache.read({ key, request, nowMs: 2, suppressRefresh: true });
+    expect(read.state).toBe("fresh");
+    expect(read.snapshot?.targetAppIds).toBeUndefined();
+    expect(read.snapshot?.apps).toEqual(apps);
+  });
+
+  it("merges targeted refreshes for one runtime instead of alternating narrow snapshots", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
+    const key = "runtime";
+    const apps = [app("calendar-app"), app("drive-app")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
+
+    await cache.refreshNow({ key, request, nowMs: 0, targetAppIds: ["calendar-app"] });
+    await cache.refreshNow({
+      key,
+      request,
+      nowMs: 1,
+      forceRefetch: true,
+      targetAppIds: ["drive-app"],
+    });
+
+    const read = cache.read({ key, request, nowMs: 2, suppressRefresh: true });
+    expect(read.state).toBe("fresh");
+    expect(read.snapshot?.targetAppIds).toEqual(["calendar-app", "drive-app"]);
+    expect(read.snapshot?.apps).toEqual(apps);
+    expect(read.snapshot?.installedApps.map((entry) => entry.id)).toEqual([
+      "calendar-app",
+      "drive-app",
+    ]);
+  });
 });
 
 function app(id: string): v2.AppInfo {

--- a/extensions/codex/src/app-server/app-inventory-cache.test.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.test.ts
@@ -551,6 +551,82 @@ describe("Codex app inventory cache", () => {
     expect(read.snapshot?.apps).toEqual(apps);
   });
 
+  it("does not renew non-target row freshness during a targeted merge", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
+    const key = "runtime";
+    const apps = [app("calendar-app"), app("drive-app")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
+
+    await cache.refreshNow({ key, request, nowMs: 0, targetAppIds: [] });
+    await cache.refreshNow({
+      key,
+      request,
+      nowMs: 900,
+      forceRefetch: true,
+      targetAppIds: ["calendar-app"],
+    });
+
+    // Freshness still belongs to the complete fetch at t=0, not the merge at t=900.
+    const read = cache.read({ key, request, nowMs: 1_100, suppressRefresh: true });
+    expect(read.state).toBe("stale");
+  });
+
+  it("keeps a scoped invalidation until a covering targeted refresh", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
+    const key = "runtime";
+    const apps = [app("calendar-app"), app("drive-app")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
+
+    await cache.refreshNow({ key, request, nowMs: 0, targetAppIds: [] });
+    cache.invalidate(key, "calendar plugin installed", 1, ["calendar-app"]);
+
+    await cache.refreshNow({
+      key,
+      request,
+      nowMs: 2,
+      forceRefetch: true,
+      targetAppIds: ["drive-app"],
+    });
+    expect(cache.read({ key, request, nowMs: 3, suppressRefresh: true }).state).toBe("stale");
+
+    await cache.refreshNow({
+      key,
+      request,
+      nowMs: 4,
+      forceRefetch: true,
+      targetAppIds: ["calendar-app"],
+    });
+    expect(cache.read({ key, request, nowMs: 5, suppressRefresh: true }).state).toBe("fresh");
+  });
+
+  it("keeps an unscoped invalidation until a complete refresh", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
+    const key = "runtime";
+    const apps = [app("calendar-app")];
+    const request = vi.fn(async (method, params) =>
+      codexAppInventoryResponse(method, apps, params),
+    );
+
+    await cache.refreshNow({ key, request, nowMs: 0, targetAppIds: [] });
+    cache.invalidate(key, "runtime identity changed", 1);
+
+    await cache.refreshNow({
+      key,
+      request,
+      nowMs: 2,
+      forceRefetch: true,
+      targetAppIds: ["calendar-app"],
+    });
+    expect(cache.read({ key, request, nowMs: 3, suppressRefresh: true }).state).toBe("stale");
+
+    await cache.refreshNow({ key, request, nowMs: 4, forceRefetch: true, targetAppIds: [] });
+    expect(cache.read({ key, request, nowMs: 5, suppressRefresh: true }).state).toBe("fresh");
+  });
+
   it("merges targeted refreshes for one runtime instead of alternating narrow snapshots", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 1_000 });
     const key = "runtime";

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -275,7 +275,7 @@ export class CodexAppInventoryCache {
       // while this request was in flight.
       if (this.refreshTokens.get(params.key) === refreshToken) {
         const existingEntry = this.entries.get(params.key);
-        const published = resolvePublishedInventorySnapshot(existingEntry, snapshot);
+        const published = resolvePublishedInventorySnapshot(existingEntry, snapshot, nowMs);
         // An uncovered invalidation keeps its remaining scope and diagnostic
         // until covering or complete refreshes prove the entry current again.
         const remaining = resolveRemainingInvalidationScope(existingEntry, snapshot);
@@ -320,25 +320,26 @@ export class CodexAppInventoryCache {
 function resolvePublishedInventorySnapshot(
   existing: CodexAppInventorySnapshot | undefined,
   snapshot: CodexAppInventorySnapshot,
+  nowMs: number,
 ): CodexAppInventorySnapshot {
   if (!snapshot.targetAppIds?.length || !existing) {
     return snapshot;
   }
+  // Merging preserves rows the refresh never re-read, which is only safe while
+  // the existing entry is within TTL. An expired entry is replaced outright so
+  // freshness restarts from this refresh; keeping expired rows would pin the
+  // entry stale no matter how many targeted refreshes cover it.
+  if (!isFutureDateTimestampMs(existing.expiresAtMs, { nowMs })) {
+    return snapshot;
+  }
   const refreshedTargetIds = new Set(snapshot.targetAppIds);
   const { targetAppIds: snapshotTargetAppIds, ...snapshotBase } = snapshot;
-  // Freshness belongs to the newest refresh that re-read every retained row: a
-  // merge keeps the existing timestamps while unrefreshed rows remain (they
-  // must not be renewed), but a targeted refresh covering the whole cached
-  // targeted scope adopts the new ones, or an expired targeted-only entry
-  // could never regain freshness from targeted refreshes.
-  const coversWholeCachedScope =
-    (existing.targetAppIds?.length ?? 0) > 0 &&
-    (existing.targetAppIds ?? []).every((appId) => refreshedTargetIds.has(appId));
   return {
     ...snapshotBase,
-    ...(coversWholeCachedScope
-      ? {}
-      : { fetchedAtMs: existing.fetchedAtMs, expiresAtMs: existing.expiresAtMs }),
+    // Freshness belongs to the still-valid prior fetch: the merge must not
+    // renew rows it never re-read.
+    fetchedAtMs: existing.fetchedAtMs,
+    expiresAtMs: existing.expiresAtMs,
     apps: mergeRefreshedRows(existing.apps, snapshot.apps, refreshedTargetIds),
     installedApps: mergeRefreshedRows(
       existing.installedApps,

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -276,16 +276,13 @@ export class CodexAppInventoryCache {
       if (this.refreshTokens.get(params.key) === refreshToken) {
         const existingEntry = this.entries.get(params.key);
         const published = resolvePublishedInventorySnapshot(existingEntry, snapshot);
-        const invalidated = resolveRemainingInvalidation(existingEntry, snapshot);
+        // An uncovered invalidation keeps its remaining scope and diagnostic
+        // until covering or complete refreshes prove the entry current again.
+        const remaining = resolveRemainingInvalidationScope(existingEntry, snapshot);
         this.entries.set(params.key, {
           ...published,
-          invalidated,
-          // An uncovered invalidation keeps its scope and diagnostic until a
-          // covering or complete refresh proves the entry current again.
-          ...(invalidated && existingEntry?.invalidatedAppIds
-            ? { invalidatedAppIds: existingEntry.invalidatedAppIds }
-            : {}),
-          ...(invalidated && existingEntry?.lastError
+          ...remaining,
+          ...(remaining.invalidated && existingEntry?.lastError
             ? { lastError: existingEntry.lastError }
             : {}),
         });
@@ -373,19 +370,26 @@ function mergeRefreshedRows<Row extends { id: string }>(
 }
 
 /**
- * A refresh only clears invalidation it can prove it re-read: complete
- * refreshes always do; targeted ones only when they cover the invalidated
- * scope. Unscoped invalidations require a complete refresh.
+ * A refresh retires exactly the invalidation scope it re-read: a complete
+ * refresh clears everything; a targeted one subtracts its target ids so
+ * separate covering refreshes accumulate until no scope remains. Unscoped
+ * invalidations require a complete refresh.
  */
-function resolveRemainingInvalidation(
+function resolveRemainingInvalidationScope(
   existing: CacheEntry | undefined,
   snapshot: CodexAppInventorySnapshot,
-): boolean {
+): { invalidated: false } | { invalidated: true; invalidatedAppIds?: readonly string[] } {
   if (!existing?.invalidated || !snapshot.targetAppIds?.length) {
-    return false;
+    return { invalidated: false };
+  }
+  if (!existing.invalidatedAppIds) {
+    return { invalidated: true };
   }
   const refreshedTargetIds = new Set(snapshot.targetAppIds);
-  return !existing.invalidatedAppIds?.every((appId) => refreshedTargetIds.has(appId));
+  const remaining = existing.invalidatedAppIds.filter((appId) => !refreshedTargetIds.has(appId));
+  return remaining.length > 0
+    ? { invalidated: true, invalidatedAppIds: remaining }
+    : { invalidated: false };
 }
 
 function doesInFlightRefreshCover(existing: InFlightRefresh, params: RefreshParams): boolean {

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -74,6 +74,8 @@ export type CodexAppInventoryCacheRead = {
 
 type CacheEntry = CodexAppInventorySnapshot & {
   invalidated: boolean;
+  /** Present while invalidated: the app ids the invalidation concerns. Absent = whole inventory. */
+  invalidatedAppIds?: readonly string[];
 };
 
 type RefreshParams = {
@@ -143,8 +145,17 @@ export class CodexAppInventoryCache {
     return this.refresh(params);
   }
 
-  /** Marks a key stale and records the reason as a diagnostic. */
-  invalidate(key: string, reason: string, nowMs = Date.now()): number {
+  /**
+   * Marks a key stale and records the reason as a diagnostic. A scope names
+   * the app ids the invalidation concerns so a covering targeted refresh can
+   * clear it; without one, only a complete refresh revalidates the entry.
+   */
+  invalidate(
+    key: string,
+    reason: string,
+    nowMs = Date.now(),
+    invalidatedAppIds?: readonly string[],
+  ): number {
     this.revision += 1;
     // Invalidation outranks in-flight refreshes: retire their publish token so
     // pre-invalidation reads cannot republish as fresh, and drop the shared
@@ -154,6 +165,17 @@ export class CodexAppInventoryCache {
     const diagnostic = { message: reason, atMs: nowMs };
     const entry = this.entries.get(key);
     if (entry) {
+      const scope = invalidatedAppIds?.filter(Boolean) ?? [];
+      if (!entry.invalidated) {
+        entry.invalidatedAppIds = scope.length ? [...scope].toSorted() : undefined;
+      } else if (entry.invalidatedAppIds && scope.length) {
+        // Stacked scoped invalidations widen; an unscoped one stays whole-inventory.
+        entry.invalidatedAppIds = Array.from(
+          new Set([...entry.invalidatedAppIds, ...scope]),
+        ).toSorted();
+      } else {
+        entry.invalidatedAppIds = undefined;
+      }
       entry.invalidated = true;
       entry.lastError = diagnostic;
       entry.revision = this.revision;
@@ -252,8 +274,21 @@ export class CodexAppInventoryCache {
       // Only publish this snapshot if no newer refresh started for the same key
       // while this request was in flight.
       if (this.refreshTokens.get(params.key) === refreshToken) {
-        const published = resolvePublishedInventorySnapshot(this.entries.get(params.key), snapshot);
-        this.entries.set(params.key, { ...published, invalidated: false });
+        const existingEntry = this.entries.get(params.key);
+        const published = resolvePublishedInventorySnapshot(existingEntry, snapshot);
+        const invalidated = resolveRemainingInvalidation(existingEntry, snapshot);
+        this.entries.set(params.key, {
+          ...published,
+          invalidated,
+          // An uncovered invalidation keeps its scope and diagnostic until a
+          // covering or complete refresh proves the entry current again.
+          ...(invalidated && existingEntry?.invalidatedAppIds
+            ? { invalidatedAppIds: existingEntry.invalidatedAppIds }
+            : {}),
+          ...(invalidated && existingEntry?.lastError
+            ? { lastError: existingEntry.lastError }
+            : {}),
+        });
         this.diagnostics.delete(params.key);
       }
       return snapshot;
@@ -296,6 +331,10 @@ function resolvePublishedInventorySnapshot(
   const { targetAppIds: snapshotTargetAppIds, ...snapshotBase } = snapshot;
   return {
     ...snapshotBase,
+    // Freshness belongs to the last complete fetch: a targeted merge must not
+    // renew rows it never re-read, or non-target rows would stay fresh forever.
+    fetchedAtMs: existing.fetchedAtMs,
+    expiresAtMs: existing.expiresAtMs,
     apps: mergeRefreshedRows(existing.apps, snapshot.apps, refreshedTargetIds),
     installedApps: mergeRefreshedRows(
       existing.installedApps,
@@ -331,6 +370,22 @@ function mergeRefreshedRows<Row extends { id: string }>(
     }),
     ...refreshedRows.filter((row) => !existingIds.has(row.id)),
   ];
+}
+
+/**
+ * A refresh only clears invalidation it can prove it re-read: complete
+ * refreshes always do; targeted ones only when they cover the invalidated
+ * scope. Unscoped invalidations require a complete refresh.
+ */
+function resolveRemainingInvalidation(
+  existing: CacheEntry | undefined,
+  snapshot: CodexAppInventorySnapshot,
+): boolean {
+  if (!existing?.invalidated || !snapshot.targetAppIds?.length) {
+    return false;
+  }
+  const refreshedTargetIds = new Set(snapshot.targetAppIds);
+  return !existing.invalidatedAppIds?.every((appId) => refreshedTargetIds.has(appId));
 }
 
 function doesInFlightRefreshCover(existing: InFlightRefresh, params: RefreshParams): boolean {
@@ -460,7 +515,7 @@ async function readInstalledApps(
 }
 
 function stripEntryState(entry: CacheEntry): CodexAppInventorySnapshot {
-  const { invalidated: _invalidated, ...snapshot } = entry;
+  const { invalidated: _invalidated, invalidatedAppIds: _invalidatedAppIds, ...snapshot } = entry;
   return snapshot;
 }
 

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -326,12 +326,19 @@ function resolvePublishedInventorySnapshot(
   }
   const refreshedTargetIds = new Set(snapshot.targetAppIds);
   const { targetAppIds: snapshotTargetAppIds, ...snapshotBase } = snapshot;
+  // Freshness belongs to the newest refresh that re-read every retained row: a
+  // merge keeps the existing timestamps while unrefreshed rows remain (they
+  // must not be renewed), but a targeted refresh covering the whole cached
+  // targeted scope adopts the new ones, or an expired targeted-only entry
+  // could never regain freshness from targeted refreshes.
+  const coversWholeCachedScope =
+    (existing.targetAppIds?.length ?? 0) > 0 &&
+    (existing.targetAppIds ?? []).every((appId) => refreshedTargetIds.has(appId));
   return {
     ...snapshotBase,
-    // Freshness belongs to the last complete fetch: a targeted merge must not
-    // renew rows it never re-read, or non-target rows would stay fresh forever.
-    fetchedAtMs: existing.fetchedAtMs,
-    expiresAtMs: existing.expiresAtMs,
+    ...(coversWholeCachedScope
+      ? {}
+      : { fetchedAtMs: existing.fetchedAtMs, expiresAtMs: existing.expiresAtMs }),
     apps: mergeRefreshedRows(existing.apps, snapshot.apps, refreshedTargetIds),
     installedApps: mergeRefreshedRows(
       existing.installedApps,

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -146,6 +146,11 @@ export class CodexAppInventoryCache {
   /** Marks a key stale and records the reason as a diagnostic. */
   invalidate(key: string, reason: string, nowMs = Date.now()): number {
     this.revision += 1;
+    // Invalidation outranks in-flight refreshes: retire their publish token so
+    // pre-invalidation reads cannot republish as fresh, and drop the shared
+    // in-flight slot so the next read starts a post-invalidation refresh.
+    this.refreshTokens.set(key, (this.refreshTokens.get(key) ?? 0) + 1);
+    this.inFlight.delete(key);
     const diagnostic = { message: reason, atMs: nowMs };
     const entry = this.entries.get(key);
     if (entry) {
@@ -247,7 +252,8 @@ export class CodexAppInventoryCache {
       // Only publish this snapshot if no newer refresh started for the same key
       // while this request was in flight.
       if (this.refreshTokens.get(params.key) === refreshToken) {
-        this.entries.set(params.key, { ...snapshot, invalidated: false });
+        const published = resolvePublishedInventorySnapshot(this.entries.get(params.key), snapshot);
+        this.entries.set(params.key, { ...published, invalidated: false });
         this.diagnostics.delete(params.key);
       }
       return snapshot;
@@ -269,6 +275,62 @@ export class CodexAppInventoryCache {
       throw error;
     }
   }
+}
+
+/**
+ * Publish policy for refreshed snapshots. A complete refresh replaces the
+ * entry, but a targeted refresh only rewrites its own target rows in place —
+ * replacing the whole entry with a narrow snapshot makes agents that share
+ * the runtime identity see each other's plugin apps vanish and force a hosted
+ * connector refresh per turn. The refreshed snapshot stays authoritative for
+ * its target set, so target rows it no longer returns are deleted.
+ */
+function resolvePublishedInventorySnapshot(
+  existing: CodexAppInventorySnapshot | undefined,
+  snapshot: CodexAppInventorySnapshot,
+): CodexAppInventorySnapshot {
+  if (!snapshot.targetAppIds?.length || !existing) {
+    return snapshot;
+  }
+  const refreshedTargetIds = new Set(snapshot.targetAppIds);
+  const { targetAppIds: snapshotTargetAppIds, ...snapshotBase } = snapshot;
+  return {
+    ...snapshotBase,
+    apps: mergeRefreshedRows(existing.apps, snapshot.apps, refreshedTargetIds),
+    installedApps: mergeRefreshedRows(
+      existing.installedApps,
+      snapshot.installedApps,
+      refreshedTargetIds,
+    ),
+    // A merge into a complete entry keeps the entry complete (no targetAppIds).
+    ...(existing.targetAppIds?.length
+      ? {
+          targetAppIds: Array.from(
+            new Set([...existing.targetAppIds, ...snapshotTargetAppIds]),
+          ).toSorted(),
+        }
+      : {}),
+  };
+}
+
+/** Replaces refreshed target rows in place, deletes vanished ones, appends new ones. */
+function mergeRefreshedRows<Row extends { id: string }>(
+  existingRows: readonly Row[],
+  refreshedRows: readonly Row[],
+  refreshedTargetIds: ReadonlySet<string>,
+): Row[] {
+  const refreshedById = new Map(refreshedRows.map((row) => [row.id, row]));
+  const existingIds = new Set(existingRows.map((row) => row.id));
+  return [
+    ...existingRows.flatMap((row) => {
+      if (!refreshedTargetIds.has(row.id)) {
+        return [row];
+      }
+      const refreshed = refreshedById.get(row.id);
+      return refreshed ? [refreshed] : [];
+    }),
+    ...refreshedRows.filter((row) => !existingIds.has(row.id)),
+  ];
 }
 
 function doesInFlightRefreshCover(existing: InFlightRefresh, params: RefreshParams): boolean {

--- a/extensions/codex/src/app-server/plugin-activation.ts
+++ b/extensions/codex/src/app-server/plugin-activation.ts
@@ -186,7 +186,14 @@ async function refreshCodexPluginRuntimeState(params: {
   await params.request("config/mcpServer/reload", undefined);
 
   if (params.appCache && params.appCacheKey) {
-    params.appCache.invalidate(params.appCacheKey, "Codex plugin activation changed app inventory");
+    // Scope the invalidation to the activated plugin's apps so the follow-up
+    // targeted refresh (immediate or deferred union) can revalidate the entry.
+    params.appCache.invalidate(
+      params.appCacheKey,
+      "Codex plugin activation changed app inventory",
+      undefined,
+      params.targetAppIds,
+    );
     if (params.deferAppInventoryRefresh) {
       return { diagnostics };
     }


### PR DESCRIPTION
## What Problem This Solves

Two latency/staleness defects in the Codex app inventory cache introduced with #115075 (neither affects admission or attestation, which remain fail-closed):

1. **Lost invalidation race.** `invalidate()` marked the entry stale but did not advance the per-key refresh token. A background non-forced refresh that started before the invalidation and finished after it passed the publish guard and republished pre-invalidation data as fresh, erasing the invalidation. Normally the forced post-install refresh supersedes it, but that refresh's failure is swallowed (`plugin-thread-app-admission.ts`), leaving the stale snapshot marked fresh for up to the 1-hour TTL.
2. **Targeted-snapshot clobbering.** A refresh with `targetAppIds` published a snapshot containing only the targeted apps as *the* entry for the shared runtime cache key. Two agents sharing one runtime identity with different plugin policies then ping-pong: each build sees the other's narrow snapshot, resolves its own proven-owned apps as missing, and triggers `shouldForceRefreshCodexNotReadyPluginApps` — a forced hosted connector-runtime refresh (30s upstream timeout) per turn, alternating indefinitely.

## Why This Change Was Made

- `invalidate()` now retires the in-flight publish token and drops the shared in-flight slot, so pre-invalidation refreshes cannot republish and the next read starts a post-invalidation refresh.
- Targeted refreshes now merge into the existing entry instead of replacing it: refreshed target rows are rewritten in place (authoritative for their target set, so vanished rows are deleted), untouched rows survive, and a merge into a complete entry keeps the entry complete. This preserves the intra-turn contract — the plugin-thread config build re-reads the cache right after its forced targeted refresh — while other agents' rows stop vanishing.

## User Impact

Multi-agent setups that share one Codex runtime identity (same account/auth profile) with different plugin configurations no longer trigger a redundant hosted connector refresh on alternating turns, and plugin installs whose follow-up refresh fails no longer pin a pre-install inventory as fresh for up to an hour. No behavior change for single-agent setups beyond fewer redundant refreshes.

## Evidence

- Regression tests: a pre-invalidation in-flight refresh is discarded instead of republished as fresh; a targeted refresh no longer clobbers the complete entry; targeted-over-targeted refreshes merge to the union instead of alternating narrow snapshots (`app-inventory-cache.test.ts`).
- Focused proof: `node scripts/run-vitest.mjs extensions/codex/src/app-server/app-inventory-cache.test.ts extensions/codex/src/app-server/plugin-thread-config.test.ts extensions/codex/src/app-server/plugin-inventory.test.ts extensions/codex/src/app-server/plugin-activation.test.ts extensions/codex/src/app-server/plugin-thread-attestation.test.ts` — 124 tests passed, including the existing union-refresh and post-install ordering assertions.

## Review-driven hardening (commits 2-4)

Codex autoreview (gpt-5.6-sol) iterated this to a precise publish contract; the final round is clean ("patch is correct"):

- `invalidate()` retires the in-flight publish token and drops the shared in-flight slot, and carries an app-id scope (plugin activation passes its target apps). Stacked scoped invalidations widen; an unscoped invalidation stays whole-inventory.
- A refresh retires exactly the invalidation scope it re-read: complete refreshes clear everything; targeted refreshes subtract their target ids, so separate covering refreshes accumulate until no scope remains; unscoped invalidations require a complete refresh.
- A targeted refresh merges into a still-valid entry (target rows rewritten in place, authoritative deletions, entry keeps the prior fetch's freshness so unrefreshed rows are never renewed) and replaces an expired entry outright, so freshness always recovers without a complete fetch and no stale/refresh loop can form.

Regression tests cover the pre-invalidation discard, no-clobber merge, union merge, non-renewal of unrefreshed rows, expired-entry replacement, stacked-scope retirement, and unscoped-until-complete behavior.
