### PR TITLE
fix(msteams): page channel thread replies

### DIFF
--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -173,6 +173,7 @@ describe("fetchThreadReplies", () => {
       token: "tok",
       path: "/teams/group-1/channels/channel-1/messages/msg-1/replies?$top=50&$select=id,from,body,createdDateTime",
       maxPages: 50,
+      retainLast: 50,
     });
   });
 
@@ -225,7 +226,22 @@ describe("fetchThreadReplies", () => {
       token: "tok",
       path: "/teams/g/channels/c/messages/m/replies?$top=50&$select=id,from,body,createdDateTime",
       maxPages: 50,
+      retainLast: 2,
     });
+  });
+
+  it("rejects truncated pagination instead of returning a stale scanned prefix", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: [
+        { id: "reply-1", createdDateTime: "2026-07-01T00:00:00Z" },
+        { id: "reply-2", createdDateTime: "2026-07-01T00:01:00Z" },
+      ],
+      truncated: true,
+    } as never);
+
+    await expect(fetchThreadReplies("tok", "g", "c", "m", 2)).rejects.toThrow(
+      "MS Teams thread replies pagination did not reach the newest replies",
+    );
   });
 
   it("forwards a shared deadline to paginated reply fetches", async () => {
@@ -241,7 +257,8 @@ describe("fetchThreadReplies", () => {
     expect(fetchAllGraphPages).toHaveBeenCalledWith({
       token: "tok",
       path: "/teams/g/channels/c/messages/m/replies?$top=50&$select=id,from,body,createdDateTime",
-      maxPages: 50,
+      maxPages: Number.MAX_SAFE_INTEGER,
+      retainLast: 50,
       deadline,
     });
   });

--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -7,19 +7,12 @@ import {
   formatThreadContext,
   stripHtmlFromTeamsMessage,
 } from "./graph-thread.js";
-import { fetchGraphJson } from "./graph.js";
+import { fetchAllGraphPages, fetchGraphJson } from "./graph.js";
 
 vi.mock("./graph.js", () => ({
+  fetchAllGraphPages: vi.fn(),
   fetchGraphJson: vi.fn(),
 }));
-
-const firstGraphPath = () => {
-  const [call] = vi.mocked(fetchGraphJson).mock.calls;
-  if (!call) {
-    throw new Error("expected Graph fetch call");
-  }
-  return call[0].path;
-};
 
 describe("stripHtmlFromTeamsMessage", () => {
   it("preserves @mention display names from <at> tags", () => {
@@ -163,44 +156,94 @@ describe("fetchChatMessageText", () => {
 
 describe("fetchThreadReplies", () => {
   beforeEach(() => {
+    vi.mocked(fetchAllGraphPages).mockReset();
     vi.mocked(fetchGraphJson).mockReset();
   });
 
   it("fetches replies with correct path and default limit", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({
-      value: [{ id: "reply-1" }, { id: "reply-2" }],
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: [{ id: "reply-1" }, { id: "reply-2" }],
+      truncated: false,
     } as never);
 
     const result = await fetchThreadReplies("tok", "group-1", "channel-1", "msg-1");
 
     expect(result).toHaveLength(2);
-    expect(fetchGraphJson).toHaveBeenCalledWith({
+    expect(fetchAllGraphPages).toHaveBeenCalledWith({
       token: "tok",
       path: "/teams/group-1/channels/channel-1/messages/msg-1/replies?$top=50&$select=id,from,body,createdDateTime",
+      maxPages: 50,
     });
   });
 
-  it("clamps limit to 50 maximum", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({ value: [] } as never);
+  it("clamps returned replies to 50 maximum", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: Array.from({ length: 60 }, (_, index) => ({ id: `reply-${index + 1}` })),
+      truncated: false,
+    } as never);
 
-    await fetchThreadReplies("tok", "g", "c", "m", 200);
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 200);
 
-    expect(firstGraphPath()).toContain("$top=50");
+    expect(result).toHaveLength(50);
+    expect(result[0]?.id).toBe("reply-11");
+    expect(result[result.length - 1]?.id).toBe("reply-60");
   });
 
-  it("clamps limit to 1 minimum", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({ value: [] } as never);
+  it("clamps returned replies to 1 minimum", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: [{ id: "reply-1" }, { id: "reply-2" }],
+      truncated: false,
+    } as never);
 
-    await fetchThreadReplies("tok", "g", "c", "m", 0);
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 0);
 
-    expect(firstGraphPath()).toContain("$top=1");
+    expect(result).toStrictEqual([{ id: "reply-2" }]);
   });
 
-  it("returns empty array when value is missing", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({} as never);
+  it("returns empty array when no replies are returned", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({ items: [], truncated: false } as never);
 
     const result = await fetchThreadReplies("tok", "g", "c", "m");
     expect(result).toStrictEqual([]);
+  });
+
+  it("uses paginated replies and returns the newest limit chronologically", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: [
+        { id: "reply-4", createdDateTime: "2026-07-01T00:03:00Z" },
+        { id: "reply-2", createdDateTime: "2026-07-01T00:01:00Z" },
+        { id: "reply-3", createdDateTime: "2026-07-01T00:02:00Z" },
+        { id: "reply-1", createdDateTime: "2026-07-01T00:00:00Z" },
+      ],
+      truncated: false,
+    } as never);
+
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 2);
+
+    expect(result.map((reply) => reply.id)).toStrictEqual(["reply-3", "reply-4"]);
+    expect(fetchAllGraphPages).toHaveBeenCalledWith({
+      token: "tok",
+      path: "/teams/g/channels/c/messages/m/replies?$top=50&$select=id,from,body,createdDateTime",
+      maxPages: 50,
+    });
+  });
+
+  it("forwards a shared deadline to paginated reply fetches", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({ items: [], truncated: false } as never);
+    const deadline = {
+      label: "MS Teams inbound preprocessing",
+      timeoutMs: 10_000,
+      deadlineAtMs: Date.now() + 10_000,
+    };
+
+    await fetchThreadReplies("tok", "g", "c", "m", 50, deadline);
+
+    expect(fetchAllGraphPages).toHaveBeenCalledWith({
+      token: "tok",
+      path: "/teams/g/channels/c/messages/m/replies?$top=50&$select=id,from,body,createdDateTime",
+      maxPages: 50,
+      deadline,
+    });
   });
 });
 

