### PR TITLE
feat(gateway): advertise chat attachment limits on hello-ok

### DIFF
--- a/docs/gateway/clients.md
+++ b/docs/gateway/clients.md
@@ -127,10 +127,12 @@ if (attachments) {
 Both values are decoded per-attachment ceilings. Still check the serialized
 request against `policy.maxPayload`: attachments travel as base64, so a file near
 `maxBytes` can exceed the frame limit on its own. Older gateways omit
-`policy.attachments`; when it is absent, send and handle the server's typed
-rejection. Accepted MIME types and per-message counts are not advertised because
-they depend on the entrypoint and the resolved model, and the values are a
-connection-time snapshot, so re-read them on every reconnect.
+`policy.attachments`; when it is absent, send and handle the server outcome.
+Accepted MIME types and per-message handling are not advertised because they
+depend on the entrypoint and the resolved model. The gateway can return a typed
+rejection, while text-only model runs can omit additional images after their
+offload cap and still complete the request. The values are a connection-time
+snapshot, so re-read them on every reconnect.
 
 ## Recover state after reconnect
 

--- a/docs/gateway/clients.md
+++ b/docs/gateway/clients.md
@@ -111,6 +111,27 @@ Capability-gated agent tools are a separate use of the same declaration. If an
 agent tool requires a client capability, the Gateway omits that tool unless the
 originating client advertised every required capability.
 
+## Validate attachments before sending
+
+Attachment limits are operator-tunable, so do not hardcode them. Read
+`hello-ok.policy.attachments` and validate locally before uploading:
+
+```ts
+const attachments = hello.policy.attachments;
+if (attachments) {
+  const ceiling = isImage ? attachments.maxImageBytes : attachments.maxBytes;
+  if (file.byteLength > ceiling) rejectLocally();
+}
+```
+
+Both values are decoded per-attachment ceilings. Still check the serialized
+request against `policy.maxPayload`: attachments travel as base64, so a file near
+`maxBytes` can exceed the frame limit on its own. Older gateways omit
+`policy.attachments`; when it is absent, send and handle the server's typed
+rejection. Accepted MIME types and per-message counts are not advertised because
+they depend on the entrypoint and the resolved model, and the values are a
+connection-time snapshot, so re-read them on every reconnect.
+
 ## Recover state after reconnect
 
 Treat every successful reconnect as a new projection over durable history and

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -181,9 +181,10 @@ Validating before send:
    promise the frame fits: attachments travel as base64, so a 20 MB file is about
    26.7 MB on the wire and exceeds the default 25 MiB frame limit on its own.
 3. Treat the server as authoritative for everything else. Accepted MIME types and
-   per-message counts are deliberately not advertised because they depend on the
-   entrypoint, the resolved model, and payload sniffing; the gateway still returns
-   a typed rejection.
+   per-message handling are deliberately not advertised because they depend on
+   the entrypoint, the resolved model, and payload sniffing. The gateway can
+   return a typed rejection, while text-only model runs can omit additional
+   images after their offload cap and still complete the request.
 4. Re-read the values on every reconnect. They are a connection-time snapshot, so
    a live `mediaMaxMb` edit reaches existing connections only after they reconnect.
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -153,7 +153,8 @@ Gateway responds with `hello-ok`:
     "policy": {
       "maxPayload": 26214400,
       "maxBufferedBytes": 52428800,
-      "tickIntervalMs": 15000
+      "tickIntervalMs": 15000,
+      "attachments": { "maxBytes": 20971520, "maxImageBytes": 6291456 }
     }
   }
 }
