### PR TITLE
fix: restore doctor install-switch release proof

### DIFF
--- a/scripts/e2e/lib/doctor-install-switch/scenario.sh
+++ b/scripts/e2e/lib/doctor-install-switch/scenario.sh
@@ -139,6 +139,7 @@ run_flow() {
 
   echo "== Flow: $name =="
   openclaw_test_state_create "switch-${name}" empty
+  unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH
   export USER="testuser"
 
   if ! openclaw_e2e_maybe_timeout "$command_timeout" bash -c "$install_cmd" >"$install_log" 2>&1; then

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -4370,11 +4370,16 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
 
     expectTextToIncludeAll(scenario, [
       'command_timeout="${OPENCLAW_DOCKER_DOCTOR_SWITCH_COMMAND_TIMEOUT:-900s}"',
+      'openclaw_test_state_create "switch-${name}" empty\n  unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH',
       'openclaw_e2e_maybe_timeout "$command_timeout" bash -c "$install_cmd"',
       'openclaw_e2e_maybe_timeout "$command_timeout" bash -c "$doctor_cmd"',
       'openclaw_e2e_maybe_timeout "$command_timeout" "$npm_bin" gateway install --wrapper "$wrapper" --force',
       'openclaw_e2e_maybe_timeout "$command_timeout" node "$git_cli" doctor --repair --force --yes',
     ]);
+
+    expect(
+      scenario.match(/unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH/gu),
+    ).toHaveLength(1);
 
     expect(scenario).not.toMatch(/^\s*if ! timeout "\$command_timeout"/mu);
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the doctor install-switch Docker scenario asked OpenClaw to install a daemon service while inherited non-default state and config paths were active. The release candidate correctly rejected that unsafe service-install request, so the harness could not reach the install/doctor switch behavior it owns.

## Why This Change Was Made

Each install-switch flow still creates and retains an isolated temporary `HOME`, then clears `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH` before invoking daemon and doctor commands. Those commands therefore use the default `$HOME/.openclaw` layout while remaining fully contained in the test home. Other scenario flows keep their intentional custom-state overrides.

## User Impact

The release doctor install-switch lane now tests the supported default-state service lifecycle instead of being stopped by the product's non-default-path safety guard. There is no product runtime change.

## Evidence

- `bash -n scripts/e2e/lib/doctor-install-switch/scenario.sh`
- focused `test/scripts/docker-build-helper.test.ts`: 175 passed
- Oxfmt and `git diff --check`
- Codex autoreview: clean, no accepted or actionable findings
