### PR TITLE
fix(memory-core): harden dreaming lifecycle

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -413,9 +413,9 @@ describe("runDreamNarrative", () => {
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
     const expectedRunKey = `dreaming-narrative-main-light-${workspaceHash}`;
-    const expectedSessionKey = `agent:main:dreaming-narrative-light-${workspaceHash}`;
+    const expectedSessionKey = `agent:main:dreaming-narrative-memory-core-v2-light-${workspaceHash}`;
 
-    await runDreamNarrative({
+    const outcome = await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -441,10 +441,42 @@ describe("runDreamNarrative", () => {
     expect(runOptions.model).toBe("anthropic/claude-sonnet-4-6");
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
     expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
+    expect(outcome).toEqual({ status: "completed" });
 
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(content).toContain("The repository whispered of forgotten endpoints.");
     expect(logger.info).toHaveBeenCalled();
+  });
+
+  it("keeps creation and cleanup on the memory-core-owned session identity", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-owner-");
+    const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
+    const legacyUnownedKey = `agent:blockdigest:dreaming-narrative-rem-${workspaceHash}`;
+    const ownedKey = `agent:blockdigest:dreaming-narrative-memory-core-v2-rem-${workspaceHash}`;
+    const subagent = createMockSubagent("The digest folded itself into a paper moon.");
+    subagent.deleteSession.mockImplementation(async ({ sessionKey }: { sessionKey: string }) => {
+      if (sessionKey === legacyUnownedKey) {
+        throw new Error('Plugin "memory-core" cannot delete session because it did not create it');
+      }
+    });
+    const logger = createMockLogger();
+
+    const outcome = await runDreamNarrative({
+      agentId: "blockdigest",
+      subagent,
+      workspaceDir,
+      data: { phase: "rem", snippets: ["A digest session needs one lifecycle owner."] },
+      logger,
+    });
+
+    expect(mockObjectArg(subagent.run, "subagent run").sessionKey).toBe(ownedKey);
+    expect(
+      subagent.deleteSession.mock.calls.map(
+        (call: unknown[]) => (call[0] as { sessionKey: string }).sessionKey,
+      ),
+    ).toEqual([ownedKey, ownedKey]);
+    expect(outcome).toEqual({ status: "completed" });
+    expectLogExcludes(logger.warn, "did not create it");
   });
 
   // Regression: unscoped narrative session keys cannot be resolved to a per-agent SQLite
@@ -456,7 +488,7 @@ describe("runDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const sessionSuffix = `dreaming-narrative-rem-${workspaceHash}`;
+    const sessionSuffix = `dreaming-narrative-memory-core-v2-rem-${workspaceHash}`;
 
     await runDreamNarrative({
       agentId: "researcher",
@@ -518,11 +550,11 @@ describe("runDreamNarrative", () => {
 
       expect(subagent.getSessionMessages).toHaveBeenCalledTimes(2);
       expect(subagent.getSessionMessages).toHaveBeenNthCalledWith(1, {
-        sessionKey: expect.stringContaining("dreaming-narrative-light-"),
+        sessionKey: expect.stringContaining("dreaming-narrative-memory-core-v2-light-"),
         limit: expect.any(Number),
       });
       expect(subagent.getSessionMessages).toHaveBeenNthCalledWith(2, {
-        sessionKey: expect.stringContaining("dreaming-narrative-light-"),
+        sessionKey: expect.stringContaining("dreaming-narrative-memory-core-v2-light-"),
         limit: expect.any(Number),
       });
       const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
@@ -573,7 +605,7 @@ describe("runDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `agent:main:dreaming-narrative-light-${workspaceHash}`;
+    const expectedSessionKey = `agent:main:dreaming-narrative-memory-core-v2-light-${workspaceHash}`;
     const retrySessionKey = `${expectedSessionKey}-retry-1`;
 
     await runDreamNarrative({
@@ -626,7 +658,7 @@ describe("runDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `agent:main:dreaming-narrative-rem-${workspaceHash}`;
+    const expectedSessionKey = `agent:main:dreaming-narrative-memory-core-v2-rem-${workspaceHash}`;
     const retrySessionKey = `${expectedSessionKey}-retry-1`;
 
     await runDreamNarrative({
@@ -773,7 +805,7 @@ describe("runDreamNarrative", () => {
     subagent.deleteSession.mockRejectedValue(new Error("still active"));
     const logger = createMockLogger();
 
-    await runDreamNarrative({
+    const outcome = await runDreamNarrative({
       agentId: "main",
       subagent,
       workspaceDir,
@@ -784,6 +816,7 @@ describe("runDreamNarrative", () => {
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
     expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(60_000);
     expectLogIncludes(logger.warn, "narrative session cleanup failed for rem phase");
+    expect(outcome).toEqual({ status: "degraded", error: "still active" });
   });
 
   it("handles subagent error gracefully", async () => {
@@ -1120,8 +1153,8 @@ describe("runDreamNarrative", () => {
     expect(firstSessionKey).toBeTypeOf("string");
     expect(secondSessionKey).toBeTypeOf("string");
     expect(firstSessionKey).not.toBe(secondSessionKey);
-    expect(firstSessionKey).toContain("dreaming-narrative-light-");
-    expect(secondSessionKey).toContain("dreaming-narrative-light-");
+    expect(firstSessionKey).toContain("dreaming-narrative-memory-core-v2-light-");
+    expect(secondSessionKey).toContain("dreaming-narrative-memory-core-v2-light-");
     const deleteKeys = subagent.deleteSession.mock.calls.map(
       (call: unknown[]) => (call[0] as { sessionKey: string })?.sessionKey,
     );

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -103,6 +103,7 @@ const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
 // is visible, so retry briefly before falling back to synthetic diary text.
 const NARRATIVE_MESSAGE_SETTLE_DELAYS_MS = [50, 150, 300, 750] as const;
 const DREAMING_SESSION_KEY_PREFIX = "dreaming-narrative-";
+const DREAMING_SESSION_OWNER_KEY = "memory-core-v2";
 const DREAMING_TRANSCRIPT_RUN_MARKER = '"runId":"dreaming-narrative-';
 const DREAMING_ORPHAN_MIN_AGE_MS = 300_000;
 const DIARY_START_MARKER = "<!-- openclaw:dreaming:diary:start -->";
@@ -299,7 +300,9 @@ function buildNarrativeSessionKey(params: {
   phase: NarrativePhaseData["phase"];
 }): string {
   const workspaceHash = buildNarrativeWorkspaceHash(params.workspaceDir);
-  return `agent:${params.agentId}:${DREAMING_SESSION_KEY_PREFIX}${params.phase}-${workspaceHash}`;
+  // Keep the plugin owner in the stable key so rows created before plugin ownership was
+  // persisted cannot be reused by a memory-core run that is then forbidden to delete them.
+  return `agent:${params.agentId}:${DREAMING_SESSION_KEY_PREFIX}${DREAMING_SESSION_OWNER_KEY}-${params.phase}-${workspaceHash}`;
 }
 
 // ── Prompt building ────────────────────────────────────────────────────
@@ -864,7 +867,13 @@ export type DreamNarrativeRequest = {
   logger: Logger;
 };
 
-async function generateAndAppendDreamNarrative(params: DreamNarrativeRequest): Promise<void> {
+export type DreamNarrativeOutcome =
+  | { status: "completed" | "pending" | "skipped" }
+  | { status: "degraded"; error: string };
+
+async function generateAndAppendDreamNarrative(
+  params: DreamNarrativeRequest,
+): Promise<DreamNarrativeOutcome> {
   // `runDreamNarrative` is the only entry point and already dropped empty narrative data.
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
   const runKey = buildNarrativeRunKey({
@@ -878,6 +887,7 @@ async function generateAndAppendDreamNarrative(params: DreamNarrativeRequest): P
     phase: params.data.phase,
   });
   const message = buildNarrativePrompt(params.data);
+  let cleanupFailure: string | undefined;
   await withNarrativeSessionLock(sessionKey, async () => {
     const attempts: Array<{ sessionKey: string; runId: string | null }> = [];
     let successfulSessionKey: string | null = null;
@@ -896,8 +906,9 @@ async function generateAndAppendDreamNarrative(params: DreamNarrativeRequest): P
             await params.subagent.deleteSession({ sessionKey: attemptSessionKey });
           } catch (preCleanupErr) {
             if (!isRequestScopedSubagentRuntimeError(preCleanupErr)) {
+              cleanupFailure = formatErrorMessage(preCleanupErr);
               params.logger.warn(
-                `memory-core: narrative pre-cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(preCleanupErr)}`,
+                `memory-core: narrative pre-cleanup failed for ${params.data.phase} phase: ${cleanupFailure}`,
               );
             }
           }
@@ -1032,19 +1043,22 @@ async function generateAndAppendDreamNarrative(params: DreamNarrativeRequest): P
         try {
           await params.subagent.deleteSession({ sessionKey: attempt.sessionKey });
         } catch (cleanupErr) {
+          cleanupFailure = formatErrorMessage(cleanupErr);
           params.logger.warn(
-            `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(cleanupErr)}`,
+            `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${cleanupFailure}`,
           );
         }
       }
 
       await scrubDreamingNarrativeArtifacts(params.logger).catch((scrubErr: unknown) => {
+        cleanupFailure = formatErrorMessage(scrubErr);
         params.logger.warn(
-          `memory-core: dreaming cleanup scrub failed for ${params.data.phase} phase: ${formatErrorMessage(scrubErr)}`,
+          `memory-core: dreaming cleanup scrub failed for ${params.data.phase} phase: ${cleanupFailure}`,
         );
       });
     }
   });
+  return cleanupFailure ? { status: "degraded", error: cleanupFailure } : { status: "completed" };
 }
 
 // ── Detached narrative concurrency limit ───────────────────────────────
@@ -1060,13 +1074,24 @@ async function generateAndAppendDreamNarrative(params: DreamNarrativeRequest): P
 const DETACHED_NARRATIVE_CONCURRENCY = 3;
 const detachedNarrativeLimit = pLimit(DETACHED_NARRATIVE_CONCURRENCY);
 
-function runDetachedNarrativeJob(job: () => Promise<void>): void {
+function runDetachedNarrativeJob(params: {
+  job: () => Promise<DreamNarrativeOutcome>;
+  logger: Logger;
+  phase: NarrativePhaseData["phase"];
+  workspaceDir: string;
+}): void {
   queueMicrotask(() => {
-    void detachedNarrativeLimit(job).catch(() => {
-      // Detached narratives intentionally swallow errors — callers (cron
-      // sweeps) cannot recover, and surfacing here would only cause noisy
-      // unhandled rejections. Logging happens inside the job itself.
-    });
+    void detachedNarrativeLimit(params.job)
+      .then((outcome) => {
+        if (outcome.status === "degraded") {
+          params.logger.warn(
+            `memory-core: detached dreaming narrative degraded for ${params.phase} phase [workspace=${params.workspaceDir}]: ${outcome.error}`,
+          );
+        }
+      })
+      .catch(() => {
+        // Unexpected failures are logged by the narrative job before reaching this boundary.
+      });
   });
 }
 
@@ -1077,28 +1102,35 @@ function runDetachedNarrativeJob(job: () => Promise<void>): void {
  */
 export async function runDreamNarrative(
   params: Omit<DreamNarrativeRequest, "agentId"> & { agentId?: string; detached?: boolean },
-): Promise<void> {
+): Promise<DreamNarrativeOutcome> {
   const { agentId, detached, ...rest } = params;
   // Nothing to narrate is a no-op on every path; checking ownership first would let an
   // ownerless empty sweep append a diary entry for material that never existed.
   if (rest.data.snippets.length === 0 && !rest.data.promotions?.length) {
-    return;
+    return { status: "skipped" };
   }
   // Narrative sessions are stored per agent, so an ownerless sweep cannot start one.
   // Write the local diary fallback instead of skipping the entry without a trace, and
   // keep it on the same dispatch so a detached cron sweep never awaits a diary write.
   const job = agentId
     ? () => generateAndAppendDreamNarrative({ ...rest, agentId })
-    : () =>
-        appendFallbackNarrativeEntry({
+    : async () => {
+        await appendFallbackNarrativeEntry({
           ...rest,
           nowMs: Number.isFinite(rest.nowMs) ? (rest.nowMs as number) : Date.now(),
           reason: "the dreaming sweep has no owning agent id",
         });
+        return { status: "completed" as const };
+      };
   if (detached) {
-    runDetachedNarrativeJob(job);
-    return;
+    runDetachedNarrativeJob({
+      job,
+      logger: rest.logger,
+      phase: rest.data.phase,
+      workspaceDir: rest.workspaceDir,
+    });
+    return { status: "pending" };
   }
-  await job();
+  return await job();
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -507,7 +507,7 @@ describe("memory-core dreaming phases", () => {
     };
     const nowMs = Date.parse("2026-04-05T10:05:00.000Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `agent:main:dreaming-narrative-light-${workspaceHash}`;
+    const expectedSessionKey = `agent:main:dreaming-narrative-memory-core-v2-light-${workspaceHash}`;
 
     await runDreamingSweepPhases({
       agentId: "main",
@@ -586,7 +586,7 @@ describe("memory-core dreaming phases", () => {
         subagent,
         nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ degradedPhases: 0, pendingNarratives: 0 });
 
     const dreams = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(dreams).toContain("A memory trace surfaced, but details were unavailable in this run.");

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -10,6 +10,7 @@ import {
   listSessionTranscriptCorpusEntriesForAgent,
   parseUsageCountedSessionIdFromFileName,
   sessionPathForFile,
+  statSessionEntrySync,
 } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
@@ -35,6 +36,7 @@ import {
 import { writeDailyDreamingPhaseBlock } from "./dreaming-markdown.js";
 import {
   type DreamNarrativeRequest,
+  type DreamNarrativeOutcome,
   readRecentDreamDiaryEntries,
   type NarrativePhaseData,
   runDreamNarrative,
@@ -873,6 +875,41 @@ async function collectSessionIngestionBatches(params: {
     let fingerprint: { mtimeMs: number; size: number };
     let entry: Awaited<ReturnType<typeof buildSessionEntry>>;
     if (file.transcriptSource === "sqlite") {
+      const sqliteIdentity = file.storePath
+        ? {
+            agentId: file.agentId,
+            sessionId: file.sessionId,
+            storePath: file.storePath,
+            ...(file.updatedAtMs !== undefined ? { updatedAtMs: file.updatedAtMs } : {}),
+          }
+        : undefined;
+      let fileState: ReturnType<typeof statSessionEntrySync> = null;
+      if (sqliteIdentity) {
+        try {
+          fileState = statSessionEntrySync(file.absolutePath, sqliteIdentity);
+        } catch {
+          // Stats only avoid a full unchanged transcript read. A racing or unavailable
+          // store remains the tolerant builder's responsibility below.
+        }
+      }
+      if (fileState) {
+        fingerprint = {
+          mtimeMs: Math.floor(Math.max(0, fileState.mtimeMs)),
+          size: Math.floor(Math.max(0, fileState.size)),
+        };
+        const cursorAtEnd =
+          previous !== undefined && previous.lastContentLine >= previous.lineCount;
+        const unchanged =
+          previous !== undefined &&
+          previous.mtimeMs === fingerprint.mtimeMs &&
+          previous.size === fingerprint.size &&
+          previous.contentHash.length > 0 &&
+          cursorAtEnd;
+        if (unchanged) {
+          nextFiles[stateKey] = previous;
+          continue;
+        }
+      }
       entry = await buildSessionEntry(file.absolutePath, {
         generatedByDreamingNarrative: file.generatedByDreamingNarrative,
         generatedByCronRun: file.generatedByCronRun,
@@ -1770,7 +1807,7 @@ async function runLightDreaming(params: {
   subagent?: DreamNarrativeRequest["subagent"];
   detachNarratives?: boolean;
   nowMs?: number;
-}): Promise<void> {
+}): Promise<DreamNarrativeOutcome> {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
   await ingestDailyMemorySignals({
     workspaceDir: params.workspaceDir,
@@ -1845,7 +1882,7 @@ async function runLightDreaming(params: {
       ...(themes.length > 0 ? { themes } : {}),
       ...(recentDiaryEntries.length > 0 ? { recentDiaryEntries } : {}),
     };
-    await runDreamNarrative({
+    return await runDreamNarrative({
       agentId: params.agentId,
       subagent: params.subagent,
       workspaceDir: params.workspaceDir,
@@ -1857,6 +1894,7 @@ async function runLightDreaming(params: {
       detached: params.detachNarratives,
     });
   }
+  return { status: "skipped" };
 }
 
 async function runRemDreaming(params: {
@@ -1869,7 +1907,7 @@ async function runRemDreaming(params: {
   subagent?: DreamNarrativeRequest["subagent"];
   detachNarratives?: boolean;
   nowMs?: number;
-}): Promise<void> {
+}): Promise<DreamNarrativeOutcome> {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
   await ingestDailyMemorySignals({
     workspaceDir: params.workspaceDir,
@@ -1951,7 +1989,7 @@ async function runRemDreaming(params: {
               .filter(Boolean),
       ...(themes.length > 0 ? { themes } : {}),
     };
-    await runDreamNarrative({
+    return await runDreamNarrative({
       agentId: params.agentId,
       subagent: params.subagent,
       workspaceDir: params.workspaceDir,
@@ -1963,7 +2001,13 @@ async function runRemDreaming(params: {
       detached: params.detachNarratives,
     });
   }
+  return { status: "skipped" };
 }
+
+export type DreamingSweepPhaseResult = {
+  degradedPhases: number;
+  pendingNarratives: number;
+};
 
 export async function runDreamingSweepPhases(params: {
   /**
@@ -1979,9 +2023,18 @@ export async function runDreamingSweepPhases(params: {
   subagent?: DreamNarrativeRequest["subagent"];
   detachNarratives?: boolean;
   nowMs?: number;
-}): Promise<void> {
+}): Promise<DreamingSweepPhaseResult> {
   // Normalize nowMs once so all phase timestamps and narrative session keys are consistent.
   const sweepNowMs: number = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
+  let degradedPhases = 0;
+  let pendingNarratives = 0;
+  const recordNarrativeOutcome = (outcome: DreamNarrativeOutcome): void => {
+    if (outcome.status === "degraded") {
+      degradedPhases += 1;
+    } else if (outcome.status === "pending") {
+      pendingNarratives += 1;
+    }
+  };
 
   const light = resolveMemoryLightDreamingConfig({
     pluginConfig: params.pluginConfig,
@@ -1989,16 +2042,18 @@ export async function runDreamingSweepPhases(params: {
   });
   if (light.enabled && light.limit > 0) {
     try {
-      await runLightDreaming({
-        agentId: params.agentId,
-        workspaceDir: params.workspaceDir,
-        cfg: params.cfg,
-        config: light,
-        logger: params.logger,
-        subagent: params.subagent,
-        nowMs: sweepNowMs,
-        detachNarratives: params.detachNarratives,
-      });
+      recordNarrativeOutcome(
+        await runLightDreaming({
+          agentId: params.agentId,
+          workspaceDir: params.workspaceDir,
+          cfg: params.cfg,
+          config: light,
+          logger: params.logger,
+          subagent: params.subagent,
+          nowMs: sweepNowMs,
+          detachNarratives: params.detachNarratives,
+        }),
+      );
     } catch (err) {
       await appendFailedDreamingEvent({
         workspaceDir: params.workspaceDir,
@@ -2018,16 +2073,18 @@ export async function runDreamingSweepPhases(params: {
   });
   if (rem.enabled && rem.limit > 0) {
     try {
-      await runRemDreaming({
-        agentId: params.agentId,
-        workspaceDir: params.workspaceDir,
-        cfg: params.cfg,
-        config: rem,
-        logger: params.logger,
-        subagent: params.subagent,
-        nowMs: sweepNowMs,
-        detachNarratives: params.detachNarratives,
-      });
+      recordNarrativeOutcome(
+        await runRemDreaming({
+          agentId: params.agentId,
+          workspaceDir: params.workspaceDir,
+          cfg: params.cfg,
+          config: rem,
+          logger: params.logger,
+          subagent: params.subagent,
+          nowMs: sweepNowMs,
+          detachNarratives: params.detachNarratives,
+        }),
+      );
     } catch (err) {
       await appendFailedDreamingEvent({
         workspaceDir: params.workspaceDir,
@@ -2040,6 +2097,7 @@ export async function runDreamingSweepPhases(params: {
       throw err;
     }
   }
+  return { degradedPhases, pendingNarratives };
 }
 
 // Session backfill is a batch driver over the live-ingestion primitives. Keep

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -2004,7 +2004,7 @@ async function runRemDreaming(params: {
   return { status: "skipped" };
 }
 
-export type DreamingSweepPhaseResult = {
+type DreamingSweepPhaseResult = {
   degradedPhases: number;
   pendingNarratives: number;
 };

--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -27,7 +27,10 @@ import { createMemoryCoreTestHarness } from "./test-helpers.js";
 
 // `runDreamingSweepPhases` is the only binding the dreaming trigger imports from this module.
 const runDreamingSweepPhasesMock = vi.hoisted(() =>
-  vi.fn(async (_params: { agentId?: string; workspaceDir: string }) => {}),
+  vi.fn(async (_params: { agentId?: string; workspaceDir: string }) => ({
+    degradedPhases: 0,
+    pendingNarratives: 0,
+  })),
 );
 vi.mock("./dreaming-phases.js", () => ({
   runDreamingSweepPhases: runDreamingSweepPhasesMock,
@@ -64,6 +67,7 @@ type CronPayload =
   | { kind: "systemEvent"; text: string }
   | { kind: "agentTurn"; message: string; lightContext?: boolean };
 type CronAddInput = {
+  declarationKey: string;
   name: string;
   description: string;
   enabled: boolean;
@@ -76,6 +80,7 @@ type CronAddInput = {
 type CronPatch = Partial<CronAddInput>;
 type CronJobLike = {
   id: string;
+  declarationKey?: string;
   name?: string;
   description?: string;
   enabled?: boolean;
@@ -123,6 +128,7 @@ function createCronHarness(
   const addCalls: CronAddInput[] = [];
   const updateCalls: Array<{ id: string; patch: CronPatch }> = [];
   const removeCalls: string[] = [];
+  const mutationCalls: string[] = [];
 
   const cron: CronParam = {
     async list() {
@@ -138,9 +144,11 @@ function createCronHarness(
       }));
     },
     async add(input) {
+      mutationCalls.push("add");
       addCalls.push(input);
       jobs.push({
         id: `job-${jobs.length + 1}`,
+        declarationKey: input.declarationKey,
         name: input.name,
         description: input.description,
         enabled: input.enabled,
@@ -154,6 +162,7 @@ function createCronHarness(
       return {};
     },
     async update(id, patch) {
+      mutationCalls.push(`update:${id}`);
       updateCalls.push({ id, patch });
       const index = jobs.findIndex((entry) => entry.id === id);
       if (index < 0) {
@@ -174,6 +183,7 @@ function createCronHarness(
       return {};
     },
     async remove(id) {
+      mutationCalls.push(`remove:${id}`);
       removeCalls.push(id);
       if (opts?.removeThrowsForIds?.includes(id)) {
         throw new Error(`remove failed for ${id}`);
@@ -195,6 +205,7 @@ function createCronHarness(
     addCalls,
     updateCalls,
     removeCalls,
+    mutationCalls,
     get listCalls() {
       return listCalls;
     },
@@ -684,6 +695,7 @@ describe("gateway startup reconciliation", () => {
 
       expect(harness.addCalls).toHaveLength(1);
       const addCall = requireAddCall(harness, 0);
+      expect(addCall.declarationKey).toBe("memory-core:memory-dreaming-promotion");
       expectCronSchedule(addCall.schedule, "15 4 * * *", "UTC");
       expect(addCall.delivery?.mode).toBe("none");
       expectLogContains(logger.info, "created managed dreaming cron job");
@@ -1028,6 +1040,111 @@ describe("gateway startup reconciliation", () => {
         "America/Los_Angeles",
       );
     } finally {
+      clearInternalHooks();
+    }
+  });
+
+  it("updates a seeded old-schedule managed job in place by its stable name", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const harness = createCronHarness([
+      {
+        id: "job-old-schedule",
+        name: constants.MANAGED_DREAMING_CRON_NAME,
+        description: `${constants.MANAGED_DREAMING_CRON_TAG} legacy managed dreaming job`,
+        enabled: true,
+        schedule: { kind: "cron", expr: "0 3 * * *" },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: { kind: "agentTurn", message: "legacy-dreaming-payload" },
+        delivery: { mode: "none" },
+        createdAtMs: 10,
+      },
+    ]);
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: { dreaming: { enabled: true, frequency: "*/3 * * * *" } },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerGatewayStart(onMock, { config: api.config, getCron: () => harness.cron });
+
+      expect(harness.addCalls).toHaveLength(1);
+      expect(harness.removeCalls).toEqual(["job-old-schedule"]);
+      expect(harness.mutationCalls).toEqual(["add", "remove:job-old-schedule"]);
+      expect(harness.updateCalls).toHaveLength(0);
+      expect(requireAddCall(harness, 0).declarationKey).toBe(
+        "memory-core:memory-dreaming-promotion",
+      );
+      expectCronSchedule(requireAddCall(harness, 0).schedule, "*/3 * * * *");
+      expect(harness.jobs).toHaveLength(1);
+    } finally {
+      await triggerGatewayStop(onMock).catch(() => undefined);
+      clearInternalHooks();
+    }
+  });
+
+  it("removes seeded stale managed duplicates before reconciling the survivor", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const seeded = (id: string, createdAtMs: number, expr: string): CronJobLike => ({
+      id,
+      name: constants.MANAGED_DREAMING_CRON_NAME,
+      description: `${constants.MANAGED_DREAMING_CRON_TAG} legacy managed dreaming job`,
+      enabled: true,
+      schedule: { kind: "cron", expr },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "legacy-dreaming-payload" },
+      delivery: { mode: "none" },
+      createdAtMs,
+    });
+    const harness = createCronHarness([
+      seeded("job-oldest", 10, "0 3 * * *"),
+      seeded("job-duplicate", 20, "*/5 * * * *"),
+    ]);
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: { dreaming: { enabled: true, frequency: "*/3 * * * *" } },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerGatewayStart(onMock, { config: api.config, getCron: () => harness.cron });
+
+      expect(harness.addCalls).toHaveLength(1);
+      expect(harness.removeCalls).toEqual(["job-oldest", "job-duplicate"]);
+      expect(harness.updateCalls).toHaveLength(0);
+      expectCronSchedule(requireAddCall(harness, 0).schedule, "*/3 * * * *");
+      expect(harness.jobs).toHaveLength(1);
+      expect(harness.jobs[0]?.declarationKey).toBe("memory-core:memory-dreaming-promotion");
+    } finally {
+      await triggerGatewayStop(onMock).catch(() => undefined);
       clearInternalHooks();
     }
   });
@@ -1605,7 +1722,8 @@ describe("gateway startup reconciliation", () => {
     const logger = createLogger();
     const managedJob: CronJobLike = {
       id: "job-managed",
-      name: constants.MANAGED_DREAMING_CRON_NAME,
+      declarationKey: "memory-core:memory-dreaming-promotion",
+      name: "Historical Dreaming Promotion Name",
       description: `${constants.MANAGED_DREAMING_CRON_TAG} test`,
       enabled: true,
       schedule: { kind: "cron", expr: "0 3 * * *" },
@@ -2104,6 +2222,57 @@ describe("gateway startup reconciliation", () => {
       )[0];
       expect(sweepArgs.agentId).toBe("researcher");
       expect(sweepArgs.workspaceDir).toBe(workspaceDir);
+    } finally {
+      clearInternalHooks();
+    }
+  });
+
+  it("reports a degraded sweep when narrative cleanup fails", async () => {
+    clearInternalHooks();
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-cleanup-degraded-");
+    const logger = createLogger();
+    const harness = createCronHarness();
+    const onMock = vi.fn();
+    runDreamingSweepPhasesMock.mockResolvedValueOnce({
+      degradedPhases: 1,
+      pendingNarratives: 0,
+    });
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        agents: { defaults: { workspace: workspaceDir } },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  limit: 1,
+                  phases: { light: { enabled: false }, rem: { enabled: false } },
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerGatewayStart(onMock, { config: api.config, getCron: () => harness.cron });
+      const result = await getBeforeAgentReplyHandler(onMock)(
+        { cleanedBody: constants.DREAMING_SYSTEM_EVENT_TEXT },
+        { trigger: "cron", agentId: "main", workspaceDir },
+      );
+
+      expect(result).toEqual({
+        handled: true,
+        reason: "memory-core: short-term dreaming degraded",
+      });
+      expectLogContains(logger.warn, "failed=0, degraded=1, narrativesPending=0");
     } finally {
       clearInternalHooks();
     }

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -35,6 +35,7 @@ const RUNTIME_CRON_RECONCILE_INTERVAL_MS = 60_000;
 const STARTUP_CRON_RETRY_DELAY_MS = 5_000;
 const STARTUP_CRON_RETRY_MAX_ATTEMPTS = 12;
 const HEARTBEAT_ISOLATED_SESSION_SUFFIX = ":heartbeat";
+const MANAGED_DREAMING_DECLARATION_KEY = "memory-core:memory-dreaming-promotion";
 
 type Logger = Pick<OpenClawPluginApi["logger"], "info" | "warn" | "error">;
 
@@ -43,6 +44,7 @@ type CronPayload =
   | { kind: "systemEvent"; text: string }
   | { kind: "agentTurn"; message: string; lightContext?: boolean };
 type ManagedCronJobCreate = {
+  declarationKey: string;
   name: string;
   description: string;
   enabled: boolean;
@@ -70,6 +72,7 @@ type ManagedCronJobPatch = {
 
 type ManagedCronJobLike = {
   id: string;
+  declarationKey?: string;
   name?: string;
   description?: string;
   enabled?: boolean;
@@ -167,6 +170,7 @@ function buildManagedDreamingCronJob(
   config: ShortTermPromotionDreamingConfig,
 ): ManagedCronJobCreate {
   return {
+    declarationKey: MANAGED_DREAMING_DECLARATION_KEY,
     name: MANAGED_DREAMING_CRON_NAME,
     description: resolveManagedCronDescription(config),
     enabled: true,
@@ -203,13 +207,18 @@ function resolveManagedDreamingPayloadToken(
 }
 
 function isManagedDreamingJob(job: ManagedCronJobLike): boolean {
+  if (normalizeTrimmedString(job.declarationKey) === MANAGED_DREAMING_DECLARATION_KEY) {
+    return true;
+  }
+  const name = normalizeTrimmedString(job.name);
+  if (name !== MANAGED_DREAMING_CRON_NAME) {
+    return false;
+  }
   const description = normalizeTrimmedString(job.description);
   if (description?.includes(MANAGED_DREAMING_CRON_TAG)) {
     return true;
   }
-  const name = normalizeTrimmedString(job.name);
-  const payloadToken = resolveManagedDreamingPayloadToken(job.payload);
-  return name === MANAGED_DREAMING_CRON_NAME && payloadToken === DREAMING_SYSTEM_EVENT_TEXT;
+  return resolveManagedDreamingPayloadToken(job.payload) === DREAMING_SYSTEM_EVENT_TEXT;
 }
 
 function isLegacyPhaseDreamingJob(job: ManagedCronJobLike): boolean {
@@ -463,7 +472,30 @@ async function reconcileShortTermDreamingCronJob(params: {
     return { status: "added", removed: migratedLegacy };
   }
 
-  const [primary, ...duplicates] = sortManagedJobs(managed);
+  if (!managed.some((job) => job.declarationKey === MANAGED_DREAMING_DECLARATION_KEY)) {
+    await cron.add(desired);
+    let removed = await migrateLegacyPhaseDreamingCronJobs({
+      cron,
+      legacyJobs: legacyPhaseJobs,
+      logger: params.logger,
+      mode: "enabled",
+    });
+    for (const job of managed) {
+      const result = await cron.remove(job.id);
+      if (result.removed !== true) {
+        throw new Error(`failed to replace legacy managed dreaming cron job ${job.id}`);
+      }
+      removed += 1;
+    }
+    params.logger.info("memory-core: replaced legacy managed dreaming cron job identity.");
+    return { status: "added", removed };
+  }
+
+  const primary = expectDefined(
+    managed.find((job) => job.declarationKey === MANAGED_DREAMING_DECLARATION_KEY),
+    "declaration-keyed managed dreaming job",
+  );
+  const duplicates = sortManagedJobs(managed.filter((job) => job.id !== primary.id));
   let removed = await migrateLegacyPhaseDreamingCronJobs({
     cron,
     legacyJobs: legacyPhaseJobs,
@@ -483,8 +515,7 @@ async function reconcileShortTermDreamingCronJob(params: {
     }
   }
 
-  const managedPrimary = expectDefined(primary, "non-empty managed dreaming jobs");
-  const patch = buildManagedDreamingPatch(managedPrimary, desired);
+  const patch = buildManagedDreamingPatch(primary, desired);
   if (!patch) {
     if (removed > 0) {
       params.logger.info("memory-core: pruned duplicate managed dreaming cron jobs.");
@@ -492,7 +523,7 @@ async function reconcileShortTermDreamingCronJob(params: {
     return { status: "noop", removed };
   }
 
-  await cron.update(managedPrimary.id, patch);
+  await cron.update(primary.id, patch);
   params.logger.info("memory-core: updated managed dreaming cron job.");
   return { status: "updated", removed };
 }
@@ -574,6 +605,8 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
   let totalCandidates = 0;
   let totalApplied = 0;
   let failedWorkspaces = 0;
+  let degradedNarratives = 0;
+  let pendingNarratives = 0;
   const pluginConfig = params.cfg ? resolveMemoryDreamingPluginConfig(params.cfg) : undefined;
   const detachNarratives = params.trigger === "cron";
   const [
@@ -594,7 +627,7 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
   for (const { agentId, workspaceDir } of workspaces) {
     const sweepNowMs = Date.now();
     try {
-      await runDreamingSweepPhases({
+      const phaseResult = await runDreamingSweepPhases({
         agentId,
         workspaceDir,
         pluginConfig,
@@ -604,6 +637,8 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
         detachNarratives,
         nowMs: sweepNowMs,
       });
+      degradedNarratives += phaseResult?.degradedPhases ?? 0;
+      pendingNarratives += phaseResult?.pendingNarratives ?? 0;
     } catch (err) {
       failedWorkspaces += 1;
       params.logger.error(
@@ -705,7 +740,7 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
             reason: "subagent runtime is unavailable",
           });
         } else {
-          await runDreamNarrative({
+          const narrativeOutcome = await runDreamNarrative({
             agentId,
             subagent: params.subagent,
             workspaceDir,
@@ -716,6 +751,11 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
             logger: params.logger,
             detached: detachNarratives,
           });
+          if (narrativeOutcome.status === "degraded") {
+            degradedNarratives += 1;
+          } else if (narrativeOutcome.status === "pending") {
+            pendingNarratives += 1;
+          }
         }
       }
     } catch (err) {
@@ -736,14 +776,20 @@ async function runShortTermDreamingPromotionIfTriggered(params: {
   }
   // A summary that reads identically whether the sweep worked or failed everywhere is how
   // a broken pipeline stays unnoticed; escalate when no workspace produced anything.
-  const summary = `memory-core: dreaming promotion complete (workspaces=${workspaces.length}, candidates=${totalCandidates}, applied=${totalApplied}, failed=${failedWorkspaces}).`;
-  if (failedWorkspaces === workspaces.length) {
+  const summary = `memory-core: dreaming promotion complete (workspaces=${workspaces.length}, candidates=${totalCandidates}, applied=${totalApplied}, failed=${failedWorkspaces}, degraded=${degradedNarratives}, narrativesPending=${pendingNarratives}).`;
+  if (failedWorkspaces === workspaces.length || degradedNarratives > 0) {
     params.logger.warn(summary);
   } else {
     params.logger.info(summary);
   }
 
-  return { handled: true, reason: "memory-core: short-term dreaming processed" };
+  return {
+    handled: true,
+    reason:
+      degradedNarratives > 0
+        ? "memory-core: short-term dreaming degraded"
+        : "memory-core: short-term dreaming processed",
+  };
 }
 
 export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void {


### PR DESCRIPTION
## What Problem This Solves

Memory-core dreaming could leave two managed promotion schedules active after a cadence change, reuse a legacy narrative session that the plugin was not allowed to delete, and repeatedly materialize unchanged SQLite transcripts during light and REM sweeps. Cleanup failures were logged but the sweep still returned a normal processed result.

## Why This Change Was Made

The managed cron now has one declaration key owned by memory-core. Legacy tagged/token jobs are migrated by creating the declaration-keyed replacement first and pruning stale jobs only after creation succeeds; later cadence changes converge that same job in place.

Narrative sessions now use a memory-core-owned stable key namespace, avoiding collisions with legacy unowned rows. Narrative cleanup returns an explicit completed, pending, or degraded lifecycle outcome; synchronous cleanup degradation reaches the sweep result, while detached cron narratives are reported as pending and log an explicit degraded outcome if their cleanup later fails.

SQLite session ingestion now compares cheap transcript stats with the completed checkpoint before serializing transcript events. A stats failure remains a cache miss and falls through to the existing tolerant builder.

## User Impact

Operators get one managed dreaming schedule after upgrades or frequency changes. Narrative cleanup ownership failures are no longer hidden behind a successful-looking sweep, and repeated unchanged sweeps retain less heap/RSS by skipping whole-transcript reconstruction.

## Evidence

- Focused exact-head tests: `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming.test.ts extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/dreaming-narrative.test.ts` — 125 passed.
- Exact-head changed gate: `node scripts/check-changed.mjs -- <six touched files>` on Blacksmith Testbox — exit 0; extension production/test typechecks, lint (0 warnings/errors), dead exports, plugin boundaries, database-first guard, and import cycles passed.
- Repeated-sweep copied-corpus measurement (3 workspaces, forced GC, isolated process): retained heap growth fell from 20.7 MB to 17.8 MB; RSS growth fell from 42.5 MB to 35.8 MB; peak RSS fell from 446.2 MB to 438.1 MB. This proves the checkpoint fast path reduces the confirmed repeated transcript holder; it does not claim the entire live 1.65 GB gateway footprint is eliminated.
- Autoreview: clean after applying four accepted lifecycle/ordering findings; final structured verdict reported no accepted/actionable findings (0.94 confidence). The one-line dead-export cleanup received a separate clean review (0.99 confidence).

This change is AI-assisted and was reviewed through the repository autoreview workflow.