--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -173,7 +173,10 @@ describe("fetchThreadReplies", () => {
       token: "tok",
       path: "/teams/group-1/channels/channel-1/messages/msg-1/replies?$top=50&$select=id,from,body,createdDateTime",
       maxPages: 50,
-      retainLast: 50,
+      retainLastBy: {
+        limit: 50,
+        compare: expect.any(Function),
+      },
     });
   });
 
@@ -226,8 +229,27 @@ describe("fetchThreadReplies", () => {
       token: "tok",
       path: "/teams/g/channels/c/messages/m/replies?$top=50&$select=id,from,body,createdDateTime",
       maxPages: 50,
-      retainLast: 2,
+      retainLastBy: {
+        limit: 2,
+        compare: expect.any(Function),
+      },
     });
+    const retainLastBy = vi.mocked(fetchAllGraphPages).mock.calls[0]?.[0]?.retainLastBy;
+    if (!retainLastBy) {
+      throw new Error("Expected fetchThreadReplies to retain replies by timestamp");
+    }
+    const oppositeOrder = [
+      { id: "reply-4", createdDateTime: "2026-07-01T00:03:00Z" },
+      { id: "reply-1", createdDateTime: "2026-07-01T00:00:00Z" },
+      { id: "reply-3", createdDateTime: "2026-07-01T00:02:00Z" },
+      { id: "reply-2", createdDateTime: "2026-07-01T00:01:00Z" },
+    ];
+    expect(
+      oppositeOrder
+        .toSorted(retainLastBy.compare)
+        .slice(-2)
+        .map((reply) => reply.id),
+    ).toStrictEqual(["reply-3", "reply-4"]);
   });
 
   it("rejects truncated pagination instead of returning a stale scanned prefix", async () => {
@@ -258,7 +280,10 @@ describe("fetchThreadReplies", () => {
       token: "tok",
       path: "/teams/g/channels/c/messages/m/replies?$top=50&$select=id,from,body,createdDateTime",
       maxPages: Number.MAX_SAFE_INTEGER,
-      retainLast: 50,
+      retainLastBy: {
+        limit: 50,
+        compare: expect.any(Function),
+      },
       deadline,
     });
   });

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -1,6 +1,6 @@
 // Msteams plugin module implements graph thread behavior.
 import { decodeHtmlEntities } from "openclaw/plugin-sdk/html-entity-runtime";
