### PR TITLE
fix(agents): deny all tools when scheduled authority names a removed account

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -969,7 +969,16 @@ describe("createOpenClawCodingTools", () => {
 
     try {
       const tools = createOpenClawCodingTools({
-        config: testConfig,
+        config: {
+          ...testConfig,
+          channels: {
+            discord: {
+              accounts: {
+                creator: {},
+              },
+            },
+          },
+        },
         agentId: "main",
         sessionKey: "agent:main:telegram:direct:alice",
         messageProvider: "discord-voice",

--- a/src/agents/agent-tools.policy.test.ts
+++ b/src/agents/agent-tools.policy.test.ts
@@ -229,7 +229,36 @@ describe("resolveGroupToolPolicy group context validation", () => {
         accountId: "removed",
         requireConfiguredAccount: true,
       }),
-    ).toEqual({ allow: [] });
+    ).toEqual({ allow: [], deny: ["*"] });
+  });
+
+  it("denies every tool when scheduled authority names a removed account", () => {
+    const policy = resolveGroupToolPolicy({
+      config: cfg,
+      sessionKey: "agent:main:whatsapp:group:safe-room",
+      accountId: "removed",
+      requireConfiguredAccount: true,
+    });
+    const tools = [
+      createStubTool("read"),
+      createStubTool("write"),
+      createStubTool("exec"),
+      createStubTool("apply_patch"),
+    ];
+    expect(filterToolsByPolicy(tools, policy)).toStrictEqual([]);
+    expect(isToolAllowedByPolicyName("exec", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("apply_patch", policy)).toBe(false);
+  });
+
+  it("fails closed when scheduled authority names a removed account without channel context", () => {
+    const policy = resolveGroupToolPolicy({
+      config: cfg,
+      sessionKey: "agent:main:main",
+      accountId: "removed",
+      requireConfiguredAccount: true,
+    });
+    expect(policy).toEqual({ allow: [], deny: ["*"] });
+    expect(isToolAllowedByPolicyName("exec", policy)).toBe(false);
   });
 
   it("resolves scheduled group policy for a still-configured named account", () => {

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -469,6 +469,10 @@ export function resolveEffectiveToolPolicy(params: {
   };
 }
 
+function denyAllToolPolicy(): SandboxToolPolicy {
+  return { allow: [], deny: ["*"] };
+}
+
 /** Resolve group-scoped tool policy after validating session provenance. */
 export function resolveGroupToolPolicy(params: {
   config?: OpenClawConfig;
@@ -509,7 +513,7 @@ export function resolveGroupToolPolicy(params: {
   const accountId = normalizeAccountId(params.accountId);
   if (!channel) {
     return params.requireConfiguredAccount && accountId !== DEFAULT_ACCOUNT_ID
-      ? { allow: [] }
+      ? denyAllToolPolicy()
       : undefined;
   }
   let plugin;
@@ -531,7 +535,7 @@ export function resolveGroupToolPolicy(params: {
     if (!configured) {
       // A named creator account is an authority boundary, not a fallback hint.
       // If it disappears, deny the scheduled surface instead of selecting default config.
-      return { allow: [] };
+      return denyAllToolPolicy();
     }
   }
   if (groupIds.length === 0) {

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -1,12 +1,16 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createAccountCronScheduledToolPolicy } from "../cron/scheduled-tool-policy.js";
+import { PLUGIN_REGISTRY_STATE } from "../plugins/runtime-state-key.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import { resolveConversationCapabilityProfile } from "./conversation-capability-profile.js";
+import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 
 describe("resolveConversationCapabilityProfile", () => {
   it("prepares a direct conversation profile with sender tool restrictions", () => {
@@ -373,5 +377,70 @@ describe("resolveConversationCapabilityProfile", () => {
 
     expect(profile.policy.trustedGroup).toEqual({ groupId: "team", dropped: false });
     expect(profile.conversation.scope).toBe("shared");
+  });
+});
+
+describe("resolveConversationCapabilityProfile scheduled account authority", () => {
+  const ownerSessionKey = "agent:main:whatsapp:group:safe-room";
+  const globalState = globalThis as Record<symbol, unknown>;
+  let previousRegistryState: unknown;
+
+  beforeAll(() => {
+    previousRegistryState = globalState[PLUGIN_REGISTRY_STATE];
+    globalState[PLUGIN_REGISTRY_STATE] = {
+      channel: {
+        version: 1,
+        registry: {
+          channels: [
+            {
+              plugin: {
+                id: "whatsapp",
+                meta: {},
+                config: createAccountListHelpers("whatsapp"),
+              },
+            },
+          ],
+        },
+      },
+    };
+  });
+
+  afterAll(() => {
+    globalState[PLUGIN_REGISTRY_STATE] = previousRegistryState;
+  });
+
+  function scheduledProfile(accounts: Record<string, unknown>) {
+    return resolveConversationCapabilityProfile({
+      config: {
+        channels: {
+          whatsapp: {
+            accounts,
+            groups: { "safe-room": { tools: { allow: ["read"] } } },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      sessionKey: ownerSessionKey,
+      agentId: "main",
+      messageProvider: "whatsapp",
+      groupId: "safe-room",
+      groupChannel: "whatsapp",
+      scheduledToolPolicy: createAccountCronScheduledToolPolicy({
+        ownerSessionKey,
+        ownerAccountId: "work",
+      }),
+    });
+  }
+
+  it("keeps the group policy while the scheduled owner account stays configured", () => {
+    expect(scheduledProfile({ work: {} }).policy.groupPolicy).toEqual({ allow: ["read"] });
+  });
+
+  it("denies every tool for a scheduled run after its owner account is removed", () => {
+    const groupPolicy = scheduledProfile({}).policy.groupPolicy;
+
+    expect(groupPolicy).toEqual({ allow: [], deny: ["*"] });
+    for (const toolName of ["read", "write", "exec", "apply_patch"]) {
+      expect(isToolAllowedByPolicyName(toolName, groupPolicy)).toBe(false);
+    }
   });
 });

--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -194,6 +194,64 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
     expect(hoisted.createLazyExecToolMock).not.toHaveBeenCalled();
   });
 
+  it("denies loopback tools after the scheduled owner account is removed", () => {
+    const resolveToolPolicy = vi.fn(() => ({ allow: ["read"] }));
+    hoisted.getLoadedChannelPluginMock.mockReturnValue({
+      config: {
+        listAccountIds: (cfg: OpenClawConfig) => Object.keys(cfg.channels?.discord?.accounts ?? {}),
+      },
+      groups: { resolveToolPolicy },
+    });
+    const scheduledToolPolicy = {
+      version: 1 as const,
+      mode: "account" as const,
+      ownerSessionKey: "agent:main:discord:group:ops",
+      ownerAccountId: "creator",
+    };
+    const configured = resolveGatewayScopedTools({
+      cfg: {
+        channels: {
+          discord: {
+            accounts: {
+              creator: {},
+              delivery: {},
+            },
+          },
+        },
+      } as OpenClawConfig,
+      sessionKey: "agent:main:cron:run-1",
+      runtimePolicySessionKey: "agent:main:cron:run-1",
+      accountId: "delivery",
+      surface: "loopback",
+      scheduledToolPolicy,
+    });
+    const removed = resolveGatewayScopedTools({
+      cfg: {
+        channels: {
+          discord: {
+            accounts: {
+              delivery: {},
+            },
+          },
+        },
+      } as OpenClawConfig,
+      sessionKey: "agent:main:cron:run-1",
+      runtimePolicySessionKey: "agent:main:cron:run-1",
+      accountId: "delivery",
+      surface: "loopback",
+      scheduledToolPolicy,
+    });
+
+    expect(configured.tools.map((tool) => tool.name)).toEqual(["read"]);
+    expect(removed.tools).toEqual([]);
+    expect(resolveToolPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "creator",
+        groupId: "ops",
+      }),
+    );
+  });
+
   it("does not fall back when policy removes a mediated coding tool", () => {
     hoisted.createOpenClawToolsMock.mockReturnValueOnce([
       hoisted.makeTool("write"),

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -164,7 +164,7 @@ export function resolveGatewayScopedTools(params: {
     groupId: params.groupId,
     groupChannel: params.groupChannel,
     groupSpace: params.groupSpace,
-    accountId: params.accountId ?? null,
+    accountId: params.scheduledToolPolicy?.ownerAccountId ?? params.accountId ?? null,
     senderId,
     senderName: params.senderName,
     senderUsername: params.senderUsername,
@@ -177,6 +177,7 @@ export function resolveGatewayScopedTools(params: {
           : "always"
         : "when-sender-id",
     groupPolicySessionKey: params.scheduledToolPolicy?.ownerSessionKey,
+    requireConfiguredGroupAccount: params.scheduledToolPolicy?.mode === "account",
   });
   const { groupPolicy, senderPolicy, subagentPolicy, inheritedToolPolicy } = requesterPolicies;
   const sandboxRuntime = resolveSandboxRuntimeStatus({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who revoke a channel account would silently widen, rather than remove, the tool access of the scheduled automations that account created.

When a scheduled run names a channel account that is no longer configured, `resolveGroupToolPolicy` is meant to fail closed and deny the scheduled surface. It returned `{ allow: [] }` to express that denial. The runtime tool matcher treats an empty allowlist as "allow everything not denied", so the intended denial resolved to a full grant.

The result inverts the operator's action. While the named account is configured, the automation is correctly narrowed to the group policy (`read`). Once the account is removed, the automation keeps running and is handed the full tool surface including `exec` and `apply_patch`.

## Why This Change Was Made

The producer of the sentinel is the code that knows denial is intended, so that is where the intent is made explicit. The two fail-closed returns in `resolveGroupToolPolicy` now carry an explicit wildcard deny instead of relying on an empty allowlist to mean "deny".

`{ allow: [], deny: ["*"] }` is the shape the repo already uses for deny-all (`src/agents/tool-policy.ts` and existing policy tests), and deny always wins in the matcher, so the denial holds regardless of how the allowlist is interpreted.

This also repairs a second consumer. `policyRestrictsNativeTools` in `src/agents/harness/selection.ts` requires `policy.allow.length > 0` before it treats a policy as restricting, so the old sentinel also failed to clamp native tools for plugin harnesses. The wildcard deny satisfies that check.

On the scheduled-authority handoff, `resolveConversationCapabilityProfile` already derives the owner account and requires it to remain configured. The gateway loopback/MCP tool resolver was the one omitted consumer: it carried `scheduledToolPolicy`, but resolved requester policy against the live delivery account and did not enable the configured-owner guard. This branch now resolves authorization from `ownerAccountId` and `ownerSessionKey` while retaining the live account for delivery routing. The guard stays scoped to persisted scheduled authority in `mode: "account"`, so ordinary inbound and default-account runs keep their existing behavior.

Deliberately out of scope: the general meaning of a configured `tools.allow: []`. That empty-means-all reading is intentional in the sandbox scope and is load bearing, with `mergeAllowlist` in `src/agents/sandbox/tool-policy.ts` explicitly commented to preserve it. Changing it is a config-semantics product decision, not part of this fail-closed repair, and this change leaves it untouched.

## User Impact

Revoking a channel account now actually revokes the scheduled automations that account created. Those runs get zero tools instead of the agent's full tool surface. Automations whose named account is still configured are unaffected and keep resolving their normal group policy.

## Evidence

Driven through the canonical scheduled execution path on pristine main and on the patched tree with identical inputs. The run enters at `resolveConversationCapabilityProfile`, the same entry point production uses, carrying a scheduled authority built by the real `createAccountCronScheduledToolPolicy`. Real account resolution (`createAccountListHelpers`), the real loaded-channel-plugin registry, the real requester policy handoff, and the real `applyToolPolicyPipeline` layering all stay in play. Nothing stubbed.

The scenario is one scheduled automation owned by named WhatsApp account `work`, first with that account configured and then with it removed.

```
# BEFORE (pristine main fde4658bf6)
scheduled run via resolveConversationCapabilityProfile
scheduledToolPolicy: {"version":1,"mode":"account","ownerSessionKey":"agent:main:whatsapp:group:safe-room","ownerAccountId":"work"}

account "work" still configured:
  group policy from profile : {"allow":["read"]}
  final tools for the run   : ["read"]

account "work" removed from config (revoked):
  group policy from profile : {"allow":[]}
  final tools for the run   : ["read","write","edit","exec","apply_patch","message"]

# AFTER (exact head 1bf64feebfe5, identical inputs)
scheduled run via resolveConversationCapabilityProfile
scheduledToolPolicy: {"version":1,"mode":"account","ownerSessionKey":"agent:main:whatsapp:group:safe-room","ownerAccountId":"work"}

account "work" still configured:
  group policy from profile : {"allow":["read"]}
  final tools for the run   : ["read"]

account "work" removed from config (revoked):
  group policy from profile : {"allow":[],"deny":["*"]}
  final tools for the run   : []
```

Only the revoked case moves. Removing the account goes from granting six tools including `exec` and `apply_patch` to granting none, while the still-configured case stays at `["read"]` in both runs. That the group policy visibly changes at the profile boundary also demonstrates the scheduled-authority fact reaching the resolver through the production handoff.

The gateway loopback control exercises the same authority boundary with a distinct live delivery account. A configured scheduled owner exposes only `read`; removing that owner exposes zero gateway tools. This proves delivery routing cannot substitute a different configured account for the persisted creator authority.

## Verification

- Exact-head focused matrix: 321 tests passed across resolver policy, capability profile, coding tools, requester/web-search policy, gateway tool resolution, plugin harness selection, and matcher semantics.
- Blacksmith Testbox repeated the same 321-test matrix successfully: https://github.com/openclaw/openclaw/actions/runs/30505472464
- `node scripts/check-changed.mjs`: all changed-file formatting, lint, core/test typecheck, dependency, plugin-boundary, schema, sidecar, and import-cycle gates passed. Testbox sync was unavailable for this gate, so trusted-source policy used the local fallback.
- Exact-head hosted CI completed with 80 passing checks and no failures. The lint runner was shut down mid-oxlint on its first attempt (`exit 143`); rerunning that failed job unchanged passed.
- Fresh post-CI high-reasoning autoreview found no actionable findings (correctness confidence 0.92).
- `git diff --check`: clean.

Not covered: no real cron scheduler tick or live channel transport was driven. `pnpm build` was not run because no dynamic import, packaging, or published surface changed.
