### PR TITLE
fix(agents): pre-warm assemble before returning raw messages on heartbeat

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -679,7 +679,7 @@ describe("installContextEngineLoopHook", () => {
 
     expect(transformed).toBe(messages);
     expect(engine.afterTurn).not.toHaveBeenCalled();
-    expect(engine.assemble).not.toHaveBeenCalled();
+    expect(engine.assemble).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the pressure guard active around ownsCompaction loop assembly", async () => {
@@ -876,7 +876,7 @@ describe("installContextEngineLoopHook", () => {
     const afterTurnParams = recordMockArg(engine.afterTurn);
     expect(afterTurnParams?.prePromptMessageCount).toBe(2);
     expect(afterTurnParams?.messages).toBe(withNew);
-    expect(engine.assemble).toHaveBeenCalledTimes(1);
+    expect(engine.assemble).toHaveBeenCalledTimes(2);
   });
 
   it("advances the fence across multiple iterations", async () => {
@@ -925,7 +925,7 @@ describe("installContextEngineLoopHook", () => {
     await callTransform(agent, messages);
 
     expect(engine.afterTurn).not.toHaveBeenCalled();
-    expect(engine.assemble).not.toHaveBeenCalled();
+    expect(engine.assemble).toHaveBeenCalledTimes(3);
   });
 
   it("returns the assembled view when its length differs from the source", async () => {
@@ -991,7 +991,7 @@ describe("installContextEngineLoopHook", () => {
       firstResultText: "r",
     });
 
-    expect(recordMockArg(engine.assemble).messages).toBe(withNew);
+    expect(recordMockArg(engine.assemble, 1).messages).toBe(withNew);
     expect(transformed).not.toBe(withNew);
     expect(transformed).toEqual([expect.objectContaining({ role: "user", content: "first" })]);
     expect((transformed as AgentMessage[]).some((message) => message.role === "toolResult")).toBe(
@@ -1146,7 +1146,7 @@ describe("installContextEngineLoopHook", () => {
     expect(recordMockArg(ingestBatch).isHeartbeat).toBe(true);
     expect(recordMockArg(ingestBatch, 1).messages).toEqual(batch2.slice(4));
     expect(recordMockArg(ingestBatch, 1).isHeartbeat).toBe(true);
-    expect(engine.assemble).toHaveBeenCalledTimes(2);
+    expect(engine.assemble).toHaveBeenCalledTimes(3);
   });
 
   it("falls back to per-message ingest when ingestBatch is absent", async () => {
@@ -1255,7 +1255,7 @@ describe("installContextEngineLoopHook", () => {
     // Retry with same messages: should return cached assembled view, not raw
     const retryResult = await callTransform(agent, withNew);
     expect(retryResult).toBe(compactedView);
-    expect(engine.assemble).toHaveBeenCalledTimes(1);
+    expect(engine.assemble).toHaveBeenCalledTimes(2);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -385,7 +385,34 @@ export function installContextEngineLoopHook(params: {
     if (!hasNewMessages) {
       lastSeenLength = prePromptMessageCount;
       lastSourceMessages = transcriptMessages;
-      return lastAssembledView ?? providerMessages;
+      if (lastAssembledView) {
+        return lastAssembledView;
+      }
+      if (contextEngine) {
+        const assembled = await contextEngine.assemble({
+          sessionId,
+          sessionKey,
+          messages: providerMessages,
+          tokenBudget,
+          model: modelId,
+          runtimeSettings: params.runtimeSettings,
+        });
+        if (
+          assembled &&
+          Array.isArray(assembled.messages) &&
+          assembled.messages !== providerMessages
+        ) {
+          lastAssembledView = assembled.messages;
+          log.warn(
+            `[context-engine] transformContext: no new messages, pre-warm assemble succeeded ` +
+              `sessionId=${sessionId} before=${providerMessages.length} after=${assembled.messages.length} ` +
+              `beforeToolResults=${providerMessages.filter((m: any) => m?.role === "toolResult").length} ` +
+              `afterToolResults=${assembled.messages.filter((m: any) => m?.role === "toolResult").length}`,
+          );
+          return assembled.messages;
+        }
+      }
+      return providerMessages;
     }
     try {
       if (typeof contextEngine.afterTurn === "function") {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -389,27 +389,34 @@ export function installContextEngineLoopHook(params: {
         return lastAssembledView;
       }
       if (contextEngine) {
-        const assembled = await contextEngine.assemble({
-          sessionId,
-          sessionKey,
-          messages: providerMessages,
-          tokenBudget,
-          model: modelId,
-          runtimeSettings: params.runtimeSettings,
-        });
-        if (
-          assembled &&
-          Array.isArray(assembled.messages) &&
-          assembled.messages !== providerMessages
-        ) {
-          lastAssembledView = assembled.messages;
+        try {
+          const assembled = await contextEngine.assemble({
+            sessionId,
+            sessionKey,
+            messages: providerMessages,
+            tokenBudget,
+            model: modelId,
+            runtimeSettings: params.runtimeSettings,
+          });
+          if (
+            assembled &&
+            Array.isArray(assembled.messages) &&
+            assembled.messages !== providerMessages
+          ) {
+            lastAssembledView = assembled.messages;
+            log.warn(
+              `[context-engine] transformContext: no new messages, pre-warm assemble succeeded ` +
+                `sessionId=${sessionId} before=${providerMessages.length} after=${assembled.messages.length} ` +
+                `beforeToolResults=${providerMessages.filter((m: any) => m?.role === "toolResult").length} ` +
+                `afterToolResults=${assembled.messages.filter((m: any) => m?.role === "toolResult").length}`,
+            );
+            return assembled.messages;
+          }
+        } catch {
           log.warn(
-            `[context-engine] transformContext: no new messages, pre-warm assemble succeeded ` +
-              `sessionId=${sessionId} before=${providerMessages.length} after=${assembled.messages.length} ` +
-              `beforeToolResults=${providerMessages.filter((m: any) => m?.role === "toolResult").length} ` +
-              `afterToolResults=${assembled.messages.filter((m: any) => m?.role === "toolResult").length}`,
+            `[context-engine] transformContext: no new messages, pre-warm assemble failed — falling back to raw messages ` +
+              `sessionId=${sessionId} error=assemble threw`,
           );
-          return assembled.messages;
         }
       }
       return providerMessages;


### PR DESCRIPTION
## What Problem This Solves

When a context engine (e.g. lossless-claw) owns compaction, `transformContext` in `installContextEngineLoopHook` skips `assemble()` when `hasNewMessages=false && lastAssembledView=null`, returning the full raw session message list (~2000 messages with ~485 tool results). This affects heartbeat/background sessions where each new hour triggers `sourceHistoryChanged=true` → `lastAssembledView=null`, but the heartbeat message was already counted in `prePromptMessageCount` → `hasNewMessages=false`. The transport layer then estimates ~391K input tokens against a 128K context window, clamping `max_tokens` to 1 via `remainingBudget = max(1, contextWindow - estimatedInput - 1)`.

After the first model call fails/drops, the tool loop produces new messages → `hasNewMessages=true` → `assemble()` finally runs and compresses the context. But this wastes one model call per hour and can cause visible output truncation for CJK-heavy sessions.

## Real environment tested

Production Co-Claw deployment, Linux x64, Node 24.13.1. Provider: ZTE MaaS (Qwen3-235B-A22B). Session: 4-month heartbeat session with 2000+ messages, 485+ tool results, mostly CJK content (auto-approve-visitor script output).

## Exact steps or command run after this patch

1. Build with `pnpm build:min`
2. Deploy patched binary to production
3. Wait 3 consecutive heartbeat cycles (12:07, 13:07, 14:07 UTC+8)
4. Collect runtime logs via the session log export tool

## Evidence after fix

Before fix - first model call of each hour returns raw messages:

```
[context-engine] transformContext: no new messages, no cached assembled view — returning raw providerMessages
  sessionId=... totalMessages=1993 toolResultCount=485 rawChars=1251669 estimatedTokens=391147
```

After fix - first model call now receives compressed context:

```
[context-engine] transformContext: no new messages, pre-warm assemble succeeded
  sessionId=... before=2003 after=47 beforeToolResults=488 afterToolResults=8
```

Verified across 3 consecutive heartbeat cycles:

| Time (UTC+8) | Before (msgs/toolResults) | After (msgs/toolResults) | Estimated tokens |
|---|---|---|---|
| 12:07 | 2003 / 488 | 47 / 8 | 57K |
| 13:07 | 2013 / 492 | 57 / 12 | 58K |
| 14:07 | 2017 / 493 | 61 / 13 | 59K |

Transport layer after fix (no `clamp_max_tokens`):

```
[completions] payload_messages messageCount=48 toolResultCount=0 estimatedInputTokens=56871 effectiveContext=128000
```

## What was not tested

- Sessions without context engine (not applicable — the `contextEngine` guard skips the new code)
- Normal interactive sessions (behavior unchanged — `hasNewMessages=true` takes existing path)
- Animated/visual proof (runtime log evidence is sufficient for this behavioral fix)
## Behavior addressed

Heartbeat session output truncation caused by `transformContext` returning raw session messages when `hasNewMessages=false && lastAssembledView=null`. The fix pre-warms `assemble()` to return compressed context instead of ~2000 raw messages.

## Environment tested

- OS: Linux x64
- Runtime: Node 24.13.1
- Provider: ZTE MaaS (Qwen3-235B-A22B)
- Plugin: lossless-claw with `ownsCompaction=true`