### PR TITLE
fix(gateway): prevent stale node connections from appearing healthy

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,3 +1,3 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it.
-519
+518

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -817,6 +817,138 @@ describe("gateway/node-registry", () => {
     await expect(registry.checkConnectivity("node-1", 50)).resolves.toEqual({ ok: true });
   });
 
+  it("does not probe an invalidated node connection", async () => {
+    const registry = createTestNodeRegistry();
+    const socket = makeConnectivitySocket(true);
+    const ping = vi.spyOn(socket, "ping");
+    const client = makeClient("conn-invalidated", "node-1", [], { socket });
+    registerNodeSession(registry, client, {});
+    client.invalidated = true;
+
+    await expect(registry.checkConnectivity("node-1", 50)).resolves.toEqual({
+      ok: false,
+      error: { code: "NOT_CONNECTED", message: "node not connected" },
+    });
+    expect(ping).not.toHaveBeenCalled();
+  });
+
+  it("does not report an old websocket as connected after its node reconnects", async () => {
+    const registry = createTestNodeRegistry();
+    const oldSocket = makeConnectivitySocket(false);
+    registerNodeSession(registry, makeClient("conn-old", "node-1", [], { socket: oldSocket }), {});
+
+    const connectivity = registry.checkConnectivity("node-1", 50);
+    const replacement = registerNodeSession(
+      registry,
+      makeClient("conn-new", "node-1", [], { socket: makeConnectivitySocket(true) }),
+      {},
+    );
+    (oldSocket as unknown as EventEmitter).emit("pong");
+
+    await expect(connectivity).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "NOT_CONNECTED",
+        message: "node connection changed during connectivity probe",
+      },
+    });
+    expect(registry.get("node-1")).toBe(replacement);
+    await expect(registry.checkConnectivity("node-1", 50)).resolves.toEqual({ ok: true });
+  });
+
+  it("does not report a replaced polling transport as connected", async () => {
+    const registry = createTestNodeRegistry();
+    let resolveProbe: ((result: { ok: true }) => void) | undefined;
+    const transportProbe = new Promise<{ ok: true }>((resolve) => {
+      resolveProbe = resolve;
+    });
+    registry.registerTransport(
+      makeClient("conn-old", "node-1"),
+      { pairingIdentity: "identity-a" },
+      {
+        send: () => true,
+        sendRaw: () => true,
+        checkConnectivity: () => transportProbe,
+      },
+    );
+
+    const connectivity = registry.checkConnectivity("node-1", 50);
+    const replacement = registerNodeSession(
+      registry,
+      makeClient("conn-new", "node-1", [], { socket: makeConnectivitySocket(true) }),
+      {},
+    );
+    resolveProbe?.({ ok: true });
+
+    await expect(connectivity).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "NOT_CONNECTED",
+        message: "node connection changed during connectivity probe",
+      },
+    });
+    expect(registry.get("node-1")).toBe(replacement);
+  });
+
+  it("keeps connectivity and invocations isolated across repeated node reconnects", async () => {
+    const registry = createTestNodeRegistry();
+    const makeTrackedSocket = (sent: string[]) => {
+      const trackedSocket = makeConnectivitySocket(false);
+      (trackedSocket as unknown as { send: (frame: unknown) => void }).send = (frame) => {
+        if (typeof frame === "string") {
+          sent.push(frame);
+        }
+      };
+      return trackedSocket;
+    };
+    let frames: string[] = [];
+    let socket = makeTrackedSocket(frames);
+    registerNodeSession(registry, makeClient("conn-0", "node-1", frames, { socket }), {});
+
+    for (let attempt = 1; attempt <= 50; attempt += 1) {
+      const previousSocket = socket;
+      const previousFrames = frames;
+      const connectivity = registry.checkConnectivity("node-1", 1_000);
+      const invoke = registry.invoke({
+        nodeId: "node-1",
+        command: "debug.ping",
+        timeoutMs: 0,
+      });
+      const disconnected = invoke.catch((error: unknown) => error);
+      const request = JSON.parse(previousFrames[0] ?? "{}") as {
+        payload?: { id?: string };
+      };
+      expect(request.payload?.id).toEqual(expect.any(String));
+
+      frames = [];
+      socket = makeTrackedSocket(frames);
+      const replacement = registerNodeSession(
+        registry,
+        makeClient(`conn-${attempt}`, "node-1", frames, { socket }),
+        {},
+      );
+      (previousSocket as unknown as EventEmitter).emit("pong");
+
+      await expect(connectivity).resolves.toEqual({
+        ok: false,
+        error: {
+          code: "NOT_CONNECTED",
+          message: "node connection changed during connectivity probe",
+        },
+      });
+      await expect(disconnected).resolves.toEqual(new Error("node disconnected (debug.ping)"));
+      expect(
+        registry.handleInvokeResult({
+          id: request.payload?.id ?? "",
+          nodeId: "node-1",
+          connId: `conn-${attempt - 1}`,
+          ok: true,
+        }),
+      ).toBe(false);
+      expect(registry.get("node-1")).toBe(replacement);
+    }
+  });
+
   it("reports stale node websocket connectivity before invoke timeout", async () => {
     const registry = createTestNodeRegistry();
     registerNodeSession(

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -820,16 +820,30 @@ export class NodeRegistry {
 
   /** Probe websocket liveness with ping/pong when the socket supports it. */
   async checkConnectivity(nodeId: string, timeoutMs = 2_000): Promise<NodeConnectivityResult> {
-    const node = this.nodesById.get(nodeId);
+    const node = this.getRegisteredSession(nodeId);
     if (!node) {
       return {
         ok: false,
         error: { code: "NOT_CONNECTED", message: "node not connected" },
       };
     }
+    // A successful old transport must never certify a replacement node.
+    const currentConnectionResult = (result: NodeConnectivityResult): NodeConnectivityResult =>
+      this.nodesById.get(nodeId) === node && node.client.invalidated !== true
+        ? result
+        : {
+            ok: false,
+            error: {
+              code: "NOT_CONNECTED",
+              message: "node connection changed during connectivity probe",
+            },
+          };
     const eventTransport = this.eventTransportsByConn.get(node.connId);
     if (eventTransport) {
-      return eventTransport.checkConnectivity?.(timeoutMs) ?? { ok: true };
+      const result = eventTransport.checkConnectivity
+        ? await eventTransport.checkConnectivity(timeoutMs)
+        : { ok: true as const };
+      return currentConnectionResult(result);
     }
     const socket = node.client.socket as PingableSocket;
     if (socket.readyState !== WEBSOCKET_OPEN_READY_STATE) {
@@ -860,7 +874,7 @@ export class NodeRegistry {
         settled = true;
         clearTimeout(timer);
         cleanup();
-        resolve(result);
+        resolve(currentConnectionResult(result));
       };
       const onPong = () => finish({ ok: true });
       const onClose = () =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where reconnecting or invalidated nodes could be reported as connected after their Gateway session had already been replaced. A stale WebSocket pong or a late polling-transport health result could incorrectly certify the new node session, leaving remote skill discovery and node work operating on the wrong connection.

## Why This Change Was Made

Gateway connectivity is owned by the registered node session, not by the node ID alone. Resolve the current, non-invalidated session before probing and revalidate that exact session when either a WebSocket or polling-transport probe completes. Preserve the replacement session and reject late invocation results from retired connections.

This change also tightens the existing production environment-variable budget from 519 to the actual count of 518. Current `main` already contained only 518 names, so its exact-count changed gate otherwise failed before typechecking the Gateway fix. The ratchet becomes stricter; no configuration option or environment variable is added.

## User Impact

Remote nodes reconnect reliably without stale connections being treated as healthy. Node-host invocations, remote skill discovery, watch/poll transports, pairing, and replacement-session routing remain isolated to the active connection.

## Evidence

- Before the fix, all three new regressions failed on current `main`: invalidated WebSocket probe, replaced WebSocket/pong probe, and replaced polling-transport probe.
- Blacksmith Testbox: 330 passing Gateway, node-host, wake/cancellation, watch HTTP, remote-skill, and Gateway-client tests.
- Real two-Gateway end-to-end: two running Gateways, HTTP, WebSockets, node pairing, and node status all pass; pairing authorization, node subscriptions, and replacement-session integration also pass.
- Five repeated lifecycle passes: 595 passing test executions and 250 forced node reconnection/replacement cycles, including rejection of late invocation results.
- The exact-head path-scoped `pnpm check:changed -- src/gateway/node-registry.ts src/gateway/node-registry.test.ts` passes on Blacksmith Testbox, including production and test types, targeted lint, formatting, API contracts, production/full-tree/script dead-code checks, plugin and import-cycle boundaries, database/schema and pairing guards, and the corrected `OPENCLAW_*` 518/518 ratchet.
- Independent structured Codex autoreview on `origin/main...HEAD`: clean, no actionable findings.
- Remote proof: initial before/after and stress proof on Blacksmith Testbox `tbx_01kyq4yh3bkt01wyevx52ae902`; final changed-gate runner `tbx_01kyq7nd43agqbn6ryf5twxzj3`.

### Inspectable before/after proof

Before the production fix, the new regressions fail against the original `main` registry:

```text
src/gateway/node-registry.test.ts (86 tests | 3 failed)
  FAIL does not probe an invalidated node connection
    expected { ok: false, error: { code: "NOT_CONNECTED" } }
    received { ok: true }
  FAIL does not report an old websocket as connected after its node reconnects
    expected { ok: false, error: { code: "NOT_CONNECTED" } }
    received { ok: true }
  FAIL does not report a replaced polling transport as connected
    expected { ok: false, error: { code: "NOT_CONNECTED" } }
    received { ok: true }
Test Files  1 failed
Tests       3 failed | 83 passed
```

After fencing each result to its actual node session, all affected lifecycle and consumer paths pass:

```text
src/gateway/node-registry.test.ts                  87 passed
src/gateway/watch-node-http.test.ts                 9 passed
src/gateway/node-connect-reconcile.test.ts         16 passed
src/gateway/node-connection-notifications.test.ts  11 passed
src/gateway/server-node-events.test.ts             70 passed
src/gateway/server-methods/nodes.invoke-wake.test.ts 51 passed
src/gateway/server-methods/nodes.invoke-abort.test.ts 2 passed
src/node-host/runner.test.ts                       33 passed
src/node-host/worker.test.ts                       13 passed
src/node-host/with-timeout.test.ts                  1 passed
src/skills/runtime/remote.test.ts                  23 passed
packages/gateway-client/src/reconnect-policy.test.ts 14 passed
Total: 330 passed
```

The real Gateway scenario starts two separate Gateway processes and exercises node pairing over actual HTTP and WebSocket transports:

```text
test/gateway.multi.e2e.test.ts
  PASS spins up two gateways and exercises WS + HTTP + node pairing
Test Files  1 passed
Tests       1 passed

src/gateway/server.node-pairing-authz.test.ts       19 passed
src/gateway/server-node-session-runtime.test.ts      5 passed
src/gateway/server.node-pairing-auto-approve.test.ts 2 passed
src/gateway/server-node-subscriptions.test.ts        4 passed
```

Repeated node replacement also verifies that each old invoke rejects, every late result is ignored, and each replacement stays registered:

```text
[stress] gateway/node lifecycle pass 1/5
[stress] gateway/node lifecycle pass 2/5
[stress] gateway/node lifecycle pass 3/5
[stress] gateway/node lifecycle pass 4/5
[stress] gateway/node lifecycle pass 5/5
[stress] passed 5 gateway/node lifecycle passes and 250 reconnect cycles
exitCode=0
```

The exact-head remote changed gate confirms the tightened budget, types, lint, and architecture guards:

```text
OPENCLAW_* count 518/518
[deadcode] Knip production unused-export scan passed with 0 entries.
[deadcode] Knip full-tree unused-export scan passed with 0 entries.
[deadcode] Knip script unused-export scan passed with 0 entries.
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core changed files
Found 0 warnings and 0 errors.
Database-first legacy-store guard passed.
Import cycle check: 0 runtime value cycle(s).
runStatus=succeeded exitCode=0
```

### Merge-base decision

The reviewed PR head is mergeable. Do not rebase solely because high-traffic `main` has advanced: the repository landing policy treats non-conflicting merge-base drift as advisory and requires `scripts/pr prepare-run` to verify the exact reviewed, tested head. A moving-main-only rebase would unnecessarily invalidate the clean exact-head hosted CI, Testbox proof, and autoreview without changing the fix.

AI-assisted; reviewed and validated against the repository's scoped Gateway guidance.
