### PR TITLE
fix(test): review Codex runtime scan chunks

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -23,31 +23,32 @@ type PublishablePluginPackage = {
 };
 
 const execFileAsync = promisify(execFile);
-const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDINGS = new Set([
-  "@openclaw/acpx:dangerous-exec:src/codex-auth-bridge.ts",
-  "@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs",
-  "@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/http.ts",
-  "@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/processes.ts",
-  "@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts",
-  "@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts",
-  "@openclaw/discord:dangerous-exec:src/voice/audio.ts",
-  "@openclaw/google-meet:dangerous-exec:src/node-host.ts",
-  "@openclaw/mxc-sandbox:dangerous-exec:src/readiness.ts",
-  "@openclaw/raft:dangerous-exec:src/gateway.ts",
-  "@openclaw/signal:dangerous-exec:src/daemon.ts",
-  "@openclaw/voice-call:dangerous-exec:src/tunnel.ts",
+const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+  ["@openclaw/acpx:dangerous-exec:src/codex-auth-bridge.ts", 1],
+  ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/http.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/processes.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts", 1],
+  ["@openclaw/discord:dangerous-exec:src/voice/audio.ts", 1],
+  ["@openclaw/google-meet:dangerous-exec:src/node-host.ts", 1],
+  ["@openclaw/mxc-sandbox:dangerous-exec:src/readiness.ts", 2],
+  ["@openclaw/raft:dangerous-exec:src/gateway.ts", 1],
+  ["@openclaw/signal:dangerous-exec:src/daemon.ts", 1],
+  ["@openclaw/voice-call:dangerous-exec:src/tunnel.ts", 1],
 ]);
 
