### PR TITLE
Restore production installs after TypeBox package removal

### DIFF
--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -10,7 +10,7 @@
     "esbuild": "0.28.1",
     "express": "5.2.1",
     "playwright-core": "1.62.0",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "ws": "8.21.1"
   },
   "devDependencies": {

--- a/extensions/canvas/package.json
+++ b/extensions/canvas/package.json
@@ -12,7 +12,7 @@
     "@lit/context": "1.1.6",
     "chokidar": "5.0.0",
     "lit": "3.3.3",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "ws": "8.21.1"
   },
   "openclaw": {

--- a/extensions/codex/package.json
+++ b/extensions/codex/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@openai/codex": "0.146.0",
     "smol-toml": "1.7.1",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "ws": "8.21.1",
     "zod": "4.4.3"
   },

--- a/extensions/diffs/package.json
+++ b/extensions/diffs/package.json
@@ -11,7 +11,7 @@
     "@pierre/diffs": "1.2.12",
     "@shikijs/langs": "4.3.1",
     "playwright-core": "1.62.0",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -14,7 +14,7 @@
     "libopus-wasm": "0.2.0",
     "mdast-util-from-markdown": "2.0.3",
     "p-map": "7.0.6",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "undici": "8.9.0",
     "ws": "8.21.1",
     "zod": "4.4.3"

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -12,7 +12,7 @@
     "mdast-util-from-markdown": "2.0.3",
     "mdast-util-gfm-table": "2.0.0",
     "micromark-extension-gfm-table": "2.1.1",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/extensions/file-transfer/package.json
+++ b/extensions/file-transfer/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "minimatch": "10.2.5",
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/firecrawl/package.json
+++ b/extensions/firecrawl/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "jszip": "3.10.1",
     "pretty-ms": "9.3.0",
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw iMessage channel plugin using imsg on a signed-in Mac",
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "dependencies": {
     "@clawdbot/lobster": "2026.6.11",
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -14,7 +14,7 @@
     "markdown-it": "14.3.0",
     "matrix-js-sdk": "41.9.0",
     "music-metadata": "11.14.0",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -8,7 +8,7 @@
     "chokidar": "5.0.0",
     "json5": "2.2.3",
     "p-limit": "7.3.1",
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -11,7 +11,7 @@
     "@lancedb/lancedb": "0.31.0",
     "apache-arrow": "18.1.0",
     "openai": "6.49.0",
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/memory-wiki/package.json
+++ b/extensions/memory-wiki/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "mdast-util-from-markdown": "2.0.3",
     "p-map": "7.0.6",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "yaml": "2.9.0",
     "zod": "4.4.3"
   },

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -12,7 +12,7 @@
     "@microsoft/teams.api": "2.0.14",
     "@microsoft/teams.apps": "2.0.14",
     "express": "5.2.1",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/extensions/ollama/package.json
+++ b/extensions/ollama/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw Ollama provider plugin",
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/qa-channel/package.json
+++ b/extensions/qa-channel/package.json
@@ -11,7 +11,7 @@
     "./test-api.js": "./test-api.ts"
   },
   "dependencies": {
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -14,7 +14,7 @@
     "@slack/web-api": "8.0.0",
     "get-east-asian-width": "1.6.0",
     "p-map": "7.0.6",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "undici": "7.28.0",
     "ws": "8.21.1",
     "zod": "4.4.3"

--- a/extensions/tavily/package.json
+++ b/extensions/tavily/package.json
@@ -4,7 +4,7 @@
   "description": "OpenClaw Tavily plugin",
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/teams-meetings/package.json
+++ b/extensions/teams-meetings/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -8,7 +8,7 @@
     "@grammyjs/runner": "2.0.3",
     "@grammyjs/transformer-throttler": "1.2.1",
     "grammy": "1.45.1",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "undici": "8.9.0",
     "zod": "4.4.3"
   },

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "ws": "8.21.1",
     "zod": "4.4.3"
   },

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "audio-decode": "2.2.3",
     "baileys": "7.0.0-rc13",
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",

--- a/extensions/workboard/package.json
+++ b/extensions/workboard/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw dashboard workboard plugin",
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",

--- a/extensions/xai/package.json
+++ b/extensions/xai/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw xAI plugin",
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "ws": "8.21.1"
   },
   "devDependencies": {

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "zca-js": "2.1.2",
     "zod": "4.4.3"
   },

--- a/extensions/zoom-meetings/package.json
+++ b/extensions/zoom-meetings/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -1974,7 +1974,7 @@
     "tar": "7.5.22",
     "tree-sitter-bash": "0.25.1",
     "tslog": "4.11.0",
