### PR TITLE
fix(agents): honor configured USER.md bootstrap limits

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -101,7 +101,7 @@ Standard files OpenClaw expects inside the workspace:
 </AccordionGroup>
 
 <Note>
-If a required bootstrap file is missing, OpenClaw injects a "missing file" marker into the session and continues. Optional `USER.md` and `MEMORY.md` files are omitted when absent. Large bootstrap files are truncated when injected; adjust general limits with `agents.defaults.bootstrapMaxChars` (default: `20000`) and `agents.defaults.bootstrapTotalMaxChars` (default: `60000`). `USER.md` keeps its separate 4,000-character cap. `openclaw setup` can recreate missing defaults without overwriting existing files.
+If a required bootstrap file is missing, OpenClaw injects a "missing file" marker into the session and continues. Optional `USER.md` and `MEMORY.md` files are omitted when absent. Large bootstrap files are truncated when injected; adjust general limits with `agents.defaults.bootstrapMaxChars` (default: `20000`) and `agents.defaults.bootstrapTotalMaxChars` (default: `60000`). `USER.md` defaults to 4,000 characters, but an explicitly higher `agents.defaults.bootstrapMaxChars` or per-agent `agents.entries.*.bootstrapMaxChars` value raises its limit. `openclaw setup` can recreate missing defaults without overwriting existing files.
 </Note>
 
 ## What is NOT in the workspace

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -101,7 +101,7 @@ Standard files OpenClaw expects inside the workspace:
 </AccordionGroup>
 
 <Note>
-If a required bootstrap file is missing, OpenClaw injects a "missing file" marker into the session and continues. Optional `USER.md` and `MEMORY.md` files are omitted when absent. Large bootstrap files are truncated when injected; adjust general limits with `agents.defaults.bootstrapMaxChars` (default: `20000`) and `agents.defaults.bootstrapTotalMaxChars` (default: `60000`). `USER.md` defaults to 4,000 characters, but an explicitly higher `agents.defaults.bootstrapMaxChars` or per-agent `agents.entries.*.bootstrapMaxChars` value raises its limit. `openclaw setup` can recreate missing defaults without overwriting existing files.
+If a required bootstrap file is missing, OpenClaw injects a "missing file" marker into the session and continues. Optional `USER.md` and `MEMORY.md` files are omitted when absent. Large bootstrap files are truncated when injected; adjust general limits with `agents.defaults.bootstrapMaxChars` (default: `20000`) and `agents.defaults.bootstrapTotalMaxChars` (default: `60000`). `USER.md` defaults to 4,000 characters when neither scope configures `bootstrapMaxChars`; otherwise it uses the per-agent value when present, then the configured default. `openclaw setup` can recreate missing defaults without overwriting existing files.
 </Note>
 
 ## What is NOT in the workspace

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -121,7 +121,7 @@ By default, OpenClaw injects a fixed set of workspace files (if present):
 - `USER.md`
 - `BOOTSTRAP.md` (first-run only)
 
-Large files are truncated per-file using `agents.defaults.bootstrapMaxChars` (default `20000` chars). `USER.md` uses a 4,000-character default unless an explicit default or per-agent `bootstrapMaxChars` setting is higher. OpenClaw also enforces a total bootstrap injection cap across files with `agents.defaults.bootstrapTotalMaxChars` (default `60000` chars). `/context` shows **raw vs injected** sizes and whether truncation happened.
+Large files are truncated per-file using `agents.defaults.bootstrapMaxChars` (default `20000` chars). `USER.md` uses a 4,000-character default when neither scope configures `bootstrapMaxChars`; otherwise it uses the per-agent value when present, then the configured default. OpenClaw also enforces a total bootstrap injection cap across files with `agents.defaults.bootstrapTotalMaxChars` (default `60000` chars). `/context` shows **raw vs injected** sizes and whether truncation happened.
 
 When truncation occurs, the runtime can inject an in-prompt warning block under Project Context. Configure this with `agents.defaults.bootstrapPromptTruncationWarning` (`off`, `once`, `always`; default `always`).
 

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -121,7 +121,7 @@ By default, OpenClaw injects a fixed set of workspace files (if present):
 - `USER.md`
 - `BOOTSTRAP.md` (first-run only)
 
-Large files are truncated per-file using `agents.defaults.bootstrapMaxChars` (default `20000` chars). OpenClaw also enforces a total bootstrap injection cap across files with `agents.defaults.bootstrapTotalMaxChars` (default `60000` chars). `/context` shows **raw vs injected** sizes and whether truncation happened.
+Large files are truncated per-file using `agents.defaults.bootstrapMaxChars` (default `20000` chars). `USER.md` uses a 4,000-character default unless an explicit default or per-agent `bootstrapMaxChars` setting is higher. OpenClaw also enforces a total bootstrap injection cap across files with `agents.defaults.bootstrapTotalMaxChars` (default `60000` chars). `/context` shows **raw vs injected** sizes and whether truncation happened.
 
 When truncation occurs, the runtime can inject an in-prompt warning block under Project Context. Configure this with `agents.defaults.bootstrapPromptTruncationWarning` (`off`, `once`, `always`; default `always`).
 

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -114,6 +114,11 @@ Max characters per workspace bootstrap file before truncation. Default: `20000`.
 Per-agent override: `agents.entries.*.bootstrapMaxChars`. Omitted values inherit
 `agents.defaults.bootstrapMaxChars`.
 
