### PR TITLE
fix(cli): preserve option values and machine output

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -12,6 +12,7 @@ import {
   isHelpOrVersionInvocation,
   isRootHelpInvocation,
   isRootVersionInvocation,
+  isSimpleCommandHelpInvocation,
   normalizeGeneratedHelpCommandArgv,
   normalizeRootHelpTargetArgv,
   normalizeRootLogLevelArgv,
@@ -478,6 +479,31 @@ describe("argv helpers", () => {
         2,
       ),
     ).toEqual(["config", "validate"]);
+  });
+
+  it("limits simple help fast paths to root options, a command, and help", () => {
+    const commands = new Set(["setup"]);
+    expect(
+      isSimpleCommandHelpInvocation(
+        ["node", "openclaw", "--profile", "work", "setup", "--help"],
+        commands,
+      ),
+    ).toBe(true);
+    expect(
+      isSimpleCommandHelpInvocation(
+        ["node", "openclaw", "setup", "--workspace", "--help"],
+        commands,
+      ),
+    ).toBe(false);
+    expect(
+      isSimpleCommandHelpInvocation(
+        ["node", "openclaw", "setup", "--profile", "work", "--help"],
+        commands,
+      ),
+    ).toBe(false);
+    expect(isSimpleCommandHelpInvocation(["node", "openclaw", "--help", "setup"], commands)).toBe(
+      false,
+    );
   });
 
   it("extracts routed config get positionals with interleaved root options", () => {

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -164,6 +164,42 @@ export function isRootHelpInvocation(argv: string[]): boolean {
   return isRootInvocationForFlags(argv, HELP_FLAGS);
 }
 
+/** Match fast-path command help only when no command option can own the help token as a value. */
+export function isSimpleCommandHelpInvocation(
+  argv: string[],
+  commandNames: ReadonlySet<string>,
+): boolean {
+  const args = argv.slice(2);
+  let commandSeen = false;
+  let helpSeen = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      return false;
+    }
+    const rootConsumed = commandSeen ? 0 : consumeRootOptionToken(args, index);
+    if (rootConsumed > 0) {
+      index += rootConsumed - 1;
+      continue;
+    }
+    if (HELP_FLAGS.has(arg)) {
+      if (!commandSeen) {
+        return false;
+      }
+      helpSeen = true;
+      continue;
+    }
+    if (arg.startsWith("-") || commandSeen) {
+      return false;
+    }
+    if (!commandNames.has(arg)) {
+      return false;
+    }
+    commandSeen = true;
+  }
+  return commandSeen && helpSeen;
+}
+
 type HelpNormalizationPositional = { value: string; index: number };
 
 type HelpNormalizationScanResult =

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -249,6 +249,19 @@ describe("CLI help process exit", () => {
     );
   });
 
