### PR TITLE
fix(memory): refresh stale openai embedding auth on 401

### DIFF
--- a/extensions/openai/embedding-auth-retry.ts
+++ b/extensions/openai/embedding-auth-retry.ts
@@ -1,0 +1,37 @@
+// Openai helper module retries memory embedding calls once after token expiry.
+
+export type RefreshableOpenAiEmbeddingClient = {
+  refreshClient?: (params?: { forceRefresh?: boolean }) => Promise<unknown>;
+};
+
+export function isOpenAiEmbeddingTokenExpiredError(error: unknown): boolean {
+  const status =
+    typeof error === "object" &&
+    error !== null &&
+    typeof (error as { status?: unknown }).status === "number"
+      ? (error as { status: number }).status
+      : undefined;
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    (status === 401 || /\b401\b/.test(message)) &&
+    /\btoken[_ -]?expired\b|\bexpired token\b/i.test(message)
+  );
+}
+
+export async function retryOpenAiEmbeddingTokenExpiredOnce<T>(params: {
+  client: RefreshableOpenAiEmbeddingClient;
+  run: () => Promise<T>;
+}): Promise<T> {
+  try {
+    return await params.run();
+  } catch (error) {
+    if (
+      !isOpenAiEmbeddingTokenExpiredError(error) ||
+      typeof params.client.refreshClient !== "function"
+    ) {
+      throw error;
+    }
+    await params.client.refreshClient({ forceRefresh: true });
+    return await params.run();
+  }
+}

