### PR TITLE
fix(build): prevent OOM on memory-constrained Linux hosts

### DIFF
--- a/scripts/lib/tsdown-config-groups.d.mts
+++ b/scripts/lib/tsdown-config-groups.d.mts
@@ -1,2 +1,12 @@
 export declare const TSDOWN_PACKAGE_CONFIG_GROUP: "openclaw-packages";
 export declare const TSDOWN_UNIFIED_CONFIG_GROUP: "openclaw-unified";
+export declare const TSDOWN_UNIFIED_DTS_CONFIG_GROUPS: readonly [
+  "openclaw-dts-base",
+  "openclaw-dts-plugin-sdk-1",
+  "openclaw-dts-plugin-sdk-2",
+  "openclaw-dts-extensions-1",
+  "openclaw-dts-extensions-2",
+  "openclaw-dts-extensions-3",
+  "openclaw-dts-extensions-4",
+  "openclaw-dts-extensions-5",
+];

--- a/scripts/lib/tsdown-config-groups.mjs
+++ b/scripts/lib/tsdown-config-groups.mjs
@@ -1,3 +1,13 @@
 // Shared config names let the build wrapper isolate the large unified DTS graph.
 export const TSDOWN_PACKAGE_CONFIG_GROUP = "openclaw-packages";
 export const TSDOWN_UNIFIED_CONFIG_GROUP = "openclaw-unified";
+export const TSDOWN_UNIFIED_DTS_CONFIG_GROUPS = [
+  "openclaw-dts-base",
+  "openclaw-dts-plugin-sdk-1",
+  "openclaw-dts-plugin-sdk-2",
+  "openclaw-dts-extensions-1",
+  "openclaw-dts-extensions-2",
+  "openclaw-dts-extensions-3",
+  "openclaw-dts-extensions-4",
+  "openclaw-dts-extensions-5",
+];

