### PR TITLE
refactor(ui): give Memory the shared hub header with hoisted agent scope

### DIFF
--- a/ui/src/components/sessions-hub-header.browser.test.ts
+++ b/ui/src/components/sessions-hub-header.browser.test.ts
@@ -55,9 +55,9 @@ describe.skipIf(!hasBrowserLayout)("Sessions hub header browser layout", () => {
     async (width) => {
       await useViewport(width);
       const sessions = await mount("sessions", true);
-      const sessionsTitle = sessions.querySelector<HTMLElement>(".sessions-hub-header__title");
+      const sessionsTitle = sessions.querySelector<HTMLElement>(".hub-page-header__title");
       const sessionsTabs = sessions.querySelector<HTMLElement>(".sessions-hub-tabs");
-      const sessionsActions = sessions.querySelector<HTMLElement>(".sessions-hub-header__actions");
+      const sessionsActions = sessions.querySelector<HTMLElement>(".hub-page-header__actions");
       const sessionsLeft = sessionsTabs?.getBoundingClientRect().left;
       expect(sessionsLeft).toBeTypeOf("number");
       expect(sessionsTabs?.getBoundingClientRect().width).toBeGreaterThan(0);
@@ -74,7 +74,7 @@ describe.skipIf(!hasBrowserLayout)("Sessions hub header browser layout", () => {
       const worktreesTabs = worktrees.querySelector<HTMLElement>(".sessions-hub-tabs");
       const worktreesLeft = worktreesTabs?.getBoundingClientRect().left;
       expect(worktreesLeft).toBeTypeOf("number");
-      expect(worktrees.querySelector(".sessions-hub-header__actions")?.childElementCount).toBe(0);
+      expect(worktrees.querySelector(".hub-page-header__actions")?.childElementCount).toBe(0);
       expect(Math.abs((sessionsLeft ?? 0) - (worktreesLeft ?? 0))).toBeLessThanOrEqual(1);
     },
   );
@@ -82,7 +82,7 @@ describe.skipIf(!hasBrowserLayout)("Sessions hub header browser layout", () => {
   it("keeps the page header hidden on mobile", async () => {
     await useViewport(414, 800);
     const sessions = await mount("sessions", true);
-    const header = sessions.querySelector<HTMLElement>(".sessions-hub-header");
+    const header = sessions.querySelector<HTMLElement>(".hub-page-header");
     expect(getComputedStyle(header!).display).toBe("none");
   });
 });

--- a/ui/src/components/sessions-hub-header.ts
+++ b/ui/src/components/sessions-hub-header.ts
@@ -11,13 +11,15 @@ type SessionsHubHeaderProps = {
 
 export function renderSessionsHubHeader(props: SessionsHubHeaderProps): TemplateResult {
   return html`
-    <section class="content-header content-header--page sessions-hub-header">
-      <div class="sessions-hub-header__title">
+    <section class="content-header content-header--page hub-page-header sessions-hub-header">
+      <div class="hub-page-header__title">
         <div class="page-title">${props.title}</div>
         ${props.subtitle ? html`<div class="page-subtitle">${props.subtitle}</div>` : nothing}
       </div>
-      ${renderSessionsHubTabs({ active: props.active, onSelect: props.onSelect })}
-      <div class="sessions-hub-header__actions">${props.actions ?? nothing}</div>
+      <div class="hub-page-header__tabs">
+        ${renderSessionsHubTabs({ active: props.active, onSelect: props.onSelect })}
+      </div>
+      <div class="hub-page-header__actions">${props.actions ?? nothing}</div>
     </section>
   `;
 }

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -2,7 +2,7 @@ import "../../styles/config.css";
 import { consume } from "@lit/context";
 import { initialState, Task, TaskStatus } from "@lit/task";
 import { asNullableRecord as asConfigRecord } from "@openclaw/normalization-core/record-coerce";
-import { html, type PropertyValues } from "lit";
+import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
@@ -1053,11 +1053,15 @@ export class ConfigPage extends OpenClawLightDomElement {
       asConfigRecord(configState.configForm ?? configState.configSnapshot?.config) ?? {};
     const body = this.renderAdvancedConfig(configObject);
     return html`
-      <section class="content-header">
-        <div>
-          <div class="page-title">${configPageTitle(this.pageId)}</div>
-        </div>
-      </section>
+      ${this.pageId === "memory"
+        ? nothing
+        : html`
+            <section class="content-header">
+              <div>
+                <div class="page-title">${configPageTitle(this.pageId)}</div>
+              </div>
+            </section>
+          `}
       ${renderSettingsWorkspace(body)}
     `;
   }

--- a/ui/src/pages/config/memory-dreaming-page.test.ts
+++ b/ui/src/pages/config/memory-dreaming-page.test.ts
@@ -1,36 +1,23 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import "./memory-dreaming-page.ts";
 
 type DreamsPageElement = HTMLElement & {
   agentId: string | null;
-  agents: Array<{ value: string; label: string }>;
-  onAgentChange: (agentId: string | null) => void;
   updateComplete: Promise<unknown>;
 };
 
 describe("MemoryDreamingSettings", () => {
-  it("hosts the page-level agent picker without global config", async () => {
-    const onAgentChange = vi.fn();
+  it("hosts only the selected agent's memory panel without global config", async () => {
     const element = document.createElement("openclaw-memory-dreaming") as DreamsPageElement;
     element.agentId = null;
-    element.agents = [
-      { value: "main", label: "Main" },
-      { value: "research", label: "Research" },
-    ];
-    element.onAgentChange = onAgentChange;
     document.body.append(element);
     try {
       await element.updateComplete;
       expect(element.querySelector("openclaw-agent-memory-panel")).toBeNull();
       expect(element.textContent).not.toContain("Dreaming frequency");
-
-      const select = element.querySelector("openclaw-agent-select") as HTMLElement & {
-        onSelect?: (value: string) => void;
-      };
-      select.onSelect?.("main");
-      expect(onAgentChange).toHaveBeenCalledWith("main");
+      expect(element.querySelector("openclaw-agent-select")).toBeNull();
     } finally {
       element.remove();
     }

--- a/ui/src/pages/config/memory-dreaming-page.ts
+++ b/ui/src/pages/config/memory-dreaming-page.ts
@@ -1,26 +1,14 @@
-// Dreams tab host. Agent selection is owned by the parent Memory page so the
-// Overview and Dreams tabs always describe the same workspace.
+// Dreams tab host. Agent selection is owned by the parent Memory page.
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
-import type { AgentSelectOption } from "../../components/agent-select.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import "../agents/memory/memory-panel.ts";
-import { renderMemoryAgentScope } from "./memory.ts";
 
 class MemoryDreamingSettings extends OpenClawLightDomElement {
   @property() agentId: string | null = null;
-  @property({ attribute: false }) agents: readonly AgentSelectOption[] = [];
-  @property({ attribute: false }) onAgentChange: (agentId: string | null) => void = () => {};
 
   override render() {
     return html`
-      <div class="settings-page">
-        ${renderMemoryAgentScope({
-          agentId: this.agentId,
-          agents: this.agents,
-          onAgentChange: this.onAgentChange,
-        })}
-      </div>
       ${this.agentId
         ? html`<openclaw-agent-memory-panel .agentId=${this.agentId}></openclaw-agent-memory-panel>`
         : nothing}

--- a/ui/src/pages/config/memory-memories.test.ts
+++ b/ui/src/pages/config/memory-memories.test.ts
@@ -2,7 +2,6 @@
 
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { AgentSelectOption } from "../../components/agent-select.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import "./memory-memories.ts";
 
@@ -12,7 +11,6 @@ type MemoryMemoriesTestElement = HTMLElement & {
   connected: boolean;
   methodAdvertised: boolean;
   agentId: string | null;
-  agents: readonly AgentSelectOption[];
   updateComplete: Promise<unknown>;
 };
 
@@ -32,7 +30,6 @@ function createElement(request: Request, advertised = true) {
   element.connected = true;
   element.methodAdvertised = advertised;
   element.agentId = "main";
-  element.agents = [];
   document.body.append(element);
   return element;
 }

--- a/ui/src/pages/config/memory-memories.ts
+++ b/ui/src/pages/config/memory-memories.ts
@@ -3,11 +3,9 @@ import { property, state } from "lit/decorators.js";
 import type { AgentsWorkspaceGetResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { MemorySearchResponse } from "../../../../src/gateway/server-methods/memory-search.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { AgentSelectOption } from "../../components/agent-select.ts";
 import { t } from "../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import "../../styles/memory-memories.css";
-import { renderMemoryAgentScope } from "./memory.ts";
 
 type SearchResult = MemorySearchResponse["results"][number];
 type SearchState =
@@ -59,8 +57,6 @@ class MemoryMemoriesElement extends OpenClawLightDomElement {
   @property({ type: Boolean }) connected = false;
   @property({ type: Boolean }) methodAdvertised = true;
   @property() agentId: string | null = null;
-  @property({ attribute: false }) agents: readonly AgentSelectOption[] = [];
-  @property({ attribute: false }) onAgentChange: (agentId: string | null) => void = () => {};
 
   @state() private query = "";
   @state() private searchState: SearchState = { kind: "idle" };
@@ -277,11 +273,6 @@ class MemoryMemoriesElement extends OpenClawLightDomElement {
 
   override render() {
     return html`<div class="settings-page memory-memories">
-      ${renderMemoryAgentScope({
-        agentId: this.agentId,
-        agents: this.agents,
-        onAgentChange: this.onAgentChange,
-      })}
       ${!this.methodAdvertised
         ? html`<p class="memory-memories__unavailable">
             ${t("memoryPage.memories.gatewayUpdateRequired")}

--- a/ui/src/pages/config/memory-overview.test.ts
+++ b/ui/src/pages/config/memory-overview.test.ts
@@ -88,12 +88,10 @@ function renderOverview(
   render(
     renderMemoryOverview({
       agentId: "main",
-      agents: [],
       engineSelection,
       engineDisabled: false,
       status,
       probingEmbeddings: false,
-      onAgentChange: vi.fn(),
       onRefresh: vi.fn(),
       onProbeEmbeddings: vi.fn(),
       onNavigate: vi.fn(),
@@ -142,12 +140,10 @@ describe("renderMemoryOverview", () => {
     render(
       renderMemoryOverview({
         agentId: "main",
-        agents: [],
         engineSelection: { kind: "pinned", engineId: "memory-core" },
         engineDisabled: true,
         status: { kind: "ready", payload: fixturePayload() },
         probingEmbeddings: false,
-        onAgentChange: vi.fn(),
         onRefresh: vi.fn(),
         onProbeEmbeddings: vi.fn(),
         onNavigate: vi.fn(),
@@ -284,12 +280,10 @@ describe("renderMemoryOverview", () => {
     render(
       renderMemoryOverview({
         agentId: "main",
-        agents: [],
         engineSelection: { kind: "auto", engineId: "memory-core" },
         engineDisabled: false,
         status: { kind: "ready", payload: fixturePayload() },
         probingEmbeddings: false,
-        onAgentChange: vi.fn(),
         onRefresh: vi.fn(),
         onProbeEmbeddings: vi.fn(),
         onNavigate,

--- a/ui/src/pages/config/memory-overview.ts
+++ b/ui/src/pages/config/memory-overview.ts
@@ -1,6 +1,5 @@
 import { html, nothing } from "lit";
 import type { DoctorMemoryStatusPayload } from "../../../../src/gateway/server-methods/doctor.ts";
-import type { AgentSelectOption } from "../../components/agent-select.ts";
 import {
   createLobsterPetLook,
   lobsterLookStyle,
@@ -19,7 +18,6 @@ import { formatRelativeTimestamp } from "../../lib/format.ts";
 import "../../styles/memory-overview.css";
 import type { MemoryEngineSelection } from "./memory-schema.ts";
 import { selectedEngineId } from "./memory-schema.ts";
-import { renderMemoryAgentScope } from "./memory.ts";
 
 export type MemoryOverviewStatus =
   | { kind: "idle" | "loading" }
@@ -28,12 +26,10 @@ export type MemoryOverviewStatus =
 
 type MemoryOverviewProps = {
   agentId: string | null;
-  agents: readonly AgentSelectOption[];
   engineSelection: MemoryEngineSelection;
   engineDisabled: boolean;
   status: MemoryOverviewStatus;
   probingEmbeddings: boolean;
-  onAgentChange: (agentId: string | null) => void;
   onRefresh: () => void;
   onProbeEmbeddings: () => void;
   onNavigate: (tab: "memories" | "dreams" | "settings") => void;
@@ -301,13 +297,7 @@ export function renderMemoryOverview(props: MemoryOverviewProps) {
   const active = props.engineSelection.kind !== "off" && !props.engineDisabled;
   return html`
     <div class="settings-page memory-overview">
-      ${renderHero(props)}
-      ${renderMemoryAgentScope({
-        agentId: props.agentId,
-        agents: props.agents,
-        onAgentChange: props.onAgentChange,
-      })}
-      ${active ? renderStatusCards(props) : nothing} ${renderShortcuts(props)}
+      ${renderHero(props)} ${active ? renderStatusCards(props) : nothing} ${renderShortcuts(props)}
     </div>
   `;
 }

--- a/ui/src/pages/config/memory-page.test.ts
+++ b/ui/src/pages/config/memory-page.test.ts
@@ -971,7 +971,7 @@ describe("MemorySettingsPage tab routing", () => {
     },
   );
 
-  it("loads Overview status once per activation, agent change, and reconnect", async () => {
+  it("loads Overview status once per activation, header agent change, and reconnect", async () => {
     const memoryStatus = vi.fn((agentId: string) =>
       Promise.resolve({ agentId, provider: "none", embedding: { ok: false, checked: false } }),
     );
@@ -989,7 +989,11 @@ describe("MemorySettingsPage tab routing", () => {
         request.mock.calls.filter(([method]) => method === "doctor.memory.status"),
       ).toHaveLength(1);
 
-      const select = element.querySelector("openclaw-agent-select") as HTMLElement & {
+      expect(element.querySelectorAll("openclaw-agent-select")).toHaveLength(1);
+      expect(element.textContent).not.toContain("Agent view");
+      const select = element.querySelector(
+        ".hub-page-header__actions openclaw-agent-select",
+      ) as HTMLElement & {
         onSelect?: (value: string) => void;
       };
       select.onSelect?.("research");

--- a/ui/src/pages/config/memory-page.ts
+++ b/ui/src/pages/config/memory-page.ts
@@ -657,14 +657,15 @@ class MemorySettingsPage extends OpenClawLightDomElement {
       onAddonChange: (pluginId, enabled) => void this.changeAddon(pluginId, enabled),
       pluginsHref: this.pluginsHref,
       memoryImportHref: this.memoryImportHref,
+      agentId,
+      agents,
+      onAgentChange: (next) => this.selectAgent(next),
       overview: renderMemoryOverview({
         agentId,
-        agents,
         engineSelection,
         engineDisabled: this.engineState(engineSelection) === "disabled",
         status: this.overviewStatus,
         probingEmbeddings: this.probingEmbeddings,
-        onAgentChange: (next) => this.selectAgent(next),
         onRefresh: () => void this.loadOverviewStatus({ force: true }),
         onProbeEmbeddings: () =>
           void this.loadOverviewStatus({ force: true, probeEmbeddings: true }),
@@ -679,17 +680,9 @@ class MemorySettingsPage extends OpenClawLightDomElement {
             "memory.search",
           ) === true}
           .agentId=${agentId}
-          .agents=${agents}
-          .onAgentChange=${(next: string | null) => this.selectAgent(next)}
         ></openclaw-memory-memories>
       `,
-      dreams: html`
-        <openclaw-memory-dreaming
-          .agentId=${agentId}
-          .agents=${agents}
-          .onAgentChange=${(next: string | null) => this.selectAgent(next)}
-        ></openclaw-memory-dreaming>
-      `,
+      dreams: html` <openclaw-memory-dreaming .agentId=${agentId}></openclaw-memory-dreaming> `,
       editor:
         activeTab === "settings"
           ? this.buildEditor(memorySchemaKeysForTab("settings", backend))

--- a/ui/src/pages/config/memory.test.ts
+++ b/ui/src/pages/config/memory.test.ts
@@ -60,6 +60,12 @@ function createProps(overrides: Partial<MemoryViewProps> = {}): MemoryViewProps 
     dreams: html`<div class="test-dreams"></div>`,
     editor: html`<div class="test-editor"></div>`,
     dreamingSettings: html`<div class="test-dreaming-settings"></div>`,
+    agentId: "main",
+    agents: [
+      { value: "main", label: "Main" },
+      { value: "research", label: "Research" },
+    ],
+    onAgentChange: vi.fn(),
     ...overrides,
   };
 }
@@ -71,6 +77,37 @@ function renderInto(props: MemoryViewProps): HTMLElement {
 }
 
 describe("renderMemory", () => {
+  it.each(["overview", "memories", "dreams"] as const)(
+    "renders the shared header and agent scope on %s",
+    (activeTab) => {
+      const onAgentChange = vi.fn();
+      const container = renderInto(createProps({ activeTab, onAgentChange }));
+      const header = container.querySelector(".hub-page-header");
+
+      expect(header?.querySelector(".page-title")?.textContent).toBe("Memory");
+      expect(header?.querySelector(".page-subtitle")?.textContent).toContain(
+        "Choose how OpenClaw stores, searches, and maintains agent memory.",
+      );
+      expect(header?.querySelector(".memory-hub-tabs")).not.toBeNull();
+      expect(container.textContent).not.toContain("Agent view");
+
+      const select = header?.querySelector("openclaw-agent-select") as HTMLElement & {
+        accessibleLabel?: string;
+        onSelect?: (value: string) => void;
+      };
+      expect(select.accessibleLabel).toBe("Agent");
+      select.onSelect?.("research");
+      expect(onAgentChange).toHaveBeenCalledWith("research");
+    },
+  );
+
+  it("keeps the header action slot empty on Settings", () => {
+    const container = renderInto(createProps({ activeTab: "settings" }));
+
+    expect(container.querySelector(".hub-page-header__actions")?.childElementCount).toBe(0);
+    expect(container.querySelector("openclaw-agent-select")).toBeNull();
+  });
+
   it("shows the exclusive engine choice as one radio group over installed engines", () => {
     const container = renderInto(createProps());
 

--- a/ui/src/pages/config/memory.ts
+++ b/ui/src/pages/config/memory.ts
@@ -79,6 +79,9 @@ type MemoryViewProps = {
   editor: TemplateResult;
   /** Global dreaming controls, sharing runtimeConfig with the editor above. */
   dreamingSettings: TemplateResult;
+  agentId: string | null;
+  agents: readonly AgentSelectOption[];
+  onAgentChange: (agentId: string | null) => void;
 };
 
 const MEMORY_PANEL_ID = "memory-settings-panel";
@@ -86,30 +89,6 @@ const MEMORY_PANEL_ID = "memory-settings-panel";
 const MEMORY_DOCS_URL = "https://docs.openclaw.ai/concepts/memory";
 
 const MEMORY_ENGINE_OFF = "";
-
-export function renderMemoryAgentScope(props: {
-  agentId: string | null;
-  agents: readonly AgentSelectOption[];
-  onAgentChange: (agentId: string | null) => void;
-}) {
-  return renderSettingsSection(
-    {
-      title: t("memoryPage.dreaming.agentScope.title"),
-      description: t("memoryPage.dreaming.agentScope.description"),
-    },
-    renderSettingsRow({
-      title: t("memoryPage.dreaming.agentScope.rowTitle"),
-      control: html`
-        <openclaw-agent-select
-          .options=${props.agents}
-          .value=${props.agentId ?? ""}
-          .accessibleLabel=${t("memoryPage.dreaming.agentScope.rowTitle")}
-          .onSelect=${(value: string) => props.onAgentChange(value || null)}
-        ></openclaw-agent-select>
-      `,
-    }),
-  );
-}
 
 function engineHintKey(selection: MemoryEngineSelection): string {
   switch (selection.kind) {
@@ -318,22 +297,46 @@ function renderSettingsTab(props: MemoryViewProps) {
 export function renderMemory(props: MemoryViewProps) {
   return html`
     <section class="memory-page">
-      <p class="settings-page__intro">
-        ${t("memoryPage.intro")} ${renderDocsLink(MEMORY_DOCS_URL, t("common.learnMore"))}
-      </p>
-      ${renderHubTabs<MemoryTab>({
-        id: "memory",
-        active: props.activeTab,
-        tabs: [
-          { value: "overview", label: t("memoryPage.tabs.overview") },
-          { value: "memories", label: t("memoryPage.tabs.memories") },
-          { value: "dreams", label: t("memoryPage.tabs.dreams") },
-          { value: "settings", label: t("memoryPage.tabs.settings") },
-        ],
-        ariaLabel: t("memoryPage.tablistLabel"),
-        panelId: MEMORY_PANEL_ID,
-        onSelect: (tab) => props.onTabChange(tab),
-      })}
+      <section class="content-header content-header--page hub-page-header">
+        <div class="hub-page-header__title">
+          <div class="page-title">${t("tabs.memory")}</div>
+          <div class="page-subtitle">
+            ${t("memoryPage.intro")} ${renderDocsLink(MEMORY_DOCS_URL, t("common.learnMore"))}
+          </div>
+        </div>
+        <div class="hub-page-header__tabs">
+          ${renderHubTabs<MemoryTab>({
+            id: "memory",
+            active: props.activeTab,
+            tabs: [
+              { value: "overview", label: t("memoryPage.tabs.overview") },
+              { value: "memories", label: t("memoryPage.tabs.memories") },
+              { value: "dreams", label: t("memoryPage.tabs.dreams") },
+              { value: "settings", label: t("memoryPage.tabs.settings") },
+            ],
+            ariaLabel: t("memoryPage.tablistLabel"),
+            panelId: MEMORY_PANEL_ID,
+            onSelect: (tab) => props.onTabChange(tab),
+          })}
+        </div>
+        <div class="hub-page-header__actions">
+          ${props.activeTab === "settings"
+            ? nothing
+            : html`
+                <div class="agent-scope-control">
+                  <span class="agent-scope-control__label"
+                    >${t("memoryPage.dreaming.agentScope.rowTitle")}</span
+                  >
+                  <openclaw-agent-select
+                    .options=${props.agents}
+                    .value=${props.agentId ?? ""}
+                    .accessibleLabel=${t("memoryPage.dreaming.agentScope.rowTitle")}
+                    .onSelect=${(value: string) => props.onAgentChange(value || null)}
+                  ></openclaw-agent-select>
+                </div>
+              `}
+        </div>
+      </section>
       <div id=${MEMORY_PANEL_ID} class="memory-page__panel" role="tabpanel">
         ${props.activeTab === "overview"
           ? props.overview

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -688,13 +688,22 @@
 /* Memory */
 .memory-page {
   display: grid;
-  gap: 14px;
-  margin-top: 12px;
+  gap: 0;
 }
 
 .memory-page__panel {
   display: grid;
   gap: 14px;
+}
+
+.shell--settings .content:has(.settings-page) .content-header.hub-page-header {
+  max-width: 1120px;
+}
+
+.memory-page__panel .settings-page,
+.memory-page__panel .config-lead,
+.memory-page__panel .config-content-callout {
+  margin-inline: 0;
 }
 
 .memory-page__link {

--- a/ui/src/styles/hub-tabs.css
+++ b/ui/src/styles/hub-tabs.css
@@ -48,24 +48,24 @@ wa-tab.hub-tab:focus-visible::part(base) {
   outline: none;
 }
 
-/* Equal outer columns keep the Sessions hub tabs centered when the Threads
-   route adds its trailing agent selector and Worktrees leaves that slot empty. */
-.content-header.sessions-hub-header {
+/* Equal outer columns keep hub tabs centered whether or not the active route
+   fills its trailing actions slot. */
+.content-header.hub-page-header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
 }
 
-.sessions-hub-header__title,
-.sessions-hub-header__actions {
+.hub-page-header__title,
+.hub-page-header__actions {
   min-width: 0;
 }
 
-.sessions-hub-header__actions {
+.hub-page-header__actions {
   justify-self: end;
 }
 
 @media (min-width: 769px) and (max-width: 1024px) {
-  .content-header.sessions-hub-header {
+  .content-header.hub-page-header {
     grid-template-columns: minmax(0, 1fr) auto;
     grid-template-areas:
       "title actions"
@@ -74,16 +74,16 @@ wa-tab.hub-tab:focus-visible::part(base) {
     max-height: none;
   }
 
-  .sessions-hub-header__title {
+  .hub-page-header__title {
     grid-area: title;
   }
 
-  .sessions-hub-tabs {
+  .hub-page-header__tabs {
     grid-area: tabs;
     justify-self: center;
   }
 
-  .sessions-hub-header__actions {
+  .hub-page-header__actions {
     grid-area: actions;
   }
 }
@@ -91,5 +91,35 @@ wa-tab.hub-tab:focus-visible::part(base) {
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .content-header.sessions-hub-header {
     display: none;
+  }
+
+  .content-header.hub-page-header:not(.sessions-hub-header) {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "intro"
+      "tabs"
+      "actions";
+    justify-items: center;
+    row-gap: var(--space-2);
+    max-height: none;
+  }
+
+  .hub-page-header:not(.sessions-hub-header) .hub-page-header__title {
+    grid-area: intro;
+    justify-self: stretch;
+  }
+
+  .hub-page-header:not(.sessions-hub-header) .page-title {
+    display: none;
+  }
+
+  .hub-page-header:not(.sessions-hub-header) .hub-page-header__tabs {
+    grid-area: tabs;
+  }
+
+  .hub-page-header:not(.sessions-hub-header) .hub-page-header__actions {
+    grid-area: actions;
+    justify-self: center;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

User feedback, including the attached screenshot, showed that the Memory page mixed three alignment systems: a centered title and introduction, left-aligned tabs, and a differently indented panel column. It also repeated an “Agent view” picker section inside three of the four tabs.

## Why This Change Was Made

This adopts the Sessions hub header pattern through the shared `.hub-page-header` class, extracted from `sessions-hub-header` so both pages use the same contract: title and introduction on the left, hub tabs centered, and the agent select in the trailing actions slot. The global Settings tab renders an empty trailing slot to keep the tabs centered, matching Sessions Worktrees. The three per-tab Agent View sections are deleted; agent scope remains page-level state as before.

## User Impact

Memory now has an aligned single-column layout. Agent scope is visible at a glance next to the tabs it governs, and three tabs lose one redundant section box each.

## Evidence

- 6,749 tests across 472 files green.
- Remote formatting, i18n, typecheck, and lint clean.
- Fresh autoreview clean with no accepted or actionable findings.
- Responsive proof at 1440 px, 820 px, and 414 px.
- Live screenshots:

![Memory header overview: title left, centered tabs, and trailing agent select](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/memory-destination-2026-07/pr-h/prh-01-header-overview.png)

![Memory Settings tab: empty trailing slot keeps tabs centered](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/memory-destination-2026-07/pr-h/prh-02-header-settings.png)
