### PR TITLE
test(qa-lab): refresh Matrix Tuwunel fixture

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -213,12 +213,13 @@ explicit subset, including portable scenarios with no channel restriction.
 Matrix live implementations live under
 `extensions/qa-lab/src/live-transports/matrix/scenarios/`.
 
-The adapter provisions a disposable Tuwunel homeserver in Docker (default
-image `ghcr.io/matrix-construct/tuwunel:v1.5.1`, server name `matrix-qa.test`,
-port `28008`), registers temporary driver, SUT, and observer users, seeds the
-required rooms, and records the redacted request/response boundary. It then
-runs the real Matrix plugin inside a child QA gateway scoped to that transport
-(no `qa-channel`) and tears the environment down.
+The adapter provisions a disposable Tuwunel homeserver in Docker (default image
+`ghcr.io/matrix-construct/tuwunel:v1.6.2`, pinned to its multi-architecture OCI
+index digest; server name `matrix-qa.test`, port `28008`), registers temporary
+driver, SUT, and observer users, seeds the required rooms, and records the
+redacted request/response boundary. It then runs the real Matrix plugin inside
+a child QA gateway scoped to that transport (no `qa-channel`) and tears the
+environment down.
 
 Common options:
 

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -221,6 +221,12 @@ redacted request/response boundary. It then runs the real Matrix plugin inside
 a child QA gateway scoped to that transport (no `qa-channel`) and tears the
 environment down.
 
