### PR TITLE
fix(perf): make Kova startup diagnostics actionable

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -715,6 +715,9 @@ jobs:
             --skip-qa \
             --startup-case default \
             --startup-case skipChannels \
+            --startup-case preparedRuntimeCatalogStall \
+            --startup-case preparedRuntimeScaleOne \
+            --startup-case preparedRuntimeScaleMany \
             --startup-case oneInternalHook \
             --startup-case allInternalHooks \
             --startup-case fiftyPlugins \

--- a/scripts/openclaw-performance-source-summary.mjs
+++ b/scripts/openclaw-performance-source-summary.mjs
@@ -360,7 +360,7 @@ function buildTraceRows(startup) {
   const rows = [];
   for (const result of startup?.results ?? []) {
     const traceEntries = Object.entries(result.summary?.startupTrace ?? {})
-      .filter(([, stats]) => typeof stats?.p50 === "number")
+      .filter(([name, stats]) => isStartupTraceDuration(name) && typeof stats?.p50 === "number")
       .toSorted((a, b) => (b[1].p50 ?? 0) - (a[1].p50 ?? 0))
       .slice(0, 5);
     for (const [name, stats] of traceEntries) {
@@ -368,6 +368,14 @@ function buildTraceRows(startup) {
     }
   }
   return rows;
+}
+
+function isStartupTraceDuration(name) {
+  if (name.endsWith(".total") || name.startsWith("memory.")) {
+    return false;
+  }
+  const metricName = name.slice(name.lastIndexOf(".") + 1);
+  return !metricName.endsWith("Count") && !metricName.endsWith("Mb");
 }
 
 function buildMockHelloRows(summaries) {

--- a/test/scripts/openclaw-performance-source-summary.test.ts
+++ b/test/scripts/openclaw-performance-source-summary.test.ts
@@ -46,6 +46,8 @@ function writeSourceFixture(sourceDir: string) {
           cpuCoreRatio: { p95: 0.25 },
           startupTrace: {
             "memory.ready.heapUsedMb": { p50: 30, p95: 32 },
+            "phase.load.total": { p50: 70, p95: 80 },
+            "phase.load.itemCount": { p50: 40, p95: 50 },
             "phase.load": { p50: 7, p95: 8 },
           },
         },
@@ -165,6 +167,10 @@ describe("buildMarkdown", () => {
     expect(buildMarkdown(sourceDir, null)).toContain("gateway health json");
     expect(buildMarkdown(sourceDir, null)).toContain("## SQLite State Smoke");
     expect(buildMarkdown(sourceDir, null)).toContain("4100");
+    expect(buildMarkdown(sourceDir, null)).toContain("| default | phase.load | 7.0ms | 8.0ms |");
+    expect(buildMarkdown(sourceDir, null)).not.toContain("phase.load.total");
+    expect(buildMarkdown(sourceDir, null)).not.toContain("phase.load.itemCount");
+    expect(buildMarkdown(sourceDir, null)).not.toContain("memory.ready.heapUsedMb");
   });
 
   it("rejects a missing source directory", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Kova startup reports could rank timestamps, memory values, and counters as duration hotspots, hiding the spans that actually consume startup time. The performance workflow also skipped three prepared-runtime stress cases that the benchmark already supports.

Stack position: 1 of 7. Base: `main`.

## Why This Change Was Made

The source summary now excludes aggregate `.total`, memory, count, and megabyte metrics from duration rankings. The workflow also runs the prepared-runtime catalog-stall and scale cases so regressions appear in the regular performance artifact.

## User Impact

Maintainers get actionable startup rankings and broader prepared-runtime regression coverage. There is no product runtime change.

## Evidence

- Fresh Kova run: https://github.com/openclaw/openclaw/actions/runs/30526912657
- The run completed successfully; prepared model-runtime samples were roughly 12-130 ms, with the highest observed p95 around 137 ms.
- `node scripts/run-vitest.mjs test/scripts/bench-gateway-startup.test.ts test/scripts/openclaw-performance-source-summary.test.ts` (40 tests)
- `actionlint .github/workflows/openclaw-performance.yml`
- Autoreview: clean
- TruffleHog: clean

AI assistance: Codex was used for investigation, implementation, and review. The resulting changes and evidence were manually inspected.
