### PR TITLE
fix(gateway): abort embeddings when clients disconnect

### DIFF
--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -623,7 +623,9 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
       receivedSignal = signal;
       embedStarted.resolve();
       await (signal
-        ? new Promise<void>((resolve) => signal.addEventListener("abort", resolve, { once: true }))
+        ? new Promise<void>((resolve) =>
+            signal.addEventListener("abort", () => resolve(), { once: true }),
+          )
         : releaseEmbed.promise);
       return [[0.1, 0.2]];
     });

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -1,13 +1,22 @@
 // Embeddings HTTP tests cover OpenAI-compatible embedding routes, provider
 // adapters, agent-scoped config, auth scopes, and disabled-surface behavior.
 import fs from "node:fs/promises";
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import {
+  createServer,
+  type IncomingMessage,
+  request as httpRequest,
+  type ServerResponse,
+} from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import { createConfigIO, resetConfigRuntimeState } from "../config/config.js";
-import type { MemoryEmbeddingProviderAdapter } from "../plugins/memory-embedding-providers.js";
+import type {
+  MemoryEmbeddingProviderAdapter,
+  MemoryEmbeddingProviderCallOptions,
+} from "../plugins/memory-embedding-providers.js";
+import { createDeferred } from "../test-utils/deferred.js";
 import { startOpenAiCompatGatewayServer } from "./openai-compatible-http.test-helpers.js";
 import { getFreePort, installGatewayTestHooks, testState } from "./test-helpers.js";
 
@@ -34,7 +43,11 @@ let createEmbeddingProviderMock: ReturnType<
     }>
   >
 >;
-let embedBatchMock: ReturnType<typeof vi.fn<(texts: string[]) => Promise<number[][]>>>;
+let embedBatchMock: ReturnType<
+  typeof vi.fn<
+    (texts: string[], options?: MemoryEmbeddingProviderCallOptions) => Promise<number[][]>
+  >
+>;
 let closeEmbeddingProviderMock: ReturnType<typeof vi.fn<() => Promise<void> | void>>;
 let clearMemoryEmbeddingProviders: typeof import("../plugins/memory-embedding-providers.js").clearMemoryEmbeddingProviders;
 let registerMemoryEmbeddingProvider: typeof import("../plugins/memory-embedding-providers.js").registerMemoryEmbeddingProvider;
@@ -598,6 +611,53 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
 
     expect(res.status).toBe(500);
     expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 1);
+  });
+
+  it("aborts provider work when the HTTP client disconnects", async () => {
+    const closesBefore = closeEmbeddingProviderMock.mock.calls.length;
+    let receivedSignal: AbortSignal | undefined;
+    const embedStarted = createDeferred();
+    const releaseEmbed = createDeferred();
+    embedBatchMock.mockImplementationOnce(async (_texts, options) => {
+      const signal = options?.signal;
+      receivedSignal = signal;
+      embedStarted.resolve();
+      await (signal
+        ? new Promise<void>((resolve) => signal.addEventListener("abort", resolve, { once: true }))
+        : releaseEmbed.promise);
+      return [[0.1, 0.2]];
+    });
+
+    const body = JSON.stringify({ model: "openclaw/default", input: "hello" });
+    const clientRequest = httpRequest({
+      host: "127.0.0.1",
+      port: enabledPort,
+      path: "/v1/embeddings",
+      method: "POST",
+      headers: {
+        authorization: "Bearer secret",
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(body),
+        ...WRITE_SCOPE_HEADER,
+      },
+    });
+    clientRequest.on("error", () => {});
+    clientRequest.end(body);
+
+    await embedStarted.promise;
+    clientRequest.destroy();
+
+    try {
+      await vi.waitFor(() => {
+        expect(receivedSignal).toBeDefined();
+        expect(receivedSignal?.aborted).toBe(true);
+      });
+    } finally {
+      releaseEmbed.resolve();
+    }
+    await vi.waitFor(() =>
+      expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 1),
+    );
   });
 
   it("supports synchronous provider cleanup", async () => {

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -723,6 +723,67 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
     expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 2);
   });
 
