### PR TITLE
refactor(agents): expose runtime turn observation

### DIFF
--- a/src/agents/openclaw-runtime.test.ts
+++ b/src/agents/openclaw-runtime.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  emitAgentAuditEvent,
+  emitAgentEvent,
+  registerAgentRunContext,
+  resetAgentEventsForTest,
+} from "../infra/agent-events.js";
+import { openClawRuntime } from "./openclaw-runtime.js";
+
+describe("openClawRuntime", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  it("synchronously forwards enriched agent turn observations", () => {
+    registerAgentRunContext("run-1", {
+      sessionKey: "agent:main:main",
+      sessionId: "session-1",
+      agentId: "main",
+      isControlUiVisible: false,
+    });
+    const observer = vi.fn();
+    const unsubscribe = openClawRuntime.observeAgentTurns(observer);
+
+    emitAgentEvent({
+      runId: "run-1",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+
+    expect(observer).toHaveBeenCalledOnce();
+    expect(observer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        seq: 1,
+        stream: "lifecycle",
+        sessionKey: "agent:main:main",
+        sessionId: "session-1",
+        agentId: "main",
+        controlUiVisible: false,
+        data: { phase: "start", startedAt: 1_000 },
+      }),
+    );
+    unsubscribe();
+  });
+
+  it("stops forwarding after unsubscribe", () => {
+    const observer = vi.fn();
+    const unsubscribe = openClawRuntime.observeAgentTurns(observer);
+
+    unsubscribe();
+    emitAgentEvent({
+      runId: "run-unsubscribed",
+      stream: "assistant",
+      data: { text: "ignored" },
+    });
+
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("does not expose private audit-only events", () => {
+    const observer = vi.fn();
+    const unsubscribe = openClawRuntime.observeAgentTurns(observer);
+
+    emitAgentAuditEvent({
+      runId: "audit-only-run",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+
+    expect(observer).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+});

--- a/src/agents/openclaw-runtime.ts
+++ b/src/agents/openclaw-runtime.ts
@@ -1,0 +1,11 @@
+import { type AgentEventRuntimePayload, onAgentRuntimeEvent } from "../infra/agent-events.js";
+
+type AgentTurnObserver = (event: AgentEventRuntimePayload) => void;
+
+type OpenClawRuntime = {
+  observeAgentTurns(observer: AgentTurnObserver): () => void;
+};
+
+export const openClawRuntime: OpenClawRuntime = {
+  observeAgentTurns: onAgentRuntimeEvent,
+};

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -1,14 +1,11 @@
 // Gateway event subscription wiring for agent, heartbeat, transcript, and lifecycle broadcasts.
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { openClawRuntime } from "../agents/openclaw-runtime.js";
 import { isAuditLedgerEnabled, resolveAuditMessageMode } from "../audit/audit-config.js";
 import { createAuditEventRecorder } from "../audit/audit-recorder.js";
 import { onTrustedMessageAuditEvent } from "../audit/message-audit-events.js";
 import { getRuntimeConfig } from "../config/io.js";
-import {
-  clearAgentRunContext,
-  onAgentAuditEvent,
-  onAgentRuntimeEvent,
-} from "../infra/agent-events.js";
+import { clearAgentRunContext, onAgentAuditEvent } from "../infra/agent-events.js";
 import { onTrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
@@ -259,7 +256,7 @@ export function startGatewayEventSubscriptions(params: {
     return lifecycleEventHandlerPromise;
   };
 
-  const unsubscribeAgentEvents = onAgentRuntimeEvent((evt) => {
+  const unsubscribeAgentEvents = openClawRuntime.observeAgentTurns((evt) => {
     sessionObserver.handleEvent(evt);
     if (auditEnabled) {
       auditRecorder.record(evt);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/116310

Part 1 of the direct ACP runtime stack. Do not merge independently; the chain is only ready when inbound ACP runs without a Gateway and the Buzz acceptance test passes.

## What Problem This Solves

ACP hosts need an OpenClaw-owned runtime boundary instead of reaching through the Gateway. Gateway currently subscribes directly to the low-level agent event implementation, so another adapter cannot observe the same canonical turn stream without duplicating internal event wiring.

## Why This Change Was Made

Introduces an internal `openClawRuntime` facade for observing sequenced agent turns and moves Gateway's main event subscription onto it. The facade delegates to the existing process-local event bus, preserving sequencing, context enrichment, synchronous delivery, audit isolation, and unsubscribe behavior.

This PR deliberately stops at observation. It does not change execution, sessions, approvals, cancellation, ACP protocol behavior, or the current Gateway-backed ACP topology. Later stacked PRs will add runtime-owned turn execution and migrate adapters onto that boundary.

## User Impact

No standalone user-visible behavior change. This establishes the first runtime-owned contract required to remove the Gateway dependency from `openclaw acp` without creating a second event path.

## Evidence

Base: `3e7ecb3aeaaf3a9dd4fa8c46c31b63c6f2031ccc`

- `node scripts/run-vitest.mjs src/agents/openclaw-runtime.test.ts src/gateway/server-runtime-subscriptions.test.ts src/gateway/server-import-boundary.test.ts`
  - 3 test files passed
  - 15 tests passed
- `node scripts/check-changed.mjs -- src/agents/openclaw-runtime.ts src/agents/openclaw-runtime.test.ts src/gateway/server-runtime-subscriptions.ts`
  - passed on Blacksmith Testbox
  - Actions run: https://github.com/openclaw/openclaw/actions/runs/30539867182
  - dead-export scans, core and core-test typechecks, changed-file lint, import-cycle checks, schema/storage guards, and all remaining changed-surface checks passed
- The refreshed head was also included in the exact-base stacked gate:
  - Actions run: https://github.com/openclaw/openclaw/actions/runs/30540838360
  - all changed-surface checks passed
- `git diff HEAD^ --check`
- fresh autoreview after rebase: clean, no accepted or actionable findings
