### PR TITLE
feat(ui): add per-connector tool access to composer

### DIFF
--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -41,17 +41,20 @@ function skill(
   };
 }
 
-function sessionsList(toolOverrides?: Record<string, unknown>) {
+function sessionsList(
+  toolOverrides?: Record<string, unknown>,
+  model: { id: string; provider: string } = { id: "gpt-5.5", provider: "openai" },
+) {
   return {
     count: 1,
-    defaults: { contextTokens: 200_000, model: "gpt-5.5", modelProvider: "openai" },
+    defaults: { contextTokens: 200_000, model: model.id, modelProvider: model.provider },
     path: "",
     sessions: [
       {
         key: "main",
         kind: "direct",
-        model: "gpt-5.5",
-        modelProvider: "openai",
+        model: model.id,
+        modelProvider: model.provider,
         status: "done",
         updatedAt: Date.now(),
         ...(toolOverrides ? { toolOverrides } : {}),
@@ -368,24 +371,44 @@ describeControlUiE2e("Control UI composer capability menu", () => {
       await expect.poll(() => menu.getByRole("menuitem", { name: "delete_page" }).count()).toBe(0);
 
       const toolRows = menu.locator('wa-dropdown-item[value^="mcp-tool:"]');
+      const rawToolNames = toolRows.locator(
+        ".agent-chat__capability-menu-label > span:first-child",
+      );
       await expect
-        .poll(() => toolRows.allTextContents())
-        .toEqual([
-          expect.stringContaining("list_issues"),
-          expect.stringContaining("search_items"),
-          expect.stringContaining("search_items"),
-        ]);
-      const collisions = toolRows.filter({ hasText: "search_items" });
-      await expect.poll(() => collisions.count()).toBe(2);
+        .poll(() => rawToolNames.allTextContents())
+        .toEqual(["list-issues", "search-items", "search_items"]);
+      await expect
+        .poll(async () => [
+          await rawToolNames.nth(1).isVisible(),
+          await rawToolNames.nth(2).isVisible(),
+        ])
+        .toEqual([true, true]);
       await expect
         .poll(() =>
-          collisions
-            .nth(1)
+          toolRows
+            .nth(2)
             .locator("wa-switch")
             .evaluate((node) => (node as HTMLElement & { checked: boolean }).checked),
         )
         .toBe(false);
-      await collisions.first().click();
+
+      await gateway.deferNext("tools.effective");
+      await gateway.setMethodResponse(
+        "sessions.list",
+        sessionsList(
+          { mcpToolsDeny: { github: ["search_items"] } },
+          { id: "gpt-5.6", provider: "openai" },
+        ),
+      );
+      await gateway.emitGatewayEvent("sessions.changed", { sessionKey: "main" });
+      await expect.poll(async () => (await gateway.getRequests("tools.effective")).length).toBe(2);
+      await expect.poll(() => menu.getByText("Loading tools…").isVisible()).toBe(true);
+      await gateway.resolveDeferred("tools.effective", effectiveToolsResponse());
+      await expect
+        .poll(() => rawToolNames.allTextContents())
+        .toEqual(["list-issues", "search-items", "search_items"]);
+
+      await toolRows.nth(1).click();
       await expect
         .poll(() => latestToolOverrides(gateway))
         .toEqual({ mcpToolsDeny: { github: ["search-items", "search_items"] } });

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -87,7 +87,7 @@ function configResponse(
   };
 }
 
-function effectiveToolsResponse() {
+function effectiveToolsResponse(serverName = "github") {
   return {
     agentId: "main",
     profile: "full",
@@ -103,7 +103,7 @@ function effectiveToolsResponse() {
             description: "List issues",
             rawDescription: "List issues",
             source: "mcp",
-            mcpServer: "github",
+            mcpServer: serverName,
             mcpToolName: "list-issues",
           },
           {
@@ -112,7 +112,7 @@ function effectiveToolsResponse() {
             description: "Search items",
             rawDescription: "Search items",
             source: "mcp",
-            mcpServer: "github",
+            mcpServer: serverName,
             mcpToolName: "search-items",
           },
           {
@@ -121,7 +121,7 @@ function effectiveToolsResponse() {
             description: "Search items",
             rawDescription: "Search items",
             source: "mcp",
-            mcpServer: "github",
+            mcpServer: serverName,
             mcpToolName: "search_items",
             deniedBySession: true,
           },
@@ -416,6 +416,37 @@ describeControlUiE2e("Control UI composer capability menu", () => {
 
       await menu.getByRole("menuitem", { name: "Back" }).click();
       await expect.poll(() => menu.getAttribute("data-view")).toBe("connectors");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it('renders tool access for a server named "constructor"', async () => {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
+      methodResponses: {
+        "config.get": configResponse({
+          constructor: { url: "https://mcp.example.test", enabled: true },
+        }),
+        "sessions.list": sessionsList({
+          mcpToolsDeny: { github: ["search_items"] },
+        }),
+        "tools.effective": effectiveToolsResponse("constructor"),
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const composer = await openMenu(page);
+      const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
+      await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
+      await menu.getByRole("menuitem", { name: "Tool access" }).click();
+
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("tools:constructor");
+      await expect.poll(() => menu.getByText("3 of 3 tools on").isVisible()).toBe(true);
+      await expect.poll(() => menu.locator('wa-dropdown-item[value^="mcp-tool:"]').count()).toBe(3);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -84,6 +84,59 @@ function configResponse(
   };
 }
 
+function effectiveToolsResponse() {
+  return {
+    agentId: "main",
+    profile: "full",
+    groups: [
+      {
+        id: "mcp",
+        label: "MCP",
+        source: "mcp",
+        tools: [
+          {
+            id: "mcp_github_list_issues",
+            label: "list_issues",
+            description: "List issues",
+            rawDescription: "List issues",
+            source: "mcp",
+            mcpServer: "github",
+            mcpToolName: "list-issues",
+          },
+          {
+            id: "mcp_github_search_items_dash",
+            label: "search_items",
+            description: "Search items",
+            rawDescription: "Search items",
+            source: "mcp",
+            mcpServer: "github",
+            mcpToolName: "search-items",
+          },
+          {
+            id: "mcp_github_search_items_underscore",
+            label: "search_items",
+            description: "Search items",
+            rawDescription: "Search items",
+            source: "mcp",
+            mcpServer: "github",
+            mcpToolName: "search_items",
+            deniedBySession: true,
+          },
+          {
+            id: "mcp_notion_delete_page",
+            label: "delete_page",
+            description: "Delete a page",
+            rawDescription: "Delete a page",
+            source: "mcp",
+            mcpServer: "notion",
+            mcpToolName: "delete_page",
+          },
+        ],
+      },
+    ],
+  };
+}
+
 async function latestToolOverrides(gateway: MockGatewayControls) {
   const requests = await gateway.getRequests("sessions.patch");
   return (requests.at(-1)?.params as { toolOverrides?: unknown } | undefined)?.toolOverrides;
@@ -99,9 +152,19 @@ function configPatchRaw(request: { params?: unknown }) {
 
 async function openMenu(page: Page) {
   const composer = page.locator(".agent-chat__input");
-  await composer.getByRole("button", { name: "Add attachment" }).click();
+  const dropdown = composer.locator("wa-dropdown.agent-chat__capability-menu");
+  const skills = composer.getByRole("menuitem", { name: "Skills" });
+  const isOpen = await dropdown.evaluate((node) => (node as HTMLElement & { open: boolean }).open);
+  if (!isOpen) {
+    await composer.getByRole("button", { name: "Add attachment" }).click();
+  }
   await expect
-    .poll(() => composer.getByRole("menuitem", { name: "Skills" }).isVisible())
+    .poll(async () => {
+      const open = await dropdown.evaluate(
+        (node) => (node as HTMLElement & { open: boolean }).open,
+      );
+      return open && (await skills.isVisible());
+    })
     .toBe(true);
   return composer;
 }
@@ -272,6 +335,115 @@ describeControlUiE2e("Control UI composer capability menu", () => {
       expect(themeBackgrounds[0]).not.toBe("");
       expect(themeBackgrounds[1]).not.toBe("");
       expect(themeBackgrounds[0]).not.toBe(themeBackgrounds[1]);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("shows per-connector tool access and preserves raw MCP tool identity", async () => {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
+      methodResponses: {
+        "config.get": configResponse({
+          github: { url: "https://mcp.example.test", enabled: true },
+          notion: { command: "notion-mcp", enabled: true },
+        }),
+        "sessions.list": sessionsList({
+          mcpToolsDeny: { github: ["search_items"] },
+        }),
+        "tools.effective": effectiveToolsResponse(),
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const composer = await openMenu(page);
+      const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
+      await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
+      await menu.getByRole("menuitem", { name: "Tool access" }).first().click();
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("tools:github");
+      await expect.poll(() => menu.getByText("2 of 3 tools on").isVisible()).toBe(true);
+      await expect.poll(() => menu.getByRole("menuitem", { name: "delete_page" }).count()).toBe(0);
+
+      const toolRows = menu.locator('wa-dropdown-item[value^="mcp-tool:"]');
+      await expect
+        .poll(() => toolRows.allTextContents())
+        .toEqual([
+          expect.stringContaining("list_issues"),
+          expect.stringContaining("search_items"),
+          expect.stringContaining("search_items"),
+        ]);
+      const collisions = toolRows.filter({ hasText: "search_items" });
+      await expect.poll(() => collisions.count()).toBe(2);
+      await expect
+        .poll(() =>
+          collisions
+            .nth(1)
+            .locator("wa-switch")
+            .evaluate((node) => (node as HTMLElement & { checked: boolean }).checked),
+        )
+        .toBe(false);
+      await collisions.first().click();
+      await expect
+        .poll(() => latestToolOverrides(gateway))
+        .toEqual({ mcpToolsDeny: { github: ["search-items", "search_items"] } });
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("tools:github");
+
+      await menu.getByRole("menuitem", { name: "Back" }).click();
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("connectors");
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("blocks tool mutations until the session, runtime config, and catalog are ready", async () => {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
+      deferredMethods: ["sessions.list", "tools.effective"],
+      methodResponses: {
+        "config.get": configResponse({
+          github: { url: "https://mcp.example.test", enabled: true },
+        }),
+        "tools.effective": effectiveToolsResponse(),
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await gateway.waitForRequest("sessions.list");
+      const composer = await openMenu(page);
+      const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
+      await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
+      await menu.getByRole("menuitem", { name: "Tool access" }).click();
+      await gateway.waitForRequest("tools.effective");
+      await expect.poll(() => menu.getByText("Loading tools…").isVisible()).toBe(true);
+      expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
+
+      await gateway.resolveDeferred("tools.effective", effectiveToolsResponse());
+      const listIssues = menu.locator('wa-dropdown-item[value="mcp-tool:0"]');
+      await expect.poll(() => listIssues.isDisabled()).toBe(true);
+      await expect.poll(() => listIssues.getAttribute("title")).toBe("Loading…");
+      await listIssues.evaluate((item) => {
+        item
+          .closest("wa-dropdown")
+          ?.dispatchEvent(new CustomEvent("wa-select", { bubbles: true, detail: { item } }));
+      });
+      expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
+
+      await gateway.resolveDeferred("sessions.list", sessionsList());
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("tools:github");
+      await menu.getByRole("menuitem", { name: "Back" }).click();
+      await menu.getByRole("menuitem", { name: "Tool access" }).click();
+      const readyListIssues = menu.locator('wa-dropdown-item[value="mcp-tool:0"]');
+      await expect.poll(() => readyListIssues.isDisabled()).toBe(false);
+      await readyListIssues.click();
+      await expect
+        .poll(() => latestToolOverrides(gateway))
+        .toEqual({ mcpToolsDeny: { github: ["list-issues"] } });
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -424,7 +424,7 @@ describeControlUiE2e("Control UI composer capability menu", () => {
   it('renders tool access for a server named "constructor"', async () => {
     const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
     const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
+    await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
       methodResponses: {
         "config.get": configResponse({

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5015,7 +5015,14 @@ export const en: TranslationMap = {
         scopeSessionHint:
           "The server is saved globally disabled and enabled only for this session.",
         scopeEverywhereHint: "The server is saved and enabled for every session.",
-        toolAccess: "Tool access",
+        toolAccess: {
+          label: "Tool access",
+          loading: "Loading tools…",
+          loadFailed: "Couldn’t load tools.",
+          noTools: "No tools available for this connector.",
+          summary: "{enabled} of {total} tools on",
+          summaryOne: "{enabled} of {total} tool on",
+        },
         enabledCount: "{count} on",
         loadingSkills: "Loading skills…",
         skillsLoadFailed: "Couldn’t load skills.",

--- a/ui/src/lib/sessions/tool-overrides.test.ts
+++ b/ui/src/lib/sessions/tool-overrides.test.ts
@@ -79,6 +79,25 @@ describe("session tool overrides", () => {
     ).toEqual({});
   });
 
+  it("treats constructor as an own MCP server key", () => {
+    expect(
+      nextMcpToolsDenyOverrides(
+        { mcpToolsDeny: { github: ["read"] } },
+        "constructor",
+        "inspect",
+        true,
+      ),
+    ).toEqual({
+      mcpToolsDeny: { constructor: ["inspect"], github: ["read"] },
+    });
+  });
+
+  it.each(["mcpServers", "skills"] as const)("treats hasOwnProperty as an own %s key", (group) => {
+    expect(nextBooleanToolOverrides({}, group, "hasOwnProperty", false, true)).toEqual({
+      [group]: { hasOwnProperty: false },
+    });
+  });
+
   it("counts override categories and returns deterministic tooltip names", () => {
     const overrides = {
       mcpServers: { zeta: false, alpha: true },

--- a/ui/src/lib/sessions/tool-overrides.test.ts
+++ b/ui/src/lib/sessions/tool-overrides.test.ts
@@ -4,6 +4,7 @@ import {
   nextBooleanToolOverrides,
   nextMcpToolsDenyOverrides,
   nextWebSearchToolOverrides,
+  readOwnEntry,
   resolveToolOverrideState,
   sessionToolOverrideNames,
 } from "./tool-overrides.ts";
@@ -14,6 +15,11 @@ describe("session tool overrides", () => {
     expect(resolveToolOverrideState(false, undefined)).toBe(false);
     expect(resolveToolOverrideState(true, false)).toBe(false);
     expect(resolveToolOverrideState(false, true)).toBe(true);
+  });
+
+  it("reads only own dynamic-key entries", () => {
+    expect(readOwnEntry({ github: false }, "constructor")).toBeUndefined();
+    expect(readOwnEntry({ constructor: false }, "constructor")).toBe(false);
   });
 
   it("adds and removes named overrides without disturbing sibling groups", () => {

--- a/ui/src/lib/sessions/tool-overrides.test.ts
+++ b/ui/src/lib/sessions/tool-overrides.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   countSessionToolOverrides,
   nextBooleanToolOverrides,
+  nextMcpToolsDenyOverrides,
   nextWebSearchToolOverrides,
   resolveToolOverrideState,
   sessionToolOverrideNames,
@@ -42,6 +43,40 @@ describe("session tool overrides", () => {
     expect(nextWebSearchToolOverrides(off, true)).toEqual({ skills: { docs: true } });
     expect(nextWebSearchToolOverrides({}, true, false)).toEqual({ webSearch: true });
     expect(nextWebSearchToolOverrides({ webSearch: true }, false, false)).toEqual({});
+  });
+
+  it("adds sorted MCP tool denials without mutating sibling overrides", () => {
+    const current = {
+      mcpToolsDeny: { github: ["zebra"], notion: ["delete_page"] },
+      webSearch: false,
+    };
+    expect(nextMcpToolsDenyOverrides(current, "github", "alpha", true)).toEqual({
+      mcpToolsDeny: { github: ["alpha", "zebra"], notion: ["delete_page"] },
+      webSearch: false,
+    });
+    expect(current.mcpToolsDeny.github).toEqual(["zebra"]);
+  });
+
+  it("removes MCP tool denials and keeps the map sparse", () => {
+    expect(
+      nextMcpToolsDenyOverrides(
+        { mcpToolsDeny: { github: ["read", "write"], notion: ["delete_page"] } },
+        "github",
+        "read",
+        false,
+      ),
+    ).toEqual({ mcpToolsDeny: { github: ["write"], notion: ["delete_page"] } });
+    expect(
+      nextMcpToolsDenyOverrides(
+        { mcpToolsDeny: { github: ["write"], notion: ["delete_page"] } },
+        "github",
+        "write",
+        false,
+      ),
+    ).toEqual({ mcpToolsDeny: { notion: ["delete_page"] } });
+    expect(
+      nextMcpToolsDenyOverrides({ mcpToolsDeny: { github: ["write"] } }, "github", "write", false),
+    ).toEqual({});
   });
 
   it("counts override categories and returns deterministic tooltip names", () => {

--- a/ui/src/lib/sessions/tool-overrides.ts
+++ b/ui/src/lib/sessions/tool-overrides.ts
@@ -2,17 +2,44 @@ import type { SessionToolOverrides } from "./patch.ts";
 
 type BooleanOverrideGroup = "mcpServers" | "skills";
 
+function copyDynamicKeyRecord<T>(
+  values: Record<string, T> | undefined,
+  copyValue: (value: T) => T = (value) => value,
+): Record<string, T> {
+  const copy: Record<string, T> = {};
+  for (const [name, value] of Object.entries(values ?? {})) {
+    Object.defineProperty(copy, name, {
+      configurable: true,
+      enumerable: true,
+      value: copyValue(value),
+      writable: true,
+    });
+  }
+  return copy;
+}
+
+function ownValue<T>(values: Record<string, T> | undefined, name: string): T | undefined {
+  return values && Object.hasOwn(values, name) ? values[name] : undefined;
+}
+
+function setOwnValue<T>(values: Record<string, T>, name: string, value: T): void {
+  Object.defineProperty(values, name, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
 function copyOverrides(overrides: SessionToolOverrides | null | undefined): SessionToolOverrides {
   return {
-    ...(overrides?.mcpServers ? { mcpServers: { ...overrides.mcpServers } } : {}),
+    ...(overrides?.mcpServers ? { mcpServers: copyDynamicKeyRecord(overrides.mcpServers) } : {}),
     ...(overrides?.mcpToolsDeny
       ? {
-          mcpToolsDeny: Object.fromEntries(
-            Object.entries(overrides.mcpToolsDeny).map(([name, tools]) => [name, [...tools]]),
-          ),
+          mcpToolsDeny: copyDynamicKeyRecord(overrides.mcpToolsDeny, (tools) => [...tools]),
         }
       : {}),
-    ...(overrides?.skills ? { skills: { ...overrides.skills } } : {}),
+    ...(overrides?.skills ? { skills: copyDynamicKeyRecord(overrides.skills) } : {}),
     ...(overrides?.webSearch !== undefined ? { webSearch: overrides.webSearch } : {}),
   };
 }
@@ -29,11 +56,11 @@ export function nextBooleanToolOverrides(
   baseEnabled: boolean,
 ): SessionToolOverrides {
   const next = copyOverrides(current);
-  const values = { ...next[group] };
+  const values = copyDynamicKeyRecord(Object.hasOwn(next, group) ? next[group] : undefined);
   if (nextEnabled === baseEnabled) {
     delete values[name];
   } else {
-    values[name] = nextEnabled;
+    setOwnValue(values, name, nextEnabled);
   }
   if (Object.keys(values).length === 0) {
     delete next[group];
@@ -64,15 +91,16 @@ export function nextMcpToolsDenyOverrides(
   denied: boolean,
 ): SessionToolOverrides {
   const next = copyOverrides(current);
-  const deniedTools = new Set(next.mcpToolsDeny?.[server] ?? []);
+  const currentDeny = Object.hasOwn(next, "mcpToolsDeny") ? next.mcpToolsDeny : undefined;
+  const deniedTools = new Set(ownValue(currentDeny, server) ?? []);
   if (denied) {
     deniedTools.add(rawToolName);
   } else {
     deniedTools.delete(rawToolName);
   }
-  const mcpToolsDeny = { ...next.mcpToolsDeny };
+  const mcpToolsDeny = copyDynamicKeyRecord(currentDeny, (tools) => [...tools]);
   if (deniedTools.size > 0) {
-    mcpToolsDeny[server] = [...deniedTools].toSorted();
+    setOwnValue(mcpToolsDeny, server, [...deniedTools].toSorted());
   } else {
     delete mcpToolsDeny[server];
   }

--- a/ui/src/lib/sessions/tool-overrides.ts
+++ b/ui/src/lib/sessions/tool-overrides.ts
@@ -18,8 +18,11 @@ function copyDynamicKeyRecord<T>(
   return copy;
 }
 
-function ownValue<T>(values: Record<string, T> | undefined, name: string): T | undefined {
-  return values && Object.hasOwn(values, name) ? values[name] : undefined;
+export function readOwnEntry<T>(
+  values: Readonly<Record<string, T>> | null | undefined,
+  name: string,
+): T | undefined {
+  return values != null && Object.hasOwn(values, name) ? values[name] : undefined;
 }
 
 function setOwnValue<T>(values: Record<string, T>, name: string, value: T): void {
@@ -92,7 +95,7 @@ export function nextMcpToolsDenyOverrides(
 ): SessionToolOverrides {
   const next = copyOverrides(current);
   const currentDeny = Object.hasOwn(next, "mcpToolsDeny") ? next.mcpToolsDeny : undefined;
-  const deniedTools = new Set(ownValue(currentDeny, server) ?? []);
+  const deniedTools = new Set(readOwnEntry(currentDeny, server) ?? []);
   if (denied) {
     deniedTools.add(rawToolName);
   } else {

--- a/ui/src/lib/sessions/tool-overrides.ts
+++ b/ui/src/lib/sessions/tool-overrides.ts
@@ -57,6 +57,33 @@ export function nextWebSearchToolOverrides(
   return next;
 }
 
+export function nextMcpToolsDenyOverrides(
+  current: SessionToolOverrides | null | undefined,
+  server: string,
+  rawToolName: string,
+  denied: boolean,
+): SessionToolOverrides {
+  const next = copyOverrides(current);
+  const deniedTools = new Set(next.mcpToolsDeny?.[server] ?? []);
+  if (denied) {
+    deniedTools.add(rawToolName);
+  } else {
+    deniedTools.delete(rawToolName);
+  }
+  const mcpToolsDeny = { ...next.mcpToolsDeny };
+  if (deniedTools.size > 0) {
+    mcpToolsDeny[server] = [...deniedTools].toSorted();
+  } else {
+    delete mcpToolsDeny[server];
+  }
+  if (Object.keys(mcpToolsDeny).length === 0) {
+    delete next.mcpToolsDeny;
+  } else {
+    next.mcpToolsDeny = mcpToolsDeny;
+  }
+  return next;
+}
+
 export function countSessionToolOverrides(
   overrides: SessionToolOverrides | null | undefined,
 ): number {

--- a/ui/src/pages/chat/chat-composer-capability-host.test.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.test.ts
@@ -294,6 +294,46 @@ describe("ChatComposerCapabilityHost", () => {
     expect(props.webSearchBaseEnabled).toBe(true);
   });
 
+  it("refetches effective tools when the active connector set changes", async () => {
+    const host = new ChatComposerCapabilityHost(vi.fn());
+    const context = createContext({
+      runtimeConfig: {
+        mcp: { servers: { github: { url: "https://mcp.example.test", enabled: true } } },
+      },
+    });
+    context.gateway.snapshot.hello = {
+      features: { methods: ["tools.effective"] },
+    } as NonNullable<typeof context.gateway.snapshot.hello>;
+    const firstResult = { agentId: "main", groups: [], profile: "full" };
+    const secondResult = { agentId: "main", groups: [], profile: "minimal" };
+    const request = vi.fn().mockResolvedValueOnce(firstResult).mockResolvedValueOnce(secondResult);
+    const state = createState();
+    state.client = { request } as unknown as GatewayBrowserClient;
+    const session = { key: "main" } as GatewaySessionRow;
+
+    host.props(context, state, session, "main").onOpenToolAccess?.("github");
+    await vi.waitFor(() => {
+      expect(host.props(context, state, session, "main").toolsEffectiveResult).toBe(firstResult);
+    });
+
+    context.runtimeConfig.state.configSnapshot = {
+      runtimeConfig: {
+        mcp: {
+          servers: {
+            github: { url: "https://mcp.example.test", enabled: true },
+            notion: { command: "notion-mcp", enabled: true },
+          },
+        },
+      },
+    };
+    host.props(context, state, session, "main").onEnsureToolAccess?.();
+
+    await vi.waitFor(() => {
+      expect(host.props(context, state, session, "main").toolsEffectiveResult).toBe(secondResult);
+    });
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
   it("records an unexpected effective-tools loader rejection", async () => {
     const notify = vi.fn();
     const host = new ChatComposerCapabilityHost(notify);

--- a/ui/src/pages/chat/chat-composer-capability-host.test.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.test.ts
@@ -327,7 +327,7 @@ describe("ChatComposerCapabilityHost", () => {
         },
       },
     };
-    host.props(context, state, session, "main").onEnsureToolAccess?.();
+    host.props(context, state, session, "main").onEnsureToolAccess?.("github");
 
     await vi.waitFor(() => {
       expect(host.props(context, state, session, "main").toolsEffectiveResult).toBe(secondResult);

--- a/ui/src/pages/chat/chat-composer-capability-host.test.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.test.ts
@@ -294,9 +294,10 @@ describe("ChatComposerCapabilityHost", () => {
     expect(props.webSearchBaseEnabled).toBe(true);
   });
 
-  it("refetches effective tools when the active connector set changes", async () => {
+  it("refetches effective tools when an active connector definition changes", async () => {
     const host = new ChatComposerCapabilityHost(vi.fn());
     const context = createContext({
+      appliedConfigHash: "config-1",
       runtimeConfig: {
         mcp: { servers: { github: { url: "https://mcp.example.test", enabled: true } } },
       },
@@ -317,11 +318,11 @@ describe("ChatComposerCapabilityHost", () => {
     });
 
     context.runtimeConfig.state.configSnapshot = {
+      appliedConfigHash: "config-2",
       runtimeConfig: {
         mcp: {
           servers: {
-            github: { url: "https://mcp.example.test", enabled: true },
-            notion: { command: "notion-mcp", enabled: true },
+            github: { url: "https://new-mcp.example.test", enabled: true },
           },
         },
       },

--- a/ui/src/pages/chat/chat-composer-capability-host.test.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.test.ts
@@ -21,6 +21,7 @@ function createContext(configSnapshot: ConfigSnapshot | null): ApplicationContex
       ensureLoaded: vi.fn(async () => undefined),
       state: { configLoading: false, configSnapshot },
     },
+    sessions: { state: { modelOverrides: {} } },
   } as unknown as ApplicationContext;
 }
 
@@ -291,5 +292,44 @@ describe("ChatComposerCapabilityHost", () => {
       { name: "runtime", enabled: false },
     ]);
     expect(props.webSearchBaseEnabled).toBe(true);
+  });
+
+  it("records an unexpected effective-tools loader rejection", async () => {
+    const notify = vi.fn();
+    const host = new ChatComposerCapabilityHost(notify);
+    const context = createContext({ runtimeConfig: {} });
+    context.gateway.snapshot.hello = {
+      features: { methods: ["tools.effective"] },
+    } as NonNullable<typeof context.gateway.snapshot.hello>;
+    let stateReads = 0;
+    Object.defineProperty(context.sessions, "state", {
+      configurable: true,
+      get: () => {
+        stateReads += 1;
+        if (stateReads === 3) {
+          throw new Error("unexpected loader failure");
+        }
+        return { modelOverrides: {} };
+      },
+    });
+    const state = createState();
+    const request = vi.fn().mockResolvedValue({ agentId: "main", groups: [], profile: "full" });
+    state.client = { request } as unknown as GatewayBrowserClient;
+    const session = { key: "main" } as GatewaySessionRow;
+
+    host.props(context, state, session, "main").onOpenToolAccess?.("github");
+    await vi.waitFor(() => {
+      expect(host.props(context, state, session, "main").toolsEffectiveError).toBe(true);
+    });
+
+    expect(host.props(context, state, session, "main").toolAccessMutationBlockedReason).toBe(
+      "Couldn’t load tools.",
+    );
+
+    host.props(context, state, session, "main").onOpenToolAccess?.("github");
+    await vi.waitFor(() => {
+      expect(host.props(context, state, session, "main").toolsEffectiveResult).not.toBeNull();
+    });
+    expect(request).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/pages/chat/chat-composer-capability-host.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.ts
@@ -201,6 +201,7 @@ export class ChatComposerCapabilityHost {
     context: ApplicationContext,
     state: ChatPageHost,
     agentId: string,
+    retryError = false,
   ): void {
     const client = state.client;
     const sessionKey = state.sessionKey;
@@ -209,7 +210,8 @@ export class ChatComposerCapabilityHost {
       !state.connected ||
       !client ||
       this.effectiveTools.has(requestKey) ||
-      this.effectiveToolsLoadingKey === requestKey
+      this.effectiveToolsLoadingKey === requestKey ||
+      (!retryError && this.effectiveToolsErrors.has(requestKey))
     ) {
       return;
     }
@@ -241,6 +243,11 @@ export class ChatComposerCapabilityHost {
         if (loader.toolsEffectiveResult && loader.toolsEffectiveResultKey === requestKey) {
           this.effectiveTools.set(requestKey, loader.toolsEffectiveResult);
         } else if (loader.toolsEffectiveError) {
+          this.effectiveToolsErrors.add(requestKey);
+        }
+      })
+      .catch(() => {
+        if (isCurrent()) {
           this.effectiveToolsErrors.add(requestKey);
         }
       })
@@ -612,7 +619,10 @@ export class ChatComposerCapabilityHost {
         this.notify();
       },
       ...(effectiveToolsAvailable
-        ? { onOpenToolAccess: () => this.loadEffectiveTools(context, state, agentId) }
+        ? {
+            onEnsureToolAccess: () => this.loadEffectiveTools(context, state, agentId),
+            onOpenToolAccess: () => this.loadEffectiveTools(context, state, agentId, true),
+          }
         : {}),
     };
   }

--- a/ui/src/pages/chat/chat-composer-capability-host.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.ts
@@ -26,7 +26,10 @@ import {
 } from "../../lib/sessions/index.ts";
 import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
-import { nextBooleanToolOverrides } from "../../lib/sessions/tool-overrides.ts";
+import {
+  nextBooleanToolOverrides,
+  readOwnEntry,
+} from "../../lib/sessions/tool-overrides.ts";
 import { loadSkillStatusReport } from "../../lib/skills/index.ts";
 import { refreshCurrentChatSessionList } from "./chat-session.ts";
 import { patchChatSessionSettings } from "./chat-settings-patches.ts";
@@ -62,6 +65,12 @@ function webSearchBaseEnabled(config: Record<string, unknown> | null): boolean {
   return asRecord(asRecord(asRecord(config?.tools)?.web)?.search)?.enabled !== false;
 }
 
+function mcpConnectorSetFingerprint(config: Record<string, unknown> | null): string {
+  return JSON.stringify(
+    (summarizeMcpServers(config) ?? []).map(({ name, enabled }) => [name, enabled] as const),
+  );
+}
+
 function toComposerSkill(skill: SkillStatusEntry): ChatComposerMenuSkill {
   const missingDeps = Object.values(skill.missing).some((values) => values.length > 0);
   const blocked = skill.blockedByAllowlist || skill.blockedByAgentFilter === true;
@@ -81,8 +90,8 @@ export class ChatComposerCapabilityHost {
   private readonly loading = new Set<string>();
   private readonly loadErrors = new Set<string>();
   private readonly patchTokens = new Map<string, symbol>();
-  private readonly effectiveTools = new Map<string, ToolsEffectiveResult>();
-  private readonly effectiveToolsErrors = new Set<string>();
+  private effectiveTools: { key: string; result: ToolsEffectiveResult } | null = null;
+  private effectiveToolsErrorKey: string | null = null;
   private effectiveToolsLoadingKey: string | null = null;
   private client: GatewayBrowserClient | null = null;
   private addDialogOpen = false;
@@ -182,12 +191,12 @@ export class ChatComposerCapabilityHost {
       });
   }
 
-  private effectiveToolsKey(
+  private effectiveToolsKeys(
     context: ApplicationContext,
     state: ChatPageHost,
     agentId: string,
-  ): string {
-    return buildToolsEffectiveRequestKey(
+  ): { cacheKey: string; requestKey: string } {
+    const requestKey = buildToolsEffectiveRequestKey(
       {
         chatModelCatalog: state.chatModelCatalog,
         sessions: context.sessions,
@@ -195,6 +204,9 @@ export class ChatComposerCapabilityHost {
       },
       { agentId, sessionKey: state.sessionKey },
     );
+    const runtimeConfig = context.runtimeConfig.state.configSnapshot?.runtimeConfig ?? null;
+    const connectorSet = mcpConnectorSetFingerprint(runtimeConfig);
+    return { cacheKey: `${requestKey}\0mcp=${connectorSet}`, requestKey };
   }
 
   private loadEffectiveTools(
@@ -205,13 +217,13 @@ export class ChatComposerCapabilityHost {
   ): void {
     const client = state.client;
     const sessionKey = state.sessionKey;
-    const requestKey = this.effectiveToolsKey(context, state, agentId);
+    const { cacheKey, requestKey } = this.effectiveToolsKeys(context, state, agentId);
     if (
       !state.connected ||
       !client ||
-      this.effectiveTools.has(requestKey) ||
-      this.effectiveToolsLoadingKey === requestKey ||
-      (!retryError && this.effectiveToolsErrors.has(requestKey))
+      this.effectiveTools?.key === cacheKey ||
+      this.effectiveToolsLoadingKey === cacheKey ||
+      (!retryError && this.effectiveToolsErrorKey === cacheKey)
     ) {
       return;
     }
@@ -231,9 +243,10 @@ export class ChatComposerCapabilityHost {
       this.client === client &&
       state.client === client &&
       state.connected &&
-      state.sessionKey === sessionKey;
-    this.effectiveToolsErrors.delete(requestKey);
-    this.effectiveToolsLoadingKey = requestKey;
+      state.sessionKey === sessionKey &&
+      this.effectiveToolsKeys(context, state, agentId).cacheKey === cacheKey;
+    this.effectiveToolsErrorKey = null;
+    this.effectiveToolsLoadingKey = cacheKey;
     this.notify();
     void loadToolsEffective(loader, { agentId, sessionKey }, { isCurrent })
       .then(() => {
@@ -241,18 +254,18 @@ export class ChatComposerCapabilityHost {
           return;
         }
         if (loader.toolsEffectiveResult && loader.toolsEffectiveResultKey === requestKey) {
-          this.effectiveTools.set(requestKey, loader.toolsEffectiveResult);
+          this.effectiveTools = { key: cacheKey, result: loader.toolsEffectiveResult };
         } else if (loader.toolsEffectiveError) {
-          this.effectiveToolsErrors.add(requestKey);
+          this.effectiveToolsErrorKey = cacheKey;
         }
       })
       .catch(() => {
         if (isCurrent()) {
-          this.effectiveToolsErrors.add(requestKey);
+          this.effectiveToolsErrorKey = cacheKey;
         }
       })
       .finally(() => {
-        if (this.effectiveToolsLoadingKey === requestKey) {
+        if (this.effectiveToolsLoadingKey === cacheKey) {
           this.effectiveToolsLoadingKey = null;
         }
         if (this.client === client) {
@@ -541,8 +554,8 @@ export class ChatComposerCapabilityHost {
       this.loading.clear();
       this.loadErrors.clear();
       this.patchTokens.clear();
-      this.effectiveTools.clear();
-      this.effectiveToolsErrors.clear();
+      this.effectiveTools = null;
+      this.effectiveToolsErrorKey = null;
       this.effectiveToolsLoadingKey = null;
     }
     // Sparse session overrides resolve against active runtime defaults, so display and key
@@ -553,14 +566,16 @@ export class ChatComposerCapabilityHost {
     const effectiveToolsAvailable =
       isGatewayMethodAdvertised(context.gateway.snapshot, "tools.effective") === true;
     const effectiveToolsKey = effectiveToolsAvailable
-      ? this.effectiveToolsKey(context, state, agentId)
+      ? this.effectiveToolsKeys(context, state, agentId).cacheKey
       : null;
     const toolsEffectiveResult =
-      effectiveToolsKey === null ? null : (this.effectiveTools.get(effectiveToolsKey) ?? null);
+      effectiveToolsKey !== null && this.effectiveTools?.key === effectiveToolsKey
+        ? this.effectiveTools.result
+        : null;
     const toolsEffectiveLoading =
       effectiveToolsKey !== null && this.effectiveToolsLoadingKey === effectiveToolsKey;
     const toolsEffectiveError =
-      effectiveToolsKey !== null && this.effectiveToolsErrors.has(effectiveToolsKey);
+      effectiveToolsKey !== null && this.effectiveToolsErrorKey === effectiveToolsKey;
     const capabilitiesReady = gatewayAvailable && session !== undefined && runtimeConfig !== null;
     const mutationBlockedReason = !gatewayAvailable
       ? t("chat.composer.menu.offlineBlocked")
@@ -591,7 +606,7 @@ export class ChatComposerCapabilityHost {
             enabled:
               skill.missingDeps || skill.blocked
                 ? false
-                : (session?.toolOverrides?.skills?.[skill.key] ?? skill.baseEnabled),
+                : (readOwnEntry(session?.toolOverrides?.skills, skill.key) ?? skill.baseEnabled),
           }),
         ) ?? null,
       skillsLoading: this.loading.has(agentId),

--- a/ui/src/pages/chat/chat-composer-capability-host.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.ts
@@ -1,7 +1,7 @@
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { GatewaySessionRow, SkillStatusEntry } from "../../api/types.ts";
+import type { GatewaySessionRow, SkillStatusEntry, ToolsEffectiveResult } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
 import "../../components/modal-dialog.ts";
@@ -9,12 +9,17 @@ import { renderMcpServerForm, type McpServerForm } from "../../components/mcp-se
 import { renderSettingsSegmented } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import {
+  buildToolsEffectiveRequestKey,
+  loadToolsEffective,
+} from "../../lib/agents/tools-effective.ts";
+import {
   buildAddMcpServerPatch,
   MCP_SERVER_NAME_PATTERN,
   parseMcpTarget,
   patchMcpServers,
   summarizeMcpServers,
 } from "../../lib/config/mcp-servers.ts";
+import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import {
   scopedAgentListParamsForSession,
   scopedAgentParamsForSession,
@@ -76,6 +81,9 @@ export class ChatComposerCapabilityHost {
   private readonly loading = new Set<string>();
   private readonly loadErrors = new Set<string>();
   private readonly patchTokens = new Map<string, symbol>();
+  private readonly effectiveTools = new Map<string, ToolsEffectiveResult>();
+  private readonly effectiveToolsErrors = new Set<string>();
+  private effectiveToolsLoadingKey: string | null = null;
   private client: GatewayBrowserClient | null = null;
   private addDialogOpen = false;
   private addScope: ComposerMcpServerScope = "session";
@@ -169,6 +177,78 @@ export class ChatComposerCapabilityHost {
       .finally(() => {
         if (this.client === client) {
           this.loading.delete(agentId);
+          this.notify();
+        }
+      });
+  }
+
+  private effectiveToolsKey(
+    context: ApplicationContext,
+    state: ChatPageHost,
+    agentId: string,
+  ): string {
+    return buildToolsEffectiveRequestKey(
+      {
+        chatModelCatalog: state.chatModelCatalog,
+        sessions: context.sessions,
+        sessionsResult: state.sessionsResult,
+      },
+      { agentId, sessionKey: state.sessionKey },
+    );
+  }
+
+  private loadEffectiveTools(
+    context: ApplicationContext,
+    state: ChatPageHost,
+    agentId: string,
+  ): void {
+    const client = state.client;
+    const sessionKey = state.sessionKey;
+    const requestKey = this.effectiveToolsKey(context, state, agentId);
+    if (
+      !state.connected ||
+      !client ||
+      this.effectiveTools.has(requestKey) ||
+      this.effectiveToolsLoadingKey === requestKey
+    ) {
+      return;
+    }
+    const loader = {
+      chatModelCatalog: state.chatModelCatalog,
+      client,
+      connected: true,
+      sessions: context.sessions,
+      sessionsResult: state.sessionsResult,
+      toolsEffectiveError: null as string | null,
+      toolsEffectiveLoading: false,
+      toolsEffectiveLoadingKey: null as string | null,
+      toolsEffectiveResult: null as ToolsEffectiveResult | null,
+      toolsEffectiveResultKey: null as string | null,
+    };
+    const isCurrent = () =>
+      this.client === client &&
+      state.client === client &&
+      state.connected &&
+      state.sessionKey === sessionKey;
+    this.effectiveToolsErrors.delete(requestKey);
+    this.effectiveToolsLoadingKey = requestKey;
+    this.notify();
+    void loadToolsEffective(loader, { agentId, sessionKey }, { isCurrent })
+      .then(() => {
+        if (!isCurrent()) {
+          return;
+        }
+        if (loader.toolsEffectiveResult && loader.toolsEffectiveResultKey === requestKey) {
+          this.effectiveTools.set(requestKey, loader.toolsEffectiveResult);
+        } else if (loader.toolsEffectiveError) {
+          this.effectiveToolsErrors.add(requestKey);
+        }
+      })
+      .finally(() => {
+        if (this.effectiveToolsLoadingKey === requestKey) {
+          this.effectiveToolsLoadingKey = null;
+        }
+        if (this.client === client) {
           this.notify();
         }
       });
@@ -454,12 +534,26 @@ export class ChatComposerCapabilityHost {
       this.loading.clear();
       this.loadErrors.clear();
       this.patchTokens.clear();
+      this.effectiveTools.clear();
+      this.effectiveToolsErrors.clear();
+      this.effectiveToolsLoadingKey = null;
     }
     // Sparse session overrides resolve against active runtime defaults, so display and key
     // removal decisions must use the same runtime snapshot that executes the session.
     const runtimeConfig = context.runtimeConfig.state.configSnapshot?.runtimeConfig ?? null;
     const access = readGatewayOperatorAccess(context.gateway.snapshot);
     const gatewayAvailable = state.connected && Boolean(state.client);
+    const effectiveToolsAvailable =
+      isGatewayMethodAdvertised(context.gateway.snapshot, "tools.effective") === true;
+    const effectiveToolsKey = effectiveToolsAvailable
+      ? this.effectiveToolsKey(context, state, agentId)
+      : null;
+    const toolsEffectiveResult =
+      effectiveToolsKey === null ? null : (this.effectiveTools.get(effectiveToolsKey) ?? null);
+    const toolsEffectiveLoading =
+      effectiveToolsKey !== null && this.effectiveToolsLoadingKey === effectiveToolsKey;
+    const toolsEffectiveError =
+      effectiveToolsKey !== null && this.effectiveToolsErrors.has(effectiveToolsKey);
     const capabilitiesReady = gatewayAvailable && session !== undefined && runtimeConfig !== null;
     const mutationBlockedReason = !gatewayAvailable
       ? t("chat.composer.menu.offlineBlocked")
@@ -470,6 +564,13 @@ export class ChatComposerCapabilityHost {
           : this.patchTokens.has(state.sessionKey)
             ? t("chat.composer.menu.savingBlocked")
             : null;
+    const toolAccessMutationBlockedReason =
+      mutationBlockedReason ??
+      (toolsEffectiveResult
+        ? null
+        : toolsEffectiveError
+          ? t("chat.composer.menu.toolAccess.loadFailed")
+          : t("common.loading"));
     const adminBlockedReason = !gatewayAvailable
       ? t("chat.composer.menu.offlineBlocked")
       : !access.canAdmin
@@ -489,6 +590,10 @@ export class ChatComposerCapabilityHost {
       skillsLoading: this.loading.has(agentId),
       skillsError: this.loadErrors.has(agentId),
       mcpServers: summarizeMcpServers(runtimeConfig) ?? [],
+      toolsEffectiveResult,
+      toolsEffectiveLoading,
+      toolsEffectiveError,
+      toolAccessMutationBlockedReason,
       webSearchBaseEnabled: webSearchBaseEnabled(runtimeConfig),
       mutationBlockedReason,
       canAdmin: access.canAdmin && gatewayAvailable,
@@ -506,6 +611,9 @@ export class ChatComposerCapabilityHost {
         this.addError = null;
         this.notify();
       },
+      ...(effectiveToolsAvailable
+        ? { onOpenToolAccess: () => this.loadEffectiveTools(context, state, agentId) }
+        : {}),
     };
   }
 }

--- a/ui/src/pages/chat/chat-composer-capability-host.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.ts
@@ -1,7 +1,12 @@
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { GatewaySessionRow, SkillStatusEntry, ToolsEffectiveResult } from "../../api/types.ts";
+import type {
+  ConfigSnapshot,
+  GatewaySessionRow,
+  SkillStatusEntry,
+  ToolsEffectiveResult,
+} from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
 import "../../components/modal-dialog.ts";
@@ -26,10 +31,7 @@ import {
 } from "../../lib/sessions/index.ts";
 import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
-import {
-  nextBooleanToolOverrides,
-  readOwnEntry,
-} from "../../lib/sessions/tool-overrides.ts";
+import { nextBooleanToolOverrides, readOwnEntry } from "../../lib/sessions/tool-overrides.ts";
 import { loadSkillStatusReport } from "../../lib/skills/index.ts";
 import { refreshCurrentChatSessionList } from "./chat-session.ts";
 import { patchChatSessionSettings } from "./chat-settings-patches.ts";
@@ -65,10 +67,15 @@ function webSearchBaseEnabled(config: Record<string, unknown> | null): boolean {
   return asRecord(asRecord(asRecord(config?.tools)?.web)?.search)?.enabled !== false;
 }
 
-function mcpConnectorSetFingerprint(config: Record<string, unknown> | null): string {
-  return JSON.stringify(
-    (summarizeMcpServers(config) ?? []).map(({ name, enabled }) => [name, enabled] as const),
-  );
+function activeConfigFingerprint(snapshot: ConfigSnapshot | null): string {
+  const revision =
+    snapshot?.appliedConfigHash ?? snapshot?.configRevisionHash ?? snapshot?.hash ?? null;
+  if (revision) {
+    return revision;
+  }
+  // Older gateways and partial test fixtures may omit revision hashes. Include the complete
+  // connector definitions so edits to targets, args, auth, or filters still invalidate tools.
+  return JSON.stringify(asRecord(asRecord(snapshot?.runtimeConfig)?.mcp)?.servers ?? null);
 }
 
 function toComposerSkill(skill: SkillStatusEntry): ChatComposerMenuSkill {
@@ -204,9 +211,10 @@ export class ChatComposerCapabilityHost {
       },
       { agentId, sessionKey: state.sessionKey },
     );
-    const runtimeConfig = context.runtimeConfig.state.configSnapshot?.runtimeConfig ?? null;
-    const connectorSet = mcpConnectorSetFingerprint(runtimeConfig);
-    return { cacheKey: `${requestKey}\0mcp=${connectorSet}`, requestKey };
+    const configFingerprint = activeConfigFingerprint(
+      context.runtimeConfig.state.configSnapshot ?? null,
+    );
+    return { cacheKey: `${requestKey}\0config=${configFingerprint}`, requestKey };
   }
 
   private loadEffectiveTools(

--- a/ui/src/pages/chat/components/chat-composer-plus-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-plus-menu.ts
@@ -1,5 +1,6 @@
 import "@awesome.me/webawesome/dist/components/switch/switch.js";
 import { html, nothing, type TemplateResult } from "lit";
+import type { ToolsEffectiveEntry, ToolsEffectiveResult } from "../../../api/types.ts";
 import { pathForPluginsHubTab, pathForRoute } from "../../../app-route-paths.ts";
 import type { ApplicationNavigationOptions } from "../../../app/context.ts";
 import { icons } from "../../../components/icons.ts";
@@ -10,6 +11,7 @@ import type { McpServerSummary } from "../../../lib/config/mcp-servers.ts";
 import type { SessionToolOverrides } from "../../../lib/sessions/patch.ts";
 import {
   nextBooleanToolOverrides,
+  nextMcpToolsDenyOverrides,
   nextWebSearchToolOverrides,
   resolveToolOverrideState,
 } from "../../../lib/sessions/tool-overrides.ts";
@@ -40,6 +42,10 @@ export type ChatComposerPlusMenuProps = {
   skillsLoading: boolean;
   skillsError: boolean;
   mcpServers: readonly McpServerSummary[];
+  toolsEffectiveResult: ToolsEffectiveResult | null;
+  toolsEffectiveLoading: boolean;
+  toolsEffectiveError: boolean;
+  toolAccessMutationBlockedReason: string | null;
   webSearchBaseEnabled: boolean;
   mutationBlockedReason: string | null;
   canAdmin: boolean;
@@ -261,7 +267,7 @@ function renderConnectorView(props: ChatComposerPlusMenuProps) {
                   value=${`tools:${index}`}
                 >
                   <span slot="icon" aria-hidden="true">${icons.wrench}</span>
-                  <span>${t("chat.composer.menu.toolAccess")}</span>
+                  <span>${t("chat.composer.menu.toolAccess.label")}</span>
                 </wa-dropdown-item>`
               : nothing}
           `;
@@ -295,6 +301,86 @@ function renderConnectorView(props: ChatComposerPlusMenuProps) {
   `;
 }
 
+function toolsForServer(
+  result: ToolsEffectiveResult | null,
+  serverName: string,
+): ToolsEffectiveEntry[] {
+  return (result?.groups ?? [])
+    .flatMap((group) => group.tools)
+    .filter(
+      (tool): tool is ToolsEffectiveEntry & { mcpToolName: string } =>
+        tool.source === "mcp" && tool.mcpServer === serverName && Boolean(tool.mcpToolName),
+    );
+}
+
+function isToolDenied(props: ChatComposerPlusMenuProps, tool: ToolsEffectiveEntry): boolean {
+  const serverName = tool.mcpServer;
+  const rawToolName = tool.mcpToolName;
+  if (!serverName || !rawToolName) {
+    return false;
+  }
+  if (props.toolOverrides != null) {
+    return props.toolOverrides.mcpToolsDeny?.[serverName]?.includes(rawToolName) ?? false;
+  }
+  return tool.deniedBySession === true;
+}
+
+function renderToolAccessView(props: ChatComposerPlusMenuProps, serverName: string) {
+  const tools = toolsForServer(props.toolsEffectiveResult, serverName);
+  const enabledCount = tools.filter((tool) => !isToolDenied(props, tool)).length;
+  const summary = t(
+    tools.length === 1
+      ? "chat.composer.menu.toolAccess.summaryOne"
+      : "chat.composer.menu.toolAccess.summary",
+    { enabled: String(enabledCount), total: String(tools.length) },
+  );
+  const rows = props.toolsEffectiveLoading
+    ? html`<div class="agent-chat__capability-menu-state" role="status">
+        ${t("chat.composer.menu.toolAccess.loading")}
+      </div>`
+    : props.toolsEffectiveError
+      ? html`<div class="agent-chat__capability-menu-state" role="alert">
+          ${t("chat.composer.menu.toolAccess.loadFailed")}
+        </div>`
+      : tools.length === 0
+        ? html`<div class="agent-chat__capability-menu-state">
+            ${t("chat.composer.menu.toolAccess.noTools")}
+          </div>`
+        : tools.map((tool, index) => {
+            const label = tool.label || tool.mcpToolName;
+            const denied = isToolDenied(props, tool);
+            return html`
+              <wa-dropdown-item
+                class="agent-chat__capability-menu-item agent-chat__capability-menu-toggle"
+                value=${`mcp-tool:${index}`}
+                ?disabled=${props.toolAccessMutationBlockedReason !== null}
+                title=${props.toolAccessMutationBlockedReason ?? ""}
+              >
+                <span>${label}</span>
+                <wa-switch
+                  slot="details"
+                  class="agent-chat__capability-menu-switch"
+                  size="s"
+                  tabindex="-1"
+                  .checked=${!denied}
+                  ?disabled=${props.toolAccessMutationBlockedReason !== null}
+                  aria-label=${label}
+                ></wa-switch>
+              </wa-dropdown-item>
+            `;
+          });
+  return html`
+    ${renderBackRow()}
+    <div class="agent-chat__capability-menu-state">
+      <span class="agent-chat__capability-menu-label">
+        <strong translate="no">${serverName}</strong>
+        <span class="agent-chat__capability-menu-note">${summary}</span>
+      </span>
+    </div>
+    ${rows}
+  `;
+}
+
 function handleMenuSelection(
   event: CustomEvent<{ item: { value?: string } }>,
   props: ChatComposerPlusMenuProps,
@@ -313,7 +399,7 @@ function handleMenuSelection(
   }
   if (value === "back") {
     event.preventDefault();
-    changeView("root");
+    changeView(props.view.startsWith("tools:") ? "connectors" : "root");
     return;
   }
   if (value === "open-skills" || value === "open-connectors") {
@@ -372,9 +458,32 @@ function handleMenuSelection(
     return;
   }
   if (value.startsWith("tools:")) {
+    event.preventDefault();
     const server = props.mcpServers[Number(value.slice("tools:".length))];
     if (server) {
       props.onOpenToolAccess?.(server.name);
+      changeView(`tools:${server.name}`);
+    }
+    return;
+  }
+  if (value.startsWith("mcp-tool:") && props.view.startsWith("tools:")) {
+    event.preventDefault();
+    if (props.toolAccessMutationBlockedReason) {
+      return;
+    }
+    const serverName = props.view.slice("tools:".length);
+    const tool = toolsForServer(props.toolsEffectiveResult, serverName)[
+      Number(value.slice("mcp-tool:".length))
+    ];
+    if (tool?.mcpToolName) {
+      props.onPatchToolOverrides(
+        nextMcpToolsDenyOverrides(
+          props.toolOverrides,
+          serverName,
+          tool.mcpToolName,
+          !isToolDenied(props, tool),
+        ),
+      );
     }
     return;
   }
@@ -400,7 +509,9 @@ export function renderChatComposerPlusMenu(props: ChatComposerPlusMenuProps) {
       ? renderSkillView(props)
       : view === "connectors"
         ? renderConnectorView(props)
-        : renderRootView(props);
+        : view.startsWith("tools:")
+          ? renderToolAccessView(props, view.slice("tools:".length))
+          : renderRootView(props);
   return html`
     <wa-dropdown
       class="agent-chat__attach-menu agent-chat__capability-menu"

--- a/ui/src/pages/chat/components/chat-composer-plus-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-plus-menu.ts
@@ -13,6 +13,7 @@ import {
   nextBooleanToolOverrides,
   nextMcpToolsDenyOverrides,
   nextWebSearchToolOverrides,
+  readOwnEntry,
   resolveToolOverrideState,
 } from "../../../lib/sessions/tool-overrides.ts";
 import { clickComposerInput, type ChatAttachmentControlsProps } from "./chat-attachments.ts";
@@ -87,7 +88,10 @@ function renderBackRow() {
 
 function renderRootView(props: ChatComposerPlusMenuProps) {
   const connectorCount = props.mcpServers.filter((server) =>
-    resolveToolOverrideState(server.enabled, props.toolOverrides?.mcpServers?.[server.name]),
+    resolveToolOverrideState(
+      server.enabled,
+      readOwnEntry(props.toolOverrides?.mcpServers, server.name),
+    ),
   ).length;
   const hasSkillOverrides = Object.keys(props.toolOverrides?.skills ?? {}).length > 0;
   const enabledSkillCount = props.skills?.filter((skill) => skill.enabled).length ?? 0;
@@ -232,7 +236,7 @@ function renderConnectorView(props: ChatComposerPlusMenuProps) {
           ${t("chat.composer.menu.noConnectors")}
         </div>`
       : props.mcpServers.map((server, index) => {
-          const override = props.toolOverrides?.mcpServers?.[server.name];
+          const override = readOwnEntry(props.toolOverrides?.mcpServers, server.name);
           const enabled = resolveToolOverrideState(server.enabled, override);
           return html`
             <wa-dropdown-item
@@ -321,7 +325,9 @@ function isToolDenied(props: ChatComposerPlusMenuProps, tool: ToolsEffectiveEntr
     return false;
   }
   if (props.toolOverrides != null) {
-    return props.toolOverrides.mcpToolsDeny?.[serverName]?.includes(rawToolName) ?? false;
+    return (
+      readOwnEntry(props.toolOverrides.mcpToolsDeny, serverName)?.includes(rawToolName) ?? false
+    );
   }
   return tool.deniedBySession === true;
 }
@@ -450,7 +456,7 @@ function handleMenuSelection(
     if (server && !props.mutationBlockedReason) {
       const enabled = resolveToolOverrideState(
         server.enabled,
-        props.toolOverrides?.mcpServers?.[server.name],
+        readOwnEntry(props.toolOverrides?.mcpServers, server.name),
       );
       props.onPatchToolOverrides(
         nextBooleanToolOverrides(

--- a/ui/src/pages/chat/components/chat-composer-plus-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-plus-menu.ts
@@ -57,6 +57,7 @@ export type ChatComposerPlusMenuProps = {
   onPatchToolOverrides: (next: SessionToolOverrides | null) => void;
   onNavigate: (routeId: MenuRoute, options?: ApplicationNavigationOptions) => void;
   onAddServer?: () => void;
+  onEnsureToolAccess?: (serverName: string) => void;
   onOpenToolAccess?: (serverName: string) => void;
 };
 
@@ -347,7 +348,8 @@ function renderToolAccessView(props: ChatComposerPlusMenuProps, serverName: stri
             ${t("chat.composer.menu.toolAccess.noTools")}
           </div>`
         : tools.map((tool, index) => {
-            const label = tool.label || tool.mcpToolName;
+            const rawToolName = tool.mcpToolName;
+            const label = tool.label?.trim();
             const denied = isToolDenied(props, tool);
             return html`
               <wa-dropdown-item
@@ -356,7 +358,12 @@ function renderToolAccessView(props: ChatComposerPlusMenuProps, serverName: stri
                 ?disabled=${props.toolAccessMutationBlockedReason !== null}
                 title=${props.toolAccessMutationBlockedReason ?? ""}
               >
-                <span>${label}</span>
+                <span class="agent-chat__capability-menu-label">
+                  <span>${rawToolName}</span>
+                  ${label && label !== rawToolName
+                    ? html`<span class="agent-chat__capability-menu-note">${label}</span>`
+                    : nothing}
+                </span>
                 <wa-switch
                   slot="details"
                   class="agent-chat__capability-menu-switch"
@@ -364,7 +371,7 @@ function renderToolAccessView(props: ChatComposerPlusMenuProps, serverName: stri
                   tabindex="-1"
                   .checked=${!denied}
                   ?disabled=${props.toolAccessMutationBlockedReason !== null}
-                  aria-label=${label}
+                  aria-label=${rawToolName}
                 ></wa-switch>
               </wa-dropdown-item>
             `;
@@ -504,6 +511,9 @@ function handleMenuSelection(
 
 export function renderChatComposerPlusMenu(props: ChatComposerPlusMenuProps) {
   const view = props.showCapabilities ? props.view : "root";
+  if (view.startsWith("tools:")) {
+    props.onEnsureToolAccess?.(view.slice("tools:".length));
+  }
   const content =
     view === "skills"
       ? renderSkillView(props)

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -352,6 +352,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                 onPatchToolOverrides: props.capabilityMenu?.onPatchToolOverrides ?? (() => {}),
                 onNavigate: props.capabilityMenu?.onNavigate ?? (() => {}),
                 onAddServer: props.capabilityMenu?.onAddServer,
+                onEnsureToolAccess: props.capabilityMenu?.onEnsureToolAccess,
                 onOpenToolAccess: props.capabilityMenu?.onOpenToolAccess,
               })}
               <div class="agent-chat__composer-combobox">

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -327,6 +327,11 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                 skillsLoading: props.capabilityMenu?.skillsLoading ?? false,
                 skillsError: props.capabilityMenu?.skillsError ?? false,
                 mcpServers: props.capabilityMenu?.mcpServers ?? [],
+                toolsEffectiveResult: props.capabilityMenu?.toolsEffectiveResult ?? null,
+                toolsEffectiveLoading: props.capabilityMenu?.toolsEffectiveLoading ?? false,
+                toolsEffectiveError: props.capabilityMenu?.toolsEffectiveError ?? false,
+                toolAccessMutationBlockedReason:
+                  props.capabilityMenu?.toolAccessMutationBlockedReason ?? null,
                 webSearchBaseEnabled: props.capabilityMenu?.webSearchBaseEnabled ?? true,
                 mutationBlockedReason: props.capabilityMenu?.mutationBlockedReason ?? null,
                 canAdmin: props.capabilityMenu?.canAdmin ?? false,


### PR DESCRIPTION
Related: #115785
Related: #115800
Related: #115870

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The composer capability menu can enable or disable an MCP connector for a session, but it cannot show or change access for individual tools on that connector. Operators therefore cannot inspect session-denied tools or make a narrow per-tool exception from the conversation where it applies.

## Why This Change Was Made

This adds a per-connector Tool access view backed by the session's effective-tools catalog. The view appears only when the Gateway advertises `tools.effective`, loads and caches the catalog on first open, preserves raw MCP tool identity when writing sparse session denials, and blocks mutations until the session row, runtime config, and catalog are all ready.

## User Impact

Operators can open Connectors → Tool access in the composer, see how many tools are on, and toggle individual MCP tools for the current session without closing the menu. Existing server `toolFilter` exclusions remain absent because the view only shows tools returned by the effective catalog.

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/sessions/tool-overrides.test.ts ui/src/pages/chat/chat-composer-capability-host.test.ts` — 8 tests passed.
- `node scripts/run-vitest.mjs ui/src/e2e/chat-composer-capability-menu.e2e.test.ts` — 6 mocked-browser tests passed, including denied startup state, sanitized-label collisions with distinct raw names, count summary, toggle patch, back navigation, and readiness gating.
- `pnpm ui:i18n:baseline` — English catalog and raw-copy baseline verified.
- `node scripts/check-changed.mjs` — passed on Blacksmith Testbox `tbx_01kyq04rs86jgsgasn9kp7tsfg` against the rebased head: https://github.com/openclaw/openclaw/actions/runs/30455046159
- Fresh Codex autoreview: clean, no accepted/actionable findings.
