### PR TITLE
fix(agents): resolve configured context tokens for provider-self-prefixed refs

### DIFF
--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -3,6 +3,7 @@ import {
   resolveClaudeSonnet5ModelIdentity,
   supportsClaude1MContext,
 } from "@openclaw/llm-core";
+import { stripSelfProviderModelPrefix } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -77,31 +78,22 @@ function resolveConfiguredProviderModel(
     providerEntries.find(
       ([providerId]) => normalizeProviderId(providerId) === normalizedProvider,
     )?.[1];
-  return providerConfig?.models?.find((entry) => {
-    const entryId = entry.id?.trim();
-    if (!entryId) {
-      return false;
+  const bareModel = stripSelfProviderModelPrefix(normalizedProvider, model);
+  const spellings = bareModel === model ? [model] : [model, bareModel];
+  for (const spelling of spellings) {
+    const match = providerConfig?.models?.find((entry) => {
+      const entryId = entry.id?.trim();
+      return (
+        entryId === spelling ||
+        (entryId !== undefined &&
+          stripSelfProviderModelPrefix(normalizedProvider, entryId) === spelling)
+      );
+    });
+    if (match) {
+      return match;
     }
-    if (entryId === model) {
-      return true;
-    }
-    const slash = entryId.indexOf("/");
-    return (
-      slash > 0 &&
-      normalizeProviderId(entryId.slice(0, slash)) === normalizedProvider &&
-      entryId.slice(slash + 1).trim() === model
-    );
-  });
-}
-
-function resolveProviderQualifiedModel(provider: string, model: string): string | undefined {
-  const slash = model.indexOf("/");
-  if (slash <= 0) {
-    return undefined;
   }
-  const prefixedProvider = normalizeProviderId(model.slice(0, slash));
-  const bareModel = model.slice(slash + 1).trim();
-  return prefixedProvider === normalizeProviderId(provider) && bareModel ? bareModel : undefined;
+  return undefined;
 }
 
 function resolveConfiguredRuntimeModel(
@@ -121,14 +113,7 @@ function resolveConfiguredRuntimeModel(
   ) {
     return undefined;
   }
-  const canonicalResult = resolveConfiguredProviderModel(cfg, canonicalProvider, model);
-  if (canonicalResult) {
-    return canonicalResult;
-  }
-  const canonicalModel = resolveProviderQualifiedModel(canonicalProvider, model);
-  return canonicalModel
-    ? resolveConfiguredProviderModel(cfg, canonicalProvider, canonicalModel)
-    : undefined;
+  return resolveConfiguredProviderModel(cfg, canonicalProvider, model);
 }
 
 function readAuthoredModelContextTokens(model: ConfigModelEntry | undefined): number | undefined {

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -1,6 +1,7 @@
 // Covers context-token lookup caches, catalog warmup, and provider-qualified
 // model resolution.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { replaceDiscoveredContextTokenCache } from "./context-cache.js";
 import { ANTHROPIC_CONTEXT_1M_TOKENS } from "./context-resolution.js";
@@ -110,6 +111,19 @@ function createContextOverrideConfig(
         },
       },
     },
+  };
+}
+
+function createConfiguredModel(id: string, contextTokens: number): ModelDefinitionConfig {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: contextTokens,
+    contextTokens,
+    maxTokens: 4096,
   };
 }
 
@@ -633,6 +647,44 @@ describe("lookupContextTokens", () => {
       model: "gemini-3.1-pro-preview",
     });
     expect(result).toBe(200_000);
+  });
+
+  it.each([
+    {
+      name: "matches a bare configured row for a provider-self-prefixed runtime model",
+      model: "kilocode/kilo-auto/balanced",
+      configuredModels: [createConfiguredModel("kilo-auto/balanced", 900_000)],
+      expected: 900_000,
+    },
+    {
+      name: "prefers the exact qualified row over an earlier bare row",
+      model: "kilocode/kilo-auto/balanced",
+      configuredModels: [
+        createConfiguredModel("kilo-auto/balanced", 111_000),
+        createConfiguredModel("kilocode/kilo-auto/balanced", 900_000),
+      ],
+      expected: 900_000,
+    },
+    {
+      name: "does not strip another provider's prefix",
+      model: "openrouter/anthropic/claude-sonnet-5",
+      configuredModels: [createConfiguredModel("anthropic/claude-sonnet-5", 900_000)],
+      expected: 128_000,
+    },
+  ])("$name", async ({ model, configuredModels, expected }) => {
+    mockDiscoveryDeps([{ provider: "kilocode", id: model, contextWindow: 128_000 }]);
+    const cfg = {
+      models: {
+        providers: {
+          kilocode: { baseUrl: "https://example.invalid", models: configuredModels },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const { lookupContextTokens, resolveContextTokensForModel } = await importContextModule();
+    lookupContextTokens(model);
+    await flushAsyncWarmup();
+
+    expect(resolveContextTokensForModel({ cfg, provider: "kilocode", model })).toBe(expected);
   });
 
   it("bounds a per-model cap by the Anthropic fixed contract", async () => {


### PR DESCRIPTION
## What Problem This Solves

A provider or runtime can report its effective model with the provider name repeated, such as provider `kilocode` and model `kilocode/kilo-auto/balanced`. Operators configure the same model as the bare provider-owned ID, `kilo-auto/balanced`.

The shared configured-model lookup did not treat those two spellings as the same model. It missed the operator's `contextTokens: 900000` row and silently persisted the discovered 128,000-token window instead.

Fixes #116010.

## Why This Change Was Made

The configured-model resolver now checks the exact runtime spelling first, then the existing shared self-prefix-normalized spelling. This keeps an exact qualified row ahead of a bare row and never strips a prefix owned by another provider.

The canonical-provider caller no longer repeats the stripped-ID lookup. One resolver now owns the spelling rule for every caller.

No fallback, configuration, migration, or public API behavior changed.

## User Impact

When a run reports a provider-self-prefixed model ID, its persisted session context budget now uses the operator's matching per-model configuration. This prevents premature compaction caused by silently storing the smaller discovered window.

## Evidence

The same isolated production-accounting scenario ran against exact main and the repaired head. It loaded a schema-valid `openclaw.json`, supplied a completed run result with `kilocode/kilo-auto/balanced`, primed the discovered window at 128,000, ran `accountAgentTurn`, and reopened the persisted session row.

| Revision | Configured row | Persisted context budget |
| --- | ---: | ---: |
| `629a47e3cc20a9f8b6d19c105f840b8a693ec4aa` | 900,000 | 128,000 |
| `e96b6a046e1b23b36faec982f031ef71ec7273c6` | 900,000 | 900,000 |

A complete HTTP model turn cannot honestly create this boundary input: provider transports keep the upstream response model in `responseModel`, while run-result accounting reads the effective model from `agentMeta.model`. The proof therefore uses the deepest production boundary that accepts this fact: real config loading, production run-result accounting, and persisted-session readback.

Regression proof:

- With the new test and exact-main production source, 1 test fails with `expected 128000 to be 900000`; the other 33 pass.
- On the repaired source, `context.lookup`, `context`, and `context-window-guard` pass 159 tests.
- The changed-scope gate passes formatting, lint, production and test type checks, dead-code checks, dependency checks, architecture guards, and `git diff --check`.

Production delta: `+16/-31` (net `-15`). Tests: `+52/-0`.
