### PR TITLE
fix(macos): back off approval socket retries

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -351,6 +351,7 @@ final class ExecApprovalsPromptServer {
     static let shared = ExecApprovalsPromptServer()
 
     private let retryDelay: Duration
+    private let maximumRetryDelay: Duration
     private let resolveSocketCredentials: @Sendable () -> (socketPath: String, token: String)
     private let onPrompt: @Sendable (ExecApprovalPromptRequest) async -> ExecApprovalDecision?
     private var server: ExecApprovalsSocketServer?
@@ -360,6 +361,7 @@ final class ExecApprovalsPromptServer {
 
     init(
         retryDelay: Duration = .seconds(1),
+        maximumRetryDelay: Duration = .seconds(30),
         resolveSocketCredentials: @escaping @Sendable () -> (socketPath: String, token: String) = {
             let approvals = ExecApprovalsStore.resolve(agentId: nil)
             return (approvals.socketPath, approvals.token)
@@ -371,6 +373,7 @@ final class ExecApprovalsPromptServer {
         })
     {
         self.retryDelay = retryDelay
+        self.maximumRetryDelay = maximumRetryDelay
         self.resolveSocketCredentials = resolveSocketCredentials
         self.onPrompt = onPrompt
     }
@@ -380,6 +383,7 @@ final class ExecApprovalsPromptServer {
         self.startupGeneration &+= 1
         let generation = self.startupGeneration
         let retryDelay = self.retryDelay
+        let maximumRetryDelay = self.maximumRetryDelay
         let resolveSocketCredentials = self.resolveSocketCredentials
         let onPrompt = self.onPrompt
         let previousStartupTask = self.previousStartupTask
@@ -394,12 +398,15 @@ final class ExecApprovalsPromptServer {
             guard !Task.isCancelled, self?.startupGeneration == generation else { return }
 
             var isFirstAttempt = true
+            var retryBackoff = ExecApprovalsPromptRetryBackoff(
+                initialDelay: retryDelay,
+                maximumDelay: maximumRetryDelay)
             while !Task.isCancelled {
                 if isFirstAttempt {
                     isFirstAttempt = false
                 } else {
                     do {
-                        try await Task.sleep(for: retryDelay)
+                        try await Task.sleep(for: retryBackoff.nextDelay())
                     } catch {
                         return
                     }
@@ -1178,6 +1185,24 @@ private final class ExecApprovalsSocketLifecycleLease: @unchecked Sendable {
         _ = self.processLock.withLock {
             self.reservedPaths.remove(path)
         }
+    }
+}
+
+struct ExecApprovalsPromptRetryBackoff {
+    private var currentDelay: Duration
+    private let maximumDelay: Duration
+
+    init(initialDelay: Duration, maximumDelay: Duration) {
+        self.currentDelay = initialDelay
+        self.maximumDelay = max(initialDelay, maximumDelay)
+    }
+
+    mutating func nextDelay() -> Duration {
+        let delay = self.currentDelay
+        // A second app can hold the lifecycle lease indefinitely. Back off the
+        // SQLite credential read and bind attempt instead of polling every second.
+        self.currentDelay = min(self.currentDelay * 2, self.maximumDelay)
+        return delay
     }
 }
 

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsPromptServerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsPromptServerTests.swift
@@ -80,6 +80,18 @@ struct ExecApprovalsPromptServerTests {
     }
 
     @Test
+    func `prompt server retry backoff grows exponentially and caps`() {
+        var backoff = ExecApprovalsPromptRetryBackoff(
+            initialDelay: .milliseconds(10),
+            maximumDelay: .milliseconds(40))
+
+        #expect(backoff.nextDelay() == .milliseconds(10))
+        #expect(backoff.nextDelay() == .milliseconds(20))
+        #expect(backoff.nextDelay() == .milliseconds(40))
+        #expect(backoff.nextDelay() == .milliseconds(40))
+    }
+
+    @Test
     func `prompt server reloads credentials after an unavailable approvals read`() async throws {
         let root = try self.makeShortSocketRoot()
         let socketPath = root.appendingPathComponent("exec-approvals.sock").path


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with overlapping native macOS app processes could see recurring CPU and filesystem spikes while both processes competed for the exec-approvals Unix socket.

A 15-second sample of the blocked process caught `ExecApprovalsStore.resolve(agentId:)` inside the prompt-server retry loop, while one-second process sampling observed bursts up to 9.4% CPU. The loop retried the SQLite credential read and socket bind every second indefinitely.

## Why This Change Was Made

The prompt server now applies bounded exponential backoff after startup failures: 1, 2, 4, 8, 16, then 30 seconds. The first startup attempt remains immediate, and a listener that later stops unexpectedly starts a fresh immediate recovery cycle.

The retry policy is isolated and deterministic so its growth and cap can be tested without timing-sensitive assertions.

## User Impact

Duplicate or briefly overlapping macOS app processes no longer keep reopening the approvals store and rebinding the same socket every second. Normal single-app startup and transient recovery behavior are unchanged.

## Evidence

- Profiler reproduction: competing app showed `ExecApprovalsPromptServer.start()` -> `ExecApprovalsStore.resolve(agentId:)` during recurring CPU bursts.
- `swift test --package-path apps/macos --build-path apps/macos/.build-local --filter ExecApprovalsPromptServerTests`
  - 6 tests passed, including credential reload, cancellation, transient bind failure, unexpected listener recovery, and the new exponential-cap policy.
- Full macOS Swift target compiled successfully as part of the focused test command.
- `swiftformat --lint ... --config config/swiftformat`: clean.
- `swiftlint lint --strict --config config/swiftlint.yml ...`: 0 violations.
- `git diff --check`: clean.
- Autoreview: clean, no accepted or actionable findings.

## Maintainer Decision

- Reviewed exact head `0b30b7b8fdfc4a7873d2dd84b633059c84614cf7`.
- Froze current `main` at `cdab1764841a369951c6b525719ec6e11983956a`; the clean three-way merge produced tree `ab07bf9896f43be65e11d5a1d07397cd8a6d40c3`.
- No commit since this branch's base changed either touched file, so rebasing would only churn a reviewed exact head.
- Confirmed the lifecycle invariant directly: `stop()` cancels and retires the current retry task, repeated `start()` calls cannot create a second task, and an unexpected active-listener stop calls `start()` with a fresh immediate attempt.
- ClawSweeper's optional current-main and macOS lifecycle rank-up moves are therefore satisfied against the frozen merge result.

AI-assisted: yes. The implementation, tests, and profiler evidence were reviewed and verified by the maintainer.
