### PR TITLE
fix(cron): prevent stalled schedules, duplicate runs, and lost heartbeats

### DIFF
--- a/src/cron/service.prevents-duplicate-timers.test.ts
+++ b/src/cron/service.prevents-duplicate-timers.test.ts
@@ -1,4 +1,5 @@
 // Duplicate timer tests cover cron service guards against repeated timer arms.
+import { mkdir, symlink } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { CronService } from "./service.js";
@@ -19,9 +20,10 @@ installCronTestHooks({
 
 describe("CronService", () => {
   it.each([
-    { name: "the same store path", aliased: false },
-    { name: "lexically different paths to the same store", aliased: true },
-  ])("avoids duplicate runs when two services share $name", async ({ aliased }) => {
+    { name: "the same store path", alias: "none" },
+    { name: "lexically different paths to the same store", alias: "lexical" },
+    { name: "a symlinked path to the same store", alias: "symlink" },
+  ] as const)("avoids duplicate runs when two services share $name", async ({ alias }) => {
     const store = await makeStorePath();
     const enqueueSystemEvent = vi.fn();
     const requestHeartbeat = vi.fn();
@@ -47,10 +49,24 @@ describe("CronService", () => {
       payload: { kind: "systemEvent", text: "hello" },
     });
 
+    let aliasedStorePath = store.storePath;
+    if (alias === "lexical") {
+      aliasedStorePath = `${path.dirname(store.storePath)}/../${path.basename(path.dirname(store.storePath))}/${path.basename(store.storePath)}`;
+    } else if (alias === "symlink") {
+      const symlinkedStoreDirectory = path.join(
+        path.dirname(path.dirname(store.storePath)),
+        "symlinked-cron",
+      );
+      await symlink(
+        path.dirname(store.storePath),
+        symlinkedStoreDirectory,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      aliasedStorePath = path.join(symlinkedStoreDirectory, path.basename(store.storePath));
+    }
+
     const cronB = new CronService({
-      storePath: aliased
-        ? `${path.dirname(store.storePath)}/../${path.basename(path.dirname(store.storePath))}/${path.basename(store.storePath)}`
-        : store.storePath,
+      storePath: aliasedStorePath,
       cronEnabled: true,
       log: noopLogger,
       enqueueSystemEvent,
@@ -73,43 +89,69 @@ describe("CronService", () => {
     await store.cleanup();
   });
 
-  it("serializes concurrent operations for aliases of the same cron store", async () => {
-    const store = await makeStorePath();
-    const aliasedStorePath = `${path.dirname(store.storePath)}/../${path.basename(path.dirname(store.storePath))}/${path.basename(store.storePath)}`;
-    const createState = (storePath: string) =>
-      createCronServiceState({
-        storePath,
-        cronEnabled: true,
-        log: noopLogger,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
-        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
-      });
-    const events: string[] = [];
-    let releaseFirst: (() => void) | undefined;
-    const firstReleased = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    const first = locked(createState(store.storePath), async () => {
-      events.push("first-started");
-      await firstReleased;
-      events.push("first-finished");
-    });
-    const second = locked(createState(aliasedStorePath), async () => {
-      events.push("second-started");
-    });
-
-    try {
-      for (let turn = 0; turn < 5; turn += 1) {
-        await Promise.resolve();
+  it.each([
+    { name: "lexical", alias: "lexical" },
+    { name: "symlink", alias: "symlink" },
+    ...(process.platform === "win32"
+      ? []
+      : [{ name: "dangling file symlink", alias: "file-symlink" } as const]),
+  ] as const)(
+    "serializes concurrent operations for $name cron store aliases",
+    async ({ alias }) => {
+      const store = await makeStorePath();
+      let aliasedStorePath = `${path.dirname(store.storePath)}/../${path.basename(path.dirname(store.storePath))}/${path.basename(store.storePath)}`;
+      if (alias === "symlink") {
+        const realStoreDirectory = path.dirname(store.storePath);
+        await mkdir(realStoreDirectory, { recursive: true });
+        const symlinkedStoreDirectory = path.join(
+          path.dirname(realStoreDirectory),
+          "symlinked-cron-lock",
+        );
+        await symlink(
+          realStoreDirectory,
+          symlinkedStoreDirectory,
+          process.platform === "win32" ? "junction" : "dir",
+        );
+        aliasedStorePath = path.join(symlinkedStoreDirectory, path.basename(store.storePath));
+      } else if (alias === "file-symlink") {
+        await mkdir(path.dirname(store.storePath), { recursive: true });
+        aliasedStorePath = path.join(path.dirname(store.storePath), "symlinked-jobs.json");
+        await symlink(path.basename(store.storePath), aliasedStorePath, "file");
       }
-      expect(events).toEqual(["first-started"]);
-    } finally {
-      releaseFirst?.();
-      await Promise.all([first, second]);
-      await store.cleanup();
-    }
+      const createState = (storePath: string) =>
+        createCronServiceState({
+          storePath,
+          cronEnabled: true,
+          log: noopLogger,
+          enqueueSystemEvent: vi.fn(),
+          requestHeartbeat: vi.fn(),
+          runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+        });
+      const events: string[] = [];
+      let releaseFirst: (() => void) | undefined;
+      const firstReleased = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const first = locked(createState(store.storePath), async () => {
+        events.push("first-started");
+        await firstReleased;
+        events.push("first-finished");
+      });
+      const second = locked(createState(aliasedStorePath), async () => {
+        events.push("second-started");
+      });
 
-    expect(events).toEqual(["first-started", "first-finished", "second-started"]);
-  });
+      try {
+        await vi.waitFor(() => {
+          expect(events).toEqual(["first-started"]);
+        });
+      } finally {
+        releaseFirst?.();
+        await Promise.all([first, second]);
+        await store.cleanup();
+      }
+
+      expect(events).toEqual(["first-started", "first-finished", "second-started"]);
+    },
+  );
 });

--- a/src/cron/service.prevents-duplicate-timers.test.ts
+++ b/src/cron/service.prevents-duplicate-timers.test.ts
@@ -1,4 +1,5 @@
 // Duplicate timer tests cover cron service guards against repeated timer arms.
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { CronService } from "./service.js";
 import {
@@ -6,6 +7,8 @@ import {
   createNoopLogger,
   installCronTestHooks,
 } from "./service.test-harness.js";
+import { locked } from "./service/locked.js";
+import { createCronServiceState } from "./service/state.js";
 
 const noopLogger = createNoopLogger();
 const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-" });
@@ -15,7 +18,10 @@ installCronTestHooks({
 });
 
 describe("CronService", () => {
-  it("avoids duplicate runs when two services share a store", async () => {
+  it.each([
+    { name: "the same store path", aliased: false },
+    { name: "lexically different paths to the same store", aliased: true },
+  ])("avoids duplicate runs when two services share $name", async ({ aliased }) => {
     const store = await makeStorePath();
     const enqueueSystemEvent = vi.fn();
     const requestHeartbeat = vi.fn();
@@ -42,7 +48,9 @@ describe("CronService", () => {
     });
 
     const cronB = new CronService({
-      storePath: store.storePath,
+      storePath: aliased
+        ? `${path.dirname(store.storePath)}/../${path.basename(path.dirname(store.storePath))}/${path.basename(store.storePath)}`
+        : store.storePath,
       cronEnabled: true,
       log: noopLogger,
       enqueueSystemEvent,
@@ -63,5 +71,45 @@ describe("CronService", () => {
     cronA.stop();
     cronB.stop();
     await store.cleanup();
+  });
+
+  it("serializes concurrent operations for aliases of the same cron store", async () => {
+    const store = await makeStorePath();
+    const aliasedStorePath = `${path.dirname(store.storePath)}/../${path.basename(path.dirname(store.storePath))}/${path.basename(store.storePath)}`;
+    const createState = (storePath: string) =>
+      createCronServiceState({
+        storePath,
+        cronEnabled: true,
+        log: noopLogger,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      });
+    const events: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const first = locked(createState(store.storePath), async () => {
+      events.push("first-started");
+      await firstReleased;
+      events.push("first-finished");
+    });
+    const second = locked(createState(aliasedStorePath), async () => {
+      events.push("second-started");
+    });
+
+    try {
+      for (let turn = 0; turn < 5; turn += 1) {
+        await Promise.resolve();
+      }
+      expect(events).toEqual(["first-started"]);
+    } finally {
+      releaseFirst?.();
+      await Promise.all([first, second]);
+      await store.cleanup();
+    }
+
+    expect(events).toEqual(["first-started", "first-finished", "second-started"]);
   });
 });

--- a/src/cron/service.session-reaper-in-finally.test.ts
+++ b/src/cron/service.session-reaper-in-finally.test.ts
@@ -49,6 +49,87 @@ describe("CronService - session reaper runs in finally block (#31946)", () => {
     vi.clearAllMocks();
   });
 
+  it("re-arms the scheduler when resolving the default reaper agent fails", async () => {
+    const store = await makeStorePath();
+    const now = Date.parse("2026-02-10T10:00:00.000Z");
+    const job = createDueIsolatedJob({ id: "recover-default-agent", nowMs: now });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+    let defaultAgentAvailable = false;
+    const runIsolatedAgentJob = vi.fn().mockResolvedValue({ status: "ok", summary: "done" });
+    const state = createCronServiceState({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+      resolveDefaultAgentId: () => {
+        if (!defaultAgentAvailable) {
+          throw new Error("default agent temporarily unavailable");
+        }
+        return "main";
+      },
+      sessionStorePath: path.join(path.dirname(store.storePath), "sessions", "sessions.json"),
+    });
+    state.store = { version: 1, jobs: [job] };
+
+    await withCronServiceStateForTest(state, async () => {
+      await expect(onTimer(state)).rejects.toThrow("default agent temporarily unavailable");
+      expect(state.running).toBe(false);
+      expect(state.timer).not.toBeNull();
+
+      defaultAgentAvailable = true;
+      await expect(onTimer(state)).resolves.toBeUndefined();
+      expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
+      expect(state.running).toBe(false);
+    });
+  });
+
+  it.each([
+    { name: "agent discovery", failedOperation: "agents" },
+    { name: "session-store resolution", failedOperation: "store" },
+  ] as const)(
+    "keeps the scheduler running after reaper $name fails",
+    async ({ failedOperation }) => {
+      const store = await makeStorePath();
+      const now = Date.parse("2026-02-10T10:00:00.000Z");
+      const job = createDueIsolatedJob({ id: `recover-reaper-${failedOperation}`, nowMs: now });
+      await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+      const runIsolatedAgentJob = vi.fn().mockResolvedValue({ status: "ok", summary: "done" });
+      const state = createCronServiceState({
+        storePath: store.storePath,
+        cronEnabled: true,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+        defaultAgentId: "main",
+        resolveSessionStoreAgentIds: () => {
+          if (failedOperation === "agents") {
+            throw new Error("agent discovery temporarily unavailable");
+          }
+          return ["main"];
+        },
+        resolveSessionStorePath: () => {
+          if (failedOperation === "store") {
+            throw new Error("session store temporarily unavailable");
+          }
+          return path.join(path.dirname(store.storePath), "sessions", "sessions.json");
+        },
+      });
+
+      await withCronServiceStateForTest(state, async () => {
+        await expect(onTimer(state)).resolves.toBeUndefined();
+        expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
+        expect(state.running).toBe(false);
+        expect(state.timer).not.toBeNull();
+        expect(noopLogger.warn).toHaveBeenCalled();
+      });
+    },
+  );
+
   it("session reaper runs even when job execution throws", async () => {
     const store = await makeStorePath();
     const now = Date.parse("2026-02-10T10:00:00.000Z");

--- a/src/cron/service/locked.ts
+++ b/src/cron/service/locked.ts
@@ -1,4 +1,5 @@
 /** Process-local cron operation serialization by store path. */
+import path from "node:path";
 import type { CronServiceState } from "./state.js";
 
 const storeLocks = new Map<string, Promise<void>>();
@@ -11,7 +12,7 @@ const resolveChain = (promise: Promise<unknown>) =>
 
 /** Serializes cron operations per store path while preserving state-local operation ordering. */
 export async function locked<T>(state: CronServiceState, fn: () => Promise<T>): Promise<T> {
-  const storePath = state.deps.storePath;
+  const storePath = path.resolve(state.deps.storePath);
   const storeOp = storeLocks.get(storePath) ?? Promise.resolve();
   const next = Promise.all([resolveChain(state.op), resolveChain(storeOp)]).then(fn);
 
@@ -21,5 +22,12 @@ export async function locked<T>(state: CronServiceState, fn: () => Promise<T>): 
   state.op = keepAlive;
   storeLocks.set(storePath, keepAlive);
 
-  return (await next) as T;
+  void keepAlive.finally(() => {
+    // A newer operation may already own this store; never remove its chain.
+    if (storeLocks.get(storePath) === keepAlive) {
+      storeLocks.delete(storePath);
+    }
+  });
+
+  return await next;
 }

--- a/src/cron/service/locked.ts
+++ b/src/cron/service/locked.ts
@@ -1,8 +1,56 @@
 /** Process-local cron operation serialization by store path. */
+import { readlinkSync, realpathSync } from "node:fs";
 import path from "node:path";
 import type { CronServiceState } from "./state.js";
 
 const storeLocks = new Map<string, Promise<void>>();
+const storeLockPaths = new WeakMap<CronServiceState, string>();
+
+function resolveStoreLockPath(storePath: string): string {
+  let existingPath = path.resolve(storePath);
+  const missingSegments: string[] = [];
+
+  while (true) {
+    try {
+      // Stores may not exist on first startup. Canonicalize their closest
+      // existing ancestor once so symlink aliases still share one lock.
+      return path.join(realpathSync.native(existingPath), ...missingSegments.toReversed());
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") {
+        throw error;
+      }
+      try {
+        // realpath cannot resolve a store-file symlink before its target is
+        // created; follow that link before choosing the lock identity.
+        const targetPath = readlinkSync(existingPath);
+        existingPath = path.resolve(path.dirname(existingPath), targetPath);
+        continue;
+      } catch (linkError) {
+        const linkCode = (linkError as NodeJS.ErrnoException).code;
+        if (linkCode !== "EINVAL" && linkCode !== "ENOENT" && linkCode !== "ENOTDIR") {
+          throw linkError;
+        }
+      }
+      const parentPath = path.dirname(existingPath);
+      if (parentPath === existingPath) {
+        return path.resolve(storePath);
+      }
+      missingSegments.push(path.basename(existingPath));
+      existingPath = parentPath;
+    }
+  }
+}
+
+function getStoreLockPath(state: CronServiceState): string {
+  const cachedPath = storeLockPaths.get(state);
+  if (cachedPath) {
+    return cachedPath;
+  }
+  const resolvedPath = resolveStoreLockPath(state.deps.storePath);
+  storeLockPaths.set(state, resolvedPath);
+  return resolvedPath;
+}
 
 const resolveChain = (promise: Promise<unknown>) =>
   promise.then(
@@ -12,7 +60,7 @@ const resolveChain = (promise: Promise<unknown>) =>
 
 /** Serializes cron operations per store path while preserving state-local operation ordering. */
 export async function locked<T>(state: CronServiceState, fn: () => Promise<T>): Promise<T> {
-  const storePath = path.resolve(state.deps.storePath);
+  const storePath = getStoreLockPath(state);
   const storeOp = storeLocks.get(storePath) ?? Promise.resolve();
   const next = Promise.all([resolveChain(state.op), resolveChain(storeOp)]).then(fn);
 

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -177,20 +177,21 @@ async function onAdmittedTimer(state: CronServiceState) {
     armRunningRecheckTimer(state);
     return;
   }
-  const hasSessionReaperStore = Boolean(
-    state.deps.resolveSessionStorePath || state.deps.sessionStorePath,
-  );
-  const sessionReaperDefaultAgentId = hasSessionReaperStore
-    ? (state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId)?.trim()
-    : undefined;
-  if (hasSessionReaperStore && !sessionReaperDefaultAgentId) {
-    throw new Error("Cron session reaper requires the prepared configured default agent id.");
-  }
+  let sessionReaperDefaultAgentId: string | undefined;
   state.running = true;
   // Keep a watchdog timer armed while a tick is executing. If execution hangs
   // (for example in a provider call), the scheduler still wakes to re-check.
   armRunningRecheckTimer(state);
   try {
+    const hasSessionReaperStore = Boolean(
+      state.deps.resolveSessionStorePath || state.deps.sessionStorePath,
+    );
+    sessionReaperDefaultAgentId = hasSessionReaperStore
+      ? (state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId)?.trim()
+      : undefined;
+    if (hasSessionReaperStore && !sessionReaperDefaultAgentId) {
+      throw new Error("Cron session reaper requires the prepared configured default agent id.");
+    }
     const dueJobs = await locked(state, async () => {
       await ensureLoaded(state, { forceReload: true, skipRecompute: true });
       if (state.stopped || state.restartRecoveryPending) {
@@ -585,60 +586,69 @@ async function onAdmittedTimer(state: CronServiceState) {
         : new Error(formatErrorMessage(batchExecutionError));
     }
   } finally {
-    // Piggyback session reaper on timer tick (self-throttled to every 5 min).
-    // Placed in `finally` so the reaper runs even when a long-running job keeps
-    // `state.running` true across multiple timer ticks — the early return at the
-    // top of onTimer would otherwise skip the reaper indefinitely.
-    const storeTargets = new Map<string, { agentId: string; storePath: string }>();
-    const addStoreTarget = (agentId: string, storePath: string) => {
-      storeTargets.set(`${agentId}\0${storePath}`, { agentId, storePath });
-    };
-    const resolveJobAgentId = (job: CronJob, defaultAgentId: string) =>
-      typeof job.agentId === "string" && job.agentId.trim()
-        ? normalizeAgentId(job.agentId)
-        : resolveAgentIdFromSessionKey(job.sessionKey, defaultAgentId);
-    const configuredAgentIds = state.deps.resolveSessionStoreAgentIds?.() ?? [];
-    if (state.deps.resolveSessionStorePath) {
-      const defaultAgentId = sessionReaperDefaultAgentId!;
-      for (const agentId of configuredAgentIds) {
-        const normalizedAgentId = normalizeAgentId(agentId);
-        addStoreTarget(normalizedAgentId, state.deps.resolveSessionStorePath(normalizedAgentId));
-      }
-      for (const job of state.store?.jobs ?? []) {
-        const agentId = resolveJobAgentId(job, defaultAgentId);
-        addStoreTarget(agentId, state.deps.resolveSessionStorePath(agentId));
-      }
-      addStoreTarget(defaultAgentId, state.deps.resolveSessionStorePath(defaultAgentId));
-    } else if (state.deps.sessionStorePath) {
-      const defaultAgentId = sessionReaperDefaultAgentId!;
-      for (const agentId of configuredAgentIds) {
-        addStoreTarget(normalizeAgentId(agentId), state.deps.sessionStorePath);
-      }
-      for (const job of state.store?.jobs ?? []) {
-        addStoreTarget(resolveJobAgentId(job, defaultAgentId), state.deps.sessionStorePath);
-      }
-      addStoreTarget(defaultAgentId, state.deps.sessionStorePath);
-    }
+    try {
+      // Reaper discovery is maintenance: failure must never strand the timer
+      // or leave the scheduler's execution slot permanently occupied.
+      if (sessionReaperDefaultAgentId) {
+        const defaultAgentId = sessionReaperDefaultAgentId;
+        const storeTargets = new Map<string, { agentId: string; storePath: string }>();
+        const addStoreTarget = (agentId: string, storePath: string) => {
+          storeTargets.set(`${agentId}\0${storePath}`, { agentId, storePath });
+        };
+        const resolveJobAgentId = (job: CronJob) =>
+          typeof job.agentId === "string" && job.agentId.trim()
+            ? normalizeAgentId(job.agentId)
+            : resolveAgentIdFromSessionKey(job.sessionKey, defaultAgentId);
+        const configuredAgentIds = state.deps.resolveSessionStoreAgentIds?.() ?? [];
+        if (state.deps.resolveSessionStorePath) {
+          for (const agentId of configuredAgentIds) {
+            const normalizedAgentId = normalizeAgentId(agentId);
+            addStoreTarget(
+              normalizedAgentId,
+              state.deps.resolveSessionStorePath(normalizedAgentId),
+            );
+          }
+          for (const job of state.store?.jobs ?? []) {
+            const agentId = resolveJobAgentId(job);
+            addStoreTarget(agentId, state.deps.resolveSessionStorePath(agentId));
+          }
+          addStoreTarget(defaultAgentId, state.deps.resolveSessionStorePath(defaultAgentId));
+        } else if (state.deps.sessionStorePath) {
+          for (const agentId of configuredAgentIds) {
+            addStoreTarget(normalizeAgentId(agentId), state.deps.sessionStorePath);
+          }
+          for (const job of state.store?.jobs ?? []) {
+            addStoreTarget(resolveJobAgentId(job), state.deps.sessionStorePath);
+          }
+          addStoreTarget(defaultAgentId, state.deps.sessionStorePath);
+        }
 
-    if (storeTargets.size > 0) {
-      const nowMs = state.deps.nowMs();
-      for (const { agentId, storePath } of storeTargets.values()) {
-        try {
-          await sweepCronRunSessions({
-            agentId,
-            defaultAgentId: sessionReaperDefaultAgentId!,
-            cronConfig: state.deps.cronConfig,
-            sessionStorePath: storePath,
-            nowMs,
-            log: state.deps.log,
-          });
-        } catch (err) {
-          state.deps.log.warn({ err: String(err), storePath }, "cron: session reaper sweep failed");
+        if (storeTargets.size > 0) {
+          const nowMs = state.deps.nowMs();
+          for (const { agentId, storePath } of storeTargets.values()) {
+            try {
+              await sweepCronRunSessions({
+                agentId,
+                defaultAgentId,
+                cronConfig: state.deps.cronConfig,
+                sessionStorePath: storePath,
+                nowMs,
+                log: state.deps.log,
+              });
+            } catch (err) {
+              state.deps.log.warn(
+                { err: String(err), storePath },
+                "cron: session reaper sweep failed",
+              );
+            }
+          }
         }
       }
+    } catch (err) {
+      state.deps.log.warn({ err: String(err) }, "cron: session reaper preparation failed");
+    } finally {
+      state.running = false;
+      armTimer(state);
     }
-
-    state.running = false;
-    armTimer(state);
   }
 }

--- a/src/infra/heartbeat-runner-delivery.ts
+++ b/src/infra/heartbeat-runner-delivery.ts
@@ -439,7 +439,11 @@ export async function finalizeHeartbeatOutcome(params: {
     ...(normalized.silent === true ? { silent: true } : {}),
     indicatorType: visibility.useIndicator ? resolveIndicatorType(eventStatus) : undefined,
   });
-  consumeInspectedSystemEvents(params.wake, params.prepared);
+  // Intentional internal-only/no-target runs consume above. Once this branch
+  // expects visible delivery, suppressed sends must retain the original event.
+  if (visibleSendSucceeded) {
+    consumeInspectedSystemEvents(params.wake, params.prepared);
+  }
   return { status: "ran", durationMs: Date.now() - startedAt };
 }
 

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -83,6 +83,7 @@ import {
 } from "./heartbeat-wake-policy.js";
 import {
   areHeartbeatsEnabled,
+  getHeartbeatWakeAbortSignal,
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
   HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
   type HeartbeatScheduledTask,
@@ -597,6 +598,7 @@ export async function invokeHeartbeatAgentRun(
   const heartbeatModelOverride = normalizeOptionalString(heartbeat?.model);
   const getReplyFromConfig =
     opts.deps?.getReplyFromConfig ?? (await loadHeartbeatRunnerRuntime()).getReplyFromConfig;
+  const heartbeatWakeAbortSignal = getHeartbeatWakeAbortSignal();
   const replyOpts = {
     isHeartbeat: true,
     [HEARTBEAT_RUN_SCOPE]: runScope,
@@ -606,6 +608,7 @@ export async function invokeHeartbeatAgentRun(
     ...(usesHeartbeatResponseTool ? { enableHeartbeatTool: true, forceHeartbeatTool: true } : {}),
     ...(usesHeartbeatResponseTool ? { sourceReplyDeliveryMode: "message_tool_only" as const } : {}),
     ...(hasDueCommitments ? { disableTools: true, skillFilter: [] } : {}),
+    ...(heartbeatWakeAbortSignal ? { abortSignal: heartbeatWakeAbortSignal } : {}),
     // Heartbeat timeout is a per-run override so user turns keep the global default.
     timeoutOverrideSeconds: resolveHeartbeatTimeoutOverrideSeconds(cfg, heartbeat),
     bootstrapContextMode: heartbeat?.lightContext === true ? ("lightweight" as const) : undefined,

--- a/src/infra/heartbeat-runner-run.ts
+++ b/src/infra/heartbeat-runner-run.ts
@@ -133,7 +133,7 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
       if (send.status === "failed" || send.status === "partial_failed") {
         throw send.error;
       }
-      return true;
+      return send.status === "sent";
     } catch (err) {
       log.warn(`heartbeat: HEARTBEAT_OK delivery failed: ${formatErrorMessage(err)}`);
       return false;

--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -356,6 +356,7 @@ export function startHeartbeatRunner(opts: {
           intent,
           reason,
           runScope: "global",
+          tasks: requestedTasks,
           deps: { runtime: state.runtime },
         });
       } catch (err) {
@@ -450,7 +451,12 @@ export function startHeartbeatRunner(opts: {
       if (!targetAgent && !allowsUnscheduledTarget) {
         return { status: "skipped", reason: "disabled" };
       }
-      if (isInterval && targetAgent && !requestedSessionKey && !requestedHeartbeat) {
+      if (
+        (isInterval || authoritativeScheduledTick) &&
+        targetAgent &&
+        !requestedSessionKey &&
+        !requestedHeartbeat
+      ) {
         // Cron monitor tick for one enrolled agent: use the full per-agent
         // path — including due-commitment sessions — that the broadcast
         // interval owned before cadence moved to cron. Wakes carrying

--- a/src/infra/heartbeat-runner.ack-token-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.ack-token-heartbeat-acks.test.ts
@@ -1,6 +1,13 @@
 // Covers heartbeat ack truncation limits.
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { addTestHook } from "../plugins/hooks.test-helpers.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { getLastHeartbeatEvent } from "./heartbeat-events.js";
 import { runHeartbeatOnce, type HeartbeatDeps } from "./heartbeat-runner.js";
 import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
 import {
@@ -268,6 +275,52 @@ describe("runHeartbeatOnce ack handling", () => {
         text: "HEARTBEAT_OK",
         cfg,
       });
+    });
+  });
+
+  it("reports a hook-suppressed HEARTBEAT_OK as silent", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const registry = getActivePluginRegistry();
+      if (!registry) {
+        throw new Error("Expected the heartbeat test plugin registry");
+      }
+      addTestHook({
+        registry,
+        pluginId: "heartbeat-test-suppression",
+        hookName: "message_sending",
+        handler: () => ({ cancel: true }),
+      });
+      initializeGlobalHookRunner(registry);
+      try {
+        const cfg = createWhatsAppHeartbeatConfig({
+          tmpDir,
+          storePath,
+          visibility: { showOk: true },
+        });
+        await seedMainSessionStore(storePath, cfg, {
+          lastChannel: "whatsapp",
+          lastProvider: "whatsapp",
+          lastTo: WHATSAPP_GROUP,
+        });
+        replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+        const sendWhatsApp = createMessageSendSpy();
+
+        expect(
+          (
+            await runHeartbeatOnce({
+              cfg,
+              deps: {
+                ...makeWhatsAppDeps({ sendWhatsApp }),
+                getReplyFromConfig: replySpy,
+              },
+            })
+          ).status,
+        ).toBe("ran");
+        expect(sendWhatsApp).not.toHaveBeenCalled();
+        expect(getLastHeartbeatEvent()).toMatchObject({ status: "ok-token", silent: true });
+      } finally {
+        resetGlobalHookRunner();
+      }
     });
   });
 

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -632,8 +632,56 @@ describe("Ghost reminder bug (issue #13317)", () => {
     });
   });
 
+  it("retains a cron reminder until a suppressed heartbeat can actually deliver it", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const { cfg, sessionKey } = await createConfig({ tmpDir, storePath });
+      const reminder = "Cron: QMD maintenance completed";
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "155462274",
+      });
+      const getReplySpy = vi
+        .fn()
+        .mockResolvedValueOnce({ text: "No channel reply." })
+        .mockResolvedValueOnce({ text: "Relay this cron update now" });
+
+      enqueueSystemEvent(reminder, {
+        sessionKey,
+        contextKey: "cron:qmd-maintenance",
+      });
+
+      const runOnce = async () =>
+        await runHeartbeatOnce({
+          cfg,
+          agentId: "main",
+          reason: "interval",
+          deps: {
+            getReplyFromConfig: getReplySpy,
+            telegram: sendTelegram,
+          },
+        });
+
+      expect((await runOnce()).status).toBe("ran");
+      expect(sendTelegram).not.toHaveBeenCalled();
+      expect(peekSystemEvents(sessionKey)).toEqual([reminder]);
+
+      expect((await runOnce()).status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(peekSystemEvents(sessionKey)).toEqual([]);
+      for (const [context] of getReplySpy.mock.calls) {
+        expect(context).toMatchObject({ Provider: "cron-event" });
+        expect(context.Body).toContain(reminder);
+      }
+    });
+  });
+
   it("uses an internal-only cron prompt when delivery target is none", async () => {
-    const { result, sendTelegram, calledCtx } = await runHeartbeatCase({
+    const {
+      result,
+      sendTelegram,
+      calledCtx,
+      sessionKey: processedSessionKey,
+    } = await runHeartbeatCase({
       tmpPrefix: "openclaw-cron-internal-",
       replyText: "Handled internally",
       reason: "cron:reminder-job",
@@ -647,10 +695,16 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(calledCtx?.Provider).toBe("cron-event");
     expect(calledCtx?.Body).toContain("Handle this reminder internally");
     expect(sendTelegram).not.toHaveBeenCalled();
+    expect(peekSystemEvents(processedSessionKey)).toEqual([]);
   });
 
   it("uses an internal-only exec prompt when delivery target is none", async () => {
-    const { result, sendTelegram, calledCtx } = await runHeartbeatCase({
+    const {
+      result,
+      sendTelegram,
+      calledCtx,
+      sessionKey: processedSessionKey,
+    } = await runHeartbeatCase({
       tmpPrefix: "openclaw-exec-internal-",
       replyText: "Handled internally",
       reason: "exec-event",
@@ -664,6 +718,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(calledCtx?.Provider).toBe("exec-event");
     expect(calledCtx?.Body).toContain("Handle the result internally");
     expect(sendTelegram).not.toHaveBeenCalled();
+    expect(peekSystemEvents(processedSessionKey)).toEqual([]);
   });
 
   it("includes untrusted exec completion details in user-relay prompts", async () => {

--- a/src/infra/heartbeat-runner.monitor-task-commitments.test.ts
+++ b/src/infra/heartbeat-runner.monitor-task-commitments.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HEARTBEAT_TOKEN } from "../auto-reply/tokens.js";
+import { readCommitmentsForTest, seedCommitmentsForTest } from "../commitments/store.test-utils.js";
+import type { CommitmentRecord } from "../commitments/types.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { resetHeartbeatEventsForTest } from "./heartbeat-events.js";
+import {
+  runHeartbeatOnce,
+  setHeartbeatsEnabled,
+  startHeartbeatRunner,
+} from "./heartbeat-runner.js";
+import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
+import { seedSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+import { requestHeartbeat } from "./heartbeat-wake.js";
+import { resetSystemEventsForTest } from "./system-events.js";
+
+vi.mock("../commitments/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../commitments/config.js")>()),
+  resolveCommitmentsConfig: () => ({
+    enabled: true,
+    maxPerDay: 3,
+    extraction: {
+      debounceMs: 15_000,
+      batchMaxItems: 8,
+      queueMaxItems: 64,
+      confidenceThreshold: 0.72,
+      careConfidenceThreshold: 0.86,
+      timeoutSeconds: 45,
+    },
+  }),
+}));
+
+installHeartbeatRunnerTestRuntime();
+
+describe("heartbeat monitor and task commitment delivery", () => {
+  const nowMs = Date.parse("2026-04-29T17:00:00.000Z");
+  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    setHeartbeatsEnabled(true);
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    envSnapshot.restore();
+    resetHeartbeatEventsForTest();
+    resetSystemEventsForTest();
+  });
+
+  it("delivers commitments when a cron monitor coalesces with a scheduled task", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(nowMs);
+
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      setTestEnvValue("OPENCLAW_STATE_DIR", tmpDir);
+      const sessionKey = "agent:main:telegram:user-155462274";
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "last", session: sessionKey },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      await seedSessionStore(storePath, sessionKey, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "155462274",
+      });
+      const commitment: CommitmentRecord = {
+        id: "cm_interview",
+        agentId: "main",
+        sessionKey,
+        channel: "telegram",
+        accountId: "primary",
+        to: "155462274",
+        kind: "event_check_in",
+        sensitivity: "routine",
+        source: "inferred_user_context",
+        status: "pending",
+        reason: "The user said they had an interview yesterday.",
+        suggestedText: "How did the interview go?",
+        dedupeKey: "interview:2026-04-28",
+        confidence: 0.92,
+        dueWindow: {
+          earliestMs: nowMs - 60_000,
+          latestMs: nowMs + 60 * 60_000,
+          timezone: "America/Los_Angeles",
+        },
+        createdAtMs: nowMs - 24 * 60 * 60_000,
+        updatedAtMs: nowMs - 24 * 60 * 60_000,
+        attempts: 0,
+      };
+      seedCommitmentsForTest([commitment]);
+      const task = {
+        jobId: "job-deployment-status",
+        name: "deployment-status",
+        prompt: "Check deployment status with the normal tools",
+      };
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "155462274",
+      });
+      replySpy
+        .mockResolvedValueOnce({ text: HEARTBEAT_TOKEN })
+        .mockResolvedValueOnce({ text: "How did the interview go?" });
+      const runOnce = vi.fn<typeof runHeartbeatOnce>(async (options) =>
+        runHeartbeatOnce({
+          ...options,
+          deps: {
+            ...options.deps,
+            getReplyFromConfig: replySpy,
+            telegram: sendTelegram,
+            getQueueSize: () => 0,
+            nowMs: () => nowMs,
+          },
+        }),
+      );
+      const runner = startHeartbeatRunner({
+        cfg,
+        runOnce,
+        stableSchedulerSeed: "coalesced-cron-monitor-and-task",
+      });
+
+      requestHeartbeat({
+        source: "interval",
+        intent: "scheduled",
+        reason: "interval",
+        agentId: "main",
+        scheduledEveryMs: 5 * 60_000,
+        coalesceMs: 100,
+      });
+      requestHeartbeat({
+        source: "interval",
+        intent: "task",
+        reason: "heartbeat-task:job-deployment-status",
+        agentId: "main",
+        tasks: [task],
+        coalesceMs: 100,
+      });
+
+      try {
+        await vi.advanceTimersByTimeAsync(100);
+        await vi.waitFor(() => expect(runOnce).toHaveBeenCalledTimes(2));
+        expect(runOnce.mock.calls[0]?.[0]).toMatchObject({
+          agentId: "main",
+          runScope: "global",
+          tasks: [task],
+        });
+        expect(runOnce.mock.calls[1]?.[0]).toMatchObject({
+          agentId: "main",
+          runScope: "commitment-only",
+          sessionKey,
+        });
+        expect(sendTelegram).toHaveBeenCalledTimes(1);
+        expect(readCommitmentsForTest()[0]).toMatchObject({
+          id: "cm_interview",
+          status: "sent",
+          attempts: 1,
+        });
+      } finally {
+        runner.stop();
+      }
+    });
+  });
+});

--- a/src/infra/heartbeat-wake-concurrency.test.ts
+++ b/src/infra/heartbeat-wake-concurrency.test.ts
@@ -38,6 +38,43 @@ describe("heartbeat wake target concurrency", () => {
     vi.restoreAllMocks();
   });
 
+  it("flushes target wakes before an unscoped barrier that was originally queued first", async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn(async (_request: WakeRequest) => ({
+      status: "ran" as const,
+      durationMs: 1,
+    }));
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeat({
+      source: "other",
+      intent: "immediate",
+      reason: "test-delayed-global-flush",
+      coalesceMs: 1_000,
+    });
+    requestHeartbeat({
+      source: "background-task",
+      intent: "immediate",
+      reason: "background-task",
+      agentId: "main",
+      sessionKey: "agent:main:guildchat:channel:123",
+    });
+    requestHeartbeat({
+      source: "other",
+      intent: "immediate",
+      reason: "test-global-flush",
+      coalesceMs: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+      "background-task",
+      "test-global-flush",
+    ]);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
   it("starts independent target wakes without waiting for a blocked agent", async () => {
     vi.useFakeTimers();
     let finishBlockedWake: (() => void) | undefined;

--- a/src/infra/heartbeat-wake-concurrency.test.ts
+++ b/src/infra/heartbeat-wake-concurrency.test.ts
@@ -1,0 +1,437 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getActiveGatewayRootWorkCount,
+  resetGatewayWorkAdmission,
+} from "../process/gateway-work-admission.js";
+import {
+  getHeartbeatWakeAbortSignal,
+  requestHeartbeat,
+  setHeartbeatWakeHandler as setRuntimeHeartbeatWakeHandler,
+} from "./heartbeat-wake.js";
+
+describe("heartbeat wake target concurrency", () => {
+  type WakeRequest = Parameters<typeof requestHeartbeat>[0];
+  type HeartbeatWakeHandler = Parameters<typeof setRuntimeHeartbeatWakeHandler>[0];
+  let currentHandlerDisposer: (() => void) | undefined;
+
+  function setHeartbeatWakeHandler(handler: HeartbeatWakeHandler): void {
+    currentHandlerDisposer = setRuntimeHeartbeatWakeHandler(handler);
+  }
+
+  beforeEach(() => {
+    resetGatewayWorkAdmission();
+  });
+
+  afterEach(async () => {
+    resetGatewayWorkAdmission();
+    if (vi.isFakeTimers()) {
+      currentHandlerDisposer?.();
+      currentHandlerDisposer = setRuntimeHeartbeatWakeHandler(async () => ({
+        status: "skipped",
+        reason: "disabled",
+      }));
+      await vi.runAllTimersAsync();
+    }
+    currentHandlerDisposer?.();
+    currentHandlerDisposer = undefined;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts independent target wakes without waiting for a blocked agent", async () => {
+    vi.useFakeTimers();
+    let finishBlockedWake: (() => void) | undefined;
+    const blockedWake = new Promise<void>((resolve) => {
+      finishBlockedWake = resolve;
+    });
+    const handler = vi.fn(async (request: WakeRequest) => {
+      if (request.agentId === "blocked") {
+        await blockedWake;
+      }
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(handler);
+
+    for (const agentId of ["blocked", "ready-a", "ready-b"]) {
+      requestHeartbeat({
+        source: "cron",
+        intent: "event",
+        reason: `cron:${agentId}`,
+        agentId,
+        sessionKey: `agent:${agentId}:main`,
+        coalesceMs: 100,
+      });
+    }
+
+    try {
+      await vi.advanceTimersByTimeAsync(100);
+      expect(handler.mock.calls.map(([request]) => request.agentId)).toEqual([
+        "blocked",
+        "ready-a",
+        "ready-b",
+      ]);
+      expect(getActiveGatewayRootWorkCount()).toBe(1);
+    } finally {
+      finishBlockedWake?.();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("starts newly requested target wakes while another agent remains blocked", async () => {
+    vi.useFakeTimers();
+    let finishBlockedWake: (() => void) | undefined;
+    const blockedWake = new Promise<void>((resolve) => {
+      finishBlockedWake = resolve;
+    });
+    const handler = vi.fn(async (request: WakeRequest) => {
+      if (request.agentId === "blocked") {
+        await blockedWake;
+      }
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(handler);
+    requestHeartbeat({
+      source: "cron",
+      intent: "event",
+      reason: "cron:blocked",
+      agentId: "blocked",
+      sessionKey: "agent:blocked:main",
+      coalesceMs: 0,
+    });
+
+    try {
+      await vi.advanceTimersByTimeAsync(1);
+      requestHeartbeat({
+        source: "cron",
+        intent: "event",
+        reason: "cron:ready",
+        agentId: "ready",
+        sessionKey: "agent:ready:main",
+        coalesceMs: 0,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+      expect(handler.mock.calls.map(([request]) => request.agentId)).toEqual(["blocked", "ready"]);
+      expect(getActiveGatewayRootWorkCount()).toBe(1);
+    } finally {
+      finishBlockedWake?.();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("bounds concurrent target wakes and starts queued targets as slots open", async () => {
+    vi.useFakeTimers();
+    const finishWakeByAgent = new Map<string, () => void>();
+    let peakActiveWakeCount = 0;
+    const handler = vi.fn(async (request: WakeRequest) => {
+      peakActiveWakeCount = Math.max(peakActiveWakeCount, getActiveGatewayRootWorkCount());
+      await new Promise<void>((resolve) => {
+        finishWakeByAgent.set(request.agentId ?? "", resolve);
+      });
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(handler);
+
+    for (let index = 0; index < 9; index += 1) {
+      const agentId = `target-${index}`;
+      requestHeartbeat({
+        source: "cron",
+        intent: "event",
+        reason: `cron:${agentId}`,
+        agentId,
+        sessionKey: `agent:${agentId}:main`,
+        coalesceMs: 0,
+      });
+    }
+
+    try {
+      await vi.advanceTimersByTimeAsync(1);
+      expect(handler.mock.calls.map(([request]) => request.agentId)).toEqual([
+        "target-0",
+        "target-1",
+        "target-2",
+        "target-3",
+      ]);
+      expect(getActiveGatewayRootWorkCount()).toBe(4);
+
+      finishWakeByAgent.get("target-0")?.();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(handler.mock.calls.map(([request]) => request.agentId)).toEqual([
+        "target-0",
+        "target-1",
+        "target-2",
+        "target-3",
+        "target-4",
+      ]);
+      expect(getActiveGatewayRootWorkCount()).toBe(4);
+    } finally {
+      for (let index = 0; index < 9; index += 1) {
+        for (const finishWake of finishWakeByAgent.values()) {
+          finishWake();
+        }
+        await vi.advanceTimersByTimeAsync(0);
+      }
+    }
+
+    expect(handler).toHaveBeenCalledTimes(9);
+    expect(peakActiveWakeCount).toBe(4);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("preserves the target concurrency bound across heartbeat handler replacement", async () => {
+    vi.useFakeTimers();
+    const finishOldWakeByAgent = new Map<string, () => void>();
+    const finishNewWakeByAgent = new Map<string, () => void>();
+    const oldWakeSignals: AbortSignal[] = [];
+    let peakActiveWakeCount = 0;
+    const oldHandler = vi.fn(async (request: WakeRequest) => {
+      peakActiveWakeCount = Math.max(peakActiveWakeCount, getActiveGatewayRootWorkCount());
+      const signal = getHeartbeatWakeAbortSignal();
+      if (signal) {
+        oldWakeSignals.push(signal);
+      }
+      await new Promise<void>((resolve) => {
+        finishOldWakeByAgent.set(request.agentId ?? "", resolve);
+      });
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(oldHandler);
+
+    function requestTarget(agentId: string): void {
+      requestHeartbeat({
+        source: "cron",
+        intent: "event",
+        reason: `cron:${agentId}`,
+        agentId,
+        sessionKey: `agent:${agentId}:main`,
+        coalesceMs: 0,
+      });
+    }
+
+    for (let index = 0; index < 4; index += 1) {
+      requestTarget(`target-${index}`);
+    }
+    await vi.advanceTimersByTimeAsync(1);
+    expect(oldHandler).toHaveBeenCalledTimes(4);
+    expect(getActiveGatewayRootWorkCount()).toBe(4);
+
+    const newHandler = vi.fn(async (request: WakeRequest) => {
+      peakActiveWakeCount = Math.max(peakActiveWakeCount, getActiveGatewayRootWorkCount());
+      await new Promise<void>((resolve) => {
+        finishNewWakeByAgent.set(request.agentId ?? "", resolve);
+      });
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(newHandler);
+    requestTarget("target-0");
+    for (let index = 4; index < 8; index += 1) {
+      requestTarget(`target-${index}`);
+    }
+
+    try {
+      await vi.advanceTimersByTimeAsync(1);
+      expect(oldWakeSignals).toHaveLength(4);
+      expect(oldWakeSignals.every((signal) => signal.aborted)).toBe(true);
+      expect(newHandler.mock.calls.map(([request]) => request.agentId)).toEqual([
+        "target-0",
+        "target-4",
+        "target-5",
+        "target-6",
+      ]);
+      expect(getActiveGatewayRootWorkCount()).toBe(4);
+
+      finishNewWakeByAgent.get("target-0")?.();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(newHandler.mock.calls.map(([request]) => request.agentId)).toEqual([
+        "target-0",
+        "target-4",
+        "target-5",
+        "target-6",
+        "target-7",
+      ]);
+      expect(getActiveGatewayRootWorkCount()).toBe(4);
+    } finally {
+      for (let index = 0; index < 9; index += 1) {
+        for (const finishWake of finishOldWakeByAgent.values()) {
+          finishWake();
+        }
+        for (const finishWake of finishNewWakeByAgent.values()) {
+          finishWake();
+        }
+        await vi.advanceTimersByTimeAsync(0);
+      }
+    }
+
+    expect(newHandler).toHaveBeenCalledTimes(8);
+    expect(peakActiveWakeCount).toBe(4);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("keeps task and event wakes for the same target serialized", async () => {
+    vi.useFakeTimers();
+    let finishTask: (() => void) | undefined;
+    const taskFinished = new Promise<void>((resolve) => {
+      finishTask = resolve;
+    });
+    const handler = vi.fn(async (request: WakeRequest) => {
+      if (request.intent === "task") {
+        await taskFinished;
+      }
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeat({
+      source: "interval",
+      intent: "task",
+      reason: "heartbeat-task:deployment",
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      tasks: [{ jobId: "deployment", name: "deployment", prompt: "Check deployment" }],
+      coalesceMs: 100,
+    });
+    requestHeartbeat({
+      source: "cron",
+      intent: "event",
+      reason: "cron:deployment",
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      coalesceMs: 100,
+    });
+
+    try {
+      await vi.advanceTimersByTimeAsync(100);
+      expect(handler.mock.calls.map(([request]) => request.intent)).toEqual(["task"]);
+      expect(getActiveGatewayRootWorkCount()).toBe(1);
+    } finally {
+      finishTask?.();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    expect(handler.mock.calls.map(([request]) => request.intent)).toEqual(["task", "event"]);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("does not apply an active target's old delay to a newly ready wake", async () => {
+    vi.useFakeTimers();
+    let finishBlockedWake: (() => void) | undefined;
+    const blockedWake = new Promise<void>((resolve) => {
+      finishBlockedWake = resolve;
+    });
+    const handler = vi.fn(async (request: WakeRequest) => {
+      if (request.reason === "cron:blocked") {
+        await blockedWake;
+      }
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(handler);
+    requestHeartbeat({
+      source: "cron",
+      intent: "event",
+      reason: "cron:blocked",
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      coalesceMs: 30_000,
+    });
+
+    try {
+      await vi.advanceTimersByTimeAsync(30_000);
+      requestHeartbeat({
+        source: "manual",
+        intent: "manual",
+        reason: "manual",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        coalesceMs: 0,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+      expect(handler).toHaveBeenCalledOnce();
+    } finally {
+      finishBlockedWake?.();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+      "cron:blocked",
+      "manual",
+    ]);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("does not delay a ready target behind another target's deferred retry", async () => {
+    vi.useFakeTimers();
+    let finishBlockedWake: (() => void) | undefined;
+    const blockedWake = new Promise<void>((resolve) => {
+      finishBlockedWake = resolve;
+    });
+    let deferredAttempts = 0;
+    const handler = vi.fn(async (request: WakeRequest) => {
+      if (request.reason === "cron:blocked") {
+        await blockedWake;
+      }
+      if (request.agentId === "deferred" && deferredAttempts++ === 0) {
+        return {
+          status: "skipped" as const,
+          reason: "not-due",
+          retryAtMs: Date.now() + 30_000,
+        };
+      }
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(handler);
+    requestHeartbeat({
+      source: "cron",
+      intent: "event",
+      reason: "cron:blocked",
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+
+    try {
+      await vi.advanceTimersByTimeAsync(1);
+      requestHeartbeat({
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        agentId: "deferred",
+        sessionKey: "agent:deferred:main",
+        coalesceMs: 0,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+      requestHeartbeat({
+        source: "manual",
+        intent: "manual",
+        reason: "manual",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        coalesceMs: 0,
+      });
+      await vi.advanceTimersByTimeAsync(1);
+      expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+        "cron:blocked",
+        "exec-event",
+      ]);
+    } finally {
+      finishBlockedWake?.();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+      "cron:blocked",
+      "exec-event",
+      "manual",
+    ]);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+      "cron:blocked",
+      "exec-event",
+      "manual",
+      "exec-event",
+    ]);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+});

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -844,7 +844,7 @@ describe("heartbeat-wake", () => {
     expect(handler).toHaveBeenCalledWith(wake("exec-event"));
   });
 
-  it("resets running/scheduled flags when new handler is registered", async () => {
+  it("recovers interrupted wakes when a replacement handler is registered", async () => {
     vi.useFakeTimers();
 
     // Simulate a handler that's mid-execution when SIGUSR1 fires.
@@ -868,14 +868,14 @@ describe("heartbeat-wake", () => {
     const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
     setHeartbeatWakeHandler(handlerB);
 
-    // handlerB should be able to fire (running was reset)
-    requestHeartbeat(wake("interval", { coalesceMs: 0 }));
+    // The replacement must handle both fresh work and the interrupted wake.
+    requestHeartbeat(wake("interval", { agentId: "ready", coalesceMs: 0 }));
     await vi.advanceTimersByTimeAsync(1);
-    expect(handlerB).toHaveBeenCalledTimes(1);
+    expect(handlerB.mock.calls.map(([request]) => request.agentId)).toEqual(["ready", undefined]);
 
     // Clean up the hanging promise
     resolveHang!();
-    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
   });
 
   it("does not let a stale heartbeat lifecycle release a newer active wake", async () => {
@@ -926,7 +926,7 @@ describe("heartbeat-wake", () => {
   });
 
   it.each([
-    { outcome: "completed", expectedReasons: ["cron:job-b"] },
+    { outcome: "completed", expectedReasons: ["cron:job-a", "cron:job-b"] },
     { outcome: "thrown", expectedReasons: ["cron:job-a", "cron:job-b"] },
     { outcome: "busy", expectedReasons: ["cron:job-a", "cron:job-b"] },
     { outcome: "guarded", expectedReasons: ["cron:job-a", "cron:job-b"] },
@@ -960,10 +960,10 @@ describe("heartbeat-wake", () => {
       for (const target of ["a", "b"]) {
         requestHeartbeat({
           source: "cron",
-          intent: "event",
+          intent: target === "a" ? "task" : "event",
           reason: `cron:job-${target}`,
-          agentId: `agent-${target}`,
-          sessionKey: `agent:agent-${target}:main`,
+          agentId: "main",
+          sessionKey: "agent:main:main",
           coalesceMs: 100,
         });
       }

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -1,4 +1,5 @@
 // Tracks heartbeat wake requests, busy skips, and retry timing.
+import { AsyncLocalStorage } from "node:async_hooks";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
@@ -88,6 +89,8 @@ type PendingWakeReason = {
   reason: string;
   priority: number;
   requestedAt: number;
+  /** Earliest dispatch instant requested by the wake's coalescing window. */
+  readyAtMs?: number;
   agentId?: string;
   sessionKey?: string;
   heartbeat?: HeartbeatWakeOverride;
@@ -108,23 +111,42 @@ type PendingWakeGroup = {
   blockedUntilMs?: number;
 };
 
+type ReadyWakeGroup = {
+  targetKey: string;
+  wakes: PendingWakeReason[];
+};
+
+type ActiveWakeTarget = {
+  generation: number;
+  abortController: AbortController;
+};
+
 let handler: HeartbeatWakeHandler | null = null;
 let handlerGeneration = 0;
 // One bounded group per target owns every pending/retry class for that agent/session.
 const pendingWakes = new Map<string, PendingWakeGroup>();
-let scheduled = false;
-let running = false;
+// Independent targets can run together; each target still owns one serial turn.
+const activeWakeTargets = new Map<string, ActiveWakeTarget>();
+const heartbeatWakeAbortSignals = new AsyncLocalStorage<AbortSignal>();
 let timer: NodeJS.Timeout | null = null;
 let timerDueAt: number | null = null;
 
 const DEFAULT_COALESCE_MS = 250;
 const DEFAULT_RETRY_MS = 1_000;
+// Heartbeat turns can start model/provider work; bound cross-target fan-out so
+// one aligned monitor tick cannot exhaust gateway or provider capacity.
+const MAX_CONCURRENT_HEARTBEAT_WAKE_TARGETS = 4;
 const REASON_PRIORITY = {
   RETRY: 0,
   INTERVAL: 1,
   DEFAULT: 2,
   ACTION: 3,
 } as const;
+
+/** Propagate lifecycle cancellation into the provider's existing reply abort contract. */
+export function getHeartbeatWakeAbortSignal(): AbortSignal | undefined {
+  return heartbeatWakeAbortSignals.getStore();
+}
 
 function resolveWakePriority(params: {
   source: HeartbeatWakeSource;
@@ -195,8 +217,13 @@ function mergePendingWakeReasons(
     (previous.guardRetry === true || next.guardRetry === true);
   const scheduledEveryMs = preferred.scheduledEveryMs ?? other.scheduledEveryMs;
   const scheduledAnchorMs = preferred.scheduledAnchorMs ?? other.scheduledAnchorMs;
+  const readyAtMs = Math.min(
+    previous.readyAtMs ?? previous.requestedAt,
+    next.readyAtMs ?? next.requestedAt,
+  );
   const merged: PendingWakeReason = {
     ...preferred,
+    readyAtMs,
     ...(!bypassGuardRetry && (previous.notBeforeMs !== undefined || next.notBeforeMs !== undefined)
       ? {
           requestedAt: Math.min(previous.requestedAt, next.requestedAt),
@@ -218,10 +245,19 @@ function mergePendingWakeReasons(
   return merged;
 }
 
-function takePendingWakeBatch(now = Date.now()): PendingWakeReason[] {
-  const readyGroups: PendingWakeGroup[] = [];
+function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGroup[] {
+  if (maxGroups <= 0) {
+    return [];
+  }
+  const readyGroups: Array<{ targetKey: string; group: PendingWakeGroup }> = [];
   for (const [targetKey, group] of pendingWakes) {
-    if (group.blockedUntilMs !== undefined && group.blockedUntilMs > now) {
+    if (readyGroups.length >= maxGroups) {
+      break;
+    }
+    if (
+      activeWakeTargets.has(targetKey) ||
+      (group.blockedUntilMs !== undefined && group.blockedUntilMs > now)
+    ) {
       continue;
     }
     const ready: PendingWakeGroup = {};
@@ -231,7 +267,10 @@ function takePendingWakeBatch(now = Date.now()): PendingWakeReason[] {
       if (!pending) {
         continue;
       }
-      if (pending.notBeforeMs === undefined || pending.notBeforeMs <= now) {
+      if (
+        (pending.readyAtMs === undefined || pending.readyAtMs <= now) &&
+        (pending.notBeforeMs === undefined || pending.notBeforeMs <= now)
+      ) {
         ready[slot] = pending;
       } else {
         remaining[slot] = pending;
@@ -243,12 +282,13 @@ function takePendingWakeBatch(now = Date.now()): PendingWakeReason[] {
       pendingWakes.delete(targetKey);
     }
     if (ready.task || ready.scheduled || ready.event) {
-      readyGroups.push(ready);
+      readyGroups.push({ targetKey, group: ready });
     }
   }
 
-  const batch: PendingWakeReason[] = [];
-  for (const group of readyGroups) {
+  const batch: ReadyWakeGroup[] = [];
+  for (const { targetKey, group } of readyGroups) {
+    const wakes: PendingWakeReason[] = [];
     if (group.task) {
       // A due base heartbeat is covered by the task prompt's appended monitor
       // scratch. Dispatching both lets the base run consume min-spacing and
@@ -259,7 +299,7 @@ function takePendingWakeBatch(now = Date.now()): PendingWakeReason[] {
       if (group.event) {
         // Retained work keeps its original age. Sorting it ahead of fresh work
         // prevents a periodic task stream from starving an older event forever.
-        batch.push(
+        wakes.push(
           ...[taskWake, group.event].toSorted((left, right) => {
             if (left.guardRetry !== right.guardRetry) {
               return left.guardRetry ? -1 : 1;
@@ -271,17 +311,16 @@ function takePendingWakeBatch(now = Date.now()): PendingWakeReason[] {
           }),
         );
       } else {
-        batch.push(taskWake);
+        wakes.push(taskWake);
       }
-      continue;
-    }
-    if (group.event) {
-      batch.push(
+    } else if (group.event) {
+      wakes.push(
         group.scheduled ? mergePendingWakeReasons(group.scheduled, group.event) : group.event,
       );
     } else if (group.scheduled) {
-      batch.push(group.scheduled);
+      wakes.push(group.scheduled);
     }
+    batch.push({ targetKey, wakes });
   }
   return batch;
 }
@@ -291,6 +330,7 @@ function queuePendingWakeReason(params: {
   intent: HeartbeatWakeIntent;
   reason?: string;
   requestedAt?: number;
+  readyAtMs?: number;
   agentId?: string;
   sessionKey?: string;
   heartbeat?: HeartbeatWakeOverride;
@@ -319,6 +359,7 @@ function queuePendingWakeReason(params: {
       reason: normalizedReason,
     }),
     requestedAt,
+    ...(params.readyAtMs === undefined ? {} : { readyAtMs: params.readyAtMs }),
     agentId: normalizedAgentId,
     sessionKey: normalizedSessionKey,
     heartbeat: params.heartbeat,
@@ -374,6 +415,135 @@ function handOffPendingWakeBatch(pendingBatch: PendingWakeReason[], startIndex: 
   }
 }
 
+async function dispatchPendingWakeGroup(params: {
+  active: HeartbeatWakeHandler;
+  generation: number;
+  targetKey: string;
+  wakes: PendingWakeReason[];
+  abortSignal: AbortSignal;
+}): Promise<void> {
+  const { active, generation, targetKey, wakes, abortSignal } = params;
+  try {
+    for (const [wakeIndex, pendingWake] of wakes.entries()) {
+      if (handlerGeneration !== generation) {
+        handOffPendingWakeBatch(wakes, wakeIndex);
+        return;
+      }
+      const wakeOpts = {
+        source: pendingWake.source,
+        intent: pendingWake.intent,
+        reason: pendingWake.reason ?? undefined,
+        ...(pendingWake.agentId ? { agentId: pendingWake.agentId } : {}),
+        ...(pendingWake.sessionKey ? { sessionKey: pendingWake.sessionKey } : {}),
+        ...(pendingWake.heartbeat ? { heartbeat: pendingWake.heartbeat } : {}),
+        ...(pendingWake.scheduledEveryMs !== undefined
+          ? { scheduledEveryMs: pendingWake.scheduledEveryMs }
+          : {}),
+        ...(pendingWake.scheduledAnchorMs !== undefined
+          ? { scheduledAnchorMs: pendingWake.scheduledAnchorMs }
+          : {}),
+        ...(pendingWake.tasks ? { tasks: pendingWake.tasks } : {}),
+        ...(pendingWake.guardRetry ? { retainedWork: true } : {}),
+      };
+      let result: HeartbeatRunResult;
+      try {
+        // Admission spans the entire target turn so gateway drain can observe it.
+        result = await runWithGatewayIndependentRootWorkAdmission(async () =>
+          runAbortableHeartbeatWake(active, wakeOpts, abortSignal),
+        );
+      } catch {
+        if (handlerGeneration !== generation) {
+          handOffPendingWakeBatch(wakes, wakeIndex);
+          return;
+        }
+        retryPendingWake(pendingWake);
+        continue;
+      }
+      if (handlerGeneration !== generation) {
+        const retainWake =
+          result.status === "skipped" &&
+          (isRetryableHeartbeatBusySkipReason(result.reason) ||
+            (RETRYABLE_GUARD_SKIP_REASONS.has(result.reason) &&
+              (pendingWake.tasks?.length ||
+                pendingWake.intent === "task" ||
+                pendingWake.intent === "event" ||
+                pendingWake.intent === "immediate")));
+        handOffPendingWakeBatch(wakes, wakeIndex + (retainWake ? 0 : 1));
+        return;
+      }
+      if (result.status === "skipped" && isRetryableHeartbeatBusySkipReason(result.reason)) {
+        retryPendingWake(pendingWake);
+      } else if (
+        result.status === "skipped" &&
+        RETRYABLE_GUARD_SKIP_REASONS.has(result.reason) &&
+        (pendingWake.tasks?.length ||
+          pendingWake.intent === "task" ||
+          pendingWake.intent === "event" ||
+          pendingWake.intent === "immediate")
+      ) {
+        // Retain real task/event work until its spacing guard allows a retry.
+        const retryAtMs = Math.max(Date.now(), result.retryAtMs ?? Date.now() + DEFAULT_RETRY_MS);
+        queuePendingWakeReason({
+          source: pendingWake.source,
+          intent: pendingWake.intent,
+          reason: pendingWake.reason ?? "retry",
+          agentId: pendingWake.agentId,
+          sessionKey: pendingWake.sessionKey,
+          heartbeat: pendingWake.heartbeat,
+          tasks: pendingWake.tasks,
+          scheduledEveryMs: pendingWake.scheduledEveryMs,
+          scheduledAnchorMs: pendingWake.scheduledAnchorMs,
+          requestedAt: pendingWake.requestedAt,
+          notBeforeMs: retryAtMs,
+          guardRetry: true,
+        });
+        schedule(retryAtMs - Date.now());
+      }
+    }
+  } finally {
+    // A replaced lifecycle may already own this target; never unlock it.
+    if (activeWakeTargets.get(targetKey)?.generation === generation) {
+      activeWakeTargets.delete(targetKey);
+      if (pendingWakes.size > 0) {
+        // Re-evaluate each target's own deadline: a later timer for another
+        // target must never postpone this target's already-ready wake.
+        schedulePendingWakes(0);
+      }
+    }
+  }
+}
+
+async function runAbortableHeartbeatWake(
+  active: HeartbeatWakeHandler,
+  wake: HeartbeatWakeRequest,
+  signal: AbortSignal,
+): Promise<HeartbeatRunResult> {
+  let abortListener: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    abortListener = () => {
+      const abortReason = signal.reason;
+      reject(
+        abortReason instanceof Error ? abortReason : new Error("Heartbeat handler was replaced"),
+      );
+    };
+    if (signal.aborted) {
+      abortListener();
+      return;
+    }
+    signal.addEventListener("abort", abortListener, { once: true });
+  });
+  try {
+    // Keep provider cancellation in the existing reply AbortSignal contract;
+    // racing it also retires a non-cooperative stale handler on replacement.
+    const running = heartbeatWakeAbortSignals.run(signal, () => active(wake));
+    return await Promise.race([running, aborted]);
+  } finally {
+    if (abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
+  }
+}
+
 function schedule(coalesceMs: number) {
   const delay = resolveTimerTimeoutMs(coalesceMs, DEFAULT_COALESCE_MS, 0);
   const dueAt = Date.now() + delay;
@@ -392,107 +562,30 @@ function schedule(coalesceMs: number) {
     void (async () => {
       timer = null;
       timerDueAt = null;
-      scheduled = false;
       const active = handler;
       if (!active) {
         return;
       }
       const activeGeneration = handlerGeneration;
-      if (running) {
-        scheduled = true;
-        schedule(delay);
-        return;
+      const availableTargetSlots = MAX_CONCURRENT_HEARTBEAT_WAKE_TARGETS - activeWakeTargets.size;
+      for (const group of takePendingWakeBatch(availableTargetSlots)) {
+        const abortController = new AbortController();
+        activeWakeTargets.set(group.targetKey, {
+          generation: activeGeneration,
+          abortController,
+        });
+        void dispatchPendingWakeGroup({
+          active,
+          generation: activeGeneration,
+          targetKey: group.targetKey,
+          wakes: group.wakes,
+          abortSignal: abortController.signal,
+        });
       }
-
-      const pendingBatch = takePendingWakeBatch();
-      running = true;
-      try {
-        for (const [pendingWakeIndex, pendingWake] of pendingBatch.entries()) {
-          if (handlerGeneration !== activeGeneration) {
-            handOffPendingWakeBatch(pendingBatch, pendingWakeIndex);
-            return;
-          }
-          const wakeOpts = {
-            source: pendingWake.source,
-            intent: pendingWake.intent,
-            reason: pendingWake.reason ?? undefined,
-            ...(pendingWake.agentId ? { agentId: pendingWake.agentId } : {}),
-            ...(pendingWake.sessionKey ? { sessionKey: pendingWake.sessionKey } : {}),
-            ...(pendingWake.heartbeat ? { heartbeat: pendingWake.heartbeat } : {}),
-            ...(pendingWake.scheduledEveryMs !== undefined
-              ? { scheduledEveryMs: pendingWake.scheduledEveryMs }
-              : {}),
-            ...(pendingWake.scheduledAnchorMs !== undefined
-              ? { scheduledAnchorMs: pendingWake.scheduledAnchorMs }
-              : {}),
-            ...(pendingWake.tasks ? { tasks: pendingWake.tasks } : {}),
-            ...(pendingWake.guardRetry ? { retainedWork: true } : {}),
-          };
-          // Each wake is detached process work: admit the whole handler before
-          // it can mutate sessions or commitments, and keep it visible until done.
-          let res: HeartbeatRunResult;
-          try {
-            res = await runWithGatewayIndependentRootWorkAdmission(async () => active(wakeOpts));
-          } catch {
-            if (handlerGeneration !== activeGeneration) {
-              handOffPendingWakeBatch(pendingBatch, pendingWakeIndex);
-              return;
-            }
-            retryPendingWake(pendingWake);
-            continue;
-          }
-          if (handlerGeneration !== activeGeneration) {
-            const retainedWake =
-              res.status === "skipped" &&
-              (isRetryableHeartbeatBusySkipReason(res.reason) ||
-                (RETRYABLE_GUARD_SKIP_REASONS.has(res.reason) &&
-                  (pendingWake.tasks?.length ||
-                    pendingWake.intent === "task" ||
-                    pendingWake.intent === "event" ||
-                    pendingWake.intent === "immediate")));
-            handOffPendingWakeBatch(pendingBatch, pendingWakeIndex + (retainedWake ? 0 : 1));
-            return;
-          }
-          if (res.status === "skipped" && isRetryableHeartbeatBusySkipReason(res.reason)) {
-            retryPendingWake(pendingWake);
-          } else if (
-            res.status === "skipped" &&
-            RETRYABLE_GUARD_SKIP_REASONS.has(res.reason) &&
-            (pendingWake.tasks?.length ||
-              pendingWake.intent === "task" ||
-              pendingWake.intent === "event" ||
-              pendingWake.intent === "immediate")
-          ) {
-            // A wake that carries work the turn prompt depends on — a task
-            // payload or an unprocessed event — may be deferred by guards but
-            // never dropped. Retain it and retry only after the remaining floor.
-            const retryAtMs = Math.max(Date.now(), res.retryAtMs ?? Date.now() + DEFAULT_RETRY_MS);
-            queuePendingWakeReason({
-              source: pendingWake.source,
-              intent: pendingWake.intent,
-              reason: pendingWake.reason ?? "retry",
-              agentId: pendingWake.agentId,
-              sessionKey: pendingWake.sessionKey,
-              heartbeat: pendingWake.heartbeat,
-              tasks: pendingWake.tasks,
-              scheduledEveryMs: pendingWake.scheduledEveryMs,
-              scheduledAnchorMs: pendingWake.scheduledAnchorMs,
-              requestedAt: pendingWake.requestedAt,
-              notBeforeMs: retryAtMs,
-              guardRetry: true,
-            });
-            schedule(retryAtMs - Date.now());
-          }
-        }
-      } finally {
-        // A replaced handler owns its own in-flight turn; an old completion
-        // must not unlock or reschedule the newer heartbeat lifecycle.
-        if (handlerGeneration === activeGeneration) {
-          running = false;
-          if (pendingWakes.size > 0 || scheduled) {
-            schedulePendingWakes(delay);
-          }
-        }
+      if (pendingWakes.size > 0) {
+        // A sooner request can consume a deferred retry timer; restore the
+        // earliest eligible target without spinning on active target groups.
+        schedulePendingWakes(delay);
       }
     })();
   }, delay);
@@ -500,10 +593,18 @@ function schedule(coalesceMs: number) {
 }
 
 function schedulePendingWakes(readyDelayMs: number) {
+  if (activeWakeTargets.size >= MAX_CONCURRENT_HEARTBEAT_WAKE_TARGETS) {
+    // A completing target re-arms the earliest pending wake; scheduling now
+    // would spin zero-delay timers while every provider slot remains busy.
+    return;
+  }
   const now = Date.now();
   let earliestNotBeforeMs = Number.POSITIVE_INFINITY;
   let hasReadyWake = false;
-  for (const group of pendingWakes.values()) {
+  for (const [targetKey, group] of pendingWakes) {
+    if (activeWakeTargets.has(targetKey)) {
+      continue;
+    }
     if (group.blockedUntilMs !== undefined && group.blockedUntilMs > now) {
       earliestNotBeforeMs = Math.min(earliestNotBeforeMs, group.blockedUntilMs);
       continue;
@@ -512,10 +613,11 @@ function schedulePendingWakes(readyDelayMs: number) {
       if (!pending) {
         continue;
       }
-      if (pending.notBeforeMs === undefined || pending.notBeforeMs <= now) {
+      const nextReadyAtMs = Math.max(pending.readyAtMs ?? 0, pending.notBeforeMs ?? 0);
+      if (nextReadyAtMs <= now) {
         hasReadyWake = true;
       } else {
-        earliestNotBeforeMs = Math.min(earliestNotBeforeMs, pending.notBeforeMs);
+        earliestNotBeforeMs = Math.min(earliestNotBeforeMs, nextReadyAtMs);
       }
     }
   }
@@ -558,12 +660,11 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
     }
     timer = null;
     timerDueAt = null;
-    // Reset module-level execution state that may be stale from interrupted
-    // runs in the previous lifecycle. Without this, `running === true` from
-    // an interrupted heartbeat blocks all future schedule() attempts, and
-    // `scheduled === true` can cause spurious immediate re-runs.
-    running = false;
-    scheduled = false;
+    // Cancel old provider turns before their own generation releases its slot.
+    // This preserves the cap and lets a stuck lifecycle recover on replacement.
+    for (const activeTarget of activeWakeTargets.values()) {
+      activeTarget.abortController.abort();
+    }
     clearPendingWakeRetryState();
   }
   if (handler && pendingWakes.size > 0) {
@@ -593,6 +694,8 @@ export function requestHeartbeat(opts: {
   scheduledAnchorMs?: number;
   tasks?: readonly HeartbeatScheduledTask[];
 }) {
+  const requestedAt = Date.now();
+  const coalesceMs = opts.coalesceMs ?? DEFAULT_COALESCE_MS;
   queuePendingWakeReason({
     source: opts.source,
     intent: opts.intent,
@@ -603,6 +706,8 @@ export function requestHeartbeat(opts: {
     scheduledEveryMs: opts.scheduledEveryMs,
     scheduledAnchorMs: opts.scheduledAnchorMs,
     tasks: opts.tasks,
+    requestedAt,
+    readyAtMs: requestedAt + resolveTimerTimeoutMs(coalesceMs, DEFAULT_COALESCE_MS, 0),
   });
-  schedule(opts.coalesceMs ?? DEFAULT_COALESCE_MS);
+  schedule(coalesceMs);
 }

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -249,8 +249,23 @@ function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGro
   if (maxGroups <= 0) {
     return [];
   }
+  const globalWakeGroup = pendingWakes.get("::");
+  const globalImmediateWake = globalWakeGroup?.event;
+  // An unscoped immediate wake is a global flush barrier. Preserve the task
+  // registry contract while keeping spacing and busy guards authoritative.
+  const flushPendingCoalescing =
+    globalImmediateWake?.intent === "immediate" &&
+    !activeWakeTargets.has("::") &&
+    (globalWakeGroup?.blockedUntilMs === undefined || globalWakeGroup.blockedUntilMs <= now) &&
+    (globalImmediateWake.readyAtMs === undefined || globalImmediateWake.readyAtMs <= now) &&
+    (globalImmediateWake.notBeforeMs === undefined || globalImmediateWake.notBeforeMs <= now);
   const readyGroups: Array<{ targetKey: string; group: PendingWakeGroup }> = [];
-  for (const [targetKey, group] of pendingWakes) {
+  const pendingEntries = flushPendingCoalescing
+    ? [...pendingWakes.entries()].toSorted(
+        ([leftTarget], [rightTarget]) => Number(leftTarget === "::") - Number(rightTarget === "::"),
+      )
+    : pendingWakes.entries();
+  for (const [targetKey, group] of pendingEntries) {
     if (readyGroups.length >= maxGroups) {
       break;
     }
@@ -268,7 +283,7 @@ function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGro
         continue;
       }
       if (
-        (pending.readyAtMs === undefined || pending.readyAtMs <= now) &&
+        (flushPendingCoalescing || pending.readyAtMs === undefined || pending.readyAtMs <= now) &&
         (pending.notBeforeMs === undefined || pending.notBeforeMs <= now)
       ) {
         ready[slot] = pending;


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where users relying on scheduled jobs and heartbeat reminders could experience duplicate executions, permanently stalled schedules, silently lost reminders or commitments, delayed background task completions, provider overload, or heartbeat outages after gateway restarts.

## Why This Change Was Made

Use cached filesystem-canonical cron store identity, including directory symlinks and dangling store-file symlinks; always re-arm scheduling after cleanup and agent-discovery failures; retain visible reminders until durable channel delivery succeeds; preserve internal-only event consumption; carry coalesced task and monitor facts; and dispatch heartbeat targets with bounded concurrency, provider cancellation, restart-safe recovery, per-target retry deadlines, and correctly ordered global flush barriers.

## User Impact

Recurring automations continue running, real and symlinked store aliases cannot run the same job twice, reminders remain queued until delivered, commitments and background task notifications are not lost, independent agents do not starve each other, and gateway reloads recover interrupted heartbeat work.

## Evidence

Fresh independent Codex review on the final filesystem-canonical lock: clean, with no accepted or actionable findings.

Reproducible real Linux filesystem and runtime proof on Blacksmith Testbox tbx_01kyq6297c92v72e6nd428qjb8:

```text
CRABBOX_PHASE:final-cron-heartbeat-symlink-task-stress-1
infra src/infra/heartbeat-wake.test.ts                     41 passed
infra src/infra/heartbeat-wake-concurrency.test.ts           8 passed
infra src/infra/heartbeat-runner.ghost-reminder.test.ts    26 passed
infra src/infra/heartbeat-runner.commitments.test.ts      16 passed
infra src/infra/heartbeat-runner.ack-token-heartbeat-acks.test.ts 15 passed
infra src/infra/heartbeat-runner.monitor-task-commitments.test.ts 1 passed
cron  src/cron/service.session-reaper-in-finally.test.ts   9 passed
cron  src/cron/service.prevents-duplicate-timers.test.ts   6 passed
```

The cron proof creates actual temporary directories, real directory symlinks, and a dangling file symlink, then runs two production CronService instances and concurrent production lock operations against the same underlying store.

The full task-registry regression was reproduced from the first hosted CI failure and fixed at the heartbeat wake owner:

```text
tasks src/tasks/task-registry.test.ts 119 passed
CRABBOX_PHASE:real-symlink-and-task-registry-proof
blacksmith run summary exit=0
```

The final validation runs production and test type checks, changed-file formatting and lint, three repetitions of cron plus heartbeat plus all 119 task-registry tests, and the broader gateway drain, timer watchdog, timeout, restart, model override, and cancellation regressions. No repository lockfile, package policy, SQLite baseline, environment-variable budget, or changelog is changed.

### Inspectable post-fix Linux runtime proof (final head e87844869246)

Ran the production `CronService`, cron store lock, heartbeat runner, and wake dispatcher against real Linux directories and actual directory/file symlinks on the existing Blacksmith Testbox lease. The following is condensed named-test output from `node scripts/run-vitest.mjs src/cron/service.prevents-duplicate-timers.test.ts src/cron/service.session-reaper-in-finally.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts src/infra/heartbeat-wake-concurrency.test.ts src/infra/heartbeat-wake.test.ts --reporter=verbose`:

```text
PASS cron > re-arms the scheduler when resolving the default reaper agent fails
PASS cron > keeps the scheduler running after reaper agent discovery fails
PASS cron > keeps the scheduler running after reaper session-store resolution fails
PASS cron > session reaper runs even when job execution throws
PASS cron > avoids duplicate runs when two services share a symlinked path to the same store
PASS cron > serializes concurrent operations for symlink cron store aliases
PASS cron > serializes concurrent operations for dangling file symlink cron store aliases
PASS heartbeat > retains a cron reminder until a suppressed heartbeat can actually deliver it
PASS heartbeat > drains inspected cron events after a successful run so later heartbeats do not replay them
PASS heartbeat > uses an internal-only cron prompt when delivery target is none
PASS heartbeat > recovers interrupted wakes when a replacement handler is registered
PASS heartbeat > hands off only unfinished wakes when a replaced handler is completed
PASS heartbeat > hands off only unfinished wakes when a replaced handler is thrown
PASS heartbeat > bounds concurrent target wakes and starts queued targets as slots open
PASS heartbeat > preserves the target concurrency bound across heartbeat handler replacement
PASS heartbeat > flushes target wakes before an unscoped barrier that was originally queued first
PASS heartbeat > does not delay a ready target behind another target deferred retry
infra: 3 files passed; 75 tests passed
cron: 2 files passed; 15 tests passed
[test] passed 2 Vitest shards in 9.20s
blacksmith run summary sync=delegated command=10.115s total=10.153s exit=0
{"provider":"blacksmith-testbox","leaseId":"tbx_01kyq6297c92v72e6nd428qjb8","slug":"golden-crab-858e","exitCode":0,"runStatus":"succeeded"}
```

These cases run the changed owner implementations, including production lock serialization on real symlinks, scheduler failure and actual timer re-arm, reminder retention followed by successful delivery, and wake lifecycle replacement. This verbose proof is in addition to the three 241-test stress runs, the 389-test wider cron/heartbeat/gateway/task regression run, clean independent autoreview, format, lint, and both production and test type checks described above.