### PR TITLE
fix(test): stop Google batch timeout test leaking requests

### DIFF
--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -24,6 +24,7 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importO
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -206,10 +207,9 @@ function makeOversizedResponse(status = 200): {
 }
 
 describe("Google embedding-batch bounded JSON reads", () => {
-  it("clamps polling to the remaining batch timeout", async () => {
+  it("stops before polling status after the batch timeout expires", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const fetchMock = stubBatchFetch();
 
     const result = runGeminiEmbeddingBatches({
@@ -222,21 +222,15 @@ describe("Google embedding-batch bounded JSON reads", () => {
       timeoutMs: 1_000,
       debug: (message) => {
         if (message.includes("batches/b-0 pending")) {
-          vi.setSystemTime(500);
+          vi.setSystemTime(1_000);
         }
       },
     });
+    const rejection = captureRejection(result);
 
-    for (let attempt = 0; attempt < 100 && setTimeoutSpy.mock.calls.length === 0; attempt++) {
-      await Promise.resolve();
-    }
-    expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
-    expect(setTimeoutSpy.mock.calls[0]?.[1]).toBe(500);
-    const rejection = expect(result).rejects.toThrow(
-      "gemini batch batches/b-0 timed out after 1000ms",
-    );
-    await vi.runAllTimersAsync();
-    await rejection;
+    await expect(rejection).resolves.toMatchObject({
+      message: "gemini batch batches/b-0 timed out after 1000ms",
+    });
     expect(
       fetchMock.mock.calls.filter(([input]) => fetchInputUrl(input).includes("/batches/")),
     ).toHaveLength(0);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Google embedding-batch timeout test failed after HTTP deadline timers were added, then left its batch promise running after mocks were restored. The orphaned request reached the real Google API with the test key and produced an unhandled rejection.

## Why This Change Was Made

The Google-owned test now verifies the owner behavior at the absolute batch deadline instead of duplicating the shared poll-helper timer implementation. It observes the batch promise immediately and restores real timers after every test.

## User Impact

No runtime behavior changes. The provider test suite no longer leaks a real network request or reports a false timeout failure.

## Evidence

- Reproduced on current `main`: 1 failed test plus an unhandled `ProviderHttpError` from the real Google API.
- `node scripts/run-vitest.mjs extensions/google/embedding-batch.test.ts` passed: 1 file, 20 tests.
- Repeated the focused file three times; all 60 test executions passed.
- `./node_modules/.bin/oxfmt --check extensions/google/embedding-batch.test.ts` passed.
- `git diff --check origin/main...HEAD` passed.
- Autoreview clean with no accepted/actionable findings (0.96 confidence).

AI-assisted: yes. I understand and verified the change.