### PR TITLE
fix: serialize hosted Swift release tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3179,6 +3179,8 @@ jobs:
           # keep the faster first-attempt Blacksmith path parallel.
           if [[ "$SWIFT_TEST_EXECUTION" == "parallel" ]]; then
             swift_test_args+=(--parallel)
+          else
+            swift_test_args+=(--no-parallel)
           fi
           for attempt in 1 2 3; do
             if swift test "${swift_test_args[@]}"; then

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3595,6 +3595,7 @@ describe("ci workflow guards", () => {
     );
     expect(testStep.run).toContain('if [[ "$SWIFT_TEST_EXECUTION" == "parallel" ]]');
     expect(testStep.run).toContain("swift_test_args+=(--parallel)");
+    expect(testStep.run).toContain("else\n  swift_test_args+=(--no-parallel)");
     expect(testStep.run).toContain('swift test "${swift_test_args[@]}"');
     expect(testStep.run).not.toContain(
       "swift test --package-path apps/macos --parallel --enable-code-coverage",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the hosted macOS release-validation path selected its serial branch but Swift Testing still executed tests concurrently, preserving the contention failure seen in job 90751811259.

## Why This Change Was Made

The hosted workflow-dispatch and retry branch now explicitly forwards `--no-parallel` to Swift Testing. First-attempt automatic Blacksmith runs continue to use `--parallel`; coverage and all three retry attempts remain unchanged.

This follows the Swift Testing entrypoint contract: Swift Testing defaults parallelization on and disables it only when `--no-parallel` is present. Swift Testing does not repurpose SwiftPM's `--num-workers`, and SwiftPM rejects combining that option with `--no-parallel`.

## User Impact

Beta release validation now exercises the macOS Swift suite serially on the GitHub-hosted fallback without slowing the normal Blacksmith path. There is no product runtime change.

## Evidence

- failing hosted-path evidence: job 90751811259 selected `SWIFT_TEST_EXECUTION=serial` but still showed concurrent Swift Testing execution
- upstream contract: `swiftlang/swift-testing` entrypoint parses explicit `--no-parallel`; its tests prove that disables global parallelization
- direct rejected-alternative proof: SwiftPM reports `--num-workers must be used with --parallel` for `--no-parallel --num-workers 1`
- `actionlint .github/workflows/ci.yml`
- focused `test/scripts/ci-workflow-guards.test.ts`: 92 passed, 1 skipped
- formatting and `git diff --check`
- Codex autoreview: clean, no accepted or actionable findings
