### PR TITLE
fix(qa): prevent gateway log cleanup from stalling profile runs

### DIFF
--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter, once } from "node:events";
 import { lstat, mkdir, mkdtemp, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Writable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -1358,6 +1359,25 @@ describe("buildQaRuntimeEnv", () => {
       gracefulTimeoutMs: 1,
       forceTimeoutMs: 2,
     });
+  });
+
+  it("force-closes a gateway log stream whose final flush never settles", async () => {
+    const stream = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+      final() {
+        // Simulate the stalled filesystem flush observed in the release profile.
+      },
+    });
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    await testing.closeWriteStream(stream as never, "stdout", 1);
+
+    expect(stream.destroyed).toBe(true);
+    expect(stderr).toHaveBeenCalledWith(
+      "[qa-suite] stdout gateway log flush exceeded 1ms; forcing close\n",
+    );
   });
 
   it.runIf(process.platform !== "win32")(

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -12,6 +12,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { finished } from "node:stream/promises";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -86,6 +87,7 @@ const QA_GATEWAY_CHILD_RESTART_BOUNDARY_TIMEOUT_MS = 90_000;
 const QA_GATEWAY_CHILD_GRACEFUL_SHUTDOWN_TIMEOUT_MS = 30_000;
 // Loaded Docker runners can take several seconds to reap a force-killed process group.
 const QA_GATEWAY_CHILD_FORCE_SHUTDOWN_TIMEOUT_MS = 10_000;
+const QA_GATEWAY_LOG_CLOSE_TIMEOUT_MS = 5_000;
 const QA_MOCK_OPENAI_API_KEY = ["qa", "mock", "openai", "key"].join("-");
 const QA_GATEWAY_CHILD_BLOCKED_SECRET_ENV_VARS = Object.freeze([
   "OPENCLAW_QA_CONVEX_SECRET_CI",
@@ -250,10 +252,29 @@ async function getFreePort() {
   });
 }
 
-async function closeWriteStream(stream: WriteStream) {
-  await new Promise<void>((resolve) => {
-    stream.end(() => resolve());
-  });
+async function closeWriteStream(
+  stream: WriteStream,
+  label: "stderr" | "stdout",
+  timeoutMs = QA_GATEWAY_LOG_CLOSE_TIMEOUT_MS,
+) {
+  if (stream.destroyed) {
+    return;
+  }
+  stream.end();
+  const signal = AbortSignal.timeout(timeoutMs);
+  try {
+    await finished(stream, { cleanup: true, signal });
+  } catch (error) {
+    if (!signal.aborted) {
+      throw error;
+    }
+    // Gateway logs are diagnostic only. Never let a stuck filesystem flush
+    // retain the stopped child runtime and its live transport credentials.
+    process.stderr.write(
+      `[qa-suite] ${label} gateway log flush exceeded ${timeoutMs}ms; forcing close\n`,
+    );
+    stream.destroy();
+  }
 }
 
 async function writeSanitizedQaGatewayDebugLog(params: { sourcePath: string; targetPath: string }) {
@@ -666,6 +687,7 @@ export const testing = {
   resolveQaGatewayChildStopTimeouts,
   stopQaGatewayChildProcessTree,
   classifyLinuxProcessGroupStats,
+  closeWriteStream,
 };
 
 function hasChildExited(child: ChildProcess) {
@@ -1718,9 +1740,12 @@ export async function startQaGatewayChild(params: {
           processStopped = false;
           cleanupErrors.push(error);
         }
-        for (const stream of [stdoutLog, stderrLog]) {
+        for (const [label, stream] of [
+          ["stdout", stdoutLog],
+          ["stderr", stderrLog],
+        ] as const) {
           try {
-            await closeWriteStream(stream);
+            await closeWriteStream(stream, label);
           } catch (error) {
             cleanupErrors.push(error);
           }
@@ -1786,9 +1811,12 @@ export async function startQaGatewayChild(params: {
         cleanupErrors.push(cleanupError);
       }
     }
-    for (const stream of [stdoutLog, stderrLog]) {
+    for (const [label, stream] of [
+      ["stdout", stdoutLog],
+      ["stderr", stderrLog],
+    ] as const) {
       try {
-        await closeWriteStream(stream);
+        await closeWriteStream(stream, label);
       } catch (cleanupError) {
         cleanupErrors.push(cleanupError);
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full QA profile runs could complete their final scenario, then remain stuck in gateway teardown until the GitHub Actions job timeout.

Related run: https://github.com/openclaw/openclaw/actions/runs/30537257802

## Why This Change Was Made

Gateway stdout and stderr logs still flush normally. If a diagnostic log stream does not finish within five seconds after the gateway process has stopped, QA now reports the affected stream and force-closes it so the stopped runtime and live transport credentials can be released.

## User Impact

QA operators no longer lose otherwise-complete release-profile runs to an unbounded diagnostic log flush. Product runtime behavior is unchanged.

## Evidence

- Run 30537257802 completed its final scenario after 66m17s, then produced no progress for 22m48s until the 90-minute job timeout.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child.test.ts` — 88 tests passed.
- `git diff --check` — passed.
- Autoreview (`--mode uncommitted`, Codex gpt-5.6-sol/high) — clean, no accepted/actionable findings.
