### PR TITLE
fix(plugins): keep registry sqlite root consistent

### DIFF
--- a/src/plugins/install-paths.test.ts
+++ b/src/plugins/install-paths.test.ts
@@ -9,7 +9,10 @@ import {
   resolvePluginNpmGenerationProjectDirPrefix,
 } from "./install-paths.js";
 import { resolvePluginInstallRoots, withPluginInstallRoots } from "./install-root-context.js";
-import { resolveInstalledPluginIndexStorePath } from "./installed-plugin-index-store-path.js";
+import {
+  resolveInstalledPluginIndexStateDatabaseOptions,
+  resolveInstalledPluginIndexStorePath,
+} from "./installed-plugin-index-store-path.js";
 
 describe("plugin install root context", () => {
   it("keeps discovery roots on the operator install while runtime state is redirected", async () => {
@@ -29,9 +32,20 @@ describe("plugin install root context", () => {
       expect(resolveInstalledPluginIndexStorePath({ env: redirectedEnv })).toBe(
         "/operator/openclaw/state/openclaw.sqlite",
       );
+      expect(
+        resolveInstalledPluginIndexStateDatabaseOptions({ env: redirectedEnv }).env
+          ?.OPENCLAW_STATE_DIR,
+      ).toBe("/operator/openclaw");
     });
 
     expect(resolveDefaultPluginExtensionsDir(redirectedEnv)).toBe("/tmp/ephemeral-run/extensions");
+    expect(resolveInstalledPluginIndexStorePath({ env: redirectedEnv })).toBe(
+      "/tmp/ephemeral-run/state/openclaw.sqlite",
+    );
+    expect(
+      resolveInstalledPluginIndexStateDatabaseOptions({ env: redirectedEnv }).env
+        ?.OPENCLAW_STATE_DIR,
+    ).toBe("/tmp/ephemeral-run");
   });
 
   it("isolates concurrent install-root scopes", async () => {

--- a/src/plugins/install-root-context.ts
+++ b/src/plugins/install-root-context.ts
@@ -42,6 +42,11 @@ export function resolveActivePluginInstallRoots(
   return pluginInstallRootContext.getStore() ?? resolvePluginInstallRoots(env, homedir);
 }
 
+/** Return whether the current run pinned operator-owned plugin install roots. */
+export function hasActivePluginInstallRoots(): boolean {
+  return pluginInstallRootContext.getStore() !== undefined;
+}
+
 /**
  * Keep plugin discovery on one operator-owned install generation while a run
  * redirects OPENCLAW_STATE_DIR for ephemeral sessions and runtime state.

--- a/src/plugins/installed-plugin-index-store-path.ts
+++ b/src/plugins/installed-plugin-index-store-path.ts
@@ -2,7 +2,10 @@
 import path from "node:path";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { resolveActivePluginInstallRoots } from "./install-root-context.js";
+import {
+  hasActivePluginInstallRoots,
+  resolveActivePluginInstallRoots,
+} from "./install-root-context.js";
 
 const LEGACY_INSTALLED_PLUGIN_INDEX_STORE_PATH = path.join("plugins", "installs.json");
 
@@ -15,8 +18,13 @@ export type InstalledPluginIndexStoreOptions = {
 
 function resolveStoreEnv(options: InstalledPluginIndexStoreOptions): NodeJS.ProcessEnv {
   const env = options.env ?? process.env;
-  const stateDir = options.stateDir ?? resolveActivePluginInstallRoots(env).stateDir;
-  return { ...env, OPENCLAW_STATE_DIR: stateDir };
+  if (options.stateDir) {
+    return { ...env, OPENCLAW_STATE_DIR: options.stateDir };
+  }
+  if (hasActivePluginInstallRoots()) {
+    return { ...env, OPENCLAW_STATE_DIR: resolveActivePluginInstallRoots(env).stateDir };
+  }
+  return env;
 }
 
 /** Resolves the canonical SQLite-backed installed plugin index path. */
@@ -39,12 +47,7 @@ export function resolveInstalledPluginIndexStateDatabaseOptions(
       path: options.filePath,
     };
   }
-  if (options.stateDir) {
-    return {
-      env: resolveStoreEnv(options),
-    };
-  }
-  return options.env ? { env: options.env } : {};
+  return { env: resolveStoreEnv(options) };
 }
 
 /** Resolves the legacy JSON installed plugin index path for migration/doctor use. */


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation exposed a deterministic plugin prerelease failure: a freshly refreshed persisted plugin registry was immediately reported as `derived` because the SQLite existence check and SQLite connection resolved different state roots while runtime state was redirected.

## Why This Change Was Made

Installed plugin registry path resolution now uses the operator-owned plugin install root only while an explicit install-root context is active. Outside that context it preserves the caller environment, including Vitest's worker-isolated SQLite root. This keeps reads, writes, and existence checks on one database without leaking registry state across tests or ordinary runtime scopes.

## User Impact

Plugin metadata refreshes remain attached to the operator-owned registry during redirected agent runs, preventing valid persisted metadata from appearing missing and being unnecessarily re-derived. Ordinary callers keep their configured or test-isolated state roots.

## Evidence

- Before: `src/plugins/status.registry-snapshot.test.ts` failed with `expected 'derived' to be 'persisted'` in Full Release Validation run 30552552219.
- Focused: `node scripts/run-vitest.mjs src/plugins/install-paths.test.ts` — 4 passed.
- Focused: `node scripts/run-vitest.mjs --config test/vitest/vitest.plugins.config.ts src/plugins/status.registry-snapshot.test.ts src/plugins/channel-plugin-ids.test.ts` — 171 passed.
- Focused: `node scripts/run-vitest.mjs --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-plugins.test.ts` — 72 passed.
- `git diff --check` passed.
- Structured autoreview — clean, patch correct at 0.96 confidence.
