### PR TITLE
fix(test): stop collecting empty Vydra helper suite

### DIFF
--- a/extensions/vydra/image-generation-provider.test.ts
+++ b/extensions/vydra/image-generation-provider.test.ts
@@ -7,7 +7,7 @@ import {
   jsonResponse,
   stubFetch,
   stubVydraApiKey,
-} from "./provider-test-helpers.test.js";
+} from "./provider-test-helpers.js";
 
 function fetchCall(fetchMock: ReturnType<typeof vi.fn>, index = 0): [string, RequestInit] {
   const call = fetchMock.mock.calls[index];

--- a/extensions/vydra/provider-test-helpers.ts
+++ b/extensions/vydra/provider-test-helpers.ts
@@ -1,4 +1,4 @@
-// Vydra tests cover provider test helpers plugin behavior.
+// Shared fixtures for Vydra provider tests.
 import * as providerAuth from "openclaw/plugin-sdk/provider-auth-runtime";
 import { vi } from "vitest";
 

--- a/extensions/vydra/video-generation-provider.test.ts
+++ b/extensions/vydra/video-generation-provider.test.ts
@@ -8,7 +8,7 @@ import {
   jsonResponse,
   stubFetch,
   stubVydraApiKey,
-} from "./provider-test-helpers.test.js";
+} from "./provider-test-helpers.js";
 import { buildVydraVideoGenerationProvider } from "./video-generation-provider.js";
 
 function fetchCall(fetchMock: ReturnType<typeof vi.fn>, index: number) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a test-suite problem where Vydra shared fixtures were collected as an empty test file, adding misleading `(0 test)` output to full extension runs.

## Why This Change Was Made

Renames the shared fixture module so it no longer matches Vitest test-file patterns, while keeping the image and video provider tests on the same reusable helpers.

## User Impact

No user-visible runtime impact. Test output now reflects only executable Vydra suites, making dead-test audits and suite accounting accurate.

## Evidence

- Before: `extensions/vydra/provider-test-helpers.test.ts (0 test)` appeared in the extension run.
- After: `node scripts/run-vitest.mjs extensions/vydra/image-generation-provider.test.ts extensions/vydra/video-generation-provider.test.ts` collected 2 files and passed all 13 tests.
- `git diff --check` passed.
- Autoreview passed with no findings (0.99 confidence).