### PR TITLE
fix(gateway): plugin session-change handlers never fire without a subscribed client [AI-assisted]

### DIFF
--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -5,7 +5,10 @@ import {
 // Gateway WebSocket broadcaster.
 // Applies event scope guards and slow-consumer handling before sending frames.
 import { logRejectedLargePayload } from "../logging/diagnostic-payload.js";
-import { queuePluginSessionsChanged } from "../plugins/gateway-events.js";
+import {
+  hasPluginSessionsChangedSubscribers,
+  queuePluginSessionsChanged,
+} from "../plugins/gateway-events.js";
 import { isBrowserCopilotClient } from "../utils/message-channel.js";
 import {
   ADMIN_SCOPE,
@@ -185,6 +188,15 @@ function hasEventScope(
     return scopes.includes(TALK_SCOPE) || scopes.includes(WRITE_SCOPE);
   }
   return required.some((scope) => scopes.includes(scope));
+}
+
+/**
+ * Emit guards must agree with the fan-out below: plugin `onSessionsChanged`
+ * subscribers receive `sessions.changed` even when no client holds a
+ * `sessions.subscribe` RPC subscription, so they count as receivers.
+ */
+export function hasSessionsChangedReceiver(connIds: ReadonlySet<string>): boolean {
+  return connIds.size > 0 || hasPluginSessionsChangedSubscribers();
 }
 
 export function createGatewayBroadcaster(params: {

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -63,6 +63,8 @@ vi.mock("./session-utils.js", () => {
 
 import { getRuntimeConfig } from "../config/io.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
+import { subscribePluginSessionsChanged } from "../plugins/gateway-events.js";
+import { createGatewayBroadcaster } from "./server-broadcast.js";
 import {
   emitAgentEvent,
   emitAgentEvents,
@@ -121,6 +123,7 @@ describe("agent event handler", () => {
 
   function createHarness(params?: {
     now?: number;
+    broadcastToConnIds?: AgentEventHandlerOptions["broadcastToConnIds"];
     resolveSessionKeyForRun?: (runId: string) => string | undefined;
     lifecycleErrorRetryGraceMs?: number;
     isChatSendRunActive?: (runId: string) => boolean;
@@ -147,7 +150,7 @@ describe("agent event handler", () => {
 
     const handler = createAgentEventHandler({
       broadcast,
-      broadcastToConnIds,
+      broadcastToConnIds: params?.broadcastToConnIds ?? broadcastToConnIds,
       nodeSendToSession,
       agentRunSeq,
       chatRunState,
@@ -3191,6 +3194,28 @@ describe("agent event handler", () => {
     expect(logErrorMock).toHaveBeenCalledWith(
       "gateway: start session persistence failed session=global run=run-global-work error=Error: start disk full",
     );
+  });
+
+  it("publishes lifecycle session changes to plugins without websocket subscribers", async () => {
+    const received = vi.fn();
+    const unsubscribe = subscribePluginSessionsChanged(received);
+    const { broadcastToConnIds } = createGatewayBroadcaster({ clients: new Set() });
+    const { chatRunState, handler } = createHarness({ broadcastToConnIds });
+    registerChatRun(chatRunState, "run-plugin-start", "global", "client-plugin-start", {
+      agentId: "work",
+    });
+
+    try {
+      emitAgentEvent(handler, "run-plugin-start", "lifecycle", { phase: "start" });
+
+      await waitForFast(() => {
+        expect(received).toHaveBeenCalledWith(
+          expect.objectContaining({ sessionKey: "global", agentId: "work", phase: "start" }),
+        );
+      });
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("routes hidden selected-agent global chat events only to matching subscribers", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -41,6 +41,7 @@ import {
   shouldSuppressAssistantEventForLiveChat,
 } from "./live-chat-projector.js";
 import type { GatewayBroadcastFn, GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
+import { hasSessionsChangedReceiver } from "./server-broadcast.js";
 import { isChatAbortMarkerCurrent } from "./server-chat-state.js";
 import type {
   BufferedAgentEvent,
@@ -817,7 +818,7 @@ export function createAgentEventHandler({
             return;
           }
           const sessionEventConnIds = sessionEventSubscribers.getAll();
-          if (sessionEventConnIds.size === 0) {
+          if (!hasSessionsChangedReceiver(sessionEventConnIds)) {
             return;
           }
           broadcastToConnIds(
@@ -1661,7 +1662,7 @@ export function createAgentEventHandler({
         );
       });
       const sessionEventConnIds = sessionEventSubscribers.getAll();
-      if (sessionEventConnIds.size > 0) {
+      if (hasSessionsChangedReceiver(sessionEventConnIds)) {
         broadcastToConnIds(
           "sessions.changed",
           {

--- a/src/gateway/server-methods/session-change-event.test.ts
+++ b/src/gateway/server-methods/session-change-event.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBroadcastToConnIdsFn } from "../server-broadcast-types.js";
+
+const sessionRow = vi.hoisted(() => ({
+  key: "agent:main:main",
+  kind: "direct",
+  sessionId: "sess-main",
+  status: "done",
+  updatedAt: 1,
+  label: "Renamed chat",
+}));
+const loadGatewaySessionRowMock = vi.hoisted(() => vi.fn(() => sessionRow));
+
+vi.mock("../session-utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../session-utils.js")>();
+  return { ...actual, loadGatewaySessionRow: loadGatewaySessionRowMock };
+});
+
+const { emitSessionsChanged } = await import("./session-change-event.js");
+const { createGatewayBroadcaster } = await import("../server-broadcast.js");
+const { subscribePluginSessionsChanged } = await import("../../plugins/gateway-events.js");
+
+type SessionsChangedContext = Parameters<typeof emitSessionsChanged>[0];
+
+const titleChange = { sessionKey: "agent:main:main", reason: "chat.title" };
+const pluginNotice = {
+  sessionKey: "agent:main:main",
+  label: "Renamed chat",
+  reason: "chat.title",
+};
+
+function createContext(
+  broadcastToConnIds: GatewayBroadcastToConnIdsFn,
+  connIds: readonly string[] = [],
+): SessionsChangedContext {
+  return {
+    broadcastToConnIds,
+    chatAbortControllers: new Map(),
+    getRuntimeConfig: () => ({}),
+    getSessionEventSubscriberConnIds: () => new Set(connIds),
+  };
+}
+
+describe("emitSessionsChanged", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("publishes session changes to plugins without websocket subscribers", async () => {
+    const received = vi.fn();
+    const unsubscribe = subscribePluginSessionsChanged(received);
+    const { broadcastToConnIds } = createGatewayBroadcaster({ clients: new Set() });
+
+    try {
+      emitSessionsChanged(createContext(broadcastToConnIds), titleChange);
+      await Promise.resolve();
+      expect(received).toHaveBeenCalledWith(pluginNotice);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("keeps publishing to plugins while websocket subscribers are connected", async () => {
+    const received = vi.fn();
+    const unsubscribe = subscribePluginSessionsChanged(received);
+    const { broadcastToConnIds } = createGatewayBroadcaster({ clients: new Set() });
+
+    try {
+      emitSessionsChanged(createContext(broadcastToConnIds, ["conn-1"]), titleChange);
+      await Promise.resolve();
+      expect(received).toHaveBeenCalledWith(pluginNotice);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("still targets websocket subscribers when no plugin subscribes", () => {
+    const broadcastToConnIds = vi.fn();
+
+    emitSessionsChanged(createContext(broadcastToConnIds, ["conn-1"]), titleChange);
+
+    expect(broadcastToConnIds).toHaveBeenCalledWith(
+      "sessions.changed",
+      expect.objectContaining(titleChange),
+      new Set(["conn-1"]),
+      expect.objectContaining({ dropIfSlow: true }),
+    );
+  });
+
+  it("skips the session row load when no websocket or plugin subscriber listens", () => {
+    const broadcastToConnIds = vi.fn();
+
+    emitSessionsChanged(createContext(broadcastToConnIds), titleChange);
+
+    expect(broadcastToConnIds).not.toHaveBeenCalled();
+    expect(loadGatewaySessionRowMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/session-change-event.ts
+++ b/src/gateway/server-methods/session-change-event.ts
@@ -1,5 +1,6 @@
 // Shared sessions.changed broadcaster for gateway RPC and chat-command mutations.
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { hasSessionsChangedReceiver } from "../server-broadcast.js";
 import { buildGatewaySessionEventFields } from "../session-event-payload.js";
 import { invalidateSessionSharingSnapshot } from "../session-sharing.js";
 import { loadGatewaySessionRow } from "../session-utils.js";
@@ -25,7 +26,7 @@ export function emitSessionsChanged(
 ) {
   invalidateSessionSharingSnapshot(payload.sessionKey);
   const connIds = context.getSessionEventSubscriberConnIds();
-  if (connIds.size === 0) {
+  if (!hasSessionsChangedReceiver(connIds)) {
     return;
   }
   const sessionRow = payload.sessionKey

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -18,6 +18,7 @@ import type { InternalSessionTranscriptUpdate } from "../sessions/transcript-eve
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import { projectChatDisplayMessage } from "./chat-display-projection.js";
 import type { GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
+import { hasSessionsChangedReceiver } from "./server-broadcast.js";
 import type {
   SessionEventSubscriberRegistry,
   SessionMessageSubscriberRegistry,
@@ -39,10 +40,6 @@ import {
 
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
-
-function hasSessionsChangedReceiver(connIds: ReadonlySet<string>): boolean {
-  return connIds.size > 0 || hasPluginSessionsChangedSubscribers();
-}
 
 function readMessageIdempotencyKey(message: unknown): string | undefined {
   if (!message || typeof message !== "object" || Array.isArray(message)) {


### PR DESCRIPTION
Closes #116371

## What Problem This Solves

Fixes an issue where plugins that register `ctx.gatewayEvents.onSessionsChanged(...)` receive nothing at all unless some connected client independently holds a `sessions.subscribe` RPC subscription. That is the steady state for headless and backend deployments — no Control UI open, no TUI attached — so on those Gateways the hook silently never fires, for any reason, including session title changes (`reason: "chat.title"`) and run lifecycle phases.

`docs/plugins/sdk-runtime.md` promises the opposite: "The handler runs in the Gateway process and does not add a Gateway protocol subscription." In practice it required somebody else's protocol subscription, so plugin authors were pushed back to polling `sessions.describe`.

## Why This Change Was Made

Plugin delivery happens inside the broadcaster: `server-broadcast.ts` queues `queuePluginSessionsChanged(payload)` for every `sessions.changed` frame it is asked to send, and both `broadcast` and `broadcastToConnIds` route through it. Any emit site that returns early on "no websocket subscribers" therefore cancels plugin delivery as well.

`server-session-events.ts` already had the right predicate — `connIds.size > 0 || hasPluginSessionsChangedSubscribers()` — added alongside the plugin fan-out in #114813, but only its own emit paths used it. Three older emit sites, all written before plugin subscribers existed as a receiver class, still gated on the RPC subscriber count alone:

- `src/gateway/server-methods/session-change-event.ts` — `emitSessionsChanged`, the shared emitter behind ~25 RPC methods and chat-command mutations. This is the site named in the issue; its `connIds.size === 0` guard dates to the file's introduction in June, weeks before the plugin fan-out existed.
- `src/gateway/server-chat.ts` — the run-terminal `sessions.changed` projection.
- `src/gateway/server-chat.ts` — the `phase: "start"` lifecycle projection.

Rather than fix only the reported site and leave a one-sided fix, the predicate moves to `hasSessionsChangedReceiver` in `server-broadcast.ts` — next to the fan-out it predicts — and the three sites that were missing it now use it. It could not stay in `server-session-events.ts`: `check-madge-import-cycles` counts type-only imports and `server-session-events.ts` type-imports `./server-chat.js`, so importing it from `server-chat.ts` would have reported a static cycle.

Payloads without a `sessionKey` are still dropped by `queuePluginSessionsChanged` — that is the existing plugin event contract, not something this change alters.

### Every `sessions.changed` emit site on current `main`

Complete sweep of `src/`, `packages/`, and `extensions/` (excluding tests); the remaining matches are consumers (`src/tui/tui.ts`, `packages/sdk/src/normalize.ts`) or registries (`server-methods-list.ts`, the scope map in `server-broadcast.ts`).

| Emit site | Guard before | After |
|---|---|---|
| `server-session-events.ts:351` (transcript batch) | `connIds.size === 0` **plus** an explicit `hasPluginSessionsChangedSubscribers()` escape | unchanged |
| `server-session-events.ts:395` (suppressed-display message) | `hasSessionsChangedReceiver` | unchanged, now imported |
| `server-session-events.ts:437` (lifecycle) | `hasSessionsChangedReceiver` | unchanged, now imported |
| `server-cron.ts:594` (cron binding) | none — unguarded `broadcast(...)` | unchanged, already reached plugins |
| `server-cron.ts:1457` (cron bindings loaded) | none — unguarded `broadcast(...)` | unchanged, already reached plugins |
| `server-methods/session-change-event.ts:54` | `connIds.size === 0` | **fixed** |
| `server-chat.ts:824` (run terminal) | `connIds.size === 0` | **fixed** |
| `server-chat.ts:1666` (`phase: "start"`) | `connIds.size > 0` | **fixed** |

No guarded emit site is left on the RPC-only predicate.

Nothing changes when a websocket subscriber exists, and nothing changes when there is no receiver of either kind: the early return still skips the session-row load and the broadcast.

## User Impact

Plugin services on headless and backend Gateways now actually receive `sessions.changed` notices through `ctx.gatewayEvents.onSessionsChanged` — including title renames and run lifecycle phases — with no Control UI or other `sessions.subscribe` client connected, which is what the SDK docs already describe. Gateways that do have subscribed clients behave exactly as before, and a Gateway with no receiver at all still does no work.

## Evidence

Regression coverage, driven through the **real** `createGatewayBroadcaster` fan-out rather than a stubbed broadcaster wherever plugin delivery is the assertion:

- `src/gateway/server-methods/session-change-event.test.ts` (new, `gateway-methods` lane — the lane that owns the changed file) covers all four subscriber combinations:
  - plugin only, no `sessions.subscribe` connections → the notice arrives (`reason: "chat.title"`);
  - plugin **and** websocket subscribers → the notice still arrives, so having RPC subscribers never suppresses the fan-out;
  - websocket only → the broadcast is still targeted at exactly those conn ids with `dropIfSlow`, unchanged;
  - neither → `emitSessionsChanged` returns before the session-row load and never broadcasts, asserted on both `broadcastToConnIds` and `loadGatewaySessionRow`, so the early return keeps its purpose.
- `src/gateway/server-chat.agent-events.test.ts` (+1 case, `gateway-server` lane): a `phase: "start"` lifecycle event reaches a plugin subscriber with no websocket subscribers. `createHarness` gained one optional `broadcastToConnIds` override for this; existing cases keep the `vi.fn()` and are untouched.

Negative controls — restoring `connIds.size === 0` in `session-change-event.ts` makes only its plugin case fail; restoring both `sessionEventConnIds.size` guards in `server-chat.ts` makes only the lifecycle case fail.

Local runs (macOS, Node 24.16.0, pnpm 11.15.1):

```
gateway-methods lane   139 files   2735 passed          (owns the changed emitter + the new test)
gateway-core   lane    252 files   4313 passed, 1 failed
gateway-server lane    crashes a Vitest worker before printing a summary
  └ the 4 files in that lane nearest the crash, incl. the one this PR edits: 148 passed
```

Both non-green results are pre-existing on this machine, not caused by this change:

- The `gateway-core` failure is `src/gateway/mcp-http.test.ts` dying on an unhandled `ECONNRESET` under parallel load rather than on an assertion; it passes 96/96 when run on its own, and it exercises MCP HTTP transport, not session events.
- The `gateway-server` lane dies with `Error: Worker exited unexpectedly` right after `server.tools-effective.global-agent-gateway.test.ts`. **The identical crash reproduces on a clean detached `origin/main` (`bf8da2537c`) with no part of this PR applied**, same file, same two failed dots — so it is a pre-existing local-parallelism problem. `server-chat.agent-events.test.ts`, `server.tools-effective.global-agent-gateway.test.ts`, `server.device-token-rotate-authz.test.ts`, and `server.node-version-mismatch.test.ts` pass together (148 tests) when run outside the full lane.

Also clean: `pnpm check:import-cycles` (0 runtime cycles), `pnpm check:madge-import-cycles` (0 cycles), `pnpm tsgo:core`, `pnpm tsgo:core:test`, `oxlint` and `oxfmt` on every touched file.

#116371 carries `clawsweeper:no-new-fix-pr` and `clawsweeper:needs-maintainer-review`. That review's blocker was that it could not inspect current-`main` source or existing coverage from its read-only environment, and its open question was whether the narrow fix holds "against sibling event paths". This is opened as a **draft** to supply exactly that: current-`main` verification, the two sibling paths it could not check (both real, both fixed here), and the plugin-only / RPC-only / combined coverage its "best possible solution" asked for. Happy to close it if a maintainer would rather own the repair.

Not run locally: `pnpm build` and the full `pnpm check` / `pnpm test` matrix — no build-output, packaging, or dynamic-import boundary changes here (`server-broadcast.ts` has no dynamic import in prod code), so this is left to CI. A first attempt at `pnpm test:gateway` was terminated by the repo's own no-output watchdog after 300s rather than by a test failure, which is why the gateway lanes are reported individually above.

**Real-Gateway proof: done.** An isolated-sandbox before/after run (throwaway `OPENCLAW_STATE_DIR`, ephemeral port, real plugin registering `onSessionsChanged`, no `sessions.subscribe` client) shows no delivery on `main`, delivery with payload on this branch, and the no-receiver case staying silent with the plugin service live — full commands and output in [this comment](https://github.com/openclaw/openclaw/pull/116392#issuecomment-5130964142).

