### PR TITLE
fix(docker): validate timezone in runtime image

### DIFF
--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -409,9 +409,16 @@ contains_disallowed_chars() {
   [[ "$value" == *$'\n'* || "$value" == *$'\r'* || "$value" == *$'\t'* ]]
 }
 
-is_valid_timezone() {
+is_valid_timezone_in_image() {
   local value="$1"
-  [[ -e "/usr/share/zoneinfo/$value" && ! -d "/usr/share/zoneinfo/$value" ]]
+  docker run --rm --network none --entrypoint node "$IMAGE_NAME" -e '
+const timezone = process.argv[1];
+try {
+  new Intl.DateTimeFormat("en", { timeZone: timezone }).format(0);
+} catch {
+  process.exit(1);
+}
+' "$value"
 }
 
 validate_mount_path_value() {
@@ -496,9 +503,6 @@ if [[ -n "$TIMEZONE" ]]; then
   fi
   if [[ ! "$TIMEZONE" =~ ^[A-Za-z0-9/_+\-]+$ ]]; then
     fail "OPENCLAW_TZ must be a valid IANA timezone string (e.g. Asia/Shanghai)."
-  fi
-  if ! is_valid_timezone "$TIMEZONE"; then
-    fail "OPENCLAW_TZ must match a timezone in /usr/share/zoneinfo (e.g. Asia/Shanghai)."
   fi
 fi
 
@@ -780,6 +784,10 @@ else
     echo "ERROR: Failed to pull image $IMAGE_NAME. Please check the image name and your access permissions." >&2
     exit 1
   fi
+fi
+
+if [[ -n "$TIMEZONE" ]] && ! is_valid_timezone_in_image "$TIMEZONE"; then
+  fail "OPENCLAW_TZ must be supported by $IMAGE_NAME (e.g. Asia/Shanghai)."
 fi
 
 # Ensure bind-mounted data directories are writable by the container's `node`

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -71,6 +71,54 @@ function extractInstallE2eInstallerFunction(): string {
   return script.slice(start, end);
 }
 
+function extractDockerTimezoneValidator(): string {
+  const script = readFileSync(DOCKER_SETUP_PATH, "utf8");
+  const match = script.match(
+    /(is_valid_timezone_in_image\(\) \{[\s\S]*?\n\})\n\nvalidate_mount_path_value/u,
+  );
+  if (!match) {
+    throw new Error("Docker timezone validator was not found");
+  }
+  return expectDefined(match[1], "Docker timezone validator capture");
+}
+
+function runDockerTimezoneValidator(timezone: string) {
+  const root = tempDirs.make("openclaw-docker-timezone-");
+  const binDir = join(root, "bin");
+  const dockerPath = join(binDir, "docker");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    dockerPath,
+    [
+      "#!/bin/bash",
+      "set -euo pipefail",
+      'while [[ "$#" -gt 0 && "$1" != "-e" ]]; do shift; done',
+      'exec "$HOST_NODE" "$@"',
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+
+  return spawnSync(
+    "bash",
+    [
+      "--noprofile",
+      "--norc",
+      "-c",
+      `${extractDockerTimezoneValidator()}\nIMAGE_NAME=openclaw:test\nis_valid_timezone_in_image "$TIMEZONE"`,
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        HOME: root,
+        HOST_NODE: process.execPath,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        TIMEZONE: timezone,
+      },
+    },
+  );
+}
+
 function runInstallE2eInstallerFixture(params: {
   curlExitCode?: number;
   installTag: string;
@@ -902,6 +950,25 @@ printf 'status=%s\\n' "$status"
     expect(timeoutHelper).toContain('"$timeout_bin" --kill-after=30s "$timeout_value" "$@"');
     expect(script).toContain('run_docker_pull "$IMAGE_NAME"');
     expect(script).not.toContain('docker pull "$IMAGE_NAME"');
+  });
+
+  it("validates Docker timezones against the selected image runtime", () => {
+    for (const timezone of ["Asia/Shanghai", "UTC", "US/Pacific"]) {
+      const result = runDockerTimezoneValidator(timezone);
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(0);
+    }
+
+    for (const timezone of ["zone.tab", "iso3166.tab", "Factory", "localtime"]) {
+      const result = runDockerTimezoneValidator(timezone);
+      expect(result.status).toBe(1);
+    }
+
+    const script = readFileSync(DOCKER_SETUP_PATH, "utf8");
+    expect(script).not.toContain("/usr/share/zoneinfo");
+    expect(script).toContain(
+      'fail "OPENCLAW_TZ must be supported by $IMAGE_NAME (e.g. Asia/Shanghai)."',
+    );
   });
 
   it("bounds Podman setup image pulls", () => {


### PR DESCRIPTION
## What Problem This Solves

`scripts/docker/setup.sh` validated `OPENCLAW_TZ` against the host's
`/usr/share/zoneinfo` tree. That accepted non-timezone metadata files such as
`zone.tab`, `iso3166.tab`, `Factory`, and `localtime`, and it could disagree
with the runtime image's actual ICU timezone support.

## Why This Change Was Made

Validate the configured timezone inside the selected OpenClaw runtime image
with `Intl.DateTimeFormat`, after the image is built or pulled. The check uses
no network and the same Node runtime that will execute OpenClaw.

The installer test harness now executes the exact validation expression and
covers canonical zones, aliases, UTC, and the metadata-file false positives.

## User Impact

Docker setup now rejects timezone values that the runtime image cannot use,
instead of accepting host filesystem entries that later produce incorrect
runtime behavior.

## Evidence

Exact head: `4807c89af2520c3e349d7bb71965bdb27046d65f`

```text
node scripts/run-vitest.mjs test/scripts/test-install-sh-docker.test.ts
Test Files  1 passed (1)
Tests  82 passed (82)

bash -n scripts/docker/setup.sh
git diff --check
autoreview: clean, no accepted/actionable findings
Blacksmith changed gate: passed

Real image smoke, node:24-bookworm:
Asia/Shanghai=0
zone.tab=1
```
