### PR TITLE
fix: preserve caller-replaced SQLite targets on Windows

### DIFF
--- a/src/infra/sqlite-snapshot.ts
+++ b/src/infra/sqlite-snapshot.ts
@@ -437,7 +437,6 @@ export async function publishVerifiedSqliteFile(
   let targetPinFileDescriptor: number | undefined;
   let failedPublicationIdentity: FileIdentityStat | undefined;
   let publishedIdentity: Stats | undefined;
-  let ownershipPinned = false;
   try {
     stagingIdentity = await fs.lstat(stagingDir);
     await fs.chmod(stagingDir, 0o700);
@@ -521,7 +520,6 @@ export async function publishVerifiedSqliteFile(
     const initialPublishedIdentity = publishedIdentity;
     target = await fs.open(options.targetPath, "r");
     await assertOpenFileIdentity(target, options.targetPath, initialPublishedIdentity);
-    ownershipPinned = true;
     // Retire the writable staging hard link before the final byte verification.
     await fs.unlink(stagedPath);
     const expectedIdentity = await target.stat();
@@ -539,10 +537,8 @@ export async function publishVerifiedSqliteFile(
     );
     await target.close();
     target = undefined;
-    ownershipPinned = false;
     targetPinFileDescriptor = fsSync.openSync(options.targetPath, "r");
     assertOpenFileIdentitySync(targetPinFileDescriptor, options.targetPath, expectedIdentity);
-    ownershipPinned = true;
 
     const guard: PublishedSqliteFileGuard = {
       assertTargetMatchesExpectedContent: (finalCheck) => {
@@ -567,22 +563,18 @@ export async function publishVerifiedSqliteFile(
     }
     fsSync.closeSync(targetPinFileDescriptor);
     targetPinFileDescriptor = undefined;
-    ownershipPinned = false;
   } catch (error) {
     if (target && publishedIdentity) {
       const openedIdentity = await target.stat().catch(() => undefined);
       if (openedIdentity && sameFileIdentity(openedIdentity, publishedIdentity)) {
         publishedIdentity = openedIdentity;
-        ownershipPinned = true;
       }
     }
     const cleanupIdentity = publishedIdentity ?? failedPublicationIdentity;
     if (cleanupIdentity) {
-      const removed = removePublishedTargetIfOwned(
-        options.targetPath,
-        cleanupIdentity,
-        !ownershipPinned,
-      );
+      // Windows can reuse a deleted file's identity while our old handle is still pinned.
+      // Require the full fingerprint so cleanup never unlinks a caller replacement.
+      const removed = removePublishedTargetIfOwned(options.targetPath, cleanupIdentity, true);
       if (removed) {
         await syncDirectory(targetDirectoryReceipt).catch(() => undefined);
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows snapshot publication cleanup could delete a replacement target created by the caller after publication. NTFS can reuse the deleted file identity while the original target handle remains pinned, so inode/file-index ownership alone is not sufficient for cleanup.

## Why This Change Was Made

Failure cleanup now always requires the complete size, mtime, ctime, and birthtime fingerprint before unlinking the published pathname. The now-redundant pinned-ownership bookkeeping is removed. This is the exact forward-port of the beta.6 release fix.

## User Impact

Windows snapshot and restore failures preserve a caller-owned replacement database instead of deleting it during cleanup.

## Evidence

- Exact-head Windows CI: https://github.com/openclaw/openclaw/actions/runs/30522914888/job/90807297005
- On the Windows runner, `src/infra/sqlite-snapshot.test.ts` passed all 32 tests (6 platform skips). The two cleanup outcomes requested by review both passed:
  - `removes its published target when the caller rejects it`
  - `preserves a target replaced by the caller after publication`
- The complete exact-head CI run passed: https://github.com/openclaw/openclaw/actions/runs/30522914888
- `git diff --check`
- Autoreview: clean, no accepted or actionable findings
