### PR TITLE
fix(whatsapp): stop retrying transport-level timed-out sends

### DIFF
--- a/extensions/whatsapp/src/inbound/socket-session.ts
+++ b/extensions/whatsapp/src/inbound/socket-session.ts
@@ -96,7 +96,17 @@ function isRetryableSendDisconnectError(error: unknown): boolean {
   if (isWhatsAppSocketOperationTimeoutError(error)) {
     return false;
   }
-  return /closed|reset|timed\s*out|disconnect|no active socket/i.test(formatError(error));
+  // A timeout does not prove the socket died and may have occurred after the
+  // message was delivered, so it is not retried; this matches
+  // shouldClearSocketRefAfterSendFailure, which also excludes it. A timeout in
+  // the text wins over a disconnect keyword (e.g. "timed out after socket
+  // closed") to avoid replaying a possibly-delivered message. Covers "timed
+  // out", "timeout", "TimeoutError", and ETIMEDOUT spellings.
+  const text = formatError(error);
+  if (/timed\s*out|timeout|ETIMEDOUT/i.test(text)) {
+    return false;
+  }
+  return /closed|reset|disconnect|no active socket/i.test(text);
 }
 
 function shouldClearSocketRefAfterSendFailure(error: unknown): boolean {

--- a/extensions/whatsapp/src/outbound-retry.test.ts
+++ b/extensions/whatsapp/src/outbound-retry.test.ts
@@ -94,6 +94,48 @@ describe("sendWhatsAppOutboundWithRetry", () => {
     expect(onRetry).not.toHaveBeenCalled();
   });
 
+  it.each([
+    new Error("request timed out"),
+    new Error("Baileys send timed out"),
+    { code: "ETIMEDOUT", message: "operation timed out" },
+    new Error("TimeoutError: socket disconnected"),
+    new Error("timeout of 10000ms exceeded"),
+  ])("does not retry a transport-level timed-out error (may have delivered)", async (error) => {
+    // A generic "timed out" (not the local WhatsAppSocketOperationTimeoutError
+    // wrapper) can occur after the message reached WhatsApp, so it must not be
+    // retried — that would replay a non-idempotent send and duplicate the message.
+    const send = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+    const onRetry = vi.fn();
+
+    const failure = await runWithFakeTimers(() =>
+      sendWhatsAppOutboundWithRetry({ send, onRetry }).catch((caught: unknown) => caught),
+    );
+
+    expect(failure).toBe(error);
+    expect(send).toHaveBeenCalledOnce();
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    new Error("request timed out after socket closed"),
+    new Error("send timed out: disconnected"),
+    { code: "ETIMEDOUT", message: "operation timed out, connection reset" },
+  ])("does not retry a mixed timeout+disconnect error (timeout wins)", async (error) => {
+    // A message that contains both a timeout and a disconnect keyword still
+    // carries ambiguous-delivery risk, so the timeout exclusion takes precedence
+    // over the disconnect pattern and the send is not retried.
+    const send = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+    const onRetry = vi.fn();
+
+    const failure = await runWithFakeTimers(() =>
+      sendWhatsAppOutboundWithRetry({ send, onRetry }).catch((caught: unknown) => caught),
+    );
+
+    expect(failure).toBe(error);
+    expect(send).toHaveBeenCalledOnce();
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
   it("preserves attempts, delays, callback fields, and terminal error identity", async () => {
     const firstError = {
       output: {

--- a/extensions/whatsapp/src/outbound-retry.ts
+++ b/extensions/whatsapp/src/outbound-retry.ts
@@ -7,7 +7,13 @@ import { isWhatsAppSocketOperationTimeoutError } from "./socket-timing.js";
 const WHATSAPP_OUTBOUND_MAX_ATTEMPTS = 3;
 const WHATSAPP_OUTBOUND_MIN_DELAY_MS = 500;
 const WHATSAPP_OUTBOUND_MAX_DELAY_MS = 1_000;
-const WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN = /closed|reset|timed\s*out|disconnect/i;
+const WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN = /closed|reset|disconnect/i;
+// A transport-level timeout can occur after the message reached WhatsApp, so any
+// error whose text mentions a timeout is treated as ambiguous-delivery and not
+// retried — even if it also mentions a disconnect keyword (e.g. "request timed
+// out after socket closed"), because the timeout ambiguity takes precedence.
+// Covers the common spellings: "timed out", "timeout", "TimeoutError", ETIMEDOUT.
+const WHATSAPP_OUTBOUND_TIMEOUT_ERROR_PATTERN = /timed\s*out|timeout|ETIMEDOUT/i;
 
 class WhatsAppOutboundRetryError extends Error {
   constructor(readonly original: unknown) {
@@ -17,11 +23,20 @@ class WhatsAppOutboundRetryError extends Error {
 
 function isRetryableWhatsAppOutboundError(error: unknown): boolean {
   // Outbound sends surface direct failures; inspecting wrappers or causes can
-  // replay a non-idempotent send. A direct local timeout may have delivered it.
+  // replay a non-idempotent send. A direct local timeout may have delivered it,
+  // and a transport-layer "timed out" (Baileys/axios) can occur after the
+  // message reached WhatsApp, so neither is retried. Only errors that prove the
+  // socket died (closed/reset/disconnect) are retried, matching
+  // shouldClearSocketRefAfterSendFailure. A timeout in the text wins over a
+  // disconnect keyword to avoid replaying a possibly-delivered message.
   if (isChannelPartialDeliveryError(error) || isWhatsAppSocketOperationTimeoutError(error)) {
     return false;
   }
-  return WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN.test(formatError(error));
+  const text = formatError(error);
+  if (WHATSAPP_OUTBOUND_TIMEOUT_ERROR_PATTERN.test(text)) {
+    return false;
+  }
+  return WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN.test(text);
 }
 
 type WhatsAppOutboundRetryInfo = {


### PR DESCRIPTION
## What Problem This Solves

WhatsApp outbound and send-disconnect retry predicates matched `timed out` in the error text, but a transport-level timeout (Baileys/axios) can occur **after** the message already reached WhatsApp. Retrying a non-idempotent send then duplicates the delivered message — the original duplicate-delivery symptom (#111549) that the local `WhatsAppSocketOperationTimeoutError` exclusion only half-fixed. Any non-local "timed out" / "timeout" / `ETIMEDOUT` error was still retried.

## Why This Change Was Made

Drop the timeout spellings from `WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN` and the send-disconnect retry predicate, and explicitly reject any error whose text mentions a timeout (`timed out`, `timeout`, `TimeoutError`, `ETIMEDOUT`) **before** applying the disconnect pattern. This makes a timeout exclusion take precedence over a disconnect keyword, so a mixed message like `"timed out after socket closed"` or `"TimeoutError: socket disconnected"` still does not retry. Both retry predicates now align with `shouldClearSocketRefAfterSendFailure`, which already excludes timeouts because a timeout does not prove the socket died. Only errors that prove the socket is gone (`closed`/`reset`/`disconnect`) are retried.

## User Impact

WhatsApp users no longer receive duplicate messages when an outbound send hits a transport-level timeout (network波动 / WhatsApp server slow response). Previously the retry replayed a possibly-delivered non-idempotent send. Retries still happen for genuine socket-death errors (`closed`/`reset`/`disconnect`), so real disconnect recovery is unchanged.

## Evidence

### Focused tests — 14 passed

`node scripts/run-vitest.mjs extensions/whatsapp/src/outbound-retry` → 14 passed. Added:
- `does not retry a transport-level timed-out error (may have delivered)` — covers `request timed out`, `Baileys send timed out`, `ETIMEDOUT`, `TimeoutError: socket disconnected`, `timeout of 10000ms exceeded`.
- `does not retry a mixed timeout+disconnect error (timeout wins)` — covers `timed out after socket closed`, `timed out: disconnected`, `ETIMEDOUT ... connection reset`.

The existing `retries a directly retryable error` (closed/ECONNRESET) and `does not retry a direct unknown-delivery socket timeout` tests pass unchanged.

### Autoreview

`codex` (gpt-5.6-sol, high) on the branch diff vs `upstream/main`: clean, no accepted/actionable findings (`overall: patch is correct`). TruffleHog clean.

### Surface changed

- `extensions/whatsapp/src/outbound-retry.ts` — `WHATSAPP_RETRYABLE_OUTBOUND_ERROR_PATTERN` drops `timed\s*out`; new `WHATSAPP_OUTBOUND_TIMEOUT_ERROR_PATTERN` (`timed out|timeout|ETIMEDOUT`) checked before the retry pattern.
- `extensions/whatsapp/src/inbound/socket-session.ts` — `isRetryableSendDisconnectError` applies the same timeout-precedence guard.
- `extensions/whatsapp/src/outbound-retry.test.ts` — new parametrized tests for timeout-only and mixed timeout+disconnect errors.

### Not tested

No live WhatsApp transport was driven; the tests cover the retry-predicate decision with representative error shapes. The predicate contract (timeout = ambiguous delivery, do not replay) is the unit under test.

### Proof scope (honest gap)

No live WhatsApp/Baileys transport run is included: this environment has no WhatsApp account credentials, so a real send/retry round-trip against the Baileys socket cannot be driven. The evidence is the deterministic predicate contract: 14 focused tests cover the timeout-only, mixed timeout+disconnect (timeout wins), and genuine closed/reset/disconnect (retried) cases, plus the existing local-socket-timeout test. The retry predicate is a pure text-classification decision over `formatError`, so the unit tests exercise the exact production decision path; a live transport would only confirm the same predicate fires on real Baileys error shapes.