### PR TITLE
fix(messages): validate configured envelope timezone

### DIFF
--- a/src/auto-reply/envelope.test.ts
+++ b/src/auto-reply/envelope.test.ts
@@ -241,7 +241,7 @@ describe("formatInboundEnvelope", () => {
       },
     });
     expect(options).toEqual({
-      timezone: "user",
+      timezone: "Europe/Vienna",
       includeTimestamp: true,
       includeElapsed: true,
       userTimezone: "Europe/Vienna",

--- a/src/auto-reply/envelope.test.ts
+++ b/src/auto-reply/envelope.test.ts
@@ -65,24 +65,21 @@ describe("formatAgentEnvelope", () => {
   });
 
   it("falls back to the host timezone for an invalid configured user timezone", () => {
-    withEnv({ TZ: "America/Los_Angeles" }, () => {
-      const ts = Date.UTC(2025, 0, 2, 3, 4, 5);
-      const options = resolveEnvelopeFormatOptions({
-        agents: { defaults: { userTimezone: "Not/A_Timezone" } },
-      });
-      expect(formatEnvelopeTimestamp(ts, options)).toBe(
-        formatEnvelopeTimestamp(ts, { timezone: "local" }),
-      );
+    const ts = Date.UTC(2025, 0, 2, 3, 4, 5);
+    const options = resolveEnvelopeFormatOptions({
+      agents: { defaults: { userTimezone: "Not/A_Timezone" } },
     });
+    expect(options.timezone).toBe("local");
+    expect(formatEnvelopeTimestamp(ts, options)).toBe(
+      formatEnvelopeTimestamp(ts, { timezone: "local" }),
+    );
   });
 
   it("keeps the UTC fallback for an invalid explicit timezone option", () => {
-    withEnv({ TZ: "America/Los_Angeles" }, () => {
-      const ts = Date.UTC(2025, 0, 2, 3, 4, 5);
-      expect(formatEnvelopeTimestamp(ts, { timezone: "Not/A_Timezone" })).toBe(
-        formatEnvelopeTimestamp(ts, { timezone: "utc" }),
-      );
-    });
+    const ts = Date.UTC(2025, 0, 2, 3, 4, 5);
+    expect(formatEnvelopeTimestamp(ts, { timezone: "Not/A_Timezone" })).toBe(
+      formatEnvelopeTimestamp(ts, { timezone: "utc" }),
+    );
   });
 
   it("omits timestamps when configured", () => {

--- a/src/auto-reply/envelope.test.ts
+++ b/src/auto-reply/envelope.test.ts
@@ -64,6 +64,27 @@ describe("formatAgentEnvelope", () => {
     expect(body).toMatch(/\[WebChat Thu 2025-01-02 04:04:05 [^\]]+\] hello/);
   });
 
+  it("falls back to the host timezone for an invalid configured user timezone", () => {
+    withEnv({ TZ: "America/Los_Angeles" }, () => {
+      const ts = Date.UTC(2025, 0, 2, 3, 4, 5);
+      const options = resolveEnvelopeFormatOptions({
+        agents: { defaults: { userTimezone: "Not/A_Timezone" } },
+      });
+      expect(formatEnvelopeTimestamp(ts, options)).toBe(
+        formatEnvelopeTimestamp(ts, { timezone: "local" }),
+      );
+    });
+  });
+
+  it("keeps the UTC fallback for an invalid explicit timezone option", () => {
+    withEnv({ TZ: "America/Los_Angeles" }, () => {
+      const ts = Date.UTC(2025, 0, 2, 3, 4, 5);
+      expect(formatEnvelopeTimestamp(ts, { timezone: "Not/A_Timezone" })).toBe(
+        formatEnvelopeTimestamp(ts, { timezone: "utc" }),
+      );
+    });
+  });
+
   it("omits timestamps when configured", () => {
     const ts = Date.UTC(2025, 0, 2, 3, 4);
     const body = formatAgentEnvelope({
@@ -220,7 +241,7 @@ describe("formatInboundEnvelope", () => {
       },
     });
     expect(options).toEqual({
-      timezone: "Europe/Vienna",
+      timezone: "user",
       includeTimestamp: true,
       includeElapsed: true,
       userTimezone: "Europe/Vienna",

--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -72,7 +72,7 @@ function sanitizeEnvelopeHeaderPart(value: string): string {
 export function resolveEnvelopeFormatOptions(cfg?: OpenClawConfig): EnvelopeFormatOptions {
   const defaults = cfg?.agents?.defaults;
   return {
-    timezone: defaults?.userTimezone,
+    timezone: defaults?.userTimezone ? "user" : undefined,
     includeTimestamp: true,
     includeElapsed: true,
     userTimezone: defaults?.userTimezone,

--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -72,7 +72,7 @@ function sanitizeEnvelopeHeaderPart(value: string): string {
 export function resolveEnvelopeFormatOptions(cfg?: OpenClawConfig): EnvelopeFormatOptions {
   const defaults = cfg?.agents?.defaults;
   return {
-    timezone: defaults?.userTimezone ? "user" : undefined,
+    timezone: defaults?.userTimezone ? resolveUserTimezone(defaults.userTimezone) : undefined,
     includeTimestamp: true,
     includeElapsed: true,
     userTimezone: defaults?.userTimezone,

--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -71,8 +71,9 @@ function sanitizeEnvelopeHeaderPart(value: string): string {
 /** Resolves envelope formatting defaults from agent config. */
 export function resolveEnvelopeFormatOptions(cfg?: OpenClawConfig): EnvelopeFormatOptions {
   const defaults = cfg?.agents?.defaults;
+  const configuredTimezone = normalizeOptionalString(defaults?.userTimezone);
   return {
-    timezone: defaults?.userTimezone ? resolveUserTimezone(defaults.userTimezone) : undefined,
+    timezone: configuredTimezone ? (resolveTimezone(configuredTimezone) ?? "local") : undefined,
     includeTimestamp: true,
     includeElapsed: true,
     userTimezone: defaults?.userTimezone,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an invalid `agents.defaults.userTimezone` could put message envelopes on UTC while prompt temporal context and queued system events fell back to the gateway host timezone. The model could therefore receive two reference clocks from one configuration error.

## Why This Change Was Made

`resolveEnvelopeFormatOptions()` mapped the canonical `agents.defaults.userTimezone` value directly into the envelope `timezone` field. Invalid configured values therefore reached the generic explicit-IANA fallback and became UTC.

Validate configured user timezones at the config owner. Valid values keep their literal, including the special compact `UTC` mode; invalid values become the envelope's `"local"` mode and therefore follow the gateway host timezone without changing formatting semantics.

The generic explicit-timezone fallback remains UTC, preserving the existing contract for programmatic `EnvelopeFormatOptions.timezone` callers.

## User Impact

A malformed timezone value now degrades consistently to host-local time across model-visible surfaces instead of silently mixing UTC and host-local timestamps.

## Evidence

- The regression runs through the canonical `agents.defaults.userTimezone` -> `resolveEnvelopeFormatOptions()` -> `formatEnvelopeTimestamp()` path under `TZ=America/Los_Angeles`.
- A second regression confirms invalid explicit programmatic timezone options still fall back to UTC.
- The existing inbound-channel regression confirms configured `UTC` still renders as compact ISO UTC.
- The focused envelope and inbound-channel suites pass 23/23 under both `TZ=UTC` and `TZ=America/Los_Angeles`.
- Focused formatting and `git diff --check` pass.
- Fresh autoreview: no accepted/actionable findings; patch correctness 0.95.
