### PR TITLE
fix(ui): explain unavailable MCP tool catalogs

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -12452,21 +12452,25 @@ public struct ToolsEffectiveNotice: Codable, Sendable {
     public let id: String
     public let severity: AnyCodable
     public let message: String
+    public let servers: [String]?
 
     public init(
         id: String,
         severity: AnyCodable,
-        message: String)
+        message: String,
+        servers: [String]? = nil)
     {
         self.id = id
         self.severity = severity
         self.message = message
+        self.servers = servers
     }
 
     private enum CodingKeys: String, CodingKey {
         case id
         case severity
         case message
+        case servers
     }
 }
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -266,6 +266,22 @@ describe("ToolsEffectiveResultSchema", () => {
     expect(Value.Check(ToolsEffectiveResultSchema, result)).toBe(true);
   });
 
+  it("accepts server-scoped inventory notices", () => {
+    const result = {
+      ...toolsEffectiveResult(),
+      notices: [
+        {
+          id: "mcp-not-yet-connected",
+          severity: "info",
+          message: "MCP tools are not available yet.",
+          servers: ["github", "notion"],
+        },
+      ],
+    };
+
+    expect(Value.Check(ToolsEffectiveResultSchema, result)).toBe(true);
+  });
+
   it("keeps tool quarantine notices strict", () => {
     const result = {
       ...toolsEffectiveResult(),

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -1042,6 +1042,7 @@ export const ToolsEffectiveNoticeSchema = closedObject({
   id: NonEmptyString,
   severity: Type.Union([Type.Literal("info"), Type.Literal("warning")]),
   message: Type.String(),
+  servers: Type.Optional(Type.Array(NonEmptyString)),
 });
 
 /** Effective tool set for a session, including profile and filtering notices. */

--- a/src/agents/tools-effective-inventory.types.ts
+++ b/src/agents/tools-effective-inventory.types.ts
@@ -38,6 +38,7 @@ export type EffectiveToolInventoryNotice = {
   id: string;
   severity: "info" | "warning";
   message: string;
+  servers?: string[];
 };
 
 /** Effective tool inventory result for one agent/profile. */

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -85,7 +85,7 @@ type RespondCall = [boolean, unknown?, { code: number; message: string }?];
 type ToolsEffectivePayload = {
   agentId?: string;
   profile?: string;
-  notices?: Array<{ id?: string; severity?: string; message?: string }>;
+  notices?: Array<{ id?: string; severity?: string; message?: string; servers?: string[] }>;
   groups?: Array<{
     id?: string;
     label?: string;
@@ -485,12 +485,14 @@ describe("tools.effective handler", () => {
   });
 
   it("reports configured MCP servers as not connected without starting them", async () => {
-    mockMcpConfigSummary();
+    mockMcpConfigSummary({ serverNames: ["zeta", "alpha"] });
     const { respond, invoke } = createInvokeParams({ sessionKey: "main:abc" });
     await invoke();
 
     expectPayloadGroupIds(respond, ["core"]);
-    expect(expectPayloadNotice(respond, "mcp-not-yet-connected")?.message).toContain("reproProbe");
+    const notice = expectPayloadNotice(respond, "mcp-not-yet-connected");
+    expect(notice?.message).toContain('"alpha", "zeta"');
+    expect(notice?.servers).toEqual(["alpha", "zeta"]);
   });
 
   it("projects MCP tools from an already-populated session runtime catalog", async () => {

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -307,25 +307,29 @@ function mcpDiscoveryNotice(
   if (mcpServerNames.length === 0) {
     return undefined;
   }
-  const servers = formatMcpServerNames(mcpServerNames);
+  const servers = mcpServerNames.toSorted((a, b) => a.localeCompare(b));
+  const formattedServers = formatMcpServerNames(servers);
   switch (reason) {
     case "stale-config":
       return {
         id: "mcp-stale-catalog",
         severity: "info",
-        message: `MCP servers ${servers} changed since the current runtime catalog was discovered. MCP tools will appear here after the next agent run discovers them.`,
+        message: `MCP servers ${formattedServers} changed since the current runtime catalog was discovered. MCP tools will appear here after the next agent run discovers them.`,
+        servers,
       };
     case "not-listed":
       return {
         id: "mcp-not-yet-listed",
         severity: "info",
-        message: `MCP servers ${servers} are connected but have not finished listing tools yet. MCP tools will appear here after the session discovers them.`,
+        message: `MCP servers ${formattedServers} are connected but have not finished listing tools yet. MCP tools will appear here after the session discovers them.`,
+        servers,
       };
     case "not-connected":
       return {
         id: "mcp-not-yet-connected",
         severity: "info",
-        message: `MCP servers ${servers} are configured but not connected for this session yet. MCP tools will appear here after an agent run discovers them.`,
+        message: `MCP servers ${formattedServers} are configured but not connected for this session yet. MCP tools will appear here after an agent run discovers them.`,
+        servers,
       };
     default:
       // Exhaustiveness guard for oxlint's consistent-return rule.

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -140,7 +140,7 @@ function effectiveToolsResponse(serverName = "github") {
   };
 }
 
-function undiscoveredMcpToolsResponse(serverName = "github") {
+function undiscoveredMcpToolsResponse(serverName = "github", scoped = true) {
   return {
     agentId: "main",
     profile: "full",
@@ -150,6 +150,7 @@ function undiscoveredMcpToolsResponse(serverName = "github") {
         id: "mcp-not-yet-connected",
         severity: "info",
         message: `MCP servers "${serverName}" are configured but not connected for this session yet. MCP tools will appear here after an agent run discovers them.`,
+        ...(scoped ? { servers: [serverName] } : {}),
       },
     ],
   };
@@ -467,7 +468,59 @@ describeControlUiE2e("Control UI composer capability menu", () => {
     }
   });
 
-  it("shows the effective-tools discovery notice while an MCP catalog has no rows", async () => {
+  it("scopes effective-tools discovery notices to their connector", async () => {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
+      methodResponses: {
+        "config.get": configResponse({
+          github: { url: "https://mcp.example.test", enabled: true },
+          notion: { command: "notion-mcp", enabled: true },
+        }),
+        "sessions.list": sessionsList(),
+        "tools.effective": undiscoveredMcpToolsResponse(),
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const composer = await openMenu(page);
+      const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
+      await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
+      await menu.getByRole("menuitem", { name: "Tool access" }).first().click();
+
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("tools:github");
+      await expect
+        .poll(() =>
+          menu
+            .getByText("MCP tools will appear here after an agent run discovers them.")
+            .isVisible(),
+        )
+        .toBe(true);
+      await expect
+        .poll(() => menu.getByText("No tools available for this connector.").count())
+        .toBe(0);
+      await expect.poll(() => menu.getByText("0 of 0 tools on").count()).toBe(0);
+
+      await menu.getByRole("menuitem", { name: "Back" }).click();
+      await menu.getByRole("menuitem", { name: "Tool access" }).nth(1).click();
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("tools:notion");
+      await expect
+        .poll(() =>
+          menu.getByText("MCP tools will appear here after an agent run discovers them.").count(),
+        )
+        .toBe(0);
+      await expect
+        .poll(() => menu.getByText("No tools available for this connector.").isVisible())
+        .toBe(true);
+      await expect.poll(() => menu.getByText("0 of 0 tools on").count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("uses the generic empty state for an unscoped discovery notice", async () => {
     const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
     const page = await context.newPage();
     await installMockGateway(page, {
@@ -477,7 +530,7 @@ describeControlUiE2e("Control UI composer capability menu", () => {
           github: { url: "https://mcp.example.test", enabled: true },
         }),
         "sessions.list": sessionsList(),
-        "tools.effective": undiscoveredMcpToolsResponse(),
+        "tools.effective": undiscoveredMcpToolsResponse("github", false),
       },
     });
 
@@ -490,14 +543,12 @@ describeControlUiE2e("Control UI composer capability menu", () => {
 
       await expect.poll(() => menu.getAttribute("data-view")).toBe("tools:github");
       await expect
-        .poll(() =>
-          menu
-            .getByText("MCP tools will appear here after an agent run discovers them.")
-            .isVisible(),
-        )
+        .poll(() => menu.getByText("No tools available for this connector.").isVisible())
         .toBe(true);
       await expect
-        .poll(() => menu.getByText("No tools available for this connector.").count())
+        .poll(() =>
+          menu.getByText("MCP tools will appear here after an agent run discovers them.").count(),
+        )
         .toBe(0);
       await expect.poll(() => menu.getByText("0 of 0 tools on").count()).toBe(0);
     } finally {

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -140,6 +140,21 @@ function effectiveToolsResponse(serverName = "github") {
   };
 }
 
+function undiscoveredMcpToolsResponse(serverName = "github") {
+  return {
+    agentId: "main",
+    profile: "full",
+    groups: [],
+    notices: [
+      {
+        id: "mcp-not-yet-connected",
+        severity: "info",
+        message: `MCP servers "${serverName}" are configured but not connected for this session yet. MCP tools will appear here after an agent run discovers them.`,
+      },
+    ],
+  };
+}
+
 async function latestToolOverrides(gateway: MockGatewayControls) {
   const requests = await gateway.getRequests("sessions.patch");
   return (requests.at(-1)?.params as { toolOverrides?: unknown } | undefined)?.toolOverrides;
@@ -447,6 +462,44 @@ describeControlUiE2e("Control UI composer capability menu", () => {
       await expect.poll(() => menu.getAttribute("data-view")).toBe("tools:constructor");
       await expect.poll(() => menu.getByText("3 of 3 tools on").isVisible()).toBe(true);
       await expect.poll(() => menu.locator('wa-dropdown-item[value^="mcp-tool:"]').count()).toBe(3);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("shows the effective-tools discovery notice while an MCP catalog has no rows", async () => {
+    const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "tools.effective"],
+      methodResponses: {
+        "config.get": configResponse({
+          github: { url: "https://mcp.example.test", enabled: true },
+        }),
+        "sessions.list": sessionsList(),
+        "tools.effective": undiscoveredMcpToolsResponse(),
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const composer = await openMenu(page);
+      const menu = composer.locator("wa-dropdown.agent-chat__capability-menu");
+      await menu.getByRole("menuitem", { name: /^Connectors/ }).click();
+      await menu.getByRole("menuitem", { name: "Tool access" }).click();
+
+      await expect.poll(() => menu.getAttribute("data-view")).toBe("tools:github");
+      await expect
+        .poll(() =>
+          menu
+            .getByText("MCP tools will appear here after an agent run discovers them.")
+            .isVisible(),
+        )
+        .toBe(true);
+      await expect
+        .poll(() => menu.getByText("No tools available for this connector.").count())
+        .toBe(0);
+      await expect.poll(() => menu.getByText("0 of 0 tools on").count()).toBe(0);
     } finally {
       await context.close();
     }

--- a/ui/src/pages/chat/components/chat-composer-plus-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-plus-menu.ts
@@ -324,8 +324,11 @@ const MCP_DISCOVERY_NOTICE_IDS = new Set([
   "mcp-stale-catalog",
 ]);
 
-function mcpDiscoveryNotice(result: ToolsEffectiveResult | null) {
-  return result?.notices?.find((notice) => MCP_DISCOVERY_NOTICE_IDS.has(notice.id));
+function mcpDiscoveryNotice(result: ToolsEffectiveResult | null, serverName: string) {
+  return result?.notices?.find(
+    (notice) =>
+      MCP_DISCOVERY_NOTICE_IDS.has(notice.id) && notice.servers?.includes(serverName) === true,
+  );
 }
 
 function isToolDenied(props: ChatComposerPlusMenuProps, tool: ToolsEffectiveEntry): boolean {
@@ -345,7 +348,7 @@ function isToolDenied(props: ChatComposerPlusMenuProps, tool: ToolsEffectiveEntr
 function renderToolAccessView(props: ChatComposerPlusMenuProps, serverName: string) {
   const tools = toolsForServer(props.toolsEffectiveResult, serverName);
   const discoveryNotice =
-    tools.length === 0 ? mcpDiscoveryNotice(props.toolsEffectiveResult) : null;
+    tools.length === 0 ? mcpDiscoveryNotice(props.toolsEffectiveResult, serverName) : null;
   const enabledCount = tools.filter((tool) => !isToolDenied(props, tool)).length;
   const summary = t(
     tools.length === 1

--- a/ui/src/pages/chat/components/chat-composer-plus-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-plus-menu.ts
@@ -318,6 +318,16 @@ function toolsForServer(
     );
 }
 
+const MCP_DISCOVERY_NOTICE_IDS = new Set([
+  "mcp-not-yet-connected",
+  "mcp-not-yet-listed",
+  "mcp-stale-catalog",
+]);
+
+function mcpDiscoveryNotice(result: ToolsEffectiveResult | null) {
+  return result?.notices?.find((notice) => MCP_DISCOVERY_NOTICE_IDS.has(notice.id));
+}
+
 function isToolDenied(props: ChatComposerPlusMenuProps, tool: ToolsEffectiveEntry): boolean {
   const serverName = tool.mcpServer;
   const rawToolName = tool.mcpToolName;
@@ -334,6 +344,8 @@ function isToolDenied(props: ChatComposerPlusMenuProps, tool: ToolsEffectiveEntr
 
 function renderToolAccessView(props: ChatComposerPlusMenuProps, serverName: string) {
   const tools = toolsForServer(props.toolsEffectiveResult, serverName);
+  const discoveryNotice =
+    tools.length === 0 ? mcpDiscoveryNotice(props.toolsEffectiveResult) : null;
   const enabledCount = tools.filter((tool) => !isToolDenied(props, tool)).length;
   const summary = t(
     tools.length === 1
@@ -349,45 +361,51 @@ function renderToolAccessView(props: ChatComposerPlusMenuProps, serverName: stri
       ? html`<div class="agent-chat__capability-menu-state" role="alert">
           ${t("chat.composer.menu.toolAccess.loadFailed")}
         </div>`
-      : tools.length === 0
-        ? html`<div class="agent-chat__capability-menu-state">
-            ${t("chat.composer.menu.toolAccess.noTools")}
+      : discoveryNotice
+        ? html`<div class="agent-chat__capability-menu-state" role="status">
+            ${discoveryNotice.message}
           </div>`
-        : tools.map((tool, index) => {
-            const rawToolName = tool.mcpToolName;
-            const label = tool.label?.trim();
-            const denied = isToolDenied(props, tool);
-            return html`
-              <wa-dropdown-item
-                class="agent-chat__capability-menu-item agent-chat__capability-menu-toggle"
-                value=${`mcp-tool:${index}`}
-                ?disabled=${props.toolAccessMutationBlockedReason !== null}
-                title=${props.toolAccessMutationBlockedReason ?? ""}
-              >
-                <span class="agent-chat__capability-menu-label">
-                  <span>${rawToolName}</span>
-                  ${label && label !== rawToolName
-                    ? html`<span class="agent-chat__capability-menu-note">${label}</span>`
-                    : nothing}
-                </span>
-                <wa-switch
-                  slot="details"
-                  class="agent-chat__capability-menu-switch"
-                  size="s"
-                  tabindex="-1"
-                  .checked=${!denied}
+        : tools.length === 0
+          ? html`<div class="agent-chat__capability-menu-state">
+              ${t("chat.composer.menu.toolAccess.noTools")}
+            </div>`
+          : tools.map((tool, index) => {
+              const rawToolName = tool.mcpToolName;
+              const label = tool.label?.trim();
+              const denied = isToolDenied(props, tool);
+              return html`
+                <wa-dropdown-item
+                  class="agent-chat__capability-menu-item agent-chat__capability-menu-toggle"
+                  value=${`mcp-tool:${index}`}
                   ?disabled=${props.toolAccessMutationBlockedReason !== null}
-                  aria-label=${rawToolName}
-                ></wa-switch>
-              </wa-dropdown-item>
-            `;
-          });
+                  title=${props.toolAccessMutationBlockedReason ?? ""}
+                >
+                  <span class="agent-chat__capability-menu-label">
+                    <span>${rawToolName}</span>
+                    ${label && label !== rawToolName
+                      ? html`<span class="agent-chat__capability-menu-note">${label}</span>`
+                      : nothing}
+                  </span>
+                  <wa-switch
+                    slot="details"
+                    class="agent-chat__capability-menu-switch"
+                    size="s"
+                    tabindex="-1"
+                    .checked=${!denied}
+                    ?disabled=${props.toolAccessMutationBlockedReason !== null}
+                    aria-label=${rawToolName}
+                  ></wa-switch>
+                </wa-dropdown-item>
+              `;
+            });
   return html`
     ${renderBackRow()}
     <div class="agent-chat__capability-menu-state">
       <span class="agent-chat__capability-menu-label">
         <strong translate="no">${serverName}</strong>
-        <span class="agent-chat__capability-menu-note">${summary}</span>
+        ${tools.length > 0
+          ? html`<span class="agent-chat__capability-menu-note">${summary}</span>`
+          : nothing}
       </span>
     </div>
     ${rows}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users opening Control UI composer → Connectors → Tool access would see `0 of 0 tools on` and “No tools available for this connector” even after the selected MCP connector had visibly run tools in the same session.

## Why This Change Was Made

The effective-tools RPC already explains unavailable MCP catalogs with `mcp-not-yet-connected`, `mcp-not-yet-listed`, and `mcp-stale-catalog` notices. The connector view now presents that server-owned explanation whenever no matching MCP rows are available and omits the false zero-count summary. It preserves the generic no-tools fallback for responses without a discovery notice.

The live session uses the Codex app-server runtime, whose thread-owned MCP catalog is distinct from the core in-process `SessionMcpRuntime` consulted by `tools.effective`. Bridging those catalogs needs a separate harness/plugin inventory lifecycle design; this fix does not weaken MCP identity filtering or infer tool identity from transcript events.

## User Impact

Operators now see why connector tools are not listable yet instead of being told that the connector has no tools.

## Evidence

- Live repro before: session transcript showed `ctx7.resolve-library-id` and `ctx7.query-docs`, while Tool access rendered `0 of 0 tools on` and “No tools available for this connector.”
- Live RPC before and after: `tools.effective` returned no `source: "mcp"` rows plus `mcp-not-yet-connected` for `ctx7`.
- Live browser after rebuilding and restarting the isolated Gateway: Tool access rendered “MCP tools will appear here after an agent run discovers them,” with neither false empty-state string present.
- Focused Control UI E2E: `9 passed` in `ui/src/e2e/chat-composer-capability-menu.e2e.test.ts`.
- `pnpm ui:build` passed, including precompressed-asset and Control UI performance checks.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- After rebasing onto current `main`, the composer E2E and the upstream-repaired Agents channel E2E passed together: 2 files, 10 tests.

### Before

<img width="295" height="145" alt="Tool access before: false empty state" src="https://github.com/user-attachments/assets/3cd214c9-f4b8-4b8b-8fe0-4b043f709db6" />

### After

<img width="584" height="346" alt="Tool access after: MCP discovery notice" src="https://github.com/user-attachments/assets/c28c8816-b9db-4402-8061-2660cb8960fe" />
