### PR TITLE
improve(macos): reuse Claude session discovery across pages

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeClaudeSessionCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeClaudeSessionCatalog.swift
@@ -165,6 +165,79 @@ enum MacNodeClaudeSessionCatalog {
         }
     }
 
+    private struct SessionFileSnapshotKey: Hashable {
+        var rootPath: String
+        var threadId: String
+    }
+
+    private struct SessionFileSnapshotEntry {
+        var fileURL: URL
+        var generation: UInt64
+    }
+
+    private final class SessionFileSnapshot: @unchecked Sendable {
+        private let lock = NSLock()
+        private var entries: [SessionFileSnapshotKey: SessionFileSnapshotEntry] = [:]
+        private var generation: UInt64 = 0
+
+        func lookup(rootPath: String, threadId: String) -> URL? {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            let key = SessionFileSnapshotKey(rootPath: rootPath, threadId: threadId)
+            guard var entry = self.entries[key] else { return nil }
+            self.generation &+= 1
+            entry.generation = self.generation
+            self.entries[key] = entry
+            return entry.fileURL
+        }
+
+        func replace(rootPath: String, records: [SessionRecord]) {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            self.entries = self.entries.filter { $0.key.rootPath != rootPath }
+            for record in records.prefix(MacNodeClaudeSessionCatalog.maxSessionFileSnapshotEntries) {
+                self.generation &+= 1
+                let key = SessionFileSnapshotKey(rootPath: rootPath, threadId: record.threadId)
+                self.entries[key] = SessionFileSnapshotEntry(
+                    fileURL: record.fileURL,
+                    generation: self.generation)
+            }
+            let overflow = self.entries.count - MacNodeClaudeSessionCatalog.maxSessionFileSnapshotEntries
+            guard overflow > 0 else { return }
+            let oldest = self.entries.sorted { $0.value.generation < $1.value.generation }
+                .prefix(overflow)
+            for entry in oldest {
+                self.entries.removeValue(forKey: entry.key)
+            }
+        }
+
+        func remove(rootPath: String, threadId: String) {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            self.entries.removeValue(forKey: SessionFileSnapshotKey(
+                rootPath: rootPath,
+                threadId: threadId))
+        }
+    }
+
+    private final class CatalogEnumerationObserver: @unchecked Sendable {
+        private let lock = NSLock()
+        private var observer: (@Sendable (String) -> Void)?
+
+        func set(_ observer: (@Sendable (String) -> Void)?) {
+            self.lock.lock()
+            self.observer = observer
+            self.lock.unlock()
+        }
+
+        func notify(rootPath: String) {
+            self.lock.lock()
+            let observer = self.observer
+            self.lock.unlock()
+            observer?(rootPath)
+        }
+    }
+
     private static let defaultPageLimit = 50
     private static let maxPageLimit = 100
     private static let defaultReadLimit = 20
