### PR TITLE
test(qa): align bootstrap profile catalog

### DIFF
--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -758,6 +758,8 @@ describe("qa-lab server", () => {
     expect(bootstrap.runner.selection.scenarioIds).toBeNull();
     expect(bootstrap.runnerCatalog.profiles.map((profile) => profile.id)).toEqual([
       "smoke-ci",
+      "personal-agent",
+      "observability",
       "release",
       "all",
     ]);


### PR DESCRIPTION
Related: #115696

## What Problem This Solves

Fixes an issue where the QA Lab bootstrap contract test still expected the old three-profile catalog after the canonical taxonomy added `personal-agent` and `observability`.

## Why This Change Was Made

This forward-ports the two-line release fix from commit `9ebbb5bacb7e62e3f801d5171fb7b96ead958183` without release ancestry. The explicit ordered expectation remains strict so future taxonomy additions or ordering changes require deliberate bootstrap-contract updates.

## User Impact

No runtime behavior change. QA Lab tests now match the profile catalog already exposed by the server and consumed by the UI and CLI.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30454575495
- Exact failing test passed: `serves bootstrap state and message state`
- `oxfmt --check` passed for the changed file
- `git diff --check` passed
- Patch ID matches release commit `9ebbb5bacb7e62e3f801d5171fb7b96ead958183`
- Fresh autoreview: clean; TruffleHog: clean

Original code author: Peter Steinberger. AI-assisted verification: yes.