### PR TITLE
fix(ci): restore subagent announce-loop guard coverage

### DIFF
--- a/src/agents/subagent-registry.announce-loop-guard.test.ts
+++ b/src/agents/subagent-registry.announce-loop-guard.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   runSubagentAnnounceFlow: vi.fn().mockResolvedValue(false),
   captureSubagentCompletionReply: vi.fn(),
   loadSubagentRegistryFromSqlite: vi.fn(() => new Map()),
+  saveSubagentRegistryChangesToSqlite: vi.fn(),
   saveSubagentRegistryToSqlite: vi.fn(),
   resolveAgentTimeoutMs: vi.fn(() => 60_000),
   scheduleOrphanRecovery: vi.fn(),
@@ -68,6 +69,7 @@ vi.mock("../infra/agent-events.js", () => ({
 
 vi.mock("./subagent-registry.store.sqlite.js", () => ({
   loadSubagentRegistryFromSqlite: mocks.loadSubagentRegistryFromSqlite,
+  saveSubagentRegistryChangesToSqlite: mocks.saveSubagentRegistryChangesToSqlite,
   saveSubagentRegistryToSqlite: mocks.saveSubagentRegistryToSqlite,
 }));
 
@@ -131,6 +133,7 @@ describe("announce loop guard (#18264)", () => {
     mocks.runSubagentAnnounceFlow.mockReset();
     mocks.runSubagentAnnounceFlow.mockResolvedValue(false);
     mocks.scheduleOrphanRecovery.mockClear();
+    mocks.saveSubagentRegistryChangesToSqlite.mockClear();
     mocks.saveSubagentRegistryToSqlite.mockClear();
     mocks.updateSessionStore.mockClear();
     registry.resetSubagentRegistryForTests({ persist: false });
@@ -221,6 +224,9 @@ describe("announce loop guard (#18264)", () => {
 
     expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
     expect(entry.cleanupCompletedAt).toBeGreaterThanOrEqual(beforeInit);
+    expect(mocks.saveSubagentRegistryChangesToSqlite).toHaveBeenCalledWith(expect.any(Map), [
+      entry.runId,
+    ]);
   });
 
   test("expired completion-message entries are still resumed for announce", async () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/116286

## What Problem This Solves

Resolves a CI failure where the subagent announce-loop guard tests stopped reaching their cleanup assertions after the registry persistence path added exact-row SQLite writes.

## Why This Change Was Made

The test's SQLite module mock did not expose the new incremental-write helper, so strict persistence threw inside the mocked cleanup path and rolled the test entry back. The mock now implements that dependency and asserts the affected run ID is persisted.

## User Impact

No runtime behavior changes. CI again exercises the restart give-up path instead of failing in an incomplete test double.

## Evidence

- Before: `subagent-registry.announce-loop-guard.test.ts` failed 2 of 5 tests with `cleanupCompletedAt` unset.
- After: 1 file, 5 tests passed.
- `oxfmt --check` and `git diff --check` passed.
- Codex autoreview: no actionable findings; patch correct at 0.98 confidence.
