### PR TITLE
feat(ui): enable tool-loop detection from Labs

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -64,6 +64,8 @@ Per-agent override (optional, at `agents.entries.*.tools.loopDetection`):
 
 The per-agent setting overrides the global setting.
 
+You can also enable the global rolling-history detectors in **Settings -> Labs** in the Control UI.
+
 ### Field behavior
 
 | Field     | Default | Effect                                                                                            |

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2695,6 +2695,11 @@ export const en: TranslationMap = {
       description:
         "Keep a bounded tool directory visible and defer the rest behind search, so large MCP and plugin catalogs stop crowding the prompt.",
     },
+    loopDetection: {
+      title: "Tool-loop detection",
+      description:
+        "Enable rolling-history guards that warn or block repeated tool calls when an agent stops making progress.",
+    },
     localModelLean: {
       title: "Lean tools for local models",
       description:

--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -159,8 +159,15 @@ describe("LabsPage", () => {
       note: "labs: update toolSearch",
     },
     {
-      label: "Lean tools for local models",
+      label: "Tool-loop detection",
       index: 3,
+      sourceConfig: { tools: { loopDetection: { enabled: false } } },
+      expectedPatch: { tools: { loopDetection: { enabled: true } } },
+      note: "labs: update loopDetection",
+    },
+    {
+      label: "Lean tools for local models",
+      index: 4,
       sourceConfig: {},
       expectedPatch: { agents: { defaults: { experimental: { localModelLean: true } } } },
       note: "labs: update localModelLean",
@@ -169,7 +176,7 @@ describe("LabsPage", () => {
       // Not a boolean gate: the on state is the conservative `direct` mode, so
       // enabling here cannot start recording group or unknown conversations.
       label: "Message audit metadata",
-      index: 4,
+      index: 5,
       sourceConfig: { logging: { audit: { messages: "off" } } },
       expectedPatch: { logging: { audit: { messages: "direct" } } },
       note: "labs: update auditMessages",
@@ -321,6 +328,47 @@ describe("LabsPage tool search enablement", () => {
     expect(runtimeConfig.patch).toHaveBeenCalledWith({
       raw: { tools: { toolSearch: { enabled: false } } },
       note: "labs: update toolSearch",
+    });
+  });
+});
+
+describe("LabsPage tool loop detection enablement", () => {
+  const loopDetectionIndex = LAB_FEATURES.findIndex((feature) => feature.id === "loopDetection");
+
+  // Mirrors resolveToolLoopDetectionConfig and the detector default: only an
+  // explicit true enables the rolling-history detectors.
+  it.each([
+    { label: "unset", config: {}, expected: false },
+    {
+      label: "explicit enabled",
+      config: { tools: { loopDetection: { enabled: true } } },
+      expected: true,
+    },
+    {
+      label: "explicit disabled",
+      config: { tools: { loopDetection: { enabled: false } } },
+      expected: false,
+    },
+  ])("reads $label as $expected", async ({ config, expected }) => {
+    const { page, provider } = await mountPage(config);
+
+    expect(labToggle(page, loopDetectionIndex, "Tool-loop detection").checked).toBe(expected);
+    provider.remove();
+  });
+
+  it("patches only enabled so sibling settings remain untouched", async () => {
+    const { page, runtimeConfig } = await mountPage({
+      tools: { loopDetection: { enabled: false, warningThreshold: 12 } },
+    });
+    const toggle = labToggle(page, loopDetectionIndex, "Tool-loop detection");
+
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+
+    await vi.waitFor(() => expect(runtimeConfig.patch).toHaveBeenCalledOnce());
+    expect(runtimeConfig.patch).toHaveBeenCalledWith({
+      raw: { tools: { loopDetection: { enabled: true } } },
+      note: "labs: update loopDetection",
     });
   });
 });

--- a/ui/src/pages/labs/labs-registry.ts
+++ b/ui/src/pages/labs/labs-registry.ts
@@ -112,6 +112,21 @@ export const LAB_FEATURES = [
     restartHint: null,
   },
   {
+    id: "loopDetection",
+    title: () => t("labsPage.loopDetection.title"),
+    description: () => t("labsPage.loopDetection.description"),
+    docsUrl: "https://docs.openclaw.ai/tools/loop-detection",
+    configPath: ["tools", "loopDetection", "enabled"],
+    onValue: true,
+    offValue: false,
+    activeValues: [true],
+    // ToolLoopDetectionSchema accepts object form only, and
+    // resolveToolLoopDetectionConfig reads this enabled leaf directly.
+    readEnabled: null,
+    enableAlso: null,
+    restartHint: null,
+  },
+  {
     id: "localModelLean",
     title: () => t("labsPage.localModelLean.title"),
     description: () => t("labsPage.localModelLean.description"),


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's rolling-history tool-loop detectors are experimental and disabled by default, but operators had no discoverable enablement path in the Control UI.

## Why This Change Was Made

Adds a Tool-loop detection row to Settings -> Labs that updates the existing global `tools.loopDetection.enabled` gate without replacing sibling configuration. The row links to the existing tool-loop detection documentation, which now notes the Labs path. This was AI-assisted and verified against the runtime resolver and config schema.

## User Impact

Operators can enable or disable rolling-history tool-loop protection from Settings -> Labs. Per-agent overrides continue to take precedence over the global setting.

Before: Settings -> Labs did not expose tool-loop detection.

After: Settings -> Labs includes a Tool-loop detection switch and documentation link.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/labs` - 1 test file passed, 31 tests passed.
- `pnpm ui:i18n:baseline` - raw-copy baseline verified with 95 entries; English source catalog verified with 4,605 keys and no generated locale changes.
- `git diff --check` - passed.
- Autoreview - clean, no accepted or actionable findings.


## Maintainer verification addendum (ClawSweeper rank-up moves)

**Move 1 (behavior proof):** Verified interactively against the repo mock Control UI harness (`pnpm dev:ui:mock --port 5217` from this branch):

- Labs page renders the new "Tool-loop detection" row between Tool Search and Lean tools, toggle off (matches shipped `enabled: false` default).
- Clicking the row's switch transitions it to on; the enabled state is served back from the mock gateway's stateful `config.apply`, i.e. the row re-reads `tools.loopDetection.enabled` rather than holding optimistic UI state.
- Sibling-preservation and exact merge-patch shape (`{tools:{loopDetection:{enabled:<bool>}}}`, no other keys) are locked by the added unit tests in `ui/src/pages/labs/labs-page.test.ts` (31/31 passing via `node scripts/run-vitest.mjs ui/src/pages/labs`).
- Screenshot files are not attached: the interactive verification ran in a session-embedded browser that does not export images, and a scripted headless capture could not activate the `wa-switch` web component under the bundled `playwright-core` Chromium (component upgrade issue in that environment, not a product path). Stating the partial skip here per repo review policy rather than merging past the move silently.

**Move 2 (refresh against main):** intentionally skipped — repo policy treats merge drift as advisory; the landing flow validates against current `main` and GitHub blocks real conflicts.

Fresh pre-land autoreview (Codex, gpt-5.6-sol, branch vs origin/main): clean, no accepted findings — "patch is correct (0.95)".
