### PR TITLE
fix(ci): pass target SHA to Telegram evidence finalizer

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -2559,6 +2559,7 @@ jobs:
           CANDIDATE_ROOT: ${{ steps.create_sut.outputs.candidate_root }}
           OUTPUT_DIR: ${{ steps.run_lane.outputs.output_dir }}
           RUN_LANE_OUTCOME: ${{ steps.run_lane.outcome }}
+          TARGET_SHA: ${{ inputs.target_sha }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What Problem This Solves

Fixes the extended-stable release validation failure after Telegram QA itself passes: the trusted evidence finalizer aborts because its Bash script reads an unset `TARGET_SHA`.

## Why This Change Was Made

The workflow already accepts `target_sha` and passes it to the other candidate-sensitive steps. This wires that same immutable input into the finalizer so its narrowly scoped frozen-candidate exception can write the expected evidence. All other candidates retain the existing strict process-boundary validation.

## User Impact

Release operators can validate the frozen extended-stable candidate without weakening Telegram QA evidence requirements. No product runtime behavior changes.

## Evidence

- Failing release run: https://github.com/openclaw/openclaw/actions/runs/30528483057
- Telegram QA ran 12/12 scenarios successfully; the finalizer then failed with `TARGET_SHA: unbound variable`.
- YAML parse: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/openclaw-release-telegram-qa.yml")'`\n- `git diff --check`\n- Focused workflow test identified but dependencies are absent in this disposable worktree; full release validation will exercise this exact finalizer.\n- Autoreview: clean; no accepted/actionable findings.