### PR TITLE
fix(hooks): report eventless hooks as not ready

### DIFF
--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -85,6 +85,20 @@ function createPluginManagedHookReport(): HookStatusReport {
   };
 }
 
+function createEventlessHookReport(): HookStatusReport {
+  return {
+    ...report,
+    hooks: [
+      {
+        ...expectDefined(report.hooks[0], "report.hooks[0] test invariant"),
+        events: [],
+        loadable: false,
+        blockedReason: "no events defined",
+      },
+    ],
+  };
+}
+
 describe("hooks cli formatting", () => {
   it("labels hooks list output", () => {
     const output = formatHooksList(report, {});
@@ -95,6 +109,33 @@ describe("hooks cli formatting", () => {
   it("labels hooks status output", () => {
     const output = formatHooksCheck(report, {});
     expect(output).toContain("Hooks Status");
+  });
+
+  it("classifies eventless hooks as not ready in human check output", () => {
+    const output = formatHooksCheck(createEventlessHookReport(), {});
+
+    expect(output).toContain("Ready: 0");
+    expect(output).toContain("Not ready: 1");
+    expect(output).toContain("session-memory - no events defined");
+  });
+
+  it("classifies eventless hooks as not eligible in JSON check output", () => {
+    const output = JSON.parse(formatHooksCheck(createEventlessHookReport(), { json: true }));
+
+    expect(output).toMatchObject({
+      total: 1,
+      eligible: 0,
+      notEligible: 1,
+      hooks: {
+        eligible: [],
+        notEligible: [
+          {
+            name: "session-memory",
+            blockedReason: "no events defined",
+          },
+        ],
+      },
+    });
   });
 
   it("labels plugin-managed hooks with plugin id", () => {

--- a/src/hooks/hooks-status.test.ts
+++ b/src/hooks/hooks-status.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildWorkspaceHookStatus } from "./hooks-status.js";
+import type { HookEntry } from "./types.js";
+
+function createHookEntry(params: {
+  source: HookEntry["hook"]["source"];
+  events: string[];
+}): HookEntry {
+  return {
+    hook: {
+      name: "session-memory",
+      description: "Save session context to memory",
+      source: params.source,
+      filePath: `/tmp/${params.source}/HOOK.md`,
+      baseDir: `/tmp/${params.source}`,
+      handlerPath: `/tmp/${params.source}/handler.js`,
+    },
+    frontmatter: {},
+    metadata: { events: params.events },
+  };
+}
+
+describe("hook status", () => {
+  it("reports an eventless managed winner as not loadable", () => {
+    const report = buildWorkspaceHookStatus("/tmp/workspace", {
+      entries: [
+        createHookEntry({
+          source: "openclaw-managed",
+          events: [],
+        }),
+        createHookEntry({
+          source: "openclaw-workspace",
+          events: ["command:new"],
+        }),
+      ],
+    });
+
+    expect(report.hooks).toHaveLength(1);
+    expect(report.hooks[0]).toMatchObject({
+      source: "openclaw-managed",
+      events: [],
+      enabledByConfig: true,
+      requirementsSatisfied: true,
+      loadable: false,
+      blockedReason: "no events defined",
+    });
+  });
+});

--- a/src/hooks/hooks-status.ts
+++ b/src/hooks/hooks-status.ts
@@ -42,7 +42,7 @@ export type HookStatusEntry = {
   enabledByConfig: boolean;
   requirementsSatisfied: boolean;
   loadable: boolean;
-  blockedReason?: HookEnableStateReason | "missing requirements";
+  blockedReason?: HookEnableStateReason | "missing requirements" | "no events defined";
   managedByPlugin: boolean;
   requirements: Requirements;
   missing: Requirements;
@@ -114,9 +114,11 @@ function buildHookStatus(
     });
 
   const enabledByConfig = enableState.enabled;
-  const loadable = enabledByConfig && requirementsSatisfied;
+  const hasEvents = events.length > 0;
+  const loadable = enabledByConfig && requirementsSatisfied && hasEvents;
   const blockedReason =
-    enableState.reason ?? (requirementsSatisfied ? undefined : "missing requirements");
+    enableState.reason ??
+    (!requirementsSatisfied ? "missing requirements" : hasEvents ? undefined : "no events defined");
 
   return {
     name: entry.hook.name,


### PR DESCRIPTION
Refs #72370

## What Problem This Solves

Fixes an issue where `openclaw hooks check` reported a selected hook as ready
even when it declared no events and the runtime loader would skip it.

## Why This Change Was Made

Hook status now applies the same event requirement as the runtime loader.
Hooks without declared events are not loadable and report the explicit blocked
reason `no events defined`. Existing managed/workspace override precedence is
unchanged.

## User Impact

Operators now receive an accurate not-ready diagnostic instead of a false
ready result for eventless hooks. For managed/workspace name collisions, the
managed hook remains authoritative and the status output makes its eventless
state visible.

Release note: `openclaw hooks check` now reports selected hooks without
declared events as not ready.

## Evidence

- 9 focused hook-status and CLI tests passed on exact head
  `b3a6ca64590e6d93e902e988c4a2b32737e01f0a`.
- Human output reports `Ready: 0`, `Not ready: 1`, and `no events defined`.
- JSON output places the hook in `notEligible` with the same blocked reason.
- Targeted lint, formatting, diff check, and native schema guard passed.
- Fresh autoreview reported no actionable findings.
