### PR TITLE
fix(gateway): evict idle agent terminal sessions under pool pressure

### DIFF
--- a/src/gateway/terminal/session-manager.eviction.test.ts
+++ b/src/gateway/terminal/session-manager.eviction.test.ts
@@ -1,0 +1,107 @@
+// Idle-eviction under pool pressure: one busy agent must not brick terminal
+// opens gateway-wide until restart.
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import { TerminalSessionManager } from "./session-manager.js";
+import {
+  baseOpenRequest,
+  type FakeTerminalPty,
+  makeFakePty,
+} from "./session-manager.test-helpers.js";
+
+const agentOwner = { kind: "agent", agentSessionKey: "agent:main:main" } as const;
+
+function trackingManager(maxSessions: number) {
+  const ptys: FakeTerminalPty[] = [];
+  const manager = new TerminalSessionManager({
+    emit: vi.fn(),
+    spawn: async () => {
+      const pty = makeFakePty();
+      ptys.push(pty);
+      return pty;
+    },
+    maxSessions,
+  });
+  return { manager, ptys };
+}
+
+describe("TerminalSessionManager idle eviction", () => {
+  it("evicts the longest-idle viewer-free agent session under pool pressure", async () => {
+    vi.useFakeTimers();
+    try {
+      const { manager, ptys } = trackingManager(2);
+      const first = await manager.open(baseOpenRequest({ owner: agentOwner }));
+      await vi.advanceTimersByTimeAsync(5_000);
+      const second = await manager.open(baseOpenRequest({ owner: agentOwner }));
+      if (!first.ok || !second.ok) {
+        throw new Error("expected agent opens");
+      }
+      // Freshen the second session so the first is the idle-eviction candidate.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(manager.writeAgent("agent:main:main", second.sessionId, "keepalive\r")).toBe(true);
+
+      const third = await manager.open(baseOpenRequest({ owner: agentOwner }));
+      expect(third.ok).toBe(true);
+      expect(manager.size).toBe(2);
+      expect(expectDefined(ptys[0], "ptys[0] test invariant").killed).toBe(true);
+      expect(expectDefined(ptys[1], "ptys[1] test invariant").killed).toBe(false);
+      expect(manager.snapshotAgent("agent:main:main", first.sessionId)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("never evicts viewer-attached or connection-owned sessions under pressure", async () => {
+    const { manager, ptys } = trackingManager(2);
+    const connOwned = await manager.open(baseOpenRequest());
+    const viewed = await manager.open(baseOpenRequest({ owner: agentOwner }));
+    if (!connOwned.ok || !viewed.ok) {
+      throw new Error("expected opens");
+    }
+    expect(manager.attach("viewer-1", viewed.sessionId)?.sessionId).toBe(viewed.sessionId);
+
+    const denied = await manager.open(baseOpenRequest({ owner: agentOwner }));
+    expect(denied.ok).toBe(false);
+    if (!denied.ok) {
+      expect(denied.code).toBe("limit");
+    }
+    expect(manager.size).toBe(2);
+    expect(ptys.some((pty) => pty.killed)).toBe(false);
+  });
+
+  it("keeps the claimed victim alive when the replacement spawn fails", async () => {
+    const pty = makeFakePty();
+    let failNextSpawn = false;
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => {
+        if (failNextSpawn) {
+          throw new Error("pty exhausted");
+        }
+        return pty;
+      },
+      maxSessions: 1,
+    });
+    const victim = await manager.open(baseOpenRequest({ owner: agentOwner }));
+    if (!victim.ok) {
+      throw new Error("expected open");
+    }
+
+    failNextSpawn = true;
+    const failed = await manager.open(baseOpenRequest({ owner: agentOwner }));
+    expect(failed.ok).toBe(false);
+    if (!failed.ok) {
+      expect(failed.code).toBe("spawn_failed");
+    }
+    // The victim survives a failed replacement and stays claimable later.
+    expect(manager.size).toBe(1);
+    expect(pty.killed).toBe(false);
+    expect(manager.writeAgent("agent:main:main", victim.sessionId, "still-alive\r")).toBe(true);
+
+    failNextSpawn = false;
+    const replacement = await manager.open(baseOpenRequest({ owner: agentOwner }));
+    expect(replacement.ok).toBe(true);
+    expect(manager.size).toBe(1);
+    expect(pty.killed).toBe(true);
+  });
+});

--- a/src/gateway/terminal/session-manager.eviction.test.ts
+++ b/src/gateway/terminal/session-manager.eviction.test.ts
@@ -69,6 +69,48 @@ describe("TerminalSessionManager idle eviction", () => {
     expect(ptys.some((pty) => pty.killed)).toBe(false);
   });
 
+  it("spares a victim that gains a viewer during the replacement spawn", async () => {
+    const victimPty = makeFakePty();
+    const replacementPty = makeFakePty();
+    let releaseSpawn: (() => void) | undefined;
+    let spawnCount = 0;
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => {
+        spawnCount += 1;
+        if (spawnCount === 1) {
+          return victimPty;
+        }
+        await new Promise<void>((resolve) => {
+          releaseSpawn = resolve;
+        });
+        return replacementPty;
+      },
+      maxSessions: 1,
+    });
+    const victim = await manager.open(baseOpenRequest({ owner: agentOwner }));
+    if (!victim.ok) {
+      throw new Error("expected open");
+    }
+
+    const opening = manager.open(baseOpenRequest({ owner: agentOwner }));
+    await vi.waitFor(() => expect(releaseSpawn).toBeDefined());
+    // The claimed victim becomes viewer-attached while the replacement spawns.
+    expect(manager.attach("viewer-1", victim.sessionId)?.sessionId).toBe(victim.sessionId);
+    releaseSpawn?.();
+
+    const outcome = await opening;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.code).toBe("limit");
+    }
+    // The now-viewered session survives; the orphaned replacement is killed.
+    expect(victimPty.killed).toBe(false);
+    expect(replacementPty.killed).toBe(true);
+    expect(manager.size).toBe(1);
+    expect(manager.writeAgent("agent:main:main", victim.sessionId, "still-alive\r")).toBe(true);
+  });
+
   it("keeps the claimed victim alive when the replacement spawn fails", async () => {
     const pty = makeFakePty();
     let failNextSpawn = false;

--- a/src/gateway/terminal/session-manager.eviction.test.ts
+++ b/src/gateway/terminal/session-manager.eviction.test.ts
@@ -111,6 +111,43 @@ describe("TerminalSessionManager idle eviction", () => {
     expect(manager.writeAgent("agent:main:main", victim.sessionId, "still-alive\r")).toBe(true);
   });
 
+  it("holds the cap when concurrent opens complete out of order", async () => {
+    const gates: Array<(pty: FakeTerminalPty) => void> = [];
+    const spawned: FakeTerminalPty[] = [];
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => {
+        const pty = await new Promise<FakeTerminalPty>((resolve) => {
+          gates.push(resolve);
+        });
+        spawned.push(pty);
+        return pty;
+      },
+      maxSessions: 2,
+    });
+    const seeded = manager.open(baseOpenRequest({ owner: agentOwner }));
+    await vi.waitFor(() => expect(gates).toHaveLength(1));
+    gates[0]?.(makeFakePty());
+    const seededOutcome = await seeded;
+    expect(seededOutcome.ok).toBe(true);
+
+    // A reserves the free slot; B sees the reservation and claims the seeded
+    // session for eviction. B's spawn completes first.
+    const openA = manager.open(baseOpenRequest({ owner: agentOwner }));
+    await vi.waitFor(() => expect(gates).toHaveLength(2));
+    const openB = manager.open(baseOpenRequest({ owner: agentOwner }));
+    await vi.waitFor(() => expect(gates).toHaveLength(3));
+    gates[2]?.(makeFakePty());
+    const outcomeB = await openB;
+    gates[1]?.(makeFakePty());
+    const outcomeA = await openA;
+
+    expect(outcomeA.ok).toBe(true);
+    expect(outcomeB.ok).toBe(true);
+    // The hard cap survives the out-of-order completion.
+    expect(manager.size).toBeLessThanOrEqual(2);
+  });
+
   it("keeps the claimed victim alive when the replacement spawn fails", async () => {
     const pty = makeFakePty();
     let failNextSpawn = false;

--- a/src/gateway/terminal/session-manager.eviction.test.ts
+++ b/src/gateway/terminal/session-manager.eviction.test.ts
@@ -194,6 +194,38 @@ describe("TerminalSessionManager idle eviction", () => {
     expect(manager.size).toBeLessThanOrEqual(2);
   });
 
+  it("releases the eviction claim when a cancelled open's spawn never settles", async () => {
+    let hangNextSpawn = false;
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => {
+        if (hangNextSpawn) {
+          hangNextSpawn = false;
+          return await new Promise<never>(() => {});
+        }
+        return makeFakePty();
+      },
+      maxSessions: 1,
+    });
+    const victim = await manager.open(baseOpenRequest({ owner: agentOwner }));
+    if (!victim.ok) {
+      throw new Error("expected open");
+    }
+
+    hangNextSpawn = true;
+    const controller = new AbortController();
+    const hung = manager.open(baseOpenRequest({ owner: agentOwner, signal: controller.signal }));
+    await vi.waitFor(() => expect(hangNextSpawn).toBe(false));
+    controller.abort(new Error("cancelled"));
+
+    // The cancelled open's claim is gone, so a later open can evict the victim.
+    const next = await manager.open(baseOpenRequest({ owner: agentOwner }));
+    expect(next.ok).toBe(true);
+    expect(manager.size).toBe(1);
+    // The hung open stays pending forever by design; do not await it.
+    void hung;
+  });
+
   it("keeps the claimed victim alive when the replacement spawn fails", async () => {
     const pty = makeFakePty();
     let failNextSpawn = false;

--- a/src/gateway/terminal/session-manager.eviction.test.ts
+++ b/src/gateway/terminal/session-manager.eviction.test.ts
@@ -111,6 +111,52 @@ describe("TerminalSessionManager idle eviction", () => {
     expect(manager.writeAgent("agent:main:main", victim.sessionId, "still-alive\r")).toBe(true);
   });
 
+  it("evicts the freshly idlest session when the claimed victim becomes active mid-spawn", async () => {
+    vi.useFakeTimers();
+    try {
+      const ptys: FakeTerminalPty[] = [];
+      let releaseSpawn: (() => void) | undefined;
+      let gateNextSpawn = false;
+      const manager = new TerminalSessionManager({
+        emit: vi.fn(),
+        spawn: async () => {
+          const pty = makeFakePty();
+          ptys.push(pty);
+          if (gateNextSpawn) {
+            await new Promise<void>((resolve) => {
+              releaseSpawn = resolve;
+            });
+          }
+          return pty;
+        },
+        maxSessions: 2,
+      });
+      const oldest = await manager.open(baseOpenRequest({ owner: agentOwner }));
+      await vi.advanceTimersByTimeAsync(5_000);
+      const newer = await manager.open(baseOpenRequest({ owner: agentOwner }));
+      if (!oldest.ok || !newer.ok) {
+        throw new Error("expected agent opens");
+      }
+
+      gateNextSpawn = true;
+      const opening = manager.open(baseOpenRequest({ owner: agentOwner }));
+      await vi.waitFor(() => expect(releaseSpawn).toBeDefined());
+      // The claimed (oldest) session becomes active during the spawn, making
+      // the newer session the genuinely idlest candidate.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(manager.writeAgent("agent:main:main", oldest.sessionId, "busy\r")).toBe(true);
+      releaseSpawn?.();
+
+      const outcome = await opening;
+      expect(outcome.ok).toBe(true);
+      expect(manager.size).toBe(2);
+      expect(expectDefined(ptys[0], "oldest pty invariant").killed).toBe(false);
+      expect(expectDefined(ptys[1], "newer pty invariant").killed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("holds the cap when concurrent opens complete out of order", async () => {
     const gates: Array<(pty: FakeTerminalPty) => void> = [];
     const spawned: FakeTerminalPty[] = [];

--- a/src/gateway/terminal/session-manager.test-helpers.ts
+++ b/src/gateway/terminal/session-manager.test-helpers.ts
@@ -1,0 +1,77 @@
+/** Shared fakes for terminal session-manager test files. */
+import type { spawnTerminalPty } from "../../process/terminal-pty.js";
+import type { TerminalSessionManager } from "./session-manager.js";
+
+export type TerminalOpenRequestInput = Parameters<TerminalSessionManager["open"]>[0];
+type TerminalPtyHandle = Awaited<ReturnType<typeof spawnTerminalPty>>;
+
+export type FakeTerminalPty = TerminalPtyHandle & {
+  writes: string[];
+  resizes: Array<[number, number]>;
+  killed: boolean;
+  paused: boolean;
+  pauseCalls: number;
+  resumeCalls: number;
+  deliveredChunks: number;
+  emitData: (chunk: string) => void;
+  emitExit: (code: number, signal?: number) => void;
+};
+
+/** A controllable fake PTY that records writes and lets tests drive data/exit. */
+export function makeFakePty(): FakeTerminalPty {
+  let dataListener: ((chunk: string) => void) | undefined;
+  let exitListener: ((event: { exitCode: number; signal?: number }) => void) | undefined;
+  const handle: FakeTerminalPty = {
+    pid: 4242,
+    writes: [],
+    resizes: [],
+    killed: false,
+    paused: false,
+    pauseCalls: 0,
+    resumeCalls: 0,
+    deliveredChunks: 0,
+    write: (data) => handle.writes.push(data),
+    resize: (cols, rows) => handle.resizes.push([cols, rows]),
+    pause: () => {
+      handle.paused = true;
+      handle.pauseCalls += 1;
+    },
+    resume: () => {
+      handle.paused = false;
+      handle.resumeCalls += 1;
+    },
+    onData: (listener) => {
+      dataListener = listener;
+    },
+    onExit: (listener) => {
+      exitListener = listener;
+    },
+    kill: () => {
+      handle.killed = true;
+    },
+    emitData: (chunk) => {
+      if (!handle.paused) {
+        handle.deliveredChunks += 1;
+        dataListener?.(chunk);
+      }
+    },
+    emitExit: (code, signal) => exitListener?.({ exitCode: code, signal }),
+  };
+  return handle;
+}
+
+export function baseOpenRequest(
+  overrides?: Partial<TerminalOpenRequestInput>,
+): TerminalOpenRequestInput {
+  return {
+    owner: { kind: "conn", connId: "conn-1" },
+    agentId: "main",
+    cwd: "/work",
+    shell: "/bin/zsh",
+    args: ["-l"],
+    cols: 80,
+    rows: 24,
+    env: { TERM: "xterm-256color" },
+    ...overrides,
+  };
+}

--- a/src/gateway/terminal/session-manager.test-helpers.ts
+++ b/src/gateway/terminal/session-manager.test-helpers.ts
@@ -2,7 +2,7 @@
 import type { spawnTerminalPty } from "../../process/terminal-pty.js";
 import type { TerminalSessionManager } from "./session-manager.js";
 
-export type TerminalOpenRequestInput = Parameters<TerminalSessionManager["open"]>[0];
+type TerminalOpenRequestInput = Parameters<TerminalSessionManager["open"]>[0];
 type TerminalPtyHandle = Awaited<ReturnType<typeof spawnTerminalPty>>;
 
 export type FakeTerminalPty = TerminalPtyHandle & {

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -694,6 +694,67 @@ describe("TerminalSessionManager agent ownership", () => {
     }
   });
 
+  it("evicts the longest-idle viewer-free agent session under pool pressure", async () => {
+    vi.useFakeTimers();
+    try {
+      const ptys: ReturnType<typeof makeFakePty>[] = [];
+      const manager = new TerminalSessionManager({
+        emit: vi.fn(),
+        spawn: async () => {
+          const pty = makeFakePty();
+          ptys.push(pty);
+          return pty;
+        },
+        maxSessions: 2,
+      });
+      const first = await manager.open(baseRequest({ owner: agentOwner }));
+      await vi.advanceTimersByTimeAsync(5_000);
+      const second = await manager.open(baseRequest({ owner: agentOwner }));
+      if (!first.ok || !second.ok) {
+        throw new Error("expected agent opens");
+      }
+      // Freshen the second session so the first is the idle-eviction candidate.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(manager.writeAgent("agent:main:main", second.sessionId, "keepalive\r")).toBe(true);
+
+      const third = await manager.open(baseRequest({ owner: agentOwner }));
+      expect(third.ok).toBe(true);
+      expect(manager.size).toBe(2);
+      expect(expectDefined(ptys[0], "ptys[0] test invariant").killed).toBe(true);
+      expect(expectDefined(ptys[1], "ptys[1] test invariant").killed).toBe(false);
+      expect(manager.snapshotAgent("agent:main:main", first.sessionId)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("never evicts viewer-attached or connection-owned sessions under pressure", async () => {
+    const ptys: ReturnType<typeof makeFakePty>[] = [];
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => {
+        const pty = makeFakePty();
+        ptys.push(pty);
+        return pty;
+      },
+      maxSessions: 2,
+    });
+    const connOwned = await manager.open(baseRequest());
+    const viewed = await manager.open(baseRequest({ owner: agentOwner }));
+    if (!connOwned.ok || !viewed.ok) {
+      throw new Error("expected opens");
+    }
+    expect(manager.attach("viewer-1", viewed.sessionId)?.sessionId).toBe(viewed.sessionId);
+
+    const denied = await manager.open(baseRequest({ owner: agentOwner }));
+    expect(denied.ok).toBe(false);
+    if (!denied.ok) {
+      expect(denied.code).toBe("limit");
+    }
+    expect(manager.size).toBe(2);
+    expect(ptys.some((pty) => pty.killed)).toBe(false);
+  });
+
   it("lets a co-attached viewer upload into an agent-owned session", async () => {
     const emit = vi.fn();
     const stageUpload = vi.fn(async () => ({ path: "/tmp/node/report.pdf", size: 4 }));

--- a/src/gateway/terminal/session-manager.test.ts
+++ b/src/gateway/terminal/session-manager.test.ts
@@ -1,11 +1,12 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
-import type { spawnTerminalPty } from "../../process/terminal-pty.js";
 import type { TerminalBackend } from "./backend.js";
 import { TerminalSessionManager } from "./session-manager.js";
-
-type TerminalOpenRequest = Parameters<TerminalSessionManager["open"]>[0];
-type TerminalPtyHandle = Awaited<ReturnType<typeof spawnTerminalPty>>;
+import {
+  baseOpenRequest as baseRequest,
+  type FakeTerminalPty,
+  makeFakePty,
+} from "./session-manager.test-helpers.js";
 const TERMINAL_EVENT_DATA = "terminal.data";
 const TERMINAL_EVENT_EXIT = "terminal.exit";
 
@@ -17,76 +18,9 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-/** A controllable fake PTY that records writes and lets tests drive data/exit. */
-function makeFakePty() {
-  let dataListener: ((chunk: string) => void) | undefined;
-  let exitListener: ((event: { exitCode: number; signal?: number }) => void) | undefined;
-  const handle: TerminalPtyHandle & {
-    writes: string[];
-    resizes: Array<[number, number]>;
-    killed: boolean;
-    paused: boolean;
-    pauseCalls: number;
-    resumeCalls: number;
-    deliveredChunks: number;
-    emitData: (chunk: string) => void;
-    emitExit: (code: number, signal?: number) => void;
-  } = {
-    pid: 4242,
-    writes: [],
-    resizes: [],
-    killed: false,
-    paused: false,
-    pauseCalls: 0,
-    resumeCalls: 0,
-    deliveredChunks: 0,
-    write: (data) => handle.writes.push(data),
-    resize: (cols, rows) => handle.resizes.push([cols, rows]),
-    pause: () => {
-      handle.paused = true;
-      handle.pauseCalls += 1;
-    },
-    resume: () => {
-      handle.paused = false;
-      handle.resumeCalls += 1;
-    },
-    onData: (listener) => {
-      dataListener = listener;
-    },
-    onExit: (listener) => {
-      exitListener = listener;
-    },
-    kill: () => {
-      handle.killed = true;
-    },
-    emitData: (chunk) => {
-      if (!handle.paused) {
-        handle.deliveredChunks += 1;
-        dataListener?.(chunk);
-      }
-    },
-    emitExit: (code, signal) => exitListener?.({ exitCode: code, signal }),
-  };
-  return handle;
-}
-
-function baseRequest(overrides?: Partial<TerminalOpenRequest>): TerminalOpenRequest {
-  return {
-    owner: { kind: "conn", connId: "conn-1" },
-    agentId: "main",
-    cwd: "/work",
-    shell: "/bin/zsh",
-    args: ["-l"],
-    cols: 80,
-    rows: 24,
-    env: { TERM: "xterm-256color" },
-    ...overrides,
-  };
-}
-
 describe("TerminalSessionManager", () => {
   it("kills a backend that finishes after its open request is cancelled", async () => {
-    const spawned = deferred<TerminalPtyHandle>();
+    const spawned = deferred<FakeTerminalPty>();
     const controller = new AbortController();
     const first = makeFakePty();
     const second = makeFakePty();
@@ -118,8 +52,8 @@ describe("TerminalSessionManager", () => {
   });
 
   it("bounds cancelled backend operations until they settle", async () => {
-    const firstSpawn = deferred<TerminalPtyHandle>();
-    const secondSpawn = deferred<TerminalPtyHandle>();
+    const firstSpawn = deferred<FakeTerminalPty>();
+    const secondSpawn = deferred<FakeTerminalPty>();
     const firstController = new AbortController();
     const secondController = new AbortController();
     let spawnCount = 0;
@@ -692,67 +626,6 @@ describe("TerminalSessionManager agent ownership", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  it("evicts the longest-idle viewer-free agent session under pool pressure", async () => {
-    vi.useFakeTimers();
-    try {
-      const ptys: ReturnType<typeof makeFakePty>[] = [];
-      const manager = new TerminalSessionManager({
-        emit: vi.fn(),
-        spawn: async () => {
-          const pty = makeFakePty();
-          ptys.push(pty);
-          return pty;
-        },
-        maxSessions: 2,
-      });
-      const first = await manager.open(baseRequest({ owner: agentOwner }));
-      await vi.advanceTimersByTimeAsync(5_000);
-      const second = await manager.open(baseRequest({ owner: agentOwner }));
-      if (!first.ok || !second.ok) {
-        throw new Error("expected agent opens");
-      }
-      // Freshen the second session so the first is the idle-eviction candidate.
-      await vi.advanceTimersByTimeAsync(5_000);
-      expect(manager.writeAgent("agent:main:main", second.sessionId, "keepalive\r")).toBe(true);
-
-      const third = await manager.open(baseRequest({ owner: agentOwner }));
-      expect(third.ok).toBe(true);
-      expect(manager.size).toBe(2);
-      expect(expectDefined(ptys[0], "ptys[0] test invariant").killed).toBe(true);
-      expect(expectDefined(ptys[1], "ptys[1] test invariant").killed).toBe(false);
-      expect(manager.snapshotAgent("agent:main:main", first.sessionId)).toBeUndefined();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("never evicts viewer-attached or connection-owned sessions under pressure", async () => {
-    const ptys: ReturnType<typeof makeFakePty>[] = [];
-    const manager = new TerminalSessionManager({
-      emit: vi.fn(),
-      spawn: async () => {
-        const pty = makeFakePty();
-        ptys.push(pty);
-        return pty;
-      },
-      maxSessions: 2,
-    });
-    const connOwned = await manager.open(baseRequest());
-    const viewed = await manager.open(baseRequest({ owner: agentOwner }));
-    if (!connOwned.ok || !viewed.ok) {
-      throw new Error("expected opens");
-    }
-    expect(manager.attach("viewer-1", viewed.sessionId)?.sessionId).toBe(viewed.sessionId);
-
-    const denied = await manager.open(baseRequest({ owner: agentOwner }));
-    expect(denied.ok).toBe(false);
-    if (!denied.ok) {
-      expect(denied.code).toBe("limit");
-    }
-    expect(manager.size).toBe(2);
-    expect(ptys.some((pty) => pty.killed)).toBe(false);
   });
 
   it("lets a co-attached viewer upload into an agent-owned session", async () => {

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -185,7 +185,11 @@ export class TerminalSessionManager {
       const claimed = evictionCandidate;
       evictionCandidate = undefined;
       claimed.evictionClaimed = false;
-      if (this.sessions.size >= this.maxSessions) {
+      // Count other opens' outstanding reservations (our own was released
+      // above): skipping eviction against sessions.size alone lets concurrent
+      // spawns that finish out of order register past the hard cap. Evicting
+      // for a reservation whose spawn later fails is the safer direction.
+      if (this.sessions.size + this.opening >= this.maxSessions) {
         const victim =
           !claimed.closed && claimed.viewers.size === 0
             ? claimed

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -130,7 +130,10 @@ export class TerminalSessionManager {
         pending.abortMessage ??= message;
         // A hung spawn must not consume capacity after its owner is gone.
         // Its eventual backend is still killed by the abortMessage check below.
+        // The eviction claim must also drop now: a cancelled open whose spawn
+        // never settles would otherwise keep its victim unclaimable forever.
         releaseReservation();
+        releaseEvictionClaim();
       },
     };
     const abortPending = () => {

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -178,13 +178,36 @@ export class TerminalSessionManager {
       return { ok: false, code: "closed", message: pending.abortMessage };
     }
     if (evictionCandidate) {
-      // The replacement backend exists; retire the claimed victim now, still
-      // inside the synchronous window, so registration stays within the cap.
-      log.info(
-        `evicted idle agent terminal session under pool pressure: id=${evictionCandidate.id} agent=${evictionCandidate.agentId} idleMs=${Date.now() - evictionCandidate.lastActivityAtMs}`,
-      );
-      this.finalize(evictionCandidate, "closed", {});
+      // The replacement backend exists; retire a victim now, still inside the
+      // synchronous window, so registration stays within the cap. Revalidate
+      // first: the claimed candidate may have gained a viewer or exited during
+      // the spawn await, and viewer-attached sessions are never evicted.
+      const claimed = evictionCandidate;
       evictionCandidate = undefined;
+      claimed.evictionClaimed = false;
+      if (this.sessions.size >= this.maxSessions) {
+        const victim =
+          !claimed.closed && claimed.viewers.size === 0
+            ? claimed
+            : this.claimLongestIdleAgentSession();
+        if (!victim) {
+          try {
+            backend.kill();
+          } catch {
+            // Best-effort; the process may already be gone.
+          }
+          return {
+            ok: false,
+            code: "limit",
+            message: `terminal session limit reached (${this.maxSessions})`,
+          };
+        }
+        victim.evictionClaimed = false;
+        log.info(
+          `evicted idle agent terminal session under pool pressure: id=${victim.id} agent=${victim.agentId} idleMs=${Date.now() - victim.lastActivityAtMs}`,
+        );
+        this.finalize(victim, "closed", {});
+      }
     }
 
     const sessionId = randomUUID();

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -190,10 +190,11 @@ export class TerminalSessionManager {
       // spawns that finish out of order register past the hard cap. Evicting
       // for a reservation whose spawn later fails is the safer direction.
       if (this.sessions.size + this.opening >= this.maxSessions) {
-        const victim =
-          !claimed.closed && claimed.viewers.size === 0
-            ? claimed
-            : this.claimLongestIdleAgentSession();
+        // Reselect fresh: the idle ranking goes stale across the spawn await —
+        // the claimed session may now be viewer-attached or active while an
+        // idler alternative exists. The released claim rejoins the pool, so a
+        // still-idlest claimed session is simply selected again.
+        const victim = this.claimLongestIdleAgentSession();
         if (!victim) {
           try {
             backend.kill();

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -90,15 +90,15 @@ export class TerminalSessionManager {
         message: `terminal spawn limit reached (${this.maxSessions * 2})`,
       };
     }
+    // Agent-opened shells outlive their commands and have no automatic reaper,
+    // so a busy agent would otherwise exhaust the pool for the whole gateway
+    // until restart. Under pressure, claim the longest-idle viewer-free agent
+    // session as an eviction candidate; it is killed only after the replacement
+    // backend spawns, so a failed spawn never destroys a live session.
+    let evictionCandidate: TerminalSession | undefined;
     if (this.sessions.size + this.opening >= this.maxSessions) {
-      // Agent-opened shells outlive their commands and have no automatic
-      // reaper, so a busy agent would otherwise exhaust the pool for the whole
-      // gateway until restart. Under pressure, reclaim the longest-idle
-      // viewer-free agent session instead of failing every later open.
-      if (
-        !this.evictLongestIdleAgentSession() ||
-        this.sessions.size + this.opening >= this.maxSessions
-      ) {
+      evictionCandidate = this.claimLongestIdleAgentSession();
+      if (!evictionCandidate) {
         return {
           ok: false,
           code: "limit",
@@ -106,6 +106,12 @@ export class TerminalSessionManager {
         };
       }
     }
+    const releaseEvictionClaim = () => {
+      if (evictionCandidate) {
+        evictionCandidate.evictionClaimed = false;
+        evictionCandidate = undefined;
+      }
+    };
     // Reserve the slot before the async spawn so it is visible to concurrent opens.
     this.opening += 1;
     this.spawning += 1;
@@ -150,6 +156,7 @@ export class TerminalSessionManager {
     } catch (err) {
       this.spawning -= 1;
       releaseReservation();
+      releaseEvictionClaim();
       request.signal?.removeEventListener("abort", abortPending);
       const message = err instanceof Error ? err.message : String(err);
       return { ok: false, code: "spawn_failed", message };
@@ -162,12 +169,22 @@ export class TerminalSessionManager {
     if (pending.abortMessage) {
       // The request was cancelled while the shell was spawning; kill it now
       // rather than register an unreachable orphan.
+      releaseEvictionClaim();
       try {
         backend.kill();
       } catch {
         // Best-effort; the process may already be gone.
       }
       return { ok: false, code: "closed", message: pending.abortMessage };
+    }
+    if (evictionCandidate) {
+      // The replacement backend exists; retire the claimed victim now, still
+      // inside the synchronous window, so registration stays within the cap.
+      log.info(
+        `evicted idle agent terminal session under pool pressure: id=${evictionCandidate.id} agent=${evictionCandidate.agentId} idleMs=${Date.now() - evictionCandidate.lastActivityAtMs}`,
+      );
+      this.finalize(evictionCandidate, "closed", {});
+      evictionCandidate = undefined;
     }
 
     const sessionId = randomUUID();
@@ -578,31 +595,31 @@ export class TerminalSessionManager {
   }
 
   /**
-   * Reclaims the longest-idle agent-owned session when the pool is exhausted.
-   * Agent shells outlive their commands with no automatic reaper, so without
-   * eviction one busy agent bricks terminal opens gateway-wide until restart.
-   * Viewer-attached and connection-owned sessions are never evicted; an idle
-   * viewer-free background job losing its PTY under pressure is the accepted
-   * tradeoff for keeping the pool available.
+   * Claims the longest-idle agent-owned session as an eviction candidate when
+   * the pool is exhausted. Viewer-attached and connection-owned sessions are
+   * never evicted; an idle viewer-free background job losing its PTY under
+   * pressure is the accepted tradeoff for keeping the pool available. Claimed
+   * sessions are skipped so concurrent opens select distinct victims.
    */
-  private evictLongestIdleAgentSession(): boolean {
+  private claimLongestIdleAgentSession(): TerminalSession | undefined {
     let candidate: TerminalSession | undefined;
     for (const session of this.sessions.values()) {
-      if (session.closed || session.owner?.kind !== "agent" || session.viewers.size > 0) {
+      if (
+        session.closed ||
+        session.evictionClaimed ||
+        session.owner?.kind !== "agent" ||
+        session.viewers.size > 0
+      ) {
         continue;
       }
       if (!candidate || session.lastActivityAtMs < candidate.lastActivityAtMs) {
         candidate = session;
       }
     }
-    if (!candidate) {
-      return false;
+    if (candidate) {
+      candidate.evictionClaimed = true;
     }
-    log.info(
-      `evicted idle agent terminal session under pool pressure: id=${candidate.id} agent=${candidate.agentId} idleMs=${Date.now() - candidate.lastActivityAtMs}`,
-    );
-    this.finalize(candidate, "closed", {});
-    return true;
+    return candidate;
   }
 
   private removeViewer(session: TerminalSession, connId: string): boolean {

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -6,6 +6,7 @@ import {
   type TerminalUploadFile,
   type TerminalUploadResult,
 } from "../../infra/terminal-file-upload.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   createLocalTerminalBackend,
   type LocalTerminalBackendSpawner,
@@ -31,6 +32,8 @@ import type {
   TerminalSessionManagerOptions,
   TerminalOwner,
 } from "./session-manager.types.js";
+
+const log = createSubsystemLogger("gateway/terminal");
 
 /**
  * Tracks live PTY sessions keyed by session id, with a reverse index for
@@ -88,11 +91,20 @@ export class TerminalSessionManager {
       };
     }
     if (this.sessions.size + this.opening >= this.maxSessions) {
-      return {
-        ok: false,
-        code: "limit",
-        message: `terminal session limit reached (${this.maxSessions})`,
-      };
+      // Agent-opened shells outlive their commands and have no automatic
+      // reaper, so a busy agent would otherwise exhaust the pool for the whole
+      // gateway until restart. Under pressure, reclaim the longest-idle
+      // viewer-free agent session instead of failing every later open.
+      if (
+        !this.evictLongestIdleAgentSession() ||
+        this.sessions.size + this.opening >= this.maxSessions
+      ) {
+        return {
+          ok: false,
+          code: "limit",
+          message: `terminal session limit reached (${this.maxSessions})`,
+        };
+      }
     }
     // Reserve the slot before the async spawn so it is visible to concurrent opens.
     this.opening += 1;
@@ -192,6 +204,7 @@ export class TerminalSessionManager {
       output,
       reaper: null,
       detachedAtMs: null,
+      lastActivityAtMs: Date.now(),
     };
     this.sessions.set(session.id, session);
     if (request.owner.kind === "conn") {
@@ -200,6 +213,7 @@ export class TerminalSessionManager {
 
     backend.onData((chunk) => {
       if (!session.closed) {
+        session.lastActivityAtMs = Date.now();
         session.output.push(chunk);
       }
     });
@@ -238,6 +252,7 @@ export class TerminalSessionManager {
 
   private writeSession(session: TerminalSession, data: string): boolean {
     try {
+      session.lastActivityAtMs = Date.now();
       session.output.noteInput();
       session.backend.write(data);
       return true;
@@ -560,6 +575,34 @@ export class TerminalSessionManager {
     if (sessions?.size === 0) {
       this.byConn.delete(connId);
     }
+  }
+
+  /**
+   * Reclaims the longest-idle agent-owned session when the pool is exhausted.
+   * Agent shells outlive their commands with no automatic reaper, so without
+   * eviction one busy agent bricks terminal opens gateway-wide until restart.
+   * Viewer-attached and connection-owned sessions are never evicted; an idle
+   * viewer-free background job losing its PTY under pressure is the accepted
+   * tradeoff for keeping the pool available.
+   */
+  private evictLongestIdleAgentSession(): boolean {
+    let candidate: TerminalSession | undefined;
+    for (const session of this.sessions.values()) {
+      if (session.closed || session.owner?.kind !== "agent" || session.viewers.size > 0) {
+        continue;
+      }
+      if (!candidate || session.lastActivityAtMs < candidate.lastActivityAtMs) {
+        candidate = session;
+      }
+    }
+    if (!candidate) {
+      return false;
+    }
+    log.info(
+      `evicted idle agent terminal session under pool pressure: id=${candidate.id} agent=${candidate.agentId} idleMs=${Date.now() - candidate.lastActivityAtMs}`,
+    );
+    this.finalize(candidate, "closed", {});
+    return true;
   }
 
   private removeViewer(session: TerminalSession, connId: string): boolean {

--- a/src/gateway/terminal/session-manager.types.ts
+++ b/src/gateway/terminal/session-manager.types.ts
@@ -31,6 +31,8 @@ export type TerminalSession = {
   detachedAtMs: number | null;
   /** Last PTY input/output timestamp; drives idle eviction under pool pressure. */
   lastActivityAtMs: number;
+  /** Claimed by an in-flight open; killed only after its replacement spawns. */
+  evictionClaimed?: boolean;
 };
 
 export type TerminalSessionManagerOptions = {

--- a/src/gateway/terminal/session-manager.types.ts
+++ b/src/gateway/terminal/session-manager.types.ts
@@ -29,6 +29,8 @@ export type TerminalSession = {
   /** Kills the session when a detach outlives the grace period. */
   reaper: ReturnType<typeof setTimeout> | null;
   detachedAtMs: number | null;
+  /** Last PTY input/output timestamp; drives idle eviction under pool pressure. */
+  lastActivityAtMs: number;
 };
 
 export type TerminalSessionManagerOptions = {


### PR DESCRIPTION
## What Problem This Solves

Agent-opened terminal sessions (the `terminal` tool, including opens made from inside code-mode `exec` scripts) spawn persistent login shells that outlive their commands and are excluded from every automatic reclamation path: disconnect-detach short-circuits agent owners, so they never get a reaper, never count toward the detached cap, and `gateway.terminal.detachedSessionTimeoutSeconds` is structurally inapplicable. Sessions accumulate monotonically to the global 24-session cap, after which every exec/terminal open on the gateway fails with `terminal session limit reached (24)` (surfaced as `⚠️ 🛠️ Exec failed`, `failurePhase: "bridge"`) until gateway restart. Live-reproduced: four deep multi-exec turns bricked exec gateway-wide.

## Why This Change Was Made

Under pool pressure, `open()` now reclaims the longest-idle viewer-free agent-owned session instead of failing. The design is claim/commit: a candidate is claimed before the async spawn (so concurrent opens pick distinct victims), and the actual victim is reselected fresh in the synchronous post-spawn window — a claimed session that gained a viewer, produced output, or exited during the spawn is spared, and the genuinely idlest eligible session is finalized. A failed or cancelled spawn never destroys a live session (the claim is released on spawn rejection and in the open-abort path, so a hung cancelled spawn cannot leak an unclaimable victim), and the commit-time capacity check counts other opens' outstanding reservations so out-of-order spawn completion cannot register past the hard cap. Viewer-attached and connection-owned sessions are never evicted; the accepted tradeoff — a silent, viewer-free background shell losing its PTY under pool pressure — is documented at the seam. Activity is tracked on PTY input and output, so streaming background jobs stay ranked as active. Each eviction logs `evicted idle agent terminal session under pool pressure` with the idle duration. No new config.

## User Impact

A busy agent can no longer permanently break terminal/exec for the whole gateway. Interactive collaborative terminals ("user sees it in web UI, can type too") are untouched.

## Evidence

- Live before/after on a scratch dev gateway (real OpenAI, `gpt-5.6-luna`): before — turns 3+ died after 2 tool calls with `terminal session limit reached (24)` inside the code-mode bridge; after — three consecutive 12-exec turns all completed, 12 evictions logged (idleMs ≈ 1.2s under burst — an idle-floor design would have failed exactly this case), zero `Exec failed`/limit errors. Re-verified on the final claim/commit code: 3/3 turns green, 12 evictions, 0 failures.
- Unit: `node scripts/run-vitest.mjs src/gateway/terminal/session-manager.test.ts src/gateway/terminal/session-manager.eviction.test.ts` — 46 passed; new eviction suite covers idle selection, viewer/conn protection, viewer-gained-mid-spawn, activity-staleness reselection, out-of-order cap race, cancelled-open claim release, and spawn-failure victim survival.
- `node scripts/check-changed.mjs` green (local fallback; Blacksmith backend unreachable). The oversized `session-manager.test.ts` was brought back under the max-lines cap by extracting shared fakes to `session-manager.test-helpers.ts` (used by both test files).
- Autoreview (Codex `gpt-5.6-sol`): five rounds; four real concurrency findings (non-transactional eviction, viewer race, reservation-blind cap check, stale idle ranking, claim leak on cancel) each fixed with a regression test; final round clean (0.88).
