### PR TITLE
fix(channels): render one line per commentary note

### DIFF
--- a/scripts/e2e/mock-openai-server.mjs
+++ b/scripts/e2e/mock-openai-server.mjs
@@ -262,19 +262,34 @@ function multiPreambleEvents(body, bodyText) {
     return null;
   }
   if (outputs === 0) {
-    return preambleThenToolCallEvents("First I check the workspace.", "exec", {
-      command: ["bash", "-lc", "sleep 2 && echo multiproof-one"],
-    }, "-1");
+    return preambleThenToolCallEvents(
+      "First I check the workspace.",
+      "exec",
+      {
+        command: ["bash", "-lc", "sleep 2 && echo multiproof-one"],
+      },
+      "-1",
+    );
   }
   if (outputs === 1) {
-    return preambleThenToolCallEvents("Now I look at the second thing.", "exec", {
-      command: ["bash", "-lc", "sleep 2 && echo multiproof-two"],
-    }, "-2");
+    return preambleThenToolCallEvents(
+      "Now I look at the second thing.",
+      "exec",
+      {
+        command: ["bash", "-lc", "sleep 2 && echo multiproof-two"],
+      },
+      "-2",
+    );
   }
   if (outputs === 2) {
-    return preambleThenToolCallEvents("Last one, then I answer.", "exec", {
-      command: ["bash", "-lc", "sleep 2 && echo multiproof-three"],
-    }, "-3");
+    return preambleThenToolCallEvents(
+      "Last one, then I answer.",
+      "exec",
+      {
+        command: ["bash", "-lc", "sleep 2 && echo multiproof-three"],
+      },
+      "-3",
+    );
   }
   return responseEvents("OPENCLAW_E2E_MULTIPROOF");
 }

