### PR TITLE
fix(memory-wiki): read exact canonical wiki pages without scanning the vault

### DIFF
--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -1588,6 +1588,47 @@ describe("getMemoryWikiPage", () => {
     expect(result?.truncated).toBe(true);
   });
 
+  it("reads an exact canonical path without enumerating unrelated pages", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    const targetPath = path.join(rootDir, "sources", "alpha.md");
+    const unrelatedPath = path.join(rootDir, "sources", "unrelated-bad.md");
+    await fs.writeFile(
+      targetPath,
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.alpha", title: "Alpha Source" },
+        body: "# Alpha Source\n\nexact path content\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(unrelatedPath, "# Unrelated\n", "utf8");
+
+    const originalReadFile = fs.readFile.bind(fs);
+    const readFileSpy = vi
+      .spyOn(fs, "readFile")
+      .mockImplementation(async (...args: Parameters<typeof fs.readFile>) => {
+        if (args[0] === unrelatedPath) {
+          throw new Error("unrelated page is unreadable");
+        }
+        return await originalReadFile(...args);
+      });
+
+    try {
+      const result = await getMemoryWikiPage({
+        config,
+        lookup: "sources/alpha.md",
+      });
+
+      expect(result?.path).toBe("sources/alpha.md");
+      expect(result?.content).toContain("exact path content");
+      expect(readFileSpy).toHaveBeenCalledWith(targetPath, "utf8");
+      expect(readFileSpy).not.toHaveBeenCalledWith(unrelatedPath, "utf8");
+    } finally {
+      readFileSpy.mockRestore();
+    }
+  });
+
   it("defaults non-finite wiki line options before slicing", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -1629,6 +1629,32 @@ describe("getMemoryWikiPage", () => {
     }
   });
 
