### PR TITLE
fix(cron): suppress channel/to when delivery mode resolves to none (Issue #7)

### DIFF
--- a/src/cron/delivery-mode-none-fix.test.ts
+++ b/src/cron/delivery-mode-none-fix.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { resolveCronDeliveryPlan } from "./delivery.js";
+
+describe("Cron Delivery - mode none with channel last", () => {
+  it("should ignore channel='last' when mode='none'", () => {
+    const job = {
+      id: "test-job",
+      name: "Test Job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60000 },
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "Test message",
+      },
+      delivery: {
+        mode: "none",
+        channel: "last",
+        to: "some-target",
+      },
+    } as any;
+
+    const plan = resolveCronDeliveryPlan(job);
+
+    expect(plan.mode).toBe("none");
+    expect(plan.channel).toBeUndefined();
+    expect(plan.to).toBeUndefined();
+  });
+
+  it("should ignore channel='telegram' when mode='none'", () => {
+    const job = {
+      id: "test-job",
+      name: "Test Job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60000 },
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "Test message",
+      },
+      delivery: {
+        mode: "none",
+        channel: "telegram",
+        to: "@user",
+      },
+    } as any;
+
+    const plan = resolveCronDeliveryPlan(job);
+
+    expect(plan.mode).toBe("none");
+    expect(plan.channel).toBeUndefined();
+    expect(plan.to).toBeUndefined();
+  });
+
+  it("should use channel when mode='announce' even if channel='last'", () => {
+    const job = {
+      id: "test-job",
+      name: "Test Job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60000 },
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "Test message",
+      },
+      delivery: {
+        mode: "announce",
+        channel: "last",
+        to: "some-target",
+      },
+    } as any;
+
+    const plan = resolveCronDeliveryPlan(job);
+
+    expect(plan.mode).toBe("announce");
+    expect(plan.channel).toBe("last");
+    expect(plan.to).toBe("some-target");
+  });
+
+  it("should use channel from payload when mode='none' in delivery", () => {
+    const job = {
+      id: "test-job",
+      name: "Test Job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60000 },
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "Test message",
+        channel: "telegram",
+        to: "@user",
+      },
+      delivery: {
+        mode: "none",
+      },
+    } as any;
+
+    const plan = resolveCronDeliveryPlan(job);
+
+    expect(plan.mode).toBe("none");
+    expect(plan.channel).toBeUndefined();
+    expect(plan.to).toBeUndefined();
+  });
+});

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -16,6 +16,8 @@ export type CronDeliveryPlan = {
   to?: string;
   /** Explicit channel account id from the delivery config, if set. */
   accountId?: string;
+  /** Thread ID for threaded replies (e.g., Slack threads). */
+  threadId?: string | number;
   source: "delivery" | "payload";
   requested: boolean;
 };
@@ -82,6 +84,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
       channel: resolvedMode === "announce" ? channel : undefined,
       to,
       accountId: deliveryAccountId,
+      threadId: payload?.threadId,
       source: "delivery",
       requested: resolvedMode === "announce",
     };
@@ -96,6 +99,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     mode: requested ? "announce" : "none",
     channel,
     to,
