### PR TITLE
fix(status): recent session listing resolves the wrong agent's model

### DIFF
--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -187,7 +187,7 @@ vi.mock("../routing/session-key.js", async () => {
     LEGACY_IMPLICIT_AGENT_ID: "main",
     normalizeAgentId: vi.fn((value: string) => value),
     normalizeMainKey: vi.fn((value?: string) => value ?? "main"),
-    parseAgentSessionKey: vi.fn(() => null),
+    parseAgentSessionKey: vi.fn(actual.parseAgentSessionKey),
   };
 });
 
@@ -1071,5 +1071,24 @@ describe("getStatusSummary", () => {
         model: "claude-opus-4-8",
       }),
     );
+  });
+
+  it("resolves aggregate selected models from each row's agent", async () => {
+    const models: Record<string, string> = { ops: "ops", research: "research" };
+    vi.mocked(statusSummaryRuntime.resolveSessionModelRef).mockImplementation(
+      (_cfg, _entry, id) => ({ provider: "openai", model: models[id ?? ""] ?? "global" }),
+    );
+    statusSummaryMocks.listSessionEntriesCore.mockReturnValue(
+      toSessionEntrySummaries({
+        "agent:ops:main": { sessionId: "ops-session", updatedAt: 3 },
+        "agent:research:main": { sessionId: "research-session", updatedAt: 2 },
+        main: { sessionId: "global-session", updatedAt: 1 },
+      }),
+    );
+
+    const summary = await getStatusSummary();
+    const selected = summary.sessions.recent.map(({ selectedModel }) => selectedModel);
+
+    expect(selected).toEqual(["openai/ops", "openai/research", "openai/global"]);
   });
 });

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -418,7 +418,7 @@ export async function getStatusSummary(
         });
         const configuredSessionModel = configuredForSession.model ?? DEFAULT_MODEL;
         const configuredSessionModelLabel = `${configuredForSession.provider ?? DEFAULT_PROVIDER}/${configuredSessionModel}`;
-        const resolvedModel = resolveSessionModelRef(cfg, entry, opts.agentIdOverride);
+        const resolvedModel = resolveSessionModelRef(cfg, entry, agentId);
         const model = resolvedModel.model ?? configuredSessionModel ?? null;
         const lookupModel =
           resolveStatusModelLookupRef({


### PR DESCRIPTION
Related: #107643

## What Problem This Solves

Fixes an issue where aggregate recent-session status could show the global default model for sessions owned by agents with their own configured model.

The per-agent status view already supplied an explicit agent override. The cross-agent recent list instead needs to resolve each row from the agent encoded in that row's session key.

## Why This Change Was Made

The status row already derives one canonical `agentId` and uses it for configured-model and runtime resolution. This change reuses that same identity for selected-model resolution instead of rereading the optional aggregate override.

The rewrite is intentionally status-only:

- production: `+1/-1`
- tests: `+20/-1`
- no config, defaults, SDK, protocol, auth, storage, session, formatter, or provider contract changes

## User Impact

`openclaw status`, `/status`, and other consumers of the aggregate recent-session summary now report each session's selected model using that session's owning agent configuration. Unscoped rows still use the global default.

## Evidence

Exact head: `aadf17a907c909a2666d95ef2d6250e2a99f3781`

- Controlled current-main regression: `36/37` passed; the two agent-scoped aggregate rows incorrectly rendered `openai/gpt-global`, while the unscoped control remained correct.
- Exact rewrite proof: `56/56` passed across `src/commands/status.summary.test.ts` and `src/commands/status.summary.runtime.test.ts`.
- Direct `oxlint`, formatting, and `git diff --check`: passed.
- Max-P1 autoreview: no accepted or actionable findings; correctness confidence `0.98`.
- The first hosted cycle caught max-lines and nullable-test-mock failures on the superseded head; both were repaired before this exact head.
- Blacksmith Testbox `tbx_01m0qn6mkf6d7c8sgzzmq6jkby`, run `32649943846`: focused tests and the full changed gate passed.
- Exact-head CI run `32649887047`: green.
- Exact-head ClawSweeper review: no actionable findings or remaining rank-up move.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 115984`: passed with hosted gates accepted.

Punchcard-Session: clear-valley-timber-rh
