### PR TITLE
fix(agents): keep date reasoning current in long-running sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent temporal grounding:** include the user-local calendar date and time zone in the volatile system-prompt suffix while keeping exact time tool-backed, so date reasoning survives long-running sessions without invalidating the stable prompt-cache prefix. Fixes #63181. Thanks @deepujain for the earlier investigation.
 - **Control UI Talk session isolation:** stop active realtime Talk media and retire its callbacks before chat session changes, Gateway disconnects, or pane disposal so previous-session audio, transcript, camera, and status updates cannot leak into the next view. Thanks @shakkernerd.
 - **Gateway reconnect event ordering:** reset the shared TypeScript client's outer event-sequence baseline for each replacement WebSocket, preventing gap recovery from comparing unrelated connection generations across Control UI, TUI, SDK, and browser extension clients. Thanks @shakkernerd.
 - **Skill Workshop offline apply:** preserve configless local proposal apply after upgrades under exclusive Gateway startup ownership, while keeping running Gateway snapshot invalidation fail-closed when CLI credentials are unavailable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Agent temporal grounding:** include the user-local calendar date and time zone in the volatile system-prompt suffix while keeping exact time tool-backed, so date reasoning survives long-running sessions without invalidating the stable prompt-cache prefix. Fixes #63181. Thanks @deepujain for the earlier investigation.
 - **Control UI Talk session isolation:** stop active realtime Talk media and retire its callbacks before chat session changes, Gateway disconnects, or pane disposal so previous-session audio, transcript, camera, and status updates cannot leak into the next view. Thanks @shakkernerd.
 - **Gateway reconnect event ordering:** reset the shared TypeScript client's outer event-sequence baseline for each replacement WebSocket, preventing gap recovery from comparing unrelated connection generations across Control UI, TUI, SDK, and browser extension clients. Thanks @shakkernerd.
 - **Skill Workshop offline apply:** preserve configless local proposal apply after upgrades under exclusive Gateway startup ownership, while keeping running Gateway snapshot invalidation fail-closed when CLI credentials are unavailable.

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -41,7 +41,7 @@ The prompt is compact, with fixed sections:
 - **Documentation**: local docs/source path and when to read them.
 - **Workspace Files (injected)**: notes that bootstrap files are included below.
 - **Sandbox** (when enabled): sandboxed runtime, sandbox paths, elevated-exec availability.
-- **Current Date & Time**: time zone only (cache-stable; the live clock comes from `session_status`).
+- **Temporal Context**: local date and time zone below the cache boundary; exact time comes from `session_status` when available.
 - **Assistant Output Directives**: compact attachment, voice-note, and reply-tag syntax.
 - **Collapsible Details** (when supported): teaches the model to keep optional depth in `<details>` disclosures while leaving the primary answer and required actions visible.
 - **Heartbeats**: heartbeat prompt and ack behavior, when heartbeats are enabled for the default agent.
