### PR TITLE
fix(signal): infer managed bind port from loopback httpUrl when absent (#116165)

### DIFF
--- a/extensions/signal/doctor-contract-api.test.ts
+++ b/extensions/signal/doctor-contract-api.test.ts
@@ -458,7 +458,8 @@ describe("signal transport compatibility", () => {
       kind: "managed-native",
       url: "http://signal:8080",
     });
-    expect(result.config.channels?.signal?.transport?.httpPort).toBeUndefined();
+    const transport = result.config.channels?.signal?.transport;
+    expect(transport?.kind === "managed-native" ? transport.httpPort : "no-port").toBeUndefined();
   });
 
   it("reserves managed bind and local connection ports during migration", () => {

--- a/extensions/signal/doctor-contract-api.test.ts
+++ b/extensions/signal/doctor-contract-api.test.ts
@@ -403,6 +403,64 @@ describe("signal transport compatibility", () => {
     });
   });
 
+  it("infers the managed bind port from a loopback httpUrl when httpPort is absent", () => {
+    // autoStart=true with a loopback httpUrl on a non-default port and no
+    // httpPort: the managed daemon must bind the URL's port so daemon bind and
+    // client probe agree (issue #116165). Before the fix the migrated transport
+    // carried the 8082 url but no httpPort, so the daemon bound 8080.
+    const result = normalizeCompatibilityConfig({
+      cfg: signalConfig({
+        apiMode: "native",
+        autoStart: true,
+        account: "+15555550123",
+        httpUrl: "http://127.0.0.1:8082",
+      }),
+    });
+
+    expect(result.config.channels?.signal?.transport).toMatchObject({
+      kind: "managed-native",
+      url: "http://127.0.0.1:8082",
+      httpPort: 8082,
+    });
+  });
+
+  it("infers the managed bind port from a localhost httpUrl alias", () => {
+    const result = normalizeCompatibilityConfig({
+      cfg: signalConfig({
+        apiMode: "native",
+        autoStart: true,
+        account: "+15555550123",
+        httpUrl: "http://localhost:9090",
+      }),
+    });
+
+    expect(result.config.channels?.signal?.transport).toMatchObject({
+      kind: "managed-native",
+      url: "http://localhost:9090",
+      httpPort: 9090,
+    });
+  });
+
+  it("does not infer a bind port from a non-loopback httpUrl", () => {
+    // A non-loopback connection URL is an external endpoint, not a bind target;
+    // resolveLocalSignalTransportPort returns undefined so no httpPort is set
+    // and behavior is unchanged.
+    const result = normalizeCompatibilityConfig({
+      cfg: signalConfig({
+        apiMode: "native",
+        autoStart: true,
+        account: "+15555550123",
+        httpUrl: "http://signal:8080",
+      }),
+    });
+
+    expect(result.config.channels?.signal?.transport).toMatchObject({
+      kind: "managed-native",
+      url: "http://signal:8080",
+    });
+    expect(result.config.channels?.signal?.transport?.httpPort).toBeUndefined();
+  });
+
   it("reserves managed bind and local connection ports during migration", () => {
     const result = normalizeCompatibilityConfig({
       cfg: signalConfig({

--- a/extensions/signal/src/config-compat.ts
+++ b/extensions/signal/src/config-compat.ts
@@ -226,7 +226,14 @@ function buildManagedNativeTransport(
   const cliPath = optionalString(value("cliPath"));
   const url = resolveManagedConnectionUrl(entry, parent);
   const httpHost = optionalString(value("httpHost"));
-  const httpPort = value("httpPort");
+  // Infer the daemon bind port from a loopback httpUrl when httpPort is absent
+  // so the managed daemon and the client probe URL agree (issue #116165).
+  // resolveLocalSignalTransportPort returns undefined for non-loopback hosts,
+  // so a remote connection URL is left without an inferred bind port.
+  const rawHttpPort = value("httpPort");
+  const inferredHttpPort =
+    typeof rawHttpPort !== "number" && url ? resolveLocalSignalTransportPort(url) : undefined;
+  const httpPort = typeof rawHttpPort === "number" ? rawHttpPort : inferredHttpPort;
   const startupTimeoutMs = value("startupTimeoutMs");
   const receiveMode = value("receiveMode");
   const ignoreStories = value("ignoreStories");


### PR DESCRIPTION
## What Problem This Solves

Signal config `{ channels: { signal: { httpUrl: "http://127.0.0.1:8082", autoStart: true } } }` (no `httpPort`) caused the managed `signal-cli` daemon to bind the default port 8080 while OpenClaw's client/probe used the `httpUrl` port 8082. Diagnostics split into two seemingly unrelated failures (daemon init failed on 8080; client probe couldn't reach 8082). Setting `httpPort=8082` aligned them.

Fixes #116165

## Why This Change Was Made

The Signal plugin migrated to a `transport` object; legacy `httpUrl`/`httpPort`/`autoStart` are migrated by the doctor compat layer (`config-compat.ts`). `buildManagedNativeTransport` carried the `url` (8082) into the migrated transport but omitted `httpPort` when it was absent — so downstream `monitor.ts` bound 8080 (`httpPort ?? 8080`) while `accounts.ts` derived `baseUrl` from `transport.url` (8082).

The fix infers `httpPort` from a loopback `httpUrl` during migration, reusing the existing `resolveLocalSignalTransportPort` helper (`transport-policy.ts:54`, already imported in `config-compat.ts` but unused there). The helper returns the URL's port only for loopback hosts (undefined for non-local), so a remote connection URL is left without an inferred bind port. This is the issue author's preferred option 1 ("infer `httpPort` from the explicit loopback `httpUrl`").

`buildManagedNativeTransport` is only reached when `resolveLegacyAutoStart` is true (autoStart=false uses `external-native`), so the inference is inherently gated on the managed-daemon case — no extra gate needed. No migration warning is emitted: the inferred config is exactly what the operator intended (daemon bound on the URL they specified), consistent with the silent aligned case.

## User Impact

- **Before:** `autoStart=true` with a loopback `httpUrl` on a non-default port and no `httpPort` → daemon bound 8080, client probed the URL port → split failures, daemon never came up.
- **After:** the migrated transport carries `httpPort` inferred from the loopback `httpUrl`, so daemon bind and client probe use the same port.

## Evidence

**Behavior addressed:** the migrated `transport` now carries `httpPort` inferred from a loopback `httpUrl` when `httpPort` is absent; daemon bind and client probe align.

**Validation (trusted source, local checkout on Node 24.18.0):**

```
node scripts/run-vitest.mjs extensions/signal/doctor-contract-api.test.ts
# Test Files 1 passed (1) | Tests 46 passed (46)
```

New test coverage (existing `normalizeCompatibilityConfig` pattern):
- `infers the managed bind port from a loopback httpUrl when httpPort is absent` — the issue's exact scenario (`httpUrl: "http://127.0.0.1:8082"`, `autoStart: true`, no `httpPort`) → transport is `{ kind: "managed-native", url: "http://127.0.0.1:8082", httpPort: 8082 }`.
- `infers the managed bind port from a localhost httpUrl alias` — `httpUrl: "http://localhost:9090"` → `httpPort: 9090` (confirms `localhost` normalization).
- `does not infer a bind port from a non-loopback httpUrl` — `httpUrl: "http://signal:8080"` → no `httpPort` (behavior unchanged; guards against over-eager inference for external endpoints).

Existing cases unchanged: the aligned case (`httpUrl=8080` + `httpPort=8080`) and the independent-endpoint case (`httpPort=8181` + `httpUrl=localhost:8080`) still pass — inference only triggers when `httpPort` is absent, so explicit operator choices are preserved.

**Real behavior proof (trusted source, local checkout on Node 24.18.0):**

A script drives the real production migration (`normalizeCompatibilityConfig`) and the real account transport resolver (`resolveSignalTransport`, used at setup to derive the daemon bind port and client probe `baseUrl`) with the issue's legacy config (`apiMode: "native"`, `autoStart: true`, `httpUrl: "http://127.0.0.1:8082"`, no `httpPort`):

```json
{
  "proof": "signal-autostart-port-alignment",
  "issue": "#116165",
  "migratedTransport": { "kind": "managed-native", "url": "http://127.0.0.1:8082", "httpPort": 8082 },
  "daemonBindPort": 8082,
  "clientProbeBaseUrl": "http://127.0.0.1:8082",
  "clientProbePort": 8082,
  "verdict": { "portsAgree": true, "daemonBindsUrlPort": true, "notDefault8080": true }
}
```

After the fix, the migrated transport carries `httpPort: 8082` (inferred from the loopback `httpUrl`), so `resolveSignalTransport` produces `baseUrl: "http://127.0.0.1:8082"` and `httpPort: 8082` — daemon bind and client probe use the same port. Before the fix, the migrated transport had no `httpPort`, so `resolveSignalTransport` produced `httpPort: 8080` (default) while `baseUrl` stayed `8082` — the split. No real signal-cli daemon or device; production migration + resolver code paths only.

**Boundary:** change is internal to `extensions/signal/src/config-compat.ts` (reuses `resolveLocalSignalTransportPort` from `./transport-policy.js`, already imported); no new helper, no SDK seam change. The fix lives in the Signal plugin's doctor/migration layer, the correct boundary for plugin-owned legacy config repair.

**Note:** a pre-existing type error in `extensions/signal/src/monitor/event-handler.ts:342` (`requireMention` missing, stale dist dts) is present on clean `origin/main` (verified by stashing this PR's changes) and is unrelated to this PR.

