### PR TITLE
fix(session): isolate memory flush lifecycle from parent recovery

### DIFF
--- a/qa/scenarios/runtime/restart-recovery-memory-flush-lifecycle-proof.yaml
+++ b/qa/scenarios/runtime/restart-recovery-memory-flush-lifecycle-proof.yaml
@@ -1,0 +1,124 @@
+title: Restart recovery memory-flush lifecycle proof
+
+scenario:
+  id: restart-recovery-memory-flush-lifecycle-proof
+  surface: runtime
+  coverage:
+    primary:
+      - session-memory.recovery-delivery
+    secondary:
+      - session-memory.recovery-restart-recovery
+      - session-memory.compaction
+  objective: Prove a forced pre-admission memory flush cannot own the parent session lifecycle and the channel turn still receives a reply.
+  successCriteria:
+    - A synthetic channel turn creates the parent session.
+    - The next turn forces a pre-admission memory flush through the real Gateway child and mock provider.
+    - The parent session remains terminally healthy and the second turn receives a visible reply.
+  gatewayConfigPatch:
+    agents:
+      defaults:
+        compaction:
+          memoryFlush:
+            enabled: true
+            forceFlushTranscriptBytes: 1
+  docsRefs:
+    - docs/channels/qa-channel.md
+    - docs/reference/session-management-compaction.md
+  codeRefs:
+    - src/auto-reply/reply/agent-runner-memory.ts
+    - src/gateway/server-chat.ts
+    - src/auto-reply/reply/restart-recovery-claim.ts
+  execution:
+    kind: flow
+    runtime: openclaw
+    summary: Force a memory-flush child before a synthetic channel turn, then verify parent lifecycle and delivery.
+    channel: qa-channel
+    config:
+      conversationPrefix: restart-recovery-memory-flush
+      senderId: qa-recovery-operator
+      seedPrompt: "RESTART-RECOVERY-MEMORY-FLUSH-SEED retain this context for the next turn."
+      proofPrompt: "RESTART-RECOVERY-MEMORY-FLUSH-PROOF reply with one short sentence."
+
+flow:
+  steps:
+    - name: keeps the parent healthy and delivers the turn after memory flush
+      actions:
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - resetTransport: true
+        - set: conversationId
+          value:
+            expr: "`${config.conversationPrefix}-${randomUUID().slice(0, 8)}`"
+        - set: sessionKey
+          value:
+            expr: "'agent:qa:main'"
+        - set: seedOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Recovery Operator
+            text:
+              ref: config.seedPrompt
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: seedOutboundIndex
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+        - set: proofOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Recovery Operator
+            text:
+              ref: config.proofPrompt
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: proofOutboundIndex
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+          saveAs: proofReply
+        - call: readRawQaSessionStore
+          saveAs: store
+          args:
+            - ref: env
+        - set: sessionEntry
+          value:
+            expr: "store[sessionKey]"
+        - assert:
+            expr: "sessionEntry?.memoryFlush?.kind === 'succeeded'"
+            message:
+              expr: "`forced memory flush did not succeed: ${JSON.stringify({ sessionKey, storeKeys: Object.keys(store), sessionEntry })}`"
+        - assert:
+            expr: "sessionEntry?.status === 'done' && sessionEntry?.abortedLastRun !== true"
+            message:
+              expr: "`parent session was not healthy after memory flush: ${JSON.stringify({ status: sessionEntry?.status, abortedLastRun: sessionEntry?.abortedLastRun })}`"
+        - assert:
+            expr: "typeof proofReply.text === 'string' && proofReply.text.length > 0"
+            message: second channel turn did not receive a visible reply
+      detailsExpr: "JSON.stringify({ verdict: 'PASS', channel: 'qa-channel', provider: env.providerMode, gateway: 'ephemeral-child', memoryFlush: sessionEntry.memoryFlush, parent: { sessionId: sessionEntry.sessionId, status: sessionEntry.status, abortedLastRun: sessionEntry.abortedLastRun ?? false }, replyDelivered: Boolean(proofReply.text) })"

