### PR TITLE
fix(ios): cover late pairing cleanup during gateway forget

### DIFF
--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -2206,24 +2206,37 @@ private func waitForActiveGateway(stableID: String, appModel: NodeAppModel) asyn
             stableID: connectedID))
         let controller = GatewayConnectionController(appModel: appModel, startDiscovery: false)
         let identity = DeviceIdentityStore.loadOrCreate()
-        defer { DeviceAuthStore.clearToken(deviceId: identity.deviceId, role: "node", gatewayID: connectedID) }
+        let resetRelease = AsyncStream<Void>.makeStream()
+        let existingReset = Task {
+            for await _ in resetRelease.stream {
+                return
+            }
+        }
+        appModel._test_setGatewaySessionResetTask(existingReset)
+        defer {
+            resetRelease.continuation.finish()
+            appModel._test_setGatewaySessionResetTask(nil)
+            DeviceAuthStore.clearToken(deviceId: identity.deviceId, role: "node", gatewayID: connectedID)
+        }
 
-        await controller.forgetGateway(stableID: connectedID)
+        let forgetTask = Task { @MainActor in
+            await controller.forgetGateway(stableID: connectedID)
+        }
+        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
+        while appModel.activeGatewayConnectConfig != nil, ContinuousClock().now < deadline {
+            await Task.yield()
+        }
+        #expect(appModel.activeGatewayConnectConfig == nil)
+
         _ = DeviceAuthStore.storeToken(
             deviceId: identity.deviceId,
             role: "node",
             token: "late-handshake-token",
             gatewayID: connectedID)
-        let deadline = ContinuousClock().now.advanced(by: .seconds(3))
-        while DeviceAuthStore.loadToken(
-            deviceId: identity.deviceId,
-            role: "node",
-            gatewayID: connectedID) != nil,
-            ContinuousClock().now < deadline
-        {
-            try await Task.sleep(for: .milliseconds(10))
-        }
+        resetRelease.continuation.yield()
+        resetRelease.continuation.finish()
 
+        #expect(await forgetTask.value)
         #expect(appModel.activeGatewayConnectConfig == nil)
         #expect(GatewaySettingsStore.activeGatewayEntry()?.stableID == selectedID)
         #expect(DeviceAuthStore.loadToken(


### PR DESCRIPTION
## What Problem This Solves

Resolves a stale iOS pairing test that wrote a late node-auth token only after the awaited gateway-forget operation had already completed. The test no longer represented the in-flight handshake race that production cleanup is designed to cover.

## Why This Change Was Made

The test now holds the gateway session-reset barrier open, starts the async forget operation, injects the token while teardown is still in progress, then releases the barrier and awaits completion. Production behavior is unchanged.

## User Impact

No user-visible behavior change. Pairing cleanup coverage now exercises the real teardown race and no longer fails under the current async forget contract.

## Evidence

- `xcodebuild ... -only-testing:OpenClawTests/GatewayConnectionControllerTests test`
  - 76 tests passed
  - the repaired `forget connected gateway disconnects and repeats device auth cleanup` case passed
- `xcodebuild ... -only-testing:OpenClawTests/GatewayConnectionIssueTests -only-testing:OpenClawTests/GatewayConnectionControllerTests -only-testing:OpenClawTests/GatewaySettingsStoreTests test`
  - 117 tests passed across 3 suites
  - repeated after rebasing onto the current `main`
- maintainer source review confirmed the test models the production boundary:
  - forgetting the connected gateway initiates session reset
  - `performForgetGateway` awaits `waitForGatewaySessionResetIfNeeded()`
  - device-auth tokens are cleared after that barrier
  - the test injects the late token after disconnect begins and before releasing the barrier
- `git diff --check`
- autoreview: clean before and after rebase, no accepted/actionable findings

AI-assisted; the change, test contract, and validation results were reviewed before submission.
