### PR TITLE
fix(ci): let trusted Telegram QA stage runtime

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1230,12 +1230,11 @@ jobs:
           sudo chown -R root:root "$CANDIDATE_ROOT"
           sudo chmod -R go-w "$CANDIDATE_ROOT"
           sudo chmod -R a+rX "$CANDIDATE_ROOT"
-          # QA plugin runtime staging uses .artifacts/qa-runtime below its repo root.
-          # Preserve the frozen tree while granting the isolated SUT this one scratch directory.
+          # The trusted runner stages the QA runtime here before the isolated SUT reads it.
           candidate_artifacts_dir="${CANDIDATE_ROOT}/.artifacts"
-          sudo install -d -o "$sut_uid" -g "$sut_gid" -m 0700 "$candidate_artifacts_dir"
-          [[ "$(stat -c '%F:%a:%u:%g' "$candidate_artifacts_dir")" == "directory:700:${sut_uid}:${sut_gid}" ]]
-          sudo install -d -o "$sut_uid" -g "$sut_gid" -m 0700 "${candidate_artifacts_dir}/qa-runtime"
+          sudo install -d -o "$runner_uid" -g "$runner_gid" -m 0755 "$candidate_artifacts_dir"
+          [[ "$(stat -c '%F:%a:%u:%g' "$candidate_artifacts_dir")" == "directory:755:${runner_uid}:${runner_gid}" ]]
+          sudo install -d -o "$runner_uid" -g "$runner_gid" -m 0755 "${candidate_artifacts_dir}/qa-runtime"
           evidence_relative=".trusted-qa-evidence/release-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           evidence_root="${CANDIDATE_ROOT}/${evidence_relative}"
           boundary_evidence_dir="${evidence_root}/process-boundary"
@@ -2052,7 +2051,7 @@ jobs:
                           ! -w "$CANDIDATE_ROOT/dist/index.js" &&
                           -r "${OPENCLAW_CONFIG_PATH:?}" &&
                           ! -w "$OPENCLAW_CONFIG_PATH" ]]
-                    [[ -d "${CANDIDATE_ARTIFACTS_DIR:?}" && -w "$CANDIDATE_ARTIFACTS_DIR" ]]
+                    [[ -d "${CANDIDATE_ARTIFACTS_DIR:?}" && -r "$CANDIDATE_ARTIFACTS_DIR" && -x "$CANDIDATE_ARTIFACTS_DIR" && ! -w "$CANDIDATE_ARTIFACTS_DIR" ]]
                     for writable_path in \
                       "${OPENCLAW_QA_TEMP_ROOT:?}/workspace" \
                       "${OPENCLAW_HOME:?}" \


### PR DESCRIPTION
## What Problem This Solves

Resolves the frozen-candidate Telegram release lane failure where trusted QA staging receives EACCES before scenarios begin.

## Why This Change Was Made

The trusted runner creates the QA runtime staging tree; the isolated SUT only needs read and traversal access to execute it. The workflow now expresses those separate permissions.

## User Impact

Release validation can run the Telegram QA lane without granting the isolated process write access to the frozen candidate tree.

## Evidence

- Reproduced failure: https://github.com/openclaw/openclaw/actions/runs/30438913887/job/90534122695
- YAML parses successfully.
- Existing workflow test is blocked locally by its unchanged Bash 5 syntax on macOS Bash 3.2; hosted CI provides the authoritative Linux check.
- Autoreview: clean.