### PR TITLE
fix(plugins): plugin install survives pnpm-only overrides

### DIFF
--- a/src/infra/npm-managed-root.test.ts
+++ b/src/infra/npm-managed-root.test.ts
@@ -269,7 +269,7 @@ describe("managed npm root", () => {
       npmRoot,
       packageName: "@openclaw/feishu",
       dependencySpec: "2026.5.4",
-      omitUnsupportedManagedOverrides: true,
+      overrideOmissions: { npmAliases: true },
       managedOverrides: {
         axios: "1.18.0",
         "node-domexception": "npm:@nolyfill/domexception@1.0.28",

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -184,15 +184,31 @@ function isUnsupportedManagedNpmOverride(value: unknown): boolean {
   return typeof value === "string" && value.trim().startsWith("npm:");
 }
 
-function filterUnsupportedManagedNpmRootOverrides(value: unknown): Record<string, unknown> {
+function isPnpmParentChildOverrideSelector(key: string): boolean {
+  // Match pnpm's parse-overrides delimiter without confusing npm ranges such as pkg@>1.
+  return /[^ |@]>/u.test(key);
+}
+
+export type ManagedNpmOverrideOmissions = {
+  npmAliases?: boolean;
+  pnpmParentChildSelectors?: boolean;
+};
+
+function filterUnsupportedManagedNpmRootOverrides(
+  value: unknown,
+  omissions: ManagedNpmOverrideOmissions,
+): Record<string, unknown> {
   const overrides = readOverrideRecord(value);
   const filtered: Record<string, unknown> = {};
   for (const [key, raw] of Object.entries(overrides)) {
-    if (isUnsupportedManagedNpmOverride(raw)) {
+    if (
+      (omissions.pnpmParentChildSelectors && isPnpmParentChildOverrideSelector(key)) ||
+      (omissions.npmAliases && isUnsupportedManagedNpmOverride(raw))
+    ) {
       continue;
     }
     if (isRecord(raw)) {
-      const nested = filterUnsupportedManagedNpmRootOverrides(raw);
+      const nested = filterUnsupportedManagedNpmRootOverrides(raw, omissions);
       if (Object.keys(nested).length > 0) {
         filtered[key] = nested;
       }
@@ -337,14 +353,14 @@ export async function upsertManagedNpmRootDependency(params: {
   packageName: string;
   dependencySpec: string;
   managedOverrides?: Record<string, unknown>;
-  omitUnsupportedManagedOverrides?: boolean;
+  overrideOmissions?: ManagedNpmOverrideOmissions;
 }): Promise<void> {
   await fs.mkdir(params.npmRoot, { recursive: true });
   const manifestPath = path.join(params.npmRoot, "package.json");
   const manifest = await readManagedNpmRootManifest(manifestPath);
   const dependencies = readDependencyRecord(manifest.dependencies);
-  const managedOverrides = params.omitUnsupportedManagedOverrides
-    ? filterUnsupportedManagedNpmRootOverrides(params.managedOverrides)
+  const managedOverrides = params.overrideOmissions
+    ? filterUnsupportedManagedNpmRootOverrides(params.managedOverrides, params.overrideOmissions)
     : readOverrideRecord(params.managedOverrides);
   const nextDependencies = {
     ...dependencies,
@@ -881,7 +897,7 @@ export async function restoreManagedNpmRootPeerDependencySnapshot(params: {
 export async function syncManagedNpmRootPeerDependencies(params: {
   npmRoot: string;
   managedOverrides?: Record<string, unknown>;
-  omitUnsupportedManagedOverrides?: boolean;
+  overrideOmissions?: ManagedNpmOverrideOmissions;
   runCommand?: ManagedNpmRootRunCommand;
   timeoutMs?: number;
 }): Promise<boolean> {
@@ -917,8 +933,8 @@ export async function syncManagedNpmRootPeerDependencies(params: {
     }
   }
 
-  const managedOverrides = params.omitUnsupportedManagedOverrides
-    ? filterUnsupportedManagedNpmRootOverrides(params.managedOverrides)
+  const managedOverrides = params.overrideOmissions
+    ? filterUnsupportedManagedNpmRootOverrides(params.managedOverrides, params.overrideOmissions)
     : readOverrideRecord(params.managedOverrides);
   // Also catches the plan-failure fallback (stale pins reused) and alias overrides whose
   // lock-resolved version can never string-match the override spec.

--- a/src/plugins/install-managed-npm-state.ts
+++ b/src/plugins/install-managed-npm-state.ts
@@ -35,7 +35,7 @@ const MANAGED_NPM_PROJECT_REBUILD_ARTIFACTS = [
   "npm-shrinkwrap.json",
 ] as const;
 
-export type NpmManagedOverrideCompatibility = {
+type NpmManagedOverrideCompatibility = {
   npmAliases: boolean;
   pnpmParentChildSelectors: boolean;
 };

--- a/src/plugins/install-managed-npm-state.ts
+++ b/src/plugins/install-managed-npm-state.ts
@@ -35,11 +35,32 @@ const MANAGED_NPM_PROJECT_REBUILD_ARTIFACTS = [
   "npm-shrinkwrap.json",
 ] as const;
 
-export function isNpmAliasOverrideComparatorError(result: {
+export type NpmManagedOverrideCompatibility = {
+  npmAliases: boolean;
+  pnpmParentChildSelectors: boolean;
+};
+
+export function classifyNpmManagedOverrideCompatibilityError(result: {
   stdout: string;
   stderr: string;
-}): boolean {
-  return `${result.stderr}\n${result.stdout}`.includes("Invalid comparator: npm:");
+}): NpmManagedOverrideCompatibility | undefined {
+  const output = `${result.stderr}\n${result.stdout}`;
+  const selectorError =
+    output.includes("EINVALIDTAGNAME") ||
+    output.includes("EINVALIDPACKAGENAME") ||
+    output.includes("Override without name:");
+  const selectorFragments = [
+    ...output.matchAll(/"([^"]+)"/gu),
+    ...output.matchAll(/Override without name: ([^\r\n]+)/gu),
+  ].flatMap((match) => match.slice(1));
+  const compatibility = {
+    npmAliases: output.includes("Invalid comparator: npm:"),
+    pnpmParentChildSelectors:
+      selectorError && selectorFragments.some((fragment) => /[^ |@]>/u.test(fragment)),
+  };
+  return compatibility.npmAliases || compatibility.pnpmParentChildSelectors
+    ? compatibility
+    : undefined;
 }
 
 export async function rollbackManagedNpmPluginInstall(params: {

--- a/src/plugins/install-managed-npm.ts
+++ b/src/plugins/install-managed-npm.ts
@@ -10,6 +10,7 @@ import {
   repairManagedNpmRootOpenClawPeer,
   syncManagedNpmRootPeerDependencies,
   upsertManagedNpmRootDependency,
+  type ManagedNpmOverrideOmissions,
   type ManagedNpmRootInstalledDependency,
 } from "../infra/npm-managed-root.js";
 import { installedPackageNeedsOpenClawPeerLinkRepair } from "../infra/package-update-utils.js";
@@ -27,7 +28,7 @@ import {
   formatManagedNpmProjectQuarantineArtifacts,
   formatNpmCommandFailureOutput,
   isManagedNpmProjectCorruptionInstallFailure,
-  isNpmAliasOverrideComparatorError,
+  classifyNpmManagedOverrideCompatibilityError,
   listManagedNpmRootPackageNames,
   listNewManagedNpmRootPackageDirs,
   quarantineManagedNpmProjectRebuildArtifacts,
@@ -242,7 +243,7 @@ export async function installPluginFromManagedNpmRoot(
       return null;
     };
     const syncManagedPeerDependenciesForInstall = async (options?: {
-      omitUnsupportedManagedOverrides?: boolean;
+      overrideOmissions?: ManagedNpmOverrideOmissions;
     }): Promise<{ ok: true; changed: boolean } | { ok: false; error: string }> => {
       try {
         return {
@@ -250,7 +251,7 @@ export async function installPluginFromManagedNpmRoot(
           changed: await syncManagedNpmRootPeerDependencies({
             npmRoot,
             managedOverrides,
-            omitUnsupportedManagedOverrides: options?.omitUnsupportedManagedOverrides,
+            overrideOmissions: options?.overrideOmissions,
             timeoutMs,
           }),
         };
@@ -261,17 +262,17 @@ export async function installPluginFromManagedNpmRoot(
         };
       }
     };
-    let omitUnsupportedManagedOverrides = false;
+    let overrideOmissions: ManagedNpmOverrideOmissions = {};
     const preInstallRootPackageNames = await listManagedNpmRootPackageNames(npmRoot);
     await upsertManagedNpmRootDependency({
       npmRoot,
       packageName: params.packageName,
       dependencySpec: prepared.dependencySpec,
       managedOverrides,
-      omitUnsupportedManagedOverrides,
+      overrideOmissions,
     });
     const initialPeerSync = await syncManagedPeerDependenciesForInstall({
-      omitUnsupportedManagedOverrides,
+      overrideOmissions,
     });
     if (!initialPeerSync.ok) {
       return await rollbackFailedManagedNpmInstall({ ok: false, error: initialPeerSync.error });
@@ -298,20 +299,34 @@ export async function installPluginFromManagedNpmRoot(
       }),
     };
     let install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
-    if (install.code !== 0 && isNpmAliasOverrideComparatorError(install)) {
+    let compatibility = classifyNpmManagedOverrideCompatibilityError(install);
+    while (install.code !== 0 && compatibility) {
+      const nextOverrideOmissions = {
+        npmAliases: Boolean(overrideOmissions.npmAliases || compatibility.npmAliases),
+        pnpmParentChildSelectors: Boolean(
+          overrideOmissions.pnpmParentChildSelectors || compatibility.pnpmParentChildSelectors,
+        ),
+      };
+      if (
+        nextOverrideOmissions.npmAliases === Boolean(overrideOmissions.npmAliases) &&
+        nextOverrideOmissions.pnpmParentChildSelectors ===
+          Boolean(overrideOmissions.pnpmParentChildSelectors)
+      ) {
+        break;
+      }
       logger.warn?.(
-        "npm rejected managed npm alias overrides; retrying plugin install without alias overrides for this npm version.",
+        "npm rejected managed npm overrides; retrying plugin install without npm-incompatible overrides for this npm version.",
       );
-      omitUnsupportedManagedOverrides = true;
+      overrideOmissions = nextOverrideOmissions;
       await upsertManagedNpmRootDependency({
         npmRoot,
         packageName: params.packageName,
         dependencySpec: prepared.dependencySpec,
         managedOverrides,
-        omitUnsupportedManagedOverrides: true,
+        overrideOmissions,
       });
       const aliasRetryPeerSync = await syncManagedPeerDependenciesForInstall({
-        omitUnsupportedManagedOverrides: true,
+        overrideOmissions,
       });
       if (!aliasRetryPeerSync.ok) {
         return await rollbackFailedManagedNpmInstall({
@@ -320,6 +335,7 @@ export async function installPluginFromManagedNpmRoot(
         });
       }
       install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
+      compatibility = classifyNpmManagedOverrideCompatibilityError(install);
     }
     if (!recovery && install.code !== 0 && isManagedNpmProjectCorruptionInstallFailure(install)) {
       const originalError = formatNpmCommandFailureOutput(install);
@@ -344,7 +360,7 @@ export async function installPluginFromManagedNpmRoot(
     let settledManagedPeerDependencies = false;
     for (let peerSyncPass = 0; peerSyncPass < 10; peerSyncPass += 1) {
       const peerSync = await syncManagedPeerDependenciesForInstall({
-        omitUnsupportedManagedOverrides,
+        overrideOmissions,
       });
       if (!peerSync.ok) {
         return await rollbackFailedManagedNpmInstall({ ok: false, error: peerSync.error });
@@ -364,7 +380,7 @@ export async function installPluginFromManagedNpmRoot(
     }
     if (!settledManagedPeerDependencies) {
       const peerSync = await syncManagedPeerDependenciesForInstall({
-        omitUnsupportedManagedOverrides,
+        overrideOmissions,
       });
       if (!peerSync.ok) {
         return await rollbackFailedManagedNpmInstall({ ok: false, error: peerSync.error });

--- a/src/plugins/install-managed-npm.ts
+++ b/src/plugins/install-managed-npm.ts
@@ -302,15 +302,15 @@ export async function installPluginFromManagedNpmRoot(
     let compatibility = classifyNpmManagedOverrideCompatibilityError(install);
     while (install.code !== 0 && compatibility) {
       const nextOverrideOmissions = {
-        npmAliases: Boolean(overrideOmissions.npmAliases || compatibility.npmAliases),
-        pnpmParentChildSelectors: Boolean(
-          overrideOmissions.pnpmParentChildSelectors || compatibility.pnpmParentChildSelectors,
-        ),
+        npmAliases: overrideOmissions.npmAliases === true || compatibility.npmAliases,
+        pnpmParentChildSelectors:
+          overrideOmissions.pnpmParentChildSelectors === true ||
+          compatibility.pnpmParentChildSelectors,
       };
       if (
-        nextOverrideOmissions.npmAliases === Boolean(overrideOmissions.npmAliases) &&
+        nextOverrideOmissions.npmAliases === (overrideOmissions.npmAliases === true) &&
         nextOverrideOmissions.pnpmParentChildSelectors ===
-          Boolean(overrideOmissions.pnpmParentChildSelectors)
+          (overrideOmissions.pnpmParentChildSelectors === true)
       ) {
         break;
       }

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -34,6 +34,8 @@ vi.resetModules();
 
 const { installPluginFromNpmPackArchive, installPluginFromNpmSpec, PLUGIN_INSTALL_ERROR_CODE } =
   await import("./install.js");
+const { classifyNpmManagedOverrideCompatibilityError } =
+  await import("./install-managed-npm-state.js");
 
 const suiteTempRootTracker = createSuiteTempRootTracker("openclaw-plugin-install-npm-spec");
 let previousNpmGlobalConfig: string | undefined;
@@ -731,6 +733,22 @@ beforeAll(async () => {
 });
 
 describe("installPluginFromNpmSpec", () => {
+  it.each([
+    "npm ERR! Invalid comparator: npm:@nolyfill/domexception@1.0.28",
+    'npm error code EINVALIDTAGNAME\nnpm error Invalid tag name "0.2.2>ip" of package "werift-ice@0.2.2>ip"',
+    "npm error Override without name: @scope/parent>child",
+    'npm error code EINVALIDPACKAGENAME\nnpm error Invalid package name "parent>" of package "parent>@scope/child"',
+  ])("detects npm-incompatible managed override errors", (stderr) => {
+    expect(classifyNpmManagedOverrideCompatibilityError({ stdout: "", stderr })).toBeDefined();
+  });
+
+  it.each([
+    'npm error code EINVALIDTAGNAME\nnpm error Invalid tag name "next" of package "pkg@next"',
+    'npm error code EINVALIDPACKAGENAME\nnpm error Invalid package name "bad name" of package "bad name@1"',
+  ])("ignores unrelated npm package validation errors", (stderr) => {
+    expect(classifyNpmManagedOverrideCompatibilityError({ stdout: "", stderr })).toBeUndefined();
+  });
+
   it("classifies npm metadata command failures", async () => {
     runCommandWithTimeoutMock.mockResolvedValue(failedSpawn("registry unavailable"));
 
@@ -2968,7 +2986,7 @@ describe("installPluginFromNpmSpec", () => {
     }
   });
 
-  it("retries without npm alias overrides when npm rejects alias comparators", async () => {
+  it("retries without each npm-incompatible override kind while preserving valid rules", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
     const hostRoot = suiteTempRootTracker.makeTempDir();
     fs.writeFileSync(
@@ -2988,6 +3006,8 @@ describe("installPluginFromNpmSpec", () => {
         "overrides:",
         "  axios: 1.18.0",
         '  node-domexception: "npm:@nolyfill/domexception@1.0.28"',
+        '  "range-target@>1": 2.0.0',
+        '  "werift-ice@0.2.2>ip": "npm:neoip@3.1.0"',
         "  nested:",
         '    alias: "npm:@scope/alias@1.0.0"',
         "    semver: 1.2.3",
@@ -3020,10 +3040,40 @@ describe("installPluginFromNpmSpec", () => {
             expect(manifest.overrides?.["node-domexception"]).toBe(
               "npm:@nolyfill/domexception@1.0.28",
             );
+            expect(manifest.overrides?.["range-target@>1"]).toBe("2.0.0");
+            expect(manifest.overrides?.["werift-ice@0.2.2>ip"]).toBe("npm:neoip@3.1.0");
             expect(manifest.openclaw?.managedOverrides).toEqual([
               "axios",
               "nested",
               "node-domexception",
+              "range-target@>1",
+              "werift-ice@0.2.2>ip",
+            ]);
+            return {
+              code: 1,
+              stdout: "",
+              stderr:
+                'npm error code EINVALIDTAGNAME\nnpm error Invalid tag name "0.2.2>ip" of package "werift-ice@0.2.2>ip"',
+              signal: null,
+              killed: false,
+              termination: "exit" as const,
+            };
+          }
+          if (installAttempts === 2) {
+            expect(manifest.overrides).toEqual({
+              axios: "1.18.0",
+              nested: {
+                alias: "npm:@scope/alias@1.0.0",
+                semver: "1.2.3",
+              },
+              "node-domexception": "npm:@nolyfill/domexception@1.0.28",
+              "range-target@>1": "2.0.0",
+            });
+            expect(manifest.openclaw?.managedOverrides).toEqual([
+              "axios",
+              "nested",
+              "node-domexception",
+              "range-target@>1",
             ]);
             return {
               code: 1,
@@ -3039,8 +3089,13 @@ describe("installPluginFromNpmSpec", () => {
             nested: {
               semver: "1.2.3",
             },
+            "range-target@>1": "2.0.0",
           });
-          expect(manifest.openclaw?.managedOverrides).toEqual(["axios", "nested"]);
+          expect(manifest.openclaw?.managedOverrides).toEqual([
+            "axios",
+            "nested",
+            "range-target@>1",
+          ]);
         }
         return await baseImplementation?.(argv, options);
       },
@@ -3054,10 +3109,11 @@ describe("installPluginFromNpmSpec", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(installAttempts).toBe(2);
-    expect(warnings).toContain(
-      "npm rejected managed npm alias overrides; retrying plugin install without alias overrides for this npm version.",
-    );
+    expect(installAttempts).toBe(3);
+    expect(warnings).toEqual([
+      "npm rejected managed npm overrides; retrying plugin install without npm-incompatible overrides for this npm version.",
+      "npm rejected managed npm overrides; retrying plugin install without npm-incompatible overrides for this npm version.",
+    ]);
   });
 
   it("keeps installed npm package output when dangerous-looking plugin code is present", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where installing or updating a plugin through the managed npm root could fail when OpenClaw's pnpm workspace overrides contained pnpm-only parent-child selectors or npm alias values unsupported by the host npm version.

## Why This Change Was Made

The installer now classifies the specific npm parser incompatibility and retries after removing only the unsupported override kind. Selector-key failures preserve valid npm aliases and semver ranges; alias-comparator failures preserve pnpm selector rules until npm itself rejects them. The fallback is bounded because each retry must add a previously unseen omission kind.

## User Impact

Plugin installs and updates no longer fail solely because the host npm cannot parse OpenClaw's pnpm-native override syntax, while compatible dependency overrides remain enforced.

## Evidence

- Exact-head CI `30516598496` passed all 69 jobs at `b8b00650b396990e17c5edf6b25444a230b3b785`.
- Blacksmith Testbox: `src/plugins/install.npm-spec.test.ts` — 69/69 passed.
- Blacksmith Testbox: `src/infra/npm-managed-root.test.ts` — 27/27 passed.
- `node scripts/check-changed.mjs -- src/infra/npm-managed-root.ts src/plugins/install-managed-npm-state.ts src/plugins/install-managed-npm.ts src/plugins/install.npm-spec.test.ts` — passed core/core-test typecheck, changed-file formatting/lint, plugin boundaries, dead-code and architecture guards.
- Codex autoreview (`--mode branch --base origin/main`) — clean, no accepted/actionable findings.
- Verified parser behavior directly against npm Arborist and `npm-package-arg`: versioned, unversioned, scoped parent-child selectors produce the covered `EINVALIDTAGNAME`, `EINVALIDPACKAGENAME`, and `Override without name` forms; `pkg@>1` remains valid npm semver syntax.

### Real managed-install proof

Ran the actual CLI install path on an ephemeral Linux Blacksmith Testbox with npm 11.16.0 and an isolated temporary `OPENCLAW_STATE_DIR`:

```text
$ pnpm openclaw plugins install npm:@openclaw/voice-call@2026.7.1 --force
Installing @openclaw/voice-call@2026.7.1 into <temporary-state>/npm/projects/openclaw-voice-call-d0fedeaf18…
npm rejected managed npm overrides; retrying plugin install without npm-incompatible overrides for this npm version.
Linked peerDependency "openclaw" -> <checkout>
Installed plugin: voice-call
Restart the gateway to load plugins.
```

The resulting managed-root manifest was inspected before cleanup:

```json
{
  "installedDependency": "2026.7.1",
  "selectorKeysRemaining": [],
  "preservedAliasOverrides": [
    "node-domexception=npm:@nolyfill/domexception@1.0.28",
    "request-promise=npm:@cypress/request-promise@5.0.0",
    "request=npm:@cypress/request@4.0.1"
  ],
  "managedOverrideCount": 31
}
```

`pnpm openclaw plugins list --json` then returned `"id": "voice-call"`. The isolated state directory and Testbox were removed after the successful run.
