### PR TITLE
fix(mattermost): preserve outbound delivery settlement

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -713,6 +713,90 @@ describe("mattermostPlugin", () => {
       expect(discovery?.schema).toBeUndefined();
     });
 
+    it("prepares supported sends for the core durable lifecycle", async () => {
+      const prepareSendPayload = mattermostPlugin.actions?.prepareSendPayload;
+      if (!prepareSendPayload) {
+        throw new Error("mattermost actions.prepareSendPayload missing");
+      }
+      const payload = { text: "report" };
+
+      const prepared = await prepareSendPayload({
+        ctx: createMattermostActionContext({
+          params: {
+            to: "channel:CHAN1",
+            message: "report",
+            filePath: "/tmp/workspace/report.md",
+            replyToId: "post-root",
+          },
+        }),
+        to: "channel:CHAN1",
+        payload,
+        replyToId: "post-root",
+      });
+
+      expect(prepared).toEqual({
+        text: "report",
+        mediaUrl: "/tmp/workspace/report.md",
+        mediaUrls: ["/tmp/workspace/report.md"],
+      });
+    });
+
+    it("carries provider attachment text through core payload delivery", async () => {
+      const prepareSendPayload = mattermostPlugin.actions?.prepareSendPayload;
+      if (!prepareSendPayload) {
+        throw new Error("mattermost actions.prepareSendPayload missing");
+      }
+      const prepared = await prepareSendPayload({
+        ctx: createMattermostActionContext({
+          params: {
+            to: "channel:CHAN1",
+            message: "report",
+            attachmentText: "native attachment",
+          },
+        }),
+        to: "channel:CHAN1",
+        payload: { text: "report" },
+      });
+      expect(prepared).toMatchObject({
+        channelData: { mattermost: { attachmentText: "native attachment" } },
+      });
+
+      await requireMattermostSendPayload()({
+        cfg: createMattermostTestConfig(),
+        to: "channel:CHAN1",
+        text: "report",
+        payload: prepared!,
+      });
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "report");
+      expect(options.attachmentText).toBe("native attachment");
+    });
+
+    it.each([
+      ["buffer attachments", { buffer: "cmVwb3J0" }, "buffer/base64 payloads"],
+      [
+        "multiple attachments",
+        { mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"] },
+        "supports one attachment per message",
+      ],
+    ])("rejects unsupported %s before provider dispatch", async (_label, extraParams, error) => {
+      const prepareSendPayload = mattermostPlugin.actions?.prepareSendPayload;
+      if (!prepareSendPayload) {
+        throw new Error("mattermost actions.prepareSendPayload missing");
+      }
+
+      await expect(async () =>
+        prepareSendPayload({
+          ctx: createMattermostActionContext({
+            params: { to: "channel:CHAN1", message: "report", ...extraParams },
+          }),
+          to: "channel:CHAN1",
+          payload: { text: "report" },
+        }),
+      ).rejects.toThrow(error);
+      expect(sendMessageMattermostMock).not.toHaveBeenCalled();
+    });
+
     it("keeps read opt in when reactions are disabled", () => {
       const cfg: OpenClawConfig = {
         channels: {
@@ -1544,6 +1628,72 @@ describe("mattermostPlugin", () => {
   });
 
   describe("outbound", () => {
+    it.each([
+      {
+        name: "text",
+        send: async (onDeliveryResult: MattermostSendTextParams["onDeliveryResult"]) =>
+          await requireMattermostSendText()({
+            cfg: createMattermostTestConfig(),
+            to: "channel:CHAN1",
+            text: "provider-final",
+            onDeliveryResult,
+          }),
+      },
+      {
+        name: "media",
+        send: async (onDeliveryResult: MattermostSendMediaParams["onDeliveryResult"]) =>
+          await requireMattermostSendMedia()({
+            cfg: createMattermostTestConfig(),
+            to: "channel:CHAN1",
+            text: "provider-final",
+            mediaUrl: "https://example.com/report.png",
+            onDeliveryResult,
+          }),
+      },
+      {
+        name: "payload",
+        send: async (onDeliveryResult: MattermostSendTextParams["onDeliveryResult"]) =>
+          await requireMattermostSendPayload()({
+            cfg: createMattermostTestConfig(),
+            to: "channel:CHAN1",
+            text: "provider-final",
+            payload: {
+              text: "provider-final",
+              channelData: {
+                mattermost: {
+                  attachmentText: "attachment",
+                },
+              },
+            },
+            onDeliveryResult,
+          }),
+      },
+    ])("reports $name provider progress before a later bookkeeping failure", async ({ send }) => {
+      const onDeliveryResult = vi.fn();
+      sendMessageMattermostMock.mockImplementationOnce(
+        async (_to: string, _text: string, options: Record<string, unknown>) => {
+          const report = options.onDeliveryResult as
+            | ((result: Record<string, unknown>) => Promise<void>)
+            | undefined;
+          await report?.({
+            messageId: "post-final",
+            channelId: "CHAN1",
+            content: "provider-final",
+          });
+          throw new Error("activity store unavailable");
+        },
+      );
+
+      await expect(send(onDeliveryResult)).rejects.toThrow("activity store unavailable");
+      expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+      expect(onDeliveryResult).toHaveBeenCalledWith({
+        channel: "mattermost",
+        messageId: "post-final",
+        channelId: "CHAN1",
+        content: "provider-final",
+      });
+    });
+
     it("renders presentation buttons for normal reply payload delivery", async () => {
       const renderPresentation = requireMattermostRenderPresentation();
       const sendPayload = requireMattermostSendPayload();

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -68,6 +68,7 @@ import {
   resolveMattermostReplyToMode,
   type ResolvedMattermostAccount,
 } from "./mattermost/accounts.js";
+import type { MattermostSendResult } from "./mattermost/send.js";
 import { looksLikeMattermostTargetId, normalizeMattermostMessagingTarget } from "./normalize.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { resolveMattermostOutboundSessionRoute } from "./session-route.js";
@@ -128,11 +129,19 @@ function hasMattermostPresentationNavigation(presentation: MessagePresentation):
   );
 }
 
+function readMattermostPayloadData(payload: {
+  channelData?: Record<string, unknown>;
+}): Record<string, unknown> | undefined {
+  const data = payload.channelData?.mattermost;
+  return data && typeof data === "object" && !Array.isArray(data)
+    ? (data as Record<string, unknown>)
+    : undefined;
+}
+
 function readMattermostPresentationButtons(payload: {
   channelData?: Record<string, unknown>;
 }): Array<unknown> | undefined {
-  const buttons = (payload.channelData?.mattermost as { presentationButtons?: unknown } | undefined)
-    ?.presentationButtons;
+  const buttons = readMattermostPayloadData(payload)?.presentationButtons;
   return Array.isArray(buttons) ? buttons : undefined;
 }
 
@@ -381,6 +390,30 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool: describeMattermostMessageTool,
   extractToolSend: ({ args }) => extractMattermostToolSend(args),
   extractToolSendResult: ({ result, send }) => extractMattermostToolSendResult(result, send),
+  prepareSendPayload: ({ ctx, payload }) => {
+    if (ctx.action !== "send") {
+      return null;
+    }
+    const mediaUrl = resolveMattermostSendAttachmentMedia(ctx.params);
+    const attachmentText =
+      typeof ctx.params.attachmentText === "string" ? ctx.params.attachmentText : undefined;
+    const existingMattermostData = readMattermostPayloadData(payload);
+    return {
+      ...payload,
+      ...(mediaUrl ? { mediaUrl, mediaUrls: [mediaUrl] } : {}),
+      ...(attachmentText !== undefined
+        ? {
+            channelData: {
+              ...payload.channelData,
+              mattermost: {
+                ...existingMattermostData,
+                attachmentText,
+              },
+            },
+          }
+        : {}),
+    };
+  },
   supportsAction: ({ action }) => {
     return action === "send" || action === "react" || action === "read";
   },
@@ -550,17 +583,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       normalizeOptionalString(params.replyTo);
     const resolvedAccountId = accountId || undefined;
 
-    const attachmentMedia = collectMattermostAttachmentMedia(params);
-    if (attachmentMedia.hasUnsupportedAttachmentPayload) {
-      throw new Error(
-        "Mattermost send attachments require media, mediaUrl, path, filePath, fileUrl, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported.",
-      );
-    }
-    if (attachmentMedia.mediaUrls.length > 1) {
-      throw new Error(
-        "Mattermost send supports one attachment per message; split multiple mediaUrls or attachments[] entries into separate sends.",
-      );
-    }
+    const mediaUrl = resolveMattermostSendAttachmentMedia(params);
     const buttons = presentation ? buildMattermostPresentationButtons(presentation) : [];
 
     const result = await (
@@ -571,13 +594,11 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       replyToId,
       buttons: buttons.length > 0 ? buttons : undefined,
       attachmentText: typeof params.attachmentText === "string" ? params.attachmentText : undefined,
-      mediaUrl: attachmentMedia.mediaUrls[0],
+      mediaUrl,
       mediaLocalRoots: mediaLocalRoots ?? mediaAccess?.localRoots,
       mediaReadFile: mediaReadFile ?? mediaAccess?.readFile,
       ...(mediaAccess?.workspaceDir ? { workspaceDir: mediaAccess.workspaceDir } : {}),
-      requireMediaUpload: requiresMattermostMediaUpload(attachmentMedia.mediaUrls[0])
-        ? true
-        : undefined,
+      requireMediaUpload: requiresMattermostMediaUpload(mediaUrl) ? true : undefined,
     });
 
     return {
@@ -725,6 +746,33 @@ function collectMattermostAttachmentMedia(params: Record<string, unknown>): {
   };
 }
 
+function resolveMattermostSendAttachmentMedia(params: Record<string, unknown>): string | undefined {
+  const attachmentMedia = collectMattermostAttachmentMedia(params);
+  if (attachmentMedia.hasUnsupportedAttachmentPayload) {
+    throw new Error(
+      "Mattermost send attachments require media, mediaUrl, path, filePath, fileUrl, mediaUrls, or attachments[] with one of those fields; buffer/base64 payloads are not supported.",
+    );
+  }
+  if (attachmentMedia.mediaUrls.length > 1) {
+    throw new Error(
+      "Mattermost send supports one attachment per message; split multiple mediaUrls or attachments[] entries into separate sends.",
+    );
+  }
+  return attachmentMedia.mediaUrls[0];
+}
+
+type MattermostOutboundContext = Parameters<NonNullable<ChannelOutboundAdapter["sendText"]>>[0];
+
+function createMattermostDeliveryProgressReporter(
+  onDeliveryResult: MattermostOutboundContext["onDeliveryResult"],
+) {
+  return onDeliveryResult
+    ? async (result: MattermostSendResult) => {
+        await onDeliveryResult(attachChannelToResult("mattermost", result));
+      }
+    : undefined;
+}
+
 const mattermostOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: chunkTextForOutbound,
@@ -769,7 +817,9 @@ const mattermostOutbound: ChannelOutboundAdapter = {
   },
   sendPayload: async (ctx) => {
     const buttons = readMattermostPresentationButtons(ctx.payload);
-    if (buttons?.length) {
+    const rawAttachmentText = readMattermostPayloadData(ctx.payload)?.attachmentText;
+    const attachmentText = typeof rawAttachmentText === "string" ? rawAttachmentText : undefined;
+    if (buttons?.length || attachmentText !== undefined) {
       const mediaUrl = resolvePayloadMediaUrls({
         ...ctx.payload,
         mediaUrl: ctx.payload.mediaUrl ?? ctx.mediaUrl,
@@ -787,7 +837,9 @@ const mattermostOutbound: ChannelOutboundAdapter = {
         ...(ctx.mediaAccess?.workspaceDir ? { workspaceDir: ctx.mediaAccess.workspaceDir } : {}),
         requireMediaUpload: requiresMattermostMediaUpload(mediaUrl) ? true : undefined,
         replyToId: ctx.replyToId ?? (ctx.threadId != null ? String(ctx.threadId) : undefined),
-        buttons,
+        buttons: buttons?.length ? buttons : undefined,
+        attachmentText,
+        onDeliveryResult: createMattermostDeliveryProgressReporter(ctx.onDeliveryResult),
       });
       return attachChannelToResult("mattermost", result);
     }
@@ -807,13 +859,14 @@ const mattermostOutbound: ChannelOutboundAdapter = {
   },
   ...createAttachedChannelResultAdapter({
     channel: "mattermost",
-    sendText: async ({ cfg, to, text, accountId, replyToId, threadId }) =>
+    sendText: async ({ cfg, to, text, accountId, replyToId, threadId, onDeliveryResult }) =>
       await (
         await loadMattermostChannelRuntime()
       ).sendMessageMattermost(to, text, {
         cfg,
         accountId: accountId ?? undefined,
         replyToId: replyToId ?? (threadId != null ? String(threadId) : undefined),
+        onDeliveryResult: createMattermostDeliveryProgressReporter(onDeliveryResult),
       }),
     sendMedia: async ({
       cfg,
@@ -826,6 +879,7 @@ const mattermostOutbound: ChannelOutboundAdapter = {
       accountId,
       replyToId,
       threadId,
+      onDeliveryResult,
     }) =>
       await (
         await loadMattermostChannelRuntime()
@@ -838,6 +892,7 @@ const mattermostOutbound: ChannelOutboundAdapter = {
         ...(mediaAccess?.workspaceDir ? { workspaceDir: mediaAccess.workspaceDir } : {}),
         requireMediaUpload: requiresMattermostMediaUpload(mediaUrl) ? true : undefined,
         replyToId: replyToId ?? (threadId != null ? String(threadId) : undefined),
+        onDeliveryResult: createMattermostDeliveryProgressReporter(onDeliveryResult),
       }),
   }),
 };

--- a/extensions/mattermost/src/delivery-trace.test.ts
+++ b/extensions/mattermost/src/delivery-trace.test.ts
@@ -15,6 +15,10 @@ import {
   type DeliveryTraceScenario,
   type WireRecorder,
 } from "openclaw/plugin-sdk/channel-contract-testing";
+import {
+  createMessageReceiptFromOutboundResults,
+  listMessageReceiptPlatformIds,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/core";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import {
@@ -32,7 +36,10 @@ import {
 } from "./mattermost/draft-stream.js";
 import { resolveMattermostReplyRootId } from "./mattermost/monitor-context.js";
 import { deliverMattermostReplyWithDraftPreview } from "./mattermost/monitor-draft-delivery.js";
-import { deliverMattermostReplyPayload } from "./mattermost/reply-delivery.js";
+import {
+  deliverMattermostReplyPayload,
+  joinMattermostVisibleContent,
+} from "./mattermost/reply-delivery.js";
 
 const CHANNEL_ID = "channel-trace";
 const ROOT_ID = "root-trace";
@@ -118,38 +125,60 @@ function setupMattermostTrace(recorder: WireRecorder) {
 
   // Replicas of the monitor's inline final-text resolution glue
   // (extensions/mattermost/src/mattermost/monitor.ts deliver wiring).
-  const resolveFinalDeliveryText = (text?: string) => {
-    if (typeof text !== "string") {
-      return undefined;
-    }
-    const resolution = draftStream.resolveFinalText(text);
-    return resolution.kind === "already-delivered" ? "" : resolution.text;
-  };
   const resolvePreviewFinalText = (text?: string) => {
-    const deliveryText = resolveFinalDeliveryText(text);
-    if (typeof deliveryText !== "string") {
-      return undefined;
-    }
+    const resolution = draftStream.resolveFinalText(typeof text === "string" ? text : "");
+    const confirmedDelivery =
+      resolution.publishedParts.length > 0
+        ? (() => {
+            const receipt = createMessageReceiptFromOutboundResults({
+              results: resolution.publishedParts.map((part) => ({
+                channel: "mattermost",
+                messageId: part.messageId,
+                channelId: CHANNEL_ID,
+              })),
+              kind: "preview",
+              replyToId: ROOT_ID,
+            });
+            return {
+              outcome: "text" as const,
+              messageIds: listMessageReceiptPlatformIds(receipt),
+              receipt,
+              visibleReplySent: true,
+              content: joinMattermostVisibleContent(
+                resolution.publishedParts.map((part) => part.content),
+              ),
+            };
+          })()
+        : undefined;
+    const deliveryText = resolution.kind === "already-delivered" ? "" : resolution.text;
     const formatted = convertMarkdownTables(deliveryText, tableMode);
     const chunks = chunkMarkdownTextWithMode(formatted, textLimit, chunkMode);
     if (!chunks.length && formatted) {
       chunks.push(formatted);
     }
     if (chunks.length !== 1) {
-      return undefined;
+      return {
+        deliveryText,
+        confirmedDelivery,
+        alreadyDelivered: resolution.kind === "already-delivered",
+      };
     }
     const trimmed = chunks[0]?.trim();
     if (!trimmed) {
-      return undefined;
+      return {
+        deliveryText,
+        confirmedDelivery,
+        alreadyDelivered: resolution.kind === "already-delivered",
+      };
     }
     if (
       lastPartialText &&
       lastPartialText.startsWith(trimmed) &&
       trimmed.length < lastPartialText.length
     ) {
-      return undefined;
+      return { deliveryText, confirmedDelivery, alreadyDelivered: false };
     }
-    return trimmed;
+    return { editText: trimmed, deliveryText, confirmedDelivery, alreadyDelivered: false };
   };
 
   const deliverPayload = async (payloadToDeliver: ReplyPayload) => {
@@ -163,7 +192,7 @@ function setupMattermostTrace(recorder: WireRecorder) {
           text: finalTextResolution.kind === "already-delivered" ? "" : finalTextResolution.text,
         }
       : payloadToDeliver;
-    await deliverMattermostReplyPayload({
+    return await deliverMattermostReplyPayload({
       core,
       cfg,
       payload: resolvedPayload,
@@ -178,11 +207,21 @@ function setupMattermostTrace(recorder: WireRecorder) {
       textLimit,
       tableMode,
       sendMessage: async (_to, text, opts) => {
-        return await createMattermostPost(client, {
+        const post = await createMattermostPost(client, {
           channelId: CHANNEL_ID,
           message: text,
           rootId: opts.replyToId,
         });
+        return {
+          messageId: post.id,
+          channelId: CHANNEL_ID,
+          receipt: createMessageReceiptFromOutboundResults({
+            results: [{ channel: "mattermost", messageId: post.id, channelId: CHANNEL_ID }],
+            kind: "text",
+            ...(opts.replyToId ? { replyToId: opts.replyToId } : {}),
+          }),
+          content: post.message ?? text,
+        };
       },
     });
   };

--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -524,14 +524,17 @@ describe("createMattermostDraftStream forceNewMessage", () => {
     expect(stream.resolveFinalText("First block\n\nSecond block complete")).toEqual({
       kind: "remaining",
       text: "Second block complete",
+      publishedParts: [{ messageId: "post-1", content: "First block" }],
     });
     expect(stream.resolveFinalText("Second block complete")).toEqual({
       kind: "full",
       text: "Second block complete",
+      publishedParts: [{ messageId: "post-1", content: "First block" }],
     });
     expect(stream.resolveFinalText("First block extended")).toEqual({
       kind: "full",
       text: "First block extended",
+      publishedParts: [{ messageId: "post-1", content: "First block" }],
     });
   });
 
@@ -554,12 +557,42 @@ describe("createMattermostDraftStream forceNewMessage", () => {
     expect(stream.resolveFinalText("First block\n\nFinal after tool")).toEqual({
       kind: "remaining",
       text: "Final after tool",
+      publishedParts: [{ messageId: "post-1", content: "First block" }],
     });
     expect(stream.resolveFinalText("First block extended")).toEqual({
       kind: "full",
       text: "First block extended",
+      publishedParts: [{ messageId: "post-1", content: "First block" }],
     });
-    expect(stream.resolveFinalText("First block")).toEqual({ kind: "already-delivered" });
+    expect(stream.resolveFinalText("First block")).toEqual({
+      kind: "already-delivered",
+      publishedParts: [{ messageId: "post-1", content: "First block" }],
+    });
+    expect(stream.resolveFinalText("")).toEqual({
+      kind: "full",
+      text: "",
+      publishedParts: [{ messageId: "post-1", content: "First block" }],
+    });
+  });
+
+  it("uses provider-finalized content from a boundary edit", async () => {
+    const { client, requestMock } = createMockClient();
+    const stream = createMattermostDraftStream({
+      client,
+      channelId: "channel-1",
+      throttleMs: 0,
+    });
+
+    stream.updateAssistantText("Draft block");
+    await stream.flush();
+    requestMock.mockResolvedValueOnce({ id: "post-1", message: "Provider-finalized block" });
+    stream.updateAssistantText("Completed block");
+    await stream.forceNewMessage();
+
+    expect(stream.resolveFinalText("Completed block")).toEqual({
+      kind: "already-delivered",
+      publishedParts: [{ messageId: "post-1", content: "Provider-finalized block" }],
+    });
   });
 
   it("keeps the canonical final when an assistant boundary fails to publish", async () => {
@@ -577,7 +610,59 @@ describe("createMattermostDraftStream forceNewMessage", () => {
     await stream.forceNewMessage();
 
     const finalText = "First block complete\n\nFinal after failure";
-    expect(stream.resolveFinalText(finalText)).toEqual({ kind: "full", text: finalText });
+    expect(stream.resolveFinalText(finalText)).toEqual({
+      kind: "remaining",
+      text: "complete\n\nFinal after failure",
+      publishedParts: [{ messageId: "post-1", content: "First block" }],
+    });
+  });
+
+  it("retains posts published before a later boundary chunk fails", async () => {
+    const { client, requestMock } = createMockClient();
+    const stream = createMattermostDraftStream({
+      client,
+      channelId: "channel-1",
+      throttleMs: 0,
+      chunkText: () => ["First half", "Second half"],
+    });
+
+    stream.updateAssistantText("First half Second half");
+    await stream.flush();
+    requestMock
+      .mockResolvedValueOnce({ id: "post-1", message: "First half" })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    await stream.forceNewMessage();
+
+    const finalText = "First half Second half\n\nFinal after failure";
+    expect(stream.resolveFinalText(finalText)).toEqual({
+      kind: "remaining",
+      text: "Second half\n\nFinal after failure",
+      publishedParts: [{ messageId: "post-1", content: "First half" }],
+    });
+  });
+
+  it("does not strip a requested prefix rewritten by the provider", async () => {
+    const { client, requestMock } = createMockClient();
+    const stream = createMattermostDraftStream({
+      client,
+      channelId: "channel-1",
+      throttleMs: 0,
+      chunkText: () => ["First half", "Second half"],
+    });
+
+    stream.updateAssistantText("First half Second half");
+    await stream.flush();
+    requestMock
+      .mockResolvedValueOnce({ id: "post-1", message: "Provider rewrite" })
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    await stream.forceNewMessage();
+
+    const finalText = "First half Second half\n\nFinal after failure";
+    expect(stream.resolveFinalText(finalText)).toEqual({
+      kind: "full",
+      text: finalText,
+      publishedParts: [{ messageId: "post-1", content: "Provider rewrite" }],
+    });
   });
 });
 

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -12,10 +12,26 @@ import {
 const MATTERMOST_STREAM_MAX_CHARS = 4000;
 const DEFAULT_THROTTLE_MS = 1000;
 
+type MattermostDraftPublishedPart = {
+  messageId: string;
+  content: string;
+};
+
 type MattermostFinalTextResolution =
-  | { kind: "full"; text: string }
-  | { kind: "remaining"; text: string }
-  | { kind: "already-delivered" };
+  | {
+      kind: "full";
+      text: string;
+      publishedParts: readonly MattermostDraftPublishedPart[];
+    }
+  | {
+      kind: "remaining";
+      text: string;
+      publishedParts: readonly MattermostDraftPublishedPart[];
+    }
+  | {
+      kind: "already-delivered";
+      publishedParts: readonly MattermostDraftPublishedPart[];
+    };
 
 type MattermostDraftStream = {
   update: (text: string) => void;
@@ -40,6 +56,22 @@ function normalizeMattermostDraftText(text: string, maxChars: number): string {
     return trimmed;
   }
   return `${sliceUtf16Safe(trimmed, 0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+}
+
+function consumeMattermostPublishedChunk(params: {
+  source: string;
+  offset: number;
+  chunk: string;
+}): number | undefined {
+  const chunk = params.chunk.trim();
+  if (!chunk) {
+    return params.offset;
+  }
+  let offset = params.offset;
+  while (offset < params.source.length && /\s/.test(params.source[offset] ?? "")) {
+    offset += 1;
+  }
+  return params.source.startsWith(chunk, offset) ? offset + chunk.length : undefined;
 }
 
 type MattermostDraftPreviewBoundaryController = {
@@ -89,6 +121,7 @@ export function createMattermostDraftStream(params: {
   type DraftGeneration = {
     postId?: string;
     lastSentText: string;
+    lastProviderText?: string;
     // A boundary can arrive after pending text flushed. Keep the full source so sealing can
     // replace the ellipsized preview with lossless chunks instead of retaining truncation.
     latestSourceText: string;
@@ -100,7 +133,11 @@ export function createMattermostDraftStream(params: {
     latestSourceText: "",
     ready: Promise.resolve(),
   };
-  const sealedAssistantTexts: string[] = [];
+  const sealedAssistantTexts: Array<{ text: string; requiresBlockBoundary: boolean }> = [];
+  const publishedAssistantParts = new Map<string, MattermostDraftPublishedPart>();
+  const trackPublishedAssistantPart = (part: MattermostDraftPublishedPart) => {
+    publishedAssistantParts.set(part.messageId, part);
+  };
 
   const sendOrEditStreamMessage = async (text: string): Promise<boolean> => {
     if (streamState.stopped && !streamState.final) {
@@ -121,9 +158,10 @@ export function createMattermostDraftStream(params: {
     }
     try {
       if (target.postId) {
-        await updateMattermostPost(params.client, target.postId, {
+        const updated = await updateMattermostPost(params.client, target.postId, {
           message: normalized,
         });
+        target.lastProviderText = updated.message ?? normalized;
       } else {
         const sent = await createMattermostPost(params.client, {
           channelId: params.channelId,
@@ -137,6 +175,7 @@ export function createMattermostDraftStream(params: {
           return false;
         }
         target.postId = postId;
+        target.lastProviderText = sent.message ?? normalized;
       }
       target.lastSentText = normalized;
       return true;
@@ -185,6 +224,8 @@ export function createMattermostDraftStream(params: {
     const pendingText = loop.takePending();
     const inFlightAtBoundary = loop.waitForInFlight();
     const sealed = currentGeneration;
+    const assistantText = sealed.latestAssistantText?.trim();
+    let publishedAssistantOffset = 0;
     const boundary = (async () => {
       try {
         await sealed.ready;
@@ -203,28 +244,97 @@ export function createMattermostDraftStream(params: {
           return;
         }
         if (sealed.postId) {
+          if (assistantText && (sealed.lastProviderText || sealed.lastSentText)) {
+            const publishedContent = sealed.lastProviderText ?? sealed.lastSentText;
+            // The existing preview remains visible if its lossless boundary edit fails.
+            trackPublishedAssistantPart({
+              messageId: sealed.postId,
+              content: publishedContent,
+            });
+            publishedAssistantOffset =
+              consumeMattermostPublishedChunk({
+                source: assistantText,
+                offset: 0,
+                chunk: publishedContent,
+              }) ?? 0;
+          }
+          let providerFirstChunk = sealed.lastProviderText ?? firstChunk;
           if (firstChunk !== sealed.lastSentText) {
-            await updateMattermostPost(params.client, sealed.postId, { message: firstChunk });
+            const updated = await updateMattermostPost(params.client, sealed.postId, {
+              message: firstChunk,
+            });
+            providerFirstChunk = updated.message ?? firstChunk;
+          }
+          if (assistantText) {
+            trackPublishedAssistantPart({
+              messageId: sealed.postId,
+              content: providerFirstChunk,
+            });
+            publishedAssistantOffset =
+              consumeMattermostPublishedChunk({
+                source: assistantText,
+                offset: 0,
+                chunk: providerFirstChunk,
+              }) ?? 0;
           }
         } else {
-          await createMattermostPost(params.client, {
+          const firstPost = await createMattermostPost(params.client, {
             channelId: params.channelId,
             message: firstChunk,
             rootId: params.rootId,
           });
+          const firstPostId = firstPost.id?.trim();
+          if (!firstPostId) {
+            throw new Error("missing post id from boundary create");
+          }
+          if (assistantText) {
+            const publishedContent = firstPost.message ?? firstChunk;
+            trackPublishedAssistantPart({
+              messageId: firstPostId,
+              content: publishedContent,
+            });
+            publishedAssistantOffset =
+              consumeMattermostPublishedChunk({
+                source: assistantText,
+                offset: 0,
+                chunk: publishedContent,
+              }) ?? 0;
+          }
         }
         for (const chunk of chunks.slice(1)) {
-          await createMattermostPost(params.client, {
+          const post = await createMattermostPost(params.client, {
             channelId: params.channelId,
             message: chunk,
             rootId: params.rootId,
           });
+          const postId = post.id?.trim();
+          if (!postId) {
+            throw new Error("missing post id from boundary create");
+          }
+          if (assistantText) {
+            const publishedContent = post.message ?? chunk;
+            trackPublishedAssistantPart({ messageId: postId, content: publishedContent });
+            publishedAssistantOffset =
+              consumeMattermostPublishedChunk({
+                source: assistantText,
+                offset: publishedAssistantOffset,
+                chunk: publishedContent,
+              }) ?? publishedAssistantOffset;
+          }
         }
-        const assistantText = sealed.latestAssistantText?.trim();
         if (assistantText) {
-          sealedAssistantTexts.push(assistantText);
+          sealedAssistantTexts.push({ text: assistantText, requiresBlockBoundary: true });
         }
       } catch (err) {
+        const publishedAssistantPrefix = assistantText?.slice(0, publishedAssistantOffset).trim();
+        if (publishedAssistantPrefix) {
+          // A later physical chunk failed after this exact source prefix became durable.
+          // Strip only that proven prefix; unlike a completed block, its suffix is inline.
+          sealedAssistantTexts.push({
+            text: publishedAssistantPrefix,
+            requiresBlockBoundary: false,
+          });
+        }
         params.warn?.(
           `mattermost stream preview boundary flush failed: ${err instanceof Error ? err.message : String(err)}`,
         );
@@ -272,32 +382,33 @@ export function createMattermostDraftStream(params: {
     await currentGeneration.ready;
   };
   const resolveFinalText = (text: string) => {
+    const publishedParts = [...publishedAssistantParts.values()];
     if (sealedAssistantTexts.length === 0) {
-      return { kind: "full" as const, text };
+      return { kind: "full" as const, text, publishedParts };
     }
 
     let remainingText = text.trim();
     for (const sealedText of sealedAssistantTexts) {
-      const completed = sealedText.trim();
+      const completed = sealedText.text.trim();
       if (!completed || !remainingText.startsWith(completed)) {
-        return { kind: "full" as const, text };
+        return { kind: "full" as const, text, publishedParts };
       }
       const suffix = remainingText.slice(completed.length);
       // Canonical assistant block aggregation uses newline separators. A plain-space
       // suffix can be a block-local final that merely shares the prior block's prefix.
-      if (suffix && !/^\r?\n/.test(suffix)) {
-        return { kind: "full" as const, text };
+      if (sealedText.requiresBlockBoundary && suffix && !/^\r?\n/.test(suffix)) {
+        return { kind: "full" as const, text, publishedParts };
       }
-      remainingText = suffix.replace(/^(?:\r?\n)+/, "");
+      remainingText = suffix.replace(sealedText.requiresBlockBoundary ? /^(?:\r?\n)+/ : /^\s+/, "");
     }
     const currentText = currentGeneration.latestAssistantText?.trim() ?? "";
     const remaining = remainingText.trim();
     if (currentText && !remaining.startsWith(currentText)) {
-      return { kind: "full" as const, text };
+      return { kind: "full" as const, text, publishedParts };
     }
     return remaining
-      ? { kind: "remaining" as const, text: remaining }
-      : { kind: "already-delivered" as const };
+      ? { kind: "remaining" as const, text: remaining, publishedParts }
+      : { kind: "already-delivered" as const, publishedParts };
   };
 
   params.log?.(`mattermost stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);

--- a/extensions/mattermost/src/mattermost/monitor-context.ts
+++ b/extensions/mattermost/src/mattermost/monitor-context.ts
@@ -38,6 +38,13 @@ export function buildMattermostModelPickerSelectMessageSid(params: {
   return `interaction:${params.postId}:select:${provider}/${model}`;
 }
 
+export function buildMattermostButtonInteractionMessageSid(params: {
+  postId: string;
+  actionId: string;
+}): string {
+  return `interaction:${params.postId}:${params.actionId}`;
+}
+
 export function resolveMattermostReplyRootId(params: {
   kind: ChatType;
   threadRootId?: string;
@@ -53,6 +60,26 @@ export function resolveMattermostReplyRootId(params: {
     return threadRootId;
   }
   return normalizeOptionalString(params.replyToId);
+}
+
+export function resolveMattermostInteractionReplyRootId(params: {
+  kind: ChatType;
+  threadRootId?: string;
+  replyToId?: string;
+  interactionMessageSid: string;
+  sourcePostId: string;
+}): string | undefined {
+  const interactionMessageSid = normalizeOptionalString(params.interactionMessageSid);
+  const replyToId = normalizeOptionalString(params.replyToId);
+  // Interaction MessageSid values identify synthetic inbound events, not provider posts.
+  // Map only reply-to-current back to the source post or Mattermost rejects the root.
+  const providerReplyToId =
+    replyToId === interactionMessageSid ? normalizeOptionalString(params.sourcePostId) : replyToId;
+  return resolveMattermostReplyRootId({
+    kind: params.kind,
+    threadRootId: params.threadRootId,
+    replyToId: providerReplyToId,
+  });
 }
 
 export function canFinalizeMattermostPreviewInPlace(params: {

--- a/extensions/mattermost/src/mattermost/monitor-draft-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-draft-delivery.test.ts
@@ -1,0 +1,716 @@
+// Mattermost tests cover draft-preview delivery settlement.
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as clientModule from "./client.js";
+import type { MattermostClient } from "./client.js";
+import { deliverMattermostReplyWithDraftPreview } from "./monitor-draft-delivery.js";
+
+const updateMattermostPostSpy = vi.spyOn(clientModule, "updateMattermostPost");
+
+function createMattermostClientMock(): MattermostClient {
+  return {
+    baseUrl: "https://chat.example.com",
+    apiBaseUrl: "https://chat.example.com/api/v4",
+    token: "token",
+    request: vi.fn(async () => ({})) as MattermostClient["request"],
+    fetchImpl: vi.fn(
+      async () => new Response(null, { status: 200 }),
+    ) as MattermostClient["fetchImpl"],
+  };
+}
+
+function createDraftStreamMock(postId: string | null | undefined = "preview-post-1") {
+  return {
+    flush: vi.fn(async () => {}),
+    postId: vi.fn(() => postId ?? undefined),
+    clear: vi.fn(async () => {}),
+    discardPending: vi.fn(async () => {}),
+    seal: vi.fn(async () => {}),
+  };
+}
+
+function createDeliverFinalMock() {
+  return vi.fn(async (payload: { text?: string }) => ({
+    outcome: "text" as const,
+    messageIds: ["delivered-post-1"],
+    receipt: createMessageReceiptFromOutboundResults({
+      results: [{ channel: "mattermost", messageId: "delivered-post-1" }],
+      kind: "text",
+    }),
+    visibleReplySent: true,
+    content: payload.text ?? "",
+  }));
+}
+
+function resolvePreviewFinalText(text?: string) {
+  const editText = text?.trim();
+  return editText ? { editText, alreadyDelivered: false } : undefined;
+}
+
+function mockCall(mock: { mock: { calls: unknown[][] } }, index: number, label: string): unknown[] {
+  const resolvedIndex = index < 0 ? mock.mock.calls.length + index : index;
+  const call = mock.mock.calls[resolvedIndex];
+  if (!call) {
+    throw new Error(`expected ${label} call ${index}`);
+  }
+  return call;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateMattermostPostSpy.mockResolvedValue({ id: "patched" } as never);
+});
+
+describe("deliverMattermostReplyWithDraftPreview", () => {
+  it("suppresses reasoning-prefixed finals before preview finalization", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+    const recordThreadParticipation = vi.fn();
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "  \n > Reasoning:\n> _hidden_" } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText,
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      recordThreadParticipation,
+      deliverPayload: deliverFinal,
+    });
+
+    expect(deliverFinal).not.toHaveBeenCalled();
+    expect(draftStream.flush).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(updateMattermostPostSpy).not.toHaveBeenCalled();
+    // No visible reply was sent, so the thread must not be marked as participated.
+    expect(recordThreadParticipation).not.toHaveBeenCalled();
+  });
+
+  it("records thread participation when a same-thread final finalizes the preview in place", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+    const recordThreadParticipation = vi.fn();
+
+    const result = await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "All good" } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText,
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      recordThreadParticipation,
+      deliverPayload: deliverFinal,
+    });
+
+    // Default streaming finalizes by editing the preview post, bypassing deliverPayload —
+    // participation must still be recorded (regression: PR #95552 review P1).
+    expect(updateMattermostPostSpy).toHaveBeenCalledWith(expect.anything(), "preview-post-1", {
+      message: "All good",
+    });
+    expect(deliverFinal).not.toHaveBeenCalled();
+    expect(recordThreadParticipation).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      outcome: "text",
+      messageIds: ["patched"],
+      visibleReplySent: true,
+      content: "All good",
+    });
+  });
+
+  it("reports a final already published in a sealed preview generation", async () => {
+    const draftStream = createDraftStreamMock(null);
+    const deliverFinal = createDeliverFinalMock();
+    const confirmedReceipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "mattermost", messageId: "sealed-post-1" }],
+      kind: "preview",
+    });
+
+    const result = await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "Already visible" } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: () => ({
+        alreadyDelivered: true,
+        confirmedDelivery: {
+          outcome: "text",
+          messageIds: ["sealed-post-1"],
+          receipt: confirmedReceipt,
+          visibleReplySent: true,
+          content: "Already visible",
+        },
+      }),
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(deliverFinal).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      outcome: "text",
+      messageIds: ["sealed-post-1"],
+      visibleReplySent: true,
+      content: "Already visible",
+    });
+  });
+
+  it("still delivers media when the text is already published", async () => {
+    const draftStream = createDraftStreamMock(null);
+    const confirmedReceipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "mattermost", messageId: "sealed-post-1" }],
+      kind: "preview",
+    });
+    const mediaReceipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "mattermost", messageId: "media-post-1" }],
+      kind: "media",
+    });
+    const deliverFinal = vi.fn(async () => ({
+      outcome: "media" as const,
+      messageIds: ["media-post-1"],
+      receipt: mediaReceipt,
+      visibleReplySent: true,
+      content: "",
+    }));
+
+    const result = await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "Already visible", mediaUrl: "https://example.com/image.png" } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: () => ({
+        alreadyDelivered: true,
+        confirmedDelivery: {
+          outcome: "text",
+          messageIds: ["sealed-post-1"],
+          receipt: confirmedReceipt,
+          visibleReplySent: true,
+          content: "Already visible",
+        },
+      }),
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(deliverFinal).toHaveBeenCalledExactlyOnceWith({
+      text: "",
+      mediaUrl: "https://example.com/image.png",
+    });
+    expect(result).toMatchObject({
+      outcome: "media",
+      messageIds: ["sealed-post-1", "media-post-1"],
+      visibleReplySent: true,
+      content: "Already visible",
+    });
+  });
+
+  it("aggregates sealed and current preview posts into one terminal result", async () => {
+    const draftStream = createDraftStreamMock("current-preview");
+    const deliverFinal = createDeliverFinalMock();
+    const confirmedReceipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "mattermost", messageId: "sealed-post-1" }],
+      kind: "preview",
+    });
+
+    const result = await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "First block\n\nSecond block" } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: () => ({
+        editText: "Second block",
+        alreadyDelivered: false,
+        confirmedDelivery: {
+          outcome: "text",
+          messageIds: ["sealed-post-1"],
+          receipt: confirmedReceipt,
+          visibleReplySent: true,
+          content: "First block",
+        },
+      }),
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(deliverFinal).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      outcome: "text",
+      messageIds: ["sealed-post-1", "patched"],
+      visibleReplySent: true,
+      content: "First block\nSecond block",
+    });
+    expect(result.receipt?.parts.map((part) => part.platformMessageId)).toEqual([
+      "sealed-post-1",
+      "patched",
+    ]);
+  });
+
+  it("sends only the remaining suffix after a partial boundary publish", async () => {
+    const draftStream = createDraftStreamMock(null);
+    const deliverFinal = createDeliverFinalMock();
+    const confirmedReceipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "mattermost", messageId: "partial-post-1" }],
+      kind: "preview",
+    });
+
+    const result = await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "First half Second half" } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: () => ({
+        editText: "Second half",
+        deliveryText: "Second half",
+        alreadyDelivered: false,
+        confirmedDelivery: {
+          outcome: "text",
+          messageIds: ["partial-post-1"],
+          receipt: confirmedReceipt,
+          visibleReplySent: true,
+          content: "First half",
+        },
+      }),
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(deliverFinal).toHaveBeenCalledExactlyOnceWith({ text: "Second half" });
+    expect(result).toMatchObject({
+      messageIds: ["partial-post-1", "delivered-post-1"],
+      visibleReplySent: true,
+      content: "First half\nSecond half",
+    });
+  });
+
+  it("keeps a finalized preview when a later tool warning is delivered", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+    const previewState = { finalizedViaPreviewPost: false };
+    const params = {
+      kind: "direct" as const,
+      client: createMattermostClientMock(),
+      draftStream,
+      resolvePreviewFinalText,
+      previewState,
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    };
+
+    await deliverMattermostReplyWithDraftPreview({
+      ...params,
+      payload: { text: "Successful assistant final" } as never,
+      info: { kind: "final" },
+    });
+    await deliverMattermostReplyWithDraftPreview({
+      ...params,
+      payload: { text: "Tool error warning", isError: true } as never,
+      info: { kind: "final" },
+    });
+
+    expect(previewState.finalizedViaPreviewPost).toBe(true);
+    expect(deliverFinal).toHaveBeenCalledExactlyOnceWith({
+      text: "Tool error warning",
+      isError: true,
+    });
+    expect(draftStream.discardPending).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+  });
+
+  it("deletes the preview after a successful normal final send", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "All good", replyToId: "reply-1" } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      resolvePreviewFinalText,
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(deliverFinal).toHaveBeenCalledTimes(1);
+    expect(draftStream.flush).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(updateMattermostPostSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves a completed normal send when preview cleanup fails", async () => {
+    const draftStream = createDraftStreamMock();
+    draftStream.clear.mockRejectedValueOnce(new Error("preview cleanup failed"));
+    const deliverFinal = createDeliverFinalMock();
+
+    let caught: unknown;
+    try {
+      await deliverMattermostReplyWithDraftPreview({
+        payload: { text: "Already visible", replyToId: "reply-1" } as never,
+        info: { kind: "final" },
+        kind: "channel",
+        client: createMattermostClientMock(),
+        draftStream,
+        resolvePreviewFinalText,
+        previewState: { finalizedViaPreviewPost: false },
+        logVerboseMessage: vi.fn(),
+        deliverPayload: deliverFinal,
+      });
+    } catch (error: unknown) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected a partial Mattermost preview delivery error");
+    }
+    expect(caught.deliveryResult).toMatchObject({
+      messageIds: ["delivered-post-1"],
+      visibleReplySent: true,
+      content: "Already visible",
+    });
+    expect(deliverFinal).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the preview after a successful non-finalizable media final", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: {
+        text: "Photo",
+        replyToId: "reply-1",
+        mediaUrl: "https://example.com/a.png",
+      } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText,
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(deliverFinal).toHaveBeenCalledTimes(1);
+    expect(draftStream.flush).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the preview and sends media-only for TTS supplement finals", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: {
+        mediaUrl: "https://example.com/tts.mp3",
+        audioAsVoice: true,
+        spokenText: "Spoken answer",
+        ttsSupplement: { spokenText: "Spoken answer" },
+      } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText,
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(updateMattermostPostSpy).toHaveBeenCalledWith(expect.anything(), "preview-post-1", {
+      message: "Spoken answer",
+    });
+    expect(draftStream.discardPending).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(deliverFinal).toHaveBeenCalledWith({
+      mediaUrl: "https://example.com/tts.mp3",
+      audioAsVoice: true,
+      spokenText: "Spoken answer",
+      ttsSupplement: { spokenText: "Spoken answer" },
+    });
+  });
+
+  it("preserves the finalized preview receipt when its supplement fails after sending", async () => {
+    const draftStream = createDraftStreamMock();
+    const mediaReceipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "mattermost", messageId: "media-post-1" }],
+      kind: "media",
+    });
+    const deliverFinal = vi.fn(async () => {
+      throw createChannelPartialDeliveryError(new Error("supplement bookkeeping failed"), {
+        messageIds: ["media-post-1"],
+        receipt: mediaReceipt,
+        visibleReplySent: true,
+        content: "",
+      });
+    });
+
+    let caught: unknown;
+    try {
+      await deliverMattermostReplyWithDraftPreview({
+        payload: {
+          mediaUrl: "https://example.com/tts.mp3",
+          audioAsVoice: true,
+          spokenText: "Spoken answer",
+          ttsSupplement: { spokenText: "Spoken answer" },
+        } as never,
+        info: { kind: "final" },
+        kind: "channel",
+        client: createMattermostClientMock(),
+        draftStream,
+        effectiveReplyToId: "thread-root-1",
+        resolvePreviewFinalText,
+        previewState: { finalizedViaPreviewPost: false },
+        logVerboseMessage: vi.fn(),
+        deliverPayload: deliverFinal,
+      });
+    } catch (error: unknown) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected a partial Mattermost preview delivery error");
+    }
+    expect(caught.deliveryResult).toMatchObject({
+      messageIds: ["patched", "media-post-1"],
+      visibleReplySent: true,
+      content: "Spoken answer",
+    });
+  });
+
+  it("falls back with visible text when TTS supplement preview finalization fails", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+    updateMattermostPostSpy.mockRejectedValueOnce(new Error("edit failed"));
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: {
+        mediaUrl: "https://example.com/tts.mp3",
+        audioAsVoice: true,
+        spokenText: "Spoken answer",
+        ttsSupplement: { spokenText: "Spoken answer" },
+      } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: (text) => ({
+        editText: text?.trim(),
+        deliveryText: "",
+        alreadyDelivered: false,
+      }),
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(updateMattermostPostSpy).toHaveBeenCalledTimes(1);
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    expect(deliverFinal).toHaveBeenCalledWith({
+      text: "Spoken answer",
+      mediaUrl: "https://example.com/tts.mp3",
+      audioAsVoice: true,
+      spokenText: "Spoken answer",
+      ttsSupplement: { spokenText: "Spoken answer" },
+    });
+  });
+
+  it("keeps already-delivered TTS supplement fallback audio-only", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+    updateMattermostPostSpy.mockRejectedValueOnce(new Error("edit failed"));
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: {
+        mediaUrl: "https://example.com/tts.mp3",
+        audioAsVoice: true,
+        spokenText: "Spoken answer",
+        ttsSupplement: {
+          spokenText: "Spoken answer",
+          visibleTextAlreadyDelivered: true,
+        },
+      } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: (text) => ({
+        editText: text?.trim(),
+        deliveryText: text?.trim(),
+        alreadyDelivered: false,
+      }),
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(deliverFinal).toHaveBeenCalledWith({
+      mediaUrl: "https://example.com/tts.mp3",
+      audioAsVoice: true,
+      spokenText: "Spoken answer",
+      ttsSupplement: {
+        spokenText: "Spoken answer",
+        visibleTextAlreadyDelivered: true,
+      },
+    });
+  });
+
+  it("keeps provider-confirmed TTS preview text out of normal media fallback", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: {
+        mediaUrl: "https://example.com/tts.mp3",
+        audioAsVoice: true,
+        spokenText: "Spoken answer",
+        ttsSupplement: { spokenText: "Spoken answer" },
+      } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText: () => ({
+        deliveryText: "",
+        confirmedDelivery: {
+          outcome: "text",
+          messageIds: ["preview-post-1"],
+          receipt: createMessageReceiptFromOutboundResults({
+            results: [{ channel: "mattermost", messageId: "preview-post-1" }],
+            kind: "preview",
+          }),
+          visibleReplySent: true,
+          content: "Spoken answer",
+        },
+        alreadyDelivered: true,
+      }),
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(deliverFinal).toHaveBeenCalledWith({
+      mediaUrl: "https://example.com/tts.mp3",
+      audioAsVoice: true,
+      spokenText: "Spoken answer",
+      ttsSupplement: { spokenText: "Spoken answer" },
+    });
+  });
+
+  it("does not flush error finals before normal delivery", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "Error", isError: true } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftStream,
+      effectiveReplyToId: "thread-root-1",
+      resolvePreviewFinalText,
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(draftStream.flush).not.toHaveBeenCalled();
+    expect(deliverFinal).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("finalizes the preview in place when the final targets the same thread", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = createDeliverFinalMock();
+    const client = createMattermostClientMock();
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "Final answer", replyToId: "child-post-789" } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client,
+      draftStream,
+      effectiveReplyToId: "thread-root-456",
+      resolvePreviewFinalText,
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverPayload: deliverFinal,
+    });
+
+    expect(updateMattermostPostSpy).toHaveBeenCalledTimes(1);
+    const [updateClient, updatePostId, updateParams] = mockCall(
+      updateMattermostPostSpy,
+      0,
+      "updateMattermostPost",
+    );
+    expect(updateClient).toBe(client);
+    expect(updatePostId).toBe("preview-post-1");
+    expect(updateParams).toStrictEqual({ message: "Final answer" });
+    expect(draftStream.flush).toHaveBeenCalledTimes(1);
+    expect(draftStream.seal).toHaveBeenCalledTimes(1);
+    expect(draftStream.seal.mock.invocationCallOrder[0]).toBeLessThan(
+      updateMattermostPostSpy.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(deliverFinal).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+  });
+
+  it("keeps the existing preview unchanged when final delivery fails", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = vi.fn(async () => {
+      throw new Error("send failed");
+    });
+
+    await expect(
+      deliverMattermostReplyWithDraftPreview({
+        payload: { text: "Broken", replyToId: "reply-1" } as never,
+        info: { kind: "final" },
+        kind: "channel",
+        client: createMattermostClientMock(),
+        draftStream,
+        resolvePreviewFinalText,
+        previewState: { finalizedViaPreviewPost: false },
+        logVerboseMessage: vi.fn(),
+        deliverPayload: deliverFinal,
+      }),
+    ).rejects.toThrow("send failed");
+
+    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(updateMattermostPostSpy).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
+++ b/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
@@ -1,21 +1,40 @@
 // Mattermost plugin module owns draft-preview final delivery.
 import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createMessageReceiptFromOutboundResults,
   defineFinalizableLivePreviewAdapter,
   deliverWithFinalizableLivePreviewAdapter,
+  listMessageReceiptPlatformIds,
+  type MessageReceipt,
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
   buildTtsSupplementMediaPayload,
   getReplyPayloadTtsSupplement,
   isReasoningReplyPayload,
+  resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
-import { updateMattermostPost, type MattermostClient } from "./client.js";
+import { updateMattermostPost, type MattermostClient, type MattermostPost } from "./client.js";
 import { createMattermostDraftStream } from "./draft-stream.js";
 import { canFinalizeMattermostPreviewInPlace } from "./monitor-context.js";
+import {
+  joinMattermostVisibleContent,
+  type MattermostReplyDeliveryResult,
+} from "./reply-delivery.js";
 import type { ChatType, ReplyPayload } from "./runtime-api.js";
 
 export type MattermostDraftPreviewState = {
   /** True once the preview is the durable final post and must not be reused as a draft. */
   finalizedViaPreviewPost: boolean;
+};
+
+export type MattermostPreviewFinalResolution = {
+  editText?: string;
+  deliveryText?: string;
+  confirmedDelivery?: MattermostReplyDeliveryResult;
+  alreadyDelivered: boolean;
 };
 
 type MattermostDraftPreviewDeliverParams = {
@@ -28,89 +47,244 @@ type MattermostDraftPreviewDeliverParams = {
     "flush" | "postId" | "clear" | "discardPending" | "seal"
   >;
   effectiveReplyToId?: string;
-  resolvePreviewFinalText: (text?: string) => string | undefined;
+  resolvePreviewFinalText: (text?: string) => MattermostPreviewFinalResolution | undefined;
   previewState: MattermostDraftPreviewState;
   logVerboseMessage: (message: string) => void;
-  deliverPayload: (payload: ReplyPayload) => Promise<void>;
+  deliverPayload: (payload: ReplyPayload) => Promise<MattermostReplyDeliveryResult>;
   // Visible same-thread finals can be delivered by editing the draft preview in
   // place (onPreviewFinalized) without ever calling deliverPayload; this lets the
   // caller record thread participation on that path too.
   recordThreadParticipation?: () => void;
 };
 
+function combineMattermostVisibleDeliveryResults(
+  results: readonly (MattermostReplyDeliveryResult | undefined)[],
+): MattermostReplyDeliveryResult | undefined {
+  const visibleResults = results.filter(
+    (result): result is MattermostReplyDeliveryResult => result?.visibleReplySent === true,
+  );
+  if (visibleResults.length === 0) {
+    return undefined;
+  }
+  const receiptResults: Array<{ receipt: MessageReceipt } | { messageId: string }> = [];
+  for (const result of visibleResults) {
+    if (result.receipt) {
+      receiptResults.push({ receipt: result.receipt });
+    } else {
+      receiptResults.push(...(result.messageIds ?? []).map((messageId) => ({ messageId })));
+    }
+  }
+  const receipt = createMessageReceiptFromOutboundResults({
+    results: receiptResults,
+  });
+  return {
+    outcome: visibleResults.some((result) => result.outcome === "media") ? "media" : "text",
+    messageIds: listMessageReceiptPlatformIds(receipt),
+    receipt,
+    visibleReplySent: true,
+    content: joinMattermostVisibleContent(visibleResults.map((result) => result.content)),
+  };
+}
+
 export async function deliverMattermostReplyWithDraftPreview(
   params: MattermostDraftPreviewDeliverParams,
-): Promise<void> {
+): Promise<MattermostReplyDeliveryResult> {
   if (isReasoningReplyPayload(params.payload)) {
-    return;
+    return {
+      outcome: "reasoning_skipped",
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    };
   }
 
-  await deliverWithFinalizableLivePreviewAdapter({
-    kind: params.info.kind,
-    payload: params.payload,
-    adapter: defineFinalizableLivePreviewAdapter<ReplyPayload, string, { message: string }>({
-      // Once the preview is finalized, later payloads must use durable sends.
-      // Reusing the sealed draft would clear and delete the successful final post.
-      ...(params.previewState.finalizedViaPreviewPost
-        ? {}
-        : {
-            draft: {
-              flush: params.draftStream.flush,
-              clear: params.draftStream.clear,
-              discardPending: params.draftStream.discardPending,
-              seal: params.draftStream.seal,
-              id: params.draftStream.postId,
-            },
-          }),
-      buildFinalEdit: (payload) => {
-        const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
-        const ttsSupplement = getReplyPayloadTtsSupplement(payload);
-        const previewFinalText = params.resolvePreviewFinalText(
-          payload.text ?? ttsSupplement?.spokenText,
-        );
+  let normalDeliveryResult: MattermostReplyDeliveryResult | undefined;
+  let supplementalDeliveryResult: MattermostReplyDeliveryResult | undefined;
+  let previewDeliveryResult: MattermostReplyDeliveryResult | undefined;
+  let confirmedPreviewDelivery: MattermostReplyDeliveryResult | undefined;
+  let previewFinalDeliveryText: string | undefined;
+  let previewFinalTextAlreadyDelivered = false;
+  let useConfirmedPreviewAsWholeFinal = false;
+  let pendingPreviewFinalContent: string | undefined;
+  let finalizedPreviewPost: MattermostPost | undefined;
+  try {
+    const finalization = await deliverWithFinalizableLivePreviewAdapter({
+      kind: params.info.kind,
+      payload: params.payload,
+      adapter: defineFinalizableLivePreviewAdapter<ReplyPayload, string, { message: string }>({
+        // Once the preview is finalized, later payloads must use durable sends.
+        // Reusing the sealed draft would clear and delete the successful final post.
+        ...(params.previewState.finalizedViaPreviewPost
+          ? {}
+          : {
+              draft: {
+                flush: params.draftStream.flush,
+                clear: params.draftStream.clear,
+                discardPending: params.draftStream.discardPending,
+                seal: params.draftStream.seal,
+                id: params.draftStream.postId,
+              },
+            }),
+        buildFinalEdit: (payload) => {
+          const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+          const ttsSupplement = getReplyPayloadTtsSupplement(payload);
+          const previewFinalResolution = params.resolvePreviewFinalText(
+            payload.text ?? ttsSupplement?.spokenText,
+          );
+          confirmedPreviewDelivery = previewFinalResolution?.confirmedDelivery;
+          previewFinalDeliveryText = previewFinalResolution?.deliveryText;
+          previewFinalTextAlreadyDelivered =
+            previewFinalResolution?.alreadyDelivered === true && payload.isError !== true;
+          useConfirmedPreviewAsWholeFinal =
+            previewFinalTextAlreadyDelivered &&
+            !resolveSendableOutboundReplyParts(payload).hasMedia;
+          const previewFinalText = previewFinalResolution?.editText;
 
+          if (
+            (hasMedia && !ttsSupplement) ||
+            typeof previewFinalText !== "string" ||
+            payload.isError ||
+            !canFinalizeMattermostPreviewInPlace({
+              kind: params.kind,
+              previewRootId: params.effectiveReplyToId,
+              threadRootId: params.effectiveReplyToId,
+              replyToId: payload.replyToId,
+            })
+          ) {
+            return undefined;
+          }
+          pendingPreviewFinalContent = previewFinalText;
+          return { message: previewFinalText };
+        },
+        editFinal: async (previewPostId, edit) => {
+          finalizedPreviewPost = await updateMattermostPost(params.client, previewPostId, edit);
+        },
+        resolveFinalizedId: (previewPostId) => finalizedPreviewPost?.id ?? previewPostId,
+        onPreviewFinalized: (_previewPostId, receipt) => {
+          params.previewState.finalizedViaPreviewPost = true;
+          previewDeliveryResult = {
+            outcome: "text",
+            messageIds: listMessageReceiptPlatformIds(receipt),
+            receipt,
+            visibleReplySent: true,
+            content: finalizedPreviewPost?.message ?? pendingPreviewFinalContent ?? "",
+          };
+          // The visible final reply landed by editing the preview post, so the normal
+          // deliverPayload record path is skipped; record participation explicitly here.
+          params.recordThreadParticipation?.();
+        },
+        buildSupplementalPayload: (payload) =>
+          getReplyPayloadTtsSupplement(payload)
+            ? buildTtsSupplementMediaPayload(payload)
+            : undefined,
+        deliverSupplemental: async (payload) => {
+          supplementalDeliveryResult = await params.deliverPayload(payload);
+          return supplementalDeliveryResult.visibleReplySent;
+        },
+        logPreviewEditFailure: (err) => {
+          params.logVerboseMessage(
+            `mattermost preview final edit failed; falling back to normal send (${String(err)})`,
+          );
+        },
+      }),
+      deliverNormally: async (payload) => {
         if (
-          (hasMedia && !ttsSupplement) ||
-          typeof previewFinalText !== "string" ||
-          payload.isError ||
-          !canFinalizeMattermostPreviewInPlace({
-            kind: params.kind,
-            previewRootId: params.effectiveReplyToId,
-            threadRootId: params.effectiveReplyToId,
-            replyToId: payload.replyToId,
-          })
+          useConfirmedPreviewAsWholeFinal &&
+          confirmedPreviewDelivery?.visibleReplySent === true
         ) {
-          return undefined;
+          // The logical final is already durable in sealed preview generations. Report
+          // those provider posts as the normal success so cleanup cannot erase the fact.
+          return true;
         }
-        return { message: previewFinalText };
+        const supplement = getReplyPayloadTtsSupplement(payload);
+        const resolvedDeliveryText =
+          previewFinalDeliveryText ?? (previewFinalTextAlreadyDelivered ? "" : undefined);
+        const payloadText = payload.text?.trim();
+        // TTS metadata is authoritative when its text is already visible. Only restore
+        // spoken text when neither that contract nor provider-confirmed preview posts cover it.
+        const deliveryPayload =
+          payload.isError !== true &&
+          supplement &&
+          (previewFinalTextAlreadyDelivered ||
+            (!payloadText && supplement.visibleTextAlreadyDelivered === true))
+            ? buildTtsSupplementMediaPayload(payload)
+            : payload.isError !== true && supplement && !payloadText
+              ? {
+                  ...payload,
+                  text: resolvedDeliveryText?.trim() ? resolvedDeliveryText : supplement.spokenText,
+                }
+              : payload.isError !== true && typeof resolvedDeliveryText === "string"
+                ? { ...payload, text: resolvedDeliveryText }
+                : payload;
+        normalDeliveryResult = await params.deliverPayload(deliveryPayload);
+        return normalDeliveryResult.visibleReplySent;
       },
-      editFinal: async (previewPostId, edit) => {
-        await updateMattermostPost(params.client, previewPostId, edit);
-      },
-      onPreviewFinalized: () => {
-        params.previewState.finalizedViaPreviewPost = true;
-        // The visible final reply landed by editing the preview post, so the normal
-        // deliverPayload record path is skipped; record participation explicitly here.
-        params.recordThreadParticipation?.();
-      },
-      buildSupplementalPayload: (payload) =>
-        getReplyPayloadTtsSupplement(payload) ? buildTtsSupplementMediaPayload(payload) : undefined,
-      deliverSupplemental: async (payload) => {
-        await params.deliverPayload(payload);
-      },
-      logPreviewEditFailure: (err) => {
-        params.logVerboseMessage(
-          `mattermost preview final edit failed; falling back to normal send (${String(err)})`,
-        );
-      },
-    }),
-    deliverNormally: async (payload) => {
-      const supplement = getReplyPayloadTtsSupplement(payload);
-      await params.deliverPayload(
-        supplement && !payload.text?.trim() && supplement.visibleTextAlreadyDelivered !== true
-          ? { ...payload, text: supplement.spokenText }
-          : payload,
+    });
+
+    if (finalization.kind !== "preview-finalized" || !previewDeliveryResult?.receipt) {
+      return (
+        combineMattermostVisibleDeliveryResults([
+          confirmedPreviewDelivery,
+          normalDeliveryResult,
+        ]) ?? {
+          outcome: "empty",
+          visibleReplySent: false,
+          suppression: { reason: "no_visible_result" },
+        }
       );
-    },
-  });
+    }
+    return (
+      combineMattermostVisibleDeliveryResults([
+        confirmedPreviewDelivery,
+        previewDeliveryResult,
+        supplementalDeliveryResult,
+      ]) ?? previewDeliveryResult
+    );
+  } catch (error: unknown) {
+    // A provider send can complete before preview cleanup fails. Preserve every
+    // completed visible receipt so core cannot mistake that post-send failure for a safe retry.
+    const completedVisibleResults: MattermostReplyDeliveryResult[] = [];
+    const completedReceiptResults: Array<{ receipt: MessageReceipt } | { messageId: string }> = [];
+    for (const result of [
+      confirmedPreviewDelivery,
+      previewDeliveryResult,
+      normalDeliveryResult,
+      supplementalDeliveryResult,
+    ]) {
+      if (result?.visibleReplySent !== true) {
+        continue;
+      }
+      completedVisibleResults.push(result);
+      if (result.receipt) {
+        completedReceiptResults.push({ receipt: result.receipt });
+      } else {
+        completedReceiptResults.push(
+          ...(result.messageIds ?? []).map((messageId) => ({ messageId })),
+        );
+      }
+    }
+    if (completedVisibleResults.length === 0) {
+      throw error;
+    }
+    const failedPartial = isChannelPartialDeliveryError(error) ? error.deliveryResult : undefined;
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [
+        ...completedReceiptResults,
+        ...(failedPartial?.receipt
+          ? [{ receipt: failedPartial.receipt }]
+          : (failedPartial?.messageIds ?? []).map((messageId) => ({ messageId }))),
+      ],
+    });
+    throw createChannelPartialDeliveryError(error, {
+      messageIds: listMessageReceiptPlatformIds(receipt),
+      receipt,
+      visibleReplySent: true,
+      content: joinMattermostVisibleContent([
+        confirmedPreviewDelivery?.content,
+        previewDeliveryResult?.content,
+        normalDeliveryResult?.content,
+        supplementalDeliveryResult?.content,
+        failedPartial?.content,
+      ]),
+    });
+  }
 }

--- a/extensions/mattermost/src/mattermost/monitor-interactions.ts
+++ b/extensions/mattermost/src/mattermost/monitor-interactions.ts
@@ -2,14 +2,14 @@
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import { createMattermostInteractionHandler } from "./interactions.js";
 import { authorizeMattermostCommandInvocation } from "./monitor-auth.js";
-import { resolveMattermostReplyRootId } from "./monitor-context.js";
+import {
+  buildMattermostButtonInteractionMessageSid,
+  resolveMattermostInteractionReplyRootId,
+} from "./monitor-context.js";
 import { buildMattermostEventPlan } from "./monitor-event-plan.js";
 import type { MattermostModelPickerInteractionHandler } from "./monitor-model-picker.js";
 import type { MattermostMonitorContext } from "./monitor-types.js";
-import {
-  deliverMattermostReplyPayload,
-  toMattermostChannelDeliveryResult,
-} from "./reply-delivery.js";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import type { ReplyPayload } from "./runtime-api.js";
 import { registerPluginHttpRoute } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
@@ -80,10 +80,15 @@ export function registerMattermostInteractions(params: {
         return eventPlan.thread.sessionKey;
       },
       dispatchButtonClick: async (button) => {
+        const sourcePostId = button.post.id || button.postId;
+        const interactionMessageSid = buildMattermostButtonInteractionMessageSid({
+          postId: button.postId,
+          actionId: button.actionId,
+        });
         const eventPlan = await buildMattermostEventPlan(monitor, {
           channelId: button.channelId,
           senderId: button.userId,
-          postId: button.post.id || button.postId,
+          postId: sourcePostId,
           threadRootId: button.post.root_id,
           dropLabel: "interaction dispatch",
         });
@@ -100,7 +105,7 @@ export function registerMattermostInteractions(params: {
           ConversationLabel: `mattermost:${button.userName}`,
           GroupSubject: kind !== "direct" ? channelDisplay || button.channelId : undefined,
           SenderName: button.userName,
-          MessageSid: `interaction:${button.postId}:${button.actionId}`,
+          MessageSid: interactionMessageSid,
           WasMentioned: true,
           CommandAuthorized: false,
         });
@@ -117,26 +122,27 @@ export function registerMattermostInteractions(params: {
           },
           ctxPayload,
           delivery: {
+            observeMessageSent: true,
             deliver: async (payload: ReplyPayload) => {
-              const result = toMattermostChannelDeliveryResult(
-                await deliverMattermostReplyPayload({
-                  core,
-                  cfg,
-                  payload,
-                  to,
-                  accountId: account.accountId,
-                  agentId: route.agentId,
-                  replyToId: resolveMattermostReplyRootId({
-                    kind,
-                    threadRootId: thread.effectiveReplyToId,
-                    replyToId: payload.replyToId,
-                  }),
-                  textLimit,
-                  tableMode,
-                  sendMessage: sendMessageMattermost,
-                  onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
+              const result = await deliverMattermostReplyPayload({
+                core,
+                cfg,
+                payload,
+                to,
+                accountId: account.accountId,
+                agentId: route.agentId,
+                replyToId: resolveMattermostInteractionReplyRootId({
+                  kind,
+                  threadRootId: thread.effectiveReplyToId,
+                  replyToId: payload.replyToId,
+                  interactionMessageSid,
+                  sourcePostId,
                 }),
-              );
+                textLimit,
+                tableMode,
+                sendMessage: sendMessageMattermost,
+                onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
+              });
               if (result.visibleReplySent) {
                 runtime.log?.(`delivered button-click reply to ${to}`);
               }

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.test.ts
@@ -1,0 +1,178 @@
+// Mattermost tests cover native model-picker interaction dispatch ownership.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  authorize: vi.fn(),
+  buildEventPlan: vi.fn(),
+  buildModelsProviderData: vi.fn(),
+  deliverReply: vi.fn(),
+  dispatch: vi.fn(),
+  markDeliverySettled: vi.fn(),
+  parseContext: vi.fn(),
+  runDetachedWebhookWork: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/webhook-request-guards", () => ({
+  runDetachedWebhookWork: mocks.runDetachedWebhookWork,
+}));
+
+vi.mock("./model-picker.js", () => ({
+  buildMattermostAllowedModelRefs: () => new Set(["openai/gpt-5.4"]),
+  parseMattermostModelPickerContext: mocks.parseContext,
+  renderMattermostModelsPickerView: () => ({ text: "updated picker", buttons: [] }),
+  renderMattermostProviderPickerView: () => ({ text: "provider picker", buttons: [] }),
+  resolveMattermostModelPickerCurrentModel: () => "openai/gpt-5.4",
+}));
+
+vi.mock("./monitor-auth.js", () => ({
+  authorizeMattermostCommandInvocation: mocks.authorize,
+}));
+
+vi.mock("./monitor-event-plan.js", () => ({
+  buildMattermostEventPlan: mocks.buildEventPlan,
+}));
+
+vi.mock("./reply-delivery.js", () => ({
+  deliverMattermostReplyPayload: mocks.deliverReply,
+}));
+
+vi.mock("./runtime-api.js", async () => {
+  const actual = await vi.importActual<typeof import("./runtime-api.js")>("./runtime-api.js");
+  return {
+    ...actual,
+    buildModelsProviderData: mocks.buildModelsProviderData,
+  };
+});
+
+import { createMattermostModelPickerInteractionHandler } from "./monitor-model-picker.js";
+import type { MattermostMonitorContext } from "./monitor-types.js";
+
+describe("Mattermost model-picker interaction dispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.parseContext.mockReturnValue({
+      action: "select",
+      ownerUserId: "user-1",
+      provider: "openai",
+      model: "gpt-5.4",
+      page: 0,
+    });
+    mocks.authorize.mockResolvedValue({
+      ok: true,
+      commandAuthorized: true,
+      channelInfo: { id: "channel-1", team_id: "team-1", type: "O" },
+      kind: "channel",
+      chatType: "channel",
+      channelName: "lifecycle",
+      channelDisplay: "Lifecycle",
+      roomLabel: "#lifecycle",
+    });
+    mocks.buildModelsProviderData.mockResolvedValue({ providers: [{ id: "openai" }] });
+    mocks.deliverReply.mockResolvedValue({
+      outcome: "text",
+      visibleReplySent: true,
+      messageIds: ["confirmation-1"],
+      content: "model updated",
+    });
+    mocks.buildEventPlan.mockResolvedValue({
+      channelDisplay: "Lifecycle",
+      kind: "channel",
+      roomLabel: "#lifecycle",
+      route: { agentId: "main", dmScope: "per-peer", sessionKey: "agent:main:mm" },
+      thread: { sessionKey: "agent:main:mm", effectiveReplyToId: undefined },
+      to: "channel:channel-1",
+      finalizeContext: (context: Record<string, unknown>) => context,
+      createReplyPlan: () => ({
+        deliveryBarrier: {
+          trackDmChannelResolution: vi.fn(),
+          resolveTimeoutPolicy: vi.fn(),
+          markDeliverySettled: mocks.markDeliverySettled,
+        },
+        replyOptions: {},
+        replyPipeline: {},
+        tableMode: "off",
+        textLimit: 4000,
+      }),
+    });
+    mocks.dispatch.mockImplementation(async (params: Record<string, unknown>) => {
+      const delivery = params.delivery as
+        | { deliver?: (payload: { text: string; replyToId?: string }) => Promise<unknown> }
+        | undefined;
+      const dispatcherOptions = params.dispatcherOptions as
+        | { onDeliverySettled?: () => void }
+        | undefined;
+      await delivery?.deliver?.({
+        text: "model updated",
+        replyToId: "interaction:picker-post-1:select:openai/gpt-5.4",
+      });
+      dispatcherOptions?.onDeliverySettled?.();
+      return {};
+    });
+  });
+
+  it("reserves independent work before ack and observes terminal settlement", async () => {
+    let detachedRun: (() => Promise<void>) | undefined;
+    mocks.runDetachedWebhookWork.mockImplementation((run: () => Promise<void>) => {
+      detachedRun = run;
+      return Promise.resolve();
+    });
+    const updateModelPickerPost = vi.fn(async () => ({}));
+    const monitor = {
+      account: { accountId: "default", config: {} },
+      cfg: {},
+      core: {
+        channel: {
+          commands: { shouldHandleTextCommands: vi.fn(() => true) },
+          inbound: { dispatch: mocks.dispatch },
+          text: {
+            convertMarkdownTables: vi.fn((text: string) => text),
+            hasControlCommand: vi.fn(() => true),
+          },
+        },
+      },
+      pairing: { readAllowFromStore: vi.fn(async () => []) },
+      resources: {
+        resolveChannelInfo: vi.fn(async () => ({ id: "channel-1", type: "O" })),
+        updateModelPickerPost,
+      },
+      runtime: { error: vi.fn() },
+    } as unknown as MattermostMonitorContext;
+    const handler = createMattermostModelPickerInteractionHandler(monitor);
+
+    const response = await handler({
+      payload: {
+        channel_id: "channel-1",
+        post_id: "picker-post-1",
+        team_id: "team-1",
+        user_id: "user-1",
+      },
+      userName: "tester",
+      context: {},
+      post: { id: "picker-post-1", channel_id: "channel-1", message: "picker" },
+    });
+
+    expect(response).toEqual({});
+    expect(mocks.runDetachedWebhookWork).toHaveBeenCalledOnce();
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+    expect(detachedRun).toBeTypeOf("function");
+
+    await detachedRun?.();
+
+    expect(mocks.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "mattermost",
+        delivery: expect.objectContaining({ observeMessageSent: true }),
+        dispatcherOptions: expect.objectContaining({
+          onDeliverySettled: mocks.markDeliverySettled,
+        }),
+      }),
+    );
+    expect(mocks.markDeliverySettled).toHaveBeenCalledOnce();
+    expect(mocks.deliverReply).toHaveBeenCalledWith(
+      expect.objectContaining({ replyToId: "picker-post-1" }),
+    );
+    expect(updateModelPickerPost).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "updated picker" }),
+    );
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.ts
@@ -1,4 +1,5 @@
 // Mattermost plugin module owns native model-picker interactions.
