### PR TITLE
fix: Ask OpenClaw reports no API key when the provider uses a file SecretRef

### DIFF
--- a/src/system-agent/applied-snapshot-config.ts
+++ b/src/system-agent/applied-snapshot-config.ts
@@ -1,0 +1,36 @@
+import {
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+type AppliedConfigSnapshot = {
+  config: OpenClawConfig;
+  sourceConfig: OpenClawConfig;
+  runtimeConfig?: OpenClawConfig;
+};
+
+/**
+ * A freshly read snapshot leaves non-env SecretRefs unresolved, so system-agent
+ * surfaces that re-read config would lose credentials the active runtime already
+ * resolved. Reuse the live runtime config while the file still matches the applied
+ * source; once they diverge the fresh materialization is the correct answer, and
+ * callers that compare against it keep failing closed on real drift.
+ */
+export function resolveAppliedSnapshotConfig(snapshot: AppliedConfigSnapshot): OpenClawConfig {
+  const runtimeConfig = getRuntimeConfigSnapshot();
+  const runtimeSourceConfig = getRuntimeConfigSourceSnapshot();
+  if (
+    runtimeConfig &&
+    runtimeSourceConfig &&
+    selectApplicableRuntimeConfig({
+      inputConfig: snapshot.sourceConfig,
+      runtimeConfig,
+      runtimeSourceConfig,
+    }) === runtimeConfig
+  ) {
+    return runtimeConfig;
+  }
+  return snapshot.runtimeConfig ?? snapshot.config;
+}

--- a/src/system-agent/inference-fallback.ts
+++ b/src/system-agent/inference-fallback.ts
@@ -6,6 +6,7 @@ import { hasAvailableAuthForProvider } from "../agents/model-auth.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import {
   resolveSystemAgentConfiguredRouteFromConfig,
   type SystemAgentConfiguredRoute,
@@ -46,7 +47,7 @@ async function readCurrentConfig(): Promise<OpenClawConfig> {
   if (!snapshot.exists || !snapshot.valid) {
     return {};
   }
-  return snapshot.runtimeConfig ?? snapshot.config;
+  return resolveAppliedSnapshotConfig(snapshot);
 }
 
 /** Requester first. Other configured, authenticated providers: provider-id order. */

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -418,7 +418,10 @@ async function verifyCurrentSetupInference(
       "The default-agent inference route changed during setup verification, so setup was not applied. Review the current config and retry.",
     );
   }
