### PR TITLE
fix(ui): preserve initials for missing user avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@ Docs: https://docs.openclaw.ai
 
 - **Skill Workshop offline apply:** preserve configless local proposal apply after upgrades under exclusive Gateway startup ownership, while keeping running Gateway snapshot invalidation fail-closed when CLI credentials are unavailable.
 - **macOS and Control UI keyboard navigation:** let Tab traverse links and controls inside embedded Dashboard, browser, and Canvas web views, and keep shortcuts working on non-Latin keyboard layouts without firing during IME composition.
-- **Control UI missing user avatars:** keep deterministic initials visible when an attributed user has no uploaded avatar or Gravatar, instead of leaving a broken image after transcript rerenders.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 
 - **Skill Workshop offline apply:** preserve configless local proposal apply after upgrades under exclusive Gateway startup ownership, while keeping running Gateway snapshot invalidation fail-closed when CLI credentials are unavailable.
 - **macOS and Control UI keyboard navigation:** let Tab traverse links and controls inside embedded Dashboard, browser, and Canvas web views, and keep shortcuts working on non-Latin keyboard layouts without firing during IME composition.
+- **Control UI missing user avatars:** keep deterministic initials visible when an attributed user has no uploaded avatar or Gravatar, instead of leaving a broken image after transcript rerenders.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.
 - **Shared state corruption recovery:** evict only the exact cached SQLite owner after proven read or write corruption so a repaired database recovers without a Gateway restart while caller-injected handles remain untouched. Fixes #114269. Thanks @rizquuula.

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -178,7 +178,16 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
         markRetrySettled();
       }
     });
