### PR TITLE
refactor(agents): centralize local turn lifecycle ownership

### DIFF
--- a/src/agents/agent-turn-registry.test.ts
+++ b/src/agents/agent-turn-registry.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
+import { AgentTurnRegistry } from "./agent-turn-registry.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("AgentTurnRegistry", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  it("registers the handle before execution and removes it after settlement", async () => {
+    const registry = new AgentTurnRegistry<{ phase: string }, string>();
+    const gate = deferred<string>();
+    let registeredDuringExecution = false;
+    const execute = vi.fn(async () => {
+      registeredDuringExecution = registry.get("run-1") !== undefined;
+      return await gate.promise;
+    });
+
+    const handle = registry.submit({
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      state: { phase: "queued" },
+      execute,
+    });
+
+    expect(registry.get("run-1")).toBe(handle);
+    expect(execute).toHaveBeenCalledOnce();
+    expect(registeredDuringExecution).toBe(true);
+
+    gate.resolve("done");
+    await expect(handle.result).resolves.toBe("done");
+    expect(registry.get("run-1")).toBeUndefined();
+  });
+
+  it("routes only turn-owned events to the adapter", async () => {
+    const registry = new AgentTurnRegistry<Record<string, never>, void>();
+    const events: string[] = [];
+    const handle = registry.submit({
+      runId: "owned-run",
+      sessionKey: "agent:main:main",
+      state: {},
+      onEvent: (event) => events.push(`${event.runId}:${String(event.data.delta)}`),
+      execute: async () => {
+        emitAgentEvent({
+          runId: "owned-run",
+          stream: "assistant",
+          data: { delta: "owned" },
+        });
+        emitAgentEvent({
+          runId: "other-run",
+          stream: "assistant",
+          data: { delta: "ignored" },
+        });
+      },
+    });
+
+    await handle.result;
+    expect(events).toEqual(["owned-run:owned"]);
+  });
+
+  it("keeps the handle active after lifecycle end until execution settles", async () => {
+    const registry = new AgentTurnRegistry<Record<string, never>, void>();
+    const gate = deferred<void>();
+    const handle = registry.submit({
+      runId: "maintenance-run",
+      sessionKey: "agent:main:main",
+      state: {},
+      execute: async () => {
+        emitAgentEvent({
+          runId: "maintenance-run",
+          stream: "lifecycle",
+          data: { phase: "end" },
+        });
+        await gate.promise;
+      },
+    });
+
+    await vi.waitFor(() => expect(registry.get("maintenance-run")).toBe(handle));
+    expect(handle.cancel("stop maintenance")).toBe(true);
+    expect(handle.signal.aborted).toBe(true);
+    gate.resolve();
+    await handle.result;
+  });
+
+  it("cancels each handle at most once", async () => {
+    const registry = new AgentTurnRegistry<Record<string, never>, void>();
+    const gate = deferred<void>();
+    const handle = registry.submit({
+      runId: "cancel-run",
+      sessionKey: "agent:main:main",
+      state: {},
+      execute: async (signal) => {
+        signal.addEventListener("abort", () => gate.resolve(), { once: true });
+        await gate.promise;
+      },
+    });
+    await vi.waitFor(() => expect(registry.get("cancel-run")).toBe(handle));
+
+    expect(handle.cancel("first")).toBe(true);
+    expect(handle.cancel("second")).toBe(false);
+    await handle.result;
+  });
+
+  it("isolates registries even when adapters reuse a run id", async () => {
+    const first = new AgentTurnRegistry<Record<string, never>, void>();
+    const second = new AgentTurnRegistry<Record<string, never>, void>();
+    const firstGate = deferred<void>();
+    const secondGate = deferred<void>();
+    const firstEvents: string[] = [];
+    const secondEvents: string[] = [];
+
+    const firstHandle = first.submit({
+      runId: "shared-run",
+      sessionKey: "agent:main:first",
+      state: {},
+      onEvent: (event) => firstEvents.push(String(event.data.owner)),
+      execute: async () => {
+        await Promise.resolve();
+        emitAgentEvent({
+          runId: "shared-run",
+          stream: "assistant",
+          data: { owner: "first" },
+        });
+        await firstGate.promise;
+      },
+    });
+    const secondHandle = second.submit({
+      runId: "shared-run",
+      sessionKey: "agent:main:second",
+      state: {},
+      onEvent: (event) => secondEvents.push(String(event.data.owner)),
+      execute: async () => {
+        await Promise.resolve();
+        emitAgentEvent({
+          runId: "shared-run",
+          stream: "assistant",
+          data: { owner: "second" },
+        });
+        await secondGate.promise;
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(firstEvents).toEqual(["first"]);
+      expect(secondEvents).toEqual(["second"]);
+    });
+    firstGate.resolve();
+    secondGate.resolve();
+    await Promise.all([firstHandle.result, secondHandle.result]);
+  });
+
+  it("isolates adapter event failures from execution", async () => {
+    const registry = new AgentTurnRegistry<Record<string, never>, string>();
+    const handle = registry.submit({
+      runId: "listener-error",
+      sessionKey: "agent:main:main",
+      state: {},
+      onEvent: () => {
+        throw new Error("render failed");
+      },
+      execute: async () => {
+        emitAgentEvent({
+          runId: "listener-error",
+          stream: "assistant",
+          data: { delta: "hello" },
+        });
+        return "done";
+      },
+    });
+
+    await expect(handle.result).resolves.toBe("done");
+  });
+
+  it("detaches unsettled turns and ignores their late events", async () => {
+    const registry = new AgentTurnRegistry<Record<string, never>, void>();
+    const gate = deferred<void>();
+    const events: string[] = [];
+    const handle = registry.submit({
+      runId: "detached-run",
+      sessionKey: "agent:main:main",
+      state: {},
+      onEvent: (event) => events.push(String(event.data.delta)),
+      execute: async () => {
+        await gate.promise;
+        emitAgentEvent({
+          runId: "detached-run",
+          stream: "assistant",
+          data: { delta: "late" },
+        });
+      },
+    });
+
+    expect(registry.detachAll("shutdown")).toEqual([handle]);
+    expect(handle.signal.aborted).toBe(true);
+    expect(registry.list()).toEqual([]);
+
+    gate.resolve();
+    await handle.result;
+    expect(events).toEqual([]);
+  });
+
+  it("does not route stale async events to a replacement handle with the same run id", async () => {
+    const registry = new AgentTurnRegistry<Record<string, never>, void>();
+    const staleEventGate = deferred<void>();
+    const replacementGate = deferred<void>();
+    const events: string[] = [];
+    const first = registry.submit({
+      runId: "reused-run",
+      sessionKey: "agent:main:first",
+      state: {},
+      onEvent: (event) => events.push(String(event.data.delta)),
+      execute: async () => {
+        void staleEventGate.promise.then(() => {
+          emitAgentEvent({
+            runId: "reused-run",
+            stream: "assistant",
+            data: { delta: "stale" },
+          });
+        });
+      },
+    });
+    await first.result;
+
+    const replacement = registry.submit({
+      runId: "reused-run",
+      sessionKey: "agent:main:replacement",
+      state: {},
+      onEvent: (event) => events.push(String(event.data.delta)),
+      execute: async () => {
+        emitAgentEvent({
+          runId: "reused-run",
+          stream: "assistant",
+          data: { delta: "fresh" },
+        });
+        await replacementGate.promise;
+      },
+    });
+
+    staleEventGate.resolve();
+    await Promise.resolve();
+    expect(events).toEqual(["fresh"]);
+
+    replacementGate.resolve();
+    await replacement.result;
+  });
+
+  it("rejects duplicate active ids and submissions after sealing", async () => {
+    const registry = new AgentTurnRegistry<Record<string, never>, void>();
+    const gate = deferred<void>();
+    registry.submit({
+      runId: "duplicate-run",
+      sessionKey: "agent:main:main",
+      state: {},
+      execute: async (signal) => {
+        if (signal.aborted) {
+          return;
+        }
+        signal.addEventListener("abort", () => gate.resolve(), { once: true });
+        await gate.promise;
+      },
+    });
+
+    expect(() =>
+      registry.submit({
+        runId: "duplicate-run",
+        sessionKey: "agent:main:main",
+        state: {},
+        execute: async () => undefined,
+      }),
+    ).toThrow('Agent turn "duplicate-run" is already active');
+
+    const sealed = registry.seal();
+    expect(sealed.map((handle) => handle.runId)).toEqual(["duplicate-run"]);
+    expect(() =>
+      registry.submit({
+        runId: "late-run",
+        sessionKey: "agent:main:main",
+        state: {},
+        execute: async () => undefined,
+      }),
+    ).toThrow("Agent turn registry is sealed");
+
+    expect(registry.cancelAll("shutdown")).toEqual(["duplicate-run"]);
+    await Promise.all(sealed.map((handle) => handle.result));
+    expect(registry.list()).toEqual([]);
+  });
+});

