### PR TITLE
fix(qa): stop waiting on yielded fanout runs

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -77,7 +77,10 @@ describe("qa scenario catalog channel contracts", () => {
     const completionWait = flow.indexOf('"saveAs":"completedFanout"');
     const storeReads = [...flow.matchAll(/readRawQaSessionStore/gu)].map((match) => match.index);
 
-    expect(flow).toContain("readSessionTranscriptSummary(env, sessionKey)");
+    expect(flow).toContain('"call":"startAgentRun"');
+    expect(flow).not.toContain('"call":"runAgentPrompt"');
+    expect(flow).toContain('"saveAs":"parentOutbound"');
+    expect(flow).toContain("messages.slice(parentOutboundStartIndex)");
     expect(flow).not.toContain("waitForAgentHistoryReply");
     expect(flow).not.toContain('"call":"waitForOutboundMessage"');
     expect(flow).not.toContain("childCompletionMarker");
@@ -87,7 +90,7 @@ describe("qa scenario catalog channel contracts", () => {
     );
     expect(flow).toContain("Boolean(env.mock) ? config.expectedChildCompletionMarkers[0] : 'ok'");
     expect(flow).toContain('saveAs":"timeoutEvidence');
-    expect(flow).toContain('saveAs":"recoveredParentTranscript');
+    expect(flow).toContain('saveAs":"recoveredParentOutbound');
     expect(flow).not.toContain('"value":"subagent-1: ok\\nsubagent-2: ok"');
     expect(flow).toContain("Promise.all([readSessionTranscriptSummary");
     expect(completionWait).toBeGreaterThan(-1);

--- a/extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts
@@ -76,5 +76,12 @@ describe("QA runtime-pair scenario catalog", () => {
       requiredProviderMode: "live-frontier",
       harnessRuntime: "codex",
     });
+    const longContextFlow = JSON.stringify(
+      readQaScenarioById("long-context-progress-watchdog").execution.flow,
+    );
+    expect(longContextFlow).toContain("agentRuntime: { id: config.harnessRuntime }, params: null");
+    expect(longContextFlow).toContain(
+      "snapshot.config.agents?.defaults?.models?.[env.primaryModel]?.params === undefined",
+    );
   });
 });

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -651,10 +651,6 @@ describe("qa scenario catalog", () => {
       "originalPluginAllow === undefined ? null : originalPluginAllow",
     );
     expect(longContextFlow).not.toContain("{ ...originalCodexPluginEntry, enabled:");
-    expect(longContextFlow).toContain("agentRuntime: { id: config.harnessRuntime }, params: null");
-    expect(longContextFlow).toContain(
-      "snapshot.config.agents?.defaults?.models?.[env.primaryModel]?.params === undefined",
-    );
     expect(readQaScenarioExecutionConfig("long-context-progress-watchdog")).toMatchObject({
       requiredProviderMode: "live-frontier",
       harnessRuntime: "codex",

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -651,6 +651,10 @@ describe("qa scenario catalog", () => {
       "originalPluginAllow === undefined ? null : originalPluginAllow",
     );
     expect(longContextFlow).not.toContain("{ ...originalCodexPluginEntry, enabled:");
+    expect(longContextFlow).toContain("agentRuntime: { id: config.harnessRuntime }, params: null");
+    expect(longContextFlow).toContain(
+      "snapshot.config.agents?.defaults?.models?.[env.primaryModel]?.params === undefined",
+    );
     expect(readQaScenarioExecutionConfig("long-context-progress-watchdog")).toMatchObject({
       requiredProviderMode: "live-frontier",
       harnessRuntime: "codex",

--- a/qa/scenarios/agents/subagent-fanout-synthesis.yaml
+++ b/qa/scenarios/agents/subagent-fanout-synthesis.yaml
@@ -93,7 +93,12 @@ flow:
                           - set: sessionKey
                             value:
                               expr: "`agent:qa:fanout:${attempt}:${randomUUID().slice(0, 8)}`"
-                          - call: runAgentPrompt
+                          - set: parentOutboundStartIndex
+                            value:
+                              expr: "state.getSnapshot().messages.length"
+                          # sessions_yield ends the original run. Observe the resumed
+                          # announce turn through channel delivery instead of agent.wait.
+                          - call: startAgentRun
                             args:
                               - ref: env
                               - sessionKey:
@@ -101,14 +106,13 @@ flow:
                                 message:
                                   ref: prompt
                                 timeoutMs:
-                                  expr: liveTurnTimeoutMs(env, 90000)
+                                  expr: liveTurnTimeoutMs(env, 30000)
                           - call: waitForCondition
-                            saveAs: parentTranscript
+                            saveAs: parentOutbound
                             args:
                               - lambda:
-                                  async: true
-                                  expr: "readSessionTranscriptSummary(env, sessionKey).then((summary) => config.expectedReplyGroups.every((group) => group.some((needle) => normalizeLowercaseStringOrEmpty(summary.finalText).includes(needle))) ? summary : undefined).catch(() => undefined)"
-                              - expr: "30000"
+                                  expr: "state.getSnapshot().messages.slice(parentOutboundStartIndex).find((message) => message.direction === 'outbound' && message.conversation.id === 'qa-operator' && config.expectedReplyGroups.every((group) => group.some((needle) => normalizeLowercaseStringOrEmpty(message.text).includes(needle))))"
+                              - expr: liveTurnTimeoutMs(env, 90000)
                               - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
                           # Native child completions are private. Wait for this parent's
                           # actual SQLite rows and both settled final transcripts.
@@ -151,7 +155,7 @@ flow:
                                       expr: "`expected at least two sessions_spawn tool calls during subagent fanout scenario, saw ${fanoutSpawnRequests.length}`"
                           - set: details
                             value:
-                              expr: "parentTranscript.finalText"
+                              expr: "parentOutbound.text"
                           - set: lastError
                             value: __done__
                         catchAs: attemptError
@@ -218,16 +222,15 @@ flow:
                                           expr: "timeoutSawAlpha && timeoutSawBeta && timeoutAlphaOk && timeoutBetaOk && (!env.mock || timeoutSpawnRequests.length >= 2)"
                                           then:
                                             - call: waitForCondition
-                                              saveAs: recoveredParentTranscript
+                                              saveAs: recoveredParentOutbound
                                               args:
                                                 - lambda:
-                                                    async: true
-                                                    expr: "readSessionTranscriptSummary(env, sessionKey).then((summary) => config.expectedReplyGroups.every((group) => group.some((needle) => normalizeLowercaseStringOrEmpty(summary.finalText).includes(needle))) ? summary : undefined).catch(() => undefined)"
+                                                    expr: "state.getSnapshot().messages.slice(parentOutboundStartIndex).find((message) => message.direction === 'outbound' && message.conversation.id === 'qa-operator' && config.expectedReplyGroups.every((group) => group.some((needle) => normalizeLowercaseStringOrEmpty(message.text).includes(needle))))"
                                                 - expr: liveTurnTimeoutMs(env, 30000)
                                                 - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
                                             - set: details
                                               value:
-                                                expr: recoveredParentTranscript.finalText
+                                                expr: recoveredParentOutbound.text
                                             - set: lastError
                                               value: __done__
                                     catchAs: recoveryError

--- a/qa/scenarios/runtime/long-context-progress-watchdog.yaml
+++ b/qa/scenarios/runtime/long-context-progress-watchdog.yaml
@@ -74,7 +74,7 @@ flow:
                       agents:
                         defaults:
                           models:
-                            expr: "({ [env.primaryModel]: { agentRuntime: { id: config.harnessRuntime } } })"
+                            expr: "({ [env.primaryModel]: { agentRuntime: { id: config.harnessRuntime }, params: null } })"
               - call: waitForGatewayHealthy
                 args:
                   - ref: env
@@ -91,6 +91,10 @@ flow:
                   expr: "snapshot.config.agents?.defaults?.models?.[env.primaryModel]?.agentRuntime?.id === config.harnessRuntime"
                   message:
                     expr: "`expected ${env.primaryModel} agentRuntime.id=${config.harnessRuntime}, got ${JSON.stringify(snapshot.config.agents?.defaults?.models?.[env.primaryModel]?.agentRuntime)}`"
+              - assert:
+                  expr: "snapshot.config.agents?.defaults?.models?.[env.primaryModel]?.params === undefined"
+                  message:
+                    expr: "`expected ${env.primaryModel} provider request params to be absent for the Codex harness, got ${JSON.stringify(snapshot.config.agents?.defaults?.models?.[env.primaryModel]?.params)}`"
               - call: reset
               - set: logCursor
                 value:


### PR DESCRIPTION
## What Problem This Solves

Fixes two deterministic QA scenario failures from maturity run https://github.com/openclaw/openclaw/actions/runs/30537257802:

- Subagent fanout produced the correct resumed parent reply within seconds, but the scenario waited on the original yielded run ID for roughly six minutes per attempt.
- Long-context Codex watchdog inherited OpenClaw-only model request params, so the Codex harness correctly rejected the authored route before the test ran.

## Why This Change Was Made

The fanout scenario now starts the parent run without waiting on that run ID, then observes the resumed announce turn on the QA channel from an attempt-scoped message boundary. It still requires both child session rows and both successful child transcripts.

The watchdog temporarily removes model request params while pinning the model to the Codex harness, verifies the normalized config, and restores the original model entry in `finally`.

## User Impact

Full QA profiles avoid approximately twelve minutes of false fanout waits and can exercise the Codex watchdog instead of failing during harness selection. Product runtime behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/scenario-catalog-channels.test.ts extensions/qa-lab/src/scenario-flow-runner.test.ts` — 71 tests passed.
- `git diff --check` — passed.
- Autoreview (`--mode uncommitted`, Codex gpt-5.6-sol/high) — clean after scoping outbound evidence to the current attempt.
- Codex contract checked in sibling source: `../codex/codex-rs/config/src/config_toml.rs` and `../codex/codex-rs/config/src/thread_config/remote.rs` confirm provider routes are config-owned; OpenClaw's Codex harness intentionally rejects unprojected authored request overrides.
