### PR TITLE
fix(test): restore isolated memory manager suites

### DIFF
--- a/extensions/memory-core/src/memory/test-runtime-mocks.ts
+++ b/extensions/memory-core/src/memory/test-runtime-mocks.ts
@@ -1,5 +1,19 @@
 // Memory Core plugin module implements test runtime mocks behavior.
-import { vi } from "vitest";
+import { afterAll, beforeAll, vi } from "vitest";
+import {
+  configureMemoryCoreDreamingStateForTests,
+  resetMemoryCoreDreamingStateForTests,
+} from "../test-helpers.js";
+
+// Memory indexing reads flush provenance from plugin state. Manager tests use
+// this shared setup instead of booting the full plugin runtime.
+beforeAll(async () => {
+  await configureMemoryCoreDreamingStateForTests();
+});
+
+afterAll(() => {
+  resetMemoryCoreDreamingStateForTests();
+});
 
 // Unit tests: avoid importing the real chokidar implementation (native fsevents, etc.).
 function createWatcherMock() {


### PR DESCRIPTION
Related: #115818

## What Problem This Solves

Resolves a problem where isolated memory-core manager suites failed whenever they indexed workspace memory after provenance reads were added. The full extension-memory gate reported 93 cascading failures with `memory-core dreaming SQLite state store is not configured` instead of exercising the manager behavior under test.

## Why This Change Was Made

The shared memory manager test bootstrap now configures and resets the plugin-owned dreaming state store around each isolated test file. This keeps the setup inside the owning plugin, preserves Vitest isolation, and leaves the production fail-fast contract and generic extension setup unchanged.

The regression was made visible by #115818 (`20668eed037cba31f4435334958b3e16f164c77e`), which made ordinary workspace-memory indexing consult flush provenance.

## User Impact

No runtime behavior changes. Maintainers regain reliable isolated memory manager tests and meaningful full extension-memory validation.

AI-assisted; the implementation, ownership boundary, and proof were reviewed before submission.

## Evidence

- Blacksmith Testbox `tbx_01kypwk4xtw3gj9d2w0bcx7axj`: 6 relevant files, 137 tests passed on Linux Node 24.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30450572850
- `pnpm format:check extensions/memory-core/src/memory/test-runtime-mocks.ts`: passed.
- `git diff --check`: passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings; TruffleHog clean.
