### PR TITLE
fix(memory): refresh stale openai embedding auth on 401

### DIFF
--- a/extensions/openai/embedding-auth-retry.ts
+++ b/extensions/openai/embedding-auth-retry.ts
@@ -1,0 +1,37 @@
+// Openai helper module retries memory embedding calls once after token expiry.
+
+type RefreshableOpenAiEmbeddingClient = {
+  refreshClient?: (params?: { forceRefresh?: boolean }) => Promise<unknown>;
+};
+
+function isOpenAiEmbeddingTokenExpiredError(error: unknown): boolean {
+  const status =
+    typeof error === "object" &&
+    error !== null &&
+    typeof (error as { status?: unknown }).status === "number"
+      ? (error as { status: number }).status
+      : undefined;
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    (status === 401 || /\b401\b/.test(message)) &&
+    /\btoken[_ -]?expired\b|\bexpired token\b/i.test(message)
+  );
+}
+
+export async function retryOpenAiEmbeddingTokenExpiredOnce<T>(params: {
+  client: RefreshableOpenAiEmbeddingClient;
+  run: () => Promise<T>;
+}): Promise<T> {
+  try {
+    return await params.run();
+  } catch (error) {
+    if (
+      !isOpenAiEmbeddingTokenExpiredError(error) ||
+      typeof params.client.refreshClient !== "function"
+    ) {
+      throw error;
+    }
+    await params.client.refreshClient({ forceRefresh: true });
+    return await params.run();
+  }
+}

--- a/extensions/openai/embedding-batch.test.ts
+++ b/extensions/openai/embedding-batch.test.ts
@@ -2,6 +2,7 @@
 import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runOpenAiEmbeddingBatches } from "./embedding-batch.js";
+import type { OpenAiEmbeddingClient } from "./embedding-provider.js";
 
 const jsonlEncoder = new TextEncoder();
 
@@ -440,6 +441,179 @@ describe("OpenAI embedding batch output", () => {
       ["2", [3]],
       ["3", [4]],
     ]);