+`USER.md` uses a 4,000-character default when neither setting is explicitly
+higher. When `agents.defaults.bootstrapMaxChars` or the agent's
+`agents.entries.*.bootstrapMaxChars` is set above `4000`, the highest configured
+value applies to `USER.md`.
+
 ### `agents.defaults.bootstrapTotalMaxChars`
 
 Max total characters injected across all workspace bootstrap files. Default: `60000`.

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -115,9 +115,8 @@ Per-agent override: `agents.entries.*.bootstrapMaxChars`. Omitted values inherit
 `agents.defaults.bootstrapMaxChars`.
 
 `USER.md` uses a 4,000-character default when neither setting is explicitly
-higher. When `agents.defaults.bootstrapMaxChars` or the agent's
-`agents.entries.*.bootstrapMaxChars` is set above `4000`, the highest configured
-value applies to `USER.md`.
+configured. Otherwise, the agent's `agents.entries.*.bootstrapMaxChars` value
+takes precedence when present, then `agents.defaults.bootstrapMaxChars`.
 
 ### `agents.defaults.bootstrapTotalMaxChars`
 

--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -133,7 +133,7 @@ describe("analyzeBootstrapBudget", () => {
     expect(analysis.truncatedFiles[0]?.causes).toStrictEqual([]);
   });
 
