### PR TITLE
test(e2e): tag the mock Responses preamble with its wire phase

### DIFF
--- a/scripts/e2e/mock-openai-server.mjs
+++ b/scripts/e2e/mock-openai-server.mjs
@@ -149,6 +149,9 @@ function buildMockFunctionCall(name, args) {
 // commentary, which channels render as the draft's status headline. Streaming
 // text and then a call in one response is the only way to exercise
 // headline-plus-tool-line composition without a live model.
+// The Responses API carries that tag as `phase` on the message item, and the
+// transport reads it straight off the item, so an untagged item produces no
+// preamble at all and the scenario silently proves nothing.
 function preambleThenToolCallEvents(preamble, name, args) {
   const messageItemId = "msg_e2e_preamble";
   const call = buildMockFunctionCall(name, args);
@@ -184,6 +187,7 @@ function preambleThenToolCallEvents(preamble, name, args) {
         id: messageItemId,
         role: "assistant",
         status: "completed",
+        phase: "commentary",
         content: [{ type: "output_text", text: preamble, annotations: [] }],
       },
     },
@@ -210,6 +214,7 @@ function preambleThenToolCallEvents(preamble, name, args) {
             id: messageItemId,
             role: "assistant",
             status: "completed",
+            phase: "commentary",
             content: [{ type: "output_text", text: preamble, annotations: [] }],
           },
           call.item,


### PR DESCRIPTION
## What Problem This Solves

The mock provider's progress-draft scenario streams assistant text before a tool call so channel harnesses can prove headline-plus-tool-line composition without a live model. On the Responses path that text produced **no preamble at all** — the scenario ran green while proving nothing.

The Responses API marks a preamble by setting `phase` on the output message item (`openai/resources/responses/responses.d.ts:504` — `phase?: 'commentary' | 'final_answer' | null`), and the transport reads it straight off the item at `packages/ai/src/transports/openai-responses-stream-internal.ts:559`. The mock emitted the message item untagged, so every Responses-transport run through this scenario silently skipped the preamble lane.

## Why This Change Was Made

The scenario's own comment already claimed the text "is tagged as commentary"; only the chat-completions path actually did it, because that transport derives the tag itself at the tool boundary (`tagPendingCommentaryText`). Adding the field to both emissions of the message item — the `response.output_item.done` event and the `response.completed` output — makes the mock match the wire, so the Responses lane exercises the same contract the Completions lane already did.

This mattered in practice: an audit run against this harness reported the preamble as broken on `openai-responses`. It was the mock, not shipped behavior.

## User Impact

Test harness only; no runtime or product surface changes. Channel E2E lanes running the draft-proof scenario on `openai-responses` now exercise the preamble path instead of quietly skipping it.

## Evidence

Live on real Telegram via the userbot lane, same prompt, `E2E_TELEGRAM_PROVIDER_API=openai-responses`:

| | Before | After |
| --- | --- | --- |
| `progress` default | `Working` ⏎ `🛠️ Exec …` | `Checking the workspace before answering.` ⏎ `🛠️ Exec …` |
| `progress.commentary: true` | `Working` ⏎ `🛠️ Exec …` | `Working` ⏎ `💬 Checking the workspace before answering.` |

Before the change the preamble appeared in neither lane on this transport; the label `Working` was the only headline. The chat-completions runs of the same scenario were already correct and are unchanged.

`node --check` and oxlint clean; autoreview clean (0.99).

### Known gap

When pre-tool text arrives with no `phase` at all, it currently disappears — no headline, no commentary line, no message (`src/agents/embedded-agent-subscribe.handlers.messages.ts:983` withholds unphased Responses text pending a tool-boundary decision that only `phase` resolves). OpenAI sets the field, so this is not reachable there. Whether any Responses-compatible endpoint omits it is unproven, so no fix is attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)