### PR TITLE
fix(systemd): clear start-limit latch before gateway start

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -862,6 +862,23 @@ describe("system-scope gateway unit detection (openclaw#87577)", () => {
     expect(requireFirstWrite(write)).toContain("Restarted systemd service");
   });
 
+  it("startSystemdService clears the start-limit latch before starting the system unit", async () => {
+    mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-gateway.service" });
+    mockEffectiveUid(0);
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["reset-failed", GATEWAY_SERVICE]);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["start", GATEWAY_SERVICE]);
+        cb(null, "", "");
+      });
+    const { stdout, write } = createWritableStreamMock();
+    await startSystemdService({ stdout, env: { HOME: TEST_MANAGED_HOME } });
+    expect(requireFirstWrite(write)).toContain("Started systemd service");
+  });
+
   it("stopSystemdService surfaces sudo guidance for system-scope units without root", async () => {
     mockUnitFileLayout({ system: "/etc/systemd/system/openclaw-gateway.service" });
     mockEffectiveUid(1000);

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -2738,6 +2738,10 @@ describe("systemd service control", () => {
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "start", GATEWAY_SERVICE);
         cb(null, "", "");
       });
@@ -2845,6 +2849,28 @@ describe("systemd service control", () => {
     // reset-failed must clear any start-limit-hit latch before the restart so a
     // crash-looped unit can recover.
     expect(restartSequence).toEqual(["reset-failed", "restart"]);
+  });
+
+  it("runs reset-failed before starting a crash-looped user unit", async () => {
+    const startSequence: string[] = [];
+    execFileMock
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
+        startSequence.push(args[1] ?? "");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "start", GATEWAY_SERVICE);
+        startSequence.push(args[1] ?? "");
+        cb(null, "", "");
+      });
+    const { write, stdout } = createWritableStreamMock();
+    await startSystemdService({ stdout, env: {} });
+    // start must clear the latch too, so `openclaw gateway start` recovers a
+    // crash-looped unit just like restart (mirrors launchd start's enable).
+    expect(startSequence).toEqual(["reset-failed", "start"]);
+    expect(requireFirstWrite(write)).toContain("Started systemd service");
   });
 
   it("surfaces stop failures with systemctl detail", async () => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -2890,6 +2890,26 @@ describe("systemd service control", () => {
     expect(requireFirstWrite(write)).toContain("Started systemd service");
   });
 
+  it("tolerates reset-failed as a no-op on a healthy start", async () => {
+    // reset-failed is idempotent: on a non-failed unit systemd returns success
+    // and leaves the unit untouched, so prepending it to start cannot regress a
+    // healthy gateway. Assert the start still proceeds and succeeds when
+    // reset-failed exits 0 with no failed state to clear.
+    execFileMock
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
+        cb(null, "", ""); // healthy unit: no failed state, exit 0
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "start", GATEWAY_SERVICE);
+        cb(null, "", "");
+      });
+    const { write, stdout } = createWritableStreamMock();
+    await startSystemdService({ stdout, env: {} });
+    expect(requireFirstWrite(write)).toContain("Started systemd service");
+  });
+
   it("surfaces stop failures with systemctl detail", async () => {
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -2752,14 +2752,17 @@ describe("systemd service control", () => {
   });
 
   it("starts the resolved user unit and ignores audit observer failures", async () => {
+    const sequence: string[] = [];
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
+        sequence.push(args[1] ?? "");
         cb(null, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "start", GATEWAY_SERVICE);
+        sequence.push(args[1] ?? "");
         cb(null, "", "");
       });
     const write = vi.fn();
@@ -2775,6 +2778,7 @@ describe("systemd service control", () => {
       }),
     ).resolves.toBeUndefined();
 
+    expect(sequence).toEqual(["reset-failed", "start"]);
     expect(onMutation).toHaveBeenCalledWith({ mode: "systemctl-start" });
     expect(
       expectDefined(onMutation.mock.invocationCallOrder[0], "start audit call order"),
@@ -2782,11 +2786,41 @@ describe("systemd service control", () => {
     expect(requireFirstWrite(write)).toContain("Started systemd service");
   });
 
+  it("still starts when reset-failed cannot resolve an unloaded user unit", async () => {
+    const sequence: string[] = [];
+    execFileMock
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
+        sequence.push(args[1] ?? "");
+        cb(
+          createExecFileError("unit not loaded", {
+            stderr: `Unit ${GATEWAY_SERVICE} not loaded.`,
+          }),
+          "",
+          `Unit ${GATEWAY_SERVICE} not loaded.`,
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "start", GATEWAY_SERVICE);
+        sequence.push(args[1] ?? "");
+        cb(null, "", "");
+      });
+    const { stdout, write } = createWritableStreamMock();
+
+    await startSystemdService({ stdout, env: {} });
+
+    expect(sequence).toEqual(["reset-failed", "start"]);
+    expect(requireFirstWrite(write)).toContain("Started systemd service");
+  });
+
   it("stops the resolved user unit", async () => {
+    const sequence: string[] = [];
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "stop", GATEWAY_SERVICE);
+        sequence.push(args[1] ?? "");
         cb(null, "", "");
       });
     const write = vi.fn();
