### PR TITLE
fix(ios): release archive compiles with Swift 6.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3295,6 +3295,19 @@ jobs:
       - name: Build iOS app
         run: pnpm ios:build
 
+      # Debug's incremental compilation can miss actor-isolation diagnostics
+      # that Swift's optimized whole-module Release build enforces.
+      - name: Build iOS app (Release)
+        if: env.HISTORICAL_TARGET != 'true'
+        run: |
+          xcodebuild \
+            -project apps/ios/OpenClaw.xcodeproj \
+            -scheme OpenClaw \
+            -configuration Release \
+            -destination "generic/platform=iOS" \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
       # App compilation and screenshots do not execute approval or notification
       # lifecycles. Exercise both owners on the already provisioned simulator.
       - name: Run focused iOS lifecycle simulator tests

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -25947,7 +25947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4174,
+      "line": 4175,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -25955,7 +25955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4175,
+      "line": 4176,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -25963,7 +25963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4890,
+      "line": 4891,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -25971,7 +25971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4891,
+      "line": 4892,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -25979,7 +25979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5246,
+      "line": 5247,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -25987,7 +25987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5246,
+      "line": 5247,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -25995,7 +25995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6416,
+      "line": 6417,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -26003,7 +26003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6478,
+      "line": 6479,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -26011,7 +26011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6478,
+      "line": 6479,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -26019,7 +26019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8837,
+      "line": 8838,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -26027,7 +26027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8837,
+      "line": 8838,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -26035,7 +26035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8843,
+      "line": 8844,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -26043,7 +26043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8844,
+      "line": 8845,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -26051,7 +26051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10214,
+      "line": 10215,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",

--- a/apps/ios/CHANGELOG.md
+++ b/apps/ios/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2026.7.22
+
 - Prevented stale Watch reconnect recovery from disconnecting a newly selected Gateway, kept delivered Watch messages from reappearing after a crash, and preserved attachments when retrying uncertain offline sends.
 
 ## 2026.7.21

--- a/apps/ios/Sources/Capabilities/NodeCapabilityRouter.swift
+++ b/apps/ios/Sources/Capabilities/NodeCapabilityRouter.swift
@@ -8,7 +8,7 @@ final class NodeCapabilityRouter {
         case handlerUnavailable
     }
 
-    typealias Handler = (BridgeInvokeRequest) async throws -> BridgeInvokeResponse
+    typealias Handler = @MainActor @Sendable (BridgeInvokeRequest) async throws -> BridgeInvokeResponse
 
     private let handlers: [String: Handler]
 

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -3267,7 +3267,8 @@ extension NodeAppModel {
 
         func register(
             _ commands: [String],
-            handler: @escaping (NodeAppModel, BridgeInvokeRequest) async throws -> BridgeInvokeResponse)
+            handler: @escaping @MainActor @Sendable (NodeAppModel, BridgeInvokeRequest) async throws
+                -> BridgeInvokeResponse)
         {
             let invoke: NodeCapabilityRouter.Handler = { [weak self] request in
                 guard let self else { throw NodeCapabilityRouter.RouterError.handlerUnavailable }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers creating the iOS 2026.7.22 release would hit a Swift 6.3 data-race diagnostic while compiling the optimized Release archive, blocking the App Store upload before any App Store Connect mutation.

## Why This Change Was Made

Capability-router callbacks now carry the main-actor isolation contract already required by `NodeAppModel`, while retaining the centralized route registry. CI also performs an unsigned Release device build so whole-module-only Swift concurrency failures are caught before release day. The prepared 2026.7.22 release notes remain included from the interrupted release attempt.

## User Impact

Maintainers can build the planned iOS release with Xcode 26.5 / Swift 6.3.2. Runtime routing behavior is unchanged.

## Evidence

- Before: `NodeAppModel.swift:3275:13: error: sending 'handler' risks causing data races` during the Release archive.
- `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build` — `BUILD SUCCEEDED`.
- `NodeAppModelInvokeTests` — 242 tests passed on an iOS simulator.
- `./scripts/format-swift.sh ios` and `./scripts/lint-swift.sh ios` — passed.
- `pnpm check:workflows` and `actionlint .github/workflows/ci.yml` — passed.
- Structured Codex autoreview — clean, no accepted/actionable findings.
