### PR TITLE
fix(android): move Wear capability keep rules to dedicated res/raw/*.keep.xml

### DIFF
--- a/apps/android/app/src/main/res/raw/ai.openclaw.app.phone.keep.xml
+++ b/apps/android/app/src/main/res/raw/ai.openclaw.app.phone.keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@array/android_wear_capabilities,@string/native_android_wear_capability" />

--- a/apps/android/app/src/main/res/values/wear.xml
+++ b/apps/android/app/src/main/res/values/wear.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:keep="@array/android_wear_capabilities">
+<resources>
     <string name="native_android_wear_capability" translatable="false">openclaw_phone_proxy_v1</string>
     <string-array name="android_wear_capabilities" translatable="false">
         <item tools:ignore="Typos">@string/native_android_wear_capability</item>

--- a/apps/android/wear/src/main/res/raw/ai.openclaw.app.wear.keep.xml
+++ b/apps/android/wear/src/main/res/raw/ai.openclaw.app.wear.keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@array/android_wear_capabilities" />

--- a/apps/android/wear/src/main/res/values/wear.xml
+++ b/apps/android/wear/src/main/res/values/wear.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:keep="@array/android_wear_capabilities">
+<resources>
     <string-array name="android_wear_capabilities" translatable="false">
         <item tools:ignore="Typos">openclaw_wear_companion_v1</item>
     </string-array>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing the official OpenClaw phone and Wear OS apps from Google Play cannot complete capability discovery. The Wear companion stays on "Phone not reachable" despite healthy phone/watch pairing, because the static Wear capability resources (`android_wear_capabilities`, `openclaw_phone_proxy_v1`, `openclaw_wear_companion_v1`) are stripped from release APKs by the Android resource shrinker.

## Why This Change Was Made

The root cause is that `tools:keep` directives were placed in `res/values/wear.xml` files. Android's resource shrinker (`R8`) only respects `tools:keep` declarations when they are placed in dedicated `res/raw/*.keep.xml` files. The issue reporter identified this and suggested the fix. Moving the keep rules to the correct location ensures capability arrays survive minification in release builds without changing any capability values or resource definitions.

## User Impact

Before: Phone and Wear OS apps install successfully from Google Play but cannot discover each other — the Wear companion shows "Phone not reachable" permanently.

After: The Wear companion can discover the phone proxy, capability negotiation succeeds, and the Wear OS experience works as designed.

## Evidence

### Verified file structure

Phone app — keep rule moved from `values/wear.xml` to `raw/ai.openclaw.app.phone.keep.xml`:

```text
# Before: tools:keep in values/wear.xml (stripped by shrinker)
apps/android/app/src/main/res/values/wear.xml
  <resources xmlns:tools="http://schemas.android.com/tools"
      tools:keep="@array/android_wear_capabilities">

# After: tools:keep in dedicated keep.xml (preserved by shrinker)
apps/android/app/src/main/res/raw/ai.openclaw.app.phone.keep.xml
  <resources xmlns:tools="http://schemas.android.com/tools"
      tools:keep="@array/android_wear_capabilities,@string/native_android_wear_capability" />

apps/android/app/src/main/res/values/wear.xml
  <resources>  (tools:keep removed)
```

Wear app — same fix:

```text
# Before
apps/android/wear/src/main/res/values/wear.xml
  <resources xmlns:tools="http://schemas.android.com/tools"
      tools:keep="@array/android_wear_capabilities">

# After
apps/android/wear/src/main/res/raw/ai.openclaw.app.wear.keep.xml
  <resources xmlns:tools="http://schemas.android.com/tools"
      tools:keep="@array/android_wear_capabilities" />

apps/android/wear/src/main/res/values/wear.xml
  <resources>  (tools:keep removed)
```

### Per Google's documentation

Android developer docs specify that shrinker keep rules must be in `res/raw/*.keep.xml`:
https://developer.android.com/topic/performance/app-optimization/customize-which-resources-to-keep

### What changed

| File | Change |
|------|--------|
| `app/src/main/res/values/wear.xml` | Removed `tools:keep` from resources tag |
| `app/src/main/res/raw/ai.openclaw.app.phone.keep.xml` | **New** — keep directive for phone capabilities |
| `wear/src/main/res/values/wear.xml` | Removed `tools:keep` from resources tag |
| `wear/src/main/res/raw/ai.openclaw.app.wear.keep.xml` | **New** — keep directive for watch capabilities |

### CI verification

Full CI will run on push — the change is a pure build config fix with no runtime code changes.

[AI-assisted]
