### PR TITLE
fix(macos): keep replacement notifications visible

### DIFF
--- a/apps/macos/Sources/OpenClaw/NotifyOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/NotifyOverlay.swift
@@ -36,8 +36,15 @@ final class NotifyOverlayController {
 
         if autoDismissAfter > 0 {
             self.dismissTask = Task { [weak self] in
-                try? await Task.sleep(nanoseconds: UInt64(autoDismissAfter * 1_000_000_000))
-                await MainActor.run { self?.dismiss() }
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(autoDismissAfter * 1_000_000_000))
+                } catch {
+                    return
+                }
+                await MainActor.run {
+                    guard !Task.isCancelled else { return }
+                    self?.dismiss()
+                }
             }
         }
     }

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageViewSmokeTests.swift
@@ -52,12 +52,15 @@ struct LowCoverageViewSmokeTests {
         AgentEventStore.shared.clear()
     }
 
-    @Test func `notify overlay presents and dismisses`() async {
+    @Test func `notify overlay keeps replacement visible`() async {
         let controller = NotifyOverlayController()
-        controller.present(title: "Hello", body: "World", autoDismissAfter: 0)
+        controller.present(title: "Hello", body: "World", autoDismissAfter: 0.05)
         controller.present(title: "Updated", body: "Again", autoDismissAfter: 0)
-        controller.dismiss()
         try? await Task.sleep(nanoseconds: 250_000_000)
+        #expect(controller.model.isVisible)
+        #expect(controller.model.title == "Updated")
+
+        controller.dismiss()
     }
 
     @Test func `talk overlay presents twice and dismisses`() async {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a replacement in-app notification could disappear immediately when the previous notification still had a pending auto-dismiss timer.

## Why This Change Was Made

Cancellation of the superseded timer is now terminal: a cancelled sleep returns without dismissing, and the task checks cancellation again before hiding the overlay. The regression test presents a timed notification, replaces it with a persistent notification, and verifies the replacement remains visible.

## User Impact

macOS users can receive back-to-back in-app notifications without an older timer hiding the newer notification.

## Evidence

- `swift test --package-path apps/macos --scratch-path apps/macos/.build-local --filter LowCoverageViewSmokeTests`: 11 tests passed, including the replacement notification regression; the focused suite then passed 10 consecutive runs with the original dismissal deadline expiring before the assertion.
- SwiftFormat lint: 0 of 2 changed files require formatting.
- SwiftLint: passed.
- Native app i18n baseline and verification: 5,382 entries, no generated changes.
- ClawSweeper rank-up move addressed: the final cancellation guard and overlay dismissal now run inside the explicit main-actor boundary; the focused 11-test suite passed again.
- Final branch autoreview: clean, no accepted/actionable findings; correctness 0.96.
- Changed-gate equivalent local fallback: all planned guards passed; SwiftLint found 0 violations across 701 Swift files; 5 Vitest shards passed 248 tests; native state schema guard passed at v6.
- Blacksmith changed-gate runs did not reach repository checks because Testbox file sync timed out: runs 30513007505 and 30513447867. Per trusted-source fallback policy, the same planned checks were run locally with the existing shared dependency install.

AI-assisted: yes. The implementation, tests, and evidence were reviewed by the maintainer.
