### PR TITLE
fix(macos): prevent stale remote tunnel recreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
+- **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.
 - **Control UI update reconciliation:** preserve an unresolved managed-update request across disconnects, accept the replacement Gateway version when it proves success, and otherwise show explicit recovery guidance instead of trusting an unrelated cached update result or failing silently. Fixes #116075. Thanks @shakkernerd.
 - **Control UI model readiness:** put AI setup first when no model is selectable, distinguish signed-in credentials from ready providers, and route accounts with no exposed models directly to provider recovery instead of leading with disabled default controls.
 - **Control UI Talk session isolation:** stop active realtime Talk media and retire its callbacks before chat session changes, Gateway disconnects, or pane disposal so previous-session audio, transcript, camera, and status updates cannot leak into the next view. Thanks @shakkernerd.

--- a/apps/macos/Sources/OpenClaw/RemoteTunnelManager.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteTunnelManager.swift
@@ -10,6 +10,25 @@ actor RemoteTunnelManager {
         let generation: UInt64
     }
 
+    private enum CreateJoinResult {
+        case none
+        case replacedMismatchedCreate(UInt64)
+        case staleConfiguration
+        case route(Route)
+    }
+
+    private enum ActiveRouteLookupResult {
+        case none
+        case retiredActive(UInt64)
+        case staleConfiguration
+        case route(Route)
+    }
+
+    private struct EnsureStepResolution {
+        let route: Route?
+        let lifecycleGeneration: UInt64
+    }
+
     private struct ActiveTunnel {
         let tunnel: RemotePortTunnel
         let configuration: RemotePortTunnel.Configuration
@@ -21,8 +40,10 @@ actor RemoteTunnelManager {
     private var createInFlight: (
         token: UUID,
         configuration: RemotePortTunnel.Configuration,
+        lifecycleGeneration: UInt64,
         task: Task<RemotePortTunnel, Error>)?
     private var tunnelGeneration: UInt64 = 0
+    private var lifecycleGeneration: UInt64 = 0
     private var restartInFlight = false
     private var lastRestartAt: Date?
     private let restartBackoffSeconds: TimeInterval = 2.0
@@ -31,6 +52,7 @@ actor RemoteTunnelManager {
         guard let configuration = try? RemotePortTunnel.configuration(
             remotePort: GatewayEnvironment.gatewayPort())
         else {
+            self.lifecycleGeneration &+= 1
             self.createInFlight?.task.cancel()
             self.createInFlight = nil
             let tunnel = self.controlTunnel?.tunnel
@@ -41,34 +63,54 @@ actor RemoteTunnelManager {
             await tunnel?.terminate()
             return nil
         }
-        return await self.controlTunnelRouteIfRunning(configuration: configuration)
+        switch await self.lookupControlTunnelRoute(configuration: configuration) {
+        case let .route(route):
+            return route
+        case .none, .retiredActive, .staleConfiguration:
+            return nil
+        }
     }
 
     func isCurrentRoute(_ route: Route) async -> Bool {
         await self.controlTunnelRouteIfRunning() == route
     }
 
-    private func controlTunnelRouteIfRunning(
-        configuration: RemotePortTunnel.Configuration) async -> Route?
+    private func lookupControlTunnelRoute(
+        configuration: RemotePortTunnel.Configuration,
+        requireCurrentConfiguration: Bool = false) async -> ActiveRouteLookupResult
     {
+        if requireCurrentConfiguration {
+            guard let currentConfiguration = try? RemotePortTunnel.configuration(
+                remotePort: GatewayEnvironment.gatewayPort()),
+                Self.isCurrentConfiguration(
+                    requested: configuration,
+                    current: currentConfiguration)
+            else {
+                return .staleConfiguration
+            }
+        }
         if self.restartInFlight {
             self.logger.info("control tunnel restart in flight; skipping reuse check")
-            return nil
+            return .none
         }
         if let active = controlTunnel {
             guard Self.canReuse(active.configuration, for: configuration) else {
                 self.logger.info("configured SSH route changed; replacing control tunnel")
+                self.lifecycleGeneration &+= 1
+                let replacementGeneration = self.lifecycleGeneration
                 self.controlTunnel = nil
                 self.tunnelGeneration &+= 1
                 await active.tunnel.terminate()
-                return nil
+                return .retiredActive(replacementGeneration)
             }
             guard active.tunnel.isRunning,
                   let local = active.tunnel.localPort
             else {
+                self.lifecycleGeneration &+= 1
+                let replacementGeneration = self.lifecycleGeneration
                 self.controlTunnel = nil
                 self.tunnelGeneration &+= 1
-                return nil
+                return .retiredActive(replacementGeneration)
             }
             let pid = active.tunnel.processIdentifier
             let isListening = await PortGuardian.shared.isListening(port: Int(local), pid: pid)
@@ -78,19 +120,22 @@ actor RemoteTunnelManager {
                   current.tunnel === active.tunnel,
                   current.configuration == active.configuration,
                   current.route == active.route
-            else { return nil }
+            else { return .none }
             if isListening {
                 self.logger.info("reusing active SSH tunnel localPort=\(local, privacy: .public)")
-                return current.route
+                return .route(current.route)
             }
             self.logger.error(
                 "active SSH tunnel on port \(local, privacy: .public) is not listening; restarting")
+            self.lifecycleGeneration &+= 1
+            let replacementGeneration = self.lifecycleGeneration
             self.controlTunnel = nil
             self.tunnelGeneration &+= 1
             self.beginRestart()
             await active.tunnel.terminate()
+            return .retiredActive(replacementGeneration)
         }
-        return nil
+        return .none
     }
 
     private static func canReuse(
@@ -100,6 +145,69 @@ actor RemoteTunnelManager {
         active == desired
     }
 
+    private static func isCurrentConfiguration(
+        requested: RemotePortTunnel.Configuration,
+        current: RemotePortTunnel.Configuration) -> Bool
+    {
+        requested == current
+    }
+
+    private func resolveActiveLookup(
+        _ result: ActiveRouteLookupResult,
+        lifecycleGeneration: UInt64) async throws -> EnsureStepResolution
+    {
+        switch result {
+        case let .route(route):
+            return EnsureStepResolution(route: route, lifecycleGeneration: lifecycleGeneration)
+        case let .retiredActive(replacementGeneration):
+            guard self.lifecycleGeneration == replacementGeneration else {
+                throw CancellationError()
+            }
+            return EnsureStepResolution(route: nil, lifecycleGeneration: replacementGeneration)
+        case .staleConfiguration:
+            try Task.checkCancellation()
+            guard self.lifecycleGeneration == lifecycleGeneration else {
+                throw CancellationError()
+            }
+            let route = try await self.ensureControlTunnelRoute(
+                lifecycleGeneration: lifecycleGeneration)
+            return EnsureStepResolution(route: route, lifecycleGeneration: lifecycleGeneration)
+        case .none:
+            guard self.lifecycleGeneration == lifecycleGeneration else {
+                throw CancellationError()
+            }
+            return EnsureStepResolution(route: nil, lifecycleGeneration: lifecycleGeneration)
+        }
+    }
+
+    private func resolveCreateJoin(
+        _ result: CreateJoinResult,
+        lifecycleGeneration: UInt64) async throws -> EnsureStepResolution
+    {
+        switch result {
+        case let .route(route):
+            return EnsureStepResolution(route: route, lifecycleGeneration: lifecycleGeneration)
+        case let .replacedMismatchedCreate(replacementGeneration):
+            guard self.lifecycleGeneration == replacementGeneration else {
+                throw CancellationError()
+            }
+            return EnsureStepResolution(route: nil, lifecycleGeneration: replacementGeneration)
+        case .staleConfiguration:
+            try Task.checkCancellation()
+            guard self.lifecycleGeneration == lifecycleGeneration else {
+                throw CancellationError()
+            }
+            let route = try await self.ensureControlTunnelRoute(
+                lifecycleGeneration: lifecycleGeneration)
+            return EnsureStepResolution(route: route, lifecycleGeneration: lifecycleGeneration)
+        case .none:
+            guard self.lifecycleGeneration == lifecycleGeneration else {
+                throw CancellationError()
+            }
+            return EnsureStepResolution(route: nil, lifecycleGeneration: lifecycleGeneration)
+        }
+    }
+
     /// Ensure an SSH tunnel is running for the gateway control port.
     /// Returns the local forwarded port (usually the configured gateway port).
     func ensureControlTunnel() async throws -> UInt16 {
@@ -107,6 +215,19 @@ actor RemoteTunnelManager {
     }
 
     func ensureControlTunnelRoute() async throws -> Route {
+        try await self.ensureControlTunnelRoute(
+            lifecycleGeneration: self.lifecycleGeneration)
+    }
+
+    private func ensureControlTunnelRoute(
+        lifecycleGeneration initialLifecycleGeneration: UInt64) async throws -> Route
+    {
+        var lifecycleGeneration = initialLifecycleGeneration
+        try Task.checkCancellation()
+        guard self.lifecycleGeneration == lifecycleGeneration else {
+            throw CancellationError()
+        }
+
         let configuration = try RemotePortTunnel.configuration(
             remotePort: GatewayEnvironment.gatewayPort())
         let identitySet = !configuration.identity.isEmpty
@@ -114,33 +235,66 @@ actor RemoteTunnelManager {
             "ensure SSH tunnel target=\(configuration.target.host, privacy: .public) " +
                 "identitySet=\(identitySet, privacy: .public)")
 
-        if let route = await self.controlTunnelRouteIfRunning(configuration: configuration) {
+        var resolution = try await self.resolveActiveLookup(
+            self.lookupControlTunnelRoute(
+                configuration: configuration,
+                requireCurrentConfiguration: true),
+            lifecycleGeneration: lifecycleGeneration)
+        if let route = resolution.route {
             return route
         }
-        if let create = self.createInFlight {
-            if create.configuration == configuration {
-                self.logger.info("control tunnel create in flight; joining")
-                let tunnel: RemotePortTunnel
-                do {
-                    tunnel = try await create.task.value
-                } catch {
-                    if self.createInFlight?.token == create.token {
-                        self.createInFlight = nil
-                    }
-                    throw error
-                }
-                return try await self.installCreatedTunnel(
-                    tunnel,
-                    token: create.token,
-                    configuration: configuration,
-                    fallbackPort: UInt16(GatewayEnvironment.gatewayPort()))
-            }
-            // A suspended create owns the prior SSH route. It must not become
-            // the loopback endpoint for the replacement Gateway.
-            create.task.cancel()
-            self.createInFlight = nil
+        lifecycleGeneration = resolution.lifecycleGeneration
+
+        var joinResult = try await self.joinCreateInFlight(configuration: configuration)
+        resolution = try await self.resolveCreateJoin(
+            joinResult,
+            lifecycleGeneration: lifecycleGeneration)
+        if let route = resolution.route {
+            return route
         }
-        await self.waitForRestartBackoffIfNeeded()
+        lifecycleGeneration = resolution.lifecycleGeneration
+
+        try await self.waitForRestartBackoffIfNeeded()
+        try Task.checkCancellation()
+        guard self.lifecycleGeneration == lifecycleGeneration else {
+            throw CancellationError()
+        }
+
+        // The backoff suspends this actor. Another caller may have installed or
+        // started the canonical tunnel while we slept, so join it instead of
+        // launching a duplicate SSH process.
+        resolution = try await self.resolveActiveLookup(
+            self.lookupControlTunnelRoute(
+                configuration: configuration,
+                requireCurrentConfiguration: true),
+            lifecycleGeneration: lifecycleGeneration)
+        if let route = resolution.route {
+            return route
+        }
+        lifecycleGeneration = resolution.lifecycleGeneration
+
+        joinResult = try await self.joinCreateInFlight(configuration: configuration)
+        resolution = try await self.resolveCreateJoin(
+            joinResult,
+            lifecycleGeneration: lifecycleGeneration)
+        if let route = resolution.route {
+            return route
+        }
+        lifecycleGeneration = resolution.lifecycleGeneration
+        try Task.checkCancellation()
+        guard self.lifecycleGeneration == lifecycleGeneration else {
+            throw CancellationError()
+        }
+
+        let currentConfiguration = try RemotePortTunnel.configuration(
+            remotePort: GatewayEnvironment.gatewayPort())
+        guard currentConfiguration == configuration else {
+            guard self.lifecycleGeneration == lifecycleGeneration else {
+                throw CancellationError()
+            }
+            return try await self.ensureControlTunnelRoute(
+                lifecycleGeneration: lifecycleGeneration)
+        }
 
         let desiredPort = UInt16(GatewayEnvironment.gatewayPort())
         let token = UUID()
@@ -150,7 +304,11 @@ actor RemoteTunnelManager {
                 preferredLocalPort: desiredPort,
                 allowRandomLocalPort: true)
         }
-        self.createInFlight = (token: token, configuration: configuration, task: task)
+        self.createInFlight = (
+            token: token,
+            configuration: configuration,
+            lifecycleGeneration: lifecycleGeneration,
+            task: task)
         let tunnel: RemotePortTunnel
         do {
             tunnel = try await task.value
@@ -164,15 +322,62 @@ actor RemoteTunnelManager {
             tunnel,
             token: token,
             configuration: configuration,
+            lifecycleGeneration: lifecycleGeneration,
             fallbackPort: desiredPort)
+    }
+
+    private func joinCreateInFlight(
+        configuration: RemotePortTunnel.Configuration) async throws -> CreateJoinResult
+    {
+        guard let create = createInFlight else { return .none }
+        guard create.configuration == configuration else {
+            let currentConfiguration = try RemotePortTunnel.configuration(
+                remotePort: GatewayEnvironment.gatewayPort())
+            guard Self.isCurrentConfiguration(
+                requested: configuration,
+                current: currentConfiguration)
+            else {
+                return .staleConfiguration
+            }
+
+            // A suspended create owns the prior SSH route. It must not become
+            // the loopback endpoint for the replacement Gateway.
+            self.lifecycleGeneration &+= 1
+            let replacementGeneration = self.lifecycleGeneration
+            create.task.cancel()
+            self.createInFlight = nil
+            return .replacedMismatchedCreate(replacementGeneration)
+        }
+
+        self.logger.info("control tunnel create in flight; joining")
+        let tunnel: RemotePortTunnel
+        do {
+            tunnel = try await create.task.value
+        } catch {
+            if self.createInFlight?.token == create.token {
+                self.createInFlight = nil
+            }
+            throw error
+        }
+        return try await .route(self.installCreatedTunnel(
+            tunnel,
+            token: create.token,
+            configuration: configuration,
+            lifecycleGeneration: create.lifecycleGeneration,
+            fallbackPort: UInt16(GatewayEnvironment.gatewayPort())))
     }
 
     private func installCreatedTunnel(
         _ tunnel: RemotePortTunnel,
         token: UUID,
         configuration: RemotePortTunnel.Configuration,
+        lifecycleGeneration: UInt64,
         fallbackPort: UInt16) async throws -> Route
     {
+        guard self.lifecycleGeneration == lifecycleGeneration else {
+            await tunnel.terminate()
+            throw CancellationError()
+        }
         if let active = controlTunnel, active.tunnel === tunnel {
             return active.route
         }
@@ -185,14 +390,22 @@ actor RemoteTunnelManager {
             currentConfiguration = try RemotePortTunnel.configuration(
                 remotePort: GatewayEnvironment.gatewayPort())
         } catch {
+            self.lifecycleGeneration &+= 1
             self.createInFlight = nil
             await tunnel.terminate()
             throw error
         }
         guard currentConfiguration == configuration else {
+            self.lifecycleGeneration &+= 1
+            let replacementGeneration = self.lifecycleGeneration
             self.createInFlight = nil
             await tunnel.terminate()
-            return try await self.ensureControlTunnelRoute()
+            try Task.checkCancellation()
+            guard self.lifecycleGeneration == replacementGeneration else {
+                throw CancellationError()
+            }
+            return try await self.ensureControlTunnelRoute(
+                lifecycleGeneration: replacementGeneration)
         }
         self.createInFlight = nil
         self.tunnelGeneration &+= 1
@@ -212,6 +425,7 @@ actor RemoteTunnelManager {
     func stopAll() async {
         // Invalidate every captured route before terminating processes. Delayed
         // health checks and create completions cannot resurrect this epoch.
+        self.lifecycleGeneration &+= 1
         self.tunnelGeneration &+= 1
         self.createInFlight?.task.cancel()
         self.createInFlight = nil
@@ -226,6 +440,20 @@ actor RemoteTunnelManager {
         for desired: RemotePortTunnel.Configuration) -> Bool
     {
         self.canReuse(active, for: desired)
+    }
+
+    static func _testIsCurrentConfiguration(
+        requested: RemotePortTunnel.Configuration,
+        current: RemotePortTunnel.Configuration) -> Bool
+    {
+        self.isCurrentConfiguration(requested: requested, current: current)
+    }
+
+    static func _testWaitForRestartBackoff(
+        seconds: TimeInterval,
+        sleep: @escaping @Sendable (UInt64) async throws -> Void) async throws
+    {
+        try await self.waitForRestartBackoff(seconds: seconds, sleep: sleep)
     }
     #endif
 
@@ -248,14 +476,24 @@ actor RemoteTunnelManager {
         }
     }
 
-    private func waitForRestartBackoffIfNeeded() async {
+    private func waitForRestartBackoffIfNeeded() async throws {
         guard let last = lastRestartAt else { return }
         let elapsed = Date().timeIntervalSince(last)
         let remaining = self.restartBackoffSeconds - elapsed
         guard remaining > 0 else { return }
         self.logger.info(
             "control tunnel restart backoff \(remaining, privacy: .public)s")
-        try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+        try await Self.waitForRestartBackoff(seconds: remaining)
+    }
+
+    private nonisolated static func waitForRestartBackoff(
+        seconds: TimeInterval,
+        sleep: @escaping @Sendable (UInt64) async throws -> Void = { try await Task.sleep(nanoseconds: $0) })
+        async throws
+    {
+        try Task.checkCancellation()
+        try await sleep(UInt64(seconds * 1_000_000_000))
+        try Task.checkCancellation()
     }
 
     // Reuse is cheap only while both the listener and its captured SSH route remain current.

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -1226,6 +1226,36 @@ extension GatewayEndpointStoreTests {
                 hostKeyPolicy: .openssh)))
     }
 
+    @Test func `ssh restart backoff propagates cancellation`() async {
+        await #expect(throws: CancellationError.self) {
+            try await RemoteTunnelManager._testWaitForRestartBackoff(seconds: 2) { _ in
+                throw CancellationError()
+            }
+        }
+    }
+
+    @Test func `stale ssh waiter cannot replace current tunnel create`() throws {
+        let oldTarget = try #require(CommandResolver.parseSSHTarget("alice@gateway-a.example"))
+        let newTarget = try #require(CommandResolver.parseSSHTarget("alice@gateway-b.example"))
+        let oldConfiguration = RemotePortTunnel.Configuration(
+            target: oldTarget,
+            identity: "/tmp/id-a",
+            remotePort: 18789,
+            hostKeyPolicy: .strict)
+        let newConfiguration = RemotePortTunnel.Configuration(
+            target: newTarget,
+            identity: "/tmp/id-b",
+            remotePort: 18789,
+            hostKeyPolicy: .strict)
+
+        #expect(!RemoteTunnelManager._testIsCurrentConfiguration(
+            requested: oldConfiguration,
+            current: newConfiguration))
+        #expect(RemoteTunnelManager._testIsCurrentConfiguration(
+            requested: newConfiguration,
+            current: newConfiguration))
+    }
+
     @Test func `normalize gateway url rejects public host ws`() {
         let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://gateway.example:18789")
         #expect(url == nil)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users switching or stopping a remote Gateway connection could have delayed tunnel work recreate an SSH process after the connection lifecycle had already moved on. Concurrent reconnects could also launch duplicate tunnel creation work after restart backoff.

## Why This Change Was Made

The remote tunnel actor now carries an explicit lifecycle generation across restart backoff, in-flight creation, and tunnel installation. Stale or cancelled work terminates without installing or recursively recreating a tunnel, while a current caller can safely retire an older create and join the canonical replacement.

## User Impact

Remote Gateway reconnects and shutdowns no longer leave behind resurrected or duplicate SSH tunnel processes. Current reconnect work continues normally when another caller already owns the same tunnel creation.

## Evidence

- `swift test --package-path apps/macos --build-path apps/macos/.build-local --filter GatewayEndpointStoreTests`: 57 passed
- `swiftlint lint --strict --config config/swiftlint.yml apps/macos/Sources/OpenClaw/RemoteTunnelManager.swift apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift`: 0 violations
- Exact rebased head `105fecb1e75`: focused Swift suite passed 57 tests; configured SwiftLint reported 0 violations; `git diff --check` passed
- Fresh exact-head autoreview: no accepted or actionable findings
- The exact-head changed gate was delegated to Blacksmith Testbox, but Testbox timed out during checkout sync before executing. A local fallback was stopped at the Codex-worktree dependency-reconciliation prompt per repository policy; GitHub CI owns the remaining broad gate.
