### PR TITLE
perf(gateway): serve config.get from the watcher-owned cache and collapse duplicate session listings

### DIFF
--- a/src/gateway/config-get-response.test.ts
+++ b/src/gateway/config-get-response.test.ts
@@ -1,12 +1,9 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 
 const mocks = vi.hoisted(() => ({
   appliedConfigHash: "applied-1" as string | null,
-  configPath: "",
   pluginRegistryVersion: 1,
   readConfigFileSnapshot: vi.fn<() => Promise<ConfigFileSnapshot>>(),
 }));
@@ -15,7 +12,6 @@ vi.mock("../config/config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/config.js")>();
   return {
     ...actual,
-    createConfigIO: () => ({ configPath: mocks.configPath }),
     readConfigFileSnapshot: mocks.readConfigFileSnapshot,
   };
 });
@@ -35,11 +31,12 @@ vi.mock("../plugins/runtime.js", () => ({
 const { invalidateConfigGetResponseCache, readConfigGetResponse } =
   await import("./config-get-response.js");
 
-const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-get-cache-"));
+const activeWatcher = () => "active" as const;
+const disabledWatcher = () => "disabled" as const;
 
 function configSnapshot(sourceConfig: OpenClawConfig): ConfigFileSnapshot {
   return {
-    path: mocks.configPath,
+    path: "/tmp/openclaw.json",
     exists: true,
     raw: JSON.stringify(sourceConfig),
     parsed: sourceConfig,
@@ -54,18 +51,12 @@ function configSnapshot(sourceConfig: OpenClawConfig): ConfigFileSnapshot {
   } as ConfigFileSnapshot;
 }
 
-beforeEach(async () => {
+beforeEach(() => {
   invalidateConfigGetResponseCache();
   mocks.appliedConfigHash = "applied-1";
   mocks.pluginRegistryVersion = 1;
-  mocks.configPath = path.join(tempRoot, "openclaw.json");
-  await fs.writeFile(mocks.configPath, '{"gateway":{"port":19001}}\n');
   mocks.readConfigFileSnapshot.mockReset();
   mocks.readConfigFileSnapshot.mockResolvedValue(configSnapshot({ gateway: { port: 19_001 } }));
-});
-
-afterAll(async () => {
-  await fs.rm(tempRoot, { recursive: true, force: true });
 });
 
 afterEach(() => {
@@ -73,55 +64,91 @@ afterEach(() => {
 });
 
 describe("config.get response cache", () => {
-  it("shares a stable response across concurrent and settled callers", async () => {
+  it("serves identical bytes without filesystem work on an active-watcher cache hit", async () => {
     const loadUiHints = vi.fn(() => undefined);
+    const first = await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
+    const stat = vi.spyOn(fs.promises, "stat");
+    mocks.readConfigFileSnapshot.mockClear();
+    loadUiHints.mockClear();
 
-    const concurrent = await Promise.all(
-      Array.from({ length: 8 }, () => readConfigGetResponse({ loadUiHints })),
-    );
-    const settled = await readConfigGetResponse({ loadUiHints });
+    const hit = await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
 
-    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(1);
-    expect(loadUiHints).toHaveBeenCalledTimes(1);
-    expect(concurrent.every((response) => response === concurrent[0])).toBe(true);
-    expect(settled).toBe(concurrent[0]);
-  });
-
-  it("rebuilds for file stamps, applied config revisions, and plugin schema generations", async () => {
-    const loadUiHints = vi.fn(() => undefined);
-    await readConfigGetResponse({ loadUiHints });
-
-    await fs.writeFile(mocks.configPath, '{"gateway":{"port":190012}}\n');
-    await readConfigGetResponse({ loadUiHints });
-
-    mocks.appliedConfigHash = "applied-2";
-    await readConfigGetResponse({ loadUiHints });
-
-    mocks.pluginRegistryVersion = 2;
-    await readConfigGetResponse({ loadUiHints });
-
-    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(4);
-    expect(loadUiHints).toHaveBeenCalledTimes(4);
-  });
-
-  it("rebuilds immediately after explicit write-path invalidation", async () => {
-    const loadUiHints = vi.fn(() => undefined);
-    await readConfigGetResponse({ loadUiHints });
+    expect(hit).toBe(first);
+    expect(stat).not.toHaveBeenCalled();
+    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+    expect(loadUiHints).not.toHaveBeenCalled();
 
     invalidateConfigGetResponseCache();
-    await readConfigGetResponse({ loadUiHints });
+    const fresh = await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
+    expect(hit).toEqual(fresh);
+  });
+
+  it("shares one projection across concurrent active-watcher callers", async () => {
+    const loadUiHints = vi.fn(() => undefined);
+
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints }),
+      ),
+    );
+
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledOnce();
+    expect(loadUiHints).toHaveBeenCalledOnce();
+    expect(responses.every((response) => response === responses[0])).toBe(true);
+  });
+
+  it("evicts a failed projection instead of retaining its rejected promise", async () => {
+    const loadUiHints = vi.fn(() => undefined);
+    mocks.readConfigFileSnapshot.mockRejectedValueOnce(new Error("transient read failure"));
+
+    await expect(
+      readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints }),
+    ).rejects.toThrow("transient read failure");
+    await expect(
+      readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints }),
+    ).resolves.toMatchObject({ appliedConfigHash: "applied-1" });
 
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
   });
 
-  it("revalidates an unchanged file stamp after the bounded cache window", async () => {
-    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+  it("rebuilds when the active plugin metadata generation changes", async () => {
     const loadUiHints = vi.fn(() => undefined);
-    await readConfigGetResponse({ loadUiHints });
+    await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
 
-    now.mockReturnValue(6_001);
+    mocks.pluginRegistryVersion = 2;
+    await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
+
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
+    expect(loadUiHints).toHaveBeenCalledTimes(2);
+  });
+
+  it("rebuilds immediately after watcher or write-path invalidation", async () => {
+    const loadUiHints = vi.fn(() => undefined);
+    await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
+
+    invalidateConfigGetResponseCache();
+    await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
+
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("bypasses the cache when hot reload is disabled", async () => {
+    const loadUiHints = vi.fn(() => undefined);
+
+    await readConfigGetResponse({ getHotReloadStatus: disabledWatcher, loadUiHints });
+    await readConfigGetResponse({ getHotReloadStatus: disabledWatcher, loadUiHints });
+
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
+    expect(loadUiHints).toHaveBeenCalledTimes(2);
+  });
+
+  it("bypasses the cache when no config watcher status is available", async () => {
+    const loadUiHints = vi.fn(() => undefined);
+
+    await readConfigGetResponse({ loadUiHints });
     await readConfigGetResponse({ loadUiHints });
 
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
+    expect(loadUiHints).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/gateway/config-get-response.test.ts
+++ b/src/gateway/config-get-response.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
+
+const mocks = vi.hoisted(() => ({
+  appliedConfigHash: "applied-1" as string | null,
+  configPath: "",
+  pluginRegistryVersion: 1,
+  readConfigFileSnapshot: vi.fn<() => Promise<ConfigFileSnapshot>>(),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    createConfigIO: () => ({ configPath: mocks.configPath }),
+    readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+  };
+});
+
+vi.mock("../config/runtime-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/runtime-snapshot.js")>();
+  return {
+    ...actual,
+    getRuntimeConfigAppliedHash: () => mocks.appliedConfigHash,
+  };
+});
+
+vi.mock("../plugins/runtime.js", () => ({
+  getActivePluginRegistryVersion: () => mocks.pluginRegistryVersion,
+}));
+
+const { invalidateConfigGetResponseCache, readConfigGetResponse } =
+  await import("./config-get-response.js");
+
+const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-get-cache-"));
+
+function configSnapshot(sourceConfig: OpenClawConfig): ConfigFileSnapshot {
+  return {
+    path: mocks.configPath,
+    exists: true,
+    raw: JSON.stringify(sourceConfig),
+    parsed: sourceConfig,
+    sourceConfig,
+    resolved: sourceConfig,
+    valid: true,
+    runtimeConfig: sourceConfig,
+    config: sourceConfig,
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
+  } as ConfigFileSnapshot;
+}
+
+beforeEach(async () => {
+  invalidateConfigGetResponseCache();
+  mocks.appliedConfigHash = "applied-1";
+  mocks.pluginRegistryVersion = 1;
+  mocks.configPath = path.join(tempRoot, "openclaw.json");
+  await fs.writeFile(mocks.configPath, '{"gateway":{"port":19001}}\n');
+  mocks.readConfigFileSnapshot.mockReset();
+  mocks.readConfigFileSnapshot.mockResolvedValue(configSnapshot({ gateway: { port: 19_001 } }));
+});
+
+afterAll(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("config.get response cache", () => {
+  it("shares a stable response across concurrent and settled callers", async () => {
+    const loadUiHints = vi.fn(() => undefined);
+
+    const concurrent = await Promise.all(
+      Array.from({ length: 8 }, () => readConfigGetResponse({ loadUiHints })),
+    );
+    const settled = await readConfigGetResponse({ loadUiHints });
+
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(1);
+    expect(loadUiHints).toHaveBeenCalledTimes(1);
+    expect(concurrent.every((response) => response === concurrent[0])).toBe(true);
+    expect(settled).toBe(concurrent[0]);
+  });
+
+  it("rebuilds for file stamps, applied config revisions, and plugin schema generations", async () => {
+    const loadUiHints = vi.fn(() => undefined);
+    await readConfigGetResponse({ loadUiHints });
+
+    await fs.writeFile(mocks.configPath, '{"gateway":{"port":190012}}\n');
+    await readConfigGetResponse({ loadUiHints });
+
+    mocks.appliedConfigHash = "applied-2";
+    await readConfigGetResponse({ loadUiHints });
+
+    mocks.pluginRegistryVersion = 2;
+    await readConfigGetResponse({ loadUiHints });
+
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(4);
+    expect(loadUiHints).toHaveBeenCalledTimes(4);
+  });
+
+  it("rebuilds immediately after explicit write-path invalidation", async () => {
+    const loadUiHints = vi.fn(() => undefined);
+    await readConfigGetResponse({ loadUiHints });
+
+    invalidateConfigGetResponseCache();
+    await readConfigGetResponse({ loadUiHints });
+
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("revalidates an unchanged file stamp after the bounded cache window", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const loadUiHints = vi.fn(() => undefined);
+    await readConfigGetResponse({ loadUiHints });
+
+    now.mockReturnValue(6_001);
+    await readConfigGetResponse({ loadUiHints });
+
+    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/gateway/config-get-response.ts
+++ b/src/gateway/config-get-response.ts
@@ -1,8 +1,36 @@
+import fs from "node:fs";
+import { createConfigIO, readConfigFileSnapshot } from "../config/config.js";
 import { redactConfigSnapshot } from "../config/redact-snapshot.js";
 import { getRuntimeConfigAppliedHash, hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
+import { getActivePluginRegistryVersion } from "../plugins/runtime.js";
 
-export function createConfigGetResponse(
+type ConfigGetResponse = ReturnType<typeof createConfigGetResponse>;
+const CONFIG_GET_REVALIDATE_MS = 5_000;
+let configGetResponseCache:
+  | { expiresAt: number; key: string; promise: Promise<ConfigGetResponse> }
+  | undefined;
+
+async function configGetResponseCacheKey(configPath: string): Promise<string | undefined> {
+  let stamp: [mtimeMs: number | null, size: number];
+  try {
+    const stat = await fs.promises.stat(configPath);
+    stamp = [stat.mtimeMs, stat.size];
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      return undefined;
+    }
+    stamp = [null, 0];
+  }
+  return JSON.stringify([
+    configPath,
+    ...stamp,
+    getRuntimeConfigAppliedHash(),
+    getActivePluginRegistryVersion(),
+  ]);
+}
+
+function createConfigGetResponse(
   snapshot: ConfigFileSnapshot,
   uiHints: Parameters<typeof redactConfigSnapshot>[1],
 ) {
@@ -11,4 +39,35 @@ export function createConfigGetResponse(
     configRevisionHash: hashRuntimeConfigValue(snapshot.sourceConfig),
     appliedConfigHash: getRuntimeConfigAppliedHash(),
   };
+}
+
+/** Reads and projects config.get once per on-disk, runtime, and plugin-schema revision. */
+export async function readConfigGetResponse(params: {
+  loadUiHints: () => Parameters<typeof redactConfigSnapshot>[1];
+}): Promise<ConfigGetResponse> {
+  const path = createConfigIO().configPath;
+  const key = await configGetResponseCacheKey(path);
+  if (!key) {
+    return createConfigGetResponse(await readConfigFileSnapshot(), params.loadUiHints());
+  }
+  if (configGetResponseCache?.key === key && configGetResponseCache.expiresAt > Date.now()) {
+    return await configGetResponseCache.promise;
+  }
+
+  const promise = (async () =>
+    createConfigGetResponse(await readConfigFileSnapshot(), params.loadUiHints()))();
+  configGetResponseCache = { expiresAt: Date.now() + CONFIG_GET_REVALIDATE_MS, key, promise };
+  try {
+    return await promise;
+  } catch (error) {
+    if (configGetResponseCache?.promise === promise) {
+      configGetResponseCache = undefined;
+    }
+    throw error;
+  }
+}
+
+/** Invalidates cached config.get work after the canonical config write commits. */
+export function invalidateConfigGetResponseCache(): void {
+  configGetResponseCache = undefined;
 }

--- a/src/gateway/config-get-response.ts
+++ b/src/gateway/config-get-response.ts
@@ -1,34 +1,19 @@
-import fs from "node:fs";
-import { createConfigIO, readConfigFileSnapshot } from "../config/config.js";
+import { readConfigFileSnapshot } from "../config/config.js";
 import { redactConfigSnapshot } from "../config/redact-snapshot.js";
 import { getRuntimeConfigAppliedHash, hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
 import { getActivePluginRegistryVersion } from "../plugins/runtime.js";
+import type { GatewayHotReloadStatus } from "./config-reload-status.types.js";
 
 type ConfigGetResponse = ReturnType<typeof createConfigGetResponse>;
-const CONFIG_GET_REVALIDATE_MS = 5_000;
 let configGetResponseCache:
-  | { expiresAt: number; key: string; promise: Promise<ConfigGetResponse> }
-  | undefined;
-
-async function configGetResponseCacheKey(configPath: string): Promise<string | undefined> {
-  let stamp: [mtimeMs: number | null, size: number];
-  try {
-    const stat = await fs.promises.stat(configPath);
-    stamp = [stat.mtimeMs, stat.size];
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      return undefined;
+  | {
+      getHotReloadStatus: () => GatewayHotReloadStatus | undefined;
+      appliedConfigHash: string | null;
+      pluginRegistryVersion: number;
+      promise: Promise<ConfigGetResponse>;
     }
-    stamp = [null, 0];
-  }
-  return JSON.stringify([
-    configPath,
-    ...stamp,
-    getRuntimeConfigAppliedHash(),
-    getActivePluginRegistryVersion(),
-  ]);
-}
+  | undefined;
 
 function createConfigGetResponse(
   snapshot: ConfigFileSnapshot,
@@ -41,22 +26,36 @@ function createConfigGetResponse(
   };
 }
 
-/** Reads and projects config.get once per on-disk, runtime, and plugin-schema revision. */
+/** Reads and projects config.get once per watcher-owned runtime and plugin-schema revision. */
 export async function readConfigGetResponse(params: {
+  getHotReloadStatus?: () => GatewayHotReloadStatus | undefined;
   loadUiHints: () => Parameters<typeof redactConfigSnapshot>[1];
 }): Promise<ConfigGetResponse> {
-  const path = createConfigIO().configPath;
-  const key = await configGetResponseCacheKey(path);
-  if (!key) {
+  const getHotReloadStatus = params.getHotReloadStatus;
+  if (!getHotReloadStatus || getHotReloadStatus() !== "active") {
     return createConfigGetResponse(await readConfigFileSnapshot(), params.loadUiHints());
   }
-  if (configGetResponseCache?.key === key && configGetResponseCache.expiresAt > Date.now()) {
+  const appliedConfigHash = getRuntimeConfigAppliedHash();
+  const pluginRegistryVersion = getActivePluginRegistryVersion();
+  // With an active watcher, cache hits never re-read the file. External edits
+  // become visible after its successful commit; the write path invalidates early.
+  if (
+    configGetResponseCache?.getHotReloadStatus === getHotReloadStatus &&
+    configGetResponseCache.appliedConfigHash === appliedConfigHash &&
+    configGetResponseCache.pluginRegistryVersion === pluginRegistryVersion
+  ) {
     return await configGetResponseCache.promise;
   }
 
   const promise = (async () =>
     createConfigGetResponse(await readConfigFileSnapshot(), params.loadUiHints()))();
-  configGetResponseCache = { expiresAt: Date.now() + CONFIG_GET_REVALIDATE_MS, key, promise };
+  configGetResponseCache = {
+    getHotReloadStatus,
+    appliedConfigHash,
+    // Metadata notification precedes registry activation; this version changes at handoff.
+    pluginRegistryVersion,
+    promise,
+  };
   try {
     return await promise;
   } catch (error) {
@@ -67,7 +66,7 @@ export async function readConfigGetResponse(params: {
   }
 }
 
-/** Invalidates cached config.get work after the canonical config write commits. */
+/** Invalidates cached config.get work after the watcher accepts a config candidate. */
 export function invalidateConfigGetResponseCache(): void {
   configGetResponseCache = undefined;
 }

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -305,6 +305,8 @@ export async function commitGatewayConfigWrite(params: {
     },
     afterWrite: { mode: "auto" },
   });
+  // Watcher acceptance is debounced; clear now so the writer's immediate
+  // follow-up config.get observes the committed bytes before that hook runs.
   invalidateConfigGetResponseCache();
   return {
     path: resolveGatewayConfigPath(params.snapshot),

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -18,6 +18,7 @@ import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime-state.js";
 import { isRecord } from "../../utils.js";
 import { resolveEffectiveSharedGatewayAuth, resolveGatewayAuth } from "../auth.js";
+import { invalidateConfigGetResponseCache } from "../config-get-response.js";
 import { buildGatewayReloadPlan, isNoopGatewayReloadPlan } from "../config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "../config-reload-settings.js";
 import { formatControlPlaneActor, type ControlPlaneActor } from "../control-plane-audit.js";
@@ -304,6 +305,7 @@ export async function commitGatewayConfigWrite(params: {
     },
     afterWrite: { mode: "auto" },
   });
+  invalidateConfigGetResponseCache();
   return {
     path: resolveGatewayConfigPath(params.snapshot),
     config: result.nextConfig,

--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -6,6 +6,8 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfigMutationConflictError } from "../../config/mutation-conflict.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import {
   clearConfigSchemaResponseCacheForTests,
@@ -139,6 +141,7 @@ async function invokeConfigOpenFile() {
 afterEach(() => {
   vi.useRealTimers();
   clearConfigSchemaResponseCacheForTests();
+  resetPluginRuntimeStateForTest();
   vi.clearAllMocks();
 });
 
@@ -258,11 +261,9 @@ describe("config schema response cache", () => {
     expect(loadGatewayRuntimeConfigSchemaMock).toHaveBeenCalledTimes(2);
   });
 
-  it("does not cache schema responses when cache expiry would exceed Date range", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(8_640_000_000_000_000));
-
+  it("rebuilds when the active plugin registry generation changes", () => {
     loadConfigSchemaResponseForTests();
+    setActivePluginRegistry(createTestRegistry([]));
     loadConfigSchemaResponseForTests();
 
     expect(loadGatewayRuntimeConfigSchemaMock).toHaveBeenCalledTimes(2);

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,9 +1,5 @@
 // Config gateway methods: validation, redaction, secrets, reload planning.
 import { isDeepStrictEqual } from "node:util";
-import {
-  asDateTimestampMs,
-  resolveExpiresAtMsFromDurationMs,
-} from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import {
@@ -46,6 +42,7 @@ import {
 import { isBuiltInModelProviderOverlayId } from "../../config/zod-schema.core.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isPlainObject } from "../../infra/plain-object.js";
+import { getActivePluginRegistryVersion } from "../../plugins/runtime.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import {
   isRetryableSecretDegradationReason,
@@ -56,7 +53,7 @@ import {
   type PreparedSecretsRuntimeSnapshot,
 } from "../../secrets/runtime.js";
 import { diffConfigPaths } from "../config-diff.js";
-import { createConfigGetResponse } from "../config-get-response.js";
+import { invalidateConfigGetResponseCache, readConfigGetResponse } from "../config-get-response.js";
 import { resolveConfigReloadMetadata } from "../config-reload-plan.js";
 import {
   formatControlPlaneActor,
@@ -82,14 +79,13 @@ import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from ".
 import { assertValidParams } from "./validation.js";
 
 const MAX_CONFIG_ISSUES_IN_ERROR_MESSAGE = 3;
-const CONFIG_SCHEMA_RESPONSE_CACHE_TTL_MS = 5_000;
 // ui.prefs is the cross-device Control UI preference surface documented in docs/web/control-ui.md.
 // Leaf preferences are LWW so independent tabs/devices do not CAS-conflict on the whole config;
 // every other path keeps strict document CAS.
 const HASHLESS_PATCH_LWW_PATH_PREFIXES = ["ui.prefs"] as const;
 
 let configSchemaResponseCache: {
-  expiresAtMs: number;
+  pluginRegistryVersion: number;
   response: ConfigSchemaResponse;
 } | null = null;
 
@@ -655,6 +651,7 @@ function preparedSecretDegradationPayload(snapshot: PreparedSecretsRuntimeSnapsh
 
 export function clearConfigSchemaResponseCacheForTests() {
   configSchemaResponseCache = null;
+  invalidateConfigGetResponseCache();
 }
 
 export function loadConfigSchemaResponseForTests(): ConfigSchemaResponse {
@@ -749,32 +746,17 @@ function respondConfigPatchNoop(params: {
 }
 
 function loadSchemaWithPlugins(): ConfigSchemaResponse {
-  const now = asDateTimestampMs(Date.now());
-  const cachedExpiresAt =
-    configSchemaResponseCache === null
-      ? undefined
-      : asDateTimestampMs(configSchemaResponseCache.expiresAtMs);
+  const pluginRegistryVersion = getActivePluginRegistryVersion();
   if (
     configSchemaResponseCache &&
-    now !== undefined &&
-    cachedExpiresAt !== undefined &&
-    cachedExpiresAt > now
+    configSchemaResponseCache.pluginRegistryVersion === pluginRegistryVersion
   ) {
     return configSchemaResponseCache.response;
   }
-  if (configSchemaResponseCache) {
-    configSchemaResponseCache = null;
-  }
 
-  // Plugin schema loading is process-local; short caching avoids repeated UI lookups per render.
+  // Plugin schema metadata is process-stable until config write or registry activation.
   const response = loadGatewayRuntimeConfigSchema();
-  const expiresAtMs = resolveExpiresAtMsFromDurationMs(CONFIG_SCHEMA_RESPONSE_CACHE_TTL_MS);
-  if (expiresAtMs !== undefined) {
-    configSchemaResponseCache = {
-      expiresAtMs,
-      response,
-    };
-  }
+  configSchemaResponseCache = { pluginRegistryVersion, response };
   return response;
 }
 
@@ -843,9 +825,11 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateConfigGetParams, "config.get", respond)) {
       return;
     }
-    const snapshot = await readConfigFileSnapshot();
-    const schema = loadSchemaWithPlugins();
-    respond(true, createConfigGetResponse(snapshot, schema.uiHints), undefined);
+    respond(
+      true,
+      await readConfigGetResponse({ loadUiHints: () => loadSchemaWithPlugins().uiHints }),
+      undefined,
+    );
   },
   "config.schema": ({ params, respond }) => {
     if (!assertValidParams(params, validateConfigSchemaParams, "config.schema", respond)) {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -821,13 +821,16 @@ function diffConfigLeafPaths(prev: unknown, next: unknown, prefix = ""): string[
 }
 
 export const configHandlers: GatewayRequestHandlers = {
-  "config.get": async ({ params, respond }) => {
+  "config.get": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateConfigGetParams, "config.get", respond)) {
       return;
     }
     respond(
       true,
-      await readConfigGetResponse({ loadUiHints: () => loadSchemaWithPlugins().uiHints }),
+      await readConfigGetResponse({
+        getHotReloadStatus: context.getConfigReloaderHotReloadStatus,
+        loadUiHints: () => loadSchemaWithPlugins().uiHints,
+      }),
       undefined,
     );
   },

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
+import { upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
+
+const loader = vi.hoisted(() => ({ calls: vi.fn(), failNext: false }));
+
+vi.mock("../session-utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../session-utils.js")>();
+  return {
+    ...actual,
+    loadCombinedSessionStoreForGateway: (
+      ...args: Parameters<typeof actual.loadCombinedSessionStoreForGateway>
+    ) => {
+      loader.calls(...args);
+      if (loader.failNext) {
+        loader.failNext = false;
+        throw new Error("synthetic store load failure");
+      }
+      return actual.loadCombinedSessionStoreForGateway(...args);
+    },
+  };
+});
+
+const { sessionReadHandlers } = await import("./sessions-read.js");
+
+function identifiedClient(profileId: string): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
+      role: "operator",
+      scopes: ["operator.read", "operator.write"],
+    },
+    authenticatedUserProfile: {
+      profileId,
+      displayName: profileId,
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
+}
+
+function requestContext(config: OpenClawConfig): GatewayRequestContext {
+  return {
+    chatAbortControllers: new Map(),
+    getRuntimeConfig: () => config,
+    loadGatewayModelCatalog: async () => [],
+    logGateway: { debug: vi.fn() },
+  } as unknown as GatewayRequestContext;
+}
+
+async function listSessions(params: {
+  client: GatewayClient;
+  context: GatewayRequestContext;
+  request: SessionsListParams;
+}) {
+  const responses: Parameters<RespondFn>[] = [];
+  await sessionReadHandlers["sessions.list"]?.({
+    params: params.request,
+    client: params.client,
+    context: params.context,
+    respond: (...response: Parameters<RespondFn>) => responses.push(response),
+  } as never);
+  expect(responses).toHaveLength(1);
+  expect(responses[0]?.[0]).toBe(true);
+  return responses[0]?.[1] as { sessions: Array<{ key: string }> };
+}
+
+async function seedSessions(): Promise<OpenClawConfig> {
+  const config: OpenClawConfig = {
+    agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+  };
+  await upsertSessionEntry(
+    { agentId: "main", sessionKey: "agent:main:active" },
+    {
+      sessionId: "main-active",
+      updatedAt: 400,
+      createdActor: { type: "human", id: "owner@example.com" },
+      visibility: "shared",
+    },
+  );
+  await upsertSessionEntry(
+    { agentId: "main", sessionKey: "agent:main:draft" },
+    {
+      sessionId: "main-draft",
+      updatedAt: 300,
+      createdActor: { type: "human", id: "owner@example.com" },
+      visibility: "draft",
+    },
+  );
+  await upsertSessionEntry(
+    { agentId: "main", sessionKey: "agent:main:archived" },
+    {
+      sessionId: "main-archived",
+      updatedAt: 200,
+      archivedAt: 200,
+      createdActor: { type: "human", id: "viewer@example.com" },
+      visibility: "shared",
+    },
+  );
+  await upsertSessionEntry(
+    { agentId: "work", sessionKey: "agent:work:active" },
+    {
+      sessionId: "work-active",
+      updatedAt: 100,
+      createdActor: { type: "human", id: "viewer@example.com" },
+      visibility: "shared",
+    },
+  );
+  return config;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  loader.calls.mockClear();
+  loader.failNext = false;
+});
+
+describe("sessions.list single-flight", () => {
+  it.each([
+    { agentId: "main", archived: false as const, limit: 10 },
+    { agentId: "main", archived: true as const, limit: 1 },
+    { agentId: "work", archived: "all" as const, limit: 10 },
+    { archived: "all" as const, limit: 2 },
+  ])("preserves output for filters and pagination: %j", async (request) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+      const config = await seedSessions();
+      const client = identifiedClient("owner@example.com");
+      const expected = await listSessions({
+        client,
+        context: requestContext(config),
+        request,
+      });
+      const sharedContext = requestContext(config);
+
+      const collapsed = await Promise.all(
+        Array.from({ length: 4 }, () => listSessions({ client, context: sharedContext, request })),
+      );
+
+      expect(collapsed).toEqual(Array.from({ length: 4 }, () => expected));
+    });
+  });
+
+  it("collapses concurrent identical requests to one combined store load", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      loader.calls.mockClear();
+
+      const results = await Promise.all(
+        Array.from({ length: 16 }, () =>
+          listSessions({ client, context, request: { archived: "all", limit: 100 } }),
+        ),
+      );
+
+      expect(loader.calls).toHaveBeenCalledTimes(1);
+      expect(results.every((result) => result === results[0])).toBe(true);
+    });
+  });
+
+  it("does not share filtered results across client identities", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const context = requestContext(config);
+
+      const [owner, viewer] = await Promise.all([
+        listSessions({
+          client: identifiedClient("owner@example.com"),
+          context,
+          request: { agentId: "main", archived: "all", limit: 100 },
+        }),
+        listSessions({
+          client: identifiedClient("viewer@example.com"),
+          context,
+          request: { agentId: "main", archived: "all", limit: 100 },
+        }),
+      ]);
+
+      expect(owner.sessions.map((session) => session.key)).toContain("agent:main:draft");
+      expect(viewer.sessions.map((session) => session.key)).not.toContain("agent:main:draft");
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("rejects followers and retries after an underlying store failure", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      const context = requestContext(config);
+      const client = identifiedClient("owner@example.com");
+      const request = { archived: "all" as const, limit: 100 };
+      loader.failNext = true;
+
+      await expect(
+        Promise.all(Array.from({ length: 4 }, () => listSessions({ client, context, request }))),
+      ).rejects.toThrow("synthetic store load failure");
+      await expect(listSessions({ client, context, request })).resolves.toMatchObject({
+        sessions: expect.any(Array),
+      });
+
+      expect(loader.calls).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not share work that started before an intervening session mutation", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      let releaseCatalog!: () => void;
+      const catalog = new Promise<[]>((resolve) => {
+        releaseCatalog = () => resolve([]);
+      });
+      const context = {
+        ...requestContext(config),
+        loadGatewayModelCatalog: async () => await catalog,
+      } as GatewayRequestContext;
+      const client = identifiedClient("owner@example.com");
+      const request = { archived: "all" as const, limit: 100 };
+
+      const beforeMutation = listSessions({ client, context, request });
+      await vi.waitFor(() => expect(loader.calls).toHaveBeenCalledTimes(1));
+      await upsertSessionEntry(
+        { agentId: "main", sessionKey: "agent:main:created-mid-list" },
+        { sessionId: "created-mid-list", updatedAt: 500, visibility: "shared" },
+      );
+      const afterMutation = listSessions({ client, context, request });
+      await vi.waitFor(() => expect(loader.calls).toHaveBeenCalledTimes(2));
+      releaseCatalog();
+
+      const [, fresh] = await Promise.all([beforeMutation, afterMutation]);
+      expect(fresh.sessions.map((session) => session.key)).toContain("agent:main:created-mid-list");
+    });
+  });
+});

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -3,6 +3,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import {
   ErrorCodes,
   errorShape,
+  type SessionsListParams,
   validateSessionsCleanupParams,
   validateSessionsDescribeParams,
   validateSessionsListParams,
@@ -23,6 +24,7 @@ import {
 } from "../../config/sessions.js";
 import { listSessionEntriesReadOnly } from "../../config/sessions/session-accessor.js";
 import { searchSessionTranscripts } from "../../config/sessions/session-transcript-search.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { buildProjectedAgentRunIndex } from "../../infra/agent-events.js";
 import {
   measureDiagnosticsTimelineSpan,
@@ -80,8 +82,40 @@ import {
   loadSessionEntriesForTarget,
   requireSessionKey,
 } from "./sessions-shared.js";
-import type { GatewayRequestHandlers } from "./types.js";
+import type { GatewayClient, GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+const sessionListsByContext = new WeakMap<
+  GatewayRequestContext,
+  { config: OpenClawConfig; inFlight: Map<string, Promise<unknown>> }
+>();
+
+function sessionListVisibilityIdentity(client: GatewayClient | null): string {
+  if (isGatewayAdmin(client)) {
+    return "admin";
+  }
+  const profileId = gatewayClientSessionCreator(client)?.id;
+  return profileId ? `profile:${profileId}` : "anonymous";
+}
+
+function sessionListWorkKey(params: SessionsListParams, client: GatewayClient | null): string {
+  return JSON.stringify([
+    sessionListVisibilityIdentity(client),
+    Object.entries(params).toSorted(([left], [right]) => left.localeCompare(right)),
+  ]);
+}
+
+function sessionListInflightMap(
+  context: GatewayRequestContext,
+  config: OpenClawConfig,
+): Map<string, Promise<unknown>> {
+  let state = sessionListsByContext.get(context);
+  if (!state || state.config !== config) {
+    state = { config, inFlight: new Map() };
+    sessionListsByContext.set(context, state);
+  }
+  return state.inFlight;
+}
 
 export const sessionReadHandlers: GatewayRequestHandlers = {
   "sessions.search": async ({ params, respond, context, client }) => {
@@ -229,222 +263,248 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateSessionsListParams, "sessions.list", respond)) {
       return;
     }
-    const p = params;
+    const p = params as SessionsListParams;
     const cfg = context.getRuntimeConfig();
     const configuredAgentsOnly = p.configuredAgentsOnly === true;
-    const payload = await measureDiagnosticsTimelineSpan(
-      "gateway.sessions.list",
-      async () => {
-        const { durableStorePath, storePath, store } = measureDiagnosticsTimelineSpanSync(
-          "gateway.sessions.list.store_load",
-          () =>
-            loadCombinedSessionStoreForGateway(cfg, {
-              agentId: p.agentId,
-              projection: "list",
-            }),
-          {
-            config: cfg,
-            phase: "sessions.list",
-            attributes: {
-              agentId: p.agentId ?? null,
-              configuredAgentsOnly,
-            },
-          },
-        );
-        const entryFilter = createSessionListEntryFilter({ client });
-        const listStore = configuredAgentsOnly
-          ? filterSessionStoreToConfiguredAgents(cfg, store)
-          : store;
-        const modelCatalog = await measureDiagnosticsTimelineSpan(
-          "gateway.sessions.list.model_catalog",
-          () =>
-            loadOptionalServerMethodModelCatalog(
-              context,
-              "sessions.list",
-              p.agentId ? { loadParams: { agentId: p.agentId } } : undefined,
-            ),
-          {
-            config: cfg,
-            phase: "sessions.list",
-          },
-        );
-        const result = await measureDiagnosticsTimelineSpan(
-          "gateway.sessions.list.rows",
-          () =>
-            listSessionsFromStoreAsync({
-              cfg,
-              durableStorePath,
-              ...(entryFilter ? { entryFilter } : {}),
-              storePath,
-              store: listStore,
-              modelCatalog,
-              opts: p,
-            }),
-          {
-            config: cfg,
-            phase: "sessions.list",
-          },
-        );
-        const identityId = gatewayClientSessionCreator(client)?.id;
-        const { sharingTargets, membershipKeys } = await measureDiagnosticsTimelineSpan(
-          "gateway.sessions.list.sharing",
-          () => {
-            // One cache for the whole listing: sharing resolution otherwise
-            // materialized every entry of a candidate store once per row.
-            const sharingStoreCache: GatewaySessionStoreCache = new Map();
-            const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
-            const resolvedSharingTargets = result.sessions.map((session) =>
-              resolveSessionSharingTarget({
-                cfg,
+    const workKey = sessionListWorkKey(p, client);
+    const inFlight = sessionListInflightMap(context, cfg);
+    const pending = inFlight.get(workKey);
+    if (pending) {
+      respond(true, await pending, undefined);
+      return;
+    }
+    const run = () =>
+      measureDiagnosticsTimelineSpan(
+        "gateway.sessions.list",
+        async () => {
+          const { durableStorePath, storePath, store } = measureDiagnosticsTimelineSpanSync(
+            "gateway.sessions.list.store_load",
+            () =>
+              loadCombinedSessionStoreForGateway(cfg, {
+                agentId: p.agentId,
                 projection: "list",
-                sessionKey: session.key,
-                storeCache: sharingStoreCache,
-                targetDiscoveryCache,
-                ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
               }),
-            );
-            const resolvedMembershipKeys = new Set<string>();
-            if (identityId && !isGatewayAdmin(client)) {
-              const groups = new Map<
-                string,
-                {
-                  agentId: string;
-                  sessionKeys: string[];
-                  storePath: string;
-                }
-              >();
-              for (const target of resolvedSharingTargets) {
-                if (!target) {
-                  continue;
-                }
-                const groupKey = `${target.agentId}\0${target.storePath}`;
-                const group = groups.get(groupKey) ?? {
-                  agentId: target.agentId,
-                  sessionKeys: [],
-                  storePath: target.storePath,
-                };
-                group.sessionKeys.push(target.storeKey);
-                groups.set(groupKey, group);
-              }
-              for (const group of groups.values()) {
-                const firstSessionKey = group.sessionKeys[0];
-                if (!firstSessionKey) {
-                  continue;
-                }
-                for (const sessionKey of listSessionMembershipKeys(
-                  {
-                    agentId: group.agentId,
-                    sessionKey: firstSessionKey,
-                    storePath: group.storePath,
-                  },
-                  group.sessionKeys,
-                  identityId,
-                )) {
-                  resolvedMembershipKeys.add(`${group.agentId}\0${group.storePath}\0${sessionKey}`);
-                }
-              }
-            }
-            return {
-              sharingTargets: resolvedSharingTargets,
-              membershipKeys: resolvedMembershipKeys,
-            };
-          },
-          {
-            config: cfg,
-            phase: "sessions.list",
-            attributes: {
-              sessions: result.sessions.length,
+            {
+              config: cfg,
+              phase: "sessions.list",
+              attributes: {
+                agentId: p.agentId ?? null,
+                configuredAgentsOnly,
+              },
             },
-          },
-        );
-        const placementsBySessionId = context.workerSessionPlacementService?.getMany(
-          result.sessions.flatMap((session) => (session.sessionId ? [session.sessionId] : [])),
-        );
-        const trackedActiveRuns = collectTrackedActiveSessionRuns(context);
-        const projectedAgentRunIndex = buildProjectedAgentRunIndex();
-        const defaultAgentId = resolveDefaultAgentId(cfg);
-        const sessions = measureDiagnosticsTimelineSpanSync(
-          "gateway.sessions.list.active_run_flags",
-          () => {
-            return result.sessions.map((session, index) => {
-              const sharingTarget = sharingTargets[index];
-              const visibility = sharingTarget
-                ? resolveSessionVisibility(sharingTarget.entry)
-                : "shared";
-              const placementRecord = session.sessionId
-                ? placementsBySessionId?.get(session.sessionId)
-                : undefined;
-              const activeRunState = resolveVisibleActiveSessionRunState({
+          );
+          const entryFilter = createSessionListEntryFilter({ client });
+          const listStore = configuredAgentsOnly
+            ? filterSessionStoreToConfiguredAgents(cfg, store)
+            : store;
+          const modelCatalog = await measureDiagnosticsTimelineSpan(
+            "gateway.sessions.list.model_catalog",
+            () =>
+              loadOptionalServerMethodModelCatalog(
                 context,
-                requestedKey: session.key,
-                canonicalKey: session.key,
-                sessionId: session.sessionId,
-                ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
-                defaultAgentId,
-                trackedActiveRuns,
-                projectedAgentRunIndex,
-              });
-              return Object.assign({}, session, {
-                visibility,
-                ...(sharingTarget
-                  ? {
-                      sharingRole: resolveSessionSharingRole({
-                        client,
-                        target: sharingTarget,
-                        isMember: membershipKeys.has(
-                          `${sharingTarget.agentId}\0${sharingTarget.storePath}\0${sharingTarget.storeKey}`,
-                        ),
-                      }),
-                    }
-                  : {}),
-                hasActiveRun: activeRunState.active,
-                ...(placementRecord
-                  ? { placement: projectWorkerSessionPlacement(placementRecord) }
-                  : {}),
-                ...(activeRunState.runIds.length > 0
-                  ? { activeRunIds: activeRunState.runIds }
-                  : {}),
-              });
-            });
-          },
-          {
-            config: cfg,
-            phase: "sessions.list",
-            attributes: {
-              sessions: result.sessions.length,
+                "sessions.list",
+                p.agentId ? { loadParams: { agentId: p.agentId } } : undefined,
+              ),
+            {
+              config: cfg,
+              phase: "sessions.list",
             },
-          },
-        );
-        // The pre-await visibility predicate used a stale store snapshot; re-drop rows
-        // whose freshly resolved sharing state is a draft this caller cannot see
-        // (a session flipped to draft mid-list, or an older shared alias hiding
-        // a now-draft canonical entry). Drafts are owner+admin only — members
-        // lose access, matching createSessionListEntryFilter — so keep a draft
-        // row only for the owner role. Admins and identity-less solo callers
-        // keep everything.
-        const canSeeDrafts = !identityId || isGatewayAdmin(client);
-        const visibleSessions = canSeeDrafts
-          ? sessions
-          : sessions.filter(
-              (session) =>
-                !session.incognito &&
-                (session.visibility !== "draft" || session.sharingRole === "owner"),
-            );
-        return {
-          ...result,
-          sessions: visibleSessions,
-        };
-      },
-      {
-        config: cfg,
-        phase: "sessions.list",
-        attributes: {
-          agentId: p.agentId ?? null,
-          configuredAgentsOnly,
+          );
+          const result = await measureDiagnosticsTimelineSpan(
+            "gateway.sessions.list.rows",
+            () =>
+              listSessionsFromStoreAsync({
+                cfg,
+                durableStorePath,
+                ...(entryFilter ? { entryFilter } : {}),
+                storePath,
+                store: listStore,
+                modelCatalog,
+                opts: p,
+              }),
+            {
+              config: cfg,
+              phase: "sessions.list",
+            },
+          );
+          const identityId = gatewayClientSessionCreator(client)?.id;
+          const { sharingTargets, membershipKeys } = await measureDiagnosticsTimelineSpan(
+            "gateway.sessions.list.sharing",
+            () => {
+              // One cache for the whole listing: sharing resolution otherwise
+              // materialized every entry of a candidate store once per row.
+              const sharingStoreCache: GatewaySessionStoreCache = new Map();
+              const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
+              const resolvedSharingTargets = result.sessions.map((session) =>
+                resolveSessionSharingTarget({
+                  cfg,
+                  projection: "list",
+                  sessionKey: session.key,
+                  storeCache: sharingStoreCache,
+                  targetDiscoveryCache,
+                  ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
+                }),
+              );
+              const resolvedMembershipKeys = new Set<string>();
+              if (identityId && !isGatewayAdmin(client)) {
+                const groups = new Map<
+                  string,
+                  {
+                    agentId: string;
+                    sessionKeys: string[];
+                    storePath: string;
+                  }
+                >();
+                for (const target of resolvedSharingTargets) {
+                  if (!target) {
+                    continue;
+                  }
+                  const groupKey = `${target.agentId}\0${target.storePath}`;
+                  const group = groups.get(groupKey) ?? {
+                    agentId: target.agentId,
+                    sessionKeys: [],
+                    storePath: target.storePath,
+                  };
+                  group.sessionKeys.push(target.storeKey);
+                  groups.set(groupKey, group);
+                }
+                for (const group of groups.values()) {
+                  const firstSessionKey = group.sessionKeys[0];
+                  if (!firstSessionKey) {
+                    continue;
+                  }
+                  for (const sessionKey of listSessionMembershipKeys(
+                    {
+                      agentId: group.agentId,
+                      sessionKey: firstSessionKey,
+                      storePath: group.storePath,
+                    },
+                    group.sessionKeys,
+                    identityId,
+                  )) {
+                    resolvedMembershipKeys.add(
+                      `${group.agentId}\0${group.storePath}\0${sessionKey}`,
+                    );
+                  }
+                }
+              }
+              return {
+                sharingTargets: resolvedSharingTargets,
+                membershipKeys: resolvedMembershipKeys,
+              };
+            },
+            {
+              config: cfg,
+              phase: "sessions.list",
+              attributes: {
+                sessions: result.sessions.length,
+              },
+            },
+          );
+          const placementsBySessionId = context.workerSessionPlacementService?.getMany(
+            result.sessions.flatMap((session) => (session.sessionId ? [session.sessionId] : [])),
+          );
+          const trackedActiveRuns = collectTrackedActiveSessionRuns(context);
+          const projectedAgentRunIndex = buildProjectedAgentRunIndex();
+          const defaultAgentId = resolveDefaultAgentId(cfg);
+          const sessions = measureDiagnosticsTimelineSpanSync(
+            "gateway.sessions.list.active_run_flags",
+            () => {
+              return result.sessions.map((session, index) => {
+                const sharingTarget = sharingTargets[index];
+                const visibility = sharingTarget
+                  ? resolveSessionVisibility(sharingTarget.entry)
+                  : "shared";
+                const placementRecord = session.sessionId
+                  ? placementsBySessionId?.get(session.sessionId)
+                  : undefined;
+                const activeRunState = resolveVisibleActiveSessionRunState({
+                  context,
+                  requestedKey: session.key,
+                  canonicalKey: session.key,
+                  sessionId: session.sessionId,
+                  ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
+                  defaultAgentId,
+                  trackedActiveRuns,
+                  projectedAgentRunIndex,
+                });
+                return Object.assign({}, session, {
+                  visibility,
+                  ...(sharingTarget
+                    ? {
+                        sharingRole: resolveSessionSharingRole({
+                          client,
+                          target: sharingTarget,
+                          isMember: membershipKeys.has(
+                            `${sharingTarget.agentId}\0${sharingTarget.storePath}\0${sharingTarget.storeKey}`,
+                          ),
+                        }),
+                      }
+                    : {}),
+                  hasActiveRun: activeRunState.active,
+                  ...(placementRecord
+                    ? { placement: projectWorkerSessionPlacement(placementRecord) }
+                    : {}),
+                  ...(activeRunState.runIds.length > 0
+                    ? { activeRunIds: activeRunState.runIds }
+                    : {}),
+                });
+              });
+            },
+            {
+              config: cfg,
+              phase: "sessions.list",
+              attributes: {
+                sessions: result.sessions.length,
+              },
+            },
+          );
+          // The pre-await visibility predicate used a stale store snapshot; re-drop rows
+          // whose freshly resolved sharing state is a draft this caller cannot see
+          // (a session flipped to draft mid-list, or an older shared alias hiding
+          // a now-draft canonical entry). Drafts are owner+admin only — members
+          // lose access, matching createSessionListEntryFilter — so keep a draft
+          // row only for the owner role. Admins and identity-less solo callers
+          // keep everything.
+          const canSeeDrafts = !identityId || isGatewayAdmin(client);
+          const visibleSessions = canSeeDrafts
+            ? sessions
+            : sessions.filter(
+                (session) =>
+                  !session.incognito &&
+                  (session.visibility !== "draft" || session.sharingRole === "owner"),
+              );
+          return {
+            ...result,
+            sessions: visibleSessions,
+          };
         },
-      },
-    );
-    respond(true, payload, undefined);
+        {
+          config: cfg,
+          phase: "sessions.list",
+          attributes: {
+            agentId: p.agentId ?? null,
+            configuredAgentsOnly,
+          },
+        },
+      );
+    // The delayed computation is the shared promise, so every failure reaches all followers.
+    const operation = new Promise<void>((done) => {
+      setImmediate(done);
+    }).then(() => {
+      // Only the pre-start socket burst may share. Once loading begins, an intervening session
+      // mutation must make the next request build a fresh projection instead of joining this one.
+      inFlight.delete(workKey);
+      return run();
+    });
+    inFlight.set(workKey, operation);
+    try {
+      respond(true, await operation, undefined);
+    } finally {
+      if (inFlight.get(workKey) === operation) {
+        inFlight.delete(workKey);
+      }
+    }
   },
   "sessions.cleanup": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateSessionsCleanupParams, "sessions.cleanup", respond)) {

--- a/src/gateway/server-reload-handlers.hot-reload-status.test.ts
+++ b/src/gateway/server-reload-handlers.hot-reload-status.test.ts
@@ -1,9 +1,8 @@
 /**
  * Proves `startManagedGatewayConfigReloader` forwards the underlying watcher's
- * live `hotReloadStatus()` accessor on its returned handle instead of only
- * `stop`. Before this test, the returned handle dropped the accessor, so
- * `openclaw health` had no live signal to surface even though the watcher
- * itself already tracked "active"/"disabled" correctly.
+ * live `hotReloadStatus()` accessor and owns cache invalidation at the accepted
+ * candidate seam. This keeps request caching coupled to the actual watcher
+ * lifecycle instead of individual config writers.
  */
 import { describe, expect, it, vi } from "vitest";
 import { getRuntimeAuthProfileStoreCredentialsRevision } from "../agents/auth-profiles/runtime-snapshots.js";
@@ -13,23 +12,49 @@ import { startManagedGatewayConfigReloader } from "./server-reload-handlers.js";
 
 const hoisted = vi.hoisted(() => ({
   hotReloadStatus: { current: "active" as "active" | "disabled" },
+  invalidateConfigGetResponseCache: vi.fn(),
+  onConfigCandidateCommitted: undefined as
+    | ((info: {
+        path: string;
+        persistedHash: string | null;
+        changedPaths: readonly string[];
+      }) => void)
+    | undefined,
+  notifyPluginMetadataChanged: vi.fn(),
   stop: vi.fn(async () => {}),
+}));
+
+vi.mock("./config-get-response.js", () => ({
+  invalidateConfigGetResponseCache: hoisted.invalidateConfigGetResponseCache,
 }));
 
 vi.mock("./config-reload.js", async () => {
   const actual = await vi.importActual<typeof import("./config-reload.js")>("./config-reload.js");
   return {
     ...actual,
-    startGatewayConfigReloader: vi.fn(() => ({
-      stop: hoisted.stop,
-      hotReloadStatus: () => hoisted.hotReloadStatus.current,
-    })),
+    startGatewayConfigReloader: vi.fn(
+      (options: {
+        onConfigCandidateCommitted?: (info: {
+          path: string;
+          persistedHash: string | null;
+          changedPaths: readonly string[];
+        }) => void;
+      }) => {
+        hoisted.onConfigCandidateCommitted = options.onConfigCandidateCommitted;
+        return {
+          stop: hoisted.stop,
+          hotReloadStatus: () => hoisted.hotReloadStatus.current,
+          notifyPluginMetadataChanged: hoisted.notifyPluginMetadataChanged,
+        };
+      },
+    ),
   };
 });
 
 describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
-  it("forwards the live watcher accessor instead of dropping it", async () => {
+  it("forwards live status and invalidates config.get on watcher commit", async () => {
     const initialConfig = { session: { store: "/tmp/sessions.json" } } as OpenClawConfig;
+    const broadcast = vi.fn();
     const reloader = startManagedGatewayConfigReloader({
       minimalTestGateway: false,
       initialConfig,
@@ -44,7 +69,7 @@ describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
       promoteSnapshot: vi.fn(async () => true) as never,
       subscribeToWrites: vi.fn(() => () => {}) as never,
       deps: {} as never,
-      broadcast: vi.fn(),
+      broadcast,
       getState: () => ({
         hooksConfig: {} as never,
         hookClientIpConfig: {} as never,
@@ -98,6 +123,18 @@ describe("startManagedGatewayConfigReloader hotReloadStatus plumbing", () => {
     // handle — a copied/snapshotted value would stay stuck on "active".
     hoisted.hotReloadStatus.current = "disabled";
     expect(reloader.hotReloadStatus?.()).toBe("disabled");
+
+    hoisted.onConfigCandidateCommitted?.({
+      path: "/tmp/openclaw.json",
+      persistedHash: "persisted-1",
+      changedPaths: ["gateway.port"],
+    });
+    expect(hoisted.invalidateConfigGetResponseCache).toHaveBeenCalledOnce();
+    expect(broadcast).toHaveBeenCalledWith(
+      "config.changed",
+      { path: "/tmp/openclaw.json", hash: "persisted-1", ts: expect.any(Number) },
+      { dropIfSlow: true },
+    );
 
     await reloader.stop();
     expect(hoisted.stop).toHaveBeenCalledOnce();

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { getActiveSecretsRuntimeSnapshotRevision } from "../secrets/runtime-state.js";
+import { invalidateConfigGetResponseCache } from "./config-get-response.js";
 import {
   startGatewayConfigReloader,
   type GatewayConfigReloadTransactionOwnership,
@@ -319,6 +320,7 @@ export function startManagedGatewayConfigReloader(
     // RPC writes, agent/CLI config_set, doctor, and hand edits all land here
     // once the candidate is accepted. Hash-only; clients refresh via config.get.
     onConfigCandidateCommitted: (info) => {
+      invalidateConfigGetResponseCache();
       params.broadcast(
         "config.changed",
         { path: info.path, hash: info.persistedHash, ts: Date.now() },

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -402,13 +402,14 @@ describe("gateway config methods", () => {
     }
   });
 
-  it("returns the persisted config from config.set responses", async () => {
+  it("invalidates a warm config.get response when config.set commits", async () => {
     const current = await getCurrentConfigObject();
     const nextConfig = structuredClone(current.config);
     delete nextConfig.meta;
-
-    const gateway = (nextConfig.gateway ??= {}) as Record<string, unknown>;
-    gateway.port = 19001;
+    const ui = (nextConfig.ui ??= {}) as Record<string, unknown>;
+    const prefs = (ui.prefs ??= {}) as Record<string, unknown>;
+    const locale = prefs.locale === "de" ? "en" : "de";
+    prefs.locale = locale;
 
     const res = await rpcReq<{
       ok?: boolean;
@@ -424,6 +425,10 @@ describe("gateway config methods", () => {
     }>(requireWs(), "config.get", {});
     expect(after.ok).toBe(true);
     expect(res.payload?.config).toEqual(after.payload?.config);
+    expect(
+      ((after.payload?.config?.ui as Record<string, unknown>)?.prefs as Record<string, unknown>)
+        ?.locale,
+    ).toBe(locale);
     requireConfigObject(res.payload?.config, "response config");
   });
 


### PR DESCRIPTION
## What Problem This Solves

Stress testing an isolated gateway loaded with a copy of production state (248 sessions, 3 agents) showed two RPCs whose latency scales strictly linearly with the number of connected clients. On a single-threaded event loop, per-call CPU is the hard scaling ceiling:

| concurrent clients | `sessions.list` | `config.get` | `sessions.catalog.list` |
|---|---:|---:|---:|
| 1 | 12ms | 27ms | 1ms |
| 8 | 75ms | 153ms | 1ms |
| 16 | 144ms | 288ms | 2ms |
| 32 | 283ms | 571ms | 3ms |

`sessions.catalog.list` is the control: earlier waves gave it cached, revalidated reads, and it stays flat. The other two had not received that treatment.

`config.get` re-read the config file from disk, re-parsed JSON5, re-ran the full redaction pass, and re-hashed the entire config on **every** call. The Control UI calls it on every page load and every reconnect, so 32 open tabs cost ~571ms of pure event-loop CPU per round.

`sessions.list` repeated a fixed store load and projection per call. Cost was limit-independent — `limit=10` (15KB) and `limit=100` (134KB) both took ~10ms — confirming the expense is the store materialization, not row serialization.

## Why This Change Was Made

The gateway already owns authoritative config-change detection: `startGatewayConfigReloader` watches the config file and every included path, and `onConfigCandidateCommitted` fires once per accepted candidate whose persisted content changed, regardless of writer (gateway RPC, agent/CLI `config_set`, doctor, or a hand edit). `config.get` simply bypassed it and re-derived freshness from disk on every request.

Root `AGENTS.md` is explicit: *"Runtime hot paths: no freshness polling (`stat`/`realpath`/JSON reread/hash). Reuse current snapshots."* So the cache is owned by the watcher rather than by a stamp or a TTL — on a cache hit `config.get` performs zero filesystem syscalls.

Invalidation owners:
- `onConfigCandidateCommitted` is the canonical invalidator, hooked alongside the existing `config.changed` broadcast.
- The write path invalidates immediately as well, because the watcher is debounced and an in-process `config.set` followed by `config.get` in the same tick must not serve stale bytes.
- Plugin/schema changes are covered by the in-memory active-registry version, which feeds the `uiHints` used for redaction.
- Caching is gated on `hotReloadStatus === "active"`. When the watcher has degraded to disabled (native retries and the polling fallback both exhausted) or is absent entirely (local/CLI/stub contexts), the cache is bypassed and the config is read fresh — so a host with exhausted inotify watches can never serve a permanently stale config.

For `sessions.list`, identical concurrent listings now share one in-flight computation, keyed by context, config identity, parameters, and caller visibility identity. The entry is released once loading starts, so intervening mutations force fresh work, and failures settle all followers without poisoning retries. Per-client filtering still runs inside the identity-keyed computation, before pagination, so results are never shared across clients with different visibility.

## User Impact

Control UI pages and reconnects stop burning event-loop CPU proportional to the number of open tabs. Measured on the benchmark harness: `config.get` 30.52µs → 0.190µs median CPU per call (99.4% reduction); `sessions.list` drops to ~0.023ms per additional concurrent caller.

One deliberate, user-visible semantic change: after an **external** hand-edit of the config file, `config.get` returns the last accepted bytes until the watcher commits the change, rather than the newest bytes on disk. This is arguably more correct — it matches the `appliedConfigHash` carried in the same response, and reports what the gateway has actually adopted rather than bytes the runtime has not yet applied. In-process writes remain visible immediately.

No protocol, config-surface, or storage-schema changes.

## Evidence

- Cache-hit test asserts zero `fs.promises.stat` and zero `readConfigFileSnapshot` calls.
- Invalidation tests: watcher commit invalidates; in-process `config.set` immediately followed by `config.get` never returns stale bytes; plugin-metadata change invalidates; `hotReloadStatus === "disabled"` bypasses the cache; a missing status accessor (local context) bypasses the cache.
- `sessions.list` tests cover agent filters, archive modes, limits, owner/viewer isolation, failure settling, and mid-list mutations.
- Focused config/sessions suites: 80/80 passing; earlier full focused set 182 tests across 13 files.
- Remote Testbox: test types, both deadcode lanes, and full lint passing; formatting and `git diff --check` clean.
- Autoreview clean, no accepted or actionable findings.
- Audited other gateway-resident `readConfigFileSnapshot` callers (`talk.config`, `channels.logout`, `update.run`, a conditional startup snapshot); all are infrequent operations intentionally reading persisted state and were left unchanged.
