### PR TITLE
fix(telegram): preserve callback action ownership

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.callback.runtime.ts
@@ -30,7 +30,10 @@ import { resolveTelegramForumFlag, withResolvedTelegramForumFlag } from "./bot/h
 import type { TelegramGetChat } from "./bot/types.js";
 import { getTelegramCallbackQueryAnswerPromise } from "./callback-query-answer-state.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
-import { parseTelegramOpaqueCallbackData } from "./native-command-callback-data.js";
+import {
+  hasTelegramOpaqueCallbackPrefix,
+  parseTelegramOpaqueCallbackData,
+} from "./native-command-callback-data.js";
 import { isTelegramMessageNotModifiedError } from "./network-errors.js";
 import {
   hasTelegramQuestionCallbackPrefix,
@@ -101,6 +104,7 @@ export function registerTelegramCallbackQueryHandler(
       const isGroup =
         callbackMessage.chat.type === "group" || callbackMessage.chat.type === "supergroup";
       const nativeCallbackCommand = parseTelegramNativeCommandCallbackData(data);
+      const hasReservedOpaquePrefix = hasTelegramOpaqueCallbackPrefix(data);
       const opaqueCallbackData = parseTelegramOpaqueCallbackData(data);
       const genericCallbackText = data.startsWith("/") ? data : `callback_data: ${data}`;
       const callbackCommandText =
@@ -118,15 +122,19 @@ export function registerTelegramCallbackQueryHandler(
         cfg: authorizationCfg,
         accountId,
       });
+      const inlineButtonsUnavailable =
+        inlineButtonsScope === "off" ||
+        (inlineButtonsScope === "dm" && isGroup) ||
+        (inlineButtonsScope === "group" && !isGroup);
       // Runtime controls retain their authorization after inline-button capability changes.
-      if (!isRuntimeControlCallback) {
-        if (
-          inlineButtonsScope === "off" ||
-          (inlineButtonsScope === "dm" && isGroup) ||
-          (inlineButtonsScope === "group" && !isGroup)
-        ) {
-          return;
-        }
+      // Stale typed controls cross this gate only to render their terminal result.
+      if (
+        !isRuntimeControlCallback &&
+        inlineButtonsUnavailable &&
+        !nativeCallbackCommand &&
+        !hasReservedOpaquePrefix
+      ) {
+        return;
       }
 
       const messageThreadId = callbackMessage.message_thread_id;
@@ -199,6 +207,23 @@ export function registerTelegramCallbackQueryHandler(
           senderUsername,
           context: eventAuthContext,
         });
+      const clearRoutedCallbackButtons = async () => {
+        try {
+          await actions.clearCallbackButtons();
+        } catch (editErr) {
+          if (
+            !isTelegramMessageNotModifiedError(editErr) &&
+            !isPermanentTelegramCallbackEditError(editErr)
+          ) {
+            throw new TelegramRetryableCallbackError(editErr);
+          }
+        }
+      };
+      const terminalizeUnavailableCallback = async () => {
+        logVerbose("telegram: typed callback unavailable (handler missing or payload invalid)");
+        await clearRoutedCallbackButtons();
+        await actions.replyToCallbackChat("This action is no longer available.");
+      };
 
       if (typedApprovalCallback) {
         await approvalRuntime.handleCanonical(typedApprovalCallback);
@@ -226,7 +251,16 @@ export function registerTelegramCallbackQueryHandler(
         return;
       }
       if (
-        await handleTelegramInteractiveCallback({
+        inlineButtonsUnavailable &&
+        ((nativeCallbackCommand && !legacyApprovalCallback) || hasReservedOpaquePrefix)
+      ) {
+        await terminalizeUnavailableCallback();
+        return;
+      }
+      if (
+        !nativeCallbackCommand &&
+        !inlineButtonsUnavailable &&
+        (await handleTelegramInteractiveCallback({
           accountId,
           callback,
           ctx,
@@ -243,7 +277,7 @@ export function registerTelegramCallbackQueryHandler(
           actions,
           messageRuntime,
           authorizeCallback,
-        })
+        }))
       ) {
         return;
       }
@@ -251,7 +285,8 @@ export function registerTelegramCallbackQueryHandler(
         await approvalRuntime.handleLegacy(legacyApprovalCallback);
         return;
       }
-      if (opaqueCallbackData) {
+      if (hasReservedOpaquePrefix) {
+        await terminalizeUnavailableCallback();
         return;
       }
       if (
@@ -277,16 +312,7 @@ export function registerTelegramCallbackQueryHandler(
       const hasCallbackInlineKeyboard =
         (callbackMessage.reply_markup?.inline_keyboard?.length ?? 0) > 0;
       if (hasCallbackInlineKeyboard) {
-        try {
-          await actions.clearCallbackButtons();
-        } catch (editErr) {
-          if (
-            !isTelegramMessageNotModifiedError(editErr) &&
-            !isPermanentTelegramCallbackEditError(editErr)
-          ) {
-            throw new TelegramRetryableCallbackError(editErr);
-          }
-        }
+        await clearRoutedCallbackButtons();
       }
       const syntheticMessage = buildSyntheticTextMessage({
         base: withResolvedTelegramForumFlag(callbackMessage, isForum),

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1853,6 +1853,38 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-plugin-1");
   });
 
+  it("preserves raw tgcb1 callbacks emitted before the prefix became reserved", async () => {
+    const pluginHandler = vi.fn(async (ctx) => {
+      expect(ctx.callback.namespace).toBe("tgcb1");
+      expect(ctx.callback.payload).toBe("inspect:123");
+      return { handled: true };
+    });
+    expect(
+      registerPluginInteractiveHandler("legacy-tgcb1", {
+        channel: "telegram",
+        namespace: "tgcb1",
+        handler: pluginHandler,
+      }),
+    ).toEqual({ ok: true });
+
+    createTelegramBot({ token: "tok" });
+    await getCallbackHandler()(
+      makeCallbackRetryContext({
+        id: "cbq-legacy-tgcb1",
+        data: "tgcb1:inspect:123",
+        messageId: 10,
+      }),
+    );
+
+    expect(pluginHandler).toHaveBeenCalledOnce();
+    expect(replySpy).not.toHaveBeenCalled();
+    expect(sendMessageSpy).not.toHaveBeenCalledWith(
+      1234,
+      "This action is no longer available.",
+      undefined,
+    );
+  });
+
   it("preserves raw slash callback_query payloads as command text", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = getCallbackHandler();
@@ -2033,6 +2065,120 @@ describe("createTelegramBot", () => {
     expect(payload.CommandSource).toBe("native");
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-native-1");
   });
+
+  it("keeps tgcmd native when a plugin registers the same namespace", async () => {
+    const pluginHandler = vi.fn(async () => ({ handled: true }));
+    expect(
+      registerPluginInteractiveHandler("namespace-collision", {
+        channel: "telegram",
+        namespace: "tgcmd",
+        handler: pluginHandler,
+      }),
+    ).toEqual({ ok: true });
+
+    createTelegramBot({ token: "tok" });
+    await getCallbackHandler()(
+      makeCallbackRetryContext({
+        id: "cbq-native-collision",
+        data: "tgcmd:/fast status",
+        messageId: 10,
+      }),
+    );
+
+    expect(pluginHandler).not.toHaveBeenCalled();
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    expect(requireValue(replySpy.mock.calls.at(0), "replySpy call")[0]).toMatchObject({
+      CommandBody: "/fast status",
+      CommandSource: "native",
+    });
+  });
+
+  it("terminalizes native callbacks after inline buttons are disabled", async () => {
+    const pluginHandler = vi.fn(async () => ({ handled: true }));
+    registerPluginInteractiveHandler("disabled-native-collision", {
+      channel: "telegram",
+      namespace: "tgcmd",
+      handler: pluginHandler,
+    });
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          capabilities: { inlineButtons: "off" },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    await getCallbackHandler()(
+      makeCallbackRetryContext({
+        id: "cbq-disabled-native",
+        data: "tgcmd:/fast status",
+        messageId: 10,
+        message: {
+          reply_markup: {
+            inline_keyboard: [[{ text: "Status", callback_data: "tgcmd:/fast status" }]],
+          },
+        },
+      }),
+    );
+
+    expect(pluginHandler).not.toHaveBeenCalled();
+    expect(replySpy).not.toHaveBeenCalled();
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
+      reply_markup: { inline_keyboard: [] },
+    });
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      1234,
+      "This action is no longer available.",
+      undefined,
+    );
+  });
+
+  it.each([
+    ["stale", buildTelegramOpaqueCallbackData("missing-plugin:approve-1")],
+    ["malformed", "tgcb1:invalid"],
+  ])("terminalizes %s typed callbacks without raw-text fallthrough", async (_name, data) => {
+    const pluginHandler = vi.fn(async () => ({ handled: true }));
+    registerPluginInteractiveHandler("disabled-typed-owner", {
+      channel: "telegram",
+      namespace: "missing-plugin",
+      handler: pluginHandler,
+    });
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          capabilities: { inlineButtons: "off" },
+        },
+      },
+    });
+    createTelegramBot({ token: "tok" });
+    await getCallbackHandler()(
+      makeCallbackRetryContext({
+        id: `cbq-opaque-${_name}`,
+        data,
+        messageId: 10,
+        message: {
+          reply_markup: { inline_keyboard: [[{ text: "Approve", callback_data: data }]] },
+        },
+      }),
+    );
+
+    expect(pluginHandler).not.toHaveBeenCalled();
+    expect(replySpy).not.toHaveBeenCalled();
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 10, {
+      reply_markup: { inline_keyboard: [] },
+    });
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      1234,
+      "This action is no longer available.",
+      undefined,
+    );
+  });
+
   it("reloads callback model routing bindings without recreating the bot", async () => {
     const buildModelsProviderDataMock =
       telegramBotDepsForTest.buildModelsProviderData as unknown as BuildModelsProviderDataMock;

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2176,7 +2176,7 @@ describe("createTelegramBot", () => {
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-plugin-approve");
   });
 
-  it("does not resolve opaque approval-shaped plugin callbacks", async () => {
+  it("terminalizes unowned opaque approval-shaped plugin callbacks", async () => {
     mockTelegramConfig({
       dmPolicy: "open",
       allowFrom: ["*"],
@@ -2194,7 +2194,14 @@ describe("createTelegramBot", () => {
     );
 
     expect(resolveExecApprovalSpy).not.toHaveBeenCalled();
-    expect(editMessageReplyMarkupSpy).not.toHaveBeenCalled();
+    expect(editMessageReplyMarkupSpy).toHaveBeenCalledWith(1234, 25, {
+      reply_markup: { inline_keyboard: [] },
+    });
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      1234,
+      "This action is no longer available.",
+      undefined,
+    );
     expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-opaque-plugin-approve");
   });
 

--- a/extensions/telegram/src/native-command-callback-data.ts
+++ b/extensions/telegram/src/native-command-callback-data.ts
@@ -22,11 +22,15 @@ export function buildTelegramOpaqueCallbackData(value: string): string {
   return `${TELEGRAM_OPAQUE_CALLBACK_PREFIX}${checksumTelegramOpaqueCallbackValue(value)}:${value}`;
 }
 
+export function hasTelegramOpaqueCallbackPrefix(data?: string | null): boolean {
+  return data?.startsWith(TELEGRAM_OPAQUE_CALLBACK_PREFIX) === true;
+}
+
 export function parseTelegramOpaqueCallbackData(data?: string | null): string | null {
   if (!data) {
     return null;
   }
-  if (!data.startsWith(TELEGRAM_OPAQUE_CALLBACK_PREFIX)) {
+  if (!hasTelegramOpaqueCallbackPrefix(data)) {
     return null;
   }
   const encoded = data.slice(TELEGRAM_OPAQUE_CALLBACK_PREFIX.length);


### PR DESCRIPTION
## What Problem This Solves

Telegram native-command buttons could be consumed by a plugin registered under the private `tgcmd` namespace. Stale or malformed typed `tgcb1` buttons acknowledged a tap but produced no visible result.

## Why This Change Was Made

The callback router now keeps parsed native commands on the native path, reserves the full typed-callback prefix, and terminalizes unhandled typed buttons by removing their controls and sending neutral unavailable feedback. Legacy raw `tgcb1:*` plugin callbacks still reach their registered owner.

No callback wire version, Plugin SDK, Gateway protocol, config, default, or question-flow change.

## User Impact

Native Telegram command buttons always run the OpenClaw command they represent. Expired or retired typed buttons explain that the action is unavailable instead of silently dead-ending.

## Verification

- Exact-head GitHub CI: all checks passed, including channel-runtime boundary, build artifact, four QA smoke profiles, types, lint, and security.
- Testbox: `273/273` passed across `bot.create-telegram-bot.test.ts` and `bot.test.ts`.
- Testbox: `pnpm check:changed` passed, including format, API baseline, boundaries, production/test `tsgo`, and lint.
- Exact-head local fallback: `pnpm build` passed after both remote SSH proof backends were unavailable.
- Telegram userbot: real user DM through an ephemeral exact-head Gateway and mock provider produced the expected Telegram reply and typing lifecycle; redacted artifact below.
- Autoreview: clean, correctness confidence `0.97`.
- Scope audit: removed the stale question/SDK work superseded by #118049.
- Rebased onto current `main`; intervening `main` commits did not touch the four changed files.

The user-driver does not expose an inline-button click command. The changed callback routes therefore use the mocked Bot API matrix below; the live userbot artifact proves the same exact-head Gateway and Telegram transport remain healthy.

```json
{
  "head": "21bc4c323bc0b98afbd8ffbb06441d2a0f82ec32",
  "proof": "telegram-e2e-userbot",
  "topology": "real Telegram user -> ephemeral exact-head Gateway -> mock provider -> Telegram bot reply",
  "providerRequests": 1,
  "recordingComplete": true,
  "timeline": [
    { "elapsedMs": 953, "kind": "typing-start", "source": "sut" },
    { "elapsedMs": 2533, "kind": "typing-stop", "source": "sut" },
    { "elapsedMs": 2533, "kind": "message", "source": "sut", "text": "OPENCLAW_E2E_OK" }
  ],
  "scratchRemovedAfterExit": true,
  "status": "PASS"
}
```

```json
{
  "head": "21bc4c323bc0b98afbd8ffbb06441d2a0f82ec32",
  "proof": "Telegram callback router with mocked Bot API",
  "nativeNamespaceCollision": {
    "pluginCalls": 0,
    "nativeRuns": 1
  },
  "staleTypedCallback": {
    "acknowledged": 1,
    "buttonsCleared": 1,
    "visibleUnavailableMessages": 1,
    "rawTextFallthrough": 0
  },
  "malformedTypedCallback": {
    "acknowledged": 1,
    "buttonsCleared": 1,
    "visibleUnavailableMessages": 1,
    "rawTextFallthrough": 0
  },
  "legacyRawCallback": {
    "pluginCalls": 1,
    "visibleUnavailableMessages": 0
  },
  "inlineButtonsOff": {
    "pluginCalls": 0,
    "buttonsCleared": 1,
    "visibleUnavailableMessages": 1
  },
  "status": "PASS"
}
```

<!-- pr116383-mock-gateway-proof:start -->
### Exact-head callback boundary proof

Ephemeral exact-head Gateway + mock Telegram Bot API + mock provider + temporary collision plugin. The harness delivered real Bot API callback updates through polling and recorded outbound Bot API effects.

```json
{
  "schemaVersion": 1,
  "pr": 116383,
  "head": "21bc4c323bc0b98afbd8ffbb06441d2a0f82ec32",
  "completed": true,
  "harness": {
    "ephemeralGateway": true,
    "mockBotApi": true,
    "mockProvider": true,
    "externalCollisionPlugin": true
  },
  "cases": [
    {
      "name": "native namespace collision",
      "callbackAnswered": true,
      "sentVisibleOutcome": true,
      "unavailableFeedback": false,
      "buttonsCleared": true,
      "pluginInvocations": []
    },
    {
      "name": "legacy raw tgcb1 callback",
      "callbackAnswered": true,
      "sentVisibleOutcome": false,
      "unavailableFeedback": false,
      "buttonsCleared": false,
      "pluginInvocations": [
        "tgcb1:inspect:123"
      ]
    },
    {
      "name": "stale typed callback",
      "callbackAnswered": true,
      "sentVisibleOutcome": true,
      "unavailableFeedback": true,
      "buttonsCleared": true,
      "pluginInvocations": []
    },
    {
      "name": "malformed typed callback",
      "callbackAnswered": true,
      "sentVisibleOutcome": true,
      "unavailableFeedback": true,
      "buttonsCleared": true,
      "pluginInvocations": []
    },
    {
      "name": "native callback after inline buttons disabled",
      "callbackAnswered": true,
      "sentVisibleOutcome": true,
      "unavailableFeedback": true,
      "buttonsCleared": true,
      "pluginInvocations": []
    }
  ],
  "assertions": {
    "nativeNamespaceRemainedTelegramOwned": true,
    "legacyRawCallbackRemainedPluginOwned": true,
    "staleTypedCallbackFailedVisible": true,
    "malformedTypedCallbackFailedVisible": true,
    "disabledNativeCallbackFailedVisible": true
  },
  "passed": true
}
```
<!-- pr116383-mock-gateway-proof:end -->
