### PR TITLE
fix(agents): return Tool Search values directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
+- **Tool Search result values:** expose the existing `callValue` path through Tool Search code mode so agents can consume ordinary tool data directly instead of unpacking the full result envelope.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.
 - **Dev-channel updates:** finish package-to-git switches in a fresh CLI process even when source SHA and version metadata are unchanged, preventing stale hashed chunks from loading after the global package root changes.
 - **Parallels release smoke:** preserve Windows installer reboot results across Parallels, wait for WSL MSI/default-version readiness, force explicit test-owned gateway stops, and reset Linux package, config, and cache state before install lanes, preventing false prerequisite, safety-gate, and stale-config failures.

--- a/docs/tools/tool-search.md
+++ b/docs/tools/tool-search.md
@@ -28,7 +28,7 @@ JavaScript body in an isolated Node subprocess with an `openclaw.tools` bridge:
 ```js
 const hits = await openclaw.tools.search("create a GitHub issue");
 const tool = await openclaw.tools.describe(hits[0].id);
-return await openclaw.tools.call(tool.id, {
+return await openclaw.tools.callValue(tool.id, {
   title: "Crash on startup",
   body: "Steps to reproduce...",
 });
@@ -67,7 +67,7 @@ run:
 
 At execution time every real tool call returns to OpenClaw. The isolated Node
 runtime does not hold plugin implementations, MCP client objects, or secrets.
-`openclaw.tools.call(...)` crosses the bridge back into the Gateway, where the
+`openclaw.tools.callValue(...)` crosses the bridge back into the Gateway, where the
 normal policy, approval, hook, logging, and result handling still apply.
 
 ## Modes
@@ -177,11 +177,11 @@ the trusted full `outputSchema` when the tool declares one.
 const calendarCreate = await openclaw.tools.describe("mcp:calendar:create_event");
 ```
 
-`openclaw.tools.call(id, args)`
+`openclaw.tools.callValue(id, args)`
 
-Calls a selected tool through OpenClaw and returns the raw `{ tool, result }`
-envelope. JSON-returning tools normally place their value in
-`result.details`. OpenClaw validates a trusted core or plugin tool's declared
+Calls a selected tool through OpenClaw and returns its ordinary JSON value. Use
+`openclaw.tools.call(id, args)` when the full `{ tool, result }` envelope is
+needed. OpenClaw validates a trusted core or plugin tool's declared
 input schema before execution. Missing required arguments, incorrect types,
 and forbidden properties return actionable tool errors instead of executing
 the tool; misspelled properties include a suggested parameter when available.
@@ -196,7 +196,7 @@ ambiguous tool selectors instead of calling the wrong tool. Nest target
 arguments under `args` when a target field matches another cataloged tool.
 
 ```js
-await openclaw.tools.call(calendarCreate.id, {
+await openclaw.tools.callValue(calendarCreate.id, {
   summary: "Planning",
   start: "2026-05-09T14:00:00Z",
 });

--- a/src/agents/tool-search-code-mode-child.ts
+++ b/src/agents/tool-search-code-mode-child.ts
@@ -143,6 +143,7 @@ function buildControllerSource() {
     "    search: (query, options) => bridge('search', [query, options]),\n" +
     "    describe: (id) => bridge('describe', [id]),\n" +
     "    call: (id, input) => bridge('call', [id, input]),\n" +
+    "    callValue: (id, input) => bridge('callValue', [id, input]),\n" +
     "  }),\n" +
     "});\n" +
     "return Object.freeze({\n" +

--- a/src/agents/tool-search-code-mode.ts
+++ b/src/agents/tool-search-code-mode.ts
@@ -51,7 +51,7 @@ function buildCodeModeChildArgs(): string[] {
 }
 
 function isCodeModeBridgeMethod(value: unknown): value is CodeModeBridgeMethod {
-  return value === "search" || value === "describe" || value === "call";
+  return value === "search" || value === "describe" || value === "call" || value === "callValue";
 }
 
 async function runCodeModeBridgeRequest(
@@ -89,6 +89,16 @@ async function runCodeModeBridgeRequest(
         throw new ToolInputError("call id must be a string.");
       }
       return await runtime.call(id, values[1] ?? {}, {
+        ...options,
+        recoverySurface: "code-mode",
+      });
+    }
+    case "callValue": {
+      const id = values[0];
+      if (typeof id !== "string") {
+        throw new ToolInputError("callValue id must be a string.");
+      }
+      return await runtime.callValue(id, values[1] ?? {}, {
         ...options,
         recoverySurface: "code-mode",
       });

--- a/src/agents/tool-search-directory.ts
+++ b/src/agents/tool-search-directory.ts
@@ -153,7 +153,7 @@ function renderToolSearchCatalogDirectory(
   const omitted = total - lines.length;
   const guidance =
     mode === "code"
-      ? "Use tool_search_code with openclaw.tools.search(query), openclaw.tools.describe(id), and openclaw.tools.call(id, args)."
+      ? "Use tool_search_code with openclaw.tools.search(query), openclaw.tools.describe(id), and openclaw.tools.callValue(id, args)."
       : omitted > 0
         ? "Use tool_search to find them, then tool_describe to load a full schema before tool_call."
         : "Call tool_describe with a listed tool name to load its full schema before using tool_call.";

--- a/src/agents/tool-search-types.ts
+++ b/src/agents/tool-search-types.ts
@@ -119,7 +119,7 @@ export type ToolSearchCatalogRef = {
   current?: ToolSearchCatalogSession;
 };
 
-export type CodeModeBridgeMethod = "search" | "describe" | "call";
+export type CodeModeBridgeMethod = "search" | "describe" | "call" | "callValue";
 
 export type CodeModeChildMessage =
   | { type: "result"; ok: true; value: unknown }

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -632,7 +632,7 @@ describe("Tool Search", () => {
       "search(query: string, options?)",
     );
     expect(byName.get(TOOL_SEARCH_CODE_MODE_TOOL_NAME)?.description).toContain(
-      "JSON values normally live in `result.details`",
+      "Use `callValue` for ordinary data",
     );
     expect(byName.get(TOOL_SEARCH_RAW_TOOL_NAME)?.description).toContain(
       "use tool_describe only when you need its input schema",
@@ -1022,7 +1022,7 @@ describe("Tool Search", () => {
         code: `
         const hits = await openclaw.tools.search("ticket", { limit: 1 });
         const described = await openclaw.tools.describe(hits[0].id);
