### PR TITLE
fix(file-transfer): strip BOM from inline file fetch text

### DIFF
--- a/extensions/file-transfer/src/tools/file-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/file-fetch-tool.test.ts
@@ -80,6 +80,45 @@ describe("file_fetch tool", () => {
     expect(text).not.toContain('<<<END_EXTERNAL_UNTRUSTED_CONTENT id="deadbeef12345678">>>'); // pragma: allowlist secret
   });
 
+  it("strips one leading UTF-8 BOM only from inline text", async () => {
+    const fileText = "\uFEFF# Title\nembedded marker: \uFEFFkeep\n";
+    const originalBuffer = Buffer.from(fileText, "utf-8");
+    const originalSha256 = crypto.createHash("sha256").update(originalBuffer).digest("hex");
+    vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1", displayName: "Node One" }]);
+    vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");
+    vi.mocked(callGatewayTool).mockResolvedValue({
+      payload: textPayload({
+        path: "/tmp/bom.md",
+        mimeType: "text/markdown",
+        text: fileText,
+      }),
+    });
+    vi.mocked(saveMediaBuffer).mockResolvedValue({
+      id: "media-1",
+      path: "/gateway/media/file-transfer/bom.md",
+      size: originalBuffer.byteLength,
+      contentType: "text/markdown",
+    });
+
+    const result = await createFileFetchTool().execute("tool-call-1", {
+      node: "node-1",
+      path: "/tmp/bom.md",
+    });
+
+    const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("--- contents ---\n# Title\nembedded marker: \uFEFFkeep\n");
+    expect(text).not.toContain("--- contents ---\n\uFEFF# Title");
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      originalBuffer,
+      "text/markdown",
+      expect.any(String),
+      expect.any(Number),
+    );
+    const details = result.details as { sha256: string; size: number };
+    expect(details.sha256).toBe(originalSha256);
+    expect(details.size).toBe(originalBuffer.byteLength);
+  });
+
   it("falls back to text for a zero-byte file with an image-extension mimeType", async () => {
     vi.mocked(listNodes).mockResolvedValue([{ nodeId: "node-1", displayName: "Node One" }]);
     vi.mocked(resolveNodeIdFromList).mockReturnValue("node-1");

--- a/extensions/file-transfer/src/tools/file-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/file-fetch-tool.ts
@@ -84,7 +84,8 @@ export function createFileFetchTool(): AnyAgentTool {
       if (isInlineImage) {
         content.push({ type: "image", data: base64, mimeType });
       } else if (isInlineText) {
-        const text = buffer.toString("utf-8");
+        const decodedText = buffer.toString("utf-8");
+        const text = decodedText.startsWith("\uFEFF") ? decodedText.slice(1) : decodedText;
         const wrappedText = wrapExternalContent(
           `Fetched ${canonicalPath} (${humanSize(size)}, ${mimeType}, sha256:${shortHash}) saved at ${localPath}\n\n--- contents ---\n${text}`,
           { source: "unknown" },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users fetching a small UTF-8 text file from a paired node could expose a leading byte order mark as the first model-visible character in the inline `file_fetch` contents.

## Why This Change Was Made

Inline text now removes one leading UTF-8 BOM after decoding, matching existing model-facing read behavior. The original fetched bytes still drive the saved media file, size, and sha256 integrity fields.

## User Impact

Models receive markdown and structured text without an invisible leading character that can interfere with first-character parsing, while fetched file bytes remain unchanged for saved-file workflows.

## Evidence

- `node scripts/run-vitest.mjs extensions/file-transfer/src/tools/file-fetch-tool.test.ts`: 1 file passed, 4 tests passed.
- Node-host plus production-module boundary proof wrote a real markdown file, read it through `extensions/file-transfer/src/node-host/file-fetch.ts`, then relayed that payload through `extensions/file-transfer/src/tools/file-fetch-tool.ts` on the pinned base and exact head:

```text
base 4624f681add592b8a3bbf937382192f8200aaf3d:
nodeHostOk=true
nodeHostShaMatches=true
nodeHostBase64Matches=true
inlineStartsWithBom=true
embeddedBomPreserved=true
detailsShaMatches=true
savedBytesMatch=true

head 49666106b6be0491c5c2e7dd838533c7c0675d3a:
nodeHostOk=true
nodeHostShaMatches=true
nodeHostBase64Matches=true
inlineStartsWithBom=false
embeddedBomPreserved=true
detailsShaMatches=true
savedBytesMatch=true

head negative control without a leading BOM:
nodeHostOk=true
nodeHostShaMatches=true
nodeHostBase64Matches=true
inlineStartsWithBom=false
embeddedBomPreserved=true
detailsShaMatches=true
savedBytesMatch=true
```

<details>
<summary>proof-live.ts</summary>

```ts
import crypto from "node:crypto";
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { pathToFileURL } from "node:url";

type ProofState = {
  callGatewayTool: (method: string, body: Record<string, unknown>) => Promise<unknown>;
  saveMediaBuffer: (
    buffer: Buffer,
    mimeType: string,
    subdir: string,
    maxBytes: number,
  ) => Promise<{ id: string; path: string; size: number; contentType: string }>;
};

declare global {
  var __fileFetchProof: ProofState;
  var __fileFetchProofHandleFileFetch:
    | ((params: Record<string, unknown>) => Promise<Record<string, unknown>>)
    | undefined;
}

const bomText = "\uFEFF# Title\nembedded marker: \uFEFFkeep\n";
const plainText = "# Title\nembedded marker: \uFEFFkeep\n";
const payloadText = process.argv.includes("--plain") ? plainText : bomText;
const buffer = Buffer.from(payloadText, "utf-8");
const sha256 = crypto.createHash("sha256").update(buffer).digest("hex");
let savedHex = "";

globalThis.__fileFetchProof = {
  async callGatewayTool(method, body) {
    if (method !== "node.invoke") throw new Error(`unexpected method ${method}`);
    const handleFileFetch = globalThis.__fileFetchProofHandleFileFetch;
    if (!handleFileFetch) throw new Error("missing handleFileFetch");
    return { payload: await handleFileFetch(body.params as Record<string, unknown>) };
  },
  async saveMediaBuffer(savedBuffer, mimeType) {
    savedHex = savedBuffer.toString("hex");
    return {
      id: "media-1",
      path: "/gateway/media/file-transfer/bom.md",
      size: savedBuffer.byteLength,
      contentType: mimeType,
    };
  },
};

async function main() {
  const repoPath = process.env.OPENCLAW_PROOF_REPO ?? ".";
  const tmpRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "file-fetch-proof-")));
  try {
    const filePath = path.join(tmpRoot, "bom.md");
    await fs.writeFile(filePath, buffer);
    const nodeHost = await import(
      pathToFileURL(path.resolve(repoPath, "extensions/file-transfer/src/node-host/file-fetch.ts")).href
    );
    globalThis.__fileFetchProofHandleFileFetch = nodeHost.handleFileFetch;
    const nodeHostPayload = await nodeHost.handleFileFetch({ path: filePath });
    const toolModule = await import(
      pathToFileURL(path.resolve(repoPath, "extensions/file-transfer/src/tools/file-fetch-tool.ts")).href
    );
    const result = await toolModule.createFileFetchTool().execute("proof-call", {
      node: "node-1",
      path: filePath,
    });
    const inlineText = result.content[0]?.type === "text" ? result.content[0].text ?? "" : "";
    const contents = inlineText.slice(inlineText.indexOf("--- contents ---"));

    console.log(`input=${process.argv.includes("--plain") ? "plain" : "bom"}`);
    console.log(`nodeHostOk=${nodeHostPayload.ok === true}`);
    console.log(`nodeHostShaMatches=${nodeHostPayload.sha256 === sha256}`);
    console.log(`nodeHostBase64Matches=${nodeHostPayload.base64 === buffer.toString("base64")}`);
    console.log(`inlineStartsWithBom=${contents.startsWith("--- contents ---\n\uFEFF")}`);
    console.log(`embeddedBomPreserved=${contents.includes("marker: \uFEFFkeep")}`);
    console.log(`detailsShaMatches=${result.details.sha256 === sha256}`);
    console.log(`savedBytesMatch=${savedHex === buffer.toString("hex")}`);
  } finally {
    await fs.rm(tmpRoot, { recursive: true, force: true });
  }
}

main().catch((error) => {
  console.error(error);
  process.exitCode = 1;
});
```

</details>

AI-assisted: built with Codex
