### PR TITLE
fix(openai): prevent superseded GPT-Live consult fan-out

### DIFF
--- a/extensions/openai/realtime-quicksilver-delegation.test.ts
+++ b/extensions/openai/realtime-quicksilver-delegation.test.ts
@@ -301,14 +301,16 @@ describe("GPT-Live sideband protocol", () => {
             content: [{ type: "input_text", text }],
           },
         });
-        await vi.waitFor(() =>
-          expect(runAgentConsult).toHaveBeenCalledTimes(id.endsWith("1") ? 1 : 2),
-        );
+        if (id.endsWith("1")) {
+          await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(1));
+        }
       }
 
       expect(signals[0]?.aborted).toBe(true);
-      expect(signals[1]?.aborted).toBe(false);
+      expect(runAgentConsult).toHaveBeenCalledTimes(1);
       resolutions[0]?.({ text: "stale" });
+      await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(2));
+      expect(signals[1]?.aborted).toBe(false);
       resolutions[1]?.({ text: "fresh" });
       await vi.waitFor(() =>
         expect(parseSent(socket)).toContainEqual(

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -68,6 +68,7 @@ type TestableGatewayBridge = {
     }) => Promise<{ text: string }>;
     signal: AbortSignal;
   }): Promise<void>;
+  startDelegation(delegationId: string, input: string): void;
 };
 
 function createDelegationBridge(
@@ -590,6 +591,54 @@ describe("GPT-Live gateway relay bridge", () => {
     } finally {
       bridge.close();
     }
+  });
+
+  it("keeps only the latest delegation pending while a consult settles", async () => {
+    const resolvers: Array<(value: { text: string }) => void> = [];
+    const signals: AbortSignal[] = [];
+    const runAgentConsult = vi.fn(
+      async ({ signal }: { prompt: string; signal?: AbortSignal }) =>
+        await new Promise<{ text: string }>((resolve) => {
+          signals.push(signal as AbortSignal);
+          resolvers.push(resolve);
+        }),
+    );
+    const { bridge, socket, testBridge } = createDelegationBridge(runAgentConsult);
+    try {
+      testBridge.startDelegation("delegation-1", "first task");
+      testBridge.startDelegation("delegation-2", "second task");
+      testBridge.startDelegation("delegation-3", "latest task");
+
+      expect(runAgentConsult).toHaveBeenCalledOnce();
+      expect(signals[0]?.aborted).toBe(true);
+      resolvers[0]?.({ text: "stale result" });
+      await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(2));
+      expect(runAgentConsult.mock.calls[1]?.[0].prompt).toContain("latest task");
+      expect(runAgentConsult.mock.calls[1]?.[0].prompt).not.toContain("second task");
+
+      resolvers[1]?.({ text: "latest result" });
+      await vi.waitFor(() =>
+        expect(parseSent(socket)).toContainEqual({
+          type: "delegation.context.append",
+          delegation_item_id: "delegation-3",
+          channel: "speakable",
+          content: [{ type: "input_text", text: "latest result" }],
+        }),
+      );
+      expect(socket.sent.some((entry) => entry.includes("stale result"))).toBe(false);
+    } finally {
+      bridge.close();
+    }
+  });
+
+  it("ignores delegation work after the bridge closes", () => {
+    const runAgentConsult = vi.fn(async () => ({ text: "unused" }));
+    const { bridge, testBridge } = createDelegationBridge(runAgentConsult);
+
+    bridge.close();
+    testBridge.startDelegation("delegation-late", "late task");
+
+    expect(runAgentConsult).not.toHaveBeenCalled();
   });
 
   it("bounds peer creation and closes a peer that resolves after the deadline", async () => {

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -593,14 +593,21 @@ describe("GPT-Live gateway relay bridge", () => {
     }
   });
 
-  it("keeps only the latest delegation pending while a consult settles", async () => {
+  it("keeps only the latest delegation when the superseded consult rejects on abort", async () => {
     const resolvers: Array<(value: { text: string }) => void> = [];
     const signals: AbortSignal[] = [];
     const runAgentConsult = vi.fn(
       async ({ signal }: { prompt: string; signal?: AbortSignal }) =>
-        await new Promise<{ text: string }>((resolve) => {
+        await new Promise<{ text: string }>((resolve, reject) => {
           signals.push(signal as AbortSignal);
           resolvers.push(resolve);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              reject(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
+            },
+            { once: true },
+          );
         }),
     );
     const { bridge, socket, testBridge } = createDelegationBridge(runAgentConsult);
@@ -611,7 +618,6 @@ describe("GPT-Live gateway relay bridge", () => {
 
       expect(runAgentConsult).toHaveBeenCalledOnce();
       expect(signals[0]?.aborted).toBe(true);
-      resolvers[0]?.({ text: "stale result" });
       await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(2));
       expect(runAgentConsult.mock.calls[1]?.[0].prompt).toContain("latest task");
       expect(runAgentConsult.mock.calls[1]?.[0].prompt).not.toContain("second task");
@@ -625,7 +631,7 @@ describe("GPT-Live gateway relay bridge", () => {
           content: [{ type: "input_text", text: "latest result" }],
         }),
       );
-      expect(socket.sent.some((entry) => entry.includes("stale result"))).toBe(false);
+      expect(socket.closed).toBe(false);
     } finally {
       bridge.close();
     }

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -75,6 +75,11 @@ type ActiveSideband = {
   requestIds: OpenAIQuicksilverRequestIds;
 };
 
+type PendingDelegation = {
+  delegationId: string;
+  prompt: string;
+};
+
 const CONSULT_FAILURE_TEXT =
   "The agent task failed. Tell the user it did not complete and offer to try again.";
 
@@ -153,6 +158,7 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
   private activeDelegationId: string | undefined;
   private connectPromise: Promise<void> | undefined;
   private consultController: AbortController | undefined;
+  private pendingDelegation: PendingDelegation | undefined;
   private connected = false;
   private closed = false;
   private closeNotified = false;
@@ -417,23 +423,46 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
   }
 
   private startDelegation(delegationId: string, input: string): void {
-    const runAgentConsult = this.config.runAgentConsult as RealtimeVoiceAgentConsultRunner;
-    if (!input.trim()) {
+    if (this.closed || !input.trim()) {
       return;
     }
     const transcript = this.transcript;
     this.transcript = [];
     this.partialTranscriptRole = undefined;
-    this.consultController?.abort(new Error("GPT-Live delegation superseded"));
+    const prompt = buildOpenAIQuicksilverDelegationPrompt({ input, transcript });
+    this.activeDelegationId = delegationId;
+    if (this.consultController) {
+      this.pendingDelegation = { delegationId, prompt };
+      this.consultController.abort(new Error("GPT-Live delegation superseded"));
+      return;
+    }
+    this.launchDelegation({ delegationId, prompt });
+  }
+
+  private launchDelegation(delegation: PendingDelegation): void {
+    if (this.closed) {
+      return;
+    }
+    const runAgentConsult = this.config.runAgentConsult as RealtimeVoiceAgentConsultRunner;
     const controller = new AbortController();
     this.consultController = controller;
-    this.activeDelegationId = delegationId;
+    this.activeDelegationId = delegation.delegationId;
     const signal = AbortSignal.any([this.abortController.signal, controller.signal]);
-    const prompt = buildOpenAIQuicksilverDelegationPrompt({ input, transcript });
-    void this.runDelegation({ delegationId, prompt, runAgentConsult, signal }).finally(() => {
+    void this.runDelegation({
+      delegationId: delegation.delegationId,
+      prompt: delegation.prompt,
+      runAgentConsult,
+      signal,
+    }).finally(() => {
       if (this.consultController === controller) {
         this.consultController = undefined;
-        this.activeDelegationId = undefined;
+        const pending = this.pendingDelegation;
+        this.pendingDelegation = undefined;
+        if (pending) {
+          this.launchDelegation(pending);
+        } else {
+          this.activeDelegationId = undefined;
+        }
       }
     });
   }
@@ -508,6 +537,7 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
     this.abortController.abort(new Error("GPT-Live gateway relay bridge closed"));
     this.consultController?.abort(new Error("GPT-Live delegation stopped"));
     this.consultController = undefined;
+    this.pendingDelegation = undefined;
     this.activeDelegationId = undefined;
     if (this.timer) {
       clearTimeout(this.timer);

--- a/extensions/openai/realtime-quicksilver-session.test.ts
+++ b/extensions/openai/realtime-quicksilver-session.test.ts
@@ -350,14 +350,21 @@ describe("GPT-Live offer broker", () => {
     }
   });
 
-  it("keeps only the latest delegation pending while a consult settles", async () => {
+  it("keeps only the latest delegation when the superseded consult rejects on abort", async () => {
     const resolvers: Array<(value: { text: string }) => void> = [];
     const signals: AbortSignal[] = [];
     const runAgentConsult = vi.fn(
       async ({ signal }: { prompt: string; signal?: AbortSignal }) =>
-        await new Promise<{ text: string }>((resolve) => {
+        await new Promise<{ text: string }>((resolve, reject) => {
           signals.push(signal as AbortSignal);
           resolvers.push(resolve);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              reject(signal.reason instanceof Error ? signal.reason : new Error("aborted"));
+            },
+            { once: true },
+          );
         }),
     );
     const { realtime, sockets } = createBroker({ runAgentConsult });
@@ -396,7 +403,6 @@ describe("GPT-Live offer broker", () => {
 
       expect(runAgentConsult).toHaveBeenCalledOnce();
       expect(signals[0]?.aborted).toBe(true);
-      resolvers[0]?.({ text: "stale result" });
       await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(2));
       expect(runAgentConsult.mock.calls[1]?.[0].prompt).toContain("latest task");
       expect(runAgentConsult.mock.calls[1]?.[0].prompt).not.toContain("second task");
@@ -405,7 +411,7 @@ describe("GPT-Live offer broker", () => {
       await vi.waitFor(() =>
         expect(socket.sent.some((entry) => entry.includes("latest result"))).toBe(true),
       );
-      expect(socket.sent.some((entry) => entry.includes("stale result"))).toBe(false);
+      expect(socket.closed).toBe(false);
     } finally {
       await realtime.cleanup();
     }

--- a/extensions/openai/realtime-quicksilver-session.test.ts
+++ b/extensions/openai/realtime-quicksilver-session.test.ts
@@ -350,6 +350,67 @@ describe("GPT-Live offer broker", () => {
     }
   });
 
+  it("keeps only the latest delegation pending while a consult settles", async () => {
+    const resolvers: Array<(value: { text: string }) => void> = [];
+    const signals: AbortSignal[] = [];
+    const runAgentConsult = vi.fn(
+      async ({ signal }: { prompt: string; signal?: AbortSignal }) =>
+        await new Promise<{ text: string }>((resolve) => {
+          signals.push(signal as AbortSignal);
+          resolvers.push(resolve);
+        }),
+    );
+    const { realtime, sockets } = createBroker({ runAgentConsult });
+    try {
+      const reservation = await realtime.broker.createBrowserSession(
+        { providerConfig: {}, model: "gpt-live-1-codex", runAgentConsult },
+        { type: "api-key", token: "platform-key" },
+      );
+      if (reservation.transport !== "webrtc") {
+        throw new Error("Expected WebRTC reservation");
+      }
+      await realtime.handler(
+        createRequest({ token: reservation.clientSecret }),
+        createResponseHarness().res,
+      );
+      const socket = sockets[0];
+      if (!socket) {
+        throw new Error("Expected sideband socket");
+      }
+
+      for (const [id, text] of [
+        ["delegation-1", "first task"],
+        ["delegation-2", "second task"],
+        ["delegation-3", "latest task"],
+      ]) {
+        emitSideband(socket, {
+          type: "delegation.created",
+          item: {
+            type: "delegation",
+            target: "client",
+            id,
+            content: [{ type: "input_text", text }],
+          },
+        });
+      }
+
+      expect(runAgentConsult).toHaveBeenCalledOnce();
+      expect(signals[0]?.aborted).toBe(true);
+      resolvers[0]?.({ text: "stale result" });
+      await vi.waitFor(() => expect(runAgentConsult).toHaveBeenCalledTimes(2));
+      expect(runAgentConsult.mock.calls[1]?.[0].prompt).toContain("latest task");
+      expect(runAgentConsult.mock.calls[1]?.[0].prompt).not.toContain("second task");
+
+      resolvers[1]?.({ text: "latest result" });
+      await vi.waitFor(() =>
+        expect(socket.sent.some((entry) => entry.includes("latest result"))).toBe(true),
+      );
+      expect(socket.sent.some((entry) => entry.includes("stale result"))).toBe(false);
+    } finally {
+      await realtime.cleanup();
+    }
+  });
+
   it.each(["error", "close"] as const)(
     "fails safely when the sideband emits %s immediately after opening",
     async (terminalEvent) => {

--- a/extensions/openai/realtime-quicksilver-session.ts
+++ b/extensions/openai/realtime-quicksilver-session.ts
@@ -71,9 +71,15 @@ type PendingOffer = {
   request: PreparedOpenAIQuicksilverSessionRequest;
 };
 
+type PendingDelegation = {
+  id: string;
+  prompt: string;
+};
+
 type ActiveSession = {
   abortController: AbortController;
   consultController?: AbortController;
+  pendingDelegation?: PendingDelegation;
   socket: OpenAIQuicksilverSocket;
   timer: NodeJS.Timeout;
   token: string;
@@ -252,6 +258,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
     reservations.delete(session.token);
     releaseOpenAIQuicksilverSession(session.token);
     clearTimeout(session.timer);
+    session.pendingDelegation = undefined;
     session.consultController?.abort(new Error("GPT-Live delegation stopped"));
     session.abortController.abort(new Error("GPT-Live session closed"));
     return true;
@@ -312,6 +319,42 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
     });
   };
 
+  const startDelegation = (
+    session: ActiveSession,
+    delegation: PendingDelegation,
+    runAgentConsult: NonNullable<OpenAIQuicksilverSessionRequest["runAgentConsult"]>,
+  ) => {
+    if (activeSessions.get(session.token) !== session || session.abortController.signal.aborted) {
+      return;
+    }
+    if (session.consultController) {
+      session.pendingDelegation = delegation;
+      session.consultController.abort(new Error("GPT-Live delegation superseded"));
+      return;
+    }
+    const consultController = new AbortController();
+    session.consultController = consultController;
+    const signal = AbortSignal.any([session.abortController.signal, consultController.signal]);
+    void handleDelegation(session, delegation.id, delegation.prompt, signal, runAgentConsult)
+      .catch((error: unknown) => {
+        params.logger.warn(
+          `OpenAI GPT-Live delegation failed: ${shortConsultFailureReason(error)}`,
+        );
+        closeSession(session);
+      })
+      .finally(() => {
+        if (session.consultController !== consultController) {
+          return;
+        }
+        session.consultController = undefined;
+        const pending = session.pendingDelegation;
+        session.pendingDelegation = undefined;
+        if (pending && activeSessions.get(session.token) === session) {
+          startDelegation(session, pending, runAgentConsult);
+        }
+      });
+  };
+
   const scheduleSessionExpiry = (session: ActiveSession, ttlMs: number) => {
     clearTimeout(session.timer);
     session.timer = setTimeout(() => closeSession(session), Math.max(0, ttlMs));
@@ -368,23 +411,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       input: delegationInput,
       transcript,
     });
-    // A newer spoken task supersedes the prior consult so steering is immediate.
-    session.consultController?.abort(new Error("GPT-Live delegation superseded"));
-    const consultController = new AbortController();
-    session.consultController = consultController;
-    const signal = AbortSignal.any([session.abortController.signal, consultController.signal]);
-    void handleDelegation(session, event.id, prompt, signal, runAgentConsult)
-      .catch((error: unknown) => {
-        params.logger.warn(
-          `OpenAI GPT-Live delegation failed: ${shortConsultFailureReason(error)}`,
-        );
-        closeSession(session);
-      })
-      .finally(() => {
-        if (session.consultController === consultController) {
-          session.consultController = undefined;
-        }
-      });
+    startDelegation(session, { id: event.id, prompt }, runAgentConsult);
   };
 
   const handleSidebandFrame = (


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where rapid GPT-Live delegation events could start one agent consult per event even after newer speech superseded the earlier task. A long-running or abort-insensitive consult runner could therefore retain many overlapping promises and duplicate work for one voice session.

## Why This Change Was Made

Both GPT-Live entry paths now own at most one running consult and one replaceable latest pending delegation. Newer speech aborts the running consult, replaces any older pending work, and terminal close/finalization drops pending work and ignores late events.

The provider protocol, configuration, retry behavior, and spoken terminal outcomes are unchanged.

## User Impact

Realtime voice keeps steering toward the latest spoken task without multiplying agent work when several delegation events arrive before the prior consult settles.

## Evidence

- Deterministic regression before the fix: 1,000 delegation events launched 1,000 consult runners and left 999 aborted unresolved runs.
- Added browser-broker and gateway-bridge coverage proving one active + latest pending, stale-result suppression, late-event rejection after close, and handoff when the superseded runner rejects on abort.
- Blacksmith Testbox focused OpenAI suite: 72 passed, 1 intentional skip across the delegation, browser-broker, and gateway-bridge tests.
- targeted type-aware oxlint (clean)
- Blacksmith Testbox `pnpm check:changed` (clean)
- `autoreview --mode local` (no actionable findings, 0.88 confidence)
- Live GA realtime on Blacksmith Testbox: `gpt-realtime-2.1` backend WebSocket connected; browser WebRTC negotiated audio and reached `connected`.
- Live audio talkback on Blacksmith Testbox: OpenAI TTS synthesis, synthesized-audio transcription, and streaming realtime STT all passed (3/3).
- GPT-Live platform probe reached OpenAI but the current API key lacks `GPT-Live` entitlement; OAuth-only rows were correctly skipped because no OAuth profile is currently installed.

AI-assisted: yes. I understand and manually validated the state ownership and terminal-event behavior in both changed paths.

