### PR TITLE
fix(test): stop cross-file state leaks in media suites

### DIFF
--- a/src/media/audio-transcode.test.ts
+++ b/src/media/audio-transcode.test.ts
@@ -2,7 +2,7 @@
 import { existsSync, realpathSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
 const runFfmpegMock = vi.hoisted(() => vi.fn());
@@ -11,7 +11,18 @@ vi.mock("./ffmpeg-exec.js", () => ({
   runFfmpeg: runFfmpegMock,
 }));
 
-import { transcodeAudioBuffer, transcodeAudioBufferToOpus } from "./audio-transcode.js";
+let transcodeAudioBuffer: typeof import("./audio-transcode.js").transcodeAudioBuffer;
+let transcodeAudioBufferToOpus: typeof import("./audio-transcode.js").transcodeAudioBufferToOpus;
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ transcodeAudioBuffer, transcodeAudioBufferToOpus } = await import("./audio-transcode.js"));
+});
+
+afterAll(() => {
+  vi.doUnmock("./ffmpeg-exec.js");
+  vi.resetModules();
+});
 
 type MockWithCalls = { mock: { calls: unknown[][] } };
 

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -239,6 +239,7 @@ describe("readRemoteMediaBuffer", () => {
   const botFileUrl = `https://files.example.test/file/bot${botToken}/photos/1.jpg`;
 
   beforeAll(async () => {
+    vi.resetModules();
     tempHome = await createTempHomeEnv("openclaw-test-home-");
     const fetchModule = await import("./fetch.js");
     readRemoteMediaBuffer = fetchModule.readRemoteMediaBuffer;
@@ -276,7 +277,12 @@ describe("readRemoteMediaBuffer", () => {
   });
 
   afterAll(async () => {
-    await tempHome.restore();
+    try {
+      await tempHome.restore();
+    } finally {
+      vi.doUnmock("../infra/net/fetch-guard.js");
+      vi.resetModules();
+    }
   });
 
   it.each([

--- a/src/media/ffmpeg-exec.test.ts
+++ b/src/media/ffmpeg-exec.test.ts
@@ -1,6 +1,5 @@
 // FFmpeg exec tests cover command execution wrappers and error mapping.
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { parseFfprobeCodecAndSampleRate, resolveFfmpegBin, runFfprobe } from "./ffmpeg-exec.js";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { runExecMock, resolveSystemBinMock } = vi.hoisted(() => ({
   runExecMock: vi.fn(),
@@ -14,6 +13,22 @@ vi.mock("../process/exec.js", () => ({
 vi.mock("../infra/resolve-system-bin.js", () => ({
   resolveSystemBin: resolveSystemBinMock,
 }));
+
+let parseFfprobeCodecAndSampleRate: typeof import("./ffmpeg-exec.js").parseFfprobeCodecAndSampleRate;
+let resolveFfmpegBin: typeof import("./ffmpeg-exec.js").resolveFfmpegBin;
+let runFfprobe: typeof import("./ffmpeg-exec.js").runFfprobe;
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ parseFfprobeCodecAndSampleRate, resolveFfmpegBin, runFfprobe } =
+    await import("./ffmpeg-exec.js"));
+});
+
+afterAll(() => {
+  vi.doUnmock("../process/exec.js");
+  vi.doUnmock("../infra/resolve-system-bin.js");
+  vi.resetModules();
+});
 
 beforeEach(() => {
   runExecMock.mockReset();

--- a/src/media/image-ops.rastermill-adapter.test.ts
+++ b/src/media/image-ops.rastermill-adapter.test.ts
@@ -1,7 +1,11 @@
 // Raster image adapter tests cover image operation integration with RasterMill.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("image ops Rastermill adapter", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   afterEach(() => {
     vi.doUnmock("rastermill");
     vi.doUnmock("@silvia-odwyer/photon-node");
@@ -10,6 +14,7 @@ describe("image ops Rastermill adapter", () => {
   });
 
   it("does not load Photon for Rastermill-backed operations", async () => {
+    const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
     const encode = vi.fn(async () => ({ data: Buffer.from("jpeg") }));
     const photonModuleFactory = vi.fn(() => {
       throw new Error("Photon loaded eagerly");
@@ -17,11 +22,8 @@ describe("image ops Rastermill adapter", () => {
 
     vi.doMock("@silvia-odwyer/photon-node", photonModuleFactory);
     vi.doMock("rastermill", () => ({
-      RastermillUnavailableError: class RastermillUnavailableError extends Error {
-        causes = [];
-      },
+      ...actualRastermill,
       createRastermill: vi.fn(() => ({ encode })),
-      isRastermillUnavailableError: () => false,
       readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
       readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "jpeg" })),
     }));
@@ -35,16 +37,14 @@ describe("image ops Rastermill adapter", () => {
   });
 
   it("configures Rastermill with OpenClaw limits, temp root, and command resolution", async () => {
+    const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
     const encode = vi.fn(async () => ({ data: Buffer.from("jpeg") }));
     const createRastermill = vi.fn((_options: unknown) => ({ encode }));
     const resolveSystemBin = vi.fn(() => "/usr/bin/tool");
 
     vi.doMock("rastermill", () => ({
-      RastermillUnavailableError: class RastermillUnavailableError extends Error {
-        causes = [];
-      },
+      ...actualRastermill,
       createRastermill,
-      isRastermillUnavailableError: () => false,
       readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
       readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "png" })),
     }));
@@ -79,19 +79,21 @@ describe("image ops Rastermill adapter", () => {
   });
 
   it("exposes Rastermill unavailable errors through the SDK alias", async () => {
-    class RastermillUnavailableError extends Error {
-      readonly causes = [new Error("missing backend")];
-    }
+    const actualRastermill = await vi.importActual<typeof import("rastermill")>("rastermill");
+    const unavailableError = new actualRastermill.RastermillUnavailableError(
+      "encode",
+      "Image processor unavailable",
+      [new Error("missing backend")],
+    );
     const createRastermill = vi.fn(() => ({
       encode: vi.fn(async () => {
-        throw new RastermillUnavailableError("Image processor unavailable");
+        throw unavailableError;
       }),
     }));
 
     vi.doMock("rastermill", () => ({
-      RastermillUnavailableError,
+      ...actualRastermill,
       createRastermill,
-      isRastermillUnavailableError: (error: unknown) => error instanceof RastermillUnavailableError,
       readImageMetadataFromHeader: vi.fn(() => ({ width: 1, height: 1 })),
       readImageProbeFromHeader: vi.fn(() => ({ width: 1, height: 1, format: "png" })),
     }));

--- a/src/media/media-probe.test.ts
+++ b/src/media/media-probe.test.ts
@@ -2,11 +2,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  probeMediaFilesWithinBudget,
-  probePlaybackMediaFileDescriptor,
-  probeVideoDimensions,
-} from "./media-probe.js";
 import type { MediaProbeKind, MediaProbeResult } from "./media-probe.js";
 
 const { runFfprobe } = vi.hoisted(() => ({
@@ -21,8 +16,14 @@ let testDir = "";
 let songPath = "";
 let clipPath = "";
 let voicePath = "";
+let probeMediaFilesWithinBudget: typeof import("./media-probe.js").probeMediaFilesWithinBudget;
+let probePlaybackMediaFileDescriptor: typeof import("./media-probe.js").probePlaybackMediaFileDescriptor;
+let probeVideoDimensions: typeof import("./media-probe.js").probeVideoDimensions;
 
 beforeAll(async () => {
+  vi.resetModules();
+  ({ probeMediaFilesWithinBudget, probePlaybackMediaFileDescriptor, probeVideoDimensions } =
+    await import("./media-probe.js"));
   testDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-probe-"));
   songPath = path.join(testDir, "song.mp3");
   clipPath = path.join(testDir, "clip.mp4");
@@ -35,7 +36,12 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await fs.rm(testDir, { recursive: true, force: true });
+  try {
+    await fs.rm(testDir, { recursive: true, force: true });
+  } finally {
+    vi.doUnmock("./ffmpeg-exec.js");
+    vi.resetModules();
+  }
 });
 
 beforeEach(() => {

--- a/src/media/playback-transcode.test.ts
+++ b/src/media/playback-transcode.test.ts
@@ -24,12 +24,19 @@ let playback: typeof import("./playback-transcode.js");
 let tempHome: TempHomeEnv;
 
 beforeAll(async () => {
+  vi.resetModules();
   tempHome = await createTempHomeEnv("openclaw-playback-transcode-");
   playback = await import("./playback-transcode.js");
 });
 
 afterAll(async () => {
-  await tempHome.restore();
+  try {
+    await tempHome.restore();
+  } finally {
+    vi.doUnmock("./ffmpeg-exec.js");
+    vi.doUnmock("./media-probe.js");
+    vi.resetModules();
+  }
 });
 
 beforeEach(() => {
@@ -786,6 +793,15 @@ describe("resolvePlaybackTranscode", () => {
       expect(runFfmpeg).toHaveBeenCalledTimes(3);
     });
     await Promise.all(finishers.slice(1).map(async (finish) => await finish()));
+    await vi.waitFor(async () => {
+      await expect(
+        Promise.all(params.map(async (param) => await playback.resolvePlaybackTranscode(param))),
+      ).resolves.toEqual([
+        expect.objectContaining({ kind: "transcoded" }),
+        expect.objectContaining({ kind: "transcoded" }),
+        expect.objectContaining({ kind: "transcoded" }),
+      ]);
+    });
   });
 
   it("passes already portable media through without invoking ffmpeg", async () => {

--- a/src/media/qr-image.test.ts
+++ b/src/media/qr-image.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { MOCK_PNG_BASE64, MOCK_PNG_BUFFER, toBuffer } = vi.hoisted(() => {
   const MOCK_PNG_BUFFERLocal = Buffer.from("fakepng");
@@ -13,13 +13,25 @@ const { MOCK_PNG_BASE64, MOCK_PNG_BUFFER, toBuffer } = vi.hoisted(() => {
   };
 });
 
-vi.mock("qrcode", () => ({
-  default: {
-    toBuffer,
-  },
-}));
+vi.mock("qrcode", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("qrcode")>();
+  return {
+    ...actual,
+    default: {
+      ...(actual.default ?? actual),
+      toBuffer,
+    },
+  };
+});
 
-import { renderQrPngBase64, renderQrPngDataUrl, writeQrPngTempFile } from "./qr-image.ts";
+let renderQrPngBase64: typeof import("./qr-image.ts").renderQrPngBase64;
+let renderQrPngDataUrl: typeof import("./qr-image.ts").renderQrPngDataUrl;
+let writeQrPngTempFile: typeof import("./qr-image.ts").writeQrPngTempFile;
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ renderQrPngBase64, renderQrPngDataUrl, writeQrPngTempFile } = await import("./qr-image.ts"));
+});
 
 describe("renderQrPngBase64", () => {
   const tmpRoot = path.join(os.tmpdir(), "openclaw-qr-image-tests");
@@ -105,4 +117,9 @@ describe("renderQrPngBase64", () => {
     ).rejects.toThrow(`${name} must be a non-empty filename segment.`);
     expect(toBuffer).not.toHaveBeenCalled();
   });
+});
+
+afterAll(() => {
+  vi.doUnmock("qrcode");
+  vi.resetModules();
 });

--- a/src/media/qr-terminal.test.ts
+++ b/src/media/qr-terminal.test.ts
@@ -1,5 +1,5 @@
 // QR terminal tests cover text normalization and terminal render calls.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { create, toString } = vi.hoisted(() => ({
   create: vi.fn(() => ({
@@ -11,14 +11,24 @@ const { create, toString } = vi.hoisted(() => ({
   toString: vi.fn(async () => "ASCII-QR"),
 }));
 
-vi.mock("qrcode", () => ({
-  default: {
-    create,
-    toString,
-  },
-}));
+vi.mock("qrcode", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("qrcode")>();
+  return {
+    ...actual,
+    default: {
+      ...(actual.default ?? actual),
+      create,
+      toString,
+    },
+  };
+});
 
-import { renderQrTerminal } from "./qr-terminal.ts";
+let renderQrTerminal: typeof import("./qr-terminal.ts").renderQrTerminal;
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ renderQrTerminal } = await import("./qr-terminal.ts"));
+});
 
 describe("renderQrTerminal", () => {
   beforeEach(() => {
@@ -40,4 +50,9 @@ describe("renderQrTerminal", () => {
     expect(create).toHaveBeenCalledWith("openclaw");
     expect(toString).not.toHaveBeenCalled();
   });
+});
+
+afterAll(() => {
+  vi.doUnmock("qrcode");
+  vi.resetModules();
 });

--- a/src/media/store.outside-workspace.test.ts
+++ b/src/media/store.outside-workspace.test.ts
@@ -46,13 +46,19 @@ describe("media store outside-workspace mapping", () => {
   let home = "";
 
   beforeAll(async () => {
+    vi.resetModules();
     ({ saveMediaSource } = await import("./store.js"));
     tempHome = await createTempHomeEnv("openclaw-media-store-test-home-");
     home = tempHome.home;
   });
 
   afterAll(async () => {
-    await tempHome.restore();
+    try {
+      await tempHome.restore();
+    } finally {
+      vi.doUnmock("./store.runtime.js");
+      vi.resetModules();
+    }
   });
 
   it("maps outside-workspace reads to a descriptive invalid-path error", async () => {

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -26,6 +26,8 @@ describe("media store", () => {
       await tempHome.restore();
     } catch {
       // ignore cleanup failures in tests
+    } finally {
+      vi.resetModules();
     }
   });
 

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -68,15 +68,19 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  resetPluginRuntimeStateForTest();
-  if (fixtureRoot) {
-    await fs.rm(fixtureRoot, { recursive: true, force: true });
-  }
-  if (stateDir) {
-    await fs.rm(path.join(stateDir, "canvas", "documents", "cv_test"), {
-      recursive: true,
-      force: true,
-    });
+  try {
+    resetPluginRuntimeStateForTest();
+    if (fixtureRoot) {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+    if (stateDir) {
+      await fs.rm(path.join(stateDir, "canvas", "documents", "cv_test"), {
+        recursive: true,
+        force: true,
+      });
+    }
+  } finally {
+    vi.resetModules();
   }
 });
 


### PR DESCRIPTION
## What Problem This Solves

`main` is red on the `core-runtime-media-ui` shard, and the failures rotate rather than repeat, which makes them read as flake and get rerun instead of fixed.

Reproduced on clean `main`:

- `node scripts/run-vitest.mjs src/media/playback-transcode.test.ts` alone → **26/26 pass**
- `node scripts/run-vitest.mjs src/media` (whole directory, shared workers) → **24 failed across 7 files**, 783 passed

And in CI (`checks-node-compact-large-4`, run 30473348999):

```
FAIL src/media/playback-transcode.test.ts > resolvePlaybackTranscode > passes already portable
AssertionError: expected { kind: 'preparing' } to deeply equal { kind: 'passthrough' }
```

The repo runs Vitest with `isolate: false` deliberately, so shared workers surface module-registry and module-state leaks close to whatever introduced them. These are real defects in the tests, not an argument for turning isolation on.

## Why This Change Was Made

Diagnosis established concrete poisoner→victim edges rather than guessing:

- `web-media.test.ts` → `fetch` (3 failures), `ffmpeg-exec` (4), `media-probe` (9), `audio-transcode` (5)
- `qr-image.test.ts` ↔ `qr-terminal.test.ts` — reversing the seed moved 2 terminal failures into 5 image failures
- `store.test.ts` ↔ `store.outside-workspace.test.ts` — reversing order produced 1 versus 8 failures
- `image-ops.helpers.test.ts` → Rastermill adapter (1 failure)
- The playback saturated-pool test → the portable-media test, via background continuations that were never awaited

Two root-cause clusters. The `{ kind: 'preparing' }` leak is legitimate playback runtime state (a transcode registry) combined with tests that finished without draining their background work, so a later "already portable" input observed an in-flight job from an earlier file. The rest are leaked module and mock caches, where a `vi.mock` from one file survived into a file expecting the real module.

Fixes are test-only: reset module state before dynamic imports, unmock and reset afterward, preserve the actual QR and Rastermill exports and error identities rather than substituting stub classes, and await all background transcodes before a test completes. **No production code changed** — the runtime registries are correct; the tests were not draining them.

## User Impact

None at runtime. This restores a trustworthy signal from the `core-runtime-media-ui` shard so genuine regressions there stop being masked by rotating noise, and unrelated PRs stop being blocked by breakage they did not cause.

## Evidence

- `src/media` run **three consecutive times**, since these failures are order and timing sensitive: 58 files / 807 tests green each time (12.61s, 11.51s, 12.17s).
- All 11 edited files still pass individually: 264 tests.
- Exact six-config `core-runtime-media-ui` shard grouping reproduced on Blacksmith Testbox `tbx_01kyqg0x52h90562qpqc0st6b3` (Actions run 30477215921): passed in 158.68s.
- `pnpm check:test-types`, both deadcode lanes (zero unused exports), full lint (zero warnings/errors), formatting, `git diff --check`: all passing.
- Autoreview clean, no findings.
- No `--isolate`, no `.skip`, no retries, no baseline or ignore-file edits, no weakened assertions.
