### PR TITLE
fix(minimax): declare video input modality for MiniMax-M3

### DIFF
--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -134,7 +134,7 @@ Model refs follow the auth path: `minimax/<model>` for API-key setups, `minimax-
                 id: "MiniMax-M3",
                 name: "MiniMax M3",
                 reasoning: true,
-                input: ["text", "image"],
+                input: ["text", "image", "video"],
                 cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0 },
                 contextWindow: 1000000,
                 maxTokens: 131072,

--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -348,7 +348,7 @@ describe("minimax provider hooks", () => {
     expect(provider?.baseUrl).toBe("https://api.minimax.io/anthropic");
     const model = provider?.models.find((entry: { id?: string }) => entry.id === "MiniMax-M3");
     expect(model?.id).toBe("MiniMax-M3");
-    expect(model?.input).toEqual(["text", "image"]);
+    expect(model?.input).toEqual(["text", "image", "video"]);
     expect(model?.name).toBe("MiniMax M3");
     expect(model?.reasoning).toBe(true);
   });
@@ -372,7 +372,7 @@ describe("minimax provider hooks", () => {
       id: "MiniMax-M3",
       api: "anthropic-messages",
       baseUrl: "https://api.minimax.io/anthropic",
-      input: ["text", "image"],
+      input: ["text", "image", "video"],
       contextWindow: 1_000_000,
     });
   });

--- a/extensions/minimax/model-definitions.test.ts
+++ b/extensions/minimax/model-definitions.test.ts
@@ -43,7 +43,7 @@ describe("minimax model definitions", () => {
       contextWindow: MINIMAX_M3_CATALOG_CONTEXT_WINDOW,
       cost: MINIMAX_API_COST,
       id: "MiniMax-M3",
-      input: ["text", "image"],
+      input: ["text", "image", "video"],
       maxTokens: DEFAULT_MINIMAX_MAX_TOKENS,
       name: "MiniMax M3",
       reasoning: true,
@@ -73,7 +73,7 @@ describe("minimax model definitions", () => {
     expect(model.cost).toEqual(MINIMAX_API_COST);
     expect(model.contextWindow).toBe(MINIMAX_M3_CATALOG_CONTEXT_WINDOW);
     expect(model.maxTokens).toBe(DEFAULT_MINIMAX_MAX_TOKENS);
-    expect(model.input).toEqual(["text", "image"]);
+    expect(model.input).toEqual(["text", "image", "video"]);
   });
 
   it("falls back to generated name for unknown model id", () => {

--- a/extensions/minimax/provider-models.ts
+++ b/extensions/minimax/provider-models.ts
@@ -14,7 +14,7 @@ export const MINIMAX_TEXT_MODEL_CATALOG = {
   "MiniMax-M3": {
     name: "MiniMax M3",
     reasoning: true,
-    input: ["text", "image"],
+    input: ["text", "image", "video"],
     contextWindow: 1_000_000,
     compat: { codeMode: "preferred" },
   },


### PR DESCRIPTION
Reason: MiniMax M3 accepts video input, but its catalog only declared text and image, so video attachments could not be selected through the model capability metadata.

## What changed

- `extensions/minimax/provider-models.ts`: add `video` to the `MiniMax-M3` catalog `input` modalities (now `["text", "image", "video"]`). The `input` field type already permits `video`, and all other MiniMax models keep their existing modalities.
- `docs/providers/minimax.md`: update the `MiniMax-M3` example config block to match the catalog.
- `extensions/minimax/model-definitions.test.ts` and `extensions/minimax/index.test.ts`: update the `MiniMax-M3` input-modality expectations to include `video`.

## Notes

Scoped to the `MiniMax-M3` input capability metadata; no runtime, routing, pricing, or context-window behavior is altered.
