### PR TITLE
fix(qa): reset Matrix streaming state between scenarios

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
@@ -4,9 +4,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const buildMatrixQaConfig = vi.hoisted(() =>
   vi.fn(() => ({ channels: { matrix: { execApprovals: { enabled: true } } } })),
 );
+const runMatrixQaCanary = vi.hoisted(() =>
+  vi.fn(async () => ({
+    driverEventId: "$canary-driver",
+    reply: { eventId: "$canary-reply" },
+    token: "MATRIX_QA_CANARY",
+  })),
+);
 
 vi.mock("../substrate/config.js", () => ({ buildMatrixQaConfig }));
-vi.mock("./scenario-runtime-room.js", () => ({ runMatrixQaCanary: vi.fn() }));
+vi.mock("./scenario-runtime-room.js", () => ({ runMatrixQaCanary }));
 
 import { createMatrixQaScenarioEnvironment } from "./scenario-environment.js";
 import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
@@ -74,12 +81,12 @@ describe("matrix scenario environment", () => {
       } as never,
     });
     const input = {
-      config: {},
+      config: { matrixRequireCanary: true },
       gateway,
       outputDir: "/tmp/matrix-qa/output",
       scenarioId: "matrix-observer-reset",
       scenarioTitle: "Matrix observer reset",
-      timeoutMs: 1_000,
+      timeoutMs: 8_000,
       waitForConfigRestartSettle: vi.fn(),
     };
     const first = await environment.prepareFlow(input);
@@ -93,6 +100,7 @@ describe("matrix scenario environment", () => {
 
     expect(second.scenarioContext.syncState).toEqual({});
     expect(second.scenarioContext.syncStreams).toEqual({});
+    expect(runMatrixQaCanary).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 60_000 }));
   });
 
   it("waits for the changed Matrix account to restart before accepting readiness", async () => {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
@@ -18,6 +18,8 @@ type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>>;
 type FlowPreparationInput = Parameters<NonNullable<AdapterDefinition["prepareFlow"]>>[0];
 type MatrixQaHarness = Awaited<ReturnType<typeof startMatrixQaHarness>>;
 
+const MATRIX_QA_CANARY_TIMEOUT_MS = 60_000;
+
 type MatrixQaScenarioEnvironmentParams = {
   accountId: string;
   harness: MatrixQaHarness;
@@ -395,7 +397,12 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
         }),
     } satisfies MatrixQaScenarioContext;
     if (input.config.matrixRequireCanary === true && !canary) {
-      canary = await runMatrixQaCanary(scenarioContext);
+      canary = await runMatrixQaCanary({
+        ...scenarioContext,
+        // The scenario timeout can intentionally be a short no-reply window.
+        // A live model round trip needs its own bounded preparation budget.
+        timeoutMs: Math.max(input.timeoutMs, MATRIX_QA_CANARY_TIMEOUT_MS),
+      });
     }
     scenarioContext.canary = canary;
     return { scenarioContext };

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/config.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/config.test.ts
@@ -73,6 +73,12 @@ describe("matrix qa config", () => {
       requireMention: true,
     });
     expect(sut?.replyToMode).toBe("off");
+    expect(sut?.streaming).toEqual({
+      block: { enabled: false },
+      chunkMode: "length",
+      mode: "off",
+      preview: { toolProgress: true },
+    });
     expect(sut?.threadReplies).toBe("inbound");
     expect(next.messages?.groupChat?.visibleReplies).toBe("automatic");
   });
