### PR TITLE
fix(ui): hydrate skill security verdicts on first load

### DIFF
--- a/ui/src/e2e/skills-any-bin-requirements.e2e.test.ts
+++ b/ui/src/e2e/skills-any-bin-requirements.e2e.test.ts
@@ -144,4 +144,68 @@ describeControlUiE2e("Control UI alternative skill binary requirements", () => {
       await context.close();
     }
   });
+
+  it("hydrates a linked skill security verdict before rendering its details", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const linkedSkill = {
+      ...codingAgentSkill([]),
+      name: "AgentReceipt",
+      description: "Verify agent output provenance.",
+      skillKey: "agentreceipt",
+      clawhub: {
+        status: "linked",
+        valid: true,
+        registry: "https://clawhub.ai",
+        slug: "agentreceipt",
+        installedVersion: "1.2.3",
+        installedAt: 123,
+      },
+    };
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "skills.status": {
+          workspaceDir: "/tmp/openclaw-e2e/workspace",
+          managedSkillsDir: "/tmp/openclaw-e2e/skills",
+          skills: [linkedSkill],
+        },
+        "skills.securityVerdicts": {
+          schema: "openclaw.skills.security-verdicts.v1",
+          items: [
+            {
+              registry: "https://clawhub.ai",
+              ok: true,
+              decision: "pass",
+              reasons: [],
+              requestedSlug: "agentreceipt",
+              requestedVersion: "1.2.3",
+              securityStatus: "clean",
+              securityPassed: true,
+            },
+          ],
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}skills`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("skills.securityVerdicts");
+      await page.getByRole("button", { name: "Open AgentReceipt details" }).click();
+
+      const dialog = page.locator("openclaw-modal-dialog", { hasText: "AgentReceipt" });
+      await expect.poll(async () => await dialog.count()).toBe(1);
+      expect(await dialog.getByText("Clean", { exact: true }).count()).toBe(1);
+      expect(await dialog.getByText("Unavailable", { exact: true }).count()).toBe(0);
+      const verdictRequests = await gateway.getRequests("skills.securityVerdicts");
+      expect(verdictRequests.length).toBeGreaterThan(0);
+      expect(verdictRequests[0]?.params).toEqual({});
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/lib/skills/index.test.ts
+++ b/ui/src/lib/skills/index.test.ts
@@ -169,14 +169,16 @@ describe("loadSkills", () => {
     expect(request).toHaveBeenCalledTimes(2);
     expect(request).toHaveBeenNthCalledWith(1, "skills.status", {});
     expect(request).toHaveBeenNthCalledWith(2, "skills.securityVerdicts", {});
-    expect(state.clawhubVerdicts).toEqual({
-      "https://clawhub.ai\u0000agentreceipt\u00001.2.3": expect.objectContaining({
-        ok: true,
-        decision: "pass",
-        securityStatus: "clean",
-        securityPassed: true,
+    await waitForFast(() =>
+      expect(state.clawhubVerdicts).toEqual({
+        "https://clawhub.ai\u0000agentreceipt\u00001.2.3": expect.objectContaining({
+          ok: true,
+          decision: "pass",
+          securityStatus: "clean",
+          securityPassed: true,
+        }),
       }),
-    });
+    );
     expect(state.clawhubVerdictsLoading).toBe(false);
     expect(state.clawhubVerdictsError).toBeNull();
   });

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -75,6 +75,8 @@ export type ClawHubSkillSecurityVerdict = {
   };
 };
 
+export type ClawHubSkillSecurityVerdicts = Record<string, ClawHubSkillSecurityVerdict>;
+
 type SkillsState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
@@ -101,7 +103,7 @@ type SkillsState = {
     acknowledgeVersion?: string;
     acknowledgeLabel?: string;
   } | null;
-  clawhubVerdicts: Record<string, ClawHubSkillSecurityVerdict>;
+  clawhubVerdicts: ClawHubSkillSecurityVerdicts;
   clawhubVerdictsLoading: boolean;
   clawhubVerdictsError: string | null;
   skillCardContents: Record<string, string>;
@@ -214,6 +216,30 @@ export async function loadSkillStatusReport(
   agentId: string | null | undefined,
 ): Promise<SkillStatusReport | undefined> {
   return client.request<SkillStatusReport | undefined>("skills.status", skillsAgentParams(agentId));
+}
+
+export async function loadClawHubSecurityVerdicts(
+  client: GatewayBrowserClient,
+  report: SkillStatusReport,
+  agentId: string | null | undefined,
+): Promise<ClawHubSkillSecurityVerdicts> {
+  if (!reportHasLinkedClawHubSkills(report)) {
+    return {};
+  }
+  const response = await client.request<{
+    schema: "openclaw.skills.security-verdicts.v1";
+    items: ClawHubSkillSecurityVerdict[];
+  }>("skills.securityVerdicts", skillsAgentParams(agentId));
+  return Object.fromEntries(
+    (response?.items ?? []).map((item) => [
+      clawhubVerdictKey({
+        registry: item.registry,
+        slug: item.requestedSlug,
+        version: item.requestedVersion,
+      }),
+      item,
+    ]),
+  );
 }
 
 type SkillsAgentScope = {
@@ -329,7 +355,7 @@ export async function loadSkills(
     if (res && Array.isArray(res.skills)) {
       state.skillsReport = res;
       pruneSkillCardState(state, res);
-      void loadClawHubSecurityVerdicts(state, res);
+      void hydrateClawHubSecurityVerdicts(state, res);
     }
   } catch (err) {
     if (!isCurrent()) {
@@ -455,7 +481,7 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
   }
 }
 
-async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStatusReport) {
+async function hydrateClawHubSecurityVerdicts(state: SkillsState, report: SkillStatusReport) {
   const client = state.client;
   const agentScope = captureSkillsAgentScope(state);
   if (!client || !state.connected || !reportHasLinkedClawHubSkills(report)) {
@@ -467,23 +493,11 @@ async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStat
   state.clawhubVerdictsLoading = true;
   state.clawhubVerdictsError = null;
   try {
-    const response = await client.request<{
-      schema: "openclaw.skills.security-verdicts.v1";
-      items: ClawHubSkillSecurityVerdict[];
-    }>("skills.securityVerdicts", stateSkillsAgentParams(state));
+    const verdicts = await loadClawHubSecurityVerdicts(client, report, state.skillsAgentId);
     if (!isSkillsAgentScopeCurrent(state, agentScope)) {
       return;
     }
-    state.clawhubVerdicts = Object.fromEntries(
-      (response?.items ?? []).map((item) => [
-        clawhubVerdictKey({
-          registry: item.registry,
-          slug: item.requestedSlug,
-          version: item.requestedVersion,
-        }),
-        item,
-      ]),
-    );
+    state.clawhubVerdicts = verdicts;
   } catch (err) {
     if (!isSkillsAgentScopeCurrent(state, agentScope)) {
       return;

--- a/ui/src/pages/gateway-source-replacement.test.ts
+++ b/ui/src/pages/gateway-source-replacement.test.ts
@@ -435,6 +435,12 @@ describe("gateway source replacement across reconnect with a reused client", () 
     const agentsList = { defaultId: "main", agents: [{ id: "main" }] };
     const context = contextWithClient(client, { connected: true, agentsList });
     const report = { skills: [{ skillKey: "old" }] } as unknown as SkillsRouteData["report"];
+    const verdicts = {
+      "https://clawhub.ai\u0000agentreceipt\u00001.2.3": {
+        decision: "pass",
+        securityStatus: "clean",
+      },
+    } as unknown as SkillsRouteData["clawhubVerdicts"];
     const routeData = {
       gateway: context.gateway,
       gatewaySnapshot: context.gateway.snapshot,
@@ -443,10 +449,13 @@ describe("gateway source replacement across reconnect with a reused client", () 
       selectedAgentId: "main",
       report,
       error: null,
+      clawhubVerdicts: verdicts,
+      clawhubVerdictsError: null,
     } as unknown as SkillsRouteData;
     const page = createPage("openclaw-skills-page", context) as TestPage & {
       routeData: SkillsRouteData;
       skillsReport: SkillsRouteData["report"];
+      clawhubVerdicts: SkillsRouteData["clawhubVerdicts"];
     };
     page.routeData = routeData;
 
@@ -454,6 +463,7 @@ describe("gateway source replacement across reconnect with a reused client", () 
     await page.updateComplete;
 
     expect(page.skillsReport).toBe(report);
+    expect(page.clawhubVerdicts).toBe(verdicts);
     expect(request).not.toHaveBeenCalled();
   });
 
@@ -478,6 +488,8 @@ describe("gateway source replacement across reconnect with a reused client", () 
       selectedAgentId: "main",
       report: staleReport,
       error: null,
+      clawhubVerdicts: {},
+      clawhubVerdictsError: null,
     } as unknown as SkillsRouteData;
 
     document.body.append(page);

--- a/ui/src/pages/route-provenance.test.ts
+++ b/ui/src/pages/route-provenance.test.ts
@@ -212,6 +212,71 @@ describe("route preload gateway provenance", () => {
     expect(data.agents).toBe(agents);
   });
 
+  it("preloads security verdicts for linked ClawHub skills", async () => {
+    const requestMethod = vi.fn(async (method: string) => {
+      if (method === "skills.status") {
+        return {
+          workspaceDir: "/tmp/workspace",
+          managedSkillsDir: "/tmp/skills",
+          skills: [
+            {
+              name: "AgentReceipt",
+              skillKey: "agentreceipt",
+              source: "workspace",
+              clawhub: {
+                status: "linked",
+                valid: true,
+                registry: "https://clawhub.ai",
+                slug: "agentreceipt",
+                installedVersion: "1.2.3",
+                installedAt: 123,
+              },
+            },
+          ],
+        };
+      }
+      if (method === "skills.securityVerdicts") {
+        return {
+          schema: "openclaw.skills.security-verdicts.v1",
+          items: [
+            {
+              registry: "https://clawhub.ai",
+              ok: true,
+              decision: "pass",
+              reasons: [],
+              requestedSlug: "agentreceipt",
+              requestedVersion: "1.2.3",
+              securityStatus: "clean",
+              securityPassed: true,
+            },
+          ],
+        };
+      }
+      return undefined;
+    });
+    const client = { request: requestMethod } as unknown as GatewayBrowserClient;
+    const mutable = mutableGateway(snapshot(client, true));
+
+    const data = await loadRoute<SkillsRouteData>(skillsPage, {
+      gateway: mutable.gateway,
+      agents: {
+        ensureList: vi.fn(async () => null),
+      },
+    } as unknown as ApplicationContext);
+
+    expect(requestMethod.mock.calls.map(([method]) => method)).toEqual([
+      "skills.status",
+      "skills.securityVerdicts",
+    ]);
+    expect(data.clawhubVerdicts).toEqual({
+      "https://clawhub.ai\u0000agentreceipt\u00001.2.3": expect.objectContaining({
+        decision: "pass",
+        securityStatus: "clean",
+      }),
+    });
+    expect(data.clawhubVerdictsError).toBeNull();
+  });
+
   it("keeps plugins provenance from before its async preload", async () => {
     const result = { plugins: [], diagnostics: [], mutationAllowed: true };
     const response = deferred<typeof result>();

--- a/ui/src/pages/skills/route.ts
+++ b/ui/src/pages/skills/route.ts
@@ -2,7 +2,7 @@ import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import { loadSkillStatusReport } from "../../lib/skills/index.ts";
+import { loadClawHubSecurityVerdicts, loadSkillStatusReport } from "../../lib/skills/index.ts";
 import type { SkillsRouteData } from "./skills-page.ts";
 
 function errorMessage(error: unknown): string {
@@ -23,12 +23,16 @@ async function loadSkillsRouteData(context: ApplicationContext): Promise<SkillsR
       selectedAgentId: null,
       report: null,
       error: null,
+      clawhubVerdicts: {},
+      clawhubVerdictsError: null,
     };
   }
 
   let error: string | null = null;
   let agentsList: SkillsRouteData["agentsList"] = null;
   let report: SkillsRouteData["report"] = null;
+  let clawhubVerdicts: SkillsRouteData["clawhubVerdicts"] = {};
+  let clawhubVerdictsError: string | null = null;
   try {
     agentsList = await agents.ensureList();
   } catch (err) {
@@ -39,6 +43,13 @@ async function loadSkillsRouteData(context: ApplicationContext): Promise<SkillsR
   } catch (err) {
     error ??= errorMessage(err);
   }
+  if (report) {
+    try {
+      clawhubVerdicts = await loadClawHubSecurityVerdicts(client, report, null);
+    } catch (err) {
+      clawhubVerdictsError = errorMessage(err);
+    }
+  }
   return {
     gateway,
     gatewaySnapshot,
@@ -47,6 +58,8 @@ async function loadSkillsRouteData(context: ApplicationContext): Promise<SkillsR
     selectedAgentId: null,
     report,
     error,
+    clawhubVerdicts,
+    clawhubVerdictsError,
   };
 }
 

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -31,6 +31,7 @@ import {
   type ClawHubSearchResult,
   type ClawHubSkillDetail,
   type ClawHubSkillSecurityVerdict,
+  type ClawHubSkillSecurityVerdicts,
   type SkillOperation,
   type SkillMessageMap,
 } from "../../lib/skills/index.ts";
@@ -51,6 +52,8 @@ export type SkillsRouteData = {
   selectedAgentId: string | null;
   report: SkillStatusReport | null;
   error: string | null;
+  clawhubVerdicts: ClawHubSkillSecurityVerdicts;
+  clawhubVerdictsError: string | null;
 };
 
 class SkillsPage extends OpenClawLightDomElement {
@@ -265,6 +268,9 @@ class SkillsPage extends OpenClawLightDomElement {
     this.skillsLoading = false;
     this.skillsReport = data.report;
     this.skillsError = data.error;
+    this.clawhubVerdicts = data.clawhubVerdicts;
+    this.clawhubVerdictsLoading = false;
+    this.clawhubVerdictsError = data.clawhubVerdictsError;
   }
 
   private ensureInitialData() {

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -859,6 +859,57 @@ describe("renderSkills", () => {
     expect(normalizeText(container)).toContain("AgentReceipt Local trust card.");
   });
 
+  it("renders a preloaded clean ClawHub verdict as Clean", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+    const linkedSkill = createSkill({
+      skillKey: "agentreceipt",
+      name: "AgentReceipt",
+      clawhub: {
+        status: "linked",
+        valid: true,
+        registry: "https://clawhub.ai",
+        slug: "agentreceipt",
+        installedVersion: "1.2.3",
+        installedAt: 123,
+      },
+    });
+
+    render(
+      renderSkills(
+        createProps({
+          report: {
+            workspaceDir: "/tmp/workspace",
+            managedSkillsDir: "/tmp/skills",
+            skills: [linkedSkill],
+          },
+          clawhubVerdicts: {
+            "https://clawhub.ai\u0000agentreceipt\u00001.2.3": {
+              registry: "https://clawhub.ai",
+              ok: true,
+              decision: "pass",
+              reasons: [],
+              requestedSlug: "agentreceipt",
+              requestedVersion: "1.2.3",
+              securityStatus: "clean",
+              securityPassed: true,
+            },
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const cleanStatus = Array.from(container.querySelectorAll(".settings-status")).find(
+      (status) => normalizeText(status) === "Clean",
+    );
+    expect(cleanStatus).toBeDefined();
+    expect(cleanStatus?.classList.contains("settings-status--ok")).toBe(true);
+    expect(normalizeText(container)).not.toContain("Unavailable");
+  });
+
   it("fails closed for inconsistent ClawHub verdict envelopes", async () => {
     const container = document.createElement("div");
     document.body.append(container);


### PR DESCRIPTION
## What Problem This Solves

The Control UI Skills route preloads `skills.status` but not `skills.securityVerdicts`. Because the route data is treated as complete, a linked ClawHub skill with a clean verdict can show `Unavailable` on first load even though the Gateway has already classified it as safe. Fixes #108647.

## Why This Change Was Made

The shared Skills data layer now exposes a pure verdict loader that skips the RPC when no valid linked skills exist and maps responses with the existing canonical verdict key. The route awaits that loader after status and passes the verdict map and any verdict-specific error into the page before first render. The existing page-level hydration remains in place for reconnects, agent changes, and manual refreshes.

## User Impact

Linked ClawHub skills show their real Clean, Review, or Blocked security status on first navigation instead of a misleading Unavailable badge. Local and unlinked skills issue no verdict request, and verdict failures remain separate from skill-status failures.

## Evidence

Base `215e49b1a2f5155a4328864ddc85e9ff87f88dcc`; head `3378c8cfa8f79b267513851c8edf4e21ee03b79a`.

Focused Control UI tests: 75 passed across 4 files.

Focused Playwright flow: 3 passed, including navigation to the real Skills route, opening a linked skill, seeing Clean, and never seeing Unavailable.

Control UI TypeScript checks passed for UI and core-test projects.

Type-aware oxlint and oxfmt passed for all 8 changed files. i18n verification, max-lines ratchet, conflict-marker scan, and `git diff --check` passed.

The production Control UI build passed with 2,951 modules, all 680 precompressed sidecars verified, and the repository performance budget passed.

The broad `check:changed` wrapper could not run normally in this checkout because the installed Node.js is 25.8.2 while the repository now requires 25.9 or newer, and its remote crabbox runner is unavailable. The selected direct repository checks above passed without reinstalling dependencies; hosted CI remains authoritative.