### PR TITLE
fix(telegram): report finalized preview sends to plugins

### DIFF
--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -27,7 +27,7 @@ import { listSkillCommandsForAgents } from "openclaw/plugin-sdk/skill-commands-r
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import { syncTelegramMenuCommands } from "./bot-native-command-menu.js";
-import { deliverReplies, emitInternalMessageSentHook } from "./bot/delivery.js";
+import { deliverReplies, emitTelegramMessageSentHooks } from "./bot/delivery.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
 import {
   resolveTelegramApproval,
@@ -64,7 +64,7 @@ export type TelegramBotDeps = {
   createTelegramDraftStream?: typeof createTelegramDraftStream;
   deliverReplies?: typeof deliverReplies;
   deliverInboundReplyWithMessageSendContext?: typeof deliverInboundReplyWithMessageSendContext;
-  emitInternalMessageSentHook?: typeof emitInternalMessageSentHook;
+  emitTelegramMessageSentHooks?: typeof emitTelegramMessageSentHooks;
   editMessageTelegram?: typeof editMessageTelegram;
   recordOutboundMessageForPromptContext?: typeof recordOutboundMessageForPromptContext;
   createChannelMessageReplyPipeline?: typeof createChannelMessageReplyPipeline;
@@ -149,8 +149,8 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
   get deliverInboundReplyWithMessageSendContext() {
     return deliverInboundReplyWithMessageSendContext;
   },
-  get emitInternalMessageSentHook() {
-    return emitInternalMessageSentHook;
+  get emitTelegramMessageSentHooks() {
+    return emitTelegramMessageSentHooks;
   },
   get editMessageTelegram() {
     return editMessageTelegram;

--- a/extensions/telegram/src/bot-message-dispatch-delivery.ts
+++ b/extensions/telegram/src/bot-message-dispatch-delivery.ts
@@ -31,7 +31,7 @@ import type {
   TelegramTranscriptMirrorPayload,
 } from "./bot-message-dispatch.types.js";
 import type { TelegramBotOptions } from "./bot.types.js";
-import { deliverReplies, emitInternalMessageSentHook } from "./bot/delivery.js";
+import { deliverReplies, emitTelegramMessageSentHooks } from "./bot/delivery.js";
 import type { TelegramThreadSpec } from "./bot/helpers.js";
 import { resolveTelegramReplyId } from "./bot/helpers.js";
 import type { TelegramNativeQuoteCandidateByMessageId } from "./bot/native-quote.js";
@@ -334,7 +334,9 @@ export function createTelegramDeliveryController(params: {
     if (params.isDispatchSuperseded() || result.kind !== "preview-finalized") {
       return;
     }
-    (params.telegramDeps.emitInternalMessageSentHook ?? emitInternalMessageSentHook)({
+    // A finalized preview is the durable Telegram message. Emit the composite
+    // terminal here so plugin and internal observers see that one provider result.
+    (params.telegramDeps.emitTelegramMessageSentHooks ?? emitTelegramMessageSentHooks)({
       sessionKeyForInternalHooks: sessionKey,
       chatId: String(context.chatId),
       accountId: context.route.accountId,

--- a/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
@@ -10,7 +10,7 @@ import {
   dispatchReplyWithBufferedBlockDispatcher,
   dispatchWithContext,
   editMessageTelegram,
-  emitInternalMessageSentHook,
+  emitTelegramMessageSentHooks,
   expectDraftStreamParams,
   expectRecordFields,
   loadSessionStore,
@@ -85,7 +85,7 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
     expect(answerDraftStream.stop).toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
     expect(editMessageTelegram).not.toHaveBeenCalled();
-    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+    expectRecordFields(mockCallArg(emitTelegramMessageSentHooks), {
       content: "Final answer",
       messageId: 2001,
     });
@@ -618,7 +618,7 @@ describeTelegramDispatch("dispatchTelegramMessage delivery-transcript", () => {
 
     expect(answerDraftStream.update).toHaveBeenCalledWith(fullAnswer);
     expect(answerDraftStream.update).not.toHaveBeenCalledWith(truncatedFinal);
-    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+    expectRecordFields(mockCallArg(emitTelegramMessageSentHooks), {
       content: fullAnswer,
       messageId: 2001,
     });

--- a/extensions/telegram/src/bot-message-dispatch.draft-finalization.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-finalization.test.ts
@@ -10,7 +10,7 @@ import {
   dispatchTelegramMessage,
   dispatchWithContext,
   editMessageTelegram,
-  emitInternalMessageSentHook,
+  emitTelegramMessageSentHooks,
   expectDeliverRepliesParams,
   expectRecordFields,
   mockCallArg,
@@ -132,10 +132,26 @@ describeTelegramDispatch("dispatchTelegramMessage draft-finalization", () => {
     expect(answerDraftStream.stop).toHaveBeenCalled();
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
-    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+    expect(emitTelegramMessageSentHooks).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(emitTelegramMessageSentHooks), {
       content: "block-only answer",
       messageId: 2001,
     });
+  });
+
+  it("does not emit a terminal when a finalized preview may have landed without an id", async () => {
+    const { answerDraftStream } = setupDraftStreams();
+    answerDraftStream.sendMayHaveLanded.mockReturnValue(true);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "uncertain final" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.stop).toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(emitTelegramMessageSentHooks).not.toHaveBeenCalled();
   });
 
   it("delivers a block-only answer when a native quote disables the draft stream", async () => {
@@ -217,7 +233,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-finalization", () => {
 
     expect(answerDraftStream.stop).toHaveBeenCalled();
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
-    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+    expectRecordFields(mockCallArg(emitTelegramMessageSentHooks), {
       content: "partial answer",
       messageId: 2001,
     });
@@ -291,7 +307,7 @@ describeTelegramDispatch("dispatchTelegramMessage draft-finalization", () => {
 
     expect(answerDraftStream.stop).toHaveBeenCalled();
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
-    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+    expectRecordFields(mockCallArg(emitTelegramMessageSentHooks), {
       content: "pending answer",
       messageId: 2001,
     });

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -15,7 +15,7 @@ import {
   dispatchReplyWithBufferedBlockDispatcher,
   dispatchWithContext,
   editMessageTelegram,
-  emitInternalMessageSentHook,
+  emitTelegramMessageSentHooks,
   expectDeliveredReply,
   expectDraftStreamParams,
   expectRecordFields,
@@ -525,7 +525,7 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
 
     expect(deliverReplies).toHaveBeenCalledTimes(2);
     expect(answerDraftStream.update).toHaveBeenCalledWith("Buffered answer");
-    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+    expectRecordFields(mockCallArg(emitTelegramMessageSentHooks), {
       content: "Buffered answer",
       messageId: 2001,
     });
@@ -560,7 +560,7 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
     expect(answerDraftStream.update).toHaveBeenCalledWith("Answer");
     expect(answerDraftStream.stop).toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
-    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+    expectRecordFields(mockCallArg(emitTelegramMessageSentHooks), {
       content: "Answer",
       messageId: 2001,
     });

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -10,6 +10,7 @@ import {
   dispatchReplyWithBufferedBlockDispatcher,
   dispatchWithContext,
   editMessageTelegram,
+  emitTelegramMessageSentHooks,
   expectDeliveredReply,
   expectDeliverRepliesParams,
   expectRecordFields,
@@ -187,6 +188,11 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
     expect(answerDraftStream.update).toHaveBeenCalledWith("Photo");
     expectDeliverRepliesParams({ mediaMaxBytes });
     expectDeliveredReply(0, { text: undefined, mediaUrl: "https://example.com/a.png" });
+    expect(emitTelegramMessageSentHooks).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(emitTelegramMessageSentHooks), {
+      content: "Photo",
+      messageId: 2001,
+    });
   });
 
   it("sends standalone MEDIA directive final replies as media", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test-harness.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-harness.ts
@@ -38,7 +38,7 @@ const dispatchReplyWithBufferedBlockDispatcherHoisted = vi.hoisted(() =>
 );
 const deliverRepliesHoisted = vi.hoisted(() => vi.fn());
 const deliverInboundReplyWithMessageSendContextHoisted = vi.hoisted(() => vi.fn());
-const emitInternalMessageSentHookHoisted = vi.hoisted(() => vi.fn());
+const emitTelegramMessageSentHooksHoisted = vi.hoisted(() => vi.fn());
 const recordOutboundMessageForPromptContextHoisted = vi.hoisted(() => vi.fn());
 const createForumTopicTelegramHoisted = vi.hoisted(() => vi.fn());
 const deleteMessageTelegramHoisted = vi.hoisted(() => vi.fn());
@@ -121,7 +121,7 @@ export const dispatchReplyWithBufferedBlockDispatcher =
 export const deliverReplies = deliverRepliesHoisted;
 export const deliverInboundReplyWithMessageSendContext =
   deliverInboundReplyWithMessageSendContextHoisted;
-export const emitInternalMessageSentHook = emitInternalMessageSentHookHoisted;
+export const emitTelegramMessageSentHooks = emitTelegramMessageSentHooksHoisted;
 export const recordOutboundMessageForPromptContext = recordOutboundMessageForPromptContextHoisted;
 const createForumTopicTelegram = createForumTopicTelegramHoisted;
 const deleteMessageTelegram = deleteMessageTelegramHoisted;
@@ -252,12 +252,12 @@ vi.mock("openclaw/plugin-sdk/session-transcript-runtime", async (importOriginal)
 
 vi.mock("./bot/delivery.js", () => ({
   deliverReplies: deliverRepliesHoisted,
-  emitInternalMessageSentHook: emitInternalMessageSentHookHoisted,
+  emitTelegramMessageSentHooks: emitTelegramMessageSentHooksHoisted,
 }));
 
 vi.mock("./bot/delivery.replies.js", () => ({
   deliverReplies: deliverRepliesHoisted,
-  emitInternalMessageSentHook: emitInternalMessageSentHookHoisted,
+  emitTelegramMessageSentHooks: emitTelegramMessageSentHooksHoisted,
 }));
 
 vi.mock("./send.js", () => ({
@@ -341,8 +341,8 @@ export const telegramDepsForTest: TelegramBotDeps = {
   deliverReplies: deliverReplies as TelegramBotDeps["deliverReplies"],
   deliverInboundReplyWithMessageSendContext:
     deliverInboundReplyWithMessageSendContext as TelegramBotDeps["deliverInboundReplyWithMessageSendContext"],
-  emitInternalMessageSentHook:
-    emitInternalMessageSentHook as TelegramBotDeps["emitInternalMessageSentHook"],
+  emitTelegramMessageSentHooks:
+    emitTelegramMessageSentHooks as TelegramBotDeps["emitTelegramMessageSentHooks"],
   editMessageTelegram: editMessageTelegram as TelegramBotDeps["editMessageTelegram"],
   recordOutboundMessageForPromptContext:
     recordOutboundMessageForPromptContext as TelegramBotDeps["recordOutboundMessageForPromptContext"],
@@ -363,7 +363,7 @@ function resetTelegramDispatchTestState() {
   dispatchReplyWithBufferedBlockDispatcher.mockReset();
   deliverReplies.mockReset();
   deliverInboundReplyWithMessageSendContext.mockReset();
-  emitInternalMessageSentHook.mockReset();
+  emitTelegramMessageSentHooks.mockReset();
   recordOutboundMessageForPromptContext.mockReset();
   createForumTopicTelegram.mockReset();
   deleteMessageTelegram.mockReset();
@@ -407,7 +407,7 @@ function resetTelegramDispatchTestState() {
     status: "unsupported",
     reason: "missing_outbound_handler",
   });
-  emitInternalMessageSentHook.mockResolvedValue(undefined);
+  emitTelegramMessageSentHooks.mockResolvedValue(undefined);
   recordOutboundMessageForPromptContext.mockResolvedValue(true);
   createForumTopicTelegram.mockResolvedValue({ message_thread_id: 777 });
   deleteMessageTelegram.mockResolvedValue(true);

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -709,7 +709,7 @@ function buildTelegramSentHookContext(params: EmitMessageSentHookParams) {
   });
 }
 
-export function emitInternalMessageSentHook(params: EmitMessageSentHookParams): void {
+function emitInternalMessageSentHook(params: EmitMessageSentHookParams): void {
   if (!params.sessionKeyForInternalHooks) {
     return;
   }

--- a/extensions/telegram/src/bot/delivery.ts
+++ b/extensions/telegram/src/bot/delivery.ts
@@ -1,6 +1,2 @@
 // Telegram plugin module implements delivery behavior.
-export {
-  deliverReplies,
-  emitInternalMessageSentHook,
-  emitTelegramMessageSentHooks,
-} from "./delivery.replies.js";
+export { deliverReplies, emitTelegramMessageSentHooks } from "./delivery.replies.js";

--- a/extensions/telegram/src/delivery-trace.test.ts
+++ b/extensions/telegram/src/delivery-trace.test.ts
@@ -191,7 +191,7 @@ function createTraceTelegramDeps(captured: CapturedDispatch): TelegramBotDeps {
       status: "unsupported",
       reason: "missing_outbound_handler",
     })) as unknown as TelegramBotDeps["deliverInboundReplyWithMessageSendContext"],
-    emitInternalMessageSentHook: (() => {}) as TelegramBotDeps["emitInternalMessageSentHook"],
+    emitTelegramMessageSentHooks: (() => {}) as TelegramBotDeps["emitTelegramMessageSentHooks"],
     recordOutboundMessageForPromptContext: (async () =>
       true) as TelegramBotDeps["recordOutboundMessageForPromptContext"],
   };


### PR DESCRIPTION
Closes #116171

Related: #101026

## What Problem This Solves

Fixes an issue where users running observer plugins would miss Telegram `message_sent`
events when a provider preview was finalized into the visible reply. The message was
successfully visible in Telegram, but audit, analytics, and post-send plugins could not
observe it.

## Why This Change Was Made

Telegram's preview finalizer now uses the plugin's existing composite terminal emitter,
which reports the provider-finalized content and Telegram message ID to both plugin and
internal observers. The change stays inside Telegram; it does not alter core lifecycle,
Plugin SDK, configuration, protocol, storage, or retry behavior.

## User Impact

Plugins observing `message_sent` now receive one successful event for Telegram replies
that settle through preview finalization, consistent with ordinary, native-command, and
durable Telegram sends. Preview cancellation and ambiguous no-ID finalization still do
not emit a false success event.

## Evidence

- Before: real Telegram bot/human Desktop/Gateway reproduction on frozen `main`
  `1065c1d6978479a671f557b38927c53f4b4cd7c2` showed visible persisted provider message
  `530` with no plugin `message_sent`; four adjacent controls each emitted exactly once.
- Candidate live proof: real bot/human Telegram Desktop/Gateway run at
  `97e5cc249929da6deda379bfdf37dcab3f31b8d4` emitted exactly once for the finalized
  preview (`538`), adjacent follow-up (`539`), ordinary stream (`541`), native command
  (`543`), and durable send (`544`). Persisted provider records and the Desktop screenshot
  agree with the hook trace. Crabbox run `run_b6959b6aaa6b`.
  The run's raw metadata contains a transcribed nonexistent SHA ending in `...cf52`;
  the reviewed provenance record binds the synced source to this head by its exact
  lifecycle fingerprint.
- Focused regression proof: 6 Telegram files, 154 assertions passed, including block-only
  finalization, mixed text/media finalization, and an ambiguous no-ID preview result.
- Full Telegram project: 177 files, 2,959 assertions passed.
- Changed-surface checks: format, guards, dead code, extension and extension-test type
  checks, lint, and import-cycle checks passed.
- Fresh autoreview: no accepted or actionable findings.
- Remote focused/check/full run: Blacksmith Testbox `tbx_01kyraz281hx2brjmtwxtjt27k`,
  Actions run `30506378517`.

## AI Assistance

Implemented and validated with Codex assistance. The maintainer directed the scope,
accepted the Telegram-owned fix direction, and reviewed the live-validation plan.
