### PR TITLE
fix(codex): accept exact finalizer prompt echo

### DIFF
--- a/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
@@ -250,6 +250,70 @@ describe("runCodexSettledTurnFinalization", () => {
     },
   );
 
+  it("accepts the exact current-turn prompt echo once", async () => {
+    const attempt = createAttempt();
+    mocks.runBounded.mockResolvedValue({
+      text: "The update was sent successfully.",
+      items: [
+        {
+          id: "prompt-echo",
+          type: "userMessage",
+          content: [{ type: "text", text: attempt.prompt, text_elements: [] }],
+        },
+        { id: "answer", type: "agentMessage", text: "The update was sent successfully." },
+      ],
+      model: "gpt-5.4",
+    });
+
+    await expect(
+      runCodexSettledTurnFinalization({ attempt, settledAttempt: createSettledAttempt() }, {}),
+    ).resolves.toMatchObject({ assistantTranscriptOwned: true });
+    expect(mocks.mirror).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a mismatched current-turn prompt echo before transcript mutation", async () => {
+    mocks.runBounded.mockResolvedValue({
+      text: "The update was sent successfully.",
+      items: [
+        {
+          id: "prompt-echo",
+          type: "userMessage",
+          content: [{ type: "text", text: "A different prompt.", text_elements: [] }],
+        },
+      ],
+      model: "gpt-5.4",
+    });
+
+    await expect(
+      runCodexSettledTurnFinalization(
+        { attempt: createAttempt(), settledAttempt: createSettledAttempt() },
+        {},
+      ),
+    ).rejects.toThrow("unexpected native item: userMessage");
+    expect(mocks.mirror).not.toHaveBeenCalled();
+  });
+
+  it("rejects a duplicate current-turn prompt echo before transcript mutation", async () => {
+    const attempt = createAttempt();
+    const promptEcho = {
+      type: "userMessage",
+      content: [{ type: "text", text: attempt.prompt, text_elements: [] }],
+    };
+    mocks.runBounded.mockResolvedValue({
+      text: "The update was sent successfully.",
+      items: [
+        { id: "prompt-echo-1", ...promptEcho },
+        { id: "prompt-echo-2", ...promptEcho },
+      ],
+      model: "gpt-5.4",
+    });
+
+    await expect(
+      runCodexSettledTurnFinalization({ attempt, settledAttempt: createSettledAttempt() }, {}),
+    ).rejects.toThrow("unexpected native item: userMessage");
+    expect(mocks.mirror).not.toHaveBeenCalled();
+  });
+
   it("rejects a missing frozen context before starting the isolated turn", async () => {
     const settledAttempt = createSettledAttempt();
     delete settledAttempt.settledTurnFinalizationContext;

--- a/extensions/codex/src/app-server/settled-turn-finalizer.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.ts
@@ -5,6 +5,7 @@ import type {
 import { isSilentReplyText } from "openclaw/plugin-sdk/reply-runtime";
 import { runBoundedCodexAppServerTurn, type CodexBoundedTurnOptions } from "./bounded-turn.js";
 import { createAssistantMessage } from "./event-projector-assistant-message.js";
+import { isJsonObject, type CodexThreadItem } from "./protocol.js";
 import { projectSettledCodexMessages } from "./settled-turn-projection.js";
 import {
   fingerprintCodexMirrorSourceMessage,
@@ -50,7 +51,28 @@ export async function runCodexSettledTurnFinalization(
     historyItems,
     requireNoExternalCapabilities: true,
   });
-  const unexpectedItem = bounded.items.find((item) => !FINALIZER_PASSIVE_ITEM_TYPES.has(item.type));
+  let promptEchoSeen = false;
+  let unexpectedItem: CodexThreadItem | undefined;
+  for (const item of bounded.items) {
+    if (FINALIZER_PASSIVE_ITEM_TYPES.has(item.type)) {
+      continue;
+    }
+    if (item.type === "userMessage" && !promptEchoSeen) {
+      const content = Array.isArray(item.content) ? item.content : [];
+      const input = content[0];
+      const isPromptEcho =
+        content.length === 1 &&
+        isJsonObject(input) &&
+        input.type === "text" &&
+        input.text === attempt.prompt;
+      if (isPromptEcho) {
+        promptEchoSeen = true;
+        continue;
+      }
+    }
+    unexpectedItem = item;
+    break;
+  }
   if (unexpectedItem) {
     throw new Error(
       `Codex settled-turn finalization returned unexpected native item: ${unexpectedItem.type}`,


### PR DESCRIPTION
Related: #110565

AI-assisted: implemented and reviewed with Codex. I understand the change and verified it against a real Codex app-server turn.

## What Problem This Solves

Fixes an issue where users could miss the final acknowledgment after a successful non-replay-safe tool call. When the isolated finalization turn echoed OpenClaw's own prompt as a `userMessage`, the finalizer rejected that protocol-owned item and stopped before mirroring the generated final reply.

## Why This Change Was Made

The finalizer now accepts exactly one `userMessage` only when it contains one text input equal to the prompt OpenClaw injected for that private turn. Mismatched or duplicate user messages, command execution, MCP calls, compaction, and unknown future items still fail closed before transcript mutation.

No provider behavior, tool access, configuration, schema, or public API changes.

## User Impact

Users can receive the missing final acknowledgment after a settled tool-only turn without replaying the completed side effect. The capability-free finalization boundary remains fail-closed.

The Codex extension uses privileged keyed state, so production adoption of this fix requires an official trusted `@openclaw/codex` catalog publication or bundled release. A local `npm-pack:` artifact is intentionally not treated as production proof and should not receive a trust bypass.

## Evidence

### Environment

- OpenClaw base: current `main` at `55dd5d5c93fcf7e9a7aa726350e325adc823f1b4`
- PR head: `ce81be1a8ff81e507f9231a09e9fa138e6ecef0d`
- macOS 26.2 arm64
- Node 26.3.1, pnpm 11.15.1
- Real proof: Codex CLI/app-server 0.145.0 over stdio
- Current OpenClaw dependency: `@openai/codex` 0.146.0
- A temporary, ephemeral workspace and OpenClaw state directory
- A fresh temporary `CODEX_HOME` containing only native auth; no config, MCP servers, hooks, plugins, or workspace state
- Synthetic tool history and prompt only; no user or production data

### App-server contract review

I also inspected the exact official Codex source used by current OpenClaw:

- OpenClaw's `extensions/codex/package.json` pins `@openai/codex` 0.146.0.
- Official Codex tag `rust-v0.146.0` resolves to `e363b08c9175ac1cbe5893615dd2cb9ddf95043b`.
- In `codex-rs/core/src/session/mod.rs`, `record_user_prompt_and_emit_turn_item` materializes each turn input as `TurnItem::UserMessage` and emits both item-started and item-completed lifecycle events.
- In `codex-rs/app-server-protocol/src/protocol/v2/item.rs`, that core item becomes `ThreadItem::UserMessage { content: Vec<UserInput> }`.
- In `codex-rs/app-server-protocol/src/protocol/event_mapping.rs`, those lifecycle events become the app-server's `item/started` and `item/completed` notifications.
- `codex-rs/app-server/README.md` documents the same lifecycle and that `userMessage.content` can contain text, image, local image, audio, or local audio inputs.

The same ownership path remains present on current Codex `main` at `a5082373f18119dc5d3eb993267c97f37880935d`. This PR therefore recognizes the app-server's protocol-owned input item; it does not add a provider-specific exception. Its guard is intentionally narrower than the protocol: it permits one item only, with one text input exactly equal to `attempt.prompt`, and rejects extra, multimodal, mismatched, duplicate, capability-bearing, or unknown items before transcript mirroring.

### Reproduction

1. Start the source-built Codex app-server over stdio from the current OpenClaw checkout.
2. Invoke `runCodexSettledTurnFinalization` with a synthetic settled non-replay-safe tool result and the prompt `Return one concise synthetic completion receipt.`
3. Record real `item/completed` item types and whether the emitted `userMessage` text equals `attempt.prompt`.
4. Query the temporary transcript SQLite database for the finalizer's exact idempotency key and count mirrored assistant messages.
5. Run once with the exact current-main finalizer and once with this PR.

Expected: one exact prompt echo is accepted, no capability item occurs, and exactly one final assistant is mirrored.

Current-main actual:

```json
{
  "observedItemTypes": ["userMessage", "agentMessage"],
  "exactPromptEchoCount": 1,
  "capabilityItemCount": 0,
  "mirroredAssistantCount": 0,
  "assistantTranscriptOwned": false,
  "failure": "Codex settled-turn finalization returned unexpected native item: userMessage",
  "status": "reproduced"
}
```

PR actual:

```json
{
  "observedItemTypes": ["userMessage", "agentMessage"],
  "exactPromptEchoCount": 1,
  "capabilityItemCount": 0,
  "mirroredAssistantCount": 1,
  "finalAssistantNonEmpty": true,
  "assistantTranscriptOwned": true,
  "failure": "",
  "status": "ok"
}
```

### Negative and repository validation

- Focused finalizer suite: 14/14 passed, including mismatched and duplicate prompt echoes rejected before mirror mutation
- Full Codex extension lane: 145 files / 3,123 tests passed
- Production build passed
- Full repository lint passed
- All 17 `pnpm check` guards passed, including all 80 package-lock validations
- Diff check passed
- Final-head extension typecheck and formatting passed after narrowing on `userMessage` before reading its content
- The six commits in the final freshness rebase do not touch `extensions/codex`; focused tests, extension typecheck, formatting, diff check, secret scan, and autoreview were repeated on the final head
- Repository-native autoreview: clean, no accepted/actionable findings; confidence 0.96
- TruffleHog pre-review scan: clean

The regression fixtures and live proof are synthetic and contain no private data.