### PR TITLE
fix(voice-call): reject duplicate media stream starts

### DIFF
--- a/extensions/voice-call/src/media-stream.lifecycle.test.ts
+++ b/extensions/voice-call/src/media-stream.lifecycle.test.ts
@@ -5,10 +5,11 @@ import { connectWs, startUpgradeWsServer, waitForClose } from "./websocket-test-
 
 describe("MediaStreamHandler lifecycle", () => {
   it("rejects duplicate start frames without creating another STT session", async () => {
+    const closeSession = vi.fn();
     const sttSession: RealtimeTranscriptionSession = {
       connect: async () => {},
       sendAudio: () => {},
-      close: vi.fn(),
+      close: closeSession,
       isConnected: () => true,
     };
     const createSession = vi.fn(() => sttSession);
@@ -61,7 +62,7 @@ describe("MediaStreamHandler lifecycle", () => {
       expect(shouldAcceptStream).toHaveBeenCalledTimes(1);
       expect(onConnect).toHaveBeenCalledTimes(1);
       await vi.waitFor(() => {
-        expect(sttSession.close).toHaveBeenCalledTimes(1);
+        expect(closeSession).toHaveBeenCalledTimes(1);
         expect(onDisconnect).toHaveBeenCalledWith("CA-first", "MZ-first");
         expect(onDisconnect).toHaveBeenCalledTimes(1);
       });

--- a/extensions/voice-call/src/media-stream.lifecycle.test.ts
+++ b/extensions/voice-call/src/media-stream.lifecycle.test.ts
@@ -1,0 +1,72 @@
+import type { RealtimeTranscriptionSession } from "openclaw/plugin-sdk/realtime-transcription";
+import { describe, expect, it, vi } from "vitest";
+import { MediaStreamHandler } from "./media-stream.js";
+import { connectWs, startUpgradeWsServer, waitForClose } from "./websocket-test-support.js";
+
+describe("MediaStreamHandler lifecycle", () => {
+  it("rejects duplicate start frames without creating another STT session", async () => {
+    const sttSession: RealtimeTranscriptionSession = {
+      connect: async () => {},
+      sendAudio: () => {},
+      close: vi.fn(),
+      isConnected: () => true,
+    };
+    const createSession = vi.fn(() => sttSession);
+    const shouldAcceptStream = vi.fn(() => true);
+    const onConnect = vi.fn();
+    const onDisconnect = vi.fn();
+    const handler = new MediaStreamHandler({
+      transcriptionProvider: {
+        createSession,
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: () => true,
+      },
+      providerConfig: {},
+      shouldAcceptStream,
+      onConnect,
+      onDisconnect,
+    });
+    const server = await startUpgradeWsServer({
+      urlPath: "/voice/stream",
+      onUpgrade: (request, socket, head) => {
+        handler.handleUpgrade(request, socket, head);
+      },
+    });
+
+    try {
+      const ws = await connectWs(server.url);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-first",
+          start: { callSid: "CA-first" },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(onConnect).toHaveBeenCalledWith("CA-first", "MZ-first");
+      });
+
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-second",
+          start: { callSid: "CA-second" },
+        }),
+      );
+      const closed = await waitForClose(ws);
+
+      expect(closed).toEqual({ code: 1008, reason: "Duplicate start" });
+      expect(createSession).toHaveBeenCalledTimes(1);
+      expect(shouldAcceptStream).toHaveBeenCalledTimes(1);
+      expect(onConnect).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(sttSession.close).toHaveBeenCalledTimes(1);
+        expect(onDisconnect).toHaveBeenCalledWith("CA-first", "MZ-first");
+        expect(onDisconnect).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -253,6 +253,63 @@ describe("MediaStreamHandler security hardening", () => {
     }
   });
 
+  it("rejects duplicate start frames without creating another STT session", async () => {
+    const sttSession = {
+      ...createStubSession(),
+      close: vi.fn(),
+    };
+    const createSession = vi.fn(() => sttSession);
+    const shouldAcceptStream = vi.fn(() => true);
+    const onConnect = vi.fn();
+    const onDisconnect = vi.fn();
+    const handler = new MediaStreamHandler({
+      transcriptionProvider: {
+        createSession,
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: () => true,
+      },
+      providerConfig: {},
+      shouldAcceptStream,
+      onConnect,
+      onDisconnect,
+    });
+    const server = await startWsServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-first",
+          start: { callSid: "CA-first" },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(onConnect).toHaveBeenCalledWith("CA-first", "MZ-first");
+      });
+
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-second",
+          start: { callSid: "CA-second" },
+        }),
+      );
+      const closed = await waitForClose(ws);
+
+      expect(closed).toEqual({ code: 1008, reason: "Duplicate start" });
+      expect(createSession).toHaveBeenCalledTimes(1);
+      expect(shouldAcceptStream).toHaveBeenCalledTimes(1);
+      expect(onConnect).toHaveBeenCalledTimes(1);
+      expect(sttSession.close).toHaveBeenCalledTimes(1);
+      expect(onDisconnect).toHaveBeenCalledWith("CA-first", "MZ-first");
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("emits common Talk events for telephony STT/TTS sessions", async () => {
     let callbacks: RealtimeTranscriptionSessionCreateRequest | undefined;
     const sentAudio: Buffer[] = [];

--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -253,65 +253,6 @@ describe("MediaStreamHandler security hardening", () => {
     }
   });
 
-  it("rejects duplicate start frames without creating another STT session", async () => {
-    const sttSession = {
-      ...createStubSession(),
-      close: vi.fn(),
-    };
-    const createSession = vi.fn(() => sttSession);
-    const shouldAcceptStream = vi.fn(() => true);
-    const onConnect = vi.fn();
-    const onDisconnect = vi.fn();
-    const handler = new MediaStreamHandler({
-      transcriptionProvider: {
-        createSession,
-        id: "openai",
-        label: "OpenAI",
-        isConfigured: () => true,
-      },
-      providerConfig: {},
-      shouldAcceptStream,
-      onConnect,
-      onDisconnect,
-    });
-    const server = await startWsServer(handler);
-
-    try {
-      const ws = await connectWs(server.url);
-      ws.send(
-        JSON.stringify({
-          event: "start",
-          streamSid: "MZ-first",
-          start: { callSid: "CA-first" },
-        }),
-      );
-      await vi.waitFor(() => {
-        expect(onConnect).toHaveBeenCalledWith("CA-first", "MZ-first");
-      });
-
-      ws.send(
-        JSON.stringify({
-          event: "start",
-          streamSid: "MZ-second",
-          start: { callSid: "CA-second" },
-        }),
-      );
-      const closed = await waitForClose(ws);
-
-      expect(closed).toEqual({ code: 1008, reason: "Duplicate start" });
-      expect(createSession).toHaveBeenCalledTimes(1);
-      expect(shouldAcceptStream).toHaveBeenCalledTimes(1);
-      expect(onConnect).toHaveBeenCalledTimes(1);
-      await vi.waitFor(() => {
-        expect(sttSession.close).toHaveBeenCalledTimes(1);
-        expect(onDisconnect).toHaveBeenCalledWith("CA-first", "MZ-first");
-        expect(onDisconnect).toHaveBeenCalledTimes(1);
-      });
-    } finally {
-      await server.close();
-    }
-  });
-
   it("emits common Talk events for telephony STT/TTS sessions", async () => {
     let callbacks: RealtimeTranscriptionSessionCreateRequest | undefined;
     const sentAudio: Buffer[] = [];

--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -302,9 +302,11 @@ describe("MediaStreamHandler security hardening", () => {
       expect(createSession).toHaveBeenCalledTimes(1);
       expect(shouldAcceptStream).toHaveBeenCalledTimes(1);
       expect(onConnect).toHaveBeenCalledTimes(1);
-      expect(sttSession.close).toHaveBeenCalledTimes(1);
-      expect(onDisconnect).toHaveBeenCalledWith("CA-first", "MZ-first");
-      expect(onDisconnect).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(sttSession.close).toHaveBeenCalledTimes(1);
+        expect(onDisconnect).toHaveBeenCalledWith("CA-first", "MZ-first");
+        expect(onDisconnect).toHaveBeenCalledTimes(1);
+      });
     } finally {
       await server.close();
     }

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -244,6 +244,11 @@ export class MediaStreamHandler {
             break;
 
           case "start":
+            if (session) {
+              console.warn("[MediaStream] Rejecting duplicate start frame for active connection");
+              ws.close(1008, "Duplicate start");
+              break;
+            }
             session = this.handleStart(ws, message, streamToken);
             if (session) {
               this.clearPendingConnection(ws);


### PR DESCRIPTION
Related: #116201

AI-assisted: yes

## What Problem This Solves

Fixes an issue where a voice-call media WebSocket could accept repeated `start` frames and create multiple realtime transcription sessions for one connection. A malformed or replayed stream could retain extra provider sessions and duplicate lifecycle callbacks until the socket closed.

## Why This Change Was Made

Each media WebSocket now owns at most one accepted transcription session. A second `start` frame closes the socket with WebSocket policy code `1008`; the existing close path remains responsible for stopping the original session exactly once.

This is intentionally limited to duplicate start ownership. It does not change provider selection, audio framing, transcription behavior, or normal Twilio stop/close handling.

## User Impact

Voice-call streams no longer accumulate transcription sessions when a provider sends duplicate start frames. Normal single-start calls behave unchanged.

## Evidence

- Real loopback WebSocket integration: the first start is accepted, a second start closes the connection with `1008 Duplicate start`, and session creation, connect, close, and disconnect each occur once.
- Focused lifecycle tests: 2 files, 23 tests passed.
- Full voice-call extension Testbox: 53 files, 568 tests passed: https://github.com/openclaw/openclaw/actions/runs/30566424282
- Rebased onto current `main` at `3ffd3864ea2`; intervening base commits did not modify `extensions/voice-call`.
- Sparse-safe `pnpm check:changed` Testbox on the rebased head: https://github.com/openclaw/openclaw/actions/runs/30569960684
- Autoreview on the rebased head: clean, no accepted/actionable findings; overall confidence 0.82.
