### PR TITLE
fix(xai): classify 'run out of credits' and 'need a Grok subscription' as billing

### DIFF
--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -54,7 +54,7 @@ import {
 const PROVIDER_ID = "xai";
 
 const XAI_CREDIT_OR_SPENDING_LIMIT_RE =
-  /\b(?:used all available credits|monthly spending limit|purchase more credits|raise your spending limit)\b/i;
+  /\b(?:used all available credits|monthly spending limit|purchase more credits|raise your spending limit|run out of credits|need a Grok subscription)\b/i;
 const XAI_RATE_LIMIT_RE = /\b(?:rate limit exceeded|too many requests)\b/i;
 
 const loadCodeExecutionModule = createLazyRuntimeModule(() => import("./code-execution.js"));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where xAI credit-exhaustion 403 responses containing "You have run out of credits" or "need a Grok subscription" are misclassified as `auth` instead of `billing`. This causes the xAI profile to only receive the normal auth cooldown, so subsequent requests retry xAI and fail again before falling back to the configured alternative provider.

## Why This Change Was Made

The xAI failover classifier (`classifyXaiFailoverReason` in `extensions/xai/index.ts`) already recognizes four credit/subscription-exhaustion phrases via the `XAI_CREDIT_OR_SPENDING_LIMIT_RE` regex, but was missing two additional phrases that xAI returns in its 403 responses: `run out of credits` and `need a Grok subscription`. This fix adds both phrases to the existing regex so they are correctly classified as `billing`, triggering the billing disabled window and skipping the exhausted profile until the window expires.

Generic errors keep their existing classifications — 403 with no matching phrase still returns `undefined` (→ `auth`), and 429 still returns `rate_limit`. The change is scoped to xAI's provider-local classifier; non-xAI providers are unaffected.

## User Impact

Users with xAI as their primary provider and a fallback provider configured will no longer see repeated xAI auth failures when their credits/subscription is exhausted. The exhausted xAI profile is now correctly skipped during the billing disabled window, and the fallback provider is used immediately instead of retrying xAI first.

## Evidence

### Inline verification — 14/14 test cases

```text
$ node -e "..."
PASS "xAI 403: You have run out of credits" -> billing
PASS "xAI 403: You need a Grok subscription to use this model" -> billing
PASS "xAI 403: need a Grok subscription" -> billing
PASS "xAI 403: run out of credits" -> billing
PASS "you have used all available credits" -> billing       (regression)
PASS "monthly spending limit exceeded" -> billing           (regression)
PASS "purchase more credits to continue" -> billing         (regression)
PASS "raise your spending limit" -> billing                 (regression)
PASS "rate limit exceeded, retry in 20s" -> rate_limit
PASS "too many requests, slow down" -> rate_limit
PASS "403 Forbidden" -> undefined                           (generic 403 stays auth)
PASS "404 Not Found" -> undefined
PASS "500 Internal Server Error" -> undefined
PASS "429 Too Many Requests" -> rate_limit

14/14 passed
```

### Code diff

```diff
 const XAI_CREDIT_OR_SPENDING_LIMIT_RE =
-  /\b(?:used all available credits|monthly spending limit|purchase more credits|raise your spending limit)\b/i;
+  /\b(?:used all available credits|monthly spending limit|purchase more credits|raise your spending limit|run out of credits|need a Grok subscription)\b/i;
```

### Real test suite run (after-fix, local)

```text
$ vitest run extensions/xai/index.test.ts

 Test Files  1 passed (1)
      Tests  44 passed (44)
   Duration  40.66s
```

### Direct regex verification against the compiled source

```text
$ node /tmp/xai-regex-check.mjs   # extracts XAI_CREDIT_OR_SPENDING_LIMIT_RE from extensions/xai/index.ts
PASS "you have run out of credits" -> true (expected true)
PASS "You need a Grok subscription to continue" -> true (expected true)
PASS "You've used all available credits" -> true (expected true)
PASS "monthly spending limit reached" -> true (expected true)
PASS "rate limit exceeded" -> false (expected false)
PASS "random server error" -> false (expected false)

6/6 passed
```

The two new phrases (`run out of credits`, `need a Grok subscription`) match the billing regex; generic errors and rate limits still do not, so they keep their existing classifications.

### CI (all green)

```
CI: 48 checks passed, 0 failures
  - check-lint: passed
  - checks-node-changed: passed
  - ci-gate: passed
  - check-guards: passed
  - check-dependencies: passed
  - check-npm-lock: passed
```

[AI-assisted]