### PR TITLE
fix(qa): complete internal image generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - **Execution and transport safety:** browser, sandbox, exec, MCP, and secret-resolution paths reject unsafe inputs and handle stream failures without crashing the host process.
 - **Delivery and channel stability:** outbound receipts, delivery evidence, channel lifecycle, health monitoring, and gateway queues recover cleanly under retries, restarts, and overload.
 - **Gateway and storage reliability:** plugin responses, process probes, workspace bootstrap reads, and SQLite writes tolerate expected transient failures while preserving correct state.
+- **Matrix QA image checks:** the mock OpenAI adapter recognizes internal completed image-generation events and emits the normal media response.
 
 ### Upcoming deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@ Docs: https://docs.openclaw.ai
 - **Execution and transport safety:** browser, sandbox, exec, MCP, and secret-resolution paths reject unsafe inputs and handle stream failures without crashing the host process.
 - **Delivery and channel stability:** outbound receipts, delivery evidence, channel lifecycle, health monitoring, and gateway queues recover cleanly under retries, restarts, and overload.
 - **Gateway and storage reliability:** plugin responses, process probes, workspace bootstrap reads, and SQLite writes tolerate expected transient failures while preserving correct state.
-- **Matrix QA reliability:** command-progress checks accept their expected final preview replacement, and mock runs scope directives and tool output to the current user turn.
-
 ### Upcoming deprecations
 
 - **Plugin SDK migration:** `before_agent_start`, root `openclaw/plugin-sdk` imports, `providerAuthEnvVars`, and `channelEnvVars` are scheduled for removal after July 24. Migrate to the modern hook stages, focused SDK subpath imports, and manifest setup descriptors. See [Plugin SDK migration](/plugins/sdk-migration) and [plugin manifests](/plugins/manifest).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - **Delivery and channel stability:** outbound receipts, delivery evidence, channel lifecycle, health monitoring, and gateway queues recover cleanly under retries, restarts, and overload.
 - **Gateway and storage reliability:** plugin responses, process probes, workspace bootstrap reads, and SQLite writes tolerate expected transient failures while preserving correct state.
 - **Matrix QA image checks:** the mock OpenAI adapter recognizes internal completed image-generation events and emits the normal media response.
+- **Matrix QA reliability:** command-progress checks accept their expected final preview replacement, and mock runs scope directives and tool output to the current user turn.
 
 ### Upcoming deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 - **Execution and transport safety:** browser, sandbox, exec, MCP, and secret-resolution paths reject unsafe inputs and handle stream failures without crashing the host process.
 - **Delivery and channel stability:** outbound receipts, delivery evidence, channel lifecycle, health monitoring, and gateway queues recover cleanly under retries, restarts, and overload.
 - **Gateway and storage reliability:** plugin responses, process probes, workspace bootstrap reads, and SQLite writes tolerate expected transient failures while preserving correct state.
-- **Matrix QA image checks:** the mock OpenAI adapter recognizes internal completed image-generation events and emits the normal media response.
 - **Matrix QA reliability:** command-progress checks accept their expected final preview replacement, and mock runs scope directives and tool output to the current user turn.
 
 ### Upcoming deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - **Execution and transport safety:** browser, sandbox, exec, MCP, and secret-resolution paths reject unsafe inputs and handle stream failures without crashing the host process.
 - **Delivery and channel stability:** outbound receipts, delivery evidence, channel lifecycle, health monitoring, and gateway queues recover cleanly under retries, restarts, and overload.
 - **Gateway and storage reliability:** plugin responses, process probes, workspace bootstrap reads, and SQLite writes tolerate expected transient failures while preserving correct state.
+
 ### Upcoming deprecations
 
 - **Plugin SDK migration:** `before_agent_start`, root `openclaw/plugin-sdk` imports, `providerAuthEnvVars`, and `channelEnvVars` are scheduled for removal after July 24. Migrate to the modern hook stages, focused SDK subpath imports, and manifest setup descriptors. See [Plugin SDK migration](/plugins/sdk-migration) and [plugin manifests](/plugins/manifest).

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -3262,6 +3262,53 @@ describe("qa mock openai server", () => {
     expect(outputText(await toolResult.json())).toContain("Attachment: /tmp/qa-lighthouse.png");
   });
 
