### PR TITLE
fix: prevent Realtime Talk from leaking across chat sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI Talk session isolation:** stop active realtime Talk media and retire its callbacks before chat session changes, Gateway disconnects, or pane disposal so previous-session audio, transcript, camera, and status updates cannot leak into the next view. Thanks @shakkernerd.
 - **Gateway reconnect event ordering:** reset the shared TypeScript client's outer event-sequence baseline for each replacement WebSocket, preventing gap recovery from comparing unrelated connection generations across Control UI, TUI, SDK, and browser extension clients. Thanks @shakkernerd.
 - **Skill Workshop offline apply:** preserve configless local proposal apply after upgrades under exclusive Gateway startup ownership, while keeping running Gateway snapshot invalidation fail-closed when CLI credentials are unavailable.
 - **macOS and Control UI keyboard navigation:** let Tab traverse links and controls inside embedded Dashboard, browser, and Canvas web views, and keep shortcuts working on non-Latin keyboard layouts without firing during IME composition.

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -23,6 +23,7 @@ import { ChatPaneLifecycle } from "./chat-pane-lifecycle.ts";
 import { applySelectedSessionProjection } from "./chat-pane-state.ts";
 import { resolveAssistantAttachmentAuthToken } from "./chat-pane-state.ts";
 import { markQueuedChatSendsWaitingForReconnect } from "./chat-queue.ts";
+import { stopChatRealtimeTalk } from "./chat-realtime.ts";
 import { retryReconnectableQueuedChatSends } from "./chat-send-actions.ts";
 import {
   invalidateChatMetadataCache,
@@ -278,16 +279,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       }
       this.connectedClient = null;
       setQuestionPromptClient(this.questionPromptState, null);
