### PR TITLE
fix(agents): prevent registry stalls during large fan-outs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Large agent fan-out persistence:** write only changed subagent registry rows during lifecycle updates, preventing retained runs from multiplying synchronous SQLite work and memory churn as concurrent agent counts grow. Fixes #116227.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Large agent fan-out persistence:** write only changed subagent registry rows during lifecycle updates, preventing retained runs from multiplying synchronous SQLite work and memory churn as concurrent agent counts grow. Fixes #116227.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -192,7 +192,7 @@ export async function emitSubagentEndedHookOnce(params: {
   outcome?: SubagentLifecycleEndedOutcome;
   error?: string;
   inFlightRunIds: Set<string>;
-  persist: () => void;
+  persist: (...runIds: string[]) => void;
 }) {
   const runId = params.entry.runId.trim();
   if (!runId) {
@@ -234,7 +234,7 @@ export async function emitSubagentEndedHookOnce(params: {
       );
     }
     params.entry.endedHookEmittedAt = Date.now();
-    params.persist();
+    params.persist(runId);
     return true;
   } catch (err) {
     log.warn(

--- a/src/agents/subagent-registry-context-cleanup.ts
+++ b/src/agents/subagent-registry-context-cleanup.ts
@@ -23,7 +23,7 @@ import type {
 
 export function createSubagentRegistryContextCleanup(config: {
   deps: () => SubagentRegistryDeps;
-  persist: () => void;
+  persist: (...runIds: string[]) => void;
   warn: (message: string, meta?: Record<string, unknown>) => void;
 }) {
   const { deps, persist, warn } = config;
@@ -93,7 +93,7 @@ export function createSubagentRegistryContextCleanup(config: {
     ]);
     if (!contextAlreadyEnded && contextEnded) {
       entry.contextEngineCleanupCompletedAt = Date.now();
-      persist();
+      persist(entry.runId);
     }
     return internalEffectsRemoved && attachmentsRemoved && contextEnded;
   }

--- a/src/agents/subagent-registry-lifecycle-bookkeeping.ts
+++ b/src/agents/subagent-registry-lifecycle-bookkeeping.ts
@@ -84,7 +84,7 @@ export function createSubagentRegistryLifecycleBookkeeping(
       // Preserve only the collector result tombstone for waits and group caps.
       cleanupParams.entry.cleanupCompletedAt = cleanupParams.completedAt;
       cleanupParams.entry.requesterSettleWake = undefined;
-      params.persist();
+      params.persist(cleanupParams.runId);
       retryDeferredCompletedAnnounces(cleanupParams.runId);
       return;
     }
@@ -99,7 +99,7 @@ export function createSubagentRegistryLifecycleBookkeeping(
       }
       if (cleanupParams.skipRequesterSettleWake) {
         params.runs.delete(cleanupParams.runId);
-        params.persist();
+        params.persist(cleanupParams.runId);
         retryDeferredCompletedAnnounces(cleanupParams.runId);
         return;
       }
@@ -117,7 +117,7 @@ export function createSubagentRegistryLifecycleBookkeeping(
       });
     } else {
       cleanupParams.entry.cleanupCompletedAt = cleanupParams.completedAt;
-      params.persist();
+      params.persist(cleanupParams.runId);
     }
     retryDeferredCompletedAnnounces(cleanupParams.runId);
     if (!cleanupParams.skipRequesterSettleWake) {

--- a/src/agents/subagent-registry-lifecycle-cleanup-base.ts
+++ b/src/agents/subagent-registry-lifecycle-cleanup-base.ts
@@ -53,7 +53,7 @@ export function createSubagentRegistryLifecycleCleanupBase(
             return;
           }
           entry.cleanupHandled = false;
-          params.persist();
+          params.persist(runId);
         }
         params.resumedRuns.delete(runId);
         params.resumeSubagentRun(runId);
@@ -104,7 +104,7 @@ export function createSubagentRegistryLifecycleCleanupBase(
         }
         current.cleanupHandled = false;
         params.resumedRuns.delete(args.runId);
-        params.persist();
+        params.persist(args.runId);
       }
     }).catch((err: unknown) => {
       defaultRuntime.log(
@@ -155,7 +155,7 @@ export function createSubagentRegistryLifecycleCleanupBase(
     logAnnounceGiveUp(args.entry, args.reason);
     markRequesterSettleWakePending(args.entry);
     try {
-      params.persistOrThrow();
+      params.persistOrThrow(args.runId);
     } catch (error) {
       const mutableEntry = args.entry as unknown as Record<string, unknown>;
       for (const key of Object.keys(mutableEntry)) {
@@ -179,7 +179,7 @@ export function createSubagentRegistryLifecycleCleanupBase(
     }
     entry.cleanupHandled = true;
     cleanupGenerations.set(entry, (cleanupGenerations.get(entry) ?? 0) + 1);
-    params.persist();
+    params.persist(runId);
     return true;
   };
 
@@ -209,7 +209,7 @@ export function createSubagentRegistryLifecycleCleanupBase(
     // Cleanup can yield to attachment, mirror, or announce work. A successor
     // registered while it was suspended owns every session-scoped side effect.
     await params.retireSupersededRun(runId, entry);
-    params.persist();
+    params.persist(runId);
     return true;
   };
 

--- a/src/agents/subagent-registry-lifecycle-cleanup.ts
+++ b/src/agents/subagent-registry-lifecycle-cleanup.ts
@@ -232,7 +232,7 @@ export function createSubagentRegistryLifecycleCleanup(
         delivery.announcedAt = delivery.announcedAt ?? deliveredAt;
         if (!options?.skipAnnounce) {
           delivery.announcedAt = deliveredAt;
-          params.persist();
+          params.persist(runId);
         }
       }
       clearPendingFinalDelivery(entry);
@@ -294,7 +294,7 @@ export function createSubagentRegistryLifecycleCleanup(
       entry.wakeOnDescendantSettle = true;
       entry.cleanupHandled = false;
       params.resumedRuns.delete(runId);
-      params.persist();
+      params.persist(runId);
       scheduleResumeSubagentRun(runId, entry, deferredDecision.delayMs);
       return;
     }
@@ -361,7 +361,7 @@ export function createSubagentRegistryLifecycleCleanup(
     });
     entry.cleanupHandled = false;
     params.resumedRuns.delete(runId);
-    params.persist();
+    params.persist(runId);
     if (deferredDecision.resumeDelayMs == null) {
       return;
     }
@@ -414,7 +414,7 @@ export function createSubagentRegistryLifecycleCleanup(
             // This durable boundary prevents a late yield from reviving a run
             // after deletion may already have reached the gateway.
             entry.deleteCleanupDispatchedAt ??= Date.now();
-            params.persist();
+            params.persist(runId);
             await deleteSubagentSessionForCleanup({
               callGateway: params.callGateway,
               childSessionKey: entry.childSessionKey,
@@ -496,7 +496,7 @@ export function createSubagentRegistryLifecycleCleanup(
               // Announce owns delete submission; fence late yields at the
               // exact handoff instead of when cleanup merely starts.
               entry.deleteCleanupDispatchedAt ??= Date.now();
-              params.persist();
+              params.persist(runId);
               return true;
             }
           : undefined,
@@ -510,7 +510,7 @@ export function createSubagentRegistryLifecycleCleanup(
           const deliveryState = ensureDeliveryState(entry);
           if (deliveryState.lastError !== undefined) {
             deliveryState.lastError = undefined;
-            params.persist();
+            params.persist(runId);
           }
           latestDeliveryError = undefined;
           return;
@@ -521,7 +521,7 @@ export function createSubagentRegistryLifecycleCleanup(
         latestDeliveryError = formatAnnounceDeliveryError(delivery);
         if (ensureDeliveryState(entry).lastError !== latestDeliveryError) {
           ensureDeliveryState(entry).lastError = latestDeliveryError;
-          params.persist();
+          params.persist(runId);
         }
       },
     };

--- a/src/agents/subagent-registry-lifecycle-completion.ts
+++ b/src/agents/subagent-registry-lifecycle-completion.ts
@@ -163,7 +163,7 @@ export function createSubagentRegistryLifecycleCompletion(
           entry.terminalOwner = "interrupted-recovery";
           mutated = true;
           try {
-            params.persistOrThrow();
+            params.persistOrThrow(completeParams.runId);
           } catch (error) {
             restoreEntrySnapshot(entrySnapshot);
             throw error;
@@ -479,7 +479,7 @@ export function createSubagentRegistryLifecycleCompletion(
         restoreEntrySnapshot(entry);
         entry = currentEntry;
         try {
-          params.persistOrThrow();
+          params.persistOrThrow(completeParams.runId);
         } catch (error) {
           restoreEntrySnapshot(liveBeforeCommit);
           throw error;
@@ -490,7 +490,7 @@ export function createSubagentRegistryLifecycleCompletion(
       } else {
         try {
           if (mutated) {
-            params.persistOrThrow();
+            params.persistOrThrow(completeParams.runId);
           }
         } catch (error) {
           restoreEntrySnapshot(entrySnapshot);
@@ -517,7 +517,7 @@ export function createSubagentRegistryLifecycleCompletion(
     const retireSupersededSession = async (currentEntry: SubagentRunRecord) => {
       if (completionReason !== SUBAGENT_ENDED_REASON_KILLED) {
         await params.retireSupersededRun(completeParams.runId, currentEntry);
-        params.persist();
+        params.persist(completeParams.runId);
       }
     };
     sessionSuperseded = sessionSuperseded || newerGenerationOwnsSession(entry);

--- a/src/agents/subagent-registry-lifecycle-contracts.ts
+++ b/src/agents/subagent-registry-lifecycle-contracts.ts
@@ -15,8 +15,8 @@ export type SubagentRegistryLifecycleParams = {
   resumedRuns: Set<string>;
   subagentAnnounceTimeoutMs: number;
   getRuntimeConfig(): OpenClawConfig;
-  persist(): void;
-  persistOrThrow(): void;
+  persist(...runIds: string[]): void;
+  persistOrThrow(...runIds: string[]): void;
   clearPendingLifecycleError(runId: string): void;
   countPendingDescendantRuns(rootSessionKey: string): number;
   suppressAnnounceForSteerRestart(entry?: SubagentRunRecord): boolean;

--- a/src/agents/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagent-registry-lifecycle-delivery.ts
@@ -383,7 +383,7 @@ export function createSubagentRegistryLifecycleDelivery(
       changed = true;
     }
     if (changed) {
-      params.persist();
+      params.persist(...candidates.map((entry) => entry.runId));
     }
     return changed;
   };

--- a/src/agents/subagent-registry-lifecycle-requester-wake.ts
+++ b/src/agents/subagent-registry-lifecycle-requester-wake.ts
@@ -32,6 +32,9 @@ export function createSubagentRegistryLifecycleRequesterWake(
           Boolean(entry?.requesterSettleWake) &&
           entry?.requesterSettleWake?.rearmGeneration === state.rearmGeneration,
       );
+    if (entries.length === 0) {
+      return;
+    }
     const previousStates = entries.map((entry) => structuredClone(entry.requesterSettleWake));
     for (const entry of entries) {
       entry.requesterSettleWake = {
@@ -42,7 +45,7 @@ export function createSubagentRegistryLifecycleRequesterWake(
       };
     }
     try {
-      params.persistOrThrow();
+      params.persistOrThrow(...entries.map((entry) => entry.runId));
     } catch (error) {
       entries.forEach((entry, index) => {
         entry.requesterSettleWake = previousStates[index];
@@ -62,6 +65,9 @@ export function createSubagentRegistryLifecycleRequesterWake(
           Boolean(pair[1]?.requesterSettleWake) &&
           pair[1]?.requesterSettleWake?.rearmGeneration === rearmGeneration,
       );
+    if (entries.length === 0) {
+      return;
+    }
     const requesterSessionKeys = new Set(entries.map(([, entry]) => entry.requesterSessionKey));
     const previousStates = entries.map(([, entry]) => ({
       requesterSettleWake: structuredClone(entry.requesterSettleWake),
@@ -82,7 +88,7 @@ export function createSubagentRegistryLifecycleRequesterWake(
       }
     }
     try {
-      params.persistOrThrow();
+      params.persistOrThrow(...entries.map(([runId]) => runId));
     } catch (error) {
       entries.forEach(([runId, entry], index) => {
         const previous = previousStates[index];
@@ -144,7 +150,7 @@ export function createSubagentRegistryLifecycleRequesterWake(
     }
     markRequesterSettleWakePending(entry, options);
     try {
-      params.persistOrThrow();
+      params.persistOrThrow(entry.runId);
     } catch (error) {
       entry.cleanupCompletedAt = previousCleanupCompletedAt;
       entry.requesterSettleWake = previousWake;

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -71,7 +71,7 @@ export function createSubagentRegistryLifecycleController(params: SubagentRegist
       settleRequesterTurnAfterSessionSpawns({
         ...args,
         runs: params.runs,
-        persistOrThrow: () => params.persistOrThrow(),
+        persistOrThrow: (...runIds) => params.persistOrThrow(...runIds),
         schedule: (runId, entry) => {
           if (state.scheduledRequesterSettleWakeRuns.has(runId)) {
             state.pendingRequesterSettleWakeRearms.add(runId);

--- a/src/agents/subagent-registry-listener.ts
+++ b/src/agents/subagent-registry-listener.ts
@@ -20,7 +20,7 @@ export function createSubagentRegistryListener(config: {
   runs: Map<string, SubagentRunRecord>;
   pendingLifecycle: ReturnType<typeof createPendingLifecycleScheduler>;
   onAgentEvent: (listener: (event: AgentEventPayload) => void) => () => void;
-  persist: () => void;
+  persist: (...runIds: string[]) => void;
   refreshFrozenResultFromSession: (sessionKey: string) => Promise<unknown>;
   completeSubagentRunWithRecovery: (
     params: SubagentCompletionRequest,
@@ -73,7 +73,7 @@ export function createSubagentRegistryListener(config: {
               entry.sessionStartedAt = startedAt;
             }
             entry.execution = { ...entry.execution, status: "running", startedAt };
-            persist();
+            persist(entry.runId);
           }
           return;
         }
@@ -101,7 +101,7 @@ export function createSubagentRegistryListener(config: {
               startedAt: startedAt ?? entry.startedAt,
             })
           ) {
-            persist();
+            persist(entry.runId);
           }
           return;
         }

--- a/src/agents/subagent-registry-public-api.ts
+++ b/src/agents/subagent-registry-public-api.ts
@@ -21,8 +21,8 @@ import type { SubagentRunRecord, SwarmStructuredOutputState } from "./subagent-r
 export function createSubagentRegistryPublicApi(config: {
   runs: Map<string, SubagentRunRecord>;
   deps: () => SubagentRegistryDeps;
-  persist: () => void;
-  persistOrThrow: () => void;
+  persist: (...runIds: string[]) => void;
+  persistOrThrow: (...runIds: string[]) => void;
   restoreOnce: () => void;
   startAnnounceCleanup: (runId: string, entry: SubagentRunRecord) => boolean;
   settleRequesterTurn: ReturnType<
@@ -52,7 +52,7 @@ export function createSubagentRegistryPublicApi(config: {
       now: params.now,
     });
     if (leased) {
-      persist();
+      persist(...leased.runIds);
     }
     return leased;
   }
@@ -69,7 +69,7 @@ export function createSubagentRegistryPublicApi(config: {
       now: params.now,
     });
     if (updated > 0) {
-      persist();
+      persist(...params.runIds);
       for (const runId of params.runIds) {
         const entry = runs.get(runId);
         if (!entry || typeof entry.cleanupCompletedAt === "number") {
@@ -94,7 +94,7 @@ export function createSubagentRegistryPublicApi(config: {
       error: params.error,
     });
     if (updated > 0) {
-      persist();
+      persist(...params.runIds);
     }
     return updated;
   }
@@ -143,7 +143,7 @@ export function createSubagentRegistryPublicApi(config: {
     entry.collectorLaunchCleanupPending = false;
     entry.cleanupCompletedAt = Date.now();
     entry.contextEngineCleanupCompletedAt ??= entry.cleanupCompletedAt;
-    persist();
+    persist(entry.runId);
   }
 
   function recordSwarmStructuredOutput(
@@ -168,7 +168,7 @@ export function createSubagentRegistryPublicApi(config: {
     const previous = entry.structuredOutput;
     entry.structuredOutput = structuredClone(state);
     try {
-      persistOrThrow();
+      persistOrThrow(entry.runId);
     } catch (error) {
       entry.structuredOutput = previous;
       throw error;

--- a/src/agents/subagent-registry-requester-yield.ts
+++ b/src/agents/subagent-registry-requester-yield.ts
@@ -7,7 +7,7 @@ export function markRequesterTurnYieldedInRuns(params: {
   requesterSessionKey: string;
   requesterTurnRunId: string;
   runs: Map<string, SubagentRunRecord>;
-  persistOrThrow(): void;
+  persistOrThrow(...runIds: string[]): void;
 }): number {
   const requesterSessionKey = params.requesterSessionKey.trim();
   const requesterTurnRunId = params.requesterTurnRunId.trim();
@@ -27,7 +27,7 @@ export function markRequesterTurnYieldedInRuns(params: {
     entry.requesterTurnYielded = true;
   }
   try {
-    params.persistOrThrow();
+    params.persistOrThrow(...entries.map((entry) => entry.runId));
   } catch (error) {
     entries.forEach((entry, index) => {
       entry.requesterTurnYielded = previous[index];
@@ -43,7 +43,7 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
   requesterYielded: boolean;
   acceptedSessionSpawns: readonly AcceptedSessionSpawn[];
   runs: Map<string, SubagentRunRecord>;
-  persistOrThrow(): void;
+  persistOrThrow(...runIds: string[]): void;
   schedule(runId: string, entry: SubagentRunRecord): void;
 }): boolean {
   const requesterSessionKey = params.requesterSessionKey.trim();
@@ -126,7 +126,7 @@ export function settleRequesterTurnAfterSessionSpawns(params: {
     }
   }
   try {
-    params.persistOrThrow();
+    params.persistOrThrow(...entries.map((entry) => entry.runId));
   } catch (error) {
     entries.forEach((entry, index) => {
       const previous = previousStates[index];

--- a/src/agents/subagent-registry-restore.ts
+++ b/src/agents/subagent-registry-restore.ts
@@ -24,7 +24,7 @@ export function createSubagentRegistryRestorer(config: {
   runs: Map<string, SubagentRunRecord>;
   resumedRuns: Set<string>;
   deps: () => SubagentRegistryDeps;
-  persist: () => void;
+  persist: (...runIds: string[]) => void;
   settleRequesterTurn: ReturnType<
     typeof createSubagentRegistryLifecycleController
   >["settleRequesterTurnAfterSessionSpawns"];

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -241,8 +241,8 @@ export type RegisterSubagentRunParams = {
 export function createSubagentRunManager(params: {
   runs: Map<string, SubagentRunRecord>;
   resumedRuns: Set<string>;
-  persist(): void;
-  persistOrThrow(): void;
+  persist(...runIds: string[]): void;
+  persistOrThrow(...runIds: string[]): void;
   callGateway: typeof callGateway;
   getRuntimeConfig: typeof getRuntimeConfig;
   ensureListener(): void;
@@ -384,7 +384,7 @@ export function createSubagentRunManager(params: {
             endedAt: wait.endedAt,
           })
         ) {
-          params.persist();
+          params.persist(entry.runId);
         }
         return;
       }
@@ -478,7 +478,7 @@ export function createSubagentRunManager(params: {
           if (typeof entry.sessionStartedAt !== "number") {
             entry.sessionStartedAt = observedStartedAt;
           }
-          params.persist();
+          params.persist(entry.runId);
         }
         scheduleWaitRetry(
           entry,
@@ -571,7 +571,7 @@ export function createSubagentRunManager(params: {
       return true;
     }
     entry.suppressAnnounceReason = "steer-restart";
-    params.persist();
+    params.persist(entry.runId);
     return true;
   };
 
@@ -622,7 +622,7 @@ export function createSubagentRunManager(params: {
       }
     }
     entry.suppressAnnounceReason = undefined;
-    params.persist();
+    params.persist(entry.runId);
     // If the interrupted run already finished while suppression was active, retry
     // cleanup now so completion output is not lost when restart dispatch fails.
     params.resumedRuns.delete(key);
@@ -744,9 +744,14 @@ export function createSubagentRunManager(params: {
       params.runs.delete(previousRunId);
     }
     params.runs.set(nextRunId, next);
-    markOlderKillReconciliationsSuperseded(next);
+    const killReconciliationSnapshots = markOlderKillReconciliationsSuperseded(next);
+    const changedRunIds = [
+      previousRunId,
+      nextRunId,
+      ...[...killReconciliationSnapshots.keys()].map((entry) => entry.runId),
+    ];
     try {
-      params.persistOrThrow();
+      params.persistOrThrow(...changedRunIds);
     } catch (error) {
       // The gateway has already started nextRunId. Keep its in-memory owner
       // authoritative and retry best-effort persistence; rolling back here
@@ -756,7 +761,7 @@ export function createSubagentRunManager(params: {
         previousRunId,
         nextRunId,
       });
-      params.persist();
+      params.persist(...changedRunIds);
     }
     if (previousRunId !== nextRunId) {
       params.clearPendingLifecycleError(previousRunId);
@@ -866,7 +871,10 @@ export function createSubagentRunManager(params: {
     params.runs.set(runId, entry);
     const killReconciliationSnapshots = markOlderKillReconciliationsSuperseded(entry);
     try {
-      params.persistOrThrow();
+      params.persistOrThrow(
+        runId,
+        ...[...killReconciliationSnapshots.keys()].map((candidate) => candidate.runId),
+      );
     } catch (error) {
       params.runs.delete(runId);
       restoreKillReconciliationSnapshots(killReconciliationSnapshots);
@@ -971,7 +979,7 @@ export function createSubagentRunManager(params: {
       entry.swarmLaunchPending = false;
       entry.queuedLaunch = undefined;
       try {
-        params.persistOrThrow();
+        params.persistOrThrow(previousRunId, nextRunId);
         return true;
       } catch (error) {
         if (previousRunId !== nextRunId) {
@@ -1010,7 +1018,7 @@ export function createSubagentRunManager(params: {
     entry.queuedLaunch = undefined;
     let persistedRunning = false;
     try {
-      params.persistOrThrow();
+      params.persistOrThrow(previousRunId, nextRunId);
       persistedRunning = true;
       startTaskRunByRunId({
         runId: entry.taskRunId ?? entry.runId,
@@ -1034,7 +1042,7 @@ export function createSubagentRunManager(params: {
       entry.swarmLaunchPending = previousSwarmLaunchPending;
       if (persistedRunning) {
         try {
-          params.persistOrThrow();
+          params.persistOrThrow(previousRunId, nextRunId);
         } catch (rollbackError) {
           // The failure callback terminalizes this in-memory queued row next.
           log.warn("failed to persist collector start rollback", {
@@ -1073,7 +1081,7 @@ export function createSubagentRunManager(params: {
     entry.completion = { required: false, resultText: error, capturedAt: endedAt };
     updateSwarmCollectorCompletion(entry, params.getRuntimeConfig());
     try {
-      params.persistOrThrow();
+      params.persistOrThrow(entry.runId);
     } catch (persistError) {
       const target = entry as unknown as Record<string, unknown>;
       for (const property of Object.keys(target)) {
@@ -1134,7 +1142,7 @@ export function createSubagentRunManager(params: {
     };
     updateSwarmCollectorCompletion(entry, params.getRuntimeConfig());
     try {
-      params.persistOrThrow();
+      params.persistOrThrow(entry.runId);
     } catch (persistError) {
       const target = entry as unknown as Record<string, unknown>;
       for (const property of Object.keys(target)) {
@@ -1162,7 +1170,7 @@ export function createSubagentRunManager(params: {
     }
     const didDelete = params.runs.delete(runId);
     if (didDelete) {
-      params.persist();
+      params.persist(runId);
     }
     if (params.runs.size === 0) {
       params.stopSweeper();
@@ -1302,7 +1310,7 @@ export function createSubagentRunManager(params: {
       try {
         // The registry tombstone is the recovery source for the provisional
         // task marker. It must commit first so the sweeper can always finish it.
-        params.persistOrThrow();
+        params.persistOrThrow(...[...entrySnapshots.keys()].map((entry) => entry.runId));
       } catch (error) {
         for (const [entry, snapshot] of entrySnapshots) {
           const target = entry as unknown as Record<string, unknown>;

--- a/src/agents/subagent-registry-state.test.ts
+++ b/src/agents/subagent-registry-state.test.ts
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   loadSubagentRunsForControllerFromSqlite:
     vi.fn<(controllerSessionKey: string) => SubagentRunRecord[]>(),
   loadSubagentRegistryFromSqlite: vi.fn<() => Map<string, SubagentRunRecord>>(),
+  saveSubagentRegistryChangesToSqlite:
+    vi.fn<(runs: Map<string, SubagentRunRecord>, changedRunIds: readonly string[]) => void>(),
   saveSubagentRegistryToSqlite: vi.fn<(runs: Map<string, SubagentRunRecord>) => void>(),
 }));
 
@@ -23,6 +25,7 @@ vi.mock("./subagent-registry.store.sqlite.js", () => ({
   loadSubagentRunsForChildSessionFromSqlite: mocks.loadSubagentRunsForChildSessionFromSqlite,
   loadSubagentRunsForControllerFromSqlite: mocks.loadSubagentRunsForControllerFromSqlite,
   loadSubagentRegistryFromSqlite: mocks.loadSubagentRegistryFromSqlite,
+  saveSubagentRegistryChangesToSqlite: mocks.saveSubagentRegistryChangesToSqlite,
   saveSubagentRegistryToSqlite: mocks.saveSubagentRegistryToSqlite,
 }));
 
@@ -50,6 +53,7 @@ describe("subagent registry state read cache", () => {
     mocks.loadSubagentRunsForChildSessionFromSqlite.mockReset();
     mocks.loadSubagentRunsForControllerFromSqlite.mockReset();
     mocks.loadSubagentRegistryFromSqlite.mockReset();
+    mocks.saveSubagentRegistryChangesToSqlite.mockReset();
     mocks.saveSubagentRegistryToSqlite.mockReset();
   });
 
@@ -92,6 +96,51 @@ describe("subagent registry state read cache", () => {
     expect([...getSubagentRunsSnapshotForRead(new Map()).keys()]).toEqual(["run-saved"]);
     expect(mocks.saveSubagentRegistryToSqlite).toHaveBeenCalledOnce();
     expect(mocks.loadSubagentRegistryFromSqlite).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates only named runs in the local read cache", () => {
+    const changed = createRun("changed");
+    const untouched = createRun("untouched");
+    mocks.loadSubagentRegistryFromSqlite.mockReturnValue(
+      new Map([
+        [changed.runId, changed],
+        [untouched.runId, untouched],
+      ]),
+    );
+    expect([...getSubagentRunsSnapshotForRead(new Map()).keys()]).toEqual(["changed", "untouched"]);
+
+    changed.task = "updated";
+    const runs = new Map([
+      [changed.runId, changed],
+      [untouched.runId, untouched],
+    ]);
+    persistSubagentRunsToDisk(runs, [changed.runId]);
+
+    expect(mocks.saveSubagentRegistryChangesToSqlite).toHaveBeenCalledWith(runs, [changed.runId]);
+    expect(mocks.saveSubagentRegistryToSqlite).not.toHaveBeenCalled();
+    expect(getSubagentRunsSnapshotForRead(new Map()).get(changed.runId)?.task).toBe("updated");
+    expect(getSubagentRunsSnapshotForRead(new Map()).get(untouched.runId)?.task).toBe(
+      untouched.task,
+    );
+  });
+
+  it("keeps an exact deletion authoritative after a best-effort write failure", () => {
+    const retained = createRun("retained");
+    const removed = createRun("removed");
+    mocks.loadSubagentRegistryFromSqlite.mockReturnValue(
+      new Map([
+        [retained.runId, retained],
+        [removed.runId, removed],
+      ]),
+    );
+    expect([...getSubagentRunsSnapshotForRead(new Map()).keys()]).toEqual(["retained", "removed"]);
+    mocks.saveSubagentRegistryChangesToSqlite.mockImplementationOnce(() => {
+      throw new Error("disk unavailable");
+    });
+
+    persistSubagentRunsToDisk(new Map([[retained.runId, retained]]), [removed.runId]);
+
+    expect([...getSubagentRunsSnapshotForRead(new Map()).keys()]).toEqual(["retained"]);
   });
 
   it("wakes local readers when a best-effort write fails", () => {

--- a/src/agents/subagent-registry-state.ts
+++ b/src/agents/subagent-registry-state.ts
@@ -8,6 +8,7 @@ import {
   loadSubagentRunsForChildSessionFromSqlite,
   loadSubagentRunsForControllerFromSqlite,
   loadSubagentRegistryFromSqlite,
+  saveSubagentRegistryChangesToSqlite,
   saveSubagentRegistryToSqlite,
 } from "./subagent-registry.store.sqlite.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -54,6 +55,25 @@ function rememberPersistedSubagentRunsSnapshot(runs: Map<string, SubagentRunReco
     loadedAtMs: Date.now(),
     runs: cloneSubagentRunsSnapshot(runs),
   };
+}
+
+function rememberPersistedSubagentRunChanges(
+  runs: Map<string, SubagentRunRecord>,
+  changedRunIds: readonly string[],
+): void {
+  if (!persistedSubagentRunsReadCache) {
+    rememberPersistedSubagentRunsSnapshot(runs);
+    return;
+  }
+  for (const runId of new Set(changedRunIds)) {
+    const entry = runs.get(runId);
+    if (entry) {
+      persistedSubagentRunsReadCache.runs.set(runId, structuredClone(entry));
+    } else {
+      persistedSubagentRunsReadCache.runs.delete(runId);
+    }
+  }
+  persistedSubagentRunsReadCache.loadedAtMs = Date.now();
 }
 
 function shouldReadPersistedSubagentRuns(): boolean {
@@ -108,21 +128,42 @@ export function clearSubagentRunsReadCacheForTest(): void {
   persistedSubagentRunsReadCache = undefined;
 }
 
-export function persistSubagentRunsToDisk(runs: Map<string, SubagentRunRecord>) {
+export function persistSubagentRunsToDisk(
+  runs: Map<string, SubagentRunRecord>,
+  // Undefined replaces the complete snapshot; an array applies exact row mutations.
+  changedRunIds?: readonly string[],
+) {
   try {
-    saveSubagentRegistryToSqlite(runs);
+    if (changedRunIds) {
+      saveSubagentRegistryChangesToSqlite(runs, changedRunIds);
+    } else {
+      saveSubagentRegistryToSqlite(runs);
+    }
   } catch {
     // ignore persistence failures
   } finally {
     // In-process readers must observe the authoritative memory snapshot before the wake.
-    rememberPersistedSubagentRunsSnapshot(runs);
+    if (changedRunIds) {
+      rememberPersistedSubagentRunChanges(runs, changedRunIds);
+    } else {
+      rememberPersistedSubagentRunsSnapshot(runs);
+    }
     emitSubagentRegistryPersisted();
   }
 }
 
-export function persistSubagentRunsToDiskOrThrow(runs: Map<string, SubagentRunRecord>) {
-  saveSubagentRegistryToSqlite(runs);
-  rememberPersistedSubagentRunsSnapshot(runs);
+export function persistSubagentRunsToDiskOrThrow(
+  runs: Map<string, SubagentRunRecord>,
+  // Undefined replaces the complete snapshot; an array applies exact row mutations.
+  changedRunIds?: readonly string[],
+) {
+  if (changedRunIds) {
+    saveSubagentRegistryChangesToSqlite(runs, changedRunIds);
+    rememberPersistedSubagentRunChanges(runs, changedRunIds);
+  } else {
+    saveSubagentRegistryToSqlite(runs);
+    rememberPersistedSubagentRunsSnapshot(runs);
+  }
   emitSubagentRegistryPersisted();
 }
 

--- a/src/agents/subagent-registry-sweeper.ts
+++ b/src/agents/subagent-registry-sweeper.ts
@@ -69,7 +69,7 @@ export async function retireSupersededSubagentRun(params: {
 export function createSubagentRegistrySweeper(params: {
   runs: Map<string, SubagentRunRecord>;
   resumedRuns: Set<string>;
-  persist: () => void;
+  persist: (...runIds: string[]) => void;
   clearPendingLifecycleError: (runId: string) => void;
   clearPendingLifecycleTimeout: (runId: string) => void;
   sweepPendingLifecycle: (now: number) => void;
@@ -233,6 +233,7 @@ export function createSubagentRegistrySweeper(params: {
       const now = Date.now();
       const storeCache: SubagentSessionStoreCache = new Map();
       let mutated = false;
+      const mutatedRunIds = new Set<string>();
       const archivedCollectorGroups = new Set<string>();
       const suspendedEntries = [...runs.entries()].filter(([, entry]) =>
         isSuspendedPendingFinalDelivery(entry),
@@ -272,6 +273,7 @@ export function createSubagentRegistrySweeper(params: {
               expired ? "expired" : "pressure-pruned",
             );
             mutated = true;
+            mutatedRunIds.add(runId);
           }
           continue;
         }
@@ -292,6 +294,7 @@ export function createSubagentRegistrySweeper(params: {
                 })
               ) {
                 mutated = true;
+                mutatedRunIds.add(runId);
               }
               continue;
             }
@@ -345,18 +348,21 @@ export function createSubagentRegistrySweeper(params: {
         }
 
         if (entry.killReconciliation) {
-          mutated =
-            (await reconcileProvisionalSubagentKill({
-              runId,
-              entry,
-              now,
-              runs,
-              storeCache,
-              completeSubagentRunWithRecovery: params.completeSubagentRunWithRecovery,
-              retireSupersededRun: params.retireSupersededRun,
-              startSubagentAnnounceCleanupFlow: params.startSubagentAnnounceCleanupFlow,
-              warn: params.warn,
-            })) || mutated;
+          const reconciled = await reconcileProvisionalSubagentKill({
+            runId,
+            entry,
+            now,
+            runs,
+            storeCache,
+            completeSubagentRunWithRecovery: params.completeSubagentRunWithRecovery,
+            retireSupersededRun: params.retireSupersededRun,
+            startSubagentAnnounceCleanupFlow: params.startSubagentAnnounceCleanupFlow,
+            warn: params.warn,
+          });
+          if (reconciled) {
+            mutated = true;
+            mutatedRunIds.add(runId);
+          }
           continue;
         }
         if (entry.collect && entry.collectorCompletion) {
@@ -382,6 +388,7 @@ export function createSubagentRegistrySweeper(params: {
             entry.collectorLaunchCleanupPending = false;
             entry.cleanupCompletedAt = now;
             mutated = true;
+            mutatedRunIds.add(runId);
           }
           const groupId = entry.groupId?.trim();
           const swarmRequesterSessionKey =
@@ -455,7 +462,7 @@ export function createSubagentRegistrySweeper(params: {
             try {
               await params.runContextEngineSubagentEnded(sweptContext(candidate));
               candidate.contextEngineCleanupCompletedAt = Date.now();
-              params.persist();
+              params.persist(candidateRunId);
             } catch (error) {
               params.warn(
                 "context-engine cleanup failed during collector group sweep; keeping group",
@@ -476,6 +483,7 @@ export function createSubagentRegistrySweeper(params: {
           for (const [candidateRunId] of groupEntries) {
             params.clearPendingLifecycleError(candidateRunId);
             runs.delete(candidateRunId);
+            mutatedRunIds.add(candidateRunId);
           }
           archivedCollectorGroups.add(groupKey);
           mutated = true;
@@ -495,6 +503,7 @@ export function createSubagentRegistrySweeper(params: {
             });
             runs.delete(runId);
             mutated = true;
+            mutatedRunIds.add(runId);
             if (!entry.retainAttachmentsOnKeep) {
               await safeRemoveAttachmentsDir(entry);
             }
@@ -517,6 +526,7 @@ export function createSubagentRegistrySweeper(params: {
         }
         runs.delete(runId);
         mutated = true;
+        mutatedRunIds.add(runId);
         await safeRemoveAttachmentsDir(entry);
         runCleanupTail(runId, "context-engine cleanup", async () => {
           await params.notifyContextEngineSubagentEnded(sweptContext(entry));
@@ -525,7 +535,7 @@ export function createSubagentRegistrySweeper(params: {
       params.sweepPendingLifecycle(now);
 
       if (mutated) {
-        params.persist();
+        params.persist(...mutatedRunIds);
       }
       if (runs.size === 0) {
         stop();

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -1,4 +1,4 @@
-// Subagent registry SQLite store tests cover canonical whole-snapshot persistence.
+// Subagent registry SQLite store tests cover canonical snapshot and exact-row persistence.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -14,6 +14,7 @@ import {
   loadSubagentRunsForChildSessionFromSqlite,
   loadSubagentRunsForControllerFromSqlite,
   loadSubagentRegistryFromSqlite,
+  saveSubagentRegistryChangesToSqlite,
   saveSubagentRegistryToSqlite,
 } from "./subagent-registry.store.sqlite.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -149,6 +150,57 @@ describe("subagent registry sqlite store", () => {
       saveSubagentRegistryToSqlite(new Map([[second.runId, second]]));
 
       expect([...loadSubagentRegistryFromSqlite().keys()]).toEqual(["run-two"]);
+    });
+  });
+
+  it("writes only named registry mutations", async () => {
+    await withTempStateEnv(async () => {
+      const first = createRun({ runId: "run-one", childSessionKey: "agent:main:subagent:one" });
+      const removed = createRun({ runId: "run-two", childSessionKey: "agent:main:subagent:two" });
+      const untouched = createRun({
+        runId: "run-three",
+        childSessionKey: "agent:main:subagent:three",
+      });
+      const runs = new Map([first, removed, untouched].map((run) => [run.runId, run] as const));
+      saveSubagentRegistryToSqlite(runs);
+
+      const { db } = openOpenClawStateDatabase();
+      db.exec(`
+        CREATE TEMP TABLE subagent_run_write_audit (
+          action TEXT NOT NULL,
+          run_id TEXT NOT NULL
+        );
+        CREATE TEMP TRIGGER subagent_run_audit_insert
+        AFTER INSERT ON subagent_runs
+        BEGIN
+          INSERT INTO subagent_run_write_audit VALUES ('insert', NEW.run_id);
+        END;
+        CREATE TEMP TRIGGER subagent_run_audit_update
+        AFTER UPDATE ON subagent_runs
+        BEGIN
+          INSERT INTO subagent_run_write_audit VALUES ('update', NEW.run_id);
+        END;
+        CREATE TEMP TRIGGER subagent_run_audit_delete
+        AFTER DELETE ON subagent_runs
+        BEGIN
+          INSERT INTO subagent_run_write_audit VALUES ('delete', OLD.run_id);
+        END;
+      `);
+
+      first.task = "updated task";
+      runs.delete(removed.runId);
+      saveSubagentRegistryChangesToSqlite(runs, [first.runId, removed.runId]);
+
+      expect(
+        db.prepare("SELECT action, run_id FROM subagent_run_write_audit ORDER BY rowid").all(),
+      ).toEqual([
+        { action: "update", run_id: first.runId },
+        { action: "delete", run_id: removed.runId },
+      ]);
+      expect([...loadSubagentRegistryFromSqlite().entries()]).toMatchObject([
+        [first.runId, { task: "updated task" }],
+        [untouched.runId, { task: untouched.task }],
+      ]);
     });
   });
 

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -381,6 +381,44 @@ function subagentRunRecordToSqliteUpdate(values: SubagentRunSqliteInsert): Subag
   return update;
 }
 
+function writeSubagentRunValues(
+  values: readonly SubagentRunSqliteInsert[],
+  deleteRunIds?: readonly string[],
+  retainedRunIds?: readonly string[],
+): void {
+  if (values.length === 0 && deleteRunIds?.length === 0 && retainedRunIds === undefined) {
+    return;
+  }
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
+    for (const row of values) {
+      executeSqliteQuerySync(
+        db,
+        stateDb
+          .insertInto("subagent_runs")
+          .values(row)
+          .onConflict((conflict) =>
+            conflict.column("run_id").doUpdateSet(subagentRunRecordToSqliteUpdate(row)),
+          ),
+      );
+    }
+    if (retainedRunIds !== undefined) {
+      const deleteQuery =
+        retainedRunIds.length === 0
+          ? stateDb.deleteFrom("subagent_runs")
+          : stateDb.deleteFrom("subagent_runs").where("run_id", "not in", retainedRunIds);
+      executeSqliteQuerySync(db, deleteQuery);
+      return;
+    }
+    if (deleteRunIds && deleteRunIds.length > 0) {
+      executeSqliteQuerySync(
+        db,
+        stateDb.deleteFrom("subagent_runs").where("run_id", "in", deleteRunIds),
+      );
+    }
+  });
+}
+
 function readSubagentRegistryRows(): SubagentRunSqliteRow[] {
   const { db } = openOpenClawStateDatabase();
   const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
@@ -472,26 +510,29 @@ export function loadSubagentRegistryFromSqlite(): Map<string, SubagentRunRecord>
 
 /** Saves the complete subagent run snapshot to sqlite and prunes rows not in the snapshot. */
 export function saveSubagentRegistryToSqlite(runs: Map<string, SubagentRunRecord>): void {
-  runOpenClawStateWriteTransaction(({ db }) => {
-    const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
-    const runIds: string[] = [];
-    for (const entry of runs.values()) {
-      const values = subagentRunRecordToSqliteInsert(entry);
-      runIds.push(values.run_id);
-      executeSqliteQuerySync(
-        db,
-        stateDb
-          .insertInto("subagent_runs")
-          .values(values)
-          .onConflict((conflict) =>
-            conflict.column("run_id").doUpdateSet(subagentRunRecordToSqliteUpdate(values)),
-          ),
-      );
+  const values = [...runs.values()].map(subagentRunRecordToSqliteInsert);
+  writeSubagentRunValues(
+    values,
+    undefined,
+    values.map((row) => row.run_id),
+  );
+}
+
+/** Persists only named run mutations, deleting names absent from the current registry. */
+export function saveSubagentRegistryChangesToSqlite(
+  runs: Map<string, SubagentRunRecord>,
+  changedRunIds: readonly string[],
+): void {
+  const runIds = [...new Set(changedRunIds.map((runId) => runId.trim()).filter(Boolean))];
+  const values: SubagentRunSqliteInsert[] = [];
+  const deleteRunIds: string[] = [];
+  for (const runId of runIds) {
+    const entry = runs.get(runId);
+    if (entry) {
+      values.push(subagentRunRecordToSqliteInsert(entry));
+    } else {
+      deleteRunIds.push(runId);
     }
-    const deleteQuery =
-      runIds.length === 0
-        ? stateDb.deleteFrom("subagent_runs")
-        : stateDb.deleteFrom("subagent_runs").where("run_id", "not in", runIds);
-    executeSqliteQuerySync(db, deleteQuery);
-  });
+  }
+  writeSubagentRunValues(values, deleteRunIds);
 }

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -4398,13 +4398,15 @@ describe("subagent registry seam flow", () => {
       "agent.wait": { status: "pending" },
     });
 
+    const runId = `run-single-persist-${queued ? "queued" : "running"}`;
     mod.registerSubagentRun({
-      runId: `run-single-persist-${queued ? "queued" : "running"}`,
+      runId,
       task: "persist one registry snapshot",
       queued,
     });
 
     expect(mocks.persistSubagentRunsToDiskOrThrow).toHaveBeenCalledOnce();
+    expect(mocks.persistSubagentRunsToDiskOrThrow).toHaveBeenCalledWith(expect.any(Map), [runId]);
     expect(mocks.persistSubagentRunsToDisk).not.toHaveBeenCalled();
   });
 

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -76,12 +76,20 @@ let lastOrphanRecoveryScheduleAt = 0;
 const SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
 const GATEWAY_ADMISSION_RETRY_DELAY_MS = 1_000;
 
-function persistSubagentRuns() {
-  subagentRegistryDeps.persistSubagentRunsToDisk(subagentRuns);
+// Hot lifecycle callers name every changed or removed row. Zero ids is reserved
+// for explicit full-registry replacement at restore/reset boundaries.
+function persistSubagentRuns(...runIds: string[]) {
+  subagentRegistryDeps.persistSubagentRunsToDisk(
+    subagentRuns,
+    runIds.length > 0 ? runIds : undefined,
+  );
 }
 
-function persistSubagentRunsOrThrow() {
-  subagentRegistryDeps.persistSubagentRunsToDiskOrThrow(subagentRuns);
+function persistSubagentRunsOrThrow(...runIds: string[]) {
+  subagentRegistryDeps.persistSubagentRunsToDiskOrThrow(
+    subagentRuns,
+    runIds.length > 0 ? runIds : undefined,
+  );
 }
 
 function findSubagentTaskForRun(entry: SubagentRunRecord) {
@@ -317,7 +325,7 @@ function resumeSubagentRun(runId: string) {
           resumedRuns,
         })
       ) {
-        persistSubagentRuns();
+        persistSubagentRuns(runId);
       }
       return;
     }
@@ -468,7 +476,7 @@ configureSubagentRegistrySteerRuntime({
     entry.swarmLaunchIdempotencyKey = idempotencyKey;
     entry.swarmLaunchPending = true;
     try {
-      persistSubagentRunsOrThrow();
+      persistSubagentRunsOrThrow(entry.runId);
     } catch (error) {
       entry.swarmLaunchIdempotencyKey = previousIdempotencyKey;
       entry.swarmLaunchPending = previousPending;


### PR DESCRIPTION
Closes #116227

## What Problem This Solves

Fixes an issue where large agent and subagent fan-outs repeatedly rewrote and deep-cloned every retained registry run for each lifecycle mutation, blocking the Gateway event loop and creating substantial transient memory churn.

## Why This Change Was Made

Hot registry mutations now name the exact changed or removed run IDs. The SQLite owner upserts those rows and deletes exact absent IDs in one transaction, while the in-process read cache updates the same entries incrementally.

Explicit restore and test-reset boundaries retain complete-snapshot replacement and pruning. The schema, serialized record shape, rollback behavior, and persistence notifications are unchanged.

## User Impact

Large concurrent fan-outs spend substantially less synchronous time persisting registrations, terminal transitions, cleanup, steering, and idle bookkeeping. Unrelated retained runs no longer multiply the work for each transition.

## Evidence

### Stress matrix

A throwaway production-module harness exercised:

- 10, 25, 50, and 100 concurrent runs
- wide active descendant queries
- nested idle parents with active descendants
- growing active registration waves
- terminal and idle lifecycle waves with 32 KiB completion results
- 10 to 100 embedded active runs with waiters and teardown

The embedded registry returned to zero active runs and settled every waiter at 100-way concurrency. The dominant defect was durable subagent registry persistence.

Same-process before/after measurements on 100-run waves:

```text
                                      full snapshot   exact rows
growing active registry wall time       17,710 ms      1,360 ms
growing active registry RSS after GC      +52.7 MiB      +3.5 MiB
terminal/idle registry wall time         13,693 ms      3,487 ms
terminal/idle registry RSS after GC        +31.6 MiB      -2.2 MiB
```

The wall-clock improvement was 13.0x for the growing wave and 3.9x for the terminal wave in that run. An earlier baseline run produced the same superlinear shape with lower absolute times, confirming normal host variance rather than a one-off ordering artifact.

### Narrow regressions

- SQLite triggers prove an incremental mutation updates one named row, deletes one named row, and does not touch an unrelated retained row.
- Read-cache coverage proves incremental updates preserve unrelated entries.
- Best-effort failure coverage proves an exact deletion remains authoritative in-process and cannot resurrect from stale SQLite state.
- Registration coverage proves queued and running paths select exact-row persistence.

### Validation

```text
node scripts/run-vitest.mjs \
  src/agents/subagent-registry.test.ts \
  src/agents/subagent-registry-state.test.ts \
  src/agents/subagent-registry.store.sqlite.test.ts \
  src/agents/subagent-registry-lifecycle.test.ts \
  src/agents/subagent-registry-requester-yield.test.ts
  5 files passed, 275 tests passed

exact rebased-head regression selection
  6 files passed, 10 tests passed, 294 skipped

node scripts/run-tsgo.mjs -p tsconfig.core.json ...
  passed

direct targeted oxlint, oxfmt, git diff --check
  passed
```

Blacksmith Testbox:

- lease: `tbx_01kyry1spj2tm24hy9y1t3t06n`
- run: https://github.com/openclaw/openclaw/actions/runs/30522336854
- `node scripts/check-changed.mjs -- <changed files>`
- core and core-test typechecks, changed-file lint, format, schema, database-first, dead-code, cycle, boundary, and guard lanes passed

Autoreview:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.9)
```

### Not tested

- No live provider or channel traffic was needed; the defect is isolated to the production registry persistence and cache modules.
- The exploratory 10/25/50/100 stress harness remains uncommitted. Only the exact behavioral regressions are permanent.
