### PR TITLE
fix(msteams): preserve stopped stream settlement

### DIFF
--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -52,15 +52,45 @@ type StreamMock = {
   clearText: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
   canceled: boolean;
+  events: {
+    on: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+  };
+  acknowledge: (text: string) => void;
 };
 
 function createStreamMock(): StreamMock {
+  let chunkHandler:
+    | ((activity: {
+        id: string;
+        type: string;
+        text: string;
+        channelData: { streamType: string };
+      }) => void)
+    | undefined;
   return {
     update: vi.fn(),
     emit: vi.fn(),
     clearText: vi.fn(),
     close: vi.fn(async () => ({ id: "stream-final" })),
     canceled: false,
+    events: {
+      on: vi.fn((_event: "chunk", handler: typeof chunkHandler) => {
+        chunkHandler = handler;
+        return 0;
+      }),
+      off: vi.fn(() => {
+        chunkHandler = undefined;
+      }),
+    },
+    acknowledge: (text: string) => {
+      chunkHandler?.({
+        id: "stream-acknowledged",
+        type: "typing",
+        text,
+        channelData: { streamType: "streaming" },
+      });
+    },
   };
 }
 
@@ -455,7 +485,7 @@ describe("createMSTeamsReplyDispatcher", () => {
   });
 
   it("falls back to normal Teams delivery when native stream close returns no final activity", async () => {
-    renderReplyPayloadsToMessagesMock.mockReturnValue([{ content: "fallback" }] as never);
+    renderReplyPayloadsToMessagesMock.mockReturnValue([{ text: "streamed final" }] as never);
     sendMSTeamsMessagesMock.mockResolvedValue(["fallback-id"] as never);
     const dispatcher = createDispatcher("personal");
     const options = dispatcherOptions();
@@ -475,8 +505,78 @@ describe("createMSTeamsReplyDispatcher", () => {
       expect.any(Object),
     );
     expect(sendMSTeamsMessagesMock).toHaveBeenCalledWith(
-      expect.objectContaining({ messages: [{ content: "fallback" }] }),
+      expect.objectContaining({ messages: [{ text: "streamed final" }] }),
     );
+  });
+
+  it("keeps acknowledged stream identity ahead of successful fallback ids", async () => {
+    renderReplyPayloadsToMessagesMock.mockReturnValue([{ text: "world" }] as never);
+    sendMSTeamsMessagesMock.mockResolvedValue(["fallback-id"] as never);
+    const dispatcher = createDispatcher("personal");
+    const options = dispatcherOptions();
+    const stream = getStreamMock();
+    stream.close.mockResolvedValueOnce(undefined);
+
+    dispatcher.replyOptions.onPartialReply?.({ text: "hello" });
+    stream.acknowledge("hello");
+    const result = await options.deliver({ text: "hello world" });
+    await dispatcher.dispatcherOptions.onSettled?.();
+
+    await expect(result?.finalization).resolves.toEqual({
+      visibleReplySent: true,
+      messageIds: ["stream-acknowledged", "fallback-id"],
+      content: "hello world",
+    });
+  });
+
+  it("preserves acknowledged text when a media-only final has no logical text", async () => {
+    renderReplyPayloadsToMessagesMock.mockImplementation(([payload]) =>
+      payload.mediaUrl ? [{ mediaUrl: payload.mediaUrl }] : [],
+    );
+    sendMSTeamsMessagesMock.mockResolvedValue(["media-id"] as never);
+    const dispatcher = createDispatcher("personal");
+    const options = dispatcherOptions();
+    const stream = getStreamMock();
+    stream.close.mockResolvedValueOnce(undefined);
+
+    dispatcher.replyOptions.onPartialReply?.({ text: "hello" });
+    stream.acknowledge("hello");
+    const result = await options.deliver({ mediaUrl: "https://example.com/image.png" });
+    await dispatcher.dispatcherOptions.onSettled?.();
+
+    await expect(result?.finalization).resolves.toEqual({
+      visibleReplySent: true,
+      messageIds: ["stream-acknowledged", "media-id"],
+      content: "hello",
+    });
+  });
+
+  it("reports only accepted native and fallback content after partial fallback failure", async () => {
+    renderReplyPayloadsToMessagesMock.mockReturnValue([
+      { text: "world-one" },
+      { text: "world-two" },
+    ] as never);
+    sendMSTeamsMessagesMock
+      .mockResolvedValueOnce(["fallback-id"] as never)
+      .mockRejectedValueOnce(new Error("fallback failed"));
+    const dispatcher = createDispatcher("personal");
+    const options = dispatcherOptions();
+    const stream = getStreamMock();
+    stream.close.mockRejectedValueOnce(new Error("close failed"));
+
+    dispatcher.replyOptions.onPartialReply?.({ text: "hello" });
+    stream.acknowledge("hello");
+    const result = await options.deliver({ text: "hello world" });
+    const finalization = expect(result?.finalization).rejects.toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        visibleReplySent: true,
+        messageIds: ["stream-acknowledged", "fallback-id"],
+        content: "hello\nworld-one",
+      },
+    });
+    await dispatcher.dispatcherOptions.onSettled?.();
+    await finalization;
   });
 
   it("sets suppressDefaultToolProgressMessages when progress tool lines are enabled", async () => {
@@ -675,10 +775,7 @@ describe("createMSTeamsReplyDispatcher", () => {
 
   it("queues a system event when some queued Teams messages fail to send", async () => {
     const onSentMessageIds = vi.fn();
-    renderReplyPayloadsToMessagesMock.mockReturnValue([
-      { content: "one" },
-      { content: "two" },
-    ] as never);
+    renderReplyPayloadsToMessagesMock.mockReturnValue([{ text: "one" }, { text: "two" }] as never);
     sendMSTeamsMessagesMock
       .mockResolvedValueOnce(["id-1"] as never)
       .mockRejectedValueOnce(Object.assign(new Error("gateway timeout"), { statusCode: 502 }));
@@ -696,7 +793,7 @@ describe("createMSTeamsReplyDispatcher", () => {
       deliveryResult: {
         visibleReplySent: true,
         messageIds: ["id-1"],
-        content: "block content",
+        content: "one",
       },
     });
     await dispatcher.dispatcherOptions.onSettled?.();

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -915,7 +915,7 @@ describe("createMSTeamsReplyDispatcher", () => {
     ] as never);
     const dispatcher = createDispatcher("personal");
     const stream = getStreamMock();
-    stream.close.mockImplementation(async () => {
+    stream.close.mockImplementation(() => {
       stream.canceled = true;
       return undefined;
     });
@@ -929,7 +929,7 @@ describe("createMSTeamsReplyDispatcher", () => {
     }
     await dispatcher.dispatcherOptions.onSettled?.();
 
-    const nativeResult = results.find((result) => result?.finalization);
+    const nativeResult = results.find((result) => result?.finalization !== undefined);
     await expect(nativeResult?.finalization).resolves.toEqual({
       visibleReplySent: true,
       messageIds: ["stream-acknowledged"],

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -1,6 +1,7 @@
 // Msteams tests cover reply dispatcher plugin behavior.
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../runtime-api.js";
 
 const createChannelMessageReplyPipelineMock = vi.hoisted(() => vi.fn());
 const getMSTeamsRuntimeMock = vi.hoisted(() => vi.fn());
@@ -199,9 +200,9 @@ describe("createMSTeamsReplyDispatcher", () => {
 
   type DispatcherOptions = {
     onReplyStart?: () => Promise<void> | void;
-    deliver: (payload: {
-      text: string;
-    }) => ReturnType<ReturnType<typeof createMSTeamsReplyDispatcher>["delivery"]["deliver"]>;
+    deliver: (
+      payload: ReplyPayload,
+    ) => ReturnType<ReturnType<typeof createMSTeamsReplyDispatcher>["delivery"]["deliver"]>;
   };
 
   type PipelineArgs = {
@@ -530,9 +531,9 @@ describe("createMSTeamsReplyDispatcher", () => {
   });
 
   it("preserves acknowledged text when a media-only final has no logical text", async () => {
-    renderReplyPayloadsToMessagesMock.mockImplementation(([payload]) =>
-      payload.mediaUrl ? [{ mediaUrl: payload.mediaUrl }] : [],
-    );
+    renderReplyPayloadsToMessagesMock.mockReturnValue([
+      { mediaUrl: "https://example.com/image.png" },
+    ] as never);
     sendMSTeamsMessagesMock.mockResolvedValue(["media-id"] as never);
     const dispatcher = createDispatcher("personal");
     const options = dispatcherOptions();
@@ -882,6 +883,92 @@ describe("createMSTeamsReplyDispatcher", () => {
       messageIds: ["stream-final"],
       content: "streamed final",
     });
+  });
+
+  it.each([
+    {
+      name: "attached media",
+      payloads: [
+        {
+          text: "provider final",
+          mediaUrl: "https://example.test/must-not-send.png",
+        },
+      ],
+    },
+    {
+      name: "media after text",
+      payloads: [
+        { text: "provider final" },
+        { mediaUrl: "https://example.test/must-not-send.png" },
+      ],
+    },
+    {
+      name: "media before text",
+      payloads: [
+        { mediaUrl: "https://example.test/must-not-send.png" },
+        { text: "provider final" },
+      ],
+    },
+  ])("settles a stopped divergent final without $name fallback", async ({ payloads }) => {
+    renderReplyPayloadsToMessagesMock.mockReturnValue([
+      { mediaUrl: "https://example.test/must-not-send.png" },
+    ] as never);
+    const dispatcher = createDispatcher("personal");
+    const stream = getStreamMock();
+    stream.close.mockImplementation(async () => {
+      stream.canceled = true;
+      return undefined;
+    });
+
+    dispatcher.replyOptions.onPartialReply?.({ text: "streamed preview" });
+    stream.acknowledge("streamed preview");
+    dispatcher.replyOptions.onPartialReply?.({ text: "provider final" });
+    const results = [];
+    for (const payload of payloads) {
+      results.push(await dispatcher.delivery.deliver(payload, { kind: "final" }));
+    }
+    await dispatcher.dispatcherOptions.onSettled?.();
+
+    const nativeResult = results.find((result) => result?.finalization);
+    await expect(nativeResult?.finalization).resolves.toEqual({
+      visibleReplySent: true,
+      messageIds: ["stream-acknowledged"],
+      content: "streamed preview",
+    });
+    expect(stream.clearText).toHaveBeenCalledTimes(1);
+    expect(stream.close).toHaveBeenCalledTimes(1);
+    expect(renderReplyPayloadsToMessagesMock).not.toHaveBeenCalled();
+    expect(sendMSTeamsMessagesMock).not.toHaveBeenCalled();
+  });
+
+  it("releases later payloads only after divergent native replacement settles", async () => {
+    renderReplyPayloadsToMessagesMock.mockReturnValue([{ text: "second payload" }] as never);
+    sendMSTeamsMessagesMock.mockResolvedValue(["post-native-id"] as never);
+    const dispatcher = createDispatcher("personal");
+    const stream = getStreamMock();
+
+    dispatcher.replyOptions.onPartialReply?.({ text: "streamed preview" });
+    stream.acknowledge("streamed preview");
+    dispatcher.replyOptions.onPartialReply?.({ text: "provider final" });
+    const nativeResult = await dispatcher.delivery.deliver(
+      { text: "provider final" },
+      { kind: "final" },
+    );
+    await dispatcher.delivery.deliver({ text: "second payload" }, { kind: "final" });
+
+    expect(sendMSTeamsMessagesMock).not.toHaveBeenCalled();
+    await dispatcher.dispatcherOptions.onSettled?.();
+
+    await expect(nativeResult?.finalization).resolves.toEqual({
+      visibleReplySent: true,
+      messageIds: ["stream-final", "post-native-id"],
+      content: "provider final\nsecond payload",
+    });
+    expect(renderReplyPayloadsToMessagesMock).toHaveBeenCalledWith(
+      [{ text: "second payload" }],
+      expect.any(Object),
+    );
+    expect(sendMSTeamsMessagesMock).toHaveBeenCalledTimes(1);
   });
 
   it("settles delivery when sent-message ID observation throws", async () => {

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -211,21 +211,28 @@ export function createMSTeamsReplyDispatcher(params: {
     content?: string;
   };
 
+  type AcceptedDeliveryPart = {
+    messageIds: string[];
+    content?: string;
+  };
+
   type PendingDelivery = {
     messages: MSTeamsRenderedMessage[];
     finalization: ReturnType<typeof createDeferred<DeliveryOutcome>>;
     content?: string;
+    nativeResult?: AcceptedDeliveryPart;
+    blockResults: AcceptedDeliveryPart[];
     native: boolean;
     nativeSettled: boolean;
     blockSettled: boolean;
     settled: boolean;
-    visibleReplySent: boolean;
-    nativeMessageId?: string;
-    messageIds: string[];
     errors: unknown[];
   };
 
   const pendingDeliveries: PendingDelivery[] = [];
+
+  const joinAcceptedContents = (contents: readonly (string | undefined)[]): string =>
+    contents.filter((content): content is string => Boolean(content)).join("\n");
 
   const sendMessages = async (messages: MSTeamsRenderedMessage[]): Promise<string[]> => {
     return sendMSTeamsMessages({
@@ -287,16 +294,19 @@ export function createMSTeamsReplyDispatcher(params: {
   };
 
   const deliveryOutcome = (delivery: PendingDelivery): DeliveryOutcome => {
-    const messageIds = [
-      ...(delivery.nativeMessageId ? [delivery.nativeMessageId] : []),
-      ...delivery.messageIds,
+    const acceptedParts = [
+      ...(delivery.nativeResult ? [delivery.nativeResult] : []),
+      ...delivery.blockResults,
     ];
+    const messageIds = acceptedParts.flatMap((part) => part.messageIds);
+    const content =
+      delivery.errors.length > 0
+        ? joinAcceptedContents(acceptedParts.map((part) => part.content))
+        : delivery.content;
     return {
-      visibleReplySent: delivery.visibleReplySent,
+      visibleReplySent: acceptedParts.length > 0,
       ...(messageIds.length > 0 ? { messageIds } : {}),
-      ...(delivery.visibleReplySent && delivery.content !== undefined
-        ? { content: delivery.content }
-        : {}),
+      ...(acceptedParts.length > 0 && content !== undefined ? { content } : {}),
     };
   };
 
@@ -320,7 +330,7 @@ export function createMSTeamsReplyDispatcher(params: {
         (candidate) => !(candidate instanceof PlatformMessageNotDispatchedError),
       ) ?? delivery.errors[0];
     delivery.finalization.reject(
-      delivery.visibleReplySent
+      outcome.visibleReplySent
         ? createChannelPartialDeliveryError(error, {
             ...outcome,
             visibleReplySent: true,
@@ -339,12 +349,11 @@ export function createMSTeamsReplyDispatcher(params: {
       messages,
       finalization,
       content: payload.text,
+      blockResults: [],
       native,
       nativeSettled: !native,
       blockSettled: messages.length === 0,
       settled: false,
-      visibleReplySent: false,
-      messageIds: [],
       errors: [],
     };
     pendingDeliveries.push(delivery);
@@ -364,9 +373,13 @@ export function createMSTeamsReplyDispatcher(params: {
       for (const msg of toSend) {
         try {
           const msgIds = await sendMessages([msg]);
-          delivery.visibleReplySent ||= msgIds.length > 0;
           const validIds = msgIds.filter((id) => id.trim() && id !== "unknown");
-          delivery.messageIds.push(...validIds);
+          if (msgIds.length > 0) {
+            delivery.blockResults.push({
+              messageIds: validIds,
+              ...(msg.text ? { content: msg.text } : {}),
+            });
+          }
           sentIds.push(...validIds);
         } catch (msgError) {
           failed += 1;
@@ -480,9 +493,16 @@ export function createMSTeamsReplyDispatcher(params: {
       return;
     }
 
-    nativeDelivery.visibleReplySent ||= nativeResult.visibleReplySent;
-    nativeDelivery.nativeMessageId = nativeResult.messageId;
-    if (nativeResult.content !== undefined) {
+    if (nativeResult.visibleReplySent) {
+      nativeDelivery.nativeResult = {
+        messageIds: nativeResult.messageId ? [nativeResult.messageId] : [],
+        ...(nativeResult.content !== undefined ? { content: nativeResult.content } : {}),
+      };
+    }
+    if (
+      nativeResult.content !== undefined &&
+      (!nativeResult.fallbackPayload || nativeDelivery.content === undefined)
+    ) {
       nativeDelivery.content = nativeResult.content;
     }
     if (nativeResult.fallbackPayload) {

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -499,14 +499,24 @@ export function createMSTeamsReplyDispatcher(params: {
         ...(nativeResult.content !== undefined ? { content: nativeResult.content } : {}),
       };
     }
-    if (
+    const hasPostNativePayloads = Boolean(nativeResult.postNativePayloads?.length);
+    if (nativeResult.logicalContent !== undefined) {
+      nativeDelivery.content = nativeResult.logicalContent;
+    } else if (
       nativeResult.content !== undefined &&
-      (!nativeResult.fallbackPayload || nativeDelivery.content === undefined)
+      ((!nativeResult.fallbackPayload && !hasPostNativePayloads) ||
+        nativeDelivery.content === undefined)
     ) {
       nativeDelivery.content = nativeResult.content;
     }
-    if (nativeResult.fallbackPayload) {
-      nativeDelivery.messages.push(...renderReplyPayload(nativeResult.fallbackPayload));
+    const afterNativePayloads = [
+      ...(nativeResult.fallbackPayload ? [nativeResult.fallbackPayload] : []),
+      ...(nativeResult.postNativePayloads ?? []),
+    ];
+    if (afterNativePayloads.length > 0) {
+      nativeDelivery.messages.push(
+        ...afterNativePayloads.flatMap((payload) => renderReplyPayload(payload)),
+      );
       nativeDelivery.blockSettled = nativeDelivery.messages.length === 0;
     }
     nativeDelivery.nativeSettled = true;

--- a/extensions/msteams/src/reply-stream-controller.sdk.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.sdk.test.ts
@@ -178,7 +178,8 @@ describe("Microsoft Teams SDK acknowledged stream fallback", () => {
 
     await expect(controller.finalize()).resolves.toEqual({
       visibleReplySent: true,
-      content: completeReply,
+      content: acknowledgedPrefix,
+      messageId: "stream-size-limit",
       fallbackPayload: { text: "b".repeat(200) },
     });
     // Finalization queues its own metadata activity; this is a second
@@ -221,6 +222,7 @@ describe("Microsoft Teams SDK acknowledged stream fallback", () => {
     await expect(controller.finalize()).resolves.toEqual({
       visibleReplySent: true,
       content: acknowledgedPrefix,
+      messageId: "stream-cancel",
     });
     expect(requests.filter((request) => request.scenario === "cancel")).toHaveLength(2);
   });

--- a/extensions/msteams/src/reply-stream-controller.sdk.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.sdk.test.ts
@@ -12,6 +12,7 @@ type TeamsLoopbackRequest = {
 
 const acknowledgedPrefix = "a".repeat(4_000);
 const completeReply = `${acknowledgedPrefix}${"b".repeat(200)}`;
+const replacementReply = "provider-final replacement";
 const requests: TeamsLoopbackRequest[] = [];
 
 const provider = createServer((request, response) => {
@@ -25,7 +26,11 @@ const provider = createServer((request, response) => {
       text?: string;
     };
     const scenario = request.url?.slice(1) ?? "";
-    const rejected = scenario === "no-ack" || (activity.text?.length ?? 0) > 4_000;
+    const priorScenarioRequests = requests.filter((entry) => entry.scenario === scenario).length;
+    const rejected =
+      scenario === "no-ack" ||
+      (scenario === "cancel-replacement" && priorScenarioRequests > 0) ||
+      (activity.text?.length ?? 0) > 4_000;
     const status = rejected ? 403 : 201;
     requests.push({
       scenario,
@@ -39,10 +44,9 @@ const provider = createServer((request, response) => {
         rejected
           ? {
               error: {
-                message:
-                  scenario === "cancel"
-                    ? "Content stream was canceled by user"
-                    : "Message size too large",
+                message: scenario.startsWith("cancel")
+                  ? "Content stream was canceled by user"
+                  : "Message size too large",
               },
             }
           : { id: `stream-${scenario}` },
@@ -225,5 +229,71 @@ describe("Microsoft Teams SDK acknowledged stream fallback", () => {
       messageId: "stream-cancel",
     });
     expect(requests.filter((request) => request.scenario === "cancel")).toHaveLength(2);
+  });
+
+  it("replaces a divergent preview through the same real Teams stream", async () => {
+    const { acknowledgements, controller, logger } = createLoopbackController("replacement");
+
+    controller.onPartialReply({ text: acknowledgedPrefix });
+    await vi.waitFor(() => {
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(acknowledgements).toEqual([{ id: "stream-replacement", text: acknowledgedPrefix }]);
+    });
+
+    controller.onPartialReply({ text: replacementReply });
+    expect(
+      controller.preparePayload({
+        text: replacementReply,
+        mediaUrl: "https://example.test/replacement.png",
+      }),
+    ).toBeUndefined();
+    await expect(controller.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      content: replacementReply,
+      logicalContent: replacementReply,
+      messageId: "stream-replacement",
+      postNativePayloads: [
+        {
+          text: undefined,
+          mediaUrl: "https://example.test/replacement.png",
+        },
+      ],
+    });
+    expect(acknowledgements).toEqual([
+      { id: "stream-replacement", text: acknowledgedPrefix },
+      { id: "stream-replacement", text: replacementReply },
+    ]);
+    expect(requests.filter((request) => request.scenario === "replacement")).toHaveLength(3);
+  });
+
+  it("detects Stop while replacing a divergent preview and suppresses the final", async () => {
+    const { acknowledgements, controller, logger, stream } =
+      createLoopbackController("cancel-replacement");
+
+    controller.onPartialReply({ text: acknowledgedPrefix });
+    await vi.waitFor(() => {
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(acknowledgements).toEqual([
+        { id: "stream-cancel-replacement", text: acknowledgedPrefix },
+      ]);
+    });
+
+    controller.onPartialReply({ text: replacementReply });
+    expect(
+      controller.preparePayload({
+        text: replacementReply,
+        mediaUrl: "https://example.test/must-not-send.png",
+      }),
+    ).toBeUndefined();
+    await expect(controller.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      content: acknowledgedPrefix,
+      messageId: "stream-cancel-replacement",
+    });
+    expect(stream.canceled).toBe(true);
+    expect(acknowledgements).toEqual([
+      { id: "stream-cancel-replacement", text: acknowledgedPrefix },
+    ]);
+    expect(requests.filter((request) => request.scenario === "cancel-replacement")).toHaveLength(2);
   });
 });

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -286,8 +286,7 @@ describe("createTeamsReplyStreamController", () => {
     expect(ctrl.preparePayload({ text: "streamed final" })).toBeUndefined();
 
     await expect(ctrl.finalize()).resolves.toEqual({
-      visibleReplySent: true,
-      content: "streamed final",
+      visibleReplySent: false,
       fallbackPayload: { text: "streamed final" },
     });
   });
@@ -304,8 +303,7 @@ describe("createTeamsReplyStreamController", () => {
     });
 
     await expect(ctrl.finalize()).resolves.toEqual({
-      visibleReplySent: true,
-      content: "streamed final",
+      visibleReplySent: false,
       fallbackPayload: {
         text: "streamed final",
         mediaUrl: undefined,
@@ -323,8 +321,7 @@ describe("createTeamsReplyStreamController", () => {
     expect(ctrl.preparePayload({ text: "streamed final" })).toBeUndefined();
 
     await expect(ctrl.finalize()).resolves.toEqual({
-      visibleReplySent: true,
-      content: "streamed final",
+      visibleReplySent: false,
       fallbackPayload: { text: "streamed final" },
     });
   });
@@ -522,6 +519,7 @@ describe("createTeamsReplyStreamController", () => {
       const stream = makeStream();
       const ctrl = makeController({ stream });
       ctrl.onPartialReply({ text: "partial" });
+      expect(ctrl.preparePayload({ text: "partial" })).toBeUndefined();
       // Cancel after we've started streaming, then make the final emit throw.
       stream.emit.mockImplementation(() => {
         throw makeCancelError();
@@ -529,8 +527,7 @@ describe("createTeamsReplyStreamController", () => {
       // Must not throw — finalize's pre-check on stream.canceled may miss
       // the cancellation that happens between check and emit.
       await expect(ctrl.finalize()).resolves.toEqual({
-        visibleReplySent: true,
-        content: "partial",
+        visibleReplySent: false,
       });
     });
 
@@ -613,7 +610,7 @@ describe("createTeamsReplyStreamController", () => {
       expect(ctrl.preparePayload({ text: "hello again" })).toEqual({
         text: "hello again",
       });
-      expect(stream.events.off).toHaveBeenCalledOnce();
+      expect(stream.events.off).not.toHaveBeenCalled();
     });
 
     it("ignores unrelated, informative, and out-of-order stream acknowledgements", () => {
@@ -681,7 +678,8 @@ describe("createTeamsReplyStreamController", () => {
 
       await expect(ctrl.finalize()).resolves.toEqual({
         visibleReplySent: true,
-        content: "hello world",
+        content: "hello",
+        messageId: "stream-acknowledged",
         fallbackPayload: { text: " world" },
       });
       expect(stream.events.off).toHaveBeenCalledWith(0);
@@ -699,6 +697,7 @@ describe("createTeamsReplyStreamController", () => {
       await expect(ctrl.finalize()).resolves.toEqual({
         visibleReplySent: true,
         content: "hello",
+        messageId: "stream-acknowledged",
       });
       expect(stream.events.off).toHaveBeenCalledWith(0);
     });
@@ -715,6 +714,7 @@ describe("createTeamsReplyStreamController", () => {
       await expect(ctrl.finalize()).resolves.toEqual({
         visibleReplySent: true,
         content: "hello",
+        messageId: "stream-acknowledged",
       });
       expect(stream.events.off).toHaveBeenCalledWith(0);
     });
@@ -739,8 +739,7 @@ describe("createTeamsReplyStreamController", () => {
       // Finalize must not propagate; it returns the retained payload so the
       // dispatcher can fall back to normal Teams delivery.
       await expect(ctrl.finalize()).resolves.toEqual({
-        visibleReplySent: true,
-        content: "partial final",
+        visibleReplySent: false,
         fallbackPayload: { text: "partial final" },
       });
     });

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -121,7 +121,7 @@ describe("createTeamsReplyStreamController", () => {
     expect(stream.emit).toHaveBeenNthCalledWith(2, "Next");
   });
 
-  it("falls back and closes the stream for non-whitespace rewrites", async () => {
+  it("replaces non-whitespace rewrites through the native stream", async () => {
     const stream = makeStream();
     const ctrl = makeController({ stream });
 
@@ -130,10 +130,217 @@ describe("createTeamsReplyStreamController", () => {
 
     expect(stream.emit).toHaveBeenCalledTimes(1);
     expect(stream.emit).toHaveBeenCalledWith("abcde");
-    expect(ctrl.preparePayload({ text: "abXYZ" })).toEqual({ text: "abXYZ" });
-    await ctrl.finalize();
+    expect(ctrl.preparePayload({ text: "abXYZ" })).toBeUndefined();
+    expect(stream.emit).toHaveBeenCalledTimes(2);
+    expect(stream.emit).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "message", text: "abXYZ" }),
+    );
+    await expect(ctrl.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      messageId: "stream-final",
+      content: "abXYZ",
+      logicalContent: "abXYZ",
+    });
     expect(stream.clearText).toHaveBeenCalledTimes(1);
     expect(stream.close).toHaveBeenCalled();
+  });
+
+  it("retains an acknowledged replacement when stream close produces no activity", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+
+    ctrl.onPartialReply({ text: "abcde" });
+    stream.acknowledge("abcde");
+    ctrl.onPartialReply({ text: "provider replacement" });
+    expect(
+      ctrl.preparePayload({
+        text: "provider replacement",
+        mediaUrl: "https://example.test/replacement.png",
+      }),
+    ).toBeUndefined();
+    stream.acknowledge("provider replacement");
+    stream.close.mockResolvedValueOnce(undefined);
+
+    await expect(ctrl.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      messageId: "stream-acknowledged",
+      content: "provider replacement",
+      logicalContent: "provider replacement",
+      postNativePayloads: [
+        {
+          text: undefined,
+          mediaUrl: "https://example.test/replacement.png",
+        },
+      ],
+    });
+  });
+
+  it("falls back to the full replacement when close fails before acknowledgement", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+
+    ctrl.onPartialReply({ text: "abcde" });
+    stream.acknowledge("abcde");
+    ctrl.onPartialReply({ text: "provider replacement" });
+    expect(ctrl.preparePayload({ mediaUrl: "https://example.test/before.png" })).toBeUndefined();
+    expect(
+      ctrl.preparePayload({
+        text: "provider replacement",
+        mediaUrl: "https://example.test/replacement.png",
+      }),
+    ).toBeUndefined();
+    stream.close.mockRejectedValueOnce(new Error("close failed"));
+
+    await expect(ctrl.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      messageId: "stream-acknowledged",
+      content: "abcde",
+      logicalContent: "provider replacement",
+      postNativePayloads: [
+        { mediaUrl: "https://example.test/before.png" },
+        {
+          text: "provider replacement",
+          mediaUrl: "https://example.test/replacement.png",
+        },
+      ],
+    });
+  });
+
+  it("ignores a delayed old chunk that is only a prefix of the replacement", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+
+    ctrl.onPartialReply({ text: "abcde" });
+    stream.acknowledge("abcde");
+    ctrl.onPartialReply({ text: "ab replacement" });
+    expect(ctrl.preparePayload({ text: "ab replacement" })).toBeUndefined();
+    stream.acknowledge("ab");
+    stream.close.mockRejectedValueOnce(new Error("close failed"));
+
+    await expect(ctrl.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      messageId: "stream-acknowledged",
+      content: "abcde",
+      logicalContent: "ab replacement",
+      postNativePayloads: [{ text: "ab replacement" }],
+    });
+  });
+
+  it("rejects a delayed common-prefix chunk while awaiting replacement acknowledgement", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+
+    ctrl.onPartialReply({ text: "abcdef" });
+    ctrl.onPartialReply({ text: "abcXYZ" });
+    expect(ctrl.preparePayload({ text: "abcXYZ" })).toBeUndefined();
+    stream.acknowledge("abc");
+    stream.close.mockRejectedValueOnce(new Error("close failed"));
+
+    await expect(ctrl.finalize()).resolves.toEqual({
+      visibleReplySent: false,
+      logicalContent: "abcXYZ",
+      postNativePayloads: [{ text: "abcXYZ" }],
+    });
+  });
+
+  it("uses the latest partial when no final text payload follows a rewrite", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+
+    ctrl.onPartialReply({ text: "abcde" });
+    stream.acknowledge("abcde");
+    ctrl.onPartialReply({ text: "abXYZ" });
+    ctrl.onPartialReply({ text: "abcdef" });
+    expect(ctrl.preparePayload({ mediaUrl: "https://example.test/final.png" })).toBeUndefined();
+
+    await expect(ctrl.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      messageId: "stream-final",
+      content: "abcdef",
+      logicalContent: "abcdef",
+      postNativePayloads: [{ mediaUrl: "https://example.test/final.png" }],
+    });
+    expect(stream.emit).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "message", text: "abcdef" }),
+    );
+  });
+
+  it("suppresses a replacement when emit synchronously discovers Stop", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+
+    ctrl.onPartialReply({ text: "abcde" });
+    stream.acknowledge("abcde");
+    ctrl.onPartialReply({ text: "provider replacement" });
+    stream.emit.mockImplementation(() => {
+      const error = new Error("stream canceled");
+      error.name = "StreamCancelledError";
+      throw error;
+    });
+
+    expect(ctrl.preparePayload({ text: "provider replacement" })).toBeUndefined();
+    await expect(ctrl.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      messageId: "stream-acknowledged",
+      content: "abcde",
+    });
+    expect(stream.close).not.toHaveBeenCalled();
+  });
+
+  it("holds payloads around replacement text until native settlement", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+
+    ctrl.onPartialReply({ text: "abcde" });
+    stream.acknowledge("abcde");
+    ctrl.onPartialReply({ text: "provider replacement" });
+
+    expect(ctrl.preparePayload({ mediaUrl: "https://example.test/before.png" })).toBeUndefined();
+    expect(ctrl.preparePayload({ text: "provider replacement" })).toBeUndefined();
+    expect(
+      ctrl.preparePayload({
+        text: "second payload",
+        mediaUrl: "https://example.test/after.png",
+      }),
+    ).toBeUndefined();
+
+    await expect(ctrl.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      messageId: "stream-final",
+      content: "provider replacement",
+      logicalContent: "provider replacement\nsecond payload",
+      postNativePayloads: [
+        { mediaUrl: "https://example.test/before.png" },
+        { text: "second payload", mediaUrl: "https://example.test/after.png" },
+      ],
+    });
+  });
+
+  it("preserves held payload order after replacement emit fails", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+
+    ctrl.onPartialReply({ text: "abcde" });
+    stream.acknowledge("abcde");
+    ctrl.onPartialReply({ text: "provider replacement" });
+    expect(ctrl.preparePayload({ mediaUrl: "https://example.test/before.png" })).toBeUndefined();
+    stream.emit.mockImplementationOnce(() => {
+      throw new Error("network failure");
+    });
+    expect(ctrl.preparePayload({ text: "provider replacement" })).toBeUndefined();
+    expect(ctrl.preparePayload({ text: "later payload" })).toBeUndefined();
+
+    await expect(ctrl.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      messageId: "stream-final",
+      content: "abcde",
+      logicalContent: "provider replacement\nlater payload",
+      postNativePayloads: [
+        { mediaUrl: "https://example.test/before.png" },
+        { text: "provider replacement" },
+        { text: "later payload" },
+      ],
+    });
   });
 
   it("ignores duplicate or out-of-order partial replies that don't extend the text", () => {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -34,9 +34,15 @@ type TeamsStreamChunkEvents = {
 type MSTeamsNativeDeliveryFinalization = {
   visibleReplySent: boolean;
   content?: string;
+  logicalContent?: string;
   messageId?: string;
   fallbackPayload?: ReplyPayload;
+  postNativePayloads?: ReplyPayload[];
 };
+
+type DeferredReplacementEntry =
+  | { kind: "payload"; payload: ReplyPayload }
+  | { kind: "replacement"; payload: ReplyPayload };
 
 // The SDK throws StreamCancelledError synchronously from stream.emit/update
 // when the user pressed Stop in Teams (Teams replies 403 to the next chunk
@@ -115,6 +121,12 @@ export function createTeamsReplyStreamController(params: {
   let emittedText = "";
   let acknowledgedText = "";
   let acknowledgedStreamId: string | undefined;
+  let replacementFinalPending = false;
+  let replacementEmitFailed = false;
+  let replacementSettlementPending = false;
+  let replacementTextAwaitingAcknowledgement: string | undefined;
+  let deferredReplacementEntries: DeferredReplacementEntry[] = [];
+  let finalMetadataQueued = false;
   let failedSegmentFallbackPrepared = false;
   const streamEvents = (stream as { events?: TeamsStreamChunkEvents } | undefined)?.events;
   let streamChunkSubscription: number | undefined;
@@ -123,19 +135,30 @@ export function createTeamsReplyStreamController(params: {
   // activity. Never infer delivered text from emit(), queued bytes, or errors.
   if (typeof streamEvents?.on === "function" && typeof streamEvents.off === "function") {
     streamChunkSubscription = streamEvents.on("chunk", (activity) => {
+      const replacementAcknowledgementPending =
+        replacementTextAwaitingAcknowledgement !== undefined;
+      const replacementAcknowledgement =
+        typeof activity.text === "string" &&
+        replacementAcknowledgementPending &&
+        activity.text === replacementTextAwaitingAcknowledgement;
       if (
         activity.type !== "typing" ||
         activity.channelData?.streamType !== "streaming" ||
         !activity.id ||
         !activity.text ||
         (acknowledgedStreamId !== undefined && activity.id !== acknowledgedStreamId) ||
-        !activity.text.startsWith(acknowledgedText) ||
+        (replacementAcknowledgementPending
+          ? !replacementAcknowledgement
+          : !activity.text.startsWith(acknowledgedText)) ||
         !emittedText.startsWith(activity.text)
       ) {
         return;
       }
       acknowledgedStreamId = activity.id;
       acknowledgedText = activity.text;
+      if (activity.text === replacementTextAwaitingAcknowledgement) {
+        replacementTextAwaitingAcknowledgement = undefined;
+      }
     });
   }
 
@@ -179,6 +202,47 @@ export function createTeamsReplyStreamController(params: {
   const fallbackPayloadForSuppressedFinal = (payload: ReplyPayload): ReplyPayload => {
     const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
     return hasMedia ? { ...payload, mediaUrl: undefined, mediaUrls: undefined } : payload;
+  };
+
+  const finalStreamActivity = (text?: string) => ({
+    type: "message" as const,
+    ...(text ? { text } : {}),
+    entities: [
+      {
+        type: "https://schema.org/Message",
+        "@type": "Message",
+        "@context": "https://schema.org",
+        "@id": "",
+        additionalType: ["AIGeneratedContent"],
+      },
+    ],
+    channelData: params.feedbackLoopEnabled ? { feedbackLoopEnabled: true } : {},
+  });
+
+  const deferredReplacementLogicalContent = (): string | undefined => {
+    const content = deferredReplacementEntries
+      .map((entry) => entry.payload.text)
+      .filter((text): text is string => Boolean(text))
+      .join("\n");
+    return content || undefined;
+  };
+
+  const takeDeferredReplacementPayloads = (
+    replacementFallback: Maybe<ReplyPayload>,
+  ): ReplyPayload[] => {
+    const payloads = deferredReplacementEntries.flatMap((entry) => {
+      if (entry.kind === "payload") {
+        return [entry.payload];
+      }
+      const hasMedia = Boolean(entry.payload.mediaUrl || entry.payload.mediaUrls?.length);
+      const text = replacementFallback?.text;
+      if (!text && !hasMedia) {
+        return [];
+      }
+      return [{ ...entry.payload, text: text || undefined }];
+    });
+    deferredReplacementEntries = [];
+    return payloads;
   };
 
   /**
@@ -241,13 +305,17 @@ export function createTeamsReplyStreamController(params: {
       // Partial-token streaming only fires in "partial" mode. In "progress"
       // mode, openclaw's pipeline doesn't deliver tokens — the model output
       // arrives as a single payload at preparePayload time.
-      if (
-        !stream ||
-        !payload.text ||
-        wasCanceled() ||
-        streamMode !== "partial" ||
-        streamFinalizationPending
-      ) {
+      if (!stream || !payload.text || wasCanceled() || streamMode !== "partial") {
+        return;
+      }
+      if (replacementSettlementPending && replacementFinalPending) {
+        // Keep the newest partial as the replacement candidate until the
+        // authoritative final payload arrives. Never append it into the SDK
+        // accumulator that clearText() reset.
+        pendingFinalPayload = { text: payload.text };
+        return;
+      }
+      if (streamFinalizationPending) {
         return;
       }
       // Convert cumulative-text from the pipeline into deltas for the SDK's
@@ -268,12 +336,24 @@ export function createTeamsReplyStreamController(params: {
       if (!delta) {
         return;
       }
-      // Non-whitespace rewrites are not safe to append into Teams. Let block
-      // delivery carry the final payload, but clear the SDK's accumulated text
-      // before closing so stale prefixes are not finalized as another message.
+      // Non-whitespace rewrites are not safe to append into Teams. Clear the
+      // SDK's local accumulator, then replace the same streamed activity with
+      // the authoritative final so a late provider Stop is still observed.
       if (previousRemainder.trim()) {
         stream.clearText();
-        streamFailed = true;
+        if (streamFailed) {
+          // A prior provider failure already transferred this and later
+          // segments to block delivery. Preserve the pending close cleanup,
+          // but do not retry final text through a failed native stream.
+          streamFinalizationPending = true;
+          return;
+        }
+        // The SDK can replace the same streamed activity after clearText().
+        // Defer the authoritative final to preparePayload so this provider
+        // round-trip also discovers a Stop before any fallback can escape.
+        replacementFinalPending = true;
+        replacementSettlementPending = true;
+        pendingFinalPayload = { text: fullText };
         streamFinalizationPending = true;
         return;
       }
@@ -384,6 +464,49 @@ export function createTeamsReplyStreamController(params: {
       if (wasCanceled()) {
         return undefined;
       }
+      if (replacementSettlementPending) {
+        if (!replacementFinalPending) {
+          deferredReplacementEntries.push({ kind: "payload", payload });
+          return undefined;
+        }
+        if (!payload.text) {
+          // The native stream activity was created before final payloads and
+          // remains the provider-visible root. Preserve deferred block order
+          // after that root; sending early would leak content after Stop.
+          deferredReplacementEntries.push({ kind: "payload", payload });
+          return undefined;
+        }
+        replacementFinalPending = false;
+        deferredReplacementEntries.push({ kind: "replacement", payload });
+        pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
+        try {
+          replacementTextAwaitingAcknowledgement = payload.text;
+          stream.emit(finalStreamActivity(payload.text));
+          finalMetadataQueued = true;
+          emittedText = payload.text;
+          tokensEmitted = false;
+          // Replacement delivery owns all later payloads until close() proves
+          // that Teams accepted the replacement or did not receive a Stop.
+          return undefined;
+        } catch (err) {
+          replacementTextAwaitingAcknowledgement = undefined;
+          tokensEmitted = false;
+          if (isStreamCancelledError(err)) {
+            canceledLocally = true;
+            pendingFinalPayload = undefined;
+            deferredReplacementEntries = [];
+            return undefined;
+          }
+          streamFailed = true;
+          replacementEmitFailed = true;
+          params.log?.warn?.(
+            `msteams stream replacement failed, falling back to block delivery: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          // Retain ownership until finalize so payloads held before this
+          // failed replacement cannot be overtaken by this or later blocks.
+          return undefined;
+        }
+      }
       // Partial mode with tokens already streamed: stream carries the text;
       // strip text from the payload (keep media if any) so block delivery
       // doesn't duplicate. Exception: if a non-cancel stream failure was
@@ -450,60 +573,92 @@ export function createTeamsReplyStreamController(params: {
         releaseStreamChunkSubscription();
         return { visibleReplySent: false };
       }
-      const content = pendingFinalPayload?.text ?? (emittedText || undefined);
+      let logicalContent: string | undefined;
       try {
         if (wasCanceled()) {
           pendingFinalPayload = undefined;
+          deferredReplacementEntries = [];
           streamFinalizationPending = false;
           return acknowledgedNativeDelivery();
         }
         if (!streamFinalizationPending) {
           return acknowledgedNativeDelivery();
         }
-        // Emit a final MessageActivity carrying the AI-generated marker and (if
-        // enabled) the feedback channelData. The SDK's HttpStream merges this
-        // into the closing activity it sends to Teams, so streamed replies still
-        // get the AI-generated label and thumbs up/down.
-        const finalEntities: Array<Record<string, unknown>> = [
-          {
-            type: "https://schema.org/Message",
-            "@type": "Message",
-            "@context": "https://schema.org",
-            "@id": "",
-            additionalType: ["AIGeneratedContent"],
-          },
-        ];
-        const finalChannelData: Record<string, unknown> = params.feedbackLoopEnabled
-          ? { feedbackLoopEnabled: true }
-          : {};
-        stream.emit({
-          type: "message",
-          entities: finalEntities,
-          channelData: finalChannelData,
-        });
+        // A media-only replacement payload may arrive before its text payload.
+        // If no authoritative text followed, re-emit the latest divergent
+        // partial so close() still performs the Stop-discovering round-trip.
+        if (replacementSettlementPending && replacementFinalPending && pendingFinalPayload?.text) {
+          replacementFinalPending = false;
+          deferredReplacementEntries.push({
+            kind: "replacement",
+            payload: pendingFinalPayload,
+          });
+          replacementTextAwaitingAcknowledgement = pendingFinalPayload.text;
+          logicalContent = deferredReplacementLogicalContent();
+          stream.emit(finalStreamActivity(pendingFinalPayload.text));
+          finalMetadataQueued = true;
+          emittedText = pendingFinalPayload.text;
+        }
+        logicalContent ??= replacementSettlementPending
+          ? deferredReplacementLogicalContent()
+          : undefined;
+        const content = pendingFinalPayload?.text ?? (emittedText || undefined);
+        // The replacement path already queued text and final metadata as one
+        // activity. Other paths add metadata here so the SDK can merge it into
+        // the closing activity without duplicating the replacement chunk.
+        if (!finalMetadataQueued) {
+          stream.emit(finalStreamActivity());
+        }
         const result = await stream.close();
         streamFinalizationPending = false;
         if (!result) {
           const fallback = pendingFinalPayload;
           pendingFinalPayload = undefined;
+          const canceled = wasCanceled();
+          const replacementFallback =
+            replacementSettlementPending && fallback && !canceled
+              ? fallbackPayloadAfterAcknowledgedText(fallback)
+              : undefined;
           const fallbackPayload =
-            fallback && !wasCanceled() ? fallbackPayloadAfterAcknowledgedText(fallback) : undefined;
+            !replacementSettlementPending && fallback && !canceled
+              ? fallbackPayloadAfterAcknowledgedText(fallback)
+              : undefined;
+          const postNativePayloads =
+            replacementSettlementPending && !canceled
+              ? takeDeferredReplacementPayloads(replacementFallback)
+              : [];
+          if (canceled) {
+            deferredReplacementEntries = [];
+          }
           return {
             ...acknowledgedNativeDelivery(),
+            ...(!canceled && logicalContent ? { logicalContent } : {}),
             ...(fallbackPayload ? { fallbackPayload } : {}),
+            ...(postNativePayloads.length > 0 ? { postNativePayloads } : {}),
           };
         }
+        const replacementFallback =
+          replacementSettlementPending && replacementEmitFailed && pendingFinalPayload
+            ? fallbackPayloadAfterAcknowledgedText(pendingFinalPayload)
+            : undefined;
         pendingFinalPayload = undefined;
         const messageId = extractMessageId(result) ?? acknowledgedStreamId;
+        const postNativePayloads = replacementSettlementPending
+          ? takeDeferredReplacementPayloads(replacementFallback)
+          : [];
+        const nativeContent = replacementEmitFailed ? acknowledgedText || undefined : content;
         return {
-          visibleReplySent: true,
-          ...(content === undefined ? {} : { content }),
-          ...(messageId ? { messageId } : {}),
+          visibleReplySent: replacementEmitFailed ? Boolean(nativeContent) : true,
+          ...(nativeContent === undefined ? {} : { content: nativeContent }),
+          ...(logicalContent ? { logicalContent } : {}),
+          ...(messageId && (!replacementEmitFailed || nativeContent) ? { messageId } : {}),
+          ...(postNativePayloads.length > 0 ? { postNativePayloads } : {}),
         };
       } catch (err) {
         if (isStreamCancelledError(err)) {
           canceledLocally = true;
           pendingFinalPayload = undefined;
+          deferredReplacementEntries = [];
           streamFinalizationPending = false;
           return acknowledgedNativeDelivery();
         }
@@ -519,14 +674,30 @@ export function createTeamsReplyStreamController(params: {
         );
         const fallback = pendingFinalPayload;
         pendingFinalPayload = undefined;
-        const fallbackPayload = fallback
-          ? fallbackPayloadAfterAcknowledgedText(fallback)
-          : undefined;
+        const replacementFallback =
+          replacementSettlementPending && fallback
+            ? fallbackPayloadAfterAcknowledgedText(fallback)
+            : undefined;
+        const fallbackPayload =
+          !replacementSettlementPending && fallback
+            ? fallbackPayloadAfterAcknowledgedText(fallback)
+            : undefined;
+        const postNativePayloads = replacementSettlementPending
+          ? takeDeferredReplacementPayloads(replacementFallback)
+          : [];
         return {
           ...acknowledgedNativeDelivery(),
+          ...(logicalContent ? { logicalContent } : {}),
           ...(fallbackPayload ? { fallbackPayload } : {}),
+          ...(postNativePayloads.length > 0 ? { postNativePayloads } : {}),
         };
       } finally {
+        finalMetadataQueued = false;
+        replacementEmitFailed = false;
+        replacementFinalPending = false;
+        replacementSettlementPending = false;
+        replacementTextAwaitingAcknowledgement = undefined;
+        deferredReplacementEntries = [];
         releaseStreamChunkSubscription();
       }
     },

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -115,6 +115,7 @@ export function createTeamsReplyStreamController(params: {
   let emittedText = "";
   let acknowledgedText = "";
   let acknowledgedStreamId: string | undefined;
+  let failedSegmentFallbackPrepared = false;
   const streamEvents = (stream as { events?: TeamsStreamChunkEvents } | undefined)?.events;
   let streamChunkSubscription: number | undefined;
 
@@ -146,6 +147,17 @@ export function createTeamsReplyStreamController(params: {
     }
     streamEvents?.off(streamChunkSubscription);
     streamChunkSubscription = undefined;
+  };
+
+  const acknowledgedNativeDelivery = (): MSTeamsNativeDeliveryFinalization => {
+    if (!acknowledgedStreamId || !acknowledgedText) {
+      return { visibleReplySent: false };
+    }
+    return {
+      visibleReplySent: true,
+      content: acknowledgedText,
+      messageId: acknowledgedStreamId,
+    };
   };
 
   const fallbackPayloadAfterAcknowledgedText = (payload: ReplyPayload): Maybe<ReplyPayload> => {
@@ -385,13 +397,13 @@ export function createTeamsReplyStreamController(params: {
         return hasMedia ? { ...payload, text: undefined } : undefined;
       }
       if (streamFailed) {
-        const fallback = fallbackPayloadAfterAcknowledgedText(payload);
-        // An acknowledged prefix belongs to this failed segment only;
-        // later tool-round payloads must never inherit its trimming state.
+        // Trim the provider-acknowledged prefix only from the failed segment.
+        // Retain its ID/text for final settlement while later tool rounds fall through whole.
+        const fallback = failedSegmentFallbackPrepared
+          ? payload
+          : fallbackPayloadAfterAcknowledgedText(payload);
+        failedSegmentFallbackPrepared = true;
         pendingFinalPayload = undefined;
-        acknowledgedText = "";
-        acknowledgedStreamId = undefined;
-        releaseStreamChunkSubscription();
         return fallback;
       }
       // Progress mode (or partial mode that received no tokens — e.g. a
@@ -438,23 +450,15 @@ export function createTeamsReplyStreamController(params: {
         releaseStreamChunkSubscription();
         return { visibleReplySent: false };
       }
-      const content = wasCanceled()
-        ? acknowledgedText || undefined
-        : (pendingFinalPayload?.text ?? (emittedText || undefined));
+      const content = pendingFinalPayload?.text ?? (emittedText || undefined);
       try {
         if (wasCanceled()) {
           pendingFinalPayload = undefined;
           streamFinalizationPending = false;
-          return {
-            visibleReplySent: content !== undefined,
-            ...(content === undefined ? {} : { content }),
-          };
+          return acknowledgedNativeDelivery();
         }
         if (!streamFinalizationPending) {
-          return {
-            visibleReplySent: true,
-            ...(content === undefined ? {} : { content }),
-          };
+          return acknowledgedNativeDelivery();
         }
         // Emit a final MessageActivity carrying the AI-generated marker and (if
         // enabled) the feedback channelData. The SDK's HttpStream merges this
@@ -485,13 +489,12 @@ export function createTeamsReplyStreamController(params: {
           const fallbackPayload =
             fallback && !wasCanceled() ? fallbackPayloadAfterAcknowledgedText(fallback) : undefined;
           return {
-            visibleReplySent: true,
-            ...(content === undefined ? {} : { content }),
+            ...acknowledgedNativeDelivery(),
             ...(fallbackPayload ? { fallbackPayload } : {}),
           };
         }
         pendingFinalPayload = undefined;
-        const messageId = extractMessageId(result) ?? undefined;
+        const messageId = extractMessageId(result) ?? acknowledgedStreamId;
         return {
           visibleReplySent: true,
           ...(content === undefined ? {} : { content }),
@@ -502,14 +505,10 @@ export function createTeamsReplyStreamController(params: {
           canceledLocally = true;
           pendingFinalPayload = undefined;
           streamFinalizationPending = false;
-          return {
-            visibleReplySent: true,
-            ...(content === undefined ? {} : { content }),
-          };
+          return acknowledgedNativeDelivery();
         }
-        // Non-cancel failure during the closing emit/close. The streamed
-        // prefix is already visible to the user; the only loss is the
-        // closing activity (AI-Generated marker, feedback channelData).
+        // Non-cancel failure during the closing emit/close. Preserve only a
+        // prefix acknowledged by Teams; queued bytes alone do not prove visibility.
         // Latch streamFailed for parity with the mid-stream path and
         // swallow the error — a thrown finalize would otherwise blow up
         // the reply pipeline after the user already saw the response.
@@ -524,8 +523,7 @@ export function createTeamsReplyStreamController(params: {
           ? fallbackPayloadAfterAcknowledgedText(fallback)
           : undefined;
         return {
-          visibleReplySent: true,
-          ...(content === undefined ? {} : { content }),
+          ...acknowledgedNativeDelivery(),
           ...(fallbackPayload ? { fallbackPayload } : {}),
         };
       } finally {


### PR DESCRIPTION
Closes #116514

AI-assisted: yes. I reviewed the implementation, dependency contract, focused/full
tests, and live Microsoft Teams behavior.

## What Problem This Solves

Fixes an issue where users streaming an automatic reply in a Microsoft Teams personal
chat could have finalized delivery recorded without the already-visible native activity
ID, or with content Teams never accepted, when the stream was stopped or only part of a
fallback delivery succeeded.

It also preserves the visible Stop contract while settling a delayed provider final:
the stopped native preview remains the only bot activity instead of allowing an
unaccepted final payload to escape as a second message.

## Why This Change Was Made

Teams now carries only provider-acknowledged native content/identity into settlement,
holds divergent replacement payloads until native finalization decides their outcome,
and aggregates accepted fallback blocks in provider-visible order. Cancellation drops
unaccepted held payloads; non-cancel failure restores only the unacknowledged text that
still needs delivery.

The change stays inside the Microsoft Teams stream controller and dispatcher. It adds
no core, public Plugin SDK, config/default, protocol, persistence, migration, durable
recovery, or sibling-provider surface.

## User Impact

Microsoft Teams users can stop a streamed response without receiving a late duplicate
final. Plugins and automations observing finalized delivery receive the actual primary
Teams activity ID and only the content the provider accepted, including partial
fallback outcomes.

## Evidence

- Exact PR head: `e2208d1de0cc051f5b97781301cef2bffc546c10`
- Frozen integration base: `ce67ffb70e83e5ebb56ea02e814e577153f84f61`
- Product diff: five Microsoft Teams files, `+781/-120`
- Full Teams lane: `84/84` files, `1291/1291` assertions
- Extension production and extension-test `tsgo`: pass
- Fresh branch autoreview: no accepted/actionable findings
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/30570346838
- Direct dependency proof: exact pinned `@microsoft/teams.apps@2.0.14` source and
  loopback behavior inspected; Microsoft documents the stream ID as the activity ID:
  https://learn.microsoft.com/en-us/microsoftteams/platform/bots/streaming-ux

Live external proof used the production plugin/Gateway, an installed Teams SUT, a
dedicated licensed driver, and signed-in Chrome in the dedicated personal QA chat:

- Inspectable redacted Stop reconciliation and terminal trace:
  https://github.com/openclaw/openclaw/pull/116515#issuecomment-5135089940
- Ordinary stream: one visible final and exactly one successful `message_sent` with
  matching provider-final content and a non-empty provider ID.
- Human Stop: Chrome clicked the native Stop control; Teams retained one stopped
  preview. After a controlled 120-second delayed provider final, no late final bot
  message appeared. Exactly one successful `message_sent` described the acknowledged
  preview and contained a non-empty provider ID.
- The live-tested SHA `d6cb065e09d28f1c7f41e8ed3949ab161a3f6549` and this PR head
  have byte-identical production files. The only post-live change is a two-expression
  test lint cleanup, proven by 48/48 focused assertions and all oxlint shards.
- Sanitized traces contain no credentials or private non-QA content.
