### PR TITLE
fix(ai): prevent websocket cache clobber on concurrent acquire

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -391,7 +391,6 @@ describe("ChatGPT Responses cached transport", () => {
     const handshakes: Array<{ connectionId: number }> = [];
     const receivedConnectionIds: number[] = [];
     const requestBodies: Array<{ connectionId: number; body: Record<string, unknown> }> = [];
-    let seedServerSocket: WebSocket | undefined;
     let holdLoserHandshake: ((res: boolean) => void) | undefined;
     let verifyCount = 0;
     let holdNextReconnect = false;
@@ -420,12 +419,9 @@ describe("ChatGPT Responses cached transport", () => {
     server.on("connection", (socket) => {
       const connectionId = handshakes.length + 1;
       handshakes.push({ connectionId });
-      if (connectionId === 1) {
-        seedServerSocket = socket;
-      }
-      socket.on("message", (raw) => {
+      socket.on("message", (raw: Buffer) => {
         receivedConnectionIds.push(connectionId);
-        const body = JSON.parse(raw.toString()) as Record<string, unknown>;
+        const body = JSON.parse(raw.toString("utf8")) as Record<string, unknown>;
         requestBodies.push({ connectionId, body });
         socket.send(JSON.stringify(completion(`resp_${connectionId}`)));
       });

--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -385,6 +385,114 @@ describe("ChatGPT Responses cached transport", () => {
     ).toEqual([]);
   });
 
+  it("closes the concurrent acquire loser promptly without leaking its socket", async () => {
+    const apiKey = createJwt();
+    const sessionId = "concurrent-acquire-loser";
+    const handshakes: Array<{ connectionId: number }> = [];
+    const receivedConnectionIds: number[] = [];
+    const requestBodies: Array<{ connectionId: number; body: Record<string, unknown> }> = [];
+    let seedServerSocket: WebSocket | undefined;
+    let holdLoserHandshake:
+      | ((accept: (info: unknown, cb?: () => void) => void) => void)
+      | undefined;
+    let verifyCount = 0;
+    let holdNextReconnect = false;
+
+    class TrackingWebSocket extends WebSocket {
+      override close(code?: number, reason?: string | Buffer): void {
+        super.close(code, reason);
+      }
+    }
+
+    vi.stubGlobal("WebSocket", TrackingWebSocket);
+    const server = new WebSocketServer({
+      host: "127.0.0.1",
+      port: 0,
+      verifyClient: (_info, cb) => {
+        verifyCount += 1;
+        // verifyCount 1 = seed; after seed is closed, holdNextReconnect is set
+        // so the first reconnect (loser A) blocks while winner B proceeds.
+        if (holdNextReconnect && !holdLoserHandshake) {
+          holdLoserHandshake = cb;
+          return;
+        }
+        cb(true);
+      },
+    });
+    server.on("connection", (socket) => {
+      const connectionId = handshakes.length + 1;
+      handshakes.push({ connectionId });
+      if (connectionId === 1) {
+        seedServerSocket = socket;
+      }
+      socket.on("message", (raw) => {
+        receivedConnectionIds.push(connectionId);
+        const body = JSON.parse(raw.toString()) as Record<string, unknown>;
+        requestBodies.push({ connectionId, body });
+        socket.send(JSON.stringify(completion(`resp_${connectionId}`)));
+      });
+    });
+
+    await once(server, "listening");
+    const port = (server.address() as AddressInfo).port;
+    const loopbackModel = {
+      ...model,
+      baseUrl: `http://127.0.0.1:${port}/backend-api`,
+    } satisfies Model<"openai-chatgpt-responses">;
+    const options = { apiKey, sessionId, transport: "websocket-cached" as const };
+
+    try {
+      // Seed connection 1 into cache.
+      expect(
+        (await streamOpenAICodexResponses(loopbackModel, context, options).result()).stopReason,
+      ).toBe("stop");
+
+      // Force the cached entry to be removed so both reconnects start fresh.
+      // This mirrors the existing authenticated-loopback tests.
+      closeOpenAICodexWebSocketSessions(sessionId);
+      holdNextReconnect = true;
+
+      // Start loser A; its verifyClient is held so winner B can install the cache entry first.
+      const loserResult = streamOpenAICodexResponses(loopbackModel, context, options).result();
+      await vi.waitFor(() => expect(holdLoserHandshake).toBeTypeOf("function"));
+
+      // Start winner B; it proceeds immediately and installs the cache entry.
+      const winnerResult = streamOpenAICodexResponses(loopbackModel, context, options).result();
+      expect((await winnerResult).stopReason).toBe("stop");
+
+      // Release loser A's handshake; it loses the CAS and should close promptly.
+      holdLoserHandshake?.(true);
+      expect((await loserResult).stopReason).toBe("stop");
+
+      // Follow-up must reuse winner B's connection, not open a fourth.
+      expect(
+        (
+          await streamOpenAICodexResponses(
+            loopbackModel,
+            {
+              messages: [...context.messages, { role: "user", content: "follow-up", timestamp: 2 }],
+            },
+            options,
+          ).result()
+        ).stopReason,
+      ).toBe("stop");
+
+      // Server saw seed=1, winner B=2, loser A=3, follow-up on connection 2.
+      expect(receivedConnectionIds).toEqual([1, 2, 3, 2]);
+      expect(handshakes).toHaveLength(3);
+      expect(requestBodies[3]?.body.previous_response_id).toBe("resp_2");
+    } finally {
+      holdLoserHandshake?.(true);
+      closeOpenAICodexWebSocketSessions(sessionId);
+      for (const socket of server.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("lazily builds authenticated SSE requests after session-scoped websocket fallback", async () => {
     let websocketAttempts = 0;
 

--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -390,10 +390,17 @@ describe("ChatGPT Responses cached transport", () => {
     const sessionId = "concurrent-acquire-loser";
     const handshakes: Array<{ connectionId: number }> = [];
     const receivedConnectionIds: number[] = [];
+    const closedConnectionIds: number[] = [];
     const requestBodies: Array<{ connectionId: number; body: Record<string, unknown> }> = [];
     let holdLoserHandshake: ((res: boolean) => void) | undefined;
     let verifyCount = 0;
     let holdNextReconnect = false;
+    const releaseLoserHandshake = () => {
+      const heldHandshake = holdLoserHandshake;
+      holdLoserHandshake = undefined;
+      holdNextReconnect = false;
+      heldHandshake?.(true);
+    };
 
     class TrackingWebSocket extends WebSocket {
       override close(code?: number, reason?: string | Buffer): void {
@@ -419,6 +426,9 @@ describe("ChatGPT Responses cached transport", () => {
     server.on("connection", (socket) => {
       const connectionId = handshakes.length + 1;
       handshakes.push({ connectionId });
+      socket.on("close", () => {
+        closedConnectionIds.push(connectionId);
+      });
       socket.on("message", (raw: Buffer) => {
         receivedConnectionIds.push(connectionId);
         const body = JSON.parse(raw.toString("utf8")) as Record<string, unknown>;
@@ -455,8 +465,10 @@ describe("ChatGPT Responses cached transport", () => {
       expect((await winnerResult).stopReason).toBe("stop");
 
       // Release loser A's handshake; it loses the CAS and should close promptly.
-      holdLoserHandshake?.(true);
+      releaseLoserHandshake();
       expect((await loserResult).stopReason).toBe("stop");
+      await vi.waitFor(() => expect(closedConnectionIds).toContain(3));
+      expect(closedConnectionIds).not.toContain(2);
 
       // Follow-up must reuse winner B's connection, not open a fourth.
       expect(
@@ -476,7 +488,7 @@ describe("ChatGPT Responses cached transport", () => {
       expect(handshakes).toHaveLength(3);
       expect(requestBodies[3]?.body.previous_response_id).toBe("resp_2");
     } finally {
-      holdLoserHandshake?.(true);
+      releaseLoserHandshake();
       closeOpenAICodexWebSocketSessions(sessionId);
       for (const socket of server.clients) {
         socket.terminate();

--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -392,9 +392,7 @@ describe("ChatGPT Responses cached transport", () => {
     const receivedConnectionIds: number[] = [];
     const requestBodies: Array<{ connectionId: number; body: Record<string, unknown> }> = [];
     let seedServerSocket: WebSocket | undefined;
-    let holdLoserHandshake:
-      | ((accept: (info: unknown, cb?: () => void) => void) => void)
-      | undefined;
+    let holdLoserHandshake: ((res: boolean) => void) | undefined;
     let verifyCount = 0;
     let holdNextReconnect = false;
 

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -1025,6 +1025,22 @@ function deleteOwnedWebSocketSession(sessionId: string, entry: CachedWebSocketCo
   }
 }
 
+// An acquire that awaited connectWebSocket() must not clobber a newer lease a
+// concurrent request installed during the await. Install the fresh entry only
+// when the cache still matches what this acquire left behind before the await:
+// the stale entry it observed (and did not remove), or undefined once it removed
+// its own stale entry (or for a first connect with no prior entry). A different
+// cached entry means a concurrent request already won this session.
+function setOwnedWebSocketSession(
+  sessionId: string,
+  entry: CachedWebSocketConnection,
+  expected: CachedWebSocketConnection | undefined,
+): void {
+  if (websocketSessionCache.get(sessionId) === expected) {
+    websocketSessionCache.set(sessionId, entry);
+  }
+}
+
 function scheduleSessionWebSocketExpiry(sessionId: string, entry: CachedWebSocketConnection): void {
   if (entry.idleTimer) {
     clearTimeout(entry.idleTimer);
@@ -1142,6 +1158,12 @@ async function acquireWebSocket(
   }
 
   const cached = websocketSessionCache.get(sessionId);
+  // Track what the cache is expected to hold after this acquire's own cleanup,
+  // so the post-await install only proceeds when no concurrent request installed
+  // a newer entry. Starts as the observed entry; reset to undefined once this
+  // acquire removes its own stale entry, since owner-checked delete leaves the
+  // cache empty (and a concurrent winner would fill it with a different entry).
+  let expectedCacheValue: CachedWebSocketConnection | undefined = cached;
   if (cached) {
     if (cached.idleTimer) {
       clearTimeout(cached.idleTimer);
@@ -1149,7 +1171,8 @@ async function acquireWebSocket(
     }
     if (!cached.busy && isWebSocketSessionExpired(cached)) {
       closeWebSocketSilently(cached.socket, 1000, "connection_age_limit");
-      websocketSessionCache.delete(sessionId);
+      deleteOwnedWebSocketSession(sessionId, cached);
+      expectedCacheValue = undefined;
     } else if (!cached.busy && isWebSocketReusable(cached.socket)) {
       cached.busy = true;
       return {
@@ -1177,13 +1200,18 @@ async function acquireWebSocket(
     }
     if (!isWebSocketReusable(cached.socket)) {
       closeWebSocketSilently(cached.socket);
-      websocketSessionCache.delete(sessionId);
+      deleteOwnedWebSocketSession(sessionId, cached);
+      expectedCacheValue = undefined;
     }
   }
 
   const socket = await connectWebSocket(url, headers, signal);
   const entry: CachedWebSocketConnection = { socket, busy: true, createdAt: Date.now() };
-  websocketSessionCache.set(sessionId, entry);
+  // Install only if the cache still matches what this acquire left behind (the
+  // stale entry it removed, or empty for a first connect). A different cached
+  // entry means a concurrent request already won this session during the await;
+  // let it keep the lease and leave this socket transient.
+  setOwnedWebSocketSession(sessionId, entry, expectedCacheValue);
   return {
     socket,
     entry,

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -1035,10 +1035,12 @@ function setOwnedWebSocketSession(
   sessionId: string,
   entry: CachedWebSocketConnection,
   expected: CachedWebSocketConnection | undefined,
-): void {
+): boolean {
   if (websocketSessionCache.get(sessionId) === expected) {
     websocketSessionCache.set(sessionId, entry);
+    return true;
   }
+  return false;
 }
 
 function scheduleSessionWebSocketExpiry(sessionId: string, entry: CachedWebSocketConnection): void {
@@ -1211,12 +1213,12 @@ async function acquireWebSocket(
   // stale entry it removed, or empty for a first connect). A different cached
   // entry means a concurrent request already won this session during the await;
   // let it keep the lease and leave this socket transient.
-  setOwnedWebSocketSession(sessionId, entry, expectedCacheValue);
+  const ownsCache = setOwnedWebSocketSession(sessionId, entry, expectedCacheValue);
   return {
     socket,
-    entry,
+    entry: ownsCache ? entry : undefined,
     release: ({ keep } = {}) => {
-      if (!keep || !isWebSocketReusable(entry.socket)) {
+      if (!ownsCache || !keep || !isWebSocketReusable(entry.socket)) {
         closeWebSocketSilently(entry.socket);
         if (entry.idleTimer) {
           clearTimeout(entry.idleTimer);


### PR DESCRIPTION
## What Problem This Solves

A concurrent Codex WebSocket request could clobber the shared session cache while another acquire was suspended in `connectWebSocket()`. That orphaned the socket carrying the canonical `previous_response_id` continuation and could corrupt later turns. The release path already used owner-checked deletion; the acquire path still had unconditional cache mutation around an await.

Closes #116215.

## Why This Change Was Made

- Delete an expired or non-reusable entry only when it is still the exact cache owner the acquire observed.
- Install a reconnected entry only when the cache still matches the acquire's expected value.
- Keep a compare-and-set loser transient so it cannot publish continuation state, then close it promptly on release.
- Preserve the existing busy-owner behavior: an overlapping request returns a transient socket before cache installation is reachable.

This extends the cache's existing ownership invariant at the boundary that owns the continuation state. It avoids broader locking, fallback state, or compatibility machinery.

## User Impact

Concurrent Codex/ChatGPT Responses requests near socket replacement no longer overwrite the continuation-bearing winner. The losing connection also closes immediately instead of remaining unreachable until idle expiry.

Affected shipped releases include `v2026.7.1` and `v2026.7.2-beta.1` through `v2026.7.2-beta.5`.

## Evidence

Exact head: `6494dca528ccbc78f31b6c5bfe160aafd68e99d4`

### Deterministic real WebSocket race proof

`packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts` exercises the race through `streamOpenAICodexResponses` and a real loopback `WebSocketServer`:

1. Seed connection 1 into the session cache.
2. Atomically hold the first reconnect's `verifyClient` callback.
3. Let connection 2 win and install its continuation-bearing cache entry.
4. Take and clear the held callback before invoking it, allowing connection 3 to lose the compare-and-set.
5. Observe server connection 3 close, assert winner connection 2 remains open, then reuse connection 2 with `previous_response_id: "resp_2"`.
6. Run idempotent cleanup that cannot invoke the held upgrade callback twice.

Assertions cover connection order `[1, 2, 3, 2]`, three handshakes total, explicit loser close, winner survival, and continuation reuse.

### Validation

- Exact-head GitHub CI: https://github.com/openclaw/openclaw/actions/runs/30595487602
- Fresh ClawSweeper review at this head: no findings; proof sufficient.
- Direct Codex contract inspection at `4642370542739d5dd080b0c87a9de06a6435d3db` confirmed that `ModelClientSession` / `WebsocketSession` own the Responses WebSocket and `previous_response_id` continuation.
- Frozen current-main target `39156a99cd1a8ff02ec914a9fa909d1a4ad70262` has no intervening `packages/ai` change; the synthetic merge is clean.

### Reviewed false positive

Autoreview suggested a later acquire could replace an already-busy canonical owner. The branch is unreachable: a reusable cached owner is marked busy and returned; any overlap seeing `cached.busy` returns a transient socket before `setOwnedWebSocketSession` can be reached. No runtime change was made for that finding.

## Surface Changed

- `packages/ai/src/providers/openai-chatgpt-responses.ts`: owner-checked acquire deletion/installation and prompt loser close.
- `packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts`: deterministic concurrent acquire regression with explicit socket lifecycle proof.
