### PR TITLE
fix(macos): preserve newest Voice Wake trigger settings

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -29995,7 +29995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 774,
+      "line": 824,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host)",
       "surface": "apple",
@@ -30003,7 +30003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 774,
+      "line": 824,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host):\\(port)",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -10,6 +10,56 @@ private enum RemoteTLSFingerprintUpdate {
     case replace(String?)
 }
 
+@MainActor
+final class VoiceWakeGlobalSyncScheduler {
+    private let delay: @Sendable () async throws -> Void
+    private let deliver: @Sendable ([String]) async -> Void
+    private var debounceTask: Task<Void, Never>?
+    private var deliveryTail: Task<Void, Never>?
+    private var generation: UInt64 = 0
+
+    init(
+        delay: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(for: .milliseconds(650))
+        },
+        deliver: @escaping @Sendable ([String]) async -> Void = { triggers in
+            await GatewayConnection.shared.voiceWakeSetTriggers(triggers)
+        })
+    {
+        self.delay = delay
+        self.deliver = deliver
+    }
+
+    @discardableResult
+    func schedule(_ triggers: [String]) -> Task<Void, Never> {
+        self.generation &+= 1
+        let generation = self.generation
+        self.debounceTask?.cancel()
+        let delay = self.delay
+        let task = Task { [weak self] in
+            do {
+                try await delay()
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self, self.generation == generation else { return }
+            self.enqueueDelivery(triggers, generation: generation)
+        }
+        self.debounceTask = task
+        return task
+    }
+
+    private func enqueueDelivery(_ triggers: [String], generation: UInt64) {
+        let previousDelivery = self.deliveryTail
+        let deliver = self.deliver
+        self.deliveryTail = Task { [weak self, previousDelivery] in
+            await previousDelivery?.value
+            guard let self, self.generation == generation else { return }
+            await deliver(triggers)
+        }
+    }
+}
+
 enum ExecApprovalsPolicyLoadState: Equatable {
     case loading
     case available
@@ -56,7 +106,7 @@ final class AppState {
     private var configWatcher: ConfigFileWatcher?
     private var lastConfigFingerprint: Data?
     private var suppressVoiceWakeGlobalSync = false
-    private var voiceWakeGlobalSyncTask: Task<Void, Never>?
+    @ObservationIgnored private let voiceWakeGlobalSyncScheduler = VoiceWakeGlobalSyncScheduler()
     @ObservationIgnored private var activeComputerPresenceTask: Task<Void, Never>?
     @ObservationIgnored private var activeComputerPresenceUpdateGeneration: UInt64 = 0
 
@@ -879,11 +929,7 @@ final class AppState {
     private func scheduleVoiceWakeGlobalSyncIfNeeded() {
         guard !self.suppressVoiceWakeGlobalSync else { return }
         let sanitized = sanitizeVoiceWakeTriggers(swabbleTriggerWords)
-        self.voiceWakeGlobalSyncTask?.cancel()
-        self.voiceWakeGlobalSyncTask = Task { [sanitized] in
-            try? await Task.sleep(nanoseconds: 650_000_000)
-            await GatewayConnection.shared.voiceWakeSetTriggers(sanitized)
-        }
+        self.voiceWakeGlobalSyncScheduler.schedule(sanitized)
     }
 
     // MARK: - Chime persistence

--- a/apps/macos/Tests/OpenClawIPCTests/VoiceWakeGlobalSettingsSyncTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/VoiceWakeGlobalSettingsSyncTests.swift
@@ -3,7 +3,84 @@ import OpenClawProtocol
 import Testing
 @testable import OpenClaw
 
-@Suite(.serialized) struct VoiceWakeGlobalSettingsSyncTests {
+private actor VoiceWakeSyncDelaySequence {
+    private var calls = 0
+    private var firstStartedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var firstReleaseWaiter: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        self.calls += 1
+        guard self.calls == 1 else { return }
+        for waiter in self.firstStartedWaiters {
+            waiter.resume()
+        }
+        self.firstStartedWaiters.removeAll()
+        await withCheckedContinuation { continuation in
+            self.firstReleaseWaiter = continuation
+        }
+    }
+
+    func waitUntilFirstStarted() async {
+        guard self.calls == 0 else { return }
+        await withCheckedContinuation { continuation in
+            self.firstStartedWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirst() {
+        self.firstReleaseWaiter?.resume()
+        self.firstReleaseWaiter = nil
+    }
+}
+
+private actor VoiceWakeSyncRecorder {
+    private let blockFirst: Bool
+    private(set) var payloads: [[String]] = []
+    private var firstStartedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var firstReleaseWaiter: CheckedContinuation<Void, Never>?
+
+    init(blockFirst: Bool = false) {
+        self.blockFirst = blockFirst
+    }
+
+    func record(_ triggers: [String]) async {
+        self.payloads.append(triggers)
+        guard self.blockFirst, self.payloads.count == 1 else { return }
+        for waiter in self.firstStartedWaiters {
+            waiter.resume()
+        }
+        self.firstStartedWaiters.removeAll()
+        await withCheckedContinuation { continuation in
+            self.firstReleaseWaiter = continuation
+        }
+    }
+
+    func waitUntilFirstStarted() async {
+        guard self.payloads.isEmpty else { return }
+        await withCheckedContinuation { continuation in
+            self.firstStartedWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirst() {
+        self.firstReleaseWaiter?.resume()
+        self.firstReleaseWaiter = nil
+    }
+
+    func waitForPayloadCount(_ expected: Int) async {
+        let deadline = ContinuousClock.now + .seconds(5)
+        while self.payloads.count < expected, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        if self.payloads.count < expected {
+            Issue.record("timed out waiting for \(expected) voice wake payloads")
+        }
+    }
+}
+
+@Suite(.serialized)
+@MainActor
+struct VoiceWakeGlobalSettingsSyncTests {
     private func voiceWakeChangedEvent(payload: OpenClawProtocol.AnyCodable) -> EventFrame {
         EventFrame(
             type: "event",
@@ -50,5 +127,41 @@ import Testing
         await MainActor.run {
             AppStateStore.shared.applyGlobalVoiceWakeTriggers(previous)
         }
+    }
+
+    @Test func `cancelled trigger sync does not send stale payload`() async {
+        let delay = VoiceWakeSyncDelaySequence()
+        let recorder = VoiceWakeSyncRecorder()
+        let scheduler = VoiceWakeGlobalSyncScheduler(
+            delay: { await delay.wait() },
+            deliver: { await recorder.record($0) })
+
+        let stale = scheduler.schedule(["stale"])
+        await delay.waitUntilFirstStarted()
+        let current = scheduler.schedule(["current"])
+        await current.value
+        await recorder.waitForPayloadCount(1)
+        await delay.releaseFirst()
+        await stale.value
+
+        #expect(await recorder.payloads == [["current"]])
+    }
+
+    @Test func `newest trigger sync is delivered after an in flight stale write`() async {
+        let recorder = VoiceWakeSyncRecorder(blockFirst: true)
+        let scheduler = VoiceWakeGlobalSyncScheduler(
+            delay: {},
+            deliver: { await recorder.record($0) })
+
+        scheduler.schedule(["stale"])
+        await recorder.waitUntilFirstStarted()
+        let current = scheduler.schedule(["current"])
+        await current.value
+
+        #expect(await recorder.payloads == [["stale"]])
+
+        await recorder.releaseFirst()
+        await recorder.waitForPayloadCount(2)
+        #expect(await recorder.payloads == [["stale"], ["current"]])
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users editing Voice Wake trigger words quickly could end up with an older trigger set on the Gateway when a previous write was still in flight.

## Why This Change Was Made

The macOS app now uses a generation-aware scheduler that cancels pending debounce work, rejects stale generations even if cancellation is delayed, and serializes Gateway writes so the newest payload follows any write already in progress. This does not change the Gateway protocol or configuration shape.

## User Impact

Rapid Voice Wake trigger edits now settle on the newest setting instead of allowing an older request to overwrite it.

## Evidence

- `swift test --package-path apps/macos --scratch-path apps/macos/.build-local --filter VoiceWakeGlobalSettingsSyncTests`: 4 tests passed in 10 consecutive runs, including stale-debounce and in-flight-write regressions.
- `swiftformat --lint ... --config config/swiftformat`: 0 of 2 changed files require formatting.
- `swiftlint lint --config config/swiftlint.yml --quiet`: passed.
- Native app i18n verification passed with 5,382 inventory entries unchanged after regeneration.
- Autoreview on exact head `152c0fe5ca1f8cba7006d6d62f8970bd007a1e1b`: no findings; patch correct at 0.96 confidence.
- Blacksmith Testbox changed gate on the implementation-equivalent source head: 211 tests passed, 37 skipped; conflict-marker, dependency-pin, changelog-attribution, package-patch, and native-state-schema guards passed. Run: https://github.com/openclaw/openclaw/actions/runs/30511063670
- Owner merge review against current main `cc48aef143551af2ce13096264335ce9954e61e6`: none of the three touched paths changed after the frozen base, and `git merge-tree --write-tree origin/main HEAD` completed cleanly.

AI-assisted: yes. The implementation and proof were reviewed against the complete branch diff.
