### PR TITLE
fix(plugins): abort hook ctx.abortSignal on hook timeout expiry

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -62,7 +62,7 @@ observation side effects.
 | `matcher`          | Non-empty list of canonical OpenClaw tool ids handled by `before_tool_call` or `after_tool_call`, such as `exec`, `apply_patch`, or `spawn_agent`. Omit to match all tools. Empty lists, wildcards, blanks, and provider-specific aliases are invalid. |
 | `priority`         | Ordering; higher runs first.                                                                                                                                                                                                                           |
 | `registrationId`   | Stable identity for one registration inside a plugin. Skill evaluators use it as `evaluatorId`; otherwise the plugin id is used.                                                                                                                       |
-| `timeoutMs`        | Per-hook await budget. When it expires, OpenClaw stops awaiting that handler and moves on. It does not cancel the handler or its side effects. Omit to use the runner's default per-hook timeout.                                                      |
+| `timeoutMs`        | Per-hook await budget. When it expires, OpenClaw stops awaiting that handler, aborts its `ctx.abortSignal`, and moves on. Omit to use the runner's default per-hook timeout.                                                                             |
 | `eligibleTriggers` | For `before_agent_reply` only, limits host dispatch to one or more of `cron`, `heartbeat`, or `user`.                                                                                                                                                  |
 
 Trigger eligibility is enforced by the host before it invokes the handler. A
@@ -96,12 +96,13 @@ plugin-authored `api.on(..., { timeoutMs })` value. Each value must be a
 positive integer up to 600000 ms. Prefer per-hook overrides for known-slow
 hooks so one plugin does not get a longer budget everywhere.
 
-A timed-out handler promise continues running because hook callbacks do not
-receive a timeout-owned cancellation signal. `before_tool_call` receives the
-owning tool call's `ctx.abortSignal`, but hook timeout expiry does not abort it.
-The hook dispatch can release its Gateway admission while that plugin work is
-still in progress. Plugins that own long-running work must provide their own
-cancellation and shutdown lifecycle.
+A handler that runs under a timeout receives `ctx.abortSignal`, and the runner
+aborts it when the budget expires. Where the host already supplies a signal, such
+as the owning tool call's signal for `before_tool_call`, the two are composed, so
+either cancellation aborts the handler's signal. Awaiting stops at expiry either
+way, so plugins that spawn child processes or other owned work must honor that
+signal; work that ignores it keeps running after the hook dispatch releases its
+Gateway admission.
 
 Policy hooks `before_tool_call` and `before_install` use a 15-second default per
 handler. A timeout fails closed: the tool call or installation is rejected
@@ -329,8 +330,8 @@ provider payloads, start the Gateway with `--raw-stream` and
 - context fields such as `ctx.agentId`, `ctx.sessionKey`, `ctx.sessionId`,
   `ctx.runId`, `ctx.toolKind`, `ctx.toolInputKind`, and diagnostic `ctx.trace`
 - optional `ctx.abortSignal`, which aborts when the owning tool call is
-  cancelled; handlers should pass it to cancellable I/O and remove any
-  listeners they register
+  cancelled or the handler's hook timeout expires; handlers should pass it to
+  cancellable I/O and remove any listeners they register
 - optional `ctx.requester`, the host-derived requester that initiated the current
   message run. It can include `channel`, `accountId`, `senderId`,
   `senderIsOwner`, and provider-native `roleIds`. Missing fields are unproven,