-      state.realtimeTalkSession?.stop();
-      state.realtimeTalkSession = null;
-      state.realtimeTalkActive = false;
-      state.realtimeTalkVideoStream = null;
-      state.realtimeTalkCameraDevices = [];
-      state.realtimeTalkVideoCapable = false;
-      state.realtimeTalkVideoPending = false;
-      state.realtimeTalkCameraError = false;
-      state.realtimeTalkStatus = "idle";
-      state.realtimeTalkInputLevel.set(0);
+      stopChatRealtimeTalk(state);
       state.resetToolStream();
       state.requestUpdate?.();
       return;

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -775,6 +775,45 @@ describe("chat pane presentation teardown", () => {
 });
 
 describe("chat pane connection lifecycle", () => {
+  it("fully tears down realtime Talk when the gateway disconnects", () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const stop = vi.fn(() => {
+      expect(state.realtimeTalkSession).toBeNull();
+    });
+    state.realtimeTalkSession = { stop } as unknown as ChatPageHost["realtimeTalkSession"];
+    state.realtimeTalkActive = true;
+    state.realtimeTalkStatus = "listening";
+    state.realtimeTalkDetail = "live";
+    state.realtimeTalkInputLevel.set(0.7);
+    state.realtimeTalkConversation = [
+      { id: "utterance", role: "user", text: "stale", isStreaming: true },
+    ];
+    state.realtimeTalkVideoStream = {} as MediaStream;
+    state.realtimeTalkCameraDevices = [{ deviceId: "camera", label: "Camera" }];
+    state.realtimeTalkVideoCapable = true;
+    state.realtimeTalkVideoPending = true;
+    state.realtimeTalkCameraError = true;
+
+    pane.applyGatewaySnapshot({
+      ...pane.context.gateway.snapshot,
+      phase: "reconnecting",
+      hello: null,
+    });
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(state.realtimeTalkActive).toBe(false);
+    expect(state.realtimeTalkStatus).toBe("idle");
+    expect(state.realtimeTalkDetail).toBeNull();
+    expect(state.realtimeTalkInputLevel.value).toBe(0);
+    expect(state.realtimeTalkConversation).toEqual([]);
+    expect(state.realtimeTalkVideoStream).toBeNull();
+    expect(state.realtimeTalkCameraDevices).toEqual([]);
+    expect(state.realtimeTalkVideoCapable).toBe(false);
+    expect(state.realtimeTalkVideoPending).toBe(false);
+    expect(state.realtimeTalkCameraError).toBe(false);
+  });
+
   it("rehydrates secondary session state after a same-client logical reconnect", () => {
     const client = {
       request: vi.fn(() => new Promise<never>(() => {})),

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -18,6 +18,7 @@ import { createInitialUserMessageHandoff } from "../../app/initial-user-message-
 import type { CatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import "./chat-pane.ts";
+import { attachChatRealtimeActions, createInitialChatRealtimeState } from "./chat-realtime.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
 import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
@@ -201,14 +202,15 @@ export function createTestChatPane(params: {
     sidebarFocusPanelId: "",
     sidebarFocusVersion: 0,
     sidebarLayout: { columns: [] },
+    ...createInitialChatRealtimeState(),
     // Minimal scroll host so scheduleChatScroll is a no-op instead of throwing.
     chatScrollGeneration: 0,
     chatScrollCommitCleanup: null,
     handleChatScroll: vi.fn(),
-    realtimeTalkInputLevel: { set: vi.fn() },
     resetToolStream: vi.fn(),
     renderLifecycle: { afterCommit: () => () => {}, invalidate: () => {} },
   } as unknown as ChatPageHost;
+  attachChatRealtimeActions(state);
   state.updateSidebarLayout = (layout) => {
     state.sidebarLayout = layout;
   };

--- a/ui/src/pages/chat/chat-realtime.test.ts
+++ b/ui/src/pages/chat/chat-realtime.test.ts
@@ -458,6 +458,44 @@ describe("chat realtime actions", () => {
     ]);
   });
 
+  it("clears partial realtime state when session startup fails", async () => {
+    let rejectStart: (error: Error) => void = () => undefined;
+    startSpy.mockImplementationOnce(
+      () =>
+        new Promise<undefined>((_resolve, reject) => {
+          rejectStart = reject;
+        }),
+    );
+    const state = createState();
+
+    const starting = state.toggleRealtimeTalk();
+    await vi.waitFor(() => expect(state.realtimeTalkSession).not.toBeNull());
+    const session = inspectSession(state);
+    session.callbacks.onStatus?.("listening");
+    session.callbacks.onVideoCapability?.(true);
+    session.callbacks.onInputLevel?.(0.8);
+    session.callbacks.onTranscript?.({ role: "user", text: "partial", final: false });
+    session.callbacks.onVideoStream?.({} as MediaStream);
+    state.realtimeTalkCameraDevices = [{ deviceId: "camera", label: "Camera" }];
+    state.realtimeTalkVideoPending = true;
+    state.realtimeTalkCameraError = true;
+
+    rejectStart(new Error("startup failed"));
+    await starting;
+
+    expect(state.realtimeTalkSession).toBeNull();
+    expect(state.realtimeTalkActive).toBe(false);
+    expect(state.realtimeTalkStatus).toBe("error");
+    expect(state.realtimeTalkDetail).toBe("startup failed");
+    expect(state.realtimeTalkInputLevel.value).toBe(0);
+    expect(state.realtimeTalkConversation).toEqual([]);
+    expect(state.realtimeTalkVideoStream).toBeNull();
+    expect(state.realtimeTalkCameraDevices).toEqual([]);
+    expect(state.realtimeTalkVideoCapable).toBe(false);
+    expect(state.realtimeTalkVideoPending).toBe(false);
+    expect(state.realtimeTalkCameraError).toBe(false);
+  });
+
   it("ignores a stopped session that rejects after its replacement starts", async () => {
     let rejectFirstStart: (error: Error) => void = () => undefined;
     startSpy.mockImplementationOnce(

--- a/ui/src/pages/chat/chat-realtime.test.ts
+++ b/ui/src/pages/chat/chat-realtime.test.ts
@@ -478,14 +478,38 @@ describe("chat realtime actions", () => {
 
     rejectFirstStart(new Error("late setup failure"));
     await firstStart;
+    firstCallbacks.onVideoCapability?.(true);
     firstCallbacks.onInputLevel?.(0.9);
     firstCallbacks.onTranscript?.({ role: "user", text: "stale", final: true });
+    firstCallbacks.onVideoStream?.({} as MediaStream);
+    firstCallbacks.onVideoError?.(new Error("stale camera failure"));
     firstCallbacks.onStatus?.("error", "stale failure");
 
     expect(state.realtimeTalkSession).toBe(secondSession);
     expect(state.realtimeTalkActive).toBe(true);
     expect(state.realtimeTalkStatus).toBe("listening");
+    expect(state.realtimeTalkDetail).toBeNull();
     expect(state.realtimeTalkInputLevel.value).toBe(0);
     expect(state.realtimeTalkConversation).toEqual([]);
+    expect(state.realtimeTalkVideoStream).toBeNull();
+    expect(state.realtimeTalkVideoCapable).toBe(false);
+    expect(state.realtimeTalkCameraError).toBe(false);
+  });
+
+  it("retires callback ownership before stopping a session", async () => {
+    const state = createState();
+    await state.toggleRealtimeTalk();
+    const firstSession = inspectSession(state);
+    const stop = vi
+      .spyOn(RealtimeTalkSession.prototype, "stop")
+      .mockImplementationOnce(() => firstSession.callbacks.onStatus?.("error", "late stop"));
+
+    await state.toggleRealtimeTalk();
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(state.realtimeTalkSession).toBeNull();
+    expect(state.realtimeTalkActive).toBe(false);
+    expect(state.realtimeTalkStatus).toBe("idle");
+    expect(state.realtimeTalkDetail).toBeNull();
   });
 });

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -61,11 +61,10 @@ export function resetChatRealtimeConversation(state: ChatRealtimeState) {
   state.realtimeTalkConversation = [];
 }
 
-export function dismissRealtimeTalkError(state: ChatRealtimeState) {
-  if (state.realtimeTalkStatus !== "error") {
-    return;
-  }
-  state.realtimeTalkSession?.stop();
+export function stopChatRealtimeTalk(state: ChatRealtimeState) {
+  const session = state.realtimeTalkSession;
+  // Retire callback ownership before stop() can synchronously report idle.
+  // Otherwise a closing session can still mutate the newly selected route.
   state.realtimeTalkSession = null;
   state.realtimeTalkActive = false;
   state.realtimeTalkStatus = "idle";
@@ -76,7 +75,15 @@ export function dismissRealtimeTalkError(state: ChatRealtimeState) {
   state.realtimeTalkVideoCapable = false;
   state.realtimeTalkVideoPending = false;
   state.realtimeTalkCameraError = false;
-  state.resetRealtimeTalkConversation();
+  resetChatRealtimeConversation(state);
+  session?.stop();
+}
+
+export function dismissRealtimeTalkError(state: ChatRealtimeState) {
+  if (state.realtimeTalkStatus !== "error") {
+    return;
+  }
+  stopChatRealtimeTalk(state);
 }
 
 export function attachChatRealtimeActions(state: ChatRealtimeState) {
@@ -143,18 +150,7 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
   };
   state.toggleRealtimeTalk = async () => {
     if (state.realtimeTalkSession) {
-      state.realtimeTalkSession.stop();
-      state.realtimeTalkSession = null;
-      state.realtimeTalkActive = false;
-      state.realtimeTalkStatus = "idle";
-      state.realtimeTalkDetail = null;
-      state.realtimeTalkInputLevel.set(0);
-      state.realtimeTalkVideoStream = null;
-      state.realtimeTalkCameraDevices = [];
-      state.realtimeTalkVideoCapable = false;
-      state.realtimeTalkVideoPending = false;
-      state.realtimeTalkCameraError = false;
-      state.resetRealtimeTalkConversation();
+      stopChatRealtimeTalk(state);
       state.requestUpdate();
       return;
     }
@@ -265,8 +261,8 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
       if (state.realtimeTalkSession !== session) {
         return;
       }
-      session.stop();
       state.realtimeTalkSession = null;
+      session.stop();
       state.realtimeTalkActive = false;
       state.realtimeTalkStatus = "error";
       state.realtimeTalkDetail = error instanceof Error ? error.message : String(error);

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -56,7 +56,7 @@ export function createInitialChatRealtimeState() {
   };
 }
 
-export function resetChatRealtimeConversation(state: ChatRealtimeState) {
+function resetChatRealtimeConversation(state: ChatRealtimeState) {
   state.realtimeTalkConversationState = createRealtimeTalkConversationState();
   state.realtimeTalkConversation = [];
 }

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -261,17 +261,10 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
       if (state.realtimeTalkSession !== session) {
         return;
       }
-      state.realtimeTalkSession = null;
-      session.stop();
-      state.realtimeTalkActive = false;
+      const detail = error instanceof Error ? error.message : String(error);
+      stopChatRealtimeTalk(state);
       state.realtimeTalkStatus = "error";
-      state.realtimeTalkDetail = error instanceof Error ? error.message : String(error);
-      state.realtimeTalkInputLevel.set(0);
-      state.realtimeTalkVideoStream = null;
-      state.realtimeTalkCameraDevices = [];
-      state.realtimeTalkVideoCapable = false;
-      state.realtimeTalkVideoPending = false;
-      state.realtimeTalkCameraError = false;
+      state.realtimeTalkDetail = detail;
       state.requestUpdate();
     }
   };

--- a/ui/src/pages/chat/chat-state-controller.ts
+++ b/ui/src/pages/chat/chat-state-controller.ts
@@ -2,6 +2,7 @@ import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import { disposeSelectedSessionMessageSubscription } from "./chat-history.ts";
 import { subscribeChatOutboxProjection } from "./chat-queue.ts";
+import { stopChatRealtimeTalk } from "./chat-realtime.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { invalidateImageLightbox } from "./chat-state-page.ts";
 import { cancelChatStreamRenderFrame } from "./chat-state-render.ts";
@@ -82,6 +83,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
       this.composerPersistence.stop();
       cancelChatStreamRenderFrame(this.stateValue);
       cancelChatScroll(this.stateValue);
+      stopChatRealtimeTalk(this.stateValue);
     }
     this.stateValue = state;
     this.previousChatLoading = state.chatLoading;
@@ -368,15 +370,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
       cancelChatScroll(state);
       invalidateImageLightbox(state);
       clearSessionWorkspaceTimers(state);
-    }
-    state?.realtimeTalkSession?.stop();
-    if (state) {
-      state.realtimeTalkSession = null;
-      state.realtimeTalkVideoStream = null;
-      state.realtimeTalkCameraDevices = [];
-      state.realtimeTalkVideoCapable = false;
-      state.realtimeTalkVideoPending = false;
-      state.realtimeTalkCameraError = false;
+      stopChatRealtimeTalk(state);
       state.resetToolStream?.();
     }
   }

--- a/ui/src/pages/chat/chat-state-route.ts
+++ b/ui/src/pages/chat/chat-state-route.ts
@@ -19,7 +19,7 @@ import {
   uiSessionRowMatchesSelectedChat,
 } from "../../lib/sessions/session-key.ts";
 import { syncVisibleChatQueueProjection } from "./chat-queue.ts";
-import { resetChatRealtimeConversation } from "./chat-realtime.ts";
+import { stopChatRealtimeTalk } from "./chat-realtime.ts";
 import { refreshCurrentChatSessionList } from "./chat-session.ts";
 import type { ChatComposerMemoryFallback, ChatPageHost } from "./chat-state-host.ts";
 import { invalidateImageLightbox } from "./chat-state-page.ts";
@@ -253,6 +253,7 @@ export function resetChatStateForRouteSession(
   } = {},
 ): ChatComposerRouteResetResult {
   cancelChatStreamRenderFrame(state);
+  stopChatRealtimeTalk(state);
   const previousSessionKey = state.sessionKey;
   const previousComposerScopeKey = storedChatOutboxScopeKey(
     options.previousComposerScope ?? resolveStoredChatOutboxScope(state, previousSessionKey),
@@ -321,7 +322,6 @@ export function resetChatStateForRouteSession(
   state.chatAvatarStatus = null;
   state.chatAvatarReason = null;
   clearAuthoritativeTerminal(state);
-  resetChatRealtimeConversation(state);
   state.chatQueue = restoreChatQueueForSession(state, sessionKey);
   restoreChatComposerState(state);
   // Composer hydration reads crash-safe queue states. Reapply the process-live

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -17,6 +17,7 @@ import {
   subscribeChatOutboxProjection,
   updateQueuedMessageForSession,
 } from "./chat-queue.ts";
+import { createInitialChatRealtimeState } from "./chat-realtime.ts";
 import { ChatStateController } from "./chat-state-controller.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
@@ -912,6 +913,68 @@ describe("ChatStateController render lifecycle", () => {
     expect(effect).not.toHaveBeenCalled();
   });
 
+  it("fully tears down realtime Talk when its state owner disconnects", () => {
+    const host = {
+      addController: () => undefined,
+      removeController: () => undefined,
+      requestUpdate: () => undefined,
+      updateComplete: Promise.resolve(true),
+    } satisfies ReactiveControllerHost;
+    const controller = new ChatStateController<ChatPageHost>(host);
+    controller.hostConnected();
+    const renderLifecycle = controller.createRenderLifecycle();
+    const context = {
+      agents: {
+        state: { agentsList: null },
+        adoptList: vi.fn(),
+      },
+      agentSelection: { state: { selectedId: "main" } },
+      basePath: "",
+      config: {
+        current: {
+          allowExternalEmbedUrls: false,
+          assistantIdentity: { name: "Assistant" },
+          embedSandboxMode: "scripts",
+          localMediaPreviewRoots: [],
+        },
+      },
+      initialUserMessage: createInitialUserMessageHandoff(),
+      sessions: {},
+    } as unknown as ApplicationContext;
+    const state = createPageState(context, renderLifecycle, { querySelector: () => null });
+    const stop = vi.fn(() => {
+      expect(state.realtimeTalkSession).toBeNull();
+    });
+    state.realtimeTalkSession = { stop } as unknown as ChatPageHost["realtimeTalkSession"];
+    state.realtimeTalkActive = true;
+    state.realtimeTalkStatus = "listening";
+    state.realtimeTalkDetail = "live";
+    state.realtimeTalkInputLevel.set(0.8);
+    state.realtimeTalkConversation = [
+      { id: "utterance", role: "user", text: "stale", isStreaming: true },
+    ];
+    state.realtimeTalkVideoStream = {} as MediaStream;
+    state.realtimeTalkCameraDevices = [{ deviceId: "camera", label: "Camera" }];
+    state.realtimeTalkVideoCapable = true;
+    state.realtimeTalkVideoPending = true;
+    state.realtimeTalkCameraError = true;
+    controller.attach(state);
+
+    controller.hostDisconnected();
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(state.realtimeTalkActive).toBe(false);
+    expect(state.realtimeTalkStatus).toBe("idle");
+    expect(state.realtimeTalkDetail).toBeNull();
+    expect(state.realtimeTalkInputLevel.value).toBe(0);
+    expect(state.realtimeTalkConversation).toEqual([]);
+    expect(state.realtimeTalkVideoStream).toBeNull();
+    expect(state.realtimeTalkCameraDevices).toEqual([]);
+    expect(state.realtimeTalkVideoCapable).toBe(false);
+    expect(state.realtimeTalkVideoPending).toBe(false);
+    expect(state.realtimeTalkCameraError).toBe(false);
+  });
+
   it("aborts attachment reads when a pane adopts a different session", () => {
     const host = {
       addController: () => undefined,
@@ -1324,8 +1387,7 @@ describe("route composer fallback", () => {
       toolStreamById: new Map(),
       toolStreamOrder: [],
       sessionsResult: null,
-      realtimeTalkConversation: [],
-      realtimeTalkConversationState: { phase: "idle" },
+      ...createInitialChatRealtimeState(),
       resetChatInputHistoryNavigation,
       resetChatScroll,
       requestUpdate: vi.fn(),
@@ -1346,6 +1408,43 @@ describe("route composer fallback", () => {
 
     expect(release).toHaveBeenCalledTimes(1);
     expect(state.imageLightbox).toBeNull();
+  });
+
+  it("retires realtime Talk before adopting the next route", () => {
+    const { state } = createRouteState("");
+    const previousSessionKey = state.sessionKey;
+    const stop = vi.fn(() => {
+      expect(state.realtimeTalkSession).toBeNull();
+      expect(state.sessionKey).toBe(previousSessionKey);
+    });
+    state.realtimeTalkSession = { stop } as unknown as ChatPageHost["realtimeTalkSession"];
+    state.realtimeTalkActive = true;
+    state.realtimeTalkStatus = "listening";
+    state.realtimeTalkDetail = "live";
+    state.realtimeTalkInputLevel.set(0.6);
+    state.realtimeTalkConversation = [
+      { id: "utterance", role: "assistant", text: "stale", isStreaming: true },
+    ];
+    state.realtimeTalkVideoStream = {} as MediaStream;
+    state.realtimeTalkCameraDevices = [{ deviceId: "camera", label: "Camera" }];
+    state.realtimeTalkVideoCapable = true;
+    state.realtimeTalkVideoPending = true;
+    state.realtimeTalkCameraError = true;
+
+    resetChatStateForRouteSession(state, "agent:main:second");
+
+    expect(stop).toHaveBeenCalledOnce();
+    expect(state.sessionKey).toBe("agent:main:second");
+    expect(state.realtimeTalkActive).toBe(false);
+    expect(state.realtimeTalkStatus).toBe("idle");
+    expect(state.realtimeTalkDetail).toBeNull();
+    expect(state.realtimeTalkInputLevel.value).toBe(0);
+    expect(state.realtimeTalkConversation).toEqual([]);
+    expect(state.realtimeTalkVideoStream).toBeNull();
+    expect(state.realtimeTalkCameraDevices).toEqual([]);
+    expect(state.realtimeTalkVideoCapable).toBe(false);
+    expect(state.realtimeTalkVideoPending).toBe(false);
+    expect(state.realtimeTalkCameraError).toBe(false);
   });
 
   it("clears transient detail content on a route switch", () => {


### PR DESCRIPTION
Closes #116064

## What Problem This Solves

Fixes an issue where switching chat sessions while Realtime Talk was active could leave the microphone and provider transport bound to the previous session. The newly selected session could then display stale Talk status, transcript, input, camera, or video updates.

## Why This Change Was Made

Centralizes complete Talk teardown across session navigation, Gateway disconnects, pane disposal, manual stops, and startup failures. Callback ownership is retired before stopping the session so synchronous or late callbacks cannot mutate replacement state.

This does not change the Gateway protocol or other clients.

## User Impact

Switching sessions or losing the pane or Gateway connection now stops active Talk media and clears its state. Updates from a previous Talk session can no longer appear in the newly selected chat.

## Evidence

- 112 focused tests passed across:
  - `chat-realtime.test.ts`
  - `chat-state.test.ts`
  - `chat-pane-lifecycle.test.ts`
- Review correction passed 24 focused Talk tests.
- UI and core-test typechecks passed.
- Targeted lint, dead-export scan, formatting, i18n verification, and changelog attribution passed.
- Final Codex autoreview reported no accepted or actionable findings.
- Blacksmith Testbox: `tbx_01kyqphcmehf72909ngaeprh0k`
