### PR TITLE
fix(agents): allow sandbox exec workdirs in mounted skills

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -65,6 +65,7 @@ import { describeProcessTool } from "./bash-tools.descriptions.js";
 import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
 import type { ProcessToolDefaults } from "./bash-tools.process.js";
 import { processSchema } from "./bash-tools.schemas.js";
+import type { BashSandboxWorkdirMount } from "./bash-tools.shared.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
 import {
@@ -131,6 +132,7 @@ type GuardContainerMount = {
 
 function readOnlySandboxReadMounts(
   sandbox: SandboxContext | null | undefined,
+  readOnlyWorkspaceSkillMounts?: readonly BashSandboxWorkdirMount[],
 ): GuardContainerMount[] | undefined {
   if (!sandbox) {
     return undefined;
@@ -144,19 +146,27 @@ function readOnlySandboxReadMounts(
   }
   if (sandbox.workspaceAccess === "rw") {
     mounts.push(
-      ...resolveReadOnlyWorkspaceSkillMounts({
-        workspaceDir: sandbox.workspaceDir,
-        agentWorkspaceDir: sandbox.agentWorkspaceDir,
-        skillsWorkspaceDir: sandbox.skillsWorkspaceDir,
-        workdir: sandbox.containerWorkdir,
-        workspaceAccess: sandbox.workspaceAccess,
-      }).map((mount) => ({
-        containerRoot: mount.containerPath,
-        hostRoot: mount.hostPath,
-      })),
+      ...(readOnlyWorkspaceSkillMounts ?? resolveReadOnlySandboxSkillMounts(sandbox)).map(
+        (mount) => ({
+          containerRoot: mount.containerPath,
+          hostRoot: mount.hostPath,
+        }),
+      ),
     );
   }
   return mounts.length > 0 ? mounts : undefined;
+}
+
+function resolveReadOnlySandboxSkillMounts(
+  sandbox: SandboxContext,
+): readonly BashSandboxWorkdirMount[] {
+  return resolveReadOnlyWorkspaceSkillMounts({
+    workspaceDir: sandbox.workspaceDir,
+    agentWorkspaceDir: sandbox.agentWorkspaceDir,
+    skillsWorkspaceDir: sandbox.skillsWorkspaceDir,
+    workdir: sandbox.containerWorkdir,
+    workspaceAccess: sandbox.workspaceAccess,
+  });
 }
 
 function resolveSkillReadRoots(skillsSnapshot?: SkillSnapshot): string[] | undefined {
@@ -637,6 +647,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const includePluginTools = toolConstructionPlan.includePluginTools;
   const workspaceOnly = fsPolicy.workspaceOnly;
   const skillReadRoots = sandboxRoot ? undefined : resolveSkillReadRoots(options?.skillsSnapshot);
+  const readOnlyWorkspaceSkillMounts = sandbox ? resolveReadOnlySandboxSkillMounts(sandbox) : [];
   const applyPatchConfig = execConfig.applyPatch;
   // Secure by default: apply_patch is workspace-contained unless explicitly disabled.
   // (tools.fs.workspaceOnly is a separate umbrella flag for read/write/edit/apply_patch.)
@@ -668,7 +679,10 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
           });
           const guarded = workspaceOnly
             ? wrapToolWorkspaceRootGuardWithOptions(sandboxed, sandboxRoot, {
-                additionalContainerMounts: readOnlySandboxReadMounts(sandbox),
+                additionalContainerMounts: readOnlySandboxReadMounts(
+                  sandbox,
+                  readOnlyWorkspaceSkillMounts,
+                ),
                 containerWorkdir: sandbox.containerWorkdir,
               })
             : sandboxed;
@@ -783,6 +797,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
               containerName: sandbox.containerName,
               workspaceDir: sandbox.workspaceDir,
               containerWorkdir: sandbox.containerWorkdir,
+              readOnlyWorkspaceSkillMounts,
               workdirValidation: sandbox.backend?.workdirValidation,
               validateWorkdir: sandbox.backend?.validateWorkdir?.bind(sandbox.backend),
               discardPreparedWorkdir: sandbox.backend?.discardPreparedWorkdir?.bind(

--- a/src/agents/bash-tools.exec-workdir.test.ts
+++ b/src/agents/bash-tools.exec-workdir.test.ts
@@ -291,6 +291,65 @@ describe("resolveExecWorkdir", () => {
     });
   });
 
+  it("maps read-only sandbox skill mount workdirs to their mounted host source", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await withTempDir(async (skillsWorkspaceDir) => {
+        const mountedSkillsRoot = path.join(skillsWorkspaceDir, "skills");
+        const demoSkillDir = path.join(mountedSkillsRoot, "demo");
+        await mkdir(demoSkillDir, { recursive: true });
+
+        await expect(
+          resolveExecWorkdir({
+            host: "sandbox",
+            workdir: "/workspace/.openclaw/sandbox-skills/skills/demo",
+            sandbox: {
+              ...sandboxConfig(workspaceDir),
+              readOnlyWorkspaceSkillMounts: [
+                {
+                  hostPath: mountedSkillsRoot,
+                  containerPath: "/workspace/.openclaw/sandbox-skills/skills",
+                },
+              ],
+            },
+          }),
+        ).resolves.toEqual({
+          kind: "sandbox",
+          hostCwd: demoSkillDir,
+          containerCwd: "/workspace/.openclaw/sandbox-skills/skills/demo",
+          scriptPreflightCwd: demoSkillDir,
+        });
+      });
+    });
+  });
+
+  it("rejects missing read-only sandbox skill mount workdirs", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await withTempDir(async (skillsWorkspaceDir) => {
+        const mountedSkillsRoot = path.join(skillsWorkspaceDir, "skills");
+        await mkdir(mountedSkillsRoot, { recursive: true });
+
+        await expect(
+          resolveExecWorkdir({
+            host: "sandbox",
+            workdir: "/workspace/.openclaw/sandbox-skills/skills/missing",
+            sandbox: {
+              ...sandboxConfig(workspaceDir),
+              readOnlyWorkspaceSkillMounts: [
+                {
+                  hostPath: mountedSkillsRoot,
+                  containerPath: "/workspace/.openclaw/sandbox-skills/skills",
+                },
+              ],
+            },
+          }),
+        ).resolves.toEqual({
+          kind: "unavailable",
+          requestedCwd: "/workspace/.openclaw/sandbox-skills/skills/missing",
+        });
+      });
+    });
+  });
+
   it("lets backend-validated sandboxes use remote-only container workdirs", async () => {
     await withTempDir(async (workspaceDir) => {
       await expect(

--- a/src/agents/bash-tools.exec-workdir.ts
+++ b/src/agents/bash-tools.exec-workdir.ts
@@ -33,6 +33,12 @@ type BackendHostWorkdirCandidate = {
   failIfInvalid: boolean;
 };
 
+type ContainerHostWorkdirMapping = {
+  hostPath: string;
+  hostRoot: string;
+  containerRoot: string;
+};
+
 type ExistingHostWorkspacePathResult =
   | { kind: "available"; workdir: SandboxWorkdir }
   | { kind: "missing"; relative: string }
@@ -73,23 +79,33 @@ function safeCurrentCwd(): string | null {
 function mapContainerWorkdirToHost(params: {
   workdir: string;
   sandbox: BashSandboxConfig;
-}): string | undefined {
+}): ContainerHostWorkdirMapping | undefined {
   const workdir = normalizeContainerPath(params.workdir);
-  const containerRoot = normalizeContainerPath(params.sandbox.containerWorkdir);
-  if (containerRoot === ".") {
-    return undefined;
+  const mappings = [
+    ...(params.sandbox.readOnlyWorkspaceSkillMounts ?? []).map((mount) => ({
+      hostRoot: path.resolve(mount.hostPath),
+      containerRoot: normalizeContainerPath(mount.containerPath),
+    })),
+    {
+      hostRoot: path.resolve(params.sandbox.workspaceDir),
+      containerRoot: normalizeContainerPath(params.sandbox.containerWorkdir),
+    },
+  ]
+    .filter((mapping) => mapping.containerRoot !== ".")
+    .sort((left, right) => right.containerRoot.length - left.containerRoot.length);
+
+  for (const mapping of mappings) {
+    const rel = mapContainerWorkdirRelativeToRoot({ workdir, root: mapping.containerRoot });
+    if (!rel) {
+      continue;
+    }
+    return {
+      hostPath: path.resolve(mapping.hostRoot, ...rel),
+      hostRoot: mapping.hostRoot,
+      containerRoot: mapping.containerRoot,
+    };
   }
-  if (workdir === containerRoot) {
-    return path.resolve(params.sandbox.workspaceDir);
-  }
-  if (!workdir.startsWith(`${containerRoot}/`)) {
-    return undefined;
-  }
-  const rel = workdir
-    .slice(containerRoot.length + 1)
-    .split("/")
-    .filter(Boolean);
-  return path.resolve(params.sandbox.workspaceDir, ...rel);
+  return undefined;
 }
 
 function normalizeContainerPath(input: string): string {
@@ -99,6 +115,25 @@ function normalizeContainerPath(input: string): string {
   }
   const posixPath = path.posix.normalize(normalized);
   return posixPath === "/" ? posixPath : posixPath.replace(/\/+$/g, "");
+}
+
+function mapContainerWorkdirRelativeToRoot(params: {
+  workdir: string;
+  root: string;
+}): string[] | null {
+  if (params.workdir === params.root) {
+    return [];
+  }
+  if (params.root === "/") {
+    return path.posix.isAbsolute(params.workdir) ? params.workdir.split("/").filter(Boolean) : null;
+  }
+  if (!params.workdir.startsWith(`${params.root}/`)) {
+    return null;
+  }
+  return params.workdir
+    .slice(params.root.length + 1)
+    .split("/")
+    .filter(Boolean);
 }
 
 function joinContainerWorkdir(containerWorkdir: string, relative: string): string {
@@ -228,7 +263,7 @@ function resolveBackendHostWorkdirCandidate(params: {
     sandbox: params.sandbox,
   });
   return containerMappedHostPath
-    ? { hostPath: containerMappedHostPath, failIfInvalid: false }
+    ? { hostPath: containerMappedHostPath.hostPath, failIfInvalid: false }
     : null;
 }
 
@@ -291,12 +326,14 @@ async function resolveHostValidatedSandboxWorkdir(params: {
     workdir: params.workdir,
     sandbox: params.sandbox,
   });
-  const candidateWorkdir = mappedHostWorkdir ?? params.workdir;
+  const candidateWorkdir = mappedHostWorkdir?.hostPath ?? params.workdir;
+  const candidateRoot = mappedHostWorkdir?.hostRoot ?? params.sandbox.workspaceDir;
+  const containerRoot = mappedHostWorkdir?.containerRoot ?? params.sandbox.containerWorkdir;
   try {
     const resolved = await assertSandboxPath({
       filePath: candidateWorkdir,
-      cwd: params.sandbox.workspaceDir,
-      root: params.sandbox.workspaceDir,
+      cwd: candidateRoot,
+      root: candidateRoot,
     });
     const stats = await fs.stat(resolved.resolved);
     if (!stats.isDirectory()) {
@@ -305,7 +342,7 @@ async function resolveHostValidatedSandboxWorkdir(params: {
     const relative = resolved.relative
       ? resolved.relative.split(path.sep).join(path.posix.sep)
       : "";
-    const containerCwd = joinContainerWorkdir(params.sandbox.containerWorkdir, relative);
+    const containerCwd = joinContainerWorkdir(containerRoot, relative);
     return { hostCwd: resolved.resolved, containerCwd, scriptPreflightCwd: resolved.resolved };
   } catch {
     return null;

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -14,10 +14,16 @@ import type {
 const CHUNK_LIMIT = 8 * 1024;
 
 /** Sandbox metadata needed to map host workspaces into container exec calls. */
+export type BashSandboxWorkdirMount = {
+  hostPath: string;
+  containerPath: string;
+};
+
 export type BashSandboxConfig = {
   containerName: string;
   workspaceDir: string;
   containerWorkdir: string;
+  readOnlyWorkspaceSkillMounts?: readonly BashSandboxWorkdirMount[];
   workdirValidation?: SandboxBackendWorkdirValidation;
   validateWorkdir?: SandboxBackendWorkdirValidator;
   discardPreparedWorkdir?: (workdir: string) => void;


### PR DESCRIPTION
Closes #116390

## What Problem This Solves

When sandbox workspace access is `rw`, OpenClaw mounts materialized skills into the container under `/workspace/.openclaw/sandbox-skills/skills/...`. Those paths are valid inside the sandbox and can be selected as `exec.workdir`, but the host-side workdir resolver only knew how to map paths under the primary `/workspace` mount back to the writable project workspace.

That made a valid mounted skill directory look like a missing host directory under the project workspace, so `exec` rejected the command before Docker could run it.

## Why This Change Was Made

The fix keeps host-side validation in place and teaches the resolver about the approved read-only skill mounts that are already created for sandbox execution:

- `agent-tools.ts` resolves the read-only workspace skill mount table once for the sandbox context.
- The same mount table is reused for read guard metadata and passed into `BashSandboxConfig`.
- `bash-tools.exec-workdir.ts` maps container workdirs through the most specific known mount first, then falls back to the primary workspace mount.
- Existing sandbox boundary checks still validate the resolved host path under the selected host root before accepting it.

This keeps the behavior narrow: only container paths that correspond to known, approved read-only skill mounts gain the correct host mapping.

## User Impact

Agents can now run sandbox commands from skill directories such as `/workspace/.openclaw/sandbox-skills/skills/<skill>` when those directories are present in the mounted skill workspace. Missing mounted skill directories are still rejected as unavailable workdirs, and non-skill workspace paths keep their existing mapping behavior.

## Evidence

- `node_modules/.bin/oxfmt.cmd --check src/agents/bash-tools.shared.ts src/agents/bash-tools.exec-workdir.ts src/agents/agent-tools.ts src/agents/bash-tools.exec-workdir.test.ts`: passed on Windows.
- `git diff --check upstream/main...HEAD`: passed.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-workdir.test.ts -t "read-only sandbox skill mount"`: passed on Windows (`4 passed | 72 skipped`), covering both accepted mounted skill workdirs and rejected missing mounted skill workdirs.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`: passed on Windows.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-workdir.test.ts`: passed on remote Ubuntu with Node `v24.18.0` (`38 passed`).
- `node_modules/.bin/oxfmt --check src/agents/bash-tools.shared.ts src/agents/bash-tools.exec-workdir.ts src/agents/agent-tools.ts src/agents/bash-tools.exec-workdir.test.ts`: passed on remote Ubuntu.
- Autoreview: attempted with `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main --engine codex --stream-engine-output` and succeeded.

## Security Impact

- No new command execution capability is added.
- No secrets, credentials, or network paths are changed.
- Host-side validation remains active for sandbox workdirs.
- The new accepted workdir paths must map through the existing approved read-only skill mount table.
- The resolver still rejects missing mounted skill directories and parent-directory escape attempts.

## Compatibility / Migration

- No config or environment variable changes.
- No migration needed.
- Backward compatible for sandboxes without read-only skill mounts because the resolver falls back to the existing primary workspace mapping.

## AI Assistance

This PR was AI-assisted. I reviewed the changed owner and caller paths and understand the behavior implemented here.
