### PR TITLE
feat(mac): hand off gateway-owned settings panes to the dashboard

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -29979,7 +29979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 765,
+      "line": 774,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host)",
       "surface": "apple",
@@ -29987,7 +29987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 765,
+      "line": 774,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host):\\(port)",
       "surface": "apple",
@@ -31818,8 +31818,32 @@
       "id": "native.apple.2be6d3dd1a0d2699"
     },
     {
+      "kind": "ui-call",
+      "line": 18,
+      "path": "apps/macos/Sources/OpenClaw/DashboardHandoffSettingsView.swift",
+      "source": "This configuration lives on your gateway and is managed in the Dashboard.",
+      "surface": "apple",
+      "id": "native.apple.179c8c2ce733969f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 24,
+      "path": "apps/macos/Sources/OpenClaw/DashboardHandoffSettingsView.swift",
+      "source": "Open in Dashboard",
+      "surface": "apple",
+      "id": "native.apple.d5271d97a623ac24"
+    },
+    {
+      "kind": "ui-call",
+      "line": 30,
+      "path": "apps/macos/Sources/OpenClaw/DashboardHandoffSettingsView.swift",
+      "source": "The legacy native pane can be re-enabled in Settings > Debug.",
+      "surface": "apple",
+      "id": "native.apple.40bf972bb1164409"
+    },
+    {
       "kind": "ui-named-argument",
-      "line": 222,
+      "line": 223,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Dashboard reconnecting",
       "surface": "apple",
@@ -31827,7 +31851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 223,
+      "line": 224,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "The selected Gateway changed.",
       "surface": "apple",
@@ -31835,7 +31859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 224,
+      "line": 225,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Waiting for a fresh authenticated connection.",
       "surface": "apple",
@@ -31843,7 +31867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 362,
+      "line": 381,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Dashboard unavailable",
       "surface": "apple",
@@ -31851,7 +31875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 364,
+      "line": 383,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
       "surface": "apple",
@@ -31859,7 +31883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 566,
+      "line": 589,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Could Not Switch Gateway",
       "surface": "apple",
@@ -31867,7 +31891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 594,
+      "line": 617,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Could Not Open Gateway Window",
       "surface": "apple",
@@ -31875,7 +31899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 698,
+      "line": 721,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "\\(base)-\\(UUID().uuidString)",
       "surface": "apple",
@@ -31883,7 +31907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 938,
+      "line": 961,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Could Not Set Primary Gateway",
       "surface": "apple",
@@ -31891,7 +31915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 907,
+      "line": 911,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",
@@ -32021,13 +32045,37 @@
       "kind": "ui-call",
       "line": 170,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
+      "source": "Settings",
+      "surface": "apple",
+      "id": "native.apple.b6368b2fc209fa07"
+    },
+    {
+      "kind": "ui-call",
+      "line": 172,
+      "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
+      "source": "Show native settings panes",
+      "surface": "apple",
+      "id": "native.apple.388a46bbd1d3df81"
+    },
+    {
+      "kind": "ui-call",
+      "line": 173,
+      "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
+      "source": "These panes are being retired in favor of the Dashboard.",
+      "surface": "apple",
+      "id": "native.apple.bac23cf85e38c7cc"
+    },
+    {
+      "kind": "ui-call",
+      "line": 179,
+      "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Binary path",
       "surface": "apple",
       "id": "native.apple.6ae192c6a5942a53"
     },
     {
       "kind": "ui-call",
-      "line": 187,
+      "line": 196,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Status",
       "surface": "apple",
@@ -32035,7 +32083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 197,
+      "line": 206,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Key",
       "surface": "apple",
@@ -32043,7 +32091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 206,
+      "line": 215,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Copy",
       "surface": "apple",
@@ -32051,7 +32099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 211,
+      "line": 220,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Copy sample URL",
       "surface": "apple",
@@ -32059,7 +32107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 222,
+      "line": 231,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Deep links (openclaw://…) are always enabled; the key controls unattended runs.",
       "surface": "apple",
@@ -32067,7 +32115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 227,
+      "line": 236,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Stdout / stderr",
       "surface": "apple",
@@ -32075,7 +32123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 244,
+      "line": 253,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart Gateway",
       "surface": "apple",
@@ -32083,7 +32131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 246,
+      "line": 255,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Clear log",
       "surface": "apple",
@@ -32091,7 +32139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 259,
+      "line": 268,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Pino log",
       "surface": "apple",
@@ -32099,7 +32147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 262,
+      "line": 271,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Open",
       "surface": "apple",
@@ -32107,7 +32155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 284,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "App logging",
       "surface": "apple",
@@ -32115,7 +32163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 277,
+      "line": 286,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Verbosity",
       "surface": "apple",
@@ -32123,7 +32171,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 284,
+      "line": 293,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Controls the macOS app log verbosity.",
       "surface": "apple",
@@ -32131,7 +32179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 286,
+      "line": 295,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Write rolling diagnostics log (JSONL)",
       "surface": "apple",
@@ -32139,7 +32187,7 @@
     },
     {
       "kind": "ui-modifier-concatenated",
-      "line": 289,
+      "line": 298,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Writes a rotating, local-only log under ~/Library/Logs/OpenClaw/. Enable only while actively debugging.",
       "surface": "apple",
@@ -32147,7 +32195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 293,
+      "line": 302,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Open folder",
       "surface": "apple",
@@ -32155,7 +32203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 297,
+      "line": 306,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Clear",
       "surface": "apple",
@@ -32163,7 +32211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 318,
+      "line": 327,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Port diagnostics",
       "surface": "apple",
@@ -32171,7 +32219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 322,
+      "line": 331,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Check gateway ports",
       "surface": "apple",
@@ -32179,7 +32227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 327,
+      "line": 336,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reset SSH tunnel",
       "surface": "apple",
@@ -32187,7 +32235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 348,
+      "line": 357,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Check which process owns \\(GatewayEnvironment.gatewayPort()) and suggest fixes.",
       "surface": "apple",
@@ -32195,7 +32243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 354,
+      "line": 363,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Port \\(report.port)",
       "surface": "apple",
@@ -32203,7 +32251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 363,
+      "line": 372,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "\\(listener.command) (\\(listener.pid))",
       "surface": "apple",
@@ -32211,7 +32259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 368,
+      "line": 377,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Kill",
       "surface": "apple",
@@ -32219,7 +32267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 397,
+      "line": 406,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "OpenClaw project root",
       "surface": "apple",
@@ -32227,7 +32275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 400,
+      "line": 409,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Path to openclaw repo",
       "surface": "apple",
@@ -32235,7 +32283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 406,
+      "line": 415,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reset",
       "surface": "apple",
@@ -32243,7 +32291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 414,
+      "line": 423,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Used for pnpm/node fallback and PATH population when launching the gateway.",
       "surface": "apple",
@@ -32251,7 +32299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 423,
+      "line": 432,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Session store",
       "surface": "apple",
@@ -32259,7 +32307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 426,
+      "line": 435,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Path",
       "surface": "apple",
@@ -32267,7 +32315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 430,
+      "line": 439,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Save",
       "surface": "apple",
@@ -32275,7 +32323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 438,
+      "line": 447,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Used by the CLI session loader; stored in ~/.openclaw/openclaw.json.",
       "surface": "apple",
@@ -32283,7 +32331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 453,
+      "line": 462,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Send Test Notification",
       "surface": "apple",
@@ -32291,7 +32339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 458,
+      "line": 467,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Open Agent Events",
       "surface": "apple",
@@ -32299,7 +32347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 471,
+      "line": 480,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Send debug voice",
       "surface": "apple",
@@ -32307,7 +32355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 471,
+      "line": 480,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Sending debug voice…",
       "surface": "apple",
@@ -32315,7 +32363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 487,
+      "line": 496,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Uses the Voice Wake path: forwards over SSH when configured,\notherwise runs locally via rpc.",
       "surface": "apple",
@@ -32323,7 +32371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 499,
+      "line": 508,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Note: macOS may require restarting OpenClaw after enabling Accessibility or Screen Recording.",
       "surface": "apple",
@@ -32331,7 +32379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 508,
+      "line": 517,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart OpenClaw",
       "surface": "apple",
@@ -32339,7 +32387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 515,
+      "line": 524,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart app",
       "surface": "apple",
@@ -32347,7 +32395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 516,
+      "line": 525,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart onboarding",
       "surface": "apple",
@@ -32355,7 +32403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 517,
+      "line": 526,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reveal app in Finder",
       "surface": "apple",
@@ -32363,7 +32411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 528,
+      "line": 537,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Enable/disable Canvas in General settings.",
       "surface": "apple",
@@ -32371,7 +32419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 533,
+      "line": 542,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Session",
       "surface": "apple",
@@ -32379,7 +32427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 537,
+      "line": 546,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Show panel",
       "surface": "apple",
@@ -32387,7 +32435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 541,
+      "line": 550,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Hide panel",
       "surface": "apple",
@@ -32395,7 +32443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 547,
+      "line": 556,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Write sample page",
       "surface": "apple",
@@ -32403,7 +32451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 555,
+      "line": 564,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Eval JS",
       "surface": "apple",
@@ -32411,7 +32459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 559,
+      "line": 568,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Eval",
       "surface": "apple",
@@ -32419,7 +32467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 563,
+      "line": 572,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Snapshot",
       "surface": "apple",
@@ -32427,7 +32475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 577,
+      "line": 586,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "eval → \\(canvasEvalResult)",
       "surface": "apple",
@@ -32435,7 +32483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 586,
+      "line": 595,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "snapshot → \\(canvasSnapshotPath)",
       "surface": "apple",
@@ -32443,7 +32491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 592,
+      "line": 601,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reveal",
       "surface": "apple",
@@ -32451,7 +32499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 605,
+      "line": 614,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Tip: the session directory is returned by “Show panel”.",
       "surface": "apple",
@@ -32459,7 +32507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 617,
+      "line": 626,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Icon override",
       "surface": "apple",
@@ -32467,7 +32515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 627,
+      "line": 636,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Chat",
       "surface": "apple",
@@ -32475,7 +32523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 628,
+      "line": 637,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Native SwiftUI",
       "surface": "apple",
@@ -32483,7 +32531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 941,
+      "line": 950,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Unknown",
       "surface": "apple",
@@ -32491,7 +32539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 942,
+      "line": 951,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Healthy",
       "surface": "apple",
@@ -32499,7 +32547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 943,
+      "line": 952,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Needs Link",
       "surface": "apple",
@@ -32507,7 +32555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 944,
+      "line": 953,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Degraded",
       "surface": "apple",
@@ -32515,7 +32563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1011,
+      "line": 1020,
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Test",
       "surface": "apple",
@@ -37867,7 +37915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 179,
+      "line": 180,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Managed by Nix",
       "surface": "apple",
@@ -37875,7 +37923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 185,
+      "line": 186,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Config: \\(configPath)",
       "surface": "apple",
@@ -37883,15 +37931,31 @@
     },
     {
       "kind": "ui-call",
-      "line": 186,
+      "line": 187,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "State:  \\(stateDir)",
       "surface": "apple",
       "id": "native.apple.96221e7b3b153764"
     },
     {
+      "kind": "ui-call",
+      "line": 276,
+      "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
+      "source": "Legacy pane — this now lives in the Dashboard",
+      "surface": "apple",
+      "id": "native.apple.82152767dcda7601"
+    },
+    {
+      "kind": "ui-call",
+      "line": 280,
+      "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
+      "source": "Open in Dashboard",
+      "surface": "apple",
+      "id": "native.apple.07f054b73f23bcb1"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 477,
+      "line": 510,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "General",
       "surface": "apple",
@@ -37899,7 +37963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 478,
+      "line": 511,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Connection",
       "surface": "apple",
@@ -37907,7 +37971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 479,
+      "line": 512,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Gateways",
       "surface": "apple",
@@ -37915,7 +37979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 480,
+      "line": 513,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Permissions",
       "surface": "apple",
@@ -37923,7 +37987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 481,
+      "line": 514,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Voice & Talk",
       "surface": "apple",
@@ -37931,7 +37995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 482,
+      "line": 515,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -37939,7 +38003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 483,
+      "line": 516,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Channels",
       "surface": "apple",
@@ -37947,7 +38011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 484,
+      "line": 517,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Skills",
       "surface": "apple",
@@ -37955,7 +38019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 485,
+      "line": 518,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -37963,7 +38027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 486,
+      "line": 519,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Exec Approvals",
       "surface": "apple",
@@ -37971,7 +38035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 487,
+      "line": 520,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Threads",
       "surface": "apple",
@@ -37979,7 +38043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 488,
+      "line": 521,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Instances",
       "surface": "apple",
@@ -37987,7 +38051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 489,
+      "line": 522,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Config",
       "surface": "apple",
@@ -37995,7 +38059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 490,
+      "line": 523,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Debug",
       "surface": "apple",
@@ -38003,7 +38067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 491,
+      "line": 524,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "About",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -31915,7 +31915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 911,
+      "line": 903,
       "path": "apps/macos/Sources/OpenClaw/DashboardWindowController.swift",
       "source": "[\\(host)]",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -88,6 +88,14 @@ final class AppState {
         }
     }
 
+    var nativeSettingsPanesEnabled: Bool {
+        didSet {
+            self.ifNotPreview {
+                UserDefaults.standard.set(self.nativeSettingsPanesEnabled, forKey: nativeSettingsPanesEnabledKey)
+            }
+        }
+    }
+
     var swabbleEnabled: Bool {
         didSet {
             self.ifNotPreview {
@@ -344,6 +352,7 @@ final class AppState {
         self.launchAtLogin = false
         self.onboardingSeen = onboardingSeen
         self.debugPaneEnabled = UserDefaults.standard.bool(forKey: debugPaneEnabledKey)
+        self.nativeSettingsPanesEnabled = UserDefaults.standard.bool(forKey: nativeSettingsPanesEnabledKey)
         let savedVoiceWake = UserDefaults.standard.bool(forKey: swabbleEnabledKey)
         self.swabbleEnabled = voiceWakeSupported ? savedVoiceWake : false
         self.swabbleTriggerWords = UserDefaults.standard
@@ -1190,6 +1199,7 @@ extension AppState {
         state.launchAtLogin = true
         state.onboardingSeen = true
         state.debugPaneEnabled = true
+        state.nativeSettingsPanesEnabled = true
         state.swabbleEnabled = true
         state.swabbleTriggerWords = ["Claude", "Computer", "Jarvis"]
         state.voiceWakeTriggerChime = .system(name: "Glass")

--- a/apps/macos/Sources/OpenClaw/Constants.swift
+++ b/apps/macos/Sources/OpenClaw/Constants.swift
@@ -61,6 +61,7 @@ let cliValidatedVersionKey = "openclaw.cliValidatedVersion"
 let macNodeIdentityProfileKey = "openclaw.macNodeIdentityProfile"
 let heartbeatsEnabledKey = "openclaw.heartbeatsEnabled"
 let debugPaneEnabledKey = "openclaw.debugPaneEnabled"
+let nativeSettingsPanesEnabledKey = "openclaw.nativeSettingsPanesEnabled"
 let debugFileLogEnabledKey = "openclaw.debug.fileLogEnabled"
 let appLogLevelKey = "openclaw.debug.appLogLevel"
 let voiceWakeSupported: Bool = ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26

--- a/apps/macos/Sources/OpenClaw/DashboardHandoffSettingsView.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardHandoffSettingsView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct DashboardHandoffSettingsView: View {
+    let tab: SettingsTab
+    let dashboardRoute: String
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Spacer()
+
+            Image(systemName: self.tab.systemImage)
+                .font(.system(size: 42, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 7) {
+                Text(self.tab.title)
+                    .font(.title2.weight(.semibold))
+                Text("This configuration lives on your gateway and is managed in the Dashboard.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            Button("Open in Dashboard") {
+                Task { await DashboardManager.shared.show(atPath: self.dashboardRoute) }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+
+            Text("The legacy native pane can be re-enabled in Settings > Debug.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(32)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -31,6 +31,7 @@ final class DashboardManager {
     @ObservationIgnored private var endpointTask: Task<Void, Never>?
     @ObservationIgnored private var pendingOpenCommands: [DashboardNativeCommand] = []
     @ObservationIgnored private var openForCommandTask: Task<Void, Never>?
+    @ObservationIgnored private var navigationGeneration: UInt64 = 0
     @ObservationIgnored private var updater: UpdaterProviding?
     @ObservationIgnored private var displayedRouteRevision: UInt64?
     @ObservationIgnored private var switchGenerations: [ObjectIdentifier: UInt64] = [:]
@@ -346,6 +347,24 @@ final class DashboardManager {
         Task { _ = try? await ControlChannel.shared.health(timeout: 3) }
     }
 
+    func show(atPath path: String) async {
+        self.navigationGeneration &+= 1
+        let generation = self.navigationGeneration
+        do {
+            try await self.show()
+            guard generation == self.navigationGeneration else { return }
+            guard let controller,
+                  let fallbackURL = DashboardRouteMap.dashboardURL(
+                      byAppendingSameAppPath: path,
+                      to: controller.dashboardBaseURL)
+            else { return }
+            controller.dispatchNativeNavigation(DashboardNativeNavigation(path: path, fallbackURL: fallbackURL))
+        } catch {
+            guard generation == self.navigationGeneration else { return }
+            self.showFailure(error)
+        }
+    }
+
     func showFailure(_ error: Error) {
         let message = (error as NSError).localizedDescription
         dashboardManagerLogger.error("dashboard setup failed error=\(message, privacy: .public)")
@@ -405,6 +424,10 @@ final class DashboardManager {
     }
 
     func dispatchNativeCommand(_ command: DashboardNativeCommand) {
+        if command.supersedesPendingNavigation {
+            // This also invalidates a handoff still suspended in show(atPath:).
+            self.navigationGeneration &+= 1
+        }
         NSApp.activate(ignoringOtherApps: true)
         if let controller, controller.isWindowOpen, controller.canDeliverNativeCommands {
             controller.show()

--- a/apps/macos/Sources/OpenClaw/DashboardWindow.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindow.swift
@@ -55,6 +55,15 @@ enum DashboardNativeCommand: String {
         case .commandPalette: "openclaw:native-open-search"
         }
     }
+
+    var supersedesPendingNavigation: Bool {
+        self == .newSession
+    }
+}
+
+struct DashboardNativeNavigation: Equatable {
+    let path: String
+    let fallbackURL: URL
 }
 
 enum DashboardLinkTarget: String, Equatable {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -406,20 +406,6 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         return window.isVisible || window.isMiniaturized
     }
 
-    /// Commands are deliverable when a document is live or a load is in flight
-    /// (the queue flushes at `didFinish`). A failure page, or a terminally
-    /// cancelled load with no successor, needs a reload before dispatch —
-    /// otherwise queued ⌘N/⌘K would wait on a `didFinish` that never comes.
-    var canDeliverNativeCommands: Bool {
-        !self.isShowingFailurePage && (self.hasLiveContent || self.webView.isLoading)
-    }
-
-    /// The canonical Dashboard mount URL supplied by the manager. WebKit route
-    /// loads and SPA history do not mutate it, so native fallbacks stay rooted.
-    var dashboardBaseURL: URL {
-        self.currentURL
-    }
-
     func show() {
         if let window {
             let frame = window.frame
@@ -1047,6 +1033,20 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 }
 
 extension DashboardWindowController {
+    /// Commands are deliverable when a document is live or a load is in flight
+    /// (the queue flushes at `didFinish`). A failure page, or a terminally
+    /// cancelled load with no successor, needs a reload before dispatch —
+    /// otherwise queued ⌘N/⌘K would wait on a `didFinish` that never comes.
+    var canDeliverNativeCommands: Bool {
+        !self.isShowingFailurePage && (self.hasLiveContent || self.webView.isLoading)
+    }
+
+    /// The canonical Dashboard mount URL supplied by the manager. WebKit route
+    /// loads and SPA history do not mutate it, so native fallbacks stay rooted.
+    var dashboardBaseURL: URL {
+        self.currentURL
+    }
+
     func windowWillClose(_: Notification) {
         self.webView.stopLoading()
         self.closeLinkBrowser(focusDashboard: false)

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -112,7 +112,9 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     private var browserProfileImportOfferRetryPending = false
     private var hasLiveContent = false
     private var isShowingFailurePage = false
+    private var navigationGeneration: UInt64 = 0
     private var pendingNativeCommands: [DashboardNativeCommand] = []
+    private var pendingNativeNavigation: DashboardNativeNavigation?
     var onClosed: (() -> Void)?
 
     init(
@@ -412,6 +414,12 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         !self.isShowingFailurePage && (self.hasLiveContent || self.webView.isLoading)
     }
 
+    /// The canonical Dashboard mount URL supplied by the manager. WebKit route
+    /// loads and SPA history do not mutate it, so native fallbacks stay rooted.
+    var dashboardBaseURL: URL {
+        self.currentURL
+    }
+
     func show() {
         if let window {
             let frame = window.frame
@@ -442,9 +450,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     func showFailure(title: String, message: String, detail: String? = nil) {
         self.hasLiveContent = false
         self.isShowingFailurePage = true
+        self.advanceNavigationGeneration()
         // Queued commands are moment-bound user intent; replaying them after a
         // later recovery reload would toggle or navigate unexpectedly.
         self.pendingNativeCommands = []
+        self.pendingNativeNavigation = nil
         self.currentURL = URL(string: "about:blank")!
         self.auth = DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil)
         self.setUpdateBridgeEnabled(false)
@@ -1017,9 +1027,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         }
         self.hasLiveContent = false
         self.isShowingFailurePage = true
+        self.advanceNavigationGeneration()
         // Same moment-bound rule as showFailure: a terminal load failure
         // invalidates commands queued for the document that never arrived.
         self.pendingNativeCommands = []
+        self.pendingNativeNavigation = nil
         dashboardWindowLogger.error(
             """
             dashboard load failed url=\(dashboardLogString(for: self.currentURL), privacy: .public) \
@@ -1119,9 +1131,15 @@ extension DashboardWindowController {
     }
 
     func dispatchNativeCommand(_ command: DashboardNativeCommand) {
+        if command.supersedesPendingNavigation {
+            self.advanceNavigationGeneration()
+        }
         guard self.hasLiveContent else {
             // Ordered queue, duplicates included: two ⌘K presses while loading
             // must toggle twice, and ⌘N followed by ⌘K must deliver both.
+            if command.supersedesPendingNavigation {
+                self.pendingNativeNavigation = nil
+            }
             self.pendingNativeCommands.append(command)
             return
         }
@@ -1129,6 +1147,9 @@ extension DashboardWindowController {
     }
 
     private func evaluateNativeCommand(_ command: DashboardNativeCommand) {
+        if command.supersedesPendingNavigation {
+            self.advanceNavigationGeneration()
+        }
         guard let fallback = command.legacyFallbackEventName else {
             self.webView.evaluateJavaScript(
                 "window.dispatchEvent(new CustomEvent(\(Self.jsStringLiteral(command.rawValue))))")
@@ -1156,6 +1177,53 @@ extension DashboardWindowController {
         for command in commands {
             self.evaluateNativeCommand(command)
         }
+    }
+
+    func dispatchNativeNavigation(_ navigation: DashboardNativeNavigation) {
+        self.advanceNavigationGeneration()
+        guard self.hasLiveContent else {
+            // Navigation is state selection, so only the newest destination matters while loading.
+            self.pendingNativeNavigation = navigation
+            return
+        }
+        self.evaluateNativeNavigation(navigation)
+    }
+
+    private func evaluateNativeNavigation(_ navigation: DashboardNativeNavigation) {
+        let generation = self.navigationGeneration
+        let sourceURL = self.currentURL
+        let script =
+            """
+            (() => !window.dispatchEvent(new CustomEvent('openclaw:native-navigate', {
+              cancelable: true,
+              detail: {path: \(Self.jsStringLiteral(navigation.path))}
+            })))()
+            """
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = try? await self.webView.evaluateJavaScript(script)
+            let handled = result as? Bool
+            // Async completions may return after another route or New Session intent.
+            // Only the newest navigation intent may load its fallback URL.
+            guard handled != true,
+                  self.navigationFallbackIsCurrent(generation: generation, sourceURL: sourceURL)
+            else { return }
+            self.load(navigation.fallbackURL)
+        }
+    }
+
+    private func advanceNavigationGeneration() {
+        self.navigationGeneration &+= 1
+    }
+
+    private func navigationFallbackIsCurrent(generation: UInt64, sourceURL: URL) -> Bool {
+        self.navigationGeneration == generation && self.currentURL == sourceURL
+    }
+
+    private func flushPendingNativeNavigation() {
+        guard let navigation = self.pendingNativeNavigation else { return }
+        self.pendingNativeNavigation = nil
+        self.evaluateNativeNavigation(navigation)
     }
 }
 
@@ -1285,6 +1353,7 @@ extension DashboardWindowController {
             self.publishNativeHistoryState()
             // History state must reach the shell before a queued command can navigate it.
             self.flushPendingNativeCommands()
+            self.flushPendingNativeNavigation()
         }
     }
 
@@ -1486,6 +1555,18 @@ extension DashboardWindowController {
 
     var _testPendingNativeCommands: [DashboardNativeCommand] {
         self.pendingNativeCommands
+    }
+
+    var _testPendingNativeNavigation: DashboardNativeNavigation? {
+        self.pendingNativeNavigation
+    }
+
+    var _testNavigationGeneration: UInt64 {
+        self.navigationGeneration
+    }
+
+    func _testNavigationFallbackIsCurrent(generation: UInt64, sourceURL: URL) -> Bool {
+        self.navigationFallbackIsCurrent(generation: generation, sourceURL: sourceURL)
     }
 
     var _testNavigationWebViewIdentity: ObjectIdentifier {

--- a/apps/macos/Sources/OpenClaw/DebugSettings.swift
+++ b/apps/macos/Sources/OpenClaw/DebugSettings.swift
@@ -167,6 +167,15 @@ struct DebugSettings: View {
                     Text("\(ProcessInfo.processInfo.processIdentifier)")
                 }
                 GridRow {
+                    self.gridLabel("Settings")
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle("Show native settings panes", isOn: self.$state.nativeSettingsPanesEnabled)
+                        Text("These panes are being retired in favor of the Dashboard.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                GridRow {
                     self.gridLabel("Binary path")
                     Text(Bundle.main.bundlePath)
                         .font(.caption2.monospaced())

--- a/apps/macos/Sources/OpenClaw/SettingsRootView.swift
+++ b/apps/macos/Sources/OpenClaw/SettingsRootView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Observation
+import OpenClawKit
 import SwiftUI
 
 struct SettingsRootView: View {
@@ -212,6 +213,19 @@ struct SettingsRootView: View {
     }
 
     private func detailView(for tab: SettingsTab) -> AnyView {
+        guard let dashboardRoute = tab.dashboardRoute else {
+            return self.nativeDetailView(for: tab)
+        }
+        guard self.state.nativeSettingsPanesEnabled else {
+            return AnyView(DashboardHandoffSettingsView(tab: tab, dashboardRoute: dashboardRoute))
+        }
+        return AnyView(VStack(alignment: .leading, spacing: 10) {
+            self.legacyDashboardBanner(route: dashboardRoute)
+            self.nativeDetailView(for: tab)
+        })
+    }
+
+    private func nativeDetailView(for tab: SettingsTab) -> AnyView {
         switch tab {
         case .general:
             AnyView(GeneralSettings(state: self.state, page: .general, isActive: self.selectedTab == tab))
@@ -253,6 +267,25 @@ struct SettingsRootView: View {
         case .about:
             AnyView(AboutSettings(updater: self.updater))
         }
+    }
+
+    private func legacyDashboardBanner(route: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.secondary)
+            Text("Legacy pane — this now lives in the Dashboard")
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 8)
+            Button("Open in Dashboard") {
+                Task { await DashboardManager.shared.show(atPath: route) }
+            }
+            .buttonStyle(.link)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 10)
+        .background(Color.gray.opacity(0.12))
+        .cornerRadius(10)
     }
 
     private func selectRequestedTab(_ requested: SettingsTab) {
@@ -509,6 +542,18 @@ enum SettingsTab: CaseIterable, Identifiable, Hashable {
         case .config: "slider.horizontal.3"
         case .debug: "ant"
         case .about: "info.circle"
+        }
+    }
+
+    var dashboardRoute: String? {
+        switch self {
+        case .channels: DashboardRouteMap.channelsSettingsPath
+        case .skills: DashboardRouteMap.skillsPagePath
+        case .cron: DashboardRouteMap.cronJobsPagePath
+        case .sessions: DashboardRouteMap.sessionsPagePath
+        case .instances: DashboardRouteMap.devicesSettingsPath
+        case .general, .connection, .gateways, .permissions, .voiceWake, .systemAgent,
+             .execApprovals, .config, .debug, .about: nil
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/SettingsDashboardHandoffTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SettingsDashboardHandoffTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct SettingsDashboardHandoffTests {
+    @Test func `settings tabs use verified Dashboard routes`() {
+        let expected: [SettingsTab: String] = [
+            .channels: "/settings/channels",
+            .skills: "/skills",
+            .cron: "/cron",
+            .sessions: "/sessions",
+            .instances: "/settings/devices",
+        ]
+
+        for tab in SettingsTab.allCases {
+            #expect(tab.dashboardRoute == expected[tab])
+        }
+        // Host-native policy is read-only in the Dashboard; the companion app remains its editor.
+        #expect(SettingsTab.execApprovals.dashboardRoute == nil)
+    }
+
+    @Test func `Dashboard tabs remain selectable while hidden tabs stay gated`() {
+        for tab in SettingsTab.allCases where tab.dashboardRoute != nil {
+            let selection = SettingsRootView.tabSelection(
+                requested: tab,
+                showDebug: false,
+                inferenceConfiguration: .loaded(nil))
+            #expect(selection.selected == tab)
+            #expect(selection.deferred == nil)
+        }
+
+        #expect(SettingsRootView.tabSelection(
+            requested: .debug,
+            showDebug: false,
+            inferenceConfiguration: .loaded(nil)).selected == .general)
+        #expect(SettingsRootView.tabSelection(
+            requested: .systemAgent,
+            showDebug: false,
+            inferenceConfiguration: .loaded(nil)).selected == .general)
+    }
+
+    @Test func `Dashboard navigation queues until the shell loads`() throws {
+        let baseURL = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let fallbackURL = try #require(URL(string: "http://127.0.0.1:18789/control/skills"))
+        let controller = DashboardWindowController(
+            url: baseURL,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+        let navigation = DashboardNativeNavigation(path: "/skills", fallbackURL: fallbackURL)
+
+        controller.dispatchNativeNavigation(navigation)
+
+        #expect(controller._testPendingNativeNavigation == navigation)
+    }
+
+    @Test func `new session supersedes an older queued Dashboard navigation`() throws {
+        let baseURL = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let fallbackURL = try #require(URL(string: "http://127.0.0.1:18789/control/skills"))
+        let controller = DashboardWindowController(
+            url: baseURL,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+
+        controller.dispatchNativeNavigation(DashboardNativeNavigation(
+            path: "/skills",
+            fallbackURL: fallbackURL))
+        let staleGeneration = controller._testNavigationGeneration
+        controller.dispatchNativeCommand(.newSession)
+
+        #expect(controller._testPendingNativeNavigation == nil)
+        #expect(controller._testPendingNativeCommands == [.newSession])
+        #expect(!controller._testNavigationFallbackIsCurrent(
+            generation: staleGeneration,
+            sourceURL: baseURL))
+        #expect(controller.dashboardBaseURL == baseURL)
+    }
+
+    @Test func `newer Dashboard dispatch invalidates stale in-flight fallback`() throws {
+        let baseURL = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let first = DashboardNativeNavigation(
+            path: "/skills",
+            fallbackURL: try #require(URL(string: "http://127.0.0.1:18789/control/skills")))
+        let second = DashboardNativeNavigation(
+            path: "/cron",
+            fallbackURL: try #require(URL(string: "http://127.0.0.1:18789/control/cron")))
+        let controller = DashboardWindowController(
+            url: baseURL,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+
+        controller.dispatchNativeNavigation(first)
+        let staleGeneration = controller._testNavigationGeneration
+        #expect(controller._testNavigationFallbackIsCurrent(
+            generation: staleGeneration,
+            sourceURL: baseURL))
+
+        controller.dispatchNativeNavigation(second)
+
+        #expect(!controller._testNavigationFallbackIsCurrent(
+            generation: staleGeneration,
+            sourceURL: baseURL))
+        #expect(controller._testPendingNativeNavigation == second)
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DashboardRouteMap.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DashboardRouteMap.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public enum DashboardRouteMap {
+    public static let channelsSettingsPath = "/settings/channels"
+    public static let skillsPagePath = "/skills"
+    public static let cronJobsPagePath = "/cron"
+    public static let sessionsPagePath = "/sessions"
+    public static let devicesSettingsPath = "/settings/devices"
+
+    public static func isValidSameAppPath(_ path: String) -> Bool {
+        guard path.hasPrefix("/"), !path.hasPrefix("//"),
+              let components = URLComponents(string: path)
+        else {
+            return false
+        }
+        return components.scheme == nil &&
+            components.host == nil &&
+            components.query == nil &&
+            components.fragment == nil
+    }
+
+    public static func dashboardURL(
+        byAppendingSameAppPath path: String,
+        to baseURL: URL) -> URL?
+    {
+        guard self.isValidSameAppPath(path),
+              var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        else {
+            return nil
+        }
+        let basePath = components.path.hasSuffix("/") ? components.path : components.path + "/"
+        components.path = basePath + path.dropFirst()
+        return components.url
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DashboardRouteMapTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DashboardRouteMapTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import OpenClawKit
+import Testing
+
+struct DashboardRouteMapTests {
+    @Test func `route constants match Control UI paths`() {
+        #expect(DashboardRouteMap.channelsSettingsPath == "/settings/channels")
+        #expect(DashboardRouteMap.skillsPagePath == "/skills")
+        #expect(DashboardRouteMap.cronJobsPagePath == "/cron")
+        #expect(DashboardRouteMap.sessionsPagePath == "/sessions")
+        #expect(DashboardRouteMap.devicesSettingsPath == "/settings/devices")
+    }
+
+    @Test(arguments: ["/settings/channels", "/skills", "/cron"])
+    func `same-app path validation accepts rooted paths`(_ path: String) {
+        #expect(DashboardRouteMap.isValidSameAppPath(path))
+    }
+
+    @Test(arguments: [
+        "",
+        "settings/channels",
+        "//example.com/settings/channels",
+        "https://example.com/settings/channels",
+        "/settings/channels?section=telegram",
+        "/settings/channels#telegram",
+    ])
+    func `same-app path validation rejects external or compound locations`(_ path: String) {
+        #expect(!DashboardRouteMap.isValidSameAppPath(path))
+    }
+
+    @Test func `Dashboard URL appends route and preserves token fragment`() throws {
+        let baseURL = try #require(URL(string: "http://127.0.0.1:18789/control/#token=test-token"))
+        let url = try #require(DashboardRouteMap.dashboardURL(
+            byAppendingSameAppPath: DashboardRouteMap.channelsSettingsPath,
+            to: baseURL))
+
+        #expect(url.absoluteString == "http://127.0.0.1:18789/control/settings/channels#token=test-token")
+    }
+}

--- a/ui/src/app/app-host-native-shell.test.ts
+++ b/ui/src/app/app-host-native-shell.test.ts
@@ -13,6 +13,7 @@ type ShellNavigationState = {
   handleNativeOpenSearch: () => void;
   handleNativeToggleSearch: (event: Event) => void;
   handleNativeNewSession: () => void;
+  handleNativeNavigate: (event: Event) => void;
   handleNativeHistoryState: (event: Event) => void;
   nativeHistoryState: { canGoBack: boolean; canGoForward: boolean };
   onboarding: boolean;
@@ -171,6 +172,47 @@ describe("OpenClaw native shell", () => {
 
     expect(navigate).toHaveBeenCalledExactlyOnceWith("new-session", { search: "?agent=main" });
   });
+
+  it("navigates valid native Dashboard paths and acknowledges them", () => {
+    const navigate = vi.fn();
+    const shell = document.createElement("openclaw-app-shell") as unknown as ShellNavigationState;
+    shell.runtime = {
+      context: {
+        navigate,
+      } as unknown as ApplicationContext,
+    };
+    const event = new CustomEvent("openclaw:native-navigate", {
+      cancelable: true,
+      detail: { path: "/settings/channels" },
+    });
+
+    shell.handleNativeNavigate(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(navigate).toHaveBeenCalledExactlyOnceWith("channels", undefined);
+  });
+
+  it.each(["https://example.com", "//example.com", "/https://example.com", "/unknown"])(
+    "leaves invalid native Dashboard path %s unhandled",
+    (path) => {
+      const navigate = vi.fn();
+      const shell = document.createElement("openclaw-app-shell") as unknown as ShellNavigationState;
+      shell.runtime = {
+        context: {
+          navigate,
+        } as unknown as ApplicationContext,
+      };
+      const event = new CustomEvent("openclaw:native-navigate", {
+        cancelable: true,
+        detail: { path },
+      });
+
+      shell.handleNativeNavigate(event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(navigate).not.toHaveBeenCalled();
+    },
+  );
 
   it("does not start a native session during onboarding", () => {
     const navigate = vi.fn();

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -26,7 +26,7 @@ import "../components/sidebar-update-card.ts";
 import "../components/tooltip.ts";
 import "../components/update-banner.ts";
 import { isSessionRouteId, workboardBoardIdFromPath } from "../app-route-paths.ts";
-import { APP_ROUTE_IDS, isRouteId, type RouteId } from "../app-routes.ts";
+import { APP_ROUTE_IDS, isRouteId, routeIdFromPath, type RouteId } from "../app-routes.ts";
 import {
   EMPTY_SIDEBAR_WORKBOARD_SNAPSHOT,
   type SidebarWorkboardRenderers,
@@ -753,6 +753,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     window.addEventListener("openclaw:native-open-search", this.handleNativeOpenSearch);
     window.addEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
     window.addEventListener("openclaw:native-new-session", this.handleNativeNewSession);
+    window.addEventListener("openclaw:native-navigate", this.handleNativeNavigate);
     window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
     window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
@@ -790,6 +791,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     window.removeEventListener("openclaw:native-open-search", this.handleNativeOpenSearch);
     window.removeEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
     window.removeEventListener("openclaw:native-new-session", this.handleNativeNewSession);
+    window.removeEventListener("openclaw:native-navigate", this.handleNativeNavigate);
     window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
     window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
@@ -1269,6 +1271,26 @@ class OpenClawShell extends OpenClawLightDomElement {
     }
     const agentId = context.agentSelection.state.selectedId ?? "";
     this.openNewSession(agentId);
+  };
+
+  private readonly handleNativeNavigate = (event: Event) => {
+    const path = (event as CustomEvent<{ path?: unknown }>).detail?.path;
+    const schemeCandidate = typeof path === "string" ? path.slice(1) : "";
+    if (
+      typeof path !== "string" ||
+      !path.startsWith("/") ||
+      path.startsWith("//") ||
+      /^[a-z][a-z\d+.-]*:/i.test(schemeCandidate)
+    ) {
+      return;
+    }
+    const routeId = routeIdFromPath(path);
+    if (!routeId || !this.context) {
+      // Leave invalid or unavailable destinations unhandled so the native host can load its URL fallback.
+      return;
+    }
+    event.preventDefault();
+    this.navigate(routeId);
   };
 
   private readonly handleNativeHistoryState = (event: Event) => {


### PR DESCRIPTION
## What Problem This Solves
The macOS app natively re-implements gateway-configuration settings that the Dashboard (Control UI) already owns - Channels, Skills, Cron Jobs, Threads, and Instances panes are hand-maintained SwiftUI forms over the same gateway state and drift every time the Dashboard evolves. This is the first step of retiring them.

## Why This Change Was Made
Maintainer decision: native owns what touches macOS or the local machine; the Dashboard owns gateway-data CRUD. Instead of deleting the panes outright, this ships a visibility gate so the retirement is reversible while we validate the handoff UX.

## User Impact
- Gateway-owned Settings tabs (Channels, Skills, Cron Jobs, Threads, Instances) now show a native handoff page with an "Open in Dashboard" button that deep-links the embedded dashboard window to the matching route (new `openclaw:native-navigate` host->shell event, cancelable, with a generation-guarded full-URL fallback for older gateway bundles).
- A new Debug settings toggle ("Show native settings panes") restores the legacy native panes, which then carry a banner + inline dashboard link.
- Exec Approvals intentionally stays native: the Dashboard's Devices page treats host-native exec policy as read-only ("Edit from the companion app or CLI"), so the Mac pane remains the canonical editor.
- The dashboard route map and same-app path validation move to shared OpenClawKit (`DashboardRouteMap`) so iOS can adopt the same handoff contract later.

## Evidence
- `cd apps/macos && swift build` green; `swift test --filter SettingsDashboardHandoffTests` (incl. stale in-flight fallback + New Session supersede coverage); `swift test --filter DashboardWindowSmokeTests` 36/36; OpenClawKit `DashboardRouteMapTests` 4/4.
- `node scripts/run-vitest.mjs ui/src/app/app-host-native-shell.test.ts` 17/17 (valid path navigates + acknowledges; external/scheme/unknown paths left unhandled for native fallback).
- Codex autoreview (gpt-5.6-sol, xhigh): one accepted P2 (in-flight navigation fallback outside latest-intent sequencing) fixed via controller-level navigation generation; final run clean.
- Routes verified against ui/src/app-route-paths.ts; remote check-changed lanes ran on Blacksmith Testbox (initial ratchet failure was a stale-base artifact, resolved by this rebase).
