### PR TITLE
fix(openai): prevent stale realtime audio after close

### DIFF
--- a/extensions/openai/realtime-quicksilver-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.test.ts
@@ -185,6 +185,72 @@ describe("OpenAIQuicksilverVoiceBridge", () => {
     expect(harness.onReady).toHaveBeenCalledOnce();
   });
 
+  it("bounds queued audio by aggregate bytes before session readiness", async () => {
+    const harness = createHarness({ autoStart: false });
+    const connecting = harness.bridge.connect();
+    await vi.waitFor(() => expect(harness.socket.readyState).toBe(1));
+
+    harness.bridge.sendAudio(Buffer.alloc(512 * 1024, 0x01));
+    harness.bridge.sendAudio(Buffer.alloc(512 * 1024, 0x02));
+    harness.bridge.sendAudio(Buffer.from("overflow"));
+    harness.socket.serverEvent({
+      type: "session.started",
+      session: { id: "live-1", expires_at: Math.floor(Date.now() / 1000) + 60 },
+    });
+    await connecting;
+
+    const audioEvents = sentEvents(harness.socket).filter(
+      (event) => event.type === "input_audio.append",
+    );
+    expect(audioEvents).toHaveLength(2);
+    expect(
+      audioEvents.map((event) => Buffer.from(String(event.audio), "base64").byteLength),
+    ).toEqual([512 * 1024, 512 * 1024]);
+    harness.bridge.close();
+  });
+
+  it("does not carry queued audio across terminal close and explicit reconnect", async () => {
+    const sockets: FakeSocket[] = [];
+    const bridge = new OpenAIQuicksilverVoiceBridge({
+      providerConfig: {},
+      model: "gpt-live-1-codex",
+      audioFormat: { encoding: "pcm16", sampleRateHz: 24000, channels: 1 },
+      resolveAuth: async () => ({ type: "api-key", token: "test-key" }),
+      webSocketFactory: (_url, _options) => {
+        const socket = new FakeSocket(false);
+        sockets.push(socket);
+        queueMicrotask(() => socket.open());
+        return socket as unknown as OpenAIQuicksilverSocket;
+      },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    const firstConnect = bridge.connect();
+    await vi.waitFor(() => expect(sockets[0]?.readyState).toBe(1));
+    bridge.sendAudio(Buffer.from("queued-before-close"));
+    bridge.close();
+    await firstConnect;
+    bridge.sendAudio(Buffer.from("sent-after-close"));
+
+    const reconnecting = bridge.connect();
+    await vi.waitFor(() => expect(sockets[1]?.readyState).toBe(1));
+    sockets[1]?.serverEvent({
+      type: "session.started",
+      session: { id: "live-2", expires_at: Math.floor(Date.now() / 1000) + 60 },
+    });
+    await reconnecting;
+
+    const secondSocket = sockets[1];
+    if (!secondSocket) {
+      throw new Error("expected bridge to reconnect");
+    }
+    expect(
+      sentEvents(secondSocket).filter((event) => event.type === "input_audio.append"),
+    ).toHaveLength(0);
+    bridge.close();
+  });
+
   it("rejects startup failures without emitting terminal callbacks", async () => {
     const harness = createHarness({ autoStart: false });
     const connecting = harness.bridge.connect();

--- a/extensions/openai/realtime-quicksilver-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.ts
@@ -38,6 +38,7 @@ import {
 const OPENAI_QUICKSILVER_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
 const OPENAI_QUICKSILVER_READY_TIMEOUT_MS = 15_000;
 const OPENAI_QUICKSILVER_PENDING_AUDIO_CHUNKS = 320;
+const OPENAI_QUICKSILVER_PENDING_AUDIO_BYTES = 1024 * 1024;
 const OPENAI_QUICKSILVER_SAMPLE_RATE = 24_000;
 const WEBSOCKET_OPEN = 1;
 
@@ -88,6 +89,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
   private connectPromise: Promise<void> | undefined;
   private readonly lifecycle = new OpenAIRealtimeVoiceLifecycle();
   private pendingAudio: Buffer[] = [];
+  private pendingAudioBytes = 0;
   private activeDelegations = new Set<string>();
   private readonly flowId = randomUUID();
   private readonly requestIds: OpenAIQuicksilverRequestIds = {
@@ -141,7 +143,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
       ) {
         return;
       }
-      this.lifecycle.failure(connection);
+      this.failLifecycle(connection);
       throw error;
     }
     if (!this.lifecycle.isCurrent(connection) || connection.signal.aborted) {
@@ -198,7 +200,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
       if (!this.lifecycle.acceptsEvents(connection) || reachedReady) {
         return;
       }
-      this.lifecycle.failure(connection);
+      this.failLifecycle(connection);
       failReady(error);
       this.closeSocket(reason, connected.socket);
     };
@@ -269,7 +271,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
           return;
         }
         const error = new Error("GPT-Live WebSocket closed before session.started");
-        this.lifecycle.failure(connection);
+        this.failLifecycle(connection);
         failReady(error);
         this.lifecycle.close(connection, "error");
         return;
@@ -309,10 +311,11 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
   }
 
   sendAudio(audio: Buffer): void {
+    if (this.lifecycle.phase() === "terminal") {
+      return;
+    }
     if (!this.lifecycle.isReady() || this.socket?.readyState !== WEBSOCKET_OPEN) {
-      if (this.pendingAudio.length < OPENAI_QUICKSILVER_PENDING_AUDIO_CHUNKS) {
-        this.pendingAudio.push(audio);
-      }
+      this.enqueuePendingAudio(audio);
       return;
     }
     this.sendAudioNow(audio);
@@ -360,6 +363,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     if (!connection || !this.lifecycle.cancel()) {
       return;
     }
+    this.resetTerminalState();
     if (this.socket?.readyState === WEBSOCKET_OPEN) {
       this.sendEvent({ type: "session.close" });
     }
@@ -425,7 +429,9 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     }
     if (event.kind === "session-started") {
       if (this.lifecycle.ready(connection)) {
-        for (const audio of this.pendingAudio.splice(0)) {
+        const pendingAudio = this.pendingAudio.splice(0);
+        this.pendingAudioBytes = 0;
+        for (const audio of pendingAudio) {
           this.sendAudioNow(audio);
         }
         this.config.onReady?.();
@@ -535,12 +541,37 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     error: Error,
     reason = "bridge error",
   ): boolean {
-    if (!this.lifecycle.failure(connection)) {
+    if (!this.failLifecycle(connection)) {
       return false;
     }
     this.config.onError?.(error);
     this.closeSocket(reason);
     return true;
+  }
+
+  private failLifecycle(connection: OpenAIRealtimeVoiceConnection): boolean {
+    if (!this.lifecycle.failure(connection)) {
+      return false;
+    }
+    this.resetTerminalState();
+    return true;
+  }
+
+  private enqueuePendingAudio(audio: Buffer): void {
+    if (
+      this.pendingAudio.length >= OPENAI_QUICKSILVER_PENDING_AUDIO_CHUNKS ||
+      this.pendingAudioBytes + audio.byteLength > OPENAI_QUICKSILVER_PENDING_AUDIO_BYTES
+    ) {
+      return;
+    }
+    this.pendingAudio.push(audio);
+    this.pendingAudioBytes += audio.byteLength;
+  }
+
+  private resetTerminalState(): void {
+    this.pendingAudio = [];
+    this.pendingAudioBytes = 0;
+    this.activeDelegations.clear();
   }
 
   private closeSocket(reason: string, socket = this.socket): void {
@@ -559,6 +590,7 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     if (!outcome) {
       return;
     }
+    this.resetTerminalState();
     this.config.onClose?.(outcome);
   }
 }

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -1517,6 +1517,75 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     expect(bridge.isConnected()).toBe(true);
   });
 
+  it("bounds queued audio by aggregate bytes before session readiness", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    await Promise.resolve();
+
+    bridge.sendAudio(Buffer.alloc(512 * 1024, 0x01));
+    bridge.sendAudio(Buffer.alloc(512 * 1024, 0x02));
+    bridge.sendAudio(Buffer.from("overflow"));
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    const audioEvents = parseSent(socket).filter(
+      (event) => event.type === "input_audio_buffer.append",
+    );
+    expect(audioEvents).toHaveLength(2);
+    expect(
+      audioEvents.map((event) => Buffer.from(String(event.audio), "base64").byteLength),
+    ).toEqual([512 * 1024, 512 * 1024]);
+    bridge.close();
+  });
+
+  it("does not carry queued audio across terminal close and explicit reconnect", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+    const firstConnect = bridge.connect();
+    const firstSocket = FakeWebSocket.instances[0];
+    if (!firstSocket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+    firstSocket.readyState = FakeWebSocket.OPEN;
+    firstSocket.emit("open");
+    await Promise.resolve();
+
+    bridge.sendAudio(Buffer.from("queued-before-close"));
+    bridge.close();
+    await firstConnect;
+    bridge.sendAudio(Buffer.from("sent-after-close"));
+
+    const reconnecting = bridge.connect();
+    const secondSocket = FakeWebSocket.instances[1];
+    if (!secondSocket) {
+      throw new Error("expected bridge to reconnect");
+    }
+    secondSocket.readyState = FakeWebSocket.OPEN;
+    secondSocket.emit("open");
+    secondSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await reconnecting;
+
+    expect(
+      parseSent(secondSocket).filter((event) => event.type === "input_audio_buffer.append"),
+    ).toHaveLength(0);
+    bridge.close();
+  });
+
   it("shares an in-flight connection until session readiness", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const onReady = vi.fn();

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -575,6 +575,8 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private static readonly MAX_RECONNECT_ATTEMPTS = 5;
   private static readonly BASE_RECONNECT_DELAY_MS = 1000;
   private static readonly CONNECT_TIMEOUT_MS = 10_000;
+  private static readonly MAX_PENDING_AUDIO_CHUNKS = 320;
+  private static readonly MAX_PENDING_AUDIO_BYTES = 1024 * 1024;
   readonly supportsToolResultContinuation = true;
   readonly supportsToolResultSuppression = true;
 
@@ -583,6 +585,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private connectPromise: Promise<void> | undefined;
   private readonly lifecycle = new OpenAIRealtimeVoiceLifecycle();
   private pendingAudio: Buffer[] = [];
+  private pendingAudioBytes = 0;
   private markQueue: string[] = [];
   private responseStartTimestamp: number | null = null;
   private responseActive = false;
@@ -633,10 +636,11 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   sendAudio(audio: Buffer): void {
+    if (this.lifecycle.phase() === "terminal") {
+      return;
+    }
     if (!this.lifecycle.isReady() || this.ws?.readyState !== WebSocket.OPEN) {
-      if (this.pendingAudio.length < 320) {
-        this.pendingAudio.push(audio);
-      }
+      this.enqueuePendingAudio(audio);
       return;
     }
     this.sendEvent({
@@ -704,6 +708,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     if (!connection || !this.lifecycle.cancel()) {
       return;
     }
+    this.resetTerminalState();
     const ws = this.ws;
     this.ws = null;
     ws?.close(1000, "Bridge closed");
@@ -1061,7 +1066,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         type: "session.reconnect.exhausted",
         detail: `reason=${reason} attempts=${OpenAIRealtimeVoiceBridge.MAX_RECONNECT_ATTEMPTS}`,
       });
-      this.lifecycle.failure(connection);
+      if (this.lifecycle.failure(connection)) {
+        this.resetTerminalState();
+      }
       this.notifyClose(connection, "error");
       return;
     }
@@ -1272,7 +1279,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           this.sessionReadyFired = true;
           this.config.onReady?.();
         }
-        for (const chunk of this.pendingAudio.splice(0)) {
+        const pendingAudio = this.pendingAudio.splice(0);
+        this.pendingAudioBytes = 0;
+        for (const chunk of pendingAudio) {
           this.sendAudio(chunk);
         }
         return;
@@ -1591,6 +1600,27 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     this.deliveredToolCallKeys.clear();
   }
 
+  private enqueuePendingAudio(audio: Buffer): void {
+    if (
+      this.pendingAudio.length >= OpenAIRealtimeVoiceBridge.MAX_PENDING_AUDIO_CHUNKS ||
+      this.pendingAudioBytes + audio.byteLength > OpenAIRealtimeVoiceBridge.MAX_PENDING_AUDIO_BYTES
+    ) {
+      return;
+    }
+    this.pendingAudio.push(audio);
+    this.pendingAudioBytes += audio.byteLength;
+  }
+
+  private clearPendingAudio(): void {
+    this.pendingAudio = [];
+    this.pendingAudioBytes = 0;
+  }
+
+  private resetTerminalState(): void {
+    this.clearPendingAudio();
+    this.resetRealtimeSessionState();
+  }
+
   private failConnection(
     error: OpenAIRealtimeMalformedAudioError,
     ws: WebSocket,
@@ -1601,7 +1631,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     }
     this.terminalError = error;
     this.lifecycle.failure(connection);
-    this.resetRealtimeSessionState();
+    this.resetTerminalState();
     try {
       this.config.onError?.(error);
     } finally {
@@ -1621,6 +1651,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     if (!terminalOutcome) {
       return;
     }
+    this.resetTerminalState();
     this.config.onClose?.(terminalOutcome);
   }
 

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -1263,7 +1263,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
       case "session.created":
         return;
 
-      case "session.updated":
+      case "session.updated": {
         if (!this.lifecycle.ready(connection)) {
           return;
         }
@@ -1285,6 +1285,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           this.sendAudio(chunk);
         }
         return;
+      }
 
       case "response.created":
         this.responseActive = true;


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where realtime voice sessions could retain a large amount of audio while the OpenAI connection was still starting, and could replay audio queued before or after a terminal close when the same bridge was explicitly connected again.