@@ -132,9 +132,9 @@ To inspect how much each injected file contributes (raw vs injected, truncation,
 
 ## Time handling
 
-The **Current Date & Time** section appears only when the user timezone is known, and only includes the **time zone** (no dynamic clock or time format) to keep the prompt cache-stable.
+The **Temporal Context** section includes the user-local calendar date and time zone. It appears below the cache boundary, so day rollover or a timezone change does not invalidate the stable prefix.
 
-Use `session_status` when the agent needs the current time; its status card includes a timestamp line. The same tool can optionally set a per-session model override (`model=default` clears it).
+Use `session_status` when the agent needs the exact current time and the tool is available; its status card includes a timestamp line. The same tool can optionally set a per-session model override (`model=default` clears it).
 
 Configure with:
 

--- a/docs/concepts/timezone.md
+++ b/docs/concepts/timezone.md
@@ -10,13 +10,13 @@ OpenClaw standardizes timestamps so the model sees a **single reference time** i
 
 ## Three timezone surfaces
 
-| Surface           | What it shows                                                                                              | Default                               | Configured via                                         |
-| ----------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------ |
-| Message envelopes | Wraps inbound channel messages: `[Signal +1555 Sun 2026-01-18 00:19:42 PST] hello`                         | Host-local                            | `agents.defaults.envelopeTimezone`                     |
-| Tool payloads     | Channel `readMessages`-style tools return raw provider time plus normalized `timestampMs` / `timestampUtc` | UTC fields always present             | Not configurable; preserves provider-native timestamps |
-| System prompt     | A small `Current Date & Time` block with the **time zone only** (no clock value, for cache stability)      | Host timezone if `userTimezone` unset | `agents.defaults.userTimezone`                         |
+| Surface           | What it shows                                                                                               | Default                               | Configured via                                         |
+| ----------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------ |
+| Message envelopes | Wraps inbound channel messages: `[Signal +1555 Sun 2026-01-18 00:19:42 PST] hello`                          | Host-local                            | `agents.defaults.envelopeTimezone`                     |
+| Tool payloads     | Channel `readMessages`-style tools return raw provider time plus normalized `timestampMs` / `timestampUtc`  | UTC fields always present             | Not configurable; preserves provider-native timestamps |
+| System prompt     | A small volatile `Temporal Context` block with the local date and time zone; exact time remains tool-backed | Host timezone if `userTimezone` unset | `agents.defaults.userTimezone`                         |
 
-The system prompt deliberately omits the live clock to keep prompt caching stable across turns. When the agent needs the current time, it calls `session_status`.
+The date and zone live below the system-prompt cache boundary, so day rollover does not invalidate the stable prefix. The prompt deliberately omits the live clock; when the agent needs exact current time and `session_status` is available, it calls that tool.
 
 ## Setting the user timezone
 
@@ -30,7 +30,7 @@ The system prompt deliberately omits the live clock to keep prompt caching stabl
 }
 ```
 
-If `userTimezone` is unset, OpenClaw resolves the host timezone at runtime via `Intl.DateTimeFormat().resolvedOptions().timeZone` (no config write). `agents.defaults.timeFormat` (`auto` | `12` | `24`) controls 12h/24h rendering in envelopes and downstream surfaces, not in the system prompt section.
+If `userTimezone` is unset, OpenClaw resolves the host timezone at runtime via `Intl.DateTimeFormat().resolvedOptions().timeZone` (no config write). `agents.defaults.timeFormat` (`auto` | `12` | `24`) controls 12h/24h rendering in envelopes and downstream surfaces, not in the system prompt section because that section has no clock value.
 
 ## Envelope timezone values
 

--- a/docs/date-time.md
+++ b/docs/date-time.md
@@ -6,9 +6,9 @@ read_when:
 title: "Date and time"
 ---
 
-OpenClaw uses **host-local time for transport timestamps** and puts **only the time zone** in the system prompt.
-Provider timestamps are preserved so tools keep their native semantics. When the agent needs the current
-time, it runs the `session_status` tool.
+OpenClaw uses **host-local time for transport timestamps** and puts the **local date plus time zone** in the system prompt.
+Provider timestamps are preserved so tools keep their native semantics. When the agent needs the exact current
+time and `session_status` is available, it runs that tool.
 
 ## Message envelopes (local by default)
 
@@ -59,18 +59,19 @@ Override under `agents.defaults`:
 [WhatsApp +1555 +30s Sun 2026-01-18T05:19:00Z] follow-up
 ```
 
-## System prompt: current date and time
+## System prompt: temporal context
 
-The system prompt includes a **Current Date & Time** section with the **time zone only**
-(no clock or time format) so prompt caching stays stable:
+The system prompt includes a volatile **Temporal Context** section with the local calendar date
+and time zone, but no live clock:
 
 ```
+Current date: 2026-01-05
 Time zone: America/Chicago
 ```
 
 The zone is `agents.defaults.userTimezone` when configured, otherwise the host timezone.
-The prompt also instructs the agent to run the `session_status` tool whenever it needs the
-current date, time, or day of week.
+The section lives below the prompt-cache boundary, so date rollover and timezone changes do not
+invalidate the stable prefix. When available, `session_status` remains the source for exact current time.
 
 ## System event lines (local by default)
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -3211,7 +3211,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Message envelopes (local by default)
   - H3: Examples
-  - H2: System prompt: current date and time
+  - H2: System prompt: temporal context
   - H2: System event lines (local by default)
   - H3: Configure user timezone + format
   - H2: Time format detection (auto)

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -325,7 +325,7 @@ Values:
 
 ### `agents.defaults.userTimezone`
 
