### PR TITLE
fix(macos): reduce gateway endpoint resolution churn

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -90,7 +90,7 @@ actor GatewayEndpointStore {
         let remoteRouteIsCurrent: @Sendable (RemoteTunnelManager.Route) async -> Bool
         let canStartRemoteTunnel: @Sendable () -> Bool
         let ensureRemoteTunnel: @Sendable () async throws -> RemoteTunnelManager.Route
-        let routingGenerationIsCurrent: @Sendable (UInt64) async -> Bool
+        let liveSourceIsCurrent: @Sendable (SourceSnapshot) async -> Bool
         let sourceSnapshot: @Sendable () async -> SourceSnapshot
 
         static let live = Deps(
@@ -117,9 +117,19 @@ actor GatewayEndpointStore {
             remoteRouteIsCurrent: { await RemoteTunnelManager.shared.isCurrentRoute($0) },
             canStartRemoteTunnel: { GatewayEndpointStore.primaryAppLaunchAdmitted.withValue { $0 } },
             ensureRemoteTunnel: { try await RemoteTunnelManager.shared.ensureControlTunnelRoute() },
-            routingGenerationIsCurrent: { generation in
+            liveSourceIsCurrent: { source in
                 await MainActor.run {
-                    AppStateStore.shared.gatewayRoutingGeneration == generation
+                    let currentTailnetIP: String? = if source.mode == .local,
+                                                       source.bindMode == "tailnet"
+                    {
+                        TailscaleService.shared.tailscaleIP ?? TailscaleService.fallbackTailnetIPv4()
+                    } else {
+                        nil
+                    }
+                    return GatewayEndpointStore.liveSourceIsCurrent(
+                        source,
+                        currentRoutingGeneration: AppStateStore.shared.gatewayRoutingGeneration,
+                        currentTailnetIP: currentTailnetIP)
                 }
             },
             sourceSnapshot: { await GatewayEndpointStore.liveSourceSnapshot() })
@@ -471,15 +481,17 @@ actor GatewayEndpointStore {
               generation == self.resolutionGeneration,
               self.activeSource == source
         else { return false }
+        if source.routingGeneration != nil {
+            // Live snapshots are anchored to the MainActor routing generation plus
+            // volatile route facts. Re-reading config here would multiply disk work.
+            let liveSourceIsCurrent = await deps.liveSourceIsCurrent(source)
+            return liveSourceIsCurrent &&
+                !Task.isCancelled &&
+                generation == self.resolutionGeneration &&
+                self.activeSource == source
+        }
         let current = await deps.sourceSnapshot()
-        guard !Task.isCancelled,
-              generation == self.resolutionGeneration,
-              self.activeSource == source,
-              current == source
-        else { return false }
-        guard let routingGeneration = source.routingGeneration else { return true }
-        let routingGenerationIsCurrent = await deps.routingGenerationIsCurrent(routingGeneration)
-        return routingGenerationIsCurrent &&
+        return current == source &&
             !Task.isCancelled &&
             generation == self.resolutionGeneration &&
             self.activeSource == source
@@ -944,6 +956,19 @@ extension GatewayEndpointStore {
             beforeConfigRead: {})
     }
 
+    private static func liveSourceIsCurrent(
+        _ source: SourceSnapshot,
+        currentRoutingGeneration: UInt64,
+        currentTailnetIP: String?) -> Bool
+    {
+        guard source.routingGeneration == currentRoutingGeneration else { return false }
+        guard source.mode == .local, source.bindMode == "tailnet" else { return true }
+        return source.localHost == self.resolveLocalGatewayHost(
+            bindMode: source.bindMode,
+            customBindHost: nil,
+            tailscaleIP: currentTailnetIP)
+    }
+
     private static func liveSourceSnapshot(
         appSnapshot: @escaping @MainActor @Sendable () -> LiveAppSnapshot,
         generationIsCurrent: @escaping @MainActor @Sendable (UInt64) -> Bool,
@@ -1288,6 +1313,17 @@ extension GatewayEndpointStore {
             appMode: appMode,
             configMode: configMode,
             configIsCurrent: configIsCurrent)
+    }
+
+    static func _testLiveSourceIsCurrent(
+        _ source: SourceSnapshot,
+        currentRoutingGeneration: UInt64,
+        currentTailnetIP: String?) -> Bool
+    {
+        self.liveSourceIsCurrent(
+            source,
+            currentRoutingGeneration: currentRoutingGeneration,
+            currentTailnetIP: currentTailnetIP)
     }
 
     static func _testResolveGatewayPassword(

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -6,6 +6,7 @@ import Testing
 
 private actor GatewayEndpointSourceGate {
     private var current: GatewayEndpointStore.SourceSnapshot
+    private var readCount = 0
     private var suspendNext = false
     private var returnCapturedSource = false
     private var suspendedReadStarted = false
@@ -17,6 +18,7 @@ private actor GatewayEndpointSourceGate {
     }
 
     func snapshot() async -> GatewayEndpointStore.SourceSnapshot {
+        self.readCount += 1
         guard self.suspendNext else { return self.current }
         self.suspendNext = false
         let capturedSource = self.returnCapturedSource ? self.current : nil
@@ -30,6 +32,10 @@ private actor GatewayEndpointSourceGate {
             self.releaseWaiter = continuation
         }
         return capturedSource ?? self.current
+    }
+
+    func reads() -> Int {
+        self.readCount
     }
 
     func suspendNextRead(returningCapturedSource: Bool = false) {
@@ -572,7 +578,7 @@ extension GatewayEndpointStoreTests {
                     tunnelStarts.withValue { $0 += 1 }
                     return .init(localPort: 18789, generation: 1)
                 },
-                routingGenerationIsCurrent: { _ in true },
+                liveSourceIsCurrent: { _ in true },
                 sourceSnapshot: { source }))
 
             await store.refresh()
@@ -598,7 +604,7 @@ extension GatewayEndpointStoreTests {
                 remoteRouteIsCurrent: { _ in true },
                 canStartRemoteTunnel: { true },
                 ensureRemoteTunnel: { throw CancellationError() },
-                routingGenerationIsCurrent: { _ in true },
+                liveSourceIsCurrent: { _ in true },
                 sourceSnapshot: { await sourceGate.snapshot() }))
 
             let first = Task { try await store.requireEndpoint() }
@@ -612,6 +618,50 @@ extension GatewayEndpointStoreTests {
             #expect(firstEndpoint.config.token == "same-token")
             #expect(firstEndpoint.revision == secondEndpoint.revision)
         }
+    }
+
+    @Test func `routing generation avoids redundant source reads within each request`() async throws {
+        try await TestIsolation.withUserDefaultsValues([connectionModeKey: "unconfigured"]) {
+            let source = self.source(mode: .local, token: "same-token", routingGeneration: 7)
+            let sourceGate = GatewayEndpointSourceGate(source)
+            let store = GatewayEndpointStore(deps: .init(
+                token: { nil },
+                password: { nil },
+                localPort: { 18789 },
+                remoteRouteIfRunning: { nil },
+                remoteRouteIsCurrent: { _ in true },
+                canStartRemoteTunnel: { true },
+                ensureRemoteTunnel: { throw CancellationError() },
+                liveSourceIsCurrent: { $0.routingGeneration == 7 },
+                sourceSnapshot: { await sourceGate.snapshot() }))
+
+            _ = try await store.requireEndpoint()
+            #expect(await sourceGate.reads() == 1)
+
+            _ = try await store.requireEndpoint()
+            #expect(await sourceGate.reads() == 2)
+        }
+    }
+
+    @Test func `live source validation rejects tailnet address changes`() {
+        let source = self.source(
+            mode: .local,
+            localHost: "100.64.1.5",
+            bindMode: "tailnet",
+            routingGeneration: 7)
+
+        #expect(GatewayEndpointStore._testLiveSourceIsCurrent(
+            source,
+            currentRoutingGeneration: 7,
+            currentTailnetIP: "100.64.1.5"))
+        #expect(!GatewayEndpointStore._testLiveSourceIsCurrent(
+            source,
+            currentRoutingGeneration: 7,
+            currentTailnetIP: "100.64.1.6"))
+        #expect(!GatewayEndpointStore._testLiveSourceIsCurrent(
+            source,
+            currentRoutingGeneration: 8,
+            currentTailnetIP: "100.64.1.5"))
     }
 
     @Test func `remote TLS fingerprint changes advance endpoint revision`() async throws {
@@ -631,7 +681,7 @@ extension GatewayEndpointStoreTests {
                 remoteRouteIsCurrent: { _ in true },
                 canStartRemoteTunnel: { true },
                 ensureRemoteTunnel: { throw CancellationError() },
-                routingGenerationIsCurrent: { _ in true },
+                liveSourceIsCurrent: { _ in true },
                 sourceSnapshot: { await sourceGate.snapshot() }))
 
             let first = try await store.requireEndpoint()