-  const afterConfig = after.runtimeConfig ?? after.config;
+  // Same selection as beforeConfig: a fresh disk read still carries unresolved
+  // file SecretRefs, so comparing it raw against the pre-probe applied config
+  // would report an untouched provider key as route drift and block setup.
+  const afterConfig = resolveAppliedSnapshotConfig(after);
   const afterRoute = await projectDefaultInferenceRoute(afterConfig);
   if (
     !sameDefaultInferenceRoute(beforeRoute, afterRoute) ||
@@ -694,7 +697,11 @@ export async function isPluginBackingDefaultInferenceRoute(pluginId: string): Pr
   if (!snapshot.exists || !snapshot.valid) {
     return true;
   }
-  const config = snapshot.runtimeConfig ?? snapshot.config;
+  // Same applied-snapshot selection as the setup probe: this guard decides
+  // whether a plugin-uninstall or config write may proceed, so a fresh disk
+  // read with an unresolved file SecretRef must not misclassify the active
+  // default-route plugin.
+  const config = resolveAppliedSnapshotConfig(snapshot);
   const route = (await projectDefaultInferenceRoute(config ?? {})).route;
   if (!route) {
     return false;

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -124,7 +124,7 @@ export async function resolveChannelSetupState(deps: SystemAgentCommandDeps | un
     (await import("../config/channel-configured-shared.js")).isStaticallyChannelConfigured;
   const { shouldShowChannelInSetup } = await import("../commands/channel-setup/discovery.js");
   const snapshot = await readConfigFileSnapshotLazy();
-  const cfg = snapshot.valid ? (snapshot.runtimeConfig ?? snapshot.config) : {};
+  const cfg = snapshot.valid ? resolveAppliedSnapshotConfig(snapshot) : {};
   const installedPlugins = listPlugins();
   const resolved = resolveEntries({ cfg, installedPlugins });
   return {

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -7,6 +7,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
+import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import { appendSystemAgentAuditEntry } from "./audit.js";
 import {
   SYSTEM_AGENT_CONFIG_WRITE_DENYLIST,
@@ -394,7 +395,7 @@ async function verifyCurrentSetupInference(
       "OpenClaw setup requires a valid configured inference route. Run `openclaw onboard` on the machine running OpenClaw, then retry.",
     );
   }
-  const beforeConfig = before.runtimeConfig ?? before.config;
+  const beforeConfig = resolveAppliedSnapshotConfig(before);
   const beforeRoute = await projectDefaultInferenceRoute(beforeConfig);
   if (!beforeRoute.route) {
     throw new Error(

--- a/src/system-agent/setup-apply.ts
+++ b/src/system-agent/setup-apply.ts
@@ -22,6 +22,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { GatewayServiceSetupOutcome } from "../wizard/setup.finalize.js";
+import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import {
   projectDefaultInferenceRoute,
   type DefaultInferenceRouteProjection,
@@ -248,9 +249,7 @@ export async function applySystemAgentSetup(
       verifiedSnapshot.path === setupSnapshot.path &&
       verifiedSnapshot.hash === setupSnapshot.hash &&
       isDeepStrictEqual(verifiedSource, setupSource)
-        ? await projectDefaultInferenceRoute(
-            verifiedSnapshot.runtimeConfig ?? verifiedSnapshot.config,
-          )
+        ? await projectDefaultInferenceRoute(resolveAppliedSnapshotConfig(verifiedSnapshot))
         : null;
     if (
       !currentRoute ||

--- a/src/system-agent/setup-inference-activate-persist.ts
+++ b/src/system-agent/setup-inference-activate-persist.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { normalizePluginTargetConfig } from "../plugins/config-state.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
+import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import {
   projectInferenceRoute,
   resolveSystemAgentConfiguredRouteFromConfig,
@@ -232,7 +233,7 @@ export async function persistActivatedSetupInference(input: {
       // The install-record owner adds a restart follow-up when this commit adopts
       // a new plugin source. Preserve that intent for structured setup clients.
       transform: async (current, context) => {
-        const latestRuntime = context.snapshot.runtimeConfig ?? context.snapshot.config;
+        const latestRuntime = resolveAppliedSnapshotConfig(context.snapshot);
         // Validate that the candidate is still admissible before reporting
         // broader route drift, so policy revocations retain their actionable error.
         const stagedRuntime = stageCandidate(latestRuntime, "runtime");
@@ -335,7 +336,7 @@ export async function persistActivatedSetupInference(input: {
     const reconciledSnapshot = await readSnapshot().catch(() => null);
     const reconciledRuntime =
       reconciledSnapshot?.exists && reconciledSnapshot.valid
-        ? (reconciledSnapshot.runtimeConfig ?? reconciledSnapshot.config)
+        ? resolveAppliedSnapshotConfig(reconciledSnapshot)
         : undefined;
     const reconciledRoute = reconciledRuntime ? await projectRoute(reconciledRuntime) : undefined;
     const codexInstallPersisted = pendingCodexInstall

--- a/src/system-agent/setup-inference-activate.ts
+++ b/src/system-agent/setup-inference-activate.ts
@@ -20,7 +20,6 @@ import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapsh
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import { getActivePluginRegistryWorkspaceDirFromState } from "../plugins/runtime-state.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
-import { resolveUserPath } from "../utils.js";
 import { createPluginCapabilityConsentPrompter } from "../wizard/plugin-capability-consent.js";
 import { WizardCancelledError, WizardNavigationError } from "../wizard/prompts.js";
 import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
@@ -45,7 +44,7 @@ import {
   SetupInferenceOwnerDriftError,
   invalidSetupConfigError,
   redactSetupInferenceError,
-  resolveSetupInferenceWorkspace,
+  resolveActivationWorkspace,
   setupInferenceLog,
   throwIfSetupInferenceCancelled,
 } from "./setup-inference-core.js";
@@ -147,14 +146,11 @@ async function activateSetupInferenceUnredacted(
   // while the writer still projects changes back onto the untouched authored bytes.
   const sourceCfg: OpenClawConfig = snapshot.sourceConfig ?? snapshot.config;
   const routeAgentId = resolveAmbientOwnerAgentId(cfg, params.agentId);
-  const workspace = params.workspace?.trim()
-    ? resolveUserPath(params.workspace)
-    : (
-        await resolveSetupInferenceWorkspace({
-          configExists: snapshot.exists,
-          configValid: snapshot.valid,
-        })
-      ).workspace;
+  const workspace = await resolveActivationWorkspace({
+    ...(params.workspace ? { requested: params.workspace } : {}),
+    configExists: snapshot.exists,
+    configValid: snapshot.valid,
+  });
 
   const tempDir = await (
     deps.createTempDir ?? (() => fs.mkdtemp(path.join(os.tmpdir(), "openclaw-setup-inference-")))

--- a/src/system-agent/setup-inference-activate.ts
+++ b/src/system-agent/setup-inference-activate.ts
@@ -23,6 +23,7 @@ import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-reque
 import { resolveUserPath } from "../utils.js";
 import { createPluginCapabilityConsentPrompter } from "../wizard/plugin-capability-consent.js";
 import { WizardCancelledError, WizardNavigationError } from "../wizard/prompts.js";
+import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import { appendSystemAgentAuditEntry } from "./audit.js";
 import {
   projectInferenceRoute,
@@ -138,7 +139,10 @@ async function activateSetupInferenceUnredacted(
   }
   // Missing-file snapshots still carry the load-time implicit-main roster.
   // Setup must probe against that runtime view without treating it as authored config.
-  const cfg: OpenClawConfig = snapshot.runtimeConfig ?? snapshot.config;
+  // A fresh re-read otherwise leaves a file SecretRef unresolved while the live
+  // runtime already resolved it; reuse the applied snapshot while the source still
+  // matches, and only fall through to the raw read once it has genuinely diverged.
+  const cfg: OpenClawConfig = resolveAppliedSnapshotConfig(snapshot);
   // The source snapshot includes raw compatibility migrations for comparison,
   // while the writer still projects changes back onto the untouched authored bytes.
   const sourceCfg: OpenClawConfig = snapshot.sourceConfig ?? snapshot.config;
@@ -556,9 +560,12 @@ async function activateSetupInferenceUnredacted(
     let gatewayRestartRequired = false;
     if (!needsPersistence) {
       const latestSnapshot = await readSnapshot();
+      // Same reuse as the initial read above: an unchanged file SecretRef must not
+      // read as drift just because this re-read is raw and the applied snapshot
+      // already resolved it.
       const latestRuntime =
         latestSnapshot.exists && latestSnapshot.valid
-          ? (latestSnapshot.runtimeConfig ?? latestSnapshot.config)
+          ? resolveAppliedSnapshotConfig(latestSnapshot)
           : undefined;
       const latestRoute = latestRuntime
         ? await projectInferenceRoute(latestRuntime, requestedAgentId, routeDeps)

--- a/src/system-agent/setup-inference-core.ts
+++ b/src/system-agent/setup-inference-core.ts
@@ -369,3 +369,19 @@ export async function resolveSetupInferenceWorkspace(params: {
     hasAuthoredSetup,
   };
 }
+
+/** Explicit workspace wins; otherwise fall back to the authored/default workspace. */
+export async function resolveActivationWorkspace(params: {
+  requested?: string;
+  configExists: boolean;
+  configValid: boolean;
+}): Promise<string> {
+  if (params.requested?.trim()) {
+    return resolveUserPath(params.requested);
+  }
+  const { workspace } = await resolveSetupInferenceWorkspace({
+    configExists: params.configExists,
+    configValid: params.configValid,
+  });
+  return workspace;
+}

--- a/src/system-agent/setup-inference-detect.ts
+++ b/src/system-agent/setup-inference-detect.ts
@@ -14,6 +14,7 @@ import {
 } from "../plugins/provider-auth-choices.js";
 import { resolvePluginProvidersCore } from "../plugins/providers.runtime.js";
 import { listRecommendedToolInstalls } from "../plugins/recommended-tool-installs.js";
+import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import { probeLocalCommand } from "./probes.js";
 import {
   listSetupInferenceAuthOptions,
@@ -79,7 +80,7 @@ export async function listManualSetupInferenceOptions(
   if (snapshot.exists && !snapshot.valid) {
     throw new Error(invalidSetupConfigError(snapshot));
   }
-  const cfg = snapshot.runtimeConfig ?? snapshot.config;
+  const cfg = resolveAppliedSnapshotConfig(snapshot);
   const targetAgentId = resolveAmbientOwnerAgentId(cfg, agentId);
   const { workspace } = await resolveSetupInferenceWorkspace({
     configExists: snapshot.exists,
@@ -115,7 +116,7 @@ export async function detectSetupInference(
   if (snapshot.exists && !snapshot.valid) {
     throw new Error(invalidSetupConfigError(snapshot));
   }
-  const cfg = snapshot.runtimeConfig ?? snapshot.config;
+  const cfg = resolveAppliedSnapshotConfig(snapshot);
   const targetAgentId = resolveAmbientOwnerAgentId(cfg, agentId);
   const detected = await (deps.detectInferenceBackends ?? detectInferenceBackends)({
     config: cfg,

--- a/src/system-agent/setup-inference-persist.ts
+++ b/src/system-agent/setup-inference-persist.ts
@@ -24,6 +24,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import {
   type ActivateSetupInferenceDeps,
   SETUP_INFERENCE_TEST_PROMPT,
@@ -181,7 +182,7 @@ export async function reloadCodexRegistryAfterActivation(params: {
   }
   const runtimeConfig =
     snapshot.exists && snapshot.valid
-      ? (snapshot.runtimeConfig ?? snapshot.config)
+      ? resolveAppliedSnapshotConfig(snapshot)
       : ({} satisfies OpenClawConfig);
   const sourceConfig =
     snapshot.exists && snapshot.valid

--- a/src/system-agent/setup-inference-verify.secret-ref.test.ts
+++ b/src/system-agent/setup-inference-verify.secret-ref.test.ts
@@ -1,0 +1,134 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { resolveApiKeyForProvider } from "../agents/model-auth-provider.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import {
+  resetConfigRuntimeState,
+  setAppliedRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
+import { projectInferenceRoute } from "./inference-route.js";
+import { verifySetupInference } from "./setup-inference-verify.js";
+
+const PROVIDER = "volcengine-plan";
+const MODEL = "ark-code-latest";
+const RESOLVED_KEY = "ark-live-key-abc123";
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  resetConfigRuntimeState();
+  for (const cleanup of cleanups.splice(0)) {
+    cleanup();
+  }
+});
+
+/** Config file with a file-backed SecretRef provider key, as the reporter had. */
+function writeSecretRefConfig(): { root: string } {
+  const root = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "setup-inference-secretref-")),
+  );
+  const secretsFile = path.join(root, "openclaw-secrets.json");
+  fs.writeFileSync(secretsFile, JSON.stringify({ volcano_engine_api_key: RESOLVED_KEY }), {
+    mode: 0o600,
+  });
+  fs.writeFileSync(
+    path.join(root, "openclaw.json"),
+    JSON.stringify({
+      models: {
+        providers: {
+          [PROVIDER]: {
+            baseUrl: "https://ark.cn-beijing.volces.com/api/coding/v3",
+            api: "openai-completions",
+            apiKey: { source: "file", provider: "local_file", id: "/volcano_engine_api_key" },
+            models: [{ id: MODEL, name: MODEL }],
+          },
+        },
+      },
+      agents: { defaults: { model: { primary: `${PROVIDER}/${MODEL}` } } },
+      secrets: { providers: { local_file: { source: "file", path: secretsFile, mode: "json" } } },
+    }),
+  );
+
+  const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  process.env.OPENCLAW_CONFIG_PATH = path.join(root, "openclaw.json");
+  cleanups.push(() => {
+    if (previousConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  return { root };
+}
+
+/** Publish the applied runtime state: resolved credential in the runtime config,
+ *  untouched SecretRef in the source config, as the Gateway does at startup. */
+async function publishAppliedRuntimeConfig(): Promise<OpenClawConfig> {
+  const startup = await readConfigFileSnapshot();
+  const runtimeConfig = structuredClone(startup.runtimeConfig ?? startup.config) as OpenClawConfig;
+  const providerEntry = runtimeConfig.models?.providers?.[PROVIDER] as { apiKey?: unknown };
+  providerEntry.apiKey = RESOLVED_KEY;
+  setAppliedRuntimeConfigSnapshot(runtimeConfig, startup.sourceConfig);
+  return runtimeConfig;
+}
+
+test("the setup-inference probe keeps a SecretRef provider key the Gateway resolved", async () => {
+  const { root } = writeSecretRefConfig();
+  await publishAppliedRuntimeConfig();
+
+  // Stub only model execution; resolve the credential exactly as the runner does.
+  let probedKey: string | undefined;
+  const runEmbeddedAgent = async (params: {
+    config: OpenClawConfig;
+    provider: string;
+    agentDir?: string;
+  }) => {
+    const auth = await resolveApiKeyForProvider({
+      provider: params.provider,
+      cfg: params.config,
+      ...(params.agentDir ? { agentDir: params.agentDir } : {}),
+      modelApi: "openai-completions",
+    });
+    probedKey = auth.apiKey;
+    return {
+      meta: {
+        finalAssistantVisibleText: "OK",
+        executionTrace: { winnerProvider: PROVIDER, winnerModel: MODEL },
+      },
+    };
+  };
+
+  const runtime: RuntimeEnv = { log: () => {}, error: () => {}, exit: () => {} };
+  const result = await verifySetupInference({
+    runtime,
+    deps: {
+      runEmbeddedAgent: runEmbeddedAgent as never,
+      createTempDir: async () => fs.mkdtempSync(path.join(root, "probe-")),
+    },
+  });
+
+  expect(result).toMatchObject({ ok: true, modelRef: `${PROVIDER}/${MODEL}` });
+  expect(probedKey).toBe(RESOLVED_KEY);
+});
+
+test("the applied-config selection projects an identical inference route", async () => {
+  writeSecretRefConfig();
+  const runtimeConfig = await publishAppliedRuntimeConfig();
+
+  // A verified binding is fingerprinted from the applied config, then revalidated
+  // against a fresh read in verified-inference.ts. Those projections carry the
+  // provider entry verbatim, so an unresolved SecretRef on one side alone would
+  // reject every later system-agent session as stale-route.
+  const appliedProjection = await projectInferenceRoute(runtimeConfig);
+  const revalidationProjection = await projectInferenceRoute(
+    resolveAppliedSnapshotConfig(await readConfigFileSnapshot()),
+  );
+
+  expect(revalidationProjection).toEqual(appliedProjection);
+});

--- a/src/system-agent/setup-inference-verify.secret-ref.test.ts
+++ b/src/system-agent/setup-inference-verify.secret-ref.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import { projectInferenceRoute } from "./inference-route.js";
 import { executeSystemAgentOperation } from "./operations.js";
@@ -25,6 +26,10 @@ const cleanups: Array<() => void> = [];
 
 afterEach(() => {
   resetConfigRuntimeState();
+  // Persistent-setup cases reach the audit writer, which caches an open handle
+  // on the shared SQLite state DB under the fixture root; close it before the
+  // cleanups delete that root so rmSync cannot fail with EBUSY on Windows.
+  closeOpenClawStateDatabaseForTest();
   for (const cleanup of cleanups.splice(0)) {
     cleanup();
   }

--- a/src/system-agent/setup-inference-verify.secret-ref.test.ts
+++ b/src/system-agent/setup-inference-verify.secret-ref.test.ts
@@ -13,6 +13,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import { projectInferenceRoute } from "./inference-route.js";
 import { executeSystemAgentOperation } from "./operations.js";
+import { activateSetupInference } from "./setup-inference-activate.js";
 import { verifySetupInference } from "./setup-inference-verify.js";
 import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
 
@@ -125,6 +126,51 @@ test("the setup-inference probe keeps a SecretRef provider key the Gateway resol
   });
 
   expect(result).toMatchObject({ ok: true, modelRef: `${PROVIDER}/${MODEL}` });
+  expect(probedKey).toBe(RESOLVED_KEY);
+});
+
+test("existing-model activation keeps a SecretRef provider key the Gateway resolved", async () => {
+  // Before this fix, activateSetupInferenceUnredacted's initial cfg read the raw file
+  // snapshot (`snapshot.runtimeConfig ?? snapshot.config`) instead of the applied one,
+  // so a file SecretRef stayed unresolved during existing-model activation even though
+  // the same probe already worked through verifySetupInference above.
+  const { root } = writeSecretRefConfig();
+  await publishAppliedRuntimeConfig();
+
+  let probedKey: string | undefined;
+  const runEmbeddedAgent = async (params: {
+    config: OpenClawConfig;
+    provider: string;
+    agentDir?: string;
+  }) => {
+    const auth = await resolveApiKeyForProviderCore({
+      provider: params.provider,
+      cfg: params.config,
+      ...(params.agentDir ? { agentDir: params.agentDir } : {}),
+      modelApi: "openai-completions",
+    });
+    probedKey = auth.apiKey;
+    return {
+      meta: {
+        finalAssistantVisibleText: "OK",
+        executionTrace: { winnerProvider: PROVIDER, winnerModel: MODEL },
+      },
+    };
+  };
+
+  const runtime: RuntimeEnv = { log: () => {}, error: () => {}, exit: () => {} };
+  await activateSetupInference({
+    kind: "existing-model",
+    surface: "cli",
+    runtime,
+    deps: {
+      runEmbeddedAgent: runEmbeddedAgent as never,
+      createTempDir: async () => fs.mkdtempSync(path.join(root, "activate-")),
+    },
+  });
+
+  // The credential resolution happens before owner attestation, so it is provable
+  // regardless of whether this bare stub run goes on to report a full owner binding.
   expect(probedKey).toBe(RESOLVED_KEY);
 });
 

--- a/src/system-agent/setup-inference-verify.secret-ref.test.ts
+++ b/src/system-agent/setup-inference-verify.secret-ref.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, expect, test } from "vitest";
-import { resolveApiKeyForProvider } from "../agents/model-auth-provider.js";
+import { afterEach, expect, test, vi } from "vitest";
+import { resolveApiKeyForProviderCore } from "../agents/model-auth.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import {
   resetConfigRuntimeState,
@@ -12,7 +12,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import { projectInferenceRoute } from "./inference-route.js";
+import { executeSystemAgentOperation } from "./operations.js";
 import { verifySetupInference } from "./setup-inference-verify.js";
+import { createSystemAgentTestRuntime } from "./system-agent.runtime.test-support.js";
 
 const PROVIDER = "volcengine-plan";
 const MODEL = "ark-code-latest";
@@ -55,12 +57,21 @@ function writeSecretRefConfig(): { root: string } {
   );
 
   const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
   process.env.OPENCLAW_CONFIG_PATH = path.join(root, "openclaw.json");
+  // Persistent-setup tests reach the audit writer, which opens a SQLite store
+  // under the shared state dir; isolate it so tests never touch real state.
+  process.env.OPENCLAW_STATE_DIR = path.join(root, "state");
   cleanups.push(() => {
     if (previousConfigPath === undefined) {
       delete process.env.OPENCLAW_CONFIG_PATH;
     } else {
       process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+    }
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
     }
     fs.rmSync(root, { recursive: true, force: true });
   });
@@ -89,7 +100,7 @@ test("the setup-inference probe keeps a SecretRef provider key the Gateway resol
     provider: string;
     agentDir?: string;
   }) => {
-    const auth = await resolveApiKeyForProvider({
+    const auth = await resolveApiKeyForProviderCore({
       provider: params.provider,
       cfg: params.config,
       ...(params.agentDir ? { agentDir: params.agentDir } : {}),
@@ -131,4 +142,70 @@ test("the applied-config selection projects an identical inference route", async
   );
 
   expect(revalidationProjection).toEqual(appliedProjection);
+});
+
+test("persistent setup succeeds when the post-probe re-read keeps an unchanged file SecretRef", async () => {
+  const { root } = writeSecretRefConfig();
+  await publishAppliedRuntimeConfig();
+  const { runtime } = createSystemAgentTestRuntime();
+  const modelRef = `${PROVIDER}/${MODEL}`;
+  const applySetup = vi.fn(async () => ({
+    configPath: path.join(root, "openclaw.json"),
+    configHashBefore: "before",
+    configHashAfter: "after",
+    bootstrapPending: false,
+    workspaceReady: true,
+    gateway: { status: "ready" as const, action: "reused" as const },
+    lines: [],
+  }));
+
+  // Before this fix, verifyCurrentSetupInference's post-probe comparison read
+  // the config file raw instead of through resolveAppliedSnapshotConfig, so an
+  // untouched file SecretRef looked like route drift and setup was refused.
+  const result = await executeSystemAgentOperation(
+    { kind: "setup", workspace: path.join(root, "work") },
+    runtime,
+    {
+      approved: true,
+      deps: {
+        applySetup,
+        loadOverview: async () => ({ defaultModel: modelRef }) as never,
+        verifyInferenceConfig: async () => ({ ok: true as const, modelRef, latencyMs: 5 }),
+      },
+    },
+  );
+
+  expect(result.applied).toBe(true);
+  expect(applySetup).toHaveBeenCalledOnce();
+});
+
+test("persistent setup still fails closed when the route genuinely changes mid-verification", async () => {
+  const { root } = writeSecretRefConfig();
+  await publishAppliedRuntimeConfig();
+  const { runtime } = createSystemAgentTestRuntime();
+  const modelRef = `${PROVIDER}/${MODEL}`;
+  const configPath = path.join(root, "openclaw.json");
+  const applySetup = vi.fn();
+
+  await expect(
+    executeSystemAgentOperation({ kind: "setup", workspace: path.join(root, "work") }, runtime, {
+      approved: true,
+      deps: {
+        applySetup,
+        loadOverview: async () => ({ defaultModel: modelRef }) as never,
+        verifyInferenceConfig: async () => {
+          // A real concurrent edit during the probe: rotate the auth profile
+          // order for the active provider. The applied-snapshot selector must
+          // not mask this as "still resolved"; the disk source no longer
+          // matches the source captured when the runtime snapshot was applied.
+          const current = JSON.parse(fs.readFileSync(configPath, "utf8"));
+          current.auth = { order: { [PROVIDER]: ["rotated-profile"] } };
+          fs.writeFileSync(configPath, JSON.stringify(current));
+          return { ok: true as const, modelRef, latencyMs: 5 };
+        },
+      },
+    }),
+  ).rejects.toThrow("changed during setup verification");
+
+  expect(applySetup).not.toHaveBeenCalled();
 });

--- a/src/system-agent/setup-inference-verify.ts
+++ b/src/system-agent/setup-inference-verify.ts
@@ -10,6 +10,7 @@ import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import {
   projectInferenceRoute,
   resolveSystemAgentConfiguredRouteFromConfig,
@@ -82,7 +83,7 @@ export async function verifySetupInference(
       error: invalidSetupConfigError(snapshot),
     };
   }
-  const cfg: OpenClawConfig = snapshot.runtimeConfig ?? snapshot.config;
+  const cfg: OpenClawConfig = resolveAppliedSnapshotConfig(snapshot);
   const baselineRoute = await projectInferenceRoute(cfg, params.agentId);
   let verifiedBinding: SystemAgentVerifiedInferenceBinding | undefined;
   const verification = await verifySetupInferenceConfig({
@@ -107,9 +108,11 @@ export async function verifySetupInference(
     return verification;
   }
   const latestSnapshot = await readSnapshot().catch(() => null);
+  // Same selection as the baseline: comparing a resolved runtime config against a
+  // freshly materialized one would report unresolved SecretRefs as route drift.
   const latestConfig =
     latestSnapshot?.exists && latestSnapshot.valid
-      ? (latestSnapshot.runtimeConfig ?? latestSnapshot.config)
+      ? resolveAppliedSnapshotConfig(latestSnapshot)
       : undefined;
   const latestRoute = latestConfig
     ? await projectInferenceRoute(latestConfig, params.agentId)
@@ -480,7 +483,7 @@ export async function completeSetupInference(params: {
     return { ok: false, status: "format", error: invalidSetupConfigError(snapshot) };
   }
   return await completeSetupInferenceConfig({
-    config: snapshot.runtimeConfig ?? snapshot.config,
+    config: resolveAppliedSnapshotConfig(snapshot),
     prompt: params.prompt,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     runtime: params.runtime,

--- a/src/system-agent/verified-inference.ts
+++ b/src/system-agent/verified-inference.ts
@@ -39,6 +39,7 @@ import {
   resolveOwningPluginIdsForModelRefs,
   resolveOwningPluginIdsForProviderRef,
 } from "../plugins/providers.js";
+import { resolveAppliedSnapshotConfig } from "./applied-snapshot-config.js";
 import {
   projectInferenceRoute,
   resolveSystemAgentConfiguredRouteFromConfig,
@@ -834,7 +835,7 @@ export async function hasCurrentSystemAgentOwnerPluginArtifacts(
   if (!snapshot.exists || !snapshot.valid) {
     return false;
   }
-  const config = snapshot.runtimeConfig ?? snapshot.config;
+  const config = resolveAppliedSnapshotConfig(snapshot);
   try {
     const ownerPluginIds = resolveRouteOwnerPluginIds(config, binding.execution);
     if (!isDeepStrictEqual(ownerPluginIds, binding.ownerPluginIds)) {
@@ -870,7 +871,7 @@ async function resolveSystemAgentVerifiedInferenceStateInternal(
   if (!snapshot.exists || !snapshot.valid) {
     return null;
   }
-  const config = snapshot.runtimeConfig ?? snapshot.config;
+  const config = resolveAppliedSnapshotConfig(snapshot);
   const currentRoute = await resolveSystemAgentConfiguredRouteFromConfig(
     config,
     binding.execution.agentId,

--- a/test/gateway-system-agent-secretref-chat.e2e.test.ts
+++ b/test/gateway-system-agent-secretref-chat.e2e.test.ts
@@ -1,0 +1,260 @@
+import { realpathSync } from "node:fs";
+import fs from "node:fs/promises";
+// E2E: bound `openclaw.chat` sessions work when the provider key is a file SecretRef.
+//
+// Regression proof for #115062: the system-agent inference verifier re-read the
+// config file directly, which leaves non-env SecretRefs unresolved, so a provider
+// configured with a file SecretRef reported "No API key found" on the bound
+// `openclaw.chat` session path even though the running gateway had the resolved
+// credential. Only the external provider is mocked (loopback HTTP); the gateway
+// is a real spawned process and the chat travels the real WS method dispatch.
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+
+const TEST_TIMEOUT_MS = 180_000;
+const PROVIDER = "secretref-proof";
+const MODEL_ID = "secretref-proof-model";
+const DRIFT_MODEL_ID = "secretref-proof-drifted";
+const SECRET_VALUE = "secretref-e2e-file-key-1187";
+const SESSION_ID = "secretref-bound-chat-session";
+
+type ProviderHit = { method: string; pathname: string; authorization: string | undefined };
+
+type MockProviderServer = {
+  baseUrl: string;
+  hits: ProviderHit[];
+  close: () => Promise<void>;
+};
+
+const instances: OpenClawTestInstance[] = [];
+const providerServers: MockProviderServer[] = [];
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(instances.splice(0).map((instance) => instance.cleanup()));
+  await Promise.allSettled(providerServers.splice(0).map((server) => server.close()));
+  await Promise.allSettled(
+    tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("gateway system-agent chat with a file SecretRef provider key", () => {
+  it(
+    "binds, revalidates, and fails closed on config drift without leaking provider I/O",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      // macOS os.tmpdir() is a /var -> /private/var symlink; resolve before any
+      // path reaches config so file-provider ownership checks see canonical paths.
+      const secretsDir = realpathSync(
+        await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-secretref-e2e-")),
+      );
+      tempDirs.push(secretsDir);
+      const secretsFile = path.join(secretsDir, "secrets.json");
+      await fs.writeFile(secretsFile, JSON.stringify({ mock_api_key: SECRET_VALUE }), {
+        mode: 0o600,
+      });
+
+      const provider = await startMockProviderServer();
+      providerServers.push(provider);
+      const instance = await createOpenClawTestInstance({
+        name: "gateway-secretref-chat",
+        config: createTestConfig(provider.baseUrl, secretsFile, MODEL_ID),
+        env: {
+          // The instance helper defaults both on; this test needs real provider
+          // dispatch so the mocked completions endpoint receives the credential.
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
+      });
+      instances.push(instance);
+      await instance.startGateway();
+
+      const client = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+        role: "operator",
+        scopes: ["operator.admin", "operator.read", "operator.write"],
+      });
+      try {
+        // Bound session creation: verifySystemAgentInferenceWithFallback must see
+        // the resolved SecretRef, and the resolved value must reach the provider.
+        const create = await chatTurn(client, "hello from the secretref e2e test");
+        expect(create.sessionId).toBe(SESSION_ID);
+        expect(typeof create.reply).toBe("string");
+        expect(create.reply.length).toBeGreaterThan(0);
+        const createHits = provider.hits.splice(0);
+        expect(createHits.length).toBeGreaterThan(0);
+        for (const hit of createHits) {
+          expect(hit.authorization).toBe(`Bearer ${SECRET_VALUE}`);
+        }
+
+        // Second turn on the same sessionId: bound-route revalidation must keep
+        // resolving the SecretRef rather than re-reading raw config.
+        const second = await chatTurn(client, "still with me?");
+        expect(second.sessionId).toBe(SESSION_ID);
+        const secondHits = provider.hits.splice(0);
+        expect(secondHits.length).toBeGreaterThan(0);
+        for (const hit of secondHits) {
+          expect(hit.authorization).toBe(`Bearer ${SECRET_VALUE}`);
+        }
+
+        // In-place config drift without a restart: the same bound session must be
+        // refused, and the refusal must precede any provider I/O.
+        await fs.writeFile(
+          instance.configPath,
+          JSON.stringify(
+            mergePersistedConfig(
+              JSON.parse(await fs.readFile(instance.configPath, "utf8")) as Record<string, unknown>,
+              createTestConfig(provider.baseUrl, secretsFile, DRIFT_MODEL_ID),
+            ),
+            null,
+            2,
+          ),
+        );
+        await expect(chatTurn(client, "after drift")).rejects.toMatchObject({
+          code: "UNAVAILABLE",
+          details: { code: "system_agent_session_invalidated" },
+        });
+        expect(provider.hits).toHaveLength(0);
+      } finally {
+        await disconnectGatewayClient(client);
+      }
+    },
+  );
+});
+
+async function chatTurn(
+  client: Awaited<ReturnType<typeof connectGatewayClient>>,
+  message: string,
+): Promise<{ sessionId: string; reply: string }> {
+  return await client.request<{ sessionId: string; reply: string }>(
+    "openclaw.chat",
+    { sessionId: SESSION_ID, message },
+    { timeoutMs: 120_000 },
+  );
+}
+
+function createTestConfig(
+  baseUrl: string,
+  secretsFile: string,
+  modelId: string,
+): Record<string, unknown> {
+  return {
+    plugins: { slots: { memory: "none" } },
+    agents: {
+      defaults: {
+        heartbeat: { every: "0m" },
+        model: { primary: `${PROVIDER}/${modelId}` },
+        skipBootstrap: true,
+        skills: [],
+      },
+    },
+    tools: { profile: "minimal" },
+    models: {
+      mode: "replace",
+      providers: {
+        [PROVIDER]: {
+          baseUrl: `${baseUrl}/v1`,
+          api: "openai-completions",
+          apiKey: { source: "file", provider: "local_file", id: "/mock_api_key" },
+          request: { allowPrivateNetwork: true },
+          models: [
+            {
+              id: modelId,
+              name: modelId,
+              api: "openai-completions",
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128_000,
+              maxTokens: 4_096,
+            },
+          ],
+        },
+      },
+    },
+    secrets: {
+      providers: { local_file: { source: "file", path: secretsFile, mode: "json" } },
+    },
+  };
+}
+
+/** Keep helper-owned sections (gateway auth/port, hooks) while swapping the drifted model config. */
+function mergePersistedConfig(
+  persisted: Record<string, unknown>,
+  next: Record<string, unknown>,
+): Record<string, unknown> {
+  return { ...persisted, ...next };
+}
+
+async function startMockProviderServer(): Promise<MockProviderServer> {
+  const hits: ProviderHit[] = [];
+  const server = createServer((request, response) => {
+    void handleProviderRequest(request, response, hits).catch((error: unknown) => {
+      response.writeHead(500, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: { message: String(error) } }));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("secretref mock provider server did not bind");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    hits,
+    close: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}
+
+async function handleProviderRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  hits: ProviderHit[],
+): Promise<void> {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  // Drain the body; only the route and Authorization header matter here.
+  await new Promise<void>((resolve) => {
+    request.on("data", () => {});
+    request.on("end", resolve);
+  });
+  hits.push({
+    method: request.method ?? "",
+    pathname: url.pathname,
+    authorization: request.headers.authorization,
+  });
+  if (request.method === "GET" && url.pathname === "/v1/models") {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ object: "list", data: [{ id: MODEL_ID, object: "model" }] }));
+    return;
+  }
+  if (request.method !== "POST" || url.pathname !== "/v1/chat/completions") {
+    response.writeHead(404).end();
+    return;
+  }
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(
+    JSON.stringify({
+      id: "chatcmpl-secretref-e2e",
+      object: "chat.completion",
+      created: Math.floor(Date.now() / 1000),
+      model: MODEL_ID,
+      choices: [{ index: 0, message: { role: "assistant", content: "OK" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+  );
+}


### PR DESCRIPTION
Closes #115062

## What Problem This Solves

Fixes an issue where users whose model provider key is a file `SecretRef` could not start the Ask OpenClaw system assistant in the Control UI. The setup check failed with `No API key found for provider "<id>"`, even though `openclaw secrets audit` reported the ref as clean and normal agent sessions reached the same provider and model successfully.

Because the error told users to sign in again or re-run `openclaw configure`, it pushed people toward reconfiguring credentials that were in fact valid.

## Why This Change Was Made

The Gateway resolves non-env `SecretRef` values once at startup into its runtime config snapshot. `resolveManagedSecretRefRuntimeProviderAuth` will only hand back that resolved credential when the caller's provider entry matches the applied snapshot — a deliberate check, so a config the Gateway cannot prove is the applied one never receives a resolved secret.

Several system-agent surfaces re-read the config file from disk before acting. A fresh read leaves `SecretRef` values unresolved, so its provider entry can never match, and the credential is refused. Normal agent runs are unaffected because they pass the Gateway's live runtime config.

This adds one shared selector, `resolveAppliedSnapshotConfig`, which returns the live runtime config while the file on disk is still exactly what the Gateway applied, and the freshly materialized config once they diverge. It routes the decision through the existing `selectApplicableRuntimeConfig` seam, matching how `server-methods/send.ts`, `cron/isolated-agent/run-config.ts`, `agents/tool-runtime-config.ts` and `web-search/runtime.ts` already resolve the same question. Credential resolution rules are untouched.

It is applied at every system-agent surface that re-reads config and then depends on provider credentials:

- `verifySetupInference` and `completeSetupInference` — the probe itself.
- The probe's post-run drift check, so an unresolved `SecretRef` is not misread as route drift.
- `resolveSystemAgentVerifiedInferenceRoute` and `hasCurrentSystemAgentOwnerPluginArtifacts` — without these the probe would succeed and the session that follows would still fail. A verified binding is fingerprinted from the config that was probed, and `projectInferenceRoute` embeds the whole provider entry, `apiKey` included. Leaving revalidation on a fresh read would reject every later system-agent turn, replacing a clear credential error with a vaguer stale-route one.
- `verifyCurrentSetupInference`, which gates the `openclaw.setup` persistent operation, and the `inference-fallback` ladder, which otherwise filters `SecretRef`-keyed providers out of the candidate list.

Config-injected entry points such as `verifySetupInferenceConfig` are deliberately unchanged: staged onboarding candidates must be probed exactly as given.

## User Impact

Users who manage a provider key with a file, keychain, or other non-env `SecretRef` can now open the Ask OpenClaw system assistant and run system-agent setup operations, instead of being blocked by a false "no API key" failure. No config change or credential re-entry is needed.

Behavior is unchanged for everyone else. When no runtime config is published (plain CLI runs), or when the config file has changed since it was applied, every one of these surfaces still uses the freshly read config exactly as before, so real config drift is still detected and still fails closed.

## Evidence

### Real behavior proof — running Gateway

A real Gateway was started against an isolated state dir with a real config file whose provider `apiKey` is a file `SecretRef` (dummy value, never a real credential), with the provider `baseUrl` pointed at a local stub endpoint so the probe can complete a turn. The same `openclaw.setup.verify` Gateway method the Control UI uses was then called over the wire.

**Before — unmodified `origin/main` (production files reverted, rebuilt):**

```
$ openclaw gateway call openclaw.setup.verify
Gateway call: openclaw.setup.verify
{
  "ok": false,
  "status": "auth",
  "error": "No API key found for provider \"volcengine-plan\". Auth store: <state>/agents/main/agent/openclaw-agent.sqlite (agentDir: <state>/agents/main/agent). Configure auth for this agent (openclaw agents add <id>) or copy only portable static auth profiles from the main agentDir."
}

# stub provider request log: (empty — the provider was never reached)
```

That is the reported failure, reproduced verbatim through a real Gateway. The empty request log confirms the failure happens at credential resolution, before any network call.

**After — this branch, same Gateway, same config:**

```
$ openclaw gateway call openclaw.setup.verify
Gateway call: openclaw.setup.verify
{
  "ok": true,
  "latencyMs": 5724,
  "modelRef": "volcengine-plan/ark-code-latest"
}

# stub provider request log:
POST /v1/chat/completions auth=Bearer <redacted-last-12>
```

The resolved `SecretRef` value reached the provider call.

**Fail-closed — this branch, config file changed to a ref the Gateway never resolved, without restarting:**

```
$ openclaw gateway call openclaw.setup.verify
Gateway call: openclaw.setup.verify
{
  "ok": false,
  "status": "unknown",
  "error": "Secret owner provider:volcengine-plan is configured but unavailable (secret reference was not found)."
}

# stub provider request log: (empty — the previously resolved credential was not reused)
```

Once the on-disk config no longer matches what the Gateway applied, the probe refuses and emits a typed, redacted diagnostic instead of falling back to the credential it had already resolved. No provider request is made.

### Regression test

The test drives the real `verifySetupInference` entry point against a real config file holding a file `SecretRef`, and stubs only model execution. The credential is resolved by the production `resolveApiKeyForProvider`.

Red, on unmodified `main` (reverting only the production files):

```
 FAIL  |unit| src/system-agent/setup-inference-verify.secret-ref.test.ts > the setup-inference probe keeps a SecretRef provider key the Gateway resolved
AssertionError: expected { ok: false, status: 'auth', …(1) } to match object { ok: true, …(1) }

- Expected
+ Received

  {
-   "modelRef": "volcengine-plan/ark-code-latest",
-   "ok": true,
+   "ok": false,
  }
```

Green, with the fix:

```
node scripts/run-vitest.mjs src/system-agent/setup-inference-verify.secret-ref.test.ts

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

### No regressions

Every suite covering the changed functions — 374 tests in 14 files:

```
node scripts/run-vitest.mjs \
  src/system-agent/setup-inference-verify.secret-ref.test.ts \
  src/system-agent/setup-inference.test.ts src/system-agent/setup-apply.test.ts \
  src/system-agent/verified-inference.test.ts src/system-agent/inference-fallback.test.ts \
  src/system-agent/operations-setup-flows.test.ts src/system-agent/operations.setup-transaction.test.ts \
  src/system-agent/operations.setup.test.ts src/system-agent/operations.test.ts \
  src/gateway/server-methods/system-agent.test.ts \
  src/gateway/server-methods/system-agent-session-ownership.test.ts \
  src/gateway/server-methods/system-agent-greeting-welcome.test.ts \
  src/wizard/setup.test.ts src/wizard/setup.inference-verification.test.ts

 Tests  282 passed  [unit, 2 shards]
 Tests   43 passed  [gateway]
 Tests   49 passed  [wizard]
```

`tsgo` core and test-src lanes both pass with no diagnostics, `oxlint` is clean on all touched files, `git diff --check` is clean, and a full `pnpm build` succeeds.

### Honest limits

- The Gateway proof drives `openclaw.setup.verify`, which is the unbound probe — the exact call whose failure the report quotes. The bound (`bindSession: true`) session path that `openclaw.chat` uses was not driven end-to-end; its revalidation call sites are covered by the reasoning above and by a test asserting that both config lineages project an identical inference route. Constructing a truthful verified binding in a unit test needs `resolveCurrentAuthFingerprint`, which is private and re-derives the fingerprint from the live credential, so mocking it would mock the thing under test. Worth a maintainer's eye.
- The provider endpoint is a local stub, and the `SecretRef` holds a dummy value. No real credential or live provider was involved; the defect and the fix both sit before the network boundary.
- The unrelated CI failure on this head is `src/agents/subagent-registry.announce-loop-guard.test.ts` (`entry.cleanupCompletedAt` undefined). That file was last touched by #116286 and fails identically on a clean checkout of current `main` with this branch's changes reverted. This PR touches only `src/system-agent/**` and has no import path to it.

## Risk

- Security/auth: no change to credential resolution rules. `resolveManagedSecretRefRuntimeProviderAuth` and `providerConfigMatchesRuntimeSnapshot` are untouched. The change only selects which already-applied config object these surfaces use, and only when the on-disk source is identical to the Gateway's applied source. No touched path is owned by `@openclaw/openclaw-secops` in `.github/CODEOWNERS`.
- Considered and rejected: relaxing `providerConfigMatchesRuntimeSnapshot` so an unresolved entry matches a resolved one. That check feeds four credential decisions, and ignoring `apiKey` would let a config carrying a *different* `SecretRef` receive the Gateway's resolved credential — credential substitution across secret owners.
- Highest-risk area: adopting a runtime config that no longer matches disk. Mitigated by requiring both a runtime and a source snapshot and routing the match through `selectApplicableRuntimeConfig`; the fail-closed capture above demonstrates the divergent case refusing rather than reusing a resolved credential.

## AI assistance

- [x] AI-assisted implementation and investigation.


---

### Update — bound `openclaw.chat` proof, now a committed test

The last review was precise about the gap: the earlier capture proved the *unbound* verifier, not the bound `openclaw.chat` session path users actually invoke. That path is now proven, and the proof is a tracked test rather than a transcript — an earlier harness lived in a git-excluded directory, so neither a reviewer nor CI could verify it.

**`test/gateway-system-agent-secretref-chat.e2e.test.ts`** (new, test-only). One real gateway on an isolated `OPENCLAW_STATE_DIR` and a free port — never 18789, `~/.openclaw` untouched — driving the real `openclaw.chat` method. Only mocked boundary: a loopback OpenAI-compatible HTTP server. The provider key is a genuine file SecretRef (`secrets.providers.*`, `source: "file"`, `mode: "json"`). Three behaviors in one flow:

1. **Bound session creation succeeds** and the `Authorization` header reaching the provider equals the file-SecretRef value.
2. **Second turn on the same `sessionId` revalidates** and still succeeds — the bound-route revalidation the review specifically asked for.
3. **After in-place config drift with no restart**, the same `sessionId` is refused with `system_agent_session_invalidated` and **zero** new provider requests — the refusal precedes provider I/O.

**An important correction to how BEFORE must be reproduced.** Reverting only the changed line in `inference-fallback.ts` does **not** reproduce this bug — I tried it first and BEFORE came out byte-identical to AFTER. `verifySystemAgentInferenceWithFallback` uses `readCurrentConfig` merely to *enumerate* routes; the "No API key" failure is produced downstream in `verifySetupInference`, which re-reads the snapshot itself at `src/system-agent/setup-inference-verify.ts:86` — a site this PR also changes. So BEFORE means the full production change reverted to `origin/main`. Flagging it so a reviewer trying the one-liner doesn't conclude the bug isn't real.

With the full revert, the committed test fails with the issue's exact symptom:

```
× binds, revalidates, and fails closed on config drift without leaking provider I/O
  GatewayClientRequestError: OpenClaw requires working inference:
    No API key found for provider "secretref-proof". ...
```

and the mock log stays empty across every phase — no provider I/O ever happens. On this head it passes, with the key on the wire and the drift call refused in 6 ms with no `model-fetch` between the hot-reload line and the refusal.

**Gate.** New e2e test passed · `src/system-agent/` 798 passed across 42 files · oxfmt clean · oxlint exit 0 · `pnpm tsgo:core` exit 0 · max-lines ratchet OK · `git diff --check` clean.

Production is unchanged by this update — the addition is test-only, and all `resolveAppliedSnapshotConfig` call sites plus `applied-snapshot-config.ts` are intact.

🤖 AI-assisted (Claude Code): investigation, fix, and proof prepared with an AI agent; a human reviews and owns the result.
