### PR TITLE
fix(memory-core): stop MEMORY.md compaction from deleting user headings

### DIFF
--- a/extensions/memory-core/src/memory-budget.test.ts
+++ b/extensions/memory-core/src/memory-budget.test.ts
@@ -296,6 +296,25 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
     expect(result.compacted).toContain("Notes I keep under a bare heading.");
   });
 
+  it.each(["---", "==="])(
+    "preserves a user Setext heading with a `%s` underline under a promotion section",
+    (underline) => {
+      const existing =
+        `${promotionSection("2026-04-10", 400)}\n\n` +
+        `My Durable Notes\n${underline}\nKeep this user-authored paragraph.\n\n` +
+        promotionSection("2026-04-20", 400);
+      const newSection = `\n${promotionSection("2026-04-29", 400)}`;
+      const result = compactMemoryForBudget({
+        existingMemory: existing,
+        newSection,
+        budgetChars: 900,
+      });
+      expect(result.droppedDates).toContain("2026-04-10");
+      expect(result.compacted).toContain(`My Durable Notes\n${underline}`);
+      expect(result.compacted).toContain("Keep this user-authored paragraph.");
+    },
+  );
+
   it("exposes a sane default budget below the bootstrap injection cap", () => {
     // Bootstrap injection is capped at 12_000 chars per file (see
     // src/agents/embedded-agent-helpers/bootstrap.ts). The MEMORY.md budget

--- a/extensions/memory-core/src/memory-budget.test.ts
+++ b/extensions/memory-core/src/memory-budget.test.ts
@@ -8,6 +8,25 @@ function promotionSection(date: string, sizeChars: number): string {
   return `${heading}${padding}`;
 }
 
+function projectGroupedSection(date: string): string {
+  return [
+    "",
+    `## Promoted From Short-Term Memory (${date})`,
+    "",
+    "### Global",
+    "",
+    "<!-- openclaw-memory-promotion:memory/short-term.md#global -->",
+    `- ${"g".repeat(120)} [score=0.900 signals=4 recalls=4 avg=0.900 source=memory/short-term.md:1-2]`,
+    "",
+    "### Project: alpha",
+    "",
+    "<!-- openclaw-memory-promotion:memory/short-term.md#alpha -->",
+    `- ${"a".repeat(120)} [score=0.900 signals=4 recalls=4 avg=0.900 source=memory/short-term.md:3-4]`,
+    "",
+    "",
+  ].join("\n");
+}
+
 describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression for #73691)", () => {
   it("returns existing memory unchanged when total fits the budget", () => {
     const existing = "# Long-Term Memory\n\nSome content.\n";
@@ -166,6 +185,52 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
     expect(
       result.compacted.length + newSection.length + headerOverhead + trailingNewline,
     ).toBeLessThanOrEqual(budget);
+  });
+
+  it("preserves a user `###` section written under a promotion section", () => {
+    const existing =
+      `${promotionSection("2026-04-10", 400)}\n` +
+      "### Correction (added by me)\nThe prod DB is db-2.corp.example, NOT db-1.\n\n" +
+      promotionSection("2026-04-20", 400);
+    const newSection = `\n${promotionSection("2026-04-29", 400)}`;
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection,
+      budgetChars: 900,
+    });
+    expect(result.droppedDates).toContain("2026-04-10");
+    expect(result.compacted).toContain("### Correction (added by me)");
+    expect(result.compacted).toContain("The prod DB is db-2.corp.example, NOT db-1.");
+  });
+
+  it("preserves a user `#` section written after the only promotion section", () => {
+    const existing =
+      `# Long-Term Memory\n\n${promotionSection("2026-04-10", 800)}\n` +
+      "# My Notes\n\nKeep this paragraph.\n";
+    const newSection = `\n${promotionSection("2026-04-29", 600)}`;
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection,
+      budgetChars: 800,
+    });
+    expect(result.droppedDates).toContain("2026-04-10");
+    expect(result.compacted).toContain("# My Notes");
+    expect(result.compacted).toContain("Keep this paragraph.");
+    expect(result.compacted).toContain("# Long-Term Memory");
+  });
+
+  it("drops a multi-project promotion section whole, including its `###` project subheadings", () => {
+    const existing = `${projectGroupedSection("2026-04-10")}\n${projectGroupedSection("2026-04-20")}`;
+    const newSection = `\n${projectGroupedSection("2026-04-29")}`;
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection,
+      budgetChars: 700,
+    });
+    expect(result.droppedDates).toEqual(["2026-04-10", "2026-04-20"]);
+    expect(result.compacted).not.toContain("### Project: alpha");
+    expect(result.compacted).not.toContain("### Global");
+    expect(result.compacted).not.toContain("openclaw-memory-promotion");
   });
 
   it("exposes a sane default budget below the bootstrap injection cap", () => {

--- a/extensions/memory-core/src/memory-budget.test.ts
+++ b/extensions/memory-core/src/memory-budget.test.ts
@@ -265,6 +265,37 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
     expect(result.compacted).toContain("Alpha ships on Fridays.");
   });
 
