### PR TITLE
fix: avoid duplicate loading for dynamic Control UI links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding duplicate Gateway requests during startup. Thanks @shakkernerd.
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.
 - **macOS location permission requests:** coalesce concurrent prompts so every caller resumes, and stop cancelled timeouts from opening Settings or completing a newer request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding duplicate Gateway requests during startup. Thanks @shakkernerd.
+- **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.
 - **macOS location permission requests:** coalesce concurrent prompts so every caller resumes, and stop cancelled timeouts from opening Settings or completing a newer request.

--- a/ui/src/app-route-paths.test.ts
+++ b/ui/src/app-route-paths.test.ts
@@ -8,8 +8,10 @@ import {
   pathForMemoryTab,
   pathForAgentPanel,
   pathForPluginsHubTab,
+  pathForWorkboardBoard,
   pluginsHubTabFromPath,
   routeIdFromPath,
+  type RouteId,
   type MemoryRouteTab,
   type PluginsHubRouteTab,
 } from "./app-route-paths.ts";
@@ -26,6 +28,167 @@ const AGENT_PANEL_CASES = [
   "cron",
   "memory",
 ] as const satisfies readonly AgentsPanel[];
+
+const DYNAMIC_STARTUP_CASES = [
+  {
+    label: "agent panel",
+    routeId: "agents",
+    location: {
+      pathname: pathForAgentPanel("team.writer", "tools"),
+      search: "?probe=1",
+      hash: "#catalog",
+    },
+  },
+  {
+    label: "chat session",
+    routeId: "chat",
+    location: {
+      pathname: "/chat/main/01JSESSIONA",
+      search: "?probe=1",
+      hash: "#message",
+    },
+  },
+  {
+    label: "dashboard session",
+    routeId: "dashboard",
+    location: {
+      pathname: "/dashboard/main/01JSESSIONA",
+      search: "?probe=1",
+      hash: "#dashboard",
+    },
+  },
+  {
+    label: "workboard board",
+    routeId: "workboard",
+    location: {
+      pathname: pathForWorkboardBoard("ops.v2"),
+      search: "?agent=main",
+      hash: "#queue",
+    },
+  },
+  {
+    label: "Memory tab",
+    routeId: "memory",
+    location: {
+      pathname: pathForMemoryTab("settings"),
+      search: "?probe=1",
+      hash: "#memory-backend",
+    },
+  },
+  {
+    label: "Plugins tab",
+    routeId: "plugins",
+    location: {
+      pathname: pathForPluginsHubTab("discover"),
+      search: "?query=calendar",
+      hash: "#featured",
+    },
+  },
+] as const satisfies readonly {
+  label: string;
+  routeId: RouteId;
+  location: RouteLocation;
+}[];
+
+describe("Dynamic route startup bridge", () => {
+  it.each(DYNAMIC_STARTUP_CASES)(
+    "loads the $label once while publishing its real location",
+    async ({ routeId, location: initialLocation }) => {
+      let location: RouteLocation = { ...initialLocation };
+      const history: RouterHistory = {
+        location: () => location,
+        push: vi.fn((next: RouteLocation) => {
+          location = next;
+        }),
+        replace: vi.fn((next: RouteLocation) => {
+          location = next;
+        }),
+        listen: () => () => undefined,
+      };
+      const router = createApplicationRouter();
+      const route = router.getRoute(routeId);
+      if (!route) {
+        throw new Error(`Route missing: ${routeId}`);
+      }
+      const loader = vi.fn(async () => ({ routeId }));
+      const originalLoader = route.loader;
+      const originalComponent = route.component;
+      try {
+        route.loader = loader;
+        route.component = async () => ({ render: () => null });
+
+        await startApplicationRouter(router, history, "", {
+          basePath: "",
+        } as unknown as ApplicationContext);
+
+        expect(loader).toHaveBeenCalledOnce();
+        expect(router.getState().location).toEqual(initialLocation);
+        expect(router.getState().matches[0]?.location).toEqual(initialLocation);
+      } finally {
+        router.stop();
+        route.loader = originalLoader;
+        route.component = originalComponent;
+      }
+    },
+  );
+
+  it("loads a later dynamic history destination exactly once", async () => {
+    let location: RouteLocation = {
+      pathname: "/chat/main/01JSESSIONA",
+      search: "",
+      hash: "#first",
+    };
+    let historyListener: ((next: RouteLocation) => void) | undefined;
+    const history: RouterHistory = {
+      location: () => location,
+      push: vi.fn((next: RouteLocation) => {
+        location = next;
+      }),
+      replace: vi.fn((next: RouteLocation) => {
+        location = next;
+      }),
+      listen: (listener) => {
+        historyListener = listener;
+        return () => {
+          historyListener = undefined;
+        };
+      },
+    };
+    const router = createApplicationRouter();
+    const route = router.getRoute("chat");
+    if (!route) {
+      throw new Error("Chat route missing");
+    }
+    const loader = vi.fn(async () => ({}));
+    const originalLoader = route.loader;
+    const originalComponent = route.component;
+    try {
+      route.loader = loader;
+      route.component = async () => ({ render: () => null });
+
+      await startApplicationRouter(router, history, "", {
+        basePath: "",
+      } as unknown as ApplicationContext);
+      expect(loader).toHaveBeenCalledOnce();
+
+      location = {
+        pathname: "/chat/main/01JSESSIONB",
+        search: "?probe=1",
+        hash: "#second",
+      };
+      historyListener?.(location);
+
+      await vi.waitFor(() => {
+        expect(loader).toHaveBeenCalledTimes(2);
+        expect(router.getState().location).toEqual(location);
+      });
+    } finally {
+      router.stop();
+      route.loader = originalLoader;
+      route.component = originalComponent;
+    }
+  });
+});
 
 describe("Agent panel route paths", () => {
   it.each(AGENT_PANEL_CASES)("round-trips the %s panel with an encoded agent id", (panel) => {

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -9,7 +9,6 @@ import {
   memoryTabFromPath,
   pathForAgentPanel,
   pathForRoute,
-  pathForWorkboardBoard,
   pluginsHubTabFromPath,
   routeIdFromPath,
   sessionRouteNamespaceFromPath,
@@ -95,61 +94,7 @@ const APP_ROUTE_TREE = [
   pluginPage,
 ] as const;
 
-const DYNAMIC_PATH_PARAM_BY_ROUTE: Partial<Record<RouteId, string>> = {
-  agents: INTERNAL_AGENT_PATH_PARAM,
-  chat: INTERNAL_SESSION_PATH_PARAM,
-  dashboard: INTERNAL_SESSION_PATH_PARAM,
-  memory: INTERNAL_MEMORY_PATH_PARAM,
-  plugins: INTERNAL_PLUGINS_PATH_PARAM,
-};
-
-function locationBeforeDynamicRouteBridge(
-  routeId: RouteId,
-  location: ReturnType<RouterHistory["location"]>,
-  basePath: string,
-) {
-  const search = new URLSearchParams(location.search);
-  const pathParam = DYNAMIC_PATH_PARAM_BY_ROUTE[routeId];
-  let pathname = pathParam ? search.get(pathParam) : null;
-  if (pathParam) {
-    search.delete(pathParam);
-  } else if (routeId === "workboard") {
-    const boardId = search.get("board");
-    if (boardId) {
-      try {
-        pathname = pathForWorkboardBoard(boardId, basePath);
-        search.delete("board");
-      } catch {
-        return location;
-      }
-    }
-  }
-  if (!pathname) {
-    return location;
-  }
-  const serializedSearch = search.toString();
-  return {
-    ...location,
-    pathname,
-    search: serializedSearch ? `?${serializedSearch}` : "",
-  };
-}
-
-function bridgeDynamicRouteLoaderDeps(route: AppRoute): AppRoute {
-  const loaderDeps = route.loaderDeps;
-  if (!loaderDeps || (route.id !== "workboard" && !DYNAMIC_PATH_PARAM_BY_ROUTE[route.id])) {
-    return route;
-  }
-  // Router matching uses an exact-path location while dynamic page loaders
-  // consume the real path. Keep one match identity across that startup bridge.
-  return {
-    ...route,
-    loaderDeps: (context, location) =>
-      loaderDeps(context, locationBeforeDynamicRouteBridge(route.id, location, context.basePath)),
-  };
-}
-
-const appRoutes = APP_ROUTE_TREE.map((route) => bridgeDynamicRouteLoaderDeps(route as AppRoute));
+const appRoutes = APP_ROUTE_TREE as readonly AppRoute[];
 
 export function createApplicationRouter(): ApplicationRouter {
   const router = createRouter<RouteId, ApplicationContext<RouteId>, AppRouteModule>({

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -3,12 +3,13 @@ import type { PageDefinition, Router, RouterHistory } from "@openclaw/uirouter";
 import {
   agentRouteFromPath,
   INTERNAL_AGENT_PATH_PARAM,
-  INTERNAL_SESSION_PATH_PARAM,
   INTERNAL_MEMORY_PATH_PARAM,
   INTERNAL_PLUGINS_PATH_PARAM,
+  INTERNAL_SESSION_PATH_PARAM,
   memoryTabFromPath,
   pathForAgentPanel,
   pathForRoute,
+  pathForWorkboardBoard,
   pluginsHubTabFromPath,
   routeIdFromPath,
   sessionRouteNamespaceFromPath,
@@ -94,7 +95,61 @@ const APP_ROUTE_TREE = [
   pluginPage,
 ] as const;
 
-const appRoutes = APP_ROUTE_TREE as readonly AppRoute[];
+const DYNAMIC_PATH_PARAM_BY_ROUTE: Partial<Record<RouteId, string>> = {
+  agents: INTERNAL_AGENT_PATH_PARAM,
+  chat: INTERNAL_SESSION_PATH_PARAM,
+  dashboard: INTERNAL_SESSION_PATH_PARAM,
+  memory: INTERNAL_MEMORY_PATH_PARAM,
+  plugins: INTERNAL_PLUGINS_PATH_PARAM,
+};
+
+function locationBeforeDynamicRouteBridge(
+  routeId: RouteId,
+  location: ReturnType<RouterHistory["location"]>,
+  basePath: string,
+) {
+  const search = new URLSearchParams(location.search);
+  const pathParam = DYNAMIC_PATH_PARAM_BY_ROUTE[routeId];
+  let pathname = pathParam ? search.get(pathParam) : null;
+  if (pathParam) {
+    search.delete(pathParam);
+  } else if (routeId === "workboard") {
+    const boardId = search.get("board");
+    if (boardId) {
+      try {
+        pathname = pathForWorkboardBoard(boardId, basePath);
+        search.delete("board");
+      } catch {
+        return location;
+      }
+    }
+  }
+  if (!pathname) {
+    return location;
+  }
+  const serializedSearch = search.toString();
+  return {
+    ...location,
+    pathname,
+    search: serializedSearch ? `?${serializedSearch}` : "",
+  };
+}
+
+function bridgeDynamicRouteLoaderDeps(route: AppRoute): AppRoute {
+  const loaderDeps = route.loaderDeps;
+  if (!loaderDeps || (route.id !== "workboard" && !DYNAMIC_PATH_PARAM_BY_ROUTE[route.id])) {
+    return route;
+  }
+  // Router matching uses an exact-path location while dynamic page loaders
+  // consume the real path. Keep one match identity across that startup bridge.
+  return {
+    ...route,
+    loaderDeps: (context, location) =>
+      loaderDeps(context, locationBeforeDynamicRouteBridge(route.id, location, context.basePath)),
+  };
+}
+
+const appRoutes = APP_ROUTE_TREE.map((route) => bridgeDynamicRouteLoaderDeps(route as AppRoute));
 
 export function createApplicationRouter(): ApplicationRouter {
   const router = createRouter<RouteId, ApplicationContext<RouteId>, AppRouteModule>({
@@ -193,12 +248,7 @@ export async function startApplicationRouter(
   if (initialDynamicRoute) {
     // Replace the synthetic exact-match location with the real browser path
     // before the shell renders; the matching loader data is already cached.
-    await router.navigate(
-      initialDynamicRoute[0],
-      context,
-      { history: "none", revalidate: true },
-      location,
-    );
+    await router.navigate(initialDynamicRoute[0], context, { history: "none" }, location);
   }
 }
 

--- a/ui/src/e2e/dynamic-route-loader-count.e2e.test.ts
+++ b/ui/src/e2e/dynamic-route-loader-count.e2e.test.ts
@@ -1,0 +1,87 @@
+// Control UI E2E tests prove dynamic startup routes do not reload their Gateway data.
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  waitForControlUiRoute,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+async function activeRouteFetchCount(page: import("playwright").Page): Promise<number | null> {
+  return page.evaluate(() => {
+    const app = document.querySelector("openclaw-app") as HTMLElement & {
+      runtime?: {
+        router: {
+          getState: () => { matches: Array<{ fetchCount: number }> };
+        };
+      };
+    };
+    return app.runtime?.router.getState().matches[0]?.fetchCount ?? null;
+  });
+}
+
+describeControlUiE2e("Control UI dynamic route startup loaders", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not available at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("loads the Plugins Discover deep link once and preserves it through reconnect", async () => {
+    const context = await browser.newContext({ viewport: { height: 900, width: 1440 } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["plugins.list"],
+      methodResponses: {
+        "plugins.list": {
+          diagnostics: [],
+          mutationAllowed: true,
+          plugins: [],
+        },
+      },
+    });
+    const pathname = "/settings/plugins/discover";
+
+    try {
+      const response = await page.goto(`${server.baseUrl}${pathname.slice(1)}`);
+      expect(response?.status()).toBe(200);
+      await waitForControlUiRoute(page, { pathname, routeId: "plugins" });
+      expect(await activeRouteFetchCount(page)).toBe(1);
+
+      const socketCount = await gateway.getSocketCount();
+      await gateway.closeLatest(1001, "route loader reconnect proof");
+      await expect
+        .poll(() => gateway.getSocketCount(), { timeout: 10_000 })
+        .toBe(socketCount + 1);
+      await waitForControlUiRoute(page, { pathname, routeId: "plugins" });
+      expect(await activeRouteFetchCount(page)).toBe(1);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/dynamic-route-loader-count.e2e.test.ts
+++ b/ui/src/e2e/dynamic-route-loader-count.e2e.test.ts
@@ -75,9 +75,7 @@ describeControlUiE2e("Control UI dynamic route startup loaders", () => {
 
       const socketCount = await gateway.getSocketCount();
       await gateway.closeLatest(1001, "route loader reconnect proof");
-      await expect
-        .poll(() => gateway.getSocketCount(), { timeout: 10_000 })
-        .toBe(socketCount + 1);
+      await expect.poll(() => gateway.getSocketCount(), { timeout: 10_000 }).toBe(socketCount + 1);
       await waitForControlUiRoute(page, { pathname, routeId: "plugins" });
       expect(await activeRouteFetchCount(page)).toBe(1);
     } finally {

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -1,11 +1,7 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html, nothing } from "lit";
-import {
-  INTERNAL_SESSION_PATH_PARAM,
-  pathForRoute,
-  routePageSpec,
-} from "../../app-route-paths.ts";
+import { INTERNAL_SESSION_PATH_PARAM, pathForRoute, routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import type { BoardFace } from "../../lib/board/settings.ts";

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -1,7 +1,11 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { definePage } from "@openclaw/uirouter";
 import { html, nothing } from "lit";
-import { routePageSpec } from "../../app-route-paths.ts";
+import {
+  INTERNAL_SESSION_PATH_PARAM,
+  pathForRoute,
+  routePageSpec,
+} from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import type { BoardFace } from "../../lib/board/settings.ts";
@@ -31,11 +35,32 @@ function renderAmbiguous(data: Extract<ChatRouteData, { kind: "ambiguous" }>) {
   `;
 }
 
+function sessionLoaderDeps(
+  face: BoardFace,
+  context: ApplicationContext,
+  location: RouteLocation,
+): string {
+  const search = new URLSearchParams(location.search);
+  const bridgedPath =
+    location.pathname === pathForRoute(face, context.basePath)
+      ? search.get(INTERNAL_SESSION_PATH_PARAM)
+      : null;
+  if (bridgedPath) {
+    search.delete(INTERNAL_SESSION_PATH_PARAM);
+  }
+  const serializedSearch = search.toString();
+  return `${bridgedPath ?? location.pathname}\u0000${
+    serializedSearch ? `?${serializedSearch}` : ""
+  }`;
+}
+
 function sessionPage(face: BoardFace) {
   return definePage({
     ...routePageSpec(face),
-    loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
-      `${location.pathname}\u0000${location.search}`,
+    // The application router temporarily maps dynamic session URLs onto the
+    // static face route. Both locations describe the same loader match.
+    loaderDeps: (context: ApplicationContext, location: RouteLocation) =>
+      sessionLoaderDeps(face, context, location),
     loader: async (context: ApplicationContext, { location, signal }) => {
       const { loadChatRoute } = await import("./route-loader.ts");
       return await loadChatRoute(context, location, face, signal);

--- a/ui/src/pages/config/route.ts
+++ b/ui/src/pages/config/route.ts
@@ -16,8 +16,10 @@ function loadConfigRoute(context: ApplicationContext, location: RouteLocation) {
 function configPage(id: ConfigPageId) {
   return definePage({
     ...routePageSpec(id),
-    loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
-      `${location.pathname}\u0000${location.search}\u0000${location.hash}`,
+    loaderDeps: (_context: ApplicationContext, location: RouteLocation) => {
+      const route = configRouteData(location);
+      return `${route.pathname}\u0000${route.search}\u0000${route.hash}`;
+    },
     loader: (context: ApplicationContext, { location }) => loadConfigRoute(context, location),
     component: () =>
       import("./config-page.ts").then(() => ({

--- a/ui/src/pages/workboard/route.ts
+++ b/ui/src/pages/workboard/route.ts
@@ -7,6 +7,14 @@ import { resolveWorkboardRouteLocation, type WorkboardRouteData } from "./route-
 
 export type { WorkboardRouteData } from "./route-location.ts";
 
+function workboardLoaderDeps(context: ApplicationContext, location: RouteLocation): string {
+  const route = resolveWorkboardRouteLocation(location, context.basePath);
+  const canonicalLocation = route.canonicalLocation;
+  return `${canonicalLocation?.pathname ?? location.pathname}\u0000${
+    canonicalLocation?.search ?? route.search
+  }`;
+}
+
 async function loadWorkboardRoute(
   context: ApplicationContext,
   location: RouteLocation,
@@ -24,8 +32,7 @@ async function loadWorkboardRoute(
 
 export const page = definePage({
   ...routePageSpec("workboard"),
-  loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
-    `${location.pathname}\u0000${location.search}`,
+  loaderDeps: workboardLoaderDeps,
   loader: (context: ApplicationContext, { location }) => loadWorkboardRoute(context, location),
   component: () =>
     import("./workboard-page.ts").then(() => ({


### PR DESCRIPTION
Closes #116193

## What Problem This Solves

Fixes an issue where opening a dynamic Control UI link directly would execute the same route loader twice during startup.

This affected Agent, Chat, Dashboard, Workboard, Memory, and Plugins links, adding redundant work and potential Gateway traffic before the requested page became usable.

## Why This Change Was Made

The initial loader result is now reused when the application replaces its temporary exact-match location with the real browser URL. Route identity remains owned by each page descriptor, and the generic router remains unchanged.

Later navigation to a different dynamic resource still receives a distinct loader identity and loads normally.

## User Impact

Dynamic Control UI links now perform one initial route load. Reconnects do not rerun the active loader, and invalid paths continue to normalize correctly.

There are no visual changes.

## Evidence

- `ui/src/app-route-paths.test.ts`: 35/35 passed across all six dynamic route families, later history navigation, and invalid-path normalization.
- Chromium mocked-Gateway E2E: direct Plugins Discover navigation and WebSocket reconnect passed with route `fetchCount` remaining at one.
- `pnpm check:changed`: passed formatting, dead-export checks, i18n verification, core-test and UI typechecks, and lint.
- Fresh autoreview: no accepted or actionable findings.
