### PR TITLE
refactor(agents): introduce runtime agent run service

### DIFF
--- a/src/agents/agent-run-service-contract.ts
+++ b/src/agents/agent-run-service-contract.ts
@@ -1,0 +1,24 @@
+import type { agentCommandFromIngress } from "./agent-command.js";
+import type { AgentCommandIngressOpts } from "./command/types.js";
+
+export type AgentRunResult = Awaited<ReturnType<typeof agentCommandFromIngress>>;
+
+export type AgentRunStart = Omit<
+  AgentCommandIngressOpts,
+  "abortSignal" | "runId" | "sessionKey" | "to"
+> & {
+  runId: string;
+  sessionKey: string;
+  signal?: AbortSignal;
+};
+
+type AgentRunHandle = {
+  readonly runId: string;
+  readonly result: Promise<AgentRunResult>;
+  cancel(): boolean;
+};
+
+export type AgentRunServiceContract = {
+  start(input: AgentRunStart): AgentRunHandle;
+  cancel(runId: string): boolean;
+};

--- a/src/agents/agent-run-service.test.ts
+++ b/src/agents/agent-run-service.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRunResult } from "./agent-run-service-contract.js";
+import { AgentRunService } from "./agent-run-service.js";
+import type { AgentCommandIngressOpts } from "./command/types.js";
+import { isAgentRunDirectAbortReason } from "./run-termination.js";
+
+const runResult = {
+  payloads: [],
+  meta: { durationMs: 0 },
+} satisfies AgentRunResult;
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function createStartInput(runId = "run-1") {
+  return {
+    runId,
+    sessionKey: "agent:main:main",
+    message: "hello",
+    allowModelOverride: false,
+  };
+}
+
+describe("AgentRunService", () => {
+  it("starts the canonical ingress command with runtime-owned identity", async () => {
+    const execute = vi.fn(async (_input: AgentCommandIngressOpts) => runResult);
+    const service = new AgentRunService(execute);
+
+    const handle = service.start(createStartInput());
+    await handle.result;
+
+    expect(handle.runId).toBe("run-1");
+    expect(execute).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-1",
+        sessionKey: "agent:main:main",
+        message: "hello",
+        allowModelOverride: false,
+        abortSignal: expect.any(AbortSignal),
+      }),
+    );
+    expect(execute.mock.calls[0]?.[0]).not.toHaveProperty("to");
+  });
+
+  it("strips a runtime-supplied routing target", async () => {
+    const execute = vi.fn(async (_input: AgentCommandIngressOpts) => runResult);
+    const service = new AgentRunService(execute);
+    const input = { ...createStartInput(), to: "unexpected-target" };
+
+    await service.start(input).result;
+
+    expect(execute.mock.calls[0]?.[0]).not.toHaveProperty("to");
+  });
+
+  it("cancels an active run with the canonical direct-abort reason", async () => {
+    const deferred = createDeferred<AgentRunResult>();
+    let signal: AbortSignal | undefined;
+    const service = new AgentRunService(async (input) => {
+      signal = input.abortSignal;
+      return await deferred.promise;
+    });
+    const handle = service.start(createStartInput());
+    await vi.waitFor(() => expect(signal).toBeDefined());
+
+    expect(handle.cancel()).toBe(true);
+    expect(signal?.aborted).toBe(true);
+    expect(isAgentRunDirectAbortReason(signal?.reason)).toBe(true);
+    expect(handle.cancel()).toBe(false);
+
+    deferred.resolve(runResult);
+    await handle.result;
+    expect(service.cancel(handle.runId)).toBe(false);
+  });
+
+  it("combines caller cancellation with runtime cancellation", async () => {
+    const caller = new AbortController();
+    const deferred = createDeferred<AgentRunResult>();
+    let signal: AbortSignal | undefined;
+    const service = new AgentRunService(async (input) => {
+      signal = input.abortSignal;
+      return await deferred.promise;
+    });
+    const handle = service.start({ ...createStartInput(), signal: caller.signal });
+    await vi.waitFor(() => expect(signal).toBeDefined());
+
+    const reason = new Error("caller stopped");
+    caller.abort(reason);
+
+    expect(signal?.aborted).toBe(true);
+    expect(signal?.reason).toBe(reason);
+    expect(service.cancel(handle.runId)).toBe(true);
+    deferred.resolve(runResult);
+    await handle.result;
+  });
+
+  it("rejects duplicate active run ids and releases them after settlement", async () => {
+    const first = createDeferred<AgentRunResult>();
+    const second = createDeferred<AgentRunResult>();
+    const execute = vi
+      .fn()
+      .mockImplementationOnce(async () => await first.promise)
+      .mockImplementationOnce(async () => await second.promise);
+    const service = new AgentRunService(execute);
+    const firstHandle = service.start(createStartInput());
+
+    expect(() => service.start(createStartInput())).toThrow("agent run already active: run-1");
+
+    first.resolve(runResult);
+    await firstHandle.result;
+    const secondHandle = service.start(createStartInput());
+
+    expect(firstHandle.cancel()).toBe(false);
+    expect(secondHandle.cancel()).toBe(true);
+    second.resolve(runResult);
+    await secondHandle.result;
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases a run id after executor failure", async () => {
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("run failed"))
+      .mockResolvedValueOnce(runResult);
+    const service = new AgentRunService(execute);
+
+    await expect(service.start(createStartInput()).result).rejects.toThrow("run failed");
+    await expect(service.start(createStartInput()).result).resolves.toBe(runResult);
+  });
+});

