### PR TITLE
fix(docker): honor legacy apt package argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -267,7 +267,7 @@ ARG OPENCLAW_DOCKER_APT_PACKAGES=""
 ENV PATH="/home/node/.local/bin:${PATH}"
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
-    packages="${OPENCLAW_IMAGE_APT_PACKAGES-$OPENCLAW_DOCKER_APT_PACKAGES}"; \
+    packages="${OPENCLAW_IMAGE_APT_PACKAGES:-$OPENCLAW_DOCKER_APT_PACKAGES}"; \
     if [ -n "$packages" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $packages; \

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -1,4 +1,5 @@
 // Tests Dockerfile metadata and expected install commands.
+import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,6 +18,20 @@ const dockerSetupDockerfilePaths = ["Dockerfile", "scripts/docker/sandbox/Docker
 
 function collapseDockerContinuations(dockerfile: string): string {
   return dockerfile.replace(/\\\r?\n[ \t]*/g, " ");
+}
+
+function resolveOptionalAptPackages(dockerfile: string, env: NodeJS.ProcessEnv): string {
+  const assignment = collapseDockerContinuations(dockerfile).match(
+    /\bpackages="(\$\{OPENCLAW_IMAGE_APT_PACKAGES:-\$OPENCLAW_DOCKER_APT_PACKAGES\})";/u,
+  )?.[1];
+  if (!assignment) {
+    throw new Error("Dockerfile optional apt package assignment is missing");
+  }
+  const script = `packages="${assignment}"; printf '%s' "$packages"`;
+  return execFileSync("/bin/sh", ["-c", script], {
+    encoding: "utf8",
+    env,
+  });
 }
 
 describe("Dockerfile", () => {
@@ -80,6 +95,38 @@ describe("Dockerfile", () => {
       "ca-certificates curl git hostname lsof openssl procps python3 tini",
     );
     expect(dockerfile).toContain('ENTRYPOINT ["tini", "-s", "--"]');
+  });
+
+  it.runIf(process.platform !== "win32").each([
+    {
+      name: "preferred packages",
+      env: { OPENCLAW_IMAGE_APT_PACKAGES: "python3 wget" },
+      expected: "python3 wget",
+    },
+    {
+      name: "legacy packages when the preferred argument is empty",
+      env: {
+        OPENCLAW_IMAGE_APT_PACKAGES: "",
+        OPENCLAW_DOCKER_APT_PACKAGES: "git curl jq",
+      },
+      expected: "git curl jq",
+    },
+    {
+      name: "no packages when both arguments are absent",
+      env: {},
+      expected: "",
+    },
+    {
+      name: "preferred packages when both arguments are present",
+      env: {
+        OPENCLAW_IMAGE_APT_PACKAGES: "python3",
+        OPENCLAW_DOCKER_APT_PACKAGES: "git",
+      },
+      expected: "python3",
+    },
+  ])("resolves optional apt package args: $name", async ({ env, expected }) => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    expect(resolveOptionalAptPackages(dockerfile, env)).toBe(expected);
   });
 
   it("installs optional browser dependencies after pnpm install", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Docker builds using the documented legacy `OPENCLAW_DOCKER_APT_PACKAGES` build argument silently installed no optional packages because the newer argument is declared with an empty default.

## Why This Change Was Made

The Dockerfile now uses the shell's empty-aware fallback for the preferred argument. Preferred packages still win when supplied, legacy-only builds work again, and builds with neither argument remain unchanged.

## User Impact

Existing Docker build commands that still pass `OPENCLAW_DOCKER_APT_PACKAGES` once again install the requested apt packages instead of producing an image without them.

## Evidence

- `src/dockerfile.test.ts`: 35/35 passed, covering preferred-only, legacy-only with an empty preferred argument, neither argument, and preferred precedence when both are present.
- Source-blind Testbox Docker build passed with `OPENCLAW_IMAGE_APT_PACKAGES=` and `OPENCLAW_DOCKER_APT_PACKAGES=tree`; the built container reported `tree v2.1.0` ([run 30558865397](https://github.com/openclaw/openclaw/actions/runs/30558865397)).
- Rebased focused Testbox proof passed at exact head `96ba216e93eb08b4165a0583e03ee8c72f0f4b60` ([run 30560395446](https://github.com/openclaw/openclaw/actions/runs/30560395446)).
- Exact-head hosted CI passed in [run 30562137622](https://github.com/openclaw/openclaw/actions/runs/30562137622).
- Current source and history confirm this remains an explicit contract: `Dockerfile` says the legacy alias is still accepted as a fallback, and commit `47b8e56e3f7bca` introduced that comment, the preferred argument, and the faulty expression together. Latest `main` through `26f107071e85991de8c7f39ba8388194d34b3c0b` has no `Dockerfile` or Dockerfile-test drift from the validated base.
- Fresh Codex autoreview against the rebased branch was clean at 0.96 confidence.
- `git diff --check` passed.
- Gitcrawl and live open-PR search found no matching duplicate.
