### PR TITLE
feat(config): add per-model contextTokens context window override

### DIFF
--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -43,11 +43,31 @@ Session pruning trims **old tool results** from the in-memory context right befo
 
 Pruning uses an estimated context window (chars ≈ tokens × 4). The base window is resolved in this order:
 
-1. `models.providers.*.models[].contextWindow` override.
-2. Model definition `contextWindow` (from the model registry).
-3. Default `200000` tokens.
+1. `agents.defaults.models["<provider>/<model>"].contextTokens` override.
+2. `models.providers.*.models[].contextWindow` override.
+3. Model definition `contextWindow` (from the model registry).
+4. Default `200000` tokens.
 
 If `agents.defaults.contextTokens` is set, it is treated as a cap (min) on the resolved window.
+
+The per-model `contextTokens` override wins outright, including over that cap, and can raise
+the window above what the model registry reports. Use it when a gateway under-reports the
+window of the model it actually routes to:
+
+```json5
+{
+  agents: {
+    defaults: {
+      models: {
+        "kilocode/anthropic/claude-sonnet-5": { contextTokens: 900000 },
+      },
+    },
+  },
+}
+```
+
+Note the key is the full `<provider>/<model>` string, and `models` is an object keyed by that
+string — not an array.
 
 ## Mode
 

--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -117,6 +117,104 @@ describe("context-window-guard", () => {
     expect(info.tokens).toBe(64_000);
   });
 
