### PR TITLE
fix(infra): don't warn on fast successful transactions when busyTimeoutMs is 0

### DIFF
--- a/src/infra/sqlite-transaction.test.ts
+++ b/src/infra/sqlite-transaction.test.ts
@@ -312,6 +312,53 @@ describe("runSqliteImmediateTransactionSync", () => {
     );
   });
 
+  it("does not warn on a fast successful transaction when busyTimeoutMs is 0", () => {
+    const logger = { warn: vi.fn() };
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      const value = now;
+      now += 1;
+      return value;
+    });
+    const db = {
+      exec() {},
+    } as unknown as import("node:sqlite").DatabaseSync;
+
+    runSqliteImmediateTransactionSync(db, () => "committed", {
+      busyTimeoutMs: 0,
+      logger,
+    });
+
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "slow SQLite transaction lock wait",
+      expect.anything(),
+    );
+  });
+
+  it("still warns on a genuinely slow transaction when busyTimeoutMs is 0", () => {
+    const logger = { warn: vi.fn() };
+    let now = 0;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      const value = now;
+      now += 1_500;
+      return value;
+    });
+    const db = {
+      exec() {},
+    } as unknown as import("node:sqlite").DatabaseSync;
+
+    runSqliteImmediateTransactionSync(db, () => "committed", {
+      busyTimeoutMs: 0,
+      logger,
+      slowTransactionHoldMs: 0,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "slow SQLite transaction lock wait",
+      expect.objectContaining({ step: "begin" }),
+    );
+  });
+
   it("waits for a separate writer and exposes the synchronous event-loop cost", async () => {
     const holdMs = 200;
     const tempDir = tempDirs.make("openclaw-sqlite-contention-");

--- a/src/infra/sqlite-transaction.ts
+++ b/src/infra/sqlite-transaction.ts
@@ -71,10 +71,10 @@ export function isSqliteLockError(error: unknown): boolean {
 }
 
 function slowBusyWaitThresholdMs(options: SqliteTransactionOptions | undefined): number {
-  if (options?.busyTimeoutMs === undefined) {
+  if (options?.busyTimeoutMs === undefined || options.busyTimeoutMs <= 0) {
     return DEFAULT_SLOW_BUSY_WAIT_MS;
   }
-  return Math.min(DEFAULT_SLOW_BUSY_WAIT_MS, Math.max(1, options.busyTimeoutMs));
+  return Math.min(DEFAULT_SLOW_BUSY_WAIT_MS, options.busyTimeoutMs);
 }
 
 function slowTransactionHoldThresholdMs(options: SqliteTransactionOptions | undefined): number {


### PR DESCRIPTION
## What Problem This Solves

`busyTimeoutMs: 0` (used intentionally by state leases) lowered the slow-lock-wait diagnostic threshold to 1ms, so ordinary successful commits that merely crossed a millisecond boundary were logged as WARN-level "slow SQLite transaction lock wait" — a false positive, not a real `SQLITE_BUSY`/`SQLITE_LOCKED` failure.

## Why This Change Was Made

`slowBusyWaitThresholdMs` used `Math.max(1, options.busyTimeoutMs)`, which turns an explicit `0` into `1`. Since the timer uses millisecond resolution, a routine 1ms successful commit met that threshold even without any real lock contention.

## User Impact

Removes noisy false-positive WARN logs for zero-timeout state-lease transactions (`src/state/openclaw-state-lease.ts`) without affecting the existing terminal `SQLite transaction lock wait failed` path for genuine `SQLITE_BUSY`/`SQLITE_LOCKED` errors, and without weakening the diagnostic for genuinely slow transactions run with `busyTimeoutMs: 0`.

## Evidence

- Root cause and fix location: `src/infra/sqlite-transaction.ts`, `slowBusyWaitThresholdMs`.
- Added two tests in `src/infra/sqlite-transaction.test.ts`:
  - a fast successful transaction with `busyTimeoutMs: 0` does not warn
  - a genuinely slow transaction with `busyTimeoutMs: 0` still warns
- Full existing test file passes: `node scripts/run-vitest.mjs src/infra/sqlite-transaction.test.ts` — 12/12 passed on Node 26.4.0 (this repo's SQLite WAL-safety gate rejects the SQLite build bundled with some newer Node point releases; verified on a compliant Node version).
- Formatted with `node_modules/.bin/oxfmt`.

Fixes #115972