@@ -2795,6 +2829,7 @@ describe("systemd service control", () => {
 
     await stopSystemdService({ stdout, env: {}, onMutation });
 
+    expect(sequence).toEqual(["stop"]);
     expect(write).toHaveBeenCalledTimes(1);
     expect(requireFirstWrite(write)).toContain("Stopped systemd service");
     expect(onMutation).toHaveBeenCalledWith({ mode: "systemctl-stop" });
@@ -2866,48 +2901,6 @@ describe("systemd service control", () => {
     // reset-failed must clear any start-limit-hit latch before the restart so a
     // crash-looped unit can recover.
     expect(restartSequence).toEqual(["reset-failed", "restart"]);
-  });
-
-  it("runs reset-failed before starting a crash-looped user unit", async () => {
-    const startSequence: string[] = [];
-    execFileMock
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
-        startSequence.push(args[1] ?? "");
-        cb(null, "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "start", GATEWAY_SERVICE);
-        startSequence.push(args[1] ?? "");
-        cb(null, "", "");
-      });
-    const { write, stdout } = createWritableStreamMock();
-    await startSystemdService({ stdout, env: {} });
-    // start must clear the latch too, so `openclaw gateway start` recovers a
-    // crash-looped unit just like restart (mirrors launchd start's enable).
-    expect(startSequence).toEqual(["reset-failed", "start"]);
-    expect(requireFirstWrite(write)).toContain("Started systemd service");
-  });
-
-  it("tolerates reset-failed as a no-op on a healthy start", async () => {
-    // reset-failed is idempotent: on a non-failed unit systemd returns success
-    // and leaves the unit untouched, so prepending it to start cannot regress a
-    // healthy gateway. Assert the start still proceeds and succeeds when
-    // reset-failed exits 0 with no failed state to clear.
-    execFileMock
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
-        cb(null, "", ""); // healthy unit: no failed state, exit 0
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "start", GATEWAY_SERVICE);
-        cb(null, "", "");
-      });
-    const { write, stdout } = createWritableStreamMock();
-    await startSystemdService({ stdout, env: {} });
-    expect(requireFirstWrite(write)).toContain("Started systemd service");
   });
 
   it("surfaces stop failures with systemctl detail", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1593,11 +1593,12 @@ async function runSystemdServiceAction(params: {
         `${unitName} is a system-scope unit (${installed.unitPath}); run \`sudo systemctl ${params.action} ${unitName}\` to ${params.action} it`,
       );
     }
-    if (params.action === "restart") {
+    if (params.action !== "stop") {
       // systemd latches a unit into failed/start-limit-hit after it crashes faster
       // than StartLimitBurst allows and then stops auto-restarting it. Clear the
-      // latch first so an operator restart can recover a crash-looped gateway;
-      // reset-failed is idempotent and a no-op on a healthy unit.
+      // latch before start/restart so an operator can recover a crash-looped
+      // gateway with the natural `openclaw gateway start` command; reset-failed is
+      // idempotent and a no-op on a healthy unit.
       await execSystemctl(["reset-failed", unitName], env);
     }
     const res = await execSystemctl([params.action, unitName], env);
@@ -1611,10 +1612,9 @@ async function runSystemdServiceAction(params: {
   await assertSystemdAvailable(env);
   if (params.action !== "stop") {
     await assertNoSystemGatewayOwnership(env);
-  }
-  if (params.action === "restart") {
-    // Clear any failed/start-limit-hit latch before restart so a crash-looped
-    // gateway recovers (see system-scope branch above). Idempotent on healthy units.
+    // Clear any failed/start-limit-hit latch before start/restart so a
+    // crash-looped gateway recovers (see system-scope branch above). Idempotent on
+    // healthy units.
     await execSystemctlUser(env, ["reset-failed", unitName]);
   }
   const res = await execSystemctlUser(env, [params.action, unitName]);

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1597,8 +1597,7 @@ async function runSystemdServiceAction(params: {
       // systemd latches a unit into failed/start-limit-hit after it crashes faster
       // than StartLimitBurst allows and then stops auto-restarting it. Clear the
       // latch before start/restart so an operator can recover a crash-looped
-      // gateway with the natural `openclaw gateway start` command; reset-failed is
-      // idempotent and a no-op on a healthy unit.
+      // gateway with the natural start command. Idempotent on healthy units.
       await execSystemctl(["reset-failed", unitName], env);
     }
     const res = await execSystemctl([params.action, unitName], env);
@@ -1612,9 +1611,8 @@ async function runSystemdServiceAction(params: {
   await assertSystemdAvailable(env);
   if (params.action !== "stop") {
     await assertNoSystemGatewayOwnership(env);
-    // Clear any failed/start-limit-hit latch before start/restart so a
-    // crash-looped gateway recovers (see system-scope branch above). Idempotent on
-    // healthy units.
+    // Clear the same latch for user-scope start/restart after the ownership
+    // guard, so a conflicting system unit is never mutated.
     await execSystemctlUser(env, ["reset-failed", unitName]);
   }
   const res = await execSystemctlUser(env, [params.action, unitName]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw gateway start` could not recover
a systemd-managed gateway after repeated crashes tripped systemd's start-limit
latch. `restart` already cleared that latch, but `start` did not.

Fixes #116177.

## Why This Change Was Made

Run `systemctl reset-failed` before both `start` and `restart`, while leaving
`stop` unchanged. The change stays in the shared systemd service-action owner,
after the existing system-unit ownership guard for user services. No config,
protocol, or new command surface is added.

## User Impact

`openclaw gateway start` now recovers a crash-looped systemd gateway instead of
returning a start-limit failure that requires an undocumented manual
`systemctl reset-failed`.

## Evidence

### Real managed-gateway CLI recovery

Validated on Linux with systemd 255 running as PID 1, using the built OpenClaw
CLI and a real OpenClaw-managed user gateway:

1. `openclaw gateway install --json` installed and enabled
   `openclaw-gateway.service`.
2. A controlled crashing gateway process forced three rapid restarts. The unit
   reached `failed`, with `NRestarts=3`.
3. Raw `systemctl --user start openclaw-gateway.service` returned nonzero;
   `systemctl status` reported `Start request repeated too quickly`.
4. After switching the gateway process healthy,
   `openclaw gateway start --json` succeeded and the unit reached
   `ActiveState=active`.
5. `strace` captured this ordering from the real CLI:

```text
systemctl --user reset-failed openclaw-gateway.service
systemctl --user start openclaw-gateway.service
```

Lifecycle controls on the same managed gateway:

- Starting an already-active healthy gateway returned `already-running`, kept
  the same main PID, and issued no `reset-failed`.
- `openclaw gateway stop --force --json` reached inactive and issued `stop`
  without `reset-failed`.
- Starting the clean inactive gateway reached active with
  reset-before-start ordering.

Hosted build and Linux proof:
https://github.com/openclaw/openclaw/actions/runs/30511918775

### Focused tests

`node scripts/run-vitest.mjs src/daemon/systemd.test.ts` passed 129/129.

Coverage includes:

- system-scope start issues `reset-failed` before `start`;
- user-scope start issues `reset-failed` before `start`;
- start still proceeds when `reset-failed` cannot resolve an unloaded unit;
- stop issues only `stop`;
- existing restart ordering and ownership-guard coverage remain green.

Targeted formatting and `git diff --check` passed.

### Autoreview

Structured Codex autoreview on final head `49c4237bcb4` found no
accepted/actionable findings. TruffleHog and `git diff --check` were clean.

### Remaining proof boundary

The real managed user-scope CLI path is fully exercised. A separate synthetic
system-scope CLI control could not complete because the isolated Testbox root
environment was rejected by OpenClaw's canonical service-target guard. The
system-scope command ordering is covered by the focused unit test and uses the
same `runSystemdServiceAction` implementation.
