### PR TITLE
feat(ui): add docs links across Settings pages

### DIFF
--- a/ui/src/components/sessions-hub-header.ts
+++ b/ui/src/components/sessions-hub-header.ts
@@ -4,6 +4,7 @@ import { renderSessionsHubTabs, type SessionsHubTab } from "./sessions-hub-tabs.
 type SessionsHubHeaderProps = {
   active: SessionsHubTab;
   title: unknown;
+  subtitle?: unknown;
   actions?: unknown;
   onSelect: (tab: SessionsHubTab) => void;
 };
@@ -13,6 +14,7 @@ export function renderSessionsHubHeader(props: SessionsHubHeaderProps): Template
     <section class="content-header content-header--page sessions-hub-header">
       <div class="sessions-hub-header__title">
         <div class="page-title">${props.title}</div>
+        ${props.subtitle ? html`<div class="page-subtitle">${props.subtitle}</div>` : nothing}
       </div>
       ${renderSessionsHubTabs({ active: props.active, onSelect: props.onSelect })}
       <div class="sessions-hub-header__actions">${props.actions ?? nothing}</div>

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -11,14 +11,16 @@ import type {
   ToolsCatalogResult,
   ToolsEffectiveResult,
 } from "../../api/types.ts";
-import { titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
 import { resolveControlUiAuthToken } from "../../app/control-ui-auth.ts";
+import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { t } from "../../i18n/index.ts";
 import { selectableAgentsList } from "../../lib/agents/display.ts";
 import {
   loadToolsCatalog,
@@ -60,6 +62,8 @@ import {
 import type { AgentsRouteData } from "./route.ts";
 import { loadAgentSkills } from "./skills.ts";
 import { renderAgents } from "./view.ts";
+
+const AGENTS_DOCS_URL = "https://docs.openclaw.ai/concepts/multi-agent";
 
 type AgentsRequestSources = Partial<
   Pick<ApplicationContext, "agents" | "agentIdentity" | "sessions">
@@ -802,6 +806,9 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("agents")}</div>
+          <div class="page-subtitle">
+            ${subtitleForRoute("agents")} ${renderDocsLink(AGENTS_DOCS_URL, t("common.learnMore"))}
+          </div>
         </div>
       </section>
       ${renderSettingsWorkspace(

--- a/ui/src/pages/approvals/approvals-page.test.ts
+++ b/ui/src/pages/approvals/approvals-page.test.ts
@@ -97,6 +97,9 @@ describe("ApprovalsPage", () => {
     await settle(page);
 
     expect(request).toHaveBeenNthCalledWith(1, "approval.history", { limit: 50 });
+    const docsLink = page.querySelector<HTMLAnchorElement>(".settings-page__intro a");
+    expect(docsLink?.textContent?.trim()).toBe("Learn more");
+    expect(docsLink?.href).toBe("https://docs.openclaw.ai/tools/exec-approvals");
     expect(page.querySelectorAll(".approval-history-table tbody tr")).toHaveLength(1);
     expect(page.querySelector(".approval-history-table")?.textContent).toContain("agent:main:test");
     expect(page.querySelector(".approval-history-table")?.textContent).toContain("echo first");

--- a/ui/src/pages/approvals/approvals-page.ts
+++ b/ui/src/pages/approvals/approvals-page.ts
@@ -19,7 +19,7 @@ import {
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
-import { renderSettingsPage } from "../../components/settings-ui.ts";
+import { renderDocsLink, renderSettingsPage } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { i18n, t } from "../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -27,6 +27,7 @@ import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 
 const APPROVAL_HISTORY_PAGE_SIZE = 50;
 const APPROVAL_HISTORY_REQUIRED_SCOPE = "operator.approvals";
+const APPROVALS_DOCS_URL = "https://docs.openclaw.ai/tools/exec-approvals";
 
 function formatResolvedAt(timestampMs: number): string {
   return new Intl.DateTimeFormat(i18n.getLocale(), {
@@ -330,7 +331,10 @@ class ApprovalsPage extends OpenClawLightDomElement {
   override render() {
     const body = renderSettingsPage(
       html`
-        <p class="settings-page__intro">${t("approvalHistory.description")}</p>
+        <p class="settings-page__intro">
+          ${t("approvalHistory.description")}
+          ${renderDocsLink(APPROVALS_DOCS_URL, t("common.learnMore"))}
+        </p>
         ${!this.connected
           ? html`<div class="callout warn">${t("approvalHistory.offline")}</div>`
           : nothing}

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -7,11 +7,12 @@ import type {
   ChannelsPairingRequest,
   NostrProfile,
 } from "../../api/types.ts";
-import { titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { resolveControlUiAuthHeader } from "../../app/control-ui-auth.ts";
 import { hasOperatorAdminAccess, hasOperatorPairingAccess } from "../../app/operator-access.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
+import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveChannelPairingAuthSignature } from "../../lib/channels/index.ts";
@@ -27,6 +28,7 @@ import { ChannelWizardHost } from "./wizard-host.ts";
 type NostrProfileFormState = ReturnType<typeof createNostrProfileFormState> | null;
 
 const CHANNEL_PAIRING_POLL_INTERVAL_MS = 30_000;
+const CHANNELS_DOCS_URL = "https://docs.openclaw.ai/channels";
 
 type NostrOperation = {
   generation: number;
@@ -658,6 +660,10 @@ class ChannelsPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("channels")}</div>
+          <div class="page-subtitle">
+            ${subtitleForRoute("channels")}
+            ${renderDocsLink(CHANNELS_DOCS_URL, t("common.learnMore"))}
+          </div>
         </div>
       </section>
       ${renderSettingsWorkspace(

--- a/ui/src/pages/connection/connection-page.ts
+++ b/ui/src/pages/connection/connection-page.ts
@@ -6,14 +6,16 @@ import { html } from "lit";
 import { state } from "lit/decorators.js";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
 import { loadGatewaySessionSelection, loadSettings, type UiSettings } from "../../app/settings.ts";
+import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { t } from "../../i18n/index.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PollController } from "../../lit/poll-controller.ts";
@@ -22,6 +24,7 @@ import { isUnknownSystemInfoMethodError, supportsSystemInfo } from "./system-inf
 import { renderConnection } from "./view.ts";
 
 const SYSTEM_INFO_POLL_INTERVAL_MS = 10_000;
+const CONNECTION_DOCS_URL = "https://docs.openclaw.ai/gateway/remote";
 
 export { supportsSystemInfo } from "./system-info.ts";
 
@@ -274,6 +277,10 @@ export class ConnectionPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("connection")}</div>
+          <div class="page-subtitle">
+            ${subtitleForRoute("connection")}
+            ${renderDocsLink(CONNECTION_DOCS_URL, t("common.learnMore"))}
+          </div>
         </div>
       </section>
       ${renderSettingsWorkspace(body)}

--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -88,6 +88,9 @@ describe("LabsPage", () => {
     });
 
     expect(page.querySelector(".settings-page__intro")?.textContent).toContain("experimental");
+    const introLink = page.querySelector<HTMLAnchorElement>(".settings-page__intro a");
+    expect(introLink?.textContent?.trim()).toBe("Learn more");
+    expect(introLink?.href).toBe("https://docs.openclaw.ai/concepts/experimental-features");
     expect(page.querySelectorAll(".settings-row")).toHaveLength(LAB_FEATURES.length);
     expect(page.textContent).toContain("Code Mode");
     expect(page.textContent).toContain("Swarm");

--- a/ui/src/pages/labs/labs-page.ts
+++ b/ui/src/pages/labs/labs-page.ts
@@ -4,6 +4,7 @@ import { state } from "lit/decorators.js";
 import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import {
+  renderDocsLink,
   renderSettingsPage,
   renderSettingsRow,
   renderSettingsSection,
@@ -136,7 +137,13 @@ class LabsPage extends OpenClawLightDomElement {
         },
         rows,
       ),
-      { intro: t("labsPage.intro") },
+      {
+        intro: html`${t("labsPage.intro")}
+        ${renderDocsLink(
+          "https://docs.openclaw.ai/concepts/experimental-features",
+          t("common.learnMore"),
+        )}`,
+      },
     );
     return html`
       <section class="content-header">

--- a/ui/src/pages/memory-import/memory-import-page.ts
+++ b/ui/src/pages/memory-import/memory-import-page.ts
@@ -6,9 +6,11 @@ import type {
   MigrationsMemoryApplyResult,
   MigrationsMemoryPlanResult,
 } from "../../../../packages/gateway-protocol/src/schema/migrations.js";
-import { titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
+import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { t } from "../../i18n/index.ts";
 import { listSelectableAgents } from "../../lib/agents/display.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -21,6 +23,7 @@ import {
 } from "./view.ts";
 
 const SESSION_BACKFILL_BATCH_DAYS = 14;
+const MEMORY_IMPORT_DOCS_URL = "https://docs.openclaw.ai/install/migrating";
 
 type PendingMemoryImport = {
   providerId: string;
@@ -567,6 +570,10 @@ export class MemoryImportPage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("memory-import")}</div>
+          <div class="page-subtitle">
+            ${subtitleForRoute("memory-import")}
+            ${renderDocsLink(MEMORY_IMPORT_DOCS_URL, t("common.learnMore"))}
+          </div>
         </div>
       </section>
       ${renderSettingsWorkspace(body)}

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -8,9 +8,10 @@ import type {
   SystemAgentSetupActivateResult,
   SystemAgentSetupDetectResult,
 } from "../../api/types.ts";
-import { titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
+import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
@@ -33,6 +34,8 @@ import {
 import { renderModelSetup, resolveSetupBrandIcon } from "./view.ts";
 import { ModelSetupWizardRunner } from "./wizard-runner.ts";
 import type { ModelSetupWizardStartMethod } from "./wizard-runner.ts";
+
+const MODEL_SETUP_DOCS_URL = "https://docs.openclaw.ai/concepts/model-providers";
 
 type Candidate = SystemAgentSetupDetectResult["candidates"][number];
 type AuthOption = NonNullable<SystemAgentSetupDetectResult["authOptions"]>[number];
@@ -573,7 +576,13 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     });
     return html`
       <section class="content-header">
-        <div class="page-title">${titleForRoute("model-setup")}</div>
+        <div>
+          <div class="page-title">${titleForRoute("model-setup")}</div>
+          <div class="page-subtitle">
+            ${subtitleForRoute("model-setup")}
+            ${renderDocsLink(MODEL_SETUP_DOCS_URL, t("common.learnMore"))}
+          </div>
+        </div>
       </section>
       ${renderSettingsWorkspace(body)}
     `;

--- a/ui/src/pages/nodes/nodes-page.ts
+++ b/ui/src/pages/nodes/nodes-page.ts
@@ -3,14 +3,16 @@ import { initialState, Task } from "@lit/task";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { PresenceEntry } from "../../api/types.ts";
-import { titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
+import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { t } from "../../i18n/index.ts";
 import { currentConfigObject } from "../../lib/config/index.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
 import {
@@ -40,6 +42,8 @@ import { PollController } from "../../lit/poll-controller.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { renderNodes } from "./view.ts";
 import type { InventoryRemovalPrompt } from "./view.types.ts";
+
+const NODES_DOCS_URL = "https://docs.openclaw.ai/nodes";
 
 export type NodesRouteData = {
   // Client identity alone cannot distinguish provider replacement or reconnect epochs.
@@ -370,6 +374,9 @@ class NodesPage extends OpenClawLightDomElement implements NodesPageDataState {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("nodes")}</div>
+          <div class="page-subtitle">
+            ${subtitleForRoute("nodes")} ${renderDocsLink(NODES_DOCS_URL, t("common.learnMore"))}
+          </div>
         </div>
       </section>
       ${renderSettingsWorkspace(

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -4,7 +4,7 @@ import type { RouteLocation } from "@openclaw/uirouter";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { serializeSidebarEntry, titleForRoute } from "../../app-navigation.ts";
+import { serializeSidebarEntry, subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { pathForPluginsHubTab, pathForRoute } from "../../app-route-paths.ts";
 import {
   applicationContext,
@@ -15,6 +15,7 @@ import { resolveControlUiAuthCandidates } from "../../app/control-ui-auth.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import type { McpServerForm } from "../../components/mcp-server-form.ts";
 import { renderPluginsHubTabs, type PluginsHubTab } from "../../components/plugins-hub-tabs.ts";
+import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveEditableSnapshotConfig } from "../../lib/config/index.ts";
@@ -55,6 +56,8 @@ import {
   type PluginRowMessage,
   type PluginsTab,
 } from "./view.ts";
+
+const PLUGINS_DOCS_URL = "https://docs.openclaw.ai/plugins/manage-plugins";
 
 export type PluginsRouteData = {
   gateway: ApplicationContext["gateway"];
@@ -969,6 +972,10 @@ class PluginsPage extends OpenClawLightDomElement {
       <section class="content-header content-header--page plugins-content-header">
         <div>
           <h1 class="page-title">${titleForRoute("plugins")}</h1>
+          <div class="page-subtitle">
+            ${subtitleForRoute("plugins")}
+            ${renderDocsLink(PLUGINS_DOCS_URL, t("common.learnMore"))}
+          </div>
         </div>
       </section>
       ${renderSettingsWorkspace(html`

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -180,6 +180,9 @@ it("renders identity before a Usage statistics link without requesting usage dat
   await waitForFast(() => expect(page.querySelector("#settings-profile-identity")).not.toBeNull());
 
   expect(request.mock.calls.map(([method]) => method)).toEqual(["users.self"]);
+  const docsLink = page.querySelector<HTMLAnchorElement>(".page-subtitle a");
+  expect(docsLink?.textContent?.trim()).toBe("Learn more");
+  expect(docsLink?.href).toBe("https://docs.openclaw.ai/concepts/user-model");
   expect(page.querySelector(".profile-stats")).toBeNull();
   expect(page.querySelector(".profile-heatmap")).toBeNull();
   const usageRow = page.querySelector<HTMLButtonElement>(".settings-row--nav");

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -8,7 +8,7 @@ import type {
   UsersSetDisplayNameResult,
 } from "../../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import {
   applicationContext,
   type ApplicationContext,
@@ -18,6 +18,7 @@ import type { AuthenticatedUser } from "../../app/user-profile.ts";
 import { resolveCurrentSelfUser, userProfileAvatarUrl } from "../../app/user-profile.ts";
 import { icons } from "../../components/icons.ts";
 import {
+  renderDocsLink,
   renderSettingsEmpty,
   renderSettingsGroup,
   renderSettingsNavRow,
@@ -32,6 +33,8 @@ import { PROFILE_SETTINGS_TARGET_IDS } from "../config/settings-targets.ts";
 import "../../styles/profile.css";
 import { processProfileAvatar, ProfileAvatarError } from "./avatar-processing.ts";
 import { renderIdentitySection } from "./identity-section.ts";
+
+const PROFILE_DOCS_URL = "https://docs.openclaw.ai/concepts/user-model";
 
 function toIdentityErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message.trim()) {
@@ -371,6 +374,10 @@ export class ProfilePage extends OpenClawLightDomElement {
       <section class="content-header">
         <div>
           <div class="page-title">${titleForRoute("profile")}</div>
+          <div class="page-subtitle">
+            ${subtitleForRoute("profile")}
+            ${renderDocsLink(PROFILE_DOCS_URL, t("common.learnMore"))}
+          </div>
         </div>
         ${this.selfUser
           ? html`<button class="btn profile-refresh" @click=${() => this.refreshManually()}>

--- a/ui/src/pages/sessions/sessions-page.test.ts
+++ b/ui/src/pages/sessions/sessions-page.test.ts
@@ -216,6 +216,10 @@ describe("sessions page lifecycle", () => {
       sessions: [],
     });
 
+    const docsLink = page.querySelector<HTMLAnchorElement>(".page-subtitle a");
+    expect(docsLink?.textContent?.trim()).toBe("Learn more");
+    expect(docsLink?.href).toBe("https://docs.openclaw.ai/concepts/session");
+
     const archived = [
       ...page.querySelectorAll<HTMLElement & { checked: boolean }>(
         ".sessions-view-segment wa-radio",

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -8,7 +8,7 @@ import type {
   SessionCompactionCheckpoint,
   SessionsListResult,
 } from "../../api/types.ts";
-import { titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { selectApplicationSession } from "../../app/agent-selection.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorWriteAccess } from "../../app/operator-access.ts";
@@ -18,6 +18,7 @@ import type { SessionMenuAction, SessionMenuWork } from "../../components/sessio
 import "../../components/session-menu.ts";
 import { isStoppableCloudWorkerPlacement } from "../../components/session-row-badges.ts";
 import { renderSessionsHubHeader } from "../../components/sessions-hub-header.ts";
+import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { openEditor } from "../../lib/editor-links.ts";
@@ -62,6 +63,8 @@ import {
 import { rememberSessionCustomGroup, sessionCategoryNames } from "./custom-groups.ts";
 import { loadStoredGroupBy, parseFilterInteger, saveStoredGroupBy } from "./page-state.ts";
 import { renderSessions, type SessionsProps, type TranscriptSearchState } from "./view.ts";
+
+const SESSIONS_DOCS_URL = "https://docs.openclaw.ai/concepts/session";
 
 export type SessionsRouteData = {
   // Client identity alone cannot distinguish provider replacement or reconnect epochs.
@@ -1329,6 +1332,8 @@ class SessionsPage extends OpenClawLightDomElement {
       ${renderSessionsHubHeader({
         active: "sessions",
         title: titleForRoute("sessions"),
+        subtitle: html`${subtitleForRoute("sessions")}
+        ${renderDocsLink(SESSIONS_DOCS_URL, t("common.learnMore"))}`,
         actions: renderAgentScopeControl({
           agents: context.agents.state.agentsList?.agents ?? [],
           selection: context.agentSelection,

--- a/ui/src/pages/worktrees/worktrees-page.test.ts
+++ b/ui/src/pages/worktrees/worktrees-page.test.ts
@@ -142,6 +142,10 @@ describe("WorktreesPage lifecycle", () => {
     await waitForFast(() => expect(page.records.length).toBe(1));
     await page.updateComplete;
 
+    const docsLink = page.querySelector<HTMLAnchorElement>(".page-subtitle a");
+    expect(docsLink?.textContent?.trim()).toBe("Learn more");
+    expect(docsLink?.href).toBe("https://docs.openclaw.ai/concepts/managed-worktrees");
+
     const link = [...page.querySelectorAll("a")].find((anchor) =>
       anchor.getAttribute("href")?.includes("12345678"),
     );

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -4,11 +4,12 @@ import { html, nothing } from "lit";
 import { state } from "lit/decorators.js";
 import type { WorktreeRecord } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { titleForRoute } from "../../app-navigation.ts";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { shouldHandleNavigationClick } from "../../components/app-sidebar-nav-menus.ts";
 import { renderSessionsHubHeader } from "../../components/sessions-hub-header.ts";
 import {
+  renderDocsLink,
   renderSettingsEmpty,
   renderSettingsPage,
   renderSettingsRow,
@@ -24,6 +25,8 @@ import {
 } from "../../lib/sessions/route-navigation.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+
+const WORKTREES_DOCS_URL = "https://docs.openclaw.ai/concepts/managed-worktrees";
 
 type WorktreesListResult = { worktrees: WorktreeRecord[] };
 type WorktreesRemoveResult = { removed: boolean; snapshotError?: string };
@@ -505,6 +508,8 @@ class WorktreesPage extends OpenClawLightDomElement {
       ${renderSessionsHubHeader({
         active: "worktrees",
         title: titleForRoute("sessions"),
+        subtitle: html`${subtitleForRoute("worktrees")}
+        ${renderDocsLink(WORKTREES_DOCS_URL, t("common.learnMore"))}`,
         onSelect: (tab) => {
           if (tab !== "worktrees") {
             this.context?.navigate(tab);


### PR DESCRIPTION
## What Problem This Solves

Rounds 1-2 (#115560, #115665) covered the config-schema settings pages, but a full sidebar sweep found 12 more Settings pages with zero docs links: Profile, Gateway/Connection, Channels hub, Devices, Agents, Plugins, Model Setup, Memory Import, Sessions, Worktrees, Approvals, and Labs.

## Why This Change Was Made

This completes contextual docs coverage across every Settings surface. It reuses the existing localized `subtitles.*` copy, so no new i18n keys are needed.

## User Impact

Every Settings sidebar page now offers a task-oriented Learn-more docs link in its header (using the page-subtitle idiom from #115665) or existing intro.

Skipped by design: Custodian (chat surface), Lobsterdex (collectible), and About (already linked).

## Evidence

- Focused tests: 82/82 across Labs, Approvals, Profile, Sessions, and Worktrees.
- `check-changed`: green.
- Autoreview: clean (0.96).
- Headless Playwright: after-screenshots of all pages against the mock harness.

Before: these pages simply had no link.

![labs](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-docs-sweep/labs.png)
![profile](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-docs-sweep/profile.png)
![connection](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-docs-sweep/connection.png)
![devices](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-docs-sweep/devices.png)
![agents](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-docs-sweep/agents.png)
![plugins](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-docs-sweep/plugins.png)
![model-setup](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-docs-sweep/model-setup.png)
![sessions](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-docs-sweep/sessions.png)
![worktrees](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-docs-sweep/worktrees.png)
![approvals](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/settings-docs-sweep/approvals.png)