-Timezone for system prompt context (not message timestamps). Falls back to host timezone.
+Timezone for the system prompt's local date context (not message timestamps). Falls back to host timezone.
 
 ```json5
 {
@@ -335,7 +335,7 @@ Timezone for system prompt context (not message timestamps). Falls back to host 
 
 ### `agents.defaults.timeFormat`
 
-Time format in system prompt. Default: `auto` (OS preference).
+Time format for envelope and other rendered clock values. The system prompt's temporal context has no live clock. Default: `auto` (OS preference).
 
 ```json5
 {

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -157,7 +157,7 @@ export function buildCliAgentSystemPrompt(params: {
     agentId: params.agentId,
   });
   const defaultModelLabel = `${defaultModelRef.provider}/${defaultModelRef.model}`;
-  const { runtimeInfo, userTimezone, userTime, userTimeFormat } = buildSystemPromptParams({
+  const { runtimeInfo, userTimezone, userDate } = buildSystemPromptParams({
     config: params.config,
     agentId: params.agentId,
     workspaceDir: runtimeWorkspaceDir,
@@ -200,8 +200,7 @@ export function buildCliAgentSystemPrompt(params: {
     toolNames: params.tools.map((tool) => tool.name),
     skillsPrompt: params.skillsPrompt,
     userTimezone,
-    userTime,
-    userTimeFormat,
+    userDate,
     contextFiles: params.contextFiles,
     bootstrapMode: params.bootstrapMode,
   });

--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -4,7 +4,7 @@
 import { execFileSync } from "node:child_process";
 import { resolveDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 
-export type ResolvedTimeFormat = "12" | "24";
+type ResolvedTimeFormat = "12" | "24";
 
 let cachedTimeFormat: ResolvedTimeFormat | undefined;
 

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -1007,6 +1007,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../date-time.js", () => ({
+    formatDateStamp: vi.fn(() => "2026-01-01"),
     formatUserTime: vi.fn(() => ""),
     resolveUserTimeFormat: vi.fn(() => ""),
     resolveUserTimezone: vi.fn(() => ""),

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -40,7 +40,7 @@ import {
   resolveChannelReactionGuidance,
 } from "../channel-tools.js";
 import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
-import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
+import { formatDateStamp, resolveUserTimezone } from "../date-time.js";
 import { resolveOpenClawReferencePaths } from "../docs-path.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
 import { prepareAgentMemoryPrompt } from "../memory-prompt-prepare.js";
@@ -503,8 +503,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       model: effectiveModel,
     });
     const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
-    const userTimeFormat = resolveUserTimeFormat(undefined);
-    const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+    const userDate = formatDateStamp(Date.now(), userTimezone);
     const promptSurface = resolveAgentPromptSurfaceForSessionKey(params.sessionKey);
     const promptMode =
       isSubagentSessionKey(params.sessionKey) || isCronSessionKey(params.sessionKey)
@@ -586,8 +585,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
         sandboxInfo,
         tools: effectiveTools,
         userTimezone,
-        userTime,
-        userTimeFormat,
+        userDate,
         contextFiles,
         activeProjectKeys,
         preparedMemoryPrompt,

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -169,7 +169,7 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
       agentId: params.sessionAgentId,
     }),
   });
