### PR TITLE
perf(macos): reuse Tailscale discovery session

### DIFF
--- a/apps/macos/Sources/OpenClawDiscovery/TailscaleServeGatewayDiscovery.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/TailscaleServeGatewayDiscovery.swift
@@ -12,6 +12,7 @@ enum TailscaleServeGatewayDiscovery {
     private static let maxCandidates = 32
     private static let probeConcurrency = 6
     private static let defaultProbeTimeoutSeconds: TimeInterval = 1.6
+    private static let probeSession = URLSession(configuration: .ephemeral)
 
     struct DiscoveryContext {
         var tailscaleStatus: @Sendable () async -> String?
@@ -218,16 +219,13 @@ enum TailscaleServeGatewayDiscovery {
         components.host = host
         guard let url = components.url else { return false }
 
-        let config = URLSessionConfiguration.ephemeral
-        config.timeoutIntervalForRequest = max(0.5, timeout)
-        config.timeoutIntervalForResource = max(0.5, timeout)
-        let session = URLSession(configuration: config)
-        let task = session.webSocketTask(with: url)
+        // Discovery fans out and retries during startup. Reuse the session;
+        // AsyncTimeout owns each deadline and every websocket task owns its cancel.
+        let task = self.probeSession.webSocketTask(with: url)
         task.resume()
 
         defer {
             task.cancel(with: .goingAway, reason: nil)
-            session.invalidateAndCancel()
         }
 
         do {
@@ -270,6 +268,12 @@ enum TailscaleServeGatewayDiscovery {
 
         return event == "connect.challenge"
     }
+
+    #if DEBUG
+    static func probeSessionIdentifierForTesting() -> ObjectIdentifier {
+        ObjectIdentifier(self.probeSession)
+    }
+    #endif
 }
 
 private struct TailscaleStatus: Decodable {

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateVoiceEarsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateVoiceEarsTests.swift
@@ -21,7 +21,6 @@ struct AppStateVoiceEarsTests {
         state.triggerVoiceEars(ttl: 60)
         state.triggerVoiceEars(ttl: 0.05)
 
-        try await Task.sleep(for: .milliseconds(20))
         #expect(state.earBoostActive)
 
         try await Task.sleep(for: .milliseconds(60))

--- a/apps/macos/Tests/OpenClawIPCTests/TailscaleServeGatewayDiscoveryTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TailscaleServeGatewayDiscoveryTests.swift
@@ -54,6 +54,15 @@ struct TailscaleServeGatewayDiscoveryTests {
         #expect(beacons.isEmpty)
     }
 
+    #if DEBUG
+    @Test func `reuses probe session across discovery passes`() {
+        let first = TailscaleServeGatewayDiscovery.probeSessionIdentifierForTesting()
+        let second = TailscaleServeGatewayDiscovery.probeSessionIdentifierForTesting()
+
+        #expect(first == second)
+    }
+    #endif
+
     @Test func `resolves bare executable from PATH`() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
## What Problem This Solves

Repeated macOS Tailscale Serve discovery probes created a fresh ephemeral `URLSession` for every WebSocket attempt. That repeated session setup and teardown during reconnect/discovery churn.

The branch also repairs a deterministic landing-gate failure in `AppStateVoiceEarsTests`: the test slept for 20 ms before checking a replacement ear-boost whose whole lifetime was 50 ms. Under loaded macOS CI, the task could resume after expiry and fail before proving the intended active-then-expired lifecycle.

## What Changed

- Reuse one process-scoped ephemeral `URLSession` for Tailscale discovery probes.
- Keep a separate WebSocket task per probe and cancel that task in `defer`.
- Preserve the existing `AsyncTimeout` boundary and cancellation behavior.
- Add a DEBUG-only identity hook and focused test for session reuse.
- Remove the pre-expiry sleep from the Voice Ears assertion; production behavior is unchanged.

## User Impact

macOS reconnect and discovery churn does less URLSession setup work. The additional test-only change makes the macOS landing gate reliable without changing app behavior.

## Evidence

- Exact head: `c4e1bf7eee31e48f7346c07b6dff090e8bf25c65`
- `TailscaleServeGatewayDiscoveryTests`: 7/7 passed.
- `AsyncTimeoutTests`: 6/6 passed on the exact-current-main merge proof for the unchanged discovery implementation.
- `AppStateVoiceEarsTests`: 20/20 focused local repetitions passed after the assertion fix.
- SwiftFormat 0.62.1: clean on all three touched files.
- SwiftLint 0.65.0 strict: clean on all three touched files.
- `git diff --check`: clean.
- Fresh final branch autoreview at this head: clean, confidence 0.84.
- TruffleHog: clean.

The prior PR-event CI first hit an unrelated `ChatViewModelTests` timeout flake, which cleared on rerun. It then reproduced `AppStateVoiceEarsTests.replacement expiry owns ear boost lifetime` three out of three times on the current merge result. This branch includes the already release-branch-proven one-line stabilization required to restore the landing gate.
