### PR TITLE
fix(feishu): preserve card actions through mention gating

### DIFF
--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -327,7 +327,35 @@ describe("Feishu Card Action Handler", () => {
 
     await handleFeishuCardAction({ cfg, event, runtime });
 
-    expect(handleMessage().content).toBe('{"text":"/new"}');
+    const message = handleMessage();
+    expect(message.content).toBe('{"text":"/new"}');
+    expect(message.mentions).toBeUndefined();
+  });
+
+  it("marks synthetic group card callbacks as mentioning the bot", async () => {
+    const event = createStructuredQuickActionEvent({
+      token: "tok5-mention",
+      action: FEISHU_APPROVAL_CONFIRM_ACTION,
+      command: "/new",
+      chatType: "group",
+    });
+
+    await handleFeishuCardAction({
+      cfg,
+      event,
+      runtime,
+      botOpenId: "ou_bot",
+    });
+
+    const message = handleMessage();
+    expect(message.chat_type).toBe("group");
+    expect(message.mentions).toEqual([
+      {
+        key: "mention_bot",
+        id: { open_id: "ou_bot" },
+        name: "bot",
+      },
+    ]);
   });
 
   it("safely rejects stale structured actions", async () => {
@@ -395,11 +423,12 @@ describe("Feishu Card Action Handler", () => {
       chatType: "p2p",
     });
 
-    await handleFeishuCardAction({ cfg, event, runtime });
+    await handleFeishuCardAction({ cfg, event, runtime, botOpenId: "ou_bot" });
 
     const message = handleMessage();
     expect(message.chat_id).toBe("p2p-chat-1");
     expect(message.chat_type).toBe("p2p");
+    expect(message.mentions).toBeUndefined();
   });
 
   it("resolves DM chat type from the Feishu chat API when card context omits it", async () => {

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -107,6 +107,7 @@ function buildSyntheticMessageEvent(
   event: FeishuCardActionEvent,
   content: string,
   chatType: "p2p" | "group",
+  botOpenId?: string,
 ): FeishuMessageEvent {
   const replyTargetMessageId = event.context.open_message_id ?? event.open_message_id;
   // card-action-c-* IDs are temporary callback tokens, not valid Feishu message IDs.
@@ -114,6 +115,7 @@ function buildSyntheticMessageEvent(
   const isTemporaryCardActionId = replyTargetMessageId?.startsWith("card-action-c-");
   const validReplyTargetId =
     replyTargetMessageId && !isTemporaryCardActionId ? replyTargetMessageId : undefined;
+  const normalizedBotOpenId = chatType === "group" ? botOpenId?.trim() : undefined;
   return {
     sender: {
       sender_id: {
@@ -131,6 +133,17 @@ function buildSyntheticMessageEvent(
       chat_type: chatType,
       message_type: "text",
       content: JSON.stringify({ text: content }),
+      ...(normalizedBotOpenId
+        ? {
+            mentions: [
+              {
+                key: "mention_bot",
+                id: { open_id: normalizedBotOpenId },
+                name: "bot",
+              },
+            ],
+          }
+        : {}),
     },
   };
 }
@@ -162,7 +175,12 @@ async function dispatchSyntheticCommand(params: {
   });
   await handleFeishuMessage({
     cfg: params.cfg,
-    event: buildSyntheticMessageEvent(params.event, params.command, resolvedChatType),
+    event: buildSyntheticMessageEvent(
+      params.event,
+      params.command,
+      resolvedChatType,
+      params.botOpenId,
+    ),
     botOpenId: params.botOpenId,
     runtime: params.runtime,
     channelRuntime: params.channelRuntime,

--- a/extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts
+++ b/extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts
@@ -42,6 +42,10 @@ const lifecycleConfig = createFeishuLifecycleConfig({
   channelConfig: {
     dmPolicy: "open",
     allowFrom: ["ou_user1"],
+    groupPolicy: "open",
+    groups: {
+      oc_group_require_mention: { requireMention: true },
+    },
   },
   accountConfig: {
     dmPolicy: "open",
@@ -253,6 +257,25 @@ describe("Feishu card-action lifecycle", () => {
     expect(dispatcherParams.chatId).toBe(chatId);
     expect(dispatcherParams.replyToMessageId).toBe("om_card_v2");
     expect(latestFinalizedContext().MessageSid).toBe("card-action-tok-card-v2-context");
+  });
+
+  it("routes authenticated group callbacks when the group requires a mention", async () => {
+    const onCardAction = await setupLifecycleMonitor();
+
+    await onCardAction(
+      createCardActionEvent({
+        token: "tok-card-require-mention",
+        action: "feishu.quick_actions.help",
+        command: "/help",
+        chatId: "oc_group_require_mention",
+        chatType: "group",
+      }),
+    );
+
+    expect(lastRuntime?.error).not.toHaveBeenCalled();
+    expect(dispatchReplyFromConfigMock).toHaveBeenCalledTimes(1);
+    expect(latestReplyDispatcherParams().chatId).toBe("oc_group_require_mention");
+    expect(latestFinalizedContext().MessageSid).toBe("card-action-tok-card-require-mention");
   });
 
   it("prefers the original context message id over a temporary callback id", async () => {

--- a/extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts
+++ b/extensions/feishu/src/monitor.card-action.lifecycle.test-support.ts
@@ -359,9 +359,16 @@ describe("Feishu card-action lifecycle", () => {
       token: "tok-card-sdk-flat",
       action: {
         tag: "button",
-        value: {
-          command: "/help",
-        },
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: "feishu.quick_actions.help",
+          q: "/help",
+          c: {
+            u: "ou_user1",
+            t: "p2p",
+            e: Date.now() + 60_000,
+          },
+        }),
       },
     });
 
@@ -382,9 +389,16 @@ describe("Feishu card-action lifecycle", () => {
       token: "tok-card-no-reply-target",
       action: {
         tag: "button",
-        value: {
-          command: "/help",
-        },
+        value: createFeishuCardInteractionEnvelope({
+          k: "quick",
+          a: "feishu.quick_actions.help",
+          q: "/help",
+          c: {
+            u: "ou_user1",
+            t: "p2p",
+            e: Date.now() + 60_000,
+          },
+        }),
       },
     });
 


### PR DESCRIPTION
## What Problem This Solves

Feishu and Lark group users can click an authenticated structured-card button and have the callback silently dropped when the group uses `requireMention: true`. The callback enters the normal group admission path without bot-mention metadata, so the agent never receives the action. Fixes #85450.

## Why This Change Was Made

The card-action handler now adds the already-resolved bot `open_id` as Feishu mention metadata only when it builds a synthetic group callback. This makes the callback satisfy the existing mention contract instead of adding a broad bypass based on a synthetic message-ID prefix. Direct-message callbacks remain unchanged, and a missing bot identity does not fabricate a mention.

Thanks to @googlerest in #85481 and @zhouhe-xydt in #85609 for the earlier investigations. Both proposals were closed unmerged; this replacement validates the current monitor lifecycle and preserves the current admission policy.

## User Impact

Card buttons such as approval confirmations and quick actions work in groups that require bot mentions. Ordinary unmentioned group messages are still rejected, and direct-message card callbacks do not gain synthetic mention metadata.

## Evidence

Base `cff7cbfdcb8089e5005e3549153e131347aeb198`; head `403df4cd76f82a6b5f4f636b47e6e19ead8c380f`.

Before the production change, the new current-main lifecycle regression failed with zero agent dispatches for an authenticated group callback under `requireMention: true`.

After the change, 152 focused Feishu tests passed across the card-action handler, real monitor lifecycle, bot admission, and policy suites. The lifecycle regression proves the callback reaches the agent; the adjacent policy tests prove ordinary mention gating remains intact.

The first hosted precise OpenGrep run found two legacy raw-command fixtures in the now-touched lifecycle test. Head `403df4cd76f82a6b5f4f636b47e6e19ead8c380f` converts them to the structured interaction envelope while preserving their no-outer-context and no-reply-target cases. The same 152 focused tests pass after that repair, and both the fresh precise OpenGrep scan and Opengrep OSS check pass.

The Feishu extension TypeScript check passed after refreshing the repository's generated Plugin SDK declarations.

Oxfmt, type-aware oxlint, max-lines ratchet, conflict-marker scan, and diff checks passed for the three-file change.

A live Feishu tenant was not available locally, so maintainer provider validation remains authoritative.