-  const { runtimeInfo, userTimezone, userTime, userTimeFormat } = buildSystemPromptParams({
+  const { runtimeInfo, userTimezone, userDate } = buildSystemPromptParams({
     config: attempt.config,
     agentId: params.sessionAgentId,
     workspaceDir: params.effectiveWorkspace,
@@ -320,8 +320,7 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
       capabilityToolNames: [...params.capabilityToolNames].toSorted(),
       tools: params.effectiveTools,
       userTimezone,
-      userTime,
-      userTimeFormat,
+      userDate,
       contextFiles: params.bootstrap.contextFiles,
       bootstrapMode: params.bootstrap.bootstrapMode,
       bootstrapTruncationNotice: buildBootstrapPromptWarningNotice(

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
@@ -58,6 +58,7 @@ describe("buildAttemptSystemPrompt", () => {
         tools: [],
         modelAliasLines: [],
         userTimezone: "UTC",
+        userDate: "2026-01-05",
         contextFiles: [
           { path: "/tmp/openclaw/SOUL.md", content: "SOUL_CONTEXT_MARKER" },
           { path: "/tmp/openclaw/IDENTITY.md", content: "IDENTITY_CONTEXT_MARKER" },
@@ -93,6 +94,7 @@ describe("buildAttemptSystemPrompt", () => {
         tools: [],
         modelAliasLines: [],
         userTimezone: "UTC",
+        userDate: "2026-01-05",
         activeProjectKeys: ["github.com/acme/Alpha"],
         contextFiles: [
           {
@@ -131,6 +133,7 @@ describe("buildAttemptSystemPrompt", () => {
         tools: [],
         modelAliasLines: [],
         userTimezone: "UTC",
+        userDate: "2026-01-05",
         bootstrapMode: "full",
         bootstrapTruncationNotice: "Bootstrap context was truncated.",
         contextFiles: [
@@ -188,6 +191,7 @@ describe("buildAttemptSystemPrompt", () => {
         tools: [],
         modelAliasLines: [],
         userTimezone: "UTC",
+        userDate: "2026-01-05",
         promptMode: "minimal",
         extraSystemPrompt:
           "# Subagent Context\n\n## Your Role\n- You were created to handle: RUN_MODE_TASK_77950",
@@ -221,6 +225,7 @@ describe("buildAttemptSystemPrompt", () => {
         tools: [],
         modelAliasLines: [],
         userTimezone: "UTC",
+        userDate: "2026-01-05",
         bootstrapMode: "full",
         contextFiles: [
           {

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -618,8 +618,7 @@ vi.mock("../../system-prompt-params.js", () => ({
   buildSystemPromptParams: () => ({
     runtimeInfo: {},
     userTimezone: "UTC",
-    userTime: "00:00",
-    userTimeFormat: "24h",
+    userDate: "2026-01-05",
   }),
 }));
 

--- a/src/agents/embedded-agent-runner/system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.test.ts
@@ -46,6 +46,7 @@ describe("buildEmbeddedSystemPrompt", () => {
       tools: [],
       modelAliasLines: [],
       userTimezone: "UTC",
+      userDate: "2026-01-05",
       promptContribution: {
         stablePrefix: "## Embedded Stable\n\nStable provider guidance.",
       },
@@ -69,6 +70,7 @@ describe("buildEmbeddedSystemPrompt", () => {
       tools: [],
       modelAliasLines: [],
       userTimezone: "UTC",
+      userDate: "2026-01-05",
       activeProjectKeys: ["github.com/acme/Alpha"],
       contextFiles: [
         {
@@ -112,6 +114,7 @@ describe("buildEmbeddedSystemPrompt", () => {
       },
       tools: [{ name: "sessions_spawn" } as never],
       userTimezone: "UTC",
+      userDate: "2026-01-05",
     });
 
     expect(prompt).toContain("## Sub-Agent Delegation");
@@ -144,6 +147,7 @@ describe("buildEmbeddedSystemPrompt", () => {
       tools: [{ name: "tool_search" } as never],
       capabilityToolNames: ["sessions_spawn"],
       userTimezone: "UTC",
+      userDate: "2026-01-05",
     });
 
     expect(prompt).toContain("## Sub-Agent Delegation");
@@ -177,6 +181,7 @@ describe("buildEmbeddedSystemPrompt", () => {
       },
       tools: [{ name: "sessions_spawn" } as never],
       userTimezone: "UTC",
+      userDate: "2026-01-05",
     });
 
     expect(prompt).toContain("## Proactive Sub-Agent Orchestration");
@@ -207,6 +212,7 @@ describe("buildEmbeddedSystemPrompt", () => {
       tools: [],
       modelAliasLines: [],
       userTimezone: "UTC",
+      userDate: "2026-01-05",
     });
 
     expect(prompt).toContain("tools.fs.workspaceOnly ON");
@@ -236,6 +242,7 @@ describe("buildEmbeddedSystemPrompt", () => {
       tools: [],
       modelAliasLines: [],
       userTimezone: "UTC",
+      userDate: "2026-01-05",
     });
 
     expect(prompt).not.toContain("tools.fs.workspaceOnly ON");
@@ -259,6 +266,7 @@ describe("buildEmbeddedSystemPrompt", () => {
       nativeCommandGuidanceLines: ["Subagent-only command guidance."],
       modelAliasLines: [],
       userTimezone: "UTC",
+      userDate: "2026-01-05",
       promptMode: "minimal",
     });
 
@@ -290,6 +298,7 @@ describe("buildEmbeddedSystemPrompt", () => {
       tools: [],
       modelAliasLines: [],
       userTimezone: "UTC",
+      userDate: "2026-01-05",
       includeMemorySection: false,
     });
 
@@ -324,6 +333,7 @@ describe("buildEmbeddedSystemPrompt", () => {
       tools: [],
       modelAliasLines: [],
       userTimezone: "UTC",
+      userDate: "2026-01-05",
     });
 
     expect(prompt).toContain("Active exec sessions:");

--- a/src/agents/embedded-agent-runner/system-prompt.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.ts
@@ -10,7 +10,6 @@ import type { PreparedMemoryPromptSection } from "../../plugins/memory-state.js"
 import type { AgentPromptSurfaceKind } from "../../plugins/types.js";
 import type { ActiveProcessSessionReference } from "../bash-process-references.js";
 import type { BootstrapMode } from "../bootstrap-mode.js";
-import type { ResolvedTimeFormat } from "../date-time.js";
 import type { EmbeddedContextFile } from "../embedded-agent-helpers.js";
 import type { AgentTool } from "../runtime/index.js";
 import type { AgentSession } from "../sessions/index.js";
@@ -86,8 +85,7 @@ export function buildEmbeddedSystemPrompt(params: {
   tools: AgentTool[];
   modelAliasLines?: string[];
   userTimezone: string;
-  userTime?: string;
-  userTimeFormat?: ResolvedTimeFormat;
+  userDate: string;
   contextFiles?: EmbeddedContextFile[];
   bootstrapMode?: BootstrapMode;
   bootstrapTruncationNotice?: string;
@@ -135,8 +133,7 @@ export function buildEmbeddedSystemPrompt(params: {
     capabilityToolNames: params.capabilityToolNames,
     modelAliasLines: params.modelAliasLines,
     userTimezone: params.userTimezone,
-    userTime: params.userTime,
-    userTimeFormat: params.userTimeFormat,
+    userDate: params.userDate,
     contextFiles: params.contextFiles,
     bootstrapMode: params.bootstrapMode,
     bootstrapTruncationNotice: params.bootstrapTruncationNotice,

--- a/src/agents/system-prompt-params.test.ts
+++ b/src/agents/system-prompt-params.test.ts
@@ -3,7 +3,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { setActiveNodeContext } from "../infra/active-node-context.js";
 import { buildSystemPromptParams, resolveSystemPromptRepoRoot } from "./system-prompt-params.js";
@@ -34,7 +34,25 @@ function buildParams(params: { config?: OpenClawConfig; workspaceDir?: string; c
 }
 
 describe("buildSystemPromptParams", () => {
-  afterEach(() => setActiveNodeContext(null));
+  afterEach(() => {
+    setActiveNodeContext(null);
+    vi.useRealTimers();
+  });
+
+  it("formats the current date in the configured user timezone", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-05T23:30:00.000Z"));
+
+    const utc = buildParams({
+      config: { agents: { defaults: { userTimezone: "UTC" } } },
+    });
+    const tokyo = buildParams({
+      config: { agents: { defaults: { userTimezone: "Asia/Tokyo" } } },
+    });
+
+    expect(utc.userDate).toBe("2026-01-05");
+    expect(tokyo.userDate).toBe("2026-01-06");
+  });
 
   it("projects only the stable active-node identity", () => {
     setActiveNodeContext({ nodeId: "mac-123" });

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -14,12 +14,7 @@ import {
 } from "../infra/active-node-context.js";
 import { findGitRoot } from "../infra/git-root.js";
 import type { ActiveProcessSessionReference } from "./bash-process-references.js";
-import {
-  formatUserTime,
-  resolveUserTimeFormat,
-  resolveUserTimezone,
-  type ResolvedTimeFormat,
-} from "./date-time.js";
+import { formatDateStamp, resolveUserTimezone } from "./date-time.js";
 
 type RuntimeInfoInput = {
   agentId?: string;
@@ -45,8 +40,7 @@ type RuntimeInfoInput = {
 type SystemPromptRuntimeParams = {
   runtimeInfo: RuntimeInfoInput;
   userTimezone: string;
-  userTime?: string;
-  userTimeFormat?: ResolvedTimeFormat;
+  userDate: string;
 };
 
 export function buildSystemPromptParams(params: {
@@ -61,8 +55,7 @@ export function buildSystemPromptParams(params: {
     ? (params.preparedRepoRoot ?? undefined)
     : resolveSystemPromptRepoRoot(params);
   const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
-  const userTimeFormat = resolveUserTimeFormat(undefined);
-  const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+  const userDate = formatDateStamp(Date.now(), userTimezone);
   return {
     runtimeInfo: {
       agentId: params.agentId,
@@ -72,8 +65,7 @@ export function buildSystemPromptParams(params: {
       repoRoot,
     },
     userTimezone,
-    userTime,
-    userTimeFormat,
+    userDate,
   };
 }
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -715,76 +715,72 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain("bootstrapMaxChars");
   });
 
-  it("shows timezone section for 12h, 24h, and timezone-only modes", () => {
-    const cases = [
-      {
-        name: "12-hour",
-        params: {
-          workspaceDir: "/tmp/openclaw",
-          userTimezone: "America/Chicago",
-          userTime: "Monday, January 5th, 2026 — 3:26 PM",
-          userTimeFormat: "12" as const,
-        },
-      },
-      {
-        name: "24-hour",
-        params: {
-          workspaceDir: "/tmp/openclaw",
-          userTimezone: "America/Chicago",
-          userTime: "Monday, January 5th, 2026 — 15:26",
-          userTimeFormat: "24" as const,
-        },
-      },
-      {
-        name: "timezone-only",
-        params: {
-          workspaceDir: "/tmp/openclaw",
-          userTimezone: "America/Chicago",
-          userTimeFormat: "24" as const,
-        },
-      },
-    ] as const;
-
-    for (const testCase of cases) {
-      const prompt = buildAgentSystemPrompt(testCase.params);
-      expect(prompt, testCase.name).toContain("## Current Date & Time");
-      expect(prompt, testCase.name).toContain("Time zone: America/Chicago");
-    }
-  });
-
-  it("hints to use session_status for current date/time", () => {
+  it("shows the current local date and timezone", () => {
     const prompt = buildAgentSystemPrompt({
-      workspaceDir: "/tmp/clawd",
+      workspaceDir: "/tmp/openclaw",
+      userDate: "2026-01-05",
       userTimezone: "America/Chicago",
     });
 
-    expect(prompt).toContain("session_status");
-    expect(prompt).toContain("Need date/time/day");
-  });
-
-  // The system prompt intentionally does NOT include the current date/time.
-  // Only the timezone is included, to keep the prompt stable for caching.
-  // See: https://github.com/moltbot/moltbot/commit/66eec295b894bce8333886cfbca3b960c57c4946
-  // Agents should use session_status or message timestamps to determine the date/time.
-  // Related: https://github.com/moltbot/moltbot/issues/1897
-  //          https://github.com/moltbot/moltbot/issues/3658
-  it("does NOT include a date or time in the system prompt (cache stability)", () => {
-    const prompt = buildAgentSystemPrompt({
-      workspaceDir: "/tmp/clawd",
-      userTimezone: "America/Chicago",
-      userTime: "Monday, January 5th, 2026 — 3:26 PM",
-      userTimeFormat: "12",
-    });
-
-    // The prompt should contain the timezone but NOT the formatted date/time string.
-    // This is intentional for prompt cache stability — the date/time was removed in
-    // commit 66eec295b. If you're here because you want to add it back, please see
-    // https://github.com/moltbot/moltbot/issues/3658 for the preferred approach:
-    // gateway-level timestamp injection into messages, not the system prompt.
+    expect(prompt).toContain("## Temporal Context");
+    expect(prompt).toContain("Current date: 2026-01-05");
     expect(prompt).toContain("Time zone: America/Chicago");
-    expect(prompt).not.toContain("Monday, January 5th, 2026");
+  });
+
+  it("points to session_status for exact time only when the tool is available", () => {
+    const withStatus = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/clawd",
+      toolNames: ["session_status"],
+      userDate: "2026-01-05",
+      userTimezone: "America/Chicago",
+    });
+    const withoutStatus = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/clawd",
+      toolNames: ["exec"],
+      userDate: "2026-01-05",
+      userTimezone: "America/Chicago",
+    });
+
+    expect(withStatus).toContain("For the exact current time, use `session_status`.");
+    expect(withoutStatus).not.toContain("session_status");
+  });
+
+  it("does not inject a live clock into temporal context", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/clawd",
+      userDate: "2026-01-05",
+      userTimezone: "America/Chicago",
+    });
+
+    expect(prompt).toContain("Current date: 2026-01-05");
+    expect(prompt).toContain("Time zone: America/Chicago");
     expect(prompt).not.toContain("3:26 PM");
     expect(prompt).not.toContain("15:26");
+  });
+
+  it("keeps date rollover and timezone changes below the prompt-cache boundary", () => {
+    const buildPrompt = (userDate: string, userTimezone: string) =>
+      buildAgentSystemPrompt({
+        workspaceDir: "/tmp/clawd",
+        toolNames: ["session_status"],
+        userDate,
+        userTimezone,
+      });
+    const first = buildPrompt("2026-01-05", "America/Chicago");
+    const nextDay = buildPrompt("2026-01-06", "America/Chicago");
+    const nextZone = buildPrompt("2026-01-06", "Asia/Tokyo");
+    const stablePrefix = (prompt: string) =>
+      prompt.slice(0, prompt.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY));
+    const volatileSuffix = (prompt: string) =>
+      prompt.slice(prompt.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY));
+
+    expect(stablePrefix(first)).toBe(stablePrefix(nextDay));
+    expect(stablePrefix(first)).toBe(stablePrefix(nextZone));
+    expect(stablePrefix(first)).not.toContain("2026-01-05");
+    expect(stablePrefix(first)).not.toContain("America/Chicago");
+    expect(volatileSuffix(first)).toContain("Current date: 2026-01-05");
+    expect(volatileSuffix(nextDay)).toContain("Current date: 2026-01-06");
+    expect(volatileSuffix(nextZone)).toContain("Time zone: Asia/Tokyo");
   });
 
   it("includes model alias guidance when aliases are provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -41,7 +41,6 @@ import {
   buildFullBootstrapPromptLines,
   buildLimitedBootstrapPromptLines,
 } from "./bootstrap-prompt.js";
-import type { ResolvedTimeFormat } from "./date-time.js";
 import type { EmbeddedContextFile } from "./embedded-agent-helpers.js";
 import type {
   EmbeddedFullAccessBlockedReason,
@@ -430,11 +429,23 @@ function buildOwnerIdentityLine(
   return `Allowlisted senders: ${displayOwnerNumbers.join(", ")}. Allowlisted != owner.`;
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
-  if (!params.userTimezone) {
+function buildTemporalContextSection(params: {
+  userDate?: string;
+  userTimezone?: string;
+  sessionStatusAvailable: boolean;
+}) {
+  const userDate = params.userDate?.trim();
+  const userTimezone = params.userTimezone?.trim();
+  if (!userDate || !userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  return [
+    "## Temporal Context",
+    `Current date: ${userDate}`,
+    `Time zone: ${userTimezone}`,
+    ...(params.sessionStatusAvailable ? ["For the exact current time, use `session_status`."] : []),
+    "",
+  ];
 }
 
 function buildAssistantOutputDirectivesSection(params: {
@@ -755,8 +766,7 @@ export function buildAgentSystemPrompt(params: {
   toolSummaries?: Record<string, string>;
   modelAliasLines?: string[];
   userTimezone?: string;
-  userTime?: string;
-  userTimeFormat?: ResolvedTimeFormat;
+  userDate?: string;
   contextFiles?: EmbeddedContextFile[];
   bootstrapMode?: BootstrapMode;
   bootstrapTruncationNotice?: string;
@@ -1004,6 +1014,7 @@ export function buildAgentSystemPrompt(params: {
     : undefined;
   const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
+  const userDate = params.userDate?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
   const runtimeInfo = params.runtimeInfo;
@@ -1270,7 +1281,6 @@ export function buildAgentSystemPrompt(params: {
         ? params.modelAliasLines.join("\n")
         : "",
       params.modelAliasLines && params.modelAliasLines.length > 0 && !isMinimal ? "" : "",
-      userTimezone ? "Need date/time/day: `session_status`." : "",
       "## Workspace",
       `Working directory: ${displayWorkspaceDir}`,
       workspaceGuidance,
@@ -1340,9 +1350,6 @@ export function buildAgentSystemPrompt(params: {
             .join("\n")
         : "",
       params.sandboxInfo?.enabled ? "" : "",
-      ...buildTimeSection({
-        userTimezone,
-      }),
       ...bootstrapSystemPromptSections,
       "## Workspace Files (injected)",
       "User-editable; OpenClaw loads below as Project Context.",
@@ -1376,6 +1383,16 @@ export function buildAgentSystemPrompt(params: {
   });
 
   const lines = [stablePrefix];
+
+  // Local date and timezone can change between turns. Keep them at the front of
+  // the volatile suffix so rollover is visible without invalidating the stable prefix.
+  lines.push(
+    ...buildTemporalContextSection({
+      userDate,
+      userTimezone,
+      sessionStatusAvailable: availableTools.has("session_status"),
+    }),
+  );
 
   lines.push(
     ...buildProjectContextSection({

--- a/src/auto-reply/reply/commands-system-prompt.test.ts
+++ b/src/auto-reply/reply/commands-system-prompt.test.ts
@@ -57,8 +57,7 @@ vi.mock("../../agents/system-prompt-params.js", () => ({
   buildSystemPromptParams: vi.fn(() => ({
     runtimeInfo: { host: "unknown", os: "unknown", arch: "unknown", node: process.version },
     userTimezone: "UTC",
-    userTime: "12:00 PM",
-    userTimeFormat: "12h",
+    userDate: "2026-01-05",
   })),
 }));
 

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -228,7 +228,7 @@ export async function resolveCommandsSystemPromptBundle(
     agentId: sessionAgentId,
   });
   const defaultModelLabel = `${defaultModelRef.provider}/${defaultModelRef.model}`;
-  const { runtimeInfo, userTimezone, userTime, userTimeFormat } = buildSystemPromptParams({
+  const { runtimeInfo, userTimezone, userDate } = buildSystemPromptParams({
     config: params.cfg,
     agentId: sessionAgentId,
     workspaceDir,
@@ -277,8 +277,7 @@ export async function resolveCommandsSystemPromptBundle(
     reasoningTagHint: false,
     toolNames,
     userTimezone,
-    userTime,
-    userTimeFormat,
+    userDate,
     contextFiles: injectedFiles,
     skillsPrompt,
     heartbeatPrompt: undefined,

--- a/test/helpers/agents/prompt-composition-scenarios.ts
+++ b/test/helpers/agents/prompt-composition-scenarios.ts
@@ -73,8 +73,7 @@ function buildCommonSystemParams(workspaceDir: string) {
       shell: "zsh",
     },
     userTimezone: "America/Los_Angeles",
-    userTime: "Monday, March 16th, 2026 - 9:00 PM",
-    userTimeFormat: "12" as const,
+    userDate: "2026-03-16",
     toolNames,
   };
 }
@@ -87,15 +86,15 @@ function buildSystemPrompt(params: {
   contextFiles?: Array<{ path: string; content: string }>;
   silentReplyPromptMode?: "generic" | "none";
 }) {
-  const { runtimeInfo, userTimezone, userTime, userTimeFormat, toolNames } =
-    buildCommonSystemParams(params.workspaceDir);
+  const { runtimeInfo, userTimezone, userDate, toolNames } = buildCommonSystemParams(
+    params.workspaceDir,
+  );
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
     extraSystemPrompt: params.extraSystemPrompt,
     runtimeInfo,
     userTimezone,
-    userTime,
-    userTimeFormat,
+    userDate,
     toolNames,
     modelAliasLines: [],
     promptMode: "full",
@@ -184,9 +183,7 @@ function buildToolRichSystemPrompt(params: {
   skillsPrompt: string;
   contextFiles: Array<{ path: string; content: string }>;
 }) {
-  const { runtimeInfo, userTimezone, userTime, userTimeFormat } = buildCommonSystemParams(
-    params.workspaceDir,
-  );
+  const { runtimeInfo, userTimezone, userDate } = buildCommonSystemParams(params.workspaceDir);
   const tools = [
     "bash",
     "read",
@@ -207,8 +204,7 @@ function buildToolRichSystemPrompt(params: {
     tools,
     modelAliasLines: [],
     userTimezone,
-    userTime,
-    userTimeFormat,
+    userDate,
     acpEnabled: true,
     skillsPrompt: params.skillsPrompt,
     reactionGuidance: { level: "extensive", channel: "Telegram" },


### PR DESCRIPTION
Fixes #63181

Supersedes #91250 with a fix for the underlying temporal-grounding failure rather than a heading-only rename.

## What Problem This Solves

Fixes an issue where users asking date-relative questions could get incorrect "today", "yesterday", or deadline reasoning in long-running sessions because the system prompt exposed only a time zone and relied on the model to notice message timestamps or call `session_status`.

## Why This Change Was Made

OpenClaw now recomputes the user-local calendar date for every prompt build and places it with the IANA time zone at the front of the volatile system-prompt suffix. The live clock stays out of the prompt, exact time remains tool-backed, and date rollover or time-zone changes cannot invalidate the stable prompt-cache prefix.

The replacement design follows the stronger current harness pattern: Codex supplies current date plus time zone in per-turn environment context, while OpenCode emits a date baseline and rollover updates. Gemini CLI's first-message-only date context can become stale across resumed multi-day sessions, and Pi's date removal left users reporting random-date behavior. A heading rename alone would not fix the reported failure.

## User Impact

Agents receive an explicit local calendar date on every turn, including after day rollover, while preserving prompt-cache reuse. Restricted agents are only told to use `session_status` for exact time when that tool is actually available.

Before:

```text
## Current Date & Time
Time zone: America/Chicago
```

After:

```text
## Temporal Context
Current date: 2026-01-05
Time zone: America/Chicago
For the exact current time, use `session_status`.
```

## Evidence

- 196 focused tests passed across prompt rendering, time-zone conversion, cache-boundary stability, embedded/CLI prompt assembly, command prompt assembly, compaction context, and prompt-composition scenarios.
- Date rollover and time-zone changes produce byte-identical stable prefixes and only change the volatile suffix.
- Restricted toolsets omit the `session_status` instruction.
- Fresh autoreview: clean, no accepted/actionable findings, confidence 0.93.
- `node scripts/check-changed.mjs -- <20 touched files>` passed on Blacksmith Testbox, including all policy guards, deadcode, three typecheck lanes, full core lint fanout, scripts, docs, and tooling: https://github.com/openclaw/openclaw/actions/runs/30490674386
- `git diff --check` and targeted `oxfmt --check` passed.
