### PR TITLE
fix(memory): return early for blank searches

### DIFF
--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1112,6 +1112,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   async search(query: string, opts?: MemoryIndexSearchOptions): Promise<MemorySearchResult[]> {
+    const normalizedQuery = query.trim();
+    if (!normalizedQuery) {
+      return [];
+    }
     const maxResults = opts?.maxResults ?? this.settings.query.maxResults;
     const minScore = opts?.minScore ?? this.settings.query.minScore;
     const hasActiveProject = (opts?.activeProjectKeys?.length ?? 0) > 0;
@@ -1119,7 +1123,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       ? Math.min(200, Math.max(maxResults, maxResults * 4))
       : maxResults;
     const candidateMinScore = hasActiveProject ? minScore / 1.15 : minScore;
-    const results = await this.searchUnranked(query, {
+    const results = await this.searchUnranked(normalizedQuery, {
       ...opts,
       maxResults: candidateMaxResults,
       minScore: candidateMinScore,
@@ -1131,15 +1135,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private async searchUnranked(
-    query: string,
+    normalizedQuery: string,
     opts?: MemoryIndexSearchOptions,
   ): Promise<MemorySearchResult[]> {
     return await this.withManagerOperation(async () => {
       opts?.onDebug?.({ backend: "builtin" });
-      const normalizedQuery = query.trim();
-      if (!normalizedQuery) {
-        return [];
-      }
       if (this.providerRequirement.mode === "required") {
         await this.ensureProviderInitialized();
         this.assertRequiredProviderAvailable("search");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where whitespace-only memory searches could throw while reading query settings before the existing blank-query fast path, especially for partially initialized managers.

## Why This Change Was Made

Normalizes and rejects blank input at the public `search()` boundary before reading settings or starting provider/index work, then passes the normalized query through the sole private search path. Nonblank searches retain the same settings, project-ranking, provider, index, and result-filtering behavior.

## User Impact

Blank memory searches now return an empty result instead of crashing or doing unnecessary initialization. Nonblank search behavior is unchanged.

## Evidence

- Full-suite Testbox discovery exposed the blank-query `TypeError` at `this.settings.query`: https://github.com/openclaw/openclaw/actions/runs/30464029744
- Final exact-head focused memory test passed 7/7 after the review update and rebase onto current `main`: https://github.com/openclaw/openclaw/actions/runs/30480717317
- Earlier focused memory test also passed 7/7: https://github.com/openclaw/openclaw/actions/runs/30477627780
- Changed gate passed formatting, env ratchets, Knip scans, plugin boundaries, extension typechecks, lint, database-first guards, and import-cycle checks with the same memory diff: https://github.com/openclaw/openclaw/actions/runs/30479160839
- Fresh final branch autoreview: no actionable findings, confidence 0.96
- `git diff --check` and `OPENCLAW_* count 518/518`: passed