### PR TITLE
fix(ios): finish Calendar and Reminders grants without relaunch

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -27739,7 +27739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 48,
+      "line": 49,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Privacy & Access",
       "surface": "apple",
@@ -27747,7 +27747,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 65,
+      "line": 66,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Search and add contacts from the assistant.",
       "surface": "apple",
@@ -27755,7 +27755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 80,
+      "line": 81,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read photos you select for the assistant.",
       "surface": "apple",
@@ -27763,7 +27763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 81,
+      "line": 82,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read recent photos for the assistant.",
       "surface": "apple",
@@ -27771,7 +27771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 83,
+      "line": 84,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Limited",
       "surface": "apple",
@@ -27779,7 +27779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 96,
+      "line": 97,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Calendar (Add Events)",
       "surface": "apple",
@@ -27787,7 +27787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 97,
+      "line": 98,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add events with least privilege.",
       "surface": "apple",
@@ -27795,7 +27795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 111,
+      "line": 112,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "List and read calendar events.",
       "surface": "apple",
@@ -27803,7 +27803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 126,
+      "line": 127,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "List, add, and complete reminders.",
       "surface": "apple",
@@ -27811,7 +27811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 128,
+      "line": 129,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add-Only",
       "surface": "apple",
@@ -27819,7 +27819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 168,
+      "line": 169,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Allow",
       "surface": "apple",
@@ -27827,7 +27827,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 170,
+      "line": 171,
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Open Settings",
       "surface": "apple",