@@ -174,6 +247,7 @@ enum MacNodeClaudeSessionCatalog {
     private static let maxSearchLength = 500
     private static let maxCatalogDiscoveryFiles = 10000
     fileprivate static let maxCatalogDiscoveryCacheEntries = 20000
+    fileprivate static let maxSessionFileSnapshotEntries = 20000
     private static let metadataPrefixBytes = 1024 * 1024
     private static let metadataReadChunkBytes = 16 * 1024
     private static let maxCatalogMetadataScanBytes = 64 * 1024 * 1024
@@ -186,6 +260,14 @@ enum MacNodeClaudeSessionCatalog {
     private static let iso8601FractionalStyle = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
     private static let iso8601Style = Date.ISO8601FormatStyle()
     private static let catalogDiscoveryCache = CatalogDiscoveryCache()
+    private static let sessionFileSnapshot = SessionFileSnapshot()
+    private static let catalogEnumerationObserver = CatalogEnumerationObserver()
+
+    static func setCatalogEnumerationObserverForTesting(
+        _ observer: (@Sendable (String) -> Void)?)
+    {
+        self.catalogEnumerationObserver.set(observer)
+    }
 
     static func shouldAdvertise(
         root: [String: Any]? = nil,
@@ -240,8 +322,9 @@ enum MacNodeClaudeSessionCatalog {
     static func read(paramsJSON: String?, homeURL: URL) throws -> String {
         try Task.checkCancellation()
         let params = try decodeReadParams(paramsJSON)
-        guard let fileURL = try sessions(homeURL: homeURL)
-            .first(where: { $0.threadId == params.threadId })?.fileURL
+        guard let fileURL = try sessionFileForRead(
+            homeURL: homeURL,
+            threadId: params.threadId)
         else { throw CatalogError.invalidParams("Claude session is unavailable") }
 
         let handle = try FileHandle(forReadingFrom: fileURL)
@@ -414,6 +497,52 @@ extension MacNodeClaudeSessionCatalog {
               !isDirectory.boolValue
         else { return nil }
         return resolvedCandidate
+    }
+
+    private static func revalidatedSessionFile(
+        homeURL: URL,
+        threadId: String,
+        candidate: URL) -> URL?
+    {
+        let resolvedRoot = self.projectsURL(homeURL: homeURL).resolvingSymlinksInPath()
+        guard let fileURL = self.safeSessionFile(
+            root: resolvedRoot,
+            resolvedRoot: resolvedRoot,
+            candidate: candidate,
+            sessionId: threadId),
+            FileManager.default.isReadableFile(atPath: fileURL.path)
+        else { return nil }
+        return fileURL
+    }
+
+    private static func sessionFileForRead(homeURL: URL, threadId: String) throws -> URL? {
+        let rootPath = self.projectsURL(homeURL: homeURL).standardizedFileURL.path
+        if let candidate = self.sessionFileSnapshot.lookup(
+            rootPath: rootPath,
+            threadId: threadId)
+        {
+            // Discovery owns archive, sidechain, and entrypoint eligibility.
+            // Reads only revalidate the selected file so transcript pagination
+            // does not rebuild the catalog; the next discovery replaces this snapshot.
+            if let fileURL = self.revalidatedSessionFile(
+                homeURL: homeURL,
+                threadId: threadId,
+                candidate: candidate)
+            {
+                return fileURL
+            }
+            self.sessionFileSnapshot.remove(rootPath: rootPath, threadId: threadId)
+        }
+
+        // A miss or stale path gets one complete refresh. Do not recurse if the
+        // refreshed record is already gone or fails the same security checks.
+        guard let candidate = try self.sessions(homeURL: homeURL)
+            .first(where: { $0.threadId == threadId })?.fileURL
+        else { return nil }
+        return self.revalidatedSessionFile(
+            homeURL: homeURL,
+            threadId: threadId,
+            candidate: candidate)
     }
 
     private static func desktopMetadata(homeURL: URL) throws -> (
@@ -685,6 +814,8 @@ extension MacNodeClaudeSessionCatalog {
     private static func sessions(homeURL: URL) throws -> [SessionRecord] {
         try Task.checkCancellation()
         let projectsURL = self.projectsURL(homeURL: homeURL)
+        let rootPath = projectsURL.standardizedFileURL.path
+        self.catalogEnumerationObserver.notify(rootPath: rootPath)
         let resolvedProjectsURL = projectsURL.resolvingSymlinksInPath()
         var records: [String: SessionRecord] = [:]
         var sidechainIds = Set<String>()
@@ -761,11 +892,13 @@ extension MacNodeClaudeSessionCatalog {
             record.source = "claude-desktop"
             records[sessionId] = record
         }
-        return records.values.sorted { left, right in
+        let sortedRecords = records.values.sorted { left, right in
             let leftTime = left.updatedAt ?? 0
             let rightTime = right.updatedAt ?? 0
             return leftTime == rightTime ? left.threadId < right.threadId : leftTime > rightTime
         }
+        self.sessionFileSnapshot.replace(rootPath: rootPath, records: sortedRecords)
+        return sortedRecords
     }
 
     private static func locateSessionFile(homeURL: URL, sessionId: String) throws -> URL? {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeClaudeSessionCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeClaudeSessionCatalog.swift
@@ -333,11 +333,12 @@ enum MacNodeClaudeSessionCatalog {
         try Task.checkCancellation()
         let params = try decodeReadParams(paramsJSON)
         let cursor = try params.cursor.map(self.decodeTranscriptCursor)
-        guard let fileURL = try sessionFileForRead(
+        guard let target = try sessionFileForRead(
             homeURL: homeURL,
             threadId: params.threadId,
             leaseId: cursor?.leaseId)
         else { throw CatalogError.invalidParams("Claude session is unavailable") }
+        let fileURL = target.fileURL
 
         let handle = try FileHandle(forReadingFrom: fileURL)
         defer { try? handle.close() }
@@ -427,7 +428,7 @@ enum MacNodeClaudeSessionCatalog {
             "items": selected.map(\.item),
         ]
         if hasEarlierItems, let earliest = selected.last?.start, earliest > 0 {
-            let leaseId = cursor?.leaseId ?? self.transcriptReadLeases.store(
+            let leaseId = target.leaseId ?? self.transcriptReadLeases.store(
                 rootPath: self.projectsURL(homeURL: homeURL).standardizedFileURL.path,
                 threadId: params.threadId,
                 fileURL: fileURL)
@@ -535,11 +536,11 @@ extension MacNodeClaudeSessionCatalog {
     private static func sessionFileForRead(
         homeURL: URL,
         threadId: String,
-        leaseId: String?) throws -> URL?
+        leaseId: String?) throws -> (fileURL: URL, leaseId: String?)?
     {
         let rootPath = self.projectsURL(homeURL: homeURL).standardizedFileURL.path
         if let leaseId {
-            guard let candidate = self.transcriptReadLeases.lookup(
+            if let candidate = self.transcriptReadLeases.lookup(
                 leaseId: leaseId,
                 rootPath: rootPath,
                 threadId: threadId),
@@ -547,20 +548,23 @@ extension MacNodeClaudeSessionCatalog {
                     homeURL: homeURL,
                     threadId: threadId,
                     candidate: candidate)
-            else {
-                self.transcriptReadLeases.remove(leaseId: leaseId)
-                throw CatalogError.invalidParams("transcript cursor is invalid")
+            {
+                return (fileURL, leaseId)
             }
-            return fileURL
+            // A lease is only an optimization. App restart, expiry, eviction, or
+            // a moved file must fall back to current eligibility discovery.
+            self.transcriptReadLeases.remove(leaseId: leaseId)
         }
 
         guard let candidate = try self.sessions(homeURL: homeURL)
             .first(where: { $0.threadId == threadId })?.fileURL
         else { return nil }
-        return self.revalidatedSessionFile(
+        guard let fileURL = self.revalidatedSessionFile(
             homeURL: homeURL,
             threadId: threadId,
             candidate: candidate)
+        else { return nil }
+        return (fileURL, nil)
     }
 
     private static func desktopMetadata(homeURL: URL) throws -> (

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeClaudeSessionCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeClaudeSessionCatalog.swift
@@ -46,6 +46,11 @@ enum MacNodeClaudeSessionCatalog {
         var limit = 20
     }
 
+    private struct TranscriptCursor {
+        var offset: Int
+        var leaseId: String?
+    }
+
     private struct SessionRecord {
         var threadId: String
         var name: String?
@@ -165,58 +170,62 @@ enum MacNodeClaudeSessionCatalog {
         }
     }
 
-    private struct SessionFileSnapshotKey: Hashable {
+    private struct TranscriptReadLease {
         var rootPath: String
         var threadId: String
-    }
-
-    private struct SessionFileSnapshotEntry {
         var fileURL: URL
+        var expiresAt: Date
         var generation: UInt64
     }
 
-    private final class SessionFileSnapshot: @unchecked Sendable {
+    private final class TranscriptReadLeaseCache: @unchecked Sendable {
         private let lock = NSLock()
-        private var entries: [SessionFileSnapshotKey: SessionFileSnapshotEntry] = [:]
+        private var entries: [String: TranscriptReadLease] = [:]
         private var generation: UInt64 = 0
 
-        func lookup(rootPath: String, threadId: String) -> URL? {
+        func lookup(leaseId: String, rootPath: String, threadId: String) -> URL? {
             self.lock.lock()
             defer { self.lock.unlock() }
-            let key = SessionFileSnapshotKey(rootPath: rootPath, threadId: threadId)
-            guard var entry = self.entries[key] else { return nil }
+            guard var entry = self.entries[leaseId],
+                  entry.rootPath == rootPath,
+                  entry.threadId == threadId,
+                  entry.expiresAt > Date()
+            else {
+                self.entries.removeValue(forKey: leaseId)
+                return nil
+            }
             self.generation &+= 1
             entry.generation = self.generation
-            self.entries[key] = entry
+            self.entries[leaseId] = entry
             return entry.fileURL
         }
 
-        func replace(rootPath: String, records: [SessionRecord]) {
+        func store(rootPath: String, threadId: String, fileURL: URL) -> String {
             self.lock.lock()
             defer { self.lock.unlock() }
-            self.entries = self.entries.filter { $0.key.rootPath != rootPath }
-            for record in records.prefix(MacNodeClaudeSessionCatalog.maxSessionFileSnapshotEntries) {
-                self.generation &+= 1
-                let key = SessionFileSnapshotKey(rootPath: rootPath, threadId: record.threadId)
-                self.entries[key] = SessionFileSnapshotEntry(
-                    fileURL: record.fileURL,
-                    generation: self.generation)
-            }
-            let overflow = self.entries.count - MacNodeClaudeSessionCatalog.maxSessionFileSnapshotEntries
-            guard overflow > 0 else { return }
+            self.generation &+= 1
+            let leaseId = UUID().uuidString
+            self.entries[leaseId] = TranscriptReadLease(
+                rootPath: rootPath,
+                threadId: threadId,
+                fileURL: fileURL,
+                expiresAt: Date().addingTimeInterval(
+                    MacNodeClaudeSessionCatalog.transcriptReadLeaseLifetimeSeconds),
+                generation: self.generation)
+            let overflow = self.entries.count - MacNodeClaudeSessionCatalog.maxTranscriptReadLeases
+            guard overflow > 0 else { return leaseId }
             let oldest = self.entries.sorted { $0.value.generation < $1.value.generation }
                 .prefix(overflow)
             for entry in oldest {
                 self.entries.removeValue(forKey: entry.key)
             }
+            return leaseId
         }
 
-        func remove(rootPath: String, threadId: String) {
+        func remove(leaseId: String) {
             self.lock.lock()
             defer { self.lock.unlock() }
-            self.entries.removeValue(forKey: SessionFileSnapshotKey(
-                rootPath: rootPath,
-                threadId: threadId))
+            self.entries.removeValue(forKey: leaseId)
         }
     }
 
@@ -247,7 +256,8 @@ enum MacNodeClaudeSessionCatalog {
     private static let maxSearchLength = 500
     private static let maxCatalogDiscoveryFiles = 10000
     fileprivate static let maxCatalogDiscoveryCacheEntries = 20000
-    fileprivate static let maxSessionFileSnapshotEntries = 20000
+    private static let maxTranscriptReadLeases = 256
+    private static let transcriptReadLeaseLifetimeSeconds: TimeInterval = 120
     private static let metadataPrefixBytes = 1024 * 1024
     private static let metadataReadChunkBytes = 16 * 1024
     private static let maxCatalogMetadataScanBytes = 64 * 1024 * 1024
@@ -260,7 +270,7 @@ enum MacNodeClaudeSessionCatalog {
     private static let iso8601FractionalStyle = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
     private static let iso8601Style = Date.ISO8601FormatStyle()
     private static let catalogDiscoveryCache = CatalogDiscoveryCache()
-    private static let sessionFileSnapshot = SessionFileSnapshot()
+    private static let transcriptReadLeases = TranscriptReadLeaseCache()
     private static let catalogEnumerationObserver = CatalogEnumerationObserver()
 
     static func setCatalogEnumerationObserverForTesting(
@@ -322,16 +332,17 @@ enum MacNodeClaudeSessionCatalog {
     static func read(paramsJSON: String?, homeURL: URL) throws -> String {
         try Task.checkCancellation()
         let params = try decodeReadParams(paramsJSON)
+        let cursor = try params.cursor.map(self.decodeTranscriptCursor)
         guard let fileURL = try sessionFileForRead(
             homeURL: homeURL,
-            threadId: params.threadId)
+            threadId: params.threadId,
+            leaseId: cursor?.leaseId)
         else { throw CatalogError.invalidParams("Claude session is unavailable") }
 
         let handle = try FileHandle(forReadingFrom: fileURL)
         defer { try? handle.close() }
         let fileSize = try handle.seekToEnd()
-        let requestedEnd = try params.cursor.map { try self.decodeCursor($0, label: "transcript") }
-        let end = UInt64(requestedEnd ?? Int(fileSize))
+        let end = UInt64(cursor?.offset ?? Int(fileSize))
         guard end <= fileSize else {
             throw CatalogError.invalidParams("transcript cursor is invalid")
         }
@@ -416,7 +427,13 @@ enum MacNodeClaudeSessionCatalog {
             "items": selected.map(\.item),
         ]
         if hasEarlierItems, let earliest = selected.last?.start, earliest > 0 {
-            response["nextCursor"] = try encodeCursor(Int(earliest))
+            let leaseId = cursor?.leaseId ?? self.transcriptReadLeases.store(
+                rootPath: self.projectsURL(homeURL: homeURL).standardizedFileURL.path,
+                threadId: params.threadId,
+                fileURL: fileURL)
+            response["nextCursor"] = try encodeTranscriptCursor(
+                offset: Int(earliest),
+                leaseId: leaseId)
         }
         return try encode(response)
     }
@@ -515,27 +532,28 @@ extension MacNodeClaudeSessionCatalog {
         return fileURL
     }
 
-    private static func sessionFileForRead(homeURL: URL, threadId: String) throws -> URL? {
+    private static func sessionFileForRead(
+        homeURL: URL,
+        threadId: String,
+        leaseId: String?) throws -> URL?
+    {
         let rootPath = self.projectsURL(homeURL: homeURL).standardizedFileURL.path
-        if let candidate = self.sessionFileSnapshot.lookup(
-            rootPath: rootPath,
-            threadId: threadId)
-        {
-            // Discovery owns archive, sidechain, and entrypoint eligibility.
-            // Reads only revalidate the selected file so transcript pagination
-            // does not rebuild the catalog; the next discovery replaces this snapshot.
-            if let fileURL = self.revalidatedSessionFile(
-                homeURL: homeURL,
-                threadId: threadId,
-                candidate: candidate)
-            {
-                return fileURL
+        if let leaseId {
+            guard let candidate = self.transcriptReadLeases.lookup(
+                leaseId: leaseId,
+                rootPath: rootPath,
+                threadId: threadId),
+                let fileURL = self.revalidatedSessionFile(
+                    homeURL: homeURL,
+                    threadId: threadId,
+                    candidate: candidate)
+            else {
+                self.transcriptReadLeases.remove(leaseId: leaseId)
+                throw CatalogError.invalidParams("transcript cursor is invalid")
             }
-            self.sessionFileSnapshot.remove(rootPath: rootPath, threadId: threadId)
+            return fileURL
         }
 
-        // A miss or stale path gets one complete refresh. Do not recurse if the
-        // refreshed record is already gone or fails the same security checks.
         guard let candidate = try self.sessions(homeURL: homeURL)
             .first(where: { $0.threadId == threadId })?.fileURL
         else { return nil }
@@ -892,13 +910,11 @@ extension MacNodeClaudeSessionCatalog {
             record.source = "claude-desktop"
             records[sessionId] = record
         }
-        let sortedRecords = records.values.sorted { left, right in
+        return records.values.sorted { left, right in
             let leftTime = left.updatedAt ?? 0
             let rightTime = right.updatedAt ?? 0
             return leftTime == rightTime ? left.threadId < right.threadId : leftTime > rightTime
         }
-        self.sessionFileSnapshot.replace(rootPath: rootPath, records: sortedRecords)
-        return sortedRecords
     }
 
     private static func locateSessionFile(homeURL: URL, sessionId: String) throws -> URL? {
@@ -971,14 +987,48 @@ extension MacNodeClaudeSessionCatalog {
 
     private static func encodeCursor(_ offset: Int) throws -> String {
         let data = try JSONSerialization.data(withJSONObject: ["offset": offset], options: [.sortedKeys])
-        return data.base64EncodedString()
+        return self.encodeCursorData(data)
+    }
+
+    private static func encodeTranscriptCursor(offset: Int, leaseId: String) throws -> String {
+        let data = try JSONSerialization.data(
+            withJSONObject: [
+                "lease": leaseId,
+                "offset": offset,
+            ],
+            options: [.sortedKeys])
+        return self.encodeCursorData(data)
+    }
+
+    private static func encodeCursorData(_ data: Data) -> String {
+        data.base64EncodedString()
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
     }
 
+    private static func decodeTranscriptCursor(_ cursor: String) throws -> TranscriptCursor {
+        let value = try self.decodeCursorObject(cursor, label: "transcript")
+        guard let offset = value["offset"] as? NSNumber,
+              offset.intValue >= 0
+        else { throw CatalogError.invalidParams("transcript cursor is invalid") }
+        let leaseId = self.string(value["lease"], maxLength: 64)
+        if value["lease"] != nil, leaseId == nil {
+            throw CatalogError.invalidParams("transcript cursor is invalid")
+        }
+        return TranscriptCursor(offset: offset.intValue, leaseId: leaseId)
+    }
+
     private static func decodeCursor(_ cursor: String?, label: String) throws -> Int {
         guard let cursor else { return 0 }
+        let value = try self.decodeCursorObject(cursor, label: label)
+        guard let offset = value["offset"] as? NSNumber,
+              offset.intValue >= 0
+        else { throw CatalogError.invalidParams("\(label) cursor is invalid") }
+        return offset.intValue
+    }
+
+    private static func decodeCursorObject(_ cursor: String, label: String) throws -> [String: Any] {
         guard cursor.count <= self.maxCursorLength else {
             throw CatalogError.invalidParams("\(label) cursor is invalid")
         }
@@ -986,11 +1036,9 @@ extension MacNodeClaudeSessionCatalog {
             .replacingOccurrences(of: "_", with: "/")
         base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
         guard let data = Data(base64Encoded: base64),
-              let value = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let offset = value["offset"] as? NSNumber,
-              offset.intValue >= 0
+              let value = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { throw CatalogError.invalidParams("\(label) cursor is invalid") }
-        return offset.intValue
+        return value
     }
 
     private static func encode(_ value: [String: Any], maxBytes: Int? = nil) throws -> String {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeClaudeSessionCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeClaudeSessionCatalogTests.swift
@@ -457,6 +457,77 @@ struct MacNodeClaudeSessionCatalogTests {
         #expect(enumerations.value() == 1)
     }
 
+    @Test func `missing pagination lease falls back to current discovery`() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let project = home.appendingPathComponent(".claude/projects/-workspace", isDirectory: true)
+        try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+        let sessionId = "lease-session"
+        let transcript = project.appendingPathComponent("\(sessionId).jsonl")
+        try writeJSON(
+            [
+                "version": 1,
+                "entries": [[
+                    "sessionId": sessionId,
+                    "fullPath": transcript.path,
+                    "isSidechain": false,
+                ]],
+            ],
+            to: project.appendingPathComponent("sessions-index.json")
+        )
+        try writeTranscript([
+            message(sessionId: sessionId, role: "user", text: "old", index: 1),
+            message(sessionId: sessionId, role: "assistant", text: "new", index: 2),
+        ], to: transcript)
+
+        let enumerations = EnumerationCounter()
+        MacNodeClaudeSessionCatalog.setCatalogEnumerationObserverForTesting { rootPath in
+            if rootPath == home.appendingPathComponent(".claude/projects").standardizedFileURL.path {
+                enumerations.increment()
+            }
+        }
+        defer { MacNodeClaudeSessionCatalog.setCatalogEnumerationObserverForTesting(nil) }
+
+        let firstJSON = try MacNodeClaudeSessionCatalog.read(
+            paramsJSON: #"{"threadId":"lease-session","limit":1}"#,
+            homeURL: home
+        )
+        let first = try #require(
+            JSONSerialization.jsonObject(with: Data(firstJSON.utf8)) as? [String: Any]
+        )
+        var encoded = try #require(first["nextCursor"] as? String)
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        encoded += String(repeating: "=", count: (4 - encoded.count % 4) % 4)
+        let cursorData = try #require(Data(base64Encoded: encoded))
+        var cursorValue = try #require(
+            JSONSerialization.jsonObject(with: cursorData) as? [String: Any]
+        )
+        cursorValue["lease"] = UUID().uuidString
+        let missingLeaseCursor = try JSONSerialization.data(
+            withJSONObject: cursorValue,
+            options: [.sortedKeys]
+        ).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+
+        let secondParams = try #require(String(
+            data: JSONSerialization.data(withJSONObject: [
+                "threadId": sessionId,
+                "limit": 1,
+                "cursor": missingLeaseCursor,
+            ]),
+            encoding: .utf8
+        ))
+        let secondJSON = try MacNodeClaudeSessionCatalog.read(paramsJSON: secondParams, homeURL: home)
+        let second = try #require(
+            JSONSerialization.jsonObject(with: Data(secondJSON.utf8)) as? [String: Any]
+        )
+        #expect((second["items"] as? [[String: Any]])?.first?["text"] as? String == "old")
+        #expect(enumerations.value() == 2)
+    }
+
     @Test func `fresh reads recheck catalog eligibility after a pagination lease`() throws {
         let home = try makeHome()
         defer { try? FileManager.default.removeItem(at: home) }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeClaudeSessionCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeClaudeSessionCatalogTests.swift
@@ -390,7 +390,7 @@ struct MacNodeClaudeSessionCatalogTests {
         #expect((refreshed["sessions"] as? [[String: Any]])?.first?["name"] as? String == "Bravo")
     }
 
-    @Test func `reuses catalog discovery across transcript read pages`() throws {
+    @Test func `reuses catalog discovery only across transcript read pages`() throws {
         let home = try makeHome()
         defer { try? FileManager.default.removeItem(at: home) }
         let project = home.appendingPathComponent(".claude/projects/-workspace", isDirectory: true)
@@ -426,8 +426,6 @@ struct MacNodeClaudeSessionCatalogTests {
             }
         }
         defer { MacNodeClaudeSessionCatalog.setCatalogEnumerationObserverForTesting(nil) }
-        _ = try MacNodeClaudeSessionCatalog.list(paramsJSON: nil, homeURL: home)
-        #expect(enumerations.value() == 1)
 
         let latestJSON = try MacNodeClaudeSessionCatalog.read(
             paramsJSON: #"{"threadId":"transcript-session","limit":2}"#,
@@ -459,7 +457,60 @@ struct MacNodeClaudeSessionCatalogTests {
         #expect(enumerations.value() == 1)
     }
 
-    @Test func `missing and stale file snapshots refresh the catalog once`() throws {
+    @Test func `fresh reads recheck catalog eligibility after a pagination lease`() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let project = home.appendingPathComponent(".claude/projects/-workspace", isDirectory: true)
+        try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+        let sessionId = "eligibility-session"
+        let transcript = project.appendingPathComponent("\(sessionId).jsonl")
+        let index = project.appendingPathComponent("sessions-index.json")
+        try writeTranscript([
+            message(sessionId: sessionId, role: "user", text: "old", index: 1),
+            message(sessionId: sessionId, role: "assistant", text: "new", index: 2),
+        ], to: transcript)
+        try writeJSON(
+            [
+                "version": 1,
+                "entries": [[
+                    "sessionId": sessionId,
+                    "fullPath": transcript.path,
+                    "isSidechain": false,
+                ]],
+            ],
+            to: index
+        )
+
+        let firstJSON = try MacNodeClaudeSessionCatalog.read(
+            paramsJSON: #"{"threadId":"eligibility-session","limit":1}"#,
+            homeURL: home
+        )
+        let first = try #require(
+            JSONSerialization.jsonObject(with: Data(firstJSON.utf8)) as? [String: Any]
+        )
+        #expect(first["nextCursor"] is String)
+
+        try writeJSON(
+            [
+                "version": 1,
+                "entries": [[
+                    "sessionId": sessionId,
+                    "fullPath": transcript.path,
+                    "isSidechain": true,
+                ]],
+            ],
+            to: index
+        )
+
+        #expect(throws: MacNodeClaudeSessionCatalog.CatalogError.self) {
+            try MacNodeClaudeSessionCatalog.read(
+                paramsJSON: #"{"threadId":"eligibility-session","limit":1}"#,
+                homeURL: home
+            )
+        }
+    }
+
+    @Test func `fresh reads discover a moved session file`() throws {
         let home = try makeHome()
         defer { try? FileManager.default.removeItem(at: home) }
         let firstProject = home.appendingPathComponent(".claude/projects/-first", isDirectory: true)
@@ -536,7 +587,7 @@ struct MacNodeClaudeSessionCatalogTests {
             paramsJSON: #"{"threadId":"moving-session","limit":1}"#,
             homeURL: home
         )
-        #expect(enumerations.value() == 2)
+        #expect(enumerations.value() == 3)
     }
 
     @Test func `bounds oversized transcript items by encoded response size`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeClaudeSessionCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeClaudeSessionCatalogTests.swift
@@ -4,6 +4,23 @@ import Testing
 
 @Suite(.serialized)
 struct MacNodeClaudeSessionCatalogTests {
+    private final class EnumerationCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        func increment() {
+            lock.lock()
+            count += 1
+            lock.unlock()
+        }
+
+        func value() -> Int {
+            lock.lock()
+            defer { self.lock.unlock() }
+            return count
+        }
+    }
+
     private func makeHome() throws -> URL {
         let home = FileManager.default.temporaryDirectory
             .appendingPathComponent("openclaw-claude-home-\(UUID().uuidString)", isDirectory: true)
@@ -373,8 +390,7 @@ struct MacNodeClaudeSessionCatalogTests {
         #expect((refreshed["sessions"] as? [[String: Any]])?.first?["name"] as? String == "Bravo")
     }
 
-
-    @Test func `reads transcript pages backward without loading the whole history`() throws {
+    @Test func `reuses catalog discovery across transcript read pages`() throws {
         let home = try makeHome()
         defer { try? FileManager.default.removeItem(at: home) }
         let project = home.appendingPathComponent(".claude/projects/-workspace", isDirectory: true)
@@ -403,6 +419,16 @@ struct MacNodeClaudeSessionCatalogTests {
             message(sessionId: sessionId, role: "assistant", text: "new assistant", index: 4),
         ], to: transcript)
 
+        let enumerations = EnumerationCounter()
+        MacNodeClaudeSessionCatalog.setCatalogEnumerationObserverForTesting { rootPath in
+            if rootPath == home.appendingPathComponent(".claude/projects").standardizedFileURL.path {
+                enumerations.increment()
+            }
+        }
+        defer { MacNodeClaudeSessionCatalog.setCatalogEnumerationObserverForTesting(nil) }
+        _ = try MacNodeClaudeSessionCatalog.list(paramsJSON: nil, homeURL: home)
+        #expect(enumerations.value() == 1)
+
         let latestJSON = try MacNodeClaudeSessionCatalog.read(
             paramsJSON: #"{"threadId":"transcript-session","limit":2}"#,
             homeURL: home
@@ -413,6 +439,7 @@ struct MacNodeClaudeSessionCatalogTests {
         let latestItems = try #require(latest["items"] as? [[String: Any]])
         #expect(latestItems.map { $0["text"] as? String } == ["new assistant", "new user"])
         let cursor = try #require(latest["nextCursor"] as? String)
+        #expect(enumerations.value() == 1)
 
         let olderParams = try #require(String(
             data: JSONSerialization.data(withJSONObject: [
@@ -429,6 +456,87 @@ struct MacNodeClaudeSessionCatalogTests {
         let olderItems = try #require(older["items"] as? [[String: Any]])
         #expect(olderItems.map { $0["text"] as? String } == ["old assistant", oldUser])
         #expect(older["nextCursor"] == nil)
+        #expect(enumerations.value() == 1)
+    }
+
+    @Test func `missing and stale file snapshots refresh the catalog once`() throws {
+        let home = try makeHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let firstProject = home.appendingPathComponent(".claude/projects/-first", isDirectory: true)
+        let secondProject = home.appendingPathComponent(".claude/projects/-second", isDirectory: true)
+        try FileManager.default.createDirectory(at: firstProject, withIntermediateDirectories: true)
+        let sessionId = "moving-session"
+        let firstTranscript = firstProject.appendingPathComponent("\(sessionId).jsonl")
+        try writeTranscript([
+            message(sessionId: sessionId, role: "user", text: "first location", index: 1),
+            message(sessionId: sessionId, role: "assistant", text: "latest", index: 2),
+        ], to: firstTranscript)
+        try writeJSON(
+            [
+                "version": 1,
+                "entries": [[
+                    "sessionId": sessionId,
+                    "fullPath": firstTranscript.path,
+                    "summary": "Moving",
+                    "isSidechain": false,
+                ]],
+            ],
+            to: firstProject.appendingPathComponent("sessions-index.json")
+        )
+
+        let enumerations = EnumerationCounter()
+        MacNodeClaudeSessionCatalog.setCatalogEnumerationObserverForTesting { rootPath in
+            if rootPath == home.appendingPathComponent(".claude/projects").standardizedFileURL.path {
+                enumerations.increment()
+            }
+        }
+        defer { MacNodeClaudeSessionCatalog.setCatalogEnumerationObserverForTesting(nil) }
+
+        let firstRead = try MacNodeClaudeSessionCatalog.read(
+            paramsJSON: #"{"threadId":"moving-session","limit":1}"#,
+            homeURL: home
+        )
+        let firstPayload = try #require(
+            JSONSerialization.jsonObject(with: Data(firstRead.utf8)) as? [String: Any]
+        )
+        #expect((firstPayload["items"] as? [[String: Any]])?.first?["text"] as? String == "latest")
+        #expect(enumerations.value() == 1)
+
+        try FileManager.default.createDirectory(at: secondProject, withIntermediateDirectories: true)
+        let secondTranscript = secondProject.appendingPathComponent("\(sessionId).jsonl")
+        try FileManager.default.moveItem(at: firstTranscript, to: secondTranscript)
+        try writeJSON(
+            ["version": 1, "entries": []],
+            to: firstProject.appendingPathComponent("sessions-index.json")
+        )
+        try writeJSON(
+            [
+                "version": 1,
+                "entries": [[
+                    "sessionId": sessionId,
+                    "fullPath": secondTranscript.path,
+                    "summary": "Moving",
+                    "isSidechain": false,
+                ]],
+            ],
+            to: secondProject.appendingPathComponent("sessions-index.json")
+        )
+
+        let refreshedRead = try MacNodeClaudeSessionCatalog.read(
+            paramsJSON: #"{"threadId":"moving-session","limit":1}"#,
+            homeURL: home
+        )
+        let refreshedPayload = try #require(
+            JSONSerialization.jsonObject(with: Data(refreshedRead.utf8)) as? [String: Any]
+        )
+        #expect((refreshedPayload["items"] as? [[String: Any]])?.first?["text"] as? String == "latest")
+        #expect(enumerations.value() == 2)
+
+        _ = try MacNodeClaudeSessionCatalog.read(
+            paramsJSON: #"{"threadId":"moving-session","limit":1}"#,
+            homeURL: home
+        )
+        #expect(enumerations.value() == 2)
     }
 
     @Test func `bounds oversized transcript items by encoded response size`() throws {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where each page of a macOS Claude transcript read could re-enumerate the full Claude session catalog.

Stack position: 6 of 7. Base: `perf/kova-stack-05-gateway-path`.

## Why This Change Was Made

Pagination cursors can now carry a bounded, short-lived read lease for the already-selected transcript. Cached paths are revalidated before use; fresh reads still perform current eligibility discovery, and missing, expired, evicted, or restart-lost leases fall back to discovery instead of breaking the cursor.

## User Impact

Reading multi-page Claude transcripts avoids repeated catalog scans without weakening archived-session, sidechain, path-containment, or file-replacement checks.

## Evidence

- Focused macOS proof: `MacNodeClaudeSessionCatalogTests` passed as part of 98 tests across 7 suites
- Covers pagination reuse, fresh-read eligibility, moved files, lease loss, replacement, cancellation, and response bounds
- SwiftFormat: clean
- Final autoreview: clean, 0.91 confidence
- TruffleHog: clean

AI assistance: Codex was used for investigation, implementation, and review. The resulting changes and evidence were manually inspected.
