### PR TITLE
fix(agents): ask the channel for its parent-relay stream mode

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -339,7 +339,6 @@ src/acp/control-plane/manager.turn-results.test.ts
 src/acp/event-ledger.ts
 src/acp/translator.ts
 src/agents/acp-spawn-parent-stream.test.ts
-src/agents/acp-spawn-parent-stream.ts
 src/agents/acp-spawn.test.ts
 src/agents/agent-bundle-mcp-runtime.test.ts
 src/agents/agent-bundle-mcp-runtime.ts

--- a/extensions/discord/src/shared.test.ts
+++ b/extensions/discord/src/shared.test.ts
@@ -7,6 +7,15 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
+describe("discord streaming adapter", () => {
+  it("declares the channel's progress default for core mode resolution", () => {
+    const plugin = createDiscordPluginBase({ setup: {} as never });
+    const resolve = plugin.streaming?.resolvePreviewStreamMode;
+    expect(resolve?.({})).toBe("progress");
+    expect(resolve?.({ streaming: { mode: "off" } })).toBe("off");
+  });
+});
+
 describe("createDiscordPluginBase", () => {
   it("owns Discord native command name overrides", () => {
     const plugin = createDiscordPluginBase({ setup: {} as never });

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -25,6 +25,7 @@ import {
 import { DiscordChannelConfigSchema } from "./config-schema.js";
 import { normalizeCompatibilityConfig } from "./doctor-contract.js";
 import { DISCORD_LEGACY_CONFIG_RULES } from "./doctor-shared.js";
+import { resolveDiscordPreviewStreamMode } from "./preview-streaming.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 import {
   collectRuntimeConfigAssignments,
@@ -142,6 +143,7 @@ export function createDiscordPluginBase(params: {
     doctor: discordDoctor,
     streaming: {
       blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
+      resolvePreviewStreamMode: resolveDiscordPreviewStreamMode,
     },
     reload: { configPrefixes: ["channels.discord"] },
     configSchema: DiscordChannelConfigSchema,

--- a/extensions/telegram/src/shared.test.ts
+++ b/extensions/telegram/src/shared.test.ts
@@ -28,6 +28,17 @@ function resolveAccount(cfg: OpenClawConfig, accountId: string): ResolvedTelegra
   return telegramPluginBase.config.resolveAccount(cfg, accountId);
 }
 
+describe("telegram streaming adapter", () => {
+  it("declares the channel's progress default for core mode resolution", () => {
+    // Core relays (ACP parent stream) ask the plugin for this instead of
+    // assuming the core "partial" default; a missing declaration silently
+    // downgrades those paths.
+    const resolve = telegramPluginBase.streaming?.resolvePreviewStreamMode;
+    expect(resolve?.({})).toBe("progress");
+    expect(resolve?.({ streaming: { mode: "off" } })).toBe("off");
+  });
+});
+
 describe("createTelegramPluginBase config duplicate token guard", () => {
   it("wires the top-level models menu adapter into the production plugin", () => {
     const channelData = telegramPluginBase.commands?.buildModelsMenuChannelData?.({

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -28,6 +28,7 @@ import {
 } from "./command-ui.js";
 import { TelegramChannelConfigSchema } from "./config-schema.js";
 import { telegramDoctor } from "./doctor.js";
+import { resolveTelegramPreviewStreamMode } from "./preview-streaming.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { telegramSecurityAdapter } from "./security.js";
 import { namedAccountPromotionKeys, singleAccountKeysToMove } from "./setup-contract.js";
@@ -186,6 +187,7 @@ export function createTelegramPluginBase(params: {
     },
     doctor: telegramDoctor,
     security: telegramSecurityAdapter,
+    streaming: { resolvePreviewStreamMode: resolveTelegramPreviewStreamMode },
     reload: { configPrefixes: ["channels.telegram"] },
     configSchema: TelegramChannelConfigSchema,
     config: {

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -7,6 +7,26 @@ const enqueueSystemEventMock = vi.fn();
 const requestHeartbeatMock = vi.fn();
 const recordAcpParentStreamEventsMock = vi.fn();
 
+// The relay asks the channel plugin for its preview-stream-mode rule. Discord
+// and Telegram default to "progress"; bundled plugins are not materialized in
+// this project, so declare the same rule the shipped channels declare.
+vi.mock("../channels/plugins/registry.js", async () => {
+  const { resolveChannelPreviewStreamMode } = await vi.importActual<
+    typeof import("../channels/streaming.js")
+  >("../channels/streaming.js");
+  return {
+    getChannelPlugin: (id: string) =>
+      id === "discord" || id === "telegram"
+        ? {
+            streaming: {
+              resolvePreviewStreamMode: (entry: { streaming?: unknown }) =>
+                resolveChannelPreviewStreamMode(entry, "progress"),
+            },
+          }
+        : undefined,
+  };
+});
+
 vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
 }));
@@ -668,6 +688,35 @@ describe("startAcpSpawnParentStreamRelay", () => {
       "codex: checking thread context; then post a tight progress reply here.",
     );
     relay.dispose();
+  });
+
+  it("uses each channel's own default mode for parent commentary", () => {
+    // The default used to be a hardcoded "discord" check, so every other
+    // progress-default channel silently relayed nothing.
+    for (const channel of ["discord", "telegram"]) {
+      const runId = `run-${channel}-unset-mode`;
+      const relay = startAcpSpawnParentStreamRelay({
+        runId,
+        parentSessionKey: "agent:main:main",
+        childSessionKey: `agent:codex:acp:child-${channel}-unset-mode`,
+        agentId: "codex",
+        cfg: { channels: { [channel]: {} } },
+        deliveryContext: { ...progressCommentaryDeliveryContext, channel },
+        streamFlushMs: 10,
+        noOutputNoticeMs: 120_000,
+        emitStartNotice: false,
+      });
+
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { delta: `relayed from ${channel}`, phase: "commentary" },
+      });
+      vi.advanceTimersByTime(15);
+
+      expectTextWithFragment(collectedTexts(), `codex: relayed from ${channel}`);
+      relay.dispose();
+    }
   });
 
   it("flushes visible commentary before final answer text", () => {

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -7,9 +7,12 @@ import {
   resolveAcpProjectionSettings,
   type AcpProjectionSettings,
 } from "../auto-reply/reply/acp-stream-settings.js";
+import { getChannelPlugin } from "../channels/plugins/registry.js";
 import {
+  resolveChannelPreviewStreamMode,
   resolveChannelStreamingProgressCommentary,
   type StreamingCompatEntry,
+  type StreamingMode,
 } from "../channels/streaming.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { onAgentEvent } from "../infra/agent-events.js";
@@ -120,35 +123,10 @@ function mergeStreamingEntry(
   };
 }
 
-function hasConfiguredPreviewStreamMode(entry: StreamingCompatEntry): boolean {
-  return asObjectRecord(entry.streaming)?.mode !== undefined;
-}
-
-function applyParentPreviewStreamModeDefault(
-  entry: StreamingCompatEntry,
-  channelId: string,
-): StreamingCompatEntry {
-  if (channelId !== "discord" || hasConfiguredPreviewStreamMode(entry)) {
-    return entry;
-  }
-  const streaming = asObjectRecord(entry.streaming);
-  return {
-    ...entry,
-    streaming: streaming
-      ? {
-          ...streaming,
-          mode: "progress",
-        }
-      : {
-          mode: "progress",
-        },
-  };
-}
-
-function resolveParentProgressStreamingEntry(params: {
+function resolveParentProgressStreaming(params: {
   cfg: OpenClawConfig | undefined;
   deliveryContext: DeliveryContext | undefined;
-}): StreamingCompatEntry | undefined {
+}): { entry: StreamingCompatEntry; mode: StreamingMode } | undefined {
   const channelId = normalizeOptionalString(params.deliveryContext?.channel);
   if (!params.cfg || !channelId) {
     return undefined;
@@ -165,20 +143,21 @@ function resolveParentProgressStreamingEntry(params: {
     normalizeAccountId(params.deliveryContext?.accountId),
     normalizeAccountId,
   );
-  return applyParentPreviewStreamModeDefault(
-    mergeStreamingEntry(channelCfg, accountCfg),
-    channelId,
-  );
+  const entry = mergeStreamingEntry(channelCfg, accountCfg);
+  // Channels own their default when `streaming.mode` is unset, so ask the
+  // channel rather than assuming one here: this relay runs outside channel
+  // dispatch, and a core-side guess silently disables progress relays for every
+  // channel whose default is not the one guessed.
+  const resolveMode = getChannelPlugin(channelId)?.streaming?.resolvePreviewStreamMode;
+  return { entry, mode: resolveMode?.(entry) ?? resolveChannelPreviewStreamMode(entry, "partial") };
 }
 
 function resolveParentProgressCommentary(params: {
   cfg: OpenClawConfig | undefined;
   deliveryContext: DeliveryContext | undefined;
 }): boolean {
-  return resolveChannelStreamingProgressCommentary(
-    resolveParentProgressStreamingEntry(params),
-    true,
-  );
+  const streaming = resolveParentProgressStreaming(params);
+  return resolveChannelStreamingProgressCommentary(streaming?.entry, true, streaming?.mode);
 }
 
 function shouldRelayAcpStatusProgress(params: {
@@ -764,4 +743,3 @@ export type AcpSpawnParentRelayHandle = {
   dispose: () => void;
   notifyStarted: () => void;
 };
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -18,6 +18,7 @@ import type { OutboundMediaAccess } from "../../media/load-options.js";
 import type { PollInput } from "../../polls.js";
 import type { ChatType } from "../chat-type.js";
 import type { InboundEventKind } from "../inbound-event/kind.js";
+import type { StreamingCompatEntry, StreamingMode } from "../streaming.js";
 import type { ChannelId } from "./channel-id.types.js";
 import type { ConversationReadInvocationOrigin } from "./conversation-read-origin.js";
 import type { ChannelMessageActionName as ChannelMessageActionNameFromList } from "./message-action-names.js";
@@ -325,6 +326,13 @@ export type ChannelStreamingAdapter = {
     minChars: number;
     idleMs: number;
   };
+  /**
+   * The channel's own rule for the effective preview stream mode. Channels pick
+   * their default when `streaming.mode` is unset, so core paths that resolve the
+   * mode outside channel dispatch (the ACP parent relay) must ask the channel
+   * instead of assuming the core "partial" default. Omit it to accept "partial".
+   */
+  resolvePreviewStreamMode?: (entry: StreamingCompatEntry) => StreamingMode;
 };
 
 // Keep core transport-agnostic. Plugins can carry richer component types on


### PR DESCRIPTION
## What Problem This Solves

An ACP sub-agent relays its commentary into the parent session. Whether that relay runs depends on the parent channel's effective preview stream mode — and the relay resolved that itself, with a hardcoded channel id:

```ts
if (channelId !== "discord" || hasConfiguredPreviewStreamMode(entry)) {
  return entry;
}
// ...stamp mode: "progress" into the config entry
```
`src/agents/acp-spawn-parent-stream.ts:127-133` before this change.

Telegram's default preview mode is now `progress` as well. On a Telegram parent session the entry carries no mode, so the resolver fell back to `partial`, and `resolveChannelStreamingProgressCommentary` returned `false`: the sub-agent's commentary was never relayed, with nothing in the session explaining why. Every future progress-default channel would have inherited the same silent no-op.

## Why This Change Was Made

The default belongs to the channel — Discord and Telegram already own that decision in `resolveDiscordPreviewStreamMode` / `resolveTelegramPreviewStreamMode` — so core should ask rather than guess. `ChannelStreamingAdapter` gains `resolvePreviewStreamMode`, alongside the `blockStreamingCoalesceDefaults` it already carries, and the relay reads it the same way block streaming reads that sibling field (`src/auto-reply/reply/block-streaming.ts:209`).

Discord and Telegram declare the helper each already had, so there is one rule per channel rather than a core copy that drifts. Channels that accept the core `partial` default declare nothing and are unaffected.

This also removes a core→plugin-identity dependency: no core file names a channel to decide channel behavior. Stamping a synthetic mode into a config entry to smuggle a resolved value is gone with it — the relay now passes the resolved mode as the argument the resolver already accepts.

## User Impact

Sub-agent commentary now reaches the parent session on Telegram, matching Discord. No config surface added, changed, or retired; `streaming.mode` and `streaming.progress.commentary` behave as documented, and an explicitly configured mode still wins on every channel.

Behavior is unchanged for Discord (same rule, now sourced from the channel) and for channels with no declared rule (still `partial`).

The relay resolves the mode through `getChannelPlugin`, which falls back to the bundled plugin for built-in channels; if no plugin resolves, it degrades to today's `partial` default rather than failing.

## Evidence

`src/agents/acp-spawn-parent-stream.test.ts`, 36 passing. New case asserts a parent relay on **both** `discord` and `telegram` with `channels.<id>: {}` — no configured mode — relays commentary; on `main` the Telegram half of that loop fails. Existing cases still pass unchanged: explicit `streaming.mode: "off"` on Discord suppresses the relay, account-level overrides keep their explicit off, and generic channels keep the partial default.

The test declares the same rule the shipped channels declare, resolved through the real `resolveChannelPreviewStreamMode`, so an explicit mode still wins in the stub exactly as in production.

Typecheck clean (`tsgo:core`, `tsgo:extensions`); oxlint clean; `check-import-cycles` reports 0 runtime cycles. Non-test source is net **−22 lines**, and dropping the stamping helper puts `acp-spawn-parent-stream.ts` under the max-lines limit, so its grandfathered suppression and baseline entry are retired (`check-max-lines-ratchet --prune`).

### Related

Surfaced while landing #116272, which fixed the same silent-no-op class on the direct channel path: the commentary gate guessing a mode instead of taking the caller's resolved one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)