### PR TITLE
fix(macos): recover dashboard after Gateway authentication

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -31859,7 +31859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 223,
+      "line": 246,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Dashboard reconnecting",
       "surface": "apple",
@@ -31867,7 +31867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 224,
+      "line": 247,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "The selected Gateway changed.",
       "surface": "apple",
@@ -31875,7 +31875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 225,
+      "line": 248,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Waiting for a fresh authenticated connection.",
       "surface": "apple",
@@ -31883,7 +31883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 381,
+      "line": 404,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Dashboard unavailable",
       "surface": "apple",
@@ -31891,7 +31891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 383,
+      "line": 406,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Check Settings → Connection or use Debug → Reset Remote Tunnel, then try again.",
       "surface": "apple",
@@ -31899,7 +31899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 589,
+      "line": 612,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Could Not Switch Gateway",
       "surface": "apple",
@@ -31907,7 +31907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 617,
+      "line": 640,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Could Not Open Gateway Window",
       "surface": "apple",
@@ -31915,7 +31915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 721,
+      "line": 744,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "\\(base)-\\(UUID().uuidString)",
       "surface": "apple",
@@ -31923,7 +31923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 961,
+      "line": 984,
       "path": "apps/macos/Sources/OpenClaw/DashboardManager.swift",
       "source": "Could Not Set Primary Gateway",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -37,6 +37,7 @@ final class DashboardManager {
     @ObservationIgnored private var switchGenerations: [ObjectIdentifier: UInt64] = [:]
     @ObservationIgnored private let authTokenProvider: @Sendable (GatewayConnection.Config) async -> String?
     @ObservationIgnored private let routeProbe: @Sendable () async -> Void
+    @ObservationIgnored private let endpointStateProvider: @Sendable () async -> GatewayEndpointState
     @ObservationIgnored private let mainWindowAutosaveName: String
     private(set) var gatewayEntries: [DashboardGatewayEntry] = []
     private(set) var frontmostDashboardTarget: DashboardGatewayTarget?
@@ -61,11 +62,15 @@ final class DashboardManager {
                 timeoutMs: 3000,
                 retryTransportFailures: false)
         },
+        endpointStateProvider: @escaping @Sendable () async -> GatewayEndpointState = {
+            await GatewayEndpointStore.shared.currentState()
+        },
         observeGatewayChanges: Bool = true,
         mainWindowAutosaveName: String = DashboardWindowLayout.windowFrameAutosaveName)
     {
         self.authTokenProvider = authTokenProvider
         self.routeProbe = routeProbe
+        self.endpointStateProvider = endpointStateProvider
         self.mainWindowAutosaveName = mainWindowAutosaveName
         if observeGatewayChanges {
             let names: [Notification.Name] = [
@@ -79,7 +84,13 @@ final class DashboardManager {
                     object: nil,
                     queue: .main)
                 { [weak self] _ in
-                    Task { @MainActor [weak self] in await self?.refreshGatewaySnapshots() }
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        if name == .controlChannelStateDidChange {
+                            await self.handleControlChannelStateChange(ControlChannel.shared.state)
+                        }
+                        await self.refreshGatewaySnapshots()
+                    }
                 }
             }
             let windowNames: [Notification.Name] = [
@@ -96,6 +107,14 @@ final class DashboardManager {
                 }
             }
         }
+    }
+
+    private func handleControlChannelStateChange(_ state: ControlChannel.ConnectionState) async {
+        guard state == .connected else { return }
+        // Endpoint readiness can precede device authentication. Replay the
+        // unchanged route once the control socket owns a usable credential.
+        let endpointState = await self.endpointStateProvider()
+        await self.handleEndpointState(endpointState, forceRouteReplacement: true)
     }
 
     func configure(updater: UpdaterProviding) {
@@ -131,7 +150,10 @@ final class DashboardManager {
         }
     }
 
