### PR TITLE
fix(openai): bound realtime playback acknowledgements

### DIFF
--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -2570,6 +2570,54 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     bridge.close();
   });
 
+  it("treats a later named mark as cumulative playback progress", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onMark = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onMark,
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    bridge.setMediaTimestamp(1000);
+    for (let index = 0; index < 3; index += 1) {
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.audio.delta",
+            item_id: "item_1",
+            delta: Buffer.from("assistant audio").toString("base64"),
+          }),
+        ),
+      );
+    }
+    const marks = onMark.mock.calls.map(([markName]) => String(markName));
+    expect(marks).toHaveLength(3);
+
+    bridge.acknowledgeMark(marks[2]);
+    bridge.acknowledgeMark(marks[0]);
+    bridge.acknowledgeMark(marks[1]);
+    bridge.setMediaTimestamp(1300);
+    bridge.handleBargeIn?.();
+
+    expect(
+      parseSent(socket).filter((event) => event.type === "conversation.item.truncate"),
+    ).toHaveLength(0);
+    bridge.close();
+  });
+
   it("forwards current realtime output audio events", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const onAudio = vi.fn();

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -2491,6 +2491,59 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     ]);
   });
 
+  it("bounds outstanding playback marks while preserving recent acknowledgements", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const onClearAudio = vi.fn();
+    const onMark = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio,
+      onMark,
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+
+    bridge.setMediaTimestamp(1000);
+    let now = 0;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => ++now);
+    for (let index = 0; index < 300; index += 1) {
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.audio.delta",
+            item_id: "item_1",
+            delta: Buffer.from("assistant audio").toString("base64"),
+          }),
+        ),
+      );
+    }
+    dateNow.mockRestore();
+
+    const marks = onMark.mock.calls.map(([markName]) => String(markName));
+    expect(marks).toHaveLength(300);
+    for (const markName of marks.slice(-256)) {
+      bridge.acknowledgeMark(markName);
+    }
+    bridge.setMediaTimestamp(1300);
+    bridge.handleBargeIn?.();
+
+    expect(
+      parseSent(socket).filter((event) => event.type === "conversation.item.truncate"),
+    ).toHaveLength(0);
+    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
+    bridge.close();
+  });
+
   it("forwards current realtime output audio events", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const onAudio = vi.fn();

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -2491,7 +2491,7 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     ]);
   });
 
-  it("bounds outstanding playback marks while preserving recent acknowledgements", async () => {
+  it("preserves FIFO playback acknowledgements after sustained output", async () => {
     const provider = buildOpenAIRealtimeVoiceProvider();
     const onClearAudio = vi.fn();
     const onMark = vi.fn();
@@ -2513,8 +2513,6 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     await connecting;
 
     bridge.setMediaTimestamp(1000);
-    let now = 0;
-    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => ++now);
     for (let index = 0; index < 300; index += 1) {
       socket.emit(
         "message",
@@ -2527,20 +2525,48 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
         ),
       );
     }
-    dateNow.mockRestore();
 
     const marks = onMark.mock.calls.map(([markName]) => String(markName));
     expect(marks).toHaveLength(300);
-    for (const markName of marks.slice(-256)) {
-      bridge.acknowledgeMark(markName);
+    for (let index = 0; index < 299; index += 1) {
+      bridge.acknowledgeMark();
     }
     bridge.setMediaTimestamp(1300);
     bridge.handleBargeIn?.();
 
+    expect(parseSent(socket).slice(-1)).toEqual([
+      {
+        type: "conversation.item.truncate",
+        item_id: "item_1",
+        content_index: 0,
+        audio_end_ms: 300,
+      },
+    ]);
+    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
+
+    for (let index = 0; index < 300; index += 1) {
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.audio.delta",
+            item_id: "item_1",
+            delta: Buffer.from("assistant audio").toString("base64"),
+          }),
+        ),
+      );
+    }
+    const latestMark = onMark.mock.calls.at(-1)?.[0];
+    if (typeof latestMark !== "string") {
+      throw new Error("expected a playback mark");
+    }
+    bridge.acknowledgeMark(latestMark);
+    bridge.setMediaTimestamp(1600);
+    bridge.handleBargeIn?.();
+
     expect(
       parseSent(socket).filter((event) => event.type === "conversation.item.truncate"),
-    ).toHaveLength(0);
-    expect(onClearAudio).toHaveBeenCalledWith("barge-in");
+    ).toHaveLength(1);
     bridge.close();
   });
 

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -558,6 +558,15 @@ function readRealtimeErrorEventId(error: unknown): string | undefined {
   return typeof eventId === "string" ? eventId : undefined;
 }
 
