### PR TITLE
improve(macos): avoid identity reads during menu rendering

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -34331,7 +34331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 242,
+      "line": 245,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Debug",
       "surface": "apple",
@@ -34339,7 +34339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 246,
+      "line": 249,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Config Folder",
       "surface": "apple",
@@ -34347,7 +34347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 251,
+      "line": 254,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Run Health Check Now",
       "surface": "apple",
@@ -34355,7 +34355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 256,
+      "line": 259,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Heartbeat",
       "surface": "apple",
@@ -34363,7 +34363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 262,
+      "line": 265,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show Pairing Panel (Demo)",
       "surface": "apple",
@@ -34371,7 +34371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 269,
+      "line": 272,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Remote Tunnel",
       "surface": "apple",
@@ -34379,7 +34379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 272,
+      "line": 275,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Reset Remote Tunnel",
       "surface": "apple",
@@ -34387,7 +34387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 280,
+      "line": 283,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): On",
       "surface": "apple",
@@ -34395,7 +34395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 281,
+      "line": 284,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): Off",
       "surface": "apple",
@@ -34403,7 +34403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 285,
+      "line": 288,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbosity",
       "surface": "apple",
@@ -34411,7 +34411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 293,
+      "line": 296,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: On",
       "surface": "apple",
@@ -34419,7 +34419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 294,
+      "line": 297,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: Off",
       "surface": "apple",
@@ -34427,7 +34427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 298,
+      "line": 301,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "App Logging",
       "surface": "apple",
@@ -34435,7 +34435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 303,
+      "line": 306,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Session Store",
       "surface": "apple",
@@ -34443,7 +34443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 309,
+      "line": 312,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Agent Events…",
       "surface": "apple",
@@ -34451,7 +34451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 314,
+      "line": 317,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Log",
       "surface": "apple",
@@ -34459,7 +34459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 319,
+      "line": 322,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Debug Voice Text",
       "surface": "apple",
@@ -34467,7 +34467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 324,
+      "line": 327,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Notification",
       "surface": "apple",
@@ -34475,7 +34475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 331,
+      "line": 334,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Gateway",
       "surface": "apple",
@@ -34483,7 +34483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 337,
+      "line": 340,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Onboarding",
       "surface": "apple",
@@ -34491,7 +34491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 342,
+      "line": 345,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart App",
       "surface": "apple",
@@ -34499,7 +34499,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 385,
+      "line": 391,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Main",
       "surface": "apple",
@@ -34507,7 +34507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 385,
+      "line": 391,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Other",
       "surface": "apple",
@@ -34515,7 +34515,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 459,
+      "line": 465,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show pairing requests",
       "surface": "apple",
@@ -34523,7 +34523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 484,
+      "line": 490,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Refreshing microphones…",
       "surface": "apple",
