### PR TITLE
docs: expand Telegram Mini App setup and auth guide

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -110,14 +110,38 @@ Token resolution is account-aware: `tokenFile` beats `botToken` beats env, and c
 
 ## Dashboard Mini App
 
-Run `/dashboard` in a DM with the bot to open the OpenClaw dashboard inside Telegram.
+The Dashboard Mini App opens the full [OpenClaw Control UI](/web/control-ui) as a Telegram WebApp. Run `/dashboard` in a DM with the bot, then tap **Open dashboard**. The command is registered automatically when the Telegram plugin is active; there is no separate Mini App flag.
 
 Requirements:
 
 - `gateway.tailscale.mode: "serve"` or `"funnel"` for the published HTTPS Mini App URL.
-- Your numeric Telegram user ID must be in the selected account's effective `allowFrom` or in `commands.ownerAllowFrom`.
+- Your numeric Telegram user ID must be in the selected account's effective `allowFrom` or in `commands.ownerAllowFrom`. Wildcards and usernames do not grant Mini App owner access.
 - Use a DM. In groups, `/dashboard` replies with `open this in a DM with the bot` and sends no button.
 - Docker installs: Serve/Funnel modes require the gateway to bind loopback next to `tailscaled`, which bridge networking with published ports cannot satisfy. Run the gateway container with `network_mode: host` and mount the host `tailscaled` socket (`/var/run/tailscale`) plus the `tailscale` CLI into the container.
+
+Configure one of the supported Tailscale publishing modes:
+
+```json5
+{
+  gateway: {
+    tailscale: {
+      mode: "serve", // or "funnel"
+    },
+  },
+}
+```
+
+OpenClaw automatically honors `gateway.tailscale.serviceName` when selecting the published host and `gateway.controlUi.basePath` when building the Control UI and WebSocket URLs.
+
+When the Mini App opens, Telegram provides signed WebApp `initData`. OpenClaw verifies its signature with the selected bot account's token, rejects missing, invalid, expired, or replayed data, extracts the numeric Telegram user ID, and checks owner access again before handing off to the Control UI.
+
+If `/dashboard` cannot resolve a published HTTPS URL, it replies with:
+
+```text
+Mini App needs an HTTPS gateway URL. Set `gateway.tailscale.mode: serve` or `funnel`, then retry.
+```
+
+Set one of the modes shown above, make sure Tailscale is running on the gateway host, and retry the command.
 
 The Mini App is a Tailscale-only v1 path and does not support Telegram Web iframe.
 


### PR DESCRIPTION
## What Problem This Solves

The Telegram channel guide mentioned `/dashboard`, but it did not explain that the Mini App loads the full Control UI, show a copy-ready HTTPS configuration, describe the Telegram WebApp authentication handoff, or include the exact URL setup error operators see.

## Why This Change Was Made

This expands the existing `Dashboard Mini App` section in `docs/channels/telegram.md` with source-verified setup, authorization, authentication, and troubleshooting details. The content stays in the Telegram page rather than moving to a dedicated page because the feature is compact, Telegram-specific, and already has a natural home in the channel guide.

## User Impact

Telegram bot owners can now discover what `/dashboard` opens, configure the required Tailscale HTTPS mode, understand the numeric owner and signed `initData` checks, and recover from the exact missing-HTTPS error without reading source code.

## Evidence

- `extensions/telegram/src/miniapp/command.ts:20-49` registers `/dashboard`, enforces DM and owner gates, returns the HTTPS setup error, and sends the `Open dashboard` WebApp button.
- `extensions/telegram/src/miniapp/url.ts:11-12` defines the exact operator response:

  > Mini App needs an HTTPS gateway URL. Set `gateway.tailscale.mode: serve` or `funnel`, then retry.
- `extensions/telegram/src/miniapp/url.ts:24-49` accepts only Serve/Funnel publishing and carries `gateway.tailscale.serviceName` plus `gateway.controlUi.basePath` into the published Control UI and WebSocket URLs.
- `extensions/telegram/src/miniapp/owner.ts:12-26` requires a numeric Telegram user ID matched through the account allowlist or `commands.ownerAllowFrom`; wildcard and username entries do not grant owner access.
- `extensions/telegram/src/miniapp/init-data.ts:24-56` verifies Telegram WebApp `initData`, including required fields, five-minute freshness, signature, and numeric user identity.
- `extensions/telegram/src/miniapp/routes.ts:100-135` repeats the owner check, rejects replayed auth data, and hands an operator bootstrap token plus Control UI/Gateway URLs to the WebApp.
- `extensions/telegram/index.ts:26` and `extensions/telegram/miniapp-api.ts:6-8` register the Mini App command and routes whenever the Telegram plugin's full runtime is registered.
- `git diff --check` passes.

AI-assisted: yes.
