### PR TITLE
fix(signal): derive autoStart daemon bind port from local httpUrl

### DIFF
--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -49,6 +49,7 @@ import { addSignalApprovalReactionHintToStructuredPayload } from "./approval-rea
 import { signalRpcRequest, signalCheck } from "./client-adapter.js";
 import type { SignalTransportKind } from "./client-adapter.js";
 import { formatSignalDaemonExit, spawnSignalDaemon, type SignalDaemonHandle } from "./daemon.js";
+import { deriveSignalManagedNativeBindPort } from "./transport-policy.js";
 import { isSignalSenderAllowed, type resolveSignalSender } from "./identity.js";
 import { createSignalEventHandler } from "./monitor/event-handler.js";
 import type {
@@ -599,7 +600,13 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       normalizeOptionalString(opts.configPath) ??
       normalizeOptionalString(managedTransport?.configPath);
     const httpHost = opts.httpHost ?? managedTransport?.httpHost ?? "127.0.0.1";
-    const httpPort = opts.httpPort ?? managedTransport?.httpPort ?? 8080;
+    // Absent httpPort follows a local plain-http baseUrl so the daemon binds
+    // the port the client probes; otherwise the two silently diverge (#116165).
+    const httpPort =
+      opts.httpPort ??
+      managedTransport?.httpPort ??
+      deriveSignalManagedNativeBindPort(baseUrl) ??
+      8080;
     daemonHandle = spawnSignalDaemon({
       cliPath,
       ...(configPath ? { configPath } : {}),

--- a/extensions/signal/src/transport-policy.test.ts
+++ b/extensions/signal/src/transport-policy.test.ts
@@ -3,7 +3,10 @@
 // sockets whose URLs must survive bind-port reassignment untouched.
 import { describe, expect, it } from "vitest";
 import type { SignalTransportConfig } from "./account-types.js";
-import { assignSignalManagedNativePort } from "./transport-policy.js";
+import {
+  assignSignalManagedNativePort,
+  deriveSignalManagedNativeBindPort,
+} from "./transport-policy.js";
 
 type SignalManagedNativeTransport = Extract<SignalTransportConfig, { kind: "managed-native" }>;
 
@@ -33,5 +36,37 @@ describe("assignSignalManagedNativePort", () => {
     );
     expect(next.url).toBe("http://[::1]:8080");
     expect(next.httpPort).toBe(9090);
+  });
+});
+
+// Regression coverage for #116165: an autoStart daemon with no configured httpPort
+// must bind the port a local plain-http connection URL names, or the daemon and the
+// client probe silently diverge onto different ports.
+describe("deriveSignalManagedNativeBindPort", () => {
+  it("derives the port from a local plain-http URL", () => {
+    expect(deriveSignalManagedNativeBindPort("http://127.0.0.1:9090")).toBe(9090);
+  });
+
+  it("derives the port from a localhost plain-http URL", () => {
+    expect(deriveSignalManagedNativeBindPort("http://localhost:9191")).toBe(9191);
+  });
+
+  it("does not steer the bind port for an https proxy endpoint", () => {
+    // signal-cli binds plain HTTP; an https URL is a proxy in front of it, not the
+    // daemon's own socket, so it must not name the daemon's bind port.
+    expect(deriveSignalManagedNativeBindPort("https://127.0.0.1:9090")).toBeUndefined();
+  });
+
+  it("does not steer the bind port for a remote daemon URL", () => {
+    expect(deriveSignalManagedNativeBindPort("http://signal.example.com:9090")).toBeUndefined();
+  });
+
+  it("returns undefined for a missing or unparseable baseUrl", () => {
+    expect(deriveSignalManagedNativeBindPort(undefined)).toBeUndefined();
+    expect(deriveSignalManagedNativeBindPort("not a url")).toBeUndefined();
+  });
+
+  it("defaults to port 80 for a local plain-http URL with no explicit port", () => {
+    expect(deriveSignalManagedNativeBindPort("http://127.0.0.1")).toBe(80);
   });
 });

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -67,6 +67,27 @@ export function resolveLocalSignalTransportPort(baseUrl: string): number | undef
   }
 }
 
+// Managed daemon bind port when httpPort is absent: follow an explicit local
+// plain-http connection URL so autoStart and the client probe agree (#116165).
+// signal-cli's bind is plain HTTP, so an https URL is a proxy endpoint and a
+// non-local URL is a remote daemon — neither may steer the bind port.
+export function deriveSignalManagedNativeBindPort(
+  baseUrl: string | undefined,
+): number | undefined {
+  if (!baseUrl) {
+    return undefined;
+  }
+  try {
+    if (new URL(baseUrl).protocol !== "http:") {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  const port = resolveLocalSignalTransportPort(baseUrl);
+  return port !== undefined && isValidSignalManagedNativePort(port) ? port : undefined;
+}
+
 export function isSignalManagedNativeConnectionUrlForBind(
   transport: SignalTransportConfig,
 ): boolean {


### PR DESCRIPTION
## What Problem This Solves

With `channels.signal.autoStart: true`, an `httpUrl` on a nondefault local port, and `httpPort` absent, the managed `signal-cli` daemon binds its default 8080 while OpenClaw probes the configured URL port. The single misconfiguration surfaces as two seemingly unrelated failures (daemon `Failed to initialize HTTP Server` when 8080 is occupied, plus client probe unreachable on the configured port). Reported in #116165.

## Why This Change Was Made

Option 1 from the issue (infer the bind port from the explicit loopback `httpUrl`) is the only one that makes the accepted config shape just work instead of rejecting it. The derivation is deliberately narrow, reusing the existing local-endpoint logic in `transport-policy.ts` (the module that already owns endpoint collision handling):

- Only an explicit **local, plain-http** URL steers the bind port — signal-cli's daemon bind is plain HTTP, so an https URL is a proxy endpoint and a non-local URL is a remote daemon; both keep the 8080 default exactly as today.
- Explicit `opts.httpPort` / `channels.signal.httpPort` still win unchanged; the derivation only replaces the hardcoded 8080 fallback.

## User Impact

The reported config shape (`httpUrl: "http://127.0.0.1:8082"`, `autoStart: true`, no `httpPort`) now starts the daemon on 8082 and the probe succeeds, instead of a split failure. No behavior change for anyone who sets `httpPort`, uses the default URL, or points `httpUrl` at an https/non-local endpoint.

## Evidence

- Root cause is visible at the changed line: `monitor.ts` resolved `opts.httpPort ?? managedTransport?.httpPort ?? 8080` while the ready-probe uses `baseUrl` from the configured `httpUrl` — nothing connected the two.
- Derivation reuses `resolveLocalSignalTransportPort` + `isSignalManagedNativePort` already exported by `extensions/signal/src/transport-policy.ts`, matching the http-only rule `isSignalManagedNativeConnectionUrlForBind` applies for the inverse (bind→URL rewrite) direction.

Fixes #116165
