### PR TITLE
fix(macos): reduce onboarding idle CPU

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingWidgets.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingWidgets.swift
@@ -23,7 +23,12 @@ struct GlowingOpenClawIcon: View {
     }
 
     var body: some View {
-        OpenClawMascotView(mood: self.mood, accessory: self.accessory, interactive: true)
+        // The large vector hero is decorative; 30 fps burns a core while setup sits idle.
+        OpenClawMascotView(
+            mood: self.mood,
+            accessory: self.accessory,
+            interactive: true,
+            minimumFrameInterval: 1.0 / 12.0)
             .frame(width: self.size, height: self.size)
             .shadow(
                 color: OpenClawMascotView.heroGlowColor(for: self.colorScheme),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS onboarding welcome screen continuously consumed about 10% of one CPU core while sitting idle.

## Why This Change Was Made

The onboarding hero redraws a large custom vector mascot. Limit that decorative surface to 12 frames per second instead of the component's 30 fps default, while preserving click reactions, pointer tracking, moods, and the higher default cadence for other consumers.

## User Impact

Leaving the setup window open uses substantially less CPU and energy. The mascot remains animated and interactive.

## Evidence

- Exact packaged release build, idle onboarding welcome screen:
  - Before: 970 running 1 ms CPU samples over 10 seconds.
  - After: 722 and 781 samples in two 10-second steady-state traces, a reproducible 19-26% reduction (22.5% using the two-run mean).
- Time Profiler attributes the hot phase to continuous SwiftUI/AppKit display work; `TimelineView`, `OpenClawMascotCanvas`, and mascot drawing frames are present in the sampled stacks.
- After the one-time onboarding load, eleven five-second samples averaged 6.63% of one core. RSS stayed flat between 156.8 and 159.7 MB for the remaining 51 seconds; no continuing growth was observed.
- Computer Use verified the exact release app still showed the visible sleeping mascot, nightcap, glow, and welcome layout after auto-doze.
- The issue is isolated to the visible onboarding hero; the change does not alter chat, iOS, or the shared mascot default.
- SwiftFormat 0.62.1, SwiftLint 0.65.0, and `git diff --check`: clean.


## Refreshed Exact-Head Proof

- Head `1b653c65ce4a815af0f843d854ae81b1b6b94596` includes current `origin/main`.
- `OnboardingMascotMoodTests` and `OnboardingViewSmokeTests`: 37 tests passed in 0.432 seconds on the refreshed head.
- Fresh exact-head autoreview: clean, no accepted/actionable findings, 0.94 confidence.


## Rank-up Closeout

- The exact head was refreshed with `main` before the 37-test native rerun. A current `origin/main` three-way merge tree is conflict-free and leaves `OnboardingWidgets.swift` plus the shared mascot implementation unchanged.
- Shared mascot source confirms `minimumFrameInterval` only configures `TimelineView` pose sampling. `onContinuousHover` and `onTapGesture` call the animator immediately outside the timeline schedule, so pointer tracking and click reactions remain event-driven; only their visual redraw cadence is capped.
