### PR TITLE
fix(test): expect memory dreaming sidecar at startup

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -2509,7 +2509,7 @@ describe("resolveGatewayStartupPluginIds", () => {
         enabledPluginIds: ["memory-lancedb"],
         memorySlot: "memory-lancedb",
       }),
-      expected: ["demo-channel", "browser", "memory-lancedb"],
+      expected: ["demo-channel", "browser", "memory-core", "memory-lancedb"],
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the full test suite fails while planning gateway startup for a selected external memory plugin because the assertion omits the default memory dreaming sidecar.

## Why This Change Was Made

Forward-ports the release-branch correction from https://github.com/openclaw/openclaw/commit/cbb3c420db02f321fd9e66f632d2e2b545943801. Dreaming defaults to enabled, and `memory-core` is intentionally authorized as the startup sidecar when `memory-lancedb` is selected; this updates only the stale expectation.

## User Impact

No product behavior changes. The main-branch test suite now matches the current startup planner and shipped release behavior.

## Evidence

- Before: focused Testbox run reproduced the stale assertion with 1 failure and 165 passes: https://github.com/openclaw/openclaw/actions/runs/30475631012
- After: focused Testbox run passed all 166 tests: https://github.com/openclaw/openclaw/actions/runs/30475889183
- Changed gate passed formatting, Knip, boundaries, typechecks, lint, and guards: https://github.com/openclaw/openclaw/actions/runs/30476084021
- Autoreview: clean, no actionable findings, confidence 0.99
- `git diff --check`: passed