### PR TITLE
fix(security): detect child_process exec calls through aliases and computed members

### DIFF
--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -191,6 +191,109 @@ const LINE_RULES: LineRule[] = [
   },
 ];
 
+const CHILD_PROCESS_EXEC_METHODS = [
+  "exec",
+  "execSync",
+  "spawn",
+  "spawnSync",
+  "execFile",
+  "execFileSync",
+];
+const CHILD_PROCESS_MODULE_PATTERN = String.raw`["'](?:node:)?child_process["']`;
+const IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/;
+
+const escapeAliasForPattern = (alias: string) => alias.replace(/\$/g, "\\$");
+
+// Aliased bindings hide the literal method names the dangerous-exec line rule
+// keys on (`spawn as launch`, `{ exec: run }`, cp["spawn"]). Derive extra
+// per-source rules only from bindings proven to come from child_process
+// imports/requires, so unrelated functions (RegExp.exec, custom run()) keep
+// their negative behavior (#116255).
+function buildChildProcessAliasRules(source: string): LineRule[] {
+  const methodAliases = new Set<string>();
+  const namespaceAliases = new Set<string>();
+  const collectAliasedBindings = (list: string, separator: RegExp) => {
+    for (const entry of list.split(",")) {
+      const parts = entry.trim().split(separator);
+      const imported = parts[0]?.trim() ?? "";
+      const alias = parts[1]?.trim() ?? "";
+      if (
+        parts.length === 2 &&
+        CHILD_PROCESS_EXEC_METHODS.includes(imported) &&
+        alias !== imported &&
+        IDENTIFIER_PATTERN.test(alias)
+      ) {
+        methodAliases.add(alias);
+      }
+    }
+  };
+  for (const match of source.matchAll(
+    new RegExp(String.raw`import\s+([^'"]+?)\s*from\s*` + CHILD_PROCESS_MODULE_PATTERN, "g"),
+  )) {
+    const clause = (match[1] ?? "").replace(/^type\s+/, "");
+    const braced = /\{([^}]*)\}/.exec(clause);
+    if (braced) {
+      collectAliasedBindings(braced[1] ?? "", /\s+as\s+/);
+    }
+    const star = /\*\s*as\s+([A-Za-z_$][\w$]*)/.exec(clause);
+    if (star?.[1]) {
+      namespaceAliases.add(star[1]);
+    }
+    const defaultName = clause
+      .replace(/\{[^}]*\}/, "")
+      .replace(/\*\s*as\s+[A-Za-z_$][\w$]*/, "")
+      .replace(/,/g, " ")
+      .trim();
+    if (IDENTIFIER_PATTERN.test(defaultName)) {
+      namespaceAliases.add(defaultName);
+    }
+  }
+  for (const match of source.matchAll(
+    new RegExp(
+      String.raw`(?:const|let|var)\s*\{([^}]*)\}\s*=\s*require\s*\(\s*` +
+        CHILD_PROCESS_MODULE_PATTERN +
+        String.raw`\s*\)`,
+      "g",
+    ),
+  )) {
+    collectAliasedBindings(match[1] ?? "", /:/);
+  }
+  for (const match of source.matchAll(
+    new RegExp(
+      String.raw`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*` +
+        CHILD_PROCESS_MODULE_PATTERN +
+        String.raw`\s*\)`,
+      "g",
+    ),
+  )) {
+    if (match[1]) {
+      namespaceAliases.add(match[1]);
+    }
+  }
+  const rules: LineRule[] = [];
+  if (methodAliases.size > 0) {
+    rules.push({
+      ruleId: "dangerous-exec",
+      severity: "critical",
+      message: "Shell command execution detected (child_process import alias)",
+      pattern: new RegExp(
+        String.raw`\b(?:${[...methodAliases].map(escapeAliasForPattern).join("|")})\s*\(`,
+      ),
+    });
+  }
+  if (namespaceAliases.size > 0) {
+    rules.push({
+      ruleId: "dangerous-exec",
+      severity: "critical",
+      message: "Shell command execution detected (child_process computed member)",
+      pattern: new RegExp(
+        String.raw`\b(?:${[...namespaceAliases].map(escapeAliasForPattern).join("|")})\s*\[\s*["'](?:${CHILD_PROCESS_EXEC_METHODS.join("|")})["']\s*\]\s*\(`,
+      ),
+    });
+  }
+  return rules;
+}
+
 const STANDARD_PORTS = new Set([80, 443, 8080, 8443, 3000]);
 const NETWORK_SEND_CONTEXT_PATTERN = /\bfetch\s*\(|\bpost\s*\(|\.\s*post\s*\(|http\.request\s*\(/i;
 
@@ -395,7 +498,8 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
   const heuristicLines = heuristicSource.split("\n");
 
   // --- Line rules ---
-  for (const rule of LINE_RULES) {
+  const lineRules = [...LINE_RULES, ...buildChildProcessAliasRules(source)];
+  for (const rule of lineRules) {
     // Skip rule entirely if context requirement not met
     if (rule.requiresContext && !rule.requiresContext.test(source)) {
       continue;

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -271,13 +271,16 @@ function buildChildProcessAliasRules(source: string): LineRule[] {
     }
   }
   const rules: LineRule[] = [];
+  // `$` is a valid identifier character but not a `\w` character, so `\b` never matches
+  // immediately before it; a negative lookbehind treats it like the rest of the alias.
+  const identifierStartGuard = String.raw`(?<![\w$])`;
   if (methodAliases.size > 0) {
     rules.push({
       ruleId: "dangerous-exec",
       severity: "critical",
       message: "Shell command execution detected (child_process import alias)",
       pattern: new RegExp(
-        String.raw`\b(?:${[...methodAliases].map(escapeAliasForPattern).join("|")})\s*\(`,
+        `${identifierStartGuard}(?:${[...methodAliases].map(escapeAliasForPattern).join("|")})\\s*\\(`,
       ),
     });
   }
@@ -287,7 +290,7 @@ function buildChildProcessAliasRules(source: string): LineRule[] {
       severity: "critical",
       message: "Shell command execution detected (child_process computed member)",
       pattern: new RegExp(
-        String.raw`\b(?:${[...namespaceAliases].map(escapeAliasForPattern).join("|")})\s*\[\s*["'](?:${CHILD_PROCESS_EXEC_METHODS.join("|")})["']\s*\]\s*\(`,
+        `${identifierStartGuard}(?:${[...namespaceAliases].map(escapeAliasForPattern).join("|")})\\s*\\[\\s*["'](?:${CHILD_PROCESS_EXEC_METHODS.join("|")})["']\\s*\\]\\s*\\(`,
       ),
     });
   }
@@ -498,7 +501,10 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
   const heuristicLines = heuristicSource.split("\n");
 
   // --- Line rules ---
-  const lineRules = [...LINE_RULES, ...buildChildProcessAliasRules(source)];
+  // Discover bindings from comment-stripped source so a commented-out import
+  // cannot manufacture a provenance-bearing alias rule that then flags an
+  // unrelated call as critical (ClawSweeper #116365 follow-up).
+  const lineRules = [...LINE_RULES, ...buildChildProcessAliasRules(heuristicSource)];
   for (const rule of lineRules) {
     // Skip rule entirely if context requirement not met
     if (rule.requiresContext && !rule.requiresContext.test(source)) {


### PR DESCRIPTION
## What Problem This Solves

The advisory `dangerous-exec` scanner rule only matches literal `child_process` method names followed by `(`, so all three shapes from #116255 scan clean:

```ts
import { spawn as launch } from "node:child_process";
launch("node", ["server.js"]);
```
```ts
const { exec: run } = require("child_process");
run("node server.js");
```
```ts
import cp from "node:child_process";
cp["spawn"]("node", ["server.js"]);
```

A deep plugin/skill audit can therefore omit a critical `code_safety` finding, and a Skill Workshop proposal using one of these forms stays `clean` instead of `failed`.

## Why This Change Was Made

Per the issue's suggested direction: derive call bindings **only from actual `child_process` imports/requires** rather than source-wide token correlation. A per-source pre-pass (`buildChildProcessAliasRules`) collects:

- method aliases from ESM named imports (`spawn as launch`) and CJS destructuring (`{ exec: run }`) — only when the imported name is one of the six exec methods and the alias differs (non-aliased bindings are already caught by the literal rule, so no double reporting);
- namespace bindings from default/`* as` imports and `const cp = require(...)`, matched only in computed-member call form `ns["spawn"](` (dot form is already caught by the literal rule).

The derived rules reuse the existing `LineRule` pipeline (same `dangerous-exec` ruleId, same severity, same per-rule finding cap and evidence formatting), so downstream consumers see identical finding shapes. Negative behavior is preserved: `RegExp.exec()`, custom `run()` with no child_process provenance, and unrelated bracket access produce nothing because rules are built only from proven bindings, and identifiers are matched with word boundaries.

## User Impact

`openclaw security audit --deep` and Skill Workshop proposal scanning now flag aliased and computed-member `child_process` execution as critical `dangerous-exec` findings instead of reporting clean.

## Evidence

- All three reproduction sources from #116255 now produce a `dangerous-exec` finding via the derived rules (method-alias rule for cases 1–2, computed-member rule for case 3).
- The issue's requested negatives hold by construction: no `child_process` import/require in the source → no derived rules → unchanged behavior.

Fixes #116255
