### PR TITLE
fix(test): require fleet doctor healthy checks

### DIFF
--- a/src/fleet/doctor.runtime.test.ts
+++ b/src/fleet/doctor.runtime.test.ts
@@ -126,6 +126,28 @@ describe("fleet doctor", () => {
         fetchImpl: vi.fn<typeof fetch>(async () => new Response(null, { status: 200 })),
       });
       expect(reports).toHaveLength(1);
+      expect(reports[0]?.findings.map((entry) => entry.check)).toEqual([
+        "runtime-local",
+        "container-present",
+        "container-owned",
+        "container-running",
+        "gateway-health",
+        "cap-drop",
+        "security-opt",
+        "init",
+        "pids-limit",
+        "memory-limit",
+        "cpu-limit",
+        "restart-policy",
+        "port-binding",
+        "gateway-token-env",
+        "network-present",
+        "network-owned",
+        "network-attachments",
+        "network-egress",
+        "data-dir",
+        "auth-dir",
+      ]);
       expect(reports[0]?.findings.every((entry) => entry.status === "pass")).toBe(true);
     },
   );


### PR DESCRIPTION
Related: #115696

## What Problem This Solves

Resolves a test gap where the healthy fleet doctor case could pass vacuously if the doctor returned no findings.

## Why This Change Was Made

The healthy Docker and Podman cases now assert the complete ordered diagnostic set before checking that every finding passes. This keeps the test sensitive to missing checks as well as failing checks.

## User Impact

No user-visible behavior changes. The fleet doctor regression suite now fails when healthy-path diagnostics disappear.

## Evidence

- Blacksmith Testbox `tbx_01kyq45hc2gf7rmb6vekyjycv6`: `pnpm test src/fleet/doctor.runtime.test.ts` passed 16/16 on the exact rebased head.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30460669285
- `oxfmt --check src/fleet/doctor.runtime.test.ts` passed.
- `git diff --check` passed.
- Autoreview (`gpt-5.6-sol`, high): clean, 0.98 confidence.