+import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import type { MattermostPost } from "./client.js";
 import type { MattermostInteractionResponse } from "./interactions.js";
 import {
@@ -11,14 +12,11 @@ import {
 import { authorizeMattermostCommandInvocation } from "./monitor-auth.js";
 import {
   buildMattermostModelPickerSelectMessageSid,
-  resolveMattermostReplyRootId,
+  resolveMattermostInteractionReplyRootId,
 } from "./monitor-context.js";
 import { buildMattermostEventPlan, type MattermostEventPlan } from "./monitor-event-plan.js";
 import type { MattermostMonitorContext } from "./monitor-types.js";
-import {
-  deliverMattermostReplyPayload,
-  toMattermostChannelDeliveryResult,
-} from "./reply-delivery.js";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import type { ReplyPayload } from "./runtime-api.js";
 import { buildModelsProviderData } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
@@ -29,6 +27,7 @@ type RunModelPickerCommandParams = {
   eventPlan: MattermostEventPlan;
   senderName: string;
   messageSid: string;
+  sourcePostId: string;
 };
 
 export type MattermostModelPickerInteractionHandler = (params: {
@@ -82,32 +81,33 @@ export function createMattermostModelPickerInteractionHandler(
       },
       ctxPayload,
       delivery: {
+        observeMessageSent: true,
         // Picker-triggered confirmations should stay immediate.
         deliver: async (payload: ReplyPayload) => {
           const trimmedPayload = {
             ...payload,
             text: core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode).trim(),
           };
-          return toMattermostChannelDeliveryResult(
-            await deliverMattermostReplyPayload({
-              core,
-              cfg,
-              payload: trimmedPayload,
-              to,
-              accountId: account.accountId,
-              agentId: route.agentId,
-              replyToId: resolveMattermostReplyRootId({
-                kind,
-                threadRootId: thread.effectiveReplyToId,
-                replyToId: trimmedPayload.replyToId,
-              }),
-              textLimit,
-              // The picker path already converts and trims text before delivery.
-              tableMode: "off",
-              sendMessage: sendMessageMattermost,
-              onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
+          return await deliverMattermostReplyPayload({
+            core,
+            cfg,
+            payload: trimmedPayload,
+            to,
+            accountId: account.accountId,
+            agentId: route.agentId,
+            replyToId: resolveMattermostInteractionReplyRootId({
+              kind,
+              threadRootId: thread.effectiveReplyToId,
+              replyToId: trimmedPayload.replyToId,
+              interactionMessageSid: params.messageSid,
+              sourcePostId: params.sourcePostId,
             }),
-          );
+            textLimit,
+            // The picker path already converts and trims text before delivery.
+            tableMode: "off",
+            sendMessage: sendMessageMattermost,
+            onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
+          });
         },
         onError: (err, info) => {
           runtime.error?.(`mattermost model picker ${info.kind} reply failed: ${String(err)}`);
@@ -247,38 +247,40 @@ export function createMattermostModelPickerInteractionHandler(
     if (!buildMattermostAllowedModelRefs(data).has(targetModelRef)) {
       return { ephemeral_text: `That model is no longer available: ${targetModelRef}` };
     }
+    const messageSid = buildMattermostModelPickerSelectMessageSid({
+      postId: params.payload.post_id,
+      provider: pickerState.provider,
+      model: pickerState.model,
+    });
 
-    void (async () => {
-      try {
-        await runModelPickerCommand({
-          commandText: `/model ${targetModelRef}`,
-          commandAuthorized: auth.commandAuthorized,
-          eventPlan,
-          senderName: params.userName,
-          messageSid: buildMattermostModelPickerSelectMessageSid({
-            postId: params.payload.post_id,
-            provider: pickerState.provider,
-            model: pickerState.model,
-          }),
-        });
-        const currentModel = resolveMattermostModelPickerCurrentModel({
-          cfg,
-          route: modelSessionRoute,
-          data,
-          readConsistency: "latest",
-        });
-        const view = renderMattermostModelsPickerView({
-          ownerUserId: pickerState.ownerUserId,
-          data,
-          provider: pickerState.provider,
-          page: pickerState.page,
-          currentModel,
-        });
-        await updatePickerPost(view.text, view.buttons);
-      } catch (err) {
-        runtime.error?.(`mattermost model picker select failed: ${String(err)}`);
-      }
-    })();
+    // The HTTP response returns before the command finishes. Reserve a new root
+    // while the request is still admitted so session dispatch survives that ack.
+    void runDetachedWebhookWork(async () => {
+      await runModelPickerCommand({
+        commandText: `/model ${targetModelRef}`,
+        commandAuthorized: auth.commandAuthorized,
+        eventPlan,
+        senderName: params.userName,
+        messageSid,
+        sourcePostId: params.post.id || params.payload.post_id,
+      });
+      const currentModel = resolveMattermostModelPickerCurrentModel({
+        cfg,
+        route: modelSessionRoute,
+        data,
+        readConsistency: "latest",
+      });
+      const view = renderMattermostModelsPickerView({
+        ownerUserId: pickerState.ownerUserId,
+        data,
+        provider: pickerState.provider,
+        page: pickerState.page,
+        currentModel,
+      });
+      await updatePickerPost(view.text, view.buttons);
+    }).catch((err: unknown) => {
+      runtime.error?.(`mattermost model picker select failed: ${String(err)}`);
+    });
 
     return {};
   };

--- a/extensions/mattermost/src/mattermost/monitor-turn.ts
+++ b/extensions/mattermost/src/mattermost/monitor-turn.ts
@@ -1,10 +1,15 @@
 // Mattermost plugin module owns one accepted message's reply turn and delivery.
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
-import type { ChannelInboundTurnPlan } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  isChannelPartialDeliveryError,
+  type ChannelInboundTurnPlan,
+} from "openclaw/plugin-sdk/channel-inbound";
 import {
   bindIngressLifecycleToReplyOptions,
   buildChannelProgressDraftLineForEntry,
+  createMessageReceiptFromOutboundResults,
   createChannelProgressDraftCompositor,
+  listMessageReceiptPlatformIds,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import type { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
@@ -23,12 +28,13 @@ import {
 } from "./monitor-context.js";
 import {
   deliverMattermostReplyWithDraftPreview,
+  type MattermostPreviewFinalResolution,
   type MattermostDraftPreviewState,
 } from "./monitor-draft-delivery.js";
 import type { MattermostEventPlan } from "./monitor-event-plan.js";
 import type { MattermostIngressLifecycle } from "./monitor-ingress.js";
 import type { MattermostMonitorContext } from "./monitor-types.js";
-import { deliverMattermostReplyPayload } from "./reply-delivery.js";
+import { deliverMattermostReplyPayload, joinMattermostVisibleContent } from "./reply-delivery.js";
 import type { HistoryEntry, ReplyPayload } from "./runtime-api.js";
 import { createChannelMessageReplyPipeline } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
@@ -59,7 +65,7 @@ function createDisabledMattermostDraftStream(): ReturnType<typeof createMattermo
     stop: noopAsync,
     forceNewMessage: noopAsync,
     settleBoundaries: noopAsync,
-    resolveFinalText: (text) => ({ kind: "full", text }),
+    resolveFinalText: (text) => ({ kind: "full", text, publishedParts: [] }),
   };
 }
 
@@ -183,11 +189,31 @@ export async function dispatchMattermostInboundTurn(
   };
   const previewState: MattermostDraftPreviewState = { finalizedViaPreviewPost: false };
 
-  const resolvePreviewFinalText = (text?: string) => {
-    if (typeof text !== "string") {
-      return undefined;
-    }
-    const resolution = draftStream.resolveFinalText(text);
+  const resolvePreviewFinalText = (text?: string): MattermostPreviewFinalResolution | undefined => {
+    const resolution = draftStream.resolveFinalText(typeof text === "string" ? text : "");
+    const confirmedDelivery =
+      resolution.publishedParts.length > 0
+        ? (() => {
+            const receipt = createMessageReceiptFromOutboundResults({
+              results: resolution.publishedParts.map((part) => ({
+                channel: "mattermost",
+                messageId: part.messageId,
+                channelId,
+              })),
+              kind: "preview",
+              ...(effectiveReplyToId ? { replyToId: effectiveReplyToId } : {}),
+            });
+            return {
+              outcome: "text" as const,
+              messageIds: listMessageReceiptPlatformIds(receipt),
+              receipt,
+              visibleReplySent: true,
+              content: joinMattermostVisibleContent(
+                resolution.publishedParts.map((part) => part.content),
+              ),
+            };
+          })()
+        : undefined;
     const deliveryText = resolution.kind === "already-delivered" ? "" : resolution.text;
     const formatted = core.channel.text.convertMarkdownTables(deliveryText, tableMode);
     const chunks = core.channel.text.chunkMarkdownTextWithMode(formatted, textLimit, chunkMode);
@@ -195,20 +221,33 @@ export async function dispatchMattermostInboundTurn(
       chunks.push(formatted);
     }
     if (chunks.length !== 1) {
-      return undefined;
+      return {
+        deliveryText,
+        confirmedDelivery,
+        alreadyDelivered: resolution.kind === "already-delivered",
+      };
     }
     const trimmed = chunks[0]?.trim();
     if (!trimmed) {
-      return undefined;
+      return {
+        deliveryText,
+        confirmedDelivery,
+        alreadyDelivered: resolution.kind === "already-delivered",
+      };
     }
     if (
       lastPartialText &&
       lastPartialText.startsWith(trimmed) &&
       trimmed.length < lastPartialText.length
     ) {
-      return undefined;
+      return { deliveryText, confirmedDelivery, alreadyDelivered: false };
     }
-    return trimmed;
+    return {
+      editText: trimmed,
+      deliveryText,
+      confirmedDelivery,
+      alreadyDelivered: false,
+    };
   };
 
   const updateDraftFromPartial = (text?: string) => {
@@ -249,6 +288,7 @@ export async function dispatchMattermostInboundTurn(
     typingCallbacks,
   };
   const delivery: ChannelInboundTurnPlan["delivery"] = {
+    observeMessageSent: true,
     deliver: async (payloadEntry: ReplyPayload, info) => {
       if (info.kind === "final") {
         await enterBlockPreviewActivity("text");
@@ -257,14 +297,16 @@ export async function dispatchMattermostInboundTurn(
         progressDraft.markFinalReplyStarted();
       }
       // A visible same-thread final can be a send or an in-place draft edit; either path records participation.
+      let threadParticipationRecorded = false;
       const markThreadParticipation = () => {
-        if (kind !== "direct" && effectiveReplyToId) {
+        if (!threadParticipationRecorded && kind !== "direct" && effectiveReplyToId) {
+          threadParticipationRecorded = true;
           recordMattermostThreadParticipation(account.accountId, channelId, effectiveReplyToId, {
             agentId: route.agentId,
           });
         }
       };
-      await deliverMattermostReplyWithDraftPreview({
+      const result = await deliverMattermostReplyWithDraftPreview({
         payload: payloadEntry,
         info,
         kind,
@@ -289,7 +331,7 @@ export async function dispatchMattermostInboundTurn(
                   finalTextResolution.kind === "already-delivered" ? "" : finalTextResolution.text,
               }
             : payloadToDeliver;
-          const outcome = await deliverMattermostReplyPayload({
+          const deliveryResult = await deliverMattermostReplyPayload({
             core,
             cfg,
             payload: resolvedPayload,
@@ -305,17 +347,25 @@ export async function dispatchMattermostInboundTurn(
             tableMode,
             sendMessage: sendMessageMattermost,
             onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
+          }).catch((error: unknown) => {
+            if (isChannelPartialDeliveryError(error)) {
+              markThreadParticipation();
+            }
+            throw error;
           });
           // Record only visible sends so reasoning-only, empty, or suppressed threads do not auto-engage later.
-          if (outcome === "text" || outcome === "media") {
+          if (deliveryResult.outcome === "text" || deliveryResult.outcome === "media") {
             markThreadParticipation();
-          } else if (outcome === "empty" && finalTextResolution?.kind === "already-delivered") {
+          } else if (
+            deliveryResult.outcome === "empty" &&
+            finalTextResolution?.kind === "already-delivered"
+          ) {
             // The terminal payload confirms the already-published assistant block as
             // the visible final reply even though this delivery has no remaining text.
             markThreadParticipation();
           }
           const deliveryLog = formatMattermostFinalDeliveryOutcomeLog({
-            outcome,
+            outcome: deliveryResult.outcome,
             payload: resolvedPayload,
             to,
             accountId: account.accountId,
@@ -324,11 +374,26 @@ export async function dispatchMattermostInboundTurn(
           if (deliveryLog) {
             runtime.log?.(deliveryLog);
           }
+          return deliveryResult;
         },
+      }).catch((error: unknown) => {
+        if (isChannelPartialDeliveryError(error)) {
+          markThreadParticipation();
+          if (info.kind === "final") {
+            // The provider final is already visible even though later bookkeeping failed.
+            // Settle progress before rethrowing so late callbacks cannot revive stale draft state.
+            progressDraft.markFinalReplyDelivered();
+          }
+        }
+        throw error;
       });
+      if (result.visibleReplySent) {
+        markThreadParticipation();
+      }
       if (info.kind === "final") {
         progressDraft.markFinalReplyDelivered();
       }
+      return result;
     },
     onError: (err, info) => {
       runtime.error?.(`mattermost ${info.kind} reply failed: ${String(err)}`);

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1,7 +1,9 @@
 // Mattermost tests cover monitor.inbound system event plugin behavior.
 import { once } from "node:events";
 import { createServer } from "node:http";
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
@@ -89,10 +91,12 @@ const mockState = vi.hoisted(() => ({
   createReplyDispatcherWithTyping: vi.fn(),
   createMattermostClient: vi.fn(),
   createMattermostDraftStream: vi.fn(),
+  deliveryPlanObserver: vi.fn(),
   dispatchInboundMessage: vi.fn(),
   enqueueSystemEvent: vi.fn(),
   fetchMattermostMe: vi.fn(),
   getGlobalHookRunner: vi.fn(),
+  progressDrafts: [] as Array<{ getSnapshot: () => { lines: readonly unknown[] } }>,
   registerMattermostMonitorSlashCommands: vi.fn(),
   registerPluginHttpRoute: vi.fn(),
   recordMattermostThreadParticipation: vi.fn(),
@@ -108,6 +112,20 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>()),
   getGlobalHookRunner: mockState.getGlobalHookRunner,
 }));
+
+vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-outbound")>();
+  return {
+    ...actual,
+    createChannelProgressDraftCompositor: (
+      ...args: Parameters<typeof actual.createChannelProgressDraftCompositor>
+    ) => {
+      const draft = actual.createChannelProgressDraftCompositor(...args);
+      mockState.progressDrafts.push(draft);
+      return draft;
+    },
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
@@ -289,6 +307,7 @@ function createRuntimeCore(
       ctxPayload: { SessionKey?: string };
       dispatcherOptions?: Record<string, unknown>;
       delivery: {
+        observeMessageSent?: true;
         deliver: (
           payload: ReplyPayload,
           info: { kind: "tool" | "block" | "final" },
@@ -303,6 +322,7 @@ function createRuntimeCore(
         onRecordError?: (err: unknown) => void;
       };
     }) => {
+      mockState.deliveryPlanObserver(turn.delivery.observeMessageSent);
       await recordInboundSession({
         storePath: "/tmp/openclaw-test-sessions.json",
         sessionKey: turn.ctxPayload.SessionKey ?? turn.route.sessionKey,
@@ -512,6 +532,7 @@ describe("mattermost inbound user posts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockState.abortController = undefined;
+    mockState.progressDrafts.length = 0;
     mockState.getGlobalHookRunner.mockReturnValue(null);
     mockState.runtimeCore = createRuntimeCore(testConfig);
     mockState.createMattermostClient.mockReturnValue({});
@@ -521,7 +542,7 @@ describe("mattermost inbound user posts", () => {
       flush: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
       settleBoundaries: vi.fn(async () => {}),
-      resolveFinalText: (text: string) => ({ kind: "full" as const, text }),
+      resolveFinalText: (text: string) => ({ kind: "full" as const, text, publishedParts: [] }),
     });
     mockState.fetchMattermostMe.mockResolvedValue({
       id: "bot-user",
@@ -587,6 +608,7 @@ describe("mattermost inbound user posts", () => {
 
     expect(mockState.enqueueSystemEvent).not.toHaveBeenCalled();
     expect(mockState.dispatchInboundMessage).toHaveBeenCalledTimes(1);
+    expect(mockState.deliveryPlanObserver).toHaveBeenCalledExactlyOnceWith(true);
     const ctx = mockState.dispatchInboundMessage.mock.calls.at(0)?.[0].ctx;
     expect(ctx?.BodyForAgent).toBe("hello from mattermost");
     expect(ctx?.ConversationLabel).toBe("Town Square id:chan-1");
@@ -1767,7 +1789,7 @@ describe("mattermost inbound user posts", () => {
       seal: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
       settleBoundaries: vi.fn(async () => {}),
-      resolveFinalText: (text: string) => ({ kind: "full" as const, text }),
+      resolveFinalText: (text: string) => ({ kind: "full" as const, text, publishedParts: [] }),
     });
 
     const socket = new FakeWebSocket();
@@ -1951,8 +1973,8 @@ describe("mattermost inbound user posts", () => {
     const updateAssistantText = vi.fn();
     const resolveFinalText = vi.fn((text: string) =>
       text === "[bot] First block\n\nSecond block"
-        ? { kind: "remaining" as const, text: "Second block" }
-        : { kind: "full" as const, text },
+        ? { kind: "remaining" as const, text: "Second block", publishedParts: [] }
+        : { kind: "full" as const, text, publishedParts: [] },
     );
     mockState.createMattermostDraftStream.mockReturnValue({
       update: vi.fn(),
@@ -2045,7 +2067,10 @@ describe("mattermost inbound user posts", () => {
       seal: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
       settleBoundaries: vi.fn(async () => {}),
-      resolveFinalText: vi.fn(() => ({ kind: "already-delivered" as const })),
+      resolveFinalText: vi.fn(() => ({
+        kind: "already-delivered" as const,
+        publishedParts: [{ messageId: "preview-sealed", content: "Only block" }],
+      })),
     });
 
     const socket = new FakeWebSocket();
@@ -2087,6 +2112,176 @@ describe("mattermost inbound user posts", () => {
       "thread-root-confirmed-preview",
       { agentId: "main" },
     );
+  });
+
+  it("records participation when confirmed-preview cleanup fails", async () => {
+    const blockConfig: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://mattermost.example.com",
+          botToken: "bot-token",
+          chatmode: "onmessage",
+          dmPolicy: "open",
+          groupPolicy: "open",
+          streaming: { mode: "block" },
+        },
+      },
+    };
+    mockState.runtimeCore = createRuntimeCore(blockConfig);
+    mockState.createMattermostDraftStream.mockReturnValue({
+      update: vi.fn(),
+      updateAssistantText: vi.fn(),
+      forceNewMessage: vi.fn(async () => {}),
+      flush: vi.fn(async () => {}),
+      postId: vi.fn(() => undefined),
+      clear: vi.fn(async () => {}),
+      discardPending: vi.fn(async () => {
+        throw new Error("preview cleanup failed");
+      }),
+      seal: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      settleBoundaries: vi.fn(async () => {}),
+      resolveFinalText: vi.fn(() => ({
+        kind: "already-delivered" as const,
+        publishedParts: [{ messageId: "preview-sealed", content: "Only block" }],
+      })),
+    });
+
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    mockState.dispatchInboundMessage.mockImplementation(async (params) => {
+      try {
+        await params.replyOptions?.onAssistantMessageStart?.();
+        await params.replyOptions?.onPartialReply?.({ text: "Only block" });
+        await params.replyOptions?.onAssistantMessageStart?.();
+        const dispatcherOptions =
+          mockState.createReplyDispatcherWithTyping.mock.results.at(-1)?.value?.options;
+        await expect(
+          dispatcherOptions?.deliver({ text: "Only block" }, { kind: "final" }),
+        ).rejects.toThrow("preview cleanup failed");
+      } finally {
+        abortController.abort();
+      }
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: blockConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+    await emitMattermostChannelPost(socket, {
+      id: "post-confirmed-preview-cleanup-failure",
+      message: "stream one block",
+      rootId: "thread-root-confirmed-preview-cleanup-failure",
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.recordMattermostThreadParticipation).toHaveBeenCalledWith(
+      "default",
+      "chan-1",
+      "thread-root-confirmed-preview-cleanup-failure",
+      { agentId: "main" },
+    );
+  });
+
+  it("records participation when a later send step fails after a visible thread post", async () => {
+    const progressConfig: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://mattermost.example.com",
+          botToken: "bot-token",
+          chatmode: "onmessage",
+          dmPolicy: "open",
+          groupPolicy: "open",
+          streaming: { mode: "progress" },
+        },
+      },
+    };
+    mockState.runtimeCore = createRuntimeCore(progressConfig);
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ channel: "mattermost", messageId: "partial-post-1", channelId: "chan-1" }],
+      kind: "text",
+      replyToId: "thread-root-partial",
+    });
+    mockState.sendMessageMattermost.mockRejectedValueOnce(
+      createChannelPartialDeliveryError(new Error("bookkeeping failed"), {
+        messageIds: ["partial-post-1"],
+        receipt,
+        visibleReplySent: true,
+        content: "Visible partial reply",
+      }),
+    );
+    mockState.createMattermostDraftStream.mockReturnValue({
+      update: vi.fn(),
+      updateAssistantText: vi.fn(),
+      forceNewMessage: vi.fn(async () => {}),
+      flush: vi.fn(async () => {}),
+      postId: vi.fn(() => undefined),
+      clear: vi.fn(async () => {}),
+      discardPending: vi.fn(async () => {}),
+      seal: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      settleBoundaries: vi.fn(async () => {}),
+      resolveFinalText: (text: string) => ({ kind: "full" as const, text, publishedParts: [] }),
+    });
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    mockState.dispatchInboundMessage.mockImplementation(
+      async (dispatchParams: {
+        replyOptions?: {
+          onReasoningStream?: (payload: ReplyPayload) => void | Promise<void>;
+        };
+      }) => {
+        try {
+          const dispatcherOptions =
+            mockState.createReplyDispatcherWithTyping.mock.results.at(-1)?.value?.options;
+          await expect(
+            dispatcherOptions?.deliver({ text: "Visible partial reply" }, { kind: "final" }),
+          ).rejects.toThrow("bookkeeping failed");
+          await dispatchParams.replyOptions?.onReasoningStream?.({ text: "late reasoning" });
+        } finally {
+          abortController.abort();
+        }
+      },
+    );
+
+    const monitor = monitorMattermostProvider({
+      config: progressConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+    await emitMattermostChannelPost(socket, {
+      id: "post-partial-thread",
+      message: "reply in this thread",
+      rootId: "thread-root-partial",
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.recordMattermostThreadParticipation).toHaveBeenCalledWith(
+      "default",
+      "chan-1",
+      "thread-root-partial",
+      { agentId: "main" },
+    );
+    expect(mockState.progressDrafts.at(-1)?.getSnapshot().lines).toEqual([]);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,13 +1,13 @@
 // Mattermost tests cover monitor plugin behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import { resolveMattermostAccount } from "./accounts.js";
-import * as clientModule from "./client.js";
-import type { MattermostClient } from "./client.js";
 import {
+  buildMattermostButtonInteractionMessageSid,
   buildMattermostModelPickerSelectMessageSid,
   canFinalizeMattermostPreviewInPlace,
   formatMattermostFinalDeliveryOutcomeLog,
+  resolveMattermostInteractionReplyRootId,
   resolveMattermostPendingHistoryKey,
   resolveMattermostReactionChannelId,
   resolveMattermostReplyRootId,
@@ -15,7 +15,6 @@ import {
   shouldSuppressMattermostDefaultToolProgressMessages,
   shouldUpdateMattermostDraftToolProgress,
 } from "./monitor-context.js";
-import { deliverMattermostReplyWithDraftPreview } from "./monitor-draft-delivery.js";
 import { buildMattermostInboundMediaPayload } from "./monitor-resources.js";
 
 function resolveMattermostEffectiveReplyToId(params: {
@@ -29,35 +28,6 @@ function resolveMattermostEffectiveReplyToId(params: {
     ...params,
   }).effectiveReplyToId;
 }
-
-const updateMattermostPostSpy = vi.spyOn(clientModule, "updateMattermostPost");
-
-function createMattermostClientMock(): MattermostClient {
-  return {
-    baseUrl: "https://chat.example.com",
-    apiBaseUrl: "https://chat.example.com/api/v4",
-    token: "token",
-    request: vi.fn(async () => ({})) as MattermostClient["request"],
-    fetchImpl: vi.fn(
-      async () => new Response(null, { status: 200 }),
-    ) as MattermostClient["fetchImpl"],
-  };
-}
-
-function createDraftStreamMock(postId: string | undefined = "preview-post-1") {
-  return {
-    flush: vi.fn(async () => {}),
-    postId: vi.fn(() => postId),
-    clear: vi.fn(async () => {}),
-    discardPending: vi.fn(async () => {}),
-    seal: vi.fn(async () => {}),
-  };
-}
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  updateMattermostPostSpy.mockResolvedValue({ id: "patched" } as never);
-});
 
 describe("buildMattermostInboundMediaPayload", () => {
   it("keeps a failed attachment kind aligned with a successful path", async () => {
@@ -130,15 +100,6 @@ describe("buildMattermostInboundMediaPayload", () => {
     });
   });
 });
-
-function mockCall(mock: { mock: { calls: unknown[][] } }, index: number, label: string): unknown[] {
-  const resolvedIndex = index < 0 ? mock.mock.calls.length + index : index;
-  const call = mock.mock.calls[resolvedIndex];
-  if (!call) {
-    throw new Error(`expected ${label} call ${index}`);
-  }
-  return call;
-}
 
 describe("resolveMattermostReplyRootId with block streaming payloads", () => {
   it("uses threadRootId for block-streamed payloads with replyToId", () => {
@@ -217,6 +178,62 @@ describe("resolveMattermostReplyRootId", () => {
         replyToId: "group-child-789",
       }),
     ).toBe("group-root-456");
+  });
+});
+
+describe("resolveMattermostInteractionReplyRootId", () => {
+  const interactionMessageSid = buildMattermostButtonInteractionMessageSid({
+    postId: "source-post-123",
+    actionId: "approve",
+  });
+
+  it("keeps the established synthetic event identity", () => {
+    expect(interactionMessageSid).toBe("interaction:source-post-123:approve");
+  });
+
+  it("maps reply-to-current from the synthetic interaction id to the provider post", () => {
+    expect(
+      resolveMattermostInteractionReplyRootId({
+        kind: "channel",
+        replyToId: interactionMessageSid,
+        interactionMessageSid,
+        sourcePostId: "source-post-123",
+      }),
+    ).toBe("source-post-123");
+  });
+
+  it("preserves an explicit provider reply target", () => {
+    expect(
+      resolveMattermostInteractionReplyRootId({
+        kind: "channel",
+        replyToId: "other-provider-post",
+        interactionMessageSid,
+        sourcePostId: "source-post-123",
+      }),
+    ).toBe("other-provider-post");
+  });
+
+  it("keeps the existing provider thread root authoritative", () => {
+    expect(
+      resolveMattermostInteractionReplyRootId({
+        kind: "channel",
+        threadRootId: "thread-root-456",
+        replyToId: interactionMessageSid,
+        interactionMessageSid,
+        sourcePostId: "source-post-123",
+      }),
+    ).toBe("thread-root-456");
+  });
+
+  it("keeps flat direct-message interactions unthreaded", () => {
+    expect(
+      resolveMattermostInteractionReplyRootId({
+        kind: "direct",
+        replyToId: interactionMessageSid,
+        interactionMessageSid,
+        sourcePostId: "source-post-123",
+      }),
+    ).toBeUndefined();
   });
 });
 
@@ -324,338 +341,6 @@ describe("shouldSuppressMattermostDefaultToolProgressMessages", () => {
         },
       }),
     ).toBe(false);
-  });
-});
-
-describe("deliverMattermostReplyWithDraftPreview", () => {
-  it("suppresses reasoning-prefixed finals before preview finalization", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {});
-    const recordThreadParticipation = vi.fn();
-
-    await deliverMattermostReplyWithDraftPreview({
-      payload: { text: "  \n > Reasoning:\n> _hidden_" } as never,
-      info: { kind: "final" },
-      kind: "channel",
-      client: createMattermostClientMock(),
-      draftStream,
-      effectiveReplyToId: "thread-root-1",
-      resolvePreviewFinalText: (text) => text?.trim(),
-      previewState: { finalizedViaPreviewPost: false },
-      logVerboseMessage: vi.fn(),
-      recordThreadParticipation,
-      deliverPayload: deliverFinal,
-    });
-
-    expect(deliverFinal).not.toHaveBeenCalled();
-    expect(draftStream.flush).not.toHaveBeenCalled();
-    expect(draftStream.discardPending).not.toHaveBeenCalled();
-    expect(draftStream.clear).not.toHaveBeenCalled();
-    expect(updateMattermostPostSpy).not.toHaveBeenCalled();
-    // No visible reply was sent, so the thread must not be marked as participated.
-    expect(recordThreadParticipation).not.toHaveBeenCalled();
-  });
-
-  it("records thread participation when a same-thread final finalizes the preview in place", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {});
-    const recordThreadParticipation = vi.fn();
-
-    await deliverMattermostReplyWithDraftPreview({
-      payload: { text: "All good" } as never,
-      info: { kind: "final" },
-      kind: "channel",
-      client: createMattermostClientMock(),
-      draftStream,
-      effectiveReplyToId: "thread-root-1",
-      resolvePreviewFinalText: (text) => text?.trim(),
-      previewState: { finalizedViaPreviewPost: false },
-      logVerboseMessage: vi.fn(),
-      recordThreadParticipation,
-      deliverPayload: deliverFinal,
-    });
-
-    // Default streaming finalizes by editing the preview post, bypassing deliverPayload —
-    // participation must still be recorded (regression: PR #95552 review P1).
-    expect(updateMattermostPostSpy).toHaveBeenCalledWith(expect.anything(), "preview-post-1", {
-      message: "All good",
-    });
-    expect(deliverFinal).not.toHaveBeenCalled();
-    expect(recordThreadParticipation).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps a finalized preview when a later tool warning is delivered", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {});
-    const previewState = { finalizedViaPreviewPost: false };
-    const params = {
-      kind: "direct" as const,
-      client: createMattermostClientMock(),
-      draftStream,
-      resolvePreviewFinalText: (text?: string) => text?.trim(),
-      previewState,
-      logVerboseMessage: vi.fn(),
-      deliverPayload: deliverFinal,
-    };
-
-    await deliverMattermostReplyWithDraftPreview({
-      ...params,
-      payload: { text: "Successful assistant final" } as never,
-      info: { kind: "final" },
-    });
-    await deliverMattermostReplyWithDraftPreview({
-      ...params,
-      payload: { text: "Tool error warning", isError: true } as never,
-      info: { kind: "final" },
-    });
-
-    expect(previewState.finalizedViaPreviewPost).toBe(true);
-    expect(deliverFinal).toHaveBeenCalledExactlyOnceWith({
-      text: "Tool error warning",
-      isError: true,
-    });
-    expect(draftStream.discardPending).not.toHaveBeenCalled();
-    expect(draftStream.clear).not.toHaveBeenCalled();
-  });
-
-  it("deletes the preview after a successful normal final send", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {});
-
-    await deliverMattermostReplyWithDraftPreview({
-      payload: { text: "All good", replyToId: "reply-1" } as never,
-      info: { kind: "final" },
-      kind: "channel",
-      client: createMattermostClientMock(),
-      draftStream,
-      resolvePreviewFinalText: (text) => text?.trim(),
-      previewState: { finalizedViaPreviewPost: false },
-      logVerboseMessage: vi.fn(),
-      deliverPayload: deliverFinal,
-    });
-
-    expect(deliverFinal).toHaveBeenCalledTimes(1);
-    expect(draftStream.flush).not.toHaveBeenCalled();
-    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
-    expect(draftStream.clear).toHaveBeenCalledTimes(1);
-    expect(updateMattermostPostSpy).not.toHaveBeenCalled();
-  });
-
-  it("deletes the preview after a successful non-finalizable media final", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {});
-
-    await deliverMattermostReplyWithDraftPreview({
-      payload: {
-        text: "Photo",
-        replyToId: "reply-1",
-        mediaUrl: "https://example.com/a.png",
-      } as never,
-      info: { kind: "final" },
-      kind: "channel",
-      client: createMattermostClientMock(),
-      draftStream,
-      effectiveReplyToId: "thread-root-1",
-      resolvePreviewFinalText: (text) => text?.trim(),
-      previewState: { finalizedViaPreviewPost: false },
-      logVerboseMessage: vi.fn(),
-      deliverPayload: deliverFinal,
-    });
-
-    expect(deliverFinal).toHaveBeenCalledTimes(1);
-    expect(draftStream.flush).not.toHaveBeenCalled();
-    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
-    expect(draftStream.clear).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps the preview and sends media-only for TTS supplement finals", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {});
-
-    await deliverMattermostReplyWithDraftPreview({
-      payload: {
-        mediaUrl: "https://example.com/tts.mp3",
-        audioAsVoice: true,
-        spokenText: "Spoken answer",
-        ttsSupplement: { spokenText: "Spoken answer" },
-      } as never,
-      info: { kind: "final" },
-      kind: "channel",
-      client: createMattermostClientMock(),
-      draftStream,
-      effectiveReplyToId: "thread-root-1",
-      resolvePreviewFinalText: (text) => text?.trim(),
-      previewState: { finalizedViaPreviewPost: false },
-      logVerboseMessage: vi.fn(),
-      deliverPayload: deliverFinal,
-    });
-
-    expect(updateMattermostPostSpy).toHaveBeenCalledWith(expect.anything(), "preview-post-1", {
-      message: "Spoken answer",
-    });
-    expect(draftStream.discardPending).not.toHaveBeenCalled();
-    expect(draftStream.clear).not.toHaveBeenCalled();
-    expect(deliverFinal).toHaveBeenCalledWith({
-      mediaUrl: "https://example.com/tts.mp3",
-      audioAsVoice: true,
-      spokenText: "Spoken answer",
-      ttsSupplement: { spokenText: "Spoken answer" },
-    });
-  });
-
-  it("falls back with visible text when TTS supplement preview finalization fails", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {});
-    updateMattermostPostSpy.mockRejectedValueOnce(new Error("edit failed"));
-
-    await deliverMattermostReplyWithDraftPreview({
-      payload: {
-        mediaUrl: "https://example.com/tts.mp3",
-        audioAsVoice: true,
-        spokenText: "Spoken answer",
-        ttsSupplement: { spokenText: "Spoken answer" },
-      } as never,
-      info: { kind: "final" },
-      kind: "channel",
-      client: createMattermostClientMock(),
-      draftStream,
-      effectiveReplyToId: "thread-root-1",
-      resolvePreviewFinalText: (text) => text?.trim(),
-      previewState: { finalizedViaPreviewPost: false },
-      logVerboseMessage: vi.fn(),
-      deliverPayload: deliverFinal,
-    });
-
-    expect(updateMattermostPostSpy).toHaveBeenCalledTimes(1);
-    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
-    expect(draftStream.clear).toHaveBeenCalledTimes(1);
-    expect(deliverFinal).toHaveBeenCalledWith({
-      text: "Spoken answer",
-      mediaUrl: "https://example.com/tts.mp3",
-      audioAsVoice: true,
-      spokenText: "Spoken answer",
-      ttsSupplement: { spokenText: "Spoken answer" },
-    });
-  });
-
-  it("keeps already-delivered TTS supplement fallback audio-only", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {});
-    updateMattermostPostSpy.mockRejectedValueOnce(new Error("edit failed"));
-
-    await deliverMattermostReplyWithDraftPreview({
-      payload: {
-        mediaUrl: "https://example.com/tts.mp3",
-        audioAsVoice: true,
-        spokenText: "Spoken answer",
-        ttsSupplement: {
-          spokenText: "Spoken answer",
-          visibleTextAlreadyDelivered: true,
-        },
-      } as never,
-      info: { kind: "final" },
-      kind: "channel",
-      client: createMattermostClientMock(),
-      draftStream,
-      effectiveReplyToId: "thread-root-1",
-      resolvePreviewFinalText: (text) => text?.trim(),
-      previewState: { finalizedViaPreviewPost: false },
-      logVerboseMessage: vi.fn(),
-      deliverPayload: deliverFinal,
-    });
-
-    expect(deliverFinal).toHaveBeenCalledWith({
-      mediaUrl: "https://example.com/tts.mp3",
-      audioAsVoice: true,
-      spokenText: "Spoken answer",
-      ttsSupplement: {
-        spokenText: "Spoken answer",
-        visibleTextAlreadyDelivered: true,
-      },
-    });
-  });
-
-  it("does not flush error finals before normal delivery", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {});
-
-    await deliverMattermostReplyWithDraftPreview({
-      payload: { text: "Error", isError: true } as never,
-      info: { kind: "final" },
-      kind: "channel",
-      client: createMattermostClientMock(),
-      draftStream,
-      effectiveReplyToId: "thread-root-1",
-      resolvePreviewFinalText: (text) => text?.trim(),
-      previewState: { finalizedViaPreviewPost: false },
-      logVerboseMessage: vi.fn(),
-      deliverPayload: deliverFinal,
-    });
-
-    expect(draftStream.flush).not.toHaveBeenCalled();
-    expect(deliverFinal).toHaveBeenCalledTimes(1);
-    expect(draftStream.clear).toHaveBeenCalledTimes(1);
-  });
-
-  it("finalizes the preview in place when the final targets the same thread", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {});
-    const client = createMattermostClientMock();
-
-    await deliverMattermostReplyWithDraftPreview({
-      payload: { text: "Final answer", replyToId: "child-post-789" } as never,
-      info: { kind: "final" },
-      kind: "channel",
-      client,
-      draftStream,
-      effectiveReplyToId: "thread-root-456",
-      resolvePreviewFinalText: (text) => text?.trim(),
-      previewState: { finalizedViaPreviewPost: false },
-      logVerboseMessage: vi.fn(),
-      deliverPayload: deliverFinal,
-    });
-
-    expect(updateMattermostPostSpy).toHaveBeenCalledTimes(1);
-    const [updateClient, updatePostId, updateParams] = mockCall(
-      updateMattermostPostSpy,
-      0,
-      "updateMattermostPost",
-    );
-    expect(updateClient).toBe(client);
-    expect(updatePostId).toBe("preview-post-1");
-    expect(updateParams).toStrictEqual({ message: "Final answer" });
-    expect(draftStream.flush).toHaveBeenCalledTimes(1);
-    expect(draftStream.seal).toHaveBeenCalledTimes(1);
-    expect(draftStream.seal.mock.invocationCallOrder[0]).toBeLessThan(
-      updateMattermostPostSpy.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    );
-    expect(deliverFinal).not.toHaveBeenCalled();
-    expect(draftStream.clear).not.toHaveBeenCalled();
-  });
-
-  it("keeps the existing preview unchanged when final delivery fails", async () => {
-    const draftStream = createDraftStreamMock();
-    const deliverFinal = vi.fn(async () => {
-      throw new Error("send failed");
-    });
-
-    await expect(
-      deliverMattermostReplyWithDraftPreview({
-        payload: { text: "Broken", replyToId: "reply-1" } as never,
-        info: { kind: "final" },
-        kind: "channel",
-        client: createMattermostClientMock(),
-        draftStream,
-        resolvePreviewFinalText: (text) => text?.trim(),
-        previewState: { finalizedViaPreviewPost: false },
-        logVerboseMessage: vi.fn(),
-        deliverPayload: deliverFinal,
-      }),
-    ).rejects.toThrow("send failed");
-
-    expect(draftStream.discardPending).toHaveBeenCalledTimes(1);
-    expect(draftStream.clear).not.toHaveBeenCalled();
-    expect(updateMattermostPostSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -1,5 +1,7 @@
 // Mattermost tests cover reply delivery plugin behavior.
 import path from "node:path";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import type { ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { describe, expect, it, vi } from "vitest";
@@ -7,8 +9,8 @@ import type { OpenClawConfig, PluginRuntime } from "../../runtime-api.js";
 import {
   createMattermostReplyDeliveryBarrier,
   deliverMattermostReplyPayload,
-  toMattermostChannelDeliveryResult,
 } from "./reply-delivery.js";
+import type { MattermostSendResult } from "./send.js";
 
 type DeliverMattermostReplyPayloadParams = Parameters<typeof deliverMattermostReplyPayload>[0];
 type ReplyDeliveryMarkdownTableMode = Parameters<
@@ -41,21 +43,21 @@ function createReplyDeliveryCore(): DeliverMattermostReplyPayloadParams["core"] 
   } as unknown as PluginRuntime;
 }
 
-describe("toMattermostChannelDeliveryResult", () => {
-  it.each(["text", "media"] as const)("marks %s delivery as visible", (outcome) => {
-    expect(toMattermostChannelDeliveryResult(outcome)).toEqual({ visibleReplySent: true });
+function createSendMessageMock() {
+  let sendCount = 0;
+  return vi.fn(async (_to: string, content: string): Promise<MattermostSendResult> => {
+    const messageId = `post-${++sendCount}`;
+    return {
+      messageId,
+      channelId: "channel-1",
+      content: content.trim(),
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ channel: "mattermost", messageId, channelId: "channel-1" }],
+        kind: "text",
+      }),
+    };
   });
-
-  it.each(["reasoning_skipped", "empty"] as const)(
-    "marks %s delivery as intentionally non-visible",
-    (outcome) => {
-      expect(toMattermostChannelDeliveryResult(outcome)).toEqual({
-        visibleReplySent: false,
-        suppression: { reason: "no_visible_result" },
-      });
-    },
-  );
-});
+}
 
 describe("createMattermostReplyDeliveryBarrier", () => {
   it("extends while direct deliveries or DM resolution remain unsettled", async () => {
@@ -121,7 +123,7 @@ describe("createMattermostReplyDeliveryBarrier", () => {
 
 describe("deliverMattermostReplyPayload", () => {
   it("suppresses payloads flagged as reasoning", async () => {
-    const sendMessage = vi.fn(async () => undefined);
+    const sendMessage = createSendMessageMock();
     const cfg = {} satisfies OpenClawConfig;
     const core = createReplyDeliveryCore();
 
@@ -139,11 +141,15 @@ describe("deliverMattermostReplyPayload", () => {
     });
 
     expect(sendMessage).not.toHaveBeenCalled();
-    expect(outcome).toBe("reasoning_skipped");
+    expect(outcome).toEqual({
+      outcome: "reasoning_skipped",
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    });
   });
 
   it("returns 'empty' for substantive text that produced no send (regression: #80501)", async () => {
-    const sendMessage = vi.fn(async () => undefined);
+    const sendMessage = createSendMessageMock();
     const cfg = {} satisfies OpenClawConfig;
     const core = createReplyDeliveryCore();
     // Make the markdown table converter strip the text to empty so
@@ -165,11 +171,15 @@ describe("deliverMattermostReplyPayload", () => {
     });
 
     expect(sendMessage).not.toHaveBeenCalled();
-    expect(outcome).toBe("empty");
+    expect(outcome).toEqual({
+      outcome: "empty",
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    });
   });
 
   it("suppresses reasoning-prefixed payloads even without an explicit flag", async () => {
-    const sendMessage = vi.fn(async () => undefined);
+    const sendMessage = createSendMessageMock();
     const cfg = {} satisfies OpenClawConfig;
     const core = createReplyDeliveryCore();
 
@@ -190,7 +200,7 @@ describe("deliverMattermostReplyPayload", () => {
   });
 
   it("suppresses reasoning payloads formatted as a Mattermost blockquote", async () => {
-    const sendMessage = vi.fn(async () => undefined);
+    const sendMessage = createSendMessageMock();
     const cfg = {} satisfies OpenClawConfig;
     const core = createReplyDeliveryCore();
 
@@ -211,7 +221,7 @@ describe("deliverMattermostReplyPayload", () => {
   });
 
   it("does not suppress messages that mention Reasoning: mid-text", async () => {
-    const sendMessage = vi.fn(async () => undefined);
+    const sendMessage = createSendMessageMock();
     const cfg = {} satisfies OpenClawConfig;
     const core = createReplyDeliveryCore();
 
@@ -248,7 +258,7 @@ describe("deliverMattermostReplyPayload", () => {
     const stateDir = openClawState.stateDir;
 
     try {
-      const sendMessage = vi.fn(async () => undefined);
+      const sendMessage = createSendMessageMock();
       const core = createReplyDeliveryCore();
 
       const agentId = "agent-1";
@@ -292,7 +302,7 @@ describe("deliverMattermostReplyPayload", () => {
   });
 
   it("forwards replyToId for text-only chunked replies", async () => {
-    const sendMessage = vi.fn(async () => undefined);
+    const sendMessage = createSendMessageMock();
     const cfg = {} satisfies OpenClawConfig;
     const core = createReplyDeliveryCore();
     core.channel.text.chunkMarkdownTextWithMode = vi.fn(() => ["hello"]);
@@ -320,6 +330,111 @@ describe("deliverMattermostReplyPayload", () => {
         replyToId: "root-post",
       }),
     );
-    expect(outcome).toBe("text");
+    expect(outcome).toMatchObject({
+      outcome: "text",
+      messageIds: ["post-1"],
+      visibleReplySent: true,
+      content: "hello",
+    });
+    expect(outcome.receipt?.primaryPlatformMessageId).toBe("post-1");
+  });
+
+  it("aggregates every provider post behind one chunked logical payload", async () => {
+    const sendMessage = createSendMessageMock();
+    const cfg = {} satisfies OpenClawConfig;
+    const core = createReplyDeliveryCore();
+    core.channel.text.chunkMarkdownTextWithMode = vi.fn(() => ["alpha", "beta"]);
+
+    const result = await deliverMattermostReplyPayload({
+      core,
+      cfg,
+      payload: { text: "alpha beta" },
+      to: "channel:town-square",
+      accountId: "default",
+      replyToId: "root-post",
+      textLimit: 6,
+      tableMode: "off",
+      sendMessage,
+    });
+
+    expect(result).toMatchObject({
+      outcome: "text",
+      messageIds: ["post-1", "post-2"],
+      visibleReplySent: true,
+      content: "alpha\nbeta",
+    });
+    expect(result.receipt?.parts.map((part) => part.platformMessageId)).toEqual([
+      "post-1",
+      "post-2",
+    ]);
+  });
+
+  it("returns provider-finalized visible content instead of the requested text", async () => {
+    const sendMessage = vi.fn(
+      async (): Promise<MattermostSendResult> => ({
+        messageId: "post-final",
+        channelId: "channel-1",
+        content: "provider-finalized",
+        receipt: createMessageReceiptFromOutboundResults({
+          results: [{ channel: "mattermost", messageId: "post-final", channelId: "channel-1" }],
+          kind: "text",
+        }),
+      }),
+    );
+
+    const result = await deliverMattermostReplyPayload({
+      core: createReplyDeliveryCore(),
+      cfg: {},
+      payload: { text: "requested text" },
+      to: "channel:town-square",
+      accountId: "default",
+      textLimit: 4000,
+      tableMode: "off",
+      sendMessage,
+    });
+
+    expect(result).toMatchObject({
+      messageIds: ["post-final"],
+      visibleReplySent: true,
+      content: "provider-finalized",
+    });
+  });
+
+  it("preserves the accepted post when a later chunk fails", async () => {
+    const firstResult = createSendMessageMock();
+    const sendMessage = vi
+      .fn<DeliverMattermostReplyPayloadParams["sendMessage"]>()
+      .mockImplementationOnce(firstResult)
+      .mockRejectedValueOnce(new Error("second chunk failed"));
+    const cfg = {} satisfies OpenClawConfig;
+    const core = createReplyDeliveryCore();
+    core.channel.text.chunkMarkdownTextWithMode = vi.fn(() => ["alpha", "beta"]);
+
+    let caught: unknown;
+    try {
+      await deliverMattermostReplyPayload({
+        core,
+        cfg,
+        payload: { text: "alpha beta" },
+        to: "channel:town-square",
+        accountId: "default",
+        replyToId: "root-post",
+        textLimit: 6,
+        tableMode: "off",
+        sendMessage,
+      });
+    } catch (error: unknown) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected a partial Mattermost delivery error");
+    }
+    expect(caught.deliveryResult).toMatchObject({
+      messageIds: ["post-1"],
+      visibleReplySent: true,
+      content: "alpha",
+    });
   });
 });

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -1,4 +1,13 @@
 // Mattermost plugin module implements reply delivery behavior.
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createMessageReceiptFromOutboundResults,
+  listMessageReceiptPlatformIds,
+  type MessageReceipt,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk/core";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import {
@@ -15,6 +24,7 @@ import {
   resolveMattermostReplyDeliveryBarrierTimeoutMs,
   type CreateDmChannelRetryOptions,
 } from "./client.js";
+import type { MattermostSendResult } from "./send.js";
 
 type MarkdownTableMode = Parameters<PluginRuntime["channel"]["text"]["convertMarkdownTables"]>[1];
 
@@ -29,7 +39,7 @@ type SendMattermostMessage = (
     replyToId?: string;
     onDmChannelResolution?: (resolution: PromiseLike<unknown>) => void;
   },
-) => Promise<unknown>;
+) => Promise<MattermostSendResult>;
 
 export function createMattermostReplyDeliveryBarrier(params: {
   isDirect: boolean;
@@ -88,13 +98,18 @@ export function createMattermostReplyDeliveryBarrier(params: {
  */
 export type MattermostReplyDeliveryOutcome = "reasoning_skipped" | "empty" | "text" | "media";
 
-export function toMattermostChannelDeliveryResult(outcome: MattermostReplyDeliveryOutcome) {
-  return outcome === "text" || outcome === "media"
-    ? { visibleReplySent: true as const }
-    : {
-        visibleReplySent: false as const,
-        suppression: { reason: "no_visible_result" as const },
-      };
+export type MattermostReplyDeliveryResult = {
+  outcome: MattermostReplyDeliveryOutcome;
+  messageIds?: string[];
+  receipt?: MessageReceipt;
+  visibleReplySent: boolean;
+  content?: string;
+  suppression?: { reason: "no_visible_result" };
+};
+
+/** Represents distinct provider posts without collapsing their visible boundary. */
+export function joinMattermostVisibleContent(contents: readonly (string | undefined)[]): string {
+  return contents.filter((content): content is string => Boolean(content)).join("\n");
 }
 
 export async function deliverMattermostReplyPayload(params: {
@@ -109,9 +124,13 @@ export async function deliverMattermostReplyPayload(params: {
   tableMode: MarkdownTableMode;
   sendMessage: SendMattermostMessage;
   onDmChannelResolution?: (resolution: PromiseLike<unknown>) => void;
-}): Promise<MattermostReplyDeliveryOutcome> {
+}): Promise<MattermostReplyDeliveryResult> {
   if (isReasoningReplyPayload(params.payload)) {
-    return "reasoning_skipped";
+    return {
+      outcome: "reasoning_skipped",
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    };
   }
   const reply = resolveSendableOutboundReplyParts(params.payload, {
     text: params.core.channel.text.convertMarkdownTables(
@@ -125,32 +144,82 @@ export async function deliverMattermostReplyPayload(params: {
     "mattermost",
     params.accountId,
   );
-  return await deliverTextOrMediaReply({
-    payload: params.payload,
-    text: reply.text,
-    chunkText: (value) =>
-      params.core.channel.text.chunkMarkdownTextWithMode(value, params.textLimit, chunkMode),
-    sendText: async (chunk) => {
-      await params.sendMessage(params.to, chunk, {
-        cfg: params.cfg,
-        accountId: params.accountId,
-        replyToId: params.replyToId,
-        ...(params.onDmChannelResolution
-          ? { onDmChannelResolution: params.onDmChannelResolution }
-          : {}),
-      });
-    },
-    sendMedia: async ({ mediaUrl, caption }) => {
-      await params.sendMessage(params.to, caption ?? "", {
-        cfg: params.cfg,
-        accountId: params.accountId,
-        mediaUrl,
-        mediaLocalRoots,
-        replyToId: params.replyToId,
-        ...(params.onDmChannelResolution
-          ? { onDmChannelResolution: params.onDmChannelResolution }
-          : {}),
-      });
-    },
+  const results: MattermostSendResult[] = [];
+  const acceptedContents: string[] = [];
+  let outcome: Exclude<MattermostReplyDeliveryOutcome, "reasoning_skipped">;
+  try {
+    outcome = await deliverTextOrMediaReply({
+      payload: params.payload,
+      text: reply.text,
+      chunkText: (value) =>
+        params.core.channel.text.chunkMarkdownTextWithMode(value, params.textLimit, chunkMode),
+      sendText: async (chunk) => {
+        const result = await params.sendMessage(params.to, chunk, {
+          cfg: params.cfg,
+          accountId: params.accountId,
+          replyToId: params.replyToId,
+          ...(params.onDmChannelResolution
+            ? { onDmChannelResolution: params.onDmChannelResolution }
+            : {}),
+        });
+        results.push(result);
+        acceptedContents.push(result.content);
+      },
+      sendMedia: async ({ mediaUrl, caption }) => {
+        const result = await params.sendMessage(params.to, caption ?? "", {
+          cfg: params.cfg,
+          accountId: params.accountId,
+          mediaUrl,
+          mediaLocalRoots,
+          replyToId: params.replyToId,
+          ...(params.onDmChannelResolution
+            ? { onDmChannelResolution: params.onDmChannelResolution }
+            : {}),
+        });
+        results.push(result);
+        acceptedContents.push(result.content);
+      },
+    });
+  } catch (error: unknown) {
+    const failedPartial = isChannelPartialDeliveryError(error) ? error.deliveryResult : undefined;
+    if (results.length === 0 && failedPartial?.visibleReplySent !== true) {
+      throw error;
+    }
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [
+        ...results.map((result) => ({ receipt: result.receipt })),
+        ...(failedPartial?.receipt
+          ? [{ receipt: failedPartial.receipt }]
+          : (failedPartial?.messageIds ?? []).map((messageId) => ({ messageId }))),
+      ],
+      kind: reply.mediaUrls.length > 0 ? "media" : "text",
+      ...(params.replyToId ? { replyToId: params.replyToId } : {}),
+    });
+    throw createChannelPartialDeliveryError(error, {
+      messageIds: listMessageReceiptPlatformIds(receipt),
+      receipt,
+      visibleReplySent: true,
+      content: joinMattermostVisibleContent([...acceptedContents, failedPartial?.content]),
+    });
+  }
+
+  if (outcome === "empty") {
+    return {
+      outcome,
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    };
+  }
+  const receipt = createMessageReceiptFromOutboundResults({
+    results: results.map((result) => ({ receipt: result.receipt })),
+    kind: outcome,
+    ...(params.replyToId ? { replyToId: params.replyToId } : {}),
   });
+  return {
+    outcome,
+    messageIds: listMessageReceiptPlatformIds(receipt),
+    receipt,
+    visibleReplySent: true,
+    content: joinMattermostVisibleContent(acceptedContents),
+  };
 }

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -1,3 +1,4 @@
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 // Mattermost tests cover send plugin behavior.
 import { expectProvidedCfgSkipsRuntimeLoad } from "openclaw/plugin-sdk/channel-test-helpers";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
@@ -319,7 +320,84 @@ describe("sendMessageMattermost", () => {
     expect(result.receipt.parts).toHaveLength(1);
     expect(result.receipt.parts[0]?.platformMessageId).toBe("post-1");
     expect(result.receipt.parts[0]?.kind).toBe("text");
+    expect(result.content).toBe("hello");
     expect(mockState.loadConfig).not.toHaveBeenCalled();
+  });
+
+  it("preserves the provider post when outbound bookkeeping fails afterward", async () => {
+    const events: string[] = [];
+    const onDeliveryResult = vi.fn(() => {
+      events.push("delivery");
+    });
+    mockState.createMattermostPost.mockResolvedValueOnce({
+      id: "post-final",
+      message: "provider-final",
+    });
+    mockState.recordActivity.mockImplementationOnce(() => {
+      events.push("activity");
+      throw new Error("activity store unavailable");
+    });
+
+    let caught: unknown;
+    try {
+      await sendMessageMattermost("channel:town-square", "requested text", {
+        cfg: TEST_CFG,
+        onDeliveryResult,
+      });
+    } catch (error: unknown) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected a partial Mattermost delivery error");
+    }
+    expect(caught.deliveryResult).toMatchObject({
+      messageIds: ["post-final"],
+      visibleReplySent: true,
+      content: "provider-final",
+    });
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+    expect(onDeliveryResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "post-final",
+        channelId: "town-square",
+        content: "provider-final",
+      }),
+    );
+    expect(events).toStrictEqual(["delivery", "activity"]);
+  });
+
+  it("preserves the provider post when delivery reporting fails afterward", async () => {
+    const onDeliveryResult = vi.fn(async () => {
+      throw new Error("delivery store unavailable");
+    });
+    mockState.createMattermostPost.mockResolvedValueOnce({
+      id: "post-final",
+      message: "provider-final",
+    });
+
+    let caught: unknown;
+    try {
+      await sendMessageMattermost("channel:town-square", "requested text", {
+        cfg: TEST_CFG,
+        onDeliveryResult,
+      });
+    } catch (error: unknown) {
+      caught = error;
+    }
+
+    expect(isChannelPartialDeliveryError(caught)).toBe(true);
+    if (!isChannelPartialDeliveryError(caught)) {
+      throw new Error("expected a partial Mattermost delivery error");
+    }
+    expect(caught.deliveryResult).toMatchObject({
+      messageIds: ["post-final"],
+      visibleReplySent: true,
+      content: "provider-final",
+    });
+    expect(onDeliveryResult).toHaveBeenCalledTimes(1);
+    expect(mockState.recordActivity).not.toHaveBeenCalled();
   });
 
   it("loads outbound media with trusted local roots before upload", async () => {

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -1,6 +1,8 @@
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 // Mattermost plugin module implements send behavior.
 import {
   createMessageReceiptFromOutboundResults,
+  listMessageReceiptPlatformIds,
   type MessageReceipt,
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -59,12 +61,15 @@ type MattermostSendOpts = {
   dmRetryOptions?: CreateDmChannelRetryOptions;
   /** Observe the bounded cache-miss DM channel resolution lifecycle. */
   onDmChannelResolution?: (resolution: PromiseLike<unknown>) => void;
+  /** Report the provider-finalized send before later fallible bookkeeping. */
+  onDeliveryResult?: (result: MattermostSendResult) => Promise<void> | void;
 };
 
-type MattermostSendResult = {
+export type MattermostSendResult = {
   messageId: string;
   channelId: string;
   receipt: MessageReceipt;
+  content: string;
 };
 
 const MATTERMOST_BOT_USER_CACHE_MAX_ENTRIES = 64;
@@ -491,21 +496,37 @@ export async function sendMessageMattermost(
     props,
   });
 
-  recordMattermostOutboundActivity(accountId);
   const messageId = post.id ?? "unknown";
-
-  return {
+  const receipt = createMattermostSendReceipt({
     messageId,
     channelId,
-    receipt: createMattermostSendReceipt({
-      messageId,
-      channelId,
-      kind: resolveMattermostReceiptKind({
-        fileIds,
-        buttons: opts.buttons,
-        props,
-      }),
-      replyToId: opts.replyToId,
+    kind: resolveMattermostReceiptKind({
+      fileIds,
+      buttons: opts.buttons,
+      props,
     }),
+    replyToId: opts.replyToId,
+  });
+  const result: MattermostSendResult = {
+    messageId,
+    channelId,
+    receipt,
+    content: post.message ?? message,
   };
+  try {
+    // Core must learn the provider identity before local bookkeeping can fail;
+    // preserve the receipt if either post-send step rejects to prevent a duplicate retry.
+    await opts.onDeliveryResult?.(result);
+    recordMattermostOutboundActivity(accountId);
+  } catch (error: unknown) {
+    // The provider post is already durable. Preserve its identity so callers do not
+    // retry and duplicate the visible message when local bookkeeping fails afterward.
+    throw createChannelPartialDeliveryError(error, {
+      messageIds: listMessageReceiptPlatformIds(receipt),
+      receipt,
+      visibleReplySent: true,
+      content: result.content,
+    });
+  }
+  return result;
 }

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -37,7 +37,6 @@ import {
 import {
   createMattermostReplyDeliveryBarrier,
   deliverMattermostReplyPayload,
-  toMattermostChannelDeliveryResult,
 } from "./reply-delivery.js";
 import {
   buildModelsProviderData,
@@ -887,21 +886,20 @@ async function handleSlashCommandAsync(params: {
     },
     ctxPayload,
     delivery: {
+      observeMessageSent: true,
       deliver: async (payload) => {
-        const result = toMattermostChannelDeliveryResult(
-          await deliverMattermostReplyPayload({
-            core,
-            cfg,
-            payload,
-            to,
-            accountId: account.accountId,
-            agentId: route.agentId,
-            textLimit,
-            tableMode,
-            sendMessage: sendMessageMattermost,
-            onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
-          }),
-        );
+        const result = await deliverMattermostReplyPayload({
+          core,
+          cfg,
+          payload,
+          to,
+          accountId: account.accountId,
+          agentId: route.agentId,
+          textLimit,
+          tableMode,
+          sendMessage: sendMessageMattermost,
+          onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
+        });
         if (result.visibleReplySent) {
           runtime.log?.(`delivered slash reply to ${to}`);
         }

--- a/extensions/mattermost/src/outbound-delivery.test.ts
+++ b/extensions/mattermost/src/outbound-delivery.test.ts
@@ -1,9 +1,14 @@
 // Mattermost tests cover the shared outbound delivery path.
 import { sendDurableMessageBatch } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  addTestHook,
+  createEmptyPluginRegistry,
   createTestRegistry,
+  initializeGlobalHookRunner,
   releasePinnedPluginChannelRegistry,
+  resetGlobalHookRunner,
   setActivePluginRegistry,
+  type PluginHookRegistration,
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -18,16 +23,23 @@ import { mattermostPlugin } from "./channel.js";
 describe("Mattermost outbound delivery", () => {
   beforeEach(() => {
     sendMessageMattermostMock.mockReset();
-    sendMessageMattermostMock.mockResolvedValue({
-      messageId: "post-1",
-      channelId: "channel-1",
+    sendMessageMattermostMock.mockImplementation(async (_to, text, options) => {
+      const result = {
+        messageId: "post-1",
+        channelId: "CHAN1",
+        content: text,
+      };
+      await options?.onDeliveryResult?.(result);
+      return result;
     });
     setActivePluginRegistry(
       createTestRegistry([{ pluginId: "mattermost", plugin: mattermostPlugin, source: "test" }]),
     );
+    resetGlobalHookRunner();
   });
 
   afterEach(() => {
+    resetGlobalHookRunner();
     releasePinnedPluginChannelRegistry();
   });
 
@@ -56,5 +68,60 @@ describe("Mattermost outbound delivery", () => {
       expected,
       expect.objectContaining({ cfg: {} }),
     );
+  });
+
+  it("applies a message rewrite exactly once before the provider post", async () => {
+    const hookRegistry = createEmptyPluginRegistry();
+    const handler = vi.fn().mockResolvedValue({ content: "rewritten once" });
+    addTestHook({
+      registry: hookRegistry,
+      pluginId: "rewrite-policy",
+      hookName: "message_sending",
+      handler: handler as PluginHookRegistration["handler"],
+    });
+    initializeGlobalHookRunner(hookRegistry);
+
+    await sendDurableMessageBatch({
+      cfg: {},
+      channel: "mattermost",
+      to: "channel:CHAN1",
+      payloads: [{ text: "original" }],
+      accountId: "default",
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(sendMessageMattermostMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+      "channel:CHAN1",
+      "rewritten once",
+      expect.objectContaining({
+        accountId: "default",
+        onDeliveryResult: expect.any(Function),
+      }),
+    );
+  });
+
+  it("does not create a provider post when the shared hook cancels", async () => {
+    const hookRegistry = createEmptyPluginRegistry();
+    const handler = vi.fn().mockResolvedValue({ cancel: true });
+    addTestHook({
+      registry: hookRegistry,
+      pluginId: "cancel-policy",
+      hookName: "message_sending",
+      handler: handler as PluginHookRegistration["handler"],
+    });
+    initializeGlobalHookRunner(hookRegistry);
+
+    const result = await sendDurableMessageBatch({
+      cfg: {},
+      channel: "mattermost",
+      to: "channel:CHAN1",
+      payloads: [{ text: "do not send" }],
+      accountId: "default",
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(sendMessageMattermostMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ status: "suppressed", results: [] });
   });
 });


### PR DESCRIPTION
Closes #115827

Supersedes the closed #115828 with the complete, exact-head validated Mattermost D3M patch.

## What Problem This Solves

Fixes an issue where Mattermost users could receive missing, unmodifiable, or incorrectly settled outbound replies when delivery entered through model-picker interactions, message-tool sends, draft finalization, slash replies, or related reply paths.

The concrete failures included model-picker work losing its confirmation after HTTP acknowledgement and message-tool sends creating provider-visible posts without the shared modifier/cancellation and terminal observation lifecycle. Sibling Mattermost reply paths shared the same provider-settlement invariant and could lose the finalized provider receipt or visible-content identity at different finalization boundaries.

## Why This Change Was Made

This keeps the repair inside the Mattermost plugin and gives its applicable outbound paths one provider-settled lifecycle: modifiers run once before native finalization, cancellation remains invisible, and the terminal observer receives the provider-finalized content and real post ID. Detached model-picker work gets an independent Gateway work root, and supported standalone message-tool sends use the existing durable sender through `prepareSendPayload`.

The implementation preserves a completed provider receipt before later fallible activity bookkeeping and maps synthetic current-reply interaction targets back to the real source post. It adds no core, plugin SDK, config, protocol, storage, dependency, or migration surface.

## User Impact

Mattermost replies now have consistent rewrite, cancellation, preview/finalization, and terminal-observation behavior across ordinary replies, interactions, slash replies, durable CLI sends, and message-tool sends. Provider-visible posts retain their real Mattermost identity for retry and audit decisions, reducing lost confirmations and duplicate-risk ambiguity.

## Evidence

- Exact candidate: `3023db50f91d03f78dac1334138031b1dceb2103` on frozen integration base `215e49b1a2f5155a4328864ddc85e9ff87f88dcc`.
- Full Mattermost project on Blacksmith Testbox: `51/51` files and `724/724` assertions passed ([Actions run](https://github.com/openclaw/openclaw/actions/runs/30493884670)).
- Changed gate passed formatting, SDK surface/boundaries, dead exports, production and extension-test type checks, lint, DB-first guard, media helper, runtime sidecar, and import-cycle checks.
- Focused provider-partial-progress integration: `27/27` passed.
- Fresh whole-branch autoreview: no findings; patch-correct confidence `0.87`.
- Real disposable Mattermost proof used the production plugin and Gateway, WebSocket ingress, provider REST readback, and authenticated browser UI:
  - canonical rewrite: exact `reply_payload_sending → message_sending → message_sent`; provider-final content/ID and UI agree;
  - observer preview: preview observed and the same post finalized; terminal content/ID and UI agree;
  - cancellation at each modifying hook: no preview, final post, attachment, or false terminal event;
  - button and model-picker interactions: exact lifecycle with real source/final post identity;
  - slash media cancellation: media reached both modifiers and remained invisible after cancellation;
  - durable CLI media: exit 0, one attachment, and CLI/provider post IDs agree;
  - message-tool text and media: one `message_sending` and one `message_sent`, with provider-final content/ID and UI agreement.
- Live runs: `run_de618382ea80` (8 rows) and `run_7bc943f789ac` (2 rows), both public/no-Tailscale AWS leases, released after artifact collection.
- Redacted live evidence bundle SHA-256: `a707ce5658a4380985ae3de46790442c8c46d107514f8a2af56710add7b300f7`. The sanitized bundle is prepared for GitHub attachment; its web-UI upload is pending Chrome-control recovery.
- TruffleHog reported zero verified and zero unverified findings across the extracted evidence; targeted credential scans were also clean.

Post-native-send activity-bookkeeping failure is covered deterministically rather than by a live fault injection because the production activity recorder is in-memory and has no safe external failure control.

AI-assisted implementation and validation. I reviewed the full patch and understand the ownership and delivery semantics.
