### PR TITLE
fix(qa): tolerate loaded-runner bus delivery stalls

### DIFF
--- a/extensions/qa-channel/src/bus-client.test.ts
+++ b/extensions/qa-channel/src/bus-client.test.ts
@@ -321,7 +321,7 @@ describe("qa-bus client", () => {
       }),
     ).rejects.toMatchObject({ name: "AbortError", cause: { name: "TimeoutError" } });
     expect(timeoutSpy).toHaveBeenCalledTimes(1);
-    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
   });
 
   it("bounds message responses that stall after headers", async () => {
@@ -360,7 +360,7 @@ describe("qa-bus client", () => {
     timeout.abort(new DOMException("qa-bus request timed out", "TimeoutError"));
     await rejection;
     expect(timeoutSpy).toHaveBeenCalledTimes(1);
-    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
   });
 
   it("keeps long polls within the server wait window plus response grace", async () => {

--- a/extensions/qa-channel/src/bus-client.ts
+++ b/extensions/qa-channel/src/bus-client.ts
@@ -48,6 +48,10 @@ type JsonResult<T> = Promise<T>;
 const QA_BUS_JSON_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 /** Total deadline for local qa-bus POST requests and long-poll response grace. */
 const QA_BUS_REQUEST_TIMEOUT_MS = 10_000;
+// Final replies can contend with CPU-heavy QA lanes on the shared release
+// runner. Keep delivery inside the outer turn budget without treating a brief
+// local scheduling stall as a channel failure.
+const QA_BUS_MESSAGE_REQUEST_TIMEOUT_MS = 30_000;
 /** Total deadline for local qa-bus state requests. */
 const QA_BUS_STATE_TIMEOUT_MS = 10_000;
 
@@ -190,7 +194,9 @@ export async function sendQaBusMessage(params: {
   attachments?: import("./protocol.js").QaBusAttachment[];
   toolCalls?: QaBusToolCall[];
 }) {
-  return await postJson<{ message: QaBusMessage }>(params.baseUrl, "/v1/outbound/message", params);
+  return await postJson<{ message: QaBusMessage }>(params.baseUrl, "/v1/outbound/message", params, {
+    timeoutMs: QA_BUS_MESSAGE_REQUEST_TIMEOUT_MS,
+  });
 }
 
 export async function createQaBusThread(params: {


### PR DESCRIPTION
## Summary

- give QA-channel final-message POSTs a 30-second local deadline
- retain the existing 10-second default for other bus requests and long-poll grace
- keep delivery bounded by the scenario's outer turn timeout

## Problem

The 100-turn soak's first runtime cell completed model generation for turn 35, then its QA-channel outbound POST hit the fixed 10-second local deadline while Matrix-heavy lanes were sharing the release runner. The channel supervisor restarted. The subsequent attempt completed all 100 turns, confirming this was a QA transport scheduling stall rather than model or session-state failure.

Only final-message delivery receives the wider deadline; ordinary QA bus operations are unchanged.

## Validation

- `node scripts/run-vitest.mjs extensions/qa-channel/src/bus-client.test.ts` (11 passed)
- `git diff --check`
- autoreview: clean, no actionable findings

## Evidence

Failed maturity run: https://github.com/openclaw/openclaw/actions/runs/30537257802

At turn 35 the log records successful model output, followed 10.024 seconds later by `OutboundDeliveryError` / `TimeoutError` and a QA-channel auto-restart. The next attempt reached `SOAK-100-100`.
