### PR TITLE
feat(android): overlay-notify popup — voice readout, small card, locked/unlocked reliability

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -312,6 +312,8 @@ dependencies {
   // AppCompat owns per-app locale persistence and Activity recreation on API 31-32.
   implementation(libs.androidx.appcompat)
   implementation(libs.androidx.lifecycle.runtime.ktx)
+  // ViewTree*Owner wiring for PopupOverlayWindow, which hosts Compose outside an Activity.
+  implementation(libs.androidx.lifecycle.viewmodel.ktx)
   implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.webkit)
 

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <!-- Lets the overlay-notify popup float over other apps while the screen is unlocked;
+         full-screen-intent alone only auto-launches while the device is locked. -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission
         android:name="android.permission.NEARBY_WIFI_DEVICES"
         android:usesPermissionFlags="neverForLocation" />

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission
         android:name="android.permission.NEARBY_WIFI_DEVICES"
         android:usesPermissionFlags="neverForLocation" />
@@ -149,5 +150,14 @@
                 <data android:mimeType="text/markdown" />
             </intent-filter>
         </activity>
+        <!-- Takeover surface for system.notify delivery=overlay; shows over the lock screen
+             without unlocking, like an incoming-call screen, so it can't be swiped away. -->
+        <activity
+            android:name=".ui.popup.PopupOverlayActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true"
+            android:theme="@style/Theme.OpenClawPopup" />
     </application>
 </manifest>

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -592,6 +592,9 @@ class MainViewModel private constructor(
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
   val installedAppsSharingEnabled: StateFlow<Boolean> = prefs.installedAppsSharingEnabled
   val accessibilityControlEnabled: StateFlow<Boolean> = prefs.accessibilityControlEnabled
+  val popupBackgroundImageUris: StateFlow<List<String>> = prefs.popupBackgroundImageUris
+  val popupOpacity: StateFlow<Float> = prefs.popupOpacity
+  val popupAutoDismissSeconds: StateFlow<Int> = prefs.popupAutoDismissSeconds
   val speakerEnabled: StateFlow<Boolean> = prefs.speakerEnabled
   val preferredCameraFacing: StateFlow<String> = prefs.preferredCameraFacing
   val preferredAudioInputDevice: StateFlow<String?> = prefs.preferredAudioInputDevice
@@ -913,6 +916,18 @@ class MainViewModel private constructor(
 
   fun setAccessibilityControlEnabled(value: Boolean) {
     prefs.setAccessibilityControlEnabled(value)
+  }
+
+  fun setPopupBackgroundImageUris(uris: List<String>) {
+    prefs.setPopupBackgroundImageUris(uris)
+  }
+
+  fun setPopupOpacity(value: Float) {
+    prefs.setPopupOpacity(value)
+  }
+
+  fun setPopupAutoDismissSeconds(value: Int) {
+    prefs.setPopupAutoDismissSeconds(value)
   }
 
   fun setNotificationForwardingEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -592,9 +592,10 @@ class MainViewModel private constructor(
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
   val installedAppsSharingEnabled: StateFlow<Boolean> = prefs.installedAppsSharingEnabled
   val accessibilityControlEnabled: StateFlow<Boolean> = prefs.accessibilityControlEnabled
-  val popupBackgroundImageUris: StateFlow<List<String>> = prefs.popupBackgroundImageUris
   val popupOpacity: StateFlow<Float> = prefs.popupOpacity
   val popupAutoDismissSeconds: StateFlow<Int> = prefs.popupAutoDismissSeconds
+  val popupCardColor: StateFlow<Int> = prefs.popupCardColor
+  val popupCardCornerRadiusDp: StateFlow<Int> = prefs.popupCardCornerRadiusDp
   val speakerEnabled: StateFlow<Boolean> = prefs.speakerEnabled
   val preferredCameraFacing: StateFlow<String> = prefs.preferredCameraFacing
   val preferredAudioInputDevice: StateFlow<String?> = prefs.preferredAudioInputDevice
@@ -918,16 +919,20 @@ class MainViewModel private constructor(
     prefs.setAccessibilityControlEnabled(value)
   }
 
-  fun setPopupBackgroundImageUris(uris: List<String>) {
-    prefs.setPopupBackgroundImageUris(uris)
-  }
-
   fun setPopupOpacity(value: Float) {
     prefs.setPopupOpacity(value)
   }
 
   fun setPopupAutoDismissSeconds(value: Int) {
     prefs.setPopupAutoDismissSeconds(value)
+  }
+
+  fun setPopupCardColor(value: Int) {
+    prefs.setPopupCardColor(value)
+  }
+
+  fun setPopupCardCornerRadiusDp(value: Int) {
+    prefs.setPopupCardCornerRadiusDp(value)
   }
 
   fun setNotificationForwardingEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeApp.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeApp.kt
@@ -1,7 +1,9 @@
 package ai.openclaw.app
 
+import ai.openclaw.app.chat.SystemSpeechSpeaker
 import ai.openclaw.app.i18n.NativeStringResources
 import ai.openclaw.app.i18n.notifyNativeLocaleChanged
+import ai.openclaw.app.ui.popup.PopupOverlayWindow
 import ai.openclaw.app.wear.GoogleWearMessageSender
 import ai.openclaw.app.wear.GoogleWearPeerResolver
 import ai.openclaw.app.wear.WearProxyBridge
@@ -42,6 +44,17 @@ class NodeApp : Application() {
 
   internal val wearRealtimeChannels: WearRealtimeChannelRegistry by lazy {
     WearRealtimeChannelRegistry(this, runtimeScope)
+  }
+
+  // One shared engine so a second overlay-notify popup correctly interrupts a still-speaking
+  // prior one (TextToSpeech.QUEUE_FLUSH) instead of two engines talking over each other.
+  internal val popupSpeechSpeaker: SystemSpeechSpeaker by lazy { SystemSpeechSpeaker(this) }
+
+  internal val popupOverlayWindow: PopupOverlayWindow by lazy { PopupOverlayWindow(this) }
+
+  /** Speaks an overlay-notify message outside the popup UI (see SystemHandler's fallback delivery mode). */
+  internal fun speakPopupMessage(text: String) {
+    runtimeScope.launch { popupSpeechSpeaker.speak(text) }
   }
 
   /**

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -58,11 +58,27 @@ class SecurePrefs(
     private const val notificationsForwardingMaxEventsPerMinuteKey =
       "notifications.forwarding.maxEventsPerMinute"
     private const val notificationsForwardingSessionKeyPrefix = "notifications.forwarding.sessionKey"
-    private const val popupBackgroundImageUrisKey = "popup.backgroundImageUris"
     private const val popupOpacityKey = "popup.opacity"
-    private const val defaultPopupOpacity = 0.55f
+    // Small solid card (not a full-screen scrim over a photo), so it needs to stay legible
+    // against whatever's behind it by default.
+    private const val defaultPopupOpacity = 0.92f
     private const val popupAutoDismissSecondsKey = "popup.autoDismissSeconds"
     private const val defaultPopupAutoDismissSeconds = 12
+    private const val popupCardColorKey = "popup.cardColor"
+    private const val defaultPopupCardColor = 0xFF1C1C1E.toInt()
+    private const val popupCardCornerRadiusDpKey = "popup.cardCornerRadiusDp"
+    private const val defaultPopupCardCornerRadiusDp = 24
+
+    /** Preset swatches offered in Settings; a full color picker is more than this needs. */
+    val POPUP_CARD_COLOR_PRESETS =
+      listOf(
+        0xFF1C1C1E.toInt(), // near-black
+        0xFF334155.toInt(), // slate
+        0xFF3730A3.toInt(), // indigo
+        0xFF7F1D1D.toInt(), // crimson
+        0xFF14532D.toInt(), // forest
+        0xFF0F172A.toInt(), // charcoal blue
+      )
     private const val installedAppsSharingEnabledKey = "device.apps.sharing.enabled"
     private const val installedAppsDisclosureConsentVersionKey =
       "device.apps.prominentDisclosure.consentVersion"
@@ -247,9 +263,6 @@ class SecurePrefs(
 
   // Full-screen popup ("delivery: overlay") appearance: user-picked background images cycle
   // randomly per popup; opacity/duration tune legibility and how long it stays on screen.
-  private val _popupBackgroundImageUris = MutableStateFlow(loadChatModelRefs(popupBackgroundImageUrisKey))
-  val popupBackgroundImageUris: StateFlow<List<String>> = _popupBackgroundImageUris
-
   private val _popupOpacity = MutableStateFlow(plainPrefs.getFloat(popupOpacityKey, defaultPopupOpacity))
   val popupOpacity: StateFlow<Float> = _popupOpacity
 
@@ -258,6 +271,15 @@ class SecurePrefs(
       plainPrefs.getInt(popupAutoDismissSecondsKey, defaultPopupAutoDismissSeconds).coerceIn(3, 30),
     )
   val popupAutoDismissSeconds: StateFlow<Int> = _popupAutoDismissSeconds
+
+  private val _popupCardColor = MutableStateFlow(plainPrefs.getInt(popupCardColorKey, defaultPopupCardColor))
+  val popupCardColor: StateFlow<Int> = _popupCardColor
+
+  private val _popupCardCornerRadiusDp =
+    MutableStateFlow(
+      plainPrefs.getInt(popupCardCornerRadiusDpKey, defaultPopupCardCornerRadiusDp).coerceIn(0, 32),
+    )
+  val popupCardCornerRadiusDp: StateFlow<Int> = _popupCardCornerRadiusDp
 
   fun setLastDiscoveredStableId(value: String) {
     val trimmed = value.trim()
@@ -748,12 +770,6 @@ class SecurePrefs(
     _sessionCustomGroups.value = sanitized
   }
 
-  fun setPopupBackgroundImageUris(uris: List<String>) {
-    val sanitized = uris.map(String::trim).filter { it.isNotEmpty() }.distinct()
-    persistChatModelRefs(popupBackgroundImageUrisKey, sanitized)
-    _popupBackgroundImageUris.value = sanitized
-  }
-
   fun setPopupOpacity(value: Float) {
     val clamped = value.coerceIn(0f, 1f)
     plainPrefs.edit { putFloat(popupOpacityKey, clamped) }
@@ -764,6 +780,19 @@ class SecurePrefs(
     val clamped = value.coerceIn(3, 30)
     plainPrefs.edit { putInt(popupAutoDismissSecondsKey, clamped) }
     _popupAutoDismissSeconds.value = clamped
+  }
+
+  fun setPopupCardColor(value: Int) {
+    // Force opaque; visual transparency is controlled separately by popupOpacity.
+    val opaque = (0xFF000000.toInt()) or (value and 0x00FFFFFF)
+    plainPrefs.edit { putInt(popupCardColorKey, opaque) }
+    _popupCardColor.value = opaque
+  }
+
+  fun setPopupCardCornerRadiusDp(value: Int) {
+    val clamped = value.coerceIn(0, 32)
+    plainPrefs.edit { putInt(popupCardCornerRadiusDpKey, clamped) }
+    _popupCardCornerRadiusDp.value = clamped
   }
 
   private fun persistChatModelRefs(

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -58,6 +58,11 @@ class SecurePrefs(
     private const val notificationsForwardingMaxEventsPerMinuteKey =
       "notifications.forwarding.maxEventsPerMinute"
     private const val notificationsForwardingSessionKeyPrefix = "notifications.forwarding.sessionKey"
+    private const val popupBackgroundImageUrisKey = "popup.backgroundImageUris"
+    private const val popupOpacityKey = "popup.opacity"
+    private const val defaultPopupOpacity = 0.55f
+    private const val popupAutoDismissSecondsKey = "popup.autoDismissSeconds"
+    private const val defaultPopupAutoDismissSeconds = 12
     private const val installedAppsSharingEnabledKey = "device.apps.sharing.enabled"
     private const val installedAppsDisclosureConsentVersionKey =
       "device.apps.prominentDisclosure.consentVersion"
@@ -239,6 +244,20 @@ class SecurePrefs(
   // persist server-side via the session category field (mirrors web localStorage).
   private val _sessionCustomGroups = MutableStateFlow(loadChatModelRefs(sessionCustomGroupsKey))
   val sessionCustomGroups: StateFlow<List<String>> = _sessionCustomGroups
+
+  // Full-screen popup ("delivery: overlay") appearance: user-picked background images cycle
+  // randomly per popup; opacity/duration tune legibility and how long it stays on screen.
+  private val _popupBackgroundImageUris = MutableStateFlow(loadChatModelRefs(popupBackgroundImageUrisKey))
+  val popupBackgroundImageUris: StateFlow<List<String>> = _popupBackgroundImageUris
+
+  private val _popupOpacity = MutableStateFlow(plainPrefs.getFloat(popupOpacityKey, defaultPopupOpacity))
+  val popupOpacity: StateFlow<Float> = _popupOpacity
+
+  private val _popupAutoDismissSeconds =
+    MutableStateFlow(
+      plainPrefs.getInt(popupAutoDismissSecondsKey, defaultPopupAutoDismissSeconds).coerceIn(3, 30),
+    )
+  val popupAutoDismissSeconds: StateFlow<Int> = _popupAutoDismissSeconds
 
   fun setLastDiscoveredStableId(value: String) {
     val trimmed = value.trim()
@@ -727,6 +746,24 @@ class SecurePrefs(
     val sanitized = groups.map(String::trim).filter { it.isNotEmpty() }.distinct()
     persistChatModelRefs(sessionCustomGroupsKey, sanitized)
     _sessionCustomGroups.value = sanitized
+  }
+
+  fun setPopupBackgroundImageUris(uris: List<String>) {
+    val sanitized = uris.map(String::trim).filter { it.isNotEmpty() }.distinct()
+    persistChatModelRefs(popupBackgroundImageUrisKey, sanitized)
+    _popupBackgroundImageUris.value = sanitized
+  }
+
+  fun setPopupOpacity(value: Float) {
+    val clamped = value.coerceIn(0f, 1f)
+    plainPrefs.edit { putFloat(popupOpacityKey, clamped) }
+    _popupOpacity.value = clamped
+  }
+
+  fun setPopupAutoDismissSeconds(value: Int) {
+    val clamped = value.coerceIn(3, 30)
+    plainPrefs.edit { putInt(popupAutoDismissSecondsKey, clamped) }
+    _popupAutoDismissSeconds.value = clamped
   }
 
   private fun persistChatModelRefs(

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/SystemHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/SystemHandler.kt
@@ -1,10 +1,13 @@
 package ai.openclaw.app.node
 
+import ai.openclaw.app.NodeApp
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.mainActivityPendingIntent
 import ai.openclaw.app.ui.popup.PopupOverlayActivity
+import ai.openclaw.app.ui.popup.popupSpokenText
 import android.Manifest
+import android.app.KeyguardManager
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -12,6 +15,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
+import android.provider.Settings
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -59,11 +63,15 @@ private class AndroidSystemNotificationPoster(
 
   /** Posts through a priority-specific channel so Android's immutable channel importance is respected. */
   override fun post(request: SystemNotifyRequest) {
+    val isOverlay = request.delivery == "overlay"
+    val deliveryMode = if (isOverlay) resolvePopupDeliveryMode(appContext) else null
     // A full-screen intent only actually fires from a HIGH-importance channel, regardless of
     // the caller's requested priority, so an overlay delivery always gets the loudest channel.
-    val channelPriority = if (request.delivery == "overlay") "timesensitive" else request.priority
+    val channelPriority = if (isOverlay) "timesensitive" else request.priority
     val channelId = ensureChannel(channelPriority)
-    val notification = buildSystemNotification(appContext, channelId, request)
+    val wantsFullScreenIntent =
+      deliveryMode == PopupDeliveryMode.FullScreenLocked && fullScreenIntentPermitted(appContext)
+    val notification = buildSystemNotification(appContext, channelId, request, wantsFullScreenIntent)
     if (
       Build.VERSION.SDK_INT >= 33 &&
       ContextCompat.checkSelfPermission(appContext, Manifest.permission.POST_NOTIFICATIONS) !=
@@ -72,6 +80,22 @@ private class AndroidSystemNotificationPoster(
       throw SecurityException("notifications permission missing")
     }
     NotificationManagerCompat.from(appContext).notify((System.currentTimeMillis() and 0x7FFFFFFF).toInt(), notification)
+
+    when (deliveryMode) {
+      PopupDeliveryMode.OverlayWindow ->
+        (appContext as NodeApp).popupOverlayWindow.show(
+          title = request.title,
+          subtitle = request.subtitle,
+          body = request.body,
+          timestampMillis = request.timestampMillis ?: System.currentTimeMillis(),
+        )
+      PopupDeliveryMode.HeadsUpFallback ->
+        // No visual card renders in this mode (the notification alone can't force full-screen
+        // while unlocked+backgrounded), so speak explicitly here — TTS has no visual-permission
+        // dependency and is the core purpose of overlay delivery, not a nice-to-have.
+        (appContext as NodeApp).speakPopupMessage(popupSpokenText(request.subtitle, request.body))
+      PopupDeliveryMode.FullScreenLocked, null -> Unit
+    }
   }
 
   private fun ensureChannel(priority: String?): String {
@@ -107,6 +131,23 @@ private class AndroidSystemNotificationPoster(
   }
 }
 
+/** Which surface an overlay-delivery notify shows through; see AndroidSystemNotificationPoster.post. */
+internal enum class PopupDeliveryMode { FullScreenLocked, OverlayWindow, HeadsUpFallback }
+
+/**
+ * Full-screen-intent notifications only auto-launch their Activity while the device is locked;
+ * unlocked+backgrounded just shows a heads-up banner (an intentional Android anti-abuse policy).
+ * So overlay delivery needs a second mechanism (PopupOverlayWindow) for the unlocked case.
+ */
+internal fun resolvePopupDeliveryMode(appContext: Context): PopupDeliveryMode {
+  val locked = appContext.getSystemService(KeyguardManager::class.java)?.isKeyguardLocked == true
+  return when {
+    locked -> PopupDeliveryMode.FullScreenLocked
+    Settings.canDrawOverlays(appContext) -> PopupDeliveryMode.OverlayWindow
+    else -> PopupDeliveryMode.HeadsUpFallback
+  }
+}
+
 private fun compatPriority(priority: String?): Int =
   when (priority.orEmpty().trim().lowercase()) {
     "passive" -> NotificationCompat.PRIORITY_LOW
@@ -123,6 +164,7 @@ internal fun buildSystemNotification(
   appContext: Context,
   channelId: String,
   request: SystemNotifyRequest,
+  wantsFullScreenIntent: Boolean = false,
 ): Notification {
   val builder =
     NotificationCompat
@@ -142,7 +184,7 @@ internal fun buildSystemNotification(
     builder.setShowWhen(true)
   }
 
-  if (request.delivery == "overlay" && fullScreenIntentPermitted(appContext)) {
+  if (wantsFullScreenIntent) {
     builder.setFullScreenIntent(popupOverlayPendingIntent(appContext, request), true)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/SystemHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/SystemHandler.kt
@@ -3,16 +3,19 @@ package ai.openclaw.app.node
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.mainActivityPendingIntent
+import ai.openclaw.app.ui.popup.PopupOverlayActivity
 import android.Manifest
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import java.time.Instant
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -20,6 +23,7 @@ import kotlinx.serialization.json.contentOrNull
 
 private const val NOTIFICATION_CHANNEL_BASE_ID = "openclaw.system.notify"
 private const val NOTIFICATION_CONTENT_REQUEST_CODE = 3
+private const val NOTIFICATION_FULL_SCREEN_REQUEST_CODE = 4
 
 /** Parsed payload for system.notify invocations. */
 internal data class SystemNotifyRequest(
@@ -27,6 +31,9 @@ internal data class SystemNotifyRequest(
   val body: String,
   val sound: String?,
   val priority: String?,
+  val delivery: String? = null,
+  val subtitle: String? = null,
+  val timestampMillis: Long? = null,
 )
 
 /** Notification posting seam used by production Android and unit tests. */
@@ -52,7 +59,10 @@ private class AndroidSystemNotificationPoster(
 
   /** Posts through a priority-specific channel so Android's immutable channel importance is respected. */
   override fun post(request: SystemNotifyRequest) {
-    val channelId = ensureChannel(request.priority)
+    // A full-screen intent only actually fires from a HIGH-importance channel, regardless of
+    // the caller's requested priority, so an overlay delivery always gets the loudest channel.
+    val channelPriority = if (request.delivery == "overlay") "timesensitive" else request.priority
+    val channelId = ensureChannel(channelPriority)
     val notification = buildSystemNotification(appContext, channelId, request)
     if (
       Build.VERSION.SDK_INT >= 33 &&
@@ -83,9 +93,15 @@ private class AndroidSystemNotificationPoster(
       }
     val channelId = "$NOTIFICATION_CHANNEL_BASE_ID.$suffix"
     val manager = appContext.getSystemService(NotificationManager::class.java)
+    // Only the full-screen-intent channel needs to cut through Do Not Disturb; this only takes
+    // effect once the user separately grants notification policy access (see SettingsScreens).
+    val bypassDnd = normalizedPriority == "timesensitive"
     val existing = manager.getNotificationChannel(channelId)
-    if (existing == null) {
-      manager.createNotificationChannel(NotificationChannel(channelId, name, importance))
+    val channel = existing ?: NotificationChannel(channelId, name, importance)
+    if (existing == null || channel.canBypassDnd() != bypassDnd) {
+      channel.setBypassDnd(bypassDnd)
+      // Re-creating with the same id+importance updates mutable fields on an existing channel.
+      manager.createNotificationChannel(channel)
     }
     return channelId
   }
@@ -107,18 +123,55 @@ internal fun buildSystemNotification(
   appContext: Context,
   channelId: String,
   request: SystemNotifyRequest,
-): Notification =
-  NotificationCompat
-    .Builder(appContext, channelId)
-    .setSmallIcon(android.R.drawable.ic_dialog_info)
-    .setContentTitle(request.title)
-    .setContentText(request.body)
-    .setContentIntent(mainActivityPendingIntent(appContext, NOTIFICATION_CONTENT_REQUEST_CODE))
-    .setPriority(compatPriority(request.priority))
-    .setAutoCancel(true)
-    .setOnlyAlertOnce(true)
-    .setSilent(isSilentSound(request.sound))
-    .build()
+): Notification {
+  val builder =
+    NotificationCompat
+      .Builder(appContext, channelId)
+      .setSmallIcon(android.R.drawable.ic_dialog_info)
+      .setContentTitle(request.title)
+      .setContentText(request.body)
+      .setContentIntent(mainActivityPendingIntent(appContext, NOTIFICATION_CONTENT_REQUEST_CODE))
+      .setPriority(compatPriority(request.priority))
+      .setAutoCancel(true)
+      .setOnlyAlertOnce(true)
+      .setSilent(isSilentSound(request.sound))
+
+  request.subtitle?.let { builder.setSubText(it) }
+  request.timestampMillis?.let {
+    builder.setWhen(it)
+    builder.setShowWhen(true)
+  }
+
+  if (request.delivery == "overlay" && fullScreenIntentPermitted(appContext)) {
+    builder.setFullScreenIntent(popupOverlayPendingIntent(appContext, request), true)
+  }
+
+  return builder.build()
+}
+
+/** Android 14+ requires an explicit OS grant; earlier versions allow full-screen intents by default. */
+private fun fullScreenIntentPermitted(appContext: Context): Boolean {
+  if (Build.VERSION.SDK_INT < 34) return true
+  val manager = appContext.getSystemService(NotificationManager::class.java)
+  return manager?.canUseFullScreenIntent() ?: false
+}
+
+private fun popupOverlayPendingIntent(
+  appContext: Context,
+  request: SystemNotifyRequest,
+): PendingIntent =
+  PendingIntent.getActivity(
+    appContext,
+    NOTIFICATION_FULL_SCREEN_REQUEST_CODE,
+    PopupOverlayActivity.launchIntent(
+      context = appContext,
+      title = request.title,
+      subtitle = request.subtitle,
+      body = request.body,
+      timestampMillis = request.timestampMillis,
+    ),
+    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+  )
 
 /** Handles system-level node.invoke commands implemented by Android services. */
 class SystemHandler private constructor(
@@ -176,13 +229,26 @@ class SystemHandler private constructor(
         ?: return null
     val sound = (params["sound"] as? JsonPrimitive)?.contentOrNull
     val priority = (params["priority"] as? JsonPrimitive)?.contentOrNull
+    val delivery = (params["delivery"] as? JsonPrimitive)?.contentOrNull
+    val subtitle = (params["subtitle"] as? JsonPrimitive)?.contentOrNull
+    val timestamp = (params["timestamp"] as? JsonPrimitive)?.contentOrNull
     return SystemNotifyRequest(
       title = rawTitle.trim(),
       body = rawBody.trim(),
       sound = sound?.trim()?.ifEmpty { null },
       priority = priority?.trim()?.ifEmpty { null },
+      delivery = delivery?.trim()?.ifEmpty { null },
+      subtitle = subtitle?.trim()?.ifEmpty { null },
+      timestampMillis = timestamp?.trim()?.ifEmpty { null }?.let(::parseIsoTimestampMillis),
     )
   }
+
+  private fun parseIsoTimestampMillis(raw: String): Long? =
+    try {
+      Instant.parse(raw).toEpochMilli()
+    } catch (_: Throwable) {
+      null
+    }
 
   private fun parseParamsObject(paramsJson: String?): JsonObject? {
     if (paramsJson.isNullOrBlank()) return null

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -22,6 +22,7 @@ import ai.openclaw.app.GatewayUsageProviderSummary
 import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NotificationPackageFilterMode
+import ai.openclaw.app.SecurePrefs
 import ai.openclaw.app.SensitiveFeatureConfig
 import ai.openclaw.app.VoiceCaptureMode
 import ai.openclaw.app.appLanguageRowSubtitle
@@ -87,10 +88,10 @@ import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -157,6 +158,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -1174,13 +1177,15 @@ private fun NotificationSettingsScreen(
 @Composable
 private fun PopupNotificationSettingsPanel(viewModel: MainViewModel) {
   val context = LocalContext.current
-  val backgroundImageUris by viewModel.popupBackgroundImageUris.collectAsState()
   val opacity by viewModel.popupOpacity.collectAsState()
   val autoDismissSeconds by viewModel.popupAutoDismissSeconds.collectAsState()
+  val cardColor by viewModel.popupCardColor.collectAsState()
+  val cornerRadiusDp by viewModel.popupCardCornerRadiusDp.collectAsState()
   var fullScreenIntentGranted by remember { mutableStateOf(fullScreenIntentPermissionGranted(context)) }
   var notificationPolicyAccessGranted by remember {
     mutableStateOf(notificationPolicyAccessPermissionGranted(context))
   }
+  var overlayPermissionGranted by remember { mutableStateOf(overlayPermissionGranted(context)) }
   val lifecycleOwner = LocalLifecycleOwner.current
 
   DisposableEffect(lifecycleOwner, context) {
@@ -1189,48 +1194,46 @@ private fun PopupNotificationSettingsPanel(viewModel: MainViewModel) {
         if (event == Lifecycle.Event.ON_RESUME) {
           fullScreenIntentGranted = fullScreenIntentPermissionGranted(context)
           notificationPolicyAccessGranted = notificationPolicyAccessPermissionGranted(context)
+          overlayPermissionGranted = overlayPermissionGranted(context)
         }
       }
     lifecycleOwner.lifecycle.addObserver(observer)
     onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
   }
 
-  val imagePickerLauncher =
-    rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(9)) { uris ->
-      if (uris.isNotEmpty()) {
-        viewModel.setPopupBackgroundImageUris(uris.map { it.toString() })
-      }
-    }
-
   ClawPanel {
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-      Text(text = nativeString("Full-Screen Popup"), style = ClawTheme.type.section, color = ClawTheme.colors.text)
+      Text(text = nativeString("Message Popup"), style = ClawTheme.type.section, color = ClawTheme.colors.text)
       Text(
-        text = nativeString("Used when the agent sends a notify with delivery=overlay — e.g. a summarized message you shouldn't miss while driving."),
+        text =
+          nativeString(
+            "Used when the agent sends a notify with delivery=overlay — a small card that reads " +
+              "the message aloud, e.g. a summary you shouldn't miss while driving.",
+          ),
         style = ClawTheme.type.caption,
         color = ClawTheme.colors.textMuted,
       )
 
-      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        ClawSecondaryButton(
-          text =
-            if (backgroundImageUris.isEmpty()) {
-              nativeString("Choose Background Images")
-            } else {
-              nativeString("\$count images selected", backgroundImageUris.size.toString())
-            },
-          onClick = {
-            imagePickerLauncher.launch(
-              PickVisualMediaRequest(mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly),
-            )
-          },
-          modifier = Modifier.weight(1f),
+      Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(
+          text = nativeString("Card Color"),
+          style = ClawTheme.type.caption,
+          color = ClawTheme.colors.textMuted,
         )
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+          SecurePrefs.POPUP_CARD_COLOR_PRESETS.forEach { preset ->
+            PopupCardColorSwatch(
+              color = Color(preset),
+              selected = preset == cardColor,
+              onClick = { viewModel.setPopupCardColor(preset) },
+            )
+          }
+        }
       }
 
       Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(
-          text = nativeString("Popup Opacity: \$percent%", (opacity * 100).toInt().toString()),
+          text = nativeString("Card Opacity: \$percent%", (opacity * 100).toInt().toString()),
           style = ClawTheme.type.caption,
           color = ClawTheme.colors.textMuted,
         )
@@ -1238,6 +1241,20 @@ private fun PopupNotificationSettingsPanel(viewModel: MainViewModel) {
           value = opacity,
           onValueChange = { viewModel.setPopupOpacity(it) },
           valueRange = 0f..1f,
+        )
+      }
+
+      Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+          text = nativeString("Corner Radius: \$dp dp", cornerRadiusDp.toString()),
+          style = ClawTheme.type.caption,
+          color = ClawTheme.colors.textMuted,
+        )
+        Slider(
+          value = cornerRadiusDp.toFloat(),
+          onValueChange = { viewModel.setPopupCardCornerRadiusDp(it.toInt()) },
+          valueRange = 0f..32f,
+          steps = 31,
         )
       }
 
@@ -1274,8 +1291,39 @@ private fun PopupNotificationSettingsPanel(viewModel: MainViewModel) {
           )
         }
       }
+
+      if (!overlayPermissionGranted) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          ClawSecondaryButton(
+            text = nativeString("Allow Display Over Other Apps"),
+            onClick = { openOverlayPermissionSettings(context) },
+            modifier = Modifier.weight(1f),
+          )
+        }
+      }
     }
   }
+}
+
+@Composable
+private fun PopupCardColorSwatch(
+  color: Color,
+  selected: Boolean,
+  onClick: () -> Unit,
+) {
+  Box(
+    modifier =
+      Modifier
+        .size(32.dp)
+        .clip(CircleShape)
+        .background(color)
+        .border(
+          width = if (selected) 2.dp else 0.dp,
+          color = if (selected) ClawTheme.colors.text else Color.Transparent,
+          shape = CircleShape,
+        )
+        .clickable(onClick = onClick),
+  )
 }
 
 /** Full-screen intent needs an explicit OS grant on Android 14+; earlier versions allow it by default. */
@@ -1301,6 +1349,15 @@ private fun notificationPolicyAccessPermissionGranted(context: Context): Boolean
 
 private fun openNotificationPolicyAccessSettings(context: Context) {
   context.startActivity(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
+}
+
+/** The unlocked-screen popup (PopupOverlayWindow) only shows once this special access is granted. */
+private fun overlayPermissionGranted(context: Context): Boolean = Settings.canDrawOverlays(context)
+
+private fun openOverlayPermissionSettings(context: Context) {
+  val intent =
+    Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:${context.packageName}"))
+  context.startActivity(intent)
 }
 
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -87,6 +87,7 @@ import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -140,6 +141,7 @@ import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -1165,7 +1167,140 @@ private fun NotificationSettingsScreen(
         viewModel.setNotificationForwardingPackagesCsv(next.sorted().joinToString(","))
       },
     )
+    PopupNotificationSettingsPanel(viewModel = viewModel)
   }
+}
+
+@Composable
+private fun PopupNotificationSettingsPanel(viewModel: MainViewModel) {
+  val context = LocalContext.current
+  val backgroundImageUris by viewModel.popupBackgroundImageUris.collectAsState()
+  val opacity by viewModel.popupOpacity.collectAsState()
+  val autoDismissSeconds by viewModel.popupAutoDismissSeconds.collectAsState()
+  var fullScreenIntentGranted by remember { mutableStateOf(fullScreenIntentPermissionGranted(context)) }
+  var notificationPolicyAccessGranted by remember {
+    mutableStateOf(notificationPolicyAccessPermissionGranted(context))
+  }
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  DisposableEffect(lifecycleOwner, context) {
+    val observer =
+      LifecycleEventObserver { _, event ->
+        if (event == Lifecycle.Event.ON_RESUME) {
+          fullScreenIntentGranted = fullScreenIntentPermissionGranted(context)
+          notificationPolicyAccessGranted = notificationPolicyAccessPermissionGranted(context)
+        }
+      }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+  }
+
+  val imagePickerLauncher =
+    rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(9)) { uris ->
+      if (uris.isNotEmpty()) {
+        viewModel.setPopupBackgroundImageUris(uris.map { it.toString() })
+      }
+    }
+
+  ClawPanel {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+      Text(text = nativeString("Full-Screen Popup"), style = ClawTheme.type.section, color = ClawTheme.colors.text)
+      Text(
+        text = nativeString("Used when the agent sends a notify with delivery=overlay — e.g. a summarized message you shouldn't miss while driving."),
+        style = ClawTheme.type.caption,
+        color = ClawTheme.colors.textMuted,
+      )
+
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        ClawSecondaryButton(
+          text =
+            if (backgroundImageUris.isEmpty()) {
+              nativeString("Choose Background Images")
+            } else {
+              nativeString("\$count images selected", backgroundImageUris.size.toString())
+            },
+          onClick = {
+            imagePickerLauncher.launch(
+              PickVisualMediaRequest(mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly),
+            )
+          },
+          modifier = Modifier.weight(1f),
+        )
+      }
+
+      Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+          text = nativeString("Popup Opacity: \$percent%", (opacity * 100).toInt().toString()),
+          style = ClawTheme.type.caption,
+          color = ClawTheme.colors.textMuted,
+        )
+        Slider(
+          value = opacity,
+          onValueChange = { viewModel.setPopupOpacity(it) },
+          valueRange = 0f..1f,
+        )
+      }
+
+      Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+          text = nativeString("Auto-Dismiss After: \$seconds s", autoDismissSeconds.toString()),
+          style = ClawTheme.type.caption,
+          color = ClawTheme.colors.textMuted,
+        )
+        Slider(
+          value = autoDismissSeconds.toFloat(),
+          onValueChange = { viewModel.setPopupAutoDismissSeconds(it.toInt()) },
+          valueRange = 3f..30f,
+          steps = 26,
+        )
+      }
+
+      if (!fullScreenIntentGranted) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          ClawSecondaryButton(
+            text = nativeString("Allow Full-Screen Popups"),
+            onClick = { openFullScreenIntentSettings(context) },
+            modifier = Modifier.weight(1f),
+          )
+        }
+      }
+
+      if (!notificationPolicyAccessGranted) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          ClawSecondaryButton(
+            text = nativeString("Allow Overriding Do Not Disturb"),
+            onClick = { openNotificationPolicyAccessSettings(context) },
+            modifier = Modifier.weight(1f),
+          )
+        }
+      }
+    }
+  }
+}
+
+/** Full-screen intent needs an explicit OS grant on Android 14+; earlier versions allow it by default. */
+private fun fullScreenIntentPermissionGranted(context: Context): Boolean {
+  if (Build.VERSION.SDK_INT < 34) return true
+  val manager = context.getSystemService(android.app.NotificationManager::class.java)
+  return manager?.canUseFullScreenIntent() ?: false
+}
+
+private fun openFullScreenIntentSettings(context: Context) {
+  val intent =
+    Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT).apply {
+      data = Uri.fromParts("package", context.packageName, null)
+    }
+  context.startActivity(intent)
+}
+
+/** The overlay channel's bypass-DND flag (SystemHandler) only takes effect once this is granted. */
+private fun notificationPolicyAccessPermissionGranted(context: Context): Boolean {
+  val manager = context.getSystemService(android.app.NotificationManager::class.java)
+  return manager?.isNotificationPolicyAccessGranted ?: false
+}
+
+private fun openNotificationPolicyAccessSettings(context: Context) {
+  context.startActivity(Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS))
 }
 
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/popup/PopupOverlayActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/popup/PopupOverlayActivity.kt
@@ -5,48 +5,18 @@ import ai.openclaw.app.ui.OpenClawTheme
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import coil3.compose.AsyncImage
-import java.text.DateFormat
-import java.util.Date
-import kotlinx.coroutines.delay
 
 /**
- * Full-screen takeover popup for `system.notify` calls with `delivery: "overlay"`.
+ * Locked-screen takeover host for `system.notify` calls with `delivery: "overlay"`.
  * Launched over the lock screen via a full-screen-intent notification (see SystemHandler)
  * so a message you shouldn't miss (e.g. while driving) can't be swiped away like a normal one.
+ * While unlocked, PopupOverlayWindow is used instead — see SystemHandler.resolvePopupDeliveryMode.
  */
 class PopupOverlayActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -56,23 +26,29 @@ class PopupOverlayActivity : AppCompatActivity() {
     val subtitle = intent.getStringExtra(EXTRA_SUBTITLE)
     val body = intent.getStringExtra(EXTRA_BODY).orEmpty()
     val timestampMillis = intent.getLongExtra(EXTRA_TIMESTAMP_MILLIS, System.currentTimeMillis())
-    val prefs = (application as NodeApp).prefs
+    val app = application as NodeApp
+    val prefs = app.prefs
 
     setContent {
-      val backgroundImageUris by prefs.popupBackgroundImageUris.collectAsState()
       val opacity by prefs.popupOpacity.collectAsState()
       val autoDismissSeconds by prefs.popupAutoDismissSeconds.collectAsState()
-      val backgroundImageUri = remember(backgroundImageUris) { backgroundImageUris.randomOrNull() }
+      val cardColor by prefs.popupCardColor.collectAsState()
+      val cornerRadiusDp by prefs.popupCardCornerRadiusDp.collectAsState()
 
       OpenClawTheme {
-        PopupOverlayScreen(
+        PopupOverlayContent(
           title = title,
           subtitle = subtitle,
           body = body,
           timestampMillis = timestampMillis,
-          backgroundImageUri = backgroundImageUri,
+          cardColorArgb = cardColor,
           opacity = opacity,
+          cornerRadiusDp = cornerRadiusDp,
           autoDismissSeconds = autoDismissSeconds,
+          cardWidthModifier = Modifier.fillMaxWidth(0.9f),
+          showScrimBackdrop = true,
+          enableBackHandler = true,
+          speaker = app.popupSpeechSpeaker,
           onDismiss = { finish() },
         )
       }
@@ -102,93 +78,3 @@ class PopupOverlayActivity : AppCompatActivity() {
       }
   }
 }
-
-/** Entering -> Visible is the slide-in/fade-in; Visible -> Exiting is the slide-out/fade-out before finish(). */
-private enum class PopupPhase { Entering, Visible, Exiting }
-
-private const val ENTER_ANIMATION_MS = 260
-private const val EXIT_ANIMATION_MS = 260L
-
-@Composable
-private fun PopupOverlayScreen(
-  title: String,
-  subtitle: String?,
-  body: String,
-  timestampMillis: Long,
-  backgroundImageUri: String?,
-  opacity: Float,
-  autoDismissSeconds: Int,
-  onDismiss: () -> Unit,
-) {
-  var phase by remember { mutableStateOf(PopupPhase.Entering) }
-
-  LaunchedEffect(Unit) { phase = PopupPhase.Visible }
-
-  LaunchedEffect(phase, autoDismissSeconds) {
-    if (phase == PopupPhase.Visible) {
-      delay(autoDismissSeconds * 1_000L)
-      phase = PopupPhase.Exiting
-    }
-  }
-
-  LaunchedEffect(phase) {
-    if (phase == PopupPhase.Exiting) {
-      delay(EXIT_ANIMATION_MS)
-      onDismiss()
-    }
-  }
-
-  BackHandler(enabled = phase == PopupPhase.Visible) { phase = PopupPhase.Exiting }
-
-  AnimatedVisibility(
-    visible = phase == PopupPhase.Visible,
-    enter = slideInVertically(animationSpec = tween(ENTER_ANIMATION_MS)) { it / 3 } + fadeIn(tween(ENTER_ANIMATION_MS)),
-    exit = slideOutVertically(animationSpec = tween(EXIT_ANIMATION_MS.toInt())) { it / 3 } + fadeOut(tween(EXIT_ANIMATION_MS.toInt())),
-  ) {
-    Box(
-      modifier =
-        Modifier
-          .fillMaxSize()
-          .clickable(
-            interactionSource = remember { MutableInteractionSource() },
-            indication = null,
-          ) { phase = PopupPhase.Exiting },
-    ) {
-      backgroundImageUri?.let { uri ->
-        AsyncImage(
-          model = uri,
-          contentDescription = null,
-          modifier = Modifier.fillMaxSize(),
-          contentScale = ContentScale.Crop,
-        )
-      }
-      Box(
-        modifier =
-          Modifier
-            .fillMaxSize()
-            .background(Color.Black.copy(alpha = opacity)),
-      )
-      Column(
-        modifier = Modifier.fillMaxSize().padding(28.dp),
-        verticalArrangement = Arrangement.Center,
-      ) {
-        Text(
-          text = title.uppercase(),
-          color = Color.White.copy(alpha = 0.75f),
-          fontSize = 15.sp,
-          fontWeight = FontWeight.SemiBold,
-        )
-        Spacer(modifier = Modifier.height(4.dp))
-        if (subtitle != null) {
-          Text(text = subtitle, color = Color.White, fontSize = 30.sp, fontWeight = FontWeight.Bold)
-          Spacer(modifier = Modifier.height(4.dp))
-        }
-        Text(text = formatLocalTime(timestampMillis), color = Color.White.copy(alpha = 0.65f), fontSize = 14.sp)
-        Spacer(modifier = Modifier.height(20.dp))
-        Text(text = body, color = Color.White, fontSize = 19.sp)
-      }
-    }
-  }
-}
-
-private fun formatLocalTime(millis: Long): String = DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(millis))

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/popup/PopupOverlayActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/popup/PopupOverlayActivity.kt
@@ -1,0 +1,194 @@
+package ai.openclaw.app.ui.popup
+
+import ai.openclaw.app.NodeApp
+import ai.openclaw.app.ui.OpenClawTheme
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import java.text.DateFormat
+import java.util.Date
+import kotlinx.coroutines.delay
+
+/**
+ * Full-screen takeover popup for `system.notify` calls with `delivery: "overlay"`.
+ * Launched over the lock screen via a full-screen-intent notification (see SystemHandler)
+ * so a message you shouldn't miss (e.g. while driving) can't be swiped away like a normal one.
+ */
+class PopupOverlayActivity : AppCompatActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    val title = intent.getStringExtra(EXTRA_TITLE).orEmpty()
+    val subtitle = intent.getStringExtra(EXTRA_SUBTITLE)
+    val body = intent.getStringExtra(EXTRA_BODY).orEmpty()
+    val timestampMillis = intent.getLongExtra(EXTRA_TIMESTAMP_MILLIS, System.currentTimeMillis())
+    val prefs = (application as NodeApp).prefs
+
+    setContent {
+      val backgroundImageUris by prefs.popupBackgroundImageUris.collectAsState()
+      val opacity by prefs.popupOpacity.collectAsState()
+      val autoDismissSeconds by prefs.popupAutoDismissSeconds.collectAsState()
+      val backgroundImageUri = remember(backgroundImageUris) { backgroundImageUris.randomOrNull() }
+
+      OpenClawTheme {
+        PopupOverlayScreen(
+          title = title,
+          subtitle = subtitle,
+          body = body,
+          timestampMillis = timestampMillis,
+          backgroundImageUri = backgroundImageUri,
+          opacity = opacity,
+          autoDismissSeconds = autoDismissSeconds,
+          onDismiss = { finish() },
+        )
+      }
+    }
+  }
+
+  companion object {
+    private const val EXTRA_TITLE = "ai.openclaw.app.popup.EXTRA_TITLE"
+    private const val EXTRA_SUBTITLE = "ai.openclaw.app.popup.EXTRA_SUBTITLE"
+    private const val EXTRA_BODY = "ai.openclaw.app.popup.EXTRA_BODY"
+    private const val EXTRA_TIMESTAMP_MILLIS = "ai.openclaw.app.popup.EXTRA_TIMESTAMP_MILLIS"
+
+    /** Builds the takeover intent a full-screen-intent notification launches. */
+    fun launchIntent(
+      context: Context,
+      title: String,
+      subtitle: String?,
+      body: String,
+      timestampMillis: Long?,
+    ): Intent =
+      Intent(context, PopupOverlayActivity::class.java).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        putExtra(EXTRA_TITLE, title)
+        subtitle?.let { putExtra(EXTRA_SUBTITLE, it) }
+        putExtra(EXTRA_BODY, body)
+        putExtra(EXTRA_TIMESTAMP_MILLIS, timestampMillis ?: System.currentTimeMillis())
+      }
+  }
+}
+
+/** Entering -> Visible is the slide-in/fade-in; Visible -> Exiting is the slide-out/fade-out before finish(). */
+private enum class PopupPhase { Entering, Visible, Exiting }
+
+private const val ENTER_ANIMATION_MS = 260
+private const val EXIT_ANIMATION_MS = 260L
+
+@Composable
+private fun PopupOverlayScreen(
+  title: String,
+  subtitle: String?,
+  body: String,
+  timestampMillis: Long,
+  backgroundImageUri: String?,
+  opacity: Float,
+  autoDismissSeconds: Int,
+  onDismiss: () -> Unit,
+) {
+  var phase by remember { mutableStateOf(PopupPhase.Entering) }
+
+  LaunchedEffect(Unit) { phase = PopupPhase.Visible }
+
+  LaunchedEffect(phase, autoDismissSeconds) {
+    if (phase == PopupPhase.Visible) {
+      delay(autoDismissSeconds * 1_000L)
+      phase = PopupPhase.Exiting
+    }
+  }
+
+  LaunchedEffect(phase) {
+    if (phase == PopupPhase.Exiting) {
+      delay(EXIT_ANIMATION_MS)
+      onDismiss()
+    }
+  }
+
+  BackHandler(enabled = phase == PopupPhase.Visible) { phase = PopupPhase.Exiting }
+
+  AnimatedVisibility(
+    visible = phase == PopupPhase.Visible,
+    enter = slideInVertically(animationSpec = tween(ENTER_ANIMATION_MS)) { it / 3 } + fadeIn(tween(ENTER_ANIMATION_MS)),
+    exit = slideOutVertically(animationSpec = tween(EXIT_ANIMATION_MS.toInt())) { it / 3 } + fadeOut(tween(EXIT_ANIMATION_MS.toInt())),
+  ) {
+    Box(
+      modifier =
+        Modifier
+          .fillMaxSize()
+          .clickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = null,
+          ) { phase = PopupPhase.Exiting },
+    ) {
+      backgroundImageUri?.let { uri ->
+        AsyncImage(
+          model = uri,
+          contentDescription = null,
+          modifier = Modifier.fillMaxSize(),
+          contentScale = ContentScale.Crop,
+        )
+      }
+      Box(
+        modifier =
+          Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = opacity)),
+      )
+      Column(
+        modifier = Modifier.fillMaxSize().padding(28.dp),
+        verticalArrangement = Arrangement.Center,
+      ) {
+        Text(
+          text = title.uppercase(),
+          color = Color.White.copy(alpha = 0.75f),
+          fontSize = 15.sp,
+          fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        if (subtitle != null) {
+          Text(text = subtitle, color = Color.White, fontSize = 30.sp, fontWeight = FontWeight.Bold)
+          Spacer(modifier = Modifier.height(4.dp))
+        }
+        Text(text = formatLocalTime(timestampMillis), color = Color.White.copy(alpha = 0.65f), fontSize = 14.sp)
+        Spacer(modifier = Modifier.height(20.dp))
+        Text(text = body, color = Color.White, fontSize = 19.sp)
+      }
+    }
+  }
+}
+
+private fun formatLocalTime(millis: Long): String = DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(millis))

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/popup/PopupOverlayContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/popup/PopupOverlayContent.kt
@@ -1,0 +1,191 @@
+package ai.openclaw.app.ui.popup
+
+import ai.openclaw.app.chat.LocalSpeechSpeaking
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import java.text.DateFormat
+import java.util.Date
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/** Entering -> Visible is the slide-in/fade-in; Visible -> Exiting is the slide-out/fade-out before onDismiss(). */
+internal enum class PopupPhase { Entering, Visible, Exiting }
+
+private const val ENTER_ANIMATION_MS = 260
+private const val EXIT_ANIMATION_MS = 260L
+
+/**
+ * Shared popup card UI plus phase/timer/dismiss/TTS logic for both display hosts:
+ * the locked-screen takeover (PopupOverlayActivity) and the unlocked floating
+ * window (PopupOverlayWindow). Hosts differ only in card width, whether a
+ * full-size dim backdrop renders, and whether back-press is wired (the floating
+ * window is non-focusable and never receives back events).
+ */
+@Composable
+internal fun PopupOverlayContent(
+  title: String,
+  subtitle: String?,
+  body: String,
+  timestampMillis: Long,
+  cardColorArgb: Int,
+  opacity: Float,
+  cornerRadiusDp: Int,
+  autoDismissSeconds: Int,
+  cardWidthModifier: Modifier,
+  showScrimBackdrop: Boolean,
+  enableBackHandler: Boolean,
+  speaker: LocalSpeechSpeaking,
+  onDismiss: () -> Unit,
+) {
+  var phase by remember { mutableStateOf(PopupPhase.Entering) }
+  val scope = rememberCoroutineScope()
+
+  LaunchedEffect(Unit) {
+    phase = PopupPhase.Visible
+    scope.launch { speaker.speak(popupSpokenText(subtitle, body)) }
+  }
+
+  // Covers tap-dismiss, auto-dismiss, back-press, and host teardown (finish()/window removal)
+  // uniformly: composition leaving is the single point where speech must stop.
+  DisposableEffect(Unit) { onDispose { speaker.stop() } }
+
+  LaunchedEffect(phase, autoDismissSeconds) {
+    if (phase == PopupPhase.Visible) {
+      delay(autoDismissSeconds * 1_000L)
+      phase = PopupPhase.Exiting
+    }
+  }
+
+  LaunchedEffect(phase) {
+    if (phase == PopupPhase.Exiting) {
+      delay(EXIT_ANIMATION_MS)
+      onDismiss()
+    }
+  }
+
+  if (enableBackHandler) {
+    BackHandler(enabled = phase == PopupPhase.Visible) { phase = PopupPhase.Exiting }
+  }
+
+  AnimatedVisibility(
+    visible = phase == PopupPhase.Visible,
+    enter = slideInVertically(animationSpec = tween(ENTER_ANIMATION_MS)) { it / 3 } + fadeIn(tween(ENTER_ANIMATION_MS)),
+    exit = slideOutVertically(animationSpec = tween(EXIT_ANIMATION_MS.toInt())) { it / 3 } + fadeOut(tween(EXIT_ANIMATION_MS.toInt())),
+  ) {
+    val dismiss = { phase = PopupPhase.Exiting }
+    if (showScrimBackdrop) {
+      // Activity host: full-size root so the card can anchor to the bottom and a dim
+      // scrim can sit behind it. The floating-window host has no root of its own — see
+      // below — since fillMaxSize() there would force the WRAP_CONTENT window to expand
+      // to the full screen.
+      Box(modifier = Modifier.fillMaxSize()) {
+        Box(
+          modifier =
+            Modifier
+              .fillMaxSize()
+              .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = dismiss)
+              .background(Color.Black.copy(alpha = opacity * 0.4f)),
+        )
+        PopupCard(
+          title = title,
+          subtitle = subtitle,
+          body = body,
+          timestampMillis = timestampMillis,
+          cardColorArgb = cardColorArgb,
+          opacity = opacity,
+          cornerRadiusDp = cornerRadiusDp,
+          modifier = Modifier.align(Alignment.BottomCenter).then(cardWidthModifier).padding(bottom = 32.dp),
+          onClick = dismiss,
+        )
+      }
+    } else {
+      PopupCard(
+        title = title,
+        subtitle = subtitle,
+        body = body,
+        timestampMillis = timestampMillis,
+        cardColorArgb = cardColorArgb,
+        opacity = opacity,
+        cornerRadiusDp = cornerRadiusDp,
+        modifier = cardWidthModifier,
+        onClick = dismiss,
+      )
+    }
+  }
+}
+
+@Composable
+private fun PopupCard(
+  title: String,
+  subtitle: String?,
+  body: String,
+  timestampMillis: Long,
+  cardColorArgb: Int,
+  opacity: Float,
+  cornerRadiusDp: Int,
+  modifier: Modifier,
+  onClick: () -> Unit,
+) {
+  Column(
+    modifier =
+      modifier
+        .clip(RoundedCornerShape(cornerRadiusDp.dp))
+        .background(Color(cardColorArgb).copy(alpha = opacity))
+        .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onClick)
+        .padding(20.dp),
+  ) {
+    Text(
+      text = title.uppercase(),
+      color = Color.White.copy(alpha = 0.75f),
+      fontSize = 15.sp,
+      fontWeight = FontWeight.SemiBold,
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    if (subtitle != null) {
+      Text(text = subtitle, color = Color.White, fontSize = 24.sp, fontWeight = FontWeight.Bold)
+      Spacer(modifier = Modifier.height(4.dp))
+    }
+    Text(text = formatLocalTime(timestampMillis), color = Color.White.copy(alpha = 0.65f), fontSize = 13.sp)
+    Spacer(modifier = Modifier.height(12.dp))
+    Text(text = body, color = Color.White, fontSize = 17.sp)
+  }
+}
+
+/** What the popup speaks aloud; the core purpose of overlay delivery, so it always runs. */
+internal fun popupSpokenText(
+  subtitle: String?,
+  body: String,
+): String = if (subtitle != null) "Message from $subtitle: $body" else body
+
+private fun formatLocalTime(millis: Long): String = DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(millis))

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/popup/PopupOverlayWindow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/popup/PopupOverlayWindow.kt
@@ -1,0 +1,185 @@
+package ai.openclaw.app.ui.popup
+
+import ai.openclaw.app.NodeApp
+import ai.openclaw.app.ui.OpenClawTheme
+import android.content.Context
+import android.graphics.PixelFormat
+import android.hardware.display.DisplayManager
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.view.Display
+import android.view.Gravity
+import android.view.WindowManager
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+
+private const val TAG = "PopupOverlayWindow"
+private const val CARD_WIDTH_DP = 340
+private const val BOTTOM_MARGIN_DP = 32
+
+/**
+ * Floating card shown while the screen is unlocked, so overlay-notify popups appear
+ * automatically even when the app is fully backgrounded. Full-screen-intent
+ * (PopupOverlayActivity) only auto-launches while the device is locked — see
+ * SystemHandler.resolvePopupDeliveryMode for the branch that picks between the two.
+ * Requires the SYSTEM_ALERT_WINDOW special-access grant (Settings.canDrawOverlays).
+ */
+internal class PopupOverlayWindow(
+  private val app: NodeApp,
+) {
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private var attached: AttachedView? = null
+
+  fun show(
+    title: String,
+    subtitle: String?,
+    body: String,
+    timestampMillis: Long,
+  ) {
+    runOnMain { showOnMain(title, subtitle, body, timestampMillis) }
+  }
+
+  fun dismiss() {
+    runOnMain { removeAttached() }
+  }
+
+  private fun showOnMain(
+    title: String,
+    subtitle: String?,
+    body: String,
+    timestampMillis: Long,
+  ) {
+    // A new popup replaces a still-visible one; the shared speaker (NodeApp.popupSpeechSpeaker)
+    // correctly interrupts that popup's speech the same way.
+    removeAttached()
+
+    try {
+      // WindowManager (and anything measuring views, like ComposeView's own init) requires a
+      // "visual" context on API 30+ — the plain Application context throws
+      // IllegalAccessException ("non-visual Context") here, so a dedicated window context is
+      // created per popup rather than reusing NodeApp's own getSystemService. The Application
+      // context itself has no associated display, so the no-Display overload of
+      // createWindowContext throws UnsupportedOperationException; the default display must be
+      // passed explicitly. The whole thing is one try/catch: any of these platform calls
+      // failing is an expected race (permission revoked, display/process teardown) the caller
+      // already has a fallback notification for, not a reason to crash the process.
+      val display = app.getSystemService(DisplayManager::class.java).getDisplay(Display.DEFAULT_DISPLAY)
+      val windowContext =
+        app.createWindowContext(display, WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY, null)
+      val windowManager = windowContext.getSystemService(WindowManager::class.java)
+
+      val owner = PopupWindowLifecycleOwner().apply { attach() }
+      val composeView =
+        ComposeView(windowContext).apply {
+          setViewTreeLifecycleOwner(owner)
+          setViewTreeSavedStateRegistryOwner(owner)
+          setViewTreeViewModelStoreOwner(owner)
+          setContent {
+            OpenClawTheme {
+              PopupOverlayContent(
+                title = title,
+                subtitle = subtitle,
+                body = body,
+                timestampMillis = timestampMillis,
+                cardColorArgb = app.prefs.popupCardColor.value,
+                opacity = app.prefs.popupOpacity.value,
+                cornerRadiusDp = app.prefs.popupCardCornerRadiusDp.value,
+                autoDismissSeconds = app.prefs.popupAutoDismissSeconds.value,
+                cardWidthModifier = androidx.compose.ui.Modifier.width(CARD_WIDTH_DP.dp),
+                showScrimBackdrop = false,
+                enableBackHandler = false,
+                speaker = app.popupSpeechSpeaker,
+                onDismiss = { dismiss() },
+              )
+            }
+          }
+        }
+
+      windowManager.addView(composeView, buildLayoutParams(windowContext))
+      attached = AttachedView(composeView, owner, windowManager)
+    } catch (err: Exception) {
+      Log.w(TAG, "failed to show overlay window: ${err.message}")
+    }
+  }
+
+  private fun removeAttached() {
+    val current = attached ?: return
+    attached = null
+    try {
+      current.windowManager.removeView(current.view)
+    } catch (err: Exception) {
+      Log.w(TAG, "failed to remove overlay window: ${err.message}")
+    }
+    current.owner.destroy()
+  }
+
+  private fun buildLayoutParams(windowContext: Context): WindowManager.LayoutParams =
+    WindowManager.LayoutParams(
+      // WRAP_CONTENT, not MATCH_PARENT: FLAG_NOT_TOUCH_MODAL only passes touches through
+      // outside the window's own bounds, so a full-width window would silently swallow taps
+      // across the whole screen even where the card isn't visible.
+      WindowManager.LayoutParams.WRAP_CONTENT,
+      WindowManager.LayoutParams.WRAP_CONTENT,
+      WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+      WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+        WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL or
+        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+      PixelFormat.TRANSLUCENT,
+    ).apply {
+      gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+      y = (BOTTOM_MARGIN_DP * windowContext.resources.displayMetrics.density).toInt()
+    }
+
+  private fun runOnMain(action: () -> Unit) {
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      action()
+    } else {
+      mainHandler.post(action)
+    }
+  }
+
+  private class AttachedView(
+    val view: ComposeView,
+    val owner: PopupWindowLifecycleOwner,
+    val windowManager: WindowManager,
+  )
+}
+
+/**
+ * Minimal Lifecycle/SavedState/ViewModelStore owner so Compose can be hosted in a raw
+ * WindowManager-attached view outside an Activity, which provides this wiring for free.
+ */
+private class PopupWindowLifecycleOwner : LifecycleOwner, SavedStateRegistryOwner, ViewModelStoreOwner {
+  private val lifecycleRegistry = LifecycleRegistry(this)
+  private val savedStateController = SavedStateRegistryController.create(this)
+
+  override val lifecycle: Lifecycle get() = lifecycleRegistry
+  override val savedStateRegistry: SavedStateRegistry get() = savedStateController.savedStateRegistry
+  override val viewModelStore = ViewModelStore()
+
+  fun attach() {
+    savedStateController.performRestore(null)
+    lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+    lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+  }
+
+  fun destroy() {
+    lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    viewModelStore.clear()
+  }
+}

