### PR TITLE
fix(security): detect child_process calls through aliases and computed members (#116255)

### DIFF
--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -256,6 +256,14 @@ proc["exec"]("node server.js");
       expected: { ruleId: "dangerous-exec", severity: "critical" as const },
     },
     {
+      name: "detects bare child_process exec through a namespace alias",
+      source: `
+const proc = require("child_process");
+proc.exec("node server.js");
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
       name: "detects eval usage",
       source: `
 const code = "1+1";

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -248,6 +248,14 @@ cp["spawn"]("node", ["server.js"]);
       expected: { ruleId: "dangerous-exec", severity: "critical" as const },
     },
     {
+      name: "detects computed child_process exec through a namespace alias",
+      source: `
+const proc = require("child_process");
+proc["exec"]("node server.js");
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
       name: "detects eval usage",
       source: `
 const code = "1+1";

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -224,6 +224,30 @@ cp.exec("node server.js");
       expected: { ruleId: "dangerous-exec", severity: "critical" as const },
     },
     {
+      name: "detects child_process call through an ESM import alias",
+      source: `
+import { spawn as launch } from "node:child_process";
+launch("node", ["server.js"]);
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
+      name: "detects child_process call through a CJS destructured alias",
+      source: `
+const { exec: run } = require("child_process");
+run("node server.js");
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
+      name: "detects child_process call through a computed member",
+      source: `
+import cp from "node:child_process";
+cp["spawn"]("node", ["server.js"]);
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
       name: "detects eval usage",
       source: `
 const code = "1+1";
@@ -308,6 +332,28 @@ const options: ExecOptions = { timeout: 5000 };
 import type { ExecOptions } from "child_process";
 const options: ExecOptions = {};
 const match = /^keychain:(.+)$/.exec(value);
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expectRulePresence(findings, "dangerous-exec", false);
+  });
+
+  it("does not flag an alias call when the alias is not from child_process", () => {
+    // child_process appears via a type import (so the context gate passes),
+    // but the `launch` alias is bound from an unrelated module. The alias map's
+    // source scoping — not the gate — must suppress this finding.
+    const source = `
+import { spawn as launch } from "./other-module";
+import type { ExecOptions } from "child_process";
+launch("node", ["server.js"]);
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expectRulePresence(findings, "dangerous-exec", false);
+  });
+
+  it("does not flag a computed RegExp.exec-style call on a non-child_process object", () => {
+    const source = `
+const { exec } = require("child_process");
+const m = re["exec"](value);
 `;
     const findings = scanSource(source, "plugin.ts");
     expectRulePresence(findings, "dangerous-exec", false);

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -279,7 +279,11 @@ const SKILL_CONTENT_RULES: SourceRule[] = [
 // Core scanner
 // ---------------------------------------------------------------------------
 
-function isBenignMemberExecMatch(line: string, match: RegExpExecArray): boolean {
+function isBenignMemberExecMatch(
+  line: string,
+  match: RegExpExecArray,
+  namespaceAliases: ReadonlySet<string>,
+): boolean {
   // Group 1 is the bare-call command; group 2 is the computed-member command.
   const command = match[1] ?? match[2];
   if (command !== "exec") {
@@ -296,10 +300,17 @@ function isBenignMemberExecMatch(line: string, match: RegExpExecArray): boolean 
     return !/\b(?:cp|childProcess|child_process)\s*\.\s*exec\s*\(/.test(line);
   }
 
-  // Computed form `["exec"](`: benign unless the object is a known
-  // child_process namespace. This preserves the RegExp.exec-style benign
-  // behavior for `someObj["exec"](` while still catching `cp["exec"](`.
-  return !/\b(?:cp|childProcess|child_process)\s*\[\s*["']exec["']\s*\]\s*\(/.test(line);
+  // Computed form `["exec"](`: benign unless the object is a known child_process
+  // namespace (including aliases bound from child_process imports/requires).
+  // This preserves the RegExp.exec-style benign behavior for `someObj["exec"](`
+  // while still catching `cp["exec"](` and `proc["exec"](` when `proc` is a
+  // child_process namespace alias.
+  for (const namespace of namespaceAliases) {
+    if (new RegExp(`\\b${namespace}\\s*\\[\\s*["']exec["']\\s*\\]\\s*\\(`).test(line)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 const DANGEROUS_EXEC_METHODS = new Set([
@@ -313,6 +324,13 @@ const DANGEROUS_EXEC_METHODS = new Set([
 
 const EMPTY_ALIAS_MAP = new Map<string, string>();
 
+// Known child_process namespace receiver names that always indicate a real
+// child_process call (never a benign RegExp.exec). Seeded with the literals
+// the bare-filter already recognized, then augmented with namespace aliases
+// collected from imports/requires so `proc["exec"]()` fires when `proc` is
+// bound from child_process.
+const DEFAULT_NAMESPACE_ALIASES = new Set(["cp", "childProcess", "child_process"]);
+
 // Matches `import { ... } from "child_process"` (ESM) or
 // `{ ... } = require("child_process")` (CJS) and collects `original -> alias`
 // bindings for dangerous exec methods. Only bindings sourced from
@@ -324,6 +342,13 @@ const CHILD_PROCESS_REQUIRE_PATTERN =
   /\{\s*([^}]*)\s*\}\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/;
 const ESM_ALIAS_PATTERN = /\b(\w+)\s+as\s+(\w+)/g;
 const CJS_ALIAS_PATTERN = /\b(\w+)\s*:\s*(\w+)/g;
+// Namespace imports/requires: `import cp from "child_process"`,
+// `import * as cp from "child_process"`, `const cp = require("child_process")`.
+// The negative lookahead excludes `import type { ... }`.
+const NAMESPACE_IMPORT_PATTERN =
+  /import\s+(?!type\b)(?:\*\s+as\s+)?(\w+)\s+from\s*["'](?:node:)?child_process["']/;
+const NAMESPACE_REQUIRE_PATTERN =
+  /(?:const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/;
 
 function collectChildProcessAliases(lines: readonly string[]): Map<string, string> {
   const aliases = new Map<string, string>();
@@ -356,6 +381,19 @@ function matchChildProcessAliasCall(line: string, aliases: Map<string, string>):
     }
   }
   return false;
+}
+
+function collectChildProcessNamespaceAliases(lines: readonly string[]): Set<string> {
+  const aliases = new Set<string>(DEFAULT_NAMESPACE_ALIASES);
+  for (const line of lines) {
+    const importMatch = NAMESPACE_IMPORT_PATTERN.exec(line);
+    const requireMatch = !importMatch ? NAMESPACE_REQUIRE_PATTERN.exec(line) : null;
+    const name = importMatch?.[1] ?? requireMatch?.[1];
+    if (name !== undefined) {
+      aliases.add(name);
+    }
+  }
+  return aliases;
 }
 
 function stripCommentsForHeuristics(source: string): string {
@@ -475,6 +513,12 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
     // guarantees child_process is present whenever aliases can exist.
     const childProcessAliases =
       rule.ruleId === "dangerous-exec" ? collectChildProcessAliases(lines) : EMPTY_ALIAS_MAP;
+    // Namespace receiver aliases (e.g. `const proc = require("child_process")`)
+    // so computed `["exec"](` on a renamed namespace is not treated as benign.
+    const childProcessNamespaceAliases =
+      rule.ruleId === "dangerous-exec"
+        ? collectChildProcessNamespaceAliases(lines)
+        : DEFAULT_NAMESPACE_ALIASES;
 
     let acceptedMatches = 0;
     let omittedMatches = 0;
@@ -488,7 +532,10 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
       );
       let matchedOnLine = false;
       for (const match of matches) {
-        if (rule.ruleId === "dangerous-exec" && isBenignMemberExecMatch(line, match)) {
+        if (
+          rule.ruleId === "dangerous-exec" &&
+          isBenignMemberExecMatch(line, match, childProcessNamespaceAliases)
+        ) {
           continue;
         }
 

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -168,7 +168,10 @@ const LINE_RULES: LineRule[] = [
     ruleId: "dangerous-exec",
     severity: "critical",
     message: "Shell command execution detected (child_process)",
-    pattern: /\b(exec|execSync|spawn|spawnSync|execFile|execFileSync)\s*\(/,
+    // Group 1: bare call (exec(...)). Group 2: computed member (obj["exec"](...)),
+    // with quotes stripped so isBenignMemberExecMatch sees the bare command.
+    pattern:
+      /\b(exec|execSync|spawn|spawnSync|execFile|execFileSync)\s*\(|["'](exec|execSync|spawn|spawnSync|execFile|execFileSync)["']\s*\]\s*\(/,
     requiresContext: /child_process/,
   },
   {
@@ -277,17 +280,82 @@ const SKILL_CONTENT_RULES: SourceRule[] = [
 // ---------------------------------------------------------------------------
 
 function isBenignMemberExecMatch(line: string, match: RegExpExecArray): boolean {
-  const command = match[1];
+  // Group 1 is the bare-call command; group 2 is the computed-member command.
+  const command = match[1] ?? match[2];
   if (command !== "exec") {
     return false;
   }
 
-  const matchIndex = match.index;
-  if (matchIndex <= 0 || line[matchIndex - 1] !== ".") {
-    return false;
+  if (match[1] !== undefined) {
+    // Bare form: only `.exec(` (e.g. RegExp.exec) is benign, unless the object
+    // is a known child_process namespace.
+    const matchIndex = match.index;
+    if (matchIndex <= 0 || line[matchIndex - 1] !== ".") {
+      return false;
+    }
+    return !/\b(?:cp|childProcess|child_process)\s*\.\s*exec\s*\(/.test(line);
   }
 
-  return !/\b(?:cp|childProcess|child_process)\s*\.\s*exec\s*\(/.test(line);
+  // Computed form `["exec"](`: benign unless the object is a known
+  // child_process namespace. This preserves the RegExp.exec-style benign
+  // behavior for `someObj["exec"](` while still catching `cp["exec"](`.
+  return !/\b(?:cp|childProcess|child_process)\s*\[\s*["']exec["']\s*\]\s*\(/.test(line);
+}
+
+const DANGEROUS_EXEC_METHODS = new Set([
+  "exec",
+  "execSync",
+  "spawn",
+  "spawnSync",
+  "execFile",
+  "execFileSync",
+]);
+
+const EMPTY_ALIAS_MAP = new Map<string, string>();
+
+// Matches `import { ... } from "child_process"` (ESM) or
+// `{ ... } = require("child_process")` (CJS) and collects `original -> alias`
+// bindings for dangerous exec methods. Only bindings sourced from
+// child_process are tracked, so an unrelated `launch(` in a file that also
+// imports child_process for something else does not false-positive.
+const CHILD_PROCESS_IMPORT_PATTERN =
+  /import\s*\{([^}]*)\}\s*from\s*["'](?:node:)?child_process["']/;
+const CHILD_PROCESS_REQUIRE_PATTERN =
+  /\{\s*([^}]*)\s*\}\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/;
+const ESM_ALIAS_PATTERN = /\b(\w+)\s+as\s+(\w+)/g;
+const CJS_ALIAS_PATTERN = /\b(\w+)\s*:\s*(\w+)/g;
+
+function collectChildProcessAliases(lines: readonly string[]): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const line of lines) {
+    const importMatch = CHILD_PROCESS_IMPORT_PATTERN.exec(line);
+    const requireMatch = !importMatch ? CHILD_PROCESS_REQUIRE_PATTERN.exec(line) : null;
+    const bindingList = importMatch?.[1] ?? requireMatch?.[1];
+    if (bindingList === undefined) {
+      continue;
+    }
+    const aliasPattern = importMatch ? ESM_ALIAS_PATTERN : CJS_ALIAS_PATTERN;
+    aliasPattern.lastIndex = 0;
+    let aliasMatch: RegExpExecArray | null;
+    while ((aliasMatch = aliasPattern.exec(bindingList)) !== null) {
+      // ESM: group1=original, group2=alias. CJS: group1=original, group2=alias.
+      const original = aliasMatch[1];
+      const alias = aliasMatch[2];
+      if (DANGEROUS_EXEC_METHODS.has(original)) {
+        aliases.set(alias, original);
+      }
+    }
+  }
+  return aliases;
+}
+
+function matchChildProcessAliasCall(line: string, aliases: Map<string, string>): boolean {
+  for (const alias of aliases.keys()) {
+    if (new RegExp(`\\b${alias}\\s*\\(`).test(line)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function stripCommentsForHeuristics(source: string): string {
@@ -401,6 +469,13 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
       continue;
     }
 
+    // For dangerous-exec, track child_process import/require aliases so calls
+    // made through a renamed binding (e.g. `import { spawn as launch }`) are
+    // still flagged. Built once per rule; the requiresContext gate above
+    // guarantees child_process is present whenever aliases can exist.
+    const childProcessAliases =
+      rule.ruleId === "dangerous-exec" ? collectChildProcessAliases(lines) : EMPTY_ALIAS_MAP;
+
     let acceptedMatches = 0;
     let omittedMatches = 0;
     let lastOmittedLine: number | undefined;
@@ -411,6 +486,7 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
           rule.pattern.flags.includes("g") ? rule.pattern.flags : `${rule.pattern.flags}g`,
         ),
       );
+      let matchedOnLine = false;
       for (const match of matches) {
         if (rule.ruleId === "dangerous-exec" && isBenignMemberExecMatch(line, match)) {
           continue;
@@ -424,6 +500,7 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
           }
         }
 
+        matchedOnLine = true;
         if (acceptedMatches >= MAX_LINE_RULE_FINDINGS_PER_RULE) {
           omittedMatches += 1;
           lastOmittedLine = i + 1;
@@ -441,6 +518,31 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
           evidence: formatScanEvidence(line),
         });
         acceptedMatches += 1;
+      }
+
+      // No direct pattern match on this line: still catch child_process calls
+      // made through a renamed binding (alias) that the bare-name pattern
+      // cannot see. Only applies to dangerous-exec with collected aliases.
+      if (
+        !matchedOnLine &&
+        rule.ruleId === "dangerous-exec" &&
+        childProcessAliases.size > 0 &&
+        matchChildProcessAliasCall(line, childProcessAliases)
+      ) {
+        if (acceptedMatches >= MAX_LINE_RULE_FINDINGS_PER_RULE) {
+          omittedMatches += 1;
+          lastOmittedLine = i + 1;
+        } else {
+          findings.push({
+            ruleId: rule.ruleId,
+            severity: rule.severity,
+            file: filePath,
+            line: i + 1,
+            message: rule.message,
+            evidence: formatScanEvidence(line),
+          });
+          acceptedMatches += 1;
+        }
       }
     }
     if (lastOmittedLine !== undefined) {

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -341,7 +341,7 @@ function collectChildProcessAliases(lines: readonly string[]): Map<string, strin
       // ESM: group1=original, group2=alias. CJS: group1=original, group2=alias.
       const original = aliasMatch[1];
       const alias = aliasMatch[2];
-      if (DANGEROUS_EXEC_METHODS.has(original)) {
+      if (original !== undefined && alias !== undefined && DANGEROUS_EXEC_METHODS.has(original)) {
         aliases.set(alias, original);
       }
     }

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -292,12 +292,19 @@ function isBenignMemberExecMatch(
 
   if (match[1] !== undefined) {
     // Bare form: only `.exec(` (e.g. RegExp.exec) is benign, unless the object
-    // is a known child_process namespace.
+    // is a known child_process namespace (including aliases bound from
+    // child_process imports/requires, so `proc.exec(` fires when `proc` is a
+    // child_process namespace alias).
     const matchIndex = match.index;
     if (matchIndex <= 0 || line[matchIndex - 1] !== ".") {
       return false;
     }
-    return !/\b(?:cp|childProcess|child_process)\s*\.\s*exec\s*\(/.test(line);
+    for (const namespace of namespaceAliases) {
+      if (new RegExp(`\\b${namespace}\\s*\\.\\s*exec\\s*\\(`).test(line)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   // Computed form `["exec"](`: benign unless the object is a known child_process


### PR DESCRIPTION
## What Problem This Solves

The advisory source scanner's `dangerous-exec` rule missed three `child_process` invocation forms that each should produce a critical finding:

- **ESM import alias:** `import { spawn as launch } from "node:child_process";` then `launch("node", ["server.js"]);`
- **CJS destructured alias:** `const { exec: run } = require("child_process");` then `run("node server.js");`
- **computed member:** `import cp from "node:child_process";` then `cp["spawn"]("node", ["server.js"]);`

The rule pattern (`/\b(exec|execSync|spawn|...)\s*\(/`) only matched bare command names, and the scanner had no cross-line binding tracking — so an aliased call (`launch(...)`, `run(...)`) and a computed access (`cp["spawn"](...)`) both escaped detection even though `child_process` was present in the file (the `requiresContext` gate passed).

Fixes #116255

## Why This Change Was Made

The scanner is purely line-based regex (no AST). The fix stays within that model (consistent with the existing `isBenignMemberExecMatch` and `stripCommentsForHeuristics` helpers) rather than introducing a parser:

- **Computed members** are a pure regex gap — extend the pattern with a second branch `["'](exec|...|spawn|...)["']\s*\]\s*\(` that captures the bare command name (quotes stripped) so `isBenignMemberExecMatch` keeps working.
- **Aliases** require linking a renamed binding to its `child_process` origin. A narrow `collectChildProcessAliases` helper collects `original -> alias` bindings **only** from actual `child_process` imports/requires (so an unrelated `launch` alias bound from another module does not false-positive — this is the issue's "avoid source-wide token correlation false positives" constraint). The scan loop then flags alias call sites when no direct pattern match fired on the line.

`isBenignMemberExecMatch` is updated so computed `["exec"](` on a non-child_process object stays benign (preserving the `RegExp.exec` negative behavior), while `cp["exec"](` still fires.

## User Impact

- **Before:** a Skill Workshop proposal (or other scanned source) using one of these three forms scanned as `clean`, missing a real shell-execution primitive.
- **After:** each form produces one critical `dangerous-exec` finding on the call line. Existing detections (`exec(...)`, `cp.spawn(...)`, `cp.exec(...)`) and the `RegExp.exec` benign exclusion are unchanged.

## Evidence

**Behavior addressed:** all three issue examples now produce a `dangerous-exec` finding; `RegExp.exec` and non-child_process aliases still do not.

**Validation (trusted source, local checkout on Node 24.18.0):**

```
node scripts/run-vitest.mjs src/skills/security/scanner.test.ts
# Test Files 1 passed (1) | Tests 38 passed (38)
```

New test coverage:
- Positive (in `scanRuleCases`, run via `expectScanRule`):
  - `detects child_process call through an ESM import alias` — `import { spawn as launch }` then `launch(...)` → finding.
  - `detects child_process call through a CJS destructured alias` — `const { exec: run } = require("child_process")` then `run(...)` → finding.
  - `detects child_process call through a computed member` — `cp["spawn"](...)` → finding.
- Negative (new `it` blocks):
  - `does not flag an alias call when the alias is not from child_process` — `import { spawn as launch } from "./other-module"` + a `child_process` type import (gate passes) + `launch(...)` → no finding. Proves the alias map's source scoping, not the gate, suppresses it.
  - `does not flag a computed RegExp.exec-style call on a non-child_process object` — `re["exec"](value)` → no finding. Proves the computed benign branch.

Existing positive cases (`exec`, `cp.spawn`, `cp.exec`) and existing negative cases (`import type { ExecOptions }` without a call, `RegExp.exec` `.exec(` benign) pass unchanged.

**Boundary:** change is internal to `src/skills/security/scanner.ts` (no exported-type change, no new `LineRule` field); the scanner stays regex-based with no AST.



**Real behavior proof (trusted source, local checkout on Node 24.18.0):**

A script drives the real production `scanSource()` entry point (no mocks) on the three issue examples plus the namespace-alias computed-exec case and the `RegExp.exec` negative case:

```json
{
  "proof": "scanner-child-process-alias-detection",
  "issue": "#116255",
  "results": [
    { "label": "ESM import alias",              "fired": true, "line": 2, "severity": "critical" },
    { "label": "CJS destructured alias",        "fired": true, "line": 2, "severity": "critical" },
    { "label": "computed member",               "fired": true, "line": 2, "severity": "critical" },
    { "label": "namespace-alias computed exec", "fired": true, "line": 2, "severity": "critical" },
    { "label": "RegExp.exec (must NOT fire)",   "fired": false }
  ]
}
```

All four attack forms produce a critical `dangerous-exec` finding on the call line; `RegExp.exec` does not fire (benign filter preserved). The namespace-alias case (`const proc = require("child_process"); proc["exec"](...)`) covers the P1 ClawSweeper flagged: a computed `exec` on a renamed child_process namespace now fires instead of being suppressed.

