### PR TITLE
fix(daemon): prevent duplicate systemd gateway ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **Control UI update reconciliation:** preserve an unresolved managed-update request across disconnects, accept the replacement Gateway version when it proves success, and otherwise show explicit recovery guidance instead of trusting an unrelated cached update result or failing silently. Fixes #116075. Thanks @shakkernerd.
 - **Control UI model readiness:** put AI setup first when no model is selectable, distinguish signed-in credentials from ready providers, and route accounts with no exposed models directly to provider recovery instead of leading with disabled default controls.
 - **Control UI Talk session isolation:** stop active realtime Talk media and retire its callbacks before chat session changes, Gateway disconnects, or pane disposal so previous-session audio, transcript, camera, and status updates cannot leak into the next view. Thanks @shakkernerd.

--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -140,6 +140,24 @@ describe("runDaemonInstall integration", () => {
     expect(runtimeLogs.join("\n")).toContain("Refusing to install or rewrite the gateway service");
   });
 
+  it.each([
+    { force: undefined, label: "normal install" },
+    { force: true, label: "forced reinstall" },
+  ])("does not bypass system ownership during $label", async ({ force }) => {
+    serviceMock.install.mockRejectedValueOnce(
+      new Error(
+        "System systemd unit openclaw-gateway.service already owns this gateway unit name. --force does not override system ownership.",
+      ),
+    );
+
+    await expect(runDaemonInstall({ json: true, force })).rejects.toThrow("__exit__:1");
+
+    expect(serviceMock.install).toHaveBeenCalledTimes(1);
+    const joined = runtimeLogs.join("\n");
+    expect(joined).toContain("System systemd unit openclaw-gateway.service");
+    expect(joined).toContain("--force does not override system ownership");
+  });
+
   it("auto-mints token when no source exists without embedding it into service env", async () => {
     await fs.writeFile(
       configPath,

--- a/src/daemon/systemd-system.test.ts
+++ b/src/daemon/systemd-system.test.ts
@@ -1,0 +1,234 @@
+// System systemd ownership tests cover loaded, installed, and unverifiable states.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  systemctl: { stdout: "not-found\n", stderr: "", code: 0 },
+  managerUnitPath: {
+    stdout:
+      "/etc/systemd/system /run/systemd/system /usr/local/lib/systemd/system /usr/lib/systemd/system\n",
+    stderr: "",
+    code: 0,
+  },
+  paths: new Set<string>(),
+  pathErrors: new Map<string, string>(),
+}));
+
+function fsError(code: string, target: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`${code}: ${target}`), { code });
+}
+
+vi.mock("node:fs/promises", () => {
+  const mocked = {
+    lstat: vi.fn(async (target: string) => {
+      const code = state.pathErrors.get(target);
+      if (code) {
+        throw fsError(code, target);
+      }
+      if (!state.paths.has(target)) {
+        throw fsError("ENOENT", target);
+      }
+      return {};
+    }),
+  };
+  return { ...mocked, default: mocked };
+});
+
+const execFileUtf8 = vi.hoisted(() =>
+  vi.fn(async (_command: string, args: string[]) =>
+    args.includes("--property=UnitPath") ? state.managerUnitPath : state.systemctl,
+  ),
+);
+vi.mock("./exec-file.js", () => ({ execFileUtf8 }));
+
+import { assertNoSystemSystemdOwnership } from "./systemd-system.js";
+
+describe("system systemd ownership", () => {
+  const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.systemctl = { stdout: "not-found\n", stderr: "", code: 0 };
+    state.managerUnitPath = {
+      stdout:
+        "/etc/systemd/system /run/systemd/system /usr/local/lib/systemd/system /usr/lib/systemd/system\n",
+      stderr: "",
+      code: 0,
+    };
+    state.paths.clear();
+    state.pathErrors.clear();
+    execFileUtf8.mockReset();
+    execFileUtf8.mockImplementation(async (_command: string, args: string[]) =>
+      args.includes("--property=UnitPath") ? state.managerUnitPath : state.systemctl,
+    );
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, "platform", {
+        ...originalPlatformDescriptor,
+        value: "linux",
+      });
+    }
+  });
+
+  afterEach(() => {
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
+  });
+
+  it("reports a unit loaded by the system manager", async () => {
+    state.systemctl = { stdout: "loaded\n", stderr: "", code: 0 };
+
+    await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
+      ownership: { status: "loaded", unitName: "openclaw-gateway.service" },
+    });
+  });
+
+  it.each([
+    "/etc/systemd/system/openclaw-gateway.service",
+    "/run/systemd/system/openclaw-gateway.service",
+    "/usr/local/lib/systemd/system/openclaw-gateway.service",
+  ])("detects a custom same-name system unit at %s", async (unitPath) => {
+    state.paths.add(unitPath);
+
+    await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
+      ownership: {
+        status: "installed",
+        unitName: "openclaw-gateway.service",
+        unitPath,
+      },
+    });
+  });
+
+  it("ignores differently named profile and custom units", async () => {
+    state.paths.add("/etc/systemd/system/openclaw-gateway-rescue.service");
+    state.paths.add("/etc/systemd/system/vendor-openclaw.service");
+
+    await expect(
+      assertNoSystemSystemdOwnership("openclaw-gateway-primary.service"),
+    ).resolves.toBeUndefined();
+    expect(execFileUtf8).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails closed when the system manager cannot be queried", async () => {
+    state.systemctl = {
+      stdout: "",
+      stderr: "Failed to connect to bus: Permission denied",
+      code: 1,
+    };
+
+    await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
+      ownership: {
+        status: "unverifiable",
+        unitName: "openclaw-gateway.service",
+        operation: "systemctl",
+        detail: "Failed to connect to bus: Permission denied",
+      },
+    });
+  });
+
+  it("does not mistake a missing system bus for a missing unit", async () => {
+    state.systemctl = {
+      stdout: "",
+      stderr: "Failed to connect to bus: No such file or directory",
+      code: 1,
+    };
+
+    await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
+      ownership: {
+        status: "unverifiable",
+        operation: "systemctl",
+        detail: "Failed to connect to bus: No such file or directory",
+      },
+    });
+  });
+
+  it("fails closed when an exact system path cannot be inspected", async () => {
+    const unitPath = "/etc/systemd/system/openclaw-gateway.service";
+    state.pathErrors.set(unitPath, "EACCES");
+
+    await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
+      ownership: {
+        status: "unverifiable",
+        unitName: "openclaw-gateway.service",
+        operation: "filesystem",
+        detail: `${unitPath}: EACCES: ${unitPath}`,
+      },
+    });
+  });
+
+  it("fails closed when manager unit load paths cannot be enumerated", async () => {
+    state.managerUnitPath = {
+      stdout: "",
+      stderr: "manager UnitPath unavailable",
+      code: 1,
+    };
+
+    await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
+      ownership: {
+        status: "unverifiable",
+        operation: "systemctl",
+        detail: "manager UnitPath unavailable",
+      },
+    });
+  });
+
+  it("rechecks the system manager after a negative filesystem snapshot", async () => {
+    let systemctlCalls = 0;
+    execFileUtf8.mockImplementation(async (_command: string, args: string[]) => {
+      if (args.includes("--property=UnitPath")) {
+        return state.managerUnitPath;
+      }
+      systemctlCalls += 1;
+      return systemctlCalls === 1
+        ? { stdout: "not-found\n", stderr: "", code: 0 }
+        : { stdout: "loaded\n", stderr: "", code: 0 };
+    });
+
+    await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
+      ownership: { status: "loaded", unitName: "openclaw-gateway.service" },
+    });
+  });
+
+  it.each([
+    { uid: 1000, prefix: "sudo " },
+    { uid: 0, prefix: "" },
+  ])("renders actionable ownership recovery for uid $uid", async ({ uid, prefix }) => {
+    const existingGeteuid = Object.getOwnPropertyDescriptor(process, "geteuid");
+    Object.defineProperty(process, "geteuid", {
+      configurable: true,
+      value: () => uid,
+    });
+    state.paths.add("/etc/systemd/system/openclaw-gateway.service");
+
+    try {
+      const error = await assertNoSystemSystemdOwnership("openclaw-gateway.service").catch(
+        (caught: unknown) => caught,
+      );
+
+      expect(error).toMatchObject({
+        name: "SystemSystemdOwnershipError",
+        code: "SYSTEM_SYSTEMD_OWNERSHIP",
+        ownership: { status: "installed" },
+      });
+      expect(String(error)).toContain("--force does not override system ownership");
+      expect(String(error)).toContain(`${prefix}systemctl disable --now openclaw-gateway.service`);
+      expect(String(error)).toContain(`${prefix}rm /etc/systemd/system/openclaw-gateway.service`);
+    } finally {
+      if (existingGeteuid) {
+        Object.defineProperty(process, "geteuid", existingGeteuid);
+      } else {
+        Reflect.deleteProperty(process, "geteuid");
+      }
+    }
+  });
+
+  it("does not recommend deleting package- or generator-owned units", async () => {
+    state.paths.add("/usr/lib/systemd/system/openclaw-gateway.service");
+
+    const error = await assertNoSystemSystemdOwnership("openclaw-gateway.service").catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(String(error)).toContain("uninstall or reconfigure the package, generator");
+    expect(String(error)).not.toContain("rm /usr/lib/systemd/system/openclaw-gateway.service");
+  });
+});

