### PR TITLE
fix: keep content after HTML-backed disclosures visible

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -12219,7 +12219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1206,
+      "line": 1208,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
       "source": "Image",
       "surface": "android",
@@ -12227,7 +12227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1212,
+      "line": 1214,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
       "source": "Image unavailable",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
@@ -763,7 +763,7 @@ internal fun parseChatMarkdownBlocks(text: String): List<ChatMarkdownRenderBlock
   var node = document.firstChild
   while (node != null) {
     val current = node
-    if (current is HtmlBlock && DisclosureTokenizer.startsWithCandidateLine(current.literal.orEmpty())) {
+    if (current is HtmlBlock && tokenizer.shouldTokenize(current.literal.orEmpty())) {
       tokens += tokenizer.tokenize(current.literal.orEmpty())
     } else {
       tokens += DisclosureToken.Block(ChatMarkdownRenderBlock.CommonMark(current))
@@ -869,6 +869,8 @@ private class DisclosureTokenizer {
   }
 
   private val balanceStack = mutableListOf<BalanceFrame>()
+
+  fun shouldTokenize(source: String): Boolean = balanceStack.isNotEmpty() || startsWithCandidateLine(source)
 
   fun tokenize(source: String): List<DisclosureToken> {
     val lines = source.split('\n')

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMarkdownTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMarkdownTest.kt
@@ -123,6 +123,28 @@ class ChatMarkdownTest {
   }
 
   @Test
+  fun type6HtmlBlockCannotAbsorbTheDetailsCloser() {
+    val blocks =
+      parseChatMarkdownBlocks(
+        """
+        <details>
+        <summary>X</summary>
+
+        <div>body</div>
+        </details>
+
+        Following
+        """.trimIndent(),
+      )
+    val disclosure = blocks[0] as ChatMarkdownRenderBlock.Disclosure
+    val html = (disclosure.blocks.single() as ChatMarkdownRenderBlock.CommonMark).node as HtmlBlock
+    val following = (blocks[1] as ChatMarkdownRenderBlock.CommonMark).node as Paragraph
+
+    assertTrue(html.literal.contains("body"))
+    assertEquals("Following", (following.firstChild as org.commonmark.node.Text).literal)
+  }
+
+  @Test
   fun unsupportedNestedDetailsBalanceWithoutClosingOuterDisclosure() {
     val blocks =
       parseChatMarkdownBlocks(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
@@ -493,7 +493,7 @@ enum ChatMarkdownBlockSegmenter {
         return result
     }
 
-    private struct Extraction {
+    fileprivate struct Extraction {
         let lineRange: Range<Int>
         let content: Content
 
@@ -513,7 +513,7 @@ enum ChatMarkdownBlockSegmenter {
         }
     }
 
-    private enum UnfoldedBlock {
+    fileprivate enum UnfoldedBlock {
         case block(ChatMarkdownBlock)
         case disclosureOpen(isExpanded: Bool)
         case disclosureSummary(String)
@@ -918,7 +918,7 @@ enum ChatMarkdownBlockSegmenter {
         return ChatMarkdownList(kind: kind, items: renderedItems)
     }
 
-    private struct SourceBuffer {
+    fileprivate struct SourceBuffer {
         let markdown: String
         let lines: [String]
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
@@ -175,7 +175,7 @@ enum ChatMarkdownBlockSegmenter {
                 continue
             }
 
-            if let html = self.disclosureHTML(child, source: source, lineRange: lineRange) {
+            if let html = self.htmlBlockSource(child, source: source, lineRange: lineRange) {
                 extractions.append(Extraction(lineRange: lineRange, html: html))
                 continue
             }
@@ -269,6 +269,11 @@ enum ChatMarkdownBlockSegmenter {
         }
 
         for extraction in extractions where extraction.lineRange.lowerBound >= proseStart {
+            if case let .html(html) = extraction.content,
+               !disclosureTokenizer.shouldTokenize(html)
+            {
+                continue
+            }
             appendProse(until: extraction.lineRange.lowerBound)
             switch extraction.content {
             case let .block(block):
@@ -420,7 +425,10 @@ enum ChatMarkdownBlockSegmenter {
     private static func containsDisclosure(in document: Document, source: SourceBuffer) -> Bool {
         document.children.contains { child in
             guard let lineRange = source.lineRange(for: child.range) else { return false }
-            return self.disclosureHTML(child, source: source, lineRange: lineRange) != nil
+            guard let html = self.htmlBlockSource(child, source: source, lineRange: lineRange) else {
+                return false
+            }
+            return DisclosureTokenizer.startsWithCandidateLine(html)
         }
     }
 
@@ -456,14 +464,13 @@ enum ChatMarkdownBlockSegmenter {
         code.hasSuffix("\n") ? String(code.dropLast()) : code
     }
 
-    private static func disclosureHTML(
+    private static func htmlBlockSource(
         _ child: any Markup,
         source: SourceBuffer,
         lineRange: Range<Int>) -> String?
     {
         guard child is Markdown.HTMLBlock else { return nil }
-        let html = source.text(in: lineRange)
-        return DisclosureTokenizer.startsWithCandidateLine(html) ? html : nil
+        return source.text(in: lineRange)
     }
 
     private static func foldDisclosures(_ unfolded: [UnfoldedBlock]) -> [ChatMarkdownBlock] {
@@ -571,6 +578,10 @@ enum ChatMarkdownBlockSegmenter {
                 .split(separator: "\n", omittingEmptySubsequences: false)
                 .first { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
             return firstContentLine.map { Self.tags(in: String($0)) != nil } ?? false
+        }
+
+        func shouldTokenize(_ source: String) -> Bool {
+            !self.balanceStack.isEmpty || Self.startsWithCandidateLine(source)
         }
 
         mutating func tokenize(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
@@ -259,36 +259,7 @@ enum ChatMarkdownBlockSegmenter {
             return left.lineRange.upperBound > right.lineRange.upperBound
         }
 
-        var unfolded: [UnfoldedBlock] = []
-        var disclosureTokenizer = DisclosureTokenizer()
-        var proseStart = 0
-
-        func appendProse(until end: Int) {
-            guard proseStart < end else { return }
-            unfolded.append(contentsOf: self.proseOnly(Array(source.lines[proseStart..<end])).map(UnfoldedBlock.block))
-        }
-
-        for extraction in extractions where extraction.lineRange.lowerBound >= proseStart {
-            if case let .html(html) = extraction.content,
-               !disclosureTokenizer.shouldTokenize(html)
-            {
-                continue
-            }
-            appendProse(until: extraction.lineRange.lowerBound)
-            switch extraction.content {
-            case let .block(block):
-                unfolded.append(.block(block))
-            case let .html(html):
-                unfolded.append(contentsOf: disclosureTokenizer.tokenize(
-                    html,
-                    parseMarkdown: { markdown in
-                        self.segments(markdown: markdown, isComplete: isComplete).map(UnfoldedBlock.block)
-                    }))
-            }
-            proseStart = extraction.lineRange.upperBound
-        }
-
-        appendProse(until: source.lines.count)
+        let unfolded = self.unfold(extractions, source: source, isComplete: isComplete)
         let blocks = self.foldDisclosures(unfolded)
         let reparsesListContent = blocks.contains { block in
             if case .list = block { return true }
@@ -1169,5 +1140,45 @@ enum ChatMarkdownBlockSegmenter {
             }
             return (count, cursor)
         }
+    }
+}
+
+extension ChatMarkdownBlockSegmenter {
+    fileprivate static func unfold(
+        _ extractions: [Extraction],
+        source: SourceBuffer,
+        isComplete: Bool) -> [UnfoldedBlock]
+    {
+        var unfolded: [UnfoldedBlock] = []
+        var disclosureTokenizer = DisclosureTokenizer()
+        var proseStart = 0
+
+        func appendProse(until end: Int) {
+            guard proseStart < end else { return }
+            unfolded.append(contentsOf: self.proseOnly(Array(source.lines[proseStart..<end])).map(UnfoldedBlock.block))
+        }
+
+        for extraction in extractions where extraction.lineRange.lowerBound >= proseStart {
+            if case let .html(html) = extraction.content,
+               !disclosureTokenizer.shouldTokenize(html)
+            {
+                continue
+            }
+            appendProse(until: extraction.lineRange.lowerBound)
+            switch extraction.content {
+            case let .block(block):
+                unfolded.append(.block(block))
+            case let .html(html):
+                unfolded.append(contentsOf: disclosureTokenizer.tokenize(
+                    html,
+                    parseMarkdown: { markdown in
+                        self.segments(markdown: markdown, isComplete: isComplete).map(UnfoldedBlock.block)
+                    }))
+            }
+            proseStart = extraction.lineRange.upperBound
+        }
+
+        appendProse(until: source.lines.count)
+        return unfolded
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
@@ -782,7 +782,7 @@ enum ChatMarkdownBlockSegmenter {
         let protectedRanges: [Range<Int>]
     }
 
-    private struct SourceReplacement {
+    fileprivate struct SourceReplacement {
         let range: SourceRange
         let markdown: String
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
@@ -165,6 +165,24 @@ struct ChatMarkdownBlockSegmenterTests {
             isComplete: true)))
     }
 
+    @Test func `type 6 HTML block cannot absorb the details closer`() {
+        #expect(self.segments("""
+        <details>
+        <summary>X</summary>
+
+        <div>body</div>
+        </details>
+
+        Following
+        """) == [
+            .disclosure(ChatMarkdownDisclosure(
+                summary: "X",
+                isExpanded: false,
+                blocks: [.prose("<div>body</div>")])),
+            .prose("Following"),
+        ])
+    }
+
     @Test @MainActor func `details preserve document scoped reference links`() throws {
         let destination = try #require(URL(string: "https://example.com"))
         let snapshot = ChatMarkdownRenderSnapshot(

--- a/ui/src/components/markdown-details.test.ts
+++ b/ui/src/components/markdown-details.test.ts
@@ -285,6 +285,38 @@ describe("multi-token details shapes", () => {
     expect(html).not.toContain("&lt;/details");
   });
 
+  it("closes before trailing prose when a type-6 HTML block absorbs the closer", () => {
+    const html = toSanitizedMarkdownHtml(
+      "<details>\n<summary>X</summary>\n\n<div>body</div>\n</details>\n\nFollowing",
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.textContent).toContain("body");
+    expect(details?.textContent).not.toContain("Following");
+    expect(fragment.lastElementChild?.textContent).toBe("Following");
+  });
+
+  it.each([
+    ["comment", "<!--\n</details>\n-->"],
+    ["pre", "<pre>\n</details>\n</pre>"],
+    ["script", "<script>\n</details>\n</script>"],
+    ["style", "<style>\n</details>\n</style>"],
+    ["processing instruction", "<?pi\n</details>\n?>"],
+    ["declaration", "<!DOCTYPE\n</details>\n>"],
+    ["CDATA", "<![CDATA[\n</details>\n]]>"],
+  ])("keeps closer-shaped text inside an embedded raw HTML %s literal", (_name, raw) => {
+    const html = toSanitizedMarkdownHtml(
+      `<details>\n<summary>X</summary>\n\n<div>\n${raw}\n</div>\n</details>\n\nFollowing`,
+    );
+    const fragment = htmlFragment(html);
+    const details = fragment.querySelector("details");
+
+    expect(details?.textContent).toContain("</details>");
+    expect(details?.textContent).not.toContain("Following");
+    expect(fragment.lastElementChild?.textContent).toBe("Following");
+  });
+
   it("renders details when body text starts without a summary", () => {
     const html = toSanitizedMarkdownHtml("<details>\nfirst line\n\nsecond paragraph\n</details>");
     const fragment = htmlFragment(html);

--- a/ui/src/components/markdown-details.ts
+++ b/ui/src/components/markdown-details.ts
@@ -12,6 +12,16 @@ const DETAILS_STACK = Symbol("markdownDetailsStack");
 
 type DetailsFrame = { hasSummary: boolean };
 type DetailsBlockState = StateBlock & { [DETAILS_STACK]?: DetailsFrame[] };
+type DetailsToken = ReturnType<StateBlock["push"]>;
+type DetailsTokenSink = {
+  push(type: string, tag: string, nesting: -1 | 0 | 1): DetailsToken;
+};
+type MarkdownRawHtmlContext =
+  | "comment"
+  | "processing_instruction"
+  | "declaration"
+  | "cdata"
+  | { element: string };
 
 type MarkdownDisclosureTag = {
   end: number;
@@ -79,7 +89,7 @@ export function scanMarkdownDisclosureLine(
   return tags.length > 0 ? tags : null;
 }
 
-function pushInlineParagraph(state: StateBlock, content: string, line: number): void {
+function pushInlineParagraph(state: DetailsTokenSink, content: string, line: number): void {
   if (!content.trim()) {
     return;
   }
@@ -92,7 +102,7 @@ function pushInlineParagraph(state: StateBlock, content: string, line: number): 
   state.push("paragraph_close", "p", -1);
 }
 
-function pushSummary(state: StateBlock, label: string, line: number): void {
+function pushSummary(state: DetailsTokenSink, label: string, line: number): void {
   const open = state.push("summary_open", "summary", 1);
   open.map = [line, line + 1];
   const inline = state.push("inline", "", 0);
@@ -102,27 +112,16 @@ function pushSummary(state: StateBlock, label: string, line: number): void {
   state.push("summary_close", "summary", -1);
 }
 
-function detailsBlockRule(
-  state: DetailsBlockState,
-  startLine: number,
-  _endLine: number,
-  silent: boolean,
+function pushDisclosureLine(
+  state: DetailsTokenSink,
+  line: string,
+  lineNumber: number,
+  stack: DetailsFrame[],
 ): boolean {
-  if ((state.sCount[startLine] ?? 0) - state.blkIndent >= 4) {
-    return false;
-  }
-  const start = (state.bMarks[startLine] ?? 0) + (state.tShift[startLine] ?? 0);
-  const end = state.eMarks[startLine] ?? state.src.length;
-  const line = state.src.slice(start, end);
   const tags = scanMarkdownDisclosureLine(line);
   if (!tags) {
     return false;
   }
-  if (silent) {
-    return true;
-  }
-
-  const stack = (state[DETAILS_STACK] ??= []);
   const kinds = tags.map((tag) => markdownDisclosureTagKind(tag.raw));
   const nextSummaryClose = Array.from({ length: tags.length }, () => -1);
   let nearestSummaryClose = -1;
@@ -135,7 +134,7 @@ function detailsBlockRule(
   let cursor = 0;
   let pendingText = "";
   const flushText = () => {
-    pushInlineParagraph(state, pendingText, startLine);
+    pushInlineParagraph(state, pendingText, lineNumber);
     pendingText = "";
   };
 
@@ -167,7 +166,7 @@ function detailsBlockRule(
       const close = closeIndex >= 0 ? tags[closeIndex] : undefined;
       if (frame && !frame.hasSummary && close) {
         flushText();
-        pushSummary(state, line.slice(tag.end, close.start), startLine);
+        pushSummary(state, line.slice(tag.end, close.start), lineNumber);
         frame.hasSummary = true;
         cursor = close.end;
         index = closeIndex;
@@ -181,8 +180,65 @@ function detailsBlockRule(
   }
   pendingText += line.slice(cursor);
   flushText();
+  return true;
+}
+
+function detailsBlockRule(
+  state: DetailsBlockState,
+  startLine: number,
+  _endLine: number,
+  silent: boolean,
+): boolean {
+  if ((state.sCount[startLine] ?? 0) - state.blkIndent >= 4) {
+    return false;
+  }
+  const start = (state.bMarks[startLine] ?? 0) + (state.tShift[startLine] ?? 0);
+  const end = state.eMarks[startLine] ?? state.src.length;
+  const line = state.src.slice(start, end);
+  if (!scanMarkdownDisclosureLine(line)) {
+    return false;
+  }
+  if (silent) {
+    return true;
+  }
+
+  pushDisclosureLine(state, line, startLine, (state[DETAILS_STACK] ??= []));
   state.line = startLine + 1;
   return true;
+}
+
+function openingRawHtmlContext(line: string): MarkdownRawHtmlContext | null {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("<!--")) {
+    return "comment";
+  }
+  if (trimmed.startsWith("<?")) {
+    return "processing_instruction";
+  }
+  if (trimmed.startsWith("<![CDATA[")) {
+    return "cdata";
+  }
+  if (/^<![A-Z]/.test(trimmed)) {
+    return "declaration";
+  }
+  const element = /^<(pre|script|style|textarea)(?=[\s>]|$)/i.exec(trimmed)?.[1];
+  return element ? { element: element.toLowerCase() } : null;
+}
+
+function closesRawHtmlContext(context: MarkdownRawHtmlContext, line: string): boolean {
+  if (typeof context === "object") {
+    return line.toLowerCase().includes(`</${context.element}>`);
+  }
+  if (context === "comment") {
+    return line.includes("-->");
+  }
+  if (context === "processing_instruction") {
+    return line.includes("?>");
+  }
+  if (context === "declaration") {
+    return line.includes(">");
+  }
+  return line.includes("]]>");
 }
 
 export function installMarkdownDetails(markdownParser: MarkdownIt): void {
@@ -190,22 +246,113 @@ export function installMarkdownDetails(markdownParser: MarkdownIt): void {
     alt: ["paragraph", "reference", "blockquote"],
   });
 
-  // Streaming can end with open details; balance only our structured tokens at EOF.
+  // CommonMark type-6/7 HTML blocks can absorb a later disclosure closer until
+  // the next blank line. Continue scanning those blocks while a disclosure is
+  // open, but leave raw HTML block types 1-5 entirely literal.
   markdownParser.core.ruler.after("block", "details_balance", (state) => {
-    let depth = 0;
+    const output: DetailsToken[] = [];
+    const stack: DetailsFrame[] = [];
+
     for (const token of state.tokens) {
       if (token.type === "details_open") {
-        depth += 1;
-      } else if (token.type === "details_close") {
-        depth = Math.max(0, depth - 1);
+        stack.push({ hasSummary: false });
+        output.push(token);
+        continue;
       }
+      if (token.type === "summary_open") {
+        const frame = stack.at(-1);
+        if (frame) {
+          frame.hasSummary = true;
+        }
+        output.push(token);
+        continue;
+      }
+      if (token.type === "details_close") {
+        stack.pop();
+        output.push(token);
+        continue;
+      }
+      if (token.type !== "html_block" || stack.length === 0) {
+        output.push(token);
+        continue;
+      }
+
+      let level = token.level;
+      const replacement: DetailsToken[] = [];
+      const sink: DetailsTokenSink = {
+        push(type, tag, nesting) {
+          const next = new state.Token(type, tag, nesting);
+          next.block = true;
+          if (nesting < 0) {
+            level -= 1;
+          }
+          next.level = level;
+          if (nesting > 0) {
+            level += 1;
+          }
+          replacement.push(next);
+          return next;
+        },
+      };
+      const lines = token.content.split("\n");
+      let pendingHtml = "";
+      let rawHtmlContext: MarkdownRawHtmlContext | null = null;
+      const flushHtml = () => {
+        if (!pendingHtml) {
+          return;
+        }
+        const raw = sink.push("html_block", "", 0);
+        raw.content = pendingHtml;
+        raw.map = token.map;
+        pendingHtml = "";
+      };
+      for (const [lineOffset, line] of lines.entries()) {
+        const hasLineBreak = lineOffset < lines.length - 1;
+        if (rawHtmlContext) {
+          pendingHtml += line + (hasLineBreak ? "\n" : "");
+          if (closesRawHtmlContext(rawHtmlContext, line)) {
+            rawHtmlContext = null;
+          }
+          continue;
+        }
+        const openingContext = openingRawHtmlContext(line);
+        if (openingContext) {
+          pendingHtml += line + (hasLineBreak ? "\n" : "");
+          if (!closesRawHtmlContext(openingContext, line)) {
+            rawHtmlContext = openingContext;
+          }
+          continue;
+        }
+        if (!scanMarkdownDisclosureLine(line)) {
+          pendingHtml += line + (hasLineBreak ? "\n" : "");
+          continue;
+        }
+        flushHtml();
+        const lineNumber = (token.map?.[0] ?? 0) + lineOffset;
+        pushDisclosureLine(sink, line, lineNumber, stack);
+      }
+      flushHtml();
+      output.push(...replacement);
     }
-    while (depth > 0) {
+
+    // Streaming can end with open details; balance only our structured tokens at EOF.
+    while (stack.length > 0) {
       const token = new state.Token("details_close", "details", -1);
       token.block = true;
-      state.tokens.push(token);
-      depth -= 1;
+      output.push(token);
+      stack.pop();
     }
+    let level = 0;
+    for (const token of output) {
+      if (token.nesting < 0) {
+        level -= 1;
+      }
+      token.level = level;
+      if (token.nesting > 0) {
+        level += 1;
+      }
+    }
+    state.tokens = output;
   });
 
   markdownParser.renderer.rules.details_open = (tokens, index) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing model-authored disclosure blocks could have all following chat content hidden inside the collapsed section when a raw HTML body block immediately preceded the closing disclosure tag.

## Why This Change Was Made

Continue disclosure scanning across CommonMark HTML blocks only while a structural disclosure is open, so a closer coalesced into a type-6 block is recovered at the correct boundary. The Control UI, shared Apple chat UI, and Android chat UI keep the same line-leading disclosure contract and preserve CommonMark raw HTML block types 1-5 as literal content.

## User Impact

Content following a collapsed model-authored disclosure remains visible in the Control UI and native apps, including when the disclosure body ends with block HTML.

## Evidence

- Control UI focused suite: 39/39 tests passed.
- Source-blind rendered-artifact replay: the exact repro plus comment, pre, script, style, processing-instruction, declaration, and CDATA probes passed (8/8 focused cases).
- Android: `:app:ktlintCheck` passed and `ChatMarkdownTest` passed under `:app:testPlayDebugUnitTest`.
- Swift formatting passed for the shared implementation and regression test; the exact-head macOS CI lane owns the Apple-framework test run.
- Normal changed gate passed on Blacksmith Testbox: formatting, dead-code scans, UI/core typechecks, lint shards, app-adjacent tests, and schema guards.
- Codex autoreview completed clean with no accepted or actionable findings.

Release note: Fix model-authored disclosure blocks hiding following chat content after an HTML body block.
