### PR TITLE
fix(skills): preserve configless workshop apply upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Skill Workshop offline apply:** preserve configless local proposal apply after upgrades under exclusive Gateway startup ownership, while keeping running Gateway snapshot invalidation fail-closed when CLI credentials are unavailable.
 - **macOS and Control UI keyboard navigation:** let Tab traverse links and controls inside embedded Dashboard, browser, and Canvas web views, and keep shortcuts working on non-Latin keyboard layouts without firing during IME composition.
 - **Control UI session diffs:** hide unchanged checkout modifications and untracked files that already existed when a thread started, so the diff panel attributes only files touched by that session. Fixes #115628.
 - **Code Mode small-model repair:** give malformed pre-dispatch `exec` calls one bounded correction turn, expose typed failure-phase and bridge-dispatch evidence, and stop retries after nested tools begin. Fixes #115311.

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -14,6 +14,7 @@ import {
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/config.js";
+import { resolveGatewayPort } from "../config/paths.js";
 import { CLAWHUB_TRUST_ERROR_CODE } from "../infra/clawhub-install-trust.js";
 import {
   CLAWHUB_SKILLS_SH_TRUST_LABEL,
@@ -123,6 +124,7 @@ type ResolvedSkillsWorkspace = ReturnType<typeof resolveSkillsWorkspace>;
 
 const GATEWAY_SKILLS_STATUS_TIMEOUT_MS = 1_500;
 const GATEWAY_SKILLS_EVALUATION_TIMEOUT_MS = 650_000;
+const GATEWAY_SKILLS_OFFLINE_LOCK_TIMEOUT_MS = 250;
 // Apply can await evaluator, proposal-change, and skill-change hook phases.
 const GATEWAY_SKILLS_APPLY_TIMEOUT_MS = 1_850_000;
 
@@ -432,7 +434,8 @@ async function runSkillProposalApply(
   resolved: ResolvedSkillsWorkspace,
   proposalId: string,
 ): Promise<SkillProposalApplyResult> {
-  const { callGateway, isGatewayTransportError } = await import("../gateway/call.js");
+  const { callGateway, isGatewayCredentialsRequiredError, isGatewayTransportError } =
+    await import("../gateway/call.js");
   try {
     // Decide offline fallback before dispatching the non-idempotent mutation.
     // Once a Gateway answers, apply failures must never be replayed locally.
@@ -446,21 +449,42 @@ async function runSkillProposalApply(
       requiredMethods: ["skills.proposals.apply"],
     });
   } catch (err) {
-    if (
-      resolved.config.gateway?.mode === "remote" ||
-      !isGatewayTransportError(err) ||
-      err.kind !== "closed" ||
-      err.code !== 1006
-    ) {
+    const isOfflineCandidate =
+      isGatewayCredentialsRequiredError(err) ||
+      (isGatewayTransportError(err) && err.kind === "closed" && err.code === 1006);
+    if (resolved.config.gateway?.mode === "remote" || !isOfflineCandidate) {
       throw err;
     }
-    return await applySkillProposal({
-      agentId: resolved.agentId,
-      eventActor: { type: "system", id: "cli" },
-      workspaceDir: resolved.workspaceDir,
-      config: resolved.config,
-      proposalId,
-    });
+
+    // Hold the canonical Gateway ownership locks across local mutation. This
+    // makes offline apply atomic with Gateway startup, so a new process cannot
+    // inherit a stale process-local skill snapshot.
+    const { acquireGatewayLock } = await import("../infra/gateway-lock.js");
+    let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
+    try {
+      lock = await acquireGatewayLock({
+        allowInTests: true,
+        port: resolveGatewayPort(resolved.config, process.env),
+        role: "skill-workshop-apply",
+        timeoutMs: GATEWAY_SKILLS_OFFLINE_LOCK_TIMEOUT_MS,
+      });
+    } catch {
+      throw err;
+    }
+    if (!lock) {
+      throw err;
+    }
+    try {
+      return await applySkillProposal({
+        agentId: resolved.agentId,
+        eventActor: { type: "system", id: "cli" },
+        workspaceDir: resolved.workspaceDir,
+        config: resolved.config,
+        proposalId,
+      });
+    } finally {
+      await lock.release();
+    }
   }
 
   return await callGateway<SkillProposalApplyResult>({

--- a/src/cli/skills-cli.workshop-cache.test.ts
+++ b/src/cli/skills-cli.workshop-cache.test.ts
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   gatewayApply: undefined as
     | ((request: { method: string; params?: { proposalId?: string } }) => Promise<unknown>)
     | undefined,
+  acquireGatewayLock: vi.fn(),
+  releaseGatewayLock: vi.fn(),
   workspaceDir: "",
   defaultRuntime: {
     log: vi.fn(),
@@ -30,7 +32,12 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.defaultRuntime }));
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
+  isGatewayCredentialsRequiredError: (error: unknown) =>
+    error instanceof Error && error.name === "GatewayCredentialsRequiredError",
   isGatewayTransportError: () => false,
+}));
+vi.mock("../infra/gateway-lock.js", () => ({
+  acquireGatewayLock: mocks.acquireGatewayLock,
 }));
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => mocks.config,
@@ -51,6 +58,8 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
     mocks.workspaceDir = await tempDirs.make("openclaw-skills-cli-workshop-cache-");
     delete mocks.config.gateway;
     mocks.gatewayApply = undefined;
