### PR TITLE
fix(test): keep plugin install fixtures portable

### DIFF
--- a/src/plugins/test-helpers/fs-fixtures.ts
+++ b/src/plugins/test-helpers/fs-fixtures.ts
@@ -58,10 +58,7 @@ export async function cleanupTrackedTempDirsAsync(trackedDirs: string[]) {
 }
 
 /** Creates a per-suite temp-root tracker with deterministic case directory names. */
-export function createSuiteTempRootTracker(
-  prefix: string,
-  baseDir = path.join(process.cwd(), ".tmp"),
-) {
+export function createSuiteTempRootTracker(prefix: string, baseDir = os.tmpdir()) {
   let suiteTempRoot = "";
   let tempDirCounter = 0;
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where plugin install tests failed on hardened Linux runners when repository parent-directory permissions made repo-local fixture executables fail the install-policy security check.

## Why This Change Was Made

Default suite fixture roots now use the operating system temporary directory, matching the repository's other temp helpers and preserving sticky-directory security semantics. Callers that deliberately provide a cache directory keep their explicit override.

## User Impact

No product behavior changes. Maintainers can run the plugin install suites across checkout permission layouts without false security-policy failures.

## Evidence

- Failure reproduced in the full Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/30464029744
- Focused Blacksmith Testbox: `src/plugins/install.test.ts`, `install.path.test.ts`, and `install.npm-spec.test.ts`; 3 files and 171 tests passed: https://github.com/openclaw/openclaw/actions/runs/30473771727
- `check:changed` passed on Blacksmith Testbox, including formatting, Knip scans, boundaries, typechecks, and lint: https://github.com/openclaw/openclaw/actions/runs/30474155173
- Fresh autoreview: clean, no actionable findings (0.91).
- `git diff --check` passes.
