### PR TITLE
fix(agents): apply_patch converts CRLF files to mixed line endings

### DIFF
--- a/src/agents/apply-patch-update.ts
+++ b/src/agents/apply-patch-update.ts
@@ -5,6 +5,7 @@
  */
 import fs from "node:fs/promises";
 import { formatErrorMessage } from "../infra/errors.js";
+import { detectLineEnding, normalizeToLF, restoreLineEndings } from "./line-endings.js";
 
 const DASH_PUNCTUATION = /[\u2010-\u2015\u2212]/g;
 const SINGLE_QUOTE_PUNCTUATION = /[\u2018-\u201B]/g;
@@ -33,7 +34,8 @@ export async function applyUpdateHunk(
     throw new Error(`Failed to read file to update ${filePath}: ${formatErrorMessage(err)}`);
   });
 
-  const originalLines = originalContents.split("\n");
+  const lineEnding = detectLineEnding(originalContents);
+  const originalLines = normalizeToLF(originalContents).split("\n");
   if (originalLines.length > 0 && originalLines[originalLines.length - 1] === "") {
     originalLines.pop();
   }
@@ -43,7 +45,7 @@ export async function applyUpdateHunk(
   if (newLines.length === 0 || newLines[newLines.length - 1] !== "") {
     newLines = [...newLines, ""];
   }
-  return newLines.join("\n");
+  return restoreLineEndings(newLines.join("\n"), lineEnding);
 }
 
 function computeReplacements(

--- a/src/agents/apply-patch-update.ts
+++ b/src/agents/apply-patch-update.ts
@@ -5,7 +5,7 @@
  */
 import fs from "node:fs/promises";
 import { formatErrorMessage } from "../infra/errors.js";
-import { detectLineEnding, normalizeToLF, restoreLineEndings } from "./line-endings.js";
+import { hasOnlyCrlfLineEndings, normalizeToLF, restoreLineEndings } from "./line-endings.js";
 
 const DASH_PUNCTUATION = /[\u2010-\u2015\u2212]/g;
 const SINGLE_QUOTE_PUNCTUATION = /[\u2018-\u201B]/g;
@@ -34,8 +34,11 @@ export async function applyUpdateHunk(
     throw new Error(`Failed to read file to update ${filePath}: ${formatErrorMessage(err)}`);
   });
 
-  const lineEnding = detectLineEnding(originalContents);
-  const originalLines = normalizeToLF(originalContents).split("\n");
+  // Normalizing mixed endings would rewrite untouched lines across the file.
+  // Keep the existing localized behavior unless every terminator is CRLF.
+  const preserveCrlf = hasOnlyCrlfLineEndings(originalContents);
+  const matchingContents = preserveCrlf ? normalizeToLF(originalContents) : originalContents;
+  const originalLines = matchingContents.split("\n");
   if (originalLines.length > 0 && originalLines[originalLines.length - 1] === "") {
     originalLines.pop();
   }
@@ -45,7 +48,8 @@ export async function applyUpdateHunk(
   if (newLines.length === 0 || newLines[newLines.length - 1] !== "") {
     newLines = [...newLines, ""];
   }
-  return restoreLineEndings(newLines.join("\n"), lineEnding);
+  const updatedContents = newLines.join("\n");
+  return preserveCrlf ? restoreLineEndings(updatedContents, "\r\n") : updatedContents;
 }
 
 function computeReplacements(

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -476,6 +476,70 @@ describe("applyPatch", () => {
     }
   });
 
