### PR TITLE
fix(test): isolate ACP startup output stream

### DIFF
--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -71,6 +71,7 @@ vi.mock("node:stream", async (importOriginal) => {
         },
       }),
   );
+  vi.spyOn(actual.Writable, "toWeb").mockImplementation(() => new WritableStream());
   return actual;
 });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the ACP startup test attached real Node stream adapter listeners to worker stdout on every case, producing `MaxListenersExceededWarning` noise during the suite.

## Why This Change Was Made

The startup fixture now mocks `Writable.toWeb` with a fresh inert web stream, matching its existing mocked stdin adapter. Production ACP stream and shutdown behavior are unchanged.

## User Impact

No user-visible behavior change. Maintainers get deterministic ACP startup tests without leaked worker stdout listeners or warning-stack overhead.

## Evidence

- Before: `node scripts/run-vitest.mjs src/acp/server.startup.test.ts` passed 21 tests but emitted five `MaxListenersExceededWarning` variants.
- After: the same focused command passed 21 tests with no warnings.
- Changed-file Testbox gate passed: https://github.com/openclaw/openclaw/actions/runs/30488750342
- Autoreview clean, score 0.93.
