### PR TITLE
fix(gateway): keep session lists responsive with retained subagent history

### DIFF
--- a/src/agents/subagent-delivery-state.ts
+++ b/src/agents/subagent-delivery-state.ts
@@ -84,7 +84,7 @@ export function clearDeliveryState(entry: SubagentRunRecord): void {
 }
 
 /** Returns true when delivery is suspended with a durable timestamp. */
-export function isDeliverySuspended(entry: SubagentRunRecord): boolean {
+export function isDeliverySuspended(entry: Pick<SubagentRunRecord, "delivery">): boolean {
   return entry.delivery?.status === "suspended" && typeof entry.delivery.suspendedAt === "number";
 }
 

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -5,11 +5,13 @@
  */
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { isDeliverySuspended } from "./subagent-delivery-state.js";
-import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import type { SubagentRunReadRecord, SubagentRunRecord } from "./subagent-registry.types.js";
 import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
 import { hasSubagentRunEnded, isLiveUnendedSubagentRun } from "./subagent-run-liveness.js";
 
-function resolveControllerSessionKey(entry: SubagentRunRecord): string {
+function resolveControllerSessionKey(
+  entry: Pick<SubagentRunRecord, "controllerSessionKey" | "requesterSessionKey">,
+): string {
   return entry.controllerSessionKey?.trim() || entry.requesterSessionKey;
 }
 
@@ -74,31 +76,31 @@ export function listRunsForControllerFromRuns(
   return results;
 }
 
-type LatestRunPair = {
+type LatestRunPair<T extends SubagentRunReadRecord = SubagentRunRecord> = {
   runId: string;
-  entry: SubagentRunRecord;
+  entry: T;
 };
 
 /** Cached read index for display, controller grouping, and descendant queries. */
-export type SubagentRunReadIndex = {
-  getDisplaySubagentRun(childSessionKey: string): SubagentRunRecord | null;
-  latestRunsByChildSessionKey: ReadonlyMap<string, SubagentRunRecord>;
+export type SubagentRunReadIndex<T extends SubagentRunReadRecord = SubagentRunRecord> = {
+  getDisplaySubagentRun(childSessionKey: string): T | null;
+  latestRunsByChildSessionKey: ReadonlyMap<string, T>;
   countActiveDescendantRuns(rootSessionKey: string): number;
   countPendingDescendantRuns(rootSessionKey: string): number;
   countPendingDescendantRunsExcludingRun(rootSessionKey: string, excludeRunId: string): number;
   hasDescendantRunAwaitingSettle(rootSessionKey: string, excludeRunId?: string): boolean;
-  listDescendantRunsForRequester(rootSessionKey: string): SubagentRunRecord[];
-  runsByControllerSessionKey: ReadonlyMap<string, readonly SubagentRunRecord[]>;
+  listDescendantRunsForRequester(rootSessionKey: string): T[];
+  runsByControllerSessionKey: ReadonlyMap<string, readonly T[]>;
 };
 
 export type LatestSubagentRunReadIndex = {
   getLatestSubagentRun(childSessionKey: string): SubagentRunRecord | null;
 };
 
-function rememberLatestRunEntry(
-  map: Map<string, SubagentRunRecord>,
+function rememberLatestRunEntry<T extends SubagentRunReadRecord>(
+  map: Map<string, T>,
   key: string,
-  entry: SubagentRunRecord,
+  entry: T,
 ): void {
   const existing = map.get(key);
   if (!existing || compareSubagentRunGeneration(entry, existing) > 0) {
@@ -124,11 +126,11 @@ export function buildLatestSubagentRunReadIndexFromRuns(
   };
 }
 
-function rememberLatestRunPair(
-  map: Map<string, LatestRunPair>,
+function rememberLatestRunPair<T extends SubagentRunReadRecord>(
+  map: Map<string, LatestRunPair<T>>,
   key: string,
   runId: string,
-  entry: SubagentRunRecord,
+  entry: T,
 ): void {
   const existing = map.get(key);
   if (!existing || compareSubagentRunGeneration(entry, existing.entry) > 0) {
@@ -137,19 +139,19 @@ function rememberLatestRunPair(
 }
 
 /** Builds a read index from snapshot and optional in-memory runs. */
-export function buildSubagentRunReadIndexFromRuns(params: {
-  runs: Map<string, SubagentRunRecord>;
-  inMemoryRuns?: Iterable<SubagentRunRecord>;
+export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecord>(params: {
+  runs: Map<string, T>;
+  inMemoryRuns?: Iterable<T>;
   now?: number;
-}): SubagentRunReadIndex {
+}): SubagentRunReadIndex<T> {
   const { runs } = params;
   const now = params.now ?? Date.now();
-  const inMemoryDisplayByChildSessionKey = new Map<string, SubagentRunRecord>();
-  const latestSnapshotActiveByChildSessionKey = new Map<string, SubagentRunRecord>();
-  const latestSnapshotEndedByChildSessionKey = new Map<string, SubagentRunRecord>();
-  const latestRunByChildSessionKey = new Map<string, LatestRunPair>();
-  const runsByControllerSessionKey = new Map<string, SubagentRunRecord[]>();
-  const latestRunByRequesterAndChildSessionKey = new Map<string, Map<string, LatestRunPair>>();
+  const inMemoryDisplayByChildSessionKey = new Map<string, T>();
+  const latestSnapshotActiveByChildSessionKey = new Map<string, T>();
+  const latestSnapshotEndedByChildSessionKey = new Map<string, T>();
+  const latestRunByChildSessionKey = new Map<string, LatestRunPair<T>>();
+  const runsByControllerSessionKey = new Map<string, T[]>();
+  const latestRunByRequesterAndChildSessionKey = new Map<string, Map<string, LatestRunPair<T>>>();
   const activeDescendantCountBySessionKey = new Map<string, number>();
   const pendingDescendantCountBySessionKey = new Map<string, number>();
 
@@ -188,18 +190,18 @@ export function buildSubagentRunReadIndexFromRuns(params: {
     }
     let latestByChild = latestRunByRequesterAndChildSessionKey.get(requesterSessionKey);
     if (!latestByChild) {
-      latestByChild = new Map<string, LatestRunPair>();
+      latestByChild = new Map<string, LatestRunPair<T>>();
       latestRunByRequesterAndChildSessionKey.set(requesterSessionKey, latestByChild);
     }
     rememberLatestRunPair(latestByChild, childSessionKey, runId, entry);
   }
 
-  const latestRunsByChildSessionKey = new Map<string, SubagentRunRecord>();
+  const latestRunsByChildSessionKey = new Map<string, T>();
   for (const [childSessionKey, pair] of latestRunByChildSessionKey) {
     latestRunsByChildSessionKey.set(childSessionKey, pair.entry);
   }
 
-  const getDisplaySubagentRun = (childSessionKey: string): SubagentRunRecord | null => {
+  const getDisplaySubagentRun = (childSessionKey: string): T | null => {
     const key = childSessionKey.trim();
     if (!key) {
       return null;
@@ -214,7 +216,7 @@ export function buildSubagentRunReadIndexFromRuns(params: {
 
   const forEachDescendantRun = (
     rootSessionKey: string,
-    visitor: (runId: string, entry: SubagentRunRecord) => void | boolean,
+    visitor: (runId: string, entry: T) => void | boolean,
   ): void => {
     const root = rootSessionKey.trim();
     if (!root) {
@@ -327,8 +329,8 @@ export function buildSubagentRunReadIndexFromRuns(params: {
       stopAtFirst: true,
     }) > 0;
 
-  const listDescendantRunsForRequester = (rootSessionKey: string): SubagentRunRecord[] => {
-    const descendants: SubagentRunRecord[] = [];
+  const listDescendantRunsForRequester = (rootSessionKey: string): T[] => {
+    const descendants: T[] = [];
     forEachDescendantRun(rootSessionKey, (_runId, entry) => {
       descendants.push(entry);
     });

--- a/src/agents/subagent-registry-read.ts
+++ b/src/agents/subagent-registry-read.ts
@@ -17,11 +17,12 @@ import {
   type SubagentRunReadIndex,
 } from "./subagent-registry-queries.js";
 import {
+  getSubagentSessionListRunsSnapshotForRead,
   getSubagentRunsSnapshotForChildSession,
   getSubagentRunsSnapshotForController,
   getSubagentRunsSnapshotForRead,
 } from "./subagent-registry-state.js";
-import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import type { SubagentRunReadRecord, SubagentRunRecord } from "./subagent-registry.types.js";
 import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
 
 export {
@@ -30,10 +31,12 @@ export {
   resolveSubagentSessionStatus,
 } from "./subagent-session-metrics.js";
 
-/** Builds a reusable read index from the current persisted and in-memory run state. */
-export function buildSubagentRunReadIndex(now = Date.now()): SubagentRunReadIndex {
+/** Builds the session-list index without hydrating full retained registry payloads. */
+export function buildSubagentSessionListReadIndex(
+  now = Date.now(),
+): SubagentRunReadIndex<SubagentRunReadRecord> {
   return buildSubagentRunReadIndexFromRuns({
-    runs: getSubagentRunsSnapshotForRead(subagentRuns),
+    runs: getSubagentSessionListRunsSnapshotForRead(subagentRuns),
     inMemoryRuns: subagentRuns.values(),
     now,
   });

--- a/src/agents/subagent-registry-state.test.ts
+++ b/src/agents/subagent-registry-state.test.ts
@@ -2,13 +2,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearSubagentRunsReadCacheForTest,
+  getSubagentSessionListRunsSnapshotForRead,
   getSubagentRunsSnapshotForChildSession,
   getSubagentRunsSnapshotForController,
   getSubagentRunsSnapshotForRead,
   onSubagentRegistryPersisted,
   persistSubagentRunsToDisk,
 } from "./subagent-registry-state.js";
-import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import type { SubagentRunReadRecord, SubagentRunRecord } from "./subagent-registry.types.js";
 
 const mocks = vi.hoisted(() => ({
   loadSubagentRunsForChildSessionFromSqlite:
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   loadSubagentRunsForControllerFromSqlite:
     vi.fn<(controllerSessionKey: string) => SubagentRunRecord[]>(),
   loadSubagentRegistryFromSqlite: vi.fn<() => Map<string, SubagentRunRecord>>(),
+  loadSubagentSessionListRunsFromSqlite: vi.fn<() => Map<string, SubagentRunReadRecord>>(),
   saveSubagentRegistryChangesToSqlite:
     vi.fn<(runs: Map<string, SubagentRunRecord>, changedRunIds: readonly string[]) => void>(),
   saveSubagentRegistryToSqlite: vi.fn<(runs: Map<string, SubagentRunRecord>) => void>(),
@@ -25,6 +27,7 @@ vi.mock("./subagent-registry.store.sqlite.js", () => ({
   loadSubagentRunsForChildSessionFromSqlite: mocks.loadSubagentRunsForChildSessionFromSqlite,
   loadSubagentRunsForControllerFromSqlite: mocks.loadSubagentRunsForControllerFromSqlite,
   loadSubagentRegistryFromSqlite: mocks.loadSubagentRegistryFromSqlite,
+  loadSubagentSessionListRunsFromSqlite: mocks.loadSubagentSessionListRunsFromSqlite,
   saveSubagentRegistryChangesToSqlite: mocks.saveSubagentRegistryChangesToSqlite,
   saveSubagentRegistryToSqlite: mocks.saveSubagentRegistryToSqlite,
 }));
@@ -53,6 +56,7 @@ describe("subagent registry state read cache", () => {
     mocks.loadSubagentRunsForChildSessionFromSqlite.mockReset();
     mocks.loadSubagentRunsForControllerFromSqlite.mockReset();
     mocks.loadSubagentRegistryFromSqlite.mockReset();
+    mocks.loadSubagentSessionListRunsFromSqlite.mockReset();
     mocks.saveSubagentRegistryChangesToSqlite.mockReset();
     mocks.saveSubagentRegistryToSqlite.mockReset();
   });
@@ -96,6 +100,70 @@ describe("subagent registry state read cache", () => {
     expect([...getSubagentRunsSnapshotForRead(new Map()).keys()]).toEqual(["run-saved"]);
     expect(mocks.saveSubagentRegistryToSqlite).toHaveBeenCalledOnce();
     expect(mocks.loadSubagentRegistryFromSqlite).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the projected sqlite snapshot for session-list reads", () => {
+    const firstRun = createRun("run-first");
+    firstRun.model = "openai/gpt-5.6";
+    const secondRun = createRun("run-second");
+    mocks.loadSubagentSessionListRunsFromSqlite
+      .mockReturnValueOnce(new Map([[firstRun.runId, firstRun]]))
+      .mockReturnValueOnce(new Map([[secondRun.runId, secondRun]]));
+
+    expect([...getSubagentSessionListRunsSnapshotForRead(new Map()).keys()]).toEqual(["run-first"]);
+    expect([...getSubagentSessionListRunsSnapshotForRead(new Map()).keys()]).toEqual(["run-first"]);
+    expect(mocks.loadSubagentSessionListRunsFromSqlite).toHaveBeenCalledTimes(1);
+    expect(mocks.loadSubagentRegistryFromSqlite).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+
+    expect([...getSubagentSessionListRunsSnapshotForRead(new Map()).keys()]).toEqual([
+      "run-second",
+    ]);
+    expect(mocks.loadSubagentSessionListRunsFromSqlite).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes session-list projections from authoritative writes", () => {
+    const savedRun = createRun("run-saved");
+    savedRun.model = "openai/gpt-5.6";
+    savedRun.outcome = { status: "ok", error: "not projected" };
+    mocks.saveSubagentRegistryToSqlite.mockImplementationOnce(() => {
+      throw new Error("disk unavailable");
+    });
+
+    persistSubagentRunsToDisk(new Map([[savedRun.runId, savedRun]]));
+
+    const projected = getSubagentSessionListRunsSnapshotForRead(new Map()).get(savedRun.runId);
+    expect(projected).toMatchObject({
+      runId: savedRun.runId,
+      model: savedRun.model,
+      outcome: { status: "ok" },
+    });
+    expect(projected?.outcome).not.toHaveProperty("error");
+    expect(mocks.loadSubagentSessionListRunsFromSqlite).not.toHaveBeenCalled();
+  });
+
+  it("preserves unrelated projected rows across incremental writes", () => {
+    const retained = createRun("retained");
+    const changed = createRun("changed");
+    mocks.loadSubagentSessionListRunsFromSqlite.mockReturnValue(
+      new Map([
+        [retained.runId, retained],
+        [changed.runId, changed],
+      ]),
+    );
+    expect([...getSubagentSessionListRunsSnapshotForRead(new Map()).keys()]).toEqual([
+      "retained",
+      "changed",
+    ]);
+
+    changed.model = "openai/gpt-5.6";
+    persistSubagentRunsToDisk(new Map([[changed.runId, changed]]), [changed.runId]);
+
+    const projected = getSubagentSessionListRunsSnapshotForRead(new Map());
+    expect([...projected.keys()]).toEqual(["retained", "changed"]);
+    expect(projected.get(changed.runId)?.model).toBe("openai/gpt-5.6");
+    expect(mocks.loadSubagentSessionListRunsFromSqlite).toHaveBeenCalledOnce();
   });
 
   it("updates only named runs in the local read cache", () => {

--- a/src/agents/subagent-registry-state.ts
+++ b/src/agents/subagent-registry-state.ts
@@ -8,10 +8,11 @@ import {
   loadSubagentRunsForChildSessionFromSqlite,
   loadSubagentRunsForControllerFromSqlite,
   loadSubagentRegistryFromSqlite,
+  loadSubagentSessionListRunsFromSqlite,
   saveSubagentRegistryChangesToSqlite,
   saveSubagentRegistryToSqlite,
 } from "./subagent-registry.store.sqlite.js";
-import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import type { SubagentRunReadRecord, SubagentRunRecord } from "./subagent-registry.types.js";
 
 const SUBAGENT_RUNS_READ_CACHE_TTL_MS = 500;
 
@@ -19,6 +20,13 @@ let persistedSubagentRunsReadCache:
   | {
       loadedAtMs: number;
       runs: Map<string, SubagentRunRecord>;
+    }
+  | undefined;
+
+let persistedSubagentSessionListRunsReadCache:
+  | {
+      loadedAtMs: number;
+      runs: Map<string, SubagentRunReadRecord>;
     }
   | undefined;
 
@@ -50,10 +58,59 @@ function cloneSubagentRunsSnapshot(
   return new Map([...runs.entries()].map(([runId, entry]) => [runId, structuredClone(entry)]));
 }
 
+function projectSubagentRunForSessionList(entry: SubagentRunRecord): SubagentRunReadRecord {
+  return {
+    runId: entry.runId,
+    childSessionKey: entry.childSessionKey,
+    ...(entry.controllerSessionKey ? { controllerSessionKey: entry.controllerSessionKey } : {}),
+    requesterSessionKey: entry.requesterSessionKey,
+    ...(entry.model ? { model: entry.model } : {}),
+    ...(entry.generation !== undefined ? { generation: entry.generation } : {}),
+    createdAt: entry.createdAt,
+    ...(entry.startedAt !== undefined ? { startedAt: entry.startedAt } : {}),
+    ...(entry.sessionStartedAt !== undefined ? { sessionStartedAt: entry.sessionStartedAt } : {}),
+    ...(entry.accumulatedRuntimeMs !== undefined
+      ? { accumulatedRuntimeMs: entry.accumulatedRuntimeMs }
+      : {}),
+    ...(entry.endedAt !== undefined ? { endedAt: entry.endedAt } : {}),
+    ...(entry.runTimeoutSeconds !== undefined
+      ? { runTimeoutSeconds: entry.runTimeoutSeconds }
+      : {}),
+    ...(entry.endedReason ? { endedReason: entry.endedReason } : {}),
+    ...(entry.outcome ? { outcome: { status: entry.outcome.status } } : {}),
+    ...(entry.cleanupCompletedAt !== undefined
+      ? { cleanupCompletedAt: entry.cleanupCompletedAt }
+      : {}),
+    ...(entry.delivery
+      ? {
+          delivery: {
+            status: entry.delivery.status,
+            ...(entry.delivery.suspendedAt !== undefined
+              ? { suspendedAt: entry.delivery.suspendedAt }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function projectSubagentRunsForSessionList(
+  runs: Map<string, SubagentRunRecord>,
+): Map<string, SubagentRunReadRecord> {
+  return new Map(
+    [...runs.entries()].map(([runId, entry]) => [runId, projectSubagentRunForSessionList(entry)]),
+  );
+}
+
 function rememberPersistedSubagentRunsSnapshot(runs: Map<string, SubagentRunRecord>): void {
+  const loadedAtMs = Date.now();
   persistedSubagentRunsReadCache = {
-    loadedAtMs: Date.now(),
+    loadedAtMs,
     runs: cloneSubagentRunsSnapshot(runs),
+  };
+  persistedSubagentSessionListRunsReadCache = {
+    loadedAtMs,
+    runs: projectSubagentRunsForSessionList(runs),
   };
 }
 
@@ -61,19 +118,43 @@ function rememberPersistedSubagentRunChanges(
   runs: Map<string, SubagentRunRecord>,
   changedRunIds: readonly string[],
 ): void {
+  const loadedAtMs = Date.now();
   if (!persistedSubagentRunsReadCache) {
-    rememberPersistedSubagentRunsSnapshot(runs);
+    persistedSubagentRunsReadCache = {
+      loadedAtMs,
+      runs: cloneSubagentRunsSnapshot(runs),
+    };
+  } else {
+    for (const runId of new Set(changedRunIds)) {
+      const entry = runs.get(runId);
+      if (entry) {
+        persistedSubagentRunsReadCache.runs.set(runId, structuredClone(entry));
+      } else {
+        persistedSubagentRunsReadCache.runs.delete(runId);
+      }
+    }
+    persistedSubagentRunsReadCache.loadedAtMs = loadedAtMs;
+  }
+
+  if (!persistedSubagentSessionListRunsReadCache) {
+    persistedSubagentSessionListRunsReadCache = {
+      loadedAtMs,
+      runs: projectSubagentRunsForSessionList(runs),
+    };
     return;
   }
   for (const runId of new Set(changedRunIds)) {
     const entry = runs.get(runId);
     if (entry) {
-      persistedSubagentRunsReadCache.runs.set(runId, structuredClone(entry));
+      persistedSubagentSessionListRunsReadCache.runs.set(
+        runId,
+        projectSubagentRunForSessionList(entry),
+      );
     } else {
-      persistedSubagentRunsReadCache.runs.delete(runId);
+      persistedSubagentSessionListRunsReadCache.runs.delete(runId);
     }
   }
-  persistedSubagentRunsReadCache.loadedAtMs = Date.now();
+  persistedSubagentSessionListRunsReadCache.loadedAtMs = loadedAtMs;
 }
 
 function shouldReadPersistedSubagentRuns(): boolean {
@@ -99,7 +180,23 @@ function loadPersistedSubagentRunsForRead(): Map<string, SubagentRunRecord> {
   }
 
   const runs = loadSubagentRegistryFromSqlite();
-  persistedSubagentRunsReadCache = {
+  rememberPersistedSubagentRunsSnapshot(runs);
+  return persistedSubagentRunsReadCache?.runs ?? runs;
+}
+
+function loadPersistedSubagentSessionListRunsForRead(): Map<string, SubagentRunReadRecord> {
+  const nowMs = Date.now();
+  const cached = persistedSubagentSessionListRunsReadCache;
+  if (
+    cached &&
+    nowMs >= cached.loadedAtMs &&
+    nowMs - cached.loadedAtMs < SUBAGENT_RUNS_READ_CACHE_TTL_MS
+  ) {
+    return cached.runs;
+  }
+
+  const runs = loadSubagentSessionListRunsFromSqlite();
+  persistedSubagentSessionListRunsReadCache = {
     loadedAtMs: nowMs,
     runs,
   };
@@ -126,6 +223,7 @@ function resolvesToControllerSessionKey(
 
 export function clearSubagentRunsReadCacheForTest(): void {
   persistedSubagentRunsReadCache = undefined;
+  persistedSubagentSessionListRunsReadCache = undefined;
 }
 
 export function persistSubagentRunsToDisk(
@@ -207,6 +305,25 @@ export function getSubagentRunsSnapshotForRead(
   }
   for (const [runId, entry] of inMemoryRuns.entries()) {
     merged.set(runId, entry);
+  }
+  return merged;
+}
+
+export function getSubagentSessionListRunsSnapshotForRead(
+  inMemoryRuns: Map<string, SubagentRunRecord>,
+): Map<string, SubagentRunReadRecord> {
+  const merged = new Map<string, SubagentRunReadRecord>();
+  if (shouldReadPersistedSubagentRuns()) {
+    try {
+      for (const [runId, entry] of loadPersistedSubagentSessionListRunsForRead()) {
+        merged.set(runId, entry);
+      }
+    } catch {
+      // Ignore disk read failures and fall back to local memory.
+    }
+  }
+  for (const [runId, entry] of inMemoryRuns) {
+    merged.set(runId, projectSubagentRunForSessionList(entry));
   }
   return merged;
 }

--- a/src/agents/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagent-registry.store.sqlite.test.ts
@@ -14,6 +14,7 @@ import {
   loadSubagentRunsForChildSessionFromSqlite,
   loadSubagentRunsForControllerFromSqlite,
   loadSubagentRegistryFromSqlite,
+  loadSubagentSessionListRunsFromSqlite,
   saveSubagentRegistryChangesToSqlite,
   saveSubagentRegistryToSqlite,
 } from "./subagent-registry.store.sqlite.js";
@@ -150,6 +151,46 @@ describe("subagent registry sqlite store", () => {
       saveSubagentRegistryToSqlite(new Map([[second.runId, second]]));
 
       expect([...loadSubagentRegistryFromSqlite().keys()]).toEqual(["run-two"]);
+    });
+  });
+
+  it("loads a canonical lightweight session-list projection", async () => {
+    await withTempStateEnv(async () => {
+      const run = createRun({
+        model: "openai/gpt-5.6",
+        generation: 3,
+        sessionStartedAt: 105,
+        accumulatedRuntimeMs: 90,
+        runTimeoutSeconds: 7_200,
+        endedReason: "subagent-error",
+        cleanupCompletedAt: 300,
+        outcome: { status: "error", error: "full payload detail" },
+        delivery: {
+          status: "suspended",
+          suspendedAt: 275,
+          suspendedReason: "retry-limit",
+        },
+        task: "x".repeat(8_192),
+      });
+      saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+
+      expect(loadSubagentSessionListRunsFromSqlite().get(run.runId)).toEqual({
+        runId: run.runId,
+        childSessionKey: run.childSessionKey,
+        requesterSessionKey: run.requesterSessionKey,
+        model: "openai/gpt-5.6",
+        generation: 3,
+        createdAt: 100,
+        startedAt: 110,
+        sessionStartedAt: 105,
+        accumulatedRuntimeMs: 90,
+        endedAt: 250,
+        runTimeoutSeconds: 7_200,
+        endedReason: "subagent-error",
+        outcome: { status: "error" },
+        cleanupCompletedAt: 300,
+        delivery: { status: "suspended", suspendedAt: 275 },
+      });
     });
   });
 
@@ -315,6 +356,7 @@ describe("subagent registry sqlite store", () => {
       );
 
       expect(loadSubagentRegistryFromSqlite()).toEqual(new Map());
+      expect(loadSubagentSessionListRunsFromSqlite()).toEqual(new Map());
 
       saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
       db.prepare("UPDATE subagent_runs SET payload_json = ? WHERE run_id = ?").run(
@@ -322,6 +364,7 @@ describe("subagent registry sqlite store", () => {
         run.runId,
       );
       expect(loadSubagentRegistryFromSqlite()).toEqual(new Map());
+      expect(loadSubagentSessionListRunsFromSqlite()).toEqual(new Map());
     });
   });
 

--- a/src/agents/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagent-registry.store.sqlite.ts
@@ -4,7 +4,7 @@
  * normalized payload JSON for forward-compatible record hydration.
  */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { Insertable, Selectable, Updateable } from "kysely";
+import { sql, type Insertable, type Selectable, type Updateable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -19,6 +19,7 @@ import type {
   SubagentCompletionDeliveryState,
   SubagentCompletionState,
   SubagentExecutionState,
+  SubagentRunReadRecord,
   SubagentRunRecord,
 } from "./subagent-registry.types.js";
 
@@ -27,6 +28,27 @@ type SubagentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "subagent_runs
 type SubagentRunSqliteRow = Selectable<SubagentRunsTable>;
 type SubagentRunSqliteInsert = Insertable<SubagentRunsTable>;
 type SubagentRunSqliteUpdate = Updateable<SubagentRunsTable>;
+type SubagentRunReadSqliteRow = Pick<
+  SubagentRunSqliteRow,
+  | "run_id"
+  | "child_session_key"
+  | "controller_session_key"
+  | "requester_session_key"
+  | "model"
+  | "run_timeout_seconds"
+  | "created_at"
+  | "started_at"
+  | "session_started_at"
+  | "accumulated_runtime_ms"
+  | "ended_at"
+  | "ended_reason"
+  | "cleanup_completed_at"
+> & {
+  generation: number | null;
+  outcome_status: string | null;
+  delivery_status: string | null;
+  delivery_suspended_at: number | null;
+};
 type CanonicalSubagentRunRecord = SubagentRunRecord &
   Required<Pick<SubagentRunRecord, "execution" | "completion" | "delivery">>;
 const EXECUTION_STATUSES = new Set("queued running interrupted terminal".split(" "));
@@ -432,6 +454,145 @@ function readSubagentRegistryRows(): SubagentRunSqliteRow[] {
   ).rows;
 }
 
+function subagentPayloadJsonValue<T>(path: string) {
+  return /* kysely-allow-raw: SQLite JSON1 projects bounded fields from the canonical payload column. */ sql<T>`json_extract(payload_json, ${path})`;
+}
+
+function subagentOutcomeStatusJsonValue() {
+  return /* kysely-allow-raw: outcome_json is authoritative when valid; canonical payload is the fallback. */ sql<
+    string | null
+  >`COALESCE(
+    CASE
+      WHEN json_valid(outcome_json)
+      THEN json_extract(outcome_json, '$.status')
+    END,
+    json_extract(payload_json, '$.outcome.status')
+  )`;
+}
+
+function canonicalSubagentPayloadFilter() {
+  return /* kysely-allow-raw: Keep projection eligibility identical to the full canonical payload parser. */ sql<boolean>`json_valid(payload_json)
+    AND json_type(payload_json, '$.execution') = 'object'
+    AND json_extract(payload_json, '$.execution.status')
+      IN ('queued', 'running', 'interrupted', 'terminal')
+    AND json_type(payload_json, '$.completion') = 'object'
+    AND json_type(payload_json, '$.completion.required') IN ('true', 'false')
+    AND json_type(payload_json, '$.delivery') = 'object'
+    AND json_extract(payload_json, '$.delivery.status')
+      IN (
+        'not_required',
+        'pending',
+        'in_progress',
+        'delivered',
+        'failed',
+        'suspended',
+        'discarded'
+      )
+    AND json_type(payload_json, '$.delivery.handoffLeaseId') IS NULL
+    AND json_type(payload_json, '$.delivery.handoffLeasedAt') IS NULL
+    AND json_type(payload_json, '$.delivery.handoffInjectedAt') IS NULL`;
+}
+
+function readSubagentSessionListRows(): SubagentRunReadSqliteRow[] {
+  const { db } = openOpenClawStateDatabase();
+  const stateDb = getNodeSqliteKysely<SubagentRegistryDatabase>(db);
+  return executeSqliteQuerySync(
+    db,
+    stateDb
+      .selectFrom("subagent_runs")
+      .select([
+        "run_id",
+        "child_session_key",
+        "controller_session_key",
+        "requester_session_key",
+        "model",
+        "run_timeout_seconds",
+        "created_at",
+        "started_at",
+        "session_started_at",
+        "accumulated_runtime_ms",
+        "ended_at",
+        "ended_reason",
+        "cleanup_completed_at",
+        subagentPayloadJsonValue<number | null>("$.generation").as("generation"),
+        subagentOutcomeStatusJsonValue().as("outcome_status"),
+        subagentPayloadJsonValue<string | null>("$.delivery.status").as("delivery_status"),
+        subagentPayloadJsonValue<number | null>("$.delivery.suspendedAt").as(
+          "delivery_suspended_at",
+        ),
+      ])
+      // Keep the projection aligned with the canonical full-registry row filter
+      // without transferring and parsing the retained payload in JavaScript.
+      .where(canonicalSubagentPayloadFilter())
+      .orderBy("created_at", "asc")
+      .orderBy("run_id", "asc"),
+  ).rows as SubagentRunReadSqliteRow[];
+}
+
+function rowToSubagentRunReadRecord(row: SubagentRunReadSqliteRow): SubagentRunReadRecord | null {
+  const runId = row.run_id.trim();
+  const childSessionKey = row.child_session_key.trim();
+  const requesterSessionKey = row.requester_session_key.trim();
+  if (!runId || !childSessionKey || !requesterSessionKey) {
+    return null;
+  }
+  const outcomeStatus =
+    row.outcome_status === "ok" ||
+    row.outcome_status === "error" ||
+    row.outcome_status === "timeout" ||
+    row.outcome_status === "unknown"
+      ? row.outcome_status
+      : undefined;
+  const deliveryStatus = DELIVERY_STATUSES.has(row.delivery_status ?? "")
+    ? (row.delivery_status as NonNullable<SubagentRunRecord["delivery"]>["status"])
+    : undefined;
+  return {
+    runId,
+    childSessionKey,
+    ...(row.controller_session_key?.trim()
+      ? { controllerSessionKey: row.controller_session_key.trim() }
+      : {}),
+    requesterSessionKey,
+    ...(row.model ? { model: row.model } : {}),
+    ...(normalizeFiniteNumber(row.generation) !== undefined
+      ? { generation: row.generation ?? undefined }
+      : {}),
+    createdAt: row.created_at,
+    ...(normalizeFiniteNumber(row.started_at) !== undefined
+      ? { startedAt: row.started_at ?? undefined }
+      : {}),
+    ...(normalizeFiniteNumber(row.session_started_at) !== undefined
+      ? { sessionStartedAt: row.session_started_at ?? undefined }
+      : {}),
+    ...(normalizeFiniteNumber(row.accumulated_runtime_ms) !== undefined
+      ? { accumulatedRuntimeMs: row.accumulated_runtime_ms ?? undefined }
+      : {}),
+    ...(normalizeFiniteNumber(row.ended_at) !== undefined
+      ? { endedAt: row.ended_at ?? undefined }
+      : {}),
+    ...(normalizeFiniteNumber(row.run_timeout_seconds) !== undefined
+      ? { runTimeoutSeconds: row.run_timeout_seconds ?? undefined }
+      : {}),
+    ...(row.ended_reason
+      ? { endedReason: row.ended_reason as SubagentRunRecord["endedReason"] }
+      : {}),
+    ...(outcomeStatus ? { outcome: { status: outcomeStatus } } : {}),
+    ...(normalizeFiniteNumber(row.cleanup_completed_at) !== undefined
+      ? { cleanupCompletedAt: row.cleanup_completed_at ?? undefined }
+      : {}),
+    ...(deliveryStatus
+      ? {
+          delivery: {
+            status: deliveryStatus,
+            ...(normalizeFiniteNumber(row.delivery_suspended_at) !== undefined
+              ? { suspendedAt: row.delivery_suspended_at ?? undefined }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}
+
 /** Loads runs controlled by one session, preserving the legacy requester fallback. */
 export function loadSubagentRunsForControllerFromSqlite(
   controllerSessionKey: string,
@@ -501,6 +662,18 @@ export function loadSubagentRegistryFromSqlite(): Map<string, SubagentRunRecord>
   const runs = new Map<string, SubagentRunRecord>();
   for (const row of readSubagentRegistryRows()) {
     const entry = rowToSubagentRunRecord(row);
+    if (entry) {
+      runs.set(entry.runId, entry);
+    }
+  }
+  return runs;
+}
+
+/** Loads only the canonical fields needed to build session-list topology metadata. */
+export function loadSubagentSessionListRunsFromSqlite(): Map<string, SubagentRunReadRecord> {
+  const runs = new Map<string, SubagentRunReadRecord>();
+  for (const row of readSubagentSessionListRows()) {
+    const entry = rowToSubagentRunReadRecord(row);
     if (entry) {
       runs.set(entry.runId, entry);
     }

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -262,3 +262,24 @@ export type SubagentRunRecord = {
   contextEngineCleanupCompletedAt?: number;
   collectorCompletion?: SwarmCollectorCompletion;
 };
+
+/** Minimal registry shape needed by session-list topology and display reads. */
+export type SubagentRunReadRecord = Pick<
+  SubagentRunRecord,
+  | "runId"
+  | "childSessionKey"
+  | "controllerSessionKey"
+  | "requesterSessionKey"
+  | "model"
+  | "generation"
+  | "createdAt"
+  | "startedAt"
+  | "sessionStartedAt"
+  | "accumulatedRuntimeMs"
+  | "endedAt"
+  | "runTimeoutSeconds"
+  | "endedReason"
+  | "outcome"
+  | "cleanupCompletedAt"
+  | "delivery"
+>;

--- a/src/gateway/session-utils-contracts.ts
+++ b/src/gateway/session-utils-contracts.ts
@@ -3,7 +3,8 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { resolveSessionModelRef } from "../agents/session-model-ref.js";
-import type { buildSubagentRunReadIndex } from "../agents/subagent-registry-read.js";
+import type { SubagentRunReadIndex } from "../agents/subagent-registry-queries.js";
+import type { SubagentRunReadRecord } from "../agents/subagent-registry.types.js";
 import type { ThinkLevel, listThinkingLevelOptions } from "../auto-reply/thinking.js";
 import type { SessionAcpMeta, SessionEntry } from "../config/sessions.js";
 import type { ModelCostConfig } from "../utils/usage-format.js";
@@ -14,7 +15,7 @@ export type SessionActorProfileIdentity = {
 };
 
 export type SessionListRowContext = {
-  subagentRuns: ReturnType<typeof buildSubagentRunReadIndex>;
+  subagentRuns: SubagentRunReadIndex<SubagentRunReadRecord>;
   storeChildSessionsByKey: Map<string, string[]>;
   selectedModelByOverrideRef: Map<string, ReturnType<typeof resolveSessionModelRef>>;
   thinkingMetadataByModelRef: Map<

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -3,7 +3,7 @@ import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveContextTokensForModel } from "../agents/context.js";
 import { normalizeStoredOverrideModel } from "../agents/model-selection.js";
 import { resolveSessionModelRef } from "../agents/session-model-ref.js";
-import { buildSubagentRunReadIndex } from "../agents/subagent-registry-read.js";
+import { buildSubagentSessionListReadIndex } from "../agents/subagent-registry-read.js";
 import { resolveStorePath, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
@@ -27,7 +27,7 @@ export function buildSessionListRowContext(params: {
   now: number;
   userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
 }): SessionListRowContext {
-  const subagentRuns = buildSubagentRunReadIndex(params.now);
+  const subagentRuns = buildSubagentSessionListReadIndex(params.now);
   return buildSessionListRowContextFromParts({
     subagentRuns,
     storeChildSessionsByKey: buildStoreChildSessionIndex(params.store, params.now, subagentRuns),
@@ -36,7 +36,7 @@ export function buildSessionListRowContext(params: {
 }
 
 function buildSessionListRowContextFromParts(params: {
-  subagentRuns: ReturnType<typeof buildSubagentRunReadIndex>;
+  subagentRuns: SessionListRowContext["subagentRuns"];
   storeChildSessionsByKey: Map<string, string[]>;
   userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
 }): SessionListRowContext {
@@ -57,7 +57,7 @@ export function buildSessionListRowMetadataContext(params: {
   userProfileIdentityById?: Map<string, SessionActorProfileIdentity | undefined>;
 }): SessionListRowContext {
   return buildSessionListRowContextFromParts({
-    subagentRuns: buildSubagentRunReadIndex(params.now),
+    subagentRuns: buildSubagentSessionListReadIndex(params.now),
     storeChildSessionsByKey: new Map(),
     userProfileIdentityById: params.userProfileIdentityById,
   });

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -11,7 +11,7 @@ import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 
 const subagentRegistryReadMock = vi.hoisted(() => {
   let runsByChildSessionKey = new Map<string, Record<string, unknown>>();
-  const buildSubagentRunReadIndex = vi.fn(() => {
+  const buildSubagentSessionListReadIndex = vi.fn(() => {
     const runsByControllerSessionKey = new Map<string, Record<string, unknown>[]>();
     for (const entry of runsByChildSessionKey.values()) {
       const controllerSessionKey =
@@ -36,7 +36,7 @@ const subagentRegistryReadMock = vi.hoisted(() => {
     };
   });
   return {
-    buildSubagentRunReadIndex,
+    buildSubagentSessionListReadIndex,
     countActiveDescendantRuns: vi.fn(() => 0),
     getSessionDisplaySubagentRunByChildSessionKey: vi.fn(
       (childSessionKey: string) => runsByChildSessionKey.get(childSessionKey) ?? null,
@@ -182,7 +182,7 @@ function expectChildMovedToNewParent(fixture: MovingChildFixture, now: number): 
   expect(loadGatewaySessionRow(fixture.newParent, { now: now + 50 })?.childSessions).toEqual([
     fixture.child,
   ]);
-  expect(subagentRegistryReadMock.buildSubagentRunReadIndex).not.toHaveBeenCalled();
+  expect(subagentRegistryReadMock.buildSubagentSessionListReadIndex).not.toHaveBeenCalled();
 }
 
 describe("single gateway session row child-session cache", () => {
@@ -223,7 +223,7 @@ describe("single gateway session row child-session cache", () => {
         expect(rowA?.childSessions).toEqual(["agent:main:subagent:child-a"]);
         expect(rowB?.childSessions).toEqual(["agent:main:subagent:child-b"]);
         expect(rowAAfterWindow?.childSessions).toEqual(["agent:main:subagent:child-a"]);
-        expect(subagentRegistryReadMock.buildSubagentRunReadIndex).not.toHaveBeenCalled();
+        expect(subagentRegistryReadMock.buildSubagentSessionListReadIndex).not.toHaveBeenCalled();
       },
     );
   });
@@ -276,7 +276,7 @@ describe("single gateway session row child-session cache", () => {
         });
 
         expect(syncListed.sessions).toHaveLength(1);
-        expect(subagentRegistryReadMock.buildSubagentRunReadIndex).toHaveBeenCalledTimes(1);
+        expect(subagentRegistryReadMock.buildSubagentSessionListReadIndex).toHaveBeenCalledTimes(1);
         expect(
           subagentRegistryReadMock.getSessionDisplaySubagentRunByChildSessionKey,
         ).not.toHaveBeenCalled();
@@ -291,7 +291,7 @@ describe("single gateway session row child-session cache", () => {
         });
 
         expect(asyncListed.sessions).toHaveLength(1);
-        expect(subagentRegistryReadMock.buildSubagentRunReadIndex).toHaveBeenCalledTimes(1);
+        expect(subagentRegistryReadMock.buildSubagentSessionListReadIndex).toHaveBeenCalledTimes(1);
         expect(
           subagentRegistryReadMock.getSessionDisplaySubagentRunByChildSessionKey,
         ).not.toHaveBeenCalled();


### PR DESCRIPTION
Fixes #116506

## What Problem This Solves

Fixes an issue where operators listing sessions with retained subagent history would repeatedly hydrate every full retained-run payload from SQLite, even when the requested page was tiny. Large histories could make `sessions.list` increasingly slow.

## Why This Change Was Made

Session-list reads now use a canonical SQLite projection containing only the topology and display fields required by the existing read index. Lifecycle, recovery, control, and delivery paths continue using full records. The projection has its own short-lived cache, preserves process-local authoritative updates, and does not change the SQLite schema version.

## User Impact

Session lists remain responsive as retained subagent history and payload size grow, without changing session metadata or subagent status behavior.

## Evidence

- Implementation benchmark, 5,000 retained rows with 8 KB payloads:
  - full canonical hydration: 413.76 ms
  - projected session-list read: 52.26 ms
  - 7.92x faster; both returned 5,000 rows
- Exact-head affected tests: 27/27 passed across gateway and agent-registry shards after rebasing onto current `main`.
- The identical patch also passed those tests on Blacksmith Testbox `tbx_01kyt7h229ys5x1q5ya0wfp61n`: https://github.com/openclaw/openclaw/actions/runs/30574398883
- Exact-head Kysely guardrails, generated-type verification, formatting, and `git diff --check` passed.
- Autoreview passed with no actionable findings after its cache-coherence finding was fixed and covered by regression test.
- No SQLite schema-version bump.
