### PR TITLE
docs(codex): replace stale app/list wording with app/installed

### DIFF
--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -66,7 +66,7 @@ Running `openclaw migrate <provider>` with no other flags plans, previews, and (
   Select one Codex plugin install item by plugin name or item id. Repeat the flag to migrate multiple Codex plugins. When omitted, interactive Codex migrations show a native Codex plugin checkbox selector and non-interactive migrations keep all planned plugins. Applies only to source-installed `openai-curated` Codex plugins discovered by the Codex app-server inventory.
 </ParamField>
 <ParamField path="--verify-plugin-apps" type="boolean">
-  Codex only. Forces a fresh source Codex app-server `app/list` traversal before planning native plugin activation. Off by default to keep migration planning fast.
+  Codex only. Forces a fresh source Codex app-server `app/installed` snapshot read before planning native plugin activation. Off by default to keep migration planning fast.
 </ParamField>
 <ParamField path="--backup-output <path>" type="string">
   Pre-migration backup archive path or directory. Passed through to `openclaw backup create`.
@@ -150,13 +150,13 @@ openclaw migrate apply codex --yes --plugin google-calendar
   recall. Raw rollout memory is not imported.
 - Codex CLI skill directories under `$CODEX_HOME/skills`, excluding Codex's `.system` cache.
 - Personal AgentSkills under `$HOME/.agents/skills`, copied into the current OpenClaw agent workspace for per-agent ownership.
-- Source-installed `openai-curated` Codex plugins discovered through Codex app-server `plugin/list`. Planning reads `plugin/read` for each enabled installed plugin.
+- Source-installed `openai-curated` Codex plugins discovered through Codex app-server `plugin/installed`. Planning reads `plugin/read` for each enabled installed plugin.
 
 App-backed plugin migration has extra gates:
 
 - App-backed plugins require the source Codex app-server account to be a ChatGPT subscription account. Non-ChatGPT or missing account responses are skipped with `codex_subscription_required`.
-- By default, migration does not call source `app/list`, so app-backed plugins that pass the account gate are planned without source app-accessibility verification, and account-lookup transport failures skip with `codex_account_unavailable`.
-- Pass `--verify-plugin-apps` to force a fresh source `app/list` snapshot and require every owned app to be present, enabled, and accessible before planning native activation. In that mode, account-lookup transport failures fall through to source app-inventory verification. The snapshot is kept in memory for the current process only; it is never written to migration output or target config.
+- By default, migration does not read the source app inventory, so app-backed plugins that pass the account gate are planned without source app-accessibility verification, and account-lookup transport failures skip with `codex_account_unavailable`.
+- Pass `--verify-plugin-apps` to force a fresh source `app/installed` snapshot (with authorized metadata from batched `app/read`) and require every owned app to be present, enabled, and accessible before planning native activation. In that mode, account-lookup transport failures fall through to source app-inventory verification. The snapshot is kept in memory for the current process only; it is never written to migration output or target config.
 
 Disabled plugins, unreadable plugin details, subscription-gated source accounts, and (when `--verify-plugin-apps` is set) missing, disabled, or inaccessible apps become manual skipped items with typed reasons instead of target config entries. Apply calls app-server `plugin/install` for each selected eligible plugin, even if the target app-server already reports that plugin as installed and enabled. Migrated Codex plugins are usable only in sessions that select the native Codex harness; they are not exposed to OpenClaw provider runs, ACP conversation bindings, or other harnesses.
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -366,7 +366,8 @@ are host-specific. See
 [Native Codex plugins](/plugins/codex-native-plugins) for app-server version and
 readiness requirements.
 
-`app/list` readiness checks are cached for one hour and refreshed
+`app/installed` readiness checks (with authorized metadata from batched
+`app/read`) are cached for one hour and refreshed
 asynchronously when stale. Codex thread app config is computed at Codex harness
 session establishment, not on every turn; use `/new`, `/reset`, or a gateway
 restart after changing native plugin config.
@@ -375,8 +376,8 @@ restart after changing native plugin config.
 app into each new native Codex thread. It does not install plugins or apps, and
 inaccessible apps stay excluded. Account apps use the global
 `codexPlugins.allow_destructive_actions` policy. Explicit plugin entries take
-precedence when the same app is present in both paths. If `app/list` cannot be
-read, account-wide exposure fails closed.
+precedence when the same app is present in both paths. If `app/installed`
+cannot be read, account-wide exposure fails closed.
 
 - `plugins.entries.firecrawl.config.webFetch`: Firecrawl web-fetch provider settings.
   - `apiKey`: Optional Firecrawl API key for higher limits (accepts SecretRef). Falls back to `plugins.entries.firecrawl.config.webSearch.apiKey` or `FIRECRAWL_API_KEY` env var.

--- a/src/cli/program/register.migrate.ts
+++ b/src/cli/program/register.migrate.ts
@@ -60,7 +60,7 @@ function addMigrationPluginOption(command: Command): Command {
 function addVerifyPluginAppsOption(command: Command): Command {
   return command.option(
     "--verify-plugin-apps",
-    "Codex only: verify source plugin app accessibility with app/list before planning native plugin activation",
+    "Codex only: verify source plugin app accessibility with app/installed before planning native plugin activation",
     false,
   );
 }


### PR DESCRIPTION
## What Problem This Solves

#115075 replaced Codex connected-app discovery (`app/list`) with `app/installed` plus batched `app/read`, but stale wording survived in surfaces that PR did not touch. The docs and the `--verify-plugin-apps` CLI help described a method the runtime no longer sends anywhere (only inert protocol type-map entries and the sandbox-guard allowlist still mention it).

## Why This Change Was Made

Docs must describe the current contract: authenticated connector runtime state comes from `app/installed`, canonical metadata from `app/read` (batched at most 100 IDs), matching the terminology already used in `docs/plugins/codex-native-plugins.md` and `docs/plugins/codex-harness.md`.

- `docs/cli/migrate.md`: `--verify-plugin-apps` now described as a fresh `app/installed` snapshot read; plugin discovery described via `plugin/installed` (not `plugin/list`, which is reserved for explicit installation discovery).
- `docs/gateway/configuration-reference.md`: readiness caching and the account-wide fail-closed rule now reference `app/installed`.
- `src/cli/program/register.migrate.ts`: `--verify-plugin-apps` help string updated.

## User Impact

Documentation and CLI help match shipped behavior; no runtime change.

## Evidence

- `rg -n "app/list" docs/ src/cli src/commands` returns no hits after the change.
- `git diff --check` clean; wording cross-checked against `extensions/codex/src/app-server/app-inventory-cache.ts` (`app/installed` + `CODEX_APP_READ_BATCH_LIMIT = 100`) and `extensions/codex/src/migration/source.ts` (`plugin/installed`).
