### PR TITLE
fix(openai): cap GPT-Live delegation responses

### DIFF
--- a/extensions/openai/realtime-quicksilver-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.test.ts
@@ -370,6 +370,31 @@ describe("OpenAIQuicksilverVoiceBridge", () => {
     });
   });
 
+  it("bounds direct tool results before sideband sends", async () => {
+    const harness = createHarness();
+    await harness.bridge.connect();
+
+    harness.socket.serverEvent({
+      type: "delegation.created",
+      item: {
+        type: "delegation",
+        target: "client",
+        id: "delegation-large",
+        content: [{ type: "input_text", text: "summarize everything" }],
+      },
+    });
+    harness.bridge.submitToolResult("delegation-large", { text: "x".repeat(10_000) });
+
+    const appends = sentEvents(harness.socket).filter(
+      (event) => event.type === "delegation.context.append",
+    );
+    expect(appends.length).toBeGreaterThan(0);
+    expect(appends.length).toBeLessThanOrEqual(11);
+    expect(
+      appends.map((event) => (event.content as Array<{ text: string }>)[0]?.text ?? "").join(""),
+    ).toMatch(/^x+ \[truncated\]$/);
+  });
+
   it("normalizes assistant completion to the shared response lifecycle", async () => {
     const harness = createHarness();
     await harness.bridge.connect();

--- a/extensions/openai/realtime-quicksilver-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-bridge.ts
@@ -22,6 +22,7 @@ import {
   type OpenAIQuicksilverSocketFactory,
 } from "./realtime-quicksilver-sideband.js";
 import {
+  boundOpenAIQuicksilverDelegationResult,
   buildOpenAIQuicksilverSessionUpdate,
   buildOpenAIQuicksilverWebSocketUrl,
   chunkOpenAIQuicksilverAppendText,
@@ -342,13 +343,13 @@ export class OpenAIQuicksilverVoiceBridge implements RealtimeVoiceBridge {
     options?: RealtimeVoiceToolResultOptions,
   ): void {
     const channel = options?.suppressResponse || options?.willContinue ? "commentary" : "speakable";
-    const type = this.activeDelegations.has(callId)
-      ? "delegation.context.append"
-      : "session.context.append";
+    const isDelegation = this.activeDelegations.has(callId);
+    const type = isDelegation ? "delegation.context.append" : "session.context.append";
+    const text = toolResultText(result);
     this.sendContext(
       type,
-      type === "delegation.context.append" ? callId : undefined,
-      toolResultText(result),
+      isDelegation ? callId : undefined,
+      isDelegation ? boundOpenAIQuicksilverDelegationResult(text) : text,
       channel,
     );
     if (!options?.willContinue) {

--- a/extensions/openai/realtime-quicksilver-delegation.test.ts
+++ b/extensions/openai/realtime-quicksilver-delegation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  boundOpenAIQuicksilverDelegationResult,
   chunkOpenAIQuicksilverAppendText,
   parseOpenAIQuicksilverEvent,
 } from "./realtime-quicksilver-wire.js";
@@ -125,6 +126,22 @@ describe("GPT-Live sideband protocol", () => {
     }
   });
 
+  it("bounds total speakable text before chunking", () => {
+    expect(boundOpenAIQuicksilverDelegationResult("  short result  ")).toBe("  short result  ");
+    const limited = boundOpenAIQuicksilverDelegationResult(
+      `${"a".repeat(1_783)}😀${"b".repeat(1_000)}`,
+    );
+    const chunks = chunkOpenAIQuicksilverAppendText(limited);
+
+    expect(limited).toMatch(/ \[truncated\]$/);
+    expect(limited.length).toBeLessThanOrEqual(1_800);
+    expect(limited).not.toContain("\uFFFD");
+    expect(chunks.length).toBeLessThanOrEqual(11);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(500);
+    }
+  });
+
   it("wraps delegated input and appends the raw speakable result", async () => {
     const runAgentConsult = vi.fn(async ({ prompt }: { prompt: string }) => ({
       text: `Result for ${prompt}`,
@@ -189,6 +206,53 @@ describe("GPT-Live sideband protocol", () => {
       await realtime.cleanup();
       expect(parseSent(socket).at(-1)).toEqual({ type: "session.close" });
       expect(socket.closed).toBe(true);
+    } finally {
+      await realtime.cleanup();
+    }
+  });
+
+  it("bounds browser delegation output before sideband sends", async () => {
+    const runAgentConsult = vi.fn(async () => ({ text: "x".repeat(10_000) }));
+    const { realtime, sockets } = createBroker({ runAgentConsult });
+    try {
+      const reservation = await realtime.broker.createBrowserSession(
+        { providerConfig: {}, model: "gpt-live-1", runAgentConsult },
+        { type: "api-key", token: "platform-key" },
+      );
+      if (reservation.transport !== "webrtc") {
+        throw new Error("Expected WebRTC reservation");
+      }
+      await realtime.handler(
+        createRequest({ token: reservation.clientSecret }),
+        createResponseHarness().res,
+      );
+      const socket = sockets[0];
+      if (!socket) {
+        throw new Error("Expected sideband socket");
+      }
+
+      emitSideband(socket, {
+        type: "delegation.created",
+        item: {
+          type: "delegation",
+          target: "client",
+          id: "delegation-large",
+          content: [{ type: "input_text", text: "summarize everything" }],
+        },
+      });
+
+      await vi.waitFor(() => {
+        const appends = parseSent(socket).filter(
+          (event) => event.type === "delegation.context.append",
+        );
+        expect(appends.length).toBeGreaterThan(0);
+        expect(appends.length).toBeLessThanOrEqual(11);
+        expect(
+          appends
+            .map((event) => (event.content as Array<{ text: string }>)[0]?.text ?? "")
+            .join(""),
+        ).toMatch(/^x+ \[truncated\]$/);
+      });
     } finally {
       await realtime.cleanup();
     }

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.test.ts
@@ -626,6 +626,30 @@ describe("GPT-Live gateway relay bridge", () => {
     }
   });
 
+  it("bounds gateway delegation output before sideband sends", async () => {
+    const runAgentConsult = vi.fn(async () => ({ text: "x".repeat(10_000) }));
+    const { bridge, socket, testBridge } = createDelegationBridge(runAgentConsult);
+    try {
+      await testBridge.runDelegation({
+        delegationId: "delegation-large",
+        prompt: "summarize everything",
+        runAgentConsult,
+        signal: new AbortController().signal,
+      });
+
+      const appends = parseSent(socket).filter(
+        (event) => event.type === "delegation.context.append",
+      );
+      expect(appends.length).toBeGreaterThan(0);
+      expect(appends.length).toBeLessThanOrEqual(11);
+      expect(
+        appends.map((event) => (event.content as Array<{ text: string }>)[0]?.text ?? "").join(""),
+      ).toMatch(/^x+ \[truncated\]$/);
+    } finally {
+      bridge.close();
+    }
+  });
+
   it("keeps only the latest delegation when the superseded consult rejects on abort", async () => {
     const resolvers: Array<(value: { text: string }) => void> = [];
     const signals: AbortSignal[] = [];

--- a/extensions/openai/realtime-quicksilver-gateway-bridge.ts
+++ b/extensions/openai/realtime-quicksilver-gateway-bridge.ts
@@ -26,6 +26,7 @@ import {
 } from "./realtime-quicksilver-sideband.js";
 import {
   boundOpenAIQuicksilverContextItems,
+  boundOpenAIQuicksilverDelegationResult,
   buildOpenAIQuicksilverSession,
   chunkOpenAIQuicksilverAppendText,
   createOpenAIQuicksilverCall,
@@ -479,7 +480,7 @@ export class OpenAIQuicksilverGatewayBridge implements RealtimeVoiceBridge {
       if (params.signal.aborted) {
         return;
       }
-      text = result.text;
+      text = boundOpenAIQuicksilverDelegationResult(result.text);
     } catch (error) {
       // Host steering aborts the runner's registered chat signal, not this bridge-owned signal.
       // Abort-shaped rejection is therefore the runner boundary's cancellation marker.

--- a/extensions/openai/realtime-quicksilver-session.ts
+++ b/extensions/openai/realtime-quicksilver-session.ts
@@ -30,6 +30,7 @@ import {
 } from "./realtime-quicksilver-sideband.js";
 import {
   boundOpenAIQuicksilverContextItems,
+  boundOpenAIQuicksilverDelegationResult,
   buildOpenAIQuicksilverSession,
   chunkOpenAIQuicksilverAppendText,
   createOpenAIQuicksilverCall,
@@ -295,7 +296,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       if (signal.aborted) {
         return;
       }
-      finalText = result.text;
+      finalText = boundOpenAIQuicksilverDelegationResult(result.text);
     } catch (error) {
       if (signal.aborted) {
         return;

--- a/extensions/openai/realtime-quicksilver-wire.ts
+++ b/extensions/openai/realtime-quicksilver-wire.ts
@@ -5,10 +5,12 @@ import {
   readResponseTextLimited,
   resolveProviderRequestHeaders,
 } from "openclaw/plugin-sdk/provider-http";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { z } from "zod";
 import { isOpenAIGptLiveModel } from "./realtime-quicksilver.js";
 
 const OPENAI_QUICKSILVER_APPEND_MAX_BYTES = 500;
+const OPENAI_QUICKSILVER_DELEGATION_RESULT_MAX_CHARS = 1_800;
 const OPENAI_QUICKSILVER_CONTEXT_MAX_ENTRIES = 16;
 const OPENAI_QUICKSILVER_CONTEXT_MAX_ITEM_CHARS = 800;
 const OPENAI_QUICKSILVER_CONTEXT_MAX_UTF8_BYTES = 8_000;
@@ -608,4 +610,15 @@ export function chunkOpenAIQuicksilverAppendText(text: string): string[] {
     chunks.push(current);
   }
   return chunks;
+}
+
+/** Bound completed delegation output while preserving under-limit text byte-for-byte. */
+export function boundOpenAIQuicksilverDelegationResult(text: string): string {
+  if (text.length <= OPENAI_QUICKSILVER_DELEGATION_RESULT_MAX_CHARS) {
+    return text;
+  }
+  return `${truncateUtf16Safe(
+    text,
+    OPENAI_QUICKSILVER_DELEGATION_RESULT_MAX_CHARS - 16,
+  ).trimEnd()} [truncated]`;
 }


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where GPT-Live sessions could retain and send an unbounded number of sideband frames when a delegated agent returned a very large speakable result.

## Why This Change Was Made

Completed GPT-Live delegation results are now capped at the existing realtime-voice 1,800-character policy before the protocol splits them into 500-byte frames. The cap is applied at the browser broker, gateway relay, and direct delegated-tool result boundaries; user steering, greetings, and non-delegated session context remain unchanged.

## User Impact

Large delegated answers remain valid UTF-16, include a visible truncation marker, and produce at most 11 sideband append frames instead of growing without bound. Normal under-limit responses are preserved byte-for-byte. No provider, config, or environment-variable surface changes.

## Evidence

- focused OpenAI extension tests: 53 passed, 1 skipped
- `OPENCLAW_TESTBOX=1 node scripts/check-changed.mjs`: passed ([run](https://github.com/openclaw/openclaw/actions/runs/30563438370))
- autoreview: clean, no accepted/actionable findings, score 0.86
- exact-head live GA OpenAI smoke passed: backend WebSocket connected, one fresh `gpt-realtime-2.1` synthesized-audio roundtrip produced the expected user/assistant transcript, `response.done`, 57,600 output audio bytes, and `lateAudioBytes: 0`; browser WebRTC connected with audio
- GPT-Live Platform probe reached OpenAI but the available key lacks `GPT-Live` entitlement; an isolated ChatGPT OAuth login is in progress for the provider-specific live row

AI-assisted implementation; maintainer reviewed the code, tests, and runtime boundaries.