--- a/src/agents/agent-turn-registry.ts
+++ b/src/agents/agent-turn-registry.ts
@@ -1,0 +1,129 @@
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import { withAgentEventSink } from "../infra/agent-events.js";
+
+export type AgentTurnHandle<TState, TResult> = {
+  readonly runId: string;
+  readonly sessionKey: string;
+  readonly agentId?: string;
+  readonly state: TState;
+  readonly signal: AbortSignal;
+  readonly result: Promise<TResult>;
+  cancel: (reason?: unknown) => boolean;
+};
+
+type AgentTurnSubmission<TState, TResult> = {
+  runId: string;
+  sessionKey: string;
+  agentId?: string;
+  state: TState;
+  execute: (signal: AbortSignal) => Promise<TResult>;
+  onEvent?: (event: AgentEventPayload) => void;
+};
+
+/**
+ * Owns process-local turn handles above the model runner.
+ *
+ * Queue policy and presentation state stay with adapters; this registry owns
+ * registration, cancellation, scoped events, and terminal cleanup.
+ */
+export class AgentTurnRegistry<TState, TResult> {
+  private readonly active = new Map<string, AgentTurnHandle<TState, TResult>>();
+  private sealed = false;
+
+  submit(input: AgentTurnSubmission<TState, TResult>): AgentTurnHandle<TState, TResult> {
+    if (this.sealed) {
+      throw new Error("Agent turn registry is sealed");
+    }
+    if (this.active.has(input.runId)) {
+      throw new Error(`Agent turn "${input.runId}" is already active`);
+    }
+
+    const controller = new AbortController();
+    let resolveResult!: (value: TResult | PromiseLike<TResult>) => void;
+    let rejectResult!: (reason?: unknown) => void;
+    const result = new Promise<TResult>((resolve, reject) => {
+      resolveResult = resolve;
+      rejectResult = reject;
+    });
+
+    const handle: AgentTurnHandle<TState, TResult> = {
+      runId: input.runId,
+      sessionKey: input.sessionKey,
+      agentId: input.agentId,
+      state: input.state,
+      signal: controller.signal,
+      result,
+      cancel: (reason) => {
+        if (controller.signal.aborted) {
+          return false;
+        }
+        controller.abort(reason);
+        return true;
+      },
+    };
+    this.active.set(input.runId, handle);
+
+    const settle = () => {
+      if (this.active.get(input.runId) === handle) {
+        this.active.delete(input.runId);
+      }
+    };
+    try {
+      const execution = withAgentEventSink(
+        (event) => {
+          if (event.runId === input.runId && this.active.get(input.runId) === handle) {
+            input.onEvent?.(event);
+          }
+        },
+        () => input.execute(controller.signal),
+      );
+      void Promise.resolve(execution).then(
+        (value) => {
+          settle();
+          resolveResult(value);
+        },
+        (error: unknown) => {
+          settle();
+          rejectResult(error);
+        },
+      );
+    } catch (error) {
+      settle();
+      rejectResult(error);
+    }
+
+    return handle;
+  }
+
+  get(runId: string): AgentTurnHandle<TState, TResult> | undefined {
+    return this.active.get(runId);
+  }
+
+  list(): AgentTurnHandle<TState, TResult>[] {
+    return [...this.active.values()];
+  }
+
+  seal(): AgentTurnHandle<TState, TResult>[] {
+    this.sealed = true;
+    return this.list();
+  }
+
+  cancelAll(reason?: unknown): string[] {
+    const cancelled: string[] = [];
+    for (const handle of this.active.values()) {
+      if (handle.cancel(reason)) {
+        cancelled.push(handle.runId);
+      }
+    }
+    return cancelled;
+  }
+
+  detachAll(reason?: unknown): AgentTurnHandle<TState, TResult>[] {
+    const detached = this.list();
+    this.active.clear();
+    for (const handle of detached) {
+      handle.cancel(reason);
+    }
+    return detached;
+  }
+}

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -21,6 +21,7 @@ import {
   rotateAgentEventLifecycleGeneration,
   runOncePerAgentRun,
   sweepStaleRunContexts,
+  withAgentEventSink,
   withAgentRunLifecycleGeneration,
 } from "./agent-events.js";
 import { emitAgentRunStatusEvent } from "./agent-run-status-events.js";
