### PR TITLE
fix(macos): prevent Dev setup timing out during cold builds

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30291,7 +30291,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 419,
+      "line": 429,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "Repairing the OpenClaw Gateway update…",
       "surface": "apple",
@@ -30299,7 +30299,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 420,
+      "line": 430,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "Updating the OpenClaw Gateway to \\(targetVersion)…",
       "surface": "apple",
@@ -30307,7 +30307,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 441,
+      "line": 451,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "Gateway update needs attention.",
       "surface": "apple",
@@ -30315,7 +30315,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 443,
+      "line": 453,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "Gateway update failed.",
       "surface": "apple",
@@ -30323,7 +30323,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 458,
+      "line": 468,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "Gateway update finished, but verification failed.",
       "surface": "apple",
@@ -30331,7 +30331,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 465,
+      "line": 475,
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "OpenClaw Gateway \\(installedVersion) is installed.",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/CLIInstaller.swift
+++ b/apps/macos/Sources/OpenClaw/CLIInstaller.swift
@@ -334,7 +334,11 @@ enum CLIInstaller {
             target: target,
             prefix: prefix,
             scriptPath: installerURL.path)
-        let response = await ShellExecutor.runDetailed(command: cmd, cwd: nil, env: nil, timeout: 900)
+        let response = await ShellExecutor.runDetailed(
+            command: cmd,
+            cwd: nil,
+            env: nil,
+            timeout: self.installWatchdogTimeout(for: target))
 
         if response.success {
             let expectedVersion = target.requiresExactVersion ? GatewayEnvironment.appVersionString() : nil
@@ -362,6 +366,12 @@ enum CLIInstaller {
         let fallback = response.errorMessage ?? "install failed"
         await statusHandler("Install failed: \(detail.isEmpty ? fallback : detail)")
         return false
+    }
+
+    static func installWatchdogTimeout(for target: InstallTarget) -> TimeInterval {
+        // Dev installs clone/fetch source, install dependencies, and build the UI
+        // plus CLI. Keep that workflow bounded without killing healthy cold builds.
+        target == .channel(.dev) ? 7200 : 900
     }
 
     private static func installPrefix() -> String {

--- a/apps/macos/Tests/OpenClawIPCTests/CLIInstallerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CLIInstallerTests.swift
@@ -67,6 +67,13 @@ struct CLIInstallerTests {
         ])
     }
 
+    @Test func `dev source installs allow a full cold build`() {
+        #expect(CLIInstaller.installWatchdogTimeout(for: .channel(.dev)) == 7200)
+        #expect(CLIInstaller.installWatchdogTimeout(for: .channel(.stable)) == 900)
+        #expect(CLIInstaller.installWatchdogTimeout(for: .channel(.beta)) == 900)
+        #expect(CLIInstaller.installWatchdogTimeout(for: .exact(String())) == 900)
+    }
+
     @Test func `managed update uses the canonical updater without accepting downgrades`() {
         let command = CLIInstaller.managedUpdateCommand(
             executable: "/Users/Test User/.openclaw/bin/openclaw",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing the Dev gateway from the native macOS app could have a healthy cold source checkout and build terminated after 15 minutes. The setup UI then reported the bundled `install-cli.sh` process as `Terminated: 15`.

## Why This Change Was Made

Dev installs clone or update the source checkout, install dependencies, build the Control UI, and build the CLI, so they now use the same two-hour aggregate watchdog as managed source updates. Stable, beta, and exact-version package installs retain the existing 15-minute watchdog.

## User Impact

Native macOS Dev setup can complete on cold or slower machines without being killed during a healthy build, while every install path remains bounded.

## Evidence

- Reproduced from the native setup failure: the app terminated the bundled installer subprocess after its 900-second watchdog.
- `swift test --package-path apps/macos --filter CLIInstallerTests`: 15 tests passed.
- `node --import tsx scripts/native-app-i18n.ts verify`: source inventory and generated locale parity inputs are current.
- SwiftFormat lint: clean for both changed files.
- SwiftLint strict: clean for both changed files.
- `git diff --check`: clean.
- Fresh whole-branch autoreview: no accepted/actionable findings, overall confidence 0.96.

## Release Note

Fixed macOS Dev gateway setup timing out during a healthy cold source build.
