### PR TITLE
fix(memory): session backfill drains and rolls back reversibly

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -157,7 +157,7 @@ openclaw memory session-backfill --agent <id> --rollback [--json]
 | `--limit-days <n>`          | `92`         | Process at most this many hash-untracked days, oldest first.                                                  |
 | `--archive-files <path...>` |              | Also inspect foreign transcript files as untrusted input; embedded owner metadata is not accepted.            |
 | `--rem`                     |              | Write deterministic grounded per-day previews to `DREAMS.md` only.                                            |
-| `--apply`                   | preview only | Stage trusted candidates and write reversible `DREAMS.md` diary blocks.                                       |
+| `--apply`                   | preview only | Drain all bounded batches, stage trusted candidates, and write reversible `DREAMS.md` diary blocks.           |
 | `--rollback`                |              | Remove all grounded backfill candidates and shared backfill diary blocks, including `rem-backfill` artifacts. |
 | `--json`                    |              | Print machine-readable per-day counts and top candidates.                                                     |
 
@@ -170,7 +170,11 @@ without trustworthy owner provenance are excluded. Foreign archive files have
 no authenticated owner-provenance contract, so their embedded ownership fields
 remain untrusted and cannot be staged.
 
-`--apply` writes only the session corpus under `memory/.dreams/`, short-term
+`--apply` drains the selected history to completion in one invocation while
+keeping each bounded batch in its own transaction. Human and JSON output report
+per-batch progress plus total batches, candidates, and staged entries. A
+successful apply followed immediately by preview therefore reports zero new
+candidates. It writes only the session corpus under `memory/.dreams/`, short-term
 staging state, and reversible diary entries in `DREAMS.md`. It never writes
 `MEMORY.md` or `USER.md`; durable promotion remains a separate `memory promote`
 or dreaming decision. `--rem` and `--apply` are mutually exclusive.
@@ -178,9 +182,9 @@ or dreaming decision. `--rem` and `--apply` are mutually exclusive.
 Backfill rollback is intentionally shared with `memory rem-backfill`: both
 commands use the same grounded-only staging class and diary markers. Run
 `session-backfill --rollback` only when you intend to clear both commands'
-grounded backfill artifacts from that workspace. Rollback preserves transcript
-ingestion cursors and tracked message hashes, so removed messages are not
-automatically re-ingested.
+grounded backfill artifacts from that workspace. Rollback also removes the
+tracked hashes added by session backfill and rewinds the affected transcript
+cursors, so the same candidates can be previewed and applied again.
 
 ## Dreaming
 

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -123,8 +123,9 @@ There is also a grounded historical backfill lane for review and recovery work:
 Session backfill uses canonical retained transcript identities, including
 sessions preserved across rotation. Messages are bucketed in the configured
 dreaming timezone and share live ingestion's tracked message hashes and signal
-caps, so bounded reruns continue forward without re-ingesting prior messages.
-Rollback removes generated artifacts but retains those ingestion checkpoints.
+caps. Apply drains bounded batches to completion in one command. Rollback
+removes generated artifacts plus the hashes and cursor progress owned by those
+batches, allowing the same candidates to be staged again.
 Foreign files supplied with `--archive-files` are treated conservatively. Their
 embedded ownership fields are caller-controlled and therefore remain untrusted;
 without an authenticated provenance contract, they cannot enter short-term

--- a/extensions/memory-core/src/cli-rem.runtime.ts
+++ b/extensions/memory-core/src/cli-rem.runtime.ts
@@ -86,9 +86,16 @@ export async function runMemorySessionBackfill(
         `${heading("Session Backfill")} ${muted(`(${agentId})`)}`,
         muted(`workspace=${shortenHomePath(workspaceDir)}`),
         muted(
-          `days=${result.days.length} candidates=${result.candidateCount} staged=${result.stagedEntries}`,
+          `batches=${result.batchCount ?? 1} days=${result.days.length} candidates=${result.candidateCount} staged=${result.stagedEntries}`,
         ),
       ];