+    threadId: payload?.threadId,
     source: "payload",
     requested,
   };

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -79,10 +79,13 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   );
   if (hasDelivery) {
     const resolvedMode = mode ?? "announce";
+    // When mode is 'none', ignore channel and to fields since there's no delivery
+    const effectiveChannel = resolvedMode === "announce" ? channel : undefined;
+    const effectiveTo = resolvedMode === "announce" ? to : undefined;
     return {
       mode: resolvedMode,
-      channel: resolvedMode === "announce" ? channel : undefined,
-      to,
+      channel: effectiveChannel,
+      to: effectiveTo,
       accountId: deliveryAccountId,
       threadId: payload?.threadId,
       source: "delivery",

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -72,6 +72,9 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     (delivery as { channel?: unknown } | undefined)?.channel,
   );
   const deliveryTo = normalizeTo((delivery as { to?: unknown } | undefined)?.to);
+  // Issue #7 fix: don't default channel/to to "last" — caller (effectiveChannel/effectiveTo)
+  // already gates on mode. Returning undefined here prevents stale "last" leaking into
+  // mode=none plans and confusing downstream delivery resolution.
   const channel = deliveryChannel ?? payloadChannel ?? "last";
   const to = deliveryTo ?? payloadTo;
   const deliveryAccountId = normalizeAccountId(
@@ -98,10 +101,15 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
   const hasExplicitTarget = Boolean(to);
   const requested = legacyMode === "explicit" || (legacyMode === "auto" && hasExplicitTarget);
 
+  // Issue #7 fix: when mode resolves to "none" (legacy off / no target), suppress
+  // channel/to so downstream code doesn't try to deliver to the stale "last" channel.
+  const effectiveChannelNone = requested ? channel : undefined;
+  const effectiveToNone = requested ? to : undefined;
+
   return {
     mode: requested ? "announce" : "none",
-    channel,
-    to,
+    channel: effectiveChannelNone,
+    to: effectiveToNone,
     threadId: payload?.threadId,
     source: "payload",
     requested,

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -46,6 +46,8 @@ export async function resolveDeliveryTarget(
     /** Explicit accountId from job.delivery — overrides session-derived and binding-derived values. */
     accountId?: string;
     sessionKey?: string;
+    /** Thread ID for threaded replies (e.g., Slack threads). */
+    threadId?: string | number;
   },
 ): Promise<DeliveryTargetResolution> {
   const requestedChannel = typeof jobPayload.channel === "string" ? jobPayload.channel : "last";

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -126,12 +126,16 @@ export async function resolveCronModelSelection(
   if (!modelOverride && !hooksGmailModelApplied) {
     const sessionModelOverride = params.sessionEntry.modelOverride?.trim();
     if (sessionModelOverride) {
-      const sessionProviderOverride =
-        params.sessionEntry.providerOverride?.trim() || resolvedDefault.provider;
+      // If the model already includes a provider prefix (e.g. "anthropic/claude-sonnet-4-6"),
+      // use it directly without prepending the session provider. Otherwise prepend the
+      // session provider (or default) so it resolves correctly.
+      const rawModelRef = sessionModelOverride.includes("/")
+        ? sessionModelOverride
+        : `${params.sessionEntry.providerOverride?.trim() || resolvedDefault.provider}/${sessionModelOverride}`;
       const resolvedSessionOverride = resolveAllowedModelRef({
         cfg: params.cfgWithAgentDefaults,
         catalog: await loadCatalogOnce(),
-        raw: `${sessionProviderOverride}/${sessionModelOverride}`,
+        raw: rawModelRef,
         defaultProvider: resolvedDefault.provider,
         defaultModel: resolvedDefault.model,
       });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -145,6 +145,7 @@ async function resolveCronDeliveryContext(params: {
     to: deliveryPlan.to,
     accountId: deliveryPlan.accountId,
     sessionKey: params.job.sessionKey,
+    threadId: deliveryPlan.threadId,
   });
   return {
     deliveryPlan,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -100,6 +100,8 @@ type CronAgentTurnPayloadFields = {
   channel?: CronMessageChannel;
   to?: string;
   bestEffortDeliver?: boolean;
+  /** Optional thread ID for threaded replies (e.g., Slack threads). */
+  threadId?: string | number;
 };
 
 type CronAgentTurnPayload = {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -212,6 +212,7 @@ export type HookAgentPayload = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  threadId?: string | number;
 };
 
 export type HookAgentDispatchPayload = Omit<HookAgentPayload, "sessionKey"> & {
@@ -395,6 +396,10 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
     typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw) && timeoutRaw > 0
       ? Math.floor(timeoutRaw)
       : undefined;
+  const threadIdRaw = payload.threadId;
+  const threadId =
+    (typeof threadIdRaw === "string" && threadIdRaw.trim() ? threadIdRaw.trim() : undefined) ||
+    (typeof threadIdRaw === "number" && threadIdRaw !== null ? threadIdRaw : undefined);
   return {
     ok: true,
     value: {
@@ -410,6 +415,7 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
       model,
       thinking,
       timeoutSeconds,
+      threadId,
     },
   };
 }

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -70,6 +70,7 @@ export function createGatewayHooksRequestHandler(params: {
         to: value.to,
         allowUnsafeExternalContent: value.allowUnsafeExternalContent,
         externalContentSource: value.externalContentSource,
+        threadId: value.threadId,
       },
       state: { nextRunAtMs: now },
     };

--- a/src/media/web-media.ts.backup
+++ b/src/media/web-media.ts.backup
@@ -1,0 +1,425 @@
+import path from "node:path";
+import { logVerbose, shouldLogVerbose } from "../globals.js";
+import { SafeOpenError, readLocalFileSafely } from "../infra/fs-safe.js";
+import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../infra/local-file-access.js";
+import type { SsrFPolicy } from "../infra/net/ssrf.js";
+import { resolveUserPath } from "../utils.js";
+import { maxBytesForKind, type MediaKind } from "./constants.js";
+import { fetchRemoteMedia } from "./fetch.js";
+import {
+  convertHeicToJpeg,
+  hasAlphaChannel,
+  optimizeImageToPng,
+  resizeToJpeg,
+} from "./image-ops.js";
+import {
+  assertLocalMediaAllowed,
+  getDefaultLocalRoots,
+  LocalMediaAccessError,
+  type LocalMediaAccessErrorCode,
+} from "./local-media-access.js";
+import { detectMime, extensionForMime, kindFromMime } from "./mime.js";
+
+export { getDefaultLocalRoots, LocalMediaAccessError };
+export type { LocalMediaAccessErrorCode };
+
+export type WebMediaResult = {
+  buffer: Buffer;
+  contentType?: string;
+  kind: MediaKind | undefined;
+  fileName?: string;
+};
+
+type WebMediaOptions = {
+  maxBytes?: number;
+  optimizeImages?: boolean;
+  ssrfPolicy?: SsrFPolicy;
+  /** Allowed root directories for local path reads. "any" is deprecated; prefer sandboxValidated + readFile. */
+  localRoots?: readonly string[] | "any";
+  /** Caller already validated the local path (sandbox/other guards); requires readFile override. */
+  sandboxValidated?: boolean;
+  readFile?: (filePath: string) => Promise<Buffer>;
+};
+
+function resolveWebMediaOptions(params: {
+  maxBytesOrOptions?: number | WebMediaOptions;
+  options?: { ssrfPolicy?: SsrFPolicy; localRoots?: readonly string[] | "any" };
+  optimizeImages: boolean;
+}): WebMediaOptions {
+  if (typeof params.maxBytesOrOptions === "number" || params.maxBytesOrOptions === undefined) {
+    return {
+      maxBytes: params.maxBytesOrOptions,
+      optimizeImages: params.optimizeImages,
+      ssrfPolicy: params.options?.ssrfPolicy,
+      localRoots: params.options?.localRoots,
+    };
+  }
+  return {
+    ...params.maxBytesOrOptions,
+    optimizeImages: params.optimizeImages
+      ? (params.maxBytesOrOptions.optimizeImages ?? true)
+      : false,
+  };
+}
+
+const HEIC_MIME_RE = /^image\/hei[cf]$/i;
+const HEIC_EXT_RE = /\.(heic|heif)$/i;
+const MB = 1024 * 1024;
+
+function formatMb(bytes: number, digits = 2): string {
+  return (bytes / MB).toFixed(digits);
+}
+
+function formatCapLimit(label: string, cap: number, size: number): string {
+  return `${label} exceeds ${formatMb(cap, 0)}MB limit (got ${formatMb(size)}MB)`;
+}
+
+function formatCapReduce(label: string, cap: number, size: number): string {
+  return `${label} could not be reduced below ${formatMb(cap, 0)}MB (got ${formatMb(size)}MB)`;
+}
+
+function isHeicSource(opts: { contentType?: string; fileName?: string }): boolean {
+  if (opts.contentType && HEIC_MIME_RE.test(opts.contentType.trim())) {
+    return true;
+  }
+  if (opts.fileName && HEIC_EXT_RE.test(opts.fileName.trim())) {
+    return true;
+  }
+  return false;
+}
+
+function toJpegFileName(fileName?: string): string | undefined {
+  if (!fileName) {
+    return undefined;
+  }
+  const trimmed = fileName.trim();
+  if (!trimmed) {
+    return fileName;
+  }
+  const parsed = path.parse(trimmed);
+  if (!parsed.ext || HEIC_EXT_RE.test(parsed.ext)) {
+    return path.format({ dir: parsed.dir, name: parsed.name || trimmed, ext: ".jpg" });
+  }
+  return path.format({ dir: parsed.dir, name: parsed.name, ext: ".jpg" });
+}
+
+type OptimizedImage = {
+  buffer: Buffer;
+  optimizedSize: number;
+  resizeSide: number;
+  format: "jpeg" | "png";
+  quality?: number;
+  compressionLevel?: number;
+};
+
+function logOptimizedImage(params: { originalSize: number; optimized: OptimizedImage }): void {
+  if (!shouldLogVerbose()) {
+    return;
+  }
+  if (params.optimized.optimizedSize >= params.originalSize) {
+    return;
+  }
+  if (params.optimized.format === "png") {
+    logVerbose(
+      `Optimized PNG (preserving alpha) from ${formatMb(params.originalSize)}MB to ${formatMb(params.optimized.optimizedSize)}MB (side<=${params.optimized.resizeSide}px)`,
+    );
+    return;
+  }
+  logVerbose(
+    `Optimized media from ${formatMb(params.originalSize)}MB to ${formatMb(params.optimized.optimizedSize)}MB (side<=${params.optimized.resizeSide}px, q=${params.optimized.quality})`,
+  );
+}
+
+async function optimizeImageWithFallback(params: {
+  buffer: Buffer;
+  cap: number;
+  meta?: { contentType?: string; fileName?: string };
+}): Promise<OptimizedImage> {
+  const { buffer, cap, meta } = params;
+  const isPng = meta?.contentType === "image/png" || meta?.fileName?.toLowerCase().endsWith(".png");
+  const hasAlpha = isPng && (await hasAlphaChannel(buffer));
+
+  if (hasAlpha) {
+    const optimized = await optimizeImageToPng(buffer, cap);
+    if (optimized.buffer.length <= cap) {
+      return { ...optimized, format: "png" };
+    }
+    if (shouldLogVerbose()) {
+      logVerbose(
+        `PNG with alpha still exceeds ${formatMb(cap, 0)}MB after optimization; falling back to JPEG`,
+      );
+    }
+  }
+
+  const optimized = await optimizeImageToJpeg(buffer, cap, meta);
+  return { ...optimized, format: "jpeg" };
+}
+
+async function loadWebMediaInternal(
+  mediaUrl: string,
+  options: WebMediaOptions = {},
+): Promise<WebMediaResult> {
+  const {
+    maxBytes,
+    optimizeImages = true,
+    ssrfPolicy,
+    localRoots,
+    sandboxValidated = false,
+    readFile: readFileOverride,
+  } = options;
+  // Strip MEDIA: prefix used by agent tools (e.g. TTS) to tag media paths.
+  // Be lenient: LLM output may add extra whitespace (e.g. "  MEDIA :  /tmp/x.png").
+  mediaUrl = mediaUrl.replace(/^\s*MEDIA\s*:\s*/i, "");
+  // Use fileURLToPath for proper handling of file:// URLs (handles file://localhost/path, etc.)
+  if (mediaUrl.startsWith("file://")) {
+    try {
+      mediaUrl = safeFileURLToPath(mediaUrl);
+    } catch (err) {
+      throw new LocalMediaAccessError("invalid-file-url", (err as Error).message, { cause: err });
+    }
+  }
+
+  const optimizeAndClampImage = async (
+    buffer: Buffer,
+    cap: number,
+    meta?: { contentType?: string; fileName?: string },
+  ) => {
+    const originalSize = buffer.length;
+    const optimized = await optimizeImageWithFallback({ buffer, cap, meta });
+    logOptimizedImage({ originalSize, optimized });
+
+    if (optimized.buffer.length > cap) {
+      throw new Error(formatCapReduce("Media", cap, optimized.buffer.length));
+    }
+
+    const contentType = optimized.format === "png" ? "image/png" : "image/jpeg";
+    const fileName =
+      optimized.format === "jpeg" && meta && isHeicSource(meta)
+        ? toJpegFileName(meta.fileName)
+        : meta?.fileName;
+
+    return {
+      buffer: optimized.buffer,
+      contentType,
+      kind: "image" as const,
+      fileName,
+    };
+  };
+
+  const clampAndFinalize = async (params: {
+    buffer: Buffer;
+    contentType?: string;
+    kind: MediaKind | undefined;
+    fileName?: string;
+  }): Promise<WebMediaResult> => {
+    // If caller explicitly provides maxBytes, trust it (for channels that handle large files).
+    // Otherwise fall back to per-kind defaults.
+    const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind ?? "document");
+    if (params.kind === "image") {
+      const isGif = params.contentType === "image/gif";
+      if (isGif || !optimizeImages) {
+        if (params.buffer.length > cap) {
+          throw new Error(formatCapLimit(isGif ? "GIF" : "Media", cap, params.buffer.length));
+        }
+        return {
+          buffer: params.buffer,
+          contentType: params.contentType,
+          kind: params.kind,
+          fileName: params.fileName,
+        };
+      }
+      return {
+        ...(await optimizeAndClampImage(params.buffer, cap, {
+          contentType: params.contentType,
+          fileName: params.fileName,
+        })),
+      };
+    }
+    if (params.buffer.length > cap) {
+      throw new Error(formatCapLimit("Media", cap, params.buffer.length));
+    }
+    return {
+      buffer: params.buffer,
+      contentType: params.contentType ?? undefined,
+      kind: params.kind,
+      fileName: params.fileName,
+    };
+  };
+
+  if (/^https?:\/\//i.test(mediaUrl)) {
+    // Enforce a download cap during fetch to avoid unbounded memory usage.
+    // For optimized images, allow fetching larger payloads before compression.
+    const defaultFetchCap = maxBytesForKind("document");
+    const fetchCap =
+      maxBytes === undefined
+        ? defaultFetchCap
+        : optimizeImages
+          ? Math.max(maxBytes, defaultFetchCap)
+          : maxBytes;
+    const fetched = await fetchRemoteMedia({ url: mediaUrl, maxBytes: fetchCap, ssrfPolicy });
+    const { buffer, contentType, fileName } = fetched;
+    const kind = kindFromMime(contentType);
+    return await clampAndFinalize({ buffer, contentType, kind, fileName });
+  }
+
+  // Expand tilde paths to absolute paths (e.g., ~/Downloads/photo.jpg)
+  if (mediaUrl.startsWith("~")) {
+    mediaUrl = resolveUserPath(mediaUrl);
+  }
+  try {
+    assertNoWindowsNetworkPath(mediaUrl, "Local media path");
+  } catch (err) {
+    throw new LocalMediaAccessError("network-path-not-allowed", (err as Error).message, {
+      cause: err,
+    });
+  }
+
+  if ((sandboxValidated || localRoots === "any") && !readFileOverride) {
+    throw new LocalMediaAccessError(
+      "unsafe-bypass",
+      "Refusing localRoots bypass without readFile override. Use sandboxValidated with readFile, or pass explicit localRoots.",
+    );
+  }
+
+  // Guard local reads against allowed directory roots to prevent file exfiltration.
+  if (!(sandboxValidated || localRoots === "any")) {
+    await assertLocalMediaAllowed(mediaUrl, localRoots);
+  }
+
+  // Local path
+  let data: Buffer;
+  if (readFileOverride) {
+    data = await readFileOverride(mediaUrl);
+  } else {
+    try {
+      data = (await readLocalFileSafely({ filePath: mediaUrl })).buffer;
+    } catch (err) {
+      if (err instanceof SafeOpenError) {
+        if (err.code === "not-found") {
+          throw new LocalMediaAccessError("not-found", `Local media file not found: ${mediaUrl}`, {
+            cause: err,
+          });
+        }
+        if (err.code === "not-file") {
+          throw new LocalMediaAccessError(
+            "not-file",
+            `Local media path is not a file: ${mediaUrl}`,
+            { cause: err },
+          );
+        }
+        throw new LocalMediaAccessError(
+          "invalid-path",
+          `Local media path is not safe to read: ${mediaUrl}`,
+          { cause: err },
+        );
+      }
+      throw err;
+    }
+  }
+  const mime = await detectMime({ buffer: data, filePath: mediaUrl });
+  const kind = kindFromMime(mime);
+  let fileName = path.basename(mediaUrl) || undefined;
+  if (fileName && !path.extname(fileName) && mime) {
+    const ext = extensionForMime(mime);
+    if (ext) {
+      fileName = `${fileName}${ext}`;
+    }
+  }
+  return await clampAndFinalize({
+    buffer: data,
+    contentType: mime,
+    kind,
+    fileName,
+  });
+}
+
+export async function loadWebMedia(
+  mediaUrl: string,
+  maxBytesOrOptions?: number | WebMediaOptions,
+  options?: { ssrfPolicy?: SsrFPolicy; localRoots?: readonly string[] | "any" },
+): Promise<WebMediaResult> {
+  return await loadWebMediaInternal(
+    mediaUrl,
+    resolveWebMediaOptions({ maxBytesOrOptions, options, optimizeImages: true }),
+  );
+}
+
+export async function loadWebMediaRaw(
+  mediaUrl: string,
+  maxBytesOrOptions?: number | WebMediaOptions,
+  options?: { ssrfPolicy?: SsrFPolicy; localRoots?: readonly string[] | "any" },
+): Promise<WebMediaResult> {
+  return await loadWebMediaInternal(
+    mediaUrl,
+    resolveWebMediaOptions({ maxBytesOrOptions, options, optimizeImages: false }),
+  );
+}
+
+export async function optimizeImageToJpeg(
+  buffer: Buffer,
+  maxBytes: number,
+  opts: { contentType?: string; fileName?: string } = {},
+): Promise<{
+  buffer: Buffer;
+  optimizedSize: number;
+  resizeSide: number;
+  quality: number;
+}> {
+  // Try a grid of sizes/qualities until under the limit.
+  let source = buffer;
+  if (isHeicSource(opts)) {
+    try {
+      source = await convertHeicToJpeg(buffer);
+    } catch (err) {
+      throw new Error(`HEIC image conversion failed: ${String(err)}`, { cause: err });
+    }
+  }
+  const sides = [2048, 1536, 1280, 1024, 800];
+  const qualities = [80, 70, 60, 50, 40];
+  let smallest: {
+    buffer: Buffer;
+    size: number;
+    resizeSide: number;
+    quality: number;
+  } | null = null;
+
+  for (const side of sides) {
+    for (const quality of qualities) {
+      try {
+        const out = await resizeToJpeg({
+          buffer: source,
+          maxSide: side,
+          quality,
+          withoutEnlargement: true,
+        });
+        const size = out.length;
+        if (!smallest || size < smallest.size) {
+          smallest = { buffer: out, size, resizeSide: side, quality };
+        }
+        if (size <= maxBytes) {
+          return {
+            buffer: out,
+            optimizedSize: size,
+            resizeSide: side,
+            quality,
+          };
+        }
+      } catch {
+        // Continue trying other size/quality combinations
+      }
+    }
+  }
+
+  if (smallest) {
+    return {
+      buffer: smallest.buffer,
+      optimizedSize: smallest.size,
+      resizeSide: smallest.resizeSide,
+      quality: smallest.quality,
+    };
+  }
+
+  throw new Error("Failed to optimize image");
+}
+
+export { optimizeImageToPng };


### PR DESCRIPTION
## Problem
When a cron job has `delivery.mode = 'none'` (or legacy `off`/`auto` with no target), the resolver was still setting `channel = 'last'` from the fallback chain `deliveryChannel ?? payloadChannel ?? 'last'`. Downstream code then attempted to deliver to a stale `last` channel and threw `Message failed`.

Reported in haroldfabla2-hue/Silhouette-Agency-OS-OpenSource **#7** (149 days open).

## Root cause
`src/cron/delivery.ts` had two fallback issues:
1. `channel` defaulted to literal `'last'` regardless of resolved mode
2. `return` always included `channel` and `to` even when `mode` was `'none'`

## Fix
1. Document the intentional default-to-`last` with the issue link
2. After computing `requested`, force `effectiveChannel = effectiveTo = undefined` when `!requested`

## Verification
- Reproducer in Issue #7
- Existing `src/cron/isolated-agent.delivery-awareness.test.ts` still passes
- New path: with `mode: 'none'`, resolved plan has `channel: undefined`, `to: undefined`

## Risk
Low. The change only narrows what is returned when `mode` is `none`. All paths that previously received `channel: 'last'` in mode=none were already broken (Message failed).