### PR TITLE
fix(macos): preserve Voice Wake listening indicator

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -329,7 +329,7 @@ final class AppState {
         didSet { self.ifNotPreview { UserDefaults.standard.set(self.remoteCliPath, forKey: remoteCliPathKey) } }
     }
 
-    private var earBoostTask: Task<Void, Never>?
+    @ObservationIgnored private var earBoostTask: Task<Void, Never>?
 
     init(
         preview: Bool = false,
@@ -782,13 +782,20 @@ final class AppState {
 
     func triggerVoiceEars(ttl: TimeInterval? = 5) {
         self.earBoostTask?.cancel()
+        self.earBoostTask = nil
         self.earBoostActive = true
 
         guard let ttl else { return }
 
         self.earBoostTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(ttl * 1_000_000_000))
-            await MainActor.run { [weak self] in self?.earBoostActive = false }
+            do {
+                try await Task.sleep(nanoseconds: UInt64(ttl * 1_000_000_000))
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self else { return }
+            self.earBoostTask = nil
+            self.earBoostActive = false
         }
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateVoiceEarsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateVoiceEarsTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct AppStateVoiceEarsTests {
+    @Test func `indefinite ear boost survives cancelled expiry`() async throws {
+        let state = AppState(preview: true)
+        state.triggerVoiceEars(ttl: 60)
+        state.triggerVoiceEars(ttl: nil)
+
+        try await Task.sleep(for: .milliseconds(20))
+
+        #expect(state.earBoostActive)
+        state.stopVoiceEars()
+    }
+
+    @Test func `replacement expiry owns ear boost lifetime`() async throws {
+        let state = AppState(preview: true)
+        state.triggerVoiceEars(ttl: 60)
+        state.triggerVoiceEars(ttl: 0.05)
+
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(state.earBoostActive)
+
+        try await Task.sleep(for: .milliseconds(60))
+        #expect(!state.earBoostActive)
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where starting a new Voice Wake capture could still let an older expiry task clear the menu-bar listening indicator. This was especially visible when a timed capture was replaced by an indefinite capture or by a later timed capture.

## Why This Change Was Made

The active expiry task now owns the indicator lifetime. Replacing or cancelling that task prevents it from clearing newer Voice Wake state, while the current expiry still clears the indicator normally.

## User Impact

The macOS listening indicator now stays active for the current Voice Wake capture instead of disappearing when a superseded timer expires.

## Evidence

- `swift test --package-path apps/macos --scratch-path apps/macos/.build-local --filter AppStateVoiceEarsTests`: 2 tests passed.
- `swiftformat --lint --config config/swiftformat ...`: 0 files require formatting.
- `swiftlint lint --strict --config config/swiftlint.yml ...`: 0 violations.
- `node scripts/check-changed.mjs -- CHANGELOG.md apps/macos/Sources/OpenClaw/AppState.swift apps/macos/Tests/OpenClawIPCTests/AppStateVoiceEarsTests.swift`: passed on Blacksmith Testbox on the implementation-equivalent prior head; 211 tests passed, 37 skipped. The only subsequent change removed the release-owned changelog entry.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base 86d300a3cb80c4cc4d719698c3ba1364ab606227`: clean on final head `11f73dc72c5`, no accepted/actionable findings, confidence 0.96.

AI-assisted; implementation and proof reviewed by the author.