@@ -233,7 +239,12 @@ describe("matrix qa config", () => {
 
     expect(reset.channels?.matrix?.accounts?.sut?.autoJoin).toBeUndefined();
     expect(reset.channels?.matrix?.accounts?.sut?.autoJoinAllowlist).toBeUndefined();
-    expect(reset.channels?.matrix?.accounts?.sut?.streaming).toBeUndefined();
+    expect(reset.channels?.matrix?.accounts?.sut?.streaming).toEqual({
+      block: { enabled: false },
+      chunkMode: "length",
+      mode: "off",
+      preview: { toolProgress: true },
+    });
   });
 
   it("normalizes Matrix QA overrides into the written account config", () => {
@@ -264,6 +275,7 @@ describe("matrix qa config", () => {
     expect(account?.groupPolicy).toBe("open");
     expect(account?.streaming).toEqual({
       block: { enabled: true },
+      chunkMode: "length",
       mode: "partial",
       preview: { toolProgress: true },
     });
@@ -298,10 +310,14 @@ describe("matrix qa config", () => {
     });
 
     expect(optedOut.channels?.matrix?.accounts?.sut?.streaming).toEqual({
+      block: { enabled: false },
+      chunkMode: "length",
       mode: "quiet",
       preview: { toolProgress: false },
     });
     expect(reset.channels?.matrix?.accounts?.sut?.streaming).toEqual({
+      block: { enabled: false },
+      chunkMode: "length",
       mode: "quiet",
       preview: { toolProgress: true },
     });

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/config.ts
@@ -437,20 +437,16 @@ function buildMatrixQaChannelAccountConfig(params: {
   );
   // Matrix accepts only the nested streaming shape; harness overrides keep
   // their scalar/boolean vocabulary and normalize here before config write.
-  const streamingSlots = {
-    ...(params.overrides?.streaming !== undefined
-      ? {
-          mode: resolveMatrixQaStreamingMode(params.overrides.streaming),
-          preview: { toolProgress: params.snapshot.streamingPreviewToolProgress },
-        }
-      : {}),
-    ...(params.snapshot.chunkMode !== undefined ? { chunkMode: params.snapshot.chunkMode } : {}),
-    ...(params.overrides?.blockStreaming !== undefined
-      ? { block: { enabled: params.snapshot.blockStreaming } }
-      : {}),
+  // Scenario config is applied with config.patch, which recursively merges objects.
+  // Write every slot so a prior streaming scenario cannot leak into the next one.
+  const streamingConfig = {
+    streaming: {
+      block: { enabled: params.snapshot.blockStreaming },
+      chunkMode: params.snapshot.chunkMode ?? "length",
+      mode: params.snapshot.streaming,
+      preview: { toolProgress: params.snapshot.streamingPreviewToolProgress },
+    },
   };
-  const streamingConfig =
-    Object.keys(streamingSlots).length > 0 ? { streaming: streamingSlots } : {};
   const startupVerificationConfig =
     params.snapshot.startupVerification !== undefined
       ? { startupVerification: params.snapshot.startupVerification }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a Matrix streaming scenario could leave preview and block-streaming settings active for later shared-suite scenarios. Those later scenarios delivered the expected reply but the verifier waited for a non-streaming event until timeout. It also prevents an intentionally short scenario timeout from prematurely failing the live Matrix canary.

## Why This Change Was Made

The Matrix QA config builder now writes every canonical streaming slot on every scenario boundary, including explicit off/default values, so recursive config patches cannot retain prior state. Canary preparation uses a separate bounded 60-second live-round-trip budget while the scenario keeps its own timeout.

## User Impact

No product behavior changes. Full QA release profiles can run Matrix streaming and ordinary Matrix scenarios in the same shared worker without false timeouts.

## Evidence

- Run 30537257802 delivered the exact expected markers for matrix-thread-root-preservation, matrix-secondary-room-open-trigger, and matrix-unsupported-media-safe as replacement events after streaming state leaked.
- The isolated matrix-reaction-not-a-reply canary started its provider request only after the scenario 8-second preparation budget had expired.
- 38 focused Matrix QA tests pass across scenario environment, config, flow catalog, shared runtime, and event normalization.
- Targeted oxlint passes.
- Autoreview clean after one rejected generic-helper design was removed.