### PR TITLE
fix(qa): stabilize Matrix progress scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - **Execution and transport safety:** browser, sandbox, exec, MCP, and secret-resolution paths reject unsafe inputs and handle stream failures without crashing the host process.
 - **Delivery and channel stability:** outbound receipts, delivery evidence, channel lifecycle, health monitoring, and gateway queues recover cleanly under retries, restarts, and overload.
 - **Gateway and storage reliability:** plugin responses, process probes, workspace bootstrap reads, and SQLite writes tolerate expected transient failures while preserving correct state.
+- **Matrix QA reliability:** command-progress checks accept their expected final preview replacement, and mock runs scope directives and tool output to the current user turn.
 
 ### Upcoming deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 - **Execution and transport safety:** browser, sandbox, exec, MCP, and secret-resolution paths reject unsafe inputs and handle stream failures without crashing the host process.
 - **Delivery and channel stability:** outbound receipts, delivery evidence, channel lifecycle, health monitoring, and gateway queues recover cleanly under retries, restarts, and overload.
 - **Gateway and storage reliability:** plugin responses, process probes, workspace bootstrap reads, and SQLite writes tolerate expected transient failures while preserving correct state.
-- **Matrix QA reliability:** command-progress checks accept their expected final preview replacement, and mock runs scope directives and tool output to the current user turn.
 
 ### Upcoming deprecations
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -610,7 +610,7 @@ describe("qa mock openai server", () => {
     expect(errorOutput.output[0]?.content?.[0]?.text).toBe("TOOL_PROGRESS_ERROR_OK");
   });
 