--- a/src/agents/agent-run-service.ts
+++ b/src/agents/agent-run-service.ts
@@ -1,0 +1,78 @@
+import type {
+  AgentRunResult,
+  AgentRunServiceContract,
+  AgentRunStart,
+} from "./agent-run-service-contract.js";
+import type { AgentCommandIngressOpts } from "./command/types.js";
+import { createAgentRunDirectAbortError } from "./run-termination.js";
+
+type AgentRunExecutor = (input: AgentCommandIngressOpts) => Promise<AgentRunResult>;
+
+const defaultAgentRunExecutor: AgentRunExecutor = async (input) => {
+  const { agentCommandFromIngress } = await import("./agent-command.js");
+  return await agentCommandFromIngress(input);
+};
+
+export class AgentRunService implements AgentRunServiceContract {
+  readonly #activeRuns = new Map<string, AbortController>();
+  readonly #execute: AgentRunExecutor;
+
+  constructor(execute: AgentRunExecutor = defaultAgentRunExecutor) {
+    this.#execute = execute;
+  }
+
+  start(input: AgentRunStart) {
+    if (this.#activeRuns.has(input.runId)) {
+      throw new Error(`agent run already active: ${input.runId}`);
+    }
+
+    const controller = new AbortController();
+    const {
+      runId,
+      sessionKey,
+      signal,
+      to: _ignoredTo,
+      ...opts
+    } = input as AgentRunStart & {
+      to?: unknown;
+    };
+    const abortSignal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal;
+
+    // Register before invoking the executor so immediate cancellation can
+    // always address the run, including executors that fail synchronously.
+    this.#activeRuns.set(runId, controller);
+    const result = Promise.resolve()
+      .then(() =>
+        this.#execute({
+          ...opts,
+          runId,
+          sessionKey,
+          abortSignal,
+        }),
+      )
+      .finally(() => {
+        if (this.#activeRuns.get(runId) === controller) {
+          this.#activeRuns.delete(runId);
+        }
+      });
+
+    return {
+      runId,
+      result,
+      cancel: () => this.#cancel(runId, controller),
+    };
+  }
+
+  cancel(runId: string): boolean {
+    const controller = this.#activeRuns.get(runId);
+    return controller ? this.#cancel(runId, controller) : false;
+  }
+
+  #cancel(runId: string, controller: AbortController): boolean {
+    if (this.#activeRuns.get(runId) !== controller || controller.signal.aborted) {
+      return false;
+    }
+    controller.abort(createAgentRunDirectAbortError());
+    return true;
+  }
+}

