### PR TITLE
fix(ui): derive cron timezone suggestions

### DIFF
--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -139,7 +139,7 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
     await server?.close();
   });
 
-  it("suggests Asia/Shanghai in the rendered cron timezone selector", async () => {
+  it("suggests browser-supported timezones without restricting free-form input", async () => {
     const context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -163,11 +163,18 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       const timezone = page.locator("#cron-cron-tz");
       await timezone.waitFor({ state: "visible" });
       expect(await timezone.getAttribute("list")).toBe("cron-tz-suggestions");
-      expect(
-        await page
-          .locator("#cron-tz-suggestions option")
-          .evaluateAll((options) => options.map((option) => option.getAttribute("value"))),
-      ).toContain("Asia/Shanghai");
+      const browserTimezone = await page.evaluate(
+        () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+      );
+      const timezoneOptions = await page
+        .locator("#cron-tz-suggestions option")
+        .evaluateAll((options) => options.map((option) => option.getAttribute("value")));
+      expect(timezoneOptions).toContain(browserTimezone);
+      expect(timezoneOptions).toContain("UTC");
+      expect(timezoneOptions.length).toBeGreaterThan(100);
+
+      await timezone.fill("Etc/GMT+3");
+      expect(await timezone.inputValue()).toBe("Etc/GMT+3");
     } finally {
       await context.close();
     }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5507,7 +5507,8 @@ export const en: TranslationMap = {
       summaryCronTz: "Cron schedule {expr} ({tz})",
       timezoneOptional: "Timezone",
       timezonePlaceholder: "America/Los_Angeles",
-      timezoneHelp: "Optional. Any valid IANA timezone.",
+      timezoneHelp:
+        "Optional. Leave blank to use the Gateway host timezone, or enter any valid IANA timezone.",
       runsIn: "Runs in",
       mainSession: "Main session",
       isolatedSession: "Isolated session",

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -39,11 +39,7 @@ import {
 } from "../../lib/sessions/route-navigation.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
-import {
-  buildCronSuggestions,
-  THINKING_SUGGESTIONS,
-  TIMEZONE_SUGGESTIONS,
-} from "./form-suggestions.ts";
+import { buildCronSuggestions, THINKING_SUGGESTIONS } from "./form-suggestions.ts";
 import { renderCron, type CronDetailTab, type CronListTab } from "./view.ts";
 
 class CronPage extends OpenClawLightDomElement {
@@ -423,7 +419,7 @@ class CronPage extends OpenClawLightDomElement {
           agentSuggestions: suggestions.agentSuggestions,
           modelSuggestions: suggestions.modelSuggestions,
           thinkingSuggestions: THINKING_SUGGESTIONS,
-          timezoneSuggestions: TIMEZONE_SUGGESTIONS,
+          timezoneSuggestions: suggestions.timezoneSuggestions,
           deliveryToSuggestions: suggestions.deliveryToSuggestions,
           accountSuggestions: suggestions.accountTargets,
           onListTabChange: (tab) => {

--- a/ui/src/pages/cron/form-suggestions.ts
+++ b/ui/src/pages/cron/form-suggestions.ts
@@ -8,19 +8,9 @@ import {
   type CronState,
 } from "../../lib/cron/index.ts";
 import { sortUniqueStrings } from "../../lib/string-coerce.ts";
+import { resolveCronTimezoneSuggestions } from "./timezone-suggestions.ts";
 
 export const THINKING_SUGGESTIONS = ["off", "minimal", "low", "medium", "high"];
-export const TIMEZONE_SUGGESTIONS = [
-  "UTC",
-  "America/Los_Angeles",
-  "America/Denver",
-  "America/Chicago",
-  "America/New_York",
-  "Europe/London",
-  "Europe/Berlin",
-  "Asia/Shanghai",
-  "Asia/Tokyo",
-];
 
 function unique(values: string[]): string[] {
   return sortUniqueStrings(values.map((value) => value.trim()).filter(Boolean));
@@ -74,6 +64,7 @@ export function buildCronSuggestions(params: {
   return {
     agentSuggestions,
     modelSuggestions,
+    timezoneSuggestions: resolveCronTimezoneSuggestions(params.cron.cronJobs),
     accountTargets,
     deliveryToSuggestions:
       params.cron.cronForm.deliveryMode === "webhook"

--- a/ui/src/pages/cron/timezone-suggestions.test.ts
+++ b/ui/src/pages/cron/timezone-suggestions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../../api/types.ts";
+import { resolveCronTimezoneSuggestions } from "./timezone-suggestions.ts";
+
+function cronJob(timezone: string): CronJob {
+  return {
+    schedule: { kind: "cron", expr: "0 9 * * *", tz: timezone },
+  } as CronJob;
+}
+
+describe("resolveCronTimezoneSuggestions", () => {
+  it("prioritizes relevant zones before the browser catalog", () => {
+    expect(
+      resolveCronTimezoneSuggestions(
+        [cronJob("Pacific/Chatham"), cronJob("UTC"), cronJob(" Pacific/Chatham ")],
+        "Asia/Singapore",
+        ["Europe/London", "America/New_York", "Asia/Singapore"],
+      ),
+    ).toEqual(["Asia/Singapore", "UTC", "Pacific/Chatham", "America/New_York", "Europe/London"]);
+  });
+
+  it("keeps useful suggestions when the browser catalog is unavailable", () => {
+    expect(resolveCronTimezoneSuggestions([cronJob("America/St_Johns")], "", [])).toEqual([
+      "UTC",
+      "America/St_Johns",
+    ]);
+  });
+});

--- a/ui/src/pages/cron/timezone-suggestions.ts
+++ b/ui/src/pages/cron/timezone-suggestions.ts
@@ -1,0 +1,47 @@
+import type { CronJob } from "../../api/types.ts";
+import { sortUniqueStrings } from "../../lib/string-coerce.ts";
+
+function resolveBrowserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return "";
+  }
+}
+
+function resolveSupportedTimezones(): string[] {
+  try {
+    return Intl.supportedValuesOf?.("timeZone") ?? [];
+  } catch {
+    return [];
+  }
+}
+
+function uniqueInOrder(values: string[]): string[] {
+  const seen = new Set<string>();
+  return values
+    .map((value) => value.trim())
+    .filter((value) => {
+      if (!value || seen.has(value)) {
+        return false;
+      }
+      seen.add(value);
+      return true;
+    });
+}
+
+export function resolveCronTimezoneSuggestions(
+  cronJobs: CronJob[],
+  browserTimezone = resolveBrowserTimezone(),
+  supportedTimezones = resolveSupportedTimezones(),
+): string[] {
+  const configuredTimezones = cronJobs.map((job) =>
+    job.schedule.kind === "cron" && typeof job.schedule.tz === "string" ? job.schedule.tz : "",
+  );
+  return uniqueInOrder([
+    browserTimezone,
+    "UTC",
+    ...configuredTimezones,
+    ...sortUniqueStrings(supportedTimezones.map((value) => value.trim()).filter(Boolean)),
+  ]);
+}


### PR DESCRIPTION
Related: #65936

## What Problem This Solves

Fixes an issue where Control UI users creating cron jobs received a hand-maintained shortlist of timezone suggestions, causing valid regions to be added one city at a time even though cron accepts arbitrary IANA timezones.

## Why This Change Was Made

The Control UI now derives suggestions from the browser's supported IANA catalog, prioritizes the browser timezone and UTC, and preserves timezones already used by loaded cron jobs. The input remains free-form because the Gateway and Croner remain authoritative for validation.

The help text also states that leaving the field blank uses the Gateway host timezone, which may differ from the browser running Control UI.

## User Impact

Users can discover the timezone their browser supports without waiting for OpenClaw to add their city to a static list. Existing aliases and manually entered values remain usable.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/cron/timezone-suggestions.test.ts ui/src/pages/cron/view.test.ts`: 44 tests passed.
- Blacksmith Testbox changed-surface checks passed, including UI typecheck, lint, formatting, i18n verification, and dead-export scans.
- Blacksmith Testbox mocked-Gateway Chromium E2E: `ui/src/e2e/cron-filters.e2e.test.ts`, 10 tests passed.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30465430254
- Structured autoreview: no findings; patch judged correct at 0.95 confidence.
- The native datalist popup is browser-owned and not stable screenshot evidence; the Chromium test asserts the browser timezone, UTC, a full catalog, and unrestricted free-form entry directly.

AI-assisted implementation; reviewed, understood, and validated by the author.