+  it("preserves CRLF line endings for changed and context lines", async () => {
+    const initial =
+      'class Program {\r\n  static void Main() {\r\n    Console.WriteLine("hello");\r\n  }\r\n}\r\n';
+    const memory = createMemoryPatchSandbox({ "source.txt": initial });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+   static void Main() {
+-    Console.WriteLine("hello");
++    Console.WriteLine("world");
+   }
+*** End Patch`;
+
+    const result = await applyPatch(patch, memory.options);
+
+    expect(result.noOp).toBeUndefined();
+    expect(memory.files.get("/sandbox/source.txt")).toBe(
+      'class Program {\r\n  static void Main() {\r\n    Console.WriteLine("world");\r\n  }\r\n}\r\n',
+    );
+  });
+
+  it("preserves CRLF line endings when the hunk spans the whole file", async () => {
+    const memory = createMemoryPatchSandbox({ "source.txt": "foo\r\nbar\r\n" });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+ foo
+-bar
++baz
+*** End Patch`;
+
+    await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/source.txt")).toBe("foo\r\nbaz\r\n");
+  });
+
+  it("preserves CRLF line endings for inserted lines", async () => {
+    const memory = createMemoryPatchSandbox({ "source.txt": "foo\r\nbar\r\n" });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@ foo
++middle
+*** End Patch`;
+
+    await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/source.txt")).toBe("foo\r\nmiddle\r\nbar\r\n");
+  });
+
+  it("keeps LF files on LF after a real update hunk", async () => {
+    const memory = createMemoryPatchSandbox({ "source.txt": "foo\nbar\n" });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+ foo
+-bar
++baz
+*** End Patch`;
+
+    await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/source.txt")).toBe("foo\nbaz\n");
+  });
+
   it("applies a real deletion of the sole blank line", async () => {
     const memory = createMemoryPatchSandbox({ "source.txt": "\n" });
     const patch = `*** Begin Patch

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -540,6 +540,22 @@ describe("applyPatch", () => {
     expect(memory.files.get("/sandbox/source.txt")).toBe("foo\nbaz\n");
   });
 
+  it("does not normalize mixed line endings outside the changed hunk", async () => {
+    const memory = createMemoryPatchSandbox({
+      "source.txt": "first\r\nsecond\nthird\r\n",
+    });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@
+-second
++changed
+*** End Patch`;
+
+    await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/source.txt")).toBe("first\r\nchanged\nthird\r\n");
+  });
+
   it("applies a real deletion of the sole blank line", async () => {
     const memory = createMemoryPatchSandbox({ "source.txt": "\n" });
     const patch = `*** Begin Patch

--- a/src/agents/line-endings.ts
+++ b/src/agents/line-endings.ts
@@ -1,0 +1,23 @@
+/**
+ * Line-ending detection and restoration shared by the file-mutating agent tools.
+ */
+
+export function detectLineEnding(content: string): "\r\n" | "\n" {
+  const crlfIdx = content.indexOf("\r\n");
+  const lfIdx = content.indexOf("\n");
+  if (lfIdx === -1) {
+    return "\n";
+  }
+  if (crlfIdx === -1) {
+    return "\n";
+  }
+  return crlfIdx < lfIdx ? "\r\n" : "\n";
+}
+
+export function normalizeToLF(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string {
+  return ending === "\r\n" ? text.replace(/\n/g, "\r\n") : text;
+}

--- a/src/agents/line-endings.ts
+++ b/src/agents/line-endings.ts
@@ -18,6 +18,11 @@ export function normalizeToLF(text: string): string {
   return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
+export function hasOnlyCrlfLineEndings(text: string): boolean {
+  const withoutCrlf = text.replaceAll("\r\n", "");
+  return withoutCrlf.length !== text.length && !/[\r\n]/.test(withoutCrlf);
+}
+
 export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string {
   return ending === "\r\n" ? text.replace(/\n/g, "\r\n") : text;
 }

--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { applyEditsToNormalizedContent, generateDiffString, normalizeToLF } from "./edit-diff.js";
+import { normalizeToLF } from "../../line-endings.js";
+import { applyEditsToNormalizedContent, generateDiffString } from "./edit-diff.js";
 
 function getMismatchMessage(
   content: string,

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -7,27 +7,8 @@ import { constants } from "node:fs";
 import { access, readFile } from "node:fs/promises";
 import { createPatch, FILE_HEADERS_ONLY, structuredPatch } from "diff";
 import { levenshteinDistance } from "../../../shared/levenshtein-distance.js";
+import { normalizeToLF } from "../../line-endings.js";
 import { resolveToCwd } from "./path-utils.js";
-
-export function detectLineEnding(content: string): "\r\n" | "\n" {
-  const crlfIdx = content.indexOf("\r\n");
-  const lfIdx = content.indexOf("\n");
-  if (lfIdx === -1) {
-    return "\n";
-  }
-  if (crlfIdx === -1) {
-    return "\n";
-  }
-  return crlfIdx < lfIdx ? "\r\n" : "\n";
-}
-
-export function normalizeToLF(text: string): string {
-  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-}
-
-export function restoreLineEndings(text: string, ending: "\r\n" | "\n"): string {
-  return ending === "\r\n" ? text.replace(/\n/g, "\r\n") : text;
-}
 
 /**
  * Normalize text for fuzzy matching. Applies progressive transformations:

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -12,6 +12,7 @@ import {
 import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
+import { detectLineEnding, normalizeToLF, restoreLineEndings } from "../../line-endings.js";
 import { renderDiff } from "../../modes/interactive/components/diff.js";
 import type { AgentTool } from "../../runtime/index.js";
 import { textResult } from "../../tools/common.js";
@@ -20,15 +21,12 @@ import type { ToolDefinition } from "../extensions/types.js";
 import {
   applyEditsToNormalizedContent,
   computeEditsDiff,
-  detectLineEnding,
   EditNoChangeError,
   type Edit,
   type EditDiffError,
   type EditDiffResult,
   generateDiffString,
   generateUnifiedPatch,
-  normalizeToLF,
-  restoreLineEndings,
   splitNoOpEdits,
   stripBom,
   validateNoOpEditTargets,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users working in a CRLF checkout (Windows with git `core.autocrlf=true`, where the entire working tree is CRLF) would end up with silently corrupted files whenever the agent used `apply_patch`.

Patching a single line of a CRLF file rewrote that line **and every surrounding context line** with a bare LF, leaving a mixed-ending file on disk. Context lines are the ones the patch explicitly declares unchanged, so the agent damaged code it never intended to touch. When the hunk spans the whole file, the file is fully converted.

The visible consequences: `git diff` reports far more changed lines than the model intended, review noise swamps the real change, and for files that must stay CRLF (`.bat`, `.cmd`, some `.ps1` and `.sln` tooling) a half-converted file can change execution behavior.

`apply_patch` ships on by default for every model, so no configuration is needed to hit this. `tools.exec.applyPatch.enabled` defaults to true (`src/config/types.tools.ts`, `src/config/schema.help.runtime.ts`), `isApplyPatchAllowedForModel` returns true for the empty default allowlist (`src/agents/apply-patch-model-policy.ts:11`), and `includeShellTools` defaults to true (`src/agents/agent-tools.ts`).

## Why This Change Was Made

`applyUpdateHunk` split the file with `originalContents.split("\n")`, so on a CRLF file every line kept a trailing `\r` while the patch's own lines never do. Exact matching therefore failed and fell through to the tolerant `value.trimEnd()` normalizer, which is the only reason CRLF files matched at all. The replacement it pushed spans the whole hunk, including context lines, and substituted the patch's CR-less text. `newLines.join("\n")` then wrote those lines back with bare LF.

before, `src/agents/apply-patch-update.ts`:

```ts
const originalLines = originalContents.split("\n");
...
return newLines.join("\n");
```

after:

```ts
const lineEnding = detectLineEnding(originalContents);
const originalLines = normalizeToLF(originalContents).split("\n");
...
return restoreLineEndings(newLines.join("\n"), lineEnding);
```

The repo already owns this contract. The sibling `edit` tool does exactly this at `src/agents/sessions/tools/edit.ts` (`detectLineEnding` -> `normalizeToLF` -> work in LF -> `restoreLineEndings`), and `apply_patch` was the one file-mutating tool that skipped it. Rather than write a second implementation, the three helpers move out of `edit-diff.ts` into `src/agents/line-endings.ts` and both tools now import the same code. That also keeps the `diff` package and the rest of the edit-tool graph out of `apply-patch-update.ts`, which matters given the import-weight guidance in `src/agents/AGENTS.md`.

Boundaries worth naming:

- Matching now hits the exact comparator on CRLF files instead of falling through to `trimEnd()`, so CRLF files get the same match strictness as LF files. The tolerant fallbacks are unchanged for everything else.
- A pure line-ending difference still never triggers a write on its own: `normalizeUpdateComparison` in `apply-patch.ts` already compares ending-insensitively, so a no-op patch stays a no-op.
- Mixed-ending and lone-CR files keep their previous localized behavior. The normalize/restore path is deliberately limited to files whose terminators are uniformly CRLF, avoiding unrelated whole-file churn.

The repo had already committed to this invariant for the no-op case only: `apply-patch.test.ts` carries a case literally named "preserves line endings and EOF state for no-op update hunks" running over `["foo\r\nbar\r\n", "foo\nbar"]`. Any real change bypassed that guard, because the guard holds only by virtue of the write being skipped. This extends an existing invariant rather than proposing a new one.

## User Impact

On a CRLF checkout, `apply_patch` now rewrites only the lines the patch actually changes and leaves the file's line endings intact. Diffs stay scoped to the intended change, and files that depend on CRLF keep working. LF checkouts are unaffected. Agents editing the same file through `edit` and `apply_patch` now produce consistent results instead of depending on which tool the model happened to pick.

## Evidence

Live run of the real `apply_patch` tool built by the production factory `createApplyPatchTool` (the same call `src/agents/agent-tools.ts` makes when it assembles the coding tools), driven against a real on-disk CRLF file in a temp workspace. Real filesystem, real parser, real writer, nothing stubbed. Identical input patch and identical starting file in both runs. Base is pristine `main` at `fde4658bf6bbf74ddfb54a1b41ca23f403645dfa`; head is this branch.

The file is a 5-line CRLF C# source. The patch changes one line and carries two context lines around it:

```
*** Begin Patch
*** Update File: app.cs
@@
   static void Main() {
-    Console.WriteLine("hello");
+    Console.WriteLine("world");
   }
*** End Patch
```

BEFORE, pristine main `fde4658bf6`:

```
tool: apply_patch
before: 82 bytes, 5 CRLF lines, 0 bare-LF lines
tool result: Success. Updated the following files: | M app.cs
after:  79 bytes, 2 CRLF lines, 3 bare-LF lines
on disk: "class Program {\r\n  static void Main() {\n    Console.WriteLine(\"world\");\n  }\n}\r\n"
```

The tool reports success. Three lines silently lost their `\r`, and two of the three are the context lines the patch declared unchanged.

AFTER, this branch, identical inputs:

```
tool: apply_patch
before: 82 bytes, 5 CRLF lines, 0 bare-LF lines
tool result: Success. Updated the following files: | M app.cs
after:  82 bytes, 5 CRLF lines, 0 bare-LF lines
on disk: "class Program {\r\n  static void Main() {\r\n    Console.WriteLine(\"world\");\r\n  }\r\n}\r\n"
```

The one intended line changed. Byte count and all five CRLF terminators are preserved.

### Checks

- `node scripts/run-vitest.mjs src/agents/apply-patch.test.ts src/agents/apply-patch-paths.test.ts src/agents/sessions/tools/edit-diff.test.ts src/agents/sessions/tools/edit.test.ts` passes, 108 assertions across 3 shards.
- The five new cases in `apply-patch.test.ts` cover a CRLF change with context lines, a whole-file CRLF hunk, a CRLF insertion-only hunk, an LF file staying LF, and a mixed-ending file retaining untouched terminators outside the changed hunk. Reverting only `apply-patch-update.ts` to `main` fails the three CRLF cases (`expected 'foo\nbaz\n' to be 'foo\r\nbaz\r\n'`) and passes the LF case, confirming no LF-path change.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` clean on all six changed files.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` reports 197 errors, all under `ui/**` and all identical on the unmodified base commit. None are in the changed files. This is a local dependency-resolution artifact, not something this branch introduces.

Not covered: no run on a real Windows host, and no full `pnpm build` (no dynamic imports, packaging, or published surfaces changed).