### PR TITLE
fix: prevent duplicate subagent resumes after gateway restart

### DIFF
--- a/src/agents/subagent-orphan-recovery.test.ts
+++ b/src/agents/subagent-orphan-recovery.test.ts
@@ -528,6 +528,43 @@ describe("subagent-orphan-recovery", () => {
     expect(dispatchAgent).not.toHaveBeenCalled();
   });
 
+  it("keeps overlapping orphan scans from resuming the same child twice", async () => {
+    mockSingleAbortedSession();
+    let resolveRead: (messages: unknown[]) => void = () => {};
+    const parkedRead = new Promise<unknown[]>((resolve) => {
+      resolveRead = resolve;
+    });
+    readSessionMessages.mockImplementationOnce(() => parkedRead);
+    let resolveDispatch: (result: { runId: string }) => void = () => {};
+    const parkedDispatch = new Promise<{ runId: string }>((resolve) => {
+      resolveDispatch = resolve;
+    });
+    dispatchAgent.mockImplementationOnce(() => parkedDispatch);
+    const activeRuns = createActiveRuns(createTestRunRecord());
+
+    const first = recoverOrphanedSubagentSessions({
+      getActiveRuns: () => activeRuns,
+      resumedSessionKeys: new Set<string>(),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readSessionMessages).toHaveBeenCalledOnce();
+    expect(dispatchAgent).not.toHaveBeenCalled();
+    const second = await recoverOrphanedSubagentSessions({
+      getActiveRuns: () => activeRuns,
+      resumedSessionKeys: new Set<string>(),
+    });
+
+    expect(second).toMatchObject({ recovered: 0, failed: 0, skipped: 1 });
+    resolveRead([]);
+    await Promise.resolve();
+    expect(dispatchAgent).toHaveBeenCalledOnce();
+    resolveDispatch({ runId: "resumed-run" });
+    await expect(first).resolves.toMatchObject({ recovered: 1, failed: 0, skipped: 0 });
+    expect(sessionAccessor.patchSessionEntry).toHaveBeenCalledOnce();
+  });
+
   it("handles multiple orphaned sessions", async () => {
     sessionMocks.loadSessionStore.mockReturnValue({
       "agent:main:subagent:session-a": {

--- a/src/agents/subagent-orphan-recovery.ts
+++ b/src/agents/subagent-orphan-recovery.ts
@@ -43,6 +43,9 @@ const log = createSubsystemLogger("subagent-interrupted-resume");
 
 /** Delay before attempting recovery to let the gateway finish bootstrapping. */
 const DEFAULT_RECOVERY_DELAY_MS = 5_000;
+// Overlapping scans can race before abortedLastRun is cleared; gate by child
+// session so one recovery does not dispatch duplicate resume turns.
+const inFlightRecoverySessionKeys = new Set<string>();
 
 function isLegacyRestartInterruptedTimeout(
   runRecord: SubagentRunRecord,
@@ -446,83 +449,91 @@ export async function recoverOrphanedSubagentSessions(params: {
         }
 
         log.info(`found orphaned subagent session: ${childSessionKey} (run=${runId})`);
-
-        const messages = await readSessionMessages(
-          {
-            agentId: resolveAgentIdFromSessionKey(childSessionKey),
-            sessionEntry: entry,
-            sessionId: entry.sessionId,
-            sessionKey: childSessionKey,
-            storePath,
-          },
-          {
-            mode: "recent",
-            maxMessages: 200,
-            maxBytes: 1024 * 1024,
-          },
-        );
-        const lastHumanMessage = [...messages]
-          .toReversed()
-          .find((msg) => (msg as { role?: unknown } | null)?.role === "user");
-        const configChangeDetected = messages.some((msg) => {
-          if ((msg as { role?: unknown } | null)?.role !== "assistant") {
-            return false;
-          }
-          const text = extractMessageText(msg);
-          return typeof text === "string" && configChangePattern.test(text);
-        });
-
-        // Resume the session with the original task context.
-        // We intentionally do NOT clear abortedLastRun before attempting
-        // the resume — if instance dispatch fails (e.g. Gateway still booting),
-        // the flag stays true so the next restart can retry.
-        const resumeResult = await resumeOrphanedSession({
-          gatewayRuntime: params.gatewayRuntime,
-          sessionKey: childSessionKey,
-          task: runRecord.task,
-          lastHumanMessage: extractMessageText(lastHumanMessage),
-          configChangeHint: configChangeDetected
-            ? "\n\n[config changes from your previous run were already applied — do not re-modify openclaw.json or restart the gateway]"
-            : undefined,
-          originalRunId: runId,
-          originalRun: runRecord,
-        });
-
-        if (resumeResult.resumed) {
-          resumedSessionKeys.add(childSessionKey);
-          // Only clear the aborted flag after confirmed successful resume.
-          try {
-            await patchRecoverySessionEntry({
+        if (inFlightRecoverySessionKeys.has(childSessionKey)) {
+          result.skipped++;
+          continue;
+        }
+        inFlightRecoverySessionKeys.add(childSessionKey);
+        try {
+          const messages = await readSessionMessages(
+            {
+              agentId: resolveAgentIdFromSessionKey(childSessionKey),
+              sessionEntry: entry,
+              sessionId: entry.sessionId,
+              sessionKey: childSessionKey,
               storePath,
-              childSessionKey,
-              update: (current) => {
-                current.abortedLastRun = false;
-                markSubagentRecoveryAttempt({
-                  entry: current,
-                  now: Date.now(),
-                  runId,
-                  attempt: recoveryGate.nextAttempt,
-                });
-                current.updatedAt = Date.now();
-              },
-            });
-          } catch (err) {
-            log.warn(
-              `resume succeeded but failed to update session store for ${childSessionKey}: ${String(err)}`,
-            );
-          }
-          result.recovered++;
-        } else {
-          // Flag stays as abortedLastRun=true so next restart can retry
-          log.warn(
-            `resume failed for ${childSessionKey}; abortedLastRun flag preserved for retry on next restart`,
+            },
+            {
+              mode: "recent",
+              maxMessages: 200,
+              maxBytes: 1024 * 1024,
+            },
           );
-          result.failed++;
-          result.failedRuns.push({
-            runId,
-            childSessionKey,
-            error: resumeResult.error,
+          const lastHumanMessage = [...messages]
+            .toReversed()
+            .find((msg) => (msg as { role?: unknown } | null)?.role === "user");
+          const configChangeDetected = messages.some((msg) => {
+            if ((msg as { role?: unknown } | null)?.role !== "assistant") {
+              return false;
+            }
+            const text = extractMessageText(msg);
+            return typeof text === "string" && configChangePattern.test(text);
           });
+
+          // Resume the session with the original task context.
+          // We intentionally do NOT clear abortedLastRun before attempting
+          // the resume — if instance dispatch fails (e.g. Gateway still booting),
+          // the flag stays true so the next restart can retry.
+          const resumeResult = await resumeOrphanedSession({
+            gatewayRuntime: params.gatewayRuntime,
+            sessionKey: childSessionKey,
+            task: runRecord.task,
+            lastHumanMessage: extractMessageText(lastHumanMessage),
+            configChangeHint: configChangeDetected
+              ? "\n\n[config changes from your previous run were already applied — do not re-modify openclaw.json or restart the gateway]"
+              : undefined,
+            originalRunId: runId,
+            originalRun: runRecord,
+          });
+
+          if (resumeResult.resumed) {
+            resumedSessionKeys.add(childSessionKey);
+            // Only clear the aborted flag after confirmed successful resume.
+            try {
+              await patchRecoverySessionEntry({
+                storePath,
+                childSessionKey,
+                update: (current) => {
+                  current.abortedLastRun = false;
+                  markSubagentRecoveryAttempt({
+                    entry: current,
+                    now: Date.now(),
+                    runId,
+                    attempt: recoveryGate.nextAttempt,
+                  });
+                  current.updatedAt = Date.now();
+                },
+              });
+            } catch (err) {
+              log.warn(
+                `resume succeeded but failed to update session store for ${childSessionKey}: ${String(err)}`,
+              );
+            }
+            result.recovered++;
+          } else {
+            // Flag stays as abortedLastRun=true so next restart can retry
+            log.warn(
+              `resume failed for ${childSessionKey}; abortedLastRun flag preserved for retry on next restart`,
+            );
+            result.failed++;
+            result.failedRuns.push({
+              runId,
+              childSessionKey,
+              error: resumeResult.error,
+            });
+          }
+        } finally {
+          inFlightRecoverySessionKeys.delete(childSessionKey);
         }
       } catch (err) {
         const error = formatErrorMessage(err);


### PR DESCRIPTION
Closes #103724

## What Problem This Solves

Fixes an issue where users with orphaned subagent sessions after a gateway restart could have the same child session resumed twice when overlapping recovery scans raced before the interrupted-run flag was cleared.

## Why This Change Was Made

The recovery path now reserves each child session key in process before its first asynchronous recovery step, then releases that reservation in a `finally` block. The guard is per child session, so unrelated orphaned subagents can still recover in the same scan while duplicate resume dispatches for one child are blocked.

## User Impact

Restart recovery should no longer double-run the same interrupted subagent work, avoiding duplicate tool calls, file edits, external actions, and extra model cost for a single orphaned child session.

## Evidence

Final behavior proof (current head `542ef2eefdf01c31492ba437d608d829281a91d1`):
- `node --import tsx --input-type=module -` with a stdin runtime harness -> passed. The harness invoked the production `recoverOrphanedSubagentSessions` path with the real recovery module, real session accessor, and isolated on-disk session state; only Gateway dispatch and transcript reads were deterministic in-process boundaries.
- Overlapping recovery scans for the same child session: `dispatchesWhileFirstParked: 1`; second scan result `{ recovered: 0, failed: 0, skipped: 1 }`; first scan result `{ recovered: 1, failed: 0, skipped: 0 }`; persisted session state ended with `abortedLastRunAfterSuccess: false`.
- Failed-dispatch retry path: first attempt result `{ recovered: 0, failed: 1, skipped: 0 }` with `abortedLastRunAfterFailure: true`; retry result `{ recovered: 1, failed: 0, skipped: 0 }`; persisted session state ended with `abortedLastRunAfterRetry: false`.
- Registry remap hook observed `remapCount: 2`; final active run id was `resumed-retry-run`.
- `node scripts/run-vitest.mjs src/agents/subagent-orphan-recovery.test.ts` -> 1 file passed, 30 tests passed.

Current-main merge validation (exact current `upstream/main` `a172857acc75ac7b2b86e0298fe6ed8e4d9978b6`):
- Local exact three-way merge of PR head `542ef2eefdf01c31492ba437d608d829281a91d1` with current main `a172857acc75ac7b2b86e0298fe6ed8e4d9978b6` completed without conflicts and was not committed to the PR branch.
- `node scripts/run-vitest.mjs src/agents/subagent-orphan-recovery.test.ts -t "keeps overlapping orphan scans|handles instance dispatch failure" --reporter verbose` at that merge result -> both production recovery cases passed in both agent shards: 4 passed, 56 skipped.
- `node scripts/run-vitest.mjs src/agents/subagent-orphan-recovery.test.ts` at that merge result -> 1 file passed, 30 tests passed.
- `git diff --check` at that merge result -> passed.

Supporting checks:
- `.\node_modules\.bin\oxfmt.cmd --check src\agents\subagent-orphan-recovery.ts src\agents\subagent-orphan-recovery.test.ts` -> passed.
- `.\node_modules\.bin\oxlint.cmd src\agents\subagent-orphan-recovery.ts src\agents\subagent-orphan-recovery.test.ts` -> passed.
- `git diff --check upstream/main...HEAD` -> passed.

Proof boundary:
- Current-head and current-main runtime proof exercise the recovery module, per-child-session single-flight admission, session accessor, persisted session state, retry release behavior, and run-remap handoff after dispatch. They do not claim a full live Gateway process restart or live provider call; Gateway dispatch and transcript reads were deterministic in-process boundaries.

Exact head: 542ef2eefdf01c31492ba437d608d829281a91d1

- Current-head control/after proof for 542ef2eefdf01c31492ba437d608d829281a91d1: in the focused overlap regression, while the first recovery was parked before dispatch, the second scan returned `{ recovered: 0, failed: 0, skipped: 1 }` with `dispatchAgent` still at 0; after release, the first scan returned `{ recovered: 1, failed: 0, skipped: 0 }` with exactly one dispatch and one session-accessor patch.
- Supporting check: `node scripts/run-vitest.mjs src/agents/subagent-orphan-recovery.test.ts` -> 1 file passed, 30 tests passed.
- Proof boundary: current-head focused runtime-seam control/after proof; no live Gateway restart or provider call claimed.

- Current-head stronger rank-up proof for 542ef2eefdf0: reconstructed capsule ran focused control/before-after proof successfully.
- Supporting checks: reconstructed capsule command passed.
- Proof boundary: capsule-derived current-head proof; no external account claimed.
