### PR TITLE
test(buzz): add opt-in thread QA coverage

### DIFF
--- a/extensions/buzz/src/qa/adapter.runtime.test.ts
+++ b/extensions/buzz/src/qa/adapter.runtime.test.ts
@@ -1,6 +1,7 @@
-import type {
-  QaBusInboundMessageInput,
-  QaBusMessage,
+import {
+  parseQaTarget,
+  type QaBusInboundMessageInput,
+  type QaBusMessage,
 } from "openclaw/plugin-sdk/qa-channel-protocol";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { parseBuzzQaCredentialPayload } from "./credentials.js";
@@ -179,7 +180,13 @@ describe("Buzz QA transport adapter", () => {
       ...input,
       id: `bus-outbound-${++outboundIndex}`,
       direction: "outbound" as const,
-      conversation: { id: "main", kind: "group" as const },
+      conversation: (() => {
+        const target = parseQaTarget(input.to);
+        return {
+          id: target.conversationId,
+          kind: target.chatType,
+        };
+      })(),
     }));
     sendMessage
       .mockResolvedValueOnce({ eventId: "native-root", timestamp: 1_750_000_000_000 })
@@ -199,7 +206,7 @@ describe("Buzz QA transport adapter", () => {
 
     const root = await adapter.sendInbound({
       accountId: "sut",
-      conversation: { id: "main", kind: "group" },
+      conversation: { id: "main", kind: "channel" },
       senderId: "driver",
       senderName: "QA Driver",
       text: "@openclaw root",
@@ -216,7 +223,7 @@ describe("Buzz QA transport adapter", () => {
     });
     const followUp = await adapter.sendInbound({
       accountId: "sut",
-      conversation: { id: "main", kind: "group" },
+      conversation: { id: "main", kind: "channel" },
       senderId: "driver",
       senderName: "QA Driver",
       text: "@openclaw follow-up",
@@ -240,6 +247,7 @@ describe("Buzz QA transport adapter", () => {
     });
     expect(addOutboundMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
+        to: "channel:main",
         threadId: root.id,
         replyToId: followUp.id,
       }),

--- a/extensions/buzz/src/qa/adapter.runtime.ts
+++ b/extensions/buzz/src/qa/adapter.runtime.ts
@@ -1,5 +1,6 @@
 import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { QaBusConversationKind } from "openclaw/plugin-sdk/qa-channel-protocol";
 import type { QaRunnerCliRegistration } from "openclaw/plugin-sdk/qa-runner-runtime";
 import type { BuzzInboundMessage } from "../message-event.js";
 import { buildBuzzTarget } from "../target.js";
@@ -90,7 +91,10 @@ export async function createBuzzQaTransportAdapter(
   const accountId = options.sutAccountId?.trim() || "sut";
   const nativeMessageIds = new Map<string, string>();
   const busMessageIds = new Map<string, string>();
+  // QA scenarios own the logical target while Buzz uses one physical group room.
+  // Preserve both logical fields so outbound matching sees the conversation it sent.
   let logicalConversationId = credentials.roomId;
+  let logicalConversationKind: QaBusConversationKind = "group";
   let relayDriver: Awaited<ReturnType<typeof createBuzzQaRelayDriver>>;
 
   const resolveBusMessageId = async (nativeId: string | undefined) => {
@@ -118,7 +122,7 @@ export async function createBuzzQaTransportAdapter(
     ]);
     const outbound = await context.messages.addOutboundMessage({
       accountId,
-      to: `group:${logicalConversationId}`,
+      to: `${logicalConversationKind}:${logicalConversationId}`,
       senderId: credentials.sutPublicKey,
       text: message.text,
       timestamp: message.createdAt * 1_000,
@@ -154,6 +158,7 @@ export async function createBuzzQaTransportAdapter(
       heartbeat.throwIfFailed();
       relayDriver.assertHealthy();
       logicalConversationId = input.conversation.id;
+      logicalConversationKind = input.conversation.kind;
       const sent = await relayDriver.sendMessage({
         text: input.text,
         mentionSut: isBuzzMention(input.text),
@@ -172,6 +177,7 @@ export async function createBuzzQaTransportAdapter(
     },
     resetTransport() {
       logicalConversationId = credentials.roomId;
+      logicalConversationKind = "group";
       nativeMessageIds.clear();
       busMessageIds.clear();
     },

--- a/extensions/buzz/src/qa/cli.test.ts
+++ b/extensions/buzz/src/qa/cli.test.ts
@@ -48,4 +48,28 @@ describe("Buzz QA CLI", () => {
       }),
     ).toEqual(["channel-canary", "channel-mention-gating"]);
   });
+
+  it("forwards an explicitly selected thread follow-up scenario", async () => {
+    const qa = new Command();
+    buzzQaCliRegistration.register(qa);
+
+    await qa.parseAsync([
+      "node",
+      "openclaw",
+      "buzz",
+      "--credential-file",
+      "/secure/buzz-qa.json",
+      "--scenario",
+      "thread-follow-up",
+    ]);
+
+    const params = runLiveTransportQaSuiteCommand.mock.calls[0]?.[0];
+    expect(
+      params?.selectScenarioIds({
+        primaryModel: "openai/gpt-5.4",
+        providerMode: "mock-openai",
+        scenarioIds: ["thread-follow-up"],
+      }),
+    ).toEqual(["thread-follow-up"]);
+  });
 });

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -1017,11 +1017,19 @@ describe("qa scenario catalog", () => {
   });
 
   it("keeps portable thread relation flows on channels with native thread semantics", () => {
-    for (const scenarioId of ["thread-follow-up", "thread-isolation"]) {
+    const expectations = [
+      {
+        scenarioId: "thread-follow-up",
+        channels: ["qa-channel", "buzz", "slack", "matrix"],
+      },
+      { scenarioId: "thread-isolation", channels: ["qa-channel", "slack", "matrix"] },
+    ];
+
+    for (const { scenarioId, channels } of expectations) {
       const scenario = requireFlowScenario(readQaScenarioById(scenarioId));
 
       expect(scenario.execution.channel, scenarioId).toBeUndefined();
-      expect(scenario.execution.channels, scenarioId).toEqual(["qa-channel", "slack", "matrix"]);
+      expect(scenario.execution.channels, scenarioId).toEqual(channels);
     }
   });
 

--- a/qa/scenarios/channels/thread-follow-up.yaml
+++ b/qa/scenarios/channels/thread-follow-up.yaml
@@ -19,11 +19,12 @@ scenario:
     - docs/concepts/qa-e2e-automation.md
   codeRefs:
     - extensions/qa-lab/src/qa-transport.ts
+    - extensions/buzz/src/qa/adapter.runtime.ts
     - extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
     - extensions/qa-lab/src/live-transports/matrix/adapter.runtime.ts
   execution:
     kind: flow
-    channels: [qa-channel, slack, matrix]
+    channels: [qa-channel, buzz, slack, matrix]
     summary: Send a deterministic follow-up through the shared host and require native thread relation evidence.
     config:
       rootMarker: QA-THREAD-ROOT-OK


### PR DESCRIPTION
## What Problem This Solves

The canonical Buzz live QA runner landed through #116298, but the shared `thread-follow-up` scenario still excludes Buzz even though the Buzz adapter preserves native thread and reply relations.

This PR now contains only the remaining catalog integration and the Buzz adapter repair needed for that flow. It does not recreate the runner or add threaded coverage to Buzz's default live lane.

## Why This Change Was Made

- Adds Buzz to the shared `thread-follow-up` scenario's declared channel set and code references.
- Keeps the default Buzz QA selection limited to `channel-canary` and `channel-mention-gating`.
- Adds focused coverage for explicit `--scenario thread-follow-up` selection.
- Splits the catalog invariant so Buzz is not accidentally added to the unproven `thread-isolation` sibling scenario.
- Preserves the scenario's logical conversation kind when Buzz records relay replies, so the shared flow's strict outbound matcher sees the requested `channel` target.

## User Impact

Maintainers can explicitly select the shared threaded follow-up flow for Buzz:

```bash
pnpm openclaw qa buzz \
  --credential-file <path-to-buzz-qa.json> \
  --scenario thread-follow-up
```

The default Buzz QA command remains unchanged.

## Evidence

- Focused Vitest: 77 tests passed across the Buzz CLI/adapter and QA scenario catalog/selection suites.
- Initial Blacksmith Testbox `check:changed`: passed with exit 0, including all-project typecheck, lint, dependency/boundary guards, dead-code checks, and import-cycle checks.
  - Testbox: `tbx_01kzvfwgwc8fd3aq8ff9m49wh0`
  - Run: https://github.com/openclaw/openclaw/actions/runs/31622205860
- Repair Blacksmith Testbox `check:changed`: passed with exit 0 after the conversation-kind fix.
  - Testbox: `tbx_01kzvjs5b0nya9cvscbyzxsrrb`
  - Run: https://github.com/openclaw/openclaw/actions/runs/31626448520
- `git diff --check`: passed.
- Autoreview: clean before push and again after the repair, no accepted/actionable findings (Codex `gpt-5.6-sol`, high reasoning, 0.98 final confidence).
- Hosted Buzz relay proof is not claimed: this maintenance session had no dedicated Buzz QA credential pair. Exact-head CI and ClawSweeper review remain pending.