--- a/apps/android/app/src/main/res/values/themes.xml
+++ b/apps/android/app/src/main/res/values/themes.xml
@@ -4,4 +4,15 @@
         <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightStatusBar">false</item>
     </style>
+
+    <!-- Translucent so the popup can dim/darken whatever was on screen (e.g. Maps) instead
+         of fully replacing it, matching the "leicht transparent" takeover the popup renders. -->
+    <style name="Theme.OpenClawPopup" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 </resources>

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -423,4 +423,31 @@ class SecurePrefsTest {
     assertEquals(mapOf("X-Two" to "secret-two"), prefs.loadGatewayCustomHeaders("manual|two.example|443"))
     assertEquals("keep", prefs.getString("unrelated.secret"))
   }
+
+  @Test
+  fun popupCardColor_defaultsToNearBlackAndForcesOpaqueOnSet() {
+    val context = RuntimeEnvironment.getApplication()
+    val prefs = testPrefs(context)
+
+    assertEquals(0xFF1C1C1E.toInt(), prefs.popupCardColor.value)
+
+    // Alpha channel is always forced opaque; visual transparency is popupOpacity's job.
+    prefs.setPopupCardColor(0x807F1D1D.toInt())
+
+    assertEquals(0xFF7F1D1D.toInt(), prefs.popupCardColor.value)
+  }
+
+  @Test
+  fun popupCardCornerRadiusDp_defaultsAndClamps() {
+    val context = RuntimeEnvironment.getApplication()
+    val prefs = testPrefs(context)
+
+    assertEquals(24, prefs.popupCardCornerRadiusDp.value)
+
+    prefs.setPopupCardCornerRadiusDp(999)
+    assertEquals(32, prefs.popupCardCornerRadiusDp.value)
+
+    prefs.setPopupCardCornerRadiusDp(-5)
+    assertEquals(0, prefs.popupCardCornerRadiusDp.value)
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/SystemHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/SystemHandlerTest.kt
@@ -1,6 +1,10 @@
 package ai.openclaw.app.node
 
 import ai.openclaw.app.MainActivity
+import android.Manifest
+import android.app.Application
+import android.app.Notification
+import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import org.junit.Assert.assertEquals
@@ -76,6 +80,73 @@ class SystemHandlerTest {
   }
 
   @Test
+  fun handleSystemNotify_parsesSubtitleTimestampAndDelivery() {
+    val poster = FakePoster(authorized = true)
+    val handler = SystemHandler.forTesting(poster = poster)
+
+    val result =
+      handler.handleSystemNotify(
+        """{"title":"WhatsApp","body":"Dinner at 7?","subtitle":"Anna","timestamp":"2026-07-29T14:32:00Z","delivery":"overlay"}""",
+      )
+
+    assertTrue(result.ok)
+    assertEquals("Anna", poster.lastRequest?.subtitle)
+    assertEquals("overlay", poster.lastRequest?.delivery)
+    assertEquals(1785335520000L, poster.lastRequest?.timestampMillis)
+  }
+
+  @Test
+  fun handleSystemNotify_ignoresUnparsableTimestamp() {
+    val poster = FakePoster(authorized = true)
+    val handler = SystemHandler.forTesting(poster = poster)
+
+    val result = handler.handleSystemNotify("""{"title":"OpenClaw","body":"done","timestamp":"not-a-date"}""")
+
+    assertTrue(result.ok)
+    assertEquals(null, poster.lastRequest?.timestampMillis)
+  }
+
+  @Test
+  @Config(sdk = [33])
+  fun buildSystemNotificationAttachesFullScreenIntentForOverlayDelivery() {
+    val context: Context = RuntimeEnvironment.getApplication()
+    val notification =
+      buildSystemNotification(
+        appContext = context,
+        channelId = "test",
+        request =
+          SystemNotifyRequest(
+            "WhatsApp",
+            "Dinner at 7?",
+            sound = null,
+            priority = null,
+            delivery = "overlay",
+            subtitle = "Anna",
+            timestampMillis = 1_785_335_520_000L,
+          ),
+      )
+
+    assertNotNull(notification.fullScreenIntent)
+    val savedIntent = Shadows.shadowOf(notification.fullScreenIntent).savedIntent
+    assertEquals("ai.openclaw.app.ui.popup.PopupOverlayActivity", savedIntent.component?.className)
+    assertEquals("Anna", notification.extras.getCharSequence(Notification.EXTRA_SUB_TEXT)?.toString())
+    assertEquals(1_785_335_520_000L, notification.`when`)
+  }
+
+  @Test
+  fun buildSystemNotificationOmitsFullScreenIntentForSystemDelivery() {
+    val context: Context = RuntimeEnvironment.getApplication()
+    val notification =
+      buildSystemNotification(
+        appContext = context,
+        channelId = "test",
+        request = SystemNotifyRequest("OpenClaw", "done", sound = null, priority = null, delivery = "system"),
+      )
+
+    assertEquals(null, notification.fullScreenIntent)
+  }
+
+  @Test
   fun buildSystemNotificationSetsImmutableAppLaunchIntent() {
     val context: Context = RuntimeEnvironment.getApplication()
     val notification =
@@ -114,6 +185,36 @@ class SystemHandlerTest {
     assertFalse(result.ok)
     assertEquals("UNAVAILABLE", result.error?.code)
     assertEquals("NOTIFICATION_FAILED: boom", result.error?.message)
+  }
+
+  @Test
+  fun handleSystemNotify_overlayDeliveryChannelBypassesDnd() {
+    val context: Context = RuntimeEnvironment.getApplication()
+    Shadows.shadowOf(context as Application).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+    val handler = SystemHandler(context)
+
+    val result = handler.handleSystemNotify("""{"title":"WhatsApp","body":"hi","delivery":"overlay"}""")
+
+    assertTrue(result.ok)
+    val manager = context.getSystemService(NotificationManager::class.java)
+    val channel = manager.getNotificationChannel("openclaw.system.notify.timesensitive")
+    assertNotNull(channel)
+    assertTrue(channel!!.canBypassDnd())
+  }
+
+  @Test
+  fun handleSystemNotify_defaultDeliveryChannelDoesNotBypassDnd() {
+    val context: Context = RuntimeEnvironment.getApplication()
+    Shadows.shadowOf(context as Application).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+    val handler = SystemHandler(context)
+
+    val result = handler.handleSystemNotify("""{"title":"OpenClaw","body":"hi"}""")
+
+    assertTrue(result.ok)
+    val manager = context.getSystemService(NotificationManager::class.java)
+    val channel = manager.getNotificationChannel("openclaw.system.notify.active")
+    assertNotNull(channel)
+    assertFalse(channel!!.canBypassDnd())
   }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/SystemHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/SystemHandlerTest.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.node
 import ai.openclaw.app.MainActivity
 import android.Manifest
 import android.app.Application
+import android.app.KeyguardManager
 import android.app.Notification
 import android.app.NotificationManager
 import android.content.Context
@@ -17,6 +18,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSettings
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -124,6 +126,7 @@ class SystemHandlerTest {
             subtitle = "Anna",
             timestampMillis = 1_785_335_520_000L,
           ),
+        wantsFullScreenIntent = true,
       )
 
     assertNotNull(notification.fullScreenIntent)
@@ -191,6 +194,9 @@ class SystemHandlerTest {
   fun handleSystemNotify_overlayDeliveryChannelBypassesDnd() {
     val context: Context = RuntimeEnvironment.getApplication()
     Shadows.shadowOf(context as Application).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+    // Isolate this from delivery-mode branching (own coverage below): locked keeps the
+    // full-screen-intent path, which is all this test cares about.
+    Shadows.shadowOf(context.getSystemService(KeyguardManager::class.java)).setKeyguardLocked(true)
     val handler = SystemHandler(context)
 
     val result = handler.handleSystemNotify("""{"title":"WhatsApp","body":"hi","delivery":"overlay"}""")
@@ -215,6 +221,32 @@ class SystemHandlerTest {
     val channel = manager.getNotificationChannel("openclaw.system.notify.active")
     assertNotNull(channel)
     assertFalse(channel!!.canBypassDnd())
+  }
+
+  @Test
+  fun resolvePopupDeliveryMode_locked_returnsFullScreenLocked() {
+    val context: Context = RuntimeEnvironment.getApplication()
+    Shadows.shadowOf(context.getSystemService(KeyguardManager::class.java)).setKeyguardLocked(true)
+
+    assertEquals(PopupDeliveryMode.FullScreenLocked, resolvePopupDeliveryMode(context))
+  }
+
+  @Test
+  fun resolvePopupDeliveryMode_unlockedWithOverlayPermission_returnsOverlayWindow() {
+    val context: Context = RuntimeEnvironment.getApplication()
+    Shadows.shadowOf(context.getSystemService(KeyguardManager::class.java)).setKeyguardLocked(false)
+    ShadowSettings.setCanDrawOverlays(true)
+
+    assertEquals(PopupDeliveryMode.OverlayWindow, resolvePopupDeliveryMode(context))
+  }
+
+  @Test
+  fun resolvePopupDeliveryMode_unlockedWithoutOverlayPermission_returnsHeadsUpFallback() {
+    val context: Context = RuntimeEnvironment.getApplication()
+    Shadows.shadowOf(context.getSystemService(KeyguardManager::class.java)).setKeyguardLocked(false)
+    ShadowSettings.setCanDrawOverlays(false)
+
+    assertEquals(PopupDeliveryMode.HeadsUpFallback, resolvePopupDeliveryMode(context))
   }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/popup/PopupOverlayContentTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/popup/PopupOverlayContentTest.kt
@@ -1,0 +1,16 @@
+package ai.openclaw.app.ui.popup
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PopupOverlayContentTest {
+  @Test
+  fun popupSpokenText_prefixesSenderWhenSubtitlePresent() {
+    assertEquals("Message from Anna: Dinner at 7?", popupSpokenText(subtitle = "Anna", body = "Dinner at 7?"))
+  }
+
+  @Test
+  fun popupSpokenText_isJustBodyWhenNoSubtitle() {
+    assertEquals("Dinner at 7?", popupSpokenText(subtitle = null, body = "Dinner at 7?"))
+  }
+}

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -936,6 +936,40 @@ describe("createNodesTool screen_record duration guardrails", () => {
     expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
   });
 
+  it("forwards notify subtitle/timestamp/delivery to system.notify", async () => {
+    gatewayMocks.callGatewayTool.mockResolvedValue({ ok: true });
+    const tool = createNodesTool();
+
+    await tool.execute("call-notify", {
+      action: "notify",
+      node: "pixel",
+      title: "WhatsApp",
+      body: "Dinner at 7?",
+      subtitle: "Anna",
+      timestamp: "2026-07-29T14:32:00.000Z",
+      delivery: "overlay",
+    });
+
+    expect(gatewayMocks.callGatewayTool).toHaveBeenCalledWith(
+      "node.invoke",
+      {},
+      {
+        nodeId: "node-1",
+        command: "system.notify",
+        params: {
+          title: "WhatsApp",
+          body: "Dinner at 7?",
+          subtitle: "Anna",
+          timestamp: "2026-07-29T14:32:00.000Z",
+          sound: undefined,
+          priority: undefined,
+          delivery: "overlay",
+        },
+        idempotencyKey: expect.any(String),
+      },
+    );
+  });
+
   it("uses operator.pairing plus operator.admin to approve exec-capable node pair requests", async () => {
     mockNodePairApproveFlow({
       requiredApproveScopes: ["operator.pairing", "operator.admin"],

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -101,6 +101,18 @@ const NodesToolSchema = Type.Object({
   // notify
   title: Type.Optional(Type.String()),
   body: Type.Optional(Type.String()),
+  subtitle: Type.Optional(
+    Type.String({
+      description:
+        "notify: short secondary line shown under the title (e.g. a contact/sender name).",
+    }),
+  ),
+  timestamp: Type.Optional(
+    Type.String({
+      description:
+        "notify: ISO-8601 time the underlying event occurred (e.g. when a message was received).",
+    }),
+  ),
   sound: Type.Optional(Type.String()),
   priority: optionalStringEnum(NOTIFY_PRIORITIES),
   delivery: optionalStringEnum(NOTIFY_DELIVERIES),
@@ -224,6 +236,8 @@ export function createNodesTool(options?: {
               params: {
                 title: title.trim(),
                 body: body.trim(),
+                subtitle: typeof params.subtitle === "string" ? params.subtitle : undefined,
+                timestamp: typeof params.timestamp === "string" ? params.timestamp : undefined,
                 sound: typeof params.sound === "string" ? params.sound : undefined,
                 priority: typeof params.priority === "string" ? params.priority : undefined,
                 delivery: typeof params.delivery === "string" ? params.delivery : undefined,


### PR DESCRIPTION
## What Problem This Solves

WhatsApp/agent summaries sent via `system.notify` with `delivery: "overlay"`
showed as a normal notification, easy to miss or swipe away while driving,
with no sender name or timestamp. Separately, the overlay channel could be
silently suppressed by Android's Do Not Disturb, defeating the "can't miss
this" purpose entirely — confirmed live via logcat
(`No FullScreenIntent: Suppressed by DND`).

## Why This Change Was Made

Adds a full-screen takeover popup (`PopupOverlayActivity`) launched via a
full-screen-intent notification, so an overlay-delivery notify appears over
the lock screen like an incoming call and can't be swiped away. New optional
`subtitle`/`timestamp` fields on the generic `nodes` tool / `system.notify`
schema carry the sender name and message time through to the popup (ignored
elsewhere, no breaking change). The overlay notification channel now also
sets `bypassDnd`, plus a Settings button ("Allow Overriding Do Not Disturb")
to grant the required `ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS` special
access, since `setBypassDnd` only takes effect once the user grants that.

## User Impact

Agents can send a `system.notify` with `delivery: "overlay"` (optionally
`subtitle`/`timestamp`) and have it show as an unmissable full-screen popup
on Android, configurable background image/opacity/auto-dismiss in Settings,
and no longer silently dropped by Do Not Disturb once the user grants
notification-policy access.

## Evidence

- Live end-to-end test on a real device (OnePlus Nord CE, Android 13):
  paired the phone as a gateway node, called `openclaw nodes invoke
  --command system.notify --params '{"delivery":"overlay",...}'`, and
  confirmed the full-screen popup renders over the lock screen with title,
  subtitle, timestamp, and body exactly as designed.
- Confirmed via logcat that Do Not Disturb suppressed the full-screen intent
  before the `bypassDnd` fix (`No FullScreenIntent: Suppressed by DND`), and
  that the popup fires correctly with DND off / policy access granted.
- `./gradlew :app:testThirdPartyDebugUnitTest --tests
  "ai.openclaw.app.node.SystemHandlerTest"` — 16/16 passed, including two new
  tests asserting the overlay channel bypasses DND and the default channel
  does not.
- `node scripts/run-vitest.mjs src/agents/tools/nodes-tool.test.ts` — 55/55
  passed (existing `notify` tests plus the new subtitle/timestamp coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)