### PR TITLE
fix(ui): retarget persisted session to default agent when owner is deleted

### DIFF
--- a/ui/src/app/agent-selection.test.ts
+++ b/ui/src/app/agent-selection.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "vitest";
-import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { GatewayBrowserClient, GatewayHelloOk } from "../api/gateway.ts";
 import type { AgentsListResult } from "../api/types.ts";
 import { createAgentSelectionCapability, selectApplicationSession } from "./agent-selection.ts";
 
-function createGateway(assistantAgentId: string | null = "Main") {
-  let snapshot = { client: null as GatewayBrowserClient | null, assistantAgentId };
+function createGateway(assistantAgentId: string | null = "Main", sessionKey = "agent:main:main") {
+  let snapshot = {
+    client: null as GatewayBrowserClient | null,
+    assistantAgentId,
+    sessionKey,
+    hello: null as GatewayHelloOk | null,
+  };
   const listeners = new Set<(next: typeof snapshot) => void>();
+  const setSessionKeyCalls: string[] = [];
   return {
     gateway: {
       get snapshot() {
@@ -15,12 +21,19 @@ function createGateway(assistantAgentId: string | null = "Main") {
         listeners.add(listener);
         return () => listeners.delete(listener);
       },
+      setSessionKey(sessionKey: string) {
+        setSessionKeyCalls.push(sessionKey);
+        snapshot = { ...snapshot, sessionKey };
+      },
     },
-    publish(next: typeof snapshot) {
-      snapshot = next;
+    publish(next: Partial<typeof snapshot>) {
+      snapshot = { ...snapshot, ...next } as typeof snapshot;
       for (const listener of listeners) {
         listener(snapshot);
       }
+    },
+    get setSessionKeyCalls() {
+      return setSessionKeyCalls;
     },
   };
 }
@@ -329,6 +342,57 @@ describe("agent selection", () => {
     });
 
     expect(selection.state).toEqual({ selectedId: "roboclaw", scopeId: "roboclaw" });
+  });
+
+  it("retargets the gateway session to the default agent when the persisted owner is deleted", () => {
+    const harness = createGateway("Main", "agent:expert-ms5rlf07:main");
+    const roster = createRoster();
+    const selection = createAgentSelectionCapability(harness.gateway, roster.roster);
+
+    roster.publish({
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [{ id: "main", kind: "agent" }],
+    });
+
+    expect(selection.state).toEqual({ selectedId: "main", scopeId: "main" });
+    expect(harness.setSessionKeyCalls).toEqual(["agent:main:main"]);
+  });
+
+  it("retargets the deleted session owner using the configured main key", () => {
+    const harness = createGateway("Main", "agent:expert-ms5rlf07:workspace");
+    const roster = createRoster();
+    const selection = createAgentSelectionCapability(harness.gateway, roster.roster);
+
+    roster.publish({
+      defaultId: "main",
+      mainKey: "workspace",
+      scope: "per-sender",
+      agents: [{ id: "main", kind: "agent" }],
+    });
+
+    expect(selection.state).toEqual({ selectedId: "main", scopeId: "main" });
+    expect(harness.setSessionKeyCalls).toEqual(["agent:main:workspace"]);
+  });
+
+  it("does not retarget the gateway session when the owner is still configured", () => {
+    const harness = createGateway("Research", "agent:research:main");
+    const roster = createRoster();
+    const selection = createAgentSelectionCapability(harness.gateway, roster.roster);
+
+    roster.publish({
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [
+        { id: "main", kind: "agent" },
+        { id: "research", kind: "agent" },
+      ],
+    });
+
+    expect(selection.state).toEqual({ selectedId: "research", scopeId: "research" });
+    expect(harness.setSessionKeyCalls).toEqual([]);
   });
 });
 

--- a/ui/src/app/agent-selection.test.ts
+++ b/ui/src/app/agent-selection.test.ts
@@ -21,9 +21,9 @@ function createGateway(assistantAgentId: string | null = "Main", sessionKey = "a
         listeners.add(listener);
         return () => listeners.delete(listener);
       },
