### PR TITLE
fix(discord): correct progress receipt timing expectations

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
@@ -95,7 +95,7 @@ describe("processDiscordMessage draft streaming progress", () => {
     expect(draftStream.retarget).toHaveBeenCalledWith("thread-1");
     expect(draftStream.update).toHaveBeenLastCalledWith(
       expect.stringMatching(
-        /^Investigating\n\n🛠️ Exec\n.*Checked the pipeline\.\n-# .*🛠️ 1 tool call.*⏱️ 5s$/,
+        /^Investigating\n\n🛠️ Exec\n.*Checked the pipeline\.\n-# .*🛠️ 1 tool call.*⏱️ 2s$/,
       ),
     );
     expect(draftStream.stop).toHaveBeenCalledTimes(1);
@@ -143,7 +143,7 @@ describe("processDiscordMessage draft streaming progress", () => {
         kind: "block",
         replies: [
           expect.objectContaining({
-            text: expect.stringMatching(/🛠️ 1 tool call.*⏱️ 5s$/),
+            text: expect.stringMatching(/🛠️ 1 tool call.*⏱️ 2s$/),
           }),
         ],
       }),
@@ -185,7 +185,7 @@ describe("processDiscordMessage draft streaming progress", () => {
         kind: "block",
         replies: [
           expect.objectContaining({
-            text: expect.stringMatching(/🛠️ 1 tool call.*⏱️ 5s$/),
+            text: expect.stringMatching(/🛠️ 1 tool call.*⏱️ 2s$/),
           }),
         ],
       }),


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Discord progress test shard fails even though the deterministic fake-clock output is correct.

## Why This Change Was Made

The shared helper advances the fake clock by 1.5 seconds and the production formatter rounds that duration to 2 seconds. The three adopted-thread receipt assertions now verify that actual contract.

## User Impact

No user-visible behavior changes. The Discord test shard no longer reports a false failure.

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts` (23 passed)
- `git diff --check`
- autoreview clean