### PR TITLE
fix(discord): prevent corrupted directory results from malformed responses

### DIFF
--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -338,6 +338,35 @@ describe("fetchDiscord", () => {
     expect(String(error)).toContain("Discord API /users/@me/guilds returned malformed JSON");
   });
 
+  it("rejects malformed UTF-8 in otherwise valid Discord JSON", async () => {
+    let response: Response | undefined;
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write('[{"id":"guild-');
+      res.write(Buffer.from([0xff]));
+      res.end('","name":"Guild"}]');
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      stubDiscordFetchToLoopback(`http://127.0.0.1:${port}`, (nextResponse) => {
+        response = nextResponse;
+      });
+
+      await expect(
+        requestDiscord("/users/@me/guilds", "test", {
+          retry: { attempts: 1 },
+        }),
+      ).rejects.toThrow("Discord API /users/@me/guilds returned malformed JSON");
+      expect(response?.bodyUsed).toBe(true);
+      console.log(
+        `[discord requestDiscord loopback proof] malformed UTF-8: rejected=true body_used=${response?.bodyUsed}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
+  });
+
   it("returns under-cap requestDiscord responses from a real loopback HTTP server", async () => {
     const payload = { id: "channel-42", name: "loopback", type: 0 };
     let contentLength: string | null | undefined;

--- a/extensions/discord/src/api.ts
+++ b/extensions/discord/src/api.ts
@@ -219,11 +219,11 @@ export async function requestDiscord<T>(
               ),
           },
         );
-        const text = new TextDecoder().decode(responseBody);
-        if (!text.trim()) {
-          return undefined as T;
-        }
         try {
+          const text = new TextDecoder("utf-8", { fatal: true }).decode(responseBody);
+          if (!text.trim()) {
+            return undefined as T;
+          }
           return JSON.parse(text) as T;
         } catch {
           throw new DiscordApiError(`Discord API ${path} returned malformed JSON`, 0);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users resolving Discord guilds, channels, or members could receive corrupted identifiers or names containing the Unicode replacement character when an API response contains malformed UTF-8. The existing success-response decoder silently replaced invalid bytes before JSON parsing, so otherwise valid JSON was accepted with altered data.

## Why This Change Was Made

Discord's bounded success-response body is now decoded with fatal UTF-8 handling inside the existing malformed-JSON error boundary. This preserves the existing empty-body behavior, response size limit, retry policy, and public error message without adding another HTTP path or configuration surface.

This PR is AI-assisted. I reviewed the affected owner, callers, sibling probe behavior, tests, and the final diff.

## User Impact

Discord directory, allowlist-resolution, and application lookup workflows now fail clearly on corrupted response bytes instead of propagating altered IDs or display names.

## Evidence

- Before, on exact upstream `main@306c02af5771` with no production patch, a real loopback HTTP server returned JSON containing raw byte `0xff`. The real `fetch()` path accepted it as `guild-�`; the response was fully consumed (`body_used=true`).
- The branch is based on `main@859fd0b11e68`; the affected Discord API owner was unchanged between those heads.
- After, the same loopback path rejects the response with `Discord API /users/@me/guilds returned malformed JSON` and verifies `bodyUsed=true`.
- Focused validation:
  - `node scripts/run-vitest.mjs extensions/discord/src/api.test.ts extensions/discord/src/directory-live.test.ts extensions/discord/src/resolve-channels.test.ts extensions/discord/src/resolve-users.test.ts --reporter=verbose`
  - Result: 4 files passed, 45 tests passed.
  - `oxfmt --check extensions/discord/src/api.ts extensions/discord/src/api.test.ts`
  - `git diff --check origin/main...HEAD`
- Fresh branch review: `gpt-5.6-sol`, `xhigh`, no accepted/actionable findings; overall correctness confidence `0.99`.
