### PR TITLE
fix(test): avoid transcript mirror lock races

### DIFF
--- a/src/plugin-sdk/session-transcript-mirror-runtime.test.ts
+++ b/src/plugin-sdk/session-transcript-mirror-runtime.test.ts
@@ -1,14 +1,14 @@
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { upsertSessionEntry } from "../config/sessions/session-accessor.js";
 import {
+  runExclusiveSqliteSessionWrite,
   resolveSqliteTranscriptScope,
   toDatabaseOptions,
 } from "../config/sessions/session-accessor.sqlite-scope.js";
 import { waitForSessionTranscriptProjection } from "../config/sessions/session-transcript-reconcile.js";
-import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js";
 import { withCodexSessionTranscriptMirrorWriteLock } from "./codex-session-transcript-runtime.js";
 import { readSessionTranscriptVisibleMessageDelta } from "./session-transcript-runtime.js";
 
@@ -121,13 +121,17 @@ describe("private session transcript mirror runtime", () => {
         result: { appended: true, message: { role: "assistant" } },
       });
     });
+    await waitForSessionTranscriptProjection(scope);
 
-    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolvedScope));
-    const external = new DatabaseSync(database.path);
-    external
-      .prepare("UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?")
-      .run(scope.sessionId);
-    external.close();
+    await runExclusiveSqliteSessionWrite(resolvedScope, async () => {
+      runOpenClawAgentWriteTransaction((database) => {
+        database.db
+          .prepare(
+            "UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?",
+          )
+          .run(scope.sessionId);
+      }, toDatabaseOptions(resolvedScope));
+    });
 
     await withCodexSessionTranscriptMirrorWriteLock(scope, async (locked) => {
       expect(await locked.readMessageFacts({ idempotencyKeys: ["mirror-user"] })).toMatchObject({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the delegated full Testbox suite could fail the private transcript mirror test with `database is locked` while preparing a dirty projection.

## Why This Change Was Made

The test now waits for the preceding projection to settle, then marks the projection dirty through the canonical session writer queue and OpenClaw agent database transaction helper. The runtime behavior and assertion remain unchanged.

## User Impact

No user-visible behavior changes. Maintainers get deterministic transcript mirror coverage in the full Testbox lane.

## Evidence

- Before: delegated full Testbox run failed at `session-transcript-mirror-runtime.test.ts` while a raw second SQLite connection updated `session_transcript_index_state`.
- After: `node scripts/run-vitest.mjs src/plugin-sdk/session-transcript-mirror-runtime.test.ts` passed in 12 clean invocations.
- `git diff --check`
- Autoreview: clean, no actionable findings, confidence 0.92.

AI-assisted: yes; maintainer-directed test audit.