### PR TITLE
fix(test): keep auth logout TTY tests portable

### DIFF
--- a/src/commands/models/auth-logout.test.ts
+++ b/src/commands/models/auth-logout.test.ts
@@ -86,6 +86,25 @@ function applyCapturedConfigUpdate(cfg: OpenClawConfig): OpenClawConfig {
   return mutator(cfg);
 }
 
+async function withStdinIsTty<T>(isTTY: boolean, run: () => Promise<T>): Promise<T> {
+  const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
+  const hadOwnIsTTY = Object.hasOwn(stdin, "isTTY");
+  const previousIsTTYDescriptor = Object.getOwnPropertyDescriptor(stdin, "isTTY");
+  Object.defineProperty(stdin, "isTTY", {
+    configurable: true,
+    value: isTTY,
+  });
+  try {
+    return await run();
+  } finally {
+    if (hadOwnIsTTY && previousIsTTYDescriptor) {
+      Object.defineProperty(stdin, "isTTY", previousIsTTYDescriptor);
+    } else {
+      Reflect.deleteProperty(stdin, "isTTY");
+    }
+  }
+}
+
 describe("models auth logout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -227,30 +246,20 @@ describe("models auth logout", () => {
 
   it("keeps the profile when an interactive confirmation is declined", async () => {
     mocks.confirm.mockResolvedValue(false);
-    const stdin = process.stdin as unknown as { isTTY: boolean };
-    const priorIsTty = stdin.isTTY;
-    stdin.isTTY = true;
-    try {
+    await withStdinIsTty(true, async () => {
       const runtime = createRuntime();
       await modelsAuthLogoutCommand({ profileId: "openai:manual" }, runtime);
       expect(mocks.removeAuthProfilesAcrossOwnerStores).not.toHaveBeenCalled();
       expect(runtime.logs).toContain("Cancelled.");
-    } finally {
-      stdin.isTTY = priorIsTty;
-    }
+    });
   });
 
   it("refuses to remove without --yes when stdin is not a TTY", async () => {
-    const stdin = process.stdin as unknown as { isTTY: boolean };
-    const priorIsTty = stdin.isTTY;
-    stdin.isTTY = false;
-    try {
+    await withStdinIsTty(false, async () => {
       await expect(
         modelsAuthLogoutCommand({ profileId: "openai:manual" }, createRuntime()),
       ).rejects.toThrow("Pass --yes to remove it non-interactively.");
       expect(mocks.removeAuthProfilesAcrossOwnerStores).not.toHaveBeenCalled();
-    } finally {
-      stdin.isTTY = priorIsTty;
-    }
+    });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the auth logout test suite failed under a real TTY because its tests assigned directly to the read-only `process.stdin.isTTY` property. This blocked full Testbox validation even though the command behavior was correct.

## Why This Change Was Made

The tests now override `stdin.isTTY` with a configurable property descriptor and restore the exact prior descriptor afterward. This matches the existing repository pattern and keeps the change test-only.

## User Impact

No product behavior changes. Maintainers can run the auth logout tests in both TTY and non-TTY test environments without environment-dependent failures.

## Evidence

- Failure reproduced in the full Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/30464029744
- Focused exact-head Blacksmith Testbox on `6ff7ebef5359fcde615357797f214ae99ff440f9`: 1 file passed, 10 tests passed: https://github.com/openclaw/openclaw/actions/runs/30473249980
- `git diff --check` passes.
- `oxfmt` passes for `src/commands/models/auth-logout.test.ts`.
- Fresh autoreview: clean, no actionable findings (0.96).
