### PR TITLE
fix(agents): retry empty completion capture before blocked terminal outcome

### DIFF
--- a/src/agents/subagent-registry-lifecycle-completion.ts
+++ b/src/agents/subagent-registry-lifecycle-completion.ts
@@ -408,6 +408,18 @@ export function createSubagentRegistryLifecycleCompletion(
         } else if (didFreezeResult) {
           mutated = true;
         }
+        // The first freeze may have committed a null result when the agent's
+        // final text had not yet landed in the session transcript (e.g. after
+        // sessions_yield resume). Reset and try once more before we finalize
+        // with a blocked terminal outcome.
+        if (
+          entry.expectsCompletionMessage === true &&
+          ensureCompletionState(entry).resultText === null
+        ) {
+          ensureCompletionState(entry).resultText = undefined;
+          ensureCompletionState(entry).capturedAt = undefined;
+          await freezeRunResultAtCompletion(entry, outcome);
+        }
       }
       if (updateSwarmCollectorCompletion(entry, params.getRuntimeConfig())) {
         mutated = true;

--- a/src/agents/subagent-registry-lifecycle-completion.ts
+++ b/src/agents/subagent-registry-lifecycle-completion.ts
@@ -408,18 +408,6 @@ export function createSubagentRegistryLifecycleCompletion(
         } else if (didFreezeResult) {
           mutated = true;
         }
-        // The first freeze may have committed a null result when the agent's
-        // final text had not yet landed in the session transcript (e.g. after
-        // sessions_yield resume). Reset and try once more before we finalize
-        // with a blocked terminal outcome.
-        if (
-          entry.expectsCompletionMessage === true &&
-          ensureCompletionState(entry).resultText === null
-        ) {
-          ensureCompletionState(entry).resultText = undefined;
-          ensureCompletionState(entry).capturedAt = undefined;
-          await freezeRunResultAtCompletion(entry, outcome);
-        }
       }
       if (updateSwarmCollectorCompletion(entry, params.getRuntimeConfig())) {
         mutated = true;

--- a/src/agents/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagent-registry-lifecycle-delivery.ts
@@ -300,6 +300,22 @@ export function createSubagentRegistryLifecycleDelivery(
         ...(sessionTarget ? { sessionTarget } : {}),
       });
       resultText = captured?.trim() ? capFrozenResultText(captured) : null;
+      // The agent's final text may not have landed in the session transcript
+      // when the lifecycle fires (e.g. after sessions_yield resume). Wait
+      // briefly and try once more before committing a null result.
+      if (resultText === null && entry.expectsCompletionMessage === true) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 200);
+        });
+        const retried = await params.captureSubagentCompletionReply(entry.childSessionKey, {
+          waitForReply: true,
+          outcome,
+          ...(sessionTarget ? { sessionTarget } : {}),
+        });
+        if (retried?.trim()) {
+          resultText = capFrozenResultText(retried);
+        }
+      }
     } catch {
       resultText = null;
     }

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -2089,6 +2089,61 @@ describe("subagent registry lifecycle hardening", () => {
     expect(taskExecutorMocks.failTaskRunByRunId).not.toHaveBeenCalled();
   });
 
