### PR TITLE
fix(exec): inherit tools.exec into new dashboard session defaults

### DIFF
--- a/src/agents/cli-runner/mcp-grant-context.test.ts
+++ b/src/agents/cli-runner/mcp-grant-context.test.ts
@@ -67,3 +67,27 @@ describe("buildCliMcpGrantContext source-reply authority", () => {
     expect(buildGrant(overrides as Partial<RunCliAgentParams>).sourceReplyOnly).toBeUndefined();
   });
 });
+
+describe("buildCliMcpGrantContext exec overrides", () => {
+  it("carries execOverrides.mode across the CLI loopback boundary (#112376)", () => {
+    const grant = buildGrant({
+      execOverrides: {
+        host: "gateway",
+        mode: "auto",
+        security: "allowlist",
+        ask: "on-miss",
+      },
+    });
+
+    expect(grant.execOverrides).toEqual({
+      host: "gateway",
+      mode: "auto",
+      security: "allowlist",
+      ask: "on-miss",
+    });
+  });
+
+  it("omits mode from the grant when no exec overrides are resolved", () => {
+    expect(buildGrant({ execOverrides: undefined }).execOverrides).toBeUndefined();
+  });
+});

--- a/src/agents/cli-runner/mcp-grant-context.ts
+++ b/src/agents/cli-runner/mcp-grant-context.ts
@@ -29,6 +29,9 @@ function buildCliMcpExecOverrides(
   }
   const scopedOverrides = {
     ...(execOverrides.host !== undefined ? { host: execOverrides.host } : {}),
+    // Carry mode through the loopback grant so a configured mode:auto still
+    // enables auto-review once resolved on the Gateway side (#112376).
+    ...(execOverrides.mode !== undefined ? { mode: execOverrides.mode } : {}),
     ...(execOverrides.security !== undefined ? { security: execOverrides.security } : {}),
     ...(execOverrides.ask !== undefined ? { ask: execOverrides.ask } : {}),
     ...(execOverrides.node !== undefined ? { node: execOverrides.node } : {}),

--- a/src/agents/exec-defaults.test.ts
+++ b/src/agents/exec-defaults.test.ts
@@ -302,6 +302,31 @@ describe("resolveExecDefaults", () => {
     });
   });
 
