### PR TITLE
fix(test): accept consumed video generation timeout budgets

### DIFF
--- a/extensions/alibaba/video-generation-provider.test.ts
+++ b/extensions/alibaba/video-generation-provider.test.ts
@@ -139,7 +139,7 @@ describe("alibaba video generation provider", () => {
         method: "GET",
         headers: expect.any(Headers),
       }),
-      120_000,
+      expect.any(Number),
       fetch,
       {
         ssrfPolicy: { allowPrivateNetwork: true },
@@ -150,7 +150,7 @@ describe("alibaba video generation provider", () => {
       2,
       "https://example.com/out.mp4",
       { method: "GET" },
-      120_000,
+      expect.any(Number),
       fetch,
       {
         ssrfPolicy: { allowPrivateNetwork: true },

--- a/extensions/qwen/video-generation-provider.test.ts
+++ b/extensions/qwen/video-generation-provider.test.ts
@@ -175,7 +175,7 @@ describe("qwen video generation provider", () => {
         method: "GET",
         headers: expect.any(Headers),
       }),
-      120_000,
+      expect.any(Number),
       fetch,
       {
         ssrfPolicy: { allowPrivateNetwork: true },
@@ -186,7 +186,7 @@ describe("qwen video generation provider", () => {
       2,
       "https://example.com/out.mp4",
       { method: "GET" },
-      120_000,
+      expect.any(Number),
       fetch,
       {
         ssrfPolicy: { allowPrivateNetwork: true },

--- a/src/plugin-sdk/test-helpers/dashscope-video-provider.ts
+++ b/src/plugin-sdk/test-helpers/dashscope-video-provider.ts
@@ -81,19 +81,14 @@ export function expectDashscopeVideoTaskPoll(
   params: {
     baseUrl?: string;
     taskId?: string;
-    timeoutMs?: number;
   } = {},
 ): void {
-  const {
-    baseUrl = "https://dashscope-intl.aliyuncs.com",
-    taskId = "task-1",
-    timeoutMs = 120_000,
-  } = params;
+  const { baseUrl = "https://dashscope-intl.aliyuncs.com", taskId = "task-1" } = params;
   expect(fetchWithTimeoutMock).toHaveBeenNthCalledWith(
     1,
     `${baseUrl}/api/v1/tasks/${taskId}`,
     expect.objectContaining({ method: "GET" }),
-    timeoutMs,
+    expect.any(Number),
     fetch,
   );
 }


### PR DESCRIPTION
Related: #115696

## What Problem This Solves

Fixes an issue where video-generation provider policy tests could fail after the shared operation deadline consumed a millisecond before polling or downloading a result.

## Why This Change Was Made

The provider tests now verify that a numeric remaining timeout budget is forwarded instead of requiring the untouched initial 120-second budget. The shared helper no longer exposes an unused exact-timeout override. Production behavior and the stable initial request-timeout assertion are unchanged.

## User Impact

No user-visible runtime change. The test suite now accepts the intended decreasing deadline budget without weakening request-policy, SSRF, header, or provider-default coverage.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30451673277
- 62 focused tests passed across Alibaba, Qwen, shared deadline, and DashScope compatibility suites
- `oxfmt --check` passed for all three changed files
- `git diff --check` passed
- Fresh autoreview: clean; TruffleHog: clean

AI-assisted: yes. The diff and deadline ownership path were reviewed directly.