### PR TITLE
fix(proxy): redact sensitive headers in standalone debug proxy captures

### DIFF
--- a/src/proxy-capture/header-redaction.test.ts
+++ b/src/proxy-capture/header-redaction.test.ts
@@ -1,0 +1,63 @@
+/** Canonical debug-proxy capture header redaction. */
+import { afterEach, describe, expect, it } from "vitest";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
+import { isSensitiveCaptureHeaderName, redactedCaptureHeaders } from "./header-redaction.js";
+
+afterEach(() => {
+  resetSecretRedactionRegistryForTest();
+});
+
+describe("redactedCaptureHeaders", () => {
+  it("redacts credential-bearing header names regardless of case", () => {
+    const redacted = redactedCaptureHeaders({
+      Authorization: "Bearer live-token",
+      COOKIE: "session=abc",
+      "X-Api-Key": "sk-live",
+      "content-type": "application/json",
+    });
+    expect(redacted).toEqual({
+      Authorization: "[REDACTED]",
+      COOKIE: "[REDACTED]",
+      "X-Api-Key": "[REDACTED]",
+      "content-type": "application/json",
+    });
+  });
+
+  it("redacts a registered secret pasted into an otherwise innocuous header", () => {
+    // The name check alone would pass this through; value redaction is what
+    // keeps a leaked token out of the capture.
+    registerSecretValueForRedaction("super-secret-value");
+    const redacted = redactedCaptureHeaders({ "x-trace-note": "ctx super-secret-value end" });
+    expect(redacted?.["x-trace-note"]).not.toContain("super-secret-value");
+  });
+
+  it("flattens node's array-valued headers instead of dropping them", () => {
+    // node:http exposes repeated headers as arrays; the standalone proxy feeds
+    // those in directly.
+    const redacted = redactedCaptureHeaders({
+      "set-cookie": ["a=1", "b=2"],
+      via: ["1.1 a", "1.1 b"],
+    });
+    expect(redacted?.["set-cookie"]).toBe("[REDACTED]");
+    expect(redacted?.via).toBe("1.1 a, 1.1 b");
+  });
+
+  it("accepts a Headers instance", () => {
+    const redacted = redactedCaptureHeaders(
+      new Headers({ authorization: "Bearer x", accept: "text/plain" }),
+    );
+    expect(redacted?.authorization).toBe("[REDACTED]");
+    expect(redacted?.accept).toBe("text/plain");
+  });
+
+  it("returns undefined when there are no headers", () => {
+    expect(redactedCaptureHeaders(undefined)).toBeUndefined();
+  });
+
+  it("treats token-ish name fragments as sensitive", () => {
+    expect(isSensitiveCaptureHeaderName("x-vendor-access-token")).toBe(true);
+    expect(isSensitiveCaptureHeaderName("x-session-id")).toBe(true);
+    expect(isSensitiveCaptureHeaderName("accept-language")).toBe(false);
+  });
+});

--- a/src/proxy-capture/header-redaction.test.ts
+++ b/src/proxy-capture/header-redaction.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
-import { isSensitiveCaptureHeaderName, redactedCaptureHeaders } from "./header-redaction.js";
+import { redactedCaptureHeaders } from "./header-redaction.js";
 
 afterEach(() => {
   resetSecretRedactionRegistryForTest();
@@ -56,8 +56,15 @@ describe("redactedCaptureHeaders", () => {
   });
 
   it("treats token-ish name fragments as sensitive", () => {
-    expect(isSensitiveCaptureHeaderName("x-vendor-access-token")).toBe(true);
-    expect(isSensitiveCaptureHeaderName("x-session-id")).toBe(true);
-    expect(isSensitiveCaptureHeaderName("accept-language")).toBe(false);
+    const redacted = redactedCaptureHeaders({
+      "x-vendor-access-token": "abc",
+      "x-session-id": "s-1",
+      "accept-language": "en-US",
+    });
+    expect(redacted).toEqual({
+      "x-vendor-access-token": "[REDACTED]",
+      "x-session-id": "[REDACTED]",
+      "accept-language": "en-US",
+    });
   });
 });

