### PR TITLE
fix(outbound): keep code blocks and code spans out of plain-text HTML stripping

### DIFF
--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -119,6 +119,12 @@ describe("sanitizeForPlainText", () => {
     );
   });
 
+  it("preserves large control-character runs around code", () => {
+    const reply = `${"\u0000".repeat(40_000)}e\u0000p\n\`\`\`text\nline one\n\n\n<Button>\n\`\`\``;
+
+    expect(sanitizeForPlainText(reply)).toBe(reply);
+  });
+
   it("preserves generics and JSX inside inline code spans", () => {
     expect(
       sanitizeForPlainText("Use `Array<string>` for ids, and render `<Button onClick={save}>`."),

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -91,6 +91,64 @@ describe("sanitizeForPlainText", () => {
     expect(sanitized).not.toContain("<script");
   });
 
+  it("preserves tag-shaped code inside fenced blocks while converting prose tags", () => {
+    const reply = [
+      "Here is the nginx snippet:",
+      "",
+      "```xml",
+      '<server port="8080">',
+      '  <route path="/api"/>',
+      "</server>",
+      "```",
+      "",
+      "Wrap it in <b>bold</b> when quoting.",
+    ].join("\n");
+
+    expect(sanitizeForPlainText(reply, { style: "markdown" })).toBe(
+      [
+        "Here is the nginx snippet:",
+        "",
+        "```xml",
+        '<server port="8080">',
+        '  <route path="/api"/>',
+        "</server>",
+        "```",
+        "",
+        "Wrap it in **bold** when quoting.",
+      ].join("\n"),
+    );
+  });
+
+  it("preserves generics and JSX inside inline code spans", () => {
+    expect(
+      sanitizeForPlainText("Use `Array<string>` for ids, and render `<Button onClick={save}>`."),
+    ).toBe("Use `Array<string>` for ids, and render `<Button onClick={save}>`.");
+  });
+
+  it("keeps paired HTML formatting that wraps an inline code span", () => {
+    expect(sanitizeForPlainText("<strong>Use `<Button>` now</strong>")).toBe(
+      "*Use `<Button>` now*",
+    );
+    expect(sanitizeForPlainText("<em>render `<Button>` twice</em>", { style: "markdown" })).toBe(
+      "_render `<Button>` twice_",
+    );
+    expect(sanitizeForPlainText("<li>call `Array<string>` first</li>")).toBe(
+      "• call `Array<string>` first\n",
+    );
+  });
+
+  it("preserves tag-shaped code inside indented code blocks", () => {
+    expect(sanitizeForPlainText('Example:\n\n    <div id="root"></div>\n\ndone')).toBe(
+      'Example:\n\n    <div id="root"></div>\n\ndone',
+    );
+  });
+
+  it("keeps stripping tags after an unterminated inline code delimiter", () => {
+    expect(sanitizeForPlainText("prefix ` unterminated <span>text</span>")).toBe(
+      "prefix ` unterminated text",
+    );
+  });
+
   it("strips known internal runtime scaffolding tags including underscore names", () => {
     expect(sanitizeForPlainText("ok <previous_response>null</previous_response> done")).toBe(
       "ok  done",

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -8,6 +8,9 @@ import { stripInternalRuntimeScaffolding } from "./protocol-scaffolding.js";
 export { stripInternalRuntimeScaffolding };
 
 const HTML_TAG_RE = /<\/?[a-z][a-z0-9_-]*\b[^>]*>/gi;
+const MAY_CONTAIN_MARKDOWN_CODE_RE = /[`~]|\t| {4}/;
+const CODE_ESCAPE = "\u0000e";
+const CODE_PLACEHOLDER = "\u0000p";
 
 // Quoted attribute values may contain `>`; normalize convertible openers without leaking attribute text.
 const CONVERTIBLE_HTML_OPEN_TAG_RE =
@@ -21,14 +24,6 @@ function stripRemainingHtmlTags(text: string): string {
     current = current.replace(HTML_TAG_RE, "");
   } while (current !== previous);
   return current;
-}
-
-function reserveCodeMarker(text: string): string {
-  let marker = "\u0000";
-  while (text.includes(marker)) {
-    marker += "\u0000";
-  }
-  return marker;
 }
 
 function convertHtmlOutsideCode(text: string, options: { style?: "markdown" }): string {
@@ -69,22 +64,33 @@ function convertHtmlOutsideCode(text: string, options: { style?: "markdown" }): 
  */
 export function sanitizeForPlainText(text: string, options: { style?: "markdown" } = {}): string {
   const prepared = flattenMarkdownDetails(stripInternalRuntimeScaffolding(text));
-  const codeRegions = findCodeRegions(prepared);
+  const conversionCanChangeCode = prepared.includes("<") || prepared.includes("\n\n\n");
+  const codeRegions =
+    conversionCanChangeCode && MAY_CONTAIN_MARKDOWN_CODE_RE.test(prepared)
+      ? findCodeRegions(prepared)
+      : [];
   if (codeRegions.length === 0) {
     return convertHtmlOutsideCode(prepared, options);
   }
-  const marker = reserveCodeMarker(prepared);
   const preservedCode: string[] = [];
   let masked = "";
   let cursor = 0;
   for (const region of codeRegions) {
-    masked += `${prepared.slice(cursor, region.start)}${marker}${preservedCode.length}${marker}`;
+    masked += prepared.slice(cursor, region.start).replaceAll("\u0000", CODE_ESCAPE);
+    masked += CODE_PLACEHOLDER;
     preservedCode.push(prepared.slice(region.start, region.end));
     cursor = region.end;
   }
-  masked += prepared.slice(cursor);
-  return convertHtmlOutsideCode(masked, options).replace(
-    new RegExp(`${marker}(\\d+)${marker}`, "g"),
-    (_match, index: string) => preservedCode[Number(index)] ?? "",
-  );
+  masked += prepared.slice(cursor).replaceAll("\u0000", CODE_ESCAPE);
+
+  const converted = convertHtmlOutsideCode(masked, options);
+  let restored = "";
+  cursor = 0;
+  for (const code of preservedCode) {
+    const placeholder = converted.indexOf(CODE_PLACEHOLDER, cursor);
+    restored += converted.slice(cursor, placeholder).replaceAll(CODE_ESCAPE, "\u0000");
+    restored += code;
+    cursor = placeholder + CODE_PLACEHOLDER.length;
+  }
+  return restored + converted.slice(cursor).replaceAll(CODE_ESCAPE, "\u0000");
 }

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -1,3 +1,4 @@
+import { findCodeRegions } from "../../shared/text/code-regions.js";
 import { flattenMarkdownDetails } from "./markdown-details.js";
 // Plain-text sanitization strips internal runtime scaffolding and converts a
 // conservative subset of model-produced HTML into channel-friendly text.
@@ -22,18 +23,18 @@ function stripRemainingHtmlTags(text: string): string {
   return current;
 }
 
-/**
- * Convert common HTML tags to their plain-text/lightweight-markup equivalents
- * and strip anything that remains.
- *
- * The function is intentionally conservative — it only targets tags that models
- * are known to produce and avoids false positives on angle brackets in normal
- * prose (e.g. `a < b`).
- */
-export function sanitizeForPlainText(text: string, options: { style?: "markdown" } = {}): string {
+function reserveCodeMarker(text: string): string {
+  let marker = "\u0000";
+  while (text.includes(marker)) {
+    marker += "\u0000";
+  }
+  return marker;
+}
+
+function convertHtmlOutsideCode(text: string, options: { style?: "markdown" }): string {
   const boldMarker = options.style === "markdown" ? "**" : "*";
   const strikeMarker = options.style === "markdown" ? "~~" : "~";
-  const converted = flattenMarkdownDetails(stripInternalRuntimeScaffolding(text))
+  const converted = text
     // Preserve angle-bracket autolinks as plain URLs before tag stripping.
     .replace(/<((?:https?:\/\/|mailto:)[^<>\s]+)>/gi, "$1")
     // Normalize attributes once; conversions below only need exact bare tag names.
@@ -56,4 +57,34 @@ export function sanitizeForPlainText(text: string, options: { style?: "markdown"
     .replace(/<li>(.*?)<\/li>/gi, "• $1\n");
 
   return stripRemainingHtmlTags(converted).replace(/\n{3,}/g, "\n\n");
+}
+
+/**
+ * Convert common HTML tags to their plain-text/lightweight-markup equivalents
+ * and strip anything that remains.
+ *
+ * The function is intentionally conservative — it only targets tags that models
+ * are known to produce and avoids false positives on angle brackets in normal
+ * prose (e.g. `a < b`), in fenced blocks, and in inline code spans.
+ */
+export function sanitizeForPlainText(text: string, options: { style?: "markdown" } = {}): string {
+  const prepared = flattenMarkdownDetails(stripInternalRuntimeScaffolding(text));
+  const codeRegions = findCodeRegions(prepared);
+  if (codeRegions.length === 0) {
+    return convertHtmlOutsideCode(prepared, options);
+  }
+  const marker = reserveCodeMarker(prepared);
+  const preservedCode: string[] = [];
+  let masked = "";
+  let cursor = 0;
+  for (const region of codeRegions) {
+    masked += `${prepared.slice(cursor, region.start)}${marker}${preservedCode.length}${marker}`;
+    preservedCode.push(prepared.slice(region.start, region.end));
+    cursor = region.end;
+  }
+  masked += prepared.slice(cursor);
+  return convertHtmlOutsideCode(masked, options).replace(
+    new RegExp(`${marker}(\\d+)${marker}`, "g"),
+    (_match, index: string) => preservedCode[Number(index)] ?? "",
+  );
 }


### PR DESCRIPTION
## What Problem This Solves

Preserve fenced, indented, and inline Markdown code while the shared plain-text outbound sanitizer converts or strips HTML. This fixes silent code corruption on Telegram's default non-rich path, WhatsApp, iMessage, Google Chat, IRC, and plugin direct-text delivery.

Examples fixed:

- `Array<string>` no longer becomes `Array`.
- JSX such as `<Button onClick={save}>` remains intact inside code spans.
- XML and template snippets no longer arrive as empty fences.
- HTML formatting around an inline code span still converts as one paired wrapper.

## Root cause

`sanitizeForPlainText` applied the HTML conversion and catch-all tag stripper to the complete reply. Markdown code boundaries were not part of that pass, so tag-shaped code was deleted without an error or delivery marker.

The first repair correctly selected the shared sanitizer as the owner and masked Markdown Core code regions. Review found two attributable implementation hazards in that masking path:

- Every outbound string built a full Markdown AST, including plain replies with no code-sensitive content.
- Marker reservation repeatedly rescanned the input, then interpolated an unbounded NUL run into a regular expression. A long NUL run could make the path quadratic and eventually throw `SyntaxError: Invalid regular expression`.

## Fix

The shared sanitizer remains the only owner. No channel-specific fork or configuration was added.

1. Strip private runtime scaffolding and flatten details before code preservation, as before.
2. Skip Markdown parsing unless the reply has both possible Markdown code syntax and content the conversion chain could change.
3. Use Markdown Core offsets as the semantic authority for fenced, indented, and inline code.
4. Replace code regions with a fixed escaped placeholder, run one whole-string HTML conversion, then restore the preserved slices in order.

The fixed placeholder keeps masking and restoration linear, avoids dynamic regular expressions, and preserves wrapper matching across code spans. Literal NUL-plus-placeholder-shaped input is escaped and restored byte-for-byte.

## Scope and compatibility

- Prose HTML conversion is unchanged outside code.
- `<br>`, paragraphs, headings, lists, emphasis, strike, inline HTML code, autolinks, and unknown-tag stripping retain their existing behavior.
- Runtime scaffolding removal still precedes code preservation. Fences cannot expose private scaffolding.
- Unterminated Markdown delimiters remain literal text and do not suppress sanitization.
- No protocol, config, dependency, storage, or public API change.

## Evidence

Exact pushed head: `352f746ca3c2b966bd24c235ca2a4bf537671518`.

Red proof on the pre-fix sanitizer with the PR regression file:

- `pnpm test src/infra/outbound/sanitize-text.test.ts`
- Result: 4 intended failures. Fenced XML, inline generics/JSX, wrapper formatting, and indented HTML code were corrupted.

Green proof on this head:

- One grouped focused run across the owner, Markdown Core, and affected adapters: 241 tests passed across 5 Vitest shards.
- `pnpm exec oxfmt --check src/infra/outbound/sanitize-text.ts src/infra/outbound/sanitize-text.test.ts`: passed.
- Focused type-aware Oxlint with `config/tsconfig/oxlint.core.json`: passed.
- `pnpm tsgo`: passed.
- `pnpm check:test-types`: passed.
- `git diff --check`: passed.
- Required `openclaw/ci-gate`: passed on exact-head run `31891943838`.
- Local ClawSweeper exact-head review: patch correct, 0 findings, 0 security concerns, no maintainer decision, 0 Rank-up moves.

Focused test command:

```bash
pnpm test \
  src/infra/outbound/sanitize-text.test.ts \
  src/infra/outbound/markdown-details.test.ts \
  packages/markdown-core/src/code-spans.test.ts \
  src/shared/text/assistant-visible-text.test.ts \
  extensions/telegram/src/outbound-adapter.sanitize.test.ts \
  extensions/googlechat/src/channel.test.ts \
  extensions/whatsapp/src/channel-outbound.test.ts \
  extensions/irc/src/channel.test.ts
```

Hot-path check, 1,000 calls unless noted:

- 10 KB plain prose: 66.7 ms.
- 10 KB HTML without Markdown code: 118.3 ms.
- 40,000-NUL adversarial input with a protected code block: 20 calls in 169.1 ms, no throw, exact output preserved.

Production-versus-test LOC against the PR base: production `+47/-10` (net `+37`), tests `+64/-0`. The production growth adds the missing shared code-region capability and bounded placeholder owner; no adapter-specific implementations or compatibility paths were added.

## Real behavior proof

Baseline Telegram userbot proof reproduced the defect: a 119-byte reply containing inline `Array<string>`, JSX, and fenced XML was delivered as 20 bytes, with the generic erased and both code examples empty.

Final exact-head Telegram userbot proof ran the canonical mock-SUT driver against the default non-rich Telegram path:

```bash
node "$TELEGRAM_E2E_SKILL_DIR/scripts/run-mock-sut-user-e2e.mjs" \
  --text '@{sut} Return the configured inline and fenced code fixture exactly.' \
  --record '<proof>/events.ndjson' \
  --output '<proof>/summary.json' \
  --gateway-port 20079 \
  --mock-port 20082 \
  --timeout-ms 120000
```

- Runner exit: 0; scratch state removed; one `POST /v1/responses` request.
- Sent Bot API message: `48764`.
- Recorded SUT reply: `48765` at 3.327 seconds; recording complete.
- Telegram entities: two inline `code` entities for `Array<string>` and `<Button onClick={save}>`, plus one 53-byte `pre` entity with language `xml` for the complete fenced block.
- Observed text preserved all tag-shaped bytes:

````text
Inline `Array<string>` and `<Button onClick={save}>`.

```xml
<server port="8080">
  <route path="/api"/>
</server>
```
````

The older PR base does not contain the current Telegram Desktop recorder harness, so no Crabbox GIF is attached. The canonical TDLib userbot event stream, gateway log, and provider request log completed successfully.

Exact-head direct delivery proof drove the production Telegram default non-rich sanitizer and IRC direct-text sanitizer with the same 159-byte reply. Telegram returned 146 bytes and IRC returned 144 bytes. Both preserved the inline generic, JSX, and complete XML fence; the only difference was each channel's existing bold delimiter:

````text
Inline `Array<string>` and `<Button onClick={save}>`.

```xml
<server port="8080">
  <route path="/api"/>
</server>
```

Wrap **`deploy.sh`** now.
````
