### PR TITLE
test(ui): stop agent tool chip hash pollution

### DIFF
--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -1,6 +1,6 @@
 // Control UI tests cover agents panels tools skills behavior.
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { SkillStatusEntry } from "../../api/types.ts";
 import { installBrowserHistoryIsolation } from "../../test-helpers/browser-history.ts";
 import { renderAgentSkills, renderAgentTools } from "./panels-tools-skills.ts";
@@ -420,19 +420,23 @@ describe("agents tools panel (browser)", () => {
     expect(group.open).toBe(false);
     expect(tool.open).toBe(false);
 
-    const previousUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    const replaceState = vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
     try {
       chip.click();
       await new Promise((resolve) => {
         requestAnimationFrame(resolve);
       });
 
+      expect(replaceState).toHaveBeenCalledWith(
+        null,
+        "",
+        expect.objectContaining({ hash: "#agent-tool-read" }),
+      );
+      expect(window.location.hash).toBe("");
       expect(group.open).toBe(true);
       expect(tool.open).toBe(true);
     } finally {
-      // Hash links mutate shared jsdom history; restore the actual prior URL
-      // so a later Settings route never inherits this tool-card deep link.
-      window.history.replaceState({}, "", previousUrl);
+      replaceState.mockRestore();
       container.remove();
     }
   });


### PR DESCRIPTION
Closes #115355

## What Problem This Solves

Fixes an issue where the agents tools panel browser test could mutate shared jsdom history by clicking the `#agent-tool-read` runtime-tool chip, allowing a leftover fragment to affect later UI tests in the same worker.

## Why This Change Was Made

The test now stubs `window.history.replaceState` around the chip click and asserts that the handler requested the expected `#agent-tool-read` deep link. This preserves the runtime-tool jump coverage while avoiding timing-sensitive cleanup after a real shared-history mutation.

Disclosure: AI was used to understand the codebase and review the fix.

## User Impact

There is no runtime user-visible behavior change. Contributors and CI get a more isolated UI test, so unrelated Settings route tests are not exposed to an agent-tool hash left behind by this test.

## Evidence

Latest pushed head: `ea4e296006036e2ee981d755e1e10f36fe9e1605`.

Before:

```text
The test clicked the real hash link and then restored the previous URL in cleanup, so it still depended on shared jsdom history being reset after mutation.
```

After:

```text
The test verifies the requested deep link through a scoped replaceState spy.
The test asserts window.location.hash remains empty after the chip click.
```

Current-head assertion excerpt:

```text
expect(replaceState).toHaveBeenCalledWith(
  null,
  "",
  expect.objectContaining({ hash: "#agent-tool-read" }),
);
expect(window.location.hash).toBe("");
expect(group.open).toBe(true);
expect(tool.open).toBe(true);
```

Focused local validation after rebasing onto current `main`:

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/pages/agents/panels-tools-skills.browser.test.ts ui/src/pages/config/config-page.test.ts --maxWorkers=1
Test Files  2 passed (2)
Tests  33 passed (33)

$ pnpm_config_verify_deps_before_run=false pnpm format:check ui/src/pages/agents/panels-tools-skills.browser.test.ts
Checking formatting...
All matched files use the correct format.

$ git diff --check origin/main...HEAD
exit 0
```

Current proof limitation:

```text
This is a browser-test isolation fix, not a runtime UI behavior change. The proof exercises the affected shared-worker UI test pair and verifies that the changed test preserves the deep-link request while leaving window.location.hash empty.
```