+  it("preserves a tab-delimited user heading written under a promotion section", () => {
+    const existing =
+      `${promotionSection("2026-04-10", 400)}\n` +
+      "###\tCorrection\nThe prod DB is db-2.corp.example, NOT db-1.\n\n" +
+      promotionSection("2026-04-20", 400);
+    const newSection = `\n${promotionSection("2026-04-29", 400)}`;
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection,
+      budgetChars: 900,
+    });
+    expect(result.droppedDates).toContain("2026-04-10");
+    expect(result.compacted).toContain("###\tCorrection");
+    expect(result.compacted).toContain("The prod DB is db-2.corp.example, NOT db-1.");
+  });
+
+  it("preserves an empty user heading line written under a promotion section", () => {
+    const existing =
+      `${promotionSection("2026-04-10", 400)}\n` +
+      "###\nNotes I keep under a bare heading.\n\n" +
+      promotionSection("2026-04-20", 400);
+    const newSection = `\n${promotionSection("2026-04-29", 400)}`;
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection,
+      budgetChars: 900,
+    });
+    expect(result.droppedDates).toContain("2026-04-10");
+    expect(result.compacted).toContain("Notes I keep under a bare heading.");
+  });
+
   it("exposes a sane default budget below the bootstrap injection cap", () => {
     // Bootstrap injection is capped at 12_000 chars per file (see
     // src/agents/embedded-agent-helpers/bootstrap.ts). The MEMORY.md budget

--- a/extensions/memory-core/src/memory-budget.test.ts
+++ b/extensions/memory-core/src/memory-budget.test.ts
@@ -233,6 +233,38 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
     expect(result.compacted).not.toContain("openclaw-memory-promotion");
   });
 
+  it("preserves a user-authored `### Global` heading written under a promotion section", () => {
+    const existing =
+      `${promotionSection("2026-04-10", 400)}\n` +
+      "### Global\n\nMy own global rule, not a promoted entry.\n\n" +
+      promotionSection("2026-04-20", 400);
+    const newSection = `\n${promotionSection("2026-04-29", 400)}`;
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection,
+      budgetChars: 900,
+    });
+    expect(result.droppedDates).toContain("2026-04-10");
+    expect(result.compacted).toContain("### Global");
+    expect(result.compacted).toContain("My own global rule, not a promoted entry.");
+  });
+
+  it("preserves a user-authored `### Project:` heading written under a promotion section", () => {
+    const existing =
+      `${promotionSection("2026-04-10", 400)}\n` +
+      "### Project: alpha\n\nAlpha ships on Fridays.\n\n" +
+      promotionSection("2026-04-20", 400);
+    const newSection = `\n${promotionSection("2026-04-29", 400)}`;
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection,
+      budgetChars: 900,
+    });
+    expect(result.droppedDates).toContain("2026-04-10");
+    expect(result.compacted).toContain("### Project: alpha");
+    expect(result.compacted).toContain("Alpha ships on Fridays.");
+  });
+
   it("exposes a sane default budget below the bootstrap injection cap", () => {
     // Bootstrap injection is capped at 12_000 chars per file (see
     // src/agents/embedded-agent-helpers/bootstrap.ts). The MEMORY.md budget

--- a/extensions/memory-core/src/memory-budget.test.ts
+++ b/extensions/memory-core/src/memory-budget.test.ts
@@ -187,10 +187,30 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
     ).toBeLessThanOrEqual(budget);
   });
 
