### PR TITLE
fix(agents): classify synthesized missing-result warnings as non-terminal

### DIFF
--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -135,6 +135,7 @@ export class CodexToolProgressProjection {
           : {}),
         ...(error.timedOut ? { timedOut: true } : {}),
         ...(error.middlewareError ? { middlewareError: true } : {}),
+        ...(error.syntheticMissingResult ? { syntheticMissingResult: true } : {}),
       },
       nativeMutation: {
         mutatingAction: error.mutatingAction === true,

--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -559,6 +559,10 @@ export class CodexToolTranscriptProjection {
       toolName: name,
       ...(meta ? { meta } : {}),
       error: formatMissingToolResultError({ id: firstMissingId, name }),
+      // Nothing reported a failure here; the call/result pairing is incomplete.
+      // Marking the origin lets the reply layer classify the warning as
+      // non-terminal instead of treating it as evidence the turn failed.
+      syntheticMissingResult: true,
       ...(item && isMutatingNativeToolItem(item) ? { mutatingAction: true } : {}),
       ...(actionFingerprint ? { actionFingerprint } : {}),
     });

--- a/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
@@ -470,6 +470,9 @@ describe("CodexAppServerEventProjector native tool finalization", () => {
       toolName: "bash",
       error: expect.stringContaining("without a matching tool.result"),
       mutatingAction: true,
+      // Synthesized from an unmatched call rather than reported by the tool, so
+      // the reply layer can classify the warning as non-terminal.
+      syntheticMissingResult: true,
     });
     expect(result.lastToolError?.actionFingerprint).toContain("node scripts/report.js --publish");
     expect(result.assistantTexts).toEqual([

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -660,6 +660,23 @@ describe("buildEmbeddedRunPayloads", () => {
     );
   });
 
+  it("marks a synthesized missing-result warning as non-terminal", () => {
+    // Identical to the case above apart from the origin of the error: nothing
+    // reported a failure, the call/result pairing was simply incomplete when the
+    // turn ended. The turn still produced an answer, so the warning is
+    // fallback-only and must not stand in for that answer.
+    const payloads = buildPayloads({
+      assistantTexts: ["Done."],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      lastToolError: { toolName: "write", error: "file missing", syntheticMissingResult: true },
+    });
+
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]?.text).toBe("Done.");
+    expect(payloads[1]?.isError).toBe(true);
+    expect(getReplyPayloadMetadata(payloads[1] as object)?.nonTerminalToolErrorWarning).toBe(true);
+  });
+
   it("still shows write tool errors when timedOut is true but no fileTarget was recorded", () => {
     // Without `fileTarget` we cannot distinguish a confirmed file write from
     // an unrelated mutating-tool timeout, so the default-visible warning is

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -177,7 +177,11 @@ function shouldIncludeToolErrorDetails(params: {
 }
 
 function shouldMarkNonTerminalToolErrorWarning(lastToolError: ToolErrorSummary): boolean {
-  return lastToolError.middlewareError === true;
+  // Both are bookkeeping errors rather than a tool reporting its own failure, so
+  // neither terminates the turn. Paired with `hasUserFacingAssistantReply` at the
+  // call site, that makes the warning fallback-only: channels deliver it when the
+  // turn produced nothing else, and suppress it in favour of a real answer.
+  return lastToolError.middlewareError === true || lastToolError.syntheticMissingResult === true;
 }
 
 function formatToolErrorWarningText(params: {

--- a/src/agents/tool-error-summary.ts
+++ b/src/agents/tool-error-summary.ts
@@ -14,6 +14,13 @@ export type ToolErrorSummary = {
   validationErrorSummary?: string;
   timedOut?: boolean;
   middlewareError?: boolean;
+  /**
+   * The error was synthesized because a tool call had no matching result when the
+   * turn ended, rather than reported by the tool itself. Like a middleware error
+   * this is non-terminal bookkeeping: the turn can still have produced a complete
+   * answer, so channels must be free to treat the warning as fallback-only.
+   */
+  syntheticMissingResult?: boolean;
   mutatingAction?: boolean;
   actionFingerprint?: string;
   fileTarget?: FileTarget;


### PR DESCRIPTION
Fixes #115117.

## What Problem This Solves

A non-terminal tool warning is supposed to be fallback-only: channels deliver it
when the turn produced nothing else, and suppress it in favour of a real answer.
Discord implements exactly that, gating on

```ts
// extensions/discord/src/monitor/message-handler.process.ts:275
if (info.kind === "final" && !isFallbackOnlyToolWarningFinal(payload)) {
  draftPreview.markFinalReplyStarted();
}
```

But the predicate behind it requires the `nonTerminalToolErrorWarning` metadata,
and that flag has a single origin gated on middleware errors:

```ts
// src/agents/embedded-agent-runner/run/payloads.ts:822
nonTerminalToolErrorWarning:
  hasUserFacingAssistantReply && shouldMarkNonTerminalToolErrorWarning(params.lastToolError),

// src/agents/embedded-agent-runner/run/payloads.ts:179
function shouldMarkNonTerminalToolErrorWarning(lastToolError: ToolErrorSummary): boolean {
  return lastToolError.middlewareError === true;
}
```

The other bookkeeping error class — the warning synthesized when a tool call has
no matching result at turn end — carries no such marker. It arrives unflagged, so
`isFallbackOnlyToolWarningFinal` returns `false`, the turn is marked final-started,
and the real assistant answer that follows is gated out. The user is left with
`⚠️ 🛠️ … failed` while the completed answer sits in the transcript.

## What this does

Marks the synthesized error at its origin and lets the existing classification
read it. Nothing is suppressed or deleted — the warning is still produced, still
recorded in the transcript and trajectory, and is still delivered when the turn
has no answer to show instead. It simply stops standing in for an answer that
exists.

- `ToolErrorSummary` gains `syntheticMissingResult`, a sibling of `middlewareError`:
  both mean "bookkeeping, not a tool reporting its own failure".
- The Codex projector sets it where it synthesizes the error
  (`event-projector-tool-transcript.ts`), and forwards it through the terminal
  observation payload alongside `middlewareError` so the reconstructed summary
  keeps it.
- `shouldMarkNonTerminalToolErrorWarning` accepts either marker.

The `hasUserFacingAssistantReply` half of the call site is unchanged, so a turn
that produced nothing still surfaces the warning exactly as before.

### Why not widen the predicate to all tool errors

`hasUserFacingAssistantReply` alone would arguably be enough to call any tool
warning non-terminal, but that would also make a genuine failure — `bash` exiting
non-zero while the assistant answers anyway — fallback-only, and users generally
do want to see that. This change is deliberately limited to errors that no tool
ever reported.

### Why not suppress the synthesized error instead

Not producing the error at all on a completed turn was the other option (#115489).
It loses information: the projector cannot tell "the tool actually succeeded and
only the mirrored item lacks a completion event" from "the command never ran", and
`event-projector.native-finalization.test.ts` pins a case of the latter where the
warning is the right thing to keep. Classifying is non-destructive; suppressing is
not.

## Evidence

### Tests

- `payloads.errors.test.ts` — new case directly contrasting with the existing
  `shows mutating tool errors when assistant output claims success`, which asserts
  the flag stays `undefined`. Same inputs plus `syntheticMissingResult: true` now
  yields `nonTerminalToolErrorWarning: true`, with the assistant answer still first
  in the payload list.
- `event-projector.native-finalization.test.ts` — the existing missing-result case
  now also asserts the marker reaches `result.lastToolError`, which covers the
  forwarding through `observeToolTerminal` (without it the flag is dropped when a
  terminal resolution replaces the summary).

Local runs:

```
src/agents/tool-error-state.test.ts
src/agents/tool-terminal-outcome.test.ts
src/agents/embedded-agent-runner/run/payloads.test.ts
src/agents/embedded-agent-runner/run/payloads.errors.test.ts
  → 4 files, 134 tests passed

extensions/codex/src/app-server/
  → 117 files, 114 passed
```

The three failing files under `extensions/codex/src/app-server/` — `auth-bridge`,
`attempt-startup`, `native-skill-isolation` — fail identically with the change
stashed, on this same checkout; they are environment-dependent (auth/env fallback
and skill isolation) and touch nothing in this diff. `oxlint` and `oxfmt --check`
are clean on all six changed files.

### Relationship to the reports

#111778 reports the Mattermost symptom; #111937 ports Discord's handling to it.
That port is faithful, but inherits this gap because it reuses the same predicate —
so on both channels the synthesized class still slips through. This change fixes
the classification once, for every channel that gates on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