@@ -34531,7 +34531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 491,
+      "line": 497,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -34539,7 +34539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 516,
+      "line": 522,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -181,6 +181,9 @@ struct MenuContent: View {
         .task {
             VoicePushToTalkHotkey.shared.setEnabled(voiceWakeSupported && self.state.voicePushToTalkEnabled)
         }
+        .task {
+            await self.nodesStore.prepareLocalNodeIdentity()
+        }
         .onChange(of: self.state.voicePushToTalkEnabled) { _, enabled in
             VoicePushToTalkHotkey.shared.setEnabled(voiceWakeSupported && enabled)
         }
@@ -353,12 +356,15 @@ struct MenuContent: View {
         guard self.state.connectionMode != .unconfigured else { return nil }
         guard case .connected = self.controlChannel.state else { return nil }
 
-        guard let identity = DeviceIdentityStore.loadOrCreatePersisted(
-            profile: MacNodeModeCoordinator.nodeIdentityProfile)
-        else {
+        let deviceId: String
+        switch self.nodesStore.localNodeIdentityState {
+        case .loading:
+            return nil
+        case let .available(id):
+            deviceId = id
+        case .unavailable:
             return ("Mac identity unavailable", .red)
         }
-        let deviceId = identity.deviceId
         if let entry = self.nodesStore.nodes.first(where: { $0.nodeId == deviceId }) {
             guard entry.isConnected else {
                 return ("Mac capabilities offline", .orange)

--- a/apps/macos/Sources/OpenClaw/NodesStore.swift
+++ b/apps/macos/Sources/OpenClaw/NodesStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import OpenClawKit
 import OSLog
 
 struct NodeInfo: Identifiable, Codable {
@@ -36,6 +37,12 @@ private struct NodeListResponse: Codable {
     let nodes: [NodeInfo]
 }
 
+enum LocalNodeIdentityState: Equatable {
+    case loading
+    case available(String)
+    case unavailable
+}
+
 @MainActor
 @Observable
 final class NodesStore {
@@ -45,19 +52,80 @@ final class NodesStore {
     var lastError: String?
     var statusMessage: String?
     var isLoading = false
+    private(set) var localNodeIdentityState: LocalNodeIdentityState = .loading
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "nodes")
     private var task: Task<Void, Never>?
     private let interval: TimeInterval = 30
+    private let localNodeIdentityProfile: GatewayDeviceIdentityProfile
+    @ObservationIgnored private let localNodeIDLoader: @Sendable (GatewayDeviceIdentityProfile) -> String?
+    @ObservationIgnored private var localNodeIdentityLoad:
+        (generation: UInt64, task: Task<String?, Never>)?
+    @ObservationIgnored private var localNodeIdentityLoadGeneration: UInt64 = 0
+    @ObservationIgnored private var localNodeIdentityPreparationTask: Task<Void, Never>?
+
+    init(
+        localNodeIdentityProfile: GatewayDeviceIdentityProfile = MacNodeModeCoordinator.nodeIdentityProfile,
+        localNodeIDLoader: @escaping @Sendable (GatewayDeviceIdentityProfile) -> String? = { profile in
+            DeviceIdentityStore.loadOrCreatePersisted(profile: profile)?.deviceId
+        })
+    {
+        self.localNodeIdentityProfile = localNodeIdentityProfile
+        self.localNodeIDLoader = localNodeIDLoader
+    }
 
     func start() {
         guard self.task == nil else { return }
+        self.scheduleLocalNodeIdentityPreparation()
         SimpleTaskSupport.startDetachedLoop(task: &self.task, interval: self.interval) { [weak self] in
             await self?.refresh()
         }
     }
 
+    private func scheduleLocalNodeIdentityPreparation() {
+        guard self.localNodeIdentityPreparationTask == nil else { return }
+        guard case .available = self.localNodeIdentityState else {
+            // Retry on the node refresh lifecycle so transient storage failures recover
+            // without moving identity I/O back into SwiftUI view evaluation.
+            self.localNodeIdentityPreparationTask = Task { [weak self] in
+                guard let self else { return }
+                await self.prepareLocalNodeIdentity()
+                self.localNodeIdentityPreparationTask = nil
+            }
+            return
+        }
+    }
+
+    func prepareLocalNodeIdentity() async {
+        if case .available = self.localNodeIdentityState {
+            return
+        }
+
+        let generation: UInt64
+        let task: Task<String?, Never>
+        if let load = self.localNodeIdentityLoad {
+            generation = load.generation
+            task = load.task
+        } else {
+            self.localNodeIdentityState = .loading
+            self.localNodeIdentityLoadGeneration &+= 1
+            generation = self.localNodeIdentityLoadGeneration
+            let profile = self.localNodeIdentityProfile
+            let loader = self.localNodeIDLoader
+            task = Task.detached(priority: .utility) {
+                loader(profile)
+            }
+            self.localNodeIdentityLoad = (generation, task)
+        }
+
+        let nodeID = await task.value
+        guard self.localNodeIdentityLoad?.generation == generation else { return }
+        self.localNodeIdentityLoad = nil
+        self.localNodeIdentityState = nodeID.map(LocalNodeIdentityState.available) ?? .unavailable
+    }
+
     func refresh() async {
+        self.scheduleLocalNodeIdentityPreparation()
         if self.isLoading { return }
         self.statusMessage = nil
         self.isLoading = true

--- a/apps/macos/Tests/OpenClawIPCTests/NodesStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NodesStoreTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct NodesStoreTests {
+    @Test func `local node identity is prepared once`() async {
+        let loader = LocalNodeIdentityLoader(results: ["node-id"])
+        let store = NodesStore(
+            localNodeIdentityProfile: .node,
+            localNodeIDLoader: loader.load)
+
+        async let first: Void = store.prepareLocalNodeIdentity()
+        async let second: Void = store.prepareLocalNodeIdentity()
+        _ = await (first, second)
+        await store.prepareLocalNodeIdentity()
+
+        #expect(store.localNodeIdentityState == .available("node-id"))
+        #expect(loader.loadedProfiles == [.node])
+    }
+
+    @Test func `unavailable local node identity can be retried`() async {
+        let loader = LocalNodeIdentityLoader(results: [nil, "node-id"])
+        let store = NodesStore(
+            localNodeIdentityProfile: .primary,
+            localNodeIDLoader: loader.load)
+
+        await store.prepareLocalNodeIdentity()
+        #expect(store.localNodeIdentityState == .unavailable)
+
+        await store.prepareLocalNodeIdentity()
+        #expect(store.localNodeIdentityState == .available("node-id"))
+        #expect(loader.loadedProfiles == [.primary, .primary])
+    }
+}
+
+private final class LocalNodeIdentityLoader: @unchecked Sendable {
+    private let lock = NSLock()
+    private var results: [String?]
+    private var profiles: [GatewayDeviceIdentityProfile] = []
+
+    init(results: [String?]) {
+        self.results = results
+    }
+
+    var loadedProfiles: [GatewayDeviceIdentityProfile] {
+        self.lock.withLock { self.profiles }
+    }
+
+    func load(profile: GatewayDeviceIdentityProfile) -> String? {
+        self.lock.withLock {
+            self.profiles.append(profile)
+            return self.results.isEmpty ? nil : self.results.removeFirst()
+        }
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rendering the macOS menu could repeatedly resolve the local node identity, adding avoidable work to a frequent main-actor path.

Stack position: 2 of 7. Base: `perf/kova-stack-01-diagnostics`.

## Why This Change Was Made

`NodesStore` now prepares and retains the local identity snapshot, while preserving retries when identity is temporarily unavailable. Menu rendering consumes that prepared value instead of starting a fresh read.

## User Impact

Opening and refreshing the macOS menu performs less repeated identity work without changing the displayed identity or retry behavior.

## Evidence

- Focused macOS proof: `NodesStoreTests` passed as part of 98 tests across 7 suites
- Covers one-time preparation and retry after an unavailable identity
- SwiftFormat: clean
- Autoreview: clean
- TruffleHog: clean

AI assistance: Codex was used for investigation, implementation, and review. The resulting changes and evidence were manually inspected.
