### PR TITLE
fix(ui): make model setup actionable before selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Control UI update reconciliation:** preserve an unresolved managed-update request across disconnects, accept the replacement Gateway version when it proves success, and otherwise show explicit recovery guidance instead of trusting an unrelated cached update result or failing silently. Fixes #116075. Thanks @shakkernerd.
+- **Control UI model readiness:** put AI setup first when no model is selectable, distinguish signed-in credentials from ready providers, and route accounts with no exposed models directly to provider recovery instead of leading with disabled default controls.
 - **Control UI Talk session isolation:** stop active realtime Talk media and retire its callbacks before chat session changes, Gateway disconnects, or pane disposal so previous-session audio, transcript, camera, and status updates cannot leak into the next view. Thanks @shakkernerd.
 - **Gateway reconnect event ordering:** reset the shared TypeScript client's outer event-sequence baseline for each replacement WebSocket, preventing gap recovery from comparing unrelated connection generations across Control UI, TUI, SDK, and browser extension clients. Thanks @shakkernerd.
 - **Skill Workshop offline apply:** preserve configless local proposal apply after upgrades under exclusive Gateway startup ownership, while keeping running Gateway snapshot invalidation fail-closed when CLI credentials are unavailable.

--- a/src/commands/models/list.probe.targets.test.ts
+++ b/src/commands/models/list.probe.targets.test.ts
@@ -776,6 +776,46 @@ describe("buildProbeTargets reason codes", () => {
     );
   });
 