--- a/src/plugins/hook-message.types.ts
+++ b/src/plugins/hook-message.types.ts
@@ -110,6 +110,8 @@ export type PluginHookMessageContext = {
   spanId?: string;
   parentSpanId?: string;
   callDepth?: number;
+  /** Aborts when this handler's hook timeout expires, composed with any caller cancellation. */
+  abortSignal?: AbortSignal;
 };
 
 export type PluginHookInboundClaimContext = PluginHookMessageContext & {

--- a/src/plugins/hook-skill.types.ts
+++ b/src/plugins/hook-skill.types.ts
@@ -132,4 +132,6 @@ export type PluginHookSkillProposalChangedEvent = {
 export type PluginHookSkillContext = {
   workspaceDir: string;
   agentId?: string;
+  /** Aborts when this handler's hook timeout expires, composed with any caller cancellation. */
+  abortSignal?: AbortSignal;
 };

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -661,7 +661,7 @@ export type PluginHookToolContext = {
   sessionKey?: string;
   sessionId?: string;
   runId?: string;
-  /** Aborts when the owning tool call is cancelled. Hook timeout expiry does not abort this signal. */
+  /** Aborts when the owning tool call is cancelled or this handler's hook timeout expires. */
   abortSignal?: AbortSignal;
   trace?: DiagnosticTraceContext;
   toolName: string;

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -300,6 +300,8 @@ export type PluginHookAgentContext = {
   senderExternalId?: string;
   /** Channel-owned sender/chat details. Plugins may augment the nested interfaces. */
   channelContext?: PluginHookChannelContext;
+  /** Aborts when this handler's hook timeout expires, composed with any caller cancellation. */
+  abortSignal?: AbortSignal;
 };
 
 export type PluginHookContextWindowSource =
@@ -498,6 +500,8 @@ export type PluginHookBeforeDispatchContext = {
   replyToBody?: string;
   replyToSender?: string;
   replyToIsQuote?: boolean;
+  /** Aborts when this handler's hook timeout expires, composed with any caller cancellation. */
+  abortSignal?: AbortSignal;
 };
 
 export type PluginHookBeforeDispatchResult = {
@@ -718,6 +722,8 @@ export type PluginHookToolResultPersistContext = {
   sessionKey?: string;
   toolName?: string;
   toolCallId?: string;
+  /** Aborts when this handler's hook timeout expires, composed with any caller cancellation. */
+  abortSignal?: AbortSignal;
 };
 
 export type PluginHookToolResultPersistEvent = {
@@ -746,6 +752,8 @@ export type PluginHookSessionContext = {
   agentId?: string;
   sessionId: string;
   sessionKey?: string;
+  /** Aborts when this handler's hook timeout expires, composed with any caller cancellation. */
+  abortSignal?: AbortSignal;
 };
 
 export type PluginHookSessionStartEvent = {
@@ -781,6 +789,8 @@ export type PluginHookSubagentContext = {
   runId?: string;
   childSessionKey?: string;
   requesterSessionKey?: string;
+  /** Aborts when this handler's hook timeout expires, composed with any caller cancellation. */
+  abortSignal?: AbortSignal;
 };
 
 type PluginHookSubagentTargetKind = "subagent" | "acp";
@@ -874,6 +884,8 @@ export type PluginHookGatewayContext = {
   config?: OpenClawConfig;
   workspaceDir?: string;
   getCron?: () => PluginHookGatewayCronService | undefined;
+  /** Aborts when this handler's hook timeout expires, composed with any caller cancellation. */
+  abortSignal?: AbortSignal;
 };
 
 export type PluginHookCronReconciledContext = PluginHookGatewayContext & {
@@ -1102,6 +1114,8 @@ export type PluginHookBeforeInstallContext = {
   targetType: PluginInstallTargetType;
   requestKind: PluginInstallRequestKind;
   origin?: string;
+  /** Aborts when this handler's hook timeout expires, composed with any caller cancellation. */
+  abortSignal?: AbortSignal;
 };
 
 export type PluginHookBeforeInstallEvent = {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -146,13 +146,13 @@ type HookRunnerOptions = {
    */
   failurePolicyByHook?: Partial<Record<PluginHookName, HookFailurePolicy>>;
   /**
-   * Optional timeout for void/observation hooks. A timed-out hook is logged and
-   * the runner continues, but the plugin's underlying work is not cancelled.
+   * Optional timeout for void/observation hooks. A timed-out hook is logged, its
+   * context abort signal fires, and the runner continues.
    */
   voidHookTimeoutMsByHook?: Partial<Record<PluginHookName, number>>;
   /**
    * Optional timeout for modifying hooks. A timed-out hook is logged and skipped,
-   * but the plugin's underlying work is not cancelled.
+   * and its context abort signal fires.
    */
   modifyingHookTimeoutMsByHook?: Partial<Record<PluginHookName, number>>;
 };
@@ -617,23 +617,53 @@ export function createHookRunner(
   const getClaimingHookTimeoutMs = (hook: PluginHookRegistration): number | undefined =>
     normalizePositiveTimeoutMs(hook.timeoutMs);
 
-  const withHookTimeout = async <T>(
-    promise: Promise<T>,
-    timeoutMs: number,
-    optionsResult: { unref?: boolean } = {},
-  ): Promise<T> => {
+  // The deadline signal is composed with any caller signal already on the context so a
+  // handler keeps observing tool-call cancellation as well as its own await budget.
+  const attachHookDeadlineSignal = (ctx: unknown, deadlineSignal: AbortSignal): unknown => {
+    if (typeof ctx !== "object" || ctx === null) {
+      return ctx;
+    }
+    const callerSignal = (ctx as { abortSignal?: AbortSignal }).abortSignal;
+    return {
+      ...ctx,
+      abortSignal: callerSignal ? AbortSignal.any([callerSignal, deadlineSignal]) : deadlineSignal,
+    };
+  };
+
+  /**
+   * Invoke one hook handler under its await budget. Expiry only stops the runner from
+   * awaiting, so aborting the deadline signal is the handler's single cancellation
+   * notice; without it the abandoned work and any child processes it spawned outlive
+   * the released hook lane and accumulate across turns (#115450).
+   */
+  const invokeHookHandler = async <T>(params: {
+    handler: unknown;
+    event: unknown;
+    ctx: unknown;
+    timeoutMs: number | undefined;
+    unrefTimeout?: boolean;
+  }): Promise<T> => {
+    const handler = params.handler as (event: unknown, ctx: unknown) => Promise<T> | T;
+    const timeoutMs = params.timeoutMs;
+    if (!timeoutMs) {
+      return await Promise.resolve(handler(params.event, params.ctx));
+    }
+
+    const deadline = new AbortController();
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
+        deadline.abort(new Error(`hook timed out after ${timeoutMs}ms`));
         reject(new Error(`timed out after ${timeoutMs}ms`));
       }, timeoutMs);
-      if (optionsResult.unref) {
+      if (params.unrefTimeout) {
         timer.unref?.();
       }
     });
 
+    const handlerCtx = attachHookDeadlineSignal(params.ctx, deadline.signal);
     try {
-      return await Promise.race([promise, timeout]);
+      return await Promise.race([Promise.resolve(handler(params.event, handlerCtx)), timeout]);
     } finally {
       if (timer) {
         clearTimeout(timer);
@@ -684,15 +714,13 @@ export function createHookRunner(
 
     const promises = hooks.map(async (hook) => {
       try {
-        const promise = Promise.resolve(
-          (hook.handler as (event: unknown, ctx: unknown) => Promise<void> | void)(event, ctx),
-        );
-        const timeoutMs = getVoidHookTimeoutMs(hookName, hook);
-        if (timeoutMs) {
-          await withHookTimeout(promise, timeoutMs, { unref: optionsValue.unrefTimeout ?? true });
-        } else {
-          await promise;
-        }
+        await invokeHookHandler<void>({
+          handler: hook.handler,
+          event,
+          ctx,
+          timeoutMs: getVoidHookTimeoutMs(hookName, hook),
+          unrefTimeout: optionsValue.unrefTimeout ?? true,
+        });
       } catch (err) {
         handleHookError({ hookName, pluginId: hook.pluginId, error: err });
       }
@@ -723,13 +751,15 @@ export function createHookRunner(
 
     for (const hook of hooks) {
       try {
-        const handler = hook.handler as (event: unknown, ctx: unknown) => Promise<TResult>;
         const handlerEvent = policy.isolateEventPerHandler
           ? cloneHookIsolationValue(hookName, event)
           : event;
-        const promise = Promise.resolve(handler(handlerEvent, ctx));
-        const timeoutMs = getModifyingHookTimeoutMs(hookName, hook);
-        const handlerResult = timeoutMs ? await withHookTimeout(promise, timeoutMs) : await promise;
+        const handlerResult = await invokeHookHandler<TResult>({
+          handler: hook.handler,
+          event: handlerEvent,
+          ctx,
+          timeoutMs: getModifyingHookTimeoutMs(hookName, hook),
+        });
 
         const shouldMergeResult =
           handlerResult !== undefined && (handlerResult !== null || policy.mergeNullResults);
@@ -812,13 +842,13 @@ export function createHookRunner(
   ): Promise<TResult | undefined> {
     for (const hook of hooks) {
       try {
-        const invokeHandler = async (): Promise<TResult | void> => {
-          const promise = Promise.resolve(
-            (hook.handler as (event: unknown, ctx: unknown) => Promise<TResult | void>)(event, ctx),
-          );
-          const timeoutMs = getClaimingHookTimeoutMs(hook);
-          return timeoutMs ? await withHookTimeout(promise, timeoutMs) : await promise;
-        };
+        const invokeHandler = (): Promise<TResult | void> =>
+          invokeHookHandler<TResult | void>({
+            handler: hook.handler,
+            event,
+            ctx,
+            timeoutMs: getClaimingHookTimeoutMs(hook),
+          });
         const handlerResult = runHandler ? await runHandler(invokeHandler) : await invokeHandler();
         if (handlerResult?.handled) {
           return handlerResult;
@@ -866,11 +896,12 @@ export function createHookRunner(
     let firstError: string | null = null;
     for (const hook of hooks) {
       try {
-        const promise = Promise.resolve(
-          (hook.handler as (event: unknown, ctx: unknown) => Promise<TResult | void>)(event, ctx),
-        );
-        const timeoutMs = getClaimingHookTimeoutMs(hook);
-        const handlerResult = timeoutMs ? await withHookTimeout(promise, timeoutMs) : await promise;
+        const handlerResult = await invokeHookHandler<TResult | void>({
+          handler: hook.handler,
+          event,
+          ctx,
+          timeoutMs: getClaimingHookTimeoutMs(hook),
+        });
         if (handlerResult?.handled) {
           return { status: "handled", result: handlerResult };
         }
@@ -1124,15 +1155,12 @@ export function createHookRunner(
 
     for (const hook of hooks) {
       try {
-        const handler = hook.handler as (
-          event: PluginHookReplyPayloadSendingEvent,
-          ctx: PluginHookReplyPayloadSendingContext,
-        ) => Promise<PluginHookReplyPayloadSendingResult | void>;
-        const promise = Promise.resolve(
-          handler({ ...event, payload: toPluginReplyPayload(currentPayload) }, ctx),
-        );
-        const timeoutMs = getModifyingHookTimeoutMs("reply_payload_sending", hook);
-        const handlerResult = timeoutMs ? await withHookTimeout(promise, timeoutMs) : await promise;
+        const handlerResult = await invokeHookHandler<PluginHookReplyPayloadSendingResult | void>({
+          handler: hook.handler,
+          event: { ...event, payload: toPluginReplyPayload(currentPayload) },
+          ctx,
+          timeoutMs: getModifyingHookTimeoutMs("reply_payload_sending", hook),
+        });
 
         if (!handlerResult) {
           continue;
@@ -1472,13 +1500,12 @@ export function createHookRunner(
           ...(pluginVersion ? { pluginVersion } : {}),
         };
         try {
-          const handler = hook.handler as (
-            event: PluginHookSkillProposalEvaluateEvent,
-            ctx: PluginHookSkillContext,
-          ) => Promise<PluginHookSkillProposalEvaluateResult | void>;
-          const promise = Promise.resolve(handler(immutableEvent, ctx));
-          const timeoutMs = getModifyingHookTimeoutMs(hookName, hook);
-          const result = timeoutMs ? await withHookTimeout(promise, timeoutMs) : await promise;
+          const result = await invokeHookHandler<PluginHookSkillProposalEvaluateResult | void>({
+            handler: hook.handler,
+            event: immutableEvent,
+            ctx,
+            timeoutMs: getModifyingHookTimeoutMs(hookName, hook),
+          });
           return result
             ? Object.assign({}, attribution, { status: "completed" as const, result })
             : Object.assign({}, attribution, { status: "skipped" as const });


### PR DESCRIPTION
## What Problem This Solves

A plugin hook that runs past its `timeoutMs` budget keeps executing after the runner gives up on it. The timeout only raced the handler's promise (`Promise.race([promise, timeout])`); it never signaled the handler itself, and `ctx.abortSignal` — documented as the signal that aborts when the owning tool call is cancelled — was never touched by hook-timeout expiry. A plugin that spawns a child process or other owned work inside a hook has no cancellation notice, so that work (and any child processes) outlives the released Gateway hook lane and accumulates across turns (#115450).

## Why This Change Was Made

Introduced one `invokeHookHandler` helper used by every hook-dispatch path (void hooks, modifying hooks, claiming hooks, `reply_payload_sending`, `skill_proposal_evaluate`). For a timed-out call it builds a per-invocation deadline `AbortController`, composes it with any caller-supplied `ctx.abortSignal` via `AbortSignal.any` (already used elsewhere in the codebase, e.g. `src/gateway/worker-environments/inference-runtime.ts`) so a handler observes both its own timeout and the owning tool call's cancellation through the same signal, and aborts the deadline exactly when the timer fires. This replaces the previous `withHookTimeout(promise, timeoutMs)` shape, which constructed the handler's promise before the timeout existed and had no way to reach into it.

Docs (`docs/plugins/hooks.md`) and the `PluginHookToolContext.abortSignal` doc comment updated to state the new contract: hook timeout expiry now aborts the signal, so plugins that own long-running work must honor it (they no longer need their own separate cancellation lifecycle for the timeout case specifically).

## User Impact

Plugin authors who honor `ctx.abortSignal` in `exec`/spawn-style hook work now get a real cancellation signal when their hook exceeds its timeout budget, instead of the runner silently walking away while the work keeps running unbounded.

## Evidence

- All five hook-dispatch call sites (`dispatchVoidHooks`, modifying-hook dispatch, claiming-hook dispatch x2, `reply_payload_sending`, `skill_proposal_evaluate`) now route through the single `invokeHookHandler`, so the behavior change is uniform rather than path-specific.
- `AbortSignal.any` is already relied on for signal composition in this codebase (`worker-turn-admission.ts`, `workspace-sync.ts`, `worker-turn-launcher.ts`), confirming it's within the supported Node/lib target here.

Fixes #115450
