### PR TITLE
fix(workboard): apply board defaultAssignee when dispatching ownerless cards

### DIFF
--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -275,9 +275,11 @@ as unavailable; they surface as command errors, and so does any Gateway
 failure when an explicit `--url`/`--token` target was given.
 
 Board metadata can set `autoDecompose`, `autoDecomposePerDispatch`,
-`defaultAssignee`, and `orchestratorProfile`. OpenClaw records this intent and
-exposes it in worker context; actual specification/decomposition still runs
-through the normal Workboard tools.
+`defaultAssignee`, and `orchestratorProfile`. Dispatch applies
+`defaultAssignee` to cards that have no `agentId`, so the board default becomes
+the card owner of record and scopes the worker session key. The remaining
+settings are recorded intent exposed in worker context; actual
+specification/decomposition still runs through the normal Workboard tools.
 
 ## CLI and slash command
 

--- a/extensions/workboard/src/dispatcher-default-assignee-sqlite.smoke.test.ts
+++ b/extensions/workboard/src/dispatcher-default-assignee-sqlite.smoke.test.ts
@@ -1,0 +1,91 @@
+// Real-setup smoke proof for #116358 (requested by ClawSweeper's "non-mock after-fix
+// dispatch evidence" ask): dispatches through a real on-disk SQLite-backed
+// WorkboardStore, then re-opens a fresh store instance from that same file to prove the
+// board default assignee, agentId, and claim were durably persisted - not just visible
+// to the in-process store instance that ran the dispatch.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
+import { createWorkboardSqliteStores } from "./sqlite-store.js";
+import { WorkboardStore } from "./store.js";
+
+function openStore(dbPath: string) {
+  const stores = createWorkboardSqliteStores({ dbPath });
+  const store = new WorkboardStore(stores.cards, {
+    boards: stores.boards,
+    subscriptions: stores.subscriptions,
+    attachments: stores.attachments,
+    dataVersion: stores.dataVersion,
+  });
+  return { store, close: stores.close };
+}
+
+describe("workboard defaultAssignee - real sqlite dispatch", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-default-assignee-"));
+    dbPath = path.join(dir, "workboard.sqlite");
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("persists the board default assignee onto a real sqlite-backed dispatch, durable across a store re-open", async () => {
+    const writer = openStore(dbPath);
+    let cardId: string;
+    try {
+      await writer.store.upsertBoard({ id: "ops", orchestration: { defaultAssignee: "ops-bot" } });
+      const card = await writer.store.create({
+        title: "Real sqlite ownerless card",
+        status: "ready",
+        boardId: "ops",
+        workspaceAccess: { unrestricted: true },
+      });
+      cardId = card.id;
+
+      const run = vi.fn().mockResolvedValue({ runId: "run-real-sqlite" });
+      const result = await dispatchAndStartWorkboardCards({
+        store: writer.store,
+        subagent: { run },
+        options: { now: Date.parse("2026-07-30T00:00:00Z"), maxStarts: 1 },
+      });
+
+      process.stdout.write(
+        `\n===WORKBOARD SQLITE SMOKE===\n` +
+          `dbPath: ${dbPath}\n` +
+          `dispatch result: started=${result.started.length} failures=${result.startFailures.length}\n` +
+          `run() called with sessionKey: ${String((run.mock.calls[0]?.[0] as { sessionKey?: string })?.sessionKey)}\n`,
+      );
+
+      expect(result.started).toEqual([
+        expect.objectContaining({ cardId, runId: "run-real-sqlite" }),
+      ]);
+    } finally {
+      writer.close();
+    }
+
+    // Fresh process-level store instance, same file: proves the write actually landed
+    // on disk rather than only existing in the writer's in-memory cache.
+    const reader = openStore(dbPath);
+    try {
+      const persisted = await reader.store.get(cardId);
+      process.stdout.write(
+        `re-opened card: agentId=${persisted?.agentId} status=${persisted?.status} ` +
+          `claimOwner=${persisted?.metadata?.claim?.ownerId}\n` +
+          `===END===\n`,
+      );
+      expect(persisted).toMatchObject({
+        agentId: "ops-bot",
+        status: "running",
+        metadata: { claim: { ownerId: "ops-bot" } },
+      });
+    } finally {
+      reader.close();
+    }
+  });
+});

