### PR TITLE
docs: add Daytona hosting guide

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1702,5 +1702,17 @@
   {
     "source": "Automations (cron)",
     "target": "自动化 (cron)"
+  },
+  {
+    "source": "Daytona",
+    "target": "Daytona"
+  },
+  {
+    "source": "Gateway remote access",
+    "target": "Gateway 远程访问"
+  },
+  {
+    "source": "Updating OpenClaw",
+    "target": "更新 OpenClaw"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1110,6 +1110,7 @@
                 "group": "Hosting",
                 "pages": [
                   "install/azure",
+                  "install/daytona",
                   "install/digitalocean",
                   "install/docker-vm-runtime",
                   "install/exe-dev",

--- a/docs/install/daytona.md
+++ b/docs/install/daytona.md
@@ -1,0 +1,312 @@
+---
+summary: "Run OpenClaw in a Daytona cloud sandbox with SSH access and signed preview URLs"
+read_when:
+  - Running OpenClaw in a Daytona sandbox
+  - You want a cloud sandbox for OpenClaw without managing a VPS
+title: "Daytona"
+---
+
+Run a persistent OpenClaw Gateway in a [Daytona](https://www.daytona.io) cloud
+sandbox: an isolated Linux environment with SSH access and built-in preview
+URLs, no VPS management required. OpenClaw comes pre-installed in the
+`daytona-medium` snapshot, so setup starts immediately after SSH.
+
+Keep the Gateway on loopback and reach the dashboard through Daytona's signed
+preview URLs. Do not expose the Gateway port directly to the public internet.
+
+## What you need
+
+- [Daytona account](https://app.daytona.io) (free tier available)
+- Daytona API key from the [Daytona dashboard](https://app.daytona.io/dashboard/keys)
+- API key for your model provider (Anthropic, OpenAI, etc.)
+
+## Install the Daytona CLI
+
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    brew install daytonaio/cli/daytona
+    ```
+  </Tab>
+  <Tab title="Windows">
+    ```powershell
+    powershell -Command "irm https://get.daytona.io/windows | iex"
+    ```
+  </Tab>
+</Tabs>
+
+Verify the installation:
+
+```bash
+daytona --version
+```
+
+Older CLI versions miss newer sandbox commands; keep it current (for example
+`brew upgrade daytonaio/cli/daytona`).
+
+## Authenticate
+
+```bash
+daytona login --api-key=YOUR_API_KEY
+```
+
+## Create a sandbox
+
+```bash
+daytona sandbox create --name openclaw --snapshot daytona-medium --auto-stop 0
+```
+
+| Flag                        | Why                                                |
+| --------------------------- | -------------------------------------------------- |
+| `--snapshot daytona-medium` | Provides enough memory headroom to run the Gateway |
+| `--auto-stop 0`             | Keeps the sandbox running until manually stopped   |
+
+## Connect via SSH
+
+```bash
+daytona ssh openclaw
+```
+
+## Run onboarding
+
+Inside the sandbox, configure OpenClaw in one command:
+
+```bash
+openclaw onboard --non-interactive --accept-risk \
+  --anthropic-api-key YOUR_ANTHROPIC_KEY \
+  --skip-daemon --skip-channels --skip-skills --skip-hooks --skip-health
+```
+
+`--skip-daemon` matters: Daytona sandboxes do not run a service manager, so
+you start the Gateway manually below. Swap the key flag for your provider
+(`--openai-api-key`, `--openrouter-api-key`, and so on); `openclaw onboard
+--help` lists them all. Channels, skills, and hooks are skipped here and
+configured later.
+
+Running `openclaw onboard` without flags starts a conversational setup
+assistant instead and requires an interactive terminal;
+`openclaw onboard --classic` runs the older step-by-step wizard.
+
+Onboarding configures a gateway auth token. Print it any time from the
+sandbox:
+
+```bash
+node -p "require(process.env.HOME + '/.openclaw/openclaw.json').gateway.auth.token"
+```
+
+`openclaw config get gateway.auth.token` returns `__OPENCLAW_REDACTED__`
+rather than the value, because the CLI masks secrets in its output.
+
+## Allow the preview URL origin
+
+The Gateway accepts browser connections only from allowed origins, and
+Daytona's preview proxy sits in front of it. Configure both before starting
+the Gateway.
+
+From your **local terminal** (not the sandbox SSH session), generate a signed
+preview URL for the Gateway port:
+
+```bash
+daytona preview-url openclaw --port 18789
+```
+
+Copy the URL it prints. Back in the sandbox SSH session, allow that origin and
+trust the in-sandbox preview proxy, replacing the example URL with your own:
+
+```bash
+openclaw config set gateway.controlUi.allowedOrigins '["PASTE_YOUR_PREVIEW_URL"]'
+openclaw config set gateway.trustedProxies '["127.0.0.1"]'
+```
+
+Paste the URL exactly as printed: scheme and host only, with no trailing slash
+and no path. The Gateway compares the browser origin literally, and browsers
+send `https://host` without a trailing slash, so `https://host/` fails to
+match and the connection is rejected. Browser address bars often display that
+trailing slash, so copy from the terminal instead.
+
+## Start the Gateway
+
+```bash
+nohup openclaw gateway run > /tmp/gateway.log 2>&1 &
+```
+
+The Gateway runs in the background and survives SSH disconnects. Verify it is
+up:
+
+```bash
+openclaw gateway health
+```
+
+The command reports the Gateway status, so `OK` means you are good to
+continue.
+
+To restart the Gateway later (after config changes or updates):
+
+```bash
+pkill -f "openclaw gateway" || true
+nohup openclaw gateway run > /tmp/gateway.log 2>&1 &
+```
+
+## Open the dashboard
+
+Open the preview URL you generated earlier in your browser. The Control UI
+asks for the gateway token on first connect; paste the value you printed
+after onboarding.
+
+### Approve your device
+
+The first browser connection queues a device pairing request. Back in your
+sandbox SSH session:
+
+```bash
+# List pending requests and copy the request id
+openclaw devices list
+
+# Approve it
+openclaw devices approve REQUEST_ID
+```
+
+## Security
+
+Access to the Gateway is protected in three layers:
+
+| Layer           | Description                                            |
+| --------------- | ------------------------------------------------------ |
+| Preview URL     | Time-limited signed URL (expires after 1 hour)         |
+| Gateway token   | Required to connect via the Control UI                 |
+| Device approval | Each new browser or client must be explicitly approved |
+
+Keep your gateway token and preview URLs private. The Gateway stays bound to
+loopback; Daytona's preview proxy handles external access.
+
+## Channel setup
+
+Unknown senders require pairing approval by default; see
+[Pairing](/channels/pairing).
+
+### Telegram
+
+Create a bot with [@BotFather](https://t.me/botfather) (`/newbot`), copy the
+token, then configure OpenClaw from the sandbox SSH session:
+
+```bash
+openclaw config set channels.telegram.enabled true
+openclaw config set channels.telegram.botToken YOUR_BOT_TOKEN
+```
+
+Restart the Gateway (see above), send your bot a DM, then approve the pairing
+code it reports:
+
+```bash
+openclaw pairing list telegram
+openclaw pairing approve telegram PAIRING_CODE
+```
+
+Pairing codes expire after 1 hour. Full reference: [Telegram](/channels/telegram).
+
+### WhatsApp
+
+WhatsApp ships as a separate plugin, so install and enable it first:
+
+```bash
+openclaw plugins install clawhub:@openclaw/whatsapp --acknowledge-clawhub-risk
+openclaw plugins enable whatsapp
+```
+
+Installing does not enable a plugin, so the `enable` step is required;
+otherwise the Gateway reports the channel as configured but untrusted. Running
+the login command below without installing first prompts you to download the
+plugin from ClawHub or npm instead.
+
+Then link the account by scanning a QR code from the sandbox SSH session:
+
+```bash
+openclaw channels login --channel whatsapp
+```
+
+On your phone: **Settings → Linked Devices → Link a Device**, then scan the QR
+code shown in the terminal. Restart the Gateway after linking, then message
+yourself on WhatsApp and OpenClaw replies in that chat.
+
+No pairing approval is needed: with no allowlist configured, the linked
+account's own number is allowed by default. Pairing applies to unknown
+senders, which is why Telegram needs it and self-chat does not. Allowlists,
+personal-number mode, and self-chat details: [WhatsApp](/channels/whatsapp).
+
+## Updating
+
+The snapshot's global npm tree is owned by root, so plain `openclaw update`
+cannot write to it. Update from the sandbox SSH session with:
+
+```bash
+sudo env "PATH=$PATH" npm install --global openclaw@latest
+openclaw doctor
+```
+
+`openclaw doctor` migrates any older config after the update. Restart the
+Gateway afterwards (see above).
+
+## Stop and resume the sandbox
+
+```bash
+# Stop
+daytona sandbox stop openclaw
+
+# Resume
+daytona sandbox start openclaw
+```
+
+Sandbox state persists across stop/start cycles, but the Gateway process does
+not auto-start. After a resume, reconnect and start it again:
+
+```bash
+daytona ssh openclaw
+nohup openclaw gateway run > /tmp/gateway.log 2>&1 &
+```
+
+## Troubleshooting
+
+### Gateway not running after sandbox restart
+
+The Gateway process does not survive a sandbox restart. Reconnect with
+`daytona ssh openclaw` and start it again with the `nohup` command above.
+
+### Preview URL expired
+
+Preview URLs are time-limited (default 3600 seconds). Regenerate from your
+local terminal, optionally with a longer expiry:
+
+```bash
+daytona preview-url openclaw --port 18789 --expires 86400
+```
+
+Each generated URL has a different host, so it is a new origin. After
+regenerating, update `gateway.controlUi.allowedOrigins` with the new URL and
+restart the Gateway, or the Control UI is rejected with `origin not allowed`.
+
+### Sandbox auto-stopped
+
+If the sandbox was created without `--auto-stop 0`, it stops automatically
+when idle. Resume it with `daytona sandbox start openclaw`.
+
+### Gateway port not reachable
+
+Confirm the Gateway is running and listening:
+
+```bash
+openclaw gateway health
+tail -20 /tmp/gateway.log
+```
+
+If you changed the Gateway port, pass the same port to `daytona preview-url`.
+
+## Notes
+
+- For programmatic sandbox provisioning, see the
+  [Daytona OpenClaw SDK guide](https://www.daytona.io/docs/en/guides/openclaw/openclaw-sdk-sandbox/)
+
+## Related
+
+- [Gateway remote access](/gateway/remote)
+- [Gateway security](/gateway/security)
+- [Updating OpenClaw](/install/updating)

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -27,12 +27,13 @@ Linux-compatible Gateway runtime.
 ## VPS and hosting
 
 - VPS hub: [VPS hosting](/vps)
-- Fly.io: [Fly.io](/install/fly)
-- Hetzner (Docker): [Hetzner](/install/hetzner)
-- GCP (Compute Engine): [GCP](/install/gcp)
 - Azure (Linux VM): [Azure](/install/azure)
-- exe.dev (VM + HTTPS proxy): [exe.dev](/install/exe-dev)
+- Daytona (cloud sandbox): [Daytona](/install/daytona)
 - EasyRunner (Podman + Caddy): [EasyRunner](/platforms/easyrunner)
+- exe.dev (VM + HTTPS proxy): [exe.dev](/install/exe-dev)
+- Fly.io: [Fly.io](/install/fly)
+- GCP (Compute Engine): [GCP](/install/gcp)
+- Hetzner (Docker): [Hetzner](/install/hetzner)
 
 ## Common links
 

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -16,6 +16,7 @@ tuning that applies everywhere.
 
 <CardGroup cols={2}>
   <Card title="Azure" href="/install/azure">Linux VM</Card>
+  <Card title="Daytona" href="/install/daytona">Cloud sandbox with preview URLs</Card>
   <Card title="DigitalOcean" href="/install/digitalocean">Simple paid VPS</Card>
   <Card title="exe.dev" href="/install/exe-dev">VM with HTTPS proxy</Card>
   <Card title="Fly.io" href="/install/fly">Fly Machines</Card>


### PR DESCRIPTION
Related: #33471 (superseded — that PR went stale and is rewritten here against current `main`)

## What Problem This Solves

There is no documentation for running OpenClaw on [Daytona](https://www.daytona.io), even though Daytona ships OpenClaw preinstalled in its `daytona-medium` snapshot and publishes its own OpenClaw guides. Users looking for a cloud sandbox in the Hosting section find Azure, Fly.io, Hetzner, Hostinger and others, but nothing for Daytona, so a low-friction hosting path is effectively undiscoverable.

Daytona also differs from the existing VPS guides in ways that make the generic Linux instructions misleading: there is no service manager for the Gateway, the dashboard is reached through a signed preview URL rather than SSH tunnelling or Tailscale, and that preview proxy changes what the Gateway sees as the browser origin.

## Why This Change Was Made

Adds `docs/install/daytona.md` covering sandbox creation, onboarding, Gateway startup, preview-URL dashboard access, device pairing, Telegram/WhatsApp setup, updating, and troubleshooting, then wires it into the three places hosting guides are surfaced (`docs.json` Hosting nav, the `vps.md` provider picker, and the `platforms/index.md` list).

The guide keeps the Gateway on its loopback default and reaches it through Daytona's preview URL, which requires allowlisting that origin in `gateway.controlUi.allowedOrigins`. Where Daytona's environment diverges from a normal VPS, the guide documents the working path rather than the conventional one: `pkill` + `nohup` instead of `openclaw gateway stop/restart` (no service manager in a sandbox), and `sudo env "PATH=$PATH" npm install --global openclaw@latest` instead of `openclaw update` (the snapshot's global npm tree is root-owned). Docs-only: no code, config, schema, or runtime behaviour changes.

## User Impact

Users can host OpenClaw on Daytona by following a single guide, and it is discoverable from the Hosting nav, the VPS provider picker, and the Platforms page. Every command in the guide is verified against the version currently shipped in `daytona-medium` (OpenClaw 2026.7.1-2), including the parts where the obvious command does not work and the guide documents the one that does.

## Evidence

**Walked end to end in a live Daytona sandbox** on the shipped snapshot (`daytona-medium`, OpenClaw 2026.7.1-2): sandbox creation → SSH → onboarding → gateway token → origin allowlist → Gateway start and `openclaw gateway health` → preview URL → Control UI → device approval → Telegram (bot token + pairing approval, messages delivered) → WhatsApp (plugin install/enable, QR link, self-chat replies) → update path → stop/resume.

Validating against the shipped CLI rather than only reading source corrected several things that would otherwise have been wrong in the guide:

- **Onboarding** now defaults to a conversational setup assistant and refuses to run without a TTY (`Onboarding needs an interactive TTY. Use openclaw onboard --non-interactive --accept-risk ...`). The guide documents the deterministic non-interactive command and notes that `--classic` still gives the older step-by-step wizard.
- **`openclaw config get gateway.auth.token` returns `__OPENCLAW_REDACTED__`**, since `config get` reads from an unconditionally redacted snapshot (`src/cli/config-cli.ts:154`) and has no reveal flag. `openclaw dashboard --no-open` also does not print it headlessly. The guide reads the value from the config file instead, and says why.
- **Preview URLs rotate**: each `daytona preview-url` call returns a different host, so it is a new origin. Regenerating an expired URL invalidates `allowedOrigins`, which the troubleshooting section now calls out.
- **`openclaw gateway stop`/`restart`** are service-manager commands (systemd user units on Linux); a sandbox has no service to act on, hence the `pkill` + `nohup` pattern.
- **WhatsApp is an external plugin**, and installing does not enable it (`enableExplicitlySelectedPluginInConfig` is only reached from the `enable` command), so both `plugins install` and `plugins enable` are documented.
- **`openclaw update` fails** on this snapshot with `EACCES: permission denied, unlink '.../node_modules/openclaw/CHANGELOG.md'`; the documented `sudo env "PATH=$PATH"` form was verified upgrading a sandbox from 2026.2.1 to 2026.7.1-2.
- **WhatsApp self-chat needs no pairing approval**, because the linked self number is allowed by default when no allowlist is configured — so that step was removed rather than copied from the Telegram flow.

**Local docs CI (`pnpm check:docs`) passes in full:** `format:docs:check` clean (737 files), `lint:docs` 0 issues (738 files), `docs:check-mdx` 753 files, `docs:check-i18n-glossary` clean, `docs:check-links` 6224 internal links / **0 broken**, `docs:map:check` up to date. Page also renders correctly under `mint dev` at `/install/daytona`.

**Note for reviewers:** `docs:check-i18n-glossary` required entries for the new page title and two link labels, so this PR adds three entries to `docs/.i18n/glossary.zh-CN.json`. `Daytona → Daytona` keeps the product name in English (matching `OpenClaw`/`iMessage`); `Gateway 远程访问` and `更新 OpenClaw` follow the existing `Gateway 安全`/`更新` patterns but would benefit from a native-speaker check.