### PR TITLE
fix(agents): honor configured sandbox skill workspace (#89743)

### DIFF
--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -654,6 +654,54 @@ describe("resolveSandboxContext", () => {
     expect(result.skillUsagePaths).toEqual(skillUsagePaths);
   }, 15_000);
 
+  it("uses agents.defaults.workspace when sandbox workspace is omitted", async () => {
+    syncSkillsToWorkspaceMock.mockClear();
+    const workspaceDir = await createSandboxFixtureDir("configured-default-workspace");
+    const sandboxRoot = await createSandboxFixtureDir("configured-default-sandbox");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          sandbox: {
+            mode: "all",
+            scope: "session",
+            workspaceAccess: "ro",
+            workspaceRoot: sandboxRoot,
+          },
+        },
+      },
+    };
+
+    const result = await ensureSandboxWorkspaceForSession({
+      config: cfg,
+      sessionKey: "agent:main:main",
+    });
+
+    if (!result) {
+      throw new Error("expected sandbox workspace resolution");
+    }
+    const syncCalls = syncSkillsToWorkspaceMock.mock.calls as unknown as Array<
+      [
+        {
+          sourceWorkspaceDir?: string;
+          targetWorkspaceDir?: string;
+          config?: OpenClawConfig;
+          agentId?: string;
+          eligibility?: unknown;
+        },
+      ]
+    >;
+    const [syncOptions] = syncCalls[0] ?? [];
+    expect(syncOptions?.sourceWorkspaceDir).toBe(workspaceDir);
+    expect(syncOptions?.targetWorkspaceDir).toBe(result.workspaceDir);
+    expect(syncOptions?.config).toBe(cfg);
+    expect(syncOptions?.agentId).toBe("main");
+    expect(syncOptions?.eligibility).toEqual({
+      nodeSkills: { canExec: false },
+      remote: { note: "test-remote" },
+    });
+  }, 15_000);
+
   it("materializes skills into a hidden read-only workspace for writable sandboxes", async () => {
     syncSkillsToWorkspaceMock.mockClear();
     const workspaceDir = await createSandboxFixtureDir("workspace");

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -15,6 +15,7 @@ import {
 } from "../../plugin-sdk/browser-profiles.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { SkillEligibilityContext, SkillUsagePath } from "../../skills/types.js";
+import { resolveAgentWorkspaceDir } from "../agent-scope.js";
 import type { ExecPolicyOverrides } from "../exec-defaults.js";
 import { getSandboxBackendWorkdirResolver, requireSandboxBackendFactory } from "./backend.js";
 import { ensureSandboxBrowser } from "./browser.js";
@@ -91,11 +92,13 @@ async function ensureSandboxWorkspaceLayout(params: {
   workspaceDir: string;
 }> {
   const { cfg, rawSessionKey } = params;
+  const resolvedAgentWorkspaceDir =
+    params.workspaceDir?.trim() || resolveAgentWorkspaceDir(params.config ?? {}, params.agentId);
   const { agentWorkspaceDir, sandboxWorkspaceDir, scopeKey, skillsWorkspaceDir, workspaceDir } =
     resolveSandboxWorkspaceLayoutPaths({
       cfg,
       rawSessionKey,
-      workspaceDir: params.workspaceDir,
+      workspaceDir: resolvedAgentWorkspaceDir,
     });
 
   let syncedSkills: Awaited<ReturnType<typeof syncSandboxSkillsToWorkspace>>;


### PR DESCRIPTION
## What Problem This Solves

Sandbox skill workspace setup for custom-workspace agents used the process default `~/.openclaw/workspace` when the sandbox caller omitted `workspaceDir`, so skills could be probed/synced from the wrong workspace before `agents.defaults.workspace` was considered. This PR makes omitted sandbox setup resolve the configured agent workspace first and includes red-first plus after-fix proof that the source path changes from the default workspace to the configured workspace.

## Summary
- Problem: sandbox skill workspace setup could run without an explicit `workspaceDir` and seed/sync skills from the process default `~/.openclaw/workspace` instead of the configured agent workspace.
- Why it matters: custom-workspace agents can probe or sync the wrong skills before the configured workspace is considered.
- What changed: omitted sandbox workspace setup now resolves through `resolveAgentWorkspaceDir(config, agentId)` before sandbox layout and skill sync.
- What did NOT change (scope boundary): explicit `workspaceDir` callers, sandbox backend selection, and skill sync semantics are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #89743
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/agents/sandbox/context.ts:ensureSandboxWorkspaceLayout` forwarded omitted `workspaceDir` into `resolveSandboxWorkspaceLayoutPaths`; that helper falls back to `DEFAULT_AGENT_WORKSPACE_DIR`, so `syncSandboxSkillsToWorkspace` used `~/.openclaw/workspace` instead of `agents.defaults.workspace`.
- Missing detection / guardrail: sandbox context tests covered explicit workspaces but not omitted workspace setup with configured `agents.defaults.workspace`.
- Contributing context: ClawSweeper identified this as the remaining source-reproducible sandbox omitted-workspace path for #89743.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `src/agents/sandbox.resolveSandboxContext.test.ts`
- Scenario the test should lock in: `ensureSandboxWorkspaceForSession` with sandbox mode enabled, `agents.defaults.workspace` configured, and no explicit `workspaceDir` must sync from the configured workspace.
- Why this is the smallest reliable guardrail: it exercises the production context-to-layout call where the wrong fallback was introduced, while mocking only backend/transport seams.

## User-visible / Behavior Changes

Sandbox skill sync for custom-workspace agents no longer probes/syncs from `~/.openclaw/workspace` when sandbox workspace setup omits an explicit workspace.

## Diagram (if applicable)

```text
Before:
omitted sandbox workspace -> DEFAULT_AGENT_WORKSPACE_DIR -> sync skills from ~/.openclaw/workspace

After:
omitted sandbox workspace -> resolveAgentWorkspaceDir(config, agentId) -> sync skills from configured workspace
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes
- If any `Yes`, explain risk + mitigation: sandbox skill sync now reads the already-configured agent workspace instead of the process default workspace; this narrows filesystem access to the documented workspace contract.

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node 24.18.0 via fnm; sandbox layout resolver / sandbox context test harness
- Model/provider: n/a
- Integration/channel: sandbox workspace skill sync
- Relevant config (redacted): `agents.defaults.workspace=<temp configured workspace>`, sandbox `mode=all`, `workspaceAccess=ro`

### Steps

1. Configure `agents.defaults.workspace` to a non-default temp directory.
2. Run sandbox workspace setup for `agent:main:main` without passing `workspaceDir`.
3. Observe the source workspace used for sandbox skill sync.

### Expected

- Skill sync uses the configured agent workspace.

### Actual on current main before fix

- Skill sync used the process default `~/.openclaw/workspace`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

### Real Behavior Proof (after fix, real setup)

Production resolver probe with a temporary configured workspace, exercising the same sandbox layout input that feeds skill sync:

```json
{
  "configuredWorkspace": "C:\Users\pss\AppData\Local\Temp\openclaw-89743-layout-Nl5aYp\configured-workspace",
  "resolvedAgentWorkspaceDir": "C:\Users\pss\AppData\Local\Temp\openclaw-89743-layout-Nl5aYp\configured-workspace",
  "oldOmittedPath": "C:\Users\pss\.openclaw\workspace",
  "fixedPath": "C:\Users\pss\AppData\Local\Temp\openclaw-89743-layout-Nl5aYp\configured-workspace",
  "beforeUsedConfiguredWorkspace": false,
  "afterUsesConfiguredWorkspace": true
}
```

Red-first before-fix proof on current main:

```text
pnpm test src/agents/sandbox.resolveSandboxContext.test.ts -t "uses agents.defaults.workspace"
Expected: ...\configured-default-workspace-0
Received: ...\.openclaw\workspace
red_first_exit=1
```

After-fix proof:

```text
pnpm test src/agents/sandbox.resolveSandboxContext.test.ts -t "uses agents.defaults.workspace"
1 passed | 15 skipped
```

## Human Verification (required)

- Verified scenarios: omitted sandbox workspace with `agents.defaults.workspace`; explicit workspace behavior remains covered by the existing sandbox context test; read-only and writable sandbox skill sync suite still passes.
- Edge cases checked: skill usage path metadata assertion preserved after codex review finding.
- What I did not verify: Docker container startup; this change is before backend/container startup and only changes host workspace path resolution.

## Test (supporting)

- `pnpm test src/agents/sandbox.resolveSandboxContext.test.ts -t "uses agents.defaults.workspace"` — passed after failing red-first.
- `pnpm test src/agents/sandbox.resolveSandboxContext.test.ts` — 16 passed.
- `pnpm tsgo` — passed.
- `pnpm exec oxfmt --check --threads=1 src/agents/sandbox/context.ts src/agents/sandbox.resolveSandboxContext.test.ts` — passed.
- `codex review --disable plugins --base origin/main` — initial P2 test-coverage finding fixed; rerun found the workspace-resolution change correct and the 16-test suite passing.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: merge-risk compatibility / data access scope.
  - Mitigation: explicit workspace callers still pass through unchanged; omitted sandbox setup now follows the documented configured workspace contract.

## Changelog

- n/a - release-owned changelog; no PR changelog edit.

## Notes

- Scope: single issue, smallest complete fix.
- AI-assisted: yes; testing degree: fully tested for the touched sandbox workspace path.

Closes #89743