+  });
+
+  it("refreshes and retries once on 401 token_expired during input-file upload", async () => {
+    const refreshClient = vi.fn(async () => {
+      openAi.headers = { Authorization: "Bearer fresh" };
+      return openAi;
+    });
+    const openAi: OpenAiEmbeddingClient = {
+      baseUrl: "https://openai-compatible.example/v1",
+      headers: { Authorization: "Bearer stale" },
+      model: "text-embedding-3-small",
+      refreshClient,
+    };
+    let uploadAttempts = 0;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = fetchInputUrl(input);
+      if (url.endsWith("/files") && init?.method === "POST") {
+        uploadAttempts += 1;
+        if (uploadAttempts === 1) {
+          return jsonResponse({ error: { code: "token_expired", message: "expired token" } }, 401);
+        }
+        return jsonResponse({ id: "file-0" });
+      }
+      if (url.endsWith("/batches") && init?.method === "POST") {
+        return jsonResponse({ id: "batch-0", status: "completed", output_file_id: "output-0" });
+      }
+      if (url.endsWith("/files/output-0/content")) {
+        return new Response(
+          JSON.stringify({
+            custom_id: "0",
+            response: { status_code: 200, body: { data: [{ embedding: [1] }] } },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("unexpected request", { status: 500 });
+    });
+    openAi.fetchImpl = fetchImpl as unknown as typeof fetch;
+
+    const byCustomId = await runOpenAiEmbeddingBatches({
+      openAi,
+      agentId: "main",
+      requests: [
+        {
+          custom_id: "0",
+          method: "POST",
+          url: "/v1/embeddings",
+          body: { model: "text-embedding-3-small", input: "payload-0" },
+        },
+      ],
+      wait: true,
+      concurrency: 1,
+      pollIntervalMs: 1000,
+      timeoutMs: 60_000,
+    });
+
+    expect(refreshClient).toHaveBeenCalledWith({ forceRefresh: true });
+    expect(uploadAttempts).toBe(2);
+    expect([...byCustomId.entries()]).toEqual([["0", [1]]]);
+  });
+
+  it("retries only batch creation on 401 token_expired, reusing the uploaded input file", async () => {
+    // Real loopback HTTP so the recovery is observed at the transport boundary:
+    // a wider retry window would show a second POST /v1/files here.
+    const requestLog: Array<{
+      method: string;
+      path: string;
+      auth?: string;
+      inputFileId?: string;
+    }> = [];
+    let batchCreateAttempts = 0;
+    const server = createServer((req, res) => {
+      const path = req.url ?? "";
+      const auth =
+        typeof req.headers.authorization === "string" ? req.headers.authorization : undefined;
+      const method = req.method ?? "GET";
+      if (path === "/v1/files" && method === "POST") {
+        requestLog.push({ method, path, auth });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ id: "file-0" }));
+        return;
+      }
+      if (path === "/v1/batches" && method === "POST") {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk: Buffer) => chunks.push(chunk));
+        req.on("end", () => {
+          const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+            input_file_id?: string;
+          };
+          requestLog.push({ method, path, auth, inputFileId: body.input_file_id });
+          batchCreateAttempts += 1;
+          if (batchCreateAttempts === 1) {
+            res.writeHead(401, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: { code: "token_expired", message: "expired token" } }));
+            return;
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({ id: "batch-0", status: "completed", output_file_id: "output-0" }),
+          );
+        });
+        return;
+      }
+      if (path === "/v1/files/output-0/content") {
+        requestLog.push({ method, path, auth });
+        res.writeHead(200, { "Content-Type": "application/jsonl" });
+        res.end(
+          JSON.stringify({
+            custom_id: "0",
+            response: { status_code: 200, body: { data: [{ embedding: [1] }] } },
+          }),
+        );
+        return;
+      }
+      res.writeHead(500);
+      res.end("unexpected request");
+    });
+
+    const port = await listenLoopbackServer(server);
+    const realFetch = globalThis.fetch.bind(globalThis);
+    const refreshClient = vi.fn(async () => {
+      openAi.headers = { Authorization: "Bearer fresh" };
+      return openAi;
+    });
+    const openAi: OpenAiEmbeddingClient = {
+      baseUrl: "https://openai-compatible.example/v1",
+      headers: { Authorization: "Bearer stale" },
+      model: "text-embedding-3-small",
+      refreshClient,
+      // vi.fn matters: the SSRF guard only skips DNS resolution for a mocked
+      // fetch, and this suite points a fake hostname at the loopback server.
+      fetchImpl: vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const originalUrl = new URL(fetchInputUrl(input));
+        const loopbackUrl = new URL(
+          `${originalUrl.pathname}${originalUrl.search}`,
+          `http://127.0.0.1:${port}`,
+        );
+        return await realFetch(loopbackUrl, init);
+      }) as unknown as typeof fetch,
+    };
+
+    try {
+      const byCustomId = await runOpenAiEmbeddingBatches({
+        openAi,
+        agentId: "main",
+        requests: [
+          {
+            custom_id: "0",
+            method: "POST",
+            url: "/v1/embeddings",
+            body: { model: "text-embedding-3-small", input: "payload-0" },
+          },
+        ],
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 1000,
+        timeoutMs: 60_000,
+      });
+      expect([...byCustomId.entries()]).toEqual([["0", [1]]]);
+    } finally {
+      await closeServer(server);
+    }
+
+    const uploads = requestLog.filter((entry) => entry.path === "/v1/files");
+    const creates = requestLog.filter((entry) => entry.path === "/v1/batches");
+    // The whole point: one upload, two creation attempts, same input file.
+    expect(uploads).toHaveLength(1);
+    expect(creates).toHaveLength(2);
+    expect(creates.map((entry) => entry.inputFileId)).toEqual(["file-0", "file-0"]);
+    expect(creates[0]?.auth).toBe("Bearer stale");
+    expect(creates[1]?.auth).toBe("Bearer fresh");
+    expect(refreshClient).toHaveBeenCalledTimes(1);
+    expect(refreshClient).toHaveBeenCalledWith({ forceRefresh: true });
   });
 
   it("bounds batch status success body via readProviderJsonResponse", async () => {

--- a/extensions/openai/embedding-batch.ts
+++ b/extensions/openai/embedding-batch.ts
@@ -31,6 +31,7 @@ import {
   waitProviderOperationPollInterval,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { retryOpenAiEmbeddingTokenExpiredOnce } from "./embedding-auth-retry.js";
 import type { OpenAiEmbeddingClient } from "./embedding-provider.js";
 
 type OpenAiBatchRequest = {
@@ -65,28 +66,43 @@ async function submitOpenAiBatch(params: {
   requests: OpenAiBatchRequest[];
   agentId: string;
 }): Promise<OpenAiBatchStatus> {
-  const baseUrl = normalizeBatchBaseUrl(params.openAi);
-  const inputFileId = await uploadBatchJsonlFile({
+  // Each remote call gets its own refresh-and-retry window. Wrapping both in
+  // one window would re-upload an input file that already landed whenever only
+  // `/batches` creation saw the expired token, leaking an unused remote file.
+  const inputFileId = await retryOpenAiEmbeddingTokenExpiredOnce({
     client: params.openAi,
-    requests: params.requests,
-    errorPrefix: "openai batch file upload failed",
+    run: async () =>
+      await uploadBatchJsonlFile({
+        client: params.openAi,
+        requests: params.requests,
+        errorPrefix: "openai batch file upload failed",
+      }),
   });
 
-  return await postJsonWithRetry<OpenAiBatchStatus>({
-    url: `${baseUrl}/batches`,
-    headers: buildBatchHeaders(params.openAi, { json: true }),
-    ssrfPolicy: params.openAi.ssrfPolicy,
-    fetchImpl: params.openAi.fetchImpl,
-    body: {
-      input_file_id: inputFileId,
-      endpoint: OPENAI_BATCH_ENDPOINT,
-      completion_window: OPENAI_BATCH_COMPLETION_WINDOW,
-      metadata: {
-        source: "openclaw-memory",
-        agent: params.agentId,
-      },
+  return await retryOpenAiEmbeddingTokenExpiredOnce({
+    client: params.openAi,
+    run: async () => {
+      // Resolved inside `run`: a forced refresh mutates the client in place, so
+      // the retry must read the refreshed base URL and headers, while reusing
+      // the input file the first attempt already uploaded.
+      const baseUrl = normalizeBatchBaseUrl(params.openAi);
+      return await postJsonWithRetry<OpenAiBatchStatus>({
+        url: `${baseUrl}/batches`,
+        headers: buildBatchHeaders(params.openAi, { json: true }),
+        ssrfPolicy: params.openAi.ssrfPolicy,
+        fetchImpl: params.openAi.fetchImpl,
+        body: {
+          input_file_id: inputFileId,
+          endpoint: OPENAI_BATCH_ENDPOINT,
+          completion_window: OPENAI_BATCH_COMPLETION_WINDOW,
+          metadata: {
+            source: "openclaw-memory",
+            agent: params.agentId,
+          },
+        },
+        errorPrefix: "openai batch create failed",
+      });
     },
-    errorPrefix: "openai batch create failed",
   });
 }
 
@@ -142,18 +158,23 @@ async function fetchOpenAiBatchResource<T>(params: {
   signal?: AbortSignal;
   parse: (res: Response) => Promise<T>;
 }): Promise<T> {
-  const baseUrl = normalizeBatchBaseUrl(params.openAi);
-  return await withRemoteHttpResponse({
-    url: `${baseUrl}${params.path}`,
-    ssrfPolicy: params.openAi.ssrfPolicy,
-    fetchImpl: params.openAi.fetchImpl,
-    signal: params.signal,
-    init: {
-      headers: buildBatchHeaders(params.openAi, { json: true }),
-    },
-    onResponse: async (res) => {
-      await assertOkOrThrowProviderError(res, params.label);
-      return await params.parse(res);
+  return await retryOpenAiEmbeddingTokenExpiredOnce({
+    client: params.openAi,
+    run: async () => {
+      const baseUrl = normalizeBatchBaseUrl(params.openAi);
+      return await withRemoteHttpResponse({
+        url: `${baseUrl}${params.path}`,
+        ssrfPolicy: params.openAi.ssrfPolicy,
+        fetchImpl: params.openAi.fetchImpl,
+        signal: params.signal,
+        init: {
+          headers: buildBatchHeaders(params.openAi, { json: true }),
+        },
+        onResponse: async (res) => {
+          await assertOkOrThrowProviderError(res, params.label);
+          return await params.parse(res);
+        },
+      });
     },
   });
 }

--- a/extensions/openai/embedding-provider.test.ts
+++ b/extensions/openai/embedding-provider.test.ts
@@ -123,6 +123,57 @@ describe("OpenAI embedding provider", () => {
     );
   });
 
+  it("refreshes and retries once on 401 token_expired", async () => {
+    mocks.resolveRemoteEmbeddingClient
+      .mockResolvedValueOnce({
+        baseUrl: "https://embeddings.example/v1",
+        headers: { Authorization: "Bearer stale" },
+        model: "text-embedding-3-small",
+      })
+      .mockResolvedValueOnce({
+        baseUrl: "https://embeddings.example/v1",
+        headers: { Authorization: "Bearer fresh" },
+        model: "text-embedding-3-small",
+      });
+    mocks.fetchRemoteEmbeddingVectors
+      .mockRejectedValueOnce(
+        Object.assign(
+          new Error('openai embeddings failed: 401 {"error":{"code":"token_expired"}}'),
+          { status: 401 },
+        ),
+      )
+      .mockResolvedValueOnce([[9, 8, 7]]);
+
+    const { provider } = await createOpenAiEmbeddingProvider(createOptions());
+
+    await expect(provider.embedQuery("hello")).resolves.toEqual([9, 8, 7]);
+
+    expect(mocks.resolveRemoteEmbeddingClient).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ forceRefresh: true }),
+    );
+    expect(mocks.fetchRemoteEmbeddingVectors).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ headers: { Authorization: "Bearer stale" } }),
+    );
+    expect(mocks.fetchRemoteEmbeddingVectors).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ headers: { Authorization: "Bearer fresh" } }),
+    );
+  });
+
+  it("does not retry non-auth failures", async () => {
+    mocks.fetchRemoteEmbeddingVectors.mockRejectedValueOnce(
+      Object.assign(new Error("openai embeddings failed: 500 upstream"), { status: 500 }),
+    );
+
+    const { provider } = await createOpenAiEmbeddingProvider(createOptions());
+
+    await expect(provider.embedQuery("hello")).rejects.toThrow(/500/);
+    expect(mocks.fetchRemoteEmbeddingVectors).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveRemoteEmbeddingClient).toHaveBeenCalledTimes(1);
+  });
+
   // --- openai/ prefix preservation ---
 
   it("strips openai/ prefix when using native OpenAI API base URL", async () => {

--- a/extensions/openai/embedding-provider.ts
+++ b/extensions/openai/embedding-provider.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { OPENAI_DEFAULT_EMBEDDING_MODEL } from "./default-models.js";
+import { retryOpenAiEmbeddingTokenExpiredOnce } from "./embedding-auth-retry.js";
 
 export type OpenAiEmbeddingClient = {
   baseUrl: string;
@@ -18,6 +19,7 @@ export type OpenAiEmbeddingClient = {
   queryInputType?: string;
   documentInputType?: string;
   outputDimensionality?: number;
+  refreshClient?: (params?: { forceRefresh?: boolean }) => Promise<OpenAiEmbeddingClient>;
 };
 
 const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
@@ -49,7 +51,13 @@ export async function createOpenAiEmbeddingProvider(
   options: MemoryEmbeddingProviderCreateOptions,
 ): Promise<{ provider: MemoryEmbeddingProvider; client: OpenAiEmbeddingClient }> {
   const client = await resolveOpenAiEmbeddingClient(options);
-  const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
+  client.refreshClient = async (params) => {
+    const refreshed = await resolveOpenAiEmbeddingClient(options, {
+      forceRefresh: params?.forceRefresh,
+    });
+    Object.assign(client, refreshed);
+    return client;
+  };
 
   const resolveInputType = (kind: "query" | "document"): string | undefined => {
     const explicit = kind === "query" ? client.queryInputType : client.documentInputType;
@@ -66,21 +74,26 @@ export async function createOpenAiEmbeddingProvider(
       return [];
     }
     const inputType = resolveInputType(kind);
-    return await fetchRemoteEmbeddingVectors({
-      url,
-      headers: client.headers,
-      ssrfPolicy: client.ssrfPolicy,
-      fetchImpl: client.fetchImpl,
-      signal,
-      body: {
-        model: client.model,
-        input,
-        ...(typeof client.outputDimensionality === "number"
-          ? { dimensions: client.outputDimensionality }
-          : {}),
-        ...(inputType ? { input_type: inputType } : {}),
-      },
-      errorPrefix: "openai embeddings failed",
+    return await retryOpenAiEmbeddingTokenExpiredOnce({
+      client,
+      run: async () =>
+        await fetchRemoteEmbeddingVectors({
+          // Re-read after a possible refresh: the client is mutated in place.
+          url: `${client.baseUrl.replace(/\/$/, "")}/embeddings`,
+          headers: client.headers,
+          ssrfPolicy: client.ssrfPolicy,
+          fetchImpl: client.fetchImpl,
+          signal,
+          body: {
+            model: client.model,
+            input,
+            ...(typeof client.outputDimensionality === "number"
+              ? { dimensions: client.outputDimensionality }
+              : {}),
+            ...(inputType ? { input_type: inputType } : {}),
+          },
+          errorPrefix: "openai embeddings failed",
+        }),
     });
   };
 
@@ -104,6 +117,7 @@ export async function createOpenAiEmbeddingProvider(
 
 async function resolveOpenAiEmbeddingClient(
   options: MemoryEmbeddingProviderCreateOptions,
+  runtimeOptions?: { forceRefresh?: boolean },
 ): Promise<OpenAiEmbeddingClient> {
   const originalModel = options.model;
   const client = await resolveRemoteEmbeddingClient({
@@ -111,6 +125,7 @@ async function resolveOpenAiEmbeddingClient(
     options,
     defaultBaseUrl: DEFAULT_OPENAI_BASE_URL,
     normalizeModel: normalizeOpenAiModel,
+    forceRefresh: runtimeOptions?.forceRefresh,
   });
   // Non-native OpenAI routers (e.g. Requesty) expect the provider-qualified
   // model name ("openai/text-embedding-3-small") in embedding requests.

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
@@ -38,6 +38,7 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;
   options: EmbeddingProviderOptions;
   defaultBaseUrl: string;
+  forceRefresh?: boolean;
 }): Promise<{ baseUrl: string; headers: Record<string, string>; ssrfPolicy?: SsrFPolicy }> {
   const remote = params.options.remote;
   const remoteApiKey = resolveMemorySecretInputString({
@@ -53,6 +54,7 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
           provider: params.provider,
           cfg: params.options.config,
           agentDir: params.options.agentDir,
+          forceRefresh: params.forceRefresh,
         }),
         params.provider,
       );

--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
@@ -53,6 +53,7 @@ export async function fetchRemoteEmbeddingVectors(params: {
     signal: params.signal,
     body: params.body,
     errorPrefix: params.errorPrefix,
+    attachStatus: true,
     parse: (payload) => {
       const root = asRecord(payload);
       if (!root || !Array.isArray(root.data)) {

--- a/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
@@ -61,11 +61,13 @@ export async function resolveRemoteEmbeddingClient(params: {
   options: EmbeddingProviderOptions;
   defaultBaseUrl: string;
   normalizeModel: (model: string) => string;
+  forceRefresh?: boolean;
 }): Promise<RemoteEmbeddingClient> {
   const { baseUrl, headers, ssrfPolicy } = await resolveRemoteEmbeddingBearerClient({
     provider: params.provider,
     options: params.options,
     defaultBaseUrl: params.defaultBaseUrl,
+    forceRefresh: params.forceRefresh,
   });
   const model = params.normalizeModel(params.options.model);
   return { baseUrl, headers, ssrfPolicy, model };


### PR DESCRIPTION
Rebased onto current `main` and reworked after the previous review. Force-pushed as a single commit; the three blocking items are addressed below.

## What Problem This Solves

A long-lived gateway keeps one OpenAI embedding client for the life of the process. When its OAuth-backed authorization goes stale, every embedding call fails with `401 token_expired` until the process is restarted — memory sync stops, and it stops silently.

It reads like a dead refresh token, but it is not one: the CLI keeps working throughout, because it resolves a fresh client per invocation, and the embedded runtime recovers after a plain restart with no re-authentication. The stale value is the long-lived client, not the credential behind it.

The change is a bounded, one-shot recovery: on `401 token_expired`, force-refresh the client and retry the failed call exactly once. Non-auth failures, and clients without a refresh hook, are rethrown untouched.

### Retry only the failed batch-creation request

The previous revision wrapped the input-file upload **and** `/batches` creation in one retry window, so a `401` seen only by creation re-ran the whole closure and uploaded a second input file.

Each remote call now has its own window — upload, creation, and batch resource reads — and creation reuses the `input_file_id` the first attempt produced. `baseUrl` and headers are resolved *inside* each retry body, because a forced refresh mutates the client in place and the second attempt has to read the refreshed credentials.

### Rebase, with abort-signal forwarding preserved

`fetchOpenAiBatchResource` gained a `signal` parameter upstream. The retry wrapper forwards it unchanged, so batch status polling and resource reads keep their cancellation behavior.

## Evidence

`extensions/openai/embedding-batch.test.ts` drives the creation path against a **real loopback HTTP server** — real sockets, a real `401`, a real retry — and records the transport-level request log. The `401` is served on the first `POST /v1/batches` only.

**After this change** (test passes):

```
#1  POST /v1/files                    Authorization: Bearer stale
#2  POST /v1/batches                  Authorization: Bearer stale  input_file_id=file-0   → 401 token_expired
#3  POST /v1/batches                  Authorization: Bearer fresh  input_file_id=file-0   → 200
#4  GET  /v1/files/output-0/content   Authorization: Bearer fresh
```

**Before this change**, same test, same server — the previous single-window retry (test fails):

```
#1  POST /v1/files                    Authorization: Bearer stale
#2  POST /v1/batches                  Authorization: Bearer stale  input_file_id=file-0   → 401 token_expired
#3  POST /v1/files                    Authorization: Bearer fresh                          ← second upload, the leaked file
#4  POST /v1/batches                  Authorization: Bearer fresh  input_file_id=file-0   → 200
#5  GET  /v1/files/output-0/content   Authorization: Bearer fresh
```

```
AssertionError: expected [ { method: 'POST', …(2) }, …(1) ] to have a length of 1 but got 2
```

The stub returns a constant file id, so the leak shows up as the extra `POST /v1/files` rather than as a changed `input_file_id`; against the real API the second upload would produce a distinct file and orphan the first.

### Test runs

- `extensions/openai/embedding-batch.test.ts` — `401` on upload (refresh and retry), `401` on creation (retry creation only, reuse the input file, one upload)
- `extensions/openai/embedding-provider.test.ts` — `401` on a direct embedding call (refresh and retry), and a non-auth `500` that must **not** retry
- `extensions/openai` shard: 776 passed, 1 skipped
- `packages/memory-host-sdk` touched suites: 21 passed
- `oxfmt --check` clean on both touched trees

One note for anyone extending these tests: the SSRF guard only skips DNS resolution when the injected fetch is a mock, so a loopback-backed `fetchImpl` has to be a `vi.fn` or the fake hostname is resolved for real.
