### PR TITLE
fix: apply doctor service identity per flow

### DIFF
--- a/scripts/e2e/lib/doctor-install-switch/scenario.sh
+++ b/scripts/e2e/lib/doctor-install-switch/scenario.sh
@@ -60,7 +60,7 @@ update_doctor_env+=" OPENCLAW_UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART=1"
 update_doctor_env+=" OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR=1"
 update_doctor_env+=" OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION=0"
 
-create_default_service_state() {
+use_default_service_identity() {
   local account_home
   account_home="$(node -p 'require("node:os").userInfo().homedir')"
 
@@ -73,7 +73,6 @@ create_default_service_state() {
     "$account_home/.config/powershell" \
     "$account_home/.local/bin/openclaw-wrapper" \
     "$account_home/openclaw-wrapper-argv.log"
-  openclaw_test_state_create "$account_home" empty
   export HOME="$account_home"
   export USERPROFILE="$account_home"
   unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH
@@ -158,7 +157,8 @@ run_flow() {
   local command_timeout="${OPENCLAW_DOCKER_DOCTOR_SWITCH_COMMAND_TIMEOUT:-900s}"
 
   echo "== Flow: $name =="
-  create_default_service_state
+  openclaw_test_state_create "switch-${name}" empty
+  use_default_service_identity
   export USER="testuser"
 
   if ! openclaw_e2e_maybe_timeout "$command_timeout" bash -c "$install_cmd" >"$install_log" 2>&1; then
@@ -282,7 +282,8 @@ run_proxy_env_flow() {
   local command_timeout="${OPENCLAW_DOCKER_DOCTOR_SWITCH_COMMAND_TIMEOUT:-900s}"
 
   echo "== Flow: $name =="
-  create_default_service_state
+  openclaw_test_state_create "switch-${name}" empty
+  use_default_service_identity
   export USER="testuser"
 
   unit_path="$HOME/.config/systemd/user/openclaw-gateway.service"
@@ -328,7 +329,8 @@ run_wrapper_flow() {
   local command_timeout="${OPENCLAW_DOCKER_DOCTOR_SWITCH_COMMAND_TIMEOUT:-900s}"
 
   echo "== Flow: $name =="
-  create_default_service_state
+  openclaw_test_state_create "switch-${name}" empty
+  use_default_service_identity
   export USER="testuser"
   mkdir -p "$HOME/.local/bin"
   local wrapper="$HOME/.local/bin/openclaw-wrapper"

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -4390,13 +4390,13 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
 
     expectTextToIncludeAll(scenario, [
       'command_timeout="${OPENCLAW_DOCKER_DOCTOR_SWITCH_COMMAND_TIMEOUT:-900s}"',
-      [
-        'openclaw_test_state_create "$account_home" empty',
-        '  export HOME="$account_home"',
-        '  export USERPROFILE="$account_home"',
-        "  unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH",
-      ].join("\n"),
-      "create_default_service_state",
+      "use_default_service_identity() {",
+      "local account_home",
+      'account_home="$(node -p \'require("node:os").userInfo().homedir\')"',
+      'export HOME="$account_home"',
+      'export USERPROFILE="$account_home"',
+      "unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH",
+      'openclaw_test_state_create "switch-${name}" empty\n  use_default_service_identity',
       'openclaw_e2e_maybe_timeout "$command_timeout" bash -c "$install_cmd"',
       'openclaw_e2e_maybe_timeout "$command_timeout" bash -c "$doctor_cmd"',
       'openclaw_e2e_maybe_timeout "$command_timeout" "$npm_bin" gateway install --wrapper "$wrapper" --force',
@@ -4407,6 +4407,7 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
       scenario.match(/unset OPENCLAW_HOME OPENCLAW_STATE_DIR OPENCLAW_CONFIG_PATH/gu),
     ).toHaveLength(1);
     expect(scenario.match(/export USERPROFILE="\$account_home"/gu)).toHaveLength(1);
+    expect(scenario.match(/^  use_default_service_identity$/gmu)).toHaveLength(3);
     expect(scenario).not.toMatch(/^\s*if ! timeout "\$command_timeout"/mu);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes the remaining doctor install-switch failure in the proxy-environment flow. Canonical service identity was bundled into one state-creation helper, which obscured the required transition and did not reliably apply after each flow's own test-state initialization.

## Why This Change Was Made

The scenario now separates concerns:

- each of the three daemon-service flows creates its own isolated test state;
- `use_default_service_identity` then selects the OS account `HOME` and `USERPROFILE`, clears the canonical account's prior service artifacts, and removes OpenClaw path overrides;
- the intentional cross-state approval flow does not call this helper and retains its custom-state contract.

A focused guard requires exactly three identity-helper calls and checks they immediately follow per-flow state creation.

## User Impact

Doctor-switch release validation can exercise the normal, proxy-cleanup, and wrapper-persistence service paths without weakening product safety or changing the intentional cross-state scenario. There is no product runtime change.

## Evidence

- `bash -n scripts/e2e/lib/doctor-install-switch/scenario.sh`
- focused `test/scripts/docker-build-helper.test.ts`: 177 passed
- Oxfmt and `git diff --check`
- Codex autoreview: clean, no accepted or actionable findings
