### PR TITLE
docs(whatsapp): document wacli messages show verification

### DIFF
--- a/extensions/whatsapp/skills/wacli/SKILL.md
+++ b/extensions/whatsapp/skills/wacli/SKILL.md
@@ -53,6 +53,12 @@ Find chats + messages
 - `wacli messages search "query" --limit 20 --chat <jid>`
 - `wacli messages search "invoice" --after 2025-01-01 --before 2025-12-31`
 
+Inspect / verify messages
+
+- `wacli messages show --chat <jid> --id <message_id> --json --full`
+- `messages show` requires both `--chat` and `--id`; do not pass the message ID as a positional argument.
+- After sending, verify the stored message when exact formatting matters, especially multiline text.
+
 History backfill
 
 - `wacli history backfill --chat <jid> --requests 2 --count 50`
@@ -62,6 +68,7 @@ Send
 - Text: `wacli send text --to "+14155551212" --message "Hello! Are you free at 3pm?"`
 - Group: `wacli send text --to "1234567890-123456789@g.us" --message "Running 5 min late."`
 - File: `wacli send file --to "+14155551212" --file /path/agenda.pdf --caption "Agenda"`
+- Multiline: `--message` is literal by default; pass `--message-escapes` to interpret `\n`, `\r`, `\t`.
 
 Notes
 


### PR DESCRIPTION
## Summary

Documents single-message inspection in the bundled `wacli` skill, which currently covers search, backfill, and send but has no way to verify what was actually stored after a send.

- Add an `Inspect / verify messages` section with `wacli messages show --chat <jid> --id <message_id> --json --full`.
- Note that `messages show` requires both `--chat` and `--id` and does not accept the message ID as a positional argument.
- Add one line under `Send` documenting `--message-escapes`, since literal-by-default `--message` is the actual cause of the multiline formatting surprises the verification guidance is meant to catch.

Fixes #88737.

Supersedes #88738, which was closed as `stalled_unproven_pr`. That PR targeted the old `skills/wacli/SKILL.md` path and shipped no installed-wacli proof. This one targets the current `extensions/whatsapp/skills/wacli/SKILL.md` and carries the terminal output below.

## Real behavior proof

**Behavior addressed:** the skill gave agents no `messages show` syntax, so the natural positional guess fails.

**Real environment tested:** Arch Linux, `wacli 0.12.0` installed from `/usr/bin/wacli`, real synced `~/.wacli` store.

**Exact steps or command run after this patch:**

```console
$ wacli --version
wacli 0.12.0

$ wacli messages show --help
Show one message

Usage:
  wacli messages show [flags]

Flags:
      --chat string   chat JID
  -h, --help          help for show
      --id string     message ID

$ wacli messages show "3EB0A9ADC55BDF882A36FF" --json --full   # positional form from the issue
{"success":false,"data":null,"error":"--chat and --id are required"}
exit=1

$ wacli --read-only messages show --chat "<REDACTED>@g.us" --id "<REDACTED>" --json --full
{
  "success": true,
  "data": {
    "ChatJID": "<REDACTED>",
    "ChatName": "<REDACTED>",
    "DeletedForMe": false,
    "FromMe": true,
    "IsForwarded": false,
    "MediaType": "",
    "MsgID": "<REDACTED>",
    "Revoked": false,
    "SenderName": "<REDACTED>",
    "Starred": false,
    "Text": "<REDACTED>",
    "Timestamp": "2026-06-02T11:34:46Z"
  },
  "error": null
}
exit=0
```

Proof for the `--message-escapes` line:

```console
$ wacli send text --help | grep message-escapes
      --message-escapes             interpret backslash escapes in --message (\n, \r, \t, \\, \")
```

**Evidence after fix:** the help output confirms `--chat` and `--id` are the only two command flags and `--json` / `--full` are valid global flags; the positional form fails with exactly the error quoted in #88737; the documented flag form returns `success: true` with the full stored record.

**Observed result after fix:** the skill's documented command matches the installed CLI contract exactly, and an agent following it no longer has to guess the invocation.

**What was not tested:** no message was sent during verification. The `messages show` run used `--read-only` against the existing store, so the send-then-verify round trip and `--message-escapes` runtime rendering were not exercised end to end; `--message-escapes` is evidenced by its help text only. JIDs, sender names, and message text are redacted.

## Verification

- `git diff --check` — clean.
- `node scripts/format-docs.mjs --check` — the changed file is not flagged (the 5 reported files are pre-existing on `main` and untouched here).
- Docs-only change: no runtime, config, dependency, or workflow surface touched.
