### PR TITLE
fix(model-catalog): stop caching null remote overlay results

### DIFF
--- a/src/model-catalog/remote-overlay.test.ts
+++ b/src/model-catalog/remote-overlay.test.ts
@@ -73,4 +73,33 @@ describe("remote model catalog overlay", () => {
     ).toBeUndefined();
     expect(mocks.read).toHaveBeenCalledTimes(2);
   });
+
+  it("re-reads the store after a negative result once a background refresh writes a bundle", () => {
+    // A cold start reads an empty store: the overlay must not cache that null,
+    // or a later background refresh can never apply without a manual restart.
+    mocks.read.mockReturnValueOnce(undefined);
+    expect(getRemoteModelCatalogOverlay({})).toBeUndefined();
+    // The background refresh writes a valid bundle into the store.
+    expect(getRemoteModelCatalogOverlay({})).toHaveProperty("anthropic");
+    // The negative result was not pinned: read was retried and the new bundle loaded.
+    expect(mocks.read).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-reads the store after a stale-bundle result once a newer bundle is written", () => {
+    // A bundle older than the bundled stamp is rejected once, then a newer bundle
+    // written by refresh must load without a process restart.
+    const newerBundle = { ...bundle, generatedAt: 300 };
+    mocks.read
+      .mockReturnValueOnce({
+        bundle_json: JSON.stringify({ ...bundle, generatedAt: 50 }),
+        source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
+      })
+      .mockReturnValueOnce({
+        bundle_json: JSON.stringify(newerBundle),
+        source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
+      });
+    expect(getRemoteModelCatalogOverlay({})).toBeUndefined();
+    expect(getRemoteModelCatalogOverlay({})).toHaveProperty("anthropic");
+    expect(mocks.read).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/model-catalog/remote-overlay.ts
+++ b/src/model-catalog/remote-overlay.ts
@@ -17,7 +17,7 @@ type ActiveRemoteModelCatalog = {
   pricing?: Readonly<Record<string, RemoteModelCatalogPricing>>;
 };
 
-let cachedOverlay: { sourceUrl: string; value: ActiveRemoteModelCatalog | null } | undefined;
+let cachedOverlay: { sourceUrl: string; value: ActiveRemoteModelCatalog } | undefined;
 let readBundledGeneratedAt = bundledCatalogGeneratedAt;
 let readStoredCatalog = readRemoteModelCatalog;
 
@@ -35,22 +35,24 @@ function getActiveRemoteModelCatalog(config: OpenClawConfig): ActiveRemoteModelC
   }
   try {
     const sourceUrl = resolveRemoteCatalogUrl(config);
+    // A successfully loaded overlay is cached for the process lifetime (the
+    // bundled/generated stamps and source URL are process-stable). Negative
+    // results are NOT cached: a cold start, a deleted store, or a stale bundle
+    // can all be resolved by a background refresh writing a newer bundle, and
+    // caching null would pin the overlay to "absent" until a manual restart.
     if (cachedOverlay?.sourceUrl === sourceUrl) {
-      return cachedOverlay.value ?? undefined;
+      return cachedOverlay.value;
     }
     const bundledGeneratedAt = readBundledGeneratedAt();
     if (bundledGeneratedAt === undefined) {
-      cachedOverlay = { sourceUrl, value: null };
       return undefined;
     }
     const stored = readStoredCatalog();
     if (!stored || stored.source_url !== sourceUrl) {
-      cachedOverlay = { sourceUrl, value: null };
       return undefined;
     }
     const bundle = validateAndSanitizeRemoteModelCatalogBundle(JSON.parse(stored.bundle_json));
     if (bundle.generatedAt <= bundledGeneratedAt || !isCompatible(bundle)) {
-      cachedOverlay = { sourceUrl, value: null };
       return undefined;
     }
     const value = {


### PR DESCRIPTION
## What Problem This Solves

A remote model catalog overlay that was absent on first read (cold install, deleted store, stale/incompatible bundle) was cached as `null` for the entire gateway process lifetime. A background `refreshRemoteModelCatalog` that later wrote a newer bundle could never apply — the cache hit branch returned the pinned `null` without re-reading the store, so the overlay stayed absent until a manual gateway restart. Operators saw "remote model catalog updated" in the logs but the catalog kept showing bundled/manifest data.

## Why This Change Was Made

Stop caching negative results. Only a successfully loaded overlay is cached (the bundled/generated stamps and source URL are process-stable). Every negative result re-reads the store, so a background refresh takes effect on the next read without a restart.

This matches the doctrine that cached facts should not be pinned past the boundary that owns their freshness: the store is the source of truth, and a null cache entry defeats the refresh path that is supposed to populate it.

## User Impact

Long-running gateways that cold-started before the remote catalog was populated now pick up remote catalog updates (model availability, pricing, compatibility, retirements) via the existing background refresh, without a manual restart. Previously the overlay was permanently absent for that process. No behavior change when the overlay loads successfully on first read.

## Evidence

### Real behavior probe — patched overlay picks up a refresh write without restart

Drove the patched `getRemoteModelCatalogOverlay` against a real isolated SQLite state store (`OPENCLAW_STATE_DIR` temp dir). The store read/write is the real `remote-store.ts` SQLite path; only the bundled generated-at stamp is injected (a source checkout has no packaged stamp):

```
=== catalog overlay null-cache probe (real SQLite store) ===
state dir: /tmp/oc-catalog-proof-iEbeoP

--- read 1: empty store (cold start) ---
overlay: undefined (absent)
    (pre-fix: this null was cached for the process lifetime)

--- background refresh writes a newer bundle into the store ---
writeRemoteModelCatalog: written

--- read 2: same process, no restart ---
overlay: PRESENT
providers: [ 'anthropic' ]

=> PASS: null was NOT cached; refresh applied without restart
```

Verified the probe catches the bug: on the unpatched (`upstream/main`) overlay, read 2 returns `undefined (STILL ABSENT = bug)` because the null is pinned; on the patched overlay it returns PRESENT.

### Focused tests — 5 passed

`node scripts/run-vitest.mjs src/model-catalog/remote-overlay` → 5 passed. Added:
- `re-reads the store after a negative result once a background refresh writes a bundle` — empty-store null is not pinned; a later valid bundle loads.
- `re-reads the store after a stale-bundle result once a newer bundle is written` — stale-bundle rejection is not pinned; a newer bundle loads.

### Autoreview

`codex` (gpt-5.6-sol, high) on the branch diff vs `upstream/main`: clean, no accepted/actionable findings (`overall: patch is correct`). TruffleHog clean.

### Surface changed

- `src/model-catalog/remote-overlay.ts` — `getActiveRemoteModelCatalog` no longer writes `{ sourceUrl, value: null }` on the three negative branches; the cache only stores successfully loaded overlays; `cachedOverlay` type narrowed to drop the `null` value.
- `src/model-catalog/remote-overlay.test.ts` — two new tests covering the negative-result re-read behavior.

### Not tested

The probe runs the real store + overlay read path in isolation (a temp state dir and an injected bundled stamp); it does not drive a full gateway boot or a live network fetch. The store read/write and the cache decision are the real production code paths.
