### PR TITLE
fix(session): preserve reset message payloads

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-context.ts
+++ b/extensions/telegram/src/bot-message-dispatch-context.ts
@@ -1,5 +1,4 @@
 // Telegram plugin module recovers dispatch routing and group-history context.
-import { CURRENT_MESSAGE_MARKER } from "openclaw/plugin-sdk/channel-mention-gating";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -83,17 +82,6 @@ function normalizeDispatchTelegramThreadPayload(params: {
       TransportThreadId: params.threadSpec.id,
     },
   };
-}
-
-function extractCurrentTelegramBody(body: string | undefined): string {
-  if (!body) {
-    return "";
-  }
-  const markerIndex = body.lastIndexOf(CURRENT_MESSAGE_MARKER);
-  if (markerIndex === -1) {
-    return body;
-  }
-  return body.slice(markerIndex + CURRENT_MESSAGE_MARKER.length).trimStart();
 }
 
 function buildRecoveredTelegramChatActionSender(params: {
@@ -231,9 +219,6 @@ export function resolveDispatchTelegramContext(params: {
         ? recoveredPromptHistoryEntries
         : undefined
       : params.context.ctxPayload.InboundHistory;
-  const recoveredBodyForAgent = extractCurrentTelegramBody(
-    params.context.ctxPayload.BodyForAgent ?? params.context.ctxPayload.Body,
-  );
   const recoveredPromptContextBase = retainTelegramGroupHistoryPromptContext({
     promptContext: params.context.ctxPayload.ChannelStructuredContext ?? [],
     entries: recoveredPromptHistoryEntries,
@@ -278,8 +263,6 @@ export function resolveDispatchTelegramContext(params: {
         ? params.context.ctxPayload
         : {
             ...params.context.ctxPayload,
-            Body: recoveredBodyForAgent,
-            BodyForAgent: recoveredBodyForAgent,
             From: recoveredFrom,
             InboundHistory: recoveredInboundHistory,
             MessageThreadId: threadSpec.id,

--- a/extensions/telegram/src/bot-message-dispatch.context-history.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.context-history.test.ts
@@ -153,12 +153,13 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
   it("moves recovered user-request history out of the original topic", async () => {
     const oldHistoryKey = "-1003774691294:topic:1";
     const recoveredHistoryKey = "-1003774691294:topic:3731";
+    const currentBody = "quote [Current message - respond to this] literally";
     const groupHistories = new Map([
       [
         oldHistoryKey,
         [
           { sender: "Alice", body: "general topic context", timestamp: 1 },
-          { sender: "Cara", body: "topic request", timestamp: 4, messageId: "27789" },
+          { sender: "Cara", body: currentBody, timestamp: 4, messageId: "27789" },
         ],
       ],
       [
@@ -186,12 +187,14 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
       context: createContext({
         ctxPayload: {
           InboundEventKind: "user_request",
-          BodyForAgent: "current recovered request",
+          Body: currentBody,
+          BodyForAgent: currentBody,
+          CommandBody: currentBody,
           ChatType: "group",
           From: "telegram:group:-1003774691294:topic:1",
           MessageSid: "27789",
           MessageThreadId: 1,
-          RawBody: "topic request",
+          RawBody: currentBody,
           SessionKey: "agent:main:telegram:group:-1003774691294:topic:3731",
           TransportThreadId: 1,
         } as unknown as TelegramMessageContext["ctxPayload"],
@@ -220,7 +223,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
       expect.objectContaining({ body: "before self marker" }),
       expect.objectContaining({ body: "self marker" }),
       expect.objectContaining({ body: "after watermark" }),
-      expect.objectContaining({ body: "topic request", messageId: "27789" }),
+      expect.objectContaining({ body: currentBody, messageId: "27789" }),
     ]);
     const outbound = expectRecordFields(mockCallArg(deliverInboundReplyWithMessageSendContext), {
       threadId: 3731,
@@ -229,7 +232,12 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
     expect(outboundCtxPayload.InboundHistory).toEqual([
       expect.objectContaining({ body: "after watermark" }),
     ]);
-    expect(outboundCtxPayload.Body).toBe("current recovered request");
+    expect(outboundCtxPayload).toMatchObject({
+      Body: currentBody,
+      BodyForAgent: currentBody,
+      CommandBody: currentBody,
+      RawBody: currentBody,
+    });
     expect(outboundCtxPayload.ChannelStructuredContext).toEqual([
       expect.objectContaining({
         label: "Conversation context",
@@ -252,9 +260,7 @@ describeTelegramDispatch("dispatchTelegramMessage context-history", () => {
     expect(JSON.stringify(outboundCtxPayload.ChannelStructuredContext)).not.toContain(
       "self marker",
     );
-    expect(JSON.stringify(outboundCtxPayload.ChannelStructuredContext)).not.toContain(
-      "topic request",
-    );
+    expect(JSON.stringify(outboundCtxPayload.ChannelStructuredContext)).not.toContain(currentBody);
   });
 
   it("keeps retained overflow draft previews", async () => {

--- a/qa/scenarios/channels/session-reset-payload-preservation.yaml
+++ b/qa/scenarios/channels/session-reset-payload-preservation.yaml
@@ -1,0 +1,163 @@
+title: Session reset payload preservation
+
+scenario:
+  id: session-reset-payload-preservation
+  surface: channels
+  category: channels.channel-actions-commands-and-approvals
+  coverage:
+    primary:
+      - channels.channel-native-commands
+    secondary:
+      - channels.qa-channel-final-reply
+  objective: Verify `/new` resets the channel lifecycle while preserving the exact trailing user payload sent to the model.
+  successCriteria:
+    - A seeded QA-channel direct session receives a new lifecycle revision after `/new`.
+    - The durable channel session id remains stable across the reset boundary.
+    - The mock provider receives the exact multiline payload, including marker-like and bracketed text.
+    - The reset command prefix is removed before model dispatch.
+    - The visible channel reply contains the requested marker.
+  docsRefs:
+    - docs/channels/qa-channel.md
+    - docs/reference/session-management-compaction.md
+  codeRefs:
+    - src/auto-reply/reply/session-reset-command.ts
+    - src/auto-reply/reply/session.ts
+    - extensions/qa-channel/src/inbound.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+  execution:
+    kind: flow
+    channel: qa-channel
+    suiteIsolation: isolated
+    isolationReason: Resets the shared QA direct-message session and compares its lifecycle revision.
+    summary: Send a multiline reset payload through an ephemeral Gateway and inspect the exact mock-provider request.
+    config:
+      requiredProviderMode: mock-openai
+      conversationId: qa-session-reset-payload
+      senderId: qa-reset-operator
+      seedMarker: QA-RESET-PAYLOAD-SEED-OK
+      replyMarker: QA-RESET-PAYLOAD-OK
+      payload: |-
+        review [Q3 report]
+        [Current message - respond to this]
+        and explain /new syntax
+        Reply exactly: QA-RESET-PAYLOAD-OK
+
+flow:
+  steps:
+    - name: resets the session and preserves the exact reset payload
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: this exact request-payload proof requires mock-openai
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - resetTransport: true
+        - set: sessionKey
+          value:
+            expr: "buildAgentSessionKey({ agentId: 'qa', channel: 'qa-channel', accountId: 'default', peer: { kind: 'direct', id: config.conversationId }, dmScope: env.cfg.session?.dmScope, identityLinks: env.cfg.session?.identityLinks })"
+        - set: seedOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Reset Operator
+            text:
+              expr: "`Reply exactly: ${config.seedMarker}`"
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            sinceIndex:
+              ref: seedOutboundIndex
+            textIncludes:
+              ref: config.seedMarker
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+        - call: readRawQaSessionStore
+          saveAs: seedStore
+          args:
+            - ref: env
+        - set: seedSession
+          value:
+            expr: "seedStore[sessionKey]"
+        - assert:
+            expr: "Boolean(seedSession?.sessionId)"
+            message:
+              expr: "`seed session missing: ${JSON.stringify({ sessionKey, storeKeys: Object.keys(seedStore) })}`"
+        - set: requestCursorBeforeReset
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor"
+        - set: resetOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Reset Operator
+            text:
+              expr: "`/new ${config.payload}`"
+        - call: waitForCondition
+          saveAs: resetRequest
+          args:
+            - lambda:
+                async: true
+                expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeReset}`)).find((request) => String(request.prompt ?? '').includes(config.payload))"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 100
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            sinceIndex:
+              ref: resetOutboundIndex
+            textIncludes:
+              ref: config.replyMarker
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+          saveAs: resetReply
+        - call: readRawQaSessionStore
+          saveAs: resetStore
+          args:
+            - ref: env
+        - set: resetSession
+          value:
+            expr: "resetStore[sessionKey]"
+        - set: resetRequests
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBeforeReset}`)).filter((request) => String(request.prompt ?? '').includes(config.payload))"
+        - assert:
+            expr: "Boolean(resetSession?.lifecycleRevision) && resetSession.lifecycleRevision !== seedSession.lifecycleRevision"
+            message:
+              expr: "`session lifecycle did not reset: ${JSON.stringify({ before: seedSession?.lifecycleRevision, after: resetSession?.lifecycleRevision })}`"
+        - assert:
+            expr: "resetSession?.sessionId === seedSession.sessionId"
+            message:
+              expr: "`durable channel session id changed across reset: ${JSON.stringify({ before: seedSession?.sessionId, after: resetSession?.sessionId })}`"
+        - assert:
+            expr: resetRequests.length === 1
+            message:
+              expr: "`expected exactly one reset payload request, saw ${resetRequests.length}`"
+        - assert:
+            expr: "String(resetRequest.prompt ?? '').includes(config.payload)"
+            message: mock-provider request did not preserve the exact reset payload
+        - assert:
+            expr: "!String(resetRequest.prompt ?? '').includes(`/new ${config.payload}`)"
+            message: reset command prefix leaked into the model prompt
+      detailsExpr: "JSON.stringify({ verdict: 'PASS', scenario: 'session-reset-payload-preservation', channel: 'qa-channel', provider: env.providerMode, gateway: 'ephemeral-child', lifecycleReset: resetSession.lifecycleRevision !== seedSession.lifecycleRevision, durableSessionRetained: resetSession.sessionId === seedSession.sessionId, payloadPreserved: String(resetRequest.prompt ?? '').includes(config.payload), commandRemoved: !String(resetRequest.prompt ?? '').includes(`/new ${config.payload}`), replyDelivered: resetReply.text.includes(config.replyMarker), transcript: { inbound: `/new ${config.payload}`, outbound: resetReply.text } })"

--- a/src/auto-reply/reply/get-reply-directives.target-session.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.target-session.test.ts
@@ -1041,4 +1041,47 @@ describe("resolveReplyDirectives", () => {
 
     expectContinueResult(directResult, { commandSource: "", cleanedBody: "" });
   });
+
+  it("does not apply or remove directives when the command projection is explicitly empty", async () => {
+    const { result } = await resolveHelloWithModelDefaults({
+      defaultThinking: "off",
+      defaultReasoning: "on",
+      body: "/trace on",
+      commandAuthorized: true,
+      sessionCtx: {
+        commandText: "",
+        agentText: "/trace on",
+        rawText: "/trace on",
+      },
+    });
+
+    expectContinueResult(result, {
+      commandSource: "",
+      cleanedBody: "/trace on",
+    });
+  });
+
+  it("preserves directives and quoted current-message markers inside flat history", async () => {
+    const agentText = [
+      "[Chat messages since your last reply - for context]",
+      "Other: /trace on",
+      "Other: [Current message - respond to this] /model gpt-5.5",
+      "",
+      "[Current message - respond to this]",
+      "Owner: hello /status",
+    ].join("\n");
+    const { result } = await resolveHelloWithModelDefaults({
+      defaultThinking: "off",
+      defaultReasoning: "on",
+      body: "hello",
+      commandAuthorized: true,
+      sessionCtx: {
+        commandText: "hello",
+        agentText,
+        rawText: "hello",
+      },
+    });
+
+    expectContinueResult(result, { cleanedBody: agentText });
+  });
 });

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -45,7 +45,8 @@ import { clearExecInlineDirectives, clearInlineDirectives } from "./get-reply-di
 import { type ReplyExecOverrides, resolveReplyExecOverrides } from "./get-reply-exec-overrides.js";
 import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
 import { defaultGroupActivation, resolveGroupRequireMention } from "./groups.js";
-import { CURRENT_MESSAGE_MARKER, stripMentions, stripStructuralPrefixes } from "./mentions.js";
+import { HISTORY_CONTEXT_MARKER } from "./history.js";
+import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import {
   createFastTestModelSelectionState,
   createModelSelectionState,
@@ -89,19 +90,6 @@ function canUseFastExplicitModelDirective(params: {
       aliasIndex: params.aliasIndex,
     }),
   );
-}
-
-function resolveDirectiveCommandText(params: {
-  ctx: FinalizedRuntimeMsgContext;
-  sessionCtx: TemplateContext;
-}) {
-  const commandSource = params.sessionCtx.commandText;
-  const promptSource = params.sessionCtx.agentText;
-  return {
-    commandSource,
-    promptSource,
-    commandText: commandSource || promptSource,
-  };
 }
 
 type ReplyDirectiveContinuation = {
@@ -225,10 +213,7 @@ export async function resolveReplyDirectives(params: {
   let provider = initialProvider;
   let model = initialModel;
 
-  const { commandText } = resolveDirectiveCommandText({
-    ctx,
-    sessionCtx,
-  });
+  const commandText = sessionCtx.commandText;
   const command = buildCommandContext({
     ctx,
     cfg,
@@ -364,6 +349,8 @@ export async function resolveReplyDirectives(params: {
         queueReset: false,
       };
   const existingBody = sessionCtx.agentText;
+  const hasLegacyHistoryEnvelope = existingBody.trimStart().startsWith(HISTORY_CONTEXT_MARKER);
+  const preserveAgentText = commandText === "" || hasLegacyHistoryEnvelope;
   let cleanedBody = (() => {
     if (!existingBody) {
       if (resetTriggered) {
@@ -371,24 +358,18 @@ export async function resolveReplyDirectives(params: {
       }
       return parsedDirectives.cleaned;
     }
-    const markerIndex = existingBody.indexOf(CURRENT_MESSAGE_MARKER);
-    if (markerIndex < 0) {
-      return parseInlineDirectives(existingBody, {
-        modelAliases: configuredAliases,
-        allowStatusDirective,
-      }).cleaned;
+    if (preserveAgentText) {
+      // An explicit empty command projection and flat history envelopes have no
+      // trustworthy directive range. Preserve prompt text instead of guessing.
+      return existingBody;
     }
-
-    const head = existingBody.slice(0, markerIndex + CURRENT_MESSAGE_MARKER.length);
-    const tail = existingBody.slice(markerIndex + CURRENT_MESSAGE_MARKER.length);
-    const cleanedTail = parseInlineDirectives(tail, {
+    return parseInlineDirectives(existingBody, {
       modelAliases: configuredAliases,
       allowStatusDirective,
     }).cleaned;
-    return `${head}${cleanedTail}`;
   })();
 
-  if (allowStatusDirective) {
+  if (allowStatusDirective && !preserveAgentText) {
     cleanedBody = stripInlineStatus(cleanedBody).cleaned;
   }
 

--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -11,7 +11,11 @@ import { resolveStorePath } from "../../config/sessions/paths.js";
 import { loadSessionEntry, listSessionEntries } from "../../config/sessions/session-accessor.js";
 import { buildSessionCreationStamp } from "../../config/sessions/session-entry-provenance.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
-import type { SessionEntry, SessionScope } from "../../config/sessions/types.js";
+import {
+  DEFAULT_RESET_TRIGGERS,
+  type SessionEntry,
+  type SessionScope,
+} from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isVitestRuntimeEnv } from "../../infra/env.js";
 import {
@@ -26,15 +30,15 @@ import type {
   FinalizedTemplateContext as TemplateContext,
 } from "../templating.js";
 import { isFormattedGoalContinuationPrompt } from "./commands-goal.js";
-import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import type { CommandContext } from "./commands-types.js";
-import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
+import { stripMentions } from "./mentions.js";
 import {
   isCompleteReplyConfig,
   markReplyConfigRuntimeMode,
   usesFullReplyRuntime,
 } from "./reply-config-runtime-mode.js";
 import { createReplySessionEntryHandle } from "./session-entry-handle.js";
+import { resolveSessionResetCommand } from "./session-reset-command.js";
 import type { SessionInitResult } from "./session.js";
 
 function isSlowReplyTestAllowed(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -192,29 +196,31 @@ export function initFastReplySessionState(params: {
   );
   const existingEntry = loadSessionEntry({ storePath, sessionKey });
   const commandSource = ctx.commandText ?? "";
-  const triggerBodyNormalized = isFormattedGoalContinuationPrompt(commandSource)
-    ? commandSource.trim()
-    : stripStructuralPrefixes(commandSource).trim();
   const normalizedChatType = normalizeChatType(ctx.ChatType);
   const isGroup = normalizedChatType != null && normalizedChatType !== "direct";
-  const strippedForReset = isGroup
-    ? stripMentions(triggerBodyNormalized, ctx, cfg, agentId)
-    : triggerBodyNormalized;
-  const normalizedResetBody = normalizeCommandBody(strippedForReset, {
-    botUsername: ctx.BotUsername,
+  const resetCommand = resolveSessionResetCommand({
+    commandText: commandSource,
+    rawText: ctx.rawText,
+    resetTriggers: cfg.session?.resetTriggers?.length
+      ? cfg.session.resetTriggers
+      : DEFAULT_RESET_TRIGGERS,
+    ctx,
+    cfg,
+    agentId,
+    isGroup,
+    resetAuthorized: commandAuthorized,
   });
-  const softReset = parseSoftResetCommand(normalizedResetBody);
-  const resetMatch = normalizedResetBody.match(/^\/(new|reset)(?:\s|$)/i);
-  const resetTriggered = Boolean(resetMatch) && !softReset.matched;
+  const triggerBodyNormalized = isFormattedGoalContinuationPrompt(commandSource)
+    ? commandSource.trim()
+    : resetCommand.triggerBodyNormalized;
+  const resetTriggered = resetCommand.matchedResetTriggerLower !== undefined;
   if (resetTriggered && isModelSelectionLocked(existingEntry)) {
     throw new ModelSelectionLockedError(MODEL_SELECTION_LOCKED_RESET_MESSAGE);
   }
   const previousSessionEntry = resetTriggered && existingEntry ? { ...existingEntry } : undefined;
   const sessionId =
     !resetTriggered && existingEntry ? existingEntry.sessionId : crypto.randomUUID();
-  const bodyStripped = resetTriggered
-    ? normalizedResetBody.slice(resetMatch?.[0].length ?? 0).trimStart()
-    : (ctx.agentText ?? "");
+  const bodyStripped = resetTriggered ? (resetCommand.payload ?? "") : (ctx.agentText ?? "");
   const now = Date.now();
   const sessionEntry: SessionEntry = {
     ...(!resetTriggered ? existingEntry : undefined),

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -824,6 +824,48 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(result.sessionEntry.responseUsage).toBe("full");
   });
 
+  it("preserves the exact multiline reset payload during fast bootstrap", () => {
+    const payload = "keep [Q3]\nline 2";
+    const result = initFastReplySessionState({
+      ctx: buildGetReplyCtx({
+        Body: `/new ${payload}`,
+        BodyForCommands: `/new ${payload}`,
+        RawBody: `[Telegram id:456] İpek: /NEW: ${payload}`,
+        SenderName: "İpek",
+        SessionKey: "agent:main:telegram:payload",
+      }),
+      cfg: {
+        session: { store: "/tmp/sessions.json", resetTriggers: ["/new"] },
+      } as OpenClawConfig,
+      agentId: "main",
+      commandAuthorized: true,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(result.resetTriggered).toBe(true);
+    expect(result.bodyStripped).toBe(payload);
+    expect(result.sessionCtx.agentText).toBe(payload);
+  });
+
+  it("does not reset from a command projection when the raw projection is explicitly empty", () => {
+    const result = initFastReplySessionState({
+      ctx: buildGetReplyCtx({
+        Body: "/new payload",
+        BodyForCommands: "/new payload",
+        RawBody: "",
+        SessionKey: "agent:main:telegram:empty-raw",
+      }),
+      cfg: {
+        session: { store: "/tmp/sessions.json", resetTriggers: ["/new"] },
+      } as OpenClawConfig,
+      agentId: "main",
+      commandAuthorized: true,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(result.resetTriggered).toBe(false);
+  });
+
   it("preserves node provenance and lineage during fast reset bootstrap", async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-reset-lineage-"));
     const storePath = path.join(home, "sessions.json");

--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -5,21 +5,6 @@ export const HISTORY_CONTEXT_MARKER = "[Chat messages since your last reply - fo
 export const CURRENT_MESSAGE_MARKER = "[Current message - respond to this]";
 export const DEFAULT_GROUP_HISTORY_LIMIT = 50;
 
-export function resolveCurrentMessageContentStart(text: string): number | undefined {
-  const firstContentIndex = text.length - text.trimStart().length;
-  const historyMarkerIndex = text.indexOf(HISTORY_CONTEXT_MARKER, firstContentIndex);
-  if (historyMarkerIndex !== firstContentIndex) {
-    return undefined;
-  }
-  const currentMessageMarkerIndex = text.indexOf(
-    CURRENT_MESSAGE_MARKER,
-    historyMarkerIndex + HISTORY_CONTEXT_MARKER.length,
-  );
-  return currentMessageMarkerIndex === -1
-    ? undefined
-    : currentMessageMarkerIndex + CURRENT_MESSAGE_MARKER.length;
-}
-
 /** Maximum number of group history keys to retain (LRU eviction when exceeded). */
 const MAX_HISTORY_KEYS = 1000;
 

--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -1,9 +1,24 @@
 /** Pending chat-history windows and prompt context builders for auto-reply turns. */
 import type { HistoryEntry, HistoryMediaEntry } from "./history.types.js";
-import { CURRENT_MESSAGE_MARKER } from "./mentions.js";
 
 export const HISTORY_CONTEXT_MARKER = "[Chat messages since your last reply - for context]";
+export const CURRENT_MESSAGE_MARKER = "[Current message - respond to this]";
 export const DEFAULT_GROUP_HISTORY_LIMIT = 50;
+
+export function resolveCurrentMessageContentStart(text: string): number | undefined {
+  const firstContentIndex = text.length - text.trimStart().length;
+  const historyMarkerIndex = text.indexOf(HISTORY_CONTEXT_MARKER, firstContentIndex);
+  if (historyMarkerIndex !== firstContentIndex) {
+    return undefined;
+  }
+  const currentMessageMarkerIndex = text.indexOf(
+    CURRENT_MESSAGE_MARKER,
+    historyMarkerIndex + HISTORY_CONTEXT_MARKER.length,
+  );
+  return currentMessageMarkerIndex === -1
+    ? undefined
+    : currentMessageMarkerIndex + CURRENT_MESSAGE_MARKER.length;
+}
 
 /** Maximum number of group history keys to retain (LRU eviction when exceeded). */
 const MAX_HISTORY_KEYS = 1000;

--- a/src/auto-reply/reply/inbound-context.test.ts
+++ b/src/auto-reply/reply/inbound-context.test.ts
@@ -247,6 +247,20 @@ describe("finalizeInboundContext text facts", () => {
     });
   });
 
+  it("preserves an explicitly empty raw projection", () => {
+    const ctx = finalizeInboundContext({
+      Body: "fallback body",
+      BodyForCommands: "/new payload",
+      RawBody: "",
+    });
+
+    expect(ctx).toMatchObject({
+      commandText: "/new payload",
+      agentText: "",
+      rawText: "",
+    });
+  });
+
   it("normalizes canonical text once and keeps repeated finalization stable", () => {
     const ctx = finalizeInboundContext({
       Body: "body\r\nline",

--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -48,12 +48,20 @@ describe("stripStructuralPrefixes", () => {
     expect(stripStructuralPrefixes("just a message")).toBe("just a message");
   });
 
-  it("does not treat a payload marker literal as a history envelope", () => {
-    expect(
-      stripStructuralPrefixes(
-        "@openclaw /new review [Current message - respond to this] and /new syntax",
-      ),
-    ).toBe("@openclaw /new review and /new syntax");
+  it("does not treat a payload marker literal as structure", () => {
+    const body = "please explain [Current message - respond to this] /status";
+    expect(stripStructuralPrefixes(body)).toBe(body);
+  });
+
+  it("does not mine commands from ambiguous flat history", () => {
+    const body = [
+      "[Chat messages since your last reply - for context]",
+      "Other: quoted [Current message - respond to this] /reset",
+      "",
+      "[Current message - respond to this]",
+      "Owner: /status",
+    ].join("\n");
+    expect(stripStructuralPrefixes(body)).toBe(body);
   });
 
   it("preserves real line breaks in slash commands for downstream command parsing", () => {

--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -48,6 +48,14 @@ describe("stripStructuralPrefixes", () => {
     expect(stripStructuralPrefixes("just a message")).toBe("just a message");
   });
 
+  it("does not treat a payload marker literal as a history envelope", () => {
+    expect(
+      stripStructuralPrefixes(
+        "@openclaw /new review [Current message - respond to this] and /new syntax",
+      ),
+    ).toBe("@openclaw /new review and /new syntax");
+  });
+
   it("preserves real line breaks in slash commands for downstream command parsing", () => {
     expect(stripStructuralPrefixes("/reset soft\nre-read persona files")).toBe(
       "/reset soft\nre-read persona files",

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -15,8 +15,10 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { compileConfigRegexes, type ConfigRegexRejectReason } from "../../security/config-regex.js";
 import { escapeRegExp } from "../../utils.js";
 import type { MsgContext } from "../templating.js";
+import { resolveCurrentMessageContentStart } from "./history.js";
 import type { BuildMentionRegexesOptions, ExplicitMentionSignal } from "./mentions.types.js";
 export type { BuildMentionRegexesOptions } from "./mentions.types.js";
+export { CURRENT_MESSAGE_MARKER } from "./history.js";
 
 type ResolvedMentionPatterns = {
   patterns: string[];
@@ -53,8 +55,6 @@ const MAX_MENTION_REGEX_COMPILE_CACHE_KEYS = 512;
 const mentionPatternWarningCache = new Set<string>();
 const MAX_MENTION_PATTERN_WARNING_KEYS = 512;
 const log = createSubsystemLogger("mentions");
-
-export const CURRENT_MESSAGE_MARKER = "[Current message - respond to this]";
 
 function normalizeMentionPattern(pattern: string): string {
   if (!pattern.includes(BACKSPACE_CHAR)) {
@@ -204,9 +204,11 @@ export function stripStructuralPrefixes(text: string): string {
   }
   // Ignore wrapper labels, timestamps, and sender prefixes so directive-only
   // detection still works in group batches that include history/context.
-  const afterMarker = text.includes(CURRENT_MESSAGE_MARKER)
-    ? text.slice(text.indexOf(CURRENT_MESSAGE_MARKER) + CURRENT_MESSAGE_MARKER.length).trimStart()
-    : text;
+  const currentMessageContentStart = resolveCurrentMessageContentStart(text);
+  const afterMarker =
+    currentMessageContentStart === undefined
+      ? text
+      : text.slice(currentMessageContentStart).trimStart();
   const afterEnvelope = afterMarker.replace(/\[[^\]]+\]\s*/g, "");
   const senderPrefixPattern =
     afterEnvelope === afterMarker

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -15,7 +15,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { compileConfigRegexes, type ConfigRegexRejectReason } from "../../security/config-regex.js";
 import { escapeRegExp } from "../../utils.js";
 import type { MsgContext } from "../templating.js";
-import { resolveCurrentMessageContentStart } from "./history.js";
+import { HISTORY_CONTEXT_MARKER } from "./history.js";
 import type { BuildMentionRegexesOptions, ExplicitMentionSignal } from "./mentions.types.js";
 export type { BuildMentionRegexesOptions } from "./mentions.types.js";
 export { CURRENT_MESSAGE_MARKER } from "./history.js";
@@ -204,12 +204,13 @@ export function stripStructuralPrefixes(text: string): string {
   }
   // Ignore wrapper labels, timestamps, and sender prefixes so directive-only
   // detection still works in group batches that include history/context.
-  const currentMessageContentStart = resolveCurrentMessageContentStart(text);
-  const afterMarker =
-    currentMessageContentStart === undefined
-      ? text
-      : text.slice(currentMessageContentStart).trimStart();
-  const afterEnvelope = afterMarker.replace(/\[[^\]]+\]\s*/g, "");
+  if (text.trimStart().startsWith(HISTORY_CONTEXT_MARKER)) {
+    // Flat history has no trustworthy current-message range when users can quote
+    // marker text. Leave it non-command-shaped instead of guessing a boundary.
+    return text.trim();
+  }
+  const afterMarker = text;
+  const afterEnvelope = afterMarker.replace(/^(?:[ \t]*\[[^\]\n]+\][ \t]*)+/, "");
   const senderPrefixPattern =
     afterEnvelope === afterMarker
       ? /^[ \t]*(?!\/)[^\n:]{1,120}:\s+/gm

--- a/src/auto-reply/reply/session-reset-command.ts
+++ b/src/auto-reply/reply/session-reset-command.ts
@@ -6,7 +6,7 @@ import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import { CURRENT_MESSAGE_MARKER, HISTORY_CONTEXT_MARKER } from "./history.js";
 import { stripMentions } from "./mentions.js";
 
-export type ResolvedSessionResetCommand = {
+type ResolvedSessionResetCommand = {
   matchedResetTriggerLower?: string;
   normalizedResetBody: string;
   payload?: string;

--- a/src/auto-reply/reply/session-reset-command.ts
+++ b/src/auto-reply/reply/session-reset-command.ts
@@ -1,0 +1,301 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { normalizeCommandBody } from "../commands-registry.js";
+import type { MsgContext } from "../templating.js";
+import { parseSoftResetCommand } from "./commands-reset-mode.js";
+import { CURRENT_MESSAGE_MARKER, HISTORY_CONTEXT_MARKER } from "./history.js";
+import { stripMentions } from "./mentions.js";
+
+export type ResolvedSessionResetCommand = {
+  matchedResetTriggerLower?: string;
+  normalizedResetBody: string;
+  payload?: string;
+  softResetMatched: boolean;
+  triggerBodyNormalized: string;
+};
+
+function skipWhitespace(source: string, start: number): number {
+  let cursor = start;
+  while (/\s/.test(source[cursor] ?? "")) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function skipHorizontalWhitespace(source: string, start: number): number {
+  let cursor = start;
+  while (source[cursor] === " " || source[cursor] === "\t") {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function startsWithHistoryMarker(source: string, start: number): boolean {
+  return (
+    source.startsWith(HISTORY_CONTEXT_MARKER, start) ||
+    source.startsWith(CURRENT_MESSAGE_MARKER, start)
+  );
+}
+
+function matchesKnownSenderPrefix(prefix: string, ctx: MsgContext): boolean {
+  const normalizedPrefix = normalizeLowercaseStringOrEmpty(prefix);
+  if (!normalizedPrefix) {
+    return false;
+  }
+  const senderUsername = ctx.SenderUsername?.trim().replace(/^@/, "");
+  const candidates = [
+    ctx.SenderName,
+    ctx.SenderTag,
+    senderUsername,
+    senderUsername ? `@${senderUsername}` : undefined,
+    ctx.SenderName && senderUsername ? `${ctx.SenderName} (@${senderUsername})` : undefined,
+  ];
+  return candidates.some(
+    (candidate) =>
+      typeof candidate === "string" &&
+      normalizeLowercaseStringOrEmpty(candidate) === normalizedPrefix,
+  );
+}
+
+function resolveExplicitMessageStart(source: string, ctx: MsgContext): number | undefined {
+  let cursor = skipWhitespace(source, 0);
+  if (startsWithHistoryMarker(source, cursor)) {
+    return undefined;
+  }
+
+  while (source[cursor] === "[") {
+    const lineEnd = source.indexOf("\n", cursor);
+    const envelopeEnd = source.indexOf("]", cursor + 1);
+    if (envelopeEnd === -1 || (lineEnd !== -1 && envelopeEnd > lineEnd)) {
+      break;
+    }
+    if (startsWithHistoryMarker(source, cursor)) {
+      return undefined;
+    }
+    cursor = skipHorizontalWhitespace(source, envelopeEnd + 1);
+  }
+
+  const lineEnd = source.indexOf("\n", cursor);
+  const effectiveLineEnd = lineEnd === -1 ? source.length : lineEnd;
+  const senderPrefixEnd = source.indexOf(":", cursor);
+  if (senderPrefixEnd !== -1 && senderPrefixEnd < effectiveLineEnd) {
+    const senderPrefix = source.slice(cursor, senderPrefixEnd).trim();
+    if (senderPrefix && senderPrefix.length <= 120 && matchesKnownSenderPrefix(senderPrefix, ctx)) {
+      cursor = skipHorizontalWhitespace(source, senderPrefixEnd + 1);
+    }
+  }
+
+  return cursor;
+}
+
+function stripLeadingMention(params: {
+  source: string;
+  start: number;
+  trigger: string;
+  commandText: string;
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  agentId: string;
+  isGroup: boolean;
+}): number | undefined {
+  const triggerLower = normalizeLowercaseStringOrEmpty(params.trigger);
+  if (
+    normalizeLowercaseStringOrEmpty(
+      params.source.slice(params.start, params.start + params.trigger.length),
+    ) === triggerLower
+  ) {
+    return params.start;
+  }
+  if (!params.isGroup) {
+    return undefined;
+  }
+
+  let triggerStart = -1;
+  for (let index = params.start; index < params.source.length; index += 1) {
+    if (
+      normalizeLowercaseStringOrEmpty(params.source.slice(index, index + params.trigger.length)) ===
+      triggerLower
+    ) {
+      triggerStart = index;
+      break;
+    }
+  }
+  if (triggerStart === -1) {
+    return undefined;
+  }
+  const prefix = params.source.slice(params.start, triggerStart);
+  if (prefix.includes("\n")) {
+    return undefined;
+  }
+  if (!stripMentions(prefix, params.ctx, params.cfg, params.agentId).trim()) {
+    return triggerStart;
+  }
+  // Some channels remove a provider-native mention from commandText before
+  // core sees it. Accept that projection only when the remaining raw suffix is exact.
+  return params.ctx.WasMentioned === true &&
+    params.source.slice(triggerStart).trimEnd() === params.commandText.trim()
+    ? triggerStart
+    : undefined;
+}
+
+function isRecognizedCommandSuffix(params: {
+  suffix: string;
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  agentId: string;
+  isGroup: boolean;
+}): boolean {
+  const botUsername = params.ctx.BotUsername?.trim().replace(/^@/, "");
+  if (
+    botUsername &&
+    normalizeLowercaseStringOrEmpty(params.suffix) === normalizeLowercaseStringOrEmpty(botUsername)
+  ) {
+    return true;
+  }
+  if (!params.isGroup) {
+    return false;
+  }
+  return !stripMentions(`@${params.suffix}`, params.ctx, params.cfg, params.agentId).trim();
+}
+
+function resolveAnchoredResetPayload(params: {
+  source: string;
+  trigger: string;
+  commandText: string;
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  agentId: string;
+  isGroup: boolean;
+}): string | undefined {
+  if (params.source === "") {
+    return undefined;
+  }
+  const messageStart = resolveExplicitMessageStart(params.source, params.ctx);
+  if (messageStart === undefined) {
+    return undefined;
+  }
+  const triggerStart = stripLeadingMention({ ...params, start: messageStart });
+  if (triggerStart === undefined) {
+    return undefined;
+  }
+
+  let payloadStart = triggerStart + params.trigger.length;
+  if (params.source[payloadStart] === "@") {
+    const suffixStart = payloadStart + 1;
+    payloadStart = suffixStart;
+    while (
+      params.source[payloadStart] !== undefined &&
+      params.source[payloadStart] !== ":" &&
+      !/\s/.test(params.source[payloadStart] ?? "")
+    ) {
+      payloadStart += 1;
+    }
+    const suffix = params.source.slice(suffixStart, payloadStart);
+    if (
+      !suffix ||
+      !isRecognizedCommandSuffix({
+        suffix,
+        ctx: params.ctx,
+        cfg: params.cfg,
+        agentId: params.agentId,
+        isGroup: params.isGroup,
+      })
+    ) {
+      return undefined;
+    }
+  }
+
+  const delimiter = params.source[payloadStart];
+  if (delimiter === undefined) {
+    return "";
+  }
+  if (delimiter === ":") {
+    payloadStart += 1;
+  } else if (!/\s/.test(delimiter)) {
+    return undefined;
+  }
+  return params.source.slice(payloadStart).trimStart();
+}
+
+function resolveCommandTextForSession(params: {
+  commandText: string;
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  agentId: string;
+  isGroup: boolean;
+}): string {
+  const messageStart = resolveExplicitMessageStart(params.commandText, params.ctx);
+  const anchored =
+    messageStart === undefined ? params.commandText.trim() : params.commandText.slice(messageStart);
+  const withoutMentions = params.isGroup
+    ? stripMentions(anchored, params.ctx, params.cfg, params.agentId)
+    : anchored;
+  return withoutMentions.replace(/\\n/g, " ").trim();
+}
+
+function isTranscriptOnlyCommand(ctx: MsgContext, commandText: string): boolean {
+  return (
+    typeof ctx.Transcript === "string" && commandText === ctx.Transcript.replace(/\\n/g, " ").trim()
+  );
+}
+
+export function resolveSessionResetCommand(params: {
+  commandText: string;
+  rawText: string;
+  resetTriggers: readonly string[];
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  agentId: string;
+  isGroup: boolean;
+  resetAuthorized: boolean;
+}): ResolvedSessionResetCommand {
+  const triggerBodyNormalized = resolveCommandTextForSession(params);
+  const normalizedResetBody = normalizeCommandBody(triggerBodyNormalized, {
+    botUsername: params.ctx.BotUsername,
+  });
+  const softResetMatched = parseSoftResetCommand(normalizedResetBody).matched;
+  const result = {
+    normalizedResetBody,
+    softResetMatched,
+    triggerBodyNormalized,
+  } satisfies ResolvedSessionResetCommand;
+
+  if (
+    !params.resetAuthorized ||
+    softResetMatched ||
+    isTranscriptOnlyCommand(params.ctx, params.commandText)
+  ) {
+    return result;
+  }
+
+  const normalizedResetBodyLower = normalizeLowercaseStringOrEmpty(normalizedResetBody);
+  for (const trigger of params.resetTriggers) {
+    const triggerLower = normalizeLowercaseStringOrEmpty(trigger);
+    if (
+      !triggerLower ||
+      (normalizedResetBodyLower !== triggerLower &&
+        !normalizedResetBodyLower.startsWith(`${triggerLower} `))
+    ) {
+      continue;
+    }
+    const payload = resolveAnchoredResetPayload({
+      source: params.rawText,
+      trigger,
+      commandText: params.commandText,
+      ctx: params.ctx,
+      cfg: params.cfg,
+      agentId: params.agentId,
+      isGroup: params.isGroup,
+    });
+    if (payload === undefined) {
+      continue;
+    }
+    return {
+      ...result,
+      matchedResetTriggerLower: triggerLower,
+      payload,
+    };
+  }
+
+  return result;
+}

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -7,6 +7,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { testing as sessionMcpTesting } from "../../agents/agent-bundle-mcp-runtime.js";
 import { getOrCreateSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
 import * as bootstrapCache from "../../agents/bootstrap-cache.js";
+import { buildChannelInboundEventContext } from "../../channels/inbound-event/context.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
 import {
@@ -1149,17 +1150,15 @@ describe("initSessionState RawBody", () => {
     },
   );
 
-  it("anchors a reset payload after structural brackets", async () => {
+  it("anchors a reset payload after an explicit channel envelope and sender prefix", async () => {
     const root = await makeCaseDir("openclaw-structural-reset-message-");
     const storePath = path.join(root, "sessions.json");
     const result = await initSessionState({
       ctx: {
-        CommandBody:
-          "[Chat messages since your last reply - for context]\n" +
-          "[Telegram /new id:123] Someone: old text\n\n" +
-          "[Current message - respond to this]\n" +
-          "[Telegram /new id:456] İpek: /NEW: keep [Q3]\nline 2",
+        BodyForCommands: "/NEW: keep [Q3]\nline 2",
+        RawBody: "[Telegram id:456] İpek: /NEW: keep [Q3]\nline 2",
         ChatType: "direct",
+        SenderName: "İpek",
         SessionKey: "agent:main:telegram:dm:s1",
       },
       cfg: {
@@ -1176,12 +1175,13 @@ describe("initSessionState RawBody", () => {
     expect(result.sessionCtx.agentText).toBe("keep [Q3]\nline 2");
   });
 
-  it("does not select a reset-like sender prefix as the command", async () => {
+  it("does not search past an anchored reset-like payload", async () => {
     const root = await makeCaseDir("openclaw-reset-like-sender-message-");
     const storePath = path.join(root, "sessions.json");
     const result = await initSessionState({
       ctx: {
-        CommandBody: "[Telegram id:456] /new: /NEW keep [Q3]\nline 2",
+        BodyForCommands: "/NEW keep [Q3]\nline 2",
+        RawBody: "[Telegram id:456] /new: /NEW keep [Q3]\nline 2",
         ChatType: "direct",
         SessionKey: "agent:main:telegram:dm:s1",
       },
@@ -1195,8 +1195,158 @@ describe("initSessionState RawBody", () => {
     });
 
     expect(result.isNewSession).toBe(true);
-    expect(result.bodyStripped).toBe("keep [Q3]\nline 2");
-    expect(result.sessionCtx.agentText).toBe("keep [Q3]\nline 2");
+    expect(result.bodyStripped).toBe("/NEW keep [Q3]\nline 2");
+    expect(result.sessionCtx.agentText).toBe("/NEW keep [Q3]\nline 2");
+  });
+
+  it("keeps quoted markers and reset text in history out of reset parsing", async () => {
+    const root = await makeCaseDir("openclaw-history-reset-message-");
+    const storePath = path.join(root, "sessions.json");
+    const payload = "review [Current message - respond to this]\nand explain /new syntax";
+    const ctx = buildChannelInboundEventContext({
+      channel: "whatsapp",
+      accountId: "default",
+      from: "whatsapp:user:1",
+      sender: { id: "1", name: "Owner" },
+      conversation: { kind: "group", id: "room-1", label: "Room One" },
+      route: {
+        agentId: "main",
+        routeSessionKey: "agent:main:whatsapp:group:room-1",
+      },
+      reply: { to: "whatsapp:room:room-1" },
+      message: {
+        body: `/new ${payload}`,
+        rawBody: `/new ${payload}`,
+        bodyForAgent: `/new ${payload}`,
+        commandBody: `/new ${payload}`,
+        inboundHistory: [
+          {
+            sender: "Other",
+            body: "quoted [Current message - respond to this] /new old text",
+          },
+        ],
+      },
+      access: { commands: { authorized: true } },
+    });
+    const result = await initSessionState({
+      ctx,
+      cfg: {
+        session: { store: storePath, resetTriggers: ["/new"] },
+      } as OpenClawConfig,
+      commandAuthorized: true,
+    });
+
+    expect(ctx).toMatchObject({
+      commandText: `/new ${payload}`,
+      rawText: `/new ${payload}`,
+      agentText: `/new ${payload}`,
+    });
+    expect(result.bodyStripped).toBe(payload);
+    expect(result.sessionCtx.agentText).toBe(payload);
+  });
+
+  it("supports a bounded Body-only legacy envelope without searching flat history", async () => {
+    const storePath = await createStorePath("openclaw-body-only-reset-");
+    const cfg = {
+      session: { store: storePath, resetTriggers: ["/new"] },
+    } as OpenClawConfig;
+
+    const legacy = await initSessionState({
+      ctx: {
+        Body: "[Telegram id:456] İpek: /NEW: keep [Q3]\nline 2",
+        ChatType: "direct",
+        SenderName: "İpek",
+        SessionKey: "agent:main:telegram:dm:legacy",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(legacy.resetTriggered).toBe(true);
+    expect(legacy.bodyStripped).toBe("keep [Q3]\nline 2");
+
+    const flatHistory = await initSessionState({
+      ctx: {
+        Body: [
+          "[Chat messages since your last reply - for context]",
+          "[Telegram id:123] Other: /new old text",
+          "",
+          "[Current message - respond to this]",
+          "[Telegram id:456] İpek: /new current text",
+        ].join("\n"),
+        ChatType: "direct",
+        SessionKey: "agent:main:telegram:dm:flat-history",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(flatHistory.resetTriggered).toBe(false);
+    expect(flatHistory.bodyStripped).toBeUndefined();
+  });
+
+  it("does not treat transcript-only or explicitly empty raw text as a reset command", async () => {
+    const storePath = await createStorePath("openclaw-audio-reset-");
+    const cfg = {
+      session: { store: storePath, resetTriggers: ["/new"] },
+    } as OpenClawConfig;
+
+    const transcriptOnly = await initSessionState({
+      ctx: {
+        Body: "/new spoken payload",
+        Transcript: "/new spoken payload",
+        ChatType: "direct",
+        SessionKey: "agent:main:whatsapp:dm:audio-transcript",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(transcriptOnly.resetTriggered).toBe(false);
+
+    const explicitEmptyRaw = await initSessionState({
+      ctx: {
+        Body: "/new spoken payload",
+        RawBody: "",
+        Transcript: "/new spoken payload",
+        ChatType: "direct",
+        SessionKey: "agent:main:whatsapp:dm:audio-empty-raw",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(explicitEmptyRaw.triggerBodyNormalized).toBe("");
+    expect(explicitEmptyRaw.resetTriggered).toBe(false);
+
+    const explicitCommandWithEmptyRaw = await initSessionState({
+      ctx: {
+        Body: "/new spoken payload",
+        BodyForCommands: "/new spoken payload",
+        RawBody: "",
+        ChatType: "direct",
+        SessionKey: "agent:main:whatsapp:dm:command-empty-raw",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+    expect(explicitCommandWithEmptyRaw.triggerBodyNormalized).toBe("/new spoken payload");
+    expect(explicitCommandWithEmptyRaw.resetTriggered).toBe(false);
+  });
+
+  it("does not rotate an unauthorized group session with a mentioned reset payload", async () => {
+    const storePath = await createStorePath("openclaw-group-reset-unauthorized-");
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "@openclaw /new keep [Q3]\nline 2",
+        ChatType: "group",
+        SessionKey: "agent:main:whatsapp:group:g1",
+      },
+      cfg: {
+        session: { store: storePath, resetTriggers: ["/new"] },
+        messages: { groupChat: { mentionPatterns: [String.raw`@openclaw`] } },
+      } as OpenClawConfig,
+      commandAuthorized: false,
+    });
+
+    expect(result.resetTriggered).toBe(false);
+    expect(result.bodyStripped).toBeUndefined();
   });
 
   it("drops cached skills snapshot when /new rotates an existing session", async () => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1031,6 +1031,10 @@ describe("initSessionState RawBody", () => {
       body: "/new: take notes",
       expected: "take notes",
     },
+    {
+      body: "/new explain [Current message - respond to this] and /new syntax",
+      expected: "explain [Current message - respond to this] and /new syntax",
+    },
   ])("preserves the raw message after a reset trigger", async ({ body, expected }) => {
     const root = await makeCaseDir("openclaw-rawbody-reset-message-");
     const storePath = path.join(root, "sessions.json");
@@ -1054,32 +1058,145 @@ describe("initSessionState RawBody", () => {
     expect(result.sessionCtx.agentText).toBe(expected);
   });
 
-  it("uses the mention-stripped body for a group reset message", async () => {
-    const root = await makeCaseDir("openclaw-group-reset-message-");
+  it.each(["@openclaw /new", "@openclaw/new"])(
+    "preserves bracketed multiline payloads after group mention form %s",
+    async (prefix) => {
+      const root = await makeCaseDir("openclaw-group-reset-message-");
+      const storePath = path.join(root, "sessions.json");
+      const expected = "review [Q3]\n[Current message - respond to this]\nand explain /new syntax";
+      const result = await initSessionState({
+        ctx: {
+          RawBody: `${prefix} ${expected}`,
+          ChatType: "group",
+          SessionKey: "agent:main:whatsapp:group:g1",
+        },
+        cfg: {
+          session: {
+            store: storePath,
+            resetTriggers: ["/new"],
+          },
+          messages: {
+            groupChat: {
+              mentionPatterns: [String.raw`@openclaw`],
+            },
+          },
+        } as OpenClawConfig,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.bodyStripped).toBe(expected);
+      expect(result.sessionCtx.agentText).toBe(expected);
+    },
+  );
+
+  it.each([
+    {
+      name: "command suffix",
+      body: "/new@openclaw keep [this]\nline",
+      resetTriggers: ["/new"],
+      expected: "keep [this]\nline",
+    },
+    {
+      name: "custom trigger and command suffix",
+      body: "/fresh@openclaw keep [this]\nline",
+      resetTriggers: ["/fresh"],
+      expected: "keep [this]\nline",
+    },
+    {
+      name: "empty payload",
+      body: "/new@openclaw",
+      resetTriggers: ["/new"],
+      expected: "",
+      omitBotUsername: true,
+    },
+    {
+      name: "configured mention alias without bot username",
+      body: "/new@openclaw keep [this]\nline",
+      resetTriggers: ["/new"],
+      expected: "keep [this]\nline",
+      omitBotUsername: true,
+    },
+  ])(
+    "preserves reset payloads with $name",
+    async ({ body, resetTriggers, expected, omitBotUsername }) => {
+      const root = await makeCaseDir("openclaw-suffixed-reset-message-");
+      const storePath = path.join(root, "sessions.json");
+      const result = await initSessionState({
+        ctx: {
+          RawBody: body,
+          BotUsername: omitBotUsername ? undefined : "openclaw",
+          ChatType: omitBotUsername ? "group" : "direct",
+          SessionKey: "agent:main:telegram:dm:s1",
+        },
+        cfg: {
+          session: {
+            store: storePath,
+            resetTriggers,
+          },
+          messages: {
+            groupChat: {
+              mentionPatterns: [String.raw`@openclaw`],
+            },
+          },
+        } as OpenClawConfig,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.bodyStripped).toBe(expected);
+      expect(result.sessionCtx.agentText).toBe(expected);
+    },
+  );
+
+  it("anchors a reset payload after structural brackets", async () => {
+    const root = await makeCaseDir("openclaw-structural-reset-message-");
     const storePath = path.join(root, "sessions.json");
     const result = await initSessionState({
       ctx: {
-        RawBody: "@openclaw /new take notes",
-        ChatType: "group",
-        SessionKey: "agent:main:whatsapp:group:g1",
+        CommandBody:
+          "[Chat messages since your last reply - for context]\n" +
+          "[Telegram /new id:123] Someone: old text\n\n" +
+          "[Current message - respond to this]\n" +
+          "[Telegram /new id:456] İpek: /NEW: keep [Q3]\nline 2",
+        ChatType: "direct",
+        SessionKey: "agent:main:telegram:dm:s1",
       },
       cfg: {
         session: {
           store: storePath,
           resetTriggers: ["/new"],
         },
-        messages: {
-          groupChat: {
-            mentionPatterns: [String.raw`@openclaw`],
-          },
+      } as OpenClawConfig,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.bodyStripped).toBe("keep [Q3]\nline 2");
+    expect(result.sessionCtx.agentText).toBe("keep [Q3]\nline 2");
+  });
+
+  it("does not select a reset-like sender prefix as the command", async () => {
+    const root = await makeCaseDir("openclaw-reset-like-sender-message-");
+    const storePath = path.join(root, "sessions.json");
+    const result = await initSessionState({
+      ctx: {
+        CommandBody: "[Telegram id:456] /new: /NEW keep [Q3]\nline 2",
+        ChatType: "direct",
+        SessionKey: "agent:main:telegram:dm:s1",
+      },
+      cfg: {
+        session: {
+          store: storePath,
+          resetTriggers: ["/new"],
         },
       } as OpenClawConfig,
       commandAuthorized: true,
     });
 
     expect(result.isNewSession).toBe(true);
-    expect(result.bodyStripped).toBe("take notes");
-    expect(result.sessionCtx.agentText).toBe("take notes");
+    expect(result.bodyStripped).toBe("keep [Q3]\nline 2");
+    expect(result.sessionCtx.agentText).toBe("keep [Q3]\nline 2");
   });
 
   it("drops cached skills snapshot when /new rotates an existing session", async () => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1013,6 +1013,75 @@ describe("initSessionState RawBody", () => {
     expect(result.triggerBodyNormalized).toBe("/NEW KeepThisCase");
   });
 
+  it.each([
+    {
+      body: "/new review this snippet:\ndef add(a, b):\nreturn a + b",
+      expected: "review this snippet:\ndef add(a, b):\nreturn a + b",
+    },
+    {
+      body: "/new Please fix this bug:\n[2026-07-29 10:00:00] ERROR: connection refused\nStack: at foo()",
+      expected:
+        "Please fix this bug:\n[2026-07-29 10:00:00] ERROR: connection refused\nStack: at foo()",
+    },
+    {
+      body: "/new summarize [Q3 report] for me",
+      expected: "summarize [Q3 report] for me",
+    },
+    {
+      body: "/new: take notes",
+      expected: "take notes",
+    },
+  ])("preserves the raw message after a reset trigger", async ({ body, expected }) => {
+    const root = await makeCaseDir("openclaw-rawbody-reset-message-");
+    const storePath = path.join(root, "sessions.json");
+    const result = await initSessionState({
+      ctx: {
+        RawBody: body,
+        ChatType: "direct",
+        SessionKey: "agent:main:whatsapp:dm:s1",
+      },
+      cfg: {
+        session: {
+          store: storePath,
+          resetTriggers: ["/new"],
+        },
+      } as OpenClawConfig,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.bodyStripped).toBe(expected);
+    expect(result.sessionCtx.agentText).toBe(expected);
+  });
+
+  it("uses the mention-stripped body for a group reset message", async () => {
+    const root = await makeCaseDir("openclaw-group-reset-message-");
+    const storePath = path.join(root, "sessions.json");
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "@openclaw /new take notes",
+        ChatType: "group",
+        SessionKey: "agent:main:whatsapp:group:g1",
+      },
+      cfg: {
+        session: {
+          store: storePath,
+          resetTriggers: ["/new"],
+        },
+        messages: {
+          groupChat: {
+            mentionPatterns: [String.raw`@openclaw`],
+          },
+        },
+      } as OpenClawConfig,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.bodyStripped).toBe("take notes");
+    expect(result.sessionCtx.agentText).toBe("take notes");
+  });
+
   it("drops cached skills snapshot when /new rotates an existing session", async () => {
     const root = await makeCaseDir("openclaw-rawbody-reset-skills-");
     const storePath = path.join(root, "sessions.json");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -549,7 +549,8 @@ async function initSessionStateAttemptLocked(
   // Reset triggers are configured as lowercased commands (e.g. "/new"), but users may type
   // "/NEW" etc. Match case-insensitively while keeping the original casing for any stripped body.
   const trimmedBodyLower = normalizeLowercaseStringOrEmpty(trimmedBody);
-  const strippedForResetLower = normalizeLowercaseStringOrEmpty(normalizedResetBody);
+  const strippedForResetLower = normalizeLowercaseStringOrEmpty(strippedForReset);
+  const normalizedResetBodyLower = normalizeLowercaseStringOrEmpty(normalizedResetBody);
   let matchedResetTriggerLower: string | undefined;
 
   for (const trigger of resetTriggers) {
@@ -560,7 +561,11 @@ async function initSessionStateAttemptLocked(
       break;
     }
     const triggerLower = normalizeLowercaseStringOrEmpty(trigger);
-    if (trimmedBodyLower === triggerLower || strippedForResetLower === triggerLower) {
+    if (
+      trimmedBodyLower === triggerLower ||
+      strippedForResetLower === triggerLower ||
+      normalizedResetBodyLower === triggerLower
+    ) {
       isNewSession = true;
       bodyStripped = "";
       resetTriggered = true;
@@ -571,10 +576,16 @@ async function initSessionStateAttemptLocked(
     if (
       !softReset.matched &&
       (trimmedBodyLower.startsWith(triggerPrefixLower) ||
-        strippedForResetLower.startsWith(triggerPrefixLower))
+        strippedForResetLower.startsWith(triggerPrefixLower) ||
+        normalizedResetBodyLower.startsWith(triggerPrefixLower))
     ) {
       isNewSession = true;
-      bodyStripped = normalizedResetBody.slice(trigger.length).trimStart();
+      const matchedBody = trimmedBodyLower.startsWith(triggerPrefixLower)
+        ? trimmedBody
+        : strippedForResetLower.startsWith(triggerPrefixLower)
+          ? strippedForReset
+          : normalizedResetBody;
+      bodyStripped = matchedBody.slice(trigger.length).trimStart();
       resetTriggered = true;
       matchedResetTriggerLower = triggerLower;
       break;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -102,6 +102,7 @@ import type {
 import { resolveEffectiveResetTargetSessionKey } from "./acp-reset-target.js";
 import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
+import { resolveCurrentMessageContentStart } from "./history.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { replyRunRegistry } from "./reply-run-registry.js";
@@ -138,6 +139,100 @@ type ReplySessionEndReason = Extract<
 
 function resolveExplicitSessionEndReason(matchedResetTriggerLower?: string): ReplySessionEndReason {
   return matchedResetTriggerLower === "/reset" ? "reset" : "new";
+}
+
+function resolveResetPayloadFromOriginal(params: {
+  source: string;
+  trigger: string;
+}): string | undefined {
+  const trigger = normalizeOptionalString(params.trigger);
+  if (!trigger) {
+    return undefined;
+  }
+  const triggerLower = trigger.toLowerCase();
+
+  let searchStart = resolveCurrentMessageContentStart(params.source) ?? 0;
+  let cursor = searchStart;
+  while (/\s/.test(params.source[cursor] ?? "")) {
+    cursor += 1;
+  }
+  let removedEnvelope = false;
+  while (params.source[cursor] === "[") {
+    const envelopeEnd = params.source.indexOf("]", cursor + 1);
+    if (envelopeEnd === -1) {
+      break;
+    }
+    removedEnvelope = true;
+    cursor = envelopeEnd + 1;
+    while (/\s/.test(params.source[cursor] ?? "")) {
+      cursor += 1;
+    }
+  }
+  if (removedEnvelope) {
+    const lineEnd = params.source.indexOf("\n", cursor);
+    const senderPrefixEnd = params.source.indexOf(":", cursor);
+    const effectiveLineEnd = lineEnd === -1 ? params.source.length : lineEnd;
+    if (
+      senderPrefixEnd !== -1 &&
+      senderPrefixEnd < effectiveLineEnd &&
+      senderPrefixEnd - cursor <= 120
+    ) {
+      cursor = senderPrefixEnd + 1;
+      while (/\s/.test(params.source[cursor] ?? "")) {
+        cursor += 1;
+      }
+    }
+  }
+  searchStart = cursor;
+  let bracketDepth = 0;
+
+  for (let index = searchStart; index < params.source.length; index += 1) {
+    const char = params.source[index];
+    if (char === "[") {
+      bracketDepth += 1;
+      continue;
+    }
+    if (char === "]") {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+      continue;
+    }
+    if (
+      bracketDepth > 0 ||
+      params.source.slice(index, index + trigger.length).toLowerCase() !== triggerLower
+    ) {
+      continue;
+    }
+
+    let payloadStart = index + trigger.length;
+    if (params.source[payloadStart] === "@") {
+      payloadStart += 1;
+      const suffixStart = payloadStart;
+      while (
+        params.source[payloadStart] !== undefined &&
+        params.source[payloadStart] !== ":" &&
+        !/\s/.test(params.source[payloadStart] ?? "")
+      ) {
+        payloadStart += 1;
+      }
+      if (payloadStart === suffixStart) {
+        continue;
+      }
+    }
+
+    const delimiter = params.source[payloadStart];
+    if (delimiter === undefined) {
+      return "";
+    }
+    if (delimiter === ":") {
+      payloadStart += 1;
+    } else if (!/\s/.test(delimiter)) {
+      continue;
+    }
+
+    return params.source.slice(payloadStart).trimStart();
+  }
+
+  return undefined;
 }
 
 function resolveSessionDefaultAccountId(params: {
@@ -573,19 +668,24 @@ async function initSessionStateAttemptLocked(
       break;
     }
     const triggerPrefixLower = `${triggerLower} `;
+    const rawPrefixMatched = trimmedBodyLower.startsWith(triggerPrefixLower);
+    const strippedPrefixMatched = strippedForResetLower.startsWith(triggerPrefixLower);
+    const normalizedPrefixMatched = normalizedResetBodyLower.startsWith(triggerPrefixLower);
     if (
       !softReset.matched &&
-      (trimmedBodyLower.startsWith(triggerPrefixLower) ||
-        strippedForResetLower.startsWith(triggerPrefixLower) ||
-        normalizedResetBodyLower.startsWith(triggerPrefixLower))
+      (rawPrefixMatched || strippedPrefixMatched || normalizedPrefixMatched)
     ) {
+      // Detection projections discard wrappers, mentions, and whitespace. Payload bytes must
+      // come from the original range so bracketed and multiline user text stays intact.
+      const resetPayload = resolveResetPayloadFromOriginal({
+        source: commandSource,
+        trigger,
+      });
+      if (resetPayload === undefined) {
+        continue;
+      }
       isNewSession = true;
-      const matchedBody = trimmedBodyLower.startsWith(triggerPrefixLower)
-        ? trimmedBody
-        : strippedForResetLower.startsWith(triggerPrefixLower)
-          ? strippedForReset
-          : normalizedResetBody;
-      bodyStripped = matchedBody.slice(trigger.length).trimStart();
+      bodyStripped = resetPayload;
       resetTriggered = true;
       matchedResetTriggerLower = triggerLower;
       break;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -1,7 +1,6 @@
 // Manages reply session records, labels, ids, and route persistence.
 import crypto from "node:crypto";
 import {
-  normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
@@ -93,18 +92,14 @@ import {
   sessionDeliveryRoute,
 } from "../../utils/delivery-context.shared.js";
 import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
-import { normalizeCommandBody } from "../commands-registry.js";
 import type {
   FinalizedRuntimeMsgContext,
   FinalizedTemplateContext as TemplateContext,
   MsgContext,
 } from "../templating.js";
 import { resolveEffectiveResetTargetSessionKey } from "./acp-reset-target.js";
-import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
-import { resolveCurrentMessageContentStart } from "./history.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
-import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { replyRunRegistry } from "./reply-run-registry.js";
 import { isResetAuthorizedForContext } from "./reset-authorization.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
@@ -124,6 +119,7 @@ import {
 } from "./session-init-conflict-retry.js";
 import { prepareReplySessionParentFork } from "./session-parent-fork-prepare.js";
 import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
+import { resolveSessionResetCommand } from "./session-reset-command.js";
 import {
   stripThreadFromSessionRoute,
   stripThreadIdFromDeliveryContext,
@@ -139,100 +135,6 @@ type ReplySessionEndReason = Extract<
 
 function resolveExplicitSessionEndReason(matchedResetTriggerLower?: string): ReplySessionEndReason {
   return matchedResetTriggerLower === "/reset" ? "reset" : "new";
-}
-
-function resolveResetPayloadFromOriginal(params: {
-  source: string;
-  trigger: string;
-}): string | undefined {
-  const trigger = normalizeOptionalString(params.trigger);
-  if (!trigger) {
-    return undefined;
-  }
-  const triggerLower = trigger.toLowerCase();
-
-  let searchStart = resolveCurrentMessageContentStart(params.source) ?? 0;
-  let cursor = searchStart;
-  while (/\s/.test(params.source[cursor] ?? "")) {
-    cursor += 1;
-  }
-  let removedEnvelope = false;
-  while (params.source[cursor] === "[") {
-    const envelopeEnd = params.source.indexOf("]", cursor + 1);
-    if (envelopeEnd === -1) {
-      break;
-    }
-    removedEnvelope = true;
-    cursor = envelopeEnd + 1;
-    while (/\s/.test(params.source[cursor] ?? "")) {
-      cursor += 1;
-    }
-  }
-  if (removedEnvelope) {
-    const lineEnd = params.source.indexOf("\n", cursor);
-    const senderPrefixEnd = params.source.indexOf(":", cursor);
-    const effectiveLineEnd = lineEnd === -1 ? params.source.length : lineEnd;
-    if (
-      senderPrefixEnd !== -1 &&
-      senderPrefixEnd < effectiveLineEnd &&
-      senderPrefixEnd - cursor <= 120
-    ) {
-      cursor = senderPrefixEnd + 1;
-      while (/\s/.test(params.source[cursor] ?? "")) {
-        cursor += 1;
-      }
-    }
-  }
-  searchStart = cursor;
-  let bracketDepth = 0;
-
-  for (let index = searchStart; index < params.source.length; index += 1) {
-    const char = params.source[index];
-    if (char === "[") {
-      bracketDepth += 1;
-      continue;
-    }
-    if (char === "]") {
-      bracketDepth = Math.max(0, bracketDepth - 1);
-      continue;
-    }
-    if (
-      bracketDepth > 0 ||
-      params.source.slice(index, index + trigger.length).toLowerCase() !== triggerLower
-    ) {
-      continue;
-    }
-
-    let payloadStart = index + trigger.length;
-    if (params.source[payloadStart] === "@") {
-      payloadStart += 1;
-      const suffixStart = payloadStart;
-      while (
-        params.source[payloadStart] !== undefined &&
-        params.source[payloadStart] !== ":" &&
-        !/\s/.test(params.source[payloadStart] ?? "")
-      ) {
-        payloadStart += 1;
-      }
-      if (payloadStart === suffixStart) {
-        continue;
-      }
-    }
-
-    const delimiter = params.source[payloadStart];
-    if (delimiter === undefined) {
-      return "";
-    }
-    if (delimiter === ":") {
-      payloadStart += 1;
-    } else if (!/\s/.test(delimiter)) {
-      continue;
-    }
-
-    return params.source.slice(payloadStart).trimStart();
-  }
-
-  return undefined;
 }
 
 function resolveSessionDefaultAccountId(params: {
@@ -618,78 +520,26 @@ async function initSessionStateAttemptLocked(
   const isGroup =
     normalizedChatType != null && normalizedChatType !== "direct" ? true : Boolean(groupResolution);
   const commandSource = ctx.commandText ?? "";
-  // IMPORTANT: do NOT lowercase the entire command body.
-  // Users often pass case-sensitive arguments (e.g. filesystem paths on Linux).
-  // Command parsing downstream lowercases only the command token for matching.
-  const triggerBodyNormalized = stripStructuralPrefixes(commandSource).trim();
-
-  // Use CommandBody/RawBody for reset trigger matching (clean message without structural context).
-  const rawBody = commandSource;
-  const trimmedBody = rawBody.trim();
   const resetAuthorized = isResetAuthorizedForContext({
     ctx,
     cfg,
     commandAuthorized,
   });
-  // Timestamp/message prefixes (e.g. "[Dec 4 17:35] ") are added by the
-  // web inbox before we get here. They prevented reset triggers like "/new"
-  // from matching, so strip structural wrappers when checking for resets.
-  const strippedForReset = isGroup
-    ? stripMentions(triggerBodyNormalized, ctx, cfg, agentId)
-    : triggerBodyNormalized;
-  const normalizedResetBody = normalizeCommandBody(strippedForReset, {
-    botUsername: ctx.BotUsername,
+  const resetCommand = resolveSessionResetCommand({
+    commandText: commandSource,
+    rawText: ctx.rawText,
+    resetTriggers,
+    ctx,
+    cfg,
+    agentId,
+    isGroup,
+    resetAuthorized,
   });
-  const softReset = parseSoftResetCommand(normalizedResetBody);
-  // Reset triggers are configured as lowercased commands (e.g. "/new"), but users may type
-  // "/NEW" etc. Match case-insensitively while keeping the original casing for any stripped body.
-  const trimmedBodyLower = normalizeLowercaseStringOrEmpty(trimmedBody);
-  const strippedForResetLower = normalizeLowercaseStringOrEmpty(strippedForReset);
-  const normalizedResetBodyLower = normalizeLowercaseStringOrEmpty(normalizedResetBody);
-  let matchedResetTriggerLower: string | undefined;
-
-  for (const trigger of resetTriggers) {
-    if (!trigger) {
-      continue;
-    }
-    if (!resetAuthorized) {
-      break;
-    }
-    const triggerLower = normalizeLowercaseStringOrEmpty(trigger);
-    if (
-      trimmedBodyLower === triggerLower ||
-      strippedForResetLower === triggerLower ||
-      normalizedResetBodyLower === triggerLower
-    ) {
-      isNewSession = true;
-      bodyStripped = "";
-      resetTriggered = true;
-      matchedResetTriggerLower = triggerLower;
-      break;
-    }
-    const triggerPrefixLower = `${triggerLower} `;
-    const rawPrefixMatched = trimmedBodyLower.startsWith(triggerPrefixLower);
-    const strippedPrefixMatched = strippedForResetLower.startsWith(triggerPrefixLower);
-    const normalizedPrefixMatched = normalizedResetBodyLower.startsWith(triggerPrefixLower);
-    if (
-      !softReset.matched &&
-      (rawPrefixMatched || strippedPrefixMatched || normalizedPrefixMatched)
-    ) {
-      // Detection projections discard wrappers, mentions, and whitespace. Payload bytes must
-      // come from the original range so bracketed and multiline user text stays intact.
-      const resetPayload = resolveResetPayloadFromOriginal({
-        source: commandSource,
-        trigger,
-      });
-      if (resetPayload === undefined) {
-        continue;
-      }
-      isNewSession = true;
-      bodyStripped = resetPayload;
-      resetTriggered = true;
-      matchedResetTriggerLower = triggerLower;
-      break;
-    }
+  const { matchedResetTriggerLower, softResetMatched, triggerBodyNormalized } = resetCommand;
+  if (matchedResetTriggerLower !== undefined) {
+    isNewSession = true;
+    bodyStripped = resetCommand.payload ?? "";
+    resetTriggered = true;
   }
 
   // Canonicalize so the written key matches what all read paths produce.
@@ -805,7 +655,7 @@ async function initSessionStateAttemptLocked(
         })
     : undefined;
   const softResetAllowed =
-    softReset.matched &&
+    softResetMatched &&
     resetAuthorized &&
     !isAcpSessionKey(
       resolveEffectiveResetTargetSessionKey({


### PR DESCRIPTION
## What Problem This Solves

Fixes corruption of the message retained after `/new <message>`, `/reset <message>`, or a configured reset trigger. Bracketed text, multiline code/logs, mention-wrapped commands, and structural channel wrappers now reach the reset session intact.

## Root Cause

Reset detection intentionally uses normalized projections that strip channel wrappers, mentions, bracketed metadata, and whitespace. The retained payload was then inferred from those lossy projections or marker-shaped history text, so detection normalization silently became a user-message transform.

## Fix

- Detect reset commands from the canonical command projection and extract payload bytes only from the current raw inbound projection.
- Share one session-owned parser between the full and fast initialization paths.
- Refuse destructive reset parsing when raw input is explicitly empty, transcript-only, unauthorized, or ambiguously history-wrapped.
- Preserve literal current-message markers, brackets, casing, whitespace, and multiline payloads.
- Keep Telegram topic recovery limited to routing/history recovery instead of rewriting current-message projections.

`initSessionState` remains the owner boundary: it detects explicit resets and constructs `sessionCtx.agentText`, which becomes the model prompt body.

## Evidence

Final patched head: `e9cfc70e7cc332f6243335c3de620f52529103f8`

- Final structured autoreview: clean, no accepted/actionable findings.
- Focused Blacksmith Testbox proof:
  - `session.test.ts`: 160 passed.
  - `get-reply.fast-path.test.ts`: 26 passed.
  - `get-reply-directives.target-session.test.ts`: 29 passed.
  - `get-reply-native-slash-fast-path.test.ts`: 9 passed.
  - `abort.test.ts`: 33 passed.
  - `mentions.test.ts`: 24 passed.
  - `inbound-context.test.ts`: 29 passed.
  - Telegram context-history test: 4 passed.
- Fresh isolated final-patch Testbox proof: fast path 26 passed and Telegram context history 4 passed.
  - Run: https://github.com/openclaw/openclaw/actions/runs/30611268911
- QA scenario catalog: 8 passed.
- Dead-code export and full-tree checks: passed.
- Full local `pnpm build`: passed.
- Full local `pnpm check`: passed.
- Touched-file formatting/lint, `git diff --check`, and TruffleHog: passed.

A separate pre-push full-suite Testbox lease produced no test verdict for 1h32m and exited `-1` at the transport layer. It is not counted as proof. Hosted exact-head CI, including its full suite, is mandatory before merge.

## Real Behavior Proof

The committed `session-reset-payload-preservation` QA scenario drives a real ephemeral Gateway child, the QA channel API, and the mock OpenAI provider. It seeds a direct channel session, sends this exact inbound turn, inspects the provider request, and waits for the visible channel reply:

```text
/new review [Q3 report]
[Current message - respond to this]
and explain /new syntax
Reply exactly: QA-RESET-PAYLOAD-OK
```

Final verdict:

```json
{
  "verdict": "PASS",
  "scenario": "session-reset-payload-preservation",
  "channel": "qa-channel",
  "provider": "mock-openai",
  "gateway": "ephemeral-child",
  "lifecycleReset": true,
  "durableSessionRetained": true,
  "payloadPreserved": true,
  "commandRemoved": true,
  "replyDelivered": true
}
```

The provider received the exact multiline payload once without the `/new` prefix, the durable channel session retained its ID while its lifecycle revision reset, and the channel delivered `QA-RESET-PAYLOAD-OK`. This satisfies the repository real-behavior gate for channel-visible changes. Deterministic Telegram dispatch-context coverage separately exercises the Telegram projection seam.
