### PR TITLE
fix(ui): keep external settings mutations from racing saves

### DIFF
--- a/ui/src/e2e/plugins-config-mutation.e2e.test.ts
+++ b/ui/src/e2e/plugins-config-mutation.e2e.test.ts
@@ -1,0 +1,184 @@
+// Control UI tests cover plugin mutations serialized behind pending config drafts.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  waitForControlUiRoute,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const uiProofArtifactDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "plugins-config-mutation",
+);
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+function configResponse(fallback: string | undefined, workboardEnabled: boolean, hash: string) {
+  const config = {
+    agents: {
+      defaults: { model: { primary: "openai/gpt-5" } },
+      list: [
+        {
+          id: "main",
+          model: {
+            primary: "openai/gpt-5",
+            ...(fallback ? { fallbacks: [fallback] } : {}),
+          },
+        },
+      ],
+    },
+    plugins: {
+      entries: { workboard: { enabled: workboardEnabled } },
+    },
+  };
+  return {
+    config,
+    hash,
+    appliedConfigHash: hash,
+    issues: [],
+    raw: JSON.stringify(config),
+    valid: true,
+  };
+}
+
+const workboardDisabled = {
+  id: "workboard",
+  name: "Workboard",
+  description: "Plan and track work",
+  origin: "bundled",
+  installed: true,
+  enabled: false,
+  state: "disabled",
+  featured: true,
+  order: 10,
+};
+
+const workboardEnabled = {
+  ...workboardDisabled,
+  enabled: true,
+  state: "enabled",
+};
+
+describeControlUiE2e("Control UI plugin config mutation mocked Gateway E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("drains a pending draft before enabling a plugin and refreshes the result", async () => {
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "agents.list": {
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+          agents: [{ id: "main", identity: { name: "Main" }, name: "Main" }],
+        },
+        "config.get": configResponse(undefined, false, "config-hash-1"),
+        "plugins.list": {
+          plugins: [workboardDisabled],
+          diagnostics: [],
+          mutationAllowed: true,
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/agents/main/overview`);
+      expect(response?.status()).toBe(200);
+
+      const fallbackInput = page.locator(".agent-chip-input input");
+      await fallbackInput.waitFor();
+      await gateway.deferNext("config.set");
+      await fallbackInput.fill("anthropic/claude-sonnet-4-6");
+      await fallbackInput.press("Enter");
+      await page.evaluate(() => {
+        history.pushState(null, "", "/settings/plugins");
+        window.dispatchEvent(new PopStateEvent("popstate"));
+      });
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/plugins",
+        routeId: "plugins",
+      });
+
+      const workboardRow = page.locator('[data-plugin-id="workboard"]');
+      await workboardRow.waitFor();
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await workboardRow.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "00-before-enable.png"),
+        });
+      }
+
+      await gateway.deferNext("plugins.setEnabled");
+      await workboardRow.getByRole("button", { name: "Enable", exact: true }).click();
+      expect(await gateway.getRequests("plugins.setEnabled")).toHaveLength(0);
+
+      const pendingDraft = await gateway.waitForRequest("config.set");
+      expect(pendingDraft.params).toMatchObject({ baseHash: "config-hash-1" });
+      await gateway.resolveDeferred("config.set", { ok: true, hash: "config-hash-2" });
+
+      const enableRequest = await gateway.waitForRequest("plugins.setEnabled");
+      expect(enableRequest.params).toEqual({ pluginId: "workboard", enabled: true });
+      await gateway.setMethodResponse(
+        "config.get",
+        configResponse("anthropic/claude-sonnet-4-6", true, "config-hash-3"),
+      );
+      await gateway.setMethodResponse("plugins.list", {
+        plugins: [workboardEnabled],
+        diagnostics: [],
+        mutationAllowed: true,
+      });
+      await gateway.resolveDeferred("plugins.setEnabled", {
+        ok: true,
+        plugin: workboardEnabled,
+        restartRequired: true,
+      });
+
+      await workboardRow.getByRole("button", { name: "Disable", exact: true }).waitFor();
+      await expect
+        .poll(async () => (await gateway.getRequests("config.get")).length)
+        .toBeGreaterThanOrEqual(2);
+      if (captureUiProofEnabled) {
+        await workboardRow.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "01-after-enable.png"),
+        });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -667,10 +667,11 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
     const agentIdentity = this.context.agentIdentity;
     void saveIdentityDraft({
       host: this,
-      client,
+      expectedClient: client,
       agentId,
       agents,
       agentIdentity,
+      runtimeConfig: this.context.runtimeConfig,
       isCurrent: () =>
         this.isCurrentRequest(client, generation, agentId, { agents, agentIdentity }),
       onSaved: () => this.syncAgentState(agents),

--- a/ui/src/pages/agents/identity-actions.test.ts
+++ b/ui/src/pages/agents/identity-actions.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { createRuntimeConfigCapability } from "../../lib/config/index.ts";
 import * as avatarImage from "./avatar-image.ts";
 import { resetIdentityDraft, saveIdentityDraft, selectIdentityAvatar } from "./identity-actions.ts";
 
@@ -11,6 +13,7 @@ beforeEach(() => {
 
 afterEach(() => {
   fileToAvatarDataUrlMock.mockReset();
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -26,19 +29,23 @@ describe("agent identity actions", () => {
   it("keeps unsupported blank edits visible without sending an update", async () => {
     const state = host();
     state.identityDraft.name = "  ";
-    const request = vi.fn();
+    const runExternalMutation = vi.fn();
+    const expectedClient = { request: vi.fn() } as unknown as GatewayBrowserClient;
 
     await saveIdentityDraft({
       host: state,
-      client: { request } as never,
+      expectedClient,
       agentId: "main",
       agents: {} as ApplicationContext["agents"],
       agentIdentity: {} as ApplicationContext["agentIdentity"],
+      runtimeConfig: {
+        runExternalMutation,
+      } as unknown as ApplicationContext["runtimeConfig"],
       isCurrent: () => true,
       onSaved: vi.fn(),
     });
 
-    expect(request).not.toHaveBeenCalled();
+    expect(runExternalMutation).not.toHaveBeenCalled();
     expect(state.identityDraft.name).toBe("  ");
   });
 
@@ -57,5 +64,146 @@ describe("agent identity actions", () => {
     await Promise.resolve();
 
     expect(state.identityDraft.avatar).toBeNull();
+  });
+
+  it("flushes a pending config draft before agents.update and refreshes afterward", async () => {
+    vi.useFakeTimers();
+    const order: string[] = [];
+    let config: Record<string, unknown> = { pending: false };
+    let hash = "hash-1";
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        order.push(method);
+        return {
+          config,
+          sourceConfig: config,
+          raw: JSON.stringify(config),
+          hash,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.set") {
+        order.push(method);
+        config = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
+        hash = "hash-2";
+        return { hash };
+      }
+      if (method === "agents.update") {
+        order.push(method);
+        config = { ...config, identityName: (params as { name: string }).name };
+        hash = "hash-3";
+        return {};
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const runtimeConfig = createRuntimeConfigCapability({
+      snapshot: { client, phase: "connected", sessionKey: "main" },
+      subscribe: () => () => undefined,
+    });
+    await runtimeConfig.ensureLoaded();
+    order.length = 0;
+    runtimeConfig.patchForm(["pending"], true);
+    const state = host();
+    state.identityDraft.name = "Agent Smith";
+    const agents = {
+      refreshList: vi.fn(async () => undefined),
+    } as unknown as ApplicationContext["agents"];
+    const agentIdentity = {
+      invalidate: vi.fn(),
+      ensure: vi.fn(async () => undefined),
+    } as unknown as ApplicationContext["agentIdentity"];
+
+    await saveIdentityDraft({
+      host: state,
+      expectedClient: client,
+      agentId: "main",
+      agents,
+      agentIdentity,
+      runtimeConfig,
+      isCurrent: () => true,
+      onSaved: vi.fn(),
+    });
+
+    expect(order).toEqual(["config.set", "agents.update", "config.get"]);
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3");
+    expect(runtimeConfig.state.configForm).toMatchObject({
+      pending: true,
+      identityName: "Agent Smith",
+    });
+    runtimeConfig.dispose();
+  });
+
+  it("does not send a stale identity draft through a replacement connection", async () => {
+    const expectedClient = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const replacementRequest = vi.fn();
+    const replacementClient = {
+      request: replacementRequest,
+    } as unknown as GatewayBrowserClient;
+    const state = host();
+    state.identityDraft.name = "Agent Smith";
+    const runtimeConfig = {
+      runExternalMutation: vi.fn(async (task) => {
+        try {
+          return {
+            ok: true as const,
+            value: await task(replacementClient),
+            refresh: { ok: true as const },
+          };
+        } catch (error) {
+          return { ok: false as const, reason: "error" as const, error: String(error) };
+        }
+      }),
+    } as unknown as ApplicationContext["runtimeConfig"];
+
+    await saveIdentityDraft({
+      host: state,
+      expectedClient,
+      agentId: "main",
+      agents: {} as ApplicationContext["agents"],
+      agentIdentity: {} as ApplicationContext["agentIdentity"],
+      runtimeConfig,
+      isCurrent: () => true,
+      onSaved: vi.fn(),
+    });
+
+    expect(replacementRequest).not.toHaveBeenCalled();
+    expect(state.identityError).toContain(
+      "Connection changed before the agent identity update started.",
+    );
+  });
+
+  it("clears a committed identity draft while surfacing a config refresh warning", async () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const state = host();
+    state.identityDraft.name = "Agent Smith";
+    const runExternalMutation = vi.fn(async () => ({
+      ok: true as const,
+      value: {},
+      refresh: { ok: false as const, error: "config.get failed after identity commit" },
+    }));
+
+    await saveIdentityDraft({
+      host: state,
+      expectedClient: client,
+      agentId: "main",
+      agents: {
+        refreshList: vi.fn(async () => undefined),
+      } as unknown as ApplicationContext["agents"],
+      agentIdentity: {
+        invalidate: vi.fn(),
+        ensure: vi.fn(async () => undefined),
+      } as unknown as ApplicationContext["agentIdentity"],
+      runtimeConfig: {
+        runExternalMutation,
+      } as unknown as ApplicationContext["runtimeConfig"],
+      isCurrent: () => true,
+      onSaved: vi.fn(),
+    });
+
+    expect(runExternalMutation).toHaveBeenCalledOnce();
+    expect(state.identityDraft).toEqual({ name: null, emoji: null, avatar: null });
+    expect(state.identityError).toContain("config.get failed after identity commit");
   });
 });

--- a/ui/src/pages/agents/identity-actions.ts
+++ b/ui/src/pages/agents/identity-actions.ts
@@ -12,6 +12,10 @@ type AgentIdentityEditorHost = {
   identityError: string | null;
 };
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 const avatarSelectionEpochs = new WeakMap<AgentIdentityEditorHost, number>();
 
 function advanceAvatarSelectionEpoch(host: AgentIdentityEditorHost): number {
@@ -55,14 +59,15 @@ export function selectIdentityAvatar(host: AgentIdentityEditorHost, file: File) 
     identity cache so the sidebar chip and page pick up the new identity. */
 export async function saveIdentityDraft(params: {
   host: AgentIdentityEditorHost;
-  client: GatewayBrowserClient;
+  expectedClient: GatewayBrowserClient;
   agentId: string;
   agents: ApplicationContext["agents"];
   agentIdentity: ApplicationContext["agentIdentity"];
+  runtimeConfig: ApplicationContext["runtimeConfig"];
   isCurrent: () => boolean;
   onSaved: () => void;
 }) {
-  const { host, agentId, agents, agentIdentity } = params;
+  const { host, expectedClient, agentId, agents, agentIdentity, runtimeConfig } = params;
   const draft = host.identityDraft;
   // Set/replace only: agents.update has no explicit clear operation. Keep a
   // blank edit visible and unsaved instead of pretending it removed a field.
@@ -79,13 +84,35 @@ export async function saveIdentityDraft(params: {
   host.identitySaving = true;
   host.identityError = null;
   try {
-    await updateAgentIdentity(params.client, { agentId, name, emoji, avatar });
+    const mutation = await runtimeConfig.runExternalMutation((client) => {
+      if (client !== expectedClient) {
+        throw new Error("Connection changed before the agent identity update started.");
+      }
+      return updateAgentIdentity(client, { agentId, name, emoji, avatar });
+    });
+    if (!mutation.ok) {
+      throw new Error(mutation.error);
+    }
+    const refreshErrors = mutation.refresh.ok ? [] : [mutation.refresh.error];
     agentIdentity.invalidate([agentId]);
-    await agents.refreshList();
-    await agentIdentity.ensure([agentId]);
+    try {
+      await agents.refreshList();
+    } catch (error) {
+      refreshErrors.push(
+        `Agent identity was saved, but the agent list refresh failed: ${errorMessage(error)}`,
+      );
+    }
+    try {
+      await agentIdentity.ensure([agentId]);
+    } catch (error) {
+      refreshErrors.push(
+        `Agent identity was saved, but the identity refresh failed: ${errorMessage(error)}`,
+      );
+    }
     if (params.isCurrent()) {
       resetIdentityDraft(host);
       params.onSaved();
+      host.identityError = refreshErrors.length > 0 ? refreshErrors.join(" ") : null;
     }
   } catch (err) {
     if (params.isCurrent()) {

--- a/ui/src/pages/model-setup/model-setup-page.test.ts
+++ b/ui/src/pages/model-setup/model-setup-page.test.ts
@@ -5,6 +5,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SystemAgentSetupDetectResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGateway } from "../../app/context.ts";
 import { i18n } from "../../i18n/index.ts";
+import { createRuntimeConfigCapability } from "../../lib/config/index.ts";
 import {
   createApplicationContextProvider,
   type ApplicationContextProvider,
@@ -50,7 +51,12 @@ function createContext() {
       protocol: 1,
       auth: { role: "operator", scopes: ["operator.read", "operator.admin"] },
       features: {
-        methods: ["openclaw.setup.detect", "openclaw.setup.verify", "openclaw.setup.prepare.start"],
+        methods: [
+          "openclaw.setup.detect",
+          "openclaw.setup.verify",
+          "openclaw.setup.activate",
+          "openclaw.setup.prepare.start",
+        ],
       },
     },
     assistantAgentId: "main",
@@ -75,13 +81,16 @@ function createContext() {
     subscribeEventLog: () => () => undefined,
     subscribeEvents: () => () => undefined,
   } as unknown as ApplicationGateway;
+  const runtimeConfig = createRuntimeConfigCapability(gateway);
   return {
     client,
     request,
+    runtimeConfig,
     context: {
       gateway,
       basePath: "/openclaw",
       navigate: vi.fn(),
+      runtimeConfig,
     } as unknown as ApplicationContext,
   };
 }
@@ -106,6 +115,7 @@ describe("ModelSetupPage catalog icons", () => {
 
   afterEach(() => {
     document.body.replaceChildren();
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -264,6 +274,170 @@ describe("ModelSetupPage catalog icons", () => {
       );
       expect(page.querySelector("openclaw-modal-dialog")).not.toBeNull();
       expect(page.textContent).toContain("Downloading model: 25%");
+    });
+  });
+
+  it("flushes a pending config draft before one-shot activation and refreshes afterward", async () => {
+    vi.useFakeTimers();
+    const { context, client, request, runtimeConfig } = createContext();
+    const order: string[] = [];
+    let config: Record<string, unknown> = { pending: false };
+    let hash = "hash-1";
+    request.mockImplementation(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        order.push(method);
+        return {
+          config,
+          sourceConfig: config,
+          raw: JSON.stringify(config),
+          hash,
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.set") {
+        order.push(method);
+        config = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
+        hash = "hash-2";
+        return { hash };
+      }
+      if (method === "openclaw.setup.activate") {
+        order.push(method);
+        config = { ...config, configuredModel: "openai/gpt-5" };
+        hash = "hash-3";
+        return { ok: true, modelRef: "openai/gpt-5", latencyMs: 42, lines: [] };
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    await runtimeConfig.ensureLoaded();
+    order.length = 0;
+    runtimeConfig.patchForm(["pending"], true);
+    const { page } = await mountPage(context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          candidates: [
+            {
+              kind: "codex-cli",
+              brandId: "openai",
+              label: "Codex CLI",
+              detail: "Signed in locally",
+              modelRef: "openai/gpt-5",
+              recommended: true,
+              credentials: true,
+            },
+          ],
+        },
+      },
+      client,
+      firstRun: false,
+    });
+
+    page.querySelector<HTMLButtonElement>('[data-candidate-kind="codex-cli"] button')?.click();
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(["config.set", "openclaw.setup.activate", "config.get"]);
+    });
+    expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3");
+    expect(runtimeConfig.state.configForm).toMatchObject({
+      pending: true,
+      configuredModel: "openai/gpt-5",
+    });
+    runtimeConfig.dispose();
+  });
+
+  it("does not activate a stale candidate through a replacement connection", async () => {
+    const { context: baseContext, client } = createContext();
+    const replacementRequest = vi.fn();
+    const replacementClient = {
+      request: replacementRequest,
+    } as unknown as GatewayBrowserClient;
+    const context = {
+      ...baseContext,
+      runtimeConfig: {
+        runExternalMutation: vi.fn(async (task) => {
+          try {
+            return {
+              ok: true as const,
+              value: await task(replacementClient),
+              refresh: { ok: true as const },
+            };
+          } catch (error) {
+            return { ok: false as const, reason: "error" as const, error: String(error) };
+          }
+        }),
+      } as unknown as ApplicationContext["runtimeConfig"],
+    } as ApplicationContext;
+    const { page } = await mountPage(context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          candidates: [
+            {
+              kind: "codex-cli",
+              brandId: "openai",
+              label: "Codex CLI",
+              detail: "Signed in locally",
+              modelRef: "openai/gpt-5",
+              recommended: true,
+              credentials: true,
+            },
+          ],
+        },
+      },
+      client,
+      firstRun: false,
+    });
+
+    page.querySelector<HTMLButtonElement>('[data-candidate-kind="codex-cli"] button')?.click();
+
+    await vi.waitFor(() => {
+      expect(page.textContent).toContain("Connection changed before model activation started.");
+    });
+    expect(replacementRequest).not.toHaveBeenCalled();
+  });
+
+  it("keeps a committed activation successful while surfacing a config refresh warning", async () => {
+    const { context: baseContext, client } = createContext();
+    const context = {
+      ...baseContext,
+      runtimeConfig: {
+        runExternalMutation: vi.fn(async () => ({
+          ok: true as const,
+          value: { ok: true, modelRef: "openai/gpt-5", latencyMs: 42, lines: [] },
+          refresh: { ok: false as const, error: "config.get failed after model commit" },
+        })),
+      } as unknown as ApplicationContext["runtimeConfig"],
+    } as ApplicationContext;
+    const { page } = await mountPage(context, {
+      state: {
+        phase: "ready",
+        result: {
+          ...detection,
+          candidates: [
+            {
+              kind: "codex-cli",
+              brandId: "openai",
+              label: "Codex CLI",
+              detail: "Signed in locally",
+              modelRef: "openai/gpt-5",
+              recommended: true,
+              credentials: true,
+            },
+          ],
+        },
+      },
+      client,
+      firstRun: false,
+    });
+
+    page.querySelector<HTMLButtonElement>('[data-candidate-kind="codex-cli"] button')?.click();
+
+    await vi.waitFor(() => {
+      expect(page.textContent).toContain("Your AI is ready");
+      expect(page.textContent).toContain("config.get failed after model commit");
     });
   });
 });

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -57,6 +57,11 @@ type BoundModelResult<T> =
   | { client: GatewayBrowserClient; value: T }
   | { client: GatewayBrowserClient; error: unknown };
 
+type ActivationTaskResult = {
+  result: SystemAgentSetupActivateResult;
+  refreshError: string | null;
+};
+
 async function captureModelResult<T>(
   client: GatewayBrowserClient,
   load: () => Promise<T>,
@@ -141,19 +146,37 @@ export class ModelSetupPage extends OpenClawLightDomElement {
 
   private readonly activationTask = new Task<
     readonly [GatewayBrowserClient | null, SystemAgentSetupActivateParams | null],
-    BoundModelResult<SystemAgentSetupActivateResult>
+    BoundModelResult<ActivationTaskResult>
   >(this, {
     autoRun: false,
     args: () => [null, null],
-    task: ([client, params], { signal }) =>
-      client && params
-        ? captureModelResult(client, () =>
-            client.request<SystemAgentSetupActivateResult>("openclaw.setup.activate", params, {
+    task: ([client, params], { signal }) => {
+      if (!client || !params) {
+        return initialState;
+      }
+      return captureModelResult(client, async () => {
+        const mutation = await this.context.runtimeConfig.runExternalMutation((mutationClient) => {
+          if (mutationClient !== client) {
+            throw new Error("Connection changed before model activation started.");
+          }
+          return mutationClient.request<SystemAgentSetupActivateResult>(
+            "openclaw.setup.activate",
+            params,
+            {
               timeoutMs: activationTimeoutForKind(params.kind),
               signal,
-            }),
-          )
-        : initialState,
+            },
+          );
+        });
+        if (!mutation.ok) {
+          throw new Error(mutation.error);
+        }
+        return {
+          result: mutation.value,
+          refreshError: mutation.refresh.ok ? null : mutation.refresh.error,
+        };
+      });
+    },
     onComplete: (outcome) => {
       const current = this.activationState;
       if (current.phase !== "testing" || this.context.gateway.snapshot.client !== outcome.client) {
@@ -168,11 +191,15 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         };
         return;
       }
-      this.activationState = mapActivationResult({
-        result: outcome.value,
+      const activationState = mapActivationResult({
+        result: outcome.value.result,
         targetId: current.targetId,
         fallbackError: t("modelSetup.errors.activationFailed"),
       });
+      this.activationState =
+        activationState.phase === "success" && outcome.value.refreshError
+          ? { ...activationState, warning: outcome.value.refreshError }
+          : activationState;
       if (this.activationState.phase === "success") {
         this.manualApiKey = "";
       }

--- a/ui/src/pages/model-setup/state.ts
+++ b/ui/src/pages/model-setup/state.ts
@@ -27,7 +27,7 @@ export type ModelSetupActivationState =
       status: Exclude<NonNullable<SystemAgentSetupActivateResult["status"]>, "ok">;
       error: string;
     }
-  | { phase: "success"; modelRef: string; latencyMs?: number };
+  | { phase: "success"; modelRef: string; latencyMs?: number; warning?: string };
 
 type ModelSetupVerifyFailure = Extract<SystemAgentSetupVerifyResult, { ok: false }>;
 

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -135,6 +135,9 @@ function renderSuccess(
                 latencyMs: String(activation.latencyMs),
               })}
         </div>
+        ${activation.warning
+          ? html`<div class="model-setup__success-warning">${activation.warning}</div>`
+          : nothing}
       </div>
       <button type="button" class="btn primary" @click=${onOpenChat}>
         ${t("modelSetup.success.openChat")}

--- a/ui/src/pages/plugins/plugins-page.test-support.ts
+++ b/ui/src/pages/plugins/plugins-page.test-support.ts
@@ -9,6 +9,7 @@ import type {
 import { t } from "../../i18n/index.ts";
 import type {
   PluginCatalogItem,
+  PluginInstallRequest,
   PluginListResult,
   PluginMutationResult,
   PluginSearchResult,
@@ -36,6 +37,9 @@ type TestPluginsPage = HTMLElement & {
   activeTab: "installed" | "discover";
   searchResults: PluginSearchResult[] | null;
   applyMutationResult: (result: PluginMutationResult) => void;
+  install: (rowKey: string, request: PluginInstallRequest) => Promise<void>;
+  updateEnabled: (pluginId: string, enabled: boolean, key?: string) => Promise<void>;
+  uninstall: (pluginId: string, rowKey: string) => Promise<void>;
 };
 
 export type RuntimeConfigTestState = {
@@ -150,6 +154,7 @@ type RuntimeConfigTestHarness = {
       typeof vi.fn<(options: { raw: Record<string, unknown>; note: string }) => Promise<boolean>>
     >;
     patchFromSnapshot: ApplicationContext["runtimeConfig"]["patchFromSnapshot"];
+    runExternalMutation: ApplicationContext["runtimeConfig"]["runExternalMutation"];
     subscribe: (listener: (state: RuntimeConfigTestState) => void) => () => void;
   };
   notify: () => void;
@@ -158,6 +163,7 @@ type RuntimeConfigTestHarness = {
 export function createRuntimeConfigHarness(
   refreshConfig: ApplicationContext["runtimeConfig"]["refresh"],
   runtimeConfigState: RuntimeConfigTestState,
+  getClient?: () => GatewayBrowserClient | null,
 ): RuntimeConfigTestHarness {
   const listeners = new Set<(state: RuntimeConfigTestState) => void>();
   const patch = vi.fn<
@@ -176,6 +182,38 @@ export function createRuntimeConfigHarness(
         return false;
       }
       return patch(built.options);
+    }),
+    runExternalMutation: vi.fn(async (task) => {
+      const client = getClient?.() ?? null;
+      if (!client) {
+        return {
+          ok: false as const,
+          reason: "unavailable" as const,
+          error: "Configuration is unavailable; reconnect and try again.",
+        };
+      }
+      try {
+        const value = await task(client);
+        try {
+          await refreshConfig();
+          return { ok: true as const, value, refresh: { ok: true as const } };
+        } catch (error) {
+          return {
+            ok: true as const,
+            value,
+            refresh: {
+              ok: false as const,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          };
+        }
+      } catch (error) {
+        return {
+          ok: false as const,
+          reason: "error" as const,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
     }),
     subscribe(listener: (state: RuntimeConfigTestState) => void) {
       listeners.add(listener);
@@ -199,7 +237,11 @@ export function createContext(
     configFormDirty: false,
     lastError: null,
   },
-  harness = createRuntimeConfigHarness(refreshConfig, runtimeConfigState),
+  harness = createRuntimeConfigHarness(
+    refreshConfig,
+    runtimeConfigState,
+    () => gateway.snapshot.client,
+  ),
 ): ApplicationContext {
   return {
     gateway,

--- a/ui/src/pages/plugins/plugins-page.test.ts
+++ b/ui/src/pages/plugins/plugins-page.test.ts
@@ -2,8 +2,14 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApplicationContext } from "../../app/context.ts";
 import { i18n } from "../../i18n/index.ts";
-import type { PluginListResult, PluginSearchResult } from "../../lib/plugins/index.ts";
+import { createRuntimeConfigCapability } from "../../lib/config/index.ts";
+import type {
+  PluginInstallRequest,
+  PluginListResult,
+  PluginSearchResult,
+} from "../../lib/plugins/index.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   clickRowAction,
@@ -315,6 +321,119 @@ describe("PluginsPage", () => {
     expect(calls).toContainEqual(["config.get", {}]);
   });
 
+  it.each(["install", "enable", "uninstall"] as const)(
+    "flushes a pending config draft before plugin %s and refreshes afterward",
+    async (action) => {
+      vi.useFakeTimers();
+      const method =
+        action === "install"
+          ? "plugins.install"
+          : action === "enable"
+            ? "plugins.setEnabled"
+            : "plugins.uninstall";
+      const order: string[] = [];
+      let config: Record<string, unknown> = { pending: false };
+      let hash = "hash-1";
+      const enabledPlugin = createPlugin({ enabled: true, state: "enabled" });
+      const installedPlugin = createPlugin({
+        id: "example-plugin",
+        name: "Example Plugin",
+        origin: "global",
+        installed: true,
+        enabled: true,
+        state: "enabled",
+      });
+      const removablePlugin = createPlugin({
+        id: "community-thing",
+        name: "Community Thing",
+        origin: "global",
+        removable: true,
+        featured: false,
+      });
+      const { client } = createClient(async (requestMethod, params) => {
+        if (requestMethod === "config.get") {
+          order.push(requestMethod);
+          return {
+            config,
+            sourceConfig: config,
+            raw: JSON.stringify(config),
+            hash,
+            valid: true,
+            issues: [],
+          };
+        }
+        if (requestMethod === "config.set") {
+          order.push(requestMethod);
+          config = JSON.parse((params as { raw: string }).raw) as Record<string, unknown>;
+          hash = "hash-2";
+          return { hash };
+        }
+        if (requestMethod === method) {
+          order.push(requestMethod);
+          config = { ...config, pluginMutation: action };
+          hash = "hash-3";
+          if (action === "uninstall") {
+            return {
+              ok: true,
+              pluginId: "community-thing",
+              restartRequired: true,
+              removed: ["config entry"],
+            };
+          }
+          return {
+            ok: true,
+            plugin: action === "install" ? installedPlugin : enabledPlugin,
+            restartRequired: true,
+          };
+        }
+        if (requestMethod === "plugins.list") {
+          order.push(requestMethod);
+          return createResult(action === "install" ? installedPlugin : enabledPlugin);
+        }
+        throw new Error(`Unexpected method ${requestMethod}`);
+      });
+      const gatewayHarness = createGateway(client);
+      const runtimeConfig = createRuntimeConfigCapability(gatewayHarness.gateway);
+      await runtimeConfig.ensureLoaded();
+      const context = {
+        ...createContext(gatewayHarness.gateway, runtimeConfig.refresh),
+        runtimeConfig,
+      } as ApplicationContext;
+      const { page } = await mountPage(context, {
+        gateway: gatewayHarness.gateway,
+        gatewaySnapshot: gatewayHarness.gateway.snapshot,
+        location: createPluginsRouteLocation(),
+        result: {
+          plugins: [createPlugin(), removablePlugin],
+          diagnostics: [],
+          mutationAllowed: true,
+        },
+        error: null,
+      });
+      order.length = 0;
+      runtimeConfig.patchForm(["pending"], true);
+
+      if (action === "install") {
+        await page.install("search:example-plugin", {
+          source: "clawhub",
+          packageName: "example-plugin",
+        } as PluginInstallRequest);
+      } else if (action === "enable") {
+        await page.updateEnabled("workboard", true);
+      } else {
+        await page.uninstall("community-thing", "plugin:community-thing");
+      }
+
+      expect(order).toEqual(["config.set", method, "config.get", "plugins.list"]);
+      expect(runtimeConfig.state.configSnapshot?.hash).toBe("hash-3");
+      expect(runtimeConfig.state.configForm).toMatchObject({
+        pending: true,
+        pluginMutation: action,
+      });
+      runtimeConfig.dispose();
+    },
+  );
+
   it("keeps the enable action retryable after a failed enable", async () => {
     const { client, request } = createClient(async (method) => {
       if (method === "plugins.setEnabled") {
@@ -415,9 +534,9 @@ describe("PluginsPage", () => {
     expect(page.loading).toBe(false);
   });
 
-  it("surfaces and retries a runtime config refresh failure", async () => {
+  it("keeps a committed enable successful when its config refresh fails", async () => {
     const enabledPlugin = createPlugin({ enabled: true, state: "enabled" });
-    const { client } = createClient(async (method) => {
+    const { client, request } = createClient(async (method) => {
       if (method === "plugins.setEnabled") {
         return { ok: true, plugin: enabledPlugin, restartRequired: false };
       }
@@ -431,13 +550,8 @@ describe("PluginsPage", () => {
       configFormDirty: false,
       lastError: null,
     };
-    let refreshCalls = 0;
     const refreshConfig = vi.fn(async () => {
-      refreshCalls += 1;
-      if (refreshCalls === 1) {
-        throw new Error("config.get failed");
-      }
-      runtimeConfigState.lastError = null;
+      throw new Error("config.get failed after plugin commit");
     });
     const { page } = await mountPage(
       createContext(harness.gateway, refreshConfig, runtimeConfigState),
@@ -446,14 +560,15 @@ describe("PluginsPage", () => {
 
     await clickRowAction(page, '[data-plugin-id="workboard"]', "Enable");
     await waitForFast(() =>
-      expect(page.querySelector(".plugins-page-error")?.textContent).toContain(
-        "Could not refresh Control UI configuration: config.get failed",
+      expect(page.querySelector('[role="status"]')?.textContent).toContain(
+        "config.get failed after plugin commit",
       ),
     );
-
-    page.querySelector<HTMLButtonElement>(".plugins-page-error button")?.click();
-    await waitForFast(() => expect(page.querySelector(".plugins-page-error")).toBeNull());
-    expect(refreshConfig).toHaveBeenCalledTimes(2);
+    expect(page.result?.plugins[0]?.enabled).toBe(true);
+    expect(request.mock.calls.filter(([method]) => method === "plugins.setEnabled")).toHaveLength(
+      1,
+    );
+    expect(refreshConfig).toHaveBeenCalledOnce();
   });
 
   it("does not let an old mutation clear replacement-source busy state", async () => {

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -72,6 +72,45 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+async function runPluginConfigMutation<T>(
+  runtimeConfig: ApplicationContext["runtimeConfig"],
+  expectedClient: GatewayBrowserClient,
+  task: (client: GatewayBrowserClient) => Promise<T>,
+): Promise<{ value: T; refreshError: string | null }> {
+  let taskError: Error | undefined;
+  const mutation = await runtimeConfig.runExternalMutation(async (client) => {
+    if (client !== expectedClient) {
+      throw new Error("Connection changed before the plugin update started.");
+    }
+    try {
+      return await task(client);
+    } catch (error) {
+      // Preserve structured Gateway errors used by the ClawHub risk prompt.
+      taskError = error instanceof Error ? error : new Error(String(error));
+      throw taskError;
+    }
+  });
+  if (mutation.ok) {
+    return {
+      value: mutation.value,
+      refreshError: mutation.refresh.ok ? null : mutation.refresh.error,
+    };
+  }
+  throw taskError ?? new Error(mutation.error);
+}
+
+function committedMutationMessage(success: string, refreshError: string | null): PluginRowMessage {
+  return {
+    kind: "success",
+    text: [
+      success,
+      refreshError ? t("pluginsPage.configRefreshFailed", { error: refreshError }) : null,
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  };
+}
+
 function withPlugin(
   current: PluginListResult | null,
   plugin: PluginCatalogItem,
@@ -701,12 +740,9 @@ class PluginsPage extends OpenClawLightDomElement {
   }
 
   /** Plugin changes can affect both catalog state and route visibility (for example Workboard). */
-  private async refreshAfterMutation(client: GatewayBrowserClient): Promise<void> {
+  private async refreshCatalogAfterMutation(client: GatewayBrowserClient): Promise<void> {
     this.error = null;
-    await Promise.all([
-      this.catalogTask.run([client]),
-      this.configTask.run([client, this.context.runtimeConfig]),
-    ]);
+    await this.catalogTask.run([client]);
   }
 
   private pageError(): string | null {
@@ -721,6 +757,7 @@ class PluginsPage extends OpenClawLightDomElement {
     mutate: (client: GatewayBrowserClient) => Promise<Result>,
     onSuccess: (
       result: Result,
+      refreshError: string | null,
       client: GatewayBrowserClient,
       isCurrent: () => boolean,
     ) => Promise<void>,
@@ -741,11 +778,11 @@ class PluginsPage extends OpenClawLightDomElement {
     this.setBusy(rowKey, true);
     this.setMessage(rowKey, null);
     try {
-      const result = await mutate(client);
+      const mutation = await runPluginConfigMutation(this.context.runtimeConfig, client, mutate);
       if (!isCurrent()) {
         return;
       }
-      await onSuccess(result, client, isCurrent);
+      await onSuccess(mutation.value, mutation.refreshError, client, isCurrent);
     } catch (error) {
       if (isCurrent()) {
         onError(error);
@@ -762,13 +799,13 @@ class PluginsPage extends OpenClawLightDomElement {
     await this.runPluginMutation(
       rowKey,
       (client) => installPlugin(client, request),
-      async (result, client) => {
+      async (result, refreshError, client) => {
         this.applyMutationResult(result);
-        this.setMessage(rowKey, {
-          kind: "success",
-          text: mutationSuccessMessage("installed", result),
-        });
-        await this.refreshAfterMutation(client);
+        this.setMessage(
+          rowKey,
+          committedMutationMessage(mutationSuccessMessage("installed", result), refreshError),
+        );
+        await this.refreshCatalogAfterMutation(client);
       },
       (error) => {
         const trust = readPluginInstallTrustError(error);
@@ -797,16 +834,19 @@ class PluginsPage extends OpenClawLightDomElement {
     await this.runPluginMutation(
       key,
       (client) => setPluginEnabled(client, pluginId, enabled),
-      async (result, client, isCurrent) => {
+      async (result, refreshError, client, isCurrent) => {
         this.applyMutationResult(result);
-        this.setMessage(key, {
-          kind: "success",
-          text: mutationSuccessMessage(enabled ? "enabled" : "disabled", result),
-        });
+        this.setMessage(
+          key,
+          committedMutationMessage(
+            mutationSuccessMessage(enabled ? "enabled" : "disabled", result),
+            refreshError,
+          ),
+        );
         if (enabled) {
           this.pinEnabledPluginRoute(pluginId);
         }
-        await this.refreshAfterMutation(client);
+        await this.refreshCatalogAfterMutation(client);
         if (isCurrent() && !result.restartRequired) {
           // Plugin tabs come from hello; reconnect after the registry refresh.
           this.context.gateway.connect();
@@ -819,7 +859,7 @@ class PluginsPage extends OpenClawLightDomElement {
     await this.runPluginMutation(
       rowKey,
       (client) => uninstallPlugin(client, pluginId),
-      async (result, client) => {
+      async (result, refreshError, client) => {
         this.setPendingRemoval(rowKey, false);
         // Removal hides its row, so keep the restart reminder on the page.
         this.pageNotice = {
@@ -827,11 +867,12 @@ class PluginsPage extends OpenClawLightDomElement {
           text: [
             t("pluginsPage.removedRestart", { name: result.pluginId }),
             ...(result.warnings ?? []),
+            refreshError ? t("pluginsPage.configRefreshFailed", { error: refreshError }) : null,
           ]
             .filter(Boolean)
             .join("\n"),
         };
-        await this.refreshAfterMutation(client);
+        await this.refreshCatalogAfterMutation(client);
       },
     );
   }

--- a/ui/src/pages/plugins/plugins.e2e.test.ts
+++ b/ui/src/pages/plugins/plugins.e2e.test.ts
@@ -494,24 +494,26 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
         version: "1.2.3",
         acknowledgeClawHubRisk: true,
       });
-      const postInstallListRequest = await waitForNextRequest(
-        gateway,
-        "plugins.list",
-        listCountBeforeInstall,
-      );
+      // The mutation boundary refreshes config before the page refreshes the
+      // plugin catalog; release the deferred requests in that contract order.
       const postInstallConfigRequest = await waitForNextRequest(
         gateway,
         "config.get",
         configCountBeforeInstall,
       );
-      expect(requestParams(postInstallListRequest)).toEqual({});
       expect(requestParams(postInstallConfigRequest)).toEqual({});
+      await gateway.resolveDeferred("config.get", configSnapshot(false));
+      const postInstallListRequest = await waitForNextRequest(
+        gateway,
+        "plugins.list",
+        listCountBeforeInstall,
+      );
+      expect(requestParams(postInstallListRequest)).toEqual({});
       await expect.poll(() => searchRow.getAttribute("aria-busy")).toBe("true");
       expect(await searchRow.getByRole("status").textContent()).toContain(
         "A Gateway restart is required",
       );
       await gateway.resolveDeferred("plugins.list", installedInventory);
-      await gateway.resolveDeferred("config.get", configSnapshot(false));
       await expect.poll(() => searchRow.getAttribute("aria-busy")).toBe("false");
       // Installed search results swap Install for the enable/disable toggle.
       await page
@@ -535,22 +537,22 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
         enableCountBefore,
       );
       expect(requestParams(enableRequest)).toEqual({ pluginId: "workboard", enabled: true });
-      const postEnableListRequest = await waitForNextRequest(
-        gateway,
-        "plugins.list",
-        listCountBeforeEnable,
-      );
       const postEnableConfigRequest = await waitForNextRequest(
         gateway,
         "config.get",
         configCountBeforeEnable,
       );
-      expect(requestParams(postEnableListRequest)).toEqual({});
       expect(requestParams(postEnableConfigRequest)).toEqual({});
       await gateway.setMethodResponse("plugins.list", finalInventory);
       await gateway.setMethodResponse("config.get", configSnapshot(true));
-      await gateway.resolveDeferred("plugins.list", finalInventory);
       await gateway.resolveDeferred("config.get", configSnapshot(true));
+      const postEnableListRequest = await waitForNextRequest(
+        gateway,
+        "plugins.list",
+        listCountBeforeEnable,
+      );
+      expect(requestParams(postEnableListRequest)).toEqual({});
+      await gateway.resolveDeferred("plugins.list", finalInventory);
       await waitForNextRequest(gateway, "connect", connectCountBeforeEnable);
       await expect.poll(() => workboardCard.getAttribute("aria-busy")).toBe("false");
 
@@ -577,10 +579,20 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
         uninstallCountBefore,
       );
       expect(requestParams(uninstallRequest)).toEqual({ pluginId: "calendar-plus" });
-      await waitForNextRequest(gateway, "plugins.list", listCountBeforeRemove);
-      await waitForNextRequest(gateway, "config.get", configCountBeforeRemove);
-      await gateway.resolveDeferred("plugins.list", uninstalledInventory);
+      const postUninstallConfigRequest = await waitForNextRequest(
+        gateway,
+        "config.get",
+        configCountBeforeRemove,
+      );
+      expect(requestParams(postUninstallConfigRequest)).toEqual({});
       await gateway.resolveDeferred("config.get", configSnapshot(true));
+      const postUninstallListRequest = await waitForNextRequest(
+        gateway,
+        "plugins.list",
+        listCountBeforeRemove,
+      );
+      expect(requestParams(postUninstallListRequest)).toEqual({});
+      await gateway.resolveDeferred("plugins.list", uninstalledInventory);
       await calendarRow.waitFor({ state: "detached" });
       expect(await page.locator(".plugins-page-notice").textContent()).toContain(
         "Removed calendar-plus",


### PR DESCRIPTION
Foundation dependency https://github.com/openclaw/openclaw/pull/116029 landed on `main` as `9eee6181d7b9983b6d75f86b5a1b924bcf3b6965`. This consumer is rebased directly onto that exact commit.

## What Problem This Solves

Fixes an issue where plugin changes, agent identity saves, and one-shot model setup activation could race pending Settings writes, execute on a replacement Gateway connection, or be replayed after the server had already committed the operation.

## Why This Change Was Made

These settings-adjacent RPCs now use the shared external-mutation boundary landed by the foundation PR. Callers preserve committed success when authoritative refresh fails, show a warning instead of retrying, and retain the current plugin hub and routing behavior.

## User Impact

Plugin enable/install/uninstall, agent identity updates, and model activation complete once, refresh safely, and clearly report partial refresh failures without duplicating the mutation.

## Evidence

Rebased proof head: `3bd726e18cf37a7825f0d21dfdfd737379eadf85`

### Plugin enable flow

| Before enable | After enable |
| --- | --- |
| ![Workboard plugin before enable](https://artifacts.openclaw.ai/control-ui/settings-proof/pr-116031/96e0ea870426f5b76ff16351082acc7feb0c65db/00-before-enable.png) | ![Workboard plugin enabled with restart notice](https://artifacts.openclaw.ai/control-ui/settings-proof/pr-116031/96e0ea870426f5b76ff16351082acc7feb0c65db/01-after-enable.png) |

- The CI-exposed plugin catalog journey passed 10/10 focused repetitions and the full plugin E2E file passed 5/5.
- 60 focused tests passed across six files.
- Plugin mutation browser E2E passed 1/1 against the rebased head.
- Fresh screenshot bytes match the hosted proof assets above.
- Diff check, formatting, targeted lint, conflict-marker, max-lines, and dead-export guards passed.
- Fresh autoreview and TruffleHog were clean with no accepted or actionable findings.

Multi-step auth/prepare and channel setup wizards are intentionally excluded: their configuration commit happens after the start RPC and needs session-lifetime ownership rather than a one-shot barrier.

