### PR TITLE
fix(release): accept legacy zero-skipped runtime summaries

### DIFF
--- a/scripts/validate-qa-runtime-pair-summary.mjs
+++ b/scripts/validate-qa-runtime-pair-summary.mjs
@@ -207,9 +207,13 @@ export function validateQaRuntimePairSummary(summary, options = {}) {
     failed: 0,
     skipped,
   };
+  const requiredCountKeys = ["total", "passed", "failed"];
+  const skippedCountMatches =
+    summary.counts?.skipped === skipped || (skipped === 0 && summary.counts?.skipped === undefined);
   if (
     !isRecord(summary.counts) ||
-    Object.entries(expectedCounts).some(([key, value]) => summary.counts[key] !== value)
+    requiredCountKeys.some((key) => summary.counts[key] !== expectedCounts[key]) ||
+    !skippedCountMatches
   ) {
     throw new Error("runtime-pair summary counts do not match validated scenario evidence");
   }

--- a/test/scripts/validate-qa-runtime-pair-summary.test.ts
+++ b/test/scripts/validate-qa-runtime-pair-summary.test.ts
@@ -162,6 +162,34 @@ describe("frozen QA runtime-pair summary validation", () => {
     });
   });
 
+  it("accepts an older all-passing summary that omitted zero skipped count", () => {
+    const fixture = summary([scenario({ name: "legacy passing", status: "pass" })]);
+    delete (fixture.counts as { skipped?: number }).skipped;
+
+    expect(validateQaRuntimePairSummary(fixture)).toEqual({
+      total: 1,
+      passed: 1,
+      failed: 0,
+      skipped: 0,
+    });
+  });
+
+  it("requires skipped count when validated evidence contains skips", () => {
+    const fixture = summary([
+      scenario({
+        name: "tracked gap",
+        status: "skip",
+        codexStatus: "skip",
+        codexDetails: "known-harness-gap exec: tracked",
+      }),
+    ]);
+    delete (fixture.counts as { skipped?: number }).skipped;
+
+    expect(() => validateQaRuntimePairSummary(fixture)).toThrow(
+      "counts do not match validated scenario evidence",
+    );
+  });
+
   it("accepts a tracked Codex harness gap kept advisory by the current classifier", () => {
     const advisoryGap = scenario({
       name: "tracked advisory gap",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/actions/runs/30537179877/job/90853730834

## What Problem This Solves

Resolves a release-validation failure where a green frozen runtime-pair candidate is rejected solely because its historical summary omitted `counts.skipped` when no scenario was skipped.

## Why This Change Was Made

The trusted validator now treats that one legacy omission as compatible only when its own derived skipped count is zero. `total`, `passed`, and `failed` remain required and exact; a nonzero derived skipped count still requires an exact `skipped` field. This is narrower than changing the candidate schema or weakening all count validation.

## User Impact

Release operators can validate compatible older candidates without bypassing runtime-pair evidence checks. Invalid or incomplete skipped evidence remains rejected.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/validate-qa-runtime-pair-summary.test.ts` (17 passing)
- `git diff --check`
- Fresh `autoreview --mode uncommitted` with the focused test: clean; no accepted/actionable findings.