### PR TITLE
feat(skills): review interrupted deep turns in experience review

### DIFF
--- a/docs/tools/self-learning.md
+++ b/docs/tools/self-learning.md
@@ -42,13 +42,19 @@ write bounded and recoverable.
 
 ### Experience review
 
-After substantial successful work, OpenClaw can run one isolated background
-review to find a reusable recovery technique or a stable procedure that would
-remove at least two future model or tool round trips.
+After substantial work, OpenClaw can run one isolated background review to find
+a reusable recovery technique or a stable procedure that would remove at least
+two future model or tool round trips. Deep turns the user interrupted qualify
+too: the wrong path and its correction are exactly the evidence worth keeping.
+The reviewer is told when a turn was interrupted and captures only procedures
+that visibly worked before the stop. Turns that ended in a provider or prompt
+error never schedule a review; that failure is transient environment noise, and
+a review on the same model would likely hit it again.
 
 Experience review starts only when all of these conditions hold:
 
-- the foreground turn completed successfully;
+- the foreground turn completed or was interrupted, but did not end in a
+  provider or prompt error;
 - the current turn used at least 10 model iterations;
 - the run was an eligible foreground conversation, not cron, heartbeat, memory,
   overflow, hook, subagent, or review work;
@@ -171,7 +177,7 @@ applying them.
 
 Deterministic correction capture does not make an extra model call. Experience
 review adds one bounded model run on the configured provider only after a
-substantial successful turn, not after every message. The review can make more
+substantial turn, not after every message. The review can make more
 than one provider request while it inspects or drafts its single proposal.
 
 The reviewer receives only the current turn beginning with its most recent user
@@ -256,8 +262,8 @@ Check the following:
 
 1. `skills.workshop.autonomous.mode` is `propose` or `auto` in the active Gateway
    config.
-2. The correction uses durable language, or the successful turn reached at least
-   10 model iterations.
+2. The correction uses durable language, or the turn reached at least 10 model
+   iterations without ending in a provider or prompt error.
 3. The conversation is eligible foreground work.
 4. The runtime reported the resolved model and actual `skill_workshop`
    availability.

