### PR TITLE
docs(hooks): mark pairing hook observation-only

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -167,16 +167,16 @@ observation-only.
 
 **Messages and delivery**
 
-| Hook                            | Purpose                                                           |
-| ------------------------------- | ----------------------------------------------------------------- |
-| **`inbound_claim`**             | Claim an inbound message before agent routing (synthetic replies) |
-| **`channel_pairing_requested`** | Observe newly created DM pairing requests                         |
-| `message_received`              | Observe inbound content, sender, thread, and metadata             |
-| **`message_sending`**           | Rewrite outbound content or cancel delivery                       |
-| **`reply_payload_sending`**     | Mutate or cancel normalized reply payloads before delivery        |
-| `message_sent`                  | Observe outbound delivery success or failure                      |
-| **`before_dispatch`**           | Inspect or rewrite an outbound dispatch before channel handoff    |
-| **`reply_dispatch`**            | Participate in the final reply-dispatch pipeline                  |
+| Hook                        | Purpose                                                           |
+| --------------------------- | ----------------------------------------------------------------- |
+| **`inbound_claim`**         | Claim an inbound message before agent routing (synthetic replies) |
+| `channel_pairing_requested` | Observe newly created DM pairing requests                         |
+| `message_received`          | Observe inbound content, sender, thread, and metadata             |
+| **`message_sending`**       | Rewrite outbound content or cancel delivery                       |
+| **`reply_payload_sending`** | Mutate or cancel normalized reply payloads before delivery        |
+| `message_sent`              | Observe outbound delivery success or failure                      |
+| **`before_dispatch`**       | Inspect or rewrite an outbound dispatch before channel handoff    |
+| **`reply_dispatch`**        | Participate in the final reply-dispatch pipeline                  |
 
 **Sessions and compaction**
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin authors could read the hook catalog as saying `channel_pairing_requested` accepts an authorization decision, even though the runtime dispatches it as observation-only.

## Why This Change Was Made

The catalog now uses normal text for `channel_pairing_requested`, matching the hook's runtime type and the detailed guidance later on the same page. No runtime behavior changes.

## User Impact

Plugin authors no longer receive contradictory guidance about whether pairing-request observers can approve, reject, suppress, or rewrite a pairing reply.

## Evidence

- `node scripts/docs-list.js`
- `oxfmt --check docs/plugins/hooks.md`
- `git diff --check`
- Fresh autoreview: clean, confidence 0.99
