### PR TITLE
fix(skills): run experience review outside released request roots

### DIFF
--- a/src/skills/workshop/experience-review-auto-apply.test.ts
+++ b/src/skills/workshop/experience-review-auto-apply.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSkillWorkshopTool } from "../../agents/tools/skill-workshop-tool.js";
 import {
+  isGatewaySubordinateWorkAdmissionClosed,
+  tryBeginGatewayRootWorkAdmission,
+} from "../../process/gateway-work-admission.js";
+import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
@@ -85,6 +89,43 @@ describe("experience review auto apply", () => {
         toolsAllow: ["skill_workshop"],
       }),
     );
+  });
+
+  it("re-enters gateway admission when fired from a released request root", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-experience-admission-workspace-");
+    let subordinateClosedInsideRun: boolean | undefined;
+    runEmbeddedAgent.mockImplementation(async () => {
+      subordinateClosedInsideRun = isGatewaySubordinateWorkAdmissionClosed();
+      return {};
+    });
+    const candidate: ExperienceReviewCandidate = {
+      ctx: {
+        agentId: "main",
+        runId: "foreground-run",
+        sessionKey: "agent:main:main",
+        workspaceDir,
+        modelProviderId: "openai",
+        modelId: "gpt-test",
+      },
+      config: { skills: { workshop: { autonomous: { mode: "propose" } } } },
+      transcript: "[user]\nRecover the deployment workflow.",
+      modelIterations: 10,
+    };
+
+    // The scheduler's idle timer inherits the foreground run's root-work ALS
+    // context, which is already released when the timer fires. The review must
+    // re-enter admission instead of being refused as GatewayDrainingError.
+    const admission = tryBeginGatewayRootWorkAdmission();
+    expect(admission).not.toBeNull();
+    await admission?.run(async () => {
+      admission.release();
+      await runSkillExperienceReview(candidate, {
+        getCurrentConfig: () => candidate.config ?? {},
+      });
+    });
+
+    expect(runEmbeddedAgent).toHaveBeenCalledTimes(1);
+    expect(subordinateClosedInsideRun).toBe(false);
   });
 
   it("leaves the capture pending when auto mode is disabled during review", async () => {

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -3,6 +3,7 @@ import { SessionManager } from "../../agents/sessions/index.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { runWithGatewayIndependentRootWorkAdmission } from "../../process/gateway-work-admission.js";
 import { CommandLane } from "../../process/lanes.js";
 import { autoApplySkillProposal } from "./auto-apply.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
@@ -319,16 +320,19 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
         arm(sessionKey, existing, EXPERIENCE_REVIEW_IDLE_MS);
       }
       if (errored) {
+        log.debug(`experience review skipped: reason=errored-completion session=${sessionKey}`);
         return;
       }
       if (resolveSkillWorkshopConfig(params.config).autonomous.mode === "off") {
         return;
       }
       if (!isEligibleContext(params.ctx)) {
+        log.debug(`experience review skipped: reason=ineligible-context session=${sessionKey}`);
         return;
       }
       const workspaceDir = params.ctx.workspaceDir?.trim();
       if (!workspaceDir) {
+        log.debug(`experience review skipped: reason=missing-workspace session=${sessionKey}`);
         return;
       }
 
@@ -391,6 +395,13 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
         pending.candidate = candidate;
         pendingBySession.set(sessionKey, pending);
         arm(sessionKey, pending, EXPERIENCE_REVIEW_IDLE_MS);
+        log.debug(
+          `experience review scheduled: session=${sessionKey} iterations=${modelIterations} aborted=${!params.event.success}`,
+        );
+      } else {
+        log.debug(
+          `experience review skipped: reason=below-depth-bar iterations=${modelIterations} session=${sessionKey}`,
+        );
       }
     },
     clear(): void {
@@ -407,6 +418,20 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
 export async function runSkillExperienceReview(
   candidate: ExperienceReviewCandidate,
   deps: ExperienceReviewRunDeps = {},
+): Promise<void> {
+  // The idle timer that fires this review was armed inside the foreground
+  // run's root-work ALS context. By fire time that root is released, so any
+  // inherited-context lane enqueue is refused as GatewayDrainingError on a
+  // healthy gateway. Re-enter admission as independent root work; real
+  // restart drain still refuses it.
+  await runWithGatewayIndependentRootWorkAdmission(() =>
+    runSkillExperienceReviewInner(candidate, deps),
+  );
+}
+
+async function runSkillExperienceReviewInner(
+  candidate: ExperienceReviewCandidate,
+  deps: ExperienceReviewRunDeps,
 ): Promise<void> {
   const workspaceDir = candidate.ctx.workspaceDir;
   const sessionKey = candidate.ctx.sessionKey;


### PR DESCRIPTION
## What Problem This Solves

On a real gateway, the autonomous experience review never ran: every delayed review died with `GatewayDrainingError: Gateway is draining; new tasks are not accepted` on a healthy, running gateway, and the candidate was silently dropped (one WARN line, no retry). Self-learning's background review + auto-apply (#115576, #115887) was effectively non-functional in production.

## Why This Change Was Made

The scheduler arms its idle timer inside the foreground run's agent-end side effects, which execute within the RPC's root-work admission `AsyncLocalStorage` context. Timer callbacks inherit that ALS context. By the time the 30s quiet timer fires, the request root is released, so `isGatewaySubordinateWorkAdmissionClosed()` returns `current.released === true` and the review's lane enqueue is refused. Unit tests inject `runReview`, and the vitest live eval calls `runSkillExperienceReview` directly with no ALS ancestor — both bypass the failing admission path, which is why this only surfaced under a real gateway.

The fix re-enters admission as independent root work (`runWithGatewayIndependentRootWorkAdmission`) around the review run — the documented seam for detached follow-up work. A genuine restart drain still refuses the review. Also adds debug-level `experience review scheduled/skipped(reason)` logging, which this investigation sorely missed.

## User Impact

Self-learning experience reviews (and `auto`-mode applies) now actually run on live gateways. No config changes.

## Evidence

- Live repro on a scratch dev gateway (worktree build, native `openai/gpt-5.6-luna` runtime, real OpenAI key): before the fix, a 10+ iteration turn produced `skill experience review failed: GatewayDrainingError` ~60s after turn end, zero proposals. After the fix: three consecutive deep turns (sessions stress-s2/s3/s4) each produced a review, a pending proposal, and an `auto`-mode apply (`skill_workshop_proposals` rows `applied`, skills on disk), with zero review failures in the gateway log.
- Regression test: `experience-review-auto-apply.test.ts` "re-enters gateway admission when fired from a released request root" — schedules the review from a released root-work ALS context and asserts `isGatewaySubordinateWorkAdmissionClosed()` is `false` inside the run (fails with `GatewayDrainingError` before the fix).
- `node scripts/run-vitest.mjs src/skills/workshop/experience-review.test.ts src/skills/workshop/experience-review-auto-apply.test.ts` — 23 passed, on top of #115950.
- `node scripts/check-changed.mjs` green locally (Blacksmith backend unreachable; documented trusted-source fallback) except a max-lines ratchet drift that resolved itself after rebasing onto latest `main`.
- Autoreview (Codex `gpt-5.6-sol`): clean, no findings (0.94).

Live stress testing also surfaced two adjacent defects tracked separately: user aborts unwind the embedded run with a raw `AbortError` before any agent-end side effects (starving interrupted-turn review, autocapture, and plugin hooks), and terminal sessions from agent exec calls outlive their runs until the 24-session cap breaks exec gateway-wide.
