### PR TITLE
fix(config): config patch deletes three array entries when asked to delete one

### DIFF
--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -300,8 +300,10 @@ export async function runConfigOperations(params: {
   const explicitSetPaths: PathSegment[][] = [];
   for (const operation of operations) {
     if (operation.mutation === "delete") {
-      unsetAtPath(next, operation.setPath);
-      unsetPaths.push(operation.setPath);
+      const unsetResult = unsetAtPath(next, operation.setPath);
+      if (!unsetResult.removed || unsetResult.leafContainer !== "array") {
+        unsetPaths.push(operation.setPath);
+      }
       continue;
     }
     explicitSetPaths.push(operation.setPath);

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2471,6 +2471,71 @@ describe("config cli", () => {
       });
     });
 
+    it("removes only the requested array element in config patch", async () => {
+      const resolved = {
+        gateway: {
+          controlUi: {
+            allowedOrigins: [
+              "https://one.example",
+              "https://two.example",
+              "https://three.example",
+              "https://four.example",
+            ],
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      const pathname = writeTempJson5File("openclaw-config-patch-array-delete", {
+        gateway: { controlUi: { allowedOrigins: { "0": null } } },
+      });
+      try {
+        await runConfigCommand(["config", "patch", "--file", pathname]);
+      } finally {
+        fs.rmSync(pathname, { force: true });
+      }
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = firstWrittenConfig() as Record<string, unknown>;
+      expect(
+        ((written.gateway as Record<string, unknown>).controlUi as Record<string, unknown>)
+          .allowedOrigins,
+      ).toEqual(["https://two.example", "https://three.example", "https://four.example"]);
+      expect(firstWriteConfigOptions()?.unsetPaths).toBeUndefined();
+    });
+
+    it("keeps write-level unset paths for object keys in config patch", async () => {
+      const resolved = {
+        channels: {
+          discord: {
+            guilds: {
+              "123": { channels: ["general"] },
+              "456": { channels: ["alerts"] },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      const pathname = writeTempJson5File("openclaw-config-patch-object-delete", {
+        channels: { discord: { guilds: { "123": null } } },
+      });
+      try {
+        await runConfigCommand(["config", "patch", "--file", pathname]);
+      } finally {
+        fs.rmSync(pathname, { force: true });
+      }
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = firstWrittenConfig() as Record<string, unknown>;
+      expect(
+        ((written.channels as Record<string, unknown>).discord as Record<string, unknown>).guilds,
+      ).toEqual({ "456": { channels: ["alerts"] } });
+      expect(firstWriteConfigOptions()?.unsetPaths).toEqual([
+        ["channels", "discord", "guilds", "123"],
+      ]);
+    });
+
     it("treats empty object config patches as recursive merges", async () => {
       const resolved = {
         channels: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users deleting a single entry from a config array with `openclaw config patch` would silently lose that entry plus the two that follow it, while the CLI reported success.

Any patch whose leaf is `null` at an array index, which is the documented way to delete through `config patch`, removes three elements instead of one. The CLI prints `Applied 1 config update(s). Restart the gateway to apply.` with no warning, so the loss is silent and deterministic. On a two-entry array the whole array is emptied.

This affects every array config surface: `agents.list` (whole agents with their model and auth wiring, which is how the sibling defect was originally reported in #76290), `gateway.controlUi.allowedOrigins`, and the rest. For `gateway.controlUi.allowedOrigins` an emptied array silently changes which origins the Control UI accepts.

Reached with no flags: `openclaw config patch --file p.json` (or `--stdin`).

## Why This Change Was Made

Root cause, `src/cli/config-cli-runner.ts` in `runConfigOperations` (before):

```ts
if (operation.mutation === "delete") {
  unsetAtPath(next, operation.setPath);
  unsetPaths.push(operation.setPath);
  continue;
}
```

A `delete` operation does two things: it splices the element out of the in-memory config through `unsetAtPath`, and it also pushes the same path into `unsetPaths`, which is handed to the writer. `writeConfigFileFromContext` replays every unset path against the persist candidate twice, at `src/config/io.write.ts:186` and again at `src/config/io.write.ts:252`.

For an object key that replay is idempotent and serves a real purpose: it forces the key out of the authored and include-projected candidate. For an array index it is not idempotent, because `unsetPathForWriteAt` does `next.splice(index, 1)` (`src/config/config-path-mutation.ts:29-31`), so each replay removes one more neighbour. One requested deletion therefore removes three elements.

This exact bug was already fixed once for the sibling command. Commit `fb73f2161e` ("fix(config): unset array index once", fixes #76290) introduced `UnsetAtPathResult.leafContainer` and used it in `runConfigUnset` to suppress `unsetPaths` for array leaves (`src/cli/config-cli.ts:268-272`). `runConfigOperations` ignored the `leafContainer` that `unsetAtPath` already returns and pushed unconditionally. It is the sibling surface that fix missed.

The fix applies the same guard at the same boundary (after):

```ts
if (operation.mutation === "delete") {
  const unsetResult = unsetAtPath(next, operation.setPath);
  if (!unsetResult.removed || unsetResult.leafContainer !== "array") {
    unsetPaths.push(operation.setPath);
  }
  continue;
}
```

An array leaf is already removed from `nextConfig`, so it does not need a write-level unset path and must not get one. Object keys keep theirs, so authored and include-projected key removal is unchanged. A path that was not present still forwards its unset path, matching both today's behavior and the sibling exactly.

Boundary and non-goals: `runConfigOperations` owns what goes into `unsetPaths` and is the only place that knows whether the leaf it just removed lived in an array, so both delete surfaces now agree. I considered the broader alternative of making `applyUnsetPathsForWrite` idempotent for array indices by matching on the removed value instead of the index, and did not take it: the writer never receives the removed value, `resolvePersistCandidateForWrite` consumes the same `unsetPaths` for a different purpose, and the second replay at `io.write.ts:252` is deliberate defensive re-pruning after `restoreEnvVarRefs` and `restoreAuthoredTildePathsForWrite` can reintroduce authored keys. Reshaping that shared writer to satisfy one caller is a much wider blast radius for the same user-visible outcome.

Sibling surfaces: `config unset` was fixed already and is unaffected, verified live below on the identical path with identical results before and after this patch. `config set --batch-json` and `config set --batch-file` route through the same `runConfigOperations` and are fixed by the same change.

Adjacent open work: #114977 touches `src/cli/config-cli-runner.ts` and `src/cli/config-cli.test.ts`, but it adds a new exported path guard and does not change the delete branch of `runConfigOperations`. Adjacent, not duplicate; a trivial rebase overlap in the shared files is possible.

## User Impact

Deleting one entry from a config array with `openclaw config patch` now removes exactly that entry. Removing a stale origin from `gateway.controlUi.allowedOrigins`, or one agent from `agents.list`, no longer destroys the neighbouring records, and a two-entry allowlist is no longer emptied by a single deletion. Object-key deletion, and every other `config patch` behavior, is unchanged.

## Evidence

Live before/after against the real CLI runtime is in the Real behavior proof section below, pinned to head `b7de4cdf3252738038942c4d305729be9089e26c` and captured on pristine main `9e8cc6fe8a6f516bc8d4d976f3132b79a108457a` with identical inputs.

Local gates:

- `node scripts/run-vitest.mjs src/cli/config-cli.test.ts` -> 155 passed.
- `node scripts/run-vitest.mjs src/config/io.write-config.test.ts src/config/io.write-prepare.test.ts src/cli/config-cli.test.ts` -> all shards passed.
- The new array-delete regression case fails on pristine main (`expected [ 'gateway', 'controlUi', 'allowedOrigins', '0' ] to be undefined`, 1 failed / 154 passed) and passes with this patch.
- A second new case pins the object-key path so the guard cannot over-apply: it asserts `unsetPaths` is still forwarded for `channels.discord.guilds.123`.
- `oxlint src/cli/config-cli-runner.ts src/cli/config-cli.test.ts` -> clean.
- `oxfmt --check src/cli/config-cli-runner.ts src/cli/config-cli.test.ts` -> all matched files use the correct format.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` -> clean.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json` -> clean.
- `CHANGELOG.md` intentionally untouched per `AGENTS.md` (release-only).

## Real behavior proof

Behavior addressed: `openclaw config patch` given a null leaf at one array index deletes that element plus the two following it, and still reports success.
Real environment tested: the real `runConfigPatch` and `runConfigUnset` entry points from `src/cli/config-cli.ts`, driven against an isolated `HOME` and `OPENCLAW_STATE_DIR` with a real on-disk `openclaw.json`, on pristine main 9e8cc6fe8a6f516bc8d4d976f3132b79a108457a and on the patched tree b7de4cdf3252738038942c4d305729be9089e26c. Nothing was stubbed: the real patch reader, the real operation builder, the real config loader, the real validator, and the real config file writer all ran, and every value below is read back from the config file on disk after the run.
Exact steps or command run after this patch: seed `$OPENCLAW_STATE_DIR/openclaw.json` with `{"gateway":{"controlUi":{"allowedOrigins":[...]}}}`, write `p.json` containing `{"gateway":{"controlUi":{"allowedOrigins":{"0":null}}}}`, call `runConfigPatch({cliOptions:{file:"p.json"}})`, then read `gateway.controlUi.allowedOrigins` back from the config file. Repeated with a two-entry array, and with `runConfigUnset({path:"gateway.controlUi.allowedOrigins[0]"})` on the same seed for contrast.
Evidence after fix:
```
# BEFORE (pristine main 9e8cc6fe8a6f516bc8d4d976f3132b79a108457a)
--- four-entry allowlist, config patch deleting index 0 ---
BEFORE: ["https://one.example","https://two.example","https://three.example","https://four.example"]
patch : {"gateway":{"controlUi":{"allowedOrigins":{"0":null}}}}
Applied 1 config update(s). Restart the gateway to apply.
AFTER : ["https://four.example"]
--- two-entry allowlist, config patch deleting index 0 ---
BEFORE: ["https://stale.example","https://keep-me.example"]
patch : {"gateway":{"controlUi":{"allowedOrigins":{"0":null}}}}
Applied 1 config update(s). Restart the gateway to apply.
AFTER : []
--- same path via config unset, for contrast ---
BEFORE: ["https://one.example","https://two.example","https://three.example","https://four.example"]
Removed gateway.controlUi.allowedOrigins[0]. Restart the gateway to apply.
AFTER : ["https://two.example","https://three.example","https://four.example"]

# AFTER (this patch b7de4cdf3252738038942c4d305729be9089e26c, identical inputs)
--- four-entry allowlist, config patch deleting index 0 ---
BEFORE: ["https://one.example","https://two.example","https://three.example","https://four.example"]
patch : {"gateway":{"controlUi":{"allowedOrigins":{"0":null}}}}
Applied 1 config update(s). Restart the gateway to apply.
AFTER : ["https://two.example","https://three.example","https://four.example"]
--- two-entry allowlist, config patch deleting index 0 ---
BEFORE: ["https://stale.example","https://keep-me.example"]
patch : {"gateway":{"controlUi":{"allowedOrigins":{"0":null}}}}
Applied 1 config update(s). Restart the gateway to apply.
AFTER : ["https://keep-me.example"]
--- same path via config unset, for contrast ---
BEFORE: ["https://one.example","https://two.example","https://three.example","https://four.example"]
Removed gateway.controlUi.allowedOrigins[0]. Restart the gateway to apply.
AFTER : ["https://two.example","https://three.example","https://four.example"]
```
Observed result after fix: on pristine main the four-entry allowlist drops from four origins to one and the two-entry allowlist is emptied, while `config unset` on the identical path correctly keeps three; with this patch the identical `config patch` input keeps exactly the three surviving origins and the two-entry allowlist keeps `https://keep-me.example`, matching `config unset`, with the success message unchanged.
What was not tested: no live gateway was started to observe the resulting origin policy at runtime; the full build was not run; only `gateway.controlUi.allowedOrigins` shaped arrays were exercised live, not every array config surface.