+  it("recovers from an empty first capture when the final text lands before the retry", async () => {
+    // Simulates the yield-resume race: the first capture returns nothing
+    // (the session transcript hasn't been written yet), but a second
+    // capture attempt succeeds because the write landed in between.
+    const entry = createRunEntry({ expectsCompletionMessage: true });
+    const captureSubagentCompletionReply = vi
+      .fn<() => Promise<string | undefined>>()
+      .mockResolvedValueOnce(undefined) // first: empty (transcript not yet written)
+      .mockResolvedValueOnce("Based on child results, the final conclusion is X."); // retry: landed
+
+    await createLifecycleController({
+      entry,
+      captureSubagentCompletionReply,
+    }).completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    const finalArg = firstCallArg(taskExecutorMocks.completeTaskRunByRunId);
+    expect(finalArg.terminalOutcome).toBeUndefined();
+    expect(finalArg.terminalSummary).toBeNull();
+    expect(finalArg.progressSummary).toBe("Based on child results, the final conclusion is X.");
+    expect(taskExecutorMocks.failTaskRunByRunId).not.toHaveBeenCalled();
+  });
+
+  it("still blocks when both capture attempts return empty", async () => {
+    // Genuinely empty completion: both attempts return nothing →
+    // terminalOutcome stays blocked.
+    const entry = createRunEntry({ expectsCompletionMessage: true });
+    const captureSubagentCompletionReply = vi
+      .fn<() => Promise<string | undefined>>()
+      .mockResolvedValue(undefined); // always empty
+
+    await createLifecycleController({
+      entry,
+      captureSubagentCompletionReply,
+    }).completeSubagentRun({
+      runId: entry.runId,
+      endedAt: 4_000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    const finalArg = firstCallArg(taskExecutorMocks.completeTaskRunByRunId);
+    expect(finalArg.terminalOutcome).toBe("blocked");
+    expect(finalArg.terminalSummary).toBe(
+      "Required completion did not produce a final deliverable.",
+    );
+    expect(taskExecutorMocks.failTaskRunByRunId).not.toHaveBeenCalled();
+  });
+
   it("does not reject cleanup give-up when task delivery status update throws", async () => {
     const persistOrThrow = vi.fn();
     const warn = vi.fn();


### PR DESCRIPTION
## What Problem This Solves

Fixes #111647

Fixes an issue where a nested subagent parent that yields via `sessions_yield`
and later produces a valid final result is incorrectly marked as
`terminalOutcome: "blocked"` in its Task record and mirrored TaskFlow,
even though the run completed successfully and the requester received the result.

The symptom: the parent Task shows `status: "succeeded"` but
`terminalOutcome: "blocked"` with summary "Required completion did not produce a
final deliverable." The mirrored TaskFlow mirrors this as `status: "blocked"`.
Downstream systems relying on Task/Flow state therefore treat successful work as
failed, breaking safe orchestration.

## Why This Change Was Made

The lifecycle controller calls `freezeRunResultAtCompletion` (in
`subagent-registry-lifecycle-delivery.ts`), which captures the parent's session
transcript via `captureSubagentCompletionReply` with `waitForReply: true`. The
shared capture reader already has a bounded retry (1500ms), but the session
transcript write can land later than any single capture attempt when the agent
yields and resumes.

This change adds a one-shot retry **inside `freezeRunResultAtCompletion`**: when
the first capture returns `null` and `expectsCompletionMessage` is true, wait
200ms and retry before committing the null result. This keeps retry ownership in
the shared completion capture boundary — the same function that already owns
`waitForReply` policy — rather than adding a second policy layer in the
lifecycle orchestrator.

## User Impact

Parent subagents that yield via `sessions_yield` and produce a valid final
result after child completions now correctly receive `terminalOutcome: undefined`
(not blocked) in their Task records, and their TaskFlow mirrors show
`succeeded`. Progress-only or truly empty completions continue to be marked as
`blocked` with no change in behavior.

## Evidence

### Test results (2026-07-30)

**Lifecycle tests** — all 117 pass, including the 2 new retry tests:

```
$ node scripts/run-vitest.mjs src/agents/subagent-registry-lifecycle.test.ts

 ✓ |agents-core| src/agents/subagent-registry-lifecycle.test.ts (117 tests) 1460ms
     ✓ recovers from an empty first capture when the final text lands before the retry  203ms
     ✓ still blocks when both capture attempts return empty  205ms

 Test Files  1 passed (1)
      Tests  117 passed (117)
```

**Completion tests** — all 8 pass:

```
$ node scripts/run-vitest.mjs src/agents/subagent-registry-completion.test.ts

 ✓ |agents-core| src/agents/subagent-registry-completion.test.ts (8 tests) 690ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
```

### Code path verified

The retry (lines 302-318 in `subagent-registry-lifecycle-delivery.ts`) is placed
correctly:

- **Before** result freezing: the retry happens before `completion.resultText` is
  set (line 334), so the freeze uses the retried value
- **ExpectsCompletionMessage gate**: only runs under `entry.expectsCompletionMessage === true`
- **sessions_yield skip preserved**: lines 323-329 still return `false` for yielded sessions
- **Error path**: the `catch` block sets `resultText = null`, preserving blocked outcome
- **Task/TaskFlow chain**: frozen `resultText` feeds into `completeTaskRunByRunId`
  via `terminalSummary`/`terminalOutcome`, which is mirrored by TaskFlow

The delivery chain: `freezeRunResultAtCompletion` → `entry.completion.resultText` →
`delivery.payload.frozenResultText` (line 490) → Task store → TaskFlow mirror.

### Lint / Format

```
$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
    src/agents/subagent-registry-lifecycle-delivery.ts \
    src/agents/subagent-registry-lifecycle.test.ts
Found 0 warnings and 0 errors.

$ npx oxfmt --check src/agents/subagent-registry-lifecycle-delivery.ts \
    src/agents/subagent-registry-lifecycle.test.ts
All matched files use the correct format.
```

### QA scenario coverage

The QA scenario `subagent-completion-direct-fallback`
(`qa/scenarios/agents/subagent-completion-direct-fallback.yaml`) exercises the
exact yielded-parent completion delivery path (`sessions_yield` → child
completion → direct fallback). This path triggers `freezeRunResultAtCompletion`
with the yield-resume race condition, making it the canonical integration test
for the retry fix. The scenario verifies:
- Parent spawns a native subagent and yields
- Child completion is delivered to the QA DM
- Durable task delivery is marked delivered (not failed)

### ClawSweeper [P1] feedback addressed

The retry has been moved from the lifecycle callback
(`subagent-registry-lifecycle-completion.ts`) into `freezeRunResultAtCompletion`
(`subagent-registry-lifecycle-delivery.ts`), which already owns the
`waitForReply` capture policy. The lifecycle layer no longer adds a second retry
policy.
