### PR TITLE
fix: align release service account state

### DIFF
--- a/scripts/e2e/lib/doctor-install-switch/scenario.sh
+++ b/scripts/e2e/lib/doctor-install-switch/scenario.sh
@@ -74,6 +74,8 @@ create_default_service_state() {
     "$account_home/.local/bin/openclaw-wrapper" \
     "$account_home/openclaw-wrapper-argv.log"
   openclaw_test_state_create "$account_home" empty
+  export HOME="$account_home"
+  export USERPROFILE="$account_home"
   unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH
 }
 

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -690,6 +690,7 @@ install_baseline() {
 }
 
 seed_state() {
+  local account_home=""
   openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_FUNCTION_B64:?missing OPENCLAW_TEST_STATE_FUNCTION_B64}"
   if [ "$ROOT_MANAGED_VPS" = "1" ]; then
     if [ "$(id -u)" -ne 0 ]; then
@@ -700,6 +701,17 @@ seed_state() {
     openclaw_test_state_create /root minimal
   else
     openclaw_test_state_create "$STATE_HOME_ROOT" minimal
+  fi
+  if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
+    account_home="$(getent passwd "$(id -u)" | cut -d: -f6)"
+    if [ -z "$account_home" ]; then
+      echo "Could not resolve the current account home" >&2
+      return 1
+    fi
+    export HOME="$account_home"
+    export USERPROFILE="$account_home"
+    export OPENCLAW_STATE_DIR="$account_home/.openclaw"
+    export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
   fi
   export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_VERSION="$baseline_version"
   node scripts/e2e/lib/upgrade-survivor/assertions.mjs seed

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -4390,7 +4390,12 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
 
     expectTextToIncludeAll(scenario, [
       'command_timeout="${OPENCLAW_DOCKER_DOCTOR_SWITCH_COMMAND_TIMEOUT:-900s}"',
-      'openclaw_test_state_create "$account_home" empty\n  unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH',
+      [
+        'openclaw_test_state_create "$account_home" empty',
+        '  export HOME="$account_home"',
+        '  export USERPROFILE="$account_home"',
+        "  unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH",
+      ].join("\n"),
       "create_default_service_state",
       'openclaw_e2e_maybe_timeout "$command_timeout" bash -c "$install_cmd"',
       'openclaw_e2e_maybe_timeout "$command_timeout" bash -c "$doctor_cmd"',
@@ -4401,7 +4406,26 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
     expect(
       scenario.match(/unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH/gu),
     ).toHaveLength(1);
+    expect(scenario.match(/export USERPROFILE="\$account_home"/gu)).toHaveLength(1);
     expect(scenario).not.toMatch(/^\s*if ! timeout "\$command_timeout"/mu);
+  });
+
+  it("uses the account home for upgrade survivor auto-auth state", () => {
+    const runner = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+
+    expectTextToIncludeAll(runner, [
+      'if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then',
+      'account_home="$(getent passwd "$(id -u)" | cut -d: -f6)"',
+      'if [ -z "$account_home" ]; then',
+      'export HOME="$account_home"',
+      'export USERPROFILE="$account_home"',
+      'export OPENCLAW_STATE_DIR="$account_home/.openclaw"',
+      'export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"',
+    ]);
+
+    expect(
+      runner.indexOf('export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"'),
+    ).toBeLessThan(runner.indexOf("node scripts/e2e/lib/upgrade-survivor/assertions.mjs seed"));
   });
 
   it("bounds doctor install switch command log diagnostics", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes two remaining release-harness identity mismatches after the service-install safety hardening. Doctor install-switch did not expose the canonical account home through `USERPROFILE`, and upgrade-survivor auto-auth still seeded and installed against temporary state that the candidate correctly rejected as non-default.

## Why This Change Was Made

Doctor install-switch now exports both `HOME` and `USERPROFILE` from its resolved account home before clearing OpenClaw path overrides.

Upgrade-survivor auto-auth now resolves the current passwd home, fails closed when it is empty, exports `HOME` and `USERPROFILE`, and points state/config at the default `$account_home/.openclaw` before assertion seeding. Manual and root-managed survivor lanes keep their existing setup; the root-managed lane seeds `/root`, matching uid 0's passwd home even if modes are manually combined.

## User Impact

The doctor-switch and update-restart-auth release lanes exercise the supported service account identity without weakening production safety checks. There is no product runtime change.

## Evidence

- `bash -n` for both changed shell scenarios
- focused `test/scripts/docker-build-helper.test.ts`: 177 passed
- Oxfmt and `git diff --check`
- Codex autoreview: clean after verifying the separate auto-auth/root-managed lane contract
