### PR TITLE
fix(ci): validate frozen release candidates faithfully

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1270,9 +1270,10 @@ jobs:
           if pnpm openclaw qa suite --help | grep -Fq -- "--runtime-pair-lane"; then
             runtime_pair_args+=(--runtime-pair-lane "$RUNTIME_PAIR_LANE")
           elif [[ "$RUNTIME_PAIR_LANE" == "core" ]]; then
-            # Before runtime-pair lanes, the frozen candidate's standard and
-            # live-only tiers together defined the current core lane.
-            runtime_pair_args+=(--runtime-parity-tier standard,live-only)
+            # Legacy explicit-tier selection bypasses its provider eligibility
+            # filter. live-only scenarios require a live provider, so the mock
+            # core lane must select only the eligible standard tier.
+            runtime_pair_args+=(--runtime-parity-tier standard)
           elif [[ "$RUNTIME_PAIR_LANE" == "soak" ]]; then
             runtime_pair_args+=(--runtime-parity-tier soak)
           else

--- a/scripts/check-docker-e2e-boundaries.mjs
+++ b/scripts/check-docker-e2e-boundaries.mjs
@@ -6,7 +6,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { laneResources, laneWeight } from "./lib/docker-e2e-plan.mjs";
-import { allReleasePathLanes, mainLanes, tailLanes } from "./lib/docker-e2e-scenarios.mjs";
+import {
+  allReleasePathLanes,
+  mainLanes,
+  publicInstallerLanes,
+  tailLanes,
+} from "./lib/docker-e2e-scenarios.mjs";
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const errors = [];
@@ -151,6 +156,7 @@ function validateLane(label, lane) {
 const releasePathLanes = allReleasePathLanes({ includeOpenWebUI: true });
 for (const [label, lanes] of [
   ["release-path", releasePathLanes],
+  ["public-installer", publicInstallerLanes],
   ["main", mainLanes],
   ["tail", tailLanes],
 ]) {

--- a/scripts/lib/docker-e2e-plan.mjs
+++ b/scripts/lib/docker-e2e-plan.mjs
@@ -11,6 +11,7 @@ import {
   allReleasePathLanes,
   mainLanes,
   normalizeReleaseProfile,
+  publicInstallerLanes,
   releasePathChunkLanes,
   tailLanes,
 } from "./docker-e2e-scenarios.mjs";
@@ -528,7 +529,12 @@ export function lanesNeedOpenClawPackage(poolLanes) {
 export function findLaneByName(name) {
   return dedupeLanes(
     expandUpgradeSurvivorBaselineLanes(
-      [...allReleasePathLanes({ includeOpenWebUI: true }), ...mainLanes, ...tailLanes],
+      [
+        ...allReleasePathLanes({ includeOpenWebUI: true }),
+        ...publicInstallerLanes,
+        ...mainLanes,
+        ...tailLanes,
+      ],
       process.env.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS,
       undefined,
       process.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS,
@@ -624,6 +630,7 @@ export function resolveDockerE2ePlan(options) {
       includeOpenWebUI: options.includeOpenWebUI,
       releaseProfile: "full",
     }),
+    ...publicInstallerLanes,
     ...retriedMainLanes,
     ...retriedTailLanes,
   ]);

--- a/scripts/lib/docker-e2e-scenarios.d.mts
+++ b/scripts/lib/docker-e2e-scenarios.d.mts
@@ -22,6 +22,7 @@ export type DockerE2eLane = {
 export const DEFAULT_LIVE_RETRIES: number;
 export const BUNDLED_PLUGIN_INSTALL_UNINSTALL_SHARDS: number;
 export const mainLanes: DockerE2eLane[];
+export const publicInstallerLanes: DockerE2eLane[];
 export const tailLanes: DockerE2eLane[];
 export function normalizeReleaseProfile(
   raw: DockerE2eReleaseProfileInput | null | undefined,

--- a/scripts/lib/docker-e2e-scenarios.mjs
+++ b/scripts/lib/docker-e2e-scenarios.mjs
@@ -781,7 +781,9 @@ const releasePathBundledChannelLanes = [
   }),
 ];
 
-const releasePathPackageInstallOpenAiLanes = [
+// Public installer smoke needs a published, immutable package version. Keep it
+// selectable for post-publish verification, but out of frozen-candidate CI.
+export const publicInstallerLanes = [
   liveLane(
     "install-e2e-openai",
     liveDockerScriptCommand(
@@ -798,18 +800,6 @@ const releasePathPackageInstallOpenAiLanes = [
       weight: 3,
     },
   ),
-  liveOpenAiChatToolsLane(),
-  liveCodexNpmPluginLane(),
-  npmLane("codex-on-demand", "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:codex-on-demand", {
-    resources: ["service"],
-    stateScenario: "empty",
-    timeoutMs: 30 * 60 * 1000,
-    weight: 3,
-  }),
-  releaseTypedOnboardingLane(),
-];
-
-const releasePathPackageInstallAnthropicLanes = [
   liveLane(
     "install-e2e-anthropic",
     liveDockerScriptCommand(
@@ -825,6 +815,18 @@ const releasePathPackageInstallAnthropicLanes = [
       weight: 3,
     },
   ),
+];
+
+const releasePathPackageUpdateOpenAiLanes = [
+  liveOpenAiChatToolsLane(),
+  liveCodexNpmPluginLane(),
+  npmLane("codex-on-demand", "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:codex-on-demand", {
+    resources: ["service"],
+    stateScenario: "empty",
+    timeoutMs: 30 * 60 * 1000,
+    weight: 3,
+  }),
+  releaseTypedOnboardingLane(),
 ];
 
 const releasePathPackageUpdateCoreLanes = [
@@ -885,8 +887,7 @@ const primaryReleasePathChunks = {
     }),
     mcpCodeModeGatewayLane(),
   ],
-  "package-update-openai": releasePathPackageInstallOpenAiLanes,
-  "package-update-anthropic": releasePathPackageInstallAnthropicLanes,
+  "package-update-openai": releasePathPackageUpdateOpenAiLanes,
   "package-update-core": releasePathPackageUpdateCoreLanes,
   "plugins-runtime-plugins": releasePathPluginRuntimePluginLanes,
   "plugins-runtime-services": releasePathPluginRuntimeServiceLanes,
@@ -904,7 +905,6 @@ const primaryReleasePathChunks = {
 const primaryReleasePathChunkProfiles = {
   core: ["stable", "full"],
   "package-update-openai": ["beta", "stable", "full"],
-  "package-update-anthropic": ["beta", "stable", "full"],
   "package-update-core": ["beta", "stable", "full"],
   "plugins-runtime-plugins": ["stable", "full"],
   "plugins-runtime-services": ["stable", "full"],
@@ -920,11 +920,7 @@ const primaryReleasePathChunkProfiles = {
 };
 
 const legacyReleasePathChunks = {
-  "package-update": [
-    ...releasePathPackageInstallOpenAiLanes,
-    ...releasePathPackageInstallAnthropicLanes,
-    ...releasePathPackageUpdateCoreLanes,
-  ],
+  "package-update": [...releasePathPackageUpdateOpenAiLanes, ...releasePathPackageUpdateCoreLanes],
   "plugins-runtime-core": releasePathPluginRuntimeCoreLanes,
   "plugins-runtime": releasePathPluginRuntimeLanes,
   "plugins-integrations": [...releasePathPluginRuntimeLanes, ...releasePathBundledChannelLanes],

--- a/scripts/plan-release-workflow-matrix.mjs
+++ b/scripts/plan-release-workflow-matrix.mjs
@@ -8,14 +8,8 @@ const DOCKER_E2E_CHUNKS = [
   },
   {
     chunk_id: "package-update-openai",
-    label: "package/update OpenAI install",
+    label: "package/update OpenAI",
     timeout_minutes: 45,
-    profiles: "beta minimum stable full",
-  },
-  {
-    chunk_id: "package-update-anthropic",
-    label: "package/update Anthropic install",
-    timeout_minutes: 60,
     profiles: "beta minimum stable full",
   },
   {

--- a/scripts/validate-qa-runtime-pair-summary.mjs
+++ b/scripts/validate-qa-runtime-pair-summary.mjs
@@ -97,6 +97,15 @@ function projectedReportCellStatus(cell) {
   return cell.runtimeErrorClass || cell.transportErrorClass ? "fail" : "pass";
 }
 
+function hasPassingRuntimeCellStatus(cell) {
+  // Early frozen candidates did not serialize the derived cell status. Accept
+  // only that absent legacy field when the same runtime evidence projects pass.
+  return (
+    cell.status === "pass" ||
+    (!Object.hasOwn(cell, "status") && projectedReportCellStatus(cell) === "pass")
+  );
+}
+
 function requireRuntimePairScenario(scenario, index) {
   if (!isRecord(scenario)) {
     throw new Error(`scenario ${index + 1} is not an object`);
@@ -116,9 +125,12 @@ function requireRuntimePairScenario(scenario, index) {
   }
 
   if (scenario.status === "pass") {
-    const hasTwoPassingCells = openclaw.status === "pass" && codex.status === "pass";
+    const hasTwoPassingCells =
+      hasPassingRuntimeCellStatus(openclaw) && hasPassingRuntimeCellStatus(codex);
     const hasAdvisoryCodexGap =
-      parity.drift === "structural" && openclaw.status === "pass" && isExplicitCodexGap(codex);
+      parity.drift === "structural" &&
+      hasPassingRuntimeCellStatus(openclaw) &&
+      isExplicitCodexGap(codex);
     if (
       parity.drift === "failure-mode" ||
       (!hasTwoPassingCells && !hasAdvisoryCodexGap) ||

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -247,12 +247,12 @@ describe("scripts/lib/docker-e2e-plan", () => {
       liveImage: true,
       package: true,
     });
-    expect(plan.credentials).toEqual(["anthropic", "openai"]);
-    expect(plan.lanes.map((lane) => lane.name)).toContain("install-e2e-openai");
+    expect(plan.credentials).toEqual(["openai"]);
+    expect(plan.lanes.map((lane) => lane.name)).not.toContain("install-e2e-openai");
     expect(plan.lanes.map((lane) => lane.name)).toContain("openai-chat-tools");
     expect(plan.lanes.map((lane) => lane.name)).toContain("live-codex-npm-plugin");
     expect(plan.lanes.map((lane) => lane.name)).toContain("codex-on-demand");
-    expect(plan.lanes.map((lane) => lane.name)).toContain("install-e2e-anthropic");
+    expect(plan.lanes.map((lane) => lane.name)).not.toContain("install-e2e-anthropic");
     expect(plan.lanes.map((lane) => lane.name)).toContain("mcp-channels");
     expect(plan.lanes.map((lane) => lane.name)).toContain("plugin-binding-command-escape");
     expect(plan.lanes.map((lane) => lane.name)).toContain("live-plugin-tool");
@@ -261,7 +261,7 @@ describe("scripts/lib/docker-e2e-plan", () => {
     expect(plan.lanes.map((lane) => lane.name)).toContain("bundled-plugin-install-uninstall-23");
     const countLane = (name: string) =>
       plan.lanes.reduce((count, lane) => count + (lane.name === name ? 1 : 0), 0);
-    expect(countLane("install-e2e-openai")).toBe(1);
+    expect(countLane("install-e2e-openai")).toBe(0);
     expect(countLane("bundled-plugin-install-uninstall-0")).toBe(1);
     expect(plan.lanes.map((lane) => lane.name)).not.toContain("bundled-plugin-install-uninstall");
     expect(plan.lanes.map((lane) => lane.name)).not.toContain("bundled-channel-deps");
@@ -316,11 +316,11 @@ describe("scripts/lib/docker-e2e-plan", () => {
 
     const laneNames = plan.lanes.map((lane) => lane.name);
     expect(plan.releaseProfile).toBe("beta");
-    expect(laneNames).toContain("install-e2e-openai");
+    expect(laneNames).not.toContain("install-e2e-openai");
     expect(laneNames).toContain("openai-chat-tools");
     expect(laneNames).toContain("live-codex-npm-plugin");
     expect(laneNames).toContain("release-typed-onboarding");
-    expect(laneNames).toContain("install-e2e-anthropic");
+    expect(laneNames).not.toContain("install-e2e-anthropic");
     expect(laneNames).toContain("update-channel-switch");
     expect(laneNames).not.toContain("plugins");
     expect(laneNames).not.toContain("live-plugin-tool");
@@ -367,11 +367,6 @@ describe("scripts/lib/docker-e2e-plan", () => {
       includeOpenWebUI: true,
       profile: RELEASE_PATH_PROFILE,
       releaseChunk: "package-update-openai",
-    });
-    const packageInstallAnthropic = planFor({
-      includeOpenWebUI: true,
-      profile: RELEASE_PATH_PROFILE,
-      releaseChunk: "package-update-anthropic",
     });
     const packageUpdateCore = planFor({
       includeOpenWebUI: true,
@@ -436,7 +431,6 @@ describe("scripts/lib/docker-e2e-plan", () => {
 
     expect(core.lanes.map((lane) => lane.name)).toContain("plugin-binding-command-escape");
     expect(packageInstallOpenAi.lanes.map((lane) => lane.name)).toEqual([
-      "install-e2e-openai",
       "openai-chat-tools",
       "live-codex-npm-plugin",
       "codex-on-demand",
@@ -457,9 +451,6 @@ describe("scripts/lib/docker-e2e-plan", () => {
         timeoutMs: 1_200_000,
         weight: 3,
       },
-    ]);
-    expect(packageInstallAnthropic.lanes.map((lane) => lane.name)).toEqual([
-      "install-e2e-anthropic",
     ]);
     expect(packageUpdateCore.lanes.map(summarizeLane)).toEqual([
       {
@@ -713,12 +704,10 @@ describe("scripts/lib/docker-e2e-plan", () => {
     );
 
     expect(packageUpdate.lanes.map((lane) => lane.name)).toEqual([
-      "install-e2e-openai",
       "openai-chat-tools",
       "live-codex-npm-plugin",
       "codex-on-demand",
       "release-typed-onboarding",
-      "install-e2e-anthropic",
       "npm-onboard-channel-agent",
       "npm-onboard-discord-channel-agent",
       "npm-onboard-slack-channel-agent",
@@ -1497,10 +1486,17 @@ describe("scripts/lib/docker-e2e-plan", () => {
     const plan = planFor({ selectedLaneNames });
 
     expect(selectedLaneNames).toEqual(["install-e2e-openai", "install-e2e-anthropic"]);
-    expect(plan.lanes.map(summarizeLane)).toEqual([
+    expect(
+      plan.lanes.map((lane) => ({
+        imageKind: lane.imageKind,
+        live: lane.live,
+        name: lane.name,
+        resources: lane.resources,
+        timeoutMs: lane.timeoutMs,
+        weight: lane.weight,
+      })),
+    ).toEqual([
       {
-        command:
-          'OPENCLAW_INSTALL_TAG=beta OPENCLAW_E2E_MODELS=openai OPENCLAW_INSTALL_E2E_IMAGE=openclaw-install-e2e-openai:local OPENCLAW_INSTALL_E2E_AGENT_TOOL_SMOKE=0 OPENCLAW_INSTALL_E2E_OPENAI_MODEL=openai/gpt-5.4-mini OPENCLAW_INSTALL_E2E_AGENT_TURN_TIMEOUT_SECONDS=120 OPENCLAW_INSTALL_E2E_OPENAI_PROVIDER_TIMEOUT_SECONDS=120 bash -c \'harness="${OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR:-.}"; OPENCLAW_LIVE_DOCKER_REPO_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$PWD}" bash "$harness/scripts/test-install-sh-e2e-docker.sh"\'',
         imageKind: "bare",
         live: true,
         name: "install-e2e-openai",
@@ -1509,8 +1505,6 @@ describe("scripts/lib/docker-e2e-plan", () => {
         weight: 3,
       },
       {
-        command:
-          'OPENCLAW_INSTALL_TAG=beta OPENCLAW_E2E_MODELS=anthropic OPENCLAW_INSTALL_E2E_IMAGE=openclaw-install-e2e-anthropic:local bash -c \'harness="${OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR:-.}"; OPENCLAW_LIVE_DOCKER_REPO_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$PWD}" bash "$harness/scripts/test-install-sh-e2e-docker.sh"\'',
         imageKind: "bare",
         live: true,
         name: "install-e2e-anthropic",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2745,7 +2745,7 @@ describe("package artifact reuse", () => {
     expect(laneJob.strategy?.matrix?.lane).toContain('["core"]');
     const runtimePairRun = workflowStep(laneJob, "Run runtime-pair lane").run;
     expect(runtimePairRun).toContain('--runtime-pair-lane "$RUNTIME_PAIR_LANE"');
-    expect(runtimePairRun).toContain("--runtime-parity-tier standard,live-only");
+    expect(runtimePairRun).toContain("--runtime-parity-tier standard");
     expect(runtimePairRun).toContain("--runtime-parity-tier soak");
     expect(runtimePairRun).toContain("Frozen candidate cannot select runtime-pair lane");
     expect(workflowStep(laneJob, "Run runtime-pair lane")["continue-on-error"]).toBe(true);

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -79,12 +79,12 @@ const WORKFLOW_CALL_ONLY_INPUTS = new Set([
 const PROFILE_EXPECTATIONS = [
   {
     profile: "minimum",
-    dockerE2eChunks: ["package-update-openai", "package-update-anthropic", "package-update-core"],
+    dockerE2eChunks: ["package-update-openai", "package-update-core"],
     liveModelProviders: ["openai"],
   },
   {
     profile: "beta",
-    dockerE2eChunks: ["package-update-openai", "package-update-anthropic", "package-update-core"],
+    dockerE2eChunks: ["package-update-openai", "package-update-core"],
     liveModelProviders: ["openai"],
   },
   {
@@ -92,7 +92,6 @@ const PROFILE_EXPECTATIONS = [
     dockerE2eChunks: [
       "core",
       "package-update-openai",
-      "package-update-anthropic",
       "package-update-core",
       "plugins-runtime-plugins",
       "plugins-runtime-services",
@@ -112,7 +111,6 @@ const PROFILE_EXPECTATIONS = [
     dockerE2eChunks: [
       "core",
       "package-update-openai",
-      "package-update-anthropic",
       "package-update-core",
       "plugins-runtime-plugins",
       "plugins-runtime-services",
@@ -238,7 +236,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
       releaseProfile: "stable",
     });
 
-    expect(plan.dockerE2e.count).toBe(14);
+    expect(plan.dockerE2e.count).toBe(13);
     expect(plan.liveModels.matrix.include.map((entry: MatrixEntry) => entry.providers)).toEqual([
       "anthropic",
       "google",

--- a/test/scripts/validate-qa-runtime-pair-summary.test.ts
+++ b/test/scripts/validate-qa-runtime-pair-summary.test.ts
@@ -9,7 +9,7 @@ type CellStatus = "pass" | "fail" | "skip";
 
 type RuntimeCell = {
   runtime: "openclaw" | "codex";
-  status: CellStatus;
+  status?: CellStatus;
   details?: string;
   runtimeErrorClass?: string;
   toolCalls: Array<{ errorClass?: string }>;
@@ -146,6 +146,19 @@ describe("frozen QA runtime-pair summary validation", () => {
       passed: 1,
       failed: 0,
       skipped: 2,
+    });
+  });
+
+  it("accepts statusless passing cells from an older frozen candidate", () => {
+    const legacyScenario = scenario({ name: "legacy passing", status: "pass" });
+    delete legacyScenario.runtimeParity.cells.openclaw.status;
+    delete legacyScenario.runtimeParity.cells.codex.status;
+
+    expect(validateQaRuntimePairSummary(summary([legacyScenario]))).toEqual({
+      total: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Full Release Validation could reject an otherwise frozen release candidate because trusted release infrastructure either ran legacy live-only QA scenarios with a mock provider or treated legacy statusless QA cells as failures. It also ran public installer smoke against the moving npm beta channel, rather than the unpublished candidate artifact.

## Why This Change Was Made

The trusted harness now selects only the legacy QA tier eligible for the mock provider, derives a passing status only when an older result omitted that derived field and its runtime evidence is passable, and keeps public installer smoke selectable for post-publish verification instead of pre-publish candidate gating. Package-backed Docker checks remain in the frozen-candidate matrix.

## User Impact

Release operators get validation evidence for the actual candidate SHA rather than failures caused by newer public beta packages or incompatible trusted-harness assumptions. The public installer lanes remain available for an explicit post-publish run.

## Evidence

- Failed validation: https://github.com/openclaw/openclaw/actions/runs/30531082565
- The Anthropic installer lane installed 2026.7.2-beta.5 while validating candidate 2026.6.34; it did not exercise the candidate.
- Focused proof: 169 passing assertions across runtime-pair validator, Docker plan/boundary, release workflow parser, and matrix planner.
- `node scripts/check-docker-e2e-boundaries.mjs` passed.
- Required autoreview: clean, no actionable findings.
- No candidate bytes changed; the previously passing npm preflight remains applicable.