### PR TITLE
fix(plugins): report request timeouts for stalled response bodies

### DIFF
--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -287,9 +287,7 @@ describe("graph upload request timeouts", () => {
     const signal = fetchSignal(fetchFn);
     const assertion = expectMSTeamsTimeout(upload, "MS Teams SharePoint upload", timeoutMs);
 
-    await vi.advanceTimersByTimeAsync(timeoutMs);
-
-    await assertion;
+    await Promise.all([assertion, vi.advanceTimersByTimeAsync(timeoutMs)]);
     expect(signal.aborted).toBe(true);
   });
 

--- a/extensions/msteams/src/graph-upload.ts
+++ b/extensions/msteams/src/graph-upload.ts
@@ -75,10 +75,11 @@ async function uploadToSharePoint(params: {
 
   // Use "OpenClawShared" folder to organize bot-uploaded files
   const uploadPath = `/OpenClawShared/${encodeURIComponent(params.filename)}`;
+  const timeoutMs = resolveMSTeamsSharePointUploadTimeoutMs(params.buffer.length);
 
   const data = await withMSTeamsAbortableRequestTimeout({
     label: SHAREPOINT_UPLOAD_TIMEOUT_LABEL,
-    timeoutMs: resolveMSTeamsSharePointUploadTimeoutMs(params.buffer.length),
+    timeoutMs,
     work: async (signal) => {
       const token = await getGraphAccessToken(params.tokenProvider);
       const res = await fetchFn(
@@ -103,7 +104,7 @@ async function uploadToSharePoint(params: {
         id?: string;
         webUrl?: string;
         name?: string;
-      }>(res, "msteams.graph-upload.uploadSharePointFile");
+      }>(res, "msteams.graph-upload.uploadSharePointFile", { chunkTimeoutMs: timeoutMs });
     },
   });
 

--- a/extensions/openai/openai-chatgpt-device-code.test.ts
+++ b/extensions/openai/openai-chatgpt-device-code.test.ts
@@ -123,11 +123,10 @@ describe("loginOpenAICodexDeviceCode", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(fetchMock).toHaveBeenCalledOnce();
-    const rejected = expect(login).rejects.toThrow(
-      "OpenAI device code user code request timed out after 30000ms",
-    );
-    await vi.advanceTimersByTimeAsync(30_000);
-    await rejected;
+    await Promise.all([
+      expect(login).rejects.toThrow("OpenAI device code user code request timed out after 30000ms"),
+      vi.advanceTimersByTimeAsync(30_000),
+    ]);
   });
 
   it("still honors caller cancellation during an active device-code request", async () => {

--- a/extensions/openai/openai-chatgpt-device-code.ts
+++ b/extensions/openai/openai-chatgpt-device-code.ts
@@ -151,12 +151,13 @@ function formatDeviceCodeError(params: {
     : `${params.prefix}: HTTP ${params.status}`;
 }
 
-async function readOpenAICodexDeviceBody(response: Response): Promise<string> {
+async function readOpenAICodexDeviceBody(response: Response, timeoutMs: number): Promise<string> {
   return await readResponseTextLimited(
     response,
     response.ok
       ? OPENAI_CODEX_DEVICE_JSON_BODY_LIMIT_BYTES
       : OPENAI_CODEX_DEVICE_ERROR_BODY_LIMIT_BYTES,
+    { chunkTimeoutMs: timeoutMs },
   );
 }
 
@@ -185,7 +186,7 @@ async function runOpenAICodexDeviceRequest(params: {
     return {
       ok: response.ok,
       status: response.status,
-      bodyText: await readOpenAICodexDeviceBody(response),
+      bodyText: await readOpenAICodexDeviceBody(response, params.timeoutMs),
     };
   } finally {
     await release();

--- a/extensions/qqbot/src/engine/tools/channel-api.ts
+++ b/extensions/qqbot/src/engine/tools/channel-api.ts
@@ -339,8 +339,12 @@ export async function executeChannelApi(
       debugLog(`[qqbot-channel-api] <<< Status: ${res.status} ${res.statusText}`);
 
       const rawBody = res.ok
-        ? await readProviderTextResponse(res, "QQ channel API response")
-        : await readResponseTextLimited(res, CHANNEL_API_ERROR_BODY_LIMIT_BYTES);
+        ? await readProviderTextResponse(res, "QQ channel API response", {
+            chunkTimeoutMs: DEFAULT_TIMEOUT_MS,
+          })
+        : await readResponseTextLimited(res, CHANNEL_API_ERROR_BODY_LIMIT_BYTES, {
+            chunkTimeoutMs: DEFAULT_TIMEOUT_MS,
+          });
       if (!rawBody || rawBody.trim() === "") {
         if (res.ok) {
           return json({ success: true, status: res.status, path: params.path });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenAI device-code login, MS Teams SharePoint uploads, and QQ channel API calls could report a generic response-body stall before the plugin's existing request deadline when response headers arrived but the body stopped streaming.

## Why This Change Was Made

Each plugin now passes its existing operation timeout into the bounded response reader, so the owner-level deadline remains authoritative without changing shared HTTP defaults. The OpenAI and Teams regression tests also await timer advancement and rejection together so a failing assertion cannot leak an unhandled rejection.

## User Impact

Users now receive the plugin's stable request-timeout result for stalled response bodies, matching the same deadline used before response headers arrive.

## Evidence

- Reproduced all three failures on current `main`: OpenAI returned `error body read stalled for 10000ms`, Teams returned a 30000ms body-reader error, and QQBot returned the 10000ms body-reader error.
- Focused validation on the rebased head: 3 Vitest shards, 55/55 tests passed. The same bundle also passed three consecutive pre-rebase repetitions.
- `git diff --check` passed; `oxfmt` completed on all five changed files.
- Autoreview: clean, no accepted/actionable findings, overall 0.93.
- OpenAI/Codex protocol contract inspected directly at `openai/codex@9a6668f674d74b35418fa534b3b6285a315d0765`: `codex-rs/login/src/device_code_auth.rs:62-178` and `codex-rs/login/tests/suite/device_code_login.rs:38-87,216-248`.

AI-assisted: yes. I reviewed the implementation and validation results.