### PR TITLE
fix(beam): release mirror upload response bodies

### DIFF
--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -101,6 +101,24 @@ function captureFetch(sent: SentRequest[], status = 200): typeof fetch {
 
 const silentLogger = { warn: () => {}, info: () => {} };
 
+// Returns a fetch whose responses stream an unread body; the source `cancel`
+// increments the counter so a test can assert the caller released the body.
+function cancelTrackingFetch(status = 200): { fetchFn: typeof fetch; canceled: () => number } {
+  let canceled = 0;
+  const fetchFn = (async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{}"));
+      },
+      cancel() {
+        canceled += 1;
+      },
+    });
+    return new Response(body, { status });
+  }) as typeof fetch;
+  return { fetchFn, canceled: () => canceled };
+}
+
 describe("parseBeamMirrorConfig", () => {
   it("returns undefined without mirror config", () => {
     expect(parseBeamMirrorConfig({ plugins: { entries: { beam: { enabled: true } } } })).toBe(
@@ -352,5 +370,38 @@ describe("createBeamMirrorRunner", () => {
     });
     await runner.tick();
     expect(sent).toHaveLength(0);
+  });
+
+  // Beam only reads the upload status; the unread response body must be
+  // released so a slow/non-terminating receiver cannot retain a connection
+  // slot and stall later retries (Undici requires consuming or canceling it).
+  it("cancels the response body after a successful upload", async () => {
+    const { fetchFn, canceled } = cancelTrackingFetch(200);
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: silentLogger,
+      fetchFn,
+      now: () => NOW,
+      listCatalogs: () => [
+        fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW - 60_000 }] }),
+      ],
+    });
+    await runner.tick();
+    expect(canceled()).toBe(1);
+  });
+
+  it("cancels the response body after a rejected upload", async () => {
+    const { fetchFn, canceled } = cancelTrackingFetch(503);
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: silentLogger,
+      fetchFn,
+      now: () => NOW,
+      listCatalogs: () => [
+        fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW - 60_000 }] }),
+      ],
+    });
+    await runner.tick();
+    expect(canceled()).toBe(1);
   });
 });

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -293,6 +293,10 @@ export function createBeamMirrorRunner(params: {
       },
       body: JSON.stringify(payload),
     });
+    // Beam only needs the upload status; release the unread response body so a
+    // slow or non-terminating receiver cannot retain a connection slot and
+    // stall later mirror retries (Undici requires callers to consume/cancel).
+    await response.body?.cancel().catch(() => undefined);
     if (!response.ok) {
       warnThrottled(`beam mirror upload failed (${response.status}) for ${payload.source}`);
       return false;


### PR DESCRIPTION
## What Problem This Solves

Beam mirror uploads never consume or cancel the HTTP response body. `upload()` in `extensions/beam/src/mirror.ts` reads only `response.ok`/`response.status` and returns on both the success and error paths, leaving `response.body` unread. Under Undici (Node's `fetch`), an unread body holds its connection until garbage collection, so a slow or non-terminating receiver/proxy response retains a connection slot and stalls later mirror retries — over time this can wedge the mirror poll loop behind a single stuck response.

## Why This Change Was Made

Beam only needs the upload status, so the body should be released as soon as the status is known. Canceling it immediately after the fetch — before the existing non-OK handling — covers both 2xx and error responses with no new API or configuration surface. This matches Undici's documented requirement that callers always consume or cancel response bodies, and the established repo idiom (`await response.body?.cancel().catch(() => undefined)` is used at ~10 sites under `src/infra`). It is the narrowest correct fix at the leaf function that owns the request.

## User Impact

Beam mirror retries no longer stall behind an unread response body; each upload releases its transport connection immediately. No wire, API, or configuration change — behavior is identical except that a leaked connection slot is now freed.

## Evidence

**Focused unit tests** — `node scripts/run-vitest.mjs extensions/beam/src/mirror.test.ts`

Two colocated tests drive the real `createBeamMirrorRunner().tick() → upload()` path with an injected fetch whose response-body `cancel` is observed, asserting the body is canceled exactly once on both a 200 and a 503 upload.

- RED (before the fix): `canceled` = 0 on both the 200 and 503 paths — the body is never released.
- GREEN (after the fix): both paths cancel the body once.
- Full `beam` suite: 24 passed. Typecheck `tsgo:extensions` + `tsgo:extensions:test` exit 0; `oxfmt` clean.

**Real-transport proof (real undici one-connection dispatcher)**

The unit tests assert the code calls `cancel()`; this standalone repro proves the user-visible symptom and its fix through a **real undici dispatcher** (`Agent({ connections: 1 })`) against a localhost server that returns `503` with a body it never finishes — a stalled receiver. It issues `upload()`'s exact request shape, reads only the status as Beam does, then races a second upload against a 1.5s timeout.

```text
=== Beam mirror upload — real undici one-connection dispatcher ===
[LEAK  (body NOT cancelled — pre-fix behaviour)] first upload status=503; second upload -> BLOCKED (no free connection)
[FIX   (body cancelled — this PR)]               first upload status=503; second upload -> PROCEEDED (status 503)
=== done ===
```

Before the fix the unread response body holds the sole connection and the next mirror upload never gets a slot (BLOCKED); with `await response.body?.cancel()` the connection is released and the next upload proceeds. Environment: Node v24.16.0, undici 8.9.0 (same consume-or-cancel body contract as the reporter's 7.25.0). The repro is a throwaway script, not committed.

_AI-assisted._

Closes #116154
