### PR TITLE
fix(diagnostics): reclaim stuck-session lane immediately on terminal progress

### DIFF
--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -439,6 +439,31 @@ describe("stuck session recovery", () => {
     ]);
   });
 
+  it("reclaims stale active reply work immediately when the recorded progress is terminal", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.isEmbeddedAgentRunHandleActive.mockReturnValue(false);
+    mocks.abortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.waitForEmbeddedAgentRunEnd.mockResolvedValue(true);
+    // The run already reported completion well inside the stale-abort window;
+    // a terminal lastProgressReason must reclaim now, not after staleAbortMs.
+    mocks.getDiagnosticSessionActivitySnapshot.mockReturnValue({
+      lastProgressReason: "run:completed",
+      lastProgressAgeMs: 53_000,
+    });
+
+    await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 49_000,
+      queueDepth: 2,
+    });
+
+    expect(mocks.abortEmbeddedAgentRun).toHaveBeenCalledWith("queued-reply-session");
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
+  });
+
   it("aborts stale reply work without an embedded handle when active abort recovery is enabled", async () => {
     mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -17,6 +17,7 @@ import {
 } from "../process/command-queue.js";
 import { getDiagnosticSessionActivitySnapshot } from "./diagnostic-run-activity.js";
 import { diagnosticLogger as diag } from "./diagnostic-runtime.js";
+import { isTerminalDiagnosticProgressReason } from "./diagnostic-session-attention.js";
 import {
   formatStoppedCronSessionDiagnosticFields,
   resolveCronSessionDiagnosticContext,
@@ -70,6 +71,12 @@ function isActiveRunProgressStale(params: {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
   });
+  // A terminal reason means the run already reported completion: there is no
+  // in-flight work left to protect, so reclaim now instead of burning the
+  // full stale-abort timer waiting for evidence that will never arrive.
+  if (isTerminalDiagnosticProgressReason(activity.lastProgressReason)) {
+    return true;
+  }
   const lastProgressAgeMs = activity.lastProgressAgeMs;
   // A missing activity row is the orphan-handle state: classification age is
   // the only progress evidence available, so it owns the stale fallback.


### PR DESCRIPTION
## What Problem This Solves

Fixes #116488 (partially — see Scope below).

`isActiveRunProgressStale()` in `src/logging/diagnostic-stuck-session-recovery.runtime.ts`
decided whether to reclaim a wedged session lane purely on elapsed time
(`lastProgressAgeMs >= staleAbortMs`). It never consulted
`isTerminalDiagnosticProgressReason(lastProgressReason)`, even though the same
activity snapshot it reads already carries that reason, and
`diagnostic-session-attention.ts`'s classifier + `formatSessionActivityLogFields`
already compute and log `terminalProgressStale: true` from the exact same field.

When the recorded `lastProgressReason` is terminal (`run:completed`,
`embedded_run:ended`, a `response.completed`/`output_item.done` family reason),
there is no in-flight work left to protect. The watchdog should reclaim the
session lane immediately instead of waiting out the full
`diagnostics.stuckSessionAbortMs` window while the channel session sits
wedged in `state=processing` with `queueDepth > 0` and the agent silent.

This is the mechanism from #116488's "Expected behavior" section:

> If a stale entry does survive, the watchdog should reclaim it immediately
> when the recorded progress reason is terminal, rather than waiting out a
> timer that exists to protect genuinely running work.

## Change

`src/logging/diagnostic-stuck-session-recovery.runtime.ts`:
`isActiveRunProgressStale()` now returns `true` immediately when
`isTerminalDiagnosticProgressReason(activity.lastProgressReason)` is true,
before falling back to the existing age-based comparison. No change to the
age-based path, so genuinely running work (non-terminal reason, or no
recorded reason at all) still waits the full `staleAbortMs` as before.

## Scope

#116488 documents two things:

1. **Root**: a superseded reply operation is never released from the
   reply-run registry (`src/auto-reply/reply/reply-run-registry.ts`), so
   `isReplyRunActiveForSessionId()` keeps reporting the session as active
   after the run itself already completed. The issue is honest that this
   exact leaking code path (the missing/short-circuited release call) was
   not pinpointed. I spent time tracing the admission/collect-queue paths
   (`reply-turn-admission.ts`, `followup-turn-admission.ts`,
   `followup-runner.ts`, `queue/drain.ts`'s collect-batch aggregation) and
   did not find a call site that provably drops a registered `ReplyOperation`
   without eventually calling `complete()`/`fail()`/`abortForRestart()` on
   it — `followup-runner.ts`'s `finally` block unconditionally calls
   `operation?.complete()` regardless of admission disposition, for example,
   which rules out the leak candidate I initially suspected in
   `followup-turn-admission.ts`'s early `isFollowupRunAborted` return. The
   root cause needs more targeted reproduction (ideally a test that drives
   the exact collect-mode burst race) than I could responsibly land in this
   pass.
2. **Amplifier**: the reclaim gate in this PR, which turns the leak (however
   it happens) into ~10 minutes of user-visible silence instead of a
   near-instant self-heal.

This PR ships the well-specified, low-risk amplifier fix only. It is
independently valuable: even if the root leak persists, every occurrence
recovers immediately instead of burning the full abort timer. I did not
touch the second inconsistency the issue flags (`isReplyRunAbortableForCompaction`
guarding `phase !== "queued"` while `isReplyRunActiveForSessionId` has no
phase guard) — `isReplyRunActiveForSessionId`/`isEmbeddedAgentRunActive` are
read by session-reset, subagent-control, and session-upstream-monitor code
where a `queued` reply operation is legitimately pending work, not a leak
signal; changing that predicate's semantics needs its own scoped review
rather than folding it into this fix.

## Evidence
- [x] `node scripts/run-vitest.mjs src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts` — 36/36 passed, including a new regression test (`reclaims stale active reply work immediately when the recorded progress is terminal`) that reproduces the exact #116488 journal shape: `lastProgressReason: "run:completed"`, `lastProgressAgeMs: 53_000`, `ageMs: 49_000`, `queueDepth: 2` — asserts immediate `abort_embedded_run`/lane release instead of `keep_lane`.
- [x] `node scripts/run-vitest.mjs src/logging/diagnostic` — 76/76 passed (no regression in the broader diagnostic suite).
- [x] `tsc --noEmit` — no errors touching the changed files.
- [ ] `pnpm lint` — could not complete in this sandbox (`oxlint-tsgolint` binary was SIGKILL'd, looks like a sandbox resource limit, unrelated to this change); flagging so CI lint is the authoritative check here.

Live observation behind this change (full journal in #116488): a WhatsApp
channel session sat in `state=processing queueDepth=2` with the run already
recorded as terminal, and the watchdog logged
`action=keep_lane reason=active_reply_work` on three consecutive passes before
each `abort_embedded_run` fired at `age=120s` (the operator's configured
`diagnostics.stuckSessionAbortMs: 120000`). Three of those cycles in ten
minutes, with the agent silent in the channel throughout. With this change the
first pass reclaims instead of waiting out the timer.
