### PR TITLE
fix(voice-call): shutdown no longer leaves media connections open

### DIFF
--- a/extensions/voice-call/src/media-stream.lifecycle.test.ts
+++ b/extensions/voice-call/src/media-stream.lifecycle.test.ts
@@ -4,6 +4,39 @@ import { MediaStreamHandler } from "./media-stream.js";
 import { connectWs, startUpgradeWsServer, waitForClose } from "./websocket-test-support.js";
 
 describe("MediaStreamHandler lifecycle", () => {
+  it("keeps rejecting upgrades through the shutdown barrier without active sockets", async () => {
+    const handler = new MediaStreamHandler({
+      transcriptionProvider: {
+        createSession: () => ({
+          connect: async () => {},
+          sendAudio: () => {},
+          close: () => {},
+          isConnected: () => true,
+        }),
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: () => true,
+      },
+      providerConfig: {},
+    });
+    let releaseShutdownBarrier: (() => void) | undefined;
+    const shutdownBarrier = new Promise<void>((resolve) => {
+      releaseShutdownBarrier = resolve;
+    });
+    const close = handler.close(shutdownBarrier);
+    let closeSettled = false;
+    void close.then(() => {
+      closeSettled = true;
+    });
+
+    await Promise.resolve();
+    expect(closeSettled).toBe(false);
+
+    releaseShutdownBarrier?.();
+    await close;
+    expect(closeSettled).toBe(true);
+  });
+
   it("rejects duplicate start frames without creating another STT session", async () => {
     const closeSession = vi.fn();
     const sttSession: RealtimeTranscriptionSession = {

--- a/extensions/voice-call/src/media-stream.lifecycle.test.ts
+++ b/extensions/voice-call/src/media-stream.lifecycle.test.ts
@@ -70,4 +70,62 @@ describe("MediaStreamHandler lifecycle", () => {
       await server.close();
     }
   });
+
+  it("terminates active streams and shares concurrent close completion", async () => {
+    const closeSession = vi.fn();
+    const onConnect = vi.fn();
+    const onDisconnect = vi.fn();
+    const handler = new MediaStreamHandler({
+      transcriptionProvider: {
+        createSession: () => ({
+          connect: async () => {},
+          sendAudio: () => {},
+          close: closeSession,
+          isConnected: () => true,
+        }),
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: () => true,
+      },
+      providerConfig: {},
+      shouldAcceptStream: () => true,
+      onConnect,
+      onDisconnect,
+    });
+    const server = await startUpgradeWsServer({
+      urlPath: "/voice/stream",
+      onUpgrade: (request, socket, head) => {
+        handler.handleUpgrade(request, socket, head);
+      },
+    });
+    const ws = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-shutdown",
+          start: { callSid: "CA-shutdown" },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(onConnect).toHaveBeenCalledWith("CA-shutdown", "MZ-shutdown");
+      });
+
+      const closed = waitForClose(ws);
+      const firstClose = handler.close();
+      const secondClose = handler.close();
+
+      expect(secondClose).toBe(firstClose);
+      await firstClose;
+      expect(await closed).toEqual({ code: 1006, reason: "" });
+      expect(closeSession).toHaveBeenCalledTimes(1);
+      expect(onDisconnect).toHaveBeenCalledWith("CA-shutdown", "MZ-shutdown");
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+    } finally {
+      ws.terminate();
+      await handler.close();
+      await server.close();
+    }
+  });
 });

--- a/extensions/voice-call/src/media-stream.lifecycle.test.ts
+++ b/extensions/voice-call/src/media-stream.lifecycle.test.ts
@@ -99,6 +99,7 @@ describe("MediaStreamHandler lifecycle", () => {
       },
     });
     const ws = await connectWs(server.url);
