### PR TITLE
fix(gateway): cap stuck pending restart recovery

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -614,6 +614,76 @@ describe("channel-health-monitor", () => {
     monitor.stop();
   });
 
+  it("caps repeated pending recovery after the handoff continuation", async () => {
+    const account: Partial<ChannelAccountSnapshot> = disconnectedAccount(Date.now() - 300_000);
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: account,
+        },
+      },
+      {
+        startChannel: vi.fn(async () => {
+          account.running = false;
+          account.connected = false;
+          account.restartPending = true;
+          account.reconnectAttempts = 0;
+        }),
+      },
+    );
+    const monitor = startDefaultMonitor(manager, {
+      checkIntervalMs: 1_000,
+      cooldownCycles: 1,
+      maxRestartsPerHour: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
+
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+    monitor.stop();
+  });
+
+  it("counts cold pending recovery when no handoff slot exists", async () => {
+    const account: Partial<ChannelAccountSnapshot> = {
+      ...disconnectedAccount(Date.now() - 300_000),
+      running: false,
+      restartPending: true,
+      reconnectAttempts: 0,
+    };
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: account,
+        },
+      },
+      {
+        startChannel: vi.fn(async () => {
+          account.running = false;
+          account.connected = false;
+          account.restartPending = true;
+          account.reconnectAttempts = 0;
+        }),
+      },
+    );
+    const monitor = startDefaultMonitor(manager, {
+      checkIntervalMs: 1_000,
+      cooldownCycles: 1,
+      maxRestartsPerHour: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
+
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
+    monitor.stop();
+  });
+
   it("defers to the channel supervisor while its own auto-restart is scheduled", async () => {
     let autoRestartScheduled = true;
     const manager = createSnapshotManager(

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -48,6 +48,7 @@ function snapshotWith(
 }
 
 const DEFAULT_CHECK_INTERVAL_MS = 5_000;
+const ONE_HOUR_MS = 60 * 60_000;
 
 function createSnapshotManager(
   accounts: Record<string, Record<string, Partial<ChannelAccountSnapshot>>>,
@@ -645,6 +646,53 @@ describe("channel-health-monitor", () => {
 
     await vi.advanceTimersByTimeAsync(5_000);
     expect(manager.startChannel).toHaveBeenCalledTimes(2);
+    monitor.stop();
+  });
+
+  it("allows each new restart record one pending recovery continuation", async () => {
+    const account: Partial<ChannelAccountSnapshot> = disconnectedAccount(Date.now() - 300_000);
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: account,
+        },
+      },
+      {
+        startChannel: vi.fn(async () => {
+          account.running = false;
+          account.connected = false;
+          account.restartPending = true;
+          account.reconnectAttempts = 0;
+        }),
+      },
+    );
+    const monitor = startDefaultMonitor(manager, {
+      cooldownCycles: 1,
+      maxRestartsPerHour: 1,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+
+    account.running = true;
+    account.connected = true;
+    account.restartPending = false;
+    account.reconnectAttempts = undefined;
+    account.lastStartAt = Date.now();
+    vi.setSystemTime(Date.now() + ONE_HOUR_MS + 1);
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+
+    account.running = true;
+    account.connected = false;
+    account.restartPending = false;
+    account.reconnectAttempts = undefined;
+    account.lastStartAt = Date.now() - 300_000;
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(3);
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(4);
     monitor.stop();
   });
 

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -51,6 +51,7 @@ export type ChannelHealthMonitor = {
 type RestartRecord = {
   lastRestartAt: number;
   restartsThisHour: { at: number }[];
+  pendingRestartContinuationConsumed: boolean;
 };
 
 function resolveTimingPolicy(
@@ -160,6 +161,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           const record = restartRecords.get(key) ?? {
             lastRestartAt: 0,
             restartsThisHour: [],
+            pendingRestartContinuationConsumed: false,
           };
 
           const continuingPendingRestart =
@@ -175,7 +177,17 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           }
 
           pruneOldRestarts(record, now);
-          if (!continuingPendingRestart && record.restartsThisHour.length >= maxRestartsPerHour) {
+          // A timed-out stop already consumed a restart slot. Allow exactly one
+          // pending continuation to finish that handoff; further stuck-pending
+          // passes must use the ordinary hourly budget.
+          const usePendingRestartContinuation =
+            continuingPendingRestart &&
+            record.restartsThisHour.length > 0 &&
+            !record.pendingRestartContinuationConsumed;
+          if (
+            !usePendingRestartContinuation &&
+            record.restartsThisHour.length >= maxRestartsPerHour
+          ) {
             log.warn?.(
               `[${channelId}:${accountId}] health-monitor: hit ${maxRestartsPerHour} restarts/hour limit, skipping`,
             );
@@ -186,9 +198,13 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
           log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
 
-          if (!continuingPendingRestart) {
+          if (usePendingRestartContinuation) {
+            record.pendingRestartContinuationConsumed = true;
+            restartRecords.set(key, record);
+          } else {
             record.lastRestartAt = now;
             record.restartsThisHour.push({ at: now });
+            record.pendingRestartContinuationConsumed = continuingPendingRestart;
             restartRecords.set(key, record);
           }
 

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -204,6 +204,8 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           } else {
             record.lastRestartAt = now;
             record.restartsThisHour.push({ at: now });
+            // Ordinary restarts begin a fresh recovery record; cold pending
+            // snapshots still mark their continuation as already consumed.
             record.pendingRestartContinuationConsumed = continuingPendingRestart;
             restartRecords.set(key, record);
           }


### PR DESCRIPTION
Closes #105189

## What Problem This Solves

Fixes an issue where an unhealthy channel that remains stuck in pending restart recovery can keep triggering health-monitor restart attempts after the initial handoff, bypassing the configured hourly restart safety budget and causing repeated manager churn/log spam.

## Why This Change Was Made

The health monitor already needs one immediate pending continuation after a timed-out stop so that the same recovery can finish without waiting for cooldown. This change records whether that continuation was already consumed for the current restart record, then sends any further stuck-pending checks through the normal `maxRestartsPerHour` guard. Each ordinary new restart record resets the continuation marker so a later timed-out recovery still gets its own one-pass handoff. A cold `restartPending=true` snapshot with no recorded handoff does not get a free continuation.

I kept this owner-local to the Gateway health monitor and did not change the public config contract or channel adapter APIs. Open PR #105415 covers the same issue but is currently marked `status: needs proof`; this PR is the smaller strict-boundary variant focused on one handoff continuation plus cap enforcement.

## User Impact

Operators keep the pending-recovery handoff needed after a stop timeout, while permanently stuck pending channels stop repeatedly thrashing the channel manager beyond the safety guard.

## Evidence

Final head: `fc72eff3d8652bafd6c4e6672737aa8275e86c11`

Real behavior proof:

- Standalone Node runtime harness imported the production `startChannelHealthMonitor` from `src/gateway/channel-health-monitor.ts`, drove the Gateway health-monitor scheduler through a disconnected account, a pending recovery continuation, hourly-cap enforcement, a healthy window after the hourly budget expired, and a second restart record. It passed with this output:

```text
[health-monitor] [discord:default] health-monitor: restarting (reason: disconnected)
[health-monitor] [discord:default] health-monitor: restarting (reason: stopped)
[health-monitor] [discord:default] health-monitor: hit 1 restarts/hour limit, skipping
[health-monitor] [discord:default] health-monitor: restarting (reason: disconnected)
[health-monitor] [discord:default] health-monitor: restarting (reason: stopped)
[health-monitor] [discord:default] health-monitor: hit 1 restarts/hour limit, skipping
phase1Starts=2 healthyWindowStarts=2 secondRecordStarts=3 secondContinuationStarts=4 cappedStarts=4
```

Focused tests:

- `node scripts/run-vitest.mjs src/gateway/channel-health-monitor.test.ts` - passed, 1 file / 51 tests. Covers the pending handoff continuation, repeated stuck-pending cap, cold pending state with no existing handoff slot, and a later restart record receiving its own continuation after the hourly budget window expires.
- `node scripts/run-vitest.mjs src/gateway/server-channels.test.ts` - passed, 1 file / 80 tests. Confirms the adjacent stop-timeout / `restartPending` Gateway source path remains compatible.

Supporting checks:

- Targeted format check for `src/gateway/channel-health-monitor.ts` and `src/gateway/channel-health-monitor.test.ts` - passed.
- `git diff --check` - passed.
- Changed-file secret scan for the two touched Gateway files - passed, 0 verified or unknown secrets.

Proof boundary:

- This proof exercises the production Gateway health monitor and adjacent Gateway channel supervisor path with an in-memory ChannelManager runtime harness. It does not claim live external provider delivery or a real third-party channel account session.