### PR TITLE
fix(auto-reply): deliver ingress-retried messages after their queued run is dropped

### DIFF
--- a/src/auto-reply/reply/queue.dedupe.test.ts
+++ b/src/auto-reply/reply/queue.dedupe.test.ts
@@ -417,6 +417,57 @@ describe("followup queue deduplication", () => {
     clearSessionQueues([key]);
   });
 
+  it("allows re-enqueueing a message compacted into a summary elision before teardown", () => {
+    const key = `test-dedup-elision-retry-${Date.now()}`;
+    const summarizeSettings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 1,
+      dropPolicy: "summarize",
+    };
+    const onAbandoned = vi.fn();
+    const first = createRun({
+      prompt: "first",
+      messageId: "m1",
+      originatingChannel: "line",
+      originatingTo: "group:G1",
+    });
+    first.turnAdoptionLifecycle = { onAdopted: () => {}, onAbandoned };
+    expect(enqueueFollowupRun(key, first, summarizeSettings)).toBe(true);
+
+    // Overflow the cap twice: the first enqueue drops `first` into the summary
+    // sources, the second compacts it into a summary elision. Compaction clones
+    // the run (createOverflowSummaryRetrySource), so from here on completion
+    // sees the clone, not the originally recorded run object.
+    for (const [prompt, messageId] of [
+      ["second", "m2"],
+      ["third", "m3"],
+    ] as const) {
+      expect(
+        enqueueFollowupRun(
+          key,
+          createRun({ prompt, messageId, originatingChannel: "line", originatingTo: "group:G1" }),
+          summarizeSettings,
+        ),
+      ).toBe(true);
+    }
+
+    // Teardown abandons the elided run via its clone; the ingress retry for the
+    // original message id must still be re-admittable.
+    clearSessionQueues([key]);
+    expect(onAbandoned).toHaveBeenCalledTimes(1);
+
+    const retry = createRun({
+      prompt: "first",
+      messageId: "m1",
+      originatingChannel: "line",
+      originatingTo: "group:G1",
+    });
+    retry.turnAdoptionLifecycle = { onAdopted: () => {} };
+    expect(enqueueFollowupRun(key, retry, summarizeSettings)).toBe(true);
+    clearSessionQueues([key]);
+  });
+
   it("still deduplicates redelivery of a message whose queued run was admitted", async () => {
     const key = `test-dedup-admitted-redelivery-${Date.now()}`;
     const onAbandoned = vi.fn();

--- a/src/auto-reply/reply/queue.dedupe.test.ts
+++ b/src/auto-reply/reply/queue.dedupe.test.ts
@@ -1,8 +1,14 @@
 // Tests follow-up queue message-id dedupe and drain scheduling behavior.
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { FollowupRun, QueueSettings } from "./queue.js";
-import { enqueueFollowupRun, scheduleFollowupDrain } from "./queue.js";
+import {
+  admitFollowupRunLifecycle,
+  clearSessionQueues,
+  completeFollowupRunLifecycle,
+  enqueueFollowupRun,
+  scheduleFollowupDrain,
+} from "./queue.js";
 import {
   createDeferred,
   createQueueTestRun as createRun,
@@ -202,7 +208,6 @@ describe("followup queue deduplication", () => {
       import.meta.url,
       "./queue/enqueue.js?scope=dedupe-b",
     );
-    const { clearSessionQueues } = await import("./queue.js");
     const key = `test-dedup-cross-module-${Date.now()}`;
     const { calls, done, runFollowup } = createFollowupCollector();
 
@@ -340,6 +345,102 @@ describe("followup queue deduplication", () => {
       collectSettings,
     );
     expect(second).toBe(true);
+  });
+
+  it("allows re-enqueueing a message whose queued run was abandoned before admission", () => {
+    const key = `test-dedup-abandoned-retry-${Date.now()}`;
+    const onAbandoned = vi.fn();
+    const first = createRun({
+      prompt: "first",
+      messageId: "same-id",
+      originatingChannel: "line",
+      originatingTo: "group:G1",
+    });
+    first.turnAdoptionLifecycle = { onAdopted: () => {}, onAbandoned };
+    expect(enqueueFollowupRun(key, first, collectSettings)).toBe(true);
+
+    // Queue teardown drops the un-admitted run; durable ingress releases the
+    // claim for retry when onAbandoned fires.
+    clearSessionQueues([key]);
+    expect(onAbandoned).toHaveBeenCalledTimes(1);
+
+    // The ingress retry redelivers the same message id on the same route. It
+    // must be admitted again instead of silently rejected as a duplicate.
+    const retry = createRun({
+      prompt: "first",
+      messageId: "same-id",
+      originatingChannel: "line",
+      originatingTo: "group:G1",
+    });
+    retry.turnAdoptionLifecycle = { onAdopted: () => {} };
+    expect(enqueueFollowupRun(key, retry, collectSettings)).toBe(true);
+    clearSessionQueues([key]);
+  });
+
+  it("allows re-enqueueing a message evicted by old-item queue overflow", () => {
+    const key = `test-dedup-evicted-retry-${Date.now()}`;
+    const evictSettings: QueueSettings = { mode: "collect", cap: 1, dropPolicy: "old" };
+    const onAbandoned = vi.fn();
+    const first = createRun({
+      prompt: "first",
+      messageId: "m1",
+      originatingChannel: "line",
+      originatingTo: "group:G1",
+    });
+    first.turnAdoptionLifecycle = { onAdopted: () => {}, onAbandoned };
+    expect(enqueueFollowupRun(key, first, evictSettings)).toBe(true);
+
+    // A newer message overflows the cap; the oldest un-admitted run is evicted
+    // and its claim is released for retry.
+    expect(
+      enqueueFollowupRun(
+        key,
+        createRun({
+          prompt: "second",
+          messageId: "m2",
+          originatingChannel: "line",
+          originatingTo: "group:G1",
+        }),
+        evictSettings,
+      ),
+    ).toBe(true);
+    expect(onAbandoned).toHaveBeenCalledTimes(1);
+
+    const retry = createRun({
+      prompt: "first",
+      messageId: "m1",
+      originatingChannel: "line",
+      originatingTo: "group:G1",
+    });
+    retry.turnAdoptionLifecycle = { onAdopted: () => {} };
+    expect(enqueueFollowupRun(key, retry, evictSettings)).toBe(true);
+    clearSessionQueues([key]);
+  });
+
+  it("still deduplicates redelivery of a message whose queued run was admitted", async () => {
+    const key = `test-dedup-admitted-redelivery-${Date.now()}`;
+    const onAbandoned = vi.fn();
+    const run = createRun({
+      prompt: "first",
+      messageId: "same-id",
+      originatingChannel: "line",
+      originatingTo: "group:G1",
+    });
+    run.turnAdoptionLifecycle = { onAdopted: () => {}, onAbandoned };
+    expect(enqueueFollowupRun(key, run, collectSettings)).toBe(true);
+
+    await admitFollowupRunLifecycle(run);
+    completeFollowupRunLifecycle(run);
+    expect(onAbandoned).not.toHaveBeenCalled();
+    clearSessionQueues([key]);
+
+    const redelivery = createRun({
+      prompt: "first-redelivery",
+      messageId: "same-id",
+      originatingChannel: "line",
+      originatingTo: "group:G1",
+    });
+    expect(enqueueFollowupRun(key, redelivery, collectSettings)).toBe(false);
   });
 
   it("can opt-in to prompt-based dedupe when message id is absent", () => {

--- a/src/auto-reply/reply/queue.dedupe.test.ts
+++ b/src/auto-reply/reply/queue.dedupe.test.ts
@@ -468,6 +468,57 @@ describe("followup queue deduplication", () => {
     clearSessionQueues([key]);
   });
 
+  it("does not let a stale abandoned lifecycle release a newer same-id owner", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-07-30T00:00:00Z"));
+      const key = "test-dedup-stale-owner";
+      const stalledAdmission = createDeferred<void>();
+      const first = createRun({
+        prompt: "first",
+        messageId: "same-id",
+        originatingChannel: "line",
+        originatingTo: "group:G1",
+      });
+      first.turnAdoptionLifecycle = {
+        onAdopted: () => stalledAdmission.promise,
+        onAbandoned: vi.fn(),
+      };
+      expect(enqueueFollowupRun(key, first, collectSettings)).toBe(true);
+
+      const admission = admitFollowupRunLifecycle(first);
+      await vi.advanceTimersByTimeAsync(0);
+      clearSessionQueues([key]);
+
+      // Once the original key expires, a later delivery can legitimately own
+      // the same identity while the old lifecycle is still settling.
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      const replacement = createRun({
+        prompt: "replacement",
+        messageId: "same-id",
+        originatingChannel: "line",
+        originatingTo: "group:G1",
+      });
+      replacement.turnAdoptionLifecycle = { onAdopted: () => {} };
+      expect(enqueueFollowupRun(key, replacement, collectSettings)).toBe(true);
+
+      stalledAdmission.reject(new Error("admission failed"));
+      await expect(admission).rejects.toThrow("admission failed");
+      await vi.advanceTimersByTimeAsync(0);
+
+      const redelivery = createRun({
+        prompt: "duplicate",
+        messageId: "same-id",
+        originatingChannel: "line",
+        originatingTo: "group:G1",
+      });
+      expect(enqueueFollowupRun(key, redelivery, collectSettings)).toBe(false);
+      clearSessionQueues([key]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("still deduplicates redelivery of a message whose queued run was admitted", async () => {
     const key = `test-dedup-admitted-redelivery-${Date.now()}`;
     const onAbandoned = vi.fn();

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,7 +1,6 @@
 // Enqueues follow-up reply runs and schedules queue drains.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../../../channels/chat-type.js";
-import { resolveGlobalDedupeCache } from "../../../infra/dedupe.js";
 import { channelRouteDedupeKey } from "../../../plugin-sdk/channel-route.js";
 import {
   applyQueueDropPolicy,
@@ -15,6 +14,11 @@ import {
   resolveFollowupDeliveryContextKey,
   resolveFollowupReplyAnchor,
 } from "./drain.js";
+import {
+  peekRecentQueueMessageId,
+  recordRecentQueueMessageId,
+  resetRecentQueuedMessageIdDedupe,
+} from "./recent-message-ids.js";
 import { getExistingFollowupQueue, getFollowupQueue, trimSummaryElisionsToCap } from "./state.js";
 import {
   completeFollowupRunLifecycle,
@@ -25,17 +29,6 @@ import {
   type QueueDedupeMode,
   type QueueSettings,
 } from "./types.js";
-
-/**
- * Keep queued message-id dedupe shared across bundled chunks so redeliveries
- * are rejected no matter which chunk receives the enqueue call.
- */
-const RECENT_QUEUE_MESSAGE_IDS_KEY = Symbol.for("openclaw.recentQueueMessageIds");
-
-const RECENT_QUEUE_MESSAGE_IDS = resolveGlobalDedupeCache(RECENT_QUEUE_MESSAGE_IDS_KEY, {
-  ttlMs: 5 * 60 * 1000,
-  maxSize: 10_000,
-});
 
 function followupRouteIdentityKey(run: FollowupRun): string {
   return JSON.stringify([
@@ -113,7 +106,7 @@ export function enqueueFollowupRun(
   }
   const queue = getFollowupQueue(key, settings);
   const recentMessageIdKey = dedupeMode !== "none" ? buildRecentMessageIdKey(run, key) : undefined;
-  if (recentMessageIdKey && RECENT_QUEUE_MESSAGE_IDS.peek(recentMessageIdKey)) {
+  if (recentMessageIdKey && peekRecentQueueMessageId(recentMessageIdKey)) {
     return false;
   }
 
@@ -200,7 +193,7 @@ export function enqueueFollowupRun(
     queue.items.push(run);
   }
   if (recentMessageIdKey) {
-    RECENT_QUEUE_MESSAGE_IDS.check(recentMessageIdKey);
+    recordRecentQueueMessageId(run, recentMessageIdKey);
   }
   if (runFollowup) {
     rememberFollowupDrainCallback(key, runFollowup);
@@ -220,10 +213,6 @@ export function getFollowupQueueDepth(key: string): number {
     return 0;
   }
   return countPendingQueueItems(queue.items, queue.inFlight);
-}
-
-function resetRecentQueuedMessageIdDedupe(): void {
-  RECENT_QUEUE_MESSAGE_IDS.clear();
 }
 
 if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {

--- a/src/auto-reply/reply/queue/recent-message-ids.ts
+++ b/src/auto-reply/reply/queue/recent-message-ids.ts
@@ -1,0 +1,47 @@
+// Recent-queue message-id dedupe shared by enqueue admission and abandonment release.
+import { resolveGlobalDedupeCache } from "../../../infra/dedupe.js";
+import { resolveGlobalSingleton } from "../../../shared/global-singleton.js";
+
+/**
+ * Keep queued message-id dedupe shared across bundled chunks so redeliveries
+ * are rejected no matter which chunk receives the enqueue call.
+ */
+const RECENT_QUEUE_MESSAGE_IDS_KEY = Symbol.for("openclaw.recentQueueMessageIds");
+
+const RECENT_QUEUE_MESSAGE_IDS = resolveGlobalDedupeCache(RECENT_QUEUE_MESSAGE_IDS_KEY, {
+  ttlMs: 5 * 60 * 1000,
+  maxSize: 10_000,
+});
+
+/** Chunk-shared run→identity association so abandonment can free the entry by object identity. */
+const RUN_MESSAGE_ID_KEYS = resolveGlobalSingleton(
+  Symbol.for("openclaw.recentQueueMessageIdKeys"),
+  () => new WeakMap<object, string>(),
+);
+
+export function peekRecentQueueMessageId(key: string): boolean {
+  return RECENT_QUEUE_MESSAGE_IDS.peek(key);
+}
+
+export function recordRecentQueueMessageId(run: object, key: string): void {
+  RUN_MESSAGE_ID_KEYS.set(run, key);
+  RECENT_QUEUE_MESSAGE_IDS.check(key);
+}
+
+/**
+ * Frees a dropped run's dedupe identity. A run abandoned before admission makes
+ * durable ingress release its claim for retry; that retry must be re-admittable
+ * instead of being rejected as a recent duplicate.
+ */
+export function releaseRecentQueueMessageId(run: object): void {
+  const key = RUN_MESSAGE_ID_KEYS.get(run);
+  if (key === undefined) {
+    return;
+  }
+  RUN_MESSAGE_ID_KEYS.delete(run);
+  RECENT_QUEUE_MESSAGE_IDS.delete(key);
+}
+
+export function resetRecentQueuedMessageIdDedupe(): void {
+  RECENT_QUEUE_MESSAGE_IDS.clear();
+}

--- a/src/auto-reply/reply/queue/recent-message-ids.ts
+++ b/src/auto-reply/reply/queue/recent-message-ids.ts
@@ -1,22 +1,33 @@
 // Recent-queue message-id dedupe shared by enqueue admission and abandonment release.
-import { resolveGlobalDedupeCache } from "../../../infra/dedupe.js";
+import { pruneMapToMaxSize } from "../../../infra/map-size.js";
 import { resolveGlobalSingleton } from "../../../shared/global-singleton.js";
+
+const RECENT_QUEUE_MESSAGE_ID_TTL_MS = 5 * 60 * 1000;
+const RECENT_QUEUE_MESSAGE_ID_MAX_SIZE = 10_000;
+
+type RecentQueueMessageIdRecord = {
+  ownerToken: object;
+  recordedAt: number;
+};
+
+type RecentQueueMessageIdOwnership = {
+  key: string;
+  ownerToken: object;
+};
 
 /**
  * Keep queued message-id dedupe shared across bundled chunks so redeliveries
  * are rejected no matter which chunk receives the enqueue call.
  */
-const RECENT_QUEUE_MESSAGE_IDS_KEY = Symbol.for("openclaw.recentQueueMessageIds");
-
-const RECENT_QUEUE_MESSAGE_IDS = resolveGlobalDedupeCache(RECENT_QUEUE_MESSAGE_IDS_KEY, {
-  ttlMs: 5 * 60 * 1000,
-  maxSize: 10_000,
-});
+const RECENT_QUEUE_MESSAGE_IDS = resolveGlobalSingleton(
+  Symbol.for("openclaw.recentQueueMessageIdOwners"),
+  () => new Map<string, RecentQueueMessageIdRecord>(),
+);
 
 /** Chunk-shared identity→key association so abandonment can free the entry. */
-const RUN_MESSAGE_ID_KEYS = resolveGlobalSingleton(
-  Symbol.for("openclaw.recentQueueMessageIdKeys"),
-  () => new WeakMap<object, string>(),
+const DEDUPE_IDENTITY_OWNERSHIPS = resolveGlobalSingleton(
+  Symbol.for("openclaw.recentQueueMessageIdOwnerships"),
+  () => new WeakMap<object, RecentQueueMessageIdOwnership>(),
 );
 
 type DedupeOwnedRun = { turnAdoptionLifecycle?: object };
@@ -32,13 +43,38 @@ function resolveDedupeIdentity(run: DedupeOwnedRun): object {
   return run.turnAdoptionLifecycle ?? run;
 }
 
-export function peekRecentQueueMessageId(key: string): boolean {
-  return RECENT_QUEUE_MESSAGE_IDS.peek(key);
+function pruneRecentQueueMessageIds(now: number): void {
+  const cutoff = now - RECENT_QUEUE_MESSAGE_ID_TTL_MS;
+  for (const [key, record] of RECENT_QUEUE_MESSAGE_IDS) {
+    if (record.recordedAt <= cutoff) {
+      RECENT_QUEUE_MESSAGE_IDS.delete(key);
+    }
+  }
+  pruneMapToMaxSize(RECENT_QUEUE_MESSAGE_IDS, RECENT_QUEUE_MESSAGE_ID_MAX_SIZE);
 }
 
-export function recordRecentQueueMessageId(run: DedupeOwnedRun, key: string): void {
-  RUN_MESSAGE_ID_KEYS.set(resolveDedupeIdentity(run), key);
-  RECENT_QUEUE_MESSAGE_IDS.check(key);
+export function peekRecentQueueMessageId(key: string, now = Date.now()): boolean {
+  const record = RECENT_QUEUE_MESSAGE_IDS.get(key);
+  if (!record) {
+    return false;
+  }
+  if (now - record.recordedAt >= RECENT_QUEUE_MESSAGE_ID_TTL_MS) {
+    RECENT_QUEUE_MESSAGE_IDS.delete(key);
+    return false;
+  }
+  return true;
+}
+
+export function recordRecentQueueMessageId(
+  run: DedupeOwnedRun,
+  key: string,
+  now = Date.now(),
+): void {
+  const ownerToken = {};
+  DEDUPE_IDENTITY_OWNERSHIPS.set(resolveDedupeIdentity(run), { key, ownerToken });
+  RECENT_QUEUE_MESSAGE_IDS.delete(key);
+  RECENT_QUEUE_MESSAGE_IDS.set(key, { ownerToken, recordedAt: now });
+  pruneRecentQueueMessageIds(now);
 }
 
 /**
@@ -48,12 +84,16 @@ export function recordRecentQueueMessageId(run: DedupeOwnedRun, key: string): vo
  */
 export function releaseRecentQueueMessageId(run: DedupeOwnedRun): void {
   const identity = resolveDedupeIdentity(run);
-  const key = RUN_MESSAGE_ID_KEYS.get(identity);
-  if (key === undefined) {
+  const ownership = DEDUPE_IDENTITY_OWNERSHIPS.get(identity);
+  if (!ownership) {
     return;
   }
-  RUN_MESSAGE_ID_KEYS.delete(identity);
-  RECENT_QUEUE_MESSAGE_IDS.delete(key);
+  DEDUPE_IDENTITY_OWNERSHIPS.delete(identity);
+  // The key may have expired and been re-recorded by a newer same-ID run.
+  // Only the lifecycle that installed the current owner may release it.
+  if (RECENT_QUEUE_MESSAGE_IDS.get(ownership.key)?.ownerToken === ownership.ownerToken) {
+    RECENT_QUEUE_MESSAGE_IDS.delete(ownership.key);
+  }
 }
 
 export function resetRecentQueuedMessageIdDedupe(): void {

--- a/src/auto-reply/reply/queue/recent-message-ids.ts
+++ b/src/auto-reply/reply/queue/recent-message-ids.ts
@@ -13,18 +13,31 @@ const RECENT_QUEUE_MESSAGE_IDS = resolveGlobalDedupeCache(RECENT_QUEUE_MESSAGE_I
   maxSize: 10_000,
 });
 
-/** Chunk-shared run→identity association so abandonment can free the entry by object identity. */
+/** Chunk-shared identity→key association so abandonment can free the entry. */
 const RUN_MESSAGE_ID_KEYS = resolveGlobalSingleton(
   Symbol.for("openclaw.recentQueueMessageIdKeys"),
   () => new WeakMap<object, string>(),
 );
 
+type DedupeOwnedRun = { turnAdoptionLifecycle?: object };
+
+/**
+ * The adoption lifecycle is the ownership identity that survives run cloning
+ * (overflow-summary retry sources copy the lifecycle reference onto a new run
+ * object), so it must key the association; completion release fires once per
+ * lifecycle. Lifecycle-less runs never release, so keying them by the run
+ * object keeps their entries for the full TTL.
+ */
+function resolveDedupeIdentity(run: DedupeOwnedRun): object {
+  return run.turnAdoptionLifecycle ?? run;
+}
+
 export function peekRecentQueueMessageId(key: string): boolean {
   return RECENT_QUEUE_MESSAGE_IDS.peek(key);
 }
 
-export function recordRecentQueueMessageId(run: object, key: string): void {
-  RUN_MESSAGE_ID_KEYS.set(run, key);
+export function recordRecentQueueMessageId(run: DedupeOwnedRun, key: string): void {
+  RUN_MESSAGE_ID_KEYS.set(resolveDedupeIdentity(run), key);
   RECENT_QUEUE_MESSAGE_IDS.check(key);
 }
 
@@ -33,12 +46,13 @@ export function recordRecentQueueMessageId(run: object, key: string): void {
  * durable ingress release its claim for retry; that retry must be re-admittable
  * instead of being rejected as a recent duplicate.
  */
-export function releaseRecentQueueMessageId(run: object): void {
-  const key = RUN_MESSAGE_ID_KEYS.get(run);
+export function releaseRecentQueueMessageId(run: DedupeOwnedRun): void {
+  const identity = resolveDedupeIdentity(run);
+  const key = RUN_MESSAGE_ID_KEYS.get(identity);
   if (key === undefined) {
     return;
   }
-  RUN_MESSAGE_ID_KEYS.delete(run);
+  RUN_MESSAGE_ID_KEYS.delete(identity);
   RECENT_QUEUE_MESSAGE_IDS.delete(key);
 }
 

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -25,6 +25,7 @@ import type {
 } from "../../get-reply-options.types.js";
 import type { OriginatingChannelType } from "../../templating.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../directives.js";
+import { releaseRecentQueueMessageId } from "./recent-message-ids.js";
 
 export type QueueMode = "steer" | "followup" | "collect" | "interrupt";
 
@@ -284,6 +285,10 @@ export function completeFollowupRunLifecycle(run: FollowupLifecycleRun): void {
     // non-rejecting promise. onSettled must still run after a synchronous throw.
     try {
       if (!admittedTurnAdoptionLifecycles.has(lifecycle)) {
+        // The queue is relinquishing an un-admitted message: free its dedupe
+        // identity so the abandonment-triggered ingress retry can re-enqueue
+        // instead of being rejected as a recent duplicate and falsely completed.
+        releaseRecentQueueMessageId(run);
         lifecycle.onAbandoned?.();
       }
     } finally {


### PR DESCRIPTION
Closes #115888
Related #112720

## What Problem This Solves

Fixes an issue where a message that arrived while the agent was busy and was queued behind the active run would be permanently lost — no reply, no transcript entry — if the queued entry was dropped before it started (session reset, compact, abort, subagent cleanup, or old-item overflow eviction). Durable ingress released the event for retry, but the retry was rejected as a recent duplicate and the event was recorded as successfully processed.

## Why This Change Was Made

The recent-message-id dedupe rejects redeliveries, but it kept an entry alive for 5 minutes regardless of what happened to the queued run, while abandonment retries arrive after about one second — so the exact retry the abandonment requested was always rejected and the drain completed the claim without any turn running. The fix scopes the dedupe identity to queue ownership: the enqueue records it against the run's adoption lifecycle by object identity (chunk-shared WeakMap, no new fields on `FollowupRun`), and the same un-admitted branch of `completeFollowupRunLifecycle` that fires `onAbandoned` releases it, so every drop path — eviction, clear, abort — frees it in one place. The lifecycle is the identity rather than the run object because overflow-summary compaction clones the run (`createOverflowSummaryRetrySource`) while copying the lifecycle reference; keying by lifecycle keeps the release correct when a run is completed via its compaction clone on the default `summarize` drop policy. Admitted runs keep their entry, preserving redelivery rejection for handled messages. Alternatives rejected: threading a retry flag from the ingress drain through the channel handlers (cross-layer, cannot distinguish platform redeliveries), and treating a rejected enqueue as retryable at the drain (breaks non-message events that legitimately complete without adoption).

## User Impact

Messages sent to a busy agent are no longer silently lost when the queue they were waiting in is torn down; the durable-ingress retry now re-queues and delivers them. Repeated teardowns end in a visible dead-letter after the bounded retry budget instead of a silent fake-completion. Duplicate suppression for delivered or still-queued messages is unchanged.

## Evidence

### Mock-gateway harness: the full durable-ingress sequence, observed end to end

Behavior addressed: an inbound message queued behind an active run whose queue entry is dropped before admission must be redelivered by the durable-ingress retry and produce a delivered turn, while a platform redelivery of an already-delivered message id must stay suppressed.

Real environment tested: the real durable-ingress SQLite spool (`createChannelIngressQueue`), the real ingress drain (`createChannelIngressDrain`), and the real follow-up queue (exported surfaces only: `enqueueFollowupRun`, `clearSessionQueues`, `scheduleFollowupDrain`, `admitFollowupRunLifecycle`), wired through `bindIngressLifecycleToReplyOptions`, with real timers (the actual ~1 s ingress retry backoff elapses on the clock). Node v24.18.0, Windows 11. Only the channel/agent boundary is scripted, and it mirrors the runner's production contract at `src/auto-reply/reply/agent-runner-run.ts:385-397`: enqueue behind the active run and defer on success; a rejected enqueue returns without deferral.

Exact steps or command run after this patch: saved the harness below as `src/channels/message/ingress-abandon-retry.harness.test.ts` (evidence-only, not committed) and ran

```
pnpm exec vitest run --config test/vitest/vitest.channels.config.ts src/channels/message/ingress-abandon-retry.harness.test.ts
```

Evidence after fix (branch head, timeline emitted by the harness; identifiers redacted):

```
[+    1ms] inbound webhook: LINE message msg-7734 arrives while agent run is active
[+  130ms] ingress dispatch: event evt-1 attempt=0 → channel handler (agent busy, routing to follow-up queue)
[+  131ms] channel handler: queued behind active run → deferred (ingress claim held)
[+  197ms] session compact/reset: clearSessionQueues drops the un-admitted queued run
[+  202ms] ingress ledger: evt-1 released for retry (attempts=1, lastError="turn-abandoned")
[+  204ms] retry backoff active: evt-1 not yet eligible for redelivery (base 1s)
[+ 1294ms] ingress dispatch: event evt-1 attempt=1 → channel handler (agent busy, routing to follow-up queue)
[+ 1294ms] channel handler: queued behind active run → deferred (ingress claim held)
[+ 1355ms] active agent run finished → draining follow-up queue
[+ 1358ms] AGENT TURN DELIVERED: "[Queued messages while agent was busy]\n\n---\nQueued #1\n[LINE] user@REDACTED: are we still on for tonight?"
[+ 1465ms] platform redelivery: new webhook delivery evt-2 carrying the SAME msg-7734
[+ 1467ms] ingress dispatch: event evt-2 attempt=0 → channel handler (agent busy, routing to follow-up queue)
[+ 1468ms] channel handler: enqueue REJECTED by recent-message-id dedupe → returning without deferral
[+ 1528ms] === FINAL LEDGER ===
[+ 1528ms] delivered agent turns: 1
[+ 1528ms] ingress pending rows: 0 | live claims: 0
[+ 1528ms] re-enqueue probe for evt-1 → kind="completed" (completed = tombstoned as processed)
[+ 1528ms] enqueue attempts seen by channel handler: 3 (rejected: 1)
[+ 1528ms] VERDICT: message DELIVERED via durable-ingress retry after queue abandonment; redelivery of delivered message suppressed
```

Observed result after fix: the abandonment releases the claim (`lastError="turn-abandoned"`), the retry redelivers after the real backoff, the re-enqueue is admitted, and exactly one agent turn delivers the message. In the same output, the unchanged half of the contract is proven: a platform redelivery of the same provider message id (new event `evt-2`, same `msg-7734`) is still rejected and completed with no second turn — `delivered agent turns: 1`.

Before evidence: the identical harness with only the three queue source files reverted to their `origin/main` (`b4d14d784806`) state — the abandonment retry is rejected and the event is tombstoned as processed with zero turns:

```
[+    4ms] inbound webhook: LINE message msg-7734 arrives while agent run is active
[+  472ms] ingress dispatch: event evt-1 attempt=0 → channel handler (agent busy, routing to follow-up queue)
[+  476ms] channel handler: queued behind active run → deferred (ingress claim held)
[+  543ms] session compact/reset: clearSessionQueues drops the un-admitted queued run
[+  554ms] ingress ledger: evt-1 released for retry (attempts=1, lastError="turn-abandoned")
[+  565ms] retry backoff active: evt-1 not yet eligible for redelivery (base 1s)
[+ 1566ms] ingress dispatch: event evt-1 attempt=1 → channel handler (agent busy, routing to follow-up queue)
[+ 1566ms] channel handler: enqueue REJECTED by recent-message-id dedupe → returning without deferral
[+ 1639ms] active agent run finished → draining follow-up queue
[+ 6040ms] platform redelivery: new webhook delivery evt-2 carrying the SAME msg-7734
[+ 6054ms] ingress dispatch: event evt-2 attempt=0 → channel handler (agent busy, routing to follow-up queue)
[+ 6054ms] channel handler: enqueue REJECTED by recent-message-id dedupe → returning without deferral
[+ 6125ms] === FINAL LEDGER ===
[+ 6126ms] delivered agent turns: 0
[+ 6126ms] ingress pending rows: 0 | live claims: 0
[+ 6126ms] re-enqueue probe for evt-1 → kind="completed" (completed = tombstoned as processed)
[+ 6126ms] enqueue attempts seen by channel handler: 3 (rejected: 2)
[+ 6126ms] VERDICT: MESSAGE LOST — retry rejected by dedupe, claim falsely tombstoned as completed, no agent turn ran
```

What was not tested: no live LINE (or other platform) webhook round-trip — no external messaging server participates in the harness.

Proof limitations or environment constraints: the agent turn is a scripted callback that performs real reply-lane admission via `admitFollowupRunLifecycle` but runs no model; the channel dispatch is scripted to the same enqueue/defer/reject contract the runner implements at `src/auto-reply/reply/agent-runner-run.ts:385-397`. Everything between those two boundaries — spool, drain, claims, retry policy, follow-up queue, dedupe, lifecycle — is the real production code.

<details>
<summary>Harness source (evidence-only; not part of the change)</summary>

```ts
/**
 * Mock-gateway harness for the durable-ingress abandonment retry path.
 * Wires the REAL durable ingress spool (SQLite), the REAL channel ingress
 * drain, and the REAL follow-up reply queue together. Only the channel/agent
 * boundary is scripted, mirroring production behavior:
 *   - dispatch tries to enqueue behind the active run and defers on success
 *     (agent-runner-run.ts:385-397 wired via bindIngressLifecycleToReplyOptions)
 *   - a rejected enqueue returns without deferral (agent-runner-run.ts:394-397)
 *   - queued-run delivery admits the reply lane via admitFollowupRunLifecycle
 */
import fs from "node:fs";
import { describe, expect, it } from "vitest";
import type { FollowupRun, QueueSettings } from "../../auto-reply/reply/queue.js";
import {
  admitFollowupRunLifecycle,
  clearSessionQueues,
  enqueueFollowupRun,
  scheduleFollowupDrain,
} from "../../auto-reply/reply/queue.js";
import { createQueueTestRun } from "../../auto-reply/reply/queue.test-helpers.js";
import { bindIngressLifecycleToReplyOptions, createChannelIngressDrain } from "./ingress-drain.js";
import { withTempState } from "./ingress-drain.test-helpers.js";
import { createChannelIngressQueue } from "./ingress-queue.js";

type HarnessPayload = { messageId: string; text: string };

const SESSION_KEY = "agent:main:line:group:g-REDACTED";
const LANE_KEY = "line:group:g-REDACTED";

const collectSettings: QueueSettings = {
  mode: "collect",
  debounceMs: 0,
  cap: 50,
  dropPolicy: "summarize",
};

function sleep(ms: number): Promise<void> {
  return new Promise((resolve) => setTimeout(resolve, ms));
}

describe("durable-ingress abandonment retry harness (manual evidence)", () => {
  it("abandonment → release → retry → re-enqueue → delivery; redelivery still suppressed", async () => {
    await withTempState(async (stateDir) => {
      const t0 = Date.now();
      const lines: string[] = [];
      const log = (message: string) => {
        const elapsed = String(Date.now() - t0).padStart(5, " ");
        const line = `[+${elapsed}ms] ${message}`;
        lines.push(line);
        console.log(line);
      };

      const queue = createChannelIngressQueue<HarnessPayload>({
        channelId: "line",
        accountId: "default",
        stateDir,
      });

      const delivered: string[] = [];
      let enqueueAttempts = 0;
      let rejectedEnqueues = 0;

      const runFollowup = async (run: FollowupRun) => {
        // Reply-lane admission: agent turn starts, onAdopted tombstones the claim.
        await admitFollowupRunLifecycle(run);
        delivered.push(run.prompt);
        log(`AGENT TURN DELIVERED: ${JSON.stringify(run.prompt)}`);
      };

      const drain = createChannelIngressDrain<HarnessPayload>({
        queue,
        onLog: (message) => log(`[drain] ${message}`),
        dispatchClaimedEvent: async (event, lifecycle) => {
          enqueueAttempts += 1;
          log(
            `ingress dispatch: event ${event.id} attempt=${event.attempts} → channel handler (agent busy, routing to follow-up queue)`,
          );
          const bound = bindIngressLifecycleToReplyOptions(lifecycle);
          const run = createQueueTestRun({
            prompt: `[LINE] user@REDACTED: are we still on for tonight?`,
            messageId: event.payload.messageId,
            originatingChannel: "line",
            originatingTo: "group:g-REDACTED",
          });
          run.turnAdoptionLifecycle = bound.turnAdoptionLifecycle;
          const enqueued = enqueueFollowupRun(SESSION_KEY, run, collectSettings);
          if (!enqueued) {
            rejectedEnqueues += 1;
            // Mirrors agent-runner-run.ts:394-397 — rejected enqueue returns
            // without deferral; the drain then completes the claim.
            log(
              `channel handler: enqueue REJECTED by recent-message-id dedupe → returning without deferral`,
            );
            return undefined;
          }
          log(`channel handler: queued behind active run → deferred (ingress claim held)`);
          return { kind: "deferred" };
        },
      });

      // ── 1. Message arrives while agent is busy ──────────────────────────
      log(`inbound webhook: LINE message msg-7734 arrives while agent run is active`);
      await queue.enqueue("evt-1", { messageId: "msg-7734", text: "redacted" }, {
        laneKey: LANE_KEY,
      });
      await drain.drainOnce();
      await sleep(50);

      // ── 2. Queued entry dropped before admission (session reset/compact) ─
      log(`session compact/reset: clearSessionQueues drops the un-admitted queued run`);
      clearSessionQueues([SESSION_KEY]);

      // onAbandoned → drain releases the claim for retry.
      let releasedRow: { attempts: number; lastError?: string } | undefined;
      for (let i = 0; i < 50 && !releasedRow; i += 1) {
        const pending = await queue.listPending();
        const row = pending.find((event) => event.id === "evt-1");
        if (row && row.lastError !== undefined) {
          releasedRow = { attempts: row.attempts, lastError: row.lastError };
        } else {
          await sleep(50);
        }
      }
      log(
        `ingress ledger: evt-1 released for retry (attempts=${releasedRow?.attempts}, lastError=${JSON.stringify(releasedRow?.lastError)})`,
      );
      expect(releasedRow?.lastError).toBe("turn-abandoned");

      // ── 3. Durable-ingress retry (real ~1s backoff) redelivers ──────────
      let loggedBackoff = false;
      for (let i = 0; i < 40 && enqueueAttempts < 2; i += 1) {
        const { started } = await drain.drainOnce();
        if (started === 0 && !loggedBackoff) {
          loggedBackoff = true;
          log(`retry backoff active: evt-1 not yet eligible for redelivery (base 1s)`);
        }
        if (started === 0) {
          await sleep(100);
        }
      }
      await sleep(50);

      // ── 4. Active run finishes → follow-up queue drains ─────────────────
      log(`active agent run finished → draining follow-up queue`);
      scheduleFollowupDrain(SESSION_KEY, runFollowup);
      for (let i = 0; i < 40 && delivered.length === 0; i += 1) {
        await sleep(100);
      }
      await drain.waitForIdle();

      // ── 5. Platform redelivery of the SAME provider message id ──────────
      log(`platform redelivery: new webhook delivery evt-2 carrying the SAME msg-7734`);
      await queue.enqueue("evt-2", { messageId: "msg-7734", text: "redacted" }, {
        laneKey: LANE_KEY,
      });
      await drain.drainOnce();
      await drain.waitForIdle();
      await sleep(50);

      // ── Final ledger ────────────────────────────────────────────────────
      const probe = await queue.enqueue("evt-1", { messageId: "msg-7734", text: "redacted" }, {
        laneKey: LANE_KEY,
      });
      const pending = await queue.listPending();
      const claims = await queue.listClaims();
      log(`=== FINAL LEDGER ===`);
      log(`delivered agent turns: ${delivered.length}`);
      log(`ingress pending rows: ${pending.length} | live claims: ${claims.length}`);
      log(`re-enqueue probe for evt-1 → kind=${JSON.stringify(probe.kind)} (completed = tombstoned as processed)`);
      log(`enqueue attempts seen by channel handler: ${enqueueAttempts} (rejected: ${rejectedEnqueues})`);
      log(
        delivered.length > 0
          ? `VERDICT: message DELIVERED via durable-ingress retry after queue abandonment; redelivery of delivered message suppressed`
          : `VERDICT: MESSAGE LOST — retry rejected by dedupe, claim falsely tombstoned as completed, no agent turn ran`,
      );

      drain.dispose();
      const outPath = process.env.HARNESS_OUT;
      if (outPath) {
        fs.writeFileSync(outPath, `${lines.join("\n")}\n`);
      }
    });
  }, 30_000);
});
```

</details>

### Focused unit red/green

Red on unmodified main (`844329284e4`) — the abandonment retry is rejected:

```
FAIL  |auto-reply-reply| src/auto-reply/reply/queue.dedupe.test.ts >
  followup queue deduplication > allows re-enqueueing a message whose queued run was abandoned before admission
AssertionError: expected false to be true
 ❯ src/auto-reply/reply/queue.dedupe.test.ts:377:61
 Test Files  1 failed (1)
      Tests  1 failed | 10 passed (11)
```

A second red/green covers the summarize-elision compaction path: compaction clones the run, so a release keyed by the run object misses runs completed via their clone. The regression test is red with the release keyed by the run object (head `101835d9950`):

```
 FAIL  |auto-reply-reply| src/auto-reply/reply/queue.dedupe.test.ts > followup queue deduplication >
   allows re-enqueueing a message compacted into a summary elision before teardown
AssertionError: expected false to be true
 Test Files  1 failed (1)      Tests  1 failed | 12 passed (13)
```

Green with the lifecycle-keyed release, including the eviction-path test and the guard test proving an admitted (handled) message's redelivery is still deduplicated:

```
 ✓ |auto-reply-reply| src/auto-reply/reply/queue.dedupe.test.ts (13 tests)
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Neighbouring queue suites green under both owning configs (`vitest.auto-reply-reply` and `vitest.unit-fast`): queue.collect (142 passed; one pre-existing local EBUSY teardown failure reproduces identically on clean main), queue.drain-restart, queue/cleanup, queue/state, queue/settings, queue/settings-runtime, queue/drain.identity-guard, queue/drain.client-caps, followup-turn-admission, followup-delivery:

```
 Test Files  3 passed (3)      Tests  153 passed | 1 failed (pre-existing EBUSY)
 Test Files  4 passed (4)      Tests  20 passed (20)
```

Typechecks clean on both lanes (`tsconfig.json`, `test/tsconfig/tsconfig.core.test.json`); oxlint and oxfmt clean on all touched files.

### Maintainer verification (2026-07-30)

Prepared head: `9fbb7df95687e52b0a85f257099fce306cad318b`

- Added per-record owner tokens so stale lifecycle completion cannot release a newer same-message-id dedupe record after TTL expiry/replacement.
- Added the expiry/replacement regression plus clone/lifecycle coverage.
- Focused queue + ingress matrix: 190/190 passed.
- Current `main` baseline for the unrelated full-suite failures: 62/62 passed across the reported WhatsApp and DeepInfra files; two include post-base test repairs.
- `pnpm build` and full `pnpm check`: passed.
- Changed core/core-tests Testbox gate: passed (https://github.com/openclaw/openclaw/actions/runs/30508913620).
- Repository-wide `pnpm test` did not complete: unrelated stale-base tooling/extension failures were followed by a Node 24 heap OOM; no touched queue/ingress test failed.