### PR TITLE
fix(qa): make Slack live observer lazy and abortable

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/adapter.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/adapter.runtime.test.ts
@@ -1,9 +1,36 @@
 // Qa Lab tests cover Slack live adapter message reconciliation.
+import type { FetchFunction } from "@slack/web-api";
 import { describe, expect, it } from "vitest";
 import { createQaBusState } from "../../bus-state.js";
 import { testing } from "./adapter.runtime.js";
 
 describe("Slack live adapter reconciliation", () => {
+  it("aborts an in-flight observer fetch when the adapter stops", async () => {
+    let observedSignal: AbortSignal | undefined;
+    const fetchImpl: FetchFunction = async (_url, init) => {
+      observedSignal = init?.signal;
+      await new Promise<void>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("observer aborted")), {
+          once: true,
+        });
+      });
+      throw new Error("unreachable");
+    };
+    const lifecycle = new AbortController();
+    const request = new AbortController();
+
+    const pending = testing.withSlackLifecycleSignal(fetchImpl, lifecycle.signal)(
+      "https://slack.test",
+      {
+        signal: request.signal,
+      },
+    );
+    lifecycle.abort();
+
+    await expect(pending).rejects.toThrow("observer aborted");
+    expect(observedSignal?.aborted).toBe(true);
+  });
+
   it("records streamed updates to the same Slack timestamp as bus edits", async () => {
     const state = createQaBusState();
     const busMessageIds = new Map<string, string>();

--- a/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
@@ -1,6 +1,11 @@
 // Qa Lab plugin module implements Slack live transport adapter behavior.
 import { setTimeout as sleep } from "node:timers/promises";
-import { createSlackWebClient, createSlackWriteClient } from "@openclaw/slack/api.js";
+import {
+  createSlackWebClient,
+  createSlackWriteClient,
+  resolveSlackWebClientOptions,
+} from "@openclaw/slack/api.js";
+import type { FetchFunction } from "@slack/web-api";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { QaRunnerCliRegistration } from "openclaw/plugin-sdk/qa-runner-runtime";
 import {
@@ -47,6 +52,17 @@ async function waitForSlackPoll(delayMs: number, signal: AbortSignal) {
       throw error;
     }
   }
+}
+
+function withSlackLifecycleSignal(
+  fetchImpl: FetchFunction,
+  lifecycleSignal: AbortSignal,
+): FetchFunction {
+  return async (url, init) =>
+    await fetchImpl(url, {
+      ...init,
+      signal: init?.signal ? AbortSignal.any([init.signal, lifecycleSignal]) : lifecycleSignal,
+    });
 }
 
 async function recordSlackObservedMessage(params: {
@@ -125,11 +141,16 @@ export async function createSlackQaTransportAdapter(
   const sutClient = createSlackWebClient(runtimeEnv.sutBotToken);
   const sutWriteClient = createSlackWriteClient(runtimeEnv.sutBotToken);
   const pollingAbort = new AbortController();
-  const pollingClient = createSlackWebClient(runtimeEnv.sutBotToken, {
+  const pollingOptions = resolveSlackWebClientOptions({
     rejectRateLimitedCalls: true,
     retryConfig: { retries: 0 },
     timeout: SLACK_POLL_REQUEST_TIMEOUT_MS,
   });
+  pollingOptions.fetch = withSlackLifecycleSignal(
+    pollingOptions.fetch ?? globalThis.fetch,
+    pollingAbort.signal,
+  );
+  const pollingClient = createSlackWebClient(runtimeEnv.sutBotToken, pollingOptions);
   const accountId = options.sutAccountId?.trim() || "sut";
   let oldestTs = `${Math.floor(Date.now() / 1_000)}.000000`;
   let stopped = false;
@@ -139,36 +160,18 @@ export async function createSlackQaTransportAdapter(
   const nativeMessageIds = new Map<string, string>();
   const busMessageIds = new Map<string, string>();
   const activeThreadRoots = new Set<string>();
-  const polling = (async () => {
-    while (!pollingAbort.signal.aborted) {
-      try {
-        const messages = await listSlackMessages({
-          channelId: runtimeEnv.channelId,
-          client: pollingClient,
-          oldestTs,
-        });
-        for (const message of messages.toReversed()) {
-          const observedTs = await recordSlackObservedMessage({
-            accountId,
-            busMessageIds,
-            logicalConversationId,
-            message,
-            messages: context.messages,
-            observedText,
-            sutUserId: sutIdentity.userId,
-          });
-          if (observedTs) {
-            oldestTs = observedTs;
-          }
-        }
-        for (const threadTs of activeThreadRoots) {
-          const threadMessages = await listSlackThreadMessages({
+  let polling: Promise<void> | undefined;
+  const startPolling = () => {
+    polling ??= (async () => {
+      while (!pollingAbort.signal.aborted) {
+        try {
+          const messages = await listSlackMessages({
             channelId: runtimeEnv.channelId,
             client: pollingClient,
-            threadTs,
+            oldestTs,
           });
-          for (const message of threadMessages) {
-            await recordSlackObservedMessage({
+          for (const message of messages.toReversed()) {
+            const observedTs = await recordSlackObservedMessage({
               accountId,
               busMessageIds,
               logicalConversationId,
@@ -177,26 +180,47 @@ export async function createSlackQaTransportAdapter(
               observedText,
               sutUserId: sutIdentity.userId,
             });
+            if (observedTs) {
+              oldestTs = observedTs;
+            }
           }
+          for (const threadTs of activeThreadRoots) {
+            const threadMessages = await listSlackThreadMessages({
+              channelId: runtimeEnv.channelId,
+              client: pollingClient,
+              threadTs,
+            });
+            for (const message of threadMessages) {
+              await recordSlackObservedMessage({
+                accountId,
+                busMessageIds,
+                logicalConversationId,
+                message,
+                messages: context.messages,
+                observedText,
+                sutUserId: sutIdentity.userId,
+              });
+            }
+          }
+        } catch (error) {
+          if (pollingAbort.signal.aborted) {
+            return;
+          }
+          const retryDelayMs = resolveSlackRateLimitDelayMs(error);
+          if (retryDelayMs === undefined) {
+            throw error;
+          }
+          await waitForSlackPoll(retryDelayMs, pollingAbort.signal);
+          continue;
         }
-      } catch (error) {
-        if (pollingAbort.signal.aborted) {
-          return;
-        }
-        const retryDelayMs = resolveSlackRateLimitDelayMs(error);
-        if (retryDelayMs === undefined) {
-          throw error;
-        }
-        await waitForSlackPoll(retryDelayMs, pollingAbort.signal);
-        continue;
+        await waitForSlackPoll(SLACK_POLL_INTERVAL_MS, pollingAbort.signal);
       }
-      await waitForSlackPoll(SLACK_POLL_INTERVAL_MS, pollingAbort.signal);
-    }
-  })().catch((error: unknown) => {
-    if (!stopped) {
-      pollingError = error instanceof Error ? error : new Error(String(error));
-    }
-  });
+    })().catch((error: unknown) => {
+      if (!stopped) {
+        pollingError = error instanceof Error ? error : new Error(String(error));
+      }
+    });
+  };
 
   return {
     id: "slack",
@@ -229,6 +253,9 @@ export async function createSlackQaTransportAdapter(
       nativeMessageIds.set(message.id, sent.ts);
       busMessageIds.set(sent.ts, message.id);
       activeThreadRoots.add(nativeThreadTs ?? sent.ts);
+      // Native Slack scenarios observe their own messages. Start the shared bus
+      // observer only when a generic transport flow actually needs it.
+      startPolling();
       return message;
     },
     resetTransport: () => {
@@ -270,10 +297,10 @@ export async function createSlackQaTransportAdapter(
     createReportNotes: () => ["Runs through the Slack live adapter and shared QA suite host."],
     async cleanup() {
       stopped = true;
-      // The Slack SDK's rate-limit sleep is not interruptible, so the observer uses
-      // bounded requests and an abortable local backoff that teardown can stop.
+      // The observer's HTTP request and local backoff share this lifecycle signal,
+      // so teardown does not wait on a stalled Slack read.
       pollingAbort.abort();
-      await polling.catch(() => undefined);
+      await polling?.catch(() => undefined);
       // Lease release must still run when heartbeat shutdown reports an error.
       try {
         await heartbeat.stop();
@@ -284,4 +311,8 @@ export async function createSlackQaTransportAdapter(
   };
 }
 
-export const testing = { recordSlackObservedMessage, resolveSlackRateLimitDelayMs };
+export const testing = {
+  recordSlackObservedMessage,
+  resolveSlackRateLimitDelayMs,
+  withSlackLifecycleSignal,
+};


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the full QA profile could complete its final Slack scenario but remain stuck in transport teardown until the 90-minute workflow timeout. The same adapter also started a second 500 ms Slack history observer for native Slack scenarios that already perform their own observations, increasing rate-limit pressure.

## Why This Change Was Made

The shared Slack bus observer now starts only when a generic transport flow calls `sendInbound`; native Slack scenarios retain their own observation path. The observer's resolved fetch implementation also composes the Slack SDK request deadline with the adapter lifecycle signal, so cleanup cancels an in-flight read instead of awaiting it indefinitely. Proxy-aware Slack fetch options remain preserved.

This deliberately does not claim to resolve every scenario failure captured by the timed-out maturity run. It ensures the profile can return and publish its real result while reducing redundant Slack API traffic.

## User Impact

QA and maturity-scorecard operators should receive completed evidence and actionable scenario failures instead of a workflow-level timeout after scenario execution has already finished.

AI-assisted change; implementation and evidence reviewed by the author.

## Evidence

- Failure evidence: [maturity scorecard run 30518987915](https://github.com/openclaw/openclaw/actions/runs/30518987915) completed the final Slack scenario at 07:25:22 UTC, then produced no progress until cancellation at 07:50:31 UTC.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/slack/adapter.runtime.test.ts` — 3 tests passed.
- Changed-surface gate on Blacksmith Testbox: [run 30526400353](https://github.com/openclaw/openclaw/actions/runs/30526400353) — formatting, guards, extension production/test typechecks, lint, and import-cycle checks passed.
- `git diff --check` passed.
- Autoreview (`--mode uncommitted`, Codex) reported no accepted/actionable findings.
