### PR TITLE
fix(channels): resolve SDK aliases for packaged dist channel entrypoints

### DIFF
--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -103,6 +103,35 @@ function writeAlphaSdkAliasDistFixture(pluginDir: string, label: string) {
   );
 }
 
+function writeAlphaSdkAliasSetupDistFixture(pluginDir: string, label: string) {
+  fs.mkdirSync(pluginDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginDir, "setup-entry.js"),
+    [
+      'import { defineBundledChannelSetupEntry } from "openclaw/plugin-sdk/channel-entry-contract";',
+      "export default defineBundledChannelSetupEntry({",
+      "  importMetaUrl: import.meta.url,",
+      "  plugin: { specifier: './setup-plugin.js', exportName: 'setupPlugin' },",
+      "});",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "setup-plugin.js"),
+    [
+      "export const setupPlugin = {",
+      "  id: 'alpha',",
+      `  meta: { id: 'alpha', label: '${label}' },`,
+      "  capabilities: {},",
+      "  config: {},",
+      "};",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
 function collectBundledChannelEntrypointOffenders(
   bundledPluginRoots: string[],
   isOffender: (source: string, filePath: string) => boolean,
@@ -434,8 +463,13 @@ describe("bundled channel entry shape guards", () => {
 
   it("falls back through the cached loader for package-local dist entries needing SDK aliases", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-package-dist-"));
-    const pluginDir = path.join(root, "extensions", "alpha", "dist");
+    // Packaged installs place channel dists under `<packageRoot>/dist/extensions/<id>/dist`.
+    // Keep the fixture package.json anonymous: giving it a `name` plus an `exports` map
+    // would let Node package self-reference resolve `openclaw/plugin-sdk/*` natively, the
+    // first load would succeed, and the SDK-alias fallback under test would never run.
+    const pluginDir = path.join(root, "dist", "extensions", "alpha", "dist");
     writeAlphaSdkAliasDistFixture(pluginDir, "Package dist Alpha");
+    writeAlphaSdkAliasSetupDistFixture(pluginDir, "Package dist Alpha Setup");
     fs.writeFileSync(path.join(root, "package.json"), '{"type":"module"}\n', "utf8");
 
     vi.doMock("./bundled-root.js", () => ({
@@ -447,14 +481,24 @@ describe("bundled channel entry shape guards", () => {
     vi.doMock("../../plugins/bundled-channel-runtime.js", () => ({
       listBundledChannelPluginMetadata: () => [
         {
-          ...alphaChannelMetadata(),
+          ...alphaChannelMetadata({ includeSetup: true }),
           source: {
-            source: path.join(root, "extensions", "alpha", "index.ts"),
-            built: path.join(root, "extensions", "alpha", "index.ts"),
+            source: path.join(root, "dist", "extensions", "alpha", "index.js"),
+            built: path.join(root, "dist", "extensions", "alpha", "index.js"),
+          },
+          setupSource: {
+            source: path.join(root, "dist", "extensions", "alpha", "setup-entry.js"),
+            built: path.join(root, "dist", "extensions", "alpha", "setup-entry.js"),
           },
         },
       ],
-      resolveBundledChannelGeneratedPath: () => path.join(pluginDir, "index.js"),
+      resolveBundledChannelGeneratedPath: (
+        _rootDir: string,
+        entry: BundledEntrySource | undefined,
+      ) =>
+        (entry?.built ?? entry?.source ?? "").includes("setup-entry")
+          ? path.join(pluginDir, "setup-entry.js")
+          : path.join(pluginDir, "index.js"),
     }));
 
     try {
@@ -464,6 +508,9 @@ describe("bundled channel entry shape guards", () => {
       );
 
       expect(bundled.getBundledChannelPlugin("alpha")?.meta.label).toBe("Package dist Alpha");
+      expect(bundled.getBundledChannelSetupPlugin("alpha")?.meta.label).toBe(
+        "Package dist Alpha Setup",
+      );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -137,6 +137,14 @@ function isPackageLocalBundledDistModulePath(params: {
       ? [path.join(params.rootScope.pluginsDir, params.metadata.dirName, "dist")]
       : []),
     path.join(params.rootScope.packageRoot, "extensions", params.metadata.dirName, "dist"),
+    path.join(params.rootScope.packageRoot, "dist", "extensions", params.metadata.dirName, "dist"),
+    path.join(
+      params.rootScope.packageRoot,
+      "dist-runtime",
+      "extensions",
+      params.metadata.dirName,
+      "dist",
+    ),
   ];
   return distRoots.some((root) => isPathInsideCanonicalRoot(root, params.modulePath));
 }


### PR DESCRIPTION
## Summary

Bundled channel entrypoints shipped in a **packaged install** cannot resolve `openclaw/plugin-sdk/*`, so the channel fails to load.

Packaged installs place channel dists under `<packageRoot>/dist/extensions/<id>/dist` (and `<packageRoot>/dist-runtime/extensions/<id>/dist` for the runtime bundle). `isPackageLocalBundledDistModulePath` recognised only:

- `<pluginsDir>/<id>/dist`
- `<packageRoot>/extensions/<id>/dist`

so a packaged entrypoint was denied the cached SDK-alias retry after its first load threw `ERR_MODULE_NOT_FOUND`. This adds the two packaged roots.

## Why these two roots

`resolveBundledChannelBoundaryRoot` — in the **same `loadGeneratedBundledChannelModule` call, on the same `modulePath`** — already probes both packaged layouts:

1. `<pluginsDir>/<id>` (override)
2. `<packageRoot>/dist/extensions/<id>`
3. `<packageRoot>/dist-runtime/extensions/<id>`
4. `<packageRoot>/extensions/<id>` (fallback)

It computes the boundary root for the first load attempt; `isPackageLocalBundledDistModulePath` then decides, inside that attempt's `catch`, whether the SDK-alias retry is permitted.

So for `<packageRoot>/dist/extensions/<id>/dist/index.js` the runtime resolves the boundary root to `<packageRoot>/dist/extensions/<id>` — it already treats the layout as a legitimate packaged channel — and then declines to classify the same path as package-local, so the retry never runs.

This is an internal-consistency fix rather than support for a new layout. Each added root is the extension's own `dist` directory, matching the existing `<packageRoot>/extensions/<id>/dist` entry.

Existing tests do cover `<packageRoot>/dist/extensions/<id>/…` (`mockAlphaDistExtensionRuntime`), but their fixtures export the entry object literally and never import the plugin SDK, so none of them exercised this path.

## Real behavior proof

Against a packaged install (OpenClaw at `/app`), before the patch:

```
$ node -e 'console.log(require("/app/dist/extensions/discord/package.json").name)'
@openclaw/discord

$ node --input-type=module -e 'import("/app/dist/extensions/discord/dist/index.js")'
ERR_MODULE_NOT_FOUND | Cannot find package 'openclaw'
  imported from /app/dist/extensions/discord/dist/index.js
```

The packaged extension ships its own `package.json` (`@openclaw/discord`, no `exports`). That is the nearest `package.json` to the entrypoint, so Node package self-reference cannot resolve the bare `openclaw` specifier — the load can only succeed via the SDK-alias fallback, which this patch re-enables for the packaged layout.

The failure above is reproduced on a live packaged install. A post-fix capture from a packaged build can be supplied on request.

## Test evidence

The regression test was verified to fail without the patch, not merely to pass with it. All runs: `test/vitest/vitest.channels.config.ts`, `src/channels/plugins/bundled.shape-guard.test.ts`.

| `bundled.ts` change | Result |
|---|---|
| applied | 26/26 pass |
| reverted to `main` | **1 failed** — `expected undefined to be 'Package dist Alpha'` |

The fixture's root `package.json` is deliberately anonymous (`{"type":"module"}`). Giving it a `name` plus an `exports` map makes Node package self-reference resolve the SDK natively, so the first load succeeds and the fallback under test never runs — the test then passes with or without the patch. A comment in the test records this.

## Gates

- `pnpm tsgo:core` exit 0
- `pnpm tsgo:core:test` exit 0
- `oxfmt --check` clean, `oxlint` clean on both changed files
- `git diff --check` clean
