### PR TITLE
fix(ci): load frozen shard runner without repository fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2060,11 +2060,23 @@ jobs:
           echo "detected cores=$cores plan_concurrency=${SHARD_PLAN_CONCURRENCY:-default} -> workers=$workers"
           echo "OPENCLAW_VITEST_MAX_WORKERS=$workers" >> "$GITHUB_ENV"
 
+      - name: Checkout trusted Node shard runner
+        # Frozen release targets can predate the workflow-owned shard runner.
+        # Keep its implementation pinned to this workflow revision, while tests
+        # continue to run against the checked-out candidate.
+        if: ${{ hashFiles('scripts/ci-run-node-test-shard.mjs') == '' }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .ci-workflow
+          sparse-checkout: |
+            scripts/ci-run-node-test-shard.mjs
+            scripts/lib/direct-run.mjs
+            scripts/lib/local-heavy-check-runtime.mjs
+          persist-credentials: false
+
       - name: Run Node test shard
-        # actionlint 1.7.11 lacks GitHub's current job.workflow_* fields. Serialize the
-        # non-secret job context, then validate the defining workflow identity below.
         env:
-          JOB_CONTEXT_JSON: ${{ toJSON(job) }}
           NODE_OPTIONS: --max-old-space-size=8192
           OPENCLAW_NODE_TEST_GROUPS_JSON: ${{ toJson(matrix.groups || null) }}
           OPENCLAW_NODE_TEST_CONFIGS_JSON: ${{ toJson(matrix.configs) }}
@@ -2084,30 +2096,8 @@ jobs:
           set -euo pipefail
           runner="scripts/ci-run-node-test-shard.mjs"
           if [[ ! -f "$runner" ]]; then
-            # Frozen release targets can predate the workflow-owned shard runner.
-            # Load only that runner from the exact trusted workflow commit while
-            # keeping its child tests rooted in the checked-out candidate.
-            job_workflow_repository=$(jq -r '.workflow_repository // empty' <<<"$JOB_CONTEXT_JSON")
-            job_workflow_sha=$(jq -r '.workflow_sha // empty' <<<"$JOB_CONTEXT_JSON")
-            if [[ ! "$job_workflow_repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-              echo "invalid job workflow repository: $job_workflow_repository" >&2
-              exit 1
-            fi
-            if [[ ! "$job_workflow_sha" =~ ^[0-9a-f]{40}$ ]]; then
-              echo "invalid job workflow SHA: $job_workflow_sha" >&2
-              exit 1
-            fi
-            harness_root="${RUNNER_TEMP}/openclaw-ci-shard-runner"
-            workflow_remote="https://github.com/${job_workflow_repository}.git"
-            timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags --depth=1 "$workflow_remote" "$job_workflow_sha"
-            for file in \
-              scripts/ci-run-node-test-shard.mjs \
-              scripts/lib/direct-run.mjs \
-              scripts/lib/local-heavy-check-runtime.mjs; do
-              mkdir -p "${harness_root}/$(dirname "$file")"
-              git show "${job_workflow_sha}:${file}" > "${harness_root}/${file}"
-            done
-            runner="${harness_root}/${runner}"
+            runner=".ci-workflow/${runner}"
+            [[ -f "$runner" ]]
           fi
           node "$runner"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2073,6 +2073,7 @@ jobs:
             scripts/ci-run-node-test-shard.mjs
             scripts/lib/direct-run.mjs
             scripts/lib/local-heavy-check-runtime.mjs
+          sparse-checkout-cone-mode: false
           persist-credentials: false
 
       - name: Run Node test shard

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4687,7 +4687,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       (step: WorkflowStep) => step.name === "Checkout trusted Node shard runner",
     );
     expect(trustedRunnerStep).toMatchObject({
-      if: "hashFiles('scripts/ci-run-node-test-shard.mjs') == ''",
+      if: "${{ hashFiles('scripts/ci-run-node-test-shard.mjs') == '' }}",
       uses: CHECKOUT_V6,
       with: {
         ref: "${{ github.workflow_sha }}",

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4683,20 +4683,19 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(runStep.env.OPENCLAW_NODE_TEST_VITEST_ARGS_JSON).toBe(
       "${{ needs.preflight.outputs.compatibility_target == 'true' && '[\"--hookTimeout=600000\"]' || '[]' }}",
     );
-    expect(runStep.env.JOB_CONTEXT_JSON).toBe("${{ toJSON(job) }}");
-    // Shard execution policy lives in the unit-tested wrapper script. Frozen
-    // release targets load that wrapper from the exact trusted workflow SHA.
-    for (const expected of [
-      'runner="scripts/ci-run-node-test-shard.mjs"',
-      'if [[ ! -f "$runner" ]]',
-      "job_workflow_repository=$(jq -r '.workflow_repository // empty' <<<\"$JOB_CONTEXT_JSON\")",
-      "job_workflow_sha=$(jq -r '.workflow_sha // empty' <<<\"$JOB_CONTEXT_JSON\")",
-      'timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags --depth=1 "$workflow_remote" "$job_workflow_sha"',
-      'git show "${job_workflow_sha}:${file}" > "${harness_root}/${file}"',
-      'node "$runner"',
-    ]) {
-      expect(runStep.run).toContain(expected);
-    }
+    const trustedRunnerStep = nodeTestJob.steps.find(
+      (step: WorkflowStep) => step.name === "Checkout trusted Node shard runner",
+    );
+    expect(trustedRunnerStep).toMatchObject({
+      if: "hashFiles('scripts/ci-run-node-test-shard.mjs') == ''",
+      uses: CHECKOUT_V6,
+      with: {
+        ref: "${{ github.workflow_sha }}",
+        path: ".ci-workflow",
+        "sparse-checkout": expect.stringContaining("scripts/ci-run-node-test-shard.mjs"),
+        "persist-credentials": false,
+      },
+    });
     expect(existsSync("scripts/ci-run-node-test-shard.mjs")).toBe(true);
   });
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4693,6 +4693,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
         ref: "${{ github.workflow_sha }}",
         path: ".ci-workflow",
         "sparse-checkout": expect.stringContaining("scripts/ci-run-node-test-shard.mjs"),
+        "sparse-checkout-cone-mode": false,
         "persist-credentials": false,
       },
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers validating an older frozen release candidate would see every normal-CI Node shard time out before its tests start. The candidate predates the workflow-owned shard runner, and the fallback fetched the repository by workflow SHA separately in every shard.

## Why This Change Was Made

When the candidate does not contain the runner, the workflow sparsely checks out only the trusted runner and its two helper modules at github.workflow_sha. The candidate remains the test target; current candidates continue using their checked-out runner unchanged. This avoids repeated full Git fetches without widening the trust boundary.

## User Impact

Release validation can execute normal CI against older release candidates instead of failing in workflow setup. No product or package behavior changes.

## Evidence

- Reproduced in [Full Release Validation CI child run 30520517143](https://github.com/openclaw/openclaw/actions/runs/30520517143); representative [Node shard job 90799663915](https://github.com/openclaw/openclaw/actions/runs/30520517143/job/90799663915) timed out after the frozen-candidate fallback fetch, before tests started.
- Confirmed candidate 2dbfe013e511d0c7e0720356f5af5c7bb210db19 lacks scripts/ci-run-node-test-shard.mjs.
- git diff --check and YAML parsing pass locally.
- Autoreview and PR CI will be added before merge.