### PR TITLE
fix(doctor): fail closed on unknown channel schema for groupAllowFrom migration

### DIFF
--- a/src/commands/doctor/shared/allowfrom-fallback-migration.test.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.test.ts
@@ -130,4 +130,20 @@ describe("doctor group allowFrom fallback migration", () => {
 
     expect(maybeRepairGroupAllowFromFallback(cfg)).toEqual({ config: cfg, changes: [] });
   });
+
+  it("skips bundled-extension channels absent from generated metadata", () => {
+    // agentmail ships as a ClawHub extension and has no generated-metadata schema entry,
+    // so doctor cannot prove groupAllowFrom is a valid field for it; regression test for a
+    // bug where the missing entry was treated as "no restriction" and doctor wrote a field
+    // agentmail's own runtime schema rejects, failing config validation on every run.
+    const cfg = {
+      channels: {
+        agentmail: {
+          allowFrom: ["someone@example.com"],
+        },
+      },
+    };
+
+    expect(maybeRepairGroupAllowFromFallback(cfg)).toEqual({ config: cfg, changes: [] });
+  });
 });

--- a/src/commands/doctor/shared/allowfrom-fallback-migration.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.ts
@@ -107,7 +107,9 @@ function schemaAllowsConfigPath(schema: unknown, path: SchemaPath): boolean {
 
 function generatedSchemaAllowsGroupAllowFrom(channelName: string, path: SchemaPath): boolean {
   const schema = findGeneratedChannelConfigSchema(channelName);
-  return !schema || schemaAllowsConfigPath(schema, path);
+  // Extension-installed channels (e.g. ClawHub agentmail) have no generated-metadata entry;
+  // without schema info we can't prove the write is safe, so fail closed rather than open.
+  return schema !== undefined && schemaAllowsConfigPath(schema, path);
 }
 
 function migrateRecord(params: {


### PR DESCRIPTION
Closes #116024

**This PR is AI-assisted** (written with Claude Code / Claude Opus, based on investigating a live production breakage during an OpenClaw beta.4 → beta.5 upgrade). See Evidence below for validation; I've read and understand the diff.

## What Problem This Solves

Fixes an issue where users with a `channels.agentmail` account configured with a non-empty `allowFrom` list would find `openclaw doctor --fix` fail outright with:

```
Error: Config validation failed: channels.agentmail: invalid config for plugin agentmail: must not have additional properties: "groupAllowFrom"
```

Because `doctor --fix` runs its migrations as one batch, this aborts every other pending migration in the same run. In the case that surfaced this, it blocked the legacy `exec-approvals.json` → SQLite migration, which in turn kept the Telegram channel from starting after an upgrade — a production-affecting failure that had no config-only workaround (the channel itself has to be disabled to route around it).

## Why This Change Was Made

`maybeRepairGroupAllowFromFallback` (in `src/commands/doctor/shared/allowfrom-fallback-migration.ts`) copies legacy `allowFrom` entries into a new `groupAllowFrom` field for any channel whose doctor capabilities allow the fallback. It's guarded by `generatedSchemaAllowsGroupAllowFrom`, which checks the channel's entry in the compile-time-generated `GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA`. That generated file only covers core-compiled channels (~26 of them: telegram, discord, slack, msteams, etc.) — channels installed at runtime as bundled extensions (e.g. the ClawHub `agentmail` extension) have no entry there.

The guard treated a missing schema entry as "no restriction" (`!schema || ...`) rather than "we don't know, so don't write it." For `agentmail`, whose actual runtime config schema doesn't define `groupAllowFrom`, this let doctor write a field that the channel's own validator then rejected — turning a missing-metadata gap into a hard validation failure that aborts the whole `doctor --fix` run.

This change flips the fallback to fail closed: if there's no generated schema entry for a channel, skip the migration for that channel instead of assuming it's safe. This is a minimal, targeted fix to the guard function only — no changes to channel capability defaults, manifests, or the broader migration flow.

## User Impact

- `openclaw doctor --fix` no longer crashes for users with `agentmail` (or any other extension-installed channel not covered by the generated core schema metadata) configured with a non-empty `allowFrom`.
- Other pending migrations queued in the same `doctor --fix` run (exec-approvals, session record canonicalization, etc.) can no longer be silently blocked by this specific failure mode.
- No behavior change for the ~26 core-compiled channels that do have generated schema entries — they're unaffected by this change.

## Evidence

Reproduced against a live OpenClaw 2026.7.2-beta.5 install with `channels.agentmail.allowFrom` set to 3 entries; `doctor --fix` failed with the exact error above, blocking the Telegram channel from starting until agentmail was manually disabled first.

Added a regression test (`allowfrom-fallback-migration.test.ts`) covering an `agentmail`-shaped config (present in `channels`, non-empty `allowFrom`, absent from generated metadata) asserting no migration is attempted.

```
$ npx vitest run src/commands/doctor/shared/allowfrom-fallback-migration.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ npx vitest run src/commands/doctor/repair-sequencing.test.ts src/commands/doctor/channel-capabilities.test.ts src/commands/doctor-config-flow.test.ts
 Test Files  3 passed (3)
      Tests  82 passed (82)

$ pnpm check   # typecheck (core/ui/extensions/scripts/test-root) + lint (oxlint core/extensions/scripts)
... all lanes ok

$ pnpm build
✓ built in 5.84s
[build-all] phase timings: total 3m 54s
```

Full repo-wide `pnpm test` was not run (large monorepo, prohibitive in this environment); the targeted and directly-related suites above cover the changed function and its callers.

### Live CLI reproduction (before/after)

Beyond unit tests, I reproduced the failure end-to-end with the real, currently-published `2026.7.2-beta.5` CLI against an isolated, disposable state directory (not touching any live install), with a synthetic `channels.agentmail` account (`allowFrom` set to 3 example.com addresses — no real user data). The `Failed to install missing configured plugin "agentmail" from @agentmail/agentmail@beta` warning below is an artifact of this isolated reproduction (the copied extension has no npm install record) and is unrelated to the bug — everything else is genuine live output.

**Before (unpatched beta.5, `doctor --fix`) — reproduces the exact reported crash:**

```
┌  OpenClaw doctor
│
◇  Doctor changes ────────────────────────────────────────────────────╮
│  Persisted agents.entries with exactly one explicit default agent.  │
├─────────────────────────────────────────────────────────────────────╯
◇  Doctor changes ───────────────────────────────╮
│  AgentMail configured, enabled automatically.  │
├────────────────────────────────────────────────╯
◇  Doctor changes ──────────────────────────────────────────────────╮
│  channels.agentmail.groupAllowFrom: copied 3 sender entries from  │
│  allowFrom for explicit group allowlist.                          │
├───────────────────────────────────────────────────────────────────╯
◇  Doctor warnings ──────────────────────────────────────────────────────╮
│  Failed to install missing configured plugin "agentmail" from          │
│  @agentmail/agentmail@beta: Package not found on npm: ...               │
├────────────────────────────────────────────────────────────────────────╯
Error: Config validation failed: channels.agentmail: invalid config for plugin agentmail: must not have additional properties: "groupAllowFrom"
```

**After (same isolated state, same command, patched build with this PR's one-line fix applied to the installed dist) — no crash, `groupAllowFrom` correctly not written, config stays valid:**

```
$ node dist/index.js doctor --fix   # patched build, same OPENCLAW_STATE_DIR as the "before" run above
┌  OpenClaw doctor
│
◇  Doctor changes ────────────────────────────────────────────────────╮
│  Persisted agents.entries with exactly one explicit default agent.  │
├─────────────────────────────────────────────────────────────────────╯
◇  Doctor warnings ──────────────────────────────────────────────────────╮
│  Failed to install missing configured plugin "agentmail" from ...      │  (repro-environment artifact, see note above)
├────────────────────────────────────────────────────────────────────────╯
[plugins] agentmail: OpenClaw can't verify where this plugin came from. ...
◇  Gateway / Command owner / etc. ─── (unrelated pre-existing housekeeping warnings from this synthetic environment; no agentmail groupAllowFrom error anywhere in the run)

$ cat state/openclaw.json | jq .channels.agentmail
{
  "enabled": true,
  "allowFrom": ["repro-1@example.com", "repro-2@example.com", "repro-3@example.com"]
}
# groupAllowFrom was correctly never written

$ node dist/index.js config validate
Config valid: state/openclaw.json
```

Same command, same starting state, same channel config — before this fix it throws and aborts; after, it completes the `agents.entries` migration and every other queued step without ever attempting (or failing on) the agentmail write, and the resulting config validates.
