### PR TITLE
fix(test): isolate tool policy audit suite

### DIFF
--- a/test/vitest/vitest.agents-paths.mjs
+++ b/test/vitest/vitest.agents-paths.mjs
@@ -15,6 +15,7 @@ const coreIsolatedFiles = [
   "src/agents/models-config.runtime-source-snapshot.test.ts",
   "src/agents/openai-transport-stream.streaming.test.ts",
   "src/agents/subagent-orphan-recovery.test.ts",
+  "src/agents/tool-policy-pipeline.test.ts",
   "src/agents/video-generation-task-status.test.ts",
 ];
 const incompleteTurnFiles = [`${embeddedRoot}/run.incomplete-turn.test.ts`];


### PR DESCRIPTION
Related: #115696

## What Problem This Solves

Resolves a problem where the full agentic test project could report six false failures in tool-policy audit assertions when shared-worker module mock invalidation disconnected the test spies from the production logger instance.

## Why This Change Was Made

Routes the existing tool-policy pipeline suite through the established isolated agent-test owner. The assertions remain strict and production behavior is unchanged.

## User Impact

Maintainers get reliable full-suite results instead of false-negative audit-policy failures under shared-worker scheduling.

## Evidence

- Blacksmith Testbox `tbx_01kyq0ny5gtg0cbg7rsvng93c9`: `pnpm test src/agents/tool-policy-pipeline.test.ts` passed 36/36 under `agents-core-isolated`.
- Same Testbox: project routing guards passed 276/276 across `test/scripts/test-projects.test.ts` and `test/vitest-projects-config.test.ts`.
- Run: https://github.com/openclaw/openclaw/actions/runs/30455749859
- Static ownership probe and `git diff --check` passed.
- Autoreview and TruffleHog completed with no findings.