### PR TITLE
fix(agents): scope overload cooldowns by model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Model fallback after overloads:** scope transient overload cooldowns to the failing model so sibling models on the same auth profile remain eligible for fallback while profile-wide auth and billing blocks remain unchanged. Fixes #49732.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Model fallback after overloads:** scope transient overload cooldowns to the failing model so sibling models on the same auth profile remain eligible for fallback while profile-wide auth and billing blocks remain unchanged. Fixes #49732.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts
+++ b/src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts
@@ -120,6 +120,40 @@ describe("getSoonestCooldownExpiry", () => {
     ).toBe(now + 10_000);
   });
 
+  it("uses only matching overloaded cooldowns across multiple profiles", () => {
+    const now = 1_700_000_000_000;
+    const store = makeStore({
+      "openai:sol-p1": {
+        cooldownUntil: now + 10_000,
+        cooldownReason: "overloaded",
+        cooldownModel: "gpt-5.6-sol",
+      },
+      "openai:terra": {
+        cooldownUntil: now + 20_000,
+        cooldownReason: "overloaded",
+        cooldownModel: "gpt-5.6-terra",
+      },
+      "openai:sol-p2": {
+        cooldownUntil: now + 30_000,
+        cooldownReason: "overloaded",
+        cooldownModel: "gpt-5.6-sol",
+      },
+    });
+
+    expect(
+      getSoonestCooldownExpiry(store, ["openai:sol-p1", "openai:terra", "openai:sol-p2"], {
+        now,
+        forModel: "gpt-5.6-sol",
+      }),
+    ).toBe(now + 30_000);
+    expect(
+      getSoonestCooldownExpiry(store, ["openai:sol-p1", "openai:terra", "openai:sol-p2"], {
+        now,
+        forModel: "gpt-5.6-terra",
+      }),
+    ).toBe(now + 20_000);
+  });
+
   it("still counts profile-wide disables for other models", () => {
     const now = 1_700_000_000_000;
     const store = makeStore({

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -21,6 +21,13 @@ export function isModelScopedCooldownReason(reason: AuthProfileFailureReason | u
   return reason === "rate_limit" || reason === "timeout" || reason === "overloaded";
 }
 
+function usesSharedModelCooldownExpiry(reason: AuthProfileFailureReason | undefined): boolean {
+  // Timeout failures remain per-profile because another transport can recover
+  // sooner. Rate-limit and overload windows describe shared model availability,
+  // so wait for the latest matching profile signal before probing that model.
+  return isModelScopedCooldownReason(reason) && reason !== "timeout";
+}
+
 /** Resolves the latest active blocked/cooldown/disabled timestamp for a profile. */
 export function resolveProfileUnusableUntil(
   stats: Pick<
@@ -148,13 +155,13 @@ export function getSoonestCooldownExpiry(
     if (typeof until !== "number" || !Number.isFinite(until) || until <= 0) {
       continue;
     }
-    const matchingModelScopedCooldown =
+    const matchingSharedModelCooldown =
       options?.forModel &&
-      stats.cooldownReason === "rate_limit" &&
+      usesSharedModelCooldownExpiry(stats.cooldownReason) &&
       stats.cooldownModel === options.forModel &&
       !isBlockedWindowActiveForModel(stats, ts, options.forModel) &&
       !isActiveUnusableWindow(stats.disabledUntil, ts);
-    if (matchingModelScopedCooldown) {
+    if (matchingSharedModelCooldown) {
       latestMatchingModelCooldown =
         latestMatchingModelCooldown === null ? until : Math.max(latestMatchingModelCooldown, until);
       continue;

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -18,7 +18,7 @@ export function isAuthCooldownBypassedForProvider(provider: string | undefined):
 // billing, format, server_error) remain profile-wide.
 /** Returns true when a failure should only cool down the failing model. */
 export function isModelScopedCooldownReason(reason: AuthProfileFailureReason | undefined): boolean {
-  return reason === "rate_limit" || reason === "timeout";
+  return reason === "rate_limit" || reason === "timeout" || reason === "overloaded";
 }
 
 /** Resolves the latest active blocked/cooldown/disabled timestamp for a profile. */

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -6,7 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
-import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
+import type { AuthProfileFailureReason, AuthProfileStore, ProfileUsageStats } from "./types.js";
 import { resolveProfileUnusableUntil } from "./usage-state.js";
 import {
   clearAuthProfileCooldown,
@@ -296,6 +296,19 @@ describe("isProfileInCooldown", () => {
     expect(isProfileInCooldown(store, "google:default", undefined, "gemini-3.1-flash-lite")).toBe(
       true,
     );
+  });
+
+  it("returns false for a sibling model when an overload cooldown is model-scoped", () => {
+    const store = makeStore({
+      "openai:default": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "overloaded",
+        cooldownModel: "gpt-5.6-sol",
+      },
+    });
+    expect(isProfileInCooldown(store, "openai:default", undefined, "gpt-5.6-terra")).toBe(false);
+    expect(isProfileInCooldown(store, "openai:default", undefined, "gpt-5.6-sol")).toBe(true);
+    expect(isProfileInCooldown(store, "openai:default")).toBe(true);
   });
 
   it("does not bypass model-scoped cooldown when disabledUntil is active", () => {
@@ -1606,6 +1619,7 @@ describe("markAuthProfileFailure — per-model cooldown metadata", () => {
     store: ReturnType<typeof makeStoreWithCopilot>;
     now: number;
     modelId?: string;
+    reason?: AuthProfileFailureReason;
   }): Promise<void> {
     vi.useFakeTimers();
     vi.setSystemTime(params.now);
@@ -1614,7 +1628,7 @@ describe("markAuthProfileFailure — per-model cooldown metadata", () => {
       await markAuthProfileFailure({
         store: params.store,
         profileId: "github-copilot:github",
-        reason: "rate_limit",
+        reason: params.reason ?? "rate_limit",
         modelId: params.modelId,
       });
     } finally {
@@ -1629,6 +1643,20 @@ describe("markAuthProfileFailure — per-model cooldown metadata", () => {
     const stats = store.usageStats?.["github-copilot:github"];
     expect(stats?.cooldownReason).toBe("rate_limit");
     expect(stats?.cooldownModel).toBe("claude-sonnet-4.6");
+  });
+
+  it("records cooldownModel on first overloaded failure", async () => {
+    const now = 1_000_000;
+    const store = makeStoreWithCopilot({});
+    await markFailure({
+      store,
+      now,
+      reason: "overloaded",
+      modelId: "gpt-5.6-sol",
+    });
+    const stats = store.usageStats?.["github-copilot:github"];
+    expect(stats?.cooldownReason).toBe("overloaded");
+    expect(stats?.cooldownModel).toBe("gpt-5.6-sol");
   });
 
   it("widens cooldownModel to undefined when a different model fails during active cooldown", async () => {


### PR DESCRIPTION
## Summary

- treat transient `overloaded` failures as model-scoped cooldowns
- keep sibling models on the same auth profile eligible for fallback
- align overload retry expiry across multiple profiles while preserving per-profile timeout recovery
- retain conservative profile-wide behavior when the caller does not supply a model
- add focused persistence and fallback regressions

Fixes #49732.
Related: #55941.

## What Problem This Solves

`markAuthProfileFailure()` already records `cooldownModel` for failure reasons classified by `isModelScopedCooldownReason()`. That classifier included `rate_limit` and `timeout`, but omitted `overloaded`.

An overload from one model was therefore persisted without `cooldownModel`. `isProfileInCooldown()` then treated the shared auth profile as unavailable for every model, so fallback to a healthy sibling model on the same provider/profile never ran.

This patch changes only the existing cooldown classification boundary and the corresponding retry-expiry selector. Rate-limit and overload windows use the latest matching signal for a model across profiles; transport timeouts retain their existing per-profile earliest-recovery behavior. Auth, billing, format, and other profile-wide failures remain profile-wide.

## Evidence

### Runtime Proof (After Fix)

This was run from rebased head `aabcdcb0816962f3385fe04bdba0597540bb5e64` on current `main` `17a8961a6a36e0bab0a56a248e9c79372ddff402`.

The one-shot runtime canary imported the production auth-profile and model-fallback modules directly. It created a real temporary SQLite-backed auth store, persisted a redacted OpenAI OAuth profile, called the real `markAuthProfileFailure()` write transaction with `reason: "overloaded"` and `modelId: "gpt-5.6-sol"`, reloaded the store from disk, and invoked the real `runWithModelFallback()` state machine with `gpt-5.6-terra` as the sibling fallback.

The provider attempt itself was deterministic and local: it raised the production `FailoverError` for the primary and returned success for the sibling. Auth persistence, cooldown checks, candidate decisions, and fallback execution were production code. No Vitest, mocked auth runtime, live credentials, or provider network request was used.

```text
[agent/embedded] auth profile failure state updated: runId=runtime-proof profile=sha256:34d0fd5534c6 provider=openai reason=overloaded window=cooldown reused=false
[model-fallback/decision] model fallback decision: decision=probe_cooldown_candidate requested=openai/gpt-5.6-sol candidate=openai/gpt-5.6-sol reason=overloaded next=openai/gpt-5.6-terra
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=openai/gpt-5.6-sol candidate=openai/gpt-5.6-sol reason=overloaded next=openai/gpt-5.6-terra detail=provider overloaded
[model-fallback/decision] model fallback decision: decision=candidate_succeeded requested=openai/gpt-5.6-sol candidate=openai/gpt-5.6-terra reason=unknown next=none
{
  "storage": {
    "kind": "real temporary SQLite-backed auth-profile store",
    "sqliteFiles": [
      "agents/main/agent/openclaw-agent.sqlite",
      "state/openclaw.sqlite"
    ]
  },
  "persistedFailure": {
    "reason": "overloaded",
    "model": "gpt-5.6-sol",
    "cooldownActive": true
  },
  "runtimeAttemptGate": {
    "failingModel": "blocked",
    "siblingModel": "eligible",
    "unspecifiedModel": "blocked"
  },
  "actualFallbackLoop": {
    "attemptedModels": [
      "openai/gpt-5.6-sol",
      "openai/gpt-5.6-terra"
    ],
    "selectedModel": "openai/gpt-5.6-terra",
    "result": "sibling-success"
  }
}
```

This demonstrates the requested behavior on one persisted auth profile: the overloaded model remains blocked, the actual fallback loop advances to the sibling model on the same profile and succeeds there, and callers that omit a model remain conservatively blocked.

The focused multi-profile regression additionally uses two `gpt-5.6-sol` cooldowns and one `gpt-5.6-terra` cooldown. The selector returns the latest matching Sol expiry for Sol and the Terra expiry for Terra, proving that a sibling model's cooldown cannot determine the requested model's retry time.

### Validation

- `node scripts/run-vitest.mjs src/agents/auth-profiles/usage.test.ts src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts` - 100 tests passed across 2 shards
- `pnpm tsgo` - passed
- `pnpm tsgo:core:test` - passed
- targeted `oxfmt` and `oxlint` checks - passed
- no `CHANGELOG.md` change remains in the PR

Local validation ran on Node 24.14.0, which emitted the repository engine-floor warning for 24.15.0+, but all listed commands and the runtime canary completed successfully.
