### PR TITLE
test(release): preserve fallback abort signal

### DIFF
--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -245,6 +245,7 @@ async function runEmbeddedFallback(params: {
     sessionId: params.sessionId,
     lane: params.lane,
     agentDir: params.agentDir,
+    abortSignal: params.abortSignal,
     run: (provider, model, options) =>
       runEmbeddedAgent({
         sessionId,


### PR DESCRIPTION
## What Problem This Solves

Resolves an extended-stable release-validation failure where the embedded fallback abort test reported a fallback summary instead of the expected abort.

## Why This Change Was Made

The release test wrapper passed its abort signal into the embedded run but not the fallback orchestrator. Propagating the existing signal makes the wrapper exercise the intended cancellation path; no product runtime behavior changes.

## User Impact

No user-visible change. This restores reliable validation of the 2026.6.34 candidate.

## Evidence

- Focused `src/agents/model-fallback.run-embedded.e2e.test.ts`: 20/20 pass.
- `git diff --check` and targeted formatting pass.
- Fresh autoreview: no actionable findings.
- The original full validation failure was `FallbackSummaryError` where the test expected the abort outcome.