### PR TITLE
fix(ui): keep hide confirmation in viewport

### DIFF
--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -243,13 +243,42 @@ describeControlUiE2e("Control UI chat message actions", () => {
       await expectHoverTooltip(replyButton, "Reply");
       await screenshot(page, "01-inline-actions.png");
 
+      const hideButton = group.getByRole("button", { name: "Hide message" });
+      expect(
+        await hideButton.evaluate((element) => {
+          const row = element.closest<HTMLElement>(".chat-virtual-row");
+          return Boolean(row && getComputedStyle(row).transform !== "none");
+        }),
+      ).toBe(true);
+      await hideButton.click();
+      const hideConfirmation = page.locator(".chat-delete-confirm");
+      await hideConfirmation.waitFor({ state: "visible" });
+      expect(
+        await hideConfirmation.evaluate((element) => element.parentElement === document.body),
+      ).toBe(true);
+      const hideConfirmationBounds = await hideConfirmation.boundingBox();
+      const viewport = page.viewportSize();
+      expect(hideConfirmationBounds).not.toBeNull();
+      expect(viewport).not.toBeNull();
+      expect(hideConfirmationBounds!.x).toBeGreaterThanOrEqual(0);
+      expect(hideConfirmationBounds!.y).toBeGreaterThanOrEqual(0);
+      expect(hideConfirmationBounds!.x + hideConfirmationBounds!.width).toBeLessThanOrEqual(
+        viewport!.width,
+      );
+      expect(hideConfirmationBounds!.y + hideConfirmationBounds!.height).toBeLessThanOrEqual(
+        viewport!.height,
+      );
+      await screenshot(page, "02-hide-confirmation.png");
+      await hideConfirmation.getByRole("button", { name: "Cancel" }).click();
+
+      await group.hover();
       await replyButton.click();
       const replyPreview = page.locator(".chat-reply-preview");
       await replyPreview.waitFor({ state: "visible" });
       expect(await replyPreview.locator(".chat-reply-preview__text").textContent()).toBe(
         messageText,
       );
-      await screenshot(page, "02-reply-preview.png");
+      await screenshot(page, "03-reply-preview.png");
       await replyPreview.getByRole("button", { name: "Cancel reply" }).click();
 
       const menu = page.locator(".chat-reply-context-menu");
@@ -287,7 +316,7 @@ describeControlUiE2e("Control UI chat message actions", () => {
         "Open in canvas",
         "Copy as markdown",
       ]);
-      await screenshot(page, "03-selected-text-context-menu.png");
+      await screenshot(page, "04-selected-text-context-menu.png");
       await menu.getByRole("menuitem", { name: "Copy", exact: true }).click();
       await expect
         .poll(() => page.evaluate(() => navigator.clipboard.readText()))
@@ -305,7 +334,7 @@ describeControlUiE2e("Control UI chat message actions", () => {
       expect(
         await menu.getByRole("menuitem", { name: "Reply to message" }).locator("svg").count(),
       ).toBe(0);
-      await screenshot(page, "04-context-menu.png");
+      await screenshot(page, "05-context-menu.png");
 
       await menu.getByRole("menuitem", { name: "Copy as markdown" }).click();
       await expect

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -652,7 +652,9 @@ function createConfirmationOwner() {
   document.body.appendChild(owner);
   confirmationOwners.add(owner);
   openChatRewindConfirmation(trigger, vi.fn());
-  return owner;
+  const popover = [...document.querySelectorAll<HTMLElement>(".chat-delete-confirm")].at(-1);
+  expect(popover).toBeInstanceOf(HTMLElement);
+  return { owner, popover: popover! };
 }
 
 afterEach(() => {
@@ -703,11 +705,11 @@ describe("chat pane presentation teardown", () => {
     expect(captureClickListeners).toHaveLength(2);
     expect(captureKeydownListeners).toHaveLength(2);
 
-    pane.appendChild(paneConfirmation);
+    pane.appendChild(paneConfirmation.owner);
     pane.disconnectedCallback();
 
-    expect(pane.querySelector(".chat-delete-confirm")).toBeNull();
-    expect(siblingConfirmation.querySelector(".chat-delete-confirm")).not.toBeNull();
+    expect(paneConfirmation.popover.isConnected).toBe(false);
+    expect(siblingConfirmation.popover.isConnected).toBe(true);
     expect(removeDocumentListener).toHaveBeenCalledWith("click", captureClickListeners[0], true);
     expect(removeDocumentListener).not.toHaveBeenCalledWith(
       "click",
@@ -740,7 +742,7 @@ describe("chat pane presentation teardown", () => {
       sessions: {} as SessionCapability,
     });
     window.localStorage.removeItem(SKIP_REWIND_CONFIRM_PREFERENCE);
-    const owner = createConfirmationOwner();
+    const confirmation = createConfirmationOwner();
 
     try {
       for (const callback of frameCallbacks.splice(0)) {
@@ -754,7 +756,7 @@ describe("chat pane presentation teardown", () => {
       )?.[1];
       expect(captureClickListener).toBeDefined();
       expect(captureKeydownListener).toBeDefined();
-      pane.appendChild(owner);
+      pane.appendChild(confirmation.owner);
 
       const stopAfterReset = new Error("stop after thread presentation reset");
       vi.spyOn(pane, "cancelHeaderRename").mockImplementation(() => {
@@ -762,12 +764,12 @@ describe("chat pane presentation teardown", () => {
       });
 
       expect(() => pane.switchPaneSession("agent:main:next")).toThrow(stopAfterReset);
-      expect(owner.querySelector(".chat-delete-confirm")).toBeNull();
+      expect(confirmation.popover.isConnected).toBe(false);
       expect(removeDocumentListener).toHaveBeenCalledWith("click", captureClickListener, true);
       expect(removeWindowListener).toHaveBeenCalledWith("keydown", captureKeydownListener, true);
     } finally {
-      dismissConfirmedActionPopovers(owner);
-      owner.remove();
+      dismissConfirmedActionPopovers(confirmation.owner);
+      confirmation.owner.remove();
     }
   });
 });

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5768,13 +5768,14 @@ describe("right-click Reply", () => {
     section.appendChild(confirmationOwner);
     window.localStorage.removeItem("openclaw:skip-rewind-confirm");
     chatMessage.openChatRewindConfirmation(confirmationTrigger, vi.fn());
+    const confirmation = document.querySelector<HTMLElement>(".chat-delete-confirm");
     const { bubble } = appendChatBubble(container, { text: "open message actions" });
 
     try {
-      expect(confirmationOwner.querySelector(".chat-delete-confirm")).not.toBeNull();
+      expect(confirmation?.isConnected).toBe(true);
       bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
 
-      expect(confirmationOwner.querySelector(".chat-delete-confirm")).toBeNull();
+      expect(confirmation?.isConnected).toBe(false);
       expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
     } finally {
       chatMessage.dismissConfirmedActionPopovers(confirmationOwner);
@@ -5924,9 +5925,7 @@ describe("right-click Reply", () => {
     rewindButton!.click();
     flushFrames();
 
-    const cancel = document.querySelector<HTMLButtonElement>(
-      ".chat-reply-context-menu .chat-delete-confirm__cancel",
-    );
+    const cancel = document.querySelector<HTMLButtonElement>(".chat-delete-confirm__cancel");
     expect(cancel).toBeInstanceOf(HTMLButtonElement);
     expect(document.activeElement).toBe(cancel);
     const confirmationEscape = new KeyboardEvent("keydown", {

--- a/ui/src/pages/chat/components/chat-message-confirmation.ts
+++ b/ui/src/pages/chat/components/chat-message-confirmation.ts
@@ -13,6 +13,9 @@ type DeleteConfirmDismissOptions = { restoreFocus?: boolean };
 type DeleteConfirmDismisser = (options?: DeleteConfirmDismissOptions) => void;
 
 const deleteConfirmDismissers = new WeakMap<Element, DeleteConfirmDismisser>();
+const deleteConfirmOwners = new WeakMap<Element, Element>();
+const deleteConfirmPopovers = new Set<HTMLElement>();
+const deleteConfirmPopoversByOwner = new WeakMap<Element, HTMLElement>();
 
 function shouldSkipActionConfirm(preferenceName: string): boolean {
   try {
@@ -32,9 +35,12 @@ function dismissDeleteConfirm(element: Element, options?: DeleteConfirmDismissOp
 }
 
 export function dismissConfirmedActionPopovers(owner: ParentNode): void {
-  owner.querySelectorAll(".chat-delete-confirm").forEach((popover) => {
-    dismissDeleteConfirm(popover);
-  });
+  for (const popover of deleteConfirmPopovers) {
+    const popoverOwner = deleteConfirmOwners.get(popover);
+    if (popoverOwner && owner instanceof Node && owner.contains(popoverOwner)) {
+      dismissDeleteConfirm(popover);
+    }
+  }
 }
 
 function resolveViewportBounds() {
@@ -179,7 +185,8 @@ function openConfirmedActionPopover(
   if (!wrap) {
     return;
   }
-  const existing = wrap.querySelector(".chat-delete-confirm");
+  const owner = wrap;
+  const existing = deleteConfirmPopoversByOwner.get(owner);
   if (existing) {
     dismissDeleteConfirm(existing, { restoreFocus: true });
     return;
@@ -208,22 +215,33 @@ function openConfirmedActionPopover(
   if (confirmButton) {
     confirmButton.textContent = params.confirmLabel;
   }
-  wrap.appendChild(popover);
+  // Virtual transcript rows use transforms for positioning, which makes fixed
+  // descendants relative to the row instead of the viewport. Portal the dialog
+  // so the viewport-clamped coordinates stay correct in web and native hosts.
+  owner.ownerDocument.body.appendChild(popover);
+  deleteConfirmOwners.set(popover, owner);
+  deleteConfirmPopovers.add(popover);
+  deleteConfirmPopoversByOwner.set(owner, popover);
   placeDeleteConfirmPopover(btn, popover, params.side);
 
   const cancel = popover.querySelector<HTMLButtonElement>(".chat-delete-confirm__cancel")!;
   const yes = popover.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes")!;
   const check = popover.querySelector<HTMLInputElement>(".chat-delete-confirm__check")!;
   let dismissed = false;
+  let ownerObserver: MutationObserver | null = null;
   function dismissPopover(options?: DeleteConfirmDismissOptions) {
     if (dismissed) {
       return;
     }
     dismissed = true;
+    ownerObserver?.disconnect();
     document.removeEventListener("click", closeOnOutside, true);
     document.removeEventListener("contextmenu", closeOnContextMenu, true);
     window.removeEventListener("keydown", closeOnEscape, true);
     deleteConfirmDismissers.delete(popover);
+    deleteConfirmOwners.delete(popover);
+    deleteConfirmPopovers.delete(popover);
+    deleteConfirmPopoversByOwner.delete(owner);
     popover.remove();
     if (options?.restoreFocus && btn.isConnected) {
       btn.focus({ preventScroll: true });
@@ -277,6 +295,12 @@ function openConfirmedActionPopover(
   popover.addEventListener("keydown", containKeyboardFocus);
   document.addEventListener("contextmenu", closeOnContextMenu, true);
   window.addEventListener("keydown", closeOnEscape, true);
+  ownerObserver = new MutationObserver(() => {
+    if (!wrap.isConnected || !btn.isConnected) {
+      dismissPopover();
+    }
+  });
+  ownerObserver.observe(wrap.ownerDocument.body, { childList: true, subtree: true });
   cancel.focus({ preventScroll: true });
   requestAnimationFrame(() => {
     if (!dismissed && popover.isConnected) {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -528,29 +528,30 @@ function setupArmedDeleteConfirm() {
   const outsideClickListener = expectLastCaptureClickListener(addListenerSpy.mock.calls);
   const outsideContextMenuListener = getLastCaptureContextMenuListener(addListenerSpy.mock.calls);
   const escapeListener = getLastCaptureKeydownListener(addKeyListenerSpy.mock.calls);
+  const popover = expectElement(document.body, ".chat-delete-confirm", HTMLElement);
   expect(typeof outsideContextMenuListener).toBe("function");
   expect(typeof escapeListener).toBe("function");
-  expect(fixture.container.querySelectorAll(".chat-delete-confirm")).toHaveLength(1);
 
   return {
     ...fixture,
     escapeListener,
     outsideClickListener,
     outsideContextMenuListener,
+    popover,
     removeKeyListenerSpy,
     removeListenerSpy,
   };
 }
 
 function expectDeleteConfirmDismissed(params: {
-  container: HTMLElement;
   escapeListener: unknown;
   outsideClickListener: unknown;
   outsideContextMenuListener: unknown;
+  popover: HTMLElement;
   removeKeyListenerSpy: ReturnType<typeof vi.spyOn>;
   removeListenerSpy: ReturnType<typeof vi.spyOn>;
 }) {
-  expect(params.container.querySelector(".chat-delete-confirm")).toBeNull();
+  expect(params.popover.isConnected).toBe(false);
   expect(
     countCaptureClickListenerRemovals(
       params.removeListenerSpy.mock.calls,
@@ -1010,9 +1011,7 @@ describe("grouped chat rendering", () => {
       expect(userDeleteButton).toBeInstanceOf(HTMLButtonElement);
       userDeleteButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
-      const userConfirm = container.querySelector<HTMLElement>(
-        ".chat-group.user .chat-delete-confirm",
-      );
+      const userConfirm = document.querySelector<HTMLElement>(".chat-delete-confirm--left");
       expect(userConfirm).toBeInstanceOf(HTMLElement);
       expect([...userConfirm!.classList]).toEqual([
         "chat-delete-confirm",
@@ -1025,9 +1024,7 @@ describe("grouped chat rendering", () => {
       expect(assistantDeleteButton).toBeInstanceOf(HTMLButtonElement);
       assistantDeleteButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
-      const assistantConfirm = container.querySelector<HTMLElement>(
-        ".chat-group.assistant .chat-delete-confirm",
-      );
+      const assistantConfirm = document.querySelector<HTMLElement>(".chat-delete-confirm--right");
       expect(assistantConfirm).toBeInstanceOf(HTMLElement);
       expect([...assistantConfirm!.classList]).toEqual([
         "chat-delete-confirm",
@@ -1054,10 +1051,10 @@ describe("grouped chat rendering", () => {
     const rewindButtons = container.querySelectorAll<HTMLButtonElement>(".chat-group-rewind");
     expect(rewindButtons).toHaveLength(1);
     rewindButtons[0]!.click();
-    expect(container.querySelector(".chat-delete-confirm__text")?.textContent).toBe(
+    expect(document.querySelector(".chat-delete-confirm__text")?.textContent).toBe(
       "Rewind to before this message?",
     );
-    container.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes")!.click();
+    document.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes")!.click();
     expect(onRewind).toHaveBeenCalledTimes(1);
   });
 
@@ -1116,7 +1113,8 @@ describe("grouped chat rendering", () => {
 
     openDeleteConfirm(fixture.deleteButton);
 
-    const element = expectElement(fixture.container, ".chat-delete-confirm", HTMLElement);
+    const element = expectElement(document.body, ".chat-delete-confirm", HTMLElement);
+    expect(element.parentElement).toBe(document.body);
     if (placement) {
       expect(element.dataset.placement).toBe(placement);
     }
@@ -1130,7 +1128,7 @@ describe("grouped chat rendering", () => {
 
     openDeleteConfirm(fixture.deleteButton);
 
-    const popover = expectElement(fixture.container, ".chat-delete-confirm", HTMLElement);
+    const popover = expectElement(document.body, ".chat-delete-confirm", HTMLElement);
     const check = expectElement(popover, ".chat-delete-confirm__check", HTMLInputElement);
     const cancel = expectElement(popover, ".chat-delete-confirm__cancel", HTMLButtonElement);
     const confirm = expectElement(popover, ".chat-delete-confirm__yes", HTMLButtonElement);
@@ -1165,7 +1163,7 @@ describe("grouped chat rendering", () => {
   it("dismisses the confirmation with Escape before underlying keyboard handlers run", () => {
     const fixture = setupArmedDeleteConfirm();
     const cancel = expectElement(
-      fixture.container,
+      fixture.popover,
       ".chat-delete-confirm__cancel",
       HTMLButtonElement,
     );
@@ -1194,12 +1192,24 @@ describe("grouped chat rendering", () => {
     const fixture = setupArmedDeleteConfirm();
     const sibling = renderDeleteConfirmFixture();
     openDeleteConfirm(sibling.deleteButton);
+    const siblingPopover = [...document.querySelectorAll<HTMLElement>(".chat-delete-confirm")].find(
+      (popover) => popover !== fixture.popover,
+    );
 
     dismissConfirmedActionPopovers(fixture.container);
 
     expectDeleteConfirmDismissed(fixture);
-    expect(sibling.container.querySelector(".chat-delete-confirm")).not.toBeNull();
+    expect(siblingPopover?.isConnected).toBe(true);
     dismissConfirmedActionPopovers(sibling.container);
+  });
+
+  it("dismisses a portaled confirmation when its owner is detached", async () => {
+    const fixture = setupArmedDeleteConfirm();
+
+    fixture.container.remove();
+    await Promise.resolve();
+
+    expectDeleteConfirmDismissed(fixture);
   });
 
   it("does not attach an outside-click listener after owner cleanup before the next frame", () => {
@@ -1218,7 +1228,7 @@ describe("grouped chat rendering", () => {
     dismissConfirmedActionPopovers(fixture.container);
     flushAnimationFrames();
 
-    expect(fixture.container.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(document.querySelector(".chat-delete-confirm")).toBeNull();
     expect(getLastCaptureClickListener(addListenerSpy.mock.calls)).toBeNull();
     expect(
       countCaptureContextMenuListenerRemovals(removeListenerSpy.mock.calls, contextMenuListener),
@@ -1230,9 +1240,7 @@ describe("grouped chat rendering", () => {
 
   it("removes the delete confirm outside-click listener when Cancel dismisses it", () => {
     const fixture = setupArmedDeleteConfirm();
-    const cancel = fixture.container.querySelector<HTMLButtonElement>(
-      ".chat-delete-confirm__cancel",
-    );
+    const cancel = fixture.popover.querySelector<HTMLButtonElement>(".chat-delete-confirm__cancel");
 
     expect(cancel).toBeInstanceOf(HTMLButtonElement);
     cancel!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -1244,7 +1252,7 @@ describe("grouped chat rendering", () => {
 
   it("removes the delete confirm outside-click listener when Delete dismisses it", () => {
     const fixture = setupArmedDeleteConfirm();
-    const confirm = fixture.container.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes");
+    const confirm = fixture.popover.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes");
 
     expect(confirm).toBeInstanceOf(HTMLButtonElement);
     confirm!.focus();
@@ -1299,7 +1307,7 @@ describe("grouped chat rendering", () => {
     openDeleteConfirm(fixture.deleteButton);
     flushAnimationFrames();
 
-    expect(fixture.container.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(document.querySelector(".chat-delete-confirm")).toBeNull();
     expect(getLastCaptureClickListener(addListenerSpy.mock.calls)).toBeNull();
     expect(fixture.onDelete).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users hiding a chat message could see the confirmation dialog rendered partly or entirely outside the viewport when the message was inside a virtualized transcript row. The same shared Control UI path affects the browser UI and the macOS app.

## Why This Change Was Made

Render the hide confirmation at the document root so transformed virtual rows cannot redefine its fixed-position containing block. The change preserves owner-scoped dismissal and removes the dialog if its message owner detaches.

## User Impact

The “Hide in this browser only” confirmation now stays fully visible and usable in virtualized chats, including the macOS app.

## Evidence

- Fresh autoreview on the rebased patch: clean, no actionable findings.
- Blacksmith Testbox: 352 shared UI tests and 19 isolated lifecycle tests passed.
- Playwright UI E2E: 1 test passed; verifies the trigger is inside a transformed virtual row, the dialog is portaled to `document.body`, and its bounds remain inside the viewport.
- UI production and test type lanes passed after the CI-reported nullable-owner narrowing fix: https://github.com/openclaw/openclaw/actions/runs/30459282661
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30458228949
- `git diff --check` passed.
