### PR TITLE
fix(openai): bound realtime voice startup responses

### DIFF
--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -9,7 +9,10 @@ import {
   releaseOpenAIQuicksilverSession,
   reserveOpenAIQuicksilverSession,
 } from "./realtime-quicksilver-session-limit.js";
-import { connectOpenAIQuicksilverSideband } from "./realtime-quicksilver-sideband.js";
+import {
+  connectOpenAIQuicksilverSideband,
+  type OpenAIQuicksilverSocketFactory,
+} from "./realtime-quicksilver-sideband.js";
 import {
   createCallResponse,
   emitSideband,
@@ -539,6 +542,36 @@ describe("GPT-Live gateway relay bridge", () => {
 
     await expect(connection).rejects.toThrow("sideband startup stopped");
     expect(socket.closed).toBe(true);
+  });
+
+  it("bounds sideband frames and aggregate pre-open buffering", async () => {
+    const controller = new AbortController();
+    const socket = new FakeSocket("manual");
+    let socketOptions: Parameters<OpenAIQuicksilverSocketFactory>[1] | undefined;
+    socket.once("close", () => controller.abort(new Error("sideband overflow observed")));
+    const connection = connectOpenAIQuicksilverSideband({
+      auth: { type: "api-key", token: "platform-key" },
+      createSocket: (_url, options) => {
+        socketOptions = options;
+        return socket;
+      },
+      requestIds: {
+        realtimeSessionId: "realtime-session",
+        sessionId: "session",
+        threadId: "thread",
+      },
+      signal: controller.signal,
+      url: "wss://api.openai.com/v1/live/rtc_test",
+    });
+
+    expect(socketOptions?.maxPayload).toBe(16 * 1024 * 1024);
+    socket.emit("message", Buffer.alloc(512 * 1024), false);
+    socket.emit("message", Buffer.alloc(512 * 1024), false);
+    socket.emit("message", Buffer.from([0]), false);
+
+    await expect(connection).rejects.toThrow("sideband overflow observed");
+    expect(socket.closeCode).toBe(1009);
+    expect(socket.closeReason).toBe("sideband startup buffer exceeded");
   });
 
   it("does not append failure text when the host cancels a delegation", async () => {

--- a/extensions/openai/realtime-quicksilver-sideband.ts
+++ b/extensions/openai/realtime-quicksilver-sideband.ts
@@ -9,6 +9,8 @@ const SIDEBAND_CONNECT_TIMEOUT_MS = 15_000;
 const SIDEBAND_CONNECT_ATTEMPTS = 5;
 const SIDEBAND_RETRY_BASE_MS = 200;
 const EARLY_FRAME_MAX = 32;
+const EARLY_FRAME_MAX_BYTES = 1024 * 1024;
+const SIDEBAND_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
 
 export type OpenAIQuicksilverSocket = {
   readonly readyState: number;
@@ -47,6 +49,13 @@ type OpenAIQuicksilverConnectedSideband = {
   bufferedFrames: OpenAIQuicksilverBufferedFrame[];
   detachBuffer: () => OpenAIQuicksilverTerminalEvent | undefined;
 };
+
+function rawDataByteLength(data: RawData): number {
+  if (Array.isArray(data)) {
+    return data.reduce((total, chunk) => total + chunk.byteLength, 0);
+  }
+  return data.byteLength;
+}
 
 function waitForSocketOpen(params: {
   socket: OpenAIQuicksilverSocket;
@@ -165,12 +174,22 @@ export async function connectOpenAIQuicksilverSideband(params: {
     }
     const socket = params.createSocket(params.url, {
       headers: openAIQuicksilverAuthHeaders(params.auth, params.requestIds),
+      maxPayload: SIDEBAND_MAX_PAYLOAD_BYTES,
     });
     const bufferedFrames: OpenAIQuicksilverBufferedFrame[] = [];
+    let bufferedBytes = 0;
     const bufferFrame = (data: RawData, isBinary: boolean) => {
-      if (bufferedFrames.length < EARLY_FRAME_MAX) {
-        bufferedFrames.push({ data, isBinary });
+      const frameBytes = rawDataByteLength(data);
+      if (
+        bufferedFrames.length >= EARLY_FRAME_MAX ||
+        bufferedBytes + frameBytes > EARLY_FRAME_MAX_BYTES
+      ) {
+        socket.off("message", bufferFrame);
+        socket.close(1009, "sideband startup buffer exceeded");
+        return;
       }
+      bufferedBytes += frameBytes;
+      bufferedFrames.push({ data, isBinary });
     };
     socket.on("message", bufferFrame);
     try {

--- a/extensions/openai/realtime-quicksilver-wire.test.ts
+++ b/extensions/openai/realtime-quicksilver-wire.test.ts
@@ -315,4 +315,37 @@ describe("GPT-Live call creation", () => {
       message: "GPT-Live call creation returned an empty SDP answer",
     });
   });
+
+  it.each([
+    {
+      label: "GPT-Live",
+      auth: { type: "oauth" as const, token: "oauth-token", accountId: "acct-1" },
+      model: "gpt-live-1-codex",
+      location: "/v1/live/rtc_oversized_answer",
+    },
+    {
+      label: "OpenAI Realtime",
+      auth: { type: "api-key" as const, token: "platform-key" },
+      model: "gpt-realtime-2.1",
+      location: undefined,
+    },
+  ])("rejects an oversized streaming $label SDP answer", async (testCase) => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(`v=answer\r\n${"x".repeat(256 * 1024)}`, {
+          status: 201,
+          headers: testCase.location ? { Location: testCase.location } : undefined,
+        }),
+    );
+
+    await expect(
+      createOpenAIQuicksilverCall({
+        auth: testCase.auth,
+        requestIds: createRequestIds(`oversized-answer-${testCase.label}`),
+        sdp: "v=offer\r\n",
+        session: buildOpenAIQuicksilverSession({ model: testCase.model }),
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(`${testCase.label} SDP answer: text response exceeds 262144 bytes`);
+  });
 });

--- a/extensions/openai/realtime-quicksilver-wire.ts
+++ b/extensions/openai/realtime-quicksilver-wire.ts
@@ -1,6 +1,7 @@
 // GPT-Live frameless session, call-creation, and sideband event wire contracts.
 import { randomBytes } from "node:crypto";
 import {
+  readProviderTextResponse,
   readResponseTextLimited,
   resolveProviderRequestHeaders,
 } from "openclaw/plugin-sdk/provider-http";
@@ -15,6 +16,7 @@ const OPENAI_QUICKSILVER_CALL_URL = "https://api.openai.com/v1/live";
 const OPENAI_REALTIME_CALL_URL = "https://api.openai.com/v1/realtime/calls";
 const OPENAI_REALTIME_ERROR_BODY_MAX_BYTES = 16 * 1024;
 const OPENAI_REALTIME_ERROR_DETAIL_MAX_CHARS = 500;
+const OPENAI_REALTIME_SDP_ANSWER_MAX_BYTES = 256 * 1024;
 const OPENAI_GPT_LIVE_WAITLIST_URL = "https://openai.com/form/gpt-live-1-in-the-api/";
 
 const OPENAI_QUICKSILVER_VOICES = [
@@ -428,7 +430,11 @@ export async function createOpenAIQuicksilverCall(params: {
       response.status,
     );
   }
-  const answerSdp = await response.text();
+  const answerSdp = await readProviderTextResponse(
+    response,
+    `${isGptLive ? "GPT-Live" : "OpenAI Realtime"} SDP answer`,
+    { maxBytes: OPENAI_REALTIME_SDP_ANSWER_MAX_BYTES },
+  );
   if (!answerSdp.trim()) {
     throw new OpenAIQuicksilverCallError(
       `${isGptLive ? "GPT-Live" : "OpenAI Realtime"} call creation returned an empty SDP answer`,


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where malformed or unexpectedly large OpenAI realtime startup responses could retain hundreds of megabytes while a voice session was connecting.

## Why This Change Was Made

OpenAI sideband sockets now cap individual frames at 16 MiB and aggregate pre-open buffering at 1 MiB. Successful GPT-Live and GA realtime SDP answers now use the shared bounded response reader with a 256 KiB limit. The limits are internal constants and add no provider or configuration surface.

## User Impact

Realtime voice startup remains unchanged for normal OpenAI responses, while oversized provider frames and SDP answers fail closed instead of consuming unbounded memory.

## Evidence

- Blacksmith Testbox focused OpenAI suite: 90 passed, 1 intentional skip across wire, browser broker, gateway bridge, and direct bridge tests.
- Blacksmith Testbox `pnpm check:changed` (clean).
- `autoreview --mode local` (no accepted/actionable findings, 0.84 confidence).
- Focused regression coverage verifies the WebSocket payload cap, 1 MiB aggregate pre-open buffer closure, and 256 KiB SDP answer rejection for GPT-Live and GA realtime.
- Live OpenAI GA backend bridge connected with `gpt-realtime-2.1`; browser WebRTC negotiated audio, applied the remote answer, and reached `connected`.
- Live audio talkback passed OpenAI TTS synthesis, synthesized-audio transcription, and streaming realtime STT (3/3).
- Direct GPT-Live sideband validation remains entitlement-limited for the current API key; this PR does not change authentication or model routing.

AI-assisted: yes. I understand and manually validated the startup buffer and response-body ownership changes.
