### PR TITLE
fix(qa): run the built plugin-tools MCP server

### DIFF
--- a/extensions/qa-lab/src/suite-runtime-agent-tools.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-tools.test.ts
@@ -124,7 +124,7 @@ describe("qa suite runtime agent tools helpers", () => {
     ).resolves.toEqual("done");
   });
 
-  it("calls plugin-tools MCP through the resolved node executable", async () => {
+  it("falls back to the source plugin-tools MCP entry", async () => {
     listToolsMock.mockResolvedValueOnce({
       tools: [{ name: "plugin.echo" }] as never[],
     });
@@ -178,6 +178,35 @@ describe("qa suite runtime agent tools helpers", () => {
       { timeout: 180_000 },
     );
     expect(closeMock).toHaveBeenCalled();
+  });
+
+  it("prefers the built plugin-tools MCP entry", async () => {
+    const builtRepoRoot = await makeTempDir("qa-built-repo-");
+    const distEntry = path.join(builtRepoRoot, "dist", "mcp", "plugin-tools-serve.js");
+    await fs.mkdir(path.dirname(distEntry), { recursive: true });
+    await fs.writeFile(distEntry, "// built MCP entry\n", "utf8");
+    listToolsMock.mockResolvedValueOnce({
+      tools: [{ name: "plugin.echo" }] as never[],
+    });
+
+    await callPluginToolsMcp({
+      env: {
+        gateway: {
+          tempRoot: gatewayTempRoot,
+          runtimeEnv: { PATH: "/usr/bin" },
+        },
+        repoRoot: builtRepoRoot,
+      } as never,
+      toolName: "plugin.echo",
+      args: {},
+    });
+
+    expect(stdioTransportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: "/usr/bin/node",
+        args: [distEntry],
+      }),
+    );
   });
 
   it("reports available plugin-tools MCP names when the requested tool is missing", async () => {

--- a/extensions/qa-lab/src/suite-runtime-agent-tools.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-tools.ts
@@ -22,6 +22,20 @@ const requireFromHere = createRequire(import.meta.url);
 const MCP_STDERR_TAIL_LIMIT = 8_192;
 const MCP_REQUEST_TIMEOUT_MS = 180_000;
 
+async function resolvePluginToolsMcpArgs(repoRoot: string) {
+  const distEntry = path.join(repoRoot, "dist", "mcp", "plugin-tools-serve.js");
+  try {
+    await fs.access(distEntry);
+    return [distEntry];
+  } catch {
+    return [
+      "--import",
+      requireFromHere.resolve("tsx"),
+      path.join(repoRoot, "src", "mcp", "plugin-tools-serve.ts"),
+    ];
+  }
+}
+
 function findSkill(skills: QaSkillStatusEntry[], name: string) {
   return skills.find((skill) => skill.name === name);
 }
@@ -73,11 +87,7 @@ async function callPluginToolsMcp(params: {
   const nodeExecPath = await resolveQaNodeExecPath();
   const transport = new StdioClientTransport({
     command: nodeExecPath,
-    args: [
-      "--import",
-      requireFromHere.resolve("tsx"),
-      path.join(params.env.repoRoot, "src/mcp/plugin-tools-serve.ts"),
-    ],
+    args: await resolvePluginToolsMcpArgs(params.env.repoRoot),
     stderr: "pipe",
     cwd: params.env.repoRoot,
     env: transportEnv,


### PR DESCRIPTION
## What Problem This Solves

Fixes the Kitchen Sink MCP stage from maturity run https://github.com/openclaw/openclaw/actions/runs/30537257802. The built release profile launched the TypeScript source entry through `tsx`, whose transformed dependency path attempted to require ESM-only `unicorn-magic`; plugin loading then failed and MCP exposed no tools.

## Why This Change Was Made

QA now follows the existing ACP bridge resolution: use `dist/mcp/plugin-tools-serve.js` when the repository has been built, and retain the `tsx` source entry only for unbuilt development checkouts.

## User Impact

Built QA profiles exercise the same compiled plugin-tools server that ships in the build instead of mixing compiled plugins with a source-loader MCP process. Development runs without `dist` continue to work.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-runtime-agent-tools.test.ts` — 9 tests passed, including built-entry and source-fallback coverage.
- `git diff --check` — passed.
- Autoreview (`--mode uncommitted`, Codex gpt-5.6-sol/high) — clean, no accepted/actionable findings.
- Dependency contract inspected directly: `unicorn-magic@0.3.0` exports import-only conditional entries; `npm-run-path@6.0.0` is ESM and imports it. The compiled entry avoids the source transformation that produced `ERR_PACKAGE_PATH_NOT_EXPORTED`.
