### PR TITLE
fix(qa): complete images when generation tool is unavailable

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
@@ -68,7 +68,8 @@ export function buildAssistantText(
   scenarioState: MockScenarioState,
 ) {
   const prompt = extractLastUserText(input);
-  const completedImageMediaPath = readCompletedImageGenerationMediaPath(prompt);
+  const latestRawUserText = extractAllUserTexts(input).at(-1) ?? "";
+  const completedImageMediaPath = readCompletedImageGenerationMediaPath(latestRawUserText);
   if (completedImageMediaPath) {
     return `Protocol note: generated the QA lighthouse image successfully.\nMEDIA:${completedImageMediaPath}`;
   }

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -4176,20 +4176,46 @@ describe("qa mock openai server", () => {
 
   it("completes an image without replaying a tool unavailable to the completion turn", async () => {
     const server = await startMockServer();
+    const prompt = "Image generation check: generate a QA lighthouse image.";
+    const imagePlan = await expectResponsesJson<unknown>(server, {
+      stream: false,
+      tools: [IMAGE_GENERATE_TOOL],
+      input: [makeUserInput(prompt)],
+    });
+    const imageCall = outputToolCall(imagePlan, "image_generate");
+    const callId = outputToolCallId(imageCall, "call_mock_image_generate_unavailable");
+    const completionEvent = [
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+      "OpenClaw runtime context (internal):",
+      "",
+      "[Internal task completion event]",
+      "source: image_generation",
+      "task: A QA lighthouse on a dark sea with a tiny protocol droid silhouette.",
+      "status: completed successfully",
+      "Generated media:",
+      "MEDIA:/tmp/qa-lighthouse.png",
+      "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+    ].join("\n");
     const completion = await expectResponsesJson<unknown>(server, {
       stream: false,
       tools: [MESSAGE_TOOL],
       input: [
-        makeUserInput("Image generation check: generate a QA lighthouse image."),
-        makeUserInput(
-          [
-            "[Internal task completion event]",
-            "source: image_generation",
-            "status: completed successfully",
-            "Generated media:",
-            "MEDIA:/tmp/qa-lighthouse.png",
-          ].join("\n"),
-        ),
+        makeUserInput(prompt),
+        {
+          type: "function_call",
+          name: "image_generate",
+          call_id: callId,
+          arguments: String(imageCall.arguments),
+        },
+        {
+          type: "function_call_output",
+          call_id: callId,
+          output: JSON.stringify({
+            content: [{ type: "text", text: "Background image generation started." }],
+            details: { async: true, status: "started" },
+          }),
+        },
+        makeUserInput(completionEvent),
       ],
     });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the QA mock provider could miss a completed background image generation when the runtime delivered that completion in its internal context carrier. The mock would then fall back to the earlier user prompt and try to call `image_generate` again even though that tool was unavailable on the completion turn.

## Why This Change Was Made

Completion recognition now reads only the latest raw user turn, which includes the internal runtime carrier, while ordinary prompt selection continues to skip that carrier. This keeps completion handling current-turn scoped and preserves the existing protection against replaying historical completion events.

## User Impact

No production runtime behavior changes. Release and QA image-generation scenarios now finish reliably after an asynchronous completion instead of attempting an unavailable duplicate tool call.

## Evidence

- Blacksmith Testbox `tbx_01kyrnjx0n2yt3fjgxekkcxmw1`: `pnpm test extensions/qa-lab/src/providers/mock-openai/server.test.ts` — 159/159 tests passed.
- Regression models the initial image tool call, its async-started output, the internal completion carrier, and a completion turn where only the message tool is available.
- The after-fix mock-server completion turn produced no `image_generate` function call and returned exactly:

  ```text
  Protocol note: generated the QA lighthouse image successfully.
  MEDIA:/tmp/qa-lighthouse.png
  ```

- Existing historical-completion regression remains in the same focused suite.
- Maintainer contract review confirmed `extractAllUserTexts(input).at(-1)` includes the current internal carrier, while `extractLastUserText(input)` deliberately retains the prior non-carrier prompt. Inspecting only the latest raw turn preserves the historical non-replay invariant.
- Autoreview: clean, no accepted or actionable findings.