-    const gateway = await installMockGateway(page, {
+    await installMockGateway(page, {
+      presenceUsers: [
+        {
+          self: true,
+          id: "viewer-profile",
+          name: "Viewer",
+          email: "viewer@example.test",
+          watchedSessions: ["agent:main:main"],
+        },
+      ],
       historyMessages: [
         {
           role: "user",
@@ -198,29 +207,33 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
       await page.goto(controlUiSessionUrl(server.baseUrl, "agent:main:main"));
       await page.getByText("Please keep my fallback avatar readable.").waitFor();
 
-      const slot = page.locator(".chat-avatar-slot");
+      const userGroup = page.locator(".chat-group.user", {
+        hasText: "Please keep my fallback avatar readable.",
+      });
+      const slot = userGroup.locator(".chat-avatar-slot");
       const image = slot.locator("img.chat-avatar.user");
       const initials = slot.locator(".chat-avatar--sender-initials");
-      await expect.poll(() => avatarRequestCount).toBe(1);
+      await retryStarted;
+      expect(avatarRequestCount).toBe(2);
       await expect(slot).toHaveClass(/\bis-fallback\b/u);
       await expect.poll(() => image.getAttribute("src")).toBeNull();
       await expect(initials).toBeVisible();
       await expect(initials).toHaveText("H");
       await captureProof(page, "missing-avatar-after-404.png");
 
-      await gateway.emitGatewayEvent("presence", {
-        presence: [
-          {
-            instanceId: "observer-instance",
-            mode: "webchat",
-            reason: "connect",
-            user: { id: "observer", name: "Observer", email: "observer@example.test" },
-            watchedSessions: ["agent:main:main"],
-          },
-        ],
-      });
-      await page.locator('[data-viewer-id="observer"]').waitFor();
-      await retryStarted;
+      await userGroup.hover();
+      await userGroup.getByRole("button", { name: "Reply to message" }).click();
+      const replyPreview = page.locator(".chat-reply-preview");
+      await replyPreview.waitFor({ state: "visible" });
+      await expect(replyPreview.locator(".chat-reply-preview__text")).toHaveText(
+        "Please keep my fallback avatar readable.",
+      );
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
 
       expect(avatarRequestCount).toBe(2);
       await expect(slot).toHaveClass(/\bis-fallback\b/u);

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -142,4 +142,101 @@ describeControlUiE2e("Control UI attributed chat identity", () => {
 
     await context.close();
   });
+
+  it("keeps missing same-origin avatar initials through a live rerender", async () => {
+    const context = await browser.newContext({ viewport: { height: 760, width: 1180 } });
+    const page = await context.newPage();
+    const sender = {
+      id: "dd7c98e2-f51d-4590-b588-fa0682e165b7",
+      name: "Hannah",
+    };
+    let avatarRequestCount = 0;
+    let releaseRetry: () => void = () => undefined;
+    const retryGate = new Promise<void>((resolve) => {
+      releaseRetry = resolve;
+    });
+    let markRetryStarted: () => void = () => undefined;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    let markRetrySettled: () => void = () => undefined;
+    const retrySettled = new Promise<void>((resolve) => {
+      markRetrySettled = resolve;
+    });
+    await page.route(`**/api/users/${sender.id}/avatar`, async (route) => {
+      const requestIndex = ++avatarRequestCount;
+      if (requestIndex === 2) {
+        markRetryStarted();
+        await retryGate;
+      }
+      await route.fulfill({
+        body: JSON.stringify({ ok: false, error: { type: "not_found" } }),
+        contentType: "application/json",
+        status: 404,
+      });
+      if (requestIndex === 2) {
+        markRetrySettled();
+      }
+    });
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "user",
+          content: "Please keep my fallback avatar readable.",
+          timestamp: Date.now(),
+          __openclaw: {
+            id: "missing-avatar-message",
+            senderId: sender.id,
+            senderName: sender.name,
+            seq: 1,
+          },
+        },
+      ],
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(server.baseUrl, "agent:main:main"));
+      await page.getByText("Please keep my fallback avatar readable.").waitFor();
+
+      const slot = page.locator(".chat-avatar-slot");
+      const image = slot.locator("img.chat-avatar.user");
+      const initials = slot.locator(".chat-avatar--sender-initials");
+      await expect.poll(() => avatarRequestCount).toBe(1);
+      await expect(slot).toHaveClass(/\bis-fallback\b/u);
+      await expect.poll(() => image.getAttribute("src")).toBeNull();
+      await expect(initials).toBeVisible();
+      await expect(initials).toHaveText("H");
+      await captureProof(page, "missing-avatar-after-404.png");
+
+      await gateway.emitGatewayEvent("presence", {
+        presence: [
+          {
+            instanceId: "observer-instance",
+            mode: "webchat",
+            reason: "connect",
+            user: { id: "observer", name: "Observer", email: "observer@example.test" },
+            watchedSessions: ["agent:main:main"],
+          },
+        ],
+      });
+      await page.locator('[data-viewer-id="observer"]').waitFor();
+      await retryStarted;
+
+      expect(avatarRequestCount).toBe(2);
+      await expect(slot).toHaveClass(/\bis-fallback\b/u);
+      await expect.poll(() => image.getAttribute("src")).toBeNull();
+      await expect(initials).toBeVisible();
+      await expect(initials).toHaveText("H");
+      await captureProof(page, "missing-avatar-after-rerender.png");
+
+      releaseRetry();
+      await retrySettled;
+      await expect.poll(() => image.getAttribute("src")).toBeNull();
+      await expect(slot).toHaveClass(/\bis-fallback\b/u);
+      await expect(initials).toBeVisible();
+    } finally {
+      releaseRetry();
+      await context.close();
+    }
+  });
 });

--- a/ui/src/lib/identity-avatar.ts
+++ b/ui/src/lib/identity-avatar.ts
@@ -171,15 +171,19 @@ function loadIdentityAvatar(url: string): string | Promise<string | null> {
   return entry.promise;
 }
 
-/** Fetch protected or cross-origin profile images once and render CSP-safe blobs. */
+/** Fetch connected-gateway profile images once and render CSP-safe blobs. */
 export function resolveAvatarImageUrl(value: string): string | Promise<string | null> | null {
   const trusted = toTrustedAvatarUrl(value, appGatewayOrigin);
   if (!trusted) {
     return null;
   }
+  // Connected same-origin routes need the loader too: it resolves a missing
+  // avatar before Lit can reconcile an <img> error back over its initials.
   const pageOrigin = globalThis.location?.origin;
   const crossOrigin = pageOrigin ? new URL(trusted, pageOrigin).origin !== pageOrigin : false;
-  return appGatewayAuthHeader || crossOrigin ? loadIdentityAvatar(trusted) : trusted;
+  return appGatewayOrigin || appGatewayAuthHeader || crossOrigin
+    ? loadIdentityAvatar(trusted)
+    : trusted;
 }
 
 /** A blob stays live until its image has finished loading or definitively failed. */

