### PR TITLE
fix(macos): reduce permission polling allocation churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS permission polling:** reuse the app's process-lifetime Core Location manager for authorization checks, preventing repeated framework allocation and cache churn while permission monitoring is active.
 - **Control UI Talk session isolation:** stop active realtime Talk media and retire its callbacks before chat session changes, Gateway disconnects, or pane disposal so previous-session audio, transcript, camera, and status updates cannot leak into the next view. Thanks @shakkernerd.
 - **Gateway reconnect event ordering:** reset the shared TypeScript client's outer event-sequence baseline for each replacement WebSocket, preventing gap recovery from comparing unrelated connection generations across Control UI, TUI, SDK, and browser extension clients. Thanks @shakkernerd.
 - **Skill Workshop offline apply:** preserve configless local proposal apply after upgrades under exclusive Gateway startup ownership, while keeping running Gateway snapshot invalidation fail-closed when CLI credentials are unavailable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS permission polling:** reuse the app's process-lifetime Core Location manager for authorization checks, preventing repeated framework allocation and cache churn while permission monitoring is active.
 - **Control UI Talk session isolation:** stop active realtime Talk media and retire its callbacks before chat session changes, Gateway disconnects, or pane disposal so previous-session audio, transcript, camera, and status updates cannot leak into the next view. Thanks @shakkernerd.
 - **Gateway reconnect event ordering:** reset the shared TypeScript client's outer event-sequence baseline for each replacement WebSocket, preventing gap recovery from comparing unrelated connection generations across Control UI, TUI, SDK, and browser extension clients. Thanks @shakkernerd.
 - **Skill Workshop offline apply:** preserve configless local proposal apply after upgrades under exclusive Gateway startup ownership, while keeping running Gateway snapshot invalidation fail-closed when CLI credentials are unavailable.

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -174,7 +174,7 @@ enum PermissionManager {
             }
             return false
         }
-        let status = CLLocationManager().authorizationStatus
+        let status = await self.locationAuthorizationStatus()
         switch status {
         case .authorizedAlways, .authorizedWhenInUse, .authorized:
             return true
@@ -196,6 +196,10 @@ enum PermissionManager {
         let mic = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
         let speech = SFSpeechRecognizer.authorizationStatus() == .authorized
         return mic && speech
+    }
+
+    static func locationAuthorizationStatus() async -> CLAuthorizationStatus {
+        await LocationPermissionRequester.shared.authorizationStatus
     }
 
     static func ensureVoiceWakePermissions(interactive: Bool) async -> Bool {
@@ -241,7 +245,7 @@ enum PermissionManager {
                     ? .granted : .notGranted
 
             case .location:
-                let status = CLLocationManager().authorizationStatus
+                let status = await self.locationAuthorizationStatus()
                 results[cap] = CLLocationManager.locationServicesEnabled()
                     && self.isLocationAuthorized(status: status, requireAlways: false) ? .granted : .notGranted
             }
@@ -301,6 +305,11 @@ final class LocationPermissionRequester: NSObject, CLLocationManagerDelegate {
     override init() {
         super.init()
         self.manager.delegate = self
+    }
+
+    var authorizationStatus: CLAuthorizationStatus {
+        // Core Location retains per-manager framework state, so status polling must reuse this process-lifetime owner.
+        self.manager.authorizationStatus
     }
 
     func request(always: Bool) async -> CLAuthorizationStatus {

--- a/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionsSettings.swift
@@ -155,7 +155,7 @@ private struct LocationAccessSettings: View {
             return false
         }
 
-        let status = CLLocationManager().authorizationStatus
+        let status = await PermissionManager.locationAuthorizationStatus()
         let requireAlways = mode == .always
         if PermissionManager.isLocationAuthorized(status: status, requireAlways: requireAlways) {
             return true

--- a/apps/macos/Tests/OpenClawIPCTests/PermissionManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PermissionManagerTests.swift
@@ -24,15 +24,25 @@ struct PermissionManagerTests {
         #expect(ensured.keys.count == caps.count)
     }
 
-    @Test func `location status matches authorization always`() async {
-        let status = CLLocationManager().authorizationStatus
-        let results = await PermissionManager.grantedStatus([.location])
-        #expect(results[.location] == (status == .authorizedAlways))
+    @Test func `location status reuses shared requester`() async {
+        let expected = LocationPermissionRequester.shared.authorizationStatus
+        let actual = await PermissionManager.locationAuthorizationStatus()
+        #expect(actual == expected)
     }
 
-    @Test func `ensure location non interactive matches authorization always`() async {
-        let status = CLLocationManager().authorizationStatus
+    @Test func `location status matches canonical authorization`() async {
+        let status = await PermissionManager.locationAuthorizationStatus()
+        let results = await PermissionManager.grantedStatus([.location])
+        let expected = CLLocationManager.locationServicesEnabled()
+            && PermissionManager.isLocationAuthorized(status: status, requireAlways: false)
+        #expect(results[.location] == expected)
+    }
+
+    @Test func `ensure location non interactive matches canonical authorization`() async {
+        let status = await PermissionManager.locationAuthorizationStatus()
         let ensured = await PermissionManager.ensure([.location], interactive: false)
-        #expect(ensured[.location] == (status == .authorizedAlways))
+        let expected = CLLocationManager.locationServicesEnabled()
+            && PermissionManager.isLocationAuthorized(status: status, requireAlways: false)
+        #expect(ensured[.location] == expected)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/PermissionManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PermissionManagerTests.swift
@@ -24,12 +24,6 @@ struct PermissionManagerTests {
         #expect(ensured.keys.count == caps.count)
     }
 
-    @Test func `location status reuses shared requester`() async {
-        let expected = LocationPermissionRequester.shared.authorizationStatus
-        let actual = await PermissionManager.locationAuthorizationStatus()
-        #expect(actual == expected)
-    }
-
     @Test func `location status matches canonical authorization`() async {
         let status = await PermissionManager.locationAuthorizationStatus()
         let results = await PermissionManager.grantedStatus([.location])


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening the macOS Permissions settings or onboarding permission step repeatedly created a new Core Location manager for each status poll, increasing allocation and framework-cache churn while permission monitoring was active.

## Why This Change Was Made

Authorization checks now reuse the process-lifetime manager already owned by `LocationPermissionRequester`. The permission monitor, non-interactive checks, and location settings preflight all share that canonical status path without changing authorization behavior or UI.

## User Impact

The macOS app performs less transient allocation and retains less Core Location framework state while permission monitoring is visible. There are no interface changes.

## Evidence

- A 1,000-read standalone probe retained 8.46 MB and 50,246 allocation nodes with temporary managers versus 4.13 MB and 13,048 nodes with one shared manager; both reported zero unreachable leaks.
- `swift test --package-path apps/macos --filter PermissionManager` — 7 tests passed across 2 suites in five consecutive runs.
- Repo-configured SwiftFormat and SwiftLint passed for all touched Swift files.
- `node --import tsx scripts/native-app-i18n.ts verify` — clean, no generated changes.
- `git diff --check` — clean.
- `git merge-tree --write-tree origin/main HEAD` — clean for exact head `0b06d6f70b25` against `origin/main` at `cff7cbfdcb80`, producing merge tree `12f2b6ce793f`.
- Autoreview — implementation review clean at 0.92 confidence; CI test-isolation follow-up clean at 0.98 confidence.

AI-assisted: yes. The implementation and profiler evidence were reviewed and verified.