@@ -57,6 +58,84 @@ describe("agent-events sequencing", () => {
       }),
     ]);
     unsubscribe();
+  });
+
+  test("delivers enriched events to the current runtime sink", () => {
+    const sink = vi.fn();
+    const shared = vi.fn();
+    const stop = onAgentEvent(shared);
+
+    withAgentEventSink(sink, () => {
+      emitAgentEvent({
+        runId: "scoped-run",
+        sessionKey: "agent:main:main",
+        stream: "assistant",
+        data: { delta: "hello" },
+      });
+    });
+
+    stop();
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "scoped-run",
+        seq: 1,
+        stream: "assistant",
+        sessionKey: "agent:main:main",
+        data: { delta: "hello" },
+      }),
+    );
+    expect(shared).toHaveBeenCalledWith(sink.mock.calls[0]?.[0]);
+  });
+
+  test("does not deliver events emitted outside the runtime sink scope", () => {
+    const sink = vi.fn();
+
+    withAgentEventSink(sink, () => {
+      emitAgentEvent({ runId: "inside", stream: "assistant", data: { delta: "inside" } });
+    });
+    emitAgentEvent({ runId: "outside", stream: "assistant", data: { delta: "outside" } });
+
+    expect(sink.mock.calls.map(([event]) => event.runId)).toEqual(["inside"]);
+  });
+
+  test("preserves the runtime sink through nested lifecycle ownership", () => {
+    const sink = vi.fn();
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+    withAgentEventSink(sink, () =>
+      withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+        emitAgentEvent({
+          runId: "nested-run",
+          lifecycleGeneration,
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: 1_000 },
+        });
+      }),
+    );
+
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "nested-run",
+        lifecycleGeneration,
+        stream: "lifecycle",
+      }),
+    );
+  });
+
+  test("isolates runtime sink failures from event producers", () => {
+    expect(() =>
+      withAgentEventSink(
+        () => {
+          throw new Error("sink failed");
+        },
+        () =>
+          emitAgentEvent({
+            runId: "sink-error",
+            stream: "assistant",
+            data: { delta: "still delivered" },
+          }),
+      ),
+    ).not.toThrow();
   });
 
   test("stores and clears run context", () => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -125,6 +125,7 @@ const AGENT_EVENT_EXECUTION_CONTEXT_KEY = Symbol.for("openclaw.agentEvents.execu
 type AgentEventExecutionContext = {
   lifecycleGeneration: string;
   onceByRun: Map<string, Promise<unknown>>;
+  eventSink?: (event: AgentEventPayload) => void;
 };
 
 function getAgentEventState(): AgentEventState {
@@ -150,7 +151,29 @@ export function withAgentRunLifecycleGeneration<T>(lifecycleGeneration: string, 
   const parent = storage.getStore();
   const onceByRun =
     parent?.lifecycleGeneration === lifecycleGeneration ? parent.onceByRun : new Map();
-  return storage.run({ lifecycleGeneration, onceByRun }, run);
+  return storage.run({ lifecycleGeneration, onceByRun, eventSink: parent?.eventSink }, run);
+}
+
+/**
+ * Delivers enriched events directly to the runtime that owns the current turn.
+ *
+ * The sink follows async work through nested lifecycle scopes while the shared
+ * listener bus remains available for Gateway projections and compatibility.
+ */
+export function withAgentEventSink<T>(
+  eventSink: (event: AgentEventPayload) => void,
+  run: () => T,
+): T {
+  const storage = getAgentEventExecutionContext();
+  const parent = storage.getStore();
+  return storage.run(
+    {
+      lifecycleGeneration: parent?.lifecycleGeneration ?? getAgentEventState().lifecycleGeneration,
+      onceByRun: parent?.onceByRun ?? new Map(),
+      eventSink,
+    },
+    run,
+  );
 }
 
 /** Shares one operation across fallback attempts that belong to the same admitted run. */
@@ -693,6 +716,10 @@ export function emitAgentEventIfCurrent(event: Omit<AgentEventPayload, "seq" | "
     return false;
   }
   notifyListeners(getAgentEventState().listeners, enriched);
+  const eventSink = getAgentEventExecutionContext().getStore()?.eventSink;
+  if (eventSink) {
+    notifyListeners([eventSink], enriched);
+  }
   return true;
 }
 
@@ -708,6 +735,10 @@ export function emitAgentEventForOwner(
   const enriched = enrichAgentEvent(event, claimId);
   if (enriched) {
     notifyListeners(getAgentEventState().listeners, enriched);
+    const eventSink = getAgentEventExecutionContext().getStore()?.eventSink;
+    if (eventSink) {
+      notifyListeners([eventSink], enriched);
+    }
   }
 }
 

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1,4 +1,5 @@
 // Covers embedded backend behavior used by the TUI runtime.
+import { AsyncLocalStorage } from "node:async_hooks";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
@@ -78,6 +79,8 @@ const loadSessionEntryMock = vi.fn(
   }),
 );
 let registeredListener: ((evt: unknown) => void) | undefined;