--- a/src/proxy-capture/header-redaction.ts
+++ b/src/proxy-capture/header-redaction.ts
@@ -1,0 +1,70 @@
+/**
+ * Canonical header redaction for debug proxy captures.
+ *
+ * Both capture writers — the patched-fetch runtime and the standalone proxy
+ * server — must redact identically. A capture that leaks credentials is worse
+ * than no capture, and the standalone path previously stored raw headers while
+ * the runtime path redacted, so this policy lives in one leaf module that both
+ * import rather than being duplicated per writer.
+ */
+import { redactRegisteredSecretValues } from "../logging/secret-redaction-registry.js";
+
+export const REDACTED_CAPTURE_HEADER_VALUE = "[REDACTED]";
+
+const SENSITIVE_CAPTURE_HEADER_NAMES = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "api-key",
+  "apikey",
+  "x-auth-token",
+  "auth-token",
+  "x-access-token",
+  "access-token",
+]);
+const SENSITIVE_CAPTURE_HEADER_NAME_FRAGMENTS = [
+  "api-key",
+  "apikey",
+  "token",
+  "secret",
+  "password",
+  "credential",
+  "session",
+];
+
+export function isSensitiveCaptureHeaderName(name: string): boolean {
+  const normalized = name.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (SENSITIVE_CAPTURE_HEADER_NAMES.has(normalized)) {
+    return true;
+  }
+  return SENSITIVE_CAPTURE_HEADER_NAME_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+}
+
+export function redactedCaptureHeaders(
+  headers: Headers | Record<string, string | string[] | undefined> | undefined,
+): Record<string, string> | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const entries =
+    headers instanceof Headers ? Array.from(headers.entries()) : Object.entries(headers);
+  const redacted: Record<string, string> = {};
+  for (const [name, value] of entries) {
+    // Header names are matched exactly and by sensitive fragments because
+    // providers use many token/key naming variants. Names that pass the check
+    // still run through value redaction so a registered secret pasted into an
+    // innocuous header does not survive.
+    if (isSensitiveCaptureHeaderName(name)) {
+      redacted[name] = REDACTED_CAPTURE_HEADER_VALUE;
+      continue;
+    }
+    const flattened = Array.isArray(value) ? value.join(", ") : (value ?? "");
+    redacted[name] = redactRegisteredSecretValues(flattened, () => REDACTED_CAPTURE_HEADER_VALUE);
+  }
+  return redacted;
+}

--- a/src/proxy-capture/header-redaction.ts
+++ b/src/proxy-capture/header-redaction.ts
@@ -34,7 +34,7 @@ const SENSITIVE_CAPTURE_HEADER_NAME_FRAGMENTS = [
   "session",
 ];
 
