### PR TITLE
fix(workboard): flag archived cards stuck in an active dispatch status

### DIFF
--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -375,6 +375,7 @@ Diagnostics are computed from local card metadata. Built-in checks flag:
 | `repeated_failures`         | Card's tracked failure count reaches 2 or more.                                |
 | `missing_proof`             | `done` card with no proof, artifacts, or attachments.                          |
 | `orphaned_session`          | `running` card with a `sessionKey` but no `execution` metadata.                |
+| `archived_but_active`       | Archived `scheduled`/`ready`/`running` card that dispatch will never pick up.  |
 
 ## Permissions
 

--- a/extensions/workboard/src/cli.ts
+++ b/extensions/workboard/src/cli.ts
@@ -69,7 +69,10 @@ function isWorkboardStatus(value: string): value is WorkboardStatus {
 function formatCardLine(card: WorkboardCard): string {
   const boardId = card.metadata?.automation?.boardId ?? "default";
   const agent = card.agentId ? ` ${card.agentId}` : "";
-  return `${card.id.slice(0, 8)}  ${card.status.padEnd(8)}  ${card.priority.padEnd(6)}  ${boardId}${agent}  ${card.title}`;
+  // Archived cards are excluded from dispatch at any status, so the marker has to stay visible
+  // wherever a card is printed, including `show` and `list --include-archived` (#116359).
+  const archived = card.metadata?.archivedAt ? " (archived)" : "";
+  return `${card.id.slice(0, 8)}  ${card.status.padEnd(8)}  ${card.priority.padEnd(6)}  ${boardId}${agent}${archived}  ${card.title}`;
 }
 
 function redactDispatchResult(result: WorkboardDispatchResult): WorkboardDispatchResult {

--- a/extensions/workboard/src/command.ts
+++ b/extensions/workboard/src/command.ts
@@ -38,7 +38,8 @@ function splitArgs(input: string | undefined): string[] {
 function formatCardLine(card: WorkboardCard): string {
   const boardId = card.metadata?.automation?.boardId ?? "default";
   const agent = card.agentId ? ` @${card.agentId}` : "";
-  return `${card.id.slice(0, 8)} ${card.status.padEnd(8)} ${card.priority.padEnd(6)} [${boardId}]${agent} ${card.title}`;
+  const archived = card.metadata?.archivedAt ? " (archived)" : "";
+  return `${card.id.slice(0, 8)} ${card.status.padEnd(8)} ${card.priority.padEnd(6)} [${boardId}]${agent}${archived} ${card.title}`;
 }
 
 function formatCardDetails(card: WorkboardCard): string {
@@ -49,6 +50,9 @@ function formatCardDetails(card: WorkboardCard): string {
     `priority: ${card.priority}`,
     `board: ${card.metadata?.automation?.boardId ?? "default"}`,
   ];
+  if (card.metadata?.archivedAt) {
+    lines.push("archived: yes (excluded from dispatch)");
+  }
   if (card.agentId) {
     lines.push(`agent: ${card.agentId}`);
   }

--- a/extensions/workboard/src/store-card-helpers.ts
+++ b/extensions/workboard/src/store-card-helpers.ts
@@ -358,6 +358,9 @@ export function retryBudgetExhausted(card: WorkboardCard): boolean {
   return Boolean(maxRetries && (card.metadata?.failureCount ?? 0) > maxRetries);
 }
 
+/** Statuses where dispatch would otherwise promote, start, or reclaim the card. */
+const ARCHIVED_ACTIVE_STATUSES = new Set<WorkboardStatus>(["scheduled", "ready", "running"]);
+
 function diagnostic(
   params: {
     kind: WorkboardDiagnosticKind;
@@ -395,7 +398,22 @@ export function mergeDiagnostics(
 
 export function computeCardDiagnostics(card: WorkboardCard, now: number): WorkboardDiagnostic[] {
   if (card.metadata?.archivedAt) {
-    return [];
+    // Archived cards never re-enter dispatch, so one left in a dispatchable status stalls with no
+    // other signal on any surface; report that instead of returning no diagnostics (#116359).
+    return ARCHIVED_ACTIVE_STATUSES.has(card.status)
+      ? [
+          diagnostic(
+            {
+              kind: "archived_but_active",
+              severity: "warning",
+              title: "Archived card is still in an active status",
+              detail: `The card is archived, so dispatch skips it while its status is ${card.status}. Unarchive it to resume dispatch, or move it to done.`,
+              actions: [],
+            },
+            now,
+          ),
+        ]
+      : [];
   }
   const diagnostics: WorkboardDiagnostic[] = [];
   const claim = card.metadata?.claim;

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -228,13 +228,16 @@ export class WorkboardStore extends WorkboardNotificationStore {
       const rows: WorkboardDiagnosticsResult["diagnostics"] = [];
       for (const card of cards) {
         const latest = await this.get(card.id);
-        if (!latest || latest.metadata?.archivedAt) {
+        if (!latest) {
           continue;
         }
-        const diagnostics = mergeDiagnostics(
-          latest.metadata?.diagnostics,
-          computeCardDiagnostics(latest, now),
-        );
+        const computed = computeCardDiagnostics(latest, now);
+        // Archived cards are refreshed only to persist the archived-but-active diagnostic (#116359);
+        // with nothing to report they keep their stored history instead of being rewritten.
+        if (latest.metadata?.archivedAt && computed.length === 0) {
+          continue;
+        }
+        const diagnostics = mergeDiagnostics(latest.metadata?.diagnostics, computed);
         if (diagnostics.length === 0 && !latest.metadata?.diagnostics?.length) {
           continue;
         }

--- a/packages/workboard-contract/src/index.ts
+++ b/packages/workboard-contract/src/index.ts
@@ -71,6 +71,7 @@ export const WORKBOARD_DIAGNOSTIC_KINDS = [
   "repeated_failures",
   "missing_proof",
   "orphaned_session",
+  "archived_but_active",
 ] as const;
 export const WORKBOARD_DIAGNOSTIC_SEVERITIES = ["warning", "error", "critical"] as const;
 export const WORKBOARD_NOTIFICATION_KINDS = ["completed", "failed", "stale"] as const;


### PR DESCRIPTION
## What Problem This Solves

`computeCardDiagnostics` returns no diagnostics at all for any archived card, regardless of status. Archiving happens unconditionally on whatever status a card is in — a race with in-flight dispatch, or a manual archive — so a card archived while `scheduled`, `ready`, or `running` stalls forever with zero signal anywhere (CLI, board text, diagnostics) that dispatch will never pick it up again (#116359).

## Why This Change Was Made

Added a new `archived_but_active` diagnostic kind, reported by `computeCardDiagnostics` only when an archived card's status is in `{scheduled, ready, running}` — the statuses where dispatch would otherwise promote, start, or reclaim it. `WorkboardStore.refreshDiagnostics` previously skipped every archived card unconditionally to avoid rewriting its stored history; it now only skips when the freshly computed diagnostics are empty, so the common case (archived while `done`) is unchanged and covered by the existing `store.test.ts` regression ("keeps archived cards out of diagnostics without rewriting their history" — that test archives a `done` card, which stays outside the active-status set and produces no diagnostic either way). CLI (`extensions/workboard/src/cli.ts`) and chat command (`command.ts`) output also mark archived cards inline so the state is visible without opening diagnostics separately.

## User Impact

An archived card left in an active dispatch status now surfaces a clear `archived_but_active` warning (in diagnostics output and inline in card listings) instead of silently stalling with no path to notice it needs unarchiving or moving to `done`.

## Evidence

- The existing `store.test.ts` "keeps archived cards out of diagnostics without rewriting their history" test archives a card with status `done`, which is not in the new active-status set, so `computeCardDiagnostics` still returns `[]` for it and the no-rewrite path is unaffected.
- `packages/workboard-contract/src/index.ts`'s `WORKBOARD_DIAGNOSTIC_KINDS` is the single source of truth consumed by both the store and docs table; the new kind was added there so all consumers stay in sync.

Fixes #116359
