### PR TITLE
fix(mac): hide duplicate Gateway in dashboard picker over SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **macOS and Control UI keyboard navigation:** let Tab traverse links and controls inside embedded Dashboard, browser, and Canvas web views, and keep shortcuts working on non-Latin keyboard layouts without firing during IME composition.
+- **macOS dashboard Gateway picker:** collapse a saved Gateway profile into the active primary row when both resolve to the same SSH tunnel endpoint, so one configured Gateway no longer appears twice.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **macOS and Control UI keyboard navigation:** let Tab traverse links and controls inside embedded Dashboard, browser, and Canvas web views, and keep shortcuts working on non-Latin keyboard layouts without firing during IME composition.
-- **macOS dashboard Gateway picker:** collapse a saved Gateway profile into the active primary row when both resolve to the same SSH tunnel endpoint, so one configured Gateway no longer appears twice.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
@@ -107,7 +107,6 @@ enum DashboardGatewayCatalog {
     static func loadEntries() async throws -> [DashboardGatewayEntry] {
         let state = AppStateStore.shared
         let root = OpenClawConfigFile.loadDict()
-        let resolution = GatewayRemoteConfig.resolveTransportResolution(root: root)
         let profiles = try await MacGatewayProfileStore.shared.catalogProfiles()
         let connectivity = GatewayConnectivityCoordinator.shared
         let resolvedRemoteURL: URL? = if case let .ready(mode, url, _, _, _) = connectivity.endpointState,
@@ -119,7 +118,7 @@ enum DashboardGatewayCatalog {
         }
         return self.entries(
             mode: state.connectionMode,
-            primaryRemoteURL: resolution.transport == .direct ? resolution.directURL : nil,
+            primaryRemoteURL: GatewayRemoteConfig.resolveGatewayUrl(root: root),
             resolvedRemoteURL: resolvedRemoteURL,
             resolvedRemoteHostLabel: connectivity.resolvedHostLabel,
             profiles: profiles,

--- a/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
@@ -53,12 +53,15 @@ enum DashboardGatewayCatalog {
     static func entries(
         mode: AppState.ConnectionMode,
         primaryRemoteURL: URL?,
+        resolvedRemoteURL: URL?,
         resolvedRemoteHostLabel: String?,
         profiles: [MacGatewayCatalogProfile],
         primaryHealth: DashboardGatewayHealth) -> [DashboardGatewayEntry]
     {
         let canonicalPrimaryURL = mode == .remote
-            ? primaryRemoteURL.flatMap { try? MacGatewayProfileStore.canonicalURL($0) }
+            ? (resolvedRemoteURL ?? primaryRemoteURL).flatMap {
+                try? MacGatewayProfileStore.canonicalURL($0)
+            }
             : nil
         let duplicate = canonicalPrimaryURL.flatMap { primaryURL in
             profiles.first { (try? MacGatewayProfileStore.canonicalURL($0.profile.url)) == primaryURL }
@@ -78,7 +81,7 @@ enum DashboardGatewayCatalog {
             canPromote: false,
             health: primaryHealth)
         let saved = profiles.compactMap { item -> DashboardGatewayEntry? in
-            // A saved identity for the active direct route is represented by the
+            // A saved identity for the active route is represented by the
             // primary row so one physical Gateway never appears twice.
             if item.profile.id == duplicate?.profile.id { return nil }
             return DashboardGatewayEntry(
@@ -106,10 +109,19 @@ enum DashboardGatewayCatalog {
         let root = OpenClawConfigFile.loadDict()
         let resolution = GatewayRemoteConfig.resolveTransportResolution(root: root)
         let profiles = try await MacGatewayProfileStore.shared.catalogProfiles()
+        let connectivity = GatewayConnectivityCoordinator.shared
+        let resolvedRemoteURL: URL? = if case let .ready(mode, url, _, _, _) = connectivity.endpointState,
+                                         mode == .remote
+        {
+            url
+        } else {
+            nil
+        }
         return self.entries(
             mode: state.connectionMode,
             primaryRemoteURL: resolution.transport == .direct ? resolution.directURL : nil,
-            resolvedRemoteHostLabel: GatewayConnectivityCoordinator.shared.resolvedHostLabel,
+            resolvedRemoteURL: resolvedRemoteURL,
+            resolvedRemoteHostLabel: connectivity.resolvedHostLabel,
             profiles: profiles,
             primaryHealth: self.primaryHealth(for: ControlChannel.shared.state))
     }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -20,6 +20,7 @@ struct DashboardGatewayCatalogTests {
         let entries = DashboardGatewayCatalog.entries(
             mode: .remote,
             primaryRemoteURL: primaryURL,
+            resolvedRemoteURL: nil,
             resolvedRemoteHostLabel: "studio.example:443",
             profiles: [duplicate, other],
             primaryHealth: .ok)
@@ -31,6 +32,24 @@ struct DashboardGatewayCatalogTests {
         #expect(!entries[0].canPromote)
         #expect(!entries[1].canPromote)
         #expect(entries[1].health == .unknown)
+    }
+
+    @Test func `catalog deduplicates profile matching resolved SSH endpoint`() throws {
+        let tunnelURL = try #require(URL(string: "ws://127.0.0.1:18789"))
+        let profile = MacGatewayCatalogProfile(
+            profile: MacGatewayProfile(id: "loopback", name: "127.0.0.1", url: tunnelURL),
+            canPromote: true)
+
+        let entries = DashboardGatewayCatalog.entries(
+            mode: .remote,
+            primaryRemoteURL: nil,
+            resolvedRemoteURL: tunnelURL,
+            resolvedRemoteHostLabel: "127.0.0.1:18789",
+            profiles: [profile],
+            primaryHealth: .ok)
+
+        #expect(entries.map(\.id) == ["primary"])
+        #expect(entries[0].name == "127.0.0.1")
     }
 
     @Test @MainActor func `catalog maps only connected control state to healthy`() {
@@ -45,6 +64,7 @@ struct DashboardGatewayCatalogTests {
         let entries = DashboardGatewayCatalog.entries(
             mode: .local,
             primaryRemoteURL: url,
+            resolvedRemoteURL: nil,
             resolvedRemoteHostLabel: "127.0.0.1:18789",
             profiles: [.init(
                 profile: .init(id: "studio", name: "Studio", url: url),

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -52,6 +52,24 @@ struct DashboardGatewayCatalogTests {
         #expect(entries[0].name == "127.0.0.1")
     }
 
+    @Test func `catalog deduplicates configured SSH endpoint before resolution`() throws {
+        let tunnelURL = try #require(URL(string: "ws://127.0.0.1:18789"))
+        let profile = MacGatewayCatalogProfile(
+            profile: MacGatewayProfile(id: "loopback", name: "127.0.0.1", url: tunnelURL),
+            canPromote: true)
+
+        let entries = DashboardGatewayCatalog.entries(
+            mode: .remote,
+            primaryRemoteURL: tunnelURL,
+            resolvedRemoteURL: nil,
+            resolvedRemoteHostLabel: nil,
+            profiles: [profile],
+            primaryHealth: .unknown)
+
+        #expect(entries.map(\.id) == ["primary"])
+        #expect(entries[0].name == "127.0.0.1")
+    }
+
     @Test @MainActor func `catalog maps only connected control state to healthy`() {
         #expect(DashboardGatewayCatalog.primaryHealth(for: .connected) == .ok)
         #expect(DashboardGatewayCatalog.primaryHealth(for: .disconnected) == .unknown)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users with one Gateway configured over SSH would see that Gateway twice in the dashboard picker when its saved profile matched the resolved loopback tunnel endpoint.

## Why This Change Was Made

The native Mac catalog now treats the connection coordinator's ready remote endpoint as the authoritative active route, with the existing direct-config URL retained as the pre-connection fallback. Saved profiles that canonicalize to that route collapse into the primary row; distinct saved Gateways remain separate.

## User Impact

The dashboard no longer offers a misleading second Gateway choice for the same SSH-tunneled Gateway. With only one logical Gateway available, the picker stays hidden.

## Evidence

- Added focused Swift regressions for both SSH lifecycle phases: before readiness, the configured `ws://127.0.0.1:18789` route deduplicates the matching saved profile; after readiness, the resolved endpoint remains authoritative. Both return only the primary row and preserve the saved display name.
- `node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift` passed on Blacksmith Testbox `tbx_01kyq66qpy9xd98bz5a69t4f33` ([run](https://github.com/openclaw/openclaw/actions/runs/30463649036)): all selected guards and 200 macOS-adjacent Node/tooling tests passed.
- Final head `9c81aeb4ab9` passed `macos-swift`, `macos-node`, and `openclaw/ci-gate` ([run](https://github.com/openclaw/openclaw/actions/runs/30469991486)).
- A clean release-config bundle built successfully from commit `8d95f29458aa` and passed Developer ID signing with `Developer ID Application: Peter Steinberger (Y5PE65HELJ)`.
- Source-blind visual validation could not safely swap the signed bundle because the installed app is supervised by `ai.openclaw.mac.clawmac-node`. A distinct-bundle side-by-side run could not reuse the installed app's authenticated device identity, so it was recorded as blocked instead of presented as runtime proof. The live supervisor and Gateway were not stopped or reconfigured.
- Two Codex autoreviews (`gpt-5.6-sol`, xhigh) reported no accepted/actionable findings, including the pre-readiness fallback added after the visual-proof audit.
