### PR TITLE
fix(test): preserve failed shard diagnostics

### DIFF
--- a/scripts/test-projects.mjs
+++ b/scripts/test-projects.mjs
@@ -369,7 +369,7 @@ async function main() {
       }
       releaseLockOnce();
       if (parallelExitCode !== 0) {
-        process.exit(parallelExitCode);
+        process.exitCode = parallelExitCode;
       }
       return;
     }
@@ -390,7 +390,8 @@ async function main() {
       if (spec.continueOnFailure !== true) {
         printTestSummary("failed", timings.length, performance.now() - suiteStartedAt);
         releaseLockOnce();
-        process.exit(result.code);
+        process.exitCode = result.code;
+        return;
       }
     }
   }
@@ -403,7 +404,7 @@ async function main() {
 
   releaseLockOnce();
   if (exitCode !== 0) {
-    process.exit(exitCode);
+    process.exitCode = exitCode;
   }
 }
 
@@ -418,6 +419,6 @@ main().catch(
   /** @param {unknown} error */ (error) => {
     releaseLockOnce();
     console.error(error);
-    process.exit(1);
+    process.exitCode = 1;
   },
 );

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -3286,6 +3286,12 @@ describe("scripts/test-projects changed-target routing", () => {
     expect(result.stderr).not.toContain("[test] starting");
   });
 
+  it("lets buffered failure diagnostics drain before the dispatcher exits", () => {
+    const source = fs.readFileSync("scripts/test-projects.mjs", "utf8");
+
+    expect(source).not.toContain("process.exit(");
+  });
+
   it("allows explicit split Vitest config targets without treating them as unmatched tests", () => {
     expect(
       findUnmatchedExplicitTestTargets(


### PR DESCRIPTION
Related: #115696

## What Problem This Solves

Fixes an issue where maintainers running parallel Vitest shards could lose the failed-shard digest and rerun commands when the dispatcher exited nonzero with buffered stderr.

## Why This Change Was Made

The dispatcher now sets `process.exitCode` after writing summaries instead of forcing immediate termination with `process.exit()`. A regression guard keeps direct forced exits out of this output-producing script.

## User Impact

Maintainers get the actual failed shard and focused rerun command after long parallel test runs instead of only a generic nonzero summary. No product runtime behavior changes.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts`: 256 tests passed
- Forced two-shard failure exited 1 and preserved both failed-shard rerun commands
- Exact-head Blacksmith Testbox changed gate passed: https://github.com/openclaw/openclaw/actions/runs/30522962100
- Autoreview clean: 0.94

AI-assisted: yes; maintainer reviewed the implementation and evidence.