-const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDINGS = new Set([
-  "@openclaw/acpx:dangerous-exec:dist/mcp-proxy.mjs",
-  "@openclaw/acpx:dangerous-exec:dist/service-<hash>.js",
-  "@openclaw/codex:dangerous-exec:dist/client-<hash>.js",
-  "@openclaw/codex:dangerous-exec:dist/run-attempt-<hash>.js",
-  "@openclaw/codex:dangerous-exec:dist/session-catalog-<hash>.js",
-  "@openclaw/codex:dangerous-exec:dist/transport-stdio-<hash>.js",
-  "@openclaw/google-meet:dangerous-exec:dist/index.js",
-  "@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js",
-  "@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js",
+// Generated chunks can contain multiple reviewed execution sites. Counts are
+// part of the contract so an added or missing site fails the release scan.
+const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+  ["@openclaw/acpx:dangerous-exec:dist/mcp-proxy.mjs", 1],
+  ["@openclaw/acpx:dangerous-exec:dist/service-<hash>.js", 1],
+  ["@openclaw/codex:dangerous-exec:dist/run-attempt-<hash>.js", 2],
+  ["@openclaw/codex:dangerous-exec:dist/session-catalog-<hash>.js", 1],
+  ["@openclaw/codex:dangerous-exec:dist/transport-stdio-<hash>.js", 1],
+  ["@openclaw/google-meet:dangerous-exec:dist/index.js", 1],
+  ["@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js", 1],
+  ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
 ]);
 
 function parseNpmPackFiles(raw: string, packageName: string): string[] {
@@ -91,7 +92,6 @@ function isScannerWalkedPackedPath(packedPath: string): boolean {
 
 function normalizePackedFindingPath(packedPath: string): string {
   for (const prefix of [
-    "client",
     "outbound-payload.test-harness",
     "run-attempt",
     "runtime-entry",
@@ -111,8 +111,12 @@ function expectedOptionalReviewedFindingsForPackedPath(
   packedPath: string,
 ): string[] {
   const normalizedPath = normalizePackedFindingPath(packedPath);
-  return [...OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDINGS].filter(
-    (key) => key.startsWith(`${packageName}:`) && key.endsWith(`:${normalizedPath}`),
+  const keyPrefix = `${packageName}:`;
+  const keySuffix = `:${normalizedPath}`;
+  return [...OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS].flatMap(([key, count]) =>
+    key.startsWith(keyPrefix) && key.endsWith(keySuffix)
+      ? Array.from({ length: count }, () => key)
+      : [],
   );
 }
 
@@ -251,8 +255,8 @@ async function scanPublishablePluginPackage(plugin: PublishablePluginPackage): P
     const packedPath = normalizePackedFindingPath(toRepoPath(relative(stageDir, finding.file)));
     const key = `${plugin.packageName}:${finding.ruleId}:${packedPath}`;
     if (
-      REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDINGS.has(key) ||
-      OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDINGS.has(key)
+      REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.has(key) ||
+      OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS.has(key)
     ) {
       reviewedCriticalFindings.push(key);
       continue;
@@ -292,7 +296,7 @@ describe("publishable plugin npm package install security scan", () => {
     );
     const missingPackages = [
       ...new Set(
-        [...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDINGS].map((key) =>
+        [...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.keys()].map((key) =>
           key.slice(0, key.indexOf(":")),
         ),
       ),
@@ -321,6 +325,26 @@ describe("publishable plugin npm package install security scan", () => {
     );
   });
 
+  it("requires exact occurrence counts for reviewed Codex dist chunks", () => {
+    const runAttemptKey = "@openclaw/codex:dangerous-exec:dist/run-attempt-<hash>.js";
+
+    expect(
+      expectedOptionalReviewedFindingsForPackedPath(
+        "@openclaw/codex",
+        "dist/run-attempt-current.js",
+      ),
+    ).toEqual([runAttemptKey, runAttemptKey]);
+    expect(
+      expectedOptionalReviewedFindingsForPackedPath(
+        "@openclaw/codex",
+        "dist/session-catalog-current.js",
+      ),
+    ).toEqual(["@openclaw/codex:dangerous-exec:dist/session-catalog-<hash>.js"]);
+    expect(
+      expectedOptionalReviewedFindingsForPackedPath("@openclaw/codex", "dist/client-retired.js"),
+    ).toEqual([]);
+  });
+
   test.concurrent.each(publishablePluginPackages)(
     "keeps $packageName files clear of unexpected critical hits",
     async (plugin) => {
@@ -328,18 +352,16 @@ describe("publishable plugin npm package install security scan", () => {
       if (!result) {
         throw new Error(`Missing package scan result for ${plugin.packageName}`);
       }
-      const expectedReviewedCriticalFindings = new Set(
-        [...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDINGS].filter((key) =>
-          key.startsWith(`${plugin.packageName}:`),
+      const expectedReviewedCriticalFindings = [
+        ...[...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS].flatMap(([key, count]) =>
+          key.startsWith(`${plugin.packageName}:`) ? Array.from({ length: count }, () => key) : [],
         ),
-      );
-      for (const key of result.expectedReviewedCriticalFindings) {
-        expectedReviewedCriticalFindings.add(key);
-      }
+        ...result.expectedReviewedCriticalFindings,
+      ];
 
       expect(result.unexpectedCriticalFindings.toSorted()).toStrictEqual([]);
       expect(result.reviewedCriticalFindings.toSorted()).toEqual(
-        [...expectedReviewedCriticalFindings].toSorted(),
+        expectedReviewedCriticalFindings.toSorted(),
       );
     },
   );

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -42,6 +42,9 @@ const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDINGS = new Set([
   "@openclaw/acpx:dangerous-exec:dist/mcp-proxy.mjs",
   "@openclaw/acpx:dangerous-exec:dist/service-<hash>.js",
   "@openclaw/codex:dangerous-exec:dist/client-<hash>.js",
+  "@openclaw/codex:dangerous-exec:dist/run-attempt-<hash>.js",
+  "@openclaw/codex:dangerous-exec:dist/session-catalog-<hash>.js",
+  "@openclaw/codex:dangerous-exec:dist/transport-stdio-<hash>.js",
   "@openclaw/google-meet:dangerous-exec:dist/index.js",
   "@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js",
   "@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js",
@@ -87,7 +90,15 @@ function isScannerWalkedPackedPath(packedPath: string): boolean {
 }
 
 function normalizePackedFindingPath(packedPath: string): string {
-  for (const prefix of ["client", "outbound-payload.test-harness", "runtime-entry", "service"]) {
+  for (const prefix of [
+    "client",
+    "outbound-payload.test-harness",
+    "run-attempt",
+    "runtime-entry",
+    "service",
+    "session-catalog",
+    "transport-stdio",
+  ]) {
     if (packedPath.startsWith(`dist/${prefix}-`) && packedPath.endsWith(".js")) {
       return `dist/${prefix}-<hash>.js`;
     }
@@ -299,6 +310,15 @@ describe("publishable plugin npm package install security scan", () => {
         packages.every((plugin) => toRepoPath(plugin.packageDir).startsWith("extensions/")),
       ).toBe(true);
     });
+  });
+
+  it("does not review unknown Codex dist chunk names", () => {
+    const packedPath = "dist/future-exec-unknown.js";
+
+    expect(normalizePackedFindingPath(packedPath)).toBe(packedPath);
+    expect(expectedOptionalReviewedFindingsForPackedPath("@openclaw/codex", packedPath)).toEqual(
+      [],
+    );
   });
 
   test.concurrent.each(publishablePluginPackages)(


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-lane failure where the publishable-plugin security scan rejected generated Codex runtime chunks even though their source execution sites are already explicitly reviewed.

## Why This Change Was Made

- Recognizes the exact `run-attempt`, `session-catalog`, and `transport-stdio` generated chunk prefixes while unknown chunk names remain failures.
- Counts reviewed findings instead of deduplicating them, so added or missing execution sites fail the release scan.
- Removes the retired `client-<hash>.js` allowance because current Codex output no longer emits that chunk.

The generated chunks map to the reviewed Codex app-server stdio transport, sandbox process/HTTP execution, and CLI session resume paths.

## User Impact

No runtime behavior change. Release validation can distinguish reviewed Codex package output from new or changed execution surfaces without hiding duplicate findings.

## Evidence

- Head: `d175c2b24cf8e99162917cde494f6cae124e85e1`
- Delegated Blacksmith Testbox: full build plus `src/plugins/npm-install-security-scan.release.test.ts`, 80/80 tests passed, exit 0, 4m28s command / 5m00s total: https://github.com/openclaw/openclaw/actions/runs/30515121656
- Autoreview clean, confidence 0.95.
- `git diff --check` and `oxfmt` clean.
- Direct OpenClaw and sibling Codex source mapping inspected; exact file/line evidence is in the current-head proof comment.
- Branch base is `2899323fe3e940a9c738a797b190a3616c136848`; current `main` is one unrelated `src/daemon/systemd*` commit ahead, so no proof-relevant rebase is needed.
