### PR TITLE
fix(googlechat): drop invalid thread resource names before send

### DIFF
--- a/extensions/googlechat/src/api.thread-name.test.ts
+++ b/extensions/googlechat/src/api.thread-name.test.ts
@@ -1,0 +1,103 @@
+// Regression coverage for #115742: Google Chat rejects a message create call outright
+// (400 INVALID_ARGUMENT) when `thread.name` is not a same-space `spaces/{space}/threads/{thread}`
+// resource name. Reply routing can hand back a bare id, a message name, or a
+// foreign-space thread, so `sendGoogleChatMessage` must drop those rather than fail the
+// send. Resource-name format verified against Google's own Chat API reference
+// (Thread resource: "Example: spaces/{space}/threads/{thread}"; threads are
+// space-scoped, so a cross-space name is never valid).
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import { isUsableGoogleChatThreadName, sendGoogleChatMessage } from "./api.js";
+
+describe("isUsableGoogleChatThreadName", () => {
+  it("accepts a same-space thread resource name", () => {
+    expect(isUsableGoogleChatThreadName("spaces/AAAA/threads/BBBB", "spaces/AAAA")).toBe(true);
+  });
+
+  it("rejects a foreign-space thread resource name", () => {
+    expect(isUsableGoogleChatThreadName("spaces/OTHER/threads/BBBB", "spaces/AAAA")).toBe(false);
+  });
+
+  it("rejects a bare thread id", () => {
+    expect(isUsableGoogleChatThreadName("BBBB", "spaces/AAAA")).toBe(false);
+  });
+
+  it("rejects a message resource name", () => {
+    expect(isUsableGoogleChatThreadName("spaces/AAAA/messages/CCCC", "spaces/AAAA")).toBe(false);
+  });
+
+  it("rejects a thread name with extra path segments", () => {
+    expect(
+      isUsableGoogleChatThreadName("spaces/AAAA/threads/BBBB/messages/CCCC", "spaces/AAAA"),
+    ).toBe(false);
+  });
+});
+
+vi.mock("./auth.js", () => ({
+  getGoogleChatAccessToken: vi.fn(async () => "test-token"),
+}));
+
+const guardedFetchMock = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, fetchWithSsrFGuard: guardedFetchMock };
+});
+
+const account: ResolvedGoogleChatAccount = {
+  accountId: "acct-1",
+  enabled: true,
+  config: {},
+  credentialSource: "service-account",
+} as unknown as ResolvedGoogleChatAccount;
+
+function mockGuardedResponse(body: unknown) {
+  guardedFetchMock.mockImplementation(async () => ({
+    response: new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    release: () => {},
+  }));
+}
+
+describe("sendGoogleChatMessage thread routing", () => {
+  afterEach(() => {
+    guardedFetchMock.mockReset();
+  });
+
+  it("sends a valid same-space thread as a threaded reply", async () => {
+    mockGuardedResponse({
+      name: "spaces/AAAA/messages/new",
+      thread: { name: "spaces/AAAA/threads/BBBB" },
+    });
+
+    await sendGoogleChatMessage({
+      account,
+      space: "spaces/AAAA",
+      text: "hello",
+      thread: "spaces/AAAA/threads/BBBB",
+    });
+
+    const call = guardedFetchMock.mock.calls[0]?.[0] as { url: string; init?: RequestInit };
+    expect(call.url).toContain("messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
+    const sentBody = JSON.parse(String(call.init?.body));
+    expect(sentBody.thread).toEqual({ name: "spaces/AAAA/threads/BBBB" });
+  });
+
+  it("drops an invalid thread hint and falls back to a new-thread send instead of failing", async () => {
+    mockGuardedResponse({ name: "spaces/AAAA/messages/new" });
+
+    const result = await sendGoogleChatMessage({
+      account,
+      space: "spaces/AAAA",
+      text: "hello",
+      thread: "spaces/OTHER/threads/BBBB",
+    });
+
+    expect(result).not.toBeNull();
+    const call = guardedFetchMock.mock.calls[0]?.[0] as { url: string; init?: RequestInit };
+    expect(call.url).not.toContain("messageReplyOption");
+    const sentBody = JSON.parse(String(call.init?.body));
+    expect(sentBody.thread).toBeUndefined();
+  });
+});

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -178,6 +178,13 @@ async function fetchBuffer(
   });
 }
 
