### PR TITLE
fix(telegram): inline buttons ignore the configured chat-kind limit when editing a message

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -2230,6 +2230,75 @@ describe("handleTelegramAction", () => {
     ).rejects.toThrow(expectedMessage);
   });
 
+  it.each([
+    {
+      name: "scope is group and the edited chat is a DM",
+      chatId: "123456",
+      content: "updated",
+      inlineButtons: "group" as const,
+      expectedMessage: /inline buttons are limited to groups/i,
+    },
+    {
+      name: "scope is dm and the edited chat is a group",
+      chatId: "-100123456",
+      content: "updated",
+      inlineButtons: "dm" as const,
+      expectedMessage: /inline buttons are limited to DMs/i,
+    },
+    {
+      name: "scope is group, the edited chat is a DM, and only the keyboard changes",
+      chatId: "123456",
+      content: undefined,
+      inlineButtons: "group" as const,
+      expectedMessage: /inline buttons are limited to groups/i,
+    },
+    {
+      // Same fail-closed treatment sendMessage already applies: a username target
+      // cannot be classified, so a scoped edit must ask for a numeric chat id.
+      name: "the edited chat is a username and the scope needs a known chat type",
+      chatId: "@publicgroup",
+      content: "updated",
+      inlineButtons: "group" as const,
+      expectedMessage: /require a numeric chat id/i,
+    },
+  ])(
+    "blocks editMessage inline buttons when $name",
+    async ({ chatId, content, inlineButtons, expectedMessage }) => {
+      await expect(
+        handleTelegramAction(
+          {
+            action: "editMessage",
+            chatId,
+            messageId: 1,
+            ...(content === undefined ? {} : { content }),
+            presentation: {
+              blocks: [{ type: "buttons", buttons: [{ label: "Ok", value: "cmd:ok" }] }],
+            },
+          },
+          telegramConfig({ capabilities: { inlineButtons } }),
+        ),
+      ).rejects.toThrow(expectedMessage);
+      expect(editMessageTelegram).not.toHaveBeenCalled();
+      expect(editMessageReplyMarkupTelegram).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows editMessage inline buttons when the edited chat matches the scope", async () => {
+    await handleTelegramAction(
+      {
+        action: "editMessage",
+        chatId: "-100123456",
+        messageId: 1,
+        content: "updated",
+        presentation: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Ok", value: "cmd:ok" }] }],
+        },
+      },
+      telegramConfig({ capabilities: { inlineButtons: "group" } }),
+    );
+    expect(editMessageTelegram).toHaveBeenCalled();
+  });
+
   it("allows inline buttons in DMs with tg: prefixed targets", async () => {
     await sendInlineButtonsMessage({
       to: "tg:5232990709",

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -342,6 +342,40 @@ function getLastDurableTelegramActionResult(
   };
 }
 
+// Scope constrains the chat an action targets, not a property the message inherited at
+// send time. Both outbound paths must agree: generic callbacks outside the scope are
+// dropped in `bot-handlers.callback.runtime.ts`, so a skipped check ships dead buttons.
+function assertTelegramInlineButtonsAllowed(params: {
+  cfg: OpenClawConfig;
+  accountId?: string;
+  target: string;
+}): void {
+  const scope = resolveTelegramInlineButtonsScope({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  if (scope === "off") {
+    throw new Error(
+      'Telegram inline buttons are disabled. Set channels.telegram.capabilities.inlineButtons to "dm", "group", "all", or "allowlist".',
+    );
+  }
+  if (scope !== "dm" && scope !== "group") {
+    return;
+  }
+  const targetType = resolveTelegramTargetChatType(params.target);
+  if (targetType === "unknown") {
+    throw new Error(
+      `Telegram inline buttons require a numeric chat id when inlineButtons="${scope}".`,
+    );
+  }
+  if (scope === "dm" && targetType !== "direct") {
+    throw new Error('Telegram inline buttons are limited to DMs when inlineButtons="dm".');
+  }
+  if (scope === "group" && targetType !== "group") {
+    throw new Error('Telegram inline buttons are limited to groups when inlineButtons="group".');
+  }
+}
+
 export async function handleTelegramAction(
   params: Record<string, unknown>,
   cfg: OpenClawConfig,
@@ -500,31 +534,11 @@ export async function handleTelegramAction(
       throw new Error("Telegram video notes require exactly one media attachment.");
     }
     if (buttons) {
-      const inlineButtonsScope = resolveTelegramInlineButtonsScope({
+      assertTelegramInlineButtonsAllowed({
         cfg,
         accountId: accountId ?? undefined,
+        target: to,
       });
-      if (inlineButtonsScope === "off") {
-        throw new Error(
-          'Telegram inline buttons are disabled. Set channels.telegram.capabilities.inlineButtons to "dm", "group", "all", or "allowlist".',
-        );
-      }
-      if (inlineButtonsScope === "dm" || inlineButtonsScope === "group") {
-        const targetType = resolveTelegramTargetChatType(to);
-        if (targetType === "unknown") {
-          throw new Error(
-            `Telegram inline buttons require a numeric chat id when inlineButtons="${inlineButtonsScope}".`,
-          );
-        }
-        if (inlineButtonsScope === "dm" && targetType !== "direct") {
-          throw new Error('Telegram inline buttons are limited to DMs when inlineButtons="dm".');
-        }
-        if (inlineButtonsScope === "group" && targetType !== "group") {
-          throw new Error(
-            'Telegram inline buttons are limited to groups when inlineButtons="group".',
-          );
-        }
-      }
     }
     // Optional threading parameters for forum topics and reply chains
     const replyToMessageId = readTelegramReplyToMessageId(params);
@@ -747,15 +761,13 @@ export async function handleTelegramAction(
       throw new Error("content required.");
     }
     if (buttons !== undefined) {
-      const inlineButtonsScope = resolveTelegramInlineButtonsScope({
+      // Validate against the binding-resolved chat id, not the raw param, so
+      // topic shorthands and aliases are scoped by the chat actually edited.
+      assertTelegramInlineButtonsAllowed({
         cfg,
         accountId: accountId ?? undefined,
+        target: String(authorizedChatId),
       });
-      if (inlineButtonsScope === "off") {
-        throw new Error(
-          'Telegram inline buttons are disabled. Set channels.telegram.capabilities.inlineButtons to "dm", "group", "all", or "allowlist".',
-        );
-      }
     }
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who restrict Telegram inline buttons to one chat kind
still get buttons attached in the other kind — and those buttons do nothing when pressed.

`channels.telegram.capabilities.inlineButtons` accepts `off` / `dm` / `group` / `all` /
`allowlist`; the `dm` and `group` values restrict which chat kind may receive inline
buttons. Sending a message honors that restriction. Editing a message does not: the edit
path checks only `off`, so with `inlineButtons: "group"` an `editMessage` action attaches a
keyboard to a DM.

The user-visible result is worse than an ignored setting. The inbound callback handler
*does* apply the same `dm`/`group` rule to generic callbacks, and silently returns when
the chat kind is out of scope. So the agent puts a button in a DM, the user taps it,
Telegram's spinner stops, and nothing happens — no action, no error, nothing recorded.

## Why This Change Was Made

The `dm`/`group` rule was already enforced on outbound `sendMessage` and on inbound
generic callbacks, and was missing only on outbound `editMessage`. This change extracts
the check the two outbound paths share into one `assertTelegramInlineButtonsAllowed`
helper and calls it from both, so the rule has a single owner instead of one full and one
partial copy. Error strings and evaluation order are unchanged: the edit path now reaches
the messages `sendMessage` has always produced.

**Behavior change worth reviewing.** The edit path becomes as strict as the send path,
which includes the send path's fail-closed treatment of targets whose chat kind cannot be
determined. `resolveTelegramTargetChatType` classifies only numeric ids (`-…` group,
otherwise direct); a `@username` target is `unknown`. Under `dm`/`group` scope
`sendMessage` already rejects those with *"inline buttons require a numeric chat id"*, and
now `editMessage` does too. Editing by username with buttons under a `dm`/`group` scope
therefore stops working and returns that actionable error instead. A test pins this so it
is a decision rather than a side effect. The alternative — enforcing the mismatch but
skipping the `unknown` case on edits only — would leave the two outbound paths disagreeing
again, which is the defect being fixed.

The edit path validates the chat id that `resolveTelegramMessageMutationChatId` returns
rather than the raw `chatId` parameter, so a delegated edit is scoped by the
provider-observed conversation it is actually bound to instead of by caller-supplied text.

**Known limitation, unchanged by this PR.** Because the classifier is syntactic, a
numeric channel id (`-100…`) reads as `group`, while the callback handler treats only
`group`/`supergroup` as a group. A channel can therefore still receive a `group`-scoped
keyboard whose taps are dropped. That gap is shared with `sendMessage` today and closing
it needs the resolved Telegram chat type, which is a larger change than this one; happy to
follow up if wanted.

Non-goals: the `off` check (already correct on both paths), the inbound callback handler
(already correct — note runtime-control callbacks such as approvals intentionally bypass
this scope gate), the `allowWebAppButtons` gate, and the `all` and `allowlist` values.
Neither constrains chat kind on the outbound side; `allowlist` is applied by the callback
handler as sender authorization, not as a chat-kind rule.

Open PR #112292 rewrites the neighbouring `allowWebAppButtons` option in these same two
files; its hunks sit ~40 lines from these and do not touch the mutation-resolved chat id
this change relies on.

## User Impact

Operators who set `inlineButtons` to `dm` or `group` now get that restriction honored on
message edits, not only on sends, so the agent can no longer produce a button that the
callback handler will silently discard. Operators using numeric chat ids see no change
when their scope already matched the chats they edit. Operators who edit **by username**
under a `dm`/`group` scope will now see *"inline buttons require a numeric chat id"* and
need to pass the numeric id — the same requirement `sendMessage` already imposes.

## Evidence

**Live Telegram, real bot, real direct chat.** The production `handleTelegramAction` runs
in a real Node process — no vitest, no mocks, no stubbed transport. Whether a button
actually landed is answered by Telegram, not by the harness: a raw
`editMessageReplyMarkup` with `{ inline_keyboard: [] }` returns `200 ok` if a keyboard was
present, and `400 message is not modified` naming *"content and reply markup are exactly
the same"* if it was not.

Base for all three runs: `5141a3593c4c965fdafd679af0b8faea77a058ab`.

**BEFORE** — production file identical to that base, `inlineButtons: "group"`, direct chat:

```
### BEFORE — production code at upstream/main 5141a3593c4c965fdafd679af0b8faea77a058ab, fix NOT applied
verified: extensions/telegram/src/action-runtime.ts is identical to 5141a3593c4

chat kind under test: direct (id <REDACTED>)
config: channels.telegram.capabilities.inlineButtons = "group"

seeded target message: status=200 message_id=431
handleTelegramAction(editMessage + buttons): RESOLVED {"ok":true,"messageId":"431","chatId":"<REDACTED>"}
Telegram oracle (editMessageReplyMarkup -> []): status=200
Telegram oracle verdict: KEYBOARD WAS PRESENT (Telegram removed it now)
```

**AFTER** — same base plus this change, same config, same chat. The diffstat line below is
the production file only; the full PR is 2 files, +109/-28:

```
### AFTER — same upstream/main 5141a3593c4c965fdafd679af0b8faea77a058ab plus this PR's fix applied
production file only: extensions/telegram/src/action-runtime.ts | 40 insertions(+), 28 deletions(-)

chat kind under test: direct (id <REDACTED>)
config: channels.telegram.capabilities.inlineButtons = "group"

seeded target message: status=200 message_id=434
handleTelegramAction(editMessage + buttons): THREW Telegram inline buttons are limited to groups when inlineButtons="group".
Telegram oracle (editMessageReplyMarkup -> []): status=400
Telegram oracle verdict: NO KEYBOARD PRESENT (Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message)
```

**AFTER, control** — same fixed tree, but `inlineButtons: "dm"`, which *does* permit this
chat, so the fix must not over-block it:

```
### AFTER — control: the scope that DOES allow this chat must keep working
same final staged tree as the AFTER capture above

chat kind under test: direct (id <REDACTED>)
config: channels.telegram.capabilities.inlineButtons = "dm"

seeded target message: status=200 message_id=435
handleTelegramAction(editMessage + buttons): RESOLVED {"ok":true,"messageId":"435","chatId":"<REDACTED>"}
Telegram oracle (editMessageReplyMarkup -> []): status=200
Telegram oracle verdict: KEYBOARD WAS PRESENT (Telegram removed it now)
```

Test messages created by these runs were deleted afterwards, and the harness redacts the
bot token from all output.

Behavior addressed: `editMessage` attaching inline buttons to a chat kind that
`channels.telegram.capabilities.inlineButtons` excludes, producing buttons whose callbacks
the inbound handler then drops.
Real environment tested: live Telegram Bot API with a real bot and a real direct chat;
production `handleTelegramAction` imported and executed in a real Node process (no vitest,
no mocks, no stubbed transport).
Exact steps or command run after this patch: `TG_PROOF_TOKEN=<bot token>
TG_PROOF_CHAT=<direct chat id> TG_PROOF_SCOPE=group node --import tsx
tg-proof-harness.mjs` (harness below), then again with `TG_PROOF_SCOPE=dm` for the control.
Evidence after fix: the AFTER and AFTER-control blocks above, plus
`./node_modules/.bin/vitest run extensions/telegram/src/action-runtime.test.ts`.
Observed result after fix: the scoped edit is rejected with *"limited to groups"* and
Telegram reports no keyboard on the message; with the permitting scope the same edit still
attaches the keyboard.
What was not tested: the inbound half (tapping an out-of-scope button and observing the
callback being dropped) was not reproduced live — the callback handler already enforces the
rule and this change only touches the outbound prevention path. Live runs cover a direct
chat only; the `dm` × group rejection, the reply-markup-only edit, and the username
rejection are covered by focused tests rather than live. The numeric-channel
misclassification described above is not covered because this PR does not change it.

**Focused tests** — five cases added to the existing
`extensions/telegram/src/action-runtime.test.ts`: reject `group` × DM, reject `dm` ×
group, reject a **reply-markup-only** edit (no text change), reject a username target
under a scope that needs a known chat kind, and a control asserting a matching scope still
edits. The four rejection cases assert that neither `editMessageTelegram` nor
`editMessageReplyMarkupTelegram` was called; the control asserts `editMessageTelegram`
*was* called.

```
$ ./node_modules/.bin/vitest run extensions/telegram/src/action-runtime.test.ts
 Test Files  1 passed (1)
      Tests  100 passed (100)

$ ./node_modules/.bin/vitest run extensions/telegram
 Test Files  177 passed (177)
      Tests  2963 passed (2963)
```

Reverting only the production change makes all four rejection cases fail while the control
keeps passing, so the tests track this fix rather than incidental behavior:

```
### TEETH CHECK — production change reverted to 5141a3593c4, new tests kept
     × blocks editMessage inline buttons when 'scope is group and the edited chat is…'
     × blocks editMessage inline buttons when 'scope is dm and the edited chat is a …'
     × blocks editMessage inline buttons when 'scope is group, the edited chat is a …'
     × blocks editMessage inline buttons when 'the edited chat is a username and the…'
 Test Files  1 failed (1)
      Tests  4 failed | 7 passed | 89 skipped (100)
```

<details>
<summary>Proof harness</summary>

Run from a checkout at the base SHA with `TG_PROOF_TOKEN` (a real bot token),
`TG_PROOF_CHAT` (a direct chat id the bot can post to), and `TG_PROOF_SCOPE`
(`group` for the defect, `dm` for the control):

```
node --import tsx tg-proof-harness.mjs
```

```js
// Live Telegram proof harness for the inlineButtons scope invariant on editMessage.
//
// Drives the PRODUCTION handler `handleTelegramAction` (no vitest, no vi.mock, no
// stubbed transport) against a REAL Telegram bot and a REAL direct chat.
//
// Server-side oracle for "does the message currently carry an inline keyboard?":
//   raw editMessageReplyMarkup with { inline_keyboard: [] }
//     -> 200 ok            => a keyboard was present and has now been removed
//     -> 400 not modified  => no keyboard was present
// That answer comes from Telegram, not from this harness.

import { handleTelegramAction } from "./extensions/telegram/src/action-runtime.ts";

const token = process.env.TG_PROOF_TOKEN;
const chat = process.env.TG_PROOF_CHAT;
if (!token || !chat) {
  throw new Error("TG_PROOF_TOKEN and TG_PROOF_CHAT are required");
}

const redact = (text) => String(text).replaceAll(token, "<BOT_TOKEN>");

// The handler's own Bot API traffic is NOT instrumented here: grammY does not route
// through global fetch, so a global-fetch counter would report 0 even when a real
// edit lands. Whether the message ended up with a keyboard is answered by Telegram
// itself, via the oracle below.
const realFetch = globalThis.fetch;

async function botApi(method, payload) {
  const res = await realFetch(`https://api.telegram.org/bot${token}/${method}`, {
    method: "POST",
    headers: { "content-type": "application/json" },
    body: JSON.stringify(payload),
  });
  return { status: res.status, body: await res.json() };
}

// Which inlineButtons scope to exercise. "group" is the mismatched case (a DM target
// is out of scope); "dm" is the matching control that must keep working.
const SCOPE = process.env.TG_PROOF_SCOPE ?? "group";

function cfg() {
  return {
    channels: {
      telegram: { botToken: token, capabilities: { inlineButtons: SCOPE } },
    },
  };
}

const BUTTONS = {
  blocks: [{ type: "buttons", buttons: [{ label: "Ok", value: "cmd:ok" }] }],
};

async function run() {
  console.log(`chat kind under test: direct (id ${chat})`);
  console.log(`config: channels.telegram.capabilities.inlineButtons = "${SCOPE}"`);
  console.log("");

  const seeded = await botApi("sendMessage", {
    chat_id: chat,
    text: "openclaw proof target (inlineButtons scope on editMessage)",
  });
  const messageId = seeded.body?.result?.message_id;
  console.log(`seeded target message: status=${seeded.status} message_id=${messageId}`);
  if (!messageId) {
    throw new Error(`could not seed a target message: ${redact(JSON.stringify(seeded.body))}`);
  }

  let outcome;
  try {
    const result = await handleTelegramAction(
      {
        action: "editMessage",
        chatId: String(chat),
        messageId,
        content: "openclaw proof target (edited, with an inline button)",
        presentation: BUTTONS,
      },
      cfg(),
      // Operator-issued edit: the same origin the gateway passes when the operator
      // (not a delegated agent turn) drives the action, so the caller supplies the
      // target chat directly instead of inheriting a provider-observed binding.
      { conversationReadOrigin: "direct-operator" },
    );
    outcome = `RESOLVED ${redact(JSON.stringify(result?.details ?? result))}`;
  } catch (err) {
    outcome = `THREW ${redact(err instanceof Error ? err.message : String(err))}`;
  }

  console.log(`handleTelegramAction(editMessage + buttons): ${outcome}`);

  // Ask Telegram whether the message ended up carrying an inline keyboard.
  const probe = await botApi("editMessageReplyMarkup", {
    chat_id: chat,
    message_id: messageId,
    reply_markup: { inline_keyboard: [] },
  });
  const verdict = probe.body?.ok
    ? "KEYBOARD WAS PRESENT (Telegram removed it now)"
    : `NO KEYBOARD PRESENT (${probe.body?.description})`;
  console.log(`Telegram oracle (editMessageReplyMarkup -> []): status=${probe.status}`);
  console.log(`Telegram oracle verdict: ${verdict}`);
}

await run();
```

</details>
