### PR TITLE
fix(apply-patch): preserve original bytes for context lines on tolerant match

### DIFF
--- a/src/agents/apply-patch-update.ts
+++ b/src/agents/apply-patch-update.ts
@@ -101,6 +101,21 @@ function computeReplacements(
       );
     }
 
+    // When the tolerant matcher (trim, normalize punctuation) locates a hunk,
+    // the model's retyped context lines may differ from the original file bytes
+    // (trailing whitespace, tab indentation, typographic punctuation). Preserve
+    // the original bytes for context lines — lines that appear with the same
+    // semantic content in both oldLines and newLines.
+    let exactMatch = true;
+    for (let i = 0; exactMatch && i < pattern.length; i++) {
+      if (originalLines[found + i] !== pattern[i]) {
+        exactMatch = false;
+      }
+    }
+    if (!exactMatch) {
+      newSlice = preserveContextLines(originalLines, found, chunk.oldLines, chunk.newLines, newSlice);
+    }
+
     replacements.push([found, pattern.length, newSlice]);
     lineIndex = found + pattern.length;
   }
@@ -190,4 +205,61 @@ function normalizePunctuation(value: string): string {
     .replace(SINGLE_QUOTE_PUNCTUATION, "'")
     .replace(DOUBLE_QUOTE_PUNCTUATION, '"')
     .replace(SPACE_PUNCTUATION, " ");
+}
+
+/**
+ * When the tolerant matcher locates a hunk at a position where the original
+ * file bytes differ from the patch pattern (trailing whitespace, tab indentation,
+ * typographic punctuation), this function preserves the original bytes for
+ * context lines — lines that appear with the same semantic content in both
+ * chunk.oldLines and chunk.newLines (and thus were never marked as changed by
+ * the patch).
+ *
+ * Without this, a tolerant match replaces the entire matched span with the
+ * model's retyped lines, silently overwriting trailing whitespace, tabs, and
+ * typographic punctuation on lines the patch never intended to change.
+ */
+function preserveContextLines(
+  originalLines: string[],
+  found: number,
+  oldLines: string[],
+  newLines: string[],
+  newSlice: string[],
+): string[] {
+  const result = newSlice.slice();
+  let oldPos = 0;
+  let newPos = 0;
+
+  while (oldPos < oldLines.length && newPos < result.length) {
+    if (newPos < newLines.length && newLines[newPos] === oldLines[oldPos]) {
+      // Context line: same content in old and new → preserve original bytes
+      const orig = originalLines[found + oldPos];
+      if (orig !== undefined && result[newPos] !== orig) {
+        result[newPos] = orig;
+      }
+      oldPos++;
+      newPos++;
+    } else if (
+      oldPos + 1 < oldLines.length &&
+      newPos < newLines.length &&
+      newLines[newPos] === oldLines[oldPos + 1]
+    ) {
+      // Current old line is a removal (next old line matches current new)
+      oldPos++;
+    } else if (
+      newPos + 1 < newLines.length &&
+      oldPos < oldLines.length &&
+      oldLines[oldPos] === newLines[newPos + 1]
+    ) {
+      // Current new line is an addition (next new line matches current old)
+      newPos++;
+    } else {
+      // Both changed simultaneously (removal + addition at same position)
+      // Keep the model's version for this changed line
+      oldPos++;
+      newPos++;
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `apply_patch` silently rewrites the bytes of lines that the patch explicitly marked as unchanged context (leading space prefix). Whenever a hunk is located by the tolerant matcher (trim, normalize punctuation) rather than an exact byte-for-byte match, the entire matched span is replaced with the model's retyped patch text. Trailing whitespace, typographic punctuation, U+2019 apostrophes, and tab indentation on context lines are overwritten — yet the tool still reports `Success. Updated the following files: M <file>`, so neither the agent nor the operator sees that unrelated bytes changed. In the Python case this can convert a file with consistent tab indentation into mixed tabs and spaces, breaking compilation.

## Why This Change Was Made

The root cause is in `src/agents/apply-patch-update.ts:104`: after `seekSequence` finds a tolerant match, the code unconditionally replaces the entire `pattern.length` lines with `newSlice` (the model's `newLines`). The fix detects whether the match was exact or fuzzy. For fuzzy matches, a new `preserveContextLines()` helper walks `oldLines` and `newLines` to identify context lines — lines with the same semantic content in both arrays — and substitutes the original file bytes for those positions. Only lines that are actually changed (removal + addition pairs) are written with the model's version.

This aligns with the established edit-tool invariant: unchanged file content must retain its original bytes.

## User Impact

- **Before:** `apply_patch` overwrites trailing spaces, typographic apostrophes, and tab indentation on unchanged context lines — silently corrupting files.
- **After:** Context lines preserve their original bytes regardless of how the tolerant matcher located the hunk. Only explicitly changed lines are modified.

## Evidence

### Inline verification
The following 9 cases are handled correctly:

```
PASS context lines with trailing whitespace preserved
PASS multiple removals with context line preservation
PASS exact match - no changes
PASS addition-only with context lines
PASS removal-only with context lines
PASS tab indentation on context lines
PASS typographic punctuation preserved
PASS EOF context line preservation
PASS multiple tolerant context lines
```

### Code diff
The fix adds 57 lines to `src/agents/apply-patch-update.ts`:
- An exact-match check after `seekSequence` returns (lines 98-111)
- The `preserveContextLines()` helper function (lines 216-259) that walks `oldLines`/`newLines` alignment to identify context lines and restore original bytes

### Bit-for-bit preservation logic
```text
For each line in the matched span:
  - If the line is a context line (same content in oldLines and newLines):
      → Use the original file's bytes (preserves trailing whitespace, tabs, punctuation)
  - If the line is a removed+added pair (changed):
      → Use the model's version (intentional change)
  - If the line is a removal-only or addition-only:
      → Respects the diff structure, no bytes to preserve
```

### Same pattern as established invariant
The edit-diff tool already preserves unchanged line bytes. This fix brings `apply_patch` in line with that contract.

CI: Will be validated by GitHub Actions on submission.

[AI-assisted]
