### PR TITLE
fix(memory-core): adopt legacy dreaming cron jobs

### DIFF
--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -96,6 +96,11 @@ type CronParam = {
   add: (input: CronAddInput) => Promise<unknown>;
   update: (id: string, patch: CronPatch) => Promise<unknown>;
   remove: (id: string) => Promise<{ removed?: boolean }>;
+  removeStaleJobFamily: (family: {
+    declarationKey: string;
+    name: string;
+    ownerPluginTag: string;
+  }) => Promise<number>;
 };
 type DreamingPluginApi = Parameters<typeof registerShortTermPromotionDreaming>[0];
 type DreamingPluginApiTestDouble = {
@@ -121,14 +126,21 @@ function createCronHarness(
     listThrowsForFirstCalls?: number;
     removeResult?: "boolean" | "unknown";
     removeThrowsForIds?: string[];
+    staleJobs?: CronJobLike[];
   },
 ) {
   const jobs: CronJobLike[] = [...initialJobs];
+  const staleJobs: CronJobLike[] = [...(opts?.staleJobs ?? [])];
   let listCalls = 0;
   const addCalls: CronAddInput[] = [];
   const updateCalls: Array<{ id: string; patch: CronPatch }> = [];
   const removeCalls: string[] = [];
   const mutationCalls: string[] = [];
+  const staleFamilyCalls: Array<{
+    declarationKey: string;
+    name: string;
+    ownerPluginTag: string;
+  }> = [];
 
   const cron: CronParam = {
     async list() {
@@ -197,15 +209,28 @@ function createCronHarness(
       }
       return { removed: index >= 0 };
     },
+    async removeStaleJobFamily(family) {
+      staleFamilyCalls.push(family);
+      const retained = staleJobs.filter(
+        (job) =>
+          job.declarationKey !== family.declarationKey &&
+          !(job.name === family.name && job.description?.includes(family.ownerPluginTag) === true),
+      );
+      const removed = staleJobs.length - retained.length;
+      staleJobs.splice(0, staleJobs.length, ...retained);
+      return removed;
+    },
   };
 
   return {
     cron,
     jobs,
+    staleJobs,
     addCalls,
     updateCalls,
     removeCalls,
     mutationCalls,
+    staleFamilyCalls,
     get listCalls() {
       return listCalls;
     },
@@ -783,6 +808,9 @@ describe("gateway startup reconciliation", () => {
       async remove() {
         return { removed: false };
       },
+      async removeStaleJobFamily() {
+        return 0;
+      },
     };
     const onMock = vi.fn();
     const api: DreamingPluginApiTestDouble = {
@@ -1143,6 +1171,85 @@ describe("gateway startup reconciliation", () => {
       expectCronSchedule(requireAddCall(harness, 0).schedule, "*/3 * * * *");
       expect(harness.jobs).toHaveLength(1);
       expect(harness.jobs[0]?.declarationKey).toBe("memory-core:memory-dreaming-promotion");
+    } finally {
+      await triggerGatewayStop(onMock).catch(() => undefined);
+      clearInternalHooks();
+    }
+  });
+
+  it("adopts the exact legacy row from an obsolete store beside the declaration job", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const legacyRow: CronJobLike = {
+      id: "75e182e6-8728-43ae-832b-01f50702feed",
+      name: "Memory Dreaming Promotion",
+      description:
+        "[managed-by=memory-core.short-term-promotion] Promote weighted short-term recalls into MEMORY.md (limit=10, minScore=0.800, minRecallCount=3, minUniqueQueries=3, recencyHalfLifeDays=14, maxAgeDays=30).",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 3 * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: constants.DREAMING_SYSTEM_EVENT_TEXT,
+        lightContext: true,
+      },
+      createdAtMs: 1_785_240_959_377,
+    };
+    const declaredRow: CronJobLike = {
+      id: "job-declared",
+      declarationKey: "memory-core:memory-dreaming-promotion",
+      name: "Memory Dreaming Promotion",
+      description: `${constants.MANAGED_DREAMING_CRON_TAG} current managed dreaming job`,
+      enabled: true,
+      schedule: { kind: "cron", expr: "*/3 * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: {
+        kind: "agentTurn",
+        message: constants.DREAMING_SYSTEM_EVENT_TEXT,
+        lightContext: true,
+      },
+      delivery: { mode: "none" },
+      createdAtMs: 1_785_338_313_079,
+    };
+    const harness = createCronHarness([declaredRow], { staleJobs: [legacyRow] });
+    const onMock = vi.fn();
+    const api: DreamingPluginApiTestDouble = {
+      config: {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: { dreaming: { enabled: true, frequency: "*/3 * * * *" } },
+            },
+          },
+        },
+      },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      on: onMock,
+    };
+
+    try {
+      registerShortTermPromotionDreamingForTest(api);
+      await triggerGatewayStart(onMock, { config: api.config, getCron: () => harness.cron });
+
+      expect(harness.staleJobs).toEqual([]);
+      expect(harness.jobs).toHaveLength(1);
+      expect(harness.jobs[0]).toMatchObject({
+        declarationKey: "memory-core:memory-dreaming-promotion",
+        name: "Memory Dreaming Promotion",
+        enabled: true,
+        schedule: { kind: "cron", expr: "*/3 * * * *" },
+      });
+      expect(harness.staleFamilyCalls).toEqual([
+        {
+          declarationKey: "memory-core:memory-dreaming-promotion",
+          name: "Memory Dreaming Promotion",
+          ownerPluginTag: constants.MANAGED_DREAMING_CRON_TAG,
+        },
+      ]);
     } finally {
       await triggerGatewayStop(onMock).catch(() => undefined);
       clearInternalHooks();

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -100,6 +100,11 @@ type CronServiceLike = {
   add: (input: ManagedCronJobCreate) => Promise<unknown>;
   update: (id: string, patch: ManagedCronJobPatch) => Promise<unknown>;
   remove: (id: string) => Promise<{ removed?: boolean }>;
+  removeStaleJobFamily: (family: {
+    declarationKey: string;
+    name: string;
+    ownerPluginTag: string;
+  }) => Promise<number>;
 };
 
 type ShortTermPromotionDreamingConfig = {
@@ -237,6 +242,18 @@ function isLegacyPhaseDreamingJob(job: ManagedCronJobLike): boolean {
   return name === LEGACY_REM_SLEEP_CRON_NAME && payloadText === LEGACY_REM_SLEEP_EVENT_TEXT;
 }
 
+async function removeStaleManagedDreamingRows(cron: CronServiceLike): Promise<number> {
+  // Adopt legacy pre-declaration-key jobs copied under obsolete store keys. Leaving one
+  // behind means both it and the declared replacement can run, producing duplicate sweeps.
+  return (
+    (await cron.removeStaleJobFamily({
+      declarationKey: MANAGED_DREAMING_DECLARATION_KEY,
+      name: MANAGED_DREAMING_CRON_NAME,
+      ownerPluginTag: MANAGED_DREAMING_CRON_TAG,
+    })) ?? 0
+  );
+}
+
 function compareOptionalStrings(a: string | undefined, b: string | undefined): boolean {
   return a === b;
 }
@@ -356,7 +373,8 @@ function resolveCronServiceFromCandidate(candidate: unknown): CronServiceLike | 
     typeof cron.list !== "function" ||
     typeof cron.add !== "function" ||
     typeof cron.update !== "function" ||
-    typeof cron.remove !== "function"
+    typeof cron.remove !== "function" ||
+    typeof cron.removeStaleJobFamily !== "function"
   ) {
     return null;
   }
@@ -453,6 +471,7 @@ async function reconcileShortTermDreamingCronJob(params: {
         );
       }
     }
