### PR TITLE
refactor(ollama): unify model inspection and setup

### DIFF
--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -13,6 +13,7 @@ import {
   isOllamaCloudModel,
   fetchOllamaModels,
   queryOllamaModelShowInfo,
+  readOllamaModelShowInfo,
   resolveOllamaApiBase,
   type OllamaTagModel,
 } from "./provider-models.js";
@@ -507,6 +508,19 @@ describe("ollama provider models", () => {
 
     await expect(queryOllamaModelShowInfo("http://127.0.0.1:11434", "llama3:8b")).resolves.toEqual(
       {},
+    );
+    expect(showResponse.wasCanceled()).toBe(true);
+  });
+
+  it("reports failed strict model inspections while releasing their response bodies", async () => {
+    const showResponse = cancelTrackedResponse("model unavailable", { status: 503 });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => showResponse.response),
+    );
+
+    await expect(readOllamaModelShowInfo("http://127.0.0.1:11434", "llama3:8b")).rejects.toThrow(
+      "Ollama model inspection failed with HTTP 503",
     );
     expect(showResponse.wasCanceled()).toBe(true);
   });

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -89,6 +89,10 @@ type OllamaModelRequestOptions = {
   signal?: AbortSignal;
 };
 
+type OllamaModelShowRequestOptions = OllamaModelRequestOptions & {
+  auditContext?: string;
+};
+
 export function throwIfOllamaRequestAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
     throw toErrorObject(signal.reason, "Ollama request aborted");
@@ -145,71 +149,82 @@ function parseOllamaNumCtxParameter(parameters: unknown): number | undefined {
   return lastValue;
 }
 
