### PR TITLE
feat(channels): grade sender identifier authentication in the ingress kernel

### DIFF
--- a/src/channels/message-access/allowlist.ts
+++ b/src/channels/message-access/allowlist.ts
@@ -4,6 +4,13 @@
  * Merges allowlists, applies mutable identifier policy, and redacts access-graph facts.
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import {
+  identifierAuthenticationFrom,
+  meetsIdentifierAuthentication,
+  minimumIdentifierAuthenticationFrom,
+  weakestIdentifierAuthentication,
+  type IdentifierAuthentication,
+} from "./identifier-authentication.js";
 import type {
   ChannelIngressPolicyInput,
   ChannelIngressState,
@@ -11,6 +18,7 @@ import type {
   RedactedIngressAllowlistFacts,
   RedactedIngressEntryDiagnostic,
   ResolvedIngressAllowlist,
+  SubjectIdentifierAuthentication,
 } from "./types.js";
 
 /**
@@ -84,40 +92,69 @@ function mergeResolvedAllowlists(
 }
 
 /**
- * Applies mutable identifier matching policy to an already-resolved allowlist.
+ * Strength an entry can actually carry for this message.
+ *
+ * An entry is matched by a subject identifier of the same kind, so the subject side is read
+ * by kind. A wildcard entry is built from the primary identity field and so carries the
+ * primary kind, which makes "how well do we know who this is" the question it answers, with
+ * no special case.
  */
-export function applyMutableIdentifierPolicy(
-  allowlist: ResolvedIngressAllowlist,
-  policy: ChannelIngressPolicyInput,
-): ResolvedIngressAllowlist {
-  if (policy.mutableIdentifierMatching === "enabled") {
-    return allowlist;
-  }
-  const dangerousEntryIds = new Set(
-    allowlist.normalizedEntries
-      .filter((entry) => entry.dangerous)
-      .map((entry) => entry.opaqueEntryId),
+function effectiveEntryAuthentication(params: {
+  entry: ResolvedIngressAllowlist["normalizedEntries"][number];
+  subjectAuthentication: SubjectIdentifierAuthentication;
+}): IdentifierAuthentication {
+  const entry = identifierAuthenticationFrom(params.entry);
+  const subject = params.subjectAuthentication[params.entry.kind];
+  // An absent subject claim does not weaken: the channel made no per-message statement.
+  return subject ? weakestIdentifierAuthentication(entry, subject) : entry;
+}
+
+/**
+ * Drops allowlist entries whose identifier claim is too weak to authorize this message.
+ *
+ * Runs after matching rather than during it so a rejected entry stays visible as a
+ * diagnostic. An operator who allowlisted a display name should be told it was ignored,
+ * not left to infer it from an unexplained block.
+ */
+export function applyIdentifierAuthenticationPolicy(params: {
+  allowlist: ResolvedIngressAllowlist;
+  policy: ChannelIngressPolicyInput;
+  subjectAuthentication?: SubjectIdentifierAuthentication;
+}): ResolvedIngressAllowlist {
+  const minimum = minimumIdentifierAuthenticationFrom(params.policy);
+  const subjectAuthentication = params.subjectAuthentication ?? {};
+  const { allowlist } = params;
+  const rejected = allowlist.normalizedEntries.filter(
+    (entry) =>
+      !meetsIdentifierAuthentication(
+        effectiveEntryAuthentication({ entry, subjectAuthentication }),
+        minimum,
+      ),
   );
-  if (dangerousEntryIds.size === 0) {
+  if (rejected.length === 0) {
     return allowlist;
   }
-  // Username-like mutable identifiers can be present for diagnostics, but when the policy
-  // disables them they must not authorize a sender.
-  const matchedEntryIds = allowlist.matchedEntryIds.filter((id) => !dangerousEntryIds.has(id));
+  const rejectedEntryIds = new Set(rejected.map((entry) => entry.opaqueEntryId));
+  const matchedEntryIds = allowlist.matchedEntryIds.filter((id) => !rejectedEntryIds.has(id));
   const disabledEntries: RedactedIngressEntryDiagnostic[] = [
     ...allowlist.disabledEntries,
-    ...allowlist.normalizedEntries
-      .filter((entry) => entry.dangerous)
-      .map((entry) => ({
-        opaqueEntryId: entry.opaqueEntryId,
-        reasonCode: "mutable_identifier_disabled" as const,
-      })),
+    ...rejected.map((entry) => ({
+      opaqueEntryId: entry.opaqueEntryId,
+      // The alias case keeps its long-standing code so existing diagnostics do not shift;
+      // the new code covers weakness the two-level policy could not express.
+      reasonCode:
+        identifierAuthenticationFrom(entry) === "mutable"
+          ? ("mutable_identifier_disabled" as const)
+          : ("identifier_authentication_too_weak" as const),
+    })),
   ];
   return {
     ...allowlist,
     disabledEntries,
     matchedEntryIds,
-    hasMatchableEntries: allowlist.normalizedEntries.some((entry) => !entry.dangerous),
+    hasMatchableEntries: allowlist.normalizedEntries.some(
+      (entry) => !rejectedEntryIds.has(entry.opaqueEntryId),
+    ),
     match: {
       matched: matchedEntryIds.length > 0,
       matchedEntryIds,
@@ -148,5 +185,9 @@ export function effectiveGroupSenderAllowlist(params: {
     // Route sender policies other than inherit replace the channel-level sender allowlist.
     effective = route.senderAllowlist;
   }
-  return applyMutableIdentifierPolicy(effective, params.policy);
+  return applyIdentifierAuthenticationPolicy({
+    allowlist: effective,
+    policy: params.policy,
+    subjectAuthentication: params.state.subjectAuthentication,
+  });
 }

--- a/src/channels/message-access/allowlist.ts
+++ b/src/channels/message-access/allowlist.ts
@@ -102,12 +102,19 @@ function mergeResolvedAllowlists(
 function effectiveEntryAuthentication(params: {
   entry: ResolvedIngressAllowlist["normalizedEntries"][number];
   subjectAuthentication: SubjectIdentifierAuthentication;
-  subjectIdentifierKinds: ReadonlySet<string>;
+  subjectIdentifierKinds: ReadonlySet<string> | undefined;
 }): IdentifierAuthentication {
   const entry = identifierAuthenticationFrom(params.entry);
   // A wildcard is normalized against one identity field. It cannot borrow that field's
-  // strength when the inbound subject did not carry the field at all.
-  if (params.entry.wildcard && !params.subjectIdentifierKinds.has(params.entry.kind)) {
+  // strength when the inbound subject did not carry the field at all. Only downgrade when the
+  // subject's carried kinds are actually known: an absent set is a caller that made no claim,
+  // and, exactly like an absent per-message authentication below, must not weaken the entry.
+  // The resolver always populates it, so this preserves the check on the real ingress path.
+  if (
+    params.entry.wildcard &&
+    params.subjectIdentifierKinds &&
+    !params.subjectIdentifierKinds.has(params.entry.kind)
+  ) {
     return "mutable";
   }
   const subject = params.subjectAuthentication[params.entry.kind];
@@ -130,7 +137,12 @@ export function applyIdentifierAuthenticationPolicy(params: {
 }): ResolvedIngressAllowlist {
   const minimum = minimumIdentifierAuthenticationFrom(params.policy);
   const subjectAuthentication = params.subjectAuthentication ?? {};
-  const subjectIdentifierKinds = new Set(params.subjectIdentifierKinds ?? []);
+  // Undefined, not an empty set, when the caller omitted it: an empty set would read as "the
+  // subject carried no kinds" and wrongly downgrade every wildcard. The resolver always
+  // supplies the real kinds; a hand-built state that omits them keeps the pre-policy behavior.
+  const subjectIdentifierKinds = params.subjectIdentifierKinds
+    ? new Set(params.subjectIdentifierKinds)
+    : undefined;
   const { allowlist } = params;
   const rejected = allowlist.normalizedEntries.filter(
     (entry) =>

--- a/src/channels/message-access/allowlist.ts
+++ b/src/channels/message-access/allowlist.ts
@@ -102,8 +102,14 @@ function mergeResolvedAllowlists(
 function effectiveEntryAuthentication(params: {
   entry: ResolvedIngressAllowlist["normalizedEntries"][number];
   subjectAuthentication: SubjectIdentifierAuthentication;
+  subjectIdentifierKinds: ReadonlySet<string>;
 }): IdentifierAuthentication {
   const entry = identifierAuthenticationFrom(params.entry);
+  // A wildcard is normalized against one identity field. It cannot borrow that field's
+  // strength when the inbound subject did not carry the field at all.
+  if (params.entry.wildcard && !params.subjectIdentifierKinds.has(params.entry.kind)) {
+    return "mutable";
+  }
   const subject = params.subjectAuthentication[params.entry.kind];
   // An absent subject claim does not weaken: the channel made no per-message statement.
   return subject ? weakestIdentifierAuthentication(entry, subject) : entry;
@@ -120,14 +126,16 @@ export function applyIdentifierAuthenticationPolicy(params: {
   allowlist: ResolvedIngressAllowlist;
   policy: ChannelIngressPolicyInput;
   subjectAuthentication?: SubjectIdentifierAuthentication;
+  subjectIdentifierKinds?: readonly string[];
 }): ResolvedIngressAllowlist {
   const minimum = minimumIdentifierAuthenticationFrom(params.policy);
   const subjectAuthentication = params.subjectAuthentication ?? {};
+  const subjectIdentifierKinds = new Set(params.subjectIdentifierKinds ?? []);
   const { allowlist } = params;
   const rejected = allowlist.normalizedEntries.filter(
     (entry) =>
       !meetsIdentifierAuthentication(
-        effectiveEntryAuthentication({ entry, subjectAuthentication }),
+        effectiveEntryAuthentication({ entry, subjectAuthentication, subjectIdentifierKinds }),
         minimum,
       ),
   );
@@ -189,5 +197,6 @@ export function effectiveGroupSenderAllowlist(params: {
     allowlist: effective,
     policy: params.policy,
     subjectAuthentication: params.state.subjectAuthentication,
+    subjectIdentifierKinds: params.state.subjectIdentifierKinds,
   });
 }

--- a/src/channels/message-access/decision.ts
+++ b/src/channels/message-access/decision.ts
@@ -9,7 +9,7 @@ import {
   allowedImplicitMentionKindsFromConfig,
   resolveInboundMentionDecision,
 } from "../mention-gating.js";
-import { applyMutableIdentifierPolicy, redactedAllowlistDiagnostics } from "./allowlist.js";
+import { applyIdentifierAuthenticationPolicy, redactedAllowlistDiagnostics } from "./allowlist.js";
 import {
   applyEventAuthModeToSenderGate,
   senderGateForDirect,
@@ -95,10 +95,20 @@ function commandGate(params: {
     };
   }
   const useAccessGroups = command.useAccessGroups ?? true;
-  // Command authorization combines owner and group allowlists after mutable-id policy so
-  // command control cannot be granted by identifiers the current policy rejects.
-  const owner = applyMutableIdentifierPolicy(params.state.allowlists.commandOwner, params.policy);
-  const group = applyMutableIdentifierPolicy(params.state.allowlists.commandGroup, params.policy);
+  // Command authorization combines owner and group allowlists after the identifier
+  // authentication gate so command control cannot be granted by identifiers this policy,
+  // or this message, does not support.
+  const subjectAuthentication = params.state.subjectAuthentication;
+  const owner = applyIdentifierAuthenticationPolicy({
+    allowlist: params.state.allowlists.commandOwner,
+    policy: params.policy,
+    subjectAuthentication,
+  });
+  const group = applyIdentifierAuthenticationPolicy({
+    allowlist: params.state.allowlists.commandGroup,
+    policy: params.policy,
+    subjectAuthentication,
+  });
   const authorized = resolveCommandAuthorizedFromAuthorizers({
     useAccessGroups,
     modeWhenAccessGroupsOff: command.modeWhenAccessGroupsOff,

--- a/src/channels/message-access/decision.ts
+++ b/src/channels/message-access/decision.ts
@@ -11,6 +11,10 @@ import {
 } from "../mention-gating.js";
 import { applyIdentifierAuthenticationPolicy, redactedAllowlistDiagnostics } from "./allowlist.js";
 import {
+  meetsIdentifierAuthentication,
+  minimumIdentifierAuthenticationFrom,
+} from "./identifier-authentication.js";
+import {
   applyEventAuthModeToSenderGate,
   senderGateForDirect,
   senderGateForGroup,
@@ -103,11 +107,13 @@ function commandGate(params: {
     allowlist: params.state.allowlists.commandOwner,
     policy: params.policy,
     subjectAuthentication,
+    subjectIdentifierKinds: params.state.subjectIdentifierKinds,
   });
   const group = applyIdentifierAuthenticationPolicy({
     allowlist: params.state.allowlists.commandGroup,
     policy: params.policy,
     subjectAuthentication,
+    subjectIdentifierKinds: params.state.subjectIdentifierKinds,
   });
   const authorized = resolveCommandAuthorizedFromAuthorizers({
     useAccessGroups,
@@ -148,6 +154,7 @@ function mergeCommandMatch(
 
 function eventGate(params: {
   state: ChannelIngressState;
+  policy: ChannelIngressPolicyInput;
   senderGate: AccessGraphGate;
   commandGate: AccessGraphGate;
 }): AccessGraphGate {
@@ -181,7 +188,14 @@ function eventGate(params: {
     if (!params.state.event.hasOriginSubject) {
       return eventResult(false, "origin_subject_missing");
     }
-    const matched = params.state.event.originSubjectMatched;
+    const authentication = params.state.event.originSubjectAuthentication;
+    const matched =
+      params.state.event.originSubjectMatched &&
+      authentication != null &&
+      meetsIdentifierAuthentication(
+        authentication,
+        minimumIdentifierAuthenticationFrom(params.policy),
+      );
     return eventResult(matched, matched ? "event_authorized" : "origin_subject_not_matched");
   }
   return eventResult(
@@ -347,7 +361,7 @@ export function decideChannelIngress(
     return decisiveDecision({ admission: "drop", decision: "block", gate: command, gates });
   }
 
-  const event = eventGate({ state, senderGate: eventModeSender, commandGate: command });
+  const event = eventGate({ state, policy, senderGate: eventModeSender, commandGate: command });
   gates.push(event);
   if (!event.allowed) {
     return decisiveDecision({ admission: "drop", decision: "block", gate: event, gates });

--- a/src/channels/message-access/decision.ts
+++ b/src/channels/message-access/decision.ts
@@ -11,6 +11,7 @@ import {
 } from "../mention-gating.js";
 import { applyIdentifierAuthenticationPolicy, redactedAllowlistDiagnostics } from "./allowlist.js";
 import {
+  DEFAULT_IDENTIFIER_AUTHENTICATION,
   meetsIdentifierAuthentication,
   minimumIdentifierAuthenticationFrom,
 } from "./identifier-authentication.js";
@@ -188,10 +189,14 @@ function eventGate(params: {
     if (!params.state.event.hasOriginSubject) {
       return eventResult(false, "origin_subject_missing");
     }
-    const authentication = params.state.event.originSubjectAuthentication;
+    // The resolver reports the matched origin identity's strength alongside the match. A
+    // hand-built state may set `originSubjectMatched` without a strength; treat that as the
+    // baseline `asserted` rather than a failed match, so the minimum is applied uniformly
+    // instead of silently dropping a matched legacy state.
+    const authentication =
+      params.state.event.originSubjectAuthentication ?? DEFAULT_IDENTIFIER_AUTHENTICATION;
     const matched =
       params.state.event.originSubjectMatched &&
-      authentication != null &&
       meetsIdentifierAuthentication(
         authentication,
         minimumIdentifierAuthenticationFrom(params.policy),

--- a/src/channels/message-access/identifier-authentication.test.ts
+++ b/src/channels/message-access/identifier-authentication.test.ts
@@ -1,0 +1,381 @@
+// Covers the graded identifier authentication gate: how entry-side and per-message claims
+// combine, and that channels which say nothing keep their current admissions.
+import { describe, expect, it } from "vitest";
+import { decideChannelIngress } from "./decision.js";
+import {
+  meetsIdentifierAuthentication,
+  minimumIdentifierAuthenticationFrom,
+  weakestIdentifierAuthentication,
+  type IdentifierAuthentication,
+} from "./identifier-authentication.js";
+import type {
+  ChannelIngressPolicyInput,
+  ChannelIngressStateInput,
+  InternalChannelIngressAdapter,
+  InternalChannelIngressSubject,
+} from "./index.js";
+import { resolveChannelIngressState } from "./state.js";
+
+/**
+ * Two kinds so the per-kind pairing is actually exercised: an address that a message can
+ * authenticate, and a display name that no message can. Mail is the motivating shape.
+ */
+const adapter: InternalChannelIngressAdapter = {
+  normalizeEntries({ entries }) {
+    return {
+      matchable: entries.map((entry, index) => {
+        const isName = entry.startsWith("name:");
+        return {
+          opaqueEntryId: `entry-${index + 1}`,
+          kind: isName ? ("username" as const) : ("email" as const),
+          value: entry,
+          ...(isName ? { authentication: "mutable" as const } : {}),
+        };
+      }),
+      invalid: [],
+      disabled: [],
+    };
+  },
+  matchSubject({ subject: inbound, entries }) {
+    const values = new Set(inbound.identifiers.map((identifier) => identifier.value));
+    const matchedEntryIds = entries
+      .filter((entry) => entry.value === "*" || values.has(entry.value))
+      .map((entry) => entry.opaqueEntryId);
+    return { matched: matchedEntryIds.length > 0, matchedEntryIds };
+  },
+};
+
+function subject(params: {
+  address: string;
+  addressAuthentication?: IdentifierAuthentication;
+  displayName?: string;
+}): InternalChannelIngressSubject {
+  return {
+    identifiers: [
+      {
+        opaqueId: "address",
+        kind: "email",
+        value: params.address,
+        ...(params.addressAuthentication ? { authentication: params.addressAuthentication } : {}),
+      },
+      ...(params.displayName
+        ? [{ opaqueId: "displayName", kind: "username" as const, value: params.displayName }]
+        : []),
+    ],
+  };
+}
+
+function input(overrides: Partial<ChannelIngressStateInput> = {}): ChannelIngressStateInput {
+  return {
+    channelId: "test",
+    accountId: "default",
+    subject: subject({ address: "operator@example.com" }),
+    conversation: { kind: "direct", id: "dm-1" },
+    adapter,
+    event: { kind: "message", authMode: "inbound", mayPair: false },
+    allowlists: { dm: ["operator@example.com"] },
+    ...overrides,
+  };
+}
+
+const allowlistPolicy: ChannelIngressPolicyInput = {
+  dmPolicy: "allowlist",
+  groupPolicy: "allowlist",
+};
+
+async function admit(
+  stateInput: ChannelIngressStateInput,
+  policy: ChannelIngressPolicyInput = allowlistPolicy,
+) {
+  return decideChannelIngress(await resolveChannelIngressState(stateInput), policy);
+}
+
+describe("identifier authentication scale", () => {
+  it("orders verified above asserted above unverified above mutable", () => {
+    expect(meetsIdentifierAuthentication("verified", "asserted")).toBe(true);
+    expect(meetsIdentifierAuthentication("asserted", "asserted")).toBe(true);
+    expect(meetsIdentifierAuthentication("unverified", "asserted")).toBe(false);
+    expect(meetsIdentifierAuthentication("mutable", "unverified")).toBe(false);
+    // The two weak levels are distinct, not aliases.
+    expect(meetsIdentifierAuthentication("unverified", "mutable")).toBe(true);
+  });
+
+  it("takes the weaker side, which is how entry and subject combine", () => {
+    expect(weakestIdentifierAuthentication("verified", "unverified")).toBe("unverified");
+    expect(weakestIdentifierAuthentication("asserted", "verified")).toBe("asserted");
+  });
+
+  it.each([
+    { policy: {}, expected: "asserted" },
+    { policy: { mutableIdentifierMatching: "enabled" as const }, expected: "mutable" },
+    { policy: { mutableIdentifierMatching: "disabled" as const }, expected: "asserted" },
+    // The graded knob is the newer, narrower statement, so it outranks the boolean.
+    {
+      policy: {
+        minIdentifierAuthentication: "verified" as const,
+        mutableIdentifierMatching: "enabled" as const,
+      },
+      expected: "verified",
+    },
+  ])("resolves minimum $expected", ({ policy, expected }) => {
+    expect(minimumIdentifierAuthenticationFrom(policy)).toBe(expected);
+  });
+});
+
+describe("channels that make no per-message claim", () => {
+  it("admits an undescribed entry at the shipped default", async () => {
+    // The whole compatibility bet: silence means `asserted`, and `asserted` clears the
+    // default minimum. Every channel on main is in exactly this state.
+    expect(await admit(input())).toMatchObject({ admission: "dispatch", decision: "allow" });
+  });
+
+  it("still rejects a mutable entry, with the long-standing reason code", async () => {
+    const stateInput = input({
+      subject: subject({ address: "someone@example.com", displayName: "name:Operator" }),
+      allowlists: { dm: ["name:Operator"] },
+    });
+    const state = await resolveChannelIngressState(stateInput);
+
+    expect(decideChannelIngress(state, allowlistPolicy)).toMatchObject({ admission: "drop" });
+    // Existing diagnostics must not shift under the new gate.
+    expect(state.allowlists.dm.normalizedEntries).toHaveLength(1);
+    const decision = decideChannelIngress(state, allowlistPolicy);
+    const gate = decision.graph.gates.find((candidate) => candidate.kind === "dmSender");
+    expect(gate?.allowlist?.disabledEntryCount).toBe(1);
+  });
+
+  it("admits that same mutable entry when the policy accepts aliases", async () => {
+    const stateInput = input({
+      subject: subject({ address: "someone@example.com", displayName: "name:Operator" }),
+      allowlists: { dm: ["name:Operator"] },
+    });
+    expect(
+      await admit(stateInput, { ...allowlistPolicy, mutableIdentifierMatching: "enabled" }),
+    ).toMatchObject({ admission: "dispatch" });
+  });
+});
+
+describe("per-message subject claims", () => {
+  it("rejects a matching entry when the message authenticated nothing", async () => {
+    // The mail case. The address is allowlisted and matched; the message did not prove the
+    // sender holds it, so the entry cannot authorize.
+    const state = await resolveChannelIngressState(
+      input({
+        subject: subject({ address: "operator@example.com", addressAuthentication: "unverified" }),
+      }),
+    );
+
+    expect(state.subjectAuthentication).toEqual({ email: "unverified" });
+    expect(decideChannelIngress(state, allowlistPolicy)).toMatchObject({ admission: "drop" });
+    expect(state.allowlists.dm.match.matched).toBe(true);
+  });
+
+  it("names the new reason on the disabled entry, not the alias reason", async () => {
+    const state = await resolveChannelIngressState(
+      input({
+        subject: subject({ address: "operator@example.com", addressAuthentication: "unverified" }),
+      }),
+    );
+    const decision = decideChannelIngress(state, allowlistPolicy);
+    const gate = decision.graph.gates.find((candidate) => candidate.kind === "dmSender");
+
+    expect(gate?.allowlist?.disabledEntryCount).toBe(1);
+    expect(gate?.allowlist?.matched).toBe(false);
+  });
+
+  it("admits the same sender when the message authenticated the address", async () => {
+    expect(
+      await admit(
+        input({
+          subject: subject({ address: "operator@example.com", addressAuthentication: "verified" }),
+        }),
+      ),
+    ).toMatchObject({ admission: "dispatch", decision: "allow" });
+  });
+
+  it("weakens only its own kind", async () => {
+    // An unauthenticated display name must not disqualify an address entry.
+    const state = await resolveChannelIngressState(
+      input({
+        subject: {
+          identifiers: [
+            { opaqueId: "address", kind: "email", value: "operator@example.com" },
+            {
+              opaqueId: "displayName",
+              kind: "username",
+              value: "name:Operator",
+              authentication: "mutable",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(state.subjectAuthentication).toEqual({ username: "mutable" });
+    expect(decideChannelIngress(state, allowlistPolicy)).toMatchObject({ admission: "dispatch" });
+  });
+
+  it("takes the weaker claim when one kind is described twice", async () => {
+    const state = await resolveChannelIngressState(
+      input({
+        subject: {
+          identifiers: [
+            {
+              opaqueId: "a",
+              kind: "email",
+              value: "operator@example.com",
+              authentication: "verified",
+            },
+            {
+              opaqueId: "b",
+              kind: "email",
+              value: "operator+tag@example.com",
+              authentication: "unverified",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(state.subjectAuthentication).toEqual({ email: "unverified" });
+  });
+
+  it("applies to a wildcard entry through the identifier it stands in for", async () => {
+    // A wildcard waives the allowlist, not authentication: an open channel still has to
+    // know who is speaking as well as the minimum requires.
+    const stateInput = input({
+      subject: subject({ address: "stranger@example.com", addressAuthentication: "unverified" }),
+      allowlists: { dm: ["*"] },
+    });
+    const wildcardAdapter: InternalChannelIngressAdapter = {
+      ...adapter,
+      normalizeEntries({ entries }) {
+        return {
+          matchable: entries.map((entry, index) => ({
+            opaqueEntryId: `entry-${index + 1}`,
+            kind: "email" as const,
+            value: entry,
+          })),
+          invalid: [],
+          disabled: [],
+        };
+      },
+    };
+
+    expect(await admit({ ...stateInput, adapter: wildcardAdapter })).toMatchObject({
+      admission: "drop",
+    });
+  });
+});
+
+describe("raising the minimum", () => {
+  /** Same shape as `adapter`, but the address field states what backs it. */
+  const declaredAdapter: InternalChannelIngressAdapter = {
+    ...adapter,
+    normalizeEntries({ entries }) {
+      return {
+        matchable: entries.map((entry, index) => ({
+          opaqueEntryId: `entry-${index + 1}`,
+          kind: "email" as const,
+          value: entry,
+          authentication: "verified" as const,
+        })),
+        invalid: [],
+        disabled: [],
+      };
+    },
+  };
+  const strict = { ...allowlistPolicy, minIdentifierAuthentication: "verified" as const };
+
+  it("rejects an entry the channel never described, however well the message did", async () => {
+    // Silence caps an entry at `asserted`, and `min()` cannot climb above it. Reaching
+    // `verified` is a claim a channel has to make explicitly; no per-message proof
+    // substitutes for it. This is what stops a strict posture from being satisfied by a
+    // channel that simply never said anything.
+    expect(
+      await admit(
+        input({
+          subject: subject({ address: "operator@example.com", addressAuthentication: "verified" }),
+        }),
+        strict,
+      ),
+    ).toMatchObject({ admission: "drop" });
+  });
+
+  it("admits when the channel declared verified and the message proved it", async () => {
+    expect(
+      await admit(
+        input({
+          adapter: declaredAdapter,
+          subject: subject({ address: "operator@example.com", addressAuthentication: "verified" }),
+        }),
+        strict,
+      ),
+    ).toMatchObject({ admission: "dispatch", decision: "allow" });
+  });
+
+  it("still rejects a declared-verified entry when the message proved less", async () => {
+    expect(
+      await admit(
+        input({
+          adapter: declaredAdapter,
+          subject: subject({ address: "operator@example.com", addressAuthentication: "asserted" }),
+        }),
+        strict,
+      ),
+    ).toMatchObject({ admission: "drop" });
+  });
+});
+
+describe("command authorization", () => {
+  // The command gate reads its own allowlists and has to apply the same bar, so a weak
+  // identifier must not become a control-command grant even when the sender gate passed on
+  // a different, stronger identifier.
+  function commandInput() {
+    return input({
+      subject: subject({ address: "operator@example.com", displayName: "name:Operator" }),
+      allowlists: { dm: ["operator@example.com"], commandOwner: ["name:Operator"] },
+    });
+  }
+  const withCommand = (
+    overrides: Partial<ChannelIngressPolicyInput> = {},
+  ): ChannelIngressPolicyInput => ({
+    ...allowlistPolicy,
+    command: { allowTextCommands: true, hasControlCommand: true },
+    ...overrides,
+  });
+
+  it("does not let an alias authorize a control command", async () => {
+    const decision = await admit(commandInput(), withCommand());
+
+    // The sender gate passes on the address, so the command gate is reached and is the one
+    // that rejects.
+    const commandGate = decision.graph.gates.find((gate) => gate.kind === "command");
+    expect(commandGate?.allowed).toBe(false);
+    expect(commandGate?.reasonCode).toBe("control_command_unauthorized");
+  });
+
+  it("lets it through when the policy accepts aliases", async () => {
+    const decision = await admit(
+      commandInput(),
+      withCommand({ mutableIdentifierMatching: "enabled" }),
+    );
+
+    expect(decision.graph.gates.find((gate) => gate.kind === "command")?.allowed).toBe(true);
+  });
+});
+
+describe("redaction", () => {
+  it("keeps raw sender values out of state and decisions", async () => {
+    const raw = "very-distinctive-sender@example.test";
+    const stateInput = input({
+      subject: subject({ address: raw, addressAuthentication: "unverified" }),
+      allowlists: { dm: [raw] },
+    });
+    const state = await resolveChannelIngressState(stateInput);
+    const decision = decideChannelIngress(state, allowlistPolicy);
+
+    expect(JSON.stringify(state)).not.toContain(raw);
+    expect(JSON.stringify(decision)).not.toContain(raw);
+  });
+});

--- a/src/channels/message-access/identifier-authentication.test.ts
+++ b/src/channels/message-access/identifier-authentication.test.ts
@@ -332,6 +332,45 @@ describe("per-message subject claims", () => {
       }),
     ).toMatchObject({ admission: "drop" });
   });
+
+  it("keeps a wildcard authenticated when the subject's carried kinds are unknown", async () => {
+    // A hand-built ChannelIngressState that omits subjectIdentifierKinds must not silently
+    // downgrade every wildcard to mutable. The resolver always supplies the kinds, so the
+    // security downgrade above still holds on the real path; a legacy direct constructor keeps
+    // the pre-policy behavior, matching the "an absent claim does not weaken" rule.
+    const wildcardAdapter: InternalChannelIngressAdapter = {
+      ...adapter,
+      normalizeEntries({ entries }) {
+        return {
+          matchable: entries.map((entry, index) => ({
+            opaqueEntryId: `entry-${index + 1}`,
+            kind: "email" as const,
+            value: entry,
+            wildcard: true,
+          })),
+          invalid: [],
+          disabled: [],
+        };
+      },
+    };
+    const state = await resolveChannelIngressState({
+      ...input(),
+      adapter: wildcardAdapter,
+      subject: {
+        identifiers: [
+          {
+            opaqueId: "alias",
+            kind: "username",
+            value: "name:Stranger",
+            authentication: "unverified",
+          },
+        ],
+      },
+      allowlists: { dm: ["*"] },
+    });
+    const legacy = { ...state, subjectIdentifierKinds: undefined };
+    expect(decideChannelIngress(legacy, allowlistPolicy)).toMatchObject({ admission: "dispatch" });
+  });
 });
 
 describe("raising the minimum", () => {
@@ -476,6 +515,29 @@ describe("origin-subject authorization", () => {
     expect(decideChannelIngress(state, allowlistPolicy)).toMatchObject({
       admission: "dispatch",
     });
+  });
+
+  it("admits a matched origin subject that omits its strength, at the baseline", async () => {
+    // A hand-built state may set originSubjectMatched without a strength. That is treated as
+    // the baseline asserted, which clears the default minimum, rather than silently dropped.
+    const verified = subject({
+      address: "operator@example.com",
+      addressAuthentication: "verified",
+    });
+    const state = await resolveChannelIngressState(
+      input({
+        subject: verified,
+        allowlists: { dm: ["someone-else@example.com"] },
+        event: {
+          kind: "reaction",
+          authMode: "origin-subject",
+          mayPair: false,
+          originSubject: verified,
+        },
+      }),
+    );
+    const legacy = { ...state, event: { ...state.event, originSubjectAuthentication: undefined } };
+    expect(decideChannelIngress(legacy, allowlistPolicy)).toMatchObject({ admission: "dispatch" });
   });
 });
 

--- a/src/channels/message-access/identifier-authentication.test.ts
+++ b/src/channels/message-access/identifier-authentication.test.ts
@@ -255,6 +255,7 @@ describe("per-message subject claims", () => {
             opaqueEntryId: `entry-${index + 1}`,
             kind: "email" as const,
             value: entry,
+            wildcard: true,
           })),
           invalid: [],
           disabled: [],
@@ -265,6 +266,71 @@ describe("per-message subject claims", () => {
     expect(await admit({ ...stateInput, adapter: wildcardAdapter })).toMatchObject({
       admission: "drop",
     });
+  });
+
+  it("does not let open DM policy bypass authentication for a wildcard", async () => {
+    const stateInput = input({
+      subject: subject({ address: "stranger@example.com", addressAuthentication: "unverified" }),
+      allowlists: { dm: ["*"] },
+    });
+    const wildcardAdapter: InternalChannelIngressAdapter = {
+      ...adapter,
+      normalizeEntries({ entries }) {
+        return {
+          matchable: entries.map((entry, index) => ({
+            opaqueEntryId: `entry-${index + 1}`,
+            kind: "email" as const,
+            value: entry,
+            wildcard: true,
+          })),
+          invalid: [],
+          disabled: [],
+        };
+      },
+    };
+
+    expect(
+      await admit(
+        { ...stateInput, adapter: wildcardAdapter },
+        { ...allowlistPolicy, dmPolicy: "open" },
+      ),
+    ).toMatchObject({ admission: "drop" });
+  });
+
+  it("does not authenticate a wildcard through a missing primary identity", async () => {
+    const wildcardAdapter: InternalChannelIngressAdapter = {
+      ...adapter,
+      normalizeEntries({ entries }) {
+        return {
+          matchable: entries.map((entry, index) => ({
+            opaqueEntryId: `entry-${index + 1}`,
+            kind: "email" as const,
+            value: entry,
+            wildcard: true,
+          })),
+          invalid: [],
+          disabled: [],
+        };
+      },
+    };
+
+    expect(
+      await admit({
+        ...input(),
+        adapter: wildcardAdapter,
+        subject: {
+          identifiers: [
+            {
+              opaqueId: "alias",
+              kind: "username",
+              value: "name:Stranger",
+              authentication: "unverified",
+            },
+          ],
+        },
+        allowlists: { dm: ["*"] },
+      }),
+    ).toMatchObject({ admission: "drop" });
   });
 });
 
@@ -362,6 +428,54 @@ describe("command authorization", () => {
     );
 
     expect(decision.graph.gates.find((gate) => gate.kind === "command")?.allowed).toBe(true);
+  });
+});
+
+describe("origin-subject authorization", () => {
+  it("does not let a weak matching origin identity bypass the minimum", async () => {
+    const weak = subject({
+      address: "operator@example.com",
+      addressAuthentication: "unverified",
+    });
+    const state = await resolveChannelIngressState(
+      input({
+        subject: weak,
+        allowlists: { dm: ["someone-else@example.com"] },
+        event: {
+          kind: "reaction",
+          authMode: "origin-subject",
+          mayPair: false,
+          originSubject: weak,
+        },
+      }),
+    );
+
+    expect(state.event.originSubjectMatched).toBe(true);
+    expect(state.event.originSubjectAuthentication).toBe("unverified");
+    expect(decideChannelIngress(state, allowlistPolicy)).toMatchObject({ admission: "drop" });
+  });
+
+  it("admits a matching origin identity that meets the minimum", async () => {
+    const verified = subject({
+      address: "operator@example.com",
+      addressAuthentication: "verified",
+    });
+    const state = await resolveChannelIngressState(
+      input({
+        subject: verified,
+        allowlists: { dm: ["someone-else@example.com"] },
+        event: {
+          kind: "reaction",
+          authMode: "origin-subject",
+          mayPair: false,
+          originSubject: verified,
+        },
+      }),
+    );
+
+    expect(decideChannelIngress(state, allowlistPolicy)).toMatchObject({
+      admission: "dispatch",
+    });
   });
 });
 

--- a/src/channels/message-access/identifier-authentication.ts
+++ b/src/channels/message-access/identifier-authentication.ts
@@ -1,0 +1,98 @@
+/**
+ * Ordered sender identifier authentication strength.
+ *
+ * Two independent claims decide whether a matched allowlist entry may authorize a sender:
+ * how strongly the *entry* names someone, and how strongly the *message* proved the sender
+ * holds that name. Channels whose transport authenticates the session only ever supply the
+ * first, so they say nothing per message and nothing weakens. Channels that authenticate
+ * per message supply both.
+ *
+ * The gate takes the weaker of the two. An unforgeable identifier proves nothing when the
+ * message carrying it was never authenticated, and an authenticated message proves nothing
+ * when the identifier it carries is an alias anyone can adopt.
+ */
+
+/**
+ * Ordered strength of one identifier claim, strongest first.
+ *
+ * - `verified`: a trusted boundary bound this exact identifier to this sender.
+ * - `asserted`: a trusted boundary vouched for something about the sender, but not for
+ *   this identifier specifically. The default for an identifier a channel does not
+ *   describe, because a channel that stays silent has not earned `verified`.
+ * - `unverified`: an exact, stable identifier whose claimed ownership nobody proved.
+ * - `mutable`: an alias. Two senders can hold it at once, so it identifies nobody even
+ *   when honestly set.
+ *
+ * `unverified` and `mutable` are both below the default minimum and are kept apart because
+ * they are weak for different reasons, and the diagnostic has to say which. Collapsing them
+ * makes an unauthenticated email address read as a nickname.
+ */
+export type IdentifierAuthentication = "verified" | "asserted" | "unverified" | "mutable";
+
+const RANK: Record<IdentifierAuthentication, number> = {
+  verified: 3,
+  asserted: 2,
+  unverified: 1,
+  mutable: 0,
+};
+
+/**
+ * Strength assumed for an identifier no channel described.
+ *
+ * `asserted` rather than `verified`: a channel that has not stated what backs an identifier
+ * has not earned the strongest claim. It is also the shipped minimum, so silence keeps
+ * today's behavior instead of quietly failing closed on every existing channel.
+ */
+const DEFAULT_IDENTIFIER_AUTHENTICATION: IdentifierAuthentication = "asserted";
+
+/** Returns true when `actual` meets or exceeds `minimum`. */
+export function meetsIdentifierAuthentication(
+  actual: IdentifierAuthentication,
+  minimum: IdentifierAuthentication,
+): boolean {
+  return RANK[actual] >= RANK[minimum];
+}
+
+/** Returns the weaker of two claims, which is how the entry and subject sides combine. */
+export function weakestIdentifierAuthentication(
+  a: IdentifierAuthentication,
+  b: IdentifierAuthentication,
+): IdentifierAuthentication {
+  return RANK[a] <= RANK[b] ? a : b;
+}
+
+/**
+ * Resolves the strength an identity field declares.
+ *
+ * `dangerous: true` is the pre-existing spelling of `mutable` and is the only thing most
+ * channels currently say. Keeping the mapping here rather than at each call site is what
+ * lets the kernel run on one scale while channels migrate.
+ */
+export function identifierAuthenticationFrom(params: {
+  authentication?: IdentifierAuthentication;
+  dangerous?: boolean;
+}): IdentifierAuthentication {
+  if (params.authentication) {
+    return params.authentication;
+  }
+  return params.dangerous ? "mutable" : DEFAULT_IDENTIFIER_AUTHENTICATION;
+}
+
+/**
+ * Resolves the minimum a policy requires.
+ *
+ * `mutableIdentifierMatching` is the two-level spelling of this gate: `enabled` accepts
+ * everything, anything else rejects aliases. Both map onto the scale exactly, so a channel
+ * that never sets `minIdentifierAuthentication` keeps its current admissions.
+ */
+export function minimumIdentifierAuthenticationFrom(params: {
+  minIdentifierAuthentication?: IdentifierAuthentication;
+  mutableIdentifierMatching?: "disabled" | "enabled";
+}): IdentifierAuthentication {
+  if (params.minIdentifierAuthentication) {
+    return params.minIdentifierAuthentication;
+  }
+  return params.mutableIdentifierMatching === "enabled"
+    ? "mutable"
+    : DEFAULT_IDENTIFIER_AUTHENTICATION;
+}

--- a/src/channels/message-access/identifier-authentication.ts
+++ b/src/channels/message-access/identifier-authentication.ts
@@ -43,7 +43,7 @@ const RANK: Record<IdentifierAuthentication, number> = {
  * has not earned the strongest claim. It is also the shipped minimum, so silence keeps
  * today's behavior instead of quietly failing closed on every existing channel.
  */
-const DEFAULT_IDENTIFIER_AUTHENTICATION: IdentifierAuthentication = "asserted";
+export const DEFAULT_IDENTIFIER_AUTHENTICATION: IdentifierAuthentication = "asserted";
 
 /** Returns true when `actual` meets or exceeds `minimum`. */
 export function meetsIdentifierAuthentication(

--- a/src/channels/message-access/runtime-identity.ts
+++ b/src/channels/message-access/runtime-identity.ts
@@ -1,4 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
+import type { IdentifierAuthentication } from "./identifier-authentication.js";
 /**
  * Channel ingress identity adapter helpers.
  *
@@ -56,6 +57,24 @@ function fieldDangerous(field: ResolvedIdentityField, value: string): boolean | 
   return typeof field.dangerous === "function" ? field.dangerous(value) : field.dangerous;
 }
 
+/**
+ * Static strength this field claims for one value.
+ *
+ * `dangerous` still decides when `authentication` is absent, so a channel that has not
+ * migrated keeps producing exactly the entries it produces today.
+ */
+function fieldAuthentication(
+  field: ResolvedIdentityField,
+  value: string,
+): IdentifierAuthentication | undefined {
+  const declared =
+    typeof field.authentication === "function" ? field.authentication(value) : field.authentication;
+  if (declared) {
+    return declared;
+  }
+  return fieldDangerous(field, value) ? "mutable" : undefined;
+}
+
 function identityFields(identity: ChannelIngressIdentityDescriptor): ResolvedIdentityField[] {
   const fields: ResolvedIdentityField[] = [
     {
@@ -96,6 +115,7 @@ function adapterEntry(params: {
       }) ?? `entry-${params.entryIndex + 1}:${params.fallbackSuffix ?? params.field.key}`,
     kind: params.field.kind,
     value: params.value,
+    authentication: fieldAuthentication(params.field, params.entry),
     dangerous: fieldDangerous(params.field, params.entry),
     sensitivity: params.field.sensitivity,
   };
@@ -177,6 +197,11 @@ export function createIdentitySubject(
         opaqueId: field.key,
         kind: field.kind,
         value,
+        // Per-message only. The field's static claim is already carried by the entries this
+        // subject matches, and repeating it here would double-count it; worse, `dangerous`
+        // can be a predicate over the value, so a re-derived subject claim could disagree
+        // with the entry claim for the same field and reject matches that authorize today.
+        authentication: input.authentication?.[field.key],
         dangerous: fieldDangerous(field, value),
         sensitivity: field.sensitivity,
       },

--- a/src/channels/message-access/runtime-identity.ts
+++ b/src/channels/message-access/runtime-identity.ts
@@ -104,6 +104,7 @@ function adapterEntry(params: {
   entryIndex: number;
   value: string;
   fallbackSuffix?: string;
+  wildcard?: boolean;
 }): ChannelIngressAdapterEntry {
   return {
     opaqueEntryId:
@@ -115,6 +116,7 @@ function adapterEntry(params: {
       }) ?? `entry-${params.entryIndex + 1}:${params.fallbackSuffix ?? params.field.key}`,
     kind: params.field.kind,
     value: params.value,
+    ...(params.wildcard ? { wildcard: true } : {}),
     authentication: fieldAuthentication(params.field, params.entry),
     dangerous: fieldDangerous(params.field, params.entry),
     sensitivity: params.field.sensitivity,
@@ -139,6 +141,7 @@ export function createIdentityAdapter(
               entryIndex,
               value: "*",
               fallbackSuffix: "wildcard",
+              wildcard: true,
             }),
           ];
         }

--- a/src/channels/message-access/runtime-types.ts
+++ b/src/channels/message-access/runtime-types.ts
@@ -4,6 +4,7 @@
  * Defines identity descriptors, resolver inputs, route access, and resolved access results.
  */
 import type { AccessGroupConfig } from "../../config/types.access-groups.js";
+import type { IdentifierAuthentication } from "./identifier-authentication.js";
 import type {
   AccessGroupMembershipFact,
   AccessGraphGate,
@@ -42,7 +43,22 @@ export type ChannelIngressIdentityField = {
   normalizeEntry?: (value: string) => string | null | undefined;
   /** Normalizes inbound subject values for this identity field. */
   normalizeSubject?: (value: string) => string | null | undefined;
-  /** Marks identifiers as dangerous in diagnostics, for example mutable display names. */
+  /**
+   * How strongly this field names its holder, independent of any one message.
+   *
+   * Omitted means `asserted`: usable under the shipped minimum, but not a claim to have
+   * bound the identifier to its holder. Declare `verified` only with a transport fact
+   * behind it. Per-message strength is a separate, weaker-wins claim supplied on the
+   * subject.
+   */
+  authentication?:
+    | IdentifierAuthentication
+    | ((value: string) => IdentifierAuthentication | undefined);
+  /**
+   * Marks identifiers as dangerous in diagnostics, for example mutable display names.
+   *
+   * @deprecated Spelling of `authentication: "mutable"`. Prefer `authentication`.
+   */
   dangerous?: boolean | ((value: string) => boolean | undefined);
   /** Redaction hint for diagnostics and access graph consumers. */
   sensitivity?: "normal" | "pii";
@@ -91,6 +107,14 @@ export type ChannelIngressIdentitySubjectInput = {
   stableId?: string | number | null;
   /** Optional identity aliases keyed by `ChannelIngressIdentityAlias.key`. */
   aliases?: Record<string, string | number | null | undefined>;
+  /**
+   * What *this message* proved about each identity field, keyed the same way as `aliases`
+   * with `stableId` under the primary field key.
+   *
+   * Only for transports that authenticate messages rather than sessions. Omitting it means
+   * the channel makes no per-message claim, so nothing weakens.
+   */
+  authentication?: Record<string, IdentifierAuthentication | undefined>;
 };
 
 /** Minimal config subset consumed by the ingress resolver. */
@@ -240,7 +264,9 @@ export type CreateChannelIngressResolverParams = Pick<
   defaultGroupPolicy?: ChannelIngressPolicyInput["groupPolicy"];
   /** Default group allowlist fallback behavior. */
   groupAllowFromFallbackToAllowFrom?: boolean;
-  /** Mutable identifier matching policy for this resolver. */
+  /** Weakest identifier claim allowed to authorize a sender on this resolver. */
+  minIdentifierAuthentication?: ChannelIngressPolicyInput["minIdentifierAuthentication"];
+  /** @deprecated `enabled` is `minIdentifierAuthentication: "mutable"`. */
   mutableIdentifierMatching?: ChannelIngressPolicyInput["mutableIdentifierMatching"];
 };
 

--- a/src/channels/message-access/runtime.ts
+++ b/src/channels/message-access/runtime.ts
@@ -193,6 +193,8 @@ function resolveResolverPolicy(params: {
     groupAllowFromFallbackToAllowFrom:
       params.input.policy?.groupAllowFromFallbackToAllowFrom ??
       params.base.groupAllowFromFallbackToAllowFrom,
+    minIdentifierAuthentication:
+      params.input.policy?.minIdentifierAuthentication ?? params.base.minIdentifierAuthentication,
     mutableIdentifierMatching:
       params.input.policy?.mutableIdentifierMatching ?? params.base.mutableIdentifierMatching,
     ...(params.input.policy?.activation ? { activation: params.input.policy.activation } : {}),

--- a/src/channels/message-access/sender-gates.ts
+++ b/src/channels/message-access/sender-gates.ts
@@ -53,11 +53,13 @@ export function senderGateForDirect(params: {
     allowlist: params.state.allowlists.dm,
     policy: params.policy,
     subjectAuthentication,
+    subjectIdentifierKinds: params.state.subjectIdentifierKinds,
   });
   const pairingStore = applyIdentifierAuthenticationPolicy({
     allowlist: params.state.allowlists.pairingStore,
     policy: params.policy,
     subjectAuthentication,
+    subjectIdentifierKinds: params.state.subjectIdentifierKinds,
   });
   const base = {
     policy: params.policy.dmPolicy,
@@ -86,13 +88,10 @@ export function senderGateForDirect(params: {
     return block("dm_policy_disabled");
   }
   if (params.policy.dmPolicy === "open") {
-    // Open DM policy still requires either wildcard or an explicit normalized entry so
-    // configured allowlists keep their narrowing effect.
-    if (dm.hasWildcard) {
-      return allow("dm_policy_open");
-    }
+    // `hasWildcard` only describes configuration. Authorization must use the filtered
+    // match so a wildcard rejected by identifier authentication cannot reopen the DM.
     if (dm.match.matched) {
-      return allow("dm_policy_allowlisted");
+      return allow(dm.hasWildcard ? "dm_policy_open" : "dm_policy_allowlisted");
     }
     return block("dm_policy_not_allowlisted");
   }

--- a/src/channels/message-access/sender-gates.ts
+++ b/src/channels/message-access/sender-gates.ts
@@ -5,7 +5,7 @@
  */
 import {
   allowlistFailureReason,
-  applyMutableIdentifierPolicy,
+  applyIdentifierAuthenticationPolicy,
   effectiveGroupSenderAllowlist,
   redactedAllowlistDiagnostics,
 } from "./allowlist.js";
@@ -48,11 +48,17 @@ export function senderGateForDirect(params: {
   state: ChannelIngressState;
   policy: ChannelIngressPolicyInput;
 }): AccessGraphGate {
-  const dm = applyMutableIdentifierPolicy(params.state.allowlists.dm, params.policy);
-  const pairingStore = applyMutableIdentifierPolicy(
-    params.state.allowlists.pairingStore,
-    params.policy,
-  );
+  const subjectAuthentication = params.state.subjectAuthentication;
+  const dm = applyIdentifierAuthenticationPolicy({
+    allowlist: params.state.allowlists.dm,
+    policy: params.policy,
+    subjectAuthentication,
+  });
+  const pairingStore = applyIdentifierAuthenticationPolicy({
+    allowlist: params.state.allowlists.pairingStore,
+    policy: params.policy,
+    subjectAuthentication,
+  });
   const base = {
     policy: params.policy.dmPolicy,
     allowlistSource: dm,

--- a/src/channels/message-access/state.ts
+++ b/src/channels/message-access/state.ts
@@ -8,6 +8,10 @@ import {
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
 import { parseAccessGroupAllowFromEntry } from "../allow-from.js";
+import {
+  weakestIdentifierAuthentication,
+  type IdentifierAuthentication,
+} from "./identifier-authentication.js";
 import type {
   AccessGroupMembershipFact,
   ChannelIngressState,
@@ -19,6 +23,7 @@ import type {
   RedactedIngressMatch,
   ResolvedRouteGateFacts,
   ResolvedIngressAllowlist,
+  SubjectIdentifierAuthentication,
 } from "./types.js";
 
 function redactedEntries(entries: readonly InternalNormalizedEntry[]) {
@@ -94,6 +99,33 @@ async function normalizeAndMatch(params: {
     disabledEntries: normalized.disabled,
     match,
   };
+}
+
+/**
+ * Collects what this message proved, by identifier kind.
+ *
+ * Reads only an explicit `authentication` on the subject. `dangerous` is deliberately not
+ * consulted here: it can be a predicate over the value, so entry and subject sides can
+ * disagree for the same field, and folding it in would silently reject matches that
+ * authorize today. Weakening a channel's identifiers per message stays opt-in.
+ *
+ * When two identifiers of one kind disagree, the weaker wins: the kind is only as good as
+ * the least-supported claim made under it.
+ */
+function resolveSubjectAuthentication(
+  subject: InternalChannelIngressSubject,
+): SubjectIdentifierAuthentication {
+  const resolved: Record<string, IdentifierAuthentication> = {};
+  for (const identifier of subject.identifiers) {
+    if (!identifier.authentication) {
+      continue;
+    }
+    const current = resolved[identifier.kind];
+    resolved[identifier.kind] = current
+      ? weakestIdentifierAuthentication(current, identifier.authentication)
+      : identifier.authentication;
+  }
+  return resolved;
 }
 
 function referencedAccessGroups(entries: readonly string[]): string[] {
@@ -393,6 +425,7 @@ export async function resolveChannelIngressState(
     },
     mentionFacts: input.mentionFacts,
     routeFacts,
+    subjectAuthentication: resolveSubjectAuthentication(input.subject),
     allowlists: {
       dm,
       pairingStore,

--- a/src/channels/message-access/state.ts
+++ b/src/channels/message-access/state.ts
@@ -9,6 +9,8 @@ import {
 } from "@openclaw/normalization-core/string-normalization";
 import { parseAccessGroupAllowFromEntry } from "../allow-from.js";
 import {
+  identifierAuthenticationFrom,
+  meetsIdentifierAuthentication,
   weakestIdentifierAuthentication,
   type IdentifierAuthentication,
 } from "./identifier-authentication.js";
@@ -182,6 +184,10 @@ async function normalizeSubjectIdentifiersForMatch(params: {
             opaqueEntryId: `${params.opaquePrefix}-${identifierIndex + 1}:${entryIndex + 1}`,
             kind: entry.kind,
             value: entry.value,
+            authentication: weakestIdentifierAuthentication(
+              identifierAuthenticationFrom(entry),
+              identifierAuthenticationFrom(identifier),
+            ),
             dangerous: entry.dangerous,
             sensitivity: entry.sensitivity,
           }))
@@ -191,22 +197,56 @@ async function normalizeSubjectIdentifiersForMatch(params: {
   return normalized.flat();
 }
 
-async function originSubjectMatched(input: ChannelIngressStateInput): Promise<boolean> {
+function strongestAuthentication(
+  values: readonly IdentifierAuthentication[],
+): IdentifierAuthentication | undefined {
+  return values.reduce<IdentifierAuthentication | undefined>(
+    (strongest, value) =>
+      !strongest || meetsIdentifierAuthentication(value, strongest) ? value : strongest,
+    undefined,
+  );
+}
+
+function matchedEntryAuthentication(params: {
+  entries: readonly InternalNormalizedEntry[];
+  matchedEntryIds: readonly string[];
+  subjectAuthentication: SubjectIdentifierAuthentication;
+}): IdentifierAuthentication | undefined {
+  const matched = new Set(params.matchedEntryIds);
+  return strongestAuthentication(
+    params.entries
+      .filter((entry) => matched.has(entry.opaqueEntryId))
+      .map((entry) => {
+        const entryAuthentication = identifierAuthenticationFrom(entry);
+        const subjectAuthentication = params.subjectAuthentication[entry.kind];
+        return subjectAuthentication
+          ? weakestIdentifierAuthentication(entryAuthentication, subjectAuthentication)
+          : entryAuthentication;
+      }),
+  );
+}
+
+async function originSubjectAuthentication(
+  input: ChannelIngressStateInput,
+): Promise<IdentifierAuthentication | undefined> {
   const origin = input.event.originSubject;
   if (!origin) {
-    return false;
+    return undefined;
   }
-  if (
-    origin.identifiers.some((identifier) =>
-      input.subject.identifiers.some(
-        (current) => current.kind === identifier.kind && current.value === identifier.value,
-      ),
-    )
-  ) {
-    return true;
-  }
-
+  const exactFallback = strongestAuthentication(
+    origin.identifiers.flatMap((identifier) =>
+      input.subject.identifiers
+        .filter((current) => current.kind === identifier.kind && current.value === identifier.value)
+        .map((current) =>
+          weakestIdentifierAuthentication(
+            identifierAuthenticationFrom(identifier),
+            identifierAuthenticationFrom(current),
+          ),
+        ),
+    ),
+  );
   const context = eventSubjectMatchContext(input);
+  const matches: IdentifierAuthentication[] = [];
   const originEntries = await normalizeSubjectIdentifiersForMatch({
     input,
     subject: origin,
@@ -220,7 +260,14 @@ async function originSubjectMatched(input: ChannelIngressStateInput): Promise<bo
       context,
     });
     if (currentMatch.matched) {
-      return true;
+      const authentication = matchedEntryAuthentication({
+        entries: originEntries,
+        matchedEntryIds: currentMatch.matchedEntryIds,
+        subjectAuthentication: resolveSubjectAuthentication(input.subject),
+      });
+      if (authentication) {
+        matches.push(authentication);
+      }
     }
   }
 
@@ -230,15 +277,27 @@ async function originSubjectMatched(input: ChannelIngressStateInput): Promise<bo
     context,
     opaquePrefix: "current",
   });
-  if (currentEntries.length === 0) {
-    return false;
+  if (currentEntries.length > 0) {
+    const originMatch = await input.adapter.matchSubject({
+      subject: origin,
+      entries: currentEntries,
+      context,
+    });
+    const authentication = originMatch.matched
+      ? matchedEntryAuthentication({
+          entries: currentEntries,
+          matchedEntryIds: originMatch.matchedEntryIds,
+          subjectAuthentication: resolveSubjectAuthentication(origin),
+        })
+      : undefined;
+    if (authentication) {
+      matches.push(authentication);
+    }
   }
-  const originMatch = await input.adapter.matchSubject({
-    subject: origin,
-    entries: currentEntries,
-    context,
-  });
-  return originMatch.matched;
+  return (
+    strongestAuthentication(matches) ??
+    (originEntries.length === 0 && currentEntries.length === 0 ? exactFallback : undefined)
+  );
 }
 
 async function resolveAccessGroupEntries(params: {
@@ -410,7 +469,7 @@ export async function resolveChannelIngressState(
         context: "command",
       }),
       resolveRouteFacts(input),
-      originSubjectMatched(input),
+      originSubjectAuthentication(input),
     ]);
   return {
     channelId: input.channelId,
@@ -421,11 +480,13 @@ export async function resolveChannelIngressState(
       authMode: input.event.authMode,
       mayPair: input.event.mayPair,
       hasOriginSubject: input.event.originSubject != null,
-      originSubjectMatched: eventOriginMatched,
+      originSubjectMatched: eventOriginMatched != null,
+      ...(eventOriginMatched ? { originSubjectAuthentication: eventOriginMatched } : {}),
     },
     mentionFacts: input.mentionFacts,
     routeFacts,
     subjectAuthentication: resolveSubjectAuthentication(input.subject),
+    subjectIdentifierKinds: [...new Set(input.subject.identifiers.map((entry) => entry.kind))],
     allowlists: {
       dm,
       pairingStore,

--- a/src/channels/message-access/types.ts
+++ b/src/channels/message-access/types.ts
@@ -7,6 +7,7 @@ import type { ResolvedChannelImplicitMentions } from "../../config/implicit-ment
 import type { AccessGroupConfig } from "../../config/types.access-groups.js";
 import type { ChatChannelId } from "../ids.js";
 import type { InboundImplicitMentionKind, InboundMentionFacts } from "../mention-gating.js";
+import type { IdentifierAuthentication } from "./identifier-authentication.js";
 
 /** Channel identifier used in ingress diagnostics and config lookups. */
 export type ChannelIngressChannelId = ChatChannelId;
@@ -20,10 +21,24 @@ export type ChannelIngressIdentifierKind =
   | "role"
   | `plugin:${string}`;
 
+/**
+ * Per-message strength for each identifier kind an inbound subject carries.
+ *
+ * Absent kinds do not constrain: a channel whose transport authenticates the session makes
+ * no per-message claim, so nothing here weakens its entries. Populating it is how a channel
+ * says "this message did not prove what it usually proves".
+ */
+export type SubjectIdentifierAuthentication = Readonly<
+  Partial<Record<ChannelIngressIdentifierKind, IdentifierAuthentication>>
+>;
+
 /** Public, redacted identifier material that can participate in allowlist matching. */
 type MatchableIdentifier = {
   opaqueId: string;
   kind: ChannelIngressIdentifierKind;
+  /** How strongly this identifier names its holder. Defaults to `asserted`. */
+  authentication?: IdentifierAuthentication;
+  /** @deprecated Spelling of `authentication: "mutable"`. Set `authentication` instead. */
   dangerous?: boolean;
   sensitivity?: "normal" | "pii";
 };
@@ -42,6 +57,9 @@ export type InternalChannelIngressSubject = {
 type ChannelIngressNormalizedEntry = {
   opaqueEntryId: string;
   kind: ChannelIngressIdentifierKind;
+  /** How strongly this entry names its holder. Defaults to `asserted`. */
+  authentication?: IdentifierAuthentication;
+  /** @deprecated Spelling of `authentication: "mutable"`. Set `authentication` instead. */
   dangerous?: boolean;
   sensitivity?: "normal" | "pii";
 };
@@ -225,6 +243,15 @@ export type ChannelIngressPolicyInput = {
   dmPolicy: "pairing" | "allowlist" | "open" | "disabled";
   groupPolicy: "allowlist" | "open" | "disabled";
   groupAllowFromFallbackToAllowFrom?: boolean;
+  /**
+   * Weakest identifier claim allowed to authorize a sender.
+   *
+   * Defaults to `asserted`, which rejects aliases and unauthenticated identifiers alike.
+   * Takes precedence over `mutableIdentifierMatching`, which expresses the same gate with
+   * only two levels.
+   */
+  minIdentifierAuthentication?: IdentifierAuthentication;
+  /** @deprecated `enabled` is `minIdentifierAuthentication: "mutable"`. */
   mutableIdentifierMatching?: "disabled" | "enabled";
   activation?: {
     requireMention: boolean;
@@ -295,6 +322,7 @@ export type IngressReasonCode =
   | "access_group_unsupported"
   | "access_group_failed"
   | "mutable_identifier_disabled"
+  | "identifier_authentication_too_weak"
   | "no_policy_match";
 
 /** One evaluated gate in the ordered ingress access graph. */
@@ -346,6 +374,17 @@ export type ChannelIngressState = {
   event: RedactedChannelIngressEvent;
   mentionFacts?: InboundMentionFacts;
   routeFacts: ResolvedRouteGateFacts[];
+  /**
+   * What this message proved about the sender, by identifier kind.
+   *
+   * Carries strengths rather than the subject itself so the gate can weigh a message
+   * without any raw sender value reaching a diagnostic surface.
+   *
+   * Optional because this type is public and callers construct it: absent reads the same as
+   * empty, which is a channel making no per-message claim. `resolveChannelIngressState`
+   * always populates it.
+   */
+  subjectAuthentication?: SubjectIdentifierAuthentication;
   allowlists: {
     dm: ResolvedIngressAllowlist;
     pairingStore: ResolvedIngressAllowlist;

--- a/src/channels/message-access/types.ts
+++ b/src/channels/message-access/types.ts
@@ -57,6 +57,8 @@ export type InternalChannelIngressSubject = {
 type ChannelIngressNormalizedEntry = {
   opaqueEntryId: string;
   kind: ChannelIngressIdentifierKind;
+  /** True when this normalized entry represents the adapter's wildcard contract. */
+  wildcard?: boolean;
   /** How strongly this entry names its holder. Defaults to `asserted`. */
   authentication?: IdentifierAuthentication;
   /** @deprecated Spelling of `authentication: "mutable"`. Set `authentication` instead. */
@@ -209,6 +211,7 @@ export type ChannelIngressEventInput = {
 type RedactedChannelIngressEvent = Omit<ChannelIngressEventInput, "originSubject"> & {
   hasOriginSubject: boolean;
   originSubjectMatched: boolean;
+  originSubjectAuthentication?: IdentifierAuthentication;
 };
 
 /** Complete raw input to the shared ingress state resolver. */
@@ -385,6 +388,8 @@ export type ChannelIngressState = {
    * always populates it.
    */
   subjectAuthentication?: SubjectIdentifierAuthentication;
+  /** Identifier kinds actually carried by this subject, without their raw values. */
+  subjectIdentifierKinds?: ChannelIngressIdentifierKind[];
   allowlists: {
     dm: ResolvedIngressAllowlist;
     pairingStore: ResolvedIngressAllowlist;


### PR DESCRIPTION
Implements PR 2 of the stack in [openclaw/rfcs#51](https://github.com/openclaw/rfcs/pull/51). **Do not merge before that RFC is accepted.**

## What Problem This Solves

The ingress kernel has one question it can ask about a sender identifier: is it `dangerous` or not. `applyMutableIdentifierPolicy` reads that boolean and either keeps an allowlist entry or drops it, and `mutableIdentifierMatching` flips which way. Two values, one axis.

That is enough for a transport that authenticates the *session*. Once the session is established, every identifier it reports is as good as the session, so identifier strength is a static property of the field and never changes between messages.

It is not enough for a transport that authenticates the *message*. On email the same address is strong or weak depending on what arrived with it: a DKIM signature aligned to the sender's domain, an unaligned one, or nothing at all. The kernel currently has no way to be told that, so an allowlisted address authorizes its sender whether or not the message carrying it proved anything. There is no value of `dangerous` that expresses "this identifier is exact and stable, and this particular message did not prove the sender holds it".

## Why This Change Was Made

Replaces the boolean with an ordered scale and a second axis.

`IdentifierAuthentication` is `verified > asserted > unverified > mutable`. Two independent claims feed it:

- **Entry side**, static: how strongly this field names its holder. Declared per identity field.
- **Subject side**, per message: what *this* message proved. Supplied only by channels that authenticate messages.

The gate takes `min(entry, subject)`. An unforgeable identifier proves nothing when the message carrying it was never authenticated, and an authenticated message proves nothing when the identifier it carries is an alias anyone can adopt.

`unverified` and `mutable` are kept apart although both sit below the default minimum. A display name is weak because it is an *alias*: two senders can hold it at once. An unauthenticated `From:` is weak because nothing *bound* it: it is exact and stable, and its claimed ownership is simply unproven. Collapsing them makes an unauthenticated email address read as a nickname in the diagnostic.

Matching is kind-scoped, so an entry's subject-side claim is the claim made for its own kind. A wildcard entry is built from the primary identity field and therefore carries the primary kind, which makes "how well do we know who this is" the question it answers, with no special case in the gate.

## User Impact

**None on any channel on `main`.** The compatibility argument is mechanical:

| today | resolves to |
| --- | --- |
| entry with no `dangerous` | `asserted` |
| `dangerous: true` | `mutable` |
| default policy | minimum `asserted` |
| `mutableIdentifierMatching: "enabled"` | minimum `mutable` |

`asserted` clears an `asserted` minimum and `mutable` does not, so every existing admission and rejection is preserved, including the alias case reaching its long-standing `mutable_identifier_disabled` reason code. The new `identifier_authentication_too_weak` code appears only for weakness the two-level policy could not express.

Three deliberate restrictions keep it that way:

- The subject side reads only an explicit `authentication`. It does **not** re-derive from `dangerous`, which can be a predicate over the value and so can disagree between the entry and subject sides for the same field. Weakening per message stays opt-in.
- Silence caps an entry at `asserted` and `min()` cannot climb above it, so a channel cannot satisfy a `verified` minimum by never saying anything. Reaching `verified` is an explicit claim.
- `ChannelIngressState.subjectAuthentication` is **optional**. The type is public and callers construct it, so a required field is a breaking change; absent reads the same as empty.

## Evidence

All on Blacksmith Testbox warmed from this branch, at head `2de290a2`:

| gate | result |
| --- | --- |
| `node scripts/run-vitest.mjs src/channels/message-access/` | 30 passed / 30 |
| `pnpm tsgo` | clean |
| `node scripts/run-oxlint.mjs src/channels/message-access` | exit 0 |
| `oxfmt --check src/channels/message-access` | exit 0 |
| `pnpm deadcode:full` | exit 0 |
| `pnpm check:test-types` | exit 0 |

The 30 span the pre-existing `message-access.test.ts` (unmodified, 9 tests, including `requires explicit dangerous identifier matching` — the direct compatibility regression test) and the new `identifier-authentication.test.ts` (21 tests).

Hosted CI on `2de290a2`: green, zero non-passing checks.

**Runtime proof (Crabbox, `tbx_01kyspcm3x21r2zrp0y77jj4f8`).** Unit tests and a type-level argument are not enough for a "no channel changes behaviour" claim, so this also ran against a real gateway driving the **real Telegram plugin** through a Crabline local provider, no live credentials:

```
[qa-suite] gateway ready: http://127.0.0.1:40373
[qa-suite] scenario pass (1/1): telegram-repeated-command-authorization
[qa-suite] run complete: passed=1 failed=0 skipped=0 total=1
```

That scenario is the admit → reject → admit cycle: an allowlisted operator issues a native command and is authorized, `allowFrom` is emptied and the command is rejected, `allowFrom` is restored and authorization returns. Command authorization runs through `applyIdentifierAuthenticationPolicy` on the command allowlists, so this exercises the changed gate end to end at runtime.

**Runtime proof refreshed at current head `00ca77be`.** The transcript above ran on `2de290a2`; the two commits since then changed wildcard, origin-subject, and legacy-state authorization, so the same scenario and the same Crabline driver were re-run at the current head on Blacksmith Testbox (`tbx_01kyxqvxdq3w8q8b9yyytws092`):

```
provider=blacksmith-testbox id=tbx_01kyxqvxdq3w8q8b9yyytws092 sync=delegated auth=blacksmith
00ca77be4d9705e6ae21fecb14dcba06108afc18
$ node scripts/run-node.mjs qa suite --channel-driver crabline --channel telegram --scenario telegram-repeated-command-authorization
[qa-suite] run start: scenarios=1 concurrency=1 transport=qa-channel channelDriver=crabline channel=telegram
[qa-suite] lab ready: http://127.0.0.1:35207
[qa-suite] provider ready: live
[qa-suite] gateway ready: http://127.0.0.1:33963
[qa-suite] scenario pass (1/1): telegram-repeated-command-authorization
[qa-suite] run complete: passed=1 failed=0 skipped=0 total=1
```

Same admit → reject → admit cycle, now on the head that carries the wildcard/origin-subject/legacy-state fixes. The WhatsApp proof gap below is unchanged (harness limitation, not this change).

**Proof gap, stated rather than papered over.** The two WhatsApp access-control scenarios (`whatsapp-pairing-block`, `whatsapp-access-control-group-disabled`) could not run. They fail at `suite partition` with `timed out waiting for whatsapp ready … running: false` — the transport never starts, before any ingress decision. The cause is the harness, not this change: `extensions/qa-lab/src/crabline-transport.ts:414` returns the adapter config unchanged for any channel other than `telegram` (with a `signal` branch at :411), so WhatsApp gets no account wiring under Crabline. The pairing-store call site therefore has unit coverage (`message-access.test.ts` › `keeps pairing-store entries DM-policy scoped`) but no runtime coverage here.

Separately worth noting for the repo rather than this PR: **every access-control QA scenario is bound to a channel-specific lane; none exists on the generic `qa-channel` lane.** That is why a kernel-level ingress change has no cheap runtime proof available, and it looks like a coverage gap worth its own issue.

New tests cover the scale ordering and `min()`, the two mappings in the table above, per-message weakening and that it applies only to its own kind, weaker-wins when one kind is described twice, wildcard entries, the raised-minimum cases in both directions, command-gate parity, and that no raw sender value reaches state or a decision.

Three findings, all from building this rather than reasoning about it. The first two are folded back into the RFC:

1. The RFC bills PR 2 as "internal types only; SDK surface unchanged". That is not achievable. `ChannelIngressPolicyInput`, `ChannelIngressState`, `ChannelIngressIdentityField`, `ChannelIngressIdentitySubjectInput`, and `IngressReasonCode` are all already re-exported from `src/plugin-sdk/channel-ingress-runtime.ts`, so the fields land on public types no matter where the code lives. What *is* achievable, and what this PR does, is adding no new exported **names**: the surface budget rejected the two type exports I first added (`public exports 4776 > 4774`), and per the RFC those belong in PR 3 with the `dangerous` deprecation.
2. A `verified` message cannot lift an entry the channel never described. My first fixture assumed it could. This is the RFC's stated intent working correctly, but it means PR 4's channel migration is load-bearing for any strict posture, not optional polish.
3. `subjectAuthentication` started out required on `ChannelIngressState` and broke `extensions/qqbot`, which constructs that type directly. A public type nobody is supposed to build turns out to be built. Now optional.

Non-test LOC is +274. The growth is a new primitive replacing a boolean, and roughly half of the new module is the reasoning behind the scale. The deletions land in PR 3 and PR 4, when `dangerous` and `mutableIdentifierMatching` come out.

