### PR TITLE
refactor: reuse canonical record guards

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,3 +1,3 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it.
-519
+518

--- a/scripts/dev/gateway-smoke.ts
+++ b/scripts/dev/gateway-smoke.ts
@@ -1,5 +1,6 @@
 // Gateway Smoke script supports OpenClaw repository automation.
 import { fileURLToPath } from "node:url";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   MIN_CLIENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
@@ -86,10 +87,6 @@ function parseGatewaySmokeCli(
     token: getArg("--token") ?? env.OPENCLAW_GATEWAY_TOKEN,
     urlRaw: getArg("--url") ?? env.OPENCLAW_GATEWAY_URL,
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function hasHealthSummaryPayload(response: unknown): boolean {

--- a/scripts/dev/ios-node-e2e.ts
+++ b/scripts/dev/ios-node-e2e.ts
@@ -1,5 +1,6 @@
 // Ios Node E2E script supports OpenClaw repository automation.
 import { randomUUID } from "node:crypto";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   MIN_CLIENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
@@ -144,10 +145,6 @@ function parseWaitSeconds(raw: string | undefined): number {
     process.exit(1);
   }
   return parsed;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function payloadShapeError(command: string, payload: unknown): string | null {

--- a/scripts/e2e/lib/agent-turn-output.mjs
+++ b/scripts/e2e/lib/agent-turn-output.mjs
@@ -1,5 +1,6 @@
 // Helpers for extracting agent turn output from E2E protocol events.
 import fs from "node:fs";
+import { isRecord } from "../../lib/record-shared.mjs";
 import { readTextFileTail, tailText } from "./text-file-utils.mjs";
 
 const ERROR_DETAIL_TAIL_BYTES = 64 * 1024;
@@ -148,10 +149,6 @@ function parseJsonPayloads(text) {
 
 function textValues(values) {
   return values.filter((value) => typeof value === "string" && value.length > 0);
-}
-
-function isRecord(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function isFailureStatus(value) {

--- a/scripts/e2e/lib/auth-profile-store-assertions.mjs
+++ b/scripts/e2e/lib/auth-profile-store-assertions.mjs
@@ -1,7 +1,5 @@
 // Shared auth profile store assertions for install/onboard E2E proof.
-function isRecord(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
+import { isRecord } from "../../lib/record-shared.mjs";
 
 function hasExpectedOpenAiEnvRef(profile) {
   if (!isRecord(profile)) {

--- a/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
+++ b/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import process from "node:process";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+import { isRecord } from "../../../lib/record-shared.mjs";
 import { resolveWindowsTaskkillPath } from "../../../lib/windows-taskkill.mjs";
 import { readBoundedResponseText } from "../bounded-response-text.mjs";
 
@@ -991,10 +992,6 @@ function hasOwnPayloadField(raw, field) {
     ((typeof raw === "object" && raw !== null) || typeof raw === "function") &&
     Object.hasOwn(raw, field)
   );
-}
-
-function isRecord(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 export function unwrapRpcPayload(raw) {

--- a/scripts/e2e/lib/gateway-network/client.mjs
+++ b/scripts/e2e/lib/gateway-network/client.mjs
@@ -4,6 +4,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { request as httpRequest } from "node:http";
 import { pathToFileURL } from "node:url";
 import { WebSocket } from "ws";
+import { isRecord } from "../../../lib/record-shared.mjs";
 import { sleep as delay } from "../../../lib/sleep.mjs";
 import { waitForWebSocketOpen } from "../websocket-open.mjs";
 import { readGatewayNetworkClientConnectTimeoutMs } from "./limits.mjs";
@@ -22,10 +23,6 @@ async function openSocket(url, timeoutMs = 10_000) {
   const ws = new WebSocket(url);
   await waitForWebSocketOpen(ws, timeoutMs, "ws open timeout");
   return ws;
-}
-
-function isRecord(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 function hasGatewayHealthSummaryPayload(response) {

--- a/scripts/e2e/lib/live-plugin-tool/assertions.mjs
+++ b/scripts/e2e/lib/live-plugin-tool/assertions.mjs
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { isRecord } from "../../../lib/record-shared.mjs";
 import { extractAgentReplyTexts } from "../agent-turn-output.mjs";
 import { readPluginInstallRecords } from "../plugin-index-sqlite.mjs";
 import { readTextFileTail, tailText } from "../text-file-utils.mjs";
@@ -62,10 +63,6 @@ function agentOutputPath() {
 
 function agentErrorPath() {
   return process.env.OPENCLAW_LIVE_PLUGIN_TOOL_AGENT_ERROR_PATH || "/tmp/openclaw-agent.err";
-}
-
-function isRecord(value) {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 function readNonEmptyString(value) {

--- a/scripts/lib/record-shared.d.mts
+++ b/scripts/lib/record-shared.d.mts
@@ -1,0 +1,5 @@
+/** Return whether a value is a non-array object record. */
+export function isRecord(value: unknown): value is Record<string, unknown>;
+
+/** Trim string values while converting non-strings to an empty string. */
+export function trimString(value: unknown): string;

--- a/scripts/validate-qa-runtime-pair-summary.mjs
+++ b/scripts/validate-qa-runtime-pair-summary.mjs
@@ -4,6 +4,7 @@
 import fs from "node:fs";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
+import { isRecord } from "./lib/record-shared.mjs";
 
 const RUNTIME_IDS = ["openclaw", "codex"];
 const HARD_RUNTIME_ERROR_CLASSES = new Set([
@@ -59,10 +60,6 @@ const FROZEN_RUNTIME_PAIR_MANIFESTS = new Map([
   ["311047822ecdde24e824d839ab105ef08f17be00:core", FROZEN_CORE_RUNTIME_PAIR_MANIFEST],
   ["c37af96b18776fecc9e24268f27fc89b563481bf:core", FROZEN_CORE_RUNTIME_PAIR_MANIFEST],
 ]);
-
-function isRecord(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function isPassableCell(cell) {
   if (!isRecord(cell) || typeof cell.transportErrorClass === "string") {

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -6,6 +6,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   getRuntimeConfig,
   getRuntimeConfigSourceSnapshot,
@@ -163,17 +164,13 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   };
 }
 
-function isRecordLike(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 async function mergeGeneratedPluginCatalogProvidersIntoExistingParsed(params: {
   agentDir: string;
   existingParsed: unknown;
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "owners">;
 }): Promise<unknown> {
-  const root = isRecordLike(params.existingParsed) ? params.existingParsed : {};
-  const providers = isRecordLike(root.providers) ? { ...root.providers } : {};
+  const root = isRecord(params.existingParsed) ? params.existingParsed : {};
+  const providers = isRecord(root.providers) ? { ...root.providers } : {};
   let changed = false;
   for (const { pluginId: catalogPluginId, contents } of listPreparedPluginModelCatalogs(
     params.agentDir,
@@ -186,8 +183,8 @@ async function mergeGeneratedPluginCatalogProvidersIntoExistingParsed(params: {
     }
     if (
       !isGeneratedPluginModelCatalog(catalog) ||
-      !isRecordLike(catalog) ||
-      !isRecordLike(catalog.providers)
+      !isRecord(catalog) ||
+      !isRecord(catalog.providers)
     ) {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

Removes remaining exact copies of OpenClaw's plain-record predicate from agent and tooling paths so those callers do not drift from the canonical guard implementations.

This PR also lowers the environment-variable count ratchet from 519 to 518. Current `main` removed one counted `OPENCLAW_*` reference without updating the baseline, which otherwise makes `check:changed` fail before reaching this refactor.

## Why This Change Was Made

TypeScript callers now use `@openclaw/normalization-core/record`, while dependency-light standalone scripts use the existing `scripts/lib/record-shared.mjs` helper. Intentional semantic variants and owner-boundary-specific guards remain untouched.

The CI ratchet correction is isolated in its own commit and only records the count already present on `main`.

## User Impact

No user-visible behavior changes. Maintainers get one canonical implementation per runtime boundary and a green environment-variable ratchet.

## Evidence

- 422 focused tests passed across unit-fast, tooling, agents-core, and E2E Vitest shards, including the old-release-target wrapper regression.
- Targeted `oxfmt`, syntax checks, `git diff --check`, and the script declaration contract check passed.
- Structured autoreview completed with no accepted or actionable findings (`correctness: 0.98`).
- A delegated Blacksmith Testbox changed gate passed on the initial cleanup stack.
- Exact-head CI completed successfully: https://github.com/openclaw/openclaw/actions/runs/30463008859
- `scripts/pr prepare-run 115951` passed review guard, artifact validation, hosted gates, and exact remote-head binding at `d220ecc41de3e4d4fd5dc8222980188df865e0c8`.