### PR TITLE
[CLOSED] feat(telegram): informative error messages (superseded by v5)

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -43,8 +43,10 @@ import {
   type TelegramNativeQuoteCandidateByMessageId,
 } from "./bot/native-quote.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
+import { formatTelegramFallbackError } from "./telegram-error-presenter.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
+
 const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-dispatch");
 
 async function resolveStickerVisionSupport(
@@ -454,7 +456,7 @@ export const dispatchTelegramMessage = async ({
       try {
         await delivery.finalizePendingAnswerBlockDraft(state);
       } catch (err) {
-        state.dispatchError ??= err;
+        state.deliveryError ??= err;
         runtime.error?.(danger(`telegram terminal block delivery failed: ${String(err)}`));
       }
       await draft.cleanup(isDispatchSuperseded());
@@ -489,12 +491,18 @@ export const dispatchTelegramMessage = async ({
     !suppressFailureFallback &&
     !progress.finalAnswerDelivered() &&
     (state.dispatchError ||
-      deliverySummary.skippedNonSilent > 0 ||
-      deliverySummary.failedNonSilent > 0);
+      state.deliveryError ||
+      deliverySummary.failedNonSilent > 0 ||
+      (deliverySummary.skippedNonSilent > 0 && !state.suppressSilentReplyFallback));
   if (shouldSendFailureFallback) {
+    // Provider/agent errors are classified by the allowlisted presenter.
+    // Telegram delivery errors get the generic fallback to avoid misattributing
+    // transport failures (e.g. flood-limit 429) as provider problems.
     const fallbackText = state.dispatchError
-      ? "Something went wrong while processing your request. Please try again."
-      : EMPTY_RESPONSE_FALLBACK;
+      ? formatTelegramFallbackError(state.dispatchError)
+      : state.deliveryError
+        ? "Something went wrong while processing your request. Please try again."
+        : EMPTY_RESPONSE_FALLBACK;
     const result = await delivery.deliverFallback(
       [{ text: fallbackText }],
       telegramCfg.silentErrorReplies === true &&
@@ -549,6 +557,7 @@ export const dispatchTelegramMessage = async ({
     (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0);
   const retryableDispatchFailure =
     state.dispatchError ??
+    state.deliveryError ??
     (deliveryFailureWithoutFinalResponse
       ? new Error(
           `Telegram reply delivery failed without a final response (failed=${deliverySummary.failedNonSilent}, skipped=${deliverySummary.skippedNonSilent})`,
@@ -560,8 +569,11 @@ export const dispatchTelegramMessage = async ({
   }
   const shouldReturnRetryableDispatchFailure =
     retryDispatchErrors &&
-    ((state.dispatchError != null && !hasFinalResponse) ||
-      (state.dispatchError == null && deliveryFailureWithoutFinalResponse && !hasVisibleResponse));
+    (((state.dispatchError != null || state.deliveryError != null) && !hasFinalResponse) ||
+      (state.dispatchError == null &&
+        state.deliveryError == null &&
+        deliveryFailureWithoutFinalResponse &&
+        !hasVisibleResponse));
   if (retryableDispatchFailure && shouldReturnRetryableDispatchFailure) {
     return { kind: "failed-retryable", error: retryableDispatchFailure };
   }
@@ -580,7 +592,8 @@ export const dispatchTelegramMessage = async ({
     status.finalizeInBackground(
       {
         outcome:
-          !progress.finalAnswerDelivered() && (state.dispatchError != null || sentFallback)
+          !progress.finalAnswerDelivered() &&
+          (state.dispatchError != null || state.deliveryError != null || sentFallback)
             ? "error"
             : "done",
       },

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -68,5 +68,8 @@ export type TelegramDispatchTurnState = {
   queuedFinal: boolean;
   suppressSilentReplyFallback: boolean;
   hadErrorReplyFailureOrSkip: boolean;
+  /** Error from the agent/provider dispatch turn (provider failures). */
   dispatchError?: unknown;
+  /** Error from terminal Telegram delivery (transport failures). */
+  deliveryError?: unknown;
 };

--- a/extensions/telegram/src/telegram-error-presenter.test.ts
+++ b/extensions/telegram/src/telegram-error-presenter.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { formatTelegramFallbackError } from "./telegram-error-presenter.js";
+
+describe("formatTelegramFallbackError", () => {
+  it("maps 429 to rate limit message", () => {
+    expect(formatTelegramFallbackError(new Error("Request failed with 429"))).toBe(
+      "⚠️ Rate limit reached. Please wait a moment and try again.",
+    );
+  });
+
+  it("maps 'rate limit exceeded' to rate limit message", () => {
+    expect(formatTelegramFallbackError(new Error("rate limit exceeded"))).toBe(
+      "⚠️ Rate limit reached. Please wait a moment and try again.",
+    );
+  });
+
+  it("maps 408 to timeout message", () => {
+    expect(formatTelegramFallbackError(new Error("Request failed with 408"))).toBe(
+      "⚠️ Request timed out. Please try again.",
+    );
+  });
+
+  it("maps ETIMEDOUT to timeout message", () => {
+    expect(formatTelegramFallbackError(new Error("ETIMEDOUT"))).toBe(
+      "⚠️ Request timed out. Please try again.",
+    );
+  });
+
+  it("maps 500 to server error message", () => {
+    expect(formatTelegramFallbackError(new Error("500 Internal server error"))).toBe(
+      "⚠️ Provider server error. Please try again in a moment.",
+    );
+  });
+
+  it("maps 502 Bad Gateway to server error message", () => {
+    expect(formatTelegramFallbackError(new Error("502 Bad Gateway"))).toBe(
+      "⚠️ Provider server error. Please try again in a moment.",
+    );
+  });
+
+  it("maps 'Internal server error' to server error message", () => {
+    expect(formatTelegramFallbackError(new Error("Internal server error"))).toBe(
+      "⚠️ Provider server error. Please try again in a moment.",
+    );
+  });
+
+  it("maps 529 to overloaded message", () => {
+    expect(formatTelegramFallbackError(new Error("529 Overloaded"))).toBe(
+      "⚠️ Provider is overloaded. Please try again in a moment.",
+    );
+  });
+
+  it("maps 401 to auth message", () => {
+    expect(formatTelegramFallbackError(new Error("401 Unauthorized"))).toBe(
+      "⚠️ Authentication failed. Check your provider configuration.",
+    );
+  });
+
+  it("maps 'unauthorized' to auth message", () => {
+    expect(formatTelegramFallbackError(new Error("unauthorized access"))).toBe(
+      "⚠️ Authentication failed. Check your provider configuration.",
+    );
+  });
+
+  it("maps 402 to billing message", () => {
+    expect(formatTelegramFallbackError(new Error("402 Payment required"))).toBe(
+      "⚠️ Billing issue: insufficient credits or quota. Check your provider account.",
+    );
+  });
+
+  it("maps 'insufficient credits' to billing message", () => {
+    expect(formatTelegramFallbackError(new Error("insufficient credits"))).toBe(
+      "⚠️ Billing issue: insufficient credits or quota. Check your provider account.",
+    );
+  });
+
+  it("maps 'model not found' to model not found message", () => {
+    expect(formatTelegramFallbackError(new Error("model not found: gpt-xyz"))).toBe(
+      "⚠️ The selected model was not found. Try a different model.

--- a/extensions/telegram/src/telegram-error-presenter.test.ts
+++ b/extensions/telegram/src/telegram-error-presenter.test.ts
@@ -76,4 +76,124 @@ describe("formatTelegramFallbackError", () => {
 
   it("maps 'model not found' to model not found message", () => {
     expect(formatTelegramFallbackError(new Error("model not found: gpt-xyz"))).toBe(
-      "⚠️ The selected model was not found. Try a different model.
+      "⚠️ The selected model was not found. Try a different model.",
+    );
+  });
+
+  it("maps 'no such model' to model not found message", () => {
+    expect(formatTelegramFallbackError(new Error("no such model: claude-xyz"))).toBe(
+      "⚠️ The selected model was not found. Try a different model.",
+    );
+  });
+
+  it("returns generic message for bare 404 without model-specific text", () => {
+    expect(formatTelegramFallbackError(new Error("404 Not Found"))).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+  });
+
+  it("returns generic message for non-model 404 (missing endpoint)", () => {
+    expect(
+      formatTelegramFallbackError(new Error("404: /v1/deployments/xyz/completions not found")),
+    ).toBe("Something went wrong while processing your request. Please try again.");
+  });
+
+  it("maps context overflow to context overflow message", () => {
+    expect(formatTelegramFallbackError(new Error("context window exceeded"))).toBe(
+      "⚠️ Context overflow: prompt too large for the model. Use /new to start a fresh session.",
+    );
+  });
+
+  it("maps 'prompt is too long' to context overflow message", () => {
+    expect(formatTelegramFallbackError(new Error("prompt is too long"))).toBe(
+      "⚠️ Context overflow: prompt too large for the model. Use /new to start a fresh session.",
+    );
+  });
+
+  it("returns generic message for unknown errors", () => {
+    expect(formatTelegramFallbackError(new Error("something unusual happened"))).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+  });
+
+  it("returns generic message for empty error text", () => {
+    expect(formatTelegramFallbackError(new Error(""))).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+  });
+
+  it("returns generic message for non-Error values", () => {
+    expect(formatTelegramFallbackError(undefined)).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+    expect(formatTelegramFallbackError(null)).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+    expect(formatTelegramFallbackError({})).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+  });
+
+  it("does not leak endpoint URLs in output", () => {
+    const err = new Error(
+      "Request to https://api.provider.com/v1/chat failed with 500 Internal server error",
+    );
+    const result = formatTelegramFallbackError(err);
+    expect(result).not.toContain("https://");
+    expect(result).not.toContain("api.provider.com");
+    expect(result).toBe("⚠️ Provider server error. Please try again in a moment.");
+  });
+
+  it("does not leak file paths in output", () => {
+    const err = new Error("Failed to read /etc/secrets/api-key.txt: 401 Unauthorized");
+    const result = formatTelegramFallbackError(err);
+    expect(result).not.toContain("/etc/secrets/");
+    expect(result).not.toContain("api-key.txt");
+    expect(result).toBe("⚠️ Authentication failed. Check your provider configuration.");
+  });
+
+  it("does not leak raw diagnostics for unknown errors", () => {
+    const err = new Error("ECONNREFUSED 10.0.0.42:443 → detailed internal stack trace info");
+    const result = formatTelegramFallbackError(err);
+    expect(result).not.toContain("10.0.0.42");
+    expect(result).not.toContain("ECONNREFUSED");
+    expect(result).not.toContain("stack");
+    expect(result).toBe("Something went wrong while processing your request. Please try again.");
+  });
+
+  it("classifies 503 Service Unavailable as server error", () => {
+    expect(formatTelegramFallbackError(new Error("503 Service Unavailable"))).toBe(
+      "⚠️ Provider server error. Please try again in a moment.",
+    );
+  });
+
+  it("classifies 'too many requests' as rate limit", () => {
+    expect(formatTelegramFallbackError(new Error("too many requests"))).toBe(
+      "⚠️ Rate limit reached. Please wait a moment and try again.",
+    );
+  });
+
+  it("classifies 'throttled' as rate limit", () => {
+    expect(formatTelegramFallbackError(new Error("request was throttled"))).toBe(
+      "⚠️ Rate limit reached. Please wait a moment and try again.",
+    );
+  });
+
+  it("classifies 'gateway timeout' as timeout (504 semantics)", () => {
+    expect(formatTelegramFallbackError(new Error("gateway timeout"))).toBe(
+      "⚠️ Request timed out. Please try again.",
+    );
+  });
+
+  it("classifies 'forbidden' as auth error", () => {
+    expect(formatTelegramFallbackError(new Error("forbidden access"))).toBe(
+      "⚠️ Authentication failed. Check your provider configuration.",
+    );
+  });
+
+  it("classifies 'spend limit' as billing error", () => {
+    expect(formatTelegramFallbackError(new Error("spend limit reached"))).toBe(
+      "⚠️ Billing issue: insufficient credits or quota. Check your provider account.",
+    );
+  });
+});

--- a/extensions/telegram/src/telegram-error-presenter.ts
+++ b/extensions/telegram/src/telegram-error-presenter.ts
@@ -1,0 +1,77 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+
+/**
+ * Maps an error to a safe, user-visible Telegram fallback message.
+ *
+ * Unlike the generic "Something went wrong", this presenter classifies
+ * known error categories (rate limit, timeout, server error, etc.) and
+ * returns actionable text without leaking operational diagnostics.
+ * Unknown errors fall back to the generic message.
+ */
+export function formatTelegramFallbackError(err: unknown): string {
+  const detail = formatErrorMessage(err).trim();
+  if (!detail) {
+    return "Something went wrong while processing your request. Please try again.";
+  }
+
+  // Order matters: more specific patterns first
+
+  // Context overflow
+  if (
+    /context(?:\s+window)?\s+(?:overflow|exceed|too\s+long)|prompt\s+is\s+too\s+long/i.test(detail)
+  ) {
+    return "⚠️ Context overflow: prompt too large for the model. Use /new to start a fresh session.";
+  }
+
+  // Rate limit (before server error — 429 is specific)
+  if (/\b429\b|rate\s+limit|too\s+many\s+requests|throttl/i.test(detail)) {
+    return "⚠️ Rate limit reached. Please wait a moment and try again.";
+  }
+
+  // Overloaded (before generic server error)
+  if (/\b529\b|overloaded/i.test(detail)) {
+    return "⚠️ Provider is overloaded. Please try again in a moment.";
+  }
+
+  // Auth
+  if (
+    /\b401\b|\b403\b|unauthorized|forbidden|invalid\s+(?:api[_\s-]?key|token|credential)/i.test(
+      detail,
+    )
+  ) {
+    return "⚠️ Authentication failed. Check your provider configuration.";
+  }
+
+  // Billing
+  if (
+    /\b402\b|insufficient\s+(?:credits|quota|balance)|billing|spend\s+limit|usage\s+limit/i.test(
+      detail,
+    )
+  ) {
+    return "⚠️ Billing issue: insufficient credits or quota. Check your provider account.";
+  }
+
+  // Model not found — only when the provider explicitly says so.
+  // A bare 404 can also mean a missing endpoint, deployment route, or base URL,
+  // so it must not trigger model-specific recovery advice.
+  if (/model\s+not\s+found|no\s+such\s+model/i.test(detail)) {
+    return "⚠️ The selected model was not found. Try a different model.";
+  }
+
+  // Server errors (before timeout — "bad gateway" contains "gateway")
+  if (
+    /\b500\b|\b502\b|\b503\b|internal\s+server\s+error|bad\s+gateway|service\s+unavailable|server\s+error|upstream\s+error/i.test(
+      detail,
+    )
+  ) {
+    return "⚠️ Provider server error. Please try again in a moment.";
+  }
+
+  // Timeout
+  if (/\b408\b|\b504\b|timed?\s+out|timeout|etimedout|esockettimedout/i.test(detail)) {
+    return "⚠️ Request timed out. Please try again.";
+  }
+
+  // Unknown — generic, no detail leakage
+  return "Something went wrong while processing your request. Please try again.";
+}


### PR DESCRIPTION
## What Problem This Solves

When a provider error occurs (rate limit, timeout, server error, auth failure, billing issue, model not found, context overflow), Telegram users see a generic "Something went wrong while processing your request" message. This is unhelpful — the user has no idea whether to wait, check their config, switch models, or start a new session.

This PR introduces `formatTelegramFallbackError()` — an allowlisted error classifier that maps known error categories to actionable, user-friendly messages without leaking operational diagnostics (URLs, file paths, internal stack traces).

Additionally, this separates `dispatchError` (provider/agent failures) from `deliveryError` (Telegram transport failures). Transport errors like flood-limit 429 get the generic fallback to avoid misattributing Telegram-side problems as provider issues.

## Evidence

### Provider error → classified message

When a provider returns a 429 rate limit error, the user now sees:

> ⚠️ Rate limit reached. Please wait a moment and try again.

Instead of the previous generic message. Similarly:
- 500/502/503 → "⚠️ Provider server error. Please try again in a moment."
- 401/403 → "⚠️ Authentication failed. Check your provider configuration."
- 402 → "⚠️ Billing issue: insufficient credits or quota. Check your provider account."
- "model not found" → "⚠️ The selected model was not found. Try a different model."
- "context window exceeded" → "⚠️ Context overflow: prompt too large for the model. Use /new to start a fresh session."

### Delivery error → generic message

When Telegram API itself fails (e.g. flood limit, network error during message delivery), `deliveryError` is set and the user gets the generic fallback — not a misleading "rate limit" message that would confuse them into thinking their provider is throttling.

### No detail leakage

The presenter never returns raw error text, URLs, file paths, or internal diagnostics. Unknown errors fall back to the generic message.

### Test coverage

30 unit tests cover all error categories, bare 404 (generic, not model-not-found), non-Error values, and leak prevention for URLs, file paths, and raw diagnostics.

## Changes

- **`telegram-error-presenter.ts`** (new) — Allowlisted error classifier with 8 categories
- **`telegram-error-presenter.test.ts`** (new) — 30 tests
- **`bot-message-dispatch.ts`** — Import `formatTelegramFallbackError`, add `deliveryError` for terminal delivery failures
- **`bot-message-dispatch.types.ts`** — Add `deliveryError?: unknown` to `TelegramDispatchTurnState`

## Design decisions

- **Bare 404 → generic** (not model-not-found): A 404 can mean missing endpoint, deployment route, or base URL. Only explicit "model not found" / "no such model" text triggers model-specific advice.
- **deliveryError vs dispatchError**: Transport failures must not be misattributed as provider problems.
- **No detail leakage**: The presenter never returns raw error text, URLs, file paths, or internal diagnostics.