### PR TITLE
fix(gateway): stop start-time repair from retargeting managed services

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -528,6 +528,7 @@ openclaw gateway restart
   </Accordion>
   <Accordion title="Lifecycle behavior">
     - `gateway start` is idempotent: when the managed service is already running, it reports the running process and leaves it untouched. A loaded but stopped service is started as before.
+    - If `gateway start` or `gateway restart` needs to repair a stale service definition, the command refuses when the invoking shell resolves a different state directory, config path, or port than the installed service. Match or unset the conflicting environment overrides, or use `openclaw gateway install --force` to retarget the service intentionally.
     - Use `gateway restart` to restart a managed service. Do not chain `gateway stop` and `gateway start` as a restart substitute.
     - In a non-interactive shell, `gateway stop` requires `--force`. Interactive terminals keep the existing prompt-free behavior. For automation and tests, prefer `gateway run --dev` or an isolated `--profile` with a free port.
     - On macOS, `gateway stop` uses `launchctl bootout` by default, which removes the LaunchAgent from the current boot session without persisting a disable — KeepAlive auto-recovery stays active for future crashes and `gateway start` re-enables cleanly without a manual `launchctl enable`. Pass `--disable` to persistently suppress KeepAlive and RunAtLoad so the gateway does not respawn until the next explicit `gateway start`; use this when a manual stop should survive reboots.

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -500,7 +500,6 @@ export async function runDaemonStart(opts: DaemonLifecycleOptions = {}) {
     repairLoadedService: async ({ json, stdout, warn, state, issues }) =>
       await repairLoadedGatewayServiceForStart({
         service,
-        port: expectedPort,
         json,
         stdout,
         warn,
@@ -600,7 +599,6 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       const result = await repairLoadedGatewayServiceForStart({
         action: "restart",
         service,
-        port: configuredPort,
         json,
         stdout,
         warn,

--- a/src/cli/daemon-cli/start-repair.test.ts
+++ b/src/cli/daemon-cli/start-repair.test.ts
@@ -1,5 +1,5 @@
 // Start repair tests cover stale service repair install-plan wiring.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayService, GatewayServiceState } from "../../daemon/service.js";
 
 const buildGatewayInstallPlanMock = vi.hoisted(() =>
@@ -30,7 +30,24 @@ const buildGatewayInstallPlanMock = vi.hoisted(() =>
 );
 const resolveGatewayInstallTokenMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotForWriteMock = vi.hoisted(() => vi.fn());
-const resolveGatewayPortMock = vi.hoisted(() => vi.fn(() => 18789));
+const resolveGatewayPortMock = vi.hoisted(() =>
+  vi.fn(
+    (config: { gateway?: { port?: number } } | undefined, env: NodeJS.ProcessEnv = process.env) => {
+      const portMatch = env.OPENCLAW_GATEWAY_PORT?.trim().match(/(?:^|:)(\d+)$/);
+      return Number(portMatch?.[1]) || config?.gateway?.port || 18_789;
+    },
+  ),
+);
+const resolveStateDirMock = vi.hoisted(() =>
+  vi.fn((env: NodeJS.ProcessEnv) => env.OPENCLAW_STATE_DIR?.trim() || `${env.HOME}/.openclaw`),
+);
+const resolveConfigPathCandidateMock = vi.hoisted(() =>
+  vi.fn(
+    (env: NodeJS.ProcessEnv) =>
+      env.OPENCLAW_CONFIG_PATH?.trim() ||
+      `${env.OPENCLAW_STATE_DIR?.trim() || `${env.HOME}/.openclaw`}/openclaw.json`,
+  ),
+);
 const resolveOpenClawWrapperPathMock = vi.hoisted(() => vi.fn());
 const formatGatewayServiceStartRepairIssuesMock = vi.hoisted(() => vi.fn());
 const defaultRuntimeLogMock = vi.hoisted(() => vi.fn());
@@ -53,7 +70,9 @@ vi.mock("../../config/io.js", () => ({
 }));
 
 vi.mock("../../config/paths.js", () => ({
+  resolveConfigPathCandidate: resolveConfigPathCandidateMock,
   resolveGatewayPort: resolveGatewayPortMock,
+  resolveStateDir: resolveStateDirMock,
 }));
 
 vi.mock("../../daemon/program-args.js", () => ({
@@ -85,6 +104,12 @@ function readFirstInstallPlanArg(): Record<string, unknown> {
 
 describe("repairLoadedGatewayServiceForStart", () => {
   beforeEach(() => {
+    vi.stubEnv("HOME", "/home/openclaw");
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", "");
+    vi.stubEnv("OPENCLAW_GATEWAY_PORT", "");
+    vi.stubEnv("OPENCLAW_HOME", "");
+    vi.stubEnv("OPENCLAW_PROFILE", "");
+    vi.stubEnv("OPENCLAW_STATE_DIR", "");
     buildGatewayInstallPlanMock.mockClear();
     resolveGatewayInstallTokenMock.mockReset();
     readConfigFileSnapshotForWriteMock.mockReset();
@@ -108,6 +133,10 @@ describe("repairLoadedGatewayServiceForStart", () => {
     );
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("forwards existing env value-source metadata when repairing stale service definitions", async () => {
     const installMock = vi.fn(async () => {});
     const isLoadedMock = vi.fn(async () => true);
@@ -116,6 +145,7 @@ describe("repairLoadedGatewayServiceForStart", () => {
       isLoaded: isLoadedMock,
     } as unknown as GatewayService;
     const existingEnvironment = {
+      HOME: "/home/openclaw",
       OPENCLAW_SERVICE_VERSION: "2026.4.24",
       TELEGRAM_DEFAULT_BOTTOKEN: "existing-env-file-token",
     };
@@ -152,5 +182,192 @@ describe("repairLoadedGatewayServiceForStart", () => {
         environmentValueSources: { TELEGRAM_DEFAULT_BOTTOKEN: "file" },
       }),
     );
+  });
+
+  it.each(["start", "restart"] as const)(
+    "refuses %s repair when ambient state, config, and port target a different service",
+    async (action) => {
+      vi.stubEnv("OPENCLAW_STATE_DIR", "/home/openclaw/stress-state");
+      vi.stubEnv("OPENCLAW_CONFIG_PATH", "/home/openclaw/stress-state/openclaw.json");
+      readConfigFileSnapshotForWriteMock.mockResolvedValue({
+        snapshot: {
+          exists: true,
+          valid: true,
+          sourceConfig: { gateway: { port: 18_999 } },
+          config: { gateway: { port: 18_999 } },
+        },
+        writeOptions: { expectedConfigPath: "/home/openclaw/stress-state/openclaw.json" },
+      });
+
+      const originalUnit = [
+        "ExecStart=/usr/bin/openclaw gateway --port 18789",
+        "EnvironmentFile=-/home/openclaw/.openclaw/gateway.systemd.env",
+        "Environment=OPENCLAW_SERVICE_MANAGED_ENV_KEYS=OPENAI_API_KEY,OPENCLAW_GATEWAY_PASSWORD",
+      ].join("\n");
+      let unit = originalUnit;
+      const installMock = vi.fn(async () => {
+        unit = "rewritten";
+      });
+      const service = {
+        install: installMock,
+        isLoaded: vi.fn(async () => true),
+      } as unknown as GatewayService;
+      const state: GatewayServiceState = {
+        installed: true,
+        loaded: true,
+        running: false,
+        env: {},
+        command: {
+          programArguments: ["/usr/bin/openclaw", "gateway", "--port", "18789"],
+          environment: {
+            HOME: "/home/openclaw",
+            OPENAI_API_KEY: "file-backed-openai-key",
+            OPENCLAW_GATEWAY_PASSWORD: "file-backed-password",
+            OPENCLAW_GATEWAY_PORT: "18789",
+            OPENCLAW_SERVICE_MANAGED_ENV_KEYS: "OPENAI_API_KEY,OPENCLAW_GATEWAY_PASSWORD",
+          },
+          environmentValueSources: {
+            HOME: "inline",
+            OPENAI_API_KEY: "file",
+            OPENCLAW_GATEWAY_PASSWORD: "file",
+            OPENCLAW_GATEWAY_PORT: "inline",
+            OPENCLAW_SERVICE_MANAGED_ENV_KEYS: "inline",
+          },
+        },
+      };
+
+      const repairParams = {
+        service,
+        state,
+        issues: [{ code: "port-mismatch" as const, message: "old port" }],
+        json: true,
+        stdout: process.stdout,
+      };
+      const repair =
+        action === "restart"
+          ? repairLoadedGatewayServiceForStart({ ...repairParams, action })
+          : repairLoadedGatewayServiceForStart(repairParams);
+      await expect(repair).rejects.toThrow(
+        [
+          "Refusing to repair the managed Gateway service because the current invocation targets a different Gateway:",
+          '- OPENCLAW_STATE_DIR: installed="/home/openclaw/.openclaw", ambient="/home/openclaw/stress-state"',
+          '- OPENCLAW_CONFIG_PATH: installed="/home/openclaw/.openclaw/openclaw.json", ambient="/home/openclaw/stress-state/openclaw.json"',
+          '- gateway.port: installed="18789", ambient="18999"',
+          `Run \`openclaw gateway ${action}\` with the installed state directory, config path, and port (or unset conflicting environment overrides). To retarget intentionally, run \`openclaw gateway install --force\`.`,
+        ].join("\n"),
+      );
+
+      expect(unit).toBe(originalUnit);
+      expect(installMock).not.toHaveBeenCalled();
+      expect(buildGatewayInstallPlanMock).not.toHaveBeenCalled();
+      expect(resolveGatewayInstallTokenMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("refuses a port-less stale service repair when ambient port overrides its config port", async () => {
+    vi.stubEnv("OPENCLAW_GATEWAY_PORT", "18999");
+    readConfigFileSnapshotForWriteMock.mockResolvedValue({
+      snapshot: {
+        exists: true,
+        valid: true,
+        sourceConfig: { gateway: { port: 18_789 } },
+        config: { gateway: { port: 18_789 } },
+      },
+      writeOptions: { expectedConfigPath: "/home/openclaw/.openclaw/openclaw.json" },
+    });
+    const installMock = vi.fn(async () => {});
+    const service = {
+      install: installMock,
+      isLoaded: vi.fn(async () => true),
+    } as unknown as GatewayService;
+    const state: GatewayServiceState = {
+      installed: true,
+      loaded: true,
+      running: false,
+      env: {},
+      command: {
+        programArguments: ["/usr/bin/openclaw", "gateway"],
+        environment: { HOME: "/home/openclaw" },
+      },
+    };
+
+    await expect(
+      repairLoadedGatewayServiceForStart({
+        service,
+        state,
+        issues: [{ code: "version-mismatch", message: "old service" }],
+        json: true,
+        stdout: process.stdout,
+      }),
+    ).rejects.toThrow('- gateway.port: installed="18789", ambient="18999"');
+
+    expect(installMock).not.toHaveBeenCalled();
+    expect(buildGatewayInstallPlanMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves installed host-and-port environment syntax before comparing repair targets", async () => {
+    const installMock = vi.fn(async () => {});
+    const service = {
+      install: installMock,
+      isLoaded: vi.fn(async () => true),
+    } as unknown as GatewayService;
+    const state: GatewayServiceState = {
+      installed: true,
+      loaded: true,
+      running: false,
+      env: {},
+      command: {
+        programArguments: ["/usr/bin/openclaw", "gateway"],
+        environment: {
+          HOME: "/home/openclaw",
+          OPENCLAW_GATEWAY_PORT: "127.0.0.1:19000",
+        },
+      },
+    };
+
+    await expect(
+      repairLoadedGatewayServiceForStart({
+        service,
+        state,
+        issues: [{ code: "version-mismatch", message: "old service" }],
+        json: true,
+        stdout: process.stdout,
+      }),
+    ).rejects.toThrow('- gateway.port: installed="19000", ambient="18789"');
+
+    expect(installMock).not.toHaveBeenCalled();
+    expect(buildGatewayInstallPlanMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses repair when a legacy service does not identify its installed state directory", async () => {
+    vi.stubEnv("HOME", "/home/ambient-user");
+    const installMock = vi.fn(async () => {});
+    const service = {
+      install: installMock,
+      isLoaded: vi.fn(async () => true),
+    } as unknown as GatewayService;
+    const state: GatewayServiceState = {
+      installed: true,
+      loaded: true,
+      running: false,
+      env: {},
+      command: {
+        programArguments: ["/usr/bin/openclaw", "gateway", "--port", "18789"],
+        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+      },
+    };
+
+    await expect(
+      repairLoadedGatewayServiceForStart({
+        service,
+        state,
+        issues: [{ code: "version-mismatch", message: "old service" }],
+        json: true,
+        stdout: process.stdout,
+      }),
+    ).rejects.toThrow("installed state directory cannot be determined");
+
+    expect(installMock).not.toHaveBeenCalled();
+    expect(buildGatewayInstallPlanMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/daemon-cli/start-repair.ts
+++ b/src/cli/daemon-cli/start-repair.ts
@@ -1,9 +1,14 @@
 // Start-time service repair: rebuilds stale service definitions before starting Gateway.
+import path from "node:path";
 import { buildGatewayInstallPlan } from "../../commands/daemon-install-helpers.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME } from "../../commands/daemon-runtime.js";
 import { resolveGatewayInstallToken } from "../../commands/gateway-install-token.js";
 import { readConfigFileSnapshotForWrite } from "../../config/io.js";
-import { resolveGatewayPort } from "../../config/paths.js";
+import {
+  resolveConfigPathCandidate,
+  resolveGatewayPort,
+  resolveStateDir,
+} from "../../config/paths.js";
 import { OPENCLAW_WRAPPER_ENV_KEY, resolveOpenClawWrapperPath } from "../../daemon/program-args.js";
 import type { GatewayServiceEnv } from "../../daemon/service-types.js";
 import type {
@@ -13,13 +18,12 @@ import type {
 } from "../../daemon/service.js";
 import { formatGatewayServiceStartRepairIssues } from "../../daemon/service.js";
 import { assertGatewayServiceMutationAllowed } from "../../infra/gateway-supervision.js";
-import { parseTcpPort, parseTcpPortFromArgs } from "../../infra/tcp-port.js";
+import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
 import { defaultRuntime } from "../../runtime.js";
 import { mergeInstallInvocationEnv } from "./install.js";
 
 type GatewayServiceRepairParams = {
   service: GatewayService;
-  port?: number;
   state: GatewayServiceState;
   issues: GatewayServiceStartRepairIssue[];
   json: boolean;
@@ -33,6 +37,95 @@ type GatewayServiceRepairResult<TResult extends "restarted" | "started"> = {
   warnings?: string[];
   loaded: boolean;
 };
+
+const GATEWAY_TARGET_ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "OPENCLAW_HOME",
+  "OPENCLAW_PROFILE",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_GATEWAY_PORT",
+] as const;
+
+function resolveInstalledGatewayTargetEnvironment(
+  existingEnvironment: Record<string, string> | undefined,
+): NodeJS.ProcessEnv {
+  const installedEnv: NodeJS.ProcessEnv = {};
+  for (const key of GATEWAY_TARGET_ENV_KEYS) {
+    const value = existingEnvironment?.[key]?.trim();
+    if (value) {
+      installedEnv[key] = value;
+    }
+  }
+  return installedEnv;
+}
+
+function normalizeTargetPath(value: string): string {
+  const resolved = path.resolve(value);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+// Start/restart may rewrite a stale service. Refuse before planning when that
+// rewrite would adopt a different state, config, or port from the invoking shell.
+function assertGatewayRepairTargetMatches(params: {
+  action: "restart" | "start";
+  config: Parameters<typeof resolveGatewayPort>[0];
+  existingEnvironment: Record<string, string> | undefined;
+  installedPort: number | null;
+}): number {
+  const installedEnv = resolveInstalledGatewayTargetEnvironment(params.existingEnvironment);
+  const installedStateOverride = installedEnv.OPENCLAW_STATE_DIR?.trim();
+  const installedHome =
+    installedEnv.OPENCLAW_HOME?.trim() ||
+    installedEnv.HOME?.trim() ||
+    installedEnv.USERPROFILE?.trim();
+  if (!installedStateOverride && !installedHome) {
+    throw new Error(
+      `Refusing to repair the managed Gateway service because its installed state directory cannot be determined from the service definition. Run \`openclaw gateway install --force\` to replace it intentionally.`,
+    );
+  }
+  const installedStateDir = resolveStateDir(installedEnv);
+  const installedConfigPath = resolveConfigPathCandidate(installedEnv);
+  const ambientStateDir = resolveStateDir(process.env);
+  const ambientConfigPath = resolveConfigPathCandidate(process.env);
+  const ambientPort = resolveGatewayPort(params.config, process.env);
+  const sameConfigPath =
+    normalizeTargetPath(installedConfigPath) === normalizeTargetPath(ambientConfigPath);
+  const installedPort =
+    params.installedPort ??
+    (sameConfigPath ? resolveGatewayPort(params.config, installedEnv) : null);
+  const differences: Array<{ name: string; installed: string; ambient: string }> = [];
+
+  for (const [name, installed, ambient] of [
+    ["OPENCLAW_STATE_DIR", installedStateDir, ambientStateDir],
+    ["OPENCLAW_CONFIG_PATH", installedConfigPath, ambientConfigPath],
+  ] as const) {
+    if (normalizeTargetPath(installed) !== normalizeTargetPath(ambient)) {
+      differences.push({ name, installed, ambient });
+    }
+  }
+  if (installedPort !== null && installedPort !== ambientPort) {
+    differences.push({
+      name: "gateway.port",
+      installed: String(installedPort),
+      ambient: String(ambientPort),
+    });
+  }
+  if (differences.length === 0) {
+    return installedPort ?? ambientPort;
+  }
+
+  const details = differences
+    .map(
+      ({ name, installed, ambient }) =>
+        `- ${name}: installed=${JSON.stringify(installed)}, ambient=${JSON.stringify(ambient)}`,
+    )
+    .join("\n");
+  throw new Error(
+    `Refusing to repair the managed Gateway service because the current invocation targets a different Gateway:\n${details}\nRun \`openclaw gateway ${params.action}\` with the installed state directory, config path, and port (or unset conflicting environment overrides). To retarget intentionally, run \`openclaw gateway install --force\`.`,
+  );
+}
 
 /** Repair a loaded but stale Gateway service definition and report the start result. */
 export function repairLoadedGatewayServiceForStart(
@@ -55,15 +148,18 @@ export async function repairLoadedGatewayServiceForStart(
   const cfg = configSnapshot.valid ? configSnapshot.sourceConfig : configSnapshot.config;
   const existingEnvironment = params.state.command?.environment;
   const existingEnvironmentValueSources = params.state.command?.environmentValueSources;
+  const installedPort = parseTcpPortFromArgs(params.state.command?.programArguments);
+  const port = assertGatewayRepairTargetMatches({
+    action: params.action ?? "start",
+    config: cfg,
+    existingEnvironment,
+    installedPort,
+  });
   const installEnv = mergeInstallInvocationEnv({
     env: process.env,
     existingServiceEnv: existingEnvironment,
   });
   const wrapperPath = await resolveOpenClawWrapperPath(installEnv[OPENCLAW_WRAPPER_ENV_KEY]);
-  const installedPort =
-    parseTcpPortFromArgs(params.state.command?.programArguments) ??
-    parseTcpPort(params.state.command?.environment?.OPENCLAW_GATEWAY_PORT);
-  const port = params.port ?? installedPort ?? resolveGatewayPort(cfg);
 
   const tokenResolution = await resolveGatewayInstallToken({
     config: cfg,

--- a/src/daemon/service-env-render-policy.ts
+++ b/src/daemon/service-env-render-policy.ts
@@ -55,13 +55,17 @@ export function applyManagedServiceEnvRenderPolicy(params: {
   if (managedKeys.size === 0) {
     return;
   }
-  if (launchAgent) {
+  // The caller limits these entries to file-backed SecretRefs active in the current config.
+  // Carry them through both file-backed supervisors or systemd can drop their env file.
+  if (launchAgent || params.platform === "linux") {
     addManagedServiceEnvEntries({
       plan: params.plan,
       entries: params.existingEnvironmentFileEnvironment,
       managedKeys,
       valueSource: "file",
     });
+  }
+  if (launchAgent) {
     addManagedServiceEnvEntries({
       plan: params.plan,
       entries: params.stateDirDotEnvEnvironment,

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 // Systemd tests cover Linux service install, start, stop, and status behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildGatewayInstallPlan } from "../commands/daemon-install-helpers.js";
 
 type ExecFileError = Error & {
   stderr?: string;
@@ -1319,6 +1320,80 @@ describe("stageSystemdService", () => {
       expect(unit).not.toContain("Environment=LLM_API_KEY=dotenv-key");
       expect(envFile).toBe("OPENCLAW_GATEWAY_TOKEN=dotenv-token\nLLM_API_KEY=dotenv-key\n");
       expect(envFileStat.mode & 0o777).toBe(0o600);
+    });
+  });
+
+  it("round-trips file-managed secrets through parse, repair planning, and emit", async () => {
+    await withStageFixture(async ({ env, unitPath, envFilePath, stateDir }) => {
+      const wrapperPath = path.join(stateDir, "openclaw-wrapper");
+      const fileBackedOpenAiKey = "file-backed-openai-test-key";
+      await fs.writeFile(wrapperPath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      await fs.chmod(wrapperPath, 0o755);
+      await fs.writeFile(envFilePath, `OPENAI_API_KEY=${fileBackedOpenAiKey}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(
+        unitPath,
+        [
+          "[Service]",
+          `ExecStart=${wrapperPath} gateway --port 18789`,
+          `EnvironmentFile=-${envFilePath}`,
+          "Environment=HOME=" + env.HOME,
+          "Environment=OPENCLAW_GATEWAY_PORT=18789",
+          "Environment=OPENCLAW_SERVICE_MANAGED_ENV_KEYS=OPENAI_API_KEY",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const command = await readSystemdServiceExecStart(env);
+      expect(command?.environment?.OPENAI_API_KEY).toBe(fileBackedOpenAiKey);
+      expect(command?.environmentValueSources?.OPENAI_API_KEY).toBe("file");
+      expect(command?.environmentValueSources?.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("inline");
+
+      const plan = await buildGatewayInstallPlan({
+        env: { ...env, PATH: "/usr/bin:/bin" },
+        port: 18_789,
+        runtime: "node",
+        platform: "linux",
+        nodePath: process.execPath,
+        wrapperPath,
+        existingEnvironment: command?.environment,
+        existingEnvironmentValueSources: command?.environmentValueSources,
+        authStore: { version: 1, profiles: {} },
+        config: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                models: [],
+              },
+            },
+          },
+        },
+      });
+      expect(plan.environmentValueSources?.OPENAI_API_KEY).toBe("file");
+      expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("OPENAI_API_KEY");
+
+      mockSystemctlStatusOk();
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        ...plan,
+      });
+
+      const [rewrittenUnit, rewrittenEnvFile] = await Promise.all([
+        fs.readFile(unitPath, "utf8"),
+        fs.readFile(envFilePath, "utf8"),
+      ]);
+      expect(rewrittenUnit).toContain(`EnvironmentFile=-${envFilePath}`);
+      expect(rewrittenUnit).toContain(
+        "Environment=OPENCLAW_SERVICE_MANAGED_ENV_KEYS=OPENAI_API_KEY",
+      );
+      expect(rewrittenUnit).not.toContain(fileBackedOpenAiKey);
+      expect(rewrittenEnvFile).toBe(`OPENAI_API_KEY=${fileBackedOpenAiKey}\n`);
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Reproduced on a live production gateway. An operator ran `openclaw gateway start` as the service user from a shell that had exported `OPENCLAW_STATE_DIR` (and `OPENCLAW_CONFIG`) pointing at a scratch state directory, intending to start a throwaway gateway. Instead the command rewrote the **managed production systemd unit** and restarted the real service.

Before:

```
ExecStart=… gateway --port 18789
EnvironmentFile=-/home/openclaw/.openclaw/gateway.systemd.env
Environment=OPENCLAW_SERVICE_MANAGED_ENV_KEYS=OPENAI_API_KEY,OPENCLAW_GATEWAY_PASSWORD
```

After:

```
ExecStart=… gateway --port 18999
Environment=OPENCLAW_STATE_DIR=/home/openclaw/stress-state
(no EnvironmentFile= line, no managed-key marker)
```

Production came back up serving the scratch state directory **and with every secret supplied via `EnvironmentFile` gone**, including the model API key. Recovery required restoring the `.bak` unit by hand.

Two distinct defects:

**Secrets dropped on repair.** systemd parsing correctly loads `EnvironmentFile=` values and their provenance (`src/daemon/systemd.ts:198-227`) and those values reach the install planner — but the guard at `src/daemon/service-env-render-policy.ts:58` re-added existing file-backed values **only for launchd**. Linux therefore emitted no file-managed keys, so the rewritten unit omitted both the `EnvironmentFile=` directive and its marker.

**Ambient environment silently retargets a managed unit.** `repairLoadedGatewayServiceForStart` (`src/cli/daemon-cli/start-repair.ts`) rebuilds the unit from `mergeInstallInvocationEnv({ env: process.env, … })` and resolves the port from the ambient config, so whatever happened to be exported in the invoking shell becomes the managed service's target. A `start` verb — which users reasonably read as "ensure running" — performed a destructive reinstall.

## Why This Change Was Made

Losing an operator's secrets during a routine `start` is the severe half, and it was a one-sided platform guard: the launchd path already did the right thing. The fix preserves active file-backed SecretRefs for systemd without ever inlining secret values into the unit.

For retargeting, neither silent resolution is safe — preferring ambient surprises the operator whose service moved, and preferring installed surprises the user whose explicit environment was ignored. So a stale-definition repair now refuses when the installed and ambient state dir, config path, or port differ: it reports every difference, exits non-zero, leaves the unit untouched, and directs intentional changes to `gateway install --force`. It fails closed when the installed target cannot be determined. Genuine staleness repairs that do not change those three values keep working unchanged.

Both managed `gateway start` and `gateway restart` are covered. launchd already preserved file provenance, and the shared conflict guard now protects it from the equivalent retarget risk.

## User Impact

User-visible behavior change, deliberate: a `gateway start`/`restart` whose ambient state dir, config path, or port conflicts with the installed managed service now fails with an explanatory diff instead of silently reinstalling and restarting. Operators who intend to change the target use `gateway install --force`. Non-conflicting repairs are unaffected.

Operators on Linux whose secrets come from an `EnvironmentFile` no longer lose them when a repair runs. Anyone who has already been bitten should verify their unit still carries `EnvironmentFile=` and re-run install if not.

## Evidence

- Exact systemd parse → repair-plan → emit round-trip test: env file directive and managed-key marker survive, and the secret value stays out of the unit.
- Real Linux CLI probes for both `start` and `restart`: both refuse, exit non-zero, print every difference, leave the unit byte-for-byte identical, and redact the secret.
- Blacksmith Testbox run 30457442893: 1,110 tests passed, 25 platform skips.
- `pnpm check:test-types`, both deadcode lanes (zero entries), full lint (zero warnings/errors), docs MDX 763 files, formatting, `git diff --check`: all passing.
- Autoreview clean; accepted three port/legacy-target edge cases, rejected a blanket credential-copy concern because preservation is restricted to active current-config SecretRefs.
