### PR TITLE
fix(agent): isolate before-finalize revision retries

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-settle.ts
@@ -140,6 +140,7 @@ export async function runEmbeddedAttemptSettledPhase(
     queueHandle,
     stopAcceptingSteerMessages,
     getBeforeAgentFinalizeRevisionReason,
+    getBeforeAgentFinalizeRevisionEntryId,
   } = preparedStream;
   const { unsubscribe, waitForPendingEvents } = subscription;
   const {
@@ -321,6 +322,7 @@ export async function runEmbeddedAttemptSettledPhase(
       shouldFlushForContextEngine: () =>
         Boolean(input.activeContextEngine && !getBeforeAgentFinalizeRevisionReason()),
       getBeforeAgentFinalizeRevisionReason,
+      getBeforeAgentFinalizeRevisionEntryId,
       getContextEngineAfterTurnCheckpoint: contextGuards.getAfterTurnCheckpoint,
       onSettleErrorState: (settleState) => {
         setFailure(settleState.promptError, settleState.promptErrorSource);

--- a/src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts
@@ -12,6 +12,7 @@ vi.mock("./attempt-stream-settle.js", () => ({
   settleEmbeddedAttemptStream: mocks.settleStream,
 }));
 
+import { SessionManager } from "../../sessions/index.js";
 import { finalizeEmbeddedAttemptStreamPhase } from "./attempt-stream-finalize.js";
 
 type FinalizeInput = Parameters<typeof finalizeEmbeddedAttemptStreamPhase>[0];
@@ -46,7 +47,7 @@ function createFixture(overrides?: Partial<FinalizeInput>) {
         order.push("release-prompt-lock");
       }),
     },
-    withOwnedSessionWriteLock: vi.fn(),
+    withOwnedSessionWriteLock: vi.fn(async (operation) => await operation()),
     waitForPendingEvents: vi.fn(async () => {
       order.push("pending-events");
     }),
@@ -54,6 +55,7 @@ function createFixture(overrides?: Partial<FinalizeInput>) {
     getRunAbortDeadlineAtMs: () => 123,
     shouldFlushForContextEngine: () => true,
     getBeforeAgentFinalizeRevisionReason: () => "revision changed",
+    getBeforeAgentFinalizeRevisionEntryId: () => undefined,
     getContextEngineAfterTurnCheckpoint: () => 7,
     onSettleErrorState: vi.fn(),
     onSettled: vi.fn(() => {
@@ -99,6 +101,81 @@ beforeEach(() => {
 });
 
 describe("finalizeEmbeddedAttemptStreamPhase", () => {
+  it("rewinds the exact rejected branch before the hidden retry can choose NO_REPLY", async () => {
+    const sessionManager = SessionManager.inMemory();
+    const promptId = sessionManager.appendMessage({
+      role: "user",
+      content: "Original request",
+      timestamp: 1,
+    });
+    const rejectedId = sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Rejected first answer" }],
+      stopReason: "stop",
+      timestamp: 2,
+    } as never);
+    sessionManager.appendCustomEntry("trailing-metadata", { source: "hook" });
+    sessionManager.appendCompaction("Summary including rejected answer", promptId, 100);
+    const originalMessages = sessionManager.buildSessionContext().messages;
+    const fixture = createFixture({
+      activeSession: { agent: { state: { messages: originalMessages } } } as never,
+      sessionManager: sessionManager as never,
+      repairedRejectedThinkingReplay: false,
+      getBeforeAgentFinalizeRevisionEntryId: () => rejectedId,
+    });
+    const settledStream = {
+      promptError: null,
+      promptErrorSource: null,
+      timedOutDuringCompaction: false,
+      compactionOccurredThisAttempt: false,
+      messagesSnapshot: originalMessages,
+      sessionIdUsed: "session-1",
+      lastAssistant: undefined,
+      currentAttemptAssistant: undefined,
+      currentAttemptCompletedAssistant: undefined,
+      attemptUsage: undefined,
+      cacheBreak: null,
+      lastCallUsage: undefined,
+      promptCache: undefined,
+    };
+    mocks.settleStream.mockImplementation(async () => {
+      expect(fixture.input.activeSession.agent.state.messages).toBe(originalMessages);
+      expect(sessionManager.getLeafId()).toBe(promptId);
+      return settledStream;
+    });
+    mocks.completeAfterTurn.mockResolvedValue({
+      sessionIdUsed: "session-1",
+      sessionFileUsed: "session.jsonl",
+    });
+
+    await finalizeEmbeddedAttemptStreamPhase(fixture.input);
+
+    const retryMessages = sessionManager.buildSessionContext().messages;
+    const retryTranscript = JSON.stringify(retryMessages);
+    expect(retryTranscript).not.toContain("Rejected first answer");
+    expect(retryTranscript).not.toContain("Summary including rejected answer");
+    const revisedText = retryTranscript.includes("Rejected first answer")
+      ? "NO_REPLY"
+      : "Authoritative revised answer";
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: revisedText }],
+      stopReason: "stop",
+      timestamp: 3,
+    } as never);
+    expect(revisedText).toBe("Authoritative revised answer");
+    expect(JSON.stringify(sessionManager.buildSessionContext().messages)).toContain(
+      "Authoritative revised answer",
+    );
+    expect(sessionManager.getEntries()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: rejectedId }),
+        expect.objectContaining({ type: "custom", customType: "trailing-metadata" }),
+        expect.objectContaining({ type: "compaction" }),
+      ]),
+    );
+  });
+
   it("settles the stream before publishing state and running after-turn work", async () => {
     const fixture = createFixture();
     const pendingError = new Error("pending event failed");
@@ -187,6 +264,83 @@ describe("finalizeEmbeddedAttemptStreamPhase", () => {
       }),
     );
     expect(fixture.input.onSettled).not.toHaveBeenCalled();
+    expect(mocks.completeAfterTurn).not.toHaveBeenCalled();
+  });
+
+  it("restores the rewound in-memory branch when prompt lock release fails", async () => {
+    const sessionManager = SessionManager.inMemory();
+    const promptId = sessionManager.appendMessage({
+      role: "user",
+      content: "Original request",
+      timestamp: 1,
+    });
+    const rejectedId = sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Rejected first answer" }],
+      stopReason: "stop",
+      timestamp: 2,
+    } as never);
+    const originalMessages = sessionManager.buildSessionContext().messages;
+    const activeSession = { agent: { state: { messages: originalMessages } } };
+    const releaseError = new Error("prompt lock release failed");
+    const fixture = createFixture({
+      activeSession: activeSession as never,
+      sessionManager: sessionManager as never,
+      sessionLockController: {
+        releaseForPrompt: vi.fn(async () => {
+          throw releaseError;
+        }),
+      } as never,
+      repairedRejectedThinkingReplay: false,
+      getBeforeAgentFinalizeRevisionEntryId: () => rejectedId,
+    });
+
+    await expect(finalizeEmbeddedAttemptStreamPhase(fixture.input)).rejects.toBe(releaseError);
+
+    expect(sessionManager.getLeafId()).toBe(promptId);
+    expect(activeSession.agent.state.messages).toEqual(
+      sessionManager.buildSessionContext().messages,
+    );
+    expect(JSON.stringify(activeSession.agent.state.messages)).not.toContain(
+      "Rejected first answer",
+    );
+    expect(mocks.settleStream).not.toHaveBeenCalled();
+    expect(fixture.input.onSettleErrorState).not.toHaveBeenCalled();
+    expect(fixture.input.onSettled).not.toHaveBeenCalled();
+    expect(mocks.completeAfterTurn).not.toHaveBeenCalled();
+  });
+
+  it("restores the rewound in-memory branch when settlement fails", async () => {
+    const sessionManager = SessionManager.inMemory();
+    const promptId = sessionManager.appendMessage({
+      role: "user",
+      content: "Original request",
+      timestamp: 1,
+    });
+    const rejectedId = sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Rejected first answer" }],
+      stopReason: "stop",
+      timestamp: 2,
+    } as never);
+    const originalMessages = sessionManager.buildSessionContext().messages;
+    const activeSession = { agent: { state: { messages: originalMessages } } };
+    const fixture = createFixture({
+      activeSession: activeSession as never,
+      sessionManager: sessionManager as never,
+      repairedRejectedThinkingReplay: false,
+      getBeforeAgentFinalizeRevisionEntryId: () => rejectedId,
+    });
+    const settlementError = new Error("settlement failed");
+    mocks.settleStream.mockRejectedValue(settlementError);
+
+    await expect(finalizeEmbeddedAttemptStreamPhase(fixture.input)).rejects.toBe(settlementError);
+
+    expect(sessionManager.getLeafId()).toBe(promptId);
+    expect(JSON.stringify(activeSession.agent.state.messages)).not.toContain(
+      "Rejected first answer",
+    );
+    expect(fixture.input.onSettleErrorState).toHaveBeenCalledOnce();
     expect(mocks.completeAfterTurn).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts
