### PR TITLE
fix(test): stabilize Codex plugin deadline coverage

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -766,6 +766,7 @@ describe("startCodexAttemptThread", () => {
   });
 
   it("continues with a deny-all apps patch when plugin discovery exceeds its shared deadline", async () => {
+    vi.useFakeTimers();
     const deadlinePluginConfig = {
       appServer: { command: "codex", requestTimeoutMs: 400 },
       codexPlugins: {
@@ -782,11 +783,8 @@ describe("startCodexAttemptThread", () => {
       pluginConfig: deadlinePluginConfig,
     });
     await answerInitialize(harness);
-    // Discovery requests (plugin/installed, and plugin/list only when the
-    // missing-plugin catalog fetch wins the race against the shared deadline)
-    // are deliberately left unanswered; the contract under test is that the
-    // thread still starts, carrying the deny-all apps patch.
     await waitForRequest(harness, "plugin/installed");
+    await vi.advanceTimersByTimeAsync(100);
 
     const threadStart = await waitForThreadStart(harness);
     const startMessage = readHarnessMessages(harness.writes).find(


### PR DESCRIPTION
Related: #115696

## What Problem This Solves

Resolves a problem where the Codex startup deadline test could wait 15 seconds for a discovery RPC and fail under shared-suite scheduling even though startup correctly continued with a deny-all apps patch.

## Why This Change Was Made

Uses fake timers, synchronizes on the initial `plugin/installed` request, then advances the documented 100 ms shared discovery budget before asserting the actual `thread/start.config.apps` contract. Production behavior is unchanged.

## User Impact

Maintainers get deterministic Codex startup coverage without intermittent deadline failures or long real-time waits.

## Evidence

- Blacksmith Testbox `tbx_01kyq2bwb2m3n48gy4kscrpsmd`: focused test passed in 182 ms.
- Run: https://github.com/openclaw/openclaw/actions/runs/30458061050
- `oxfmt --check` and `git diff --check` passed.
- Autoreview and TruffleHog completed with no findings.
- Directly inspected current OpenAI Codex `9a6668f674`: `plugin/list` and `plugin/installed` are independent RPCs in `codex-rs/app-server-protocol/src/protocol/common.rs`; `thread/start.config` is accepted in `codex-rs/app-server-protocol/src/protocol/v2/thread.rs` and merged by `codex-rs/app-server/src/config_manager.rs`.