### PR TITLE
fix(agents): compare shell tool names case-insensitively and stop re-parsing tool labels

### DIFF
--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -1,0 +1,47 @@
+// Telegram renders progress lines from their structured fields, so a line that
+// arrives without detail falls back to text that already carries its icon.
+import { buildChannelProgressDraftLine } from "openclaw/plugin-sdk/channel-outbound";
+import { describe, expect, it } from "vitest";
+import { renderTelegramProgressDraftPreview } from "./progress-draft-preview.js";
+
+function renderToolLine(name: string) {
+  const line = buildChannelProgressDraftLine({
+    event: "tool",
+    toolCallId: "call-1",
+    name,
+    phase: "start",
+    args: { command: "echo alpha", description: "print text" },
+  });
+  if (!line) {
+    throw new Error(`expected a progress line for ${name}`);
+  }
+  return renderTelegramProgressDraftPreview("Working", [line], false, true).text;
+}
+
+describe("renderTelegramProgressDraftPreview", () => {
+  it("prints one tool icon per line for every backend spelling", () => {
+    for (const name of ["Bash", "bash", "exec"]) {
+      const rendered = renderToolLine(name);
+      expect(rendered.match(/🛠️/gu) ?? []).toHaveLength(1);
+      expect(rendered).toContain("print text");
+    }
+  });
+
+  it("keeps the label and detail separate for a non-shell tool", () => {
+    const line = buildChannelProgressDraftLine({
+      event: "tool",
+      toolCallId: "call-1",
+      name: "Read",
+      phase: "start",
+      args: { file_path: "/tmp/x.ts" },
+    });
+    if (!line) {
+      throw new Error("expected a progress line for Read");
+    }
+
+    const rendered = renderTelegramProgressDraftPreview("Working", [line], false, true).text;
+
+    expect(rendered).toContain("<b>📖 Read</b>");
+    expect(rendered.match(/📖/gu) ?? []).toHaveLength(1);
+  });
+});

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -10,7 +10,30 @@ import {
   splitTopLevelStages,
 } from "./tool-display-exec-shell.js";
 import { resolveExecDetail } from "./tool-display-exec.js";
