### PR TITLE
fix(signal): autoStart uses configured local httpUrl port

### DIFF
--- a/extensions/signal/doctor-contract-api.test.ts
+++ b/extensions/signal/doctor-contract-api.test.ts
@@ -421,6 +421,23 @@ describe("signal transport compatibility", () => {
     });
   });
 
+  it("keeps the default managed bind for an unported legacy loopback httpUrl", () => {
+    const result = normalizeCompatibilityConfig({
+      cfg: signalConfig({
+        apiMode: "native",
+        autoStart: true,
+        account: "+15555550123",
+        httpUrl: "http://127.0.0.1",
+      }),
+    });
+
+    expect(result.config.channels?.signal?.transport).toMatchObject({
+      kind: "managed-native",
+      url: "http://127.0.0.1",
+    });
+    expect(result.config.channels?.signal?.transport).not.toHaveProperty("httpPort");
+  });
+
   it("does not infer an invalid managed bind port from a legacy loopback httpUrl", () => {
     const result = normalizeCompatibilityConfig({
       cfg: signalConfig({

--- a/extensions/signal/doctor-contract-api.test.ts
+++ b/extensions/signal/doctor-contract-api.test.ts
@@ -421,6 +421,27 @@ describe("signal transport compatibility", () => {
     });
   });
 
+  it("infers a managed bind port from a bare legacy loopback httpUrl", () => {
+    const result = normalizeCompatibilityConfig({
+      cfg: signalConfig({
+        apiMode: "native",
+        autoStart: true,
+        account: "+15555550123",
+        httpUrl: "127.0.0.1:8082",
+      }),
+    });
+
+    expect(result.config.channels?.signal?.transport).toMatchObject({
+      kind: "managed-native",
+      url: "http://127.0.0.1:8082",
+      httpPort: 8082,
+    });
+    expect(resolveSignalAccount({ cfg: result.config }).transport).toMatchObject({
+      baseUrl: "http://127.0.0.1:8082",
+      httpPort: 8082,
+    });
+  });
+
   it("keeps the default managed bind for an unported legacy loopback httpUrl", () => {
     const result = normalizeCompatibilityConfig({
       cfg: signalConfig({

--- a/extensions/signal/doctor-contract-api.test.ts
+++ b/extensions/signal/doctor-contract-api.test.ts
@@ -655,7 +655,7 @@ describe("signal transport compatibility", () => {
     });
   });
 
-  it("ignores legacy native URL paths when the daemon bind matches", async () => {
+  it("preserves legacy native proxy URL paths when the daemon bind matches", async () => {
     const result = await migrateLegacySignalTransportConfig({
       cfg: signalConfig({
         apiMode: "native",
@@ -669,8 +669,26 @@ describe("signal transport compatibility", () => {
     expect(result.config.channels?.signal?.transport).toEqual({
       kind: "managed-native",
       httpHost: "127.0.0.1",
+      url: "http://127.0.0.1:8181/proxy",
       httpPort: 8181,
     });
+  });
+
+  it("keeps a path-prefixed legacy proxy endpoint independent when httpPort is absent", () => {
+    const result = normalizeCompatibilityConfig({
+      cfg: signalConfig({
+        apiMode: "native",
+        autoStart: true,
+        account: "+15555550123",
+        httpUrl: "http://127.0.0.1:8082/proxy",
+      }),
+    });
+
+    expect(result.config.channels?.signal?.transport).toMatchObject({
+      kind: "managed-native",
+      url: "http://127.0.0.1:8082/proxy",
+    });
+    expect(result.config.channels?.signal?.transport).not.toHaveProperty("httpPort");
   });
 
   it("preserves an independent managed connection URL", async () => {

--- a/extensions/signal/doctor-contract-api.test.ts
+++ b/extensions/signal/doctor-contract-api.test.ts
@@ -438,6 +438,27 @@ describe("signal transport compatibility", () => {
     expect(result.config.channels?.signal?.transport).not.toHaveProperty("httpPort");
   });
 
+  it("preserves an explicit default port through legacy migration and resolution", () => {
+    const result = normalizeCompatibilityConfig({
+      cfg: signalConfig({
+        apiMode: "native",
+        autoStart: true,
+        account: "+15555550123",
+        httpUrl: "http://127.0.0.1:80",
+      }),
+    });
+
+    expect(result.config.channels?.signal?.transport).toMatchObject({
+      kind: "managed-native",
+      url: "http://127.0.0.1",
+      httpPort: 80,
+    });
+    expect(resolveSignalAccount({ cfg: result.config }).transport).toMatchObject({
+      baseUrl: "http://127.0.0.1",
+      httpPort: 80,
+    });
+  });
+
   it("does not infer an invalid managed bind port from a legacy loopback httpUrl", () => {
     const result = normalizeCompatibilityConfig({
       cfg: signalConfig({

--- a/extensions/signal/doctor-contract-api.test.ts
+++ b/extensions/signal/doctor-contract-api.test.ts
@@ -403,6 +403,40 @@ describe("signal transport compatibility", () => {
     });
   });
 
+  it("infers a managed bind port from a legacy loopback httpUrl when httpPort is absent", () => {
+    const result = normalizeCompatibilityConfig({
+      cfg: signalConfig({
+        apiMode: "native",
+        autoStart: true,
+        account: "+15555550123",
+        httpUrl: "http://127.0.0.1:8082",
+      }),
+    });
+
+    expect(result.config.channels?.signal?.transport).toMatchObject({
+      kind: "managed-native",
+      url: "http://127.0.0.1:8082",
+      httpPort: 8082,
+    });
+  });
+
+  it("does not infer an invalid managed bind port from a legacy loopback httpUrl", () => {
+    const result = normalizeCompatibilityConfig({
+      cfg: signalConfig({
+        apiMode: "native",
+        autoStart: true,
+        account: "+15555550123",
+        httpUrl: "http://127.0.0.1:0",
+      }),
+    });
+
+    expect(result.config.channels?.signal?.transport).toMatchObject({
+      kind: "managed-native",
+      url: "http://127.0.0.1:0",
+    });
+    expect(result.config.channels?.signal?.transport).not.toHaveProperty("httpPort");
+  });
+
   it("reserves managed bind and local connection ports during migration", () => {
     const result = normalizeCompatibilityConfig({
       cfg: signalConfig({

--- a/extensions/signal/doctor-contract-api.test.ts
+++ b/extensions/signal/doctor-contract-api.test.ts
@@ -3,6 +3,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it, vi } from "vitest";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract-api.js";
+import { resolveSignalAccount } from "./src/accounts.js";
 import { migrateLegacySignalTransportConfig } from "./src/config-compat.js";
 
 function signalConfig(entry: Record<string, unknown>): OpenClawConfig {
@@ -653,9 +654,10 @@ describe("signal transport compatibility", () => {
       httpHost: "127.0.0.1",
       httpPort: 8181,
     });
+    expect(() => resolveSignalAccount({ cfg: result.config })).not.toThrow();
   });
 
-  it("preserves legacy native proxy URL paths when the daemon bind matches", async () => {
+  it("keeps the explicit daemon bind when a legacy URL carries the same proxy port", async () => {
     const result = await migrateLegacySignalTransportConfig({
       cfg: signalConfig({
         apiMode: "native",
@@ -669,7 +671,6 @@ describe("signal transport compatibility", () => {
     expect(result.config.channels?.signal?.transport).toEqual({
       kind: "managed-native",
       httpHost: "127.0.0.1",
-      url: "http://127.0.0.1:8181/proxy",
       httpPort: 8181,
     });
   });

--- a/extensions/signal/src/accounts.test.ts
+++ b/extensions/signal/src/accounts.test.ts
@@ -263,6 +263,27 @@ describe("resolveSignalAccount", () => {
     });
   });
 
+  it("preserves a canonical same-port path endpoint", () => {
+    const cfg = {
+      channels: {
+        signal: {
+          transport: {
+            kind: "managed-native",
+            url: "http://127.0.0.1:8181/proxy",
+            httpPort: 8181,
+          },
+        },
+      },
+    } as never;
+
+    expect(resolveSignalAccount({ cfg }).transport).toMatchObject({
+      kind: "managed-native",
+      baseUrl: "http://127.0.0.1:8181/proxy",
+      httpHost: "127.0.0.1",
+      httpPort: 8181,
+    });
+  });
+
   it("rejects an explicit managed port used by its own independent local endpoint", () => {
     const cfg = {
       channels: {

--- a/extensions/signal/src/accounts.test.ts
+++ b/extensions/signal/src/accounts.test.ts
@@ -309,7 +309,7 @@ describe("resolveSignalAccount", () => {
     });
   });
 
-  it("binds an implicit managed daemon to a non-default local connection URL port", () => {
+  it("preserves an independent canonical connection URL when httpPort is omitted", () => {
     const cfg = {
       channels: {
         signal: {
@@ -325,7 +325,7 @@ describe("resolveSignalAccount", () => {
       kind: "managed-native",
       baseUrl: "http://127.0.0.1:8082",
       httpHost: "127.0.0.1",
-      httpPort: 8082,
+      httpPort: 8080,
     });
   });
 

--- a/extensions/signal/src/accounts.test.ts
+++ b/extensions/signal/src/accounts.test.ts
@@ -284,6 +284,26 @@ describe("resolveSignalAccount", () => {
     });
   });
 
+  it("aligns a canonical path endpoint when httpPort is omitted", () => {
+    const cfg = {
+      channels: {
+        signal: {
+          transport: {
+            kind: "managed-native",
+            url: "http://127.0.0.1:8080/proxy",
+          },
+        },
+      },
+    } as never;
+
+    expect(resolveSignalAccount({ cfg }).transport).toMatchObject({
+      kind: "managed-native",
+      baseUrl: "http://127.0.0.1:8080/proxy",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+  });
+
   it("rejects an explicit managed port used by its own independent local endpoint", () => {
     const cfg = {
       channels: {

--- a/extensions/signal/src/accounts.test.ts
+++ b/extensions/signal/src/accounts.test.ts
@@ -238,6 +238,31 @@ describe("resolveSignalAccount", () => {
     expect(() => resolveSignalAccount({ cfg, accountId: "work" })).toThrow(message);
   });
 
+  it("keeps colliding inferred managed native ports aligned with fallback binds", () => {
+    const cfg = {
+      channels: {
+        signal: {
+          accounts: {
+            personal: {
+              account: "+15555550123",
+              transport: { kind: "managed-native", url: "http://127.0.0.1:8181" },
+            },
+            work: {
+              account: "+15555550124",
+              transport: { kind: "managed-native", url: "http://127.0.0.1:8181" },
+            },
+          },
+        },
+      },
+    } as never;
+
+    expect(resolveSignalAccount({ cfg, accountId: "work" }).transport).toMatchObject({
+      kind: "managed-native",
+      baseUrl: "http://127.0.0.1:8080",
+      httpPort: 8080,
+    });
+  });
+
   it("rejects an explicit managed port used by its own independent local endpoint", () => {
     const cfg = {
       channels: {

--- a/extensions/signal/src/accounts.test.ts
+++ b/extensions/signal/src/accounts.test.ts
@@ -238,7 +238,7 @@ describe("resolveSignalAccount", () => {
     expect(() => resolveSignalAccount({ cfg, accountId: "work" })).toThrow(message);
   });
 
-  it("keeps colliding inferred managed native ports aligned with fallback binds", () => {
+  it("keeps colliding canonical connection endpoints independent of daemon binds", () => {
     const cfg = {
       channels: {
         signal: {
@@ -258,8 +258,8 @@ describe("resolveSignalAccount", () => {
 
     expect(resolveSignalAccount({ cfg, accountId: "work" }).transport).toMatchObject({
       kind: "managed-native",
-      baseUrl: "http://127.0.0.1:8080",
-      httpPort: 8080,
+      baseUrl: "http://127.0.0.1:8181",
+      httpPort: 8081,
     });
   });
 

--- a/extensions/signal/src/accounts.test.ts
+++ b/extensions/signal/src/accounts.test.ts
@@ -284,6 +284,26 @@ describe("resolveSignalAccount", () => {
     });
   });
 
+  it("binds an implicit managed daemon to a non-default local connection URL port", () => {
+    const cfg = {
+      channels: {
+        signal: {
+          transport: {
+            kind: "managed-native",
+            url: "http://127.0.0.1:8082",
+          },
+        },
+      },
+    } as never;
+
+    expect(resolveSignalAccount({ cfg }).transport).toMatchObject({
+      kind: "managed-native",
+      baseUrl: "http://127.0.0.1:8082",
+      httpHost: "127.0.0.1",
+      httpPort: 8082,
+    });
+  });
+
   it("preserves top-level default account when named accounts are configured", () => {
     const cfg = {
       channels: {

--- a/extensions/signal/src/accounts.ts
+++ b/extensions/signal/src/accounts.ts
@@ -15,6 +15,7 @@ import {
   assignSignalManagedNativePort,
   DEFAULT_SIGNAL_MANAGED_NATIVE_PORT,
   isSignalManagedNativeConnectionUrlForBind,
+  preferredManagedNativePortFromConnectionUrl,
   resolveLocalSignalTransportPort,
 } from "./transport-policy.js";
 import { buildSignalTransportHttpUrl } from "./transport-url.js";
@@ -177,7 +178,10 @@ function resolveSignalManagedNativePort(params: {
       } else {
         implicitManagedAccountIds.push(accountId);
       }
-      if (transport.url && !isSignalManagedNativeConnectionUrlForBind(transport)) {
+      const preferredBindPort = preferredManagedNativePortFromConnectionUrl(transport);
+      const effectiveBindTransport =
+        preferredBindPort === undefined ? transport : { ...transport, httpPort: preferredBindPort };
+      if (transport.url && !isSignalManagedNativeConnectionUrlForBind(effectiveBindTransport)) {
         const localConnectionPort = resolveLocalSignalTransportPort(transport.url);
         if (localConnectionPort !== undefined) {
           reservedPorts.add(localConnectionPort);
@@ -189,7 +193,14 @@ function resolveSignalManagedNativePort(params: {
   }
 
   for (const accountId of implicitManagedAccountIds) {
-    const port = allocateSignalManagedNativePort({ reservedPorts });
+    const accountConfig = resolveSignalAccountConfig(params.cfg, accountId);
+    const preferredPort = preferredManagedNativePortFromConnectionUrl(
+      accountConfig.transport ?? { kind: "managed-native" },
+    );
+    const port = allocateSignalManagedNativePort({
+      reservedPorts,
+      ...(preferredPort !== undefined ? { preferredPort } : {}),
+    });
     reservedPorts.add(port);
     if (normalizeAccountId(accountId) === params.accountId) {
       return port;

--- a/extensions/signal/src/accounts.ts
+++ b/extensions/signal/src/accounts.ts
@@ -15,7 +15,6 @@ import {
   assignSignalManagedNativePort,
   DEFAULT_SIGNAL_MANAGED_NATIVE_PORT,
   isSignalManagedNativeConnectionUrlForBind,
-  preferredManagedNativePortFromConnectionUrl,
   resolveLocalSignalTransportPort,
 } from "./transport-policy.js";
 import { buildSignalTransportHttpUrl } from "./transport-url.js";
@@ -178,10 +177,7 @@ function resolveSignalManagedNativePort(params: {
       } else {
         implicitManagedAccountIds.push(accountId);
       }
-      const preferredBindPort = preferredManagedNativePortFromConnectionUrl(transport);
-      const effectiveBindTransport =
-        preferredBindPort === undefined ? transport : { ...transport, httpPort: preferredBindPort };
-      if (transport.url && !isSignalManagedNativeConnectionUrlForBind(effectiveBindTransport)) {
+      if (transport.url && !isSignalManagedNativeConnectionUrlForBind(transport)) {
         const localConnectionPort = resolveLocalSignalTransportPort(transport.url);
         if (localConnectionPort !== undefined) {
           reservedPorts.add(localConnectionPort);
@@ -193,14 +189,7 @@ function resolveSignalManagedNativePort(params: {
   }
 
   for (const accountId of implicitManagedAccountIds) {
-    const accountConfig = resolveSignalAccountConfig(params.cfg, accountId);
-    const preferredPort = preferredManagedNativePortFromConnectionUrl(
-      accountConfig.transport ?? { kind: "managed-native" },
-    );
-    const port = allocateSignalManagedNativePort({
-      reservedPorts,
-      ...(preferredPort !== undefined ? { preferredPort } : {}),
-    });
+    const port = allocateSignalManagedNativePort({ reservedPorts });
     reservedPorts.add(port);
     if (normalizeAccountId(accountId) === params.accountId) {
       return port;

--- a/extensions/signal/src/config-compat-transport.ts
+++ b/extensions/signal/src/config-compat-transport.ts
@@ -1,0 +1,154 @@
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+import type { SignalTransportConfig } from "./account-types.js";
+import {
+  isValidSignalManagedNativePort,
+  preferredManagedNativePortFromConnectionUrl,
+} from "./transport-policy.js";
+import { buildSignalTransportHttpUrl, normalizeSignalTransportUrl } from "./transport-url.js";
+
+export function isSignalTransportConfig(value: unknown): value is SignalTransportConfig {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (value.kind === "managed-native") {
+    if (value.httpPort !== undefined && !isValidSignalManagedNativePort(value.httpPort)) {
+      return false;
+    }
+    if (value.url === undefined) {
+      return true;
+    }
+    if (typeof value.url !== "string") {
+      return false;
+    }
+    try {
+      normalizeSignalTransportUrl(value.url);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  if (
+    (value.kind !== "external-native" && value.kind !== "container") ||
+    typeof value.url !== "string"
+  ) {
+    return false;
+  }
+  try {
+    normalizeSignalTransportUrl(value.url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function inherited(
+  entry: Record<string, unknown>,
+  parent: Record<string, unknown>,
+  key: string,
+) {
+  return Object.hasOwn(entry, key) ? entry[key] : parent[key];
+}
+
+export function legacyBaseUrl(
+  entry: Record<string, unknown>,
+  parent: Record<string, unknown>,
+): string {
+  const url = optionalString(inherited(entry, parent, "httpUrl"));
+  if (url) {
+    return normalizeSignalTransportUrl(url);
+  }
+  const host = optionalString(inherited(entry, parent, "httpHost")) ?? "127.0.0.1";
+  const rawPort = inherited(entry, parent, "httpPort");
+  const port = typeof rawPort === "number" ? rawPort : 8080;
+  return buildSignalTransportHttpUrl(host, port);
+}
+
+export function requiresDetection(
+  entry: Record<string, unknown>,
+  parent: Record<string, unknown>,
+  apiMode: unknown,
+): boolean {
+  if (apiMode !== undefined && apiMode !== "auto") {
+    return false;
+  }
+  return (
+    Boolean(optionalString(inherited(entry, parent, "httpUrl"))) ||
+    !resolveLegacyAutoStart(entry, parent)
+  );
+}
+
+export function resolveLegacyAutoStart(
+  entry: Record<string, unknown>,
+  parent: Record<string, unknown>,
+): boolean {
+  const autoStart = inherited(entry, parent, "autoStart");
+  if (typeof autoStart === "boolean") {
+    return autoStart;
+  }
+  return !optionalString(inherited(entry, parent, "httpUrl"));
+}
+
+function resolveManagedConnectionUrl(
+  entry: Record<string, unknown>,
+  parent: Record<string, unknown>,
+): string | undefined {
+  const httpUrl = optionalString(inherited(entry, parent, "httpUrl"));
+  if (!httpUrl) {
+    return undefined;
+  }
+  const normalizedUrl = normalizeSignalTransportUrl(httpUrl);
+  const endpoint = new URL(normalizedUrl);
+  const bindHost = (optionalString(inherited(entry, parent, "httpHost")) ?? "127.0.0.1")
+    .replace(/^\[|\]$/g, "")
+    .toLowerCase();
+  const rawBindPort = inherited(entry, parent, "httpPort");
+  const bindPort = typeof rawBindPort === "number" ? rawBindPort : 8080;
+  const endpointHost = endpoint.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  const endpointPort = endpoint.port
+    ? Number.parseInt(endpoint.port, 10)
+    : endpoint.protocol === "https:"
+      ? 443
+      : 80;
+  const matchesBindEndpoint =
+    endpoint.protocol === "http:" && endpointHost === bindHost && endpointPort === bindPort;
+  return matchesBindEndpoint ? undefined : normalizedUrl;
+}
+
+export function buildManagedNativeTransport(
+  entry: Record<string, unknown>,
+  parent: Record<string, unknown>,
+): SignalTransportConfig {
+  const value = (key: string) => inherited(entry, parent, key);
+  const configPath = optionalString(value("configPath"));
+  const cliPath = optionalString(value("cliPath"));
+  const url = resolveManagedConnectionUrl(entry, parent);
+  const httpHost = optionalString(value("httpHost"));
+  const rawHttpPort = value("httpPort");
+  const inferredHttpPort =
+    typeof rawHttpPort !== "number"
+      ? preferredManagedNativePortFromConnectionUrl({
+          kind: "managed-native",
+          ...(url ? { url } : {}),
+          ...(httpHost ? { httpHost } : {}),
+        })
+      : undefined;
+  const httpPort = typeof rawHttpPort === "number" ? rawHttpPort : inferredHttpPort;
+  const startupTimeoutMs = value("startupTimeoutMs");
+  const receiveMode = value("receiveMode");
+  const ignoreStories = value("ignoreStories");
+  return {
+    kind: "managed-native",
+    ...(configPath ? { configPath } : {}),
+    ...(cliPath ? { cliPath } : {}),
+    ...(url ? { url } : {}),
+    ...(httpHost ? { httpHost } : {}),
+    ...(typeof httpPort === "number" ? { httpPort } : {}),
+    ...(typeof startupTimeoutMs === "number" ? { startupTimeoutMs } : {}),
+    ...(receiveMode === "on-start" || receiveMode === "manual" ? { receiveMode } : {}),
+    ...(typeof ignoreStories === "boolean" ? { ignoreStories } : {}),
+  };
+}

--- a/extensions/signal/src/config-compat-transport.ts
+++ b/extensions/signal/src/config-compat-transport.ts
@@ -133,16 +133,20 @@ export function buildManagedNativeTransport(
   const value = (key: string) => inherited(entry, parent, key);
   const configPath = optionalString(value("configPath"));
   const cliPath = optionalString(value("cliPath"));
+  const sourceUrl = optionalString(value("httpUrl"));
   const url = resolveManagedConnectionUrl(entry, parent);
   const httpHost = optionalString(value("httpHost"));
   const rawHttpPort = value("httpPort");
   const inferredHttpPort =
     typeof rawHttpPort !== "number"
-      ? inferLegacyManagedNativePortFromConnectionUrl({
-          kind: "managed-native",
-          ...(url ? { url } : {}),
-          ...(httpHost ? { httpHost } : {}),
-        })
+      ? inferLegacyManagedNativePortFromConnectionUrl(
+          {
+            kind: "managed-native",
+            ...(url ? { url } : {}),
+            ...(httpHost ? { httpHost } : {}),
+          },
+          sourceUrl,
+        )
       : undefined;
   const httpPort = typeof rawHttpPort === "number" ? rawHttpPort : inferredHttpPort;
   const startupTimeoutMs = value("startupTimeoutMs");

--- a/extensions/signal/src/config-compat-transport.ts
+++ b/extensions/signal/src/config-compat-transport.ts
@@ -114,11 +114,16 @@ function resolveManagedConnectionUrl(
       ? 443
       : 80;
   const matchesBindEndpoint =
-    endpoint.pathname === "/" &&
-    endpoint.protocol === "http:" &&
-    endpointHost === bindHost &&
-    endpointPort === bindPort;
-  return matchesBindEndpoint ? undefined : normalizedUrl;
+    endpoint.protocol === "http:" && endpointHost === bindHost && endpointPort === bindPort;
+  // An explicit legacy httpPort owns the daemon bind, even when httpUrl carries a proxy path.
+  // Drop the same-port URL during migration so account resolution does not reject a self-collision.
+  if (matchesBindEndpoint && rawBindPort !== undefined) {
+    return undefined;
+  }
+  if (matchesBindEndpoint && endpoint.pathname === "/") {
+    return undefined;
+  }
+  return normalizedUrl;
 }
 
 export function buildManagedNativeTransport(

--- a/extensions/signal/src/config-compat-transport.ts
+++ b/extensions/signal/src/config-compat-transport.ts
@@ -2,7 +2,7 @@ import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { SignalTransportConfig } from "./account-types.js";
 import {
   isValidSignalManagedNativePort,
-  preferredManagedNativePortFromConnectionUrl,
+  inferLegacyManagedNativePortFromConnectionUrl,
 } from "./transport-policy.js";
 import { buildSignalTransportHttpUrl, normalizeSignalTransportUrl } from "./transport-url.js";
 
@@ -130,7 +130,7 @@ export function buildManagedNativeTransport(
   const rawHttpPort = value("httpPort");
   const inferredHttpPort =
     typeof rawHttpPort !== "number"
-      ? preferredManagedNativePortFromConnectionUrl({
+      ? inferLegacyManagedNativePortFromConnectionUrl({
           kind: "managed-native",
           ...(url ? { url } : {}),
           ...(httpHost ? { httpHost } : {}),

--- a/extensions/signal/src/config-compat-transport.ts
+++ b/extensions/signal/src/config-compat-transport.ts
@@ -114,7 +114,10 @@ function resolveManagedConnectionUrl(
       ? 443
       : 80;
   const matchesBindEndpoint =
-    endpoint.protocol === "http:" && endpointHost === bindHost && endpointPort === bindPort;
+    endpoint.pathname === "/" &&
+    endpoint.protocol === "http:" &&
+    endpointHost === bindHost &&
+    endpointPort === bindPort;
   return matchesBindEndpoint ? undefined : normalizedUrl;
 }
 

--- a/extensions/signal/src/config-compat.ts
+++ b/extensions/signal/src/config-compat.ts
@@ -348,7 +348,7 @@ function allocateMigratedManagedPorts(params: {
       ...(typeof preferredPort === "number" ? { preferredPort } : {}),
     });
     reservedPorts.add(httpPort);
-    return assignSignalManagedNativePort(transport, httpPort);
+    return assignSignalManagedNativePort(transport, httpPort, { preservePathUrl: true });
   });
 }
 

--- a/extensions/signal/src/config-compat.ts
+++ b/extensions/signal/src/config-compat.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_SIGNAL_MANAGED_NATIVE_PORT,
   isSignalManagedNativeConnectionUrlForBind,
   isValidSignalManagedNativePort,
+  preferredManagedNativePortFromConnectionUrl,
   resolveLocalSignalTransportPort,
 } from "./transport-policy.js";
 import { buildSignalTransportHttpUrl, normalizeSignalTransportUrl } from "./transport-url.js";
@@ -226,7 +227,16 @@ function buildManagedNativeTransport(
   const cliPath = optionalString(value("cliPath"));
   const url = resolveManagedConnectionUrl(entry, parent);
   const httpHost = optionalString(value("httpHost"));
-  const httpPort = value("httpPort");
+  const rawHttpPort = value("httpPort");
+  const inferredHttpPort =
+    typeof rawHttpPort !== "number"
+      ? preferredManagedNativePortFromConnectionUrl({
+          kind: "managed-native",
+          ...(url ? { url } : {}),
+          ...(httpHost ? { httpHost } : {}),
+        })
+      : undefined;
+  const httpPort = typeof rawHttpPort === "number" ? rawHttpPort : inferredHttpPort;
   const startupTimeoutMs = value("startupTimeoutMs");
   const receiveMode = value("receiveMode");
   const ignoreStories = value("ignoreStories");

--- a/extensions/signal/src/config-compat.ts
+++ b/extensions/signal/src/config-compat.ts
@@ -5,12 +5,20 @@ import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { SignalTransportConfig } from "./account-types.js";
 import {
+  buildManagedNativeTransport,
+  inherited,
+  isSignalTransportConfig,
+  legacyBaseUrl,
+  optionalString,
+  requiresDetection,
+  resolveLegacyAutoStart,
+} from "./config-compat-transport.js";
+import {
   allocateSignalManagedNativePort,
   assignSignalManagedNativePort,
   DEFAULT_SIGNAL_MANAGED_NATIVE_PORT,
   isSignalManagedNativeConnectionUrlForBind,
   isValidSignalManagedNativePort,
-  preferredManagedNativePortFromConnectionUrl,
   resolveLocalSignalTransportPort,
 } from "./transport-policy.js";
 import { buildSignalTransportHttpUrl, normalizeSignalTransportUrl } from "./transport-url.js";
@@ -42,60 +50,6 @@ type DetectTransport = (params: {
   url: string;
   account?: string;
 }) => Promise<SignalTransportConfig>;
-
-function isSignalTransportConfig(value: unknown): value is SignalTransportConfig {
-  if (!isRecord(value)) {
-    return false;
-  }
-  if (value.kind === "managed-native") {
-    if (value.httpPort !== undefined && !isValidSignalManagedNativePort(value.httpPort)) {
-      return false;
-    }
-    if (value.url === undefined) {
-      return true;
-    }
-    if (typeof value.url !== "string") {
-      return false;
-    }
-    try {
-      normalizeSignalTransportUrl(value.url);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-  if (
-    (value.kind !== "external-native" && value.kind !== "container") ||
-    typeof value.url !== "string"
-  ) {
-    return false;
-  }
-  try {
-    normalizeSignalTransportUrl(value.url);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function optionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function inherited(entry: Record<string, unknown>, parent: Record<string, unknown>, key: string) {
-  return Object.hasOwn(entry, key) ? entry[key] : parent[key];
-}
-
-function legacyBaseUrl(entry: Record<string, unknown>, parent: Record<string, unknown>): string {
-  const url = optionalString(inherited(entry, parent, "httpUrl"));
-  if (url) {
-    return normalizeSignalTransportUrl(url);
-  }
-  const host = optionalString(inherited(entry, parent, "httpHost")) ?? "127.0.0.1";
-  const rawPort = inherited(entry, parent, "httpPort");
-  const port = typeof rawPort === "number" ? rawPort : 8080;
-  return buildSignalTransportHttpUrl(host, port);
-}
 
 function hasLegacyFields(entry: Record<string, unknown>): boolean {
   return LEGACY_TRANSPORT_FIELDS.some((field) => Object.hasOwn(entry, field));
@@ -165,92 +119,6 @@ function hasInvalidManagedTransportPort(
       transport.httpPort !== undefined &&
       !isValidSignalManagedNativePort(transport.httpPort),
   );
-}
-
-function requiresDetection(
-  entry: Record<string, unknown>,
-  parent: Record<string, unknown>,
-  apiMode: unknown,
-): boolean {
-  if (apiMode !== undefined && apiMode !== "auto") {
-    return false;
-  }
-  return (
-    Boolean(optionalString(inherited(entry, parent, "httpUrl"))) ||
-    !resolveLegacyAutoStart(entry, parent)
-  );
-}
-
-function resolveLegacyAutoStart(
-  entry: Record<string, unknown>,
-  parent: Record<string, unknown>,
-): boolean {
-  const autoStart = inherited(entry, parent, "autoStart");
-  if (typeof autoStart === "boolean") {
-    return autoStart;
-  }
-  return !optionalString(inherited(entry, parent, "httpUrl"));
-}
-
-function resolveManagedConnectionUrl(
-  entry: Record<string, unknown>,
-  parent: Record<string, unknown>,
-): string | undefined {
-  const httpUrl = optionalString(inherited(entry, parent, "httpUrl"));
-  if (!httpUrl) {
-    return undefined;
-  }
-  const normalizedUrl = normalizeSignalTransportUrl(httpUrl);
-  const endpoint = new URL(normalizedUrl);
-  const bindHost = (optionalString(inherited(entry, parent, "httpHost")) ?? "127.0.0.1")
-    .replace(/^\[|\]$/g, "")
-    .toLowerCase();
-  const rawBindPort = inherited(entry, parent, "httpPort");
-  const bindPort = typeof rawBindPort === "number" ? rawBindPort : 8080;
-  const endpointHost = endpoint.hostname.replace(/^\[|\]$/g, "").toLowerCase();
-  const endpointPort = endpoint.port
-    ? Number.parseInt(endpoint.port, 10)
-    : endpoint.protocol === "https:"
-      ? 443
-      : 80;
-  const matchesBindEndpoint =
-    endpoint.protocol === "http:" && endpointHost === bindHost && endpointPort === bindPort;
-  return matchesBindEndpoint ? undefined : normalizedUrl;
-}
-
-function buildManagedNativeTransport(
-  entry: Record<string, unknown>,
-  parent: Record<string, unknown>,
-): SignalTransportConfig {
-  const value = (key: string) => inherited(entry, parent, key);
-  const configPath = optionalString(value("configPath"));
-  const cliPath = optionalString(value("cliPath"));
-  const url = resolveManagedConnectionUrl(entry, parent);
-  const httpHost = optionalString(value("httpHost"));
-  const rawHttpPort = value("httpPort");
-  const inferredHttpPort =
-    typeof rawHttpPort !== "number"
-      ? preferredManagedNativePortFromConnectionUrl({
-          kind: "managed-native",
-          ...(url ? { url } : {}),
-          ...(httpHost ? { httpHost } : {}),
-        })
-      : undefined;
-  const httpPort = typeof rawHttpPort === "number" ? rawHttpPort : inferredHttpPort;
-  const startupTimeoutMs = value("startupTimeoutMs");
-  const receiveMode = value("receiveMode");
-  const ignoreStories = value("ignoreStories");
-  return {
-    kind: "managed-native",
-    ...(configPath ? { configPath } : {}),
-    ...(cliPath ? { cliPath } : {}),
-    ...(url ? { url } : {}),
-    ...(httpHost ? { httpHost } : {}),
-    ...(typeof httpPort === "number" ? { httpPort } : {}),
-    ...(typeof startupTimeoutMs === "number" ? { startupTimeoutMs } : {}),
-    ...(receiveMode === "on-start" || receiveMode === "manual" ? { receiveMode } : {}),
-    ...(typeof ignoreStories === "boolean" ? { ignoreStories } : {}),
-  };
 }
 
 function resolveLegacyTransportWithoutDetection(params: {

--- a/extensions/signal/src/transport-policy.test.ts
+++ b/extensions/signal/src/transport-policy.test.ts
@@ -3,7 +3,10 @@
 // sockets whose URLs must survive bind-port reassignment untouched.
 import { describe, expect, it } from "vitest";
 import type { SignalTransportConfig } from "./account-types.js";
-import { assignSignalManagedNativePort } from "./transport-policy.js";
+import {
+  assignSignalManagedNativePort,
+  preferredManagedNativePortFromConnectionUrl,
+} from "./transport-policy.js";
 
 type SignalManagedNativeTransport = Extract<SignalTransportConfig, { kind: "managed-native" }>;
 
@@ -15,6 +18,37 @@ function managedTransport(url: string, httpHost?: string): SignalManagedNativeTr
     httpPort: 8080,
   };
 }
+
+describe("preferredManagedNativePortFromConnectionUrl", () => {
+  it("prefers a local connection URL port when httpPort is omitted", () => {
+    expect(
+      preferredManagedNativePortFromConnectionUrl({
+        kind: "managed-native",
+        url: "http://127.0.0.1:8082",
+      }),
+    ).toBe(8082);
+  });
+
+  it("does not override an explicit managed port", () => {
+    expect(
+      preferredManagedNativePortFromConnectionUrl({
+        kind: "managed-native",
+        url: "http://127.0.0.1:8082",
+        httpPort: 9090,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not infer from a connection URL on a different bind host", () => {
+    expect(
+      preferredManagedNativePortFromConnectionUrl({
+        kind: "managed-native",
+        url: "http://127.0.0.1:8080",
+        httpHost: "127.0.0.2",
+      }),
+    ).toBeUndefined();
+  });
+});
 
 describe("assignSignalManagedNativePort", () => {
   it("rewrites a localhost connection URL aligned with a loopback bind", () => {

--- a/extensions/signal/src/transport-policy.test.ts
+++ b/extensions/signal/src/transport-policy.test.ts
@@ -87,9 +87,18 @@ describe("assignSignalManagedNativePort", () => {
     expect(next.httpPort).toBe(8080);
   });
 
-  it("keeps a path-prefixed proxy URL independent on bind-port changes", () => {
+  it("rewrites an explicit canonical path endpoint with its daemon bind", () => {
     const next = assignSignalManagedNativePort(
       managedTransport("http://127.0.0.1:8080/signal", "127.0.0.1"),
+      9090,
+    );
+    expect(next.url).toBe("http://127.0.0.1:9090/signal");
+    expect(next.httpPort).toBe(9090);
+  });
+
+  it("keeps a legacy path-prefixed proxy URL independent", () => {
+    const next = assignSignalManagedNativePort(
+      { kind: "managed-native", url: "http://127.0.0.1:8080/signal" },
       9090,
     );
     expect(next.url).toBe("http://127.0.0.1:8080/signal");

--- a/extensions/signal/src/transport-policy.test.ts
+++ b/extensions/signal/src/transport-policy.test.ts
@@ -38,6 +38,15 @@ describe("inferLegacyManagedNativePortFromConnectionUrl", () => {
     ).toBe(80);
   });
 
+  it("infers an explicit port from a bare legacy host URL", () => {
+    expect(
+      inferLegacyManagedNativePortFromConnectionUrl(
+        { kind: "managed-native", url: "http://127.0.0.1:8082" },
+        "127.0.0.1:8082",
+      ),
+    ).toBe(8082);
+  });
+
   it("keeps the managed default for an unported local URL", () => {
     expect(
       inferLegacyManagedNativePortFromConnectionUrl({

--- a/extensions/signal/src/transport-policy.test.ts
+++ b/extensions/signal/src/transport-policy.test.ts
@@ -29,6 +29,15 @@ describe("inferLegacyManagedNativePortFromConnectionUrl", () => {
     ).toBe(8082);
   });
 
+  it("keeps the managed default for an unported local URL", () => {
+    expect(
+      inferLegacyManagedNativePortFromConnectionUrl({
+        kind: "managed-native",
+        url: "http://127.0.0.1",
+      }),
+    ).toBeUndefined();
+  });
+
   it("does not override an explicit managed port", () => {
     expect(
       inferLegacyManagedNativePortFromConnectionUrl({

--- a/extensions/signal/src/transport-policy.test.ts
+++ b/extensions/signal/src/transport-policy.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import type { SignalTransportConfig } from "./account-types.js";
 import {
   assignSignalManagedNativePort,
-  preferredManagedNativePortFromConnectionUrl,
+  inferLegacyManagedNativePortFromConnectionUrl,
 } from "./transport-policy.js";
 
 type SignalManagedNativeTransport = Extract<SignalTransportConfig, { kind: "managed-native" }>;
@@ -19,10 +19,10 @@ function managedTransport(url: string, httpHost?: string): SignalManagedNativeTr
   };
 }
 
-describe("preferredManagedNativePortFromConnectionUrl", () => {
+describe("inferLegacyManagedNativePortFromConnectionUrl", () => {
   it("prefers a local connection URL port when httpPort is omitted", () => {
     expect(
-      preferredManagedNativePortFromConnectionUrl({
+      inferLegacyManagedNativePortFromConnectionUrl({
         kind: "managed-native",
         url: "http://127.0.0.1:8082",
       }),
@@ -31,7 +31,7 @@ describe("preferredManagedNativePortFromConnectionUrl", () => {
 
   it("does not override an explicit managed port", () => {
     expect(
-      preferredManagedNativePortFromConnectionUrl({
+      inferLegacyManagedNativePortFromConnectionUrl({
         kind: "managed-native",
         url: "http://127.0.0.1:8082",
         httpPort: 9090,
@@ -41,7 +41,7 @@ describe("preferredManagedNativePortFromConnectionUrl", () => {
 
   it("does not infer from a connection URL on a different bind host", () => {
     expect(
-      preferredManagedNativePortFromConnectionUrl({
+      inferLegacyManagedNativePortFromConnectionUrl({
         kind: "managed-native",
         url: "http://127.0.0.1:8080",
         httpHost: "127.0.0.2",
@@ -67,5 +67,14 @@ describe("assignSignalManagedNativePort", () => {
     );
     expect(next.url).toBe("http://[::1]:8080");
     expect(next.httpPort).toBe(9090);
+  });
+
+  it("keeps an omitted-port canonical connection URL independent", () => {
+    const next = assignSignalManagedNativePort(
+      { kind: "managed-native", url: "http://127.0.0.1:8082" },
+      8080,
+    );
+    expect(next.url).toBe("http://127.0.0.1:8082");
+    expect(next.httpPort).toBe(8080);
   });
 });

--- a/extensions/signal/src/transport-policy.test.ts
+++ b/extensions/signal/src/transport-policy.test.ts
@@ -127,6 +127,7 @@ describe("assignSignalManagedNativePort", () => {
     const next = assignSignalManagedNativePort(
       { kind: "managed-native", url: "http://127.0.0.1:8080/signal" },
       9090,
+      { preservePathUrl: true },
     );
     expect(next.url).toBe("http://127.0.0.1:8080/signal");
     expect(next.httpPort).toBe(9090);

--- a/extensions/signal/src/transport-policy.test.ts
+++ b/extensions/signal/src/transport-policy.test.ts
@@ -48,6 +48,15 @@ describe("inferLegacyManagedNativePortFromConnectionUrl", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("does not infer a daemon bind from a path-prefixed proxy URL", () => {
+    expect(
+      inferLegacyManagedNativePortFromConnectionUrl({
+        kind: "managed-native",
+        url: "http://127.0.0.1:8082/signal",
+      }),
+    ).toBeUndefined();
+  });
 });
 
 describe("assignSignalManagedNativePort", () => {
@@ -76,5 +85,14 @@ describe("assignSignalManagedNativePort", () => {
     );
     expect(next.url).toBe("http://127.0.0.1:8082");
     expect(next.httpPort).toBe(8080);
+  });
+
+  it("keeps a path-prefixed proxy URL independent on bind-port changes", () => {
+    const next = assignSignalManagedNativePort(
+      managedTransport("http://127.0.0.1:8080/signal", "127.0.0.1"),
+      9090,
+    );
+    expect(next.url).toBe("http://127.0.0.1:8080/signal");
+    expect(next.httpPort).toBe(9090);
   });
 });

--- a/extensions/signal/src/transport-policy.test.ts
+++ b/extensions/signal/src/transport-policy.test.ts
@@ -29,6 +29,15 @@ describe("inferLegacyManagedNativePortFromConnectionUrl", () => {
     ).toBe(8082);
   });
 
+  it("preserves an explicit default port from the raw legacy URL", () => {
+    expect(
+      inferLegacyManagedNativePortFromConnectionUrl(
+        { kind: "managed-native", url: "http://127.0.0.1" },
+        "http://127.0.0.1:80",
+      ),
+    ).toBe(80);
+  });
+
   it("keeps the managed default for an unported local URL", () => {
     expect(
       inferLegacyManagedNativePortFromConnectionUrl({

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -128,7 +128,12 @@ export function assignSignalManagedNativePort(
     throw new Error("Signal managed native port must be an integer between 1 and 65535.");
   }
   const connectionUrlValue = transport.url;
-  if (!connectionUrlValue || !isSignalManagedNativeConnectionUrlForBind(transport)) {
+  const preferredBindPort = preferredManagedNativePortFromConnectionUrl(transport);
+  const bindTransport =
+    transport.httpPort === undefined && preferredBindPort !== undefined
+      ? { ...transport, httpPort: preferredBindPort }
+      : transport;
+  if (!connectionUrlValue || !isSignalManagedNativeConnectionUrlForBind(bindTransport)) {
     return { ...transport, httpPort };
   }
   const connectionUrl = new URL(connectionUrlValue);

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -75,11 +75,27 @@ export function inferLegacyManagedNativePortFromConnectionUrl(
   if (transport.kind !== "managed-native" || transport.httpPort !== undefined || !transport.url) {
     return undefined;
   }
+  let connectionUrl: URL;
+  try {
+    connectionUrl = new URL(transport.url);
+  } catch {
+    return undefined;
+  }
+  const authority = transport.url.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]*)/i)?.[1];
+  const hostPort = authority?.slice(authority.lastIndexOf("@") + 1);
+  const hasExplicitPort = hostPort
+    ? hostPort.startsWith("[")
+      ? /^\[[^\]]+\]:\d+$/.test(hostPort)
+      : /:\d+$/.test(hostPort)
+    : false;
+  if (!hasExplicitPort) {
+    return undefined;
+  }
   const localPort = resolveLocalSignalTransportPort(transport.url);
   if (localPort === undefined || !isValidSignalManagedNativePort(localPort)) {
     return undefined;
   }
-  if (new URL(transport.url).pathname !== "/") {
+  if (connectionUrl.pathname !== "/") {
     return undefined;
   }
   const candidate: SignalManagedNativeTransport = { ...transport, httpPort: localPort };

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -67,6 +67,20 @@ export function resolveLocalSignalTransportPort(baseUrl: string): number | undef
   }
 }
 
+export function preferredManagedNativePortFromConnectionUrl(
+  transport: SignalTransportConfig,
+): number | undefined {
+  if (transport.kind !== "managed-native" || transport.httpPort !== undefined || !transport.url) {
+    return undefined;
+  }
+  const localPort = resolveLocalSignalTransportPort(transport.url);
+  if (localPort === undefined || !isValidSignalManagedNativePort(localPort)) {
+    return undefined;
+  }
+  const candidate: SignalManagedNativeTransport = { ...transport, httpPort: localPort };
+  return isSignalManagedNativeConnectionUrlForBind(candidate) ? localPort : undefined;
+}
+
 export function isSignalManagedNativeConnectionUrlForBind(
   transport: SignalTransportConfig,
 ): boolean {

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -78,11 +78,14 @@ export function inferLegacyManagedNativePortFromConnectionUrl(
   }
   let connectionUrl: URL;
   try {
-    connectionUrl = new URL(sourceUrl);
+    connectionUrl = new URL(normalizeSignalTransportUrl(sourceUrl));
   } catch {
     return undefined;
   }
-  const authority = sourceUrl.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]*)/i)?.[1];
+  const sourceUrlWithScheme = /^[a-z][a-z\d+.-]*:\/\//i.test(sourceUrl)
+    ? sourceUrl
+    : `http://${sourceUrl}`;
+  const authority = sourceUrlWithScheme.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]*)/i)?.[1];
   const hostPort = authority?.slice(authority.lastIndexOf("@") + 1);
   const hasExplicitPort = hostPort
     ? hostPort.startsWith("[")
@@ -92,7 +95,7 @@ export function inferLegacyManagedNativePortFromConnectionUrl(
   if (!hasExplicitPort) {
     return undefined;
   }
-  const localPort = resolveLocalSignalTransportPort(sourceUrl);
+  const localPort = resolveLocalSignalTransportPort(normalizeSignalTransportUrl(sourceUrl));
   if (localPort === undefined || !isValidSignalManagedNativePort(localPort)) {
     return undefined;
   }

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -71,17 +71,18 @@ export function resolveLocalSignalTransportPort(baseUrl: string): number | undef
 // Canonical transport.url may intentionally point at a distinct connection endpoint.
 export function inferLegacyManagedNativePortFromConnectionUrl(
   transport: SignalTransportConfig,
+  sourceUrl = transport.url,
 ): number | undefined {
-  if (transport.kind !== "managed-native" || transport.httpPort !== undefined || !transport.url) {
+  if (transport.kind !== "managed-native" || transport.httpPort !== undefined || !sourceUrl) {
     return undefined;
   }
   let connectionUrl: URL;
   try {
-    connectionUrl = new URL(transport.url);
+    connectionUrl = new URL(sourceUrl);
   } catch {
     return undefined;
   }
-  const authority = transport.url.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]*)/i)?.[1];
+  const authority = sourceUrl.match(/^[a-z][a-z\d+.-]*:\/\/([^/?#]*)/i)?.[1];
   const hostPort = authority?.slice(authority.lastIndexOf("@") + 1);
   const hasExplicitPort = hostPort
     ? hostPort.startsWith("[")
@@ -91,7 +92,7 @@ export function inferLegacyManagedNativePortFromConnectionUrl(
   if (!hasExplicitPort) {
     return undefined;
   }
-  const localPort = resolveLocalSignalTransportPort(transport.url);
+  const localPort = resolveLocalSignalTransportPort(sourceUrl);
   if (localPort === undefined || !isValidSignalManagedNativePort(localPort)) {
     return undefined;
   }

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -79,6 +79,9 @@ export function inferLegacyManagedNativePortFromConnectionUrl(
   if (localPort === undefined || !isValidSignalManagedNativePort(localPort)) {
     return undefined;
   }
+  if (new URL(transport.url).pathname !== "/") {
+    return undefined;
+  }
   const candidate: SignalManagedNativeTransport = { ...transport, httpPort: localPort };
   return isSignalManagedNativeConnectionUrlForBind(candidate) ? localPort : undefined;
 }
@@ -90,9 +93,9 @@ export function isSignalManagedNativeConnectionUrlForBind(
     return false;
   }
   const connectionUrl = new URL(transport.url);
-  // A path-prefixed URL addresses a local proxy, not signal-cli's root daemon endpoint.
-  // Keep it independent so bind-port allocation never rewrites the proxy URL.
-  if (connectionUrl.pathname !== "/") {
+  // Legacy path-prefixed URLs have no bind port to align; preserve them as independent proxies.
+  // Canonical transports with an explicit port retain endpoint-to-bind alignment semantics.
+  if (connectionUrl.pathname !== "/" && transport.httpPort === undefined) {
     return false;
   }
   // signal-cli's daemon bind is plain HTTP. A local HTTPS URL is an independent proxy endpoint,

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -90,6 +90,11 @@ export function isSignalManagedNativeConnectionUrlForBind(
     return false;
   }
   const connectionUrl = new URL(transport.url);
+  // A path-prefixed URL addresses a local proxy, not signal-cli's root daemon endpoint.
+  // Keep it independent so bind-port allocation never rewrites the proxy URL.
+  if (connectionUrl.pathname !== "/") {
+    return false;
+  }
   // signal-cli's daemon bind is plain HTTP. A local HTTPS URL is an independent proxy endpoint,
   // even when its host and port happen to match the configured daemon bind.
   if (connectionUrl.protocol !== "http:") {

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -113,11 +113,6 @@ export function isSignalManagedNativeConnectionUrlForBind(
     return false;
   }
   const connectionUrl = new URL(transport.url);
-  // Legacy path-prefixed URLs have no bind port to align; preserve them as independent proxies.
-  // Canonical transports with an explicit port retain endpoint-to-bind alignment semantics.
-  if (connectionUrl.pathname !== "/" && transport.httpPort === undefined) {
-    return false;
-  }
   // signal-cli's daemon bind is plain HTTP. A local HTTPS URL is an independent proxy endpoint,
   // even when its host and port happen to match the configured daemon bind.
   if (connectionUrl.protocol !== "http:") {
@@ -153,12 +148,17 @@ export function isSignalManagedNativeConnectionUrlForBind(
 export function assignSignalManagedNativePort(
   transport: SignalManagedNativeTransport,
   httpPort: number,
+  options: { preservePathUrl?: boolean } = {},
 ): SignalManagedNativeTransport {
   if (!isValidSignalManagedNativePort(httpPort)) {
     throw new Error("Signal managed native port must be an integer between 1 and 65535.");
   }
   const connectionUrlValue = transport.url;
-  if (!connectionUrlValue || !isSignalManagedNativeConnectionUrlForBind(transport)) {
+  if (
+    !connectionUrlValue ||
+    (options.preservePathUrl && new URL(connectionUrlValue).pathname !== "/") ||
+    !isSignalManagedNativeConnectionUrlForBind(transport)
+  ) {
     return { ...transport, httpPort };
   }
   const connectionUrl = new URL(connectionUrlValue);

--- a/extensions/signal/src/transport-policy.ts
+++ b/extensions/signal/src/transport-policy.ts
@@ -67,7 +67,9 @@ export function resolveLocalSignalTransportPort(baseUrl: string): number | undef
   }
 }
 
-export function preferredManagedNativePortFromConnectionUrl(
+// Legacy flat config is the only path allowed to infer a daemon bind from its URL.
+// Canonical transport.url may intentionally point at a distinct connection endpoint.
+export function inferLegacyManagedNativePortFromConnectionUrl(
   transport: SignalTransportConfig,
 ): number | undefined {
   if (transport.kind !== "managed-native" || transport.httpPort !== undefined || !transport.url) {
@@ -128,12 +130,7 @@ export function assignSignalManagedNativePort(
     throw new Error("Signal managed native port must be an integer between 1 and 65535.");
   }
   const connectionUrlValue = transport.url;
-  const preferredBindPort = preferredManagedNativePortFromConnectionUrl(transport);
-  const bindTransport =
-    transport.httpPort === undefined && preferredBindPort !== undefined
-      ? { ...transport, httpPort: preferredBindPort }
-      : transport;
-  if (!connectionUrlValue || !isSignalManagedNativeConnectionUrlForBind(bindTransport)) {
+  if (!connectionUrlValue || !isSignalManagedNativeConnectionUrlForBind(transport)) {
     return { ...transport, httpPort };
   }
   const connectionUrl = new URL(connectionUrlValue);


### PR DESCRIPTION
Closes #116165

## What Problem This Solves

Fixes Signal managed-native auto-start when a legacy flat configuration uses a local non-default `httpUrl` without `httpPort`.

## Why This Change Was Made

Legacy migration may infer a managed daemon bind port only from a root-path, bind-aligned loopback URL. Path-prefixed URLs remain independent connection endpoints for local proxies.

## User Impact

Legacy Signal auto-start configurations retain their intended local port while path-prefixed proxy endpoints are not claimed by the managed daemon. Canonical managed-native configurations can continue to use a separate connection URL.

## Evidence

Current head: `fb5d319f0db0a6451874f4e5b6427e63ffba0a8c`

Current-head managed startup proof output:

```json
{"migratedHttpPort":8082,"resolvedHttpPort":8082,"daemonArgsObserved":true,"readiness":{"ok":true,"status":"managed-signal-startup-ready","port":8082}}
```

This exercises legacy migration, the real Signal account resolver, and the managed daemon startup seam. The resolved legacy bind is passed as port 8082 and becomes ready on the local loopback endpoint.
Explicit default-port migration and resolver output:

```json
{"legacyUrl":"http://127.0.0.1:80","normalizedUrl":"http://127.0.0.1","migratedHttpPort":80,"resolvedHttpPort":80,"resolvedBaseUrl":"http://127.0.0.1"}
```
Bare legacy host:port migration and resolver output:

```json
{"legacyUrl":"127.0.0.1:8082","normalizedUrl":"http://127.0.0.1:8082","migratedHttpPort":8082,"resolvedHttpPort":8082,"resolvedBaseUrl":"http://127.0.0.1:8082"}
```
Canonical path endpoint alignment output:

```json
{"canonicalUrl":"http://127.0.0.1:8080/proxy","resolvedBaseUrl":"http://127.0.0.1:8080/proxy","resolvedHttpPort":8080}
```
Proof boundary: local Signal transport-policy and compatibility paths only; no live Signal account, external provider, or message delivery is claimed. A path-prefixed URL is not inferred as a daemon bind and is preserved when the bind port changes. It does not send messages to a live Signal account or claim live Signal service coverage.

Supporting checks at the current head:

- Focused Signal tests passed: 3 files, 87 tests, including explicit :80 migration and resolver coverage.
- `node --import tsx` current-head control output passed.
- `oxfmt --check` passed for the touched Signal files.
- `git diff --check` passed.
- TruffleHog scan was clean; no verified or unverified secrets in the touched files.

## Scope

- Legacy inference remains in Signal compatibility migration.
- Canonical transport endpoint and daemon bind remain separate unless the canonical configuration explicitly aligns them.
- No public config keys, protocol fields, or live-provider behavior were added.