### PR TITLE
fix(memory): keep degraded status actionable

### DIFF
--- a/extensions/memory-core/doctor-contract-api.ts
+++ b/extensions/memory-core/doctor-contract-api.ts
@@ -5,10 +5,12 @@ import {
   memorySidecarStateMigration,
   qmdLocksStateMigration,
 } from "./src/migration/doctor-memory-sidecar.js";
+import { vectorIndexProviderDiagnostic } from "./src/migration/doctor-vector-index-provider.js";
 
 export const stateMigrations: PluginDoctorStateMigration[] = [
   hostEventsStateMigration,
   dreamingStateMigration,
   memorySidecarStateMigration,
   qmdLocksStateMigration,
+  vectorIndexProviderDiagnostic,
 ];

--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -30,16 +30,60 @@ type MemoryManagerPurpose = Parameters<typeof getMemorySearchManager>[0]["purpos
 function getMemoryCommandSecretTargetIds(): Set<string> {
   return new Set(["memory.search.remote.apiKey", "agents.entries.*.memory.search.remote.apiKey"]);
 }
-async function loadMemoryCommandConfig(commandName: string) {
-  const { resolvedConfig, diagnostics } = await resolveCommandSecretRefsViaGateway({
-    config: getRuntimeConfig(),
-    commandName,
-    targetIds: getMemoryCommandSecretTargetIds(),
-  });
-  return {
-    config: resolvedConfig,
-    diagnostics,
-  };
+function isMemorySecretOwnerFailure(error: unknown, message: string): boolean {
+  const candidate = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
+  if (
+    candidate.ownerKind === "capability" &&
+    typeof candidate.ownerId === "string" &&
+    candidate.ownerId.startsWith("memory-provider:")
+  ) {
+    return true;
+  }
+  if (
+    Array.isArray(candidate.paths) &&
+    candidate.paths.some(
+      (entry) => typeof entry === "string" && entry.includes("memory.search.remote.apiKey"),
+    )
+  ) {
+    return true;
+  }
+  // Gateway RPC errors preserve the typed owner's redacted message even when
+  // structured owner fields are unavailable to the CLI process.
+  return message.includes("capability:memory-provider:");
+}
+async function loadMemoryCommandConfig(
+  commandName: string,
+  mode?: "enforce_resolved" | "read_only_status",
+) {
+  const config = getRuntimeConfig();
+  try {
+    const { resolvedConfig, diagnostics } = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName,
+      targetIds: getMemoryCommandSecretTargetIds(),
+      ...(mode ? { mode } : {}),
+    });
+    return { config: resolvedConfig, diagnostics };
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error
+        ? String((error as { code?: unknown }).code)
+        : "";
+    const message = formatErrorMessage(error);
+    if (
+      mode !== "read_only_status" ||
+      isMemorySecretOwnerFailure(error, message) ||
+      (code !== "SECRET_SURFACE_UNAVAILABLE" && !message.includes("SECRET_SURFACE_UNAVAILABLE"))
+    ) {
+      throw error;
+    }
+    return {
+      config,
+      diagnostics: [
+        `${commandName}: ${message}; continuing with degraded read-only config so healthy memory surfaces remain visible.`,
+      ],
+    };
+  }
 }
 function emitMemorySecretResolveDiagnostics(
   diagnostics: string[],
@@ -155,7 +199,10 @@ export async function withMemoryCommand(params: {
   withLease?: PluginStateLeaseRunner;
   run: (context: { manager: MemoryManager; cfg: OpenClawConfig; agentId: string }) => Promise<void>;
 }): Promise<OpenClawConfig> {
-  const { config: cfg, diagnostics } = await loadMemoryCommandConfig(params.commandName);
+  const { config: cfg, diagnostics } = await loadMemoryCommandConfig(
+    params.commandName,
+    params.purpose === "status" ? "read_only_status" : undefined,
+  );
   emitMemorySecretResolveDiagnostics(diagnostics, { json: params.diagnosticsToStderr });
   const agentIds = params.allAgents
     ? resolveAgentIds(cfg, params.agent)

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -507,6 +507,34 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it("still aborts status when its own memory SecretRef cannot be resolved", async () => {
+    getRuntimeConfig.mockReturnValue({
+      memory: {
+        search: {
+          remote: {
+            apiKey: { source: "env", provider: "default", id: "MISSING_MEMORY_API_KEY" },
+          },
+        },
+      },
+    });
+    resolveCommandSecretRefsViaGateway.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          "Secret owner capability:memory-provider:main is configured but unavailable: code=SECRET_SURFACE_UNAVAILABLE",
+        ),
+        {
+          code: "SECRET_SURFACE_UNAVAILABLE",
+          ownerKind: "capability",
+          ownerId: "memory-provider:main",
+          paths: ["memory.search.remote.apiKey"],
+        },
+      ),
+    );
+
+    await expect(runMemoryCli(["status", "--deep"])).rejects.toThrow("SECRET_SURFACE_UNAVAILABLE");
+    expect(getMemorySearchManager).not.toHaveBeenCalled();
+  });
+
   it("prints index identity mismatch reasons", async () => {
     const close = vi.fn(async () => {});
     mockManager({
@@ -603,12 +631,51 @@ describe("memory cli", () => {
     const secretRefsCall = firstMockCallArg(
       resolveCommandSecretRefsViaGateway,
       "resolve command secret refs",
-    ) as { config?: unknown; commandName?: unknown; targetIds?: unknown };
+    ) as { config?: unknown; commandName?: unknown; targetIds?: unknown; mode?: unknown };
     expect(secretRefsCall.config).toBe(config);
     expect(secretRefsCall.commandName).toBe("memory status");
     expect(secretRefsCall.targetIds).toStrictEqual(
       new Set(["memory.search.remote.apiKey", "agents.entries.*.memory.search.remote.apiKey"]),
     );
+    expect(secretRefsCall.mode).toBe("read_only_status");
+  });
+
+  it("keeps status available when a memory SecretRef owner is degraded", async () => {
+    const close = vi.fn(async () => {});
+    getRuntimeConfig.mockReturnValue({
+      memory: {
+        search: {
+          remote: {
+            apiKey: { source: "env", provider: "default", id: "HEALTHY_MEMORY_API_KEY" },
+          },
+        },
+      },
+    });
+    resolveCommandSecretRefsViaGateway.mockRejectedValueOnce(
+      Object.assign(
+        new Error(
+          "Secret owner agent:main:openai:manual is configured but unavailable: code=SECRET_SURFACE_UNAVAILABLE",
+        ),
+        { code: "SECRET_SURFACE_UNAVAILABLE" },
+      ),
+    );
+    mockManager({
+      probeVectorAvailability: vi.fn(async () => true),
+      probeEmbeddingAvailability: vi.fn(async () => ({
+        ok: false,
+        error: "embedding provider unavailable",
+      })),
+      status: () => makeMemoryStatus({ workspaceDir: undefined }),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status", "--deep"]);
+
+    expect(loggedOutput(log)).toContain("agent:main:openai:manual");
+    expect(loggedOutput(log)).toContain("healthy memory surfaces remain visible");
+    expect(loggedOutput(log)).toContain("Embeddings: unavailable");
+    expect(close).toHaveBeenCalled();
   });
 
   it("logs gateway secret diagnostics for non-json status output", async () => {

--- a/extensions/memory-core/src/migration/doctor-vector-index-provider.test-support.ts
+++ b/extensions/memory-core/src/migration/doctor-vector-index-provider.test-support.ts
@@ -1,0 +1,31 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import "./doctor-vector-index-provider.js";
+
+type TestApi = {
+  setInspectConfiguredProviderForTest(
+    inspect: (params: {
+      config: OpenClawConfig;
+      agentId: string;
+      env: NodeJS.ProcessEnv;
+      agentDatabasePath: string;
+    }) => Promise<{ provider: string; reason: string } | null>,
+  ): void;
+  reset(): void;
+};
+
+function getTestApi(): TestApi {
+  return (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.memoryCoreVectorIndexProviderDiagnosticTestApi")
+  ] as TestApi;
+}
+
+export const vectorIndexProviderDiagnosticTesting = {
+  setInspectConfiguredProviderForTest(
+    inspect: Parameters<TestApi["setInspectConfiguredProviderForTest"]>[0],
+  ): void {
+    getTestApi().setInspectConfiguredProviderForTest(inspect);
+  },
+  reset(): void {
+    getTestApi().reset();
+  },
+};

--- a/extensions/memory-core/src/migration/doctor-vector-index-provider.test.ts
+++ b/extensions/memory-core/src/migration/doctor-vector-index-provider.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
+import { afterEach, describe, expect, it } from "vitest";
+import { vectorIndexProviderDiagnostic } from "./doctor-vector-index-provider.js";
+import { vectorIndexProviderDiagnosticTesting } from "./doctor-vector-index-provider.test-support.js";
+
+const roots = new Set<string>();
+
+afterEach(async () => {
+  vectorIndexProviderDiagnosticTesting.reset();
+  await Promise.all([...roots].map((root) => fs.rm(root, { recursive: true, force: true })));
+  roots.clear();
+});
+
+describe("memory vector index provider doctor diagnostic", () => {
+  it("reports a protected semantic index when the configured provider cannot bootstrap", async () => {
+    vectorIndexProviderDiagnosticTesting.setInspectConfiguredProviderForTest(async () => ({
+      provider: "openai",
+      reason: "OpenAI API key missing",
+    }));
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-vector-doctor-"));
+    roots.add(stateDir);
+    const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await fs.mkdir(path.dirname(agentPath), { recursive: true });
+    const db = new DatabaseSync(agentPath);
+    db.exec("CREATE TABLE memory_index_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL) STRICT");
+    db.prepare("INSERT INTO memory_index_meta (key, value) VALUES (?, ?)").run(
+      "memory_index_meta_v1",
+      JSON.stringify({ model: "text-embedding-3-small", vectorDims: 1536 }),
+    );
+    db.close();
+    const config = {
+      memory: {},
+      agents: { entries: {} },
+    } satisfies OpenClawConfig;
+    const params = {
+      config,
+      env: { OPENCLAW_STATE_DIR: stateDir },
+      stateDir,
+      oauthDir: path.join(stateDir, "oauth"),
+      context: {} as PluginDoctorStateMigrationContext,
+    };
+
+    const preview = await vectorIndexProviderDiagnostic.detectLegacyState(params);
+    const result = await vectorIndexProviderDiagnostic.migrateLegacyState(params);
+
+    expect(preview?.preview.join("\n")).toContain(
+      "Memory index for agent main uses vector model text-embedding-3-small",
+    );
+    expect(preview?.preview.join("\n")).toContain("memory.search.remote.apiKey");
+    expect(preview?.preview.join("\n")).toContain("memory.search.provider");
+    expect(preview?.preview.join("\n")).toContain(
+      "Memory sync will abort rather than overwrite this semantic index with FTS-only data",
+    );
+    expect(result).toEqual({
+      changes: [],
+      warnings: [expect.stringContaining('embedding provider "openai" cannot initialize')],
+    });
+
+    await expect(
+      vectorIndexProviderDiagnostic.detectLegacyState({
+        ...params,
+        config: { ...config, memory: { backend: "qmd" } },
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      vectorIndexProviderDiagnostic.detectLegacyState({
+        ...params,
+        config: {
+          ...config,
+          memory: {
+            search: {
+              remote: {
+                apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+              },
+            },
+          },
+        },
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/extensions/memory-core/src/migration/doctor-vector-index-provider.ts
+++ b/extensions/memory-core/src/migration/doctor-vector-index-provider.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
+import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 
 const MEMORY_INDEX_META_KEY = "memory_index_meta_v1";
 
@@ -89,9 +89,9 @@ function readExistingVectorModel(databasePath: string): string | null {
   if (!fs.existsSync(databasePath)) {
     return null;
   }
-  let db: DatabaseSync | undefined;
+  let db: ReturnType<typeof openNodeSqliteDatabase> | undefined;
   try {
-    db = new DatabaseSync(databasePath, { readOnly: true });
+    db = openNodeSqliteDatabase(databasePath, { readOnly: true });
     const row = db
       .prepare("SELECT value FROM memory_index_meta WHERE key = ?")
       .get(MEMORY_INDEX_META_KEY) as { value?: unknown } | undefined;

--- a/extensions/memory-core/src/migration/doctor-vector-index-provider.ts
+++ b/extensions/memory-core/src/migration/doctor-vector-index-provider.ts
@@ -1,0 +1,196 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor";
+
+const MEMORY_INDEX_META_KEY = "memory_index_meta_v1";
+
+type ProviderFailure = { provider: string; reason: string };
+type VectorProviderFinding = ProviderFailure & {
+  agentId: string;
+  model: string;
+  configPrefix: string;
+};
+
+async function inspectConfiguredProvider(params: {
+  config: OpenClawConfig;
+  agentId: string;
+  env: NodeJS.ProcessEnv;
+  agentDatabasePath: string;
+}): Promise<ProviderFailure | null> {
+  const [{ resolveAgentConfig }, foundation, embeddings, providerState] = await Promise.all([
+    import("openclaw/plugin-sdk/agent-runtime"),
+    import("openclaw/plugin-sdk/memory-core-host-engine-foundation"),
+    import("../memory/embeddings.js"),
+    import("../memory/manager-provider-state.js"),
+  ]);
+  let settings: ReturnType<typeof foundation.resolveMemorySearchConfig>;
+  try {
+    settings = foundation.resolveMemorySearchConfig(params.config, params.agentId);
+  } catch (error) {
+    return {
+      provider: params.config.memory?.search?.provider ?? "openai",
+      reason: formatErrorMessage(error),
+    };
+  }
+  if (!settings || settings.provider === "none") {
+    return null;
+  }
+  try {
+    const configuredAgentDir = resolveAgentConfig(params.config, params.agentId)?.agentDir?.trim();
+    const result = await embeddings.createEmbeddingProvider({
+      config: params.config,
+      agentDir: configuredAgentDir
+        ? foundation.resolveUserPath(configuredAgentDir, params.env)
+        : path.dirname(params.agentDatabasePath),
+      ...providerState.resolveMemoryPrimaryProviderRequest({ settings }),
+    });
+    await result.provider?.close?.();
+    return result.provider
+      ? null
+      : {
+          provider: settings.provider,
+          reason: result.providerUnavailableReason ?? "provider did not initialize",
+        };
+  } catch (error) {
+    return { provider: settings.provider, reason: formatErrorMessage(error) };
+  }
+}
+
+const deps = { inspectConfiguredProvider };
+const testing = {
+  setInspectConfiguredProviderForTest(inspect: typeof inspectConfiguredProvider): void {
+    deps.inspectConfiguredProvider = inspect;
+  },
+  reset(): void {
+    deps.inspectConfiguredProvider = inspectConfiguredProvider;
+  },
+};
+
+if (process.env.VITEST || process.env.NODE_ENV === "test") {
+  (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.memoryCoreVectorIndexProviderDiagnosticTestApi")
+  ] = testing;
+}
+
+function listConfiguredAgentIds(config: OpenClawConfig): string[] {
+  const ids = new Set(Object.keys(config.agents?.entries ?? {}));
+  for (const entry of config.agents?.list ?? []) {
+    if (entry.id.trim()) {
+      ids.add(entry.id.trim());
+    }
+  }
+  return ids.size > 0 ? [...ids] : ["main"];
+}
+
+function readExistingVectorModel(databasePath: string): string | null {
+  if (!fs.existsSync(databasePath)) {
+    return null;
+  }
+  let db: DatabaseSync | undefined;
+  try {
+    db = new DatabaseSync(databasePath, { readOnly: true });
+    const row = db
+      .prepare("SELECT value FROM memory_index_meta WHERE key = ?")
+      .get(MEMORY_INDEX_META_KEY) as { value?: unknown } | undefined;
+    const parsed = typeof row?.value === "string" ? JSON.parse(row.value) : null;
+    const model =
+      parsed && typeof parsed === "object" && typeof parsed.model === "string"
+        ? parsed.model.trim()
+        : "";
+    return model && model !== "fts-only" ? model : null;
+  } catch {
+    return null;
+  } finally {
+    db?.close();
+  }
+}
+
+function resolveConfigPrefix(config: OpenClawConfig, agentId: string): string {
+  if (config.agents?.entries?.[agentId]?.memory?.search) {
+    return `agents.entries.${agentId}.memory.search`;
+  }
+  if (config.agents?.list?.find((entry) => entry.id === agentId)?.memory?.search) {
+    return `agents.list[].memory.search (agent id ${agentId})`;
+  }
+  return "memory.search";
+}
+
+function hasConfiguredMemorySecretRef(config: OpenClawConfig, agentId: string): boolean {
+  const agent =
+    config.agents?.entries?.[agentId] ?? config.agents?.list?.find((entry) => entry.id === agentId);
+  const apiKey = agent?.memory?.search?.remote?.apiKey ?? config.memory?.search?.remote?.apiKey;
+  return apiKey !== null && typeof apiKey === "object";
+}
+
+async function collectVectorProviderFindings(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  stateDir: string;
+}): Promise<VectorProviderFinding[]> {
+  if (params.config.memory?.backend === "qmd") {
+    return [];
+  }
+  const findings: VectorProviderFinding[] = [];
+  for (const agentId of listConfiguredAgentIds(params.config)) {
+    // Memory indexes always live in the canonical per-agent state DB; a custom
+    // agentDir affects provider credential lookup, not index storage.
+    const agentDatabasePath = path.join(
+      params.stateDir,
+      "agents",
+      agentId,
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    const model = readExistingVectorModel(agentDatabasePath);
+    if (!model) {
+      continue;
+    }
+    // Status owns SecretRef resolution diagnostics. Doctor must not treat an
+    // unresolved ref object as an API key and report a false provider failure.
+    if (hasConfiguredMemorySecretRef(params.config, agentId)) {
+      continue;
+    }
+    const failure = await deps.inspectConfiguredProvider({
+      config: params.config,
+      agentId,
+      env: params.env,
+      agentDatabasePath,
+    });
+    if (failure) {
+      findings.push({
+        ...failure,
+        agentId,
+        model,
+        configPrefix: resolveConfigPrefix(params.config, agentId),
+      });
+    }
+  }
+  return findings;
+}
+
+function formatFinding(finding: VectorProviderFinding): string {
+  return (
+    `Memory index for agent ${finding.agentId} uses vector model ${finding.model}, but embedding provider ` +
+    `"${finding.provider}" cannot initialize (${finding.reason}). Set ${finding.configPrefix}.remote.apiKey ` +
+    `(for example, to a SecretRef) or choose a working ${finding.configPrefix}.provider. ` +
+    "Memory sync will abort rather than overwrite this semantic index with FTS-only data."
+  );
+}
+
+export const vectorIndexProviderDiagnostic: PluginDoctorStateMigration = {
+  id: "memory-core-vector-index-provider-diagnostic",
+  label: "Memory Core vector index provider readiness",
+  async detectLegacyState(params) {
+    const findings = await collectVectorProviderFindings(params);
+    return findings.length > 0
+      ? { preview: findings.map((finding) => `- ${formatFinding(finding)}`) }
+      : null;
+  },
+  async migrateLegacyState(params) {
+    const findings = await collectVectorProviderFindings(params);
+    return { changes: [], warnings: findings.map(formatFinding) };
+  },
+};

--- a/src/commands/doctor/shared/stale-auth-order.test.ts
+++ b/src/commands/doctor/shared/stale-auth-order.test.ts
@@ -137,6 +137,134 @@ describe("repairStaleConfiguredAuthOrders", () => {
     ]);
   });
 
+  it("repairs an undeclared order id to the only declared profile for that provider", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
+    try {
+      const cfg = {
+        memory: {},
+        auth: {
+          profiles: {
+            "openai:chatgpt-manual": { provider: "openai", mode: "oauth" },
+          },
+          order: { openai: ["openai:manual"] },
+        },
+      } satisfies OpenClawConfig;
+
+      const result = maybeRepairStaleConfiguredAuthOrders({
+        cfg,
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      });
+
+      expect(result.config.auth?.order?.openai).toEqual(["openai:chatgpt-manual"]);
+      expect(result.changes).toEqual([
+        "auth.order.openai: replaced undeclared openai:manual with openai:chatgpt-manual.",
+      ]);
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports an undeclared order id without changing ambiguous provider profiles", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
+    try {
+      const cfg = {
+        memory: {},
+        auth: {
+          profiles: {
+            "openai:chatgpt-manual": { provider: "openai", mode: "oauth" },
+            "openai:api-manual": { provider: "openai", mode: "api_key" },
+          },
+          order: { openai: ["openai:manual"] },
+        },
+      } satisfies OpenClawConfig;
+
+      const preview = collectStaleConfiguredAuthOrderWarnings({
+        cfg,
+        doctorFixCommand: "openclaw doctor --fix",
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      });
+      const result = maybeRepairStaleConfiguredAuthOrders({
+        cfg,
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      });
+
+      expect(result.config).toBe(cfg);
+      expect(result.changes).toEqual([]);
+      expect(preview.join("\n")).toContain(
+        "declared profiles for this provider are ambiguous (openai:chatgpt-manual, openai:api-manual)",
+      );
+      expect(result.warnings?.join("\n")).toContain("Set auth.order.openai explicitly");
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves an undeclared order id backed by a usable stored credential", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
+    try {
+      const cfg = {
+        auth: {
+          profiles: {
+            "openai:chatgpt-manual": { provider: "openai", mode: "oauth" },
+          },
+          order: { openai: ["openai:manual"] },
+        },
+      } satisfies OpenClawConfig;
+      writePersistedAuthProfileStoreRaw(
+        {
+          version: 1,
+          profiles: {
+            "openai:manual": { type: "api_key", provider: "openai", key: "stored-key" },
+          },
+        },
+        path.join(stateDir, "agents", "main", "agent"),
+      );
+
+      const result = maybeRepairStaleConfiguredAuthOrders({
+        cfg,
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      });
+
+      expect(result).toEqual({ config: cfg, changes: [] });
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops undeclared-profile warnings after automatic fallback removes the order", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stale-auth-order-"));
+    try {
+      const cfg = {
+        auth: {
+          profiles: {
+            "openai:chatgpt-manual": { provider: "openai", mode: "oauth" },
+            "openai:api-manual": { provider: "openai", mode: "api_key" },
+          },
+          order: { openai: ["openai:missing"] },
+        },
+      } satisfies OpenClawConfig;
+      writePersistedAuthProfileStoreRaw(
+        {
+          version: 1,
+          profiles: {
+            "openai:fallback": { type: "api_key", provider: "openai", key: "stored-key" },
+          },
+        },
+        path.join(stateDir, "agents", "main", "agent"),
+      );
+
+      const result = maybeRepairStaleConfiguredAuthOrders({
+        cfg,
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      });
+
+      expect(result.config.auth?.order?.openai).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves an explicit empty order", () => {
     const cfg = { auth: { order: { anthropic: [] } } } satisfies OpenClawConfig;
 

--- a/src/commands/doctor/shared/stale-auth-order.ts
+++ b/src/commands/doctor/shared/stale-auth-order.ts
@@ -3,7 +3,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { listAgentIds, resolveAgentDir } from "../../../agents/agent-scope-config.js";
 import { listRuntimeExternalAuthProfiles } from "../../../agents/auth-profiles/external-auth.js";
-import { resolveAuthProfileOrder } from "../../../agents/auth-profiles/order.js";
+import {
+  resolveAuthProfileEligibility,
+  resolveAuthProfileOrder,
+} from "../../../agents/auth-profiles/order.js";
 import {
   coercePersistedAuthProfileStore,
   mergeAuthProfileStores,
@@ -39,6 +42,12 @@ import {
 type StaleConfiguredAuthOrder = {
   provider: string;
   staleProfileCount: number;
+};
+
+type UndeclaredConfiguredAuthOrder = {
+  provider: string;
+  undeclaredProfileIds: string[];
+  declaredProviderProfileIds: string[];
 };
 
 type LoadedAuthStores =
@@ -492,6 +501,90 @@ function removeAuthOrderKeys(cfg: OpenClawConfig, providers: ReadonlySet<string>
   };
 }
 
+function scanUndeclaredConfiguredAuthOrders(
+  cfg: OpenClawConfig,
+  loaded?: Extract<LoadedAuthStores, { status: "ready" }>,
+): UndeclaredConfiguredAuthOrder[] {
+  const order = readValidConfiguredAuthOrder(cfg);
+  if (!order || !hasValidConfiguredAuthProfiles(cfg) || !cfg.auth?.profiles) {
+    return [];
+  }
+  const configuredProfileIds = new Set(Object.keys(cfg.auth.profiles));
+  return Object.entries(order).flatMap(([provider, profileIds]) => {
+    const undeclaredProfileIds = profileIds.filter((profileId) => {
+      if (configuredProfileIds.has(profileId) || loaded?.runtimeProfileIds.has(profileId)) {
+        return false;
+      }
+      return !loaded?.stores.some(
+        (store) => resolveAuthProfileEligibility({ cfg, store, provider, profileId }).eligible,
+      );
+    });
+    if (undeclaredProfileIds.length === 0) {
+      return [];
+    }
+    const canonicalProvider = resolveProviderIdForAuth(provider, { config: cfg });
+    const declaredProviderProfileIds = Object.entries(cfg.auth?.profiles ?? {})
+      .filter(
+        ([, profile]) =>
+          resolveProviderIdForAuth(profile.provider, { config: cfg }) === canonicalProvider,
+      )
+      .map(([profileId]) => profileId);
+    return [{ provider, undeclaredProfileIds, declaredProviderProfileIds }];
+  });
+}
+
+function repairUndeclaredConfiguredAuthOrders(
+  cfg: OpenClawConfig,
+  loaded?: Extract<LoadedAuthStores, { status: "ready" }>,
+): {
+  config: OpenClawConfig;
+  changes: string[];
+  warnings: string[];
+} {
+  const hits = scanUndeclaredConfiguredAuthOrders(cfg, loaded);
+  const order = readValidConfiguredAuthOrder(cfg) ?? {};
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  for (const hit of hits) {
+    if (hit.declaredProviderProfileIds.length !== 1) {
+      const candidates = hit.declaredProviderProfileIds.join(", ") || "none";
+      warnings.push(
+        `- auth.order.${hit.provider} references undeclared ${hit.undeclaredProfileIds.join(", ")}; declared profiles for this provider are ambiguous (${candidates}). Set auth.order.${hit.provider} explicitly.`,
+      );
+      continue;
+    }
+    const replacement = hit.declaredProviderProfileIds[0];
+    if (!replacement) {
+      continue;
+    }
+    const undeclared = new Set(hit.undeclaredProfileIds);
+    order[hit.provider] = [
+      ...new Set(
+        (order[hit.provider] ?? []).map((profileId) =>
+          undeclared.has(profileId) ? replacement : profileId,
+        ),
+      ),
+    ];
+    changes.push(
+      `auth.order.${hit.provider}: replaced undeclared ${hit.undeclaredProfileIds.join(", ")} with ${replacement}.`,
+    );
+  }
+  return {
+    config:
+      changes.length === 0
+        ? cfg
+        : {
+            ...cfg,
+            auth: {
+              ...cfg.auth,
+              order,
+            },
+          },
+    changes,
+    warnings,
+  };
+}
+
 /** Find nonempty config orders that only reference removed profiles. */
 function scanStaleConfiguredAuthOrders(params: {
   cfg: OpenClawConfig;
@@ -582,14 +675,25 @@ export function maybeRepairStaleConfiguredAuthOrders(params: {
   if (!hasNonemptyConfiguredAuthOrder(params.cfg)) {
     return { config: params.cfg, changes: [] };
   }
-  const loaded = loadConfiguredAgentAuthStores(params.cfg, params.env ?? process.env);
-  if (!loaded) {
+  const initialLoaded = loadConfiguredAgentAuthStores(params.cfg, params.env ?? process.env);
+  if (!initialLoaded) {
     return { config: params.cfg, changes: [] };
   }
-  if (loaded.status === "blocked") {
-    return { config: params.cfg, changes: [], warnings: loaded.warnings };
+  if (initialLoaded.status === "blocked") {
+    return { config: params.cfg, changes: [], warnings: initialLoaded.warnings };
   }
-  return repairStaleConfiguredAuthOrders({ cfg: params.cfg, ...loaded });
+  const declaredRepair = repairUndeclaredConfiguredAuthOrders(params.cfg, initialLoaded);
+  const cfg = declaredRepair.config;
+  const staleRepair = repairStaleConfiguredAuthOrders({ cfg, ...initialLoaded });
+  const remainingDeclaredWarnings = repairUndeclaredConfiguredAuthOrders(
+    staleRepair.config,
+    initialLoaded,
+  ).warnings;
+  return {
+    config: staleRepair.config,
+    changes: [...declaredRepair.changes, ...staleRepair.changes],
+    ...(remainingDeclaredWarnings.length > 0 ? { warnings: remainingDeclaredWarnings } : {}),
+  };
 }
 
 /** Build preview warnings for stale config auth orders. */
@@ -608,10 +712,20 @@ export function collectStaleConfiguredAuthOrderWarnings(params: {
   if (loaded.status === "blocked") {
     return loaded.warnings;
   }
-  return scanStaleConfiguredAuthOrders({ cfg: params.cfg, ...loaded }).map(
-    (hit) =>
-      `- auth.order.${hit.provider} references only missing profiles while compatible stored credentials exist; run ${params.doctorFixCommand} to remove the stale override and restore automatic selection.`,
-  );
+  const declaredWarnings = scanUndeclaredConfiguredAuthOrders(params.cfg, loaded).map((hit) => {
+    if (hit.declaredProviderProfileIds.length === 1) {
+      return `- auth.order.${hit.provider} references undeclared ${hit.undeclaredProfileIds.join(", ")}; run ${params.doctorFixCommand} to replace it with ${hit.declaredProviderProfileIds[0]}.`;
+    }
+    const candidates = hit.declaredProviderProfileIds.join(", ") || "none";
+    return `- auth.order.${hit.provider} references undeclared ${hit.undeclaredProfileIds.join(", ")}; declared profiles for this provider are ambiguous (${candidates}). Set auth.order.${hit.provider} explicitly.`;
+  });
+  return [
+    ...declaredWarnings,
+    ...scanStaleConfiguredAuthOrders({ cfg: params.cfg, ...loaded }).map(
+      (hit) =>
+        `- auth.order.${hit.provider} references only missing profiles while compatible stored credentials exist; run ${params.doctorFixCommand} to remove the stale override and restore automatic selection.`,
+    ),
+  ];
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {


### PR DESCRIPTION
## What Problem This Solves

Fixes three upgrade diagnostics observed during the 2026-07-29 memory-system deployment: `openclaw memory status --deep` could abort on an unrelated degraded secret owner, Doctor left stale `auth.order` entries pointing at unavailable undeclared profiles, and an existing semantic index could become permanently sync-blocked without an actionable Doctor finding when its embedding provider could not initialize.

## Why This Change Was Made

Memory status now uses read-only secret resolution and converts typed failures from unrelated owners into redacted diagnostics while preserving hard failure for the queried memory owner. Doctor repairs an undeclared order only when the credential stores are readable, the old profile is not usable, and exactly one same-provider profile is declared; ambiguous or unreadable cases remain report-only. Memory Core also adds a read-only Doctor check for builtin semantic indexes whose provider cannot bootstrap, naming `memory.search.remote.apiKey` / `memory.search.provider` and explaining that sync intentionally aborts rather than downgrading vectors to FTS-only.

The vector-protection behavior in `assertFtsOnlySyncAllowed` is unchanged. QMD and configured SecretRef surfaces are excluded from the bootstrap warning because their diagnostics are owned elsewhere.

## User Impact

Operators can inspect healthy memory surfaces even when another secret owner is degraded, recover the exact declared-vs-order mismatch with `openclaw doctor --fix`, and see an actionable warning before a protected semantic index turns every sync into an unexplained abort. Doctor does not modify key material and does not guess when profile selection is ambiguous.

## Evidence

- Focused Vitest: 53 command/Doctor tests plus 79 Memory Core tests passed.
- Final changed gate passed on Blacksmith Testbox `tbx_01kyqrdh066kndqz4jj0dahpxs` (Actions run 30487904333), covering core and extension typechecks, lint, formatting, plugin boundaries, dead-code, schema, database-first, and import-cycle guards.
- Post-rebase focused proof passed against current `origin/main`; the SQLite architecture correction is at head `c3c37ba95bd`.
- `node scripts/check-kysely-guardrails.mjs` passed after replacing the direct SQLite opener found by the first CI attempt.
- Repo autoreview workflow completed clean with no accepted/actionable findings.
- No `CHANGELOG.md` change, per repository policy.

This change is AI-assisted and was reviewed through the repository autoreview workflow. I understand the implementation and its owner boundaries.
