### PR TITLE
fix: session transcript loses the reply text when a message includes media

### DIFF
--- a/src/config/sessions/transcript-mirror.test.ts
+++ b/src/config/sessions/transcript-mirror.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveMirroredTranscriptText } from "./transcript-mirror.js";
+
+describe("resolveMirroredTranscriptText", () => {
+  it("keeps the message text when media is attached", () => {
+    expect(
+      resolveMirroredTranscriptText({
+        text: "Revenue fell 12% quarter over quarter.",
+        mediaUrls: ["https://example.com/files/chart-q3.png?token=abc"],
+      }),
+    ).toBe("Revenue fell 12% quarter over quarter.\nchart-q3.png");
+  });
+
+  it("joins multiple media names after the text", () => {
+    expect(
+      resolveMirroredTranscriptText({
+        text: "See attachments",
+        mediaUrls: ["https://example.com/a.png", "https://example.com/b.pdf"],
+      }),
+    ).toBe("See attachments\na.png, b.pdf");
+  });
+
+  it("keeps text with the media placeholder when no name can be derived", () => {
+    expect(resolveMirroredTranscriptText({ text: "hello", mediaUrls: ["   /   "] })).toBe(
+      "hello\nmedia",
+    );
+  });
+
+  it("returns media names alone when there is no text", () => {
+    expect(
+      resolveMirroredTranscriptText({ mediaUrls: ["https://example.com/voice-note.ogg"] }),
+    ).toBe("voice-note.ogg");
+  });
+
+  it("returns the placeholder alone for unnamed media without text", () => {
+    expect(resolveMirroredTranscriptText({ text: "  ", mediaUrls: ["   /   "] })).toBe("media");
+  });
+
+  it("returns trimmed text when there is no media", () => {
+    expect(resolveMirroredTranscriptText({ text: "  hi  ", mediaUrls: [] })).toBe("hi");
+  });
+
+  it("returns null when both text and media are empty", () => {
+    expect(resolveMirroredTranscriptText({ text: "   ", mediaUrls: ["  "] })).toBeNull();
+  });
+});