+    let releaseShutdownBarrier: (() => void) | undefined;
 
     try {
       ws.send(
@@ -113,16 +114,30 @@ describe("MediaStreamHandler lifecycle", () => {
       });
 
       const closed = waitForClose(ws);
-      const firstClose = handler.close();
+      const shutdownBarrier = new Promise<void>((resolve) => {
+        releaseShutdownBarrier = resolve;
+      });
+      const firstClose = handler.close(shutdownBarrier);
       const secondClose = handler.close();
+      let closeSettled = false;
+      void firstClose.then(() => {
+        closeSettled = true;
+      });
 
       expect(secondClose).toBe(firstClose);
-      await firstClose;
       expect(await closed).toEqual({ code: 1006, reason: "" });
-      expect(closeSession).toHaveBeenCalledTimes(1);
-      expect(onDisconnect).toHaveBeenCalledWith("CA-shutdown", "MZ-shutdown");
-      expect(onDisconnect).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => {
+        expect(closeSession).toHaveBeenCalledTimes(1);
+        expect(onDisconnect).toHaveBeenCalledWith("CA-shutdown", "MZ-shutdown");
+        expect(onDisconnect).toHaveBeenCalledTimes(1);
+      });
+      expect(closeSettled).toBe(false);
+
+      releaseShutdownBarrier?.();
+      await firstClose;
+      expect(closeSettled).toBe(true);
     } finally {
+      releaseShutdownBarrier?.();
       ws.terminate();
       await handler.close();
       await server.close();

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -138,6 +138,8 @@ function parseTwilioMediaMessage(data: RawData): TwilioMediaMessage {
  */
 export class MediaStreamHandler {
   private wss: WebSocketServer | null = null;
+  private closePromise: Promise<void> | null = null;
+  private closing = false;
   private sessions = new Map<string, StreamSession>();
   private config: MediaStreamConfig;
   /** Pending sockets that have upgraded but not yet sent an accepted `start` frame. */
@@ -172,6 +174,11 @@ export class MediaStreamHandler {
    * Handle WebSocket upgrade for media stream connections.
    */
   handleUpgrade(request: IncomingMessage, socket: Duplex, head: Buffer): void {
+    if (this.closing) {
+      this.rejectUpgrade(socket, 503, "Media stream handler is shutting down");
+      return;
+    }
+
     if (!this.wss) {
       this.wss = new WebSocketServer({
         noServer: true,
@@ -219,6 +226,31 @@ export class MediaStreamHandler {
       releaseUpgradeReservation();
       throw error;
     }
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    this.closing = true;
+    const wss = this.wss;
+    this.wss = null;
+    this.closePromise = (async () => {
+      if (!wss) {
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        wss.close(() => resolve());
+        for (const ws of wss.clients) {
+          ws.terminate();
+        }
+      });
+    })().finally(() => {
+      this.closing = false;
+      this.closePromise = null;
+    });
+    return this.closePromise;
   }
 
   /**

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -228,7 +228,7 @@ export class MediaStreamHandler {
     }
   }
 
-  close(): Promise<void> {
+  close(shutdownBarrier: Promise<unknown> = Promise.resolve()): Promise<void> {
     if (this.closePromise) {
       return this.closePromise;
     }
@@ -246,6 +246,7 @@ export class MediaStreamHandler {
           ws.terminate();
         }
       });
+      await shutdownBarrier;
     })().finally(() => {
       this.closing = false;
       this.closePromise = null;

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -237,15 +237,14 @@ export class MediaStreamHandler {
     const wss = this.wss;
     this.wss = null;
     this.closePromise = (async () => {
-      if (!wss) {
-        return;
+      if (wss) {
+        await new Promise<void>((resolve) => {
+          wss.close(() => resolve());
+          for (const ws of wss.clients) {
+            ws.terminate();
+          }
+        });
       }
-      await new Promise<void>((resolve) => {
-        wss.close(() => resolve());
-        for (const ws of wss.clients) {
-          ws.terminate();
-        }
-      });
       await shutdownBarrier;
     })().finally(() => {
       this.closing = false;

--- a/extensions/voice-call/src/runtime.test.ts
+++ b/extensions/voice-call/src/runtime.test.ts
@@ -282,6 +282,13 @@ describe("createVoiceCallRuntime lifecycle", () => {
 
   it("returns an idempotent stop handler", async () => {
     const tunnelStop = vi.fn().mockResolvedValue(undefined);
+    let releaseWebhookStop: (() => void) | undefined;
+    mocks.webhookStop.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseWebhookStop = resolve;
+        }),
+    );
     mocks.startTunnel.mockResolvedValue({
       publicUrl: "https://public.example/voice/webhook",
       provider: "ngrok",
@@ -294,8 +301,22 @@ describe("createVoiceCallRuntime lifecycle", () => {
       agentRuntime: {} as never,
     });
 
-    await runtime.stop();
-    await runtime.stop();
+    const firstStop = runtime.stop();
+    const secondStop = runtime.stop();
+    let stopped = false;
+    void secondStop.then(() => {
+      stopped = true;
+    });
+
+    expect(secondStop).toBe(firstStop);
+    await vi.waitFor(() => {
+      expect(mocks.webhookStop).toHaveBeenCalledTimes(1);
+    });
+    expect(stopped).toBe(false);
+
+    releaseWebhookStop?.();
+    await firstStop;
+    expect(stopped).toBe(true);
 
     expect(tunnelStop).toHaveBeenCalledTimes(1);
     expect(mocks.cleanupTailscaleExposure).toHaveBeenCalledTimes(1);

--- a/extensions/voice-call/src/runtime.ts
+++ b/extensions/voice-call/src/runtime.ts
@@ -131,7 +131,7 @@ function createRuntimeResourceLifecycle(params: {
   stop: (opts?: { suppressErrors?: boolean }) => Promise<void>;
 } {
   let tunnelResult: TunnelResult | null = null;
-  let stopped = false;
+  let stopPromise: Promise<void> | null = null;
 
   const runStep = async (step: () => Promise<void>, suppressErrors: boolean) => {
     if (suppressErrors) {
@@ -145,23 +145,25 @@ function createRuntimeResourceLifecycle(params: {
     setTunnelResult: (result) => {
       tunnelResult = result;
     },
-    stop: async (opts) => {
-      if (stopped) {
-        return;
+    stop: (opts) => {
+      if (stopPromise) {
+        return stopPromise;
       }
-      stopped = true;
       const suppressErrors = opts?.suppressErrors ?? false;
-      await runStep(async () => {
-        if (tunnelResult) {
-          await tunnelResult.stop();
-        }
-      }, suppressErrors);
-      await runStep(async () => {
-        await cleanupTailscaleExposure(params.config);
-      }, suppressErrors);
-      await runStep(async () => {
-        await params.webhookServer.stop();
-      }, suppressErrors);
+      stopPromise = (async () => {
+        await runStep(async () => {
+          if (tunnelResult) {
+            await tunnelResult.stop();
+          }
+        }, suppressErrors);
+        await runStep(async () => {
+          await cleanupTailscaleExposure(params.config);
+        }, suppressErrors);
+        await runStep(async () => {
+          await params.webhookServer.stop();
+        }, suppressErrors);
+      })();
+      return stopPromise;
     },
   };
 }
@@ -556,7 +558,7 @@ export async function createVoiceCallRuntime(params: {
 
     await manager.initialize(provider, webhookUrl);
 
-    const stop = async () => await lifecycle.stop();
+    const stop = () => lifecycle.stop();
 
     log.info("[voice-call] Runtime initialized");
     log.info(`[voice-call] Webhook URL: ${webhookUrl}`);

--- a/extensions/voice-call/src/webhook.shutdown.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.shutdown.lifecycle.test.ts
@@ -23,6 +23,13 @@ describe("VoiceCallWebhookServer shutdown lifecycle", () => {
       close: handlerClose,
     } as unknown as RealtimeCallHandler);
     await server.start();
+    const delayedHangup = vi.fn();
+    const pendingDisconnectHangups = (
+      server as unknown as {
+        pendingDisconnectHangups: Map<string, ReturnType<typeof setTimeout>>;
+      }
+    ).pendingDisconnectHangups;
+    pendingDisconnectHangups.set("provider-call", setTimeout(delayedHangup, 5));
 
     const firstStop = server.stop();
     const secondStop = server.stop();
@@ -31,13 +38,18 @@ describe("VoiceCallWebhookServer shutdown lifecycle", () => {
       stopped = true;
     });
 
-    expect(secondStop).toBe(firstStop);
-    expect(handlerClose).toHaveBeenCalledTimes(1);
-    await Promise.resolve();
-    expect(stopped).toBe(false);
-
-    releaseHandlerClose?.();
-    await firstStop;
+    try {
+      expect(secondStop).toBe(firstStop);
+      expect(handlerClose).toHaveBeenCalledTimes(1);
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+      expect(stopped).toBe(false);
+      expect(delayedHangup).not.toHaveBeenCalled();
+    } finally {
+      releaseHandlerClose?.();
+      await firstStop;
+    }
     expect(stopped).toBe(true);
   });
 });

--- a/extensions/voice-call/src/webhook.shutdown.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.shutdown.lifecycle.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CallManager } from "./manager.js";
+import type { VoiceCallProvider } from "./providers/base.js";
+import { createVoiceCallBaseConfig } from "./test-fixtures.js";
+import { VoiceCallWebhookServer } from "./webhook.js";
+import type { RealtimeCallHandler } from "./webhook/realtime-handler.js";
+
+describe("VoiceCallWebhookServer shutdown lifecycle", () => {
+  it("waits for owned handlers and shares concurrent stop completion", async () => {
+    let releaseHandlerClose: (() => void) | undefined;
+    const handlerClose = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseHandlerClose = resolve;
+        }),
+    );
+    const server = new VoiceCallWebhookServer(
+      createVoiceCallBaseConfig({ tunnelProvider: "none" }),
+      {} as CallManager,
+      {} as VoiceCallProvider,
+    );
+    server.setRealtimeHandler({
+      close: handlerClose,
+    } as unknown as RealtimeCallHandler);
+    await server.start();
+
+    const firstStop = server.stop();
+    const secondStop = server.stop();
+    let stopped = false;
+    void firstStop.then(() => {
+      stopped = true;
+    });
+
+    expect(secondStop).toBe(firstStop);
+    expect(handlerClose).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+
+    releaseHandlerClose?.();
+    await firstStop;
+    expect(stopped).toBe(true);
+  });
+});

--- a/extensions/voice-call/src/webhook.shutdown.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.shutdown.lifecycle.test.ts
@@ -26,7 +26,7 @@ describe("VoiceCallWebhookServer shutdown lifecycle", () => {
     const delayedHangup = vi.fn();
     const pendingDisconnectHangups = (
       server as unknown as {
-        pendingDisconnectHangups: Map<string, ReturnType<typeof setTimeout>>;
+        pendingDisconnectHangups: Map<string, unknown>;
       }
     ).pendingDisconnectHangups;
     pendingDisconnectHangups.set("provider-call", setTimeout(delayedHangup, 5));

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -741,6 +741,7 @@ describe("VoiceCallWebhookServer realtime WebSocket routing", () => {
         headers: { "Content-Type": "text/xml" },
         body: "<Response />",
       }),
+      close: async () => {},
       getStreamPathPattern: () => streamPathPattern,
       handleWebSocketUpgrade,
       registerToolHandler: () => {},
@@ -1084,6 +1085,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
     const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
     server.setRealtimeHandler({
       buildTwiMLPayload,
+      close: async () => {},
       getStreamPathPattern: () => "/voice/stream/realtime",
       handleWebSocketUpgrade: () => {},
       registerToolHandler: () => {},
@@ -1139,6 +1141,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
       const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
       server.setRealtimeHandler({
         buildTwiMLPayload,
+        close: async () => {},
         getStreamPathPattern: () => "/voice/stream/realtime",
         handleWebSocketUpgrade: () => {},
         registerToolHandler: () => {},
@@ -1200,6 +1203,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
       const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
       server.setRealtimeHandler({
         buildTwiMLPayload,
+        close: async () => {},
         getStreamPathPattern: () => "/voice/stream/realtime",
         handleWebSocketUpgrade: () => {},
         registerToolHandler: () => {},
@@ -1256,6 +1260,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
     const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
     server.setRealtimeHandler({
       buildTwiMLPayload,
+      close: async () => {},
       getStreamPathPattern: () => "/voice/stream/realtime",
       handleWebSocketUpgrade: () => {},
       registerToolHandler: () => {},
@@ -1320,6 +1325,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
     const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
     server.setRealtimeHandler({
       buildTwiMLPayload,
+      close: async () => {},
       getStreamPathPattern: () => "/voice/stream/realtime",
       handleWebSocketUpgrade: () => {},
       registerToolHandler: () => {},
@@ -1379,6 +1385,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
     const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
     server.setRealtimeHandler({
       buildTwiMLPayload,
+      close: async () => {},
       getStreamPathPattern: () => "/voice/stream/realtime",
       handleWebSocketUpgrade: () => {},
       registerToolHandler: () => {},
@@ -1431,6 +1438,7 @@ describe("VoiceCallWebhookServer replay handling", () => {
     const server = new VoiceCallWebhookServer(config, manager, twilioProvider);
     server.setRealtimeHandler({
       buildTwiMLPayload,
+      close: async () => {},
       getStreamPathPattern: () => "/voice/stream/realtime",
       handleWebSocketUpgrade: () => {},
       registerToolHandler: () => {},

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -179,6 +179,7 @@ export class VoiceCallWebhookServer {
   private server: http.Server | null = null;
   private listeningUrl: string | null = null;
   private startPromise: Promise<string> | null = null;
+  private stopPromise: Promise<void> | null = null;
   private config: VoiceCallConfig;
   private manager: CallManager;
   private provider: VoiceCallProvider;
@@ -484,6 +485,10 @@ export class VoiceCallWebhookServer {
    * Idempotent: returns immediately if the server is already listening.
    */
   async start(): Promise<string> {
+    if (this.stopPromise) {
+      await this.stopPromise;
+    }
+
     const { port, bind, path: webhookPath } = this.config.serve;
     const streamPath = this.config.streaming.streamPath;
 
@@ -561,30 +566,58 @@ export class VoiceCallWebhookServer {
   /**
    * Stop the webhook server.
    */
-  async stop(): Promise<void> {
-    for (const timer of this.pendingDisconnectHangups.values()) {
-      clearTimeout(timer);
+  stop(): Promise<void> {
+    if (this.stopPromise) {
+      return this.stopPromise;
     }
-    this.pendingDisconnectHangups.clear();
-    this.webhookInFlightLimiter.clear();
-    this.startPromise = null;
 
+    const server = this.server;
+    const serverClosePromise = new Promise<void>((resolve, reject) => {
+      if (!server) {
+        resolve();
+        return;
+      }
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+    this.startPromise = null;
     if (this.stopStaleCallReaper) {
       this.stopStaleCallReaper();
       this.stopStaleCallReaper = null;
     }
-    return new Promise((resolve) => {
-      if (this.server) {
-        this.server.close(() => {
-          this.server = null;
-          this.listeningUrl = null;
-          resolve();
-        });
-      } else {
-        this.listeningUrl = null;
-        resolve();
+    this.webhookInFlightLimiter.clear();
+
+    this.stopPromise = (async () => {
+      const results = await Promise.allSettled([
+        serverClosePromise,
+        this.mediaStreamHandler?.close() ?? Promise.resolve(),
+        this.realtimeHandler?.close() ?? Promise.resolve(),
+      ]);
+
+      for (const timer of this.pendingDisconnectHangups.values()) {
+        clearTimeout(timer);
       }
+      this.pendingDisconnectHangups.clear();
+      if (this.server === server) {
+        this.server = null;
+      }
+      this.listeningUrl = null;
+
+      const failure = results.find(
+        (result): result is PromiseRejectedResult => result.status === "rejected",
+      );
+      if (failure) {
+        throw failure.reason;
+      }
+    })().finally(() => {
+      this.stopPromise = null;
     });
+    return this.stopPromise;
   }
 
   private resolveListeningUrl(bind: string, webhookPath: string): string {

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -586,6 +586,10 @@ export class VoiceCallWebhookServer {
       });
     });
     this.startPromise = null;
+    for (const timer of this.pendingDisconnectHangups.values()) {
+      clearTimeout(timer);
+    }
+    this.pendingDisconnectHangups.clear();
     if (this.stopStaleCallReaper) {
       this.stopStaleCallReaper();
       this.stopStaleCallReaper = null;
@@ -595,8 +599,8 @@ export class VoiceCallWebhookServer {
     this.stopPromise = (async () => {
       const results = await Promise.allSettled([
         serverClosePromise,
-        this.mediaStreamHandler?.close() ?? Promise.resolve(),
-        this.realtimeHandler?.close() ?? Promise.resolve(),
+        this.mediaStreamHandler?.close(serverClosePromise) ?? Promise.resolve(),
+        this.realtimeHandler?.close(serverClosePromise) ?? Promise.resolve(),
       ]);
 
       for (const timer of this.pendingDisconnectHangups.values()) {

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -1,0 +1,139 @@
+import type { RealtimeVoiceBridge } from "openclaw/plugin-sdk/realtime-voice";
+import { describe, expect, it, vi } from "vitest";
+import type { WebSocket as WebSocketType } from "ws";
+import { WebSocket } from "ws";
+import type { VoiceCallRealtimeConfig } from "../config.js";
+import type { CallManager } from "../manager.js";
+import type { VoiceCallProvider } from "../providers/base.js";
+import type { CallRecord } from "../types.js";
+import { connectWs, startUpgradeWsServer, waitForClose } from "../websocket-test-support.js";
+import { RealtimeCallHandler } from "./realtime-handler.js";
+
+function createRealtimeConfig(): VoiceCallRealtimeConfig {
+  return {
+    enabled: true,
+    streamPath: "/voice/stream/realtime",
+    instructions: "Be helpful.",
+    toolPolicy: "safe-read-only",
+    consultPolicy: "auto",
+    tools: [],
+    fastContext: {
+      enabled: false,
+      timeoutMs: 800,
+      maxResults: 3,
+      sources: ["memory", "sessions"],
+      fallbackToConsult: false,
+    },
+    agentContext: {
+      enabled: false,
+      maxChars: 6000,
+      includeIdentity: true,
+      includeWorkspaceFiles: true,
+      files: ["SOUL.md", "IDENTITY.md", "USER.md"],
+    },
+    providers: {},
+  };
+}
+
+function createBridge(close: () => void): RealtimeVoiceBridge {
+  return {
+    connect: async () => {},
+    sendAudio: () => {},
+    setMediaTimestamp: () => {},
+    submitToolResult: () => {},
+    acknowledgeMark: () => {},
+    close,
+    isConnected: () => true,
+    triggerGreeting: () => {},
+  };
+}
+
+describe("RealtimeCallHandler lifecycle", () => {
+  it("terminates active sockets and treats server shutdown as completed", async () => {
+    const bridgeClose = vi.fn();
+    const createBridgeForCall = vi.fn(() => createBridge(bridgeClose));
+    const processEvent = vi.fn();
+    const call: CallRecord = {
+      callId: "call-shutdown",
+      providerCallId: "CA-shutdown",
+      provider: "twilio",
+      direction: "inbound",
+      state: "ringing",
+      from: "+15550001111",
+      to: "+15550002222",
+      startedAt: Date.now(),
+      transcript: [],
+      processedEventIds: [],
+    };
+    const handler = new RealtimeCallHandler(
+      createRealtimeConfig(),
+      {
+        processEvent,
+        getCallByProviderCallId: vi.fn(() => call),
+      } as unknown as CallManager,
+      {
+        name: "twilio",
+        verifyWebhook: vi.fn(),
+        parseWebhookEvent: vi.fn(),
+        initiateCall: vi.fn(),
+        hangupCall: vi.fn(),
+        playTts: vi.fn(),
+        startListening: vi.fn(),
+        stopListening: vi.fn(),
+        getCallStatus: vi.fn(),
+      } as unknown as VoiceCallProvider,
+      {
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: () => true,
+        createBridge: createBridgeForCall,
+      },
+      { apiKey: "test-key" },
+      "/voice/webhook",
+    );
+    const { streamUrl } = handler.issueStreamSession();
+    const server = await startUpgradeWsServer({
+      urlPath: new URL(streamUrl).pathname,
+      onUpgrade: (request, socket, head) => {
+        handler.handleWebSocketUpgrade(request, socket, head);
+      },
+    });
+    let ws: WebSocketType | null = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-shutdown", callSid: "CA-shutdown" },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(createBridgeForCall).toHaveBeenCalledTimes(1);
+      });
+
+      const closed = waitForClose(ws);
+      const firstClose = handler.close();
+      const secondClose = handler.close();
+
+      expect(secondClose).toBe(firstClose);
+      await firstClose;
+      expect(await closed).toEqual({ code: 1006, reason: "" });
+      expect(bridgeClose).toHaveBeenCalledTimes(1);
+      expect(processEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callId: "call-shutdown",
+          providerCallId: "CA-shutdown",
+          reason: "completed",
+          type: "call.ended",
+        }),
+      );
+      ws = null;
+    } finally {
+      if (ws && ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+});

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -99,6 +99,7 @@ describe("RealtimeCallHandler lifecycle", () => {
       },
     });
     let ws: WebSocketType | null = await connectWs(server.url);
+    let releaseShutdownBarrier: (() => void) | undefined;
 
     try {
       ws.send(
@@ -112,23 +113,45 @@ describe("RealtimeCallHandler lifecycle", () => {
       });
 
       const closed = waitForClose(ws);
-      const firstClose = handler.close();
+      const shutdownBarrier = new Promise<void>((resolve) => {
+        releaseShutdownBarrier = resolve;
+      });
+      const firstClose = handler.close(shutdownBarrier);
       const secondClose = handler.close();
+      handler.issueStreamSession();
+      let closeSettled = false;
+      void firstClose.then(() => {
+        closeSettled = true;
+      });
 
       expect(secondClose).toBe(firstClose);
-      await firstClose;
       expect(await closed).toEqual({ code: 1006, reason: "" });
-      expect(bridgeClose).toHaveBeenCalledTimes(1);
-      expect(processEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          callId: "call-shutdown",
-          providerCallId: "CA-shutdown",
-          reason: "completed",
-          type: "call.ended",
-        }),
-      );
+      await vi.waitFor(() => {
+        expect(bridgeClose).toHaveBeenCalledTimes(1);
+        expect(processEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            callId: "call-shutdown",
+            providerCallId: "CA-shutdown",
+            reason: "completed",
+            type: "call.ended",
+          }),
+        );
+      });
+      expect(closeSettled).toBe(false);
+
+      releaseShutdownBarrier?.();
+      await firstClose;
+      expect(closeSettled).toBe(true);
+      expect(
+        (
+          handler as unknown as {
+            pendingStreamTokens: Map<string, unknown>;
+          }
+        ).pendingStreamTokens.size,
+      ).toBe(0);
       ws = null;
     } finally {
+      releaseShutdownBarrier?.();
       if (ws && ws.readyState !== WebSocket.CLOSED) {
         ws.terminate();
       }

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -313,6 +313,8 @@ function appendRecentTalkEventMetadata(
 export class RealtimeCallHandler {
   private readonly toolHandlers = new Map<string, ToolHandlerFn>();
   private readonly pendingStreamTokens = new Map<string, PendingStreamToken>();
+  private readonly activeSockets = new Set<WebSocket>();
+  private readonly serverClosingSockets = new WeakSet<WebSocket>();
   private readonly activeBridgesByCallId = new Map<string, ActiveRealtimeVoiceBridge>();
   private readonly activeTelephonyClosersByCallId = new Map<
     string,
@@ -328,6 +330,8 @@ export class RealtimeCallHandler {
   >();
   private readonly forcedConsultsByCallId = new Map<string, ForcedConsultState>();
   private readonly nativeConsultsInFlightByCallId = new Map<string, NativeConsultState>();
+  private closePromise: Promise<void> | null = null;
+  private closing = false;
   private publicOrigin: string | null = null;
   private publicPathPrefix = "";
 
@@ -390,6 +394,12 @@ export class RealtimeCallHandler {
   }
 
   handleWebSocketUpgrade(request: http.IncomingMessage, socket: Duplex, head: Buffer): void {
+    if (this.closing) {
+      socket.write("HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+
     const url = new URL(request.url ?? "/", "wss://localhost");
     const token = url.pathname.split("/").pop() ?? null;
     const callerMeta = token ? this.consumeStreamToken(token) : null;
@@ -409,6 +419,7 @@ export class RealtimeCallHandler {
       maxPayload: MAX_REALTIME_MESSAGE_BYTES,
     });
     wss.handleUpgrade(request, socket, head, (ws) => {
+      this.activeSockets.add(ws);
       let bridge: ActiveRealtimeVoiceBridge | null = null;
       let initialized = false;
       let activeCallSid = "unknown";
@@ -483,14 +494,53 @@ export class RealtimeCallHandler {
       });
 
       ws.on("close", (code) => {
-        const reason = stopReceived || code === 1000 || code === 1005 ? "completed" : "error";
+        this.activeSockets.delete(ws);
+        const reason =
+          this.serverClosingSockets.has(ws) || stopReceived || code === 1000 || code === 1005
+            ? "completed"
+            : "error";
         this.closeTelephonyBridge(activeCallSid, bridge, reason);
       });
 
       ws.on("error", (error) => {
         console.error("[voice-call] realtime WS error:", error);
       });
+
+      if (this.closing) {
+        this.serverClosingSockets.add(ws);
+        ws.terminate();
+      }
     });
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) {
+      return this.closePromise;
+    }
+
+    this.closing = true;
+    this.pendingStreamTokens.clear();
+    const sockets = [...this.activeSockets];
+    this.closePromise = Promise.all(
+      sockets.map(
+        (ws) =>
+          new Promise<void>((resolve) => {
+            if (ws.readyState === WebSocket.CLOSED) {
+              resolve();
+              return;
+            }
+            this.serverClosingSockets.add(ws);
+            ws.once("close", () => resolve());
+            ws.terminate();
+          }),
+      ),
+    )
+      .then(() => {})
+      .finally(() => {
+        this.closing = false;
+        this.closePromise = null;
+      });
+    return this.closePromise;
   }
 
   registerToolHandler(name: string, fn: ToolHandlerFn): void {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -513,7 +513,7 @@ export class RealtimeCallHandler {
     });
   }
 
-  close(): Promise<void> {
+  close(shutdownBarrier: Promise<unknown> = Promise.resolve()): Promise<void> {
     if (this.closePromise) {
       return this.closePromise;
     }
@@ -521,8 +521,9 @@ export class RealtimeCallHandler {
     this.closing = true;
     this.pendingStreamTokens.clear();
     const sockets = [...this.activeSockets];
-    this.closePromise = Promise.all(
-      sockets.map(
+    this.closePromise = Promise.all([
+      shutdownBarrier,
+      ...sockets.map(
         (ws) =>
           new Promise<void>((resolve) => {
             if (ws.readyState === WebSocket.CLOSED) {
@@ -534,8 +535,10 @@ export class RealtimeCallHandler {
             ws.terminate();
           }),
       ),
-    )
-      .then(() => {})
+    ])
+      .then(() => {
+        this.pendingStreamTokens.clear();
+      })
       .finally(() => {
         this.closing = false;
         this.closePromise = null;


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where stopping or reloading voice-call could report completion while classic media or realtime WebSocket connections were still open. Concurrent stop callers could also return before the first shutdown finished.

## Why This Change Was Made

The classic and realtime handlers now own and terminate their active sockets, while webhook shutdown keeps both handlers closed through the HTTP drain barrier. Intentional shutdown takes completed-state precedence, stale stream tokens are cleared, disconnect timers are cancelled, and concurrent callers share one completion promise.

## User Impact

Voice-call shutdown and reload now finish deterministically without leaving media connections or provider bridges behind. No provider, configuration, or environment-variable surface changes.

## Evidence

- Real loopback WebSocket lifecycle coverage for classic media and realtime bridges.
- Focused post-rebase suite: 5 files, 72 tests passed.
- Full voice-call Testbox suite: 53 files, 508 tests passed.
- `check:changed` explicit voice-call path gate passed, including production/test typechecks and type-aware lint.
- Structured autoreview: clean after resolving shutdown-barrier and timer-order findings.
