### PR TITLE
fix(active-memory): inject cold first-turn memory in QA-channel DMs

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -722,7 +722,98 @@ describe("active-memory plugin", () => {
     expect(typeof handler).toBe("function");
     expect(options).toEqual({ timeoutMs: 153_000 });
     expect(hookOptions.before_prompt_build?.timeoutMs).toBe(153_000);
+    expect(typeof hooks.before_model_resolve).toBe("function");
     expect(typeof hooks.agent_end).toBe("function");
+  });
+
+  it("prewarms a cold lane-1 lookup before the first QA-channel turn budget starts", async () => {
+    registerPluginConfig({ mode: "off" });
+    let cold = true;
+    const simulatedBudgetMs = 500;
+    const coldDelayMs = 650;
+    const runtimePreparationMs = 500;
+    const runId = "run-cold-qa-channel";
+    const triggerEntry = {
+      path: "MEMORY.md",
+      startLine: 1,
+      endLine: 1,
+      score: 1,
+      snippet: "Prefer aisle seats.",
+      source: "memory" as const,
+      originClass: "agent" as const,
+      triggers: "booking a flight",
+    };
+    const warmLookup = async () => {
+      if (cold) {
+        await new Promise((resolve) => setTimeout(resolve, coldDelayMs));
+        cold = false;
+      }
+    };
+    const search = vi.fn(async () => {
+      await warmLookup();
+      return [];
+    });
+    const listTriggerCandidates = vi.fn(async () => {
+      await warmLookup();
+      return [triggerEntry];
+    });
+    hoisted.getActiveMemorySearchManager.mockResolvedValue({
+      manager: { search, listTriggerCandidates },
+    } as never);
+
+    const prewarmResult = await requireHook("before_model_resolve")(
+      { prompt: "Help when booking a flight" },
+      {
+        agentId: "main",
+        runId,
+        trigger: "user",
+        sessionKey: "agent:main:qa-channel:direct:owner",
+        messageProvider: "qa-channel",
+        channelId: "owner",
+      },
+    );
+    expect(prewarmResult).toBeUndefined();
+    expect(coldDelayMs).toBeGreaterThan(simulatedBudgetMs);
+    await new Promise((resolve) => setTimeout(resolve, runtimePreparationMs));
+
+    const startedAt = performance.now();
+    const result = await runPromptBuild(
+      { prompt: "Help when booking a flight" },
+      {
+        sessionKey: "agent:main:qa-channel:direct:owner",
+        messageProvider: "qa-channel",
+        channelId: "owner",
+        runId,
+      },
+    );
+    const firstTurnMs = performance.now() - startedAt;
+
+    expectPrependContextContains(result, "Prefer aisle seats.");
+    expect(cold).toBe(false);
+    expect(firstTurnMs).toBeLessThan(simulatedBudgetMs);
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(listTriggerCandidates).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
+  it("does not prewarm a session disabled with /active-memory off", async () => {
+    const sessionKey = "agent:main:qa-channel:direct:paused";
+    seedSession(sessionKey, "s-paused");
+    await runActiveMemoryCommand({ sessionKey, args: "off" });
+
+    await requireHook("before_model_resolve")(
+      { prompt: "Help when booking a flight" },
+      {
+        agentId: "main",
+        runId: "run-paused-qa-channel",
+        trigger: "user",
+        sessionKey,
+        messageProvider: "qa-channel",
+        channelId: "paused",
+      },
+    );
+
+    expect(hoisted.getActiveMemorySearchManager).not.toHaveBeenCalled();
   });
 
   it("does not synthesize a main agent when every configured agent opts out", () => {

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -745,7 +745,9 @@ describe("active-memory plugin", () => {
     };
     const warmLookup = async () => {
       if (cold) {
-        await new Promise((resolve) => setTimeout(resolve, coldDelayMs));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, coldDelayMs);
+        });
         cold = false;
       }
     };
@@ -774,7 +776,9 @@ describe("active-memory plugin", () => {
     );
     expect(prewarmResult).toBeUndefined();
     expect(coldDelayMs).toBeGreaterThan(simulatedBudgetMs);
-    await new Promise((resolve) => setTimeout(resolve, runtimePreparationMs));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, runtimePreparationMs);
+    });
 
     const startedAt = performance.now();
     const result = await runPromptBuild(

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -67,7 +67,12 @@ import {
   createActiveMemoryHookDeadline,
   hasUsableMemoryResultInSessionRecord,
 } from "./transcript.js";
-import { resolveTriggerRecall } from "./trigger-recall.js";
+import {
+  forgetTriggerRecallPrewarm,
+  prewarmTriggerRecall,
+  resetTriggerRecallPrewarmsForTests,
+  resolveTriggerRecall,
+} from "./trigger-recall.js";
 import {
   HOOK_TIMEOUT_RECOVERY_GRACE_MS,
   MAX_SETUP_GRACE_TIMEOUT_MS,
@@ -368,6 +373,7 @@ export default definePluginEntry({
                 message: event.prompt,
                 activeProjectKeys: ctx.activeProjectKeys,
                 signal: AbortSignal.timeout(HOOK_TIMEOUT_RECOVERY_GRACE_MS),
+                runId: ctx.runId,
               }).catch((error: unknown) => {
                 api.logger.debug?.(
                   `active-memory: lane-1 trigger recall failed: ${toSingleLineLogValue(
@@ -495,8 +501,62 @@ export default definePluginEntry({
       },
       { timeoutMs: beforePromptBuildTimeoutMs },
     );
+    api.on("before_model_resolve", async (event, ctx) => {
+      refreshLiveConfigFromRuntime();
+      const liveConfig = readCurrentConfig() ?? (api.config as OpenClawConfig);
+      const effectiveAgentId = resolveStatusUpdateAgentId(ctx);
+      const sessionContext = {
+        ...ctx,
+        sessionKey:
+          ctx.sessionKey?.trim() ||
+          (effectiveAgentId
+            ? resolveCanonicalSessionKeyFromSessionId({
+                api,
+                agentId: effectiveAgentId,
+                sessionId: ctx.sessionId,
+              })
+            : undefined),
+        mainKey: liveConfig.session?.mainKey ?? api.config.session?.mainKey,
+      };
+      if (
+        !isEligibleInteractiveSession(sessionContext) ||
+        !isEnabledForAgent(config, effectiveAgentId) ||
+        !effectiveAgentId ||
+        normalizePluginsConfig(liveConfig.plugins).slots.memory !== MEMORY_CORE_PLUGIN_ID ||
+        !isPrivateRecallDestination(sessionContext) ||
+        !isAllowedChatId(config, sessionContext)
+      ) {
+        return;
+      }
+      if (
+        await isSessionActiveMemoryDisabled({
+          api,
+          sessionKey: sessionContext.sessionKey,
+        })
+      ) {
+        return;
+      }
+
+      // Start now, but do not await: runtime/model preparation overlaps the
+      // cold SQLite open and FTS statement/page warmup before lane 1 is budgeted.
+      void prewarmTriggerRecall({
+        cfg: liveConfig,
+        agentId: effectiveAgentId,
+        query: buildSearchQuery({ latestUserMessage: event.prompt }),
+        activeProjectKeys: ctx.activeProjectKeys,
+        runId: ctx.runId,
+      }).catch((error: unknown) => {
+        api.logger.debug?.(
+          `active-memory: lane-1 prewarm failed: ${toSingleLineLogValue(
+            error instanceof Error ? error.message : String(error),
+          )}`,
+        );
+      });
+    });
     api.on("agent_end", (event, ctx) => {
-      forgetActiveRecallRun(event.runId ?? ctx.runId);
+      const runId = event.runId ?? ctx.runId;
+      forgetActiveRecallRun(runId);
+      forgetTriggerRecallPrewarm(runId);
     });
   },
 });
@@ -520,6 +580,7 @@ const testing = {
     resetActiveRecallStateForTests();
     resetActiveMemoryConfigForTests();
     resetActiveMemoryTranscriptForTests();
+    resetTriggerRecallPrewarmsForTests();
   },
   setMinimumTimeoutMsForTests,
   setSetupGraceTimeoutMsForTests,

--- a/extensions/active-memory/trigger-recall.test.ts
+++ b/extensions/active-memory/trigger-recall.test.ts
@@ -4,6 +4,7 @@ import {
   buildTriggerRecallContext,
   isPromotedTrustedMemoryEntry,
   MAX_TRIGGER_CONTEXT_CHARS,
+  prewarmTriggerRecall,
   scoreTriggerMatch,
   resolveTriggerRecall,
   selectStrongTriggerMatches,
@@ -237,6 +238,130 @@ describe("active-memory trigger recall", () => {
     expect(hoisted.listTriggerCandidates).toHaveBeenCalledWith({
       activeProjectKeys: ["github.com/openclaw/openclaw"],
     });
+  });
+
+  it("prewarms the exact lexical and trigger-candidate lookup path", async () => {
+    hoisted.search.mockResolvedValue([]);
+    hoisted.listTriggerCandidates.mockResolvedValue([]);
+
+    await prewarmTriggerRecall({
+      cfg: {} as never,
+      agentId: "main",
+      query: "flight booking",
+    });
+
+    expect(hoisted.getManager).toHaveBeenCalledWith({ cfg: {}, agentId: "main" });
+    expect(hoisted.search).toHaveBeenCalledWith(
+      "flight booking",
+      expect.objectContaining({ lexicalOnly: true, qmdSearchModeOverride: "search" }),
+    );
+    expect(hoisted.listTriggerCandidates).toHaveBeenCalledWith({ activeProjectKeys: [] });
+  });
+
+  it("shares one in-flight prewarm with the lane-1 lookup for a run", async () => {
+    let releaseLookup: () => void = () => {
+      throw new Error("lookup gate was not initialized");
+    };
+    const lookupGate = new Promise<void>((resolve) => {
+      releaseLookup = resolve;
+    });
+    hoisted.search.mockImplementation(async () => {
+      await lookupGate;
+      return [];
+    });
+    hoisted.listTriggerCandidates.mockImplementation(async () => {
+      await lookupGate;
+      return [result()];
+    });
+    const cfg = {} as never;
+
+    const prewarm = prewarmTriggerRecall({
+      cfg,
+      agentId: "main",
+      query: "flight booking",
+      runId: "run-shared-prewarm",
+    });
+    const recall = resolveTriggerRecall({
+      cfg,
+      agentId: "main",
+      query: "flight booking",
+      message: "Help when booking a flight",
+      runId: "run-shared-prewarm",
+    });
+    await vi.waitFor(() => expect(hoisted.search).toHaveBeenCalledTimes(1));
+    releaseLookup();
+
+    await expect(prewarm).resolves.toBeUndefined();
+    await expect(recall).resolves.toEqual(
+      expect.objectContaining({ hasStrongHit: true, injectedCount: 1 }),
+    );
+    expect(hoisted.search).toHaveBeenCalledTimes(1);
+    expect(hoisted.listTriggerCandidates).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the lane-1 abort deadline while a shared prewarm continues", async () => {
+    let releaseLookup: () => void = () => {
+      throw new Error("lookup gate was not initialized");
+    };
+    const lookupGate = new Promise<void>((resolve) => {
+      releaseLookup = resolve;
+    });
+    hoisted.search.mockImplementation(async () => {
+      await lookupGate;
+      return [];
+    });
+    hoisted.listTriggerCandidates.mockImplementation(async () => {
+      await lookupGate;
+      return [];
+    });
+    const prewarm = prewarmTriggerRecall({
+      cfg: {} as never,
+      agentId: "main",
+      query: "flight booking",
+      runId: "run-aborted-shared-prewarm",
+    });
+    const controller = new AbortController();
+    const recall = resolveTriggerRecall({
+      cfg: {} as never,
+      agentId: "main",
+      query: "flight booking",
+      message: "Help when booking a flight",
+      runId: "run-aborted-shared-prewarm",
+      signal: controller.signal,
+    });
+
+    controller.abort(new Error("lane-1 budget expired"));
+    await expect(recall).rejects.toThrow("lane-1 budget expired");
+    releaseLookup();
+    await expect(prewarm).resolves.toBeUndefined();
+  });
+
+  it("does not reuse an unscoped prewarm for a project-scoped lookup", async () => {
+    const global = result({ startLine: 1 });
+    const project = result({ startLine: 2, projectKey: "alpha-key" });
+    hoisted.search.mockResolvedValue([]);
+    hoisted.listTriggerCandidates
+      .mockResolvedValueOnce([global])
+      .mockResolvedValueOnce([global, project]);
+    const cfg = {} as never;
+
+    await prewarmTriggerRecall({
+      cfg,
+      agentId: "main",
+      query: "flight booking",
+      runId: "run-project-prewarm",
+    });
+    const recall = await resolveTriggerRecall({
+      cfg,
+      agentId: "main",
+      query: "flight booking",
+      message: "Help when booking a flight",
+      activeProjectKeys: ["alpha-key"],
+      runId: "run-project-prewarm",
+    });
+
+    expect(hoisted.listTriggerCandidates).toHaveBeenCalledTimes(2);
+    expect(recall.injectedCount).toBe(2);
   });
 
   it("skips backends that cannot enumerate curated trigger candidates", async () => {

--- a/extensions/active-memory/trigger-recall.ts
+++ b/extensions/active-memory/trigger-recall.ts
@@ -130,14 +130,26 @@ export function buildTriggerRecallContext(matches: TriggerRecallMatch[]): string
   return buildPromptPrefix(truncateUtf16Safe(summary, MAX_TRIGGER_CONTEXT_CHARS));
 }
 
-export async function resolveTriggerRecall(params: {
+type TriggerLookupParams = {
   cfg: OpenClawConfig;
   agentId: string;
   query: string;
-  message: string;
   activeProjectKeys?: string[];
   signal?: AbortSignal;
-}): Promise<{ context?: string; hasStrongHit: boolean; injectedCount: number }> {
+  runId?: string;
+};
+
+type TriggerRecallPrewarmEntry = {
+  activeProjectKeys: string[];
+  agentId: string;
+  cfg: OpenClawConfig;
+  promise: Promise<MemorySearchResult[]>;
+  query: string;
+};
+
+const triggerRecallPrewarms = new Map<string, TriggerRecallPrewarmEntry>();
+
+async function loadTriggerRecallCandidates(params: TriggerLookupParams) {
   params.signal?.throwIfAborted();
   const activeProjectKeys = params.activeProjectKeys ?? [];
   const lookup = await waitForTriggerLookup(
@@ -148,7 +160,7 @@ export async function resolveTriggerRecall(params: {
     params.signal,
   );
   if (!lookup.manager?.listTriggerCandidates) {
-    return { hasStrongHit: false, injectedCount: 0 };
+    return [];
   }
   const lookupWork = Promise.all([
     lookup.manager
@@ -169,7 +181,7 @@ export async function resolveTriggerRecall(params: {
       .catch(() => []),
   ]);
   const [retrieved, triggerCandidates] = await waitForTriggerLookup(lookupWork, params.signal);
-  const candidates = [
+  return [
     ...new Map(
       [...triggerCandidates, ...retrieved].map((entry) => [
         `${entry.source}:${entry.path}:${String(entry.startLine)}:${String(entry.endLine)}`,
@@ -177,6 +189,55 @@ export async function resolveTriggerRecall(params: {
       ]),
     ).values(),
   ];
+}
+
+function resolveTriggerRecallCandidates(params: TriggerLookupParams) {
+  const runId = params.runId?.trim();
+  if (!runId) {
+    return loadTriggerRecallCandidates(params);
+  }
+  const existing = triggerRecallPrewarms.get(runId);
+  const activeProjectKeys = params.activeProjectKeys ?? [];
+  if (
+    existing &&
+    existing.cfg === params.cfg &&
+    existing.agentId === params.agentId &&
+    existing.query === params.query &&
+    existing.activeProjectKeys.length === activeProjectKeys.length &&
+    existing.activeProjectKeys.every((key, index) => key === activeProjectKeys[index])
+  ) {
+    return existing.promise;
+  }
+  const entry: TriggerRecallPrewarmEntry = {
+    activeProjectKeys: [...activeProjectKeys],
+    agentId: params.agentId,
+    cfg: params.cfg,
+    promise: loadTriggerRecallCandidates(params),
+    query: params.query,
+  };
+  triggerRecallPrewarms.set(runId, entry);
+  void entry.promise.catch(() => {
+    if (triggerRecallPrewarms.get(runId) === entry) {
+      triggerRecallPrewarms.delete(runId);
+    }
+  });
+  return entry.promise;
+}
+
+/** Open and exercise the exact local lookup path used by lane 1 before its deadline starts. */
+export async function prewarmTriggerRecall(params: TriggerLookupParams): Promise<void> {
+  await resolveTriggerRecallCandidates(params);
+}
+
+export async function resolveTriggerRecall(
+  params: TriggerLookupParams & { message: string },
+): Promise<{ context?: string; hasStrongHit: boolean; injectedCount: number }> {
+  params.signal?.throwIfAborted();
+  const activeProjectKeys = params.activeProjectKeys ?? [];
+  const candidates = await waitForTriggerLookup(
+    resolveTriggerRecallCandidates(params),
+    params.signal,
+  );
   const matches = selectStrongTriggerMatches(params.message, candidates, activeProjectKeys);
   const context = buildTriggerRecallContext(matches);
   return {
@@ -184,6 +245,16 @@ export async function resolveTriggerRecall(params: {
     hasStrongHit: matches.length > 0,
     injectedCount: matches.length,
   };
+}
+
+export function forgetTriggerRecallPrewarm(runId: string | undefined): void {
+  if (runId) {
+    triggerRecallPrewarms.delete(runId);
+  }
+}
+
+export function resetTriggerRecallPrewarmsForTests(): void {
+  triggerRecallPrewarms.clear();
 }
 
 function waitForTriggerLookup<T>(work: Promise<T>, signal?: AbortSignal): Promise<T> {

--- a/extensions/qa-lab/src/bus-state.test.ts
+++ b/extensions/qa-lab/src/bus-state.test.ts
@@ -46,6 +46,33 @@ describe("qa-bus state", () => {
     expect(snapshot.messages.map((message) => message.id)).toEqual([inbound.id, outbound.id]);
   });
 
+  it("normalizes the dm ingress alias before channel routing", () => {
+    const state = createQaBusState();
+
+    const inbound = state.addInboundMessage({
+      conversation: { id: "alice", kind: "dm" as never },
+      senderId: "alice",
+      text: "hello",
+    });
+
+    expect(inbound.conversation).toEqual({ id: "alice", kind: "direct" });
+    expect(state.getSnapshot().conversations).toEqual([
+      expect.objectContaining({ id: "alice", kind: "direct" }),
+    ]);
+  });
+
+  it("rejects unknown inbound conversation kinds instead of treating them as groups", () => {
+    const state = createQaBusState();
+
+    expect(() =>
+      state.addInboundMessage({
+        conversation: { id: "alice", kind: "private" as never },
+        senderId: "alice",
+        text: "hello",
+      }),
+    ).toThrow("invalid qa-channel conversation kind: private");
+  });
+
   it("creates threads and mutates message state", () => {
     const state = createQaBusState();
 

--- a/extensions/qa-lab/src/bus-state.ts
+++ b/extensions/qa-lab/src/bus-state.ts
@@ -36,6 +36,15 @@ import type {
 const DEFAULT_BOT_ID = "openclaw";
 const DEFAULT_BOT_NAME = "OpenClaw QA";
 
+function normalizeInboundConversation(conversation: QaBusConversation): QaBusConversation {
+  const rawKind = (conversation as { kind?: unknown }).kind;
+  const kind = rawKind === "dm" ? "direct" : rawKind;
+  if (kind !== "direct" && kind !== "channel" && kind !== "group") {
+    throw new Error(`invalid qa-channel conversation kind: ${String(rawKind)}`);
+  }
+  return kind === conversation.kind ? conversation : { ...conversation, kind };
+}
+
 type QaBusEventSeed =
   | {
       kind: "inbound-message";
@@ -179,7 +188,10 @@ export function createQaBusState() {
       const message = createMessage({
         direction: "inbound",
         accountId,
-        conversation: input.conversation,
+        // `dm:` is the canonical target spelling and is also used by manual
+        // QA-bus clients. Normalize its matching ingress alias before routing
+        // so a DM can never silently acquire group/channel privacy semantics.
+        conversation: normalizeInboundConversation(input.conversation),
         senderId: input.senderId,
         senderName: input.senderName,
         text: input.text,

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -49,11 +49,13 @@ scenario:
     config:
       baselineConversationId: qa-active-memory-off
       activeConversationId: qa-active-memory-on
-      memoryFact: "Stable QA movie night usual favorite snack preference: lemon pepper wings with blue cheese."
+      memoryFact: "Stable QA movie night usual favorite snack preference: lemon pepper wings with blue cheese. <!-- trigger: apply the global memory guidance --> <!-- importance: 9 -->"
       memoryQuery: "QA movie night snack lemon pepper wings blue cheese"
       expectedNeedle: lemon pepper wings
       prompt: "Silent snack recall check: what snack do I usually want for QA movie night? Reply in one short sentence."
       promptSnippet: "Silent snack recall check"
+      laneOneConversationId: qa-active-memory-lane-one
+      laneOnePrompt: "Apply the global memory guidance, then describe my usual QA movie night snack in one short sentence."
 
 flow:
   steps:
@@ -223,4 +225,63 @@ flow:
               - assert:
                   expr: "mockRequests.some((request) => request.allInputText.includes('You are a memory search agent.') && request.plannedToolName === 'memory_get')"
                   message: expected mock Active Memory memory_get request
+              - call: patchConfig
+                args:
+                  - env:
+                      ref: env
+                    patch:
+                      plugins:
+                        entries:
+                          active-memory:
+                            config:
+                              mode: "off"
+              - call: waitForGatewayHealthy
+                args:
+                  - ref: env
+                  - 60000
+              - call: waitForQaChannelReady
+                args:
+                  - ref: env
+                  - 60000
+              - set: laneOneRequestCursor
+                value:
+                  expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+              - set: laneOneStartIndex
+                value:
+                  expr: "state.getSnapshot().messages.length"
+              - sendInbound:
+                  conversation:
+                    id:
+                      expr: config.laneOneConversationId
+                    kind: dm
+                  senderId:
+                    expr: config.laneOneConversationId
+                  senderName: Active Memory Lane One
+                  text:
+                    expr: config.laneOnePrompt
+              - call: waitForOutboundMessage
+                saveAs: laneOneOutbound
+                args:
+                  - ref: state
+                  - lambda:
+                      params: [candidate]
+                      expr: "candidate.conversation.id === config.laneOneConversationId && candidate.conversation.kind === 'direct'"
+                  - expr: liveTurnTimeoutMs(env, 30000)
+                  - sinceIndex:
+                      ref: laneOneStartIndex
+              - call: waitForCondition
+                saveAs: laneOneRequests
+                args:
+                  - lambda:
+                      async: true
+                      expr: "await (async () => { const requests = await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${laneOneRequestCursor}`); return requests.some((request) => String(request.allInputText ?? '').includes(config.laneOnePrompt)) ? requests : undefined; })()"
+                  - expr: liveTurnTimeoutMs(env, 30000)
+                  - 100
+              - assert:
+                  expr: "laneOneRequests.some((request) => String(request.allInputText ?? '').includes(config.laneOnePrompt) && String(request.allInputText ?? '').includes('<active_memory_plugin>') && String(request.allInputText ?? '').includes(config.expectedNeedle))"
+                  message:
+                    expr: "`qa-channel lane-1 turn missed injected Active Memory context: ${JSON.stringify(laneOneRequests)}`"
+              - assert:
+                  expr: "laneOneRequests.every((request) => !String(request.allInputText ?? '').includes('You are a memory search agent.'))"
+                  message: mode=off lane-1 regression unexpectedly escalated to the recall sub-agent
       detailsExpr: activeOutbound.text

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -310,6 +310,7 @@ async function runEmbeddedAgentInternal(
           sessionKey: resolvedSessionKey,
           sessionId: params.sessionId,
           workspaceDir: resolvedWorkspace,
+          activeProjectKeys: [...activeProjectKeys],
           modelProviderId: provider,
           modelId,
           trigger: params.trigger,

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -30,7 +30,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
 ] as const;
 const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/acpx/index.ts": ["reply_dispatch"],
-  "extensions/active-memory/index.ts": ["agent_end", "before_prompt_build"],
+  "extensions/active-memory/index.ts": ["agent_end", "before_model_resolve", "before_prompt_build"],
   "extensions/clickclack/src/discussions/register.ts": ["before_tool_call"],
   "extensions/codex/index.ts": ["after_compaction", "inbound_claim", "session_end"],
   "extensions/diffs/src/plugin.ts": ["before_prompt_build"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a user's first conversational turn could silently miss trigger-matched Active Memory when a real-scale index was still cold. It also fixes QA-channel DM ingress that accepted the natural `dm` conversation kind but silently classified it as a group/channel session, making private Active Memory injection ineligible.

## Why This Change Was Made

Active Memory now starts the exact lexical and trigger-candidate lookup during early agent model preparation and shares that run-scoped work with lane 1. Reuse is limited to the same config snapshot, agent, query, and active-project set; session opt-outs remain respected, failures evict the prewarm, `agent_end` clears it, and the existing 1,500 ms timeout remains the safety net.

QA Lab now canonicalizes the established `dm` ingress alias to `direct` before conversation routing and rejects unknown kinds instead of silently granting them group semantics. The prepared agent hook context also carries the already-resolved active project keys so prewarm cannot drop project-scoped triggers.

## User Impact

The first memory-bearing turn now benefits from a warm local index without raising budgets or adding configuration. QA-channel DMs retain private-conversation semantics and receive the same trigger injection as other direct channel turns.

## Evidence

- Live pre-fix scale evidence: cold lane 1 took 1,519.98 ms against a 1,500 ms budget while steady-state p95 was 92.56 ms.
- Focused post-rebase tests: Active Memory/trigger/escalation 228 passed; QA bus/catalog/flow 77 passed.
- Cold-start regression: simulated cold work exceeds its test budget, runtime preparation overlaps it, the first turn completes under budget, and search/candidate enumeration each run exactly once.
- Timeout-skip, session opt-out, retry sharing, project gating, and escalation coverage remain green.
- Full-stack QA-channel scenario: 1/1 passed on Blacksmith Testbox `tbx_01kyq2z4w607g3n0cr8wy0h5r2` (https://github.com/openclaw/openclaw/actions/runs/30458937939), including `kind: dm` ingress, direct-session routing, `<active_memory_plugin>` in the main model request, and no escalation in mode `off`.
- Changed-surface checks: all-file typecheck/static gates passed; the gate found two timing-test lint issues, which were corrected, and the follow-up changed gate passed with 0 lint warnings/errors.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.

This change is AI-assisted and was reviewed through the repository autoreview workflow.
