### PR TITLE
fix: use account home in doctor release proof

### DIFF
--- a/scripts/e2e/lib/doctor-install-switch/scenario.sh
+++ b/scripts/e2e/lib/doctor-install-switch/scenario.sh
@@ -136,9 +136,16 @@ run_flow() {
   local install_log="/tmp/openclaw-doctor-switch-${name}-install.log"
   local doctor_log="/tmp/openclaw-doctor-switch-${name}-doctor.log"
   local command_timeout="${OPENCLAW_DOCKER_DOCTOR_SWITCH_COMMAND_TIMEOUT:-900s}"
+  local account_home=""
 
   echo "== Flow: $name =="
   openclaw_test_state_create "switch-${name}" empty
+  account_home="$(getent passwd "$(id -u)" | cut -d: -f6)"
+  if [ -z "$account_home" ]; then
+    echo "Could not resolve the current account home" >&2
+    exit 1
+  fi
+  export HOME="$account_home"
   unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH
   export USER="testuser"
 

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -4370,7 +4370,16 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
 
     expectTextToIncludeAll(scenario, [
       'command_timeout="${OPENCLAW_DOCKER_DOCTOR_SWITCH_COMMAND_TIMEOUT:-900s}"',
-      'openclaw_test_state_create "switch-${name}" empty\n  unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH',
+      [
+        'openclaw_test_state_create "switch-${name}" empty',
+        '  account_home="$(getent passwd "$(id -u)" | cut -d: -f6)"',
+        '  if [ -z "$account_home" ]; then',
+        '    echo "Could not resolve the current account home" >&2',
+        "    exit 1",
+        "  fi",
+        '  export HOME="$account_home"',
+        "  unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH",
+      ].join("\n"),
       'openclaw_e2e_maybe_timeout "$command_timeout" bash -c "$install_cmd"',
       'openclaw_e2e_maybe_timeout "$command_timeout" bash -c "$doctor_cmd"',
       'openclaw_e2e_maybe_timeout "$command_timeout" "$npm_bin" gateway install --wrapper "$wrapper" --force',
@@ -4380,6 +4389,8 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
     expect(
       scenario.match(/unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH/gu),
     ).toHaveLength(1);
+    expect(scenario.match(/getent passwd "\$\(id -u\)"/gu)).toHaveLength(1);
+    expect(scenario.match(/export HOME="\$account_home"/gu)).toHaveLength(1);
 
     expect(scenario).not.toMatch(/^\s*if ! timeout "\$command_timeout"/mu);
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes the remaining doctor install-switch release-harness failure after #116190. The product compares daemon-install identity against the OS passwd home, so retaining a temporary `HOME` still correctly looked non-default even after OpenClaw path overrides were cleared.

## Why This Change Was Made

Each Docker install-switch flow now resolves the current account home through `getent passwd "$(id -u)"`, fails closed if it is empty, exports that canonical `HOME`, and then clears `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`. The disposable Docker container remains the isolation boundary, while daemon and doctor operations now exercise the actual default account layout required by the product safety contract.

## User Impact

The beta release lane can reach daemon installation and doctor repair without weakening the production non-default-path guard. There is no product runtime change.

## Evidence

- `bash -n scripts/e2e/lib/doctor-install-switch/scenario.sh`
- focused `test/scripts/docker-build-helper.test.ts`: 175 passed
- Oxfmt and `git diff --check`
- Codex autoreview: clean, no accepted or actionable findings