--- a/apps/ios/Sources/Permissions/DevicePermissions.swift
+++ b/apps/ios/Sources/Permissions/DevicePermissions.swift
@@ -170,10 +170,13 @@ enum DevicePermissionStatusMap {
 final class DevicePermissionsModel {
     private(set) var grants: [DevicePermissionKind: DevicePermissionGrant] = [:]
     private(set) var requesting: Set<DevicePermissionKind> = []
+    private let eventKitPermissions: EventKitPermissionRequester
+
     /// Owns its manager so authorization callbacks resolve without the app-wide service.
     private let locationService = LocationService()
 
-    init() {
+    init(eventKitPermissions: EventKitPermissionRequester = EventKitPermissionRequester()) {
+        self.eventKitPermissions = eventKitPermissions
         self.locationService.setAuthorizationChangeHandler { [weak self] snapshot in
             self?.grants[.location] = DevicePermissionStatusMap.location(snapshot.authorizationStatus)
         }
@@ -225,17 +228,9 @@ final class DevicePermissionsModel {
                 }
             }
         case .calendar:
-            _ = await PermissionRequestBridge.awaitRequest { completion in
-                EKEventStore().requestFullAccessToEvents { granted, _ in
-                    completion(granted)
-                }
-            }
+            _ = await self.eventKitPermissions.requestFullAccessToEvents()
         case .reminders:
-            _ = await PermissionRequestBridge.awaitRequest { completion in
-                EKEventStore().requestFullAccessToReminders { granted, _ in
-                    completion(granted)
-                }
-            }
+            _ = await self.eventKitPermissions.requestFullAccessToReminders()
         case .location:
             _ = await self.locationService.ensureAuthorization(mode: .whileUsing)
         }

--- a/apps/ios/Sources/Permissions/EventKitPermissionRequester.swift
+++ b/apps/ios/Sources/Permissions/EventKitPermissionRequester.swift
@@ -1,0 +1,51 @@
+import EventKit
+
+protocol EventKitPermissionStore: AnyObject {
+    func requestWriteOnlyAccessToEvents(
+        completion: @escaping @Sendable (Bool, (any Error)?) -> Void)
+    func requestFullAccessToEvents(
+        completion: @escaping @Sendable (Bool, (any Error)?) -> Void)
+    func requestFullAccessToReminders(
+        completion: @escaping @Sendable (Bool, (any Error)?) -> Void)
+}
+
+extension EKEventStore: EventKitPermissionStore {}
+
+/// Keeps one event store alive while Calendar or Reminders permission sheets are active.
+///
+/// EventKit recommends retaining a long-lived store. A temporary store can disappear
+/// before its asynchronous authorization callback completes, leaving the UI waiting
+/// even though iOS persisted the user's choice.
+/// `PermissionRequestBridge` starts every store request on the main actor; the unchecked
+/// conformance only allows that private store owner to cross the bridge's sendable closure.
+final class EventKitPermissionRequester: @unchecked Sendable {
+    private let store: any EventKitPermissionStore
+
+    init(store: any EventKitPermissionStore = EKEventStore()) {
+        self.store = store
+    }
+
+    func requestWriteOnlyAccessToEvents() async -> Bool {
+        await PermissionRequestBridge.awaitRequest { [self] completion in
+            self.store.requestWriteOnlyAccessToEvents { granted, _ in
+                completion(granted)
+            }
+        }
+    }
+
+    func requestFullAccessToEvents() async -> Bool {
+        await PermissionRequestBridge.awaitRequest { [self] completion in
+            self.store.requestFullAccessToEvents { granted, _ in
+                completion(granted)
+            }
+        }
+    }
+
+    func requestFullAccessToReminders() async -> Bool {
+        await PermissionRequestBridge.awaitRequest { [self] completion in
+            self.store.requestFullAccessToReminders { granted, _ in
+                completion(granted)
+            }
+        }
+    }
+}

--- a/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
+++ b/apps/ios/Sources/Settings/PrivacyAccessSectionView.swift
@@ -34,6 +34,7 @@ struct PrivacyAccessSectionView: View {
     @State private var remindersStatus: EKAuthorizationStatus = EKEventStore.authorizationStatus(for: .reminder)
     @State private var photosStatus = PhotoLibraryAccess.authorizationStatus()
     @State private var requestingIdentifiers: Set<String> = []
+    @State private var eventKitPermissions = EventKitPermissionRequester()
 
     @Environment(\.scenePhase) private var scenePhase
 
@@ -255,30 +256,15 @@ struct PrivacyAccessSectionView: View {
     }
 
     private func requestCalendarWriteOnly() async -> Bool {
-        await PermissionRequestBridge.awaitRequest { completion in
-            let store = EKEventStore()
-            store.requestWriteOnlyAccessToEvents { granted, _ in
-                completion(granted)
-            }
-        }
+        await self.eventKitPermissions.requestWriteOnlyAccessToEvents()
     }
 
     private func requestCalendarFull() async -> Bool {
-        await PermissionRequestBridge.awaitRequest { completion in
-            let store = EKEventStore()
-            store.requestFullAccessToEvents { granted, _ in
-                completion(granted)
-            }
-        }
+        await self.eventKitPermissions.requestFullAccessToEvents()
     }
 
     private func requestRemindersFull() async -> Bool {
-        await PermissionRequestBridge.awaitRequest { completion in
-            let store = EKEventStore()
-            store.requestFullAccessToReminders { granted, _ in
-                completion(granted)
-            }
-        }
+        await self.eventKitPermissions.requestFullAccessToReminders()
     }
 
     private func openSettings() {

--- a/apps/ios/Tests/EventKitPermissionRequesterTests.swift
+++ b/apps/ios/Tests/EventKitPermissionRequesterTests.swift
@@ -1,0 +1,66 @@
+import EventKit
+@testable import OpenClaw
+import Testing
+
+@Suite(.serialized) struct EventKitPermissionRequesterTests {
+    @Test func `requester retains its event store`() throws {
+        var store: TestEventKitPermissionStore? = TestEventKitPermissionStore()
+        let weakStore = WeakEventKitPermissionStore(store)
+
+        let requester = EventKitPermissionRequester(store: try #require(store))
+        store = nil
+
+        withExtendedLifetime(requester) {
+            #expect(weakStore.value != nil)
+        }
+    }
+
+    @Test func `requester routes every EventKit grant through its retained store`() async {
+        let store = TestEventKitPermissionStore()
+        let requester = EventKitPermissionRequester(store: store)
+
+        #expect(await requester.requestWriteOnlyAccessToEvents())
+        #expect(await requester.requestFullAccessToEvents())
+        #expect(await requester.requestFullAccessToReminders())
+        #expect(store.requests == [.writeOnlyEvents, .fullEvents, .fullReminders])
+    }
+}
+
+private final class WeakEventKitPermissionStore {
+    weak var value: TestEventKitPermissionStore?
+
+    init(_ value: TestEventKitPermissionStore?) {
+        self.value = value
+    }
+}
+
+private final class TestEventKitPermissionStore: EventKitPermissionStore {
+    enum Request: Equatable {
+        case writeOnlyEvents
+        case fullEvents
+        case fullReminders
+    }
+
+    private(set) var requests: [Request] = []
+
+    func requestWriteOnlyAccessToEvents(
+        completion: @escaping @Sendable (Bool, (any Error)?) -> Void
+    ) {
+        requests.append(.writeOnlyEvents)
+        completion(true, nil)
+    }
+
+    func requestFullAccessToEvents(
+        completion: @escaping @Sendable (Bool, (any Error)?) -> Void
+    ) {
+        requests.append(.fullEvents)
+        completion(true, nil)
+    }
+
+    func requestFullAccessToReminders(
+        completion: @escaping @Sendable (Bool, (any Error)?) -> Void
+    ) {
+        requests.append(.fullReminders)
+        completion(true, nil)
+    }
+}


### PR DESCRIPTION
Closes #116503

## What Problem This Solves

Fixes an issue where iOS users granting Calendar or Reminders access could see the permission flow remain unfinished until relaunch, even though iOS persisted the grant.

## Why This Change Was Made

Both onboarding and Settings now share a retained EventKit permission requester that owns one long-lived `EKEventStore` across the asynchronous system permission sheet and callback. The requester covers calendar add-only/full access and reminders full access without changing permission semantics or copy.

Apple's EventKit contract recommends keeping an event store long-lived. The previous request paths created temporary stores immediately before starting asynchronous authorization.

## User Impact

Calendar and Reminders permission rows can complete and reconcile immediately after the system choice instead of requiring an app restart.

## Evidence

- Reviewed and signed exact head: `44245a7d53a943c5cff6c206abca9d73abdd54d0`.
- Contributor authorship is preserved: the single code commit remains authored by `PollyBot13`; maintainer-only merge-sync commits were removed.
- Exact-head real-behavior evidence gate: https://github.com/openclaw/openclaw/actions/runs/30675996706
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/30675997689
  - `ios-build`: Swift lint, Debug build, Release build, focused simulator lifecycle tests, and evidence upload passed. The unrelated release-screenshot tail is still running.
  - `macos-swift`: Swift lint, Release build, and the dependency opt-out contract passed. The broad parallel OpenClawKit suite then had one unrelated outbox timing failure among 1,311 tests; that exact test passed locally in isolation (`1/1`, 0.156s).
  - `checks-node-compact-small-9`: one unrelated QA integration test hit its 120-second per-test timeout after 707 passing tests; the exact file passed locally (`2/2`) in 88.70s.
  - `openclaw/ci-gate`: pending the still-running iOS screenshot tail; it will remain non-green until the two unrelated failed jobs are rerun.
- Exact-head local checks:
  - native i18n verification: `entries=5406 changed=false`
  - Swift format: 362 files checked, 0 changes
  - Swift lint: 362 files checked, 0 violations
  - `git diff --check`: clean
  - fresh autoreview: no findings, confidence `0.98`
- Patch-identical immutable runtime proof: the four Swift/test blobs at exact head are byte-identical to the proven code commit `7cefc4705e97175a3a5127ddef9e915e66b405c8`. On a fresh iPhone 17 simulator running iOS 26.5, the real Calendar and Reminders sheets completed, both rows changed green immediately in the same process, seven focused EventKit/permissions tests passed, and the iOS build succeeded.
- Complete runtime evidence bundle: https://github.com/PollyBot13/openclaw/tree/0c768d4a4cbcb20a93ca563aec49e4c11b196cd5/artifacts/pr-116504/current-head
- Redacted terminal proof: https://github.com/PollyBot13/openclaw/blob/0c768d4a4cbcb20a93ca563aec49e4c11b196cd5/artifacts/pr-116504/current-head/terminal-proof.txt
- Physical-device evidence before the fix: OpenClaw `main` at `85466bd89e748aa2ac972bc31bd03bb9eb5b92c2` on an iPhone XR running iOS 18.7.9. After the Reminders grant appeared not to finish, relaunching showed EventKit status `fullAccess`; a read-only EventKit query found a reminder calendar. This confirms iOS persisted the grant while the app flow had not completed.
- Dependency/lifecycle review covered onboarding and Settings entry points, the retained requester, the async continuation bridge, Calendar/Reminders service siblings, status refresh, and macOS/shared call sites. No blocking finding was found. macOS has no EventKit consumer on this path.
- Current-main integration at `af687f920f61d5f252280c0a0b54ca54fbd058ad`: zero touched-file drift; clean merge tree `ec0b990c8c29b14a94e757351b9b8612e6f95318`.
- A second local exact-head focused `xcodebuild test` attempt was stopped after Xcode stalled before compilation at build-description creation. This is recorded as a local Xcode build-service limitation, not as passing proof; hosted Apple builds and the patch-identical focused/runtime evidence above provide the validation.

No layout or copy changed; the screenshots below are runtime permission evidence rather than visual-design proof.

![Calendar full-access system sheet](https://raw.githubusercontent.com/PollyBot13/openclaw/0c768d4a4cbcb20a93ca563aec49e4c11b196cd5/artifacts/pr-116504/current-head/calendar-system-prompt.png)

![Calendar row reconciled immediately after grant](https://raw.githubusercontent.com/PollyBot13/openclaw/0c768d4a4cbcb20a93ca563aec49e4c11b196cd5/artifacts/pr-116504/current-head/calendar-after-grant.png)

![Reminders system sheet](https://raw.githubusercontent.com/PollyBot13/openclaw/0c768d4a4cbcb20a93ca563aec49e4c11b196cd5/artifacts/pr-116504/current-head/reminders-system-prompt.png)

![Both Calendar and Reminders rows reconciled without relaunch](https://raw.githubusercontent.com/PollyBot13/openclaw/0c768d4a4cbcb20a93ca563aec49e4c11b196cd5/artifacts/pr-116504/current-head/both-after-grant.png)

AI-assisted: yes.
