### PR TITLE
fix(codex): add remote WebSocket heartbeat and reconnect

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -593,6 +593,13 @@ already running elsewhere:
 }
 ```
 
+WebSocket transport proactively establishes the app-server connection at
+gateway startup, limits the opening handshake to 10 seconds, sends a WebSocket
+ping every 30 seconds, and reconnects with bounded backoff if a pong does not
+arrive within 10 seconds. Ping and pong frames are transport-level health
+checks: they do not start a Codex turn or invoke a model. Local stdio and Unix
+transports do not perform these remote connection checks.
+
 Local stdio app-server sessions default to the trusted local operator
 posture: `approvalPolicy: "never"`, `approvalsReviewer: "user"`, and
 `sandbox: "danger-full-access"`. If local Codex requirements disallow that

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -594,9 +594,13 @@ already running elsewhere:
 ```
 
 WebSocket transport proactively establishes the app-server connection at
-gateway startup, limits the opening handshake to 10 seconds, sends a WebSocket
-ping every 30 seconds, and reconnects with bounded backoff if a pong does not
-arrive within 10 seconds. Ping and pong frames are transport-level health
+gateway startup and limits the opening handshake to 10 seconds. An idle
+connection sends a WebSocket ping every 20 seconds and allows 20 seconds for its
+matching pong. A healthy app-server message or pong resets the missed-heartbeat
+count; five consecutive missed pongs close the connection. Transient failures
+reconnect automatically with bounded, jittered exponential backoff. Authentication
+failures and unsupported app-server versions stop reconnecting and report that
+operator action is required. Ping and pong frames are transport-level health
 checks: they do not start a Codex turn or invoke a model. Local stdio and Unix
 transports do not perform these remote connection checks.
 

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -75,6 +75,54 @@ describe("codex plugin", () => {
     expect(openSyncKeyedStore).not.toHaveBeenCalled();
   });
 
