### PR TITLE
fix: avoid Swift contention on hosted release runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2984,6 +2984,7 @@ jobs:
     timeout-minutes: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 30 || 20 }}
     env:
       HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
+      SWIFT_TEST_EXECUTION: ${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'serial' || 'parallel' }}
     steps:
       - *platform_checkout_step
 
@@ -3173,8 +3174,14 @@ jobs:
       - name: Swift test
         run: |
           set -euo pipefail
+          swift_test_args=(--package-path apps/macos --enable-code-coverage)
+          # Hosted release and retry runs have shown test-process contention;
+          # keep the faster first-attempt Blacksmith path parallel.
+          if [[ "$SWIFT_TEST_EXECUTION" == "parallel" ]]; then
+            swift_test_args+=(--parallel)
+          fi
           for attempt in 1 2 3; do
-            if swift test --package-path apps/macos --parallel --enable-code-coverage; then
+            if swift test "${swift_test_args[@]}"; then
               exit 0
             fi
             echo "swift test failed (attempt $attempt/3). Retrying…"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3582,6 +3582,26 @@ describe("ci workflow guards", () => {
     );
   });
 
+  it("serializes macOS Swift tests only on hosted dispatches and retries", () => {
+    const workflow = readCiWorkflow();
+    const macosSwift = workflow.jobs["macos-swift"];
+    const testStep = macosSwift.steps.find((step: WorkflowStep) => step.name === "Swift test");
+
+    expect(macosSwift.env.SWIFT_TEST_EXECUTION).toBe(
+      "${{ (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'serial' || 'parallel' }}",
+    );
+    expect(testStep.run).toContain(
+      "swift_test_args=(--package-path apps/macos --enable-code-coverage)",
+    );
+    expect(testStep.run).toContain('if [[ "$SWIFT_TEST_EXECUTION" == "parallel" ]]');
+    expect(testStep.run).toContain("swift_test_args+=(--parallel)");
+    expect(testStep.run).toContain('swift test "${swift_test_args[@]}"');
+    expect(testStep.run).not.toContain(
+      "swift test --package-path apps/macos --parallel --enable-code-coverage",
+    );
+    expect(testStep.run).toContain("for attempt in 1 2 3");
+  });
+
   it("bounds the Windows Crabbox hydrate main fetch", () => {
     const workflow = readFileSync(".github/workflows/crabbox-hydrate.yml", "utf8");
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where manual release validation and retry CI runs could repeatedly fail the macOS Swift suite when parallel test processes contended on GitHub-hosted macOS runners.

## Why This Change Was Made

The macOS Swift job now omits SwiftPM parallel test execution only for manual dispatches and workflow reruns, which are already routed to GitHub-hosted macOS. First-attempt automatic runs retain parallel execution on Blacksmith. Coverage, assertions, and all three retry attempts remain unchanged.

## User Impact

Release validation gets a lower-contention hosted fallback without slowing the normal Blacksmith CI path. There is no product runtime change.

## Evidence

- `actionlint .github/workflows/ci.yml`
- focused `test/scripts/ci-workflow-guards.test.ts`: 92 passed, 1 skipped
- formatting check for both changed files
- `git diff --check`
- Codex autoreview: clean, no accepted or actionable findings
