### PR TITLE
fix(qqbot): honor Gateway timezone for recurring reminders

### DIFF
--- a/extensions/qqbot/src/engine/tools/remind-logic.test.ts
+++ b/extensions/qqbot/src/engine/tools/remind-logic.test.ts
@@ -59,6 +59,54 @@ describe("engine/tools/remind-logic", () => {
       });
     });
 
+    it.each([
+      {
+        name: "uses the Gateway timezone when omitted",
+        timezone: undefined,
+        expectedSchedule: { kind: "cron", expr: "0 9 * * *" },
+        expectedSummary: '⏰ Recurring reminder: "test reminder" (0 9 * * *, tz=gateway local)',
+      },
+      {
+        name: "preserves an explicit IANA timezone",
+        timezone: " America/New_York ",
+        expectedSchedule: {
+          kind: "cron",
+          expr: "0 9 * * *",
+          tz: "America/New_York",
+        },
+        expectedSummary: '⏰ Recurring reminder: "test reminder" (0 9 * * *, tz=America/New_York)',
+      },
+    ])("$name for recurring reminders", async ({ timezone, expectedSchedule, expectedSummary }) => {
+      const calls: RemindCronAction[] = [];
+      const result = await executeScheduledRemind(
+        {
+          action: "add",
+          content: "test reminder",
+          to: "qqbot:c2c:123",
+          time: "0 9 * * *",
+          ...(timezone ? { timezone } : {}),
+        },
+        {},
+        async (params) => {
+          calls.push(params);
+          return { id: "job-cron" };
+        },
+      );
+
+      const call = calls[0];
+      expect(call?.action).toBe("add");
+      if (call?.action !== "add") {
+        throw new Error("expected add cron action");
+      }
+      expect(call.job.schedule).toEqual(expectedSchedule);
+      expect(result.details).toEqual({
+        ok: true,
+        action: "add",
+        summary: expectedSummary,
+        cronResult: { id: "job-cron" },
+      });
+    });
+
     it("runs cron list and remove through the scheduler", async () => {
       const calls: unknown[] = [];
       await executeScheduledRemind({ action: "list" }, {}, async (params) => {

--- a/extensions/qqbot/src/engine/tools/remind-logic.ts
+++ b/extensions/qqbot/src/engine/tools/remind-logic.ts
@@ -27,8 +27,6 @@ export interface RemindParams {
   jobId?: string;
 }
 
-const QQBOT_DEFAULT_REMINDER_TIMEZONE = "Asia/Shanghai";
-
 /**
  * Context supplied by the bridge layer so the engine can remain free of
  * framework / AsyncLocalStorage dependencies. `fallbackTo` and
@@ -99,7 +97,7 @@ export const RemindSchema = {
     timezone: {
       type: "string",
       description:
-        "Optional IANA timezone used for cron reminders. Include it when the user provides or confirms a timezone; if omitted, QQBot preserves its existing default timezone.",
+        "Optional IANA timezone used for cron reminders. Include it when the user provides or confirms a timezone; if omitted, Gateway cron uses the host timezone.",
     },
     name: {
       type: "string",
@@ -226,12 +224,16 @@ function buildOnceJob(params: RemindParams, atMs: number, to: string, accountId:
 function buildCronJob(params: RemindParams, to: string, accountId: string) {
   const content = params.content!;
   const name = params.name || generateJobName(content);
-  const tz = params.timezone || QQBOT_DEFAULT_REMINDER_TIMEZONE;
+  const timezone = params.timezone?.trim();
   return {
     action: "add" as const,
     job: {
       name,
-      schedule: { kind: "cron" as const, expr: params.time!.trim(), tz },
+      schedule: {
+        kind: "cron" as const,
+        expr: params.time!.trim(),
+        ...(timezone ? { tz: timezone } : {}),
+      },
       sessionTarget: "isolated" as const,
       wakeMode: "now" as const,
       payload: {
@@ -309,11 +311,12 @@ function prepareRemindCronAction(
   const resolvedAccountId = ctx.fallbackAccountId || "default";
 
   if (isCronExpression(params.time)) {
+    const timezone = params.timezone?.trim();
     return {
       ok: true,
       action: "add",
       cronAction: buildCronJob(params, resolvedTo, resolvedAccountId),
-      summary: `⏰ Recurring reminder: "${params.content}" (${params.time}, tz=${params.timezone || QQBOT_DEFAULT_REMINDER_TIMEZONE})`,
+      summary: `⏰ Recurring reminder: "${params.content}" (${params.time}, tz=${timezone || "gateway local"})`,
     };
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QQBot recurring reminders without an explicit timezone always ran in `Asia/Shanghai`, regardless of the Gateway host timezone. This made the plugin disagree with core cron behavior and surprised operators outside that zone.

## Why This Change Was Made

QQBot now omits `schedule.tz` when the model does not supply a timezone, allowing the canonical Gateway cron scheduler to use its host timezone. Explicit IANA timezone values are trimmed and preserved.

The fixed fallback originated in the QQBot reminder implementation and was later named while #98032 tightened guardrails; that PR explicitly preserved the existing default rather than establishing a cross-product timezone contract.

## User Impact

Recurring QQBot reminders now follow the same rule as every other Gateway cron job: an explicit timezone wins, otherwise the Gateway host timezone applies. Existing reminders with an explicit timezone are unchanged.

Upgrade semantics are bounded: the previous QQBot implementation always persisted `tz: "Asia/Shanghai"` when creating a reminder without an explicit timezone. Those existing jobs retain that stored timezone and are not rewritten by this change. Only newly created QQBot reminders with an omitted timezone adopt Gateway-local behavior; manually created existing cron jobs that already omit `tz` already use Gateway-local behavior.

## Evidence

- Focused QQBot reminder tests: 2 files, 9 tests passed.
- Fresh changed-surface gate passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30523488490
- Fresh autoreview: clean, no accepted or actionable findings.
- Regression coverage proves:
  - omitted timezone produces a cron schedule without `tz` and reports `gateway local`;
  - whitespace-padded `America/New_York` is trimmed and preserved.
- Core contract checked in `src/cron/schedule.ts`: omitted `tz` resolves through the Gateway process timezone.
- Croner 10.0.1 contract checked directly: timezone is optional and accepts IANA identifiers.

## Alternatives Considered

- Keep `Asia/Shanghai`: rejected because it is a plugin-specific global default with no operator signal.
- Default to UTC: rejected because it would still diverge from documented Gateway cron behavior.
- Add a QQBot-specific config key: rejected because the existing explicit `timezone` field and canonical Gateway default already cover both needs.

AI-assisted implementation; the runtime path, history, core scheduler, and dependency contract were manually inspected.