@@ -667,7 +717,7 @@ extension GatewayEndpointStoreTests {
                     remoteRouteIsCurrent: { _ in true },
                     canStartRemoteTunnel: { true },
                     ensureRemoteTunnel: { throw CancellationError() },
-                    routingGenerationIsCurrent: { _ in true },
+                    liveSourceIsCurrent: { _ in true },
                     sourceSnapshot: { source }))
 
                 let first = try await store.requireEndpoint()
@@ -703,7 +753,7 @@ extension GatewayEndpointStoreTests {
                 remoteRouteIsCurrent: { _ in true },
                 canStartRemoteTunnel: { true },
                 ensureRemoteTunnel: { throw CancellationError() },
-                routingGenerationIsCurrent: { _ in true },
+                liveSourceIsCurrent: { _ in true },
                 sourceSnapshot: { await sourceGate.snapshot() }))
 
             let staleRequest = Task { try await store.requireEndpoint() }
@@ -747,8 +797,8 @@ extension GatewayEndpointStoreTests {
                 remoteRouteIsCurrent: { _ in true },
                 canStartRemoteTunnel: { true },
                 ensureRemoteTunnel: { throw CancellationError() },
-                routingGenerationIsCurrent: { generation in
-                    currentRoutingGeneration.withValue { $0 == generation }
+                liveSourceIsCurrent: { source in
+                    currentRoutingGeneration.withValue { $0 == source.routingGeneration }
                 },
                 sourceSnapshot: { await sourceGate.snapshot() }))
 
