### PR TITLE
fix(macos): coalesce Tailscale status checks

### DIFF
--- a/apps/macos/Sources/OpenClaw/TailscaleService.swift
+++ b/apps/macos/Sources/OpenClaw/TailscaleService.swift
@@ -8,13 +8,19 @@ import os
 @Observable
 @MainActor
 final class TailscaleService {
+    typealias InstallationProbe = @Sendable () -> Bool
+    typealias StatusDataLoader = @Sendable (URL) async throws -> (Data, URLResponse)
+    #if DEBUG
+    typealias StatusCheckJoinHandler = @Sendable () async -> Void
+    #endif
+
     static let shared = TailscaleService()
 
     /// Tailscale local API endpoint.
     private static let tailscaleAPIEndpoint = "http://100.100.100.100/api/data"
 
     /// API request timeout in seconds.
-    private static let apiTimeoutInterval: TimeInterval = 5.0
+    private nonisolated static let apiTimeoutInterval: TimeInterval = 5.0
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "tailscale")
 
@@ -36,7 +42,21 @@ final class TailscaleService {
     /// Error message if status check fails.
     private(set) var statusError: String?
 
+    @ObservationIgnored private let appInstallationProbe: InstallationProbe
+    @ObservationIgnored private let cliInstallationProbe: InstallationProbe
+    @ObservationIgnored private let statusDataLoader: StatusDataLoader
+    @ObservationIgnored private var statusCheckTask: Task<Void, Never>?
+    #if DEBUG
+    @ObservationIgnored private let statusCheckJoinHandler: StatusCheckJoinHandler?
+    #endif
+
     private init() {
+        self.appInstallationProbe = Self.detectAppInstallation
+        self.cliInstallationProbe = Self.detectCLIInstallation
+        self.statusDataLoader = Self.makeStatusDataLoader()
+        #if DEBUG
+        self.statusCheckJoinHandler = nil
+        #endif
         Task { await self.checkTailscaleStatus() }
     }
 
@@ -47,7 +67,11 @@ final class TailscaleService {
         isRunning: Bool,
         tailscaleHostname: String? = nil,
         tailscaleIP: String? = nil,
-        statusError: String? = nil)
+        statusError: String? = nil,
+        appInstallationProbe: @escaping InstallationProbe = TailscaleService.detectAppInstallation,
+        cliInstallationProbe: @escaping InstallationProbe = TailscaleService.detectCLIInstallation,
+        statusDataLoader: @escaping StatusDataLoader = TailscaleService.makeStatusDataLoader(),
+        statusCheckJoinHandler: StatusCheckJoinHandler? = nil)
     {
         self.isInstalled = isInstalled
         self.isAppInstalled = isAppInstalled
@@ -55,31 +79,26 @@ final class TailscaleService {
         self.tailscaleHostname = tailscaleHostname
         self.tailscaleIP = tailscaleIP
         self.statusError = statusError
+        self.appInstallationProbe = appInstallationProbe
+        self.cliInstallationProbe = cliInstallationProbe
+        self.statusDataLoader = statusDataLoader
+        self.statusCheckJoinHandler = statusCheckJoinHandler
     }
     #endif
 
     func checkAppInstallation() -> Bool {
-        let installed = FileManager().fileExists(atPath: "/Applications/Tailscale.app")
+        let installed = self.appInstallationProbe()
         self.logger.info("Tailscale app installed: \(installed)")
         return installed
     }
 
     func checkCLIInstallation() -> Bool {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        let candidates = [
-            "/usr/local/bin/tailscale",
-            "/usr/local/bin/tailscaled",
-            "/opt/homebrew/bin/tailscale",
-            "/opt/homebrew/bin/tailscaled",
-            "\(home)/go/bin/tailscale",
-            "\(home)/go/bin/tailscaled",
-        ]
-        let installed = Self.hasExecutableCLI(at: candidates)
+        let installed = self.cliInstallationProbe()
         self.logger.info("Tailscale CLI installed: \(installed)")
         return installed
     }
 
-    static func hasExecutableCLI(at candidates: [String]) -> Bool {
+    nonisolated static func hasExecutableCLI(at candidates: [String]) -> Bool {
         candidates.contains { FileManager.default.isExecutableFile(atPath: $0) }
     }
 
@@ -104,11 +123,7 @@ final class TailscaleService {
         }
 
         do {
-            let configuration = URLSessionConfiguration.default
-            configuration.timeoutIntervalForRequest = Self.apiTimeoutInterval
-            let session = URLSession(configuration: configuration)
-
-            let (data, response) = try await session.data(from: url)
+            let (data, response) = try await self.statusDataLoader(url)
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200
             else {
@@ -125,6 +140,28 @@ final class TailscaleService {
     }
 
     func checkTailscaleStatus() async {
+        // Every caller that awaits a refresh must observe the same completed
+        // status update; returning early here would expose stale state.
+        if let statusCheckTask = self.statusCheckTask {
+            #if DEBUG
+            if let statusCheckJoinHandler = self.statusCheckJoinHandler {
+                await statusCheckJoinHandler()
+            }
+            #endif
+            await statusCheckTask.value
+            return
+        }
+
+        let statusCheckTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.performTailscaleStatusCheck()
+        }
+        self.statusCheckTask = statusCheckTask
+        await statusCheckTask.value
+        self.statusCheckTask = nil
+    }
+
+    private func performTailscaleStatusCheck() async {
         let previousIP = self.tailscaleIP
         let appInstalled = self.checkAppInstallation()
         let cliInstalled = self.checkCLIInstallation()
@@ -225,5 +262,31 @@ final class TailscaleService {
 
     nonisolated static func fallbackTailnetIPv4() -> String? {
         TailscaleNetwork.detectTailnetIPv4()
+    }
+
+    private nonisolated static func detectAppInstallation() -> Bool {
+        FileManager().fileExists(atPath: "/Applications/Tailscale.app")
+    }
+
+    private nonisolated static func detectCLIInstallation() -> Bool {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let candidates = [
+            "/usr/local/bin/tailscale",
+            "/usr/local/bin/tailscaled",
+            "/opt/homebrew/bin/tailscale",
+            "/opt/homebrew/bin/tailscaled",
+            "\(home)/go/bin/tailscale",
+            "\(home)/go/bin/tailscaled",
+        ]
+        return Self.hasExecutableCLI(at: candidates)
+    }
+
+    private nonisolated static func makeStatusDataLoader() -> StatusDataLoader {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = Self.apiTimeoutInterval
+        let session = URLSession(configuration: configuration)
+        return { url in
+            try await session.data(from: url)
+        }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/TailscaleIntegrationSectionTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TailscaleIntegrationSectionTests.swift
@@ -88,6 +88,42 @@ struct TailscaleIntegrationSectionTests {
         #expect(service.statusError == nil)
     }
 
+    @Test func `concurrent status checks share one request`() async {
+        let loader = TailscaleStatusLoader()
+        let completion = TailscaleStatusCompletion()
+        let joinBarrier = TailscaleStatusJoinBarrier()
+        let service = TailscaleService(
+            isInstalled: true,
+            isRunning: true,
+            tailscaleHostname: "april.tail7a0b9.ts.net",
+            tailscaleIP: "100.66.5.88",
+            appInstallationProbe: { true },
+            cliInstallationProbe: { false },
+            statusDataLoader: loader.load,
+            statusCheckJoinHandler: { await joinBarrier.signal() })
+
+        let first = Task { await service.checkTailscaleStatus() }
+        await loader.waitForRequestStart()
+        let second = Task {
+            await service.checkTailscaleStatus()
+            await completion.markFinished()
+        }
+        await joinBarrier.wait()
+
+        #expect(await loader.requestCount == 1)
+        #expect(await completion.finishedCount == 0)
+
+        await loader.releaseRequest()
+        await first.value
+        await second.value
+
+        #expect(await completion.finishedCount == 1)
+        #expect(service.tailscaleIP == "100.66.5.88")
+
+        await service.checkTailscaleStatus()
+        #expect(await loader.requestCount == 2)
+    }
+
     @Test func `tailscale section builds body when not installed`() {
         let service = TailscaleService(isInstalled: false, isRunning: false, statusError: "not installed")
         var view = TailscaleIntegrationSection(connectionMode: .local, isPaused: false)
@@ -211,5 +247,77 @@ struct TailscaleIntegrationSectionTests {
         #expect(messages.validationMessage == nil)
         #expect(messages.shouldRecordSuccess == false)
         #expect(messages.shouldRestartGateway == false)
+    }
+}
+
+private actor TailscaleStatusLoader {
+    private(set) var requestCount = 0
+    private var requestStartedContinuations: [CheckedContinuation<Void, Never>] = []
+    private var requestContinuation: CheckedContinuation<Void, Never>?
+    private var shouldSuspendRequest = true
+
+    func load(url: URL) async throws -> (Data, URLResponse) {
+        self.requestCount += 1
+        for continuation in self.requestStartedContinuations {
+            continuation.resume()
+        }
+        self.requestStartedContinuations.removeAll()
+        if self.shouldSuspendRequest {
+            self.shouldSuspendRequest = false
+            await withCheckedContinuation { continuation in
+                self.requestContinuation = continuation
+            }
+        }
+        let data = try JSONEncoder().encode(
+            TailscaleService.TailscaleAPIResponse(
+                status: "Running",
+                deviceName: "april",
+                tailnetName: "tail7a0b9.ts.net",
+                iPv4: "100.66.5.88"))
+        let response = try #require(
+            HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil))
+        return (data, response)
+    }
+
+    func waitForRequestStart() async {
+        guard self.requestCount == 0 else { return }
+        await withCheckedContinuation { continuation in
+            self.requestStartedContinuations.append(continuation)
+        }
+    }
+
+    func releaseRequest() {
+        self.requestContinuation?.resume()
+        self.requestContinuation = nil
+    }
+}
+
+private actor TailscaleStatusCompletion {
+    private(set) var finishedCount = 0
+
+    func markFinished() {
+        self.finishedCount += 1
+    }
+}
+
+private actor TailscaleStatusJoinBarrier {
+    private var joined = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func signal() {
+        self.joined = true
+        self.continuation?.resume()
+        self.continuation = nil
+    }
+
+    func wait() async {
+        guard !self.joined else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Concurrent macOS settings and status refreshes could launch duplicate Tailscale status probes.

## Why This Change Was Made

The Tailscale service now coalesces overlapping status requests behind one in-flight task while preserving CLI detection, daemon-state handling, and interface fallback behavior.

## User Impact

Concurrent Tailscale UI refreshes avoid duplicate process and network work while returning the same completed status result to every caller.

## Evidence

- Exact head: `32cdbdc9ee3d49340135baa1c598bac015ab3b8a`
- Focused macOS proof: all 11 `TailscaleIntegrationSectionTests` passed
- Concurrent-request coverage proves one shared request, both callers await completion, and a later refresh starts a new request
- SwiftFormat: clean
- SwiftLint strict: clean
- `git diff --check origin/main...HEAD`: clean
- Fresh Codex autoreview: clean, no actionable findings
- TruffleHog pre-review scan: clean

AI assistance: Codex was used for investigation, implementation, and review. The resulting changes and evidence were manually inspected.
