### PR TITLE
fix(sandbox): keep file-transfer media in the managed media set

### DIFF
--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -42,6 +42,7 @@ async function withManagedMediaRoot<T>(run: (ctx: { stateDir: string }) => Promi
     return await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
       await fs.mkdir(path.join(stateDir, "media", "outbound"), { recursive: true });
       await fs.mkdir(path.join(stateDir, "media", "tool-image-generation"), { recursive: true });
+      await fs.mkdir(path.join(stateDir, "media", "file-transfer"), { recursive: true });
       return await run({ stateDir });
     });
   } finally {
@@ -267,6 +268,12 @@ describe("resolveSandboxedMediaSource", () => {
     {
       name: "managed tool media",
       relative: path.join("media", "tool-image-generation", "generated.png"),
+    },
+    {
+      // file_fetch/dir_fetch write into FILE_TRANSFER_SUBDIR, so the subdir has
+      // to stay in the managed set or sandboxed replies drop those attachments.
+      name: "managed file-transfer media",
+      relative: path.join("media", "file-transfer", "receipt.png"),
     },
   ])("allows $name outside the sandbox root", async ({ relative }) => {
     await withManagedMediaRoot(async ({ stateDir }) => {

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -23,7 +23,7 @@ import { resolveConfigDir, shortenHomePath } from "../utils.js";
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const DATA_URL_RE = /^data:/i;
 const SANDBOX_CONTAINER_WORKDIR = "/workspace";
-const MANAGED_MEDIA_SUBDIRS = new Set(["outbound"]);
+const MANAGED_MEDIA_SUBDIRS = new Set(["outbound", "file-transfer"]);
 
 function normalizeUnicodeSpaces(str: string): string {
   return str.replace(UNICODE_SPACES, " ");


### PR DESCRIPTION
Closes #116338

## What Problem This Solves

With sandbox enabled, a reply that attaches a file produced by `file_fetch`/`dir_fetch` loses the attachment.

`MANAGED_MEDIA_SUBDIRS` (`src/agents/sandbox-paths.ts:26`) listed only `outbound`, but those tools save into `FILE_TRANSFER_SUBDIR = "file-transfer"` (`extensions/file-transfer/src/tools/descriptors.ts:13`). So `resolveAllowedManagedMediaPath` returned `undefined`, `assertSandboxPath` threw `Path escapes sandbox root` (`src/agents/sandbox-paths.ts:86`), and `src/auto-reply/reply/reply-media-paths.ts:211-213` dropped the media with a verbose-only log.

The user was not left with nothing — `appendReplyMediaFailureWarning` appends `⚠️ Media failed.` (`src/auto-reply/reply-payload.ts:147`) — but that warning names no file, no reason and no remedy, and the agent itself receives no signal, so it reports the file as delivered.

## Why This Change Was Made

This is an omission rather than a deliberate restriction, and #71138 / a31374f0 (`fix: allow managed media from sandbox replies`) is the precedent: that fix added `outbound` plus the `tool-` prefix for exactly this failure mode. The file-transfer tools introduced their own subdir after that fix and were never added to the set.

Two things kept the change minimal:

- `src/media/local-roots.ts` already treats the whole `<stateDir>/media` tree as an allowed local media root, so widening the sandbox check to one more OpenClaw-written subdir does not broaden the trust boundary beyond what the rest of the code already grants.
- `src/agents/sandbox-paths.ts:26` is the only place in the repo that enumerates media subdirs for this check (`rg '"outbound"' src extensions` — every other hit is a delivery-queue name or a channel-direction enum), so there is no sibling surface to keep in sync.

The negative boundary is unchanged: `media/inbound/**` stays outside the managed set, and the existing assertion for that still passes.

## User Impact

- Agents running with sandbox enabled can once again attach files fetched from a paired node — screenshots, receipts, exported reports — instead of delivering prose plus `⚠️ Media failed.`
- No change on the default path: `sandbox.mode` defaults to `off` (`src/agents/sandbox/config.ts:255`), so only operators who opted into sandboxing were affected and only they see behavior change.
- No config, migration, or operator action required.

## Evidence

Added the `file-transfer` case to the existing managed-media `it.each` in `src/agents/sandbox-paths.test.ts`, alongside the `outbound` and `tool-image-generation` cases it already covers, and pre-created that subdir in the `withManagedMediaRoot` helper next to the other two managed subdirs.

On `main` without the one-line fix, the new case fails:

```
Error: ENOENT/Path escapes sandbox root (<sandboxRoot>): <stateDir>/media/file-transfer/receipt.png
```

With the fix:

```
$ node scripts/run-vitest.mjs src/agents/sandbox-paths.test.ts
 Test Files  1 passed (1)
      Tests  38 passed | 1 skipped (39)
```

That run includes the pre-existing negative test `does not allow unrelated state media directories as managed media` (`media/inbound`), so the boundary is still enforced.

Formatted with `oxfmt`. AI-assisted change; the repro, every line reference, and the sibling-surface check were verified against current `main` before filing.