+  it("treats --help as a required option value when Commander does", async () => {
+    let failure: CliProcessFailure | undefined;
+    try {
+      await runCliProcess({ args: ["secrets", "apply", "--from", "--help"], config: {} });
+    } catch (error) {
+      failure = error as CliProcessFailure;
+    }
+
+    expect(failure?.code).toBe(1);
+    expect(failure?.stdout ?? "").not.toContain("Usage:");
+    expect(failure?.stderr).toContain("plan file not found: --help");
+  });
+
   it.each(LAZY_GROUP_HELP_CASES)(
     "renders in-process help for $group",
     async ({ group, usageCommand, registry }) => {
@@ -356,6 +369,19 @@ describe("JSON console style process output", () => {
 
     expect(result.stderr).toBe("");
     expect(JSON.parse(result.stdout)).toEqual([]);
+  });
+
+  it("emits one JSON object for baseline setup", async () => {
+    const result = await runCliProcess({ args: ["setup", "--baseline", "--json"], config: {} });
+
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      configPath: expect.any(String),
+      configStatus: "updated",
+      workspaceDir: expect.any(String),
+      sessionsDir: expect.any(String),
+    });
   });
 
   it("structures invalid log-level environment warnings", async () => {

--- a/src/cli/precomputed-help.test.ts
+++ b/src/cli/precomputed-help.test.ts
@@ -1,0 +1,29 @@
+// Precomputed help tests cover the strict argv shape required by help fast paths.
+import { describe, expect, it, vi } from "vitest";
+import { tryOutputPrecomputedCommandHelp } from "./precomputed-help.js";
+
+describe("tryOutputPrecomputedCommandHelp", () => {
+  it("renders only an unambiguous command help request", async () => {
+    const outputBrowserHelp = vi.fn(() => true);
+
+    await expect(
+      tryOutputPrecomputedCommandHelp(["node", "openclaw", "browser", "--help"], {
+        outputPrecomputedBrowserHelpText: outputBrowserHelp,
+        env: {},
+      }),
+    ).resolves.toBe(true);
+    expect(outputBrowserHelp).toHaveBeenCalledOnce();
+  });
+
+  it("falls back when a command option may own --help as its value", async () => {
+    const outputBrowserHelp = vi.fn(() => true);
+
+    await expect(
+      tryOutputPrecomputedCommandHelp(["node", "openclaw", "browser", "--target", "--help"], {
+        outputPrecomputedBrowserHelpText: outputBrowserHelp,
+        env: {},
+      }),
+    ).resolves.toBe(false);
+    expect(outputBrowserHelp).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/precomputed-help.ts
+++ b/src/cli/precomputed-help.ts
@@ -1,5 +1,5 @@
 import { consumeRootOptionToken } from "../infra/cli-root-options.js";
-import { getCommandPathWithRootOptions, hasFlag } from "./argv.js";
+import { getCommandPathWithRootOptions, isSimpleCommandHelpInvocation } from "./argv.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
 
 type PrecomputedSubcommandHelpName =
@@ -12,6 +12,8 @@ type PrecomputedSubcommandHelpName =
 
 type PrecomputedCommandHelpName = "browser" | "secrets" | "nodes";
 type OutputPrecomputedHelpText = () => boolean;
+
+const PRECOMPUTED_COMMAND_HELP_NAMES = new Set<string>(["browser", "secrets", "nodes"]);
 
 export type PrecomputedCommandHelpDeps = {
   outputPrecomputedBrowserHelpText?: OutputPrecomputedHelpText;
@@ -80,7 +82,7 @@ function resolvePrecomputedSubcommandHelpCommand(
 }
 
 function resolvePrecomputedCommandHelpName(argv: string[]): PrecomputedCommandHelpName | null {
-  if (!hasFlag(argv, "--help") && !hasFlag(argv, "-h")) {
+  if (!isSimpleCommandHelpInvocation(argv, PRECOMPUTED_COMMAND_HELP_NAMES)) {
     return null;
   }
   const commandPath = getCommandPathWithRootOptions(argv, 2);

--- a/src/cli/program/build-program.test.ts
+++ b/src/cli/program/build-program.test.ts
@@ -138,4 +138,28 @@ describe("buildProgram", () => {
     expect(error.code).toBe("commander.help");
     expect(process.exitCode).toBe(1);
   });
+
+  it("preserves caller-configured Commander error output", async () => {
+    let stderr = "";
+    const outputError = vi.fn((value: string, write: (value: string) => void) => {
+      write(`custom: ${value}`);
+    });
+    const originalArgv = process.argv;
+    const program = buildProgram().configureOutput({
+      writeErr: (value) => {
+        stderr += value;
+      },
+      outputError,
+    });
+    program.command("probe").action(() => {});
+    process.argv = ["node", "openclaw", "probe", "--wat"];
+    try {
+      await expectCommanderExit(program.parseAsync(process.argv), 1);
+    } finally {
+      process.argv = originalArgv;
+    }
+
+    expect(outputError).toHaveBeenCalledOnce();
+    expect(stderr).toContain("custom: error: unknown option '--wat'");
+  });
 });

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -1,14 +1,14 @@
 // Builds the root Commander program, context, help, hooks, and command registry.
 import process from "node:process";
-import { Command } from "commander";
 import { registerProgramCommands } from "./command-registry.js";
 import { createProgramContext } from "./context.js";
 import { configureProgramHelp } from "./help.js";
+import { OpenClawCommand } from "./openclaw-command.js";
 import { registerPreActionHooks } from "./preaction.js";
 import { setProgramContext } from "./program-context.js";
 
 export function buildProgram() {
-  const program = new Command();
+  const program = new OpenClawCommand();
   program.enablePositionalOptions();
   // Preserve Commander-computed exit codes while still aborting parse flow.
   // Without this, unknown nested commands can print an error

--- a/src/cli/program/commander-parse-facts.ts
+++ b/src/cli/program/commander-parse-facts.ts
@@ -1,0 +1,105 @@
+// Facts Commander owns after parsing: the active path and which tokens became option values.
+import type { Command, Option } from "commander";
+
+const activeErrorCommandByRoot = new WeakMap<Command, Command>();
+
+function getCommandHierarchy(command: Command): Command[] {
+  const hierarchy: Command[] = [];
+  for (let current: Command | null = command; current; current = current.parent ?? null) {
+    hierarchy.unshift(current);
+  }
+  return hierarchy;
+}
+
+function requiresFollowingValue(token: string, options: readonly Option[]): boolean {
+  if (token.includes("=")) {
+    return false;
+  }
+  const exact = options.find((option) => option.short === token || option.long === token);
+  if (exact) {
+    return exact.required;
+  }
+  if (!token.startsWith("-") || token.startsWith("--")) {
+    return false;
+  }
+  const shortGroup = token.slice(1);
+  for (let index = 0; index < shortGroup.length; index += 1) {
+    const option = options.find((candidate) => candidate.short === `-${shortGroup[index]}`);
+    if (!option) {
+      return false;
+    }
+    if (option.required || option.optional) {
+      return option.required && index === shortGroup.length - 1;
+    }
+  }
+  return false;
+}
+
+/** Return whether Commander consumed one of the supplied argv tokens as a required option value. */
+export function hasCommanderOptionValue(
+  command: Command,
+  argv: readonly string[],
+  tokens: ReadonlySet<string>,
+): boolean {
+  const hierarchy = getCommandHierarchy(command);
+  const args = argv.slice(2);
+  let commandIndex = 0;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === undefined || arg === "--") {
+      break;
+    }
+    const nextCommand = hierarchy[commandIndex + 1];
+    if (nextCommand && (arg === nextCommand.name() || nextCommand.aliases().includes(arg))) {
+      commandIndex += 1;
+      continue;
+    }
+    // The root program enables positional options, so after dispatch Commander
+    // parses only the active command's options; ancestor flags there never reach pre-action.
+    if (requiresFollowingValue(arg, hierarchy[commandIndex]?.options ?? [])) {
+      const value = args[index + 1];
+      if (value && tokens.has(value)) {
+        return true;
+      }
+      index += 1;
+    }
+  }
+  return false;
+}
+
+/** Return the registered command path for the exact Commander node handling an error or action. */
+export function getCommanderCommandPath(command: Command): string[] {
+  const commandPath: string[] = [];
+  for (let current: Command | null = command; current?.parent; current = current.parent) {
+    commandPath.unshift(current.name());
+  }
+  return commandPath;
+}
+
+function getRootCommand(command: Command): Command {
+  let root = command;
+  while (root.parent) {
+    root = root.parent;
+  }
+  return root;
+}
+
+/** Scope the exact Commander node synchronously emitting an error. */
+export function setCommanderErrorCommand(command: Command): () => void {
+  const root = getRootCommand(command);
+  const previous = activeErrorCommandByRoot.get(root);
+  activeErrorCommandByRoot.set(root, command);
+  return () => {
+    if (previous) {
+      activeErrorCommandByRoot.set(root, previous);
+    } else {
+      activeErrorCommandByRoot.delete(root);
+    }
+  };
+}
+
+/** Return the active parse-error path without replacing Commander's configured output handler. */
+export function getCommanderErrorCommandPath(program: Command): string[] | undefined {
+  const command = activeErrorCommandByRoot.get(getRootCommand(program));
+  return command ? getCommanderCommandPath(command) : undefined;
+}

--- a/src/cli/program/error-output.test.ts
+++ b/src/cli/program/error-output.test.ts
@@ -68,4 +68,15 @@ describe("formatCliParseErrorOutput", () => {
       'Missing required argument "name".\nTry: openclaw plugins install --help\n',
     );
   });
+
+  it("prefers the parsed Commander path over option-like argv values", () => {
+    const output = formatCliParseErrorOutput("error: unknown option '--wat'\n", {
+      argv: ["node", "openclaw", "plugins", "--source", "install", "list", "--wat"],
+      commandPath: ["plugins", "list"],
+    });
+
+    expect(output).toBe(
+      'OpenClaw does not recognize option "--wat".\nTry: openclaw plugins list --help\n',
+    );
+  });
 });

--- a/src/cli/program/error-output.ts
+++ b/src/cli/program/error-output.ts
@@ -7,6 +7,7 @@ import { formatCliCommandSuggestions } from "./command-suggestions.js";
 
 type FormatCliParseErrorOptions = {
   argv?: string[];
+  commandPath?: string[];
 };
 
 function stripCommanderErrorPrefix(raw: string): string {
@@ -20,11 +21,14 @@ function quote(value: string): string {
   return `"${value}"`;
 }
 
-function resolveHelpCommand(argv: string[] | undefined, options?: { root?: boolean }): string {
-  if (options?.root || !argv) {
+function resolveHelpCommand(
+  argv: string[] | undefined,
+  options?: { commandPath?: string[]; root?: boolean },
+): string {
+  if (options?.root) {
     return formatCliCommand("openclaw --help");
   }
-  const commandPath = getCommandPathWithRootOptions(argv, 2);
+  const commandPath = options?.commandPath ?? (argv ? getCommandPathWithRootOptions(argv, 2) : []);
   if (commandPath.length === 0) {
     return formatCliCommand("openclaw --help");
   }
@@ -35,7 +39,10 @@ function lines(...items: Array<string | undefined>): string {
   return `${items.filter((item): item is string => Boolean(item)).join("\n")}\n`;
 }
 
-function formatHelpHint(argv: string[] | undefined, options?: { root?: boolean }): string {
+function formatHelpHint(
+  argv: string[] | undefined,
+  options?: { commandPath?: string[]; root?: boolean },
+): string {
   return `${theme.muted("Try:")} ${theme.command(resolveHelpCommand(argv, options))}`;
 }
 
@@ -66,7 +73,7 @@ export function formatCliParseErrorOutput(
     const option = unknownOption[1] ?? "";
     return lines(
       theme.error(`OpenClaw does not recognize option ${quote(option)}.`),
-      formatHelpHint(options.argv),
+      formatHelpHint(options.argv, { commandPath: options.commandPath }),
     );
   }
 
@@ -75,7 +82,7 @@ export function formatCliParseErrorOutput(
     const argument = missingArgument[1] ?? "";
     return lines(
       theme.error(`Missing required argument ${quote(argument)}.`),
-      formatHelpHint(options.argv),
+      formatHelpHint(options.argv, { commandPath: options.commandPath }),
     );
   }
 
@@ -84,16 +91,19 @@ export function formatCliParseErrorOutput(
     const option = missingOption[1] ?? "";
     return lines(
       theme.error(`Missing required option ${quote(option)}.`),
-      formatHelpHint(options.argv),
+      formatHelpHint(options.argv, { commandPath: options.commandPath }),
     );
   }
 
   if (/^too many arguments\b/i.test(message)) {
-    return lines(theme.error("Too many arguments for this command."), formatHelpHint(options.argv));
+    return lines(
+      theme.error("Too many arguments for this command."),
+      formatHelpHint(options.argv, { commandPath: options.commandPath }),
+    );
   }
 
   return lines(
     theme.error(`OpenClaw could not parse this command: ${message}`),
-    formatHelpHint(options.argv),
+    formatHelpHint(options.argv, { commandPath: options.commandPath }),
   );
 }

--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -1,8 +1,9 @@
 // Help tests cover command help generation and inherited help options.
-import { Command } from "commander";
+import { Command, CommanderError } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProgramContext } from "./context.js";
 import { configureProgramHelp } from "./help.js";
+import { OpenClawCommand } from "./openclaw-command.js";
 
 const hasEmittedCliBannerMock = vi.hoisted(() => vi.fn(() => false));
 const formatCliBannerLineMock = vi.hoisted(() => vi.fn(() => "BANNER-LINE"));
@@ -143,6 +144,32 @@ describe("configureProgramHelp", () => {
     expect(options?.mode).toBe("default");
     expect(help).toContain("Examples:");
     expect(help).toContain("https://docs.openclaw.ai/cli");
+  });
+
+  it("formats parse errors from the exact Commander command path", async () => {
+    let stderr = "";
+    process.argv = ["node", "openclaw", "plugins", "--source", "list", "list", "--wat"];
+    const program = new OpenClawCommand().enablePositionalOptions().exitOverride();
+    configureProgramHelp(program, testProgramContext);
+    program.configureOutput({
+      writeErr: (value) => {
+        stderr += value;
+      },
+    });
+    program
+      .command("plugins")
+      .option("--source <source>")
+      .command("list")
+      .action(() => {});
+
+    const firstError = await program.parseAsync(process.argv).catch((error: unknown) => error);
+    expect(firstError).toBeInstanceOf(CommanderError);
+    process.argv = ["node", "openclaw", "plugins", "list", "--still-wat"];
+    const secondError = await program.parseAsync(process.argv).catch((error: unknown) => error);
+    expect(secondError).toBeInstanceOf(CommanderError);
+
+    expect(stderr.match(/Try: openclaw plugins list --help/g)).toHaveLength(2);
+    expect(stderr).not.toContain("openclaw plugins list list --help");
   });
 
   it("suppresses banner formatting when parent default help requests it", () => {

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -9,6 +9,7 @@ import { isRootVersionInvocation } from "../argv.js";
 import { formatCliBannerLine, hasEmittedCliBanner } from "../banner.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { CLI_LOG_LEVEL_VALUES, parseCliLogLevelOption } from "../log-level-option.js";
+import { getCommanderErrorCommandPath } from "./commander-parse-facts.js";
 import type { ProgramContext } from "./context.js";
 import { getCoreCliCommandsWithSubcommands } from "./core-command-descriptors.js";
 import { formatCliParseErrorOutput } from "./error-output.js";
@@ -118,7 +119,13 @@ export function configureProgramHelp(
       const message = formatProgramHelpOutput(str);
       process.stderr.write(formatConsoleDiagnosticBlock({ level: "error", message }));
     },
-    outputError: (str, write) => write(formatCliParseErrorOutput(str, { argv: process.argv })),
+    outputError: (str, write) =>
+      write(
+        formatCliParseErrorOutput(str, {
+          argv: process.argv,
+          commandPath: getCommanderErrorCommandPath(program),
+        }),
+      ),
   });
 
   if (isRootVersionInvocation(process.argv)) {

--- a/src/cli/program/json-mode.ts
+++ b/src/cli/program/json-mode.ts
@@ -5,8 +5,10 @@ import {
   isMachineOutputStdoutTTY,
   type MachineOutputResolverParams,
 } from "../machine-output-argv.js";
+import { hasCommanderOptionValue } from "./commander-parse-facts.js";
 
 const jsonModeSymbol = Symbol("openclaw.cli.jsonMode");
+const JSON_FLAG = new Set(["--json"]);
 
 type CommandJsonMode = "output" | "parse-only";
 type CommandJsonModeResolver = (
@@ -31,8 +33,9 @@ function getCommandJsonMode(
   command: Command,
   argv: string[] = process.argv,
 ): CommandJsonMode | null {
+  const rawJsonFlag = hasFlag(argv, "--json") && !hasCommanderOptionValue(command, argv, JSON_FLAG);
   const literalJsonMode =
-    command.optsWithGlobals<{ json?: unknown }>().json === true || hasFlag(argv, "--json");
+    command.optsWithGlobals<{ json?: unknown }>().json === true || rawJsonFlag;
   for (let current: Command | null = command; current; current = current.parent ?? null) {
     const metadata = (current as JsonModeCommand)[jsonModeSymbol];
     if (metadata?.resolve?.({ command, argv, stdoutIsTTY: isMachineOutputStdoutTTY() })) {

--- a/src/cli/program/openclaw-command.ts
+++ b/src/cli/program/openclaw-command.ts
@@ -1,0 +1,18 @@
+// Commander subclass that preserves the exact failing command for parse-error guidance.
+import { Command, type ErrorOptions } from "commander";
+import { setCommanderErrorCommand } from "./commander-parse-facts.js";
+
+export class OpenClawCommand extends Command {
+  override createCommand(name?: string): Command {
+    return new OpenClawCommand(name);
+  }
+
+  override error(message: string, errorOptions?: ErrorOptions): never {
+    const restoreErrorCommand = setCommanderErrorCommand(this);
+    try {
+      return super.error(message, errorOptions);
+    } finally {
+      restoreErrorCommand();
+    }
+  }
+}

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -152,6 +152,7 @@ describe("registerPreActionHooks", () => {
     const programLocal = new Command().name("openclaw");
     const agent = programLocal
       .command("agent")
+      .argument("[note]")
       .requiredOption("-m, --message <text>")
       .option("--local")
       .option("--json")
@@ -663,6 +664,18 @@ describe("registerPreActionHooks", () => {
     expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
   });
 
+  it("bootstraps when Commander consumed --help as a required option value", async () => {
+    const parseProgram = buildProgram();
+    process.argv = ["node", "openclaw", "agent", "--message", "--help", "--message", "hello"];
+
+    await parseProgram.parseAsync(process.argv);
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["agent"],
+    });
+  });
+
   it.each([
     {
       name: "version-pinned skill install",
@@ -745,6 +758,19 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["config", "set"],
     });
+  });
+
+  it("does not select JSON output when Commander consumed --json as an option value", async () => {
+    const parseProgram = buildProgram();
+    process.argv = ["node", "openclaw", "agent", "", "--message", "--json", "--message", "hello"];
+
+    await parseProgram.parseAsync(process.argv);
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["agent"],
+    });
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
   });
 
   it("routes logs to stderr in --json mode so stdout stays clean", async () => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -18,8 +18,11 @@ import {
   resolvePluginInstallInvalidConfigPolicy,
   resolvePluginInstallPreactionRequest,
 } from "../plugin-install-config-policy.js";
+import { getCommanderCommandPath, hasCommanderOptionValue } from "./commander-parse-facts.js";
 import { isCommandJsonOutputMode } from "./json-mode.js";
 import { isParentDefaultHelpAction } from "./parent-default-help.js";
+
+const HELP_OR_VERSION_FLAGS = new Set(["-h", "--help", "-V", "--version"]);
 
 function setProcessTitleForCommand(actionCommand: Command) {
   let current: Command = actionCommand;
@@ -45,16 +48,6 @@ function shouldAllowInvalidConfigForAction(actionCommand: Command, commandPath: 
       }),
     ) === "allow-plugin-recovery"
   );
-}
-
-function getActionCommandPath(actionCommand: Command): string[] {
-  const commandPath: string[] = [];
-  let current: Command | null = actionCommand;
-  while (current.parent) {
-    commandPath.unshift(current.name());
-    current = current.parent;
-  }
-  return commandPath;
 }
 
 function getCliLogLevel(actionCommand: Command): LogLevel | undefined {
@@ -113,14 +106,22 @@ export function registerPreActionHooks(program: Command, programVersion: string)
   program.hook("preAction", async (_thisCommand, actionCommand) => {
     setProcessTitleForCommand(actionCommand);
     const argv = process.argv;
-    if (isHelpOrVersionInvocation(argv) || isBareParentDefaultHelpInvocation(actionCommand, argv)) {
+    const helpOrVersionWasOptionValue = hasCommanderOptionValue(
+      actionCommand,
+      argv,
+      HELP_OR_VERSION_FLAGS,
+    );
+    if (
+      (isHelpOrVersionInvocation(argv) && !helpOrVersionWasOptionValue) ||
+      isBareParentDefaultHelpInvocation(actionCommand, argv)
+    ) {
       return;
     }
     const jsonOutputMode = isCommandJsonOutputMode(actionCommand, argv);
     applyResolvedCommandOutputMode(jsonOutputMode);
     const { commandPath, startupPolicy } = resolveCliExecutionStartupContext({
       argv,
-      protocolCommandPath: getActionCommandPath(actionCommand),
+      protocolCommandPath: getCommanderCommandPath(actionCommand),
       jsonOutputMode,
       env: process.env,
     });

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -176,6 +176,7 @@ describe("registerSetupCommand", () => {
 
     expect(setupCommandMock).toHaveBeenCalledWith(lastSetupOptions(), runtime);
     expect(lastSetupOptions()?.workspace).toBe("/tmp/ws");
+    expect(lastSetupOptions()?.json).toBe(true);
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -116,7 +116,10 @@ async function runOnboardingEntry(
       return;
     }
     const { setupCommand } = await import("../../commands/setup.js");
-    await setupCommand({ workspace: optionalString(options.workspace) }, runtime);
+    await setupCommand(
+      { workspace: optionalString(options.workspace), json: Boolean(options.json) },
+      runtime,
+    );
     return;
   }
   if (!validateOnboardAuthOptionValues(options, runtime)) {

--- a/src/cli/run-main-policy.ts
+++ b/src/cli/run-main-policy.ts
@@ -13,6 +13,7 @@ import {
   type PluginManifestToolOwnerRecord,
 } from "../plugins/manifest-command-aliases.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
+import { isSimpleCommandHelpInvocation } from "./argv.js";
 import {
   resolveCliCommandPathPolicy,
   resolveCliNetworkProxyPolicy,
@@ -103,12 +104,7 @@ export function shouldUseSetupOnboardConfigureHelpFastPath(
   if (env.OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH === "1") {
     return false;
   }
-  const invocation = resolveCliArgvInvocation(argv);
-  return (
-    invocation.commandPath.length === 1 &&
-    SETUP_ONBOARD_CONFIGURE_HELP_COMMANDS.has(invocation.commandPath[0] ?? "") &&
-    invocation.hasHelpOrVersion
-  );
+  return isSimpleCommandHelpInvocation(argv, SETUP_ONBOARD_CONFIGURE_HELP_COMMANDS);
 }
 
 export function shouldHandleBareRoot(argv: string[]): boolean {

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -324,6 +324,15 @@ describe("shouldUseSetupOnboardConfigureHelpFastPath", () => {
     expect(
       shouldUseSetupOnboardConfigureHelpFastPath(["node", "openclaw", "status", "--help"]),
     ).toBe(false);
+    expect(
+      shouldUseSetupOnboardConfigureHelpFastPath([
+        "node",
+        "openclaw",
+        "onboard",
+        "--gateway-port",
+        "--help",
+      ]),
+    ).toBe(false);
   });
 });
 

--- a/src/cli/setup-onboard-configure-help-fast-path.ts
+++ b/src/cli/setup-onboard-configure-help-fast-path.ts
@@ -2,6 +2,7 @@
 import { Command, CommanderError } from "commander";
 import { VERSION } from "../version.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
+import { isSimpleCommandHelpInvocation } from "./argv.js";
 import type { ProgramContext } from "./program/context.js";
 import { configureProgramHelp } from "./program/help.js";
 
@@ -17,7 +18,10 @@ function resolveSetupOnboardConfigureHelpCommand(
   argv: string[],
 ): SetupOnboardConfigureHelpCommand | null {
   const invocation = resolveCliArgvInvocation(argv);
-  if (invocation.commandPath.length !== 1 || !invocation.hasHelpOrVersion) {
+  if (
+    invocation.commandPath.length !== 1 ||
+    !isSimpleCommandHelpInvocation(argv, SETUP_ONBOARD_CONFIGURE_HELP_COMMANDS)
+  ) {
     return null;
   }
   const command = invocation.commandPath[0];

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -833,7 +833,14 @@ describe("setupWizardCommand", () => {
 
     // Unset Commander booleans arrive as false and must not force classic.
     await setupWizardCommand(
-      { skipChannels: false, skipSkills: false, acceptRisk: false, json: false },
+      {
+        skipChannels: false,
+        skipSkills: false,
+        acceptRisk: false,
+        json: false,
+        tailscaleResetOnExit: undefined,
+        customImageInput: undefined,
+      },
       runtime,
     );
 
@@ -861,6 +868,8 @@ describe("setupWizardCommand", () => {
     ["--remote-url", { remoteUrl: "wss://gw.example.ts.net" }],
     ["--skip-bootstrap", { skipBootstrap: true }],
     ["--no-install-daemon", { installDaemon: false }],
+    ["--no-tailscale-reset-on-exit", { tailscaleResetOnExit: false }],
+    ["--custom-text-input", { customImageInput: false }],
     ["--daemon-runtime", { daemonRuntime: "node" as const }],
     ["a provider auth flag", { mistralApiKey: "sk-x" }],
   ])("keeps the classic interactive wizard for %s", async (_label, opts) => {

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -408,10 +408,11 @@ function validateResetNonInteractiveGateway(params: {
  * Interactive onboarding defaults to guided setup. Any explicit
  * setup flag beyond this allowlist keeps the classic wizard — those flags are
  * a public automation contract and guided setup does not honor them.
- * Boolean false and undefined mean "not passed" (Commander coerces unset
- * booleans to false); explicit `--no-install-daemon` arrives as `false` via
- * resolveInstallDaemonFlag and is special-cased. `--modern` never reaches this
- * dispatch; the command layer routes it through the inference-gated OpenClaw.
+ * Most false booleans mean "not passed" because the command layer normalizes
+ * them with Boolean(). False-valued explicit choices preserve undefined when
+ * omitted, so daemon, Tailscale-reset, and custom-model input overrides are
+ * special-cased. `--modern` never reaches this dispatch; the command layer
+ * routes it through the inference-gated OpenClaw.
  */
 const GUIDED_SAFE_ONBOARD_KEYS = new Set([
   "workspace",
@@ -427,7 +428,11 @@ function wantsClassicInteractiveSetup(opts: OnboardOptions): boolean {
   if (opts.classic === true) {
     return true;
   }
-  if (opts.installDaemon !== undefined) {
+  if (
+    opts.installDaemon !== undefined ||
+    opts.tailscaleResetOnExit !== undefined ||
+    opts.customImageInput !== undefined
+  ) {
     return true;
   }
   for (const [key, value] of Object.entries(opts)) {

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -118,6 +118,29 @@ describe("setupCommand", () => {
     });
   });
 
+  it("emits one structured result for baseline JSON output", async () => {
+    await withTempHome(async (home) => {
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+      const deps = createSetupDeps(home);
+      const workspace = path.join(home, ".openclaw", "workspace");
+
+      await setupCommand({ workspace, json: true }, runtime, deps);
+
+      expect(runtime.log).toHaveBeenCalledOnce();
+      expect(JSON.parse(String(runtime.log.mock.calls[0]?.[0]))).toEqual({
+        ok: true,
+        configPath: path.join(home, ".openclaw", "openclaw.json"),
+        configStatus: "created",
+        workspaceDir: workspace,
+        sessionsDir: path.join(home, ".openclaw", "sessions"),
+      });
+    });
+  });
+
   it("updates the default entry workspace created by fresh setup", async () => {
     await withTempHome(async (home) => {
       const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -21,7 +21,7 @@ import { migratePersistedImplicitMainRoster } from "../config/legacy.js";
 import type { OptionalBootstrapFileName } from "../config/types.agent-defaults.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { defaultRuntime } from "../runtime.js";
+import { defaultRuntime, writeRuntimeJson } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { shortenHomePath } from "../utils.js";
 
@@ -134,7 +134,7 @@ async function resolveDefaultSessionTranscriptsDir(agentId: string): Promise<str
 
 /** Prepares config, workspace, and session directories for a usable installation. */
 export async function setupCommand(
-  opts?: { workspace?: string },
+  opts?: { workspace?: string; json?: boolean },
   runtime: RuntimeEnv = defaultRuntime,
   deps: SetupCommandDeps = {},
 ) {
@@ -225,7 +225,10 @@ export async function setupCommand(
     next = (await ensureOnboardingAgent({ config: next, workspace, baseConfig: cfg })).config;
   }
 
-  if (!snapshot.exists || shouldPersistRoster || shouldWriteWorkspace || shouldWriteGatewayMode) {
+  const configChanged =
+    !snapshot.exists || shouldPersistRoster || shouldWriteWorkspace || shouldWriteGatewayMode;
+  let configStatus: "created" | "updated" | "unchanged";
+  if (configChanged) {
     // Preserve all existing config fields and touch only workspace/gateway mode
     // defaults that this command owns.
     const replaceConfig = deps.replaceConfigFile ?? writeDefaultConfigFile;
@@ -250,10 +253,11 @@ export async function setupCommand(
           : {}),
       },
     });
-    if (!snapshot.exists) {
+    configStatus = snapshot.exists ? "updated" : "created";
+    if (!opts?.json && !snapshot.exists) {
       const formatConfigPath = deps.formatConfigPath ?? formatDefaultConfigPath;
       runtime.log(`Wrote ${await formatConfigPath(configPath)}`);
-    } else {
+    } else if (!opts?.json) {
       const updates: string[] = [];
       if (shouldWriteWorkspace) {
         updates.push("set agents.defaults.workspace");
@@ -268,8 +272,11 @@ export async function setupCommand(
       });
     }
   } else {
-    const formatConfigPath = deps.formatConfigPath ?? formatDefaultConfigPath;
-    runtime.log(`Config OK: ${await formatConfigPath(configPath)}`);
+    configStatus = "unchanged";
+    if (!opts?.json) {
+      const formatConfigPath = deps.formatConfigPath ?? formatDefaultConfigPath;
+      runtime.log(`Config OK: ${await formatConfigPath(configPath)}`);
+    }
   }
 
   const ws = await (deps.ensureAgentWorkspace ?? ensureDefaultAgentWorkspace)({
@@ -277,13 +284,25 @@ export async function setupCommand(
     ensureBootstrapFiles: !resolvedDefaults.skipBootstrap,
     skipOptionalBootstrapFiles: resolvedDefaults.skipOptionalBootstrapFiles,
   });
-  runtime.log(`Workspace OK: ${shortenHomePath(ws.dir)}`);
+  if (!opts?.json) {
+    runtime.log(`Workspace OK: ${shortenHomePath(ws.dir)}`);
+  }
 
   const defaultAgentId = resolveDefaultAgentId(next);
   const sessionsDir = await (
     deps.resolveSessionTranscriptsDir ?? resolveDefaultSessionTranscriptsDir
   )(defaultAgentId);
   await (deps.mkdir ?? fs.mkdir)(sessionsDir, { recursive: true });
+  if (opts?.json) {
+    writeRuntimeJson(runtime, {
+      ok: true,
+      configPath,
+      configStatus,
+      workspaceDir: ws.dir,
+      sessionsDir,
+    });
+    return;
+  }
   runtime.log(`Sessions OK: ${shortenHomePath(sessionsDir)}`);
   runtime.log("");
   runtime.log("Setup complete: config, workspace, and session directories are ready.");


### PR DESCRIPTION
## What Problem This Solves

Fixes five CLI contract failures: required option values named `--help` or `--json` were mistaken for flags, parse errors suggested help paths built from option values, `setup --baseline --json` emitted no JSON, and explicit false-valued onboarding controls silently entered a wizard that ignored them.

## Why This Change Was Made

Commander-owned parse facts now distinguish real options from consumed values, errors use the active command node instead of reparsing raw argv, baseline setup emits one structured result, and onboarding dispatch preserves explicit false provenance without treating omitted defaults as user intent. This is an AI-assisted maintainer QA fix.

## User Impact

Automation can pass dash-leading values safely, machine-output modes remain trustworthy, parse errors point to real commands, baseline setup is scriptable, and documented negated/text-only onboarding flags reach the path that honors them.

## Evidence

- Real process reproduction before the fix created a literal `--help` workspace while startup bootstrap was skipped; `--json` as a required value redirected human output to stderr.
- Blacksmith Testbox `tbx_01kys7hva9qdktr7mchpekc70g`: 381 focused tests across 10 CLI/setup/onboard files passed — https://github.com/openclaw/openclaw/actions/runs/30533059373
- Review-triggered regressions: 184 and 52 affected tests passed after fixing repeated-option, empty-argv, configured-output, and post-command ownership cases.
- Remote `check:changed`: core/coreTests typecheck, format, lint, deadcode, cycles, and storage/security guards passed.
- Commander 15 source and typings were inspected directly for required-value consumption, option sources, custom command factories, and error ownership.
- Conflict-free rebase to `7a9d2c3e`; stable patch ID unchanged; final Codex autoreview found no accepted/actionable findings, confidence `0.87`.

### Source-blind CLI behavior proof

Validated exact head `cd3b5eeb85bf9fa7d71611b9a2582b269983076d` on Blacksmith Testbox [`tbx_01kysed0tp5zye9e1e77wryetk`](https://github.com/openclaw/openclaw/actions/runs/30540831006). The validator did not inspect source, diffs, tests, history, or credentials. Each probe used distinct temporary HOME/state/workspace paths, split stdout/stderr capture, a scrubbed environment, bounded timeouts, and cleanup; the Testbox was stopped afterward.

- `openclaw setup --help`: exit 0; setup usage/help on stdout; stderr empty.
- `openclaw secrets apply --from --help`: exit 1; stdout empty; stderr reports plan file `--help` missing, proving the token was consumed as the required value rather than activating help.
- `openclaw secrets apply --from --json`: exit 1; stdout empty; human stderr reports plan file `--json` missing, proving JSON mode was not activated.
- `openclaw status --timeout 5000 --wat`: exit 1; stderr suggests exactly `openclaw status --help`; no synthetic `status 5000` path.
- `openclaw setup --baseline --json`: exit 0; stderr empty; stdout is exactly one parseable object containing `ok`, config path/status, workspace path, and sessions path.
- Real-PTY routing: `onboard --no-tailscale-reset-on-exit` and `setup --custom-text-input` both displayed the classic `OpenClaw setup` wizard. Flagless `onboard` displayed guided setup (“Hi — I’m OpenClaw… Setup choices”). PTY exits were intentional timeout 124 while awaiting user input.
