### PR TITLE
fix(ui): harden chat and session interactions

### DIFF
--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -17,6 +17,35 @@ import {
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
+  it("keeps valid assistant history visible after a malformed transcript block", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const visibleAnswer = "The valid assistant answer remains visible.";
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "assistant",
+          content: [null, { type: "output_text", text: visibleAnswer }],
+          timestamp: Date.parse("2026-07-12T14:30:00.000Z"),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.locator(".chat-thread").getByText(visibleAnswer, { exact: true }).waitFor({
+        timeout: 10_000,
+      });
+      expect((await gateway.getRequests("chat.startup")).length).toBeGreaterThan(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("shows persisted user messages after opening History and scrolling mixed history", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/e2e/session-list-filter.e2e.test.ts
+++ b/ui/src/e2e/session-list-filter.e2e.test.ts
@@ -131,7 +131,6 @@ describeControlUiE2e("Control UI session-list event scope", () => {
       ],
       ts: 1,
     };
-    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;

--- a/ui/src/e2e/session-transcript-search.e2e.test.ts
+++ b/ui/src/e2e/session-transcript-search.e2e.test.ts
@@ -188,6 +188,88 @@ describeControlUiE2e("Control UI session transcript search", () => {
     await captureUiProof("04-matching-chat.png");
   });
 
+  it.each([
+    {
+      label: "a later session page cannot be loaded",
+      response: null,
+      message: /Unable to load all sessions for transcript search\./,
+      proofFile: "05-incomplete-roster-error.png",
+    },
+    {
+      label: "the session pagination cursor stops advancing",
+      response: {
+        count: 0,
+        hasMore: true,
+        nextOffset: 50,
+        offset: 50,
+        sessions: [],
+      },
+      message: /Session pagination did not advance during transcript search\./,
+      proofFile: "06-stalled-roster-error.png",
+    },
+  ])("shows a retryable search error when $label", async (testCase) => {
+    const timestamp = Date.parse("2026-07-12T14:30:00.000Z");
+    context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 800, width: 1200 },
+    });
+    page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "sessions.search"],
+      methodResponses: {
+        "sessions.list": {
+          cases: [
+            { match: { offset: 50 }, response: testCase.response },
+            {
+              response: {
+                count: 1,
+                defaults: { contextTokens: null, model: null, modelProvider: null },
+                hasMore: true,
+                nextOffset: 50,
+                offset: 0,
+                path: "",
+                sessions: [
+                  {
+                    key: "agent:main:visible",
+                    kind: "direct",
+                    label: "Visible session",
+                    updatedAt: timestamp,
+                  },
+                ],
+                totalCount: 51,
+                ts: timestamp,
+              },
+            },
+          ],
+        },
+        "sessions.search": { results: [] },
+      },
+    });
+
+    await page.goto(`${server?.baseUrl ?? ""}sessions`);
+    const search = page.getByRole("search", { name: "Search transcripts" });
+    const input = search.getByRole("searchbox", { name: "Search thread transcripts" });
+    await input.waitFor({ state: "visible", timeout: 10_000 });
+    await input.fill("needle");
+    await input.press("Enter");
+
+    await page
+      .locator(".sessions-transcript-search__notice--danger")
+      .getByText(testCase.message)
+      .waitFor({ state: "visible", timeout: 10_000 });
+    await page.getByRole("button", { name: "Retry" }).waitFor({ state: "visible" });
+    await expect
+      .poll(async () =>
+        (await gateway.getRequests("sessions.list")).some(
+          (request) => (request.params as { offset?: number } | undefined)?.offset === 50,
+        ),
+      )
+      .toBe(true);
+    expect(await gateway.getRequests("sessions.search")).toHaveLength(0);
+    await captureUiProof(testCase.proofFile);
+  });
+
   it("ignores stale results and exposes indexing and request errors", async () => {
     const timestamp = Date.parse("2026-07-12T14:30:00.000Z");
     context = await browser.newContext({

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -36,6 +36,33 @@ describe("message-normalizer", () => {
         expect(isStandaloneToolMessageForDisplay(input)).toBe(false);
       },
     );
+
+    it.each([undefined, null, "malformed block", 42, true, []])(
+      "preserves valid assistant text after the malformed content block %o",
+      (block) => {
+        expect(
+          normalizeMessage({
+            role: "assistant",
+            content: [block, { type: "output_text", text: "The valid answer remains visible." }],
+          }),
+        ).toMatchObject({
+          role: "assistant",
+          content: [{ type: "text", text: "The valid answer remains visible." }],
+        });
+      },
+    );
+
+    it("preserves valid tool blocks after malformed content", () => {
+      expect(
+        normalizeMessage({
+          role: "assistant",
+          content: [null, { type: "tool_use", name: "read", args: { path: "notes.md" } }],
+        }),
+      ).toMatchObject({
+        role: "toolResult",
+        content: [{ type: "tool_use", name: "read", args: { path: "notes.md" } }],
+      });
+    });
   });
 
   describe("normalizeMessage", () => {

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -3,6 +3,7 @@
  */
 
 import { mediaKindFromMime } from "@openclaw/media-core/constants";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { extractCanvasShortcodes } from "../../../../src/chat/canvas-render.js";
 import {
@@ -413,13 +414,11 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
     typeof m.tool_use_id === "string";
 
   const contentRaw = m.content;
-  const contentItems = Array.isArray(contentRaw) ? contentRaw : null;
+  const contentItems = Array.isArray(contentRaw) ? contentRaw.filter(isRecord) : null;
   const hasToolContent =
-    Array.isArray(contentItems) &&
-    contentItems.some((item) => {
-      const x = item as Record<string, unknown>;
-      return isToolResultContentType(x.type) || isToolCallContentType(x.type);
-    });
+    contentItems?.some(
+      (item) => isToolResultContentType(item.type) || isToolCallContentType(item.type),
+    ) ?? false;
 
   const hasToolName = typeof m.toolName === "string" || typeof m.tool_name === "string";
 
@@ -442,8 +441,8 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
     } else {
       content = [{ type: "text", text: m.content }];
     }
-  } else if (Array.isArray(m.content)) {
-    content = m.content.flatMap((item: Record<string, unknown>) => {
+  } else if (contentItems) {
+    content = contentItems.flatMap((item) => {
       if (isAssistantMessage) {
         const audioAttachment = coerceAudioContentBlock(item);
         if (audioAttachment) {

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -303,53 +303,56 @@ export async function handleSendChat(
     if (parsed?.command.executeLocal && !forwardModelCommand) {
       const shouldQueueCommand = shouldQueueLocalSlashCommand(parsed.command.key);
       if (shouldQueueCommand) {
-        if (messageOverride == null) {
-          recordNonTranscriptInputHistory(host, message);
-          host.chatMessage = "";
-          resetChatInputHistoryNavigation(host);
-        }
-        const queued = enqueueChatMessage(
-          host,
-          message,
-          undefined,
-          isChatResetCommand(message),
-          {
-            args: parsed.args,
-            name: parsed.command.key,
-          },
-          resolveCurrentUserIdentity(host.hello, host.client?.instanceId) ?? undefined,
-        );
-        if (queued) {
-          queued.sendState = reconnectSafeQueuedSendState(host);
-        }
-        if (!queued) {
-          return;
-        }
-        if (!admitQueuedMessageForSession(host, host.sessionKey, queued)) {
-          removeQueuedMessageWithoutReleasing(host, queued.id);
+        const submitKey = chatSubmitKey(host, "local", message, attachmentsToSend);
+        await withChatSubmitGuard(host, submitKey, async () => {
           if (messageOverride == null) {
-            host.chatMessage = previousDraft;
-            host.chatAttachments = attachmentsToSend;
+            recordNonTranscriptInputHistory(host, message);
+            host.chatMessage = "";
+            resetChatInputHistoryNavigation(host);
           }
-          setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
-          return;
-        }
-        if (host.connected && host.client && !isChatBusy(host)) {
-          const outbox = listStoredChatOutboxes(host).find((candidate) =>
-            candidate.queue.some((entry) => entry.id === queued.id),
+          const queued = enqueueChatMessage(
+            host,
+            message,
+            undefined,
+            isChatResetCommand(message),
+            {
+              args: parsed.args,
+              name: parsed.command.key,
+            },
+            resolveCurrentUserIdentity(host.hello, host.client?.instanceId) ?? undefined,
           );
-          if (outbox) {
-            await scheduleStoredChatOutboxDrain(
-              host,
-              outbox,
-              chatOutboxDrainDependencies,
-              queued.id,
-              {
-                routingSessionKey: host.sessionKey,
-              },
-            );
+          if (queued) {
+            queued.sendState = reconnectSafeQueuedSendState(host);
           }
-        }
+          if (!queued) {
+            return;
+          }
+          if (!admitQueuedMessageForSession(host, host.sessionKey, queued)) {
+            removeQueuedMessageWithoutReleasing(host, queued.id);
+            if (messageOverride == null) {
+              host.chatMessage = previousDraft;
+              host.chatAttachments = attachmentsToSend;
+            }
+            setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
+            return;
+          }
+          if (host.connected && host.client && !isChatBusy(host)) {
+            const outbox = listStoredChatOutboxes(host).find((candidate) =>
+              candidate.queue.some((entry) => entry.id === queued.id),
+            );
+            if (outbox) {
+              await scheduleStoredChatOutboxDrain(
+                host,
+                outbox,
+                chatOutboxDrainDependencies,
+                queued.id,
+                {
+                  routingSessionKey: host.sessionKey,
+                },
+              );
+            }
+          }
+        });
         return;
       }
       const waitsForPicker = parsed.command.key === "redirect";

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -4558,6 +4558,30 @@ describe("handleSendChat", () => {
     expect(host.chatMessages).toStrictEqual([]);
   });
 
+  it("coalesces duplicate queued local commands while the first command is running", async () => {
+    const command = createDeferred<{ content: string }>();
+    executeSlashCommandMock.mockImplementation(() => command.promise);
+    const host = makeHost({
+      requestHandlers: {
+        "chat.history": () => idleChatHistory(),
+      },
+    });
+
+    const first = handleSendChat(host, "/compact");
+    await waitForFast(() => expect(executeSlashCommandMock).toHaveBeenCalledOnce());
+    const duplicate = handleSendChat(host, "/compact");
+
+    try {
+      expect(host.chatQueue.filter((item) => item.localCommandName === "compact")).toHaveLength(1);
+      expect(executeSlashCommandMock).toHaveBeenCalledOnce();
+    } finally {
+      command.resolve({ content: "Compaction complete." });
+      await Promise.all([first, duplicate]);
+    }
+
+    expect(executeSlashCommandMock).toHaveBeenCalledOnce();
+  });
+
   it("keeps normal prompt text visible as pending until chat.send is acknowledged", async () => {
     const sent = createDeferred<unknown>();
 

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -14,6 +14,8 @@ const textareaControllers: NewSessionComposerTextareaController[] = [];
 
 function renderComposer(
   overrides: {
+    canSubmit?: boolean;
+    requiresModifier?: boolean;
     submitting?: boolean;
     messageLocked?: boolean;
     visibility?: NewSessionVisibility;
@@ -21,6 +23,7 @@ function renderComposer(
     onVisibilityChange?: (visibility: NewSessionVisibility) => void;
     message?: string;
     onInput?: (message: string) => void;
+    onSubmit?: () => void;
     textareaController?: NewSessionComposerTextareaController;
   } = {},
 ) {
@@ -36,20 +39,20 @@ function renderComposer(
     renderNewSessionDraftComposer({
       agentId: "main",
       attachmentDraft,
-      canSubmit: true,
+      canSubmit: overrides.canSubmit ?? true,
       context: undefined,
       isCatalogTarget: true,
       message: overrides.message ?? "",
       visibility: overrides.visibility,
       draftAvailable: overrides.draftAvailable,
       modelControl: new NewSessionModelControl(() => undefined),
-      requiresModifier: false,
+      requiresModifier: overrides.requiresModifier ?? false,
       submitting: overrides.submitting ?? false,
       textareaController,
       messageLocked: overrides.messageLocked,
       onInput: overrides.onInput ?? (() => undefined),
       onVisibilityChange: overrides.onVisibilityChange,
-      onSubmit: () => undefined,
+      onSubmit: overrides.onSubmit ?? (() => undefined),
     }),
     container,
   );
@@ -79,6 +82,66 @@ afterEach(() => {
   textareaControllers.length = 0;
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+describe("new-session composer keyboard submission", () => {
+  it.each([
+    { label: "Enter", requiresModifier: false, ctrlKey: false, metaKey: false },
+    { label: "Ctrl+Enter", requiresModifier: true, ctrlKey: true, metaKey: false },
+    { label: "Meta+Enter", requiresModifier: true, ctrlKey: false, metaKey: true },
+  ])("keeps $label native when starting a session is disabled", (testCase) => {
+    const onSubmit = vi.fn();
+    const { composer } = renderComposer({
+      canSubmit: false,
+      onSubmit,
+      requiresModifier: testCase.requiresModifier,
+    });
+    const textarea = composer.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) {
+      throw new Error("Expected composer textarea");
+    }
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: testCase.ctrlKey,
+      key: "Enter",
+      metaKey: testCase.metaKey,
+    });
+
+    textarea.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "Enter", requiresModifier: false, ctrlKey: false, metaKey: false },
+    { label: "Ctrl+Enter", requiresModifier: true, ctrlKey: true, metaKey: false },
+    { label: "Meta+Enter", requiresModifier: true, ctrlKey: false, metaKey: true },
+  ])("submits once with $label when starting a session is enabled", (testCase) => {
+    const onSubmit = vi.fn();
+    const { composer } = renderComposer({
+      canSubmit: true,
+      onSubmit,
+      requiresModifier: testCase.requiresModifier,
+    });
+    const textarea = composer.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) {
+      throw new Error("Expected composer textarea");
+    }
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: testCase.ctrlKey,
+      key: "Enter",
+      metaKey: testCase.metaKey,
+    });
+
+    textarea.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
 });
 
 describe("new-session composer sizing lifecycle", () => {

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -110,6 +110,7 @@ export function renderDraftError(message: string) {
 
 function handleComposerKeydown(event: KeyboardEvent, options: NewSessionComposerOptions) {
   if (
+    !options.canSubmit ||
     options.submitting ||
     event.key !== "Enter" ||
     event.shiftKey ||

--- a/ui/src/pages/sessions/agent-scope.test.ts
+++ b/ui/src/pages/sessions/agent-scope.test.ts
@@ -83,4 +83,50 @@ describe("searchVisibleSessionTranscripts", () => {
       expect.objectContaining({ sessionKeys: [lastSession.key] }),
     );
   });
+
+  it.each([
+    {
+      label: "a later session page cannot be loaded",
+      page: null,
+      error: /load.*session|session.*load/i,
+    },
+    {
+      label: "a later session page does not advance its cursor",
+      page: {
+        ts: 1,
+        path: "",
+        count: 0,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [],
+        hasMore: true,
+        nextOffset: 1,
+      } satisfies SessionsListResult,
+      error: /session.*advance|pagination.*advance/i,
+    },
+  ])("fails transcript search when $label", async ({ page, error }) => {
+    const request = vi.fn(async (_method: string, _params: unknown) => ({ results: [] }));
+    const listSessions = vi.fn().mockResolvedValueOnce(page);
+
+    await expect(
+      searchVisibleSessionTranscripts({
+        client: { request } as unknown as GatewayBrowserClient,
+        query: "needle",
+        result: {
+          ts: 1,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: null },
+          sessions: [{ key: "agent:main:session-0", kind: "direct", updatedAt: 1 }],
+          hasMore: true,
+          nextOffset: 1,
+        } satisfies SessionsListResult,
+        listSessions,
+        listOptions: { agentId: "main" },
+        resolveAgentId: () => "main",
+      }),
+    ).rejects.toThrow(error);
+
+    expect(listSessions).toHaveBeenCalledWith({ agentId: "main", limit: 200, offset: 1 });
+    expect(request).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/pages/sessions/agent-scope.ts
+++ b/ui/src/pages/sessions/agent-scope.ts
@@ -50,19 +50,15 @@ export async function searchVisibleSessionTranscripts(params: {
       offset: nextOffset,
     });
     if (!page) {
-      break;
+      throw new Error("Unable to load all sessions for transcript search.");
     }
     sessions.push(...page.sessions);
-    const followingOffset =
-      page.hasMore === true
-        ? (page.nextOffset ?? (page.offset ?? nextOffset) + page.sessions.length)
-        : null;
-    if (
-      followingOffset === null ||
-      followingOffset === undefined ||
-      followingOffset <= nextOffset
-    ) {
+    if (page.hasMore !== true) {
       break;
+    }
+    const followingOffset = page.nextOffset ?? (page.offset ?? nextOffset) + page.sessions.length;
+    if (followingOffset <= nextOffset) {
+      throw new Error("Session pagination did not advance during transcript search.");
     }
     nextOffset = followingOffset;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI users could lose otherwise valid assistant replies after a malformed transcript block, run the same local compact command twice through rapid repeated actions, receive silently incomplete transcript search results after a failed or stalled session-list page, or have Enter swallowed when starting a session was disabled. The session filtering browser suite also leaked its original Chromium process during repeated runs.

## Why This Change Was Made

Normalize gateway content blocks once with the existing canonical record guard, use the existing per-session submission guard for queued local commands, reject incomplete or non-advancing transcript pagination before searching, and gate composer keyboard submission on the same eligibility used by the visible Start button. Reuse the suite-owned Chromium process. No gateway protocol, configuration, authentication, dependency, migration, or generated locale changes.

## User Impact

Valid chat replies remain visible, repeated compact actions execute once, transcript-search failures show an existing actionable error and Retry control instead of misleading empty results, disabled composers retain native Enter behavior, and repeated browser testing does not orphan Chromium.

## Evidence

AI-assisted implementation with independently clean Codex autoreview. Reproduced all four defects before production changes: 9 failing regression assertions and 307 existing passes on upstream. After the fixes, the complete Control UI suite passed 7,082 tests across 487 files, the complete changed gate passed core and UI typechecking, lint, formatting, dead-export, boundary, and locale checks, and the 14 real-Chromium history, offline reconnect, paginated transcript-search, and session-filtering scenarios passed three consecutive stress runs. Remote proof: Blacksmith Testbox tbx_01kyq5zsbnqp7t2gv2t3x06xht; final committed head cc83d31c45259cab88e7f3f311e0ad6737a914bb.