@@ -162,7 +163,31 @@ Gateway responds with `hello-ok`:
 `server`, `features`, `snapshot`, `policy`, and `auth` are all required by
 `HelloOkSchema` (`packages/gateway-protocol/src/schema/frames.ts`). `auth`
 reports the negotiated role/scopes even when no device token is issued (shape
-above). `pluginSurfaceUrls` is optional and maps plugin surface names (e.g.
+above). `policy.attachments` is optional (older gateways omit it) and advertises
+the decoded-size ceilings chat attachments face on `chat.send`, `sessions.send`,
+and session-creation initial turns:
+
+| Field           | Meaning                                                                                             |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| `maxBytes`      | Largest decoded size accepted for a single attachment (`agents.defaults.mediaMaxMb`, default 20 MB) |
+| `maxImageBytes` | Largest decoded size accepted for a single image: `min(maxBytes, 6 MB agent-hydration cap)`         |
+
+Validating before send:
+
+1. Check each file's decoded size against `maxImageBytes` for images and
+   `maxBytes` for everything else.
+2. Serialize the whole request and check its encoded size against
+   `policy.maxPayload`. `policy.attachments` is a per-attachment ceiling, never a
+   promise the frame fits: attachments travel as base64, so a 20 MB file is about
+   26.7 MB on the wire and exceeds the default 25 MiB frame limit on its own.
+3. Treat the server as authoritative for everything else. Accepted MIME types and
+   per-message counts are deliberately not advertised because they depend on the
+   entrypoint, the resolved model, and payload sniffing; the gateway still returns
+   a typed rejection.
+4. Re-read the values on every reconnect. They are a connection-time snapshot, so
+   a live `mediaMaxMb` edit reaches existing connections only after they reconnect.
+
+`pluginSurfaceUrls` is optional and maps plugin surface names (e.g.
 `canvas`) to scoped hosted URLs; it may expire, so nodes call
 `node.pluginSurface.refresh` with `{ "surface": "canvas" }` for a fresh entry.
 The deprecated `canvasHostUrl` / `canvasCapability` / `node.canvas.capability.refresh`
@@ -1034,10 +1059,13 @@ third-party clients.
 | Default tick interval (pre `hello-ok`)    | `30_000` ms                                           | `packages/gateway-client/src/client.ts`                                                                                   |
 | Tick-timeout close                        | code `4000` when silence exceeds `tickIntervalMs * 2` | `packages/gateway-client/src/client.ts`                                                                                   |
 | `MAX_PAYLOAD_BYTES`                       | `25 * 1024 * 1024` (25 MB)                            | `src/gateway/server-constants.ts`                                                                                         |
+| Chat attachment ceiling                   | `agents.defaults.mediaMaxMb`, default 20 MB decoded   | `src/gateway/chat-attachment-policy.ts`                                                                                   |
+| Chat attachment image ceiling             | `min(attachment ceiling, 6 MB)`                       | `src/gateway/chat-attachment-policy.ts`, `packages/media-core/src/constants.ts`                                           |
 
 The server advertises the effective `policy.tickIntervalMs`,
-`policy.maxPayload`, and `policy.maxBufferedBytes` in `hello-ok`; clients
-should honor those values rather than the pre-handshake defaults.
+`policy.maxPayload`, `policy.maxBufferedBytes`, and `policy.attachments` in
+`hello-ok`; clients should honor those values rather than the pre-handshake
+defaults or hardcoded attachment sizes.
 
 The reference client lets finite requests own their configured deadline when
 every pending request has one. An `expectFinal` request without a finite

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -138,6 +138,17 @@ export const HelloOkSchema = closedObject({
     maxPayload: Type.Integer({ minimum: 1 }),
     maxBufferedBytes: Type.Integer({ minimum: 1 }),
     tickIntervalMs: Type.Integer({ minimum: 1 }),
+    // Additive: unconditional decoded-size ceilings for chat attachments, so
+    // clients can validate a file before sending instead of hardcoding guesses.
+    // Per attachment, not per frame: the encoded request must still fit
+    // `maxPayload`. MIME acceptance and per-message counts stay server-side
+    // because they depend on the entrypoint, resolved model, and payload sniffing.
+    attachments: Type.Optional(
+      closedObject({
+        maxBytes: Type.Integer({ minimum: 1 }),
+        maxImageBytes: Type.Integer({ minimum: 1 }),
+      }),
+    ),
     allowedSessionVisibilities: Type.Optional(Type.Array(SessionVisibilitySchema)),
     hasMultipleSessionSharingIdentities: Type.Optional(Type.Boolean()),
   }),