--- a/scripts/e2e/mock-openai-server.mjs
+++ b/scripts/e2e/mock-openai-server.mjs
@@ -152,8 +152,10 @@ function buildMockFunctionCall(name, args) {
 // The Responses API carries that tag as `phase` on the message item, and the
 // transport reads it straight off the item, so an untagged item produces no
 // preamble at all and the scenario silently proves nothing.
-function preambleThenToolCallEvents(preamble, name, args) {
-  const messageItemId = "msg_e2e_preamble";
+function preambleThenToolCallEvents(preamble, name, args, itemSuffix = "") {
+  // Providers give each assistant message its own id; reusing one id makes the
+  // runner accumulate every turn's text into a single growing item.
+  const messageItemId = `msg_e2e_preamble${itemSuffix}`;
   const call = buildMockFunctionCall(name, args);
   return [
     {
@@ -245,6 +247,41 @@ function progressDraftEvents(body, bodyText) {
     });
   }
   return responseEvents("OPENCLAW_E2E_DRAFTPROOF");
+}
+
+// Multi-preamble proof: several commentary runs interleaved with tool calls in
+// one turn. A single-tool turn cannot show commentary that arrives repeatedly,
+// which is the shape channel progress has to keep in one draft.
+function multiPreambleEvents(body, bodyText) {
+  const allText = collectText(body).join("\n");
+  if (!allText.includes("OPENCLAW_E2E_MULTIPROOF")) {
+    return null;
+  }
+  const outputs = collectFunctionCallOutputCount(body);
+  if (!hasDeclaredTool(bodyText, "exec")) {
+    return null;
+  }
+  if (outputs === 0) {
+    return preambleThenToolCallEvents("First I check the workspace.", "exec", {
+      command: ["bash", "-lc", "sleep 2 && echo multiproof-one"],
+    }, "-1");
+  }
+  if (outputs === 1) {
+    return preambleThenToolCallEvents("Now I look at the second thing.", "exec", {
+      command: ["bash", "-lc", "sleep 2 && echo multiproof-two"],
+    }, "-2");
+  }
+  if (outputs === 2) {
+    return preambleThenToolCallEvents("Last one, then I answer.", "exec", {
+      command: ["bash", "-lc", "sleep 2 && echo multiproof-three"],
+    }, "-3");
+  }
+  return responseEvents("OPENCLAW_E2E_MULTIPROOF");
+}
+
+function collectFunctionCallOutputCount(body) {
+  const input = Array.isArray(body?.input) ? body.input : [];
+  return input.filter((item) => item?.type === "function_call_output").length;
 }
 
 function toolCallEvents(name, args) {
@@ -563,6 +600,14 @@ const server = http.createServer((req, res) => {
       const draftEvents = progressDraftEvents(body, bodyText);
       if (draftEvents) {
         writeResponsesEvents(res, body.stream, draftEvents);
+        return;
+      }
+      const multiEvents = multiPreambleEvents(body, bodyText);
+      if (multiEvents) {
+        // Space the turns out: a draft that renders and edits between steps is
+        // the whole point of this scenario, and the mock answers instantly.
+        await delay(readPositiveIntEnv("MOCK_MULTIPROOF_STEP_DELAY_MS", 2500));
+        writeResponsesEvents(res, body.stream, multiEvents);
         return;
       }
       const responseText = resolveResponseText(bodyText);

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -24,12 +24,16 @@ describe("commentary reported twice", () => {
     });
     const receipt = createChannelProgressReceiptTracker({ now: () => 0 });
 
-    for (const note of ["First step.", "Second step."]) {
-      await compositor.pushCommentaryProgress(note, { itemId: `item-${note}` });
-      receipt.noteCommentary(`item-${note}`, note);
-      await compositor.pushCommentaryProgress(note);
-      receipt.noteCommentary(undefined, note);
-    }
+    // Both arrival orders: the id-bearing report can land first or last.
+    await compositor.pushCommentaryProgress("First step.", { itemId: "item-1" });
+    receipt.noteCommentary("item-1", "First step.");
+    await compositor.pushCommentaryProgress("First step.");
+    receipt.noteCommentary(undefined, "First step.");
+
+    await compositor.pushCommentaryProgress("Second step.");
+    receipt.noteCommentary(undefined, "Second step.");
+    await compositor.pushCommentaryProgress("Second step.", { itemId: "item-2" });
+    receipt.noteCommentary("item-2", "Second step.");
 
     const rendered = updates.at(-1) ?? "";
     expect(rendered.match(/First step\./gu) ?? []).toHaveLength(1);

--- a/src/channels/progress-draft-compositor.test.ts
+++ b/src/channels/progress-draft-compositor.test.ts
@@ -7,6 +7,37 @@ import {
 } from "./progress-draft-compositor.js";
 import { DEFAULT_PROGRESS_DRAFT_INITIAL_DELAY_MS } from "./streaming.js";
 
+describe("commentary reported twice", () => {
+  // Transports report one commentary item twice: once with the provider's item
+  // id and once without it. Both describe the same note.
+  it("renders one line and counts one note per item", async () => {
+    const updates: string[] = [];
+    const compositor = createChannelProgressDraftCompositor({
+      entry: { streaming: { mode: "progress", progress: { commentary: true } } },
+      mode: "progress",
+      active: true,
+      seed: "",
+      update: (text) => {
+        updates.push(text);
+      },
+      now: () => 0,
+    });
+    const receipt = createChannelProgressReceiptTracker({ now: () => 0 });
+
+    for (const note of ["First step.", "Second step."]) {
+      await compositor.pushCommentaryProgress(note, { itemId: `item-${note}` });
+      receipt.noteCommentary(`item-${note}`, note);
+      await compositor.pushCommentaryProgress(note);
+      receipt.noteCommentary(undefined, note);
+    }
+
+    const rendered = updates.at(-1) ?? "";
+    expect(rendered.match(/First step\./gu) ?? []).toHaveLength(1);
+    expect(rendered.match(/Second step\./gu) ?? []).toHaveLength(1);
+    expect(receipt.buildSummaryLine()).toContain("💬 2 notes");
+  });
+});
+
 describe("createChannelProgressDraftCompositor", () => {
   it("tracks compact per-turn progress receipts", () => {
     let now = 1_000;

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -50,7 +50,7 @@ export function createChannelProgressReceiptTracker(params?: { now?: () => numbe
   let commentaryNotes = 0;
   let reasoningOpen = false;
   const seenCommentaryIds = new Set<string>();
-  let lastCommentaryText = "";
+  const seenCommentaryTexts = new Set<string>();
 
   const closeReasoning = () => {
     if (!reasoningOpen) {
@@ -67,7 +67,7 @@ export function createChannelProgressReceiptTracker(params?: { now?: () => numbe
     commentaryNotes = 0;
     reasoningOpen = false;
     seenCommentaryIds.clear();
-    lastCommentaryText = "";
+    seenCommentaryTexts.clear();
   };
 
   return {
@@ -86,18 +86,15 @@ export function createChannelProgressReceiptTracker(params?: { now?: () => numbe
       if (!trimmed) {
         return;
       }
+      // One note is reported twice, with and without its item id, in either
+      // order. Counting on first sight of either fact keeps the total honest.
+      const seen =
+        seenCommentaryTexts.has(trimmed) || (itemId ? seenCommentaryIds.has(itemId) : false);
+      seenCommentaryTexts.add(trimmed);
       if (itemId) {
-        if (!seenCommentaryIds.has(itemId)) {
-          seenCommentaryIds.add(itemId);
-          commentaryNotes += 1;
-        }
-        // The same note is reported again without its id; remembering the text
-        // keeps that repeat from counting as a second note.
-        lastCommentaryText = trimmed;
-        return;
+        seenCommentaryIds.add(itemId);
       }
-      if (trimmed !== lastCommentaryText) {
-        lastCommentaryText = trimmed;
+      if (!seen) {
         commentaryNotes += 1;
       }
     },
@@ -331,14 +328,17 @@ export function createChannelProgressDraftCompositor(params: {
     normalized: string;
     bareNormalized: string;
   }): string => {
-    if (commentary.itemId) {
-      return `commentary:${commentary.itemId}`;
-    }
+    // Text first, so the pair resolves to one line in either arrival order: the
+    // id-less report cannot know the item id, and the id-bearing one must not
+    // open a second line for a note already on the board.
     const knownLineId = commentary.bareNormalized
       ? commentaryLineIdByBareText.get(commentary.bareNormalized)
       : undefined;
     if (knownLineId) {
       return knownLineId;
+    }
+    if (commentary.itemId) {
+      return `commentary:${commentary.itemId}`;
     }
     if (!commentary.normalized) {
       // Sanitized to nothing (directive-only / NO_REPLY): no line to address, so

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -91,6 +91,9 @@ export function createChannelProgressReceiptTracker(params?: { now?: () => numbe
           seenCommentaryIds.add(itemId);
           commentaryNotes += 1;
         }
+        // The same note is reported again without its id; remembering the text
+        // keeps that repeat from counting as a second note.
+        lastCommentaryText = trimmed;
         return;
       }
       if (trimmed !== lastCommentaryText) {
@@ -182,6 +185,10 @@ export function createChannelProgressDraftCompositor(params: {
   // place instead of appending one line per growing prefix.
   let lastIdLessCommentaryId: string | undefined;
   let lastIdLessCommentaryBare = "";
+  // Transports report one commentary item twice: once carrying the provider's
+  // item id and once without it. Keying by text lets both resolve to the same
+  // line instead of rendering the note twice.
+  const commentaryLineIdByBareText = new Map<string, string>();
   // Model preambles and narration share the status slot while tool lines keep
   // accumulating underneath for turns where neither source is available.
   let preambleText = "";
@@ -256,6 +263,7 @@ export function createChannelProgressDraftCompositor(params: {
     lastReasoningLine = undefined;
     lastIdLessCommentaryId = undefined;
     lastIdLessCommentaryBare = "";
+    commentaryLineIdByBareText.clear();
     preambleText = "";
     preambleItemId = undefined;
     preambleAt = undefined;
@@ -325,6 +333,12 @@ export function createChannelProgressDraftCompositor(params: {
   }): string => {
     if (commentary.itemId) {
       return `commentary:${commentary.itemId}`;
+    }
+    const knownLineId = commentary.bareNormalized
+      ? commentaryLineIdByBareText.get(commentary.bareNormalized)
+      : undefined;
+    if (knownLineId) {
+      return knownLineId;
     }
     if (!commentary.normalized) {
       // Sanitized to nothing (directive-only / NO_REPLY): no line to address, so
@@ -720,6 +734,9 @@ export function createChannelProgressDraftCompositor(params: {
       if (!itemId) {
         lastIdLessCommentaryId = lineId;
         lastIdLessCommentaryBare = bareNormalized;
+      }
+      if (bareNormalized) {
+        commentaryLineIdByBareText.set(bareNormalized, lineId);
       }
       const alreadyStarted = gate.hasStarted;
       await gate.startNow();


### PR DESCRIPTION
## What Problem This Solves

With `streaming.progress.commentary` enabled, every commentary note rendered **twice** in the progress draft, and the receipt counted it twice. Recorded live on Telegram, three preambles interleaved with three tool calls:

```
Working
💬 First I check the workspace.
💬 First I check the workspace.          ← same note, second line
🛠️ Exec … failed
💬 Now I look at the second thing.
💬 Now I look at the second thing.       ← again
🛠️ Exec … failed
…
💬 6 notes · 🛠️ 3 tool calls · ⏱️ 13s    ← 6 notes for 3
```

Transports report one commentary item twice — once carrying the provider's item id, once without it. Instrumenting the compositor's entry point during a live turn shows the pair plainly:

```
PUSH itemId=msg_e2e_preamble-1  text="First I check the workspace."
PUSH itemId=-                   text="First I check the workspace."
```

The id-ful report opened `commentary:<itemId>`; the id-less repeat derived `commentary:<text>`. Two identities for one note, so `mergeChannelProgressDraftLine` had nothing to match and appended a second line.

## Why This Change Was Made

The compositor owns "same fact, one line", so identity belongs there rather than in each transport. Commentary lines are now keyed by the note's text as well as its item id: whichever report arrives first opens the line, and the other resolves to it. The receipt tracker remembers a note it has already counted so the id-less repeat does not count again.

This is the same class as the cumulative-snapshot fix in #116272 — that one collapsed a note that *grows* across reports; this one collapses a note reported twice in the same instant. Both are the transport describing one item more than once.

Why it survived the earlier commentary work: `resolveChannelStreamingProgressCommentary` used to guess a stream mode that made `progress.commentary` a silent no-op, so no duplicate ever reached a draft. #116272 made the lane take effect, which surfaced this.

## User Impact

Operators running `progress.commentary: true` get one 💬 line per note and an accurate note count. Everything else in the draft is untouched, and the lane is still off by default. No config surface added, changed, or retired.

## Evidence

**Live on real Telegram** (userbot lane, DM to remove other bots' traffic from the window), same scenario before and after:

| | Before | After |
| --- | --- | --- |
| 💬 lines for 3 notes | 6 | **3** |
| receipt | `💬 6 notes` | `💬 3 notes` |

```
Working
💬 First I check the workspace.
🛠️ Exec … one failed
💬 Now I look at the second thing.
🛠️ Exec … two failed
💬 Last one, then I answer.
🛠️ Exec … three failed
```

**Unit**: `src/channels/progress-draft-compositor.test.ts` gains a case that pushes each note twice — once with an item id, once without — and asserts one rendered line per note plus `💬 2 notes`. Verified failing with the fix stashed. 41 passing in that file.

**Harness**: the mock provider gains `OPENCLAW_E2E_MULTIPROOF` — three preamble/tool-call rounds in one turn, each preamble with its own message item id, spaced by `MOCK_MULTIPROOF_STEP_DELAY_MS` so a draft renders between steps. The existing draft-proof scenario is single-tool, which structurally cannot show a note arriving twice; that gap is why the earlier commentary work missed this.

Typecheck clean (`tsgo:core`), oxlint clean, autoreview clean (0.99). `src/channels` has 5 pre-existing failures in `plugin-shape.contract.test.ts` (matrix/twitch sanitizer wiring) that reproduce identically with this change stashed.

### Provenance

Found from a live report on a deployed bot whose config had `progress.commentary: true` sitting inert for months; it went live with #116272 and the doubled notes read as message spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)