-    func handleEndpointState(_ state: GatewayEndpointState) async {
+    func handleEndpointState(
+        _ state: GatewayEndpointState,
+        forceRouteReplacement: Bool = false) async
+    {
         // The shared endpoint stream owns only the main window's primary route.
         // Profile-targeted documents keep their saved endpoint and credentials.
         guard self.mainTarget == .primary else { return }
@@ -143,8 +165,9 @@ final class DashboardManager {
         }
         let config: GatewayConnection.Config = (url, token, password)
         let tlsParams = Self.primaryTLSParams(for: config, mode: mode)
-        let routeChanged = self.displayedRouteRevision.map { $0 != routeRevision }
-            ?? (routeRevision > 0) || !controller.hasTLSParams(tlsParams)
+        let routeChanged = forceRouteReplacement ||
+            (self.displayedRouteRevision.map { $0 != routeRevision }
+                ?? (routeRevision > 0) || !controller.hasTLSParams(tlsParams))
         var authToken = await self.authTokenProvider(config)
         if authToken == nil, password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty == nil {
             await self.routeProbe()
@@ -977,6 +1000,9 @@ extension DashboardManager {
     static func _testMake(
         authTokenProvider: @escaping @Sendable (GatewayConnection.Config) async -> String? = { $0.token },
         routeProbe: @escaping @Sendable () async -> Void = {},
+        endpointStateProvider: @escaping @Sendable () async -> GatewayEndpointState = {
+            .unavailable(mode: .unconfigured, reason: "not configured")
+        },
         primaryEndpointProvider: (@Sendable (AppState.ConnectionMode) async throws
             -> GatewayConnection.EndpointSnapshot)? = nil,
         profileEndpointProvider: (@Sendable (String) async throws
@@ -987,6 +1013,7 @@ extension DashboardManager {
         let manager = DashboardManager(
             authTokenProvider: authTokenProvider,
             routeProbe: routeProbe,
+            endpointStateProvider: endpointStateProvider,
             observeGatewayChanges: false,
             mainWindowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
         manager.testPrimaryEndpointProvider = primaryEndpointProvider
@@ -1017,6 +1044,10 @@ extension DashboardManager {
 
     func _testSwitchFrontmostDashboard(to target: DashboardGatewayTarget) async {
         await self.performSwitchFrontmostDashboard(to: target)
+    }
+
+    func _testHandleControlChannelStateChange(_ state: ControlChannel.ConnectionState) async {
+        await self.handleControlChannelStateChange(state)
     }
 
     func _testWindowTLSParams(for target: DashboardGatewayTarget) async throws -> GatewayTLSParams? {

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -426,6 +426,10 @@ actor GatewayEndpointStore {
         }
     }
 
+    func currentState() async -> GatewayEndpointState {
+        self.state
+    }
+
     func refresh() async {
         _ = await self.refreshIfCurrent()
     }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardReconnectTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+private actor DashboardReconnectAuthGate {
+    private var token: String?
+
+    func authToken() -> String? {
+        self.token
+    }
+
+    func replaceToken(_ token: String) {
+        self.token = token
+    }
+}
+
+@Suite(.serialized)
+@MainActor
+struct DashboardReconnectTests {
+    @Test func `authenticated control reconnect recovers unchanged ready route`() async throws {
+        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=route-a-device-token"))
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(
+                gatewayUrl: "ws://127.0.0.1:60001/",
+                token: "route-a-device-token",
+                password: nil),
+            windowAutosaveName: "OpenClawDashboardWindow-Test-\(UUID().uuidString)")
+        controller.show()
+        let authGate = DashboardReconnectAuthGate()
+        let socketURL = try #require(URL(string: "ws://127.0.0.1:60002"))
+        let endpointState = GatewayEndpointState.ready(
+            mode: .remote,
+            url: socketURL,
+            token: nil,
+            password: nil,
+            routeRevision: 2)
+        let manager = DashboardManager._testMake(
+            authTokenProvider: { _ in await authGate.authToken() },
+            endpointStateProvider: { endpointState })
+        manager._testSetController(controller)
+        defer { manager._testController()?.closeDashboard() }
+
+        await manager.handleEndpointState(endpointState)
+        let failureController = try #require(manager._testController())
+        #expect(failureController !== controller)
+        #expect(failureController.currentURL == URL(string: "about:blank"))
+
+        await manager.handleEndpointState(endpointState)
+        #expect(manager._testController() === failureController)
+
+        await authGate.replaceToken("route-b-device-token")
+        await manager._testHandleControlChannelStateChange(.connecting)
+        #expect(manager._testController() === failureController)
+
+        await manager._testHandleControlChannelStateChange(.connected)
+
+        let recoveredController = try #require(manager._testController())
+        #expect(recoveredController !== failureController)
+        #expect(!failureController.isWindowOpen)
+        #expect(recoveredController.currentURL.absoluteString ==
+            "http://127.0.0.1:60002/#token=route-b-device-token")
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the native macOS dashboard could remain on "Dashboard reconnecting" after the selected Gateway changed. This occurred when the endpoint became ready before the control channel finished device authentication, with no later endpoint revision to trigger another dashboard load.

## Why This Change Was Made

The dashboard now replays the current endpoint when the control channel reaches authenticated `connected` state. A route without a usable credential also remains undisplayed, ensuring recovery recreates the WebView with the fresh route and TLS policy instead of mutating the credentialless failure controller.

## User Impact

After changing or reconnecting the selected Gateway, the native dashboard automatically leaves the reconnecting screen as soon as authentication completes.

## Evidence

- `swift test --package-path apps/macos --filter Dashboard`
  - 69 tests passed across 9 Dashboard suites.
- `swift test --package-path apps/macos --filter DashboardReconnectTests`
  - focused unchanged-route authentication regression passed on rebased head `7a9f362dea6a42c07fc04fbb2ab94cb71edee40b`.
- SwiftFormat lint: clean.
- SwiftLint strict: clean.
- Native app i18n inventory: 5,382 entries, unchanged after generated line metadata refresh.
- `git diff --check`: clean.
- Final branch autoreview: clean, no accepted/actionable findings, confidence 0.90.
