### PR TITLE
fix(plugins): keep next-turn injections callable after register

### DIFF
--- a/src/plugins/api-lifecycle.test.ts
+++ b/src/plugins/api-lifecycle.test.ts
@@ -1,0 +1,61 @@
+// Plugin API lifecycle guard: registration-only methods stop working once
+// register() returns, runtime-phase methods keep working from hooks.
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { buildPluginApi } from "./api-builder.js";
+import type { PluginNextTurnInjection } from "./host-hooks.js";
+import { runPluginRegisterSync } from "./loader-module-runtime.js";
+import type { PluginRuntime } from "./runtime/types.js";
+import type { OpenClawPluginApi } from "./types.js";
+
+function captureRegisteredPluginApi(handlers: Parameters<typeof buildPluginApi>[0]["handlers"]) {
+  const api = buildPluginApi({
+    id: "late-call-fixture",
+    name: "Late Call Fixture",
+    source: "test",
+    registrationMode: "full",
+    config: {} as OpenClawConfig,
+    runtime: {} as PluginRuntime,
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    resolvePath: (input) => input,
+    handlers,
+  });
+  let captured: OpenClawPluginApi | undefined;
+  runPluginRegisterSync((pluginApi) => {
+    captured = pluginApi;
+  }, api);
+  return expectDefined(captured, "captured plugin api");
+}
+
+describe("plugin api lifecycle", () => {
+  it("keeps next-turn injections callable after registration", async () => {
+    const injections: PluginNextTurnInjection[] = [];
+    const api = captureRegisteredPluginApi({
+      enqueueNextTurnInjection: async (injection) => {
+        injections.push(injection);
+        return { enqueued: true, id: "injection-1", sessionKey: injection.sessionKey };
+      },
+    });
+
+    const result = await api.session.workflow.enqueueNextTurnInjection({
+      sessionKey: "agent:main:main",
+      text: "resume approval workflow",
+    });
+
+    expect(result).toEqual({ enqueued: true, id: "injection-1", sessionKey: "agent:main:main" });
+    expect(injections).toHaveLength(1);
+  });
+
+  it("blocks registration-phase methods after registration", () => {
+    const registered: string[] = [];
+    const api = captureRegisteredPluginApi({
+      registerSessionExtension: (extension) => {
+        registered.push(extension.namespace);
+      },
+    });
+
+    api.session.state.registerSessionExtension({ namespace: "workflow", description: "workflow" });
+    expect(registered).toEqual([]);
+  });
+});

--- a/src/plugins/api-lifecycle.ts
+++ b/src/plugins/api-lifecycle.ts
@@ -19,6 +19,7 @@ type PluginApiLifecyclePolicy = {
 
 const PLUGIN_API_METHOD_POLICIES: Partial<Record<PluginApiMethodName, PluginApiLifecyclePolicy>> = {
   emitAgentEvent: { phase: "runtime", lateCallable: true },
+  enqueueNextTurnInjection: { phase: "runtime", lateCallable: true },
   sendSessionAttachment: { phase: "runtime", lateCallable: true },
   scheduleSessionTurn: { phase: "runtime", lateCallable: true },
   unscheduleSessionTurnsByTag: { phase: "runtime", lateCallable: true },


### PR DESCRIPTION
Fixes #115812

`runPluginRegisterSync` wraps the plugin API in a guard proxy that returns `undefined` for any API method a plugin calls after its `register()` returns, unless the method is marked late-callable in `PLUGIN_API_METHOD_POLICIES` (`src/plugins/api-lifecycle.ts`). `enqueueNextTurnInjection` is a runtime-phase method that plugins are documented to call from hooks, but it was never added to that table, so every hook-time call resolved to `undefined` and never reached `enqueuePluginNextTurnInjection`. The runtime methods bundled plugins call (`emitAgentEvent`, `sendSessionAttachment`, `scheduleSessionTurn`, `unscheduleSessionTurnsByTag`) are all listed, which is why only this seam broke.

The fix is one policy entry. Both `api.session.workflow.enqueueNextTurnInjection(...)` and the deprecated flat alias go through the same guard, which matches the reporter's observation that both were functions and both returned `undefined`.

Verified on Linux (Node 24.18):

- New `src/plugins/api-lifecycle.test.ts` captures the API inside `register()` and calls it afterwards. Before the change it fails with `expected undefined to deeply equal { enqueued: true, ... }`; after, it passes and the host handler receives the injection. A second case pins the guard's actual purpose: a registration-phase method stays blocked after registration.
- Existing suites: `src/plugins/loader.test.ts` (179 tests), `src/plugins/contracts/host-hooks.contract.test.ts` (64 tests), `src/plugins/captured-registration.test.ts`, `src/plugins/compat/registry.test.ts`. Typecheck (`tsgo` core and core-test), oxlint, and oxfmt are clean.

Not verified: no live gateway run, so the reporter's end state (queued records moving to `injected`) is not confirmed here. In a loader-level scratch run I could see the behavior change at the seam, before the fix the plugin's hook got `undefined`, after it got the real core result object, but I could not get a session entry to resolve in that ad hoc fixture, so persistence end to end rests on the existing host-hook contract tests. I also did not change the run-context methods (`setRunContext` / `getRunContext` / `clearRunContext`), which are documented as per-run state and look like they have the same gap; no caller or reported failure for them, so they are left alone.

Reported by @dailylights, with a clear trace that narrowed this to the core call returning `undefined` rather than the plugin's call site.