### PR TITLE
fix(googlechat): cancel unread auth response bodies before release

### DIFF
--- a/extensions/googlechat/src/google-auth.fetchok.transport.test.ts
+++ b/extensions/googlechat/src/google-auth.fetchok.transport.test.ts
@@ -1,0 +1,86 @@
+// Exercise Google auth requests through a real guarded HTTP transport.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loopback = vi.hoisted(() => ({
+  baseUrl: "",
+  contentLength: "",
+  releases: [] as Array<{ bodyIsNull: boolean; bodyUsed: boolean }>,
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: async (...args: Parameters<typeof actual.fetchWithSsrFGuard>) => {
+      const [params] = args;
+      const guarded = await actual.fetchWithSsrFGuard({
+        ...params,
+        policy: { allowPrivateNetwork: true },
+        url: loopback.baseUrl,
+      });
+      return {
+        ...guarded,
+        release: async () => {
+          loopback.releases.push({
+            bodyIsNull: guarded.response.body === null,
+            bodyUsed: guarded.response.bodyUsed,
+          });
+          await guarded.release();
+        },
+      };
+    },
+  };
+});
+
+const { getGoogleAuthTransport } = await import("./google-auth.runtime.js");
+
+const RESPONSE_BODY = '{"access_token":"probe"}';
+
+let server: Server;
+
+beforeAll(async () => {
+  server = createServer((_req, res) => {
+    res.writeHead(200, {
+      "content-length": loopback.contentLength || String(RESPONSE_BODY.length),
+      "content-type": "application/json",
+    });
+    res.end(RESPONSE_BODY);
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  loopback.baseUrl = `http://127.0.0.1:${address.port}/token`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+beforeEach(() => {
+  loopback.contentLength = "";
+  loopback.releases = [];
+});
+
+describe("google auth guarded fetch", () => {
+  it("cancels the unread body when the size guard rejects the response", async () => {
+    loopback.contentLength = String(1024 * 1024 + 1);
+    const transport = await getGoogleAuthTransport();
+
+    await expect(transport.request({ url: loopback.baseUrl })).rejects.toThrow();
+
+    expect(loopback.releases).toEqual([{ bodyIsNull: false, bodyUsed: true }]);
+  });
+
+  it("leaves a fully read response alone", async () => {
+    const transport = await getGoogleAuthTransport();
+
+    await transport.request({ url: loopback.baseUrl });
+
+    expect(loopback.releases).toEqual([{ bodyIsNull: false, bodyUsed: true }]);
+  });
+});

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -432,6 +432,12 @@ function createGoogleAuthFetch(): FetchLike {
         statusText: response.statusText,
       });
     } finally {
+      // The size guard can reject before the stream is touched, leaving an
+      // unread body. Start cancellation before release; awaiting it can
+      // deadlock when debug capture tees the stream.
+      if (!response.bodyUsed) {
+        void response.body?.cancel().catch(() => undefined);
+      }
       await release();
     }
   };


### PR DESCRIPTION
Follow-up to #111290, as offered in review there.

## What Problem This Solves

Fixes an issue where a Google Chat operator whose auth endpoint returns an oversized response would leave a live HTTP response body unread and uncancelled when the SSRF dispatcher is released, holding the socket open until the runtime gets around to it.

Nothing errors and nothing is logged — the request fails with the expected size error, and the leak sits behind it.

## Why This Change Was Made

#111290 established the invariant for this extension and documented it at the `api.ts` guard site: `release()` does not cancel streams, so a status-only response has to be cancelled explicitly before release.

The auth transport has its own guard site, and it was not covered by that change. `readGoogleAuthResponseBytes` inspects `content-length` first:

```ts
const contentLengthHeader = response.headers.get("content-length");
if (contentLengthHeader) {
  const contentLength = parseMediaContentLength(contentLengthHeader);
  if (contentLength !== null && contentLength > MAX_GOOGLE_AUTH_RESPONSE_BYTES) {
    throw new Error(`Google auth response exceeds ${MAX_GOOGLE_AUTH_RESPONSE_BYTES} bytes.`);
  }
}

const reader = response.body?.getReader();
```

The throw happens before `getReader()`, so on that path the stream is never touched and the `finally` releases the dispatcher with the body still unread. This is the same shape as the one just fixed, reached by a different route: there the body is unread because the response is status-only, here because the guard rejected it early.

The fix mirrors the merged one exactly — same predicate, same non-awaited cancellation, same reasoning about the tee'd-capture deadlock — so both guard sites in this extension now read alike.

Note this is only reachable through the size guard's own rejection path, so the fix is narrow by construction: a response that is read normally is untouched.

## User Impact

An oversized auth response no longer leaves its body open when the dispatcher is released; the socket is torn down at the same point it already is on every other path. Normal auth responses are unaffected.

## Evidence

Added `extensions/googlechat/src/google-auth.fetchok.transport.test.ts`, following the harness #111290 landed: a real loopback server, the real `fetchWithSsrFGuard`, and the real `release` — the wrapper only records what `release()` observes and then delegates, so the assertions run against `closeDispatcher` → `waitForDispatcherClose` rather than a stub.

Both directions are covered, and the control case is the point: the site does not leak generally, only on the throw-before-read path.

| case | `release()` observes, before | after |
|---|---|---|
| `content-length: 1048577` | `{ bodyIsNull: false, bodyUsed: false }` | `{ bodyIsNull: false, bodyUsed: true }` |
| normal response (control) | `{ bodyIsNull: false, bodyUsed: true }` | unchanged |

Against the unfixed source the first case fails with exactly that difference:

```
- Expected
+ Received
-   "bodyUsed": true,
+   "bodyUsed": false,

Test Files  1 failed (1)
     Tests  1 failed | 1 passed (2)
```

The control case passes before and after, so the test is measuring the leak rather than the request path.

After the fix, the whole extension suite is green:

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts \
  extensions/googlechat/src/

Test Files  28 passed (28)
     Tests  285 passed (285)
```

`oxfmt --check` is clean on both touched files.

AI-assisted: written and verified with an AI coding agent; the failing-test-first measurement, the control case, and the suite run above were reviewed by me.
