### PR TITLE
fix: preserve untouched bytes outside fuzzy-match span in edit tool (#116459)

### DIFF
--- a/src/agents/agent-tools.sandbox-mounted-paths.workspace-only.test.ts
+++ b/src/agents/agent-tools.sandbox-mounted-paths.workspace-only.test.ts
@@ -138,6 +138,28 @@ describe("tools.fs.workspaceOnly", () => {
     });
   });
 
+  it("preserves unrelated Unicode bytes through the real sandbox edit bridge", async () => {
+    await withUnsafeMountedSandboxHarness(async ({ sandboxRoot, sandbox }) => {
+      const filePath = path.join(sandboxRoot, "source.txt");
+      const original =
+        "const value\u00A0= 1; // keep \uFF08\uFF13\uFF09 \uFF71\uFF72\uFF73 \u2014 unchanged\r\n";
+      const expected =
+        "const value = 2; // keep \uFF08\uFF13\uFF09 \uFF71\uFF72\uFF73 \u2014 unchanged\r\n";
+      const editTool = createSandboxedEditTool({
+        root: sandbox.workspaceDir,
+        bridge: sandbox.fsBridge!,
+      });
+
+      await fs.writeFile(filePath, original, "utf8");
+      await editTool.execute("sandbox-edit-fuzzy-unicode", {
+        path: "source.txt",
+        edits: [{ oldText: "const value = 1;", newText: "const value = 2;" }],
+      });
+
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe(expected);
+    });
+  });
+
   it("rejects invalid UTF-8 before sandbox edit or patch bridge writes", async () => {
     await withUnsafeMountedSandboxHarness(async ({ sandboxRoot, sandbox }) => {
       const filePath = path.join(sandboxRoot, "source.txt");

--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -151,6 +151,57 @@ describe("applyEditsToNormalizedContent uniqueness", () => {
   });
 });
 
+describe("fuzzy edit — byte preservation on matched line", () => {
+  it("preserves unicode bytes outside the edited span when fuzzy matching", () => {
+    // Line has NBSP (U+00A0 between RETRY and MAX), fullwidth parens,
+    // fullwidth digit, halfwidth katakana, and em-dash — all outside
+    // the span being replaced.
+    const content =
+      'export const RETRY MAX = 3; // 再試行（最大３回）ｱｲｳ — 設定\nexport const OTHER = 1;\n';
+
+    // oldText uses plain space instead of NBSP → triggers fuzzy match
+    const edits = [
+      { oldText: "export const RETRY MAX = 3;", newText: "export const RETRY_MAX = 5;" },
+    ];
+
+    const result = applyEditsPreservingLineEndings(content, edits, "config.ts");
+
+    // The replacement itself must be applied
+    expect(result.finalContent).toContain("RETRY_MAX = 5;");
+
+    // The comment must remain byte-identical (no NFKC normalization)
+    const originalComment = content.slice(content.indexOf("//"));
+    const afterComment = result.finalContent.slice(result.finalContent.indexOf("//"));
+    expect(afterComment).toBe(originalComment);
+
+    // The exact-match path on the same file must produce the same result
+    const exactContent =
+      'export const RETRY MAX = 3; // 再試行（最大３回）ｱｲｳ — 設定\nexport const OTHER = 1;\n';
+    const exactEdits = [
+      {
+        oldText: "export const RETRY MAX = 3;",
+        newText: "export const RETRY_MAX = 5;",
+      },
+    ];
+    const exactResult = applyEditsPreservingLineEndings(
+      exactContent,
+      exactEdits,
+      "config.ts",
+    );
+    expect(result.finalContent).toBe(exactResult.finalContent);
+  });
+
+  it("preserves smart quotes in comments during fuzzy edit", () => {
+    const content = 'let x = "hello"; // says "hello world" — nice\nlet y = 2;\n';
+    // Use straight quotes in oldText while the file has smart quotes
+    const edits = [{ oldText: 'let x = "hello";', newText: "let x = 'hi';" }];
+    const result = applyEditsPreservingLineEndings(content, edits, "test.ts");
+
+    expect(result.finalContent).toContain("let x = 'hi';");
+    expect(result.finalContent).toContain('// says "hello world" — nice');
+  });
+});
+
 describe("applyEditsToNormalizedContent fuzzy uniqueness", () => {
   it("still rejects a fuzzy match that is ambiguous once normalization is applied", () => {
     const content = "foo();  \nfoo();\t\nbar();\n";

--- a/src/agents/sessions/tools/edit-diff.test.ts
+++ b/src/agents/sessions/tools/edit-diff.test.ts
@@ -151,54 +151,110 @@ describe("applyEditsToNormalizedContent uniqueness", () => {
   });
 });
 
-describe("fuzzy edit — byte preservation on matched line", () => {
-  it("preserves unicode bytes outside the edited span when fuzzy matching", () => {
-    // Line has NBSP (U+00A0 between RETRY and MAX), fullwidth parens,
-    // fullwidth digit, halfwidth katakana, and em-dash — all outside
-    // the span being replaced.
+describe("fuzzy edit source-span mapping", () => {
+  it("preserves escaped Unicode bytes outside a fuzzy-matched span", () => {
     const content =
-      'export const RETRY MAX = 3; // 再試行（最大３回）ｱｲｳ — 設定\nexport const OTHER = 1;\n';
+      "export const RETRY\u00A0MAX = 3; // \u518D\u8A66\u884C\uFF08\u6700\u5927\uFF13\u56DE\uFF09\uFF71\uFF72\uFF73 \u2014 \u8A2D\u5B9A\n" +
+      "export const OTHER = 1;\n";
 
-    // oldText uses plain space instead of NBSP → triggers fuzzy match
-    const edits = [
-      { oldText: "export const RETRY MAX = 3;", newText: "export const RETRY_MAX = 5;" },
-    ];
-
-    const result = applyEditsPreservingLineEndings(content, edits, "config.ts");
-
-    // The replacement itself must be applied
-    expect(result.finalContent).toContain("RETRY_MAX = 5;");
-
-    // The comment must remain byte-identical (no NFKC normalization)
-    const originalComment = content.slice(content.indexOf("//"));
-    const afterComment = result.finalContent.slice(result.finalContent.indexOf("//"));
-    expect(afterComment).toBe(originalComment);
-
-    // The exact-match path on the same file must produce the same result
-    const exactContent =
-      'export const RETRY MAX = 3; // 再試行（最大３回）ｱｲｳ — 設定\nexport const OTHER = 1;\n';
-    const exactEdits = [
-      {
-        oldText: "export const RETRY MAX = 3;",
-        newText: "export const RETRY_MAX = 5;",
-      },
-    ];
-    const exactResult = applyEditsPreservingLineEndings(
-      exactContent,
-      exactEdits,
+    const result = applyEditsPreservingLineEndings(
+      content,
+      [{ oldText: "export const RETRY MAX = 3;", newText: "export const RETRY_MAX = 5;" }],
       "config.ts",
     );
-    expect(result.finalContent).toBe(exactResult.finalContent);
+
+    expect(result.finalContent).toBe(
+      "export const RETRY_MAX = 5; // \u518D\u8A66\u884C\uFF08\u6700\u5927\uFF13\u56DE\uFF09\uFF71\uFF72\uFF73 \u2014 \u8A2D\u5B9A\n" +
+        "export const OTHER = 1;\n",
+    );
   });
 
-  it("preserves smart quotes in comments during fuzzy edit", () => {
-    const content = 'let x = "hello"; // says "hello world" — nice\nlet y = 2;\n';
-    // Use straight quotes in oldText while the file has smart quotes
-    const edits = [{ oldText: 'let x = "hello";', newText: "let x = 'hi';" }];
-    const result = applyEditsPreservingLineEndings(content, edits, "test.ts");
+  it("maps smart-quote folds while preserving a smart-quote comment", () => {
+    const content =
+      "const label = \u201Chello\u201D; // keep \u201Ccomment\u201D \u2014 unchanged\n";
+    const result = applyEditsPreservingLineEndings(
+      content,
+      [{ oldText: 'const label = "hello";', newText: "const label = 'hi';" }],
+      "test.ts",
+    );
 
-    expect(result.finalContent).toContain("let x = 'hi';");
-    expect(result.finalContent).toContain('// says "hello world" — nice');
+    expect(result.finalContent).toBe(
+      "const label = 'hi'; // keep \u201Ccomment\u201D \u2014 unchanged\n",
+    );
+  });
+
+  it("allows a match that covers a complete NFKC expansion", () => {
+    const result = applyEditsPreservingLineEndings(
+      "const value = \uFB01;\n",
+      [{ oldText: "fi", newText: "pair" }],
+      "test.ts",
+    );
+
+    expect(result.finalContent).toBe("const value = pair;\n");
+  });
+
+  it("rejects a match ending inside an NFKC expansion", () => {
+    expect(() =>
+      applyEditsPreservingLineEndings(
+        "const value = \uFB01;\n",
+        [{ oldText: "f", newText: "x" }],
+        "test.ts",
+      ),
+    ).toThrow(/ambiguous Unicode-normalization or trimmed-whitespace boundary/);
+  });
+
+  it("maps a complete combining sequence and preserves supplementary characters", () => {
+    const content = "const caf\u0065\u0301 = 1; // \u{1F642}\n";
+    const result = applyEditsPreservingLineEndings(
+      content,
+      [{ oldText: "const caf\u00E9 = 1;", newText: "const cafe = 2;" }],
+      "test.ts",
+    );
+
+    expect(result.finalContent).toBe("const cafe = 2; // \u{1F642}\n");
+  });
+
+  it("preserves trimmed bytes at EOF", () => {
+    const result = applyEditsPreservingLineEndings(
+      "const value\u00A0= 1;  ",
+      [{ oldText: "const value = 1;", newText: "const value = 2;" }],
+      "test.ts",
+    );
+
+    expect(result.finalContent).toBe("const value = 2;  ");
+  });
+
+  it("keeps trim-folding behavior inside a complete fuzzy span", () => {
+    const result = applyEditsPreservingLineEndings(
+      "before\nfirst  \nsecond\nafter  \n",
+      [{ oldText: "first\nsecond", newText: "combined" }],
+      "test.ts",
+    );
+
+    expect(result.finalContent).toBe("before\ncombined\nafter  \n");
+  });
+
+  it("preserves CRLF while mapping a fuzzy Unicode span", () => {
+    const result = applyEditsPreservingLineEndings(
+      "const value\u00A0= 1;\r\nnext\r\n",
+      [{ oldText: "const value = 1;", newText: "const value = 2;" }],
+      "test.ts",
+    );
+
+    expect(result.finalContent).toBe("const value = 2;\r\nnext\r\n");
+  });
+
+  it("keeps exact and fuzzy replacements in original coordinates", () => {
+    const result = applyEditsPreservingLineEndings(
+      "const a\u00A0= 1;\nconst b = 2;\n",
+      [
+        { oldText: "const a = 1;", newText: "const a = 3;" },
+        { oldText: "const b = 2;", newText: "const b = 4;" },
+      ],
+      "test.ts",
+    );
+
+    expect(result.finalContent).toBe("const a = 3;\nconst b = 4;\n");
   });
 });
 

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -11,10 +11,24 @@ import { normalizeToLF } from "../../line-endings.js";
 import {
   applyReplacements,
   applyReplacementsPreservingLineEndings,
-  applyReplacementsPreservingUnchangedLines,
   type TextReplacement,
 } from "./edit-replacements.js";
 import { resolveToCwd } from "./path-utils.js";
+
+/**
+ * Result of normalizeForFuzzyMatchWithMap — the normalized text plus a position
+ * map that translates every normalized position back to the original text.
+ */
+interface FuzzyNormalizedFile {
+  text: string;
+  /**
+   * For each position i in the normalized text, offsetMap[i] is the position
+   * in the original text that normalized[i] originates from.  A sentinel at
+   * offsetMap[text.length] holds original.length so that span lengths can be
+   * computed as `offsetMap[end] - offsetMap[start]`.
+   */
+  offsetMap: number[];
+}
 
 /**
  * Normalize text for fuzzy matching. Applies progressive transformations:
@@ -22,42 +36,133 @@ import { resolveToCwd } from "./path-utils.js";
  * - Normalize smart quotes to ASCII equivalents
  * - Normalize Unicode dashes/hyphens to ASCII hyphen
  * - Normalize special Unicode spaces to regular space
+ *
+ * Also returns an offset map that translates each position in the normalized
+ * output back to its corresponding position in the input text.  The map uses
+ * the sentinel convention: offsetMap[normalized.length] = original.length.
  */
-function normalizeForFuzzyMatch(text: string): string {
-  return (
-    text
-      .normalize("NFKC")
-      // Strip trailing whitespace per line
-      .split("\n")
-      .map((line) => line.trimEnd())
-      .join("\n")
-      // Smart single quotes → '
-      .replace(/[\u2018\u2019\u201A\u201B]/g, "'")
-      // Smart double quotes → "
-      .replace(/[\u201C\u201D\u201E\u201F]/g, '"')
-      // Various dashes/hyphens → -
-      // U+2010 hyphen, U+2011 non-breaking hyphen, U+2012 figure dash,
-      // U+2013 en-dash, U+2014 em-dash, U+2015 horizontal bar, U+2212 minus
-      .replace(/[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/g, "-")
-      // Special spaces → regular space
-      // U+00A0 NBSP, U+2002-U+200A various spaces, U+202F narrow NBSP,
-      // U+205F medium math space, U+3000 ideographic space
-      .replace(/[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g, " ")
+function normalizeForFuzzyMatch(text: string): string;
+function normalizeForFuzzyMatch(
+  text: string,
+  withMap: true,
+): FuzzyNormalizedFile;
+function normalizeForFuzzyMatch(
+  text: string,
+  withMap?: true,
+): string | FuzzyNormalizedFile {
+  // Step 1: NFKC — character-level folding. We track offsets by normalizing
+  // one code point at a time so we know which original position each
+  // normalized character corresponds to.
+  const nfkcBuilder: string[] = [];
+  const nfkcMap: number[] = []; // maps normalized position → original position
+  let origPos = 0;
+  while (origPos < text.length) {
+    const origCP = text.codePointAt(origPos)!;
+    const origCharLen = String.fromCodePoint(origCP).length;
+    const normChars = String.fromCodePoint(origCP).normalize("NFKC");
+    const startNormPos = nfkcBuilder.length;
+    nfkcBuilder.push(normChars);
+    for (let j = 0; j < normChars.length; j++) {
+      nfkcMap[startNormPos + j] = origPos;
+    }
+    origPos += origCharLen;
+  }
+
+  // Step 2: line-wise trimEnd and quote/dash/space replacements
+  const nfkcText = nfkcBuilder.join("");
+  const lines = nfkcText.split("\n");
+  const trimmed: string[] = [];
+  let normPos = 0;
+  for (const line of lines) {
+    const trimmedLine = line.trimEnd();
+    trimmed.push(trimmedLine);
+    // Advance normPos past the line (including the trailing newline if any)
+    normPos += line.length + 1;
+  }
+  const trimmedText = trimmed.join("\n");
+
+  // Build the trimmed → nfkc offset map
+  const trimmedMap: number[] = [];
+  let trimmedPos = 0;
+  let nfkcPos = 0;
+  for (let li = 0; li < trimmed.length; li++) {
+    const trimmedLine = trimmed[li];
+    const origLine = lines[li];
+    // Map each character of the trimmed line (they're the same up to the end
+    // of the trimmed content)
+    for (let ci = 0; ci < trimmedLine.length; ci++) {
+      trimmedMap[trimmedPos] = nfkcPos;
+      trimmedPos++;
+      nfkcPos++;
+    }
+    // After the trimmed line, there may be trailing whitespace in the original.
+    // Skip it in nfkcPos, then add a newline to trimmedPos.
+    nfkcPos += origLine.length - trimmedLine.length;
+    if (li < trimmed.length - 1) {
+      trimmedMap[trimmedPos] = nfkcPos;
+      trimmedPos++;
+      nfkcPos++; // newline
+    }
+  }
+
+  // Step 3: quote, dash, space replacement (all 1→1, so offset map is
+  // identity at this stage).
+  let finalText = trimmedText;
+  finalText = finalText.replace(/[\u2018\u2019\u201A\u201B]/g, "'");
+  finalText = finalText.replace(/[\u201C\u201D\u201E\u201F]/g, '"');
+  finalText = finalText.replace(
+    /[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/g,
+    "-",
   );
+  finalText = finalText.replace(
+    /[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g,
+    " ",
+  );
+
+  // Compose maps: nfkcMap(orig←nfkc) ∘ trimmedMap(nfkc←trimmed) ∘ replace(identity)
+  // → direct mapping from final normalized position to original position
+  const combinedMap: number[] = [];
+  for (let fi = 0; fi < finalText.length; fi++) {
+    const trimmedPosFromFinal = fi; // identity — replacements are 1→1
+    const nfkcPos = trimmedMap[trimmedPosFromFinal];
+    combinedMap[fi] = nfkcMap[nfkcPos];
+  }
+  // sentinel
+  combinedMap[finalText.length] = text.length;
+
+  if (withMap) {
+    return { text: finalText, offsetMap: combinedMap };
+  }
+  return finalText;
+}
+
+/**
+ * Given a span in fuzzy-normalized coordinates, translate it to original-text
+ * coordinates using the offset map produced by normalizeForFuzzyMatch(_, true).
+ */
+function translateFuzzySpan(
+  offsetMap: number[],
+  fuzzyStart: number,
+  fuzzyLength: number,
+): { originalStart: number; originalLength: number } {
+  return {
+    originalStart: offsetMap[fuzzyStart],
+    originalLength: offsetMap[fuzzyStart + fuzzyLength] - offsetMap[fuzzyStart],
+  };
 }
 
 interface FuzzyMatchResult {
   /** Whether a match was found */
   found: boolean;
-  /** The index where the match starts (in the content that should be used for replacement) */
+  /** The index where the match starts (in original-content coordinates) */
   index: number;
-  /** Length of the matched text */
+  /** Length of the matched text (in original-content coordinates) */
   matchLength: number;
   /** Whether fuzzy matching was used (false = exact match) */
   usedFuzzyMatch: boolean;
   /**
    * The content to use for replacement operations.
-   * When exact match: original content. When fuzzy match: normalized content.
+   * Always the original (un-normalized) content.
    */
   contentForReplacement: string;
 }
@@ -87,11 +192,15 @@ interface AppliedEdits {
 
 /**
  * Find oldText in content, trying exact match first, then fuzzy match.
- * When fuzzy matching is used, the returned contentForReplacement is the
- * fuzzy-normalized version of the content (trailing whitespace stripped,
- * Unicode quotes/dashes normalized to ASCII).
+ * When fuzzy matching is used and an offsetMap is provided, the returned
+ * index and matchLength are translated back to original-content coordinates
+ * so the caller can apply replacements against the un-normalized content.
  */
-function fuzzyFindText(content: string, oldText: string): FuzzyMatchResult {
+function fuzzyFindText(
+  content: string,
+  oldText: string,
+  offsetMap?: number[],
+): FuzzyMatchResult {
   // Try exact match first
   const exactIndex = content.indexOf(oldText);
   if (exactIndex !== -1) {
@@ -105,8 +214,8 @@ function fuzzyFindText(content: string, oldText: string): FuzzyMatchResult {
   }
 
   // Try fuzzy match - work entirely in normalized space
-  const fuzzyContent = normalizeForFuzzyMatch(content);
-  const fuzzyOldText = normalizeForFuzzyMatch(oldText);
+  const fuzzyContent = normalizeForFuzzyMatch(content) as string;
+  const fuzzyOldText = normalizeForFuzzyMatch(oldText) as string;
   const fuzzyIndex = fuzzyContent.indexOf(fuzzyOldText);
 
   if (fuzzyIndex === -1) {
@@ -119,9 +228,24 @@ function fuzzyFindText(content: string, oldText: string): FuzzyMatchResult {
     };
   }
 
-  // When fuzzy matching, we work in the normalized space for replacement.
-  // This means the output will have normalized whitespace/quotes/dashes,
-  // which is acceptable since we're fixing minor formatting differences anyway.
+  // Translate fuzzy-match span back to original-content coordinates
+  // when an offset map is available.
+  if (offsetMap) {
+    const { originalStart, originalLength } = translateFuzzySpan(
+      offsetMap,
+      fuzzyIndex,
+      fuzzyOldText.length,
+    );
+    return {
+      found: true,
+      index: originalStart,
+      matchLength: originalLength,
+      usedFuzzyMatch: true,
+      contentForReplacement: content,
+    };
+  }
+
+  // Legacy path (no map) — keep the fuzzy-normalized content as the base.
   return {
     found: true,
     index: fuzzyIndex,
@@ -355,26 +479,38 @@ function applyEdits(normalizedContent: string, edits: Edit[], path: string): App
     }
   }
 
+  // Check if any edit needs fuzzy matching.  When fuzzy matching is required
+  // we build an offset map so that match positions can be translated back to
+  // original-content coordinates, preserving bytes outside the edited span.
   const initialMatches = normalizedEdits.map((edit) =>
     fuzzyFindText(normalizedContent, edit.oldText),
   );
   const usedFuzzyMatch = initialMatches.some((match) => match.usedFuzzyMatch);
-  const replacementBaseContent = usedFuzzyMatch
-    ? normalizeForFuzzyMatch(normalizedContent)
-    : normalizedContent;
+
+  let offsetMap: number[] | undefined;
+  let replacementBaseContent = normalizedContent;
+  if (usedFuzzyMatch) {
+    // Build the offset map and use the original content as the replacement
+    // base, so untouched bytes are never rebuilt from a normalized copy.
+    const fuzzyFile = normalizeForFuzzyMatch(normalizedContent, true);
+    offsetMap = fuzzyFile.offsetMap;
+    // replacementBaseContent stays as normalizedContent (original)
+  }
 
   const matchedEdits: MatchedEdit[] = [];
   for (const [i, edit] of normalizedEdits.entries()) {
-    const matchResult = fuzzyFindText(replacementBaseContent, edit.oldText);
+    const matchResult = fuzzyFindText(
+      normalizedContent,
+      edit.oldText,
+      offsetMap,
+    );
     if (!matchResult.found) {
       throw getNotFoundError(path, i, normalizedEdits.length, normalizedContent, edit.oldText);
     }
 
-    // Count in the same space the match was found in. Fuzzy counting collapses
-    // distinctions the exact match relied on, which would reject a genuinely
-    // unique edit as ambiguous.
+    // Count occurrences in the same space the match was found in.
     const occurrences = matchResult.usedFuzzyMatch
-      ? countOccurrences(replacementBaseContent, edit.oldText)
+      ? countOccurrences(normalizedContent, edit.oldText)
       : countExactOccurrences(replacementBaseContent, edit.oldText);
     if (occurrences > 1) {
       throw getDuplicateError(path, i, normalizedEdits.length, occurrences);
@@ -403,13 +539,7 @@ function applyEdits(normalizedContent: string, edits: Edit[], path: string): App
   }
 
   const baseContent = normalizedContent;
-  const newContent = usedFuzzyMatch
-    ? applyReplacementsPreservingUnchangedLines(
-        normalizedContent,
-        replacementBaseContent,
-        matchedEdits,
-      )
-    : applyReplacements(replacementBaseContent, matchedEdits);
+  const newContent = applyReplacements(replacementBaseContent, matchedEdits);
 
   if (baseContent === newContent) {
     throw getNoChangeError(path, normalizedEdits.length);

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -15,19 +15,26 @@ import {
 } from "./edit-replacements.js";
 import { resolveToCwd } from "./path-utils.js";
 
-/**
- * Result of normalizeForFuzzyMatchWithMap — the normalized text plus a position
- * map that translates every normalized position back to the original text.
- */
+interface FuzzyBoundary {
+  /** Original offset when the normalized boundary begins a replacement. */
+  start?: number;
+  /** Original offset when the normalized boundary ends a replacement. */
+  end?: number;
+}
+
 interface FuzzyNormalizedFile {
   text: string;
-  /**
-   * For each position i in the normalized text, offsetMap[i] is the position
-   * in the original text that normalized[i] originates from.  A sentinel at
-   * offsetMap[text.length] holds original.length so that span lengths can be
-   * computed as `offsetMap[end] - offsetMap[start]`.
-   */
-  offsetMap: number[];
+  boundaries: Array<FuzzyBoundary | undefined>;
+}
+
+const fuzzyGraphemeSegmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+
+function foldFuzzyCharacters(text: string): string {
+  return text
+    .replace(/[\u2018\u2019\u201A\u201B]/g, "'")
+    .replace(/[\u201C\u201D\u201E\u201F]/g, '"')
+    .replace(/[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/g, "-")
+    .replace(/[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g, " ");
 }
 
 /**
@@ -37,117 +44,122 @@ interface FuzzyNormalizedFile {
  * - Normalize Unicode dashes/hyphens to ASCII hyphen
  * - Normalize special Unicode spaces to regular space
  *
- * Also returns an offset map that translates each position in the normalized
- * output back to its corresponding position in the input text.  The map uses
- * the sentinel convention: offsetMap[normalized.length] = original.length.
  */
-function normalizeForFuzzyMatch(text: string): string;
-function normalizeForFuzzyMatch(
-  text: string,
-  withMap: true,
-): FuzzyNormalizedFile;
-function normalizeForFuzzyMatch(
-  text: string,
-  withMap?: true,
-): string | FuzzyNormalizedFile {
-  // Step 1: NFKC — character-level folding. We track offsets by normalizing
-  // one code point at a time so we know which original position each
-  // normalized character corresponds to.
-  const nfkcBuilder: string[] = [];
-  const nfkcMap: number[] = []; // maps normalized position → original position
-  let origPos = 0;
-  while (origPos < text.length) {
-    const origCP = text.codePointAt(origPos)!;
-    const origCharLen = String.fromCodePoint(origCP).length;
-    const normChars = String.fromCodePoint(origCP).normalize("NFKC");
-    const startNormPos = nfkcBuilder.length;
-    nfkcBuilder.push(normChars);
-    for (let j = 0; j < normChars.length; j++) {
-      nfkcMap[startNormPos + j] = origPos;
-    }
-    origPos += origCharLen;
-  }
-
-  // Step 2: line-wise trimEnd and quote/dash/space replacements
-  const nfkcText = nfkcBuilder.join("");
-  const lines = nfkcText.split("\n");
-  const trimmed: string[] = [];
-  let normPos = 0;
-  for (const line of lines) {
-    const trimmedLine = line.trimEnd();
-    trimmed.push(trimmedLine);
-    // Advance normPos past the line (including the trailing newline if any)
-    normPos += line.length + 1;
-  }
-  const trimmedText = trimmed.join("\n");
-
-  // Build the trimmed → nfkc offset map
-  const trimmedMap: number[] = [];
-  let trimmedPos = 0;
-  let nfkcPos = 0;
-  for (let li = 0; li < trimmed.length; li++) {
-    const trimmedLine = trimmed[li];
-    const origLine = lines[li];
-    // Map each character of the trimmed line (they're the same up to the end
-    // of the trimmed content)
-    for (let ci = 0; ci < trimmedLine.length; ci++) {
-      trimmedMap[trimmedPos] = nfkcPos;
-      trimmedPos++;
-      nfkcPos++;
-    }
-    // After the trimmed line, there may be trailing whitespace in the original.
-    // Skip it in nfkcPos, then add a newline to trimmedPos.
-    nfkcPos += origLine.length - trimmedLine.length;
-    if (li < trimmed.length - 1) {
-      trimmedMap[trimmedPos] = nfkcPos;
-      trimmedPos++;
-      nfkcPos++; // newline
-    }
-  }
-
-  // Step 3: quote, dash, space replacement (all 1→1, so offset map is
-  // identity at this stage).
-  let finalText = trimmedText;
-  finalText = finalText.replace(/[\u2018\u2019\u201A\u201B]/g, "'");
-  finalText = finalText.replace(/[\u201C\u201D\u201E\u201F]/g, '"');
-  finalText = finalText.replace(
-    /[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]/g,
-    "-",
+function normalizeForFuzzyMatch(text: string): string {
+  return foldFuzzyCharacters(
+    text
+      .normalize("NFKC")
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .join("\n"),
   );
-  finalText = finalText.replace(
-    /[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g,
-    " ",
-  );
-
-  // Compose maps: nfkcMap(orig←nfkc) ∘ trimmedMap(nfkc←trimmed) ∘ replace(identity)
-  // → direct mapping from final normalized position to original position
-  const combinedMap: number[] = [];
-  for (let fi = 0; fi < finalText.length; fi++) {
-    const trimmedPosFromFinal = fi; // identity — replacements are 1→1
-    const nfkcPos = trimmedMap[trimmedPosFromFinal];
-    combinedMap[fi] = nfkcMap[nfkcPos];
-  }
-  // sentinel
-  combinedMap[finalText.length] = text.length;
-
-  if (withMap) {
-    return { text: finalText, offsetMap: combinedMap };
-  }
-  return finalText;
 }
 
-/**
- * Given a span in fuzzy-normalized coordinates, translate it to original-text
- * coordinates using the offset map produced by normalizeForFuzzyMatch(_, true).
- */
+function buildNfkcBoundaries(
+  text: string,
+  authoritativeNfkc: string,
+): FuzzyNormalizedFile["boundaries"] | undefined {
+  const boundaries: Array<FuzzyBoundary | undefined> = [];
+  const normalizedSegments: string[] = [];
+  let normalizedOffset = 0;
+
+  for (const segment of fuzzyGraphemeSegmenter.segment(text)) {
+    const sourceStart = segment.index;
+    const sourceEnd = sourceStart + segment.segment.length;
+    const normalizedSegment = segment.segment.normalize("NFKC");
+    normalizedSegments.push(normalizedSegment);
+
+    const boundary = boundaries[normalizedOffset] ?? {};
+    if (normalizedSegment.length === 0) {
+      // Preserve omitted source text on either side of this collapsed boundary.
+      boundaries[normalizedOffset] = {
+        end: boundary.end ?? sourceStart,
+        start: sourceEnd,
+      };
+      continue;
+    }
+
+    boundaries[normalizedOffset] = {
+      start: boundary.start ?? sourceStart,
+      end: boundary.end ?? sourceStart,
+    };
+    normalizedOffset += normalizedSegment.length;
+    boundaries[normalizedOffset] = { start: sourceEnd, end: sourceEnd };
+  }
+
+  // Grapheme segmentation is only a mapping aid. Whole-string NFKC remains
+  // authoritative; fail closed if a runtime ever segments it differently.
+  if (normalizedSegments.join("") !== authoritativeNfkc) {
+    return undefined;
+  }
+  return boundaries;
+}
+
+function buildFuzzyNormalizedFile(text: string): FuzzyNormalizedFile | undefined {
+  const authoritativeNfkc = text.normalize("NFKC");
+  const nfkcBoundaries = buildNfkcBoundaries(text, authoritativeNfkc);
+  if (!nfkcBoundaries) {
+    return undefined;
+  }
+
+  const boundaries: Array<FuzzyBoundary | undefined> = [];
+  let sourceLineStart = 0;
+  let normalizedLineStart = 0;
+
+  while (sourceLineStart <= authoritativeNfkc.length) {
+    const newlineIndex = authoritativeNfkc.indexOf("\n", sourceLineStart);
+    const sourceLineEnd = newlineIndex === -1 ? authoritativeNfkc.length : newlineIndex;
+    const line = authoritativeNfkc.slice(sourceLineStart, sourceLineEnd);
+    const keptLineEnd = sourceLineStart + line.trimEnd().length;
+
+    for (let offset = sourceLineStart; offset <= keptLineEnd; offset++) {
+      const boundary = nfkcBoundaries[offset];
+      if (boundary) {
+        boundaries[normalizedLineStart + offset - sourceLineStart] = { ...boundary };
+      }
+    }
+
+    const normalizedLineEnd = normalizedLineStart + keptLineEnd - sourceLineStart;
+    if (keptLineEnd < sourceLineEnd) {
+      const beforeTrim = nfkcBoundaries[keptLineEnd];
+      const afterTrim = nfkcBoundaries[sourceLineEnd];
+      boundaries[normalizedLineEnd] = {
+        end: beforeTrim?.end,
+        start: afterTrim?.start,
+      };
+    }
+
+    if (newlineIndex === -1) {
+      break;
+    }
+
+    const afterNewline = nfkcBoundaries[sourceLineEnd + 1];
+    boundaries[normalizedLineEnd + 1] = afterNewline ? { ...afterNewline } : undefined;
+    normalizedLineStart = normalizedLineEnd + 1;
+    sourceLineStart = sourceLineEnd + 1;
+  }
+
+  const normalizedText = normalizeForFuzzyMatch(text);
+  if (boundaries.length > normalizedText.length + 1) {
+    return undefined;
+  }
+  return { text: normalizedText, boundaries };
+}
+
 function translateFuzzySpan(
-  offsetMap: number[],
+  normalized: FuzzyNormalizedFile,
   fuzzyStart: number,
   fuzzyLength: number,
-): { originalStart: number; originalLength: number } {
+): { originalStart: number; originalLength: number } | undefined {
+  const fuzzyEnd = fuzzyStart + fuzzyLength;
+  const originalStart = normalized.boundaries[fuzzyStart]?.start;
+  const originalEnd = normalized.boundaries[fuzzyEnd]?.end;
+  if (originalStart === undefined || originalEnd === undefined) {
+    return undefined;
+  }
   return {
-    originalStart: offsetMap[fuzzyStart],
-    originalLength: offsetMap[fuzzyStart + fuzzyLength] - offsetMap[fuzzyStart],
+    originalStart,
+    originalLength: originalEnd - originalStart,
   };
 }
 
@@ -160,11 +172,8 @@ interface FuzzyMatchResult {
   matchLength: number;
   /** Whether fuzzy matching was used (false = exact match) */
   usedFuzzyMatch: boolean;
-  /**
-   * The content to use for replacement operations.
-   * Always the original (un-normalized) content.
-   */
-  contentForReplacement: string;
+  /** The normalized match exists but cannot map to an unambiguous source span. */
+  unsafeBoundary?: boolean;
 }
 
 export interface Edit {
@@ -199,7 +208,7 @@ interface AppliedEdits {
 function fuzzyFindText(
   content: string,
   oldText: string,
-  offsetMap?: number[],
+  normalizedFile?: FuzzyNormalizedFile,
 ): FuzzyMatchResult {
   // Try exact match first
   const exactIndex = content.indexOf(oldText);
@@ -209,13 +218,21 @@ function fuzzyFindText(
       index: exactIndex,
       matchLength: oldText.length,
       usedFuzzyMatch: false,
-      contentForReplacement: content,
     };
   }
 
   // Try fuzzy match - work entirely in normalized space
-  const fuzzyContent = normalizeForFuzzyMatch(content) as string;
-  const fuzzyOldText = normalizeForFuzzyMatch(oldText) as string;
+  const fuzzyContent = normalizedFile?.text ?? normalizeForFuzzyMatch(content);
+  const fuzzyOldText = normalizeForFuzzyMatch(oldText);
+  if (!fuzzyOldText) {
+    return {
+      found: false,
+      index: -1,
+      matchLength: 0,
+      usedFuzzyMatch: true,
+      unsafeBoundary: true,
+    };
+  }
   const fuzzyIndex = fuzzyContent.indexOf(fuzzyOldText);
 
   if (fuzzyIndex === -1) {
@@ -224,34 +241,27 @@ function fuzzyFindText(
       index: -1,
       matchLength: 0,
       usedFuzzyMatch: false,
-      contentForReplacement: content,
     };
   }
 
-  // Translate fuzzy-match span back to original-content coordinates
-  // when an offset map is available.
-  if (offsetMap) {
-    const { originalStart, originalLength } = translateFuzzySpan(
-      offsetMap,
-      fuzzyIndex,
-      fuzzyOldText.length,
-    );
+  const translated = normalizedFile
+    ? translateFuzzySpan(normalizedFile, fuzzyIndex, fuzzyOldText.length)
+    : undefined;
+  if (!translated) {
     return {
-      found: true,
-      index: originalStart,
-      matchLength: originalLength,
+      found: false,
+      index: -1,
+      matchLength: 0,
       usedFuzzyMatch: true,
-      contentForReplacement: content,
+      unsafeBoundary: true,
     };
   }
 
-  // Legacy path (no map) — keep the fuzzy-normalized content as the base.
   return {
     found: true,
-    index: fuzzyIndex,
-    matchLength: fuzzyOldText.length,
+    index: translated.originalStart,
+    matchLength: translated.originalLength,
     usedFuzzyMatch: true,
-    contentForReplacement: fuzzyContent,
   };
 }
 
@@ -265,6 +275,9 @@ export function stripBom(content: string): { bom: string; text: string } {
 function countOccurrences(content: string, oldText: string): number {
   const fuzzyContent = normalizeForFuzzyMatch(content);
   const fuzzyOldText = normalizeForFuzzyMatch(oldText);
+  if (!fuzzyOldText) {
+    return 0;
+  }
   return fuzzyContent.split(fuzzyOldText).length - 1;
 }
 
@@ -460,12 +473,19 @@ function getNoChangeError(path: string, totalEdits: number): EditNoChangeError {
   );
 }
 
+function getUnsafeFuzzyBoundaryError(path: string, editIndex: number, totalEdits: number): Error {
+  const target = totalEdits === 1 ? "The fuzzy match" : `The fuzzy match for edits[${editIndex}]`;
+  return new Error(
+    `${target} in ${path} crosses an ambiguous Unicode-normalization or trimmed-whitespace boundary. Copy the exact source text or use a span whose normalized boundaries map cleanly.`,
+  );
+}
+
 /**
  * Apply one or more exact-text replacements to LF-normalized content.
  *
  * All edits are matched against the same original content. Replacements are
- * then applied in reverse order so offsets remain stable. If any edit needs
- * fuzzy matching, only touched lines are rewritten from normalized content.
+ * then applied in reverse order so offsets remain stable. Fuzzy matching is
+ * lookup-only: replacements always splice into the original content.
  */
 function applyEdits(normalizedContent: string, edits: Edit[], path: string): AppliedEdits {
   const normalizedEdits = edits.map((edit) => ({
@@ -479,41 +499,26 @@ function applyEdits(normalizedContent: string, edits: Edit[], path: string): App
     }
   }
 
-  // Check if any edit needs fuzzy matching.  When fuzzy matching is required
-  // we build an offset map so that match positions can be translated back to
-  // original-content coordinates, preserving bytes outside the edited span.
-  const initialMatches = normalizedEdits.map((edit) =>
-    fuzzyFindText(normalizedContent, edit.oldText),
+  const needsFuzzyMapping = normalizedEdits.some(
+    (edit) => !normalizedContent.includes(edit.oldText),
   );
-  const usedFuzzyMatch = initialMatches.some((match) => match.usedFuzzyMatch);
-
-  let offsetMap: number[] | undefined;
-  let replacementBaseContent = normalizedContent;
-  if (usedFuzzyMatch) {
-    // Build the offset map and use the original content as the replacement
-    // base, so untouched bytes are never rebuilt from a normalized copy.
-    const fuzzyFile = normalizeForFuzzyMatch(normalizedContent, true);
-    offsetMap = fuzzyFile.offsetMap;
-    // replacementBaseContent stays as normalizedContent (original)
-  }
+  const fuzzyFile = needsFuzzyMapping ? buildFuzzyNormalizedFile(normalizedContent) : undefined;
+  const replacementBaseContent = normalizedContent;
 
   const matchedEdits: MatchedEdit[] = [];
   for (const [i, edit] of normalizedEdits.entries()) {
-    const matchResult = fuzzyFindText(
-      normalizedContent,
-      edit.oldText,
-      offsetMap,
-    );
-    if (!matchResult.found) {
-      throw getNotFoundError(path, i, normalizedEdits.length, normalizedContent, edit.oldText);
-    }
-
-    // Count occurrences in the same space the match was found in.
+    const matchResult = fuzzyFindText(normalizedContent, edit.oldText, fuzzyFile);
     const occurrences = matchResult.usedFuzzyMatch
       ? countOccurrences(normalizedContent, edit.oldText)
       : countExactOccurrences(replacementBaseContent, edit.oldText);
     if (occurrences > 1) {
       throw getDuplicateError(path, i, normalizedEdits.length, occurrences);
+    }
+    if (matchResult.unsafeBoundary) {
+      throw getUnsafeFuzzyBoundaryError(path, i, normalizedEdits.length);
+    }
+    if (!matchResult.found) {
+      throw getNotFoundError(path, i, normalizedEdits.length, normalizedContent, edit.oldText);
     }
 
     matchedEdits.push({

--- a/src/agents/sessions/tools/edit-replacements.ts
+++ b/src/agents/sessions/tools/edit-replacements.ts
@@ -90,43 +90,6 @@ function groupReplacementsByLine(
   return { lines, groups };
 }
 
-/**
- * Rewrite only lines touched by fuzzy replacements. Untouched lines retain
- * their original bytes even though matching used normalized content.
- */
-export function applyReplacementsPreservingUnchangedLines(
-  originalContent: string,
-  baseContent: string,
-  replacements: TextReplacement[],
-): string {
-  const originalLines = splitLinesWithEndings(originalContent);
-  const { lines: baseLines, groups } = groupReplacementsByLine(baseContent, replacements);
-  if (originalLines.length !== baseLines.length) {
-    throw new Error(
-      "Cannot preserve unchanged lines because the base content has a different line count.",
-    );
-  }
-
-  let originalLineIndex = 0;
-  let result = "";
-  for (const group of groups) {
-    result += originalLines.slice(originalLineIndex, group.startLine).join("");
-    const firstLine = baseLines.at(group.startLine);
-    const lastLine = baseLines.at(group.endLine - 1);
-    if (!firstLine || !lastLine) {
-      throw new Error("Replacement group is outside the base content.");
-    }
-    const groupStartOffset = firstLine.start;
-    result += applyReplacements(
-      baseContent.slice(groupStartOffset, lastLine.end),
-      group.replacements,
-      groupStartOffset,
-    );
-    originalLineIndex = group.endLine;
-  }
-  return result + originalLines.slice(originalLineIndex).join("");
-}
-
 function splitLinesWithTerminators(content: string): string[] {
   return content.match(/[^\r\n]*(?:\r\n|\r|\n)|[^\r\n]+/g) ?? [];
 }

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -52,6 +52,36 @@ describe("edit tool", () => {
     );
   });
 
+  it("writes and reports only the requested fuzzy Unicode replacement", async () => {
+    const original =
+      "export const RETRY\u00A0MAX = 3; // \u518D\u8A66\u884C\uFF08\u6700\u5927\uFF13\u56DE\uFF09\uFF71\uFF72\uFF73 \u2014 \u8A2D\u5B9A\n";
+    const expected =
+      "export const RETRY_MAX = 5; // \u518D\u8A66\u884C\uFF08\u6700\u5927\uFF13\u56DE\uFF09\uFF71\uFF72\uFF73 \u2014 \u8A2D\u5B9A\n";
+    const filePath = await createTempFile(original);
+    const tool = createEditTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-fuzzy-unicode",
+      {
+        path: filePath,
+        edits: [{ oldText: "export const RETRY MAX = 3;", newText: "export const RETRY_MAX = 5;" }],
+      },
+      undefined,
+    );
+
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe(expected);
+    const details = result.details as EditToolDetails;
+    expect(details.changed).toBe(true);
+    if (!details.changed) {
+      throw new Error("Expected the edit to change the file.");
+    }
+    expect(details.diff).toContain(
+      "+1 export const RETRY_MAX = 5; // \u518D\u8A66\u884C\uFF08\u6700\u5927\uFF13\u56DE\uFF09\uFF71\uFF72\uFF73 \u2014 \u8A2D\u5B9A",
+    );
+    expect(details.diff).not.toContain("// \u518D\u8A66\u884C(\u6700\u59273\u56DE)");
+    expect(applyPatch(original, details.patch)).toBe(expected);
+  });
+
   it("rejects invalid UTF-8 without changing a real file", async () => {
     const original = Buffer.concat([Buffer.from("heading\nprice: 5\n"), Buffer.from([0xff, 0xfe])]);
     const filePath = await createTempFile(original);
@@ -351,6 +381,49 @@ describe("edit tool", () => {
     expect((component as { preview?: { diff?: string } } | undefined)?.preview?.diff).toContain(
       "remote changed",
     );
+  });
+
+  it("renders fuzzy Unicode previews from the original source bytes", async () => {
+    const readFile = vi.fn(async () =>
+      Buffer.from(
+        "const label\u00A0= \u201Chello\u201D; // keep \uFF08\uFF13\uFF09 \u2014 unchanged\n",
+      ),
+    );
+    const operations: EditOperations = {
+      access: async () => {},
+      readFile,
+      writeFile: async () => {},
+    };
+    const tool = createEditToolDefinition("/workspace", { operations });
+    const args = {
+      path: "remote.txt",
+      edits: [{ oldText: 'const label = "hello";', newText: "const label = 'hi';" }],
+    };
+    const context = {
+      args,
+      argsComplete: true,
+      cwd: "/workspace",
+      executionStarted: false,
+      expanded: false,
+      invalidate: vi.fn(),
+      isError: false,
+      isPartial: false,
+      lastComponent: undefined,
+      showImages: false,
+      state: {},
+      toolCallId: "call-preview-fuzzy-unicode",
+    };
+
+    const component = tool.renderCall?.(args, testTheme, context);
+    await vi.waitFor(() => expect(context.invalidate).toHaveBeenCalled());
+
+    const preview = (component as { preview?: { error?: string; diff?: string } } | undefined)
+      ?.preview;
+    expect(preview?.error).toBeUndefined();
+    expect(preview?.diff).toContain(
+      "+1 const label = 'hi'; // keep \uFF08\uFF13\uFF09 \u2014 unchanged",
+    );
+    expect(preview?.diff).not.toContain("// keep (3) - unchanged");
   });
 
   it("filters fuzzy no-op edits from mixed previews", async () => {


### PR DESCRIPTION
Closes #116459

## What Problem This Solves

Fixes a data-loss bug where a fuzzy-matched `edit` call could silently rewrite
unrelated bytes on the matched line. A harmless formatting mismatch in
`oldText`, such as a plain space instead of NBSP, caused the write path to
rebuild the line from NFKC-normalized content and alter fullwidth punctuation,
halfwidth katakana, smart quotes, dashes, and other source text the edit did not
target.

## Why This Change Was Made

Fuzzy normalization remains the authoritative lookup contract, but normalized
matches are now translated back to stable boundaries in the original source.
The mapper:

- verifies grapheme-segment NFKC against whole-string NFKC before using it;
- maps complete expansions and contractions back to their full source range;
- rejects matches that start or end inside an NFKC expansion;
- uses directional boundaries around trimmed suffixes so EOF and line-end bytes
  are not accidentally consumed; and
- applies exact and fuzzy replacements directly to the original content.

Host workspace edits, sandbox edits, and TUI previews all use this shared
mapping path.

## User Impact

Fuzzy edits now preserve every byte outside the selected source span. Ambiguous
partial-normalization matches fail with an actionable error instead of guessing
and corrupting a workspace file.

## Evidence

Reviewed head: `bba4f5f76cd0467e8e0afb4daa198750154a5085`

### Focused regression proof

```text
src/agents/sessions/tools/edit-diff.test.ts
  23/23 passed

src/agents/sessions/tools/edit.test.ts
  48/48 passed

src/agents/agent-tools.sandbox-mounted-paths.workspace-only.test.ts
  9/9 passed

Total: 80/80 passed
```

Coverage includes real escaped Unicode, NBSP, smart quotes, complete and partial
NFKC expansions, combining sequences, supplementary characters, trailing bytes
at EOF, interior trim folding, CRLF, mixed exact/fuzzy batches, real host
write/readback, returned diff/patch round-trip, TUI preview, and the real sandbox
filesystem bridge.

### Real edit write/readback

The production `createEditTool` test writes a real temporary workspace file,
executes the fuzzy `edit`, reads the file back, and verifies:

```text
before:
export const RETRY<NBSP>MAX = 3; // 再試行（最大３回）ｱｲｳ — 設定

after:
export const RETRY_MAX = 5; // 再試行（最大３回）ｱｲｳ — 設定
```

The returned diff retains the original fullwidth punctuation, halfwidth
katakana, and em dash, and applying the returned patch reproduces the exact
on-disk bytes.

### Review and static proof

- `git diff --check`: passed
- `oxfmt --check` on all five touched files: passed
- fresh Codex autoreview: no findings, patch correct, confidence `0.94`
- sanitized AWS allocation was attempted with public networking, no Tailscale,
  no instance role, and no hydration; allocation failed before code execution
  because the coordinator had no EC2 credential source
- secretless exact-head pull-request CI is running as the remote fallback

[AI-assisted]