+const activeEventSinks = new Set<(evt: unknown) => void>();
+const eventSinkStorage = new AsyncLocalStorage<(evt: unknown) => void>();
 const embeddedEventTimestamp = Date.parse("2026-05-09T07:26:00.000Z");
 
 vi.mock("../agents/agent-command.js", () => ({
@@ -99,15 +102,31 @@ vi.mock("../infra/agent-events.js", () => ({
   getAgentEventLifecycleGeneration: () => "test-generation",
   isAgentEventLifecycleGenerationCurrent: (generation: string) => generation === "test-generation",
   registerAgentEventLifecycleRotationHandler: vi.fn(),
-  onAgentEvent: (listener: (evt: unknown) => void) => {
-    registeredListener = listener;
-    return () => {
-      if (registeredListener === listener) {
-        registeredListener = undefined;
+  withAgentEventSink: <T>(sink: (evt: unknown) => void, run: () => T): T =>
+    eventSinkStorage.run(sink, () => {
+      activeEventSinks.add(sink);
+      try {
+        const result = run();
+        if (result instanceof Promise) {
+          return result.finally(() => activeEventSinks.delete(sink)) as T;
+        }
+        activeEventSinks.delete(sink);
+        return result;
+      } catch (error) {
+        activeEventSinks.delete(sink);
+        throw error;
       }
-    };
-  },
+    }),
+  withAgentRunLifecycleGeneration: <T>(_generation: string, run: () => T): T => run(),
 }));
+
+function installEventDispatcher() {
+  registeredListener = (event) => {
+    for (const sink of activeEventSinks) {
+      notifyListeners([sink], event);
+    }
+  };
+}
 
 vi.mock("../cli/deps.js", () => ({
   createDefaultDeps: () => ({}),
@@ -373,7 +392,8 @@ describe("EmbeddedTuiBackend", () => {
     }));
     buildGatewaySessionInfoMock.mockClear();
     getSessionDefaultsMock.mockClear();
-    registeredListener = undefined;
+    activeEventSinks.clear();
+    installEventDispatcher();
     setEmbeddedMode(false);
     defaultRuntime.log = originalRuntimeLog;
     defaultRuntime.error = originalRuntimeError;
@@ -557,6 +577,119 @@ describe("EmbeddedTuiBackend", () => {
     backend.onEvent = undefined;
     pending.resolve({ payloads: [{ text: "hello" }], meta: {} });
     await flushMicrotasks();
+    await backend.stop();
+  });
+
+  it("can start again after stopping", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    agentCommandFromIngressMock.mockResolvedValueOnce({
+      payloads: [{ text: "after restart" }],
+      meta: {},
+    });
+    const backend = new EmbeddedTuiBackend();
+    const onConnected = vi.fn();
+    backend.onConnected = onConnected;
+
+    backend.start();
+    await flushMicrotasks();
+    await backend.stop();
+    backend.start();
+    await flushMicrotasks();
+
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "hello again",
+      runId: "run-after-restart",
+    });
+    await vi.waitFor(() => expect(agentCommandFromIngressMock).toHaveBeenCalledOnce());
+    expect(onConnected).toHaveBeenCalledTimes(2);
+    await backend.stop();
+  });
+
+  it("ignores late turn events after stopping", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (event) => {
+      events.push({ event: event.event, payload: event.payload });
+    };
+
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "still running",
+      runId: "run-detached-on-stop",
+    });
+    await backend.stop();
+
+    registeredListener?.({
+      runId: "run-detached-on-stop",
+      stream: "assistant",
+      data: { delta: "too late" },
+    });
+    expect(events).toEqual([]);
+
+    pending.resolve({ payloads: [{ text: "too late" }], meta: {} });
+    await flushMicrotasks();
+    expect(events).toEqual([]);
+  });
+
+  it("does not let a stopped turn settle into a reused run id after restart", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const stale = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    const replacement = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(replacement.promise);
+    const backend = new EmbeddedTuiBackend();
+    const chatEvents: Array<{ runId?: string; state?: string; message?: unknown }> = [];
+    backend.onEvent = (event) => {
+      if (event.event === "chat") {
+        chatEvents.push(event.payload as (typeof chatEvents)[number]);
+      }
+    };
+
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "old",
+      runId: "reused-after-restart",
+    });
+    await backend.stop();
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "new",
+      runId: "reused-after-restart",
+    });
+
+    stale.resolve({ payloads: [{ text: "stale result" }], meta: {} });
+    await flushMicrotasks();
+    expect(chatEvents).toEqual([]);
+
+    replacement.resolve({ payloads: [{ text: "fresh result" }], meta: {} });
+    await vi.waitFor(() => {
+      expect(chatEvents).toEqual([
+        expect.objectContaining({
+          runId: "reused-after-restart",
+          state: "final",
+          message: expect.objectContaining({
+            content: [{ type: "text", text: "fresh result" }],
+          }),
+        }),
+      ]);
+    });
     await backend.stop();
   });
 
@@ -1315,7 +1448,7 @@ describe("EmbeddedTuiBackend", () => {
     await stopPromise;
 
     expect(abortListener).not.toHaveBeenCalled();
-    expect(registeredListener).toBeUndefined();
+    expect(activeEventSinks.size).toBe(0);
     expect(isEmbeddedMode()).toBe(false);
   });
 
