### PR TITLE
fix(google): prevent stale realtime sessions after close

### DIFF
--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -122,6 +122,29 @@ function createMalformedToolName(name: unknown): RealtimeVoiceTool {
   } as unknown as RealtimeVoiceTool;
 }
 
+function createMockGoogleLiveSession(): MockGoogleLiveSession {
+  return {
+    close: vi.fn(),
+    sendClientContent: vi.fn(),
+    sendRealtimeInput: vi.fn(),
+    sendToolResponse: vi.fn(),
+  };
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve = (_value: T) => {};
+  let reject = (_error: unknown) => {};
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("buildGoogleRealtimeVoiceProvider", () => {
   beforeEach(() => {
     envSnapshot = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
@@ -701,7 +724,82 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     expect(lastConnectParams().config).not.toHaveProperty("sessionResumption");
   });
 
+  it("shares one pending Google Live connection across concurrent callers", async () => {
+    const pendingSession = createDeferred<MockGoogleLiveSession>();
+    const connectedSession = createMockGoogleLiveSession();
+    connectMock.mockReturnValueOnce(pendingSession.promise);
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "gemini-key" },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    const firstConnect = bridge.connect();
+    const secondConnect = bridge.connect();
+
+    expect(connectMock).toHaveBeenCalledTimes(1);
+    pendingSession.resolve(connectedSession);
+    await Promise.all([firstConnect, secondConnect]);
+    expect(connectedSession.close).not.toHaveBeenCalled();
+  });
+
+  it("disposes a late session and ignores stale callbacks after reconnecting", async () => {
+    vi.useFakeTimers();
+    const pendingSession = createDeferred<MockGoogleLiveSession>();
+    const lateSession = createMockGoogleLiveSession();
+    const replacementSession = createMockGoogleLiveSession();
+    connectMock
+      .mockReturnValueOnce(pendingSession.promise)
+      .mockResolvedValueOnce(replacementSession);
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const onReady = vi.fn();
+    const onError = vi.fn();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "gemini-key" },
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onReady,
+      onError,
+    });
+
+    const cancelledConnect = bridge.connect();
+    const staleCallbacks = lastConnectParams().callbacks;
+    bridge.close();
+    await cancelledConnect;
+
+    await bridge.connect();
+    const activeCallbacks = lastConnectParams().callbacks;
+    activeCallbacks.onopen();
+    activeCallbacks.onmessage({ setupComplete: {} });
+    expect(bridge.isConnected()).toBe(true);
+    expect(onReady).toHaveBeenCalledTimes(1);
+
+    staleCallbacks.onopen();
+    staleCallbacks.onmessage({ setupComplete: {} });
+    staleCallbacks.onerror({ message: "stale error" });
+    staleCallbacks.onclose({ code: 1011, reason: "stale close" });
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(connectMock).toHaveBeenCalledTimes(2);
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(bridge.isConnected()).toBe(true);
+    expect(replacementSession.close).not.toHaveBeenCalled();
+
+    pendingSession.resolve(lateSession);
+    await vi.waitFor(() => {
+      expect(lateSession.close).toHaveBeenCalledTimes(1);
+    });
+    expect(bridge.isConnected()).toBe(true);
+
+    bridge.close();
+    bridge.close();
+    expect(replacementSession.close).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves transcript fragments while reusing a resumption handle", async () => {
+    vi.useFakeTimers();
     const provider = buildGoogleRealtimeVoiceProvider();
     const onTranscript = vi.fn();
     const bridge = provider.createBridge({
@@ -712,12 +810,13 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     });
 
     await bridge.connect();
-    lastConnectParams().callbacks.onmessage({
+    const firstSession = lastConnectParams().callbacks;
+    firstSession.onmessage({
       sessionResumptionUpdate: { resumable: true, newHandle: "resume-1" },
       serverContent: { inputTranscription: { text: "Before " } },
     });
-
-    await bridge.connect();
+    firstSession.onclose({ code: 1011, reason: "temporary" });
+    await vi.advanceTimersByTimeAsync(250);
     lastConnectParams().callbacks.onmessage({
       serverContent: { inputTranscription: { text: "after", finished: true } },
     });
@@ -729,6 +828,7 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
   });
 
   it("drops unfinished hypotheses when a new session has no continuity", async () => {
+    vi.useFakeTimers();
     const provider = buildGoogleRealtimeVoiceProvider();
     const onTranscript = vi.fn();
     const bridge = provider.createBridge({
@@ -739,11 +839,12 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
     });
 
     await bridge.connect();
-    lastConnectParams().callbacks.onmessage({
+    const firstSession = lastConnectParams().callbacks;
+    firstSession.onmessage({
       serverContent: { inputTranscription: { text: "Old fragment " } },
     });
-
-    await bridge.connect();
+    firstSession.onclose({ code: 1011, reason: "temporary" });
+    await vi.advanceTimersByTimeAsync(250);
     lastConnectParams().callbacks.onmessage({
       serverContent: { inputTranscription: { text: "New turn", finished: true } },
     });

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -450,6 +450,11 @@ function formatGoogleLiveCloseEvent(
   return `code=${code} reason=${reason}${clean}`;
 }
 
+type GoogleLiveConnectionAttempt = {
+  promise: Promise<void>;
+  cancel: () => void;
+};
+
 class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
   readonly supportsToolResultContinuation: boolean;
   readonly supportsToolResultSuppression = false;
@@ -470,7 +475,9 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
   private hasConnectedSession = false;
   private terminalError: Error | undefined;
-  private terminalCloseNotified = false;
+  private closeNotified = false;
+  private connectionOwner: GoogleLiveConnectionAttempt | undefined;
+  private connectAttempt: GoogleLiveConnectionAttempt | undefined;
   private readonly pendingTranscripts: Record<RealtimeVoiceRole, string> = {
     user: "",
     assistant: "",
@@ -486,6 +493,32 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
     if (this.terminalError) {
       throw this.terminalError;
     }
+    if (this.session) {
+      return;
+    }
+    if (this.connectAttempt) {
+      return this.connectAttempt.promise;
+    }
+    let cancel = () => {};
+    const cancelled = new Promise<void>((resolve) => {
+      cancel = resolve;
+    });
+    const attempt: GoogleLiveConnectionAttempt = {
+      promise: cancelled,
+      cancel,
+    };
+    this.connectionOwner = attempt;
+    this.connectAttempt = attempt;
+    const connection = this.connectOwned(attempt);
+    attempt.promise = Promise.race([connection, cancelled]).finally(() => {
+      if (this.connectAttempt === attempt) {
+        this.connectAttempt = undefined;
+      }
+    });
+    return attempt.promise;
+  }
+
+  private async connectOwned(attempt: GoogleLiveConnectionAttempt): Promise<void> {
     const canResumeSession =
       this.config.sessionResumption !== false && Boolean(this.resumptionHandle);
     if (this.hasConnectedSession && !canResumeSession) {
@@ -494,6 +527,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       this.resetPendingTranscripts();
     }
     this.intentionallyClosed = false;
+    this.closeNotified = false;
     this.sessionConfigured = false;
     this.sessionReadyFired = false;
     this.consecutiveSilenceMs = 0;
@@ -506,63 +540,91 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       },
     });
 
-    this.session = await ai.live.connect({
-      model: this.model,
-      config: {
-        ...buildGoogleLiveConnectConfig(this.config, this.model),
-        ...(this.config.sessionResumption === false
-          ? {}
-          : {
-              sessionResumption: this.resumptionHandle ? { handle: this.resumptionHandle } : {},
-            }),
-        ...(this.config.contextWindowCompression === false
-          ? {}
-          : { contextWindowCompression: { slidingWindow: {} } }),
-      },
-      callbacks: {
-        onopen: () => {
-          this.connected = true;
+    try {
+      const session = await ai.live.connect({
+        model: this.model,
+        config: {
+          ...buildGoogleLiveConnectConfig(this.config, this.model),
+          ...(this.config.sessionResumption === false
+            ? {}
+            : {
+                sessionResumption: this.resumptionHandle ? { handle: this.resumptionHandle } : {},
+              }),
+          ...(this.config.contextWindowCompression === false
+            ? {}
+            : { contextWindowCompression: { slidingWindow: {} } }),
         },
-        onmessage: (message) => {
-          this.handleMessage(message);
+        callbacks: {
+          onopen: () => {
+            if (this.connectionOwner !== attempt) {
+              return;
+            }
+            this.connected = true;
+          },
+          onmessage: (message) => {
+            if (this.connectionOwner !== attempt) {
+              return;
+            }
+            this.handleMessage(message);
+          },
+          onerror: (event) => {
+            if (this.connectionOwner !== attempt) {
+              return;
+            }
+            const error =
+              event.error instanceof Error
+                ? event.error
+                : new Error(
+                    typeof event.message === "string" ? event.message : "Google Live API error",
+                  );
+            this.config.onError?.(error);
+          },
+          onclose: (event) => {
+            if (this.connectionOwner !== attempt) {
+              return;
+            }
+            this.connectionOwner = undefined;
+            this.cancelConnectAttempt(attempt);
+            this.connected = false;
+            this.sessionConfigured = false;
+            this.pendingFunctionNames.clear();
+            this.session = null;
+            if (this.terminalError) {
+              this.notifyClose("error");
+              return;
+            }
+            if (this.intentionallyClosed) {
+              this.notifyClose("completed");
+              return;
+            }
+            const closeDetails = formatGoogleLiveCloseEvent(event);
+            if (this.scheduleReconnect(closeDetails)) {
+              return;
+            }
+            // Transport failure is not an utterance boundary. Preserve transcript
+            // fragments across reconnects and finalize only when recovery is exhausted.
+            this.flushPendingTranscripts();
+            this.config.onError?.(
+              new Error(`Google Live session closed after reconnect attempts: ${closeDetails}`),
+            );
+            this.notifyClose("error");
+          },
         },
-        onerror: (event) => {
-          const error =
-            event.error instanceof Error
-              ? event.error
-              : new Error(
-                  typeof event.message === "string" ? event.message : "Google Live API error",
-                );
-          this.config.onError?.(error);
-        },
-        onclose: (event) => {
-          this.connected = false;
-          this.sessionConfigured = false;
-          this.pendingFunctionNames.clear();
-          this.session = null;
-          if (this.terminalError) {
-            this.notifyTerminalClose();
-            return;
-          }
-          if (this.intentionallyClosed) {
-            this.config.onClose?.("completed");
-            return;
-          }
-          const closeDetails = formatGoogleLiveCloseEvent(event);
-          if (this.scheduleReconnect(closeDetails)) {
-            return;
-          }
-          // Transport failure is not an utterance boundary. Preserve transcript
-          // fragments across reconnects and finalize only when recovery is exhausted.
-          this.flushPendingTranscripts();
-          this.config.onError?.(
-            new Error(`Google Live session closed after reconnect attempts: ${closeDetails}`),
-          );
-          this.config.onClose?.("error");
-        },
-      },
-    });
-    this.hasConnectedSession = true;
+      });
+      if (this.connectionOwner !== attempt) {
+        session.close();
+        return;
+      }
+      this.session = session;
+      this.hasConnectedSession = true;
+    } catch (error) {
+      if (this.connectionOwner === attempt) {
+        this.connectionOwner = undefined;
+        this.connected = false;
+        this.sessionConfigured = false;
+      }
+      throw error;
+    }
   }
 
   sendAudio(audio: Buffer): void {
@@ -692,6 +754,9 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
   acknowledgeMark(_markName?: string): void {}
 
   close(): void {
+    const hadConnection = Boolean(
+      this.connectionOwner || this.connectAttempt || this.session || this.reconnectTimer,
+    );
     this.intentionallyClosed = true;
     this.connected = false;
     this.sessionConfigured = false;
@@ -704,9 +769,15 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
     this.audioStreamEnded = false;
     this.pendingFunctionNames.clear();
     this.flushPendingTranscripts();
+    const owner = this.connectionOwner;
+    this.connectionOwner = undefined;
+    this.cancelConnectAttempt(owner);
     const session = this.session;
     this.session = null;
     session?.close();
+    if (hadConnection) {
+      this.notifyClose("completed");
+    }
   }
 
   isConnected(): boolean {
@@ -874,6 +945,9 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
     }
     this.pendingFunctionNames.clear();
     this.flushPendingTranscripts();
+    const owner = this.connectionOwner;
+    this.connectionOwner = undefined;
+    this.cancelConnectAttempt(owner);
     const session = this.session;
     this.session = null;
     try {
@@ -882,17 +956,27 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
       try {
         session?.close();
       } finally {
-        this.notifyTerminalClose();
+        this.notifyClose("error");
       }
     }
   }
 
-  private notifyTerminalClose(): void {
-    if (this.terminalCloseNotified) {
+  private notifyClose(reason: "completed" | "error"): void {
+    if (this.closeNotified) {
       return;
     }
-    this.terminalCloseNotified = true;
-    this.config.onClose?.("error");
+    this.closeNotified = true;
+    this.config.onClose?.(reason);
+  }
+
+  private cancelConnectAttempt(attempt: GoogleLiveConnectionAttempt | undefined): void {
+    if (!attempt) {
+      return;
+    }
+    if (this.connectAttempt === attempt) {
+      this.connectAttempt = undefined;
+    }
+    attempt.cancel();
   }
 
   private handleToolCall(toolCall: LiveServerToolCall): void {
@@ -936,7 +1020,7 @@ class GoogleRealtimeVoiceBridge implements RealtimeVoiceBridge {
         this.config.onError?.(error instanceof Error ? error : new Error(message));
         if (!this.scheduleReconnect(`connect failed: ${message}`)) {
           this.flushPendingTranscripts();
-          this.config.onClose?.("error");
+          this.notifyClose("error");
         }
       });
     }, delayMs);


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where Google Live users could retain a late provider session or let callbacks from an abandoned connection mutate a replacement session when a realtime connection was closed or restarted during setup. Concurrent `connect()` calls could also open multiple provider sessions for one bridge.

## Why This Change Was Made

The Google bridge now owns one connection attempt at a time, settles callers when that attempt is cancelled, disposes any session that resolves after cancellation, and ignores callbacks whose attempt no longer owns the bridge. Explicit close and terminal close notification remain idempotent. SDK startup timeouts and transport backpressure are intentionally out of scope.

This is separate from #116204, which changes Google media base64 handling in the same files but does not address connection ownership.

## User Impact

Google Live reconnects no longer allow a cancelled setup attempt to resurrect after close or interfere with the active replacement session. Duplicate callers share one provider connection.

## Evidence

Exact reviewed head: `6354c269d4b`.

- Live Google `gemini-3.1-flash-live-preview`: three fresh cycles produced provider audio and final transcripts with no errors.
- Live lifecycle race: the first cycle cancelled during setup, immediately connected a replacement, reached ready exactly once for the replacement, produced 20,960 audio bytes plus a final transcript, and ignored the abandoned attempt.
- Live terminal behavior: repeated close remained harmless; the process exited normally after provider shutdown.
- Blacksmith Testbox focused provider suite: 47/47 passed on the exact head.
- Blacksmith Testbox `CI=true pnpm check:changed`: passed on the exact head, including production/test typechecks, formatting, lint, dead-code, boundaries, and import-cycle checks.
- Full Google extension Testbox suite: 492/492 passed after the lifecycle patch was first rebased.
- Structured autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings, correctness confidence 0.93.
