### PR TITLE
fix(qa): avoid classifying fetched prose as tool failure

### DIFF
--- a/extensions/qa-lab/src/runtime-tool-fixture.test.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.test.ts
@@ -671,6 +671,69 @@ describe("runtime tool fixture", () => {
     ).rejects.toThrow("expected live happy-path successful tool output for read");
   });
 
+  it("allows successful live happy-path tool output to mention failure words", async () => {
+    const env = await makeEnv();
+    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:web_fetch:happy", [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call-web-fetch-happy",
+            name: "web_fetch",
+            input: { url: "https://example.com/" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        toolName: "web_fetch",
+        tool_call_id: "call-web-fetch-happy",
+        content: "The page documents invalid requests, errors, and denied inputs.",
+      },
+    ]);
+    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:web_fetch:failure", [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call-web-fetch-failure",
+            name: "web_fetch",
+            input: { url: "file:///etc/passwd" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        toolName: "web_fetch",
+        tool_call_id: "call-web-fetch-failure",
+        isError: true,
+        content: "Invalid URL: must be http or https",
+      },
+    ]);
+
+    await expect(
+      runRuntimeToolFixture(
+        env,
+        {
+          toolName: "web_fetch",
+          toolCoverage: {
+            bucket: "openclaw-dynamic-integration",
+            expectedLayer: "openclaw-dynamic",
+          },
+        },
+        {
+          createSession: vi.fn(async (_env, _label, key) => key!),
+          readEffectiveTools: vi.fn(async () => new Set(["web_fetch"])),
+          runAgentPrompt: vi.fn(async () => ({})),
+          fetchJson: vi.fn(),
+          ensureImageGenerationConfigured: vi.fn(),
+        },
+      ),
+    ).resolves.toContain("web_fetch live provider happy planned args");
+  });
+
   it("skips Codex-native fixtures when only OpenClaw dynamic exposure evidence is absent", async () => {
     const env = await makeEnv({
       mock: { baseUrl: "http://127.0.0.1:9999" },

--- a/extensions/qa-lab/src/runtime-tool-fixture.test.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.test.ts
@@ -563,7 +563,7 @@ describe("runtime tool fixture", () => {
         role: "tool",
         toolName: "read",
         tool_call_id: "call-read-happy",
-        content: "README contents",
+        content: "README documents invalid requests, errors, and denied inputs.",
       },
     ]);
     await writeQaSessionTranscript(env, "agent:qa:runtime-tool:read:failure", [
@@ -669,69 +669,6 @@ describe("runtime tool fixture", () => {
         },
       ),
     ).rejects.toThrow("expected live happy-path successful tool output for read");
-  });
-
-  it("allows successful live happy-path tool output to mention failure words", async () => {
-    const env = await makeEnv();
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:web_fetch:happy", [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call-web-fetch-happy",
-            name: "web_fetch",
-            input: { url: "https://example.com/" },
-          },
-        ],
-      },
-      {
-        role: "tool",
-        toolName: "web_fetch",
-        tool_call_id: "call-web-fetch-happy",
-        content: "The page documents invalid requests, errors, and denied inputs.",
-      },
-    ]);
-    await writeQaSessionTranscript(env, "agent:qa:runtime-tool:web_fetch:failure", [
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call-web-fetch-failure",
-            name: "web_fetch",
-            input: { url: "file:///etc/passwd" },
-          },
-        ],
-      },
-      {
-        role: "tool",
-        toolName: "web_fetch",
-        tool_call_id: "call-web-fetch-failure",
-        isError: true,
-        content: "Invalid URL: must be http or https",
-      },
-    ]);
-
-    await expect(
-      runRuntimeToolFixture(
-        env,
-        {
-          toolName: "web_fetch",
-          toolCoverage: {
-            bucket: "openclaw-dynamic-integration",
-            expectedLayer: "openclaw-dynamic",
-          },
-        },
-        {
-          createSession: vi.fn(async (_env, _label, key) => key!),
-          readEffectiveTools: vi.fn(async () => new Set(["web_fetch"])),
-          runAgentPrompt: vi.fn(async () => ({})),
-          fetchJson: vi.fn(),
-          ensureImageGenerationConfigured: vi.fn(),
-        },
-      ),
-    ).resolves.toContain("web_fetch live provider happy planned args");
   });
 
   it("skips Codex-native fixtures when only OpenClaw dynamic exposure evidence is absent", async () => {

--- a/extensions/qa-lab/src/runtime-tool-fixture.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.ts
@@ -55,6 +55,7 @@ type QaRuntimeToolFixtureTranscriptToolResult = {
   tool?: string;
   text: string;
   failure: boolean;
+  hardFailure: boolean;
   structuredFailure: boolean;
 };
 
@@ -531,6 +532,19 @@ function isFailureLikeToolResult(params: {
   );
 }
 
+function isHardFailureToolResult(params: {
+  type?: string;
+  text: string;
+  isError?: unknown;
+  is_error?: unknown;
+}) {
+  return (
+    isStructuredFailureToolResult(params) ||
+    isHardFailureToolOutputText(params.text) ||
+    isWorkspaceBoundaryFailureToolOutput(params.text)
+  );
+}
+
 function isStructuredFailureToolResult(params: {
   type?: string;
   isError?: unknown;
@@ -566,6 +580,11 @@ function extractTranscriptToolResults(
         normalizeToolCallId(message.id),
       ...(tool ? { tool } : {}),
       text,
+      hardFailure: isHardFailureToolResult({
+        text,
+        isError: message.isError,
+        is_error: message.is_error,
+      }),
       structuredFailure,
       failure: isFailureLikeToolResult({
         text,
@@ -609,6 +628,12 @@ function extractTranscriptToolResults(
         normalizeToolCallId(block.id),
       ...(blockTool ? { tool: blockTool } : {}),
       text,
+      hardFailure: isHardFailureToolResult({
+        type,
+        text,
+        isError: block.isError,
+        is_error: block.is_error,
+      }),
       structuredFailure,
       failure: isFailureLikeToolResult({
         type,
@@ -1077,7 +1102,7 @@ export async function runRuntimeToolFixture(
         );
       }
     }
-    if (happyRequest.outputRequest?.failure) {
+    if (happyRequest.outputRequest?.hardFailure) {
       if (isKnownHarnessGap(config.knownHarnessGap)) {
         skipFixture(formatKnownHarnessGapDetails(toolName, config));
       }


### PR DESCRIPTION
## Summary

- distinguish hard/structured tool failures from incidental failure-related prose
- use the hard classification for live happy-path validation
- keep the broader heuristic for intentionally induced failure-path evidence

## Problem

The full release profile successfully fetched `https://example.com/` and produced a normal summary, but QA rejected the result because the fetched page content contained a word matched by the broad failure-text heuristic. Arbitrary tool output, especially web content, can legitimately discuss errors, invalid requests, or denied inputs.

## Validation

- `node scripts/run-vitest.mjs extensions/qa-lab/src/runtime-tool-fixture.test.ts` (62 passed)
- `git diff --check`
- autoreview: clean, no actionable findings

## Evidence

Failed maturity run: https://github.com/openclaw/openclaw/actions/runs/30537257802

The run log shows `web_fetch` completed against Example.com and the agent summarized it before the fixture raised `expected live happy-path successful tool output for web_fetch`.