--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -407,4 +407,39 @@ describe("attributed sender avatars", () => {
     image?.dispatchEvent(new Event("load"));
     expect(slot?.classList.contains("is-fallback")).toBe(false);
   });
+
+  it("keeps a missing same-origin sender avatar on initials across rerenders", async () => {
+    const gatewayOrigin = globalThis.location.origin;
+    setAvatarGatewayOrigin(gatewayOrigin);
+    const fetchAvatar = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 404 }));
+    const container = document.createElement("div");
+    const sender = {
+      id: "dd7c98e2-f51d-4590-b588-fa0682e165b7",
+      name: "hrudolph",
+    };
+    const renderSender = () =>
+      render(renderChatAvatar("user", undefined, undefined, "", null, sender), container);
+
+    renderSender();
+    expect(container.querySelector(".chat-avatar-slot")?.classList.contains("is-fallback")).toBe(
+      true,
+    );
+    expect(container.querySelector(".chat-avatar--sender-initials")?.textContent?.trim()).toBe("H");
+    await vi.waitFor(() => {
+      expect(fetchAvatar).toHaveBeenCalledOnce();
+      expect(container.querySelector(".chat-avatar-slot img")?.hasAttribute("src")).toBe(false);
+    });
+    expect(fetchAvatar).toHaveBeenCalledWith(
+      `${gatewayOrigin}/api/users/${sender.id}/avatar`,
+      expect.objectContaining({ credentials: "include", signal: expect.any(AbortSignal) }),
+    );
+
+    renderSender();
+    expect(container.querySelector(".chat-avatar-slot")?.classList.contains("is-fallback")).toBe(
+      true,
+    );
+    expect(container.querySelector(".chat-avatar--sender-initials")?.textContent?.trim()).toBe("H");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Attributed Control UI messages can show a broken image glyph instead of readable initials when a user has neither an uploaded avatar nor a Gravatar.

## Why This Change Was Made

The canonical user-avatar endpoint correctly returns `404` for that state. Connected same-origin avatar routes previously bypassed the shared loader and rendered directly as `<img>` URLs. The image error briefly selected the initials fallback, but a later Lit render reconciled the wrapper back to its non-fallback class and exposed the broken image again.

Route connected same-origin user avatars through the existing bounded, origin-pinned loader too. A missing avatar now resolves to no image source before rendering, while the loader retains the existing authorization, cross-origin, cache, upload-retry, MIME, size, and credential-boundary behavior.

## User Impact

People without profile images keep deterministic initials in attributed chat messages. Uploaded avatars and Gateway-proxied Gravatars continue to load through the same shared cache.

## Evidence

- Authenticated production Chrome reproduction on `team.openclaw.ai`: the affected `/api/users/<profile-id>/avatar` request returned `404 application/json` with `{"ok":false,"error":{"type":"not_found"}}`; comparison user-avatar requests returned `200 image/png`.
- Production DOM inspection showed the initials sibling was present but hidden because a transcript rerender had restored `class="chat-avatar-slot"` after the image failure.
- Unit regression covers a same-origin Gateway without a bearer header, a `404` avatar response, removal of the image `src`, visible initials fallback state, and a subsequent rerender. Focused Testbox proof: 2 files, 44 tests passed.
- Real Chromium proof on Blacksmith Testbox: `ui/src/e2e/chat-attributed-identity.e2e.test.ts` passed both cases. The missing-avatar case observes the initial `404`, holds the uncached retry open, clicks the real Reply action to rerender the chat pane, proves `H` remains visible with no image source and no third request, then settles the retried `404` and rechecks the fallback. [Run 30471844830](https://github.com/openclaw/openclaw/actions/runs/30471844830).
- Blacksmith Testbox changed gate passed: UI/core test types, targeted lint with 0 warnings/errors, formatting, Control UI i18n, changelog attribution, dependency guards, dead-code scans, and boundary guards.
- Final Codex autoreview on the tested browser-proof diff: clean, no accepted/actionable findings. TruffleHog: clean.

The production screenshot contains private team-user identities, so it is intentionally not uploaded to this public PR. The Chromium proof uses synthetic identities and its terminal result is public above; a source-blind production hard-reload check will follow deployment.

AI-assisted; root cause, production request/DOM behavior, regression coverage, security boundary, and final branch diff were independently reviewed.
