### PR TITLE
refactor(sessions): move canonical session resolution

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -137,7 +137,7 @@ export const migratedSessionAccessorFiles = new Set([
   "src/gateway/boot.ts",
   "src/gateway/server-methods/artifacts.ts",
   "src/gateway/server-methods/chat.ts",
-  "src/gateway/sessions-resolve.ts",
+  "src/sessions/session-resolve.ts",
   "src/gateway/server-methods/sessions-files.ts",
   ...gatewaySessionServerMethodFiles,
   "src/gateway/server-session-events.ts",

--- a/src/agents/openclaw-runtime.test.ts
+++ b/src/agents/openclaw-runtime.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  emitAgentAuditEvent,
+  emitAgentEvent,
+  registerAgentRunContext,
+  resetAgentEventsForTest,
+} from "../infra/agent-events.js";
+import { openClawRuntime } from "./openclaw-runtime.js";
+
+describe("openClawRuntime", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  it("synchronously forwards enriched agent turn observations", () => {
+    registerAgentRunContext("run-1", {
+      sessionKey: "agent:main:main",
+      sessionId: "session-1",
+      agentId: "main",
+      isControlUiVisible: false,
+    });
+    const observer = vi.fn();
+    const unsubscribe = openClawRuntime.observeAgentTurns(observer);
+
+    emitAgentEvent({
+      runId: "run-1",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+
+    expect(observer).toHaveBeenCalledOnce();
+    expect(observer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        seq: 1,
+        stream: "lifecycle",
+        sessionKey: "agent:main:main",
+        sessionId: "session-1",
+        agentId: "main",
+        controlUiVisible: false,
+        data: { phase: "start", startedAt: 1_000 },
+      }),
+    );
+    unsubscribe();
+  });
+
+  it("stops forwarding after unsubscribe", () => {
+    const observer = vi.fn();
+    const unsubscribe = openClawRuntime.observeAgentTurns(observer);
+
+    unsubscribe();
+    emitAgentEvent({
+      runId: "run-unsubscribed",
+      stream: "assistant",
+      data: { text: "ignored" },
+    });
+
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("does not expose private audit-only events", () => {
+    const observer = vi.fn();
+    const unsubscribe = openClawRuntime.observeAgentTurns(observer);
+
+    emitAgentAuditEvent({
+      runId: "audit-only-run",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+
+    expect(observer).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+});

--- a/src/agents/openclaw-runtime.ts
+++ b/src/agents/openclaw-runtime.ts
@@ -1,0 +1,11 @@
+import { type AgentEventRuntimePayload, onAgentRuntimeEvent } from "../infra/agent-events.js";
+
+type AgentTurnObserver = (event: AgentEventRuntimePayload) => void;
+
+type OpenClawRuntime = {
+  observeAgentTurns(observer: AgentTurnObserver): () => void;
+};
+
+export const openClawRuntime: OpenClawRuntime = {
+  observeAgentTurns: onAgentRuntimeEvent,
+};

--- a/src/agents/tools/embedded-gateway-stub.runtime.ts
+++ b/src/agents/tools/embedded-gateway-stub.runtime.ts
@@ -37,5 +37,5 @@ export {
   loadSessionEntryReadOnly as loadSessionEntry,
   resolveSessionModelRef,
 } from "../../gateway/session-utils.js";
-export { resolveSessionKeyFromResolveParams } from "../../gateway/sessions-resolve.js";
+export { resolveSessionKeyFromResolveParams } from "../../sessions/session-resolve.js";
 export type { SessionsListResult } from "../../gateway/session-utils.types.js";

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -15,8 +15,8 @@ import type {
   SessionTranscriptReadScope,
 } from "../../gateway/session-transcript-readers.js";
 import type { SessionsListResult } from "../../gateway/session-utils.types.js";
-import type { SessionsResolveResult } from "../../gateway/sessions-resolve.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
+import type { SessionsResolveResult } from "../../sessions/session-resolve.js";
 import { readNonNegativeIntegerParam, readPositiveIntegerParam } from "./common.js";
 
 type EmbeddedCallGateway = <T = Record<string, unknown>>(opts: CallGatewayOptions) => Promise<T>;

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -36,6 +36,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
+import { resolveSessionKeyFromResolveParams } from "../../sessions/session-resolve.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
 import {
   canAccessIncognitoSession,
@@ -68,7 +69,6 @@ import {
   type SessionsPreviewEntry,
   type SessionsPreviewResult,
 } from "../session-utils.js";
-import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { projectWorkerSessionPlacement } from "../worker-environments/placement-projector.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -16,6 +16,7 @@ import {
   validateTalkSessionTurnParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { buildAgentMainSessionKey } from "../../routing/session-key.js";
+import { resolveSessionKeyFromResolveParams } from "../../sessions/session-resolve.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../../talk/agent-run-control-shared.js";
 import { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
@@ -23,7 +24,6 @@ import { resolveTalkSessionAgentId } from "../../talk/agent-target.js";
 import { ensureClientVoiceAgentSessionEntry } from "../../talk/client-voice-session.js";
 import { resolveConfiguredRealtimeVoiceProvider } from "../../talk/provider-resolver.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
-import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import {
   cancelTalkHandoffTurn,
   createTalkHandoff,

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -184,7 +184,7 @@ vi.mock("./chat.js", () => ({
   },
 }));
 
-vi.mock("../sessions-resolve.js", () => ({
+vi.mock("../../sessions/session-resolve.js", () => ({
   resolveSessionKeyFromResolveParams: mocks.resolveSessionKeyFromResolveParams,
 }));
 

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -1,14 +1,11 @@
 // Gateway event subscription wiring for agent, heartbeat, transcript, and lifecycle broadcasts.
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { openClawRuntime } from "../agents/openclaw-runtime.js";
 import { isAuditLedgerEnabled, resolveAuditMessageMode } from "../audit/audit-config.js";
 import { createAuditEventRecorder } from "../audit/audit-recorder.js";
 import { onTrustedMessageAuditEvent } from "../audit/message-audit-events.js";
 import { getRuntimeConfig } from "../config/io.js";
-import {
-  clearAgentRunContext,
-  onAgentAuditEvent,
-  onAgentRuntimeEvent,
-} from "../infra/agent-events.js";
+import { clearAgentRunContext, onAgentAuditEvent } from "../infra/agent-events.js";
 import { onTrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
@@ -259,7 +256,7 @@ export function startGatewayEventSubscriptions(params: {
     return lifecycleEventHandlerPromise;
   };
 
-  const unsubscribeAgentEvents = onAgentRuntimeEvent((evt) => {
+  const unsubscribeAgentEvents = openClawRuntime.observeAgentTurns((evt) => {
     sessionObserver.handleEvent(evt);
     if (auditEnabled) {
       auditRecorder.record(evt);

--- a/src/sessions/session-resolve-store.test.ts
+++ b/src/sessions/session-resolve-store.test.ts
@@ -11,7 +11,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withStateDirEnv as withRawStateDirEnv } from "../test-helpers/state-dir-env.js";
-import { resolveSessionKeyFromResolveParams } from "./sessions-resolve.js";
+import { resolveSessionKeyFromResolveParams } from "./session-resolve.js";
 
 describe("resolveSessionKeyFromResolveParams store canonicalization", () => {
   const freshUpdatedAt = () => Date.now();

--- a/src/sessions/session-resolve.test.ts
+++ b/src/sessions/session-resolve.test.ts
@@ -32,8 +32,10 @@ vi.mock("../config/sessions.js", async () => {
   };
 });
 
-vi.mock("./session-utils.js", async () => {
-  const actual = await vi.importActual<typeof import("./session-utils.js")>("./session-utils.js");
+vi.mock("../gateway/session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../gateway/session-utils.js")>(
+    "../gateway/session-utils.js",
+  );
   return {
     ...actual,
     listSessionsFromStore: hoisted.listSessionsFromStoreMock,
@@ -43,7 +45,7 @@ vi.mock("./session-utils.js", async () => {
   };
 });
 
-const { resolveSessionKeyFromResolveParams } = await import("./sessions-resolve.js");
+const { resolveSessionKeyFromResolveParams } = await import("./session-resolve.js");
 
 describe("resolveSessionKeyFromResolveParams", () => {
   const canonicalKey = "agent:main:canon";

--- a/src/sessions/session-resolve.ts
+++ b/src/sessions/session-resolve.ts
@@ -1,5 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
-// Gateway sessions.resolve implementation helper.
+// Canonical session selector resolution.
 // Resolves key/sessionId/label selectors into one canonical session key.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -10,15 +10,15 @@ import {
 } from "../../packages/gateway-protocol/src/index.js";
 import { canonicalizeSessionEntryAliases, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveSessionIdMatchSelection } from "../sessions/session-id-resolution.js";
-import { parseSessionLabel } from "../sessions/session-label.js";
 import {
   filterAndSortSessionEntries,
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
   resolveDeletedAgentIdFromSessionKey,
   resolveGatewaySessionStoreTargetWithStore,
-} from "./session-utils.js";
+} from "../gateway/session-utils.js";
+import { resolveSessionIdMatchSelection } from "./session-id-resolution.js";
+import { parseSessionLabel } from "./session-label.js";
 
 export type SessionsResolveResult =
   | { ok: true; key: string }

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -95,7 +95,7 @@ describe("session accessor boundary guard", () => {
         "src/gateway/boot.ts",
         "src/gateway/server-methods/artifacts.ts",
         "src/gateway/server-methods/chat.ts",
-        "src/gateway/sessions-resolve.ts",
+        "src/sessions/session-resolve.ts",
         "src/gateway/server-methods/sessions-files.ts",
         "src/gateway/server-methods/sessions-abort.ts",
         "src/gateway/server-methods/sessions-compact.ts",


### PR DESCRIPTION
Related: #116310

Part 2 of the direct ACP runtime stack. Do not merge independently; the chain is only ready when inbound ACP runs without a Gateway and the Buzz acceptance test passes.

## What Problem This Solves

Canonical session selector resolution currently lives under `src/gateway`, even though embedded tools and the planned direct ACP adapter need the same key, session ID, and label semantics. Leaving that logic Gateway-owned would force a new runtime service to depend on a transport adapter.

## Why This Change Was Made

Moves the existing resolver and its tests to `src/sessions`, then updates all callers, mocks, and boundary guards to use the new owner. This is a behavior-preserving ownership move: selector precedence, store lookup, ambiguity handling, deleted-agent handling, and error results remain unchanged.

The moved resolver still imports Gateway-named session store helpers from `src/gateway/session-utils.ts`. That dependency is intentionally visible and temporary. The next stack part will extract the canonical `SessionService` and remove the remaining Gateway ownership instead of hiding it behind a compatibility re-export.

## User Impact

No standalone user-visible behavior change. This establishes the canonical session-resolution owner needed for Gateway and inbound ACP to share one runtime path.

## Evidence

- `node scripts/run-vitest.mjs src/sessions/session-resolve.test.ts src/sessions/session-resolve-store.test.ts src/gateway/server-methods/talk.test.ts src/agents/tools/embedded-gateway-stub.test.ts test/scripts/check-session-accessor-boundary.test.ts`
  - 5 test files passed
  - 137 tests passed
- `node scripts/check-changed.mjs -- scripts/check-session-accessor-boundary.mjs src/agents/tools/embedded-gateway-stub.runtime.ts src/agents/tools/embedded-gateway-stub.ts src/gateway/server-methods/sessions-read.ts src/gateway/server-methods/talk-session.ts src/gateway/server-methods/talk.test.ts src/sessions/session-resolve.ts src/sessions/session-resolve.test.ts src/sessions/session-resolve-store.test.ts test/scripts/check-session-accessor-boundary.test.ts`
  - passed on Blacksmith Testbox lease `tbx_01kys3477cv7h40y8k6rtgk2z8`
  - covered dead-export scans, core/core-test/test-root typechecks, changed-file lint, import-cycle checks, schema/storage guards, and the remaining changed-surface checks
  - timing result: `exitCode: 0`, `runStatus: succeeded`
- `git diff --check`
- autoreview: clean, no actionable findings, 0.98 confidence
