### PR TITLE
docs(hooks): clarify inbound claim ownership

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -167,16 +167,22 @@ observation-only.
 
 **Messages and delivery**
 
-| Hook                        | Purpose                                                           |
-| --------------------------- | ----------------------------------------------------------------- |
-| **`inbound_claim`**         | Claim an inbound message before agent routing (synthetic replies) |
-| `channel_pairing_requested` | Observe newly created DM pairing requests                         |
-| `message_received`          | Observe inbound content, sender, thread, and metadata             |
-| **`message_sending`**       | Rewrite outbound content or cancel delivery                       |
-| **`reply_payload_sending`** | Mutate or cancel normalized reply payloads before delivery        |
-| `message_sent`              | Observe outbound delivery success or failure                      |
-| **`before_dispatch`**       | Inspect or rewrite an outbound dispatch before channel handoff    |
-| **`reply_dispatch`**        | Participate in the final reply-dispatch pipeline                  |
+| Hook                        | Purpose                                                                    |
+| --------------------------- | -------------------------------------------------------------------------- |
+| **`inbound_claim`**         | Claim an inbound message for the plugin that owns its conversation binding |
+| `channel_pairing_requested` | Observe newly created DM pairing requests                                  |
+| `message_received`          | Observe inbound content, sender, thread, and metadata                      |
+| **`message_sending`**       | Rewrite outbound content or cancel delivery                                |
+| **`reply_payload_sending`** | Mutate or cancel normalized reply payloads before delivery                 |
+| `message_sent`              | Observe outbound delivery success or failure                               |
+| **`before_dispatch`**       | Inspect or rewrite an outbound dispatch before channel handoff             |
+| **`reply_dispatch`**        | Participate in the final reply-dispatch pipeline                           |
+
+`inbound_claim` is not a global pre-routing broadcast. OpenClaw invokes it only
+for the plugin that owns the message's core-managed conversation binding. To
+suppress an ordinary agent turn before model input without retaining the
+original prompt in transcript, use `before_agent_run`. To short-circuit an agent
+turn with a synthetic reply or silence, use `before_agent_reply`.
 
 **Sessions and compaction**
 


### PR DESCRIPTION
Related: #109353
Related design: #81061

## What Problem This Solves

Fixes documentation that could lead plugin authors to interpret
`inbound_claim` as a global pre-routing hook for every inbound message.

## Why This Change Was Made

Clarifies that `inbound_claim` is invoked only for the plugin owning the
core-managed conversation binding. It directs ordinary transcript-safe
pre-model suppression to `before_agent_run` and synthetic replies or silence
to `before_agent_reply`.

## User Impact

Plugin authors can select the correct hook without relying on behavior that
OpenClaw does not provide.

## Evidence

- Confirmed ordinary messages do not broadcast inbound claims.
- Confirmed bound conversations target only their owning plugin.
- Confirmed `before_agent_run` blocks before model input without retaining the
  original prompt in transcript.
- Confirmed `before_agent_reply` supplies synthetic replies or silence.
- Docs MDX check passed: 764 files.
- Link audit passed: 6,340 links, 0 broken.
- Formatting and `git diff --check` passed.