@@ -3023,8 +3156,7 @@ describe("EmbeddedTuiBackend", () => {
       expect(sentDuringError).toBeDefined();
     });
     await sentDuringError;
-    await flushMicrotasks();
-    expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2));
   });
 
   it.each([

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -15,6 +15,7 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../agents/agent-scope.js";
+import { type AgentTurnHandle, AgentTurnRegistry } from "../agents/agent-turn-registry.js";
 import { ensureContextWindowCacheLoaded } from "../agents/context.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
@@ -78,7 +79,7 @@ import {
 } from "../gateway/session-utils.js";
 import { projectSessionsPatchEntry } from "../gateway/sessions-patch.js";
 import { waitForAbortSignal } from "../infra/abort-signal.js";
-import { type AgentEventPayload, onAgentEvent } from "../infra/agent-events.js";
+import type { AgentEventPayload } from "../infra/agent-events.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import {
   clearEmbeddedPluginApprovalBroker,
@@ -114,7 +115,6 @@ import { formatTuiErrorMessage } from "./tui-formatters.js";
 type LocalRunState = {
   sessionKey: string;
   agentId: string;
-  controller: AbortController;
   buffer: string;
   lastBroadcastText?: string;
   isBtw: boolean;
@@ -140,6 +140,8 @@ type LocalRunState = {
   markQueuedRunReady: () => void;
 };
 
+type LocalTurnHandle = AgentTurnHandle<LocalRunState, void>;
+
 type QueuedSessionRun = {
   runId: string;
   run: LocalRunState;
@@ -147,7 +149,7 @@ type QueuedSessionRun = {
 };
 
 type LocalPendingMessage = {
-  run: LocalRunState;
+  turn: LocalTurnHandle;
   messageIndex: number;
   message: string;
 };
@@ -360,9 +362,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
   onGap?: (info: { expected: number; received: number }) => void;
 
   private readonly deps = createDefaultDeps();
-  private readonly runs = new Map<string, LocalRunState>();
-  private readonly runPromises = new Map<string, Promise<void>>();
-  private unsubscribe?: () => void;
+  private turns = new AgentTurnRegistry<LocalRunState, void>();
+  private started = false;
   private previousRuntimeLog?: typeof defaultRuntime.log;
   private previousRuntimeError?: typeof defaultRuntime.error;
   private seq = 0;
@@ -373,9 +374,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
   private ready: Promise<void> = Promise.resolve();
 
   start() {
-    if (this.unsubscribe) {
+    if (this.started) {
       return;
     }
+    this.started = true;
     setEmbeddedMode(true);
     void ensureContextWindowCacheLoaded();
     // Suppress console output from logError/logInfo that would pollute the TUI.
@@ -384,8 +386,6 @@ export class EmbeddedTuiBackend implements TuiBackend {
     this.previousRuntimeError = defaultRuntime.error;
     defaultRuntime.log = silentRuntime.log;
     defaultRuntime.error = silentRuntime.error;
-    // Keep this synchronous so the shared event bus can isolate listener failures.
-    this.unsubscribe = onAgentEvent((evt) => this.handleAgentEvent(evt));
     setEmbeddedPluginApprovalBroker(this.pluginApprovalBroker);
     this.unsubscribePluginApprovals = this.pluginApprovalBroker.subscribe((event) => {
       this.emit(event.event, event.payload);
@@ -410,33 +410,29 @@ export class EmbeddedTuiBackend implements TuiBackend {
     this.unsubscribePluginApprovals?.();
     this.unsubscribePluginApprovals = undefined;
     const maintenancePromises: Promise<void>[] = [];
-    for (const [runId, run] of this.runs) {
+    const activeTurns = this.turns.seal();
+    for (const turn of activeTurns) {
+      const run = turn.state;
       if (run.finishing || run.lifecycleEnded) {
-        const promise = this.runPromises.get(runId);
-        if (promise) {
-          maintenancePromises.push(promise);
-        }
+        maintenancePromises.push(turn.result);
         continue;
       }
-      run.controller.abort();
+      turn.cancel();
     }
     this.pluginApprovalBroker.stop();
     const maintenanceCompleted = await waitForLocalRunShutdown(maintenancePromises);
     if (!maintenanceCompleted) {
-      for (const run of this.runs.values()) {
+      for (const turn of this.turns.list()) {
+        const run = turn.state;
         if (run.finishing || run.lifecycleEnded) {
-          run.controller.abort();
+          turn.cancel();
         }
       }
     }
-    this.unsubscribe?.();
-    this.unsubscribe = undefined;
     this.clearPendingLifecycleErrors();
-    for (const run of this.runs.values()) {
-      run.controller.abort();
-    }
-    this.runs.clear();
-    this.runPromises.clear();
+    this.turns.detachAll("embedded TUI stopped");
+    this.turns = new AgentTurnRegistry<LocalRunState, void>();
+    this.started = false;
     defaultRuntime.log = this.previousRuntimeLog ?? defaultRuntime.log;
     defaultRuntime.error = this.previousRuntimeError ?? defaultRuntime.error;
     this.previousRuntimeLog = undefined;
@@ -509,12 +505,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
         pendingQueue = queued.queue;
       }
     }
-    const controller = new AbortController();
     const queuedRunReadiness = createQueuedRunReadiness();
-    this.runs.set(runId, {
+    const state: LocalRunState = {
       sessionKey: opts.sessionKey,
       agentId,
-      controller,
       buffer: "",
       isBtw: Boolean(question),
       question,
@@ -526,28 +520,32 @@ export class EmbeddedTuiBackend implements TuiBackend {
       ...(queuedAfter ? { queuedAfter } : {}),
       queuedRunReady: queuedRunReadiness.promise,
       markQueuedRunReady: queuedRunReadiness.markReady,
-    });
-
-    const runPromise = this.runTurn({
+    };
+    const turn = this.turns.submit({
       runId,
       sessionKey: opts.sessionKey,
-      agentId: opts.agentId,
-      message: opts.message,
-      thinking: opts.thinking,
-      deliver: opts.deliver,
-      timeoutMs: opts.timeoutMs,
-      controller,
-      queuedAfter,
-    });
-    this.runPromises.set(runId, runPromise);
-    void runPromise.finally(() => {
-      this.runPromises.delete(runId);
+      agentId,
+      state,
+      onEvent: (event) => this.handleAgentEvent(event),
+      execute: async (signal) =>
+        await this.runTurn({
+          runId,
+          sessionKey: opts.sessionKey,
+          agentId,
+          message: opts.message,
+          thinking: opts.thinking,
+          deliver: opts.deliver,
+          timeoutMs: opts.timeoutMs,
+          signal,
+          state,
+          queuedAfter,
+        }),
     });
 
     if (isQueueCommand) {
       // Queue directives are control-plane mutations. Complete them before
       // admitting another local prompt so later sends cannot overtake the new mode.
-      await runPromise;
+      await turn.result;
     }
 
     return { runId };
@@ -558,7 +556,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
       // Session-scoped abort for local embedded: abort all matching runs.
       let aborted = false;
       const runIds: string[] = [];
-      for (const [runId, run] of this.runs) {
+      for (const turn of this.turns.list()) {
+        const { runId, state: run } = turn;
         if (run.isBtw) {
           continue;
         }
@@ -576,14 +575,15 @@ export class EmbeddedTuiBackend implements TuiBackend {
         if (!this.isAbortableRun(runId, run)) {
           continue;
         }
-        run.controller.abort();
+        turn.cancel();
         aborted = true;
         runIds.push(runId);
       }
       return { ok: true, aborted, runIds };
     }
-    const run = this.runs.get(opts.runId);
-    if (!run || run.sessionKey !== opts.sessionKey) {
+    const turn = this.turns.get(opts.runId);
+    const run = turn?.state;
+    if (!turn || !run || run.sessionKey !== opts.sessionKey) {
       return { ok: true, aborted: false, runIds: [] };
     }
     if (opts.sessionKey === "global") {
@@ -597,7 +597,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     if (!this.isAbortableRun(opts.runId, run)) {
       return { ok: true, aborted: false, runIds: [] };
     }
-    run.controller.abort();
+    turn.cancel();
     return { ok: true, aborted: true, runIds: [opts.runId] };
   }
 
@@ -646,18 +646,20 @@ export class EmbeddedTuiBackend implements TuiBackend {
     const capped = capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
     const bounded = enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
     const messages = bounded.messages;
-    const newestInFlightRun = [...this.runs.entries()].findLast(
-      ([, run]) =>
-        !run.isBtw &&
-        !run.finalSent &&
-        agentSessionKeysMatchByRequestKey(run.sessionKey, opts.sessionKey) &&
-        normalizeAgentId(run.agentId) === normalizeAgentId(sessionAgentId),
-    );
+    const newestInFlightRun = this.turns
+      .list()
+      .findLast(
+        (turn) =>
+          !turn.state.isBtw &&
+          !turn.state.finalSent &&
+          agentSessionKeysMatchByRequestKey(turn.sessionKey, opts.sessionKey) &&
+          normalizeAgentId(turn.agentId) === normalizeAgentId(sessionAgentId),
+      );
     const inFlightRun = newestInFlightRun
       ? {
-          runId: newestInFlightRun[0],
+          runId: newestInFlightRun.runId,
           text: projectLiveAssistantBufferedText(
-            normalizeLiveAssistantBufferedText(newestInFlightRun[1].buffer).trim(),
+            normalizeLiveAssistantBufferedText(newestInFlightRun.state.buffer).trim(),
             { suppressLeadFragments: true },
           ).text.trim(),
         }
@@ -829,7 +831,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     agentId?: string;
     question: string;
     timeoutMs?: number;
-    controller: AbortController;
+    signal: AbortSignal;
   }) {
     const loadOptions = params.agentId ? { agentId: params.agentId } : undefined;
     const { cfg, canonicalKey, storePath, store, entry } = loadSessionEntry(
@@ -861,7 +863,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       resolvedReasoningLevel: "off",
       opts: {
         runId: params.runId,
-        abortSignal: params.controller.signal,
+        abortSignal: params.signal,
         ...(timeoutSeconds !== undefined ? { timeoutOverrideSeconds: Number(timeoutSeconds) } : {}),
       },
       isNewSession: false,
@@ -881,7 +883,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   async getGatewayStatus() {
-    return `local embedded mode${this.runs.size > 0 ? ` (${String(this.runs.size)} active run${this.runs.size === 1 ? "" : "s"})` : ""}`;
+    const activeCount = this.turns.list().length;
+    return `local embedded mode${activeCount > 0 ? ` (${String(activeCount)} active run${activeCount === 1 ? "" : "s"})` : ""}`;
   }
 
   async listPluginApprovals(): Promise<unknown> {
@@ -957,24 +960,25 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
 
     const retained = new Set(overflowQueue.items);
-    const droppedByRun = new Map<LocalRunState, number[]>();
+    const droppedByTurn = new Map<LocalTurnHandle, number[]>();
     for (const dropped of pendingMessages) {
       if (retained.has(dropped)) {
         continue;
       }
-      const indices = droppedByRun.get(dropped.run) ?? [];
+      const indices = droppedByTurn.get(dropped.turn) ?? [];
       indices.push(dropped.messageIndex);
-      droppedByRun.set(dropped.run, indices);
+      droppedByTurn.set(dropped.turn, indices);
     }
     const inheritedSummaryLines: string[] = [];
-    for (const [run, indices] of droppedByRun) {
+    for (const [turn, indices] of droppedByTurn) {
+      const run = turn.state;
       for (const index of indices.toSorted((a, b) => b - a)) {
         run.pendingQueue?.messages.splice(index, 1);
       }
       if (run.pendingQueue?.messages.length === 0) {
         inheritedSummaryLines.push(...run.pendingQueue.summaryLines);
         overflowQueue.droppedCount += run.pendingQueue.droppedCount;
-        run.controller.abort();
+        turn.cancel();
       }
     }
     overflowQueue.summaryLines.unshift(...inheritedSummaryLines);
@@ -983,7 +987,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
 
     const enqueuedAt = Date.now();
-    for (const run of this.runs.values()) {
+    for (const turn of this.turns.list()) {
+      const run = turn.state;
       if (!this.isSameRunScope(run, params.runScope) || !run.pendingQueue) {
         continue;
       }
@@ -992,17 +997,18 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
 
     if (params.settings.mode === "collect") {
-      const target = [...this.runs.entries()].findLast(
-        ([, run]) => this.isSameRunScope(run, params.runScope) && run.pendingQueue,
-      );
-      const targetQueue = target?.[1].pendingQueue;
-      if (target && targetQueue?.mode === "collect" && !target[1].controller.signal.aborted) {
-        const [targetRunId] = target;
+      const target = this.turns
+        .list()
+        .findLast(
+          (turn) => this.isSameRunScope(turn.state, params.runScope) && turn.state.pendingQueue,
+        );
+      const targetQueue = target?.state.pendingQueue;
+      if (target && targetQueue?.mode === "collect" && !target.signal.aborted) {
         targetQueue.messages.push(params.message);
         targetQueue.dropPolicy = params.settings.dropPolicy ?? DEFAULT_QUEUE_DROP;
         targetQueue.droppedCount += overflowQueue.droppedCount;
         targetQueue.summaryLines.push(...overflowQueue.summaryLines);
-        return { kind: "handled", runId: targetRunId };
+        return { kind: "handled", runId: target.runId };
       }
     }
 
@@ -1025,12 +1031,13 @@ export class EmbeddedTuiBackend implements TuiBackend {
     agentId?: string;
   }): LocalPendingMessage[] {
     const pending: LocalPendingMessage[] = [];
-    for (const run of this.runs.values()) {
+    for (const turn of this.turns.list()) {
+      const run = turn.state;
       if (!this.isSameRunScope(run, params) || !run.pendingQueue) {
         continue;
       }
       run.pendingQueue.messages.forEach((message, messageIndex) => {
-        pending.push({ run, messageIndex, message });
+        pending.push({ turn, messageIndex, message });
       });
     }
     return pending;
@@ -1041,28 +1048,28 @@ export class EmbeddedTuiBackend implements TuiBackend {
     agentId?: string;
   }): QueuedSessionRun | undefined {
     let queuedAfter: QueuedSessionRun | undefined;
-    for (const [runId, run] of this.runs) {
+    for (const turn of this.turns.list()) {
+      const run = turn.state;
       if (this.isSameRunScope(run, params) && !run.isBtw) {
-        const promise = this.runPromises.get(runId);
-        if (promise) {
-          queuedAfter = { runId, run, promise };
-        }
+        queuedAfter = { runId: turn.runId, run, promise: turn.result };
       }
     }
     return queuedAfter;
   }
 
   private abortSessionRuns(params: { sessionKey: string; agentId?: string }) {
-    for (const [runId, run] of this.runs) {
-      if (this.isSameRunScope(run, params) && !run.isBtw && this.isAbortableRun(runId, run)) {
-        run.controller.abort();
+    for (const turn of this.turns.list()) {
+      const run = turn.state;
+      if (this.isSameRunScope(run, params) && !run.isBtw && this.isAbortableRun(turn.runId, run)) {
+        turn.cancel();
       }
     }
   }
 
   private hasAbortableSessionRun(params: { sessionKey: string; agentId?: string }): boolean {
-    for (const [runId, run] of this.runs) {
-      if (this.isSameRunScope(run, params) && !run.isBtw && this.isAbortableRun(runId, run)) {
+    for (const turn of this.turns.list()) {
+      const run = turn.state;
+      if (this.isSameRunScope(run, params) && !run.isBtw && this.isAbortableRun(turn.runId, run)) {
         return true;
       }
     }
@@ -1077,7 +1084,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   private isAbortableRun(runId: string, run: LocalRunState): boolean {
-    return !run.lifecycleEnded || this.runPromises.has(runId);
+    return !run.lifecycleEnded || this.turns.get(runId) !== undefined;
   }
 
   private emit(event: string, payload: unknown) {
@@ -1183,7 +1190,9 @@ export class EmbeddedTuiBackend implements TuiBackend {
     } = {},
   ): boolean {
     const aborted =
-      typeof metadata.aborted === "boolean" ? metadata.aborted : run.controller.signal.aborted;
+      typeof metadata.aborted === "boolean"
+        ? metadata.aborted
+        : this.turns.get(runId)?.signal.aborted === true;
     const stopReason = metadata.stopReason ?? (aborted ? "aborted" : undefined);
     const terminalError =
       metadata.error && typeof metadata.error === "object" && "message" in metadata.error
@@ -1245,10 +1254,11 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   private handleAgentEvent(evt: AgentEventPayload) {
-    const run = this.runs.get(evt.runId);
-    if (!run) {
+    const turn = this.turns.get(evt.runId);
+    if (!turn) {
       return;
     }
+    const run = turn.state;
 
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : "";
@@ -1319,6 +1329,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
     run.lifecycleYielded = isAgentLifecycleYieldedWaiting(evt.data);
   }
 
+  private getCurrentTurnState(runId: string, state: LocalRunState): LocalRunState | undefined {
+    return this.turns.get(runId)?.state === state ? state : undefined;
+  }
+
   private async runTurn(params: {
     runId: string;
     sessionKey: string;
@@ -1327,18 +1341,27 @@ export class EmbeddedTuiBackend implements TuiBackend {
     thinking?: string;
     deliver?: boolean;
     timeoutMs?: number;
-    controller: AbortController;
+    signal: AbortSignal;
+    state: LocalRunState;
     queuedAfter?: QueuedSessionRun;
   }) {
     try {
+      const activeRun = this.getCurrentTurnState(params.runId, params.state);
+      if (!activeRun) {
+        return;
+      }
+      if (params.signal.aborted) {
+        this.emitChatTerminal(params.runId, activeRun, "aborted");
+        return;
+      }
       if (params.queuedAfter) {
         try {
           await Promise.race([
             waitForQueuedLocalRun(params.queuedAfter, params.runId),
-            waitForAbortSignal(params.controller.signal),
+            waitForAbortSignal(params.signal),
           ]);
         } catch (error) {
-          const run = this.runs.get(params.runId);
+          const run = this.getCurrentTurnState(params.runId, params.state);
           if (run) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             this.emitChatTerminal(
@@ -1350,20 +1373,22 @@ export class EmbeddedTuiBackend implements TuiBackend {
           }
           return;
         }
-        if (params.controller.signal.aborted) {
-          const run = this.runs.get(params.runId);
+        if (params.signal.aborted) {
+          const run = this.getCurrentTurnState(params.runId, params.state);
           if (run) {
             this.emitChatTerminal(params.runId, run, "aborted");
           }
           return;
         }
       }
-      const activeRun = this.runs.get(params.runId);
-      delete activeRun?.queuedAfter;
+      delete activeRun.queuedAfter;
       let message = params.message;
-      if (activeRun?.pendingQueue) {
-        await waitForQueueDebounce(activeRun.pendingQueue, params.controller.signal);
-        if (params.controller.signal.aborted) {
+      if (activeRun.pendingQueue) {
+        await waitForQueueDebounce(activeRun.pendingQueue, params.signal);
+        if (!this.getCurrentTurnState(params.runId, params.state)) {
+          return;
+        }
+        if (params.signal.aborted) {
           this.emitChatTerminal(params.runId, activeRun, "aborted");
           return;
         }
@@ -1377,13 +1402,13 @@ export class EmbeddedTuiBackend implements TuiBackend {
           ...(params.agentId ? { agentId: params.agentId } : {}),
           question: activeRun.question,
           timeoutMs: params.timeoutMs,
-          controller: params.controller,
+          signal: params.signal,
         });
-        const run = this.runs.get(params.runId);
+        const run = this.getCurrentTurnState(params.runId, params.state);
         if (!run) {
           return;
         }
-        if (params.controller.signal.aborted) {
+        if (params.signal.aborted) {
           this.emitChatTerminal(params.runId, run, "aborted");
           return;
         }
@@ -1419,13 +1444,13 @@ export class EmbeddedTuiBackend implements TuiBackend {
           },
           timeout: timeoutSecondsFromMs(params.timeoutMs),
           runId: params.runId,
-          abortSignal: params.controller.signal,
+          abortSignal: params.signal,
           allowModelOverride: false,
         },
         silentRuntime,
         this.deps,
       );
-      const run = this.runs.get(params.runId);
+      const run = this.getCurrentTurnState(params.runId, params.state);
       if (!run) {
         return;
       }
@@ -1466,7 +1491,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
         this.emitChatTerminal(params.runId, run, "final", stopReason);
       }
     } catch (error) {
-      const run = this.runs.get(params.runId);
+      const run = this.getCurrentTurnState(params.runId, params.state);
       if (!run) {
         return;
       }
@@ -1479,8 +1504,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
         outcome ? { terminalOutcome: outcome } : {},
       );
     } finally {
-      this.runs.get(params.runId)?.markQueuedRunReady();
-      this.runs.delete(params.runId);
+      this.getCurrentTurnState(params.runId, params.state)?.markQueuedRunReady();
     }
   }
 }


### PR DESCRIPTION
Related: #116402

## What Problem This Solves

Resolves a runtime ownership problem where local adapters independently tracked turn cancellation, promises, and global agent-event subscriptions. That structure prevents ACP from becoming a clean direct adapter over the same process-local runtime used by other OpenClaw surfaces.

## Why This Change Was Made

This first stack layer introduces a generic process-local turn registry that owns handle registration, cancellation, result settlement, scoped event delivery, detachment, and shutdown fencing. The embedded TUI now uses that owner while retaining its existing queue and presentation policy.

This PR intentionally does not change ACP behavior yet. It establishes the lifecycle boundary required by the remaining stack.

## User Impact

No intended user-visible behavior change. Local TUI runs keep their existing queue, abort, restart, history restoration, and shutdown behavior, with stronger isolation against stale events and reused run IDs.

## Evidence

- Focused stack validation:
  - 492 tests passed across 7 Vitest shards
  - includes 69 embedded TUI tests after rebasing over current session-history restoration behavior
- `git diff --check`
  - clean for both stack layers
- `$autoreview`
  - clean; no accepted/actionable findings
  - overall patch correct: 0.87
  - the final rebased commit retains the reviewed stable patch ID
- `node scripts/check-changed.mjs`
  - broad gate blocked before repository command execution by repeated Blacksmith Testbox environment hydration failures
  - runs: https://github.com/openclaw/openclaw/actions/runs/30555617812 and https://github.com/openclaw/openclaw/actions/runs/30556065666
  - trusted local fallback was also unavailable because the shared dependency refresh requires more disk than the machine currently has

Regression coverage includes:

- backend stop/start reuse
- cancellation-ignoring turns detached at shutdown
- late events after detachment
- stale async events with a reused run ID
- stale execution settlement across stop/restart
- queue, history restoration, and post-turn maintenance behavior

AI-assisted implementation; reviewed and validated against the repository's required gates.
