### PR TITLE
fix(workboard): cards created with metadata.archivedAt are silently undispatchable

### DIFF
--- a/extensions/workboard/src/dispatcher-ownership.test.ts
+++ b/extensions/workboard/src/dispatcher-ownership.test.ts
@@ -24,6 +24,29 @@ function createMemoryStore(): WorkboardKeyedStore {
 }
 
 describe("Workboard dispatcher ownership", () => {
+  it("dispatches a card whose create input tried to inject archivedAt", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const now = 10;
+    const card = await store.create({
+      title: "Injected archive",
+      status: "ready",
+      workspaceAccess: { unrestricted: true },
+      metadata: { archivedAt: now },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-injected" });
+
+    await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now, maxStarts: 1 },
+    });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      execution: { runId: "run-injected" },
+    });
+  });
+
   it("falls back to one default owner for persisted blank and unassigned agents", async () => {
     const keyed = createMemoryStore();
     const store = new WorkboardStore(keyed);

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -389,7 +389,7 @@ export class WorkboardCoreStore {
         templateId: normalizeTemplateId(input.templateId),
         ...(childAutomation ? { automation: childAutomation } : {}),
       },
-      { allowDependencyLinks: false },
+      { allowDependencyLinks: false, allowArchivedAt: false },
     );
     const syncedMetadata = trimMetadataToBudget(
       syncExecutionAttemptMetadata(metadata, execution, now),

--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -1024,7 +1024,11 @@ export function appendCompletionProof(
 export function normalizeMetadata(
   value: unknown,
   fallback: WorkboardMetadata = {},
-  options: { allowDependencyLinks?: boolean; preserveProofId?: string } = {},
+  options: {
+    allowDependencyLinks?: boolean;
+    allowArchivedAt?: boolean;
+    preserveProofId?: string;
+  } = {},
 ): WorkboardMetadata {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return trimMetadataToBudget(fallback, options);
@@ -1034,7 +1038,11 @@ export function normalizeMetadata(
     record.stale && typeof record.stale === "object" && !Array.isArray(record.stale)
       ? (record.stale as Record<string, unknown>)
       : null;
-  const hasArchivedAt = Object.hasOwn(record, "archivedAt");
+  // Archival is a transition owned by archive(), which appends the matching
+  // `archived` event. Callers that cannot produce that event (create) must not
+  // be able to declare it, or the card is excluded from dispatch from the
+  // instant it exists with an event log recording only `created`.
+  const hasArchivedAt = Object.hasOwn(record, "archivedAt") && options.allowArchivedAt !== false;
   const hasStale = Object.hasOwn(record, "stale");
   const hasLifecycleStatusSourceUpdatedAt = Object.hasOwn(record, "lifecycleStatusSourceUpdatedAt");
   const links = Array.isArray(record.links)

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1010,6 +1010,24 @@ describe("WorkboardStore", () => {
     expect(restored.events?.at(-1)).toMatchObject({ kind: "unarchived" });
   });
 
+  it("ignores caller-supplied archivedAt on create so no card is born archived", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Injected archive",
+      metadata: { archivedAt: Date.now() },
+    });
+
+    // Archival is a transition owned by archive(), which appends the matching
+    // event. Honouring it here would exclude the card from dispatch from birth
+    // with an event log recording only "created".
+    expect(card.metadata?.archivedAt).toBeUndefined();
+    expect(card.events?.map((event) => event.kind)).toEqual(["created"]);
+
+    const archived = await store.archive(card.id, true);
+    expect(archived.metadata?.archivedAt).toBeGreaterThan(0);
+    expect(archived.events?.at(-1)).toMatchObject({ kind: "archived" });
+  });
+
   it("resolves matching unknown proof on completion without duplicating it", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
Fixes #116395

AI-assisted (Claude Code): the trace, patch, and tests below were produced with AI assistance and reviewed by me before submitting.

## What Problem This Solves

Fixes an issue where a Workboard card created with `metadata.archivedAt` was born already archived: excluded from dispatch at every status from the instant it existed, listed normally by the dashboard and `cards.list`, and carrying an event log that recorded only `created`.

Because no archiving ever happened, there was no `archived` event to point at. The reporter lost roughly two days to a high-priority blocker card that sat on the board as a ghost while the investigation looked for a rogue archiver that did not exist. Any caller with create access could produce the state, and an operator had no way to defend against it — the card looks normal everywhere except in the dispatcher.

## Why This Change Was Made

Archiving is a lifecycle transition owned by `archive()`. It routes through `updateCard`, which diffs old against new and appends the matching `archived` event (`store-card-helpers.ts:302`). The create path had no equivalent guard: `createDirect` passed `input.metadata` straight into `normalizeMetadata`, which treats `archivedAt` as an ordinary caller-supplied field (`store-normalizers.ts:1037`). `appendEvent` is never involved on create, so the resulting card asserts in its own history that nothing unusual happened.

`normalizeMetadata` already carries an options bag for exactly this category of rule — "create is more restrictive than update" — in `allowDependencyLinks`, passed as `false` from `createDirect` and as a caller-controlled flag from `updateCard`. This change adds `allowArchivedAt` next to it rather than introducing a second mechanism, so `archivedAt` falls back to the create fallback (`undefined`) instead of the caller's value.

Boundary: the update path is deliberately untouched. A patch that sets `archivedAt` still archives the card and still emits the `archived` event, so that state keeps its provenance. Of the three options the issue offered, this is the first (ignore) rather than reject-with-error, because create already silently normalizes every other out-of-range metadata field rather than throwing, and a hard error would break callers that spread an existing card's metadata into a new one.

## User Impact

A card can no longer be created in a state that makes it permanently undispatchable without a trace. Cards created with `metadata.archivedAt` are now ordinary active cards and dispatch normally; archiving still works exactly as before and still records the event.

## Evidence

Two regression tests, both verified to fail before the fix and pass after:

- `extensions/workboard/src/store.test.ts` — asserts create ignores `metadata.archivedAt` and that `archive()` still sets it and appends the `archived` event.
- `extensions/workboard/src/dispatcher-ownership.test.ts` — asserts the reported *harm* rather than just the field: a `ready` card created with injected `archivedAt` is actually picked up by `dispatchAndStartWorkboardCards` and gets an execution.

Failing before (fix stashed, both test files):

```
× ignores caller-supplied archivedAt on create so no card is born archived
× dispatches a card whose create input tried to inject archivedAt
Tests  2 failed | 139 passed (141)
```

with `AssertionError: expected 1785414298156 to be undefined`.

Passing after, full extension suite:

```
pnpm vitest run extensions/workboard/
Test Files  12 passed (12)
     Tests  218 passed (218)
```

Also clean on the same tree:

- `oxfmt --check` on all four changed files
- `oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/workboard`
- `tsgo -p tsconfig.extensions.json`
- `node scripts/check-max-lines-ratchet.mjs`

I checked every card constructor funnels through `createDirect` (`store-core.ts:315`, `store-workflow.ts:565` decompose, `gateway-workspace-methods.ts:54`, `tools.ts:297`, `cli.ts:197`, `command.ts:153`); `store-promote.ts` creates no cards. There is no import/restore/clone path that legitimately needs to create an already-archived card — `exportCards` has no counterpart — and sqlite hydration reads `archived_at` from rows without going through `createDirect`, so restoring a persisted archived card is unaffected.

### Maintainer verification on refreshed current main

Original contributor: @MaheshBhushan. Original issue reporter: @sergei-ivanisenko.

The exact original four-file contributor patch was replayed unchanged onto current main, preserving the original commit author, authored timestamp, subject, and stable patch ID. This is real production WorkboardStore, real on-disk SQLite, and the real production dispatcher in the original create-then-dispatch execution order, not a mocked store or a unit-only claim.

Before, current main:

```json
{"injectedCard":{"archivedAt":1700000000000,"status":"ready","events":["created"]},"sqliteRow":{"archived_at":1700000000000,"status":"ready"},"sqliteEvents":[{"kind":"created"}],"dispatch":{"started":0,"failures":0,"runCalls":0,"persistedStatus":"ready"},"normalArchive":{"archivedAt":1785599662538,"lastEvent":"edited"},"reopenedArchive":{"archivedAt":1785599662538,"lastEvent":"edited"},"decomposeChild":{"archivedAt":1700000000001},"existingClaimContract":{"ownerId":"fixture-owner"}}
```

After, exact refreshed contributor head:

```json
{"injectedCard":{"archivedAt":null,"status":"ready","events":["created"]},"sqliteRow":{"archived_at":null,"status":"ready"},"sqliteEvents":[{"kind":"created"}],"dispatch":{"started":1,"failures":0,"runCalls":1,"persistedStatus":"running","persistedRunId":"proof-run"},"normalArchive":{"archivedAt":1785599669077,"lastEvent":"archived"},"reopenedArchive":{"archivedAt":1785599669077,"lastEvent":"archived"},"decomposeChild":{"archivedAt":null},"existingClaimContract":{"ownerId":"fixture-owner"}}
```

The injected timestamp previously persisted as SQLite archived_at with only a created event, and dispatcher starts/run calls were both zero. The repaired creator writes archived_at=null with only the legitimate created event, then the real dispatcher starts exactly one run and persists running status. Normal archive records its archived event, reopening SQLite preserves that archive, decomposed child creation rejects the same injected state, and existing claim creation remains unchanged. No schema or storage migration is involved.

Focused owner-boundary proof:

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-s02-116412-f474df70 node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts extensions/workboard/src/dispatcher-ownership.test.ts
```

Result: 2 test files and 126 tests passed. All four changed files pass oxfmt, git diff --check is clean, and a fresh Codex Sol xhigh autoreview found no accepted or actionable findings.

## Open questions

**`metadata.claim` has the same shape of defect and I deliberately did not fix it here.** The issue mentions it, and it reproduces: a card created with an active `claim` is filtered out of `selectStartableCards` by `cardHasActiveClaim` (`dispatcher.ts:283`) with only a `created` event. It is arguably worse than the archived case, because a non-`done` card with an active claim sets `consumesOwnerSlot` (`dispatcher.ts:262-273`) and the `cardIsArchived` escape hatch does not apply — so injecting `claim.ownerId: "workboard"` (the `DEFAULT_DISPATCH_OWNER` fallback) can stall dispatch board-wide rather than ghosting a single card.

I left it out because it is not a clear-cut defect the way `archivedAt` is: `dispatcher-ownership.test.ts:345` ("evaluates claim capacity at dispatch time instead of wall time") *deliberately* builds its fixture by passing `metadata.claim` to `store.create`. Blocking it would mean rewriting one of your tests, which is a call I would rather you make than smuggle into a bug fix. If you want it closed too, `allowArchivedAt` generalises to `allowLifecycleMetadata` in one line plus a fixture change — happy to follow up in a separate PR either way.

Same door, lower severity, also unfixed and unreported until now: `metadata.stale` is honoured on create with no `stale` event (update emits one at `store-card-helpers.ts:308`), and `metadata.failureCount` is honoured verbatim, which feeds the retry budget.