+// A Chat `thread` must be a same-space `spaces/{space}/threads/{thread}` name. Reply
+// routing also yields bare ids, message names, and foreign-space threads, and the API
+// rejects the whole send with 400 INVALID_ARGUMENT rather than ignoring it (#115742).
+export function isUsableGoogleChatThreadName(thread: string, space: string): boolean {
+  return /^spaces\/[^/]+\/threads\/[^/]+$/.test(thread) && thread.startsWith(`${space}/threads/`);
+}
+
 export async function sendGoogleChatMessage(params: {
   account: ResolvedGoogleChatAccount;
   space: string;
@@ -186,6 +193,9 @@ export async function sendGoogleChatMessage(params: {
   cardsV2?: GoogleChatCardV2[];
 }): Promise<{ messageName?: string; threadName?: string } | null> {
   const { account, space, text, thread, cardsV2 } = params;
+  // Unusable thread names are dropped so the reply still lands in the space as a new
+  // thread instead of failing the send and losing the message entirely.
+  const usableThread = thread && isUsableGoogleChatThreadName(thread, space) ? thread : undefined;
   if (
     text &&
     (!cardsV2 || cardsV2.length === 0) &&
@@ -200,11 +210,11 @@ export async function sendGoogleChatMessage(params: {
   if (cardsV2 && cardsV2.length > 0) {
     body.cardsV2 = cardsV2;
   }
-  if (thread) {
-    body.thread = { name: thread };
+  if (usableThread) {
+    body.thread = { name: usableThread };
   }
   const urlObj = new URL(`${CHAT_API_BASE}/${space}/messages`);
-  if (thread) {
+  if (usableThread) {
     urlObj.searchParams.set("messageReplyOption", "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
   }
   const url = urlObj.toString();


### PR DESCRIPTION
## What Problem This Solves

A Google Chat DM reply can be lost entirely. `deliverGoogleChatReply` deletes the
"typing…" placeholder whenever the placeholder's thread differs from the reply's
resolved thread (`extensions/googlechat/src/monitor-reply-delivery.ts`), then falls
through to `sendGoogleChatMessage({ thread: replyThreadName, ... })`. When
`replyThreadName` is not a valid `spaces/{space}/threads/{thread}` resource name, the
Chat API rejects the whole send with `400 INVALID_ARGUMENT: The request contains an
invalid thread resource name`. Net result: placeholder gone ("Message deleted by its
author"), replacement send rejected, agent answer never shown — a silent drop even
though the run completed successfully.

## Why This Change Was Made

`thread` is a routing hint, not the destination — the destination is the space in the
request URL. Chat treats a malformed or foreign-space thread name as a hard argument
error rather than ignoring it, so one bad hint takes down delivery that would
otherwise succeed. `sendGoogleChatMessage` is the single choke point every
Google Chat sender goes through (monitor reply delivery, channel adapters, actions,
approval delivery, access notices), so validating there fixes all of them without
adding a second code path. `#87054` only stopped setting `replyToId` on the ingress
side; the send side stayed unguarded, which is why this still reproduces.

## User Impact

Google Chat DM conversations reply again instead of ending in a deleted placeholder
and nothing else. A reply whose thread hint cannot be honored is posted to the space
as a new thread rather than being dropped. Sends with a valid same-space thread name
are unchanged: `body.thread` and
`messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD` are still set exactly as
before, so existing in-thread space replies keep their threading.

## Evidence

- `extensions/googlechat/src/api.ts`: `sendGoogleChatMessage` previously gated both
  `body.thread = { name: thread }` and the `messageReplyOption` query parameter on a
  bare truthiness check of `thread`. Any non-empty string was forwarded verbatim to
  `POST {space}/messages`, which is what produces the `400 INVALID_ARGUMENT`.
- The new `isUsableGoogleChatThreadName(thread, space)` accepts only
  `^spaces/[^/]+/threads/[^/]+$` **and** requires the name to start with
  `${space}/threads/`. Both halves matter: the pattern rejects bare ids and
  `spaces/{space}/messages/{id}` names, and the prefix check rejects a well-formed
  thread that belongs to a different space (also a `400` from Chat). `space` already
  carries the `spaces/` prefix — it is interpolated directly into
  `` `${CHAT_API_BASE}/${space}/messages` `` — so the comparison is against the same
  string the request is addressed to.
- Both usages now read the derived `usableThread`, keeping `body.thread` and
  `messageReplyOption` symmetric. Setting one without the other would still be
  rejected, so they must be gated by the same condition.
- Real thread values reaching this parameter are full resource names: ingress derives
  them from `payload.replyToId` / `turnSourceThreadId`
  (`extensions/googlechat/src/monitor-durable.ts`,
  `extensions/googlechat/src/approval-native.ts`), which carry
  `spaces/{space}/threads/{thread}`. Valid space/thread replies therefore pass the
  guard unchanged; only the shapes that the API already refuses are dropped.
- Doctrine fit: severity order puts silent failure above crash. Dropping an
  unhonorable routing hint converts a lost reply into a delivered reply in the correct
  space, which is the visible outcome the operator expects.

Fixes #115742
