### PR TITLE
fix(agents): scrub refusal markers for native Anthropic attempts

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
@@ -96,7 +96,7 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
   }
   const basePrompt =
     sessionPromptState.activePrompt.override ??
-    resolveEmbeddedAttemptBasePrompt({ nativeModelOwned, provider, prompt: params.prompt });
+    resolveEmbeddedAttemptBasePrompt({ provider, prompt: params.prompt });
   const prompt = terminalRetryState.compactionContinuationInstruction
     ? `${basePrompt}\n\n${terminalRetryState.compactionContinuationInstruction}`
     : basePrompt;

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -18,30 +18,18 @@ import {
 describe("resolveEmbeddedAttemptBasePrompt", () => {
   const refusalTrigger = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 
-  it("scrubs the refusal marker for native Anthropic attempts", () => {
+  it("scrubs the refusal marker for Anthropic transport", () => {
     expect(
       resolveEmbeddedAttemptBasePrompt({
-        nativeModelOwned: true,
         provider: "anthropic",
         prompt: refusalTrigger,
       }),
     ).toBe("ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)");
   });
 
-  it("keeps the outer Anthropic transport scrub for ordinary runs", () => {
+  it("keeps non-Anthropic prompts byte-for-byte", () => {
     expect(
       resolveEmbeddedAttemptBasePrompt({
-        nativeModelOwned: false,
-        provider: "anthropic",
-        prompt: refusalTrigger,
-      }),
-    ).not.toContain(refusalTrigger);
-  });
-
-  it("keeps native non-Anthropic prompts byte-for-byte", () => {
-    expect(
-      resolveEmbeddedAttemptBasePrompt({
-        nativeModelOwned: true,
         provider: "openai",
         prompt: refusalTrigger,
       }),

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -18,14 +18,14 @@ import {
 describe("resolveEmbeddedAttemptBasePrompt", () => {
   const refusalTrigger = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 
-  it("preserves prompts verbatim for native model-owned harnesses", () => {
+  it("scrubs the refusal marker for native Anthropic attempts", () => {
     expect(
       resolveEmbeddedAttemptBasePrompt({
         nativeModelOwned: true,
         provider: "anthropic",
         prompt: refusalTrigger,
       }),
-    ).toBe(refusalTrigger);
+    ).toBe("ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)");
   });
 
   it("keeps the outer Anthropic transport scrub for ordinary runs", () => {
@@ -36,6 +36,16 @@ describe("resolveEmbeddedAttemptBasePrompt", () => {
         prompt: refusalTrigger,
       }),
     ).not.toContain(refusalTrigger);
+  });
+
+  it("keeps native non-Anthropic prompts byte-for-byte", () => {
+    expect(
+      resolveEmbeddedAttemptBasePrompt({
+        nativeModelOwned: true,
+        provider: "openai",
+        prompt: refusalTrigger,
+      }),
+    ).toBe(refusalTrigger);
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -102,13 +102,13 @@ function scrubAnthropicRefusalMagic(prompt: string): string {
   );
 }
 
-/** Applies only outer-transport prompt rewrites; native model owners receive the prompt verbatim. */
+/** Anthropic's transport interprets this marker even for native-owned attempts. */
 export function resolveEmbeddedAttemptBasePrompt(params: {
   nativeModelOwned: boolean;
   provider: string;
   prompt: string;
 }): string {
-  if (params.nativeModelOwned || params.provider !== "anthropic") {
+  if (params.provider !== "anthropic") {
     return params.prompt;
   }
   return scrubAnthropicRefusalMagic(params.prompt);

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -104,7 +104,6 @@ function scrubAnthropicRefusalMagic(prompt: string): string {
 
 /** Anthropic's transport interprets this marker even for native-owned attempts. */
 export function resolveEmbeddedAttemptBasePrompt(params: {
-  nativeModelOwned: boolean;
   provider: string;
   prompt: string;
 }): string {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/actions/runs/30537179877/job/90853740464

## What Problem This Solves

Fixes a live Anthropic refusal probe failure where native-owned Anthropic attempts retain a transport refusal marker and terminate the run, while the equivalent non-native path succeeds.

## Why This Change Was Made

The refusal marker is an Anthropic transport-safety concern, not an ownership concern. The prompt helper therefore applies the existing scrub whenever `provider === "anthropic"`; it no longer receives the unrelated `nativeModelOwned` flag. Non-Anthropic prompts, including native OpenAI/Codex attempts, remain byte-for-byte unchanged. This is narrower than changing provider routing or native harness behavior.

## User Impact

Native Anthropic attempts no longer carry a known refusal trigger into the Anthropic transport. Native Codex/OpenAI behavior is unchanged.

## Evidence

- Direct Codex source checked: `codex-rs/core/src/config/mod.rs` defaults the model provider to `openai`; `codex-rs/model-provider-info/src/lib.rs` and `codex-rs/core/src/client.rs` define/use the OpenAI Responses transport.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/helpers.test.ts` — 18 passing
- `git diff --check` — clean
- Fresh `autoreview --mode uncommitted` — no accepted/actionable findings.