--- a/src/skills/workshop/experience-review-prompt.ts
+++ b/src/skills/workshop/experience-review-prompt.ts
@@ -7,6 +7,7 @@ type ExperienceReviewPromptCandidate = {
   ctx: { runId?: string };
   transcript: string;
   modelIterations: number;
+  turnAborted?: boolean;
 };
 
 function safeJson(value: unknown): string {
@@ -73,7 +74,7 @@ export function buildSkillExperienceReviewPrompt(
   candidate: ExperienceReviewPromptCandidate,
 ): string {
   return [
-    "Review this completed agent turn after the foreground run has ended.",
+    "Review this agent turn after the foreground run has ended.",
     "",
     "This is a conservative learning pass. Use skill_workshop to mutate a proposal only when at least one high-value condition has concrete evidence in the trajectory:",
     "- the model struggled, took a wrong path, needed correction, repeated failures, or found a reusable recovery technique; or",
@@ -87,7 +88,14 @@ export function buildSkillExperienceReviewPrompt(
     "",
     "Use list/inspect before mutation when useful. Prefer revising a relevant pending proposal. Otherwise create one broad skill. Make at most one create/revise call. The tool cannot update a live skill or apply, reject, or quarantine a proposal. If nothing clears the bar, make no mutation and answer NOTHING_TO_LEARN.",
     "",
-    `Completed run: ${candidate.ctx.runId ?? "unknown"}`,
+    candidate.turnAborted === true
+      ? `Interrupted run (stopped before completion): ${candidate.ctx.runId ?? "unknown"}`
+      : `Completed run: ${candidate.ctx.runId ?? "unknown"}`,
+    ...(candidate.turnAborted === true
+      ? [
+          "The trajectory may end mid-task. Only capture procedures that visibly worked before the interruption.",
+        ]
+      : []),
     `Model iterations in turn: ${candidate.modelIterations}`,
     "",
     "Trajectory:",

--- a/src/skills/workshop/experience-review.live.test.ts
+++ b/src/skills/workshop/experience-review.live.test.ts
@@ -17,7 +17,11 @@ const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
 let workspaceDir = "";
 
-function candidate(runId: string, messages: unknown[]): ExperienceReviewCandidate {
+function candidate(
+  runId: string,
+  messages: unknown[],
+  options: { turnAborted?: boolean } = {},
+): ExperienceReviewCandidate {
   const modelId = process.env.OPENCLAW_LIVE_SKILL_EXPERIENCE_MODEL ?? "gpt-5.6-luna";
   return {
     ctx: {
@@ -54,6 +58,7 @@ function candidate(runId: string, messages: unknown[]): ExperienceReviewCandidat
         },
       },
       agents: {
+        entries: { main: { default: true } },
         defaults: {
           model: { primary: `openai/${modelId}` },
           models: {
@@ -68,6 +73,7 @@ function candidate(runId: string, messages: unknown[]): ExperienceReviewCandidat
     },
     transcript: formatSkillExperienceReviewTranscript(messages),
     modelIterations: 10,
+    ...(options.turnAborted === undefined ? {} : { turnAborted: options.turnAborted }),
   };
 }
 
@@ -174,5 +180,56 @@ describeLive("skill experience review live OpenAI eval", () => {
     });
     const afterNegative = await listSkillProposals({ workspaceDir });
     expect(afterNegative.proposals).toEqual(afterPositive.proposals);
-  }, 180_000);
+
+    const interruptedMessages = [
+      {
+        role: "user",
+        content: "Publish the package. The registry keeps rejecting the token.",
+      },
+      { role: "assistant", content: [{ type: "toolCall", name: "publish", arguments: {} }] },
+      { role: "toolResult", toolName: "publish", isError: true, content: "401 invalid token" },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "publish", arguments: { retry: true } }],
+      },
+      { role: "toolResult", toolName: "publish", isError: true, content: "401 invalid token" },
+      { role: "assistant", content: "Retrying does not help; the stored scope must be wrong." },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "exec", arguments: { command: "registry whoami" } }],
+      },
+      {
+        role: "toolResult",
+        toolName: "exec",
+        content: "authenticated to legacy-registry.example, expected registry.example",
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "exec",
+            arguments: { command: "registry login --host registry.example" },
+          },
+        ],
+      },
+      { role: "toolResult", toolName: "exec", content: "login ok" },
+      { role: "assistant", content: [{ type: "toolCall", name: "publish", arguments: {} }] },
+      { role: "toolResult", toolName: "publish", content: "published 1.2.3" },
+      { role: "assistant", content: "Publish verified. Moving on to the release notes." },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "read", arguments: { path: "CHANGELOG.md" } }],
+      },
+    ];
+
+    const interruptedCandidate = candidate("live-interrupted", interruptedMessages, {
+      turnAborted: true,
+    });
+    await runSkillExperienceReview(interruptedCandidate, {
+      getCurrentConfig: () => interruptedCandidate.config ?? {},
+    });
+    const afterInterrupted = await listSkillProposals({ workspaceDir });
+    expect(afterInterrupted.proposals.length).toBeGreaterThan(afterNegative.proposals.length);
+  }, 300_000);
 });

--- a/src/skills/workshop/experience-review.live.test.ts
+++ b/src/skills/workshop/experience-review.live.test.ts
@@ -70,6 +70,10 @@ function candidate(
         },
       },
       skills: { workshop: { autonomous: { mode: "propose" } } },
+      // Only the OpenAI provider plugin is needed. A cold unrestricted load
+      // compiles all bundled extensions and runs provider discovery inside the
+      // review lane, which can exceed the lane's no-progress watchdog.
+      plugins: { allow: ["openai"] },
     },
     transcript: formatSkillExperienceReviewTranscript(messages),
     modelIterations: 10,