## Why This Change Was Made

Both the GA Realtime and GPT-Live backend bridges now retain at most 1 MiB across their existing 320-chunk pre-ready queues. Terminal close and failure paths clear provider-owned audio and session state immediately, and audio arriving after terminal close is ignored until an explicit reconnect starts a new lifecycle.

The limits are internal and preserve the existing drop-newest behavior. No provider, config, protocol, or environment-variable surface changes.

## User Impact

Realtime voice startup has bounded per-session audio ownership, close remains idempotent, and an explicitly reused bridge cannot send stale audio into a later session.

## Evidence

- Blacksmith Testbox: `pnpm test:serial extensions/openai/realtime-voice-provider.test.ts extensions/openai/realtime-gpt-live-bridge.test.ts` — 98 passed.
- Blacksmith Testbox: `pnpm check:changed` — passed, including extension and test typecheck plus changed-file lint.
- Live OpenAI key: speech voice listing/TTS, synthesized-audio transcription, realtime STT startup, and streaming realtime STT — 4 passed.
- Live OpenAI key: backend GA Realtime bridge reached `session.created` and `session.updated`; browser WebRTC negotiated an audio answer, applied the remote description, and reached `connected` on `gpt-realtime-2.1`.
- Regression coverage verifies the 1 MiB aggregate budget independently for GA Realtime and GPT-Live.
- Regression coverage closes each bridge before readiness, sends more audio after close, reconnects, and verifies no stale audio is emitted.
- Autoreview on head `34373a00d26`: no accepted/actionable findings, confidence 0.83.

