### PR TITLE
fix(gateway): cancel requests disconnected during preparation

### DIFF
--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -337,6 +337,51 @@ describe("watchClientDisconnect", () => {
     expect(controller.signal.aborted).toBe(true);
   });
 
+  it("aborts when the client disconnected before close listeners were installed", () => {
+    const socket = Object.assign(new EventEmitter(), { destroyed: true });
+    const { req, res } = makeMockHttpReqRes(socket, socket);
+    Object.assign(req, { complete: true, destroyed: true });
+    Object.assign(res, { destroyed: true, writableEnded: false });
+    socket.emit("close");
+
+    const controller = new AbortController();
+    const onDisconnect = vi.fn();
+    watchClientDisconnect(req, res, controller, onDisconnect);
+
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it.each([
+    ["an incomplete request was destroyed", { req: { complete: false, destroyed: true } }],
+    ["the response was destroyed", { res: { destroyed: true } }],
+    ["the response already ended", { res: { writableEnded: true } }],
+  ])("aborts immediately when %s", (_name, state) => {
+    const socket = Object.assign(new EventEmitter(), { destroyed: false });
+    const { req, res } = makeMockHttpReqRes(socket, socket);
+    Object.assign(req, { complete: false, destroyed: false }, state.req);
+    Object.assign(res, { destroyed: false, writableEnded: false }, state.res);
+    const controller = new AbortController();
+
+    watchClientDisconnect(req, res, controller);
+
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it("keeps watching after a complete request was consumed on a live socket", () => {
+    const socket = Object.assign(new EventEmitter(), { destroyed: false });
+    const { req, res } = makeMockHttpReqRes(socket, socket);
+    Object.assign(req, { complete: true, destroyed: true });
+    Object.assign(res, { destroyed: false, writableEnded: false });
+    const controller = new AbortController();
+
+    const cleanup = watchClientDisconnect(req, res, controller);
+
+    expect(controller.signal.aborted).toBe(false);
+    expect(socket.listenerCount("close")).toBe(1);
+    cleanup();
+  });
+
   it("does not double-abort when the controller is already aborted", () => {
     const socket = new EventEmitter();
     const { req, res } = makeMockHttpReqRes(socket, null);

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -353,9 +353,9 @@ describe("watchClientDisconnect", () => {
   });
 
   it.each([
-    ["an incomplete request was destroyed", { req: { complete: false, destroyed: true } }],
-    ["the response was destroyed", { res: { destroyed: true } }],
-    ["the response already ended", { res: { writableEnded: true } }],
+    ["an incomplete request was destroyed", { req: { complete: false, destroyed: true }, res: {} }],
+    ["the response was destroyed", { req: {}, res: { destroyed: true } }],
+    ["the response already ended", { req: {}, res: { writableEnded: true } }],
   ])("aborts immediately when %s", (_name, state) => {
     const socket = Object.assign(new EventEmitter(), { destroyed: false });
     const { req, res } = makeMockHttpReqRes(socket, socket);

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -171,21 +171,26 @@ export function watchClientDisconnect(
       ),
     ),
   );
-  if (sockets.length === 0) {
-    return () => {};
-  }
   const handleClose = () => {
     onDisconnect?.();
     if (!abortController.signal.aborted) {
       abortController.abort(new ClientDisconnectError());
     }
   };
-  for (const socket of sockets) {
-    socket.on("close", handleClose);
-  }
-  return () => {
+  const stopWatching = () => {
     for (const socket of sockets) {
       socket.off("close", handleClose);
     }
   };
+  for (const socket of sockets) {
+    socket.on("close", handleClose);
+  }
+  // A fully consumed IncomingMessage may be destroyed while its keep-alive socket is still open.
+  const requestTerminatedEarly = req.destroyed && !req.complete;
+  const socketClosed = sockets.some((socket) => socket.destroyed);
+  if (requestTerminatedEarly || socketClosed || res.destroyed || res.writableEnded) {
+    stopWatching();
+    handleClose();
+  }
+  return stopWatching;
 }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where OpenAI-compatible Gateway clients that disconnect while request preparation is still running can still trigger downstream model work when the disconnect happens before client-close monitoring is installed.

## Why This Change Was Made

`watchClientDisconnect` remains the canonical owner of the disconnect invariant. It now installs socket listeners first and then checks whether the request, response, or socket is already terminal; a destroyed request only counts as an early termination when `req.complete` is false, preserving normally consumed keep-alive requests whose `IncomingMessage` has already been destroyed.

## User Impact

Abandoned chat-completion requests are canceled before downstream model work starts, including the narrow pre-listener race. Connected requests and fully consumed requests on live keep-alive sockets continue normally.

## Evidence

- The exact regression failed before the fix in all three Gateway test projects: the pre-destroyed socket produced zero disconnect callbacks and left the controller un-aborted.
- The full affected test file passes in all three Gateway projects: 3 test files, 114 tests. Coverage includes a pre-listener socket close, incomplete destroyed requests, destroyed/ended responses, and a negative guard for complete requests on a live keep-alive socket.
- A near-real live proof started an isolated real Gateway with `/v1/chat/completions` enabled and a local protocol-compatible OpenAI provider. Six large PNG data URLs created a deterministic request-setup window:
  - Connected control: HTTP 200 and exactly one chat-completion provider request.
  - Client destroyed after 100 ms: zero chat-completion provider requests during a 10-second observation window. One auxiliary embeddings request occurred during setup, but no downstream model completion started.
- Repository formatting, the real pre-commit hook, and a focused two-file format check all passed.

The live proof used the real Gateway and HTTP request path; only the external model provider was replaced with a local protocol-compatible server so provider-call initiation could be counted deterministically.