--- a/extensions/workboard/src/dispatcher-default-assignee.test.ts
+++ b/extensions/workboard/src/dispatcher-default-assignee.test.ts
@@ -1,0 +1,148 @@
+// Regression coverage for #116358: dispatch must apply the board's
+// `orchestration.defaultAssignee` to ownerless cards *before* the claim, persisting it
+// as the card's `agentId` so it becomes the owner of record and scopes the worker
+// session key - not just a transient dispatcher identity. Also proves the existing
+// no-default and explicit-owner-override compatibility cases, and that owner-capacity
+// accounting sees the resolved (default-assignee-aware) owner.
+import { describe, expect, it, vi } from "vitest";
+import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
+import type { PersistedWorkboardBoard, PersistedWorkboardCard } from "./persistence-types.js";
+import { WorkboardStore } from "./store.js";
+
+function createMemoryStore<T>() {
+  const entries = new Map<string, T>();
+  return {
+    async register(key: string, value: T) {
+      entries.set(key, value);
+    },
+    async lookup(key: string) {
+      return entries.get(key);
+    },
+    async delete(key: string) {
+      return entries.delete(key);
+    },
+    async entries() {
+      return [...entries].flatMap(([key, value]) => (value ? [{ key, value }] : []));
+    },
+  };
+}
+
+describe("dispatchAndStartWorkboardCards - board defaultAssignee", () => {
+  it("applies the board default assignee to an ownerless card, persists it, and scopes the session key", async () => {
+    const boards = createMemoryStore<PersistedWorkboardBoard>();
+    const store = new WorkboardStore(createMemoryStore<PersistedWorkboardCard>(), { boards });
+    await store.upsertBoard({ id: "ops", orchestration: { defaultAssignee: "ops-bot" } });
+    const card = await store.create({
+      title: "Ownerless ops card",
+      status: "ready",
+      boardId: "ops",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-default-assignee" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: card.id, runId: "run-default-assignee" }),
+    ]);
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      agentId: "ops-bot",
+      status: "running",
+      metadata: { claim: { ownerId: "ops-bot" } },
+    });
+    expect(run.mock.calls[0]?.[0]).toMatchObject({
+      sessionKey: expect.stringMatching(/^agent:ops-bot:/),
+    });
+  });
+
+  it("does not override an existing agentId with the board default", async () => {
+    // Explicit-owner compatibility case: a card someone already assigned keeps its
+    // own owner even when the board has a default.
+    const boards = createMemoryStore<PersistedWorkboardBoard>();
+    const store = new WorkboardStore(createMemoryStore<PersistedWorkboardCard>(), { boards });
+    await store.upsertBoard({ id: "ops", orchestration: { defaultAssignee: "ops-bot" } });
+    const card = await store.create({
+      title: "Already owned card",
+      status: "ready",
+      boardId: "ops",
+      agentId: "alice",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-explicit-owner" });
+
+    await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    await expect(store.get(card.id)).resolves.toMatchObject({ agentId: "alice" });
+  });
+
+  it("leaves cards on a board with no default assignee unaffected", async () => {
+    // No-default compatibility case: unchanged behavior when the board sets no
+    // orchestration default at all. The claim step already backfills agentId from
+    // the resolved dispatch owner regardless of this PR (store-workflow.ts, existing
+    // on main), so the invariant this PR must not disturb is that the *fallback*
+    // dispatcher owner - not a board default - is what lands there.
+    const boards = createMemoryStore<PersistedWorkboardBoard>();
+    const store = new WorkboardStore(createMemoryStore<PersistedWorkboardCard>(), { boards });
+    await store.upsertBoard({ id: "ops" });
+    const card = await store.create({
+      title: "No default board card",
+      status: "ready",
+      boardId: "ops",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-no-default" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: card.id, runId: "run-no-default" }),
+    ]);
+    await expect(store.get(card.id)).resolves.toMatchObject({ agentId: "workboard-dispatcher" });
+  });
+
+  it("counts the default-assignee-resolved owner when checking worker capacity", async () => {
+    // Owner-capacity accounting: two ownerless cards on a board with a default
+    // assignee must share that owner's single worker slot, exactly like two cards
+    // sharing an explicit ownerId already do.
+    const boards = createMemoryStore<PersistedWorkboardBoard>();
+    const store = new WorkboardStore(createMemoryStore<PersistedWorkboardCard>(), { boards });
+    await store.upsertBoard({ id: "ops", orchestration: { defaultAssignee: "ops-bot" } });
+    const first = await store.create({
+      title: "First ownerless ops card",
+      status: "ready",
+      priority: "urgent",
+      boardId: "ops",
+      workspaceAccess: { unrestricted: true },
+    });
+    await store.create({
+      title: "Second ownerless ops card",
+      status: "ready",
+      boardId: "ops",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-capacity" });
+
+    const result = await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 3 },
+    });
+
+    expect(result.started).toEqual([
+      expect.objectContaining({ cardId: first.id, runId: "run-capacity" }),
+    ]);
+    expect(run).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -219,11 +219,17 @@ function sortReadyCards(a: WorkboardCard, b: WorkboardCard): number {
   );
 }
 
-function resolveDispatchOwner(card: WorkboardCard, now: number, ownerOverride?: string): string {
+function resolveDispatchOwner(
+  card: WorkboardCard,
+  now: number,
+  ownerOverride: string | undefined,
+  defaultAssignees: ReadonlyMap<string, string>,
+): string {
   return (
     ownerOverride ||
     (cardHasActiveClaim(card, now) ? card.metadata?.claim?.ownerId : undefined) ||
     card.agentId ||
+    defaultAssignees.get(cardBoardId(card)) ||
     DEFAULT_DISPATCH_OWNER
   );
 }
@@ -233,6 +239,7 @@ function selectStartableCards(
   limit: number,
   candidates: WorkboardCard[],
   ownerOverride: string | undefined,
+  defaultAssignees: ReadonlyMap<string, string>,
   now: number,
 ): WorkboardCard[] {
   if (limit <= 0) {
@@ -253,7 +260,7 @@ function selectStartableCards(
     }
     // A grace-protected running claim still occupies its actual worker, even
     // after the lease expires and the card's assigned agent differs.
-    const owner = claim?.ownerId ?? resolveDispatchOwner(card, now);
+    const owner = claim?.ownerId ?? resolveDispatchOwner(card, now, undefined, defaultAssignees);
     runningByOwner.set(owner, (runningByOwner.get(owner) ?? 0) + 1);
   }
   const selected: WorkboardCard[] = [];
@@ -265,7 +272,7 @@ function selectStartableCards(
         entry.status === "ready" && !cardHasActiveClaim(entry, now) && !cardIsArchived(entry),
     )
     .toSorted(sortReadyCards)) {
-    const owner = resolveDispatchOwner(card, now, ownerOverride);
+    const owner = resolveDispatchOwner(card, now, ownerOverride, defaultAssignees);
     if ((runningByOwner.get(owner) ?? 0) > 0) {
       continue;
     }
@@ -318,19 +325,44 @@ async function runWorkboardDispatch(
   const cards = await params.store.list();
   const candidates = await params.store.list({ boardId });
   const ownerOverride = params.options?.ownerId?.trim() || undefined;
+  const defaultAssignees = await params.store.boardDefaultAssignees();
   const startedOwners = new Set<string>();
   // Allow one fallback per worker slot without draining the queue during an outage.
   const maxAttempts = maxStarts * 2;
   let acceptedStarts = 0;
   let attemptedStarts = 0;
 
-  for (const card of selectStartableCards(cards, maxStarts, candidates, ownerOverride, now)) {
-    const ownerId = resolveDispatchOwner(card, now, ownerOverride);
+  for (const startable of selectStartableCards(
+    cards,
+    maxStarts,
+    candidates,
+    ownerOverride,
+    defaultAssignees,
+    now,
+  )) {
+    const ownerId = resolveDispatchOwner(startable, now, ownerOverride, defaultAssignees);
     if (acceptedStarts >= maxStarts || attemptedStarts >= maxAttempts) {
       break;
     }
     if (startedOwners.has(ownerId)) {
       continue;
+    }
+    let card = startable;
+    const boardAssignee = card.agentId ? undefined : defaultAssignees.get(cardBoardId(card));
+    if (boardAssignee) {
+      // The board default assignee is the owner of record, so adopt it before the claim;
+      // otherwise the claim persists the dispatcher's transient identity into agentId and
+      // the session key stays unscoped (#116358).
+      try {
+        card = await params.store.update(card.id, { agentId: boardAssignee });
+      } catch (error) {
+        startFailures.push({
+          cardId: card.id,
+          title: card.title,
+          error: formatErrorMessage(error),
+        });
+        continue;
+      }
     }
     const sessionKey = workboardSessionKeyForCard(card);
     let claimValue = "";

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -241,6 +241,21 @@ export class WorkboardCoreStore {
     };
   }
 
+  async boardDefaultAssignees(): Promise<Map<string, string>> {
+    const assignees = new Map<string, string>();
+    for (const entry of await this.boardStore.entries()) {
+      if (entry.value?.version !== 1 || !entry.value.board?.id) {
+        continue;
+      }
+      const board = entry.value.board;
+      const assignee = board.orchestration?.defaultAssignee;
+      if (assignee) {
+        assignees.set(board.id, assignee);
+      }
+    }
+    return assignees;
+  }
+
   async upsertBoard(input: WorkboardBoardInput): Promise<WorkboardBoardMetadata> {
     return await this.enqueueMutation(async () => {
       const id = normalizeBoardIdRequired(input.id);


### PR DESCRIPTION
## What Problem This Solves

Dispatching a Workboard card that has no `agentId` overwrote the card's owner of
record with the dispatcher's own synthetic identity, and a board's
`orchestration.defaultAssignee` was never consulted at all.

`resolveDispatchOwner` fell back to the `workboard-dispatcher` constant, and
`WorkboardWorkflowStore.claim` persists the claim owner via
`agentId: card.agentId ?? ownerId`, so the transient claim identity became the
permanent assignment. Two visible consequences: every ownerless card reported
`agentId: workboard-dispatcher`, and its worker session key stayed unscoped
(`subagent:workboard-<board>-<card>` instead of `agent:<assignee>:subagent:...`).
`defaultAssignee` was settable and documented board metadata with no effect on
dispatch.

## Why This Change Was Made

`claim.ownerId` (the caller holding the lease) and `card.agentId` (owner of
record) are distinct concepts everywhere else in the plugin; dispatch was the one
path that collapsed them. The board default assignee is the assignment fact that
belongs in `agentId`, so dispatch now looks it up and adopts it before claiming,
instead of letting the claim invent an owner.

Adoption happens before the claim so the same value drives every downstream
identity decision in one pass — session key scoping, restricted-workspace target
resolution, `expectedAuthority.agentId`, and the persisted `agentId` — rather
than threading a second "effective agent" concept alongside `card.agentId`.

Owner-capacity accounting in `selectStartableCards` resolves owners through the
same helper, so a ready ownerless card and an already-running card on the same
board now key on the same owner instead of splitting between the assignee and the
dispatcher constant.

Behavior is unchanged for boards with no `defaultAssignee` and for cards that
already carry an `agentId`; an explicit `--owner` override still wins the claim
while the board default remains the owner of record, which is the distinction the
issue points at.

## User Impact

- `orchestration.defaultAssignee` is now applied at dispatch: ownerless cards on
  a configured board are assigned to that agent instead of `workboard-dispatcher`.
- Worker runs for those cards get an agent-scoped session key, so the assignee's
  agent owns the session and its workspace target resolution.
- Boards with no `defaultAssignee` behave exactly as before.
- One extra card write per adopted card, only for cards that dispatch is about to
  start and only when the board default actually applies.

## Evidence

Code-level reasoning against the changed paths:

- `extensions/workboard/src/store-workflow.ts:153` — `claim()` writes
  `agentId: card.agentId ?? ownerId`. With `ownerId` coming from the dispatcher
  fallback, that is where `workboard-dispatcher` became the owner of record. With
  the assignee adopted first, `card.agentId` is set, so this expression keeps the
  assignee and the claim owner stays in `metadata.claim.ownerId` only.
- `extensions/workboard/src/dispatcher.ts` — `resolveDispatchOwner` gains the
  board-default lookup between `card.agentId` and `DEFAULT_DISPATCH_OWNER`, so
  the constant is now reached only when no assignment exists anywhere. Both call
  sites in `selectStartableCards` (running-card capacity and candidate selection)
  pass the same map, keeping `runningByOwner` keys and candidate owner keys
  consistent.
- Adoption is placed after the `maxStarts`/`maxAttempts` and `startedOwners`
  early exits, so cards that dispatch skips are never written. A failed adopt
  records a `startFailures` entry and continues, matching the existing
  workspace-authority failure handling in the same loop rather than aborting a
  pass that may already have started other cards.
- `buildSessionKey` reads `card.agentId`; it now receives the adopted card, which
  is why the session key becomes `agent:<assignee>:subagent:workboard-...`. The
  same adopted card feeds `resolveDispatchWorkspaceAccess` (which resolves the
  target workspace from `card.agentId`) and `expectedAuthority.agentId`, so the
  claim's authority guard compares against the persisted value and cannot trip on
  the adoption write.
- `boardDefaultAssignees()` mirrors the existing `listBoards()` entry guard
  (`entry.value?.version !== 1 || !entry.value.board?.id`), so it is safe on
  stores that share one keyed namespace for cards and boards, and it reads board
  rows only — no card scan.
- Docs updated at `docs/plugins/workboard.md`, which previously stated the
  orchestration block was recorded intent only.

Fixes #116358
