### PR TITLE
docs(agents): calibrate defaults ambition and security tradeoff in Product Doctrine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,13 @@ Skills own workflows; root owns hard policy and routing. Product direction and m
 
 - Judge from the operator's chair: a competent person following the docs must end with a working, comprehensible bot. Code correctness is table stakes, not the verdict.
 - Severity order: silent failure > crash > missing feature. Every user or agent action ends in a visible outcome or a recorded, intentional non-outcome. An action that produces nothing, with nothing explaining why, is the worst bug class in this repo.
-- Defaults are the product. Most operators never change them; a regression on a default path outranks feature work and config-path bugs.
+- Defaults are the product. Most operators never change them, so the out-of-box path gets the best experience we can ship, not the most conservative one; a regression on a default path outranks feature work and config-path bugs.
 - Record facts where they happen; read them where they are needed. Answering "did X happen?" by combining several indirect signals rots as sibling paths evolve; prefer a recorded fact at the boundary that owns it.
 - The model's experience is the product. Capability that prompt/tool text does not mention — or contradicts — does not exist for users. Tool results are prompts: return what the model needs next, not a bare ack. Review prompt and description text with the same rigor as code.
 - Latency is model round-trips, not milliseconds. Collapse act-then-observe pairs into one tool result; keep expensive resources warm across a session.
 - Never dead-end the agent: failure text states what to try next; unavailable tools are hidden by gating, not left to fail; missing pieces provision automatically where safe — within the fallback rules in Architecture.
 - A capability shipped off by default needs a named enablement path (onboarding, doctor hint, preset, or docs surfacing) in the same change. Dark-shipped features are a review smell.
+- Security is a calibrated tradeoff, not a veto. Strong defaults are required; a change that protects a path by deleting the capability, or by making the normal flow unusable, is not the fix — gate it, scope it, or make the risky step explicit and operator-owned. Refusing a capability outright needs a concrete exploit path, not a hypothetical one.
 
 ## ClawSweeper Review Policy
 


### PR DESCRIPTION
## What Problem This Solves

Two judgment calls that agents and reviewers need every day were missing from the Product Doctrine an agent actually reads before triaging, reviewing, or landing.

**Defaults ambition.** The existing defaults bullet is purely defensive: it protects the default path from regressing, but never says which default to choose in the first place. That asymmetry shows up in the tree as capability shipped off by default with nobody arguing for the better out-of-box value.

**Security calibration.** `VISION.md` already frames security as "strong defaults without killing capability", but nothing in the root `AGENTS.md` judgment section carries that calibration. A reviewer working from Product Doctrine alone has no rule telling them that protecting a path by removing the feature, or by making the normal flow unusable, is not an acceptable fix — and no rule requiring a concrete exploit path before a capability is refused outright.

## Why This Change Was Made

`AGENTS.md` Product Doctrine is where per-change judgment lives; `VISION.md` owns direction. Both additions are judgment, so they belong here rather than in `VISION.md`.

Deliberately not added: a fourth restatement of "do not over-engineer". `AGENTS.md` Code already covers it ("Correct but not over-engineered", the LOC/numstat rules, and the helper-rent rule); another phrasing would dilute the ones that already carry weight.

The security rule is calibrated rather than absolute. "Never let security block a feature" would invite waving through a real hole; the rule that survives review is that refusal needs a demonstrated exploit path, and that gating, scoping, or an explicit operator-owned step is the expected shape.

## User Impact

None at runtime. Agent- and reviewer-facing guidance only: default-path changes get judged on out-of-box quality, not just on regression risk, and security-motivated capability removals need a concrete exploit path plus a look at gating alternatives first.

## Evidence

- Docs-only change, 2 insertions / 1 deletion in `AGENTS.md`.
- `git diff --check` clean.
- No scripts, config, generated files, package metadata, or runtime behavior touched, so no test/typecheck/build lane applies.
