### PR TITLE
fix(matrix): agent reply buttons never reach the room

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -413,6 +413,7 @@ export function createMatrixReplyDispatcher(config: {
         const shouldRedactDraft =
           Boolean(draftEventId) &&
           (payload.isError ||
+            carriesPresentationControls ||
             payloadReplyMismatch ||
             mustDeliverFinalNormally ||
             draftFinalTextNeedsNormalMentionDelivery);

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -5,6 +5,10 @@ import {
   type MessageReceipt,
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  hasMessagePresentationBlocks,
+  normalizeMessagePresentation,
+} from "openclaw/plugin-sdk/interactive-runtime";
+import {
   buildTtsSupplementMediaPayload,
   getReplyPayloadTtsSupplement,
 } from "openclaw/plugin-sdk/reply-payload";
@@ -171,9 +175,15 @@ export function createMatrixReplyDispatcher(config: {
           !threadTarget &&
           payloadReplyToId !== draftController.currentReplyToId();
         let mustDeliverFinalNormally = draftStream.mustDeliverFinalNormally();
+        // Finalizing edits the draft event in place, which cannot attach the
+        // presentation controls; normal delivery owns that encoding.
+        const carriesPresentationControls = hasMessagePresentationBlocks(
+          normalizeMessagePresentation(payload.presentation),
+        );
         const canPotentiallyFinalizeDraft =
           Boolean(payload.text?.trim()) &&
           !payload.isError &&
+          !carriesPresentationControls &&
           !payloadReplyMismatch &&
           !mustDeliverFinalNormally;
 
@@ -198,6 +208,7 @@ export function createMatrixReplyDispatcher(config: {
           payload.text &&
           !payload.isError &&
           !hasMedia &&
+          !carriesPresentationControls &&
           !payloadReplyMismatch &&
           !mustDeliverFinalNormally &&
           !draftFinalTextNeedsNormalMentionDelivery

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3654,7 +3654,7 @@ describe("matrix monitor handler draft streaming", () => {
         presentation: {
           blocks: [{ type: "buttons", buttons: [{ label: "Approve", value: "approve" }] }],
         },
-      },
+      } as never,
       { kind: "final" },
     );
 

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3636,6 +3636,43 @@ describe("matrix monitor handler draft streaming", () => {
     await finish();
   });
 
+  it("redacts the draft and routes control-bearing finals through normal delivery", async () => {
+    const { dispatch, redactEventMock } = createStreamingHarness({
+      blockStreamingEnabled: true,
+      streaming: "partial",
+    });
+    const { deliver, opts, finish } = await dispatch();
+
+    opts.onPartialReply?.({ text: "Deployment ready." });
+    await waitForMatrixState(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    await deliver(
+      {
+        text: "Deployment ready.",
+        presentation: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Approve", value: "approve" }] }],
+        },
+      },
+      { kind: "final" },
+    );
+
+    // An in-place finalize edit cannot carry controls, so the draft must be
+    // redacted and the final must go through normal delivery exactly once.
+    expect(editMessageMatrixMock).not.toHaveBeenCalled();
+    expect(redactEventMock).toHaveBeenCalledWith("!room:example.org", "$draft1");
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
+    const deliverParams = requireRecord(
+      callArg(deliverMatrixRepliesMock, 0, 0, "deliver replies params"),
+      "deliver replies params",
+    );
+    const replies = requireArray(deliverParams.replies, "delivered replies");
+    expect(replies).toHaveLength(1);
+    expect(requireRecord(replies[0], "delivered reply").presentation).toBeDefined();
+    await finish();
+  });
+
   it("redacts partial previews before normal final delivery for changed Matrix mentions", async () => {
     const { dispatch, redactEventMock } = createStreamingHarness({
       blockStreamingEnabled: true,

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -1,3 +1,4 @@
+import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 // Matrix tests cover replies plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime, RuntimeEnv } from "../../../runtime-api.js";
@@ -559,7 +560,7 @@ describe("deliverMatrixReplies presentation controls", () => {
     error: errorMock,
   } as unknown as RuntimeEnv;
 
-  const buttonPresentation = {
+  const buttonPresentation: MessagePresentation = {
     title: "FY25 outlook",
     blocks: [{ type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] }],
   };
@@ -580,6 +581,7 @@ describe("deliverMatrixReplies presentation controls", () => {
     client: {} as MatrixClient,
     runtime: runtimeEnv,
     textLimit: 4000,
+    replyToMode: "off" as const,
   };
 
   beforeEach(() => {
@@ -646,8 +648,10 @@ describe("deliverMatrixReplies presentation controls", () => {
       replies: [
         {
           text: "Ready to deploy?",
-          presentation: { blocks: [{ type: "text", text: "Ready to deploy?" }] },
-          presentationTextMode: "fallback",
+          presentation: {
+            blocks: [{ type: "text", text: "Ready to deploy?" }],
+          } satisfies MessagePresentation,
+          presentationTextMode: "fallback" as const,
         },
       ],
     });

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -538,3 +538,129 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(0).mediaUrl).toBe("https://example.com/a.jpg");
   });
 });
+
+describe("deliverMatrixReplies presentation controls", () => {
+  const cfg = { channels: { matrix: {} } };
+  const runtimeStub = {
+    config: { current: () => ({}) },
+    channel: {
+      text: {
+        resolveMarkdownTableMode: () => "code",
+        convertMarkdownTables: (text: string) => text,
+        resolveChunkMode: () => "length",
+        chunkMarkdownTextWithMode: (text: string) => [text],
+      },
+    },
+    logging: { shouldLogVerbose: () => false },
+  } as unknown as PluginRuntime;
+  const errorMock = vi.fn();
+  const runtimeEnv: RuntimeEnv = {
+    log: vi.fn(),
+    error: errorMock,
+  } as unknown as RuntimeEnv;
+
+  const buttonPresentation = {
+    title: "FY25 outlook",
+    blocks: [{ type: "buttons", buttons: [{ label: "Refresh", value: "refresh" }] }],
+  };
+
+  function presentationContent(index: number) {
+    const extraContent = sendOptions(index).extraContent;
+    if (!extraContent || typeof extraContent !== "object") {
+      return undefined;
+    }
+    return (extraContent as Record<string, unknown>)["com.openclaw.presentation"] as
+      | Record<string, unknown>
+      | undefined;
+  }
+
+  const delivery = {
+    cfg,
+    roomId: "room:1",
+    client: {} as MatrixClient,
+    runtime: runtimeEnv,
+    textLimit: 4000,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    nextMessageId = 0;
+    sendMessageMatrixMock.mockReset().mockImplementation(resolveMockMatrixSend);
+    setMatrixRuntime(runtimeStub);
+    chunkMatrixTextMock.mockReset().mockImplementation((text: string) => ({
+      trimmedText: text.trim(),
+      convertedText: text,
+      singleEventLimit: 4000,
+      fitsInSingleEvent: true,
+      chunks: text ? [text] : [],
+    }));
+  });
+
+  it("encodes presentation controls onto the delivered event", async () => {
+    await deliverMatrixReplies({
+      ...delivery,
+      replies: [{ text: "Quarterly results", presentation: buttonPresentation }],
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    const presentation = presentationContent(0);
+    expect(presentation).toBeDefined();
+    expect(presentation?.version).toBe(1);
+    expect(presentation?.type).toBe("message.presentation");
+    expect(presentation?.blocks).toEqual(buttonPresentation.blocks);
+  });
+
+  it("delivers a controls-only reply instead of dropping it as missing text", async () => {
+    await deliverMatrixReplies({
+      ...delivery,
+      replies: [{ presentation: buttonPresentation }],
+    });
+
+    expect(errorMock).not.toHaveBeenCalledWith("matrix reply missing text/media");
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(presentationContent(0)).toBeDefined();
+  });
+
+  it("attaches controls to the first chunk only", async () => {
+    chunkMatrixTextMock.mockImplementation((text: string) => ({
+      trimmedText: text.trim(),
+      convertedText: text,
+      singleEventLimit: 10,
+      fitsInSingleEvent: false,
+      chunks: text.split("|"),
+    }));
+
+    await deliverMatrixReplies({
+      ...delivery,
+      replies: [{ text: "part-a|part-b", presentation: buttonPresentation }],
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(2);
+    expect(presentationContent(0)).toBeDefined();
+    expect(sendOptions(1).extraContent).toBeUndefined();
+  });
+
+  it("does not duplicate authored fallback text when presentationTextMode=fallback", async () => {
+    await deliverMatrixReplies({
+      ...delivery,
+      replies: [
+        {
+          text: "Ready to deploy?",
+          presentation: { blocks: [{ type: "text", text: "Ready to deploy?" }] },
+          presentationTextMode: "fallback",
+        },
+      ],
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    const body = String(sendCall(0)[1]);
+    expect(body.match(/Ready to deploy\?/g)).toHaveLength(1);
+  });
+
+  it("leaves replies without presentation unchanged", async () => {
+    await deliverMatrixReplies({ ...delivery, replies: [{ text: "plain" }] });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(sendOptions(0).extraContent).toBeUndefined();
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -11,6 +11,10 @@ import {
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
 import { getMatrixRuntime } from "../../runtime.js";
+import {
+  applyMatrixPresentationPayload,
+  resolveMatrixExtraContent,
+} from "../presentation-content.js";
 import type { MatrixClient } from "../sdk.js";
 import { chunkMatrixText, sendMessageMatrix } from "../send.js";
 import type { MatrixSendResult } from "../send/types.js";
@@ -138,14 +142,18 @@ export async function deliverMatrixReplies(params: {
   const hasRepliedRef = params.hasRepliedRef ?? { value: false };
   const acceptedResults: MatrixSendResult[] = [];
   try {
-    for (const reply of params.replies) {
+    for (const sourceReply of params.replies) {
+      // Inbound delivery never runs the core renderPresentation hook, so encode
+      // the portable presentation here or buttons/selects reach nobody.
+      const reply = applyMatrixPresentationPayload(sourceReply);
+      const presentationExtraContent = resolveMatrixExtraContent(reply);
       const visibleText = resolveVisibleMatrixReplyText(reply.text);
       const hasMedia = Boolean(reply?.mediaUrl) || (reply?.mediaUrls?.length ?? 0) > 0;
       if (reply.isReasoning === true || (!hasMedia && reply.text && visibleText === undefined)) {
         logVerbose("matrix reply suppressed as reasoning-only");
         continue;
       }
-      if (!reply?.text && !hasMedia) {
+      if (!reply?.text && !hasMedia && !presentationExtraContent) {
         if (reply?.audioAsVoice) {
           logVerbose("matrix reply has audioAsVoice without media/text; skipping");
           continue;
@@ -184,18 +192,23 @@ export async function deliverMatrixReplies(params: {
           tableMode,
           preserveWhitespace: true,
         });
+        let isFirstChunk = true;
         for (const chunk of chunks) {
           if (!chunk.trim()) {
             continue;
           }
+          // Controls belong to one event; repeating them per chunk would render
+          // duplicate button rows in the room.
           await sendMessageMatrix(params.roomId, chunk, {
             client: params.client,
             cfg: params.cfg,
             replyToId: replyToIdForReply,
             threadId: params.threadId,
             accountId: params.accountId,
+            extraContent: isFirstChunk ? presentationExtraContent : undefined,
             onDeliveryResult,
           });
+          isFirstChunk = false;
         }
         continue;
       }
@@ -212,6 +225,7 @@ export async function deliverMatrixReplies(params: {
           threadId: params.threadId,
           audioAsVoice: reply.audioAsVoice,
           accountId: params.accountId,
+          extraContent: first ? presentationExtraContent : undefined,
           onDeliveryResult,
         });
         first = false;

--- a/extensions/matrix/src/matrix/presentation-content.ts
+++ b/extensions/matrix/src/matrix/presentation-content.ts
@@ -1,0 +1,139 @@
+// Matrix plugin module owns portable presentation encoding for room events.
+import {
+  adaptMessagePresentationForChannel,
+  hasMessagePresentationBlocks,
+  normalizeMessagePresentation,
+  renderMessagePresentationFallbackText,
+  type MessagePresentation,
+} from "openclaw/plugin-sdk/interactive-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import type { MatrixExtraContentFields } from "./send/types.js";
+
+const MATRIX_OPENCLAW_PRESENTATION_KEY = "com.openclaw.presentation" as const;
+const MATRIX_OPENCLAW_PRESENTATION_TYPE = "message.presentation" as const;
+const MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT = "---";
+
+/** Declared once so inbound rendering adapts controls exactly like outbound. */
+export const MATRIX_PRESENTATION_CAPABILITIES = {
+  supported: true,
+  buttons: true,
+  selects: true,
+  context: true,
+  divider: true,
+  limits: {
+    text: {
+      markdownDialect: "markdown",
+      supportsEdit: true,
+    },
+  },
+} as const;
+
+type MatrixChannelData = {
+  extraContent?: MatrixExtraContentFields;
+};
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function resolveMatrixChannelData(payload: ReplyPayload): MatrixChannelData {
+  const raw = toRecord(payload.channelData)?.matrix;
+  return (toRecord(raw) as MatrixChannelData | undefined) ?? {};
+}
+
+function buildMatrixPresentationContent(presentation: MessagePresentation) {
+  return {
+    ...presentation,
+    version: 1,
+    type: MATRIX_OPENCLAW_PRESENTATION_TYPE,
+  };
+}
+
+function resolveMatrixPresentationContent(
+  payload: ReplyPayload,
+): Record<string, unknown> | undefined {
+  const extraContent = toRecord(resolveMatrixChannelData(payload).extraContent);
+  const presentation = toRecord(extraContent?.[MATRIX_OPENCLAW_PRESENTATION_KEY]);
+  if (
+    !presentation ||
+    presentation.version !== 1 ||
+    presentation.type !== MATRIX_OPENCLAW_PRESENTATION_TYPE
+  ) {
+    return undefined;
+  }
+  return presentation;
+}
+
+/** Encodes a portable presentation into the room-event field Matrix clients read. */
+export function renderMatrixPresentationPayload(params: {
+  payload: ReplyPayload;
+  presentation: MessagePresentation;
+}): ReplyPayload {
+  const matrixData = resolveMatrixChannelData(params.payload);
+  const fallbackText = renderMessagePresentationFallbackText({
+    text: params.payload.text,
+    presentation: params.presentation,
+    emptyFallback: MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT,
+  });
+  return {
+    ...params.payload,
+    text: fallbackText,
+    channelData: {
+      ...params.payload.channelData,
+      matrix: {
+        ...matrixData,
+        extraContent: {
+          [MATRIX_OPENCLAW_PRESENTATION_KEY]: buildMatrixPresentationContent(params.presentation),
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Applies the presentation encoding the outbound adapter would have applied.
+ * Inbound monitor delivery bypasses the core `renderPresentation` hook, so
+ * without this the encoded field never exists and buttons/selects are dropped.
+ */
+export function applyMatrixPresentationPayload(payload: ReplyPayload): ReplyPayload {
+  if (resolveMatrixPresentationContent(payload)) {
+    return payload;
+  }
+  const presentation = normalizeMessagePresentation(payload.presentation);
+  if (!presentation || !hasMessagePresentationBlocks(presentation)) {
+    return payload;
+  }
+  const adapted = adaptMessagePresentationForChannel({
+    presentation,
+    capabilities: MATRIX_PRESENTATION_CAPABILITIES,
+  });
+  // Mirrors renderPresentationForDelivery: authored fallback text is replaced by
+  // the rendered one, and the portable fields never reach the transport.
+  const textIsFallback = payload.presentationTextMode === "fallback";
+  const {
+    presentation: _presentation,
+    presentationTextMode: _presentationTextMode,
+    ...rest
+  } = renderMatrixPresentationPayload({
+    payload: { ...payload, ...(textIsFallback ? { text: undefined } : {}) },
+    presentation: adapted,
+  });
+  return rest;
+}
+
+export function resolveMatrixPayloadText(payload: ReplyPayload): string {
+  const text = payload.text ?? "";
+  if (text.trim() || !resolveMatrixPresentationContent(payload)) {
+    return text;
+  }
+  return MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT;
+}
+
+export function resolveMatrixExtraContent(
+  payload: ReplyPayload,
+): MatrixExtraContentFields | undefined {
+  const presentation = resolveMatrixPresentationContent(payload);
+  return presentation ? { [MATRIX_OPENCLAW_PRESENTATION_KEY]: presentation } : undefined;
+}

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -5,101 +5,20 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import {
-  renderMessagePresentationFallbackText,
-  type MessagePresentation,
-} from "openclaw/plugin-sdk/interactive-runtime";
-import {
   resolvePayloadMediaUrls,
   sendPayloadMediaSequence,
 } from "openclaw/plugin-sdk/reply-payload";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  renderMatrixPresentationPayload,
+  resolveMatrixExtraContent,
+  resolveMatrixPayloadText,
+} from "./matrix/presentation-content.js";
 import { sendMessageMatrix, sendPollMatrix } from "./matrix/send.js";
-import type { MatrixExtraContentFields } from "./matrix/send/types.js";
 import {
   chunkTextForOutbound,
   resolveOutboundSendDep,
   type ChannelOutboundAdapter,
 } from "./runtime-api.js";
-
-const MATRIX_OPENCLAW_PRESENTATION_KEY = "com.openclaw.presentation" as const;
-const MATRIX_OPENCLAW_PRESENTATION_TYPE = "message.presentation" as const;
-const MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT = "---";
-
-type MatrixChannelData = {
-  extraContent?: MatrixExtraContentFields;
-};
-
-function toRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function resolveMatrixChannelData(payload: ReplyPayload): MatrixChannelData {
-  const raw = toRecord(payload.channelData)?.matrix;
-  return (toRecord(raw) as MatrixChannelData | undefined) ?? {};
-}
-
-function buildMatrixPresentationContent(presentation: MessagePresentation) {
-  return {
-    ...presentation,
-    version: 1,
-    type: MATRIX_OPENCLAW_PRESENTATION_TYPE,
-  };
-}
-
-function resolveMatrixPresentationContent(
-  payload: ReplyPayload,
-): Record<string, unknown> | undefined {
-  const extraContent = toRecord(resolveMatrixChannelData(payload).extraContent);
-  const presentation = toRecord(extraContent?.[MATRIX_OPENCLAW_PRESENTATION_KEY]);
-  if (
-    !presentation ||
-    presentation.version !== 1 ||
-    presentation.type !== MATRIX_OPENCLAW_PRESENTATION_TYPE
-  ) {
-    return undefined;
-  }
-  return presentation;
-}
-
-function renderMatrixPresentationPayload(params: {
-  payload: ReplyPayload;
-  presentation: MessagePresentation;
-}): ReplyPayload {
-  const matrixData = resolveMatrixChannelData(params.payload);
-  const fallbackText = renderMessagePresentationFallbackText({
-    text: params.payload.text,
-    presentation: params.presentation,
-    emptyFallback: MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT,
-  });
-  return {
-    ...params.payload,
-    text: fallbackText,
-    channelData: {
-      ...params.payload.channelData,
-      matrix: {
-        ...matrixData,
-        extraContent: {
-          [MATRIX_OPENCLAW_PRESENTATION_KEY]: buildMatrixPresentationContent(params.presentation),
-        },
-      },
-    },
-  };
-}
-
-function resolveMatrixPayloadText(payload: ReplyPayload): string {
-  const text = payload.text ?? "";
-  if (text.trim() || !resolveMatrixPresentationContent(payload)) {
-    return text;
-  }
-  return MATRIX_EMPTY_PRESENTATION_FALLBACK_TEXT;
-}
-
-function resolveMatrixExtraContent(payload: ReplyPayload): MatrixExtraContentFields | undefined {
-  const presentation = resolveMatrixPresentationContent(payload);
-  return presentation ? { [MATRIX_OPENCLAW_PRESENTATION_KEY]: presentation } : undefined;
-}
 
 function resolveMatrixDeliveryProgress(
   onDeliveryResult: Parameters<

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -9,6 +9,7 @@ import {
   sendPayloadMediaSequence,
 } from "openclaw/plugin-sdk/reply-payload";
 import {
+  MATRIX_PRESENTATION_CAPABILITIES,
   renderMatrixPresentationPayload,
   resolveMatrixExtraContent,
   resolveMatrixPayloadText,
@@ -37,19 +38,7 @@ export const matrixOutbound: ChannelOutboundAdapter = {
   chunker: chunkTextForOutbound,
   chunkerMode: "markdown",
   textChunkLimit: 4000,
-  presentationCapabilities: {
-    supported: true,
-    buttons: true,
-    selects: true,
-    context: true,
-    divider: true,
-    limits: {
-      text: {
-        markdownDialect: "markdown",
-        supportsEdit: true,
-      },
-    },
-  },
+  presentationCapabilities: MATRIX_PRESENTATION_CAPABILITIES,
   renderPresentation: ({ payload, presentation }) =>
     renderMatrixPresentationPayload({ payload, presentation }),
   sendPayload: async ({


### PR DESCRIPTION
## What Problem This Solves

Matrix declares portable presentation support on its outbound adapter — `presentationCapabilities: { supported: true, buttons: true, selects: true, ... }` — and registers a `renderPresentation` hook that encodes controls into the `com.openclaw.presentation` room-event field (`extensions/matrix/src/outbound.ts`).

That hook only runs in **core outbound delivery** (`renderPresentationForDelivery`, `src/infra/outbound/deliver-core.ts`). The **inbound monitor reply path** — the path an agent's own turn reply takes — never calls it:

- **non-streamed**: `extensions/matrix/src/matrix/monitor/replies.ts` called `sendMessageMatrix` with no `extraContent`, and treated a controls-only payload as `"matrix reply missing text/media"`, dropping it entirely.
- **streamed**: `monitor/handler-reply-dispatcher.ts` finalizes an eligible text-only final by editing the draft event in place, bypassing `deliverMatrixReplies` — and an in-place edit cannot attach the controls.

So an agent reply carrying buttons/selects arrived on Matrix with the controls silently missing, and a controls-only reply produced **no room event at all**.

## Why This Change Was Made

Per `AGENTS.md`: *"Severity order: silent failure > crash > missing feature. Every user or agent action ends in a visible outcome or a recorded, intentional non-outcome."* A declared capability that produces nothing on the default reply path is that class of bug.

The sibling channels already handle presentation on their reply paths, so Matrix was the outlier:

| channel | reply-path handling |
| --- | --- |
| Telegram | `bot-message-dispatch-reply.ts` — `resolvePayloadTelegramInlineButtons` reads `payload.presentation` |
| Discord | `monitor/reply-delivery.ts` routes through `sendDurableMessageBatch` (core pipeline); `monitor/reply-safety.ts` protects presentation payloads |
| Slack | `reply-blocks.ts` — `buildSlackPresentationBlocks` / `canRenderSlackPresentation` |

The encoding moved out of `outbound.ts` into `extensions/matrix/src/matrix/presentation-content.ts` so there is one canonical encoder shared by both paths, and the capability object is now declared once and reused. `applyMatrixPresentationPayload` mirrors the core contract: it adapts the presentation to the declared capabilities, honors `presentationTextMode: "fallback"` (so authored fallback text is not duplicated), and strips the portable fields before they reach the transport.

Payloads carrying controls are excluded from in-place draft finalization and redact the stale draft, so streaming yields one visible final message rather than a leftover draft plus the control message.

Kept in the plugin rather than routed through core: this monitor owns its own direct sends and draft lifecycle, and `AGENTS.md` puts portable presentation rendering in the channel plugin.

## User Impact

On Matrix, agent replies that attach buttons or selects now actually render them, and a controls-only reply is delivered instead of silently discarded. No config, no new surface. Behavior for replies without presentation is unchanged.

## Evidence

Real production path: the harness drives `deliverMatrixReplies` → the real chunker → the real `sendMessageMatrix`. Only `client.sendMessage(roomId, content)` is captured, so the captured object is the room event that would go to the homeserver.

```text
base: cad499d7ca0654b6bb8ae03af7e870eda413f215  (this PR head's merge base)
head: 9a6f6a08b13d6ace4228fa64e20464696fbf517c

===================== BEFORE (files restored to base) =====================
  (base verified: presentation-content.ts absent; outbound.ts imports of presentation-content: 0; replies.ts references to applyMatrixPresentationPayload: 0)

### agent reply with approve/reject buttons
events sent: 1
runtime errors: []
  event[0] body="Deployment ready." presentation=ABSENT

### controls-only reply (no text, no media)
events sent: 0
runtime errors: ["matrix reply missing text/media"]

===================== AFTER (this branch head) =====================

### agent reply with approve/reject buttons
events sent: 1
runtime errors: []
  event[0] body="Deployment ready.\n\nDeploy check\n\nReady to deploy?\n\n- Approve\n- Reject" presentation={"title":"Deploy check","blocks":[{"type":"text","text":"Ready to deploy?"},{"type":"buttons","buttons":[{"label":"Approve","value":"approve"},{"label":"Reject","value":"reject"}]}],"version":1,"type":"message.presentation"}

### controls-only reply (no text, no media)
events sent: 1
runtime errors: []
  event[0] body="Deploy check\n\nReady to deploy?\n\n- Approve\n- Reject" presentation={"title":"Deploy check","blocks":[{"type":"text","text":"Ready to deploy?"},{"type":"buttons","buttons":[{"label":"Approve","value":"approve"},{"label":"Reject","value":"reject"}]}],"version":1,"type":"message.presentation"}
```

**Streamed draft → final transition** (this is the path the review flagged). Real draft controller, real dispatcher, real `deliverMatrixReplies`; captured seams are `client.sendMessage` / `client.redactEvent`.

```text
base: cad499d7ca0654b6bb8ae03af7e870eda413f215  (this PR head's merge base)
head: 9a6f6a08b13d6ace4228fa64e20464696fbf517c

===================== STREAMED PATH — BEFORE (files restored to base) =====================
observed transport calls, in order:
  [0] sendMessage: $evt1 body="Deployment ready" presentation=ABSENT
  [1] sendMessage: $evt2 body="* Deployment ready." presentation=ABSENT

final events carrying controls: 0
draft redactions: 0

===================== STREAMED PATH — AFTER (this branch head) =====================
observed transport calls, in order:
  [0] sendMessage: $evt1 body="Deployment ready" presentation=ABSENT
  [1] redactEvent: $evt1
  [2] sendMessage: $evt2 body="Deployment ready.\n\n- Approve\n- Reject" presentation=PRESENT

final events carrying controls: 1
draft redactions: 1
```

Before the fix the streamed path emitted two visible events and neither carried controls. After it, the draft is redacted and exactly one control-bearing event carries `com.openclaw.presentation`. (Long replies can still chunk into additional plain-text events; the controls ride on the first one only.)

Tests: `extensions/matrix` — **120 files / 1898 tests pass**. Five cases added to `monitor/replies.test.ts` (controls encoded; controls-only delivered; controls on the first chunk only; no `presentationTextMode: "fallback"` duplication; no-presentation replies unchanged). A sixth case in `monitor/handler.test.ts` covers the streamed **routing**: draft redacted, no in-place edit, one normal-delivery call carrying the controls. That test mocks `deliverMatrixReplies`, so the event encoding itself is proven by `replies.test.ts` and by the captures above, not by it. **Teeth check**: restoring the three production files to the merge base fails exactly four named cases and nothing else — `encodes presentation controls onto the delivered event`, `delivers a controls-only reply instead of dropping it as missing text`, `attaches controls to the first chunk only`, and the streamed `redacts the draft and routes control-bearing finals through normal delivery` (4 failed | 166 passed). The controls-only case fails with the exact production error `matrix reply missing text/media`.

`oxfmt --check` and `oxlint` clean on the changed files, and the `check-test-types` lane (`tsgo -p test/tsconfig/tsconfig.extensions.test.json`) is clean locally after typing the new test fixtures. Rebased onto current `main`; the head now sits on `cad499d7ca0`, 2,206 commits ahead of where the first capture was taken. Both captures above were re-run at the rebased head and reproduce **identically** — every observed line matches the pre-rebase capture, so the defect is still live on the rebase target rather than merely still described. The BEFORE arm restores exactly the three production files this PR touches to this head's merge base inside the same worktree and prints the restored state first (`presentation-content.ts` absent, zero `outbound.ts` imports of it, zero `replies.ts` references to `applyMatrixPresentationPayload`), so a botched restore cannot silently produce a false AFTER.

One conflict had to be resolved by hand and is worth naming, because replaying our side would have reverted an upstream fix: upstream added `preserveWhitespace: true` to `chunkMatrixText` and switched the send argument from `chunk.trim()` to the raw `chunk`. This branch keeps **upstream's** version of that line and layers only its own contribution on top (`isFirstChunk` plus the `extraContent` argument). The proof harness also needed one boundary stub added after the rebase: upstream moved the room-encryption gate behind `client.prepareRoomForMessageSend` (`extensions/matrix/src/matrix/send.ts:215`), so the fake client now implements it, returning `"m.room.message"` — what the real implementation returns for an unencrypted room on its first branch (`extensions/matrix/src/matrix/sdk/client-core.ts:254-258`). No production code is stubbed.

### Proof gaps, stated plainly

- The homeserver socket is stubbed in both captures; these are production-path captures, not a live Synapse run. The assertion is about the event content and redaction calls the client is handed.
- `monitor/replies.ts` picks the first entry of `mediaUrls` rather than the first *non-empty* one, unlike the canonical `sendPayloadMediaSequence` helper. With a leading empty media URL the controls would land on an extra text event. That shape is pre-existing on this path; left out of scope here.

Mattermost has the same gap (`monitor-draft-delivery.ts` returns only `{ message }`; its normal fallback reduces to text/media) and is deliberately left for a separate PR.

