### PR TITLE
feat(gateway): expose MCP tool identity in effective tools

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -12350,6 +12350,9 @@ public struct ToolsEffectiveEntry: Codable, Sendable {
     public let source: AnyCodable
     public let pluginid: String?
     public let channelid: String?
+    public let mcpserver: String?
+    public let mcptoolname: String?
+    public let deniedbysession: Bool?
     public let risk: AnyCodable?
     public let tags: [String]?
 
@@ -12361,6 +12364,9 @@ public struct ToolsEffectiveEntry: Codable, Sendable {
         source: AnyCodable,
         pluginid: String? = nil,
         channelid: String? = nil,
+        mcpserver: String? = nil,
+        mcptoolname: String? = nil,
+        deniedbysession: Bool? = nil,
         risk: AnyCodable? = nil,
         tags: [String]? = nil)
     {
@@ -12371,6 +12377,9 @@ public struct ToolsEffectiveEntry: Codable, Sendable {
         self.source = source
         self.pluginid = pluginid
         self.channelid = channelid
+        self.mcpserver = mcpserver
+        self.mcptoolname = mcptoolname
+        self.deniedbysession = deniedbysession
         self.risk = risk
         self.tags = tags
     }
@@ -12383,6 +12392,9 @@ public struct ToolsEffectiveEntry: Codable, Sendable {
         case source
         case pluginid = "pluginId"
         case channelid = "channelId"
+        case mcpserver = "mcpServer"
+        case mcptoolname = "mcpToolName"
+        case deniedbysession = "deniedBySession"
         case risk
         case tags
     }

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -210,6 +210,46 @@ describe("ModelsProbe schemas", () => {
 });
 
 describe("ToolsEffectiveResultSchema", () => {
+  it("accepts MCP identity and a true session-denial marker", () => {
+    const result = {
+      ...toolsEffectiveResult(),
+      groups: [
+        ...toolsEffectiveResult().groups,
+        {
+          id: "mcp",
+          label: "MCP server tools",
+          source: "mcp",
+          tools: [
+            {
+              id: "notion__delete-page",
+              label: "Delete page",
+              description: "Delete a page",
+              rawDescription: "Delete a page",
+              source: "mcp",
+              mcpServer: "notion",
+              mcpToolName: "delete_page",
+              deniedBySession: true,
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(Value.Check(ToolsEffectiveResultSchema, result)).toBe(true);
+    expect(
+      Value.Check(ToolsEffectiveResultSchema, {
+        ...result,
+        groups: [
+          ...result.groups.slice(0, -1),
+          {
+            ...result.groups.at(-1),
+            tools: [{ ...result.groups.at(-1)?.tools[0], deniedBySession: false }],
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
   it("accepts runtime tool quarantine notices", () => {
     const result = {
       ...toolsEffectiveResult(),

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -1010,6 +1010,9 @@ export const ToolsEffectiveEntrySchema = closedObject({
   ]),
   pluginId: Type.Optional(NonEmptyString),
   channelId: Type.Optional(NonEmptyString),
+  mcpServer: Type.Optional(NonEmptyString),
+  mcpToolName: Type.Optional(NonEmptyString),
+  deniedBySession: Type.Optional(Type.Literal(true)),
   risk: Type.Optional(
     Type.Union([Type.Literal("low"), Type.Literal("medium"), Type.Literal("high")]),
   ),

--- a/src/agents/agent-bundle-mcp-combined.ts
+++ b/src/agents/agent-bundle-mcp-combined.ts
@@ -27,6 +27,7 @@ export function isCombinedSessionMcpRuntime(
 export function mergeMcpToolCatalogs(catalogs: readonly McpToolCatalog[]): McpToolCatalog {
   const servers: Record<string, McpServerCatalog> = {};
   const tools: McpCatalogTool[] = [];
+  const sessionDeniedTools: McpCatalogTool[] = [];
   const diagnostics: McpToolCatalogDiagnostic[] = [];
 
   for (const catalog of catalogs) {
@@ -36,6 +37,9 @@ export function mergeMcpToolCatalogs(catalogs: readonly McpToolCatalog[]): McpTo
       servers[serverName] = server;
     }
     tools.push(...catalog.tools);
+    if (catalog.sessionDeniedTools) {
+      sessionDeniedTools.push(...catalog.sessionDeniedTools);
+    }
     if (catalog.diagnostics) {
       diagnostics.push(...catalog.diagnostics);
     }
@@ -51,11 +55,20 @@ export function mergeMcpToolCatalogs(catalogs: readonly McpToolCatalog[]): McpTo
     }
     return a.serverName.localeCompare(b.serverName);
   });
+  sessionDeniedTools.sort((a, b) => {
+    const serverOrder = a.safeServerName.localeCompare(b.safeServerName);
+    return (
+      serverOrder ||
+      a.toolName.localeCompare(b.toolName) ||
+      a.serverName.localeCompare(b.serverName)
+    );
+  });
   return {
     version: 1,
     generatedAt: Math.max(0, ...catalogs.map((catalog) => catalog.generatedAt)),
     servers,
     tools,
+    ...(sessionDeniedTools.length > 0 ? { sessionDeniedTools } : {}),
     ...(diagnostics.length > 0 ? { diagnostics } : {}),
   };
 }

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -194,8 +194,9 @@ function optionalStringRecordArg(input: unknown, key: string): Record<string, st
 function serverAllowsUtilityTool(
   server: McpToolCatalog["servers"][string],
   operation: string,
+  sessionDeniedOnly: boolean,
 ): boolean {
-  if (server.deniedToolNames?.includes(operation)) {
+  if ((server.deniedToolNames?.includes(operation) === true) !== sessionDeniedOnly) {
     return false;
   }
   const include = server.toolFilter?.include ?? [];
@@ -219,6 +220,7 @@ function addMcpUtilityTool(params: {
   label: string;
   description: string;
   parameters: Record<string, unknown>;
+  deniedBySession?: true;
   execute?: AnyAgentTool["execute"];
 }) {
   const name = buildSafeToolName({
@@ -247,6 +249,7 @@ function addMcpUtilityTool(params: {
       safeServerName: params.safeServerName,
       toolName: params.operation,
       operation: params.operation,
+      ...(params.deniedBySession ? { deniedBySession: true } : {}),
     },
   });
   params.tools.push(agentTool);
@@ -264,10 +267,26 @@ export function buildBundleMcpToolsFromCatalog(params: {
   createResourceReadExecute?: (serverName: string) => AnyAgentTool["execute"];
   createPromptListExecute?: (serverName: string) => AnyAgentTool["execute"];
   createPromptGetExecute?: (serverName: string) => AnyAgentTool["execute"];
+  includeSessionDenied?: boolean;
 }): AnyAgentTool[] {
-  const reservedNames = normalizeReservedToolNames(params.reservedToolNames);
-  const tools: AnyAgentTool[] = [];
-  const sortedCatalogTools = [...params.catalog.tools].toSorted((a, b) => {
+  const initialReservedNames = normalizeReservedToolNames(params.reservedToolNames);
+  const sessionDeniedOnly = params.includeSessionDenied === true;
+  // Preserve executable IDs by allocating them before denied-only inventory rows.
+  const tools = sessionDeniedOnly
+    ? buildBundleMcpToolsFromCatalog({
+        ...params,
+        reservedToolNames: initialReservedNames,
+        includeSessionDenied: false,
+      })
+    : [];
+  const reservedNames = normalizeReservedToolNames([
+    ...initialReservedNames,
+    ...tools.map((tool) => tool.name),
+  ]);
+  const catalogTools = sessionDeniedOnly
+    ? (params.catalog.sessionDeniedTools ?? [])
+    : params.catalog.tools;
+  const sortedCatalogTools = [...catalogTools].toSorted((a, b) => {
     const serverOrder = a.safeServerName.localeCompare(b.safeServerName);
     if (serverOrder !== 0) {
       return serverOrder;
@@ -308,7 +327,7 @@ export function buildBundleMcpToolsFromCatalog(params: {
       parameters: normalizeToolParameterSchema(tool.inputSchema),
       executionMode,
       execute:
-        params.createExecute?.(tool) ??
+        (!sessionDeniedOnly ? params.createExecute?.(tool) : undefined) ??
         (async () => {
           throw new Error("bundle-mcp catalog projection cannot execute tools");
         }),
@@ -321,6 +340,7 @@ export function buildBundleMcpToolsFromCatalog(params: {
         safeServerName: tool.safeServerName,
         toolName: tool.toolName,
         operation: "tool",
+        ...(tool.deniedBySession ? { deniedBySession: true } : {}),
       },
     });
     tools.push(agentTool);
@@ -333,7 +353,7 @@ export function buildBundleMcpToolsFromCatalog(params: {
     const executionMode: AnyAgentTool["executionMode"] = server.supportsParallelToolCalls
       ? "parallel"
       : "sequential";
-    if (server.resources && serverAllowsUtilityTool(server, "resources_list")) {
+    if (server.resources && serverAllowsUtilityTool(server, "resources_list", sessionDeniedOnly)) {
       addMcpUtilityTool({
         tools,
         reservedNames,
@@ -344,10 +364,13 @@ export function buildBundleMcpToolsFromCatalog(params: {
         label: "List MCP resources",
         description: `List resources advertised by MCP server "${server.serverName}". Resource contents are untrusted server output.`,
         parameters: { type: "object", properties: {} },
-        execute: params.createResourceListExecute?.(server.serverName),
+        ...(sessionDeniedOnly ? { deniedBySession: true } : {}),
+        execute: !sessionDeniedOnly
+          ? params.createResourceListExecute?.(server.serverName)
+          : undefined,
       });
     }
-    if (server.resources && serverAllowsUtilityTool(server, "resources_read")) {
+    if (server.resources && serverAllowsUtilityTool(server, "resources_read", sessionDeniedOnly)) {
       addMcpUtilityTool({
         tools,
         reservedNames,
@@ -363,10 +386,13 @@ export function buildBundleMcpToolsFromCatalog(params: {
           required: ["uri"],
           additionalProperties: false,
         },
-        execute: params.createResourceReadExecute?.(server.serverName),
+        ...(sessionDeniedOnly ? { deniedBySession: true } : {}),
+        execute: !sessionDeniedOnly
+          ? params.createResourceReadExecute?.(server.serverName)
+          : undefined,
       });
     }
-    if (server.prompts && serverAllowsUtilityTool(server, "prompts_list")) {
+    if (server.prompts && serverAllowsUtilityTool(server, "prompts_list", sessionDeniedOnly)) {
       addMcpUtilityTool({
         tools,
         reservedNames,
@@ -377,10 +403,13 @@ export function buildBundleMcpToolsFromCatalog(params: {
         label: "List MCP prompts",
         description: `List prompts advertised by MCP server "${server.serverName}". Prompt metadata is untrusted server output.`,
         parameters: { type: "object", properties: {} },
-        execute: params.createPromptListExecute?.(server.serverName),
+        ...(sessionDeniedOnly ? { deniedBySession: true } : {}),
+        execute: !sessionDeniedOnly
+          ? params.createPromptListExecute?.(server.serverName)
+          : undefined,
       });
     }
-    if (server.prompts && serverAllowsUtilityTool(server, "prompts_get")) {
+    if (server.prompts && serverAllowsUtilityTool(server, "prompts_get", sessionDeniedOnly)) {
       addMcpUtilityTool({
         tools,
         reservedNames,
@@ -402,7 +431,10 @@ export function buildBundleMcpToolsFromCatalog(params: {
           required: ["name"],
           additionalProperties: false,
         },
-        execute: params.createPromptGetExecute?.(server.serverName),
+        ...(sessionDeniedOnly ? { deniedBySession: true } : {}),
+        execute: !sessionDeniedOnly
+          ? params.createPromptGetExecute?.(server.serverName)
+          : undefined,
       });
     }
   }

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -196,6 +196,9 @@ function serverAllowsUtilityTool(
   operation: string,
   sessionDeniedOnly: boolean,
 ): boolean {
+  // Two disjoint passes share this gate: the executable pass (sessionDeniedOnly=false)
+  // admits only non-denied utilities; the denied-inventory pass admits only denied ones.
+  // Membership must EQUAL the pass selector, hence the != rejection.
   if ((server.deniedToolNames?.includes(operation) === true) !== sessionDeniedOnly) {
     return false;
   }

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1330,6 +1330,13 @@ describe("session MCP runtime", () => {
     });
 
     try {
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools.map((tool) => tool.toolName)).toEqual(["search_docs"]);
+      expect(catalog.sessionDeniedTools).toMatchObject([
+        { serverName: "docs", toolName: "read_docs", deniedBySession: true },
+      ]);
+      expect(catalog.servers.docs?.toolCount).toBe(1);
+
       const materialized = await materializeBundleMcpToolsForRun({ runtime });
       expect(materialized.tools.map((tool) => tool.name)).toEqual([
         "docs__resources_list",

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -658,6 +658,9 @@ export function createSessionMcpRuntime(params: {
       const tools: McpCatalogTool[] = (retryBaseCatalog?.tools ?? []).filter(
         (tool) => !retryServerNames?.has(tool.serverName),
       );
+      const sessionDeniedTools: McpCatalogTool[] = (
+        retryBaseCatalog?.sessionDeniedTools ?? []
+      ).filter((tool) => !retryServerNames?.has(tool.serverName));
       const diagnostics: McpToolCatalogDiagnostic[] = [];
       // Prefer session-wide precomputed assignments; fall back only for isolated runtimes.
       const safeServerNamesByServer =
@@ -832,9 +835,12 @@ export function createSessionMcpRuntime(params: {
                 const deniedToolNames = new Set(
                   denialMap && Object.hasOwn(denialMap, serverName) ? denialMap[serverName] : [],
                 );
-                const exposedTools = listedTools.filter((tool) => {
+                const policyEligibleTools = listedTools.filter((tool) =>
+                  shouldExposeMcpTool(selection, tool.name.trim()),
+                );
+                const exposedTools = policyEligibleTools.filter((tool) => {
                   const toolName = tool.name.trim();
-                  return !deniedToolNames.has(toolName) && shouldExposeMcpTool(selection, toolName);
+                  return !deniedToolNames.has(toolName);
                 });
                 const serverEntry: McpServerCatalog = {
                   serverName,
@@ -868,7 +874,7 @@ export function createSessionMcpRuntime(params: {
                     : {}),
                 };
                 const toolEntries: McpCatalogTool[] = [];
-                for (const tool of exposedTools) {
+                for (const tool of policyEligibleTools) {
                   const toolName = tool.name.trim();
                   if (!toolName) {
                     continue;
@@ -894,6 +900,7 @@ export function createSessionMcpRuntime(params: {
                     fallbackDescription: `Provided by bundle MCP server "${serverName}" (${launchDescription}).`,
                     ...(uiResourceUri ? { uiResourceUri } : {}),
                     ...(uiVisibility ? { uiVisibility } : {}),
+                    ...(deniedToolNames.has(toolName) ? { deniedBySession: true } : {}),
                   });
                 }
                 return {
@@ -961,7 +968,13 @@ export function createSessionMcpRuntime(params: {
           if (serverEntry) {
             servers[result.serverName] = serverEntry;
           }
-          tools.push(...toolEntries);
+          for (const tool of toolEntries) {
+            if (tool.deniedBySession) {
+              sessionDeniedTools.push(tool);
+            } else {
+              tools.push(tool);
+            }
+          }
           diagnostics.push(...serverDiags);
         }
 
@@ -971,6 +984,7 @@ export function createSessionMcpRuntime(params: {
           generatedAt: Date.now(),
           servers,
           tools,
+          ...(sessionDeniedTools.length > 0 ? { sessionDeniedTools } : {}),
           ...(diagnostics.length > 0 ? { diagnostics } : {}),
         };
       } catch (error) {

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -602,6 +602,68 @@ describe("createBundleMcpToolRuntime", () => {
     ).rejects.toThrow("bundle-mcp catalog projection cannot execute tools");
   });
 
+  it("projects session-denied tools only for read-only inventory", () => {
+    const catalog = {
+      version: 1,
+      generatedAt: 0,
+      servers: {
+        knowledge: {
+          serverName: "knowledge",
+          safeServerName: "knowledge",
+          launchSummary: "knowledge",
+          toolCount: 0,
+          resources: { listChanged: false },
+          deniedToolNames: ["resources_read"],
+        },
+      },
+      tools: [
+        {
+          serverName: "knowledge",
+          safeServerName: "knowledge",
+          toolName: "alpha?",
+          inputSchema: { type: "object", properties: {} },
+          fallbackDescription: "Enabled knowledge tool",
+        },
+      ],
+      sessionDeniedTools: [
+        {
+          serverName: "knowledge",
+          safeServerName: "knowledge",
+          toolName: "alpha!",
+          inputSchema: { type: "object", properties: {} },
+          fallbackDescription: "Denied knowledge tool",
+          deniedBySession: true,
+        },
+      ],
+    } satisfies Parameters<typeof buildBundleMcpToolsFromCatalog>[0]["catalog"];
+
+    expect(buildBundleMcpToolsFromCatalog({ catalog }).map((tool) => tool.name)).toEqual([
+      "knowledge__alpha-",
+      "knowledge__resources_list",
+    ]);
+    const inventoryTools = buildBundleMcpToolsFromCatalog({
+      catalog,
+      includeSessionDenied: true,
+    });
+    expect(inventoryTools.map((tool) => tool.name)).toEqual([
+      "knowledge__alpha-",
+      "knowledge__alpha--2",
+      "knowledge__resources_list",
+      "knowledge__resources_read",
+    ]);
+    expect(
+      inventoryTools.map((tool) => ({
+        name: tool.name,
+        deniedBySession: getPluginToolMeta(tool)?.mcp?.deniedBySession,
+      })),
+    ).toEqual([
+      { name: "knowledge__alpha-", deniedBySession: undefined },
+      { name: "knowledge__alpha--2", deniedBySession: true },
+      { name: "knowledge__resources_list", deniedBySession: undefined },
+      { name: "knowledge__resources_read", deniedBySession: true },
+    ]);
+  });
+
   it("materializes configured MCP tools through the session runtime boundary", async () => {
     const created: Parameters<
       NonNullable<Parameters<typeof createBundleMcpToolRuntime>[0]["createRuntime"]>

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -56,6 +56,7 @@ export type McpCatalogTool = {
   fallbackDescription: string;
   uiResourceUri?: string;
   uiVisibility?: Array<"app" | "model">;
+  deniedBySession?: true;
 };
 
 /** Complete tool catalog for a session-scoped MCP runtime. */
@@ -64,6 +65,8 @@ export type McpToolCatalog = {
   generatedAt: number;
   servers: Record<string, McpServerCatalog>;
   tools: McpCatalogTool[];
+  /** Listed tools hidden only by the session override, retained for read-only inventory. */
+  sessionDeniedTools?: McpCatalogTool[];
   diagnostics?: readonly McpToolCatalogDiagnostic[];
 };
 

--- a/src/agents/tools-effective-inventory.types.ts
+++ b/src/agents/tools-effective-inventory.types.ts
@@ -18,6 +18,9 @@ export type EffectiveToolInventoryEntry = {
   source: EffectiveToolSource;
   pluginId?: string;
   channelId?: string;
+  mcpServer?: string;
+  mcpToolName?: string;
+  deniedBySession?: true;
   risk?: "low" | "medium" | "high";
   tags?: string[];
 };

--- a/src/agents/tools-effective-mcp-inventory.ts
+++ b/src/agents/tools-effective-mcp-inventory.ts
@@ -5,6 +5,7 @@
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import { getPluginToolMeta } from "../plugins/tools.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import {
   filterProviderNormalizableTools,
@@ -42,18 +43,25 @@ function buildMcpToolInventoryEntries(
 ): EffectiveToolInventoryEntry[] {
   return disambiguateEffectiveToolLabels(
     tools
-      .map(
-        (tool) =>
-          ({
-            id: tool.name,
-            label: resolveEffectiveToolLabel(tool),
-            description: summarizeEffectiveToolDescription(tool),
-            rawDescription:
-              resolveEffectiveToolRawDescription(tool) || summarizeEffectiveToolDescription(tool),
-            source: "mcp",
-            pluginId: BUNDLE_MCP_PLUGIN_ID,
-          }) satisfies EffectiveToolInventoryEntry,
-      )
+      .map((tool) => {
+        const mcp = getPluginToolMeta(tool)?.mcp;
+        return {
+          id: tool.name,
+          label: resolveEffectiveToolLabel(tool),
+          description: summarizeEffectiveToolDescription(tool),
+          rawDescription:
+            resolveEffectiveToolRawDescription(tool) || summarizeEffectiveToolDescription(tool),
+          source: "mcp",
+          pluginId: BUNDLE_MCP_PLUGIN_ID,
+          ...(mcp
+            ? {
+                mcpServer: mcp.serverName,
+                mcpToolName: mcp.toolName,
+                ...(mcp.deniedBySession ? { deniedBySession: true } : {}),
+              }
+            : {}),
+        } satisfies EffectiveToolInventoryEntry;
+      })
       .toSorted((a, b) => a.label.localeCompare(b.label)),
     (entry) => entry.pluginId ?? entry.id,
   );

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { McpToolCatalog, SessionMcpRuntime } from "../../agents/agent-bundle-mcp-types.js";
+import { setPluginToolMeta } from "../../plugins/tools.js";
 import { testing, toolsEffectiveHandlers } from "./tools-effective.js";
 
 const runtimeMocks = vi.hoisted(() => ({
@@ -96,6 +97,9 @@ type ToolsEffectivePayload = {
       rawDescription?: string;
       source?: string;
       pluginId?: string;
+      mcpServer?: string;
+      mcpToolName?: string;
+      deniedBySession?: true;
     }>;
   }>;
 };
@@ -131,13 +135,24 @@ function firstRespondCall(respond: ReturnType<typeof vi.fn>): RespondCall | unde
 }
 
 function makeMcpTool(params: Record<string, unknown> = { type: "object", properties: {} }) {
-  return {
+  const tool = {
     name: "reproProbe__probe_tool",
     label: "Probe Tool",
     description: "Probe from MCP",
     parameters: params,
     execute: vi.fn(),
   };
+  setPluginToolMeta(tool, {
+    pluginId: "bundle-mcp",
+    optional: false,
+    mcp: {
+      serverName: "reproProbe",
+      safeServerName: "reproProbe",
+      toolName: "probe_tool",
+      operation: "tool",
+    },
+  });
+  return tool;
 }
 
 function makeCoreInventory(
@@ -498,13 +513,75 @@ describe("tools.effective handler", () => {
           rawDescription: "Probe from MCP",
           source: "mcp",
           pluginId: "bundle-mcp",
+          mcpServer: "reproProbe",
+          mcpToolName: "probe_tool",
         },
       ],
     });
     expect(runtimeMocks.buildBundleMcpToolsFromCatalog).toHaveBeenCalledWith({
       catalog,
       reservedToolNames: ["exec"],
+      includeSessionDenied: true,
     });
+  });
+
+  it("preserves raw MCP identities and session denials across sanitized collisions", async () => {
+    const enabled = makeMcpTool();
+    enabled.name = "collision__alpha-";
+    enabled.label = "Alpha bang";
+    setPluginToolMeta(enabled, {
+      pluginId: "bundle-mcp",
+      optional: false,
+      mcp: {
+        serverName: "collision",
+        safeServerName: "collision",
+        toolName: "alpha!",
+        operation: "tool",
+      },
+    });
+    const denied = makeMcpTool();
+    denied.name = "collision__alpha--2";
+    denied.label = "Alpha question";
+    setPluginToolMeta(denied, {
+      pluginId: "bundle-mcp",
+      optional: false,
+      mcp: {
+        serverName: "collision",
+        safeServerName: "collision",
+        toolName: "alpha?",
+        operation: "tool",
+        deniedBySession: true,
+      },
+    });
+    const catalog = makeMcpCatalog();
+    mockMcpConfigSummary({ serverNames: ["collision"] });
+    mockWarmMcpRuntime(catalog);
+    runtimeMocks.buildBundleMcpToolsFromCatalog.mockReturnValueOnce([enabled, denied]);
+
+    const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
+    await invoke();
+
+    const payload = firstRespondCall(respond)?.[1] as ToolsEffectivePayload | undefined;
+    expect(payload?.groups?.[0]?.tools?.[0]).toEqual({
+      id: "exec",
+      label: "Exec",
+      description: "Run shell commands",
+      rawDescription: "Run shell commands",
+      source: "core",
+    });
+    expect(payload?.groups?.[1]?.tools).toEqual([
+      expect.objectContaining({
+        id: "collision__alpha-",
+        mcpServer: "collision",
+        mcpToolName: "alpha!",
+      }),
+      expect.objectContaining({
+        id: "collision__alpha--2",
+        mcpServer: "collision",
+        mcpToolName: "alpha?",
+        deniedBySession: true,
+      }),
+    ]);
   });
 
   it("uses the warm runtime workspace when comparing sandboxed MCP catalogs", async () => {

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -437,6 +437,7 @@ async function resolveReadOnlyToolsEffectiveInventory(
   const projectedMcpTools = buildBundleMcpToolsFromCatalog({
     catalog,
     reservedToolNames: base.groups.flatMap((group) => group.tools.map((tool) => tool.id)),
+    includeSessionDenied: true,
   });
   const filteredMcpTools = filterMcpTools({ context, mcpTools: projectedMcpTools });
   const agentDir = resolveAgentDir(context.cfg, context.agentId);

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -52,6 +52,7 @@ export type PluginToolMcpMeta = {
   safeServerName: string;
   toolName: string;
   operation: "tool" | "resources_list" | "resources_read" | "prompts_list" | "prompts_get";
+  deniedBySession?: true;
   node?: {
     id: string;
     displayName?: string;


### PR DESCRIPTION
Related: #115785
Related: #115800

## What Problem This Solves

The Control UI cannot build a reliable per-connector Tool access view from `tools.effective`: MCP rows expose only lossy, collision-resolved IDs, while tools denied through the session-level `mcpToolsDeny` override disappear from the catalog entirely.

## Why This Change Was Made

This adds the original MCP server and raw tool names to MCP-sourced effective-tool rows and keeps session-denied MCP tools in the read-only catalog with `deniedBySession: true`. The projection reuses the prepared MCP runtime catalog, preserves executable tool IDs when sanitized names collide, and continues to omit tools excluded by server filters or agent policy. The protocol change is additive with no version bump, and there are no UI or config changes.

## User Impact

The Control UI can now group MCP tools by connector and accurately render session-level on/off state using the same raw names accepted by `mcpToolsDeny`. Existing consumers and non-MCP rows are unchanged.

## Evidence

- `node scripts/run-vitest.mjs packages/gateway-protocol/src/schema/agents-models-skills.test.ts src/agents/agent-bundle-mcp-runtime.test.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts src/gateway/server-methods/tools-effective.test.ts` (4 shards, 158 tests passed)
- `pnpm protocol:check`
- `node scripts/check-changed.mjs` delegated to Blacksmith Testbox and passed (run 30446351385)
- Codex autoreview accepted and fixed one collision-order finding; the final review reported no actionable findings
