### PR TITLE
fix(test): verify followup completion ordering

### DIFF
--- a/src/auto-reply/reply/followup-presentation.ts
+++ b/src/auto-reply/reply/followup-presentation.ts
@@ -1,0 +1,15 @@
+import { formatErrorMessage } from "../../infra/errors.js";
+import { defaultRuntime } from "../../runtime.js";
+import type { InternalGetReplyOptions } from "./get-reply.types.js";
+
+export async function settleQueuedFollowupPresentation(
+  onQueuedFollowupSettled: InternalGetReplyOptions["onQueuedFollowupSettled"],
+): Promise<void> {
+  try {
+    await onQueuedFollowupSettled?.();
+  } catch (error) {
+    defaultRuntime.error?.(
+      `followup queue: queued presentation cleanup failed: ${formatErrorMessage(error)}`,
+    );
+  }
+}

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -27,16 +27,11 @@ vi.mock("./agent-runner-result-accounting.js", () => ({
   accountFollowupTurn: (...args: unknown[]) => state.account(...args),
 }));
 
-vi.mock("./followup-turn-admission.js", () => ({
-  admitFollowupTurn: (...args: unknown[]) => state.admit(...args),
-  settleQueuedFollowupPresentation: async (defaults: {
-    opts?: { onQueuedFollowupSettled?: () => Promise<void> | void };
-  }) => {
-    try {
-      await defaults.opts?.onQueuedFollowupSettled?.();
-    } catch {}
-  },
-}));
+vi.mock("./followup-turn-admission.js", () => {
+  return {
+    admitFollowupTurn: (...args: unknown[]) => state.admit(...args),
+  };
+});
 
 vi.mock("./followup-turn-execution.js", () => ({
   executeFollowupTurn: (...args: unknown[]) => state.execute(...args),
@@ -245,6 +240,10 @@ describe("createFollowupRunner", () => {
     const typing = createTypingController();
     const turn = createTurn(order);
     const execution = createRejectedExecution(order);
+    let releasePresentation: (() => void) | undefined;
+    const presentationGate = new Promise<void>((resolve) => {
+      releasePresentation = resolve;
+    });
     state.admit.mockResolvedValue({ kind: "admitted", turn });
     state.execute.mockResolvedValue(execution);
     state.account.mockImplementation(async () => {
@@ -260,22 +259,34 @@ describe("createFollowupRunner", () => {
     });
     state.completeLifecycle.mockImplementation(() => order.push("lifecycle-complete"));
 
-    await createFollowupRunner({
+    const run = createFollowupRunner({
       typing,
       typingMode: "instant",
       defaultModel: "claude",
       opts: {
-        onQueuedFollowupSettled: () => {
+        onQueuedFollowupSettled: async () => {
+          order.push("presentation-settling");
+          await presentationGate;
           order.push("presentation-settled");
         },
       },
     })(turn.queued);
+
+    await vi.waitFor(() => {
+      expect(order).toContain("presentation-settling");
+    });
+    expect(state.completeLifecycle).not.toHaveBeenCalled();
+    expect(turn.operation.complete).not.toHaveBeenCalled();
+
+    releasePresentation?.();
+    await run;
 
     expect(order).toEqual([
       "progress-drained",
       "accounted",
       "decision",
       "delivered",
+      "presentation-settling",
       "presentation-settled",
       "lifecycle-complete",
       "operation-complete",

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -5,9 +5,9 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime } from "../../runtime.js";
 import { accountFollowupTurn } from "./agent-runner-result-accounting.js";
 import { deliverFollowupDecision, resolveFollowupDeliveryDecision } from "./followup-delivery.js";
+import { settleQueuedFollowupPresentation } from "./followup-presentation.js";
 import {
   admitFollowupTurn,
-  settleQueuedFollowupPresentation,
   type AdmittedFollowupTurn,
   type FollowupRunnerParams,
 } from "./followup-turn-admission.js";
@@ -155,7 +155,7 @@ export function createFollowupRunner(
       }
     } finally {
       if (queuedFollowupAdmitted) {
-        await settleQueuedFollowupPresentation(defaults);
+        await settleQueuedFollowupPresentation(defaults.opts?.onQueuedFollowupSettled);
       }
       for (const end of endDeliveryCorrelations.toReversed()) {
         try {

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -24,6 +24,7 @@ import {
   shouldNotifyUserAboutCompaction,
   type CompactionNoticePhase,
 } from "./compaction-notice.js";
+import { settleQueuedFollowupPresentation } from "./followup-presentation.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import { refreshActiveGoalContext } from "./inbound-meta.js";
 import {
@@ -48,18 +49,6 @@ export type FollowupRunnerParams = {
   agentCfgContextTokens?: number;
   toolProgressDetail?: "explain" | "raw";
 };
-
-export async function settleQueuedFollowupPresentation(
-  defaults: FollowupRunnerParams,
-): Promise<void> {
-  try {
-    await defaults.opts?.onQueuedFollowupSettled?.();
-  } catch (error) {
-    defaultRuntime.error?.(
-      `followup queue: queued presentation cleanup failed: ${formatErrorMessage(error)}`,
-    );
-  }
-}
 
 type FollowupSessionOwner =
   | {
@@ -662,7 +651,7 @@ export async function admitFollowupTurn(params: {
     return { kind: "admitted", turn };
   } catch (error) {
     if (queuedFollowupAdmitted) {
-      await settleQueuedFollowupPresentation(params.defaults);
+      await settleQueuedFollowupPresentation(params.defaults.opts?.onQueuedFollowupSettled);
     }
     operation.complete();
     throw error instanceof Error ? error : new Error(formatErrorMessage(error));


### PR DESCRIPTION
## What Problem This Solves

Resolves a false-positive test where followup completion ordering was verified against a copied settlement mock instead of the production settlement helper. The test could remain green if the real runner stopped awaiting presentation cleanup.

## Why This Change Was Made

Moves queued presentation settlement into a focused module shared by admission and runner paths. The runner test now mocks admission only, blocks the real settlement callback, and proves lifecycle and operation completion cannot run until settlement resolves.

## User Impact

No runtime behavior changes. Maintainers now get a regression test that fails when asynchronous followup presentation cleanup is no longer awaited.

## Evidence

- Blacksmith Testbox: formatter passed for all four touched files.
- Auto-reply shard: 45 tests passed.
- Telegram progress shard: 24 tests passed.
- Focused proof: https://github.com/openclaw/openclaw/actions/runs/30464969081
- Fresh autoreview: clean, 0.96 confidence.

AI-assisted: yes; implementation and proof were reviewed by the maintainer.