### PR TITLE
fix(ui): prevent embedded terminal content clipping

### DIFF
--- a/ui/src/components/terminal/terminal-panel-session-controller.ts
+++ b/ui/src/components/terminal/terminal-panel-session-controller.ts
@@ -287,7 +287,7 @@ export class TerminalPanelSessionController
         parent: host,
         readOnly: false,
         terminalOptions: {
-          fontSize: 13,
+          fontSize: 11,
           fontFamily: TERMINAL_FONT_FAMILY,
           cursorBlink: true,
           theme: terminalTheme(this.host.themeMode),

--- a/ui/src/components/terminal/terminal-panel.test-support.ts
+++ b/ui/src/components/terminal/terminal-panel.test-support.ts
@@ -4,6 +4,7 @@ import { OpenClawTerminalPanel } from "./terminal-panel.ts";
 export type CreateOptions = {
   parent: HTMLElement;
   terminalOptions?: {
+    fontSize?: number;
     fontFamily?: string;
     theme?: { background?: string; foreground?: string };
   };

--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -122,6 +122,7 @@ describe("OpenClawTerminalPanel", () => {
         params: { agentId: "ops", cols: 100, rows: 30 },
       });
     });
+    expect(createOptions?.terminalOptions?.fontSize).toBe(11);
     expect(createOptions?.terminalOptions?.fontFamily).toContain("MesloLGLDZ Nerd Font Mono");
     expect(getComputedStyle(createOptions!.parent).caretColor).toBe("rgba(0, 0, 0, 0)");
     const styleResults = Array.isArray(OpenClawTerminalPanel.styles)

--- a/ui/src/e2e/terminal-repaint.e2e.test.ts
+++ b/ui/src/e2e/terminal-repaint.e2e.test.ts
@@ -45,7 +45,7 @@ describeControlUiE2e("Control UI terminal repaint", () => {
     await server?.close();
   });
 
-  it("keeps one interactive terminal clean across repeated hide and show cycles", async () => {
+  it("keeps one interactive terminal sized and clean across repeated hide and show cycles", async () => {
     const context = await browser.newContext({
       serviceWorkers: "block",
       viewport: { width: 1180, height: 520 },
@@ -81,7 +81,8 @@ describeControlUiE2e("Control UI terminal repaint", () => {
       await waitForControlUiGatewayReady(page);
       await waitForControlUiTerminalReady(page);
       await page.keyboard.press("Control+Backquote");
-      await gateway.waitForRequest("terminal.open");
+      const openRequest = await gateway.waitForRequest("terminal.open");
+      const openParams = openRequest.params as { cols?: unknown };
 
       const hideTerminal = page.getByRole("button", { name: "Hide terminal" });
       const terminalCanvas = page.locator(".tp-host canvas");
@@ -94,6 +95,14 @@ describeControlUiE2e("Control UI terminal repaint", () => {
       });
       await expect.poll(() => terminalCanvasDigest(terminalCanvas)).not.toBe(blankCanvasDigest);
       const renderedCanvasDigest = await terminalCanvasDigest(terminalCanvas);
+
+      if (screenshotPath) {
+        await fs.mkdir(path.dirname(screenshotPath), { recursive: true });
+        await page.screenshot({ path: screenshotPath });
+      }
+
+      expect(openParams.cols).toBeTypeOf("number");
+      expect(openParams.cols).toBeGreaterThanOrEqual(125);
 
       for (let cycle = 0; cycle < 3; cycle += 1) {
         await hideTerminal.click();
@@ -109,11 +118,6 @@ describeControlUiE2e("Control UI terminal repaint", () => {
         .poll(async () => (await gateway.getRequests("terminal.input")).length)
         .toBeGreaterThan(0);
       expect(await gateway.getRequests("terminal.open")).toHaveLength(1);
-
-      if (screenshotPath) {
-        await fs.mkdir(path.dirname(screenshotPath), { recursive: true });
-        await page.screenshot({ path: screenshotPath });
-      }
     } finally {
       await context.close();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Claude Code or other full-screen terminal applications in the Control UI terminal dock would see oversized text and prematurely clipped layouts. The same shared terminal surface is used by the macOS app.

## Why This Change Was Made

The embedded terminal now uses an 11px default font instead of 13px. This crosses Ghostty's rounded cell-width boundary at the standard dock width, increasing the usable grid from 111 to at least 125 columns without adding another preference or changing terminal lifecycle behavior.

The browser regression test now enforces that density while retaining the existing hide/show repaint and input checks.

## User Impact

Terminal applications fit substantially more content in the dock, so multi-column TUIs no longer truncate as early and the default text size better matches the surrounding operator UI.

## Evidence

- Before: 13px default opened a standard 1180px Control UI viewport at 111 columns.
- After: 11px default opens the same viewport at 125 or more columns.
- Before/after Playwright screenshots captured from the same mocked Control UI scenario.
- `ui/src/components/terminal/terminal-panel.test.ts`: 22 tests passed.
- `ui/src/e2e/terminal-repaint.e2e.test.ts`: passed with terminal density, repaint, and input assertions.
- `pnpm check:changed`: passed formatting, guards, dead-code checks, i18n verification, core-test/UI typechecks, and changed-file lint.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
