### PR TITLE
fix(qa): prevent Slack cleanup from stalling profile runs

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
@@ -295,12 +295,13 @@ export async function createSlackQaTransportAdapter(
       throw new Error("Slack live QA adapter does not implement transport actions");
     },
     createReportNotes: () => ["Runs through the Slack live adapter and shared QA suite host."],
-    async cleanup() {
+    cleanup() {
       stopped = true;
-      // The observer's HTTP request and local backoff share this lifecycle signal,
-      // so teardown does not wait on a stalled Slack read.
+      // The observer owns its rejection handler, so cancellation must not hold the
+      // Gateway shutdown boundary open if the Slack SDK never settles its request.
       pollingAbort.abort();
-      await polling?.catch(() => undefined);
+    },
+    async cleanupAfterGatewayStop() {
       // Lease release must still run when heartbeat shutdown reports an error.
       try {
         await heartbeat.stop();

--- a/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/adapter.runtime.ts
@@ -295,7 +295,7 @@ export async function createSlackQaTransportAdapter(
       throw new Error("Slack live QA adapter does not implement transport actions");
     },
     createReportNotes: () => ["Runs through the Slack live adapter and shared QA suite host."],
-    cleanup() {
+    async cleanup() {
       stopped = true;
       // The observer owns its rejection handler, so cancellation must not hold the
       // Gateway shutdown boundary open if the Slack SDK never settles its request.

--- a/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/adapter.runtime.ts
@@ -26,9 +26,7 @@ import {
 
 type AdapterFactory = NonNullable<QaRunnerCliRegistration["adapterFactory"]>;
 type FactoryContext = Parameters<AdapterFactory["create"]>[0];
-type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>> & {
-  cleanupAfterGatewayStop?: () => Promise<void>;
-};
+type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>>;
 
 function renderTelegramQaInboundText(
   input: { text: string; nativeCommand?: { name: string } },

--- a/extensions/qa-lab/src/qa-transport.ts
+++ b/extensions/qa-lab/src/qa-transport.ts
@@ -184,9 +184,7 @@ function createFailureAwareTransportWaitForCondition(state: QaTransportState) {
 
 type QaTransportAdapterDefinition = Awaited<
   ReturnType<NonNullable<QaRunnerCliRegistration["adapterFactory"]>["create"]>
-> & {
-  cleanupAfterGatewayStop?: () => Promise<void>;
-};
+>;
 
 export type QaTransportAdapter = Omit<
   QaTransportAdapterDefinition,

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -136,6 +136,7 @@ type QaRunnerTransportAdapterDefinition = {
     isolatedWorkers?: boolean;
   }) => string[];
   cleanup?: () => Promise<void>;
+  cleanupAfterGatewayStop?: () => Promise<void>;
 };
 
 type QaRunnerTransportFactory = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maturity profile runs would hang after the final Slack scenario had already passed, eventually consuming the full 90-minute job timeout without producing aggregate evidence.

The failed run completed the final `thread-isolation` scenario at 09:56:31, then emitted no further QA progress before cancellation at 10:26:48: https://github.com/openclaw/openclaw/actions/runs/30528316514

## Why This Change Was Made

Slack observer cancellation no longer awaits the SDK request at the pre-Gateway cleanup boundary. The observer already owns its rejection handler, so cancellation can safely proceed while Gateway shutdown runs. Heartbeat shutdown and Convex credential release now use the existing post-Gateway cleanup phase, ensuring the Gateway is stopped before its lease is released.

## User Impact

Maturity and live Slack QA runs can finish after their last scenario instead of stalling during cleanup. This has no product-runtime behavior change.

AI-assisted: yes.

## Evidence

- Failure artifact: the final child wrote a passing `Thread and top-level session isolation` summary (`wallMs: 30783`) but the parent never received completion before the job timeout.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/slack/adapter.runtime.test.ts` — 3 tests passed.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings.
- Focused current-main live reproducer (running): https://github.com/openclaw/openclaw/actions/runs/30535256408

