### PR TITLE
fix(qa): make Slack invalid-block fallback probe deterministic

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.invalid-blocks.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.invalid-blocks.ts
@@ -8,7 +8,10 @@ import {
 
 function buildSlackInvalidBlocksTableRow(index: number) {
   const rowId = String(index).padStart(3, "0");
-  return [`row-${rowId}`, `value-${rowId}`] as const;
+  // Cross both independently documented native-table limits. Slack has
+  // accepted the over-row-limit shape alone, so the probe also exceeds the
+  // 10,000-character aggregate cell contract.
+  return [`row-${rowId}`, `value-${rowId}-${"x".repeat(96)}`] as const;
 }
 
 export function buildSlackInvalidBlocksTableProbe() {
@@ -32,8 +35,13 @@ export function buildSlackInvalidBlocksTableProbe() {
     SLACK_QA_INVALID_TABLE_HEADERS.join("\t"),
     ...dataRows.map((row) => row.join("\t")),
   ].join("\n");
+  const cellCharacterCount = [...SLACK_QA_INVALID_TABLE_HEADERS, ...dataRows.flat()].reduce(
+    (total, value) => total + Array.from(value).length,
+    0,
+  );
   return {
     block,
+    cellCharacterCount,
     dataRowCount: dataRows.length,
     fallbackText,
     firstRowText: buildSlackInvalidBlocksTableRow(1).join("\t"),

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -993,13 +993,15 @@ describe("Slack live QA runtime helpers", () => {
       { type: "raw_text", text: "Row" },
       { type: "raw_text", text: "Value" },
     ]);
-    expect(probe.firstRowText).toBe("row-001\tvalue-001");
-    expect(probe.finalRowText).toBe("row-101\tvalue-101");
+    expect(probe.cellCharacterCount).toBeGreaterThan(10_000);
+    expect(probe.firstRowText).toMatch(/^row-001\tvalue-001-x{96}$/u);
+    expect(probe.finalRowText).toMatch(/^row-101\tvalue-101-x{96}$/u);
     expect(probe.fallbackText.split("\n")).toContain(probe.firstRowText);
     expect(probe.fallbackText.split("\n")).toContain(probe.finalRowText);
   });
 
   it("proves the public Slack send path stores one complete formatting-disabled fallback", async () => {
+    const probe = testing.buildSlackInvalidBlocksTableProbe();
     const invalidBlocksError = Object.assign(new Error("An API error occurred: invalid_blocks"), {
       code: "slack_webapi_platform_error",
       data: { error: "invalid_blocks", ok: false },
@@ -1060,8 +1062,8 @@ describe("Slack live QA runtime helpers", () => {
     expect(fallbackRequest).toMatchObject({ mrkdwn: false });
     const fallbackText = typeof fallbackRequest?.text === "string" ? fallbackRequest.text : "";
     expect(fallbackText).toBe(nativeRequest?.text);
-    expect(fallbackText.split("\n")).toContain("row-001\tvalue-001");
-    expect(fallbackText.split("\n")).toContain("row-101\tvalue-101");
+    expect(fallbackText.split("\n")).toContain(probe.firstRowText);
+    expect(fallbackText.split("\n")).toContain(probe.finalRowText);
     expect(result.message).toMatchObject({
       text: fallbackText,
       ts: "2.000000",


### PR DESCRIPTION
## Summary

- make the Slack invalid-block fallback probe exceed the aggregate cell-character limit
- retain the existing over-row-limit shape
- assert the generated probe crosses the documented 10,000-character boundary

## Problem

The release profile expected Slack to reject a 101-data-row native table, but Slack accepted that payload in one API attempt. The scenario therefore never exercised OpenClaw's `invalid_blocks` text-fallback retry.

Slack's current table-block contract independently caps aggregate cell content at 10,000 characters: https://docs.slack.dev/reference/block-kit/blocks/table-block/

The probe now crosses both limits while keeping the complete formatting-disabled fallback below Slack's ordinary message-text capacity.

## Validation

- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts` (43 passed)
- `git diff --check`
- autoreview: clean, no actionable findings

## Evidence

Failed maturity run: https://github.com/openclaw/openclaw/actions/runs/30537257802

Observed failure: `expected exactly two Slack API attempts; observed 1`.