--- a/src/daemon/systemd-system.ts
+++ b/src/daemon/systemd-system.ts
@@ -1,0 +1,202 @@
+/** Detects system-scope systemd ownership before mutating a user gateway unit. */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
+import { execFileUtf8 } from "./exec-file.js";
+
+type SystemSystemdOwnership =
+  | { status: "absent"; unitName: string }
+  | { status: "loaded"; unitName: string }
+  | { status: "installed"; unitName: string; unitPath: string }
+  | {
+      status: "unverifiable";
+      unitName: string;
+      operation: "systemctl" | "filesystem";
+      detail: string;
+    };
+
+type SystemSystemdConflict = Exclude<SystemSystemdOwnership, { status: "absent" }>;
+
+function formatUnknownError(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return truncateUtf16Safe(sanitizeForLog(raw), 500);
+}
+
+function isMissingPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function quotePosixArgument(value: string): string {
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function querySystemManager(unitName: string): Promise<SystemSystemdOwnership> {
+  const result = await execFileUtf8("systemctl", [
+    "show",
+    "--property=LoadState",
+    "--value",
+    unitName,
+  ]);
+  const loadState = result.stdout.trim().toLowerCase();
+  if (result.code === 0) {
+    if (loadState === "not-found") {
+      return { status: "absent", unitName };
+    }
+    if (loadState) {
+      return { status: "loaded", unitName };
+    }
+    return {
+      status: "unverifiable",
+      unitName,
+      operation: "systemctl",
+      detail: "systemctl returned no LoadState",
+    };
+  }
+  const detail = `${result.stderr} ${result.stdout}`.trim();
+  const normalizedDetail = detail.toLowerCase();
+  if (
+    normalizedDetail.includes(unitName.toLowerCase()) &&
+    /not[- ]found|could not be found/i.test(normalizedDetail)
+  ) {
+    return { status: "absent", unitName };
+  }
+  return {
+    status: "unverifiable",
+    unitName,
+    operation: "systemctl",
+    detail: detail || `systemctl exited with code ${result.code}`,
+  };
+}
+
+async function readSystemUnitLoadPaths(
+  unitName: string,
+): Promise<string[] | SystemSystemdOwnership> {
+  const result = await execFileUtf8("systemctl", ["show", "--property=UnitPath", "--value"]);
+  if (result.code !== 0) {
+    const detail = `${result.stderr} ${result.stdout}`.trim();
+    return {
+      status: "unverifiable",
+      unitName,
+      operation: "systemctl",
+      detail: detail || `systemctl exited with code ${result.code}`,
+    };
+  }
+  const paths = [
+    ...new Set(
+      result.stdout
+        .split(/\s+/)
+        .map((entry) => entry.trim())
+        .filter((entry) => path.posix.isAbsolute(entry)),
+    ),
+  ];
+  if (paths.length === 0) {
+    return {
+      status: "unverifiable",
+      unitName,
+      operation: "systemctl",
+      detail: "systemctl returned no system manager unit load paths",
+    };
+  }
+  return paths;
+}
+
+async function findInstalledSystemUnit(unitName: string): Promise<SystemSystemdOwnership> {
+  const loadPaths = await readSystemUnitLoadPaths(unitName);
+  if (!Array.isArray(loadPaths)) {
+    return loadPaths;
+  }
+  for (const dir of loadPaths) {
+    const unitPath = path.posix.join(dir, unitName);
+    try {
+      await fs.lstat(unitPath);
+      return { status: "installed", unitName, unitPath };
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        continue;
+      }
+      return {
+        status: "unverifiable",
+        unitName,
+        operation: "filesystem",
+        detail: `${unitPath}: ${formatUnknownError(error)}`,
+      };
+    }
+  }
+  return { status: "absent", unitName };
+}
+
+async function inspectSystemSystemdOwnership(unitName: string): Promise<SystemSystemdOwnership> {
+  if (process.platform !== "linux") {
+    return { status: "absent", unitName };
+  }
+
+  const initialQuery = await querySystemManager(unitName);
+  if (initialQuery.status !== "absent") {
+    return initialQuery;
+  }
+  const installed = await findInstalledSystemUnit(unitName);
+  if (installed.status !== "absent") {
+    return installed;
+  }
+  // Close the manager-query-to-filesystem-snapshot race. Publication and
+  // activation repeat the complete probe because root installers share no lock.
+  return await querySystemManager(unitName);
+}
+
+function isRunningAsRoot(): boolean {
+  if (typeof process.geteuid !== "function") {
+    return false;
+  }
+  try {
+    return process.geteuid() === 0;
+  } catch {
+    return false;
+  }
+}
+
+function formatSystemSystemdOwnershipError(ownership: SystemSystemdConflict): string {
+  const privilegePrefix = isRunningAsRoot() ? "" : "sudo ";
+  const unitName = quotePosixArgument(ownership.unitName);
+  const summary =
+    ownership.status === "loaded"
+      ? `System systemd unit ${ownership.unitName} already owns this gateway unit name.`
+      : ownership.status === "installed"
+        ? `System systemd unit ${ownership.unitPath} already owns this gateway unit name.`
+        : `System systemd ownership for ${ownership.unitName} could not be verified: ${ownership.detail}`;
+  const installedInAdministratorPath =
+    ownership.status === "installed" &&
+    (ownership.unitPath.startsWith("/etc/systemd/system/") ||
+      ownership.unitPath.startsWith("/etc/systemd/system.control/"));
+  const recovery =
+    ownership.status === "loaded"
+      ? `Keep it as the sole gateway manager, or inspect it with \`${privilegePrefix}systemctl cat ${unitName}\`, then disable it and uninstall or reconfigure the package, generator, or administrator unit that owns it before retrying.`
+      : installedInAdministratorPath
+        ? `Keep it as the sole gateway manager, or run \`${privilegePrefix}systemctl disable --now ${unitName}\`, \`${privilegePrefix}rm ${quotePosixArgument(ownership.unitPath)}\`, and \`${privilegePrefix}systemctl daemon-reload\` before retrying.`
+        : ownership.status === "installed"
+          ? `Keep it as the sole gateway manager, or inspect it with \`${privilegePrefix}systemctl cat ${unitName}\`, then uninstall or reconfigure the package, generator, or runtime owner of ${quotePosixArgument(ownership.unitPath)} before retrying.`
+          : "Fix the reported systemctl or filesystem access error, then retry.";
+  return [
+    summary,
+    "Refusing to create or activate a user systemd unit with the same name because duplicate managers can restart-loop the gateway.",
+    "OpenClaw does not manage system-scope units, and --force does not override system ownership.",
+    recovery,
+  ].join("\n");
+}
+
+class SystemSystemdOwnershipError extends Error {
+  readonly code = "SYSTEM_SYSTEMD_OWNERSHIP";
+
+  constructor(readonly ownership: SystemSystemdConflict) {
+    super(formatSystemSystemdOwnershipError(ownership));
+    this.name = "SystemSystemdOwnershipError";
+  }
+}
+
+export async function assertNoSystemSystemdOwnership(unitName: string): Promise<void> {
+  const ownership = await inspectSystemSystemdOwnership(unitName);
+  if (ownership.status !== "absent") {
+    throw new SystemSystemdOwnershipError(ownership);
+  }
+}

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -21,6 +21,9 @@ type ExecFileMock = (
 
 const execFileMock = vi.hoisted(() => vi.fn<ExecFileMock>());
 const existsSyncMock = vi.hoisted(() => vi.fn(() => false));
+const assertNoSystemSystemdOwnershipMock = vi.hoisted(() =>
+  vi.fn<(unitName: string) => Promise<void>>(async () => {}),
+);
 const findSystemGatewayServicesMock = vi.hoisted(() =>
   vi.fn<
     () => Promise<
@@ -38,6 +41,11 @@ const findSystemGatewayServicesMock = vi.hoisted(() =>
 
 vi.mock("./inspect.js", () => ({
   findSystemGatewayServices: () => findSystemGatewayServicesMock(),
+}));
+
+vi.mock("./systemd-system.js", () => ({
+  assertNoSystemSystemdOwnership: (unitName: string) =>
+    assertNoSystemSystemdOwnershipMock(unitName),
 }));
 
 vi.mock("node:fs", async (importOriginal) => ({
@@ -528,6 +536,8 @@ describe("isSystemdUnitActive", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     execFileMock.mockReset();
+    assertNoSystemSystemdOwnershipMock.mockReset();
+    assertNoSystemSystemdOwnershipMock.mockResolvedValue();
   });
 
   it("checks user-scoped units through the user systemd manager", async () => {
@@ -1380,6 +1390,208 @@ describe("stageSystemdService", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     execFileMock.mockReset();
+    assertNoSystemSystemdOwnershipMock.mockReset();
+    assertNoSystemSystemdOwnershipMock.mockResolvedValue();
+  });
+
+  it("blocks before mutating user files when the same system unit owns the name", async () => {
+    await withStageFixture(async ({ env, unitPath, envFilePath }) => {
+      const previous = "[Unit]\nDescription=Existing user gateway\n";
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(unitPath, previous, "utf8");
+      mockSystemctlStatusOk();
+      assertNoSystemSystemdOwnershipMock.mockRejectedValueOnce(
+        new Error("system scope owns openclaw-gateway-stage-test.service"),
+      );
+
+      await expect(
+        stageSystemdService({
+          env,
+          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+          workingDirectory: "/tmp",
+          environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+        }),
+      ).rejects.toThrow("system scope owns openclaw-gateway-stage-test.service");
+
+      await expect(fs.readFile(unitPath, "utf8")).resolves.toBe(previous);
+      await expect(fs.access(envFilePath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(`${unitPath}.bak`)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(assertNoSystemSystemdOwnershipMock).toHaveBeenCalledWith(
+        "openclaw-gateway-stage-test.service",
+      );
+    });
+  });
+
+  it("refuses to rewrite a symlinked managed user unit", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      const targetPath = path.join(path.dirname(unitPath), "operator-gateway.service");
+      const previous = "[Unit]\nDescription=Operator gateway\n";
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(targetPath, previous, "utf8");
+      await fs.symlink(targetPath, unitPath);
+      mockSystemctlStatusOk();
+
+      await expect(
+        stageSystemdService({
+          env,
+          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+          workingDirectory: "/tmp",
+          environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+        }),
+      ).rejects.toThrow(`Refusing to rewrite symlinked managed systemd file: ${unitPath}`);
+
+      await expect(fs.lstat(unitPath)).resolves.toMatchObject({});
+      await expect(fs.readlink(unitPath)).resolves.toBe(targetPath);
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(previous);
+    });
+  });
+
+  it("refuses to rewrite a symlinked managed environment file", async () => {
+    await withStageFixture(async ({ env, envFilePath }) => {
+      const targetPath = path.join(path.dirname(envFilePath), "operator-gateway.env");
+      const previous = "OPENCLAW_GATEWAY_TOKEN=operator-token\n";
+      await fs.writeFile(targetPath, previous, "utf8");
+      await fs.symlink(targetPath, envFilePath);
+      mockSystemctlStatusOk();
+
+      await expect(
+        stageSystemdService({
+          env,
+          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+          workingDirectory: "/tmp",
+          environment: { OPENCLAW_GATEWAY_TOKEN: "new-token" },
+          environmentValueSources: { OPENCLAW_GATEWAY_TOKEN: "file" },
+        }),
+      ).rejects.toThrow(`Refusing to rewrite symlinked managed systemd file: ${envFilePath}`);
+
+      await expect(fs.readlink(envFilePath)).resolves.toBe(targetPath);
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(previous);
+    });
+  });
+
+  it("rolls back a new environment file when ownership appears before publication", async () => {
+    await withStageFixture(async ({ env, unitPath, envFilePath }) => {
+      mockSystemctlStatusOk();
+      assertNoSystemSystemdOwnershipMock
+        .mockResolvedValueOnce()
+        .mockRejectedValueOnce(new Error("system ownership appeared"));
+
+      await expect(
+        stageSystemdService({
+          env,
+          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+          workingDirectory: "/tmp",
+          environment: {
+            OPENCLAW_GATEWAY_PORT: "18789",
+            OPENCLAW_GATEWAY_TOKEN: "new-token",
+          },
+          environmentValueSources: { OPENCLAW_GATEWAY_TOKEN: "file" },
+        }),
+      ).rejects.toThrow("system ownership appeared");
+
+      await expect(fs.access(unitPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(envFilePath)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("restores existing unit and environment files after a publication race", async () => {
+    await withStageFixture(async ({ env, unitPath, envFilePath }) => {
+      const previous = "[Unit]\nDescription=Previous gateway\n";
+      const previousEnv = "OPENCLAW_GATEWAY_TOKEN=previous-token\n";
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(unitPath, previous, "utf8");
+      await fs.writeFile(envFilePath, previousEnv, "utf8");
+      const originalLstat = fs.lstat.bind(fs);
+      vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+        const stat = await originalLstat(...args);
+        if (args[0] === unitPath || args[0] === envFilePath) {
+          Object.defineProperty(stat, "mode", { value: 0 });
+        }
+        return stat;
+      });
+      mockSystemctlStatusOk();
+      assertNoSystemSystemdOwnershipMock
+        .mockResolvedValueOnce()
+        .mockResolvedValueOnce()
+        .mockRejectedValueOnce(new Error("system ownership appeared"));
+
+      await expect(
+        stageSystemdService({
+          env,
+          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+          workingDirectory: "/tmp",
+          environment: {
+            OPENCLAW_GATEWAY_PORT: "18789",
+            OPENCLAW_GATEWAY_TOKEN: "new-token",
+          },
+          environmentValueSources: { OPENCLAW_GATEWAY_TOKEN: "file" },
+        }),
+      ).rejects.toThrow("system ownership appeared");
+
+      const [unitStat, environmentStat] = await Promise.all([
+        fs.stat(unitPath),
+        fs.stat(envFilePath),
+      ]);
+      expect(unitStat.mode & 0o777).toBe(0);
+      expect(environmentStat.mode & 0o777).toBe(0);
+      await Promise.all([fs.chmod(unitPath, 0o600), fs.chmod(envFilePath, 0o600)]);
+      await expect(fs.readFile(unitPath, "utf8")).resolves.toBe(previous);
+      await expect(fs.readFile(envFilePath, "utf8")).resolves.toBe(previousEnv);
+    });
+  });
+
+  it("uses the profile-derived gateway unit name for ownership checks", async () => {
+    const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-profile-"));
+    const env = {
+      HOME: path.join(tempHomeRoot, "home"),
+      OPENCLAW_STATE_DIR: path.join(tempHomeRoot, "state"),
+      OPENCLAW_PROFILE: "work",
+    };
+    try {
+      mockSystemctlStatusOk();
+      await stageSystemdService({
+        env,
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+        workingDirectory: "/tmp",
+        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+      });
+      expect(assertNoSystemSystemdOwnershipMock).toHaveBeenCalledWith(
+        "openclaw-gateway-work.service",
+      );
+    } finally {
+      await fs.rm(tempHomeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rechecks ownership before install activation", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      mockSystemctlStatusOk();
+      assertNoSystemSystemdOwnershipMock
+        .mockResolvedValueOnce()
+        .mockResolvedValueOnce()
+        .mockResolvedValueOnce()
+        .mockRejectedValueOnce(new Error("system ownership appeared before activation"));
+
+      await expect(
+        installSystemdService({
+          env,
+          stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+          programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+          workingDirectory: "/tmp",
+          environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+        }),
+      ).rejects.toThrow("system ownership appeared before activation");
+
+      await expect(fs.access(unitPath)).resolves.toBeUndefined();
+      expect(assertNoSystemSystemdOwnershipMock).toHaveBeenCalledTimes(4);
+      expect(execFileMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("writes dotenv-backed values to a separate env file and keeps inline env minimal", async () => {
@@ -2496,6 +2708,30 @@ describe("systemd service control", () => {
 
   beforeEach(() => {
     execFileMock.mockReset();
+    assertNoSystemSystemdOwnershipMock.mockReset();
+    assertNoSystemSystemdOwnershipMock.mockResolvedValue();
+  });
+
+  it("refuses to start an existing user unit when same-name system ownership is present", async () => {
+    vi.spyOn(fs, "access").mockImplementation(async (target) => {
+      if (pathLikeToString(target).includes("/.config/systemd/user/")) {
+        return;
+      }
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    });
+    assertNoSystemSystemdOwnershipMock.mockRejectedValueOnce(
+      new Error("same-name system ownership"),
+    );
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""));
+
+    await expect(
+      startSystemdService({
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        env: { HOME: TEST_MANAGED_HOME },
+      }),
+    ).rejects.toThrow("same-name system ownership");
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
   });
 
   it("starts the resolved user unit and ignores audit observer failures", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1,4 +1,5 @@
 /** Linux systemd user service installer, parser, and lifecycle controls. */
+import { randomUUID } from "node:crypto";
 import * as fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -48,6 +49,7 @@ import type {
   GatewayServiceRestartResult,
 } from "./service-types.js";
 import { enableSystemdUserLinger, readSystemdUserLingerStatus } from "./systemd-linger.js";
+import { assertNoSystemSystemdOwnership } from "./systemd-system.js";
 import {
   classifySystemdUnavailableDetail,
   isSystemctlMissingDetail,
@@ -514,6 +516,13 @@ function resolveLegacyNodeSystemdEnvironmentFilePath(params: {
 
 function isNodeSystemdEnvironment(env: GatewayServiceEnv): boolean {
   return env.OPENCLAW_SERVICE_KIND?.trim() === "node";
+}
+
+async function assertNoSystemGatewayOwnership(env: GatewayServiceEnv): Promise<void> {
+  if (isNodeSystemdEnvironment(env)) {
+    return;
+  }
+  await assertNoSystemSystemdOwnership(`${resolveSystemdServiceName(env)}.service`);
 }
 
 function expandSystemdSpecifier(input: string, env: GatewayServiceEnv): string {
@@ -1097,9 +1106,11 @@ async function writeSystemdUnit({
   description,
 }: Omit<GatewayServiceInstallArgs, "stdout">): Promise<{ unitPath: string; backedUp: boolean }> {
   await assertSystemdAvailable(env);
+  await assertNoSystemGatewayOwnership(env);
 
   const unitPath = resolveSystemdUnitPath(env);
   await fs.mkdir(path.dirname(unitPath), { recursive: true });
+  await assertSystemdManagedPathIsNotSymlink(unitPath);
   const fileManagedKeys = collectSystemdFileManagedKeys({
     environmentValueSources,
   });
@@ -1139,51 +1150,163 @@ async function writeSystemdUnit({
     environment,
     environmentValueSources,
   });
-  const environmentFileResult = await writeSystemdGatewayEnvironmentFile({
+  const environmentFilePath = resolveSystemdEnvironmentFilePath({
     stateDir,
-    dotenvVars: stateDirDotEnvVars,
-    inlineManagedKeys,
-    fileManagedKeys,
-    skippedManagedKeys: skippedShellReferenceKeys,
-    fileBackedEnvironment: collectSystemdFileBackedEnvironment({
-      environment,
-      fileManagedKeys,
-    }),
     environment,
   });
-  const environmentSansDotEnvEntries = Object.fromEntries(
-    Object.entries(environment ?? {}).filter(([key, value]) => {
-      if (typeof value !== "string") {
-        return false;
+  const environmentFileSnapshot = isNodeSystemdEnvironment(env)
+    ? undefined
+    : await readSystemdFileSnapshot(environmentFilePath);
+  try {
+    const environmentFileResult = await writeSystemdGatewayEnvironmentFile({
+      stateDir,
+      dotenvVars: stateDirDotEnvVars,
+      inlineManagedKeys,
+      fileManagedKeys,
+      skippedManagedKeys: skippedShellReferenceKeys,
+      fileBackedEnvironment: collectSystemdFileBackedEnvironment({
+        environment,
+        fileManagedKeys,
+      }),
+      environment,
+    });
+    const environmentSansDotEnvEntries = Object.fromEntries(
+      Object.entries(environment ?? {}).filter(([key, value]) => {
+        if (typeof value !== "string") {
+          return false;
+        }
+        const source = readEnvironmentValueSource(environmentValueSources, key);
+        if (hasEnvironmentFileSource(source) && isUnresolvedShellReference(value)) {
+          return false;
+        }
+        const normalizedKey = normalizeSystemdEnvironmentKey(key);
+        if (
+          normalizedKey &&
+          environmentFileResult.environmentKeys.has(normalizedKey) &&
+          !inlineManagedKeys.has(normalizedKey)
+        ) {
+          return false;
+        }
+        const stateDirValue = stateDirDotEnvVars[key];
+        if (typeof stateDirValue !== "string") {
+          return true;
+        }
+        return value.trim() !== stateDirValue.trim();
+      }),
+    );
+    const unit = buildSystemdUnit({
+      description: serviceDescription,
+      programArguments,
+      workingDirectory,
+      environment: environmentSansDotEnvEntries,
+      environmentFiles: environmentFileResult.environmentFiles,
+    });
+    await publishSystemdUnit({ env, unitPath, contents: unit });
+  } catch (error) {
+    if (environmentFileSnapshot !== undefined) {
+      try {
+        await restoreSystemdFileSnapshot(environmentFilePath, environmentFileSnapshot);
+      } catch (rollbackError) {
+        const failureDetail = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `${failureDetail}\nThe previous systemd environment file at ${environmentFilePath} could not be restored.`,
+          { cause: rollbackError },
+        );
       }
-      const source = readEnvironmentValueSource(environmentValueSources, key);
-      if (hasEnvironmentFileSource(source) && isUnresolvedShellReference(value)) {
-        return false;
-      }
-      const normalizedKey = normalizeSystemdEnvironmentKey(key);
-      if (
-        normalizedKey &&
-        environmentFileResult.environmentKeys.has(normalizedKey) &&
-        !inlineManagedKeys.has(normalizedKey)
-      ) {
-        return false;
-      }
-      const stateDirValue = stateDirDotEnvVars[key];
-      if (typeof stateDirValue !== "string") {
-        return true;
-      }
-      return value.trim() !== stateDirValue.trim();
-    }),
-  );
-  const unit = buildSystemdUnit({
-    description: serviceDescription,
-    programArguments,
-    workingDirectory,
-    environment: environmentSansDotEnvEntries,
-    environmentFiles: environmentFileResult.environmentFiles,
-  });
-  await fs.writeFile(unitPath, unit, "utf8");
+    }
+    throw error;
+  }
   return { unitPath, backedUp };
+}
+
+type SystemdFileSnapshot = { contents: Buffer; mode: number } | null;
+
+async function assertSystemdManagedPathIsNotSymlink(filePath: string): Promise<void> {
+  try {
+    const stat = await fs.lstat(filePath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to rewrite symlinked managed systemd file: ${filePath}`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function readSystemdFileSnapshot(filePath: string): Promise<SystemdFileSnapshot> {
+  try {
+    const stat = await fs.lstat(filePath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing to rewrite symlinked managed systemd file: ${filePath}`);
+    }
+    const contents = await fs.readFile(filePath);
+    return { contents, mode: stat.mode & 0o777 };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function restoreSystemdFileSnapshot(
+  filePath: string,
+  snapshot: SystemdFileSnapshot,
+): Promise<void> {
+  if (snapshot === null) {
+    await fs.rm(filePath, { force: true });
+    return;
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const rollbackPath = `${filePath}.openclaw-${randomUUID()}.rollback`;
+  try {
+    await fs.writeFile(rollbackPath, snapshot.contents, {
+      flag: "wx",
+      mode: snapshot.mode,
+    });
+    await fs.rename(rollbackPath, filePath);
+  } finally {
+    await fs.unlink(rollbackPath).catch(() => undefined);
+  }
+}
+
+async function publishSystemdUnit(params: {
+  env: GatewayServiceEnv;
+  unitPath: string;
+  contents: string;
+}): Promise<void> {
+  const previous = await readSystemdFileSnapshot(params.unitPath);
+  const temporaryPath = `${params.unitPath}.openclaw-${randomUUID()}.tmp`;
+  await fs.writeFile(temporaryPath, params.contents, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: previous?.mode ?? 0o644,
+  });
+  try {
+    // systemd ignores the temporary suffix, so this is the last ownership check
+    // before the canonical user unit becomes discoverable.
+    await assertNoSystemGatewayOwnership(params.env);
+    await fs.rename(temporaryPath, params.unitPath);
+    try {
+      await assertNoSystemGatewayOwnership(params.env);
+    } catch (ownershipError) {
+      try {
+        await restoreSystemdFileSnapshot(params.unitPath, previous);
+      } catch (rollbackError) {
+        const ownershipDetail =
+          ownershipError instanceof Error ? ownershipError.message : String(ownershipError);
+        throw new Error(
+          `${ownershipDetail}\nThe previous user systemd unit at ${params.unitPath} could not be restored.`,
+          { cause: rollbackError },
+        );
+      }
+      throw ownershipError;
+    }
+  } finally {
+    await fs.unlink(temporaryPath).catch(() => undefined);
+  }
 }
 
 async function writeSystemdGatewayEnvironmentFile(params: {
@@ -1347,6 +1470,9 @@ export async function stageSystemdService({
 async function activateSystemdService(params: { env: GatewayServiceEnv }) {
   const serviceName = resolveSystemdServiceName(params.env);
   const unitName = `${serviceName}.service`;
+  // A system unit may appear after publication. Refuse before the user manager
+  // can load a second supervisor for the same gateway name.
+  await assertNoSystemGatewayOwnership(params.env);
   const reloadSystemd = async () => await execSystemctlUser(params.env, ["daemon-reload"]);
   const throwActivationFailure = (
     action: "daemon-reload" | "enable" | "restart",
@@ -1483,6 +1609,9 @@ async function runSystemdServiceAction(params: {
     return;
   }
   await assertSystemdAvailable(env);
+  if (params.action !== "stop") {
+    await assertNoSystemGatewayOwnership(env);
+  }
   if (params.action === "restart") {
     // Clear any failed/start-limit-hit latch before restart so a crash-looped
     // gateway recovers (see system-scope branch above). Idempotent on healthy units.


### PR DESCRIPTION
Fixes #116129

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Linux operators could install the same OpenClaw gateway unit in both system and user systemd scopes, leaving two supervisors competing over one gateway and causing restart loops or unreliable message delivery.

## Why This Change Was Made

Gateway install, stage, start, and restart now fail closed when the system manager owns the exact canonical unit name. The check uses the running system manager's unit search path, is repeated around publication and activation to close races, and cannot be bypassed with `--force`.

OpenClaw does not mutate system-scope units automatically. Differently named and profile-specific units remain independent, while user-unit and environment-file publication is atomic and rolls back exact prior contents and permissions if ownership changes mid-install.

## User Impact

Linux operators get an actionable error before OpenClaw creates or activates a conflicting user gateway. Existing system units remain untouched, custom differently named services continue to work, and failed publication does not leave partial user-scope files behind.

## Evidence

- Blacksmith Testbox focused proof: 145/145 tests passed across `src/daemon/systemd-system.test.ts`, `src/daemon/systemd.test.ts`, and `src/cli/daemon-cli/install.integration.test.ts`.
- Blacksmith Testbox changed gate passed formatting, dead-code, boundary, core/core-test typecheck, lint, schema, storage, and import-cycle checks.
- Live Linux proof created an ephemeral same-name unit in `/run/systemd/system`, confirmed install failed with `SYSTEM_SYSTEMD_OWNERSHIP`, confirmed a differently named unit passed, and verified no user unit or gateway environment file was published.
- Regression coverage includes system-only normal and forced install, pre-existing duel, `/etc`, `/run`, `/usr/local`, generator/package guidance, uncheckable ownership, root/non-root recovery, profile names, publication and activation races, symlink refusal, rollback, and zero-valued permission preservation.
- Fresh autoreview: clean, no accepted/actionable findings.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
source: local Codex session
redaction: local paths, runner identities, raw tool output, secrets, and unrelated PR work omitted

[assistant]
Issue policy is explicit: user-scope install must fail closed when the canonical system unit exists, including --force, and must never mutate the system unit.

[assistant]
The launchd comparison confirms the right boundary: an exact-name system owner is a hard ownership conflict, not a cleanup opportunity.

[assistant]
The live Linux proof is clean: a real system-manager unit blocked the user install before publication, while a different name passed; cleanup removed the ephemeral proof unit and reloaded systemd.

[assistant]
Autoreview found and drove fixes for missing-bus classification, environment-file rollback, complete systemd unit paths, symlink safety, recovery guidance, and exact permission preservation.

[assistant]
Final proof is green: 145 focused tests, the scoped changed gate, live systemd ownership proof, and a clean fresh autoreview.
```

</details>
<!-- agent-transcript:end -->
