### PR TITLE
refactor(agents): allow process-local exec approval hosts

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -3,6 +3,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
+import { interruptSessionWorkAdmissions } from "../sessions/session-lifecycle-admission.js";
 import { createUserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.js";
 import {
   deliveryContextFromSession,
@@ -30,6 +31,10 @@ import {
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "./internal-runtime-context.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
+import {
+  ExecApprovalRunAbortedError,
+  getLocalExecApprovalBroker,
+} from "./local-exec-approval-broker.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
   createAgentRunDirectAbortError,
@@ -1401,6 +1406,49 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       ]),
     );
     expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending local exec approval when session work is interrupted", async () => {
+    setupStoredSession();
+    setupSingleAttemptFallback();
+    let markApprovalPending: () => void = () => {};
+    const approvalPending = new Promise<void>((resolve) => {
+      markApprovalPending = resolve;
+    });
+    state.runAgentAttemptMock.mockImplementation(async () => {
+      const broker = getLocalExecApprovalBroker();
+      if (!broker) {
+        throw new Error("expected process-local exec approval broker");
+      }
+      broker.register({
+        id: "approval-session-interrupt",
+        command: "buzz messages send",
+        host: "gateway",
+        security: "allowlist",
+        ask: "on-miss",
+        timeoutMs: 60_000,
+      });
+      markApprovalPending();
+      await broker.wait("approval-session-interrupt");
+      return makeSuccessResult("openai", "gpt-5.4");
+    });
+
+    const command = agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      localExecApprovalHandler: async () => await new Promise<never>(() => {}),
+    });
+    const rejected = expect(command).rejects.toBeInstanceOf(ExecApprovalRunAbortedError);
+    await approvalPending;
+
+    await expect(
+      interruptSessionWorkAdmissions({
+        scope: "/tmp/openclaw-sessions.json",
+        identities: ["agent:main:main", "session-1"],
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBe(true);
+    await rejected;
   });
 
   it("preserves restart ownership when an aborted ACP turn resolves normally", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -55,6 +55,7 @@ import {
   resolveInternalSessionEffectsTarget,
 } from "./internal-session-effects.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
+import { runWithLocalExecApprovalHandler } from "./local-exec-approval-broker.js";
 import type { MainSessionRecoveryPendingTarget } from "./main-session-recovery-store.js";
 import type { AgentRunSessionTarget } from "./run-session-target.js";
 import { createAgentRunRestartAbortError } from "./run-termination.js";
@@ -62,7 +63,7 @@ import { measureAgentStartup } from "./startup-timing.js";
 
 const log = createSubsystemLogger("agents/agent-command");
 
-async function agentCommandInternal(
+async function agentCommandInternalUnwrapped(
   prepared: Awaited<ReturnType<typeof prepareAgentCommandExecution>>,
   initialOpts: AgentCommandOpts,
   runtime: RuntimeEnv = defaultRuntime,
@@ -575,6 +576,19 @@ async function agentCommandInternal(
     }
     clearAgentRunContext(runId, lifecycleGeneration);
   }
+}
+
+async function agentCommandInternal(
+  prepared: Awaited<ReturnType<typeof prepareAgentCommandExecution>>,
+  initialOpts: AgentCommandOpts,
+  runtime: RuntimeEnv = defaultRuntime,
+  deps?: CliDeps,
+) {
+  return await runWithLocalExecApprovalHandler({
+    handler: initialOpts.localExecApprovalHandler,
+    signal: initialOpts.abortSignal,
+    run: async () => await agentCommandInternalUnwrapped(prepared, initialOpts, runtime, deps),
+  });
 }
 
 /** Runs an agent turn from CLI/runtime options against the resolved session and model policy. */

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -66,6 +66,8 @@ const log = createSubsystemLogger("agents/agent-command");
 async function agentCommandInternalUnwrapped(
   prepared: Awaited<ReturnType<typeof prepareAgentCommandExecution>>,
   initialOpts: AgentCommandOpts,
+  lifecycleAbortController: AbortController,
+  runAbortSignal: AbortSignal,
   runtime: RuntimeEnv = defaultRuntime,
   deps?: CliDeps,
 ) {
@@ -74,7 +76,6 @@ async function agentCommandInternalUnwrapped(
   const suppressVisibleSessionEffects = initialOpts.sessionEffects === "internal";
   const preserveUserFacingSessionModelState =
     initialOpts.preserveUserFacingSessionModelState === true;
-  const lifecycleAbortController = new AbortController();
   const storedDeliveryMediaUrls =
     prepared.sessionEntry?.restartRecoveryDeliveryRunId === prepared.runId &&
     Array.isArray(prepared.sessionEntry.restartRecoveryDeliveryMediaUrls)
@@ -106,9 +107,7 @@ async function agentCommandInternalUnwrapped(
   }
   let opts: AgentCommandOpts = {
     ...preparedOpts,
-    abortSignal: preparedOpts.abortSignal
-      ? AbortSignal.any([preparedOpts.abortSignal, lifecycleAbortController.signal])
-      : lifecycleAbortController.signal,
+    abortSignal: runAbortSignal,
   };
   const {
     body,
@@ -584,10 +583,22 @@ async function agentCommandInternal(
   runtime: RuntimeEnv = defaultRuntime,
   deps?: CliDeps,
 ) {
+  const lifecycleAbortController = new AbortController();
+  const runAbortSignal = initialOpts.abortSignal
+    ? AbortSignal.any([initialOpts.abortSignal, lifecycleAbortController.signal])
+    : lifecycleAbortController.signal;
   return await runWithLocalExecApprovalHandler({
     handler: initialOpts.localExecApprovalHandler,
-    signal: initialOpts.abortSignal,
-    run: async () => await agentCommandInternalUnwrapped(prepared, initialOpts, runtime, deps),
+    signal: runAbortSignal,
+    run: async () =>
+      await agentCommandInternalUnwrapped(
+        prepared,
+        initialOpts,
+        lifecycleAbortController,
+        runAbortSignal,
+        runtime,
+        deps,
+      ),
   });
 }
 

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -157,6 +157,39 @@ describe("exec approval requests", () => {
     expect(callGatewayTool).not.toHaveBeenCalled();
   });
 
+  it("does not turn local cancellation into permissive ask fallback", async () => {
+    const controller = new AbortController();
+    let fallbackAuthorizationReached = false;
+
+    await runWithLocalExecApprovalHandler({
+      handler: async () => await new Promise<never>(() => {}),
+      signal: controller.signal,
+      run: async () => {
+        const registration = await registerExecApprovalRequestForHostOrThrow({
+          approvalId: "cancelled-local-approval",
+          command: "echo hi",
+          workdir: "/tmp",
+          host: "gateway",
+          security: "full",
+          ask: "always",
+        });
+        const decision = resolveRegisteredExecApprovalDecision({
+          approvalId: registration.id,
+          preResolvedDecision: registration.finalDecision,
+        }).then((value) => {
+          fallbackAuthorizationReached = value === null;
+          return value;
+        });
+
+        controller.abort(new Error("turn cancelled"));
+        await expect(decision).rejects.toSatisfy(isExecApprovalRunAbortedError);
+      },
+    });
+
+    expect(fallbackAuthorizationReached).toBe(false);
+    expect(callGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("bounds missing registration expiries when the process clock is invalid", async () => {
     vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id" });
     const dateNow = vi.spyOn(Date, "now").mockReturnValue(Number.NaN);

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -5,6 +5,7 @@
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_APPROVAL_TIMEOUT_MS } from "./bash-tools.exec-runtime.js";
+import { runWithLocalExecApprovalHandler } from "./local-exec-approval-broker.js";
 
 const commandExplainerMock = vi.hoisted(() => ({
   importCount: 0,
@@ -140,6 +141,20 @@ describe("exec approval requests", () => {
         preResolvedDecision: undefined,
       }),
     ).rejects.toSatisfy(isExecApprovalRunAbortedError);
+  });
+
+  it("does not fall through to the Gateway when a local approval is missing", async () => {
+    await expect(
+      runWithLocalExecApprovalHandler({
+        handler: async () => "allow-once",
+        run: async () =>
+          await resolveRegisteredExecApprovalDecision({
+            approvalId: "missing-local-approval",
+            preResolvedDecision: undefined,
+          }),
+      }),
+    ).resolves.toBeNull();
+    expect(callGatewayTool).not.toHaveBeenCalled();
   });
 
   it("bounds missing registration expiries when the process clock is invalid", async () => {

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -27,7 +27,10 @@ import {
   DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS,
   DEFAULT_APPROVAL_TIMEOUT_MS,
 } from "./bash-tools.exec-runtime.js";
-import { getLocalExecApprovalBroker } from "./local-exec-approval-broker.js";
+import {
+  ExecApprovalRunAbortedError,
+  getLocalExecApprovalBroker,
+} from "./local-exec-approval-broker.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 const POSIX_COMMAND_HIGHLIGHT_SHELLS: ReadonlySet<string> = POSIX_PARSEABLE_SHELL_WRAPPERS;
@@ -138,13 +141,6 @@ export type ExecApprovalRegistration = {
   expiresAtMs: number;
   finalDecision?: string | null;
 };
-
-class ExecApprovalRunAbortedError extends Error {
-  constructor() {
-    super("Exec approval cancelled because its run was aborted");
-    this.name = "ExecApprovalRunAbortedError";
-  }
-}
 
 export function isExecApprovalRunAbortedError(error: unknown): boolean {
   return error instanceof ExecApprovalRunAbortedError;

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS,
   DEFAULT_APPROVAL_TIMEOUT_MS,
 } from "./bash-tools.exec-runtime.js";
+import { getLocalExecApprovalBroker } from "./local-exec-approval-broker.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 const POSIX_COMMAND_HIGHLIGHT_SHELLS: ReadonlySet<string> = POSIX_PARSEABLE_SHELL_WRAPPERS;
@@ -153,6 +154,13 @@ export function isExecApprovalRunAbortedError(error: unknown): boolean {
 async function registerExecApprovalRequest(
   params: RequestExecApprovalDecisionParams,
 ): Promise<ExecApprovalRegistration> {
+  const localBroker = getLocalExecApprovalBroker();
+  if (localBroker) {
+    return localBroker.register({
+      ...params,
+      timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    });
+  }
   // Two-phase registration is critical: the ID must be registered server-side
   // before exec returns `approval-pending`, otherwise `/approve` can race and orphan.
   const registrationResult = await callGatewayTool(
@@ -178,6 +186,10 @@ export async function resolveRegisteredExecApprovalDecision(params: {
 }): Promise<string | null> {
   if (params.preResolvedDecision !== undefined) {
     return params.preResolvedDecision ?? null;
+  }
+  const localBroker = getLocalExecApprovalBroker();
+  if (localBroker) {
+    return (await localBroker.wait(params.approvalId)) ?? null;
   }
   try {
     const decisionResult = await callGatewayTool<{ decision: string }>(

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -146,6 +146,11 @@ export function isExecApprovalRunAbortedError(error: unknown): boolean {
   return error instanceof ExecApprovalRunAbortedError;
 }
 
+/** Returns whether the current agent execution owns a process-local approval host. */
+export function hasLocalExecApprovalHost(): boolean {
+  return getLocalExecApprovalBroker() !== undefined;
+}
+
 /** Registers a two-phase exec approval request with the gateway. */
 async function registerExecApprovalRequest(
   params: RequestExecApprovalDecisionParams,

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -11,6 +11,7 @@ import { normalizeOptionalString as parseString } from "@openclaw/normalization-
 import { isApprovalNotFoundError } from "../infra/approval-errors.js";
 import type {
   ExecApprovalCommandSpan,
+  ExecApprovalDecision,
   ExecApprovalUnavailableDecision,
   ExecAsk,
   ExecSecurity,
@@ -385,7 +386,13 @@ export async function registerResolvedLocalExecApprovalForHostOrThrow(
     if (!localBroker) {
       throw new Error("process-local exec approval host is unavailable");
     }
-    return localBroker.registerResolved(await buildHostApprovalDecisionParams(params), decision);
+    return localBroker.registerResolved(
+      {
+        ...(await buildHostApprovalDecisionParams(params)),
+        timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+      },
+      decision,
+    );
   } catch (err) {
     throw new Error(`Exec approval registration failed: ${String(err)}`, { cause: err });
   }

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -374,3 +374,19 @@ export async function registerExecApprovalRequestForHostOrThrow(
     throw new Error(`Exec approval registration failed: ${String(err)}`, { cause: err });
   }
 }
+
+/** Registers an already-settled approval with the process-local authority. */
+export async function registerResolvedLocalExecApprovalForHostOrThrow(
+  params: HostExecApprovalParams,
+  decision: ExecApprovalDecision,
+): Promise<ExecApprovalRegistration> {
+  try {
+    const localBroker = getLocalExecApprovalBroker();
+    if (!localBroker) {
+      throw new Error("process-local exec approval host is unavailable");
+    }
+    return localBroker.registerResolved(await buildHostApprovalDecisionParams(params), decision);
+  } catch (err) {
+    throw new Error(`Exec approval registration failed: ${String(err)}`, { cause: err });
+  }
+}

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -2289,6 +2289,16 @@ EOF`,
 
   it("waits inline for a process-local approval host on non-native channels", async () => {
     hasLocalExecApprovalHostMock.mockReturnValue(true);
+    createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
+      approvalId: "req-1",
+      approvalSlug: "slug-1",
+      warningText: "",
+      expiresAtMs: Date.now() + 60_000,
+      preResolvedDecision: undefined,
+      initiatingSurface: "origin",
+      sentApproverDms: false,
+      unavailableReason: "no-approval-route",
+    });
     resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
     createExecApprovalDecisionStateMock.mockReturnValue({
       baseDecision: { timedOut: false },

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -181,6 +181,7 @@ const sendExecApprovalFollowupResultMock = vi.hoisted(() =>
 const shouldResolveExecApprovalUnavailableInlineMock = vi.hoisted(() =>
   vi.fn<ShouldResolveExecApprovalUnavailableInline>(() => false),
 );
+const hasLocalExecApprovalHostMock = vi.hoisted(() => vi.fn(() => false));
 const enforceStrictInlineEvalApprovalBoundaryMock = vi.hoisted(() =>
   vi.fn<StrictInlineEvalBoundary>((value) => ({
     approvedByAsk: value.approvedByAsk,
@@ -220,6 +221,7 @@ vi.mock("../infra/exec-auto-review.js", async (importOriginal) => ({
 vi.mock("./bash-tools.exec-approval-request.js", () => ({
   buildExecApprovalRequesterContext: vi.fn(() => ({})),
   buildExecApprovalTurnSourceContext: vi.fn(() => ({})),
+  hasLocalExecApprovalHost: hasLocalExecApprovalHostMock,
   registerExecApprovalRequestForHostOrThrow: vi.fn(async () => undefined),
   isExecApprovalRunAbortedError: (error: unknown) => error === runAbortedApprovalError,
 }));
@@ -358,6 +360,8 @@ describe("processGatewayAllowlist", () => {
     resolveApprovalDecisionOrUndefinedMock.mockResolvedValue(undefined);
     shouldResolveExecApprovalUnavailableInlineMock.mockReset();
     shouldResolveExecApprovalUnavailableInlineMock.mockReturnValue(false);
+    hasLocalExecApprovalHostMock.mockReset();
+    hasLocalExecApprovalHostMock.mockReturnValue(false);
     resolveExecHostApprovalContextMock.mockReset();
     resolveExecHostApprovalContextMock.mockReturnValue({
       approvals: { allowlist: [], file: { version: 1, agents: {} } },
@@ -2282,6 +2286,26 @@ EOF`,
       expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
     },
   );
+
+  it("waits inline for a process-local approval host on non-native channels", async () => {
+    hasLocalExecApprovalHostMock.mockReturnValue(true);
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "find . -maxdepth 1",
+      turnSourceChannel: "feishu",
+    });
+
+    expect(result.pendingResult).toBeUndefined();
+    expect(result.deniedResult).toBeUndefined();
+    expect(result.allowWithoutEnforcedCommand).toBe(true);
+    expect(buildExecApprovalFollowupTargetMock).not.toHaveBeenCalled();
+  });
 
   it.each([
     ["telegram"],

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -418,9 +418,13 @@ function buildGatewayExecApprovalFollowupSummary(params: {
 function shouldAwaitGatewayApprovalInline(params: {
   turnSourceChannel?: string;
   approvalFollowupMode?: "agent" | "direct";
+  unavailableReason: string | null;
 }): boolean {
   if (hasLocalExecApprovalHost()) {
     return true;
+  }
+  if (params.unavailableReason !== null) {
+    return false;
   }
   if (params.approvalFollowupMode !== undefined) {
     return false;
@@ -1127,7 +1131,7 @@ export async function processGatewayAllowlist(
       };
     };
 
-    if (unavailableReason === null && shouldAwaitGatewayApprovalInline(params)) {
+    if (shouldAwaitGatewayApprovalInline({ ...params, unavailableReason })) {
       if (params.runId) {
         emitAgentEvent({
           runId: params.runId,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -52,6 +52,7 @@ import { formatExecApprovalContinuationSourceOutput } from "./bash-tools.exec-ap
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
+  hasLocalExecApprovalHost,
   isExecApprovalRunAbortedError,
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
@@ -418,6 +419,9 @@ function shouldAwaitGatewayApprovalInline(params: {
   turnSourceChannel?: string;
   approvalFollowupMode?: "agent" | "direct";
 }): boolean {
+  if (hasLocalExecApprovalHost()) {
+    return true;
+  }
   if (params.approvalFollowupMode !== undefined) {
     return false;
   }

--- a/src/agents/bash-tools.exec-host-node-failure.ts
+++ b/src/agents/bash-tools.exec-host-node-failure.ts
@@ -142,6 +142,27 @@ export function formatNodeInvokeFailureToolResult(params: {
   };
 }
 
+export function formatNodeExecApprovalDeniedToolResult(params: {
+  nodeId: string;
+  approvalId: string;
+  deniedReason: string;
+  command: string;
+  cwd: string | undefined;
+}): AgentToolResult<ExecToolDetails> {
+  const text = `Exec denied (node=${params.nodeId} id=${params.approvalId}, ${params.deniedReason}): ${params.command}`;
+  return {
+    content: [{ type: "text", text }],
+    details: {
+      status: "failed",
+      exitCode: null,
+      durationMs: 0,
+      aggregated: text,
+      timedOut: params.deniedReason.includes("timeout"),
+      cwd: params.cwd,
+    },
+  };
+}
+
 /** Invokes node system.run and turns every non-cancellation failure into provenance-aware data. */
 export async function invokeNodeSystemRun(params: {
   invokeWaitMs: number;

--- a/src/agents/bash-tools.exec-host-node-policy.ts
+++ b/src/agents/bash-tools.exec-host-node-policy.ts
@@ -1,0 +1,58 @@
+import type { ExecAsk, ExecSecurity } from "../infra/exec-approvals.js";
+import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
+import * as execHostShared from "./bash-tools.exec-host-shared.js";
+
+export type NodeGatewayDispatchAuthority =
+  | "current-policy"
+  | "human-approval"
+  | "auto-review"
+  | "ask-fallback";
+
+export type NodeGatewayPolicyCheckpoint = {
+  hostSecurity: ExecSecurity;
+  hostAsk: ExecAsk;
+  askFallback: ExecSecurity;
+};
+
+export async function assertCurrentNodeGatewayPolicyAllowsDispatch(params: {
+  request: ExecuteNodeHostCommandParams;
+  authority: NodeGatewayDispatchAuthority;
+  currentPolicyAllows?: (policy: { hostSecurity: ExecSecurity; hostAsk: ExecAsk }) => boolean;
+  fallbackPolicy?: NodeGatewayPolicyCheckpoint;
+}): Promise<void> {
+  const current = await execHostShared.resolveExecHostApprovalContext({
+    agentId: params.request.agentId,
+    security: params.request.security,
+    ask: params.request.ask,
+    host: "node",
+  });
+  // A human grant may bypass ask/allowlist, but never a later deny. Auto-review
+  // additionally cannot stand in for a newly required human decision.
+  if (current.hostSecurity === "deny") {
+    throw new Error("exec denied: host=node security=deny");
+  }
+  if (params.authority === "human-approval") {
+    return;
+  }
+  if (params.authority === "auto-review") {
+    if (current.hostAsk === "always") {
+      throw new Error("exec denied: host=node ask=always requires human approval");
+    }
+    return;
+  }
+  if (params.authority === "ask-fallback") {
+    const expected = params.fallbackPolicy;
+    if (
+      !expected ||
+      current.hostSecurity !== expected.hostSecurity ||
+      current.hostAsk !== expected.hostAsk ||
+      current.askFallback !== expected.askFallback
+    ) {
+      throw new Error("exec denied: host=node fallback policy changed before dispatch");
+    }
+    return;
+  }
+  if (!params.currentPolicyAllows?.(current)) {
+    throw new Error("exec denied: host=node policy changed before dispatch");
+  }
+}

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -842,6 +842,51 @@ describe("executeNodeHostCommand", () => {
     ).toBe(true);
   });
 
+  it("returns a structured failure when a process-local node approval is denied", async () => {
+    hasLocalExecApprovalHostMock.mockReturnValue(true);
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("deny");
+    createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
+      approvalId: "approval-denied",
+      approvalSlug: "slug-denied",
+      warningText: "",
+      expiresAtMs: Date.now() + 60_000,
+      preResolvedDecision: undefined,
+      initiatingSurface: "origin",
+      sentApproverDms: false,
+      unavailableReason: null,
+    });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: false,
+      deniedReason: "user-denied",
+    });
+
+    const result = await executeNodeHostCommand(createNodeHostRequest({ ask: "always" }));
+
+    expect(result.details).toMatchObject({
+      status: "failed",
+      timedOut: false,
+    });
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining("Exec denied (node=node-1 id=approval-denied, user-denied)"),
+      },
+    ]);
+    expect(callGatewayToolMock).not.toHaveBeenCalledWith(
+      "node.invoke",
+      expect.anything(),
+      expect.objectContaining({ command: "system.run" }),
+      expect.anything(),
+    );
+  });
+
   it.each([
     { name: "an already-rejected approval", delayed: false },
     { name: "an approval cancelled after the pending result", delayed: true },

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -887,6 +887,48 @@ describe("executeNodeHostCommand", () => {
     );
   });
 
+  it("returns a structured failure when process-local node approval resolution fails", async () => {
+    hasLocalExecApprovalHostMock.mockReturnValue(true);
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue(undefined);
+    createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
+      approvalId: "approval-failed",
+      approvalSlug: "slug-failed",
+      warningText: "",
+      expiresAtMs: Date.now() + 60_000,
+      preResolvedDecision: undefined,
+      initiatingSurface: "origin",
+      sentApproverDms: false,
+      unavailableReason: null,
+    });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+
+    const result = await executeNodeHostCommand(createNodeHostRequest({ ask: "always" }));
+
+    expect(result.details).toMatchObject({
+      status: "failed",
+      timedOut: false,
+    });
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining(
+          "Exec denied (node=node-1 id=approval-failed, approval-request-failed)",
+        ),
+      },
+    ]);
+    expect(callGatewayToolMock).not.toHaveBeenCalledWith(
+      "node.invoke",
+      expect.anything(),
+      expect.objectContaining({ command: "system.run" }),
+      expect.anything(),
+    );
+  });
+
   it.each([
     { name: "an already-rejected approval", delayed: false },
     { name: "an approval cancelled after the pending result", delayed: true },

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -1607,15 +1607,25 @@ describe("executeNodeHostCommand", () => {
       deniedReason: null,
     });
 
-    await expect(
-      executeNodeHostCommand(
-        createNodeHostRequest({
-          ask: "always",
-          trigger: "cron",
-        }),
-      ),
-    ).rejects.toThrow("denied");
+    const result = await executeNodeHostCommand(
+      createNodeHostRequest({
+        ask: "always",
+        trigger: "cron",
+      }),
+    );
 
+    expect(result.details).toMatchObject({
+      status: "failed",
+      timedOut: true,
+    });
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: expect.stringContaining(
+          "Exec denied (node=node-1 id=approval-1, approval-timeout: policy-unavailable)",
+        ),
+      },
+    ]);
     expect(resolveExecHostApprovalContextMock).toHaveBeenCalledTimes(2);
     expect(
       callGatewayToolMock.mock.calls.some(

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -222,6 +222,9 @@ const enforceStrictInlineEvalApprovalBoundaryMock = vi.hoisted(() =>
 const registerExecApprovalRequestForHostOrThrowMock = vi.hoisted(() =>
   vi.fn(async () => undefined),
 );
+const registerResolvedLocalExecApprovalForHostOrThrowMock = vi.hoisted(() =>
+  vi.fn(async () => ({ finalDecision: "allow-once" })),
+);
 const hasLocalExecApprovalHostMock = vi.hoisted(() => vi.fn(() => false));
 const detectInterpreterInlineEvalArgvMock = vi.hoisted(() =>
   vi.fn(
@@ -276,6 +279,8 @@ vi.mock("./bash-tools.exec-approval-request.js", () => ({
   hasLocalExecApprovalHost: hasLocalExecApprovalHostMock,
   isExecApprovalRunAbortedError: (error: unknown) => error === runAbortedApprovalError,
   registerExecApprovalRequestForHostOrThrow: registerExecApprovalRequestForHostOrThrowMock,
+  registerResolvedLocalExecApprovalForHostOrThrow:
+    registerResolvedLocalExecApprovalForHostOrThrowMock,
 }));
 
 vi.mock("./bash-tools.exec-host-shared.js", () => ({
@@ -1923,6 +1928,43 @@ describe("executeNodeHostCommand", () => {
       { id: expect.any(String), decision: "allow-once" },
       { scopes: ["operator.approvals"], requireAgentRuntimeIdentity: true },
     );
+  });
+
+  it("keeps node auto-review settlement on the process-local authority", async () => {
+    hasLocalExecApprovalHostMock.mockReturnValue(true);
+    const autoReviewer = vi.fn<ExecAutoReviewer>(async () => ({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "safe read",
+    }));
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "on-miss",
+      askFallback: "deny",
+    });
+    requiresExecApprovalMock.mockImplementation(
+      (params?: { allowlistSatisfied?: boolean; durableApprovalSatisfied?: boolean }) =>
+        params?.allowlistSatisfied !== true && params?.durableApprovalSatisfied !== true,
+    );
+
+    const result = await executeNodeHostCommand(
+      createNodeHostRequest({
+        security: "allowlist",
+        ask: "on-miss",
+        autoReview: true,
+        autoReviewer,
+      }),
+    );
+
+    expect(result.details?.status).toBe("completed");
+    expect(registerResolvedLocalExecApprovalForHostOrThrowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ host: "node" }),
+      "allow-once",
+    );
+    expect(
+      callGatewayToolMock.mock.calls.some(([method]) => method === "exec.approval.resolve"),
+    ).toBe(false);
   });
 
   it("does not invoke the node after cancellation wins during auto-review", async () => {

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -222,6 +222,7 @@ const enforceStrictInlineEvalApprovalBoundaryMock = vi.hoisted(() =>
 const registerExecApprovalRequestForHostOrThrowMock = vi.hoisted(() =>
   vi.fn(async () => undefined),
 );
+const hasLocalExecApprovalHostMock = vi.hoisted(() => vi.fn(() => false));
 const detectInterpreterInlineEvalArgvMock = vi.hoisted(() =>
   vi.fn(
     (): {
@@ -272,6 +273,7 @@ vi.mock("../infra/system-run-approval-context.js", () => ({
 vi.mock("./bash-tools.exec-approval-request.js", () => ({
   buildExecApprovalRequesterContext: vi.fn(() => ({})),
   buildExecApprovalTurnSourceContext: vi.fn(() => ({})),
+  hasLocalExecApprovalHost: hasLocalExecApprovalHostMock,
   isExecApprovalRunAbortedError: (error: unknown) => error === runAbortedApprovalError,
   registerExecApprovalRequestForHostOrThrow: registerExecApprovalRequestForHostOrThrowMock,
 }));
@@ -669,6 +671,8 @@ describe("executeNodeHostCommand", () => {
     detectInterpreterInlineEvalArgvMock.mockReset();
     detectInterpreterInlineEvalArgvMock.mockReturnValue(null);
     registerExecApprovalRequestForHostOrThrowMock.mockReset();
+    hasLocalExecApprovalHostMock.mockReset();
+    hasLocalExecApprovalHostMock.mockReturnValue(false);
   });
 
   it("returns outcome-unknown for an ambiguous direct node timeout", async () => {
@@ -798,6 +802,44 @@ describe("executeNodeHostCommand", () => {
     });
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
     expect(registerExecApprovalRequestForHostOrThrowMock).not.toHaveBeenCalled();
+  });
+
+  it("waits inline for a process-local node approval host", async () => {
+    hasLocalExecApprovalHostMock.mockReturnValue(true);
+    createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
+      approvalId: "approval-1",
+      approvalSlug: "slug-1",
+      warningText: "",
+      expiresAtMs: Date.now() + 60_000,
+      preResolvedDecision: undefined,
+      initiatingSurface: "origin",
+      sentApproverDms: false,
+      unavailableReason: null,
+    });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+
+    const result = await executeNodeHostCommand(createNodeHostRequest({ ask: "always" }));
+
+    expect(result.details?.status).not.toBe("approval-pending");
+    expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledOnce();
+    expect(buildExecApprovalPendingToolResultMock).not.toHaveBeenCalled();
+    expect(
+      callGatewayToolMock.mock.calls.some(
+        ([method, , params]) =>
+          method === "node.invoke" &&
+          (params as MockNodeInvokeParams | undefined)?.command === "system.run",
+      ),
+    ).toBe(true);
   });
 
   it.each([

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -21,6 +21,7 @@ import {
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
 import {
+  formatNodeExecApprovalDeniedToolResult,
   formatNodeInvokeFailureFollowup,
   formatNodeInvokeFailureToolResult,
   invokeNodeSystemRun,
@@ -409,15 +410,13 @@ export async function executeNodeHostCommand(
           requiresAutoReviewHumanApproval: autoReviewRequiresHumanApproval,
         });
         if (strictInlineEvalDecision.deniedReason || !strictInlineEvalDecision.approvedByAsk) {
-          throw new Error(
-            execHostShared.buildHeadlessExecApprovalDeniedMessage({
-              trigger: params.trigger,
-              host: "node",
-              security: currentFallback?.hostSecurity ?? hostSecurity,
-              ask: currentFallback?.hostAsk ?? hostAsk,
-              askFallback: currentFallback?.askFallback ?? askFallback,
-            }),
-          );
+          return formatNodeExecApprovalDeniedToolResult({
+            nodeId: target.nodeId,
+            approvalId,
+            deniedReason: strictInlineEvalDecision.deniedReason ?? "approval-required",
+            command: params.command,
+            cwd: params.workdir,
+          });
         }
         inlineApprovedByAsk = strictInlineEvalDecision.approvedByAsk;
         inlineApprovalSource = inlineDecision === null ? "ask-fallback" : undefined;

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -367,15 +367,13 @@ export async function executeNodeHostCommand(
           : preResolvedDecision;
       params.signal?.throwIfAborted();
       if (localApprovalHost && inlineDecision === undefined) {
-        throw new Error(
-          execHostShared.buildHeadlessExecApprovalDeniedMessage({
-            trigger: params.trigger,
-            host: "node",
-            security: hostSecurity,
-            ask: hostAsk,
-            askFallback,
-          }),
-        );
+        return formatNodeExecApprovalDeniedToolResult({
+          nodeId: target.nodeId,
+          approvalId,
+          deniedReason: "approval-request-failed",
+          command: params.command,
+          cwd: params.workdir,
+        });
       }
       if (
         localApprovalHost ||

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -22,6 +22,7 @@ import { formatExecApprovalContinuationSourceOutput } from "./bash-tools.exec-ap
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
+  hasLocalExecApprovalHost,
   isExecApprovalRunAbortedError,
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
@@ -413,10 +414,32 @@ export async function executeNodeHostCommand(
         ...requestArgs,
         register: registerNodeApproval,
       });
+      const localApprovalHost = hasLocalExecApprovalHost();
+      const inlineDecision =
+        localApprovalHost && preResolvedDecision === undefined
+          ? await execHostShared.resolveApprovalDecisionOrUndefined({
+              approvalId,
+              preResolvedDecision,
+              onFailure: () => undefined,
+            })
+          : preResolvedDecision;
+      params.signal?.throwIfAborted();
+      if (localApprovalHost && inlineDecision === undefined) {
+        throw new Error(
+          execHostShared.buildHeadlessExecApprovalDeniedMessage({
+            trigger: params.trigger,
+            host: "node",
+            security: hostSecurity,
+            ask: hostAsk,
+            askFallback,
+          }),
+        );
+      }
       if (
+        localApprovalHost ||
         execHostShared.shouldResolveExecApprovalUnavailableInline({
           unavailableReason,
-          preResolvedDecision,
+          preResolvedDecision: inlineDecision,
         })
       ) {
         const {
@@ -424,7 +447,7 @@ export async function executeNodeHostCommand(
           approvedByAsk: initialApprovedByAsk,
           deniedReason: initialDeniedReason,
         } = execHostShared.createExecApprovalDecisionState({
-          decision: preResolvedDecision,
+          decision: inlineDecision,
           askFallback,
         });
         let approvedByAsk = initialApprovedByAsk;
@@ -456,7 +479,7 @@ export async function executeNodeHostCommand(
           );
         }
         inlineApprovedByAsk = strictInlineEvalDecision.approvedByAsk;
-        inlineApprovalSource = preResolvedDecision === null ? "ask-fallback" : undefined;
+        inlineApprovalSource = inlineDecision === null ? "ask-fallback" : undefined;
         if (inlineApprovalSource) {
           inlineDispatchAuthority = "ask-fallback";
           inlineFallbackPolicy = currentFallback ?? undefined;
@@ -465,9 +488,11 @@ export async function executeNodeHostCommand(
         }
         inlineApprovalDecision = inlineApprovalSource
           ? null
-          : strictInlineEvalDecision.approvedByAsk
-            ? "allow-once"
-            : null;
+          : inlineDecision === "allow-always"
+            ? "allow-always"
+            : strictInlineEvalDecision.approvedByAsk
+              ? "allow-once"
+              : null;
         inlineApprovalId = approvalId;
       } else {
         const followupTarget = execHostShared.buildExecApprovalFollowupTarget({

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -1,12 +1,6 @@
-/**
- * Node-host exec orchestration.
- * Combines local policy, remote node policy, auto-review, approval follow-ups,
- * and `node.invoke system.run` execution for host=node calls.
- */
 import { randomUUID } from "node:crypto";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "../gateway/operator-scopes.js";
 import {
-  type ExecAsk,
   type ExecSecurity,
   maxAsk,
   minSecurity,
@@ -40,6 +34,11 @@ import {
   resolveNodeExecutionTarget,
   shouldSkipNodeApprovalPrepare,
 } from "./bash-tools.exec-host-node-phases.js";
+import {
+  assertCurrentNodeGatewayPolicyAllowsDispatch,
+  type NodeGatewayDispatchAuthority,
+  type NodeGatewayPolicyCheckpoint,
+} from "./bash-tools.exec-host-node-policy.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
 import * as execHostShared from "./bash-tools.exec-host-shared.js";
 import { createApprovalSlug } from "./bash-tools.exec-runtime.js";
@@ -50,65 +49,7 @@ import { callGatewayTool } from "./tools/gateway.js";
 
 const APPROVED_NODE_INVOKE_SCOPES = [WRITE_SCOPE, APPROVALS_SCOPE];
 
-type NodeGatewayDispatchAuthority =
-  | "current-policy"
-  | "human-approval"
-  | "auto-review"
-  | "ask-fallback";
-
-type NodeGatewayPolicyCheckpoint = {
-  hostSecurity: ExecSecurity;
-  hostAsk: ExecAsk;
-  askFallback: ExecSecurity;
-};
-
-async function assertCurrentNodeGatewayPolicyAllowsDispatch(params: {
-  request: ExecuteNodeHostCommandParams;
-  authority: NodeGatewayDispatchAuthority;
-  currentPolicyAllows?: (policy: { hostSecurity: ExecSecurity; hostAsk: ExecAsk }) => boolean;
-  fallbackPolicy?: NodeGatewayPolicyCheckpoint;
-}): Promise<void> {
-  const current = await execHostShared.resolveExecHostApprovalContext({
-    agentId: params.request.agentId,
-    security: params.request.security,
-    ask: params.request.ask,
-    host: "node",
-  });
-  // A human grant may bypass ask/allowlist, but never a later deny. Auto-review
-  // additionally cannot stand in for a newly required human decision.
-  if (current.hostSecurity === "deny") {
-    throw new Error("exec denied: host=node security=deny");
-  }
-  if (params.authority === "human-approval") {
-    return;
-  }
-  if (params.authority === "auto-review") {
-    if (current.hostAsk === "always") {
-      throw new Error("exec denied: host=node ask=always requires human approval");
-    }
-    return;
-  }
-  if (params.authority === "ask-fallback") {
-    const expected = params.fallbackPolicy;
-    if (
-      !expected ||
-      current.hostSecurity !== expected.hostSecurity ||
-      current.hostAsk !== expected.hostAsk ||
-      current.askFallback !== expected.askFallback
-    ) {
-      throw new Error("exec denied: host=node fallback policy changed before dispatch");
-    }
-    return;
-  }
-  if (!params.currentPolicyAllows?.(current)) {
-    throw new Error("exec denied: host=node policy changed before dispatch");
-  }
-}
-
-/**
- * Executes a command on a remote node, requesting approval when policy requires it.
- * Node-host approval combines caller policy and remote node approval snapshots.
- */
+/** Executes a remote node command under combined caller and node approval policy. */
 export async function executeNodeHostCommand(
   params: ExecuteNodeHostCommandParams,
 ): Promise<AgentToolResult<ExecToolDetails>> {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -19,6 +19,7 @@ import {
   hasLocalExecApprovalHost,
   isExecApprovalRunAbortedError,
   registerExecApprovalRequestForHostOrThrow,
+  registerResolvedLocalExecApprovalForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
 import {
   formatNodeExecApprovalDeniedToolResult,
@@ -311,16 +312,40 @@ export async function executeNodeHostCommand(
       const autoReviewAllowed = decision.decision === "allow-once" && decision.risk === "low";
       if (autoReviewAllowed) {
         const approvalId = randomUUID();
-        await registerNodeApproval(approvalId, {
-          requireDeliveryRoute: false,
-          suppressDelivery: true,
-        });
-        await callGatewayTool(
-          "exec.approval.resolve",
-          { timeoutMs: 15_000 },
-          { id: approvalId, decision: "allow-once" },
-          { scopes: [APPROVALS_SCOPE], requireAgentRuntimeIdentity: true },
-        );
+        if (hasLocalExecApprovalHost()) {
+          await registerResolvedLocalExecApprovalForHostOrThrow(
+            {
+              approvalId,
+              systemRunPlan: prepared.plan,
+              env: target.env,
+              workdir: prepared.cwd,
+              host: "node",
+              nodeId: target.nodeId,
+              toolCallId: params.toolCallId,
+              security: hostSecurity,
+              ask: hostAsk,
+              ...unavailableDecisionRequestParams,
+              commandHighlighting: params.commandHighlighting,
+              ...buildExecApprovalRequesterContext({
+                agentId: prepared.agentId,
+                sessionKey: prepared.sessionKey,
+              }),
+              ...buildExecApprovalTurnSourceContext(params),
+            },
+            "allow-once",
+          );
+        } else {
+          await registerNodeApproval(approvalId, {
+            requireDeliveryRoute: false,
+            suppressDelivery: true,
+          });
+          await callGatewayTool(
+            "exec.approval.resolve",
+            { timeoutMs: 15_000 },
+            { id: approvalId, decision: "allow-once" },
+            { scopes: [APPROVALS_SCOPE], requireAgentRuntimeIdentity: true },
+          );
+        }
         inlineApprovedByAsk = true;
         inlineApprovalDecision = "allow-once";
         inlineApprovalId = approvalId;

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -20,6 +20,7 @@ import type { ExecApprovalContinuationPromptRange } from "../bash-tools.exec-app
 import type { ExecElevatedDefaults } from "../bash-tools.exec-types.js";
 import type { BootstrapContextRunKind } from "../bootstrap-mode.js";
 import type { CliSessionBindingFacts } from "../cli-runner/types.js";
+import type { LocalExecApprovalRequest } from "../local-exec-approval-broker.js";
 import type { MainSessionRecoveryOwnerLease } from "../main-session-recovery-store.js";
 import type { ScheduledToolPolicyContext } from "../scheduled-tool-policy.js";
 import type { TrustedSubagentCompletionHandoff } from "../subagent-announce-handoff.js";
@@ -106,6 +107,11 @@ export type AgentCommandOpts = {
   runContext?: AgentRunContext;
   /** Device-scoped operator session allowed to review approvals initiated by this run. */
   approvalReviewerDeviceId?: string;
+  /** Process-local host callback for exec approvals initiated by this run. */
+  localExecApprovalHandler?: (
+    request: LocalExecApprovalRequest,
+    signal: AbortSignal,
+  ) => Promise<"allow-once" | "allow-always" | "deny" | null>;
   /** Internal trusted exec approval follow-up elevated defaults. */
   bashElevated?: ExecElevatedDefaults;
   /** Trusted span whose final cap is resolved with the selected model. */

--- a/src/agents/local-exec-approval-broker.test.ts
+++ b/src/agents/local-exec-approval-broker.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getLocalExecApprovalBroker,
+  runWithLocalExecApprovalHandler,
+  type LocalExecApprovalRequest,
+} from "./local-exec-approval-broker.js";
+
+function approvalRequest(id: string) {
+  return {
+    id,
+    command: "buzz messages send",
+    host: "gateway" as const,
+    security: "allowlist" as const,
+    ask: "on-miss" as const,
+    timeoutMs: 1_000,
+  };
+}
+
+describe("LocalExecApprovalBroker", () => {
+  it("preserves the two-phase registration contract", async () => {
+    const requestApproval = vi.fn(async () => "allow-once" as const);
+    await runWithLocalExecApprovalHandler({
+      handler: requestApproval,
+      run: async () => {
+        const broker = getLocalExecApprovalBroker();
+        expect(broker).toBeDefined();
+        const registration = broker?.register(approvalRequest("approval-1"));
+
+        expect(registration).toMatchObject({ id: "approval-1" });
+        await expect(broker?.wait("approval-1")).resolves.toBe("allow-once");
+        await expect(broker?.wait("approval-1")).resolves.toBeUndefined();
+      },
+    });
+    expect(requestApproval).toHaveBeenCalledWith(
+      {
+        ...approvalRequest("approval-1"),
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+      },
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("rejects duplicate pending approval ids", async () => {
+    await runWithLocalExecApprovalHandler({
+      handler: async () => "deny",
+      run: async () => {
+        const broker = getLocalExecApprovalBroker();
+        broker?.register(approvalRequest("approval-1"));
+
+        expect(() => broker?.register(approvalRequest("approval-1"))).toThrow(
+          'Exec approval "approval-1" is already pending',
+        );
+      },
+    });
+  });
+
+  it("scopes brokers to the owning async execution", async () => {
+    expect(getLocalExecApprovalBroker()).toBeUndefined();
+    await runWithLocalExecApprovalHandler({
+      handler: async () => "deny",
+      run: async () => {
+        const outer = getLocalExecApprovalBroker();
+        expect(outer).toBeDefined();
+        await runWithLocalExecApprovalHandler({
+          handler: async () => "allow-once",
+          run: async () => {
+            await Promise.resolve();
+            expect(getLocalExecApprovalBroker()).not.toBe(outer);
+          },
+        });
+        expect(getLocalExecApprovalBroker()).toBe(outer);
+      },
+    });
+    expect(getLocalExecApprovalBroker()).toBeUndefined();
+  });
+
+  it("owns timeout and cancellation even when the host handler does not settle", async () => {
+    const controller = new AbortController();
+    await runWithLocalExecApprovalHandler({
+      handler: async () => await new Promise<never>(() => {}),
+      signal: controller.signal,
+      run: async () => {
+        const broker = getLocalExecApprovalBroker();
+        broker?.register({ ...approvalRequest("approval-1"), timeoutMs: 5 });
+        await expect(broker?.wait("approval-1")).resolves.toBeNull();
+
+        broker?.register(approvalRequest("approval-2"));
+        controller.abort(new Error("turn cancelled"));
+        await expect(broker?.wait("approval-2")).resolves.toBeNull();
+      },
+    });
+  });
+
+  it("rejects allow-always when ask policy permits one-shot approval only", async () => {
+    await runWithLocalExecApprovalHandler({
+      handler: async () => "allow-always",
+      run: async () => {
+        const broker = getLocalExecApprovalBroker();
+        broker?.register({ ...approvalRequest("approval-1"), ask: "always" });
+        await expect(broker?.wait("approval-1")).resolves.toBe("deny");
+      },
+    });
+  });
+
+  it("rejects decisions explicitly unavailable for the request", async () => {
+    await runWithLocalExecApprovalHandler({
+      handler: async () => "allow-always",
+      run: async () => {
+        const broker = getLocalExecApprovalBroker();
+        broker?.register({
+          ...approvalRequest("approval-1"),
+          unavailableDecisions: ["allow-always"],
+        });
+        await expect(broker?.wait("approval-1")).resolves.toBe("deny");
+      },
+    });
+  });
+
+  it("projects secrets and spoofable display text out of host requests", async () => {
+    const projectedRequests: LocalExecApprovalRequest[] = [];
+    const requestApproval = vi.fn(async (request: LocalExecApprovalRequest) => {
+      projectedRequests.push(request);
+      return "deny" as const;
+    });
+    await runWithLocalExecApprovalHandler({
+      handler: requestApproval,
+      run: async () => {
+        const broker = getLocalExecApprovalBroker();
+        broker?.register({
+          ...approvalRequest("approval-1"),
+          command: "echo sk-abc123\u200B456789012345678",
+          commandArgv: ["echo", "must-not-leak"],
+          env: {
+            BUZZ_PRIVATE_KEY: "must-not-leak",
+            SAFE: "visible-only-as-a-key",
+          },
+          warningText: "review\u2028sk-abc123456789012345678",
+          systemRunPlan: {
+            argv: ["echo", "must-not-leak"],
+            cwd: "/tmp",
+            commandText: "must-not-leak",
+            commandPreview: "must-not-leak",
+            agentId: "main",
+            sessionKey: "agent:main:test",
+          },
+        });
+        await broker?.wait("approval-1");
+      },
+    });
+
+    const projected = projectedRequests[0];
+    expect(projected).toMatchObject({
+      envKeys: ["BUZZ_PRIVATE_KEY", "SAFE"],
+      warningText: expect.stringContaining("\n"),
+    });
+    expect(JSON.stringify(projected)).not.toContain("must-not-leak");
+    expect(JSON.stringify(projected)).not.toContain("sk-abc123");
+    expect(projected?.command).not.toContain("\u200B");
+    expect(projected?.warningText).not.toContain("\u2028");
+    expect(projected).not.toHaveProperty("env");
+    expect(projected).not.toHaveProperty("commandArgv");
+    expect(projected).not.toHaveProperty("systemRunPlan");
+  });
+
+  it("rejects approvals registered through retained async context after the turn settles", async () => {
+    const requestApproval = vi.fn(async () => "deny" as const);
+    let resolveLateRegistration: (error: unknown) => void = () => {};
+    const lateRegistration = new Promise<unknown>((resolve) => {
+      resolveLateRegistration = resolve;
+    });
+    await runWithLocalExecApprovalHandler({
+      handler: requestApproval,
+      run: async () => {
+        setImmediate(() => {
+          try {
+            getLocalExecApprovalBroker()?.register(approvalRequest("approval-late"));
+            resolveLateRegistration(undefined);
+          } catch (error) {
+            resolveLateRegistration(error);
+          }
+        });
+      },
+    });
+
+    await expect(lateRegistration).resolves.toMatchObject(
+      new Error('Exec approval "approval-late" rejected because its local scope ended'),
+    );
+    expect(requestApproval).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/local-exec-approval-broker.test.ts
+++ b/src/agents/local-exec-approval-broker.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  ExecApprovalRunAbortedError,
   getLocalExecApprovalBroker,
   runWithLocalExecApprovalHandler,
   type LocalExecApprovalRequest,
@@ -74,7 +75,7 @@ describe("LocalExecApprovalBroker", () => {
     expect(getLocalExecApprovalBroker()).toBeUndefined();
   });
 
-  it("owns timeout and cancellation even when the host handler does not settle", async () => {
+  it("distinguishes timeout from cancellation when the host handler does not settle", async () => {
     const controller = new AbortController();
     await runWithLocalExecApprovalHandler({
       handler: async () => await new Promise<never>(() => {}),
@@ -86,7 +87,9 @@ describe("LocalExecApprovalBroker", () => {
 
         broker?.register(approvalRequest("approval-2"));
         controller.abort(new Error("turn cancelled"));
-        await expect(broker?.wait("approval-2")).resolves.toBeNull();
+        await expect(broker?.wait("approval-2")).rejects.toBeInstanceOf(
+          ExecApprovalRunAbortedError,
+        );
       },
     });
   });

--- a/src/agents/local-exec-approval-broker.test.ts
+++ b/src/agents/local-exec-approval-broker.test.ts
@@ -141,6 +141,25 @@ describe("LocalExecApprovalBroker", () => {
     });
   });
 
+  it("keeps authorization policy private from host mutation", async () => {
+    await runWithLocalExecApprovalHandler({
+      handler: async (request) => {
+        expect(Object.isFrozen(request.allowedDecisions)).toBe(true);
+        try {
+          (request.allowedDecisions as Array<"allow-once" | "allow-always" | "deny">).push(
+            "allow-always",
+          );
+        } catch {}
+        return "allow-always";
+      },
+      run: async () => {
+        const broker = getLocalExecApprovalBroker();
+        broker?.register({ ...approvalRequest("approval-1"), ask: "always" });
+        await expect(broker?.wait("approval-1")).resolves.toBe("deny");
+      },
+    });
+  });
+
   it("projects secrets and spoofable display text out of host requests", async () => {
     const projectedRequests: LocalExecApprovalRequest[] = [];
     const requestApproval = vi.fn(async (request: LocalExecApprovalRequest) => {

--- a/src/agents/local-exec-approval-broker.test.ts
+++ b/src/agents/local-exec-approval-broker.test.ts
@@ -94,6 +94,28 @@ describe("LocalExecApprovalBroker", () => {
     });
   });
 
+  it("rejects a handler decision that settles after the absolute deadline", async () => {
+    let resolveDecision: (decision: "allow-once") => void = () => {};
+    const decision = new Promise<"allow-once">((resolve) => {
+      resolveDecision = resolve;
+    });
+    const now = vi.spyOn(Date, "now").mockReturnValue(100);
+    try {
+      await runWithLocalExecApprovalHandler({
+        handler: async () => await decision,
+        run: async () => {
+          const broker = getLocalExecApprovalBroker();
+          broker?.register({ ...approvalRequest("approval-1"), timeoutMs: 1_000 });
+          now.mockReturnValue(1_100);
+          resolveDecision("allow-once");
+          await expect(broker?.wait("approval-1")).resolves.toBeNull();
+        },
+      });
+    } finally {
+      now.mockRestore();
+    }
+  });
+
   it("rejects allow-always when ask policy permits one-shot approval only", async () => {
     await runWithLocalExecApprovalHandler({
       handler: async () => "allow-always",
@@ -189,5 +211,20 @@ describe("LocalExecApprovalBroker", () => {
       new Error('Exec approval "approval-late" rejected because its local scope ended'),
     );
     expect(requestApproval).not.toHaveBeenCalled();
+  });
+
+  it("rejects waits through retained async context after the turn settles", async () => {
+    let broker: ReturnType<typeof getLocalExecApprovalBroker>;
+    await runWithLocalExecApprovalHandler({
+      handler: async () => await new Promise<never>(() => {}),
+      run: async () => {
+        broker = getLocalExecApprovalBroker();
+        broker?.register(approvalRequest("approval-late-wait"));
+      },
+    });
+
+    await expect(broker?.wait("approval-late-wait")).rejects.toBeInstanceOf(
+      ExecApprovalRunAbortedError,
+    );
   });
 });

--- a/src/agents/local-exec-approval-broker.test.ts
+++ b/src/agents/local-exec-approval-broker.test.ts
@@ -41,6 +41,25 @@ describe("LocalExecApprovalBroker", () => {
     );
   });
 
+  it("settles trusted local decisions without invoking the approval handler", async () => {
+    const requestApproval = vi.fn(async () => "deny" as const);
+    await runWithLocalExecApprovalHandler({
+      handler: requestApproval,
+      run: async () => {
+        const registration = getLocalExecApprovalBroker()?.registerResolved(
+          approvalRequest("approval-1"),
+          "allow-once",
+        );
+
+        expect(registration).toMatchObject({
+          id: "approval-1",
+          finalDecision: "allow-once",
+        });
+      },
+    });
+    expect(requestApproval).not.toHaveBeenCalled();
+  });
+
   it("rejects duplicate pending approval ids", async () => {
     await runWithLocalExecApprovalHandler({
       handler: async () => "deny",

--- a/src/agents/local-exec-approval-broker.ts
+++ b/src/agents/local-exec-approval-broker.ts
@@ -89,6 +89,13 @@ type PendingApproval = {
   expiresAtMs: number;
 };
 
+export class ExecApprovalRunAbortedError extends Error {
+  constructor() {
+    super("Exec approval cancelled because its run was aborted");
+    this.name = "ExecApprovalRunAbortedError";
+  }
+}
+
 /**
  * Owns two-phase exec approvals for one process-local agent turn.
  *
@@ -154,22 +161,27 @@ class LocalExecApprovalBroker {
     };
     const expiresAtMs = Date.now() + request.timeoutMs;
     const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(new Error(`Exec approval "${request.id}" expired`)),
-      request.timeoutMs,
-    );
+    const timeoutReason = new Error(`Exec approval "${request.id}" expired`);
+    const timeout = setTimeout(() => controller.abort(timeoutReason), request.timeoutMs);
     timeout.unref?.();
     const onAbort = () => controller.abort(this.signal?.reason);
     this.signal?.addEventListener("abort", onAbort, { once: true });
     if (this.signal?.aborted) {
       onAbort();
     }
-    const aborted = new Promise<null>((resolve) => {
+    const aborted = new Promise<null>((resolve, reject) => {
+      const settleAbort = () => {
+        if (controller.signal.reason === timeoutReason) {
+          resolve(null);
+          return;
+        }
+        reject(new ExecApprovalRunAbortedError());
+      };
       if (controller.signal.aborted) {
-        resolve(null);
+        settleAbort();
         return;
       }
-      controller.signal.addEventListener("abort", () => resolve(null), { once: true });
+      controller.signal.addEventListener("abort", settleAbort, { once: true });
     });
     const decision = Promise.race([
       Promise.resolve()

--- a/src/agents/local-exec-approval-broker.ts
+++ b/src/agents/local-exec-approval-broker.ts
@@ -1,0 +1,241 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  resolveExecApprovalCommandDisplay,
+  sanitizeExecApprovalDisplayTextWithStatus,
+  sanitizeExecApprovalWarningText,
+} from "../infra/exec-approval-command-display.js";
+import { resolveExecApprovalRequestAllowedDecisions } from "../infra/exec-approvals-policy.js";
+import type {
+  ExecApprovalCommandSpan,
+  ExecApprovalDecision,
+  ExecApprovalUnavailableDecision,
+  ExecAsk,
+  ExecSecurity,
+  SystemRunApprovalPlan,
+} from "../infra/exec-approvals.js";
+import { buildSystemRunApprovalEnvBinding } from "../infra/system-run-approval-binding.js";
+
+/** Reviewer-safe request projected to a process-local approval host. */
+export type LocalExecApprovalRequest = {
+  id: string;
+  command: string;
+  commandPreview?: string;
+  envKeys?: string[];
+  cwd?: string;
+  nodeId?: string;
+  host: "gateway" | "node";
+  security: ExecSecurity;
+  ask: ExecAsk;
+  warningText?: string;
+  commandSpans?: ExecApprovalCommandSpan[];
+  unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  allowedDecisions: readonly ExecApprovalDecision[];
+  agentId?: string;
+  resolvedPath?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+  toolCallId?: string;
+  turnSourceChannel?: string;
+  turnSourceTo?: string;
+  turnSourceAccountId?: string;
+  turnSourceThreadId?: string | number;
+  timeoutMs: number;
+};
+
+type LocalExecApprovalRegistrationRequest = {
+  id: string;
+  command?: string;
+  commandArgv?: string[];
+  systemRunPlan?: SystemRunApprovalPlan;
+  env?: Record<string, string>;
+  cwd?: string;
+  nodeId?: string;
+  host: "gateway" | "node";
+  security: ExecSecurity;
+  ask: ExecAsk;
+  warningText?: string;
+  commandSpans?: ExecApprovalCommandSpan[];
+  unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
+  agentId?: string;
+  resolvedPath?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+  toolCallId?: string;
+  turnSourceChannel?: string;
+  turnSourceTo?: string;
+  turnSourceAccountId?: string;
+  turnSourceThreadId?: string | number;
+  requireDeliveryRoute?: boolean;
+  suppressDelivery?: boolean;
+  timeoutMs: number;
+};
+
+type LocalExecApprovalRegistration = {
+  id: string;
+  expiresAtMs: number;
+  finalDecision?: ExecApprovalDecision | null;
+};
+
+type LocalExecApprovalHandler = (
+  request: LocalExecApprovalRequest,
+  signal: AbortSignal,
+) => Promise<ExecApprovalDecision | null>;
+
+type PendingApproval = {
+  controller: AbortController;
+  decision: Promise<ExecApprovalDecision | null>;
+  expiresAtMs: number;
+};
+
+/**
+ * Owns two-phase exec approvals for one process-local agent turn.
+ *
+ * The existing exec engine keeps its register-then-wait contract while the
+ * launching adapter supplies the actual approval UI.
+ */
+class LocalExecApprovalBroker {
+  private readonly pending = new Map<string, PendingApproval>();
+  private active = true;
+
+  constructor(
+    private readonly requestApproval: LocalExecApprovalHandler,
+    private readonly signal?: AbortSignal,
+  ) {}
+
+  register(request: LocalExecApprovalRegistrationRequest): LocalExecApprovalRegistration {
+    if (!this.active) {
+      throw new Error(`Exec approval "${request.id}" rejected because its local scope ended`);
+    }
+    if (this.pending.has(request.id)) {
+      throw new Error(`Exec approval "${request.id}" is already pending`);
+    }
+    const commandTextSource =
+      request.command ??
+      (request.host === "node" ? (request.systemRunPlan?.commandText ?? "") : "");
+    const sanitizedCommand = sanitizeExecApprovalDisplayTextWithStatus(commandTextSource);
+    if (sanitizedCommand.truncated || sanitizedCommand.oversized) {
+      throw new Error("command exceeds exec approval display limit");
+    }
+    const commandDisplay = resolveExecApprovalCommandDisplay({
+      ...request,
+      command: commandTextSource,
+    });
+    const allowedDecisions = resolveExecApprovalRequestAllowedDecisions(request);
+    const envKeys = buildSystemRunApprovalEnvBinding(request.env).envKeys;
+    const reviewerRequest: LocalExecApprovalRequest = {
+      id: request.id,
+      command: sanitizedCommand.text,
+      ...(commandDisplay.commandPreview ? { commandPreview: commandDisplay.commandPreview } : {}),
+      ...(envKeys.length > 0 ? { envKeys } : {}),
+      cwd: request.cwd,
+      nodeId: request.nodeId,
+      host: request.host,
+      security: request.security,
+      ask: request.ask,
+      warningText: request.warningText
+        ? sanitizeExecApprovalWarningText(request.warningText)
+        : undefined,
+      commandSpans: sanitizedCommand.text === commandTextSource ? request.commandSpans : undefined,
+      unavailableDecisions: request.unavailableDecisions,
+      allowedDecisions,
+      agentId: request.agentId,
+      resolvedPath: request.resolvedPath,
+      sessionKey: request.sessionKey,
+      sessionId: request.sessionId,
+      runId: request.runId,
+      toolCallId: request.toolCallId,
+      turnSourceChannel: request.turnSourceChannel,
+      turnSourceTo: request.turnSourceTo,
+      turnSourceAccountId: request.turnSourceAccountId,
+      turnSourceThreadId: request.turnSourceThreadId,
+      timeoutMs: request.timeoutMs,
+    };
+    const expiresAtMs = Date.now() + request.timeoutMs;
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(new Error(`Exec approval "${request.id}" expired`)),
+      request.timeoutMs,
+    );
+    timeout.unref?.();
+    const onAbort = () => controller.abort(this.signal?.reason);
+    this.signal?.addEventListener("abort", onAbort, { once: true });
+    if (this.signal?.aborted) {
+      onAbort();
+    }
+    const aborted = new Promise<null>((resolve) => {
+      if (controller.signal.aborted) {
+        resolve(null);
+        return;
+      }
+      controller.signal.addEventListener("abort", () => resolve(null), { once: true });
+    });
+    const decision = Promise.race([
+      Promise.resolve()
+        .then(() => this.requestApproval(reviewerRequest, controller.signal))
+        .then((result) => {
+          if (result === null) {
+            return null;
+          }
+          // Local hosts replace Gateway transport, not Gateway policy. An
+          // excluded verdict must fail closed before exec authorization sees it.
+          return allowedDecisions.includes(result) ? result : "deny";
+        }),
+      aborted,
+    ]).finally(() => {
+      clearTimeout(timeout);
+      this.signal?.removeEventListener("abort", onAbort);
+    });
+    this.pending.set(request.id, { controller, decision, expiresAtMs });
+    void decision.catch(() => {});
+    return { id: request.id, expiresAtMs };
+  }
+
+  async wait(approvalId: string): Promise<ExecApprovalDecision | null | undefined> {
+    const pending = this.pending.get(approvalId);
+    if (!pending) {
+      return undefined;
+    }
+    try {
+      if (Date.now() >= pending.expiresAtMs) {
+        return null;
+      }
+      return await pending.decision;
+    } finally {
+      this.pending.delete(approvalId);
+    }
+  }
+
+  stop(reason: unknown = new Error("Local exec approval broker stopped")): void {
+    this.active = false;
+    for (const pending of this.pending.values()) {
+      pending.controller.abort(reason);
+    }
+    this.pending.clear();
+  }
+}
+
+const localExecApprovalBroker = new AsyncLocalStorage<LocalExecApprovalBroker>();
+
+/** Runs one agent command with adapter-owned exec approvals. */
+export async function runWithLocalExecApprovalHandler<T>(params: {
+  handler?: LocalExecApprovalHandler;
+  signal?: AbortSignal;
+  run: () => Promise<T>;
+}): Promise<T> {
+  if (!params.handler) {
+    return await params.run();
+  }
+  const broker = new LocalExecApprovalBroker(params.handler, params.signal);
+  try {
+    return await localExecApprovalBroker.run(broker, params.run);
+  } finally {
+    broker.stop();
+  }
+}
+
+/** Returns the broker attached to the current local agent execution. */
+export function getLocalExecApprovalBroker(): LocalExecApprovalBroker | undefined {
+  return localExecApprovalBroker.getStore();
+}

--- a/src/agents/local-exec-approval-broker.ts
+++ b/src/agents/local-exec-approval-broker.ts
@@ -187,6 +187,9 @@ class LocalExecApprovalBroker {
       Promise.resolve()
         .then(() => this.requestApproval(reviewerRequest, controller.signal))
         .then((result) => {
+          if (Date.now() >= expiresAtMs) {
+            return null;
+          }
           if (result === null) {
             return null;
           }
@@ -207,13 +210,20 @@ class LocalExecApprovalBroker {
   async wait(approvalId: string): Promise<ExecApprovalDecision | null | undefined> {
     const pending = this.pending.get(approvalId);
     if (!pending) {
+      if (!this.active) {
+        throw new ExecApprovalRunAbortedError();
+      }
       return undefined;
     }
     try {
       if (Date.now() >= pending.expiresAtMs) {
         return null;
       }
-      return await pending.decision;
+      const decision = await pending.decision;
+      if (!this.active) {
+        throw new ExecApprovalRunAbortedError();
+      }
+      return Date.now() >= pending.expiresAtMs ? null : decision;
     } finally {
       this.pending.delete(approvalId);
     }

--- a/src/agents/local-exec-approval-broker.ts
+++ b/src/agents/local-exec-approval-broker.ts
@@ -130,6 +130,7 @@ class LocalExecApprovalBroker {
       command: commandTextSource,
     });
     const allowedDecisions = resolveExecApprovalRequestAllowedDecisions(request);
+    const allowedDecisionSet = new Set(allowedDecisions);
     const envKeys = buildSystemRunApprovalEnvBinding(request.env).envKeys;
     const reviewerRequest: LocalExecApprovalRequest = {
       id: request.id,
@@ -146,7 +147,7 @@ class LocalExecApprovalBroker {
         : undefined,
       commandSpans: sanitizedCommand.text === commandTextSource ? request.commandSpans : undefined,
       unavailableDecisions: request.unavailableDecisions,
-      allowedDecisions,
+      allowedDecisions: Object.freeze([...allowedDecisions]),
       agentId: request.agentId,
       resolvedPath: request.resolvedPath,
       sessionKey: request.sessionKey,
@@ -195,7 +196,7 @@ class LocalExecApprovalBroker {
           }
           // Local hosts replace Gateway transport, not Gateway policy. An
           // excluded verdict must fail closed before exec authorization sees it.
-          return allowedDecisions.includes(result) ? result : "deny";
+          return allowedDecisionSet.has(result) ? result : "deny";
         }),
       aborted,
     ]).finally(() => {

--- a/src/agents/local-exec-approval-broker.ts
+++ b/src/agents/local-exec-approval-broker.ts
@@ -208,6 +208,27 @@ class LocalExecApprovalBroker {
     return { id: request.id, expiresAtMs };
   }
 
+  registerResolved(
+    request: LocalExecApprovalRegistrationRequest,
+    decision: ExecApprovalDecision,
+  ): LocalExecApprovalRegistration {
+    if (!this.active) {
+      throw new Error(`Exec approval "${request.id}" rejected because its local scope ended`);
+    }
+    if (this.pending.has(request.id)) {
+      throw new Error(`Exec approval "${request.id}" is already pending`);
+    }
+    const allowedDecisions = resolveExecApprovalRequestAllowedDecisions(request);
+    if (!allowedDecisions.includes(decision)) {
+      throw new Error(`Exec approval decision "${decision}" is unavailable for this request`);
+    }
+    return {
+      id: request.id,
+      expiresAtMs: Date.now() + request.timeoutMs,
+      finalDecision: decision,
+    };
+  }
+
   async wait(approvalId: string): Promise<ExecApprovalDecision | null | undefined> {
     const pending = this.pending.get(approvalId);
     if (!pending) {


### PR DESCRIPTION
Related: #116310

Stack: 1 of 2. The native ACP host is https://github.com/openclaw/openclaw/pull/116678.

## What Problem This Solves

OpenClaw's canonical agent loop assumes exec approvals are registered and settled through a running Gateway. A self-contained process host cannot preserve that policy without either depending on a Gateway or adding a second agent implementation.

## Contract

This PR adds a process-local approval handler to the existing agent command contract and scopes its broker with `AsyncLocalStorage`:

- `AgentCommandOpts.localExecApprovalHandler` lets an in-process host supply approval UI without replacing the agent loop
- a process-local host owns approval registration, timeout, cancellation, and settlement while its context is active
- approval expiry remains a normal no-decision result so configured timeout fallback can apply
- absolute deadlines are rechecked after the handler settles; late decisions cannot authorize execution
- turn cancellation, session interruption, and scope teardown preserve the established run-aborted outcome; they cannot become permissive timeout fallback
- the broker is bound to the lifecycle-composed run signal, not only the caller's initial signal
- raw execution data stays inside the agent engine; hosts receive a reviewer-safe projection with sanitized command/warning text and environment key names only
- raw environment values, argv, and mutable execution plans never cross the host callback boundary
- the broker keeps the canonical request-specific decision set private and gives the host a frozen projection
- host mutation cannot expand approval authority before exec authorization sees the result
- excluded host verdicts fail closed as `deny`
- retained async resources cannot register or settle approvals after the owning turn ends
- gateway and node hosts wait inline when the current turn owns a process-local approval host
- missing local approval context never falls through to a different Gateway process
- explicit local node denial or approval-resolution failure returns the same structured failed tool result as the Gateway host instead of headless-approval guidance
- callers without a local handler keep the existing Gateway behavior unchanged
- no ACP command, Gateway lifecycle, model loop, or user-facing default changes in this layer

The boundary is intentionally generic enough for an in-process host, but it is not a new agent-host framework.

## User Impact

No standalone user-visible change. This is the narrow lower layer that lets the native ACP process reuse OpenClaw's canonical agent loop and normal exec approval policy.

## Evidence

- process-local broker/request tests: 26 passed
- gateway/node process-local regressions: 4 passed
- session-interruption approval regression: 2 passed across core/support shards
- node policy regression slice: 50 passed
- focused structured local-node denial regressions: 4 passed
- final approval-policy mutation and local-resolution failure regressions: 2 passed
- exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30896269705
- exact head: `46520d8ef9f4e70e47ec4cc9d13cb2286867cb05`
- formatting, changed-file lint, typecheck, import-cycle checks, and `git diff --check`: clean
- TruffleHog pre-review scan: clean
- autoreview infrastructure blocker: the required `gpt-5.6-sol` subprocess was SIGKILLed with exit `-9` before producing findings

The final head closes the exact-review findings around detached non-native/node approvals, post-deadline authorization, late waits after broker teardown, lifecycle interruption ownership, host-mutable approval policy, and structured local-node failures.
