### PR TITLE
fix(signal): re-probe managed daemon liveness so hangs surface as disconnected

### DIFF
--- a/extensions/signal/src/monitor.daemon-heartbeat.test.ts
+++ b/extensions/signal/src/monitor.daemon-heartbeat.test.ts
@@ -1,0 +1,103 @@
+// Regression coverage for #116295: the managed signal-cli daemon's SSE endpoint stays
+// idle between inbound events, so a live child process is the only other liveness
+// signal and a hung daemon looked healthy forever. The heartbeat must (1) re-probe on
+// an interval, (2) publish connected/transport-activity status on success, (3) publish
+// disconnected status and log on failure so the gateway health monitor can restart it,
+// and (4) recover to connected once the daemon answers again — without restart churn
+// on an isolated failure.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const signalCheckMock = vi.hoisted(() => vi.fn());
+vi.mock("./client-adapter.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, signalCheck: signalCheckMock };
+});
+
+import { startSignalDaemonHeartbeat } from "./monitor.js";
+
+describe("startSignalDaemonHeartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    signalCheckMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("probes immediately, then republishes connected status on each successful interval", async () => {
+    signalCheckMock.mockResolvedValue({ ok: true });
+    const setStatus = vi.fn();
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    const heartbeat = startSignalDaemonHeartbeat({
+      baseUrl: "http://127.0.0.1:8080",
+      runtime,
+      statusSink: setStatus,
+    });
+    await vi.waitFor(() => expect(signalCheckMock).toHaveBeenCalledTimes(1));
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ connected: true, lastError: null }),
+    );
+
+    setStatus.mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(signalCheckMock).toHaveBeenCalledTimes(2);
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ connected: true, lastError: null }),
+    );
+    expect(runtime.error).not.toHaveBeenCalled();
+
+    heartbeat.stop();
+  });
+
+  it("publishes disconnected status and logs when a probe fails, then recovers on the next success", async () => {
+    signalCheckMock.mockResolvedValueOnce({ ok: false, status: null, error: "timeout" });
+    const setStatus = vi.fn();
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    const heartbeat = startSignalDaemonHeartbeat({
+      baseUrl: "http://127.0.0.1:8080",
+      runtime,
+      statusSink: setStatus,
+    });
+    await vi.waitFor(() => expect(signalCheckMock).toHaveBeenCalledTimes(1));
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: false,
+        lastError: expect.stringContaining("timeout"),
+      }),
+    );
+    expect(runtime.error).toHaveBeenCalledTimes(1);
+
+    // Recovery: a transient hang must not wedge the daemon as permanently
+    // disconnected, and must not itself trigger a restart-churn side effect here -
+    // the heartbeat only reports state, the health monitor owns restart decisions.
+    signalCheckMock.mockResolvedValueOnce({ ok: true });
+    setStatus.mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ connected: true, lastError: null }),
+    );
+
+    heartbeat.stop();
+  });
+
+  it("stops probing once stopped", async () => {
+    signalCheckMock.mockResolvedValue({ ok: true });
+    const setStatus = vi.fn();
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    const heartbeat = startSignalDaemonHeartbeat({
+      baseUrl: "http://127.0.0.1:8080",
+      runtime,
+      statusSink: setStatus,
+    });
+    await vi.waitFor(() => expect(signalCheckMock).toHaveBeenCalledTimes(1));
+    heartbeat.stop();
+
+    await vi.advanceTimersByTimeAsync(180_000);
+    expect(signalCheckMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -9,6 +9,10 @@ import type {
   SignalReactionNotificationMode,
 } from "openclaw/plugin-sdk/config-contracts";
 import {
+  createConnectedChannelStatusPatch,
+  createTransportActivityStatusPatch,
+} from "openclaw/plugin-sdk/gateway-runtime";
+import {
   canonicalizeBase64,
   detectMime,
   estimateBase64DecodedBytes,
@@ -223,6 +227,42 @@ async function waitForSignalDaemonReady(params: {
       };
     },
   });
+}
+
+const SIGNAL_DAEMON_HEARTBEAT_INTERVAL_MS = 60_000;
+const SIGNAL_DAEMON_HEARTBEAT_TIMEOUT_MS = 5_000;
+
+/**
+ * Re-proves the managed signal-cli daemon still serves requests after startup.
+ * The daemon's SSE endpoint stays idle between inbound events, so a live child
+ * process is the only other liveness signal and a hung daemon looks healthy
+ * forever. Publishing transport activity lets the gateway health monitor treat
+ * an unresponsive daemon as disconnected and restart it (#116295).
+ */
+export function startSignalDaemonHeartbeat(params: {
+  baseUrl: string;
+  runtime: RuntimeEnv;
+  statusSink?: SignalStatusSink;
+}): { stop: () => void } {
+  const probe = async () => {
+    const res = await signalCheck(params.baseUrl, SIGNAL_DAEMON_HEARTBEAT_TIMEOUT_MS);
+    const at = Date.now();
+    if (res.ok) {
+      params.statusSink?.({
+        ...createConnectedChannelStatusPatch(at),
+        ...createTransportActivityStatusPatch(at),
+        lastError: null,
+      });
+      return;
+    }
+    const error = res.error ?? (res.status ? `HTTP ${res.status}` : "unreachable");
+    params.statusSink?.({ connected: false, lastError: `signal daemon unresponsive: ${error}` });
+    params.runtime.error?.(`signal daemon health probe failed: ${error}`);
+  };
+  void probe();
+  const timer = setInterval(() => void probe(), SIGNAL_DAEMON_HEARTBEAT_INTERVAL_MS);
+  timer.unref?.();
+  return { stop: () => clearInterval(timer) };
 }
 
 const SIGNAL_ATTACHMENT_RPC_RESPONSE_HEADROOM_BYTES = 64 * 1024;
@@ -559,6 +599,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   const daemonLifecycle = createSignalDaemonLifecycle({ abortSignal: opts.abortSignal });
   const monitorTaskRunner = createSignalMonitorTaskRunner(runtime);
   let daemonHandle: SignalDaemonHandle | null = null;
+  let daemonHeartbeat: { stop: () => void } | null = null;
   let ingressMonitor: SignalIngressMonitor | undefined;
 
   if (autoStart) {
@@ -601,6 +642,11 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       if (daemonExitError) {
         throw daemonExitError;
       }
+      daemonHeartbeat = startSignalDaemonHeartbeat({
+        baseUrl,
+        runtime,
+        statusSink: opts.statusSink,
+      });
     }
 
     registerChannelRuntimeContext({
@@ -689,6 +735,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     }
     throw err;
   } finally {
+    daemonHeartbeat?.stop();
     await ingressMonitor?.stop();
     // Daemon attachment finishes before monitor tasks start. Keep teardown open until both the
     // child has exited and already-started reply work has drained.


### PR DESCRIPTION
## What Problem This Solves

The managed signal-cli daemon is only proven alive once, at startup (`waitForSignalDaemonReady`). After that, the daemon's SSE endpoint stays idle between inbound Signal events, so a daemon that hangs (deadlocked, wedged on a syscall, etc.) without exiting its process keeps reporting `connected: true` forever — there is no other liveness signal, so the gateway health monitor has nothing to act on and never restarts it (#116295).

## Why This Change Was Made

Added a periodic (60s) liveness probe that re-checks the daemon's own `/api/v1/check` endpoint via the existing `signalCheck` adapter, started once `autoStart` brings the managed daemon up and stopped in the same `finally` block that already tears down the ingress monitor. A successful probe publishes a connected + transport-activity status patch (`createConnectedChannelStatusPatch`/`createTransportActivityStatusPatch`, the same factories the SSE path already uses); a failed probe marks the account `connected: false` with the probe error in `lastError`, which is what the gateway health monitor reads. Wiring reuses the account's existing `setStatus` sink (`createAccountStatusSink`), the same one `startAccount` already writes an initial snapshot through.

## User Impact

A wedged managed signal-cli daemon now flips to disconnected within ~60s of going unresponsive instead of appearing healthy indefinitely, letting the gateway's existing restart/alerting machinery react to it.

## Evidence

- `autoStart` (and therefore the heartbeat) only ever applies to `managed-native` transport, the exact case this issue is about — container-transport accounts don't spawn a daemon here and are unaffected.
- The probe reuses `signalCheck`, the same function `waitForSignalDaemonReady` uses for startup readiness, applied periodically instead of once.

Fixes #116295