-      setSessionKey(sessionKey: string) {
-        setSessionKeyCalls.push(sessionKey);
-        snapshot = { ...snapshot, sessionKey };
+      setSessionKey(nextSessionKey: string) {
+        setSessionKeyCalls.push(nextSessionKey);
+        snapshot = { ...snapshot, sessionKey: nextSessionKey };
       },
     },
     publish(next: Partial<typeof snapshot>) {

--- a/ui/src/app/agent-selection.test.ts
+++ b/ui/src/app/agent-selection.test.ts
@@ -394,6 +394,33 @@ describe("agent selection", () => {
     expect(selection.state).toEqual({ selectedId: "research", scopeId: "research" });
     expect(harness.setSessionKeyCalls).toEqual([]);
   });
+
+  it("does not retarget a session switch that happens after the initial roster load", () => {
+    const harness = createGateway("Main", "agent:main:main");
+    const roster = createRoster();
+    const selection = createAgentSelectionCapability(harness.gateway, roster.roster);
+
+    roster.publish({
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [{ id: "main", kind: "agent" }],
+    });
+    expect(harness.setSessionKeyCalls).toEqual([]);
+
+    // Simulate a deliberate pane switch to an agent that has not yet appeared
+    // in the roster (for example, ahead of a deferred chat.startup).
+    harness.publish({ sessionKey: "agent:work:main" });
+    roster.publish({
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [{ id: "main", kind: "agent" }],
+    });
+
+    expect(selection.state).toEqual({ selectedId: "main", scopeId: "main" });
+    expect(harness.setSessionKeyCalls).toEqual([]);
+  });
 });
 
 describe("application session selection", () => {

--- a/ui/src/app/agent-selection.ts
+++ b/ui/src/app/agent-selection.ts
@@ -1,11 +1,20 @@
+import type { GatewayHelloOk } from "../api/gateway.ts";
 import type { AgentsListResult } from "../api/types.ts";
-import { normalizeAgentId, parseAgentSessionKey } from "../lib/sessions/session-key.ts";
+import {
+  buildAgentMainSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveUiConfiguredMainKey,
+} from "../lib/sessions/session-key.ts";
 
 type AgentSelectionGateway = {
   readonly snapshot: {
     assistantAgentId: string | null;
+    sessionKey: string;
+    hello: GatewayHelloOk | null;
   };
   subscribe: (listener: (snapshot: AgentSelectionGateway["snapshot"]) => void) => () => void;
+  setSessionKey: (sessionKey: string) => void;
 };
 
 type AgentSelectionRoster = {
@@ -107,6 +116,17 @@ export function createAgentSelectionCapability(
       publish({ selectedId: nextAssistantAgentId, scopeId: nextAssistantAgentId });
     }
   });
+  const isAgentInRoster = (agentId: string): boolean => {
+    const agentsList = roster.state.agentsList;
+    if (!agentsList || agentsList.agents.length === 0) {
+      // Roster not loaded yet; do not assume the agent is invalid.
+      return true;
+    }
+    return agentsList.agents.some(
+      (agent) => normalizeAgentId(agent.id) === normalizeAgentId(agentId),
+    );
+  };
+
   roster.subscribe(() => {
     // Re-enable implicit ownership before publishing the roster fallback. A
     // synchronous subscriber may establish a new explicit owner during publish.
@@ -117,6 +137,32 @@ export function createAgentSelectionCapability(
       publish({ selectedId: assistantAgentId, scopeId: assistantAgentId });
     } else {
       publish(state);
+    }
+    // When the roster invalidates the agent that owns the current gateway session,
+    // retarget the session to the reconciled default's main key. Without this, a
+    // persisted sessionKey for a deleted agent keeps chat.send/sessions.resolve
+    // failing with "Agent ... no longer exists in configuration".
+    if (!followsGatewayDefault) {
+      return;
+    }
+    const parsed = parseAgentSessionKey(gateway.snapshot.sessionKey);
+    if (!parsed) {
+      return;
+    }
+    if (isAgentInRoster(parsed.agentId)) {
+      return;
+    }
+    const fallbackAgentId = state.selectedId;
+    if (!fallbackAgentId) {
+      return;
+    }
+    const mainKey = resolveUiConfiguredMainKey({
+      agentsList: roster.state.agentsList,
+      hello: gateway.snapshot.hello,
+    });
+    const fallbackSessionKey = buildAgentMainSessionKey({ agentId: fallbackAgentId, mainKey });
+    if (fallbackSessionKey !== gateway.snapshot.sessionKey) {
+      gateway.setSessionKey(fallbackSessionKey);
     }
   });
 

--- a/ui/src/app/agent-selection.ts
+++ b/ui/src/app/agent-selection.ts
@@ -87,6 +87,7 @@ export function createAgentSelectionCapability(
   // Construction has no explicit-selection input: a roster repair still follows
   // hello until a navigation or picker action establishes explicit ownership.
   let followsGatewayDefault = true;
+  let initialRosterResolved = false;
   const listeners = new Set<(next: AgentSelectionState) => void>();
 
   const publish = (next: AgentSelectionState) => {
@@ -138,10 +139,20 @@ export function createAgentSelectionCapability(
     } else {
       publish(state);
     }
-    // When the roster invalidates the agent that owns the current gateway session,
-    // retarget the session to the reconciled default's main key. Without this, a
-    // persisted sessionKey for a deleted agent keeps chat.send/sessions.resolve
-    // failing with "Agent ... no longer exists in configuration".
+    // When the first authoritative roster invalidates the agent that owns the
+    // current gateway session, retarget the session to the reconciled default's
+    // main key. Without this, a persisted sessionKey for a deleted agent keeps
+    // chat.send/sessions.resolve failing with "Agent ... no longer exists in
+    // configuration". Restricting the repair to the initial roster avoids
+    // clobbering later deliberate session switches (for example, a pane switch
+    // that races ahead of a deferred chat.startup agents list).
+    const agentsList = roster.state.agentsList;
+    const isFirstAuthoritativeRoster =
+      !initialRosterResolved && agentsList && agentsList.agents.length > 0;
+    if (!isFirstAuthoritativeRoster) {
+      return;
+    }
+    initialRosterResolved = true;
     if (!followsGatewayDefault) {
       return;
     }
@@ -156,10 +167,7 @@ export function createAgentSelectionCapability(
     if (!fallbackAgentId) {
       return;
     }
-    const mainKey = resolveUiConfiguredMainKey({
-      agentsList: roster.state.agentsList,
-      hello: gateway.snapshot.hello,
-    });
+    const mainKey = resolveUiConfiguredMainKey({ agentsList, hello: gateway.snapshot.hello });
     const fallbackSessionKey = buildAgentMainSessionKey({ agentId: fallbackAgentId, mainKey });
     if (fallbackSessionKey !== gateway.snapshot.sessionKey) {
       gateway.setSessionKey(fallbackSessionKey);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who had a deleted agent's session key persisted in Control UI localStorage would see `Agent "..." no longer exists in configuration` on every `chat.send` / `chat.history` request. Re-starting the Co-Claw gateway or Electron tray did not help because the stale session key is stored in the browser's localStorage and survives app restarts.

## Why This Change Was Made

`createAgentSelectionCapability` already reconciles the selected agent against the gateway's configured agents list and falls back to the default agent when the persisted selection no longer exists. However, that fallback only updated the in-memory selection state; it did not update the gateway session key that chat RPCs actually use. This change retargets the gateway session key to the reconciled default agent's main session key whenever the roster invalidates the current session owner.

## User Impact

After deleting an agent, refreshing Control UI now automatically lands the user on the default agent's main session instead of retrying the deleted agent and surfacing a backend error.

## Evidence

- Added three focused unit tests in `ui/src/app/agent-selection.test.ts` covering:
  - fallback to `agent:<default>:main` when the persisted owner is deleted,
  - use of the configured `mainKey` for the fallback session key,
  - no retargeting when the persisted owner is still configured.
- Ran:
  ```bash
  node scripts/run-vitest.mjs ui/src/app/agent-selection.test.ts ui/src/app/bootstrap.test.ts ui/src/app/app-host.test.ts
  ```
  Result: 69 tests passed across `|ui|` and `|ui-isolated|` shards.
- Formatted with `oxfmt`.