--- a/src/agents/openclaw-runtime.test.ts
+++ b/src/agents/openclaw-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   resetAgentEventsForTest,
 } from "../infra/agent-events.js";
 import { SessionService } from "../sessions/session-service.js";
+import { AgentRunService } from "./agent-run-service.js";
 import { openClawRuntime } from "./openclaw-runtime.js";
 
 describe("openClawRuntime", () => {
@@ -15,6 +16,10 @@ describe("openClawRuntime", () => {
 
   it("exposes the canonical session service", () => {
     expect(openClawRuntime.sessions).toBeInstanceOf(SessionService);
+  });
+
+  it("exposes the canonical agent run service", () => {
+    expect(openClawRuntime.agentRuns).toBeInstanceOf(AgentRunService);
   });
 
   it("synchronously forwards enriched agent turn observations", () => {

--- a/src/agents/openclaw-runtime.ts
+++ b/src/agents/openclaw-runtime.ts
@@ -1,15 +1,19 @@
 import { type AgentEventRuntimePayload, onAgentRuntimeEvent } from "../infra/agent-events.js";
 import type { SessionServiceContract } from "../sessions/session-service-contract.js";
 import { SessionService } from "../sessions/session-service.js";
+import type { AgentRunServiceContract } from "./agent-run-service-contract.js";
+import { AgentRunService } from "./agent-run-service.js";
 
 type AgentTurnObserver = (event: AgentEventRuntimePayload) => void;
 
 type OpenClawRuntime = {
+  agentRuns: AgentRunServiceContract;
   observeAgentTurns(observer: AgentTurnObserver): () => void;
   sessions: SessionServiceContract;
 };
 
 export const openClawRuntime: OpenClawRuntime = {
+  agentRuns: new AgentRunService(),
   observeAgentTurns: onAgentRuntimeEvent,
   sessions: new SessionService(),
 };


### PR DESCRIPTION
Related: #116310

Part 4 of the direct ACP runtime stack. Do not merge independently; the chain is only ready when inbound ACP runs without a Gateway and the Buzz acceptance test passes.

## What Problem This Solves

OpenClaw has a canonical agent ingress path, but no runtime-owned service for starting and cancelling a turn. A direct ACP adapter would otherwise need to call command internals directly or create its own run registry, producing another lifecycle owner.

## Why This Change Was Made

Introduces `AgentRunService` on `OpenClawRuntime`. The service delegates to the existing `agentCommandFromIngress` path, so provider selection, tools, memory, sessions, lifecycle events, delivery results, and model fallback remain canonical.

The service owns only process-level run concerns:

- required run and session identity
- duplicate active-run rejection
- caller/runtime cancellation composition
- canonical direct-abort reasons
- instance-bound handles that cannot cancel a later run reusing the same ID
- deterministic cleanup after success or failure

The default executor lazy-loads the command implementation, preserving lightweight runtime imports. Gateway protocol state, streaming projection, approvals, and transport delivery policy remain outside this service.

## User Impact

No standalone user-visible behavior change. This creates the single agent-run entry point that Gateway and inbound ACP can share instead of implementing separate agent loops.

## Evidence

- `node scripts/run-vitest.mjs src/agents/agent-run-service.test.ts src/agents/openclaw-runtime.test.ts`
  - 2 test files passed
  - 11 tests passed
- `node scripts/check-deadcode-exports.mjs`
  - production, full-tree, and script scans passed with 0 entries
- `node scripts/check-changed.mjs -- src/agents/agent-run-service-contract.ts src/agents/agent-run-service.ts src/agents/agent-run-service.test.ts src/agents/openclaw-runtime.ts src/agents/openclaw-runtime.test.ts`
  - Blacksmith Testbox lease `tbx_01kysbpagm89rkvzjw6jmnpnb6`
  - https://github.com/openclaw/openclaw/actions/runs/30537752107
  - `exitCode: 0`, `runStatus: succeeded`
  - covered core/core-test typechecks, changed-file lint, formatting, dead exports, plugin boundaries, import cycles, and schema/storage guards
- `git diff --check`
- autoreview: clean, no actionable findings, 0.91 confidence