--- a/src/agents/main-session-restart-recovery-shared.ts
+++ b/src/agents/main-session-restart-recovery-shared.ts
@@ -35,12 +35,8 @@ export function buildRestartRecoveryExpectedState(
   const expectedMainRestartRecovery = mainRestartRecovery ?? entry.mainRestartRecovery;
   return {
     abortedLastRun: entry.abortedLastRun,
-    ...(expectedMainRestartRecovery
-      ? {
-          mainRestartRecoveryCycleId: expectedMainRestartRecovery.cycleId,
-          mainRestartRecoveryRevision: expectedMainRestartRecovery.revision,
-        }
-      : {}),
+    mainRestartRecoveryCycleId: expectedMainRestartRecovery?.cycleId,
+    mainRestartRecoveryRevision: expectedMainRestartRecovery?.revision,
     restartRecoveryBeforeAgentReplyState: entry.restartRecoveryBeforeAgentReplyState,
     restartRecoveryDeliveryReceiptState: entry.restartRecoveryDeliveryReceiptState,
     restartRecoveryDeliveryToolCallId: entry.restartRecoveryDeliveryToolCallId,

--- a/src/agents/main-session-restart-recovery-shared.ts
+++ b/src/agents/main-session-restart-recovery-shared.ts
@@ -32,12 +32,13 @@ export function buildRestartRecoveryExpectedState(
   entry: SessionEntry,
   mainRestartRecovery?: { cycleId: string; revision: number },
 ): SessionTranscriptTurnExpectedState {
+  const expectedMainRestartRecovery = mainRestartRecovery ?? entry.mainRestartRecovery;
   return {
     abortedLastRun: entry.abortedLastRun,
-    ...(mainRestartRecovery
+    ...(expectedMainRestartRecovery
       ? {
-          mainRestartRecoveryCycleId: mainRestartRecovery.cycleId,
-          mainRestartRecoveryRevision: mainRestartRecovery.revision,
+          mainRestartRecoveryCycleId: expectedMainRestartRecovery.cycleId,
+          mainRestartRecoveryRevision: expectedMainRestartRecovery.revision,
         }
       : {}),
     restartRecoveryBeforeAgentReplyState: entry.restartRecoveryBeforeAgentReplyState,
@@ -53,7 +54,6 @@ export function buildRestartRecoveryExpectedState(
     restartRecoverySourceReplyDeliveryMode: entry.restartRecoverySourceReplyDeliveryMode,
     restartRecoveryTerminalRunIds: entry.restartRecoveryTerminalRunIds,
     status: entry.status,
-    updatedAt: entry.updatedAt,
   };
 }
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -38,6 +38,7 @@ const incrementCompactionCountMock = vi.fn();
 const ensureSelectedAgentHarnessPluginMock = vi.fn();
 const ensureMemoryFlushTargetFileMock = vi.fn();
 const emitAgentEventMock = vi.fn();
+const registerAgentRunContextMock = vi.fn();
 const TEST_MAX_FLUSH_FAILURES = 3;
 
 function registerMemoryFlushPlanResolverForTest(resolver: MemoryFlushPlanResolver): void {
@@ -314,6 +315,7 @@ describe("runMemoryFlushIfNeeded", () => {
     ensureMemoryFlushTargetFileMock.mockReset().mockResolvedValue(undefined);
     ensureSelectedAgentHarnessPluginMock.mockReset().mockResolvedValue(undefined);
     emitAgentEventMock.mockReset();
+    registerAgentRunContextMock.mockReset();
     incrementCompactionCountMock.mockReset().mockImplementation(async (params) => {
       const sessionKey = String(params.sessionKey ?? "");
       if (!sessionKey || !params.sessionStore?.[sessionKey]) {
@@ -340,7 +342,7 @@ describe("runMemoryFlushIfNeeded", () => {
       ensureMemoryFlushTargetFile: ensureMemoryFlushTargetFileMock as never,
       refreshQueuedFollowupSession: refreshQueuedFollowupSessionMock as never,
       incrementCompactionCount: incrementCompactionCountMock as never,
-      registerAgentRunContext: vi.fn() as never,
+      registerAgentRunContext: registerAgentRunContextMock as never,
       emitAgentEvent: emitAgentEventMock as never,
       resolveSessionLogPath: (
         _sessionId: string | undefined,
@@ -417,6 +419,16 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.prompt).not.toBe(flushCall.transcriptPrompt);
     expect(flushCall.memoryFlushWritePath).toMatch(/^memory\/\d{4}-\d{2}-\d{2}\.md$/);
     expect(flushCall.silentExpected).toBe(true);
+    expect(registerAgentRunContextMock).toHaveBeenCalledWith(
+      "00000000-0000-0000-0000-000000000001",
+      expect.objectContaining({
+        isControlUiVisible: false,
+        projectSessionActive: false,
+        projectSessionLifecycle: false,
+        sessionId: "session",
+        sessionKey,
+      }),
+    );
     expect(ensureMemoryFlushTargetFileMock).toHaveBeenCalledWith({
       workspaceDir: followupRun.run.workspaceDir,
       relativePath: flushCall.memoryFlushWritePath,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1436,6 +1436,9 @@ export async function runMemoryFlushIfNeeded(params: {
       sessionKey: params.sessionKey,
       ...(activeSessionEntry?.sessionId ? { sessionId: activeSessionEntry.sessionId } : {}),
       verboseLevel: params.resolvedVerboseLevel,
+      isControlUiVisible: false,
+      projectSessionActive: false,
+      projectSessionLifecycle: false,
     });
   }
   let memoryCompactionCompleted = false;

--- a/src/auto-reply/reply/restart-recovery-claim.test.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.test.ts
@@ -7,6 +7,7 @@ import {
   updateSessionEntry,
 } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import type {
   UserTurnTranscriptRecorder,
   UserTurnTranscriptTarget,
@@ -145,6 +146,97 @@ describe("createReplyRestartRecoveryClaimController", () => {
       model: "gpt-5.6-luna",
       restartRecoveryDeliverySourceRunId: sourceTurnId,
       status: "running",
+    });
+  });
+
+  it("rejects claim adoption when a recovery cycle starts after the snapshot", async () => {
+    const root = tempDirs.make("openclaw-reply-admission-cycle-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:telegram:group:chat:topic:thread";
+    const sessionId = "channel-session-id";
+    const sourceTurnId = "telegram-update-new";
+    const deliveryContext = {
+      channel: "telegram",
+      to: "chat",
+      accountId: "default",
+      threadId: "thread",
+    };
+    let entry: SessionEntry = {
+      sessionId,
+      updatedAt: 10,
+      abortedLastRun: false,
+      restartRecoveryDeliveryContext: deliveryContext,
+      restartRecoveryDeliveryRunId: "orphaned-run",
+      restartRecoveryDeliverySourceRunId: "telegram-update-old",
+      status: "done",
+    };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    const sourceMessage = {
+      role: "user" as const,
+      content: "continue",
+      idempotencyKey: sourceTurnId,
+      timestamp: Date.now(),
+    };
+    const recorder = {
+      message: undefined,
+      getPersistedMessage: () => sourceMessage,
+      resolveMessage: async () => sourceMessage,
+      markRuntimePersistencePending: () => {},
+      markRuntimePersisted: () => {},
+      markBlocked: () => {},
+      hasPersisted: () => false,
+      isBlocked: () => false,
+      hasRuntimePersistencePending: () => false,
+      waitForRuntimePersistence: async () => {},
+      persistApproved: async (
+        options?: Parameters<UserTurnTranscriptRecorder["persistApproved"]>[0],
+      ) => {
+        await updateSessionEntry({ storePath, sessionKey }, () => ({
+          mainRestartRecovery: {
+            cycleId: "cycle-new",
+            revision: 1,
+            chargedAttempts: 0,
+          },
+        }));
+        return await createUserTurnTranscriptRecorder({
+          message: sourceMessage,
+          target: {
+            agentId: "main",
+            sessionEntry: entry,
+            sessionId,
+            sessionKey,
+            storePath,
+          },
+          updateMode: "none",
+        }).persistApproved(options);
+      },
+      persistBlocked: async () => undefined,
+      persistFallback: async () => undefined,
+    } satisfies UserTurnTranscriptRecorder;
+    const controller = createReplyRestartRecoveryClaimController({
+      getEntry: () => entry,
+      getSessionId: () => sessionId,
+      isRestartAbort: () => false,
+      resolveDeliveryContext: () => deliveryContext,
+      sessionKey,
+      setEntry: (next) => {
+        entry = next;
+      },
+      sourceTurnId,
+      storePath,
+    });
+
+    await expect(controller.admitUserTurn(recorder)).rejects.toThrow(
+      "session changed before durable user-turn admission",
+    );
+    expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject({
+      mainRestartRecovery: {
+        cycleId: "cycle-new",
+        revision: 1,
+      },
+      restartRecoveryDeliveryRunId: "orphaned-run",
+      restartRecoveryDeliverySourceRunId: "telegram-update-old",
+      status: "done",
     });
   });
 });

--- a/src/auto-reply/reply/restart-recovery-claim.test.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.test.ts
@@ -6,7 +6,7 @@ import {
   replaceSessionEntry,
   updateSessionEntry,
 } from "../../config/sessions/session-accessor.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import type { InternalSessionEntry, SessionEntry } from "../../config/sessions/types.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import type {
   UserTurnTranscriptRecorder,
@@ -191,13 +191,14 @@ describe("createReplyRestartRecoveryClaimController", () => {
       persistApproved: async (
         options?: Parameters<UserTurnTranscriptRecorder["persistApproved"]>[0],
       ) => {
-        await updateSessionEntry({ storePath, sessionKey }, () => ({
+        const recoveryPatch: Partial<InternalSessionEntry> = {
           mainRestartRecovery: {
             cycleId: "cycle-new",
             revision: 1,
             chargedAttempts: 0,
           },
-        }));
+        };
+        await updateSessionEntry({ storePath, sessionKey }, () => recoveryPatch);
         return await createUserTurnTranscriptRecorder({
           message: sourceMessage,
           target: {

--- a/src/auto-reply/reply/restart-recovery-claim.test.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.test.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  loadSessionEntry,
+  replaceSessionEntry,
+  updateSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import type {
   UserTurnTranscriptRecorder,
   UserTurnTranscriptTarget,
@@ -69,6 +74,77 @@ describe("createReplyRestartRecoveryClaimController", () => {
       sessionKey,
       storePath,
       agentId: "main",
+    });
+  });
+
+  it("keeps claim adoption valid across unrelated same-session metadata writes", async () => {
+    const root = tempDirs.make("openclaw-reply-admission-metadata-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:telegram:group:chat:topic:thread";
+    const sessionId = "channel-session-id";
+    const sourceTurnId = "telegram-update-new";
+    const deliveryContext = {
+      channel: "telegram",
+      to: "chat",
+      accountId: "default",
+      threadId: "thread",
+    };
+    let entry: SessionEntry = {
+      sessionId,
+      updatedAt: 10,
+      abortedLastRun: false,
+      restartRecoveryDeliveryContext: deliveryContext,
+      restartRecoveryDeliveryRunId: "orphaned-run",
+      restartRecoveryDeliverySourceRunId: "telegram-update-old",
+      status: "done",
+    };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    const persistApproved = vi.fn<UserTurnTranscriptRecorder["persistApproved"]>();
+    const recorder = {
+      message: undefined,
+      getPersistedMessage: () => undefined,
+      resolveMessage: async () => {
+        await updateSessionEntry({ storePath, sessionKey }, (current) => ({
+          model: "gpt-5.6-luna",
+          updatedAt: current.updatedAt + 1,
+        }));
+        return {
+          role: "user" as const,
+          content: "continue",
+          idempotencyKey: sourceTurnId,
+          timestamp: Date.now(),
+        };
+      },
+      markRuntimePersistencePending: () => {},
+      markRuntimePersisted: () => {},
+      markBlocked: () => {},
+      hasPersisted: () => true,
+      isBlocked: () => false,
+      hasRuntimePersistencePending: () => false,
+      waitForRuntimePersistence: async () => {},
+      persistApproved,
+      persistBlocked: async () => undefined,
+      persistFallback: async () => undefined,
+    } satisfies UserTurnTranscriptRecorder;
+    const controller = createReplyRestartRecoveryClaimController({
+      getEntry: () => entry,
+      getSessionId: () => sessionId,
+      isRestartAbort: () => false,
+      resolveDeliveryContext: () => deliveryContext,
+      sessionKey,
+      setEntry: (next) => {
+        entry = next;
+      },
+      sourceTurnId,
+      storePath,
+    });
+
+    await expect(controller.admitUserTurn(recorder)).resolves.toBe("admitted");
+    expect(persistApproved).not.toHaveBeenCalled();
+    expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject({
+      model: "gpt-5.6-luna",
+      restartRecoveryDeliverySourceRunId: sourceTurnId,
+      status: "running",
     });
   });
 });

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -12,7 +12,7 @@ import type {
   SessionTranscriptTurnExpectedState,
   SessionTranscriptTurnLifecyclePatch,
 } from "../../config/sessions/session-transcript-turn-lifecycle.types.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
 import type {
   UserTurnTranscriptRecorder,
   UserTurnTranscriptTarget,
@@ -86,6 +86,12 @@ export async function retireTerminalRestartRecoverySourceClaim(params: {
 function buildExpectedSessionState(entry: SessionEntry): SessionTranscriptTurnExpectedState {
   return {
     abortedLastRun: entry.abortedLastRun,
+    ...(entry.mainRestartRecovery
+      ? {
+          mainRestartRecoveryCycleId: entry.mainRestartRecovery.cycleId,
+          mainRestartRecoveryRevision: entry.mainRestartRecovery.revision,
+        }
+      : {}),
     restartRecoveryBeforeAgentReplyState: entry.restartRecoveryBeforeAgentReplyState,
     restartRecoveryDeliveryReceiptState: entry.restartRecoveryDeliveryReceiptState,
     restartRecoveryDeliveryToolCallId: entry.restartRecoveryDeliveryToolCallId,
@@ -99,7 +105,6 @@ function buildExpectedSessionState(entry: SessionEntry): SessionTranscriptTurnEx
     restartRecoverySourceReplyDeliveryMode: entry.restartRecoverySourceReplyDeliveryMode,
     restartRecoveryTerminalRunIds: entry.restartRecoveryTerminalRunIds,
     status: entry.status,
-    updatedAt: entry.updatedAt,
   };
 }
 
@@ -111,6 +116,10 @@ function matchesExpectedSessionState(
   return (
     entry.sessionId === sessionId &&
     entry.abortedLastRun === expected.abortedLastRun &&
+    (expected.mainRestartRecoveryCycleId === undefined ||
+      entry.mainRestartRecovery?.cycleId === expected.mainRestartRecoveryCycleId) &&
+    (expected.mainRestartRecoveryRevision === undefined ||
+      entry.mainRestartRecovery?.revision === expected.mainRestartRecoveryRevision) &&
     entry.restartRecoveryBeforeAgentReplyState === expected.restartRecoveryBeforeAgentReplyState &&
     entry.restartRecoveryDeliveryReceiptState === expected.restartRecoveryDeliveryReceiptState &&
     entry.restartRecoveryDeliveryToolCallId === expected.restartRecoveryDeliveryToolCallId &&
@@ -129,8 +138,7 @@ function matchesExpectedSessionState(
       entry.restartRecoveryTerminalRunIds,
       expected.restartRecoveryTerminalRunIds,
     ) &&
-    entry.status === expected.status &&
-    entry.updatedAt === expected.updatedAt
+    entry.status === expected.status
   );
 }
 

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -86,12 +86,8 @@ export async function retireTerminalRestartRecoverySourceClaim(params: {
 function buildExpectedSessionState(entry: SessionEntry): SessionTranscriptTurnExpectedState {
   return {
     abortedLastRun: entry.abortedLastRun,
-    ...(entry.mainRestartRecovery
-      ? {
-          mainRestartRecoveryCycleId: entry.mainRestartRecovery.cycleId,
-          mainRestartRecoveryRevision: entry.mainRestartRecovery.revision,
-        }
-      : {}),
+    mainRestartRecoveryCycleId: entry.mainRestartRecovery?.cycleId,
+    mainRestartRecoveryRevision: entry.mainRestartRecovery?.revision,
     restartRecoveryBeforeAgentReplyState: entry.restartRecoveryBeforeAgentReplyState,
     restartRecoveryDeliveryReceiptState: entry.restartRecoveryDeliveryReceiptState,
     restartRecoveryDeliveryToolCallId: entry.restartRecoveryDeliveryToolCallId,
@@ -116,10 +112,8 @@ function matchesExpectedSessionState(
   return (
     entry.sessionId === sessionId &&
     entry.abortedLastRun === expected.abortedLastRun &&
-    (expected.mainRestartRecoveryCycleId === undefined ||
-      entry.mainRestartRecovery?.cycleId === expected.mainRestartRecoveryCycleId) &&
-    (expected.mainRestartRecoveryRevision === undefined ||
-      entry.mainRestartRecovery?.revision === expected.mainRestartRecoveryRevision) &&
+    entry.mainRestartRecovery?.cycleId === expected.mainRestartRecoveryCycleId &&
+    entry.mainRestartRecovery?.revision === expected.mainRestartRecoveryRevision &&
     entry.restartRecoveryBeforeAgentReplyState === expected.restartRecoveryBeforeAgentReplyState &&
     entry.restartRecoveryDeliveryReceiptState === expected.restartRecoveryDeliveryReceiptState &&
     entry.restartRecoveryDeliveryToolCallId === expected.restartRecoveryDeliveryToolCallId &&

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -3190,7 +3190,6 @@ describe("session accessor seam", () => {
         restartRecoverySourceReplyDeliveryMode: retryable.restartRecoverySourceReplyDeliveryMode,
         restartRecoveryTerminalRunIds: retryable.restartRecoveryTerminalRunIds,
         status: retryable.status,
-        updatedAt: retryable.updatedAt,
       },
       messages: [
         {
@@ -3414,7 +3413,6 @@ describe("session accessor seam", () => {
       restartRecoverySourceReplyDeliveryMode: stored.restartRecoverySourceReplyDeliveryMode,
       restartRecoveryTerminalRunIds: stored.restartRecoveryTerminalRunIds,
       status: stored.status,
-      updatedAt: stored.updatedAt,
     };
     let releasePredicate!: () => void;
     let markPredicateStarted!: () => void;

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -3175,6 +3175,8 @@ describe("session accessor seam", () => {
       expectedSessionId: scope.sessionId,
       expectedSessionState: {
         abortedLastRun: retryable.abortedLastRun,
+        mainRestartRecoveryCycleId: retryable.mainRestartRecovery?.cycleId,
+        mainRestartRecoveryRevision: retryable.mainRestartRecovery?.revision,
         restartRecoveryBeforeAgentReplyState: retryable.restartRecoveryBeforeAgentReplyState,
         restartRecoveryDeliveryReceiptState: retryable.restartRecoveryDeliveryReceiptState,
         restartRecoveryDeliveryToolCallId: retryable.restartRecoveryDeliveryToolCallId,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -72,7 +72,7 @@ import {
 } from "./session-accessor.sqlite.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { withOwnedSessionTranscriptWrites } from "./transcript-write-context.js";
-import type { SessionEntry } from "./types.js";
+import type { InternalSessionEntry, SessionEntry } from "./types.js";
 
 const cleanupArchivedSessionTranscriptsMock = vi.hoisted(() => vi.fn(async () => {}));
 
@@ -3171,12 +3171,13 @@ describe("session accessor seam", () => {
     if (!retryable) {
       throw new Error("expected retryable admission");
     }
+    const retryableMainRestartRecovery = (retryable as InternalSessionEntry).mainRestartRecovery;
     const deduplicated = await persistSessionTranscriptTurn(scope, {
       expectedSessionId: scope.sessionId,
       expectedSessionState: {
         abortedLastRun: retryable.abortedLastRun,
-        mainRestartRecoveryCycleId: retryable.mainRestartRecovery?.cycleId,
-        mainRestartRecoveryRevision: retryable.mainRestartRecovery?.revision,
+        mainRestartRecoveryCycleId: retryableMainRestartRecovery?.cycleId,
+        mainRestartRecoveryRevision: retryableMainRestartRecovery?.revision,
         restartRecoveryBeforeAgentReplyState: retryable.restartRecoveryBeforeAgentReplyState,
         restartRecoveryDeliveryReceiptState: retryable.restartRecoveryDeliveryReceiptState,
         restartRecoveryDeliveryToolCallId: retryable.restartRecoveryDeliveryToolCallId,
@@ -3402,6 +3403,8 @@ describe("session accessor seam", () => {
     }
     const expectedSessionState = {
       abortedLastRun: stored.abortedLastRun,
+      mainRestartRecoveryCycleId: undefined,
+      mainRestartRecoveryRevision: undefined,
       restartRecoveryBeforeAgentReplyState: stored.restartRecoveryBeforeAgentReplyState,
       restartRecoveryDeliveryReceiptState: stored.restartRecoveryDeliveryReceiptState,
       restartRecoveryDeliveryToolCallId: stored.restartRecoveryDeliveryToolCallId,

--- a/src/config/sessions/session-transcript-turn-lifecycle.types.ts
+++ b/src/config/sessions/session-transcript-turn-lifecycle.types.ts
@@ -7,8 +7,8 @@ type SessionRunStatus = "running" | "done" | "failed" | "killed" | "timeout";
 export type SessionTranscriptTurnExpectedState = {
   abortedLastRun: boolean | undefined;
   /** Fences recovery-only transcript writes against concurrent ownership changes. */
-  mainRestartRecoveryCycleId?: string;
-  mainRestartRecoveryRevision?: number;
+  mainRestartRecoveryCycleId: string | undefined;
+  mainRestartRecoveryRevision: number | undefined;
   restartRecoveryBeforeAgentReplyState: SessionRestartRecoveryState["restartRecoveryBeforeAgentReplyState"];
   restartRecoveryDeliveryReceiptState: SessionRestartRecoveryState["restartRecoveryDeliveryReceiptState"];
   restartRecoveryDeliveryToolCallId: SessionRestartRecoveryState["restartRecoveryDeliveryToolCallId"];

--- a/src/config/sessions/session-transcript-turn-lifecycle.types.ts
+++ b/src/config/sessions/session-transcript-turn-lifecycle.types.ts
@@ -22,7 +22,6 @@ export type SessionTranscriptTurnExpectedState = {
   restartRecoverySourceReplyDeliveryMode: SessionRestartRecoveryState["restartRecoverySourceReplyDeliveryMode"];
   restartRecoveryTerminalRunIds: SessionRestartRecoveryState["restartRecoveryTerminalRunIds"];
   status: SessionRunStatus | undefined;
-  updatedAt: number;
 };
 
 /** Lifecycle fields committed with an accepted transcript turn. */

--- a/src/config/sessions/session-transcript-turn-state.ts
+++ b/src/config/sessions/session-transcript-turn-state.ts
@@ -56,8 +56,7 @@ export function sessionMatchesExpectedTranscriptTurn<T extends { entry: SessionE
           selected.entry.restartRecoveryTerminalRunIds,
           expectedState.restartRecoveryTerminalRunIds,
         ) &&
-        selected.entry.status === expectedState.status &&
-        selected.entry.updatedAt === expectedState.updatedAt)),
+        selected.entry.status === expectedState.status)),
   );
 }
 

--- a/src/config/sessions/session-transcript-turn-state.ts
+++ b/src/config/sessions/session-transcript-turn-state.ts
@@ -24,12 +24,9 @@ export function sessionMatchesExpectedTranscriptTurn<T extends { entry: SessionE
       selected.entry.lifecycleRevision === expected.expectedLifecycleRevision) &&
     (expectedState === undefined ||
       (selected.entry.abortedLastRun === expectedState.abortedLastRun &&
-        (expectedState.mainRestartRecoveryCycleId === undefined ||
-          selected.entry.mainRestartRecovery?.cycleId ===
-            expectedState.mainRestartRecoveryCycleId) &&
-        (expectedState.mainRestartRecoveryRevision === undefined ||
-          selected.entry.mainRestartRecovery?.revision ===
-            expectedState.mainRestartRecoveryRevision) &&
+        selected.entry.mainRestartRecovery?.cycleId === expectedState.mainRestartRecoveryCycleId &&
+        selected.entry.mainRestartRecovery?.revision ===
+          expectedState.mainRestartRecoveryRevision &&
         selected.entry.restartRecoveryBeforeAgentReplyState ===
           expectedState.restartRecoveryBeforeAgentReplyState &&
         selected.entry.restartRecoveryDeliveryReceiptState ===

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -10,6 +10,7 @@ import {
 import { formatChannelProgressDraftLine } from "../channels/streaming.js";
 import {
   claimAgentRunContext,
+  emitAgentEvent as emitRuntimeAgentEvent,
   emitAgentEventForOwner,
   onAgentRuntimeEvent,
   registerAgentRunContext,
@@ -3674,6 +3675,34 @@ describe("agent event handler", () => {
     const persistEvent = requireRecord(persistParams.event, "persist lifecycle event");
     expect(persistEvent.runId).toBe("run-hidden");
     expect(requireRecord(persistEvent.data, "persist lifecycle event data").phase).toBe("end");
+  });
+
+  it("does not project maintenance child lifecycle onto its parent session", () => {
+    const { handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-maintenance-parent",
+    });
+    registerAgentRunContext("run-maintenance-child", {
+      isControlUiVisible: false,
+      projectSessionActive: false,
+      projectSessionLifecycle: false,
+      sessionId: "session-parent",
+      sessionKey: "session-maintenance-parent",
+    });
+    const stop = onAgentRuntimeEvent(handler);
+
+    emitRuntimeAgentEvent({
+      runId: "run-maintenance-child",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    emitRuntimeAgentEvent({
+      runId: "run-maintenance-child",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 2_000 },
+    });
+    stop();
+
+    expect(persistGatewaySessionLifecycleEventMock).not.toHaveBeenCalled();
   });
 
   it("sends non-control-UI-visible live chat only to exact session message subscribers", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -671,6 +671,8 @@ export function createAgentEventHandler({
       (typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined);
     const isControlUiVisible =
       evt.controlUiVisible ?? currentRunContext?.isControlUiVisible ?? true;
+    const projectSessionLifecycle =
+      evt.projectSessionLifecycle ?? currentRunContext?.projectSessionLifecycle ?? true;
     const sessionKey =
       chatLink?.sessionKey ?? eventSessionKey ?? resolveSessionKeyForRun(evt.runId);
     const restartRecoverySessionKey = eventSessionKey ?? sessionKey;
@@ -798,7 +800,7 @@ export function createAgentEventHandler({
 
     if (sessionKey) {
       clearTrackedActiveRun?.({ runId: evt.runId, clientRunId, sessionKey });
-      if (!suppressRestartRecoveryProjection) {
+      if (!suppressRestartRecoveryProjection && projectSessionLifecycle) {
         const persistence = persistGatewaySessionLifecycleEvent({
           sessionKey,
           agentId: sessionAgentId,
@@ -1310,6 +1312,8 @@ export function createAgentEventHandler({
     const runContext = getAgentRunContext(evt.runId);
     const activeLifecycleGeneration = resolveActiveLifecycleGenerationForRun(evt.runId);
     const isControlUiVisible = evt.controlUiVisible ?? runContext?.isControlUiVisible ?? true;
+    const projectSessionLifecycle =
+      evt.projectSessionLifecycle ?? runContext?.projectSessionLifecycle ?? true;
     const isHeartbeat = runContext?.isHeartbeat;
     const sessionKey =
       chatLink?.sessionKey ?? eventSessionKey ?? resolveSessionKeyForRun(evt.runId);
@@ -1647,7 +1651,7 @@ export function createAgentEventHandler({
       return;
     }
 
-    if (sessionKey && lifecyclePhase === "start") {
+    if (projectSessionLifecycle && sessionKey && lifecyclePhase === "start") {
       void persistGatewaySessionLifecycleEvent({
         sessionKey,
         agentId: sessionAgentId,

--- a/src/gateway/server-methods/chat-restart-recovery.ts
+++ b/src/gateway/server-methods/chat-restart-recovery.ts
@@ -18,6 +18,7 @@ import {
   type SessionTranscriptTurnExpectedState,
   type SessionTranscriptTurnLifecyclePatch,
 } from "../../config/sessions/session-accessor.js";
+import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadOrCreateProcessDeviceIdentity } from "../../infra/device-identity.js";
 import { findRestartRecoveryUnsafeChatAdmissionHook } from "../../plugins/restart-recovery-hook-safety.js";
@@ -304,12 +305,15 @@ export function resolveRestartSafeChatAdmission(params: {
   if (retryableClaim && entry.restartRecoveryDeliveryRequestFingerprint !== request.fingerprint) {
     throw new Error("chat retry does not match its durable admission");
   }
+  const mainRestartRecovery = (entry as InternalSessionEntry).mainRestartRecovery;
   return {
     requestFingerprint: request.fingerprint,
     ...(retryableClaim
       ? {
           retryExpectedState: {
             abortedLastRun: entry.abortedLastRun,
+            mainRestartRecoveryCycleId: mainRestartRecovery?.cycleId,
+            mainRestartRecoveryRevision: mainRestartRecovery?.revision,
             restartRecoveryBeforeAgentReplyState: entry.restartRecoveryBeforeAgentReplyState,
             restartRecoveryDeliveryReceiptState: entry.restartRecoveryDeliveryReceiptState,
             restartRecoveryDeliveryToolCallId: entry.restartRecoveryDeliveryToolCallId,

--- a/src/gateway/server-methods/chat-restart-recovery.ts
+++ b/src/gateway/server-methods/chat-restart-recovery.ts
@@ -325,7 +325,6 @@ export function resolveRestartSafeChatAdmission(params: {
             restartRecoverySourceReplyDeliveryMode: entry.restartRecoverySourceReplyDeliveryMode,
             restartRecoveryTerminalRunIds: entry.restartRecoveryTerminalRunIds,
             status: entry.status,
-            updatedAt: entry.updatedAt,
           },
         }
       : entry.restartRecoveryDeliverySourceRunId

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -14,6 +14,7 @@ import {
   listAgentRunsForSession,
   onAgentAuditEvent,
   onAgentEvent,
+  onAgentRuntimeEvent,
   registerAgentRunContext,
   releaseAgentRunContext,
   resetAgentEventsForTest,
@@ -558,6 +559,35 @@ describe("agent-events sequencing", () => {
     expect(seen.has("old-run")).toBe(false);
     expect(seen.get("new-run")?.generation).toBe(newGeneration);
     expect(seen.get("new-run")?.keys).not.toContain("lifecycleGeneration");
+  });
+
+  test("stamps session lifecycle projection policy without serializing it", () => {
+    registerAgentRunContext("maintenance-run", {
+      projectSessionLifecycle: false,
+      sessionKey: "main",
+    });
+    let received:
+      | {
+          projectSessionLifecycle?: boolean;
+          keys: string[];
+        }
+      | undefined;
+    const stop = onAgentRuntimeEvent((evt) => {
+      received = {
+        projectSessionLifecycle: evt.projectSessionLifecycle,
+        keys: Object.keys(evt),
+      };
+    });
+
+    emitAgentEvent({
+      runId: "maintenance-run",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_234 },
+    });
+    stop();
+
+    expect(received?.projectSessionLifecycle).toBe(false);
+    expect(received?.keys).not.toContain("projectSessionLifecycle");
   });
 
   test("lets a newly admitted retry claim an explicit lifecycle generation", () => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -72,6 +72,7 @@ export type AgentEventRuntimePayload = AgentEventPayload & {
   readonly controlUiVisible?: boolean;
   readonly contextClaimId?: string;
   readonly deliverySessionKey?: string;
+  readonly projectSessionLifecycle?: boolean;
 };
 
 /** Per-run metadata used to stamp events and gate Control UI visibility. */
@@ -88,6 +89,8 @@ type AgentRunContext = {
   /** Whether control UI clients should receive chat/agent updates for this run. */
   isControlUiVisible?: boolean;
   projectSessionActive?: boolean;
+  /** Whether lifecycle events may update the shared session row. */
+  projectSessionLifecycle?: boolean;
   /** Active cadence state by job; admission permits one invocation per job. */
   cronRunsByJobId?: Map<string, { pacingEnabled: boolean; nextCheckMs?: number }>;
   /** Timestamp when this context was first registered (for TTL-based cleanup). */
@@ -270,6 +273,9 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext,
   }
   if (context.projectSessionActive !== undefined) {
     existing.projectSessionActive = context.projectSessionActive;
+  }
+  if (context.projectSessionLifecycle !== undefined) {
+    existing.projectSessionLifecycle = context.projectSessionLifecycle;
   }
   if (context.cronRunsByJobId !== undefined) {
     existing.cronRunsByJobId ??= new Map();
@@ -656,6 +662,12 @@ function enrichAgentEvent(
   if (context?.isControlUiVisible !== undefined) {
     Object.defineProperty(enriched, "controlUiVisible", {
       value: context.isControlUiVisible,
+      enumerable: false,
+    });
+  }
+  if (context?.projectSessionLifecycle !== undefined) {
+    Object.defineProperty(enriched, "projectSessionLifecycle", {
+      value: context.projectSessionLifecycle,
       enumerable: false,
     });
   }


### PR DESCRIPTION
Fixes #112509

Related: #91564, #114272

## What Problem This Solves

A pre-admission memory flush is a child maintenance run that shares the parent session key. Its lifecycle start/end events were projected onto the parent session row. During restart-safe admission or recovery, the child could terminalize the parent before claim adoption, leaving an admitted user turn unanswered and later channel updates retrying `Session ... changed while starting work. Retry.` indefinitely.

## Why This Change Was Made

- Add an internal per-run `projectSessionLifecycle` policy that defaults to `true`.
- Mark memory-flush runs as hidden, non-active, and non-projecting.
- Stamp the policy as non-enumerable runtime metadata so Gateway can gate start and terminal persistence without exposing it to clients.
- Replace generic `updatedAt` ownership fencing with session ID and explicit recovery/lifecycle fields.
- Require symmetric equality for the main recovery cycle and revision, including absent-to-present transitions, so a newly introduced concurrent recovery cycle rejects the stale claim.

This preserves lifecycle projection for existing user-facing runs while preventing maintenance metadata and lifecycle events from taking ownership of the parent session.

## User Impact

Interrupted channel sessions can recover and accept queued turns instead of becoming permanently unresponsive and requiring manual session deletion or ingress dead-lettering. This requires no configuration, schema migration, or operator action.

## Evidence

Current rebased head: `b601abc2744108b9d1b037ffd33181911349c5a8`, based on `main` at `f1ee2a3098f6f2b125d031401a2d848ff6f3d4ab`.

- 265 focused tests passed across Gateway lifecycle projection, session accessors, restart-recovery claim fencing, and the QA scenario catalog on the exact rebased head.
- The exact CI-equivalent test-type sequence passed: `pnpm check:test-types`, `pnpm tsgo:scripts`, and `pnpm tsgo:test:root`.
- `pnpm tsgo:core`, targeted formatting, and `git diff --check` passed.
- 467 broader recovery/session/Gateway tests passed before the final no-overlap rebase.
- The earlier branch version also passed full `pnpm check`, 590 recovery/lifecycle tests, production/test type checks, and all 125 extension package-boundary compiles.
- Subsequent upstream deltas changed only CI/test-runner/workflow and unrelated CLI/plugin/package/diagnostics/PTY/UI/tool-display/streaming/node-relay files; none of the 14 PR files or tested lifecycle/session paths overlapped. Hosted CI is attached to the current exact head.

### Current-main launch-path audit

- `src/auto-reply/reply/agent-runner-execute.ts` is the sole production caller of `runMemoryFlushIfNeeded`.
- Every actual flush converges on the single child context registration in `src/auto-reply/reply/agent-runner-memory.ts`, which sets `projectSessionLifecycle: false`.
- Ordinary/user-facing runs register separately in `src/auto-reply/reply/agent-runner-execution.ts` without the optional flag, preserving the Gateway default of `true`.
- No other production source writes `projectSessionLifecycle`.
- The focused suites and committed QA scenario passed after this audit on the reviewed current-main merge result. The latest no-overlap rebase changed only diagnostics/PTY/UI files, and the focused suites passed again on the exact rebased head.

### Runtime proof

The committed scenario `qa/scenarios/runtime/restart-recovery-memory-flush-lifecycle-proof.yaml` drives the real OpenClaw channel/Gateway lifecycle using:

- `qa-channel`
- `mock-openai`
- a fresh isolated ephemeral child Gateway
- forced pre-admission memory flush (`forceFlushTranscriptBytes: 1`)
- two channel turns with an assertion that the parent remains healthy and the second reply is delivered

Command:

```text
node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario restart-recovery-memory-flush-lifecycle-proof --concurrency 1 --output-dir .artifacts/qa-e2e/pr-116198-memory-flush-maintainer-audit
```

Verdict before the latest no-overlap upstream rebases:

```json
{"verdict":"PASS","channel":"qa-channel","provider":"mock-openai","gateway":"ephemeral-child","memoryFlush":{"kind":"succeeded","compactionCount":0},"parent":{"sessionId":"58452589-a24f-4428-b49a-f04bafc3a002","status":"done","abortedLastRun":false},"replyDelivered":true}
```

This proves memory-flush completion no longer terminalizes the parent and the following channel turn is delivered. No operator/live Gateway was restarted, stopped, deployed, or mutated.

### Codex runtime compatibility

The native Codex app-server path was checked against the sibling protocol/runtime:

- `codex-rs/app-server-protocol/src/protocol/common.rs:1534-1536` maps `TurnStarted` and `TurnCompleted` to `turn/started` and `turn/completed`.
- `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:356-375` defines those notification payloads.
- `codex-rs/app-server/src/bespoke_event_handling.rs:152-180` and `:1303-1324` emit the start/completion notifications.
- OpenClaw `extensions/codex/src/conversation-binding.ts:824-826` routes them to `conversation-turn-collector.ts:59-120`, which scopes them by thread/turn and completes on `turn/completed`.

The PR changes the shared OpenClaw host lifecycle/claim boundary; it does not alter Codex's native app-server protocol.
