### PR TITLE
fix-(agent-core): strip orphaned tool_use on mid-turn abort

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1905,7 +1905,10 @@ describe("agentLoop tool termination", () => {
         execute: async () => {
           executed.push("tool_b");
           controller.abort(new Error("user stopped"));
-          return { content: [{ type: "text", text: "tool_b result" }], details: { name: "tool_b" } };
+          return {
+            content: [{ type: "text", text: "tool_b result" }],
+            details: { name: "tool_b" },
+          };
         },
       },
       makeTool("tool_c", executed),
@@ -1917,7 +1920,9 @@ describe("agentLoop tool termination", () => {
       [{ role: "user", content: "test", timestamp: 1 }],
       { systemPrompt: "", messages: [], tools },
       { ...config, toolExecution: "sequential" },
-      (event) => { events.push(event); },
+      (event) => {
+        events.push(event);
+      },
       controller.signal,
       streamFn,
     );
@@ -1937,6 +1942,30 @@ describe("agentLoop tool termination", () => {
     expect(remainingCalls.map((c) => c.name)).toEqual(["tool_a", "tool_b"]);
 
     expect(messages.at(-2)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+
+    // Boundary proof: the turn_end event consumer (persistence / session writer)
+    // must observe the cleaned context, not the pre-repair state. Before the fix
+    // orphaned tool_c was still present in the emitted message because cleanup ran
+    // after emit. Now stripOrphanedToolCalls runs first.
+    // There are two turn_end events: the tool-use turn then the aborted turn.
+    // We assert the first one — the tool-use turn — because that is the one
+    // persistence consumers snapshot.
+    const toolUseTurnEnd = events.find(
+      (e) =>
+        e.type === "turn_end" &&
+        Array.isArray((e as { message: AgentMessage }).message?.content) &&
+        (
+          (e as { message: AgentMessage }).message as { content: Array<{ type: string }> }
+        ).content.some((c) => c.type === "toolCall"),
+    );
+    expect(toolUseTurnEnd).toBeDefined();
+    const emittedCalls = (
+      (toolUseTurnEnd as { message: AgentMessage }).message as {
+        content: Array<{ type: string; name?: string }>;
+      }
+    ).content.filter((c) => c.type === "toolCall");
+    expect(emittedCalls).toHaveLength(2);
+    expect(emittedCalls.map((c) => c.name)).toEqual(["tool_a", "tool_b"]);
   });
 });
 

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1967,6 +1967,121 @@ describe("agentLoop tool termination", () => {
     expect(emittedCalls).toHaveLength(2);
     expect(emittedCalls.map((c) => c.name)).toEqual(["tool_a", "tool_b"]);
   });
+
+  it("strips orphaned tool_use from context.messages on parallel abort (#116379)", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const executed: string[] = [];
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "p-call-a", name: "p_tool_a", arguments: {} },
+          { type: "toolCall", id: "p-call-b", name: "p_tool_b", arguments: {} },
+          { type: "toolCall", id: "p-call-c", name: "p_tool_c", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const tools: AgentTool[] = [
+      {
+        name: "p_tool_a",
+        label: "p_tool_a",
+        description: "First parallel tool",
+        parameters: Type.Object({}, { additionalProperties: false }),
+        execute: async () => {
+          executed.push("p_tool_a");
+          return {
+            content: [{ type: "text", text: "a done" }],
+            details: {},
+          };
+        },
+      },
+      {
+        name: "p_tool_b",
+        label: "p_tool_b",
+        description: "Aborts during preparation so tool_c is never dispatched",
+        parameters: Type.Object({}, { additionalProperties: false }),
+        prepareArguments: (toolCall) => {
+          controller.abort(new Error("user stopped"));
+          return toolCall;
+        },
+        execute: async () => {
+          executed.push("p_tool_b");
+          return {
+            content: [{ type: "text", text: "b done" }],
+            details: {},
+          };
+        },
+      },
+      {
+        name: "p_tool_c",
+        label: "p_tool_c",
+        description: "Should be skipped by abort",
+        parameters: Type.Object({}, { additionalProperties: false }),
+        execute: async () => {
+          throw new Error("p_tool_c should never execute");
+        },
+      },
+    ];
+
+    const events: AgentEvent[] = [];
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "abort parallel", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools },
+      { ...config, toolExecution: "parallel" },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    // When prepareArguments triggers abort, executePreparedToolCall returns
+    // "Operation aborted" before calling execute() for every dispatched call.
+    // tool_c was never dispatched, so it has no tool_result — the orphan our
+    // cleanup strips.
+    expect(executed).not.toContain("p_tool_c");
+    expect(streamCalls).toBe(1);
+
+    // The assistant message should have p_tool_c stripped
+    const assistantMsg = messages.findLast(
+      (m) => m.role === "assistant" && m.stopReason !== "aborted",
+    );
+    expect(assistantMsg).toBeDefined();
+    const remainingCalls = (assistantMsg as AssistantMessage).content.filter(
+      (c) => c.type === "toolCall",
+    );
+    expect(remainingCalls).toHaveLength(2);
+    expect(remainingCalls.map((c) => c.name).toSorted()).toEqual(["p_tool_a", "p_tool_b"]);
+
+    // The turn_end event consumer must also see only the completed calls
+    const toolUseTurnEnd = events.find(
+      (e) =>
+        e.type === "turn_end" &&
+        Array.isArray((e as { message: AgentMessage }).message?.content) &&
+        (
+          (e as { message: AgentMessage }).message as { content: Array<{ type: string }> }
+        ).content.some((c) => c.type === "toolCall"),
+    );
+    expect(toolUseTurnEnd).toBeDefined();
+    const emittedCalls = (
+      (toolUseTurnEnd as { message: AgentMessage }).message as {
+        content: Array<{ type: string; name?: string }>;
+      }
+    ).content.filter((c) => c.type === "toolCall");
+    expect(emittedCalls).toHaveLength(2);
+    expect(emittedCalls.map((c) => c.name).toSorted()).toEqual(["p_tool_a", "p_tool_b"]);
+
+    expect(messages.at(-2)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+  });
 });
 
 describe("Agent next-turn preparation", () => {

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1943,6 +1943,16 @@ describe("agentLoop tool termination", () => {
 
     expect(messages.at(-2)).toMatchObject({ role: "assistant", stopReason: "aborted" });
 
+    // Invariant: every remaining tool_use must have a matching tool_result.
+    const resultIds = new Set(
+      messages
+        .filter((m) => m.role === "toolResult")
+        .map((m) => (m as Extract<AgentMessage, { role: "toolResult" }>).toolCallId),
+    );
+    for (const call of remainingCalls) {
+      expect(resultIds.has(call.id)).toBe(true);
+    }
+
     // Boundary proof: the turn_end event consumer (persistence / session writer)
     // must observe the cleaned context, not the pre-repair state. Before the fix
     // orphaned tool_c was still present in the emitted message because cleanup ran
@@ -2079,6 +2089,16 @@ describe("agentLoop tool termination", () => {
     ).content.filter((c) => c.type === "toolCall");
     expect(emittedCalls).toHaveLength(2);
     expect(emittedCalls.map((c) => c.name).toSorted()).toEqual(["p_tool_a", "p_tool_b"]);
+
+    // Every remaining tool_use must have a matching tool_result.
+    const pResultIds = new Set(
+      messages
+        .filter((m) => m.role === "toolResult")
+        .map((m) => (m as Extract<AgentMessage, { role: "toolResult" }>).toolCallId),
+    );
+    for (const call of remainingCalls) {
+      expect(pResultIds.has(call.id)).toBe(true);
+    }
 
     expect(messages.at(-2)).toMatchObject({ role: "assistant", stopReason: "aborted" });
   });

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1872,6 +1872,72 @@ describe("agentLoop tool termination", () => {
     ]);
     expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
+
+  it("strips orphaned tool_use from context.messages when the run aborts mid-batch", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const executed: string[] = [];
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-a", name: "tool_a", arguments: {} },
+          { type: "toolCall", id: "call-b", name: "tool_b", arguments: {} },
+          { type: "toolCall", id: "call-c", name: "tool_c", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const tools: AgentTool[] = [
+      makeTool("tool_a", executed),
+      {
+        name: "tool_b",
+        label: "tool_b",
+        description: "tool_b",
+        parameters: Type.Object({}, { additionalProperties: false }),
+        execute: async () => {
+          executed.push("tool_b");
+          controller.abort(new Error("user stopped"));
+          return { content: [{ type: "text", text: "tool_b result" }], details: { name: "tool_b" } };
+        },
+      },
+      makeTool("tool_c", executed),
+    ];
+
+    const events: AgentEvent[] = [];
+
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "test", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools },
+      { ...config, toolExecution: "sequential" },
+      (event) => { events.push(event); },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(executed).toEqual(["tool_a", "tool_b"]);
+    expect(streamCalls).toBe(1);
+
+    // The assistant message (before the failure message) should have tool_c stripped
+    const assistantMsg = messages.findLast(
+      (m) => m.role === "assistant" && m.stopReason !== "aborted",
+    );
+    expect(assistantMsg).toBeDefined();
+    const remainingCalls = (assistantMsg as AssistantMessage).content.filter(
+      (c) => c.type === "toolCall",
+    );
+    expect(remainingCalls).toHaveLength(2);
+    expect(remainingCalls.map((c) => c.name)).toEqual(["tool_a", "tool_b"]);
+
+    expect(messages.at(-2)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+  });
 });
 
 describe("Agent next-turn preparation", () => {

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -431,9 +431,9 @@ async function runLoop(
         }
       }
 
+      stripOrphanedToolCalls(currentContext.messages);
       await emit({ type: "turn_end", message, toolResults });
       turnOpen = false;
-      stripOrphanedToolCalls(currentContext.messages);
       if (await stopIfAborted()) {
         return;
       }

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -93,6 +93,45 @@ function removeNonExecutableToolCalls(message: AssistantMessage): AssistantMessa
   return content.length === message.content.length ? message : { ...message, content };
 }
 
+/**
+ * Remove toolCall entries from the latest assistant message that have no
+ * matching toolResult. This prevents orphaned tool_use from polluting
+ * context.messages after a mid-turn abort where tool execution was skipped
+ * or partially completed.
+ *
+ * Mutates the message in-place so all array references see the fix.
+ */
+function stripOrphanedToolCalls(messages: AgentMessage[]): void {
+  const assistantIdx = messages.map((m) => m.role).lastIndexOf("assistant");
+  if (assistantIdx === -1) {
+    return;
+  }
+
+  const msg = messages[assistantIdx] as AssistantMessage;
+  const toolCalls = msg.content.filter((c): c is AgentToolCall => c.type === "toolCall");
+  if (toolCalls.length === 0) {
+    return;
+  }
+
+  const executedIds = new Set<string>();
+  for (const m of messages) {
+    if (m.role === "toolResult") {
+      executedIds.add((m as ToolResultMessage).toolCallId);
+    }
+  }
+
+  const orphanedIds = toolCalls
+    .filter((tc) => !executedIds.has(tc.id))
+    .map((tc) => tc.id);
+  if (orphanedIds.length === 0) {
+    return;
+  }
+
+  (msg as { content: unknown[] }).content = msg.content.filter(
+    (c) => !(c.type === "toolCall" && orphanedIds.includes((c as AgentToolCall).id)),
+  );
+}
+
 function ensureToolTurnIdentity(message: AssistantMessage): AssistantMessage {
   if (message.stopReason !== "toolUse" || message.responseId?.trim() || message.turnId?.trim()) {
     return message;
@@ -394,6 +433,7 @@ async function runLoop(
 
       await emit({ type: "turn_end", message, toolResults });
       turnOpen = false;
+      stripOrphanedToolCalls(currentContext.messages);
       if (await stopIfAborted()) {
         return;
       }


### PR DESCRIPTION
Description: fix #116379
## What Problem This Solves

Fixes an issue where when a user stops execution (or RPC disconnects) after
the LLM streams `tool_use` but before `tool_result` is written back, the
persisted session transcript retains orphaned `tool_use` blocks without
matching `tool_result` entries. On the next retry or continuation, strict
providers (Anthropic, Bedrock, Gemini) reject the malformed transcript,
making the session permanently unusable.

The original fix stripped orphaned tool calls from the in-memory context,
but the cleanup ran **after** `turn_end` was emitted to event consumers.
Any persistence or session writer that snapshots during `turn_end` would
still capture the pre-repair state — the fix was invisible at the boundary
that matters.

## Why This Change Was Made

The cleanup is now ordered **before** the `turn_end` publication boundary.
`stripOrphanedToolCalls` mutates the assistant message in-place on
`currentContext.messages`, and the same object reference is passed to
`emit({ type: "turn_end", message, toolResults })`. Every event consumer —
persistence writers, session recorders, transcript mirrors — now observes
the already-cleaned context.

The regression test additionally asserts that the `turn_end` event consumer
sees only the completed tool calls (`tool_a`, `tool_b`) and not the orphaned
one (`tool_c`). Before this fix, the emitted message would still contain all
three tool calls.

## User Impact

After a mid-turn abort, the persisted session transcript no longer contains
orphaned `tool_use` blocks. Retries and continuations receive a valid
transcript on every provider path. No user-visible behavior change in the
normal (non-abort) execution path.

## Evidence

Exact branch head: `211b15ddb5`

```console
$ node scripts/run-vitest.mjs run packages/agent-core/src/agent-loop.test.ts

Test Files  1 passed (1)
Tests       35 passed (35)

The focused test (strips orphaned tool_use from context.messages when the run aborts mid-batch) asserts:

orphaned tool_c is stripped from the assistant message content — only tool_a and tool_b remain (2 tool calls, down from 3);
the first turn_end event (the tool-use turn, which is the one persistence consumers snapshot) carries only tool_a and tool_b — proving the cleanup is visible at the publication boundary;
executed tools are ["tool_a", "tool_b"] — tool_c never executes;
the abort sequence preserves the aborted assistant turn at messages.at(-2) with stopReason: "aborted";
streamCalls is 1 — the model is never called after abort.
All 35 existing agent-loop tests continue to pass with no changes to
event sequence assertions.