+      for (const batch of result.batches ?? []) {
+        lines.push(
+          muted(
+            `batch=${batch.batch} days=${batch.days} candidates=${batch.candidates} staged=${batch.stagedEntries}`,
+          ),
+        );
+      }
       for (const day of result.days) {
         lines.push("", heading(day.day), muted(`candidates=${day.candidateCount}`));
         lines.push(...day.topCandidates.map((candidate) => `- ${candidate}`));

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
-import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { resolveSessionTranscriptsDirForAgent as resolveTestSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import {
@@ -43,7 +43,7 @@ async function expectPathMissing(targetPath: string): Promise<void> {
 
 async function seedCliBackfillTranscript(sessionId: string, days: string[]): Promise<void> {
   const agentId = "main";
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+  const sessionsDir = resolveTestSessionTranscriptsDirForAgent(agentId);
   const storePath = path.join(sessionsDir, "sessions.json");
   const sessionKey = `agent:${agentId}:cli-session-backfill:${sessionId}`;
   const entry = { sessionId, updatedAt: Date.parse(`${days.at(-1)}T12:00:00.000Z`) };

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -3,6 +3,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
+import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import {
   firstWrittenJsonArg,
   spyRuntimeErrors,
@@ -36,6 +39,31 @@ async function expectPathMissing(targetPath: string): Promise<void> {
   }
   expect(error).toBeInstanceOf(Error);
   expect((error as NodeJS.ErrnoException).code).toBe("ENOENT");
+}
+
+async function seedCliBackfillTranscript(sessionId: string, days: string[]): Promise<void> {
+  const agentId = "main";
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+  const storePath = path.join(sessionsDir, "sessions.json");
+  const sessionKey = `agent:${agentId}:cli-session-backfill:${sessionId}`;
+  const entry = { sessionId, updatedAt: Date.parse(`${days.at(-1)}T12:00:00.000Z`) };
+  await fs.mkdir(sessionsDir, { recursive: true });
+  await upsertSessionEntry({ agentId, sessionKey, storePath, entry });
+  for (const day of days) {
+    await appendSessionTranscriptMessageByIdentity({
+      agentId,
+      sessionId,
+      sessionKey,
+      storePath,
+      message: {
+        role: "user",
+        content: `CLI lifecycle note for ${day}`,
+        timestamp: `${day}T12:00:00.000Z`,
+        __openclaw: { senderIsOwner: true },
+      },
+    });
+  }
+  await upsertSessionEntry({ agentId, sessionKey, storePath, entry });
 }
 
 vi.mock("./cli.host.runtime.js", async () => {
@@ -119,6 +147,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   process.exitCode = undefined;
   setVerbose(false);
 });
@@ -240,6 +269,40 @@ describe("memory cli", () => {
     registerMemoryCli(program, hostOptions);
     await program.parseAsync(["memory", ...args], { from: "user" });
   }
+
+  it("drains session backfill in one apply command before preview", async () => {
+    const workspaceDir = path.join(workspaceFixtureRoot, `session-backfill-${workspaceCaseId++}`);
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, "state"));
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(workspaceDir, "openclaw.json"));
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await seedCliBackfillTranscript("drain", ["2026-01-01", "2026-01-02", "2026-01-03"]);
+
+    mockManager({ status: () => makeMemoryStatus({ workspaceDir }), close: vi.fn() });
+    const applyJson = spyRuntimeJson(defaultRuntime);
+    await runMemoryCli([
+      "session-backfill",
+      "--agent",
+      "main",
+      "--limit-days",
+      "1",
+      "--apply",
+      "--json",
+    ]);
+    const applied = firstWrittenJsonArg<{
+      batchCount: number;
+      batches: Array<{ candidates: number }>;
+      candidateCount: number;
+    }>(applyJson);
+    expect(applied).toMatchObject({ batchCount: 3, candidateCount: 3 });
+    expect(applied?.batches.map((batch) => batch.candidates)).toEqual([1, 1, 1]);
+
+    mockManager({ status: () => makeMemoryStatus({ workspaceDir }), close: vi.fn() });
+    applyJson.mockClear();
+    await runMemoryCli(["session-backfill", "--agent", "main", "--limit-days", "1", "--json"]);
+    expect(firstWrittenJsonArg<{ candidateCount: number }>(applyJson)).toMatchObject({
+      candidateCount: 0,
+    });
+  });
 
   it("rejects invalid memory search numeric options before running the command", async () => {
     const program = new Command();

--- a/extensions/memory-core/src/dreaming-state.ts
+++ b/extensions/memory-core/src/dreaming-state.ts
@@ -11,6 +11,7 @@ export const DREAMING_DAILY_INGESTION_NAMESPACE = "dreaming-daily-ingestion";
 export const DREAMING_DAILY_PROVENANCE_NAMESPACE = "dreaming-daily-provenance";
 export const DREAMING_SESSION_INGESTION_FILES_NAMESPACE = "dreaming-session-ingestion-files";
 export const DREAMING_SESSION_INGESTION_SEEN_NAMESPACE = "dreaming-session-ingestion-seen";
+export const SESSION_BACKFILL_REWIND_NAMESPACE = "session-backfill-rewind";
 export const DREAMING_MEMORY_BACKUP_NAMESPACE = "dreaming-memory-backups";
 export const SHORT_TERM_RECALL_NAMESPACE = "short-term-recall";
 export const SHORT_TERM_PHASE_SIGNAL_NAMESPACE = "short-term-phase-signals";

--- a/extensions/memory-core/src/session-backfill-contract.ts
+++ b/extensions/memory-core/src/session-backfill-contract.ts
@@ -4,7 +4,7 @@ export type SessionBackfillDay = {
   topCandidates: string[];
 };
 
-export type SessionBackfillBatchProgress = {
+type SessionBackfillBatchProgress = {
   batch: number;
   days: number;
   candidates: number;
@@ -29,7 +29,7 @@ export type SessionBackfillResult = {
   };
 };
 
-export type SessionBackfillContinuation = {
+type SessionBackfillContinuation = {
   advanced: boolean;
   hasMore: boolean;
 };

--- a/extensions/memory-core/src/session-backfill-contract.ts
+++ b/extensions/memory-core/src/session-backfill-contract.ts
@@ -1,0 +1,40 @@
+export type SessionBackfillDay = {
+  day: string;
+  candidateCount: number;
+  topCandidates: string[];
+};
+
+export type SessionBackfillBatchProgress = {
+  batch: number;
+  days: number;
+  candidates: number;
+  stagedEntries: number;
+};
+
+export type SessionBackfillResult = {
+  agentId: string;
+  workspaceDir: string;
+  applied: boolean;
+  rem: boolean;
+  days: SessionBackfillDay[];
+  candidateCount: number;
+  stagedEntries: number;
+  writtenDiaryEntries: number;
+  replacedDiaryEntries: number;
+  batchCount?: number;
+  batches?: SessionBackfillBatchProgress[];
+  rollback?: {
+    removedDiaryEntries: number;
+    removedStagedEntries: number;
+  };
+};
+
+export type SessionBackfillContinuation = {
+  advanced: boolean;
+  hasMore: boolean;
+};
+
+export type SessionBackfillExecution = {
+  result: SessionBackfillResult;
+  continuation: SessionBackfillContinuation;
+};

--- a/extensions/memory-core/src/session-backfill-lifecycle.ts
+++ b/extensions/memory-core/src/session-backfill-lifecycle.ts
@@ -1,0 +1,224 @@
+import { createHash } from "node:crypto";
+import { readSessionIngestionState, writeSessionIngestionState } from "./dreaming-phases.js";
+import {
+  clearMemoryCoreWorkspaceNamespace,
+  readMemoryCoreWorkspaceEntries,
+  SESSION_BACKFILL_REWIND_NAMESPACE,
+  writeMemoryCoreWorkspaceEntry,
+} from "./dreaming-state.js";
+import type { SessionBackfillExecution, SessionBackfillResult } from "./session-backfill.js";
+
+const DEFAULT_SESSION_BACKFILL_LIMIT_DAYS = 92;
+const MEMORY_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+type SessionBackfillRewindCandidate = {
+  contentIndex: number;
+  hash: string;
+  scope: string;
+  stateKey: string;
+};
+
+type SessionBackfillRewindBatch = {
+  version: 1;
+  candidates: SessionBackfillRewindCandidate[];
+};
+
+function normalizeMemoryDay(value: string | undefined, flag: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const day = value.trim();
+  if (!MEMORY_DAY_RE.test(day)) {
+    throw new Error(`${flag} must use YYYY-MM-DD.`);
+  }
+  const parsed = new Date(`${day}T00:00:00.000Z`);
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== day) {
+    throw new Error(`${flag} must be a valid calendar day.`);
+  }
+  return day;
+}
+
+export function normalizeSessionBackfillSelection(
+  params: { from?: string; to?: string; limitDays?: number },
+  labels: { from: string; to: string; limitDays: string } = {
+    from: "--from",
+    to: "--to",
+    limitDays: "--limit-days",
+  },
+): { from?: string; to?: string; limitDays: number } {
+  const from = normalizeMemoryDay(params.from, labels.from);
+  const to = normalizeMemoryDay(params.to, labels.to);
+  if (from !== undefined && to !== undefined && from > to) {
+    throw new Error(`${labels.from} must not be after ${labels.to}.`);
+  }
+  const limitDays = params.limitDays ?? DEFAULT_SESSION_BACKFILL_LIMIT_DAYS;
+  if (!Number.isInteger(limitDays) || limitDays <= 0) {
+    throw new Error(`${labels.limitDays} must be a positive integer.`);
+  }
+  return {
+    ...(from !== undefined ? { from } : {}),
+    ...(to !== undefined ? { to } : {}),
+    limitDays,
+  };
+}
+
+export async function recordSessionBackfillRewindBatch(params: {
+  workspaceDir: string;
+  candidates: SessionBackfillRewindCandidate[];
+}): Promise<void> {
+  if (params.candidates.length === 0) {
+    return;
+  }
+  const key = createHash("sha256").update(JSON.stringify(params.candidates)).digest("hex");
+  await writeMemoryCoreWorkspaceEntry<SessionBackfillRewindBatch>({
+    namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
+    workspaceDir: params.workspaceDir,
+    key,
+    value: { version: 1, candidates: params.candidates },
+  });
+}
+
+function isSessionBackfillRewindCandidate(value: unknown): value is SessionBackfillRewindCandidate {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    Number.isInteger(candidate.contentIndex) &&
+    (candidate.contentIndex as number) >= 0 &&
+    typeof candidate.hash === "string" &&
+    candidate.hash.length > 0 &&
+    typeof candidate.scope === "string" &&
+    candidate.scope.length > 0 &&
+    typeof candidate.stateKey === "string" &&
+    candidate.stateKey.length > 0
+  );
+}
+
+export async function rewindSessionBackfillIngestionState(workspaceDir: string): Promise<void> {
+  const entries = await readMemoryCoreWorkspaceEntries<SessionBackfillRewindBatch>({
+    namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
+    workspaceDir,
+  });
+  const candidates = entries.flatMap((entry) =>
+    entry.value?.version === 1 && Array.isArray(entry.value.candidates)
+      ? entry.value.candidates.filter(isSessionBackfillRewindCandidate)
+      : [],
+  );
+  if (candidates.length === 0) {
+    await clearMemoryCoreWorkspaceNamespace({
+      namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
+      workspaceDir,
+    });
+    return;
+  }
+
+  const state = await readSessionIngestionState(workspaceDir);
+  const removedHashesByScope = new Map<string, Set<string>>();
+  const rewindLineByStateKey = new Map<string, number>();
+  for (const candidate of candidates) {
+    const hashes = removedHashesByScope.get(candidate.scope) ?? new Set<string>();
+    hashes.add(candidate.hash);
+    removedHashesByScope.set(candidate.scope, hashes);
+    rewindLineByStateKey.set(
+      candidate.stateKey,
+      Math.min(
+        rewindLineByStateKey.get(candidate.stateKey) ?? candidate.contentIndex,
+        candidate.contentIndex,
+      ),
+    );
+  }
+
+  const seenMessages = { ...state.seenMessages };
+  for (const [scope, removedHashes] of removedHashesByScope) {
+    const remaining = (seenMessages[scope] ?? []).filter((hash) => !removedHashes.has(hash));
+    if (remaining.length > 0) {
+      seenMessages[scope] = remaining;
+    } else {
+      delete seenMessages[scope];
+    }
+  }
+  const files = { ...state.files };
+  // Rollback intentionally reopens only the journaled backfill range. Every
+  // non-backfill hash stays tracked, so later live-ingestion work remains skipped.
+  for (const [stateKey, lastContentLine] of rewindLineByStateKey) {
+    const current = files[stateKey];
+    if (current) {
+      files[stateKey] = {
+        ...current,
+        lastContentLine: Math.min(current.lastContentLine, lastContentLine),
+      };
+    }
+  }
+  await writeSessionIngestionState(workspaceDir, { ...state, files, seenMessages });
+  await clearMemoryCoreWorkspaceNamespace({
+    namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
+    workspaceDir,
+  });
+}
+
+export async function drainSessionBackfill(params: {
+  executeBatch: () => Promise<SessionBackfillExecution>;
+  maxBatches: number;
+  topCandidateLimit: number;
+}): Promise<SessionBackfillResult> {
+  const batches: SessionBackfillExecution[] = [];
+  for (let batch = 1; batch <= params.maxBatches; batch += 1) {
+    const execution = await params.executeBatch();
+    batches.push(execution);
+    if (!execution.continuation.hasMore) {
+      return aggregateSessionBackfillBatches(batches, params.topCandidateLimit);
+    }
+    if (!execution.continuation.advanced) {
+      throw new Error(
+        `Memory session-backfill stopped after ${batch} batches because the ingestion cursor did not advance.`,
+      );
+    }
+  }
+  throw new Error(`Memory session-backfill exceeded the ${params.maxBatches}-batch safety limit.`);
+}
+
+function aggregateSessionBackfillBatches(
+  executions: SessionBackfillExecution[],
+  topCandidateLimit: number,
+): SessionBackfillResult {
+  const first = executions[0]?.result;
+  if (!first) {
+    throw new Error("Memory session-backfill completed without executing a batch.");
+  }
+  const days = new Map<string, SessionBackfillResult["days"][number]>();
+  for (const execution of executions) {
+    for (const day of execution.result.days) {
+      const current = days.get(day.day);
+      days.set(day.day, {
+        day: day.day,
+        candidateCount: (current?.candidateCount ?? 0) + day.candidateCount,
+        topCandidates: [...(current?.topCandidates ?? []), ...day.topCandidates].slice(
+          0,
+          topCandidateLimit,
+        ),
+      });
+    }
+  }
+  return {
+    ...first,
+    days: [...days.values()].toSorted((a, b) => a.day.localeCompare(b.day)),
+    candidateCount: executions.reduce((sum, execution) => sum + execution.result.candidateCount, 0),
+    stagedEntries: executions.reduce((sum, execution) => sum + execution.result.stagedEntries, 0),
+    writtenDiaryEntries: executions.reduce(
+      (sum, execution) => sum + execution.result.writtenDiaryEntries,
+      0,
+    ),
+    replacedDiaryEntries: executions.reduce(
+      (sum, execution) => sum + execution.result.replacedDiaryEntries,
+      0,
+    ),
+    batchCount: executions.length,
+    batches: executions.map((execution, index) => ({
+      batch: index + 1,
+      days: execution.result.days.length,
+      candidates: execution.result.candidateCount,
+      stagedEntries: execution.result.stagedEntries,
+    })),
+  };
+}

--- a/extensions/memory-core/src/session-backfill-lifecycle.ts
+++ b/extensions/memory-core/src/session-backfill-lifecycle.ts
@@ -6,7 +6,10 @@ import {
   SESSION_BACKFILL_REWIND_NAMESPACE,
   writeMemoryCoreWorkspaceEntry,
 } from "./dreaming-state.js";
-import type { SessionBackfillExecution, SessionBackfillResult } from "./session-backfill.js";
+import type {
+  SessionBackfillExecution,
+  SessionBackfillResult,
+} from "./session-backfill-contract.js";
 
 const DEFAULT_SESSION_BACKFILL_LIMIT_DAYS = 92;
 const MEMORY_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
@@ -83,6 +84,19 @@ async function createIsolatedWorkspace(prefix: string): Promise<string> {
   return workspaceDir;
 }
 
+function hashStagedContent(
+  entries: Awaited<ReturnType<typeof readShortTermRecallEntries>>,
+): string {
+  const content = entries
+    .map((entry) => ({
+      claimHash: entry.claimHash,
+      provenance: entry.provenance,
+      snippet: entry.snippet,
+    }))
+    .toSorted((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  return createHash("sha256").update(JSON.stringify(content)).digest("hex");
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
   clearRuntimeConfigSnapshot();
@@ -90,8 +104,8 @@ afterEach(() => {
 });
 
 describe("runSessionBackfill", () => {
-  it("keeps the CLI export on the canonical shared executor", () => {
-    expect(runSessionBackfill).toBe(executeSessionBackfill);
+  it("keeps CLI draining separate from the single-batch executor", () => {
+    expect(runSessionBackfill).not.toBe(executeSessionBackfill);
   });
 
   it("keeps REM preview mode mutually exclusive with apply", async () => {
@@ -190,6 +204,38 @@ describe("runSessionBackfill", () => {
     expect(exhausted.continuation).toEqual({ advanced: false, hasMore: false });
   });
 
+  it("drains at least three internal batches in one CLI executor invocation", async () => {
+    const workspaceDir = await createIsolatedWorkspace("cli-drain-");
+    await seedCanonicalTranscript(
+      "cli-drain",
+      ["2026-01-01", "2026-01-02", "2026-01-03"].map((day) => ({
+        role: "user" as const,
+        content: `CLI drain note for ${day}`,
+        timestamp: `${day}T12:00:00.000Z`,
+        owner: true,
+      })),
+    );
+
+    const applied = await runSessionBackfill({
+      agentId: "main",
+      workspaceDir,
+      apply: true,
+      limitDays: 1,
+      timezone: "UTC",
+    });
+    const preview = await runSessionBackfill({
+      agentId: "main",
+      workspaceDir,
+      limitDays: 1,
+      timezone: "UTC",
+    });
+
+    expect(applied.batchCount).toBe(3);
+    expect(applied.batches?.map((batch) => batch.candidates)).toEqual([1, 1, 1]);
+    expect(applied.candidateCount).toBe(3);
+    expect(preview.candidateCount).toBe(0);
+  });
+
   it("does not advance the cursor past messages excluded by a date range", async () => {
     const workspaceDir = await createIsolatedWorkspace("range-cursor-");
     await seedCanonicalTranscript("range-cursor", [
@@ -247,8 +293,9 @@ describe("runSessionBackfill", () => {
         timezone: "UTC",
       });
 
-    expect((await run()).candidateCount).toBe(80);
-    expect((await run()).candidateCount).toBe(20);
+    const drained = await run();
+    expect(drained.candidateCount).toBe(100);
+    expect(drained.batchCount).toBe(2);
     expect((await run()).candidateCount).toBe(0);
     const dreams = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(dreams.match(/openclaw:dreaming:backfill-entry/g)).toHaveLength(2);
@@ -461,6 +508,7 @@ describe("runSessionBackfill", () => {
       timezone: "UTC",
     });
     const afterFirst = await readShortTermRecallEntries({ workspaceDir });
+    const firstContentHash = hashStagedContent(afterFirst);
 
     // Count-level proof stays stable across the sibling claim-key implementation.
     expect(first.stagedEntries).toBe(1);
@@ -494,15 +542,15 @@ describe("runSessionBackfill", () => {
     expect(await fs.readFile(dreamsPath, "utf-8")).not.toContain(
       "openclaw:dreaming:backfill-entry",
     );
-    expect(
-      (
-        await runSessionBackfill({
-          agentId: "main",
-          workspaceDir,
-          apply: true,
-          timezone: "UTC",
-        })
-      ).candidateCount,
-    ).toBe(0);
+    const reapplied = await runSessionBackfill({
+      agentId: "main",
+      workspaceDir,
+      apply: true,
+      nowMs: Date.parse("2026-03-02T12:00:00.000Z"),
+      timezone: "UTC",
+    });
+    const afterReapply = await readShortTermRecallEntries({ workspaceDir });
+    expect(reapplied.candidateCount).toBe(2);
+    expect(hashStagedContent(afterReapply)).toBe(firstContentHash);
   });
 });

--- a/extensions/memory-core/src/session-backfill.ts
+++ b/extensions/memory-core/src/session-backfill.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -31,25 +30,25 @@ import {
   writeSessionIngestionState,
   type SessionIngestionMessage,
 } from "./dreaming-phases.js";
-import {
-  clearMemoryCoreWorkspaceNamespace,
-  readMemoryCoreWorkspaceEntries,
-  SESSION_BACKFILL_REWIND_NAMESPACE,
-  writeMemoryCoreWorkspaceEntry,
-} from "./dreaming-state.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
+import {
+  drainSessionBackfill,
+  normalizeSessionBackfillSelection,
+  recordSessionBackfillRewindBatch,
+  rewindSessionBackfillIngestionState,
+} from "./session-backfill-lifecycle.js";
 import {
   readShortTermRecallEntries,
   recordGroundedShortTermCandidates,
   removeGroundedShortTermCandidates,
 } from "./short-term-promotion.js";
 
-const DEFAULT_SESSION_BACKFILL_LIMIT_DAYS = 92;
 const SESSION_BACKFILL_QUERY_PREFIX = "__dreaming_session_backfill__";
 const SESSION_CORPUS_RELATIVE_DIR = path.join("memory", ".dreams", "session-corpus");
 const TOP_CANDIDATE_LIMIT = 5;
-const MEMORY_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
 const MAX_SESSION_BACKFILL_APPLY_BATCHES = 10_000;
+
+export { normalizeSessionBackfillSelection } from "./session-backfill-lifecycle.js";
 
 export type MemorySessionBackfillOptions = {
   agent?: string;
@@ -129,7 +128,7 @@ export type SessionBackfillResult = {
   };
 };
 
-export type SessionBackfillBatchProgress = {
+type SessionBackfillBatchProgress = {
   batch: number;
   days: number;
   candidates: number;
@@ -141,19 +140,9 @@ type SessionBackfillContinuation = {
   hasMore: boolean;
 };
 
-type SessionBackfillExecution = {
+export type SessionBackfillExecution = {
   result: SessionBackfillResult;
   continuation: SessionBackfillContinuation;
-};
-
-type SessionBackfillRewindBatch = {
-  version: 1;
-  candidates: Array<{
-    contentIndex: number;
-    hash: string;
-    scope: string;
-    stateKey: string;
-  }>;
 };
 
 export type RunSessionBackfillParams = {
@@ -169,57 +158,6 @@ export type RunSessionBackfillParams = {
   nowMs?: number;
   timezone?: string;
 };
-
-function normalizeMemoryDay(value: string | undefined, flag: string): string | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  const day = value.trim();
-  if (!MEMORY_DAY_RE.test(day)) {
-    throw new Error(`${flag} must use YYYY-MM-DD.`);
-  }
-  const parsed = new Date(`${day}T00:00:00.000Z`);
-  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== day) {
-    throw new Error(`${flag} must be a valid calendar day.`);
-  }
-  return day;
-}
-
-function resolveLimitDays(value: number | undefined): number {
-  if (value === undefined) {
-    return DEFAULT_SESSION_BACKFILL_LIMIT_DAYS;
-  }
-  if (!Number.isInteger(value) || value <= 0) {
-    throw new Error("--limit-days must be a positive integer.");
-  }
-  return value;
-}
-
-export function normalizeSessionBackfillSelection(
-  params: Pick<RunSessionBackfillParams, "from" | "to" | "limitDays">,
-  labels: { from: string; to: string; limitDays: string } = {
-    from: "--from",
-    to: "--to",
-    limitDays: "--limit-days",
-  },
-): { from?: string; to?: string; limitDays: number } {
-  const from = normalizeMemoryDay(params.from, labels.from);
-  const to = normalizeMemoryDay(params.to, labels.to);
-  if (from !== undefined && to !== undefined && from > to) {
-    throw new Error(`${labels.from} must not be after ${labels.to}.`);
-  }
-  let limitDays: number;
-  try {
-    limitDays = resolveLimitDays(params.limitDays);
-  } catch {
-    throw new Error(`${labels.limitDays} must be a positive integer.`);
-  }
-  return {
-    ...(from !== undefined ? { from } : {}),
-    ...(to !== undefined ? { to } : {}),
-    limitDays,
-  };
-}
 
 function sourceFromCorpusEntry(entry: SessionTranscriptCorpusEntry): SessionBackfillSource | null {
   if (
@@ -457,112 +395,6 @@ async function collectSessionBackfillCandidates(params: {
     byDay.set(candidate.day, bucket);
   }
   return { byDay, scans };
-}
-
-async function recordSessionBackfillRewindBatch(params: {
-  workspaceDir: string;
-  days: Array<{ candidates: SessionBackfillCandidate[] }>;
-}): Promise<void> {
-  const candidates = params.days.flatMap((day) =>
-    day.candidates.map((candidate) => ({
-      contentIndex: candidate.contentIndex,
-      hash: candidate.hash,
-      scope: candidate.scope,
-      stateKey: candidate.stateKey,
-    })),
-  );
-  if (candidates.length === 0) {
-    return;
-  }
-  const key = createHash("sha256").update(JSON.stringify(candidates)).digest("hex");
-  await writeMemoryCoreWorkspaceEntry<SessionBackfillRewindBatch>({
-    namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
-    workspaceDir: params.workspaceDir,
-    key,
-    value: { version: 1, candidates },
-  });
-}
-
-function isSessionBackfillRewindCandidate(
-  value: unknown,
-): value is SessionBackfillRewindBatch["candidates"][number] {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  const candidate = value as Record<string, unknown>;
-  return (
-    Number.isInteger(candidate.contentIndex) &&
-    (candidate.contentIndex as number) >= 0 &&
-    typeof candidate.hash === "string" &&
-    candidate.hash.length > 0 &&
-    typeof candidate.scope === "string" &&
-    candidate.scope.length > 0 &&
-    typeof candidate.stateKey === "string" &&
-    candidate.stateKey.length > 0
-  );
-}
-
-async function rewindSessionBackfillIngestionState(workspaceDir: string): Promise<number> {
-  const entries = await readMemoryCoreWorkspaceEntries<SessionBackfillRewindBatch>({
-    namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
-    workspaceDir,
-  });
-  const candidates = entries.flatMap((entry) =>
-    entry.value?.version === 1 && Array.isArray(entry.value.candidates)
-      ? entry.value.candidates.filter(isSessionBackfillRewindCandidate)
-      : [],
-  );
-  if (candidates.length === 0) {
-    await clearMemoryCoreWorkspaceNamespace({
-      namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
-      workspaceDir,
-    });
-    return 0;
-  }
-
-  const state = await readSessionIngestionState(workspaceDir);
-  const removedHashesByScope = new Map<string, Set<string>>();
-  const rewindLineByStateKey = new Map<string, number>();
-  for (const candidate of candidates) {
-    const hashes = removedHashesByScope.get(candidate.scope) ?? new Set<string>();
-    hashes.add(candidate.hash);
-    removedHashesByScope.set(candidate.scope, hashes);
-    rewindLineByStateKey.set(
-      candidate.stateKey,
-      Math.min(
-        rewindLineByStateKey.get(candidate.stateKey) ?? candidate.contentIndex,
-        candidate.contentIndex,
-      ),
-    );
-  }
-
-  const seenMessages = { ...state.seenMessages };
-  for (const [scope, removedHashes] of removedHashesByScope) {
-    const remaining = (seenMessages[scope] ?? []).filter((hash) => !removedHashes.has(hash));
-    if (remaining.length > 0) {
-      seenMessages[scope] = remaining;
-    } else {
-      delete seenMessages[scope];
-    }
-  }
-  const files = { ...state.files };
-  // Rollback intentionally reopens only the journaled backfill range. Every
-  // non-backfill hash stays tracked, so later live-ingestion work remains skipped.
-  for (const [stateKey, lastContentLine] of rewindLineByStateKey) {
-    const current = files[stateKey];
-    if (current) {
-      files[stateKey] = {
-        ...current,
-        lastContentLine: Math.min(current.lastContentLine, lastContentLine),
-      };
-    }
-  }
-  await writeSessionIngestionState(workspaceDir, { ...state, files, seenMessages });
-  await clearMemoryCoreWorkspaceNamespace({
-    namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
-    workspaceDir,
-  });
-  return candidates.length;
 }
 
 function mergeSessionBackfillFileProgress(params: {
@@ -815,7 +647,17 @@ async function executeSessionBackfillCore(
   }
 
   if (params.apply) {
-    await recordSessionBackfillRewindBatch({ workspaceDir, days: selectedDays });
+    await recordSessionBackfillRewindBatch({
+      workspaceDir,
+      candidates: selectedDays.flatMap((day) =>
+        day.candidates.map((candidate) => ({
+          contentIndex: candidate.contentIndex,
+          hash: candidate.hash,
+          scope: candidate.scope,
+          stateKey: candidate.stateKey,
+        })),
+      ),
+    });
     if (selectedDays.length > 0) {
       stagedEntries = await applySessionBackfillDays({
         workspaceDir,
@@ -878,66 +720,11 @@ export async function runSessionBackfill(
     return (await executeSessionBackfillCore(params)).result;
   }
 
-  const batches: SessionBackfillExecution[] = [];
-  for (let batch = 1; batch <= MAX_SESSION_BACKFILL_APPLY_BATCHES; batch += 1) {
-    const execution = await executeSessionBackfillCore(params);
-    batches.push(execution);
-    if (!execution.continuation.hasMore) {
-      return aggregateSessionBackfillBatches(batches);
-    }
-    if (!execution.continuation.advanced) {
-      throw new Error(
-        `Memory session-backfill stopped after ${batch} batches because the ingestion cursor did not advance.`,
-      );
-    }
-  }
-  throw new Error(
-    `Memory session-backfill exceeded the ${MAX_SESSION_BACKFILL_APPLY_BATCHES}-batch safety limit.`,
-  );
-}
-
-function aggregateSessionBackfillBatches(
-  executions: SessionBackfillExecution[],
-): SessionBackfillResult {
-  const first = executions[0]?.result;
-  if (!first) {
-    throw new Error("Memory session-backfill completed without executing a batch.");
-  }
-  const days = new Map<string, SessionBackfillDay>();
-  for (const execution of executions) {
-    for (const day of execution.result.days) {
-      const current = days.get(day.day);
-      days.set(day.day, {
-        day: day.day,
-        candidateCount: (current?.candidateCount ?? 0) + day.candidateCount,
-        topCandidates: [...(current?.topCandidates ?? []), ...day.topCandidates].slice(
-          0,
-          TOP_CANDIDATE_LIMIT,
-        ),
-      });
-    }
-  }
-  return {
-    ...first,
-    days: [...days.values()].toSorted((a, b) => a.day.localeCompare(b.day)),
-    candidateCount: executions.reduce((sum, execution) => sum + execution.result.candidateCount, 0),
-    stagedEntries: executions.reduce((sum, execution) => sum + execution.result.stagedEntries, 0),
-    writtenDiaryEntries: executions.reduce(
-      (sum, execution) => sum + execution.result.writtenDiaryEntries,
-      0,
-    ),
-    replacedDiaryEntries: executions.reduce(
-      (sum, execution) => sum + execution.result.replacedDiaryEntries,
-      0,
-    ),
-    batchCount: executions.length,
-    batches: executions.map((execution, index) => ({
-      batch: index + 1,
-      days: execution.result.days.length,
-      candidates: execution.result.candidateCount,
-      stagedEntries: execution.result.stagedEntries,
-    })),
-  };
+  return await drainSessionBackfill({
+    executeBatch: () => executeSessionBackfillCore(params),
+    maxBatches: MAX_SESSION_BACKFILL_APPLY_BATCHES,
+    topCandidateLimit: TOP_CANDIDATE_LIMIT,
+  });
 }
 
 export async function executeSessionBackfillBatch(

--- a/extensions/memory-core/src/session-backfill.ts
+++ b/extensions/memory-core/src/session-backfill.ts
@@ -31,6 +31,11 @@ import {
   type SessionIngestionMessage,
 } from "./dreaming-phases.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
+import type {
+  SessionBackfillDay,
+  SessionBackfillExecution,
+  SessionBackfillResult,
+} from "./session-backfill-contract.js";
 import {
   drainSessionBackfill,
   normalizeSessionBackfillSelection,
@@ -49,6 +54,10 @@ const TOP_CANDIDATE_LIMIT = 5;
 const MAX_SESSION_BACKFILL_APPLY_BATCHES = 10_000;
 
 export { normalizeSessionBackfillSelection } from "./session-backfill-lifecycle.js";
+export type {
+  SessionBackfillExecution,
+  SessionBackfillResult,
+} from "./session-backfill-contract.js";
 
 export type MemorySessionBackfillOptions = {
   agent?: string;
@@ -102,47 +111,6 @@ type SessionBackfillScan = {
 type SessionBackfillCollection = {
   byDay: Map<string, SessionBackfillCandidate[]>;
   scans: SessionBackfillScan[];
-};
-
-type SessionBackfillDay = {
-  day: string;
-  candidateCount: number;
-  topCandidates: string[];
-};
-
-export type SessionBackfillResult = {
-  agentId: string;
-  workspaceDir: string;
-  applied: boolean;
-  rem: boolean;
-  days: SessionBackfillDay[];
-  candidateCount: number;
-  stagedEntries: number;
-  writtenDiaryEntries: number;
-  replacedDiaryEntries: number;
-  batchCount?: number;
-  batches?: SessionBackfillBatchProgress[];
-  rollback?: {
-    removedDiaryEntries: number;
-    removedStagedEntries: number;
-  };
-};
-
-type SessionBackfillBatchProgress = {
-  batch: number;
-  days: number;
-  candidates: number;
-  stagedEntries: number;
-};
-
-type SessionBackfillContinuation = {
-  advanced: boolean;
-  hasMore: boolean;
-};
-
-export type SessionBackfillExecution = {
-  result: SessionBackfillResult;
-  continuation: SessionBackfillContinuation;
 };
 
 export type RunSessionBackfillParams = {

--- a/extensions/memory-core/src/session-backfill.ts
+++ b/extensions/memory-core/src/session-backfill.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -30,6 +31,12 @@ import {
   writeSessionIngestionState,
   type SessionIngestionMessage,
 } from "./dreaming-phases.js";
+import {
+  clearMemoryCoreWorkspaceNamespace,
+  readMemoryCoreWorkspaceEntries,
+  SESSION_BACKFILL_REWIND_NAMESPACE,
+  writeMemoryCoreWorkspaceEntry,
+} from "./dreaming-state.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
 import {
   readShortTermRecallEntries,
@@ -42,6 +49,7 @@ const SESSION_BACKFILL_QUERY_PREFIX = "__dreaming_session_backfill__";
 const SESSION_CORPUS_RELATIVE_DIR = path.join("memory", ".dreams", "session-corpus");
 const TOP_CANDIDATE_LIMIT = 5;
 const MEMORY_DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_SESSION_BACKFILL_APPLY_BATCHES = 10_000;
 
 export type MemorySessionBackfillOptions = {
   agent?: string;
@@ -78,6 +86,7 @@ type SessionBackfillCandidate = SessionIngestionMessage & {
   legacyHash?: string;
   lineNumber: number;
   scope: string;
+  stateKey: string;
 };
 
 type SessionBackfillScan = {
@@ -112,10 +121,19 @@ export type SessionBackfillResult = {
   stagedEntries: number;
   writtenDiaryEntries: number;
   replacedDiaryEntries: number;
+  batchCount?: number;
+  batches?: SessionBackfillBatchProgress[];
   rollback?: {
     removedDiaryEntries: number;
     removedStagedEntries: number;
   };
+};
+
+export type SessionBackfillBatchProgress = {
+  batch: number;
+  days: number;
+  candidates: number;
+  stagedEntries: number;
 };
 
 type SessionBackfillContinuation = {
@@ -126,6 +144,16 @@ type SessionBackfillContinuation = {
 type SessionBackfillExecution = {
   result: SessionBackfillResult;
   continuation: SessionBackfillContinuation;
+};
+
+type SessionBackfillRewindBatch = {
+  version: 1;
+  candidates: Array<{
+    contentIndex: number;
+    hash: string;
+    scope: string;
+    stateKey: string;
+  }>;
 };
 
 export type RunSessionBackfillParams = {
@@ -399,6 +427,7 @@ async function collectSessionBackfillCandidates(params: {
         provenance,
         rendered,
         scope: source.scope,
+        stateKey: source.stateKey,
         snippet,
       } satisfies SessionBackfillCandidate;
       sourceCandidates.push(candidate);
@@ -428,6 +457,112 @@ async function collectSessionBackfillCandidates(params: {
     byDay.set(candidate.day, bucket);
   }
   return { byDay, scans };
+}
+
+async function recordSessionBackfillRewindBatch(params: {
+  workspaceDir: string;
+  days: Array<{ candidates: SessionBackfillCandidate[] }>;
+}): Promise<void> {
+  const candidates = params.days.flatMap((day) =>
+    day.candidates.map((candidate) => ({
+      contentIndex: candidate.contentIndex,
+      hash: candidate.hash,
+      scope: candidate.scope,
+      stateKey: candidate.stateKey,
+    })),
+  );
+  if (candidates.length === 0) {
+    return;
+  }
+  const key = createHash("sha256").update(JSON.stringify(candidates)).digest("hex");
+  await writeMemoryCoreWorkspaceEntry<SessionBackfillRewindBatch>({
+    namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
+    workspaceDir: params.workspaceDir,
+    key,
+    value: { version: 1, candidates },
+  });
+}
+
+function isSessionBackfillRewindCandidate(
+  value: unknown,
+): value is SessionBackfillRewindBatch["candidates"][number] {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    Number.isInteger(candidate.contentIndex) &&
+    (candidate.contentIndex as number) >= 0 &&
+    typeof candidate.hash === "string" &&
+    candidate.hash.length > 0 &&
+    typeof candidate.scope === "string" &&
+    candidate.scope.length > 0 &&
+    typeof candidate.stateKey === "string" &&
+    candidate.stateKey.length > 0
+  );
+}
+
+async function rewindSessionBackfillIngestionState(workspaceDir: string): Promise<number> {
+  const entries = await readMemoryCoreWorkspaceEntries<SessionBackfillRewindBatch>({
+    namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
+    workspaceDir,
+  });
+  const candidates = entries.flatMap((entry) =>
+    entry.value?.version === 1 && Array.isArray(entry.value.candidates)
+      ? entry.value.candidates.filter(isSessionBackfillRewindCandidate)
+      : [],
+  );
+  if (candidates.length === 0) {
+    await clearMemoryCoreWorkspaceNamespace({
+      namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
+      workspaceDir,
+    });
+    return 0;
+  }
+
+  const state = await readSessionIngestionState(workspaceDir);
+  const removedHashesByScope = new Map<string, Set<string>>();
+  const rewindLineByStateKey = new Map<string, number>();
+  for (const candidate of candidates) {
+    const hashes = removedHashesByScope.get(candidate.scope) ?? new Set<string>();
+    hashes.add(candidate.hash);
+    removedHashesByScope.set(candidate.scope, hashes);
+    rewindLineByStateKey.set(
+      candidate.stateKey,
+      Math.min(
+        rewindLineByStateKey.get(candidate.stateKey) ?? candidate.contentIndex,
+        candidate.contentIndex,
+      ),
+    );
+  }
+
+  const seenMessages = { ...state.seenMessages };
+  for (const [scope, removedHashes] of removedHashesByScope) {
+    const remaining = (seenMessages[scope] ?? []).filter((hash) => !removedHashes.has(hash));
+    if (remaining.length > 0) {
+      seenMessages[scope] = remaining;
+    } else {
+      delete seenMessages[scope];
+    }
+  }
+  const files = { ...state.files };
+  // Rollback intentionally reopens only the journaled backfill range. Every
+  // non-backfill hash stays tracked, so later live-ingestion work remains skipped.
+  for (const [stateKey, lastContentLine] of rewindLineByStateKey) {
+    const current = files[stateKey];
+    if (current) {
+      files[stateKey] = {
+        ...current,
+        lastContentLine: Math.min(current.lastContentLine, lastContentLine),
+      };
+    }
+  }
+  await writeSessionIngestionState(workspaceDir, { ...state, files, seenMessages });
+  await clearMemoryCoreWorkspaceNamespace({
+    namespace: SESSION_BACKFILL_REWIND_NAMESPACE,
+    workspaceDir,
+  });
+  return candidates.length;
 }
 
 function mergeSessionBackfillFileProgress(params: {
@@ -601,11 +736,11 @@ async function executeSessionBackfillCore(
   if (params.rollback) {
     // Backfill diary markers and grounded-only candidates are a shared artifact
     // class with rem-backfill; the stable removal APIs intentionally clear both.
-    // Ingestion cursors and hashes remain: rollback must not re-ingest tracked messages.
     const [diary, staged] = await Promise.all([
       removeBackfillDiaryEntries({ workspaceDir }),
       removeGroundedShortTermCandidates({ workspaceDir }),
     ]);
+    await rewindSessionBackfillIngestionState(workspaceDir);
     return {
       result: {
         agentId: params.agentId,
@@ -680,6 +815,7 @@ async function executeSessionBackfillCore(
   }
 
   if (params.apply) {
+    await recordSessionBackfillRewindBatch({ workspaceDir, days: selectedDays });
     if (selectedDays.length > 0) {
       stagedEntries = await applySessionBackfillDays({
         workspaceDir,
@@ -733,11 +869,79 @@ export async function executeSessionBackfill(
   return (await executeSessionBackfillCore(params)).result;
 }
 
+// The CLI owns drain-to-completion. Cursor-driven clients must keep using
+// executeSessionBackfillBatch so one request remains one bounded transaction.
+export async function runSessionBackfill(
+  params: RunSessionBackfillParams,
+): Promise<SessionBackfillResult> {
+  if (!params.apply || params.rollback) {
+    return (await executeSessionBackfillCore(params)).result;
+  }
+
+  const batches: SessionBackfillExecution[] = [];
+  for (let batch = 1; batch <= MAX_SESSION_BACKFILL_APPLY_BATCHES; batch += 1) {
+    const execution = await executeSessionBackfillCore(params);
+    batches.push(execution);
+    if (!execution.continuation.hasMore) {
+      return aggregateSessionBackfillBatches(batches);
+    }
+    if (!execution.continuation.advanced) {
+      throw new Error(
+        `Memory session-backfill stopped after ${batch} batches because the ingestion cursor did not advance.`,
+      );
+    }
+  }
+  throw new Error(
+    `Memory session-backfill exceeded the ${MAX_SESSION_BACKFILL_APPLY_BATCHES}-batch safety limit.`,
+  );
+}
+
+function aggregateSessionBackfillBatches(
+  executions: SessionBackfillExecution[],
+): SessionBackfillResult {
+  const first = executions[0]?.result;
+  if (!first) {
+    throw new Error("Memory session-backfill completed without executing a batch.");
+  }
+  const days = new Map<string, SessionBackfillDay>();
+  for (const execution of executions) {
+    for (const day of execution.result.days) {
+      const current = days.get(day.day);
+      days.set(day.day, {
+        day: day.day,
+        candidateCount: (current?.candidateCount ?? 0) + day.candidateCount,
+        topCandidates: [...(current?.topCandidates ?? []), ...day.topCandidates].slice(
+          0,
+          TOP_CANDIDATE_LIMIT,
+        ),
+      });
+    }
+  }
+  return {
+    ...first,
+    days: [...days.values()].toSorted((a, b) => a.day.localeCompare(b.day)),
+    candidateCount: executions.reduce((sum, execution) => sum + execution.result.candidateCount, 0),
+    stagedEntries: executions.reduce((sum, execution) => sum + execution.result.stagedEntries, 0),
+    writtenDiaryEntries: executions.reduce(
+      (sum, execution) => sum + execution.result.writtenDiaryEntries,
+      0,
+    ),
+    replacedDiaryEntries: executions.reduce(
+      (sum, execution) => sum + execution.result.replacedDiaryEntries,
+      0,
+    ),
+    batchCount: executions.length,
+    batches: executions.map((execution, index) => ({
+      batch: index + 1,
+      days: execution.result.days.length,
+      candidates: execution.result.candidateCount,
+      stagedEntries: execution.result.stagedEntries,
+    })),
+  };
+}
+
 export async function executeSessionBackfillBatch(
   params: RunSessionBackfillParams,
 ): Promise<SessionBackfillExecution> {
   return await executeSessionBackfillCore(params);
 }
-
-// Preserve the CLI-facing name while every caller shares the same executor.
-export { executeSessionBackfill as runSessionBackfill };

--- a/extensions/memory-core/src/session-backfill.ts
+++ b/extensions/memory-core/src/session-backfill.ts
@@ -54,10 +54,7 @@ const TOP_CANDIDATE_LIMIT = 5;
 const MAX_SESSION_BACKFILL_APPLY_BATCHES = 10_000;
 
 export { normalizeSessionBackfillSelection } from "./session-backfill-lifecycle.js";
-export type {
-  SessionBackfillExecution,
-  SessionBackfillResult,
-} from "./session-backfill-contract.js";
+export type { SessionBackfillResult } from "./session-backfill-contract.js";
 
 export type MemorySessionBackfillOptions = {
   agent?: string;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2135,7 +2135,7 @@ export const en: TranslationMap = {
       rollbackConfirmDescription:
         "Remove diary entries and staged memories created by session backfill for this agent.",
       rollbackWarning:
-        "Tracked session cursors stay in place, so removed entries will not be staged again.",
+        "Session backfill cursors are rewound, so the same candidates can be staged again.",
       rollbackComplete: "Session backfill rolled back",
       rollbackCounts: "{diary} diary entries and {staged} staged entries removed",
       unavailable: "Session backfill is unavailable on this Gateway.",

--- a/ui/src/pages/memory-import/view.test.ts
+++ b/ui/src/pages/memory-import/view.test.ts
@@ -199,7 +199,7 @@ describe("renderMemoryImport", () => {
       container,
     );
 
-    expect(container.textContent).toContain("Tracked session cursors stay in place");
+    expect(container.textContent).toContain("Session backfill cursors are rewound");
     container
       .querySelector<HTMLButtonElement>("[data-test-id='memory-backfill-rollback-confirm']")
       ?.click();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw memory session-backfill --apply` had to repeat the command several times before preview reached zero, because one CLI invocation processed only one internal batch. It also fixes rollback leaving ingestion checkpoints behind, which made removed candidates impossible to stage again.

## Why This Change Was Made

The CLI now drains bounded batches to completion and reports per-batch plus aggregate progress, while the Control UI gateway keeps its existing client-driven one-batch cursor protocol. Apply records a SQLite-backed rewind journal for only the candidate hashes and source offsets it owns; rollback removes those hashes and reopens the affected ranges without clearing unrelated live-ingestion hashes.

The change is AI-assisted and was reviewed through the repository autoreview workflow until no accepted or actionable findings remained.

## User Impact

One successful CLI apply now converges immediately: the next preview reports zero candidates. Operators can also run apply, rollback, and apply again to recover the same staged candidate set instead of hitting a one-way checkpoint.

The Control UI remains chunked and continues to show incremental progress. Its rollback warning now accurately explains that the backfill cursor is rewound.

## Evidence

- Real-install reproduction before the fix: a 12k-session copied install required four apply commands (42, 13, 12, and 10 candidates) before preview reached zero; rollback removed 74 staged rows and 11 diary entries but re-apply found nothing.
- Focused post-rebase proof: `node scripts/run-vitest.mjs extensions/memory-core/src/session-backfill.test.ts extensions/memory-core/src/session-backfill-gateway.test.ts extensions/memory-core/src/cli.test.ts ui/src/pages/memory-import/view.test.ts ui/src/pages/memory-import/memory-import-page.test.ts` — 96 tests passed across both shards.
- Regression fixtures force three internal batches in one CLI invocation, assert immediate preview is zero, and verify apply → rollback → apply with a SHA-256 hash of the semantic staged set.
- Final changed-file gate: `node scripts/check-changed.mjs -- <touched files>` — all typecheck, lint, dead-code, i18n, boundary, database-first, and import-cycle lanes passed on Blacksmith Testbox (run 30457519196).
- Final autoreview: clean, no accepted/actionable findings.
