### PR TITLE
fix(discord): preserve webhook timeout errors on stalled responses

### DIFF
--- a/extensions/discord/src/send.webhook.timeout.test.ts
+++ b/extensions/discord/src/send.webhook.timeout.test.ts
@@ -51,8 +51,7 @@ async function expectWebhookTimeout(promise: Promise<unknown>): Promise<void> {
     name: "TimeoutError",
     message: "request timed out",
   });
-  await vi.advanceTimersByTimeAsync(DISCORD_REST_TIMEOUT_MS);
-  await rejection;
+  await Promise.all([vi.advanceTimersByTimeAsync(DISCORD_REST_TIMEOUT_MS), rejection]);
 }
 
 describe("sendWebhookMessageDiscord timeout", () => {

--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -77,12 +77,14 @@ async function throwWebhookResponseError(
   response: Response,
   signal: AbortSignal | undefined,
 ): Promise<never> {
-  const raw = await readResponseTextLimited(response, DISCORD_WEBHOOK_ERROR_BODY_LIMIT_BYTES).catch(
-    () => {
-      throwIfWebhookDeadlineExpired(signal);
-      return "";
-    },
-  );
+  const raw = await readResponseTextLimited(response, DISCORD_WEBHOOK_ERROR_BODY_LIMIT_BYTES, {
+    // The request deadline owns every body read; a shorter shared idle bound
+    // would turn a stalled Discord response into the wrong error class.
+    chunkTimeoutMs: DISCORD_WEBHOOK_TIMEOUT_MS,
+  }).catch(() => {
+    throwIfWebhookDeadlineExpired(signal);
+    return "";
+  });
   const parsed = coerceWebhookErrorBody(raw);
   if (response.status === 429) {
     throw new RateLimitError(response, {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord webhook sends could report a generic Discord response error instead of the request timeout when an error response body stalled.

## Why This Change Was Made

The webhook request deadline now also bounds error-body idle reads, so the shared shorter body-reader default cannot preempt Discord's operation-level timeout contract. The timeout test observes timer advancement and rejection concurrently to keep failures deterministic.

## User Impact

Operators now receive the correct timeout error when Discord returns headers but stalls while streaming an error body.

## Evidence

- Reproduced on current `main`: `send.webhook.timeout.test.ts` returned `DiscordError` and emitted `PromiseRejectionHandledWarning`.
- `node scripts/run-vitest.mjs extensions/discord/src/send.webhook.timeout.test.ts extensions/discord/src/send.webhook-activity.test.ts extensions/discord/src/send.webhook.chunk-limit.test.ts` (3 files, 7 tests passed).
- `./node_modules/.bin/oxfmt --check extensions/discord/src/send.webhook.ts extensions/discord/src/send.webhook.timeout.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- Autoreview clean with no accepted/actionable findings (0.91 confidence).

AI-assisted: yes. I understand and verified the change.