### PR TITLE
fix(beam): release mirror response bodies

### DIFF
--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -87,7 +87,7 @@ function fakeRuntime(config: unknown): PluginRuntime {
 
 type SentRequest = { url: string; auth?: string; payload: BeamMirrorUpload };
 
-function captureFetch(sent: SentRequest[], status = 200): typeof fetch {
+function captureFetch(sent: SentRequest[], status = 200, onCancel?: () => void): typeof fetch {
   return (async (url: unknown, init?: RequestInit) => {
     const headers = (init?.headers ?? {}) as Record<string, string>;
     sent.push({
@@ -95,7 +95,12 @@ function captureFetch(sent: SentRequest[], status = 200): typeof fetch {
       ...(headers.Authorization ? { auth: headers.Authorization } : {}),
       payload: JSON.parse(init?.body as string) as BeamMirrorUpload,
     });
-    return new Response("{}", { status });
+    return new Response(
+      new ReadableStream({
+        cancel: onCancel,
+      }),
+      { status },
+    );
   }) as typeof fetch;
 }
 
@@ -334,6 +339,29 @@ describe("createBeamMirrorRunner", () => {
     // Both ticks retry because the failed upload was never fingerprinted.
     expect(sent).toHaveLength(2);
     expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  it.each([200, 503])("cancels the response body after an upload returns %i", async (status) => {
+    const sent: SentRequest[] = [];
+    let cancelCount = 0;
+    const catalog = fakeCatalog({
+      id: "claude",
+      sessions: [{ threadId: "t1", recencyAt: NOW - 60_000 }],
+    });
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: silentLogger,
+      fetchFn: captureFetch(sent, status, () => {
+        cancelCount += 1;
+      }),
+      now: () => NOW,
+      listCatalogs: () => [catalog],
+    });
+
+    await runner.tick();
+
+    expect(sent).toHaveLength(1);
+    expect(cancelCount).toBe(1);
   });
 
   it("skips ticks when a configured token cannot be resolved", async () => {

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -293,11 +293,15 @@ export function createBeamMirrorRunner(params: {
       },
       body: JSON.stringify(payload),
     });
-    if (!response.ok) {
-      warnThrottled(`beam mirror upload failed (${response.status}) for ${payload.source}`);
-      return false;
+    try {
+      if (!response.ok) {
+        warnThrottled(`beam mirror upload failed (${response.status}) for ${payload.source}`);
+        return false;
+      }
+      return true;
+    } finally {
+      await response.body?.cancel().catch(() => undefined);
     }
-    return true;
   };
 
   const buildUpload = async (


### PR DESCRIPTION
Closes #116154

## What Problem This Solves

Beam mirror uploads inspect only the HTTP status and leave the response body unread. With a slow or non-terminating receiver and a constrained connection pool, that response can retain the only connection and stall later mirror retries.

## Why This Change Was Made

Always cancel the unused fetch response body in a `finally` block for both successful and failed uploads. Beam needs only the status code, so this releases the connection without changing warning or retry tracking behavior.

## User Impact

Beam mirroring can continue making progress after slow or error responses instead of silently stalling subsequent retries. There are no configuration, protocol, or persistence changes.

## Evidence

- Base: `2e1bf01f51f4fa65fab8b4c809e0d5b20cd5ea5d`
- Head: `76d77c4432f`
- Environment: macOS arm64; local loopback HTTP server; no credentials or external services. Repository checks used Node 24.14.0 and locked Undici 8.9.0. The standalone connection-pool reproduction also reproduced with Node 22.23.0 / Undici 8.6.0.
- Setup: a one-connection Undici dispatcher targets a local server that returns `503` headers and a response body that never completes. Two production `createBeamMirrorRunner` ticks are then attempted.
- Before, on the base commit: `{"head":"2e1bf01f51f","firstTick":"completed","secondTick":"blocked","requests":1}`
- After, on this change: `{"head":"76d77c4432f","firstTick":"completed","secondTick":"completed","requests":2}`
- The Undici response-body contract requires callers to consume or cancel bodies; Beam does not consume response payloads.
- Regression coverage verifies cancellation for both `200` and `503` responses.
- Focused and adjacent tests: 24 passed across `extensions/beam/src/mirror.test.ts` and `extensions/beam/src/beam.test.ts`.
- Extension production and test type checks passed.
- Formatting, lint, `git diff --check`, and secret scanning passed.
- Local autoreview: no findings; patch correct with 0.98 confidence.