### PR TITLE
fix(compaction): prevent repeat compaction after successful recovery

### DIFF
--- a/packages/agent-core/src/harness/session/session-context.test.ts
+++ b/packages/agent-core/src/harness/session/session-context.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { SessionTreeEntry } from "../types.js";
-import { buildSessionContext } from "./session.js";
+import {
+  buildSessionContext,
+  buildSessionRecoveryContext,
+  projectSessionReplayWindow,
+} from "./session.js";
 
 const timestamp = "2026-07-17T00:00:00.000Z";
 
@@ -15,6 +19,35 @@ function userEntry(id: string, parentId: string | null, content: string): Sessio
 }
 
 describe("buildSessionContext", () => {
+  it("projects valid and invalid retained-tail positions conservatively", () => {
+    expect(
+      projectSessionReplayWindow({
+        boundaryPosition: 3,
+        boundaryType: "compaction",
+        entryCount: 5,
+        firstKeptPosition: 1,
+      }),
+    ).toEqual({
+      boundaryPosition: 3,
+      boundaryType: "compaction",
+      postBoundaryPosition: 4,
+      retainedStartPosition: 1,
+    });
+    expect(
+      projectSessionReplayWindow({
+        boundaryPosition: 3,
+        boundaryType: "reset",
+        entryCount: 5,
+        firstKeptPosition: 4,
+      }),
+    ).toEqual({
+      boundaryPosition: 3,
+      boundaryType: "reset",
+      postBoundaryPosition: 4,
+      retainedStartPosition: 3,
+    });
+  });
+
   it("replays only the retained tail and newer entries after compaction", () => {
     const entries: SessionTreeEntry[] = [
       userEntry("old", null, "discarded"),
@@ -119,6 +152,89 @@ describe("buildSessionContext", () => {
     expect(JSON.stringify(context.messages)).not.toContain("hidden tool result");
   });
 
+  it("pairs retained reset tool results only for safeguard recovery", () => {
+    const entries: SessionTreeEntry[] = [
+      userEntry("discarded", null, "discarded"),
+      userEntry("kept-user", "discarded", "kept question"),
+      {
+        type: "message",
+        id: "kept-assistant",
+        parentId: "kept-user",
+        timestamp,
+        message: {
+          role: "assistant",
+          api: "openai-responses",
+          content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+          provider: "test-provider",
+          model: "test-model",
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "toolUse",
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "message",
+        id: "kept-result",
+        parentId: "kept-assistant",
+        timestamp,
+        message: {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: "paired result" }],
+          isError: false,
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "message",
+        id: "unrelated-result",
+        parentId: "kept-result",
+        timestamp,
+        message: {
+          role: "toolResult",
+          toolCallId: "unrelated",
+          toolName: "read",
+          content: [{ type: "text", text: "unrelated result" }],
+          isError: false,
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "reset",
+        id: "reset",
+        parentId: "unrelated-result",
+        timestamp,
+        reason: "new",
+        firstKeptEntryId: "kept-user",
+      },
+      userEntry("new", "reset", "new turn"),
+    ];
+
+    expect(buildSessionContext(entries).messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+    ]);
+
+    const recovered = buildSessionRecoveryContext(entries).messages;
+    expect(recovered.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
+    expect(JSON.stringify(recovered)).toContain("paired result");
+    expect(JSON.stringify(recovered)).not.toContain("unrelated result");
+  });
+
   it("lets the latest compaction shadow an earlier reset boundary", () => {
     const entries: SessionTreeEntry[] = [
       userEntry("old", null, "old"),
@@ -144,6 +260,93 @@ describe("buildSessionContext", () => {
     expect(buildSessionContext(entries).messages).toMatchObject([
       { role: "compactionSummary", summary: "latest summary" },
       { role: "user", content: "post reset" },
+    ]);
+  });
+
+  it("keeps a compaction tool call and result pair without duplicating its summary", () => {
+    const entries: SessionTreeEntry[] = [
+      userEntry("discarded", null, "discarded"),
+      userEntry("kept", "discarded", "inspect"),
+      {
+        type: "message",
+        id: "assistant-tool",
+        parentId: "kept",
+        timestamp,
+        message: {
+          role: "assistant",
+          api: "openai-responses",
+          content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
+          provider: "test-provider",
+          model: "test-model",
+          usage: {
+            input: 1,
+            output: 1,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 2,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "toolUse",
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "message",
+        id: "tool-result",
+        parentId: "assistant-tool",
+        timestamp,
+        message: {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: "result" }],
+          isError: false,
+          timestamp: Date.parse(timestamp),
+        },
+      },
+      {
+        type: "compaction",
+        id: "compaction",
+        parentId: "tool-result",
+        timestamp,
+        summary: "summary-once",
+        firstKeptEntryId: "kept",
+        tokensBefore: 10,
+      },
+      userEntry("post", "compaction", "continue"),
+    ];
+
+    const messages = buildSessionContext(entries).messages;
+
+    expect(messages.map((message) => message.role)).toEqual([
+      "compactionSummary",
+      "user",
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
+    expect(JSON.stringify(messages).match(/summary-once/g)).toHaveLength(1);
+    expect(JSON.stringify(messages)).not.toContain("discarded");
+  });
+
+  it("keeps only the summary and post-boundary entries when firstKeptEntryId is invalid", () => {
+    const entries: SessionTreeEntry[] = [
+      userEntry("discarded", null, "discarded"),
+      {
+        type: "compaction",
+        id: "compaction",
+        parentId: "discarded",
+        timestamp,
+        summary: "summary",
+        firstKeptEntryId: "missing",
+        tokensBefore: 10,
+      },
+      userEntry("post", "compaction", "continue"),
+    ];
+
+    expect(buildSessionContext(entries).messages).toMatchObject([
+      { role: "compactionSummary", summary: "summary" },
+      { role: "user", content: "continue" },
     ]);
   });
 });

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -10,6 +10,69 @@ import type { CompactionEntry, ResetEntry, SessionContext, SessionTreeEntry } fr
 type ContextBoundary = CompactionEntry | ResetEntry;
 const SESSION_HISTORY_PRELUDE = Symbol.for("openclaw.sessionHistoryPrelude");
 
+export type SessionReplayWindow = {
+  boundaryPosition: number;
+  boundaryType: ContextBoundary["type"];
+  postBoundaryPosition: number;
+  retainedStartPosition: number;
+};
+
+export function projectSessionReplayWindow(params: {
+  boundaryPosition: number;
+  boundaryType: ContextBoundary["type"];
+  entryCount: number;
+  firstKeptPosition?: number;
+}): SessionReplayWindow | undefined {
+  const entryCount = Number.isFinite(params.entryCount)
+    ? Math.max(0, Math.floor(params.entryCount))
+    : 0;
+  const boundaryPosition = Number.isFinite(params.boundaryPosition)
+    ? Math.floor(params.boundaryPosition)
+    : -1;
+  if (boundaryPosition < 0 || boundaryPosition >= entryCount) {
+    return undefined;
+  }
+  const firstKeptPosition = params.firstKeptPosition;
+  const retainedStartPosition =
+    typeof firstKeptPosition === "number" &&
+    Number.isInteger(firstKeptPosition) &&
+    firstKeptPosition >= 0 &&
+    firstKeptPosition < boundaryPosition
+      ? firstKeptPosition
+      : boundaryPosition;
+  return {
+    boundaryPosition,
+    boundaryType: params.boundaryType,
+    postBoundaryPosition: boundaryPosition + 1,
+    retainedStartPosition,
+  };
+}
+
+function resolveSessionReplayWindow(pathEntries: SessionTreeEntry[]):
+  | {
+      boundary: ContextBoundary;
+      window: SessionReplayWindow;
+    }
+  | undefined {
+  const boundaryPosition = pathEntries.findLastIndex(
+    (entry) => entry.type === "compaction" || entry.type === "reset",
+  );
+  const boundary = pathEntries[boundaryPosition];
+  if (!boundary || (boundary.type !== "compaction" && boundary.type !== "reset")) {
+    return undefined;
+  }
+  const firstKeptPosition = pathEntries.findIndex(
+    (entry, index) => index < boundaryPosition && entry.id === boundary.firstKeptEntryId,
+  );
+  const window = projectSessionReplayWindow({
+    boundaryPosition,
+    boundaryType: boundary.type,
+    entryCount: pathEntries.length,
+    ...(firstKeptPosition >= 0 ? { firstKeptPosition } : {}),
+  });
+  return window ? { boundary, window } : undefined;
+}
+
 function appendContextMessage(messages: AgentMessage[], entry: SessionTreeEntry): void {
   if (entry.type === "message") {
     messages.push(entry.message);
@@ -47,11 +110,76 @@ function appendResetKeptMessage(messages: AgentMessage[], entry: SessionTreeEntr
   }
 }
 
-/** Build model context from an ordered session branch and its latest state markers. */
-export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionContext {
+function collectAssistantToolCallIds(entries: SessionTreeEntry[]): Set<string> {
+  const ids = new Set<string>();
+  for (const entry of entries) {
+    if (entry.type !== "message" || entry.message.role !== "assistant") {
+      continue;
+    }
+    const content = entry.message.content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    for (const block of content) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const record = block as { type?: unknown; id?: unknown };
+      if (
+        typeof record.id === "string" &&
+        record.id &&
+        (record.type === "toolCall" || record.type === "toolUse" || record.type === "functionCall")
+      ) {
+        ids.add(record.id);
+      }
+    }
+  }
+  return ids;
+}
+
+function extractToolResultIds(message: AgentMessage): string[] {
+  if (message.role !== "toolResult") {
+    return [];
+  }
+  const record = message as AgentMessage & {
+    toolCallId?: unknown;
+    toolUseId?: unknown;
+    tool_call_id?: unknown;
+    tool_use_id?: unknown;
+    callId?: unknown;
+    call_id?: unknown;
+  };
+  return [
+    record.toolCallId,
+    record.toolUseId,
+    record.tool_call_id,
+    record.tool_use_id,
+    record.callId,
+    record.call_id,
+  ].flatMap((value) => (typeof value === "string" && value.trim() ? [value.trim()] : []));
+}
+
+function appendResetRecoveryMessage(
+  messages: AgentMessage[],
+  entry: SessionTreeEntry,
+  retainedToolCallIds: Set<string>,
+): void {
+  appendResetKeptMessage(messages, entry);
+  if (
+    entry.type === "message" &&
+    entry.message.role === "toolResult" &&
+    extractToolResultIds(entry.message).some((id) => retainedToolCallIds.has(id))
+  ) {
+    messages.push(entry.message);
+  }
+}
+
+function buildSessionContextInternal(
+  pathEntries: SessionTreeEntry[],
+  options?: { pairResetToolResultsForRecovery?: boolean },
+): SessionContext {
   let thinkingLevel = "off";
   let model: { provider: string; modelId: string } | null = null;
-  let boundary: ContextBoundary | null = null;
 
   for (const entry of pathEntries) {
     if (entry.type === "thinking_level_change") {
@@ -60,13 +188,13 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
       model = { provider: entry.provider, modelId: entry.modelId };
     } else if (entry.type === "message" && entry.message.role === "assistant") {
       model = { provider: entry.message.provider, modelId: entry.message.model };
-    } else if (entry.type === "compaction" || entry.type === "reset") {
-      boundary = entry;
     }
   }
 
   const messages: AgentMessage[] = [];
-  if (boundary) {
+  const replay = resolveSessionReplayWindow(pathEntries);
+  if (replay) {
+    const { boundary, window } = replay;
     if (boundary.type === "compaction") {
       messages.push(
         asAgentMessage(
@@ -78,23 +206,29 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
         ),
       );
     }
-    const boundaryIdx = pathEntries.findIndex((entry) => entry.id === boundary.id);
-    // A reset kept tail mirrors the old cross-log replay contract: only user/assistant
-    // rows survive. Compaction keeps its existing richer retained-tail behavior.
-    let foundFirstKept = false;
-    for (const entry of pathEntries.slice(0, boundaryIdx)) {
-      if (entry.id === boundary.firstKeptEntryId) {
-        foundFirstKept = true;
-      }
-      if (foundFirstKept) {
-        if (boundary.type === "reset") {
-          appendResetKeptMessage(messages, entry);
+    const retainedEntries = pathEntries.slice(
+      window.retainedStartPosition,
+      window.boundaryPosition,
+    );
+    const retainedToolCallIds =
+      boundary.type === "reset" && options?.pairResetToolResultsForRecovery
+        ? collectAssistantToolCallIds(retainedEntries)
+        : undefined;
+    // Normal reset replay mirrors the old cross-log contract: only user/assistant
+    // rows survive. Safeguard recovery additionally retains tool results paired to
+    // those assistant rows so redistillation never sees orphaned tool calls.
+    for (const entry of retainedEntries) {
+      if (boundary.type === "reset") {
+        if (retainedToolCallIds) {
+          appendResetRecoveryMessage(messages, entry, retainedToolCallIds);
         } else {
-          appendContextMessage(messages, entry);
+          appendResetKeptMessage(messages, entry);
         }
+      } else {
+        appendContextMessage(messages, entry);
       }
     }
-    for (const entry of pathEntries.slice(boundaryIdx + 1)) {
+    for (const entry of pathEntries.slice(window.postBoundaryPosition)) {
       appendContextMessage(messages, entry);
     }
   } else {
@@ -104,4 +238,14 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
   }
 
   return { messages, thinkingLevel, model };
+}
+
+/** Build model context from an ordered session branch and its latest state markers. */
+export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionContext {
+  return buildSessionContextInternal(pathEntries);
+}
+
+/** Build safeguard recovery context while retaining paired reset tool results. */
+export function buildSessionRecoveryContext(pathEntries: SessionTreeEntry[]): SessionContext {
+  return buildSessionContextInternal(pathEntries, { pairResetToolResultsForRecovery: true });
 }

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -3239,6 +3239,302 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(JSON.stringify(messages)).toContain("historical reply");
   });
 
+  it("recovers the retained compaction tail without duplicating the previous summary", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(summaryResult("active branch summary"));
+
+    const now = Date.now();
+    const sessionManager = {
+      ...stubSessionManager(),
+      getBranch: () => [
+        {
+          type: "message",
+          id: "old-user",
+          parentId: null,
+          timestamp: new Date(now).toISOString(),
+          message: { role: "user", content: "already summarized request", timestamp: now },
+        },
+        {
+          type: "message",
+          id: "kept-user",
+          parentId: "old-user",
+          timestamp: new Date(now + 1).toISOString(),
+          message: { role: "user", content: "inspect the active state", timestamp: now + 1 },
+        },
+        {
+          type: "message",
+          id: "kept-assistant",
+          parentId: "kept-user",
+          timestamp: new Date(now + 2).toISOString(),
+          message: {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call-1", name: "status", arguments: {} }],
+            timestamp: now + 2,
+          },
+        },
+        {
+          type: "message",
+          id: "kept-result",
+          parentId: "kept-assistant",
+          timestamp: new Date(now + 3).toISOString(),
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "status",
+            content: [{ type: "text", text: "active result" }],
+            timestamp: now + 3,
+          },
+        },
+        {
+          type: "compaction",
+          id: "latest-compaction",
+          parentId: "kept-result",
+          timestamp: new Date(now + 4).toISOString(),
+          summary: "prior summary",
+          firstKeptEntryId: "kept-user",
+          tokensBefore: 38_000,
+        },
+        {
+          type: "message",
+          id: "post-user",
+          parentId: "latest-compaction",
+          timestamp: new Date(now + 5).toISOString(),
+          message: { role: "user", content: "continue the active work", timestamp: now + 5 },
+        },
+      ],
+    } as ExtensionContext["sessionManager"];
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event: {
+        preparation: {
+          messagesToSummarize: [
+            {
+              role: "toolResult",
+              toolCallId: "unpaired",
+              toolName: "status",
+              content: [{ type: "text", text: "orphaned preparation output" }],
+              timestamp: now + 6,
+            },
+          ] as AgentMessage[],
+          turnPrefixMessages: [] as AgentMessage[],
+          previousSummary: undefined,
+          firstKeptEntryId: "post-user",
+          tokensBefore: 38_085,
+          fileOps: { read: [], edited: [], written: [] },
+          settings: { reserveTokens: 4_000 },
+          isSplitTurn: true,
+        },
+        customInstructions: "",
+        signal: new AbortController().signal,
+      },
+      apiKey: "dummy",
+    });
+
+    expect(expectCompactionResult(result).summary).toContain("active branch summary");
+    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
+    const serializedMessages = JSON.stringify(requireArray(summarizeCall.messages));
+    expect(serializedMessages.match(/prior summary/g)).toHaveLength(1);
+    expect(serializedMessages).not.toContain("already summarized request");
+    expect(serializedMessages).toContain("inspect the active state");
+    expect(serializedMessages).toContain("active result");
+    expect(serializedMessages).toContain("continue the active work");
+  });
+
+  it("recovers paired tool results from a retained reset tail", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(summaryResult("reset branch summary"));
+
+    const now = Date.now();
+    const sessionManager = {
+      ...stubSessionManager(),
+      getBranch: () => [
+        {
+          type: "message",
+          id: "old-user",
+          parentId: null,
+          timestamp: new Date(now).toISOString(),
+          message: { role: "user", content: "discarded request", timestamp: now },
+        },
+        {
+          type: "message",
+          id: "kept-user",
+          parentId: "old-user",
+          timestamp: new Date(now + 1).toISOString(),
+          message: { role: "user", content: "inspect active state", timestamp: now + 1 },
+        },
+        {
+          type: "message",
+          id: "kept-assistant",
+          parentId: "kept-user",
+          timestamp: new Date(now + 2).toISOString(),
+          message: {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call-1", name: "status", arguments: {} }],
+            timestamp: now + 2,
+          },
+        },
+        {
+          type: "message",
+          id: "kept-result",
+          parentId: "kept-assistant",
+          timestamp: new Date(now + 3).toISOString(),
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "status",
+            content: [{ type: "text", text: "active reset result" }],
+            timestamp: now + 3,
+          },
+        },
+        {
+          type: "message",
+          id: "unrelated-result",
+          parentId: "kept-result",
+          timestamp: new Date(now + 4).toISOString(),
+          message: {
+            role: "toolResult",
+            toolCallId: "unrelated",
+            toolName: "status",
+            content: [{ type: "text", text: "unrelated reset output" }],
+            timestamp: now + 4,
+          },
+        },
+        {
+          type: "reset",
+          id: "latest-reset",
+          parentId: "unrelated-result",
+          timestamp: new Date(now + 5).toISOString(),
+          reason: "new",
+          firstKeptEntryId: "kept-user",
+        },
+        {
+          type: "message",
+          id: "post-user",
+          parentId: "latest-reset",
+          timestamp: new Date(now + 6).toISOString(),
+          message: { role: "user", content: "continue after reset", timestamp: now + 6 },
+        },
+      ],
+    } as ExtensionContext["sessionManager"];
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event: {
+        preparation: {
+          messagesToSummarize: [
+            {
+              role: "toolResult",
+              toolCallId: "orphaned",
+              toolName: "status",
+              content: [{ type: "text", text: "orphaned preparation output" }],
+              timestamp: now + 7,
+            },
+          ] as AgentMessage[],
+          turnPrefixMessages: [] as AgentMessage[],
+          previousSummary: undefined,
+          firstKeptEntryId: "post-user",
+          tokensBefore: 38_085,
+          fileOps: { read: [], edited: [], written: [] },
+          settings: { reserveTokens: 4_000 },
+          isSplitTurn: true,
+        },
+        customInstructions: "",
+        signal: new AbortController().signal,
+      },
+      apiKey: "dummy",
+    });
+
+    expect(expectCompactionResult(result).summary).toContain("reset branch summary");
+    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
+    const serializedMessages = JSON.stringify(requireArray(summarizeCall.messages));
+    expect(serializedMessages).toContain("inspect active state");
+    expect(serializedMessages).toContain("active reset result");
+    expect(serializedMessages).toContain("continue after reset");
+    expect(serializedMessages).not.toContain("discarded request");
+    expect(serializedMessages).not.toContain("unrelated reset output");
+  });
+
+  it("passes a recovered branch summary to a configured compaction provider", async () => {
+    const providerSummarize = vi.fn().mockResolvedValue("provider branch summary");
+    registerCompactionProvider({
+      id: "branch-recovery-provider",
+      label: "Branch Recovery Provider",
+      summarize: providerSummarize,
+    });
+
+    const now = Date.now();
+    const sessionManager = {
+      ...stubSessionManager(),
+      getBranch: () => [
+        {
+          type: "message",
+          id: "old-user",
+          parentId: null,
+          timestamp: new Date(now).toISOString(),
+          message: { role: "user", content: "already summarized request", timestamp: now },
+        },
+        {
+          type: "compaction",
+          id: "latest-compaction",
+          parentId: "old-user",
+          timestamp: new Date(now + 1).toISOString(),
+          summary: "recovered prior summary",
+          firstKeptEntryId: "missing",
+          tokensBefore: 38_000,
+        },
+        {
+          type: "message",
+          id: "post-user",
+          parentId: "latest-compaction",
+          timestamp: new Date(now + 2).toISOString(),
+          message: { role: "user", content: "continue active work", timestamp: now + 2 },
+        },
+      ],
+    } as ExtensionContext["sessionManager"];
+    setCompactionSafeguardRuntime(sessionManager, {
+      provider: "branch-recovery-provider",
+      recentTurnsPreserve: 0,
+    });
+
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event: {
+        preparation: {
+          messagesToSummarize: [
+            {
+              role: "toolResult",
+              toolCallId: "unpaired",
+              toolName: "status",
+              content: [{ type: "text", text: "orphaned output" }],
+              timestamp: now + 3,
+            },
+          ] as AgentMessage[],
+          turnPrefixMessages: [] as AgentMessage[],
+          previousSummary: undefined,
+          firstKeptEntryId: "post-user",
+          tokensBefore: 38_085,
+          fileOps: { read: [], edited: [], written: [] },
+          settings: { reserveTokens: 4_000 },
+          isSplitTurn: true,
+        },
+        customInstructions: "",
+        signal: new AbortController().signal,
+      },
+      apiKey: null,
+    });
+
+    expect(expectCompactionResult(result).summary).toContain("provider branch summary");
+    const providerInput = requireRecord(mockCallArg(providerSummarize));
+    expect(providerInput.previousSummary).toBe("recovered prior summary");
+    expect(JSON.stringify(providerInput.messages)).toContain("continue active work");
+    expect(JSON.stringify(providerInput.messages)).not.toContain("already summarized request");
+  });
+
   it("recovers user and assistant branch turns when compaction preparation has only tool output", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages.mockResolvedValue(summaryResult("branch summary with visible turns"));

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -4,6 +4,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { buildSessionRecoveryContext } from "../../../packages/agent-core/src/harness/session/session.js";
+import type { SessionTreeEntry } from "../../../packages/agent-core/src/harness/types.js";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
 import { isAbortError } from "../../infra/abort-signal.js";
 import { openRootFile } from "../../infra/boundary-file-read.js";
@@ -106,51 +108,33 @@ function prependPreviousSummaryForRedistill(params: {
   ];
 }
 
-function coerceTimestamp(value: unknown): number {
-  const timestamp = typeof value === "string" ? Date.parse(value) : value;
-  return typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : 0;
-}
-
-function sessionBranchEntryToMessage(entry: Record<string, unknown>): unknown {
-  if (entry.type === "message" && entry.message && typeof entry.message === "object") {
-    return entry.message;
-  }
-  if (entry.type === "custom_message") {
-    return {
-      role: "custom",
-      customType: typeof entry.customType === "string" ? entry.customType : "custom",
-      content: entry.content,
-      display: entry.display !== false,
-      details: entry.details,
-      timestamp: coerceTimestamp(entry.timestamp),
-    };
-  }
-  if (entry.type === "branch_summary") {
-    return {
-      role: "branchSummary",
-      summary: typeof entry.summary === "string" ? entry.summary : "",
-      fromId: typeof entry.fromId === "string" ? entry.fromId : "root",
-      timestamp: coerceTimestamp(entry.timestamp),
-    };
-  }
-  return undefined;
-}
-
 function collectSessionBranchMessages(sessionManager: unknown): AgentMessage[] {
   try {
     const entries: unknown = (sessionManager as { getBranch?: () => unknown })?.getBranch?.();
     return Array.isArray(entries)
-      ? entries.flatMap((entry) => {
-          const message =
-            entry && typeof entry === "object"
-              ? sessionBranchEntryToMessage(entry as Record<string, unknown>)
-              : undefined;
-          return message ? [message as AgentMessage] : [];
-        })
+      ? (buildSessionRecoveryContext(entries as SessionTreeEntry[]).messages as AgentMessage[])
       : [];
   } catch {
     return [];
   }
+}
+
+function splitSessionBranchCompactionSummary(messages: AgentMessage[]): {
+  messages: AgentMessage[];
+  previousSummary?: string;
+} {
+  let previousSummary: string | undefined;
+  const replayMessages = messages.filter((message) => {
+    if (message.role !== "compactionSummary") {
+      return true;
+    }
+    const summary = (message as { summary?: unknown }).summary;
+    if (!previousSummary && typeof summary === "string" && summary.trim()) {
+      previousSummary = summary.trim();
+    }
+    return false;
+  });
+  return { messages: replayMessages, ...(previousSummary ? { previousSummary } : {}) };
 }
 
 function isSessionsSendToolName(value: unknown): boolean {
@@ -861,18 +845,21 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       preparation.messagesToSummarize,
     );
     let baseTurnPrefixMessages = stripRuntimeContextCustomMessages(rawTurnPrefixMessages);
+    let recoveredPreviousSummary: string | undefined;
     let hasRealSummarizable = containsRealConversation(baseMessagesToSummarize);
     let hasRealTurnPrefix = containsRealConversation(baseTurnPrefixMessages);
     if (!hasRealSummarizable && !hasRealTurnPrefix) {
-      const branchMessages = filterReplayUnsafeSessionBranchMessages(
+      const recoveredBranch = splitSessionBranchCompactionSummary(
         stripRuntimeContextCustomMessages(collectSessionBranchMessages(ctx.sessionManager)),
       );
+      const branchMessages = filterReplayUnsafeSessionBranchMessages(recoveredBranch.messages);
       if (containsRealConversation(branchMessages)) {
         log.info(
           "Compaction safeguard: using session branch messages after compaction preparation omitted real conversation content.",
         );
         baseMessagesToSummarize = branchMessages;
         baseTurnPrefixMessages = [];
+        recoveredPreviousSummary = recoveredBranch.previousSummary;
         hasRealSummarizable = true;
         hasRealTurnPrefix = false;
       }
@@ -963,7 +950,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             signal,
             customInstructions: structuredInstructions,
             summarizationInstructions,
-            previousSummary: preparation.previousSummary,
+            previousSummary: preparation.previousSummary ?? recoveredPreviousSummary,
           });
           if (typeof providerResult === "string" && providerResult.trim()) {
             const { preservedMessages } = splitPreservedRecentTurns({
@@ -1090,7 +1077,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   messages: pruned.droppedMessagesList,
                   maxChunkTokens: droppedMaxChunkTokens,
                   customInstructions: structuredInstructions,
-                  previousSummary: preparation.previousSummary,
+                  previousSummary: preparation.previousSummary ?? recoveredPreviousSummary,
                 });
               } catch (droppedError) {
                 if (signal?.aborted) {
@@ -1134,7 +1121,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       );
       // Feed dropped-messages summary as previousSummary so the main summarization
       // incorporates context from pruned messages instead of losing it entirely.
-      const effectivePreviousSummary = droppedSummary ?? preparation.previousSummary;
+      const effectivePreviousSummary =
+        droppedSummary ?? preparation.previousSummary ?? recoveredPreviousSummary;
 
       let lastHistorySummary = "";
       let lastSplitTurnSection = "";

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -3031,6 +3031,81 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.preflightCompactionTrigger).toBe("transcript_bytes");
   });
 
+  it("does not recompact durable SQLite history before the latest compaction boundary", async () => {
+    const storePath = path.join(rootDir, "sqlite-compacted-session.json");
+    const sessionKey = "agent:main:main";
+    const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
+    await upsertSessionEntry(scope, { sessionId: "session", updatedAt: 10 });
+    await replaceSqliteTranscriptEvents(scope, [
+      {
+        type: "message",
+        id: "large-old",
+        parentId: null,
+        timestamp: "2026-07-25T00:00:00.000Z",
+        message: { role: "user", content: "x".repeat(8_000) },
+      },
+      {
+        type: "message",
+        id: "kept",
+        parentId: "large-old",
+        timestamp: "2026-07-25T00:00:01.000Z",
+        message: { role: "assistant", content: "kept" },
+      },
+      {
+        type: "compaction",
+        id: "compacted",
+        parentId: "kept",
+        timestamp: "2026-07-25T00:00:02.000Z",
+        summary: "short summary",
+        firstKeptEntryId: "kept",
+        tokensBefore: 2_000,
+      },
+      {
+        type: "message",
+        id: "post-compaction",
+        parentId: "compacted",
+        timestamp: "2026-07-25T00:00:03.000Z",
+        message: { role: "user", content: "continue" },
+      },
+    ]);
+    expect(readTranscriptStatsSync(scope).sizeBytes).toBeGreaterThan(8_000);
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 10,
+      totalTokensFresh: true,
+      compactionCount: 1,
+    };
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: "1kb",
+            },
+          },
+        },
+      },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionKey,
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
   it("keeps incognito preflight compaction in the process-local transcript store", async () => {
     const durableStorePath = path.join(rootDir, "durable-sessions.json");
     const sessionKey = "agent:main:dashboard:incognito-preflight";

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -40,7 +40,7 @@ import {
 } from "../../config/sessions.js";
 import {
   readRecentSessionTranscriptActiveEvents,
-  readSessionTranscriptActiveStats,
+  readSessionTranscriptContextByteSize,
   updateSessionEntry,
 } from "../../config/sessions/session-accessor.js";
 import { resolveSessionStorePathForScope } from "../../config/sessions/session-store-path.js";
@@ -465,7 +465,7 @@ function readSqliteSessionLogSnapshot(
   const snapshot: SessionLogSnapshot = {};
   try {
     if (options.includeByteSize) {
-      snapshot.byteSize = readSessionTranscriptActiveStats(scope).sizeBytes;
+      snapshot.byteSize = readSessionTranscriptContextByteSize(scope);
     }
     if (options.includeUsage || options.includeTurnTaint) {
       const events = readRecentSessionTranscriptActiveEvents(scope, SQLITE_USAGE_TAIL_MAX_EVENTS);

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -14,6 +14,7 @@ import {
   readSessionTranscriptActiveLeafEvents,
   readSessionTranscriptActiveStats,
   readSessionTranscriptBoundedMessageTailPage,
+  readSessionTranscriptContextByteSize,
   readSessionTranscriptMessageAnchorPage,
   readSessionTranscriptMessageEventById,
   readSessionTranscriptMessageEventCount,
@@ -154,6 +155,77 @@ describe("SQLite active transcript event projection", () => {
     });
   });
 
+  it("measures the latest compaction replay window while retaining durable history", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "large-old",
+          parentId: null,
+          message: { role: "user", content: `old ${"x".repeat(8_000)}` },
+        },
+        {
+          eventId: "kept",
+          parentId: "large-old",
+          message: { role: "assistant", content: "kept answer" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    const bytesBefore = readSessionTranscriptContextByteSize(scope);
+
+    await appendTranscriptEvent(scope, {
+      type: "compaction",
+      id: "first-compaction",
+      parentId: "kept",
+      timestamp: "2026-07-22T00:01:00.000Z",
+      summary: "short summary",
+      firstKeptEntryId: "kept",
+      tokensBefore: 2_000,
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "post-compaction",
+          parentId: "first-compaction",
+          message: { role: "user", content: `new turn ${"y".repeat(2_000)}` },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    const bytesAfterFirstCompaction = readSessionTranscriptContextByteSize(scope);
+
+    await appendTranscriptEvent(scope, {
+      type: "compaction",
+      id: "latest-compaction",
+      parentId: "post-compaction",
+      timestamp: "2026-07-22T00:02:00.000Z",
+      summary: "latest summary",
+      firstKeptEntryId: "missing-entry",
+      tokensBefore: 1_000,
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "latest-turn",
+          parentId: "latest-compaction",
+          message: { role: "user", content: "latest turn" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+
+    const activeStats = readSessionTranscriptActiveStats(scope);
+    const latestBytes = readSessionTranscriptContextByteSize(scope);
+    expect(bytesBefore).toBeGreaterThan(8_000);
+    expect(bytesAfterFirstCompaction).toBeGreaterThan(2_000);
+    expect(bytesAfterFirstCompaction).toBeLessThan(bytesBefore / 2);
+    expect(latestBytes).toBeGreaterThan(0);
+    expect(latestBytes).toBeLessThan(bytesAfterFirstCompaction / 2);
+    expect(activeStats.sizeBytes).toBeGreaterThan(bytesBefore);
+    expect(readSessionTranscriptMessageEventCount(scope)).toBe(4);
+    expect(readSessionTranscriptMessageEventById(scope, "large-old")).toBeDefined();
+  });
+
   it("defers mixed legacy and canonical rebuilds off request stacks", async () => {
     await persistSessionTranscriptTurn(scope, {
       messages: [
@@ -264,7 +336,11 @@ describe("SQLite active transcript event projection", () => {
   it("projects reset kept-tail and post-boundary messages without rewriting raw positions", async () => {
     await persistSessionTranscriptTurn(scope, {
       messages: [
-        { eventId: "old", parentId: null, message: { role: "user", content: "old" } },
+        {
+          eventId: "old",
+          parentId: null,
+          message: { role: "user", content: `old ${"x".repeat(8_000)}` },
+        },
         {
           eventId: "kept-user",
           parentId: "old",
@@ -303,6 +379,13 @@ describe("SQLite active transcript event projection", () => {
     });
 
     const page = readSessionTranscriptMessageEventPage(scope, { maxMessages: 10, offset: 0 });
+    const contextBytes = readSessionTranscriptContextByteSize(scope);
+    const visibleJsonlBytes = page.events.reduce(
+      (total, entry) => total + Buffer.byteLength(JSON.stringify(entry.event)) + 1,
+      0,
+    );
+    expect(contextBytes).toBe(visibleJsonlBytes);
+    expect(contextBytes).toBeLessThan(readSessionTranscriptActiveStats(scope).sizeBytes / 2);
 
     expect(page.events.map((entry) => (entry.event as { id?: unknown }).id)).toEqual([
       "kept-user",

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -10,6 +10,10 @@ import {
   openOpenClawAgentDatabase,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
+import {
+  readActiveTranscriptReplayByteSize,
+  readActiveTranscriptStats,
+} from "./session-accessor.sqlite-active-stats.js";
 import type {
   SessionTranscriptVisibleMessageDeltaLimits,
   SessionTranscriptVisibleMessageDeltaResult,
@@ -18,6 +22,7 @@ import type {
 } from "./session-accessor.sqlite-contract.js";
 import {
   readVisibleMessageRange,
+  resolveActiveSessionReplayWindow,
   resolveVisibleMessagePositionRange,
   resolveVisibleMessagePositions,
 } from "./session-accessor.sqlite-reset-window.js";
@@ -265,35 +270,23 @@ export function readRecentSessionTranscriptActiveEvents(
   });
 }
 
-/** Reads active-path event count and JSONL byte size without materializing payloads. */
 export function readSessionTranscriptActiveStats(scope: SessionTranscriptReadScope): {
   eventCount: number;
   sizeBytes: number;
 } {
-  return withCurrentProjectionSnapshot(scope, (projection) => {
-    const db = getActiveTranscriptKysely(projection.database);
-    const row = executeSqliteQueryTakeFirstSync(
-      projection.database.db,
-      db
-        .selectFrom("session_transcript_active_events as active")
-        .innerJoin("transcript_events as event", (join) =>
-          join
-            .onRef("event.session_id", "=", "active.session_id")
-            .onRef("event.seq", "=", "active.event_seq"),
-        )
-        .select((eb) => [
-          eb.fn.count<number>("active.event_seq").as("event_count"),
-          /* kysely-allow-raw: JSONL size includes one terminating newline per event. */
-          sql<number>`COALESCE(SUM(LENGTH(CAST(event.event_json AS BLOB))), 0)
-            + COUNT(*)`.as("size_bytes"),
-        ])
-        .where("active.session_id", "=", projection.resolved.sessionId),
-    );
-    return {
-      eventCount: row?.event_count ?? 0,
-      sizeBytes: row?.size_bytes ?? 0,
-    };
-  });
+  return withCurrentProjectionSnapshot(scope, (projection) =>
+    readActiveTranscriptStats(projection.database, projection.resolved.sessionId),
+  );
+}
+
+export function readSessionTranscriptContextByteSize(scope: SessionTranscriptReadScope): number {
+  return withCurrentProjectionSnapshot(scope, (projection) =>
+    readActiveTranscriptReplayByteSize(
+      projection.database,
+      projection.resolved.sessionId,
+      resolveActiveSessionReplayWindow(projection),
+    ),
+  );
 }
 
 /** Reads one append-stable forward page from the materialized active-message projection. */

--- a/src/config/sessions/session-accessor.sqlite-active-stats.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-stats.ts
@@ -1,0 +1,81 @@
+import { sql } from "kysely";
+import type { SessionReplayWindow } from "../../../packages/agent-core/src/harness/session/session.js";
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+
+type ActiveStatsDatabase = Pick<
+  OpenClawAgentKyselyDatabase,
+  "session_transcript_active_events" | "transcript_events"
+>;
+
+function getActiveStatsKysely(database: OpenClawAgentDatabase) {
+  return getNodeSqliteKysely<ActiveStatsDatabase>(database.db);
+}
+
+export function readActiveTranscriptStats(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): { eventCount: number; sizeBytes: number } {
+  const db = getActiveStatsKysely(database);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("session_transcript_active_events as active")
+      .innerJoin("transcript_events as event", (join) =>
+        join
+          .onRef("event.session_id", "=", "active.session_id")
+          .onRef("event.seq", "=", "active.event_seq"),
+      )
+      .select((eb) => [
+        eb.fn.count<number>("active.event_seq").as("event_count"),
+        /* kysely-allow-raw: JSONL size includes one terminating newline per event. */
+        sql<number>`COALESCE(SUM(LENGTH(CAST(event.event_json AS BLOB))), 0)
+          + COUNT(*)`.as("size_bytes"),
+      ])
+      .where("active.session_id", "=", sessionId),
+  );
+  return {
+    eventCount: row?.event_count ?? 0,
+    sizeBytes: row?.size_bytes ?? 0,
+  };
+}
+
+export function readActiveTranscriptReplayByteSize(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  window: SessionReplayWindow | null,
+): number {
+  const db = getActiveStatsKysely(database);
+  let query = db
+    .selectFrom("session_transcript_active_events as active")
+    .innerJoin("transcript_events as event", (join) =>
+      join
+        .onRef("event.session_id", "=", "active.session_id")
+        .onRef("event.seq", "=", "active.event_seq"),
+    )
+    .select(
+      /* kysely-allow-raw: JSONL size includes one terminating newline per replayed event. */
+      sql<number>`COALESCE(SUM(LENGTH(CAST(event.event_json AS BLOB))), 0)
+        + COUNT(*)`.as("size_bytes"),
+    )
+    .where("active.session_id", "=", sessionId);
+  if (window?.boundaryType === "reset") {
+    // Reset's retained tail intentionally replays only user and assistant rows;
+    // post-boundary entries retain their normal richer replay semantics.
+    query = query.where(
+      /* kysely-allow-raw: Reset replay combines position ranges with a JSON message-role predicate. */
+      sql<boolean>`(
+        active.active_position >= ${window.postBoundaryPosition}
+        OR (
+          active.active_position >= ${window.retainedStartPosition}
+          AND active.active_position < ${window.boundaryPosition}
+          AND json_extract(event.event_json, '$.message.role') IN ('user', 'assistant')
+        )
+      )`,
+    );
+  } else if (window) {
+    query = query.where("active.active_position", ">=", window.retainedStartPosition);
+  }
+  return executeSqliteQueryTakeFirstSync(database.db, query)?.size_bytes ?? 0;
+}

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -1,5 +1,9 @@
 // Reset boundaries project a logical message window without rewriting raw cursor positions.
 import {
+  projectSessionReplayWindow,
+  type SessionReplayWindow,
+} from "../../../packages/agent-core/src/harness/session/session.js";
+import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
@@ -37,20 +41,19 @@ type ResetWindowMessageEvent = {
 };
 
 type ResetMessageWindow = {
-  generation: string | undefined;
-  indexedSeq: number;
   keptMessagePositions: number[];
   postBoundaryMessagePosition: number;
 };
 
-type ResetMessageWindowCacheEntry = {
+type ActiveSessionWindow = {
   generation: string | undefined;
   indexedSeq: number;
-  window: ResetMessageWindow | null;
+  replayWindow: SessionReplayWindow | null;
+  resetWindow: ResetMessageWindow | null;
 };
 
-const resetMessageWindowCache = new Map<string, ResetMessageWindowCacheEntry>();
-const MAX_RESET_MESSAGE_WINDOW_CACHE = 64;
+const activeSessionWindowCache = new Map<string, ActiveSessionWindow>();
+const MAX_ACTIVE_SESSION_WINDOW_CACHE = 64;
 
 function getResetWindowKysely(database: OpenClawAgentDatabase) {
   return getNodeSqliteKysely<ResetWindowDatabase>(database.db);
@@ -105,7 +108,7 @@ function parseTranscriptEventType(eventJson: string): string | undefined {
   }
 }
 
-function resetMessageWindowCacheKey(projection: ResetWindowProjection): string {
+function activeSessionWindowCacheKey(projection: ResetWindowProjection): string {
   return `${projection.database.path}\0${projection.resolved.sessionId}`;
 }
 
@@ -119,16 +122,16 @@ function readTranscriptGeneration(projection: ResetWindowProjection): string | u
   )?.generation;
 }
 
-function cacheResetMessageWindow(key: string, entry: ResetMessageWindowCacheEntry): void {
-  resetMessageWindowCache.delete(key);
-  resetMessageWindowCache.set(key, entry);
-  pruneMapToMaxSize(resetMessageWindowCache, MAX_RESET_MESSAGE_WINDOW_CACHE);
+function cacheActiveSessionWindow(key: string, entry: ActiveSessionWindow): void {
+  activeSessionWindowCache.delete(key);
+  activeSessionWindowCache.set(key, entry);
+  pruneMapToMaxSize(activeSessionWindowCache, MAX_ACTIVE_SESSION_WINDOW_CACHE);
 }
 
-function findLatestResetMessageWindow(
+function findLatestActiveSessionWindow(
   projection: ResetWindowProjection,
   generation: string | undefined,
-): ResetMessageWindow | null {
+): ActiveSessionWindow {
   const db = getResetWindowKysely(projection.database);
   const nonMessageRows = executeSqliteQuerySync(
     projection.database.db,
@@ -148,25 +151,28 @@ function findLatestResetMessageWindow(
     const type = parseTranscriptEventType(row.event_json);
     return type === "reset" || type === "compaction";
   });
-  if (!latestBoundaryRow || parseTranscriptEventType(latestBoundaryRow.event_json) !== "reset") {
-    return null;
+  if (!latestBoundaryRow) {
+    return {
+      generation,
+      indexedSeq: projection.state.indexedSeq,
+      replayWindow: null,
+      resetWindow: null,
+    };
   }
-  const resetRow = latestBoundaryRow;
-  const reset = JSON.parse(resetRow.event_json) as { firstKeptEntryId?: unknown };
-  const postBoundaryMessagePosition =
-    executeSqliteQueryTakeFirstSync(
-      projection.database.db,
-      db
-        .selectFrom("session_transcript_active_events")
-        .select("message_position")
-        .where("session_id", "=", projection.resolved.sessionId)
-        .where("active_position", ">", resetRow.active_position)
-        .where("message_position", "is not", null)
-        .orderBy("active_position", "asc")
-        .limit(1),
-    )?.message_position ?? projection.state.activeMessageCount;
-  let keptMessagePositions: number[] = [];
-  if (typeof reset.firstKeptEntryId === "string") {
+  const boundary = JSON.parse(latestBoundaryRow.event_json) as {
+    firstKeptEntryId?: unknown;
+    type?: unknown;
+  };
+  if (boundary.type !== "reset" && boundary.type !== "compaction") {
+    return {
+      generation,
+      indexedSeq: projection.state.indexedSeq,
+      replayWindow: null,
+      resetWindow: null,
+    };
+  }
+  let firstKeptPosition: number | undefined;
+  if (typeof boundary.firstKeptEntryId === "string") {
     const firstKept = executeSqliteQueryTakeFirstSync(
       projection.database.db,
       db
@@ -178,68 +184,110 @@ function findLatestResetMessageWindow(
         )
         .select("active.active_position")
         .where("identity.session_id", "=", projection.resolved.sessionId)
-        .where("identity.event_id", "=", reset.firstKeptEntryId),
+        .where("identity.event_id", "=", boundary.firstKeptEntryId),
     );
-    if (firstKept && firstKept.active_position < resetRow.active_position) {
-      keptMessagePositions = executeSqliteQuerySync(
-        projection.database.db,
-        db
-          .selectFrom("session_transcript_active_events as active")
-          .innerJoin("transcript_events as event", (join) =>
-            join
-              .onRef("event.session_id", "=", "active.session_id")
-              .onRef("event.seq", "=", "active.event_seq"),
-          )
-          .select(["active.message_position", "event.event_json"])
-          .where("active.session_id", "=", projection.resolved.sessionId)
-          .where("active.active_position", ">=", firstKept.active_position)
-          .where("active.active_position", "<", resetRow.active_position)
-          .where("active.message_position", "is not", null)
-          .orderBy("active.active_position", "asc"),
-      ).rows.flatMap((row) => {
-        if (row.message_position === null) {
-          return [];
-        }
-        try {
-          const role = (JSON.parse(row.event_json) as { message?: { role?: unknown } }).message
-            ?.role;
-          return role === "user" || role === "assistant" ? [row.message_position] : [];
-        } catch {
-          return [];
-        }
-      });
+    if (firstKept && firstKept.active_position < latestBoundaryRow.active_position) {
+      firstKeptPosition = firstKept.active_position;
     }
+  }
+  const replayWindow = projectSessionReplayWindow({
+    boundaryPosition: latestBoundaryRow.active_position,
+    boundaryType: boundary.type,
+    entryCount: projection.state.activeEventCount,
+    ...(firstKeptPosition === undefined ? {} : { firstKeptPosition }),
+  });
+  if (!replayWindow) {
+    return {
+      generation,
+      indexedSeq: projection.state.indexedSeq,
+      replayWindow: null,
+      resetWindow: null,
+    };
+  }
+  if (boundary.type !== "reset") {
+    return {
+      generation,
+      indexedSeq: projection.state.indexedSeq,
+      replayWindow,
+      resetWindow: null,
+    };
+  }
+  const postBoundaryMessagePosition =
+    executeSqliteQueryTakeFirstSync(
+      projection.database.db,
+      db
+        .selectFrom("session_transcript_active_events")
+        .select("message_position")
+        .where("session_id", "=", projection.resolved.sessionId)
+        .where("active_position", ">", replayWindow.boundaryPosition)
+        .where("message_position", "is not", null)
+        .orderBy("active_position", "asc")
+        .limit(1),
+    )?.message_position ?? projection.state.activeMessageCount;
+  let keptMessagePositions: number[] = [];
+  if (replayWindow.retainedStartPosition < replayWindow.boundaryPosition) {
+    keptMessagePositions = executeSqliteQuerySync(
+      projection.database.db,
+      db
+        .selectFrom("session_transcript_active_events as active")
+        .innerJoin("transcript_events as event", (join) =>
+          join
+            .onRef("event.session_id", "=", "active.session_id")
+            .onRef("event.seq", "=", "active.event_seq"),
+        )
+        .select(["active.message_position", "event.event_json"])
+        .where("active.session_id", "=", projection.resolved.sessionId)
+        .where("active.active_position", ">=", replayWindow.retainedStartPosition)
+        .where("active.active_position", "<", replayWindow.boundaryPosition)
+        .where("active.message_position", "is not", null)
+        .orderBy("active.active_position", "asc"),
+    ).rows.flatMap((row) => {
+      if (row.message_position === null) {
+        return [];
+      }
+      try {
+        const role = (JSON.parse(row.event_json) as { message?: { role?: unknown } }).message?.role;
+        return role === "user" || role === "assistant" ? [row.message_position] : [];
+      } catch {
+        return [];
+      }
+    });
   }
   return {
     generation,
     indexedSeq: projection.state.indexedSeq,
-    keptMessagePositions,
-    postBoundaryMessagePosition,
+    replayWindow,
+    resetWindow: {
+      keptMessagePositions,
+      postBoundaryMessagePosition,
+    },
   };
 }
 
-function resolveResetMessageWindow(projection: ResetWindowProjection): ResetMessageWindow | null {
-  const key = resetMessageWindowCacheKey(projection);
-  const cached = resetMessageWindowCache.get(key);
+function resolveActiveSessionWindow(projection: ResetWindowProjection): ActiveSessionWindow {
+  const key = activeSessionWindowCacheKey(projection);
+  const cached = activeSessionWindowCache.get(key);
   const generation = readTranscriptGeneration(projection);
   if (cached) {
     if (cached.generation === generation && cached.indexedSeq === projection.state.indexedSeq) {
-      return cached.window;
+      return cached;
     }
   }
-  const window = findLatestResetMessageWindow(projection, generation);
-  cacheResetMessageWindow(key, {
-    generation,
-    indexedSeq: projection.state.indexedSeq,
-    window,
-  });
+  const window = findLatestActiveSessionWindow(projection, generation);
+  cacheActiveSessionWindow(key, window);
   return window;
+}
+
+export function resolveActiveSessionReplayWindow(
+  projection: ResetWindowProjection,
+): SessionReplayWindow | null {
+  return resolveActiveSessionWindow(projection).replayWindow;
 }
 
 export function resolveVisibleMessagePositions(
   projection: ResetWindowProjection,
 ): VisibleMessagePositions {
-  const window = resolveResetMessageWindow(projection);
+  const window = resolveActiveSessionWindow(projection).resetWindow;
   if (!window) {
     return { kept: [], postStart: 0, total: projection.state.activeMessageCount };
   }

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -222,6 +222,7 @@ export {
   readRecentSessionTranscriptActiveEvents,
   readSessionTranscriptActiveStats,
   readSessionTranscriptBoundedMessageTailPage,
+  readSessionTranscriptContextByteSize,
   readRecentSessionTranscriptMessageEvents,
   readSessionTranscriptActiveLeafEvents,
   readSessionTranscriptMessageAnchorPage,


### PR DESCRIPTION
Fixes #115904.
Related: #81178, #115476, #116588.

## What Problem This Solves

Fixes an issue where SQLite-backed sessions could immediately compact again after a successful compaction. Durable pre-compaction history is intentionally retained for UI, audit, and history, but the transcript byte guard measured that full history instead of the model's current replay window.

Recovery fallback could also rebuild from the entire branch when compaction preparation omitted real conversation messages, causing already summarized history to be summarized again. Reset recovery additionally needed to preserve real tool results that pair with retained assistant tool calls without changing normal reset visibility.

## Why This Change Was Made

This introduces one owner-level replay-window projection shared by model context construction and SQLite byte accounting. It resolves the latest compaction or reset boundary, honors an earlier valid `firstKeptEntryId`, and falls back conservatively when that ID is missing or invalid.

The preflight byte guard now measures that projection inside the same current-projection SQLite transaction. The safeguard fallback uses a recovery-specific canonical session-context projection, carries a recovered prior summary exactly once, and preserves only tool results paired to retained reset assistant tool calls. Normal reset replay keeps its established visibility contract: retained user/assistant rows before the boundary, followed by normal post-reset replay.

Durable transcript rows are not deleted or rewritten.

## User Impact

Long-running SQLite sessions no longer enter a repeat-compaction/recovery loop simply because old history remains queryable. Successful compaction reduces the bytes used by the guard while preserving the complete transcript for history and audit surfaces.

## Evidence

Validated after rebasing onto fetched `upstream/main` `6a8e11e63ceed04aed5476180b2a9a4dccea44a0` at exact head `263e580778e705d48f6a704f580c236f8874ec31`:

```text
packages/agent-core/src/harness/session/session-context.test.ts: 7 passed
src/config/sessions/session-accessor.sqlite-active-events.test.ts: 12 passed
src/agents/agent-hooks/compaction-safeguard.test.ts: 123 passed
src/auto-reply/reply/agent-runner-memory.test.ts: 62 passed

Total: 204 passed
```

The focused regressions prove:

- an 8 KB pre-compaction message remains queryable through durable history
- a valid retained tail, including a tool call/result pair, is replayed once with the compaction summary
- the replay-window byte count falls below the guard while durable history stays intact
- the latest boundary wins when multiple boundaries exist
- invalid `firstKeptEntryId` values fall back to summary plus post-boundary replay
- normal reset context still excludes retained tool results
- safeguard recovery includes only tool results paired to retained reset assistant tool calls, excluding unrelated and orphaned outputs
- reset byte accounting exactly matches its visible retained tail
- branch recovery passes the recovered prior summary to both LLM and configured provider paths

Additional checks passed:

- `oxfmt --check` on all 11 changed files
- type-aware `oxlint --deny-warnings` on all 11 changed files
- `node scripts/check-kysely-guardrails.mjs`
- `git diff --check`
- fresh branch autoreview at this head: no P0/P1 findings; patch correctness 0.88

AI-assisted: Codex helped investigate, implement, test, and independently review this change.
