### PR TITLE
improve(ci): rebalance embedded agent test configs

### DIFF
--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -279,11 +279,15 @@ function expandCompactGroup(group) {
     throw new Error(`compact split for ${group.shard_name} does not cover its configs exactly`);
   }
 
-  return splits.map((split) => ({
-    ...group,
-    configs: [split.config],
-    shard_name: split.shardName,
-  }));
+  const expandedGroups = [];
+  for (const split of splits) {
+    expandedGroups.push({
+      ...group,
+      configs: [split.config],
+      shard_name: split.shardName,
+    });
+  }
+  return expandedGroups;
 }
 const TOOLING_CONFIG = "test/vitest/vitest.tooling.config.ts";
 const TOOLING_DOCKER_TEST_FILE = "test/scripts/docker-build-helper.test.ts";

--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -39,6 +39,29 @@ const GATEWAY_STARTUP_HEALTH_RUNTIME_ENV = {
 const AGENTS_EMBEDDED_AGENT_ENV = {
   OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "660000",
 };
+const COMPACT_GROUP_SPLITS = new Map([
+  [
+    "agentic-agents-embedded",
+    [
+      {
+        config: agentVitestProjectOwners.embedded.config,
+        shardName: "agentic-agents-embedded-base",
+      },
+      {
+        config: agentVitestProjectOwners.embeddedIncompleteTurn.config,
+        shardName: "agentic-agents-embedded-incomplete-turn",
+      },
+      {
+        config: agentVitestProjectOwners.embeddedOverflowCompaction.config,
+        shardName: "agentic-agents-embedded-overflow-compaction",
+      },
+      {
+        config: agentVitestProjectOwners.embeddedRun.config,
+        shardName: "agentic-agents-embedded-run",
+      },
+    ],
+  ],
+]);
 const MAX_BUNDLED_NODE_TEST_PATTERNS = 64;
 // PR-only bundles trade a little serial work for fewer ephemeral runner registrations.
 // Keep runner classes and subprocess isolation intact while bounding each combined job.
@@ -82,9 +105,15 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map([
   ["agentic-agents-core-runtime", 79],
   ["agentic-agents-core-subagents", 32],
   ["agentic-agents-core-tools", 52],
-  // A cold fork run is about 430s and emits no file result for most of its
-  // first five minutes. Keep this whole-config whale in its own compact job.
+  // Keep the composite hint for the baseline registration count. Compact
+  // packing then splits its independent configs and redistributes them across
+  // those existing jobs. Split hints are medians from four recent 2-core runs
+  // (30532132189, 30532967046, 30534273298, 30536274496).
   ["agentic-agents-embedded", 430],
+  ["agentic-agents-embedded-base", 363],
+  ["agentic-agents-embedded-incomplete-turn", 146],
+  ["agentic-agents-embedded-overflow-compaction", 150],
+  ["agentic-agents-embedded-run", 30],
   ["agentic-agents-support", 105],
   ["agentic-agents-tools", 42],
   ["agentic-cli", 72],
@@ -233,6 +262,28 @@ function estimateCompactGroupSeconds(group) {
     return Math.max(3, Math.round(group.includePatterns.length * DEFAULT_SECONDS_PER_TEST_FILE));
   }
   return DEFAULT_WHOLE_GROUP_SECONDS;
+}
+
+function expandCompactGroup(group) {
+  const splits = COMPACT_GROUP_SPLITS.get(group.shard_name);
+  if (!splits) {
+    return [group];
+  }
+
+  const actualConfigs = group.configs.toSorted((a, b) => a.localeCompare(b));
+  const splitConfigs = splits.map((split) => split.config).toSorted((a, b) => a.localeCompare(b));
+  if (
+    actualConfigs.length !== splitConfigs.length ||
+    actualConfigs.some((config, index) => config !== splitConfigs[index])
+  ) {
+    throw new Error(`compact split for ${group.shard_name} does not cover its configs exactly`);
+  }
+
+  return splits.map((split) => ({
+    ...group,
+    configs: [split.config],
+    shard_name: split.shardName,
+  }));
 }
 const TOOLING_CONFIG = "test/vitest/vitest.tooling.config.ts";
 const TOOLING_DOCKER_TEST_FILE = "test/scripts/docker-build-helper.test.ts";
@@ -1478,6 +1529,86 @@ export function assignVitestFsCacheWriter(shards) {
   }));
 }
 
