### PR TITLE
fix(ci): support legacy Telegram release candidates

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -2556,6 +2556,7 @@ jobs:
         if: always() && steps.terminate_sut.outputs.quiescent == 'true' && steps.run_lane.outputs.output_dir != ''
         env:
           BOUNDARY_EVIDENCE_DIR: ${{ steps.create_sut.outputs.boundary_evidence_dir }}
+          CANDIDATE_ROOT: ${{ steps.create_sut.outputs.candidate_root }}
           OUTPUT_DIR: ${{ steps.run_lane.outputs.output_dir }}
           RUN_LANE_OUTCOME: ${{ steps.run_lane.outcome }}
         shell: bash
@@ -2568,17 +2569,6 @@ jobs:
           shopt -s nullglob
           retain_lease_paths=("${BOUNDARY_EVIDENCE_DIR}"/retain-credential-lease-*.json)
           ((${#retain_lease_paths[@]} == 0))
-          runtime_parts=("${BOUNDARY_EVIDENCE_DIR}"/runtime-boundary-*.json)
-          ((${#runtime_parts[@]} > 0))
-          jq -s \
-            '{
-              version: 1,
-              kind: "qa-gateway-process-boundary",
-              launches: [.[].launches[]]
-            }' \
-            "${runtime_parts[@]}" >"${runtime_path}.tmp"
-          chmod 0600 "${runtime_path}.tmp"
-          mv "${runtime_path}.tmp" "$runtime_path"
 
           jq -e \
             --arg runId "$GITHUB_RUN_ID" \
@@ -2600,6 +2590,31 @@ jobs:
               (.candidateArtifact.sourceSha | test("^[a-f0-9]{40}$")) and
               (.candidateArtifact.version | length > 0)
             ' "$context_path" >/dev/null
+
+          candidate_telegram_cli="${CANDIDATE_ROOT}/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts"
+          candidate_boundary_controller="${CANDIDATE_ROOT}/extensions/qa-lab/src/gateway-process-boundary.ts"
+          if [[ ! -f "$candidate_boundary_controller" ]] ||
+            ! grep -Fq "resolveTelegramQaSutOpenClawCommand" "$candidate_telegram_cli"; then
+            # Frozen candidates before the boundary protocol have no runtime evidence to emit.
+            jq --arg executionMode "legacy-runner" \
+              '. + {executionMode: $executionMode}' "$context_path" >"$aggregate_path"
+            chmod 0600 "$aggregate_path"
+            echo "aggregate_path=$aggregate_path" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          runtime_parts=("${BOUNDARY_EVIDENCE_DIR}"/runtime-boundary-*.json)
+          ((${#runtime_parts[@]} > 0))
+          jq -s \
+            '{
+              version: 1,
+              kind: "qa-gateway-process-boundary",
+              launches: [.[].launches[]]
+            }' \
+            "${runtime_parts[@]}" >"${runtime_path}.tmp"
+          chmod 0600 "${runtime_path}.tmp"
+          mv "${runtime_path}.tmp" "$runtime_path"
+
           jq -e \
             --arg runLaneOutcome "$RUN_LANE_OUTCOME" \
             '

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -2591,11 +2591,10 @@ jobs:
               (.candidateArtifact.version | length > 0)
             ' "$context_path" >/dev/null
 
-          candidate_telegram_cli="${CANDIDATE_ROOT}/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts"
-          candidate_boundary_controller="${CANDIDATE_ROOT}/extensions/qa-lab/src/gateway-process-boundary.ts"
-          if [[ ! -f "$candidate_boundary_controller" ]] ||
-            ! grep -Fq "resolveTelegramQaSutOpenClawCommand" "$candidate_telegram_cli"; then
-            # Frozen candidates before the boundary protocol have no runtime evidence to emit.
+          # This frozen extended-stable candidate predates the boundary protocol.
+          # Every other target fails closed until it emits the required evidence.
+          legacy_process_boundary_target_sha="2dbfe013e511d0c7e0720356f5af5c7bb210db19"
+          if [[ "$TARGET_SHA" == "$legacy_process_boundary_target_sha" ]]; then
             jq --arg executionMode "legacy-runner" \
               '. + {executionMode: $executionMode}' "$context_path" >"$aggregate_path"
             chmod 0600 "$aggregate_path"


### PR DESCRIPTION
## What Problem This Solves

The frozen `2026.6.34` Code SHA predates Telegram gateway process-boundary evidence. It completed all Telegram scenarios, then failed only because the newer trusted workflow unconditionally required `runtime-boundary-*.json` files it cannot emit.

## Why This Change Was Made

The finalizer grants one explicit compatibility exception for the immutable `2026.6.34` Code SHA (`2dbfe013e511d0c7e0720356f5af5c7bb210db19`). That target publishes trusted context with `executionMode: legacy-runner`. Every other candidate remains fail-closed and must provide process-boundary evidence; no mutable source probe decides the security contract.

## User Impact

This unblocks the named extended-stable release without weakening checks for any other candidate. No product behavior changes.

## Evidence

- [Full Release Validation #30523612498](https://github.com/openclaw/openclaw/actions/runs/30523612498): all 12 Telegram scenarios passed; finalization alone failed because the frozen candidate emitted no `runtime-boundary-*.json` files.
- The exception SHA is the frozen `2026.6.34` Code SHA and is not a descendant of the process-boundary introduction commit `2a1d6e49d5bd835090e3ec9ac991698f76a2e509`.
- `git diff --check`, YAML parsing, and fresh autoreview pass.
- Hosted CI covers actionlint and workflow checks.

AI-assisted.