-  it("uses the latest user prompt path for tool-progress plans", async () => {
+  it("uses the latest user tool-progress prompt kind and target for plans", async () => {
     const server = await startMockServer();
 
     const response = await fetch(`${server.baseUrl}/v1/responses`, {
@@ -639,6 +639,30 @@ describe("qa mock openai server", () => {
     expect(body).toContain('"name":"read"');
     expect(body).toContain("latest-missing-progress-target.txt");
     expect(body).not.toContain("older-progress-target.txt");
+
+    const command = "sleep 2; cat 'current-progress-target.txt'";
+    const currentNormal = await postResponses(server, {
+      stream: true,
+      input: [
+        makeUserInput(
+          "Tool progress error QA check: read `stale-missing-progress-target.txt` before answering. After the read fails, reply exactly `STALE_PROGRESS_OK`.",
+        ),
+        {
+          type: "function_call_output",
+          call_id: "call_stale_progress_read",
+          output: JSON.stringify({ error: "ENOENT: stale turn" }),
+        },
+        makeUserInput(
+          `Tool progress QA check: call the exec tool exactly once with this exact command before answering: \`${command}\`. After that command completes, reply exactly \`CURRENT_PROGRESS_OK\`.`,
+        ),
+      ],
+    });
+
+    expect(currentNormal.status).toBe(200);
+    const currentNormalBody = await currentNormal.text();
+    expect(currentNormalBody).toContain('"name":"exec"');
+    expect(currentNormalBody).toContain(command);
+    expect(currentNormalBody).not.toContain("stale-missing-progress-target.txt");
   });
 
   it("prefers path-like refs over generic quoted keys in prompts", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -627,9 +627,6 @@ describe("qa mock openai server", () => {
           makeUserInput(
             "Tool progress error QA check: read `latest-missing-progress-target.txt` before answering. After the read fails, reply exactly `LATEST_PROGRESS_OK`.",
           ),
-          makeUserInput(
-            "Continue with the QA scenario plan and report worked, failed, and blocked items.",
-          ),
         ],
       }),
     });
@@ -663,6 +660,37 @@ describe("qa mock openai server", () => {
     expect(currentNormalBody).toContain('"name":"exec"');
     expect(currentNormalBody).toContain(command);
     expect(currentNormalBody).not.toContain("stale-missing-progress-target.txt");
+  });
+
+  it("does not recover tool-progress directives from an earlier user turn", async () => {
+    const server = await startMockServer();
+
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: true,
+        input: [
+          makeUserInput(
+            "Tool progress QA check: read `stale-progress-target.txt` before answering. After the read completes, reply exactly `STALE_PROGRESS_OK`.",
+          ),
+          {
+            type: "function_call_output",
+            call_id: "call_stale_progress_read",
+            output: JSON.stringify({ text: "stale turn" }),
+          },
+          makeUserInput("Summarize the current turn in one short sentence."),
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).not.toContain('"name":"read"');
+    expect(body).not.toContain("stale-progress-target.txt");
+    expect(body).not.toContain("STALE_PROGRESS_OK");
   });
 
   it("prefers path-like refs over generic quoted keys in prompts", async () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -320,43 +320,28 @@ function buildDeterministicEmbedding(text: string, dimensions = 16) {
   return values.map((value) => Number((value / magnitude).toFixed(8)));
 }
 
-function extractLastUserText(input: ResponsesInputItem[]) {
+type CurrentUserTurn = {
+  index: number;
+  text: string;
+};
+
+function findCurrentUserTurn(input: ResponsesInputItem[]): CurrentUserTurn | undefined {
   for (let index = input.length - 1; index >= 0; index -= 1) {
     const item = input[index];
     if (item.role !== "user" || !Array.isArray(item.content)) {
       continue;
     }
-    const text = extractInputText(item.content);
-    if (text) {
-      return text;
-    }
+    return { index, text: extractInputText(item.content) };
   }
-  return "";
+  return undefined;
 }
 
-function extractLastMatchingUserTurn(input: ResponsesInputItem[], pattern: RegExp) {
-  const matcher = new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""));
-  for (let index = input.length - 1; index >= 0; index -= 1) {
-    const item = input[index];
-    if (item.role !== "user" || !Array.isArray(item.content)) {
-      continue;
-    }
-    const text = extractInputText(item.content);
-    if (text && matcher.test(text)) {
-      return { index, text };
-    }
-  }
-  return null;
+function extractLastUserText(input: ResponsesInputItem[]) {
+  return findCurrentUserTurn(input)?.text ?? "";
 }
 
 function findLastUserIndex(input: ResponsesInputItem[]) {
-  for (let index = input.length - 1; index >= 0; index -= 1) {
-    const item = input[index];
-    if (item.role === "user" && Array.isArray(item.content)) {
-      return index;
-    }
-  }
-  return -1;
+  return findCurrentUserTurn(input)?.index ?? -1;
 }
 
 function isToolOutputContinuationText(text: string) {
@@ -2018,13 +2003,13 @@ async function buildResponsesPayload(
   const canCallSessionsYield =
     hasDeclaredTool(body, "sessions_yield") ||
     QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE.test(allInputText);
-  const toolProgressTurn = extractLastMatchingUserTurn(
-    input,
-    /tool progress(?: error)? qa check/i,
-  );
-  const toolProgressPrompt = toolProgressTurn?.text ?? "";
-  const toolProgressToolOutput = toolProgressTurn
-    ? extractToolOutput(input.slice(toolProgressTurn.index))
+  const currentUserTurn = findCurrentUserTurn(input);
+  const toolProgressPrompt = currentUserTurn?.text ?? "";
+  const currentTurnIsToolProgress =
+    QA_TOOL_PROGRESS_ERROR_PROMPT_RE.test(toolProgressPrompt) ||
+    QA_TOOL_PROGRESS_PROMPT_RE.test(toolProgressPrompt);
+  const toolProgressToolOutput = currentTurnIsToolProgress && currentUserTurn
+    ? extractToolOutput(input.slice(currentUserTurn.index))
     : "";
   const toolProgressToolJson = parseToolOutputJson(toolProgressToolOutput);
   const buildToolProgressReadEvents = () => {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -334,6 +334,21 @@ function extractLastUserText(input: ResponsesInputItem[]) {
   return "";
 }
 
+function extractLastMatchingUserTurn(input: ResponsesInputItem[], pattern: RegExp) {
+  const matcher = new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""));
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    const item = input[index];
+    if (item.role !== "user" || !Array.isArray(item.content)) {
+      continue;
+    }
+    const text = extractInputText(item.content);
+    if (text && matcher.test(text)) {
+      return { index, text };
+    }
+  }
+  return null;
+}
+
 function findLastUserIndex(input: ResponsesInputItem[]) {
   for (let index = input.length - 1; index >= 0; index -= 1) {
     const item = input[index];
@@ -2003,14 +2018,21 @@ async function buildResponsesPayload(
   const canCallSessionsYield =
     hasDeclaredTool(body, "sessions_yield") ||
     QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE.test(allInputText);
-  const buildToolProgressReadEvents = (pattern: RegExp) => {
-    const toolProgressPrompt = extractLastMatchingUserText(extractAllUserTexts(input), pattern);
+  const toolProgressTurn = extractLastMatchingUserTurn(
+    input,
+    /tool progress(?: error)? qa check/i,
+  );
+  const toolProgressPrompt = toolProgressTurn?.text ?? "";
+  const toolProgressToolOutput = toolProgressTurn
+    ? extractToolOutput(input.slice(toolProgressTurn.index))
+    : "";
+  const toolProgressToolJson = parseToolOutputJson(toolProgressToolOutput);
+  const buildToolProgressReadEvents = () => {
     return buildToolCallEventsWithArgs("read", {
       path: readTargetFromPrompt(toolProgressPrompt || prompt || allInputText),
     });
   };
-  const buildToolProgressExecEvents = (pattern: RegExp) => {
-    const toolProgressPrompt = extractLastMatchingUserText(extractAllUserTexts(input), pattern);
+  const buildToolProgressExecEvents = () => {
     const command = execCommandFromToolProgressPrompt(toolProgressPrompt || prompt || allInputText);
     return command ? buildToolCallEventsWithArgs("exec", { command }) : null;
   };
@@ -2266,25 +2288,30 @@ async function buildResponsesPayload(
       },
     ]);
   }
-  const toolProgressReplyDirective = exactReplyDirective ?? exactMarkerDirective;
-  if (QA_TOOL_PROGRESS_ERROR_PROMPT_RE.test(allInputText) && toolProgressReplyDirective) {
-    if (!toolOutput) {
-      return buildToolProgressReadEvents(QA_TOOL_PROGRESS_ERROR_PROMPT_RE);
+  const toolProgressReplyDirective =
+    extractExactReplyDirective(toolProgressPrompt) ??
+    extractExactMarkerDirective(toolProgressPrompt) ??
+    extractExactReplyDirective(toolProgressToolOutput) ??
+    extractExactMarkerDirective(toolProgressToolOutput);
+  if (QA_TOOL_PROGRESS_ERROR_PROMPT_RE.test(toolProgressPrompt)) {
+    if (!toolProgressToolOutput) {
+      return buildToolProgressReadEvents();
     }
-    return buildAssistantEvents(
-      hasToolErrorOutput(toolJson, toolOutput)
-        ? toolProgressReplyDirective
-        : "BUG-TOOL-DID-NOT-FAIL",
-    );
-  }
-  if (QA_TOOL_PROGRESS_PROMPT_RE.test(allInputText) && toolProgressReplyDirective) {
-    if (!toolOutput) {
-      return (
-        buildToolProgressExecEvents(QA_TOOL_PROGRESS_PROMPT_RE) ??
-        buildToolProgressReadEvents(QA_TOOL_PROGRESS_PROMPT_RE)
+    if (toolProgressReplyDirective) {
+      return buildAssistantEvents(
+        hasToolErrorOutput(toolProgressToolJson, toolProgressToolOutput)
+          ? toolProgressReplyDirective
+          : "BUG-TOOL-DID-NOT-FAIL",
       );
     }
-    return buildAssistantEvents(toolProgressReplyDirective);
+  }
+  if (QA_TOOL_PROGRESS_PROMPT_RE.test(toolProgressPrompt)) {
+    if (!toolProgressToolOutput) {
+      return buildToolProgressExecEvents() ?? buildToolProgressReadEvents();
+    }
+    if (toolProgressReplyDirective) {
+      return buildAssistantEvents(toolProgressReplyDirective);
+    }
   }
   if (QA_BLOCK_STREAMING_PROMPT_RE.test(allInputText) && blockStreamingMarkers) {
     if (!toolOutput) {

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
@@ -872,6 +872,7 @@ async function runMatrixToolProgressScenario(
     finalText: string;
     allowFinalOnly?: boolean;
     allowFinalBeforeProgress?: boolean;
+    allowFinalReplacementAsCompletion?: boolean;
     allowTopLevelFinalWithProgress?: boolean;
     label: string;
     allowGenericProgressLine?: boolean;
@@ -927,6 +928,13 @@ async function runMatrixToolProgressScenario(
     event.relatesTo?.relType === "m.replace" &&
     event.relatesTo.eventId === previewRootEventId &&
     matchesExpectedProgress(event.body);
+  const isFinalReplacement = (event: MatrixQaObservedEvent, previewRootEventId: string) =>
+    event.roomId === context.roomId &&
+    event.sender === context.sutUserId &&
+    isMatrixQaMessageLikeKind(event.kind) &&
+    event.relatesTo?.relType === "m.replace" &&
+    event.relatesTo.eventId === previewRootEventId &&
+    doesMatrixQaReplyBodyMatchToken(event, params.finalText);
   const throwProgressTimeout = (err: unknown, previewEventId: string): never => {
     throw new Error(
       buildMatrixQaToolProgressTimeoutMessage({
@@ -1056,6 +1064,7 @@ async function runMatrixToolProgressScenario(
     isProgressReplacement(event, previewRootEventId) ||
     (params.allowTopLevelFinalWithProgress === true && isProgressProofEvent(event));
   let topLevelFinalBeforeProgress: typeof preview | undefined;
+  let finalReplacementBeforeProgress: typeof preview | undefined;
   let progress = preview;
   if (!matchesExpectedProgress(preview.event.body)) {
     const progressOrFinal = await client
@@ -1063,13 +1072,21 @@ async function runMatrixToolProgressScenario(
         observedEvents: context.observedEvents,
         predicate: (event) =>
           isProgressProofForPreview(event) ||
+          (params.allowFinalReplacementAsCompletion === true &&
+            isFinalReplacement(event, previewRootEventId)) ||
           (params.allowTopLevelFinalWithProgress === true && isFinalReply(event)),
         roomId: context.roomId,
         since: preview.since,
         timeoutMs: context.timeoutMs,
       })
       .catch((err: unknown) => throwProgressTimeout(err, previewRootEventId));
-    if (isFinalReply(progressOrFinal.event)) {
+    if (
+      params.allowFinalReplacementAsCompletion === true &&
+      isFinalReplacement(progressOrFinal.event, previewRootEventId)
+    ) {
+      finalReplacementBeforeProgress = progressOrFinal;
+      progress = progressOrFinal;
+    } else if (isFinalReply(progressOrFinal.event)) {
       topLevelFinalBeforeProgress = progressOrFinal;
       progress = await client
         .waitForRoomEvent({
@@ -1099,6 +1116,7 @@ async function runMatrixToolProgressScenario(
 
   const finalized =
     topLevelFinalBeforeProgress ??
+    finalReplacementBeforeProgress ??
     (await client
       .waitForRoomEvent({
         observedEvents: context.observedEvents,
@@ -1202,6 +1220,7 @@ export async function runToolProgressCommandPreviewScenario(context: MatrixQaSce
     expectedPreviewKind: "notice",
     finalText: buildMatrixQaToken("MATRIX_QA_TOOL_PROGRESS_COMMAND"),
     label: "tool progress command preview",
+    allowFinalReplacementAsCompletion: true,
     progressPattern: /\bcompleted\b|\bexit\s+0\b/i,
     rejectProgressBodyPattern:
       /`(?![^`]*\bcompleted\b)[^`]*(?:matrix-command-progress-start|print text\s*→\s*run sleep 2)[^`]*`/i,

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -3392,6 +3392,52 @@ describe("matrix live qa scenarios", () => {
     expect(artifacts.reply?.tokenMatched).toBe(true);
   });
 
+  it("accepts a final replacement as Matrix command completion", async () => {
+    const previewEventId = "$tool-progress-command-final-replacement-preview";
+    mockMatrixQaRoomClient({
+      driverEventId: "$tool-progress-command-final-replacement-trigger",
+      events: [
+        {
+          event: matrixQaMessageEvent({
+            kind: "notice",
+            eventId: previewEventId,
+            body: "Working\n`🛠️ print text → run sleep 2`",
+          }),
+          since: "driver-sync-preview",
+        },
+        {
+          event: ({ sendTextMessage }) =>
+            matrixQaMessageEvent({
+              kind: "notice",
+              eventId: "$tool-progress-command-final-replacement",
+              body: readMatrixQaReplyDirective(
+                mockMessageBody(sendTextMessage, "sendTextMessage"),
+                "MATRIX_QA_TOOL_PROGRESS_COMMAND",
+              ),
+              relatesTo: {
+                relType: "m.replace",
+                eventId: previewEventId,
+              },
+            }),
+          since: "driver-sync-final",
+        },
+      ],
+    });
+
+    const scenario = requireMatrixQaScenario("matrix-room-tool-progress-command-preview");
+
+    const result = await runMatrixQaScenario(scenario, matrixQaScenarioContext());
+    const artifacts = result.artifacts as {
+      previewBodyPreview?: unknown;
+      previewEventId?: unknown;
+      reply?: { eventId?: unknown; tokenMatched?: unknown };
+    };
+    expect(artifacts.previewBodyPreview).toMatch(/^MATRIX_QA_TOOL_PROGRESS_COMMAND_/);
+    expect(artifacts.previewEventId).toBe(previewEventId);
+    expect(artifacts.reply?.eventId).toBe("$tool-progress-command-final-replacement");
+    expect(artifacts.reply?.tokenMatched).toBe(true);
+  });
+
   it("reports Matrix tool progress preview candidates when the progress wait times out", async () => {
     const previewEvent = matrixQaMessageEvent({
       kind: "notice",


### PR DESCRIPTION
## Summary

Targets `extended-stable/2026.6.33` from frozen candidate `2dbfe013e511d0c7e0720356f5af5c7bb210db19`.

The release validation Matrix lane timed out because command progress accepted only an intermediate `m.replace` edit even when the expected final token arrived as the final replacement. Separately, the candidate mock allowed stale tool-progress directives and tool output from an earlier transcript turn to affect a later prompt.

This backport keeps the command-preview contract narrow: only that contract accepts a matching final replacement as completion. The mock now selects the current user turn structurally, then scopes directives and tool output to that turn and later. It does not add scenario/profile-specific behavior or the later QA refactor.

This is preferable to relaxing all Matrix replacement handling or retaining transcript-wide mock state: both would conceal unrelated regressions and weaken the contract.

## Validation

- `node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.test.ts extensions/qa-matrix/src/runners/contract/scenarios.test.ts` — 195 tests passed
- `git diff --check` — clean
- Fresh `autoreview --mode uncommitted` — no actionable findings

No release validation was dispatched. This candidate/release backport requires a new npm preflight only after it lands.