+    removed += await removeStaleManagedDreamingRows(cron);
     if (removed > 0) {
       params.logger.info(`memory-core: removed ${removed} managed dreaming cron job(s).`);
     }
@@ -468,8 +487,9 @@ async function reconcileShortTermDreamingCronJob(params: {
       logger: params.logger,
       mode: "enabled",
     });
+    const removedStale = await removeStaleManagedDreamingRows(cron);
     params.logger.info("memory-core: created managed dreaming cron job.");
-    return { status: "added", removed: migratedLegacy };
+    return { status: "added", removed: migratedLegacy + removedStale };
   }
 
   if (!managed.some((job) => job.declarationKey === MANAGED_DREAMING_DECLARATION_KEY)) {
@@ -487,6 +507,7 @@ async function reconcileShortTermDreamingCronJob(params: {
       }
       removed += 1;
     }
+    removed += await removeStaleManagedDreamingRows(cron);
     params.logger.info("memory-core: replaced legacy managed dreaming cron job identity.");
     return { status: "added", removed };
   }
@@ -514,6 +535,7 @@ async function reconcileShortTermDreamingCronJob(params: {
       );
     }
   }
+  removed += await removeStaleManagedDreamingRows(cron);
 
   const patch = buildManagedDreamingPatch(primary, desired);
   if (!patch) {

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -109,6 +109,14 @@ export class CronService implements CronServiceContract {
     return await mutationOps.add(this.state, input, opts);
   }
 
+  async removeStaleJobFamily(family: {
+    declarationKey: string;
+    name: string;
+    ownerPluginTag: string;
+  }) {
+    return await mutationOps.removeStaleJobFamily(this.state, family);
+  }
+
   async update(id: string, patch: CronJobPatch, opts?: CronUpdateOptions) {
     return await mutationOps.update(this.state, id, patch, opts);
   }

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -11,6 +11,7 @@ import {
 } from "../active-jobs.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { deleteCronJobScratch } from "../scratch-store.js";
+import { removeStaleCronJobFamilyRows } from "../store.js";
 import { createCronStreamSourceIdentity, cronStreamScheduleKey } from "../stream-schedule.js";
 import { normalizeCronTaskRunJobId } from "../task-run-history.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
@@ -292,6 +293,17 @@ export async function add(state: CronServiceState, input: CronJobCreate, opts?: 
       nextRunAtMs: job.state.nextRunAtMs,
     });
     return declarationKey ? { ...job, created: true, job } : job;
