### PR TITLE
fix(memory-core): MEMORY.md compaction deletes user notes written under a promotion-style heading

### DIFF
--- a/extensions/memory-core/src/memory-budget.test.ts
+++ b/extensions/memory-core/src/memory-budget.test.ts
@@ -7,8 +7,11 @@ const PROMOTION_MARKER_LINE = "<!-- openclaw-memory-promotion:memory/short-term.
 function promotionSection(date: string, sizeChars: number): string {
   const heading = `## Promoted From Short-Term Memory (${date})\n`;
   const marker = `${PROMOTION_MARKER_LINE}\n`;
-  const padding = "x".repeat(Math.max(0, sizeChars - heading.length - marker.length));
-  return `${heading}${marker}${padding}`;
+  const entryPrefix = "- ";
+  const padding = "x".repeat(
+    Math.max(0, sizeChars - heading.length - marker.length - entryPrefix.length),
+  );
+  return `${heading}${marker}${entryPrefix}${padding}`;
 }
 
 function markerFreeSection(date: string, body: string): string {
@@ -214,10 +217,10 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
     },
   );
 
-  it("does not treat a four-space-indented hash line as an ATX heading", () => {
+  it("preserves a generated-looking block with ambiguous indented content", () => {
     const existing =
       `${promotionSection("2026-04-10", 400)}\n` +
-      "    ### Indented code\n    keep this inside the generated block\n\n" +
+      "    ### Indented user note\n    keep this durable content\n\n" +
       promotionSection("2026-04-20", 400);
     const newSection = `\n${promotionSection("2026-04-29", 400)}`;
     const result = compactMemoryForBudget({
@@ -225,9 +228,9 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
       newSection,
       budgetChars: 900,
     });
-    expect(result.droppedDates).toContain("2026-04-10");
-    expect(result.compacted).not.toContain("### Indented code");
-    expect(result.compacted).not.toContain("keep this inside the generated block");
+    expect(result.droppedDates).not.toContain("2026-04-10");
+    expect(result.compacted).toContain("### Indented user note");
+    expect(result.compacted).toContain("keep this durable content");
   });
 
   it("preserves a user `#` section written after the only promotion section", () => {
@@ -342,7 +345,7 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
     },
   );
 
-  it("preserves a marker-free section whose heading matches the generated promotion pattern", () => {
+  it("preserves a marker-free section whose heading matches the promotion pattern", () => {
     const existing = `# Long-Term Memory\n\n${markerFreeSection(
       "2026-04-10",
       "USER-AUTHORED: recovery key is paper-copy-17",
@@ -355,42 +358,75 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
     });
     expect(result.droppedDates).toEqual([]);
     expect(result.compacted).toBe(existing);
-    expect(result.compacted).toContain("USER-AUTHORED: recovery key is paper-copy-17");
   });
 
-  it("drops only the marker-backed section when a marker-free lookalike sits beside it", () => {
+  it("drops only a clean generated section beside a marker-free lookalike", () => {
     const userSection = markerFreeSection(
       "2026-04-10",
       "USER-AUTHORED: recovery key is paper-copy-17",
     );
     const existing = `# Long-Term Memory\n\n${userSection}\n${promotionSection("2026-04-20", 600)}`;
-    const newSection = `\n${promotionSection("2026-04-29", 600)}`;
     const result = compactMemoryForBudget({
       existingMemory: existing,
-      newSection,
+      newSection: `\n${promotionSection("2026-04-29", 600)}`,
       budgetChars: 700,
     });
     expect(result.droppedDates).toEqual(["2026-04-20"]);
-    expect(result.compacted).not.toContain("(2026-04-20)");
-    expect(result.compacted).toContain("## Promoted From Short-Term Memory (2026-04-10)");
     expect(result.compacted).toContain("USER-AUTHORED: recovery key is paper-copy-17");
+    expect(result.compacted).not.toContain("(2026-04-20)");
   });
 
-  it("still drops a marker-backed multi-project section that a user heading follows", () => {
-    const existing =
-      `${projectGroupedSection("2026-04-10")}\n` +
-      "### Global\n\nMy own global rule, not a promoted entry.\n\n" +
-      projectGroupedSection("2026-04-20");
-    const newSection = `\n${projectGroupedSection("2026-04-29")}`;
+  it("preserves a marker-only promotion-shaped block", () => {
+    const existing = [
+      "## Promoted From Short-Term Memory (2026-04-10)",
+      PROMOTION_MARKER_LINE,
+      "",
+    ].join("\n");
     const result = compactMemoryForBudget({
       existingMemory: existing,
-      newSection,
+      newSection: `\n${promotionSection("2026-04-29", 600)}`,
+      budgetChars: 400,
+    });
+    expect(result.droppedDates).toEqual([]);
+    expect(result.compacted).toBe(existing);
+  });
+
+  it("preserves an entire mixed block when user text follows a generated entry", () => {
+    const existing = [
+      promotionSection("2026-04-10", 400),
+      "",
+      "USER-AUTHORED: keep this unheaded durable note.",
+      "",
+      promotionSection("2026-04-20", 400),
+    ].join("\n");
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection: `\n${promotionSection("2026-04-29", 400)}`,
       budgetChars: 900,
     });
-    expect(result.droppedDates).toContain("2026-04-10");
-    expect(result.compacted).not.toContain("### Project: alpha");
-    expect(result.compacted).toContain("### Global");
-    expect(result.compacted).toContain("My own global rule, not a promoted entry.");
+    expect(result.droppedDates).toEqual(["2026-04-20"]);
+    expect(result.compacted).toContain("(2026-04-10)");
+    expect(result.compacted).toContain("USER-AUTHORED: keep this unheaded durable note.");
+    expect(result.compacted).not.toContain("(2026-04-20)");
+  });
+
+  it("preserves a block with user text between generated entries", () => {
+    const existing = [
+      "## Promoted From Short-Term Memory (2026-04-10)",
+      PROMOTION_MARKER_LINE,
+      "- first generated entry",
+      "USER-AUTHORED: this line is not owned by either marker.",
+      "<!-- openclaw-memory-promotion:memory/short-term.md#second -->",
+      "- second generated entry",
+      "",
+    ].join("\n");
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection: `\n${promotionSection("2026-04-29", 600)}`,
+      budgetChars: 400,
+    });
+    expect(result.droppedDates).toEqual([]);
+    expect(result.compacted).toBe(existing);
   });
 
   it("exposes a sane default budget below the bootstrap injection cap", () => {

--- a/extensions/memory-core/src/memory-budget.test.ts
+++ b/extensions/memory-core/src/memory-budget.test.ts
@@ -2,10 +2,17 @@
 import { describe, expect, it } from "vitest";
 import { compactMemoryForBudget, DEFAULT_MEMORY_FILE_MAX_CHARS } from "./memory-budget.js";
 
+const PROMOTION_MARKER_LINE = "<!-- openclaw-memory-promotion:memory/short-term.md#entry -->";
+
 function promotionSection(date: string, sizeChars: number): string {
   const heading = `## Promoted From Short-Term Memory (${date})\n`;
-  const padding = "x".repeat(Math.max(0, sizeChars - heading.length));
-  return `${heading}${padding}`;
+  const marker = `${PROMOTION_MARKER_LINE}\n`;
+  const padding = "x".repeat(Math.max(0, sizeChars - heading.length - marker.length));
+  return `${heading}${marker}${padding}`;
+}
+
+function markerFreeSection(date: string, body: string): string {
+  return `## Promoted From Short-Term Memory (${date})\n${body}\n`;
 }
 
 function projectGroupedSection(date: string): string {
@@ -334,6 +341,57 @@ describe("compactMemoryForBudget — bounded MEMORY.md compaction (regression fo
       expect(result.compacted).toContain("Keep this user-authored paragraph.");
     },
   );
+
+  it("preserves a marker-free section whose heading matches the generated promotion pattern", () => {
+    const existing = `# Long-Term Memory\n\n${markerFreeSection(
+      "2026-04-10",
+      "USER-AUTHORED: recovery key is paper-copy-17",
+    )}`;
+    const newSection = `\n${promotionSection("2026-04-29", 600)}`;
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection,
+      budgetChars: 400,
+    });
+    expect(result.droppedDates).toEqual([]);
+    expect(result.compacted).toBe(existing);
+    expect(result.compacted).toContain("USER-AUTHORED: recovery key is paper-copy-17");
+  });
+
+  it("drops only the marker-backed section when a marker-free lookalike sits beside it", () => {
+    const userSection = markerFreeSection(
+      "2026-04-10",
+      "USER-AUTHORED: recovery key is paper-copy-17",
+    );
+    const existing = `# Long-Term Memory\n\n${userSection}\n${promotionSection("2026-04-20", 600)}`;
+    const newSection = `\n${promotionSection("2026-04-29", 600)}`;
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection,
+      budgetChars: 700,
+    });
+    expect(result.droppedDates).toEqual(["2026-04-20"]);
+    expect(result.compacted).not.toContain("(2026-04-20)");
+    expect(result.compacted).toContain("## Promoted From Short-Term Memory (2026-04-10)");
+    expect(result.compacted).toContain("USER-AUTHORED: recovery key is paper-copy-17");
+  });
+
+  it("still drops a marker-backed multi-project section that a user heading follows", () => {
+    const existing =
+      `${projectGroupedSection("2026-04-10")}\n` +
+      "### Global\n\nMy own global rule, not a promoted entry.\n\n" +
+      projectGroupedSection("2026-04-20");
+    const newSection = `\n${projectGroupedSection("2026-04-29")}`;
+    const result = compactMemoryForBudget({
+      existingMemory: existing,
+      newSection,
+      budgetChars: 900,
+    });
+    expect(result.droppedDates).toContain("2026-04-10");
+    expect(result.compacted).not.toContain("### Project: alpha");
+    expect(result.compacted).toContain("### Global");
+    expect(result.compacted).toContain("My own global rule, not a promoted entry.");
+  });
 
   it("exposes a sane default budget below the bootstrap injection cap", () => {
     // Bootstrap injection is capped at 12_000 chars per file (see

--- a/extensions/memory-core/src/memory-budget.ts
+++ b/extensions/memory-core/src/memory-budget.ts
@@ -9,12 +9,9 @@
  *
  * Strategy: drop the OLDEST auto-promoted sections (date-ordered) until
  * the file plus the new section fit within the budget. A section counts as
- * dreaming-owned only when a `## Promoted From Short-Term Memory (DATE)`
- * heading is backed by at least one authoritative
- * `<!-- openclaw-memory-promotion:... -->` marker, which every generated
- * section carries (see `buildPromotionSection`). Everything else, including
- * user-authored content under a heading that merely looks generated, is
- * preserved unconditionally.
+ * dreaming-owned only when its complete body matches the marker + entry
+ * structure emitted by `buildPromotionSection`. Ambiguous or mixed content
+ * is preserved unconditionally.
  */
 
 const PROMOTION_SECTION_HEADING_RE = /^## Promoted From Short-Term Memory \(([^)]+)\)\s*$/;
@@ -49,8 +46,37 @@ type MemoryBlock =
   | { kind: "preserved"; text: string }
   | { kind: "promotion"; date: string; text: string };
 
-function hasPromotionEntryMarker(lines: string[]): boolean {
-  return lines.some((line) => PROMOTION_ENTRY_MARKER_RE.test(line));
+function isGeneratedPromotionBlock(lines: string[]): boolean {
+  let sawEntry = false;
+  let index = 1;
+
+  while (index < lines.length) {
+    const line = lines[index] ?? "";
+    if (line.trim().length === 0) {
+      index += 1;
+      continue;
+    }
+
+    if (PROMOTION_SUBSECTION_HEADING_RE.test(line)) {
+      index += 1;
+      while (index < lines.length && (lines[index] ?? "").trim().length === 0) {
+        index += 1;
+      }
+    }
+
+    if (!PROMOTION_ENTRY_MARKER_RE.test(lines[index] ?? "")) {
+      return false;
+    }
+    // A marker owns only the single bullet emitted with it. Treat any other
+    // body shape as mixed user content so compaction cannot delete it.
+    if (!(lines[index + 1] ?? "").startsWith("- ")) {
+      return false;
+    }
+    sawEntry = true;
+    index += 2;
+  }
+
+  return sawEntry;
 }
 
 function startsGeneratedPromotionSubsection(lines: string[], index: number): boolean {
@@ -76,7 +102,7 @@ function takeSetextHeadingLines(lines: string[]): string[] | undefined {
     return undefined;
   }
   const headingLines = lines.slice(start);
-  if (hasPromotionEntryMarker(headingLines)) {
+  if (headingLines.some((line) => PROMOTION_ENTRY_MARKER_RE.test(line))) {
     return undefined;
   }
   lines.splice(start);
@@ -98,7 +124,7 @@ function parseMemoryBlocks(content: string): MemoryBlock[] {
       return;
     }
     const text = currentLines.join("\n");
-    if (currentKind === "promotion" && currentDate && hasPromotionEntryMarker(currentLines)) {
+    if (currentKind === "promotion" && currentDate && isGeneratedPromotionBlock(currentLines)) {
       blocks.push({ kind: "promotion", date: currentDate, text });
     } else {
       blocks.push({ kind: "preserved", text });
@@ -159,8 +185,8 @@ type CompactMemoryResult = {
  *
  * Guarantees:
  * - Non-promotion content (user-authored markdown, the file header, any
- *   heading of any level not matching the promotion pattern, and any
- *   matching heading whose section carries no promotion marker) is preserved.
+ *   heading of any level not matching the promotion pattern, and any mixed
+ *   or malformed promotion-shaped block) is preserved.
  * - Promotion sections are dropped in ascending date order (oldest first).
  * - If `existingMemory + newSection` already fits the budget, the existing
  *   memory is returned unchanged.

--- a/extensions/memory-core/src/memory-budget.ts
+++ b/extensions/memory-core/src/memory-budget.ts
@@ -8,10 +8,13 @@
  * See issue #73691.
  *
  * Strategy: drop the OLDEST auto-promoted sections (date-ordered) until
- * the file plus the new section fit within the budget. User-authored
- * content (anything that is not a `## Promoted From Short-Term Memory
- * (DATE)` section) is preserved unconditionally — only dreaming-owned
- * sections are eligible for compaction.
+ * the file plus the new section fit within the budget. A section counts as
+ * dreaming-owned only when a `## Promoted From Short-Term Memory (DATE)`
+ * heading is backed by at least one authoritative
+ * `<!-- openclaw-memory-promotion:... -->` marker, which every generated
+ * section carries (see `buildPromotionSection`). Everything else, including
+ * user-authored content under a heading that merely looks generated, is
+ * preserved unconditionally.
  */
 
 const PROMOTION_SECTION_HEADING_RE = /^## Promoted From Short-Term Memory \(([^)]+)\)\s*$/;
@@ -46,6 +49,10 @@ type MemoryBlock =
   | { kind: "preserved"; text: string }
   | { kind: "promotion"; date: string; text: string };
 
+function hasPromotionEntryMarker(lines: string[]): boolean {
+  return lines.some((line) => PROMOTION_ENTRY_MARKER_RE.test(line));
+}
+
 function startsGeneratedPromotionSubsection(lines: string[], index: number): boolean {
   if (!PROMOTION_SUBSECTION_HEADING_RE.test(lines[index] ?? "")) {
     return false;
@@ -69,7 +76,7 @@ function takeSetextHeadingLines(lines: string[]): string[] | undefined {
     return undefined;
   }
   const headingLines = lines.slice(start);
-  if (headingLines.some((line) => PROMOTION_ENTRY_MARKER_RE.test(line))) {
+  if (hasPromotionEntryMarker(headingLines)) {
     return undefined;
   }
   lines.splice(start);
@@ -91,7 +98,7 @@ function parseMemoryBlocks(content: string): MemoryBlock[] {
       return;
     }
     const text = currentLines.join("\n");
-    if (currentKind === "promotion" && currentDate) {
+    if (currentKind === "promotion" && currentDate && hasPromotionEntryMarker(currentLines)) {
       blocks.push({ kind: "promotion", date: currentDate, text });
     } else {
       blocks.push({ kind: "preserved", text });
@@ -152,7 +159,8 @@ type CompactMemoryResult = {
  *
  * Guarantees:
  * - Non-promotion content (user-authored markdown, the file header, any
- *   heading of any level not matching the promotion pattern) is preserved.
+ *   heading of any level not matching the promotion pattern, and any
+ *   matching heading whose section carries no promotion marker) is preserved.
  * - Promotion sections are dropped in ascending date order (oldest first).
  * - If `existingMemory + newSection` already fits the budget, the existing
  *   memory is returned unchanged.

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -3712,6 +3712,74 @@ describe("short-term promotion", () => {
   });
 
   describe("MEMORY.md budget compaction (#73691)", () => {
+    it("preserves mixed marker-backed user text during a real promotion write", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        await writeDailyMemoryNote(workspaceDir, "2026-04-29", [
+          "Notes",
+          "",
+          "Rotate the staging Postgres credentials before next deploy.",
+        ]);
+
+        const memoryPath = path.join(workspaceDir, "MEMORY.md");
+        const filler = "x".repeat(600);
+        const seeded = [
+          "# Long-Term Memory",
+          "",
+          "## Promoted From Short-Term Memory (2026-04-10)",
+          "<!-- openclaw-memory-promotion:legacy-mixed -->",
+          `- ${filler}`,
+          "",
+          "USER-AUTHORED: recovery key is paper-copy-17",
+          "",
+          "## Promoted From Short-Term Memory (2026-04-20)",
+          "<!-- openclaw-memory-promotion:legacy-generated -->",
+          `- ${filler}`,
+          "",
+        ].join("\n");
+        await fs.writeFile(memoryPath, seeded, "utf-8");
+
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "rotate creds",
+          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
+          results: [
+            {
+              path: "memory/2026-04-29.md",
+              startLine: 3,
+              endLine: 3,
+              score: 0.96,
+              snippet: "Rotate the staging Postgres credentials before next deploy.",
+              source: "memory",
+            },
+          ],
+        });
+
+        const ranked = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+        });
+        const applied = await applyShortTermPromotions({
+          workspaceDir,
+          candidates: ranked,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+          nowMs: Date.parse("2026-04-29T10:00:00.000Z"),
+          memoryFileMaxChars: 1_400,
+        });
+
+        expect(applied.applied).toBe(1);
+        expect(applied.compactedDates).toEqual(["2026-04-20"]);
+        const memoryText = await fs.readFile(memoryPath, "utf-8");
+        expect(memoryText).toContain("legacy-mixed");
+        expect(memoryText).toContain("USER-AUTHORED: recovery key is paper-copy-17");
+        expect(memoryText).not.toContain("legacy-generated");
+        expect(memoryText).toContain("Rotate the staging Postgres credentials");
+      });
+    });
+
     it("preserves an indented user ATX heading when compaction writes MEMORY.md", async () => {
       await withTempWorkspace(async (workspaceDir) => {
         await writeDailyMemoryNote(workspaceDir, "2026-04-29", [

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -93,6 +93,7 @@ describe("memory search citations", () => {
     return result;
   }
 
+  // The first tool call pays Vitest's cold lazy-runtime transform cost on Node 24 CI.
   it("appends source information when citations are enabled", async () => {
     setMemoryBackend("builtin");
     const cfg = asOpenClawConfig({
@@ -105,7 +106,7 @@ describe("memory search citations", () => {
     const firstResult = expectFirstMemoryResult(details);
     expect(firstResult.snippet).toMatch(/Source: MEMORY.md#L5-L7/);
     expect(firstResult.citation).toBe("MEMORY.md#L5-L7");
-  });
+  }, 180_000);
 
   it("leaves snippet untouched when citations are off", async () => {
     setMemoryBackend("builtin");


### PR DESCRIPTION
Related: #116057

## What Problem This Solves

Budget compaction could silently delete durable operator notes from `MEMORY.md` when a top-level heading resembled generated promotion history. The original patch correctly rejected heading-only ownership, but one marker still claimed the entire accumulated block, including unheaded user prose after a generated entry.

This is a shipped P1 data-integrity bug in `v2026.7.2-beta.5` and remained present on `main`.

## Best Fix

Compaction now treats a promotion-shaped block as OpenClaw-owned only when its complete nonblank body matches the grammar emitted by `buildPromotionSection`:

- optional marker-backed `### Global` / `### Project:` headings;
- an `<!-- openclaw-memory-promotion:... -->` marker;
- the immediately following single-line `- ` entry.

Marker-free, marker-only, malformed, or mixed blocks are preserved whole. A marker authenticates its generated entry, not arbitrary trailing operator text. Genuine generated blocks remain eligible for oldest-first compaction.

## User Impact

Durable notes survive budget pressure even when they use a promotion-style heading or sit unheaded after generated entries. No config, migration, schema, or operator action changes.

## Evidence

Exact repaired head: `c976279982759d9ba7825c1f62f0541ad71c72c3`.

- `memory-budget.test.ts`: 30 tests passed.
- `short-term-promotion.test.ts`: 85 tests passed.
- Blacksmith Testbox `tbx_01kyryz9gy6xe62pw7d91pk5dn`: 143 focused tests passed, including the cold citation startup regression.
- Current merge-result proof: 115/115 compaction and promotion tests passed on `c9762799827` merged into live `main` `cc570a74532e` in Testbox `tbx_01kys1qtmatt5nw3skv32m96z0`.
- Real filesystem + SQLite-backed recall/ranking/apply/write regression proves a mixed block sentinel survives while a clean generated neighbor is compacted.
- `pnpm check:changed` passed on the same Testbox lease, including extension production/test typechecks, lint, format, ownership guards, deadcode, database-first, and import-cycle checks.
- Fresh autoreview: clean, no accepted/actionable findings, 0.99 confidence.

Hosted exact-head CI run `30524117587` is green, including `checks-node-changed-3` and `openclaw/ci-gate`. Latest ClawSweeper review found no code defect; its current-merge-result rank-up move is satisfied by the proof above.

## Attribution

Original diagnosis and marker-ownership direction by @yetval. Maintainer repair preserves contributor ancestry and co-author credit.