### PR TITLE
fix(agents): keep streamed pre-tool assistant text in claude-cli final output

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -494,6 +494,109 @@ describe("parseCliJsonl", () => {
     });
   });
 
+  it("keeps streamed pre-tool text over the final-message result in transcript reparses", () => {
+    const result = parseCliJsonl(
+      [
+        JSON.stringify({ type: "init", session_id: "session-reparse" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Marker caribou-lampion-473 explanation." },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", id: "tool-1", name: "session_status" },
+          },
+        }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_stop" } }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "TEST DONE" },
+          },
+        }),
+        JSON.stringify({ type: "result", session_id: "session-reparse", result: "TEST DONE" }),
+      ].join("\n"),
+      {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      "local-cli",
+    );
+
+    expect(result).toEqual({
+      text: "Marker caribou-lampion-473 explanation.\n\nTEST DONE",
+      sessionId: "session-reparse",
+      usage: undefined,
+    });
+  });
+
+  it("continues transcript reparses past an interim result", () => {
+    const result = parseCliJsonl(
+      [
+        JSON.stringify({ type: "init", session_id: "session-interim-reparse" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Interim answer." },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-interim-reparse",
+          result: "Interim answer.",
+        }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Pre-tool follow-up." },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", id: "tool-2", name: "session_status" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "DONE" },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-interim-reparse",
+          result: "DONE",
+        }),
+      ].join("\n"),
+      {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      "local-cli",
+    );
+
+    expect(result?.text).toBe("Interim answer.\nPre-tool follow-up.\n\nDONE");
+  });
+
   it.each(OPENAI_COMPATIBLE_CLI_USAGE_CASES)(
     "normalizes $name from CLI JSONL output",
     ({ raw, normalized }) => {
@@ -1402,6 +1505,508 @@ describe("createCliJsonlStreamingParser", () => {
     expect(parser.getOutput()).toEqual({
       text: "hello world",
       sessionId: "session-stream",
+      usage: undefined,
+    });
+  });
+
+  it("keeps streamed pre-tool text when the result envelope carries only the final message", () => {
+    const deltas: Array<{ text: string; delta?: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: (delta) => deltas.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-tool-split" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Marker caribou-lampion-473 explanation." },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", id: "tool-1", name: "session_status" },
+          },
+        }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_stop" } }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "TEST DONE" },
+          },
+        }),
+        JSON.stringify({ type: "result", session_id: "session-tool-split", result: "TEST DONE" }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()).toEqual({
+      text: "Marker caribou-lampion-473 explanation.\n\nTEST DONE",
+      sessionId: "session-tool-split",
+      usage: undefined,
+    });
+    // Cumulative text must stay reconstructible from deltas for preview streams.
+    expect(deltas.map((entry) => entry.delta).join("")).toBe(
+      "Marker caribou-lampion-473 explanation.\n\nTEST DONE",
+    );
+    expect(deltas.at(-1)?.text).toBe("Marker caribou-lampion-473 explanation.\n\nTEST DONE");
+  });
+
+  it("keeps pre-tool text when text, tool_use, and text share one assistant message", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-single-message" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Marker caribou-lampion-473 explanation." },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", id: "tool-1", name: "session_status" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "TEST DONE" },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-single-message",
+          result: "TEST DONE",
+        }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()?.text).toBe("Marker caribou-lampion-473 explanation.\n\nTEST DONE");
+  });
+
+  it("keeps pre-tool text when a toolless closer message follows a tool-using message", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-closer" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Pre-tool analysis." },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", id: "tool-1", name: "session_status" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Post-tool summary." },
+          },
+        }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_stop" } }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "DONE" },
+          },
+        }),
+        JSON.stringify({ type: "result", session_id: "session-closer", result: "DONE" }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()?.text).toBe("Pre-tool analysis.\n\nPost-tool summary.\n\nDONE");
+  });
+
+  it("judges post-interim-result segments on their own stream state", () => {
+    const deltas: Array<{ text: string; delta?: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: (delta) => deltas.push(delta),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-interim" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Interim answer." },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-interim",
+          result: "Interim answer.",
+        }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Pre-tool follow-up." },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", id: "tool-2", name: "session_status" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "DONE" },
+          },
+        }),
+        JSON.stringify({ type: "result", session_id: "session-interim", result: "DONE" }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()?.text).toBe("Interim answer.\nPre-tool follow-up.\n\nDONE");
+    // Preview snapshots stay cumulative across the interim result.
+    expect(deltas.at(-1)?.text).toBe("Interim answer.\n\nPre-tool follow-up.\n\nDONE");
+    expect(deltas.map((entry) => entry.delta).join("")).toBe(
+      "Interim answer.\n\nPre-tool follow-up.\n\nDONE",
+    );
+  });
+
+  it("does not duplicate existing newlines at message boundaries", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-newlines" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Pre-tool explanation.\n\n" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", id: "tool-1", name: "session_status" },
+          },
+        }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "TEST DONE" },
+          },
+        }),
+        JSON.stringify({ type: "result", session_id: "session-newlines", result: "TEST DONE" }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()?.text).toBe("Pre-tool explanation.\n\nTEST DONE");
+  });
+
+  it("keeps a later tool split's pre-tool text after an earlier ordinary boundary", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-mixed" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Superseded draft." },
+          },
+        }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_stop" } }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Important pre-tool text." },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", id: "tool-1", name: "session_status" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "DONE" },
+          },
+        }),
+        JSON.stringify({ type: "result", session_id: "session-mixed", result: "DONE" }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()?.text).toBe("Important pre-tool text.\n\nDONE");
+  });
+
+  it("drops an earlier draft when a fresh message starts with a tool call", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-tool-first" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Superseded draft." },
+          },
+        }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_stop" } }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", id: "tool-1", name: "session_status" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Fresh answer." },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-tool-first",
+          result: "Fresh answer.",
+        }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()?.text).toBe("Fresh answer.");
+  });
+
+  it("defers to the result envelope across message boundaries without a tool split", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-draft" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Superseded draft." },
+          },
+        }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_stop" } }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Final answer." },
+          },
+        }),
+        JSON.stringify({ type: "result", session_id: "session-draft", result: "Final answer." }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()?.text).toBe("Final answer.");
+  });
+
+  it("defers to the result envelope on a suffix match inside a single message", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-suffix" }),
+        JSON.stringify({ type: "stream_event", event: { type: "message_start" } }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "discarded draft authoritative result" },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-suffix",
+          result: "authoritative result",
+        }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()).toEqual({
+      text: "authoritative result",
+      sessionId: "session-suffix",
+      usage: undefined,
+    });
+  });
+
+  it("prefers the result envelope when streamed text diverges from it", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "local-cli",
+        output: "jsonl",
+        jsonlDialect: "claude-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "local-cli",
+      onAssistantDelta: () => {},
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-diverged" }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "draft wording" },
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "session-diverged",
+          result: "authoritative result",
+        }),
+        "",
+      ].join("\n"),
+    );
+    parser.finish();
+
+    expect(parser.getOutput()).toEqual({
+      text: "authoritative result",
+      sessionId: "session-diverged",
       usage: undefined,
     });
   });

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -681,6 +681,35 @@ function parseClaudeCliJsonlResult(params: {
   return null;
 }
 
+// A tool-split turn streams pre-tool answer text the terminal result envelope
+// omits (it carries only the final message). Prefer the fuller streamed text so
+// final delivery cannot erase already-streamed content (#106760). The result
+// must match the complete final streamed message: a bare suffix match inside a
+// single divergent message defers to the authoritative result envelope.
+function preferStreamedClaudeTextOverResult(params: {
+  streamedText: string;
+  finalMessageText: string;
+  resultText: string;
+}): boolean {
+  return (
+    Boolean(params.resultText) &&
+    params.streamedText !== params.resultText &&
+    params.finalMessageText === params.resultText
+  );
+}
+
+// Assistant-message boundaries join with one blank line; add only the missing
+// newlines so messages that already end or start with breaks are not
+// double-spaced.
+function missingMessageBoundarySeparator(previousText: string, nextDelta: string): string {
+  if (!previousText) {
+    return "";
+  }
+  const trailing = previousText.match(/\n*$/u)?.[0].length ?? 0;
+  const leading = nextDelta.match(/^\n*/u)?.[0].length ?? 0;
+  return "\n".repeat(Math.max(0, 2 - trailing - leading));
+}
+
 function parseClaudeCliStreamingDelta(params: {
   backend: CliBackendConfig;
   providerId: string;
@@ -1225,6 +1254,15 @@ export function createCliJsonlStreamingParser(params: {
   let assistantText = "";
   let customThinkingText = "";
   let pendingClaudeText = "";
+  let pendingMessageSeparator = false;
+  let currentMessageStart = 0;
+  let segmentStart = 0;
+  // Streamed text from this offset on is still a candidate to outrank the
+  // result envelope; every non-tool boundary or interim result restarts it.
+  let preserveFrom = 0;
+  let sawToolUseSinceText = false;
+  let currentMessageHadToolUse = false;
+  let previousMessageHadToolUse = false;
   let sessionId: string | undefined;
   let resumeCheckpointId: string | undefined;
   let usage: CliUsage | undefined;
@@ -1457,7 +1495,16 @@ export function createCliJsonlStreamingParser(params: {
         return;
       }
       // Empty terminal result can follow already-streamed text; keep that text.
-      const nextText = (result.text || assistantText.trim() || texts.join("\n").trim()).trim();
+      const streamedText = assistantText.slice(segmentStart).trim();
+      const preservedCandidate = assistantText.slice(preserveFrom).trim();
+      const keepStreamed = preferStreamedClaudeTextOverResult({
+        streamedText: preservedCandidate,
+        finalMessageText: assistantText.slice(currentMessageStart).trim(),
+        resultText: result.text,
+      });
+      const nextText = (
+        keepStreamed ? preservedCandidate : result.text || streamedText || texts.join("\n").trim()
+      ).trim();
       const previousText = output?.text?.trim() ?? "";
       // Claude Code may emit an interim result while background agents run, then
       // a second result after task-notification. Preserve earlier result text
@@ -1479,6 +1526,15 @@ export function createCliJsonlStreamingParser(params: {
         ...(resumeCheckpointId ? { resumeCheckpointId } : {}),
         ...(diagnosticUsage ? { diagnosticUsage } : {}),
       };
+      // An interim result commits its segment. Rebase boundary state so later
+      // text is judged on its own, while delta snapshots stay cumulative.
+      segmentStart = assistantText.length;
+      currentMessageStart = segmentStart;
+      preserveFrom = segmentStart;
+      pendingMessageSeparator = false;
+      sawToolUseSinceText = false;
+      currentMessageHadToolUse = false;
+      previousMessageHadToolUse = false;
       return;
     }
 
@@ -1507,16 +1563,30 @@ export function createCliJsonlStreamingParser(params: {
       }
     }
 
-    if (classifyClaudeCommentary && parsed.type === "stream_event" && isRecord(parsed.event)) {
+    if (parsed.type === "stream_event" && isRecord(parsed.event)) {
       const evt = parsed.event;
-      if (
+      // Tool-split turns stream as separate assistant messages. Mark the
+      // boundary so accumulated text joins with a paragraph break instead of
+      // gluing the pre-tool text to the next message's first delta.
+      if (evt.type === "message_start") {
+        pendingMessageSeparator = true;
+        previousMessageHadToolUse = currentMessageHadToolUse;
+        currentMessageHadToolUse = false;
+      }
+      const isToolUseBlockStart =
         evt.type === "content_block_start" &&
         isRecord(evt.content_block) &&
-        isClaudeToolUseBlockType(evt.content_block.type)
-      ) {
-        flushPendingClaudeCommentaryText();
-      } else if (evt.type === "content_block_start" || evt.type === "message_stop") {
-        flushPendingClaudeAssistantText();
+        isClaudeToolUseBlockType(evt.content_block.type);
+      if (isToolUseBlockStart) {
+        sawToolUseSinceText = true;
+        currentMessageHadToolUse = true;
+      }
+      if (classifyClaudeCommentary) {
+        if (isToolUseBlockStart) {
+          flushPendingClaudeCommentaryText();
+        } else if (evt.type === "content_block_start" || evt.type === "message_stop") {
+          flushPendingClaudeAssistantText();
+        }
       }
     }
 
@@ -1592,8 +1662,32 @@ export function createCliJsonlStreamingParser(params: {
       pendingClaudeText = `${pendingClaudeText}${delta.delta}`;
       return;
     }
-    assistantText = delta.text;
-    params.onAssistantDelta(delta);
+    // A tool_use block starts a new post-tool segment even inside one assistant
+    // message; only tool-split boundaries may later outrank the result envelope.
+    // A message boundary is a tool split only when the PREVIOUS message used a
+    // tool: a tool-first fresh message must not connect an earlier draft, while
+    // a tool-using message keeps its text connected across its own boundary.
+    const boundaryPending = pendingMessageSeparator || sawToolUseSinceText;
+    const isToolSplitBoundary = pendingMessageSeparator
+      ? previousMessageHadToolUse
+      : sawToolUseSinceText;
+    const separator =
+      boundaryPending && assistantText
+        ? missingMessageBoundarySeparator(assistantText, delta.delta)
+        : "";
+    if (boundaryPending && assistantText) {
+      currentMessageStart = assistantText.length + separator.length;
+      // Text before a non-tool boundary may be a superseded draft; only text
+      // connected to the result through tool splits stays a candidate.
+      if (!isToolSplitBoundary) {
+        preserveFrom = currentMessageStart;
+      }
+    }
+    pendingMessageSeparator = false;
+    sawToolUseSinceText = false;
+    const deltaText = `${separator}${delta.delta}`;
+    assistantText = `${assistantText}${deltaText}`;
+    params.onAssistantDelta({ ...delta, text: assistantText, delta: deltaText });
   };
 
   const flushLines = (flushPartial: boolean) => {
@@ -1718,6 +1812,14 @@ function parseCliJsonl(
   let usage: CliUsage | undefined;
   const texts: string[] = [];
   let streamJsonText = "";
+  let pendingMessageSeparator = false;
+  let currentMessageStart = 0;
+  let segmentStart = 0;
+  let preserveFrom = 0;
+  let sawToolUseSinceText = false;
+  let currentMessageHadToolUse = false;
+  let previousMessageHadToolUse = false;
+  let committedResult: CliOutput | null = null;
   let geminiErrorText: string | undefined;
   let sawGeminiStructuredOutput = false;
   const streamJsonDialect = isStreamJsonDialect({ backend, providerId });
@@ -1768,21 +1870,71 @@ function parseCliJsonl(
         usage,
       });
       if (claudeResult) {
-        if (claudeResult.text || claudeResult.errorText) {
+        if (claudeResult.errorText) {
           return {
             ...claudeResult,
             ...(resumeCheckpointId ? { resumeCheckpointId } : {}),
           };
         }
         // Live sessions reparse the completed JSONL transcript, so preserve
-        // streamed text here as well as in the incremental parser above.
-        return {
+        // streamed text here as well as in the incremental parser above, and
+        // keep scanning: an interim result can be followed by more stream
+        // events and the actual terminal result.
+        const streamedText = streamJsonText.slice(segmentStart).trim();
+        const preservedCandidate = streamJsonText.slice(preserveFrom).trim();
+        const keepStreamed = preferStreamedClaudeTextOverResult({
+          streamedText: preservedCandidate,
+          finalMessageText: streamJsonText.slice(currentMessageStart).trim(),
+          resultText: claudeResult.text,
+        });
+        const nextText = (
+          keepStreamed
+            ? preservedCandidate
+            : claudeResult.text || streamedText || texts.join("\n").trim()
+        ).trim();
+        const previousText = committedResult?.text?.trim() ?? "";
+        let text = nextText;
+        if (
+          previousText &&
+          nextText &&
+          previousText !== nextText &&
+          !nextText.startsWith(previousText)
+        ) {
+          text = `${previousText}\n${nextText}`;
+        } else if (!nextText) {
+          text = previousText;
+        }
+        committedResult = {
           ...claudeResult,
-          text: streamJsonText.trim() || texts.join("\n").trim(),
+          text,
           ...(resumeCheckpointId ? { resumeCheckpointId } : {}),
         };
+        segmentStart = streamJsonText.length;
+        currentMessageStart = segmentStart;
+        preserveFrom = segmentStart;
+        pendingMessageSeparator = false;
+        sawToolUseSinceText = false;
+        currentMessageHadToolUse = false;
+        previousMessageHadToolUse = false;
+        continue;
       }
 
+      if (parsed.type === "stream_event" && isRecord(parsed.event)) {
+        // Same boundary contracts as the incremental parser above.
+        if (parsed.event.type === "message_start") {
+          pendingMessageSeparator = true;
+          previousMessageHadToolUse = currentMessageHadToolUse;
+          currentMessageHadToolUse = false;
+        }
+        if (
+          parsed.event.type === "content_block_start" &&
+          isRecord(parsed.event.content_block) &&
+          isClaudeToolUseBlockType(parsed.event.content_block.type)
+        ) {
+          sawToolUseSinceText = true;
+          currentMessageHadToolUse = true;
+        }
+      }
       const claudeDelta = parseClaudeCliStreamingDelta({
         backend,
         providerId,
@@ -1792,7 +1944,23 @@ function parseCliJsonl(
         usage,
       });
       if (claudeDelta) {
-        streamJsonText = claudeDelta.text;
+        const boundaryPending = pendingMessageSeparator || sawToolUseSinceText;
+        const isToolSplitBoundary = pendingMessageSeparator
+          ? previousMessageHadToolUse
+          : sawToolUseSinceText;
+        const separator =
+          boundaryPending && streamJsonText
+            ? missingMessageBoundarySeparator(streamJsonText, claudeDelta.delta)
+            : "";
+        if (boundaryPending && streamJsonText) {
+          currentMessageStart = streamJsonText.length + separator.length;
+          if (!isToolSplitBoundary) {
+            preserveFrom = currentMessageStart;
+          }
+        }
+        pendingMessageSeparator = false;
+        sawToolUseSinceText = false;
+        streamJsonText = `${streamJsonText}${separator}${claudeDelta.delta}`;
         continue;
       }
 
@@ -1804,6 +1972,9 @@ function parseCliJsonl(
         }
       }
     }
+  }
+  if (committedResult) {
+    return committedResult;
   }
   if (isGeminiStreamJsonDialect({ backend, providerId }) && geminiErrorText) {
     return { text: "", sessionId, usage, errorText: geminiErrorText };


### PR DESCRIPTION
## What Problem This Solves

On the default Telegram/claude-cli path (draft previews, block streaming disabled), an assistant turn shaped `[text, tool_use, text]` visibly streams the pre-tool explanation, then the final render overwrites it with only the post-tool closer. The content survives in session history, but the user-visible message silently loses the explanation — reporter examples include medical explanations replaced by a short "TEST DONE"-style closer.

Fixes #106760.

## Why This Change Was Made

The root cause is upstream of Telegram, in claude-cli output parsing (`src/agents/cli-output.ts`), not in the answer-lane rotation the issue hypothesized. Without commentary classification (the default when block streaming and commentary/preamble bridges are off), every text block streams into the cumulative preview via `onAssistantDelta`, but the terminal `result` envelope — which carries only the final message's text — wins as the final payload. Final delivery then edits the preview down to just the closer. Fixing the parser repairs every channel's durable delivery, not just Telegram's rendering, and matches ClawSweeper's guidance on the issue to solve this with provider-neutral text-segment semantics rather than a Telegram-specific rotation patch.

The rule after this change: streamed text outranks the result envelope only when it is connected to the result through tool splits, judged per committed segment.

- Assistant message boundaries and post-tool blocks join with a paragraph break (only the missing newlines), emitted in-band so delta consumers stay consistent (`text` ≡ concatenation of `delta`s).
- A boundary counts as a tool split when the previous message used a tool (or a `tool_use` block splits one message); non-tool boundaries restart preservation candidacy, so superseded drafts still defer to the authoritative result envelope, including tool-first fresh messages.
- Preservation additionally requires the result text to exactly match the final streamed message — a bare suffix match inside a divergent single message defers to the envelope.
- Interim results (emitted while background agents run) commit their segment: later text is judged on its own, while preview snapshots stay cumulative.
- `parseCliJsonl` (live-session transcript reparses) now continues past interim results with the same merge semantics as the incremental parser instead of returning the interim answer.

Related: #110119 delivers pre-tool blocks durably for the block-streaming-enabled CLI path and is untouched by this change; this PR fixes the block-streaming-disabled default path where that PR intentionally changed nothing.

## User Impact

claude-cli users on any channel receive the full streamed answer — pre-tool explanations included — in the final durable message, matching what they watched stream and what session history records. Message segments are separated by a blank line instead of being glued together.

## Evidence

- 11 new regression tests in `src/agents/cli-output.test.ts` (88 total passing): the reported single-message `[text, tool_use, text]` shape, the two-message tool-split shape, tool-using message followed by a toolless closer, draft superseded across a non-tool boundary, tool-first fresh message after a draft, suffix match inside one divergent message, newline dedup at boundaries, interim-result segmentation with cumulative delta snapshots, and transcript reparses that continue past interim results. The primary regression was verified to fail against the unpatched parser.
- Structured autoreview (Codex, gpt-5.6-sol, high) ran after every change; 7 accepted findings across the cycles were each fixed with an added regression test before this final shape.
- Focused local proof (remote proof backend was unavailable — crabbox binary failed sanity checks — so trusted-source validation ran locally per repo policy): `node scripts/run-vitest.mjs src/agents/cli-output.test.ts` (88 passed), plus `cli-output-error`, `session-history`, `claude-live-session.background-tasks`, and `agent-runner-execution-cli-sessions` consumer suites (all green), `pnpm tsgo:core` and `pnpm tsgo:core:test`, `scripts/run-oxlint.mjs`, and `oxfmt --check` on both files.
- Reporter reconfirmed the bug live on 2026.6.11, 2026.7.1, and 2026.7.1-2 (`0790d9f`) with marker-string repros and offered to test a candidate fix on a live gateway; no live Telegram re-repro was run here — hosted CI covers breadth, and a live claude-cli probe is the known proof gap.

## AI Assistance

Implemented with Claude assistance: source-path analysis, fix, regression tests, and repeated structured autoreview cycles; validation commands as listed above.
