### PR TITLE
fix(slack): preserve repeated system events and retries

### DIFF
--- a/extensions/slack/src/monitor/events/agent.ts
+++ b/extensions/slack/src/monitor/events/agent.ts
@@ -1,6 +1,4 @@
 // Slack plugin module handles Agent View lifecycle events.
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackAppContextChangedEvent } from "../types.js";
 
@@ -22,16 +20,10 @@ export function registerSlackAgentEvents(params: {
   const slackApp = ctx.app as unknown as { event: SlackAgentEventRegistrar };
 
   slackApp.event("app_context_changed", async ({ body }) => {
-    try {
-      if (ctx.shouldDropMismatchedSlackEvent(body)) {
-        return;
-      }
-      trackEvent?.();
-      await ctx.recordSlackAgentView();
-    } catch (error) {
-      ctx.runtime.error?.(
-        danger(`slack app_context_changed handler failed: ${formatErrorMessage(error)}`),
-      );
+    if (ctx.shouldDropMismatchedSlackEvent(body)) {
+      return;
     }
+    trackEvent?.();
+    await ctx.recordSlackAgentView();
   });
 }

--- a/extensions/slack/src/monitor/events/assistant.ts
+++ b/extensions/slack/src/monitor/events/assistant.ts
@@ -1,7 +1,6 @@
 // Slack plugin module implements assistant behavior.
 import type { Block, KnownBlock } from "@slack/web-api";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { buildSlackAssistantThreadMetadata, DEFAULT_SLACK_SUGGESTED_PROMPTS } from "../context.js";
 import type { SlackMonitorContext, SlackAssistantThreadContext } from "../context.js";
 
@@ -93,42 +92,36 @@ async function persistAssistantThreadMetadata(params: {
   assistantThread: Omit<SlackAssistantThreadContext, "updatedAt">;
 }) {
   const { ctx, assistantThread } = params;
-  try {
-    const response = (await ctx.app.client.conversations.replies({
-      token: ctx.botToken,
-      channel: assistantThread.assistantChannelId,
-      ts: assistantThread.threadTs,
-      oldest: assistantThread.threadTs,
-      include_all_metadata: true,
-      limit: 4,
-    })) as {
-      messages?: Array<{
-        subtype?: string;
-        user?: string;
-        ts?: string;
-        text?: string;
-        blocks?: (Block | KnownBlock)[];
-      }>;
-    };
-    const initialMessage = (response.messages ?? []).find(
-      (message) => !message.subtype && message.user === ctx.botUserId && message.ts,
-    );
-    if (!initialMessage?.ts) {
-      return;
-    }
-    await ctx.app.client.chat.update({
-      token: ctx.botToken,
-      channel: assistantThread.assistantChannelId,
-      ts: initialMessage.ts,
-      text: initialMessage.text ?? "",
-      blocks: Array.isArray(initialMessage.blocks) ? initialMessage.blocks : [],
-      metadata: buildSlackAssistantThreadMetadata(assistantThread),
-    });
-  } catch (err) {
-    logVerbose(
-      `slack assistant thread metadata persist failed for channel ${assistantThread.assistantChannelId}: ${formatErrorMessage(err)}`,
-    );
+  const response = (await ctx.app.client.conversations.replies({
+    token: ctx.botToken,
+    channel: assistantThread.assistantChannelId,
+    ts: assistantThread.threadTs,
+    oldest: assistantThread.threadTs,
+    include_all_metadata: true,
+    limit: 4,
+  })) as {
+    messages?: Array<{
+      subtype?: string;
+      user?: string;
+      ts?: string;
+      text?: string;
+      blocks?: (Block | KnownBlock)[];
+    }>;
+  };
+  const initialMessage = (response.messages ?? []).find(
+    (message) => !message.subtype && message.user === ctx.botUserId && message.ts,
+  );
+  if (!initialMessage?.ts) {
+    return;
   }
+  await ctx.app.client.chat.update({
+    token: ctx.botToken,
+    channel: assistantThread.assistantChannelId,
+    ts: initialMessage.ts,
+    text: initialMessage.text ?? "",
+    blocks: Array.isArray(initialMessage.blocks) ? initialMessage.blocks : [],
+    metadata: buildSlackAssistantThreadMetadata(assistantThread),
+  });
 }
 
 export function registerSlackAssistantEvents(params: {
@@ -140,51 +133,37 @@ export function registerSlackAssistantEvents(params: {
   const slackApp = ctx.app as unknown as { event: SlackAssistantEventRegistrar };
 
   slackApp.event("assistant_thread_started", async ({ event, body }) => {
-    try {
-      if (ctx.shouldDropMismatchedSlackEvent(body)) {
-        return;
-      }
-      trackEvent?.();
-      const assistantThread = normalizeAssistantThread(event, ctx.getSlackAssistantThreadContext);
-      if (!assistantThread) {
-        logVerbose(
-          "slack assistant_thread_started dropped: missing assistant thread channel/thread",
-        );
-        return;
-      }
-      ctx.saveSlackAssistantThreadContext(assistantThread);
-      await ctx.setSlackSuggestedPrompts({
-        channelId: assistantThread.assistantChannelId,
-        threadTs: assistantThread.threadTs,
-        title: "Try asking",
-        prompts: DEFAULT_SLACK_SUGGESTED_PROMPTS,
-      });
-    } catch (err) {
-      ctx.runtime.error?.(
-        danger(`slack assistant_thread_started handler failed: ${formatErrorMessage(err)}`),
-      );
+    if (ctx.shouldDropMismatchedSlackEvent(body)) {
+      return;
     }
+    trackEvent?.();
+    const assistantThread = normalizeAssistantThread(event, ctx.getSlackAssistantThreadContext);
+    if (!assistantThread) {
+      logVerbose("slack assistant_thread_started dropped: missing assistant thread channel/thread");
+      return;
+    }
+    ctx.saveSlackAssistantThreadContext(assistantThread);
+    await ctx.setSlackSuggestedPrompts({
+      channelId: assistantThread.assistantChannelId,
+      threadTs: assistantThread.threadTs,
+      title: "Try asking",
+      prompts: DEFAULT_SLACK_SUGGESTED_PROMPTS,
+    });
   });
 
   slackApp.event("assistant_thread_context_changed", async ({ event, body }) => {
-    try {
-      if (ctx.shouldDropMismatchedSlackEvent(body)) {
-        return;
-      }
-      trackEvent?.();
-      const assistantThread = normalizeAssistantThread(event, ctx.getSlackAssistantThreadContext);
-      if (!assistantThread) {
-        logVerbose(
-          "slack assistant_thread_context_changed dropped: missing assistant thread channel/thread",
-        );
-        return;
-      }
-      ctx.saveSlackAssistantThreadContext(assistantThread);
-      await persistAssistantThreadMetadata({ ctx, assistantThread });
-    } catch (err) {
-      ctx.runtime.error?.(
-        danger(`slack assistant_thread_context_changed handler failed: ${formatErrorMessage(err)}`),
-      );
+    if (ctx.shouldDropMismatchedSlackEvent(body)) {
+      return;
     }
+    trackEvent?.();
+    const assistantThread = normalizeAssistantThread(event, ctx.getSlackAssistantThreadContext);
+    if (!assistantThread) {
+      logVerbose(
+        "slack assistant_thread_context_changed dropped: missing assistant thread channel/thread",
+      );
+      return;
+    }
+    ctx.saveSlackAssistantThreadContext(assistantThread);
+    await persistAssistantThreadMetadata({ ctx, assistantThread });
   });
 }

--- a/extensions/slack/src/monitor/events/channels.test.ts
+++ b/extensions/slack/src/monitor/events/channels.test.ts
@@ -88,13 +88,13 @@ describe("registerSlackChannelEvents", () => {
       event: {
         channel: { id: "C1", name: "general" },
       },
-      body: {},
+      body: { event_id: "Ev-channel-1" },
     });
 
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(enqueueSystemEventMock).toHaveBeenCalledWith("Slack channel created: #general.", {
       sessionKey: "agent:main:main",
-      contextKey: "slack:channel:created:C1",
+      contextKey: "slack:channel:created:C1:Ev-channel-1",
     });
   });
 

--- a/extensions/slack/src/monitor/events/channels.ts
+++ b/extensions/slack/src/monitor/events/channels.ts
@@ -28,6 +28,7 @@ export function registerSlackChannelEvents(params: {
     kind: "created" | "renamed";
     channelId: string | undefined;
     channelName: string | undefined;
+    eventId: string;
   }) => {
     if (
       !ctx.isChannelAllowed({
@@ -49,49 +50,47 @@ export function registerSlackChannelEvents(params: {
     });
     enqueueSystemEvent(`Slack channel ${paramsLocal.kind}: ${label}.`, {
       sessionKey,
-      contextKey: `slack:channel:${paramsLocal.kind}:${paramsLocal.channelId ?? paramsLocal.channelName ?? "unknown"}`,
+      contextKey: `slack:channel:${paramsLocal.kind}:${paramsLocal.channelId ?? paramsLocal.channelName ?? "unknown"}:${paramsLocal.eventId}`,
     });
   };
 
   ctx.app.event(
     "channel_created",
     async ({ event, body }: SlackEventMiddlewareArgs<"channel_created">) => {
-      try {
-        if (ctx.shouldDropMismatchedSlackEvent(body)) {
-          return;
-        }
-        trackEvent?.();
-
-        const payload = event as SlackChannelCreatedEvent;
-        const channelId = payload.channel?.id;
-        const channelName = payload.channel?.name;
-        enqueueChannelSystemEvent({ kind: "created", channelId, channelName });
-      } catch (err) {
-        ctx.runtime.error?.(
-          danger(`slack channel created handler failed: ${formatErrorMessage(err)}`),
-        );
+      if (ctx.shouldDropMismatchedSlackEvent(body)) {
+        return;
       }
+      trackEvent?.();
+
+      const payload = event as SlackChannelCreatedEvent;
+      const channelId = payload.channel?.id;
+      const channelName = payload.channel?.name;
+      enqueueChannelSystemEvent({
+        kind: "created",
+        channelId,
+        channelName,
+        eventId: body.event_id,
+      });
     },
   );
 
   ctx.app.event(
     "channel_rename",
     async ({ event, body }: SlackEventMiddlewareArgs<"channel_rename">) => {
-      try {
-        if (ctx.shouldDropMismatchedSlackEvent(body)) {
-          return;
-        }
-        trackEvent?.();
-
-        const payload = event as SlackChannelRenamedEvent;
-        const channelId = payload.channel?.id;
-        const channelName = payload.channel?.name_normalized ?? payload.channel?.name;
-        enqueueChannelSystemEvent({ kind: "renamed", channelId, channelName });
-      } catch (err) {
-        ctx.runtime.error?.(
-          danger(`slack channel rename handler failed: ${formatErrorMessage(err)}`),
-        );
+      if (ctx.shouldDropMismatchedSlackEvent(body)) {
+        return;
       }
+      trackEvent?.();
+
+      const payload = event as SlackChannelRenamedEvent;
+      const channelId = payload.channel?.id;
+      const channelName = payload.channel?.name_normalized ?? payload.channel?.name;
+      enqueueChannelSystemEvent({
+        kind: "renamed",
+        channelId,
+        channelName,
+        eventId: body.event_id,
+      });
     },
   );
 

--- a/extensions/slack/src/monitor/events/home.ts
+++ b/extensions/slack/src/monitor/events/home.ts
@@ -1,8 +1,6 @@
 // Slack plugin module implements home behavior.
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
 import type { HomeView } from "@slack/types";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { DEFAULT_SLACK_SUGGESTED_PROMPTS, type SlackMonitorContext } from "../context.js";
 import type { SlackAppHomeOpenedEvent } from "../types.js";
 
@@ -51,42 +49,38 @@ export function registerSlackHomeEvents(params: {
   ctx.app.event(
     "app_home_opened",
     async ({ event, body }: SlackEventMiddlewareArgs<"app_home_opened">) => {
-      try {
-        if (ctx.shouldDropMismatchedSlackEvent(body)) {
-          return;
-        }
-        trackEvent?.();
-
-        const payload = event as SlackAppHomeOpenedEvent;
-        if (!payload.user) {
-          return;
-        }
-        if (payload.tab === "messages") {
-          if (!payload.channel) {
-            return;
-          }
-          const promptsSet = await ctx.setSlackSuggestedPrompts({
-            channelId: payload.channel,
-            title: "Try asking",
-            prompts: DEFAULT_SLACK_SUGGESTED_PROMPTS,
-          });
-          // Both experiences can subscribe to App Home events. Assistant View
-          // requires thread_ts here, so only Slack accepting this threadless
-          // call proves Agent View and makes the durable mode write safe.
-          if (promptsSet) {
-            await ctx.recordSlackAgentView();
-          }
-          return;
-        }
-
-        await ctx.app.client.views.publish({
-          token: ctx.botToken,
-          user_id: payload.user,
-          view: buildSlackHomeView(slashCommandName),
-        });
-      } catch (err) {
-        ctx.runtime.error?.(danger(`slack app home handler failed: ${formatErrorMessage(err)}`));
+      if (ctx.shouldDropMismatchedSlackEvent(body)) {
+        return;
       }
+      trackEvent?.();
+
+      const payload = event as SlackAppHomeOpenedEvent;
+      if (!payload.user) {
+        return;
+      }
+      if (payload.tab === "messages") {
+        if (!payload.channel) {
+          return;
+        }
+        const promptsSet = await ctx.setSlackSuggestedPrompts({
+          channelId: payload.channel,
+          title: "Try asking",
+          prompts: DEFAULT_SLACK_SUGGESTED_PROMPTS,
+        });
+        // Both experiences can subscribe to App Home events. Assistant View
+        // requires thread_ts here, so only Slack accepting this threadless
+        // call proves Agent View and makes the durable mode write safe.
+        if (promptsSet) {
+          await ctx.recordSlackAgentView();
+        }
+        return;
+      }
+
+      await ctx.app.client.views.publish({
+        token: ctx.botToken,
+        user_id: payload.user,
+        view: buildSlackHomeView(slashCommandName),
+      });
     },
   );
 }

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -116,6 +116,7 @@ type ParsedSlackBlockAction = {
   typedAction: Record<string, unknown>;
   typedActionWithText: {
     action_id?: string;
+    action_ts?: string;
     block_id?: string;
     type?: string;
     text?: { text?: string };
@@ -437,6 +438,7 @@ function parseSlackBlockAction(params: {
   }
   const typedActionWithText = typedAction as {
     action_id?: string;
+    action_ts?: string;
     block_id?: string;
     type?: string;
     text?: { text?: string };
@@ -947,6 +949,8 @@ function enqueueSlackBlockActionEvent(params: {
     params.parsed.channelId,
     params.parsed.messageTs,
     params.parsed.actionId,
+    normalizeOptionalString(params.parsed.typedActionWithText.action_ts) ??
+      params.parsed.typedBody.trigger_id,
   ].filter(Boolean);
   const queued = enqueueSystemEvent(params.formatSystemEvent(eventPayload), {
     sessionKey,

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -1204,6 +1204,7 @@ describe("registerSlackInteractionEvents", () => {
         type: "button",
         action_id: "openclaw:reply_button",
         block_id: "reply_actions",
+        action_ts: "100.201",
         value: "codex",
         text: { type: "plain_text", text: "codex" },
       },
@@ -1219,7 +1220,7 @@ describe("registerSlackInteractionEvents", () => {
         "event options",
       ),
       {
-        contextKey: "slack:interaction:C1:100.200:openclaw:reply_button",
+        contextKey: "slack:interaction:C1:100.200:openclaw:reply_button:100.201",
         deliveryContext: {
           accountId: "default",
           channel: "slack",

--- a/extensions/slack/src/monitor/events/members.test.ts
+++ b/extensions/slack/src/monitor/events/members.test.ts
@@ -61,7 +61,7 @@ async function runMemberCase(args: MemberCaseArgs = {}): Promise<void> {
   }
   await handler({
     event: (args.event ?? makeMemberEvent()) as Record<string, unknown>,
-    body: args.body ?? {},
+    body: args.body ?? { event_id: "Ev-member-default" },
   });
 }
 
@@ -138,5 +138,16 @@ describe("registerSlackMemberEvents", () => {
     await runMemberCase({ trackEvent });
 
     expect(trackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys each queued event by the envelope occurrence", async () => {
+    await runMemberCase({ body: { event_id: "Ev-member-2" } });
+
+    expect(memberMocks.enqueue).toHaveBeenCalledWith(
+      "Slack: alice joined #direct.",
+      expect.objectContaining({
+        contextKey: "slack:member:joined:D1:U1:Ev-member-2",
+      }),
+    );
   });
 });

--- a/extensions/slack/src/monitor/events/members.ts
+++ b/extensions/slack/src/monitor/events/members.ts
@@ -1,7 +1,5 @@
 // Slack plugin module implements members behavior.
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackMemberChannelEvent } from "../types.js";
@@ -17,40 +15,32 @@ export function registerSlackMemberEvents(params: {
     verb: "joined" | "left";
     event: SlackMemberChannelEvent;
     body: unknown;
+    eventId: string;
   }) => {
-    try {
-      if (ctx.shouldDropMismatchedSlackEvent(paramsLocal.body)) {
-        return;
-      }
-      trackEvent?.();
-      const payload = paramsLocal.event;
-      const channelId = payload.channel;
-      const channelInfo = channelId ? await ctx.resolveChannelName(channelId) : {};
-      const channelType = payload.channel_type ?? channelInfo?.type;
-      const ingressContext = await authorizeAndResolveSlackSystemEventContext({
-        ctx,
-        senderId: payload.user,
-        channelId,
-        channelType,
-        eventKind: `member-${paramsLocal.verb}`,
-      });
-      if (!ingressContext) {
-        return;
-      }
-      const userInfo = payload.user ? await ctx.resolveUserName(payload.user) : {};
-      const userLabel = userInfo?.name ?? payload.user ?? "someone";
-      enqueueSystemEvent(
-        `Slack: ${userLabel} ${paramsLocal.verb} ${ingressContext.channelLabel}.`,
-        {
-          sessionKey: ingressContext.sessionKey,
-          contextKey: `slack:member:${paramsLocal.verb}:${channelId ?? "unknown"}:${payload.user ?? "unknown"}`,
-        },
-      );
-    } catch (err) {
-      ctx.runtime.error?.(
-        danger(`slack ${paramsLocal.verb} handler failed: ${formatErrorMessage(err)}`),
-      );
+    if (ctx.shouldDropMismatchedSlackEvent(paramsLocal.body)) {
+      return;
     }
+    trackEvent?.();
+    const payload = paramsLocal.event;
+    const channelId = payload.channel;
+    const channelInfo = channelId ? await ctx.resolveChannelName(channelId) : {};
+    const channelType = payload.channel_type ?? channelInfo?.type;
+    const ingressContext = await authorizeAndResolveSlackSystemEventContext({
+      ctx,
+      senderId: payload.user,
+      channelId,
+      channelType,
+      eventKind: `member-${paramsLocal.verb}`,
+    });
+    if (!ingressContext) {
+      return;
+    }
+    const userInfo = payload.user ? await ctx.resolveUserName(payload.user) : {};
+    const userLabel = userInfo?.name ?? payload.user ?? "someone";
+    enqueueSystemEvent(`Slack: ${userLabel} ${paramsLocal.verb} ${ingressContext.channelLabel}.`, {
+      sessionKey: ingressContext.sessionKey,
+      contextKey: `slack:member:${paramsLocal.verb}:${channelId ?? "unknown"}:${payload.user ?? "unknown"}:${paramsLocal.eventId}`,
+    });
   };
 
   ctx.app.event(
@@ -60,6 +50,7 @@ export function registerSlackMemberEvents(params: {
         verb: "joined",
         event: event as SlackMemberChannelEvent,
         body,
+        eventId: body.event_id,
       });
     },
   );
@@ -71,6 +62,7 @@ export function registerSlackMemberEvents(params: {
         verb: "left",
         event: event as SlackMemberChannelEvent,
         body,
+        eventId: body.event_id,
       });
     },
   );

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -653,10 +653,15 @@ describe("registerSlackMessageEvents", () => {
         ...makeChangedEvent({ channel: "C1", user: "U1" }),
         channel_type: "channel",
       },
+      body: { event_id: "Ev-message-change-1" },
     });
 
     expect(handleSlackMessage).not.toHaveBeenCalled();
     expect(messageQueueMock).toHaveBeenCalledTimes(1);
+    expect(messageQueueMock).toHaveBeenCalledWith("Slack message edited in #general.", {
+      sessionKey: "agent:main:main",
+      contextKey: "slack:message:changed:C1:123.456:Ev-message-change-1",
+    });
   });
 
   it("keeps bot edit and delete events on a remembered C-prefix mpDM session", async () => {

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -237,7 +237,7 @@ export function registerSlackMessageEvents(params: {
     client,
   }: {
     event: unknown;
-    body: unknown;
+    body: SlackEventMiddlewareArgs<"message">["body"];
     context: AllMiddlewareArgs["context"];
     client: AllMiddlewareArgs["client"];
   }) => {
@@ -306,7 +306,7 @@ export function registerSlackMessageEvents(params: {
         }
         enqueueSystemEvent(subtypeHandler.describe(ingressContext.channelLabel), {
           sessionKey: ingressContext.sessionKey,
-          contextKey: subtypeHandler.contextKey(message),
+          contextKey: `${subtypeHandler.contextKey(message)}:${body.event_id}`,
         });
         return;
       }

--- a/extensions/slack/src/monitor/events/pins.test.ts
+++ b/extensions/slack/src/monitor/events/pins.test.ts
@@ -62,7 +62,7 @@ async function runPinCase(input: PinCase = {}): Promise<void> {
     throw new Error(`expected Slack pin ${handlerKey} handler`);
   }
   const event = (input.event ?? makePinEvent()) as Record<string, unknown>;
-  const body = input.body ?? {};
+  const body = input.body ?? { event_id: "Ev-pin-default" };
   await handler({
     body,
     event,
@@ -141,5 +141,14 @@ describe("registerSlackPinEvents", () => {
     await runPinCase({ trackEvent });
 
     expect(trackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys each queued event by the envelope occurrence", async () => {
+    await runPinCase({ body: { event_id: "Ev-pin-2" } });
+
+    expect(pinEnqueueMock).toHaveBeenCalledWith("Slack: alice pinned a message in #direct.", {
+      sessionKey: "agent:main:main",
+      contextKey: "slack:pin:added:D1:123.456:Ev-pin-2",
+    });
   });
 });

--- a/extensions/slack/src/monitor/events/pins.ts
+++ b/extensions/slack/src/monitor/events/pins.ts
@@ -1,7 +1,5 @@
 // Slack plugin module implements pins behavior.
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackPinEvent } from "../types.js";
@@ -12,43 +10,39 @@ async function handleSlackPinEvent(params: {
   trackEvent?: () => void;
   body: unknown;
   event: unknown;
+  eventId: string;
   action: "pinned" | "unpinned";
   contextKeySuffix: "added" | "removed";
-  errorLabel: string;
 }): Promise<void> {
-  const { ctx, trackEvent, body, event, action, contextKeySuffix, errorLabel } = params;
+  const { ctx, trackEvent, body, event, eventId, action, contextKeySuffix } = params;
 
-  try {
-    if (ctx.shouldDropMismatchedSlackEvent(body)) {
-      return;
-    }
-    trackEvent?.();
-
-    const payload = event as SlackPinEvent;
-    const channelId = payload.channel_id;
-    const ingressContext = await authorizeAndResolveSlackSystemEventContext({
-      ctx,
-      senderId: payload.user,
-      channelId,
-      eventKind: "pin",
-    });
-    if (!ingressContext) {
-      return;
-    }
-    const userInfo = payload.user ? await ctx.resolveUserName(payload.user) : {};
-    const userLabel = userInfo?.name ?? payload.user ?? "someone";
-    const itemType = payload.item?.type ?? "item";
-    const messageId = payload.item?.message?.ts ?? payload.event_ts;
-    enqueueSystemEvent(
-      `Slack: ${userLabel} ${action} a ${itemType} in ${ingressContext.channelLabel}.`,
-      {
-        sessionKey: ingressContext.sessionKey,
-        contextKey: `slack:pin:${contextKeySuffix}:${channelId ?? "unknown"}:${messageId ?? "unknown"}`,
-      },
-    );
-  } catch (err) {
-    ctx.runtime.error?.(danger(`slack ${errorLabel} handler failed: ${formatErrorMessage(err)}`));
+  if (ctx.shouldDropMismatchedSlackEvent(body)) {
+    return;
   }
+  trackEvent?.();
+
+  const payload = event as SlackPinEvent;
+  const channelId = payload.channel_id;
+  const ingressContext = await authorizeAndResolveSlackSystemEventContext({
+    ctx,
+    senderId: payload.user,
+    channelId,
+    eventKind: "pin",
+  });
+  if (!ingressContext) {
+    return;
+  }
+  const userInfo = payload.user ? await ctx.resolveUserName(payload.user) : {};
+  const userLabel = userInfo?.name ?? payload.user ?? "someone";
+  const itemType = payload.item?.type ?? "item";
+  const messageId = payload.item?.message?.ts ?? payload.event_ts;
+  enqueueSystemEvent(
+    `Slack: ${userLabel} ${action} a ${itemType} in ${ingressContext.channelLabel}.`,
+    {
+      sessionKey: ingressContext.sessionKey,
+      contextKey: `slack:pin:${contextKeySuffix}:${channelId ?? "unknown"}:${messageId ?? "unknown"}:${eventId}`,
+    },
+  );
 }
 
 export function registerSlackPinEvents(params: {
@@ -63,9 +57,9 @@ export function registerSlackPinEvents(params: {
       trackEvent,
       body,
       event,
+      eventId: body.event_id,
       action: "pinned",
       contextKeySuffix: "added",
-      errorLabel: "pin added",
     });
   });
 
@@ -75,9 +69,9 @@ export function registerSlackPinEvents(params: {
       trackEvent,
       body,
       event,
+      eventId: body.event_id,
       action: "unpinned",
       contextKeySuffix: "removed",
-      errorLabel: "pin removed",
     });
   });
 }

--- a/extensions/slack/src/monitor/events/reactions.test.ts
+++ b/extensions/slack/src/monitor/events/reactions.test.ts
@@ -69,7 +69,7 @@ async function executeReactionCase(input: ReactionRunInput = {}) {
   const handler = requireReactionHandler(handlers[handlerName], handlerName);
   await handler({
     event: (input.event ?? buildReactionEvent()) as Record<string, unknown>,
-    body: input.body ?? {},
+    body: input.body ?? { event_id: "Ev-reaction-default" },
   });
 }
 
@@ -227,7 +227,7 @@ describe("registerSlackReactionEvents", () => {
 
     expect(reactionQueueMock).toHaveBeenCalledWith(expect.any(String), {
       sessionKey: "agent:main:main",
-      contextKey: "slack:reaction:added:D1:123.456:U1:thumbsup",
+      contextKey: "slack:reaction:added:D1:123.456:U1:thumbsup:Ev-reaction-default",
     });
   });
 

--- a/extensions/slack/src/monitor/events/reactions.ts
+++ b/extensions/slack/src/monitor/events/reactions.ts
@@ -1,7 +1,5 @@
 // Slack plugin module implements reactions behavior.
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { allowListMatches, normalizeAllowListLower } from "../allow-list.js";
 import type { SlackMonitorContext } from "../context.js";
@@ -41,58 +39,58 @@ export function registerSlackReactionEvents(params: {
 }) {
   const { ctx, trackEvent } = params;
 
-  const handleReactionEvent = async (event: SlackReactionEvent, action: string) => {
-    try {
-      const item = event.item;
-      if (!item || item.type !== "message") {
-        return;
-      }
-      if (ctx.reactionMode === "off") {
-        return;
-      }
-      if (ctx.reactionMode === "own" && (!ctx.botUserId || event.item_user !== ctx.botUserId)) {
-        return;
-      }
-      trackEvent?.();
-
-      const ingressContext = await authorizeAndResolveSlackSystemEventContext({
-        ctx,
-        senderId: event.user,
-        channelId: item.channel,
-        eventKind: "reaction",
-      });
-      if (!ingressContext) {
-        return;
-      }
-
-      const actorInfoPromise: Promise<{ name?: string } | undefined> = event.user
-        ? ctx.resolveUserName(event.user)
-        : Promise.resolve(undefined);
-      const authorInfoPromise: Promise<{ name?: string } | undefined> = event.item_user
-        ? ctx.resolveUserName(event.item_user)
-        : Promise.resolve(undefined);
-      const [actorInfo, authorInfo] = await Promise.all([actorInfoPromise, authorInfoPromise]);
-      if (
-        !shouldEmitSlackReactionNotification({
-          ctx,
-          event,
-          actorName: actorInfo?.name,
-        })
-      ) {
-        return;
-      }
-      const actorLabel = actorInfo?.name ?? event.user;
-      const emojiLabel = event.reaction ?? "emoji";
-      const authorLabel = authorInfo?.name ?? event.item_user;
-      const baseText = `Slack reaction ${action}: :${emojiLabel}: by ${actorLabel} in ${ingressContext.channelLabel} msg ${item.ts}`;
-      const text = authorLabel ? `${baseText} from ${authorLabel}` : baseText;
-      enqueueSystemEvent(text, {
-        sessionKey: ingressContext.sessionKey,
-        contextKey: `slack:reaction:${action}:${item.channel}:${item.ts}:${event.user}:${emojiLabel}`,
-      });
-    } catch (err) {
-      ctx.runtime.error?.(danger(`slack reaction handler failed: ${formatErrorMessage(err)}`));
+  const handleReactionEvent = async (
+    event: SlackReactionEvent,
+    action: "added" | "removed",
+    eventId: string,
+  ) => {
+    const item = event.item;
+    if (!item || item.type !== "message") {
+      return;
     }
+    if (ctx.reactionMode === "off") {
+      return;
+    }
+    if (ctx.reactionMode === "own" && (!ctx.botUserId || event.item_user !== ctx.botUserId)) {
+      return;
+    }
+    trackEvent?.();
+
+    const ingressContext = await authorizeAndResolveSlackSystemEventContext({
+      ctx,
+      senderId: event.user,
+      channelId: item.channel,
+      eventKind: "reaction",
+    });
+    if (!ingressContext) {
+      return;
+    }
+
+    const actorInfoPromise: Promise<{ name?: string } | undefined> = event.user
+      ? ctx.resolveUserName(event.user)
+      : Promise.resolve(undefined);
+    const authorInfoPromise: Promise<{ name?: string } | undefined> = event.item_user
+      ? ctx.resolveUserName(event.item_user)
+      : Promise.resolve(undefined);
+    const [actorInfo, authorInfo] = await Promise.all([actorInfoPromise, authorInfoPromise]);
+    if (
+      !shouldEmitSlackReactionNotification({
+        ctx,
+        event,
+        actorName: actorInfo?.name,
+      })
+    ) {
+      return;
+    }
+    const actorLabel = actorInfo?.name ?? event.user;
+    const emojiLabel = event.reaction ?? "emoji";
+    const authorLabel = authorInfo?.name ?? event.item_user;
+    const baseText = `Slack reaction ${action}: :${emojiLabel}: by ${actorLabel} in ${ingressContext.channelLabel} msg ${item.ts}`;
+    const text = authorLabel ? `${baseText} from ${authorLabel}` : baseText;
+    enqueueSystemEvent(text, {
+      sessionKey: ingressContext.sessionKey,
+      contextKey: `slack:reaction:${action}:${item.channel}:${item.ts}:${event.user}:${emojiLabel}:${eventId}`,
+    });
   };
 
   ctx.app.event(
@@ -101,7 +99,7 @@ export function registerSlackReactionEvents(params: {
       if (ctx.shouldDropMismatchedSlackEvent(body)) {
         return;
       }
-      await handleReactionEvent(event as SlackReactionEvent, "added");
+      await handleReactionEvent(event as SlackReactionEvent, "added", body.event_id);
     },
   );
 
@@ -111,7 +109,7 @@ export function registerSlackReactionEvents(params: {
       if (ctx.shouldDropMismatchedSlackEvent(body)) {
         return;
       }
-      await handleReactionEvent(event as SlackReactionEvent, "removed");
+      await handleReactionEvent(event as SlackReactionEvent, "removed", body.event_id);
     },
   );
 }

--- a/extensions/slack/src/monitor/ingress.test.ts
+++ b/extensions/slack/src/monitor/ingress.test.ts
@@ -3,26 +3,37 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { App, Receiver, ReceiverEvent } from "@slack/bolt";
+import { App, type Receiver, type ReceiverEvent } from "@slack/bolt";
 import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
+import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  peekSystemEventEntries,
+  resetSystemEventsForTest,
+} from "openclaw/plugin-sdk/system-event-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerSlackMemberEvents } from "./events/members.js";
+import { createSlackSystemEventTestHarness } from "./events/system-event-test-harness.js";
 import { createSlackDurableIngress, resolveSlackIngressTurnLifecycle } from "./ingress.js";
 
 type SlackIngressQueue = NonNullable<Parameters<typeof createSlackDurableIngress>[0]["queue"]>;
 type SlackIngressPayload = Parameters<SlackIngressQueue["enqueue"]>[1];
 
-function createSlackEnvelope(eventId: string, ts = "1700000000.000100") {
+function createSlackEnvelope(
+  eventId: string,
+  ts = "1700000000.000100",
+  event?: Record<string, PluginJsonValue>,
+) {
   return {
     team_id: "T_TEST",
     api_app_id: "A_TEST",
     type: "event_callback",
     event_id: eventId,
     event_time: 1_700_000_000,
-    event: {
+    event: event ?? {
       type: "message",
       channel: "C_TEST",
       user: "U_TEST",
@@ -75,13 +86,56 @@ function createReceiverHarness() {
 function createReceiverEvent(
   eventId: string,
   ack = vi.fn(async () => {}),
-  options: { retryNum?: number; ts?: string } = {},
+  options: { retryNum?: number; ts?: string; event?: Record<string, PluginJsonValue> } = {},
 ): ReceiverEvent {
   return {
-    body: createSlackEnvelope(eventId, options.ts),
+    body: createSlackEnvelope(eventId, options.ts, options.event),
     ack,
     ...(options.retryNum === undefined ? {} : { retryNum: options.retryNum }),
   };
+}
+
+function createMemberEvent(type: "member_joined_channel" | "member_left_channel", eventTs: string) {
+  return {
+    type,
+    user: "U_TEST",
+    channel: "C_TEST",
+    channel_type: "channel",
+    event_ts: eventTs,
+  };
+}
+
+function attachBoltMemberIngress(params: {
+  queue: ChannelIngressQueue<SlackIngressPayload>;
+  trackEvent: () => void;
+  resolveUserName?: (userId: string) => Promise<{ name?: string }>;
+  pollIntervalMs?: number;
+}) {
+  const ingress = createSlackDurableIngress({
+    accountId: "default",
+    queue: params.queue,
+    pollIntervalMs: params.pollIntervalMs ?? 60_000,
+    adoptionStallTimeoutMs: 5_000,
+  });
+  const receiverHarness = createReceiverHarness();
+  const app = new App({
+    receiver: ingress.wrapReceiver(receiverHarness.receiver),
+    authorize: async () => ({
+      botToken: "xoxb-test",
+      botId: "B_BOT",
+      botUserId: "U_BOT",
+      teamId: "T_TEST",
+    }),
+    convoStore: false,
+    ignoreSelf: false,
+  });
+  const memberHarness = createSlackSystemEventTestHarness({ channelType: "channel" });
+  memberHarness.ctx.app = app;
+  if (params.resolveUserName) {
+    memberHarness.ctx.resolveUserName = params.resolveUserName;
+  }
+  registerSlackMemberEvents({ ctx: memberHarness.ctx, trackEvent: params.trackEvent });
+  return { ingress, receive: receiverHarness.receive };
 }
 
 function createReceiverEventWithBody(body: Record<string, unknown>): ReceiverEvent {
@@ -126,6 +180,7 @@ async function withQueue(
 describe("Slack durable ingress", () => {
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
+    resetSystemEventsForTest();
   });
 
   it("does not acknowledge when the durable append fails", async () => {
@@ -359,6 +414,90 @@ describe("Slack durable ingress", () => {
       expect(retryAck).toHaveBeenCalledTimes(1);
       expect(replayDispatch).not.toHaveBeenCalled();
       await restarted.ingress.stop();
+    });
+  });
+
+  it("preserves repeated member occurrences through Bolt while deduping Slack retries", async () => {
+    await withQueue(async (queue) => {
+      const trackEvent = vi.fn();
+      const { ingress, receive } = attachBoltMemberIngress({ queue, trackEvent });
+      ingress.start();
+      try {
+        for (const [eventId, event] of [
+          ["Ev-member-join-1", createMemberEvent("member_joined_channel", "100.001")],
+          ["Ev-member-left", createMemberEvent("member_left_channel", "100.002")],
+          ["Ev-member-join-2", createMemberEvent("member_joined_channel", "100.003")],
+        ] as const) {
+          await receive(createReceiverEvent(eventId, undefined, { event }));
+          await ingress.waitForIdle();
+        }
+        await receive(
+          createReceiverEvent("Ev-member-join-2", undefined, {
+            retryNum: 1,
+            event: createMemberEvent("member_joined_channel", "100.003"),
+          }),
+        );
+        await ingress.waitForIdle();
+
+        expect(trackEvent).toHaveBeenCalledTimes(3);
+        expect(peekSystemEventEntries("agent:main:main").map((entry) => entry.contextKey)).toEqual([
+          "slack:member:joined:c_test:u_test:ev-member-join-1",
+          "slack:member:left:c_test:u_test:ev-member-left",
+          "slack:member:joined:c_test:u_test:ev-member-join-2",
+        ]);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("retries transient member failures through Bolt after restart", async () => {
+    await withQueue(async (queue) => {
+      const trackEvent = vi.fn();
+      let userLookupCount = 0;
+      const resolveUserName = async () => {
+        userLookupCount += 1;
+        if (userLookupCount === 2) {
+          throw new Error("users.info temporarily unavailable");
+        }
+        return { name: "alice" };
+      };
+      const first = attachBoltMemberIngress({ queue, trackEvent, resolveUserName });
+      first.ingress.start();
+      let restarted: ReturnType<typeof attachBoltMemberIngress> | undefined;
+      try {
+        await first.receive(
+          createReceiverEvent("Ev-member-retry", undefined, {
+            event: createMemberEvent("member_joined_channel", "200.001"),
+          }),
+        );
+        await first.ingress.waitForIdle();
+        await first.ingress.stop();
+
+        expect(trackEvent).toHaveBeenCalledTimes(1);
+        expect(peekSystemEventEntries("agent:main:main")).toHaveLength(0);
+        expect((await queue.listPending()).map((entry) => entry.id)).toContain("Ev-member-retry");
+
+        restarted = attachBoltMemberIngress({
+          queue,
+          trackEvent,
+          resolveUserName,
+          pollIntervalMs: 25,
+        });
+        restarted.ingress.start();
+        await vi.waitFor(
+          async () => {
+            await restarted?.ingress.waitForIdle();
+            expect(trackEvent).toHaveBeenCalledTimes(2);
+          },
+          { timeout: 15_000, interval: 100 },
+        );
+
+        expect(peekSystemEventEntries("agent:main:main")).toHaveLength(1);
+      } finally {
+        await first.ingress.stop();
+        await restarted?.ingress.stop();
+      }
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Slack Events API callbacks could lose real work in two ways. Separate join/leave/rejoin, reaction, pin, channel, and message-subtype occurrences reused state-shaped system-event keys, so a later occurrence could collapse into an earlier pending event. Separately, several event handlers caught transient failures and returned success, causing durable ingress to tombstone the failed event instead of retrying it.

## Why This Change Was Made

The Slack plugin now carries Slack's authoritative occurrence identity into queued system-event keys: Events API handlers use the required envelope `event_id`, and block actions use native `action_ts` with `trigger_id` fallback. Swallow-only leaf error wrappers were deleted so the existing Bolt rejection path and Slack durable ingress remain the single retry owner. Intentional authorization and policy drops still return normally. No core queue policy or product command policy moved into the transport plugin.

## User Impact

Agents receive every real Slack state transition and repeated interaction in order. Temporary Slack lookup or projection failures remain retryable across restart instead of disappearing silently.

## Evidence

- Pre-fix real-boundary reproduction: `node scripts/run-vitest.mjs extensions/slack/src/monitor/ingress.test.ts` failed 2 of 12 tests. Join/leave/join produced only two queued keys, and the transient member failure remained at one dispatch after restart.
- Post-fix focused proof: `node scripts/run-vitest.mjs extensions/slack/src/monitor/ingress.test.ts extensions/slack/src/monitor/events/agent.test.ts extensions/slack/src/monitor/events/assistant.test.ts extensions/slack/src/monitor/events/channels.test.ts extensions/slack/src/monitor/events/home.test.ts extensions/slack/src/monitor/events/interactions.test.ts extensions/slack/src/monitor/events/members.test.ts extensions/slack/src/monitor/events/messages.test.ts extensions/slack/src/monitor/events/pins.test.ts extensions/slack/src/monitor/events/reactions.test.ts` passed 10 files and 165 tests.
- The regression constructs a real `@slack/bolt` v5 `App`, drives the ingress-wrapped receiver through `App.processEvent`, verifies `customProperties` reaches handler context, persists the transient failure in SQLite, and succeeds through a fresh Bolt/ingress instance after restart.
- `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01kzkfqjk8fvs71fq5v5r4b5ew`; Actions run: https://github.com/openclaw/openclaw/actions/runs/31319256316
- Codex autoreview: clean on the first round, no accepted/actionable findings, correctness confidence 0.97.
- Production LOC: +227/-275 (net -48). Tests: +177/-12.
- ClawSweeper rank-up moves addressed: the branch is rebased onto current `main`, and the prior manual custom-properties harness was replaced with direct Bolt-to-handler runtime proof.
- No live Slack workspace was mutated; proof uses the pinned real Bolt runtime, mocked Slack envelopes, and the real SQLite ingress queue.
