### PR TITLE
fix(auto-reply): suppress no-visible-reply fallback on group/channel surfaces

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -269,8 +269,15 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   const replyAcceptedByActiveRun = replyAdmission?.status === "accepted";
   const queueCapRejected =
     replyAdmission?.status === "skipped" && replyAdmission.reason === "queue-cap";
+  // Group/channel surfaces: a long run's final can settle under a newer dispatch
+  // of the same conversation (#116356), so an empty ledger here does not prove
+  // the conversation saw silence. Posting the canned failure text on that false
+  // negative spams every member; keep the fallback for direct chats only, where
+  // overlapping dispatches are rare and the notice is a real signal.
+  const noVisibleReplyFallbackSurface = chatType !== "group" && chatType !== "channel";
   const noVisibleReplyFallbackAllowed = () =>
     noVisibleReplyFallbackDirected &&
+    noVisibleReplyFallbackSurface &&
     !suppressDelivery &&
     !sendPolicyDenied &&
     state.sourceReplyDeliveryMode !== "message_tool_only" &&
@@ -375,6 +382,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       // timed-out settle leaves delivery unresolved, and a fallback reported as
       // delivered must not stay recoverable — either could double-send.
       ...(noVisibleReplyFallbackDirected &&
+      noVisibleReplyFallbackSurface &&
       queuedSettleResult === "settled" &&
       !turnLedger.hasVisibleDelivery() &&
       !noVisibleReplyFallbackDelivered &&


### PR DESCRIPTION
## What Problem This Solves

In busy group chats, the hardcoded fallback "No reply was generated for this message. This is usually a temporary model failure - please try again." is posted on turns that in fact **succeeded**. When a long tool-heavy run overlaps newer inbound messages, the run's final settles under a newer dispatch of the same conversation; the originating dispatch then finalizes with an empty turn ledger, passes `noVisibleReplyFallbackAllowed()`, and posts the fallback — so the group receives the real answer **plus** the spam line. Full diagnosis with sanitized log timeline: #116356.

#115016 fixed the steered/follow-up dispatch direction (`replyAcceptedByActiveRun`), but the **originating** dispatch of the run still has admission `owned` and no way to know its reply was delivered under the other dispatch operation.

## Why This Change Was Made

The per-dispatch ledger cannot prove conversation-level silence on group/channel surfaces where dispatches overlap. Rather than infer delivery from indirect signals, this restricts the fallback (and `noVisibleReplyFallbackEligible` channel recovery) to **direct chats**, where overlapping dispatches are rare and the notice is a genuine failure signal:

- In groups, the canned failure text is noise for every member except the operator, and today it fires on false negatives. Operators keep detection via the existing WARN (`visible channel turn dispatched with no queued reply payloads`), which this PR does not touch.
- `agents.defaults.silentReply` cannot mitigate this in `requireMention` groups because `emptyFinalAllowedAsSilent` requires `ctx.WasMentioned !== true` (#116348) — and mention-gated busy groups are exactly where the race happens.

If maintainers prefer a conversation-level delivery ledger (suppress the fallback only when another dispatch of the same conversation delivered a visible reply after the triggering message arrived), happy to rework in that direction — this PR is the minimal change that stops the user-visible spam on the surface where it is pure noise.

## User Impact

- Group/channel members no longer see spurious "No reply was generated" messages when the bot actually answered.
- Genuine empty turns in groups become silent (WARN still logged); DMs keep the visible fallback unchanged.

## Evidence

- Production incident 2026-07-30 (2026.7.2-beta.5, Telegram supergroup with `requireMention: true`, `openrouter/moonshotai/kimi-k2.5`): 5 fallback posts in a 40-minute window; every one correlated to a transcript turn whose final had real text (up to 974 chars, `stopReason: "stop"`) and a successful `telegram outbound send ok` under a newer messageId's dispatch. Sanitized timeline in #116356.
- Equivalent gate change (chatType guard on the fallback condition) has been running as a dist patch on that production gateway since 2026-07-30, eliminating the spam while normal group replies continue to deliver.

Fixes #116356. Related: #116348, #115339/#115016.
