### PR TITLE
fix(plugins): propagate bundled capability contracts

### DIFF
--- a/src/plugins/bundled-capability-runtime.test.ts
+++ b/src/plugins/bundled-capability-runtime.test.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadBundledCapabilityRuntimeRegistry } from "./bundled-capability-runtime.js";
+import type { PluginDiscoveryResult } from "./discovery.js";
+import type { PluginManifest } from "./manifest.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeBundledToolPlugin(params: {
+  pluginId: string;
+  toolName: string;
+  contracts?: PluginManifest["contracts"];
+}): PluginDiscoveryResult {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-capability-"));
+  tempDirs.push(rootDir);
+  const source = path.join(rootDir, "index.cjs");
+  const manifestPath = path.join(rootDir, "openclaw.plugin.json");
+  const manifest: PluginManifest = {
+    id: params.pluginId,
+    configSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    },
+    ...(params.contracts ? { contracts: params.contracts } : {}),
+  };
+  fs.writeFileSync(
+    source,
+    `module.exports = {
+  register(api) {
+    api.registerTool({
+      name: ${JSON.stringify(params.toolName)},
+      description: "test capability tool",
+      parameters: { type: "object", additionalProperties: false, properties: {} },
+      execute: async () => ({ content: [] }),
+    });
+  },
+};
+`,
+    "utf-8",
+  );
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+  return {
+    candidates: [
+      {
+        idHint: params.pluginId,
+        source,
+        rootDir,
+        origin: "bundled",
+        bundledManifest: manifest,
+        bundledManifestPath: manifestPath,
+      },
+    ],
+    diagnostics: [],
+  };
+}
+
+function loadFixtureRegistry(params: { pluginId: string; discovery: PluginDiscoveryResult }) {
+  return loadBundledCapabilityRuntimeRegistry({
+    pluginIds: [params.pluginId],
+    discovery: params.discovery,
+    env: {
+      ...process.env,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    },
+  });
+}
+
+describe("loadBundledCapabilityRuntimeRegistry", () => {
+  it("uses manifest-owned contracts when validating bundled capability tools", () => {
+    const pluginId = "bundled-contract-tool";
+    const toolName = "bundled_contract_tool";
+    const discovery = writeBundledToolPlugin({
+      pluginId,
+      toolName,
+      contracts: { tools: [toolName] },
+    });
+
+    const registry = loadFixtureRegistry({ pluginId, discovery });
+
+    expect(registry.plugins).toMatchObject([
+      {
+        id: pluginId,
+        contracts: { tools: [toolName] },
+        status: "loaded",
+        toolNames: [toolName],
+      },
+    ]);
+    expect(registry.tools.flatMap((tool) => tool.names)).toContain(toolName);
+    expect(registry.diagnostics).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          pluginId,
+          message: `plugin must declare contracts.tools for: ${toolName}`,
+        }),
+      ]),
+    );
+  });
+
+  it("still rejects bundled capability tools that are missing manifest contracts", () => {
+    const pluginId = "bundled-contract-missing-tool";
+    const toolName = "undeclared_bundled_tool";
+    const discovery = writeBundledToolPlugin({
+      pluginId,
+      toolName,
+    });
+
+    const registry = loadFixtureRegistry({ pluginId, discovery });
+
+    expect(registry.plugins).toMatchObject([
+      {
+        id: pluginId,
+        status: "loaded",
+        toolNames: [toolName],
+      },
+    ]);
+    expect(registry.tools.flatMap((tool) => tool.names)).not.toContain(toolName);
+    expect(registry.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: "error",
+          pluginId,
+          message: `plugin must declare contracts.tools for: ${toolName}`,
+        }),
+      ]),
+    );
+  });
+});

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -133,6 +133,7 @@ function createCapabilityPluginRecord(params: {
   source: string;
   rootDir?: string;
   workspaceDir?: string;
+  contracts?: PluginRecord["contracts"];
 }): PluginRecord {
   return {
     id: params.id,
@@ -143,6 +144,7 @@ function createCapabilityPluginRecord(params: {
     rootDir: params.rootDir,
     origin: "bundled",
     workspaceDir: params.workspaceDir,
+    contracts: params.contracts,
     enabled: true,
     status: "loaded",
     toolNames: [],
@@ -275,6 +277,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
           : candidate.source,
       rootDir: candidate.rootDir,
       workspaceDir: candidate.workspaceDir,
+      contracts: manifest.contracts,
     });
 
     const boundaryLabel = record.source === candidate.source ? "plugin root" : "repo root";


### PR DESCRIPTION
Related to #77982, but this PR no longer claims to close it.

## Current Status

This branch is superseded by the current `main` plugin-loader refactor in #117373. The original branch attempted to pass `manifest.contracts` into the old bundled capability record, but that old record path has been replaced by the canonical scoped plugin loader.

## Why This No Longer Closes The Issue

The linked Lark report describes contracts declared through the plugin module export. This branch only addressed manifest-owned contracts, so keeping a closing keyword for #77982 would risk closing the report without proving the module-export contract source.

## Current Main Evidence

Current `main` now routes bundled capability discovery through the canonical loader path:

- `src/plugins/bundled-capability-runtime.ts` calls `loadOpenClawPluginsWithInternalOverrides(...)` instead of maintaining its own capability-only plugin record constructor.
- `src/plugins/loader-shared.ts` builds manifest-backed records with `contracts: manifestRecord.contracts`.
- `src/plugins/registry-registrars-tools-hooks.ts` validates registered tools against `record.contracts`.

Focused proof on current `main`:

- `node scripts/run-vitest.mjs src/plugins/loader.registration.test-utils.ts -t "manifest_tool|contracts.tools|manifest"`
  - passed: 2 tests, 32 skipped

Known unrelated current-main proof issue:

- A broader plugin proof command also surfaced current-main failures in `src/plugins/bundled-capability-runtime.test.ts` and `src/plugins/capability-provider-runtime.test.ts` around Discord voice/capability metadata expectations. I am not treating those as caused by this branch.

## Recommended Next Step

Do not merge this stale branch as-is. Either close it as superseded by #117373/current main, or open a new focused PR only if module-export-owned `contracts.tools` is still intended to be supported for bundled capability plugins.