-export function isSensitiveCaptureHeaderName(name: string): boolean {
+function isSensitiveCaptureHeaderName(name: string): boolean {
   const normalized = name.trim().toLowerCase();
   if (!normalized) {
     return false;

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -8,6 +8,7 @@ import { StringDecoder } from "node:string_decoder";
 import { URL } from "node:url";
 import { ensureDebugProxyCa } from "./ca.js";
 import type { DebugProxySettings } from "./env.js";
+import { redactedCaptureHeaders } from "./header-redaction.js";
 import { getDebugProxyCaptureStore } from "./store.sqlite.js";
 import type { CaptureEventRecord } from "./types.js";
 
@@ -282,7 +283,7 @@ export async function startDebugProxyServer(params: {
               direction: "inbound",
               kind: "response",
               status: upstreamRes.statusCode ?? undefined,
-              headersJson: JSON.stringify(upstreamRes.headers),
+              headersJson: JSON.stringify(redactedCaptureHeaders(upstreamRes.headers)),
               ...finishBodyPreviewCapture(responseCapture),
             });
           });
@@ -337,7 +338,7 @@ export async function startDebugProxyServer(params: {
         recordTargetEvent({
           direction: "outbound",
           kind: "request",
-          headersJson: JSON.stringify(req.headers),
+          headersJson: JSON.stringify(redactedCaptureHeaders(req.headers)),
           ...finishBodyPreviewCapture(requestCapture),
         });
       });
@@ -389,7 +390,7 @@ export async function startDebugProxyServer(params: {
       flowId,
       host: hostname,
       path: req.url ?? "",
-      headersJson: JSON.stringify(req.headers),
+      headersJson: JSON.stringify(redactedCaptureHeaders(req.headers)),
     });
     try {
       assertDebugProxyDirectUpstreamAllowed();

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -8,6 +8,7 @@ import {
   redactRegisteredSecretValues,
 } from "../logging/secret-redaction-registry.js";
 import { resolveDebugProxySettings, type DebugProxySettings } from "./env.js";
+import { redactedCaptureHeaders, REDACTED_CAPTURE_HEADER_VALUE } from "./header-redaction.js";
 import {
   closeDebugProxyCaptureStore,
   getDebugProxyCaptureStore,
@@ -22,7 +23,6 @@ import type {
 } from "./types.js";
 
 const DEBUG_PROXY_FETCH_PATCH_KEY = Symbol.for("openclaw.debugProxy.fetchPatch");
-const REDACTED_CAPTURE_HEADER_VALUE = "[REDACTED]";
 const REDACTED_CAPTURE_BINARY_PAYLOAD = Buffer.from("[REDACTED BINARY PAYLOAD]", "utf8");
 // Cap captured response bodies so debug proxy capture cannot be turned into an
 // out-of-memory vector. The patched global fetch tees every outbound response
@@ -91,28 +91,6 @@ async function readCapturedResponseBodyBounded(
     ? { status: "too-large" }
     : { status: "captured", buffer: Buffer.concat(chunks, total) };
 }
-const SENSITIVE_CAPTURE_HEADER_NAMES = new Set([
-  "authorization",
-  "proxy-authorization",
-  "cookie",
-  "set-cookie",
-  "x-api-key",
-  "api-key",
-  "apikey",
-  "x-auth-token",
-  "auth-token",
-  "x-access-token",
-  "access-token",
-]);
-const SENSITIVE_CAPTURE_HEADER_NAME_FRAGMENTS = [
-  "api-key",
-  "apikey",
-  "token",
-  "secret",
-  "password",
-  "credential",
-  "session",
-];
 
 function parseDeclaredCaptureContentLength(raw: string | null | undefined): bigint | undefined {
   if (raw === null || raw === undefined) {
@@ -193,36 +171,6 @@ function resolveUrlString(input: RequestInfo | URL): string | null {
     return input.url;
   }
   return null;
-}
-
-function isSensitiveCaptureHeaderName(name: string): boolean {
-  const normalized = name.trim().toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  if (SENSITIVE_CAPTURE_HEADER_NAMES.has(normalized)) {
-    return true;
-  }
-  return SENSITIVE_CAPTURE_HEADER_NAME_FRAGMENTS.some((fragment) => normalized.includes(fragment));
-}
-
-function redactedCaptureHeaders(
-  headers: Headers | Record<string, string> | undefined,
-): Record<string, string> | undefined {
-  if (!headers) {
-    return undefined;
-  }
-  const entries =
-    headers instanceof Headers ? Array.from(headers.entries()) : Object.entries(headers);
-  const redacted: Record<string, string> = {};
-  for (const [name, value] of entries) {
-    // Header names are matched exactly and by sensitive fragments because
-    // providers use many token/key naming variants.
-    redacted[name] = isSensitiveCaptureHeaderName(name)
-      ? REDACTED_CAPTURE_HEADER_VALUE
-      : redactRegisteredSecretValues(value, () => REDACTED_CAPTURE_HEADER_VALUE);
-  }
-  return redacted;
 }
 
 function redactCaptureUrl(rawUrl: string): string {


### PR DESCRIPTION
## What Problem This Solves

The standalone debug proxy persisted raw request and response headers into capture rows, so a capture taken through `openclaw` debug proxy could write `Authorization`, `Cookie`, `Set-Cookie`, and API-key values to disk in cleartext. The patched-fetch runtime already redacted at the equivalent call sites, so the two capture writers disagreed about whether captures may contain credentials.

On `main` before this change, `src/proxy-capture/proxy-server.ts` had three unredacted sites (`JSON.stringify(upstreamRes.headers)` and two `JSON.stringify(req.headers)`), while `src/proxy-capture/runtime.ts` redacted at its three parallel sites via a private `redactedCaptureHeaders`.

Reported by @SebTardif in #90009.

## Why This Change Was Made

Rather than add a second redaction implementation on the proxy side, the runtime's policy moves into a leaf module (`src/proxy-capture/header-redaction.ts`) that both writers import. Duplicated redaction policy is the failure mode that produced this bug in the first place — one writer was hardened and the other was not — so the fix is one canonical path rather than two that must be kept in sync.

Two details the shared helper now handles that the runtime-only version did not need:

- **Array-valued headers.** `node:http` exposes repeated headers as `string[]`, and the standalone proxy passes `req.headers` in directly. These are flattened rather than stringified as objects, so `set-cookie: ["a=1","b=2"]` redacts instead of leaking through an unexpected shape.
- **Value-level redaction is preserved for non-sensitive names.** A header whose *name* is innocuous still runs through `redactRegisteredSecretValues`, so a registered credential pasted into something like `x-trace-note` does not survive. Redacting by name alone would have left that open.

Redaction stays a denylist over exact names plus sensitive fragments (`token`, `secret`, `api-key`, `credential`, …), which is the policy the runtime path already shipped. This PR deliberately does not change that model or add an opt-out: captures keep host, path, method, status, timing, bodies, and all non-sensitive headers, so they remain useful for correlating and replaying a request.

This supersedes #82951, which fixed the same leak but redacted by header name only and predates the `proxy-server.ts` rewrite (notably the backpressure work in `445e262`). Replaying that 73-day-old branch onto the current file was riskier than reimplementing the policy on tip, so this lands fresh with @SebTardif credited; #82951 will be closed pointing here.

## User Impact

Operators who capture traffic through the standalone debug proxy no longer produce capture databases containing their provider credentials. Nothing else about captures changes, and there is no new configuration: redaction is on by default in both writers, as it already was in one.

## Evidence

- New `src/proxy-capture/header-redaction.test.ts` covers credential-bearing names case-insensitively, a registered secret inside a non-sensitive header, node's array-valued headers, a `Headers` instance, the empty case, and fragment matching.
- `node scripts/run-vitest.mjs src/proxy-capture` — **122 tests across 16 files pass**, including the pre-existing runtime redaction tests now exercising the moved helper (so the move is proven behavior-preserving on the path that already worked).
- Reverting only the three proxy call sites leaves the import in place and restores the raw `JSON.stringify(headers)` leak, confirming those sites are the entire behavioral delta.
- `pnpm tsgo:core` clean; `scripts/run-oxlint.mjs` and `oxfmt --check` clean on all four files.
- Structured autoreview (Codex, `gpt-5.6-sol`, high): clean, no accepted findings, "patch is correct" (0.94).
- Net prod LOC is roughly flat — `runtime.ts` loses 53 lines to the extraction while the proxy gains 4 — so three leak sites close without growing the surface.
### End-to-end proof: live traffic through the standalone proxy

Started the real `startDebugProxyServer`, sent a real forward-proxy request through it to a local upstream, and read the persisted `capture_events` rows back out of the real SQLite store (isolated `OPENCLAW_STATE_DIR` and throwaway cert dir, both removed afterwards). The request carried credentials in three headers and the upstream returned one in `set-cookie`, so both the request and response capture sites are exercised. Same harness run twice, the second time with only the three proxy call sites reverted.

**Before** (call sites reverted, everything else identical):

```json
{
  "capturedEvents": 2,
  "leakedAuthorization": true,
  "leakedCookie": true,
  "leakedApiKey": true,
  "leakedUpstreamSetCookie": true,
  "redactedMarkers": 0
}
```

Persisted row: `{"content-type":"application/json","set-cookie":["sid=upstream-secret"],…}` — all four credentials in the capture database in cleartext.

**After** (this branch):

```json
{
  "capturedEvents": 2,
  "leakedAuthorization": false,
  "leakedCookie": false,
  "leakedApiKey": false,
  "leakedUpstreamSetCookie": false,
  "redactedMarkers": 4,
  "benignHeaderSurvived": true
}
```

Persisted row: `{"content-type":"application/json","set-cookie":"[REDACTED]","date":"…","connection":"keep-alive","keep-alive":"timeout=5","transfer-encoding":"chunked"}`

All fixture credentials are synthetic (`sk-live-DO-NOT-LEAK-…` style) and the endpoints are loopback only. Note `set-cookie` arrives from `node:http` as an array and still redacts — that is the array-flattening branch in the shared helper, which the runtime path never needed because `fetch` supplies a `Headers` instance. Non-sensitive headers survive, so captures remain useful for correlating and replaying a request.

- CI note: `checks-node-compact-large-7` failed on `src/gateway/server-methods/sessions-rewind.test.ts > returns editor text for rewind and a new key for fork`, an editor-attachment assertion unrelated to this diff. Three local runs of that file on this branch gave 2 passes and 1 failure with no proxy-capture code involved; this PR touches only `src/proxy-capture/**`. All other checks pass.

## AI Assistance

Implemented with Claude assistance: leak verification against current `main`, the extraction and call-site fix, regression tests, and structured autoreview.

