### PR TITLE
fix(gateway): keep MCP loopback identity stable across in-process restarts

### DIFF
--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -160,13 +160,45 @@ function createRequestAbortSignal(req: IncomingMessage, res: ServerResponse) {
   };
 }
 
+type StickyMcpLoopbackIdentity = {
+  port: number;
+  ownerToken: string;
+  nonOwnerToken: string;
+};
+
+let stickyMcpLoopbackIdentityState: StickyMcpLoopbackIdentity | undefined;
+
+/**
+ * Loopback identity (port + bearer tokens) is reused across server generations
+ * within one gateway process. CLI runs freeze the loopback URL and bearer into
+ * per-run MCP config files at prepare time; regenerating either during an
+ * in-process gateway restart strands every live CLI session on a dead port
+ * with an invalid credential ("Unable to connect" for the rest of the run).
+ * OPENCLAW_MCP_LOOPBACK_PORT optionally pins the port across hard restarts.
+ */
+function resolveStickyMcpLoopbackIdentity(): StickyMcpLoopbackIdentity {
+  if (!stickyMcpLoopbackIdentityState) {
+    const envPort = Number.parseInt(process.env.OPENCLAW_MCP_LOOPBACK_PORT ?? "", 10);
+    stickyMcpLoopbackIdentityState = {
+      port: Number.isInteger(envPort) && envPort > 0 && envPort < 65536 ? envPort : 0,
+      ownerToken: crypto.randomBytes(32).toString("hex"),
+      nonOwnerToken: crypto.randomBytes(32).toString("hex"),
+    };
+  }
+  return stickyMcpLoopbackIdentityState;
+}
+
 /** Starts a new MCP loopback HTTP server and registers its bearer tokens. */
 async function startMcpLoopbackServer(port = 0): Promise<{
   port: number;
   close: () => Promise<void>;
 }> {
-  const ownerToken = crypto.randomBytes(32).toString("hex");
-  const nonOwnerToken = crypto.randomBytes(32).toString("hex");
+  const stickyIdentity = resolveStickyMcpLoopbackIdentity();
+  const ownerToken = stickyIdentity.ownerToken;
+  const nonOwnerToken = stickyIdentity.nonOwnerToken;
+  if (!port) {
+    port = stickyIdentity.port;
+  }
   const toolCache = new McpLoopbackToolCache();
   // GET notification streams are intentionally long-lived; shutdown must end
   // them itself before waiting for httpServer.close() to drain active responses.
@@ -461,13 +493,24 @@ async function startMcpLoopbackServer(port = 0): Promise<{
     })();
   });
 
-  await new Promise<void>((resolve, reject) => {
-    httpServer.once("error", reject);
-    httpServer.listen(port, "127.0.0.1", () => {
-      httpServer.removeListener("error", reject);
-      resolve();
+  const listenLoopback = (listenPort: number) =>
+    new Promise<void>((resolve, reject) => {
+      httpServer.once("error", reject);
+      httpServer.listen(listenPort, "127.0.0.1", () => {
+        httpServer.removeListener("error", reject);
+        resolve();
+      });
     });
-  });
+  try {
+    await listenLoopback(port);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    if (port && code === "EADDRINUSE") {
+      await listenLoopback(0);
+    } else {
+      throw error;
+    }
+  }
 
   const address = httpServer.address();
   if (!address || typeof address === "string") {
@@ -475,6 +518,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
   }
   // Register tokens only after the TCP listener is live so clients never learn
   // a bearer token for a server that failed to bind.
+  stickyIdentity.port = address.port;
   setActiveMcpLoopbackRuntime({ port: address.port, ownerToken, nonOwnerToken });
   logDebug(`mcp loopback listening on 127.0.0.1:${address.port}`);
 


### PR DESCRIPTION
Fixes #116235

### Problem
The loopback MCP server (`src/gateway/mcp-http.ts`) regenerates a random port and fresh bearer tokens each time it starts. Per-run MCP config freezes `{url, bearer}` at prepare time, so any in-process gateway restart strands every live CLI session: all `mcp__openclaw__*` calls fail client-side ("Unable to connect") for the rest of the run while the gateway looks healthy. With concurrent multi-agent traffic this is fleet-wide on every config apply.

### Change
- `resolveStickyMcpLoopbackIdentity()`: one `{port, ownerToken, nonOwnerToken}` per gateway process, reused by every server generation.
- Optional `OPENCLAW_MCP_LOOPBACK_PORT` env pin (also survives hard restarts; without it, the first ephemeral bind becomes the process-lifetime port).
- `EADDRINUSE` on the preferred port falls back to an ephemeral bind, then adopts the actually-bound port as sticky.

Stranded sessions self-heal on their next tool call (streamable HTTP reconnects per request; port and bearer stay valid). No behavior change for single-generation lifetimes; token scope is unchanged (loopback-only, same process trust domain).

### Validation
Deployed as a dist-level equivalent on a production gateway (2026.7.1-2, ~36 concurrent agents): reproduced the stranding live pre-patch; post-patch a mid-session server regeneration rebound to the same port and the session's tools kept working. Happy to add a unit test (ensure → close → ensure returns identical port/bearers) if you can point me at the preferred harness in `mcp-http.test.ts`.