@@ -779,7 +829,7 @@ extension GatewayEndpointStoreTests {
                 remoteRouteIsCurrent: { _ in true },
                 canStartRemoteTunnel: { true },
                 ensureRemoteTunnel: { throw CancellationError() },
-                routingGenerationIsCurrent: { _ in true },
+                liveSourceIsCurrent: { _ in true },
                 sourceSnapshot: { await sourceGate.snapshot() }))
 
             let request = Task { try await store.requireEndpoint() }
@@ -815,7 +865,7 @@ extension GatewayEndpointStoreTests {
                 remoteRouteIsCurrent: { _ in true },
                 canStartRemoteTunnel: { true },
                 ensureRemoteTunnel: { throw CancellationError() },
-                routingGenerationIsCurrent: { _ in true },
+                liveSourceIsCurrent: { _ in true },
                 sourceSnapshot: { await sourceGate.snapshot() }))
             let initialURL = try #require(URL(string: "ws://127.0.0.1:18789"))
 
@@ -856,7 +906,7 @@ extension GatewayEndpointStoreTests {
                 remoteRouteIsCurrent: { _ in true },
                 canStartRemoteTunnel: { true },
                 ensureRemoteTunnel: { throw CancellationError() },
-                routingGenerationIsCurrent: { _ in true },
+                liveSourceIsCurrent: { _ in true },
                 sourceSnapshot: { await sourceGate.snapshot() }))
             let stream = await store.subscribe(bufferingNewest: 10)
             var iterator = stream.makeAsyncIterator()
@@ -900,7 +950,7 @@ extension GatewayEndpointStoreTests {
                 remoteRouteIsCurrent: { await remoteGate.isCurrent($0) },
                 canStartRemoteTunnel: { true },
                 ensureRemoteTunnel: { await remoteGate.ensure() },
-                routingGenerationIsCurrent: { _ in true },
+                liveSourceIsCurrent: { _ in true },
                 sourceSnapshot: { source }))
 
             let cancelledWaiter = Task { try await store.requireEndpoint() }
@@ -940,7 +990,7 @@ extension GatewayEndpointStoreTests {
                 remoteRouteIsCurrent: { await remoteGate.isCurrent($0) },
                 canStartRemoteTunnel: { true },
                 ensureRemoteTunnel: { await remoteGate.ensure() },
-                routingGenerationIsCurrent: { _ in true },
+                liveSourceIsCurrent: { _ in true },
                 sourceSnapshot: { source }))
 
             let first = Task { try await store.requireEndpoint() }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repeated macOS Gateway endpoint requests reloaded the same canonical configuration several times within one resolution, adding avoidable disk and configuration parsing work to dashboard, control-channel, and node connection paths.

## Why This Change Was Made

Live endpoint snapshots are anchored to the MainActor-owned Gateway routing generation. Generation-backed snapshots now validate that generation plus volatile live route facts after each suspension instead of rebuilding the complete source snapshot, while injected snapshots without a generation retain the existing full equality check.

The volatile validation rejects a Tailscale address change that races endpoint resolution. Cancellation, actor generation, and active-source checks remain in place after every await.

## User Impact

The macOS app performs less repeated configuration work while resolving an unchanged Gateway endpoint. Connection behavior and configuration compatibility are unchanged.

## Evidence

- `swift test --package-path apps/macos --build-path apps/macos/.build-local --filter GatewayEndpointStoreTests` (59 tests passed)
- Regression test proves one source read per generation-backed `requireEndpoint()` request
- Regression test rejects a changed Tailscale address and stale routing generation
- Existing stale-generation and source-replacement tests remain green
- SwiftFormat: 0/2 files require formatting
- SwiftLint: 0 violations
- `git diff --check`
- Fresh Codex autoreview: no accepted/actionable findings

AI-assisted: yes. The implementation, owner boundary, tests, and generated review findings were manually verified.