+  it("completes background image generation from the current internal completion event", async () => {
+    const server = await startMockServer();
+    const prompt = "Image generation check: generate a QA lighthouse image.";
+    const imagePlan = await expectResponsesJson<{ output?: Array<{ type?: string }> }>(server, {
+      stream: false,
+      input: [makeUserInput(prompt)],
+    });
+    expect(imagePlan.output?.[0]?.type).toBe("function_call");
+
+    const completion = await expectResponsesJson<{
+      output?: Array<{ content?: Array<{ text?: string }> }>;
+    }>(server, {
+      stream: false,
+      input: [
+        makeUserInput(prompt),
+        {
+          type: "function_call",
+          name: "image_generate",
+          call_id: "call_mock_image_generate_1",
+          arguments: JSON.stringify({
+            prompt: "A QA lighthouse",
+            filename: "qa-lighthouse.png",
+          }),
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_mock_image_generate_1",
+          output: JSON.stringify({
+            content: [{ type: "text", text: "Background image generation started." }],
+            details: { async: true, status: "started" },
+          }),
+        },
+        makeUserInput(
+          [
+            "[Internal task completion event]",
+            "source: image_generation",
+            "status: completed successfully",
+            "Generated media:",
+            "MEDIA:/tmp/qa-lighthouse.png",
+          ].join("\n"),
+        ),
+      ],
+    });
+
+    expect(outputText(completion)).toContain("MEDIA:/tmp/qa-lighthouse.png");
+  });
+
   it("plans QA tool-search calls for instruction-declared Codex dynamic tools", async () => {
     const server = await startMockServer();
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1229,12 +1229,33 @@ function readFirstMediaPath(value: unknown): string {
   return "";
 }
 
+function readCompletedImageGenerationMediaPath(text: string): string | undefined {
+  const eventStart = text.lastIndexOf("[Internal task completion event]");
+  if (eventStart < 0) {
+    return undefined;
+  }
+  const completionEvent = text.slice(eventStart);
+  if (
+    !/^source:\s*image_generation\s*$/im.test(completionEvent) ||
+    !/^status:\s*completed successfully\s*$/im.test(completionEvent)
+  ) {
+    return undefined;
+  }
+  return /^MEDIA:\s*([^\r\n]+)$/im.exec(completionEvent)?.[1]?.trim() || undefined;
+}
+
 function buildAssistantText(
   input: ResponsesInputItem[],
   body: Record<string, unknown>,
   scenarioState: MockScenarioState,
 ) {
   const prompt = extractLastUserText(input);
+  const completedImageMediaPath = readCompletedImageGenerationMediaPath(
+    extractAllUserTexts(input).at(-1) ?? "",
+  );
+  if (completedImageMediaPath) {
+    return `Protocol note: generated the QA lighthouse image successfully.\nMEDIA:${completedImageMediaPath}`;
+  }
   const toolOutput = extractToolOutput(input);
   const scenarioToolOutput =
     toolOutput ||
@@ -1957,6 +1978,9 @@ async function buildResponsesPayload(
   const input = Array.isArray(body.input) ? (body.input as ResponsesInputItem[]) : [];
   const prompt = extractLastUserText(input);
   const toolOutput = extractToolOutput(input);
+  const completedImageMediaPath = readCompletedImageGenerationMediaPath(
+    extractAllUserTexts(input).at(-1) ?? "",
+  );
   const allInputText = extractAllRequestTexts(input, body);
   const scenarioToolOutput =
     toolOutput ||
@@ -2777,7 +2801,11 @@ async function buildResponsesPayload(
       });
     }
   }
-  if (QA_IMAGE_GENERATION_PROMPT_RE.test(allInputText) && !toolOutput) {
+  if (
+    QA_IMAGE_GENERATION_PROMPT_RE.test(allInputText) &&
+    !toolOutput &&
+    !completedImageMediaPath
+  ) {
     return buildToolCallEventsWithArgs("image_generate", {
       prompt: "A QA lighthouse on a dark sea with a tiny protocol droid silhouette.",
       filename: "qa-lighthouse.png",

--- a/test/scripts/secret-provider-integrations.test.ts
+++ b/test/scripts/secret-provider-integrations.test.ts
@@ -789,7 +789,8 @@ describe("secret provider integration proof harness", () => {
 
       try {
         const command = proof.runCommand(process.execPath, [scriptPath], {
-          timeoutMs: 150,
+          // Let the nested Node process publish its PID before exercising timeout cleanup.
+          timeoutMs: 1_000,
         });
 
         await waitFor(() => fs.existsSync(descendantPidPath));


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/actions/runs/30537179877/job/90853740464

## What Problem This Solves

The Matrix generated-image scenario starts its background image operation, but the candidate mock only recognizes direct `function_call_output.details.media`. Its later internal image-completion event therefore re-plans image generation rather than emitting the expected media final.

## Why This Change Was Made

This narrow backport decodes the current internal completion text only when it identifies a successful `image_generation` event with a `MEDIA:` path. At the Responses mock boundary, the candidate represents that internal event as a user-text block, not a structured Responses item. The normal assistant response then emits that media path. Direct function-output media behavior remains unchanged.

This is preferable to adding a Matrix-specific delivery exception or accepting arbitrary internal text: the completion envelope is the candidate's existing producer contract and keeps unrelated image scenarios strict.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.test.ts` — 107 tests passed
- `git diff --check` — clean
- Fresh `autoreview --mode uncommitted` — no actionable findings

No release validation was dispatched. This candidate/release backport requires a new npm preflight only after it lands.