### PR TITLE
fix(gateway): require admin access for remote execution [AI]

### DIFF
--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -52,8 +52,9 @@ dispatch so authorization failures have one canonical structured response:
 - `agent` needs `operator.write` for ordinary turns and `operator.admin` for
   `/new` or `/reset` session lifecycle commands.
 - `node.invoke` needs `operator.write` for ordinary relay commands and
-  `operator.admin` for `browser.proxy`, `browser.proxy.upload.v1`, `fs.listDir`,
-  and `terminal.upload`.
+  `operator.admin` for `system.run`, `system.run.prepare`, `system.which`,
+  `browser.proxy`, `browser.proxy.upload.v1`, `fs.listDir`, and
+  `terminal.upload`.
 - `talk.config` needs `operator.read`; `includeSecrets: true` also needs
   `operator.talk.secrets`.
 - `talk.client.*`, `talk.session.*`, `talk.speak`, and `talk.mode` need

--- a/src/agents/bash-tools.exec-host-node.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node.cancellation.test.ts
@@ -227,7 +227,7 @@ describe("node-host dispatch cancellation", () => {
       "node.invoke",
       { timeoutMs: 30_000 },
       expect.objectContaining({ command: "system.run" }),
-      { scopes: ["operator.write", "operator.approvals"], signal: controller.signal },
+      { scopes: ["operator.admin", "operator.approvals"], signal: controller.signal },
     );
   });
 

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -955,7 +955,7 @@ describe("executeNodeHostCommand", () => {
 
     const call = requireGatewayCall(2);
     expect(call.options.timeoutMs).toBe(35_000);
-    expect(call.callOptions).toEqual({ scopes: ["operator.write", "operator.approvals"] });
+    expect(call.callOptions).toEqual({ scopes: ["operator.admin", "operator.approvals"] });
     const runParams = requireRunParams(call);
     expect(runParams.approved).toBe(true);
     expect(runParams.approvalDecision).toBe("allow-once");
@@ -987,7 +987,7 @@ describe("executeNodeHostCommand", () => {
     expect(result.details?.status).toBe("approval-pending");
     await vi.waitFor(() => {
       expect(requireGatewayCommand("system.run").callOptions).toEqual({
-        scopes: ["operator.write", "operator.approvals"],
+        scopes: ["operator.admin", "operator.approvals"],
         signal: abortController.signal,
       });
     });
@@ -1031,7 +1031,7 @@ describe("executeNodeHostCommand", () => {
       expect(result.details?.status).toBe("approval-pending");
       await vi.waitFor(() => {
         expect(requireGatewayCommand("system.run").callOptions).toEqual({
-          scopes: ["operator.write", "operator.approvals"],
+          scopes: ["operator.admin", "operator.approvals"],
           signal: abortController.signal,
         });
       });

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -4,7 +4,7 @@
  * and `node.invoke system.run` execution for host=node calls.
  */
 import { randomUUID } from "node:crypto";
-import { APPROVALS_SCOPE, WRITE_SCOPE } from "../gateway/operator-scopes.js";
+import { ADMIN_SCOPE, APPROVALS_SCOPE } from "../gateway/operator-scopes.js";
 import {
   type ExecAsk,
   type ExecSecurity,
@@ -46,7 +46,7 @@ import { abortable } from "./embedded-agent-runner/run/abortable.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
-const APPROVED_NODE_INVOKE_SCOPES = [WRITE_SCOPE, APPROVALS_SCOPE];
+const APPROVED_NODE_INVOKE_SCOPES = [ADMIN_SCOPE, APPROVALS_SCOPE];
 
 type NodeGatewayDispatchAuthority =
   | "current-policy"

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -153,6 +153,14 @@ describe("method scope resolution", () => {
     expect(
       resolveLeastPrivilegeOperatorScopesForMethod("node.invoke", { command: "device.info" }),
     ).toEqual(["operator.write"]);
+    for (const command of ["system.run.prepare", "system.run", "system.which"]) {
+      expect(resolveLeastPrivilegeOperatorScopesForMethod("node.invoke", { command })).toEqual([
+        "operator.admin",
+      ]);
+      expect(
+        authorizeOperatorScopesForMethod("node.invoke", ["operator.write"], { command }),
+      ).toEqual({ allowed: false, missingScope: "operator.admin" });
+    }
     expect(
       resolveLeastPrivilegeOperatorScopesForMethod("node.invoke", { command: "browser.proxy" }),
     ).toEqual(["operator.admin"]);

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -10,6 +10,7 @@ import {
   publicKeyRawBase64UrlFromPem,
   signDevicePayload,
 } from "../infra/device-identity.js";
+import { NODE_SYSTEM_RUN_COMMANDS } from "../infra/node-commands.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";
 import { buildDeviceAuthPayload } from "./device-auth.js";
@@ -502,7 +503,7 @@ describe("node.invoke approval bypass", () => {
     const node = await connectLinuxNode(() => {
       sawInvoke = true;
     });
-    const ws = await connectOperator(["operator.write"]);
+    const ws = await connectOperator(["operator.admin"]);
     try {
       const nodeId = await getConnectedNodeIdForTest(ws);
       const cases = [
@@ -586,6 +587,43 @@ describe("node.invoke approval bypass", () => {
         expect(res.error?.message ?? "").toContain(
           `node.invoke cannot mutate persistent browser profiles via ${command}`,
         );
+        await expectNoForwardedInvoke(() => sawInvoke);
+      } finally {
+        ws.close();
+        node.stop();
+      }
+    },
+  );
+
+  test.each(NODE_SYSTEM_RUN_COMMANDS)(
+    "requires admin scope for direct %s node.invoke",
+    async (command) => {
+      let sawInvoke = false;
+      const nodeIdentity = createDeviceIdentity();
+      const node = await connectLinuxNode(
+        () => {
+          sawInvoke = true;
+        },
+        nodeIdentity,
+        [command],
+      );
+      const ws = await connectDeviceTokenOperator(["operator.write"]);
+      try {
+        const directRun = await rpcReq(ws, "node.invoke", {
+          nodeId: nodeIdentity.deviceId,
+          command,
+          params: {},
+          idempotencyKey: crypto.randomUUID(),
+        });
+        expect(directRun.ok).toBe(false);
+        expect(directRun.error).toMatchObject({
+          code: "FORBIDDEN",
+          details: {
+            code: "MISSING_SCOPE",
+            missingScope: "operator.admin",
+            requiredScopes: ["operator.admin"],
+          },
+        });
         await expectNoForwardedInvoke(() => sawInvoke);
       } finally {
         ws.close();
@@ -732,9 +770,13 @@ describe("node.invoke approval bypass", () => {
     const invokeCapture = createInvokeParamCapture();
     const node = await connectLinuxNode(invokeCapture.onInvoke);
 
-    const wsApprover = await connectOperator(["operator.write", "operator.approvals"]);
-    const wsCaller = await connectOperator(["operator.write"]);
-    const wsOtherDevice = await connectOperatorWithNewDevice(["operator.write"]);
+    const wsApprover = await connectOperator([
+      "operator.admin",
+      "operator.write",
+      "operator.approvals",
+    ]);
+    const wsCaller = await connectOperator(["operator.admin", "operator.write"]);
+    const wsOtherDevice = await connectOperatorWithNewDevice(["operator.admin", "operator.write"]);
 
     try {
       const nodeId = await getConnectedNodeIdForTest(wsApprover);
@@ -776,8 +818,16 @@ describe("node.invoke approval bypass", () => {
     const invokeCapture = createInvokeParamCapture();
     const node = await connectLinuxNode(invokeCapture.onInvoke);
 
-    const wsRequest = await connectTrustedBackend(["operator.write", "operator.approvals"]);
-    const wsReplay = await connectTrustedBackend(["operator.write", "operator.approvals"]);
+    const wsRequest = await connectTrustedBackend([
+      "operator.admin",
+      "operator.write",
+      "operator.approvals",
+    ]);
+    const wsReplay = await connectTrustedBackend([
+      "operator.admin",
+      "operator.write",
+      "operator.approvals",
+    ]);
 
     try {
       const nodeId = await getConnectedNodeIdForTest(wsRequest);
@@ -843,8 +893,12 @@ describe("node.invoke approval bypass", () => {
     const nodeA = await connectLinuxNode(onInvoke, createDeviceIdentity());
     const nodeB = await connectLinuxNode(onInvoke, createDeviceIdentity());
 
-    const wsApprover = await connectOperator(["operator.write", "operator.approvals"]);
-    const wsCaller = await connectOperator(["operator.write"]);
+    const wsApprover = await connectOperator([
+      "operator.admin",
+      "operator.write",
+      "operator.approvals",
+    ]);
+    const wsCaller = await connectOperator(["operator.admin", "operator.write"]);
 
     try {
       await expect

--- a/src/infra/node-commands.ts
+++ b/src/infra/node-commands.ts
@@ -30,6 +30,7 @@ export const NODE_EXEC_APPROVALS_COMMANDS = [
 
 // Direct node.invoke and pairing approval share this admin-only subset.
 const NODE_ADMIN_ONLY_INVOKE_COMMANDS = [
+  ...NODE_SYSTEM_RUN_COMMANDS,
   ...NODE_BROWSER_PROXY_COMMANDS,
   NODE_FS_LIST_DIR_COMMAND,
   NODE_TERMINAL_UPLOAD_COMMAND,

--- a/src/infra/node-pairing-authz.test.ts
+++ b/src/infra/node-pairing-authz.test.ts
@@ -11,6 +11,7 @@ import {
 import { resolveNodePairApprovalScopes } from "./node-pairing-authz.js";
 
 const ADMIN_ONLY_INVOKE_COMMANDS = [
+  ...NODE_SYSTEM_RUN_COMMANDS,
   ...NODE_BROWSER_PROXY_COMMANDS,
   NODE_FS_LIST_DIR_COMMAND,
   NODE_TERMINAL_UPLOAD_COMMAND,
@@ -24,15 +25,12 @@ describe("resolveNodePairApprovalScopes", () => {
     ]);
   });
 
-  it.each([...NODE_SYSTEM_RUN_COMMANDS, ...ADMIN_ONLY_INVOKE_COMMANDS])(
-    "requires operator.admin for %s commands",
-    (command) => {
-      expect(resolveNodePairApprovalScopes([command])).toEqual([
-        "operator.pairing",
-        "operator.admin",
-      ]);
-    },
-  );
+  it.each(ADMIN_ONLY_INVOKE_COMMANDS)("requires operator.admin for %s commands", (command) => {
+    expect(resolveNodePairApprovalScopes([command])).toEqual([
+      "operator.pairing",
+      "operator.admin",
+    ]);
+  });
 
   it.each(ADMIN_ONLY_INVOKE_COMMANDS)("classifies %s as admin-only at invocation", (command) => {
     expect(isAdminOnlyNodeInvokeCommand(command)).toBe(true);

--- a/src/infra/node-pairing-authz.ts
+++ b/src/infra/node-pairing-authz.ts
@@ -1,9 +1,5 @@
 // Maps node pairing command declarations to required operator scopes.
-import {
-  NODE_EXEC_APPROVALS_COMMANDS,
-  NODE_SYSTEM_RUN_COMMANDS,
-  isAdminOnlyNodeInvokeCommand,
-} from "./node-commands.js";
+import { NODE_EXEC_APPROVALS_COMMANDS, isAdminOnlyNodeInvokeCommand } from "./node-commands.js";
 
 /** Operator scopes required to approve a pending node pairing surface. */
 export type NodeApprovalScope = "operator.pairing" | "operator.write" | "operator.admin";
@@ -15,7 +11,6 @@ const OPERATOR_ADMIN_SCOPE: NodeApprovalScope = "operator.admin";
 function isAdminPairApprovalCommand(command: string): boolean {
   return (
     isAdminOnlyNodeInvokeCommand(command) ||
-    NODE_SYSTEM_RUN_COMMANDS.some((allowed) => allowed === command) ||
     NODE_EXEC_APPROVALS_COMMANDS.some((allowed) => allowed === command)
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a write-scoped Gateway operator could invoke remote command-execution commands on an already-paired node without administrative scope.

## Why This Change Was Made

The shared node-command classifier now treats the complete `system.run` command family as admin-only. Both the Gateway authorization resolver and the pre-forwarding handler consume that classifier, node-pair approval continues to enforce the same boundary without a separate command-family special case, and approved agent node-exec dispatches request the matching admin scope.

## User Impact

Operators using `operator.write` alone can still invoke ordinary node relay commands, but `system.run`, `system.run.prepare`, and `system.which` now require `operator.admin`. Existing admin-scoped Gateway, CLI, and agent paths continue to work.

## Evidence

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-host-node.cancellation.test.ts src/gateway/method-scopes.test.ts src/gateway/server.node-invoke-approval-bypass.test.ts src/infra/node-pairing-authz.test.ts` — 258 tests passed across agent, unit, and real Gateway forwarding coverage.
- Targeted formatting and lint checks passed for all changed source and documentation files.
- Gateway coverage proves write-scoped calls are rejected before the paired node receives them, while admin-scoped execution and approval flows remain functional.

AI-assisted: yes.
