### PR TITLE
fix(ci): accept one verified Telegram SUT launch

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -2632,10 +2632,7 @@ jobs:
                   )
                 )
               ) and
-              (
-                [.launches[] | select(.terminalState == "ready-exited")] | length >=
-                  (if $runLaneOutcome == "success" then 2 else 1 end)
-              )
+              ([.launches[] | select(.terminalState == "ready-exited")] | length >= 1)
             ' "$runtime_path" >/dev/null
 
           while IFS=$'\t' read -r relative_path expected_sha256; do


### PR DESCRIPTION
## What Problem This Solves

Fixes a release-validation failure after a successful Telegram QA run: the process-boundary evidence finalizer rejects valid evidence when the current default scenario catalog starts the isolated SUT once.

## Why This Change Was Made

The finalizer now requires at least one verified ready SUT launch. That is the isolation contract; requiring two encoded the former optional `channel-canary` scenario topology rather than a security or runtime requirement.

## User Impact

No product behavior change. Extended-stable release validation can accept a passing Telegram live lane and its valid isolated-runtime evidence.

## Evidence

- Failed run: Telegram QA passed 12/12 scenarios, then the evidence finalizer failed only on the obsolete two-launch count.
- Verified directly: one `ready-exited` launch passes; zero does not.
- `git diff --check` passed.
- Autoreview: clean, no actionable findings.