+The v1.8.2 GHCR index resolves to
+`sha256:6f950bb139411a7964781e986321e395e045e4a6a52240a4dda9d23d04075f78`.
+`docker buildx imagetools inspect ghcr.io/matrix-construct/tuwunel:v1.8.2`
+reports manifests for `linux/arm64`, `linux/amd64`, `linux/amd64/v2`, and
+`linux/amd64/v3`.
+
 Common options:
 
 | Flag                     | Default           | Purpose                                                                              |

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -214,7 +214,7 @@ Matrix live implementations live under
 `extensions/qa-lab/src/live-transports/matrix/scenarios/`.
 
 The adapter provisions a disposable Tuwunel homeserver in Docker (default image
-`ghcr.io/matrix-construct/tuwunel:v1.6.2`, pinned to its multi-architecture OCI
+`ghcr.io/matrix-construct/tuwunel:v1.8.2`, pinned to its multi-architecture OCI
 index digest; server name `matrix-qa.test`, port `28008`), registers temporary
 driver, SUT, and observer users, seeds the required rooms, and records the
 redacted request/response boundary. It then runs the real Matrix plugin inside

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,7 +70,7 @@
     },
     {
       "source": "/concepts/qa-matrix",
-      "destination": "/concepts/qa-e2e-automation#matrix-smoke-lanes"
+      "destination": "/concepts/qa-e2e-automation#matrix-live-lane"
     },
     {
       "source": "/plugins/reference/qa-matrix",

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime-internals.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime-internals.ts
@@ -3,7 +3,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { FetchLike } from "../../../docker-runtime.js";
 
-const MATRIX_QA_DEFAULT_IMAGE = "ghcr.io/matrix-construct/tuwunel:v1.5.1";
+const MATRIX_QA_DEFAULT_IMAGE =
+  "ghcr.io/matrix-construct/tuwunel:v1.6.2@sha256:43ca6a5c13841b4e40c99370ab1518b5692953ee3b661f91ee10d002249af375";
 const MATRIX_QA_DEFAULT_SERVER_NAME = "matrix-qa.test";
 export const MATRIX_QA_INTERNAL_PORT = 8008;
 export const MATRIX_QA_SERVICE = "matrix-qa-homeserver";

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime-internals.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime-internals.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { FetchLike } from "../../../docker-runtime.js";
 
 const MATRIX_QA_DEFAULT_IMAGE =
-  "ghcr.io/matrix-construct/tuwunel:v1.6.2@sha256:43ca6a5c13841b4e40c99370ab1518b5692953ee3b661f91ee10d002249af375";
+  "ghcr.io/matrix-construct/tuwunel:v1.8.2@sha256:6f950bb139411a7964781e986321e395e045e4a6a52240a4dda9d23d04075f78";
 const MATRIX_QA_DEFAULT_SERVER_NAME = "matrix-qa.test";
 export const MATRIX_QA_INTERNAL_PORT = 8008;
 export const MATRIX_QA_SERVICE = "matrix-qa-homeserver";

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
@@ -101,7 +101,7 @@ describe("matrix harness runtime", () => {
 
       const compose = await readFile(result.composeFile, "utf8");
       expect(compose).toContain(
-        "image: ghcr.io/matrix-construct/tuwunel:v1.6.2@sha256:43ca6a5c13841b4e40c99370ab1518b5692953ee3b661f91ee10d002249af375",
+        "image: ghcr.io/matrix-construct/tuwunel:v1.8.2@sha256:6f950bb139411a7964781e986321e395e045e4a6a52240a4dda9d23d04075f78",
       );
       expect(compose).toContain('      - "127.0.0.1:28008:8008"');
       expect(compose).toContain('TUWUNEL_ALLOW_ENCRYPTION: "true"');

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
@@ -100,7 +100,9 @@ describe("matrix harness runtime", () => {
       });
 
       const compose = await readFile(result.composeFile, "utf8");
-      expect(compose).toContain("image: ghcr.io/matrix-construct/tuwunel:v1.5.1");
+      expect(compose).toContain(
+        "image: ghcr.io/matrix-construct/tuwunel:v1.6.2@sha256:43ca6a5c13841b4e40c99370ab1518b5692953ee3b661f91ee10d002249af375",
+      );
       expect(compose).toContain('      - "127.0.0.1:28008:8008"');
       expect(compose).toContain('TUWUNEL_ALLOW_ENCRYPTION: "true"');
       expect(compose).toContain('TUWUNEL_ALLOW_REGISTRATION: "true"');


### PR DESCRIPTION
## Summary

- update the disposable Matrix QA homeserver from Tuwunel v1.5.1 to v1.8.2
- pin the v1.8.2 multi-architecture OCI index digest for reproducible runs
- avoid the documented v1.6.2 non-S3 first-upload regression
- update the focused harness assertion and canonical QA documentation
- point the retired Matrix QA page redirect at the canonical `#matrix-live-lane` section

## Validation

- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts` (14/14 passed)
- pre-rebase runtime-state `pnpm check:changed` passed on Blacksmith Testbox (run 30565436316)
- runtime `$autoreview` clean with no actionable findings (0.99 confidence)
- `pnpm docs:list` passed
- `pnpm check:docs` passed: formatting, Markdown lint, MDX, glossary, 6,418 internal links with zero broken, and docs-map consistency
- redirect `$autoreview` clean with no actionable findings (0.98 confidence)

### GHCR manifest provenance

Command: `docker buildx imagetools inspect ghcr.io/matrix-construct/tuwunel:v1.8.2`

```text
media type: application/vnd.oci.image.index.v1+json
index digest: sha256:6f950bb139411a7964781e986321e395e045e4a6a52240a4dda9d23d04075f78
platforms:
  linux/arm64
  linux/amd64
  linux/amd64/v2
  linux/amd64/v3
```

The checked-in default uses that exact tag and index digest.

### Live Matrix proof

Current HEAD: `9136f8a4c6fa6641f30be8a58ce1a572fd495c2a`  
Live runtime proof source commit: `288304dd01428e857a74e39287b9682d0e165953` (pre-rebase)  
Patch-equivalent rebased runtime commit: `35cdc6467967eccb2f5202fb4fe95ed6bcc2c334`  
The runtime-affecting commit is patch-equivalent across the rebase; later commits only add GHCR provenance documentation and correct the retired-page redirect.  
Image: `ghcr.io/matrix-construct/tuwunel:v1.8.2@sha256:6f950bb139411a7964781e986321e395e045e4a6a52240a4dda9d23d04075f78`

```text
matrix-media-type-coverage: PASS
  production Matrix client: true
  live Matrix homeserver: true
  exact default image: true
  JPEG upload/event/reply: PASS
  PDF upload/event/reply: PASS
  EPUB upload/event/reply: PASS
  WAV upload/event/reply: PASS
  MP4 upload/event/reply: PASS
  observed provider events: 5
  matched replies: 5

matrix-homeserver-restart-resume: PASS
  production Matrix client: true
  live Matrix homeserver: true
  exact default image: true
  post-restart driver event: true
  post-restart reply: true
```

The historical v1.5.1 restart failure did not reproduce on the current Docker host, so this remains a maintained QA dependency refresh rather than a product-runtime fix.