-  it("preserves a user `###` section written under a promotion section", () => {
+  it.each([0, 1, 2, 3])(
+    "preserves a user `###` section with %i leading spaces under a promotion section",
+    (leadingSpaces) => {
+      const heading = `${" ".repeat(leadingSpaces)}### Correction (added by me)`;
+      const existing =
+        `${promotionSection("2026-04-10", 400)}\n` +
+        `${heading}\nThe prod DB is db-2.corp.example, NOT db-1.\n\n` +
+        promotionSection("2026-04-20", 400);
+      const newSection = `\n${promotionSection("2026-04-29", 400)}`;
+      const result = compactMemoryForBudget({
+        existingMemory: existing,
+        newSection,
+        budgetChars: 900,
+      });
+      expect(result.droppedDates).toContain("2026-04-10");
+      expect(result.compacted).toContain(heading);
+      expect(result.compacted).toContain("The prod DB is db-2.corp.example, NOT db-1.");
+    },
+  );
+
+  it("does not treat a four-space-indented hash line as an ATX heading", () => {
     const existing =
       `${promotionSection("2026-04-10", 400)}\n` +
-      "### Correction (added by me)\nThe prod DB is db-2.corp.example, NOT db-1.\n\n" +
+      "    ### Indented code\n    keep this inside the generated block\n\n" +
       promotionSection("2026-04-20", 400);
     const newSection = `\n${promotionSection("2026-04-29", 400)}`;
     const result = compactMemoryForBudget({
@@ -199,8 +219,8 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
       budgetChars: 900,
     });
     expect(result.droppedDates).toContain("2026-04-10");
-    expect(result.compacted).toContain("### Correction (added by me)");
-    expect(result.compacted).toContain("The prod DB is db-2.corp.example, NOT db-1.");
+    expect(result.compacted).not.toContain("### Indented code");
+    expect(result.compacted).not.toContain("keep this inside the generated block");
   });
 
   it("preserves a user `#` section written after the only promotion section", () => {

--- a/extensions/memory-core/src/memory-budget.ts
+++ b/extensions/memory-core/src/memory-budget.ts
@@ -22,6 +22,8 @@ const PROMOTION_ENTRY_MARKER_RE = /^<!--\s*openclaw-memory-promotion:.*-->\s*$/i
 
 const ATX_HEADING_RE = /^#{1,6}(?:[ \t]|$)/;
 
+const SETEXT_HEADING_UNDERLINE_RE = /^ {0,3}(?:=+|-+)[ \t]*$/;
+
 /**
  * Default budget for MEMORY.md content on disk, in characters. Chosen to
  * stay safely below the bootstrap injection cap (~12KB per file at the
@@ -58,6 +60,22 @@ function startsGeneratedPromotionSubsection(lines: string[], index: number): boo
   return false;
 }
 
+function takeSetextHeadingLines(lines: string[]): string[] | undefined {
+  let start = lines.length;
+  while (start > 1 && lines[start - 1]?.trim().length !== 0) {
+    start -= 1;
+  }
+  if (start === lines.length) {
+    return undefined;
+  }
+  const headingLines = lines.slice(start);
+  if (headingLines.some((line) => PROMOTION_ENTRY_MARKER_RE.test(line))) {
+    return undefined;
+  }
+  lines.splice(start);
+  return headingLines;
+}
+
 function parseMemoryBlocks(content: string): MemoryBlock[] {
   if (content.length === 0) {
     return [];
@@ -84,6 +102,14 @@ function parseMemoryBlocks(content: string): MemoryBlock[] {
   };
 
   for (const [index, line] of lines.entries()) {
+    if (currentKind === "promotion" && SETEXT_HEADING_UNDERLINE_RE.test(line)) {
+      const headingLines = takeSetextHeadingLines(currentLines);
+      if (headingLines) {
+        flush();
+        currentLines = [...headingLines, line];
+        continue;
+      }
+    }
     const continuesPromotionBody =
       currentKind === "promotion" && startsGeneratedPromotionSubsection(lines, index);
     if (ATX_HEADING_RE.test(line) && !continuesPromotionBody) {

--- a/extensions/memory-core/src/memory-budget.ts
+++ b/extensions/memory-core/src/memory-budget.ts
@@ -20,7 +20,7 @@ const PROMOTION_SUBSECTION_HEADING_RE = /^### (?:Global|Project: .+?)\s*$/;
 
 const PROMOTION_ENTRY_MARKER_RE = /^<!--\s*openclaw-memory-promotion:.*-->\s*$/i;
 
-const ATX_HEADING_RE = /^#{1,6} /;
+const ATX_HEADING_RE = /^#{1,6}(?:[ \t]|$)/;
 
 /**
  * Default budget for MEMORY.md content on disk, in characters. Chosen to

--- a/extensions/memory-core/src/memory-budget.ts
+++ b/extensions/memory-core/src/memory-budget.ts
@@ -20,7 +20,7 @@ const PROMOTION_SUBSECTION_HEADING_RE = /^### (?:Global|Project: .+?)\s*$/;
 
 const PROMOTION_ENTRY_MARKER_RE = /^<!--\s*openclaw-memory-promotion:.*-->\s*$/i;
 
-const ATX_HEADING_RE = /^#{1,6}(?:[ \t]|$)/;
+const ATX_HEADING_RE = /^ {0,3}#{1,6}(?:[ \t]|$)/;
 
 const SETEXT_HEADING_UNDERLINE_RE = /^ {0,3}(?:=+|-+)[ \t]*$/;
 

--- a/extensions/memory-core/src/memory-budget.ts
+++ b/extensions/memory-core/src/memory-budget.ts
@@ -16,6 +16,10 @@
 
 const PROMOTION_SECTION_HEADING_RE = /^## Promoted From Short-Term Memory \(([^)]+)\)\s*$/;
 
+const PROMOTION_SUBSECTION_HEADING_RE = /^### (?:Global|Project: .+?)\s*$/;
+
+const ATX_HEADING_RE = /^#{1,6} /;
+
 /**
  * Default budget for MEMORY.md content on disk, in characters. Chosen to
  * stay safely below the bootstrap injection cap (~12KB per file at the
@@ -64,7 +68,9 @@ function parseMemoryBlocks(content: string): MemoryBlock[] {
   };
 
   for (const line of lines) {
-    if (line.startsWith("## ")) {
+    const continuesPromotionBody =
+      currentKind === "promotion" && PROMOTION_SUBSECTION_HEADING_RE.test(line);
+    if (ATX_HEADING_RE.test(line) && !continuesPromotionBody) {
       flush();
       const match = PROMOTION_SECTION_HEADING_RE.exec(line);
       if (match) {
@@ -104,7 +110,7 @@ type CompactMemoryResult = {
  *
  * Guarantees:
  * - Non-promotion content (user-authored markdown, the file header, any
- *   `##` heading not matching the promotion pattern) is preserved.
+ *   heading of any level not matching the promotion pattern) is preserved.
  * - Promotion sections are dropped in ascending date order (oldest first).
  * - If `existingMemory + newSection` already fits the budget, the existing
  *   memory is returned unchanged.

--- a/extensions/memory-core/src/memory-budget.ts
+++ b/extensions/memory-core/src/memory-budget.ts
@@ -18,6 +18,8 @@ const PROMOTION_SECTION_HEADING_RE = /^## Promoted From Short-Term Memory \(([^)
 
 const PROMOTION_SUBSECTION_HEADING_RE = /^### (?:Global|Project: .+?)\s*$/;
 
+const PROMOTION_ENTRY_MARKER_RE = /^<!--\s*openclaw-memory-promotion:.*-->\s*$/i;
+
 const ATX_HEADING_RE = /^#{1,6} /;
 
 /**
@@ -41,6 +43,20 @@ const WRITE_OVERHEAD_RESERVE = 21;
 type MemoryBlock =
   | { kind: "preserved"; text: string }
   | { kind: "promotion"; date: string; text: string };
+
+function startsGeneratedPromotionSubsection(lines: string[], index: number): boolean {
+  if (!PROMOTION_SUBSECTION_HEADING_RE.test(lines[index] ?? "")) {
+    return false;
+  }
+  for (let next = index + 1; next < lines.length; next += 1) {
+    const line = lines[next] ?? "";
+    if (line.trim().length === 0) {
+      continue;
+    }
+    return PROMOTION_ENTRY_MARKER_RE.test(line);
+  }
+  return false;
+}
 
 function parseMemoryBlocks(content: string): MemoryBlock[] {
   if (content.length === 0) {
@@ -67,9 +83,9 @@ function parseMemoryBlocks(content: string): MemoryBlock[] {
     currentDate = undefined;
   };
 
-  for (const line of lines) {
+  for (const [index, line] of lines.entries()) {
     const continuesPromotionBody =
-      currentKind === "promotion" && PROMOTION_SUBSECTION_HEADING_RE.test(line);
+      currentKind === "promotion" && startsGeneratedPromotionSubsection(lines, index);
     if (ATX_HEADING_RE.test(line) && !continuesPromotionBody) {
       flush();
       const match = PROMOTION_SECTION_HEADING_RE.exec(line);

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -3712,6 +3712,76 @@ describe("short-term promotion", () => {
   });
 
   describe("MEMORY.md budget compaction (#73691)", () => {
+    it("preserves an indented user ATX heading when compaction writes MEMORY.md", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        await writeDailyMemoryNote(workspaceDir, "2026-04-29", [
+          "Notes",
+          "",
+          "Rotate the staging Postgres credentials before next deploy.",
+        ]);
+
+        const memoryPath = path.join(workspaceDir, "MEMORY.md");
+        const filler = "x".repeat(600);
+        const seeded = [
+          "# Long-Term Memory",
+          "",
+          "## Promoted From Short-Term Memory (2026-04-10)",
+          "<!-- openclaw-memory-promotion:legacy-old -->",
+          `- ${filler}`,
+          "",
+          "   ### Correction (added by me)",
+          "The prod DB is db-2.corp.example, NOT db-1.",
+          "",
+          "## Promoted From Short-Term Memory (2026-04-20)",
+          "<!-- openclaw-memory-promotion:legacy-newer -->",
+          `- ${filler}`,
+          "",
+        ].join("\n");
+        await fs.writeFile(memoryPath, seeded, "utf-8");
+
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "rotate creds",
+          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
+          results: [
+            {
+              path: "memory/2026-04-29.md",
+              startLine: 3,
+              endLine: 3,
+              score: 0.96,
+              snippet: "Rotate the staging Postgres credentials before next deploy.",
+              source: "memory",
+            },
+          ],
+        });
+
+        const ranked = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+        });
+
+        const applied = await applyShortTermPromotions({
+          workspaceDir,
+          candidates: ranked,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
+          memoryFileMaxChars: 1_400,
+        });
+
+        expect(applied.applied).toBe(1);
+        expect(applied.compactedDates).toContain("2026-04-10");
+        const memoryText = await fs.readFile(memoryPath, "utf-8");
+        expect(memoryText).not.toContain("legacy-old");
+        expect(memoryText).toContain("   ### Correction (added by me)");
+        expect(memoryText).toContain("The prod DB is db-2.corp.example, NOT db-1.");
+        expect(memoryText).toContain("Rotate the staging Postgres credentials");
+      });
+    });
+
     it("drops the oldest promoted section before write when memoryFileMaxChars would be exceeded", async () => {
       await withTempWorkspace(async (workspaceDir) => {
         // Source daily note that the candidate references (rehydrate reads it).


### PR DESCRIPTION
## What Problem This Solves

Dreaming's bounded `MEMORY.md` compaction can silently delete user-authored durable notes.

`compactMemoryForBudget` drops the oldest `## Promoted From Short-Term Memory (DATE)` sections when the file exceeds `DEFAULT_MEMORY_FILE_MAX_CHARS`. Its contract says all non-promotion content is preserved, but `parseMemoryBlocks` originally recognized only `## ` as a block boundary. User content under any other heading stayed attached to the generated section above it and was deleted with that section.

The initial repair covered ATX headings, including generated-name collisions, tab-delimited headings, and bare headings. Review then found two remaining CommonMark boundaries: Setext headings such as `My Durable Notes` followed by `---` or `===`, and ATX headings preceded by one to three spaces. Both forms were still absorbed into the promotion block above them.

This path writes durable agent memory. The append fallback stores no preimage, and `compactedDates` reports only generated section dates, so the deleted user text had no recovery path or diagnostic.

## Why This Change Was Made

The parser now recognizes both CommonMark heading forms while keeping generated promotion structure compactable.

For ATX headings, any level with CommonMark's permitted zero to three leading spaces closes the current block. Four leading spaces remain indented code and do not create a block boundary:

```ts
const ATX_HEADING_RE = /^ {0,3}#{1,6}(?:[ \t]|$)/;
```

Generated `### Global` and `### Project: <key>` subsections remain inside their promotion section only when the next nonblank line is an authoritative `openclaw-memory-promotion` marker. Matching the heading name alone would let a user-authored heading with the same name be deleted.

For Setext headings, an underline of `=` or `-`, with CommonMark's permitted indentation and trailing whitespace, moves the preceding heading paragraph out of the promotion block before it is flushed:

```ts
const SETEXT_HEADING_UNDERLINE_RE = /^ {0,3}(?:=+|-+)[ \t]*$/;
```

`takeSetextHeadingLines` preserves all contiguous heading text lines. It refuses to split a range containing a promotion marker, so marker-backed generated content remains owned by and compacted with its section.

This is the narrow ownership boundary: generated promotion sections remain droppable, while headed user content is preserved independently. No product, config, API, or storage-format change is introduced.

## User Impact

Text written under a generated promotion now survives nightly dreaming compaction when it begins with:

- an ATX heading of any level with zero to three leading spaces;
- a user heading named `### Global` or `### Project: <key>`;
- a tab-delimited or bare ATX heading;
- a Setext level-1 or level-2 heading using `===` or `---`.

Generated multi-project sections still compact whole, the oldest dates are still dropped first, and newly promoted memory is still appended within the same file budget.

## Real behavior proof
Behavior addressed: user-authored Setext headings and one-to-three-space-indented ATX headings beneath an older generated promotion were silently removed during the real promotion write.
Real environment tested: production `recordShortTermRecalls`, `rankShortTermPromotionCandidates`, and `applyShortTermPromotions` on pristine PR base `3f4d65a6727`, contributor head `93f56e4e58cb71c4ad94f13d30e76d3751dc3940`, and repaired exact head `a5496372ca3ff87c2037551632f73c607a1a7cec`; real temporary workspace files, real SQLite plugin state, real budget calculation, and real atomic `MEMORY.md` replacement, with no stubs.
Exact steps or command run after this patch: seed a daily memory file and an over-budget `MEMORY.md`, record and rank a fresh recall, then apply it through the production functions. The repaired-head regression places `   ### Correction (added by me)` and its paragraph beneath the oldest generated section and asserts they survive while that generated section is compacted.
Evidence after fix:
```
# BEFORE (pristine PR base 3f4d65a6727)
MEMORY.md before: 9879 chars
compacted sections reported: ["2026-07-01"]
MEMORY.md after: 5249 chars
Setext heading survived: false
user text survived: false
newest promoted section kept: true
fresh promotion appended: true

# AFTER (exact commit 93f56e4e58cb71c4ad94f13d30e76d3751dc3940, identical inputs)
MEMORY.md before: 9879 chars
compacted sections reported: ["2026-07-01"]
MEMORY.md after: 5311 chars
Setext heading survived: true
user text survived: true
newest promoted section kept: true
fresh promotion appended: true

# MAINTAINER REPAIR (exact commit a5496372ca3ff87c2037551632f73c607a1a7cec)
three-space ATX heading survived: true
user paragraph survived: true
four-space indented-code control remains non-heading: true
oldest generated section dropped: true
fresh promotion appended: true
```
Observed result after fix: identical inputs retain Setext and zero-to-three-space ATX heading blocks on disk, while four-space indented code keeps its non-heading behavior and generated-section compaction remains correct.
What was not tested: no live gateway or scheduled cron trigger; the sweep was driven through the production promotion functions called by the cron path. Full build not run.

## Evidence

- Blacksmith Testbox `tbx_01kyr757hq3rave1vx9y01tcwk`: 113 tests passed across `memory-budget.test.ts`, `short-term-promotion.test.ts`, and `short-term-promotion-metadata.test.ts`.
- The two new Setext cases fail on the prior PR head for both `---` and `===`, then pass at `93f56e4e58cb71c4ad94f13d30e76d3751dc3940`.
- The production three-space ATX write regression fails on `93f56e4e58cb71c4ad94f13d30e76d3751dc3940`, deleting the heading and paragraph, then passes at `a5496372ca3ff87c2037551632f73c607a1a7cec`.
- The ATX unit matrix covers zero, one, two, and three leading spaces; a four-space negative control remains non-heading.
- The generated multi-project regression still proves marker-backed `### Global` and `### Project: alpha` subsections are dropped with their generated section.
- Remote changed gates passed formatting, lint, extension production/test typechecks, dependency and boundary guards, dead-code checks, and runtime-cycle checks.
- Fresh autoreview at `a5496372ca3ff87c2037551632f73c607a1a7cec`: no findings, patch correct at 0.97 confidence.
- Hosted exact-head CI: green after rerunning one unrelated flaky SQLite flip-proof job; run `30503649424`.
- ClawSweeper's optional rebase rank-up move was not applied: repository policy does not rebase solely because `main` advanced, the touched files have no intervening `main` changes, and native `scripts/pr prepare-run` verified this exact remote head with hosted gates.
- `git diff --check`: clean.
