### PR TITLE
fix(talk): prevent unbounded realtime consult backlog

### DIFF
--- a/src/talk/agent-talkback-runtime.test.ts
+++ b/src/talk/agent-talkback-runtime.test.ts
@@ -163,6 +163,92 @@ describe("realtime voice agent talkback queue", () => {
     expect(deliver).toHaveBeenCalledWith("guest-answer");
   });
 
+  it("bounds merged pending question text while a consult is active", async () => {
+    vi.useFakeTimers();
+    const logger = makeLogger();
+    let finishFirst: ((value: { text: string }) => void) | undefined;
+    const consult = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ text: string }>((resolve) => {
+            finishFirst = resolve;
+          }),
+      )
+      .mockResolvedValue({ text: "queued-answer" });
+    const queue = createRealtimeVoiceAgentTalkbackQueue({
+      debounceMs: 1,
+      isStopped: () => false,
+      logger,
+      logPrefix: "[test]",
+      responseStyle: "brief",
+      fallbackText: "fallback",
+      consult,
+      deliver: vi.fn(),
+    });
+
+    queue.enqueue("first");
+    await vi.advanceTimersByTimeAsync(1);
+    const fragment = "x".repeat(4096);
+    for (let index = 0; index < 10; index += 1) {
+      queue.enqueue(fragment);
+    }
+    finishFirst?.({ text: "first-answer" });
+    await vi.runAllTimersAsync();
+
+    expectConsultCall(consult, 1, {
+      metadata: undefined,
+      question: Array.from({ length: 7 }, () => fragment).join("\n"),
+      responseStyle: "brief",
+    });
+    expect(consult).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+      "[test] consult queue full: droppedChars=4096 queued=1 queuedChars=28678",
+    );
+  });
+
+  it("bounds pending question count while preserving retained order", async () => {
+    vi.useFakeTimers();
+    const logger = makeLogger();
+    let finishFirst: ((value: { text: string }) => void) | undefined;
+    const consult = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ text: string }>((resolve) => {
+            finishFirst = resolve;
+          }),
+      )
+      .mockResolvedValue({ text: "queued-answer" });
+    const queue = createRealtimeVoiceAgentTalkbackQueue({
+      debounceMs: 1,
+      isStopped: () => false,
+      logger,
+      logPrefix: "[test]",
+      responseStyle: "brief",
+      fallbackText: "fallback",
+      consult,
+      deliver: vi.fn(),
+    });
+
+    queue.enqueue("first");
+    await vi.advanceTimersByTimeAsync(1);
+    const metadata = Array.from({ length: 40 }, (_, index) => ({ index }));
+    metadata.forEach((entry, index) => queue.enqueue(`question-${index}`, entry));
+    finishFirst?.({ text: "first-answer" });
+    await vi.runAllTimersAsync();
+
+    expect(consult).toHaveBeenCalledTimes(33);
+    expect(
+      consult.mock.calls.slice(1).map(([request]) => {
+        return (request as { metadata?: unknown }).metadata;
+      }),
+    ).toStrictEqual(metadata.slice(0, 32));
+    expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+      "[test] consult queue full: droppedChars=11 queued=32 queuedChars=342",
+    );
+  });
+
   it("delivers fallback text when consult fails", async () => {
     vi.useFakeTimers();
     const logger = makeLogger();
@@ -238,12 +324,15 @@ describe("realtime voice agent talkback queue", () => {
     queue.enqueue("question");
     await vi.advanceTimersByTimeAsync(1);
     queue.close();
+    queue.close();
+    queue.enqueue("late question");
     await vi.runAllTimersAsync();
 
     if (!signal) {
       throw new Error("Expected talkback consult abort signal");
     }
     expect(signal.aborted).toBe(true);
+    expect(consult).toHaveBeenCalledOnce();
     expect(deliver).not.toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();
   });

--- a/src/talk/agent-talkback-runtime.ts
+++ b/src/talk/agent-talkback-runtime.ts
@@ -175,12 +175,12 @@ export function createRealtimeVoiceAgentTalkbackQueue(
       active = false;
       if (shouldStop()) {
         clearPendingQuestions();
-        return;
-      }
-      const queuedQuestion = shiftPendingQuestion();
-      if (queuedQuestion) {
-        // Continue draining any questions queued while the active consult ran.
-        void run(queuedQuestion);
+      } else {
+        const queuedQuestion = shiftPendingQuestion();
+        if (queuedQuestion) {
+          // Continue draining any questions queued while the active consult ran.
+          void run(queuedQuestion);
+        }
       }
     }
   };

--- a/src/talk/agent-talkback-runtime.ts
+++ b/src/talk/agent-talkback-runtime.ts
@@ -7,6 +7,9 @@
  */
 import type { RuntimeLogger } from "../plugins/runtime/types-core.js";
 
+const MAX_PENDING_QUESTIONS = 32;
+const MAX_PENDING_QUESTION_CHARS = 32 * 1024;
+
 /** Text produced by a delegated voice consult. */
 export type RealtimeVoiceAgentTalkbackResult = {
   text: string;
@@ -48,9 +51,14 @@ export function createRealtimeVoiceAgentTalkbackQueue(
   params: RealtimeVoiceAgentTalkbackQueueParams,
 ): RealtimeVoiceAgentTalkbackQueue {
   let active = false;
+  let closed = false;
   let pendingQuestions: PendingQuestion[] = [];
+  let pendingQuestionChars = 0;
+  let overflowWarned = false;
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
   let activeAbortController: AbortController | undefined;
+
+  const shouldStop = () => closed || params.isStopped();
 
   const clearDebounceTimer = () => {
     if (!debounceTimer) {
@@ -60,15 +68,60 @@ export function createRealtimeVoiceAgentTalkbackQueue(
     debounceTimer = undefined;
   };
 
+  const appendPendingQuestion = (next: PendingQuestion): boolean => {
+    const current = pendingQuestions.at(-1);
+    const mergeWithCurrent = current !== undefined && Object.is(current.metadata, next.metadata);
+    const addedChars = next.question.length + (mergeWithCurrent ? 1 : 0);
+    const exceedsQuestionLimit =
+      !mergeWithCurrent && pendingQuestions.length >= MAX_PENDING_QUESTIONS;
+    const exceedsCharacterLimit = pendingQuestionChars + addedChars > MAX_PENDING_QUESTION_CHARS;
+    if (exceedsQuestionLimit || exceedsCharacterLimit) {
+      if (!overflowWarned) {
+        overflowWarned = true;
+        params.logger.warn(
+          `${params.logPrefix} consult queue full: droppedChars=${next.question.length} queued=${pendingQuestions.length} queuedChars=${pendingQuestionChars}`,
+        );
+      }
+      return false;
+    }
+    if (current && mergeWithCurrent) {
+      // Metadata identity represents the caller/context lane; merge only when the
+      // same lane produced adjacent fragments.
+      current.question = `${current.question}\n${next.question}`;
+    } else {
+      pendingQuestions.push(next);
+    }
+    pendingQuestionChars += addedChars;
+    return true;
+  };
+
+  const shiftPendingQuestion = (): PendingQuestion | undefined => {
+    const next = pendingQuestions.shift();
+    if (!next) {
+      return undefined;
+    }
+    pendingQuestionChars -= next.question.length;
+    if (pendingQuestions.length === 0) {
+      overflowWarned = false;
+    }
+    return next;
+  };
+
+  const clearPendingQuestions = () => {
+    pendingQuestions = [];
+    pendingQuestionChars = 0;
+    overflowWarned = false;
+  };
+
   const run = async (pending: PendingQuestion): Promise<void> => {
     const trimmed = pending.question.trim();
-    if (!trimmed || params.isStopped()) {
+    if (!trimmed || shouldStop()) {
       return;
     }
     if (active) {
       // Preserve order while avoiding concurrent consults; compatible metadata
-      // fragments are merged by appendPendingQuestion below.
-      appendPendingQuestion(pendingQuestions, {
+      // fragments are merged by appendPendingQuestion above.
+      appendPendingQuestion({
         question: trimmed,
         metadata: pending.metadata,
       });
@@ -83,7 +136,7 @@ export function createRealtimeVoiceAgentTalkbackQueue(
     let consultStartedAt: number | undefined;
     try {
       while (nextQuestion) {
-        if (params.isStopped()) {
+        if (shouldStop()) {
           return;
         }
         const currentQuestion = nextQuestion;
@@ -103,14 +156,14 @@ export function createRealtimeVoiceAgentTalkbackQueue(
         params.logger.info(
           `${params.logPrefix} consult done: elapsedMs=${Date.now() - consultStartedAt} answerChars=${text.length} queued=${pendingQuestions.length}`,
         );
-        if (!params.isStopped() && text) {
+        if (!shouldStop() && text) {
           params.deliver(text);
         }
-        nextQuestion = pendingQuestions.shift();
+        nextQuestion = shiftPendingQuestion();
       }
     } catch (error) {
       activeAbortController = undefined;
-      if (params.isStopped() || isAbortError(error)) {
+      if (shouldStop() || isAbortError(error)) {
         return;
       }
       const message = error instanceof Error ? error.message : String(error);
@@ -120,8 +173,12 @@ export function createRealtimeVoiceAgentTalkbackQueue(
       params.deliver(params.fallbackText);
     } finally {
       active = false;
-      const queuedQuestion = pendingQuestions.shift();
-      if (queuedQuestion && !params.isStopped()) {
+      if (shouldStop()) {
+        clearPendingQuestions();
+        return;
+      }
+      const queuedQuestion = shiftPendingQuestion();
+      if (queuedQuestion) {
         // Continue draining any questions queued while the active consult ran.
         void run(queuedQuestion);
       }
@@ -130,49 +187,45 @@ export function createRealtimeVoiceAgentTalkbackQueue(
 
   return {
     close: () => {
+      if (closed) {
+        return;
+      }
+      closed = true;
       clearDebounceTimer();
-      pendingQuestions = [];
+      clearPendingQuestions();
       // Abort only the active consult; pending work has already been dropped.
       activeAbortController?.abort();
     },
     enqueue: (question, metadata) => {
       const trimmed = question.trim();
-      if (!trimmed || params.isStopped()) {
+      if (!trimmed || shouldStop()) {
         return;
       }
       if (active) {
-        appendPendingQuestion(pendingQuestions, { question: trimmed, metadata });
-        params.logger.info(
-          `${params.logPrefix} consult queued: chars=${trimmed.length} queued=${pendingQuestions.length}`,
-        );
+        if (appendPendingQuestion({ question: trimmed, metadata })) {
+          params.logger.info(
+            `${params.logPrefix} consult queued: chars=${trimmed.length} queued=${pendingQuestions.length}`,
+          );
+        }
         clearDebounceTimer();
         return;
       }
-      appendPendingQuestion(pendingQuestions, { question: trimmed, metadata });
+      if (!appendPendingQuestion({ question: trimmed, metadata })) {
+        return;
+      }
       clearDebounceTimer();
       // Debounce short transcript bursts so partial ASR fragments become a
       // single consult question instead of multiple back-to-back agent turns.
       debounceTimer = setTimeout(() => {
         debounceTimer = undefined;
-        const queuedQuestion = pendingQuestions.shift();
-        if (queuedQuestion && !params.isStopped()) {
+        const queuedQuestion = shiftPendingQuestion();
+        if (queuedQuestion && !shouldStop()) {
           void run(queuedQuestion);
         }
       }, params.debounceMs);
       debounceTimer.unref?.();
     },
   };
-}
-
-function appendPendingQuestion(queue: PendingQuestion[], next: PendingQuestion): void {
-  const current = queue.at(-1);
-  if (current && Object.is(current.metadata, next.metadata)) {
-    // Metadata identity represents the caller/context lane; merge only when the
-    // same lane produced adjacent fragments.
-    current.question = `${current.question}\n${next.question}`;
-    return;
-  }
-  queue.push(next);
 }
 
 function isAbortError(error: unknown): boolean {


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where realtime voice sessions could retain an unbounded backlog of delegated talkback questions while an agent consult was slow or stalled. Same-context transcript fragments could grow one pending string indefinitely, while alternating contexts could grow the pending array for the full session.

## Why This Change Was Made

The shared talkback owner now retains at most 32 pending questions and 32 KiB of aggregate pending question text. Normal adjacent-fragment batching and FIFO delivery are unchanged; once either bound is reached, newer work is dropped with one warning per saturation burst. Queue closure now independently rejects late enqueues, clears pending state, and aborts the active consult idempotently.

The limits are internal. No provider, config, protocol, or environment-variable surface changes.

## User Impact

Slow or stalled realtime agent consultation can no longer make session-owned transcript work grow without bound. Normal voice talkback ordering, metadata-lane batching, fallback delivery, and cancellation behavior remain unchanged.

## Evidence

- Exact branch head: `ec86ead62599b805cd6529fcad03fced1225f3dd`.
- Blacksmith Testbox `tbx_01kysqe4wqpsf6s2jvmcd6rmn1`: `CI=1 pnpm test:serial src/talk/agent-talkback-runtime.test.ts src/talk/realtime-session-harness.test.ts` — 14 passed.
- Same exact-head Testbox: `CI=1 pnpm check:changed` — passed the two-file `core, coreTests` lane, including typecheck, lint, dead-code, import-cycle, schema, and runtime guards.
- Regression coverage holds the first consult open, floods same-metadata fragments and alternating metadata lanes, verifies the retained 32 KiB / 32-item bounds, preserves retained FIFO order, and confirms repeated close plus late enqueue are harmless.
- Autoreview on the exact three-commit branch: clean, no accepted/actionable findings, confidence 0.98; secret scan clean.
- Collision audit: #112820 adds metadata propagation and #98201 adds log semantics in the same file; neither bounds pending work. This PR intentionally leaves those APIs unchanged so the drafts can rebase their orthogonal changes.
