### PR TITLE
fix(security): expose every executable call in plugin scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Plugin security scan coverage:** report every matching executable call in a file instead of stopping after the first, preventing later process-execution sites from hiding behind an already-reviewed finding.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Plugin security scan coverage:** report every matching executable call in a file instead of stopping after the first, preventing later process-execution sites from hiding behind an already-reviewed finding.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -163,6 +163,29 @@ spawn("node", ["second.js"]); execFile("node", ["third.js"]);
     expect(findings.map((finding) => finding.line)).toEqual([3, 4, 4]);
   });
 
+  it("bounds dense line-rule findings and reports truncation", () => {
+    const source = [
+      `import { spawn } from "node:child_process";`,
+      ...Array.from({ length: 40 }, (_, index) => `spawn("node", ["${index}.js"]);`),
+    ].join("\n");
+
+    const findings = scanSource(source, "plugin.ts").filter((candidate) =>
+      candidate.ruleId.startsWith("dangerous-exec"),
+    );
+
+    expect(findings).toHaveLength(33);
+    expect(findings.slice(0, -1).every((finding) => finding.ruleId === "dangerous-exec")).toBe(
+      true,
+    );
+    expect(findings.at(-1)).toMatchObject({
+      ruleId: "dangerous-exec-truncated",
+      severity: "critical",
+      line: 41,
+      message: "8 additional dangerous-exec matches omitted after 32 findings",
+      evidence: "[8 additional matches omitted after 32 findings]",
+    });
+  });
+
   it("keeps bounded evidence free of lone surrogates", () => {
     const source = `${"a".repeat(119)}😀 child_process.exec("echo unsafe")`;
     const finding = scanSource(source, "plugin.ts").find(

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -149,6 +149,20 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("scanSource", () => {
+  it("reports every dangerous execution call in a file", () => {
+    const source = `
+import { execFile, spawn } from "node:child_process";
+spawn("node", ["first.js"]);
+spawn("node", ["second.js"]); execFile("node", ["third.js"]);
+`;
+
+    const findings = scanSource(source, "plugin.ts").filter(
+      (candidate) => candidate.ruleId === "dangerous-exec",
+    );
+
+    expect(findings.map((finding) => finding.line)).toEqual([3, 4, 4]);
+  });
+
   it("keeps bounded evidence free of lone surrogates", () => {
     const source = `${"a".repeat(119)}😀 child_process.exec("echo unsafe")`;
     const finding = scanSource(source, "plugin.ts").find(

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -392,47 +392,45 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
   const lines = source.split("\n");
   const heuristicSource = stripCommentsForHeuristics(source);
   const heuristicLines = heuristicSource.split("\n");
-  const matchedLineRules = new Set<string>();
 
   // --- Line rules ---
   for (const rule of LINE_RULES) {
-    if (matchedLineRules.has(rule.ruleId)) {
-      continue;
-    }
-
     // Skip rule entirely if context requirement not met
     if (rule.requiresContext && !rule.requiresContext.test(source)) {
       continue;
     }
 
     for (const [i, line] of lines.entries()) {
-      const match = rule.pattern.exec(line);
-      if (!match) {
-        continue;
-      }
-
-      if (rule.ruleId === "dangerous-exec" && isBenignMemberExecMatch(line, match)) {
-        continue;
-      }
-
-      // Special handling for suspicious-network: check port
-      if (rule.ruleId === "suspicious-network") {
-        const port = Number.parseInt(expectDefined(match[1], "scanner regex capture 1"), 10);
-        if (STANDARD_PORTS.has(port)) {
+      const matches = line.matchAll(
+        new RegExp(
+          rule.pattern.source,
+          rule.pattern.flags.includes("g") ? rule.pattern.flags : `${rule.pattern.flags}g`,
+        ),
+      );
+      for (const match of matches) {
+        if (rule.ruleId === "dangerous-exec" && isBenignMemberExecMatch(line, match)) {
           continue;
         }
-      }
 
-      findings.push({
-        ruleId: rule.ruleId,
-        severity: rule.severity,
-        file: filePath,
-        line: i + 1,
-        message: rule.message,
-        evidence: formatScanEvidence(line),
-      });
-      matchedLineRules.add(rule.ruleId);
-      break; // one finding per line-rule per file
+        // Special handling for suspicious-network: check port
+        if (rule.ruleId === "suspicious-network") {
+          const port = Number.parseInt(expectDefined(match[1], "scanner regex capture 1"), 10);
+          if (STANDARD_PORTS.has(port)) {
+            continue;
+          }
+        }
+
+        // Every call is independently reviewable. Stopping after the first match
+        // lets later execution sites hide behind an already-approved finding.
+        findings.push({
+          ruleId: rule.ruleId,
+          severity: rule.severity,
+          file: filePath,
+          line: i + 1,
+          message: rule.message,
+          evidence: formatScanEvidence(line),
+        });
+      }
     }
   }
 

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -59,6 +59,7 @@ const SCANNABLE_EXTENSIONS = new Set([
 
 const DEFAULT_MAX_SCAN_FILES = 500;
 const DEFAULT_MAX_FILE_BYTES = 1024 * 1024;
+const MAX_LINE_RULE_FINDINGS_PER_RULE = 32;
 const FILE_SCAN_CACHE_MAX = 5000;
 const DIR_ENTRY_CACHE_MAX = 5000;
 const TEST_DIRECTORY_NAMES = new Set(["__fixtures__", "__mocks__", "__tests__", "test", "tests"]);
@@ -400,6 +401,9 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
       continue;
     }
 
+    let acceptedMatches = 0;
+    let omittedMatches = 0;
+    let lastOmittedLine: number | undefined;
     for (const [i, line] of lines.entries()) {
       const matches = line.matchAll(
         new RegExp(
@@ -420,8 +424,14 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
           }
         }
 
-        // Every call is independently reviewable. Stopping after the first match
-        // lets later execution sites hide behind an already-approved finding.
+        if (acceptedMatches >= MAX_LINE_RULE_FINDINGS_PER_RULE) {
+          omittedMatches += 1;
+          lastOmittedLine = i + 1;
+          continue;
+        }
+
+        // Retain distinct calls up to the cap, then aggregate every remaining match.
+        // This keeps hostile output bounded without hiding that later sites exist.
         findings.push({
           ruleId: rule.ruleId,
           severity: rule.severity,
@@ -430,7 +440,18 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
           message: rule.message,
           evidence: formatScanEvidence(line),
         });
+        acceptedMatches += 1;
       }
+    }
+    if (lastOmittedLine !== undefined) {
+      findings.push({
+        ruleId: `${rule.ruleId}-truncated`,
+        severity: rule.severity,
+        file: filePath,
+        line: lastOmittedLine,
+        message: `${omittedMatches} additional ${rule.ruleId} matches omitted after ${MAX_LINE_RULE_FINDINGS_PER_RULE} findings`,
+        evidence: `[${omittedMatches} additional matches omitted after ${MAX_LINE_RULE_FINDINGS_PER_RULE} findings]`,
+      });
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin package security scans could omit later executable calls after finding the first matching call in a file. That made reviewed scan output incomplete when one generated or source file contained multiple process-execution sites.

## Why This Change Was Made

The line-rule scanner now reports distinct matches in source order, capped at 32 findings per rule and file. Dense input is still scanned to EOF; overflow becomes a same-severity aggregate finding with the omitted count and final affected line, so output stays bounded without silent omission. Existing context checks, benign member-call filtering, standard-port filtering, bounded evidence, and deterministic order remain intact.

Provenance: the first-match cap was introduced in https://github.com/openclaw/openclaw/pull/9806, merged February 6, 2026. Later scanner work carried that behavior forward.

## User Impact

Operators and reviewers now see each normal-volume executable call in plugin security scan output. Dense hostile input produces bounded findings plus explicit aggregate overflow evidence. Runtime plugin behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/skills/security/scanner.test.ts`: 36/36 passed
- Dense-input regression proves 32 retained findings plus an aggregate for 8 omitted matches through the final affected line
- Direct Codex package scan after a clean build: 8 critical findings instead of 7, exposing both distinct `run-attempt` execution sites
- `git diff --check`: clean
- Autoreview: clean, 0.96 confidence, no actionable findings
- Local `src/plugins/npm-install-security-scan.release.test.ts` could not start because npm 11 returned the separate package-name-keyed `npm pack --dry-run --json` shape; exact PR CI is the authoritative broader gate
