### PR TITLE
fix(whatsapp): silently drops inbound messages when more than 450 are waiting

### DIFF
--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import type { WAMessage } from "baileys";
 import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   deserializeWhatsAppDurableInboundMessage,
   serializeWhatsAppDurableInboundMessage,
@@ -194,6 +194,43 @@ describe("createWhatsAppIngressMonitor", () => {
     });
   });
 
+  it("dispatches accepted pending records older than the legacy 30-day TTL", async () => {
+    await withTempState(async (stateDir) => {
+      const thirtyOneDaysAgo = Date.now() - 31 * 24 * 60 * 60 * 1_000;
+      const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
+        channelId: "whatsapp",
+        accountId: "acct",
+        stateDir,
+        now: () => thirtyOneDaysAgo,
+      });
+      await queue.enqueue(eventId("msg-old"), payload("msg-old"), {
+        laneKey: REMOTE_JID,
+        receivedAt: thirtyOneDaysAgo,
+      });
+
+      const dispatched: string[] = [];
+      const monitor = createWhatsAppIngressMonitor({
+        queue,
+        pollIntervalMs: 10,
+        dispatch: async (admission) => {
+          const id = admission.message.key.id;
+          if (!id) {
+            throw new Error("expected transport id");
+          }
+          dispatched.push(id);
+          return { kind: "completed" };
+        },
+      });
+
+      monitor.start();
+      await monitor.waitForIdle();
+      await monitor.stop();
+
+      expect(dispatched).toEqual(["msg-old"]);
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
+    });
+  });
+
   it("dispatches every accepted pending record past the legacy 450-entry cap", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
@@ -232,6 +269,34 @@ describe("createWhatsAppIngressMonitor", () => {
 
       expect(dispatched.toSorted()).toEqual(transportIds.toSorted());
       expect(await queue.listPending({ limit: "all" })).toEqual([]);
+    });
+  });
+
+  it("keeps completed and failed replay guards bounded", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
+        channelId: "whatsapp",
+        accountId: "acct",
+        stateDir,
+      });
+      const prune = vi.spyOn(queue, "prune");
+      const monitor = createWhatsAppIngressMonitor({
+        queue,
+        pollIntervalMs: 10,
+        dispatch: async () => ({ kind: "completed" }),
+      });
+
+      monitor.start();
+      await monitor.waitForIdle();
+      await monitor.stop();
+
+      expect(prune).toHaveBeenCalledWith({
+        completedTtlMs: 7 * 24 * 60 * 60 * 1_000,
+        completedMaxEntries: 5_000,
+        failedTtlMs: 30 * 24 * 60 * 60 * 1_000,
+        failedMaxEntries: 450,
+        now: expect.any(Number),
+      });
     });
   });
 });

--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -193,6 +193,47 @@ describe("createWhatsAppIngressMonitor", () => {
       await monitor.stop();
     });
   });
+
+  it("dispatches every accepted pending record past the legacy 450-entry cap", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
+        channelId: "whatsapp",
+        accountId: "acct",
+        stateDir,
+      });
+      const transportIds = Array.from(
+        { length: 451 },
+        (_unused, index) => `msg-${String(index).padStart(3, "0")}`,
+      );
+      for (const [index, transportId] of transportIds.entries()) {
+        await queue.enqueue(eventId(transportId), payload(transportId), {
+          laneKey: REMOTE_JID,
+          receivedAt: index + 1,
+        });
+      }
+
+      const dispatched: string[] = [];
+      const monitor = createWhatsAppIngressMonitor({
+        queue,
+        pollIntervalMs: 10,
+        dispatch: async (admission) => {
+          const id = admission.message.key.id;
+          if (!id) {
+            throw new Error("expected transport id");
+          }
+          dispatched.push(id);
+          return { kind: "completed" };
+        },
+      });
+
+      monitor.start();
+      await monitor.waitForIdle();
+      await monitor.stop();
+
+      expect(dispatched.toSorted()).toEqual(transportIds.toSorted());
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
+    });
+  });
 });
 
 describe("WhatsApp durable message serialization", () => {

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -132,8 +132,6 @@ export function createWhatsAppIngressMonitor(params: {
     deliver: (admission, lifecycle) => params.dispatch(admission, lifecycle),
     pollIntervalMs: params.pollIntervalMs,
     retention: {
-      pendingTtlMs: 30 * 24 * 60 * 60 * 1_000,
-      pendingMaxEntries: 450,
       completedTtlMs: 7 * 24 * 60 * 60 * 1_000,
       completedMaxEntries: 5_000,
       failedMaxEntries: 450,


### PR DESCRIPTION
Related: #50563
Related: #85506

## What Problem This Solves

WhatsApp durably accepts each inbound `messages.upsert` before agent dispatch, but its shared ingress monitor was configured to hard-delete pending rows after 30 days or above 450 entries.

Pending rows are accepted, undelivered work. The monitor prunes before its first claim, so a restart with 451 queued messages deleted the oldest message before dispatch. A pending row older than 30 days was deleted the same way. Both paths removed the payload and durable identity without a tombstone, failure record, or warning.

## Why This Change Was Made

Remove only WhatsApp's `pendingTtlMs` and `pendingMaxEntries` overrides. Completed and failed replay guards remain bounded:

- completed: 7-day TTL and 5,000 entries
- failed: inherited 30-day TTL and 450 entries

This is the correct plugin-owner boundary. Shared core is enforcing an explicit pruning API, and all 20 sibling shared-monitor adapters omit pending retention. The fix does not add configuration, change the SQLite schema, or weaken terminal replay-guard retention.

The limits originated in the pre-specialized-ingress-queue WhatsApp durable receive journal backed by the generic SQLite plugin-state keyed store. PR #85506 introduced the 450-entry/30-day pending journal, `b0679d1f13d` carried those bounds into `channel_ingress_events`, and #115824 later inlined them. The predecessor was durable accepted work, not a pre-SQLite replay-guard cache.

## User Impact

Accepted WhatsApp messages remain recoverable until dispatch, permanent failure, or explicit operator action. Backlogs above 450 and pending work older than 30 days no longer lose messages silently.

No migration or configuration change is required.

## Evidence

The regression suite uses the production `createWhatsAppIngressMonitor` and the real SQLite-backed ingress queue.

Legacy limits restored:

- 31-day pending row: 0 of 1 dispatched
- 451 pending rows: 450 of 451 dispatched; `msg-000` was deleted

Patched behavior:

- 31-day pending row: 1 of 1 dispatched
- 451 pending rows: 451 of 451 dispatched
- completed and failed retention options remain bounded as listed above

Focused Testbox proof:

```text
extensions/whatsapp/src/inbound/durable-receive.test.ts: 9 passed
src/channels/message/ingress-monitor.test.ts: 22 passed
src/channels/message/ingress-queue.test.ts: 30 passed
total: 61 passed
```

Additional proof:

- `pnpm check:changed`: passed, including formatting, plugin/API boundaries, dead-code scans, extension and extension-test typechecks, lint, database-first guard, and import-cycle checks
- fresh Codex autoreview: clean, no actionable findings, confidence 0.91
- `git diff --check`: passed

## Testing

- [x] Real SQLite + production WhatsApp monitor regression for the legacy 450-entry cap
- [x] Real SQLite + production WhatsApp monitor regression for the legacy 30-day TTL
- [x] Completed and failed replay-guard retention remains bounded
- [x] Focused WhatsApp and shared ingress tests on Blacksmith Testbox
- [x] Changed-file gates
- [x] Fresh autoreview
- [x] Exact-head hosted CI