### PR TITLE
fix(agents): settle aborted runs through after-turn so agent_end fires

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-after-turn.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-after-turn.ts
@@ -180,11 +180,18 @@ export async function completeEmbeddedAttemptAfterTurn(
     !state.beforeAgentFinalizeRevisionReason
   ) {
     const lifecycleForAgentEnd = input.readLifecycleState();
+    // Abort outranks failure in terminal-outcome precedence: teardown races can
+    // stamp an AbortError into promptError, and surfacing it as `error` would
+    // make agent_end consumers treat a user abort as an errored completion.
+    const agentEndError =
+      state.promptError && !lifecycleForAgentEnd.aborted
+        ? formatErrorMessage(state.promptError)
+        : undefined;
     runAgentEndSideEffects({
       event: {
         messages: state.messagesSnapshot,
         success: !lifecycleForAgentEnd.aborted && !state.promptError,
-        error: state.promptError ? formatErrorMessage(state.promptError) : undefined,
+        error: agentEndError,
         durationMs: Date.now() - runtime.promptStartedAt,
       },
       ctx: buildEmbeddedAgentEndContext({

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   runAgentEndSideEffects: vi.fn(),
+  shouldWaitForCompletionRequiredAsyncTasks: vi.fn((): boolean => false),
+  waitForCompletionRequiredAsyncTasks: vi.fn(),
 }));
 
 vi.mock("../../harness/agent-end-side-effects.js", () => ({
@@ -10,6 +12,10 @@ vi.mock("../../harness/agent-end-side-effects.js", () => ({
 vi.mock("./agent-end-context.js", () => ({
   buildEmbeddedAgentEndContext: () => ({}),
 }));
+vi.mock("./attempt.async-tasks.js", () => ({
+  shouldWaitForCompletionRequiredAsyncTasks: hoisted.shouldWaitForCompletionRequiredAsyncTasks,
+  waitForCompletionRequiredAsyncTasks: hoisted.waitForCompletionRequiredAsyncTasks,
+}));
 
 import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
@@ -17,6 +23,8 @@ import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 describe("embedded attempt phase lifecycle state", () => {
   beforeEach(() => {
     hoisted.runAgentEndSideEffects.mockReset();
+    hoisted.shouldWaitForCompletionRequiredAsyncTasks.mockReset().mockReturnValue(false);
+    hoisted.waitForCompletionRequiredAsyncTasks.mockReset();
   });
 
   it("re-reads compaction timeout state after the retry wait", async () => {
@@ -93,6 +101,135 @@ describe("embedded attempt phase lifecycle state", () => {
 
     expect(result.timedOutDuringCompaction).toBe(true);
     expect(removeTrailingEntries).toHaveBeenCalledOnce();
+  });
+
+  it("settles a user-aborted run whose async-task wait throws AbortError", async () => {
+    const abortError = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+    hoisted.shouldWaitForCompletionRequiredAsyncTasks.mockReturnValue(true);
+    hoisted.waitForCompletionRequiredAsyncTasks
+      .mockRejectedValueOnce(abortError)
+      .mockResolvedValueOnce({ timedOutRunIds: ["exec-run-1"] });
+    const messages: never[] = [];
+    const sessionManager = {
+      appendCustomEntry: vi.fn(),
+      buildSessionContext: () => ({ messages }),
+      getEntries: () => [],
+      removeTrailingEntries: vi.fn(() => 0),
+    };
+    const activeSession = {
+      agent: { state: { messages } },
+      isCompacting: false,
+      isStreaming: false,
+      messages,
+      sessionId: "session-1",
+    };
+
+    const result = await settleEmbeddedAttemptStream({
+      attempt: {
+        runId: "run-1",
+        sessionId: "session-1",
+        sessionKey: "agent:main:main",
+        sessionFile: "/tmp/session.jsonl",
+        provider: "test",
+        modelId: "model",
+        model: { api: "openai-responses" },
+      } as never,
+      activeSession: activeSession as never,
+      sessionManager: sessionManager as never,
+      sessionLockController: {} as never,
+      withOwnedSessionWriteLock: async (operation) => await operation(),
+      subscription: {
+        toolMetas: [{ toolName: "exec", asyncStarted: true }],
+        waitForCompactionRetry: async () => {},
+        isCompactionInFlight: () => false,
+        getCompactionCount: () => 0,
+        getCurrentAttemptAssistant: () => undefined,
+        getUsageTotals: () => undefined,
+        getLastAssistantUsage: () => undefined,
+      } as never,
+      state: {
+        promptError: null,
+        promptErrorSource: null,
+        yieldAborted: false,
+        sessionIdUsed: "session-1",
+      },
+      readLifecycleState: () => ({
+        aborted: true,
+        timedOut: false,
+        timedOutDuringCompaction: false,
+      }),
+      markTimedOutDuringCompaction: () => {},
+      runAbortDeadlineAtMs: Date.now() + 60_000,
+      runAbortSignal: AbortSignal.abort(),
+      isProbeSession: true,
+      abortable: async (promise) => await promise,
+      prePromptMessageCount: 0,
+      toolSearchTargetTranscriptProjections: [],
+      cache: {
+        observabilityEnabled: false,
+        changesForTurn: null,
+        retention: undefined,
+      },
+      shouldFlushForContextEngine: false,
+    });
+
+    // The aborted run settles instead of unwinding the lane task, and its
+    // unfinished async tasks are not reclassified as a timeout failure.
+    expect(result.promptError).toBeNull();
+    expect(hoisted.waitForCompletionRequiredAsyncTasks).toHaveBeenCalledTimes(2);
+  });
+
+  it("emits an abort-classified agent_end event when a teardown error races the abort", async () => {
+    const abortError = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+    await completeEmbeddedAttemptAfterTurn({
+      attempt: {
+        runId: "run-1",
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+      } as never,
+      activeSession: {} as never,
+      sessionManager: { appendCustomEntry: vi.fn() } as never,
+      sessionLockController: {} as never,
+      withOwnedSessionWriteLock: async (operation) => await operation(),
+      state: {
+        promptError: abortError,
+        yieldAborted: false,
+        sessionIdUsed: "session-1",
+        messagesSnapshot: [],
+        prePromptMessageCount: 0,
+        contextEngineAfterTurnCheckpoint: null,
+        compactionOccurredThisAttempt: false,
+      },
+      readLifecycleState: () => ({
+        aborted: true,
+        timedOut: false,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+      }),
+      runtime: {
+        effectiveWorkspace: "/tmp/workspace",
+        agentDir: "/tmp/agent",
+        sessionAgentId: "main",
+        resolveActiveContextEnginePluginId: () => undefined,
+        shouldRecordCompletedBootstrapTurn: false,
+        cacheTrace: null,
+        anthropicPayloadLogger: null,
+        hookAgentId: "main",
+        diagnosticTrace: { traceId: "trace-1", spanId: "span-1" } as never,
+        skillWorkshopAvailable: true,
+        hookRunner: null,
+        promptStartedAt: Date.now(),
+      },
+    });
+
+    expect(hoisted.runAgentEndSideEffects).toHaveBeenCalledTimes(1);
+    const event = hoisted.runAgentEndSideEffects.mock.calls[0]?.[0]?.event;
+    expect(event).toMatchObject({ success: false });
+    expect(event?.error).toBeUndefined();
   });
 
   it("re-reads abort state inside the post-turn session write", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-finalize.ts
@@ -1,4 +1,5 @@
 /** Settles the provider stream and completes the post-turn lifecycle phase. */
+import { isRunnerAbortError } from "../abort.js";
 import { completeEmbeddedAttemptAfterTurn } from "./attempt-after-turn.js";
 import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 
@@ -70,7 +71,16 @@ export async function finalizeEmbeddedAttemptStreamPhase(input: {
     if (input.repairedRejectedThinkingReplay && !rewoundBeforeAgentFinalizeRevision) {
       activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
     }
-    await sessionLockController.releaseForPrompt();
+    try {
+      await sessionLockController.releaseForPrompt();
+    } catch (err) {
+      // An aborted attempt never submits another prompt, so a submission-blocked
+      // release is expected teardown noise. Rethrowing would skip settle and
+      // after-turn, silently starving every agent_end consumer for aborted runs.
+      if (!input.settle.readLifecycleState().aborted || !isRunnerAbortError(err)) {
+        throw err;
+      }
+    }
 
     const currentState = input.getState();
     const streamSettleState = {

--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.ts
@@ -144,7 +144,12 @@ export async function settleEmbeddedAttemptStream(input: {
         abortSignal: input.runAbortSignal,
       });
     } catch (err) {
-      if (!input.readLifecycleState().timedOut || !isRunnerAbortError(err)) {
+      // Timeouts AND user aborts must still settle so the attempt reaches
+      // after-turn (transcript flush, agent-end side effects). Rethrowing here
+      // unwinds the whole lane task and silently starves every agent_end
+      // consumer for aborted runs.
+      const lifecycle = input.readLifecycleState();
+      if ((!lifecycle.timedOut && !lifecycle.aborted) || !isRunnerAbortError(err)) {
         throw err;
       }
       asyncTaskWait = await waitForCompletionRequiredAsyncTasks({
@@ -153,7 +158,9 @@ export async function settleEmbeddedAttemptStream(input: {
         deadlineAtMs: Date.now(),
       });
     }
-    if (asyncTaskWait.timedOutRunIds.length > 0) {
+    // An aborted run legitimately leaves async tasks unfinished; stamping a
+    // timeout failure here would reclassify the abort as an errored completion.
+    if (asyncTaskWait.timedOutRunIds.length > 0 && !input.readLifecycleState().aborted) {
       promptError = new Error(
         `Timed out waiting for async task completion: ${asyncTaskWait.timedOutRunIds.join(", ")}`,
       );

--- a/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { findAgentRunTerminalOutcome } from "../../agent-run-terminal-outcome.js";
+import { buildAgentRunTerminalOutcomeFromAttempt } from "../../agent-run-terminal-outcome.js";
 import {
   cleanupTempPaths,
   createContextEngineAttemptRunner,
@@ -89,16 +89,14 @@ describe("runEmbeddedAttempt abort races", () => {
       },
     });
 
-    const error = await attempt.catch((caught: unknown) => caught);
+    // The abort-blocked prompt release no longer unwinds the attempt: the run
+    // settles so after-turn side effects still fire, and the run-budget
+    // timeout attribution survives on the resolved terminal.
+    const result = await attempt;
 
-    expect(error).toMatchObject({
-      message: "attempt aborted before prompt submission",
-    });
-    expect(findAgentRunTerminalOutcome(error)).toMatchObject({
-      reason: "hard_timeout",
+    expect(result.terminal).toMatchObject({ kind: "timeout" });
+    expect(buildAgentRunTerminalOutcomeFromAttempt({ terminal: result.terminal })).toMatchObject({
       status: "timeout",
-      timeoutPhase: "provider",
-      providerStarted: true,
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

User-aborted agent runs unwound with a raw `AbortError` out of the embedded run's lane task, skipping `completeEmbeddedAttemptAfterTurn` entirely. No agent-end side effects ever fired for aborted turns: the interrupted-turn experience review (#115887) was unreachable on the primary abort path, deterministic correction autocapture never ran (its own doc says failed-turn corrections are the most worth keeping), and plugin `agent_end` hooks were starved. Live-verified on a scratch gateway: `lane task error: lane=main ... error="AbortError: This operation was aborted"` / `"Error: attempt aborted before prompt submission"`, with zero scheduling activity.

## Why This Change Was Made

Three escape hatches let aborts bypass the settle → after-turn pipeline that already handles aborted lifecycles everywhere else (`finalizeAttemptContextEngineTurn` takes `aborted`, bootstrap persistence checks it, the agent-end event computes `success = !aborted && !promptError`):

1. `attempt-stream-finalize.ts` — `releaseForPrompt()` throws "attempt aborted before prompt submission" when abort blocks the next round's submission; an aborted attempt never submits another prompt, so this is expected teardown noise, now tolerated when the lifecycle is aborted.
2. `attempt-stream-settle.ts` — the completion-required async-task wait rethrew `AbortError` unless the lifecycle was `timedOut`; user aborts now settle the same way timeout-aborts always have. An aborted run's unfinished async tasks no longer stamp a "Timed out waiting for async task completion" prompt error (that would reclassify the abort as an errored completion).
3. `attempt-after-turn.ts` — teardown races can leave an `AbortError` in `promptError`; abort outranks failure in terminal-outcome precedence, so the agent-end event no longer attaches `error` when the lifecycle is aborted. The scheduler's abort-vs-error split then classifies correctly.

The abort-race test that pinned the old unwind ("preserves a run-budget timeout when abort blocks prompt submission") now asserts the run resolves with its run-budget timeout attribution preserved on the terminal — convergent with the normal timeout contract, which always settled through this path.

## User Impact

Interrupting a deep agent turn now feeds self-learning and plugin hooks instead of silently dropping the turn. No config or API changes.

## Evidence

- Live before/after on a scratch dev gateway (real OpenAI, `gpt-5.6-luna`, native runtime): before — SIGINT mid-turn produced a lane-task `AbortError` rejection and no scheduling; after — a 22-iteration aborted turn logs `experience review scheduled: session=agent:main:abort-live-3 iterations=22 aborted=true`, the review runs cleanly (isolated incognito session, correct self-exclusion), zero lane task errors. A completed short turn logs the `below-depth-bar` skip, proving the event path fires for every turn.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts src/agents/embedded-agent-runner/run/attempt-abort.test.ts src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts src/agents/embedded-agent-runner/run/attempt-session-settle.test.ts` — 16 passed, incl. two new regressions: aborted async-task wait settles without reclassification, and a teardown-raced `AbortError` yields an abort-classified agent-end event (`success:false`, no `error`).
- `node scripts/check-changed.mjs` green (local fallback; Blacksmith backend unreachable).
