### PR TITLE
fix(protocol): accept config hint documentation URLs

### DIFF
--- a/packages/gateway-protocol/src/schema/config.test.ts
+++ b/packages/gateway-protocol/src/schema/config.test.ts
@@ -1,11 +1,12 @@
 import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
-import { ConfigSchemaResponseSchema } from "./config.js";
+import { ConfigSchemaLookupResultSchema, ConfigSchemaResponseSchema } from "./config.js";
 
 const response = {
   schema: {},
   uiHints: {
     "channels.sms.fromNumber": {
+      docsUrl: "https://docs.openclaw.ai/channels/sms",
       presentation: "phone-number",
     },
   },
@@ -29,5 +30,18 @@ describe("ConfigSchemaResponseSchema", () => {
         },
       }),
     ).toBe(false);
+  });
+});
+
+describe("ConfigSchemaLookupResultSchema", () => {
+  it("accepts a documentation URL in the resolved hint", () => {
+    expect(
+      Value.Check(ConfigSchemaLookupResultSchema, {
+        path: "gateway",
+        schema: { type: "object" },
+        hint: { docsUrl: "https://docs.openclaw.ai/gateway" },
+        children: [],
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/gateway-protocol/src/schema/config.ts
+++ b/packages/gateway-protocol/src/schema/config.ts
@@ -77,6 +77,7 @@ export const UpdateRunParamsSchema = closedObject({
 const ConfigUiHintSchema = closedObject({
   label: Type.Optional(Type.String()),
   help: Type.Optional(Type.String()),
+  docsUrl: Type.Optional(Type.String()),
   tags: Type.Optional(Type.Array(Type.String())),
   group: Type.Optional(Type.String()),
   order: Type.Optional(Type.Integer()),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where config schema lookup failed when canonical UI hints included a documentation URL. This blocked the Kitchen Sink RPC package lane during beta.6 validation because the gateway rejected its own `hint.docsUrl` output as an unexpected property.

## Why This Change Was Made

The shared config hint contract already emits optional documentation URLs. This adds the same optional field to the additive Gateway protocol validator and covers both full-schema and lookup responses. No protocol version bump or compatibility shim is needed.

## User Impact

Config schema consumers and official plugins can use documentation-linked hints without `config.schema.lookup` failing validation.

## Evidence

- Reproduced in Full Release Validation child run 30485133625: `config.schema.lookup returned invalid payload` at `/hint` because `docsUrl` was rejected.
- Added focused TypeBox validation coverage for full schema hints and lookup hints.
- Formatting and `git diff --check` passed.
- Autoreview passed with no actionable findings.
- Exact-head hosted CI is the execution proof because the isolated worktree intentionally had no dependency install.