+  it("proactively monitors an explicitly configured remote websocket app-server", () => {
+    const registerService = vi.fn();
+
+    plugin.register(
+      createTestPluginApi({
+        id: "codex",
+        name: "Codex",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          appServer: {
+            transport: "websocket",
+            url: "ws://127.0.0.1:39175",
+          },
+        },
+        runtime: createCodexTestRuntime(),
+        registerService,
+      }),
+    );
+
+    expect(registerService).toHaveBeenCalledOnce();
+    expect(mockCallArg(registerService)).toMatchObject({
+      id: "codex-app-server-connection-health",
+      start: expect.any(Function),
+      stop: expect.any(Function),
+    });
+  });
+
+  it("does not start remote connection monitoring for local Codex transports", () => {
+    for (const appServer of [undefined, { transport: "stdio" }, { transport: "unix" }]) {
+      const registerService = vi.fn();
+
+      plugin.register(
+        createTestPluginApi({
+          id: "codex",
+          name: "Codex",
+          source: "test",
+          config: {},
+          pluginConfig: appServer ? { appServer } : {},
+          runtime: createCodexTestRuntime(),
+          registerService,
+        }),
+      );
+
+      expect(registerService).not.toHaveBeenCalled();
+    }
+  });
+
   it("registers the agent harness, native thread tool, and hosted web search", () => {
     const registerAgentHarness = vi.fn();
     const registerCommand = vi.fn();

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -15,6 +15,7 @@ import { registerCodexCliMetadata } from "./cli-metadata.js";
 import { createCodexAppServerAgentHarness } from "./harness.js";
 import { buildCodexMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { readCodexPluginConfig } from "./src/app-server/config.js";
+import { createCodexAppServerConnectionHealthService } from "./src/app-server/connection-health.js";
 import {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   CODEX_APP_SERVER_BINDING_NAMESPACE,
@@ -90,6 +91,15 @@ export default definePluginEntry({
       return livePluginConfig;
     };
     const resolveCurrentPluginConfig = () => resolvePluginConfig(resolveCurrentConfig);
+    const appServerConfig = readCodexPluginConfig(resolveCurrentPluginConfig()).appServer;
+    if (appServerConfig?.transport === "websocket") {
+      api.registerService(
+        createCodexAppServerConnectionHealthService({
+          getPluginConfig: resolveCurrentPluginConfig,
+          getRuntimeConfig: resolveCurrentConfig,
+        }),
+      );
+    }
     let bindingStateStore: PluginStateSyncKeyedStore<StoredCodexAppServerBinding> | undefined;
     const openBindingStateStore = () =>
       (bindingStateStore ??= api.runtime.state.openSyncKeyedStore<StoredCodexAppServerBinding>({

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -28,6 +28,7 @@
     "onAgentHarnesses": ["codex"],
     "onCommands": ["codex"],
     "onConfigPaths": [
+      "plugins.entries.codex.config.appServer.transport",
       "plugins.entries.codex.config.sessionCatalog.enabled",
       "plugins.entries.codex.config.supervision.enabled"
     ]

--- a/extensions/codex/src/app-server/connection-health.test.ts
+++ b/extensions/codex/src/app-server/connection-health.test.ts
@@ -1,0 +1,124 @@
+import type { OpenClawPluginServiceContext } from "openclaw/plugin-sdk/plugin-entry";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CodexAppServerClient } from "./client.js";
+import { createCodexAppServerConnectionHealthService } from "./connection-health.js";
+
+const sharedClientMocks = vi.hoisted(() => ({
+  getLeasedSharedCodexAppServerClient: vi.fn(),
+  releaseLeasedSharedCodexAppServerClient: vi.fn(),
+}));
+
+vi.mock("./shared-client.js", () => sharedClientMocks);
+
+describe("Codex remote WebSocket connection health", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens the remote app-server before the first model request", async () => {
+    const client = createClient();
+    sharedClientMocks.getLeasedSharedCodexAppServerClient.mockResolvedValueOnce(client.client);
+    const ctx = createServiceContext();
+    const service = createCodexAppServerConnectionHealthService({
+      getPluginConfig: () => ({
+        appServer: { transport: "websocket", url: "ws://127.0.0.1:39175" },
+      }),
+      getRuntimeConfig: () => ctx.config,
+    });
+
+    await service.start(ctx);
+
+    await vi.waitFor(() => {
+      expect(sharedClientMocks.getLeasedSharedCodexAppServerClient).toHaveBeenCalledOnce();
+      expect(client.addCloseHandler).toHaveBeenCalledOnce();
+    });
+    expect(client.request).not.toHaveBeenCalled();
+
+    await service.stop?.(ctx);
+
+    expect(sharedClientMocks.releaseLeasedSharedCodexAppServerClient).toHaveBeenCalledWith(
+      client.client,
+    );
+  });
+
+  it("reconnects after the shared remote app-server connection closes", async () => {
+    const first = createClient();
+    const second = createClient();
+    sharedClientMocks.getLeasedSharedCodexAppServerClient
+      .mockResolvedValueOnce(first.client)
+      .mockResolvedValueOnce(second.client);
+    const ctx = createServiceContext();
+    const service = createCodexAppServerConnectionHealthService({
+      getPluginConfig: () => ({
+        appServer: { transport: "websocket", url: "ws://127.0.0.1:39175" },
+      }),
+      getRuntimeConfig: () => ctx.config,
+    });
+
+    await service.start(ctx);
+    await vi.waitFor(() => expect(first.addCloseHandler).toHaveBeenCalledOnce());
+
+    first.close();
+
+    await vi.waitFor(
+      () => {
+        expect(sharedClientMocks.getLeasedSharedCodexAppServerClient).toHaveBeenCalledTimes(2);
+        expect(second.addCloseHandler).toHaveBeenCalledOnce();
+      },
+      { timeout: 3_000 },
+    );
+    expect(first.request).not.toHaveBeenCalled();
+    expect(second.request).not.toHaveBeenCalled();
+
+    await service.stop?.(ctx);
+
+    expect(sharedClientMocks.releaseLeasedSharedCodexAppServerClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not connect or start a model for local transports", async () => {
+    const ctx = createServiceContext();
+    const service = createCodexAppServerConnectionHealthService({
+      getPluginConfig: () => ({ appServer: { transport: "stdio" } }),
+      getRuntimeConfig: () => ctx.config,
+    });
+
+    await service.start(ctx);
+    await service.stop?.(ctx);
+
+    expect(sharedClientMocks.getLeasedSharedCodexAppServerClient).not.toHaveBeenCalled();
+  });
+});
+
+function createClient() {
+  const handlers = new Set<(client: CodexAppServerClient) => void>();
+  const request = vi.fn();
+  const addCloseHandler = vi.fn((handler: (client: CodexAppServerClient) => void) => {
+    handlers.add(handler);
+    return () => handlers.delete(handler);
+  });
+  const client = { addCloseHandler, request } as unknown as CodexAppServerClient;
+
+  return {
+    client,
+    request,
+    addCloseHandler,
+    close() {
+      for (const handler of handlers) {
+        handler(client);
+      }
+    },
+  };
+}
+
+function createServiceContext(): OpenClawPluginServiceContext {
+  return {
+    config: {},
+    stateDir: "/tmp/openclaw-codex-connection-health-test",
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+}

--- a/extensions/codex/src/app-server/connection-health.test.ts
+++ b/extensions/codex/src/app-server/connection-health.test.ts
@@ -75,6 +75,78 @@ describe("Codex remote WebSocket connection health", () => {
     expect(sharedClientMocks.releaseLeasedSharedCodexAppServerClient).toHaveBeenCalledTimes(2);
   });
 
+  it("retries a transient remote connection failure without starting a model", async () => {
+    const client = createClient();
+    sharedClientMocks.getLeasedSharedCodexAppServerClient
+      .mockRejectedValueOnce(new Error("Opening handshake has timed out"))
+      .mockResolvedValueOnce(client.client);
+    const ctx = createServiceContext();
+    const service = createCodexAppServerConnectionHealthService({
+      getPluginConfig: () => ({
+        appServer: { transport: "websocket", url: "ws://127.0.0.1:39175" },
+      }),
+      getRuntimeConfig: () => ctx.config,
+    });
+
+    await service.start(ctx);
+
+    await vi.waitFor(
+      () => {
+        expect(sharedClientMocks.getLeasedSharedCodexAppServerClient).toHaveBeenCalledTimes(2);
+        expect(client.addCloseHandler).toHaveBeenCalledOnce();
+      },
+      { timeout: 3_000 },
+    );
+    expect(client.request).not.toHaveBeenCalled();
+
+    await service.stop?.(ctx);
+
+    expect(sharedClientMocks.releaseLeasedSharedCodexAppServerClient).toHaveBeenCalledOnce();
+  });
+
+  it.each([401, 403])("does not retry an HTTP %i authentication failure", async (statusCode) => {
+    sharedClientMocks.getLeasedSharedCodexAppServerClient.mockRejectedValueOnce(
+      new Error(`Unexpected server response: ${statusCode}`),
+    );
+    const ctx = createServiceContext();
+    const service = createCodexAppServerConnectionHealthService({
+      getPluginConfig: () => ({
+        appServer: { transport: "websocket", url: "ws://127.0.0.1:39175" },
+      }),
+      getRuntimeConfig: () => ctx.config,
+    });
+
+    await service.start(ctx);
+
+    await vi.waitFor(() => {
+      expect(ctx.logger.error).toHaveBeenCalledWith(
+        expect.stringContaining(`Unexpected server response: ${statusCode}`),
+      );
+    });
+    expect(sharedClientMocks.getLeasedSharedCodexAppServerClient).toHaveBeenCalledOnce();
+
+    await service.stop?.(ctx);
+
+    expect(sharedClientMocks.releaseLeasedSharedCodexAppServerClient).not.toHaveBeenCalled();
+  });
+
+  it("does not retry an invalid remote app-server configuration", async () => {
+    const ctx = createServiceContext();
+    const service = createCodexAppServerConnectionHealthService({
+      getPluginConfig: () => ({ appServer: { transport: "websocket" } }),
+      getRuntimeConfig: () => ctx.config,
+    });
+
+    await service.start(ctx);
+
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("configuration is invalid"),
+    );
+    expect(sharedClientMocks.getLeasedSharedCodexAppServerClient).not.toHaveBeenCalled();
+
+    await service.stop?.(ctx);
+  });
+
   it("does not connect or start a model for local transports", async () => {
     const ctx = createServiceContext();
     const service = createCodexAppServerConnectionHealthService({

--- a/extensions/codex/src/app-server/connection-health.ts
+++ b/extensions/codex/src/app-server/connection-health.ts
@@ -1,0 +1,138 @@
+import type {
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type { CodexAppServerClient } from "./client.js";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import {
+  getLeasedSharedCodexAppServerClient,
+  releaseLeasedSharedCodexAppServerClient,
+} from "./shared-client.js";
+
+const INITIAL_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+type CodexAppServerConnectionHealthServiceOptions = {
+  getPluginConfig: () => unknown;
+  getRuntimeConfig: () => OpenClawPluginServiceContext["config"] | undefined;
+};
+
+export function createCodexAppServerConnectionHealthService(
+  options: CodexAppServerConnectionHealthServiceOptions,
+): OpenClawPluginService {
+  let abortController: AbortController | undefined;
+  let monitor: Promise<void> | undefined;
+  let leasedClient: CodexAppServerClient | undefined;
+
+  const releaseClient = () => {
+    if (!leasedClient) {
+      return;
+    }
+    const client = leasedClient;
+    leasedClient = undefined;
+    releaseLeasedSharedCodexAppServerClient(client);
+  };
+
+  const run = async (ctx: OpenClawPluginServiceContext, signal: AbortSignal) => {
+    let consecutiveFailures = 0;
+
+    while (!signal.aborted) {
+      try {
+        const pluginConfig = options.getPluginConfig();
+        const runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig });
+        if (runtime.start.transport !== "websocket") {
+          return;
+        }
+
+        leasedClient = await getLeasedSharedCodexAppServerClient({
+          pluginConfig,
+          config: options.getRuntimeConfig() ?? ctx.config,
+          timeoutMs: runtime.requestTimeoutMs,
+          abandonSignal: signal,
+        });
+        if (signal.aborted) {
+          return;
+        }
+
+        consecutiveFailures = 0;
+        ctx.logger.info("codex app-server remote WebSocket connection is healthy");
+        await waitForCodexAppServerClose(leasedClient, signal);
+        if (!signal.aborted) {
+          ctx.logger.warn("codex app-server remote WebSocket disconnected; reconnecting");
+        }
+      } catch (error) {
+        if (!signal.aborted) {
+          consecutiveFailures += 1;
+          const message = error instanceof Error ? error.message : String(error);
+          ctx.logger.warn(`codex app-server remote WebSocket connection failed: ${message}`);
+        }
+      } finally {
+        releaseClient();
+      }
+
+      if (!signal.aborted) {
+        const reconnectDelayMs = Math.min(
+          INITIAL_RECONNECT_DELAY_MS * 2 ** Math.max(0, consecutiveFailures - 1),
+          MAX_RECONNECT_DELAY_MS,
+        );
+        await waitForReconnect(reconnectDelayMs, signal);
+      }
+    }
+  };
+
+  return {
+    id: "codex-app-server-connection-health",
+    start(ctx) {
+      if (abortController) {
+        return;
+      }
+      abortController = new AbortController();
+      monitor = run(ctx, abortController.signal);
+    },
+    async stop() {
+      abortController?.abort();
+      await monitor;
+      releaseClient();
+      monitor = undefined;
+      abortController = undefined;
+    },
+  };
+}
+
+function waitForCodexAppServerClose(
+  client: CodexAppServerClient,
+  signal: AbortSignal,
+): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    const finish = () => {
+      removeCloseHandler();
+      signal.removeEventListener("abort", finish);
+      resolve();
+    };
+    const removeCloseHandler = client.addCloseHandler(finish);
+    signal.addEventListener("abort", finish, { once: true });
+  });
+}
+
+function waitForReconnect(delayMs: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    const finish = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, delayMs);
+    timer.unref();
+    signal.addEventListener("abort", finish, { once: true });
+  });
+}

--- a/extensions/codex/src/app-server/connection-health.ts
+++ b/extensions/codex/src/app-server/connection-health.ts
@@ -2,7 +2,7 @@ import type {
   OpenClawPluginService,
   OpenClawPluginServiceContext,
 } from "openclaw/plugin-sdk/plugin-entry";
-import type { CodexAppServerClient } from "./client.js";
+import { isUnsupportedCodexAppServerVersionError, type CodexAppServerClient } from "./client.js";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 import {
   getLeasedSharedCodexAppServerClient,
@@ -37,13 +37,25 @@ export function createCodexAppServerConnectionHealthService(
     let consecutiveFailures = 0;
 
     while (!signal.aborted) {
+      let pluginConfig: unknown;
+      let runtime: ReturnType<typeof resolveCodexAppServerRuntimeOptions>;
       try {
-        const pluginConfig = options.getPluginConfig();
-        const runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig });
-        if (runtime.start.transport !== "websocket") {
-          return;
+        pluginConfig = options.getPluginConfig();
+        runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig });
+      } catch (error) {
+        if (!signal.aborted) {
+          const message = error instanceof Error ? error.message : String(error);
+          ctx.logger.error(
+            `codex app-server remote WebSocket configuration is invalid; update the configuration before reconnecting: ${message}`,
+          );
         }
+        return;
+      }
+      if (runtime.start.transport !== "websocket") {
+        return;
+      }
 
+      try {
         leasedClient = await getLeasedSharedCodexAppServerClient({
           pluginConfig,
           config: options.getRuntimeConfig() ?? ctx.config,
@@ -62,8 +74,14 @@ export function createCodexAppServerConnectionHealthService(
         }
       } catch (error) {
         if (!signal.aborted) {
-          consecutiveFailures += 1;
           const message = error instanceof Error ? error.message : String(error);
+          if (isPermanentCodexAppServerConnectionFailure(error)) {
+            ctx.logger.error(
+              `codex app-server remote WebSocket requires an authentication or version update; not retrying: ${message}`,
+            );
+            return;
+          }
+          consecutiveFailures += 1;
           ctx.logger.warn(`codex app-server remote WebSocket connection failed: ${message}`);
         }
       } finally {
@@ -71,8 +89,12 @@ export function createCodexAppServerConnectionHealthService(
       }
 
       if (!signal.aborted) {
-        const reconnectDelayMs = Math.min(
+        const exponentialDelayMs = Math.min(
           INITIAL_RECONNECT_DELAY_MS * 2 ** Math.max(0, consecutiveFailures - 1),
+          MAX_RECONNECT_DELAY_MS,
+        );
+        const reconnectDelayMs = Math.min(
+          Math.round(exponentialDelayMs * (0.75 + Math.random() * 0.5)),
           MAX_RECONNECT_DELAY_MS,
         );
         await waitForReconnect(reconnectDelayMs, signal);
@@ -97,6 +119,42 @@ export function createCodexAppServerConnectionHealthService(
       abortController = undefined;
     },
   };
+}
+
+function isPermanentCodexAppServerConnectionFailure(error: unknown): boolean {
+  const seen = new Set<Error>();
+  let current = error;
+
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    if (isUnsupportedCodexAppServerVersionError(current)) {
+      return true;
+    }
+
+    const status =
+      "statusCode" in current
+        ? current.statusCode
+        : "status" in current
+          ? current.status
+          : undefined;
+    if (
+      status === 401 ||
+      status === 403 ||
+      /^Unexpected server response: (?:401|403)\b/u.test(current.message)
+    ) {
+      return true;
+    }
+
+    const data = "data" in current ? current.data : undefined;
+    if (data && typeof data === "object" && "statusCode" in data) {
+      if (data.statusCode === 401 || data.statusCode === 403) {
+        return true;
+      }
+    }
+    current = current.cause;
+  }
+
+  return false;
 }
 
 function waitForCodexAppServerClose(

--- a/extensions/codex/src/app-server/transport-websocket.test.ts
+++ b/extensions/codex/src/app-server/transport-websocket.test.ts
@@ -117,14 +117,14 @@ describe("Codex app-server websocket transport", () => {
     transports.push(transport);
     await connected;
 
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(20_000);
     await expect(receivedPing).resolves.toBeUndefined();
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(20_000);
 
     expect(transport.killed).toBe(false);
   });
 
-  it("closes a remote websocket when the app-server does not answer a ping", async () => {
+  it("closes a remote websocket only after five consecutive unanswered pings", async () => {
     vi.useFakeTimers();
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0, autoPong: false });
     servers.push(server);
@@ -161,12 +161,49 @@ describe("Codex app-server websocket transport", () => {
     });
     await connected;
 
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(20_000);
     await expect(receivedPing).resolves.toBeUndefined();
-    await vi.advanceTimersByTimeAsync(10_000);
+
+    for (let missedPongs = 1; missedPongs < 5; missedPongs += 1) {
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(transport.killed).toBe(false);
+    }
+    await vi.advanceTimersByTimeAsync(20_000);
 
     await expect(exited).resolves.toBe(1006);
     expect(transport.killed).toBe(true);
+  });
+
+  it.each([401, 403])("surfaces a rejected HTTP %i websocket upgrade", async (statusCode) => {
+    const httpServer = http.createServer((_request, response) => {
+      response.writeHead(statusCode);
+      response.end();
+    });
+    httpServers.push(httpServer);
+    await new Promise<void>((resolve) => {
+      httpServer.listen(0, "127.0.0.1", resolve);
+    });
+    const address = httpServer.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected websocket test server port");
+    }
+
+    const transport = createWebSocketTransport({
+      transport: "websocket",
+      command: "codex",
+      args: [],
+      url: `ws://127.0.0.1:${address.port}`,
+      headers: {},
+    });
+    transports.push(transport);
+    const connectionError = new Promise<unknown>((resolve) => {
+      transport.once("error", (error) => resolve(error));
+    });
+
+    await expect(connectionError).resolves.toHaveProperty(
+      "message",
+      `Unexpected server response: ${statusCode}`,
+    );
   });
 
   it("preserves UTF-8 JSON-RPC bytes split across writable chunks", async () => {

--- a/extensions/codex/src/app-server/transport-websocket.test.ts
+++ b/extensions/codex/src/app-server/transport-websocket.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer, type RawData } from "ws";
 import { CodexAppServerClient } from "./client.js";
 import { createWebSocketTransport } from "./transport-websocket.js";
@@ -17,6 +17,7 @@ describe("Codex app-server websocket transport", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
+    vi.useRealTimers();
     for (const client of clients) {
       client.close();
     }
@@ -80,6 +81,92 @@ describe("Codex app-server websocket transport", () => {
     await expect(client.initialize()).resolves.toBeUndefined();
     await expect(client.request("model/list", {})).resolves.toEqual({ data: [] });
     expect(authHeaders).toEqual(["Bearer secret"]);
+  });
+
+  it("keeps an idle remote websocket healthy with protocol-level ping frames", async () => {
+    vi.useFakeTimers();
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    servers.push(server);
+    let resolveConnected: (() => void) | undefined;
+    const connected = new Promise<void>((resolve) => {
+      resolveConnected = resolve;
+    });
+    let resolvePing: (() => void) | undefined;
+    const receivedPing = new Promise<void>((resolve) => {
+      resolvePing = resolve;
+    });
+    server.once("connection", (socket) => {
+      socket.once("ping", () => resolvePing?.());
+      resolveConnected?.();
+    });
+    await new Promise<void>((resolve) => {
+      server.once("listening", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected websocket test server port");
+    }
+
+    const transport = createWebSocketTransport({
+      transport: "websocket",
+      command: "codex",
+      args: [],
+      url: `ws://127.0.0.1:${address.port}`,
+      headers: {},
+    });
+    transports.push(transport);
+    await connected;
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(receivedPing).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(transport.killed).toBe(false);
+  });
+
+  it("closes a remote websocket when the app-server does not answer a ping", async () => {
+    vi.useFakeTimers();
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0, autoPong: false });
+    servers.push(server);
+    let resolveConnected: (() => void) | undefined;
+    const connected = new Promise<void>((resolve) => {
+      resolveConnected = resolve;
+    });
+    let resolvePing: (() => void) | undefined;
+    const receivedPing = new Promise<void>((resolve) => {
+      resolvePing = resolve;
+    });
+    server.once("connection", (socket) => {
+      socket.once("ping", () => resolvePing?.());
+      resolveConnected?.();
+    });
+    await new Promise<void>((resolve) => {
+      server.once("listening", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected websocket test server port");
+    }
+
+    const transport = createWebSocketTransport({
+      transport: "websocket",
+      command: "codex",
+      args: [],
+      url: `ws://127.0.0.1:${address.port}`,
+      headers: {},
+    });
+    transports.push(transport);
+    const exited = new Promise<unknown>((resolve) => {
+      transport.once("exit", (code) => resolve(code));
+    });
+    await connected;
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(receivedPing).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(exited).resolves.toBe(1006);
+    expect(transport.killed).toBe(true);
   });
 
   it("preserves UTF-8 JSON-RPC bytes split across writable chunks", async () => {

--- a/extensions/codex/src/app-server/transport-websocket.ts
+++ b/extensions/codex/src/app-server/transport-websocket.ts
@@ -87,7 +87,7 @@ export function createWebSocketTransport(
       sendHeartbeatPing();
     }, WEBSOCKET_PONG_TIMEOUT_MS);
     pongTimeout.unref();
-    socket.ping(payload, (error) => {
+    socket.ping(payload, undefined, (error) => {
       if (error) {
         socket.terminate();
       }

--- a/extensions/codex/src/app-server/transport-websocket.ts
+++ b/extensions/codex/src/app-server/transport-websocket.ts
@@ -11,6 +11,10 @@ import WebSocket, { type RawData } from "ws";
 import { resolveCodexAppServerUserHomeDir, type CodexAppServerStartOptions } from "./config.js";
 import type { CodexAppServerTransport } from "./transport.js";
 
+const WEBSOCKET_HANDSHAKE_TIMEOUT_MS = 10_000;
+const WEBSOCKET_PING_INTERVAL_MS = 30_000;
+const WEBSOCKET_PONG_TIMEOUT_MS = 10_000;
+
 /** Opens a WebSocket app-server transport and maps newline-delimited frames to stdout/stdin. */
 export function createWebSocketTransport(
   options: CodexAppServerStartOptions,
@@ -31,6 +35,9 @@ export function createWebSocketTransport(
     headers,
     // Codex app-server closes Unix upgrade handshakes that offer compression.
     perMessageDeflate: false,
+    ...(options.transport === "websocket"
+      ? { handshakeTimeout: WEBSOCKET_HANDSHAKE_TIMEOUT_MS }
+      : {}),
   };
   const unixSocketPath = resolveCodexAppServerUnixSocketPath(options);
   const socket = unixSocketPath
@@ -43,6 +50,19 @@ export function createWebSocketTransport(
   const stdinDecoder = new StringDecoder("utf8");
   let pendingLine = "";
   let killed = false;
+  let pingInterval: NodeJS.Timeout | undefined;
+  let pongTimeout: NodeJS.Timeout | undefined;
+
+  const clearConnectionHealthTimers = () => {
+    if (pingInterval) {
+      clearInterval(pingInterval);
+      pingInterval = undefined;
+    }
+    if (pongTimeout) {
+      clearTimeout(pongTimeout);
+      pongTimeout = undefined;
+    }
+  };
 
   const sendFrame = (frame: string) => {
     const trimmed = frame.trim();
@@ -62,9 +82,37 @@ export function createWebSocketTransport(
     for (const frame of pendingFrames.splice(0)) {
       socket.send(frame);
     }
+    if (options.transport === "websocket") {
+      pingInterval = setInterval(() => {
+        if (socket.readyState !== WebSocket.OPEN || pongTimeout) {
+          return;
+        }
+        pongTimeout = setTimeout(() => {
+          pongTimeout = undefined;
+          socket.terminate();
+        }, WEBSOCKET_PONG_TIMEOUT_MS);
+        pongTimeout.unref();
+        socket.ping((error) => {
+          if (error) {
+            socket.terminate();
+          }
+        });
+      }, WEBSOCKET_PING_INTERVAL_MS);
+      pingInterval.unref();
+    }
   });
-  socket.once("error", (error) => events.emit("error", error));
+  socket.on("pong", () => {
+    if (pongTimeout) {
+      clearTimeout(pongTimeout);
+      pongTimeout = undefined;
+    }
+  });
+  socket.once("error", (error) => {
+    clearConnectionHealthTimers();
+    events.emit("error", error);
+  });
   socket.once("close", (code, reason) => {
+    clearConnectionHealthTimers();
     killed = true;
     events.emit("exit", code, reason.toString("utf8"));
   });
@@ -110,6 +158,7 @@ export function createWebSocketTransport(
     },
     kill: () => {
       killed = true;
+      clearConnectionHealthTimers();
       socket.close();
     },
     once: (event, listener) => events.once(event, listener),

--- a/extensions/codex/src/app-server/transport-websocket.ts
+++ b/extensions/codex/src/app-server/transport-websocket.ts
@@ -12,8 +12,9 @@ import { resolveCodexAppServerUserHomeDir, type CodexAppServerStartOptions } fro
 import type { CodexAppServerTransport } from "./transport.js";
 
 const WEBSOCKET_HANDSHAKE_TIMEOUT_MS = 10_000;
-const WEBSOCKET_PING_INTERVAL_MS = 30_000;
-const WEBSOCKET_PONG_TIMEOUT_MS = 10_000;
+const WEBSOCKET_PING_INTERVAL_MS = 20_000;
+const WEBSOCKET_PONG_TIMEOUT_MS = 20_000;
+const MAX_CONSECUTIVE_MISSED_WEBSOCKET_PONGS = 5;
 
 /** Opens a WebSocket app-server transport and maps newline-delimited frames to stdout/stdin. */
 export function createWebSocketTransport(
@@ -50,18 +51,73 @@ export function createWebSocketTransport(
   const stdinDecoder = new StringDecoder("utf8");
   let pendingLine = "";
   let killed = false;
-  let pingInterval: NodeJS.Timeout | undefined;
+  let pingTimeout: NodeJS.Timeout | undefined;
   let pongTimeout: NodeJS.Timeout | undefined;
+  let expectedPong: Buffer | undefined;
+  let consecutiveMissedPongs = 0;
+  let heartbeatSequence = 0;
 
   const clearConnectionHealthTimers = () => {
-    if (pingInterval) {
-      clearInterval(pingInterval);
-      pingInterval = undefined;
+    if (pingTimeout) {
+      clearTimeout(pingTimeout);
+      pingTimeout = undefined;
     }
     if (pongTimeout) {
       clearTimeout(pongTimeout);
       pongTimeout = undefined;
     }
+    expectedPong = undefined;
+  };
+
+  const sendHeartbeatPing = () => {
+    if (socket.readyState !== WebSocket.OPEN || pongTimeout) {
+      return;
+    }
+
+    const payload = Buffer.from(`openclaw-codex-${++heartbeatSequence}`);
+    expectedPong = payload;
+    pongTimeout = setTimeout(() => {
+      pongTimeout = undefined;
+      expectedPong = undefined;
+      consecutiveMissedPongs += 1;
+      if (consecutiveMissedPongs >= MAX_CONSECUTIVE_MISSED_WEBSOCKET_PONGS) {
+        socket.terminate();
+        return;
+      }
+      sendHeartbeatPing();
+    }, WEBSOCKET_PONG_TIMEOUT_MS);
+    pongTimeout.unref();
+    socket.ping(payload, (error) => {
+      if (error) {
+        socket.terminate();
+      }
+    });
+  };
+
+  const scheduleHeartbeatPing = () => {
+    if (
+      options.transport !== "websocket" ||
+      socket.readyState !== WebSocket.OPEN ||
+      pingTimeout ||
+      pongTimeout
+    ) {
+      return;
+    }
+    pingTimeout = setTimeout(() => {
+      pingTimeout = undefined;
+      sendHeartbeatPing();
+    }, WEBSOCKET_PING_INTERVAL_MS);
+    pingTimeout.unref();
+  };
+
+  const recordConnectionActivity = () => {
+    consecutiveMissedPongs = 0;
+    if (pongTimeout) {
+      clearTimeout(pongTimeout);
+      pongTimeout = undefined;
+    }
+    expectedPong = undefined;
+    scheduleHeartbeatPing();
   };
 
   const sendFrame = (frame: string) => {
@@ -82,29 +138,11 @@ export function createWebSocketTransport(
     for (const frame of pendingFrames.splice(0)) {
       socket.send(frame);
     }
-    if (options.transport === "websocket") {
-      pingInterval = setInterval(() => {
-        if (socket.readyState !== WebSocket.OPEN || pongTimeout) {
-          return;
-        }
-        pongTimeout = setTimeout(() => {
-          pongTimeout = undefined;
-          socket.terminate();
-        }, WEBSOCKET_PONG_TIMEOUT_MS);
-        pongTimeout.unref();
-        socket.ping((error) => {
-          if (error) {
-            socket.terminate();
-          }
-        });
-      }, WEBSOCKET_PING_INTERVAL_MS);
-      pingInterval.unref();
-    }
+    scheduleHeartbeatPing();
   });
-  socket.on("pong", () => {
-    if (pongTimeout) {
-      clearTimeout(pongTimeout);
-      pongTimeout = undefined;
+  socket.on("pong", (payload) => {
+    if (expectedPong?.equals(payload)) {
+      recordConnectionActivity();
     }
   });
   socket.once("error", (error) => {
@@ -117,6 +155,9 @@ export function createWebSocketTransport(
     events.emit("exit", code, reason.toString("utf8"));
   });
   socket.on("message", (data) => {
+    if (options.transport === "websocket") {
+      recordConnectionActivity();
+    }
     const text = websocketFrameToText(data);
     stdout.write(text.endsWith("\n") ? text : `${text}\n`);
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Codex with a remote WebSocket app-server could see a session remain in progress after the opening handshake stalled or the established connection became half-open. The gateway did not proactively notice or reconnect until another request attempted to use the connection.

## Why This Change Was Made

Remote WebSocket transport now has a bounded opening handshake and sends WebSocket protocol-level ping frames every 20 seconds, with a 20-second pong deadline. The transport tolerates five consecutive missed pongs and resets the failure count when a matching pong or app-server message proves the connection is alive. A plugin-owned background service establishes and recovers the existing shared client using bounded, jittered exponential backoff. Authentication failures, invalid configuration, and unsupported app-server versions stop retrying and produce an actionable operator-visible error. Explicit remote transport also activates the Codex plugin at gateway startup, so recovery does not depend on a user starting a model turn.

This behavior applies automatically to `transport: "websocket"`. Local `stdio` and Unix socket transports retain their existing behavior. Ping and pong frames do not invoke a model.

## User Impact

Remote Codex sessions fail promptly on stalled handshakes, tolerate transient packet loss, detect persistently dead connections while idle, and reconnect in the background without synchronized retry storms. Permanent failures are reported instead of retried indefinitely. Users do not need to discover or enable a new configuration option.

## Before-Fix Evidence From a Real Deployment

An existing deployment without this PR repeatedly failed to reach its separately hosted Codex app-server. Six independent incidents occurred approximately 30 minutes apart; every affected session waited roughly ten minutes before surfacing the failure. Endpoints, tenant identifiers, user identifiers, credentials, and unrelated request data are omitted.

```text
2026-07-29 17:05 PDT  codex app-server startup timed out
2026-07-29 17:35 PDT  codex app-server startup timed out
2026-07-29 18:05 PDT  codex app-server startup timed out
2026-07-29 18:35 PDT  codex app-server startup timed out
2026-07-29 19:05 PDT  codex app-server startup timed out
2026-07-29 19:35 PDT  codex app-server startup timed out

Codex agent harness failed; not falling back to embedded OpenClaw backend
lane task error: durationMs=602205
CodexAppServerStartupError: codex app-server startup timed out
Transient HTTP provider error before reply; retrying once in 2500ms
```

The deployed source did not contain this PR's background health service. These lines are before-fix problem evidence, not claimed recovery evidence.

## After-Fix Evidence Against a Real Remote Codex App-Server

On 2026-07-30 PDT, the exact `transport-websocket.ts` and `connection-health.ts` modules from PR commit `687c7fcf499ef2452b36ad0a8061221082c9130f` were executed from a running gateway against an existing, separately hosted, authenticated Codex app-server `0.146.0`. This was not a mock server or loopback fixture. Only an isolated proof-owned WebSocket was closed; the production gateway and app-server were not restarted, and all gateway containers remained ready with zero restarts afterward.

```text
[live-proof] starting exact PR transport and connection-health modules against existing remote Codex app-server
[live-proof] authenticated remote Codex initialize succeeded; app-server version=0.146.0
[gateway][info] codex app-server remote WebSocket connection is healthy
[live-proof] WebSocket protocol ping sent to real remote Codex app-server
[live-proof] matching WebSocket protocol pong received from real Codex app-server
[live-proof] fault injection: closing only the isolated proof WebSocket; production gateway and app-server remain running
[gateway][warn] codex app-server remote WebSocket disconnected; reconnecting
[live-proof] authenticated remote Codex initialize succeeded; app-server version=0.146.0
[gateway][info] codex app-server remote WebSocket connection is healthy
[live-proof] PASS startup, real heartbeat/pong, connection-loss detection, and automatic reconnect
[live-proof] PASS model turns invoked: 0; only initialize/initialized were sent
[live-proof] PASS startup connections=2 healthy events=2 reconnect events=1
```

## Direct Upstream Codex Contract Inspection

The sibling `../codex` checkout was directly inspected at immutable upstream commit `410c22b30e71265cb5a0cfe69f5e80391393b946`; this is source-level dependency verification, not an inference from an OpenClaw wrapper or the live transcript.

```text
$ git -C ../codex rev-parse HEAD
410c22b30e71265cb5a0cfe69f5e80391393b946

$ sed -n '361,373p' ../codex/codex-rs/app-server-transport/src/transport/websocket.rs
Some(IncomingWebSocketMessage::Ping(payload)) => {
    match writer_control_tx.try_send(M::pong(payload)) {
        Ok(()) => {}
        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => break,
        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
            warn!("websocket control queue full while replying to ping; closing connection");
            break;
        }
    }
}
Some(IncomingWebSocketMessage::Pong) => {}
Some(IncomingWebSocketMessage::Close) => break,
```

- [Exact upstream ping/pong handling](https://github.com/openai/codex/blob/410c22b30e71265cb5a0cfe69f5e80391393b946/codex-rs/app-server-transport/src/transport/websocket.rs#L330-L384): inbound protocol pings enqueue a pong carrying the same payload; inbound pongs do not become JSON-RPC/model requests; a full control queue closes the connection.
- [Exact upstream connection-close lifecycle](https://github.com/openai/codex/blob/410c22b30e71265cb5a0cfe69f5e80391393b946/codex-rs/app-server-transport/src/transport/websocket.rs#L172-L228): either inbound or outbound termination cancels its peer and emits `TransportEvent::ConnectionClosed`.
- [Exact upstream authenticated-upgrade contract](https://github.com/openai/codex/blob/410c22b30e71265cb5a0cfe69f5e80391393b946/codex-rs/app-server-transport/src/transport/auth.rs#L273-L303): configured capability-token and signed-bearer policies authenticate the existing WebSocket upgrade; this PR does not change that contract.
- [Upstream reconnect regression coverage](https://github.com/openai/codex/blob/410c22b30e71265cb5a0cfe69f5e80391393b946/codex-rs/app-server/tests/suite/v2/connection_handling_websocket.rs#L449-L472): the upstream integration test closes one WebSocket, reconnects and reinitializes another, and confirms the subscribed thread remains loaded.
- [Upstream support-status limitation](https://github.com/openai/codex/blob/410c22b30e71265cb5a0cfe69f5e80391393b946/codex-rs/app-server/README.md#L24-L37): the WebSocket listener is explicitly experimental/unsupported. The observed implementation supports this PR's ping/pong, auth, close, and reconnect behavior at the cited commit, but upstream does not promise compatibility across future versions.

Protocol ping/pong exchanges therefore require no `turn/start` or model invocation; the zero-turn live transcript above independently confirms that source-derived contract against a real app-server.

## Startup Compatibility and Maintainer Decision

This PR deliberately changes **only explicitly configured** `appServer.transport: "websocket"` from request-driven connection to gateway-startup-managed connection. This is the intentional behavior needed to detect and repair broken remote sessions before a user sends another message; maintainers should explicitly accept that operational contract before merge.

- Plugin-wide `activation.onStartup` remains `false`; only the existing, explicitly authored transport configuration activates this path.
- Default local `stdio`, explicitly configured local `stdio`, and Unix-socket transport do not register the background connection-health service.
- Startup opens one shared app-server connection and performs `initialize`/`initialized`; it never invokes inference or creates a model turn.
- Gateway startup is not blocked by the monitor: service startup schedules asynchronous work, and a failed endpoint is handled in the background.
- WebSocket opening handshakes are bounded to 10 seconds; idle pings run every 20 seconds with a 20-second pong timeout; five consecutive failures are required before the connection is closed.
- Reconnect uses bounded exponential backoff with jitter and never restarts the remote app-server process.
- HTTP 401/403, invalid configuration, and unsupported Codex versions are logged once as actionable operator errors and stop retrying.
- Existing bearer-token handling, protocol version checks, plugin policy, and local transport behavior are unchanged. No dependency, lockfile, credential, security-owned file, or gateway authentication surface is modified.

## Evidence

- Checked the actual Codex app-server WebSocket implementation and confirmed that app-server responds to protocol ping frames.
- Added coverage for healthy idle WebSockets, five consecutive missed pongs, real HTTP 401/403 WebSocket upgrade failures, remote service registration, local-transport isolation, startup without inference, transient reconnect, permanent authentication failures, invalid configuration, and shared-client lease cleanup.
- Executed the exact PR WebSocket transport and connection-health service against a real separately hosted Codex app-server; the complete redacted startup, ping/pong, connection-loss, and automatic reconnect transcript is included above.
- Also exercised focused real loopback WebSocket and HTTP fault injection for matching pongs, five consecutive unanswered pings, app-server-message liveness, and actual HTTP 401/403 upgrade failures.
- TruffleHog reports no verified or unknown secrets in the reviewed changes.
- Repository `autoreview --mode uncommitted --no-web-search` reports no accepted or actionable findings.
- `git diff --check` passes.
- `oxfmt --check` passes for all changed source, tests, manifest, and documentation.
- `oxlint` passes for all changed TypeScript source and tests.
- Node 24 TypeScript syntax checks pass for the remote transport, reconnection service, and plugin registration.
- Full Vitest collection is blocked locally because the existing repository dependency installation is missing `chalk` and `@openclaw/fs-safe`; a temporary, exact-version `chalk` source confirmed the additional missing package without changing `node_modules`, accessing a public package registry, or reconfiguring the package manager.

AI-assisted: drafted and validated with Codex; the change and its transport-specific blast radius were reviewed against the upstream app-server protocol and existing OpenClaw shared-client lifecycle.