--- a/src/gateway/chat-attachment-policy.test.ts
+++ b/src/gateway/chat-attachment-policy.test.ts
@@ -1,0 +1,69 @@
+// Attachment policy tests guard the numbers advertised on `hello-ok` against the
+// ceilings the parser actually enforces.
+import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  DEFAULT_CHAT_ATTACHMENT_MAX_BYTES,
+  resolveChatAttachmentMaxBytes,
+  resolveChatAttachmentPolicy,
+} from "./chat-attachment-policy.js";
+
+const MB = 1024 * 1024;
+
+const cfgWithMediaMaxMb = (value: unknown): OpenClawConfig =>
+  ({ agents: { defaults: { mediaMaxMb: value } } }) as unknown as OpenClawConfig;
+
+describe("resolveChatAttachmentMaxBytes", () => {
+  it("honours a configured agents.defaults.mediaMaxMb", () => {
+    expect(resolveChatAttachmentMaxBytes(cfgWithMediaMaxMb(10))).toBe(10 * MB);
+    expect(resolveChatAttachmentMaxBytes(cfgWithMediaMaxMb(50))).toBe(50 * MB);
+  });
+
+  it("falls back to the default ceiling when unset", () => {
+    expect(resolveChatAttachmentMaxBytes({} as OpenClawConfig)).toBe(
+      DEFAULT_CHAT_ATTACHMENT_MAX_BYTES,
+    );
+    expect(resolveChatAttachmentMaxBytes({ agents: {} } as unknown as OpenClawConfig)).toBe(
+      DEFAULT_CHAT_ATTACHMENT_MAX_BYTES,
+    );
+  });
+
+  it("rejects non-positive, non-finite, or non-number values", () => {
+    for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY, "50", null, undefined]) {
+      expect(resolveChatAttachmentMaxBytes(cfgWithMediaMaxMb(bad))).toBe(
+        DEFAULT_CHAT_ATTACHMENT_MAX_BYTES,
+      );
+    }
+  });
+
+  it("never floors a legal sub-byte mediaMaxMb to zero", () => {
+    expect(resolveChatAttachmentMaxBytes(cfgWithMediaMaxMb(0.0000001))).toBe(1);
+  });
+
+  it("keeps an enormous mediaMaxMb representable instead of overflowing", () => {
+    expect(resolveChatAttachmentMaxBytes(cfgWithMediaMaxMb(1e308))).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});
+
+describe("resolveChatAttachmentPolicy", () => {
+  it("advertises the configured ceiling with the image hydration cap applied", () => {
+    expect(resolveChatAttachmentPolicy(cfgWithMediaMaxMb(20))).toEqual({
+      maxBytes: 20 * MB,
+      maxImageBytes: MAX_IMAGE_BYTES,
+    });
+  });
+
+  it("clamps maxImageBytes to the configured ceiling when it is the smaller limit", () => {
+    expect(resolveChatAttachmentPolicy(cfgWithMediaMaxMb(1))).toEqual({
+      maxBytes: MB,
+      maxImageBytes: MB,
+    });
+  });
+
+  it("keeps both ceilings positive so the hello-ok schema stays satisfiable", () => {
+    const policy = resolveChatAttachmentPolicy(cfgWithMediaMaxMb(0.0000001));
+    expect(policy.maxBytes).toBeGreaterThanOrEqual(1);
+    expect(policy.maxImageBytes).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/gateway/chat-attachment-policy.ts
+++ b/src/gateway/chat-attachment-policy.ts
@@ -1,0 +1,42 @@
+// Connection-level chat attachment ceilings shared by the parser and the
+// `hello-ok` handshake. Kept out of chat-attachments.ts so the handshake path
+// does not pull the media probe/store graph in just to read two numbers.
+import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const DEFAULT_CHAT_ATTACHMENT_MAX_MB = 20;
+
+/** Default decoded-size ceiling when `agents.defaults.mediaMaxMb` is unset or invalid. */
+export const DEFAULT_CHAT_ATTACHMENT_MAX_BYTES = DEFAULT_CHAT_ATTACHMENT_MAX_MB * 1024 * 1024;
+
+/** Resolve the maximum decoded attachment size accepted for chat inputs. */
+export function resolveChatAttachmentMaxBytes(cfg: OpenClawConfig): number {
+  const configured = cfg.agents?.defaults?.mediaMaxMb;
+  const mb =
+    typeof configured === "number" && Number.isFinite(configured) && configured > 0
+      ? configured
+      : DEFAULT_CHAT_ATTACHMENT_MAX_MB;
+  // mediaMaxMb only has to be positive, so a sub-byte value would floor to 0 and
+  // a huge one overflows to Infinity, which serializes as null on the handshake
+  // frame and fails its integer schema. Both ends have to stay representable.
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.max(1, Math.floor(mb * 1024 * 1024)));
+}
+
+/** Unconditional decoded-size ceilings advertised on `hello-ok.policy.attachments`. */
+type ChatAttachmentPolicy = {
+  maxBytes: number;
+  maxImageBytes: number;
+};
+
+/**
+ * Resolve the decoded-size ceilings every chat attachment faces regardless of
+ * entrypoint or model. Images are checked against the configured ceiling first
+ * and the agent-hydration cap second, so their effective limit is the smaller of
+ * the two. MIME acceptance and per-message counts are deliberately absent: they
+ * depend on the entrypoint, the resolved model, and payload sniffing, so they
+ * cannot be stated once per connection.
+ */
+export function resolveChatAttachmentPolicy(cfg: OpenClawConfig): ChatAttachmentPolicy {
+  const maxBytes = resolveChatAttachmentMaxBytes(cfg);
+  return { maxBytes, maxImageBytes: Math.min(maxBytes, MAX_IMAGE_BYTES) };
+}

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -34,10 +34,13 @@ vi.mock("../media/media-probe.js", () => ({
 import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  resolveChatAttachmentMaxBytes,
+  resolveChatAttachmentPolicy,
+} from "./chat-attachment-policy.js";
+import {
   type ChatAttachment,
   parseMessageWithAttachments,
   persistInboundImagesForTranscript,
-  resolveChatAttachmentMaxBytes,
   stripImageMediaMarkers,
   UnsupportedAttachmentError,
 } from "./chat-attachments.js";
@@ -67,11 +70,15 @@ function pdfAttachment(overrides: Partial<ChatAttachment> = {}): ChatAttachment 
   };
 }
 
-function oversizedPngBase64(): string {
+function pngBase64OfBytes(bytes: number): string {
   const pngHeader = PNG_1x1.slice(0, 64);
-  let base64Length = Math.ceil(((MAX_IMAGE_BYTES + 1) * 4) / 3);
+  let base64Length = Math.ceil((bytes * 4) / 3);
   base64Length += (4 - (base64Length % 4)) % 4;
   return `${pngHeader}${"A".repeat(base64Length - pngHeader.length)}`;
+}
+
+function oversizedPngBase64(): string {
+  return pngBase64OfBytes(MAX_IMAGE_BYTES + 1);
 }
 
 async function parseWithWarnings(
@@ -623,29 +630,46 @@ describe("parseMessageWithAttachments validation errors", () => {
   });
 });
 
-describe("resolveChatAttachmentMaxBytes", () => {
+describe("advertised attachment policy matches enforcement", () => {
   const MB = 1024 * 1024;
-  const DEFAULT_BYTES = 20 * MB;
 
-  const cfgWithMediaMaxMb = (value: unknown): OpenClawConfig =>
+  const cfgWithMediaMaxMb = (value: number): OpenClawConfig =>
     ({ agents: { defaults: { mediaMaxMb: value } } }) as unknown as OpenClawConfig;
 
-  it("honours a configured agents.defaults.mediaMaxMb", () => {
-    expect(resolveChatAttachmentMaxBytes(cfgWithMediaMaxMb(10))).toBe(10 * MB);
-    expect(resolveChatAttachmentMaxBytes(cfgWithMediaMaxMb(50))).toBe(50 * MB);
-  });
-
-  it("falls back to DEFAULT_CHAT_ATTACHMENT_MAX_MB when unset", () => {
-    expect(resolveChatAttachmentMaxBytes({} as OpenClawConfig)).toBe(DEFAULT_BYTES);
-    expect(resolveChatAttachmentMaxBytes({ agents: {} } as unknown as OpenClawConfig)).toBe(
-      DEFAULT_BYTES,
+  async function parseImageWithPolicy(cfg: OpenClawConfig, imageBytes: number) {
+    const policy = resolveChatAttachmentPolicy(cfg);
+    const parse = parseMessageWithAttachments(
+      "x",
+      [pngAttachment({ fileName: "big.png", content: pngBase64OfBytes(imageBytes) })],
+      { maxBytes: policy.maxBytes, log: { warn: () => {} } },
     );
+    return { policy, parse };
+  }
+
+  it("rejects images above the advertised maxImageBytes when the config ceiling is the smaller limit", async () => {
+    const { policy, parse } = await parseImageWithPolicy(cfgWithMediaMaxMb(1), 3 * MB);
+    expect(policy.maxImageBytes).toBe(MB);
+    await expect(parse).rejects.toThrow(/exceeds size limit/i);
   });
 
-  it("rejects non-positive, non-finite, or non-number values", () => {
-    for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY, "50", null, undefined]) {
-      expect(resolveChatAttachmentMaxBytes(cfgWithMediaMaxMb(bad))).toBe(DEFAULT_BYTES);
+  it("accepts images under the advertised maxImageBytes", async () => {
+    const { policy, parse } = await parseImageWithPolicy(cfgWithMediaMaxMb(20), 3 * MB);
+    expect(policy.maxImageBytes).toBe(MAX_IMAGE_BYTES);
+    const parsed = await parse;
+    try {
+      expect(parsed.offloadedRefs).toHaveLength(1);
+    } finally {
+      await cleanupOffloadedRefs(parsed.offloadedRefs);
     }
+  });
+
+  it("rejects images above the advertised maxImageBytes when the hydration cap is the smaller limit", async () => {
+    const { policy, parse } = await parseImageWithPolicy(
+      cfgWithMediaMaxMb(20),
+      MAX_IMAGE_BYTES + 3,
+    );
+    expect(policy.maxImageBytes).toBe(MAX_IMAGE_BYTES);
+    await expect(parse).rejects.toThrow(/image exceeds size limit/i);
   });
 });
 

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -5,7 +5,6 @@ import { MAX_IMAGE_BYTES, type MediaKind } from "@openclaw/media-core/constants"
 import { extensionForMime, kindFromMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage, formatUncaughtError } from "../infra/errors.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
 import type { MediaFact } from "../media/media-facts.js";
@@ -13,6 +12,7 @@ import { probeMediaFilesWithinBudget } from "../media/media-probe.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import { deleteMediaBuffer, saveMediaBuffer, type SavedMedia } from "../media/store.js";
+import { DEFAULT_CHAT_ATTACHMENT_MAX_BYTES } from "./chat-attachment-policy.js";
 import { formatForLog } from "./ws-log.js";
 
 export type ChatAttachment = {
@@ -77,8 +77,6 @@ const TEXT_ONLY_OFFLOAD_LIMIT = 10;
 const MAX_CHAT_ATTACHMENT_MEDIA_PROBES = 8;
 const CHAT_ATTACHMENT_MEDIA_PROBE_CONCURRENCY = 2;
 const CHAT_ATTACHMENT_MEDIA_PROBE_BUDGET_MS = 3000;
-
-const DEFAULT_CHAT_ATTACHMENT_MAX_MB = 20;
 
 async function enrichOffloadedMediaMetadata(refs: OffloadedRef[]): Promise<void> {
   const candidates = refs.flatMap((ref) => {
@@ -172,16 +170,6 @@ export async function persistInboundImagesForTranscript(params: {
     ...nonImageOffloaded,
   );
   return ordered;
-}
-
-/** Resolve the maximum decoded attachment size accepted for chat image inputs. */
-export function resolveChatAttachmentMaxBytes(cfg: OpenClawConfig): number {
-  const configured = cfg.agents?.defaults?.mediaMaxMb;
-  const mb =
-    typeof configured === "number" && Number.isFinite(configured) && configured > 0
-      ? configured
-      : DEFAULT_CHAT_ATTACHMENT_MAX_MB;
-  return Math.floor(mb * 1024 * 1024);
 }
 
 type UnsupportedAttachmentReason =
@@ -374,7 +362,7 @@ export async function parseMessageWithAttachments(
     acceptNonImage?: boolean;
   },
 ): Promise<ParsedMessageWithImages> {
-  const maxBytes = opts?.maxBytes ?? DEFAULT_CHAT_ATTACHMENT_MAX_MB * 1024 * 1024;
+  const maxBytes = opts?.maxBytes ?? DEFAULT_CHAT_ATTACHMENT_MAX_BYTES;
   const log = opts?.log;
   const shouldForceImageOffload = opts?.supportsImages === false;
   const supportsInlineImages = opts?.supportsInlineImages !== false;

--- a/src/gateway/server-methods/agent-content-phase.ts
+++ b/src/gateway/server-methods/agent-content-phase.ts
@@ -29,11 +29,11 @@ import {
   isInternalNonDeliveryChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { resolveChatAttachmentMaxBytes } from "../chat-attachment-policy.js";
 import {
   MediaOffloadError,
   logAttachmentFailure,
   parseMessageWithAttachments,
-  resolveChatAttachmentMaxBytes,
   type ChatAttachment,
 } from "../chat-attachments.js";
 import {

--- a/src/gateway/server-methods/chat-send-attachments.ts
+++ b/src/gateway/server-methods/chat-send-attachments.ts
@@ -14,12 +14,12 @@ import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline
 import { formatErrorMessage } from "../../infra/errors.js";
 import { parseInboundMediaUri } from "../../media/media-reference.js";
 import { deleteMediaBuffer, MEDIA_MAX_BYTES } from "../../media/store.js";
+import { resolveChatAttachmentMaxBytes } from "../chat-attachment-policy.js";
 import {
   MediaOffloadError,
   type OffloadedRef,
   logAttachmentFailure,
   parseMessageWithAttachments,
-  resolveChatAttachmentMaxBytes,
   stripImageMediaMarkers,
   UnsupportedAttachmentError,
 } from "../chat-attachments.js";

--- a/src/gateway/server-node-events.runtime.ts
+++ b/src/gateway/server-node-events.runtime.ts
@@ -20,10 +20,10 @@ export { enqueueSystemEvent } from "../infra/system-events.js";
 export { deleteMediaBuffer } from "../media/store.js";
 export { normalizeMainKey } from "../routing/session-key.js";
 export { defaultRuntime } from "../runtime.js";
+export { resolveChatAttachmentMaxBytes } from "./chat-attachment-policy.js";
 export {
   parseMessageWithAttachments,
   persistInboundImagesForTranscript,
-  resolveChatAttachmentMaxBytes,
 } from "./chat-attachments.js";
 export { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
 export {

--- a/src/gateway/server.hello-attachments.test.ts
+++ b/src/gateway/server.hello-attachments.test.ts
@@ -1,0 +1,62 @@
+// Handshake coverage for the additive chat-attachment limits on `hello-ok`, so
+// clients can validate a file before sending instead of hardcoding guesses.
+import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import {
+  connectOk,
+  createGatewaySuiteHarness,
+  installGatewayTestHooks,
+  testState,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+type GatewayHarness = Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
+let gateway: GatewayHarness;
+
+type HelloPolicy = {
+  policy?: { attachments?: { maxBytes?: number; maxImageBytes?: number } };
+};
+
+async function readAdvertisedAttachments(mediaMaxMb: number): Promise<unknown> {
+  testState.agentConfig = { mediaMaxMb };
+  // The handshake reads the pinned runtime snapshot, so drop it to pick the
+  // override up on the next connection.
+  clearConfigCache();
+  clearRuntimeConfigSnapshot();
+  const socket = await gateway.openWs();
+  try {
+    const hello = (await connectOk(socket)) as HelloPolicy;
+    return hello.policy?.attachments;
+  } finally {
+    socket.close();
+  }
+}
+
+describe("hello-ok attachment limits", () => {
+  beforeAll(async () => {
+    gateway = await createGatewaySuiteHarness();
+  });
+
+  afterAll(async () => {
+    await gateway.close();
+    testState.agentConfig = undefined;
+    clearConfigCache();
+    clearRuntimeConfigSnapshot();
+  });
+
+  test("advertises the configured ceiling and the image hydration cap", async () => {
+    expect(await readAdvertisedAttachments(7)).toEqual({
+      maxBytes: 7 * 1024 * 1024,
+      maxImageBytes: MAX_IMAGE_BYTES,
+    });
+  });
+
+  test("clamps the advertised image ceiling to a smaller configured ceiling", async () => {
+    expect(await readAdvertisedAttachments(2)).toEqual({
+      maxBytes: 2 * 1024 * 1024,
+      maxImageBytes: 2 * 1024 * 1024,
+    });
+  });
+});

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../infra/node-pairing.js";
 import { listProfiles } from "../../../state/user-profiles.js";
 import { resolveRuntimeServiceVersion } from "../../../version.js";
+import { resolveChatAttachmentPolicy } from "../../chat-attachment-policy.js";
 import {
   listControlUiPluginTabs,
   listControlUiPluginWidgetKinds,
@@ -124,6 +125,7 @@ export async function sendGatewayHello(
       maxPayload: MAX_PAYLOAD_BYTES,
       maxBufferedBytes: MAX_BUFFERED_BYTES,
       tickIntervalMs: TICK_INTERVAL_MS,
+      attachments: resolveChatAttachmentPolicy(context.configSnapshot),
       allowedSessionVisibilities: allowedSessionVisibilities(context.configSnapshot),
       hasMultipleSessionSharingIdentities:
         listProfiles().filter((profile) => !profile.mergedInto).length >= 2,


### PR DESCRIPTION
## What Problem This Solves

The gateway accepts attachments on `chat.send`, `sessions.send`, and session-creation initial turns, but never tells clients what it will accept. The real limits are operator-tunable and server-private, so every external client hardcodes a guess that silently disagrees with the server: files get uploaded and rejected after the round-trip, or valid files get blocked locally by a limit that is too tight. Fixes #116144.

## Why This Change Was Made

Adds an optional `attachments` descriptor to `hello-ok.policy`, next to `maxPayload`, carrying the two ceilings a client can act on before sending:

```jsonc
"attachments": {
  "maxBytes": 20971520,      // per-attachment decoded ceiling
  "maxImageBytes": 6291456   // effective image ceiling
}
```

Both values come from one shared resolver (`src/gateway/chat-attachment-policy.ts`) that the enforcement path also uses, so the advertised numbers cannot drift from what the parser actually rejects.

Design notes:

- **`maxImageBytes` is the effective minimum, not the raw constant.** The configured ceiling is checked first and the image ceiling second, so under a 1 MB `mediaMaxMb` advertising the 6 MiB image constant would be a lie. It is `min(maxBytes, MAX_IMAGE_BYTES)`.
- **MIME types and per-message counts are excluded.** `acceptNonImage` is `true` for `chat.send` but `false` for agent-content and node events; MIME is sniffed from payload content; image support depends on the resolved model; the text-only offload limit drops rather than rejects. None of that can be stated once per connection, so the server stays authoritative and returns a typed rejection.
- **The inline/offload threshold is excluded.** It does not affect acceptance, so it does not serve pre-send validation.
- **Both values are clamped to a representable positive integer.** `mediaMaxMb` is only validated as positive, so a sub-byte value would floor to `0` and an enormous one would overflow to `Infinity` (serialized as `null`) — either would violate the frame's integer schema and break the handshake.

Additive, no protocol version bump: the field is optional in the schema, matching how `allowedSessionVisibilities` and `hasMultipleSessionSharingIdentities` were previously added to the same `policy` object. No shipped client validates `hello-ok` against the schema at runtime — the reference TS client uses `HelloOk` as a type only, Swift decodes `policy` as `[String: AnyCodable]`, and Android has no `policy` model — so `additionalProperties: false` here is an authoring/codegen guard, not a client-enforced wire contract.

## User Impact

No behavior change to the send path; enforcement is untouched. Clients can now reject an oversized file locally with an accurate limit instead of uploading it and waiting for a server error, or guessing a limit that is wrong in either direction.

Documented in `docs/gateway/protocol.md` and `docs/gateway/clients.md`, including the trap that `policy.attachments` is a **per-attachment decoded** ceiling and never a promise the frame fits: attachments travel as base64, so a 20 MB file is about 26.7 MB on the wire and exceeds the default 25 MiB `maxPayload` on its own. The docs also note the values are a connection-time snapshot and should be re-read on reconnect.

## Evidence

Local (macOS, this checkout):

- `node scripts/run-vitest.mjs src/gateway/chat-attachment-policy.test.ts src/gateway/chat-attachments.test.ts src/gateway/server.hello-attachments.test.ts src/gateway/server-node-events.test.ts` — 4 files, 112 tests passed
- `pnpm protocol:check` — passed; registry check, schema gen, Swift check, Kotlin gen, since guard, and `git diff --exit-code` on the committed generated artifacts all clean (no Swift/Kotlin model drift, as expected for a nested `policy` field)
- `pnpm tsgo` — clean
- `pnpm check:test-types` — clean
- `oxfmt` + `scripts/run-oxlint.mjs src/gateway packages/gateway-protocol` — clean
- `pnpm build` — clean, no `[INEFFECTIVE_DYNAMIC_IMPORT]` (the new module sits between `connect-hello.ts` and the runtime barrel)
- `autoreview --mode local` (codex / gpt-5.6-sol / high) — two passes; one finding accepted and fixed (the `Infinity` overflow clamp above), one rejected with the compatibility evidence cited in the previous section

New coverage:

- `src/gateway/chat-attachment-policy.test.ts` — configured value, default fallback, invalid-value rejection, sub-byte clamp, overflow clamp, and `min()` behavior in both directions
- `src/gateway/server.hello-attachments.test.ts` — real WebSocket handshake asserting `hello-ok.policy.attachments` reflects a configured `mediaMaxMb`, and that the image ceiling clamps down when the configured ceiling is smaller
- `src/gateway/chat-attachments.test.ts` — drift guard tying the advertised numbers to the parser's actual accept/reject boundaries

### Live gateway proof

Isolated gateway on a scratch state dir (`--port 18991 --auth none --bind loopback`), driven by an external client built on the shipped reference client (`@openclaw/gateway-client`) that reads the advertised policy and preflights files locally before any upload.

**Run 1 — operator config `agents.defaults.mediaMaxMb: 3`** (proves the config ceiling is honored and that the image ceiling clamps *down* below the 6 MiB constant):

```
hello-ok policy.maxPayload  = 26214400
hello-ok policy.attachments = {"maxBytes":3145728,"maxImageBytes":3145728}

screenshot.png   4MB  ceiling=3MB  -> REJECT locally, never uploaded
screenshot.png   2MB  ceiling=3MB  -> OK to send
report.pdf       4MB  ceiling=3MB  -> REJECT locally, never uploaded
report.pdf       2MB  ceiling=3MB  -> OK to send
```

**Run 2 — default config** (proves the two ceilings differ, and shows the base64/`maxPayload` interaction a client must also check):

```
hello-ok policy.maxPayload  = 26214400
hello-ok policy.attachments = {"maxBytes":20971520,"maxImageBytes":6291456}

screenshot.png   8MB  ceiling=6MB  encoded=10.7MB  -> REJECT (over attachment ceiling)
screenshot.png   5MB  ceiling=6MB  encoded=6.7MB   -> OK to send
report.pdf       8MB  ceiling=20MB encoded=10.7MB  -> OK to send
archive.zip      24MB ceiling=20MB encoded=32.0MB  -> REJECT (over attachment ceiling)
```

The 6 MiB image ceiling and 20 MiB other-file ceiling match the enforcement constants exercised by the drift-guard tests, and the 3 MiB run matches the operator's configured value — the numbers a client sees are the numbers the parser enforces.

Rebased on `origin/main` after the initial review.