### PR TITLE
fix(heartbeat): serialize wake lifecycle state

### DIFF
--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -585,10 +585,15 @@ export function startHeartbeatRunner(opts: {
       return;
     }
     state.stopped = true;
+    opts.abortSignal?.removeEventListener("abort", cleanup);
     disposeWakeHandler();
   };
 
-  opts.abortSignal?.addEventListener("abort", cleanup, { once: true });
+  if (opts.abortSignal?.aborted) {
+    cleanup();
+  } else {
+    opts.abortSignal?.addEventListener("abort", cleanup, { once: true });
+  }
 
   return { stop: cleanup, updateConfig };
 }

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -12,6 +12,7 @@ import {
 import { startHeartbeatRunner } from "./heartbeat-runner.js";
 import { computeNextHeartbeatPhaseDueMs, resolveHeartbeatPhaseMs } from "./heartbeat-schedule.js";
 import {
+  getHeartbeatWakeAbortSignal,
   HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
   requestHeartbeat,
   setHeartbeatWakeHandler,
@@ -62,6 +63,86 @@ describe("startHeartbeatRunner", () => {
     await vi.advanceTimersByTimeAsync(31 * 60_000);
     expect(runOnce).not.toHaveBeenCalled();
     runner.stop();
+  });
+
+  it("starts stopped when its owner signal is already aborted", async () => {
+    useFakeHeartbeatTime();
+    const owner = new AbortController();
+    owner.abort();
+    const runOnce = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig(),
+      runOnce,
+      abortSignal: owner.signal,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    requestHeartbeat({
+      source: "manual",
+      intent: "manual",
+      reason: "manual",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runOnce).not.toHaveBeenCalled();
+
+    const drain = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" });
+    const disposeDrain = setHeartbeatWakeHandler(drain);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(drain).toHaveBeenCalledOnce();
+    disposeDrain();
+    runner.stop();
+  });
+
+  it("removes its owner abort listener on manual stop", () => {
+    const owner = new AbortController();
+    const removeListener = vi.spyOn(owner.signal, "removeEventListener");
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig(),
+      abortSignal: owner.signal,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    runner.stop();
+
+    expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+  });
+
+  it("aborts an active wake when the runner stops", async () => {
+    useFakeHeartbeatTime();
+    let finishWake: (() => void) | undefined;
+    const wakeFinished = new Promise<void>((resolve) => {
+      finishWake = resolve;
+    });
+    let wakeSignal: AbortSignal | undefined;
+    const runOnce = vi.fn(async () => {
+      wakeSignal = getHeartbeatWakeAbortSignal();
+      await wakeFinished;
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    const runner = startDefaultRunner(runOnce);
+    requestHeartbeat({
+      source: "manual",
+      intent: "manual",
+      reason: "manual",
+      sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(wakeSignal?.aborted).toBe(false);
+
+    runner.stop();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(wakeSignal?.aborted).toBe(true);
+    finishWake?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const drain = vi.fn().mockResolvedValue({ status: "skipped", reason: "disabled" });
+    const disposeDrain = setHeartbeatWakeHandler(drain);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(drain).toHaveBeenCalledOnce();
+    disposeDrain();
   });
 
   function resolveDueFromNow(nowMs: number, intervalMs: number, agentId: string) {

--- a/src/infra/heartbeat-wake-concurrency.test.ts
+++ b/src/infra/heartbeat-wake-concurrency.test.ts
@@ -38,7 +38,7 @@ describe("heartbeat wake target concurrency", () => {
     vi.restoreAllMocks();
   });
 
-  it("flushes target wakes before an unscoped barrier that was originally queued first", async () => {
+  it("holds a post-barrier target while an earlier unscoped wake coalesces", async () => {
     vi.useFakeTimers();
     const handler = vi.fn(async (_request: WakeRequest) => ({
       status: "ran" as const,
@@ -59,18 +59,18 @@ describe("heartbeat wake target concurrency", () => {
       agentId: "main",
       sessionKey: "agent:main:guildchat:channel:123",
     });
-    requestHeartbeat({
-      source: "other",
-      intent: "immediate",
-      reason: "test-global-flush",
-      coalesceMs: 0,
-    });
+    await vi.advanceTimersByTimeAsync(999);
+    expect(handler).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(1);
 
     expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+      "test-delayed-global-flush",
+    ]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+      "test-delayed-global-flush",
       "background-task",
-      "test-global-flush",
     ]);
     expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
@@ -156,6 +156,120 @@ describe("heartbeat wake target concurrency", () => {
       await vi.advanceTimersByTimeAsync(0);
     }
 
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("serializes redundant agent-plus-session identity with the same canonical session", async () => {
+    vi.useFakeTimers();
+    let finishFirstWake: (() => void) | undefined;
+    const firstWakeFinished = new Promise<void>((resolve) => {
+      finishFirstWake = resolve;
+    });
+    const handler = vi.fn(async (request: WakeRequest) => {
+      if (request.reason === "session-only") {
+        await firstWakeFinished;
+      }
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(handler);
+    const sessionKey = "agent:main:guildchat:channel:123";
+
+    requestHeartbeat({
+      source: "cron",
+      intent: "event",
+      reason: "session-only",
+      sessionKey,
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    requestHeartbeat({
+      source: "cron",
+      intent: "event",
+      reason: "redundant-agent",
+      agentId: "main",
+      sessionKey,
+      coalesceMs: 0,
+    });
+
+    try {
+      await vi.advanceTimersByTimeAsync(1);
+      expect(handler.mock.calls.map(([request]) => request.reason)).toEqual(["session-only"]);
+      expect(getActiveGatewayRootWorkCount()).toBe(1);
+    } finally {
+      finishFirstWake?.();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+      "session-only",
+      "redundant-agent",
+    ]);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("runs an unscoped wake as an exclusive barrier between targeted groups", async () => {
+    vi.useFakeTimers();
+    let finishBeforeBarrier: (() => void) | undefined;
+    let finishBarrier: (() => void) | undefined;
+    const beforeBarrierFinished = new Promise<void>((resolve) => {
+      finishBeforeBarrier = resolve;
+    });
+    const barrierFinished = new Promise<void>((resolve) => {
+      finishBarrier = resolve;
+    });
+    const handler = vi.fn(async (request: WakeRequest) => {
+      if (request.reason === "before-barrier") {
+        await beforeBarrierFinished;
+      } else if (request.reason === "global-barrier") {
+        await barrierFinished;
+      }
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeat({
+      source: "cron",
+      intent: "event",
+      reason: "before-barrier",
+      sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    requestHeartbeat({
+      source: "other",
+      intent: "immediate",
+      reason: "global-barrier",
+      coalesceMs: 0,
+    });
+    for (const agentId of ["ops", "support"]) {
+      requestHeartbeat({
+        source: "cron",
+        intent: "event",
+        reason: `after-barrier:${agentId}`,
+        sessionKey: `agent:${agentId}:main`,
+        coalesceMs: 0,
+      });
+    }
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler.mock.calls.map(([request]) => request.reason)).toEqual(["before-barrier"]);
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+
+    finishBeforeBarrier?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+      "before-barrier",
+      "global-barrier",
+    ]);
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+
+    finishBarrier?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(handler.mock.calls.map(([request]) => request.reason)).toEqual([
+      "before-barrier",
+      "global-barrier",
+      "after-barrier:ops",
+      "after-barrier:support",
+    ]);
     expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
 
@@ -304,6 +418,63 @@ describe("heartbeat wake target concurrency", () => {
 
     expect(newHandler).toHaveBeenCalledTimes(8);
     expect(peakActiveWakeCount).toBe(4);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
+  it("aborts the disposed generation without letting its stale disposer abort a replacement", async () => {
+    vi.useFakeTimers();
+    let finishOldWake: (() => void) | undefined;
+    let finishNewWake: (() => void) | undefined;
+    const oldWakeFinished = new Promise<void>((resolve) => {
+      finishOldWake = resolve;
+    });
+    const newWakeFinished = new Promise<void>((resolve) => {
+      finishNewWake = resolve;
+    });
+    let oldSignal: AbortSignal | undefined;
+    let newSignal: AbortSignal | undefined;
+    const oldHandler = vi.fn(async () => {
+      oldSignal = getHeartbeatWakeAbortSignal();
+      await oldWakeFinished;
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    const disposeOld = setRuntimeHeartbeatWakeHandler(oldHandler);
+    currentHandlerDisposer = disposeOld;
+    requestHeartbeat({
+      source: "cron",
+      intent: "event",
+      reason: "generation-owned",
+      sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(oldSignal?.aborted).toBe(false);
+
+    disposeOld();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(oldSignal?.aborted).toBe(true);
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+
+    const newHandler = vi.fn(async () => {
+      newSignal = getHeartbeatWakeAbortSignal();
+      await newWakeFinished;
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    const disposeNew = setRuntimeHeartbeatWakeHandler(newHandler);
+    currentHandlerDisposer = disposeNew;
+    await vi.advanceTimersByTimeAsync(250);
+    expect(newHandler).toHaveBeenCalledOnce();
+    expect(newSignal?.aborted).toBe(false);
+
+    disposeOld();
+    expect(newSignal?.aborted).toBe(false);
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+
+    disposeNew();
+    finishOldWake?.();
+    finishNewWake?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(newSignal?.aborted).toBe(true);
     expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
 

--- a/src/infra/heartbeat-wake-contracts.ts
+++ b/src/infra/heartbeat-wake-contracts.ts
@@ -1,0 +1,53 @@
+export type HeartbeatRunResult =
+  | { status: "ran"; durationMs: number }
+  | { status: "skipped"; reason: string; retryAtMs?: number }
+  | { status: "failed"; reason: string };
+
+export type HeartbeatWakeIntent = "scheduled" | "task" | "event" | "immediate" | "manual";
+
+export type HeartbeatWakeSource =
+  | "interval"
+  | "manual"
+  | "exec-event"
+  | "notifications-event"
+  | "cron"
+  | "hook"
+  | "background-task"
+  | "background-task-blocked"
+  | "acp-spawn"
+  | "session-state"
+  | "cli-watchdog"
+  | "restart-sentinel"
+  | "retry"
+  | "other";
+
+export type HeartbeatWakeOverride = {
+  target?: string;
+  to?: string | undefined;
+  accountId?: string | undefined;
+};
+
+/** Cron-owned periodic work carried directly into a guarded heartbeat turn. */
+export type HeartbeatScheduledTask = {
+  jobId: string;
+  name: string;
+  prompt: string;
+};
+
+export type HeartbeatWakeRequest = {
+  source: HeartbeatWakeSource;
+  intent: HeartbeatWakeIntent;
+  reason?: string;
+  agentId?: string;
+  sessionKey?: string;
+  heartbeat?: HeartbeatWakeOverride;
+  /** Persisted cron monitor cadence carried with a scheduled heartbeat tick. */
+  scheduledEveryMs?: number;
+  /** Persisted cron monitor phase anchor carried with a scheduled heartbeat tick. */
+  scheduledAnchorMs?: number;
+  tasks?: readonly HeartbeatScheduledTask[];
+  /** Internal marker for work retained after a spacing/cooldown deferral. */
+  retainedWork?: boolean;
+};
+
+export type HeartbeatWakeHandler = (opts: HeartbeatWakeRequest) => Promise<HeartbeatRunResult>;

--- a/src/infra/heartbeat-wake-lifecycle.ts
+++ b/src/infra/heartbeat-wake-lifecycle.ts
@@ -1,0 +1,60 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type {
+  HeartbeatRunResult,
+  HeartbeatWakeHandler,
+  HeartbeatWakeRequest,
+} from "./heartbeat-wake.js";
+
+export type ActiveHeartbeatWakeTarget = {
+  generation: number;
+  abortController: AbortController;
+};
+
+const heartbeatWakeAbortSignals = new AsyncLocalStorage<AbortSignal>();
+
+/** Propagate lifecycle cancellation into the provider's existing reply abort contract. */
+export function getHeartbeatWakeAbortSignal(): AbortSignal | undefined {
+  return heartbeatWakeAbortSignals.getStore();
+}
+
+export async function runAbortableHeartbeatWake(
+  active: HeartbeatWakeHandler,
+  wake: HeartbeatWakeRequest,
+  signal: AbortSignal,
+): Promise<HeartbeatRunResult> {
+  let abortListener: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    abortListener = () => {
+      const abortReason = signal.reason;
+      reject(
+        abortReason instanceof Error ? abortReason : new Error("Heartbeat handler was replaced"),
+      );
+    };
+    if (signal.aborted) {
+      abortListener();
+      return;
+    }
+    signal.addEventListener("abort", abortListener, { once: true });
+  });
+  try {
+    // Keep provider cancellation in the existing reply AbortSignal contract;
+    // racing it also retires a non-cooperative stale handler on replacement.
+    const running = heartbeatWakeAbortSignals.run(signal, () => active(wake));
+    return await Promise.race([running, aborted]);
+  } finally {
+    if (abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
+  }
+}
+
+export function abortHeartbeatWakeGeneration(
+  activeTargets: Iterable<ActiveHeartbeatWakeTarget>,
+  generation: number,
+): void {
+  for (const activeTarget of activeTargets) {
+    if (activeTarget.generation === generation) {
+      activeTarget.abortController.abort();
+    }
+  }
+}

--- a/src/infra/heartbeat-wake-lifecycle.ts
+++ b/src/infra/heartbeat-wake-lifecycle.ts
@@ -3,7 +3,7 @@ import type {
   HeartbeatRunResult,
   HeartbeatWakeHandler,
   HeartbeatWakeRequest,
-} from "./heartbeat-wake.js";
+} from "./heartbeat-wake-contracts.js";
 
 export type ActiveHeartbeatWakeTarget = {
   generation: number;

--- a/src/infra/heartbeat-wake-target.ts
+++ b/src/infra/heartbeat-wake-target.ts
@@ -1,0 +1,59 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+
+export const GLOBAL_HEARTBEAT_WAKE_TARGET_KEY = "::";
+
+type HeartbeatWakeReadiness = {
+  readyAtMs?: number;
+  notBeforeMs?: number;
+};
+
+export function normalizeHeartbeatWakeTarget(value?: string): string | undefined {
+  const trimmed = normalizeOptionalString(value) ?? "";
+  return trimmed || undefined;
+}
+
+export function resolveHeartbeatWakeTargetKey(params: {
+  agentId?: string;
+  sessionKey?: string;
+}): string {
+  const agentId = normalizeHeartbeatWakeTarget(params.agentId);
+  const sessionKey = normalizeHeartbeatWakeTarget(params.sessionKey);
+  // A canonical session owns serialization. Some callers also carry the
+  // already-derived agent id; that redundant routing fact must not split one
+  // session into two concurrent target groups.
+  return sessionKey ? `::${sessionKey}` : `${agentId ?? ""}::`;
+}
+
+export function isHeartbeatWakeAfterGlobalBarrier(
+  targetKey: string,
+  enqueueSequence: number,
+  barrierSequence: number | undefined,
+): boolean {
+  return (
+    barrierSequence !== undefined &&
+    targetKey !== GLOBAL_HEARTBEAT_WAKE_TARGET_KEY &&
+    enqueueSequence >= barrierSequence
+  );
+}
+
+export function isHeartbeatWakeTargetGroupReady(
+  group:
+    | {
+        blockedUntilMs?: number;
+        task?: HeartbeatWakeReadiness;
+        scheduled?: HeartbeatWakeReadiness;
+        event?: HeartbeatWakeReadiness;
+      }
+    | undefined,
+  now: number,
+): boolean {
+  if (!group || (group.blockedUntilMs !== undefined && group.blockedUntilMs > now)) {
+    return false;
+  }
+  return [group.task, group.scheduled, group.event].some(
+    (pending) =>
+      pending !== undefined &&
+      (pending.readyAtMs === undefined || pending.readyAtMs <= now) &&
+      (pending.notBeforeMs === undefined || pending.notBeforeMs <= now),
+  );
+}

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -868,10 +868,11 @@ describe("heartbeat-wake", () => {
     const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
     setHeartbeatWakeHandler(handlerB);
 
-    // The replacement must handle both fresh work and the interrupted wake.
+    // The replacement must handle both the interrupted global barrier and fresh
+    // targeted work. The recovered barrier runs first so the two cannot overlap.
     requestHeartbeat(wake("interval", { agentId: "ready", coalesceMs: 0 }));
     await vi.advanceTimersByTimeAsync(1);
-    expect(handlerB.mock.calls.map(([request]) => request.agentId)).toEqual(["ready", undefined]);
+    expect(handlerB.mock.calls.map(([request]) => request.agentId)).toEqual([undefined, "ready"]);
 
     // Clean up the hanging promise
     resolveHang!();

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -89,6 +89,10 @@ type PendingWakeReason = {
   reason: string;
   priority: number;
   requestedAt: number;
+  /** Stable enqueue order retained across coalescing, deferral, and lifecycle handoff. */
+  enqueueSequence: number;
+  /** First immediate-global request represented by this coalesced wake. */
+  immediateBarrierSequence?: number;
   /** Earliest dispatch instant requested by the wake's coalescing window. */
   readyAtMs?: number;
   agentId?: string;
@@ -130,12 +134,14 @@ const activeWakeTargets = new Map<string, ActiveWakeTarget>();
 const heartbeatWakeAbortSignals = new AsyncLocalStorage<AbortSignal>();
 let timer: NodeJS.Timeout | null = null;
 let timerDueAt: number | null = null;
+let wakeEnqueueSequence = 0;
 
 const DEFAULT_COALESCE_MS = 250;
 const DEFAULT_RETRY_MS = 1_000;
 // Heartbeat turns can start model/provider work; bound cross-target fan-out so
 // one aligned monitor tick cannot exhaust gateway or provider capacity.
 const MAX_CONCURRENT_HEARTBEAT_WAKE_TARGETS = 4;
+const GLOBAL_WAKE_TARGET_KEY = "::";
 const REASON_PRIORITY = {
   RETRY: 0,
   INTERVAL: 1,
@@ -181,7 +187,38 @@ function normalizeWakeTarget(value?: string): string | undefined {
 function getWakeTargetBaseKey(params: { agentId?: string; sessionKey?: string }) {
   const agentId = normalizeWakeTarget(params.agentId);
   const sessionKey = normalizeWakeTarget(params.sessionKey);
-  return `${agentId ?? ""}::${sessionKey ?? ""}`;
+  // A canonical session owns serialization. Some callers also carry the
+  // already-derived agent id; that redundant routing fact must not split one
+  // session into two concurrent target groups.
+  return sessionKey ? `::${sessionKey}` : `${agentId ?? ""}::`;
+}
+
+function isPendingWakeReady(pending: PendingWakeReason, now: number): boolean {
+  return (
+    (pending.readyAtMs === undefined || pending.readyAtMs <= now) &&
+    (pending.notBeforeMs === undefined || pending.notBeforeMs <= now)
+  );
+}
+
+function isPendingWakeGroupReady(group: PendingWakeGroup | undefined, now: number): boolean {
+  if (!group || (group.blockedUntilMs !== undefined && group.blockedUntilMs > now)) {
+    return false;
+  }
+  return [group.task, group.scheduled, group.event].some(
+    (pending) => pending !== undefined && isPendingWakeReady(pending, now),
+  );
+}
+
+function isPostBarrierTargetWake(
+  targetKey: string,
+  pending: PendingWakeReason,
+  barrierSequence: number | undefined,
+): boolean {
+  return (
+    barrierSequence !== undefined &&
+    targetKey !== GLOBAL_WAKE_TARGET_KEY &&
+    pending.enqueueSequence >= barrierSequence
+  );
 }
 
 function mergePendingWakeReasons(
@@ -217,12 +254,17 @@ function mergePendingWakeReasons(
     (previous.guardRetry === true || next.guardRetry === true);
   const scheduledEveryMs = preferred.scheduledEveryMs ?? other.scheduledEveryMs;
   const scheduledAnchorMs = preferred.scheduledAnchorMs ?? other.scheduledAnchorMs;
+  const immediateBarrierSequences = [
+    previous.immediateBarrierSequence,
+    next.immediateBarrierSequence,
+  ].filter((value): value is number => value !== undefined);
   const readyAtMs = Math.min(
     previous.readyAtMs ?? previous.requestedAt,
     next.readyAtMs ?? next.requestedAt,
   );
   const merged: PendingWakeReason = {
     ...preferred,
+    enqueueSequence: Math.min(previous.enqueueSequence, next.enqueueSequence),
     readyAtMs,
     ...(!bypassGuardRetry && (previous.notBeforeMs !== undefined || next.notBeforeMs !== undefined)
       ? {
@@ -242,6 +284,11 @@ function mergePendingWakeReasons(
   } else {
     delete merged.guardRetry;
   }
+  if (immediateBarrierSequences.length > 0) {
+    merged.immediateBarrierSequence = Math.min(...immediateBarrierSequences);
+  } else {
+    delete merged.immediateBarrierSequence;
+  }
   return merged;
 }
 
@@ -249,21 +296,40 @@ function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGro
   if (maxGroups <= 0) {
     return [];
   }
-  const globalWakeGroup = pendingWakes.get("::");
+  const globalWakeGroup = pendingWakes.get(GLOBAL_WAKE_TARGET_KEY);
   const globalImmediateWake = globalWakeGroup?.event;
   // An unscoped immediate wake is a global flush barrier. Preserve the task
   // registry contract while keeping spacing and busy guards authoritative.
   const flushPendingCoalescing =
     globalImmediateWake?.intent === "immediate" &&
-    !activeWakeTargets.has("::") &&
+    !activeWakeTargets.has(GLOBAL_WAKE_TARGET_KEY) &&
     (globalWakeGroup?.blockedUntilMs === undefined || globalWakeGroup.blockedUntilMs <= now) &&
     (globalImmediateWake.readyAtMs === undefined || globalImmediateWake.readyAtMs <= now) &&
     (globalImmediateWake.notBeforeMs === undefined || globalImmediateWake.notBeforeMs <= now);
+  const globalBarrierCutoffSequence =
+    globalImmediateWake?.intent === "immediate"
+      ? globalImmediateWake.immediateBarrierSequence
+      : undefined;
+  const globalBarrierReady = isPendingWakeGroupReady(globalWakeGroup, now);
+  if (activeWakeTargets.has(GLOBAL_WAKE_TARGET_KEY)) {
+    return [];
+  }
+  // An unscoped wake can fan out across every configured heartbeat agent.
+  // Never admit it beside a targeted turn. Immediate flushes first drain only
+  // target work that predates the barrier; every other global wake takes the
+  // barrier as soon as existing targeted turns have retired.
+  if (globalBarrierReady && activeWakeTargets.size > 0) {
+    return [];
+  }
   const readyGroups: Array<{ targetKey: string; group: PendingWakeGroup }> = [];
-  const pendingEntries = flushPendingCoalescing
-    ? [...pendingWakes.entries()].toSorted(
-        ([leftTarget], [rightTarget]) => Number(leftTarget === "::") - Number(rightTarget === "::"),
-      )
+  const pendingEntries = globalBarrierReady
+    ? flushPendingCoalescing
+      ? [...pendingWakes.entries()].toSorted(
+          ([leftTarget], [rightTarget]) =>
+            Number(leftTarget === GLOBAL_WAKE_TARGET_KEY) -
+            Number(rightTarget === GLOBAL_WAKE_TARGET_KEY),
+        )
+      : [[GLOBAL_WAKE_TARGET_KEY, globalWakeGroup as PendingWakeGroup] as const]
     : pendingWakes.entries();
   for (const [targetKey, group] of pendingEntries) {
     if (readyGroups.length >= maxGroups) {
@@ -275,6 +341,12 @@ function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGro
     ) {
       continue;
     }
+    if (
+      targetKey === GLOBAL_WAKE_TARGET_KEY &&
+      (activeWakeTargets.size > 0 || readyGroups.length > 0)
+    ) {
+      continue;
+    }
     const ready: PendingWakeGroup = {};
     const remaining: PendingWakeGroup = {};
     for (const slot of ["task", "scheduled", "event"] as const) {
@@ -282,7 +354,13 @@ function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGro
       if (!pending) {
         continue;
       }
+      const isPostBarrierTarget = isPostBarrierTargetWake(
+        targetKey,
+        pending,
+        globalBarrierCutoffSequence,
+      );
       if (
+        !isPostBarrierTarget &&
         (flushPendingCoalescing || pending.readyAtMs === undefined || pending.readyAtMs <= now) &&
         (pending.notBeforeMs === undefined || pending.notBeforeMs <= now)
       ) {
@@ -345,6 +423,8 @@ function queuePendingWakeReason(params: {
   intent: HeartbeatWakeIntent;
   reason?: string;
   requestedAt?: number;
+  enqueueSequence?: number;
+  immediateBarrierSequence?: number;
   readyAtMs?: number;
   agentId?: string;
   sessionKey?: string;
@@ -357,6 +437,7 @@ function queuePendingWakeReason(params: {
   guardRetry?: boolean;
 }) {
   const requestedAt = params.requestedAt ?? Date.now();
+  const enqueueSequence = params.enqueueSequence ?? ++wakeEnqueueSequence;
   const normalizedReason = normalizeWakeReason(params.reason);
   const normalizedAgentId = normalizeWakeTarget(params.agentId);
   const normalizedSessionKey = normalizeWakeTarget(params.sessionKey);
@@ -364,6 +445,11 @@ function queuePendingWakeReason(params: {
     agentId: normalizedAgentId,
     sessionKey: normalizedSessionKey,
   });
+  const immediateBarrierSequence =
+    params.immediateBarrierSequence ??
+    (wakeTargetKey === GLOBAL_WAKE_TARGET_KEY && params.intent === "immediate"
+      ? enqueueSequence
+      : undefined);
   const next: PendingWakeReason = {
     source: params.source,
     intent: params.intent,
@@ -374,6 +460,8 @@ function queuePendingWakeReason(params: {
       reason: normalizedReason,
     }),
     requestedAt,
+    enqueueSequence,
+    ...(immediateBarrierSequence === undefined ? {} : { immediateBarrierSequence }),
     ...(params.readyAtMs === undefined ? {} : { readyAtMs: params.readyAtMs }),
     agentId: normalizedAgentId,
     sessionKey: normalizedSessionKey,
@@ -414,6 +502,8 @@ function retryPendingWake(pendingWake: PendingWakeReason) {
     scheduledAnchorMs: pendingWake.scheduledAnchorMs,
     tasks: pendingWake.tasks,
     requestedAt: pendingWake.requestedAt,
+    enqueueSequence: pendingWake.enqueueSequence,
+    immediateBarrierSequence: pendingWake.immediateBarrierSequence,
     blockTargetUntilMs: Date.now() + DEFAULT_RETRY_MS,
   });
   schedule(DEFAULT_RETRY_MS);
@@ -509,6 +599,8 @@ async function dispatchPendingWakeGroup(params: {
           scheduledEveryMs: pendingWake.scheduledEveryMs,
           scheduledAnchorMs: pendingWake.scheduledAnchorMs,
           requestedAt: pendingWake.requestedAt,
+          enqueueSequence: pendingWake.enqueueSequence,
+          immediateBarrierSequence: pendingWake.immediateBarrierSequence,
           notBeforeMs: retryAtMs,
           guardRetry: true,
         });
@@ -614,18 +706,44 @@ function schedulePendingWakes(readyDelayMs: number) {
     return;
   }
   const now = Date.now();
+  if (
+    activeWakeTargets.has(GLOBAL_WAKE_TARGET_KEY) ||
+    (activeWakeTargets.size > 0 &&
+      isPendingWakeGroupReady(pendingWakes.get(GLOBAL_WAKE_TARGET_KEY), now))
+  ) {
+    // The active side of a global barrier re-arms pending work when it exits.
+    // Avoid zero-delay timer churn while the other side is still draining.
+    return;
+  }
+  const pendingGlobalImmediateWake = pendingWakes.get(GLOBAL_WAKE_TARGET_KEY)?.event;
+  const globalBarrierCutoffSequence =
+    pendingGlobalImmediateWake?.intent === "immediate"
+      ? pendingGlobalImmediateWake.immediateBarrierSequence
+      : undefined;
   let earliestNotBeforeMs = Number.POSITIVE_INFINITY;
   let hasReadyWake = false;
   for (const [targetKey, group] of pendingWakes) {
     if (activeWakeTargets.has(targetKey)) {
       continue;
     }
+    const groupWakes = [group.task, group.scheduled, group.event];
+    if (
+      groupWakes.every(
+        (pending) =>
+          !pending || isPostBarrierTargetWake(targetKey, pending, globalBarrierCutoffSequence),
+      )
+    ) {
+      continue;
+    }
     if (group.blockedUntilMs !== undefined && group.blockedUntilMs > now) {
       earliestNotBeforeMs = Math.min(earliestNotBeforeMs, group.blockedUntilMs);
       continue;
     }
-    for (const pending of [group.task, group.scheduled, group.event]) {
-      if (!pending) {
+    for (const pending of groupWakes) {
+      if (
+        !pending ||
+        isPostBarrierTargetWake(targetKey, pending, globalBarrierCutoffSequence)
+      ) {
         continue;
       }
       const nextReadyAtMs = Math.max(pending.readyAtMs ?? 0, pending.notBeforeMs ?? 0);
@@ -656,6 +774,14 @@ function clearPendingWakeRetryState() {
   }
 }
 
+function abortActiveWakeTargets(generation: number) {
+  for (const activeTarget of activeWakeTargets.values()) {
+    if (activeTarget.generation === generation) {
+      activeTarget.abortController.abort();
+    }
+  }
+}
+
 /**
  * Register (or clear) the heartbeat wake handler.
  * Returns a disposer function that clears this specific registration.
@@ -663,9 +789,13 @@ function clearPendingWakeRetryState() {
  * a race where an old runner's cleanup clears a newer runner's handler.
  */
 export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () => void {
+  const previousGeneration = handlerGeneration;
   handlerGeneration += 1;
   const generation = handlerGeneration;
   handler = next;
+  // Registration changes retire only the lifecycle they replaced. A stale
+  // disposer must never cancel active work owned by a newer handler.
+  abortActiveWakeTargets(previousGeneration);
   if (next) {
     // New lifecycle starting (e.g. after SIGUSR1 in-process restart).
     // Clear any timer metadata from the previous lifecycle so stale retry
@@ -675,11 +805,6 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
     }
     timer = null;
     timerDueAt = null;
-    // Cancel old provider turns before their own generation releases its slot.
-    // This preserves the cap and lets a stuck lifecycle recover on replacement.
-    for (const activeTarget of activeWakeTargets.values()) {
-      activeTarget.abortController.abort();
-    }
     clearPendingWakeRetryState();
   }
   if (handler && pendingWakes.size > 0) {
@@ -692,6 +817,7 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
     if (handler !== next) {
       return;
     }
+    abortActiveWakeTargets(generation);
     handlerGeneration += 1;
     handler = null;
   };

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -2,6 +2,14 @@
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { normalizeHeartbeatWakeReason } from "./heartbeat-reason.js";
+import type {
+  HeartbeatRunResult,
+  HeartbeatScheduledTask,
+  HeartbeatWakeHandler,
+  HeartbeatWakeIntent,
+  HeartbeatWakeOverride,
+  HeartbeatWakeSource,
+} from "./heartbeat-wake-contracts.js";
 import {
   abortHeartbeatWakeGeneration,
   type ActiveHeartbeatWakeTarget,
@@ -16,11 +24,14 @@ import {
 } from "./heartbeat-wake-target.js";
 
 export { getHeartbeatWakeAbortSignal } from "./heartbeat-wake-lifecycle.js";
-
-export type HeartbeatRunResult =
-  | { status: "ran"; durationMs: number }
-  | { status: "skipped"; reason: string; retryAtMs?: number }
-  | { status: "failed"; reason: string };
+export type {
+  HeartbeatRunResult,
+  HeartbeatScheduledTask,
+  HeartbeatWakeHandler,
+  HeartbeatWakeIntent,
+  HeartbeatWakeRequest,
+  HeartbeatWakeSource,
+} from "./heartbeat-wake-contracts.js";
 
 export const HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT = "requests-in-flight";
 export const HEARTBEAT_SKIP_CRON_IN_PROGRESS = "cron-in-progress";
@@ -35,55 +46,6 @@ const RETRYABLE_GUARD_SKIP_REASONS = new Set(["not-due", "min-spacing", "flood"]
 export function isRetryableHeartbeatBusySkipReason(reason: string): boolean {
   return RETRYABLE_BUSY_SKIP_REASONS.has(reason);
 }
-
-export type HeartbeatWakeIntent = "scheduled" | "task" | "event" | "immediate" | "manual";
-
-export type HeartbeatWakeSource =
-  | "interval"
-  | "manual"
-  | "exec-event"
-  | "notifications-event"
-  | "cron"
-  | "hook"
-  | "background-task"
-  | "background-task-blocked"
-  | "acp-spawn"
-  | "session-state"
-  | "cli-watchdog"
-  | "restart-sentinel"
-  | "retry"
-  | "other";
-
-type HeartbeatWakeOverride = {
-  target?: string;
-  to?: string | undefined;
-  accountId?: string | undefined;
-};
-
-/** Cron-owned periodic work carried directly into a guarded heartbeat turn. */
-export type HeartbeatScheduledTask = {
-  jobId: string;
-  name: string;
-  prompt: string;
-};
-
-export type HeartbeatWakeRequest = {
-  source: HeartbeatWakeSource;
-  intent: HeartbeatWakeIntent;
-  reason?: string;
-  agentId?: string;
-  sessionKey?: string;
-  heartbeat?: HeartbeatWakeOverride;
-  /** Persisted cron monitor cadence carried with a scheduled heartbeat tick. */
-  scheduledEveryMs?: number;
-  /** Persisted cron monitor phase anchor carried with a scheduled heartbeat tick. */
-  scheduledAnchorMs?: number;
-  tasks?: readonly HeartbeatScheduledTask[];
-  /** Internal marker for work retained after a spacing/cooldown deferral. */
-  retainedWork?: boolean;
-};
-
-export type HeartbeatWakeHandler = (opts: HeartbeatWakeRequest) => Promise<HeartbeatRunResult>;
 
 let heartbeatsEnabled = true;
 

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -740,10 +740,7 @@ function schedulePendingWakes(readyDelayMs: number) {
       continue;
     }
     for (const pending of groupWakes) {
-      if (
-        !pending ||
-        isPostBarrierTargetWake(targetKey, pending, globalBarrierCutoffSequence)
-      ) {
+      if (!pending || isPostBarrierTargetWake(targetKey, pending, globalBarrierCutoffSequence)) {
         continue;
       }
       const nextReadyAtMs = Math.max(pending.readyAtMs ?? 0, pending.notBeforeMs ?? 0);

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -1,9 +1,21 @@
 // Tracks heartbeat wake requests, busy skips, and retry timing.
-import { AsyncLocalStorage } from "node:async_hooks";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { resolveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { normalizeHeartbeatWakeReason } from "./heartbeat-reason.js";
+import {
+  abortHeartbeatWakeGeneration,
+  type ActiveHeartbeatWakeTarget,
+  runAbortableHeartbeatWake,
+} from "./heartbeat-wake-lifecycle.js";
+import {
+  GLOBAL_HEARTBEAT_WAKE_TARGET_KEY,
+  isHeartbeatWakeAfterGlobalBarrier,
+  isHeartbeatWakeTargetGroupReady,
+  normalizeHeartbeatWakeTarget,
+  resolveHeartbeatWakeTargetKey,
+} from "./heartbeat-wake-target.js";
+
+export { getHeartbeatWakeAbortSignal } from "./heartbeat-wake-lifecycle.js";
 
 export type HeartbeatRunResult =
   | { status: "ran"; durationMs: number }
@@ -120,18 +132,12 @@ type ReadyWakeGroup = {
   wakes: PendingWakeReason[];
 };
 
-type ActiveWakeTarget = {
-  generation: number;
-  abortController: AbortController;
-};
-
 let handler: HeartbeatWakeHandler | null = null;
 let handlerGeneration = 0;
 // One bounded group per target owns every pending/retry class for that agent/session.
 const pendingWakes = new Map<string, PendingWakeGroup>();
 // Independent targets can run together; each target still owns one serial turn.
-const activeWakeTargets = new Map<string, ActiveWakeTarget>();
-const heartbeatWakeAbortSignals = new AsyncLocalStorage<AbortSignal>();
+const activeWakeTargets = new Map<string, ActiveHeartbeatWakeTarget>();
 let timer: NodeJS.Timeout | null = null;
 let timerDueAt: number | null = null;
 let wakeEnqueueSequence = 0;
@@ -141,18 +147,12 @@ const DEFAULT_RETRY_MS = 1_000;
 // Heartbeat turns can start model/provider work; bound cross-target fan-out so
 // one aligned monitor tick cannot exhaust gateway or provider capacity.
 const MAX_CONCURRENT_HEARTBEAT_WAKE_TARGETS = 4;
-const GLOBAL_WAKE_TARGET_KEY = "::";
 const REASON_PRIORITY = {
   RETRY: 0,
   INTERVAL: 1,
   DEFAULT: 2,
   ACTION: 3,
 } as const;
-
-/** Propagate lifecycle cancellation into the provider's existing reply abort contract. */
-export function getHeartbeatWakeAbortSignal(): AbortSignal | undefined {
-  return heartbeatWakeAbortSignals.getStore();
-}
 
 function resolveWakePriority(params: {
   source: HeartbeatWakeSource;
@@ -177,48 +177,6 @@ function resolveWakePriority(params: {
 
 function normalizeWakeReason(reason?: string): string {
   return normalizeHeartbeatWakeReason(reason);
-}
-
-function normalizeWakeTarget(value?: string): string | undefined {
-  const trimmed = normalizeOptionalString(value) ?? "";
-  return trimmed || undefined;
-}
-
-function getWakeTargetBaseKey(params: { agentId?: string; sessionKey?: string }) {
-  const agentId = normalizeWakeTarget(params.agentId);
-  const sessionKey = normalizeWakeTarget(params.sessionKey);
-  // A canonical session owns serialization. Some callers also carry the
-  // already-derived agent id; that redundant routing fact must not split one
-  // session into two concurrent target groups.
-  return sessionKey ? `::${sessionKey}` : `${agentId ?? ""}::`;
-}
-
-function isPendingWakeReady(pending: PendingWakeReason, now: number): boolean {
-  return (
-    (pending.readyAtMs === undefined || pending.readyAtMs <= now) &&
-    (pending.notBeforeMs === undefined || pending.notBeforeMs <= now)
-  );
-}
-
-function isPendingWakeGroupReady(group: PendingWakeGroup | undefined, now: number): boolean {
-  if (!group || (group.blockedUntilMs !== undefined && group.blockedUntilMs > now)) {
-    return false;
-  }
-  return [group.task, group.scheduled, group.event].some(
-    (pending) => pending !== undefined && isPendingWakeReady(pending, now),
-  );
-}
-
-function isPostBarrierTargetWake(
-  targetKey: string,
-  pending: PendingWakeReason,
-  barrierSequence: number | undefined,
-): boolean {
-  return (
-    barrierSequence !== undefined &&
-    targetKey !== GLOBAL_WAKE_TARGET_KEY &&
-    pending.enqueueSequence >= barrierSequence
-  );
 }
 
 function mergePendingWakeReasons(
@@ -296,13 +254,13 @@ function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGro
   if (maxGroups <= 0) {
     return [];
   }
-  const globalWakeGroup = pendingWakes.get(GLOBAL_WAKE_TARGET_KEY);
+  const globalWakeGroup = pendingWakes.get(GLOBAL_HEARTBEAT_WAKE_TARGET_KEY);
   const globalImmediateWake = globalWakeGroup?.event;
   // An unscoped immediate wake is a global flush barrier. Preserve the task
   // registry contract while keeping spacing and busy guards authoritative.
   const flushPendingCoalescing =
     globalImmediateWake?.intent === "immediate" &&
-    !activeWakeTargets.has(GLOBAL_WAKE_TARGET_KEY) &&
+    !activeWakeTargets.has(GLOBAL_HEARTBEAT_WAKE_TARGET_KEY) &&
     (globalWakeGroup?.blockedUntilMs === undefined || globalWakeGroup.blockedUntilMs <= now) &&
     (globalImmediateWake.readyAtMs === undefined || globalImmediateWake.readyAtMs <= now) &&
     (globalImmediateWake.notBeforeMs === undefined || globalImmediateWake.notBeforeMs <= now);
@@ -310,8 +268,8 @@ function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGro
     globalImmediateWake?.intent === "immediate"
       ? globalImmediateWake.immediateBarrierSequence
       : undefined;
-  const globalBarrierReady = isPendingWakeGroupReady(globalWakeGroup, now);
-  if (activeWakeTargets.has(GLOBAL_WAKE_TARGET_KEY)) {
+  const globalBarrierReady = isHeartbeatWakeTargetGroupReady(globalWakeGroup, now);
+  if (activeWakeTargets.has(GLOBAL_HEARTBEAT_WAKE_TARGET_KEY)) {
     return [];
   }
   // An unscoped wake can fan out across every configured heartbeat agent.
@@ -326,10 +284,10 @@ function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGro
     ? flushPendingCoalescing
       ? [...pendingWakes.entries()].toSorted(
           ([leftTarget], [rightTarget]) =>
-            Number(leftTarget === GLOBAL_WAKE_TARGET_KEY) -
-            Number(rightTarget === GLOBAL_WAKE_TARGET_KEY),
+            Number(leftTarget === GLOBAL_HEARTBEAT_WAKE_TARGET_KEY) -
+            Number(rightTarget === GLOBAL_HEARTBEAT_WAKE_TARGET_KEY),
         )
-      : [[GLOBAL_WAKE_TARGET_KEY, globalWakeGroup as PendingWakeGroup] as const]
+      : [[GLOBAL_HEARTBEAT_WAKE_TARGET_KEY, globalWakeGroup as PendingWakeGroup] as const]
     : pendingWakes.entries();
   for (const [targetKey, group] of pendingEntries) {
     if (readyGroups.length >= maxGroups) {
@@ -342,7 +300,7 @@ function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGro
       continue;
     }
     if (
-      targetKey === GLOBAL_WAKE_TARGET_KEY &&
+      targetKey === GLOBAL_HEARTBEAT_WAKE_TARGET_KEY &&
       (activeWakeTargets.size > 0 || readyGroups.length > 0)
     ) {
       continue;
@@ -354,9 +312,9 @@ function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGro
       if (!pending) {
         continue;
       }
-      const isPostBarrierTarget = isPostBarrierTargetWake(
+      const isPostBarrierTarget = isHeartbeatWakeAfterGlobalBarrier(
         targetKey,
-        pending,
+        pending.enqueueSequence,
         globalBarrierCutoffSequence,
       );
       if (
@@ -439,15 +397,15 @@ function queuePendingWakeReason(params: {
   const requestedAt = params.requestedAt ?? Date.now();
   const enqueueSequence = params.enqueueSequence ?? ++wakeEnqueueSequence;
   const normalizedReason = normalizeWakeReason(params.reason);
-  const normalizedAgentId = normalizeWakeTarget(params.agentId);
-  const normalizedSessionKey = normalizeWakeTarget(params.sessionKey);
-  const wakeTargetKey = getWakeTargetBaseKey({
+  const normalizedAgentId = normalizeHeartbeatWakeTarget(params.agentId);
+  const normalizedSessionKey = normalizeHeartbeatWakeTarget(params.sessionKey);
+  const wakeTargetKey = resolveHeartbeatWakeTargetKey({
     agentId: normalizedAgentId,
     sessionKey: normalizedSessionKey,
   });
   const immediateBarrierSequence =
     params.immediateBarrierSequence ??
-    (wakeTargetKey === GLOBAL_WAKE_TARGET_KEY && params.intent === "immediate"
+    (wakeTargetKey === GLOBAL_HEARTBEAT_WAKE_TARGET_KEY && params.intent === "immediate"
       ? enqueueSequence
       : undefined);
   const next: PendingWakeReason = {
@@ -620,37 +578,6 @@ async function dispatchPendingWakeGroup(params: {
   }
 }
 
-async function runAbortableHeartbeatWake(
-  active: HeartbeatWakeHandler,
-  wake: HeartbeatWakeRequest,
-  signal: AbortSignal,
-): Promise<HeartbeatRunResult> {
-  let abortListener: (() => void) | undefined;
-  const aborted = new Promise<never>((_resolve, reject) => {
-    abortListener = () => {
-      const abortReason = signal.reason;
-      reject(
-        abortReason instanceof Error ? abortReason : new Error("Heartbeat handler was replaced"),
-      );
-    };
-    if (signal.aborted) {
-      abortListener();
-      return;
-    }
-    signal.addEventListener("abort", abortListener, { once: true });
-  });
-  try {
-    // Keep provider cancellation in the existing reply AbortSignal contract;
-    // racing it also retires a non-cooperative stale handler on replacement.
-    const running = heartbeatWakeAbortSignals.run(signal, () => active(wake));
-    return await Promise.race([running, aborted]);
-  } finally {
-    if (abortListener) {
-      signal.removeEventListener("abort", abortListener);
-    }
-  }
-}
-
 function schedule(coalesceMs: number) {
   const delay = resolveTimerTimeoutMs(coalesceMs, DEFAULT_COALESCE_MS, 0);
   const dueAt = Date.now() + delay;
@@ -707,15 +634,15 @@ function schedulePendingWakes(readyDelayMs: number) {
   }
   const now = Date.now();
   if (
-    activeWakeTargets.has(GLOBAL_WAKE_TARGET_KEY) ||
+    activeWakeTargets.has(GLOBAL_HEARTBEAT_WAKE_TARGET_KEY) ||
     (activeWakeTargets.size > 0 &&
-      isPendingWakeGroupReady(pendingWakes.get(GLOBAL_WAKE_TARGET_KEY), now))
+      isHeartbeatWakeTargetGroupReady(pendingWakes.get(GLOBAL_HEARTBEAT_WAKE_TARGET_KEY), now))
   ) {
     // The active side of a global barrier re-arms pending work when it exits.
     // Avoid zero-delay timer churn while the other side is still draining.
     return;
   }
-  const pendingGlobalImmediateWake = pendingWakes.get(GLOBAL_WAKE_TARGET_KEY)?.event;
+  const pendingGlobalImmediateWake = pendingWakes.get(GLOBAL_HEARTBEAT_WAKE_TARGET_KEY)?.event;
   const globalBarrierCutoffSequence =
     pendingGlobalImmediateWake?.intent === "immediate"
       ? pendingGlobalImmediateWake.immediateBarrierSequence
@@ -730,7 +657,12 @@ function schedulePendingWakes(readyDelayMs: number) {
     if (
       groupWakes.every(
         (pending) =>
-          !pending || isPostBarrierTargetWake(targetKey, pending, globalBarrierCutoffSequence),
+          !pending ||
+          isHeartbeatWakeAfterGlobalBarrier(
+            targetKey,
+            pending.enqueueSequence,
+            globalBarrierCutoffSequence,
+          ),
       )
     ) {
       continue;
@@ -740,7 +672,14 @@ function schedulePendingWakes(readyDelayMs: number) {
       continue;
     }
     for (const pending of groupWakes) {
-      if (!pending || isPostBarrierTargetWake(targetKey, pending, globalBarrierCutoffSequence)) {
+      if (
+        !pending ||
+        isHeartbeatWakeAfterGlobalBarrier(
+          targetKey,
+          pending.enqueueSequence,
+          globalBarrierCutoffSequence,
+        )
+      ) {
         continue;
       }
       const nextReadyAtMs = Math.max(pending.readyAtMs ?? 0, pending.notBeforeMs ?? 0);
@@ -771,14 +710,6 @@ function clearPendingWakeRetryState() {
   }
 }
 
-function abortActiveWakeTargets(generation: number) {
-  for (const activeTarget of activeWakeTargets.values()) {
-    if (activeTarget.generation === generation) {
-      activeTarget.abortController.abort();
-    }
-  }
-}
-
 /**
  * Register (or clear) the heartbeat wake handler.
  * Returns a disposer function that clears this specific registration.
@@ -792,7 +723,7 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
   handler = next;
   // Registration changes retire only the lifecycle they replaced. A stale
   // disposer must never cancel active work owned by a newer handler.
-  abortActiveWakeTargets(previousGeneration);
+  abortHeartbeatWakeGeneration(activeWakeTargets.values(), previousGeneration);
   if (next) {
     // New lifecycle starting (e.g. after SIGUSR1 in-process restart).
     // Clear any timer metadata from the previous lifecycle so stale retry
@@ -814,7 +745,7 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
     if (handler !== next) {
       return;
     }
-    abortActiveWakeTargets(generation);
+    abortHeartbeatWakeGeneration(activeWakeTargets.values(), generation);
     handlerGeneration += 1;
     handler = null;
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes three heartbeat lifecycle races: the same canonical session could run concurrently when callers supplied different agent/session tuple shapes, an unscoped immediate wake could overlap or starve behind targeted work instead of acting as a barrier, and stopping the heartbeat runner did not cancel active provider work.

## Why This Change Was Made

Heartbeat scheduling now derives one session-first target identity, gives immediate global wakes an enqueue cutoff that separates pre-barrier from post-barrier work, and tears down active work by handler generation so stale disposers cannot cancel replacements. This is an AI-assisted change from a maintainer QA campaign.

## User Impact

Operators no longer get duplicate concurrent turns for one session, global wake requests cannot be indefinitely postponed by newer targeted work, and Gateway shutdown stops active heartbeat turns before their dependencies disappear.

## Evidence

- Reproduced before the fix with two root admissions for one canonical session, a targeted/global overlap, and an un-aborted active signal after runner stop.
- Blacksmith Testbox focused suite: 84/84 passed — https://github.com/openclaw/openclaw/actions/runs/30533434987
- Exact final concurrency regression: 11/11 passed — https://github.com/openclaw/openclaw/actions/runs/30533573830
- Final formatter-only head rerun: 11/11 passed — https://github.com/openclaw/openclaw/actions/runs/30535340072
- Final module split: 84/84 focused, Madge `0` cycles, remote `check:changed` green, autoreview clean at `0.98`; exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30539267063
- Remote `check:changed`: passed core/coreTests formatting, typecheck, lint, dead-export, architecture, storage, and boundary guards.
- Fresh Codex autoreview initially found a post-barrier starvation edge; the queue gained a monotonic cutoff, the regression was added, and the final autoreview was clean with no accepted/actionable findings.
