### PR TITLE
fix(hooks): show eventless status consistently

### DIFF
--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -128,19 +128,6 @@ describe("hooks cli formatting", () => {
     expect(output).not.toContain("Internal Hooks");
   });
 
-  it("labels hooks status output", () => {
-    const output = formatHooksCheck(report, {});
-    expect(output).toContain("Hooks Status");
-  });
-
-  it("classifies eventless hooks as not ready in human check output", () => {
-    const output = formatHooksCheck(createEventlessHookReport(), {});
-
-    expect(output).toContain("Ready: 0");
-    expect(output).toContain("Not ready: 1");
-    expect(output).toContain("session-memory - no events defined");
-  });
-
   it("shows eventless hooks as blocked by their event declaration in list output", () => {
     const output = formatHooksList(createEventlessHookReport(), {});
 
@@ -156,6 +143,30 @@ describe("hooks cli formatting", () => {
     expect(output).not.toContain("missing requirements");
   });
 
+  it.each([
+    ["disabled in config", "disabled in config"],
+    ["workspace hook (disabled by default)", "workspace hook"],
+  ] as const)(
+    "does not report disabled hook policy as a missing requirement: %s",
+    (blockedReason, displayedPolicyReason) => {
+      const disabledReport: HookStatusReport = {
+        ...report,
+        hooks: [
+          {
+            ...expectDefined(report.hooks[0], "report.hooks[0] test invariant"),
+            enabledByConfig: false,
+            loadable: false,
+            blockedReason,
+          },
+        ],
+      };
+      const output = formatHooksList(disabledReport, { verbose: true });
+
+      expect(output).toContain("disabled");
+      expect(output).not.toContain(displayedPolicyReason);
+    },
+  );
+
   it("shows eventless hooks as blocked by their event declaration in info output", () => {
     const output = formatHookInfo(createEventlessHookReport(), "session-memory", {});
 
@@ -169,6 +180,19 @@ describe("hooks cli formatting", () => {
 
     expect(output).toContain("Missing requirements");
     expect(output).toContain("DEMO_HOOK_TOKEN");
+  });
+
+  it("labels hooks status output", () => {
+    const output = formatHooksCheck(report, {});
+    expect(output).toContain("Hooks Status");
+  });
+
+  it("classifies eventless hooks as not ready in human check output", () => {
+    const output = formatHooksCheck(createEventlessHookReport(), {});
+
+    expect(output).toContain("Ready: 0");
+    expect(output).toContain("Not ready: 1");
+    expect(output).toContain("session-memory - no events defined");
   });
 
   it("classifies eventless hooks as not eligible in JSON check output", () => {

--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -99,6 +99,28 @@ function createEventlessHookReport(): HookStatusReport {
   };
 }
 
+function createMissingRequirementHookReport(): HookStatusReport {
+  return {
+    ...report,
+    hooks: [
+      {
+        ...expectDefined(report.hooks[0], "report.hooks[0] test invariant"),
+        requirementsSatisfied: false,
+        loadable: false,
+        blockedReason: "missing requirements",
+        requirements: {
+          ...expectDefined(report.hooks[0], "report.hooks[0] test invariant").requirements,
+          env: ["DEMO_HOOK_TOKEN"],
+        },
+        missing: {
+          ...expectDefined(report.hooks[0], "report.hooks[0] test invariant").missing,
+          env: ["DEMO_HOOK_TOKEN"],
+        },
+      },
+    ],
+  };
+}
+
 describe("hooks cli formatting", () => {
   it("labels hooks list output", () => {
     const output = formatHooksList(report, {});
@@ -117,6 +139,36 @@ describe("hooks cli formatting", () => {
     expect(output).toContain("Ready: 0");
     expect(output).toContain("Not ready: 1");
     expect(output).toContain("session-memory - no events defined");
+  });
+
+  it("shows eventless hooks as blocked by their event declaration in list output", () => {
+    const output = formatHooksList(createEventlessHookReport(), {});
+
+    expect(output).toContain("0/1 ready");
+    expect(output).toContain("no events defined");
+    expect(output).not.toContain("missing requirements");
+  });
+
+  it("shows eventless hooks as blocked by their event declaration in verbose list output", () => {
+    const output = formatHooksList(createEventlessHookReport(), { verbose: true });
+
+    expect(output).toContain("no events defined");
+    expect(output).not.toContain("missing requirements");
+  });
+
+  it("shows eventless hooks as blocked by their event declaration in info output", () => {
+    const output = formatHookInfo(createEventlessHookReport(), "session-memory", {});
+
+    expect(output).toContain("No events defined");
+    expect(output).toContain("Blocked reason: no events defined");
+    expect(output).not.toContain("Missing requirements");
+  });
+
+  it("keeps missing requirement hooks labeled as missing requirements in info output", () => {
+    const output = formatHookInfo(createMissingRequirementHookReport(), "session-memory", {});
+
+    expect(output).toContain("Missing requirements");
+    expect(output).toContain("DEMO_HOOK_TOKEN");
   });
 
   it("classifies eventless hooks as not eligible in JSON check output", () => {

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -143,7 +143,7 @@ function formatHookSource(hook: HookStatusEntry): string {
 
 function formatHookMissingSummary(hook: HookStatusEntry): string {
   const missing: string[] = [];
-  if (hook.blockedReason && hook.blockedReason !== "missing requirements") {
+  if (hook.enabledByConfig && hook.blockedReason && hook.blockedReason !== "missing requirements") {
     missing.push(hook.blockedReason);
   }
   if (hook.missing.bins.length > 0) {

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -111,7 +111,21 @@ function formatHookStatus(hook: HookStatusEntry): string {
   if (!hook.enabledByConfig) {
     return theme.warn(decorativePrefix("⏸", "disabled"));
   }
-  return theme.error("✗ missing");
+  return theme.error(`✗ ${formatHookBlockedStatusReason(hook)}`);
+}
+
+function formatHookBlockedStatusReason(hook: HookStatusEntry): string {
+  return hook.blockedReason && hook.blockedReason !== "missing requirements"
+    ? hook.blockedReason
+    : "missing";
+}
+
+function formatHookInfoBlockedStatusReason(hook: HookStatusEntry): string {
+  const reason =
+    hook.blockedReason && hook.blockedReason !== "missing requirements"
+      ? hook.blockedReason
+      : "missing requirements";
+  return reason ? `${reason[0]?.toUpperCase() ?? ""}${reason.slice(1)}` : reason;
 }
 
 function formatHookName(hook: HookStatusEntry): string {
@@ -129,6 +143,9 @@ function formatHookSource(hook: HookStatusEntry): string {
 
 function formatHookMissingSummary(hook: HookStatusEntry): string {
   const missing: string[] = [];
+  if (hook.blockedReason && hook.blockedReason !== "missing requirements") {
+    missing.push(hook.blockedReason);
+  }
   if (hook.missing.bins.length > 0) {
     missing.push(`bins: ${hook.missing.bins.join(", ")}`);
   }
@@ -288,7 +305,7 @@ export function formatHookInfo(
     ? theme.success("✓ Ready")
     : !hook.enabledByConfig
       ? theme.warn(decorativePrefix("⏸", "Disabled"))
-      : theme.error("✗ Missing requirements");
+      : theme.error(`✗ ${formatHookInfoBlockedStatusReason(hook)}`);
 
   lines.push(`${emoji ? `${emoji} ` : ""}${theme.heading(hook.name)} ${status}`);
   lines.push("");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where eventless hooks were classified correctly by `openclaw hooks check`, but `openclaw hooks list` and `openclaw hooks info` still described the same state as a generic missing-requirements problem.

## Why This Change Was Made

The CLI now reuses the hook status `blockedReason` for human list and info output, while keeping true missing-requirement hooks labeled as missing requirements.

## User Impact

Operators see the actionable reason `no events defined` consistently across hook status commands.

## Evidence

- `pnpm test src/cli/hooks-cli.test.ts src/hooks/hooks-status.test.ts`
- Head SHA: `70decfe1ee783c9803815a8e501e31820cc313f4`
- Local preflight passed on the rebased branch against current `main`.
- GitHub checks were green before the rebase; this update refreshes exact-current-main verification.
- Real CLI base/head proof ran `pnpm openclaw hooks list` and `pnpm openclaw hooks info eventless-demo` against the same isolated hook fixture.
- Exact-head negative control ran `pnpm openclaw hooks info missing-req-demo` and kept true missing-requirement output unchanged.

```text
base list:
Hooks (0/2 ready)
| x missing | eventless-demo | Eventless proof hook | openclaw-managed |

base info:
eventless-demo x Missing requirements
  Blocked reason: no events defined

head list:
Hooks (0/2 ready)
| x no events defined | eventless-demo | Eventless proof hook | openclaw-managed |

head info:
eventless-demo x No events defined
  Blocked reason: no events defined

head negative control:
missing-req-demo x Missing requirements
  Environment: x DEMO_HOOK_TOKEN
```

Additional module-boundary proof imported `src/cli/hooks-cli.ts` directly and confirmed eventless list/info output now uses the blocked reason while missing-requirement output remains unchanged.

<details>
<summary>proof-live.ts</summary>

```ts
import { createRequire } from "node:module";
import { formatHookInfo, formatHooksList } from "./src/cli/hooks-cli.ts";
import type { HookStatusReport } from "./src/hooks/hooks-status.ts";
import { createEmptyInstallChecks } from "./src/cli/requirements-test-fixtures.ts";

const require = createRequire(import.meta.url);
require.extensions[".css"] = () => "";

const baseHook = {
  name: "session-memory",
  description: "Save session context to memory",
  source: "openclaw-bundled",
  pluginId: undefined,
  filePath: "/tmp/hooks/session-memory/HOOK.md",
  baseDir: "/tmp/hooks/session-memory",
  handlerPath: "/tmp/hooks/session-memory/handler.js",
  hookKey: "session-memory",
  emoji: undefined,
  homepage: undefined,
  events: ["command:new"],
  unknownEvents: [],
  always: false,
  enabledByConfig: true,
  requirementsSatisfied: true,
  loadable: true,
  blockedReason: undefined,
  managedByPlugin: false,
  ...createEmptyInstallChecks(),
} satisfies HookStatusReport["hooks"][number];

const eventlessReport = {
  workspaceDir: "/tmp/workspace",
  managedHooksDir: "/tmp/hooks",
  hooks: [
    {
      ...baseHook,
      events: [],
      loadable: false,
      blockedReason: "no events defined",
    },
  ],
} satisfies HookStatusReport;

const missingRequirementReport = {
  ...eventlessReport,
  hooks: [
    {
      ...baseHook,
      requirementsSatisfied: false,
      loadable: false,
      blockedReason: "missing requirements",
      requirements: { ...baseHook.requirements, env: ["DEMO_HOOK_TOKEN"] },
      missing: { ...baseHook.missing, env: ["DEMO_HOOK_TOKEN"] },
    },
  ],
} satisfies HookStatusReport;

const eventlessList = formatHooksList(eventlessReport, {});
const eventlessInfo = formatHookInfo(eventlessReport, "session-memory", {});
const missingRequirementInfo = formatHookInfo(
  missingRequirementReport,
  "session-memory",
  {},
);

console.log(
  `eventless-list-status=${eventlessList.includes("no events defined") ? "blocked-reason" : "missing"}`,
);
console.log(
  `eventless-info-status=${eventlessInfo.includes("No events defined") ? "blocked-reason" : "missing-requirements"}`,
);
console.log(
  `negative-control=${missingRequirementInfo.includes("Missing requirements") ? "missing-requirements" : "changed"}`,
);
```

</details>

AI-assisted: built with Codex