-  it("accounts for the fixed USER.md budget", () => {
+  it("accounts for the default USER.md budget", () => {
     const analysis = analyzeBootstrapBudget({
       files: [
         {
@@ -151,31 +151,34 @@ describe("analyzeBootstrapBudget", () => {
 
     expect(analysis.truncatedFiles[0]?.causes).toContain("per-file-limit");
     const lines = buildBootstrapPromptWarning({ analysis, mode: "always" }).lines;
-    expect(lines).toContain("USER.md has a fixed 4000-character bootstrap cap; keep it compact.");
-    expect(lines.join("\n")).not.toContain("raise agents.defaults.bootstrapMaxChars");
+    expect(lines).toContain(
+      "USER.md uses its default 4000-character bootstrap limit; configure a higher bootstrapMaxChars to expand it.",
+    );
+    expect(lines.join("\n")).toContain("raise agents.defaults.bootstrapMaxChars");
   });
 
-  it("keeps USER.md advice accurate for lower per-file and exhausted total limits", () => {
-    const lowerPerFile = analyzeBootstrapBudget({
+  it("keeps USER.md advice accurate for configured and exhausted total limits", () => {
+    const configuredPerFile = analyzeBootstrapBudget({
       files: [
         {
           name: "USER.md",
           path: "/tmp/USER.md",
           missing: false,
-          rawChars: 3_000,
-          injectedChars: 2_000,
+          rawChars: 9_000,
+          injectedChars: 8_000,
           truncated: true,
         },
       ],
-      bootstrapMaxChars: 2_000,
+      bootstrapMaxChars: 20_000,
       bootstrapTotalMaxChars: 60_000,
+      userBootstrapMaxChars: 8_000,
     });
-    const lowerLines = buildBootstrapPromptWarning({
-      analysis: lowerPerFile,
+    const configuredLines = buildBootstrapPromptWarning({
+      analysis: configuredPerFile,
       mode: "always",
     }).lines;
-    expect(lowerLines.join("\n")).not.toContain("fixed 4000-character");
-    expect(lowerLines.join("\n")).toContain("raise agents.defaults.bootstrapMaxChars");
+    expect(configuredLines.join("\n")).not.toContain("default 4000-character");
+    expect(configuredLines.join("\n")).toContain("raise agents.defaults.bootstrapMaxChars");
 
     const exhaustedTotal = analyzeBootstrapBudget({
       files: [
@@ -204,7 +207,7 @@ describe("analyzeBootstrapBudget", () => {
       mode: "always",
     }).lines;
     expect(exhaustedTotal.truncatedFiles[0]?.causes).toContain("total-limit");
-    expect(exhaustedLines.join("\n")).toContain("fixed 4000-character");
+    expect(exhaustedLines.join("\n")).toContain("default 4000-character");
     expect(exhaustedLines.join("\n")).toContain("bootstrapTotalMaxChars");
 
     const laterExhaustion = analyzeBootstrapBudget({

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -82,10 +82,12 @@ function isUserBootstrapName(name: string | undefined): boolean {
   return name?.toLowerCase() === "user.md";
 }
 
-function effectiveBootstrapFileLimit(name: string, bootstrapMaxChars: number): number {
-  return name.toLowerCase() === "user.md"
-    ? Math.min(bootstrapMaxChars, USER_BOOTSTRAP_MAX_CHARS)
-    : bootstrapMaxChars;
+function effectiveBootstrapFileLimit(
+  name: string,
+  bootstrapMaxChars: number,
+  userBootstrapMaxChars: number,
+): number {
+  return name.toLowerCase() === "user.md" ? userBootstrapMaxChars : bootstrapMaxChars;
 }
 
 function normalizeSeenSignatures(signatures?: string[]): string[] {
@@ -196,10 +198,14 @@ export function analyzeBootstrapBudget(params: {
   files: BootstrapInjectionStat[];
   bootstrapMaxChars: number;
   bootstrapTotalMaxChars: number;
+  userBootstrapMaxChars?: number;
   nearLimitRatio?: number;
 }): BootstrapBudgetAnalysis {
   const bootstrapMaxChars = normalizePositiveLimit(params.bootstrapMaxChars);
   const bootstrapTotalMaxChars = normalizePositiveLimit(params.bootstrapTotalMaxChars);
+  const userBootstrapMaxChars = normalizePositiveLimit(
+    params.userBootstrapMaxChars ?? USER_BOOTSTRAP_MAX_CHARS,
+  );
   const nearLimitRatio =
     typeof params.nearLimitRatio === "number" &&
     Number.isFinite(params.nearLimitRatio) &&
@@ -213,7 +219,11 @@ export function analyzeBootstrapBudget(params: {
   const totalNearLimit = injectedChars >= Math.ceil(bootstrapTotalMaxChars * nearLimitRatio);
   let remainingTotalChars = bootstrapTotalMaxChars;
   const files = params.files.map((file) => {
-    const effectiveFileLimit = effectiveBootstrapFileLimit(file.name, bootstrapMaxChars);
+    const effectiveFileLimit = effectiveBootstrapFileLimit(
+      file.name,
+      bootstrapMaxChars,
+      userBootstrapMaxChars,
+    );
     const availableTotalChars = remainingTotalChars;
     remainingTotalChars = Math.max(0, remainingTotalChars - file.injectedChars);
     if (file.missing) {
@@ -328,28 +338,20 @@ function formatBootstrapTruncationWarningLines(params: {
   if (params.analysis.truncatedFiles.some((file) => isAgentsBootstrapName(file.name))) {
     lines.push("AGENTS.md was truncated; read the full AGENTS.md before relying on scoped policy.");
   }
-  const fixedUserCapApplied = params.analysis.truncatedFiles.some(
+  const defaultUserLimitApplied = params.analysis.truncatedFiles.some(
     (file) =>
       isUserBootstrapName(file.name) &&
       file.effectiveFileLimit === USER_BOOTSTRAP_MAX_CHARS &&
       file.causes.includes("per-file-limit"),
   );
-  if (fixedUserCapApplied) {
+  if (defaultUserLimitApplied) {
     lines.push(
-      `USER.md has a fixed ${USER_BOOTSTRAP_MAX_CHARS}-character bootstrap cap; keep it compact.`,
+      `USER.md uses its default ${USER_BOOTSTRAP_MAX_CHARS}-character bootstrap limit; configure a higher bootstrapMaxChars to expand it.`,
     );
   }
-  const configurableLimitApplied = params.analysis.truncatedFiles.some(
-    (file) =>
-      !isUserBootstrapName(file.name) ||
-      file.effectiveFileLimit < USER_BOOTSTRAP_MAX_CHARS ||
-      file.causes.includes("total-limit"),
+  lines.push(
+    "If unintentional, raise agents.defaults.bootstrapMaxChars and/or agents.defaults.bootstrapTotalMaxChars.",
   );
-  if (configurableLimitApplied) {
-    lines.push(
-      "If unintentional, raise agents.defaults.bootstrapMaxChars and/or agents.defaults.bootstrapTotalMaxChars.",
-    );
-  }
   return lines;
 }
 

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   clearInternalHooks,
   registerInternalHook,
@@ -400,6 +401,27 @@ describe("resolveBootstrapContextForRun", () => {
     );
 
     expect(extra?.content).toBe("extra");
+  });
+
+  it("honors an explicitly higher USER.md bootstrap limit", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const content = "u".repeat(10_000);
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), content, "utf8");
+
+    const result = await resolveBootstrapContextForRun({
+      workspaceDir,
+      agentId: "main",
+      config: {
+        agents: {
+          defaults: { bootstrapMaxChars: 12_000 },
+          entries: { main: { default: true } },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(result.contextFiles.find((file) => file.path.endsWith("USER.md"))?.content).toBe(
+      content,
+    );
   });
 
   it("keeps BOOTSTRAP.md available in shared injected context for non-attempt consumers", async () => {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -18,6 +18,7 @@ import {
   buildBootstrapContextFiles,
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
+  resolveUserBootstrapMaxChars,
 } from "./embedded-agent-helpers.js";
 import {
   DEFAULT_BOOTSTRAP_FILENAME,
@@ -319,6 +320,7 @@ export function buildBootstrapContextForFiles(
   const contextFiles = buildBootstrapContextFiles(bootstrapFiles, {
     maxChars: resolveBootstrapMaxChars(params.config, params.agentId),
     totalMaxChars: resolveBootstrapTotalMaxChars(params.config, params.agentId),
+    userMaxChars: resolveUserBootstrapMaxChars(params.config, params.agentId),
     warn: params.warn,
   });
   return contextFiles;

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -88,6 +88,7 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
+  resolveUserBootstrapMaxChars,
 } from "../embedded-agent-helpers.js";
 import { resolvePromptBuildHookResult } from "../embedded-agent-runner/run/attempt.prompt-helpers.js";
 import {
@@ -827,6 +828,7 @@ export async function prepareCliRunContext(
     : bootstrapFiles.filter((file) => file.name !== DEFAULT_BOOTSTRAP_FILENAME);
   const bootstrapMaxChars = resolveBootstrapMaxChars(params.config, sessionAgentId);
   const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config, sessionAgentId);
+  const userBootstrapMaxChars = resolveUserBootstrapMaxChars(params.config, sessionAgentId);
   const bootstrapAnalysis = analyzeBootstrapBudget({
     files: buildBootstrapInjectionStats({
       bootstrapFiles: bootstrapFilesForInjectionStats,
@@ -834,6 +836,7 @@ export async function prepareCliRunContext(
     }),
     bootstrapMaxChars,
     bootstrapTotalMaxChars,
+    userBootstrapMaxChars,
   });
   const bootstrapPromptWarningMode = resolveBootstrapPromptTruncationWarningMode(params.config);
   const bootstrapPromptWarning = buildBootstrapPromptWarning({

--- a/src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
@@ -6,6 +6,7 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
+  resolveUserBootstrapMaxChars,
 } from "./embedded-agent-helpers.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 import { DEFAULT_AGENTS_FILENAME } from "./workspace.js";
@@ -135,6 +136,15 @@ describe("buildBootstrapContextFiles", () => {
     expect(result[0]?.content).toContain("read USER.md for full content");
     expect(result[1]?.content).toBe("m".repeat(10_000));
   });
+  it("honors an explicit USER.md budget above the default", () => {
+    const content = "u".repeat(10_000);
+    const result = buildBootstrapContextFiles(
+      [makeFile({ name: "USER.md", path: "/tmp/USER.md", content })],
+      { userMaxChars: 12_000 },
+    );
+
+    expect(result[0]?.content).toBe(content);
+  });
   it("keeps policy digest lines from oversized AGENTS.md middle content", () => {
     // AGENTS.md truncation keeps scoped-policy signals from the middle so model
     // prompts do not lose routing instructions just because head/tail are large.
@@ -162,8 +172,8 @@ describe("buildBootstrapContextFiles", () => {
     const content = `HEAD-${"a".repeat(1_000)}-TAIL`;
     const files = [
       makeFile({
-        name: "USER.md",
-        path: "/tmp/USER.md",
+        name: "SOUL.md",
+        path: "/tmp/SOUL.md",
         content,
       }),
     ];
@@ -178,8 +188,8 @@ describe("buildBootstrapContextFiles", () => {
     const content = `HEAD-${"a".repeat(1_000)}-TAIL`;
     const files = [
       makeFile({
-        name: "USER.md",
-        path: "/tmp/USER.md",
+        name: "SOUL.md",
+        path: "/tmp/SOUL.md",
         content,
       }),
     ];
@@ -367,6 +377,27 @@ describe("bootstrap limit resolvers", () => {
       } as OpenClawConfig;
       expect(resolver.resolve(cfg)).toBe(resolver.defaultValue);
     }
+  });
+});
+
+describe("resolveUserBootstrapMaxChars", () => {
+  it("uses 4000 when no higher limit is explicitly configured", () => {
+    expect(resolveUserBootstrapMaxChars()).toBe(4_000);
+  });
+
+  it("uses the highest explicit agent or default limit", () => {
+    const cfg = {
+      agents: {
+        defaults: { bootstrapMaxChars: 12_000 },
+        entries: {
+          worker: { bootstrapMaxChars: 8_000 },
+          larger: { bootstrapMaxChars: 16_000 },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveUserBootstrapMaxChars(cfg, "worker")).toBe(12_000);
+    expect(resolveUserBootstrapMaxChars(cfg, "larger")).toBe(16_000);
   });
 });
 

--- a/src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts
@@ -381,23 +381,26 @@ describe("bootstrap limit resolvers", () => {
 });
 
 describe("resolveUserBootstrapMaxChars", () => {
-  it("uses 4000 when no higher limit is explicitly configured", () => {
+  it("uses 4000 when no limit is explicitly configured", () => {
     expect(resolveUserBootstrapMaxChars()).toBe(4_000);
   });
 
-  it("uses the highest explicit agent or default limit", () => {
+  it("uses the agent override before the default limit", () => {
     const cfg = {
       agents: {
         defaults: { bootstrapMaxChars: 12_000 },
         entries: {
           worker: { bootstrapMaxChars: 8_000 },
           larger: { bootstrapMaxChars: 16_000 },
+          smaller: { bootstrapMaxChars: 2_000 },
         },
       },
     } as OpenClawConfig;
 
-    expect(resolveUserBootstrapMaxChars(cfg, "worker")).toBe(12_000);
+    expect(resolveUserBootstrapMaxChars(cfg, "missing")).toBe(12_000);
+    expect(resolveUserBootstrapMaxChars(cfg, "worker")).toBe(8_000);
     expect(resolveUserBootstrapMaxChars(cfg, "larger")).toBe(16_000);
+    expect(resolveUserBootstrapMaxChars(cfg, "smaller")).toBe(2_000);
   });
 });
 

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -5,6 +5,7 @@ export {
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
+  resolveUserBootstrapMaxChars,
 } from "./embedded-agent-helpers/bootstrap.js";
 export {
   BILLING_ERROR_USER_MESSAGE,

--- a/src/agents/embedded-agent-helpers/bootstrap.ts
+++ b/src/agents/embedded-agent-helpers/bootstrap.ts
@@ -88,8 +88,8 @@ export function stripThoughtSignatures<T>(
 
 const DEFAULT_BOOTSTRAP_MAX_CHARS = 20_000;
 const DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS = 60_000;
-// USER.md stays directive-sized by default, while an explicit operator-selected
-// bootstrapMaxChars above this floor remains authoritative.
+// USER.md stays directive-sized by default, while an explicit effective
+// bootstrapMaxChars remains authoritative.
 export const USER_BOOTSTRAP_MAX_CHARS = 4_000;
 const DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE = "always";
 const MIN_BOOTSTRAP_FILE_BUDGET_CHARS = 64;
@@ -139,14 +139,12 @@ export function resolveUserBootstrapMaxChars(
   cfg?: OpenClawConfig,
   agentId?: string | null,
 ): number {
-  const agentMaxChars =
+  const raw =
     cfg && agentId
-      ? normalizeConfiguredBootstrapLimit(resolveAgentConfig(cfg, agentId)?.bootstrapMaxChars)
-      : undefined;
-  const defaultMaxChars = normalizeConfiguredBootstrapLimit(
-    cfg?.agents?.defaults?.bootstrapMaxChars,
-  );
-  return Math.max(USER_BOOTSTRAP_MAX_CHARS, agentMaxChars ?? 0, defaultMaxChars ?? 0);
+      ? (resolveAgentConfig(cfg, agentId)?.bootstrapMaxChars ??
+        cfg.agents?.defaults?.bootstrapMaxChars)
+      : cfg?.agents?.defaults?.bootstrapMaxChars;
+  return normalizeConfiguredBootstrapLimit(raw) ?? USER_BOOTSTRAP_MAX_CHARS;
 }
 
 export function resolveBootstrapTotalMaxChars(

--- a/src/agents/embedded-agent-helpers/bootstrap.ts
+++ b/src/agents/embedded-agent-helpers/bootstrap.ts
@@ -88,8 +88,8 @@ export function stripThoughtSignatures<T>(
 
 const DEFAULT_BOOTSTRAP_MAX_CHARS = 20_000;
 const DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS = 60_000;
-// USER.md stays directive-sized so profile guidance cannot crowd out project
-// rules or durable facts from the shared bootstrap budget.
+// USER.md stays directive-sized by default, while an explicit operator-selected
+// bootstrapMaxChars above this floor remains authoritative.
 export const USER_BOOTSTRAP_MAX_CHARS = 4_000;
 const DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE = "always";
 const MIN_BOOTSTRAP_FILE_BUDGET_CHARS = 64;
@@ -119,16 +119,34 @@ type PolicyDigest = {
   omittedLines: number;
 };
 
+function normalizeConfiguredBootstrapLimit(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  return undefined;
+}
+
 export function resolveBootstrapMaxChars(cfg?: OpenClawConfig, agentId?: string | null): number {
   const raw =
     cfg && agentId
       ? (resolveAgentConfig(cfg, agentId)?.bootstrapMaxChars ??
         cfg.agents?.defaults?.bootstrapMaxChars)
       : cfg?.agents?.defaults?.bootstrapMaxChars;
-  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
-    return Math.floor(raw);
-  }
-  return DEFAULT_BOOTSTRAP_MAX_CHARS;
+  return normalizeConfiguredBootstrapLimit(raw) ?? DEFAULT_BOOTSTRAP_MAX_CHARS;
+}
+
+export function resolveUserBootstrapMaxChars(
+  cfg?: OpenClawConfig,
+  agentId?: string | null,
+): number {
+  const agentMaxChars =
+    cfg && agentId
+      ? normalizeConfiguredBootstrapLimit(resolveAgentConfig(cfg, agentId)?.bootstrapMaxChars)
+      : undefined;
+  const defaultMaxChars = normalizeConfiguredBootstrapLimit(
+    cfg?.agents?.defaults?.bootstrapMaxChars,
+  );
+  return Math.max(USER_BOOTSTRAP_MAX_CHARS, agentMaxChars ?? 0, defaultMaxChars ?? 0);
 }
 
 export function resolveBootstrapTotalMaxChars(
@@ -140,10 +158,7 @@ export function resolveBootstrapTotalMaxChars(
       ? (resolveAgentConfig(cfg, agentId)?.bootstrapTotalMaxChars ??
         cfg.agents?.defaults?.bootstrapTotalMaxChars)
       : cfg?.agents?.defaults?.bootstrapTotalMaxChars;
-  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
-    return Math.floor(raw);
-  }
-  return DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS;
+  return normalizeConfiguredBootstrapLimit(raw) ?? DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS;
 }
 
 export function resolveBootstrapPromptTruncationWarningMode(
@@ -387,9 +402,15 @@ function clampToBudget(content: string, budget: number): string {
 
 export function buildBootstrapContextFiles(
   files: WorkspaceBootstrapFile[],
-  opts?: { warn?: (message: string) => void; maxChars?: number; totalMaxChars?: number },
+  opts?: {
+    warn?: (message: string) => void;
+    maxChars?: number;
+    totalMaxChars?: number;
+    userMaxChars?: number;
+  },
 ): EmbeddedContextFile[] {
   const maxChars = opts?.maxChars ?? DEFAULT_BOOTSTRAP_MAX_CHARS;
+  const userMaxChars = opts?.userMaxChars ?? USER_BOOTSTRAP_MAX_CHARS;
   const totalMaxChars = Math.max(
     1,
     Math.floor(opts?.totalMaxChars ?? Math.max(maxChars, DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS)),
@@ -426,9 +447,7 @@ export function buildBootstrapContextFiles(
       );
       break;
     }
-    const fileBudget = isUserBootstrapFile(file.name)
-      ? Math.min(maxChars, USER_BOOTSTRAP_MAX_CHARS)
-      : maxChars;
+    const fileBudget = isUserBootstrapFile(file.name) ? userMaxChars : maxChars;
     const fileMaxChars = Math.max(1, Math.min(fileBudget, remainingTotalChars));
     const trimmed = trimBootstrapContent(file.content ?? "", file.name, fileMaxChars);
     const contentWithinBudget = clampToBudget(trimmed.content, remainingTotalChars);

--- a/src/agents/embedded-agent-runner/run/attempt-bootstrap-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bootstrap-prepare.ts
@@ -20,6 +20,7 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
+  resolveUserBootstrapMaxChars,
 } from "../../embedded-agent-helpers.js";
 import {
   DEFAULT_BOOTSTRAP_FILENAME,
@@ -150,6 +151,7 @@ export async function prepareEmbeddedAttemptBootstrap(params: {
     attempt.config,
     params.sessionAgentId,
   );
+  const userBootstrapMaxChars = resolveUserBootstrapMaxChars(attempt.config, params.sessionAgentId);
   const bootstrapAnalysis = analyzeBootstrapBudget({
     files: buildBootstrapInjectionStats({
       bootstrapFiles: bootstrapFilesForInjectionStats,
@@ -157,6 +159,7 @@ export async function prepareEmbeddedAttemptBootstrap(params: {
     }),
     bootstrapMaxChars,
     bootstrapTotalMaxChars,
+    userBootstrapMaxChars,
   });
   const bootstrapPromptWarningMode = resolveBootstrapPromptTruncationWarningMode(attempt.config);
   const bootstrapPromptWarning = buildBootstrapPromptWarning({

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -6,6 +6,7 @@ import { isRealConversationMessage } from "../../agents/compaction-real-conversa
 import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
+  resolveUserBootstrapMaxChars,
 } from "../../agents/embedded-agent-helpers/bootstrap.js";
 import {
   createMessageCharEstimateCache,
@@ -317,6 +318,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     files: report.injectedWorkspaceFiles,
     bootstrapMaxChars,
     bootstrapTotalMaxChars,
+    userBootstrapMaxChars: resolveUserBootstrapMaxChars(params.cfg, sessionAgentId),
   });
   const truncatedBootstrapFiles = bootstrapAnalysis.truncatedFiles;
   const truncationCauseCounts = truncatedBootstrapFiles.reduce(

--- a/src/commands/doctor-bootstrap-size.test.ts
+++ b/src/commands/doctor-bootstrap-size.test.ts
@@ -11,6 +11,7 @@ const listAgentIds = vi.hoisted(() => vi.fn(() => ["main"]));
 const resolveBootstrapContextForRun = vi.hoisted(() => vi.fn());
 const resolveBootstrapMaxChars = vi.hoisted(() => vi.fn(() => 20_000));
 const resolveBootstrapTotalMaxChars = vi.hoisted(() => vi.fn(() => 150_000));
+const resolveUserBootstrapMaxChars = vi.hoisted(() => vi.fn(() => 4_000));
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note,
@@ -29,6 +30,7 @@ vi.mock("../agents/bootstrap-files.js", () => ({
 vi.mock("../agents/embedded-agent-helpers.js", () => ({
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
+  resolveUserBootstrapMaxChars,
 }));
 
 import { noteBootstrapFileSize } from "./doctor-bootstrap-size.js";

--- a/src/commands/doctor-bootstrap-size.ts
+++ b/src/commands/doctor-bootstrap-size.ts
@@ -13,6 +13,7 @@ import { resolveBootstrapContextForRun } from "../agents/bootstrap-files.js";
 import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
+  resolveUserBootstrapMaxChars,
 } from "../agents/embedded-agent-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
@@ -51,6 +52,7 @@ export async function noteBootstrapFileSize(cfg: OpenClawConfig) {
   for (const { agentId, workspaceDir } of workspaces) {
     const bootstrapMaxChars = resolveBootstrapMaxChars(cfg, agentId);
     const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(cfg, agentId);
+    const userBootstrapMaxChars = resolveUserBootstrapMaxChars(cfg, agentId);
     const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
       workspaceDir,
       config: cfg,
@@ -64,6 +66,7 @@ export async function noteBootstrapFileSize(cfg: OpenClawConfig) {
       files: stats,
       bootstrapMaxChars,
       bootstrapTotalMaxChars,
+      userBootstrapMaxChars,
     });
     if (agentId === defaultAgentId) {
       defaultAnalysis = analysis;
@@ -93,7 +96,7 @@ export async function noteBootstrapFileSize(cfg: OpenClawConfig) {
     if (nonTruncatedNearLimit.length > 0) {
       for (const file of nonTruncatedNearLimit) {
         lines.push(
-          `- ${file.name}: ${formatInt(file.rawChars)} chars (${formatPercent(file.rawChars, bootstrapMaxChars)} of max/file ${formatInt(bootstrapMaxChars)})`,
+          `- ${file.name}: ${formatInt(file.rawChars)} chars (${formatPercent(file.rawChars, file.effectiveFileLimit)} of max/file ${formatInt(file.effectiveFileLimit)})`,
         );
       }
     }

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -254,7 +254,7 @@ export const CORE_FIELD_HELP: Record<string, string> = {
   "agents.entries.*.contextInjection":
     "Per-agent override for when workspace bootstrap files are injected into this agent's system prompt. Omit to inherit agents.defaults.contextInjection.",
   "agents.entries.*.bootstrapMaxChars":
-    "Per-agent max characters for each workspace bootstrap file injected into this agent's system prompt. USER.md keeps a 4000-character default unless this value or agents.defaults.bootstrapMaxChars is higher.",
+    "Per-agent max characters for each workspace bootstrap file injected into this agent's system prompt. USER.md uses this value when present, then agents.defaults.bootstrapMaxChars, then its 4000-character default.",
   "agents.entries.*.bootstrapTotalMaxChars":
     "Per-agent override for max total characters across all workspace bootstrap files injected into this agent's system prompt. Omit to inherit agents.defaults.bootstrapTotalMaxChars.",
   "agents.entries.*.experimental":

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -254,7 +254,7 @@ export const CORE_FIELD_HELP: Record<string, string> = {
   "agents.entries.*.contextInjection":
     "Per-agent override for when workspace bootstrap files are injected into this agent's system prompt. Omit to inherit agents.defaults.contextInjection.",
   "agents.entries.*.bootstrapMaxChars":
-    "Per-agent override for max characters of each workspace bootstrap file injected into this agent's system prompt. Omit to inherit agents.defaults.bootstrapMaxChars.",
+    "Per-agent max characters for each workspace bootstrap file injected into this agent's system prompt. USER.md keeps a 4000-character default unless this value or agents.defaults.bootstrapMaxChars is higher.",
   "agents.entries.*.bootstrapTotalMaxChars":
     "Per-agent override for max total characters across all workspace bootstrap files injected into this agent's system prompt. Omit to inherit agents.defaults.bootstrapTotalMaxChars.",
   "agents.entries.*.experimental":

--- a/src/config/schema.help.models.ts
+++ b/src/config/schema.help.models.ts
@@ -162,7 +162,7 @@ export const MODEL_FIELD_HELP: Record<string, string> = {
   "agents.defaults.contextInjection":
     'Controls when workspace bootstrap files are injected into the system prompt: "always" (default) or "continuation-skip" for safe continuation turns after a completed assistant response.',
   "agents.defaults.bootstrapMaxChars":
-    "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000). USER.md uses 4000 unless this value or its agent override is explicitly higher.",
+    "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000). USER.md uses an explicit agent override first, then this configured value, then 4000.",
   "agents.defaults.bootstrapTotalMaxChars":
     "Max total characters across all injected workspace bootstrap files (default: 60000).",
   "agents.defaults.experimental":

--- a/src/config/schema.help.models.ts
+++ b/src/config/schema.help.models.ts
@@ -162,7 +162,7 @@ export const MODEL_FIELD_HELP: Record<string, string> = {
   "agents.defaults.contextInjection":
     'Controls when workspace bootstrap files are injected into the system prompt: "always" (default) or "continuation-skip" for safe continuation turns after a completed assistant response.',
   "agents.defaults.bootstrapMaxChars":
-    "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
+    "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000). USER.md uses 4000 unless this value or its agent override is explicitly higher.",
   "agents.defaults.bootstrapTotalMaxChars":
     "Max total characters across all injected workspace bootstrap files (default: 60000).",
   "agents.defaults.experimental":

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -552,8 +552,11 @@ const bootstrapSizeCheck: HealthCheck = {
     const { buildBootstrapInjectionStats, analyzeBootstrapBudget } =
       await import("../agents/bootstrap-budget.js");
     const { resolveBootstrapContextForRun } = await import("../agents/bootstrap-files.js");
-    const { resolveBootstrapMaxChars, resolveBootstrapTotalMaxChars } =
-      await import("../agents/embedded-agent-helpers.js");
+    const {
+      resolveBootstrapMaxChars,
+      resolveBootstrapTotalMaxChars,
+      resolveUserBootstrapMaxChars,
+    } = await import("../agents/embedded-agent-helpers.js");
     const defaultAgentId = resolveDefaultAgentId(ctx.cfg);
     const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, defaultAgentId);
     const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
@@ -568,6 +571,7 @@ const bootstrapSizeCheck: HealthCheck = {
       }),
       bootstrapMaxChars: resolveBootstrapMaxChars(ctx.cfg, defaultAgentId),
       bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(ctx.cfg, defaultAgentId),
+      userBootstrapMaxChars: resolveUserBootstrapMaxChars(ctx.cfg, defaultAgentId),
     });
     const findings: HealthFinding[] = [];
     for (const file of analysis.truncatedFiles) {


### PR DESCRIPTION
Related: #84424
Related: #114819

> AI-assisted by Codex. I reviewed the resulting implementation and understand the behavior and tests described below.

## What Problem This Solves

Users who explicitly configure `agents.entries.*.bootstrapMaxChars` or
`agents.defaults.bootstrapMaxChars` can still have `USER.md` forcibly truncated
at 4,000 characters.

On the pre-change base, runtime injection applied:

```ts
Math.min(maxChars, USER_BOOTSTRAP_MAX_CHARS)
```

to every `USER.md`. That made the configured setting able to lower the file's
limit, but unable to raise it. This conflicts with Doctor's actionable guidance
to tune the agent-specific or default `bootstrapMaxChars`, and with #84424's
intent that Doctor diagnose bootstrap size using the same effective per-agent
profile as runtime.

The concrete report that prompted this change had:

```text
USER.md: 7,743 raw / 3,999 injected (48% truncated; max/file)
Total bootstrap injected chars: 160,859 (40% of max/total 400,000)
```

despite `bootstrapMaxChars` being explicitly set to `200000`. The total budget
was not exhausted; the separate 4,000-character ceiling caused the truncation.

## Why This Change Was Made

`USER.md` now preserves its 4,000-character unconfigured default while following
the established bootstrap override contract:

1. use the selected agent's explicit
   `agents.entries.*.bootstrapMaxChars`, when present;
2. otherwise use explicitly configured
   `agents.defaults.bootstrapMaxChars`;
3. otherwise use `USER_BOOTSTRAP_MAX_CHARS` (`4000`).

This is intentionally **not** `Math.max(agent, defaults, 4000)`. A per-agent
value is an override, so an agent set to `8000` must remain at `8000` even when
defaults are `12000`; an explicit lower value such as `2000` must also remain
effective. This preserves the pre-existing ability to constrain `USER.md` while
making explicit values above 4,000 actionable.

The same resolved value is used by:

- runtime bootstrap injection;
- Doctor and health diagnostics;
- CLI and embedded-run prompt warnings;
- `/context` reporting.

Existing boundaries remain:

- unconfigured users retain the 4,000-character `USER.md` default;
- other bootstrap files keep their existing effective per-file limit;
- `bootstrapTotalMaxChars` still bounds the complete bootstrap payload;
- no new setting, config migration, or persisted state is introduced.

## User Impact

Operators can determine how much of an agent's `USER.md` is injected using the
existing documented setting. A deliberately larger setting is respected, and a
deliberately smaller per-agent override is not silently replaced by a larger
default. Operators continue to own the context-size, token, latency, and cost
tradeoffs of the values they select.

## Evidence

### Source and history before implementation

- Pre-change `main` declared `USER_BOOTSTRAP_MAX_CHARS = 4_000` and applied
  `Math.min(maxChars, USER_BOOTSTRAP_MAX_CHARS)` to every `USER.md`.
- On 2026-03-15, commit
  `1f68e6e89cfb83290ce2879eb83b06a970bef5ee` used the configured per-file
  limit without a separate `USER.md` ceiling.
- The fixed ceiling was introduced by #114819 / commit
  `28630a9a6501dd3835d1cf5660eb5dd9c337d3bc`.
- #84424 made Doctor honor each agent's effective bootstrap profile. The
  resulting recommendation to tune agent/default `bootstrapMaxChars` should
  therefore change `USER.md` behavior rather than being overridden by an
  undocumented hard stop.

### Original PR-head behavior before this correction

The first implementation head,
`74bc96d034caf40d3aa5cdff64dd134967abe1d4`, fixed values above 4,000 but
incorrectly used the maximum of agent and defaults. The real bootstrap path
produced:

```json
{"proof":"environment","head":"74bc96d034caf40d3aa5cdff64dd134967abe1d4","stateDir":"<disposable>","liveInstallationUsed":false}
{"scenario":"default-above-4000","resolvedUserLimit":12000,"rawChars":10000,"injectedChars":10000,"injectedIntact":true,"containsTruncationMarker":false}
{"scenario":"agent-override-below-default","resolvedUserLimit":12000,"rawChars":10000,"injectedChars":10000,"injectedIntact":true,"containsTruncationMarker":false}
{"scenario":"unconfigured-default","resolvedUserLimit":4000,"rawChars":10000,"injectedChars":4000,"injectedIntact":false,"containsTruncationMarker":true}
```

The second line proves the desired above-4,000 behavior. The third line proves
the compatibility defect: an explicit `8000` agent override lost to the
`12000` default and incorrectly injected all 10,000 characters.

ClawSweeper identified this as
`[P1] Preserve the explicit per-agent bootstrap limit` in its
[durable review comment](https://github.com/openclaw/openclaw/pull/116537#issuecomment-5135660149).

### Original-head CI failures

- `checks-node-compact-small-12` failed four
  `doctor-bootstrap-size.test.ts` cases because the explicit module mock omitted
  the newly used `resolveUserBootstrapMaxChars` export. The corrected head
  registers that binding and the four tests pass.
- `check-lint` ended with runner shutdown/cancellation (`exit 143`) while
  oxlint was running; it did not report a lint finding.
- The original head's GitHub `check-test-types` job passed.

### Current base and corrected head

- Rebased base: `31ccf56a8110bb9c425adde725f8fbfb218b1367`
- Corrected head: `d7e25e274ca76c488ba81ab0da9beacd21fb7919`
- Correction commit: `fix(agents): preserve bootstrap override precedence`

### Final-head real behavior proof

The proof creates an ephemeral workspace, writes only synthetic `AGENTS.md` and
`USER.md` files, and invokes `resolveBootstrapContextForRun`, the production
bootstrap loading and bounding path. It uses an explicit disposable
`OPENCLAW_STATE_DIR`; it does not invoke the installed CLI or gateway and does
not read or mount `~/.openclaw`.

```json
{"proof":"environment","head":"d7e25e274ca76c488ba81ab0da9beacd21fb7919","stateDir":"<disposable>","liveInstallationUsed":false}
{"scenario":"default-above-4000","resolvedUserLimit":12000,"rawChars":10000,"injectedChars":10000,"injectedIntact":true,"containsTruncationMarker":false}
{"scenario":"agent-override-below-default","resolvedUserLimit":8000,"rawChars":10000,"injectedChars":7999,"injectedIntact":false,"containsTruncationMarker":true}
{"scenario":"agent-override-below-4000","resolvedUserLimit":2000,"rawChars":10000,"injectedChars":2000,"injectedIntact":false,"containsTruncationMarker":true}
{"scenario":"unconfigured-default","resolvedUserLimit":4000,"rawChars":10000,"injectedChars":4000,"injectedIntact":false,"containsTruncationMarker":true}
```

The bounded 8,000 scenario produces 7,999 injected characters including the
truncation marker; the important invariant is that it remains within the
explicit agent limit and no longer inherits 12,000.

### Focused validation

```text
node scripts/run-vitest.mjs \
  src/agents/embedded-agent-helpers.buildbootstrapcontextfiles.test.ts \
  src/agents/bootstrap-budget.test.ts \
  src/agents/bootstrap-files.test.ts \
  src/commands/doctor-bootstrap-size.test.ts

Test Files  4 passed
Tests       95 passed
Vitest shards 3 passed
```

Additional checks:

```text
pnpm tsgo:core
  passed

pnpm docs:list
  passed

oxfmt --check <18 changed TypeScript/Markdown files>
  all matched files use the correct format

git diff --check
  passed
```

The authoritative pushed-head GitHub CI run is in progress and will provide the
full repository-selected test/type/lint matrix. The installed OpenClaw instance
was deliberately not changed, invoked, stopped, restarted, mounted, or used for
testing.

### AI prompt summary

Preserve the safe 4,000-character `USER.md` default when no bootstrap limit is
configured. When a limit is configured, follow normal precedence: the selected
agent's explicit value overrides the configured default. Use that one effective
value consistently in runtime injection and every diagnostic surface.