+  it("does not direct-read through a directory symlink outside the vault", async () => {
+    const { rootDir, config } = await createQueryVault({
+      initialize: true,
+    });
+    const outsideDir = `${rootDir}-outside`;
+    const outsidePage = path.join(outsideDir, "external.md");
+    const linkedDir = path.join(rootDir, "sources", "linked");
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.writeFile(
+      outsidePage,
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.external", title: "External Source" },
+        body: "# External Source\n\nmust remain outside\n",
+      }),
+      "utf8",
+    );
+    await fs.symlink(outsideDir, linkedDir, process.platform === "win32" ? "junction" : "dir");
+
+    const result = await getMemoryWikiPage({
+      config,
+      lookup: "sources/linked/external.md",
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("defaults non-finite wiki line options before slicing", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -1237,6 +1237,74 @@ function resolveDigestClaimLookup(digest: QueryDigestBundle, lookup: string): st
   return match?.pagePath ?? null;
 }
 
+async function readCanonicalWikiPage(
+  rootDir: string,
+  lookup: string,
+): Promise<QueryableWikiPage | null> {
+  const normalized = normalizeLookupKey(lookup);
+  const relativePath = normalized.endsWith(".md") ? normalized : `${normalized}.md`;
+  const segments = relativePath.split("/");
+  const [rootSegment] = segments;
+  // Only vault-relative paths under a queryable dir may bypass enumeration; absolute paths,
+  // traversal, empty segments, and reserved index pages fall back to the scanning path (#116048).
+  if (
+    segments.length < 2 ||
+    segments.some((segment) => segment === "" || segment === "." || segment === "..") ||
+    !QUERY_DIRS.some((queryDir) => queryDir === rootSegment) ||
+    path.basename(relativePath) === "index.md"
+  ) {
+    return null;
+  }
+
+  // Vault enumeration walks with a skip-symlink policy, so the direct read must reject symlinked
+  // targets too; comparing real paths keeps the fast path on the same files the scan would see.
+  const absolutePath = path.join(rootDir, relativePath);
+  const [rootReal, pageReal] = await Promise.all([
+    fs.realpath(rootDir).catch(() => null),
+    fs.realpath(absolutePath).catch(() => null),
+  ]);
+  if (!rootReal || pageReal !== path.join(rootReal, ...segments)) {
+    return null;
+  }
+
+  const raw = await fs.readFile(absolutePath, "utf8").catch(() => null);
+  if (raw === null) {
+    return null;
+  }
+  const summary = toWikiPageSummary({ absolutePath, relativePath, raw });
+  return summary ? { ...summary, raw } : null;
+}
+
+async function resolveWikiGetPage(params: {
+  config: ResolvedMemoryWikiConfig;
+  lookup: string;
+  canReadPage: (page: QueryableWikiPage) => boolean;
+}): Promise<QueryableWikiPage | null> {
+  const rootDir = params.config.vault.path;
+  const canonicalPage = await readCanonicalWikiPage(rootDir, params.lookup);
+  if (
+    canonicalPage &&
+    params.canReadPage(canonicalPage) &&
+    resolveQueryableWikiPageByLookup([canonicalPage], params.lookup)
+  ) {
+    return canonicalPage;
+  }
+
+  const digest = await readQueryDigestBundle(params.config);
+  const digestClaimPagePath = digest ? resolveDigestClaimLookup(digest, params.lookup) : null;
+  const digestLookupPage = digestClaimPagePath
+    ? ((await readQueryableWikiPagesByPaths(rootDir, [digestClaimPagePath])).find(
+        params.canReadPage,
+      ) ?? null)
+    : null;
+  if (digestLookupPage) {
+    return digestLookupPage;
+  }
+
+  const pages = (await readQueryableWikiPages(rootDir)).filter(params.canReadPage);
+  return resolveQueryableWikiPageByLookup(pages, params.lookup);
+}
+
 export function resolveQueryableWikiPageByLookup(
   pages: QueryableWikiPage[],
   lookup: string,
@@ -1370,18 +1438,11 @@ export async function getMemoryWikiPage(input: {
   const lineCount = normalizePositiveInteger(params.lineCount, 200);
 
   if (shouldSearchWiki(effectiveConfig)) {
-    const canReadPage = createWikiPageVisibilityFilter(params);
-    const digest = await readQueryDigestBundle(effectiveConfig);
-    const digestClaimPagePath = digest ? resolveDigestClaimLookup(digest, params.lookup) : null;
-    const digestLookupPage = digestClaimPagePath
-      ? ((
-          await readQueryableWikiPagesByPaths(effectiveConfig.vault.path, [digestClaimPagePath])
-        ).find(canReadPage) ?? null)
-      : null;
-    const pages = digestLookupPage
-      ? [digestLookupPage]
-      : (await readQueryableWikiPages(effectiveConfig.vault.path)).filter(canReadPage);
-    const page = digestLookupPage ?? resolveQueryableWikiPageByLookup(pages, params.lookup);
+    const page = await resolveWikiGetPage({
+      config: effectiveConfig,
+      lookup: params.lookup,
+      canReadPage: createWikiPageVisibilityFilter(params),
+    });
     if (page) {
       const parsed = parseWikiMarkdown(page.raw);
       const lines = parsed.body.split(/\r?\n/);

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -1246,7 +1246,7 @@ async function readCanonicalWikiPage(
   const segments = relativePath.split("/");
   const [rootSegment] = segments;
   // Only vault-relative paths under a queryable dir may bypass enumeration; absolute paths,
-  // traversal, empty segments, and reserved index pages fall back to the scanning path (#116048).
+  // traversal, empty segments, and reserved index pages fall back to the scanning path.
   if (
     segments.length < 2 ||
     segments.some((segment) => segment === "" || segment === "." || segment === "..") ||


### PR DESCRIPTION
## What Problem This Solves

`wiki.get` resolved exact canonical page paths by enumerating and parsing the whole Memory
Wiki vault. Because that scan uses `pMap(..., { stopOnError: true })`, one unrelated
unreadable page could reject a read whose target was valid and readable.

## Why This Change Was Made

Exact queryable paths now take a bounded direct-read path before the existing digest and
full-scan fallbacks:

- the lookup must be vault-relative, Markdown, below one of the five queryable directories,
  free of empty/traversal segments, and not an `index.md`;
- the vault and page realpaths must equal the exact canonical path, rejecting file and
  intermediate-directory symlinks just as the scanner's `symlinkPolicy: "skip"` does;
- the same Markdown summary parser, lookup resolver, and visibility filter must accept the
  page before it is returned.

Missing, malformed, fuzzy, claim-id, non-visible, reserved, or noncanonical lookups retain
the existing digest-then-scan behavior.

## User Impact

An operator reading `sources/example.md` gets one bounded page read instead of a whole-vault
scan. The read succeeds even if an unrelated page is temporarily unreadable. Fuzzy/title
lookups and visibility behavior are unchanged, and direct reads cannot follow a path the
scanner would skip.

## Evidence

Focused current-head suite:

```text
node scripts/run-vitest.mjs extensions/memory-wiki/src/query.test.ts

Test Files  1 passed (1)
Tests       51 passed (51)
```

The suite proves that an exact path does not enumerate an unrelated failing page and that
a directory symlink to a valid page outside the vault returns `null`.

A no-mock real-vault transcript also ran the public query entry point as an unprivileged
effective user. The requested page was readable, an unrelated Markdown page was root-only
and deterministically returned EACCES if scanned, and a queryable-directory symlink pointed
to a valid page outside the vault.

Before the patch on current `main`:

```json
{
  "exactLookup": {
    "status": "error",
    "code": "EACCES"
  },
  "externalSymlinkLookup": null
}
```

At this PR's current head:

```json
{
  "exactLookup": {
    "status": "returned",
    "path": "sources/alpha.md",
    "containsExpected": true
  },
  "externalSymlinkLookup": null
}
```

This reproduces the availability failure before the patch, proves the exact read after the
patch, and independently confirms that the fast path does not cross the scanner's symlink
boundary.

Fixes #116048