+  it("does not create a provider for a disconnected request waiting behind cleanup", async () => {
+    Reflect.set(openAiAdapter, "transport", "local");
+    let releaseClose: () => void = () => {};
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    closeEmbeddingProviderMock.mockImplementationOnce(async () => {
+      await closeGate;
+    });
+    const createsBefore = createEmbeddingProviderMock.mock.calls.length;
+    const closesBefore = closeEmbeddingProviderMock.mock.calls.length;
+    const firstPromise = postEmbeddings({ model: "openclaw/default", input: "first" });
+    let secondRequest: ReturnType<typeof httpRequest> | undefined;
+
+    try {
+      await vi.waitFor(() =>
+        expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(closesBefore + 1),
+      );
+
+      const body = JSON.stringify({ model: "openclaw/default", input: "second" });
+      secondRequest = httpRequest({
+        host: "127.0.0.1",
+        port: enabledPort,
+        path: "/v1/embeddings",
+        method: "POST",
+        headers: {
+          authorization: "******",
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+          ...WRITE_SCOPE_HEADER,
+        },
+      });
+      secondRequest.on("error", () => {});
+      const secondRequestFinished = createDeferred();
+      secondRequest.once("finish", secondRequestFinished.resolve);
+      const secondRequestClosed = createDeferred();
+      secondRequest.once("close", secondRequestClosed.resolve);
+      secondRequest.end(body);
+      await secondRequestFinished.promise;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      secondRequest.destroy();
+      await secondRequestClosed.promise;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+
+      releaseClose();
+      expect((await firstPromise).status).toBe(200);
+
+      const next = await postEmbeddings({ model: "openclaw/default", input: "next" });
+      expect(next.status).toBe(200);
+      expect(createEmbeddingProviderMock).toHaveBeenCalledTimes(createsBefore + 2);
+    } finally {
+      releaseClose();
+      secondRequest?.destroy();
+      Reflect.set(openAiAdapter, "transport", "remote");
+    }
+  });
+
   it("serializes cleanup when a remote request creates a local provider", async () => {
     let releaseClose: () => void = () => {};
     const closeGate = new Promise<void>((resolve) => {

--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -623,9 +623,9 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
       receivedSignal = signal;
       embedStarted.resolve();
       await (signal
-        ? new Promise<void>((resolve) =>
-            signal.addEventListener("abort", () => resolve(), { once: true }),
-          )
+        ? new Promise<void>((resolve) => {
+            signal.addEventListener("abort", () => resolve(), { once: true });
+          })
         : releaseEmbed.promise);
       return [[0.1, 0.2]];
     });

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -72,13 +72,21 @@ const EMBEDDING_PROVIDER_ADMISSION_TAILS = new Map<string, Promise<void>>();
 
 async function acquireEmbeddingProviderLease(
   scopeKey: string,
+  signal: AbortSignal,
   create: () => Promise<MemoryEmbeddingProvider>,
   holdForCleanup: (provider: MemoryEmbeddingProvider) => boolean,
 ): Promise<{ provider: MemoryEmbeddingProvider; release: () => void }> {
   const previous = EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) ?? Promise.resolve();
   const createLease = async () => {
+    signal.throwIfAborted();
     await drainEmbeddingProviderRetirements(scopeKey);
+    // Keep the cleanup fence intact, but do not create a provider for an aborted waiter.
+    signal.throwIfAborted();
     const provider = await create();
+    if (signal.aborted) {
+      await closeEmbeddingProvider(scopeKey, provider);
+      signal.throwIfAborted();
+    }
     if (!holdForCleanup(provider)) {
       return { provider, lifecycle: Promise.resolve(), release: () => {} };
     }
@@ -138,6 +146,18 @@ function retainEmbeddingProviderForRetirement(
   const pending = EMBEDDING_PROVIDER_RETIREMENTS.get(scopeKey) ?? new Set();
   pending.add(provider);
   EMBEDDING_PROVIDER_RETIREMENTS.set(scopeKey, pending);
+}
+
+async function closeEmbeddingProvider(
+  scopeKey: string,
+  provider: MemoryEmbeddingProvider,
+): Promise<void> {
+  try {
+    await provider.close?.();
+  } catch (closeErr) {
+    retainEmbeddingProviderForRetirement(scopeKey, provider);
+    logWarn(`openai-compat: failed to close embeddings provider: ${formatErrorMessage(closeErr)}`);
+  }
 }
 
 export async function drainRetainedOpenAiEmbeddingProviders(): Promise<void> {
@@ -458,6 +478,7 @@ export async function handleOpenAiEmbeddingsHttpRequest(
   try {
     const { provider, release } = await acquireEmbeddingProviderLease(
       providerScopeKey,
+      abortController.signal,
       async () =>
         await createConfiguredEmbeddingProvider({
           cfg,
@@ -500,12 +521,7 @@ export async function handleOpenAiEmbeddingsHttpRequest(
       });
     } finally {
       try {
-        await provider.close?.();
-      } catch (closeErr) {
-        retainEmbeddingProviderForRetirement(providerScopeKey, provider);
-        logWarn(
-          `openai-compat: failed to close embeddings provider: ${formatErrorMessage(closeErr)}`,
-        );
+        await closeEmbeddingProvider(providerScopeKey, provider);
       } finally {
         release();
       }

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -25,7 +25,7 @@ import type {
 } from "../plugins/memory-embedding-providers.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, sendMissingScopeForbidden } from "./http-common.js";
+import { sendJson, sendMissingScopeForbidden, watchClientDisconnect } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   OPENCLAW_MODEL_ID,
@@ -449,6 +449,11 @@ export async function handleOpenAiEmbeddingsHttpRequest(
     cfg,
     provider: target.provider,
   });
+  if (req.socket.destroyed || res.destroyed || res.socket?.destroyed) {
+    return true;
+  }
+  const abortController = new AbortController();
+  const stopWatchingDisconnect = watchClientDisconnect(req, res, abortController);
 
   try {
     const { provider, release } = await acquireEmbeddingProviderLease(
@@ -474,7 +479,10 @@ export async function handleOpenAiEmbeddingsHttpRequest(
         isLocalEmbeddingProvider({ cfg, provider: createdProvider.id }),
     );
     try {
-      const embeddings = await provider.embedBatch(texts);
+      const embeddings = await provider.embedBatch(texts, { signal: abortController.signal });
+      if (abortController.signal.aborted) {
+        return true;
+      }
       const encodingFormat = payload.encoding_format === "base64" ? "base64" : "float";
 
       sendJson(res, 200, {
@@ -503,13 +511,17 @@ export async function handleOpenAiEmbeddingsHttpRequest(
       }
     }
   } catch (err) {
-    logWarn(`openai-compat: embeddings request failed: ${formatErrorMessage(err)}`);
-    sendJson(res, 500, {
-      error: {
-        message: "internal error",
-        type: "api_error",
-      },
-    });
+    if (!abortController.signal.aborted) {
+      logWarn(`openai-compat: embeddings request failed: ${formatErrorMessage(err)}`);
+      sendJson(res, 500, {
+        error: {
+          message: "internal error",
+          type: "api_error",
+        },
+      });
+    }
+  } finally {
+    stopWatchingDisconnect();
   }
 
   return true;


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where callers of `POST /v1/embeddings` could disconnect while the Gateway continued running the abandoned embedding request against the configured provider.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

The embeddings handler now watches the request connection with a request-scoped abort controller and passes its signal to `embedBatch`, matching the cancellation boundary already used by adjacent Gateway routes. Disconnect-triggered aborts no longer attempt to write or log an internal-error response, while provider lease release and cleanup remain unchanged.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Cancellation-aware embedding providers can stop expensive or blocked work promptly when the requesting client goes away. This does not change the embeddings API, configuration, schema, or behavior of completed requests.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

- Fresh-red regression check on the pre-fix `main` snapshot failed because `embedBatch` received no `AbortSignal` after the client socket was destroyed.
- A live OpenClaw development Gateway using the OpenAI embedding provider sent an embedding request to a blocking OpenAI-compatible upstream. On the final repaired HEAD (`cb182041`), destroying the Gateway client socket after the upstream request began aborted the in-flight upstream connection in 28 ms. The bounded proof runner passed with exit code 0 and completed process cleanup.

  Redacted terminal transcript from the after-fix run:

  ```text
  gateway_ready=true
  embeddings_endpoint_ready=true
  upstream_embed_request_started=true
  gateway_client_socket_destroyed=true
  upstream_connection_aborted=true
  ```

  The emitted result record reported `runtime_kind=openclaw_dev_gateway_with_openai_embedding_provider`, `route=POST /v1/embeddings`, `ok=true`, `near_real=true`, and `abort_latency_ms=28`. The proof used only local loopback endpoints; no credentials, private endpoints, or external addresses are included above.

- Full `src/gateway/embeddings-http.test.ts` suite: 48/48 tests passed across both configured projects.
- CI-equivalent `pnpm check:test-types` passed after correcting the abort-listener callback signature.
- Focused formatting validation passed for the changed Gateway source and test files.


### Exact-head maintainer verification (48b1f8ee2db238ab0b559f31d1e701d9dc6eb008)

The final head was re-verified with real loopback HTTP sockets using the Gateway embeddings E2E harness:

- `aborts provider work when the HTTP client disconnects`: passed in both Gateway projects (84–85 ms).
- `does not create a provider for a disconnected request waiting behind cleanup`: passed in both Gateway projects (61 ms); the disconnected queued request did not create a replacement provider.
- Result: 4 selected executions passed across 2 projects; exit code 0.

Command: `node scripts/run-vitest.mjs src/gateway/embeddings-http.test.ts -t <the two cancellation test names> --reporter=verbose`

The run used only local loopback HTTP sockets and test providers. No credentials, private endpoints, or external addresses were involved.