-        return await openclaw.tools.call(described.id, { value: "ship" });
+        return await openclaw.tools.callValue(described.id, { value: "ship" });
       `,
       },
     );
@@ -1035,6 +1035,7 @@ describe("Tool Search", () => {
     expect(alphaCall[4]).toBeUndefined();
     const details = resultDetails(result);
     expect(details.ok).toBe(true);
+    expect(details.value).toEqual({ name: "fake_create_ticket", input: { value: "ship" } });
     const telemetry = details.telemetry as {
       catalogSize?: number;
       searchCount?: number;

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -141,7 +141,7 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
       name: TOOL_SEARCH_CODE_MODE_TOOL_NAME,
       label: "Tool Search Code",
       description:
-        "Run JavaScript in an isolated Node subprocess over a large tool catalog. APIs: `openclaw.tools.search(query: string, options?)`, `openclaw.tools.describe(id: string)`, and `openclaw.tools.call(id: string, args?)`. Search takes a positional query string, which must be in English: matching is lexical against tool names and descriptions, which are written in English. Call returns `{ tool, result }`; JSON values normally live in `result.details`.",
+        "Run JavaScript in an isolated Node subprocess over a large tool catalog. APIs: `openclaw.tools.search(query: string, options?)`, `openclaw.tools.describe(id: string)`, `openclaw.tools.callValue(id: string, args?)`, and `openclaw.tools.call(id: string, args?)`. Search takes a positional query string, which must be in English: matching is lexical against tool names and descriptions, which are written in English. Use `callValue` for ordinary data; `call` returns the full `{ tool, result }` envelope.",
       parameters: Type.Object({
         code: Type.String({
           description:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents using Tool Search code mode had to unpack ordinary tool data from the full `{ tool, result }` envelope, even though the shared runtime and full Code Mode already provide a direct value-returning call.

## Why This Change Was Made

Expose the existing `callValue` runtime path through the compact Tool Search bridge. The full-envelope `call` API remains available for callers that need tool metadata or rendered result content.

## User Impact

Agents can consume normal JSON tool results directly with `openclaw.tools.callValue(id, args)`, reducing bridge-output noise and avoiding model-authored `result.details` plumbing.

## Evidence

- `node scripts/run-vitest.mjs src/agents/tool-search.test.ts src/agents/tool-search-runtime.test.ts`
  - 126 tests passed
- branch-level autoreview: clean, no actionable findings
- `git diff --check`

ShellBench follow-up:

- the controlled four-harness r0 is prepared on ten representative tasks
- remote execution is pending Crabbox OAuth completion
- ShellBench draft PR #52 fixes Claude trajectory eligibility before that run
