### PR TITLE
fix(ui): prevent settings writes from racing

### DIFF
--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -389,20 +389,20 @@ describe("OpenClaw shell source initialization", () => {
     shell.routeState = { routeId: "usage" };
     const client = {} as GatewayBrowserClient;
     const snapshot = { client, phase: "connected" } as ApplicationGatewaySnapshot;
-    const firstAgents = {
-      state: { agentsList: null },
-      ensureList: vi.fn(() => Promise.resolve(null)),
-    } as unknown as ApplicationContext["agents"];
-    const secondAgents = {
-      state: { agentsList: null },
-      ensureList: vi.fn(() => Promise.resolve(null)),
-    } as unknown as ApplicationContext["agents"];
-    const firstRuntimeConfig = {
-      ensureLoaded: vi.fn(() => Promise.resolve()),
-    } as unknown as ApplicationContext["runtimeConfig"];
-    const secondRuntimeConfig = {
-      ensureLoaded: vi.fn(() => Promise.resolve()),
-    } as unknown as ApplicationContext["runtimeConfig"];
+    const createAgents = () =>
+      ({
+        state: { agentsList: null },
+        ensureList: vi.fn(() => Promise.resolve(null)),
+      }) as unknown as ApplicationContext["agents"];
+    const createRuntimeConfig = () =>
+      ({
+        state: { client, connected: true },
+        ensureLoaded: vi.fn(() => Promise.resolve()),
+      }) as unknown as ApplicationContext["runtimeConfig"];
+    const firstAgents = createAgents();
+    const secondAgents = createAgents();
+    const firstRuntimeConfig = createRuntimeConfig();
+    const secondRuntimeConfig = createRuntimeConfig();
 
     shell.ensureAgentsList(snapshot, firstAgents);
     shell.ensureAgentsList(snapshot, firstAgents);

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -731,6 +731,20 @@ class OpenClawShell extends OpenClawLightDomElement {
     });
   }
 
