### PR TITLE
fix(feishu): preserve source time in message envelopes

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -303,6 +303,7 @@ const {
   mockTranscribeFirstAudio,
   mockMaybeCreateDynamicAgent,
   mockBuildChannelInboundEventContext,
+  mockFormatAgentEnvelope,
   mockDispatchInboundMessage,
   mockResolveFeishuBotName,
 } = vi.hoisted(() => ({
@@ -343,6 +344,7 @@ const {
   mockTranscribeFirstAudio: vi.fn(),
   mockMaybeCreateDynamicAgent: vi.fn(),
   mockBuildChannelInboundEventContext: vi.fn(),
+  mockFormatAgentEnvelope: vi.fn(({ body }: { body: string }) => body),
   mockDispatchInboundMessage: vi
     .fn()
     .mockResolvedValue({ queuedFinal: false, counts: { final: 1 } }),
@@ -357,7 +359,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
   );
   return {
     ...actual,
-    formatAgentEnvelope: ({ body }: { body: string }) => body,
+    formatAgentEnvelope: mockFormatAgentEnvelope,
     resolveEnvelopeFormatOptions: () => ({}),
     buildChannelInboundEventContext: (
       params: Parameters<typeof actual.buildChannelInboundEventContext>[0],
@@ -1427,7 +1429,7 @@ describe("handleFeishuMessage command authorization", () => {
     expect(context.SupplementalContext?.quote?.body).toBe("quoted content");
   });
 
-  it("uses message create_time as Timestamp instead of Date.now()", async () => {
+  it("uses message create_time for the inbound context and model envelope", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     await dispatchMessage({
       cfg: createFeishuTestConfig({ dmPolicy: "open" }),
@@ -1440,6 +1442,8 @@ describe("handleFeishuMessage command authorization", () => {
 
     const context = mockCallArg<{ Timestamp?: number }>(mockFinalizeInboundContext, 0, 0);
     expect(context.Timestamp).toBe(1700000000000);
+    const envelope = mockCallArg<{ timestamp?: number | Date }>(mockFormatAgentEnvelope, 0, 0);
+    expect(envelope.timestamp).toBe(1700000000000);
   });
 
   it.each([

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1143,7 +1143,7 @@ export async function handleFeishuMessage(params: {
     const body = formatAgentEnvelope({
       channel: "Feishu",
       from: envelopeFrom,
-      timestamp: new Date(),
+      timestamp: messageCreateTimeMs,
       envelope: envelopeOptions,
       body: messageBody,
     });


### PR DESCRIPTION
## What Problem This Solves

Feishu computes the source message timestamp from the event's `create_time` and
uses it in inbound context, but the model-facing message envelope replaced it
with `new Date()`. Delayed or replayed events therefore showed processing time
instead of the time the message was created.

## Why This Change Was Made

Use the already-normalized `messageCreateTimeMs` for the model-facing envelope.
That keeps the envelope and inbound context on one source-time contract without
adding channel-specific timezone logic.

The regression test now asserts that the same Feishu `create_time` reaches both
the final inbound context and the envelope formatter.

## User Impact

Feishu message timestamps shown to the model remain accurate when delivery is
delayed or an event is replayed.

## Evidence

Exact head: `11e9766aac69cedf67f791451b647b088ecb9075`

```text
node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts
Test Files  1 passed (1)
Tests  95 passed (95)

oxfmt: clean
git diff --check: clean
autoreview: clean, no accepted/actionable findings
Blacksmith changed gate: passed
```