-    "typebox": "1.3.8",
+    "typebox": "1.3.6",
     "typescript": "6.0.3",
     "undici": "8.9.0",
     "web-push": "3.6.7",

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -66,6 +66,6 @@
     "@openclaw/ai": "workspace:*",
     "@openclaw/llm-core": "workspace:*",
     "@openclaw/normalization-core": "workspace:*",
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   }
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -98,7 +98,7 @@
     "@mistralai/mistralai": "2.5.0",
     "openai": "6.49.0",
     "partial-json": "0.1.7",
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/packages/gateway-protocol/package.json
+++ b/packages/gateway-protocol/package.json
@@ -78,7 +78,7 @@
     "prepack": "pnpm run build && node --import tsx ../../scripts/protocol-gen.ts --out ./protocol.schema.json"
   },
   "dependencies": {
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/packages/llm-core/package.json
+++ b/packages/llm-core/package.json
@@ -36,6 +36,6 @@
     }
   },
   "dependencies": {
-    "typebox": "1.3.8"
+    "typebox": "1.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ overrides:
   qs: 6.15.3
   sharp: 0.35.3
   node-domexception: npm:@nolyfill/domexception@1.0.28
-  typebox: 1.3.8
+  typebox: 1.3.6
   tar: 7.5.22
   tough-cookie: 5.1.2
   yauzl: 3.4.0
@@ -211,8 +211,8 @@ importers:
         specifier: 4.11.0
         version: 4.11.0
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -524,8 +524,8 @@ importers:
         specifier: 1.62.0
         version: 1.62.0
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -577,8 +577,8 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -636,8 +636,8 @@ importers:
         specifier: 1.7.1
         version: 1.7.1
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -775,8 +775,8 @@ importers:
         specifier: 1.62.0
         version: 1.62.0
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -812,8 +812,8 @@ importers:
         specifier: 7.0.6
         version: 7.0.6
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       undici:
         specifier: 8.9.0
         version: 8.9.0
@@ -886,8 +886,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -905,8 +905,8 @@ importers:
         specifier: 10.2.5
         version: 10.2.5
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -915,8 +915,8 @@ importers:
   extensions/firecrawl:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -972,8 +972,8 @@ importers:
         specifier: 9.3.0
         version: 9.3.0
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1025,8 +1025,8 @@ importers:
   extensions/imessage:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -1118,8 +1118,8 @@ importers:
   extensions/llm-task:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1133,8 +1133,8 @@ importers:
         specifier: 2026.6.11
         version: 2026.6.11
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1176,8 +1176,8 @@ importers:
         specifier: 11.14.0
         version: 11.14.0(supports-color@10.2.2)
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -1223,8 +1223,8 @@ importers:
         specifier: 7.3.1
         version: 7.3.1
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1245,8 +1245,8 @@ importers:
         specifier: 6.49.0
         version: 6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/hash-node@4.4.14)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3)
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1261,8 +1261,8 @@ importers:
         specifier: 7.0.6
         version: 7.0.6
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -1357,8 +1357,8 @@ importers:
         specifier: 5.2.1
         version: 5.2.1(supports-color@10.2.2)
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -1455,8 +1455,8 @@ importers:
   extensions/ollama:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1568,8 +1568,8 @@ importers:
   extensions/qa-channel:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -1778,8 +1778,8 @@ importers:
         specifier: 7.0.6
         version: 7.0.6
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       undici:
         specifier: 7.28.0
         version: 7.28.0
@@ -1832,8 +1832,8 @@ importers:
   extensions/tavily:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1842,8 +1842,8 @@ importers:
   extensions/teams-meetings:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1864,8 +1864,8 @@ importers:
         specifier: 1.45.1
         version: 1.45.1(supports-color@10.2.2)
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       undici:
         specifier: 8.9.0
         version: 8.9.0
@@ -1985,8 +1985,8 @@ importers:
   extensions/voice-call:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -2051,8 +2051,8 @@ importers:
         specifier: 7.0.0-rc13
         version: 7.0.0-rc13(audio-decode@2.2.3)(sharp@0.35.3(@types/node@26.1.2))(supports-color@10.2.2)
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -2064,8 +2064,8 @@ importers:
   extensions/workboard:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -2080,8 +2080,8 @@ importers:
   extensions/xai:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -2118,8 +2118,8 @@ importers:
   extensions/zalouser:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
       zca-js:
         specifier: 2.1.2
         version: 2.1.2
@@ -2137,8 +2137,8 @@ importers:
   extensions/zoom-meetings:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -2165,8 +2165,8 @@ importers:
         specifier: workspace:*
         version: link:../normalization-core
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
 
   packages/ai:
     dependencies:
@@ -2186,8 +2186,8 @@ importers:
         specifier: 0.1.7
         version: 0.1.7
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
 
   packages/gateway-client:
     dependencies:
@@ -2204,14 +2204,14 @@ importers:
   packages/gateway-protocol:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
 
   packages/llm-core:
     dependencies:
       typebox:
-        specifier: 1.3.8
-        version: 1.3.8
+        specifier: 1.3.6
+        version: 1.3.6
 
   packages/markdown-core:
     dependencies:
@@ -8882,8 +8882,8 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typebox@1.3.8:
-    resolution: {integrity: sha512-xYaJgF0KMvBViKWRaKTAtfR6sDt/yH6xAjGAHXYJxKxUF4pVyPXZZhIlwOg6cDIE81N7L0pyIHs136RHBm6rLQ==}
+  typebox@1.3.6:
+    resolution: {integrity: sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==}
 
   typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
@@ -16499,7 +16499,7 @@ snapshots:
       media-typer: 1.1.1
       mime-types: 3.0.2
 
-  typebox@1.3.8: {}
+  typebox@1.3.6: {}
 
   typescript@5.2.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -144,7 +144,7 @@ overrides:
   qs: 6.15.3
   sharp: 0.35.3
   node-domexception: "npm:@nolyfill/domexception@1.0.28"
-  typebox: 1.3.8
+  typebox: 1.3.6
   tar: 7.5.22
   tough-cookie: 5.1.2
   yauzl: 3.4.0


### PR DESCRIPTION
## What Problem This Solves

The gateway image can no longer be built because `typebox@1.3.8` was removed from npm. Fresh installs now fail with a 404 before OpenClaw can compile, which is blocking the production Claw rollout.

## Why This Change Was Made

This pins TypeBox to `1.3.6`, the newest release that is still published, everywhere the workspace declares it. The lockfile and workspace override stay aligned so clean frozen installs resolve one available artifact instead of the removed tarball.

## User Impact

Fresh installs and production image builds work again. There is no intended runtime behavior change.

## Evidence

A frozen offline lockfile validation passes, npm serves the `1.3.6` tarball with the recorded integrity, and its `Type`, `Compile`, and `Value` entry points successfully build and validate the representative object schema used by OpenClaw.