+export async function readOllamaModelShowInfo(
+  apiBase: string,
+  modelName: string,
+  opts?: OllamaModelShowRequestOptions,
+): Promise<OllamaModelShowInfo> {
+  const normalizedApiBase = resolveOllamaApiBase(apiBase);
+  const auditContext = opts?.auditContext ?? "ollama-provider-models.show";
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (opts?.apiKey) {
+    headers.Authorization = `Bearer ${opts.apiKey}`;
+  }
+  const { response, release } = await fetchWithSsrFGuard({
+    url: `${normalizedApiBase}/api/show`,
+    init: {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name: modelName }),
+    },
+    // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
+    timeoutMs: Math.min(opts?.timeoutMs ?? OLLAMA_SHOW_TIMEOUT_MS, OLLAMA_SHOW_TIMEOUT_MS),
+    ...(opts?.signal ? { signal: opts.signal } : {}),
+    policy: buildOllamaBaseUrlSsrFPolicy(normalizedApiBase),
+    auditContext,
+  });
+  try {
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new Error(`Ollama model inspection failed with HTTP ${response.status}`);
+    }
+    const data = await readProviderJsonResponse<{
+      model_info?: Record<string, unknown>;
+      capabilities?: unknown;
+      parameters?: unknown;
+    }>(response, auditContext);
+
+    let contextWindow: number | undefined;
+    if (data.model_info) {
+      for (const [key, value] of Object.entries(data.model_info)) {
+        if (
+          key.endsWith(".context_length") &&
+          typeof value === "number" &&
+          Number.isFinite(value)
+        ) {
+          const ctx = Math.floor(value);
+          if (ctx > 0) {
+            contextWindow = ctx;
+            break;
+          }
+        }
+      }
+    }
+
+    const paramCtx = parseOllamaNumCtxParameter(data.parameters);
+    if (paramCtx !== undefined && (contextWindow === undefined || paramCtx > contextWindow)) {
+      contextWindow = paramCtx;
+    }
+
+    const capabilities = Array.isArray(data.capabilities)
+      ? (data.capabilities as unknown[]).filter(
+          (capability): capability is string => typeof capability === "string",
+        )
+      : undefined;
+
+    return { contextWindow, capabilities };
+  } finally {
+    await release();
+  }
+}
+
 export async function queryOllamaModelShowInfo(
   apiBase: string,
   modelName: string,
   opts?: OllamaModelRequestOptions,
 ): Promise<OllamaModelShowInfo> {
-  const normalizedApiBase = resolveOllamaApiBase(apiBase);
   try {
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (opts?.apiKey) {
-      headers.Authorization = `Bearer ${opts.apiKey}`;
-    }
-    const { response, release } = await fetchWithSsrFGuard({
-      url: `${normalizedApiBase}/api/show`,
-      init: {
-        method: "POST",
-        headers,
-        body: JSON.stringify({ name: modelName }),
-      },
-      // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
-      timeoutMs: Math.min(opts?.timeoutMs ?? OLLAMA_SHOW_TIMEOUT_MS, OLLAMA_SHOW_TIMEOUT_MS),
-      ...(opts?.signal ? { signal: opts.signal } : {}),
-      policy: buildOllamaBaseUrlSsrFPolicy(normalizedApiBase),
-      auditContext: "ollama-provider-models.show",
-    });
-    try {
-      if (!response.ok) {
-        await response.body?.cancel().catch(() => undefined);
-        return {};
-      }
-      const data = await readProviderJsonResponse<{
-        model_info?: Record<string, unknown>;
-        capabilities?: unknown;
-        parameters?: unknown;
-      }>(response, "ollama-provider-models.show");
-
-      let contextWindow: number | undefined;
-      if (data.model_info) {
-        for (const [key, value] of Object.entries(data.model_info)) {
-          if (
-            key.endsWith(".context_length") &&
-            typeof value === "number" &&
-            Number.isFinite(value)
-          ) {
-            const ctx = Math.floor(value);
-            if (ctx > 0) {
-              contextWindow = ctx;
-              break;
-            }
-          }
-        }
-      }
-
-      const paramCtx = parseOllamaNumCtxParameter(data.parameters);
-      if (paramCtx !== undefined && (contextWindow === undefined || paramCtx > contextWindow)) {
-        contextWindow = paramCtx;
-      }
-
-      const capabilities = Array.isArray(data.capabilities)
-        ? (data.capabilities as unknown[]).filter((c): c is string => typeof c === "string")
-        : undefined;
-
-      return { contextWindow, capabilities };
-    } finally {
-      await release();
-    }
+    return await readOllamaModelShowInfo(apiBase, modelName, opts);
   } catch {
     throwIfOllamaRequestAborted(opts?.signal);
     return {};
@@ -336,18 +351,11 @@ export function buildOllamaModelDefinition(
     (capabilities === undefined
       ? isReasoningModelHeuristic(modelId)
       : capabilities.includes("thinking"));
-  const compat =
-    capabilities === undefined
-      ? {
-          supportsTools: true,
-          supportsUsageInStreaming: true,
-          supportsJsonSchemaResponseFormat: !isOllamaCloudModel(modelId),
-        }
-      : {
-          supportsTools: capabilities.includes("tools"),
-          supportsUsageInStreaming: true,
-          supportsJsonSchemaResponseFormat: !isOllamaCloudModel(modelId),
-        };
+  const compat = {
+    supportsTools: capabilities?.includes("tools") ?? true,
+    supportsUsageInStreaming: true,
+    supportsJsonSchemaResponseFormat: !isOllamaCloudModel(modelId),
+  };
   return {
     id: modelId,
     name: modelId,

--- a/extensions/ollama/src/setup-model-selection.ts
+++ b/extensions/ollama/src/setup-model-selection.ts
@@ -1,13 +1,11 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { OLLAMA_CLOUD_DEFAULT_MODELS } from "./defaults.js";
 import {
   buildDefaultOllamaCloudModelDefinition,
-  buildOllamaBaseUrlSsrFPolicy,
   buildOllamaModelDefinition,
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
+  readOllamaModelShowInfo,
   resolveOllamaApiBase,
   type OllamaModelWithContext,
 } from "./provider-models.js";
@@ -84,33 +82,6 @@ export function buildOllamaModelsConfig(
   });
 }
 
-function parseOllamaSetupShowInfo(data: {
-  model_info?: Record<string, unknown>;
-  capabilities?: unknown;
-  parameters?: unknown;
-}): Pick<OllamaModelWithContext, "contextWindow" | "capabilities"> {
-  let contextWindow: number | undefined;
-  for (const [key, value] of Object.entries(data.model_info ?? {})) {
-    if (key.endsWith(".context_length") && typeof value === "number" && value > 0) {
-      contextWindow = Math.floor(value);
-      break;
-    }
-  }
-  if (typeof data.parameters === "string") {
-    for (const line of data.parameters.split(/\r?\n/)) {
-      const match = line.trim().match(/^num_ctx\s+(-?\d+)\b/);
-      const parsed = match?.[1] ? Number.parseInt(match[1], 10) : undefined;
-      if (parsed && parsed > 0 && (contextWindow === undefined || parsed > contextWindow)) {
-        contextWindow = parsed;
-      }
-    }
-  }
-  const capabilities = Array.isArray(data.capabilities)
-    ? data.capabilities.filter((value): value is string => typeof value === "string")
-    : undefined;
-  return { contextWindow, capabilities };
-}
-
 export async function inspectOllamaModelsForSetup(
   baseUrl: string,
   models: OllamaModelWithContext[],
@@ -125,34 +96,12 @@ export async function inspectOllamaModelsForSetup(
     const results = await Promise.all(
       batch.map(async (model) => {
         try {
-          const requestSignal = signal
-            ? AbortSignal.any([AbortSignal.timeout(3000), signal])
-            : AbortSignal.timeout(3000);
-          const { response, release } = await fetchWithSsrFGuard({
-            url: `${apiBase}/api/show`,
-            init: {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ name: model.name }),
-              signal: requestSignal,
-            },
-            signal: requestSignal,
-            policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
+          const showInfo = await readOllamaModelShowInfo(apiBase, model.name, {
+            timeoutMs: 3000,
+            signal,
             auditContext: "ollama-setup.tools-scan",
           });
-          try {
-            if (!response.ok) {
-              throw new Error(`Ollama model inspection failed with HTTP ${response.status}`);
-            }
-            const data = await readProviderJsonResponse<{
-              model_info?: Record<string, unknown>;
-              capabilities?: unknown;
-              parameters?: unknown;
-            }>(response, "ollama-setup.tools-scan");
-            return Object.assign({}, model, parseOllamaSetupShowInfo(data));
-          } finally {
-            await release();
-          }
+          return Object.assign({}, model, showInfo);
         } catch (error) {
           signal?.throwIfAborted();
           // A failed inspection must not inherit the optimistic tools default


### PR DESCRIPTION
## What Problem This Solves

Local Ollama onboarding and provider discovery independently implemented the same model inspection, JSON parsing, context-window extraction, capability detection, SSRF policy, and request lifecycle. That duplication made Gemma and other local models more likely to behave differently between onboarding and normal inference.

## Why This Change Was Made

Use one provider-owned, bounded, SSRF-guarded model-inspection implementation. Onboarding retains strict, actionable inspection failures; normal discovery retains its existing soft-failure contract. Collapse duplicate capability defaults and preserve cancellation, response-body cleanup, setup audit context, and model metadata.

## User Impact

Ollama setup and local inference now use consistent model capabilities and context limits. Broken model inspections remain visible, and setup model probes are explicitly bounded across DNS and network preflight. Production code decreases by 43 lines; total code decreases by 29 lines including the new regression test.

## Evidence

- Blacksmith Testbox tbx_01kypvb88ggv12ps4de9mtzp1j: all 108 focused tests passed across 10 files, including authenticated Gateway-to-paired-node end-to-end inference, Gemma onboarding, model discovery, SSRF, cancellation, stalled DNS preflight, shared inference deadlines, model downloads, and strict inspection response cleanup.
- The same Testbox passed the complete pnpm check:changed gate: production and test type checks, formatting, lint, zero dead exports, plugin boundaries, dependency guards, and zero runtime import cycles.
- Independent structured Codex autoreview: clean; patch is correct.
- AI-assisted; reviewed against the guarded-fetch source, provider HTTP contract, current main, and adjacent setup and inference tests.