### PR TITLE
fix(media): preserve code whitespace in media replies

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -11,11 +11,15 @@ describe("splitMediaFromOutput", () => {
       mediaUrls?: string[];
       text?: string;
       audioAsVoice?: boolean;
+      segments?: ReturnType<typeof splitMediaFromOutput>["segments"];
     },
     options?: SplitMediaFromOutputOptions,
   ) {
     const result = splitMediaFromOutput(input, options);
     expect(result.text).toBe(expected.text ?? "");
+    if ("segments" in expected) {
+      expect(result.segments).toEqual(expected.segments);
+    }
     if ("audioAsVoice" in expected) {
       expect(result.audioAsVoice).toBe(expected.audioAsVoice);
     } else {
@@ -397,6 +401,120 @@ describe("splitMediaFromOutput", () => {
         mediaUrls: [
           "https://img.shields.io/badge/status-passing-green",
           "https://example.com/photo.png",
+        ],
+      },
+      extractMarkdownImages,
+    );
+  });
+
+  it("preserves code indentation and paragraph breaks around media directives", () => {
+    const input = [
+      "Here is the config you asked for.",
+      "",
+      "```yaml",
+      "server:",
+      "  host: 0.0.0.0",
+      "  ports:",
+      "    - 80",
+      "    - 443",
+      "```",
+      "",
+      "MEDIA:https://example.com/chart.png",
+    ].join("\n");
+
+    expectParsedMediaOutputCase(input, {
+      text: [
+        "Here is the config you asked for.",
+        "",
+        "```yaml",
+        "server:",
+        "  host: 0.0.0.0",
+        "  ports:",
+        "    - 80",
+        "    - 443",
+        "```",
+      ].join("\n"),
+      mediaUrls: ["https://example.com/chart.png"],
+      segments: [
+        {
+          type: "text",
+          text: [
+            "Here is the config you asked for.",
+            "",
+            "```yaml",
+            "server:",
+            "  host: 0.0.0.0",
+            "  ports:",
+            "    - 80",
+            "    - 443",
+            "```",
+          ].join("\n"),
+        },
+        { type: "media", url: "https://example.com/chart.png" },
+      ],
+    });
+  });
+
+  it("preserves code indentation and paragraph breaks around extracted markdown images", () => {
+    const input = [
+      "Rendered the chart, and here is the code behind it.",
+      "",
+      "```python",
+      "def summarize(rows):",
+      "    totals = {}",
+      "    for row in rows:",
+      "        key = row['bucket']",
+      "        if key not in totals:",
+      "            totals[key] = 0",
+      "        totals[key] += row['value']",
+      "    return totals",
+      "```",
+      "",
+      "![chart](https://example.com/chart.png)",
+      "",
+      "Let me know if you want it grouped differently.",
+    ].join("\n");
+
+    expectParsedMediaOutputCase(
+      input,
+      {
+        text: [
+          "Rendered the chart, and here is the code behind it.",
+          "",
+          "```python",
+          "def summarize(rows):",
+          "    totals = {}",
+          "    for row in rows:",
+          "        key = row['bucket']",
+          "        if key not in totals:",
+          "            totals[key] = 0",
+          "        totals[key] += row['value']",
+          "    return totals",
+          "```",
+          "",
+          "Let me know if you want it grouped differently.",
+        ].join("\n"),
+        mediaUrls: ["https://example.com/chart.png"],
+        segments: [
+          {
+            type: "text",
+            text: [
+              "Rendered the chart, and here is the code behind it.",
+              "",
+              "```python",
+              "def summarize(rows):",
+              "    totals = {}",
+              "    for row in rows:",
+              "        key = row['bucket']",
+              "        if key not in totals:",
+              "            totals[key] = 0",
+              "        totals[key] += row['value']",
+              "    return totals",
+              "```",
+            ].join("\n"),
+          },
+          { type: "media", url: "https://example.com/chart.png" },
+          { type: "text", text: "Let me know if you want it grouped differently." },
         ],
       },
       extractMarkdownImages,

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -466,6 +466,18 @@ describe("splitMediaFromOutput", () => {
     });
   });
 
+  it("preserves visible whitespace after a media directive", () => {
+    expectParsedMediaOutputCase("Use `a  b`\nMEDIA:https://example.com/chart.png\nA  B  C", {
+      text: "Use `a  b`\nA  B  C",
+      mediaUrls: ["https://example.com/chart.png"],
+      segments: [
+        { type: "text", text: "Use `a  b`" },
+        { type: "media", url: "https://example.com/chart.png" },
+        { type: "text", text: "A  B  C" },
+      ],
+    });
+  });
+
   it("preserves a leading indented code block after a media directive", () => {
     expectParsedMediaOutputCase("MEDIA:https://example.com/chart.png\n    const answer = 42;", {
       text: "    const answer = 42;",

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -455,6 +455,28 @@ describe("splitMediaFromOutput", () => {
     });
   });
 
+  it("trims leading prose whitespace after a media directive", () => {
+    expectParsedMediaOutputCase("MEDIA:https://example.com/chart.png\n  hello", {
+      text: "hello",
+      mediaUrls: ["https://example.com/chart.png"],
+      segments: [
+        { type: "media", url: "https://example.com/chart.png" },
+        { type: "text", text: "hello" },
+      ],
+    });
+  });
+
+  it("preserves a leading indented code block after a media directive", () => {
+    expectParsedMediaOutputCase("MEDIA:https://example.com/chart.png\n    const answer = 42;", {
+      text: "    const answer = 42;",
+      mediaUrls: ["https://example.com/chart.png"],
+      segments: [
+        { type: "media", url: "https://example.com/chart.png" },
+        { type: "text", text: "    const answer = 42;" },
+      ],
+    });
+  });
+
   it("preserves code indentation and paragraph breaks around extracted markdown images", () => {
     const input = [
       "Rendered the chart, and here is the code behind it.",

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -499,6 +499,20 @@ describe("splitMediaFromOutput", () => {
     });
   });
 
+  it("preserves blank lines inside an indented code block after a media directive", () => {
+    expectParsedMediaOutputCase(
+      "MEDIA:https://example.com/chart.png\n    const first = 1;\n\n    const second = 2;",
+      {
+        text: "    const first = 1;\n\n    const second = 2;",
+        mediaUrls: ["https://example.com/chart.png"],
+        segments: [
+          { type: "media", url: "https://example.com/chart.png" },
+          { type: "text", text: "    const first = 1;\n\n    const second = 2;" },
+        ],
+      },
+    );
+  });
+
   it("preserves code indentation and paragraph breaks around extracted markdown images", () => {
     const input = [
       "Rendered the chart, and here is the code behind it.",

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -488,6 +488,17 @@ describe("splitMediaFromOutput", () => {
     });
   });
 
+  it("preserves an indented code block after a media directive and whitespace-only blank line", () => {
+    expectParsedMediaOutputCase("MEDIA:https://example.com/chart.png\n  \n    const answer = 42;", {
+      text: "    const answer = 42;",
+      mediaUrls: ["https://example.com/chart.png"],
+      segments: [
+        { type: "media", url: "https://example.com/chart.png" },
+        { type: "text", text: "    const answer = 42;" },
+      ],
+    });
+  });
+
   it("preserves code indentation and paragraph breaks around extracted markdown images", () => {
     const input = [
       "Rendered the chart, and here is the code behind it.",

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -477,6 +477,17 @@ describe("splitMediaFromOutput", () => {
     });
   });
 
+  it("preserves an indented code block after a media directive and blank line", () => {
+    expectParsedMediaOutputCase("MEDIA:https://example.com/chart.png\n\n    const answer = 42;", {
+      text: "    const answer = 42;",
+      mediaUrls: ["https://example.com/chart.png"],
+      segments: [
+        { type: "media", url: "https://example.com/chart.png" },
+        { type: "text", text: "    const answer = 42;" },
+      ],
+    });
+  });
+
   it("preserves code indentation and paragraph breaks around extracted markdown images", () => {
     const input = [
       "Rendered the chart, and here is the code behind it.",

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -590,4 +590,15 @@ describe("splitMediaFromOutput", () => {
       extractMarkdownImages,
     );
   });
+
+  it("preserves a paragraph separator before a standalone image without a trailing blank line", () => {
+    expectParsedMediaOutputCase(
+      "First paragraph.\n\n![chart](https://example.com/chart.png)\nSecond paragraph.",
+      {
+        text: "First paragraph.\n\nSecond paragraph.",
+        mediaUrls: ["https://example.com/chart.png"],
+      },
+      extractMarkdownImages,
+    );
+  });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -586,14 +586,13 @@ export function splitMediaFromOutput(
         pushTextSegment(line);
       } else {
         foundMediaToken = true;
-        // The image line is removed below. When it is surrounded by blank
-        // lines, discard one preceding separator so the two paragraphs keep
-        // a single blank line between them.
-        if (keptLines.at(-1) === "") {
-          keptLines.pop();
-        }
         if (markdownImageResult.cleanedLine) {
           keptLines.push(markdownImageResult.cleanedLine);
+        } else if (keptLines.at(-1) === "") {
+          // The standalone image line is removed below. When it is surrounded
+          // by blank lines, discard one preceding separator so the two
+          // paragraphs keep a single blank line between them.
+          keptLines.pop();
         }
         for (const segment of markdownImageResult.lineSegments) {
           if (segment.type === "text") {

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -567,7 +567,7 @@ export function splitMediaFromOutput(
   const keptLines: string[] = [];
 
   let lineOffset = 0; // Track character offset for fence checking
-  for (const line of lines) {
+  for (const [lineIndex, line] of lines.entries()) {
     // Fenced examples must remain text; extracting their MEDIA tokens would mutate transcripts.
     if (fenceSpans.some((span) => lineOffset >= span.start && lineOffset < span.end)) {
       keptLines.push(line);
@@ -588,7 +588,7 @@ export function splitMediaFromOutput(
         foundMediaToken = true;
         if (markdownImageResult.cleanedLine) {
           keptLines.push(markdownImageResult.cleanedLine);
-        } else if (keptLines.at(-1) === "") {
+        } else if (keptLines.at(-1) === "" && lines[lineIndex + 1]?.trim() === "") {
           // The standalone image line is removed below. When it is surrounded
           // by blank lines, discard one preceding separator so the two
           // paragraphs keep a single blank line between them.

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -20,7 +20,7 @@ function normalizeMediaVisibleWhitespace(text: string): string {
     return "";
   }
   const normalized = normalizeDirectiveWhitespace(text);
-  const withoutLeadingBlankLines = normalized.replace(/^\n+/, "");
+  const withoutLeadingBlankLines = normalized.replace(/^(?:[ \t]*\n)+/, "");
   return /^(?: {4}|\t)/.test(withoutLeadingBlankLines)
     ? withoutLeadingBlankLines
     : normalized.trimStart();

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -16,6 +16,9 @@ import { normalizeDirectiveWhitespace } from "../utils/directive-whitespace.js";
 import { parseAudioTag } from "./audio-tags.js";
 
 function normalizeMediaVisibleWhitespace(text: string): string {
+  if (!text.trim()) {
+    return "";
+  }
   const normalized = normalizeDirectiveWhitespace(text);
   const withoutLeadingBlankLines = normalized.replace(/^\n+/, "");
   return /^(?: {4}|\t)/.test(withoutLeadingBlankLines)
@@ -537,16 +540,21 @@ export function splitMediaFromOutput(
         normalizedSegments.push(segment);
         continue;
       }
-      const text = normalizeMediaVisibleWhitespace(segment.text);
-      if (!text.trim()) {
+      if (!segment.text.trim()) {
         continue;
       }
+      const hadTrailingNewline = /\n$/.test(segment.text);
+      const text = normalizeMediaVisibleWhitespace(segment.text);
+      const endsWithCodeFence = /(?:^|\n) {0,3}(?:`{3,}|~{3,})[^\n]*$/.test(text);
+      const isIndentedCode = /^(?: {4}|\t)/.test(text);
+      const normalizedText =
+        hadTrailingNewline && text && !endsWithCodeFence && !isIndentedCode ? `${text}\n` : text;
       const last = normalizedSegments[normalizedSegments.length - 1];
       if (last?.type === "text") {
-        last.text = normalizeMediaVisibleWhitespace(`${last.text}\n${text}`);
+        last.text = normalizeMediaVisibleWhitespace(`${last.text}\n${normalizedText}`);
         continue;
       }
-      normalizedSegments.push({ type: "text", text });
+      normalizedSegments.push({ type: "text", text: normalizedText });
     }
     return normalizedSegments;
   };

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -12,18 +12,17 @@ import {
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { expectDefined } from "@openclaw/normalization-core";
 import { parseFenceSpans } from "../../packages/markdown-core/src/fences.js";
-import { normalizeDirectiveWhitespace } from "../utils/directive-whitespace.js";
 import { parseAudioTag } from "./audio-tags.js";
 
 function normalizeMediaVisibleWhitespace(text: string): string {
   if (!text.trim()) {
     return "";
   }
-  const normalized = normalizeDirectiveWhitespace(text);
-  const withoutLeadingBlankLines = normalized.replace(/^(?:[ \t]*\n)+/, "");
-  return /^(?: {4}|\t)/.test(withoutLeadingBlankLines)
-    ? withoutLeadingBlankLines
-    : normalized.trimStart();
+  const withoutLeadingBlankLines = text.replace(/^(?:[ \t]*\r?\n)+/, "");
+  const withoutTrailingBoundaryWhitespace = withoutLeadingBlankLines.trimEnd();
+  return /^(?: {4}|\t)/.test(withoutTrailingBoundaryWhitespace)
+    ? withoutTrailingBoundaryWhitespace
+    : withoutTrailingBoundaryWhitespace.trimStart();
 }
 
 /** Captures legacy MEDIA: attachment directives from model/tool output. */
@@ -587,6 +586,12 @@ export function splitMediaFromOutput(
         pushTextSegment(line);
       } else {
         foundMediaToken = true;
+        // The image line is removed below. When it is surrounded by blank
+        // lines, discard one preceding separator so the two paragraphs keep
+        // a single blank line between them.
+        if (keptLines.at(-1) === "") {
+          keptLines.pop();
+        }
         if (markdownImageResult.cleanedLine) {
           keptLines.push(markdownImageResult.cleanedLine);
         }

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -12,7 +12,16 @@ import {
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { expectDefined } from "@openclaw/normalization-core";
 import { parseFenceSpans } from "../../packages/markdown-core/src/fences.js";
+import { normalizeDirectiveWhitespace } from "../utils/directive-whitespace.js";
 import { parseAudioTag } from "./audio-tags.js";
+
+function normalizeMediaVisibleWhitespace(text: string): string {
+  const normalized = normalizeDirectiveWhitespace(text);
+  const withoutLeadingBlankLines = normalized.replace(/^\n+/, "");
+  return /^(?: {4}|\t)/.test(withoutLeadingBlankLines)
+    ? withoutLeadingBlankLines
+    : normalized.trimStart();
+}
 
 /** Captures legacy MEDIA: attachment directives from model/tool output. */
 const MEDIA_TOKEN_RE = /\bMEDIA:\s*`?([^\n]+)`?/gi;
@@ -521,6 +530,27 @@ export function splitMediaFromOutput(
     }
   };
 
+  const normalizeTextSegments = () => {
+    const normalizedSegments: ParsedMediaOutputSegment[] = [];
+    for (const segment of segments) {
+      if (segment.type === "media") {
+        normalizedSegments.push(segment);
+        continue;
+      }
+      const text = normalizeMediaVisibleWhitespace(segment.text);
+      if (!text.trim()) {
+        continue;
+      }
+      const last = normalizedSegments[normalizedSegments.length - 1];
+      if (last?.type === "text") {
+        last.text = normalizeMediaVisibleWhitespace(`${last.text}\n${text}`);
+        continue;
+      }
+      normalizedSegments.push({ type: "text", text });
+    }
+    return normalizedSegments;
+  };
+
   // Parse fenced code blocks to avoid extracting MEDIA tokens from inside them
   const hasFenceMarkers = mayContainFenceMarkers(trimmedRaw);
   const fenceSpans = hasFenceMarkers ? parseFenceSpans(trimmedRaw) : [];
@@ -685,10 +715,14 @@ export function splitMediaFromOutput(
     lineOffset += line.length + 1; // +1 for newline
   }
 
-  const visibleText = keptLines.join("\n").replace(/^(?:[ \t]*\n)+/, "");
-  const audioTagResult = parseAudioTag(visibleText);
-  const cleanedText = audioTagResult.text.trimEnd();
+  let cleanedText = normalizeMediaVisibleWhitespace(keptLines.join("\n"));
+
+  // Detect and strip [[audio_as_voice]] tag
+  const audioTagResult = parseAudioTag(cleanedText);
   const hasAudioAsVoice = audioTagResult.audioAsVoice;
+  if (audioTagResult.hadTag) {
+    cleanedText = normalizeMediaVisibleWhitespace(audioTagResult.text);
+  }
 
   if (media.length === 0) {
     const parsedText = foundMediaToken || hasAudioAsVoice ? cleanedText : trimmedRaw;
@@ -705,7 +739,7 @@ export function splitMediaFromOutput(
   return {
     text: cleanedText,
     mediaUrls: media,
-    segments: segments.length > 0 ? segments : [{ type: "text", text: cleanedText }],
+    segments: normalizeTextSegments(),
     ...(hasAudioAsVoice ? { audioAsVoice: true } : {}),
   };
 }

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -1,7 +1,6 @@
-import { expectDefined } from "@openclaw/normalization-core";
 // Directive tag helpers parse inline directive tags from user text.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { parseFenceSpans } from "../../packages/markdown-core/src/fences.js";
+import { normalizeDirectiveWhitespace } from "./directive-whitespace.js";
 
 export type InlineDirectiveParseResult = {
   text: string;
@@ -29,51 +28,6 @@ function replacementPreservesWordBoundary(source: string, offset: number, length
   const before = source[offset - 1];
   const after = source[offset + length];
   return before && after && !/\s/u.test(before) && !/\s/u.test(after) ? " " : "";
-}
-
-const BLOCK_SENTINEL_SEED = "\uE000";
-
-function createBlockSentinel(text: string): string {
-  let sentinel = BLOCK_SENTINEL_SEED;
-  while (text.includes(sentinel)) {
-    sentinel += BLOCK_SENTINEL_SEED;
-  }
-  return sentinel;
-}
-
-function normalizeDirectiveWhitespace(text: string): string {
-  // Extract → normalize prose → restore:
-  // Stash every code block (fenced ``` / ~~~ and indent-code 4-space/tab)
-  // under a sentinel-delimited placeholder so the prose regexes never touch them.
-  const blockSentinel = createBlockSentinel(text);
-  const blockPlaceholderRe = new RegExp(`${blockSentinel}(\\d+)${blockSentinel}`, "g");
-  const blocks: string[] = [];
-  const fenceSpans = text.includes("```") || text.includes("~~~") ? parseFenceSpans(text) : [];
-  let masked = "";
-  let cursor = 0;
-  // The canonical scanner keeps false closers, indented closers, and open fences intact.
-  for (const span of fenceSpans) {
-    blocks.push(text.slice(span.start, span.end));
-    masked += `${text.slice(cursor, span.start)}${blockSentinel}${blocks.length - 1}${blockSentinel}`;
-    cursor = span.end;
-  }
-  masked = `${masked}${text.slice(cursor)}`.replace(/(?:(?:^|\n)(?:    |\t)[^\n]*)+/gm, (block) => {
-    blocks.push(block);
-    return `${blockSentinel}${blocks.length - 1}${blockSentinel}`;
-  });
-
-  const normalized = masked
-    .replace(/\r\n/g, "\n")
-    .replace(/([^\s])[ \t]{2,}([^\s])/g, "$1 $2")
-    .replace(/^\n+/, "")
-    .replace(/^[ \t](?=\S)/, "")
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trimEnd();
-
-  return normalized.replace(blockPlaceholderRe, (_, i) =>
-    expectDefined(blocks[Number(i)], "blocks entry at number(i)"),
-  );
 }
 
 type StripInlineDirectiveTagsResult = {

--- a/src/utils/directive-whitespace.ts
+++ b/src/utils/directive-whitespace.ts
@@ -1,0 +1,50 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { parseFenceSpans } from "../../packages/markdown-core/src/fences.js";
+
+const BLOCK_SENTINEL_SEED = "\uE000";
+
+function createBlockSentinel(text: string): string {
+  let sentinel = BLOCK_SENTINEL_SEED;
+  while (text.includes(sentinel)) {
+    sentinel += BLOCK_SENTINEL_SEED;
+  }
+  return sentinel;
+}
+
+export function normalizeDirectiveWhitespace(text: string): string {
+  // Extract -> normalize prose -> restore:
+  // Stash every code block (fenced ``` / ~~~ and indent-code 4-space/tab)
+  // under a sentinel-delimited placeholder so the prose regexes never touch them.
+  const blockSentinel = createBlockSentinel(text);
+  const blockPlaceholderRe = new RegExp(`${blockSentinel}(\\d+)${blockSentinel}`, "g");
+  const blocks: string[] = [];
+  const fenceSpans = text.includes("```") || text.includes("~~~") ? parseFenceSpans(text) : [];
+  let masked = "";
+  let cursor = 0;
+  // The canonical scanner keeps false closers, indented closers, and open fences intact.
+  for (const span of fenceSpans) {
+    blocks.push(text.slice(span.start, span.end));
+    masked += `${text.slice(cursor, span.start)}${blockSentinel}${blocks.length - 1}${blockSentinel}`;
+    cursor = span.end;
+  }
+  masked = `${masked}${text.slice(cursor)}`.replace(
+    /(?:(?:^|\n)(?:    |\t)[^\n]*)+/gm,
+    (block) => {
+      blocks.push(block);
+      return `${blockSentinel}${blocks.length - 1}${blockSentinel}`;
+    },
+  );
+
+  const normalized = masked
+    .replace(/\r\n/g, "\n")
+    .replace(/([^\s])[ \t]{2,}([^\s])/g, "$1 $2")
+    .replace(/^\n+/, "")
+    .replace(/^[ \t](?=\S)/, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
+
+  return normalized.replace(blockPlaceholderRe, (_, i) =>
+    expectDefined(blocks[Number(i)], "blocks entry at number(i)"),
+  );
+}

--- a/src/utils/directive-whitespace.ts
+++ b/src/utils/directive-whitespace.ts
@@ -27,13 +27,10 @@ export function normalizeDirectiveWhitespace(text: string): string {
     masked += `${text.slice(cursor, span.start)}${blockSentinel}${blocks.length - 1}${blockSentinel}`;
     cursor = span.end;
   }
-  masked = `${masked}${text.slice(cursor)}`.replace(
-    /(?:(?:^|\n)(?:    |\t)[^\n]*)+/gm,
-    (block) => {
-      blocks.push(block);
-      return `${blockSentinel}${blocks.length - 1}${blockSentinel}`;
-    },
-  );
+  masked = `${masked}${text.slice(cursor)}`.replace(/(?:(?:^|\n)(?:    |\t)[^\n]*)+/gm, (block) => {
+    blocks.push(block);
+    return `${blockSentinel}${blocks.length - 1}${blockSentinel}`;
+  });
 
   const normalized = masked
     .replace(/\r\n/g, "\n")

--- a/src/utils/directive-whitespace.ts
+++ b/src/utils/directive-whitespace.ts
@@ -27,10 +27,13 @@ export function normalizeDirectiveWhitespace(text: string): string {
     masked += `${text.slice(cursor, span.start)}${blockSentinel}${blocks.length - 1}${blockSentinel}`;
     cursor = span.end;
   }
-  masked = `${masked}${text.slice(cursor)}`.replace(/(?:(?:^|\n)(?:    |\t)[^\n]*)+/gm, (block) => {
-    blocks.push(block);
-    return `${blockSentinel}${blocks.length - 1}${blockSentinel}`;
-  });
+  masked = `${masked}${text.slice(cursor)}`.replace(
+    /(?:(?:^|\n)(?:    |\t)[^\n]*)(?:\n(?:[ \t]*\n)*(?:    |\t)[^\n]*)*/gm,
+    (block) => {
+      blocks.push(block);
+      return `${blockSentinel}${blocks.length - 1}${blockSentinel}`;
+    },
+  );
 
   const normalized = masked
     .replace(/\r\n/g, "\n")


### PR DESCRIPTION
Closes #116458

## What Problem This Solves

Media-bearing replies could lose meaningful code indentation and paragraph spacing when `MEDIA:` directives or extracted Markdown images were removed from visible text.

## Why This Change Was Made

The media parser now cleans only whitespace at media boundaries. It preserves visible prose whitespace, fenced and four-space/tab-indented code, internal blank lines, and paragraph separators. Markdown image extraction removes an adjacent separator only when the standalone image has a matching trailing blank line, so inline text and one-sided paragraph breaks remain unchanged.

## User Impact

Replies containing media keep readable prose, Markdown formatting, and syntactically valid indented code after media extraction.

## Evidence

- `node scripts/run-vitest.mjs src/media/parse.test.ts src/utils/directive-tags.test.ts`: passed, 2 files / 120 tests.
- `./node_modules/.bin/oxfmt --check --threads=1 src/media/parse.ts src/media/parse.test.ts src/utils/directive-tags.ts src/utils/directive-whitespace.ts`: passed.
- `node --max-old-space-size=8192 scripts/plugin-sdk-surface-report.mjs --check`: passed; no forbidden package-exported SDK subpaths.
- `git diff --check upstream/main...HEAD`: passed.
- Current-head outbound projection proof at `001b73c7d63278a62e0c6b9472a5349e83e5d97b`: `MEDIA:https://example.com/chart.png` followed by two-space prose and four-space code produced text `hello\n    const answer = 42;` and the expected media URL.
- Structured autoreview: `PI_CODING_AGENT_DIR=/root/.pi/agent .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --engine pi --model asxs/gpt-5.5 --thinking high --pi-bin /usr/local/bin/pi`: passed; TruffleHog clean and no accepted/actionable findings.
- CI: triggered for current pushed head `001b73c7d63278a62e0c6b9472a5349e83e5d97b`; awaiting GitHub results.

This PR was AI-assisted. I reviewed the changed parser, segment-boundary, and outbound projection paths and understand the behavior implemented here.