### PR TITLE
docs(config): clarify user timezone contract

### DIFF
--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -196,23 +196,15 @@ export type AgentDefaultsConfig = {
    * - once: inject once per unique truncation signature
    * - always: inject on every run with truncation (default)
    */
-  /** Optional IANA timezone for the user (used in system prompt; defaults to host timezone). */
+  /**
+   * Optional IANA timezone for model-visible timestamps, prompt context, system events,
+   * and heartbeat active hours. Defaults to the host timezone.
+   */
   userTimezone?: string;
   /** Runtime-owned first-turn startup context for bare /new and /reset. */
   startupContext?: AgentStartupContextConfig;
   /** Focused context-budget overrides for high-volume injected/read surfaces. */
   contextLimits?: AgentContextLimitsConfig;
-  /** Time format in system prompt: auto (OS preference), 12-hour, or 24-hour. */
-  /**
-   * Envelope timestamp timezone: "utc" (default), "local", "user", or an IANA timezone string.
-   */
-  /**
-   * Include absolute timestamps in message envelopes, direct agent prompt prefixes,
-   * and embedded model-input prefixes ("on" | "off", default: "on").
-   */
-  /**
-   * Include elapsed time in message envelopes ("on" | "off", default: "on").
-   */
   /** Optional context window cap (used for runtime estimates + status %). */
   contextTokens?: number;
   /** Opt-in: prune old tool results from the LLM context to reduce token usage. */


### PR DESCRIPTION
## What Problem This Solves

The exported `userTimezone` config type still described the setting as
system-prompt-only, even though the resolved zone is shared by model-visible
timestamps, prompt context, queued system events, and heartbeat active hours.
The same area also retained four orphaned comments for legacy fields that had
moved to the doctor-only compatibility block.

## Why This Change Was Made

State the current shared timezone contract once on `userTimezone` and remove
the detached legacy comments. The runtime and config shape are unchanged.

## User Impact

Maintainers and plugin authors reading the exported config type now see the
actual timezone ownership boundary instead of stale guidance.

## Evidence

Exact head: `f325707948e8b745b693068f320badd46f0ed362`

```text
oxfmt: clean
git diff --check: clean
autoreview: clean, no accepted/actionable findings
Blacksmith changed gate: passed
```

