### PR TITLE
fix(qa): forward-port beta 6 validation fixes

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/BoundedCommandTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/BoundedCommandTests.swift
@@ -24,7 +24,7 @@ struct BoundedCommandTests {
         let startedAt = clock.now
         let output = await BoundedCommand.run(
             path: "/bin/sh",
-            arguments: ["-c", "echo $$ > \"$PID_FILE\"; trap '' TERM; while :; do :; done"],
+            arguments: ["-c", "echo $$ > \"$PID_FILE\"; trap '' TERM; exec /bin/sleep 30"],
             environment: ["PID_FILE": pidFile.path],
             timeout: 0.1)
 

--- a/apps/macos/Tests/OpenClawIPCTests/ShellExecutorTimeoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ShellExecutorTimeoutTests.swift
@@ -13,7 +13,7 @@ struct ShellExecutorTimeoutTests {
             command: [
                 "/bin/sh",
                 "-c",
-                "echo $$ > \"$PID_FILE\"; trap '' TERM; while :; do :; done",
+                "echo $$ > \"$PID_FILE\"; trap '' TERM; exec /bin/sleep 30",
             ],
             cwd: nil,
             env: ["PID_FILE": pidFile.path],

--- a/extensions/feishu/src/monitor.cleanup.test-helpers.ts
+++ b/extensions/feishu/src/monitor.cleanup.test-helpers.ts
@@ -1,3 +1,4 @@
+import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { botNames, botOpenIds, httpServers, wsClients } from "./monitor.state.js";
 
 export function cleanupFeishuMonitorStateForTests(): void {
@@ -21,4 +22,5 @@ export function cleanupFeishuMonitorStateForTests(): void {
   httpServers.clear();
   botOpenIds.clear();
   botNames.clear();
+  closeOpenClawStateDatabaseForTest();
 }

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -409,7 +409,9 @@ describe("openai video generation provider", () => {
       fetchWithTimeoutGuardedCall();
     expect(downloadUrl).toBe("http://127.0.0.1:44080/v1/videos/vid_local/content?variant=video");
     expect(downloadInit?.method).toBe("GET");
-    expect(downloadTimeout).toBe(120000);
+    // Download shares the generation deadline, so earlier phases consume part of this budget.
+    expect(downloadTimeout).toBeGreaterThan(0);
+    expect(downloadTimeout).toBeLessThanOrEqual(120_000);
     expect(downloadFetch).toBe(fetch);
     expect(downloadOptions).toEqual({
       ssrfPolicy: { allowPrivateNetwork: true },

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
@@ -125,6 +125,7 @@ describe("Telegram live QA scenario gate", () => {
       },
     ]);
     mocks.resolveTelegramQaRunOptions.mockReturnValueOnce({
+      allowFailures: false,
       listScenarios: true,
       providerMode: "mock-openai",
       repoRoot: process.cwd(),

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   createTelegramQaTransportAdapter: vi.fn(),
+  listTelegramQaScenarios: vi.fn(),
   printLiveTransportQaArtifacts: vi.fn(),
   resolveTelegramQaRunOptions: vi.fn(
     (options: { allowFailures?: boolean; providerMode?: string; repoRoot: string }) => ({
@@ -34,7 +35,7 @@ vi.mock("./run-options.runtime.js", () => ({
 }));
 
 vi.mock("./scenario-selection.js", () => ({
-  listTelegramQaScenarios: vi.fn(),
+  listTelegramQaScenarios: mocks.listTelegramQaScenarios,
   resolveTelegramQaScenarioIds: mocks.resolveTelegramQaScenarioIds,
 }));
 
@@ -110,5 +111,54 @@ describe("Telegram live QA scenario gate", () => {
     });
 
     expect(process.exitCode).toBeUndefined();
+  });
+
+  it("lists only scenarios accepted by its flow runner", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mocks.listTelegramQaScenarios.mockReturnValue([
+      {
+        id: "channel-message-flows",
+        defaultEnabled: true,
+        title: "Message flows",
+        rationale: "Exercise Telegram message flows",
+        regressionRefs: [],
+      },
+    ]);
+    mocks.resolveTelegramQaRunOptions.mockReturnValueOnce({
+      listScenarios: true,
+      providerMode: "mock-openai",
+      repoRoot: process.cwd(),
+    });
+
+    await runQaTelegramSuite({
+      listScenarios: true,
+      providerMode: "mock-openai",
+      repoRoot: process.cwd(),
+    });
+
+    const output = write.mock.calls.map(([chunk]) => String(chunk)).join("");
+    expect(output).toContain("channel-message-flows\tdefault\t");
+    expect(output).not.toContain("telegram-startup-getme-live");
+    expect(mocks.runQaFlowSuiteFromRuntime).not.toHaveBeenCalled();
+  });
+
+  it("keeps script scenarios out of the default flow-suite invocation", async () => {
+    writeSummary("pass");
+    mocks.resolveTelegramQaScenarioIds.mockReturnValue([
+      "channel-message-flows",
+      "telegram-help-command",
+    ]);
+
+    await runQaTelegramSuite({
+      allowFailures: true,
+      providerMode: "mock-openai",
+      repoRoot: process.cwd(),
+    });
+
+    expect(mocks.runQaFlowSuiteFromRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scenarioIds: expect.not.arrayContaining(["telegram-startup-getme-live"]),
+      }),
+    );
   });
 });

--- a/extensions/qa-lab/src/live-transports/telegram/profiles.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/profiles.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { readQaScenarioPack } from "../../scenario-catalog.js";
 import { listTelegramQaScenarios, resolveTelegramQaScenarioIds } from "./scenario-selection.js";
 
 describe("Telegram QA profiles", () => {
@@ -10,6 +11,7 @@ describe("Telegram QA profiles", () => {
     expect(live).not.toContain("telegram-long-final-reuses-preview");
     expect(mock).toContain("telegram-long-final-reuses-preview");
     expect(mock).toContain("telegram-assistant-transcript-role-boundary");
+    expect(mock).not.toContain("telegram-startup-getme-live");
   });
 
   it("selects every taxonomy-owned executable Telegram scenario through all", () => {
@@ -30,6 +32,13 @@ describe("Telegram QA profiles", () => {
         scenarioIds: ["telegram-help-command"],
       }),
     ).toEqual(["telegram-help-command"]);
+    expect(() =>
+      resolveTelegramQaScenarioIds({
+        profile: "release",
+        providerMode: "live-frontier",
+        scenarioIds: ["telegram-startup-getme-live"],
+      }),
+    ).toThrow("Telegram QA flow runner cannot execute non-flow scenario(s)");
   });
 
   it("rejects unknown profiles and channel-ineligible explicit scenarios", () => {
@@ -47,15 +56,21 @@ describe("Telegram QA profiles", () => {
   it("lists catalog-eligible scenarios with provider-specific release defaults", () => {
     const scenarios = listTelegramQaScenarios("mock-openai");
     const defaultIds = new Set(resolveTelegramQaScenarioIds({ providerMode: "mock-openai" }));
+    const scenarioById = new Map(
+      readQaScenarioPack().scenarios.map((scenario) => [scenario.id, scenario] as const),
+    );
 
     expect(
       new Set(scenarios.filter(({ defaultEnabled }) => defaultEnabled).map(({ id }) => id)),
     ).toEqual(defaultIds);
+    expect(scenarios.every(({ id }) => scenarioById.get(id)?.execution.kind === "flow")).toBe(true);
     expect(
       scenarios.find(({ id }) => id === "telegram-long-final-reuses-preview")?.defaultEnabled,
     ).toBe(true);
     expect(
       scenarios.find(({ id }) => id === "telegram-long-final-three-chunks")?.defaultEnabled,
     ).toBe(true);
+    expect(scenarios.some(({ id }) => id === "telegram-startup-getme-live")).toBe(false);
+    expect(scenarioById.get("telegram-startup-getme-live")?.execution.kind).toBe("script");
   });
 });

--- a/extensions/qa-lab/src/live-transports/telegram/scenario-selection.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/scenario-selection.ts
@@ -1,5 +1,6 @@
 import type { QaProviderModeInput } from "../../model-selection.js";
 import {
+  resolveCatalogLiveTransportQaScenarioIds,
   listLiveTransportQaScenarios,
   resolveLiveTransportQaScenarioIds,
 } from "../shared/scenario-selection.js";
@@ -11,12 +12,38 @@ export function resolveTelegramQaScenarioIds(params: {
   providerMode: QaProviderModeInput;
   scenarioIds?: readonly string[];
 }): string[] {
-  return resolveLiveTransportQaScenarioIds({ channelId: TELEGRAM_QA_CHANNEL_ID, ...params });
+  const selectedIds = resolveLiveTransportQaScenarioIds({
+    channelId: TELEGRAM_QA_CHANNEL_ID,
+    ...params,
+  });
+  const flowIds = new Set(
+    resolveCatalogLiveTransportQaScenarioIds({
+      channelId: TELEGRAM_QA_CHANNEL_ID,
+      providerMode: params.providerMode,
+    }),
+  );
+  const unsupportedIds = selectedIds.filter((scenarioId) => !flowIds.has(scenarioId));
+  if (params.scenarioIds?.length && unsupportedIds.length > 0) {
+    throw new Error(
+      `Telegram QA flow runner cannot execute non-flow scenario(s): ${unsupportedIds.join(", ")}`,
+    );
+  }
+  const scenarioIds = selectedIds.filter((scenarioId) => flowIds.has(scenarioId));
+  if (scenarioIds.length === 0) {
+    throw new Error("Telegram QA flow selection resolved no scenarios.");
+  }
+  return scenarioIds;
 }
 
 export function listTelegramQaScenarios(providerMode: QaProviderModeInput) {
+  const flowIds = new Set(
+    resolveCatalogLiveTransportQaScenarioIds({
+      channelId: TELEGRAM_QA_CHANNEL_ID,
+      providerMode,
+    }),
+  );
   return listLiveTransportQaScenarios({
     channelId: TELEGRAM_QA_CHANNEL_ID,
     providerMode,
-  });
+  }).filter((scenario) => flowIds.has(scenario.id));
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves several validation failures found while preparing beta.6: macOS timeout fixtures could starve hosted runners, Telegram's flow-only CLI exposed a script scenario it could not execute, an OpenAI video assertion ignored elapsed deadline budget, and Feishu cleanup left the shared test database open.

## Why This Change Was Made

This forward-ports the smallest reusable fixes from the release branch onto current `main`. The macOS fixtures preserve the same PID, TERM-ignore, timeout, SIGKILL, and reap assertions while blocking instead of busy-spinning. Telegram selection now distinguishes flow scenarios from dedicated scripts at the taxonomy boundary.

## User Impact

No direct product behavior changes. Release and main validation avoid self-inflicted CPU contention and select only executable flow scenarios, without weakening assertions or increasing timeouts. Hosted scheduler timing can still vary under the full parallel Swift suite.

## Evidence

- macOS failure reproduced across beta.6 Full Release Validation attempts; cleanup/reaping passed while the hot loop missed only the wall-clock assertion.
- Exact shell probe confirmed same PID, ignored TERM, SIGKILL, and reap after replacing the spin with `exec /bin/sleep 30`.
- Telegram selector and CLI tests cover list/resolve rejection of script-only scenarios while the dedicated runner retains them.
- OpenAI assertion now checks the positive remaining budget capped at 120 seconds.
- `git diff --check`, changed-lane classification, and autoreview passed.
- Exact-head hosted CI will provide execution proof because the isolated worktree intentionally had no dependency install.