@@ -79,12 +83,20 @@ function candidate(
 
 describeLive("skill experience review live OpenAI eval", () => {
   beforeAll(async () => {
+    // Full home isolation: the embedded review resolves the shared-main auth
+    // store via HOME, and a real ~/.openclaw with pending doctor migration
+    // must never leak into (or fail) this live run.
     testState = await createOpenClawTestState({
-      layout: "state-only",
+      layout: "home",
       prefix: "openclaw-live-skill-review-state-",
     });
     workspaceDir = await tempDirs.make("openclaw-live-skill-review-workspace-");
-  });
+    // Warm the plugin runtime outside the review lane: the first load compiles
+    // extensions synchronously and can exceed the lane's no-progress watchdog
+    // on a loaded machine.
+    const { ensureRuntimePluginsLoaded } = await import("../../agents/runtime-plugins.js");
+    ensureRuntimePluginsLoaded({ config: candidate("warmup", []).config ?? {}, workspaceDir });
+  }, 600_000);
 
   afterAll(async () => {
     await testState.cleanup();

--- a/src/skills/workshop/experience-review.test.ts
+++ b/src/skills/workshop/experience-review.test.ts
@@ -13,6 +13,7 @@ function completedRun(
   options: {
     iterations?: number;
     success?: boolean;
+    error?: string;
     sessionKey?: string;
     runId?: string;
     mode?: "off" | "propose" | "auto";
@@ -26,6 +27,7 @@ function completedRun(
   return {
     event: {
       success: options.success ?? true,
+      ...(options.error === undefined ? {} : { error: options.error }),
       messages: [
         { role: "user", content: "Diagnose and repair the workflow." },
         ...Array.from({ length: iterations }, (_, index) => ({
@@ -186,7 +188,7 @@ describe("skill experience review scheduler", () => {
     ).resolves.toBeDefined();
   });
 
-  it("skips short, failed, disabled, metadata-missing, restricted, and internal runs", async () => {
+  it("skips short, errored, disabled, metadata-missing, restricted, and internal runs", async () => {
     vi.useFakeTimers();
     const runReview = vi.fn().mockResolvedValue(undefined);
     const scheduler = createSkillExperienceReviewScheduler({
@@ -195,7 +197,7 @@ describe("skill experience review scheduler", () => {
     });
 
     scheduler.schedule(completedRun({ iterations: 9 }));
-    scheduler.schedule(completedRun({ success: false }));
+    scheduler.schedule(completedRun({ success: false, error: "provider failed" }));
     scheduler.schedule(completedRun({ compacted: true, sessionKey: "agent:main:compacted" }));
     scheduler.schedule(completedRun({ mode: "off" }));
     scheduler.schedule(
@@ -253,7 +255,7 @@ describe("skill experience review scheduler", () => {
     scheduler.clear();
   });
 
-  it("discards a queued candidate when the same run later fails", async () => {
+  it("discards a queued candidate when the same run later errors", async () => {
     vi.useFakeTimers();
     const runReview = vi.fn().mockResolvedValue(undefined);
     const scheduler = createSkillExperienceReviewScheduler({
@@ -262,9 +264,46 @@ describe("skill experience review scheduler", () => {
     });
 
     scheduler.schedule(completedRun({ runId: "retried-run" }));
-    scheduler.schedule(completedRun({ runId: "retried-run", success: false }));
+    scheduler.schedule(completedRun({ runId: "retried-run", success: false, error: "boom" }));
     await vi.runAllTimersAsync();
     expect(runReview).not.toHaveBeenCalled();
+    scheduler.clear();
+  });
+
+  it("reviews a deep user-aborted turn and marks the candidate interrupted", async () => {
+    vi.useFakeTimers();
+    const runReview = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createSkillExperienceReviewScheduler({
+      isSystemActive: () => false,
+      runReview,
+    });
+
+    scheduler.schedule(completedRun({ success: false }));
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(runReview).toHaveBeenCalledTimes(1);
+    expect(runReview.mock.calls[0]?.[0]).toMatchObject({
+      modelIterations: 10,
+      turnAborted: true,
+    });
+    scheduler.clear();
+  });
+
+  it("replaces queued evidence when the same run is later aborted deep in the turn", async () => {
+    vi.useFakeTimers();
+    const runReview = vi.fn().mockResolvedValue(undefined);
+    const scheduler = createSkillExperienceReviewScheduler({
+      isSystemActive: () => false,
+      runReview,
+    });
+
+    scheduler.schedule(completedRun({ runId: "retried-run", iterations: 10 }));
+    scheduler.schedule(completedRun({ runId: "retried-run", iterations: 12, success: false }));
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(runReview).toHaveBeenCalledTimes(1);
+    expect(runReview.mock.calls[0]?.[0]).toMatchObject({
+      modelIterations: 12,
+      turnAborted: true,
+    });
     scheduler.clear();
   });
 
@@ -373,6 +412,21 @@ describe("skill experience review scheduler", () => {
     expect(prompt).toContain("cannot update a live skill");
     expect(prompt).toContain("NOTHING_TO_LEARN");
     expect(prompt).toContain("[tool call: exec]");
+    expect(prompt).toContain("Completed run: run-1");
+    expect(prompt).not.toContain("Interrupted run");
+  });
+
+  it("flags interrupted turns in the review prompt", () => {
+    const params = completedRun({ success: false });
+    const prompt = buildSkillExperienceReviewPrompt({
+      ctx: params.ctx,
+      transcript: formatSkillExperienceReviewTranscript(params.event.messages),
+      modelIterations: 10,
+      turnAborted: true,
+    });
+
+    expect(prompt).toContain("Interrupted run (stopped before completion): run-1");
+    expect(prompt).toContain("Only capture procedures that visibly worked");
   });
 });
 

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -31,6 +31,7 @@ const log = createSubsystemLogger("skills/workshop");
 type ExperienceReviewAgentEndEvent = {
   messages: unknown[];
   success: boolean;
+  error?: string;
 };
 
 type ExperienceReviewAgentContext = {
@@ -73,6 +74,7 @@ export type ExperienceReviewCandidate = {
   config?: OpenClawConfig;
   transcript: string;
   modelIterations: number;
+  turnAborted?: boolean;
 };
 
 type ExperienceReviewRunDeps = {
@@ -276,9 +278,14 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
         return;
       }
       const existing = pendingBySession.get(sessionKey);
+      // Errored completions (provider/prompt failures) are transient environment
+      // noise, not learnable evidence, and a same-model review would likely hit
+      // the same failure. User aborts carry no error and stay eligible: deep
+      // interrupted turns are exactly where corrective evidence lives.
+      const errored = typeof params.event.error === "string" && params.event.error.trim() !== "";
       if (
         existing &&
-        !params.event.success &&
+        errored &&
         params.ctx.runId?.trim() &&
         params.ctx.runId === existing.candidate.ctx.runId
       ) {
@@ -292,6 +299,9 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
       // eligibility only decides whether that completion can replace the evidence.
       if (existing) {
         arm(sessionKey, existing, EXPERIENCE_REVIEW_IDLE_MS);
+      }
+      if (errored) {
+        return;
       }
       if (resolveSkillWorkshopConfig(params.config).autonomous.mode === "off") {
         return;
@@ -314,7 +324,7 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
           : Number.isSafeInteger(reportedModelIterations) && reportedModelIterations >= 0
             ? reportedModelIterations
             : 0;
-      if (params.event.success && modelIterations >= EXPERIENCE_REVIEW_MIN_MODEL_ITERATIONS) {
+      if (modelIterations >= EXPERIENCE_REVIEW_MIN_MODEL_ITERATIONS) {
         if (!existing && pendingBySession.size >= EXPERIENCE_REVIEW_MAX_PENDING) {
           const oldest = pendingBySession.entries().next().value as
             | [string, PendingExperienceReview]
@@ -357,6 +367,7 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
           ...(params.config ? { config: params.config } : {}),
           transcript: formatSkillExperienceReviewTranscript(turnMessages),
           modelIterations,
+          turnAborted: !params.event.success,
         };
         const pending = existing ?? { candidate, generation: 0 };
         pending.candidate = candidate;


### PR DESCRIPTION
## What Problem This Solves

Experience review (the autonomous self-learning pass that runs after a deep foreground turn) only scheduled for successful turns. Deep turns the user interrupted — often exactly the turns where the model took a wrong path, was corrected, or found a recovery — never got a learning review. Follow-up to #115576.

## Why This Change Was Made

The success-only gate conflated two very different failure classes:

- **User aborts** carry no `error` on the agent-end event. The trajectory is real evidence; the review prompt already values "took a wrong path, needed correction". These now schedule a review when they meet the existing ≥10-model-iteration depth bar.
- **Provider/prompt errors** carry `error`. They are transient environment noise (the review prompt itself says to skip such content), and a same-model review scheduled off a broken provider would likely fail the same way. These stay excluded, and a same-run error still withdraws a queued candidate.

The reviewer is told when a turn was interrupted ("Interrupted run (stopped before completion)") and instructed to capture only procedures that visibly worked before the stop, keeping the authoring standard of never preserving standalone does-not-work claims.

## User Impact

With default `skills.workshop.autonomous.mode: "auto"`, corrective evidence from deep interrupted turns now becomes skill proposals/skills instead of being dropped. No config surface changes. Docs updated (`docs/tools/self-learning.md`).

## Evidence

- Unit: `node scripts/run-vitest.mjs src/skills/workshop/experience-review.test.ts src/skills/workshop/experience-review-auto-apply.test.ts` — 22 passed, incl. new cases: aborted deep turn schedules with `turnAborted`, errored run withdraws same-run candidate, interrupted prompt wording.
- Live: `OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW=1 node scripts/test-live.mjs -- src/skills/workshop/experience-review.live.test.ts` green against real OpenAI (`gpt-5.6-luna`): positive case proposes, routine work abstains, and the new interrupted-turn case captures a visible recovery (registry re-login) from an aborted trajectory.
- The live test needed three environment fixes that are part of this PR: an agent roster (`agents.entries`) required since run-workspace resolution hardening, full `home` layout isolation (a real `~/.openclaw` pending doctor migration leaked into the run and failed it), and plugin-runtime warmup outside the review lane (a cold synchronous extension compile blocked the event loop past the lane's 150s no-progress watchdog on a loaded machine). Runner-hardening follow-up for the last two is tracked separately.
- Gates: `node scripts/check-changed.mjs` green (local fallback; Blacksmith backend unreachable at the time). Autoreview (Codex `gpt-5.6-sol`): clean, no findings (0.92).
