### PR TITLE
fix(matrix): report automatic reply delivery settlement

### DIFF
--- a/extensions/matrix/src/matrix/draft-stream.test.ts
+++ b/extensions/matrix/src/matrix/draft-stream.test.ts
@@ -230,6 +230,20 @@ describe("createMatrixDraftStream", () => {
     expect(stream.eventId()).toBe("$evt1");
   });
 
+  it("tracks the provider-visible prepared draft content", async () => {
+    convertMarkdownTablesMock.mockImplementation((text: string) => `prepared:${text}`);
+    const stream = createMatrixDraftStream({
+      roomId: "!room:test",
+      client,
+      cfg: {} as import("../types.js").CoreConfig,
+    });
+
+    stream.update("raw table");
+    await stream.flush();
+
+    expect(stream.content()).toBe("prepared:raw table");
+  });
+
   it("sends quiet preview notices when quiet mode is enabled", async () => {
     const stream = createMatrixDraftStream({
       roomId: "!room:test",

--- a/extensions/matrix/src/matrix/draft-stream.ts
+++ b/extensions/matrix/src/matrix/draft-stream.ts
@@ -41,6 +41,8 @@ type MatrixDraftStream = {
   reset: () => void;
   /** The event ID of the current draft message, if any. */
   eventId: () => string | undefined;
+  /** The last content accepted for the current draft event, if any. */
+  content: () => string | undefined;
   /** True when the provided text matches the last rendered draft payload. */
   matchesPreparedText: (text: string) => boolean;
   /** True when preview streaming must fall back to normal final delivery. */
@@ -68,6 +70,7 @@ export function createMatrixDraftStream(params: {
 
   let currentEventId: string | undefined;
   let lastSentText = "";
+  let lastSentContent = "";
   let stopped = false;
   let sendFailed = false;
   let finalizeInPlaceBlocked = false;
@@ -111,6 +114,7 @@ export function createMatrixDraftStream(params: {
         });
         currentEventId = result.messageId;
         lastSentText = preparedText.trimmedText;
+        lastSentContent = preparedText.convertedText;
         log?.(`draft-stream: created message ${currentEventId}${useLive ? " (MSC4357 live)" : ""}`);
       } else {
         await editMessageMatrix(roomId, currentEventId, preparedText.trimmedText, {
@@ -123,6 +127,7 @@ export function createMatrixDraftStream(params: {
           live: useLive,
         });
         lastSentText = preparedText.trimmedText;
+        lastSentContent = preparedText.convertedText;
       }
       return true;
     } catch (err) {
@@ -198,6 +203,7 @@ export function createMatrixDraftStream(params: {
     replyToId = params.preserveReplyId ? params.replyToId : undefined;
     currentEventId = undefined;
     lastSentText = "";
+    lastSentContent = "";
     stopped = false;
     sendFailed = false;
     finalizeInPlaceBlocked = false;
@@ -219,6 +225,7 @@ export function createMatrixDraftStream(params: {
     finalizeLive,
     reset,
     eventId: () => currentEventId,
+    content: () => lastSentContent || undefined,
     matchesPreparedText: (text: string) =>
       prepareMatrixSingleText(text, {
         cfg,

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -19,7 +19,12 @@ import {
   redactMatrixDraftEvent,
   type MatrixDraftStreamHandle,
 } from "./handler-runtime.js";
-import { deliverMatrixReplies } from "./replies.js";
+import {
+  deliverMatrixReplies,
+  mergeMatrixReplyDeliveryResults,
+  toMatrixPartialDeliveryError,
+  type MatrixReplyDeliveryResult,
+} from "./replies.js";
 import {
   createReplyPrefixOptions,
   createTypingCallbacks,
@@ -81,6 +86,54 @@ export function createMatrixReplyDispatcher(config: {
     ...prefixOptions,
     humanDelay,
     deliver: async (payload: ReplyPayload, info: { kind: string }) => {
+      const completeDelivery = async (
+        result: MatrixReplyDeliveryResult,
+      ): Promise<MatrixReplyDeliveryResult> => {
+        if (info.kind === "block") {
+          draftController.clearDraftConsumed();
+          draftController.advanceDraftBlockBoundary({ fallbackToLatestEnd: true });
+          draftStream?.reset();
+          draftController.resetReplyToIdForNextBlock();
+          draftController.updateDraftFromLatestFullText();
+
+          // Re-assert typing so the user still sees the indicator while
+          // the next block generates.
+          const { sendTypingMatrix } = await loadMatrixSendModule();
+          await sendTypingMatrix(roomId, true, undefined, client).catch(() => {});
+        }
+        return result;
+      };
+      const createDraftReceipt = (id: string): MessageReceipt =>
+        createPreviewMessageReceipt({
+          id,
+          ...(threadTarget ? { threadId: threadTarget } : {}),
+          ...(draftController.currentReplyToId()
+            ? { replyToId: draftController.currentReplyToId() }
+            : {}),
+        });
+      const createDraftDeliveryResult = (
+        id: string,
+        content: string,
+      ): MatrixReplyDeliveryResult => {
+        const receipt = createDraftReceipt(id);
+        return {
+          messageIds: receipt.platformMessageIds,
+          receipt,
+          visibleReplySent: true,
+          content,
+        };
+      };
+      const createSurvivingDraftDelivery = (
+        id: string,
+        redacted: boolean,
+      ): MatrixReplyDeliveryResult => {
+        const content = redacted ? undefined : draftStream?.content();
+        return content
+          ? // Failed redaction leaves an accepted provider event visible. Preserve it so
+            // settlement and retries cannot mistake a partial delivery for total failure.
+            createDraftDeliveryResult(id, content)
+          : mergeMatrixReplyDeliveryResults([]);
+      };
       if (draftStream && info.kind !== "tool" && !payload.isCompactionNotice) {
         const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
         const ttsSupplement = getReplyPayloadTtsSupplement(payload);
@@ -93,22 +146,23 @@ export function createMatrixReplyDispatcher(config: {
 
         if (draftController.isDraftConsumed()) {
           await draftStream.discardPending();
-          await deliverMatrixReplies({
-            cfg,
-            replies: [fallbackPayload],
-            roomId,
-            client,
-            runtime,
-            textLimit,
-            replyToMode,
-            hasRepliedRef,
-            threadId: threadTarget,
-            replyToId: threadTarget ?? replyToEventId ?? undefined,
-            accountId,
-            mediaLocalRoots,
-            tableMode,
-          });
-          return;
+          return await completeDelivery(
+            await deliverMatrixReplies({
+              cfg,
+              replies: [fallbackPayload],
+              roomId,
+              client,
+              runtime,
+              textLimit,
+              replyToMode,
+              hasRepliedRef,
+              threadId: threadTarget,
+              replyToId: threadTarget ?? replyToEventId ?? undefined,
+              accountId,
+              mediaLocalRoots,
+              tableMode,
+            }),
+          );
         }
 
         const payloadReplyToId = normalizeOptionalString(payload.replyToId);
@@ -149,7 +203,15 @@ export function createMatrixReplyDispatcher(config: {
           !draftFinalTextNeedsNormalMentionDelivery
         ) {
           const finalPreviewText = payload.text;
-          await deliverWithFinalizableLivePreviewAdapter<
+          const { prepareMatrixSingleText } = await loadMatrixSendModule();
+          const preparedFinalPreviewContent = prepareMatrixSingleText(finalPreviewText, {
+            cfg,
+            accountId,
+            preserveWhitespace: true,
+          }).convertedText;
+          let finalizedDraftContent = draftStream.content() ?? preparedFinalPreviewContent;
+          let fallbackResult: MatrixReplyDeliveryResult | undefined;
+          const previewResult = await deliverWithFinalizableLivePreviewAdapter<
             ReplyPayload,
             string,
             {
@@ -181,6 +243,7 @@ export function createMatrixReplyDispatcher(config: {
                   if (!(await draftStream.finalizeLive())) {
                     throw new Error("Matrix draft live finalize failed");
                   }
+                  finalizedDraftContent = draftStream.content() ?? preparedFinalPreviewContent;
                   return;
                 }
                 const { editMessageMatrix } = await loadMatrixSendModule();
@@ -191,42 +254,65 @@ export function createMatrixReplyDispatcher(config: {
                   accountId,
                   extraContent: edit.extraContent,
                 });
+                finalizedDraftContent = prepareMatrixSingleText(edit.text, {
+                  cfg,
+                  accountId,
+                  preserveWhitespace: true,
+                }).convertedText;
               },
-              createPreviewReceipt: (id): MessageReceipt =>
-                createPreviewMessageReceipt({
-                  id,
-                  ...(threadTarget ? { threadId: threadTarget } : {}),
-                  ...(draftController.currentReplyToId()
-                    ? { replyToId: draftController.currentReplyToId() }
-                    : {}),
-                }),
+              createPreviewReceipt: createDraftReceipt,
               logPreviewEditFailure: (err) => {
                 logVerboseMessage(`matrix: preview final edit failed: ${String(err)}`);
               },
             }),
             deliverNormally: async () => {
-              await redactMatrixDraftEvent(client, roomId, draftEventId);
-              await deliverMatrixReplies({
-                cfg,
-                replies: [fallbackPayload],
-                roomId,
-                client,
-                runtime,
-                textLimit,
-                replyToMode,
-                hasRepliedRef,
-                threadId: threadTarget,
-                replyToId: threadTarget ?? replyToEventId ?? undefined,
-                accountId,
-                mediaLocalRoots,
-                tableMode,
-              });
+              const draftRedacted = await redactMatrixDraftEvent(client, roomId, draftEventId);
+              const survivingDraft = createSurvivingDraftDelivery(draftEventId, draftRedacted);
+              let deliveredFallback: MatrixReplyDeliveryResult;
+              try {
+                deliveredFallback = await deliverMatrixReplies({
+                  cfg,
+                  replies: [fallbackPayload],
+                  roomId,
+                  client,
+                  runtime,
+                  textLimit,
+                  replyToMode,
+                  hasRepliedRef,
+                  threadId: threadTarget,
+                  replyToId: threadTarget ?? replyToEventId ?? undefined,
+                  accountId,
+                  mediaLocalRoots,
+                  tableMode,
+                });
+              } catch (error: unknown) {
+                throw toMatrixPartialDeliveryError(error, [survivingDraft]);
+              }
+              fallbackResult = mergeMatrixReplyDeliveryResults([survivingDraft, deliveredFallback]);
+              return fallbackResult.visibleReplySent;
             },
           });
           draftController.markDraftConsumed();
+          const settledResult =
+            previewResult.kind === "preview-finalized" && previewResult.liveState?.receipt
+              ? createDraftDeliveryResult(
+                  draftEventId,
+                  finalizedDraftContent ?? preparedFinalPreviewContent,
+                )
+              : (fallbackResult ?? mergeMatrixReplyDeliveryResults([]));
+          return await completeDelivery(settledResult);
         } else if (draftEventId && hasMedia && !payloadReplyMismatch) {
           let textEditOk = !mustDeliverFinalNormally;
           const payloadText = payload.text ?? ttsSupplement?.spokenText;
+          const preparedPayloadContent =
+            typeof payloadText === "string"
+              ? (await loadMatrixSendModule()).prepareMatrixSingleText(payloadText, {
+                  cfg,
+                  accountId,
+                  preserveWhitespace: true,
+                }).convertedText
+              : undefined;
+          let finalizedDraftContent = draftStream.content() ?? preparedPayloadContent;
           const payloadTextMatchesDraft =
             typeof payloadText === "string" && draftStream.matchesPreparedText(payloadText);
           const reusesDraftTextUnchanged =
@@ -242,7 +328,7 @@ export function createMatrixReplyDispatcher(config: {
           if (textEditOk && mediaTextNeedsNormalMentionDelivery) {
             textEditOk = false;
           } else if (textEditOk && payloadText && requiresFinalTextEdit) {
-            const { editMessageMatrix } = await loadMatrixSendModule();
+            const { editMessageMatrix, prepareMatrixSingleText } = await loadMatrixSendModule();
             textEditOk = await editMessageMatrix(roomId, draftEventId, payloadText, {
               client,
               cfg,
@@ -250,16 +336,25 @@ export function createMatrixReplyDispatcher(config: {
               accountId,
               extraContent: quietDraftStreaming ? buildMatrixFinalizedPreviewContent() : undefined,
             }).then(
-              () => true,
+              () => {
+                finalizedDraftContent = prepareMatrixSingleText(payloadText, {
+                  cfg,
+                  accountId,
+                  preserveWhitespace: true,
+                }).convertedText;
+                return true;
+              },
               () => false,
             );
           } else if (textEditOk && reusesDraftTextUnchanged) {
             textEditOk = await draftStream.finalizeLive();
+            finalizedDraftContent = draftStream.content();
           }
           const reusesDraftAsFinalText = Boolean(payloadText?.trim()) && textEditOk;
-          if (!reusesDraftAsFinalText) {
-            await redactMatrixDraftEvent(client, roomId, draftEventId);
-          }
+          const draftContent = draftStream.content();
+          const draftRedacted = reusesDraftAsFinalText
+            ? false
+            : await redactMatrixDraftEvent(client, roomId, draftEventId);
           const mediaPayload =
             ttsSupplement && reusesDraftAsFinalText
               ? buildTtsSupplementMediaPayload(payload)
@@ -272,33 +367,55 @@ export function createMatrixReplyDispatcher(config: {
                         ? undefined
                         : ttsSupplement?.spokenText)),
                 };
-          await deliverMatrixReplies({
-            cfg,
-            replies: [mediaPayload],
-            roomId,
-            client,
-            runtime,
-            textLimit,
-            replyToMode,
-            hasRepliedRef,
-            threadId: threadTarget,
-            replyToId: threadTarget ?? replyToEventId ?? undefined,
-            accountId,
-            mediaLocalRoots,
-            tableMode,
-          });
-          draftController.markDraftConsumed();
-        } else {
-          const draftRedacted =
-            Boolean(draftEventId) &&
-            (payload.isError ||
-              payloadReplyMismatch ||
-              mustDeliverFinalNormally ||
-              draftFinalTextNeedsNormalMentionDelivery);
-          if (draftRedacted && draftEventId) {
-            await redactMatrixDraftEvent(client, roomId, draftEventId);
+          const providerDraftContent = finalizedDraftContent ?? preparedPayloadContent;
+          const previewDelivery =
+            reusesDraftAsFinalText && providerDraftContent
+              ? createDraftDeliveryResult(draftEventId, providerDraftContent)
+              : !draftRedacted && draftContent
+                ? createDraftDeliveryResult(draftEventId, draftContent)
+                : mergeMatrixReplyDeliveryResults([]);
+          let mediaDelivery: MatrixReplyDeliveryResult;
+          try {
+            mediaDelivery = await deliverMatrixReplies({
+              cfg,
+              replies: [mediaPayload],
+              roomId,
+              client,
+              runtime,
+              textLimit,
+              replyToMode,
+              hasRepliedRef,
+              threadId: threadTarget,
+              replyToId: threadTarget ?? replyToEventId ?? undefined,
+              accountId,
+              mediaLocalRoots,
+              tableMode,
+            });
+          } catch (error: unknown) {
+            throw toMatrixPartialDeliveryError(error, [previewDelivery]);
           }
-          const deliveredFallback = await deliverMatrixReplies({
+          draftController.markDraftConsumed();
+          return await completeDelivery(
+            mergeMatrixReplyDeliveryResults([previewDelivery, mediaDelivery]),
+          );
+        }
+        const shouldRedactDraft =
+          Boolean(draftEventId) &&
+          (payload.isError ||
+            payloadReplyMismatch ||
+            mustDeliverFinalNormally ||
+            draftFinalTextNeedsNormalMentionDelivery);
+        const draftRedacted =
+          shouldRedactDraft && draftEventId
+            ? await redactMatrixDraftEvent(client, roomId, draftEventId)
+            : false;
+        const survivingDraft =
+          shouldRedactDraft && draftEventId
+            ? createSurvivingDraftDelivery(draftEventId, draftRedacted)
+            : mergeMatrixReplyDeliveryResults([]);
+        let deliveredFallback: MatrixReplyDeliveryResult;
+        try {
+          deliveredFallback = await deliverMatrixReplies({
             cfg,
             replies: [fallbackPayload],
             roomId,
@@ -313,24 +430,17 @@ export function createMatrixReplyDispatcher(config: {
             mediaLocalRoots,
             tableMode,
           });
-          if (draftRedacted || deliveredFallback) {
-            draftController.markDraftConsumed();
-          }
+        } catch (error: unknown) {
+          throw toMatrixPartialDeliveryError(error, [survivingDraft]);
         }
-
-        if (info.kind === "block") {
-          draftController.clearDraftConsumed();
-          draftController.advanceDraftBlockBoundary({ fallbackToLatestEnd: true });
-          draftStream.reset();
-          draftController.resetReplyToIdForNextBlock();
-          draftController.updateDraftFromLatestFullText();
-
-          // Re-assert typing so the user still sees the indicator while
-          // the next block generates.
-          const { sendTypingMatrix } = await loadMatrixSendModule();
-          await sendTypingMatrix(roomId, true, undefined, client).catch(() => {});
+        if (shouldRedactDraft || deliveredFallback.visibleReplySent) {
+          draftController.markDraftConsumed();
         }
-      } else {
+        return await completeDelivery(
+          mergeMatrixReplyDeliveryResults([survivingDraft, deliveredFallback]),
+        );
+      }
+      return await completeDelivery(
         await deliverMatrixReplies({
           cfg,
           replies: [payload],
@@ -345,8 +455,8 @@ export function createMatrixReplyDispatcher(config: {
           accountId,
           mediaLocalRoots,
           tableMode,
-        });
-      }
+        }),
+      );
     },
     onError: (err: unknown, info: { kind: "tool" | "block" | "final" }) => {
       if (info.kind === "final") {

--- a/extensions/matrix/src/matrix/monitor/handler-runtime.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-runtime.ts
@@ -7,6 +7,7 @@ export type MatrixDraftStreamHandle = {
   stop: () => Promise<string | undefined>;
   discardPending: () => Promise<void>;
   eventId: () => string | undefined;
+  content: () => string | undefined;
   mustDeliverFinalNormally: () => boolean;
   matchesPreparedText: (text: string) => boolean;
   finalizeLive: () => Promise<boolean>;
@@ -17,8 +18,11 @@ export async function redactMatrixDraftEvent(
   client: MatrixClient,
   roomId: string,
   draftEventId: string,
-): Promise<void> {
-  await client.redactEvent(roomId, draftEventId).catch(() => {});
+): Promise<boolean> {
+  return await client.redactEvent(roomId, draftEventId).then(
+    () => true,
+    () => false,
+  );
 }
 
 export function buildMatrixFinalizedPreviewContent(): Record<string, unknown> {

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -78,9 +78,10 @@ vi.mock("../send.js", () => ({
   sendTypingMatrix: vi.fn(async () => {}),
 }));
 
-const deliverMatrixRepliesMock = vi.hoisted(() => vi.fn(async () => true));
+const deliverMatrixRepliesMock = vi.hoisted(() => vi.fn());
 
-vi.mock("./replies.js", () => ({
+vi.mock("./replies.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./replies.js")>()),
   deliverMatrixReplies: deliverMatrixRepliesMock,
 }));
 
@@ -140,6 +141,7 @@ beforeEach(() => {
     };
   });
   resolveMatrixMentionsForBodyMock.mockClear();
+  deliverMatrixRepliesMock.mockReset().mockResolvedValue(createMockMatrixDeliveryResult());
 });
 
 afterEach(() => {
@@ -288,6 +290,20 @@ function expectDeliveredMediaReply() {
   const reply = requireRecord(replies[0], "media reply");
   expect(reply.mediaUrl).toBe("https://example.com/image.png");
   expect(reply.text).toBeUndefined();
+}
+
+function createMockMatrixDeliveryResult(messageId = "$reply1", content = "delivered") {
+  return {
+    messageIds: [messageId],
+    receipt: {
+      primaryPlatformMessageId: messageId,
+      platformMessageIds: [messageId],
+      parts: [{ platformMessageId: messageId, kind: "text" as const, index: 0 }],
+      sentAt: 1,
+    },
+    visibleReplySent: true,
+    content,
+  };
 }
 
 describe("matrix monitor handler pairing account scope", () => {
@@ -2837,7 +2853,7 @@ describe("matrix monitor handler draft streaming", () => {
       replyToId?: string;
     },
     info: { kind: string },
-  ) => Promise<void>;
+  ) => Promise<unknown>;
   type ReplyOpts = {
     onReplyStart?: () => Promise<void> | void;
     onPartialReply?: (payload: { text: string }) => void;
@@ -2928,7 +2944,7 @@ describe("matrix monitor handler draft streaming", () => {
       .mockReset()
       .mockResolvedValue({ messageId: "$draft1", roomId: "!room" });
     editMessageMatrixMock.mockReset().mockResolvedValue("$edited");
-    deliverMatrixRepliesMock.mockReset().mockResolvedValue(true);
+    deliverMatrixRepliesMock.mockReset().mockResolvedValue(createMockMatrixDeliveryResult());
 
     const redactEventMock = vi.fn(async () => "$redacted");
 
@@ -3015,12 +3031,69 @@ describe("matrix monitor handler draft streaming", () => {
     });
 
     deliverMatrixRepliesMock.mockClear();
-    await deliver({ text: "Single block" }, { kind: "final" });
+    const result = await deliver({ text: "Single block" }, { kind: "final" });
 
     expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     expectFinalizedPreviewEdit("$draft1", "Single block");
     expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
     expect(redactEventMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      messageIds: ["$draft1"],
+      visibleReplySent: true,
+      content: "Single block",
+      receipt: { primaryPlatformMessageId: "$draft1" },
+    });
+    await finish();
+  });
+
+  it("settles finalized previews with provider-prepared content", async () => {
+    prepareMatrixSingleTextMock.mockImplementation((text: string) => ({
+      trimmedText: text.trim(),
+      convertedText: `prepared:${text.trim()}`,
+      singleEventLimit: 4000,
+      fitsInSingleEvent: true,
+    }));
+    const { dispatch } = createStreamingHarness({ streaming: "quiet" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Raw preview" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    const result = await deliver({ text: "Raw final" }, { kind: "final" });
+
+    expect(result).toMatchObject({
+      messageIds: ["$draft1"],
+      content: "prepared:Raw final",
+    });
+    await finish();
+  });
+
+  it("settles reused media previews with provider-prepared content", async () => {
+    prepareMatrixSingleTextMock.mockImplementation((text: string) => ({
+      trimmedText: text.trim(),
+      convertedText: `prepared:${text.trim()}`,
+      singleEventLimit: 4000,
+      fitsInSingleEvent: true,
+    }));
+    const { dispatch } = createStreamingHarness({ streaming: "partial" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Raw caption" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    const result = await deliver(
+      { text: "Raw caption", mediaUrl: "https://example.com/image.png" },
+      { kind: "final" },
+    );
+
+    expect(result).toMatchObject({
+      messageIds: ["$draft1", "$reply1"],
+      content: "prepared:Raw caption\ndelivered",
+    });
     await finish();
   });
 
@@ -3520,7 +3593,7 @@ describe("matrix monitor handler draft streaming", () => {
       expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
     });
 
-    await deliver(
+    const result = await deliver(
       {
         mediaUrl: "https://example.com/tts.mp3",
         audioAsVoice: true,
@@ -3546,6 +3619,47 @@ describe("matrix monitor handler draft streaming", () => {
         ttsSupplement: { spokenText: "Spoken answer" },
       },
     ]);
+    expect(result).toMatchObject({
+      messageIds: ["$draft1", "$reply1"],
+      visibleReplySent: true,
+      content: "Spoken answer\ndelivered",
+      receipt: { primaryPlatformMessageId: "$draft1" },
+    });
+    await finish();
+  });
+
+  it("preserves a finalized draft receipt when the following media send fails", async () => {
+    const { dispatch } = createStreamingHarness({
+      blockStreamingEnabled: true,
+      streaming: "partial",
+    });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Spoken answer" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+    deliverMatrixRepliesMock.mockRejectedValueOnce(new Error("media send failed"));
+
+    const error = await deliver(
+      {
+        mediaUrl: "https://example.com/tts.mp3",
+        audioAsVoice: true,
+        spokenText: "Spoken answer",
+        ttsSupplement: { spokenText: "Spoken answer" },
+      },
+      { kind: "final" },
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        messageIds: ["$draft1"],
+        visibleReplySent: true,
+        content: "Spoken answer",
+        receipt: { primaryPlatformMessageId: "$draft1" },
+      },
+    });
     await finish();
   });
 
@@ -3588,6 +3702,89 @@ describe("matrix monitor handler draft streaming", () => {
         ttsSupplement: { spokenText: "Spoken answer" },
       },
     ]);
+    await finish();
+  });
+
+  it("preserves a surviving draft receipt when redaction and media delivery fail", async () => {
+    const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Visible preview" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    redactEventMock.mockRejectedValueOnce(new Error("redaction failed"));
+    deliverMatrixRepliesMock.mockRejectedValueOnce(new Error("media send failed"));
+    const error = await deliver(
+      { mediaUrl: "https://example.com/image.png" },
+      { kind: "final" },
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        messageIds: ["$draft1"],
+        visibleReplySent: true,
+        content: "Visible preview",
+        receipt: { primaryPlatformMessageId: "$draft1" },
+      },
+    });
+    await finish();
+  });
+
+  it("preserves a surviving draft receipt when final-edit fallback also fails", async () => {
+    const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Visible preview" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    editMessageMatrixMock.mockRejectedValueOnce(new Error("final edit failed"));
+    redactEventMock.mockRejectedValueOnce(new Error("redaction failed"));
+    deliverMatrixRepliesMock.mockRejectedValueOnce(new Error("fallback send failed"));
+    const error = await deliver({ text: "Final text" }, { kind: "final" }).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        messageIds: ["$draft1"],
+        visibleReplySent: true,
+        content: "Visible preview",
+        receipt: { primaryPlatformMessageId: "$draft1" },
+      },
+    });
+    await finish();
+  });
+
+  it("preserves a surviving draft receipt when generic fallback delivery fails", async () => {
+    const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Visible preview" });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    redactEventMock.mockRejectedValueOnce(new Error("redaction failed"));
+    deliverMatrixRepliesMock.mockRejectedValueOnce(new Error("fallback send failed"));
+    const error = await deliver({ text: "Something failed", isError: true } as never, {
+      kind: "final",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        messageIds: ["$draft1"],
+        visibleReplySent: true,
+        content: "Visible preview",
+        receipt: { primaryPlatformMessageId: "$draft1" },
+      },
+    });
     await finish();
   });
 
@@ -4073,7 +4270,7 @@ describe("matrix monitor handler draft streaming", () => {
         .mockReset()
         .mockResolvedValue({ messageId: "$draft1", roomId: "!room" });
       editMessageMatrixMock.mockReset().mockResolvedValue("$edited");
-      deliverMatrixRepliesMock.mockReset().mockResolvedValue(true);
+      deliverMatrixRepliesMock.mockReset().mockResolvedValue(createMockMatrixDeliveryResult());
       const redactEventMock = vi.fn(async () => "$redacted");
 
       let capturedReplyOpts: ReplyOpts | undefined;
@@ -4122,7 +4319,7 @@ describe("matrix monitor handler draft streaming", () => {
       .mockReset()
       .mockResolvedValue({ messageId: "$draft1", roomId: "!room" });
     editMessageMatrixMock.mockReset().mockResolvedValue("$edited");
-    deliverMatrixRepliesMock.mockReset().mockResolvedValue(true);
+    deliverMatrixRepliesMock.mockReset().mockResolvedValue(createMockMatrixDeliveryResult());
 
     const redactEventMock = vi.fn(async () => "$redacted");
     let capturedReplyOpts: ReplyOpts | undefined;
@@ -4164,7 +4361,10 @@ describe("matrix monitor handler draft streaming", () => {
     });
 
     deliverMatrixRepliesMock.mockClear();
-    deliverMatrixRepliesMock.mockResolvedValue(false);
+    deliverMatrixRepliesMock.mockResolvedValue({
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    });
     await deliver({}, { kind: "final" });
 
     expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -520,6 +520,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
               }
             },
             delivery: {
+              observeMessageSent: true,
               deliver: deliverReply,
               onError: (err, info) => onReplyError(err, info as Parameters<typeof onReplyError>[1]),
             },

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime, RuntimeEnv } from "../../../runtime-api.js";
 import type { MatrixClient } from "../sdk.js";
 
-const sendMessageMatrixMock = vi.hoisted(() => vi.fn().mockResolvedValue({ messageId: "mx-1" }));
+const sendMessageMatrixMock = vi.hoisted(() => vi.fn());
 const chunkMatrixTextMock = vi.hoisted(() =>
   vi.fn((text: string, _opts?: unknown) => ({
     trimmedText: text.trim(),
@@ -22,6 +22,32 @@ vi.mock("../send.js", () => ({
 
 import { setMatrixRuntime } from "../../runtime.js";
 import { deliverMatrixReplies } from "./replies.js";
+
+let nextMessageId = 0;
+
+async function resolveMockMatrixSend(_to: string, message: string, opts?: Record<string, unknown>) {
+  nextMessageId += 1;
+  const messageId = `mx-${nextMessageId}`;
+  const mediaUrl = typeof opts?.mediaUrl === "string" ? opts.mediaUrl : "unknown";
+  const content = message || `media:${mediaUrl}`;
+  const result = {
+    messageId,
+    roomId: "room:1",
+    primaryMessageId: messageId,
+    receipt: {
+      primaryPlatformMessageId: messageId,
+      platformMessageIds: [messageId],
+      parts: [{ platformMessageId: messageId, kind: "text" as const, index: 0 }],
+      sentAt: 1,
+    },
+    content,
+  };
+  const onDeliveryResult = opts?.onDeliveryResult;
+  if (typeof onDeliveryResult === "function") {
+    await onDeliveryResult(result);
+  }
+  return result;
+}
 
 function sendCall(index: number) {
   const call = sendMessageMatrixMock.mock.calls.at(index);
@@ -74,6 +100,8 @@ describe("deliverMatrixReplies", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    nextMessageId = 0;
+    sendMessageMatrixMock.mockReset().mockImplementation(resolveMockMatrixSend);
     setMatrixRuntime(runtimeStub);
     chunkMatrixTextMock.mockReset().mockImplementation((text: string) => ({
       trimmedText: text.trim(),
@@ -163,10 +191,98 @@ describe("deliverMatrixReplies", () => {
     await expect(deliverMatrixReplies(delivery)).rejects.toThrow("Matrix unavailable");
     expect(hasRepliedRef.value).toBe(false);
 
-    await expect(deliverMatrixReplies(delivery)).resolves.toBe(true);
+    await expect(deliverMatrixReplies(delivery)).resolves.toMatchObject({
+      visibleReplySent: true,
+    });
     expect(sendOptions(0).replyToId).toBe("reply-1");
     expect(sendOptions(1).replyToId).toBe("reply-1");
     expect(hasRepliedRef.value).toBe(true);
+  });
+
+  it("returns ordered provider receipts and visible content for a chunked reply", async () => {
+    chunkMatrixTextMock.mockImplementation((text: string) => ({
+      trimmedText: text.trim(),
+      convertedText: text,
+      singleEventLimit: 4000,
+      fitsInSingleEvent: true,
+      chunks: text.split("|"),
+    }));
+
+    const result = await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "first|second" }],
+      roomId: "room:1",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(result).toMatchObject({
+      messageIds: ["mx-1", "mx-2"],
+      visibleReplySent: true,
+      content: "first\nsecond",
+    });
+    expect(result.receipt?.primaryPlatformMessageId).toBe("mx-1");
+  });
+
+  it("preserves the accepted prefix when a later Matrix event fails", async () => {
+    chunkMatrixTextMock.mockImplementation((text: string) => ({
+      trimmedText: text.trim(),
+      convertedText: text,
+      singleEventLimit: 4000,
+      fitsInSingleEvent: true,
+      chunks: text.split("|"),
+    }));
+    let sendCount = 0;
+    sendMessageMatrixMock.mockImplementation(async (...args: unknown[]) => {
+      sendCount += 1;
+      if (sendCount === 2) {
+        throw new Error("second event failed");
+      }
+      return await resolveMockMatrixSend(
+        String(args[0]),
+        String(args[1]),
+        args[2] as Record<string, unknown> | undefined,
+      );
+    });
+
+    const error = await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "first|second", replyToId: "reply-1" }],
+      roomId: "room:1",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "first",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        messageIds: ["mx-1"],
+        visibleReplySent: true,
+        content: "first",
+      },
+    });
+  });
+
+  it("returns an explicit non-visible result when every reply is suppressed", async () => {
+    const result = await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "<think>hidden</think>" }],
+      roomId: "room:1",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(result).toEqual({
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    });
+    expect(sendMessageMatrixMock).not.toHaveBeenCalled();
   });
 
   it("preserves native thread fallback after the first reply has been consumed", async () => {

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -1,10 +1,96 @@
 // Matrix plugin module implements replies behavior.
+import {
+  createChannelPartialDeliveryError,
+  isChannelPartialDeliveryError,
+} from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createMessageReceiptFromOutboundResults,
+  listMessageReceiptPlatformIds,
+  type MessageReceipt,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixClient } from "../sdk.js";
 import { chunkMatrixText, sendMessageMatrix } from "../send.js";
+import type { MatrixSendResult } from "../send/types.js";
 import type { MarkdownTableMode, OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
+
+export type MatrixReplyDeliveryResult = {
+  messageIds?: string[];
+  receipt?: MessageReceipt;
+  visibleReplySent: boolean;
+  content?: string;
+  suppression?: { reason: "no_visible_result" };
+};
+
+function joinMatrixVisibleContent(contents: readonly (string | undefined)[]): string {
+  return contents.filter((content): content is string => Boolean(content)).join("\n");
+}
+
+export function mergeMatrixReplyDeliveryResults(
+  results: readonly MatrixReplyDeliveryResult[],
+): MatrixReplyDeliveryResult {
+  const visibleResults = results.filter((result) => result.visibleReplySent);
+  if (visibleResults.length === 0) {
+    return {
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    };
+  }
+  const receiptInputs: Array<{ receipt: MessageReceipt } | { messageId: string }> = [];
+  for (const result of visibleResults) {
+    if (result.receipt) {
+      receiptInputs.push({ receipt: result.receipt });
+      continue;
+    }
+    for (const messageId of result.messageIds ?? []) {
+      receiptInputs.push({ messageId });
+    }
+  }
+  const receipt =
+    receiptInputs.length > 0
+      ? createMessageReceiptFromOutboundResults({ results: receiptInputs })
+      : undefined;
+  return {
+    ...(receipt ? { messageIds: listMessageReceiptPlatformIds(receipt), receipt } : {}),
+    visibleReplySent: true,
+    content: joinMatrixVisibleContent(visibleResults.map((result) => result.content)),
+  };
+}
+
+export function toMatrixPartialDeliveryError(
+  error: unknown,
+  settled: readonly MatrixReplyDeliveryResult[],
+): unknown {
+  const failedPartial = isChannelPartialDeliveryError(error)
+    ? (error.deliveryResult as MatrixReplyDeliveryResult)
+    : undefined;
+  const merged = mergeMatrixReplyDeliveryResults([
+    ...settled,
+    ...(failedPartial ? [failedPartial] : []),
+  ]);
+  return merged.visibleReplySent
+    ? createChannelPartialDeliveryError(error, { ...merged, visibleReplySent: true })
+    : error;
+}
+
+function createMatrixReplyDeliveryResult(
+  results: readonly MatrixSendResult[],
+): MatrixReplyDeliveryResult {
+  if (results.length === 0) {
+    return mergeMatrixReplyDeliveryResults([]);
+  }
+  const receipt = createMessageReceiptFromOutboundResults({
+    results: results.map((result) => ({ receipt: result.receipt })),
+  });
+  return {
+    messageIds: listMessageReceiptPlatformIds(receipt),
+    receipt,
+    visibleReplySent: true,
+    content: joinMatrixVisibleContent(results.map((result) => result.content)),
+  };
+}
 
 function resolveVisibleMatrixReplyText(text?: string): string | undefined {
   if (typeof text !== "string") {
@@ -35,7 +121,7 @@ export async function deliverMatrixReplies(params: {
   accountId?: string;
   mediaLocalRoots?: readonly string[];
   tableMode?: MarkdownTableMode;
-}): Promise<boolean> {
+}): Promise<MatrixReplyDeliveryResult> {
   const core = getMatrixRuntime();
   const tableMode =
     params.tableMode ??
@@ -50,84 +136,89 @@ export async function deliverMatrixReplies(params: {
     }
   };
   const hasRepliedRef = params.hasRepliedRef ?? { value: false };
-  let deliveredAny = false;
-  for (const reply of params.replies) {
-    const visibleText = resolveVisibleMatrixReplyText(reply.text);
-    const hasMedia = Boolean(reply?.mediaUrl) || (reply?.mediaUrls?.length ?? 0) > 0;
-    if (reply.isReasoning === true || (!hasMedia && reply.text && visibleText === undefined)) {
-      logVerbose("matrix reply suppressed as reasoning-only");
-      continue;
-    }
-    if (!reply?.text && !hasMedia) {
-      if (reply?.audioAsVoice) {
-        logVerbose("matrix reply has audioAsVoice without media/text; skipping");
+  const acceptedResults: MatrixSendResult[] = [];
+  try {
+    for (const reply of params.replies) {
+      const visibleText = resolveVisibleMatrixReplyText(reply.text);
+      const hasMedia = Boolean(reply?.mediaUrl) || (reply?.mediaUrls?.length ?? 0) > 0;
+      if (reply.isReasoning === true || (!hasMedia && reply.text && visibleText === undefined)) {
+        logVerbose("matrix reply suppressed as reasoning-only");
         continue;
       }
-      params.runtime.error?.("matrix reply missing text/media");
-      continue;
-    }
-    const replyToIdRaw = (reply.replyToId ?? params.replyToId)?.trim();
-    const replyToId = params.threadId
-      ? replyToIdRaw
-      : params.replyToMode === "off"
-        ? undefined
-        : replyToIdRaw;
-    const rawText = visibleText ?? "";
-    const mediaList = reply.mediaUrls?.length
-      ? reply.mediaUrls
-      : reply.mediaUrl
-        ? [reply.mediaUrl]
-        : [];
-
-    const shouldIncludeReply = (id?: string) =>
-      Boolean(id) && (params.threadId || params.replyToMode === "all" || !hasRepliedRef.value);
-    const replyToIdForReply = shouldIncludeReply(replyToId) ? replyToId : undefined;
-
-    if (mediaList.length === 0) {
-      const { chunks } = chunkMatrixText(rawText, {
-        cfg: params.cfg,
-        accountId: params.accountId,
-        tableMode,
-      });
-      for (const chunk of chunks) {
-        const trimmed = chunk.trim();
-        if (!trimmed) {
+      if (!reply?.text && !hasMedia) {
+        if (reply?.audioAsVoice) {
+          logVerbose("matrix reply has audioAsVoice without media/text; skipping");
           continue;
         }
-        await sendMessageMatrix(params.roomId, trimmed, {
-          client: params.client,
-          cfg: params.cfg,
-          replyToId: replyToIdForReply,
-          threadId: params.threadId,
-          accountId: params.accountId,
-        });
-        deliveredAny = true;
+        params.runtime.error?.("matrix reply missing text/media");
+        continue;
+      }
+      const replyToIdRaw = (reply.replyToId ?? params.replyToId)?.trim();
+      const replyToId = params.threadId
+        ? replyToIdRaw
+        : params.replyToMode === "off"
+          ? undefined
+          : replyToIdRaw;
+      const rawText = visibleText ?? "";
+      const mediaList = reply.mediaUrls?.length
+        ? reply.mediaUrls
+        : reply.mediaUrl
+          ? [reply.mediaUrl]
+          : [];
+
+      const shouldIncludeReply = (id?: string) =>
+        Boolean(id) && (params.threadId || params.replyToMode === "all" || !hasRepliedRef.value);
+      const replyToIdForReply = shouldIncludeReply(replyToId) ? replyToId : undefined;
+      const onDeliveryResult = (result: MatrixSendResult) => {
+        // A concrete event consumes the first-reply slot even when a later event fails.
+        acceptedResults.push(result);
         if (replyToIdForReply) {
           hasRepliedRef.value = true;
         }
-      }
-      continue;
-    }
+      };
 
-    let first = true;
-    for (const mediaUrl of mediaList) {
-      const caption = first ? rawText : "";
-      await sendMessageMatrix(params.roomId, caption, {
-        client: params.client,
-        cfg: params.cfg,
-        mediaUrl,
-        mediaLocalRoots: params.mediaLocalRoots,
-        replyToId: replyToIdForReply,
-        threadId: params.threadId,
-        audioAsVoice: reply.audioAsVoice,
-        accountId: params.accountId,
-      });
-      deliveredAny = true;
-      if (replyToIdForReply) {
-        hasRepliedRef.value = true;
+      if (mediaList.length === 0) {
+        const { chunks } = chunkMatrixText(rawText, {
+          cfg: params.cfg,
+          accountId: params.accountId,
+          tableMode,
+        });
+        for (const chunk of chunks) {
+          const trimmed = chunk.trim();
+          if (!trimmed) {
+            continue;
+          }
+          await sendMessageMatrix(params.roomId, trimmed, {
+            client: params.client,
+            cfg: params.cfg,
+            replyToId: replyToIdForReply,
+            threadId: params.threadId,
+            accountId: params.accountId,
+            onDeliveryResult,
+          });
+        }
+        continue;
       }
-      first = false;
+
+      let first = true;
+      for (const mediaUrl of mediaList) {
+        const caption = first ? rawText : "";
+        await sendMessageMatrix(params.roomId, caption, {
+          client: params.client,
+          cfg: params.cfg,
+          mediaUrl,
+          mediaLocalRoots: params.mediaLocalRoots,
+          replyToId: replyToIdForReply,
+          threadId: params.threadId,
+          audioAsVoice: reply.audioAsVoice,
+          accountId: params.accountId,
+          onDeliveryResult,
+        });
+        first = false;
+      }
     }
+  } catch (error: unknown) {
+    throw toMatrixPartialDeliveryError(error, [createMatrixReplyDeliveryResult(acceptedResults)]);
   }
-  return deliveredAny;
+  return createMatrixReplyDeliveryResult(acceptedResults);
 }

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -870,6 +870,7 @@ describe("sendMessageMatrix threads", () => {
     expect(result.roomId).toBe("!room:example");
     expect(result.primaryMessageId).toBe("$m1");
     expect(result.messageId).toBe("$m3");
+    expect(result.content).toBe("part1\npart2\npart3");
     expect(result.receipt.primaryPlatformMessageId).toBe("$m1");
     expect(result.receipt.platformMessageIds).toEqual(["$m1", "$m2", "$m3"]);
     const parts = requireArray(result.receipt.parts, "receipt parts");
@@ -897,6 +898,7 @@ describe("sendMessageMatrix threads", () => {
     ).rejects.toThrow("second event failed");
 
     expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual(["$m1"]);
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.content)).toEqual(["part1"]);
   });
 
   it("merges extra content into only the first chunked text event", async () => {
@@ -1066,6 +1068,7 @@ describe("sendSingleTextMessageMatrix", () => {
     expect(result.receipt.primaryPlatformMessageId).toBe("evt1");
     expect(result.receipt.platformMessageIds).toEqual(["evt1"]);
     expectTextReceiptPart(result.receipt.parts[0], "evt1");
+    expect(result.content).toBe("done");
   });
 });
 

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -197,7 +197,9 @@ export async function sendMessageMatrix(
         const contentWithExtra = withMatrixExtraContentFields(content, pendingExtraContent);
         pendingExtraContent = undefined;
         const eventId = await client.sendMessage(roomId, contentWithExtra);
+        const visibleContent = contentWithExtra.body ?? "";
         if (eventId) {
+          acceptedContents.push(visibleContent);
           await opts.onDeliveryResult?.({
             messageId: eventId,
             roomId,
@@ -209,12 +211,14 @@ export async function sendMessageMatrix(
               replyToId: opts.replyToId,
               threadId,
             }),
+            content: visibleContent,
           });
         }
         return eventId;
       };
 
       const platformMessageIds: string[] = [];
+      const acceptedContents: string[] = [];
       let lastMessageId = "";
       let receiptKind: MessageReceiptPartKind = "text";
       if (opts.mediaUrl) {
@@ -332,6 +336,7 @@ export async function sendMessageMatrix(
           replyToId: opts.replyToId,
           threadId,
         }),
+        content: acceptedContents.join("\n"),
       };
     },
   );
@@ -499,6 +504,7 @@ export async function sendSingleTextMessageMatrix(
           replyToId: opts.replyToId,
           threadId: normalizedThreadId,
         }),
+        content: content.body,
       };
     },
   );

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -82,6 +82,8 @@ export type MatrixSendResult = {
   roomId: string;
   primaryMessageId?: string;
   receipt: MessageReceipt;
+  /** Provider-accepted visible bodies in event order for this send operation. */
+  content: string;
 };
 
 export type MatrixSendOpts = {


### PR DESCRIPTION
Closes #116269

AI-assisted: yes (Codex), with maintainer-directed investigation, source review, and live validation.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Matrix users receiving automatic agent replies would see the message in the room, but outbound lifecycle observers would receive no terminal delivery event or provider event ID. Partial multi-payload failures also could not report the prefix already accepted by Matrix.

## Why This Change Was Made

The Matrix plugin now carries provider-accepted receipts and provider-prepared visible content through automatic reply dispatch, including draft/edit finalization and partial failures, then opts the routed Matrix adapter into the existing terminal observer. The change stays within the Matrix owner boundary and does not alter core, the public plugin SDK, configuration, protocol, persistence, retry, or replay behavior.

## User Impact

Installed plugins can observe each completed Matrix automatic reply exactly once with the provider-visible content and actual Matrix event ID. Cancellation still produces no visible message or false terminal event, while partial failures preserve accepted delivery information.

## Evidence

- Frozen integration base: `48b3c1ea00e9825dfbc8cfdcee52be762b415ae9`; reviewed commit: `2751da2f19e7320228dfdf7d6cf4521297188ad3`.
- Real disposable Tuwunel validation passed the full selected Matrix catalog: 88/88 scenarios, including transport, media, formatting, reply/thread relations, E2EE, CLI, restart, replay/dedupe, and resume paths.
- Exact-candidate automatic observer row: one terminal event with provider-finalized content and actual preview-root event ID; provider history and lifecycle trace agreed.
- Controlled partial failure: first payload accepted with a real event ID, second provider send returned 502, and one failed terminal retained the accepted ID/content without duplication.
- Cancellation at both modifying-hook boundaries: zero preview/final provider events and zero false terminal events.
- Controlled first-send failure: one failed terminal with no provider ID and no visible room event.
- Media-only automatic reply: provider-visible media and terminal settlement reconciled.
- Focused regression tests: 230 assertions passed; final post-review selection: 167 assertions passed.
- Changed-surface gates passed on [Blacksmith Testbox run 30517574307](https://github.com/openclaw/openclaw/actions/runs/30517574307); the broad disposable selection ran in [30515007724](https://github.com/openclaw/openclaw/actions/runs/30515007724).
- Fresh autoreview: no accepted or actionable findings.

The standalone durable CLI provider row also passed real `m.image`, native reply-relation, and clean queue-state checks. Its separate process did not load the Gateway observer plugin, so it is not claimed as additional hook-lifecycle proof; durable retry/replay semantics remain outside this bounded automatic-reply fix.
