### PR TITLE
fix(browser): stabilize atomic download staging

### DIFF
--- a/extensions/browser/src/browser/output-files.ts
+++ b/extensions/browser/src/browser/output-files.ts
@@ -29,8 +29,8 @@ export async function writeExternalFileWithinOutputRoot(params: {
     path: outputPath,
     write: params.write,
   }).catch((err: unknown) => {
-    if (err instanceof Error && /file not found/i.test(err.message)) {
-      throw new Error("output directory changed while writing file");
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error("output directory changed while writing file", { cause: err });
     }
     throw err;
   });

--- a/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -388,13 +388,14 @@ describe("pw-tools-core", () => {
   });
 
   it.runIf(process.platform !== "win32")(
-    "does not overwrite outside files when explicit output path is a hardlink alias",
+    "replaces a hardlink path without overwriting the outside inode",
     async () => {
       await withTempDir(async (tempDir) => {
         const outsidePath = path.join(tempDir, "outside.txt");
         await fs.writeFile(outsidePath, "outside-before", "utf8");
         const linkedPath = path.join(tempDir, "linked.txt");
         await fs.link(outsidePath, linkedPath);
+        const outsideBefore = await fs.stat(outsidePath);
 
         const harness = createDownloadEventHarness();
         const saveAs = vi.fn(async (outPath: string) => {
@@ -415,9 +416,23 @@ describe("pw-tools-core", () => {
           saveAs,
         });
 
-        await expect(p).rejects.toThrow(/alias escape blocked|Hardlinked path is not allowed/i);
-        expect(await fs.readFile(linkedPath, "utf8")).toBe("outside-before");
+        await expect(p).resolves.toMatchObject({ path: linkedPath });
+        await expectAtomicDownloadSave({
+          saveAs,
+          targetPath: linkedPath,
+          content: "download-content",
+        });
+        const outsideAfter = await fs.stat(outsidePath);
+        const linkedAfter = await fs.stat(linkedPath);
         expect(await fs.readFile(outsidePath, "utf8")).toBe("outside-before");
+        expect({ dev: outsideAfter.dev, ino: outsideAfter.ino }).toEqual({
+          dev: outsideBefore.dev,
+          ino: outsideBefore.ino,
+        });
+        expect({ dev: linkedAfter.dev, ino: linkedAfter.ino }).not.toEqual({
+          dev: outsideAfter.dev,
+          ino: outsideAfter.ino,
+        });
       });
     },
   );
@@ -433,9 +448,11 @@ describe("pw-tools-core", () => {
       path.join(path.sep, "tmp", "openclaw-preferred", "downloads"),
     );
     const expectedDownloadsTail = `${path.join("tmp", "openclaw-preferred", "downloads")}${path.sep}`;
-    expect(path.dirname(outPath)).not.toBe(expectedRootedDownloadsDir);
+    expect(path.dirname(outPath)).toBe(expectedRootedDownloadsDir);
+    expect(path.dirname(res.path)).toBe(expectedRootedDownloadsDir);
     expect(path.basename(outPath)).toContain(path.basename(res.path));
     expect(path.basename(outPath)).toMatch(/\.part$/);
+    await expectPathMissing(outPath);
     await expect(fs.readFile(res.path, "utf8")).resolves.toBe("download-content");
     expect(path.normalize(res.path)).toContain(path.normalize(expectedDownloadsTail));
     expect(tmpDirMocks.resolvePreferredOpenClawTmpDir).toHaveBeenCalled();
@@ -448,11 +465,15 @@ describe("pw-tools-core", () => {
       suggestedFilename: "../../../../etc/passwd",
     });
     expect(typeof outPath).toBe("string");
-    expect(path.dirname(outPath)).not.toBe(
-      path.resolve(path.join(path.sep, "tmp", "openclaw-preferred", "downloads")),
+    const expectedRootedDownloadsDir = path.resolve(
+      path.join(path.sep, "tmp", "openclaw-preferred", "downloads"),
     );
+    expect(path.dirname(outPath)).toBe(expectedRootedDownloadsDir);
+    expect(path.dirname(res.path)).toBe(expectedRootedDownloadsDir);
     expect(path.basename(outPath)).toContain(path.basename(res.path));
     expect(path.basename(outPath)).toMatch(/\.part$/);
+    expect(path.basename(res.path)).toMatch(/-passwd$/);
+    await expectPathMissing(outPath);
     await expect(fs.readFile(res.path, "utf8")).resolves.toBe("download-content");
     expect(path.normalize(res.path)).toContain(
       path.normalize(`${path.join("tmp", "openclaw-preferred", "downloads")}${path.sep}`),


### PR DESCRIPTION
Related: #115696

## What Problem This Solves

Fixes an issue where a browser download could expose a raw `ENOENT` error when its output directory changed during finalization. It also corrects browser tests that still expected pre-fs-safe hardlink and temporary-staging behavior.

## Why This Change Was Made

This forward-ports the two-file fix from release commit `962390228594cae5a74da590423446983657ef75` without release ancestry. Browser output handling now recognizes `ENOENT` by its standard error code and retains the original error as the cause. Tests verify that sibling staging atomically replaces a hardlink path without changing the outside inode, cleans staging files, and keeps sanitized implicit downloads inside the guarded download root.

## User Impact

Users receive the intended browser output-directory error instead of a raw filesystem exception during a directory race. Download finalization remains atomic and does not overwrite hardlinked outside files.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30453116930
- 55 tests passed across the browser download suite and shared fs-safe staging suites
- `oxfmt --check` passed for both changed files
- `git diff --check` passed
- Patch ID matches release commit `962390228594cae5a74da590423446983657ef75`
- Fresh autoreview: clean; TruffleHog: clean

Original code author: Peter Steinberger. AI-assisted verification: yes.