--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -11,6 +11,7 @@ import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import {
   TSDOWN_PACKAGE_CONFIG_GROUP,
   TSDOWN_UNIFIED_CONFIG_GROUP,
+  TSDOWN_UNIFIED_DTS_CONFIG_GROUPS,
 } from "./lib/tsdown-config-groups.mjs";
 import {
   TSDOWN_PACKAGE_OUTPUT_ROOTS,
@@ -262,7 +263,10 @@ export function resolveTsdownCleanOutputRoots(args = []) {
     if (filter === TSDOWN_PACKAGE_CONFIG_GROUP) {
       return packageRoots;
     }
-    if (filter === TSDOWN_UNIFIED_CONFIG_GROUP) {
+    if (
+      filter === TSDOWN_UNIFIED_CONFIG_GROUP ||
+      TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.includes(filter)
+    ) {
       return [...ROOT_TSDOWN_OUTPUT_ROOTS];
     }
     return [...ROOT_TSDOWN_OUTPUT_ROOTS, ...packageRoots];
@@ -270,7 +274,10 @@ export function resolveTsdownCleanOutputRoots(args = []) {
   if (!config && filter === TSDOWN_PACKAGE_CONFIG_GROUP) {
     return [aiRoot, ...packageRoots];
   }
-  if (!config && filter === TSDOWN_UNIFIED_CONFIG_GROUP) {
+  if (
+    !config &&
+    (filter === TSDOWN_UNIFIED_CONFIG_GROUP || TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.includes(filter))
+  ) {
     return [aiRoot, ...ROOT_TSDOWN_OUTPUT_ROOTS];
   }
   return listTsdownOutputRoots();
@@ -683,7 +690,39 @@ export function resolveTsdownBuildInvocations(params = {}) {
     aiArgs.push(arg);
   }
 
+  const forwardedConfig = readForwardedOption(forwardedArgs, ["--config", "-c"]);
+  const forwardedFilter = readForwardedOption(forwardedArgs, ["--filter", "-F"]);
+  const mainConfigPath = path.resolve("tsdown.config.ts");
+  const selectsMainUnifiedBuild =
+    forwardedConfig !== undefined &&
+    path.resolve(forwardedConfig) === mainConfigPath &&
+    forwardedFilter === TSDOWN_UNIFIED_CONFIG_GROUP;
+  const declarationEnv =
+    declarationsEnabled && env[RUN_NODE_SKIP_DTS_BUILD_ENV] === "1"
+      ? { ...env, [RUN_NODE_SKIP_DTS_BUILD_ENV]: "0" }
+      : env;
+
   if (hasForwardedConfig) {
+    if (declarationsEnabled && selectsMainUnifiedBuild) {
+      const argsWithoutFilter = forwardedArgs.filter((arg, index) => {
+        const previous = forwardedArgs[index - 1];
+        return (
+          arg !== "--filter" &&
+          arg !== "-F" &&
+          previous !== "--filter" &&
+          previous !== "-F" &&
+          !arg.startsWith("--filter=") &&
+          !arg.startsWith("-F=")
+        );
+      });
+      return [TSDOWN_UNIFIED_CONFIG_GROUP, ...TSDOWN_UNIFIED_DTS_CONFIG_GROUPS].map((group) =>
+        resolveTsdownBuildInvocation({
+          ...params,
+          args: ["--filter", group, ...argsWithoutFilter],
+          env: declarationEnv,
+        }),
+      );
+    }
     return [resolveTsdownBuildInvocation(params)];
   }
 
@@ -695,15 +734,24 @@ export function resolveTsdownBuildInvocations(params = {}) {
   ];
 
   if (!declarationsEnabled || hasForwardedFilter) {
-    invocations.push(resolveTsdownBuildInvocation(params));
+    const mainEnv =
+      !declarationsEnabled && env[RUN_NODE_SKIP_DTS_BUILD_ENV] !== "1"
+        ? { ...env, [RUN_NODE_SKIP_DTS_BUILD_ENV]: "1" }
+        : env;
+    invocations.push(resolveTsdownBuildInvocation({ ...params, env: mainEnv }));
     return invocations;
   }
 
-  for (const group of [TSDOWN_PACKAGE_CONFIG_GROUP, TSDOWN_UNIFIED_CONFIG_GROUP]) {
+  for (const group of [
+    TSDOWN_PACKAGE_CONFIG_GROUP,
+    TSDOWN_UNIFIED_CONFIG_GROUP,
+    ...TSDOWN_UNIFIED_DTS_CONFIG_GROUPS,
+  ]) {
     invocations.push(
       resolveTsdownBuildInvocation({
         ...params,
         args: ["--filter", group, ...forwardedArgs],
+        env: declarationEnv,
       }),
     );
   }

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -5,6 +5,11 @@ import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
+import {
+  TSDOWN_PACKAGE_CONFIG_GROUP,
+  TSDOWN_UNIFIED_CONFIG_GROUP,
+  TSDOWN_UNIFIED_DTS_CONFIG_GROUPS,
+} from "../../scripts/lib/tsdown-config-groups.mjs";
 import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
 import {
   cleanTsdownOutputRoots,
@@ -152,7 +157,7 @@ describe("resolveTsdownBuildInvocation", () => {
     expect(result.args.slice(-2)).toEqual(["--format", "esm"]);
   });
 
-  it("builds AI, package, and unified declarations without overlapping the main graphs", () => {
+  it("builds AI, packages, runtime, and bounded declarations sequentially", () => {
     const results = resolveTsdownBuildInvocations({
       args: ["--format", "esm"],
       platform: "linux",
@@ -162,16 +167,22 @@ describe("resolveTsdownBuildInvocation", () => {
       ...NO_MEMORY_LIMIT,
     });
 
-    expect(results).toHaveLength(3);
+    expect(results).toHaveLength(3 + TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.length);
     expect(results[0]?.args).toEqual(
       expect.arrayContaining(["--config", "tsdown.ai.config.ts", "--format", "esm"]),
     );
-    expect(results[1]?.args).toEqual(
-      expect.arrayContaining(["--filter", "openclaw-packages", "--format", "esm"]),
-    );
-    expect(results[2]?.args).toEqual(
-      expect.arrayContaining(["--filter", "openclaw-unified", "--format", "esm"]),
-    );
+    const filters = results.slice(1).map((result) => {
+      const filterIndex = result.args.indexOf("--filter");
+      return result.args[filterIndex + 1];
+    });
+    expect(filters).toEqual([
+      TSDOWN_PACKAGE_CONFIG_GROUP,
+      TSDOWN_UNIFIED_CONFIG_GROUP,
+      ...TSDOWN_UNIFIED_DTS_CONFIG_GROUPS,
+    ]);
+    for (const result of results.slice(1)) {
+      expect(result.args).toEqual(expect.arrayContaining(["--format", "esm"]));
+    }
   });
 
   it.each([
@@ -202,9 +213,42 @@ describe("resolveTsdownBuildInvocation", () => {
       ...NO_MEMORY_LIMIT,
     });
 
-    expect(results).toHaveLength(3);
+    expect(results).toHaveLength(3 + TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.length);
     expect(results[1]?.args).toEqual(expect.arrayContaining(["--filter", "openclaw-packages"]));
     expect(results[2]?.args).toEqual(expect.arrayContaining(["--filter", "openclaw-unified"]));
+    expect(results.at(-1)?.args).toEqual(
+      expect.arrayContaining(["--filter", TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.at(-1)]),
+    );
+  });
+
+  it("expands the full-build unified selector into one runtime and bounded declaration graphs", () => {
+    const results = resolveTsdownBuildInvocations({
+      args: [
+        "--config",
+        "tsdown.config.ts",
+        "--filter",
+        TSDOWN_UNIFIED_CONFIG_GROUP,
+        "--format",
+        "esm",
+      ],
+      platform: "linux",
+      nodeExecPath: "/usr/bin/node",
+      npmExecPath: "/tmp/pnpm.cjs",
+      env: {},
+      ...NO_MEMORY_LIMIT,
+    });
+
+    expect(results).toHaveLength(1 + TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.length);
+    expect(
+      results.map((result) => {
+        const filterIndex = result.args.indexOf("--filter");
+        return result.args[filterIndex + 1];
+      }),
+    ).toEqual([TSDOWN_UNIFIED_CONFIG_GROUP, ...TSDOWN_UNIFIED_DTS_CONFIG_GROUPS]);
+    for (const result of results) {
+      expect(result.args).toEqual(expect.arrayContaining(["--config", "tsdown.config.ts"]));
+      expect(result.args).toEqual(expect.arrayContaining(["--format", "esm"]));
+    }
   });
 
   it.each([
@@ -486,6 +530,12 @@ describe("resolveTsdownBuildInvocation", () => {
       "dist",
       "dist-runtime",
     ]);
+    expect(
+      resolveTsdownCleanOutputRoots([
+        "-c=tsdown.config.ts",
+        `-F=${TSDOWN_UNIFIED_DTS_CONFIG_GROUPS[0]}`,
+      ]),
+    ).toEqual(["dist", "dist-runtime"]);
     expect(
       resolveTsdownCleanOutputRoots([
         "--config",

--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -1,9 +1,11 @@
 // Tsdown config tests protect package artifact build contracts.
 import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   TSDOWN_PACKAGE_CONFIG_GROUP,
   TSDOWN_UNIFIED_CONFIG_GROUP,
+  TSDOWN_UNIFIED_DTS_CONFIG_GROUPS,
 } from "../../scripts/lib/tsdown-config-groups.mjs";
 import config from "../../tsdown.config.ts";
 
@@ -21,16 +23,49 @@ describe("tsdown config", () => {
     },
   );
 
-  it("enables declaration output explicitly for package artifact builds", () => {
-    expect(configs).not.toHaveLength(0);
-    expect(configs.map((entry) => entry.dts)).toEqual(configs.map(() => true));
+  it("isolates runtime output from bounded declaration-only graphs", () => {
+    const packageConfigs = configs.filter((entry) => entry.name === TSDOWN_PACKAGE_CONFIG_GROUP);
+    const unifiedRuntimeConfig = configs.find(
+      (entry) => entry.name === TSDOWN_UNIFIED_CONFIG_GROUP,
+    );
+    const unifiedDeclarationConfigs = TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.map((name) =>
+      configs.find((entry) => entry.name === name),
+    );
+
+    expect(packageConfigs).not.toHaveLength(0);
+    expect(packageConfigs.map((entry) => entry.dts)).toEqual(packageConfigs.map(() => true));
+    expect(unifiedRuntimeConfig?.dts).toBe(false);
+    expect(unifiedDeclarationConfigs.every(Boolean)).toBe(true);
+    for (const declarationConfig of unifiedDeclarationConfigs) {
+      expect(declarationConfig?.dts).toMatchObject({ emitDtsOnly: true });
+      expect(Object.keys(declarationConfig?.entry ?? {})).toEqual(
+        Object.keys(unifiedRuntimeConfig?.entry ?? {}),
+      );
+    }
   });
 
-  it("isolates the unified graph from package declaration builds", () => {
-    expect(configs.slice(0, -1).map((entry) => entry.name)).toEqual(
-      configs.slice(0, -1).map(() => TSDOWN_PACKAGE_CONFIG_GROUP),
+  it("assigns every unified entry to exactly one bounded declaration graph", () => {
+    const unifiedRuntimeConfig = configs.find(
+      (entry) => entry.name === TSDOWN_UNIFIED_CONFIG_GROUP,
     );
-    expect(configs.at(-1)?.name).toBe(TSDOWN_UNIFIED_CONFIG_GROUP);
+    const runtimeSources = Object.values(unifiedRuntimeConfig?.entry ?? {}).map((source) => {
+      const sourceString = String(source);
+      return (
+        path.isAbsolute(sourceString) ? path.relative(process.cwd(), sourceString) : sourceString
+      ).replaceAll("\\", "/");
+    });
+    const declarationSources = TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.flatMap((name) => {
+      const declarationConfig = configs.find((entry) => entry.name === name);
+      const dts = declarationConfig?.dts;
+      if (!dts || typeof dts !== "object" || !Array.isArray(dts.entry)) {
+        return [];
+      }
+      expect(dts.entry.length).toBeLessThanOrEqual(200);
+      return dts.entry;
+    });
+
+    expect(declarationSources.toSorted()).toEqual(runtimeSources.toSorted());
+    expect(new Set(declarationSources).size).toBe(declarationSources.length);
   });
 
   it("keeps node package artifacts on the declared js and dts extensions", () => {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -14,6 +14,7 @@ import {
 import {
   TSDOWN_PACKAGE_CONFIG_GROUP,
   TSDOWN_UNIFIED_CONFIG_GROUP,
+  TSDOWN_UNIFIED_DTS_CONFIG_GROUPS,
 } from "./scripts/lib/tsdown-config-groups.mjs";
 import { tsdownPackageOutputRoot } from "./scripts/lib/tsdown-output-roots.mjs";
 
@@ -138,10 +139,13 @@ function buildInputOptions(options: InputOptionsArg): InputOptionsReturn {
   };
 }
 
-function nodeBuildConfig(config: UserConfig): UserConfig {
+function nodeBuildConfig(
+  config: UserConfig,
+  declarations: UserConfig["dts"] = TSDOWN_DECLARATIONS,
+): UserConfig {
   return {
     ...config,
-    dts: TSDOWN_DECLARATIONS,
+    dts: declarations,
     env,
     outExtensions: () => ({ js: ".js", dts: ".d.ts" }),
     fixedExtension: false,
@@ -525,6 +529,93 @@ function buildUnifiedDistEntries(): Record<string, string> {
   };
 }
 
+type UnifiedEntry = [name: string, source: string];
+
+function partitionUnifiedEntryGroups(
+  entryGroups: UnifiedEntry[][],
+  partitionCount: number,
+): UnifiedEntry[][] {
+  const partitions = Array.from({ length: partitionCount }, () => [] as UnifiedEntry[]);
+  for (const entryGroup of entryGroups) {
+    let targetIndex = 0;
+    for (let index = 1; index < partitions.length; index += 1) {
+      const candidate = partitions[index];
+      const target = partitions[targetIndex];
+      if (candidate && target && candidate.length < target.length) {
+        targetIndex = index;
+      }
+    }
+    const target = partitions[targetIndex];
+    if (!target) {
+      throw new Error("unified declaration partition count must be positive");
+    }
+    target.push(...entryGroup);
+  }
+  return partitions;
+}
+
+function normalizeDeclarationEntrySource(source: string): string {
+  const relativeSource = path.isAbsolute(source) ? path.relative(process.cwd(), source) : source;
+  return relativeSource.replaceAll(path.sep, "/");
+}
+
+function buildUnifiedDeclarationPartitions(
+  entries: Record<string, string>,
+): Array<{ name: string; sources: string[] }> {
+  const sortedEntries = Object.entries(entries).toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  const baseEntries = sortedEntries.filter(
+    ([name]) => !name.startsWith("plugin-sdk/") && !name.startsWith("extensions/"),
+  );
+  const pluginSdkEntries = sortedEntries.filter(([name]) => name.startsWith("plugin-sdk/"));
+  const extensionEntriesById = new Map<string, UnifiedEntry[]>();
+  for (const entry of sortedEntries) {
+    const [name] = entry;
+    if (!name.startsWith("extensions/")) {
+      continue;
+    }
+    const extensionId = name.split("/", 3)[1];
+    if (!extensionId) {
+      continue;
+    }
+    const extensionEntries = extensionEntriesById.get(extensionId) ?? [];
+    extensionEntries.push(entry);
+    extensionEntriesById.set(extensionId, extensionEntries);
+  }
+
+  const pluginSdkPartitions = partitionUnifiedEntryGroups(
+    pluginSdkEntries.map((entry) => [entry]),
+    2,
+  );
+  const extensionPartitions = partitionUnifiedEntryGroups(
+    [...extensionEntriesById.entries()]
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([, extensionEntries]) => extensionEntries),
+    5,
+  );
+  const partitions = [baseEntries, ...pluginSdkPartitions, ...extensionPartitions];
+
+  return TSDOWN_UNIFIED_DTS_CONFIG_GROUPS.map((name, index) => {
+    const partition = partitions[index];
+    if (!partition) {
+      throw new Error(`missing unified declaration partition for ${name}`);
+    }
+    return {
+      name,
+      sources: partition.map(([, source]) => normalizeDeclarationEntrySource(source)),
+    };
+  });
+}
+
+const unifiedDistEntries = buildUnifiedDistEntries();
+const unifiedDeps = {
+  alwaysBundle: shouldAlwaysBundleDependency,
+  neverBundle: shouldNeverBundleDependency,
+  // Keep dts generation from inlining externalized package types.
+  dts: { neverBundle: shouldNeverBundleDependency },
+};
+
 const configs = [
   nodeBuildConfig({
     name: TSDOWN_PACKAGE_CONFIG_GROUP,
@@ -578,18 +669,28 @@ const configs = [
     },
   }),
   nodeWorkspacePackageBuildConfig("model-catalog-core"),
-  nodeBuildConfig({
-    name: TSDOWN_UNIFIED_CONFIG_GROUP,
-    // Build core entrypoints, plugin-sdk subpaths, bundled plugin entrypoints,
-    // and bundled hooks in one graph so runtime singletons are emitted once.
-    entry: buildUnifiedDistEntries(),
-    deps: {
-      alwaysBundle: shouldAlwaysBundleDependency,
-      neverBundle: shouldNeverBundleDependency,
-      // Keep dts generation from inlining externalized package types.
-      dts: { neverBundle: shouldNeverBundleDependency },
+  nodeBuildConfig(
+    {
+      name: TSDOWN_UNIFIED_CONFIG_GROUP,
+      // Build core entrypoints, plugin-sdk subpaths, bundled plugin entrypoints,
+      // and bundled hooks in one graph so runtime singletons are emitted once.
+      entry: unifiedDistEntries,
+      deps: unifiedDeps,
     },
-  }),
+    false,
+  ),
+  ...(TSDOWN_DECLARATIONS
+    ? buildUnifiedDeclarationPartitions(unifiedDistEntries).map(({ name, sources }) =>
+        nodeBuildConfig(
+          {
+            name,
+            entry: unifiedDistEntries,
+            deps: unifiedDeps,
+          },
+          { emitDtsOnly: true, entry: sources },
+        ),
+      )
+    : []),
 ] satisfies UserConfig[];
 
 export default configs;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users building OpenClaw from source on memory-constrained Linux systems could have `pnpm build` killed by the kernel during the unified declaration build, even on an 8 GB host with swap available.

## Why This Change Was Made

The runtime JavaScript remains in one unified graph so singleton bundling is unchanged. Declaration generation is split into deterministic, bounded declaration-only graphs that the build wrapper runs sequentially; every unified entry is assigned exactly once, while explicit heap overrides and no-DTS builds retain their existing behavior.

## User Impact

Developers can build OpenClaw on smaller Linux hosts without adding private build flags, stopping a running Gateway, or moving the build off-machine. Larger builders keep the same complete runtime, declaration, UI, and metadata outputs.

## Evidence

- Canonical-base red control on Spud (Linux Mint, 7.7 GiB RAM, 2 GiB swap): the unmodified unified graph reached the exact 6.5 GB cgroup ceiling, consumed about 987 MiB swap, and ended with `Result=oom-kill`; the live Gateway remained active.
- Patched constrained proof on Spud under the identical cgroup and live-Gateway load: the full build completed in 9m09s with a 4.8 GiB cgroup peak and zero swap. Later upstream graph changes were impact-mapped and their affected runtime/declaration partitions completed at a 4.4 GiB peak with zero swap.
- Live acceptance: Spud ran the built patched runtime with passing `/healthz` and `/readyz`; Discord authenticated/resolved the Spud guild and Telegram polling started normally. A rollback snapshot was retained before the service switch.
- Artifact guards: CLI bootstrap imports passed; all 146 public plugin-SDK subpaths passed; all 1,218 declaration-producing unified entries emitted stable `.d.ts` files on the fully built tested graph (the five known JavaScript-only OnePassword/Vault sidecars remained the only non-declaration entries).
- Focused regression suite: `node scripts/run-vitest.mjs test/scripts/tsdown-config.test.ts test/scripts/tsdown-build.test.ts test/scripts/build-all.test.ts` — 106/106 passed on Spud and Blacksmith Testbox.
- Repository gate: `node scripts/check-changed.mjs` passed, including formatting, declaration contracts, typecheck, lint, plugin boundaries, and runtime import cycles.
- Autoreview reported no accepted/actionable findings; secret scan was clean.

AI-assisted: yes. I reviewed the implementation and validation evidence. No agent transcript is included.