--- a/extensions/openai/embedding-batch.ts
+++ b/extensions/openai/embedding-batch.ts
@@ -5,29 +5,31 @@ import {
   buildEmbeddingBatchGroupOptions,
   EMBEDDING_BATCH_ENDPOINT,
   extractBatchErrorMessage,
+  formatBatchErrorDetail,
   formatUnavailableBatchError,
   normalizeBatchBaseUrl,
   postJsonWithRetry,
+  readEmbeddingBatchJsonl,
   resolveBatchCompletionFromStatus,
   resolveCompletedBatchResult,
   runEmbeddingBatchGroups,
+  throwIfBatchCompletionError,
   throwIfBatchTerminalFailure,
+  type EmbeddingBatchExecutionParams,
   type EmbeddingBatchStatus,
   type BatchCompletionResult,
   type ProviderBatchOutputLine,
   uploadBatchJsonlFile,
   withRemoteHttpResponse,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
+import {
+  assertOkOrThrowProviderError,
+  readProviderJsonResponse,
+  readProviderTextResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { retryOpenAiEmbeddingTokenExpiredOnce } from "./embedding-auth-retry.js";
 import type { OpenAiEmbeddingClient } from "./embedding-provider.js";
-
-type EmbeddingBatchExecutionParams = {
-  wait: boolean;
-  pollIntervalMs: number;
-  timeoutMs: number;
-  concurrency: number;
-  debug?: (message: string, data?: Record<string, unknown>) => void;
-};
 
 type OpenAiBatchRequest = {
   custom_id: string;
@@ -61,28 +63,33 @@ async function submitOpenAiBatch(params: {
   requests: OpenAiBatchRequest[];
   agentId: string;
 }): Promise<OpenAiBatchStatus> {
-  const baseUrl = normalizeBatchBaseUrl(params.openAi);
-  const inputFileId = await uploadBatchJsonlFile({
+  return await retryOpenAiEmbeddingTokenExpiredOnce({
     client: params.openAi,
-    requests: params.requests,
-    errorPrefix: "openai batch file upload failed",
-  });
+    run: async () => {
+      const baseUrl = normalizeBatchBaseUrl(params.openAi);
+      const inputFileId = await uploadBatchJsonlFile({
+        client: params.openAi,
+        requests: params.requests,
+        errorPrefix: "openai batch file upload failed",
+      });
 
-  return await postJsonWithRetry<OpenAiBatchStatus>({
-    url: `${baseUrl}/batches`,
-    headers: buildBatchHeaders(params.openAi, { json: true }),
-    ssrfPolicy: params.openAi.ssrfPolicy,
-    fetchImpl: params.openAi.fetchImpl,
-    body: {
-      input_file_id: inputFileId,
-      endpoint: OPENAI_BATCH_ENDPOINT,
-      completion_window: OPENAI_BATCH_COMPLETION_WINDOW,
-      metadata: {
-        source: "openclaw-memory",
-        agent: params.agentId,
-      },
+      return await postJsonWithRetry<OpenAiBatchStatus>({
+        url: `${baseUrl}/batches`,
+        headers: buildBatchHeaders(params.openAi, { json: true }),
+        ssrfPolicy: params.openAi.ssrfPolicy,
+        fetchImpl: params.openAi.fetchImpl,
+        body: {
+          input_file_id: inputFileId,
+          endpoint: OPENAI_BATCH_ENDPOINT,
+          completion_window: OPENAI_BATCH_COMPLETION_WINDOW,
+          metadata: {
+            source: "openclaw-memory",
+            agent: params.agentId,
+          },
+        },
+        errorPrefix: "openai batch create failed",
+      });
     },
-    errorPrefix: "openai batch create failed",
   });
 }
 
@@ -93,8 +100,8 @@ async function fetchOpenAiBatchStatus(params: {
   return await fetchOpenAiBatchResource({
     openAi: params.openAi,
     path: `/batches/${params.batchId}`,
-    errorPrefix: "openai batch status",
-    parse: async (res) => (await res.json()) as OpenAiBatchStatus,
+    label: "openai.batch-status",
+    parse: async (res) => readProviderJsonResponse<OpenAiBatchStatus>(res, "openai.batch-status"),
   });
 }
 
@@ -105,37 +112,62 @@ async function fetchOpenAiFileContent(params: {
   return await fetchOpenAiBatchResource({
     openAi: params.openAi,
     path: `/files/${params.fileId}/content`,
-    errorPrefix: "openai batch file content",
-    parse: async (res) => await res.text(),
+    label: "openai.batch-file-content",
+    parse: async (res) => await readProviderTextResponse(res, "openai.batch-file-content"),
+  });
+}
+
+async function readOpenAiBatchOutputFile(params: {
+  openAi: OpenAiEmbeddingClient;
+  fileId: string;
+  maxLines: number;
+  onLine: (line: OpenAiBatchOutputLine) => boolean;
+}): Promise<void> {
+  return await fetchOpenAiBatchResource({
+    openAi: params.openAi,
+    path: `/files/${params.fileId}/content`,
+    label: "openai.batch-file-content",
+    parse: async (res) =>
+      await readEmbeddingBatchJsonl<OpenAiBatchOutputLine>(res, {
+        label: "openai.batch-file-content",
+        maxRecords: params.maxLines,
+        onRecord: params.onLine,
+      }),
   });
 }
 
 async function fetchOpenAiBatchResource<T>(params: {
   openAi: OpenAiEmbeddingClient;
   path: string;
-  errorPrefix: string;
+  label: string;
   parse: (res: Response) => Promise<T>;
 }): Promise<T> {
-  const baseUrl = normalizeBatchBaseUrl(params.openAi);
-  return await withRemoteHttpResponse({
-    url: `${baseUrl}${params.path}`,
-    ssrfPolicy: params.openAi.ssrfPolicy,
-    fetchImpl: params.openAi.fetchImpl,
-    init: {
-      headers: buildBatchHeaders(params.openAi, { json: true }),
-    },
-    onResponse: async (res) => {
-      if (!res.ok) {
-        const text = await res.text();
-        throw new Error(`${params.errorPrefix} failed: ${res.status} ${text}`);
-      }
-      return await params.parse(res);
+  return await retryOpenAiEmbeddingTokenExpiredOnce({
+    client: params.openAi,
+    run: async () => {
+      const baseUrl = normalizeBatchBaseUrl(params.openAi);
+      return await withRemoteHttpResponse({
+        url: `${baseUrl}${params.path}`,
+        ssrfPolicy: params.openAi.ssrfPolicy,
+        fetchImpl: params.openAi.fetchImpl,
+        init: {
+          headers: buildBatchHeaders(params.openAi, { json: true }),
+        },
+        onResponse: async (res) => {
+          await assertOkOrThrowProviderError(res, params.label);
+          return await params.parse(res);
+        },
+      });
     },
   });
 }
 
 function formatOpenAiBatchError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function formatOpenAiBatchDiagnostic(error: unknown): string {
+  return formatBatchErrorDetail(formatOpenAiBatchError(error)) ?? "unknown error";
 }
 
 function isOpenAiBatchUploadTooLargeError(error: unknown): boolean {
@@ -153,17 +185,19 @@ function isOpenAiBatchUploadTooLargeError(error: unknown): boolean {
   );
 }
 
-export function parseOpenAiBatchOutput(text: string): OpenAiBatchOutputLine[] {
+function parseOpenAiBatchOutput(text: string): OpenAiBatchOutputLine[] {
   if (!text.trim()) {
     return [];
   }
-  return normalizeStringEntries(text.split("\n")).map((line) => {
-    try {
-      return JSON.parse(line) as OpenAiBatchOutputLine;
-    } catch {
-      throw new Error("OpenAI embedding batch output contained malformed JSONL");
-    }
-  });
+  return normalizeStringEntries(text.split("\n")).map(parseOpenAiBatchOutputLine);
+}
+
+function parseOpenAiBatchOutputLine(line: string): OpenAiBatchOutputLine {
+  try {
+    return JSON.parse(line) as OpenAiBatchOutputLine;
+  } catch {
+    throw new Error("OpenAI embedding batch output contained malformed JSONL");
+  }
 }
 
 async function readOpenAiBatchError(params: {
@@ -176,7 +210,7 @@ async function readOpenAiBatchError(params: {
       fileId: params.errorFileId,
     });
     const lines = parseOpenAiBatchOutput(content);
-    return extractBatchErrorMessage(lines);
+    return formatBatchErrorDetail(extractBatchErrorMessage(lines));
   } catch (err) {
     return formatUnavailableBatchError(err);
   }
@@ -209,14 +243,17 @@ function formatOpenAiBatchProgress(status: OpenAiBatchStatus): string {
   return `; progress ${completed}/${counts.total} failed=${failed}`;
 }
 
-function formatOpenAiBatchPollError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function isRetryableOpenAiBatchPollError(error: unknown): boolean {
-  const message = formatOpenAiBatchPollError(error);
+  const message = formatOpenAiBatchError(error);
+  const status =
+    error && typeof error === "object" ? (error as { status?: unknown }).status : undefined;
   return (
-    /openai batch status failed: (408|409|425|429|5\d\d)\b/i.test(message) ||
+    (typeof status === "number" &&
+      (status === 408 ||
+        status === 409 ||
+        status === 425 ||
+        status === 429 ||
+        (status >= 500 && status <= 599))) ||
     /\b(ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN)\b|fetch failed|network error/i.test(message)
   );
 }
@@ -253,9 +290,7 @@ async function waitForOpenAiBatch(params: {
       }
       const delayMs = pollBackoff.nextDelayMs();
       params.debug?.(
-        `openai batch ${params.batchId} status check failed: ${formatOpenAiBatchPollError(
-          error,
-        )}; waiting ${delayMs}ms`,
+        `openai batch ${params.batchId} status check failed: ${formatOpenAiBatchDiagnostic(error)}; waiting ${delayMs}ms`,
       );
       await new Promise((resolve) => {
         setTimeout(resolve, delayMs);
@@ -264,6 +299,15 @@ async function waitForOpenAiBatch(params: {
       continue;
     }
     const state = status.status ?? "unknown";
+    await throwIfBatchCompletionError({
+      provider: "openai",
+      status: { ...status, id: params.batchId },
+      readError: async (errorFileId) =>
+        await readOpenAiBatchError({
+          openAi: params.openAi,
+          errorFileId,
+        }),
+    });
     if (state === "completed") {
       return resolveBatchCompletionFromStatus({
         provider: "openai",
@@ -319,7 +363,7 @@ export async function runOpenAiEmbeddingBatches(
         requests: group.length,
         parts: parts.map((part) => part.length),
         depth,
-        error: formatOpenAiBatchError(error),
+        error: formatOpenAiBatchDiagnostic(error),
       });
     },
     runGroup: async ({ group, groupIndex, groups, byCustomId, pollIntervalMs, timeoutMs }) => {
@@ -341,6 +385,13 @@ export async function runOpenAiEmbeddingBatches(
         requests: group.length,
       });
 
+      await throwIfBatchCompletionError({
+        provider: "openai",
+        status: batchInfo,
+        readError: async (errorFileId) =>
+          await readOpenAiBatchError({ openAi: params.openAi, errorFileId }),
+      });
+
       const completed = await resolveCompletedBatchResult({
         provider: "openai",
         status: batchInfo,
@@ -357,20 +408,26 @@ export async function runOpenAiEmbeddingBatches(
           }),
       });
 
-      const content = await fetchOpenAiFileContent({
-        openAi: params.openAi,
-        fileId: completed.outputFileId,
-      });
-      const outputLines = parseOpenAiBatchOutput(content);
       const errors: string[] = [];
       const remaining = new Set(group.map((request) => request.custom_id));
 
-      for (const line of outputLines) {
-        applyEmbeddingBatchOutputLine({ line, remaining, errors, byCustomId });
-      }
+      await readOpenAiBatchOutputFile({
+        openAi: params.openAi,
+        fileId: completed.outputFileId,
+        maxLines: group.length,
+        onLine: (line) => {
+          // Only the first response for a submitted id may mutate results.
+          if (line.custom_id && remaining.has(line.custom_id)) {
+            applyEmbeddingBatchOutputLine({ line, remaining, errors, byCustomId });
+          }
+          return errors.length === 0 && remaining.size > 0;
+        },
+      });
 
       if (errors.length > 0) {
-        throw new Error(`openai batch ${batchInfo.id} failed: ${errors.join("; ")}`);
+        throw new Error(
+          `openai batch ${batchInfo.id} failed: ${formatBatchErrorDetail(errors[0]) ?? "unknown error"}`,
+        );
       }
       if (remaining.size > 0) {
         throw new Error(

--- a/extensions/openai/embedding-provider.ts
+++ b/extensions/openai/embedding-provider.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { OPENAI_DEFAULT_EMBEDDING_MODEL } from "./default-models.js";
+import { retryOpenAiEmbeddingTokenExpiredOnce } from "./embedding-auth-retry.js";
 
 export type OpenAiEmbeddingClient = {
   baseUrl: string;
@@ -18,6 +19,7 @@ export type OpenAiEmbeddingClient = {
   queryInputType?: string;
   documentInputType?: string;
   outputDimensionality?: number;
+  refreshClient?: (params?: { forceRefresh?: boolean }) => Promise<OpenAiEmbeddingClient>;
 };
 
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
@@ -36,11 +38,26 @@ function normalizeOpenAiModel(model: string): string {
   return trimmed.startsWith("openai/") ? trimmed.slice("openai/".length) : trimmed;
 }
 
+/** Whether the embedding base URL points to the native OpenAI API endpoint. */
+function isNativeOpenAiBaseUrl(baseUrl: string): boolean {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase().replace(/\.+$/, "") === "api.openai.com";
+  } catch {
+    return false;
+  }
+}
+
 export async function createOpenAiEmbeddingProvider(
   options: MemoryEmbeddingProviderCreateOptions,
 ): Promise<{ provider: MemoryEmbeddingProvider; client: OpenAiEmbeddingClient }> {
   const client = await resolveOpenAiEmbeddingClient(options);
-  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+  client.refreshClient = async (params) => {
+    const refreshed = await resolveOpenAiEmbeddingClient(options, {
+      forceRefresh: params?.forceRefresh,
+    });
+    Object.assign(client, refreshed);
+    return client;
+  };
 
   const resolveInputType = (kind: "query" | "document"): string | undefined => {
     const explicit = kind === "query" ? client.queryInputType : client.documentInputType;
@@ -57,21 +74,25 @@ export async function createOpenAiEmbeddingProvider(
       return [];
     }
     const inputType = resolveInputType(kind);
-    return await fetchRemoteEmbeddingVectors({
-      url,
-      headers: client.headers,
-      ssrfPolicy: client.ssrfPolicy,
-      fetchImpl: client.fetchImpl,
-      signal,
-      body: {
-        model: client.model,
-        input,
-        ...(typeof client.outputDimensionality === "number"
-          ? { dimensions: client.outputDimensionality }
-          : {}),
-        ...(inputType ? { input_type: inputType } : {}),
-      },
-      errorPrefix: "openai embeddings failed",
+    return await retryOpenAiEmbeddingTokenExpiredOnce({
+      client,
+      run: async () =>
+        await fetchRemoteEmbeddingVectors({
+          url: `${client.baseUrl.replace(/\/$/, "")}/embeddings`,
+          headers: client.headers,
+          ssrfPolicy: client.ssrfPolicy,
+          fetchImpl: client.fetchImpl,
+          signal,
+          body: {
+            model: client.model,
+            input,
+            ...(typeof client.outputDimensionality === "number"
+              ? { dimensions: client.outputDimensionality }
+              : {}),
+            ...(inputType ? { input_type: inputType } : {}),
+          },
+          errorPrefix: "openai embeddings failed",
+        }),
     });
   };
 
@@ -79,8 +100,8 @@ export async function createOpenAiEmbeddingProvider(
     provider: {
       id: "openai",
       model: client.model,
-      ...(typeof OPENAI_MAX_INPUT_TOKENS[client.model] === "number"
-        ? { maxInputTokens: OPENAI_MAX_INPUT_TOKENS[client.model] }
+      ...(typeof OPENAI_MAX_INPUT_TOKENS[normalizeOpenAiModel(client.model)] === "number"
+        ? { maxInputTokens: OPENAI_MAX_INPUT_TOKENS[normalizeOpenAiModel(client.model)] }
         : {}),
       embedQuery: async (text, optionsValue) => {
         const [vec] = await embed([text], "query", optionsValue?.signal);
@@ -95,13 +116,22 @@ export async function createOpenAiEmbeddingProvider(
 
 async function resolveOpenAiEmbeddingClient(
   options: MemoryEmbeddingProviderCreateOptions,
+  runtimeOptions?: { forceRefresh?: boolean },
 ): Promise<OpenAiEmbeddingClient> {
+  const originalModel = options.model;
   const client = await resolveRemoteEmbeddingClient({
     provider: options.provider ?? "openai",
     options,
     defaultBaseUrl: DEFAULT_OPENAI_BASE_URL,
     normalizeModel: normalizeOpenAiModel,
+    forceRefresh: runtimeOptions?.forceRefresh,
   });
+  // Non-native OpenAI routers (e.g. Requesty) expect the provider-qualified
+  // model name ("openai/text-embedding-3-small") in embedding requests.
+  // Strip the prefix only when talking to the native OpenAI API.
+  if (!isNativeOpenAiBaseUrl(client.baseUrl) && originalModel.startsWith("openai/")) {
+    client.model = `openai/${normalizeOpenAiModel(originalModel)}`;
+  }
   return {
     ...client,
     inputType: options.inputType,

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
@@ -1,10 +1,10 @@
 // Memory Host SDK module implements embeddings remote client behavior.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { EmbeddingProviderOptions } from "./embeddings.types.js";
 import { requireApiKey, resolveApiKeyForProvider } from "./openclaw-runtime-auth.js";
 import { buildRemoteBaseUrlPolicy } from "./remote-http.js";
 import { resolveMemorySecretInputString } from "./secret-input.js";
 import type { SsrFPolicy } from "./ssrf-policy.js";
-import { normalizeOptionalString } from "./string-utils.js";
 
 // Builds authenticated remote embedding HTTP clients from agent memory config.
 
@@ -38,11 +38,12 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;
   options: EmbeddingProviderOptions;
   defaultBaseUrl: string;
+  forceRefresh?: boolean;
 }): Promise<{ baseUrl: string; headers: Record<string, string>; ssrfPolicy?: SsrFPolicy }> {
   const remote = params.options.remote;
   const remoteApiKey = resolveMemorySecretInputString({
     value: remote?.apiKey,
-    path: "agents.*.memorySearch.remote.apiKey",
+    path: "memory.search.remote.apiKey",
   });
   const remoteBaseUrl = normalizeOptionalString(remote?.baseUrl);
   const providerConfig = params.options.config.models?.providers?.[params.provider];
@@ -53,6 +54,7 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
           provider: params.provider,
           cfg: params.options.config,
           agentDir: params.options.agentDir,
+          forceRefresh: params.forceRefresh,
         }),
         params.provider,
       );

--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
@@ -53,6 +53,7 @@ export async function fetchRemoteEmbeddingVectors(params: {
     signal: params.signal,
     body: params.body,
     errorPrefix: params.errorPrefix,
+    attachStatus: true,
     parse: (payload) => {
       const root = asRecord(payload);
       if (!root || !Array.isArray(root.data)) {

--- a/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
@@ -61,11 +61,13 @@ export async function resolveRemoteEmbeddingClient(params: {
   options: EmbeddingProviderOptions;
   defaultBaseUrl: string;
   normalizeModel: (model: string) => string;
+  forceRefresh?: boolean;
 }): Promise<RemoteEmbeddingClient> {
   const { baseUrl, headers, ssrfPolicy } = await resolveRemoteEmbeddingBearerClient({
     provider: params.provider,
     options: params.options,
     defaultBaseUrl: params.defaultBaseUrl,
+    forceRefresh: params.forceRefresh,
   });
   const model = params.normalizeModel(params.options.model);
   return { baseUrl, headers, ssrfPolicy, model };


### PR DESCRIPTION
Closes #116278

## Summary
When a long-lived runtime holds a stale OpenAI embedding client or bearer, the first `401 token_expired` can wedge memory embedding calls until the gateway/runtime is restarted.

This change adds a single recovery path for that specific case:
- catch only `401` with `token_expired`
- call `refreshClient({ forceRefresh: true })`
- rebuild auth/client state
- retry the request once

It covers both direct embedding requests and the batch/runtime embedding path used by memory sync/indexing.

This is intentionally narrow hardening for the stale-runtime-client case. It does not try to recover a dead refresh token; those failures should still surface the existing re-auth flow.

## Notes
This PR is code-only because the current fork token could not sync newer upstream workflow history (`workflow` scope would be needed for that path). I have the companion regression tests prepared separately and can follow up with them once the fork can be rebased cleanly onto current upstream history.

## Background
In the original incident, CLI `openclaw memory search` and `memory status --deep` stayed healthy while the long-lived embedded runtime path failed until gateway/runtime restart, which matches the stale in-memory client diagnosis.