### PR TITLE
fix(beam): prevent mirror retries from stalling on slow responses

### DIFF
--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -87,7 +87,11 @@ function fakeRuntime(config: unknown): PluginRuntime {
 
 type SentRequest = { url: string; auth?: string; payload: BeamMirrorUpload };
 
-function captureFetch(sent: SentRequest[], status = 200, onCancel?: () => void): typeof fetch {
+function captureFetch(
+  sent: SentRequest[],
+  status = 200,
+  onCancel?: () => void | Promise<void>,
+): typeof fetch {
   return (async (url: unknown, init?: RequestInit) => {
     const headers = (init?.headers ?? {}) as Record<string, string>;
     sent.push({
@@ -97,9 +101,7 @@ function captureFetch(sent: SentRequest[], status = 200, onCancel?: () => void):
     });
     const body = onCancel
       ? new ReadableStream<Uint8Array>({
-          cancel: () => {
-            onCancel();
-          },
+          cancel: onCancel,
         })
       : "{}";
     return new Response(body, { status });
@@ -244,6 +246,32 @@ describe("createBeamMirrorRunner", () => {
     });
     expect(parseBeamUpload(structuredClone(sent[0]?.payload)).ok).toBe(true);
     expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("keeps successful uploads successful when response cancellation rejects", async () => {
+    const sent: SentRequest[] = [];
+    const warnings: string[] = [];
+    const cancel = vi.fn(async () => {
+      throw new Error("cancel failed");
+    });
+    const catalog = fakeCatalog({
+      id: "claude",
+      sessions: [{ threadId: "t1", recencyAt: NOW - 60_000 }],
+    });
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: { warn: (message) => warnings.push(message), info: () => {} },
+      fetchFn: captureFetch(sent, 200, cancel),
+      now: () => NOW,
+      listCatalogs: () => [catalog],
+    });
+
+    await runner.tick();
+    await runner.tick();
+
+    expect(sent).toHaveLength(1);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(warnings).toEqual([]);
   });
 
   it("ignores idle sessions, node hosts, the beam catalog, and unlisted catalogs", async () => {

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -5,7 +5,7 @@ import type {
   SessionsCatalogReadResult,
 } from "openclaw/plugin-sdk/session-catalog";
 import type { ActiveSessionCatalog } from "openclaw/plugin-sdk/session-catalog-runtime";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   beamMirrorId,
   buildBeamMirrorItems,
@@ -87,7 +87,7 @@ function fakeRuntime(config: unknown): PluginRuntime {
 
 type SentRequest = { url: string; auth?: string; payload: BeamMirrorUpload };
 
-function captureFetch(sent: SentRequest[], status = 200): typeof fetch {
+function captureFetch(sent: SentRequest[], status = 200, onCancel?: () => void): typeof fetch {
   return (async (url: unknown, init?: RequestInit) => {
     const headers = (init?.headers ?? {}) as Record<string, string>;
     sent.push({
@@ -95,7 +95,14 @@ function captureFetch(sent: SentRequest[], status = 200): typeof fetch {
       ...(headers.Authorization ? { auth: headers.Authorization } : {}),
       payload: JSON.parse(init?.body as string) as BeamMirrorUpload,
     });
-    return new Response("{}", { status });
+    const body = onCancel
+      ? new ReadableStream<Uint8Array>({
+          cancel: () => {
+            onCancel();
+          },
+        })
+      : "{}";
+    return new Response(body, { status });
   }) as typeof fetch;
 }
 
@@ -210,6 +217,7 @@ describe("createBeamMirrorRunner", () => {
   it("uploads active local sessions and skips unchanged ones", async () => {
     const sent: SentRequest[] = [];
     const reads: string[] = [];
+    const cancel = vi.fn();
     const catalog = fakeCatalog({
       id: "claude",
       sessions: [{ threadId: "t1", name: "Fix flow", recencyAt: NOW - 60_000 }],
@@ -218,7 +226,7 @@ describe("createBeamMirrorRunner", () => {
     const runner = createBeamMirrorRunner({
       runtime: fakeRuntime(mirrorConfig({ token: "scratch-token" })),
       logger: silentLogger,
-      fetchFn: captureFetch(sent),
+      fetchFn: captureFetch(sent, 200, cancel),
       now: () => NOW,
       listCatalogs: () => [catalog],
     });
@@ -235,6 +243,7 @@ describe("createBeamMirrorRunner", () => {
       completed: false,
     });
     expect(parseBeamUpload(structuredClone(sent[0]?.payload)).ok).toBe(true);
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it("ignores idle sessions, node hosts, the beam catalog, and unlisted catalogs", async () => {
@@ -318,6 +327,7 @@ describe("createBeamMirrorRunner", () => {
   it("keeps tracking for retry when the receiver rejects an upload", async () => {
     const sent: SentRequest[] = [];
     const warnings: string[] = [];
+    const cancel = vi.fn();
     const catalog = fakeCatalog({
       id: "claude",
       sessions: [{ threadId: "t1", recencyAt: NOW - 60_000 }],
@@ -325,7 +335,7 @@ describe("createBeamMirrorRunner", () => {
     const runner = createBeamMirrorRunner({
       runtime: fakeRuntime(mirrorConfig()),
       logger: { warn: (message) => warnings.push(message), info: () => {} },
-      fetchFn: captureFetch(sent, 503),
+      fetchFn: captureFetch(sent, 503, cancel),
       now: () => NOW,
       listCatalogs: () => [catalog],
     });
@@ -334,6 +344,7 @@ describe("createBeamMirrorRunner", () => {
     // Both ticks retry because the failed upload was never fingerprinted.
     expect(sent).toHaveLength(2);
     expect(warnings.length).toBeGreaterThan(0);
+    expect(cancel).toHaveBeenCalledTimes(2);
   });
 
   it("skips ticks when a configured token cannot be resolved", async () => {

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -293,11 +293,17 @@ export function createBeamMirrorRunner(params: {
       },
       body: JSON.stringify(payload),
     });
-    if (!response.ok) {
-      warnThrottled(`beam mirror upload failed (${response.status}) for ${payload.source}`);
-      return false;
+    try {
+      if (!response.ok) {
+        warnThrottled(`beam mirror upload failed (${response.status}) for ${payload.source}`);
+        return false;
+      }
+      return true;
+    } finally {
+      // The mirror uses only the status; cancel the ignored payload so slow
+      // receiver responses cannot retain connection slots across poll retries.
+      await response.body?.cancel().catch(() => undefined);
     }
-    return true;
   };
 
   const buildUpload = async (

--- a/extensions/buzz/src/gateway.lifecycle.test.ts
+++ b/extensions/buzz/src/gateway.lifecycle.test.ts
@@ -399,6 +399,7 @@ describe("Buzz gateway lifecycle", () => {
       {
         publicKey: "a".repeat(64),
         sendText: async () => "event-id",
+        sendTyping: async () => {},
         close: async () => {},
       },
     );

--- a/extensions/buzz/src/inbound.ts
+++ b/extensions/buzz/src/inbound.ts
@@ -4,6 +4,7 @@ import {
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveStableChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
 import type { BuzzBus } from "./buzz-bus.js";
 import {
   BUZZ_DIFF_MESSAGE_KIND,
@@ -13,6 +14,8 @@ import {
 import { getBuzzRuntime } from "./runtime.js";
 import { buildBuzzTarget, parseBuzzTarget } from "./target.js";
 import type { ResolvedBuzzAccount } from "./types.js";
+
+const log = createSubsystemLogger("buzz/inbound");
 
 function senderLabel(pubkey: string): string {
   return `${pubkey.slice(0, 8)}...${pubkey.slice(-6)}`;
@@ -172,9 +175,7 @@ export async function handleBuzzInbound(params: {
         },
         keepaliveIntervalMs: 3_000,
         onStartError: (error: unknown) => {
-          runtime.error(
-            `[${account.accountId}] Buzz typing failed for ${channelId}: ${String(error)}`,
-          );
+          log.error(`[${account.accountId}] Buzz typing failed for ${channelId}: ${String(error)}`);
         },
       },
     },


### PR DESCRIPTION
Closes #116154

AI-assisted: Codex was used to investigate, implement, test, and review this change. I reviewed and understand the resulting code.

## What Problem This Solves

Fixes an issue where users with Beam mirroring enabled could see mirror uploads and retries stop progressing when a receiver or ingress returned a slow or non-terminating response body. The Gateway remained healthy, but ignored response payloads could retain HTTP connection slots until garbage collection.

## Why This Change Was Made

Beam only uses the upload status, so the Beam-owned upload boundary now cancels the ignored response body in a `finally` block for both successful and rejected responses. Cancellation errors remain non-fatal, and there are no config, protocol, or shared-runtime changes.

## User Impact

Beam mirroring releases transport resources after every upload response, allowing later polling attempts and retries to continue instead of stalling behind occupied connection slots.

## Evidence

- Rechecked current `main` at `5a3c3b3f4f06a21b20d8ec04f0546011e632d258`: the upload path still returned after checking `response.ok` without consuming or canceling the body. Neither touched Beam file changed between the original reproduction base and this current-main head.
- Upstream contract: [Undici v7.28.0, Garbage Collection](https://github.com/nodejs/undici/blob/v7.28.0/README.md#garbage-collection) states that Node callers must consume or cancel response bodies; otherwise connection usage can grow and requests can stall or deadlock.
- Standalone one-connection transport reproduction on the Node 24 fetch runtime:

  ```json
  {"node":"v24.13.1","undici":"7.18.2","beforeCancel":"blocked","requestsBeforeCancel":1,"requests":2,"secondStatus":503}
  ```

  The second request remained blocked for 250 ms and did not reach the server until the first response body was canceled.
- Beam runner before the fix failed the cancellation assertion:

  ```text
  actual:   { requests: 1, cancels: 0 }
  expected: { requests: 1, cancels: 1 }
  ```

- The patched Beam runner passed both status paths:

  ```json
  {"success":{"requests":1,"cancels":1},"failure":{"requests":2,"cancels":2}}
  ```

- Exact-head CI for `f239b691339bc8b35b6a9e52440df70501bcd745`: [all 30 selected jobs passed](https://github.com/openclaw/openclaw/actions/runs/30508251359), including build, production/test types, lint/format, extension package boundary, plugin/channel contracts, and changed tests.
- Focused CI test result: `extensions/beam/src/mirror.test.ts` — 1 file passed, 14 tests passed.
- `oxfmt --check extensions/beam/src/mirror.ts extensions/beam/src/mirror.test.ts` — passed.
- `git diff --check` — passed.
- `autoreview --mode uncommitted --stream-engine-output` using `gpt-5.6-sol` / `xhigh` — clean, no accepted/actionable findings; overall correctness `patch is correct` (0.95 confidence).

## Maintainer merge repair

After the branch was refreshed, current `main` at `e7d01b511b4e842fd4584db5d4b78caddf715489` was red from the newly merged Buzz typing-indicator change in PR #116194. Its production/test type lanes and extension package-boundary compile failed because `PluginRuntime.error` is not a runtime API and one `BuzzBus` lifecycle fixture omitted the new `sendTyping` member. Per the no-red-main landing policy, this PR includes the smallest repair: log through the plugin logging facade and complete that test fixture.

Repair proof on the prepared tree:

- Beam mirror plus Buzz inbound/lifecycle tests: 33/33 passed.
- `pnpm tsgo:prod`: passed.
- `pnpm tsgo:test`: passed.
- Extension package-boundary compile: all 125 plugins passed.
- Scoped `pnpm check:changed` for Beam and Buzz: passed, including format, production/test extension types, lint, plugin boundaries, dead-code scans, storage guards, and import-cycle checks.
- Fresh autoreview: clean, no accepted/actionable findings; patch correct at 0.95 confidence.