+    mocks.releaseGatewayLock.mockReset();
+    mocks.acquireGatewayLock.mockReset().mockResolvedValue({ release: mocks.releaseGatewayLock });
     mocks.defaultRuntime.error.mockClear();
     mocks.defaultRuntime.exit.mockClear();
     mocks.callGateway.mockReset().mockImplementation(async (request) => {
@@ -157,6 +166,76 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       "health",
       "skills.proposals.apply",
     ]);
+    await expect(workshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
+      record: { status: "pending" },
+    });
+  });
+
+  it("preserves configless offline apply when no local gateway is listening", async () => {
+    const workshop = await import("../skills/workshop/service.js");
+    const proposal = await workshop.proposeCreateSkill({
+      workspaceDir: mocks.workspaceDir,
+      name: "Offline Upgrade",
+      description: "Keep shipped configless Workshop apply behavior",
+      content: "# Offline Upgrade\n\nApply without a running gateway.\n",
+    });
+    const authError = Object.assign(new Error("gateway health requires credentials"), {
+      name: "GatewayCredentialsRequiredError",
+      method: "health",
+      configPath: "/tmp/openclaw.json",
+    });
+    mocks.callGateway.mockRejectedValueOnce(authError);
+
+    vi.resetModules();
+    const { registerSkillsCli } = await import("./skills-cli.js");
+    const program = new Command();
+    program.exitOverride();
+    registerSkillsCli(program);
+    await program.parseAsync(["skills", "workshop", "apply", proposal.record.id], {
+      from: "user",
+    });
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.acquireGatewayLock).toHaveBeenCalledWith({
+      allowInTests: true,
+      port: 18789,
+      role: "skill-workshop-apply",
+      timeoutMs: 250,
+    });
+    expect(mocks.releaseGatewayLock).toHaveBeenCalledTimes(1);
+    await expect(workshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
+      record: { status: "applied" },
+    });
+  });
+
+  it("does not bypass Gateway ownership when CLI credentials are missing", async () => {
+    const workshop = await import("../skills/workshop/service.js");
+    const proposal = await workshop.proposeCreateSkill({
+      workspaceDir: mocks.workspaceDir,
+      name: "Gateway Owned Upgrade",
+      description: "Keep snapshot invalidation in the running gateway",
+      content: "# Gateway Owned Upgrade\n\nDo not apply in the CLI process.\n",
+    });
+    const authError = Object.assign(new Error("gateway health requires credentials"), {
+      name: "GatewayCredentialsRequiredError",
+      method: "health",
+      configPath: "/tmp/openclaw.json",
+    });
+    mocks.callGateway.mockRejectedValueOnce(authError);
+    mocks.acquireGatewayLock.mockRejectedValueOnce(new Error("gateway lock is owned"));
+
+    vi.resetModules();
+    const { registerSkillsCli } = await import("./skills-cli.js");
+    const program = new Command();
+    program.exitOverride();
+    registerSkillsCli(program);
+    await expect(
+      program.parseAsync(["skills", "workshop", "apply", proposal.record.id], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.acquireGatewayLock).toHaveBeenCalledTimes(1);
+    expect(mocks.releaseGatewayLock).not.toHaveBeenCalled();
     await expect(workshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
       record: { status: "pending" },
     });

--- a/src/cli/skills-cli.workshop.test.ts
+++ b/src/cli/skills-cli.workshop.test.ts
@@ -50,7 +50,14 @@ vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(async () => {
     throw Object.assign(new Error("gateway unavailable"), { kind: "closed", code: 1006 });
   }),
+  isGatewayCredentialsRequiredError: () => false,
   isGatewayTransportError: () => true,
+}));
+
+vi.mock("../infra/gateway-lock.js", () => ({
+  acquireGatewayLock: vi.fn(async () => ({
+    release: vi.fn(async () => undefined),
+  })),
 }));
 
 vi.mock("../terminal/links.js", () => ({

--- a/src/infra/gateway-lock.roles.test.ts
+++ b/src/infra/gateway-lock.roles.test.ts
@@ -1,0 +1,121 @@
+// Tests named Gateway lock roles and active-port compatibility.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setTimeout as nativeSleep } from "node:timers/promises";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { acquireGatewayLock, GatewayLockError, readActiveGatewayLockPort } from "./gateway-lock.js";
+
+const fixtureRootTracker = createSuiteTempRootTracker({
+  prefix: "openclaw-gateway-lock-workshop-",
+});
+let fixtureRoot = "";
+
+describe("Gateway lock roles", () => {
+  beforeAll(async () => {
+    fixtureRoot = await fixtureRootTracker.setup();
+  });
+
+  afterAll(async () => {
+    await fixtureRootTracker.cleanup();
+    fixtureRoot = "";
+  });
+
+  it("keeps a live Workshop apply owner while Gateway startup races", async () => {
+    const stateDir = await fixtureRootTracker.make("case");
+    const lockDir = path.join(fixtureRoot, "__locks");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.writeFile(configPath, "{}", "utf8");
+    const env = {
+      ...process.env,
+      OPENCLAW_ALLOW_MULTI_GATEWAY: "1",
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    const readProcessCmdline = () => ["openclaw", "skills", "workshop", "apply", "proposal-id"];
+    const lock = await acquireGatewayLock({
+      allowInTests: true,
+      env,
+      lockDir,
+      platform: "darwin",
+      port: 18789,
+      readProcessStartTime: () => null,
+      role: "skill-workshop-apply",
+      timeoutMs: 30,
+    });
+    expect(lock).not.toBeNull();
+    if (!lock) {
+      throw new Error("Expected Workshop Gateway lock");
+    }
+
+    try {
+      expect(lock.lockPath).not.toBe(lock.stateLockPath);
+      await expect(
+        readActiveGatewayLockPort({
+          env,
+          lockDir,
+          platform: "darwin",
+          readProcessCmdline,
+          readProcessStartTime: () => null,
+        }),
+      ).resolves.toBeUndefined();
+      await expect(
+        acquireGatewayLock({
+          allowInTests: true,
+          env,
+          lockDir,
+          platform: "darwin",
+          port: 18789,
+          pollIntervalMs: 2,
+          readProcessCmdline,
+          readProcessStartTime: () => null,
+          sleep: nativeSleep,
+          timeoutMs: 15,
+        }),
+      ).rejects.toBeInstanceOf(GatewayLockError);
+    } finally {
+      await lock.release();
+    }
+  });
+
+  it("keeps an explicit Gateway role visible to active-port discovery", async () => {
+    const stateDir = await fixtureRootTracker.make("gateway-role");
+    const lockDir = path.join(fixtureRoot, "__locks");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.writeFile(configPath, "{}", "utf8");
+    const env = {
+      ...process.env,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    const lock = await acquireGatewayLock({
+      allowInTests: true,
+      env,
+      lockDir,
+      platform: "darwin",
+      port: 28789,
+      readProcessStartTime: () => null,
+      timeoutMs: 30,
+    });
+    expect(lock).not.toBeNull();
+    if (!lock) {
+      throw new Error("Expected Gateway lock");
+    }
+
+    const payload = JSON.parse(await fs.readFile(lock.lockPath, "utf8")) as Record<string, unknown>;
+    await fs.writeFile(lock.lockPath, JSON.stringify({ ...payload, role: "gateway" }), "utf8");
+    try {
+      await expect(
+        readActiveGatewayLockPort({
+          env,
+          lockDir,
+          platform: "darwin",
+          readProcessCmdline: () => ["openclaw-gateway"],
+          readProcessStartTime: () => null,
+        }),
+      ).resolves.toBe(28789);
+    } finally {
+      await lock.release();
+    }
+  });
+});

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -44,7 +44,7 @@ const LockPayloadSchema = z.object({
   createdAt: z.string(),
   configPath: z.string(),
   port: z.number().int().min(1).max(65_535).optional(),
-  role: z.enum(["gateway", "sqlite-maintenance"]).optional(),
+  role: z.enum(["gateway", "skill-workshop-apply", "sqlite-maintenance"]).optional(),
   stateDir: z.string().optional(),
   startTime: z.number().optional(),
 }) as z.ZodType<LockPayload>;
@@ -56,7 +56,7 @@ type GatewayLockHandle = {
   release: () => Promise<void>;
 };
 
-type GatewayLockRole = "gateway" | "sqlite-maintenance";
+type GatewayLockRole = "gateway" | "skill-workshop-apply" | "sqlite-maintenance";
 
 export type GatewayLockIdentity = {
   pid: number;
@@ -198,12 +198,13 @@ async function resolveGatewayOwnerStatus(
   }
 
   const readFn = readCmdline ?? ((p: number) => defaultReadProcessCmdline(p, platform));
-  if (role === "sqlite-maintenance") {
+  if (role === "sqlite-maintenance" || role === "skill-workshop-apply") {
     const args = readFn(pid);
     if (!args) {
       return "unknown";
     }
-    return isOpenClawCommandArgv(args, "doctor") ? "alive" : "dead";
+    const command = role === "sqlite-maintenance" ? "doctor" : "skills";
+    return isOpenClawCommandArgv(args, command) ? "alive" : "dead";
   }
 
   const args = readFn(pid);
@@ -332,7 +333,7 @@ async function readVerifiedGatewayLockIdentity(
   opts: Pick<GatewayLockOptions, "platform" | "readProcessCmdline" | "readProcessStartTime">,
 ): Promise<GatewayLockIdentity | undefined> {
   const payload = await readLockPayload(lockPath);
-  if (!payload?.port || payload.role === "sqlite-maintenance") {
+  if (!payload?.port || (payload.role && payload.role !== "gateway")) {
     return undefined;
   }
   const ownerStatus = await resolveGatewayOwnerStatus(
@@ -375,8 +376,7 @@ export async function acquireGatewayLock(
     stateDir: paths.stateDir,
     ownerId,
   });
-  const shouldAcquireConfigLock =
-    role === "sqlite-maintenance" || env.OPENCLAW_ALLOW_MULTI_GATEWAY !== "1";
+  const shouldAcquireConfigLock = role !== "gateway" || env.OPENCLAW_ALLOW_MULTI_GATEWAY !== "1";
   if (!shouldAcquireConfigLock) {
     return {
       ...stateLock,


### PR DESCRIPTION
Closes #115949

## What Problem This Solves

Fixes an issue where users upgrading a configless OpenClaw installation could no longer apply an existing Skill Workshop proposal when no Gateway was running. The CLI failed before opening a websocket because Gateway credentials were absent, even though local proposal apply was the previously shipped behavior.

## Why This Change Was Made

The CLI now treats missing local Gateway credentials as an offline candidate, then acquires the canonical Gateway state/config ownership locks before applying locally. This makes local mutation atomic with Gateway startup: configless offline apply remains available, while a running or starting Gateway keeps exclusive ownership of process-local skill snapshot invalidation.

Remote Gateway mode and post-dispatch failures remain fail-closed. The change adds no schema version, config surface, state file, storage backend, or compatibility fallback.

**Maintainer decision:** accept `skill-workshop-apply` as a first-class temporary owner of the canonical Gateway locks. This preserves the shipped configless apply contract without the startup race and stale-session risk of a port probe or unlocked local fallback.

## User Impact

Users can upgrade from the last shipped package and still apply pending Skill Workshop proposals without configuring Gateway credentials when no Gateway is running. If a local Gateway owns or is acquiring the runtime snapshot, the CLI refuses the local fallback instead of risking stale sessions.

## Evidence

- Blacksmith Testbox focused proof: 45 Workshop/Gateway lock tests passed on the initial lock implementation. Run: https://github.com/openclaw/openclaw/actions/runs/30463057180
- Packaged upgrade proof on the same Testbox:
  - installed `openclaw@2026.7.1-2` (`0790d9f`)
  - created a pending proposal in an explicit persistent workspace
  - installed the branch package as `OpenClaw 2026.7.2` (`0570d53`)
  - ran `openclaw doctor --fix --non-interactive`
  - applied with Gateway token/password/URL/port unset
  - verified the exact `SKILL.md` content and durable proposal status `applied`
  - result: `UPGRADE_E2E_PASS`
- Exact rebased head `4cc9d0457836c2bec9c41aed68057ca2e0ec82e4` on Blacksmith Testbox `tbx_01kyqd6sh2kxb9q08bk9kqmhs1`:
  - 46 focused Workshop/Gateway lock tests passed
  - max-lines ratchet passed
  - core test `tsgo` passed
  - targeted `oxlint` passed
  - run: https://github.com/openclaw/openclaw/actions/runs/30473474853
- Fresh autoreview: clean, no accepted/actionable findings.
- `git diff --check`: passed.

AI-assisted: yes. The implementation, upgrade scenario, failure modes, and final diff were reviewed during this maintainer session.
