### PR TITLE
fix(ui): recover memory and curated settings controls

### DIFF
--- a/ui/src/e2e/memory-settings-engine.e2e.test.ts
+++ b/ui/src/e2e/memory-settings-engine.e2e.test.ts
@@ -49,7 +49,8 @@ const memoryPlugins = [
   },
   {
     id: "memory-core",
-    name: "OpenClaw Memory",
+    // The UI owns this product label; catalog ids/names are implementation detail.
+    name: "memory-core",
     installed: true,
     enabled: true,
     state: "enabled",
@@ -137,6 +138,59 @@ describeControlUiE2e("Control UI memory engine settings mocked Gateway E2E", () 
           .screenshot({
             animations: "disabled",
             path: path.join(uiProofArtifactDir, "01-openclaw-memory-selected.png"),
+          });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps a missing default engine labelled, first, and selected as unavailable", async () => {
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "config.get": configResponse("memory-core", "memory-hash-missing-default"),
+        "plugins.list": {
+          plugins: memoryPlugins.filter((plugin) => plugin.id !== "memory-core"),
+          diagnostics: [],
+          mutationAllowed: true,
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/memory/settings`);
+      expect(response?.status()).toBe(200);
+
+      const engineGroup = page.locator("wa-radio-group.settings-segmented").first();
+      await engineGroup.waitFor();
+      await expect
+        .poll(async () =>
+          (await engineGroup.locator("wa-radio").allTextContents()).map((label) => label.trim()),
+        )
+        .toEqual(["OpenClaw Memory (Unavailable)", "Memory LanceDB", "Off"]);
+      await expect
+        .poll(() =>
+          engineGroup
+            .getByRole("radio", { name: "OpenClaw Memory (Unavailable)", exact: true })
+            .getAttribute("aria-checked"),
+        )
+        .toBe("true");
+
+      if (captureUiProofEnabled) {
+        await mkdir(uiProofArtifactDir, { recursive: true });
+        await page
+          .locator(".settings-page > .settings-section")
+          .first()
+          .screenshot({
+            animations: "disabled",
+            path: path.join(uiProofArtifactDir, "02-configured-engine-unavailable.png"),
           });
       }
     } finally {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2400,7 +2400,9 @@ export const en: TranslationMap = {
       description:
         "Exactly one memory plugin owns the memory slot. Selecting an engine enables it and disables the others.",
       rowTitle: "Memory engine",
+      openClawMemory: "OpenClaw Memory",
       off: "Off",
+      unavailable: "Unavailable",
       autoHint: "No engine is pinned in config, so the slot falls back to its default owner.",
       explicitHint: "This engine is pinned in config under plugins.slots.memory.",
       offHint: "Memory is switched off in config: plugins.slots.memory is set to none.",

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -242,7 +242,7 @@ describe("ConfigPage media discovery", () => {
 });
 
 describe("ConfigPage camera selection", () => {
-  it("clears recovered errors and ignores failures from superseded selections", async () => {
+  it("persists only confirmed camera selections and ignores superseded failures", async () => {
     let rejectFirst: (error: Error) => void = () => undefined;
     const first = new Promise<void>((_resolve, reject) => {
       rejectFirst = reject;
@@ -256,23 +256,32 @@ describe("ConfigPage camera selection", () => {
     const state = page as unknown as {
       cameraError: string | null;
       selectCamera: (deviceId: string) => Promise<void>;
-      applySettings: () => void;
+      applySettings: ReturnType<typeof vi.fn>;
     };
-    state.applySettings = () => undefined;
+    state.applySettings = vi.fn();
 
     await state.selectCamera("missing-camera");
     expect(state.cameraError).toBe("The selected camera is unavailable");
+    expect(state.applySettings).not.toHaveBeenCalled();
 
     const staleSelection = state.selectCamera("slow-camera");
     expect(state.cameraError).toBeNull();
     await state.selectCamera("back-camera");
+    expect(state.applySettings).toHaveBeenCalledOnce();
+    expect(state.applySettings).toHaveBeenLastCalledWith(
+      expect.objectContaining({ realtimeTalkVideoDeviceId: "back-camera" }),
+    );
     rejectFirst(new Error("The selected camera is unavailable"));
     await staleSelection;
     expect(state.cameraError).toBeNull();
+    expect(state.applySettings).toHaveBeenCalledOnce();
 
     state.cameraError = "Another camera error";
     await state.selectCamera("");
     expect(state.cameraError).toBeNull();
+    expect(state.applySettings).toHaveBeenLastCalledWith(
+      expect.objectContaining({ realtimeTalkVideoDeviceId: undefined }),
+    );
   });
 });
 
@@ -318,8 +327,11 @@ describe("ConfigPage session observer models", () => {
     expect(chatModels.loadModels).toHaveBeenCalledTimes(2);
   });
 
-  it("marks a failed client unavailable without polling it again", async () => {
-    vi.spyOn(chatModels, "loadModels").mockRejectedValue(new Error("catalog unavailable"));
+  it("retries a transient catalog failure on the next status refresh", async () => {
+    const recoveredModels = [{ id: "small", name: "Small", provider: "openai" }];
+    vi.spyOn(chatModels, "loadModels")
+      .mockRejectedValueOnce(new Error("catalog unavailable"))
+      .mockResolvedValueOnce(recoveredModels);
     const client = {} as GatewayBrowserClient;
     const gateway = {
       snapshot: { client, phase: "connected" },
@@ -337,11 +349,49 @@ describe("ConfigPage session observer models", () => {
     state.systemInfoGatewaySource = gateway;
 
     await state.ensureSessionObserverModels(client);
-    await state.ensureSessionObserverModels(client);
-
     expect(state.sessionObserverModels).toEqual([]);
     expect(state.sessionObserverModelsUnavailable).toBe(true);
-    expect(chatModels.loadModels).toHaveBeenCalledOnce();
+
+    await state.ensureSessionObserverModels(client);
+
+    expect(state.sessionObserverModels).toEqual(recoveredModels);
+    expect(state.sessionObserverModelsUnavailable).toBe(false);
+    expect(chatModels.loadModels).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("ConfigPage curated mutation eligibility", () => {
+  it.each([
+    ["offline", { connected: false }, ["operator.admin"], false],
+    ["read-only operator", { connected: true }, ["operator.read"], false],
+    ["config save", { connected: true, configSaving: true }, ["operator.admin"], false],
+    ["app update", { connected: true }, ["operator.admin"], true],
+    ["idle administrator", { connected: true }, ["operator.admin"], false],
+  ])("locks server-backed controls for %s", (_name, statePatch, scopes, updateRunning) => {
+    const page = new ConfigPage();
+    const state = page as unknown as {
+      context: ApplicationContext;
+      isCuratedConfigMutationDisabled: () => boolean;
+    };
+    state.context = {
+      runtimeConfig: {
+        state: {
+          configLoading: false,
+          configSaving: false,
+          configApplying: false,
+          ...statePatch,
+        },
+      },
+      gateway: {
+        snapshot: { hello: { auth: { role: "operator", scopes } } },
+      },
+      overlays: {
+        snapshot: { updateRunning, updateReconciliationPending: false },
+      },
+    } as unknown as ApplicationContext;
+
+    const expectedUnlocked = _name === "idle administrator";
+    expect(state.isCuratedConfigMutationDisabled()).toBe(!expectedUnlocked);
   });
 });
 

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -271,7 +271,6 @@ export class ConfigPage extends OpenClawLightDomElement {
   private systemInfoClient: GatewayBrowserClient | null = null;
   private sessionObserverModelsClient: GatewayBrowserClient | null = null;
   private readonly sessionObserverModelLoads = new WeakMap<GatewayBrowserClient, Promise<void>>();
-  private readonly sessionObserverModelFailures = new WeakSet<GatewayBrowserClient>();
   private readonly systemInfoPolling = new PollController(
     this,
     SESSION_OBSERVER_STATUS_POLL_INTERVAL_MS,
@@ -594,10 +593,7 @@ export class ConfigPage extends OpenClawLightDomElement {
   }
 
   private ensureSessionObserverModels(client: GatewayBrowserClient): Promise<void> {
-    if (
-      this.sessionObserverModelsClient === client ||
-      this.sessionObserverModelFailures.has(client)
-    ) {
+    if (this.sessionObserverModelsClient === client) {
       return Promise.resolve();
     }
     const existing = this.sessionObserverModelLoads.get(client);
@@ -618,7 +614,6 @@ export class ConfigPage extends OpenClawLightDomElement {
         }
       })
       .catch(() => {
-        this.sessionObserverModelFailures.add(client);
         if (
           this.isConnected &&
           this.systemInfoGatewaySource === gatewaySource &&
@@ -728,12 +723,17 @@ export class ConfigPage extends OpenClawLightDomElement {
     const request = ++this.cameraSelectionRequest;
     const videoDeviceId = deviceId.trim() || undefined;
     this.cameraError = null;
-    this.applySettings({
-      ...this.settings,
-      realtimeTalkVideoDeviceId: videoDeviceId,
-    });
     try {
       await switchActiveRealtimeTalkCameras(videoDeviceId);
+      if (request !== this.cameraSelectionRequest) {
+        return;
+      }
+      // Persist only a camera the active Talk session accepted. A superseded
+      // request must not overwrite the newer confirmed selection.
+      this.applySettings({
+        ...this.settings,
+        realtimeTalkVideoDeviceId: videoDeviceId,
+      });
     } catch (error) {
       if (request === this.cameraSelectionRequest) {
         this.cameraError = error instanceof Error ? error.message : String(error);
@@ -801,6 +801,18 @@ export class ConfigPage extends OpenClawLightDomElement {
   private isUpdateBusy(): boolean {
     const update = this.context.overlays.snapshot;
     return update.updateRunning || update.updateReconciliationPending;
+  }
+
+  private isCuratedConfigMutationDisabled(): boolean {
+    const runtimeState = this.context.runtimeConfig.state;
+    return (
+      !runtimeState.connected ||
+      runtimeState.configLoading ||
+      runtimeState.configSaving ||
+      runtimeState.configApplying ||
+      this.isUpdateBusy() ||
+      !hasOperatorAdminAccess(this.context.gateway.snapshot.hello?.auth ?? null)
+    );
   }
 
   private renderAdvancedConfig(configObject: Record<string, unknown>) {
@@ -995,6 +1007,7 @@ export class ConfigPage extends OpenClawLightDomElement {
     if (this.pageId === "memory") {
       return renderMemoryPage({
         configObject,
+        mutationDisabled: this.isCuratedConfigMutationDisabled(),
         pluginsHref: pathForRoute("plugins", this.context.basePath),
         memoryImportHref: pathForRoute("memory-import", this.context.basePath),
         routeData: this.routeData,
@@ -1013,6 +1026,7 @@ export class ConfigPage extends OpenClawLightDomElement {
     if (this.pageId === "talk") {
       return renderTalkPage({
         configObject,
+        mutationDisabled: this.isCuratedConfigMutationDisabled(),
         buildEditor: () =>
           renderConfig({
             ...props,
@@ -1026,11 +1040,7 @@ export class ConfigPage extends OpenClawLightDomElement {
     }
     if (this.pageId === "security") {
       const runtimeState = runtimeConfig.state;
-      const configBusy =
-        runtimeState.configLoading ||
-        runtimeState.configSaving ||
-        runtimeState.configApplying ||
-        this.isUpdateBusy();
+      const configBusy = this.isCuratedConfigMutationDisabled();
       return renderSecurity({
         security: extractQuickSettingsSecurity(configObject),
         configBusy,

--- a/ui/src/pages/config/memory-dreaming.test.ts
+++ b/ui/src/pages/config/memory-dreaming.test.ts
@@ -7,9 +7,10 @@ import { renderDreamingSettings } from "./memory-dreaming.ts";
 function renderInto(
   dreaming: Record<string, unknown> | null,
   onPatch: (path: readonly string[], value: unknown) => void = vi.fn(),
+  disabled = false,
 ): HTMLElement {
   const container = document.createElement("div");
-  render(renderDreamingSettings({ dreaming, onPatch }), container);
+  render(renderDreamingSettings({ dreaming, disabled, onPatch }), container);
   return container;
 }
 
@@ -81,6 +82,22 @@ describe("renderDreamingSettings", () => {
     expect(selectedSegment(renderInto({ storage: { mode: "both" } }))).toBe("both");
     // An unreadable stored value is not a fourth mode: it reads as the default.
     expect(selectedSegment(renderInto({ storage: { mode: "nonsense" } }))).toBe("separate");
+  });
+
+  it("locks every global dreaming control when config mutation is unavailable", () => {
+    const container = renderInto(null, vi.fn(), true);
+
+    expect(
+      [...container.querySelectorAll<HTMLInputElement>("input")].every((input) => input.disabled),
+    ).toBe(true);
+    expect(
+      [...container.querySelectorAll<HTMLElement & { disabled?: boolean }>("wa-switch")].every(
+        (toggle) => toggle.disabled === true,
+      ),
+    ).toBe(true);
+    expect(
+      container.querySelector<HTMLElement & { disabled?: boolean }>("wa-radio-group")?.disabled,
+    ).toBe(true);
   });
 });
 

--- a/ui/src/pages/config/memory-dreaming.ts
+++ b/ui/src/pages/config/memory-dreaming.ts
@@ -232,6 +232,7 @@ const DEFAULT_STORAGE_MODE: StorageMode = "separate";
 type DreamingSettingsProps = {
   /** `plugins.entries.<slot owner>.config.dreaming`, or null when unset. */
   dreaming: Record<string, unknown> | null;
+  disabled: boolean;
   onPatch: (path: readonly string[], value: unknown) => void;
 };
 
@@ -273,6 +274,7 @@ function renderField(props: DreamingSettingsProps, spec: DreamingFieldSpec) {
       title: t(spec.labelKey),
       description: t(spec.helpKey),
       checked: typeof value === "boolean" ? value : spec.fallback,
+      disabled: props.disabled,
       onChange: (checked) => props.onPatch(spec.path, checked),
     });
   }
@@ -297,6 +299,7 @@ function renderField(props: DreamingSettingsProps, spec: DreamingFieldSpec) {
         step=${bounds ? (bounds.integer ? "1" : "any") : nothing}
         spellcheck="false"
         aria-label=${t(spec.labelKey)}
+        ?disabled=${props.disabled}
         .value=${text}
         placeholder=${spec.kind === "text" && spec.placeholderKey ? t(spec.placeholderKey) : ""}
         @change=${(event: Event) => {
@@ -352,6 +355,7 @@ export function renderDreamingSettings(props: DreamingSettingsProps): TemplateRe
               label: t(`memoryPage.dreaming.storage.modes.${mode}`),
             })),
             ariaLabel: t("memoryPage.dreaming.storage.modeLabel"),
+            disabled: props.disabled,
             onChange: (mode) => props.onPatch(["storage", "mode"], mode),
           }),
         })}

--- a/ui/src/pages/config/memory-page.test.ts
+++ b/ui/src/pages/config/memory-page.test.ts
@@ -289,7 +289,7 @@ describe("MemorySettingsPage engine slot", () => {
       configObject: {},
       catalog: [
         engine("memory-lancedb", true, "Memory LanceDB"),
-        engine("memory-core", false, "OpenClaw Memory"),
+        engine("memory-core", false, "memory-core"),
       ],
     });
     document.body.append(element);
@@ -542,6 +542,10 @@ describe("MemorySettingsPage catalog state", () => {
       expect(addonStatus(element, "Memory wiki")).toBe("Disabled");
       expect(addonSwitch(element, "Active memory")).toBeNull();
       expect(addonSwitch(element, "Memory wiki")).toBeNull();
+      const engineGroup = element.querySelector<HTMLElement & { disabled?: boolean }>(
+        "wa-radio-group.settings-segmented",
+      );
+      expect(engineGroup?.disabled).toBe(true);
     } finally {
       element.remove();
     }

--- a/ui/src/pages/config/memory-page.ts
+++ b/ui/src/pages/config/memory-page.ts
@@ -81,6 +81,7 @@ type MemoryAddonNotice = {
 
 type MemoryPageProps = {
   configObject: Record<string, unknown>;
+  mutationDisabled: boolean;
   pluginsHref: string;
   memoryImportHref: string;
   routeData: ConfigRouteData | null;
@@ -117,6 +118,7 @@ class MemorySettingsPage extends OpenClawLightDomElement {
   private context!: ApplicationContext;
 
   @property({ attribute: false }) configObject: Record<string, unknown> = {};
+  @property({ type: Boolean }) mutationDisabled = false;
   @property() pluginsHref = "";
   @property() memoryImportHref = "";
   @property({ attribute: false }) routeData: ConfigRouteData | null = null;
@@ -408,9 +410,16 @@ class MemorySettingsPage extends OpenClawLightDomElement {
     if (this.catalog.kind !== "ready") {
       return [];
     }
-    return this.catalog.plugins
+    const options = this.catalog.plugins
       .filter(isMemoryEngine)
-      .map((plugin) => ({ id: plugin.id, label: plugin.name }))
+      .map((plugin) => ({
+        id: plugin.id,
+        label:
+          plugin.id === DEFAULT_MEMORY_ENGINE_ID
+            ? t("memoryPage.engine.openClawMemory")
+            : plugin.name,
+        available: true,
+      }))
       .toSorted((left, right) => {
         const leftIsDefault = left.id === DEFAULT_MEMORY_ENGINE_ID;
         const rightIsDefault = right.id === DEFAULT_MEMORY_ENGINE_ID;
@@ -419,6 +428,21 @@ class MemorySettingsPage extends OpenClawLightDomElement {
         }
         return left.label.localeCompare(right.label);
       });
+    const selected = selectedEngineId(resolveMemoryEngineSelection(this.configObject));
+    if (selected && !options.some((option) => option.id === selected)) {
+      const unavailable = {
+        id: selected,
+        label:
+          selected === DEFAULT_MEMORY_ENGINE_ID ? t("memoryPage.engine.openClawMemory") : selected,
+        available: false,
+      };
+      if (selected === DEFAULT_MEMORY_ENGINE_ID) {
+        options.unshift(unavailable);
+      } else {
+        options.push(unavailable);
+      }
+    }
+    return options;
   }
 
   private engineState(selection: MemoryEngineSelection): MemoryPluginState {
@@ -456,6 +480,7 @@ class MemorySettingsPage extends OpenClawLightDomElement {
   private async changeAddon(pluginId: string, enabled: boolean) {
     if (
       this.addonBusy.has(pluginId) ||
+      this.mutationDisabled ||
       this.catalog.kind !== "ready" ||
       !this.catalog.mutationAllowed ||
       !readGatewayOperatorAccess(this.context.gateway.snapshot).canAdmin
@@ -516,7 +541,11 @@ class MemorySettingsPage extends OpenClawLightDomElement {
   }
 
   private async changeEngine(engineId: string | null, currentSelection: MemoryEngineSelection) {
-    if (this.engineBusy) {
+    if (
+      this.engineBusy ||
+      this.mutationDisabled ||
+      (this.catalog.kind === "ready" && !this.catalog.mutationAllowed)
+    ) {
       return;
     }
     if (engineId === selectedEngineId(currentSelection)) {
@@ -592,6 +621,9 @@ class MemorySettingsPage extends OpenClawLightDomElement {
   }
 
   private patchDreaming(path: readonly string[], value: unknown) {
+    if (this.mutationDisabled) {
+      return;
+    }
     const runtimeConfig = this.context.runtimeConfig;
     const writePath = [
       "plugins",
@@ -619,6 +651,7 @@ class MemorySettingsPage extends OpenClawLightDomElement {
         ? renderDreamingUnsupported(pluginId)
         : renderDreamingSettings({
             dreaming: this.dreamingConfig(),
+            disabled: this.mutationDisabled,
             onPatch: (path, value) => this.patchDreaming(path, value),
           })}
     `;
@@ -633,6 +666,8 @@ class MemorySettingsPage extends OpenClawLightDomElement {
   override render() {
     const runtimeConfig = this.context.runtimeConfig;
     const engineSelection = resolveMemoryEngineSelection(this.configObject);
+    const engineMutationDisabled =
+      this.mutationDisabled || (this.catalog.kind === "ready" && !this.catalog.mutationAllowed);
     const backend = resolveMemoryBackend(this.configObject);
     const activeTab = this.activeTab();
     const agentId = this.resolveAgentId();
@@ -643,16 +678,21 @@ class MemorySettingsPage extends OpenClawLightDomElement {
       engineOptions: this.engineOptions(),
       engineSelection,
       engineState: this.engineState(engineSelection),
-      engineBusy: this.engineBusy,
+      engineBusy: this.engineBusy || engineMutationDisabled,
       engineError: this.engineError,
       onEngineChange: (nextEngineId) => void this.changeEngine(nextEngineId, engineSelection),
       backend,
-      backendBusy: runtimeConfig.state.configSaving || runtimeConfig.state.configApplying,
-      onBackendChange: (next) => runtimeConfig.patchForm(["memory", "backend"], next),
+      backendBusy: this.mutationDisabled,
+      onBackendChange: (next) => {
+        if (!this.mutationDisabled) {
+          runtimeConfig.patchForm(["memory", "backend"], next);
+        }
+      },
       addons: this.addonRows(),
       canToggleAddons:
         this.catalog.kind === "ready" &&
         this.catalog.mutationAllowed &&
+        !this.mutationDisabled &&
         readGatewayOperatorAccess(this.context.gateway.snapshot).canAdmin,
       onAddonChange: (pluginId, enabled) => void this.changeAddon(pluginId, enabled),
       pluginsHref: this.pluginsHref,
@@ -700,6 +740,7 @@ export function renderMemoryPage(props: MemoryPageProps) {
   return html`
     <openclaw-memory-settings
       .configObject=${props.configObject}
+      .mutationDisabled=${props.mutationDisabled}
       .pluginsHref=${props.pluginsHref}
       .memoryImportHref=${props.memoryImportHref}
       .routeData=${props.routeData}

--- a/ui/src/pages/config/memory.test.ts
+++ b/ui/src/pages/config/memory.test.ts
@@ -20,8 +20,8 @@ function createProps(overrides: Partial<MemoryViewProps> = {}): MemoryViewProps 
     activeTab: "settings",
     onTabChange: vi.fn(),
     engineOptions: [
-      { id: "memory-core", label: "OpenClaw Memory" },
-      { id: "memory-lancedb", label: "Memory LanceDB" },
+      { id: "memory-core", label: "OpenClaw Memory", available: true },
+      { id: "memory-lancedb", label: "Memory LanceDB", available: true },
     ],
     engineSelection: { kind: "auto", engineId: "memory-core" },
     engineState: "enabled",
@@ -130,6 +130,28 @@ describe("renderMemory", () => {
       createProps({ engineSelection: { kind: "pinned", engineId: "memory-core" } }),
     );
     expect(pinned.textContent).toContain("pinned in config");
+  });
+
+  it("keeps a configured missing engine selected and labels it unavailable", () => {
+    const container = renderInto(
+      createProps({
+        engineOptions: [{ id: "retired-memory", label: "retired-memory", available: false }],
+        engineSelection: { kind: "pinned", engineId: "retired-memory" },
+        engineState: "unknown",
+      }),
+    );
+
+    expect(
+      container
+        .querySelector('wa-radio[value="retired-memory"]')
+        ?.textContent?.replace(/\s+/g, " ")
+        .trim(),
+    ).toBe("retired-memory (Unavailable)");
+    expect(
+      container
+        .querySelector('wa-radio[value="retired-memory"]')
+        ?.classList.contains("settings-segmented__btn--active"),
+    ).toBe(true);
   });
 
   it("surfaces a failed engine write next to the control", () => {

--- a/ui/src/pages/config/memory.ts
+++ b/ui/src/pages/config/memory.ts
@@ -25,6 +25,8 @@ import {
 export type MemoryEngineOption = {
   id: string;
   label: string;
+  /** False when config names an engine absent from the current plugin catalog. */
+  available: boolean;
 };
 
 /**
@@ -119,7 +121,12 @@ function renderEngineSection(props: MemoryViewProps) {
     );
   }
   const options = [
-    ...props.engineOptions.map((option) => ({ value: option.id, label: option.label })),
+    ...props.engineOptions.map((option) => ({
+      value: option.id,
+      label: option.available
+        ? option.label
+        : `${option.label} (${t("memoryPage.engine.unavailable")})`,
+    })),
     { value: MEMORY_ENGINE_OFF, label: t("memoryPage.engine.off") },
   ];
   return renderSettingsSection(

--- a/ui/src/pages/config/talk-page.ts
+++ b/ui/src/pages/config/talk-page.ts
@@ -31,6 +31,7 @@ type CatalogConnection = {
 
 type TalkPageProps = {
   configObject: Record<string, unknown>;
+  mutationDisabled: boolean;
   /** Builds the embedded schema editor over the full `talk` section. */
   buildEditor: () => TemplateResult;
 };
@@ -58,6 +59,7 @@ class TalkSettingsPage extends OpenClawLightDomElement {
   private context!: ApplicationContext;
 
   @property({ attribute: false }) configObject: Record<string, unknown> = {};
+  @property({ type: Boolean }) mutationDisabled = false;
   @property({ attribute: false }) buildEditor: TalkPageProps["buildEditor"] = () => html``;
 
   @state() private catalog: TalkCatalogState = { kind: "unavailable" };
@@ -188,6 +190,9 @@ class TalkSettingsPage extends OpenClawLightDomElement {
    * the top-level key would make Default a no-op over provider-level config.
    */
   private changeModel(model: string | null) {
+    if (this.mutationDisabled) {
+      return;
+    }
     const runtimeConfig = this.context.runtimeConfig;
     if (model !== null) {
       runtimeConfig.patchForm(["talk", "realtime", "model"], model);
@@ -207,6 +212,9 @@ class TalkSettingsPage extends OpenClawLightDomElement {
   }
 
   private changeVoice(voice: string | null) {
+    if (this.mutationDisabled) {
+      return;
+    }
     const runtimeConfig = this.context.runtimeConfig;
     if (voice !== null) {
       runtimeConfig.patchForm(["talk", "realtime", "speakerVoice"], voice);
@@ -246,6 +254,9 @@ class TalkSettingsPage extends OpenClawLightDomElement {
    * supplies that provider's fallback values.
    */
   private changeProvider(providerId: string | null) {
+    if (this.mutationDisabled) {
+      return;
+    }
     const runtimeConfig = this.context.runtimeConfig;
     for (const key of ["model", "speakerVoice", "speakerVoiceId"]) {
       runtimeConfig.removeFormValue(["talk", "realtime", key]);
@@ -281,7 +292,10 @@ class TalkSettingsPage extends OpenClawLightDomElement {
       selection: resolveTalkRealtimeSelection(this.configObject),
       catalog: this.catalog,
       configBusy:
-        runtimeState.configLoading || runtimeState.configSaving || runtimeState.configApplying,
+        this.mutationDisabled ||
+        runtimeState.configLoading ||
+        runtimeState.configSaving ||
+        runtimeState.configApplying,
       onProviderChange: (providerId) => this.changeProvider(providerId),
       onModelChange: (model) => this.changeModel(model),
       onVoiceChange: (voice) => this.changeVoice(voice),
@@ -298,6 +312,7 @@ export function renderTalkPage(props: TalkPageProps) {
   return html`
     <openclaw-talk-settings
       .configObject=${props.configObject}
+      .mutationDisabled=${props.mutationDisabled}
       .buildEditor=${props.buildEditor}
     ></openclaw-talk-settings>
   `;

--- a/ui/src/pages/config/talk.test.ts
+++ b/ui/src/pages/config/talk.test.ts
@@ -1,0 +1,56 @@
+/* @vitest-environment jsdom */
+
+import { html, render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import { renderTalk } from "./talk.ts";
+
+describe("renderTalk", () => {
+  it("locks every curated picker when config mutation is unavailable", () => {
+    const container = document.createElement("div");
+    render(
+      renderTalk({
+        selection: {
+          provider: "openai",
+          model: "gpt-live",
+          speakerVoice: "marin",
+          transport: "webrtc",
+          providerEntries: {},
+        },
+        catalog: {
+          kind: "ready",
+          ready: true,
+          activeProvider: "openai",
+          providers: [
+            {
+              id: "openai",
+              label: "OpenAI",
+              configured: true,
+              aliases: [],
+              models: ["gpt-live"],
+              voices: ["marin"],
+              transports: ["webrtc"],
+              defaultModel: "gpt-live",
+            },
+          ],
+        },
+        configBusy: true,
+        onProviderChange: vi.fn(),
+        onModelChange: vi.fn(),
+        onVoiceChange: vi.fn(),
+        editor: html``,
+      }),
+      container,
+    );
+
+    const provider = container.querySelector<HTMLElement & { disabled?: boolean }>(
+      "wa-radio-group",
+    );
+    expect(provider?.disabled).toBe(true);
+    expect([...container.querySelectorAll<HTMLSelectElement>("select")]).toHaveLength(2);
+    expect(
+      [...container.querySelectorAll<HTMLSelectElement>("select")].every(
+        (select) => select.disabled,
+      ),
+    ).toBe(true);
+  });
+});

--- a/ui/src/pages/config/view-appearance.ts
+++ b/ui/src/pages/config/view-appearance.ts
@@ -151,6 +151,7 @@ export function renderAppearanceSection(
                     props.theme
                       ? "settings-theme-card--active"
                       : ""}"
+                    aria-pressed=${String(opt.id === props.theme)}
                     title=${opt.description}
                     @click=${(e: Event) => {
                       if (opt.id === "custom" && !props.hasCustomTheme) {
@@ -267,6 +268,7 @@ export function renderAppearanceSection(
                     <button
                       type="button"
                       class="settings-text-scale__btn ${stop === props.textScale ? "active" : ""}"
+                      aria-pressed=${String(stop === props.textScale)}
                       @click=${() => props.setTextScale(stop)}
                     >
                       <span class="settings-text-scale__sample">${t(TEXT_SCALE_LABELS[stop])}</span>

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -1376,6 +1376,31 @@ describe("config view", () => {
     expect(onOpenCustomThemeImport).toHaveBeenCalledTimes(1);
   });
 
+  it("exposes theme and text-size selection to assistive technology", () => {
+    const { container } = renderConfigView({
+      activeSection: "__appearance__",
+      includeSections: ["__appearance__"],
+      theme: "knot",
+      textScale: 110,
+    });
+
+    expect(findButtonByText(container, "Knot").getAttribute("aria-pressed")).toBe("true");
+    expect(findButtonByText(container, "Claw").getAttribute("aria-pressed")).toBe("false");
+    const textScaleButtons = [
+      ...container.querySelectorAll<HTMLButtonElement>(".settings-text-scale__btn"),
+    ];
+    expect(
+      textScaleButtons
+        .find((button) => button.textContent?.includes("110%"))
+        ?.getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      textScaleButtons
+        .find((button) => button.textContent?.includes("100%"))
+        ?.getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
   it("shows the tweakcn importer once the custom slot is opened", () => {
     const { container } = renderConfigView({
       activeSection: "__appearance__",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Memory and other curated Settings controls could show unstable plugin IDs, lose configured-but-unavailable choices, cache transient load failures, persist unconfirmed selections, or remain interactive while permissions, updates, or pending writes made mutation unsafe.

## Why This Change Was Made

Curated settings now keep stable product labels and ordering, preserve unavailable configured engines, retry transient observer catalogs, persist only confirmed camera choices, and share consistent authorization/busy gating across Memory, Talk, Security, and Appearance.

## User Impact

OpenClaw Memory is labelled correctly and appears first, missing configured engines remain visible for recovery, and curated controls accurately reflect when changes can be made.

## Evidence

### Memory label, order, and unavailable recovery

| Before | Fixed default | Configured engine unavailable |
| --- | --- | --- |
| ![Memory engine catalog label before the fix](https://artifacts.openclaw.ai/control-ui/settings-proof/pr-116032/96e0ea870426f5b76ff16351082acc7feb0c65db/00-before-memory-core-catalog-label.png) | ![OpenClaw Memory is leftmost and selected by default](https://artifacts.openclaw.ai/control-ui/settings-proof/pr-116032/96e0ea870426f5b76ff16351082acc7feb0c65db/01-openclaw-memory-selected.png) | ![Unavailable configured memory engine is shown without breaking settings](https://artifacts.openclaw.ai/control-ui/settings-proof/pr-116032/96e0ea870426f5b76ff16351082acc7feb0c65db/02-configured-engine-unavailable.png) |

- 148 focused tests passed.
- Memory browser E2E passed 2/2.
- Frozen-base changed gate passed all guards, formatting, deadcode, i18n, core/UI typechecks, and lint.
- Fresh autoreview and TruffleHog were clean.
