### PR TITLE
test(cli): keep help-exit process children single-process with a diagnosable timeout

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -15,7 +15,9 @@ const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 // This is a deadlock guard, not a startup SLO. Fork CI can take over a minute
 // to cold-load the CLI graph on shared hosted runners, while still exiting correctly.
-const CHILD_PROCESS_TIMEOUT_MS = 120_000;
+// It must stay below Vitest's 120s testTimeout so a hung child fails through
+// execFile with captured stdout/stderr instead of a blind vitest test timeout.
+const CHILD_PROCESS_TIMEOUT_MS = 100_000;
 const LAZY_GROUP_HELP_CASES = [
   { group: "backup", usageCommand: "backup", registry: "core" },
   { group: "capability", usageCommand: "infer|capability", registry: "subcli" },
@@ -176,6 +178,13 @@ async function runCliProcess(params: {
       env: {
         ...process.env,
         HOME: fixture.root,
+        // CI shard runners export NODE_COMPILE_CACHE; in a source checkout entry.ts
+        // then respawns a detached grandchild that shares this child's stdio pipes.
+        // If the deadlock guard SIGKILLs the parent, the orphan keeps the pipes open
+        // and execFile never settles, turning any slow child into a blind vitest
+        // timeout with no diagnostics. Keep these children single-process; the
+        // compile-cache respawn contract has dedicated entry.compile-cache coverage.
+        NODE_DISABLE_COMPILE_CACHE: "1",
         NODE_ENV: undefined,
         NODE_OPTIONS: undefined,
         NODE_USE_SYSTEM_CA: "1",


### PR DESCRIPTION
## What Problem This Solves

`src/cli/help-exit.process.test.ts > JSON console style process output > keeps valid container dispatch ahead of host dotenv loading` intermittently times out at 120000ms on CI Node shards (seen 2026-07-29 on PR #115870, run 30450868529, shard `checks-node-compact-small-7`, on a comment-only diff). When it happens, the failure is a blind vitest timeout with zero diagnostics.

Two harness defects make that possible:

1. **CI-only detached grandchild.** CI shard runners export `NODE_COMPILE_CACHE` into vitest workers, so every CLI child spawned by this file takes the source-checkout compile-cache-disabled respawn in `entry.ts`: the parent spawns a **detached** grandchild (`detachForProcessTree`) that shares the child's stdout/stderr pipes. If the `execFile` deadlock guard fires, its SIGKILL kills only the parent; the detached grandchild survives holding the pipes, the `execFileAsync` promise never settles, and the test can only die as a blind vitest timeout. Locally this never reproduces because `scripts/run-vitest.mjs` strips `NODE_COMPILE_CACHE`. The two-process chain also doubles cold-start cost per child and runs the parent's ESM loading with the Node compile cache active against a shard-shared cache directory — the same deadlock class `entry.compile-cache.ts` already documents for Node 24.0–24.14.
2. **Guard timeout == test timeout.** `CHILD_PROCESS_TIMEOUT_MS` (120s) equals the global vitest `testTimeout` (120s), so the vitest timeout always wins by a few ms and discards the child's partial stdout/stderr.

## Why This Change Was Made

Fix the flake's enabling conditions at the harness root instead of bumping timeouts: set `NODE_DISABLE_COMPILE_CACHE=1` in the spawned-CLI env so children stay single-process in CI (the compile-cache respawn contract keeps its dedicated coverage in `src/entry.compile-cache.test.ts` and `hooks-cli.process.test.ts`), and lower the child deadlock guard to 100s so any future hang fails through `execFile` with the child's captured stdout/stderr instead of a diagnostic-free vitest timeout.

## User Impact

None at runtime — test-harness only. CI gets fewer blind timeouts on the `cli-process` suite, and any future child hang produces actionable output.

## Evidence

- Respawn chain proven and suppressed: with `NODE_COMPILE_CACHE` set, `node --import tsx src/entry.ts gateway status` under `OPENCLAW_GATEWAY_STARTUP_TRACE=1` emits `entry.bootstrap` twice (parent + respawned grandchild); with `NODE_DISABLE_COMPILE_CACHE=1` it emits it once.
- Probe boundedness verified (ruling out the container-probe theory): `spawnSync` returns at its `timeout` even when a killed child leaks a pipe-holding grandchild, so the podman/docker probes stay ≤10s each.
- `node scripts/run-vitest.mjs src/cli/help-exit.process.test.ts`: 52/52 pass.
- Bounded repetition of the affected test ×3: pass (13.2s / 13.0s / 13.0s), on a host where the docker CLI genuinely hangs — exercising the real probe-timeout path.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, no findings.
