### PR TITLE
refactor(context-engine): remove legacy host parameter default

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -204,9 +204,8 @@ Set `info.acceptedHostParams` to the host-added lifecycle fields the engine
 accepts. Current keys are `sessionKey`, `prompt`, `runtimeSettings`,
 `sessionTarget`, and `runtimeContext`. OpenClaw intersects the declaration with
 the fields available for each lifecycle method, so undeclared or unknown keys
-are never injected. Engines without this declaration receive the pre-host-field
-legacy parameter set through 2026-08-12; after that date, undeclared engines
-receive every current host field.
+are never injected. Engines without this declaration receive every current host
+field.
 
 `assemble` returns an `AssembleResult` with:
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -618,10 +618,10 @@ For an end-to-end authoring guide, see
 
 ### Exclusive slots
 
-| Method                                     | What it registers                                                                                                                                                                                                             |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api.registerContextEngine(id, factory)`   | Context engine (one active at a time). Declare accepted host-added lifecycle fields with `info.acceptedHostParams`; undeclared engines receive the legacy field set through 2026-08-12, then receive all current host fields. |
-| `api.registerMemoryCapability(capability)` | Unified memory capability                                                                                                                                                                                                     |
+| Method                                     | What it registers                                                                                                                                                       |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api.registerContextEngine(id, factory)`   | Context engine (one active at a time). Declare accepted host-added lifecycle fields with `info.acceptedHostParams`; undeclared engines receive all current host fields. |
+| `api.registerMemoryCapability(capability)` | Unified memory capability                                                                                                                                               |
 
 ### Deprecated memory embedding adapters
 

