### PR TITLE
fix(mattermost): honor configured envelope timezone

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -2,6 +2,7 @@
 import {
   formatInboundEnvelope,
   implicitMentionKindWhen,
+  resolveInboundSessionEnvelopeContext,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
   resolveChannelContextVisibilityMode,
@@ -111,6 +112,11 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
     const rawPostText = typeof post.message === "string" ? post.message : "";
     const rawText = normalizeOptionalString(rawPostText) ?? "";
     const { effectiveReplyToId, sessionKey } = thread;
+    const { envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
+      cfg,
+      agentId: route.agentId,
+      sessionKey,
+    });
     const historyKey = resolveMattermostPendingHistoryKey({ kind, sessionKey });
     const fileIds = uniqueStrings(normalizeTrimmedStringList(post.file_ids ?? []));
     const nativeMedia = fileIds.map(() => ({}));
@@ -353,6 +359,8 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
       body: textWithId,
       chatType: kind,
       sender: { name: senderName, id: senderId },
+      previousTimestamp,
+      envelope: envelopeOptions,
     });
     let combinedBody = body;
     if (historyKey) {
@@ -371,6 +379,7 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
             }`,
             chatType: kind,
             senderLabel: entry.sender,
+            envelope: envelopeOptions,
           }),
       });
     }

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -482,6 +482,7 @@ async function emitMattermostChannelPost(
     rootId?: string;
     senderId?: string;
     senderName?: string;
+    createAt?: number;
   },
 ) {
   const senderId = params.senderId ?? "user-1";
@@ -498,7 +499,7 @@ async function emitMattermostChannelPost(
         user_id: senderId,
         message: params.message,
         root_id: params.rootId,
-        create_at: 1_714_000_000_000,
+        create_at: params.createAt ?? 1_714_000_000_000,
       }),
     },
     broadcast: {
@@ -593,6 +594,68 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.MessageSid).toBe("post-inbound-system-event-regular");
     expect(ctx?.OriginatingChannel).toBe("mattermost");
     expect(ctx?.Provider).toBe("mattermost");
+  });
+
+  it("formats current and pending-history timestamps in the configured user timezone", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: {
+          envelopeTimezone: "user",
+          userTimezone: "Asia/Jakarta",
+        },
+      },
+      messages: { groupChat: { historyLimit: 1 } },
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://mattermost.example.com",
+          botToken: "bot-token",
+          chatmode: "onmessage",
+          dmPolicy: "open",
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["allowed-user"],
+        },
+      },
+    };
+    mockState.runtimeCore = createRuntimeCore(config);
+
+    const monitor = monitorMattermostProvider({
+      config,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await emitMattermostChannelPost(socket, {
+      id: "timezone-history",
+      message: "history in Jakarta",
+      senderId: "denied-user",
+      senderName: "mallory",
+      createAt: 1_714_000_000_000,
+    });
+    await emitMattermostChannelPost(socket, {
+      id: "timezone-current",
+      message: "current in Jakarta",
+      senderId: "allowed-user",
+      senderName: "alice",
+      createAt: 1_714_003_600_000,
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    const ctx = mockState.dispatchInboundMessage.mock.calls.at(0)?.[0].ctx;
+    expect(ctx?.Body).toContain("Thu 2024-04-25 06:06:40");
+    expect(ctx?.Body).toContain("Thu 2024-04-25 07:06:40");
+    expect(ctx?.Body).toContain("history in Jakarta");
+    expect(ctx?.Body).toContain("current in Jakarta");
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Mattermost users who selected user-timezone message
envelopes would still see current and pending-history timestamps formatted in
the Gateway host timezone.

## Why This Change Was Made

The Mattermost inbound handler now resolves the canonical session envelope
context once and applies it to both the current message and pending history. It
also carries the previous session timestamp into the current envelope, matching
the shared channel contract instead of adding Mattermost-specific timezone
logic.

The regression was introduced when the Mattermost inbound monitor was split in
https://github.com/openclaw/openclaw/pull/113775 and the new formatter calls did
not receive the shared envelope options.

## User Impact

Mattermost inbound timestamps now follow `agents.defaults.envelopeTimezone` and
`agents.defaults.userTimezone` consistently for both the triggering message and
the pending-history context shown to the model.

## Evidence

Exact head: `dc6ff2ff9d20b91b48bf6409b22d9c715b387c64`

```text
node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
Test Files  1 passed (1)
Tests  26 passed (26)

oxfmt: clean
git diff --check: clean
autoreview: clean, no accepted/actionable findings
```

The regression fixes two event timestamps one hour apart and asserts the
rendered Jakarta times for both pending history and the current message.

