### PR TITLE
improve(macos): reuse Gateway search path discovery

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -32987,7 +32987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 195,
+      "line": 217,
       "path": "apps/macos/Sources/OpenClaw/GatewayEnvironment.swift",
       "source": " (local: \\(projectEntrypoint ?? \"unknown\"))",
       "surface": "apple",
@@ -32995,7 +32995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 199,
+      "line": 221,
       "path": "apps/macos/Sources/OpenClaw/GatewayEnvironment.swift",
       "source": "(\\(gatewayLabel))",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
@@ -96,6 +96,16 @@ struct GatewayCommandResolution {
 }
 
 enum GatewayEnvironment {
+    private enum CommandSource {
+        case executable(String)
+        case project(runtime: RuntimeResolution, entrypoint: String)
+    }
+
+    private struct EnvironmentResolution {
+        let status: GatewayEnvironmentStatus
+        let commandSource: CommandSource?
+    }
+
     private static let logger = Logger(subsystem: "ai.openclaw", category: "gateway.env")
     private static let supportedBindModes: Set<String> = ["loopback", "tailnet", "lan", "auto"]
 
@@ -133,6 +143,11 @@ enum GatewayEnvironment {
     }
 
     static func check() async -> GatewayEnvironmentStatus {
+        let searchPaths = await CommandResolver.preferredPathsAsync()
+        return await self.resolveEnvironment(searchPaths: searchPaths).status
+    }
+
+    private static func resolveEnvironment(searchPaths: [String]) async -> EnvironmentResolution {
         let start = Date()
         defer {
             let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
@@ -148,44 +163,51 @@ enum GatewayEnvironment {
         let projectRoot = CommandResolver.projectRoot()
         let projectEntrypoint = CommandResolver.gatewayEntrypoint(in: projectRoot)
 
-        switch await RuntimeLocator.resolve(searchPaths: CommandResolver.preferredPaths()) {
+        switch await RuntimeLocator.resolve(searchPaths: searchPaths) {
         case let .failure(err):
-            return GatewayEnvironmentStatus(
-                kind: .missingNode,
-                nodeVersion: nil,
-                gatewayVersion: nil,
-                requiredGateway: expectedString,
-                message: RuntimeLocator.describeFailure(err))
-        case let .success(runtime):
-            let gatewayBin = CommandResolver.openclawExecutable()
-
-            if gatewayBin == nil, projectEntrypoint == nil {
-                return GatewayEnvironmentStatus(
-                    kind: .missingGateway,
-                    nodeVersion: runtime.version.description,
+            return EnvironmentResolution(
+                status: GatewayEnvironmentStatus(
+                    kind: .missingNode,
+                    nodeVersion: nil,
                     gatewayVersion: nil,
                     requiredGateway: expectedString,
-                    message: "openclaw CLI not found in PATH; install the CLI.")
+                    message: RuntimeLocator.describeFailure(err)),
+                commandSource: nil)
+        case let .success(runtime):
+            let gatewayBin = CommandResolver.openclawExecutable(searchPaths: searchPaths)
+
+            if gatewayBin == nil, projectEntrypoint == nil {
+                return EnvironmentResolution(
+                    status: GatewayEnvironmentStatus(
+                        kind: .missingGateway,
+                        nodeVersion: runtime.version.description,
+                        gatewayVersion: nil,
+                        requiredGateway: expectedString,
+                        message: "openclaw CLI not found in PATH; install the CLI."),
+                    commandSource: nil)
             }
 
             let installedRaw = await self.installedGatewayVersion(
                 gatewayBin: gatewayBin,
-                projectRoot: projectRoot)
+                projectRoot: projectRoot,
+                searchPaths: searchPaths)
             let installed = Semver.parse(installedRaw)
 
             if let expected, let installedRaw, installed != nil,
                !Semver.satisfiesExpectedGatewayVersion(installed: installedRaw, expected: expectedString)
             {
                 let expectedText = expectedString ?? expected.description
-                return GatewayEnvironmentStatus(
-                    kind: .incompatible(found: installedRaw, required: expectedText),
-                    nodeVersion: runtime.version.description,
-                    gatewayVersion: installedRaw,
-                    requiredGateway: expectedText,
-                    message: """
-                    Gateway version \(installedRaw) is incompatible with app \(expectedText);
-                    install or update the global package.
-                    """)
+                return EnvironmentResolution(
+                    status: GatewayEnvironmentStatus(
+                        kind: .incompatible(found: installedRaw, required: expectedText),
+                        nodeVersion: runtime.version.description,
+                        gatewayVersion: installedRaw,
+                        requiredGateway: expectedText,
+                        message: """
+                        Gateway version \(installedRaw) is incompatible with app \(expectedText);
+                        install or update the global package.
+                        """),
+                    commandSource: nil)
             }
 
             let gatewayLabel = gatewayBin != nil ? "global" : "local"
@@ -197,16 +219,28 @@ enum GatewayEnvironment {
             let gatewayLabelText = gatewayBin != nil
                 ? "(\(gatewayLabel))"
                 : localPathHint.isEmpty ? "(\(gatewayLabel))" : localPathHint
-            return GatewayEnvironmentStatus(
-                kind: .ok,
-                nodeVersion: runtime.version.description,
-                gatewayVersion: gatewayVersionText,
-                requiredGateway: expectedString,
-                message: "Node \(runtime.version.description); gateway \(gatewayVersionText) \(gatewayLabelText)")
+            let commandSource: CommandSource? = if let gatewayBin {
+                CommandSource.executable(gatewayBin)
+            } else if let projectEntrypoint {
+                CommandSource.project(runtime: runtime, entrypoint: projectEntrypoint)
+            } else {
+                nil
+            }
+            return EnvironmentResolution(
+                status: GatewayEnvironmentStatus(
+                    kind: .ok,
+                    nodeVersion: runtime.version.description,
+                    gatewayVersion: gatewayVersionText,
+                    requiredGateway: expectedString,
+                    message: "Node \(runtime.version.description); gateway \(gatewayVersionText) \(gatewayLabelText)"),
+                commandSource: commandSource)
         }
     }
 
-    static func resolveGatewayCommand() async -> GatewayCommandResolution {
+    static func resolveGatewayCommand(
+        searchPathsProvider: @Sendable () async -> [String] = CommandResolver.preferredPathsAsync) async
+        -> GatewayCommandResolution
+    {
         let start = Date()
         defer {
             let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
@@ -216,32 +250,25 @@ enum GatewayEnvironment {
                 self.logger.debug("gateway command resolve ok (\(elapsedMs, privacy: .public)ms)")
             }
         }
-        let projectRoot = CommandResolver.projectRoot()
-        let projectEntrypoint = CommandResolver.gatewayEntrypoint(in: projectRoot)
-        let status = await self.check()
-        let gatewayBin = CommandResolver.openclawExecutable()
-        let runtime = await RuntimeLocator.resolve(searchPaths: CommandResolver.preferredPaths())
+        let searchPaths = await searchPathsProvider()
+        let environment = await self.resolveEnvironment(searchPaths: searchPaths)
 
-        guard case .ok = status.kind else {
-            return GatewayCommandResolution(status: status, command: nil)
+        guard case .ok = environment.status.kind else {
+            return GatewayCommandResolution(status: environment.status, command: nil)
         }
 
         let port = self.gatewayPort()
-        if let gatewayBin {
-            let bind = self.preferredGatewayBind() ?? "loopback"
+        let bind = self.preferredGatewayBind() ?? "loopback"
+        switch environment.commandSource {
+        case let .executable(gatewayBin):
             let cmd = [gatewayBin, "gateway", "--port", "\(port)", "--bind", bind]
-            return GatewayCommandResolution(status: status, command: cmd)
+            return GatewayCommandResolution(status: environment.status, command: cmd)
+        case let .project(runtime, entrypoint):
+            let cmd = [runtime.path, entrypoint, "gateway", "--port", "\(port)", "--bind", bind]
+            return GatewayCommandResolution(status: environment.status, command: cmd)
+        case nil:
+            return GatewayCommandResolution(status: environment.status, command: nil)
         }
-
-        if let entry = projectEntrypoint,
-           case let .success(resolvedRuntime) = runtime
-        {
-            let bind = self.preferredGatewayBind() ?? "loopback"
-            let cmd = [resolvedRuntime.path, entry, "gateway", "--port", "\(port)", "--bind", bind]
-            return GatewayCommandResolution(status: status, command: cmd)
-        }
-
-        return GatewayCommandResolution(status: status, command: nil)
     }
 
     private static func preferredGatewayBind() -> String? {
@@ -285,20 +312,26 @@ enum GatewayEnvironment {
         return normalized
     }
 
-    static func installedGatewayVersion(gatewayBin: String?, projectRoot: URL) async -> String? {
-        if let gatewayBin, let version = await self.readGatewayVersion(binary: gatewayBin) {
+    static func installedGatewayVersion(
+        gatewayBin: String?,
+        projectRoot: URL,
+        searchPaths: [String]) async -> String?
+    {
+        if let gatewayBin,
+           let version = await self.readGatewayVersion(binary: gatewayBin, searchPaths: searchPaths)
+        {
             return version
         }
         return self.readLocalGatewayVersion(projectRoot: projectRoot)
     }
 
-    private static func readGatewayVersion(binary: String) async -> String? {
+    private static func readGatewayVersion(binary: String, searchPaths: [String]) async -> String? {
         let start = Date()
         do {
             let result = try await BoundedProcess.run(
                 path: binary,
                 arguments: ["--version"],
-                environment: ["PATH": CommandResolver.preferredPaths().joined(separator: ":")],
+                environment: ["PATH": searchPaths.joined(separator: ":")],
                 timeout: 2)
             let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)
             if elapsedMs > 500 {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
@@ -3,6 +3,21 @@ import Testing
 @testable import OpenClaw
 
 struct GatewayEnvironmentTests {
+    private final class LockedCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        func increment() {
+            self.lock.withLock {
+                self.count += 1
+            }
+        }
+
+        func value() -> Int {
+            self.lock.withLock { self.count }
+        }
+    }
+
     @Test func `semver parses common forms`() {
         #expect(Semver.parse("1.2.3") == Semver(major: 1, minor: 2, patch: 3))
         #expect(Semver.parse("  v1.2.3  \n") == Semver(major: 1, minor: 2, patch: 3))
@@ -51,9 +66,48 @@ struct GatewayEnvironmentTests {
 
         let version = await GatewayEnvironment.installedGatewayVersion(
             gatewayBin: "/usr/bin/false",
-            projectRoot: projectRoot)
+            projectRoot: projectRoot,
+            searchPaths: ["/usr/bin"])
 
         #expect(version == "2026.7.29")
+    }
+
+    @Test func `gateway launch resolution scans preferred paths once`() async throws {
+        let root = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        let node = bin.appendingPathComponent("node")
+        let gateway = bin.appendingPathComponent("openclaw")
+        try makeExecutableForTests(at: node)
+        try makeExecutableForTests(at: gateway)
+        try "#!/bin/sh\necho v24.15.0\n".write(to: node, atomically: true, encoding: .utf8)
+        let expectedVersion = GatewayEnvironment.expectedGatewayVersionString()
+        let gatewayVersion = expectedVersion.flatMap { Semver.parse($0) == nil ? nil : $0 } ?? "2026.7.30"
+        try "#!/bin/sh\necho OpenClaw \(gatewayVersion)\n"
+            .write(to: gateway, atomically: true, encoding: .utf8)
+
+        let scans = LockedCounter()
+        let resolution = await GatewayEnvironment.resolveGatewayCommand(searchPathsProvider: {
+            scans.increment()
+            return [bin.path]
+        })
+
+        #expect(scans.value() == 1)
+        #expect(resolution.status.kind == .ok)
+        #expect(resolution.status.gatewayVersion == gatewayVersion)
+        #expect(resolution.command?.first == gateway.path)
+    }
+
+    @Test func `failed gateway launch resolution scans preferred paths once`() async {
+        let scans = LockedCounter()
+        let resolution = await GatewayEnvironment.resolveGatewayCommand(searchPathsProvider: {
+            scans.increment()
+            return ["/missing/\(UUID().uuidString)"]
+        })
+
+        #expect(scans.value() == 1)
+        #expect(resolution.status.kind == .missingNode)
+        #expect(resolution.command == nil)
     }
 
     @Test func `semver compatibility requires same major and not older`() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repeated macOS Gateway launch and version resolution could rescan the same preferred executable paths within one process.

Stack position: 5 of 7. Base: `perf/kova-stack-04-refresh-cancellation`.

## Why This Change Was Made

Gateway resolution now prepares one process-stable search-path snapshot and reuses it across launch and version probes. Resolution results still reflect each probe's executable and version checks.

## User Impact

Repeated Gateway discovery avoids redundant filesystem path enumeration, reducing background startup and refresh work.

## Evidence

- Focused macOS proof: `GatewayEnvironmentTests` passed as part of 98 tests across 7 suites
- Covers successful and failed resolution scanning preferred paths once
- SwiftFormat: clean
- Autoreview: clean
- TruffleHog: clean

AI assistance: Codex was used for investigation, implementation, and review. The resulting changes and evidence were manually inspected.