+  });
+}
+
+/** Prunes an owned job family from obsolete store partitions after active-store convergence. */
+export async function removeStaleJobFamily(
+  state: CronServiceState,
+  family: { declarationKey: string; name: string; ownerPluginTag: string },
+): Promise<number> {
+  return await locked(state, async () => {
+    await ensureLoaded(state, { skipRecompute: true });
+    return removeStaleCronJobFamilyRows(state.deps.storePath, family);
   });
 }
 

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -16,7 +16,7 @@ import { loadCronJobsStoreWithConfigJobs, loadCronStore } from "../store.js";
 import { cronStoreKey } from "../store/key.js";
 import type { CronJob } from "../types.js";
 import { start, stop } from "./ops-lifecycle.js";
-import { add, remove, update } from "./ops-mutations.js";
+import { add, remove, removeStaleJobFamily, update } from "./ops-mutations.js";
 import { list } from "./ops-read.js";
 import { run } from "./ops-run.js";
 import { createCronServiceState, type CronEvent } from "./state.js";
@@ -231,18 +231,20 @@ function insertCronJobRow(storePath: string, job: CronJob) {
   runOpenClawStateWriteTransaction(({ db }) => {
     db.prepare(
       `INSERT INTO cron_jobs (
-        store_key, job_id, name, enabled, created_at_ms, schedule_kind,
+        store_key, job_id, declaration_key, name, description, enabled, created_at_ms, schedule_kind,
         at, every_ms, anchor_ms, schedule_expr, session_target, wake_mode, payload_kind,
         payload_message, delivery_mode, delivery_to, job_json, state_json, updated_at
       ) VALUES (
-        $storeKey, $jobId, $name, $enabled, $createdAtMs, $scheduleKind,
+        $storeKey, $jobId, $declarationKey, $name, $description, $enabled, $createdAtMs, $scheduleKind,
         $at, $everyMs, $anchorMs, $scheduleExpr, $sessionTarget, $wakeMode, $payloadKind,
         $payloadMessage, $deliveryMode, $deliveryTo, $jobJson, $stateJson, $updatedAt
       )`,
     ).run({
       $storeKey: path.resolve(storePath),
       $jobId: job.id,
+      $declarationKey: job.declarationKey ?? null,
       $name: job.name,
+      $description: job.description ?? null,
       $enabled: job.enabled ? 1 : 0,
       $createdAtMs: job.createdAtMs,
       $scheduleKind: job.schedule.kind,
@@ -262,6 +264,67 @@ function insertCronJobRow(storePath: string, job: CronJob) {
     });
   });
 }
+
+describe("cron stale job-family adoption", () => {
+  it("removes owner-tagged legacy rows outside the active store", async () => {
+    const { storePath } = await makeStorePath();
+    const staleStorePath = path.join(path.dirname(storePath), "legacy-copy", "jobs.json");
+    const now = Date.parse("2026-07-29T12:00:00.000Z");
+    const state = createOkIsolatedCronState({ storePath, now });
+    const family = {
+      declarationKey: "memory-core:memory-dreaming-promotion",
+      name: "Memory Dreaming Promotion",
+      ownerPluginTag: "[managed-by=memory-core.short-term-promotion]",
+    };
+    await add(state, {
+      declarationKey: family.declarationKey,
+      name: family.name,
+      description: `${family.ownerPluginTag} current`,
+      enabled: true,
+      schedule: { kind: "cron", expr: "*/3 * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "dream" },
+    });
+    const legacy = {
+      id: "75e182e6-8728-43ae-832b-01f50702feed",
+      name: family.name,
+      description: `${family.ownerPluginTag} legacy`,
+      enabled: true,
+      createdAtMs: now - 10_000,
+      updatedAtMs: now - 10_000,
+      schedule: { kind: "cron" as const, expr: "0 3 * * *" },
+      sessionTarget: "isolated" as const,
+      wakeMode: "now" as const,
+      payload: { kind: "agentTurn" as const, message: "dream" },
+      state: {},
+    } satisfies CronJob;
+    insertCronJobRow(staleStorePath, legacy);
+    insertCronJobRow(staleStorePath, {
+      ...legacy,
+      id: "operator-same-name",
+      description: "Operator-owned job with the same display name",
+    });
+
+    await expect(removeStaleJobFamily(state, family)).resolves.toBe(1);
+
+    const remaining = runOpenClawStateWriteTransaction(({ db }) =>
+      db
+        .prepare("SELECT store_key, job_id FROM cron_jobs WHERE name = ? ORDER BY job_id")
+        .all(family.name),
+    );
+    expect(remaining).toHaveLength(2);
+    expect(remaining).toEqual(
+      expect.arrayContaining([
+        { store_key: path.resolve(storePath), job_id: expect.any(String) },
+        { store_key: path.resolve(staleStorePath), job_id: "operator-same-name" },
+      ]),
+    );
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+  });
+});
 
 async function expectDueIsolatedManualRunProgresses(storePath: string, now: number) {
   const state = createOkIsolatedCronState({ storePath, now, summary: "done" });

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -18,11 +18,13 @@ import { readCronStoreStatePath } from "./store/config-state.js";
 import { cronStoreKey } from "./store/key.js";
 import {
   assertCronStoreCanPersist,
+  deleteStaleCronJobFamilyRows,
   loadedCronStoreFromRows,
   loadCronRows,
   replaceCronRows,
   updateCronRuntimeRows,
 } from "./store/row-codec.js";
+import type { CronJobFamilyIdentity } from "./store/row-codec.js";
 import type {
   CronQuarantineFile,
   LoadedCronStore,
@@ -89,6 +91,19 @@ export async function loadCronJobsStoreWithConfigJobs(storePath: string): Promis
     configJobRuntimeEntries: [],
     invalidConfigRows: [],
   };
+}
+
+/** Removes an owned declarative job family left under obsolete absolute store keys. */
+export function removeStaleCronJobFamilyRows(
+  storePath: string,
+  family: CronJobFamilyIdentity,
+): number {
+  const activeStoreKey = cronStoreKey(path.resolve(storePath));
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => deleteStaleCronJobFamilyRows(db, activeStoreKey, family),
+    {},
+    { operationLabel: "cron.job-family-adoption" },
+  );
 }
 
 function emptyLoadedCronStore(): LoadedCronStore {

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -354,6 +354,48 @@ export function loadCronRows(db: DatabaseSync, storeKey: string): CronJobRow[] {
   ).rows;
 }
 
+export type CronJobFamilyIdentity = {
+  declarationKey: string;
+  name: string;
+  ownerPluginTag: string;
+};
+
+/** Removes one owned job family from obsolete store partitions. */
+export function deleteStaleCronJobFamilyRows(
+  db: DatabaseSync,
+  activeStoreKey: string,
+  family: CronJobFamilyIdentity,
+): number {
+  const staleRows = executeSqliteQuerySync(
+    db,
+    getCronStoreKysely(db)
+      .selectFrom("cron_jobs")
+      .select(["store_key", "job_id", "declaration_key", "name", "description"])
+      .where("store_key", "!=", activeStoreKey),
+  ).rows.filter(
+    (row) =>
+      row.declaration_key === family.declarationKey ||
+      (row.name === family.name && row.description?.includes(family.ownerPluginTag) === true),
+  );
+  for (const row of staleRows) {
+    executeSqliteQuerySync(
+      db,
+      getCronStoreKysely(db)
+        .deleteFrom("cron_job_scratch")
+        .where("store_key", "=", row.store_key)
+        .where("job_id", "=", row.job_id),
+    );
+    executeSqliteQuerySync(
+      db,
+      getCronStoreKysely(db)
+        .deleteFrom("cron_jobs")
+        .where("store_key", "=", row.store_key)
+        .where("job_id", "=", row.job_id),
+    );
+  }
+  return staleRows.length;
+}
+
 /** Replaces all persisted cron rows for one store key from the config store snapshot. */
 export function replaceCronRows(db: DatabaseSync, storeKey: string, store: CronStoreFile): void {
   executeSqliteQuerySync(

--- a/src/gateway/local-request-context.ts
+++ b/src/gateway/local-request-context.ts
@@ -46,6 +46,7 @@ const unavailableCron: GatewayCronServiceContract = {
   update: async () => cronUnavailable(),
   updateWithPrecondition: async () => cronUnavailable(),
   remove: async () => cronUnavailable(),
+  removeStaleJobFamily: async () => cronUnavailable(),
   removeAgentJobsTransactional: async () => cronUnavailable(),
   run: async () => cronUnavailable(),
   enqueueRun: async () => cronUnavailable(),

--- a/src/gateway/server-cron-contract.ts
+++ b/src/gateway/server-cron-contract.ts
@@ -4,6 +4,12 @@ import type { CronJobScratchState, CronJobScratchWriteResult } from "../cron/scr
 import type { CronServiceContract } from "../cron/service-contract.js";
 
 export type GatewayCronServiceContract = CronServiceContract & {
+  /** Remove an owned declarative job family from obsolete SQLite store partitions. */
+  removeStaleJobFamily(family: {
+    declarationKey: string;
+    name: string;
+    ownerPluginTag: string;
+  }): Promise<number>;
   readScratch(id: string): Promise<CronJobScratchState>;
   writeScratch(
     id: string,

--- a/src/gateway/server-cron-lazy.test.ts
+++ b/src/gateway/server-cron-lazy.test.ts
@@ -330,6 +330,7 @@ function createCronService(): GatewayCronServiceContract {
     update: vi.fn(async () => ({ ok: true }) as never),
     updateWithPrecondition: vi.fn(async () => ({ ok: true }) as never),
     remove: vi.fn(async () => ({ ok: true }) as never),
+    removeStaleJobFamily: vi.fn(async () => 0),
     removeAgentJobsTransactional: vi.fn(async (_agentId, commit) => await commit()),
     run: vi.fn(async () => ({ ok: true, ran: false, reason: "invalid-spec" }) as never),
     enqueueRun: vi.fn(async () => ({ ok: true, ran: false, reason: "invalid-spec" }) as never),

--- a/src/gateway/server-cron-lazy.ts
+++ b/src/gateway/server-cron-lazy.ts
@@ -262,6 +262,9 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
     async remove(id) {
       return await (await load()).state.cron.remove(id);
     },
+    async removeStaleJobFamily(family) {
+      return await (await load()).state.cron.removeStaleJobFamily(family);
+    },
     async removeAgentJobsTransactional(agentId, commit) {
       return await (await load()).state.cron.removeAgentJobsTransactional(agentId, commit);
     },

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -2377,7 +2377,13 @@ describe("startGatewayPostAttachRuntime", () => {
       hasHooks: vi.fn((hookName: string) => hookName === "gateway_start"),
       runGatewayStart,
     };
-    const initialCron = { list: vi.fn(), add: vi.fn(), update: vi.fn(), remove: vi.fn() };
+    const initialCron = {
+      list: vi.fn(),
+      add: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      removeStaleJobFamily: vi.fn(),
+    };
     const params = createPostAttachParams({
       gatewayPluginConfigAtStart: {
         hooks: { internal: { enabled: false } },
@@ -2412,7 +2418,13 @@ describe("startGatewayPostAttachRuntime", () => {
     }
     expect(getCron()).toBe(initialCron);
 
-    const reloadedCron = { list: vi.fn(), add: vi.fn(), update: vi.fn(), remove: vi.fn() };
+    const reloadedCron = {
+      list: vi.fn(),
+      add: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      removeStaleJobFamily: vi.fn(),
+    };
     params.deps.cron = reloadedCron as never;
     expect(getCron()).toBe(reloadedCron);
   });
@@ -2438,9 +2450,27 @@ describe("startGatewayPostAttachRuntime", () => {
       hasHooks: vi.fn((hookName: string) => hookName === "gateway_start"),
       runGatewayStart,
     };
-    const depsCron = { list: vi.fn(), add: vi.fn(), update: vi.fn(), remove: vi.fn() };
-    const liveCron = { list: vi.fn(), add: vi.fn(), update: vi.fn(), remove: vi.fn() };
-    const reloadedCron = { list: vi.fn(), add: vi.fn(), update: vi.fn(), remove: vi.fn() };
+    const depsCron = {
+      list: vi.fn(),
+      add: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      removeStaleJobFamily: vi.fn(),
+    };
+    const liveCron = {
+      list: vi.fn(),
+      add: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      removeStaleJobFamily: vi.fn(),
+    };
+    const reloadedCron = {
+      list: vi.fn(),
+      add: vi.fn(),
+      update: vi.fn(),
+      remove: vi.fn(),
+      removeStaleJobFamily: vi.fn(),
+    };
     let currentLiveCron = liveCron;
     const params = createPostAttachParams({
       deps: { cron: depsCron } as never,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -997,6 +997,7 @@ type PluginHookGatewayCronJobState = {
 
 export type PluginHookGatewayCronJob = {
   id: string;
+  declarationKey?: string;
   /** Agent id that owns this cron job. */
   agentId?: string;
   name?: string;
@@ -1068,6 +1069,7 @@ export type PluginHookCronChangedEvent = {
 };
 
 type PluginHookGatewayCronCreateInput = {
+  declarationKey?: string;
   name: string;
   description: string;
   enabled: boolean;
@@ -1095,6 +1097,11 @@ export type PluginHookGatewayCronService = {
   add: (input: PluginHookGatewayCronCreateInput) => Promise<unknown>;
   update: (id: string, patch: PluginHookGatewayCronUpdateInput) => Promise<unknown>;
   remove: (id: string) => Promise<PluginHookGatewayCronRemoveResult>;
+  removeStaleJobFamily: (family: {
+    declarationKey: string;
+    name: string;
+    ownerPluginTag: string;
+  }) => Promise<number>;
 };
 
 export type PluginInstallTargetType = "skill" | "plugin";


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #115925: a real copied install can contain a pre-declaration-key `Memory Dreaming Promotion` row under its original absolute cron store key and the new declaration-keyed row under the copied install's active store key. The active-store-only cron list hid the legacy row from memory-core reconciliation, leaving two enabled schedules in the shared SQLite state.

## Why This Change Was Made

Memory-core still defines the family identity: the declaration key, or the legacy memory-core owner tag plus exact job name. The cron service now provides a narrow adoption seam that removes matching family rows and scratch state from obsolete SQLite store partitions after the active canonical job has been created or updated. This keeps raw SQLite ownership in core and prevents add failure from deleting the only working schedule.

The adoption branch is explicitly documented: these are legacy pre-declaration-key jobs, and leaving one behind causes duplicate sweeps. Reconciliation removes the cache-class rows rather than disabling or migrating them.

## User Impact

After startup reconciliation, copied/upgraded installs retain exactly one enabled declaration-keyed `Memory Dreaming Promotion` job with the configured schedule. Unrelated operator jobs with the same display name but without the memory-core owner tag are preserved.

## Evidence

- Production seam against an APFS clone of the reported copied-state DB: the query returned the legacy enabled `0 3 * * *` row plus the enabled declaration-keyed `*/3 * * * *` row before adoption; adoption returned `removed=1`; the same query afterward returned only the declaration-keyed `*/3` row. The preserved repro DB was not mutated.
- Focused exact-head tests: 74 Gateway tests, 50 cron-service tests, and 38 memory-core tests passed.
- Exact-head changed gate on Blacksmith Testbox: all core/extension production and test typechecks, lint, schema-version/database-first guards, plugin boundaries, dead exports, and runtime import cycles passed.
- Autoreview: clean with no accepted/actionable findings (0.94 confidence).

This change is AI-assisted and was reviewed through the repository autoreview workflow.
