### PR TITLE
fix(logging): prevent Vitest exit listener leaks

### DIFF
--- a/src/logging/logger-file-transport.test.ts
+++ b/src/logging/logger-file-transport.test.ts
@@ -31,6 +31,26 @@ afterAll(async () => {
 });
 
 describe("async logger file transport", () => {
+  it("installs process hooks only while file logging is active", () => {
+    const beforeExitListeners = process.listenerCount("beforeExit");
+    const exitListeners = process.listenerCount("exit");
+    const logPath = logPathTracker.nextPath();
+    setLoggerOverride({ level: "info", file: logPath });
+
+    expect(process.listenerCount("beforeExit")).toBe(beforeExitListeners);
+    expect(process.listenerCount("exit")).toBe(exitListeners);
+
+    getLogger().info("install-file-transport-hooks");
+
+    expect(process.listenerCount("beforeExit")).toBe(beforeExitListeners + 1);
+    expect(process.listenerCount("exit")).toBe(exitListeners + 1);
+
+    testApi.resetFileLogTransportForTests();
+
+    expect(process.listenerCount("beforeExit")).toBe(beforeExitListeners);
+    expect(process.listenerCount("exit")).toBe(exitListeners);
+  });
+
   it("writes queued records in order and byte-identically to the synchronous drain", async () => {
     const syncPath = logPathTracker.nextPath();
     const asyncPath = logPathTracker.nextPath();

--- a/src/logging/logger-file-transport.ts
+++ b/src/logging/logger-file-transport.ts
@@ -36,6 +36,7 @@ let scheduledFlush: NodeJS.Immediate | null = null;
 let flushPromise: Promise<void> | null = null;
 let drainGeneration = 0;
 let processExiting = false;
+let processHooksInstalled = false;
 let appendFile: FileLogAppender = appendRegularFile;
 const warnedRotationFiles = new Map<string, number>();
 
@@ -248,13 +249,38 @@ function scheduleFlush(): void {
   });
 }
 
-process.on("beforeExit", () => {
+function handleProcessBeforeExit(): void {
   void flushFileLogQueue();
-});
-process.on("exit", () => {
+}
+
+function handleProcessExit(): void {
   processExiting = true;
   drainFileLogQueueSync();
-});
+}
+
+function installProcessHooks(): void {
+  if (processHooksInstalled) {
+    return;
+  }
+  processHooksInstalled = true;
+  process.on("beforeExit", handleProcessBeforeExit);
+  process.on("exit", handleProcessExit);
+}
+
+function removeProcessHooks(): void {
+  if (!processHooksInstalled) {
+    return;
+  }
+  process.removeListener("beforeExit", handleProcessBeforeExit);
+  process.removeListener("exit", handleProcessExit);
+  processHooksInstalled = false;
+}
+
+// Production installs eagerly so logs emitted by another exit listener are still rescued.
+// Vitest shared workers reload modules, so defer there until file logging is actually used.
+if (process.env.VITEST !== "true") {
+  installProcessHooks();
+}
 
 /** Enqueues one serialized record without waiting for filesystem I/O. */
 export function enqueueFileLog(entry: FileLogQueueEntry): void {
@@ -262,6 +288,7 @@ export function enqueueFileLog(entry: FileLogQueueEntry): void {
     writeEntriesSync([entry]);
     return;
   }
+  installProcessHooks();
   // Keep the newest diagnostics and report every eviction once in the next drain batch.
   if (queue.length >= maxQueuedRecords) {
     const dropped = queue[queueStart];
@@ -322,6 +349,8 @@ export function setFileLogAppenderForTests(value?: FileLogAppender): void {
 
 export function resetFileLogTransportForTests(): void {
   drainFileLogQueueSync();
+  removeProcessHooks();
+  processExiting = false;
   appendFile = appendRegularFile;
   maxQueuedRecords = DEFAULT_MAX_QUEUED_RECORDS;
   warnedRotationFiles.clear();


### PR DESCRIPTION
Related: #115696

## What Problem This Solves

Resolves a problem where shared Vitest workers could accumulate process exit listeners when the file transport module was reloaded, producing `MaxListenersExceededWarning` noise and eventual worker exits in broad test runs.

## Why This Change Was Made

Keeps production exit hooks eager so late shutdown logs remain recoverable, while Vitest installs them only when file logging starts and removes them during the existing test reset lifecycle.

## User Impact

Maintainers get stable broad-suite execution without leaked logger lifecycle handlers. Production logging behavior is unchanged.

## Evidence

- Rebased onto current `main` at `fde4658bf6` and reran focused Blacksmith Testbox proof.
- Blacksmith Testbox `tbx_01kyq3svnjh79p9exn5xm6zvp5`: logger-file-transport and logger-transport passed 7/7; formatting passed.
- Refreshed run: https://github.com/openclaw/openclaw/actions/runs/30460148325
- An earlier traced broad agentic run identified the leaked listener at `src/logging/logger-file-transport.ts`; the regression test verifies install/reset symmetry.
- `git diff --check` passed.
- Fresh autoreview completed with no actionable findings.