+  private reconcileCommittedServerUiPrefs(
+    runtimeConfig: ApplicationContext["runtimeConfig"],
+    needsRefresh: boolean,
+  ) {
+    if (this.context?.runtimeConfig !== runtimeConfig) {
+      return;
+    }
+    if (needsRefresh) {
+      void runtimeConfig.refresh();
+      return;
+    }
+    this.reconcileServerUiPrefs(runtimeConfig);
+  }
+
   override connectedCallback() {
     super.connectedCallback();
     if (this.outboxStoreRuntime) {
@@ -764,15 +778,11 @@ class OpenClawShell extends OpenClawLightDomElement {
         return;
       }
       const prefs = changedServerUiPrefs(previous, next);
-      const snapshot = this.context?.gateway.snapshot;
-      if (prefs && snapshot?.client) {
-        pushServerUiPrefs(snapshot.client, prefs, {
-          afterCommit: () => {
-            const runtimeConfig = this.context?.runtimeConfig;
-            if (runtimeConfig) {
-              void runtimeConfig.refresh();
-            }
-          },
+      const runtimeConfig = this.context?.runtimeConfig;
+      if (prefs && runtimeConfig) {
+        pushServerUiPrefs(runtimeConfig, prefs, {
+          afterCommit: ({ needsRefresh }) =>
+            this.reconcileCommittedServerUiPrefs(runtimeConfig, needsRefresh),
         });
       }
     });
@@ -1740,13 +1750,9 @@ class OpenClawShell extends OpenClawLightDomElement {
     }
     this.runtimeConfigClient = snapshot.client;
     this.runtimeConfigSource = runtimeConfig;
-    flushServerUiPrefs(snapshot.client, {
-      afterCommit: () => {
-        const currentRuntimeConfig = this.context?.runtimeConfig;
-        if (currentRuntimeConfig) {
-          void currentRuntimeConfig.refresh();
-        }
-      },
+    flushServerUiPrefs(runtimeConfig, {
+      afterCommit: ({ needsRefresh }) =>
+        this.reconcileCommittedServerUiPrefs(runtimeConfig, needsRefresh),
     });
     void runtimeConfig.ensureLoaded();
   }

--- a/ui/src/app/server-prefs.test.ts
+++ b/ui/src/app/server-prefs.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import {
   applyServerUiPrefs,
@@ -24,6 +25,46 @@ afterEach(() => {
 
 function configWithPrefs(prefs: Record<string, unknown>) {
   return { ui: { prefs } };
+}
+
+type RequestMock = ReturnType<typeof vi.fn<(method: string, params?: unknown) => Promise<unknown>>>;
+
+function createServerPrefsWriter(
+  request: RequestMock,
+  gatewayUrl = "ws://gw",
+  connected = true,
+  refresh: { ok: true } | { ok: false; error: string } = { ok: true },
+): Parameters<typeof pushServerUiPrefs>[0] {
+  const client = { request, gatewayUrl, connected } as unknown as GatewayBrowserClient;
+  const writer = {
+    state: { client, connected },
+    runExternalMutation: async <T>(task: (client: GatewayBrowserClient) => Promise<T>) => {
+      if (!writer.state.connected) {
+        return {
+          ok: false as const,
+          reason: "unavailable" as const,
+          error: "offline",
+        };
+      }
+      try {
+        return {
+          ok: true as const,
+          value: await task(client),
+          refresh,
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          ok: false as const,
+          reason: message.includes("config changed since last load")
+            ? ("conflict" as const)
+            : ("error" as const),
+          error: message,
+        };
+      }
+    },
+  };
+  return writer;
 }
 
 describe("server pref extraction", () => {
@@ -93,9 +134,7 @@ describe("applyServerUiPrefs", () => {
     applyServerUiPrefs(oldSnapshot, { scope, onApplied });
     patchSettings({ themeMode: "dark" });
     const request = vi.fn(async () => ({}));
-    const client = { connected: true, gatewayUrl: scope, request } as unknown as Parameters<
-      typeof pushServerUiPrefs
-    >[0];
+    const client = createServerPrefsWriter(request, scope);
 
     pushServerUiPrefs(client, { themeMode: "dark" });
     await vi.waitFor(() =>
@@ -113,9 +152,7 @@ describe("applyServerUiPrefs", () => {
     applyServerUiPrefs(oldSnapshot, { scope, onApplied });
     patchSettings({ themeMode: "dark" });
     const request = vi.fn(async () => ({}));
-    const client = { connected: true, gatewayUrl: scope, request } as unknown as Parameters<
-      typeof pushServerUiPrefs
-    >[0];
+    const client = createServerPrefsWriter(request, scope);
     pushServerUiPrefs(client, { themeMode: "dark" });
     await vi.waitFor(() =>
       expect(localStorage.getItem(`openclaw.control.serverPrefs.pending.v1:${scope}`)).toBeNull(),
@@ -272,9 +309,6 @@ describe("clearable pref removal from the server", () => {
 });
 
 describe("pushServerUiPrefs", () => {
-  type RequestMock = ReturnType<
-    typeof vi.fn<(method: string, params?: unknown) => Promise<unknown>>
-  >;
   const deferred = () => {
     let resolve!: (value: unknown) => void;
     let reject!: (reason?: unknown) => void;
@@ -288,8 +322,7 @@ describe("pushServerUiPrefs", () => {
   const lastSeenKey = (scope: string) => `openclaw.control.serverPrefs.v1:${scope}`;
   const readPending = (scope: string) =>
     JSON.parse(localStorage.getItem(pendingKey(scope)) ?? "{}") as Record<string, unknown>;
-  const createClient = (request: RequestMock, gatewayUrl = "ws://gw", connected = true) =>
-    ({ request, gatewayUrl, connected }) as unknown as Parameters<typeof pushServerUiPrefs>[0];
+  const createClient = createServerPrefsWriter;
 
   it("sends one hash-free patch and acknowledges lastSeen plus pending", async () => {
     const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => ({}));
@@ -298,6 +331,7 @@ describe("pushServerUiPrefs", () => {
 
     pushServerUiPrefs(client, { themeMode: "dark" }, { afterCommit });
     await vi.waitFor(() => expect(afterCommit).toHaveBeenCalledOnce());
+    expect(afterCommit).toHaveBeenCalledWith({ needsRefresh: false });
 
     expect(request).toHaveBeenCalledExactlyOnceWith("config.patch", {
       raw: JSON.stringify({ ui: { prefs: { themeMode: "dark" } } }),
@@ -401,20 +435,19 @@ describe("pushServerUiPrefs", () => {
     const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => {
       throw new Error("socket closed");
     });
-    const clientState = { request, gatewayUrl: "ws://gw", connected: false };
-    const client = clientState as unknown as Parameters<typeof pushServerUiPrefs>[0];
+    const client = createClient(request, "ws://gw", false);
 
     pushServerUiPrefs(client, { locale: "de" });
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    expect(request).not.toHaveBeenCalled();
     expect(JSON.parse(localStorage.getItem(pendingKey("ws://gw")) ?? "{}")).toEqual({
       locale: "de",
     });
 
-    clientState.connected = true;
+    (client.state as { connected: boolean }).connected = true;
     request.mockResolvedValue({});
     flushServerUiPrefs(client);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
   });
 
   it("supersedes a hung prior-connection request on same-client flush", async () => {
@@ -455,18 +488,23 @@ describe("pushServerUiPrefs", () => {
     await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
   });
 
-  it("keeps pending shadow active during the post-commit refresh hook", async () => {
-    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => ({}));
-    const client = createClient(request);
+  it("reconciles the refreshed snapshot again after clearing its pending shadow", async () => {
+    const refreshedSnapshot = configWithPrefs({ themeMode: "light" });
     patchSettings({ themeMode: "dark" });
     const onApplied = vi.fn();
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => {
+      applyServerUiPrefs(refreshedSnapshot, { scope: "ws://gw", onApplied });
+      return {};
+    });
+    const client = createClient(request);
 
     pushServerUiPrefs(
       client,
       { themeMode: "dark" },
       {
-        afterCommit: () => {
-          applyServerUiPrefs(configWithPrefs({ themeMode: "light" }), {
+        afterCommit: ({ needsRefresh }) => {
+          expect(needsRefresh).toBe(false);
+          applyServerUiPrefs(refreshedSnapshot, {
             scope: "ws://gw",
             onApplied,
           });
@@ -476,8 +514,25 @@ describe("pushServerUiPrefs", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
     await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://gw"))).toBeNull());
 
-    expect(onApplied).not.toHaveBeenCalled();
-    expect(loadSettings().themeMode).toBe("dark");
+    expect(onApplied).toHaveBeenCalledWith({ themeMode: "light" });
+    expect(loadSettings().themeMode).toBe("light");
+  });
+
+  it("requests a retry refresh when the post-mutation refresh failed", async () => {
+    const afterCommit = vi.fn();
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => ({}));
+    const client = createClient(request, "ws://gw", true, {
+      ok: false,
+      error: "config.get failed",
+    });
+
+    pushServerUiPrefs(client, { themeMode: "dark" }, { afterCommit });
+
+    await vi.waitFor(() =>
+      expect(afterCommit).toHaveBeenCalledWith({
+        needsRefresh: true,
+      }),
+    );
   });
 
   it("lets pending local intent shadow only its own server key", async () => {
@@ -649,9 +704,9 @@ describe("pushServerUiPrefs", () => {
       },
     );
     pushServerUiPrefs(createClient(offlineRequest, "ws://a", false), { themeMode: "dark" });
-    await vi.waitFor(() => expect(offlineRequest).toHaveBeenCalledTimes(1));
+    expect(offlineRequest).not.toHaveBeenCalled();
     pushServerUiPrefs(createClient(offlineRequest, "ws://b", false), { locale: "de" });
-    await vi.waitFor(() => expect(offlineRequest).toHaveBeenCalledTimes(2));
+    expect(offlineRequest).not.toHaveBeenCalled();
 
     expect(JSON.parse(localStorage.getItem(pendingKey("ws://a")) ?? "{}")).toEqual({
       themeMode: "dark",
@@ -670,5 +725,54 @@ describe("pushServerUiPrefs", () => {
       raw: JSON.stringify({ ui: { prefs: { locale: "de" } } }),
     });
     expect(localStorage.getItem(pendingKey("ws://a"))).not.toBeNull();
+  });
+
+  it("re-adopts scope when a stable writer gains or changes its gateway client", async () => {
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => ({}));
+    const writer = createClient(request, "", false);
+    (writer.state as { client: GatewayBrowserClient | null }).client = null;
+
+    pushServerUiPrefs(writer, { locale: "de" });
+    expect(JSON.parse(localStorage.getItem(pendingKey("")) ?? "{}")).toEqual({ locale: "de" });
+
+    const firstClient = {
+      request,
+      gatewayUrl: "ws://first",
+      connected: true,
+    } as unknown as GatewayBrowserClient;
+    (writer.state as { client: GatewayBrowserClient | null; connected: boolean }).client =
+      firstClient;
+    (writer.state as { connected: boolean }).connected = true;
+    flushServerUiPrefs(writer);
+    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://first"))).toBeNull());
+    expect(localStorage.getItem(pendingKey(""))).toBeNull();
+
+    localStorage.setItem(pendingKey("ws://second"), JSON.stringify({ themeMode: "dark" }));
+    const secondClient = {
+      request,
+      gatewayUrl: "ws://second",
+      connected: true,
+    } as unknown as GatewayBrowserClient;
+    (writer.state as { client: GatewayBrowserClient | null }).client = secondClient;
+    flushServerUiPrefs(writer);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(request.mock.calls[1]?.[1]).toMatchObject({
+      raw: JSON.stringify({ ui: { prefs: { themeMode: "dark" } } }),
+    });
+  });
+
+  it("recovers persisted pre-connection intent when the first gateway is adopted", async () => {
+    localStorage.setItem(pendingKey(""), JSON.stringify({ locale: "de" }));
+    const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>(async () => ({}));
+
+    flushServerUiPrefs(createClient(request, "ws://first"));
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    expect(request.mock.calls[0]?.[1]).toMatchObject({
+      raw: JSON.stringify({ ui: { prefs: { locale: "de" } } }),
+    });
+    await vi.waitFor(() => expect(localStorage.getItem(pendingKey("ws://first"))).toBeNull());
+    expect(localStorage.getItem(pendingKey(""))).toBeNull();
   });
 });

--- a/ui/src/app/server-prefs.ts
+++ b/ui/src/app/server-prefs.ts
@@ -6,6 +6,7 @@ import { asNullableRecord as asRecord } from "@openclaw/normalization-core/recor
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { normalizeSidebarEntries } from "../app-navigation.ts";
 import { isSupportedLocale } from "../i18n/index.ts";
+import type { RuntimeConfigCapability } from "../lib/config/index.ts";
 import {
   loadSettings,
   normalizeChatFollowUpModeOverride,
@@ -88,6 +89,15 @@ type SyncedPrefKey = keyof typeof SYNCED_PREFS;
 type SyncedPrefValue<K extends SyncedPrefKey> =
   ReturnType<(typeof SYNCED_PREFS)[K]["extract"]> extends (infer T) | undefined ? T : never;
 type ServerUiPrefs = { [K in SyncedPrefKey]?: SyncedPrefValue<K> | null };
+type ServerUiPrefsWriter = Pick<RuntimeConfigCapability, "runExternalMutation"> & {
+  readonly state: {
+    readonly client: GatewayBrowserClient | null;
+    readonly connected: boolean;
+  };
+};
+type ServerUiPrefsCommit = {
+  needsRefresh: boolean;
+};
 const SYNCED_PREF_KEYS = Object.keys(SYNCED_PREFS) as SyncedPrefKey[];
 function extractServerUiPrefs(configObject: unknown): ServerUiPrefs {
   const prefs = asRecord(asRecord(asRecord(configObject)?.ui)?.prefs);
@@ -172,8 +182,9 @@ const MAX_CONFLICT_REDRAINS = 5;
 let applyingServerPrefs = false;
 let pendingScope = "";
 let pendingPrefs: ServerUiPrefs | null = null;
-let pushClient: GatewayBrowserClient | null = null;
-let pushAfterCommit: (() => void) | undefined;
+let pushWriter: ServerUiPrefsWriter | null = null;
+let pushScope = "";
+let pushAfterCommit: ((commit: ServerUiPrefsCommit) => void) | undefined;
 let pushDraining = false;
 let drainRequested = false;
 let pushEpoch = 0;
@@ -250,7 +261,8 @@ export function resetServerUiPrefsSync() {
   clearConflictRedrain();
   applyingServerPrefs = pushDraining = drainRequested = false;
   pendingScope = "";
-  pendingPrefs = pushClient = null;
+  pendingPrefs = pushWriter = null;
+  pushScope = "";
   lastReconciledScope = "";
   lastReconciledConfigObject = null;
 }
@@ -317,15 +329,32 @@ export function applyServerUiPrefs(
 export function isApplyingServerUiPrefs(): boolean {
   return applyingServerPrefs;
 }
-function adoptPushClient(client: GatewayBrowserClient): void {
-  if (pushClient === client) {
+function adoptPushWriter(writer: ServerUiPrefsWriter): void {
+  const scope = writer.state.client?.gatewayUrl ?? "";
+  if (pushWriter === writer && pushScope === scope) {
     return;
   }
+  const unscopedPending =
+    pendingScope === ""
+      ? {
+          ...parseStoredPrefs(readStorage(PENDING_KEY, "")),
+          ...pendingPrefs,
+        }
+      : null;
   clearConflictRedrain();
   pushEpoch += 1;
-  pushClient = client;
+  pushWriter = writer;
+  pushScope = scope;
   pushDraining = false;
-  adoptPendingScope(client.gatewayUrl, true);
+  adoptPendingScope(scope, true);
+  if (scope && unscopedPending && Object.keys(unscopedPending).length) {
+    // A preference can be edited before the first gateway client is adopted.
+    // Move only that unscoped intent forward; preferences from one real
+    // gateway must never bleed into another gateway's scope.
+    pendingPrefs = { ...pendingPrefs, ...unscopedPending };
+    mergePendingIntoStorage();
+    writeStorage(PENDING_KEY, "", null);
+  }
 }
 function removeBatch(batch: ServerUiPrefs): void {
   if (!pendingPrefs) {
@@ -342,79 +371,88 @@ function removeBatch(batch: ServerUiPrefs): void {
 }
 // Conflicts mean another writer committed, so bounded rescheduling converges under progress.
 // The cap prevents an endlessly conflicting server from keeping a timer chain alive.
-function scheduleConflictRedrain(client: GatewayBrowserClient, epoch: number): void {
+function scheduleConflictRedrain(writer: ServerUiPrefsWriter, epoch: number): void {
   if (conflictRedrainTimer !== null || consecutiveConflictRedrains >= MAX_CONFLICT_REDRAINS) {
     return;
   }
   consecutiveConflictRedrains += 1;
   conflictRedrainTimer = setTimeout(() => {
     conflictRedrainTimer = null;
-    if (pushClient === client && pushEpoch === epoch && pendingPrefs) {
-      startPendingDrain(client);
+    if (pushWriter === writer && pushEpoch === epoch && pendingPrefs) {
+      startPendingDrain(writer);
     }
   }, CONFLICT_REDRAIN_DELAY_MS);
 }
-async function drainPendingPrefs(client: GatewayBrowserClient, epoch: number): Promise<void> {
+async function drainPendingPrefs(writer: ServerUiPrefsWriter, epoch: number): Promise<void> {
   while (pendingPrefs) {
-    if (pushClient !== client || pushEpoch !== epoch) {
+    if (pushWriter !== writer || pushEpoch !== epoch) {
       return;
     }
     const batch = { ...pendingPrefs };
     const afterCommit = pushAfterCommit;
     for (let attempt = 0; attempt < 2; attempt += 1) {
-      if (pushClient !== client || pushEpoch !== epoch) {
+      if (pushWriter !== writer || pushEpoch !== epoch) {
         return;
       }
-      try {
-        await client.request("config.patch", {
-          raw: JSON.stringify({ ui: { prefs: batch } }),
-          ...(batch.sidebarEntries !== undefined
-            ? { replacePaths: ["ui.prefs.sidebarEntries"] }
-            : {}),
-          note: "control-ui prefs sync",
-        });
-        if (pushClient !== client || pushEpoch !== epoch) {
-          return;
-        }
-        // Start refresh while pending still shadows the pre-commit snapshot published by load.
-        afterCommit?.();
-        if (pushClient !== client || pushEpoch !== epoch) {
-          return;
-        }
+      const result = await writer.runExternalMutation(
+        (client) =>
+          // ui.prefs is a deliberately narrow hashless LWW surface enforced by
+          // hasHashlessPatchLwwStructure in the gateway. Serialization still
+          // matters: a pending whole-config save must commit before this merge.
+          client.request("config.patch", {
+            raw: JSON.stringify({ ui: { prefs: batch } }),
+            ...(batch.sidebarEntries !== undefined
+              ? { replacePaths: ["ui.prefs.sidebarEntries"] }
+              : {}),
+            note: "control-ui prefs sync",
+          }),
+        { waitForWritesResumed: true },
+      );
+      if (pushWriter !== writer || pushEpoch !== epoch) {
+        return;
+      }
+      if (result.ok) {
         removeBatch(batch);
         const lastSeen = parseStoredPrefs(readStorage(LAST_SEEN_KEY, pendingScope)) ?? {};
         writeStorage(LAST_SEEN_KEY, pendingScope, JSON.stringify({ ...lastSeen, ...batch }));
         settlePendingStorage(batch);
         clearConflictRedrain();
+        if (pushWriter !== writer || pushEpoch !== epoch) {
+          return;
+        }
+        if (result.refresh.ok && afterCommit && lastReconciledScope === pendingScope) {
+          // The authoritative refresh published while pending intent still
+          // shadowed this batch. Re-evaluate that same snapshot after cleanup
+          // so a concurrent server value wins without another config.get.
+          lastReconciledConfigObject = null;
+        }
+        afterCommit?.({ needsRefresh: !result.refresh.ok });
+        if (pushWriter !== writer || pushEpoch !== epoch) {
+          return;
+        }
         break;
-      } catch (error) {
-        if (pushClient !== client || pushEpoch !== epoch) {
-          return;
-        }
-        const conflict = String(error).includes("config changed since last load");
-        if (conflict && attempt === 0) {
-          await new Promise<void>((resolve) => {
-            setTimeout(resolve, 250);
-          });
-          continue;
-        }
-        if (conflict) {
-          scheduleConflictRedrain(client, epoch);
-          return;
-        }
-        if (!client.connected) {
-          return;
-        }
-        // Connected viewer-scope or validation failures degrade silently to device-local state;
-        // connection loss and CAS conflicts retain pending intent for replay.
-        removeBatch(batch);
-        settlePendingStorage(batch);
+      }
+      if (result.reason === "conflict" && attempt === 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 250);
+        });
+        continue;
+      }
+      if (result.reason === "conflict") {
+        scheduleConflictRedrain(writer, epoch);
         return;
       }
+      if (result.reason === "unavailable" || result.reason === "suspended") {
+        return;
+      }
+      // Connected viewer-scope or validation failures degrade silently to device-local state.
+      removeBatch(batch);
+      settlePendingStorage(batch);
+      return;
     }
   }
 }
-function startPendingDrain(client: GatewayBrowserClient): void {
+function startPendingDrain(writer: ServerUiPrefsWriter): void {
   if (pushDraining) {
     drainRequested = true;
     return;
@@ -424,38 +462,38 @@ function startPendingDrain(client: GatewayBrowserClient): void {
   }
   pushDraining = true;
   const epoch = pushEpoch;
-  void drainPendingPrefs(client, epoch)
+  void drainPendingPrefs(writer, epoch)
     .catch(() => undefined)
     .finally(() => {
-      if (pushClient === client && pushEpoch === epoch) {
+      if (pushWriter === writer && pushEpoch === epoch) {
         pushDraining = false;
         if (drainRequested) {
           drainRequested = false;
-          startPendingDrain(client);
+          startPendingDrain(writer);
         }
       }
     });
 }
 export function pushServerUiPrefs(
-  client: GatewayBrowserClient,
+  writer: ServerUiPrefsWriter,
   prefs: ServerUiPrefs,
-  hooks: { afterCommit?: () => void } = {},
+  hooks: { afterCommit?: (commit: ServerUiPrefsCommit) => void } = {},
 ): void {
-  adoptPushClient(client);
+  adoptPushWriter(writer);
   clearConflictRedrain();
   pendingPrefs = { ...pendingPrefs, ...prefs };
   pushAfterCommit = hooks.afterCommit;
   mergePendingIntoStorage();
-  startPendingDrain(client);
+  startPendingDrain(writer);
 }
 export function flushServerUiPrefs(
-  client: GatewayBrowserClient,
-  hooks: { afterCommit?: () => void } = {},
+  writer: ServerUiPrefsWriter,
+  hooks: { afterCommit?: (commit: ServerUiPrefsCommit) => void } = {},
 ): void {
-  adoptPushClient(client);
+  adoptPushWriter(writer);
   clearConflictRedrain();
   pushEpoch += 1;
   pushDraining = drainRequested = false;
   pushAfterCommit = hooks.afterCommit;
-  startPendingDrain(client);
+  startPendingDrain(writer);
 }

--- a/ui/src/e2e/memory-settings-engine.e2e.test.ts
+++ b/ui/src/e2e/memory-settings-engine.e2e.test.ts
@@ -106,12 +106,24 @@ describeControlUiE2e("Control UI memory engine settings mocked Gateway E2E", () 
       await gateway.deferNext("config.set");
       await gateway.deferNext("plugins.setEnabled");
       await engineGroup.getByRole("radio", { name: "Off", exact: true }).click();
-      const pendingOffSave = await gateway.waitForRequest("config.set");
-      expect(pendingOffSave.params).toMatchObject({ baseHash: "memory-hash-1" });
-
+      // Click again immediately, before the 800 ms autosave debounce. The
+      // write barrier must flush Off first instead of letting the plugin RPC
+      // race a still-scheduled config.set.
       await engineGroup.getByRole("radio", { name: "OpenClaw Memory", exact: true }).click();
       expect(await gateway.getRequests("plugins.setEnabled")).toHaveLength(0);
 
+      const pendingOffSave = await gateway.waitForRequest("config.set");
+      expect(pendingOffSave.params).toMatchObject({ baseHash: "memory-hash-1" });
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await page
+          .locator(".settings-page > .settings-section")
+          .first()
+          .screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "00-off-write-draining.png"),
+          });
+      }
       await gateway.resolveDeferred("config.set", { ok: true, hash: "mock-config-hash-1" });
       const enableRequest = await gateway.waitForRequest("plugins.setEnabled");
       expect(enableRequest.params).toEqual({ pluginId: "memory-core", enabled: true });

--- a/ui/src/lib/config/index.test.ts
+++ b/ui/src/lib/config/index.test.ts
@@ -35,9 +35,9 @@ function createGatewayHarness(client: GatewayBrowserClient) {
         return () => listeners.delete(listener);
       },
     },
-    publish: (connected: boolean) => {
+    publish: (connected: boolean, nextClient: GatewayBrowserClient = client) => {
       snapshot = {
-        client,
+        client: nextClient,
         phase: connected ? "connected" : "reconnecting",
         sessionKey: "main",
       };
@@ -1509,6 +1509,594 @@ describe("config form auto-save", () => {
     runtimeConfig.dispose();
   });
 
+  it("flushes a scheduled autosave when a write barrier runs before the debounce", async () => {
+    vi.useFakeTimers();
+    const setGate = deferred<unknown>();
+    const methods: string[] = [];
+    const request = vi.fn((method: string, params?: unknown) => {
+      methods.push(method);
+      if (method === "config.get") {
+        return Promise.resolve({
+          config: { count: 1 },
+          raw: '{\n  "count": 1\n}\n',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        });
+      }
+      if (method === "config.set") {
+        expect(params).toMatchObject({ baseHash: "hash-1" });
+        return setGate.promise;
+      }
+      return Promise.resolve({});
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    runtimeConfig.patchForm(["count"], 2);
+    let drained = false;
+    const drain = runtimeConfig.waitForPendingWrites().then(() => {
+      drained = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(methods.filter((method) => method === "config.set")).toHaveLength(1);
+    expect(drained).toBe(false);
+
+    setGate.resolve({ hash: "hash-2" });
+    await drain;
+    expect(drained).toBe(true);
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+    runtimeConfig.dispose();
+  });
+
+  it("adopts config.patch acknowledgements for consecutive queued patches", async () => {
+    const patchBaseHashes: string[] = [];
+    let storedConfig: Record<string, unknown> = { count: 1 };
+    let hashCounter = 1;
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        return {
+          config: storedConfig,
+          raw: JSON.stringify(storedConfig),
+          hash: `hash-${hashCounter}`,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.patch") {
+        const patch = params as { baseHash: string; raw: string };
+        patchBaseHashes.push(patch.baseHash);
+        storedConfig = { ...storedConfig, ...(JSON.parse(patch.raw) as Record<string, unknown>) };
+        hashCounter += 1;
+        return { config: storedConfig, hash: `hash-${hashCounter}` };
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const first = runtimeConfig.patch({ raw: { first: true }, note: "first test patch" });
+    const second = runtimeConfig.patch({ raw: { second: true }, note: "second test patch" });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(patchBaseHashes).toEqual(["hash-1", "hash-2"]);
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3");
+    expect(runtimeConfig.state.configForm).toEqual({ count: 1, first: true, second: true });
+    runtimeConfig.dispose();
+  });
+
+  it("preserves JSON5 raw text when config.patch reports a no-op", async () => {
+    const originalRaw = "{\n  // keep this operator note\n  count: 1,\n}\n";
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        return {
+          config: { count: 1 },
+          raw: originalRaw,
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.patch") {
+        return { config: { count: 1 }, noop: true };
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    await expect(
+      runtimeConfig.patch({ raw: { count: 1 }, note: "no-op test patch" }),
+    ).resolves.toBe(true);
+    expect(runtimeConfig.state.configSnapshot?.raw).toBe(originalRaw);
+    expect(runtimeConfig.state.configRaw).toBe(originalRaw);
+    runtimeConfig.dispose();
+  });
+
+  it("keeps a concurrent dirty draft on its pre-patch CAS base", async () => {
+    vi.useFakeTimers();
+    const patchGate = deferred<unknown>();
+    const request = vi.fn((method: string) => {
+      if (method === "config.get") {
+        return Promise.resolve({
+          config: { count: 1 },
+          raw: '{"count":1}',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        });
+      }
+      if (method === "config.patch") {
+        return patchGate.promise;
+      }
+      return Promise.resolve({});
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const patch = runtimeConfig.patch({ raw: { patched: true }, note: "concurrent test patch" });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("config.patch", expect.anything()));
+    runtimeConfig.patchForm(["count"], 2);
+    patchGate.resolve({ config: { count: 1, patched: true }, hash: "hash-2" });
+    await expect(patch).resolves.toBe(true);
+
+    expect(runtimeConfig.state.configFormDirty).toBe(true);
+    expect(runtimeConfig.state.configDraftBaseHash).toBe("hash-1");
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+    runtimeConfig.resetDraft();
+    runtimeConfig.dispose();
+  });
+
+  it("orders a patch acknowledgement after an older in-flight config load", async () => {
+    const staleLoad = deferred<ConfigSnapshot>();
+    let getCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 2) {
+          return staleLoad.promise;
+        }
+        return {
+          config: { count: 1 },
+          raw: '{"count":1}',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.patch") {
+        return { config: { count: 1, patched: true }, hash: "hash-2" };
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const staleRefresh = runtimeConfig.refresh();
+    await vi.waitFor(() => expect(getCalls).toBe(2));
+    await expect(
+      runtimeConfig.patch({ raw: { patched: true }, note: "ordered patch test" }),
+    ).resolves.toBe(true);
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+
+    staleLoad.resolve({
+      config: { count: 999 },
+      raw: '{"count":999}',
+      hash: "stale-hash",
+      valid: true,
+      issues: [],
+    });
+    await staleRefresh;
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+    expect(runtimeConfig.state.configForm).toEqual({ count: 1, patched: true });
+    runtimeConfig.dispose();
+  });
+
+  it("refreshes hash-only patch acknowledgements before publishing their revision", async () => {
+    let storedConfig: Record<string, unknown> = { count: 1 };
+    let hash = "hash-1";
+    let getCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        return {
+          config: storedConfig,
+          raw: JSON.stringify(storedConfig),
+          hash,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.patch") {
+        storedConfig = { count: 1, patched: true };
+        hash = "hash-2";
+        return { hash };
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    await expect(
+      runtimeConfig.patch({ raw: { patched: true }, note: "hash-only patch test" }),
+    ).resolves.toBe(true);
+
+    expect(getCalls).toBe(2);
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+    expect(runtimeConfig.state.configForm).toEqual({ count: 1, patched: true });
+    runtimeConfig.dispose();
+  });
+
+  it("records a committed hash-only patch when its acknowledgement refresh fails", async () => {
+    let getCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls > 1) {
+          throw new Error("refresh unavailable");
+        }
+        return {
+          config: { count: 1 },
+          raw: '{"count":1}',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.patch") {
+        return { hash: "hash-2" };
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    await expect(
+      runtimeConfig.patch({ raw: { patched: true }, note: "hash-only refresh failure" }),
+    ).resolves.toBe(false);
+
+    expect(runtimeConfig.state.configNeedsApply).toBe(true);
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-1");
+    expect(runtimeConfig.state.lastError).toContain("refresh unavailable");
+    runtimeConfig.dispose();
+  });
+
+  it("serializes external mutations after scheduled drafts and refreshes before resolving", async () => {
+    vi.useFakeTimers();
+    const order: string[] = [];
+    let storedConfig: Record<string, unknown> = { count: 1 };
+    let hash = "hash-1";
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        order.push("config.get");
+        return {
+          config: storedConfig,
+          raw: JSON.stringify(storedConfig),
+          hash,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.set") {
+        order.push("config.set");
+        storedConfig = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
+        hash = "hash-2";
+        return { hash };
+      }
+      if (method === "plugins.setEnabled") {
+        order.push("plugins.setEnabled");
+        storedConfig = { ...storedConfig, pluginEnabled: true };
+        hash = "hash-3";
+        return { ok: true };
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    order.length = 0;
+
+    runtimeConfig.patchForm(["count"], 2);
+    const result = await runtimeConfig.runExternalMutation((client) =>
+      client.request("plugins.setEnabled", { pluginId: "memory-core", enabled: true }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      value: { ok: true },
+      refresh: { ok: true },
+    });
+    expect(order).toEqual(["config.set", "plugins.setEnabled", "config.get"]);
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3");
+    expect(runtimeConfig.state.configForm).toEqual({ count: 2, pluginEnabled: true });
+    runtimeConfig.dispose();
+  });
+
+  it("forces a post-mutation refresh instead of joining a pre-existing config load", async () => {
+    const staleLoad = deferred<ConfigSnapshot>();
+    let getCalls = 0;
+    let storedConfig: Record<string, unknown> = { count: 1 };
+    let hash = "hash-1";
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 2) {
+          return staleLoad.promise;
+        }
+        return {
+          config: storedConfig,
+          raw: JSON.stringify(storedConfig),
+          hash,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "plugins.setEnabled") {
+        storedConfig = { count: 1, pluginEnabled: true };
+        hash = "hash-2";
+        return { ok: true };
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const overlappingRefresh = runtimeConfig.refresh();
+    await vi.waitFor(() => expect(getCalls).toBe(2));
+    const result = await runtimeConfig.runExternalMutation((client) =>
+      client.request("plugins.setEnabled", { pluginId: "memory-core", enabled: true }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(getCalls).toBe(3);
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+    expect(runtimeConfig.state.configForm).toEqual({ count: 1, pluginEnabled: true });
+
+    staleLoad.resolve({
+      config: { count: 999 },
+      raw: '{"count":999}',
+      hash: "stale-hash",
+      valid: true,
+      issues: [],
+    });
+    await overlappingRefresh;
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-2");
+    runtimeConfig.dispose();
+  });
+
+  it("preserves a committed external mutation when its authoritative refresh fails", async () => {
+    let getCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        getCalls += 1;
+        if (getCalls === 1) {
+          return {
+            config: { count: 1 },
+            raw: '{"count":1}',
+            hash: "hash-1",
+            valid: true,
+            issues: [],
+          };
+        }
+        throw new Error("refresh unavailable");
+      }
+      if (method === "plugins.setEnabled") {
+        return { ok: true };
+      }
+      return {};
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const result = await runtimeConfig.runExternalMutation((client) =>
+      client.request("plugins.setEnabled", { pluginId: "memory-core", enabled: true }),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      value: { ok: true },
+      refresh: { ok: false, error: "Error: refresh unavailable" },
+    });
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-1");
+    runtimeConfig.dispose();
+  });
+
+  it("classifies an external mutation interrupted by disconnect as retryable", async () => {
+    const mutation = deferred<unknown>();
+    const request = vi.fn((method: string) => {
+      if (method === "config.get") {
+        return Promise.resolve({
+          config: { count: 1 },
+          raw: '{"count":1}',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        });
+      }
+      if (method === "plugins.setEnabled") {
+        return mutation.promise;
+      }
+      return Promise.resolve({});
+    });
+    const { runtimeConfig, publish } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    const resultPromise = runtimeConfig.runExternalMutation((client) =>
+      client.request("plugins.setEnabled", { pluginId: "memory-core", enabled: true }),
+    );
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("plugins.setEnabled", expect.anything()),
+    );
+    publish(false);
+    mutation.reject(new Error("socket closed"));
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      reason: "unavailable",
+      error: "Connection changed before the configuration update completed.",
+    });
+    runtimeConfig.dispose();
+  });
+
+  it("queues background external mutations until write suspension ends", async () => {
+    const methods: string[] = [];
+    const request = vi.fn(async (method: string) => {
+      methods.push(method);
+      if (method === "config.get") {
+        return {
+          config: { count: 1 },
+          raw: '{"count":1}',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      return { ok: true };
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    methods.length = 0;
+    runtimeConfig.setWritesSuspended(true);
+
+    const resultPromise = runtimeConfig.runExternalMutation(
+      (client) => client.request("config.patch", { raw: '{"ui":{"prefs":{"locale":"de"}}}' }),
+      { waitForWritesResumed: true },
+    );
+    await Promise.resolve();
+    expect(methods).toEqual([]);
+
+    runtimeConfig.setWritesSuspended(false);
+    await expect(resultPromise).resolves.toEqual({
+      ok: true,
+      value: { ok: true },
+      refresh: { ok: true },
+    });
+    expect(methods).toEqual(["config.patch", "config.get"]);
+    runtimeConfig.dispose();
+  });
+
+  it("preserves queued mutation waiters when suspension is repeated", async () => {
+    const methods: string[] = [];
+    const request = vi.fn(async (method: string) => {
+      methods.push(method);
+      if (method === "config.get") {
+        return {
+          config: { count: 1 },
+          raw: '{"count":1}',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      return { ok: true };
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    methods.length = 0;
+    runtimeConfig.setWritesSuspended(true);
+
+    const resultPromise = runtimeConfig.runExternalMutation(
+      (client) => client.request("config.patch", { raw: '{"ui":{"prefs":{"locale":"de"}}}' }),
+      { waitForWritesResumed: true },
+    );
+    await Promise.resolve();
+    runtimeConfig.setWritesSuspended(true);
+    runtimeConfig.setWritesSuspended(false);
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: true,
+      value: { ok: true },
+      refresh: { ok: true },
+    });
+    expect(methods).toEqual(["config.patch", "config.get"]);
+    runtimeConfig.dispose();
+  });
+
+  it("does not retarget a suspended external mutation after the gateway changes", async () => {
+    const requestA = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        return {
+          config: { count: 1 },
+          raw: '{"count":1}',
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      return { ok: true };
+    });
+    const requestB = vi.fn(async () => ({ ok: true }));
+    const clientA = { request: requestA } as unknown as GatewayBrowserClient;
+    const clientB = { request: requestB } as unknown as GatewayBrowserClient;
+    const { gateway, publish } = createGatewayHarness(clientA);
+    const runtimeConfig = createRuntimeConfigCapability(gateway);
+    await runtimeConfig.ensureLoaded();
+    requestA.mockClear();
+    runtimeConfig.setWritesSuspended(true);
+
+    const resultPromise = runtimeConfig.runExternalMutation(
+      (client) => client.request("config.patch", { raw: '{"ui":{"prefs":{"locale":"de"}}}' }),
+      { waitForWritesResumed: true },
+    );
+    await Promise.resolve();
+    publish(true, clientB);
+    runtimeConfig.setWritesSuspended(false);
+
+    await expect(resultPromise).resolves.toEqual({
+      ok: false,
+      reason: "unavailable",
+      error: "Connection changed before the configuration update started.",
+    });
+    expect(requestA).not.toHaveBeenCalled();
+    expect(requestB).not.toHaveBeenCalled();
+    runtimeConfig.dispose();
+  });
+
+  it("retries a background mutation when suspension begins during its write drain", async () => {
+    vi.useFakeTimers();
+    const firstSet = deferred<unknown>();
+    const methods: string[] = [];
+    const request = vi.fn((method: string) => {
+      methods.push(method);
+      if (method === "config.get") {
+        return Promise.resolve({
+          config: { count: 1 },
+          raw: '{"count":1}',
+          hash: methods.filter((entry) => entry === "config.set").length ? "hash-2" : "hash-1",
+          valid: true,
+          issues: [],
+        });
+      }
+      if (method === "config.set") {
+        return firstSet.promise;
+      }
+      return Promise.resolve({ ok: true });
+    });
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+    methods.length = 0;
+
+    runtimeConfig.patchForm(["count"], 2);
+    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+    const resultPromise = runtimeConfig.runExternalMutation(
+      (client) => client.request("config.patch", { raw: '{"ui":{"prefs":{"locale":"de"}}}' }),
+      { waitForWritesResumed: true },
+    );
+    runtimeConfig.setWritesSuspended(true);
+    firstSet.resolve({ hash: "hash-2" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(methods).toEqual(["config.set"]);
+
+    runtimeConfig.setWritesSuspended(false);
+    await expect(resultPromise).resolves.toEqual({
+      ok: true,
+      value: { ok: true },
+      refresh: { ok: true },
+    });
+    expect(methods).toEqual(["config.set", "config.patch", "config.get"]);
+    runtimeConfig.dispose();
+  });
+
   it("refreshes applied revision truth after config.patch", async () => {
     vi.useFakeTimers();
     let getCount = 0;
@@ -1659,6 +2247,30 @@ describe("config form auto-save", () => {
     expect(submissions[1]?.baseHash).toBe("hash-2");
     expect(applySubmissions).toHaveLength(1);
     expect(applySubmissions[0]?.baseHash).toBe("hash-3");
+    runtimeConfig.dispose();
+  });
+
+  it("cancels a debounce armed while an explicit save drains another write", async () => {
+    vi.useFakeTimers();
+    const { request, submissions, firstSet } = createDeferredSetServerMock();
+    const { runtimeConfig } = createHarness(request as GatewayBrowserClient["request"]);
+    await runtimeConfig.ensureLoaded();
+
+    runtimeConfig.patchForm(["count"], 2);
+    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+    expect(submissions).toHaveLength(1);
+
+    const save = runtimeConfig.save();
+    runtimeConfig.patchForm(["count"], 3);
+    firstSet.resolve({});
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(save).resolves.toBe(true);
+    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS * 2);
+
+    expect(submissions).toEqual([
+      { raw: '{\n  "count": 2\n}\n', baseHash: "hash-1" },
+      { raw: '{\n  "count": 3\n}\n', baseHash: "hash-2" },
+    ]);
     runtimeConfig.dispose();
   });
 

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -17,6 +17,18 @@ import { createAppliedConfigRefreshController } from "./applied-refresh.ts";
 
 export type ConfigAutoSaveStatus = "idle" | "saving" | "saved" | "error" | "conflict";
 
+type RuntimeConfigExternalMutationResult<T> =
+  | {
+      ok: true;
+      value: T;
+      refresh: { ok: true } | { ok: false; error: string };
+    }
+  | {
+      ok: false;
+      reason: "conflict" | "error" | "suspended" | "unavailable";
+      error: string;
+    };
+
 /** Debounce window between the last form edit and its automatic config.set. */
 const CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS = 800;
 
@@ -109,6 +121,14 @@ export type RuntimeConfigCapability = {
   stageDefaultAgent: (agentId: string) => boolean;
   patch: (options: ConfigPatchOptions) => Promise<boolean>;
   patchFromSnapshot: (build: ConfigPatchBuilder) => Promise<boolean>;
+  /**
+   * Serializes a config-writing RPC behind this capability's pending draft,
+   * then refreshes the authoritative snapshot before resolving.
+   */
+  runExternalMutation: <T>(
+    task: (client: GatewayBrowserClient) => Promise<T>,
+    options?: { waitForWritesResumed?: boolean },
+  ) => Promise<RuntimeConfigExternalMutationResult<T>>;
   lookupSchemaPath: (path: string) => Promise<unknown>;
   subscribe: (listener: (state: ConfigState) => void) => () => void;
   dispose: () => void;
@@ -127,6 +147,11 @@ type ConfigPatchOptions = {
 
 type ConfigPatchBuildResult = { options: ConfigPatchOptions } | { error: string };
 type ConfigPatchBuilder = (config: Readonly<Record<string, unknown>>) => ConfigPatchBuildResult;
+type ConfigPatchAck = {
+  config?: unknown;
+  hash?: unknown;
+  noop?: boolean;
+};
 
 type ConfigGatewayClient = {
   request<T = unknown>(method: string, params?: unknown): Promise<T>;
@@ -135,18 +160,6 @@ type ConfigGatewayClient = {
 type ConfigConnectionState = {
   client: ConfigGatewayClient | null;
   connected: boolean;
-};
-
-type ConfigGatewayState = Pick<
-  ConfigState,
-  | "connected"
-  | "applySessionKey"
-  | "configNeedsApply"
-  | "configSnapshot"
-  | "lastError"
-  | "chatError"
-> & {
-  client: ConfigGatewayClient | null;
 };
 
 function createInitialConfigState(snapshot?: Partial<RuntimeConfigGatewaySnapshot>): ConfigState {
@@ -842,15 +855,17 @@ async function applyConfig(state: ConfigState): Promise<boolean> {
 }
 
 async function patchConfig(
-  state: ConfigGatewayState,
+  state: ConfigState,
   options: ConfigPatchOptions,
+  onAck?: (ack: ConfigPatchAck, snapshotAtDispatch: ConfigSnapshot) => Promise<void> | void,
 ): Promise<boolean> {
   const client = state.client;
-  if (!client || !state.connected) {
+  const currentSnapshot = state.configSnapshot;
+  if (!client || !state.connected || !currentSnapshot) {
     return false;
   }
   const connectionEpoch = currentConfigConnectionEpoch(state);
-  const baseHash = state.configSnapshot?.hash;
+  const baseHash = currentSnapshot.hash;
   if (!baseHash) {
     state.lastError = "Config hash missing; refresh and retry.";
     return false;
@@ -858,7 +873,7 @@ async function patchConfig(
   state.lastError = null;
   state.chatError = null;
   try {
-    const ack = await client.request<{ noop?: boolean }>("config.patch", {
+    const ack = await client.request<ConfigPatchAck>("config.patch", {
       baseHash,
       raw: typeof options.raw === "string" ? options.raw : JSON.stringify(options.raw),
       sessionKey: state.applySessionKey,
@@ -868,7 +883,17 @@ async function patchConfig(
     if (!isCurrentConfigConnection(state, client, connectionEpoch)) {
       return false;
     }
-    if (ack.noop !== true) {
+    const committed = ack.noop !== true;
+    if (committed) {
+      // The patch is committed once the gateway acknowledges it. Preserve
+      // that fact even if a legacy hash-only ack requires a fallible refresh.
+      state.configNeedsApply = true;
+    }
+    await onAck?.(ack, currentSnapshot);
+    if (committed) {
+      // A successful acknowledgement refresh may publish the previous
+      // applied revision. Keep the existing immediate apply-needed signal;
+      // reconcileAppliedRefresh replaces it with authoritative process truth.
       state.configNeedsApply = true;
     }
     return true;
@@ -878,6 +903,33 @@ async function patchConfig(
     }
     return false;
   }
+}
+
+function adoptConfigPatchAck(
+  state: ConfigState,
+  ack: ConfigPatchAck,
+  snapshotAtDispatch: ConfigSnapshot,
+) {
+  const ackConfig = asConfigRecord(ack.config);
+  const ackHash = readAckHash(ack);
+  if (!ackConfig) {
+    return;
+  }
+  const currentSnapshot = state.configSnapshot ?? snapshotAtDispatch;
+  const raw =
+    ack.noop === true
+      ? (currentSnapshot.raw ?? state.configRaw)
+      : ackConfig
+        ? serializeConfigForm(ackConfig)
+        : (currentSnapshot.raw ?? state.configRaw);
+  applyConfigSnapshot(state, {
+    ...currentSnapshot,
+    ...(ackConfig ? { config: ackConfig, sourceConfig: ackConfig } : {}),
+    hash: ackHash ?? currentSnapshot.hash ?? null,
+    raw,
+    valid: true,
+    issues: [],
+  });
 }
 
 async function lookupConfigSchemaPath(
@@ -1236,6 +1288,8 @@ export function createRuntimeConfigCapability(
   // App-updater interlock: config writes or gateway restarts mid-update can
   // corrupt the install, so all writes pause until the updater settles.
   let writesSuspended = false;
+  let writesResumed: (() => void) | null = null;
+  let writesResumedPromise: Promise<void> = Promise.resolve();
   // Submission info of the pending manual SAVE (applies never register:
   // a post-apply write is meaningless while the gateway restarts, so the
   // teardown flush fail-closes on them).
@@ -1350,6 +1404,14 @@ export function createRuntimeConfigCapability(
       });
     autoSaveInFlight = flight;
   };
+  const flushScheduledAutoSave = () => {
+    if (!autoSaveTimer) {
+      return;
+    }
+    clearTimeout(autoSaveTimer);
+    autoSaveTimer = null;
+    runAutoSave();
+  };
   const scheduleAutoSave = () => {
     // Only form-draft edits auto-save; raw-text drafts stay manual so a
     // half-typed JSON5 buffer never gets written to disk. Suspended writes
@@ -1379,9 +1441,15 @@ export function createRuntimeConfigCapability(
   // connection epoch.
   // Drains ALL pending config writes: the autosave chain (a settling flight
   // can spawn a trailing save) AND any manual Save still in flight.
-  const drainPendingWrites = async (): Promise<void> => {
-    let flight = autoSaveInFlight ?? manualSubmitInFlight;
-    while (flight) {
+  const drainPendingWrites = async (flushScheduledDraft = false): Promise<void> => {
+    while (true) {
+      if (flushScheduledDraft) {
+        flushScheduledAutoSave();
+      }
+      const flight = autoSaveInFlight ?? manualSubmitInFlight;
+      if (!flight) {
+        return;
+      }
       // Race the connection wake: a disconnect deregisters in-flight writes,
       // and a drain already awaiting one resumes from that deregistration
       // instead of depending on the transport's close-time rejection order.
@@ -1389,8 +1457,13 @@ export function createRuntimeConfigCapability(
       if (disposed) {
         return;
       }
-      cancelScheduledAutoSave();
-      flight = autoSaveInFlight ?? manualSubmitInFlight;
+      if (!flushScheduledDraft) {
+        // save/apply submit the latest full draft themselves. Edits made
+        // while the preceding flight settled may have armed a fresh debounce;
+        // cancel it before the explicit write starts or it can race the same
+        // post-flight base hash.
+        cancelScheduledAutoSave();
+      }
     }
   };
   // Discard barrier shared by discardDraft and refresh({discardPendingChanges}):
@@ -1411,13 +1484,21 @@ export function createRuntimeConfigCapability(
   // callers queued behind the same in-flight write would otherwise both
   // finish draining and dispatch against the same base hash.
   let explicitOpQueue: Promise<unknown> | null = null;
-  const afterPendingWritesSettled = (task: () => Promise<boolean>): Promise<boolean> => {
+  const afterPendingWritesSettled = <T>(
+    task: () => Promise<T>,
+    unavailable: T,
+    options: { flushScheduledDraft?: boolean } = {},
+  ): Promise<T> => {
     if (writesSuspended) {
-      return Promise.resolve(false);
+      return Promise.resolve(unavailable);
     }
     const client = state.client;
     const connectionEpoch = currentConfigConnectionEpoch(state);
-    cancelScheduledAutoSave();
+    if (options.flushScheduledDraft) {
+      flushScheduledAutoSave();
+    } else {
+      cancelScheduledAutoSave();
+    }
     // Start synchronously when no explicit op is queued so the submit binds
     // to the CURRENT connection epoch; only genuine queuing pays the hop.
     const start = () =>
@@ -1425,20 +1506,20 @@ export function createRuntimeConfigCapability(
         // Drain before the explicit op — otherwise an apply could race a
         // pending config.set on the same base hash into a CAS failure.
         if (autoSaveInFlight ?? manualSubmitInFlight) {
-          await drainPendingWrites();
+          await drainPendingWrites(options.flushScheduledDraft);
         }
         // The updater may have started while we drained; suspension must be a
         // real barrier or an apply could restart the gateway mid-update.
         if (writesSuspended || disposed) {
-          return false;
+          return unavailable;
         }
         if (!client || !isCurrentConfigConnection(state, client, connectionEpoch)) {
-          return false;
+          return unavailable;
         }
         manualFlightInfo = null;
         const submit = task();
         const settled = submit
-          .catch(() => false)
+          .catch(() => unavailable)
           .then(() => {
             if (manualSubmitInFlight !== settled) {
               return;
@@ -1598,24 +1679,46 @@ export function createRuntimeConfigCapability(
 
   const queueConfigPatch = (resolveOptions: () => ConfigPatchBuildResult): Promise<boolean> => {
     cancelAppliedRefresh();
-    if (autoSaveTimer) {
-      cancelScheduledAutoSave();
-      runAutoSave();
-    }
-    return afterPendingWritesSettled(async () => {
-      // A drained autosave can start its own refresh while this patch waits.
-      cancelAppliedRefresh();
-      try {
-        const resolved = resolveOptions();
-        if ("error" in resolved) {
-          state.lastError = resolved.error;
-          return false;
+    return afterPendingWritesSettled(
+      async () => {
+        // A drained autosave can start its own refresh while this patch waits.
+        cancelAppliedRefresh();
+        try {
+          const resolved = resolveOptions();
+          if ("error" in resolved) {
+            state.lastError = resolved.error;
+            return false;
+          }
+          return await patchConfig(state, resolved.options, async (ack, snapshotAtDispatch) => {
+            // The ack is newer than every config.get that began before it.
+            // Detach and invalidate those loads so stale pre-patch responses
+            // cannot replace the acknowledged config/hash.
+            configLoad = null;
+            nextRequestVersion(state, "config");
+            state.configLoading = false;
+            if (asConfigRecord(ack.config)) {
+              adoptConfigPatchAck(state, ack, snapshotAtDispatch);
+              return;
+            }
+            // Older/hash-only acknowledgements do not carry enough data to
+            // pair their new hash with a safe local document. Force a fresh
+            // snapshot instead of publishing an inconsistent hash/config.
+            const refresh = run(() => loadConfig(state));
+            void trackLoad("config", refresh);
+            if (!(await refresh)) {
+              throw new Error(
+                state.lastError ??
+                  "The configuration patch completed, but its authoritative refresh failed.",
+              );
+            }
+          });
+        } finally {
+          reconcileAppliedRefresh();
         }
-        return await patchConfig(state, resolved.options);
-      } finally {
-        reconcileAppliedRefresh();
-      }
-    }).finally(() => {
+      },
+      false,
+      { flushScheduledDraft: true },
+    ).finally(() => {
       scheduleAutoSave();
     });
   };
@@ -1696,12 +1799,24 @@ export function createRuntimeConfigCapability(
       writesSuspended = suspended;
       if (suspended) {
         cancelScheduledAutoSave();
+        writesResumedPromise = new Promise((resolve) => {
+          writesResumed = resolve;
+        });
       } else {
+        const resume = writesResumed;
+        writesResumed = null;
+        resume?.();
         // Edits made during the update save once it ends.
         scheduleAutoSave();
       }
     },
-    waitForPendingWrites: () => drainPendingWrites(),
+    waitForPendingWrites: () => {
+      // A debounce timer represents pending persisted intent too. Convert it
+      // into a tracked flight before draining so external writers cannot race
+      // the draft simply because the user clicked again within 800 ms.
+      flushScheduledAutoSave();
+      return drainPendingWrites(true);
+    },
     save: () =>
       afterPendingWritesSettled(async () => {
         cancelAppliedRefresh();
@@ -1712,7 +1827,7 @@ export function createRuntimeConfigCapability(
         } finally {
           reconcileAppliedRefresh();
         }
-      }),
+      }, false),
     apply: () =>
       afterPendingWritesSettled(async () => {
         cancelAppliedRefresh();
@@ -1731,7 +1846,7 @@ export function createRuntimeConfigCapability(
         } finally {
           reconcileAppliedRefresh();
         }
-      }),
+      }, false),
     openFile: () => run(() => openConfigFile(state)),
     ensureAgentEntry: (agentId) => {
       const index = ensureAgentConfigEntry(state, agentId);
@@ -1758,6 +1873,120 @@ export function createRuntimeConfigCapability(
           ? build(config)
           : { error: "Configuration is unavailable; refresh and try again." };
       }),
+    runExternalMutation: async <T>(
+      task: (client: GatewayBrowserClient) => Promise<T>,
+      options: { waitForWritesResumed?: boolean } = {},
+    ): Promise<RuntimeConfigExternalMutationResult<T>> => {
+      const mutationClient = state.client;
+      const mutationConnectionEpoch = currentConfigConnectionEpoch(state);
+      while (true) {
+        if (options.waitForWritesResumed && writesSuspended && !disposed) {
+          await writesResumedPromise;
+        }
+        const unavailable: RuntimeConfigExternalMutationResult<T> = {
+          ok: false,
+          reason: writesSuspended ? "suspended" : "unavailable",
+          error: writesSuspended
+            ? "Configuration writes are temporarily suspended."
+            : "Configuration is unavailable; reconnect and try again.",
+        };
+        if (
+          !mutationClient ||
+          !isCurrentConfigConnection(state, mutationClient, mutationConnectionEpoch)
+        ) {
+          return {
+            ok: false,
+            reason: "unavailable",
+            error: "Connection changed before the configuration update started.",
+          };
+        }
+        const result = await afterPendingWritesSettled<RuntimeConfigExternalMutationResult<T>>(
+          async (): Promise<RuntimeConfigExternalMutationResult<T>> => {
+            if (!isCurrentConfigConnection(state, mutationClient, mutationConnectionEpoch)) {
+              return unavailable;
+            }
+            let value: T;
+            try {
+              value = await task(mutationClient);
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              if (!isCurrentConfigConnection(state, mutationClient, mutationConnectionEpoch)) {
+                return {
+                  ok: false,
+                  reason: "unavailable",
+                  error: "Connection changed before the configuration update completed.",
+                };
+              }
+              return {
+                ok: false,
+                reason: isConfigBaseHashConflictError(error) ? "conflict" : "error",
+                error: message,
+              };
+            }
+            if (!isCurrentConfigConnection(state, mutationClient, mutationConnectionEpoch)) {
+              return {
+                ok: true,
+                value,
+                refresh: {
+                  ok: false,
+                  error: "Connection changed before the configuration update was refreshed.",
+                },
+              };
+            }
+            try {
+              // Do not join an older config.get that started before the external
+              // RPC. Start a fresh versioned load so only post-mutation state can
+              // satisfy this method's authoritative-refresh contract.
+              const refresh = run(() => loadConfig(state));
+              void trackLoad("config", refresh);
+              const refreshed = await refresh;
+              if (!isCurrentConfigConnection(state, mutationClient, mutationConnectionEpoch)) {
+                return {
+                  ok: true,
+                  value,
+                  refresh: {
+                    ok: false,
+                    error: "Connection changed before the configuration update was refreshed.",
+                  },
+                };
+              }
+              if (!refreshed) {
+                return {
+                  ok: true,
+                  value,
+                  refresh: {
+                    ok: false,
+                    error:
+                      state.lastError ??
+                      "The configuration update completed, but its authoritative refresh failed.",
+                  },
+                };
+              }
+              return { ok: true, value, refresh: { ok: true } };
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              return {
+                ok: true,
+                value,
+                refresh: { ok: false, error: message },
+              };
+            }
+          },
+          unavailable,
+          { flushScheduledDraft: true },
+        );
+        if (
+          !(
+            options.waitForWritesResumed &&
+            !disposed &&
+            !result.ok &&
+            (result.reason === "suspended" || writesSuspended)
+          )
+        ) {
+          return result;
+        }
+      }
+    },
     lookupSchemaPath: (path) => run(() => lookupConfigSchemaPath(state, path)),
     subscribe(listener) {
       listeners.add(listener);
@@ -1765,6 +1994,8 @@ export function createRuntimeConfigCapability(
     },
     dispose() {
       disposed = true;
+      writesResumed?.();
+      writesResumed = null;
       // Free any drain awaiting a flight that will never be reconciled now;
       // the disposed guard exits its loop.
       connectionWake?.();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI settings writes could race each other, causing immediate Memory Off -> engine switches, consecutive patches, or external configuration mutations to fail with `config changed since last load` or overwrite newer state.

## Why This Change Was Made

Settings now use one serialized write boundary that flushes scheduled autosaves, adopts authoritative patch acknowledgements, binds external mutations to the submitting Gateway connection, and distinguishes a failed mutation from a committed mutation whose refresh failed. UI preferences use the same ordered handoff.

## User Impact

Rapid settings changes no longer self-conflict, silently target a replacement Gateway connection, or invite unsafe retries after the server already committed the operation.

## Evidence

### Memory Off -> engine regression

| Off write draining | OpenClaw Memory restored |
| --- | --- |
| ![Memory engine set to Off while the settings write drains](https://artifacts.openclaw.ai/control-ui/settings-proof/pr-116029/96e0ea870426f5b76ff16351082acc7feb0c65db/00-off-write-draining.png) | ![OpenClaw Memory selected after the serialized write completes](https://artifacts.openclaw.ai/control-ui/settings-proof/pr-116029/96e0ea870426f5b76ff16351082acc7feb0c65db/01-openclaw-memory-selected.png) |

- 150 focused tests passed.
- Memory settings browser E2E passed 1/1.
- Frozen-base branch guards, formatting, i18n, max-lines, and focused lint passed.
- Fresh autoreview reported no accepted/actionable findings.

The exact-base remote gate was unavailable during final proof; the trusted local fallback stopped only on an untouched shared dependency missing from the linked install. PR CI remains the authoritative broad gate.