-import { formatToolDetail, formatToolSummary, resolveToolDisplay } from "./tool-display.js";
+import {
+  formatToolDetail,
+  formatToolSummary,
+  isShellToolDisplayName,
+  resolveToolDisplay,
+} from "./tool-display.js";
+
+describe("isShellToolDisplayName", () => {
+  it("matches shell tools whatever case the backend spells them in", () => {
+    // The Claude CLI sends "Bash"; embedded runs send "bash"/"exec".
+    for (const name of ["Bash", "bash", "BASH", "Exec", "exec", "shell"]) {
+      expect(isShellToolDisplayName(name)).toBe(true);
+    }
+    for (const name of ["Read", "web_search", undefined, ""]) {
+      expect(isShellToolDisplayName(name)).toBe(false);
+    }
+  });
+
+  it("keeps the compact summary form for a capitalized shell tool", () => {
+    const display = resolveToolDisplay({ name: "Bash", args: { command: "echo alpha" } });
+    // Compact form is "<emoji> <detail>", not "<emoji> Bash: <detail>".
+    expect(formatToolSummary(display)).toBe(`${display.emoji} ${formatToolDetail(display)}`);
+  });
+});
 
 describe("tool display details", () => {
   it("keeps same-line heredoc operators from attaching the body to later stages", () => {

--- a/src/agents/tool-display.ts
+++ b/src/agents/tool-display.ts
@@ -94,10 +94,21 @@ export function formatToolDetail(display: ToolDisplay): string | undefined {
   return formatToolDetailText(detailRaw);
 }
 
+/**
+ * Shell-family tools render their command as the whole line instead of
+ * "Label: detail". Backends spell the same tool differently — the Claude CLI
+ * sends "Bash" where embedded runs send "bash"/"exec" — so every caller must
+ * compare the normalized name or the shell line silently loses its detail.
+ */
+export function isShellToolDisplayName(name: string | undefined): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(name);
+  return normalized === "bash" || normalized === "exec" || normalized === "shell";
+}
+
 /** Builds the compact one-line summary shown in transcripts and logs. */
 export function formatToolSummary(display: ToolDisplay): string {
   const detail = formatToolDetail(display);
-  if (detail && (display.name === "bash" || display.name === "exec")) {
+  if (detail && isShellToolDisplayName(display.name)) {
     return `${display.emoji} ${detail}`;
   }
   return detail

--- a/src/auto-reply/tool-meta.ts
+++ b/src/auto-reply/tool-meta.ts
@@ -1,5 +1,5 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { resolveToolDisplay } from "../agents/tool-display.js";
+import { isShellToolDisplayName, resolveToolDisplay } from "../agents/tool-display.js";
 /** Formats compact tool metadata labels for auto-reply progress/status messages. */
 import { formatInlineCodeSpan } from "../shared/markdown-code.js";
 import { shortenHomeInString } from "../utils.js";
@@ -16,9 +16,7 @@ export function formatToolAggregate(
 ): string {
   const filtered = (metas ?? []).filter(Boolean).map(shortenHomeInString);
   const display = resolveToolDisplay({ name: toolName });
-  const normalizedToolName = normalizeLowercaseStringOrEmpty(toolName);
-  const compactCommandSummary =
-    filtered.length > 0 && (normalizedToolName === "exec" || normalizedToolName === "bash");
+  const compactCommandSummary = filtered.length > 0 && isShellToolDisplayName(toolName);
   const prefix = compactCommandSummary ? display.emoji : `${display.emoji} ${display.label}`;
   if (!filtered.length) {
     return `${display.emoji} ${display.label}`;

--- a/src/auto-reply/tool-meta.ts
+++ b/src/auto-reply/tool-meta.ts
@@ -8,18 +8,23 @@ type ToolAggregateOptions = {
   markdown?: boolean;
 };
 
-/** Formats one grouped tool-progress label from a tool name and metadata entries. */
-export function formatToolAggregate(
+/**
+ * Formats one grouped tool-progress label and returns the detail segment it was
+ * composed from. Callers that need both must not re-parse the label: recovering
+ * the detail by stripping the rendered prefix silently yields nothing whenever
+ * the prefix shape changes.
+ */
+export function formatToolAggregateParts(
   toolName?: string,
   metas?: string[],
   options?: ToolAggregateOptions,
-): string {
+): { text: string; detail?: string } {
   const filtered = (metas ?? []).filter(Boolean).map(shortenHomeInString);
   const display = resolveToolDisplay({ name: toolName });
   const compactCommandSummary = filtered.length > 0 && isShellToolDisplayName(toolName);
   const prefix = compactCommandSummary ? display.emoji : `${display.emoji} ${display.label}`;
   if (!filtered.length) {
-    return `${display.emoji} ${display.label}`;
+    return { text: `${display.emoji} ${display.label}` };
   }
 
   const rawSegments: string[] = [];
@@ -60,8 +65,20 @@ export function formatToolAggregate(
 
   const allSegments = [...rawSegments, ...segments];
   const meta = allSegments.join("; ");
-  const formattedMeta = formatMetaForDisplay(toolName, meta, options?.markdown);
-  return compactCommandSummary ? `${prefix} ${formattedMeta}` : `${prefix}: ${formattedMeta}`;
+  const detail = formatMetaForDisplay(toolName, meta, options?.markdown);
+  return {
+    text: compactCommandSummary ? `${prefix} ${detail}` : `${prefix}: ${detail}`,
+    detail,
+  };
+}
+
+/** Formats one grouped tool-progress label from a tool name and metadata entries. */
+export function formatToolAggregate(
+  toolName?: string,
+  metas?: string[],
+  options?: ToolAggregateOptions,
+): string {
+  return formatToolAggregateParts(toolName, metas, options).text;
 }
 
 function formatMetaForDisplay(

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { inferToolMetaFromArgs } from "../agents/embedded-agent-utils.js";
+import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import {
   buildChannelProgressDraftLine,
   formatChannelProgressDraftText,
@@ -100,6 +102,53 @@ describe("buildChannelProgressDraftLine", () => {
       status: "exit 2",
     });
     expect(line?.text).not.toContain("command false");
+  });
+});
+
+// Claude CLI tool names arrive capitalized. Each tool call is described twice —
+// a structured progress line and the tool-summary payload that channels without
+// a progress draft render as text — so both must resolve to one draft line.
+describe("backend tool-name casing", () => {
+  const CLI_TOOL_CALLS = [
+    { name: "Bash", args: { command: "echo alpha", description: "print text" } },
+    { name: "Read", args: { file_path: "/tmp/x.ts" } },
+    { name: "Edit", args: { file_path: "/tmp/x.ts", old_string: "a", new_string: "b" } },
+    { name: "mcp__openclaw__exec", args: { command: "echo alpha" } },
+  ] as const;
+
+  it.each(CLI_TOOL_CALLS)("renders $name as one line", ({ name, args }) => {
+    const structured = buildChannelProgressDraftLine({
+      event: "tool",
+      toolCallId: "call-1",
+      name,
+      phase: "start",
+      args,
+    });
+    const meta = inferToolMetaFromArgs(name, args, { detailMode: "explain" });
+    const summaryText = formatToolAggregate(name, meta ? [meta] : undefined, { markdown: true });
+
+    const merged = mergeChannelProgressDraftLine(
+      structured ? [structured] : [],
+      { kind: "item", label: "", text: summaryText, prefix: false },
+      { maxLines: 8 },
+    );
+
+    expect(merged).toHaveLength(1);
+  });
+
+  it("keeps the shell detail so renderers never fall back to prefixed text", () => {
+    // Without detail, a renderer composing "<icon> <label>" then appending the
+    // line text prints the icon twice ("🛠️ Bash 🛠️ print text").
+    const line = buildChannelProgressDraftLine({
+      event: "tool",
+      toolCallId: "call-1",
+      name: "Bash",
+      phase: "start",
+      args: { command: "echo alpha", description: "print text" },
+    });
+
+    expect(line?.detail).toBe("print text");
+    expect(line?.text).toBe(`${line?.icon} print text`);
   });
 });
 

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -2,7 +2,11 @@ import { expectDefined } from "@openclaw/normalization-core";
 // Channel streaming config normalization and progress-draft formatting helpers.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
-import { formatToolDetail, resolveToolDisplay } from "../agents/tool-display.js";
+import {
+  formatToolDetail,
+  isShellToolDisplayName,
+  resolveToolDisplay,
+} from "../agents/tool-display.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import type {
   BlockStreamingChunkConfig,
@@ -331,7 +335,7 @@ function buildNamedProgressLine(
   const display = resolveToolDisplay({ name: normalizedName });
   const prefix = `${display.emoji} ${display.label}`;
   const compactCommandDetail =
-    (display.name === "exec" || display.name === "bash") && text.startsWith(`${display.emoji} `)
+    isShellToolDisplayName(display.name) && text.startsWith(`${display.emoji} `)
       ? text.slice(display.emoji.length + 1).trim()
       : undefined;
   const compactCommandPrefix =
@@ -1135,8 +1139,7 @@ function getProgressDraftLineText(line: string | ChannelProgressDraftLine): stri
   const status = line.status?.trim();
   const displayStatus = status === "completed" ? undefined : status;
   if (detail) {
-    const compactCommandLine =
-      line.toolName === "exec" || line.toolName === "bash" || line.toolName === "shell";
+    const compactCommandLine = isShellToolDisplayName(line.toolName);
     if (line.kind === "command-output" && displayStatus && detail !== displayStatus) {
       const outputDetail = detail.startsWith(`${displayStatus};`)
         ? detail

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -7,7 +7,7 @@ import {
   isShellToolDisplayName,
   resolveToolDisplay,
 } from "../agents/tool-display.js";
-import { formatToolAggregate } from "../auto-reply/tool-meta.js";
+import { formatToolAggregate, formatToolAggregateParts } from "../auto-reply/tool-meta.js";
 import type {
   BlockStreamingChunkConfig,
   BlockStreamingCoalesceConfig,
@@ -329,22 +329,14 @@ function buildNamedProgressLine(
 ): ChannelProgressDraftLine | undefined {
   const normalizedName = name?.trim() || "tool_call";
   const compactMetas = compactStrings(metas ?? []);
-  const text = formatToolAggregate(normalizedName, compactMetas.length ? compactMetas : undefined, {
-    markdown: options?.markdown,
-  });
+  // The formatter owns both halves: taking the detail from it keeps the line's
+  // structured fields and its rendered text describing the same thing.
+  const { text, detail } = formatToolAggregateParts(
+    normalizedName,
+    compactMetas.length ? compactMetas : undefined,
+    { markdown: options?.markdown },
+  );
   const display = resolveToolDisplay({ name: normalizedName });
-  const prefix = `${display.emoji} ${display.label}`;
-  const compactCommandDetail =
-    isShellToolDisplayName(display.name) && text.startsWith(`${display.emoji} `)
-      ? text.slice(display.emoji.length + 1).trim()
-      : undefined;
-  const compactCommandPrefix =
-    compactCommandDetail && compactCommandDetail !== display.label
-      ? compactCommandDetail
-      : undefined;
-  const detail = text.startsWith(`${prefix}: `)
-    ? text.slice(prefix.length + 2).trim()
-    : compactCommandPrefix;
   const line = {
     ...(fields?.id ? { id: fields.id } : {}),
     kind,


### PR DESCRIPTION
## What Problem This Solves

Every Claude CLI tool call rendered **two** progress-draft lines on Telegram, the first with its icon printed twice. Recorded live — real Claude CLI backend, real Telegram group, prompt `echo alpha && sleep 2 && echo beta`:

```
Working
🛠️ Bash 🛠️ print text → run sleep 2 → print text
🛠️ print text → run sleep 2 → print text
```

Both symptoms trace to one fact being derived twice, two different ways.

**A line's `detail` was recovered by re-parsing the label just rendered for it.** `buildNamedProgressLine` called `formatToolAggregate`, then string-sliced the result back apart to recover the detail — guessing the prefix shape, with a shell-specific branch and a label-collision guard to patch the cases where the guess was wrong (`src/channels/streaming.ts:333-343` before this change).

**That guess is name-dependent, and backends spell tools differently.** The Claude CLI sends `Bash`; embedded runs send `bash`/`exec`. Three sites answered "is this a shell tool?" against the lowercase spellings only:

- `src/channels/streaming.ts:334` — deriving `detail`
- `src/channels/streaming.ts:1139` — resolving a line's canonical text
- `src/agents/tool-display.ts:100` — `formatToolSummary`

A capitalized name missed all three, so the slice returned nothing and the line shipped with no `detail`. Two user-visible consequences followed:

1. **Doubled icon.** With no detail, Telegram composes `icon + label`, finds none, and falls back to `line.text` — which already carries the icon (`extensions/telegram/src/progress-draft-preview.ts:57-73`).
2. **Duplicate line.** Each tool call is described twice by design: a structured progress line, plus the tool-summary payload that channels without a progress draft render as text. `mergeChannelProgressDraftLine` dedupes them by canonical line text, which is built from `detail` — so losing `detail` lost the match, and the summary landed as a second, id-less line that never completed.

Verified by direct comparison, same args, only the name's case differing:

```
line(Bash) detail=undefined  → 2 lines
line(bash) detail="print text" → 1 line
```

## Why This Change Was Made

`formatToolAggregate` was a fourth site asking the same question and the only one that got it right — it already normalized the name (`src/auto-reply/tool-meta.ts:19-21`), which is why the summary payload rendered its compact form while the structured line did not. Four copies of one rule, three of them wrong.

Two changes, innermost first:

- **`formatToolAggregateParts` returns the label and the detail it composed.** The line's structured fields and its rendered text now come from one place, so a line can no longer disagree with its own label. The slicing, the shell branch, and the collision guard are deleted — this removes the whole bug class, not just this instance.
- **`isShellToolDisplayName` owns the shell question,** and all remaining sites call it. The shell set is now identical everywhere (`exec`, `bash`, `shell`); previously `streaming.ts:334` and `tool-meta.ts` omitted `shell` while `streaming.ts:1139` included it.

Compared against the Codex harness, which renders this correctly today: it emits one structured item per tool call keyed by the backend's own item id (`extensions/codex/src/app-server/event-projector-events.ts:104-130`). The CLI runner's events were never the problem — only the shared display layer that mis-read their names.

## User Impact

Claude CLI turns now render one line per tool call with a single icon, matching embedded-runner turns. This is the default path for operators running `agentRuntime.id: "claude-cli"`.

Non-shell CLI tools (`Read`, `Edit`, `Grep`, `WebFetch`, MCP tools) were affected through the same merge path and now dedupe too. Embedded runs are unchanged: they already sent lowercase names, so every comparison already matched. No config surface added, changed, or retired.

One behavior note: a tool literally named `shell` now takes the compact command form in `formatToolAggregate` and in line `detail`, matching what `getProgressDraftLineText` already did for it.

## Evidence

**Live A/B on the real Claude CLI backend** (`claude` 2.1.220, haiku), identical prompt, real Telegram group via the userbot lane:

| | Before | After |
| --- | --- | --- |
| lines per tool call | 2 | **1** |
| `🛠️` per line | 2 | **1** |

```
before: Working ⏎ 🛠️ Bash 🛠️ print text → run sleep 2 → print text ⏎ 🛠️ print text → run sleep 2 → print text
after:  Working ⏎ 🛠️ Bash print text → run sleep 2 → print text ⏎ alpha beta ⏎ 🛠️ 1 tool call · ⏱️ 12s
```

Re-confirmed live on the final commit, after the formatter refactor.

**Unit coverage, all falsifying** (each verified failing with the fix stashed):

- `extensions/telegram/src/progress-draft-preview.test.ts` (new) — exactly one tool icon per rendered line for `Bash`, `bash`, `exec`; label and detail stay separate for a non-shell tool.
- `src/channels/streaming.test.ts` — table-driven over real Claude CLI tool shapes (`Bash`, `Read`, `Edit`, `mcp__openclaw__exec`): the structured line and the tool-summary payload merge to one line, with both sides deriving meta through the same helper the CLI summary tracker uses; plus an assertion that the shell line keeps its `detail` and its text is `icon + detail`.
- `src/agents/tool-display.test.ts` — the predicate across casings, and the compact summary form for a capitalized shell tool.

**Suites:** `src/auto-reply` 1229, `src/channels` 3786, `src/agents/tool-display` 1008, `extensions/telegram` 2961 — all passing. Typecheck clean (`tsgo:core`, `tsgo:extensions`), oxlint clean, autoreview clean (0.98). Non-test source is net **−12 lines**.

**Performance** (measured, not estimated): the normalized predicate costs +9.9 ns/call versus the previous direct comparisons, about 128 ns per tool event across the bounded `maxLines` merge loop — six orders of magnitude below the 50–200 ms Telegram edit round trip it precedes, and 0.013% of one core at 100× event volume. No caching added.

### Known gap, not addressed here

Claude CLI tool lines still carry no lifecycle status. The CLI runner emits `stream: "tool"` but never the item/`command-output` lane, so a failed call renders identically to a successful one, while embedded and Codex show `exit 2; false` or a failed status. Measured across the three lanes:

```
CLI      (event:"tool", phase result)  → "🛠️ false"          status: none
embedded (command-output, exitCode 2)  → "🛠️ exit 2; false"  status: "exit 2"
codex    (item, status failed)         → "🛠️ Exec"           status: "failed"
```

That is an emission-side change in the CLI runner rather than a display-layer fix, so it belongs in its own PR with its own proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)