--- a/src/context-engine/host-param-projection.test.ts
+++ b/src/context-engine/host-param-projection.test.ts
@@ -82,7 +82,6 @@ describe("context-engine host parameter projection", () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -90,17 +89,11 @@ describe("context-engine host parameter projection", () => {
     restoreRegistry();
   });
 
-  it("passes declared current host parameters", async () => {
+  it("passes exactly the declared current host parameters", async () => {
     const assembleCalls: Array<Record<string, unknown>> = [];
     const compactCalls: Array<Record<string, unknown>> = [];
     const engineId = registerProbeEngine({
-      acceptedHostParams: [
-        "sessionKey",
-        "prompt",
-        "runtimeSettings",
-        "sessionTarget",
-        "runtimeContext",
-      ],
+      acceptedHostParams: ["prompt", "sessionTarget"],
       assembleCalls,
       compactCalls,
     });
@@ -109,22 +102,18 @@ describe("context-engine host parameter projection", () => {
       await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } }),
     );
 
-    expect(assembleCalls[0]).toMatchObject({
-      sessionKey: "agent:main:session-1",
+    expect(assembleCalls[0]).toEqual({
+      sessionId: "session-1",
+      messages: [message],
       prompt: "hello",
-      runtimeSettings,
     });
-    expect(compactCalls[0]).toMatchObject({
-      sessionKey: "agent:main:session-1",
+    expect(compactCalls[0]).toEqual({
+      sessionId: "session-1",
       sessionTarget: { agentId: "main", sessionId: "session-1" },
-      runtimeSettings,
-      runtimeContext: { tokenBudget: 1000 },
     });
   });
 
-  it("uses the legacy parameter set for undeclared engines during the window", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-29T12:00:00Z"));
+  it("passes full host parameters to undeclared engines", async () => {
     const assembleCalls: Array<Record<string, unknown>> = [];
     const compactCalls: Array<Record<string, unknown>> = [];
     const engineId = registerProbeEngine({ assembleCalls, compactCalls });
@@ -133,30 +122,20 @@ describe("context-engine host parameter projection", () => {
       await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } }),
     );
 
-    for (const call of [...assembleCalls, ...compactCalls]) {
-      expect(call).not.toHaveProperty("sessionKey");
-      expect(call).not.toHaveProperty("runtimeSettings");
-    }
-    expect(assembleCalls[0]).not.toHaveProperty("prompt");
-    expect(compactCalls[0]).not.toHaveProperty("sessionTarget");
-    expect(compactCalls[0]).not.toHaveProperty("runtimeContext");
-    expect(compactCalls[0]).toHaveProperty("sessionId", "session-1");
-  });
-
-  it("passes full host parameters to undeclared engines after the window", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-29T12:00:00Z"));
-    const assembleCalls: Array<Record<string, unknown>> = [];
-    const compactCalls: Array<Record<string, unknown>> = [];
-    const engineId = registerProbeEngine({ assembleCalls, compactCalls });
-    const engine = await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
-
-    vi.setSystemTime(new Date("2026-08-13T00:00:00Z"));
-    await invokeHostParamMethods(engine);
-
-    expect(assembleCalls[0]).toHaveProperty("sessionKey", "agent:main:session-1");
-    expect(assembleCalls[0]).toHaveProperty("prompt", "hello");
-    expect(compactCalls[0]).toHaveProperty("runtimeContext", { tokenBudget: 1000 });
+    expect(assembleCalls[0]).toEqual({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      messages: [message],
+      prompt: "hello",
+      runtimeSettings,
+    });
+    expect(compactCalls[0]).toEqual({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionTarget: { agentId: "main", sessionId: "session-1" },
+      runtimeSettings,
+      runtimeContext: { tokenBudget: 1000 },
+    });
   });
 
   it("does not retry validator-shaped engine failures", async () => {
@@ -185,15 +164,13 @@ describe("context-engine host parameter projection", () => {
   });
 
   it("does not mutate frozen engines reused by a factory", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-29T12:00:00Z"));
     const engineId = `host-param-frozen-${++engineCounter}`;
     const assemble = vi.fn<ContextEngine["assemble"]>(async (params) => ({
       messages: params.messages,
       estimatedTokens: 0,
     }));
     class FrozenProbeEngine implements ContextEngine {
-      readonly #info = { id: engineId, name: "Frozen Probe" };
+      readonly #info = { id: engineId, name: "Frozen Probe", acceptedHostParams: [] };
 
       get info() {
         return this.#info;
@@ -214,7 +191,7 @@ describe("context-engine host parameter projection", () => {
 
     const first = await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
     const second = await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
-    expect(first.info).toEqual({ id: engineId, name: "Frozen Probe" });
+    expect(first.info).toEqual({ id: engineId, name: "Frozen Probe", acceptedHostParams: [] });
     await first.assemble({ sessionId: "session-1", sessionKey: "first", messages: [message] });
     await second.assemble({ sessionId: "session-2", sessionKey: "second", messages: [message] });
 

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -2,7 +2,6 @@
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { createAbortError } from "../infra/abort-signal.js";
-import { getPluginCompatRecord } from "../plugins/compat/registry.js";
 import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import {
@@ -66,8 +65,10 @@ export const CONTEXT_ENGINE_HOST_PARAMS = new Set(
   "sessionKey prompt runtimeSettings sessionTarget runtimeContext".split(" "),
 );
 function wrapContextEngineWithHostParamProjection(engine: ContextEngine): ContextEngine {
-  const removeAfter = getPluginCompatRecord("context-engine-legacy-host-param-default").removeAfter;
   const accepted = engine.info.acceptedHostParams;
+  if (!accepted) {
+    return engine;
+  }
   const engineRecord = engine as unknown as Record<PropertyKey, unknown>;
   const wrappedRecord: Record<PropertyKey, unknown> = {};
   Object.defineProperty(wrappedRecord, "info", { get: () => engine.info });
@@ -77,16 +78,9 @@ function wrapContextEngineWithHostParamProjection(engine: ContextEngine): Contex
       continue;
     }
     wrappedRecord[methodName] = (params: Record<string, unknown>) => {
-      // Removal(2026-08-12): undeclared engines get full params. Contract: context-engine-legacy-host-param-default.
-      const useLegacyDefault =
-        removeAfter !== undefined && new Date().toISOString().slice(0, 10) <= removeAfter;
-      const currentAccepted = accepted ?? (useLegacyDefault ? [] : undefined);
-      if (!currentAccepted) {
-        return method.call(engine, params);
-      }
       const projected = Object.fromEntries(
         Object.entries(params).filter(
-          ([key]) => currentAccepted.includes(key) || !CONTEXT_ENGINE_HOST_PARAMS.has(key),
+          ([key]) => accepted.includes(key) || !CONTEXT_ENGINE_HOST_PARAMS.has(key),
         ),
       );
       return method.call(engine, projected);

--- a/src/plugins/compat/registry-records.ts
+++ b/src/plugins/compat/registry-records.ts
@@ -12,21 +12,6 @@ export const PLUGIN_COMPAT_RECORDS = [
   ...DEPRECATION_MARKING_COMPAT_RECORDS,
   MEDIA_LEGACY_PROJECTION_COMPAT_RECORD,
   {
-    code: "context-engine-legacy-host-param-default",
-    status: "deprecated",
-    owner: "sdk",
-    introduced: "2026-07-29",
-    deprecated: "2026-07-29",
-    warningStarts: "2026-07-29",
-    removeAfter: "2026-08-12",
-    replacement:
-      "declare `ContextEngineInfo.acceptedHostParams`; full host params after the window",
-    docsPath: "/concepts/context-engine#the-contextengine-interface",
-    surfaces: ["ContextEngineInfo.acceptedHostParams and undeclared-engine default projection"],
-    diagnostics: ["plugin compatibility registry and dated runtime removal marker"],
-    tests: ["src/context-engine/host-param-projection.test.ts"],
-  },
-  {
     code: "removed-global-api-provider-publication",
     status: "removed",
     owner: "sdk",

--- a/src/plugins/compat/registry.test.ts
+++ b/src/plugins/compat/registry.test.ts
@@ -166,19 +166,6 @@ describe("plugin compatibility registry", () => {
     );
   });
 
-  it("tracks the context-engine legacy host-param default through its two-week window", () => {
-    const record = listPluginCompatRecords().find(
-      (candidate) => candidate.code === "context-engine-legacy-host-param-default",
-    );
-
-    expect(record).toMatchObject({
-      status: "deprecated",
-      deprecated: "2026-07-29",
-      warningStarts: "2026-07-29",
-      removeAfter: "2026-08-12",
-    });
-  });
-
   it("keeps deprecated explicit target parser calls inside compatibility shims", () => {
     expect(deprecatedTargetParserOffenders).toEqual([]);
   });


### PR DESCRIPTION
Related: #115872

## What Problem This Solves

This draft is the scheduled cleanup for the temporary context-engine host-parameter compatibility default. It cannot be landed as a behavior-neutral refactor on August 9, 2026: current main and public docs preserve that default through August 12 inclusive.

## Why This Change Was Made

The repair pass is stopped pending maintainer decision. `src/context-engine/registry.ts` currently strips all five host-added fields from undeclared engines while the compatibility window is active. Removing that branch today immediately sends those fields and weakens a shipped public plugin contract.

The newest known external engine is ready: Martian Engineering's LosslessClaw PR #1046 merged, and npm shows `@martian-engineering/lossless-claw@0.15.1` published July 29 with `acceptedHostParams`. That does not update pinned or older installed engines, and the SDK still permits other undeclared third-party engines.

On August 13, deleting the expired branch can be behavior-neutral because current main already changes to the full-parameter default on that date. The eventual rewrite must be made against the current centralized projection helper, not by reviving this stale branch wholesale.

## User Impact

No change is landed. An early merge would expose undeclared engines to `sessionKey`, `prompt`, `runtimeSettings`, `sessionTarget`, and `runtimeContext` before the documented cutoff. LosslessClaw versions at or below 0.3.x are the known hard-failure risk; not every pre-0.15.1 version is known to reject extra fields.

## Evidence

- Current date: 2026-08-09. `src/context-engine/registry.ts:68-73` uses the legacy default through `removeAfter` inclusive.
- `src/plugins/compat/registry-records.ts:14-27` records the 2026-08-12 shipped SDK window; `docs/concepts/context-engine.md:217-223` and `docs/plugins/sdk-overview.md:624` publish the same promise.
- `src/context-engine/host-param-projection.test.ts:131-150` proves undeclared engines receive no host-added fields during the window; `:238-293` proves full fields after it.
- The contract shipped in `v2026.7.2-beta.6` and `v2026.7.2-beta.7`, so early removal is a public compatibility decision, not dead-code cleanup.
- Upstream LosslessClaw PR #1046 merged July 29. Registry truth: npm latest is `0.15.1`, published `2026-07-29T16:29:49.895Z`; its source declares `sessionKey`, `prompt`, and `runtimeContext`.
- Existing installations do not update automatically; exact/tagged specs remain pinned as documented in `docs/cli/plugins.md:432-458`.
- Latest ClawSweeper rank-up moves remain applicable: preserve the gate until satisfied, port onto current main, fix the stale `runtimeSettings` window wording at `docs/concepts/context-engine.md:307-310`, and add installed declared/undeclared engine proof.

Decision-gate outcome: stopped without code changes or merge. Re-evaluate on or after 2026-08-13, or merge earlier only with explicit maintainer acceptance of the compatibility cutoff.
