### PR TITLE
improve(ui): guide optional channel setup after model setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Control UI first-run setup:** continue verified model setup into Custodian, explain that the web app is ready without a channel, and offer an optional dismissible path to Channels.
 - **Fish Audio speech:** add hosted S2.1 synthesis with streaming, voice notes, voice discovery, and telephony, plus local Fish S2 Pro reference-voice streaming in native macOS Talk. Thanks @Conan-Scott for the earlier community-plugin implementation.
 - **Control UI cloud workspace conflicts:** surface staged-ref guidance, bounded conflicted paths, structured transcript events, and sidebar attention for cloud worker results that kept local versions.
 - **Control UI update recovery:** the "A new version is available" Reload button now waits out the gateway restart that stranded the chunk and reloads as soon as it answers, instead of silently doing nothing and leaving a manual hard reload as the only way out.

--- a/ui/src/e2e/custodian-channel-onboarding.e2e.test.ts
+++ b/ui/src/e2e/custodian-channel-onboarding.e2e.test.ts
@@ -1,0 +1,206 @@
+// Control UI tests cover the first-run model-to-channel onboarding handoff.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  waitForControlUiRoute,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const artifactDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "custodian-channel-onboarding",
+);
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+const emptyChannelSnapshot = {
+  ts: 1_700_000_000_000,
+  channelOrder: ["whatsapp", "telegram", "discord"],
+  channelLabels: {
+    whatsapp: "WhatsApp",
+    telegram: "Telegram",
+    discord: "Discord",
+  },
+  channelMeta: [
+    { id: "whatsapp", label: "WhatsApp", detailLabel: "WhatsApp Web" },
+    { id: "telegram", label: "Telegram", detailLabel: "Telegram Bot" },
+    { id: "discord", label: "Discord", detailLabel: "Discord Bot" },
+  ],
+  channels: {
+    whatsapp: { configured: false, running: false, connected: false },
+    telegram: { configured: false, running: false, connected: false },
+    discord: { configured: false, running: false, connected: false },
+  },
+  channelAccounts: {
+    whatsapp: [],
+    telegram: [],
+    discord: [],
+  },
+  channelDefaultAccountId: {},
+};
+
+describeControlUiE2e("Control UI Custodian channel onboarding mocked Gateway E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    await mkdir(artifactDir, { recursive: true });
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("offers optional channels after model setup and opens the real Channels hub", async () => {
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "channels.pairing.list",
+        "channels.status",
+        "openclaw.setup.detect",
+        "openclaw.setup.activate",
+        "openclaw.chat",
+      ],
+      methodResponses: {
+        "channels.pairing.list": {
+          accounts: [],
+          requests: [],
+          commandOwnerConfigured: true,
+          limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+        },
+        "channels.status": emptyChannelSnapshot,
+        "openclaw.setup.detect": {
+          candidates: [
+            {
+              kind: "codex-cli",
+              brandId: "openai",
+              label: "Codex CLI",
+              detail: "Signed in locally",
+              modelRef: "openai/gpt-5",
+              recommended: true,
+              credentials: true,
+            },
+          ],
+          manualProviders: [{ id: "openai", label: "OpenAI" }],
+          workspace: "/tmp/openclaw-e2e",
+          setupComplete: false,
+        },
+        "openclaw.setup.activate": {
+          ok: true,
+          modelRef: "openai/gpt-5",
+          latencyMs: 73,
+          lines: ["Model ready"],
+        },
+        "openclaw.chat": {
+          sessionId: "e2e-channel-onboarding",
+          reply: "Your AI is ready. The web app works now.",
+          action: "none",
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/model-setup?firstRun=1`);
+      expect(response?.status()).toBe(200);
+      await page.getByRole("button", { name: "Test & use" }).click();
+      const continueSetup = page.getByRole("button", { name: "Continue setup" });
+      await continueSetup.waitFor();
+      await page.screenshot({
+        animations: "disabled",
+        path: path.join(artifactDir, "01-after-model-ready-continue-setup.png"),
+      });
+
+      await continueSetup.click();
+      await waitForControlUiRoute(page, {
+        pathname: "/custodian",
+        routeId: "custodian",
+        search: "?onboarding=1",
+      });
+      const channelNudge = page.locator(".custodian__nudge--channel-onboarding");
+      await channelNudge.waitFor();
+      await expect.poll(() => channelNudge.textContent()).toContain("The web app already works");
+      await page.screenshot({
+        animations: "disabled",
+        path: path.join(artifactDir, "02-after-custodian-channel-nudge.png"),
+      });
+
+      await page.setViewportSize({ height: 844, width: 390 });
+      const mobileNudgeBox = await channelNudge.boundingBox();
+      const mobileCtaBox = await page
+        .getByRole("button", { name: "Set up a channel" })
+        .boundingBox();
+      expect(mobileNudgeBox).not.toBeNull();
+      expect(mobileCtaBox).not.toBeNull();
+      expect(mobileNudgeBox!.x).toBeGreaterThanOrEqual(0);
+      expect(mobileNudgeBox!.x + mobileNudgeBox!.width).toBeLessThanOrEqual(390);
+      expect(mobileCtaBox!.x).toBeGreaterThanOrEqual(mobileNudgeBox!.x);
+      expect(mobileCtaBox!.x + mobileCtaBox!.width).toBeLessThanOrEqual(
+        mobileNudgeBox!.x + mobileNudgeBox!.width,
+      );
+      expect(
+        await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth),
+      ).toBe(false);
+      await page.screenshot({
+        animations: "disabled",
+        path: path.join(artifactDir, "02b-after-custodian-channel-nudge-mobile.png"),
+      });
+      await page.setViewportSize({ height: 900, width: 1280 });
+
+      const channelStatusRequests = await gateway.getRequests("channels.status");
+      expect(channelStatusRequests).toHaveLength(1);
+      expect(channelStatusRequests[0]?.params).toMatchObject({ probe: false });
+
+      await page.getByRole("button", { name: "Set up a channel" }).click();
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/channels",
+        routeId: "channels",
+        search: "",
+      });
+      await page.getByText("No channels connected yet. Pick one below to get started.").waitFor();
+      await page.getByText("No configured channel accounts use DM sender pairing.").waitFor();
+      await page.getByRole("heading", { name: "Add a channel" }).waitFor();
+      expect(new URL(page.url()).searchParams.has("onboarding")).toBe(false);
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(artifactDir, "03-after-channels-destination.png"),
+      });
+
+      await page.goBack();
+      await waitForControlUiRoute(page, {
+        pathname: "/custodian",
+        routeId: "custodian",
+        search: "?onboarding=1",
+      });
+      await expect
+        .poll(() => page.locator(".custodian__nudge--channel-onboarding").count())
+        .toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -108,7 +108,7 @@ describeControlUiE2e("Control UI Model Setup mocked Gateway E2E", () => {
       await expect
         .poll(async () => page.locator(".model-setup__success").textContent())
         .toContain("openai/gpt-5 · 73 ms");
-      await page.getByRole("button", { name: "Open Chat" }).click();
+      await page.getByRole("button", { name: "Continue setup" }).click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/custodian");
       expect(new URL(page.url()).searchParams.get("onboarding")).toBe("1");
       await page.getByRole("heading", { name: "OpenClaw", exact: true }).waitFor();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2034,6 +2034,7 @@ export const en: TranslationMap = {
       title: "Your AI is ready",
       detail: "{modelRef} · {latencyMs} ms",
       openChat: "Open Chat",
+      continueSetup: "Continue setup",
       configuredModel: "Configured model",
     },
     failure: {
@@ -2219,6 +2220,11 @@ export const en: TranslationMap = {
       channelDegraded: "{channel} is degraded — ask me what happened",
       channelFallback: "A channel",
       dismiss: "Dismiss this update",
+      channelSetupTitle: "Reach OpenClaw outside this app",
+      channelSetupBody:
+        "The web app already works. Add a channel only if you want to message OpenClaw from another service.",
+      channelSetupAction: "Set up a channel",
+      channelSetupDismiss: "Keep using the web app",
     },
   },
   mcpServers: {

--- a/ui/src/lib/channels/index.test.ts
+++ b/ui/src/lib/channels/index.test.ts
@@ -1,7 +1,11 @@
 // Channels domain tests.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelsPairingListResult, ChannelsStatusSnapshot } from "../../api/types.ts";
-import { createChannelCapability } from "./index.ts";
+import {
+  channelSnapshotEntryIsActive,
+  channelSnapshotHasActiveChannel,
+  createChannelCapability,
+} from "./index.ts";
 
 function createDeferred<T>() {
   let resolve: ((value: T) => void) | undefined;
@@ -26,6 +30,39 @@ function createChannelsSnapshot(label: string): ChannelsStatusSnapshot {
     channelDefaultAccountId: {},
   };
 }
+
+describe("channel readiness", () => {
+  it("treats aggregate or account configuration as active", () => {
+    const snapshot = createChannelsSnapshot("Test");
+    snapshot.channelOrder = ["configured", "connected", "empty"];
+    snapshot.channels = {
+      configured: { configured: true },
+      connected: { configured: false, connected: false },
+      empty: { configured: false, running: false, connected: false },
+    };
+    snapshot.channelAccounts = {
+      connected: [{ accountId: "work", connected: true }],
+      empty: [],
+    };
+
+    expect(channelSnapshotEntryIsActive(snapshot, "configured")).toBe(true);
+    expect(channelSnapshotEntryIsActive(snapshot, "connected")).toBe(true);
+    expect(channelSnapshotEntryIsActive(snapshot, "empty")).toBe(false);
+    expect(channelSnapshotHasActiveChannel(snapshot)).toBe(true);
+  });
+
+  it("recognizes active channels omitted from channelOrder", () => {
+    const snapshot = createChannelsSnapshot("Test");
+    snapshot.channelOrder = [];
+    snapshot.channels = {};
+    snapshot.channelAccounts = {
+      telegram: [{ accountId: "default", running: true }],
+    };
+
+    expect(channelSnapshotHasActiveChannel(snapshot)).toBe(true);
+    expect(channelSnapshotHasActiveChannel(null)).toBe(false);
+  });
+});
 
 describe("channels controller WhatsApp wait", () => {
   beforeEach(() => {

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { roleScopesAllow } from "../../../../src/shared/operator-scope-compat.ts";
 import type {
   ChannelsPairingApproveResult,
@@ -79,6 +80,36 @@ export type ChannelCapability = {
   subscribe: (listener: (state: ChannelsState) => void) => () => void;
   dispose: () => void;
 };
+
+export function channelSnapshotEntryIsActive(
+  snapshot: ChannelsStatusSnapshot | null,
+  channelId: string,
+): boolean {
+  if (!snapshot) {
+    return false;
+  }
+  const status = asRecord(snapshot.channels[channelId]);
+  if (status?.configured === true || status?.running === true || status?.connected === true) {
+    return true;
+  }
+  return (snapshot.channelAccounts[channelId] ?? []).some(
+    (account) =>
+      account.configured === true || account.running === true || account.connected === true,
+  );
+}
+
+/** Matches the Channels hub's definition of a transport the operator already uses. */
+export function channelSnapshotHasActiveChannel(snapshot: ChannelsStatusSnapshot | null): boolean {
+  if (!snapshot) {
+    return false;
+  }
+  const channelIds = new Set([
+    ...snapshot.channelOrder,
+    ...Object.keys(snapshot.channels),
+    ...Object.keys(snapshot.channelAccounts),
+  ]);
+  return [...channelIds].some((channelId) => channelSnapshotEntryIsActive(snapshot, channelId));
+}
 
 export function resolveChannelPairingAuthSignature(
   snapshot: Partial<ChannelGatewaySnapshot>,

--- a/ui/src/pages/channels/view.shared.ts
+++ b/ui/src/pages/channels/view.shared.ts
@@ -3,6 +3,7 @@ import { html, nothing } from "lit";
 import type { ChannelAccountSnapshot } from "../../api/types.ts";
 import { renderSettingsSection, renderSettingsStatus } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
+import { channelSnapshotEntryIsActive } from "../../lib/channels/index.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
 import type { ChannelKey, ChannelsProps } from "./view.types.ts";
 
@@ -11,7 +12,6 @@ type ChannelDisplayState = {
   running: boolean | null;
   connected: boolean | null;
   defaultAccount: ChannelAccountSnapshot | null;
-  hasAnyActiveAccount: boolean;
   status: Record<string, unknown> | undefined;
 };
 
@@ -52,7 +52,6 @@ export function resolveChannelDisplayState(
   props: ChannelsProps,
 ): ChannelDisplayState {
   const status = resolveChannelStatus(key, props);
-  const accounts = props.snapshot?.channelAccounts?.[key] ?? [];
   const defaultAccount = resolveDefaultChannelAccount(key, props);
   const configured =
     typeof status?.configured === "boolean"
@@ -62,31 +61,18 @@ export function resolveChannelDisplayState(
         : null;
   const running = typeof status?.running === "boolean" ? status.running : null;
   const connected = typeof status?.connected === "boolean" ? status.connected : null;
-  const hasAnyActiveAccount = accounts.some(
-    (account) => account.configured || account.running || account.connected,
-  );
 
   return {
     configured,
     running,
     connected,
     defaultAccount,
-    hasAnyActiveAccount,
     status,
   };
 }
 
 export function channelEnabled(key: ChannelKey, props: ChannelsProps) {
-  if (!props.snapshot) {
-    return false;
-  }
-  const displayState = resolveChannelDisplayState(key, props);
-  return (
-    displayState.configured === true ||
-    displayState.running === true ||
-    displayState.connected === true ||
-    displayState.hasAnyActiveAccount
-  );
+  return channelSnapshotEntryIsActive(props.snapshot, key);
 }
 
 export function resolveChannelConfigured(key: ChannelKey, props: ChannelsProps): boolean | null {

--- a/ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts
+++ b/ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts
@@ -1,0 +1,170 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelsStatusSnapshot } from "../../api/types.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { createContext, mountPage } from "./custodian-page.test-harness.ts";
+
+function channelSnapshot(patch: Partial<ChannelsStatusSnapshot> = {}): ChannelsStatusSnapshot {
+  return {
+    ts: 1_700_000_000_000,
+    channelOrder: ["telegram"],
+    channelLabels: { telegram: "Telegram" },
+    channels: { telegram: { configured: false, running: false, connected: false } },
+    channelAccounts: { telegram: [] },
+    channelDefaultAccountId: {},
+    ...patch,
+  };
+}
+
+describe("custodian channel onboarding", () => {
+  beforeEach(() => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("shows optional channel setup after first-run model setup and consumes dismissal", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Your AI is ready.",
+      action: "none",
+    });
+    const { context } = createContext(request, ["openclaw.chat"], {
+      channelsSnapshot: channelSnapshot(),
+    });
+    const { page } = await mountPage(context, { onboarding: true });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    const nudge = page.querySelector(".custodian__nudge--channel-onboarding");
+    expect(nudge?.textContent).toContain("Reach OpenClaw outside this app");
+    expect(nudge?.textContent).toContain("The web app already works");
+
+    page.querySelector<HTMLButtonElement>('button[aria-label="Keep using the web app"]')?.click();
+    await page.updateComplete;
+
+    expect(context.replace).toHaveBeenCalledWith("custodian");
+    expect(page.querySelector(".custodian__nudge--channel-onboarding")).toBeNull();
+  });
+
+  it("opens Channels from the optional first-run nudge", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Your AI is ready.",
+      action: "none",
+    });
+    const { context } = createContext(request, ["openclaw.chat"], {
+      channelsSnapshot: channelSnapshot(),
+    });
+    const { page } = await mountPage(context, { onboarding: true });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    page.querySelector<HTMLButtonElement>(".custodian__nudge-cta")?.click();
+    await page.updateComplete;
+
+    expect(context.navigate).toHaveBeenCalledWith("channels");
+    expect(context.replace).not.toHaveBeenCalled();
+    expect(page.querySelector(".custodian__nudge--channel-onboarding")).toBeNull();
+  });
+
+  it("loads channel status once when onboarding has no snapshot", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Your AI is ready.",
+      action: "none",
+    });
+    const { context } = createContext(request);
+    await mountPage(context, { onboarding: true });
+
+    await waitForFast(() => expect(context.channels.refresh).toHaveBeenCalledWith(false));
+    expect(context.channels.refresh).toHaveBeenCalledOnce();
+  });
+
+  it("retries channel status after a disconnect invalidates the first refresh", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Your AI is ready.",
+      action: "none",
+    });
+    const { context, setChannelsConnected } = createContext(request);
+    await mountPage(context, { onboarding: true });
+    await waitForFast(() => expect(context.channels.refresh).toHaveBeenCalledOnce());
+
+    setChannelsConnected(false);
+    setChannelsConnected(true);
+
+    expect(context.channels.refresh).toHaveBeenCalledTimes(2);
+    expect(context.channels.refresh).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it.each([
+    {
+      name: "normal caretaker visits",
+      onboarding: false,
+      snapshot: channelSnapshot(),
+    },
+    {
+      name: "partial channel snapshots",
+      onboarding: true,
+      snapshot: channelSnapshot({ partial: true }),
+    },
+    {
+      name: "configured aggregate channels",
+      onboarding: true,
+      snapshot: channelSnapshot({
+        channels: { telegram: { configured: true, running: false, connected: false } },
+      }),
+    },
+    {
+      name: "connected channel accounts",
+      onboarding: true,
+      snapshot: channelSnapshot({
+        channelAccounts: {
+          telegram: [{ accountId: "work", configured: false, connected: true }],
+        },
+      }),
+    },
+  ])("does not show optional channel setup for $name", async ({ onboarding, snapshot }) => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Ready.",
+      action: "none",
+    });
+    const { context } = createContext(request, ["openclaw.chat"], {
+      channelsSnapshot: snapshot,
+    });
+    const { page } = await mountPage(context, { onboarding });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    expect(page.querySelector(".custodian__nudge--channel-onboarding")).toBeNull();
+  });
+
+  it("removes channel setup as soon as a channel becomes active", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Ready.",
+      action: "none",
+    });
+    const { context, setChannelsSnapshot } = createContext(request, ["openclaw.chat"], {
+      channelsSnapshot: channelSnapshot(),
+    });
+    const { page } = await mountPage(context, { onboarding: true });
+    await waitForFast(() =>
+      expect(page.querySelector(".custodian__nudge--channel-onboarding")).not.toBeNull(),
+    );
+
+    setChannelsSnapshot(
+      channelSnapshot({
+        channelAccounts: {
+          telegram: [{ accountId: "default", configured: true, connected: true }],
+        },
+      }),
+    );
+    await page.updateComplete;
+
+    expect(page.querySelector(".custodian__nudge--channel-onboarding")).toBeNull();
+  });
+});

--- a/ui/src/pages/custodian/custodian-page.test-harness.ts
+++ b/ui/src/pages/custodian/custodian-page.test-harness.ts
@@ -4,6 +4,7 @@ import type {
   GatewayEventFrame,
   GatewayEventListener,
 } from "../../api/gateway.ts";
+import type { ChannelsStatusSnapshot } from "../../api/types.ts";
 import type {
   ApplicationContext,
   ApplicationGateway,
@@ -26,6 +27,8 @@ type ContextHarness = {
   context: ApplicationContext;
   setGatewaySnapshot: (patch: Partial<ApplicationGatewaySnapshot>) => void;
   setGatewayToken: (token: string) => void;
+  setChannelsConnected: (connected: boolean) => void;
+  setChannelsSnapshot: (snapshot: ChannelsStatusSnapshot | null) => void;
   emitGatewayEvent: (event: Pick<GatewayEventFrame, "event" | "payload">) => void;
 };
 
@@ -34,6 +37,7 @@ export function createContext(
   methods: string[] = ["openclaw.chat"],
   options: {
     agentsList?: ApplicationContext["agents"]["state"]["agentsList"];
+    channelsSnapshot?: ChannelsStatusSnapshot | null;
   } = {},
 ): ContextHarness {
   const client = { request } as unknown as GatewayBrowserClient;
@@ -76,6 +80,27 @@ export function createContext(
     },
   } as unknown as ApplicationGateway;
   const agentListeners = new Set<() => void>();
+  const channelListeners = new Set<(state: ApplicationContext["channels"]["state"]) => void>();
+  const channelState = {
+    client,
+    connected: true,
+    channelsLoading: false,
+    channelsLoadingProbe: null,
+    channelsRefreshSeq: 0,
+    channelsSnapshot: options.channelsSnapshot ?? null,
+    channelsError: null,
+    channelsLastSuccess: options.channelsSnapshot ? Date.now() : null,
+    pairingLoading: false,
+    pairingRefreshSeq: 0,
+    pairingSnapshot: null,
+    pairingError: null,
+    pairingLastSuccess: null,
+    pairingBusyRequestId: null,
+    whatsappLoginMessage: null,
+    whatsappLoginQrDataUrl: null,
+    whatsappLoginConnected: null,
+    whatsappBusy: false,
+  };
   const context = {
     gateway,
     agents: {
@@ -94,8 +119,17 @@ export function createContext(
       refreshList: vi.fn(),
     },
     agentSelection: { state: { selectedId: "main" } },
+    channels: {
+      state: channelState,
+      refresh: vi.fn().mockResolvedValue(undefined),
+      subscribe: (listener: (state: ApplicationContext["channels"]["state"]) => void) => {
+        channelListeners.add(listener);
+        return () => channelListeners.delete(listener);
+      },
+    },
     basePath: "",
     navigate: vi.fn(),
+    replace: vi.fn(),
   } as unknown as ApplicationContext;
   return {
     context,
@@ -108,6 +142,19 @@ export function createContext(
     setGatewayToken: (value) => {
       const credentials = { token: value };
       connection.token = credentials.token;
+    },
+    setChannelsConnected: (connected) => {
+      channelState.connected = connected;
+      for (const listener of channelListeners) {
+        listener(channelState);
+      }
+    },
+    setChannelsSnapshot: (nextSnapshot) => {
+      channelState.channelsSnapshot = nextSnapshot;
+      channelState.channelsLastSuccess = nextSnapshot ? Date.now() : null;
+      for (const listener of channelListeners) {
+        listener(channelState);
+      }
     },
     emitGatewayEvent: (event) => {
       for (const listener of eventListeners) {

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -6,8 +6,10 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import "../../components/openclaw-mascot.ts";
 import { t } from "../../i18n/index.ts";
+import { channelSnapshotHasActiveChannel } from "../../lib/channels/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
+import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import "../../styles/custodian.css";
 import { renderCustodianChangeHistory } from "./custodian-history.ts";
 import { custodianSessionStore, type CustodianSessionStore } from "./custodian-session-store.ts";
@@ -36,6 +38,30 @@ export class CustodianPage extends OpenClawLightDomElement {
   private historyRequestEpoch = 0;
   private subscribedStore: CustodianSessionStore | null = null;
   private storeCleanup: (() => void) | null = null;
+  private channelsSource: ApplicationContext["channels"] | null = null;
+  private channelRefreshRequested = false;
+  private readonly subscriptions = new SubscriptionsController(this).effect(
+    () => this.context?.channels,
+    (channels) => {
+      this.channelsSource = channels;
+      this.channelRefreshRequested = false;
+      const stop = channels.subscribe((channelState) => {
+        if (!channelState.connected) {
+          // Disconnect invalidates an in-flight refresh; reconnect must be able to retry.
+          this.channelRefreshRequested = false;
+        }
+        this.ensureOnboardingChannelStatus();
+        this.requestUpdate();
+      });
+      this.ensureOnboardingChannelStatus();
+      return () => {
+        stop();
+        if (this.channelsSource === channels) {
+          this.channelsSource = null;
+        }
+      };
+    },
+  );
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -46,6 +72,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.storeCleanup?.();
     this.storeCleanup = null;
     this.subscribedStore = null;
+    this.subscriptions.clear();
     super.disconnectedCallback();
   }
 
@@ -63,6 +90,25 @@ export class CustodianPage extends OpenClawLightDomElement {
       this.subscribeToStore();
     }
     this.synchronizeHistoryClient();
+    this.ensureOnboardingChannelStatus();
+  }
+
+  private ensureOnboardingChannelStatus(): void {
+    const channels = this.channelsSource;
+    if (!this.onboarding || !channels || this.channelRefreshRequested) {
+      return;
+    }
+    const channelState = channels.state;
+    if (
+      !channelState.connected ||
+      channelState.channelsSnapshot ||
+      channelState.channelsLoading ||
+      channelState.channelsError
+    ) {
+      return;
+    }
+    this.channelRefreshRequested = true;
+    void channels.refresh(false);
   }
 
   private subscribeToStore(): void {
@@ -153,6 +199,13 @@ export class CustodianPage extends OpenClawLightDomElement {
   }
 
   override render() {
+    const channelSnapshot = this.channelsSource?.state.channelsSnapshot ?? null;
+    const showChannelOnboardingNudge =
+      this.onboarding &&
+      !this.store.channelOnboardingNudgeClosed &&
+      channelSnapshot !== null &&
+      channelSnapshot.partial !== true &&
+      !channelSnapshotHasActiveChannel(channelSnapshot);
     const historyContent =
       this.historyOpen && this.historyAvailable
         ? renderCustodianChangeHistory({
@@ -212,6 +265,7 @@ export class CustodianPage extends OpenClawLightDomElement {
           .store=${this.store}
           .onboarding=${this.onboarding}
           .newAgentIntent=${this.newAgentIntent}
+          .showChannelOnboardingNudge=${showChannelOnboardingNudge}
           .historyContent=${historyContent}
         ></openclaw-custodian-surface>
       </section>

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -50,6 +50,7 @@ export class CustodianSessionStore {
   chatAvailable = false;
   eventNudge: eventNudgeState.CustodianEventNudge | null = null;
   eventNudgePending: eventNudgeState.CustodianEventNudge | null = null;
+  channelOnboardingNudgeClosed = false;
   earlierBoundaryAfterId: number | null = null;
   abandonedTurnOutcomeUnknown = false;
 
@@ -217,6 +218,18 @@ export class CustodianSessionStore {
   dismissEventNudge(): void {
     [this.eventNudge, this.eventNudgeClosed] = [null, true];
     this.emit();
+  }
+
+  dismissChannelOnboardingNudge(): void {
+    this.channelOnboardingNudgeClosed = true;
+    this.emit();
+    this.context?.replace("custodian");
+  }
+
+  openChannelsFromOnboarding(): void {
+    this.channelOnboardingNudgeClosed = true;
+    this.emit();
+    this.context?.navigate("channels");
   }
 
   async dismissQuestion(message: CustodianMessage): Promise<void> {

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -23,6 +23,7 @@ class CustodianSurface extends OpenClawLightDomElement {
   @property({ attribute: false }) store: CustodianSessionStore = custodianSessionStore;
   @property({ attribute: false }) onboarding = false;
   @property({ attribute: false }) newAgentIntent = false;
+  @property({ attribute: false }) showChannelOnboardingNudge = false;
   @property({ attribute: false }) compact = false;
   @property({ attribute: false }) historyContent: TemplateResult | typeof nothing = nothing;
 
@@ -139,6 +140,12 @@ class CustodianSurface extends OpenClawLightDomElement {
           : ""}"
       >
         <div class="custodian__messages" aria-live="polite">
+          ${this.showChannelOnboardingNudge
+            ? eventNudgeState.renderCustodianChannelOnboardingNudge({
+                onOpenChannels: () => store.openChannelsFromOnboarding(),
+                onDismiss: () => store.dismissChannelOnboardingNudge(),
+              })
+            : nothing}
           ${!this.onboarding && store.eventNudge && !store.eventNudgePending
             ? eventNudgeState.renderCustodianEventNudge({
                 nudge: store.eventNudge,

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -100,6 +100,33 @@ export function renderCustodianEventNudge(params: {
   </div>`;
 }
 
+export function renderCustodianChannelOnboardingNudge(params: {
+  onOpenChannels: () => void;
+  onDismiss: () => void;
+}) {
+  return html`<div class="custodian__nudge custodian__nudge--channel-onboarding" role="status">
+    <div class="custodian__nudge-copy">
+      <strong>${t("custodian.nudge.channelSetupTitle")}</strong>
+      <span>${t("custodian.nudge.channelSetupBody")}</span>
+    </div>
+    <button
+      class="btn btn--sm primary custodian__nudge-cta"
+      type="button"
+      @click=${params.onOpenChannels}
+    >
+      ${t("custodian.nudge.channelSetupAction")}
+    </button>
+    <button
+      class="custodian__nudge-dismiss"
+      type="button"
+      aria-label=${t("custodian.nudge.channelSetupDismiss")}
+      @click=${params.onDismiss}
+    >
+      ×
+    </button>
+  </div>`;
+}
+
 type UnknownRecord = Record<string, unknown>;
 
 const CONSEQUENTIAL_CHANNEL_STATES = new Set([

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -568,6 +568,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
       manualApiKey: this.manualApiKey,
       manualError: this.manualError,
       moreSignInOpen: this.moreSignInOpen,
+      firstRun: this.routeData?.firstRun === true,
       iconUrls: this.iconUrls,
       onDetect: () => void this.detect(),
       onVerify: () => void this.verifyConnection(),

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -104,6 +104,7 @@ function props(overrides: Partial<ModelSetupViewProps> = {}): ModelSetupViewProp
     manualApiKey: "",
     manualError: null,
     moreSignInOpen: false,
+    firstRun: false,
     iconUrls: {
       "https://cdn.example.com/codex.png": "blob:codex",
       "https://cdn.example.com/openai.png": "blob:openai",
@@ -495,6 +496,17 @@ describe("renderModelSetup", () => {
     container.querySelector<HTMLButtonElement>(".model-setup__success button")?.click();
     expect(onOpenChat).toHaveBeenCalledOnce();
     expect(container.querySelector(".settings-section")).toBeNull();
+  });
+
+  it("continues first-run setup after the model is ready", () => {
+    const container = mount(
+      props({
+        activation: { phase: "success", modelRef: "openai/gpt-5" },
+        firstRun: true,
+      }),
+    );
+    expect(text(container)).toContain("Continue setup");
+    expect(text(container)).not.toContain("Open Chat");
   });
 
   it("renders an idle current connection and verifies it", () => {

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -74,6 +74,7 @@ type ModelSetupViewProps = {
   manualApiKey: string;
   manualError: string | null;
   moreSignInOpen: boolean;
+  firstRun: boolean;
   iconUrls: Readonly<Record<string, string>>;
   onDetect: () => void;
   onVerify: () => void;
@@ -122,6 +123,7 @@ function failureLabel(status: string): string {
 function renderSuccess(
   activation: Extract<ModelSetupActivationState, { phase: "success" }>,
   onOpenChat: () => void,
+  firstRun: boolean,
 ) {
   return html`
     <div class="model-setup__success" role="status">
@@ -140,7 +142,7 @@ function renderSuccess(
           : nothing}
       </div>
       <button type="button" class="btn primary" @click=${onOpenChat}>
-        ${t("modelSetup.success.openChat")}
+        ${t(firstRun ? "modelSetup.success.continueSetup" : "modelSetup.success.openChat")}
       </button>
     </div>
   `;
@@ -526,7 +528,7 @@ function renderManual(props: ModelSetupViewProps, result: SystemAgentSetupDetect
 
 function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectResult) {
   if (props.activation.phase === "success") {
-    return renderSuccess(props.activation, props.onOpenChat);
+    return renderSuccess(props.activation, props.onOpenChat, props.firstRun);
   }
   const current = result.configuredModel
     ? renderCurrentConnection(props, result.configuredModel)

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -165,6 +165,39 @@ openclaw-custodian-page {
   color: var(--text);
 }
 
+.custodian__nudge--channel-onboarding {
+  width: 100%;
+  max-width: none;
+  padding: 12px;
+  border-color: var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+}
+
+.custodian__nudge-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.custodian__nudge-copy strong {
+  color: var(--text-strong);
+  font-size: 13px;
+}
+
+.custodian__nudge-copy span {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.custodian__nudge-cta {
+  flex: 0 0 auto;
+  align-self: center;
+}
+
 .custodian__nudge-action,
 .custodian__nudge-dismiss {
   border: 0;
@@ -204,6 +237,17 @@ openclaw-custodian-page {
 .custodian__nudge-dismiss:hover {
   background: var(--bg-hover);
   color: var(--text-strong);
+}
+
+@media (max-width: 640px) {
+  .custodian__nudge--channel-onboarding {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .custodian__nudge-copy {
+    flex-basis: calc(100% - 36px);
+  }
 }
 
 .custodian__option-card {


### PR DESCRIPTION
## What Problem This Solves

Fixes a first-run setup gap where successful model setup offered "Open Chat" even though it continued into Custodian, then left users with no clear explanation that channels are optional or how to reach OpenClaw outside the web app.

## Why This Change Was Made

First-run model setup now says "Continue setup." Custodian reuses the canonical Channels status snapshot to show one optional, dismissible channel prompt only when an authoritative snapshot proves no aggregate or account is configured, running, or connected. Web-only use remains fully functional and unblocked.

## User Impact

New users reach a working Custodian immediately after model setup, understand that the web app is already ready, and can choose whether to connect a channel. The channel action opens the existing Channels setup surface, while dismissal consumes the onboarding route and avoids repeated prompting.

## Evidence

- Focused UI units: 96 passed.
- Reconnect regression and adjacent Custodian suites: 38 passed after review repair.
- Mocked Control UI E2E: 5 passed across model setup and the new onboarding flow.
- Targeted oxlint and touched-file oxfmt checks: passed.
- `git diff --check`: passed.
- Mobile 390px assertions cover nudge/CTA overflow and page horizontal scrolling.
- Fresh post-fix autoreview: no accepted/actionable findings; patch rated correct at 0.90 confidence.
- Blacksmith Testbox UI production typecheck: `pnpm tsgo:ui` passed ([run](https://github.com/openclaw/openclaw/actions/runs/30504167907)).

### Before

Custodian after first-run model setup had no channel guidance:

![00-before-custodian-no-channel-guidance.png](https://github.com/user-attachments/assets/9ed9232b-720e-4040-8529-eaa7bd4025c3)

### After

Model setup continues into the remaining setup journey:

![01-after-model-ready-continue-setup.png](https://github.com/user-attachments/assets/786b75f9-9ee8-4054-8a0e-6b6854efbd12)

Custodian explains that web-only use is ready and channels are optional:

![02-after-custodian-channel-nudge.png](https://github.com/user-attachments/assets/4693a649-905e-4569-8087-e51dbbe214f5)

Mobile:

![02b-after-custodian-channel-nudge-mobile.png](https://github.com/user-attachments/assets/0f1e5bc8-1b84-43c5-80b3-05d87ae96916)

The CTA lands on the existing Channels setup surface:

![03-after-channels-destination.png](https://github.com/user-attachments/assets/45506675-1f09-4b86-859a-dd3ac70856d3)

AI-assisted: Codex was used for implementation and structured review; the maintainer inspected the diff, tests, and visual evidence.