+function packCompactGroupsWithinSecondsCap(groups) {
+  const bins = [];
+  const sortedGroups = groups.toSorted(
+    (a, b) =>
+      estimateCompactGroupSeconds(b) - estimateCompactGroupSeconds(a) ||
+      a.shard_name.localeCompare(b.shard_name),
+  );
+  for (const group of sortedGroups) {
+    const weight = estimateCompactGroupSeconds(group);
+    const exclusive = isExclusiveCompactGroup(group);
+    const secondsCap = exclusive ? COMPACT_EXCLUSIVE_JOB_SECONDS : COMPACT_NODE_TEST_JOB_SECONDS;
+    const bin = bins.find(
+      (candidate) =>
+        candidate.exclusive === exclusive &&
+        candidate.groups.length < COMPACT_NODE_TEST_JOB_GROUPS &&
+        candidate.weight + weight <= secondsCap,
+    );
+    if (bin) {
+      bin.groups.push(group);
+      bin.weight += weight;
+      bin.hasWholeConfigGroup ||= !group.includePatterns;
+    } else {
+      bins.push({
+        exclusive,
+        groups: [group],
+        hasWholeConfigGroup: !group.includePatterns,
+        weight,
+      });
+    }
+  }
+  return bins;
+}
+
+function repackCompactGroupsIntoExistingBins(groups, baselineBins) {
+  const bins = [];
+  for (const exclusive of [false, true]) {
+    const classGroups = groups.filter((group) => isExclusiveCompactGroup(group) === exclusive);
+    if (classGroups.length === 0) {
+      continue;
+    }
+
+    const binCount = baselineBins.filter((bin) => bin.exclusive === exclusive).length;
+    if (binCount === 0 || classGroups.length > binCount * COMPACT_NODE_TEST_JOB_GROUPS) {
+      throw new Error(
+        `compact split cannot fit into existing ${exclusive ? "exclusive" : "regular"} bins`,
+      );
+    }
+
+    const classBins = Array.from({ length: binCount }, (_, index) => ({
+      exclusive,
+      groups: [],
+      hasWholeConfigGroup: false,
+      index,
+      weight: 0,
+    }));
+    const sortedGroups = classGroups.toSorted(
+      (a, b) =>
+        estimateCompactGroupSeconds(b) - estimateCompactGroupSeconds(a) ||
+        a.shard_name.localeCompare(b.shard_name),
+    );
+    for (const group of sortedGroups) {
+      const weight = estimateCompactGroupSeconds(group);
+      const bin = classBins
+        .filter((candidate) => candidate.groups.length < COMPACT_NODE_TEST_JOB_GROUPS)
+        .toSorted((a, b) => a.weight - b.weight || a.index - b.index)[0];
+      if (!bin) {
+        throw new Error("compact split exhausted existing bin capacity");
+      }
+      bin.groups.push(group);
+      bin.weight += weight;
+      bin.hasWholeConfigGroup ||= !group.includePatterns;
+    }
+    if (classBins.some((bin) => bin.groups.length === 0)) {
+      throw new Error("compact split left an existing bin empty");
+    }
+    bins.push(...classBins);
+  }
+  return bins;
+}
+
 function createCompactNodeTestShardBundles(options = {}) {
   const shards = createNodeTestShards(options);
   const groupsByRunner = new Map();
@@ -1500,38 +1631,15 @@ function createCompactNodeTestShardBundles(options = {}) {
 
   const compactJobs = [];
   for (const groups of groupsByRunner.values()) {
-    // First-fit decreasing on estimated serial seconds keeps every job near
-    // the same runtime; the old per-file weights let one 3-minute group land
-    // next to nine trivial ones and own the PR wall clock.
-    const bins = [];
-    const sortedGroups = groups.toSorted(
-      (a, b) =>
-        estimateCompactGroupSeconds(b) - estimateCompactGroupSeconds(a) ||
-        a.shard_name.localeCompare(b.shard_name),
-    );
-    for (const group of sortedGroups) {
-      const weight = estimateCompactGroupSeconds(group);
-      const exclusive = isExclusiveCompactGroup(group);
-      const secondsCap = exclusive ? COMPACT_EXCLUSIVE_JOB_SECONDS : COMPACT_NODE_TEST_JOB_SECONDS;
-      const bin = bins.find(
-        (candidate) =>
-          candidate.exclusive === exclusive &&
-          candidate.groups.length < COMPACT_NODE_TEST_JOB_GROUPS &&
-          candidate.weight + weight <= secondsCap,
-      );
-      if (bin) {
-        bin.groups.push(group);
-        bin.weight += weight;
-        bin.hasWholeConfigGroup ||= !group.includePatterns;
-      } else {
-        bins.push({
-          exclusive,
-          groups: [group],
-          hasWholeConfigGroup: !group.includePatterns,
-          weight,
-        });
-      }
-    }
+    // The seconds cap chooses the existing registration count. Independent
+    // configs inside a composite whale are then balanced across that fixed
+    // number of jobs, avoiding both a serial straggler and extra fanout.
+    const baselineBins = packCompactGroupsWithinSecondsCap(groups);
+    const expandedGroups = groups.flatMap(expandCompactGroup);
+    const bins =
+      expandedGroups.length === groups.length
+        ? baselineBins
+        : repackCompactGroupsIntoExistingBins(expandedGroups, baselineBins);
 
     for (const [index, bin] of bins.entries()) {
       const runnerClass = bin.groups[0].runner.includes("-8vcpu-") ? "large" : "small";

--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -39,38 +39,17 @@ const GATEWAY_STARTUP_HEALTH_RUNTIME_ENV = {
 const AGENTS_EMBEDDED_AGENT_ENV = {
   OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "660000",
 };
-const COMPACT_GROUP_SPLITS = new Map([
-  [
-    "agentic-agents-embedded",
-    [
-      {
-        config: agentVitestProjectOwners.embedded.config,
-        shardName: "agentic-agents-embedded-base",
-      },
-      {
-        config: agentVitestProjectOwners.embeddedIncompleteTurn.config,
-        shardName: "agentic-agents-embedded-incomplete-turn",
-      },
-      {
-        config: agentVitestProjectOwners.embeddedOverflowCompaction.config,
-        shardName: "agentic-agents-embedded-overflow-compaction",
-      },
-      {
-        config: agentVitestProjectOwners.embeddedRun.config,
-        shardName: "agentic-agents-embedded-run",
-      },
-    ],
-  ],
-]);
+const COMPACT_EMBEDDED_GROUP_NAMES = [
+  "agentic-agents-embedded-base",
+  "agentic-agents-embedded-incomplete-turn",
+  "agentic-agents-embedded-overflow-compaction",
+  "agentic-agents-embedded-run",
+];
 const MAX_BUNDLED_NODE_TEST_PATTERNS = 64;
 // PR-only bundles trade a little serial work for fewer ephemeral runner registrations.
 // Keep runner classes and subprocess isolation intact while bounding each combined job.
-// The group hints below are loaded-fleet CI walls, so the cap is the real per-bin
-// test budget: 235s packs both runner classes into the same job count as before
-// (6 large + 15 small) while the measured ~60s median job setup keeps the slowest
-// bin near the 5-minute PR wall-clock budget. 220 with honest hints adds a job to
-// each pool for no ceiling win.
-// 190s cap: forbids pairings like core-runtime-media-ui (124) +
+// The group hints below are loaded-fleet CI walls. The 190s cap forbids
+// pairings like core-runtime-media-ui (124) +
 // core-unit-src-security (95) that produced a 195s real-wall straggler bin
 // while the pack sat at ~160s; ~3 extra bins buy ~30-40s of run wall.
 const COMPACT_NODE_TEST_JOB_SECONDS = 190;
@@ -105,9 +84,9 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map([
   ["agentic-agents-core-runtime", 79],
   ["agentic-agents-core-subagents", 32],
   ["agentic-agents-core-tools", 52],
-  // Keep the composite hint for the baseline registration count. Compact
-  // packing then splits its independent configs and redistributes them across
-  // those existing jobs. Split hints are medians from four recent 2-core runs
+  // The composite hint sets the existing job count before its independent
+  // configs are striped across those jobs. Split hints are medians from four
+  // recent 2-core runs
   // (30532132189, 30532967046, 30534273298, 30536274496).
   ["agentic-agents-embedded", 430],
   ["agentic-agents-embedded-base", 363],
@@ -265,26 +244,19 @@ function estimateCompactGroupSeconds(group) {
 }
 
 function expandCompactGroup(group) {
-  const splits = COMPACT_GROUP_SPLITS.get(group.shard_name);
-  if (!splits) {
+  if (group.shard_name !== "agentic-agents-embedded") {
     return [group];
   }
-
-  const actualConfigs = group.configs.toSorted((a, b) => a.localeCompare(b));
-  const splitConfigs = splits.map((split) => split.config).toSorted((a, b) => a.localeCompare(b));
-  if (
-    actualConfigs.length !== splitConfigs.length ||
-    actualConfigs.some((config, index) => config !== splitConfigs[index])
-  ) {
-    throw new Error(`compact split for ${group.shard_name} does not cover its configs exactly`);
+  if (group.configs.length !== COMPACT_EMBEDDED_GROUP_NAMES.length) {
+    throw new Error("embedded compact group names must cover every config");
   }
 
   const expandedGroups = [];
-  for (const split of splits) {
+  for (const [index, config] of group.configs.entries()) {
     expandedGroups.push({
       ...group,
-      configs: [split.config],
-      shard_name: split.shardName,
+      configs: [config],
+      shard_name: COMPACT_EMBEDDED_GROUP_NAMES[index],
     });
   }
   return expandedGroups;
@@ -1389,14 +1361,14 @@ function stripeFileWeight(file) {
   return STRIPE_FILE_SECONDS_HINTS.get(file) ?? DEFAULT_STRIPE_FILE_SECONDS;
 }
 
-// Deterministic cost-aware striping (greedy LPT): heaviest files first, each
-// into the currently lightest batch. Round-robin by discovery order packed one
-// whale next to another and left sibling stripes ~10x lighter.
-function createStripedBatches(values, batchCount) {
+// Deterministic cost-aware batching (greedy LPT): heaviest values first, each
+// into the currently lightest batch. Round-robin by discovery order can pack
+// one whale next to another and leave sibling batches much lighter.
+function createStripedBatches(values, batchCount, weightForValue = stripeFileWeight) {
   const entries = values.map((value, index) => ({
     index,
     value,
-    weight: stripeFileWeight(value),
+    weight: weightForValue(value),
   }));
   entries.sort((a, b) => b.weight - a.weight || a.index - b.index);
   const batches = Array.from({ length: batchCount }, () => ({ totalWeight: 0, entries: [] }));
@@ -1410,7 +1382,7 @@ function createStripedBatches(values, batchCount) {
     target.totalWeight += entry.weight;
     target.entries.push(entry);
   }
-  // Keep discovery order inside each stripe so include lists stay stable.
+  // Keep discovery order inside each batch so include lists stay stable.
   return batches.map((batch) =>
     batch.entries.toSorted((a, b) => a.index - b.index).map((entry) => entry.value),
   );
@@ -1533,86 +1505,6 @@ export function assignVitestFsCacheWriter(shards) {
   }));
 }
 
-function packCompactGroupsWithinSecondsCap(groups) {
-  const bins = [];
-  const sortedGroups = groups.toSorted(
-    (a, b) =>
-      estimateCompactGroupSeconds(b) - estimateCompactGroupSeconds(a) ||
-      a.shard_name.localeCompare(b.shard_name),
-  );
-  for (const group of sortedGroups) {
-    const weight = estimateCompactGroupSeconds(group);
-    const exclusive = isExclusiveCompactGroup(group);
-    const secondsCap = exclusive ? COMPACT_EXCLUSIVE_JOB_SECONDS : COMPACT_NODE_TEST_JOB_SECONDS;
-    const bin = bins.find(
-      (candidate) =>
-        candidate.exclusive === exclusive &&
-        candidate.groups.length < COMPACT_NODE_TEST_JOB_GROUPS &&
-        candidate.weight + weight <= secondsCap,
-    );
-    if (bin) {
-      bin.groups.push(group);
-      bin.weight += weight;
-      bin.hasWholeConfigGroup ||= !group.includePatterns;
-    } else {
-      bins.push({
-        exclusive,
-        groups: [group],
-        hasWholeConfigGroup: !group.includePatterns,
-        weight,
-      });
-    }
-  }
-  return bins;
-}
-
-function repackCompactGroupsIntoExistingBins(groups, baselineBins) {
-  const bins = [];
-  for (const exclusive of [false, true]) {
-    const classGroups = groups.filter((group) => isExclusiveCompactGroup(group) === exclusive);
-    if (classGroups.length === 0) {
-      continue;
-    }
-
-    const binCount = baselineBins.filter((bin) => bin.exclusive === exclusive).length;
-    if (binCount === 0 || classGroups.length > binCount * COMPACT_NODE_TEST_JOB_GROUPS) {
-      throw new Error(
-        `compact split cannot fit into existing ${exclusive ? "exclusive" : "regular"} bins`,
-      );
-    }
-
-    const classBins = Array.from({ length: binCount }, (_, index) => ({
-      exclusive,
-      groups: [],
-      hasWholeConfigGroup: false,
-      index,
-      weight: 0,
-    }));
-    const sortedGroups = classGroups.toSorted(
-      (a, b) =>
-        estimateCompactGroupSeconds(b) - estimateCompactGroupSeconds(a) ||
-        a.shard_name.localeCompare(b.shard_name),
-    );
-    for (const group of sortedGroups) {
-      const weight = estimateCompactGroupSeconds(group);
-      const bin = classBins
-        .filter((candidate) => candidate.groups.length < COMPACT_NODE_TEST_JOB_GROUPS)
-        .toSorted((a, b) => a.weight - b.weight || a.index - b.index)[0];
-      if (!bin) {
-        throw new Error("compact split exhausted existing bin capacity");
-      }
-      bin.groups.push(group);
-      bin.weight += weight;
-      bin.hasWholeConfigGroup ||= !group.includePatterns;
-    }
-    if (classBins.some((bin) => bin.groups.length === 0)) {
-      throw new Error("compact split left an existing bin empty");
-    }
-    bins.push(...classBins);
-  }
-  return bins;
-}
-
 function createCompactNodeTestShardBundles(options = {}) {
   const shards = createNodeTestShards(options);
   const groupsByRunner = new Map();
@@ -1635,15 +1527,60 @@ function createCompactNodeTestShardBundles(options = {}) {
 
   const compactJobs = [];
   for (const groups of groupsByRunner.values()) {
-    // The seconds cap chooses the existing registration count. Independent
-    // configs inside a composite whale are then balanced across that fixed
-    // number of jobs, avoiding both a serial straggler and extra fanout.
-    const baselineBins = packCompactGroupsWithinSecondsCap(groups);
+    // First-fit decreasing sets the existing registration count from the
+    // composite groups and their runtime cap.
+    const bins = [];
+    const sortedGroups = groups.toSorted(
+      (a, b) =>
+        estimateCompactGroupSeconds(b) - estimateCompactGroupSeconds(a) ||
+        a.shard_name.localeCompare(b.shard_name),
+    );
+    for (const group of sortedGroups) {
+      const weight = estimateCompactGroupSeconds(group);
+      const exclusive = isExclusiveCompactGroup(group);
+      const secondsCap = exclusive ? COMPACT_EXCLUSIVE_JOB_SECONDS : COMPACT_NODE_TEST_JOB_SECONDS;
+      const bin = bins.find(
+        (candidate) =>
+          candidate.exclusive === exclusive &&
+          candidate.groups.length < COMPACT_NODE_TEST_JOB_GROUPS &&
+          candidate.weight + weight <= secondsCap,
+      );
+      if (bin) {
+        bin.groups.push(group);
+        bin.weight += weight;
+        bin.hasWholeConfigGroup ||= !group.includePatterns;
+      } else {
+        bins.push({
+          exclusive,
+          groups: [group],
+          hasWholeConfigGroup: !group.includePatterns,
+          weight,
+        });
+      }
+    }
+
     const expandedGroups = groups.flatMap(expandCompactGroup);
-    const bins =
-      expandedGroups.length === groups.length
-        ? baselineBins
-        : repackCompactGroupsIntoExistingBins(expandedGroups, baselineBins);
+    if (expandedGroups.length !== groups.length) {
+      const regularGroups = expandedGroups
+        .filter((group) => !isExclusiveCompactGroup(group))
+        .toSorted((a, b) => a.shard_name.localeCompare(b.shard_name));
+      const regularBinCount = bins.filter((bin) => !bin.exclusive).length;
+      const regularBatches = createStripedBatches(
+        regularGroups,
+        regularBinCount,
+        estimateCompactGroupSeconds,
+      );
+      if (regularBatches.some((batch) => batch.length > COMPACT_NODE_TEST_JOB_GROUPS)) {
+        throw new Error("striped compact job exceeds its group capacity");
+      }
+      const regularBins = regularBatches.map((batch) => ({
+        exclusive: false,
+        groups: batch,
+        hasWholeConfigGroup: batch.some((group) => !group.includePatterns),
+      }));
+      const exclusiveBins = bins.filter((bin) => bin.exclusive);
+      bins.splice(0, bins.length, ...regularBins, ...exclusiveBins);
+    }
 
     for (const [index, bin] of bins.entries()) {
       const runnerClass = bin.groups[0].runner.includes("-8vcpu-") ? "large" : "small";

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -312,13 +312,36 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
         .flatMap((shard) => shard.groups)
         .find((group) => group.shard_name === "agentic-control-plane-startup-health-runtime")?.env,
     ).toEqual({ OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "60000" });
-    const embeddedAgentJob = compact.find((shard) =>
-      shard.groups.some((group) => group.shard_name === "agentic-agents-embedded"),
+    const largeJobs = compact.filter(
+      (shard) => shard.runner === DEFAULT_NODE_TEST_RUNNER && !shard.requiresDist,
     );
-    expect(embeddedAgentJob?.groups).toHaveLength(1);
-    expect(embeddedAgentJob?.groups[0]?.env).toEqual({
-      OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "660000",
-    });
+    expect(largeJobs).toHaveLength(8);
+    const embeddedAgentGroups = compact
+      .flatMap((shard) => shard.groups)
+      .filter((group) => group.shard_name.startsWith("agentic-agents-embedded-"));
+    expect(embeddedAgentGroups.map((group) => group.shard_name).toSorted()).toEqual([
+      "agentic-agents-embedded-base",
+      "agentic-agents-embedded-incomplete-turn",
+      "agentic-agents-embedded-overflow-compaction",
+      "agentic-agents-embedded-run",
+    ]);
+    expect(
+      compact.some((shard) =>
+        shard.groups.some((group) => group.shard_name === "agentic-agents-embedded"),
+      ),
+    ).toBe(false);
+    expect(embeddedAgentGroups.flatMap((group) => group.configs).toSorted()).toEqual(
+      embeddedAgentVitestProjectOwners.map((owner) => owner.config).toSorted(),
+    );
+    expect(
+      embeddedAgentGroups.every(
+        (group) => group.env?.OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS === "660000",
+      ),
+    ).toBe(true);
+    const embeddedBaseJob = compact.find((shard) =>
+      shard.groups.some((group) => group.shard_name === "agentic-agents-embedded-base"),
+    );
+    expect(embeddedBaseJob?.groups).toHaveLength(1);
     expect(
       compact
         .filter((shard) => shard.groups.some((group) => !group.includePatterns))

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -249,6 +249,7 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
     // The complete Control UI and model catalog both cold-load broad graphs;
     // pairing them starves model visibility and repeatedly hits its timeout.
     expect(jobOf("agentic-agents-core-models")).not.toBe(jobOf("core-runtime-media-ui"));
+    expect(jobOf("core-runtime-media-ui")).not.toBe(jobOf("core-unit-src-security"));
     // Cheap stripes may legally co-locate in one bin; only existence matters.
     expect(jobOf("core-unit-fast-1")).toBeGreaterThanOrEqual(0);
     expect(jobOf("core-unit-fast-2")).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/actions/runs/30536274496/job/90850541759?pr=116361

AI-assisted: Codex investigated the CI history, implemented the planner change, and ran the focused validation below. I reviewed and understand the change.

## What Problem This Solves

Resolves a problem where one compact Node CI shard consistently takes almost twice as long as its peers because four independently isolated embedded-agent Vitest configs run serially in one job.

## Why This Change Was Made

The compact planner now splits that composite group only at packing time and uses measured per-config runtime hints to redistribute the configs across the existing eight large-runner jobs. The original composite estimate still determines registration count, so the fix does not add CI fanout or change the full/release shard plan.

## User Impact

Pull-request CI should spend less time waiting on a single embedded-agent straggler without registering another runner. There is no product runtime impact.

## Evidence

- The linked job spent 694.71 seconds in its test wrapper. Its four serial configs took 373.30s, 142.65s, 147.81s, and 29.36s; recent successful runs showed the same systematic imbalance.
- Generated compact plan still has exactly eight non-dist large-runner jobs. Estimated packed runtimes are one 363s embedded base job and seven jobs between 220s and 230s, instead of one approximately 695s composite job.
- `node scripts/run-vitest.mjs test/scripts/ci-node-test-plan.test.ts` — 21 tests passed after rebasing onto current `origin/main`.
- `git diff --check origin/main...HEAD` — passed.
- Autoreview (`--mode uncommitted`) — clean; no accepted/actionable findings.
