### PR TITLE
docs: prevent CLI placeholders from rendering as MDX

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -378,8 +378,8 @@ OpenClaw Gateway so old threads and hook registrations are dropped, then
 retry in a fresh session.
 
 **Turn-start auto-install refuses a source.** This is intentional. Add the
-source with explicit `/codex computer-use install --source
-<marketplace-source>` first, then future turn-start auto-install can use the
+source with explicit `/codex computer-use install --source <marketplace-source>`
+first, then future turn-start auto-install can use the
 discovered local or remote marketplace.
 
 ## Related

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -26,8 +26,9 @@ without starting OpenClaw.
 The classic wizard remains available for custom providers, remote Gateway
 setup, channel pairing, daemon controls, skills, and imports. Run it explicitly
 with `openclaw onboard --classic`; the guided inference picker does not delegate
-into it. After inference passes, OpenClaw can use `open channel wizard for
-<channel>` to hand channel setup that needs secrets to a masked terminal wizard.
+into it. After inference passes, OpenClaw can use
+`open channel wizard for <channel>` to hand channel setup that needs secrets to
+a masked terminal wizard.
 Workspace skills and web search are configured the same conversational way:
 `configure skills` and `configure web search` host those setup flows in the
 chat, and `open search wizard` hands credential entry to the masked terminal


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where readers of the onboarding and Codex computer-use docs could see CLI placeholders parsed as MDX tags when inline command examples wrapped across source lines.

## Why This Change Was Made

Keeps each affected command and its angle-bracket placeholder inside one inline-code source line. This is limited to documentation source formatting and does not change the documented commands.

## User Impact

The `<channel>` and `<marketplace-source>` placeholders render consistently as literal command text in the published docs.

## Evidence

- `node scripts/check-docs-mdx.mjs docs/start/wizard.md docs/plugins/codex-computer-use.md`
- `node scripts/docs-link-audit.mjs` (`checked_internal_links=6340`, `broken_links=0`)
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` (TruffleHog clean; no accepted/actionable findings; overall 0.99)

AI-assisted: Codex identified, validated, and prepared this documentation fix; all cited checks were run locally.