### PR TITLE
fix(infra): stop warning on fast commits with a zero SQLite busy timeout

### DIFF
--- a/src/infra/sqlite-transaction.test.ts
+++ b/src/infra/sqlite-transaction.test.ts
@@ -312,6 +312,27 @@ describe("runSqliteImmediateTransactionSync", () => {
     );
   });
 
+  it("does not warn for fast successful steps with a zero busy timeout", () => {
+    const logger = { warn: vi.fn() };
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      const value = now;
+      now += 1;
+      return value;
+    });
+    const db = {
+      exec() {},
+    } as unknown as import("node:sqlite").DatabaseSync;
+
+    runSqliteImmediateTransactionSync(db, () => "committed", {
+      busyTimeoutMs: 0,
+      databaseLabel: "agent.sqlite",
+      logger,
+    });
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it("waits for a separate writer and exposes the synchronous event-loop cost", async () => {
     const holdMs = 200;
     const tempDir = tempDirs.make("openclaw-sqlite-contention-");

--- a/src/infra/sqlite-transaction.ts
+++ b/src/infra/sqlite-transaction.ts
@@ -79,10 +79,14 @@ export function isSqliteCorruptionError(error: unknown): boolean {
 }
 
 function slowBusyWaitThresholdMs(options: SqliteTransactionOptions | undefined): number {
-  if (options?.busyTimeoutMs === undefined) {
+  const busyTimeoutMs = options?.busyTimeoutMs;
+  // A non-positive busy timeout never waits, so scaling the threshold down to it
+  // would flag every successful commit that crosses a millisecond tick.
+  // Genuine contention there still surfaces as "SQLite transaction lock wait failed".
+  if (busyTimeoutMs === undefined || busyTimeoutMs <= 0) {
     return DEFAULT_SLOW_BUSY_WAIT_MS;
   }
-  return Math.min(DEFAULT_SLOW_BUSY_WAIT_MS, Math.max(1, options.busyTimeoutMs));
+  return Math.min(DEFAULT_SLOW_BUSY_WAIT_MS, busyTimeoutMs);
 }
 
 function slowTransactionHoldThresholdMs(options: SqliteTransactionOptions | undefined): number {


### PR DESCRIPTION
## What Problem This Solves

A **successful** SQLite transaction that took 1 ms could be logged at WARN level as
`slow SQLite transaction lock wait`. This happened on every code path that deliberately
disables waiting with `busyTimeoutMs: 0`, so operators saw repeated lock-contention
warnings for healthy, uncontended commits.

## Why This Change Was Made

`slowBusyWaitThresholdMs` in `src/infra/sqlite-transaction.ts` scaled the diagnostic
threshold to the caller's busy timeout, but funneled an explicit value through
`Math.max(1, options.busyTimeoutMs)`. An explicit `0` therefore became a **1 ms**
threshold. Because `execTimedTransactionStep` measures with `Date.now()` (millisecond
resolution), any `BEGIN`/`COMMIT` that merely crosses a millisecond tick reached that
threshold and warned.

A non-positive busy timeout means "do not wait at all", so there is no wait budget to
scale against; the correct behavior is the default diagnostic threshold. The
`Math.max(1, ...)` floor existed only to keep the zero case from producing a `0` ms
threshold, so it is removed along with the branch it guarded — for any positive timeout
the result is unchanged.

## User Impact

- No more WARN noise for successful, fast commits on the zero-timeout paths
  (`state.lease` in `src/state/openclaw-state-lease.ts` and `session.write-lease` in
  `src/agents/session-write-lock.ts`, the only callers that pass `0`).
- Genuinely slow successful waits still warn, now at the intended 1 s threshold.
- Real `SQLITE_BUSY` / `SQLITE_LOCKED` failures are untouched: they still throw and still
  log `SQLite transaction lock wait failed` from the catch path, which does not consult
  this threshold at all.

## Evidence

- `slowBusyWaitThresholdMs` is consumed only by `logSlowTransactionStep`, which gates on
  `params.elapsedMs < slowBusyWaitThresholdMs(params.options)` — the sole use of the
  success-path threshold, so the change cannot affect failure diagnostics.
- The lock-failure warning lives in the `catch` block of `execTimedTransactionStep` and is
  gated on `isSqliteLockError(error)`, independent of any threshold; that path is
  unchanged.
- `slowTransactionHoldThresholdMs` (used by `logSlowTransactionHold`) is a separate
  constant and is not touched.
- Behavior for positive timeouts is identical: for any `busyTimeoutMs > 0`,
  `Math.max(1, busyTimeoutMs)` and `busyTimeoutMs` produce the same integer-millisecond
  comparison against `elapsedMs`, so `Math.min(DEFAULT_SLOW_BUSY_WAIT_MS, busyTimeoutMs)`
  preserves the existing clamp semantics.
- Existing tests in `src/infra/sqlite-transaction.test.ts` exercise only positive timeouts
  (`5_000`, `1_000`, `20`), including the real separate-writer contention proof that
  asserts `SQLite transaction lock wait failed` with `busyTimeoutMs: 20`; none of them
  depend on the removed `Math.max(1, ...)` floor.

Fixes #115972