@@ -27,6 +27,7 @@ export async function finalizeEmbeddedAttemptStreamPhase(input: {
   getRunAbortDeadlineAtMs: () => number;
   shouldFlushForContextEngine: () => boolean;
   getBeforeAgentFinalizeRevisionReason: () => string | undefined;
+  getBeforeAgentFinalizeRevisionEntryId: () => string | undefined;
   getContextEngineAfterTurnCheckpoint: () => number | null;
   onSettleErrorState: (state: {
     promptError: unknown;
@@ -43,40 +44,73 @@ export async function finalizeEmbeddedAttemptStreamPhase(input: {
   const { activeSession, sessionManager, sessionLockController, withOwnedSessionWriteLock } = input;
 
   await input.waitForPendingEvents();
-  if (input.repairedRejectedThinkingReplay) {
-    activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
+  const beforeAgentFinalizeRevisionReason = input.getBeforeAgentFinalizeRevisionReason();
+  const beforeAgentFinalizeRevisionEntryId = input.getBeforeAgentFinalizeRevisionEntryId();
+  let rewoundBeforeAgentFinalizeRevision = false;
+  if (beforeAgentFinalizeRevisionReason && beforeAgentFinalizeRevisionEntryId) {
+    await withOwnedSessionWriteLock(() => {
+      const rejectedEntry = sessionManager.getEntry(beforeAgentFinalizeRevisionEntryId);
+      if (rejectedEntry?.type !== "message" || rejectedEntry.message.role !== "assistant") {
+        throw new Error(
+          `before_agent_finalize persisted assistant entry is missing or invalid ` +
+            `(entry=${beforeAgentFinalizeRevisionEntryId})`,
+        );
+      }
+      // Keep persistence append-only while excluding the rejected draft and
+      // every trailing descendant from the hidden retry's active branch.
+      sessionManager.appendLeafControl({
+        targetId: rejectedEntry.parentId,
+        appendParentId: rejectedEntry.parentId,
+      });
+      rewoundBeforeAgentFinalizeRevision = true;
+    });
   }
-  await sessionLockController.releaseForPrompt();
+  let settledStream: StreamSettleResult;
+  try {
+    if (input.repairedRejectedThinkingReplay && !rewoundBeforeAgentFinalizeRevision) {
+      activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
+    }
+    await sessionLockController.releaseForPrompt();
 
-  const currentState = input.getState();
-  const streamSettleState = {
-    promptError: currentState.promptError,
-    promptErrorSource: currentState.promptErrorSource,
-    yieldAborted: currentState.yieldAborted,
-    sessionIdUsed: currentState.sessionIdUsed,
-  };
-  const settledStream = await settleEmbeddedAttemptStream({
-    attempt: input.attempt,
-    activeSession,
-    sessionManager,
-    sessionLockController,
-    withOwnedSessionWriteLock,
-    state: streamSettleState,
-    ...input.settle,
-    runAbortDeadlineAtMs: input.getRunAbortDeadlineAtMs(),
-    shouldFlushForContextEngine: input.shouldFlushForContextEngine(),
-  }).catch((error: unknown) => {
-    // Settlement mutates this shared state before some failures. Publish it so
-    // outer teardown keeps the recorded prompt error and attribution.
-    input.onSettleErrorState(streamSettleState);
-    throw error;
-  });
+    const currentState = input.getState();
+    const streamSettleState = {
+      promptError: currentState.promptError,
+      promptErrorSource: currentState.promptErrorSource,
+      yieldAborted: currentState.yieldAborted,
+      sessionIdUsed: currentState.sessionIdUsed,
+    };
+    try {
+      settledStream = await settleEmbeddedAttemptStream({
+        attempt: input.attempt,
+        activeSession,
+        sessionManager,
+        sessionLockController,
+        withOwnedSessionWriteLock,
+        state: streamSettleState,
+        ...input.settle,
+        runAbortDeadlineAtMs: input.getRunAbortDeadlineAtMs(),
+        shouldFlushForContextEngine: input.shouldFlushForContextEngine(),
+      });
+    } catch (error) {
+      // Settlement mutates this shared state before some failures. Publish it so
+      // outer teardown keeps the recorded prompt error and attribution.
+      input.onSettleErrorState(streamSettleState);
+      throw error;
+    }
+  } finally {
+    if (rewoundBeforeAgentFinalizeRevision) {
+      await withOwnedSessionWriteLock(() => {
+        // Settlement classifies the completed attempt from its original
+        // in-memory messages. Later work always sees the rewound branch.
+        activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
+      });
+    }
+  }
   // Publish settled fields before after-turn hooks: those hooks may throw, and
   // outer teardown still needs the completed stream snapshot and usage state.
   input.onSettled(settledStream);
 
   const afterSettleState = input.getState();
-  const beforeAgentFinalizeRevisionReason = input.getBeforeAgentFinalizeRevisionReason();
   const afterTurn = await completeEmbeddedAttemptAfterTurn({
     attempt: input.attempt,
     activeSession,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   buildSubscriptionParams: vi.fn(),
   clearActiveRun: vi.fn(),
   notifyToolActivity: vi.fn(),
+  runBeforeFinalizeHook: vi.fn(),
   setActiveRun: vi.fn(),
   subscribe: vi.fn(),
 }));
@@ -21,6 +22,9 @@ vi.mock("./attempt.subscription-cleanup.js", () => ({
 }));
 vi.mock("./tool-activity-heartbeat.js", () => ({
   notifyToolActivity: mocks.notifyToolActivity,
+}));
+vi.mock("../../harness/lifecycle-hook-helpers.js", () => ({
+  runAgentHarnessBeforeAgentFinalizeHook: mocks.runBeforeFinalizeHook,
 }));
 
 import { prepareEmbeddedAttemptStream } from "./attempt-stream-prepare.js";
@@ -84,6 +88,159 @@ describe("prepareEmbeddedAttemptStream", () => {
       runToolLifecycle: vi.fn(async ({ execute }) => await execute()),
       isCompacting: vi.fn(() => false),
     });
+    mocks.runBeforeFinalizeHook.mockResolvedValue({ action: "continue" });
+  });
+
+  it("uses the persisted assistant entry id and closes steering during revision settlement", async () => {
+    let resolveHook: ((value: { action: "revise"; reason: string }) => void) | undefined;
+    mocks.runBeforeFinalizeHook.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveHook = resolve;
+        }),
+    );
+    const prepared = prepareEmbeddedAttemptStream({
+      attempt: {
+        runId: "run-finalize-id",
+        sessionId: "session-finalize-id",
+        sessionKey: "agent:main:main",
+        maxBeforeAgentFinalizeRevisions: 3,
+        beforeAgentFinalizeRevisionAttempts: 0,
+      } as never,
+      activeSession: {
+        agent: { hasQueuedMessages: () => false },
+        isStreaming: false,
+        messages: [],
+        pendingMessageCount: 0,
+      } as never,
+      hookRunner: { hasHooks: (name: string) => name === "before_agent_finalize" } as never,
+      hookAgentId: "main",
+      diagnosticTrace: {} as never,
+      clientToolCallSlots: [],
+      toolSearchTargetTranscriptProjections: [],
+      isReplaySafeTool: () => false,
+      runAbortController: new AbortController(),
+      abortRun: vi.fn(),
+      markExternalAbort: vi.fn(),
+      getRunState: () => ({
+        aborted: false,
+        promptError: undefined,
+        timedOut: false,
+        yieldDetected: false,
+      }),
+      hasDeliveredSourceReply: () => false,
+      markSourceReplyDelivered: vi.fn(),
+      onBlockReply: vi.fn(),
+      onBlockReplyFlush: vi.fn(),
+      sandboxSessionKey: "agent:main:main",
+      builtinToolNames: new Set(),
+      replaySafeToolNames: new Set(),
+    });
+    const subscriptionInput = mocks.buildSubscriptionParams.mock.calls.at(-1)?.[0] as {
+      onBeforeTerminalDelivery?: (event: unknown) => Promise<unknown>;
+    };
+    const decision = subscriptionInput.onBeforeTerminalDelivery?.({
+      messages: [],
+      willRetry: false,
+      assistantEntryId: "canonical-entry-id",
+      lastAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "Draft answer" }],
+        stopReason: "stop",
+      },
+      assistantTexts: ["Draft answer"],
+      hasAssistantVisibleText: true,
+      isError: false,
+      incompleteTerminalAssistant: false,
+      hadDeterministicSideEffect: false,
+    });
+
+    await vi.waitFor(() => expect(mocks.runBeforeFinalizeHook).toHaveBeenCalledOnce());
+    expect(prepared.queueHandle.isStopped?.()).toBe(true);
+    await expect(prepared.queueHandle.queueMessage("too late")).rejects.toThrow(
+      "active session is finalizing",
+    );
+
+    resolveHook?.({ action: "revise", reason: "Tighten the answer" });
+    await expect(decision).resolves.toEqual({ suppressTerminalDelivery: true });
+    expect(prepared.getBeforeAgentFinalizeRevisionEntryId()).toBe("canonical-entry-id");
+    expect(prepared.queueHandle.isStopped?.()).toBe(true);
+  });
+
+  it("keeps already-started steering authoritative over finalization", async () => {
+    let resolveSteer: (() => void) | undefined;
+    const activeSession = {
+      agent: { hasQueuedMessages: () => false },
+      isStreaming: false,
+      messages: [],
+      pendingMessageCount: 0,
+      steer: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSteer = resolve;
+          }),
+      ),
+      subscribe: vi.fn(() => () => {}),
+    };
+    const prepared = prepareEmbeddedAttemptStream({
+      attempt: {
+        runId: "run-finalize-steer",
+        sessionId: "session-finalize-steer",
+        sessionKey: "agent:main:main",
+        maxBeforeAgentFinalizeRevisions: 3,
+        beforeAgentFinalizeRevisionAttempts: 0,
+      } as never,
+      activeSession: activeSession as never,
+      hookRunner: { hasHooks: (name: string) => name === "before_agent_finalize" } as never,
+      hookAgentId: "main",
+      diagnosticTrace: {} as never,
+      clientToolCallSlots: [],
+      toolSearchTargetTranscriptProjections: [],
+      isReplaySafeTool: () => false,
+      runAbortController: new AbortController(),
+      abortRun: vi.fn(),
+      markExternalAbort: vi.fn(),
+      getRunState: () => ({
+        aborted: false,
+        promptError: undefined,
+        timedOut: false,
+        yieldDetected: false,
+      }),
+      hasDeliveredSourceReply: () => false,
+      markSourceReplyDelivered: vi.fn(),
+      onBlockReply: vi.fn(),
+      onBlockReplyFlush: vi.fn(),
+      sandboxSessionKey: "agent:main:main",
+      builtinToolNames: new Set(),
+      replaySafeToolNames: new Set(),
+    });
+    const queued = prepared.queueHandle.queueMessage("new user input");
+    const subscriptionInput = mocks.buildSubscriptionParams.mock.calls.at(-1)?.[0] as {
+      onBeforeTerminalDelivery?: (event: unknown) => Promise<unknown>;
+    };
+
+    await expect(
+      subscriptionInput.onBeforeTerminalDelivery?.({
+        messages: [],
+        willRetry: false,
+        assistantEntryId: "canonical-entry-id",
+        lastAssistant: {
+          role: "assistant",
+          content: [{ type: "text", text: "Draft answer" }],
+          stopReason: "stop",
+        },
+        assistantTexts: ["Draft answer"],
+        hasAssistantVisibleText: true,
+        isError: false,
+        incompleteTerminalAssistant: false,
+        hadDeterministicSideEffect: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.runBeforeFinalizeHook).not.toHaveBeenCalled();
+    expect(prepared.queueHandle.isStopped?.()).toBe(false);
+    resolveSteer?.();
+    await queued;
   });
 
   it("routes live events to the transcript session instead of the sandbox authority session", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -90,6 +90,9 @@ export function prepareEmbeddedAttemptStream(input: {
   const attempt = input.attempt;
   const hookRunner = input.hookRunner;
   let beforeAgentFinalizeRevisionReason: string | undefined;
+  let beforeAgentFinalizeRevisionEntryId: string | undefined;
+  let acceptingSteerMessages = true;
+  let activeQueueAdmissions = 0;
   const shouldRunBeforeAgentFinalize =
     attempt.operation !== "settled-tool-finalization" &&
     hookRunner?.hasHooks("before_agent_finalize");
@@ -97,6 +100,7 @@ export function prepareEmbeddedAttemptStream(input: {
     ? async (event: {
         messages: AgentMessage[];
         willRetry: boolean;
+        assistantEntryId?: string;
         lastAssistant?: AgentMessage;
         assistantTexts: readonly string[];
         hasAssistantVisibleText: boolean;
@@ -156,53 +160,80 @@ export function prepareEmbeddedAttemptStream(input: {
           );
           return;
         }
-        const outcome = await runAgentHarnessBeforeAgentFinalizeHook({
-          event: {
-            runId: attempt.runId,
-            sessionId: attempt.sessionId,
-            ...(attempt.sessionKey ? { sessionKey: attempt.sessionKey } : {}),
-            provider: reportedModelRef.provider,
-            model: reportedModelRef.model,
-            ...((attempt.cwd ?? attempt.workspaceDir)
-              ? { cwd: attempt.cwd ?? attempt.workspaceDir }
-              : {}),
-            ...(attempt.sessionFile ? { transcriptPath: attempt.sessionFile } : {}),
-            stopHookActive: false,
-            lastAssistantMessage,
-            messages: hookMessages,
-          },
-          ctx: {
-            runId: attempt.runId,
-            trace: freezeDiagnosticTraceContext(input.diagnosticTrace),
-            agentId: input.hookAgentId,
-            sessionKey: attempt.sessionKey,
-            sessionId: attempt.sessionId,
-            workspaceDir: attempt.workspaceDir,
-            modelProviderId: reportedModelRef.provider,
-            modelId: reportedModelRef.model,
-            trigger: attempt.trigger,
-            ...buildAgentHookContextChannelFields(attempt),
-            ...buildAgentHookContextIdentityFields({
+        // A queued user message wins over finalization. Close admission before
+        // awaiting the hook so no later steer can become a child of the draft.
+        acceptingSteerMessages = false;
+        if (
+          activeQueueAdmissions > 0 ||
+          input.activeSession.pendingMessageCount > 0 ||
+          input.activeSession.agent.hasQueuedMessages()
+        ) {
+          acceptingSteerMessages = true;
+          return;
+        }
+        let keepAdmissionClosed = false;
+        try {
+          const outcome = await runAgentHarnessBeforeAgentFinalizeHook({
+            event: {
+              runId: attempt.runId,
+              sessionId: attempt.sessionId,
+              ...(attempt.sessionKey ? { sessionKey: attempt.sessionKey } : {}),
+              provider: reportedModelRef.provider,
+              model: reportedModelRef.model,
+              ...((attempt.cwd ?? attempt.workspaceDir)
+                ? { cwd: attempt.cwd ?? attempt.workspaceDir }
+                : {}),
+              ...(attempt.sessionFile ? { transcriptPath: attempt.sessionFile } : {}),
+              stopHookActive: false,
+              lastAssistantMessage,
+              messages: hookMessages,
+            },
+            ctx: {
+              runId: attempt.runId,
+              trace: freezeDiagnosticTraceContext(input.diagnosticTrace),
+              agentId: input.hookAgentId,
+              sessionKey: attempt.sessionKey,
+              sessionId: attempt.sessionId,
+              workspaceDir: attempt.workspaceDir,
+              modelProviderId: reportedModelRef.provider,
+              modelId: reportedModelRef.model,
               trigger: attempt.trigger,
-              senderId: attempt.senderId,
-              chatId: attempt.chatId,
-              channelContext: attempt.channelContext,
-            }),
-          },
-          hookRunner,
-        });
-        if (outcome.action !== "revise") {
-          return;
+              ...buildAgentHookContextChannelFields(attempt),
+              ...buildAgentHookContextIdentityFields({
+                trigger: attempt.trigger,
+                senderId: attempt.senderId,
+                chatId: attempt.chatId,
+                channelContext: attempt.channelContext,
+              }),
+            },
+            hookRunner,
+          });
+          if (outcome.action !== "revise") {
+            return;
+          }
+          if (event.hadDeterministicSideEffect) {
+            log.warn(
+              `before_agent_finalize requested revision after potential side effects; finalizing ` +
+                `runId=${attempt.runId} sessionId=${attempt.sessionId}`,
+            );
+            return;
+          }
+          if (!event.assistantEntryId) {
+            log.warn(
+              `before_agent_finalize revision lacks a persisted assistant entry; finalizing ` +
+                `runId=${attempt.runId} sessionId=${attempt.sessionId}`,
+            );
+            return;
+          }
+          keepAdmissionClosed = true;
+          beforeAgentFinalizeRevisionEntryId = event.assistantEntryId;
+          beforeAgentFinalizeRevisionReason = outcome.reason;
+          return { suppressTerminalDelivery: true };
+        } finally {
+          if (!keepAdmissionClosed) {
+            acceptingSteerMessages = true;
+          }
         }
-        if (event.hadDeterministicSideEffect) {
-          log.warn(
-            `before_agent_finalize requested revision after potential side effects; finalizing ` +
-              `runId=${attempt.runId} sessionId=${attempt.sessionId}`,
-          );
-          return;
-        }
-        beforeAgentFinalizeRevisionReason = outcome.reason;
-        return { suppressTerminalDelivery: true };
       }
     : undefined;
 
@@ -352,20 +383,27 @@ export function prepareEmbeddedAttemptStream(input: {
     attempt.onAttemptAbort?.();
     input.abortRun(false, reason === "restart" ? createAgentRunRestartAbortError() : undefined);
   };
-  let acceptingSteerMessages = true;
   const queueHandle: AttemptStreamQueueHandle = {
     kind: "embedded",
     runId: attempt.runId,
     queueMessage: async (text: string, options) => {
-      if (options?.steeringMode) {
-        input.activeSession.agent.steeringMode = options.steeringMode;
+      if (!acceptingSteerMessages) {
+        throw new Error("active session is finalizing");
       }
-      await steerActiveSessionWithOptionalDeliveryWait(
-        input.activeSession,
-        text,
-        options,
-        attempt.sessionKey,
-      );
+      activeQueueAdmissions++;
+      try {
+        if (options?.steeringMode) {
+          input.activeSession.agent.steeringMode = options.steeringMode;
+        }
+        await steerActiveSessionWithOptionalDeliveryWait(
+          input.activeSession,
+          text,
+          options,
+          attempt.sessionKey,
+        );
+      } finally {
+        activeQueueAdmissions--;
+      }
     },
     isStreaming: () => input.activeSession.isStreaming,
     isAborted: () => input.getRunState().aborted,
@@ -393,6 +431,7 @@ export function prepareEmbeddedAttemptStream(input: {
     queueHandle,
     toolSearchCatalogExecutor,
     getBeforeAgentFinalizeRevisionReason: () => beforeAgentFinalizeRevisionReason,
+    getBeforeAgentFinalizeRevisionEntryId: () => beforeAgentFinalizeRevisionEntryId,
     stopAcceptingSteerMessages: () => {
       acceptingSteerMessages = false;
     },

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -289,6 +289,7 @@ export function handleAgentEnd(
     const result = ctx.params.onBeforeTerminalDelivery?.({
       messages: evt?.messages ?? [],
       willRetry: evt?.willRetry === true,
+      ...(evt?.assistantEntryId ? { assistantEntryId: evt.assistantEntryId } : {}),
       ...(lastAssistant ? { lastAssistant } : {}),
       assistantTexts: ctx.state.assistantTexts,
       hasAssistantVisibleText,

--- a/src/agents/embedded-agent-subscribe.handlers.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.ts
@@ -33,7 +33,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
     evt: EmbeddedAgentSubscribeEvent,
     handler: () => void | Promise<void>,
     options?: { detach?: boolean },
-  ): void => {
+  ): void | Promise<void> => {
     // Most stream events must preserve order across async formatting and flush
     // work. A detached event may run after the chain without blocking delivery.
     const run = () => {
@@ -60,6 +60,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
         });
       if (!options?.detach) {
         ctx.state.pendingEventChain = task;
+        return task;
       }
       return;
     }
@@ -76,6 +77,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
       });
     if (!options?.detach) {
       ctx.state.pendingEventChain = task;
+      return task;
     }
   };
 
@@ -86,7 +88,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
         // message-scoped. Reset only its accounting boundary synchronously so
         // this message's streamed usage cannot inherit the prior commit state.
         resetPendingAssistantUsage(ctx, evt.message as AgentMessage);
-        scheduleEvent(evt, () => {
+        void scheduleEvent(evt, () => {
           handleMessageStart(ctx, evt as never);
         });
         return;
@@ -95,7 +97,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
         // delivery handlers may still be queued. Capture usage synchronously so
         // the following final snapshot can be repaired before persistence.
         capturePendingAssistantUsage(ctx, evt as never);
-        scheduleEvent(evt, () => {
+        void scheduleEvent(evt, () => {
           handleMessageUpdate(ctx, evt as never);
         });
         return;
@@ -106,22 +108,22 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
             ctx.state.pendingAssistantUsage,
           );
         }
-        scheduleEvent(evt, () => {
+        void scheduleEvent(evt, () => {
           return handleMessageEnd(ctx, evt as never);
         });
         return;
       case "tool_execution_start":
-        scheduleEvent(evt, () => {
+        void scheduleEvent(evt, () => {
           return handleToolExecutionStart(ctx, evt as never);
         });
         return;
       case "tool_execution_update":
-        scheduleEvent(evt, () => {
+        void scheduleEvent(evt, () => {
           handleToolExecutionUpdate(ctx, evt as never);
         });
         return;
       case "tool_execution_end":
-        scheduleEvent(
+        void scheduleEvent(
           evt,
           () => {
             return handleToolExecutionEnd(ctx, evt as never);
@@ -130,12 +132,12 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
         );
         return;
       case "agent_start":
-        scheduleEvent(evt, () => {
+        void scheduleEvent(evt, () => {
           handleAgentStart(ctx);
         });
         return;
       case "compaction_start":
-        scheduleEvent(evt, () => {
+        void scheduleEvent(evt, () => {
           handleCompactionStart(ctx, {
             type: "compaction_start",
             reason: evt.reason,
@@ -143,7 +145,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
         });
         return;
       case "compaction_end":
-        scheduleEvent(evt, () => {
+        void scheduleEvent(evt, () => {
           handleCompactionEnd(ctx, {
             type: "compaction_end",
             reason: evt.reason,
@@ -154,7 +156,7 @@ export function createEmbeddedAgentSessionEventHandler(ctx: EmbeddedAgentSubscri
         });
         return;
       case "agent_end":
-        scheduleEvent(evt, () => {
+        return scheduleEvent(evt, () => {
           return handleAgentEnd(ctx, evt as never);
         });
       default:

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -91,6 +91,7 @@ export type SubscribeEmbeddedAgentSessionParams = {
   onBeforeTerminalDelivery?: (event: {
     messages: AgentMessage[];
     willRetry: boolean;
+    assistantEntryId?: string;
     lastAssistant?: AgentMessage;
     assistantTexts: readonly string[];
     hasAssistantVisibleText: boolean;

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -1,5 +1,6 @@
 import { cleanupSessionResources } from "@openclaw/ai/internal/runtime";
 import type { AssistantMessage, Model } from "../../llm/types.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type {
   Agent,
   AgentEvent,
@@ -43,6 +44,8 @@ import type { SessionManager } from "./session-manager.js";
 import type { SettingsManager } from "./settings-manager.js";
 import type { SourceInfo } from "./source-info.js";
 import { type BuildSystemPromptOptions, buildSystemPrompt } from "./system-prompt.js";
+
+const log = createSubsystemLogger("agents/session");
 
 interface ToolDefinitionEntry {
   definition: ToolDefinition;
@@ -277,7 +280,21 @@ export abstract class AgentSessionBase {
   /** Emit an event to all listeners */
   protected emit(event: AgentSessionEvent): void {
     for (const l of this.eventListeners) {
-      l(event);
+      void l(event);
+    }
+  }
+
+  /** Terminal listeners form a barrier before retry, compaction, or queue draining. */
+  private async emitTerminal(
+    event: Extract<AgentSessionEvent, { type: "agent_end" }>,
+  ): Promise<void> {
+    const listeners = this.eventListeners.slice();
+    for (const listener of listeners) {
+      try {
+        await listener(event);
+      } catch (error) {
+        log.warn(`agent_end listener failed: ${String(error)}`);
+      }
     }
   }
 
@@ -291,6 +308,7 @@ export abstract class AgentSessionBase {
 
   // Track last assistant message for auto-compaction check
   protected lastAssistantMessage: AssistantMessage | undefined = undefined;
+  private lastAssistantEntryId: string | undefined;
   protected lastRunEndedForTurnHandoff = false;
 
   /** Internal handler for agent events - shared by subscribe and reconnect */
@@ -311,6 +329,10 @@ export abstract class AgentSessionBase {
   };
 
   private async handleAgentEventUnlocked(event: AgentEvent): Promise<void> {
+    if (event.type === "agent_start") {
+      this.lastAssistantEntryId = undefined;
+    }
+
     // When a user message starts, check if it's from either queue and remove it BEFORE emitting
     // This ensures the UI sees the updated queue state
     if (event.type === "message_start" && event.message.role === "user") {
@@ -337,11 +359,15 @@ export abstract class AgentSessionBase {
     const messageChangedByExtension = await this.emitExtensionEvent(event);
 
     // Notify all listeners
-    this.emit(
-      event.type === "agent_end"
-        ? { ...event, willRetry: this.willRetryAfterAgentEnd(event) }
-        : event,
-    );
+    if (event.type === "agent_end") {
+      await this.emitTerminal({
+        ...event,
+        willRetry: this.willRetryAfterAgentEnd(event),
+        ...(this.lastAssistantEntryId ? { assistantEntryId: this.lastAssistantEntryId } : {}),
+      });
+    } else {
+      this.emit(event);
+    }
 
     // Handle session persistence
     if (event.type === "message_end") {
@@ -363,10 +389,13 @@ export abstract class AgentSessionBase {
         const toolResultChangedByExtension =
           event.message.role === "toolResult" &&
           this.extensionModifiedToolResultIds.delete(event.message.toolCallId);
-        this.sessionManager.appendMessage(event.message, {
+        const entryId = this.sessionManager.appendMessage(event.message, {
           invalidateSerializedPrefixCache:
             messageChangedByExtension || toolResultChangedByExtension,
         });
+        if (event.message.role === "assistant") {
+          this.lastAssistantEntryId = entryId;
+        }
       }
       // Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
 

--- a/src/agents/sessions/agent-session-loop-correctness.test.ts
+++ b/src/agents/sessions/agent-session-loop-correctness.test.ts
@@ -208,6 +208,59 @@ afterEach(() => {
 });
 
 describe("AgentSession loop correctness", () => {
+  it("carries the canonical assistant entry id through ordered terminal listeners", async () => {
+    const assistant = createAssistant(testModel, [{ type: "text", text: "same answer" }]);
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });
+    sessionManager.appendMessage({ ...assistant });
+    streamMocks.streamSimple.mockImplementation(() => createAssistantResultStream(assistant));
+    const appendMessage = vi.spyOn(sessionManager, "appendMessage");
+    const { session } = await createTestSession({ sessionManager });
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    let promptSettled = false;
+    let terminalEntryId: string | undefined;
+
+    session.subscribe(async (event) => {
+      if (event.type !== "agent_end") {
+        return;
+      }
+      terminalEntryId = event.assistantEntryId;
+      order.push("first:start");
+      session.subscribe((lateEvent) => {
+        if (lateEvent.type === "agent_end") {
+          order.push("late");
+        }
+      });
+      unsubscribeSecond();
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      order.push("first:end");
+      throw new Error("listener rejected");
+    });
+    const unsubscribeSecond = session.subscribe(async (event) => {
+      if (event.type === "agent_end") {
+        order.push("second");
+      }
+    });
+
+    const prompt = session.prompt("new prompt").then(() => {
+      promptSettled = true;
+    });
+    await vi.waitFor(() => expect(order).toEqual(["first:start"]));
+    expect(promptSettled).toBe(false);
+
+    releaseFirst?.();
+    await prompt;
+
+    const persistedAssistantCall = appendMessage.mock.results.findLast(
+      (result) => result.type === "return",
+    );
+    expect(terminalEntryId).toBe(persistedAssistantCall?.value);
+    expect(order).toEqual(["first:start", "first:end", "second"]);
+  });
+
   it("emits agent_settled once after a normal run", async () => {
     const lifecycleEvents: string[] = [];
     const handlers = new Map<string, Array<(...args: unknown[]) => Promise<unknown>>>([

--- a/src/agents/sessions/agent-session-types.ts
+++ b/src/agents/sessions/agent-session-types.ts
@@ -25,7 +25,12 @@ import type { SettingsManager } from "./settings-manager.js";
 
 export type AgentSessionEvent =
   | Exclude<AgentEvent, { type: "agent_end" }>
-  | { type: "agent_end"; messages: AgentMessage[]; willRetry: boolean }
+  | {
+      type: "agent_end";
+      messages: AgentMessage[];
+      willRetry: boolean;
+      assistantEntryId?: string;
+    }
   | { type: "queue_update"; steering: readonly string[]; followUp: readonly string[] }
   | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
   | { type: "session_info_changed"; name: string | undefined }
@@ -47,7 +52,7 @@ export type AgentSessionEvent =
     }
   | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string };
 
-export type AgentSessionEventListener = (event: AgentSessionEvent) => void;
+export type AgentSessionEventListener = (event: AgentSessionEvent) => unknown;
 export type AgentSessionWriteLockRunner = <T>(run: () => Promise<T> | T) => Promise<T>;
 
 export interface AgentSessionConfig {


### PR DESCRIPTION
## What Problem This Solves

The `before_agent_finalize` hook could request a revision after the rejected
assistant response had already been committed to the active transcript. The
hidden retry then saw that rejected answer and could return `NO_REPLY`, silently
dropping the response.

Fixes #93166

## Why This Change Was Made

The revision pass must be authoritative without restoring or duplicating the
rejected draft. This change captures the exact persisted assistant entry before
the asynchronous hook runs, keeps the transcript append-only, and moves the
active leaf back to that entry's parent before the hidden retry.

It also closes active steering admission while the finalization hook is
deciding. A user message already admitted is drained by the current session and
postpones revision; a later message follows the normal queued-turn path. This
prevents concurrent user input from becoming a discarded descendant of the
rejected draft.

Stream settlement still classifies the completed attempt from its original
in-memory messages, including tool-use turns, before the next prompt receives
the rewound transcript. If prompt-lock release or settlement fails after the
rewind, the in-memory session branch is restored to the canonical persisted
history before the error escapes.

## User Impact

Hook-enabled chats no longer lose a valid response because the revision retry
can see the answer it was meant to replace. Concurrent steering and follow-up
messages are also protected from being silently discarded during finalization.

## Evidence

Base: `1225aa822f2d14aacb64aca54b5115c0b2281a83`

Head: `aa753a5f485f8c72421eaa4ceaa4cba83500c3fe`

- 144 focused and adjacent tests passed across queue admission, transcript
  commitment, payload projection, stream preparation/finalization/settlement,
  subscription delivery, phase lifecycle, and AgentSession loop correctness.
- After the final conflict-free rebase, 28 directly affected tests passed
  across the three changed test surfaces.
- Changed-file TypeScript diagnostics and the production core TypeScript graph
  passed before the final patch-only rebase.
- Formatting, targeted lint, and `git diff --check` passed on the final head.
- Fresh autoreview found no actionable defects after the queue race and
  prompt-lock cleanup gap were fixed.
- Exact-head private-QA build completed from a standalone clean clone.
- Real packaged Gateway proof passed with a temporary
  `before_agent_finalize` plugin and mock OpenAI provider:
  - the first hook call observed `VISIBLE-SKILL-OK` and requested a revision;
  - the second provider request contained the replacement instruction but did
    not contain the rejected answer;
  - the second hook call observed `REPLACEMENT_RESPONSE` and continued;
  - the run completed with status `ok`, and qa-channel delivered only
    `REPLACEMENT_RESPONSE`.

  Redacted terminal result from the exact-head packaged run:

  ```json
  {
    "verdict": "PASS",
    "waited": {
      "status": "ok",
      "stopReason": "stop"
    },
    "hookEvents": [
      {
        "call": 1,
        "lastAssistantMessage": "VISIBLE-SKILL-OK"
      },
      {
        "call": 2,
        "lastAssistantMessage": "REPLACEMENT_RESPONSE"
      }
    ],
    "providerRequestCount": 2,
    "retryInputContainsRejectedText": false,
    "outboundTexts": [
      "REPLACEMENT_RESPONSE"
    ]
  }
  ```
- Blacksmith Testbox was unavailable because this machine was not
  authenticated, and direct AWS Crabbox was unavailable because its broker was
  not configured. Per trusted-source fallback policy, the packaged live proof
  ran locally in the isolated exact-head clone.
- Hosted CI is validating the exact final head; no selected job is failing.

## Release Notes

Release-note context is included here; the root changelog is release-owned.
