### PR TITLE
fix(nodes): open terminals promptly and honor renames

### DIFF
--- a/src/gateway/node-catalog.test.ts
+++ b/src/gateway/node-catalog.test.ts
@@ -149,6 +149,48 @@ describe("gateway/node-catalog", () => {
     });
   });
 
+  it("keeps the operator node name across live metadata and reconnects", () => {
+    const connectedNode = (connId: string, displayName: string) => ({
+      nodeId: "mac-1",
+      connId,
+      client: {} as never,
+      displayName,
+      platform: "macos",
+      declaredCaps: [],
+      caps: [],
+      declaredCommands: [],
+      commands: [],
+      declaredNodePluginTools: [],
+      nodePluginTools: [],
+      nodeSkills: [],
+      connectedAtMs: 1,
+    });
+    const pairedDevices = [pairedDevice({ displayName: "Device Name" })];
+    const pairedNodes = [pairedNode({ displayName: "Operator Name" })];
+
+    const connected = createKnownNodeCatalog({
+      pairedDevices,
+      pairedNodes,
+      connectedNodes: [connectedNode("conn-1", "Live Name")],
+    });
+    expect(listKnownNodes(connected)[0]?.displayName).toBe("Operator Name");
+    expect(getKnownNode(connected, "mac-1")?.displayName).toBe("Operator Name");
+
+    const reconnected = createKnownNodeCatalog({
+      pairedDevices,
+      pairedNodes,
+      connectedNodes: [connectedNode("conn-2", "Replacement Live Name")],
+    });
+    expect(getKnownNode(reconnected, "mac-1")?.displayName).toBe("Operator Name");
+
+    const liveFallback = createKnownNodeCatalog({
+      pairedDevices,
+      pairedNodes: [pairedNode({ displayName: undefined })],
+      connectedNodes: [connectedNode("conn-3", "Live Fallback")],
+    });
+    expect(getKnownNode(liveFallback, "mac-1")?.displayName).toBe("Live Fallback");
+  });
+
   it("surfaces paired-node metadata while the node is offline", () => {
     const catalog = createKnownNodeCatalog({
       pairedDevices: [pairedDevice()],
@@ -483,8 +525,7 @@ describe("gateway/node-catalog", () => {
   });
 
   it("falls through a non-string higher-priority scalar to a valid lower-priority value", () => {
-    // A corrupted live (higher-priority) scalar must be treated as ABSENT so the valid paired
-    // (lower-priority) value still surfaces, instead of the malformed value suppressing it.
+    // A corrupted live scalar must be treated as ABSENT so the valid paired value still surfaces.
     const catalog = createKnownNodeCatalog({
       pairedDevices: [pairedDevice({ deviceId: "mac-1" })],
       pairedNodes: [

--- a/src/gateway/node-catalog.ts
+++ b/src/gateway/node-catalog.ts
@@ -223,8 +223,10 @@ function buildEffectiveKnownNode(entry: {
   return {
     nodeId,
     displayName: firstNormalizedString(
-      live?.displayName,
+      // The approved surface owns the operator's rename. Live metadata is a
+      // fallback only, or every reconnect would temporarily undo that choice.
       nodePairing?.displayName,
+      live?.displayName,
       devicePairing?.displayName,
       pendingNodePairing?.displayName,
     ),

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -1068,8 +1068,8 @@ export class NodeRegistry {
     signal?: AbortSignal;
     idempotencyKey?: string;
     sessionKey?: string;
-    /** Receives the id synchronously after send; the terminal relay depends on this timing. */
-    onInvokeId?: (invokeId: string) => void;
+    /** Receives the id after pairing validation and a successful dispatch. */
+    onDispatchReady?: (invokeId: string) => void;
   }): Promise<NodeInvokeResult> {
     if (params.signal?.aborted) {
       return { ok: false, error: { code: "ABORTED", message: "node invoke cancelled" } };
@@ -1199,7 +1199,7 @@ export class NodeRegistry {
         ...systemRunEvent,
       });
     }
-    params.onInvokeId?.(requestId);
+    params.onDispatchReady?.(requestId);
     return await result;
   }
 

--- a/src/gateway/server-methods/terminal.test.ts
+++ b/src/gateway/server-methods/terminal.test.ts
@@ -578,8 +578,8 @@ describe("terminal gateway policy", () => {
       commands: [command],
     };
     const invoke = vi.fn((rawParams: unknown) => {
-      const params = rawParams as { onInvokeId?: (id: string) => void };
-      params.onInvokeId?.("invoke-1");
+      const params = rawParams as { onDispatchReady?: (id: string) => void };
+      params.onDispatchReady?.("invoke-1");
       return Promise.resolve({ ok: true });
     });
     const nodeRegistry = { get: () => node, invoke, sendInvokeInput: vi.fn() };

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -5,6 +5,7 @@ import { WebSocket } from "ws";
 import { getPairedDevice, listDevicePairing } from "../infra/device-pairing.js";
 import { NODE_MCP_TOOLS_CALL_COMMAND } from "../infra/node-commands.js";
 import { approveNodePairing, listNodePairing, requestNodePairing } from "../infra/node-pairing.js";
+import { resolveNodeIdFromNodeList } from "../shared/node-resolve.js";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -57,6 +58,7 @@ async function connectNodeClient(params: {
   deviceIdentity: ReturnType<typeof loadDeviceIdentity>["identity"];
   commands: string[];
   clientName?: GatewayClientName;
+  displayName?: string;
   platform?: string;
   deviceFamily?: string;
 }) {
@@ -65,7 +67,7 @@ async function connectNodeClient(params: {
     token: "secret",
     role: "node",
     clientName: params.clientName ?? GATEWAY_CLIENT_NAMES.NODE_HOST,
-    clientDisplayName: "node-command-pin",
+    clientDisplayName: params.displayName ?? "node-command-pin",
     clientVersion: "1.0.0",
     platform: params.platform ?? "macos",
     deviceFamily: params.deviceFamily ?? "Mac",
@@ -620,6 +622,93 @@ describe("gateway node pairing authorization", () => {
         expect(reject.ok).toBe(true);
       } finally {
         ws.close();
+      }
+    });
+
+    test("projects an operator rename immediately and after the node reconnects", async () => {
+      const pairedNode = await pairDeviceIdentity({
+        name: "node-rename-projection",
+        role: "node",
+        scopes: [],
+        clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+      });
+      const requested = await requestNodePairing({
+        nodeId: pairedNode.identity.deviceId,
+        displayName: "Approval Name",
+        platform: "macos",
+        deviceFamily: "Mac",
+        commands: [],
+      });
+      requireApprovedPairing(
+        await approveNodePairing(requested.request.requestId, {
+          callerScopes: ["operator.pairing"],
+        }),
+      );
+
+      const controlWs = await openTrackedWs(getStarted().port);
+      let nodeClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+      try {
+        await connectOk(controlWs, { token: "secret" });
+        nodeClient = await connectNodeClient({
+          port: getStarted().port,
+          deviceIdentity: pairedNode.identity,
+          commands: [],
+          displayName: "Live Name",
+        });
+
+        const renamed = await rpcReq(controlWs, "node.rename", {
+          nodeId: pairedNode.identity.deviceId,
+          displayName: "Operator Name",
+        });
+        expect(renamed.ok).toBe(true);
+
+        type NodeRead = { nodeId: string; displayName?: string; connected?: boolean };
+        const readNodes = async (): Promise<NodeRead[]> => {
+          const listed = await rpcReq<{ nodes?: NodeRead[] }>(controlWs, "node.list", {});
+          return listed.payload?.nodes ?? [];
+        };
+        const readConnectedNode = async (): Promise<NodeRead | undefined> => {
+          return (await readNodes()).find((entry) => entry.nodeId === pairedNode.identity.deviceId);
+        };
+        await vi.waitFor(async () => {
+          expect(await readConnectedNode()).toMatchObject({
+            displayName: "Operator Name",
+            connected: true,
+          });
+        });
+        const listedNodes = await readNodes();
+        expect(resolveNodeIdFromNodeList(listedNodes, "Operator Name")).toBe(
+          pairedNode.identity.deviceId,
+        );
+        expect(() => resolveNodeIdFromNodeList(listedNodes, "Live Name")).toThrow(
+          "unknown node: Live Name",
+        );
+        const described = await rpcReq<NodeRead>(controlWs, "node.describe", {
+          nodeId: pairedNode.identity.deviceId,
+        });
+        expect(described.payload).toMatchObject({
+          displayName: "Operator Name",
+          connected: true,
+        });
+
+        await nodeClient.stopAndWait();
+        nodeClient = undefined;
+        nodeClient = await connectNodeClient({
+          port: getStarted().port,
+          deviceIdentity: pairedNode.identity,
+          commands: [],
+          displayName: "Replacement Live Name",
+        });
+        await vi.waitFor(async () => {
+          expect(await readConnectedNode()).toMatchObject({
+            displayName: "Operator Name",
+            connected: true,
+          });
+        });
+      } finally {
+        await nodeClient?.stopAndWait();
+        controlWs.close();
       }
     });
   });

--- a/src/gateway/terminal/node-relay.test.ts
+++ b/src/gateway/terminal/node-relay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { NodeInvokeResult, NodeRegistry } from "../node-registry.js";
+import { withTestTimeout } from "../../../test/helpers/promise.js";
+import { type NodeInvokeResult, NodeRegistry } from "../node-registry.js";
 import { createNodeRelayBackend } from "./node-relay.js";
 
 function deferred<T>() {
@@ -11,6 +12,64 @@ function deferred<T>() {
 }
 
 describe("createNodeRelayBackend", () => {
+  it("waits for pairing validation and dispatch instead of the final node exit", async () => {
+    const pairingState = deferred<{ identity: string; generation: string }>();
+    const frames: string[] = [];
+    const resolveCurrentPairingState = vi.fn(async () => await pairingState.promise);
+    const registry = new NodeRegistry({
+      resolveCurrentPairingState,
+    });
+    registry.register(
+      {
+        connId: "conn-validated",
+        usesSharedGatewayAuth: false,
+        socket: {
+          send(frame: unknown) {
+            if (typeof frame === "string") {
+              frames.push(frame);
+            }
+          },
+        },
+        connect: {
+          client: { id: "openclaw-node-host", mode: "node" },
+          device: { id: "node-validated" },
+          commands: ["codex.terminal.resume.v1"],
+        },
+      } as never,
+      { pairingIdentity: "identity-a", pairingGeneration: "generation-a" },
+    );
+
+    const opening = createNodeRelayBackend({
+      registry,
+      nodeId: "node-validated",
+      expectedConnId: "conn-validated",
+      expectedPairingGeneration: "generation-a",
+      command: "codex.terminal.resume.v1",
+      params: { threadId: "thread" },
+    });
+    await vi.waitFor(() =>
+      expect(resolveCurrentPairingState).toHaveBeenCalledWith("node-validated"),
+    );
+    expect(frames).toEqual([]);
+
+    pairingState.resolve({ identity: "identity-a", generation: "generation-a" });
+    const backend = await withTestTimeout(
+      opening,
+      500,
+      "timed out waiting for node terminal dispatch readiness",
+    );
+
+    expect(JSON.parse(frames[0] ?? "{}")).toMatchObject({
+      event: "node.invoke.request",
+      payload: {
+        nodeId: "node-validated",
+        command: "codex.terminal.resume.v1",
+      },
+    });
+    backend.kill();
+    registry.unregister("conn-validated");
+  });
+
   it("relays progress, input, resize, cancellation, and the node exit result", async () => {
     const invokeResult = deferred<NodeInvokeResult>();
     let onProgress: ((chunk: string) => void) | undefined;
@@ -19,13 +78,13 @@ describe("createNodeRelayBackend", () => {
     const registry = {
       invoke: vi.fn(
         (params: {
-          onInvokeId?: (id: string) => void;
+          onDispatchReady?: (id: string) => void;
           onProgress?: (chunk: string) => void;
           signal?: AbortSignal;
         }) => {
           onProgress = params.onProgress;
           signal = params.signal;
-          params.onInvokeId?.("invoke-1");
+          params.onDispatchReady?.("invoke-1");
           return invokeResult.promise;
         },
       ),
@@ -67,8 +126,8 @@ describe("createNodeRelayBackend", () => {
 
   it("maps node disconnect failures to terminal errors", async () => {
     const registry = {
-      invoke: vi.fn((params: { onInvokeId?: (id: string) => void }) => {
-        params.onInvokeId?.("invoke-2");
+      invoke: vi.fn((params: { onDispatchReady?: (id: string) => void }) => {
+        params.onDispatchReady?.("invoke-2");
         return Promise.resolve({
           ok: false,
           error: { code: "NOT_CONNECTED", message: "node disconnected" },
@@ -91,8 +150,8 @@ describe("createNodeRelayBackend", () => {
   });
 
   it("pins the expected connection and reports route changes through onExit", async () => {
-    const invoke = vi.fn((params: { onInvokeId?: (id: string) => void }) => {
-      params.onInvokeId?.("invoke-route-changed");
+    const invoke = vi.fn((params: { onDispatchReady?: (id: string) => void }) => {
+      params.onDispatchReady?.("invoke-route-changed");
       return Promise.resolve({
         ok: false,
         error: { code: "ROUTE_CHANGED", message: "node connection changed before dispatch" },
@@ -128,9 +187,12 @@ describe("createNodeRelayBackend", () => {
     let onProgress: ((chunk: string) => void) | undefined;
     const registry = {
       invoke: vi.fn(
-        (params: { onInvokeId?: (id: string) => void; onProgress?: (chunk: string) => void }) => {
+        (params: {
+          onDispatchReady?: (id: string) => void;
+          onProgress?: (chunk: string) => void;
+        }) => {
           onProgress = params.onProgress;
-          params.onInvokeId?.("invoke-buffered");
+          params.onDispatchReady?.("invoke-buffered");
           return Promise.resolve({ ok: true });
         },
       ),
@@ -175,8 +237,8 @@ describe("createNodeRelayBackend", () => {
   it("never splits a surrogate pair at the input chunk boundary", async () => {
     const sendInvokeInput = vi.fn();
     const registry = {
-      invoke: vi.fn((params: { onInvokeId?: (id: string) => void }) => {
-        params.onInvokeId?.("invoke-input");
+      invoke: vi.fn((params: { onDispatchReady?: (id: string) => void }) => {
+        params.onDispatchReady?.("invoke-input");
         return Promise.resolve({ ok: true });
       }),
       sendInvokeInput,

--- a/src/gateway/terminal/node-relay.ts
+++ b/src/gateway/terminal/node-relay.ts
@@ -69,7 +69,10 @@ export async function createNodeRelayBackend(params: {
   command: string;
   params: Record<string, unknown>;
 }): Promise<TerminalBackend> {
-  let invokeId: string | undefined;
+  let resolveDispatchReady!: (invokeId: string) => void;
+  const dispatchReady = new Promise<string>((resolve) => {
+    resolveDispatchReady = resolve;
+  });
   let dataCallback: ((data: string) => void) | undefined;
   let exitCallback: ((exit: TerminalBackendExit) => void) | undefined;
   const pendingData = new BoundedBuffer<string>(
@@ -91,9 +94,7 @@ export async function createNodeRelayBackend(params: {
       timeoutMs: 0,
       idleTimeoutMs: NODE_DUPLEX_INVOKE_IDLE_TIMEOUT_MS,
       signal: abort.signal,
-      onInvokeId: (id) => {
-        invokeId = id;
-      },
+      onDispatchReady: resolveDispatchReady,
       onProgress: (chunk) => {
         if (!chunk) {
           return;
@@ -120,14 +121,14 @@ export async function createNodeRelayBackend(params: {
       }
       return exit;
     });
-  // NodeRegistry invokes onInvokeId synchronously after a successful send, before its first await.
-  // Failure paths resolve the result instead; keeping that callback synchronous is load-bearing.
-  await Promise.resolve();
-  if (!invokeId) {
-    const exit = await result;
-    throw new Error(exit.error ?? "failed to start node terminal invoke");
-  }
-  const activeInvokeId = invokeId;
+  // Pairing-generation validation is asynchronous. Open only after the exact
+  // admitted connection is dispatch-ready; a pre-dispatch failure wins instead.
+  const activeInvokeId = await Promise.race([
+    dispatchReady,
+    result.then((exit) => {
+      throw new Error(exit.error ?? "failed to start node terminal invoke");
+    }),
+  ]);
   const send = (payload: unknown) => params.registry.sendInvokeInput(activeInvokeId, payload);
   return {
     write(data) {


### PR DESCRIPTION
## What Problem This Solves

Related: #116363

Fixes two node-runtime regressions: node-backed terminals could wait until the remote process exited and then report a successful process as an open failure, and `node.rename` persisted the operator name while connected node lists and descriptions continued showing the client’s old name.

## Why This Change Was Made

Terminal dispatch now exposes an explicit ready latch only after asynchronous pairing-generation validation and send, without weakening generation fencing. Node catalogs prefer the durable operator-facing name and fall back to live client metadata only when no override exists. This is an AI-assisted maintainer QA fix.

## User Impact

Remote terminals become usable immediately after secure dispatch, and operator node renames appear consistently in list, describe, name lookup, and reconnect flows.

## Evidence

- Production-shaped pre-fix reproduction: terminal open remained pending until the final successful exit, then rejected.
- Connected rename reproduction: persisted `OPERATOR NEW` while catalog returned `CLIENT OLD`.
- Blacksmith Testbox `tbx_01kys7jg8whvstk0heds3wwzme`: 65/65 focused node, terminal, catalog, and pairing-authorization tests passed.
- Remote `check:changed`: passed core/coreTests gates; no build lane was required.
- Fresh Codex autoreview: no accepted/actionable findings; confidence `0.90`.
- The separate result-frame-vs-immediate-close race remains out of scope because a correct fix needs explicit admitted-frame drain ownership rather than a timer or pairing bypass; it is tracked in #116363.
