### PR TITLE
fix(gateway-client): reset outer event sequence on reconnect

### DIFF
--- a/packages/gateway-client/src/protocol-client.event-seq.test.ts
+++ b/packages/gateway-client/src/protocol-client.event-seq.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GatewayProtocolClient,
+  type GatewayProtocolSocket,
+  type GatewayProtocolSocketHandlers,
+} from "./protocol-client.js";
+
+type SeqHarness = {
+  client: GatewayProtocolClient<Record<string, never>>;
+  createSocket: ReturnType<
+    typeof vi.fn<(handlers: GatewayProtocolSocketHandlers) => GatewayProtocolSocket>
+  >;
+  onGap: ReturnType<typeof vi.fn<(info: { expected: number; received: number }) => void>>;
+  handlers: () => GatewayProtocolSocketHandlers;
+};
+
+// Build a client whose transport is a mock socket. Each connect() captures the
+// generation's handlers so the test can drive real event frames and a real
+// close-triggered reconnect through the production message/gap path.
+function createSeqHarness(): SeqHarness {
+  let latest: GatewayProtocolSocketHandlers | null = null;
+  const onGap = vi.fn<(info: { expected: number; received: number }) => void>();
+  const createSocket = vi.fn<(handlers: GatewayProtocolSocketHandlers) => GatewayProtocolSocket>(
+    (handlers) => {
+      latest = handlers;
+      return { isOpen: () => true, send: vi.fn(), close: vi.fn() };
+    },
+  );
+  const client = new GatewayProtocolClient<Record<string, never>>({
+    createSocket,
+    createRequestId: () => "request-1",
+    buildConnectPlan: () => ({}),
+    buildConnectParams: (plan) => plan,
+    resolveClose: () => ({ retry: true, notify: true }),
+    onConnectError: vi.fn(),
+    onGap,
+    handshake: { mode: "require-challenge", timeoutMs: 100 },
+    reconnect: { initialMs: 10, multiplier: 2, maxMs: 100 },
+  });
+  return {
+    client,
+    createSocket,
+    onGap,
+    handlers: () => {
+      if (!latest) {
+        throw new Error("socket handlers not captured");
+      }
+      return latest;
+    },
+  };
+}
+
+function event(seq: number): string {
+  return JSON.stringify({ type: "event", event: "tick", seq });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("GatewayProtocolClient outer event sequence across reconnects", () => {
+  it("does not report a false gap when a new connection starts a fresh sequence", async () => {
+    vi.useFakeTimers();
+    const { client, createSocket, onGap, handlers } = createSeqHarness();
+
+    client.start();
+    // First connection reaches seq 5.
+    handlers().message(event(5));
+    expect(onGap).not.toHaveBeenCalled();
+
+    // Retire the socket; the client schedules a reconnect and opens a new one.
+    handlers().close(1006, "boom");
+    await vi.advanceTimersByTimeAsync(10);
+    expect(createSocket).toHaveBeenCalledTimes(2);
+
+    // The replacement connection's outer sequence resets on the server, so its
+    // first event is unrelated to the retired connection's seq 5.
+    handlers().message(event(7));
+
+    expect(onGap).not.toHaveBeenCalled();
+    client.stop();
+  });
+
+  it("still reports a real gap within a single connection", async () => {
+    vi.useFakeTimers();
+    const { client, onGap, handlers } = createSeqHarness();
+
+    client.start();
+    handlers().message(event(0));
+    handlers().message(event(2));
+
+    expect(onGap).toHaveBeenCalledExactlyOnceWith({ expected: 1, received: 2 });
+    client.stop();
+  });
+});

--- a/packages/gateway-client/src/protocol-client.ts
+++ b/packages/gateway-client/src/protocol-client.ts
@@ -352,6 +352,10 @@ export class GatewayProtocolClient<TPlan> {
       return;
     }
     const generation = this.generation + 1;
+    // Outer event sequence is scoped to one connection and resets when the
+    // server opens a replacement socket. Clear it here so gap detection on the
+    // new generation never compares against a retired connection's seq.
+    this.lastSeq = null;
     this.connectNonce = null;
     this.connectSent = false;
     this.connectRequestSent = false;


### PR DESCRIPTION
## What Problem This Solves

`GatewayProtocolClient` kept its outer event sequence (`lastSeq`) across WebSocket generations. The server resets outer sequence numbers per connection, so after a reconnect or gateway restart the client compared a fresh connection's events against the retired connection's sequence and raised false "event gap" errors. Per #116035 this makes the Control UI reconnect again, the TUI reload history/approvals/task suggestions, and SDK / Chrome-copilot gap handlers fire spuriously. It affects every `@openclaw/gateway-client` consumer.

## Why This Change Was Made

`connect()` already resets every other per-connection field (`connectNonce`, `connectSent`, `connectRequestSent`, `socketOpened`, `helloReceived`, `connectFailure`) when it opens a new socket generation — but not `lastSeq`. Clearing it there matches the documented per-connection contract and the iOS client (`GatewayChannel.swift`), which already resets its sequence per connection. `protocol-client.ts` is the single owner of the outer-event sequence; `onGap` consumers are pass-through. A prior fix (#32881) addressed the same bug in the pre-refactor files and was closed during the refactor, not rejected on design.

## User Impact

No more false "event gap detected" churn after reconnects or gateway restarts. Genuine gaps within a single connection are still detected. No protocol, server, or public API change.

## Evidence

`node scripts/run-vitest.mjs packages/gateway-client/src/protocol-client.event-seq.test.ts`

New colocated test drives the real message + reconnect path (event on generation 1 → close → the scheduled reconnect opens generation 2 → generation 2's first event).

- RED (unpatched): false `onGap({expected:6, received:7})` fired across the reconnect.
- GREEN (patched): no false gap; a companion test confirms a real in-connection gap still fires.
- Full `gateway-client` suite: 204 passed (13 files). Typecheck: `tsgo:core` + `tsgo:test:packages` exit 0.

Blast radius: 4-line source change in one file; a repo-wide grep confirms a single owner of the outer-event `lastSeq`; `onGap` consumers are unchanged.

_AI-assisted._

Closes #116035
