### PR TITLE
fix(test): run Gmail watcher process integration on Unix

### DIFF
--- a/src/hooks/gmail-watcher.integration.test.ts
+++ b/src/hooks/gmail-watcher.integration.test.ts
@@ -10,8 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// Only run when explicitly opted in — requires real subprocess spawning.
-const RUN = process.platform !== "win32" && process.env["OPENCLAW_INTEGRATION_TEST"] === "1";
+const describePosix = process.platform === "win32" ? describe.skip : describe;
 
 function alive(pid: number): boolean {
   try {
@@ -22,7 +21,7 @@ function alive(pid: number): boolean {
   }
 }
 
-describe.skipIf(!RUN)("gmail-watcher process-tree shutdown (integration)", () => {
+describePosix("gmail-watcher process-tree shutdown (integration)", () => {
   let tmpDir: string;
   let savedPath: string | undefined;
   let gogPid: number | undefined;


### PR DESCRIPTION
Related: #115696

## What Problem This Solves

Resolves a problem where the Gmail watcher process-tree integration test was always skipped because it required an opt-in environment variable that no script, workflow, or documented test lane set.

## Why This Change Was Made

Removes the orphaned environment gate and retains the real Windows exclusion. The test uses only a local fake `gog` binary and POSIX process groups, so it can run on every Unix test lane without credentials or network access.

## User Impact

Maintainers now get continuous regression coverage that `stopGmailWatcher` terminates both the watcher and a resistant descendant process. Production behavior is unchanged.

## Evidence

- Blacksmith Testbox `tbx_01kyq3axnd2d05kbww1mhtajvm`: the hooks project executed the previously skipped test and passed 1/1.
- The run observed both the fake `gog` process and credential-helper descendant alive before shutdown and dead afterward.
- Run: https://github.com/openclaw/openclaw/actions/runs/30459472564
- `oxfmt --check` and `git diff --check` passed.
- Fresh autoreview and TruffleHog completed with no findings.