+function parsePlaybackMarkSequence(markName: string): number | undefined {
+  const match = /^audio-(\d+)$/u.exec(markName);
+  if (!match) {
+    return undefined;
+  }
+  const sequence = Number(match[1]);
+  return Number.isSafeInteger(sequence) && sequence > 0 ? sequence : undefined;
+}
+
 class OpenAIRealtimeMalformedAudioError extends Error {}
 
 function base64ToBuffer(b64: string): Buffer {
@@ -577,7 +586,6 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private static readonly CONNECT_TIMEOUT_MS = 10_000;
   private static readonly MAX_PENDING_AUDIO_CHUNKS = 320;
   private static readonly MAX_PENDING_AUDIO_BYTES = 1024 * 1024;
-  private static readonly MAX_OUTSTANDING_MARKS = 256;
   readonly supportsToolResultContinuation = true;
   readonly supportsToolResultSuppression = true;
 
@@ -587,7 +595,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private readonly lifecycle = new OpenAIRealtimeVoiceLifecycle();
   private pendingAudio: Buffer[] = [];
   private pendingAudioBytes = 0;
-  private markQueue: string[] = [];
+  private nextMarkSequence = 1;
+  private oldestOutstandingMarkSequence: number | null = null;
+  private latestOutstandingMarkSequence: number | null = null;
   private responseStartTimestamp: number | null = null;
   private responseActive = false;
   private responseCreateInFlight = false;
@@ -698,10 +708,26 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   acknowledgeMark(markName?: string): void {
-    const index = markName === undefined ? 0 : this.markQueue.indexOf(markName);
-    if (index >= 0) {
-      this.markQueue.splice(index, 1);
+    const oldest = this.oldestOutstandingMarkSequence;
+    const latest = this.latestOutstandingMarkSequence;
+    if (oldest === null || latest === null) {
+      return;
     }
+    const acknowledgedSequence =
+      markName === undefined ? oldest : parsePlaybackMarkSequence(markName);
+    if (
+      acknowledgedSequence === undefined ||
+      acknowledgedSequence < oldest ||
+      acknowledgedSequence > latest
+    ) {
+      return;
+    }
+    if (acknowledgedSequence === latest) {
+      this.oldestOutstandingMarkSequence = null;
+      this.latestOutstandingMarkSequence = null;
+      return;
+    }
+    this.oldestOutstandingMarkSequence = acknowledgedSequence + 1;
   }
 
   close(): void {
@@ -1462,7 +1488,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     const shouldInterruptProvider =
       assistantItemId !== null &&
       ((responseStartTimestamp !== null &&
-        (this.markQueue.length > 0 || options?.audioPlaybackActive === true)) ||
+        (this.oldestOutstandingMarkSequence !== null || options?.audioPlaybackActive === true)) ||
         force);
     const audioEndMs = shouldInterruptProvider
       ? Math.max(
@@ -1503,7 +1529,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         `reason=barge-in audioEndMs=${audioEndMs}`,
       );
       this.config.onClearAudio("barge-in");
-      this.markQueue = [];
+      this.clearOutstandingMarks();
       this.lastAssistantItemId = null;
       this.responseStartTimestamp = null;
       return;
@@ -1587,7 +1613,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private resetRealtimeSessionState(): void {
-    this.markQueue = [];
+    this.clearOutstandingMarks();
     this.responseStartTimestamp = null;
     this.responseActive = false;
     this.responseCreateInFlight = false;
@@ -1658,12 +1684,19 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private sendMark(): void {
-    const markName = `audio-${Date.now()}`;
-    this.markQueue.push(markName);
-    if (this.markQueue.length > OpenAIRealtimeVoiceBridge.MAX_OUTSTANDING_MARKS) {
-      this.markQueue.shift();
+    const sequence = this.nextMarkSequence;
+    this.nextMarkSequence += 1;
+    if (this.oldestOutstandingMarkSequence === null) {
+      this.oldestOutstandingMarkSequence = sequence;
     }
+    this.latestOutstandingMarkSequence = sequence;
+    const markName = `audio-${sequence}`;
     this.config.onMark?.(markName);
+  }
+
+  private clearOutstandingMarks(): void {
+    this.oldestOutstandingMarkSequence = null;
+    this.latestOutstandingMarkSequence = null;
   }
 
   private sendEvent(event: unknown, detail?: string): void {

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -722,6 +722,8 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
     ) {
       return;
     }
+    // Marks follow ordered playback. Reaching a named mark also acknowledges every
+    // earlier mark, while late acknowledgements from that prefix remain harmless.
     if (acknowledgedSequence === latest) {
       this.oldestOutstandingMarkSequence = null;
       this.latestOutstandingMarkSequence = null;

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -577,6 +577,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private static readonly CONNECT_TIMEOUT_MS = 10_000;
   private static readonly MAX_PENDING_AUDIO_CHUNKS = 320;
   private static readonly MAX_PENDING_AUDIO_BYTES = 1024 * 1024;
+  private static readonly MAX_OUTSTANDING_MARKS = 256;
   readonly supportsToolResultContinuation = true;
   readonly supportsToolResultSuppression = true;
 
@@ -1659,6 +1660,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private sendMark(): void {
     const markName = `audio-${Date.now()}`;
     this.markQueue.push(markName);
+    if (this.markQueue.length > OpenAIRealtimeVoiceBridge.MAX_OUTSTANDING_MARKS) {
+      this.markQueue.shift();
+    }
     this.config.onMark?.(markName);
   }
 


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where OpenAI realtime voice sessions could retain one playback acknowledgement marker for every output-audio delta when a client did not acknowledge marks, allowing provider-owned history to grow for the full session.

## Why This Change Was Made

The legacy OpenAI realtime bridge now represents outstanding playback with constant-space monotonic sequence watermarks instead of retaining every mark name. Unnamed acknowledgements still consume playback progress one mark at a time. Named acknowledgements advance cumulatively because both supported transports emit marks behind ordered audio playback; late or invalid acknowledgements are ignored.

Mark names remain transport-visible strings. No provider, config, protocol, or environment-variable surface changes.

## User Impact

Long-running realtime voice sessions keep constant provider-owned playback acknowledgement state even when a client omits acknowledgements. FIFO telephony acknowledgements, named browser acknowledgements, barge-in truncation, and stale late-event handling remain unchanged.

## Evidence

- Exact head: `35e53100a345881b61b92707a3ee9adf688041cf`.
- Blacksmith Testbox: `pnpm test:serial extensions/openai/realtime-voice-provider.test.ts` — 87 passed.
- Blacksmith Testbox: `pnpm check:changed` — passed against current `origin/main`; only the provider and its direct test were in scope.
- Live OpenAI key: speech voice listing/TTS, synthesized-audio transcription, realtime STT startup, and streaming realtime STT — 4 passed.
- Live OpenAI key: backend GA Realtime bridge reached `session.created` and `session.updated`; browser WebRTC negotiated an audio answer and reached `connected` on `gpt-realtime-2.1`.
- Regression coverage verifies sustained unnamed FIFO acknowledgements, cumulative named progress, ignored stale named acknowledgements, and barge-in truncation precedence.
- Autoreview on the exact branch: no accepted/actionable findings, confidence 0.85.
