### PR TITLE
fix(update): restore the production environment-variable gate

### DIFF
--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -77,7 +77,7 @@ export function parseTimeoutMsOrExit(timeout?: string): number | undefined | nul
 const OPENCLAW_REPO_URL = "https://github.com/openclaw/openclaw.git";
 // Keep the full commit graph for dev ref switching while deferring historical blobs.
 // A shallow clone would make older or non-default dev targets unreachable.
-const OPENCLAW_CLONE_FILTER = "--filter=blob:none";
+const GIT_PARTIAL_CLONE_FILTER = "--filter=blob:none";
 const MAX_LOG_CHARS = 8000;
 
 export const DEFAULT_PACKAGE_NAME = "openclaw";
@@ -254,7 +254,7 @@ export async function ensureGitCheckout(params: {
     await fs.mkdir(path.dirname(params.dir), { recursive: true });
     return await runUpdateStep({
       name: "git clone",
-      argv: ["git", "clone", OPENCLAW_CLONE_FILTER, OPENCLAW_REPO_URL, params.dir],
+      argv: ["git", "clone", GIT_PARTIAL_CLONE_FILTER, OPENCLAW_REPO_URL, params.dir],
       env: gitEnv,
       timeoutMs: params.timeoutMs,
       progress: params.progress,
@@ -271,7 +271,7 @@ export async function ensureGitCheckout(params: {
 
     return await runUpdateStep({
       name: "git clone",
-      argv: ["git", "clone", OPENCLAW_CLONE_FILTER, OPENCLAW_REPO_URL, params.dir],
+      argv: ["git", "clone", GIT_PARTIAL_CLONE_FILTER, OPENCLAW_REPO_URL, params.dir],
       cwd: params.dir,
       env: gitEnv,
       timeoutMs: params.timeoutMs,


### PR DESCRIPTION
Related: #115651

## What Problem This Solves

Resolves a problem where every production-source pull request and the main-branch changed-file validation fail the environment-variable count gate after the development-update partial-clone improvement. The gate reports `OPENCLAW_* count 520 exceeds budget 519` because a private Git argument constant is named like an environment variable.

## Why This Change Was Made

Rename only the private partial-clone argument constant to `GIT_PARTIAL_CLONE_FILTER` at its declaration and its two existing call sites. Preserve the exact `git clone --filter=blob:none` arguments, the existing full Git history, the public `OPENCLAW_GIT_DIR` contract, and the unchanged 519-variable ratchet. No budget, configuration, scanner, documentation, or test baseline is changed.

## User Impact

Production validation and pending maintainer fixes can pass again without weakening the environment-variable guard or changing development-update behavior.

## Evidence

- Before on the exact main parent: `OPENCLAW_* count 520 exceeds budget 519`.
- After: `node scripts/check-env-var-count.mjs --base origin/main` → `OPENCLAW_* count 519/519`.
- Trusted Blacksmith Testbox `tbx_01kypz2a5sfz17e1z2t9997yej`: 222/222 existing tests, including all 209 update CLI regressions, 4 shared command-runner regressions, and 9 environment-ratchet regressions.
- The same remote run passed complete `pnpm check:changed`, the complete `pnpm build`, and a second final `519/519` ratchet check.
- Fresh structured Codex autoreview at xhigh: no accepted/actionable findings, correctness 0.99.
- Two independent maintainer-agent source reviews confirm the immutable one-file `+3/-3` fix preserves both actual Git clone call paths.
- AI-assisted; no secrets, environment settings, or public API are added.