+  it("carries a per-call execOverrides.mode through as the most specific policy layer (#112376)", () => {
+    // Mirrors the CLI loopback grant: only `mode` is forwarded (no explicit
+    // security/ask), so mode must still win over the configured deny policy
+    // instead of being silently dropped and leaving the stale deny/off pair.
+    expect(
+      resolveExecDefaults({
+        cfg: withDefaultAgent({
+          tools: {
+            exec: {
+              mode: "deny",
+            },
+          },
+        }),
+        execOverrides: {
+          mode: "auto",
+        },
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      mode: "auto",
+      security: "allowlist",
+      ask: "on-miss",
+    });
+  });
+
   it("uses the configured default agent for an unscoped session", () => {
     expect(
       resolveExecDefaults({

--- a/src/agents/exec-defaults.ts
+++ b/src/agents/exec-defaults.ts
@@ -40,7 +40,9 @@ type ResolvedExecConfig = {
   node?: string;
 };
 
-export type ExecPolicyOverrides = Omit<ResolvedExecConfig, "mode">;
+// Includes mode so a configured mode:auto (auto-review) is not flattened
+// away once it crosses the CLI loopback / MCP grant boundary (#112376).
+export type ExecPolicyOverrides = ResolvedExecConfig;
 
 // Layering keeps the most specific mode/security/ask while preserving policy
 // bounds from approvals and sandbox availability later in resolution.

--- a/src/auto-reply/reply/get-reply-directives.target-session.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.target-session.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   applyInlineDirectiveOverrides: vi.fn(),
   listAgentEntries: vi.fn(),
   resolveFastModeState: vi.fn(),
+  resolveConfigExecDefaults: vi.fn(),
   resolveReplyExecOverrides: vi.fn(),
   shouldHandleTextCommands: vi.fn(() => false),
 }));
@@ -235,6 +236,7 @@ vi.mock("./runtime-policy-session-key.js", () => ({
 }));
 
 vi.mock("./get-reply-exec-overrides.js", () => ({
+  resolveConfigExecDefaults: (...args: unknown[]) => mocks.resolveConfigExecDefaults(...args),
   resolveReplyExecOverrides: (...args: unknown[]) => mocks.resolveReplyExecOverrides(...args),
 }));
 
@@ -268,6 +270,7 @@ describe("resolveReplyDirectives", () => {
     mocks.applyInlineDirectiveOverrides.mockReset();
     mocks.listAgentEntries.mockReset();
     mocks.resolveFastModeState.mockReset();
+    mocks.resolveConfigExecDefaults.mockReset();
     mocks.resolveReplyExecOverrides.mockReset();
     mocks.shouldHandleTextCommands.mockReset().mockReturnValue(false);
 
@@ -295,6 +298,7 @@ describe("resolveReplyDirectives", () => {
       source: "session",
       fastAutoOnSeconds: 60,
     }));
+    mocks.resolveConfigExecDefaults.mockReturnValue(undefined);
     mocks.resolveReplyExecOverrides.mockReturnValue(undefined);
   });
 

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -46,7 +46,11 @@ import {
 } from "./get-reply-directive-aliases.js";
 import { applyInlineDirectiveOverrides } from "./get-reply-directives-apply.js";
 import { resolveReplyDirectiveRouting } from "./get-reply-directives-routing.js";
-import { type ReplyExecOverrides, resolveReplyExecOverrides } from "./get-reply-exec-overrides.js";
+import {
+  type ReplyExecOverrides,
+  resolveConfigExecDefaults,
+  resolveReplyExecOverrides,
+} from "./get-reply-exec-overrides.js";
 import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
 import { defaultGroupActivation, resolveGroupRequireMention } from "./groups.js";
 import {
@@ -599,7 +603,12 @@ export async function resolveReplyDirectives(params: {
   const execOverrides = resolveReplyExecOverrides({
     directives,
     sessionEntry: targetSessionEntry,
-    agentExecDefaults: agentEntry?.tools?.exec,
+    // New dashboard/WebChat sessions have no session exec fields; inherit canonical
+    // tools.exec via resolveExecToolConfig so reply policy matches coding tools (#112376).
+    agentExecDefaults: resolveConfigExecDefaults({
+      cfg,
+      agentId,
+    }),
   });
 
   return {

--- a/src/auto-reply/reply/get-reply-exec-overrides.test.ts
+++ b/src/auto-reply/reply/get-reply-exec-overrides.test.ts
@@ -1,8 +1,13 @@
 // Tests execution override directives passed through get-reply.
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { parseInlineSessionDirectives } from "./directive-handling.parse.js";
-import { type ReplyExecOverrides, resolveReplyExecOverrides } from "./get-reply-exec-overrides.js";
+import {
+  type ReplyExecOverrides,
+  resolveConfigExecDefaults,
+  resolveReplyExecOverrides,
+} from "./get-reply-exec-overrides.js";
 
 const AGENT_EXEC_DEFAULTS = {
   host: "node",
@@ -117,5 +122,110 @@ describe("reply exec overrides", () => {
       ask: undefined,
       node: "other-node",
     });
+  });
+
+  it("carries agentExecDefaults.mode into the resolved overrides when nothing else sets policy", () => {
+    expect(
+      resolveReplyExecOverrides({
+        directives: parseInlineSessionDirectives("run a command"),
+        sessionEntry: createSessionEntry(),
+        agentExecDefaults: {
+          host: "gateway",
+          mode: "auto",
+          security: "allowlist",
+          ask: "on-miss",
+        },
+      }),
+    ).toEqual({
+      host: "gateway",
+      mode: "auto",
+      security: "allowlist",
+      ask: "on-miss",
+    });
+  });
+
+  it("drops the config-derived mode once a session or inline security/ask override applies", () => {
+    expect(
+      resolveReplyExecOverrides({
+        directives: parseInlineSessionDirectives("run a command"),
+        sessionEntry: createSessionEntry({ execSecurity: "deny" }),
+        agentExecDefaults: {
+          host: "gateway",
+          mode: "auto",
+          security: "allowlist",
+          ask: "on-miss",
+        },
+      }),
+    ).toEqual({
+      host: "gateway",
+      security: "deny",
+      ask: "on-miss",
+    });
+  });
+});
+
+describe("resolveConfigExecDefaults", () => {
+  it("inherits the persistent global tools.exec policy for a fresh session (#112376)", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "full",
+          ask: "off",
+        },
+      },
+    };
+
+    expect(resolveConfigExecDefaults({ cfg })).toEqual({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      node: undefined,
+    });
+  });
+
+  it("lets a per-agent tools.exec override win over the global policy", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            tools: { exec: { security: "full", ask: "off" } },
+          },
+        ],
+      },
+      tools: {
+        exec: {
+          host: "gateway",
+          security: "deny",
+        },
+      },
+    };
+
+    const resolved = resolveConfigExecDefaults({ cfg, agentId: "main" });
+    expect(resolved?.security).toBe("full");
+    expect(resolved?.ask).toBe("off");
+  });
+
+  it("surfaces a configured exec mode alongside its derived security/ask", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        exec: {
+          mode: "auto",
+        },
+      },
+    };
+
+    expect(resolveConfigExecDefaults({ cfg })).toEqual({
+      host: undefined,
+      mode: "auto",
+      security: "allowlist",
+      ask: "on-miss",
+      node: undefined,
+    });
+  });
+
+  it("returns undefined when no exec policy is configured anywhere", () => {
+    expect(resolveConfigExecDefaults({ cfg: {} })).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/get-reply-exec-overrides.ts
+++ b/src/auto-reply/reply/get-reply-exec-overrides.ts
@@ -1,13 +1,40 @@
 /** Resolves effective exec-tool overrides for reply runs. */
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
+import { resolveExecToolConfig } from "../../agents/lazy-exec-tool.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 
 /** Exec defaults that can be overridden by inline directives or session state. */
 export type ReplyExecOverrides = Pick<
   ExecToolDefaults,
-  "host" | "security" | "ask" | "node" | "nodeCwd"
+  "host" | "mode" | "security" | "ask" | "node" | "nodeCwd"
 >;
+
+/**
+ * Project canonical `tools.exec` resolution into reply-session defaults (#112376).
+ *
+ * New Dashboard/WebChat sessions have no session-level exec fields yet, so the
+ * previous `agentEntry?.tools?.exec` lookup silently dropped the global
+ * `tools.exec` layer and any policy-file layering. Reusing `resolveExecToolConfig`
+ * keeps fresh sessions aligned with the same precedence coding tools already use.
+ * `nodeCwd` is intentionally left out here: it is session/runtime-scoped only and
+ * must not be seeded from persistent config.
+ */
+export function resolveConfigExecDefaults(params: {
+  cfg?: OpenClawConfig;
+  agentId?: string;
+}): ReplyExecOverrides | undefined {
+  const execConfig = resolveExecToolConfig({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+  const { host, mode, security, ask, node } = execConfig;
+  if (!host && !mode && !security && !ask && !node) {
+    return undefined;
+  }
+  return { host, ...(mode ? { mode } : {}), security, ask, node };
+}
 
 /** Resolves effective exec defaults for a reply run. */
 export function resolveReplyExecOverrides(params: {
@@ -19,6 +46,16 @@ export function resolveReplyExecOverrides(params: {
     params.directives.execHost ??
     (params.sessionEntry?.execHost as ReplyExecOverrides["host"]) ??
     params.agentExecDefaults?.host;
+  // Inline /exec directives and legacy session fields only ever carry
+  // security/ask, not mode. Once either layer supplies an explicit
+  // security/ask override, drop the config-derived mode rather than let a
+  // stale mode (e.g. mode:auto) mismatch the now-overridden policy.
+  const hasSessionOrInlinePolicy =
+    params.directives.execSecurity !== undefined ||
+    params.directives.execAsk !== undefined ||
+    params.sessionEntry?.execSecurity !== undefined ||
+    params.sessionEntry?.execAsk !== undefined;
+  const mode = hasSessionOrInlinePolicy ? undefined : params.agentExecDefaults?.mode;
   const security =
     params.directives.execSecurity ??
     (params.sessionEntry?.execSecurity as ReplyExecOverrides["security"]) ??
@@ -31,8 +68,15 @@ export function resolveReplyExecOverrides(params: {
     params.directives.execNode ?? params.sessionEntry?.execNode ?? params.agentExecDefaults?.node;
   const nodeCwd =
     node && node === params.sessionEntry?.execNode ? params.sessionEntry.execCwd : undefined;
-  if (!host && !security && !ask && !node && !nodeCwd) {
+  if (!host && !mode && !security && !ask && !node && !nodeCwd) {
     return undefined;
   }
-  return { host, security, ask, node, ...(nodeCwd ? { nodeCwd } : {}) };
+  return {
+    host,
+    ...(mode ? { mode } : {}),
+    security,
+    ask,
+    node,
+    ...(nodeCwd ? { nodeCwd } : {}),
+  };
 }

--- a/src/auto-reply/reply/get-reply-run-helpers.ts
+++ b/src/auto-reply/reply/get-reply-run-helpers.ts
@@ -242,6 +242,9 @@ export function buildExecOverridePromptHint(params: {
   }
   const parts = [
     exec?.host ? `host=${exec.host}` : undefined,
+    // Keep mode visible so mode:auto (auto-review) is not mistaken for a plain
+    // allowlist/on-miss pair by the model (#112376).
+    exec?.mode ? `mode=${exec.mode}` : undefined,
     exec?.security ? `security=${exec.security}` : undefined,
     exec?.ask ? `ask=${exec.ask}` : undefined,
     exec?.node ? `node=${exec.node}` : undefined,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -405,6 +405,23 @@ describe("runPreparedReply media-only handling", () => {
     expect(prompt).toContain("Do not assume a prior denial still applies");
   });
 
+  it("includes mode:auto in the current-session exec prompt hint (#112376)", async () => {
+    await runPrepared({
+      execOverrides: {
+        host: "gateway",
+        mode: "auto",
+        security: "allowlist",
+        ask: "on-miss",
+      },
+      resolvedElevatedLevel: "off",
+    });
+
+    const prompt = requireRunReplyAgentCall().followupRun.run.extraSystemPromptStatic;
+    expect(prompt).toContain(
+      "Current session exec defaults: host=gateway mode=auto security=allowlist ask=on-miss.",
+    );
+  });
+
   it("preserves parent session provenance in queued runs", async () => {
     const spawnedBy = "agent:main:telegram:group:parent";
 

--- a/src/auto-reply/reply/get-reply-run.types.ts
+++ b/src/auto-reply/reply/get-reply-run.types.ts
@@ -37,7 +37,7 @@ export type InternalGetReplyOptions = BaseInternalGetReplyOptions & {
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 export type ExecOverrides = Pick<
   ExecToolDefaults,
-  "host" | "security" | "ask" | "node" | "nodeCwd"
+  "host" | "mode" | "security" | "ask" | "node" | "nodeCwd"
 >;
 
 export type RunPreparedReplyParams = {

--- a/src/gateway/mcp-http.runtime.test.ts
+++ b/src/gateway/mcp-http.runtime.test.ts
@@ -201,6 +201,28 @@ describe("McpLoopbackToolCache", () => {
     expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(3);
   });
 
+  it("does not share cache rows across different exec modes (#112376)", () => {
+    // ask and auto both resolve to security=allowlist/ask=on-miss but differ
+    // on autoReview, so a shared cache row would serve the wrong tool
+    // closure to one of the two modes.
+    const cache = new McpLoopbackToolCache();
+    const cfg = {} as OpenClawConfig;
+
+    cache.resolve(
+      scopeParams({ cfg, execOverrides: { mode: "ask", security: "allowlist", ask: "on-miss" } }),
+    );
+    cache.resolve(
+      scopeParams({ cfg, execOverrides: { mode: "auto", security: "allowlist", ask: "on-miss" } }),
+    );
+    expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
+
+    // Same mode reuses the cached row.
+    cache.resolve(
+      scopeParams({ cfg, execOverrides: { mode: "ask", security: "allowlist", ask: "on-miss" } }),
+    );
+    expect(resolveGatewayScopedTools).toHaveBeenCalledTimes(2);
+  });
+
   it("evicts only the revoked grant's cached tool closures", () => {
     const cache = new McpLoopbackToolCache();
     const cfg = {} as OpenClawConfig;

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -211,6 +211,10 @@ export class McpLoopbackToolCache {
       params.execSession?.execAsk ?? "",
       params.execSession?.execNode ?? "",
       params.execOverrides?.host ?? "",
+      // ask and auto both derive security=allowlist/ask=on-miss but differ on
+      // autoReview, so mode must stay in the key to avoid serving one mode's
+      // cached tool closure to the other (#112376).
+      params.execOverrides?.mode ?? "",
       params.execOverrides?.security ?? "",
       params.execOverrides?.ask ?? "",
       params.execOverrides?.node ?? "",


### PR DESCRIPTION
## Summary
- New WebChat/Dashboard sessions do not seed execSecurity/execAsk, so reply-time overrides previously skipped persistent tools.exec and fell through toward deny.
- Seed reply defaults from cfg.tools.exec + agent tools.exec, preserving mode (including mode:auto) and nodeCwd.
- Carry mode + nodeCwd through CLI loopback grants and gateway tool construction/cache keys.
- Fixes https://github.com/openclaw/openclaw/issues/112376

## Test plan
- [x] get-reply-exec-overrides + mcp-grant-context tests (17 passed)
- [x] Exact-head proof: mode=auto preserved; CLI grant includes nodeCwd (see latest proof comment)