### PR TITLE
fix(hooks): keep manual reset memory writes admitted

### DIFF
--- a/src/hooks/bundled/session-memory/handler-admission.test.ts
+++ b/src/hooks/bundled/session-memory/handler-admission.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../../../config/config.js";
+import { replaceTranscriptEvents } from "../../../config/sessions/session-accessor.js";
+import {
+  isGatewaySubordinateWorkAdmissionClosed,
+  tryBeginGatewayRootWorkAdmission,
+} from "../../../process/gateway-work-admission.js";
+import { withEnvAsync } from "../../../test-utils/env.js";
+import { createInternalHookEvent } from "../../internal-hooks.js";
+
+const generateSlugViaLLM = vi.hoisted(() => vi.fn());
+
+vi.mock("../../llm-slug-generator.js", () => ({ generateSlugViaLLM }));
+
+import handler, { flushSessionMemoryWritesForTest } from "./handler.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(async () => {
+  generateSlugViaLLM.mockReset();
+  await flushSessionMemoryWritesForTest();
+});
+
+describe("session-memory gateway admission", () => {
+  it("keeps detached manual-reset slug generation admitted after the request returns", async () => {
+    const tempDir = tempDirs.make("openclaw-session-memory-admission-");
+    const sessionId = "manual-reset-session";
+    const sessionKey = "agent:main:main";
+    const storePath = path.join(tempDir, "sessions.json");
+    const cfg = {
+      agents: { defaults: { workspace: tempDir } },
+      hooks: {
+        internal: {
+          entries: {
+            "session-memory": { enabled: true, llmSlug: true },
+          },
+        },
+      },
+      session: { store: storePath },
+    } satisfies OpenClawConfig;
+    await replaceTranscriptEvents({ agentId: "main", sessionId, sessionKey, storePath }, [
+      {
+        type: "message",
+        id: "manual-reset-user",
+        parentId: null,
+        message: { role: "user", content: "Keep a descriptive memory filename" },
+      },
+      {
+        type: "message",
+        id: "manual-reset-assistant",
+        parentId: "manual-reset-user",
+        message: { role: "assistant", content: "I will retain the slug generation work" },
+      },
+    ]);
+    const event = createInternalHookEvent("command", "reset", sessionKey, {
+      cfg,
+      previousSessionEntry: { sessionId },
+      workspaceDir: tempDir,
+    });
+    let subordinateClosedInsideSlug: boolean | undefined;
+    generateSlugViaLLM.mockImplementationOnce(async () => {
+      subordinateClosedInsideSlug = isGatewaySubordinateWorkAdmissionClosed();
+      return subordinateClosedInsideSlug ? null : "admitted-slug";
+    });
+
+    await withEnvAsync(
+      {
+        NODE_ENV: "production",
+        OPENCLAW_TEST_FAST: undefined,
+        VITEST: undefined,
+        VITEST_POOL_ID: undefined,
+        VITEST_WORKER_ID: undefined,
+      },
+      async () => {
+        const admission = tryBeginGatewayRootWorkAdmission();
+        expect(admission).not.toBeNull();
+        await admission?.run(async () => {
+          void handler(event);
+          admission.release();
+        });
+        await flushSessionMemoryWritesForTest();
+
+        await expect(fs.readdir(path.join(tempDir, "memory"))).resolves.toEqual([
+          expect.stringMatching(/-admitted-slug\.md$/),
+        ]);
+      },
+    );
+
+    expect(subordinateClosedInsideSlug).toBe(false);
+  });
+});

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -25,6 +25,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { isVitestRuntimeEnv } from "../../../infra/env.js";
 import { root } from "../../../infra/fs-safe.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { runWithGatewayIndependentRootWorkContinuation } from "../../../process/gateway-work-admission.js";
 import {
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
@@ -434,7 +435,11 @@ const saveSessionToMemory: HookHandler = (event) => {
     // one transaction. An in-flight rebuild throws here and schedules repair,
     // so the async writer falls back to the authoritative transcript rows.
   }
-  const writePromise = saveSessionMemoryNow(event, capturedEvents);
+  const writePromise = isAutoReset
+    ? saveSessionMemoryNow(event, capturedEvents)
+    : runWithGatewayIndependentRootWorkContinuation(() =>
+        saveSessionMemoryNow(event, capturedEvents),
+      );
   pendingSessionMemoryWrites.add(writePromise);
   void writePromise.finally(() => {
     pendingSessionMemoryWrites.delete(writePromise);


### PR DESCRIPTION
Closes #113396

## What Problem This Solves

Fixes an issue where users running manual `/new` or `/reset` commands with the session-memory hook's `llmSlug` option enabled could lose the detached memory write when LLM-backed filename generation continued after the command request returned.

## Why This Change Was Made

Manual reset memory writes now reserve an independent Gateway root-work continuation before request admission is released. Automatic reset handling keeps its existing execution path.

## User Impact

Session-memory files from manual `/new` and `/reset` commands can finish LLM-backed filename generation without failing with `GatewayDrainingError`.

## Evidence

- Exact head: `168f744d5905fc6e956b8b8d50b011c32ebedc13`.
- 31 focused session-memory and Gateway-admission tests passed.
- Added a regression test that releases the command request admission before LLM slug generation completes.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh exact-head autoreview completed with no actionable findings (0.91 confidence).
- Release-note context is captured here; `CHANGELOG.md` remains release-owned.
