### PR TITLE
fix(ci): invalidate tsgo incremental state whenever boundary dts inputs go stale

### DIFF
--- a/scripts/prepare-extension-package-boundary-artifacts.mjs
+++ b/scripts/prepare-extension-package-boundary-artifacts.mjs
@@ -416,10 +416,11 @@ function hasMissingOutput(paths) {
   return paths.some((relativePath) => !fs.existsSync(resolve(repoRoot, relativePath)));
 }
 
-function removeIncrementalStateForMissingOutput(params) {
-  if (!hasMissingOutput(params.outputPaths)) {
-    return;
-  }
+// Stale inputs invalidate the whole incremental emit graph, not just missing
+// outputs: reused .tsbuildinfo can skip re-emitting declarations whose own
+// sources did not change even when the cached d.ts predates their current
+// exports (observed on sticky-disk CI runners).
+function removeStaleIncrementalState(params) {
   fs.rmSync(resolve(repoRoot, params.tsBuildInfoPath), { force: true });
 }
 
@@ -802,8 +803,7 @@ async function main(argv = process.argv.slice(2)) {
     const dependentSteps = [];
     if (mode === "all") {
       if (!rootDtsFresh) {
-        removeIncrementalStateForMissingOutput({
-          outputPaths: ROOT_DTS_REQUIRED_OUTPUTS,
+        removeStaleIncrementalState({
           tsBuildInfoPath: "dist/plugin-sdk/.tsbuildinfo",
         });
         prerequisiteSteps.push({
@@ -818,8 +818,7 @@ async function main(argv = process.argv.slice(2)) {
       }
     }
     if (!packageDtsFresh) {
-      removeIncrementalStateForMissingOutput({
-        outputPaths: PACKAGE_DTS_REQUIRED_OUTPUTS,
+      removeStaleIncrementalState({
         tsBuildInfoPath: "packages/plugin-sdk/dist/.tsbuildinfo",
       });
       prerequisiteSteps.push({
@@ -834,8 +833,7 @@ async function main(argv = process.argv.slice(2)) {
     }
     if (mode === "all") {
       if (!qaChannelDtsFresh) {
-        removeIncrementalStateForMissingOutput({
-          outputPaths: QA_CHANNEL_DTS_REQUIRED_OUTPUTS,
+        removeStaleIncrementalState({
           tsBuildInfoPath: "dist/plugin-sdk/extensions/qa-channel/.tsbuildinfo",
         });
         dependentSteps.push({
@@ -865,8 +863,7 @@ async function main(argv = process.argv.slice(2)) {
         process.stdout.write("[qa-channel boundary dts] fresh; skipping\n");
       }
       if (!matrixDtsFresh) {
-        removeIncrementalStateForMissingOutput({
-          outputPaths: MATRIX_DTS_REQUIRED_OUTPUTS,
+        removeStaleIncrementalState({
           tsBuildInfoPath: "dist/plugin-sdk/extensions/matrix/.tsbuildinfo",
         });
         dependentSteps.push({
@@ -896,8 +893,7 @@ async function main(argv = process.argv.slice(2)) {
         process.stdout.write("[matrix boundary dts] fresh; skipping\n");
       }
       if (!discordDtsFresh) {
-        removeIncrementalStateForMissingOutput({
-          outputPaths: DISCORD_DTS_REQUIRED_OUTPUTS,
+        removeStaleIncrementalState({
           tsBuildInfoPath: "dist/plugin-sdk/extensions/discord/.tsbuildinfo",
         });
         dependentSteps.push({
@@ -927,8 +923,7 @@ async function main(argv = process.argv.slice(2)) {
         process.stdout.write("[discord boundary dts] fresh; skipping\n");
       }
       if (!slackDtsFresh) {
-        removeIncrementalStateForMissingOutput({
-          outputPaths: SLACK_DTS_REQUIRED_OUTPUTS,
+        removeStaleIncrementalState({
           tsBuildInfoPath: "dist/plugin-sdk/extensions/slack/.tsbuildinfo",
         });
         dependentSteps.push({
@@ -958,8 +953,7 @@ async function main(argv = process.argv.slice(2)) {
         process.stdout.write("[slack boundary dts] fresh; skipping\n");
       }
       if (!whatsappDtsFresh) {
-        removeIncrementalStateForMissingOutput({
-          outputPaths: WHATSAPP_DTS_REQUIRED_OUTPUTS,
+        removeStaleIncrementalState({
           tsBuildInfoPath: "dist/plugin-sdk/extensions/whatsapp/.tsbuildinfo",
         });
         dependentSteps.push({
@@ -989,8 +983,7 @@ async function main(argv = process.argv.slice(2)) {
         process.stdout.write("[whatsapp boundary dts] fresh; skipping\n");
       }
       if (!telegramDtsFresh) {
-        removeIncrementalStateForMissingOutput({
-          outputPaths: TELEGRAM_DTS_REQUIRED_OUTPUTS,
+        removeStaleIncrementalState({
           tsBuildInfoPath: "dist/plugin-sdk/extensions/telegram/.tsbuildinfo",
         });
         dependentSteps.push({


### PR DESCRIPTION
### What Problem This Solves

The extension-package-boundary check intermittently fails on sticky-disk CI runners with TS2305 "has no exported member" errors for exports that exist and build cleanly from scratch (observed on `extensions/matrix`, then `extensions/slack`). The stale `.tsbuildinfo` from a previous run survives on the runner, and the prepare script only removed incremental state when the *output* was missing — not when the boundary dts *inputs* had gone stale — so tsgo trusted a stale graph and reported phantom missing exports.

### Why This Change Was Made

`removeIncrementalStateForMissingOutput` becomes `removeStaleIncrementalState`: the prepare script now unconditionally removes the affected `.tsbuildinfo` whenever freshness validation fails, instead of only when the output file is absent. A stale incremental graph is never trusted; tsgo rebuilds that package's boundary state from real inputs.

This was originally part of the automations rename stack (#114852) because it first bit there; review feedback correctly asked for it to be a focused standalone change with its own proof.

### User Impact

None at runtime — CI-only. Contributors stop hitting phantom TS2305 boundary failures after unrelated dts churn on reused runners.

### Evidence

- Original failure: `check-extension-package-boundaries` red on #114852 with TS2305 for exports present in the branch; the same command built clean on a Blacksmith Testbox forced rebuild and in a fresh local checkout — isolating the failure to reused incremental state on sticky-disk runners.
- After this change, the same lane went green on the stack branch across multiple pushes (see #114852 CI history) including runs on reused runners.
- Deterministic behavior: removal only triggers when freshness validation already failed, so warm-cache fast paths are unchanged.

Maintainer/build-owner signoff requested per review: @omarshahine.

### Landing Proof (2026-08-01)

Direct AWS Crabbox proof on exact PR head `bbcdb3342d84e690449c21328a954bebdcee4c76`:

- Provider: direct AWS Crabbox, lease `cbx_6e27b5d52373` (`c7a.8xlarge`)
- Run: [run_a719e940a2f5](https://crabbox.openclaw.ai/portal/runs/run_a719e940a2f5)
- Toolchain: Node `v24.15.0`, pnpm `11.15.1`, frozen lockfile install
- Focused regression suite: `18 passed`
- Repro state: every declaration output present, a declaration deliberately stale, input newer than the freshness stamp, valid `.tsbuildinfo` retained and made read-only
- Cleanup observation: filesystem watcher saw `.tsbuildinfo` removed (`exists=false`)
- Rebuild observation: the stale declaration SHA `125e8f...` returned exactly to the original SHA `de79b9...`; rebuilt `.tsbuildinfo` mode changed from `444` to `664`
- Product gate: all `125` extension package boundaries compiled successfully
- Static gate: `git diff --check` passed

```text
SETUP outputs_present=yes target_corrupted=yes input_newer_than_stamp=yes tsbuildinfo_mode=444
expected_target_sha=de79b918d32498307551263d98fd46e19f88c5c408b89513cf5434c398a57322
stale_target_sha=125e8f58051dfddee02857f1da7d9d8b46dfe93ca826946b1d17491f5164610b
WATCH tsbuildinfo rename observed exists=false
AFTER rebuilt_target_sha=de79b918d32498307551263d98fd46e19f88c5c408b89513cf5434c398a57322 tsbuildinfo_mode=664
extension package boundary check passed
mode: compile
compiled plugins: 125
PROOF_RESULT=PASS stale-but-present declaration repaired incremental-state replaced boundary-compile passed
```