### PR TITLE
fix(ci): unblock checks after ClawHub environment cleanup

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,3 +1,3 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it.
-519
+518


### PR DESCRIPTION
Related: #115654

## What Problem This Solves

Fixes an issue where all pull requests and main-branch checks fail the production environment-variable ratchet after a redundant ClawHub workspace denylist prefix was removed.

## Why This Change Was Made

Commit fde4658bf6bbf74ddfb54a1b41ca23f403645dfa (#115654) correctly removed the redundant OPENCLAW_CLAWHUB_ prefix: the existing OPENCLAW_ namespace already blocks the same untrusted workspace variables. The canonical production scanner now finds 518 distinct names, while the ratchet still expected 519. Lower the existing budget to the observed count; leave the scanner, production denylist, and security regression tests unchanged.

## User Impact

Pull requests and main-branch checks can pass the environment-variable gate again. Workspace ClawHub security and runtime configuration behavior do not change.

## Evidence

- Pinned clean main 41f118cec3ab3a890477a3e64b378285dea8e8d7, actual before: `node scripts/check-env-var-count.mjs --base origin/main` exits 1 with `OPENCLAW_* count 518 is below budget 519`.
- Actual after: the same canonical command exits 0 with `OPENCLAW_* count 518/518`.
- `node scripts/run-vitest.mjs src/infra/dotenv-workspace-blocklist.test.ts --reporter=verbose`: 1 file, 7 tests passed, including the existing ClawHub workspace denylist.
- `node scripts/run-vitest.mjs test/scripts/check-env-var-count.test.ts --reporter=verbose`: 1 file, 9 tests passed, including the existing stale-headroom regression.
- `git diff --check` passes; immutable comparison changes only `config/env-var-count-budget.txt`.
- Fresh AI-assisted Codex gpt-5.6-sol xhigh structured autoreview: clean, no accepted or actionable findings.