-import { fetchGraphJson, type GraphResponse } from "./graph.js";
+import { fetchAllGraphPages, fetchGraphJson } from "./graph.js";
 import type { MSTeamsRequestDeadline } from "./request-timeout.js";
 
 export type GraphThreadMessage = {
@@ -12,6 +12,21 @@ export type GraphThreadMessage = {
   body?: { content?: string; contentType?: string };
   createdDateTime?: string;
 };
+
+function compareThreadMessagesChronologically(
+  a: GraphThreadMessage,
+  b: GraphThreadMessage,
+): number {
+  if (!a.createdDateTime || !b.createdDateTime) {
+    return 0;
+  }
+  const aTime = Date.parse(a.createdDateTime);
+  const bTime = Date.parse(b.createdDateTime);
+  if (Number.isNaN(aTime) || Number.isNaN(bTime)) {
+    return 0;
+  }
+  return aTime - bTime;
+}
 
 /**
  * Strip HTML tags from Teams message content, preserving @mention display names.
@@ -88,12 +103,9 @@ export async function fetchChatMessageText(
 /**
  * Fetch thread replies for a channel message, ordered chronologically.
  *
- * **Limitation:** The Graph API replies endpoint (`/messages/{id}/replies`) does not
- * support `$orderby`, so results are always returned in ascending (oldest-first) order.
- * Combined with the `$top` cap of 50, this means only the **oldest 50 replies** are
- * returned for long threads — newer replies are silently omitted. There is currently no
- * Graph API workaround for this; pagination via `@odata.nextLink` can retrieve more
- * replies but still in ascending order only.
+ * Graph returns replies oldest-first, has a per-page `$top` cap of 50, and does
+ * not support `$orderby`. Follow `@odata.nextLink` with a bounded page cap, then
+ * keep the newest requested reply window in chronological order.
  */
 export async function fetchThreadReplies(
   token: string,
@@ -103,17 +115,15 @@ export async function fetchThreadReplies(
   limit = 50,
   deadline?: MSTeamsRequestDeadline,
 ): Promise<GraphThreadMessage[]> {
-  const top = Math.min(Math.max(limit, 1), 50);
-  // NOTE: Graph replies endpoint returns oldest-first and does not support $orderby.
-  // For threads with >50 replies, only the oldest 50 are returned. The most recent
-  // replies (often the most relevant context) may be truncated.
-  const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=${top}&$select=id,from,body,createdDateTime`;
-  const res = await fetchGraphJson<GraphResponse<GraphThreadMessage>>({
+  const requestedLimit = Math.min(Math.max(limit, 1), 50);
+  const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=50&$select=id,from,body,createdDateTime`;
+  const res = await fetchAllGraphPages<GraphThreadMessage>({
     token,
     path,
+    maxPages: 50,
     ...(deadline ? { deadline } : {}),
   });
-  return res.value ?? [];
+  return res.items.toSorted(compareThreadMessagesChronologically).slice(-requestedLimit);
 }
 
 /**

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -120,9 +120,13 @@ export async function fetchThreadReplies(
   const res = await fetchAllGraphPages<GraphThreadMessage>({
     token,
     path,
-    maxPages: 50,
+    maxPages: deadline ? Number.MAX_SAFE_INTEGER : 50,
+    retainLast: requestedLimit,
     ...(deadline ? { deadline } : {}),
   });
+  if (res.truncated) {
+    throw new Error("MS Teams thread replies pagination did not reach the newest replies");
+  }
   return res.items.toSorted(compareThreadMessagesChronologically).slice(-requestedLimit);
 }
 

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -103,9 +103,9 @@ export async function fetchChatMessageText(
 /**
  * Fetch thread replies for a channel message, ordered chronologically.
  *
- * Graph returns replies oldest-first, has a per-page `$top` cap of 50, and does
- * not support `$orderby`. Follow `@odata.nextLink` with a bounded page cap, then
- * keep the newest requested reply window in chronological order.
+ * Graph has a per-page `$top` cap of 50 and does not support `$orderby`.
+ * Follow `@odata.nextLink` with a bounded page cap, then keep the newest
+ * requested reply window by timestamp in chronological order.
  */
 export async function fetchThreadReplies(
   token: string,
@@ -121,7 +121,10 @@ export async function fetchThreadReplies(
     token,
     path,
     maxPages: deadline ? Number.MAX_SAFE_INTEGER : 50,
-    retainLast: requestedLimit,
+    retainLastBy: {
+      limit: requestedLimit,
+      compare: compareThreadMessagesChronologically,
+    },
     ...(deadline ? { deadline } : {}),
   });
   if (res.truncated) {

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -583,6 +583,40 @@ describe("msteams graph helpers", () => {
       expect(globalThis.fetch).toHaveBeenCalledTimes(3);
     });
 
+    it("forwards deadline to each paginated request", async () => {
+      const deadline = {
+        label: "MS Teams inbound preprocessing",
+        timeoutMs: 10_000,
+        deadlineAtMs: Date.now() + 10_000,
+      };
+      let callCount = 0;
+
+      mockFetch(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return jsonResponse(
+            pagedResponse(
+              [{ id: "1", name: "a" }],
+              "https://graph.microsoft.com/v1.0/items?$skiptoken=page2",
+            ),
+          );
+        }
+        return jsonResponse(pagedResponse([{ id: "2", name: "b" }]));
+      });
+
+      await fetchAllGraphPages<Item>({
+        token: graphToken,
+        path: "/items",
+        deadline,
+      });
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+      expect(fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.timeoutMs).toBeGreaterThan(0);
+      expect(fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.timeoutMs).toBeLessThanOrEqual(10_000);
+      expect(fetchWithSsrFGuardMock.mock.calls[1]?.[0]?.timeoutMs).toBeGreaterThan(0);
+      expect(fetchWithSsrFGuardMock.mock.calls[1]?.[0]?.timeoutMs).toBeLessThanOrEqual(10_000);
+    });
+
     it("truncation at maxPages", async () => {
       mockFetch(async () =>
         jsonResponse(

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -528,7 +528,7 @@ describe("msteams graph helpers", () => {
   });
 
   describe("fetchAllGraphPages", () => {
-    type Item = { id: string; name: string };
+    type Item = { id: string; name: string; createdDateTime?: string };
 
     /** Build a paged Graph response with optional nextLink. */
     function pagedResponse(items: Item[], nextLink?: string) {
@@ -683,6 +683,60 @@ describe("msteams graph helpers", () => {
           { id: "4", name: "d" },
           { id: "5", name: "e" },
           { id: "6", name: "f" },
+        ],
+        truncated: false,
+      });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("retains only the final requested items by comparator while continuing pagination", async () => {
+      let callCount = 0;
+      mockFetch(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return jsonResponse(
+            pagedResponse(
+              [
+                { id: "1", name: "oldest", createdDateTime: "2026-07-01T00:00:00Z" },
+                { id: "5", name: "newer", createdDateTime: "2026-07-01T00:04:00Z" },
+              ],
+              "https://graph.microsoft.com/v1.0/items?$skiptoken=page2",
+            ),
+          );
+        }
+        if (callCount === 2) {
+          return jsonResponse(
+            pagedResponse(
+              [
+                { id: "2", name: "older", createdDateTime: "2026-07-01T00:01:00Z" },
+                { id: "4", name: "middle", createdDateTime: "2026-07-01T00:03:00Z" },
+              ],
+              "https://graph.microsoft.com/v1.0/items?$skiptoken=page3",
+            ),
+          );
+        }
+        return jsonResponse(
+          pagedResponse([
+            { id: "3", name: "middle-old", createdDateTime: "2026-07-01T00:02:00Z" },
+            { id: "6", name: "newest", createdDateTime: "2026-07-01T00:05:00Z" },
+          ]),
+        );
+      });
+
+      const result = await fetchAllGraphPages<Item>({
+        token: graphToken,
+        path: "/items",
+        retainLastBy: {
+          limit: 2,
+          compare: (a, b) =>
+            Date.parse(a.createdDateTime ?? "") - Date.parse(b.createdDateTime ?? ""),
+        },
+      });
+
+      expect(result).toEqual({
+        items: [
+          { id: "5", name: "newer", createdDateTime: "2026-07-01T00:04:00Z" },
+          { id: "6", name: "newest", createdDateTime: "2026-07-01T00:05:00Z" },
         ],
         truncated: false,
       });

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -638,6 +638,57 @@ describe("msteams graph helpers", () => {
       expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     });
 
+    it("retains only the final requested items while continuing pagination", async () => {
+      let callCount = 0;
+      mockFetch(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return jsonResponse(
+            pagedResponse(
+              [
+                { id: "1", name: "a" },
+                { id: "2", name: "b" },
+              ],
+              "https://graph.microsoft.com/v1.0/items?$skiptoken=page2",
+            ),
+          );
+        }
+        if (callCount === 2) {
+          return jsonResponse(
+            pagedResponse(
+              [
+                { id: "3", name: "c" },
+                { id: "4", name: "d" },
+              ],
+              "https://graph.microsoft.com/v1.0/items?$skiptoken=page3",
+            ),
+          );
+        }
+        return jsonResponse(
+          pagedResponse([
+            { id: "5", name: "e" },
+            { id: "6", name: "f" },
+          ]),
+        );
+      });
+
+      const result = await fetchAllGraphPages<Item>({
+        token: graphToken,
+        path: "/items",
+        retainLast: 3,
+      });
+
+      expect(result).toEqual({
+        items: [
+          { id: "4", name: "d" },
+          { id: "5", name: "e" },
+          { id: "6", name: "f" },
+        ],
+        truncated: false,
+      });
+      expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    });
+
     it("findOne early exit", async () => {
       const target = { id: "target", name: "found-it" };
       let callCount = 0;

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -178,11 +178,17 @@ export async function fetchAllGraphPages<T>(params: {
   maxPages?: number;
   /** Keep only the final N items while pagination continues. */
   retainLast?: number;
+  /** Keep only the final N items by comparator while pagination continues. */
+  retainLastBy?: {
+    limit: number;
+    compare: (a: T, b: T) => number;
+  };
   /** Stop pagination early when this predicate returns true. */
   findOne?: (item: T) => boolean;
 }): Promise<PaginatedResult<T>> {
   const maxPages = params.maxPages ?? 50;
   const retainLast = params.retainLast;
+  const retainLastBy = params.retainLastBy;
   const items: T[] = [];
   let nextPath: string | undefined = params.path;
 
@@ -205,7 +211,10 @@ export async function fetchAllGraphPages<T>(params: {
     }
 
     items.push(...pageItems);
-    if (typeof retainLast === "number" && retainLast > 0 && items.length > retainLast) {
+    if (retainLastBy && retainLastBy.limit > 0 && items.length > retainLastBy.limit) {
+      items.sort(retainLastBy.compare);
+      items.splice(0, items.length - retainLastBy.limit);
+    } else if (typeof retainLast === "number" && retainLast > 0 && items.length > retainLast) {
       items.splice(0, items.length - retainLast);
     }
 

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -176,10 +176,13 @@ export async function fetchAllGraphPages<T>(params: {
   deadline?: MSTeamsRequestDeadline;
   /** Max pages to fetch before stopping. Default: 50. */
   maxPages?: number;
+  /** Keep only the final N items while pagination continues. */
+  retainLast?: number;
   /** Stop pagination early when this predicate returns true. */
   findOne?: (item: T) => boolean;
 }): Promise<PaginatedResult<T>> {
   const maxPages = params.maxPages ?? 50;
+  const retainLast = params.retainLast;
   const items: T[] = [];
   let nextPath: string | undefined = params.path;
 
@@ -202,6 +205,9 @@ export async function fetchAllGraphPages<T>(params: {
     }
 
     items.push(...pageItems);
+    if (typeof retainLast === "number" && retainLast > 0 && items.length > retainLast) {
+      items.splice(0, items.length - retainLast);
+    }
 
     // @odata.nextLink is an absolute URL; strip the Graph root to get a relative path
     const rawNext: string | undefined = res["@odata.nextLink"];

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -172,6 +172,8 @@ export async function fetchAllGraphPages<T>(params: {
   token: string;
   path: string;
   headers?: Record<string, string>;
+  /** Optional shared operation deadline; actively aborts each guarded fetch when spent. */
+  deadline?: MSTeamsRequestDeadline;
   /** Max pages to fetch before stopping. Default: 50. */
   maxPages?: number;
   /** Stop pagination early when this predicate returns true. */
@@ -186,6 +188,7 @@ export async function fetchAllGraphPages<T>(params: {
       token: params.token,
       path: nextPath,
       headers: params.headers,
+      deadline: params.deadline,
     });
 
     const pageItems = res.value ?? [];


### PR DESCRIPTION
Closes #98870

## What Problem This Solves

Teams channel thread context only read a single `/replies?$top=50` page. Long channel threads could therefore omit newer replies from the context passed to the agent.

The earlier repair still had a correctness risk: bounded pagination retained replies by page position before establishing chronological order, so non-chronological Graph page order could still pass stale thread context to the agent.

## Why This Change Was Made

`fetchThreadReplies` now follows `@odata.nextLink` through the shared Graph pagination helper and retains the bounded newest-reply window by `createdDateTime`, not by page position. The helper supports `retainLastBy`, which keeps only the highest-ranked N items by comparator while pagination continues.

If pagination is still truncated, `fetchThreadReplies` rejects instead of returning a stale scanned prefix as current context. In production, where a shared inbound deadline is supplied, it continues through Graph reply pages until terminal pagination or deadline expiry.

## User Impact

Agents get recent replies from long Teams channel threads instead of stale first-page or stale page-order context. If Graph pagination cannot reach the newest replies inside the bounded operation, thread replies are omitted rather than silently presenting older replies as current context. Parent message context still degrades independently.

## Evidence

Current head: `e52a50c318d30b99d71f2550fc75c4ccdcf9e2e4`

Rebased onto current upstream/main: `b08569f6fdc130810ad73fcec34ebcee72fbe25f`

Changed files:

- `extensions/msteams/src/graph.ts`
- `extensions/msteams/src/graph-thread.ts`
- `extensions/msteams/src/graph.test.ts`
- `extensions/msteams/src/graph-thread.test.ts`

Local validation on this head:

- `node scripts/run-vitest.mjs extensions/msteams/src/graph-thread.test.ts extensions/msteams/src/graph.test.ts extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts`
  - passed: 3 files, 64 tests
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/msteams/src/graph.ts extensions/msteams/src/graph-thread.ts extensions/msteams/src/graph-thread.test.ts extensions/msteams/src/graph.test.ts`
  - passed
- `git diff --check upstream/main...HEAD`
  - passed

Coverage for the prior blockers:

- `fetchAllGraphPages` supports `retainLastBy`, retaining only the final requested items by comparator while continuing across multiple pages.
- `fetchThreadReplies` passes a `createdDateTime` chronological comparator to `retainLastBy`, so the bounded window is selected by timestamp before any items are discarded.
- Regression coverage includes a non-page-order / opposite-order reply set and verifies the retained window is the newest replies chronologically.
- `fetchThreadReplies` rejects `truncated: true` rather than returning the stale scanned prefix.
- `fetchThreadReplies` uses `Number.MAX_SAFE_INTEGER` max pages when a shared deadline is available, so the deadline bounds the operation and the helper can reach terminal pagination.

Proof gap:

- I do not have live Teams tenant credentials in this checkout, so validation remains source-level and mocked Graph pagination coverage.
- The branch intentionally does not claim authenticated tenant proof. A maintainer or contributor with a real Teams/Graph tenant should add redacted after-fix output for a thread over 50 replies before merge if required by the project proof gate.

## External API Note

Microsoft Learn documents `chatMessage: list replies` at `GET /teams/{team-id}/channels/{channel-id}/messages/{message-id}/replies`. The endpoint supports `$top` only, with maximum value 50; other OData query parameters are not currently supported.

Official reference: https://learn.microsoft.com/en-us/graph/api/chatmessage-list-replies?view=graph-rest-1.0

The repair therefore follows Graph pagination via `@odata.nextLink` and locally returns the newest requested window in chronological order instead of relying on unsupported server-side ordering.

This PR was AI-assisted. I reviewed the changed owner/caller paths and understand the pagination behavior implemented here.