+  it("uses agents.defaults.models[].contextTokens when present", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "kilocode/anthropic/claude-sonnet-5": { contextTokens: 900_000 },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "kilocode",
+      modelId: "anthropic/claude-sonnet-5",
+      modelContextWindow: 128_000,
+      defaultTokens: 200_000,
+    });
+    expect(info.source).toBe("agentModelContextTokens");
+    expect(info.tokens).toBe(900_000);
+  });
+
+  it("only applies the per-model override to the matching model", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "kilocode/anthropic/claude-sonnet-5": { contextTokens: 900_000 },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "kilocode",
+      modelId: "kilo-auto/balanced",
+      modelContextWindow: 128_000,
+      defaultTokens: 200_000,
+    });
+    expect(info.source).toBe("model");
+    expect(info.tokens).toBe(128_000);
+  });
+
+  it("prefers the per-model override over models.providers and the global cap", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          contextTokens: 50_000,
+          models: { "openrouter/tiny": { contextTokens: 300_000 } },
+        },
+      },
+      models: {
+        providers: {
+          openrouter: {
+            baseUrl: "http://localhost",
+            apiKey: "x",
+            models: [
+              {
+                id: "tiny",
+                name: "tiny",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 12_000,
+                maxTokens: 256,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "openrouter",
+      modelId: "tiny",
+      modelContextWindow: 64_000,
+      defaultTokens: 200_000,
+    });
+    expect(info.source).toBe("agentModelContextTokens");
+    expect(info.tokens).toBe(300_000);
+  });
+
+  it("ignores a non-positive per-model override", () => {
+    const cfg = {
+      agents: {
+        defaults: { models: { "anthropic/whatever": { contextTokens: 0 } } },
+      },
+    } as unknown as OpenClawConfig;
+    const info = resolveContextWindowInfo({
+      cfg,
+      provider: "anthropic",
+      modelId: "whatever",
+      modelContextWindow: 64_000,
+      defaultTokens: 200_000,
+    });
+    expect(info.source).toBe("model");
+    expect(info.tokens).toBe(64_000);
+  });
+
   it("uses default when nothing else is available", () => {
     const info = resolveContextWindowInfo({
       cfg: undefined,

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -3,7 +3,12 @@ import type { OpenClawConfig } from "../config/config.js";
 export const CONTEXT_WINDOW_HARD_MIN_TOKENS = 16_000;
 export const CONTEXT_WINDOW_WARN_BELOW_TOKENS = 32_000;
 
-export type ContextWindowSource = "model" | "modelsConfig" | "agentContextTokens" | "default";
+export type ContextWindowSource =
+  | "model"
+  | "modelsConfig"
+  | "agentModelContextTokens"
+  | "agentContextTokens"
+  | "default";
 
 export type ContextWindowInfo = {
   tokens: number;
@@ -25,6 +30,18 @@ export function resolveContextWindowInfo(params: {
   modelContextWindow?: number;
   defaultTokens: number;
 }): ContextWindowInfo {
+  // `agents.defaults.models` is keyed by `<provider>/<modelId>` (see modelKey()
+  // in model-selection.ts). Built inline so this module stays dependency-free.
+  // An explicit per-model override is the most specific signal available, so it
+  // wins outright — including over the global `agents.defaults.contextTokens`
+  // cap, which exists to trim windows the user did not set deliberately.
+  const fromAgentModel = normalizePositiveInt(
+    params.cfg?.agents?.defaults?.models?.[`${params.provider}/${params.modelId}`]?.contextTokens,
+  );
+  if (fromAgentModel) {
+    return { tokens: fromAgentModel, source: "agentModelContextTokens" };
+  }
+
   const fromModelsConfig = (() => {
     const providers = params.cfg?.models?.providers as
       | Record<string, { models?: Array<{ id?: string; contextWindow?: number }> }>

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -14,6 +14,12 @@ export type AgentModelEntryConfig = {
   params?: Record<string, unknown>;
   /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
   streaming?: boolean;
+  /**
+   * Context window override for this model, in tokens. Takes precedence over
+   * provider catalog metadata and over `agents.defaults.contextTokens`. Use it
+   * when a gateway under-reports the window of the model it actually routes to.
+   */
+  contextTokens?: number;
 };
 
 export type AgentModelListConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -31,6 +31,8 @@ export const AgentDefaultsSchema = z
             params: z.record(z.string(), z.unknown()).optional(),
             /** Enable streaming for this model (default: true, false for Ollama to avoid SDK issue #1205). */
             streaming: z.boolean().optional(),
+            /** Context window override for this model, in tokens. */
+            contextTokens: z.number().int().positive().optional(),
           })
           .strict(),
       )


### PR DESCRIPTION
> **AI-assisted PR.** Written with Claude Code. Degree of testing: **lightly tested** — unit tests and static checks pass locally (details below), but I could **not** reproduce the original #116010 report, which needs a live KiloCode gateway account. Please read the "What I did NOT verify" section before merging.

## Summary

- **Problem:** `agents.defaults.models[].contextTokens` does not exist. Because the per-model entry schema is `.strict()`, configs that set it are **rejected outright** rather than ignored, so the override silently has no effect (#79011).
- **Why it matters:** The only related knob, `agents.defaults.contextTokens`, is agent-wide and applied as a *downward cap* (`cap < base`). It can lower a window but never raise one, so there is currently no way to correct a gateway that under-reports the context window of the model it actually routes to.
- **What changed:** Added `contextTokens` to the per-model entry (type + zod) and resolved it first in `resolveContextWindowInfo`, under a new `agentModelContextTokens` source.
- **What did NOT change (scope boundary):** No change to compaction logic, to any provider's model discovery, to the KiloCode provider, or to how windows are resolved when the new key is absent. No existing config can reach the new code path.

## Change Type (select all)

- [x] Feature
- [x] Docs

## Scope (select all touched areas)

- [x] API / contracts

## Linked Issue/PR

- Closes #79011
- Related #116010

## User-visible / Behavior Changes

New optional config key:

```json5
{
  agents: {
    defaults: {
      models: {
        "kilocode/anthropic/claude-sonnet-5": { contextTokens: 900000 },
      },
    },
  },
}
```

Precedence, highest first:

1. `agents.defaults.models["<provider>/<model>"].contextTokens` **(new)**
2. `models.providers.*.models[].contextWindow`
3. Model registry `contextWindow`
4. Default `200000`

The new per-model override wins outright, **including over the agent-wide `agents.defaults.contextTokens` cap**, and unlike that cap it can raise a window as well as lower it. Rationale: an explicit per-model value is the most specific signal a user can give, whereas the agent-wide cap exists to trim windows the user did not set deliberately. Happy to invert this if you'd prefer the cap stay authoritative.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux 7.1.1 (x64)
- Runtime/container: Node 26, pnpm 10.23.0
- Model/provider: n/a — verified at the resolver level with unit tests
- Relevant config (redacted): see above

### Steps

1. Add `contextTokens` under an `agents.defaults.models["<provider>/<model>"]` entry.
2. Load the config and call `resolveContextWindowInfo` for that provider/model.

### Expected

Resolved window is the configured value, `source === "agentModelContextTokens"`.

### Actual (before this change)

Config is rejected by the `.strict()` per-model schema; when bypassed, the value is ignored and the model registry window is used.

## Evidence

- [x] Failing test/log before + passing after

Four tests added to `src/agents/context-window-guard.test.ts`. With the fix reverted (`git stash push src/agents/context-window-guard.ts`), the two positive tests fail and the two negative-path tests still pass, as expected:

```
× uses agents.defaults.models[].contextTokens when present
× prefers the per-model override over models.providers and the global cap
✓ only applies the per-model override to the matching model
✓ ignores a non-positive per-model override
Tests  2 failed | 11 passed (13)
```

With the fix applied:

```
✓ src/agents/context-window-guard.test.ts (13 tests)
Test Files  1 passed (1)
```

Also run locally, all passing:

- `vitest run --config vitest.config.ts src/agents/pi-embedded-runner/extensions src/agents/pi-extensions/compaction-safeguard src/agents/compaction src/config/zod-schema` → **11 files, 65 tests passed**
- `vitest run --config vitest.unit.config.ts src/config/schema.test.ts src/config/schema.help.quality.test.ts src/config/config.schema-regressions.test.ts` → **40 tests passed**
- `tsgo --noEmit` → clean
- `oxlint --type-aware` → 0 warnings, 0 errors
- `oxfmt --check` → clean

## Human Verification (required)

**Verified scenarios:**
- Override applied for an exact `<provider>/<model>` key match.
- Override correctly *not* applied to a different model under the same provider.
- Override takes precedence over both `models.providers[].contextWindow` and the agent-wide cap.
- Non-positive / non-finite values are rejected and fall through to existing behavior.
- Confirmed no other module consumes the `ContextWindowSource` union, so the added variant breaks no exhaustive switch.

**Edge cases checked:** zero, and key-miss fallthrough. `.strict()` schema now accepts the key.

**What I did NOT verify:**
- **I could not reproduce #116010.** The `kilo-auto/*` aliases are fetched from the KiloCode gateway at runtime and appear nowhere in this repo, so confirming the reported 128k ceiling needs a live KiloCode account I don't have.
- I did **not** confirm that OpenClaw was mis-resolving the KiloCode window. It is entirely possible the gateway legitimately advertises 128k for an auto-router alias, since such a router may select an upstream model with a smaller window. **This PR does not claim to fix that**; it gives affected users a supported way to override an under-reported window, and implements the separately-filed #79011.
- No end-to-end run against a real provider; verification is at the resolver level only.

## Compatibility / Migration

- Backward compatible? **Yes** — new optional key; absent it, resolution is byte-for-byte unchanged.
- Config/env changes? **No** (opt-in only)
- Migration needed? **No**

## Failure Recovery (if this breaks)

- Remove `contextTokens` from any `agents.defaults.models` entry to restore prior behavior immediately.
- Revert this commit; it touches one resolver function, two schema files, and one docs page.
- Known bad symptoms to watch for: a session reporting a window larger than the provider truly supports, causing upstream context-overflow errors instead of timely compaction. That can only occur if a user sets the key too high.

## Risks and Mitigations

- **Risk:** A user sets `contextTokens` above the model's real window and delays compaction until upstream overflow.
  - **Mitigation:** Opt-in and explicit. This matches the existing behavior of `models.providers[].contextWindow`, which can already be set too high.
- **Risk:** Precedence over the agent-wide cap may surprise someone using that cap as a blanket ceiling.
  - **Mitigation:** Documented in `docs/concepts/session-pruning.md`. Easy to invert if you disagree — see the note above.

## Open questions

1. **Is the precedence right?** Should the per-model override beat `agents.defaults.contextTokens`, or should that cap remain an absolute ceiling?
2. **Is a per-model override the right fix for #116010 at all,** or should the KiloCode provider instead resolve the real window of the routed model? If the latter, this PR is still useful for #79011 but should not be treated as addressing #116010.
3. I only updated the English docs; let me know if you'd like the `zh-CN` copy of `session-pruning.md` updated to match.

Separately, and **not** fixed here to keep scope tight: the reporter in #116010 configured `models` as an **array** of `{id, contextTokens}` objects, but `agents.defaults.models` is a `Record` keyed by `"<provider>/<model>"`. Combined with `.strict()`, their config would have been rejected regardless of this change. That may be worth a clearer validation error or a docs note.