--- a/src/config/sessions/transcript-mirror.ts
+++ b/src/config/sessions/transcript-mirror.ts
@@ -40,17 +40,14 @@ export function resolveMirroredTranscriptText(params: {
   mediaUrls?: string[];
 }): string | null {
   const mediaUrls = params.mediaUrls?.filter((url) => url && url.trim()) ?? [];
+  const trimmedText = params.text?.trim() ?? "";
   if (mediaUrls.length > 0) {
     const names = mediaUrls
       .map((url) => extractFileNameFromMediaUrl(url))
       .filter((name): name is string => Boolean(name && name.trim()));
-    if (names.length > 0) {
-      return names.join(", ");
-    }
-    return "media";
+    const mediaText = names.length > 0 ? names.join(", ") : "media";
+    return trimmedText ? `${trimmedText}\n${mediaText}` : mediaText;
   }
 
-  const text = params.text ?? "";
-  const trimmed = text.trim();
-  return trimmed ? trimmed : null;
+  return trimmedText ? trimmedText : null;
 }

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -325,6 +325,33 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
+  it("persists reply text alongside media names in SQLite", async () => {
+    await writeTranscriptStore();
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Revenue fell 12% quarter over quarter.",
+      mediaUrls: ["https://example.com/files/chart-q3.png?token=secret"],
+      storePath: fixture.storePath(),
+    });
+
+    expect(result.ok).toBe(true);
+    const events = await loadFixtureMessages();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        message: expect.objectContaining({
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Revenue fell 12% quarter over quarter.\nchart-q3.png",
+            },
+          ],
+        }),
+      }),
+    );
+  });
+
   it("advances the session registry marker after managed transcript appends", async () => {
     const updatedAt = Date.parse("2026-05-18T09:00:00.000Z");
     const appendedAt = Date.parse("2026-05-18T09:05:00.000Z");

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -2396,12 +2396,14 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       "openclaw-chat-send-agent-source-reply-deduped-",
       async (fixtureDir) => {
         const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+        const replyText = "Source reply with media";
         const savedImagePath = path.join(fixtureDir, "source-reply-deduped.png");
         fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
         mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
         const mirrorIdempotencyKey = "idem-agent-source-reply-deduped:internal-source-reply:0";
         await appendSourceReplyMirrorEntry({
-          text: resolveMirroredTranscriptText({ mediaUrls: [mediaUrl] }) ?? "media",
+          text:
+            resolveMirroredTranscriptText({ text: replyText, mediaUrls: [mediaUrl] }) ?? "media",
         });
         mockState.triggerAgentRunStart = true;
         mockState.dispatchedReplies = [
@@ -2409,11 +2411,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             kind: "final",
             payload: setReplyPayloadMetadata(
               {
+                text: replyText,
                 mediaUrls: [mediaUrl],
               },
               {
                 sourceReplyTranscriptMirror: {
                   sessionKey: "main",
+                  text: replyText,
                   mediaUrls: [mediaUrl],
                   idempotencyKey: mirrorIdempotencyKey,
                 },
@@ -2434,6 +2438,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         const assistantEntries = await readActiveAssistantTranscriptMessages();
         expect(assistantEntries).toHaveLength(1);
         expect(assistantEntries[0]?.idempotencyKey).toBe(mirrorIdempotencyKey);
+        expect(JSON.stringify(assistantEntries[0])).toContain(replyText);
         expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
         expect(JSON.stringify(assistantEntries[0])).not.toContain(mediaUrl);
       },

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4359,7 +4359,7 @@ describe("deliverOutboundPayloads", () => {
         [{ config?: unknown; idempotencyKey?: unknown; text?: unknown }]
       >
     )[0]?.[0];
-    expect(appendOptions?.text).toBe("report.pdf");
+    expect(appendOptions?.text).toBe("caption\nreport.pdf");
     expect(appendOptions?.idempotencyKey).toBe("idem-deliver-1");
     expect(appendOptions?.config).toBe(cfg);
   });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where any assistant reply that pairs commentary with an attachment loses its text in the session transcript. The delivery mirror stores only the attachment filename, so a reply like a chart plus analysis, a screenshot plus explanation, or a generated image plus caption is persisted as just `chart-q3.png`. The mirror reports success, the real words never enter the session history or the FTS index, transcript search cannot recover them, and on the next turn the model cannot see what it just told the user.

All delivery mirror chains are affected because they share one helper: core outbound delivery (gateway `message.send`, CLI send, the agent message tool via `src/infra/outbound/deliver.ts`), the plugin SDK mirror runtime (`src/plugin-sdk/session-transcript-runtime.ts`), and the gateway mirror matcher (`src/gateway/server-methods/chat-transcript-persistence.ts`).

## Why This Change Was Made

`resolveMirroredTranscriptText` in `src/config/sessions/transcript-mirror.ts` returns early with the joined media names whenever `mediaUrls` is non-empty, which makes the `params.text` branch unreachable for exactly the messages that carry both. The fix makes the helper emit the text followed by the media names when both are present, and keeps every existing single-input behavior unchanged: media-only mirrors still store the names (or the `media` placeholder), text-only mirrors still store the trimmed text, and empty input still resolves to null. Fixing the shared helper covers every mirror chain at once; the media-only call sites in `src/cron/isolated-agent/delivery-dispatch.ts` pass no text and are unaffected. The gateway mirror matcher recomputes expected text through the same helper, so lookup and write stay consistent.

## User Impact

Replies that combine text with attachments now keep their full text in session history. The agent's own words remain visible to the next turn, transcript search finds them, and the attachment name is still recorded alongside.

## Evidence

Real transcript append driven twice against a real temp SQLite session store with identical reply text, once with `mediaUrls` and once without, then the stored assistant rows read back. Before, on pristine main `cc48aef1435`:

```
session=sid-text-plus-media append.ok=true
  stored assistant content: [{"type":"text","text":"chart-q3.png"}]
session=sid-text-only-control append.ok=true
  stored assistant content: [{"type":"text","text":"Revenue fell 12% quarter over quarter, driven by churn in the SMB tier. I recommend we cut the ads budget by 30% and reinvest in retention."}]
```

After, with this patch on identical inputs:

```
session=sid-text-plus-media append.ok=true
  stored assistant content: [{"type":"text","text":"Revenue fell 12% quarter over quarter, driven by churn in the SMB tier. I recommend we cut the ads budget by 30% and reinvest in retention.\nchart-q3.png"}]
session=sid-text-only-control append.ok=true
  stored assistant content: [{"type":"text","text":"Revenue fell 12% quarter over quarter, driven by churn in the SMB tier. I recommend we cut the ads budget by 30% and reinvest in retention."}]
```

The agent's actual reply was "Revenue fell 12% quarter over quarter, ...". The only difference between the two appends is the presence of `mediaUrls`; before the patch that alone replaced the stored text with the filename.

Validation on the changed files: new colocated regression suite `src/config/sessions/transcript-mirror.test.ts` (7 tests, 3 fail on pristine main for the text-plus-media cases, all green with the patch), plus `src/config/sessions/transcript.test.ts`, `src/infra/outbound/deliver.test.ts`, `src/gateway/server-methods/chat.directive-tags.test.ts`, `src/plugin-sdk/session-transcript-runtime.test.ts`, and `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` all passing via `scripts/run-vitest.mjs`; `run-oxlint` and `oxfmt --check` clean; `tsgo` core lane clean. One existing assertion in `deliver.test.ts` expected the mirror text for a caption-plus-media payload to be `report.pdf`; it encoded the buggy behavior and is updated to `caption\nreport.pdf`.

Not tested live: an end-to-end channel send through a real provider; the proof drives the real append and read path that every mirror chain funnels into.

### Maintainer validation

Validated repaired head `fd16d5075079a640bde2e297b32201939d00093d` on July 30, 2026. The maintainer repair adds a real SQLite persistence regression and exercises the gateway unkeyed text-plus-media fallback so the writer and matcher cannot drift.

- Blacksmith Testbox focused proof: 394/394 tests passed (`chat.directive-tags` 159, `deliver` 161, `transcript` 67, `transcript-mirror` 7).
- `pnpm check:changed`: passed for `core, coreTests`, including core/test typechecks, lint, dependency/boundary/dead-export checks, import-cycle and database-first guards.
- Fresh structured autoreview: clean, no accepted/actionable findings, correctness confidence 0.97.
- No exact duplicate is open. Closest prior overlap, #53607, mixed this rule with a broader Discord metadata design; this PR keeps the correction at the shared transcript-mirror owner.