### PR TITLE
fix(ci): pass OpenAI credentials to Matrix live frontier

### DIFF
--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -398,6 +398,8 @@ jobs:
         env:
           OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
           FAIL_FAST: ${{ inputs.fail_fast }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENCLAW_LIVE_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2636,6 +2636,8 @@ describe("package artifact reuse", () => {
     expect(matrixJob.strategy).toBeUndefined();
     expect(workflowStep(matrixJob, "Run Matrix live lane").env).toEqual({
       FAIL_FAST: "${{ inputs.fail_fast }}",
+      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
+      OPENCLAW_LIVE_OPENAI_KEY: "${{ secrets.OPENAI_API_KEY }}",
       OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1",
     });
     expect(releaseTelegramWorkflow).toContain(


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/actions/runs/30537179877/job/90853730834

## What Problem This Solves

Fixes the Matrix live-frontier voice scenario failing in the otherwise mock Matrix catalog because the workflow did not provide portable OpenAI credentials to the isolated QA agent.

## Why This Change Was Made

The Matrix run step now forwards the repository environment OpenAI secret under both portable names recognized by live-frontier. The change is limited to workflow credential wiring: it does not add an auth fallback, copy host OAuth profiles, or change candidate product authentication behavior.

## User Impact

The intentional Matrix live-frontier voice coverage can authenticate inside its isolated QA store while the rest of the Matrix catalog continues in mock mode.

## Evidence

- Structured workflow assertion verifies the parsed Matrix run-step environment contains both portable names.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` (93 passing)
- `git diff --check`
- Fresh `autoreview --mode uncommitted` with the focused test: clean; no accepted/actionable findings.