### PR TITLE
fix: npm release preflight reruns reject stale build files

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -185,6 +185,17 @@ jobs:
         id: preflight_cache_key
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      # setup-node-env may restore a broader build-all snapshot. Clear every
+      # preflight cache output first so actions/cache cannot overlay stale or
+      # private-QA artifacts that are absent from this release build.
+      - name: Clean preflight build outputs before cache restore
+        run: |
+          set -euo pipefail
+          rm -rf -- dist dist-runtime packages/*/dist
+          find extensions -type f -path '*/src/host/*' \
+            \( -name '.bundle.hash' -o -name '*.bundle.js' \) \
+            -delete
+
       - name: Restore preflight build outputs
         id: dist_build_cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -656,6 +656,7 @@ const GITHUB_WORKFLOW_OWNER_TEST_TARGETS = new Map([
     ".github/workflows/openclaw-npm-release.yml",
     [
       "test/openclaw-npm-postpublish-verify.test.ts",
+      "test/scripts/openclaw-npm-extended-stable-workflow.test.ts",
       "test/scripts/package-acceptance-workflow.test.ts",
     ],
   ],

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -156,9 +156,21 @@ describe("minimal npm extended-stable workflow", () => {
   it("restores same-SHA preflight build outputs and keeps validation steps running", () => {
     const parsed = workflow();
     const preflight = parsed.jobs?.preflight_openclaw_npm;
+    const stepNames = preflight?.steps?.map((candidate) => candidate.name) ?? [];
 
+    const cleanup = step(preflight, "Clean preflight build outputs before cache restore");
     const restore = step(preflight, "Restore preflight build outputs");
+    expect(stepNames.indexOf(cleanup.name)).toBeLessThan(stepNames.indexOf(restore.name));
+    expect(cleanup.run).toContain("rm -rf -- dist dist-runtime packages/*/dist");
+    expect(cleanup.run).toContain("-path '*/src/host/*'");
+    expect(cleanup.run).toContain("-name '.bundle.hash'");
+    expect(cleanup.run).toContain("-name '*.bundle.js'");
     expect(restore.uses).toContain("actions/cache/restore@");
+    expect(restore.with?.path).toContain("dist/");
+    expect(restore.with?.path).toContain("dist-runtime/");
+    expect(restore.with?.path).toContain("packages/*/dist/");
+    expect(restore.with?.path).toContain("extensions/*/src/host/**/.bundle.hash");
+    expect(restore.with?.path).toContain("extensions/*/src/host/**/*.bundle.js");
     expect(restore.with?.key).toBe(
       "${{ runner.os }}-npm-preflight-dist-v1-${{ steps.preflight_cache_key.outputs.sha }}-${{ hashFiles('pnpm-lock.yaml') }}",
     );

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1319,6 +1319,18 @@ describe("scripts/test-projects changed-target routing", () => {
     });
   });
 
+  it("keeps npm release workflow edits on the preflight cache guard", () => {
+    expect(resolveChangedTestTargetPlan([".github/workflows/openclaw-npm-release.yml"])).toEqual({
+      mode: "targets",
+      targets: [
+        "test/openclaw-npm-postpublish-verify.test.ts",
+        "test/scripts/openclaw-npm-extended-stable-workflow.test.ts",
+        "test/scripts/package-acceptance-workflow.test.ts",
+        "test/scripts/ci-workflow-guards.test.ts",
+      ],
+    });
+  });
+
   it("keeps generated locale publisher and inventory edits on workflow guards", () => {
     for (const actionPath of [
       ".github/actions/create-generated-pr-tokens/action.yml",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rerunning the npm release preflight at the same SHA could fail package-content validation because stale private-QA build files survived the build-cache restore.

## Why This Change Was Made

The setup action may restore a broader build-all snapshot before the release-specific cache is restored. The release job now clears every cached output root first, so the immutable preflight cache replaces those outputs instead of overlaying them. A focused workflow guard locks the cleanup order and complete output-root inventory, and changed-test routing ensures that guard runs for future edits to this workflow.

## User Impact

Release operators can rerun an unchanged npm preflight without stale files from an earlier build contaminating the package candidate. There is no product runtime behavior change.

## Evidence

- `actionlint .github/workflows/openclaw-npm-release.yml`
- `git diff --check`
- `node scripts/run-vitest.mjs test/scripts/openclaw-npm-extended-stable-workflow.test.ts` — 11 passed on Blacksmith Testbox
- Autoreview: clean, no accepted or actionable findings
