### PR TITLE
fix(agents): edit tool rewrites line endings on lines it did not touch

### DIFF
--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { normalizeToLF } from "../../line-endings.js";
-import { applyEditsToNormalizedContent, generateDiffString } from "./edit-diff.js";
+import { applyEditsPreservingLineEndings, generateDiffString } from "./edit-diff.js";
 
 function getMismatchMessage(
   content: string,
   edits: Array<{ oldText: string; newText: string }>,
 ): string {
   try {
-    applyEditsToNormalizedContent(normalizeToLF(content), edits, "test.ts");
+    applyEditsPreservingLineEndings(content, edits, "test.ts");
   } catch (error) {
     return error instanceof Error ? error.message : String(error);
   }
@@ -142,8 +141,8 @@ describe("applyEditsToNormalizedContent uniqueness", () => {
   it("replaces an exactly unique match when trailing whitespace makes a sibling line fuzzy-identical", () => {
     const content = "foo();  \nfoo();\nbar();\n";
 
-    const result = applyEditsToNormalizedContent(
-      normalizeToLF(content),
+    const result = applyEditsPreservingLineEndings(
+      content,
       [{ oldText: "foo();\n", newText: "baz();\n" }],
       "test.ts",
     );
@@ -157,8 +156,8 @@ describe("applyEditsToNormalizedContent fuzzy uniqueness", () => {
     const content = "foo();  \nfoo();\t\nbar();\n";
 
     expect(() =>
-      applyEditsToNormalizedContent(
-        normalizeToLF(content),
+      applyEditsPreservingLineEndings(
+        content,
         [{ oldText: "foo();\n", newText: "baz();\n" }],
         "test.ts",
       ),

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -423,7 +423,7 @@ function applyEdits(normalizedContent: string, edits: Edit[], path: string): App
   };
 }
 
-export function applyEditsToNormalizedContent(
+function applyEditsToNormalizedContent(
   normalizedContent: string,
   edits: Edit[],
   path: string,

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -5,7 +5,7 @@
 
 import { constants } from "node:fs";
 import { access, readFile } from "node:fs/promises";
-import { type Change, createPatch, diffLines, FILE_HEADERS_ONLY, structuredPatch } from "diff";
+import { createPatch, FILE_HEADERS_ONLY, structuredPatch } from "diff";
 import { levenshteinDistance } from "../../../shared/levenshtein-distance.js";
 import { detectLineEnding, normalizeToLF } from "../../line-endings.js";
 import { resolveToCwd } from "./path-utils.js";
@@ -82,6 +82,12 @@ interface LineSpan {
   end: number;
 }
 
+interface ReplacementGroup {
+  startLine: number;
+  endLine: number;
+  replacements: TextReplacement[];
+}
+
 function splitLinesWithEndings(content: string): string[] {
   return content.match(/[^\n]*\n|[^\n]+/g) ?? [];
 }
@@ -131,6 +137,26 @@ function applyReplacements(content: string, replacements: TextReplacement[], off
   return result;
 }
 
+function groupReplacementsByLine(
+  baseContent: string,
+  replacements: TextReplacement[],
+): { lines: LineSpan[]; groups: ReplacementGroup[] } {
+  const lines = getLineSpans(baseContent);
+  const groups: ReplacementGroup[] = [];
+  const sortedReplacements = replacements.toSorted((a, b) => a.matchIndex - b.matchIndex);
+  for (const replacement of sortedReplacements) {
+    const range = getReplacementLineRange(lines, replacement);
+    const current = groups.at(-1);
+    if (current && range.startLine < current.endLine) {
+      current.endLine = Math.max(current.endLine, range.endLine);
+      current.replacements.push(replacement);
+    } else {
+      groups.push({ ...range, replacements: [replacement] });
+    }
+  }
+  return { lines, groups };
+}
+
 /**
  * Rewrite only lines touched by fuzzy replacements. Untouched lines retain
  * their original bytes even though matching used normalized content.
@@ -141,28 +167,11 @@ function applyReplacementsPreservingUnchangedLines(
   replacements: TextReplacement[],
 ): string {
   const originalLines = splitLinesWithEndings(originalContent);
-  const baseLines = getLineSpans(baseContent);
+  const { lines: baseLines, groups } = groupReplacementsByLine(baseContent, replacements);
   if (originalLines.length !== baseLines.length) {
     throw new Error(
       "Cannot preserve unchanged lines because the base content has a different line count.",
     );
-  }
-
-  const groups: Array<{
-    startLine: number;
-    endLine: number;
-    replacements: TextReplacement[];
-  }> = [];
-  const sortedReplacements = replacements.toSorted((a, b) => a.matchIndex - b.matchIndex);
-  for (const replacement of sortedReplacements) {
-    const range = getReplacementLineRange(baseLines, replacement);
-    const current = groups.at(-1);
-    if (current && range.startLine < current.endLine) {
-      current.endLine = Math.max(current.endLine, range.endLine);
-      current.replacements.push(replacement);
-    } else {
-      groups.push({ ...range, replacements: [replacement] });
-    }
   }
 
   let originalLineIndex = 0;
@@ -184,6 +193,13 @@ function applyReplacementsPreservingUnchangedLines(
     originalLineIndex = group.endLine;
   }
   return result + originalLines.slice(originalLineIndex).join("");
+}
+
+interface AppliedEdits {
+  baseContent: string;
+  newContent: string;
+  replacementBaseContent: string;
+  replacements: MatchedEdit[];
 }
 
 /**
@@ -444,11 +460,11 @@ function getNoChangeError(path: string, totalEdits: number): EditNoChangeError {
  * then applied in reverse order so offsets remain stable. If any edit needs
  * fuzzy matching, only touched lines are rewritten from normalized content.
  */
-export function applyEditsToNormalizedContent(
+function applyEdits(
   normalizedContent: string,
   edits: Edit[],
   path: string,
-): { baseContent: string; newContent: string } {
+): AppliedEdits {
   const normalizedEdits = edits.map((edit) => ({
     oldText: normalizeToLF(edit.oldText),
     newText: normalizeToLF(edit.newText),
@@ -520,6 +536,20 @@ export function applyEditsToNormalizedContent(
     throw getNoChangeError(path, normalizedEdits.length);
   }
 
+  return {
+    baseContent,
+    newContent,
+    replacementBaseContent,
+    replacements: matchedEdits,
+  };
+}
+
+export function applyEditsToNormalizedContent(
+  normalizedContent: string,
+  edits: Edit[],
+  path: string,
+): { baseContent: string; newContent: string } {
+  const { baseContent, newContent } = applyEdits(normalizedContent, edits, path);
   return { baseContent, newContent };
 }
 
@@ -542,60 +572,125 @@ function getLineTerminator(line: string | undefined): LineTerminator | undefined
   return line.endsWith("\r") ? "\r" : undefined;
 }
 
-function getRemovedLineCount(part: Change | undefined): number {
-  return part?.removed ? (part.count ?? 0) : 0;
-}
-
-function restoreReplacedLineEndings(
-  addedText: string,
-  replacedLines: string[],
+function restoreNormalizedLineEndings(
+  normalizedContent: string,
+  sourceLines: string[],
   fallback: LineTerminator,
 ): string {
-  const addedLines = splitLinesWithTerminators(addedText);
-  // Align from the end so the boundary before untouched content keeps the
-  // terminator of the last replaced line when replacements collapse lines.
-  const sourceOffset = Math.max(0, replacedLines.length - addedLines.length);
-  let result = "";
-  for (const [index, line] of addedLines.entries()) {
-    if (!line.endsWith("\n")) {
-      result += line;
-      continue;
-    }
-    const source = replacedLines[sourceOffset + index] ?? replacedLines.at(-1);
-    result += line.replace(/\r?\n$/, "") + (getLineTerminator(source) ?? fallback);
-  }
-  return result;
+  let sourceIndex = 0;
+  return normalizedContent.replace(/\n/g, () => {
+    const source = sourceLines[sourceIndex] ?? sourceLines.at(-1);
+    sourceIndex++;
+    return getLineTerminator(source) ?? fallback;
+  });
 }
 
-export function restoreOriginalLineEndings(
+function countLineBreaks(content: string): number {
+  return content.match(/\n/g)?.length ?? 0;
+}
+
+function applyReplacementsPreservingLineEndings(
   originalContent: string,
-  updatedContent: string,
+  baseContent: string,
+  replacements: TextReplacement[],
 ): string {
   const originalLines = splitLinesWithTerminators(originalContent);
-  const normalizedContent = originalLines.map((line) => line.replace(/\r\n?$/, "\n")).join("");
-  const parts = diffLines(normalizedContent, updatedContent);
-  let ending: LineTerminator =
-    getLineTerminator(originalLines[0]) ?? detectLineEnding(originalContent);
+  const { lines: baseLines, groups } = groupReplacementsByLine(baseContent, replacements);
+  if (originalLines.length !== baseLines.length) {
+    throw new Error(
+      "Cannot preserve original line endings because the base content has a different line count.",
+    );
+  }
+
+  const fileFallback = detectLineEnding(originalContent);
   let originalIndex = 0;
   let result = "";
-  for (const [index, part] of parts.entries()) {
-    if (part.added) {
-      const removedBefore = getRemovedLineCount(parts[index - 1]);
-      const removedAfter = getRemovedLineCount(parts[index + 1]);
-      const replacedLines = removedBefore
-        ? originalLines.slice(originalIndex - removedBefore, originalIndex)
-        : originalLines.slice(originalIndex, originalIndex + Math.max(removedAfter, 1));
-      result += restoreReplacedLineEndings(part.value, replacedLines, ending);
-      continue;
+  for (const group of groups) {
+    result += originalLines.slice(originalIndex, group.startLine).join("");
+    const firstLine = baseLines.at(group.startLine);
+    const lastLine = baseLines.at(group.endLine - 1);
+    if (!firstLine || !lastLine) {
+      throw new Error("Replacement group is outside the base content.");
     }
-    const lines = originalLines.slice(originalIndex, originalIndex + (part.count ?? 0));
-    if (!part.removed) {
-      result += lines.join("");
-    }
-    ending = getLineTerminator(lines.at(-1)) ?? ending;
-    originalIndex += lines.length;
+
+    const groupStartOffset = firstLine.start;
+    const normalizedGroup = baseContent.slice(groupStartOffset, lastLine.end);
+    const sourceGroup = originalLines.slice(group.startLine, group.endLine);
+    const groupFallback =
+      getLineTerminator(sourceGroup[0]) ??
+      getLineTerminator(originalLines[group.startLine - 1]) ??
+      fileFallback;
+    const restoredGroup = restoreNormalizedLineEndings(
+      normalizedGroup,
+      sourceGroup,
+      groupFallback,
+    );
+    const restoredReplacements = group.replacements.map((replacement) => {
+      const relativeStart = replacement.matchIndex - groupStartOffset;
+      const relativeEnd = relativeStart + replacement.matchLength;
+      const restoredStart = restoreNormalizedLineEndings(
+        normalizedGroup.slice(0, relativeStart),
+        sourceGroup,
+        groupFallback,
+      ).length;
+      const restoredEnd = restoreNormalizedLineEndings(
+        normalizedGroup.slice(0, relativeEnd),
+        sourceGroup,
+        groupFallback,
+      ).length;
+      const range = getReplacementLineRange(baseLines, replacement);
+      const replacementSource = originalLines.slice(range.startLine, range.endLine);
+      const replacementFallback =
+        getLineTerminator(replacementSource[0]) ??
+        getLineTerminator(originalLines[range.startLine - 1]) ??
+        fileFallback;
+      const consumedTerminatorCount = countLineBreaks(
+        normalizedGroup.slice(relativeStart, relativeEnd),
+      );
+      const replacementTerminatorCount = countLineBreaks(replacement.newText);
+      const terminatorSources =
+        consumedTerminatorCount > 0
+          ? replacementSource.slice(0, consumedTerminatorCount)
+          : replacementSource.slice(0, 1);
+      const sourceOffset = Math.max(
+        0,
+        terminatorSources.length - replacementTerminatorCount,
+      );
+      return {
+        matchIndex: restoredStart,
+        matchLength: restoredEnd - restoredStart,
+        newText: restoreNormalizedLineEndings(
+          replacement.newText,
+          terminatorSources.slice(sourceOffset),
+          replacementFallback,
+        ),
+      };
+    });
+    result += applyReplacements(restoredGroup, restoredReplacements);
+    originalIndex = group.endLine;
   }
-  return result;
+  return result + originalLines.slice(originalIndex).join("");
+}
+
+export function applyEditsPreservingLineEndings(
+  originalContent: string,
+  edits: Edit[],
+  path: string,
+): { baseContent: string; newContent: string; finalContent: string } {
+  const applied = applyEdits(normalizeToLF(originalContent), edits, path);
+  const finalContent = applyReplacementsPreservingLineEndings(
+    originalContent,
+    applied.replacementBaseContent,
+    applied.replacements,
+  );
+  if (normalizeToLF(finalContent) !== applied.newContent) {
+    throw new Error("Line-ending restoration changed the normalized edit result.");
+  }
+  return {
+    baseContent: applied.baseContent,
+    newContent: applied.newContent,
+    finalContent,
+  };
 }
 
 /** Generate a standard unified patch. */

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -570,7 +570,8 @@ export function restoreOriginalLineEndings(
   const originalLines = splitLinesWithTerminators(originalContent);
   const normalizedContent = originalLines.map((line) => line.replace(/\r\n?$/, "\n")).join("");
   const parts = diffLines(normalizedContent, updatedContent);
-  let ending: LineTerminator = detectLineEnding(originalContent);
+  let ending: LineTerminator =
+    getLineTerminator(originalLines[0]) ?? detectLineEnding(originalContent);
   let originalIndex = 0;
   let result = "";
   for (const [index, part] of parts.entries()) {

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -551,13 +551,17 @@ function restoreReplacedLineEndings(
   replacedLines: string[],
   fallback: LineTerminator,
 ): string {
+  const addedLines = splitLinesWithTerminators(addedText);
+  // Align from the end so the boundary before untouched content keeps the
+  // terminator of the last replaced line when replacements collapse lines.
+  const sourceOffset = Math.max(0, replacedLines.length - addedLines.length);
   let result = "";
-  for (const [index, line] of splitLinesWithTerminators(addedText).entries()) {
+  for (const [index, line] of addedLines.entries()) {
     if (!line.endsWith("\n")) {
       result += line;
       continue;
     }
-    const source = replacedLines[index] ?? replacedLines.at(-1);
+    const source = replacedLines[sourceOffset + index] ?? replacedLines.at(-1);
     result += line.replace(/\r?\n$/, "") + (getLineTerminator(source) ?? fallback);
   }
   return result;
@@ -580,7 +584,7 @@ export function restoreOriginalLineEndings(
       const removedAfter = getRemovedLineCount(parts[index + 1]);
       const replacedLines = removedBefore
         ? originalLines.slice(originalIndex - removedBefore, originalIndex)
-        : originalLines.slice(originalIndex, originalIndex + removedAfter);
+        : originalLines.slice(originalIndex, originalIndex + Math.max(removedAfter, 1));
       result += restoreReplacedLineEndings(part.value, replacedLines, ending);
       continue;
     }

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -5,9 +5,9 @@
 
 import { constants } from "node:fs";
 import { access, readFile } from "node:fs/promises";
-import { createPatch, FILE_HEADERS_ONLY, structuredPatch } from "diff";
+import { type Change, createPatch, diffLines, FILE_HEADERS_ONLY, structuredPatch } from "diff";
 import { levenshteinDistance } from "../../../shared/levenshtein-distance.js";
-import { normalizeToLF } from "../../line-endings.js";
+import { detectLineEnding, normalizeToLF } from "../../line-endings.js";
 import { resolveToCwd } from "./path-utils.js";
 
 /**
@@ -521,6 +521,76 @@ export function applyEditsToNormalizedContent(
   }
 
   return { baseContent, newContent };
+}
+
+function splitLinesWithTerminators(content: string): string[] {
+  return content.match(/[^\r\n]*(?:\r\n|\r|\n)|[^\r\n]+/g) ?? [];
+}
+
+type LineTerminator = "\r\n" | "\r" | "\n";
+
+function getLineTerminator(line: string | undefined): LineTerminator | undefined {
+  if (line === undefined) {
+    return undefined;
+  }
+  if (line.endsWith("\r\n")) {
+    return "\r\n";
+  }
+  if (line.endsWith("\n")) {
+    return "\n";
+  }
+  return line.endsWith("\r") ? "\r" : undefined;
+}
+
+function getRemovedLineCount(part: Change | undefined): number {
+  return part?.removed ? (part.count ?? 0) : 0;
+}
+
+function restoreReplacedLineEndings(
+  addedText: string,
+  replacedLines: string[],
+  fallback: LineTerminator,
+): string {
+  let result = "";
+  for (const [index, line] of splitLinesWithTerminators(addedText).entries()) {
+    if (!line.endsWith("\n")) {
+      result += line;
+      continue;
+    }
+    const source = replacedLines[index] ?? replacedLines.at(-1);
+    result += line.replace(/\r?\n$/, "") + (getLineTerminator(source) ?? fallback);
+  }
+  return result;
+}
+
+export function restoreOriginalLineEndings(
+  originalContent: string,
+  updatedContent: string,
+): string {
+  const originalLines = splitLinesWithTerminators(originalContent);
+  const normalizedContent = originalLines.map((line) => line.replace(/\r\n?$/, "\n")).join("");
+  const parts = diffLines(normalizedContent, updatedContent);
+  let ending: LineTerminator = detectLineEnding(originalContent);
+  let originalIndex = 0;
+  let result = "";
+  for (const [index, part] of parts.entries()) {
+    if (part.added) {
+      const removedBefore = getRemovedLineCount(parts[index - 1]);
+      const removedAfter = getRemovedLineCount(parts[index + 1]);
+      const replacedLines = removedBefore
+        ? originalLines.slice(originalIndex - removedBefore, originalIndex)
+        : originalLines.slice(originalIndex, originalIndex + removedAfter);
+      result += restoreReplacedLineEndings(part.value, replacedLines, ending);
+      continue;
+    }
+    const lines = originalLines.slice(originalIndex, originalIndex + (part.count ?? 0));
+    if (!part.removed) {
+      result += lines.join("");
+    }
+    ending = getLineTerminator(lines.at(-1)) ?? ending;
+    originalIndex += lines.length;
+  }
+  return result;
 }
 
 /** Generate a standard unified patch. */

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -7,7 +7,13 @@ import { constants } from "node:fs";
 import { access, readFile } from "node:fs/promises";
 import { createPatch, FILE_HEADERS_ONLY, structuredPatch } from "diff";
 import { levenshteinDistance } from "../../../shared/levenshtein-distance.js";
-import { detectLineEnding, normalizeToLF } from "../../line-endings.js";
+import { normalizeToLF } from "../../line-endings.js";
+import {
+  applyReplacements,
+  applyReplacementsPreservingLineEndings,
+  applyReplacementsPreservingUnchangedLines,
+  type TextReplacement,
+} from "./edit-replacements.js";
 import { resolveToCwd } from "./path-utils.js";
 
 /**
@@ -68,131 +74,8 @@ export class EditNoChangeError extends Error {
   }
 }
 
-interface MatchedEdit {
+interface MatchedEdit extends TextReplacement {
   editIndex: number;
-  matchIndex: number;
-  matchLength: number;
-  newText: string;
-}
-
-type TextReplacement = Pick<MatchedEdit, "matchIndex" | "matchLength" | "newText">;
-
-interface LineSpan {
-  start: number;
-  end: number;
-}
-
-interface ReplacementGroup {
-  startLine: number;
-  endLine: number;
-  replacements: TextReplacement[];
-}
-
-function splitLinesWithEndings(content: string): string[] {
-  return content.match(/[^\n]*\n|[^\n]+/g) ?? [];
-}
-
-function getLineSpans(content: string): LineSpan[] {
-  let offset = 0;
-  return splitLinesWithEndings(content).map((line) => {
-    const span = { start: offset, end: offset + line.length };
-    offset = span.end;
-    return span;
-  });
-}
-
-function getReplacementLineRange(lines: LineSpan[], replacement: TextReplacement) {
-  const replacementStart = replacement.matchIndex;
-  const replacementEnd = replacement.matchIndex + replacement.matchLength;
-  const startLine = lines.findIndex(
-    (line) => replacementStart >= line.start && replacementStart < line.end,
-  );
-  if (startLine === -1) {
-    throw new Error("Replacement range is outside the base content.");
-  }
-
-  let endLine = startLine;
-  while (endLine < lines.length) {
-    const line = lines.at(endLine);
-    if (!line || line.end >= replacementEnd) {
-      break;
-    }
-    endLine++;
-  }
-  if (endLine >= lines.length) {
-    throw new Error("Replacement range is outside the base content.");
-  }
-  return { startLine, endLine: endLine + 1 };
-}
-
-function applyReplacements(content: string, replacements: TextReplacement[], offset = 0): string {
-  let result = content;
-  for (const replacement of replacements.toReversed()) {
-    const matchIndex = replacement.matchIndex - offset;
-    result =
-      result.slice(0, matchIndex) +
-      replacement.newText +
-      result.slice(matchIndex + replacement.matchLength);
-  }
-  return result;
-}
-
-function groupReplacementsByLine(
-  baseContent: string,
-  replacements: TextReplacement[],
-): { lines: LineSpan[]; groups: ReplacementGroup[] } {
-  const lines = getLineSpans(baseContent);
-  const groups: ReplacementGroup[] = [];
-  const sortedReplacements = replacements.toSorted((a, b) => a.matchIndex - b.matchIndex);
-  for (const replacement of sortedReplacements) {
-    const range = getReplacementLineRange(lines, replacement);
-    const current = groups.at(-1);
-    if (current && range.startLine < current.endLine) {
-      current.endLine = Math.max(current.endLine, range.endLine);
-      current.replacements.push(replacement);
-    } else {
-      groups.push({ ...range, replacements: [replacement] });
-    }
-  }
-  return { lines, groups };
-}
-
-/**
- * Rewrite only lines touched by fuzzy replacements. Untouched lines retain
- * their original bytes even though matching used normalized content.
- */
-function applyReplacementsPreservingUnchangedLines(
-  originalContent: string,
-  baseContent: string,
-  replacements: TextReplacement[],
-): string {
-  const originalLines = splitLinesWithEndings(originalContent);
-  const { lines: baseLines, groups } = groupReplacementsByLine(baseContent, replacements);
-  if (originalLines.length !== baseLines.length) {
-    throw new Error(
-      "Cannot preserve unchanged lines because the base content has a different line count.",
-    );
-  }
-
-  let originalLineIndex = 0;
-  let result = "";
-  for (const group of groups) {
-    result += originalLines.slice(originalLineIndex, group.startLine).join("");
-    const firstLine = baseLines.at(group.startLine);
-    const lastLine = baseLines.at(group.endLine - 1);
-    if (!firstLine || !lastLine) {
-      throw new Error("Replacement group is outside the base content.");
-    }
-    const groupStartOffset = firstLine.start;
-    const groupEndOffset = lastLine.end;
-    result += applyReplacements(
-      baseContent.slice(groupStartOffset, groupEndOffset),
-      group.replacements,
-      groupStartOffset,
-    );
-    originalLineIndex = group.endLine;
-  }
-  return result + originalLines.slice(originalLineIndex).join("");
 }
 
 interface AppliedEdits {
@@ -460,11 +343,7 @@ function getNoChangeError(path: string, totalEdits: number): EditNoChangeError {
  * then applied in reverse order so offsets remain stable. If any edit needs
  * fuzzy matching, only touched lines are rewritten from normalized content.
  */
-function applyEdits(
-  normalizedContent: string,
-  edits: Edit[],
-  path: string,
-): AppliedEdits {
+function applyEdits(normalizedContent: string, edits: Edit[], path: string): AppliedEdits {
   const normalizedEdits = edits.map((edit) => ({
     oldText: normalizeToLF(edit.oldText),
     newText: normalizeToLF(edit.newText),
@@ -551,125 +430,6 @@ export function applyEditsToNormalizedContent(
 ): { baseContent: string; newContent: string } {
   const { baseContent, newContent } = applyEdits(normalizedContent, edits, path);
   return { baseContent, newContent };
-}
-
-function splitLinesWithTerminators(content: string): string[] {
-  return content.match(/[^\r\n]*(?:\r\n|\r|\n)|[^\r\n]+/g) ?? [];
-}
-
-type LineTerminator = "\r\n" | "\r" | "\n";
-
-function getLineTerminator(line: string | undefined): LineTerminator | undefined {
-  if (line === undefined) {
-    return undefined;
-  }
-  if (line.endsWith("\r\n")) {
-    return "\r\n";
-  }
-  if (line.endsWith("\n")) {
-    return "\n";
-  }
-  return line.endsWith("\r") ? "\r" : undefined;
-}
-
-function restoreNormalizedLineEndings(
-  normalizedContent: string,
-  sourceLines: string[],
-  fallback: LineTerminator,
-): string {
-  let sourceIndex = 0;
-  return normalizedContent.replace(/\n/g, () => {
-    const source = sourceLines[sourceIndex] ?? sourceLines.at(-1);
-    sourceIndex++;
-    return getLineTerminator(source) ?? fallback;
-  });
-}
-
-function countLineBreaks(content: string): number {
-  return content.match(/\n/g)?.length ?? 0;
-}
-
-function applyReplacementsPreservingLineEndings(
-  originalContent: string,
-  baseContent: string,
-  replacements: TextReplacement[],
-): string {
-  const originalLines = splitLinesWithTerminators(originalContent);
-  const { lines: baseLines, groups } = groupReplacementsByLine(baseContent, replacements);
-  if (originalLines.length !== baseLines.length) {
-    throw new Error(
-      "Cannot preserve original line endings because the base content has a different line count.",
-    );
-  }
-
-  const fileFallback = detectLineEnding(originalContent);
-  let originalIndex = 0;
-  let result = "";
-  for (const group of groups) {
-    result += originalLines.slice(originalIndex, group.startLine).join("");
-    const firstLine = baseLines.at(group.startLine);
-    const lastLine = baseLines.at(group.endLine - 1);
-    if (!firstLine || !lastLine) {
-      throw new Error("Replacement group is outside the base content.");
-    }
-
-    const groupStartOffset = firstLine.start;
-    const normalizedGroup = baseContent.slice(groupStartOffset, lastLine.end);
-    const sourceGroup = originalLines.slice(group.startLine, group.endLine);
-    const groupFallback =
-      getLineTerminator(sourceGroup[0]) ??
-      getLineTerminator(originalLines[group.startLine - 1]) ??
-      fileFallback;
-    const restoredGroup = restoreNormalizedLineEndings(
-      normalizedGroup,
-      sourceGroup,
-      groupFallback,
-    );
-    const restoredReplacements = group.replacements.map((replacement) => {
-      const relativeStart = replacement.matchIndex - groupStartOffset;
-      const relativeEnd = relativeStart + replacement.matchLength;
-      const restoredStart = restoreNormalizedLineEndings(
-        normalizedGroup.slice(0, relativeStart),
-        sourceGroup,
-        groupFallback,
-      ).length;
-      const restoredEnd = restoreNormalizedLineEndings(
-        normalizedGroup.slice(0, relativeEnd),
-        sourceGroup,
-        groupFallback,
-      ).length;
-      const range = getReplacementLineRange(baseLines, replacement);
-      const replacementSource = originalLines.slice(range.startLine, range.endLine);
-      const replacementFallback =
-        getLineTerminator(replacementSource[0]) ??
-        getLineTerminator(originalLines[range.startLine - 1]) ??
-        fileFallback;
-      const consumedTerminatorCount = countLineBreaks(
-        normalizedGroup.slice(relativeStart, relativeEnd),
-      );
-      const replacementTerminatorCount = countLineBreaks(replacement.newText);
-      const terminatorSources =
-        consumedTerminatorCount > 0
-          ? replacementSource.slice(0, consumedTerminatorCount)
-          : replacementSource.slice(0, 1);
-      const sourceOffset = Math.max(
-        0,
-        terminatorSources.length - replacementTerminatorCount,
-      );
-      return {
-        matchIndex: restoredStart,
-        matchLength: restoredEnd - restoredStart,
-        newText: restoreNormalizedLineEndings(
-          replacement.newText,
-          terminatorSources.slice(sourceOffset),
-          replacementFallback,
-        ),
-      };
-    });
-    result += applyReplacements(restoredGroup, restoredReplacements);
-    originalIndex = group.endLine;
-  }
-  return result + originalLines.slice(originalIndex).join("");
 }
 
 export function applyEditsPreservingLineEndings(

--- a/src/agents/sessions/tools/edit-replacements.ts
+++ b/src/agents/sessions/tools/edit-replacements.ts
@@ -1,0 +1,240 @@
+import { detectLineEnding } from "../../line-endings.js";
+
+export interface TextReplacement {
+  matchIndex: number;
+  matchLength: number;
+  newText: string;
+}
+
+interface LineSpan {
+  start: number;
+  end: number;
+}
+
+interface ReplacementGroup {
+  startLine: number;
+  endLine: number;
+  replacements: TextReplacement[];
+}
+
+function splitLinesWithEndings(content: string): string[] {
+  return content.match(/[^\n]*\n|[^\n]+/g) ?? [];
+}
+
+function getLineSpans(content: string): LineSpan[] {
+  let offset = 0;
+  return splitLinesWithEndings(content).map((line) => {
+    const span = { start: offset, end: offset + line.length };
+    offset = span.end;
+    return span;
+  });
+}
+
+function getReplacementLineRange(lines: LineSpan[], replacement: TextReplacement) {
+  const replacementStart = replacement.matchIndex;
+  const replacementEnd = replacement.matchIndex + replacement.matchLength;
+  const startLine = lines.findIndex(
+    (line) => replacementStart >= line.start && replacementStart < line.end,
+  );
+  if (startLine === -1) {
+    throw new Error("Replacement range is outside the base content.");
+  }
+
+  let endLine = startLine;
+  while (endLine < lines.length) {
+    const line = lines.at(endLine);
+    if (!line || line.end >= replacementEnd) {
+      break;
+    }
+    endLine++;
+  }
+  if (endLine >= lines.length) {
+    throw new Error("Replacement range is outside the base content.");
+  }
+  return { startLine, endLine: endLine + 1 };
+}
+
+export function applyReplacements(
+  content: string,
+  replacements: TextReplacement[],
+  offset = 0,
+): string {
+  let result = content;
+  for (const replacement of replacements.toReversed()) {
+    const matchIndex = replacement.matchIndex - offset;
+    result =
+      result.slice(0, matchIndex) +
+      replacement.newText +
+      result.slice(matchIndex + replacement.matchLength);
+  }
+  return result;
+}
+
+function groupReplacementsByLine(
+  baseContent: string,
+  replacements: TextReplacement[],
+): { lines: LineSpan[]; groups: ReplacementGroup[] } {
+  const lines = getLineSpans(baseContent);
+  const groups: ReplacementGroup[] = [];
+  const sortedReplacements = replacements.toSorted((a, b) => a.matchIndex - b.matchIndex);
+  for (const replacement of sortedReplacements) {
+    const range = getReplacementLineRange(lines, replacement);
+    const current = groups.at(-1);
+    if (current && range.startLine < current.endLine) {
+      current.endLine = Math.max(current.endLine, range.endLine);
+      current.replacements.push(replacement);
+    } else {
+      groups.push({ ...range, replacements: [replacement] });
+    }
+  }
+  return { lines, groups };
+}
+
+/**
+ * Rewrite only lines touched by fuzzy replacements. Untouched lines retain
+ * their original bytes even though matching used normalized content.
+ */
+export function applyReplacementsPreservingUnchangedLines(
+  originalContent: string,
+  baseContent: string,
+  replacements: TextReplacement[],
+): string {
+  const originalLines = splitLinesWithEndings(originalContent);
+  const { lines: baseLines, groups } = groupReplacementsByLine(baseContent, replacements);
+  if (originalLines.length !== baseLines.length) {
+    throw new Error(
+      "Cannot preserve unchanged lines because the base content has a different line count.",
+    );
+  }
+
+  let originalLineIndex = 0;
+  let result = "";
+  for (const group of groups) {
+    result += originalLines.slice(originalLineIndex, group.startLine).join("");
+    const firstLine = baseLines.at(group.startLine);
+    const lastLine = baseLines.at(group.endLine - 1);
+    if (!firstLine || !lastLine) {
+      throw new Error("Replacement group is outside the base content.");
+    }
+    const groupStartOffset = firstLine.start;
+    result += applyReplacements(
+      baseContent.slice(groupStartOffset, lastLine.end),
+      group.replacements,
+      groupStartOffset,
+    );
+    originalLineIndex = group.endLine;
+  }
+  return result + originalLines.slice(originalLineIndex).join("");
+}
+
+function splitLinesWithTerminators(content: string): string[] {
+  return content.match(/[^\r\n]*(?:\r\n|\r|\n)|[^\r\n]+/g) ?? [];
+}
+
+type LineTerminator = "\r\n" | "\r" | "\n";
+
+function getLineTerminator(line: string | undefined): LineTerminator | undefined {
+  if (line === undefined) {
+    return undefined;
+  }
+  if (line.endsWith("\r\n")) {
+    return "\r\n";
+  }
+  if (line.endsWith("\n")) {
+    return "\n";
+  }
+  return line.endsWith("\r") ? "\r" : undefined;
+}
+
+function restoreNormalizedLineEndings(
+  normalizedContent: string,
+  sourceLines: string[],
+  fallback: LineTerminator,
+): string {
+  let sourceIndex = 0;
+  return normalizedContent.replace(/\n/g, () => {
+    const source = sourceLines[sourceIndex] ?? sourceLines.at(-1);
+    sourceIndex++;
+    return getLineTerminator(source) ?? fallback;
+  });
+}
+
+function countLineBreaks(content: string): number {
+  return content.match(/\n/g)?.length ?? 0;
+}
+
+export function applyReplacementsPreservingLineEndings(
+  originalContent: string,
+  baseContent: string,
+  replacements: TextReplacement[],
+): string {
+  const originalLines = splitLinesWithTerminators(originalContent);
+  const { lines: baseLines, groups } = groupReplacementsByLine(baseContent, replacements);
+  if (originalLines.length !== baseLines.length) {
+    throw new Error(
+      "Cannot preserve original line endings because the base content has a different line count.",
+    );
+  }
+
+  const fileFallback = detectLineEnding(originalContent);
+  let originalIndex = 0;
+  let result = "";
+  for (const group of groups) {
+    result += originalLines.slice(originalIndex, group.startLine).join("");
+    const firstLine = baseLines.at(group.startLine);
+    const lastLine = baseLines.at(group.endLine - 1);
+    if (!firstLine || !lastLine) {
+      throw new Error("Replacement group is outside the base content.");
+    }
+
+    const groupStartOffset = firstLine.start;
+    const normalizedGroup = baseContent.slice(groupStartOffset, lastLine.end);
+    const sourceGroup = originalLines.slice(group.startLine, group.endLine);
+    const groupFallback =
+      getLineTerminator(sourceGroup[0]) ??
+      getLineTerminator(originalLines[group.startLine - 1]) ??
+      fileFallback;
+    const restoredGroup = restoreNormalizedLineEndings(normalizedGroup, sourceGroup, groupFallback);
+    const restoredReplacements = group.replacements.map((replacement) => {
+      const relativeStart = replacement.matchIndex - groupStartOffset;
+      const relativeEnd = relativeStart + replacement.matchLength;
+      const restoredStart = restoreNormalizedLineEndings(
+        normalizedGroup.slice(0, relativeStart),
+        sourceGroup,
+        groupFallback,
+      ).length;
+      const restoredEnd = restoreNormalizedLineEndings(
+        normalizedGroup.slice(0, relativeEnd),
+        sourceGroup,
+        groupFallback,
+      ).length;
+      const range = getReplacementLineRange(baseLines, replacement);
+      const replacementSource = originalLines.slice(range.startLine, range.endLine);
+      const replacementFallback =
+        getLineTerminator(replacementSource[0]) ??
+        getLineTerminator(originalLines[range.startLine - 1]) ??
+        fileFallback;
+      const consumedTerminatorCount = countLineBreaks(
+        normalizedGroup.slice(relativeStart, relativeEnd),
+      );
+      const replacementTerminatorCount = countLineBreaks(replacement.newText);
+      const terminatorSources =
+        consumedTerminatorCount > 0
+          ? replacementSource.slice(0, consumedTerminatorCount)
+          : replacementSource.slice(0, 1);
+      const sourceOffset = Math.max(0, terminatorSources.length - replacementTerminatorCount);
+      return {
+        matchIndex: restoredStart,
+        matchLength: restoredEnd - restoredStart,
+        newText: restoreNormalizedLineEndings(
+          replacement.newText,
+          terminatorSources.slice(sourceOffset),
+          replacementFallback,
+        ),
+      };
+    });
+    result += applyReplacements(restoredGroup, restoredReplacements);
+    originalIndex = group.endLine;
+  }
+  return result + originalLines.slice(originalIndex).join("");
+}

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -733,6 +733,24 @@ describe("edit tool", () => {
       expected: "prefix\ralpha\rbeta\r",
     },
     {
+      name: "uses the retained target terminator for a prefixed line",
+      original: "alpha\r\nbeta\ngamma\n",
+      edits: [{ oldText: "beta", newText: "prefix\nbeta" }],
+      expected: "alpha\r\nprefix\nbeta\ngamma\n",
+    },
+    {
+      name: "keeps the trailing boundary when replacement collapses mixed lines",
+      original: "alpha\r\nbeta\ngamma\n",
+      edits: [{ oldText: "alpha\nbeta", newText: "merged" }],
+      expected: "merged\ngamma\n",
+    },
+    {
+      name: "aligns an unterminated replacement at end of file",
+      original: "h1\r\nh2\r\none\ntwo",
+      edits: [{ oldText: "one\ntwo", newText: "x\ny" }],
+      expected: "h1\r\nh2\r\nx\ny",
+    },
+    {
       name: "keeps trailing CRLF lines when the first line ends with LF",
       original: "alpha\nbeta\r\ngamma\r\n",
       edits: [{ oldText: "alpha", newText: "ALPHA" }],

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -694,4 +694,111 @@ describe("edit tool", () => {
     expect("text" in tc1 ? tc1.text : "").toContain("Successfully replaced");
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new content\n");
   });
+
+  const lineEndingCases = [
+    {
+      name: "keeps a lone carriage return that carries data",
+      original: "start\n10%\r50%\r100%\ndone\n",
+      edits: [{ oldText: "done", newText: "finished" }],
+      expected: "start\n10%\r50%\r100%\nfinished\n",
+    },
+    {
+      name: "keeps a lone carriage return that terminates the edited line",
+      original: "prefix\rprogress\n",
+      edits: [{ oldText: "prefix", newText: "PREFIX" }],
+      expected: "PREFIX\rprogress\n",
+    },
+    {
+      name: "keeps carriage return separators when a middle record is rewritten",
+      original: "id=1\rid=2\rid=3\nfooter\n",
+      edits: [{ oldText: "id=2", newText: "id=two" }],
+      expected: "id=1\rid=two\rid=3\nfooter\n",
+    },
+    {
+      name: "expands a carriage return terminated line into carriage return terminated lines",
+      original: "id=1\rid=2\nfooter\n",
+      edits: [{ oldText: "id=1", newText: "id=1a\nid=1b" }],
+      expected: "id=1a\rid=1b\rid=2\nfooter\n",
+    },
+    {
+      name: "keeps a lone carriage return at end of file on the edited line",
+      original: "only\r",
+      edits: [{ oldText: "only", newText: "ONLY" }],
+      expected: "ONLY\r",
+    },
+    {
+      name: "keeps trailing CRLF lines when the first line ends with LF",
+      original: "alpha\nbeta\r\ngamma\r\n",
+      edits: [{ oldText: "alpha", newText: "ALPHA" }],
+      expected: "ALPHA\nbeta\r\ngamma\r\n",
+    },
+    {
+      name: "keeps trailing LF lines when the first line ends with CRLF",
+      original: "alpha\r\nbeta\ngamma\n",
+      edits: [{ oldText: "gamma", newText: "GAMMA" }],
+      expected: "alpha\r\nbeta\nGAMMA\n",
+    },
+    {
+      name: "keeps untouched lines between two separate edits",
+      original: "one\r\ntwo\nthree\r75%\rfour\nfive\r\n",
+      edits: [
+        { oldText: "one", newText: "ONE" },
+        { oldText: "five", newText: "FIVE" },
+      ],
+      expected: "ONE\r\ntwo\nthree\r75%\rfour\nFIVE\r\n",
+    },
+    {
+      name: "writes inserted lines with the terminator of the replaced line",
+      original: "alpha\r\nbeta\r\ngamma\r\n",
+      edits: [{ oldText: "beta", newText: "beta1\nbeta2" }],
+      expected: "alpha\r\nbeta1\r\nbeta2\r\ngamma\r\n",
+    },
+    {
+      name: "leaves a uniform CRLF file uniform",
+      original: "alpha\r\nbeta\r\ngamma\r\n",
+      edits: [{ oldText: "beta", newText: "BETA" }],
+      expected: "alpha\r\nBETA\r\ngamma\r\n",
+    },
+    {
+      name: "leaves a uniform LF file uniform",
+      original: "alpha\nbeta\ngamma\n",
+      edits: [{ oldText: "beta", newText: "BETA" }],
+      expected: "alpha\nBETA\ngamma\n",
+    },
+  ];
+
+  for (const testCase of lineEndingCases) {
+    it(testCase.name, async () => {
+      const filePath = await createTempFile(testCase.original);
+      const tool = createEditTool(tmpDir);
+
+      const result = await tool.execute(
+        "call-line-endings",
+        { path: filePath, edits: testCase.edits },
+        undefined,
+      );
+
+      const first = expectDefined(result.content[0], "result.content[0] test invariant");
+      expect("text" in first ? first.text : "").toContain("Successfully replaced");
+      await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(testCase.expected);
+    });
+  }
+
+  it("preserves a lone carriage return on an edited line", async () => {
+    const filePath = await createTempFile("start\nprogress 10%\rprogress 50%\ndone\n");
+    const tool = createEditTool(tmpDir);
+
+    await tool.execute(
+      "call-cr-line",
+      {
+        path: filePath,
+        edits: [{ oldText: "progress 50%", newText: "progress 90%" }],
+      },
+      undefined,
+    );
+
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(
+      "start\nprogress 10%\rprogress 90%\ndone\n",
+    );
+  });
 });

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -739,10 +739,34 @@ describe("edit tool", () => {
       expected: "alpha\r\nprefix\nbeta\ngamma\n",
     },
     {
+      name: "uses the edited target terminator for an appended line",
+      original: "alpha\r\nbeta\n",
+      edits: [{ oldText: "alpha", newText: "alpha\nsuffix" }],
+      expected: "alpha\r\nsuffix\r\nbeta\n",
+    },
+    {
+      name: "keeps neighboring duplicate line terminators unchanged",
+      original: "A\r\nB\nC\r",
+      edits: [{ oldText: "A", newText: "B" }],
+      expected: "B\r\nB\nC\r",
+    },
+    {
+      name: "preserves mixed terminators during a fuzzy multi-line edit",
+      original: "keep\r\ntarget   \nafter\r\n",
+      edits: [{ oldText: "target\nafter", newText: "TARGET\nAFTER" }],
+      expected: "keep\r\nTARGET\nAFTER\r\n",
+    },
+    {
       name: "keeps the trailing boundary when replacement collapses mixed lines",
       original: "alpha\r\nbeta\ngamma\n",
       edits: [{ oldText: "alpha\nbeta", newText: "merged" }],
       expected: "merged\ngamma\n",
+    },
+    {
+      name: "uses the last consumed terminator when collapsing complete lines",
+      original: "alpha\r\nbeta\ngamma\n",
+      edits: [{ oldText: "alpha\nbeta\n", newText: "combined\n" }],
+      expected: "combined\ngamma\n",
     },
     {
       name: "aligns an unterminated replacement at end of file",

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -727,6 +727,12 @@ describe("edit tool", () => {
       expected: "ONLY\r",
     },
     {
+      name: "uses the first carriage return for a leading inserted line",
+      original: "alpha\rbeta\r",
+      edits: [{ oldText: "alpha", newText: "prefix\nalpha" }],
+      expected: "prefix\ralpha\rbeta\r",
+    },
+    {
       name: "keeps trailing CRLF lines when the first line ends with LF",
       original: "alpha\nbeta\r\ngamma\r\n",
       edits: [{ oldText: "alpha", newText: "ALPHA" }],

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -12,7 +12,7 @@ import {
 import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
-import { detectLineEnding, normalizeToLF, restoreLineEndings } from "../../line-endings.js";
+import { normalizeToLF } from "../../line-endings.js";
 import { renderDiff } from "../../modes/interactive/components/diff.js";
 import type { AgentTool } from "../../runtime/index.js";
 import { textResult } from "../../tools/common.js";
@@ -27,6 +27,7 @@ import {
   type EditDiffResult,
   generateDiffString,
   generateUnifiedPatch,
+  restoreOriginalLineEndings,
   splitNoOpEdits,
   stripBom,
   validateNoOpEditTargets,
@@ -443,7 +444,6 @@ export function createEditToolDefinition(
           }
 
           const { bom, text: content } = stripBom(rawContent);
-          const originalEnding = detectLineEnding(content);
           const normalizedContent = normalizeToLF(content);
           const editSets = splitNoOpEdits(normalizedContent, originalEdits, path);
           const noOpEdits = editSets.noOpEdits;
@@ -463,7 +463,7 @@ export function createEditToolDefinition(
             realEdits,
             path,
           );
-          const finalContent = bom + restoreLineEndings(newContent, originalEnding);
+          const finalContent = bom + restoreOriginalLineEndings(content, newContent);
           await ops.writeFile(absolutePath, finalContent);
           if (signal?.aborted) {
             throw new Error("Operation aborted");

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -19,7 +19,7 @@ import { textResult } from "../../tools/common.js";
 import { decodeUtf8File } from "../../utf8-file.js";
 import type { ToolDefinition } from "../extensions/types.js";
 import {
-  applyEditsToNormalizedContent,
+  applyEditsPreservingLineEndings,
   computeEditsDiff,
   EditNoChangeError,
   type Edit,
@@ -27,7 +27,6 @@ import {
   type EditDiffResult,
   generateDiffString,
   generateUnifiedPatch,
-  restoreOriginalLineEndings,
   splitNoOpEdits,
   stripBom,
   validateNoOpEditTargets,
@@ -458,13 +457,12 @@ export function createEditToolDefinition(
               terminate: true,
             };
           }
-          const { baseContent, newContent } = applyEditsToNormalizedContent(
-            normalizedContent,
+          const { baseContent, newContent, finalContent } = applyEditsPreservingLineEndings(
+            content,
             realEdits,
             path,
           );
-          const finalContent = bom + restoreOriginalLineEndings(content, newContent);
-          await ops.writeFile(absolutePath, finalContent);
+          await ops.writeFile(absolutePath, bom + finalContent);
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users whose agent edits a file through the `edit` tool would find lines the edit never targeted silently rewritten on disk, with the tool reporting success and showing a clean one-line diff.

Two real cases:

- A text file that contains a bare carriage return as data rather than as a line break, for example a captured terminal log where `\r` separates progress updates, or a record stream that uses `\r` as its separator. Editing one word in that file deletes carriage returns, and what was one logical line becomes several.
- A working tree with mixed line endings, common when a Windows checkout, a generated file, or a pasted snippet lands in an otherwise LF repo. Editing one line converts every other line in the file to whichever ending happened to come first.

Nothing about this is visible to the model or in the TUI. The diff and the unified patch returned to the model are computed on the LF-normalized text, so the rewritten lines render as unchanged context, and the tool result reads `Successfully replaced 1 block(s)`. The next `git diff` shows a whole-file change that the agent did not intend and cannot explain.

This is on the default path. The `edit` branch sits inside `includeBaseCodingTools` in `src/agents/agent-tools.ts`, `includeCoreTools` defaults to on, and no config gates it. It reaches both the host and sandbox operation sets, since the line-ending handling runs inside `execute` upstream of `ops.writeFile`.

## Why This Change Was Made

`src/agents/sessions/tools/edit.ts` picked one line ending for the whole file from the very first newline, normalized the entire file to LF for matching, then re-applied that single ending to every `\n` on write.

before:

```ts
const originalEnding = detectLineEnding(content);
const normalizedContent = normalizeToLF(content);
...
const finalContent = bom + restoreLineEndings(newContent, originalEnding);
```

`normalizeToLF` is `text.replace(/\r\n/g, "\n").replace(/\r/g, "\n")`, so it destroys every CR in the file including the ones that are data. `restoreLineEndings` then stamps one terminator onto every line. The round trip alone, with zero edits applied, is already lossy for any file that is not uniformly CRLF.

after:

```ts
const finalContent = bom + restoreOriginalLineEndings(content, newContent);
```

`restoreOriginalLineEndings` splits the original on any terminator, keeps each line's own terminator bytes, and walks a line diff between the normalized original and the edited result. Lines the edits did not touch are emitted from the original verbatim. Newly written lines take the terminator of the original line they replaced, falling back to the terminator of the nearest preceding original line for a pure insertion. Matching still happens in LF space, so a model that sends LF `oldText` against a CRLF file still matches exactly as before.

A bare carriage return is both a line boundary and a data byte, so the reconstruction tracks `\r` as a terminator in its own right alongside `\n` and `\r\n`. That distinction matters when the edit lands on the CR-terminated line itself: the split treats the `\r` as the boundary, and a reconstruction that can only emit `\n` or `\r\n` writes `PREFIX\nprogress\n` for an edit to `prefix\rprogress\n`, deleting a byte the edit never targeted. Because the model-facing diff is computed on normalized text, that byte loss is invisible in review. The pairing is per line rather than per hunk, so a one-line-to-many expansion inside a CR-separated file keeps the separator on each new line.

This completes a fix the repo already made on the sibling path. Issue #89994 reported that a fuzzy edit rewrote unrelated lines across the whole file, and the resolution was `applyReplacementsPreservingUnchangedLines` in `edit-diff.ts`, which rewrites only the lines a replacement covers. The same invariant, untouched lines keep their bytes, was never applied to the line-ending path, so the identical class of damage survived on every edit rather than only fuzzy ones. The new helper lives next to that one and follows its shape.

The other file-mutating tool, `apply_patch`, is unaffected. Its normalize and restore round trip is gated on `hasOnlyCrlfLineEndings` (`src/agents/apply-patch-update.ts`), so it never touches a mixed-ending or lone-CR file. `edit` was the remaining surface without that protection.

## User Impact

An agent edit now changes the lines it says it changed and nothing else. Terminal captures, fixtures, record streams, and generated files keep their carriage returns, including on the line the edit rewrote. Mixed-ending working trees stop collapsing to a single ending on the first edit. Diffs stay scoped to the real change, so review noise and spurious whole-file churn go away. Uniform LF and uniform CRLF files behave exactly as before.

## Evidence

Live runs of the real production factory `createHostWorkspaceEditTool` (`src/agents/agent-tools.read.ts`), the same call `src/agents/agent-tools.ts` makes when it assembles the coding tools for an agent. Real on-disk files in a temp workspace, real guarded host filesystem operations, real matcher and writer, nothing stubbed. Identical starting files and identical edits in both runs. Base is pristine `main` at `bfc99c97c57a70d030a068cf1b435903c5f9fb19`, head is `349e1542e36cb375a4210c98f97d1dccff58fa4f`.

BEFORE, pristine main `bfc99c97c5`:

```
--- bare CR terminates the edited line (progress log, replace the prefix)
on disk before: "prefix\rprogress\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      "-1 prefix\n+1 PREFIX\n 2 progress"
on disk after:  "PREFIX\nprogress\n"  bytes 16 -> 16  CR 1 -> 0

--- terminal capture with CR progress separators, edit the last line
on disk before: "start\n10%\r50%\r100%\ndone\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      " 1 start\n 2 10%\n 3 50%\n 4 100%\n-5 done\n+5 finished"
on disk after:  "start\n10%\n50%\n100%\nfinished\n"  bytes 24 -> 28  CR 2 -> 0

--- CR-separated record rewritten in the middle
on disk before: "id=1\rid=2\rid=3\nfooter\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      " 1 id=1\n-2 id=2\n+2 id=two\n 3 id=3\n 4 footer"
on disk after:  "id=1\nid=two\nid=3\nfooter\n"  bytes 22 -> 24  CR 2 -> 0

--- mixed tree, first line LF and the rest CRLF, edit the first line
on disk before: "alpha\nbeta\r\ngamma\r\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      "-1 alpha\n+1 ALPHA\n 2 beta\n 3 gamma"
on disk after:  "ALPHA\nbeta\ngamma\n"  bytes 19 -> 17  CR 2 -> 0

--- mixed tree, first line CRLF and the rest LF, edit the last line
on disk before: "alpha\r\nbeta\ngamma\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      " 1 alpha\n 2 beta\n-3 gamma\n+3 GAMMA"
on disk after:  "alpha\r\nbeta\r\nGAMMA\r\n"  bytes 18 -> 20  CR 1 -> 3

--- uniform CRLF file, edit the middle line
on disk before: "alpha\r\nbeta\r\ngamma\r\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      " 1 alpha\n-2 beta\n+2 BETA\n 3 gamma"
on disk after:  "alpha\r\nBETA\r\ngamma\r\n"  bytes 20 -> 20  CR 3 -> 3
```

AFTER, this branch at `349e1542e3`, identical inputs:

```
--- bare CR terminates the edited line (progress log, replace the prefix)
on disk before: "prefix\rprogress\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      "-1 prefix\n+1 PREFIX\n 2 progress"
on disk after:  "PREFIX\rprogress\n"  bytes 16 -> 16  CR 1 -> 1

--- terminal capture with CR progress separators, edit the last line
on disk before: "start\n10%\r50%\r100%\ndone\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      " 1 start\n 2 10%\n 3 50%\n 4 100%\n-5 done\n+5 finished"
on disk after:  "start\n10%\r50%\r100%\nfinished\n"  bytes 24 -> 28  CR 2 -> 2

--- CR-separated record rewritten in the middle
on disk before: "id=1\rid=2\rid=3\nfooter\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      " 1 id=1\n-2 id=2\n+2 id=two\n 3 id=3\n 4 footer"
on disk after:  "id=1\rid=two\rid=3\nfooter\n"  bytes 22 -> 24  CR 2 -> 2

--- mixed tree, first line LF and the rest CRLF, edit the first line
on disk before: "alpha\nbeta\r\ngamma\r\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      "-1 alpha\n+1 ALPHA\n 2 beta\n 3 gamma"
on disk after:  "ALPHA\nbeta\r\ngamma\r\n"  bytes 19 -> 19  CR 2 -> 2

--- mixed tree, first line CRLF and the rest LF, edit the last line
on disk before: "alpha\r\nbeta\ngamma\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      " 1 alpha\n 2 beta\n-3 gamma\n+3 GAMMA"
on disk after:  "alpha\r\nbeta\nGAMMA\n"  bytes 18 -> 18  CR 1 -> 1

--- uniform CRLF file, edit the middle line
on disk before: "alpha\r\nbeta\r\ngamma\r\n"
tool result:    Successfully replaced 1 block(s) in run.txt.
tool diff:      " 1 alpha\n-2 beta\n+2 BETA\n 3 gamma"
on disk after:  "alpha\r\nBETA\r\ngamma\r\n"  bytes 20 -> 20  CR 3 -> 3
```

The tool result string and the diff returned to the model are byte-identical between the two runs in every scenario. Only the file on disk differs, which is exactly why this is invisible today. On this branch the five damaged scenarios preserve their original terminators and byte counts, and the sixth, uniform CRLF, is unchanged from current behavior.

### Checks

- `node scripts/run-vitest.mjs src/agents/sessions/tools/edit.test.ts src/agents/sessions/tools/edit-diff.test.ts src/agents/apply-patch.test.ts` passes, 3 shards.
- Eleven table-driven cases plus one focused case were added to `edit.test.ts`, covering a lone CR as data, a lone CR terminating the edited line, a CR-separated record rewritten in the middle, a CR-terminated line expanded into several lines, a lone CR at end of file on the edited line, LF-first mixed, CRLF-first mixed, two edits with untouched mixed lines between them, multi-line insertion into a CRLF file, uniform CRLF, and uniform LF. Reverting only `edit.ts` and `edit-diff.ts` to `main` fails nine of them with assertions such as `expected 'PREFIX\nprogress\n' to be 'PREFIX\rprogress\n'` and `expected 'start\n10%\n50%\n100%\nfinished\n' to be 'start\n10%\r50%\r100%\nfinished\n'`, and leaves the two uniform-file cases passing, so the LF and CRLF paths are provably unchanged.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` clean on all three changed files.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` reports 197 errors, all under `ui/**` and all present identically on the unmodified base. None are in the changed files. Local dependency-resolution artifact, not introduced here.

Not covered: no run on a real Windows host, and no full `pnpm build`, since no dynamic imports, packaging, or published surfaces changed.
