### PR TITLE
fix(github-copilot): stop advertising unsupported Raptor mini

### DIFF
--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -204,14 +204,6 @@
             "contextTokens": 272000,
             "maxTokens": 128000,
             "cost": { "input": 0.75, "output": 4.5, "cacheRead": 0.075, "cacheWrite": 0 }
-          },
-          {
-            "id": "raptor-mini",
-            "name": "Raptor mini",
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 8192,
-            "cost": { "input": 0.25, "output": 2, "cacheRead": 0.025, "cacheWrite": 0 }
           }
         ]
       }

--- a/extensions/github-copilot/provider-runtime.contract.test.ts
+++ b/extensions/github-copilot/provider-runtime.contract.test.ts
@@ -1,8 +1,15 @@
 // Github Copilot tests cover provider runtime.contract plugin behavior.
 import { describeGithubCopilotProviderRuntimeContract } from "openclaw/plugin-sdk/provider-test-contracts";
+import { expect, it } from "vitest";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 describeGithubCopilotProviderRuntimeContract(
   () => import("./index.js"),
   manifest.modelCatalog.providers["github-copilot"],
 );
+
+it("does not advertise live-only models through the static fallback catalog", () => {
+  expect(
+    manifest.modelCatalog.providers["github-copilot"].models.map((model) => model.id),
+  ).not.toContain("raptor-mini");
+});


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's static GitHub Copilot catalog still advertises `raptor-mini`, although GitHub retired Raptor mini on September 1, 2026.

## Why This Change Was Made

This removes only the retired model's static fallback row. Authenticated live discovery and explicit model resolution remain unchanged.

## User Impact

The model picker no longer recommends a retired GitHub Copilot model.

## Evidence

- GitHub model retirement history: https://docs.github.com/en/copilot/reference/ai-models/supported-models#model-retirement-history
- Exact-head Testbox `tbx_01m2hwxj78kv8m2342jc7x36y7`, hydrated by https://github.com/openclaw/openclaw/actions/runs/34938255933 at `40ccf11ea8c6b9576a9b51462a464640da2fe85e`.
- Static manifest comparison on Testbox: `raptor-mini` rows changed from `1` on the base to `0` on the candidate; the candidate retains `17` catalog rows.
- `pnpm test:extension github-copilot` on Testbox: `16` test files and `268` tests passed.
- `pnpm check:changed` on Testbox: passed for the exact manifest path, including extension typechecks, lint, formatting, metadata, and policy guards.