+  it("keeps no_model when a credential has no account-visible catalog model", async () => {
+    mockStore = {
+      version: 1,
+      profiles: {
+        "provider:account": {
+          type: "oauth",
+          provider: "provider",
+          access: "account-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+      },
+      order: { provider: ["provider:account"] },
+    };
+    mockAllowedProfiles = ["provider:account"];
+    resolveAuthProfileEligibilityMock.mockReturnValue({ eligible: true, reasonCode: "ok" });
+    loadModelCatalogMock.mockResolvedValueOnce([]);
+
+    const plan = await buildProbeTargets({
+      cfg: {} as OpenClawConfig,
+      providers: ["provider"],
+      modelCandidates: [],
+      options: {
+        timeoutMs: 5_000,
+        concurrency: 1,
+        maxTokens: 16,
+      },
+    });
+
+    expect(plan.targets).toStrictEqual([]);
+    expect(plan.results).toContainEqual(
+      expect.objectContaining({
+        provider: "provider",
+        profileId: "provider:account",
+        status: "no_model",
+        reasonCode: "no_model",
+      }),
+    );
+  });
+
   it("matches canonical providers against alias-valued catalog probe models", async () => {
     await withClearedZaiEnv(async () => {
       mockStore = {

--- a/src/gateway/server-methods/models-probe.test.ts
+++ b/src/gateway/server-methods/models-probe.test.ts
@@ -207,6 +207,21 @@ describe("models.probe", () => {
     );
   });
 
+  it("does not require a configured default before probing provider credentials", async () => {
+    const cfg: OpenClawConfig = {};
+    const { options } = createOptions({ provider: "openai" }, cfg);
+
+    await handler(options);
+
+    expect(mocks.runAuthProbes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        providers: ["openai"],
+        modelCandidates: [],
+      }),
+    );
+  });
+
   it("maps target results and reports provider success when one credential works", async () => {
     mocks.runAuthProbes.mockResolvedValue(
       summary([

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -20,6 +20,7 @@ const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? descri
 const NOW = Date.now();
 const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
 const artifactDir = path.resolve(".artifacts/control-ui-e2e/model-providers");
+const readinessArtifactDir = path.resolve(".artifacts/control-ui-e2e/models-provider-readiness");
 const redactedConfigValue = "[redacted]";
 const openaiInputValue = ["e2e", "test", "key"].join("-");
 const googleInputValue = ["e2e", "google", "key"].join("-");
@@ -48,12 +49,119 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     if (recordVisuals) {
       await mkdir(artifactDir, { recursive: true });
+      await mkdir(readinessArtifactDir, { recursive: true });
     }
   });
 
   afterAll(async () => {
     await browser?.close();
     await server?.close();
+  });
+
+  it("surfaces credential-only model setup as the primary action", async () => {
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1000, width: 1440 },
+    });
+    const page = await context.newPage();
+    const config = { auth: { profiles: { "openai:chatgpt": { provider: "openai" } } } };
+    await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "models.probe", "openclaw.setup.detect"],
+      methodResponses: {
+        "config.get": {
+          config,
+          sourceConfig: config,
+          hash: "credential-only-model-provider",
+          issues: [],
+          raw: JSON.stringify(config),
+          valid: true,
+        },
+        "models.list": {
+          cases: [
+            { match: { view: "configured" }, response: { models: [] } },
+            {
+              match: { view: "all", includeProviderCapabilities: true },
+              response: {
+                models: [
+                  {
+                    id: "gpt-5.6",
+                    name: "GPT-5.6",
+                    provider: "openai",
+                    available: false,
+                    apiKeySupported: true,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        "models.authStatus": {
+          ts: NOW,
+          providers: [
+            {
+              provider: "openai",
+              displayName: "OpenAI",
+              status: "ok",
+              profiles: [{ profileId: "openai:chatgpt", type: "oauth", status: "ok" }],
+            },
+          ],
+        },
+        "openclaw.setup.detect": {
+          candidates: [],
+          manualProviders: [{ id: "openai", label: "OpenAI" }],
+          workspace: "/tmp/openclaw-e2e",
+          setupComplete: false,
+        },
+        "usage.status": { updatedAt: NOW, providers: [] },
+        "sessions.usage": { aggregates: { byProvider: [] } },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/model-providers`);
+      expect(response?.status()).toBe(200);
+      const openaiCard = page.locator('[data-provider-id="openai"]');
+      const readiness = page.locator('[data-model-readiness="model-required"]');
+      await readiness.waitFor();
+      await expect.poll(async () => readiness.textContent()).toContain("Connect your AI");
+      await expect.poll(async () => readiness.textContent()).toContain("No models available");
+      await expect.poll(async () => openaiCard.textContent()).toContain("Signed in");
+      expect(await page.locator(".model-providers__defaults").count()).toBe(0);
+
+      if (recordVisuals) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(readinessArtifactDir, "after-desktop.png"),
+        });
+        await page.setViewportSize({ height: 844, width: 390 });
+        await expect
+          .poll(() =>
+            page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
+          )
+          .toBe(true);
+        const providerTitle = openaiCard.locator(".settings-row__title").first();
+        await expect
+          .poll(() => providerTitle.evaluate((node) => node.getBoundingClientRect().width))
+          .toBeGreaterThan(40);
+        await expect
+          .poll(() => providerTitle.evaluate((node) => node.getBoundingClientRect().height))
+          .toBeLessThan(32);
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(readinessArtifactDir, "after-mobile.png"),
+        });
+        await page.setViewportSize({ height: 1000, width: 1440 });
+      }
+
+      await readiness.getByRole("button", { name: "Choose another provider" }).click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-setup");
+    } finally {
+      await context.close();
+    }
   });
 
   it("lists configured providers with auth state, quota, billing, and local spend", async () => {
@@ -157,7 +265,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
         .poll(async () => claudeCard.locator(".settings-row__desc").first().textContent())
         .toContain("anthropic");
       await expect.poll(async () => claudeCard.textContent()).toContain("Max 20x");
-      await expect.poll(async () => claudeCard.textContent()).toContain("Connected");
+      await expect.poll(async () => claudeCard.textContent()).toContain("Ready");
       await expect.poll(async () => claudeCard.textContent()).toContain("$4.20");
       await claudeCard.locator(".provider-usage-progress").first().waitFor();
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3850,7 +3850,8 @@ export const en: TranslationMap = {
     emptyTitle: "No model providers configured",
     emptySubtitle: "Sign in to a provider or add an API key, then refresh.",
     status: {
-      ok: "Connected",
+      ok: "Signed in",
+      ready: "Ready",
       expiring: "Expiring",
       expired: "Expired",
       missing: "Not signed in",
@@ -3901,8 +3902,18 @@ export const en: TranslationMap = {
         timeout: "Timed out",
         format: "Invalid response",
         unknown: "Connection failed",
-        no_model: "No model available",
+        no_model: "No models available",
       },
+    },
+    readiness: {
+      title: "AI setup",
+      heading: "Connect your AI",
+      signedInNoModels:
+        "You're signed in, but this account exposes no usable models. Choose another provider or account to continue.",
+      notConfigured: "Choose a provider and verify the model OpenClaw will use.",
+      noModels: "No models available",
+      modelRequired: "Model required",
+      chooseProvider: "Choose another provider",
     },
     logout: {
       action: "Log out",

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -613,6 +613,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     ]);
     const advertised = isGatewayMethodAdvertised(gatewaySnapshot, "models.probe");
     const blockedReason = this.mutationBlockedReason();
+    const configuredModels = buildSelectableDefaultModels(data.models, defaults);
     const body = renderModelProviders({
       connected: gatewaySnapshot.phase === "connected",
       loading: gatewaySnapshot.phase === "connected" && this.data === null,
@@ -622,7 +623,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       costDays: MODEL_PROVIDERS_COST_DAYS,
       credentialAgentLabel: selectedAgentLabel,
       cards,
-      configuredModels: buildSelectableDefaultModels(data.models, defaults),
+      configuredModels,
       defaultModels: defaults,
       defaultModelsDirty: this.defaultsDraft !== null,
       thinkingLevel,
@@ -697,6 +698,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
         runtimeConfig.patchForm(["agents", "defaults", "thinkingDefault"], level),
       onFastModeChange: (mode: FastMode) =>
         runtimeConfig.patchForm(["agents", "defaults", "fastModeDefault"], mode),
+      onOpenModelSetup: () => this.context.navigate("model-setup"),
     });
     return html`
       <section class="content-header">
@@ -715,7 +717,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
             selectedId: this.selectedAgentId,
           })}
           <button class="btn" @click=${() => this.context.navigate("model-setup")}>
-            ${t("modelSetup.heading")}
+            ${t("tabs.modelSetup")}
           </button>
         </div>
       </section>

--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -75,6 +75,7 @@ function props(overrides: Partial<ModelProvidersViewProps> = {}): ModelProviders
     onDefaultModelsReset: () => undefined,
     onThinkingChange: () => undefined,
     onFastModeChange: () => undefined,
+    onOpenModelSetup: () => undefined,
     ...overrides,
   };
 }
@@ -210,6 +211,97 @@ describe("renderModelProviders", () => {
     expect(text(provider)).toContain("Default profile");
   });
 
+  it("puts model recovery first when credentials expose no selectable models", () => {
+    const onOpenModelSetup = vi.fn();
+    const container = mount(
+      props({
+        cards: [
+          card({
+            auth: { kind: "ok", profileCount: 1 },
+            profiles: [{ profileId: "openai:chatgpt", type: "oauth", status: "ok" }],
+            modelCount: 0,
+            availableModelCount: 0,
+          }),
+        ],
+        configuredModels: [],
+        defaultModels: { primary: "", fallbacks: [], utilityModel: null },
+        onOpenModelSetup,
+      }),
+    );
+
+    const readiness = container.querySelector('[data-model-readiness="model-required"]');
+    expect(text(readiness)).toContain("Connect your AI");
+    expect(text(readiness)).toContain("No models available");
+    expect(text(readiness)).toContain("Choose another provider");
+    expect(container.querySelector(".model-providers__defaults")).toBeNull();
+    expect(text(container.querySelector('[data-provider-id="openai"]'))).toContain("Signed in");
+
+    button(readiness!, "Choose another provider")?.click();
+    expect(onOpenModelSetup).toHaveBeenCalledOnce();
+  });
+
+  it("does not report an unverified API key as ready", () => {
+    const container = mount(
+      props({
+        cards: [
+          card({
+            auth: { kind: "api-key", profileCount: 0 },
+          }),
+        ],
+      }),
+    );
+
+    const provider = container.querySelector('[data-provider-id="openai"]');
+    expect(text(provider)).toContain("API key");
+    expect(text(provider)).not.toContain("Ready");
+  });
+
+  it("starts provider setup before showing disabled model controls", () => {
+    const onOpenModelSetup = vi.fn();
+    const container = mount(
+      props({
+        cards: [],
+        configuredModels: [],
+        defaultModels: { primary: "", fallbacks: [], utilityModel: null },
+        onOpenModelSetup,
+      }),
+    );
+
+    const readiness = container.querySelector('[data-model-readiness="model-required"]');
+    expect(text(readiness)).toContain("Model required");
+    expect(button(readiness!, "Connect your AI")).toBeDefined();
+    expect(container.querySelector(".model-providers__defaults")).toBeNull();
+  });
+
+  it("recovers from a saved default that is no longer selectable", () => {
+    const container = mount(
+      props({
+        configuredModels: [
+          {
+            id: "retired-model",
+            provider: "openai",
+            name: "Retired model",
+            available: false,
+          },
+        ],
+        defaultModels: {
+          primary: "openai/retired-model",
+          fallbacks: [],
+          utilityModel: null,
+        },
+      }),
+    );
+
+    expect(container.querySelector('[data-model-readiness="model-required"]')).not.toBeNull();
+    expect(container.querySelector(".model-providers__defaults")).toBeNull();
+  });
+
+  it("shows defaults normally when a selectable model exists", () => {
+    const container = mount(props());
+    expect(container.querySelector('[data-model-readiness="model-required"]')).toBeNull();
+    expect(container.querySelector(".model-providers__defaults")).not.toBeNull();
+  });
+
   it("labels provider usage and session cost as global", () => {
     const container = mount(
       props({
@@ -285,6 +377,41 @@ describe("renderModelProviders", () => {
     const probe = container.querySelector(".model-providers__probe--error");
     expect(text(probe)).toContain("Billing problem");
     expect(text(probe)).toContain("Account has no credits");
+  });
+
+  it("presents no-model probe results as a setup state, not a connection failure", () => {
+    const container = mount(
+      props({
+        cards: [
+          card({
+            auth: { kind: "ok", profileCount: 1 },
+            profiles: [{ profileId: "openai:chatgpt", type: "oauth", status: "ok" }],
+            modelCount: 0,
+            availableModelCount: 0,
+          }),
+        ],
+        configuredModels: [],
+        probeResults: {
+          openai: {
+            provider: "openai",
+            status: "no_model",
+            error: "No model is available for this provider.",
+            results: [
+              {
+                profileId: "openai:chatgpt",
+                label: "ChatGPT",
+                status: "no_model",
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    const provider = container.querySelector('[data-provider-id="openai"]');
+    expect(text(provider)).toContain("Signed in");
+    expect(text(provider)).toContain("No models available");
+    expect(text(provider)).not.toContain("Connection failed");
   });
 
   it("qualifies slash-bearing model IDs with their catalog provider", () => {

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -82,6 +82,7 @@ type ModelProvidersViewProps = {
   onDefaultModelsReset: () => void;
   onThinkingChange: (level: string) => void;
   onFastModeChange: (mode: FastMode) => void;
+  onOpenModelSetup: () => void;
 };
 
 // The global default intentionally omits "minimal"; the full list stays
@@ -161,6 +162,38 @@ function renderAuthStatus(card: ModelProviderCard) {
       ${renderSettingsStatus({ kind: AUTH_KIND_STATUS[auth.kind], label })}
     </span>
   `;
+}
+
+function hasProviderCredentials(card: ModelProviderCard): boolean {
+  return card.hasConfigApiKey || Boolean(card.apiKey) || card.profiles.length > 0;
+}
+
+function hasValidProviderSignIn(card: ModelProviderCard): boolean {
+  return card.auth?.kind === "ok";
+}
+
+function renderProviderStatus(card: ModelProviderCard) {
+  if (card.auth?.kind === "expired" || card.auth?.kind === "missing") {
+    return renderAuthStatus(card);
+  }
+  if (card.auth?.kind === "expiring") {
+    return renderAuthStatus(card);
+  }
+  if (!hasProviderCredentials(card)) {
+    return renderAuthStatus(card);
+  }
+  if (card.availableModelCount > 0 && (hasValidProviderSignIn(card) || !card.auth)) {
+    return renderSettingsStatus({
+      kind: "ok",
+      label: t("modelProviders.status.ready"),
+    });
+  }
+  return hasValidProviderSignIn(card)
+    ? renderSettingsStatus({
+        kind: "muted",
+        label: t("modelProviders.status.ok"),
+      })
+    : renderAuthStatus(card);
 }
 
 function modelsText(card: ModelProviderCard): string | null {
@@ -428,7 +461,7 @@ function renderProviderRow(card: ModelProviderCard, props: ModelProvidersViewPro
         </div>
         <div class="settings-row__control">
           ${card.usage?.plan ? renderSettingsValue(card.usage.plan) : nothing}
-          ${renderAuthStatus(card)}
+          ${renderProviderStatus(card)}
         </div>
       </div>
       ${renderCredentialSummary(card, props.credentialAgentLabel)}
@@ -521,6 +554,34 @@ function renderAddProvider(props: ModelProvidersViewProps) {
   );
 }
 
+function renderModelReadiness(props: ModelProvidersViewProps) {
+  const signedIn = props.cards.some(hasValidProviderSignIn);
+  return html`
+    <div class="model-providers__setup" data-model-readiness="model-required">
+      ${renderSettingsSection(
+        { title: t("modelProviders.readiness.title") },
+        renderSettingsRow({
+          title: t("modelProviders.readiness.heading"),
+          description: signedIn
+            ? t("modelProviders.readiness.signedInNoModels")
+            : t("modelProviders.readiness.notConfigured"),
+          control: html`
+            ${renderSettingsStatus({
+              kind: "warn",
+              label: signedIn
+                ? t("modelProviders.readiness.noModels")
+                : t("modelProviders.readiness.modelRequired"),
+            })}
+            <button class="btn primary" @click=${props.onOpenModelSetup}>
+              ${signedIn ? t("modelProviders.readiness.chooseProvider") : t("modelSetup.heading")}
+            </button>
+          `,
+        }),
+      )}
+    </div>
+  `;
+}
+
 export function renderModelProviders(props: ModelProvidersViewProps) {
   if (!props.connected) {
     return renderSettingsPage(
@@ -551,22 +612,25 @@ export function renderModelProviders(props: ModelProvidersViewProps) {
         )
       : props.cards.map((card) => renderProviderRow(card, props))}
   `;
+  const needsModelSetup = !props.configuredModels.some((model) => model.available !== false);
   return renderSettingsPage(html`
-    ${renderDefaultModels({
-      models: props.configuredModels,
-      selection: props.defaultModels,
-      dirty: props.defaultModelsDirty,
-      canMutate: props.canMutate,
-      mutationBlockedReason: props.mutationBlockedReason,
-      busy: props.busy,
-      message: props.messages.defaults,
-      onPrimaryChange: props.onPrimaryChange,
-      onFallbackAdd: props.onFallbackAdd,
-      onFallbackRemove: props.onFallbackRemove,
-      onUtilityChange: props.onUtilityChange,
-      onSave: props.onDefaultModelsSave,
-      onReset: props.onDefaultModelsReset,
-    })}
+    ${needsModelSetup
+      ? renderModelReadiness(props)
+      : renderDefaultModels({
+          models: props.configuredModels,
+          selection: props.defaultModels,
+          dirty: props.defaultModelsDirty,
+          canMutate: props.canMutate,
+          mutationBlockedReason: props.mutationBlockedReason,
+          busy: props.busy,
+          message: props.messages.defaults,
+          onPrimaryChange: props.onPrimaryChange,
+          onFallbackAdd: props.onFallbackAdd,
+          onFallbackRemove: props.onFallbackRemove,
+          onUtilityChange: props.onUtilityChange,
+          onSave: props.onDefaultModelsSave,
+          onReset: props.onDefaultModelsReset,
+        })}
     ${renderModelBehavior(props)}
     ${renderSettingsSection(
       {

--- a/ui/src/styles/model-providers.css
+++ b/ui/src/styles/model-providers.css
@@ -61,6 +61,16 @@
   gap: 12px;
 }
 
+.model-providers__setup .settings-row {
+  min-height: 92px;
+  padding-block: var(--space-5);
+}
+
+.model-providers__setup .settings-row__title {
+  font-size: var(--control-ui-text-lg);
+  font-weight: 600;
+}
+
 .model-providers__credentials {
   display: flex;
   align-items: baseline;
@@ -190,6 +200,21 @@
 }
 
 @media (max-width: 700px) {
+  .model-providers__head {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .model-providers__identity,
+  .model-providers__head > .settings-row__control {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+
+  .model-providers__head > .settings-row__control {
+    justify-content: flex-start;
+  }
+
   .model-providers__default-grid,
   .model-providers__add-form {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with provider credentials but no selectable model were shown disabled default-model controls first, while the recovery action was hidden in the page header. The same state labeled credentials as "Connected" even when the account exposed no usable models.

## Why This Change Was Made

The Models page now leads with the existing Model Setup flow whenever no usable model is selectable. Provider status distinguishes valid sign-in from model readiness, and authoritative empty provider catalogs remain empty rather than assuming static catalog entries are account entitlements.

## User Impact

Users can immediately see what is missing and open Model Setup. Signed-in accounts with no available models now direct users to another provider or account instead of presenting a misleading connection failure or unusable default controls. Configured but unverified API keys remain labeled as API keys rather than being presented as ready.

## Evidence

- Focused units: 55 passed across gateway probe, probe planner, and Models UI coverage.
- Mocked Control UI E2E: 4 passed.
- `control-ui-i18n verify`: passed.
- `git diff --check`: passed.
- Fresh autoreview: no accepted/actionable findings; patch rated correct at 0.82 confidence.
- Desktop and mobile geometry assertions cover the readiness action and provider-row wrapping.

### Desktop

Before:

![before-desktop.png](https://github.com/user-attachments/assets/0e562829-9137-4420-8f5d-7d54d33d0c2e)

After:

![after-desktop.png](https://github.com/user-attachments/assets/373bde97-8b38-4d7d-bb1e-49554d8ce29c)

### Mobile

Before:

![before-mobile.png](https://github.com/user-attachments/assets/45791121-b21d-4f8d-8f04-b9c4b8f8a6e7)

After:

![after-mobile.png](https://github.com/user-attachments/assets/dd4cb642-65af-43fd-9b29-f7f6dd18a235)

AI-assisted: Codex was used for implementation and structured review; the maintainer inspected the diff, tests, and visual evidence.
