### PR TITLE
fix(auto-reply): continue after transient preflight compaction failures

### DIFF
--- a/src/agents/embedded-agent-runner/compact-reasons.test.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.test.ts
@@ -5,6 +5,7 @@ import {
   formatUnknownCompactionReasonDetail,
   isBenignCompactionSkipResult,
   isBenignCompactionSkipReason,
+  isTransientCompactionFailureReason,
   resolveCompactionFailureReason,
 } from "./compact-reasons.js";
 
@@ -64,6 +65,17 @@ describe("classifyCompactionReason", () => {
   it("keeps unclassified provider errors in the stable unknown bucket", () => {
     expect(classifyCompactionReason("No API provider registered for api: ollama")).toBe("unknown");
   });
+
+  it.each([
+    ["Compaction timed out", "timeout"],
+    ["Provider returned 429 rate limit", "provider_error_429"],
+    ["Provider returned 503 from model", "provider_error_5xx"],
+    ["Provider returned 400", "provider_error_4xx"],
+    ["Provider returned 401", "provider_error_4xx"],
+    ["Provider returned 403", "provider_error_4xx"],
+  ])("classifies provider failure %s as %s", (reason, expected) => {
+    expect(classifyCompactionReason(reason)).toBe(expected);
+  });
 });
 
 describe("isBenignCompactionSkipReason", () => {
@@ -86,6 +98,22 @@ describe("isBenignCompactionSkipReason", () => {
     "does not hide the failure reason %s",
     (reason) => {
       expect(isBenignCompactionSkipResult({ ok: true, compacted: false, reason })).toBe(false);
+    },
+  );
+});
+
+describe("isTransientCompactionFailureReason", () => {
+  it.each(["Compaction timed out", "Provider returned 429", "Provider returned 503"])(
+    "treats retryable preflight compaction failure %s as transient",
+    (reason) => {
+      expect(isTransientCompactionFailureReason(reason)).toBe(true);
+    },
+  );
+
+  it.each(["Provider returned 400", "Provider returned 401", "Provider returned 403", undefined])(
+    "does not treat non-retryable preflight compaction failure %s as transient",
+    (reason) => {
+      expect(isTransientCompactionFailureReason(reason)).toBe(false);
     },
   );
 });

--- a/src/agents/embedded-agent-runner/compact-reasons.test.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.test.ts
@@ -118,6 +118,11 @@ describe("isTransientCompactionFailureResult", () => {
       reason: "Provider returned 503 but the context engine failed internally",
       failure: { reason: "auth", status: 401, code: "context_engine_failure" },
     },
+    {
+      ok: false,
+      compacted: false,
+      failure: { reason: "server_error", status: 401, code: "context_engine_failure" },
+    },
     { ok: false, compacted: false, reason: "Provider returned 503" },
     { ok: false, compacted: false, failure: { reason: "format", status: 400 } },
     { ok: false, compacted: false, failure: { reason: "tls_certificate", status: 502 } },

--- a/src/agents/embedded-agent-runner/compact-reasons.test.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.test.ts
@@ -120,6 +120,7 @@ describe("isTransientCompactionFailureResult", () => {
     },
     { ok: false, compacted: false, reason: "Provider returned 503" },
     { ok: false, compacted: false, failure: { reason: "format", status: 400 } },
+    { ok: false, compacted: false, failure: { reason: "tls_certificate", status: 502 } },
     { ok: true, compacted: false, failure: { reason: "server_error", status: 503 } },
   ])("keeps non-transient or non-failure result %j blocking", (result) => {
     expect(isTransientCompactionFailureResult(result)).toBe(false);

--- a/src/agents/embedded-agent-runner/compact-reasons.test.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.test.ts
@@ -5,7 +5,7 @@ import {
   formatUnknownCompactionReasonDetail,
   isBenignCompactionSkipResult,
   isBenignCompactionSkipReason,
-  isTransientCompactionFailureReason,
+  isTransientCompactionFailureResult,
   resolveCompactionFailureReason,
 } from "./compact-reasons.js";
 
@@ -102,20 +102,28 @@ describe("isBenignCompactionSkipReason", () => {
   );
 });
 
-describe("isTransientCompactionFailureReason", () => {
-  it.each(["Compaction timed out", "Provider returned 429", "Provider returned 503"])(
-    "treats retryable preflight compaction failure %s as transient",
-    (reason) => {
-      expect(isTransientCompactionFailureReason(reason)).toBe(true);
-    },
-  );
+describe("isTransientCompactionFailureResult", () => {
+  it.each([
+    [{ reason: "provider timeout", status: 408, code: "ETIMEDOUT" }],
+    [{ reason: "rate_limit", status: 429, code: "rate_limit_exceeded" }],
+    [{ reason: "server_error", status: 503, code: "upstream_unavailable" }],
+  ])("treats structured provider failure %j as transient", (failure) => {
+    expect(isTransientCompactionFailureResult({ ok: false, compacted: false, failure })).toBe(true);
+  });
 
-  it.each(["Provider returned 400", "Provider returned 401", "Provider returned 403", undefined])(
-    "does not treat non-retryable preflight compaction failure %s as transient",
-    (reason) => {
-      expect(isTransientCompactionFailureReason(reason)).toBe(false);
+  it.each([
+    {
+      ok: false,
+      compacted: false,
+      reason: "Provider returned 503 but the context engine failed internally",
+      failure: { reason: "auth", status: 401, code: "context_engine_failure" },
     },
-  );
+    { ok: false, compacted: false, reason: "Provider returned 503" },
+    { ok: false, compacted: false, failure: { reason: "format", status: 400 } },
+    { ok: true, compacted: false, failure: { reason: "server_error", status: 503 } },
+  ])("keeps non-transient or non-failure result %j blocking", (result) => {
+    expect(isTransientCompactionFailureResult(result)).toBe(false);
+  });
 });
 
 describe("formatUnknownCompactionReasonDetail", () => {

--- a/src/agents/embedded-agent-runner/compact-reasons.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.ts
@@ -80,13 +80,38 @@ export function isBenignCompactionSkipReason(reason?: string): boolean {
   return classification === "below_threshold" || classification === "already_compacted";
 }
 
-/** Return whether a failed compaction result came from a retryable provider outage. */
-export function isTransientCompactionFailureReason(reason?: string): boolean {
-  const classification = classifyCompactionReason(reason);
+/** Return whether structured failure metadata identifies a retryable provider outage. */
+export function isTransientCompactionFailureResult(result: {
+  ok: boolean;
+  compacted: boolean;
+  failure?: {
+    reason?: string;
+    status?: number;
+    code?: string;
+  };
+}): boolean {
+  if (result.ok || result.compacted || !result.failure) {
+    return false;
+  }
+  const status = result.failure.status;
+  if (status === 408 || status === 429 || (status !== undefined && status >= 500 && status < 600)) {
+    return true;
+  }
+  if (
+    result.failure.reason === "timeout" ||
+    result.failure.reason === "rate_limit" ||
+    result.failure.reason === "server_error" ||
+    result.failure.reason === "overloaded"
+  ) {
+    return true;
+  }
   return (
-    classification === "timeout" ||
-    classification === "provider_error_429" ||
-    classification === "provider_error_5xx"
+    result.failure.code === "ETIMEDOUT" ||
+    result.failure.code === "ESOCKETTIMEDOUT" ||
+    result.failure.code === "UND_ERR_CONNECT_TIMEOUT" ||
+    result.failure.code === "UND_ERR_HEADERS_TIMEOUT" ||
+    result.failure.code === "UND_ERR_BODY_TIMEOUT" ||
+    result.failure.code === "rate_limit_exceeded"
   );
 }
 

--- a/src/agents/embedded-agent-runner/compact-reasons.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.ts
@@ -97,6 +97,9 @@ export function isTransientCompactionFailureResult(result: {
     return false;
   }
   const status = result.failure.status;
+  if (status !== undefined && status >= 400 && status < 500 && status !== 408 && status !== 429) {
+    return false;
+  }
   if (status === 408 || status === 429 || (status !== undefined && status >= 500 && status < 600)) {
     return true;
   }

--- a/src/agents/embedded-agent-runner/compact-reasons.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.ts
@@ -93,6 +93,9 @@ export function isTransientCompactionFailureResult(result: {
   if (result.ok || result.compacted || !result.failure) {
     return false;
   }
+  if (result.failure.reason === "tls_certificate") {
+    return false;
+  }
   const status = result.failure.status;
   if (status === 408 || status === 429 || (status !== undefined && status >= 500 && status < 600)) {
     return true;

--- a/src/agents/embedded-agent-runner/compact-reasons.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.ts
@@ -57,12 +57,10 @@ export function classifyCompactionReason(reason?: string): string {
   if (text.includes("timed out") || text.includes("timeout")) {
     return "timeout";
   }
-  if (
-    text.includes("400") ||
-    text.includes("401") ||
-    text.includes("403") ||
-    text.includes("429")
-  ) {
+  if (text.includes("429")) {
+    return "provider_error_429";
+  }
+  if (text.includes("400") || text.includes("401") || text.includes("403")) {
     return "provider_error_4xx";
   }
   if (
@@ -80,6 +78,16 @@ export function classifyCompactionReason(reason?: string): string {
 export function isBenignCompactionSkipReason(reason?: string): boolean {
   const classification = classifyCompactionReason(reason);
   return classification === "below_threshold" || classification === "already_compacted";
+}
+
+/** Return whether a failed compaction result came from a retryable provider outage. */
+export function isTransientCompactionFailureReason(reason?: string): boolean {
+  const classification = classifyCompactionReason(reason);
+  return (
+    classification === "timeout" ||
+    classification === "provider_error_429" ||
+    classification === "provider_error_5xx"
+  );
 }
 
 /** Return whether a compaction result is an intentional no-op rather than a failure. */

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -32,22 +32,27 @@ type MockEmbeddedAgentStreamFn = Mock<
   (model?: unknown, context?: unknown, options?: unknown) => unknown
 >;
 
-export const contextEngineCompactMock = vi.fn(async () => ({
-  ok: true as boolean,
-  compacted: true as boolean,
-  reason: undefined as string | undefined,
-  failure: undefined as
-    | {
-        reason?: string;
-        status?: number;
-        code?: string;
-        rawError?: string;
-      }
-    | undefined,
-  result: { summary: "engine-summary", tokensAfter: 50 } as
-    | { summary: string; tokensAfter: number }
-    | undefined,
-}));
+type MockCompactionResult = {
+  ok: boolean;
+  compacted: boolean;
+  reason?: string;
+  failure?: {
+    reason?: string;
+    status?: number;
+    code?: string;
+    rawError?: string;
+  };
+  result?: { summary: string; tokensAfter: number };
+};
+
+export const contextEngineCompactMock = vi.fn(
+  async (): Promise<MockCompactionResult> => ({
+    ok: true,
+    compacted: true,
+    reason: undefined,
+    result: { summary: "engine-summary", tokensAfter: 50 },
+  }),
+);
 
 export const hookRunner = {
   hasHooks: vi.fn<(hookName?: string) => boolean>(),

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -36,6 +36,14 @@ export const contextEngineCompactMock = vi.fn(async () => ({
   ok: true as boolean,
   compacted: true as boolean,
   reason: undefined as string | undefined,
+  failure: undefined as
+    | {
+        reason?: string;
+        status?: number;
+        code?: string;
+        rawError?: string;
+      }
+    | undefined,
   result: { summary: "engine-summary", tokensAfter: 50 } as
     | { summary: string; tokensAfter: number }
     | undefined,
@@ -578,6 +586,7 @@ export function resetCompactHooksHarnessMocks(): void {
     ok: true,
     compacted: true,
     reason: undefined,
+    failure: undefined,
     result: { summary: "engine-summary", tokensAfter: 50 },
   });
   compactWithSafetyTimeoutMock.mockReset();

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -3987,6 +3987,25 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(sync).not.toHaveBeenCalled();
   });
 
+  it("preserves structured provider failures through queued compaction", async () => {
+    contextEngineCompactMock.mockResolvedValue({
+      ok: false,
+      compacted: false,
+      reason: "Provider returned 503",
+      failure: { reason: "server_error", status: 503, code: "upstream_unavailable" },
+      result: undefined,
+    });
+
+    const result = await compactEmbeddedAgentSession(wrappedCompactionArgs());
+
+    expect(result).toMatchObject({
+      ok: false,
+      compacted: false,
+      reason: "Provider returned 503",
+      failure: { reason: "server_error", status: 503, code: "upstream_unavailable" },
+    });
+  });
+
   it("surfaces a hung/throwing engine compact() as a clean ok:false result", async () => {
     hookRunner.hasHooks.mockReturnValue(true);
     // The safety-timeout wrapper rejects on timeout; a thrown rejection here

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -4018,7 +4018,34 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     expect(result.ok).toBe(false);
     expect(result.compacted).toBe(false);
     expect(result.reason).toContain("timed out");
+    expect(result.failure).toMatchObject({ reason: "timeout", status: 408 });
     expect(hookRunner.runAfterCompaction).not.toHaveBeenCalled();
+  });
+
+  it("preserves transient failure metadata after all compaction fallbacks fail", async () => {
+    sessionCompactImpl
+      .mockRejectedValueOnce(
+        Object.assign(new Error("primary compaction rate limited"), {
+          status: 429,
+          code: "rate_limit_exceeded",
+        }),
+      )
+      .mockRejectedValueOnce(
+        Object.assign(new Error("fallback compaction rate limited"), {
+          status: 429,
+          code: "rate_limit_exceeded",
+        }),
+      );
+
+    const result = await compactEmbeddedAgentSessionDirect({
+      ...wrappedCompactionArgs({ provider: "openai", model: "gpt-primary" }),
+      modelFallbacksOverride: ["anthropic/claude-fallback"],
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      failure: { reason: "rate_limit", status: 429, code: "rate_limit_exceeded" },
+    });
   });
 
   it("forces engine-owned compaction for preflight-required budget compaction", async () => {

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -4048,6 +4048,39 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
   });
 
+  it.each([
+    [
+      "400 then 503",
+      Object.assign(new Error("primary compaction rejected"), { status: 400 }),
+      Object.assign(new Error("fallback compaction unavailable"), {
+        status: 503,
+        code: "upstream_unavailable",
+      }),
+      { reason: "format", status: 400 },
+    ],
+    [
+      "401 then timeout",
+      Object.assign(new Error("primary compaction unauthorized"), { status: 401 }),
+      Object.assign(new Error("fallback compaction timed out"), {
+        status: 408,
+        code: "ETIMEDOUT",
+      }),
+      { reason: "auth", status: 401 },
+    ],
+  ])(
+    "keeps the terminal failure across %s fallback exhaustion",
+    async (_caseName, primaryError, fallbackError, expectedFailure) => {
+      sessionCompactImpl.mockRejectedValueOnce(primaryError).mockRejectedValueOnce(fallbackError);
+
+      const result = await compactEmbeddedAgentSessionDirect({
+        ...wrappedCompactionArgs({ provider: "openai", model: "gpt-primary" }),
+        modelFallbacksOverride: ["anthropic/claude-fallback"],
+      });
+
+      expect(result).toMatchObject({ ok: false, failure: expectedFailure });
+    },
+  );
+
   it("forces engine-owned compaction for preflight-required budget compaction", async () => {
     const result = await compactEmbeddedAgentSession(
       wrappedCompactionArgs({

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -827,6 +827,7 @@ async function compactResolvedContextEngine(
           ok: result.ok,
           compacted: result.compacted,
           reason: result.reason,
+          ...(result.failure ? { failure: result.failure } : {}),
           result: result.result
             ? {
                 summary: result.result.summary ?? "",

--- a/src/agents/embedded-agent-runner/compact.queued.ts
+++ b/src/agents/embedded-agent-runner/compact.queued.ts
@@ -24,6 +24,7 @@ import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { resolveUserPath } from "../../utils.js";
 import { normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
 import { resolveAgentDir, resolveDefaultAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
+import { coerceToFailoverError } from "../failover-error.js";
 import { isRecoverableNativeHarnessBindingFailure } from "../harness/compaction-recovery.js";
 import { maybeCompactAgentHarnessSession } from "../harness/compaction.js";
 import { ensureSelectedAgentHarnessPlugin } from "../harness/runtime-plugin.js";
@@ -693,10 +694,24 @@ async function compactResolvedContextEngine(
           log.warn("context-engine compaction failed", {
             errorMessage: formatErrorMessage(compactErr),
           });
+          const failoverError = coerceToFailoverError(compactErr, {
+            provider: params.provider,
+            model: params.model,
+          });
           result = {
             ok: false,
             compacted: false,
             reason: formatErrorMessage(compactErr),
+            ...(failoverError
+              ? {
+                  failure: {
+                    reason: failoverError.reason,
+                    status: failoverError.status,
+                    code: failoverError.code,
+                    rawError: failoverError.rawError,
+                  },
+                }
+              : {}),
           };
         }
         const successor = await resolveContextEngineCompactionSuccessor({

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -27,6 +27,7 @@ import {
   resolveAgentRunSessionTarget,
 } from "../run-session-target.js";
 import { resolveSystemPromptRepoRoot } from "../system-prompt-params.js";
+import { isTransientCompactionFailureResult } from "./compact-reasons.js";
 import type {
   CompactEmbeddedAgentSessionParams,
   CompactEmbeddedAgentSessionRuntimeParams,
@@ -107,6 +108,7 @@ function classifyCompactionFallbackResult(
         code: failoverError.code,
         rawError: failoverError.rawError,
         preserveResultOnExhaustion: true,
+        preserveResultPriority: isTransientCompactionFailureResult(result) ? 0 : 1,
       }
     : null;
 }

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -99,15 +99,35 @@ function classifyCompactionFallbackResult(
     code: result.failure?.code,
   });
   const failoverError = coerceToFailoverError(failureError, { provider, model });
-  return failoverError ? { error: failoverError } : null;
+  return failoverError
+    ? {
+        message: failoverError.message,
+        reason: failoverError.reason,
+        status: failoverError.status,
+        code: failoverError.code,
+        rawError: failoverError.rawError,
+        preserveResultOnExhaustion: true,
+      }
+    : null;
 }
 
 function fallbackFailureToCompactionResult(err: unknown): EmbeddedAgentCompactResult {
   const reason = isFallbackSummaryError(err) ? err.message : formatErrorMessage(err);
+  const failoverError = coerceToFailoverError(err);
   return {
     ok: false,
     compacted: false,
     reason,
+    ...(failoverError
+      ? {
+          failure: {
+            reason: failoverError.reason,
+            status: failoverError.status,
+            code: failoverError.code,
+            rawError: failoverError.rawError,
+          },
+        }
+      : {}),
   };
 }
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1632,15 +1632,24 @@ describe("runMemoryFlushIfNeeded", () => {
   });
 
   it.each([
-    ["failed timeout", false, "Compaction timed out"],
-    ["failed 429", false, "Provider returned 429 rate limit"],
-    ["failed 503", false, "Provider returned 503 from model"],
-    ["successful timeout no-op", true, "Compaction timed out"],
-    ["successful 429 no-op", true, "Provider returned 429 rate limit"],
-    ["successful 503 no-op", true, "Provider returned 503 from model"],
+    [
+      "failed timeout",
+      "Compaction timed out",
+      { reason: "timeout", status: 408, code: "ETIMEDOUT" },
+    ],
+    [
+      "failed 429",
+      "Provider returned 429 rate limit",
+      { reason: "rate_limit", status: 429, code: "rate_limit_exceeded" },
+    ],
+    [
+      "failed 503",
+      "Provider returned 503 from model",
+      { reason: "server_error", status: 503, code: "upstream_unavailable" },
+    ],
   ])(
     "continues when required preflight compaction reports a transient %s result",
-    async (_caseName, ok, reason) => {
+    async (_caseName, reason, failure) => {
       const sessionFile = path.join(rootDir, "session.jsonl");
       await fs.writeFile(
         sessionFile,
@@ -1656,9 +1665,10 @@ describe("runMemoryFlushIfNeeded", () => {
         relativePath: "memory/2023-11-14.md",
       }));
       compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
-        ok,
+        ok: false,
         compacted: false,
         reason,
+        failure,
       });
       const sessionEntry: SessionEntry = {
         sessionId: "session",
@@ -1696,12 +1706,13 @@ describe("runMemoryFlushIfNeeded", () => {
   );
 
   it.each([
-    ["failed 400", false, "Provider returned 400"],
-    ["failed 401", false, "Provider returned 401"],
+    ["failed 400", false, "Provider returned 400", { reason: "format", status: 400 }],
+    ["failed 401", false, "Provider returned 401", { reason: "auth", status: 401 }],
     ["successful 403 no-op", true, "Provider returned 403"],
+    ["text-only transient", false, "Provider returned 503 from model"],
   ])(
     "still fails required preflight compaction for non-retryable %s result",
-    async (_caseName, ok, reason) => {
+    async (_caseName, ok, reason, failure) => {
       const sessionFile = path.join(rootDir, "session.jsonl");
       await fs.writeFile(
         sessionFile,
@@ -1720,6 +1731,7 @@ describe("runMemoryFlushIfNeeded", () => {
         ok,
         compacted: false,
         reason,
+        ...(failure ? { failure } : {}),
       });
       const sessionEntry: SessionEntry = {
         sessionId: "session",

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1708,6 +1708,12 @@ describe("runMemoryFlushIfNeeded", () => {
   it.each([
     ["failed 400", false, "Provider returned 400", { reason: "format", status: 400 }],
     ["failed 401", false, "Provider returned 401", { reason: "auth", status: 401 }],
+    [
+      "failed TLS certificate",
+      false,
+      "Provider certificate verification failed",
+      { reason: "tls_certificate", status: 502 },
+    ],
     ["successful 403 no-op", true, "Provider returned 403", undefined],
     ["text-only transient", false, "Provider returned 503 from model", undefined],
   ])(

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -22,6 +22,8 @@ import {
 } from "../../plugins/memory-state.test-fixtures.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import { cleanupSessionStateForTest } from "../../test-utils/session-state-cleanup.js";
 import type { TemplateContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { runMemoryFlushIfNeeded, runPreflightCompactionIfNeeded } from "./agent-runner-memory.js";
@@ -372,7 +374,9 @@ describe("runMemoryFlushIfNeeded", () => {
     cliBackendsTesting.resetDepsForTest();
     setActivePluginRegistry(createEmptyPluginRegistry());
     clearMemoryPluginState();
-    await fs.rm(rootDir, { recursive: true, force: true });
+    await cleanupSessionStateForTest();
+    closeOpenClawAgentDatabasesForTest();
+    await fs.rm(rootDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 25 });
   });
 
   it("runs a memory flush turn, rotates after compaction, and persists metadata", async () => {
@@ -1626,6 +1630,132 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
     expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "incomplete");
   });
+
+  it.each([
+    ["failed timeout", false, "Compaction timed out"],
+    ["failed 429", false, "Provider returned 429 rate limit"],
+    ["failed 503", false, "Provider returned 503 from model"],
+    ["successful timeout no-op", true, "Compaction timed out"],
+    ["successful 429 no-op", true, "Provider returned 429 rate limit"],
+    ["successful 503 no-op", true, "Provider returned 503 from model"],
+  ])(
+    "continues when required preflight compaction reports a transient %s result",
+    async (_caseName, ok, reason) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+        "utf8",
+      );
+      registerMemoryFlushPlanResolverForTest(() => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 0,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
+      compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+        ok,
+        compacted: false,
+        reason,
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        transcriptPath: sessionFile,
+        updatedAt: Date.now(),
+        totalTokens: 120,
+        totalTokensFresh: true,
+      };
+      const onCompactionNotice = vi.fn();
+
+      const entry = await runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:main",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore: { "agent:main:main": sessionEntry },
+        sessionKey: "agent:main:main",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+        onCompactionNotice,
+      });
+
+      expect(entry).toBe(sessionEntry);
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "skipped");
+    },
+  );
+
+  it.each([
+    ["failed 400", false, "Provider returned 400"],
+    ["failed 401", false, "Provider returned 401"],
+    ["successful 403 no-op", true, "Provider returned 403"],
+  ])(
+    "still fails required preflight compaction for non-retryable %s result",
+    async (_caseName, ok, reason) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+        "utf8",
+      );
+      registerMemoryFlushPlanResolverForTest(() => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 0,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
+      compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+        ok,
+        compacted: false,
+        reason,
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        transcriptPath: sessionFile,
+        updatedAt: Date.now(),
+        totalTokens: 120,
+        totalTokensFresh: true,
+      };
+      const onCompactionNotice = vi.fn();
+
+      await expect(
+        runPreflightCompactionIfNeeded({
+          cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+          followupRun: createTestFollowupRun({
+            sessionId: "session",
+            sessionFile,
+            sessionKey: "agent:main:main",
+          }),
+          defaultModel: "anthropic/claude-opus-4-6",
+          agentCfgContextTokens: 100,
+          sessionEntry,
+          sessionStore: { "agent:main:main": sessionEntry },
+          sessionKey: "agent:main:main",
+          storePath: path.join(rootDir, "sessions.json"),
+          isHeartbeat: false,
+          replyOperation: createReplyOperation(),
+          onCompactionNotice,
+        }),
+      ).rejects.toThrow(`Preflight compaction required but failed: ${reason}`);
+
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "incomplete");
+    },
+  );
 
   it("fails when required preflight context-engine compaction is deferred to background maintenance", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1701,7 +1701,7 @@ describe("runMemoryFlushIfNeeded", () => {
       expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
       expect(incrementCompactionCountMock).not.toHaveBeenCalled();
       expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
-      expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "skipped");
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "transient_failure");
     },
   );
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1708,8 +1708,8 @@ describe("runMemoryFlushIfNeeded", () => {
   it.each([
     ["failed 400", false, "Provider returned 400", { reason: "format", status: 400 }],
     ["failed 401", false, "Provider returned 401", { reason: "auth", status: 401 }],
-    ["successful 403 no-op", true, "Provider returned 403"],
-    ["text-only transient", false, "Provider returned 503 from model"],
+    ["successful 403 no-op", true, "Provider returned 403", undefined],
+    ["text-only transient", false, "Provider returned 503 from model", undefined],
   ])(
     "still fails required preflight compaction for non-retryable %s result",
     async (_caseName, ok, reason, failure) => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -66,12 +66,12 @@ type TestReplyOperation = ReplyOperation & {
   updateSessionId: ReturnType<typeof vi.fn<ReplyOperation["updateSessionId"]>>;
 };
 
-function createReplyOperation(): TestReplyOperation {
+function createReplyOperation(abortSignal = new AbortController().signal): TestReplyOperation {
   const now = Date.now();
   return {
     key: "test",
     sessionId: "session",
-    abortSignal: new AbortController().signal,
+    abortSignal,
     staleExpiryReason: undefined,
     resetTriggered: false,
     terminalRecovery: false,
@@ -1704,6 +1704,67 @@ describe("runMemoryFlushIfNeeded", () => {
       expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "skipped");
     },
   );
+
+  it("keeps a timeout-shaped external cancellation terminal", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    const abortController = new AbortController();
+    const replyOperation = createReplyOperation(abortController.signal);
+    compactEmbeddedAgentSessionMock.mockImplementationOnce(async () => {
+      abortController.abort(new Error("request timed out"));
+      return {
+        ok: false,
+        compacted: false,
+        reason: "Compaction timed out",
+        failure: { reason: "timeout", status: 408, code: "ETIMEDOUT" },
+      };
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      transcriptPath: sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 120,
+      totalTokensFresh: true,
+    };
+    const onCompactionNotice = vi.fn();
+
+    await expect(
+      runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:main",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore: { "agent:main:main": sessionEntry },
+        sessionKey: "agent:main:main",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation,
+        onCompactionNotice,
+      }),
+    ).rejects.toThrow("Preflight compaction required but failed: Compaction timed out");
+
+    expect(replyOperation.abortSignal.aborted).toBe(true);
+    expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
+    expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "incomplete");
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+  });
 
   it.each([
     ["failed 400", false, "Provider returned 400", { reason: "format", status: 400 }],

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -11,7 +11,10 @@ import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
 import { estimateMessagesTokens } from "../../agents/compaction.js";
-import { isBenignCompactionSkipResult } from "../../agents/embedded-agent-runner/compact-reasons.js";
+import {
+  isBenignCompactionSkipResult,
+  isTransientCompactionFailureReason,
+} from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-entry.js";
 import { isCliRuntimeAliasForProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -193,6 +196,17 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.agentRunnerMemoryTestApi")] = {
     setAgentRunnerMemoryTestDeps,
   };
+}
+
+function shouldSkipRequiredPreflightCompactionResult(result: {
+  ok: boolean;
+  compacted: boolean;
+  reason?: string;
+}): boolean {
+  if (result.compacted) {
+    return false;
+  }
+  return isBenignCompactionSkipResult(result) || isTransientCompactionFailureReason(result.reason);
 }
 
 function estimatePromptTokensForMemoryFlush(prompt?: string): number | undefined {
@@ -920,7 +934,7 @@ export async function runPreflightCompactionIfNeeded(params: {
 
     if (!result?.ok) {
       const reason = result?.reason ?? "not_compacted";
-      if (result && isBenignCompactionSkipResult(result)) {
+      if (result && shouldSkipRequiredPreflightCompactionResult(result)) {
         await notifyTerminalCompaction("skipped");
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;
@@ -932,7 +946,7 @@ export async function runPreflightCompactionIfNeeded(params: {
 
     if (!result.compacted) {
       const reason = normalizeOptionalString(result.reason) ?? "not_compacted";
-      if (isBenignCompactionSkipResult(result)) {
+      if (shouldSkipRequiredPreflightCompactionResult(result)) {
         await notifyTerminalCompaction("skipped");
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -885,7 +885,9 @@ export async function runPreflightCompactionIfNeeded(params: {
     startedCompactionNotice = true;
     await notifyCompaction("start");
   };
-  const notifyTerminalCompaction = async (phase: "end" | "incomplete" | "skipped") => {
+  const notifyTerminalCompaction = async (
+    phase: "end" | "incomplete" | "skipped" | "transient_failure",
+  ) => {
     terminalCompactionNoticeSent = true;
     await notifyCompaction(phase);
   };
@@ -949,8 +951,14 @@ export async function runPreflightCompactionIfNeeded(params: {
         result &&
         shouldSkipRequiredPreflightCompactionResult(result, params.replyOperation.abortSignal)
       ) {
-        await notifyTerminalCompaction("skipped");
-        logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
+        await notifyTerminalCompaction(
+          isTransientCompactionFailureResult(result) ? "transient_failure" : "skipped",
+        );
+        logVerbose(
+          isTransientCompactionFailureResult(result)
+            ? `preflightCompaction continued after transient failure: sessionKey=${params.sessionKey} reason=${reason}`
+            : `preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`,
+        );
         return entry ?? params.sessionEntry;
       }
       await notifyTerminalCompaction("incomplete");
@@ -961,8 +969,14 @@ export async function runPreflightCompactionIfNeeded(params: {
     if (!result.compacted) {
       const reason = normalizeOptionalString(result.reason) ?? "not_compacted";
       if (shouldSkipRequiredPreflightCompactionResult(result, params.replyOperation.abortSignal)) {
-        await notifyTerminalCompaction("skipped");
-        logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
+        await notifyTerminalCompaction(
+          isTransientCompactionFailureResult(result) ? "transient_failure" : "skipped",
+        );
+        logVerbose(
+          isTransientCompactionFailureResult(result)
+            ? `preflightCompaction continued after transient failure: sessionKey=${params.sessionKey} reason=${reason}`
+            : `preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`,
+        );
         return entry ?? params.sessionEntry;
       }
       await notifyTerminalCompaction("incomplete");

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -198,17 +198,23 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   };
 }
 
-function shouldSkipRequiredPreflightCompactionResult(result: {
-  ok: boolean;
-  compacted: boolean;
-  reason?: string;
-  failure?: {
+function shouldSkipRequiredPreflightCompactionResult(
+  result: {
+    ok: boolean;
+    compacted: boolean;
     reason?: string;
-    status?: number;
-    code?: string;
-  };
-}): boolean {
+    failure?: {
+      reason?: string;
+      status?: number;
+      code?: string;
+    };
+  },
+  abortSignal?: AbortSignal,
+): boolean {
   if (result.compacted) {
+    return false;
+  }
+  if (abortSignal?.aborted) {
     return false;
   }
   return isBenignCompactionSkipResult(result) || isTransientCompactionFailureResult(result);
@@ -939,7 +945,10 @@ export async function runPreflightCompactionIfNeeded(params: {
 
     if (!result?.ok) {
       const reason = result?.reason ?? "not_compacted";
-      if (result && shouldSkipRequiredPreflightCompactionResult(result)) {
+      if (
+        result &&
+        shouldSkipRequiredPreflightCompactionResult(result, params.replyOperation.abortSignal)
+      ) {
         await notifyTerminalCompaction("skipped");
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;
@@ -951,7 +960,7 @@ export async function runPreflightCompactionIfNeeded(params: {
 
     if (!result.compacted) {
       const reason = normalizeOptionalString(result.reason) ?? "not_compacted";
-      if (shouldSkipRequiredPreflightCompactionResult(result)) {
+      if (shouldSkipRequiredPreflightCompactionResult(result, params.replyOperation.abortSignal)) {
         await notifyTerminalCompaction("skipped");
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -13,7 +13,7 @@ import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
 import { estimateMessagesTokens } from "../../agents/compaction.js";
 import {
   isBenignCompactionSkipResult,
-  isTransientCompactionFailureReason,
+  isTransientCompactionFailureResult,
 } from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-entry.js";
 import { isCliRuntimeAliasForProvider } from "../../agents/model-runtime-aliases.js";
@@ -202,11 +202,16 @@ function shouldSkipRequiredPreflightCompactionResult(result: {
   ok: boolean;
   compacted: boolean;
   reason?: string;
+  failure?: {
+    reason?: string;
+    status?: number;
+    code?: string;
+  };
 }): boolean {
   if (result.compacted) {
     return false;
   }
-  return isBenignCompactionSkipResult(result) || isTransientCompactionFailureReason(result.reason);
+  return isBenignCompactionSkipResult(result) || isTransientCompactionFailureResult(result);
 }
 
 function estimatePromptTokensForMemoryFlush(prompt?: string): number | undefined {

--- a/src/auto-reply/reply/compaction-notice.test.ts
+++ b/src/auto-reply/reply/compaction-notice.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { createCompactionNoticePayload } from "./compaction-notice.js";
+
+describe("compaction notice payloads", () => {
+  it("reports transient recovery as degraded while continuing", () => {
+    expect(createCompactionNoticePayload({ phase: "transient_failure" }).text).toBe(
+      "⚠️ Compaction temporarily failed; continuing your reply.",
+    );
+  });
+
+  it("keeps skipped for genuine no-op compaction", () => {
+    expect(createCompactionNoticePayload({ phase: "skipped" }).text).toBe(
+      "🧹 Compaction not needed",
+    );
+  });
+});

--- a/src/auto-reply/reply/compaction-notice.ts
+++ b/src/auto-reply/reply/compaction-notice.ts
@@ -9,6 +9,7 @@ export type CompactionNoticePhase =
   | "end"
   | "incomplete"
   | "skipped"
+  | "transient_failure"
   | "memory_flush_degraded";
 
 const COMPACTION_NOTICE_TEXT: Record<CompactionNoticePhase, string> = {
@@ -16,6 +17,7 @@ const COMPACTION_NOTICE_TEXT: Record<CompactionNoticePhase, string> = {
   end: "🧹 Compaction complete",
   incomplete: "🧹 Compaction incomplete",
   skipped: "🧹 Compaction not needed",
+  transient_failure: "⚠️ Compaction temporarily failed; continuing your reply.",
   memory_flush_degraded: "⚠️ Memory maintenance temporarily failed; continuing your reply.",
 };
 

--- a/src/auto-reply/reply/followup-turn-admission.test.ts
+++ b/src/auto-reply/reply/followup-turn-admission.test.ts
@@ -121,6 +121,30 @@ beforeEach(() => {
 });
 
 describe("admitFollowupTurn", () => {
+  it("delivers a degraded notice when transient preflight compaction continues", async () => {
+    const operation = createOperation();
+    const sessionEntry: SessionEntry = { sessionId: "queued-session", updatedAt: 1 };
+    const onCompactionNoticePayload = vi.fn();
+    state.admitReply.mockResolvedValue({ status: "owned", operation, sessionEntry });
+    state.shouldNotifyCompaction = true;
+    state.preflight.mockImplementation(async ({ onCompactionNotice, sessionEntry: entry }) => {
+      await onCompactionNotice?.("transient_failure");
+      return entry;
+    });
+
+    await expect(
+      admitFollowupTurn({
+        queued: createRun(),
+        defaults: createDefaults({ sessionEntry }),
+        onCompactionNoticePayload,
+      }),
+    ).resolves.toMatchObject({ kind: "admitted" });
+    expect(onCompactionNoticePayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "transient_failure" }),
+      expect.anything(),
+    );
+  });
+
   it("returns a closed deferral without adopting the queued source", async () => {
     state.admitReply.mockResolvedValue({ status: "skipped", reason: "active-run" });
 

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -299,6 +299,51 @@ describe("Engine contract tests", () => {
     });
   });
 
+  it("delegateCompactionToRuntime preserves structured provider failures", async () => {
+    installCompactRuntimeSpy();
+    const failure = {
+      ok: false,
+      compacted: false,
+      reason: "Provider returned 503",
+      failure: {
+        reason: "server_error",
+        status: 503,
+        code: "upstream_unavailable",
+        rawError: "loopback upstream unavailable",
+      },
+    } as const;
+    compactEmbeddedAgentSessionDirectMock
+      .mockResolvedValueOnce(failure)
+      .mockResolvedValueOnce(failure);
+
+    const expected = {
+      ok: false,
+      compacted: false,
+      reason: "Provider returned 503",
+      failure: {
+        reason: "server_error",
+        status: 503,
+        code: "upstream_unavailable",
+      },
+    };
+
+    await expect(
+      new LegacyContextEngine().compact({
+        sessionId: "s-failure",
+        sessionKey: "agent:main:s-failure",
+        runtimeContext: { workspaceDir: "/tmp/workspace" },
+      }),
+    ).resolves.toMatchObject(expected);
+
+    await expect(
+      delegateCompactionToRuntime({
+        sessionId: "s-failure",
+        sessionKey: "agent:main:s-failure",
+        runtimeContext: { workspaceDir: "/tmp/workspace" },
+      }),
+    ).resolves.toMatchObject(expected);
+  });
+
   it("delegateCompactionToRuntime returns successor sessionTarget without sessionFile", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "context-successor-target-"));
     const storePath = path.join(root, "openclaw-agent.sqlite");

--- a/src/context-engine/delegate.ts
+++ b/src/context-engine/delegate.ts
@@ -201,6 +201,7 @@ export async function delegateCompactionToRuntime(
     ok: result.ok,
     compacted: result.compacted,
     reason: result.reason,
+    ...(result.failure ? { failure: result.failure } : {}),
     result: result.result
       ? {
           summary: result.result.summary,

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -113,6 +113,13 @@ export type CompactResult = {
   ok: boolean;
   compacted: boolean;
   reason?: string;
+  /** Structured provider failure metadata used by callers to classify retryable errors. */
+  failure?: {
+    reason?: string;
+    status?: number;
+    code?: string;
+    rawError?: string;
+  };
   result?: {
     summary?: string;
     firstKeptEntryId?: string;


### PR DESCRIPTION
Closes #100778

## What Problem This Solves

Fixes reply runs ending before the agent starts when required preflight compaction encounters a transient maintenance-model timeout, rate limit, or 5xx provider failure.

## Why This Change Was Made

The preflight compaction runner distinguishes retryable provider failures from non-retryable request/auth failures. Transient failures keep the existing session entry so the reply can continue; terminal provider, auth, binding, cancellation, and malformed-request failures remain blocking.

## User Impact

Transient compaction-provider outages no longer terminate the active reply. A recovered transient failure is reported honestly as degraded continuation, while genuine no-op compaction remains reported as skipped.

## Evidence

Exact current-head behavior proof for `4383a10dcff2c6a506eb88b278ef5a546c837be4`:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts -t "continues when preflight compaction reports the session is already under target|continues when required preflight compaction reports a transient|keeps a timeout-shaped external cancellation terminal"
5 passed, 65 skipped

node scripts/run-vitest.mjs src/auto-reply/reply/compaction-notice.test.ts src/auto-reply/reply/followup-turn-admission.test.ts -t "transient|degraded|compaction notice payloads"
3 passed, 36 skipped
```

Observed result:

- Transient timeout/408, rate-limit/429, and server-error/503 results continue with the original session when they are the surviving fallback result.
- Transient preflight recovery emits `⚠️ Compaction temporarily failed; continuing your reply.`.
- Genuine `already under target` no-op compaction emits `🧹 Compaction not needed`.
- Follow-up admission forwards the degraded transient notice payload.
- Timeout-shaped external cancellation and terminal 400/401 failures remain terminal.

Supporting checks:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compact-reasons.test.ts` — 33 passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compact.hooks.test.ts -t "preserves transient failure metadata after all compaction fallbacks fail|preserves structured provider failures through queued compaction|keeps the terminal failure across"` — 8 passed, 248 skipped.
- `oxfmt --check` on the five touched TypeScript files and `git diff --check` passed.

Proof boundary:

This is local Composer/preflight behavior proof with controlled fixtures and no external credentials. It proves the transient recovery classification and user-visible notice mapping, but does not claim credentialed external-provider or channel-specific delivery.

Exact head: `4383a10dcff2c6a506eb88b278ef5a546c837be4`