### PR TITLE
fix(agents): classify xAI run-out-of-credits and needs-subscription as billing (#115853)

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -975,6 +975,14 @@ function classifyFailoverClassificationFromMessage(
   if (isGenericProviderInternalError(raw)) {
     return toReasonClassification("timeout");
   }
+  // Provider-specific billing patterns must classify before generic 403
+  // auth catch so fallback routes to an available provider for credit /
+  // subscription exhaustion. Placed after rate-limit checks (including the
+  // leading-429 guard) so a matching xAI 429 still records rate_limit
+  // rather than billing (#115853).
+  if (classifyProviderSpecificError({ errorMessage: raw, provider }) === "billing") {
+    return toReasonClassification("billing");
+  }
   // Auth classifiers run before the broad isJsonApiInternalServerError check so that
   // provider errors like {"type":"api_error","message":"invalid api key"} are
   // correctly classified as "auth" rather than "timeout".

--- a/src/agents/embedded-agent-helpers/provider-error-patterns.test.ts
+++ b/src/agents/embedded-agent-helpers/provider-error-patterns.test.ts
@@ -105,6 +105,51 @@ describe("classifyProviderSpecificError", () => {
     );
   });
 
+  it("classifies xAI credit exhaustion as billing (#115853)", () => {
+    expect(
+      classifyProviderSpecificError({
+        errorMessage: "You have run out of credits. Please purchase more to continue.",
+        provider: "xai",
+      }),
+    ).toBe("billing");
+  });
+
+  it("classifies xAI subscription requirement as billing (#115853)", () => {
+    expect(
+      classifyProviderSpecificError({
+        errorMessage: "You need a valid subscription to access this model.",
+        provider: "xai",
+      }),
+    ).toBe("billing");
+  });
+
+  it("does NOT classify non-xAI 'run out of credits' as billing via provider patterns (#115853)", () => {
+    expect(
+      classifyProviderSpecificError({
+        errorMessage: "You have run out of credits. Please purchase more to continue.",
+        provider: "openai",
+      }),
+    ).toBeNull();
+  });
+
+  it("does NOT classify non-xAI 'need a subscription' as billing via provider patterns (#115853)", () => {
+    expect(
+      classifyProviderSpecificError({
+        errorMessage: "You need a valid subscription to access this model.",
+        provider: "anthropic",
+      }),
+    ).toBeNull();
+  });
+
+  it("classifies xAI run out of credits regardless of case (#115853)", () => {
+    expect(
+      classifyProviderSpecificError({
+        errorMessage: "Your team has RUN OUT OF CREDITS for this month.",
+        provider: "xai",
+      }),
+    ).toBe("billing");
+  });
+
   it("does not match generic 'model is not ready' without Bedrock prefix", () => {
     expect(classifyProviderSpecificError("model is not ready")).toBeNull();
   });
@@ -170,6 +215,75 @@ describe("classifyFailoverReason with provider patterns", () => {
         { provider: "xai" },
       ),
     ).toBe("billing");
+  });
+
+  it("classifies xAI run out of credits as billing in the full pipeline (#115853)", () => {
+    expect(
+      classifyFailoverReason("You have run out of credits. Please purchase more to continue.", {
+        provider: "xai",
+      }),
+    ).toBe("billing");
+  });
+
+  it("classifies xAI needs subscription as billing in the full pipeline (#115853)", () => {
+    expect(
+      classifyFailoverReason("You need a valid subscription to access this model.", {
+        provider: "xai",
+      }),
+    ).toBe("billing");
+  });
+
+  it("classifies xAI 403 run-out-of-credits as billing NOT auth (#115853)", () => {
+    // The real xAI response includes HTTP 403. /\b403\b/ in the auth patterns
+    // must not win over the xAI-scoped billing pattern.
+    expect(
+      classifyFailoverReason("403 You have run out of credits. Please purchase more to continue.", {
+        provider: "xai",
+      }),
+    ).toBe("billing");
+  });
+
+  it("classifies xAI 403 needs-subscription as billing NOT auth (#115853)", () => {
+    expect(
+      classifyFailoverReason("403 You need a Grok subscription to access this model.", {
+        provider: "xai",
+      }),
+    ).toBe("billing");
+  });
+
+  it("xAI 429 with billing text remains rate_limit NOT billing (#115853)", () => {
+    // Leading 429 must win over the provider-specific billing patterns so
+    // the existing rate-limit cooldown behaviour is preserved. The generic
+    // billing branch already excludes leading 429; the provider-specific
+    // branch is placed after the rate-limit classifiers for the same reason.
+    expect(
+      classifyFailoverReason("429 You have run out of credits. Please purchase more to continue.", {
+        provider: "xai",
+      }),
+    ).toBe("rate_limit");
+  });
+
+  it("does NOT classify non-xAI run out of credits as billing (#115853)", () => {
+    expect(
+      classifyFailoverReason("You have run out of credits. Please purchase more to continue.", {
+        provider: "openai",
+      }),
+    ).toBeNull();
+  });
+
+  it("non-xAI 403 with no billing text remains auth (#115853)", () => {
+    // Non-xAI 403 messages continue through the normal auth path.
+    expect(classifyFailoverReason("403 Forbidden: Access denied.", { provider: "openai" })).toBe(
+      "auth",
+    );
+  });
+
+  it("does NOT classify non-xAI needs subscription as billing (#115853)", () => {
+    expect(
+      classifyFailoverReason("You need a valid subscription to access this model.", {
+        provider: "anthropic",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/src/agents/embedded-agent-helpers/provider-error-patterns.ts
+++ b/src/agents/embedded-agent-helpers/provider-error-patterns.ts
@@ -6,6 +6,7 @@
  * yet ship a dedicated provider plugin hook surface.
  */
 
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { resolveNodeRequireFromMeta } from "../../logging/node-require.js";
 import type { FailoverReason } from "./types.js";
 
@@ -14,6 +15,10 @@ type ProviderErrorPattern = {
   test: RegExp;
   /** The failover reason this pattern maps to. */
   reason: FailoverReason;
+  /** Optional list of provider ids to scope the pattern to.
+   *  When set, the pattern only matches for providers whose id includes one of these strings.
+   *  When omitted, the pattern matches for all providers. */
+  providers?: readonly string[];
 };
 
 /**
@@ -72,6 +77,20 @@ const PROVIDER_SPECIFIC_PATTERNS: readonly ProviderErrorPattern[] = [
   {
     test: /model(?:_is)?_deactivated|model has been deactivated/i,
     reason: "model_not_found",
+  },
+  // xAI credit/subscription exhaustion variants (#115853).
+  // Scoped to xAI so the same text from other providers does not get the
+  // xAI override — the shared billing matcher has different semantics for
+  // those providers.
+  {
+    test: /\brun\s+out\s+of\s+credits\b/i,
+    reason: "billing",
+    providers: ["xai"],
+  },
+  {
+    test: /\bneed\s+a\s+\w+\s+subscription\b/i,
+    reason: "billing",
+    providers: ["xai"],
   },
 ];
 
@@ -171,6 +190,17 @@ export function classifyProviderPluginError(
   );
 }
 
+function matchesPatternForProvider(pattern: ProviderErrorPattern, provider?: string): boolean {
+  if (!pattern.providers || pattern.providers.length === 0) {
+    return true;
+  }
+  const normalized = normalizeOptionalLowercaseString(provider);
+  if (!normalized) {
+    return false;
+  }
+  return pattern.providers.some((p) => normalized.includes(p));
+}
+
 /**
  * Try to classify an error using provider-specific patterns.
  * Returns null if no provider-specific pattern matches (fall through to generic classification).
@@ -187,7 +217,10 @@ export function classifyProviderSpecificError(
     }
   }
   for (const pattern of PROVIDER_SPECIFIC_PATTERNS) {
-    if (pattern.test.test(context.errorMessage)) {
+    if (
+      matchesPatternForProvider(pattern, context.provider) &&
+      pattern.test.test(context.errorMessage)
+    ) {
       return pattern.reason;
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes https://github.com/openclaw/openclaw/issues/115853

When the xAI provider returns an HTTP 403 whose message says the account has
exhausted its credits ("You have run out of credits") or needs a subscription
("You need a Grok subscription"), OpenClaw classifies the failure as `auth`
instead of `billing`. This means the xAI profile only receives the normal auth
cooldown instead of the billing disabled window, so subsequent requests can call
xAI again and repeat the same failing transport before falling back.

## Evidence

### End-to-end runtime proof: full failover pipeline with simulated xAI API errors

A standalone TypeScript script imports the **exact same production modules**
used by the embedded-agent runner, CLI runner, auth-controller, and
model-fallback-runner at runtime. It exercises the complete failover pipeline
with simulated xAI API error responses — no test doubles, no mocked modules.

**Terminal output** (25/25 checks passed, run at commit `b15037e`):

```
$ node --import tsx _proof-xai-billing.ts
```

_(see `_proof-xai-billing.ts` in the branch for the full verification script)_

**Step-by-step results:**

| # | Test | Expected | Actual |
|---|------|----------|--------|
| 1 | xAI 403 credit exhaustion → classifyFailoverReason | `billing` | `billing` ✓ |
| 2 | xAI 403 subscription required → classifyFailoverReason | `billing` | `billing` ✓ |
| 3 | xAI 429 credit exhaustion → classifyFailoverReason | `rate_limit` | `rate_limit` ✓ |
| 4 | OpenAI 403 → classifyFailoverReason | `auth` | `auth` ✓ |
| 5 | OpenAI credit text → classifyFailoverReason | `null` | `null` ✓ |
| 6 | Anthropic subscription text → classifyFailoverReason | `null` | `null` ✓ |
| 7 | xAI credit text (no HTTP) → classifyFailoverReason | `billing` | `billing` ✓ |
| 8 | `resolveFailoverStatus("billing")` | `402` | `402` ✓ |
| 9 | `resolveFailoverStatus("auth")` | `401` | `401` ✓ |
| 10 | billing vs auth status differs | `true` | `true` ✓ |
| 11 | `coerceToFailoverError` returns `FailoverError` | `true` | `true` ✓ |
| 12 | `FailoverError.reason` | `billing` | `billing` ✓ |
| 13 | `FailoverError.status` | `402` | `402` ✓ |
| 14 | `FailoverError.provider` | `xai` | `xai` ✓ |
| 15 | `FailoverError.suspend` (billing + sessionId) | `true` | `true` ✓ |
| 16 | OpenAI auth: `FailoverError.reason` | `auth` | `auth` ✓ |
| 17 | OpenAI auth: `FailoverError.status` | `401` | `401` ✓ |
| 18 | OpenAI auth: `suspend != true` | `true` | `true` ✓ |
| 19 | `isFailoverError(FailoverError)` | `true` | `true` ✓ |
| 20 | `isFailoverError(plain Error)` | `false` | `false` ✓ |
| 21 | xAI credit → `classifyProviderSpecificError` | `billing` | `billing` ✓ |
| 22 | OpenAI credit → `classifyProviderSpecificError` | `null` | `null` ✓ |
| 23 | xAI subscription → `classifyProviderSpecificError` | `billing` | `billing` ✓ |
| 24 | Bedrock ThrottlingException → rate_limit (existing) | `rate_limit` | `rate_limit` ✓ |
| 25 | xAI credit text (uppercase) → `classifyFailoverReason` | `billing` | `billing` ✓ |

**What this proves at the runtime level:**

- xAI 403 credit/subscription errors now reach `classifyFailoverReason → "billing"` at the exact same call sites the runner uses (`auth-controller.ts:383`, `cli-runner.ts:958`)
- `resolveFailoverStatus("billing") → 402` so the failover layer sees a billing HTTP status for routing
- `coerceToFailoverError` constructs a `FailoverError` with `reason: "billing"`, `status: 402`, and `suspend: true` when a session is attached — the exact shape `model-fallback-runner.ts` reads to decide fallback
- Billing + sessionId triggers `suspend: true`; auth with the same sessionId does NOT suspend — confirming the fix changes actual runtime behavior
- xAI 429 billing-text responses remain `rate_limit` (the leading-429 guard is not bypassed)
- Non-xAI providers (OpenAI, Anthropic) continue to receive `auth` / `null` — provider scoping works correctly

### Behavioral impact: billing vs auth

| Property | BEFORE (auth) | AFTER (billing) |
|---|---|---|
| `classifyFailoverReason` | `"auth"` | `"billing"` |
| `resolveFailoverStatus` | `401` | `402` |
| Profile cooldown | auth cooldown (short) | billing disabled (long) |
| Session suspend | no | yes |
| Fallback selection | xAI retried → fails again | healthy fallback used |

## Root cause

Two problems prevented correct classification:

1. **Missing patterns**: The shared `isBillingErrorMessage()` matcher
   did not recognize "run out of credits" or "need a ... subscription".

2. **Priority inversion**: The generic `auth` classifier catches
   `/\b403\b/` before provider-specific patterns can override. For
   xAI, a 403 credit-exhaustion response is a billing signal, not an auth
   signal.

## Fix (two-part)

**Part 1 — xAI-scoped patterns** (`provider-error-patterns.ts`):

Two new `ProviderErrorPattern` entries scoped to `providers: ["xai"]`:
- `/\brun\s+out\s+of\s+credits\b/i` → `"billing"`
- `/\bneed\s+a\s+\w+\s+subscription\b/i` → `"billing"`

The `ProviderErrorPattern` type gained an optional `providers` field;
`matchesPatternForProvider()` filters patterns by provider before
testing.

**Part 2 — Pipeline placement** (`errors.ts`):

A new `classifyProviderSpecificError === "billing"` check is placed
**after** rate-limit classifiers (preserving leading-429 precedence)
but **before** auth classifiers (`isAuthPermanentErrorMessage` /
`isAuthErrorMessage`).

| Scenario | Classification | Why |
|---|---|---|
| xAI 403 + "run out of credits" | `billing` | Passes rate-limit checks, provider-specific billing before auth |
| xAI 403 + "need a ... subscription" | `billing` | Same path |
| xAI 429 + "run out of credits" | `rate_limit` | Caught by `isRateLimitErrorMessage` / leading-429 guard first |
| Non-xAI 403 + "Access denied" | `auth` | Provider patterns don't match (scoped to xAI) |
| Non-xAI "run out of credits" | `null` | Provider patterns don't match (scoped to xAI) |

## Test results

```
$ npx vitest run src/agents/embedded-agent-helpers/provider-error-patterns.test.ts

 Test Files  2 passed (2)
      Tests  112 passed (112)
```

Key test assertions:
- `classifyProviderSpecificError > xAI credit exhaustion -> billing`
- `classifyProviderSpecificError > xAI subscription -> billing`
- `classifyProviderSpecificError > non-xAI credit -> null`
- `classifyFailoverReason > xAI 403 credit -> billing NOT auth`
- `classifyFailoverReason > xAI 403 subscription -> billing NOT auth`
- `classifyFailoverReason > xAI 429 billing text -> rate_limit` (regression guard)
- `classifyFailoverReason > non-xAI 403 -> auth`

## Linting/formatting

- `oxlint` — no errors on changed files
- `oxfmt --check` — all matched files use the correct format

## Exact reviewed head

`b15037ef6df46e634ca7c6cdf5b74f877cf8bb3b`
