### PR TITLE
fix(gateway): cap channels stuck in pending restart

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -614,6 +614,145 @@ describe("channel-health-monitor", () => {
     monitor.stop();
   });
 
+  it("caps an account stuck in pending restart instead of thrashing forever", async () => {
+    const account: Partial<ChannelAccountSnapshot> = disconnectedAccount(Date.now() - 300_000);
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: account,
+        },
+      },
+      {
+        // Every start attempt leaves the account stuck in pending restart.
+        startChannel: vi.fn(async () => {
+          account.running = false;
+          account.connected = false;
+          account.restartPending = true;
+          account.reconnectAttempts = 0;
+        }),
+      },
+    );
+    const monitor = startDefaultMonitor(manager, {
+      checkIntervalMs: 1_000,
+      cooldownCycles: 1,
+      maxRestartsPerHour: 3,
+    });
+    await vi.advanceTimersByTimeAsync(20_001);
+    // Budgeted restart, one free continuation, then two more budgeted restarts
+    // before the hourly cap closes; a stuck account must not restart per check.
+    expect(manager.startChannel).toHaveBeenCalledTimes(4);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(manager.startChannel).toHaveBeenCalledTimes(4);
+    monitor.stop();
+  });
+
+  it("runs the free continuation even when the hourly budget is exhausted", async () => {
+    const account: Partial<ChannelAccountSnapshot> = disconnectedAccount(Date.now() - 300_000);
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: account,
+        },
+      },
+      {
+        startChannel: vi.fn(async () => {
+          account.running = false;
+          account.connected = false;
+          account.restartPending = true;
+          account.reconnectAttempts = 0;
+        }),
+      },
+    );
+    // The budgeted restart consumes the only hourly slot; the continuation that
+    // finishes that same recovery must still run.
+    const monitor = await startAndRunCheck(manager, { maxRestartsPerHour: 1 });
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+    monitor.stop();
+  });
+
+  it("does not re-arm the free continuation on a transient reconnect-attempt bump", async () => {
+    const account: Partial<ChannelAccountSnapshot> = disconnectedAccount(Date.now() - 300_000);
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: account,
+        },
+      },
+      {
+        startChannel: vi.fn(async () => {
+          account.running = false;
+          account.connected = false;
+          account.restartPending = true;
+          account.reconnectAttempts = 0;
+        }),
+      },
+    );
+    const monitor = await startAndRunCheck(manager, { cooldownCycles: 10 });
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+
+    // Supervisor retry bumps attempts while the account stays stuck pending…
+    account.reconnectAttempts = 2;
+    await advanceHealthCheck();
+    // …and returning to zero must not grant another unmetered continuation.
+    account.reconnectAttempts = 0;
+    await advanceHealthCheck();
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+    monitor.stop();
+  });
+
+  it("grants a fresh pending continuation after the account recovers", async () => {
+    const account: Partial<ChannelAccountSnapshot> = disconnectedAccount(Date.now() - 300_000);
+    let startBehavior: "pending" | "healthy" = "pending";
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: account,
+        },
+      },
+      {
+        startChannel: vi.fn(async () => {
+          if (startBehavior === "pending") {
+            account.running = false;
+            account.connected = false;
+            account.restartPending = true;
+            account.reconnectAttempts = 0;
+          } else {
+            account.running = true;
+            account.connected = true;
+            account.restartPending = false;
+          }
+        }),
+      },
+    );
+    // Long cooldown proves later continuations run on the free pass, not on an
+    // expired cooldown window.
+    const monitor = await startAndRunCheck(manager, { cooldownCycles: 10 });
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
+
+    startBehavior = "healthy";
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+
+    // Healthy pass clears the used continuation.
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+
+    // A new timed-out recovery marks pending again; its continuation must not
+    // wait behind the still-active cooldown.
+    account.running = false;
+    account.connected = false;
+    account.restartPending = true;
+    account.reconnectAttempts = 0;
+    await advanceHealthCheck();
+    expect(manager.startChannel).toHaveBeenCalledTimes(3);
+    monitor.stop();
+  });
+
   it("defers to the channel supervisor while its own auto-restart is scheduled", async () => {
     let autoRestartScheduled = true;
     const manager = createSnapshotManager(

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -51,6 +51,9 @@ export type ChannelHealthMonitor = {
 type RestartRecord = {
   lastRestartAt: number;
   restartsThisHour: { at: number }[];
+  // True once the free pending-continuation pass ran; cleared when the account
+  // leaves the pending-restart state so the next recovery earns a new pass.
+  pendingContinuationUsed?: boolean;
 };
 
 function resolveTimingPolicy(
@@ -133,6 +136,18 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             continue;
           }
           suppressedAccounts.delete(key);
+          const pendingRestartState =
+            status.running !== true &&
+            status.restartPending === true &&
+            (status.reconnectAttempts ?? 0) === 0;
+          // Clear only on genuine recovery (running or pending flag dropped);
+          // a transient reconnectAttempts bump while still stuck pending must
+          // not re-arm the free continuation pass.
+          const leftPendingRestart = status.running === true || status.restartPending !== true;
+          const trackedRecord = restartRecords.get(key);
+          if (trackedRecord?.pendingContinuationUsed && leftPendingRestart) {
+            trackedRecord.pendingContinuationUsed = false;
+          }
           const healthPolicy: ChannelHealthPolicy = {
             channelId,
             now,
@@ -162,14 +177,14 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             restartsThisHour: [],
           };
 
-          const continuingPendingRestart =
-            status.running !== true &&
-            status.restartPending === true &&
-            (status.reconnectAttempts ?? 0) === 0;
-
           // A timed-out recovery stop uses the first start request to mark
           // restartPending; the next monitor pass must finish that same recovery
           // instead of waiting behind this monitor's fresh-restart cooldown.
+          // Only one continuation is free: an account stuck in restartPending
+          // rejoins cooldown + hourly budget so it cannot thrash forever (#105189).
+          const continuingPendingRestart =
+            pendingRestartState && record.pendingContinuationUsed !== true;
+
           if (!continuingPendingRestart && now - record.lastRestartAt <= cooldownMs) {
             continue;
           }
@@ -186,11 +201,13 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
           log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
 
-          if (!continuingPendingRestart) {
+          if (continuingPendingRestart) {
+            record.pendingContinuationUsed = true;
+          } else {
             record.lastRestartAt = now;
             record.restartsThisHour.push({ at: now });
-            restartRecords.set(key, record);
           }
+          restartRecords.set(key, record);
 
           try {
             if (status.running) {


### PR DESCRIPTION
## What Problem This Solves

The gateway channel health monitor could restart the same channel on every check forever, entirely bypassing `maxRestartsPerHour`. A channel stuck in `restartPending` with `reconnectAttempts === 0` matched the "continuing pending restart" branch on every pass, which skipped the cooldown gate, skipped the hourly budget gate, and recorded nothing — so the budget never filled and the account never reached a give-up state. Symptoms: endless `stop`/`start` thrash against the channel manager, log spam, and a channel that stays unavailable with no explanation.

Fixes #105189.

## Why This Change Was Made

The continuation branch exists for a real reason: a timed-out recovery stop marks `restartPending` on its first start request, and the next monitor pass must finish that same recovery instead of waiting behind this monitor's fresh-restart cooldown. Removing it would strand that recovery; leaving it unmetered lets a permanently stuck account thrash forever.

So the continuation is now a one-shot per pending episode:

- The first continuation pass stays free (still skips cooldown and the hourly cap) and is recorded on the restart record.
- Every later pass while the account is still stuck rejoins both the cooldown and the `maxRestartsPerHour` budget.
- The free pass re-arms only on genuine recovery — the account is running again, or `restartPending` cleared. A transient `reconnectAttempts` bump that returns to zero while the account is still stuck cannot mint another free restart.

Alternative considered and rejected: metering the continuation unconditionally. With `maxRestartsPerHour: 1` the initial restart consumes the only slot, so the required follow-up start would be rejected and the channel would sit pending for an hour — the failure ClawSweeper's review of the issue explicitly called out.

## User Impact

A channel that cannot recover now stops thrashing after its budget is spent instead of restarting every check indefinitely, so the hourly limit means what it says and the give-up state is reachable. Operators keep the existing recovery behavior for the normal case: a stop-timeout recovery still completes on the next monitor pass without waiting for cooldown, including on low `maxRestartsPerHour` values.

## Evidence

- 4 new regression tests in `src/gateway/channel-health-monitor.test.ts` (52 total passing):
  - a channel stuck pending restarts 4 times under `maxRestartsPerHour: 3` (budgeted restart, one free continuation, two more budgeted) and then stops — proven to fail before the fix, where it restarted on every check
  - the free continuation still runs when the hourly budget is already exhausted (`maxRestartsPerHour: 1`)
  - a transient `reconnectAttempts` bump back to zero does not re-arm the free continuation
  - a genuine recovery re-arms it, and the next timed-out recovery's continuation does not wait behind an active cooldown
- The existing `continues pending recovery on the next check without waiting for cooldown` test is unchanged and still passes, so the intentional stop-timeout handoff is preserved.
- Local proof (remote proof backend unavailable — the crabbox binary failed its sanity checks — so trusted-source validation ran locally per repo policy): `node scripts/run-vitest.mjs src/gateway/channel-health-monitor.test.ts` (52 passed), `pnpm tsgo:core`, `scripts/run-oxlint.mjs`, `oxfmt --check` on both files.
- Structured autoreview (Codex, gpt-5.6-sol, high) is clean on the final shape: no accepted findings, "patch is correct" (0.89). One earlier finding — that the continuation would still be blocked by the hourly cap — was disproven by the `maxRestartsPerHour: 1` test above, since the cap guard already exempts continuations; the test is kept to pin that behavior.
- Proof gap: no live gateway run. The monitor's inputs are channel-manager snapshots, and the added tests drive the real `startChannelHealthMonitor` loop with fake timers through the exact stuck-pending state transitions.

## AI Assistance

Implemented with Claude assistance: issue and source analysis, fix, regression tests, and structured autoreview cycles; validation commands as listed above.
