### PR TITLE
refactor(gateway): split node pairing reconnect coverage

### DIFF
--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -1,29 +1,24 @@
-// Node pairing authorization tests cover approved node reconnects, visible
-// command scopes, and gateway enforcement around node client identity.
+// Node pairing authorization tests cover approval scopes, cross-device
+// management, and gateway diagnostics around node client identity.
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
-import type { HelloOk } from "../../packages/gateway-protocol/src/index.js";
-import { getPairedDevice, listDevicePairing } from "../infra/device-pairing.js";
 import { NODE_MCP_TOOLS_CALL_COMMAND } from "../infra/node-commands.js";
 import { approveNodePairing, listNodePairing, requestNodePairing } from "../infra/node-pairing.js";
 import { resolveNodeIdFromNodeList } from "../shared/node-resolve.js";
-import {
-  GATEWAY_CLIENT_MODES,
-  GATEWAY_CLIENT_NAMES,
-  type GatewayClientName,
-} from "../utils/message-channel.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { callGateway } from "./call.js";
 import {
   issueOperatorToken,
-  loadDeviceIdentity,
   openTrackedWs,
   pairDeviceIdentity,
 } from "./device-authz.test-helpers.js";
 import {
+  connectNodeClient,
   createNodePairingTestState,
   describeWithGatewayServer,
+  findPairedNode,
+  requireApprovedPairing,
 } from "./server.node-pairing.test-support.js";
-import { connectGatewayClient } from "./test-helpers.e2e.js";
 import {
   connectOk,
   installGatewayTestHooks,
@@ -39,160 +34,6 @@ const {
   seedNodeDevice,
   setup: setupNodePairingTestState,
 } = createNodePairingTestState("openclaw-node-pair-authz-");
-
-async function findPairedNode(nodeId: string, baseDir?: string) {
-  const pairing = await listNodePairing(baseDir);
-  return pairing.paired.find((node) => node.nodeId === nodeId) ?? null;
-}
-
-function requireApprovedPairing(
-  result: Awaited<ReturnType<typeof approveNodePairing>>,
-): Exclude<typeof result, null | { status: "forbidden"; missingScope: string }> {
-  if (!result || "status" in result) {
-    throw new Error(`Expected approved node pairing, got ${JSON.stringify(result)}`);
-  }
-  return result;
-}
-
-async function connectNodeClient(params: {
-  port: number;
-  deviceIdentity: ReturnType<typeof loadDeviceIdentity>["identity"];
-  commands: string[];
-  clientName?: GatewayClientName;
-  displayName?: string;
-  platform?: string;
-  deviceFamily?: string;
-  caps?: string[];
-  onHelloOk?: (hello: HelloOk) => void;
-}) {
-  return await connectGatewayClient({
-    url: `ws://127.0.0.1:${params.port}`,
-    token: "secret",
-    role: "node",
-    clientName: params.clientName ?? GATEWAY_CLIENT_NAMES.NODE_HOST,
-    clientDisplayName: params.displayName ?? "node-command-pin",
-    clientVersion: "1.0.0",
-    platform: params.platform ?? "macos",
-    deviceFamily: params.deviceFamily ?? "Mac",
-    mode: GATEWAY_CLIENT_MODES.NODE,
-    scopes: [],
-    caps: params.caps,
-    commands: params.commands,
-    deviceIdentity: params.deviceIdentity,
-    onHelloOk: params.onHelloOk,
-    timeoutMessage: "timeout waiting for paired node to connect",
-  });
-}
-
-async function expectRePairingRequest(params: {
-  started: Awaited<ReturnType<typeof startServerWithClient>>;
-  pairedName: string;
-  initialCommands?: string[];
-  reconnectCommands: string[];
-  approvalScopes: string[];
-  expectedVisibleCommands: string[];
-}) {
-  const pairedNode = await pairDeviceIdentity({
-    name: params.pairedName,
-    role: "node",
-    scopes: [],
-    clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
-    clientMode: GATEWAY_CLIENT_MODES.NODE,
-  });
-
-  let controlWs: WebSocket | undefined;
-  let firstClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
-  let nodeClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
-  try {
-    controlWs = await openTrackedWs(params.started.port);
-    await connectOk(controlWs, { token: "secret" });
-
-    if (params.initialCommands) {
-      firstClient = await connectNodeClient({
-        port: params.started.port,
-        deviceIdentity: pairedNode.identity,
-        commands: params.initialCommands,
-      });
-      await firstClient.stopAndWait();
-    }
-
-    const request = await requestNodePairing({
-      nodeId: pairedNode.identity.deviceId,
-      platform: "macos",
-      deviceFamily: "Mac",
-      ...(params.initialCommands ? { commands: params.initialCommands } : {}),
-    });
-    await approveNodePairing(request.request.requestId, {
-      callerScopes: params.approvalScopes,
-    });
-
-    nodeClient = await connectNodeClient({
-      port: params.started.port,
-      deviceIdentity: pairedNode.identity,
-      commands: params.reconnectCommands,
-    });
-    const connectedControlWs = controlWs;
-
-    type NodeDiagnostics = {
-      nodeId: string;
-      connected?: boolean;
-      commands?: string[];
-      approvalState?: string;
-      pendingRequestId?: string;
-      pendingDeclaredCommands?: string[];
-    };
-    let lastNodes: NodeDiagnostics[] = [];
-    await vi.waitFor(async () => {
-      const list = await rpcReq<{
-        nodes?: NodeDiagnostics[];
-      }>(connectedControlWs, "node.list", {});
-      lastNodes = list.payload?.nodes ?? [];
-      const node = lastNodes.find(
-        (entry) => entry.nodeId === pairedNode.identity.deviceId && entry.connected,
-      );
-      if (
-        JSON.stringify(node?.commands?.toSorted() ?? []) ===
-        JSON.stringify(params.expectedVisibleCommands)
-      ) {
-        return;
-      }
-      throw new Error(`node commands not visible yet: ${JSON.stringify(lastNodes)}`);
-    });
-
-    expect(
-      lastNodes
-        .find((entry) => entry.nodeId === pairedNode.identity.deviceId && entry.connected)
-        ?.commands?.toSorted(),
-      JSON.stringify(lastNodes),
-    ).toEqual(params.expectedVisibleCommands);
-
-    const pairing = await listNodePairing();
-    const pending = pairing.pending?.find((entry) => entry.nodeId === pairedNode.identity.deviceId);
-    expect(pending?.nodeId).toBe(pairedNode.identity.deviceId);
-    expect(pending?.commands).toEqual(params.reconnectCommands);
-    const listedNode = lastNodes.find((entry) => entry.nodeId === pairedNode.identity.deviceId);
-    expect(listedNode).toMatchObject({
-      approvalState: "pending-reapproval",
-      pendingRequestId: pending?.requestId,
-      pendingDeclaredCommands: params.reconnectCommands,
-      commands: params.expectedVisibleCommands,
-    });
-
-    const described = await rpcReq<NodeDiagnostics>(connectedControlWs, "node.describe", {
-      nodeId: pairedNode.identity.deviceId,
-    });
-    expect(described.payload).toMatchObject({
-      approvalState: "pending-reapproval",
-      pendingRequestId: pending?.requestId,
-      pendingDeclaredCommands: params.reconnectCommands,
-      commands: params.expectedVisibleCommands,
-    });
-  } finally {
-    controlWs?.close();
-    await firstClient?.stopAndWait();
-    await nodeClient?.stopAndWait();
-  }
-}
 
 async function expectRpcNodePairingApprovalRejected(params: {
   started: Awaited<ReturnType<typeof startServerWithClient>>;
@@ -652,7 +493,7 @@ describe("gateway node pairing authorization", () => {
       );
 
       const controlWs = await openTrackedWs(getStarted().port);
-      let nodeClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+      let nodeClient: Awaited<ReturnType<typeof connectNodeClient>> | undefined;
       try {
         await connectOk(controlWs, { token: "secret" });
         nodeClient = await connectNodeClient({
@@ -922,228 +763,6 @@ describe("gateway node pairing authorization", () => {
       } finally {
         ws.close();
       }
-    });
-  });
-
-  describeWithGatewayServer("paired node reconnects", (getStarted) => {
-    test("withholds plugin surface URLs until the node capability is approved", async () => {
-      // The shared Gateway harness disables Canvas startup; expose its descriptor
-      // so this handshake test exercises production capability issuance.
-      const previousSkipCanvasHost = process.env.OPENCLAW_SKIP_CANVAS_HOST;
-      delete process.env.OPENCLAW_SKIP_CANVAS_HOST;
-      try {
-        const pairedNode = await pairDeviceIdentity({
-          name: "node-plugin-surface-approval",
-          role: "node",
-          scopes: [],
-          clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
-          clientMode: GATEWAY_CLIENT_MODES.NODE,
-        });
-        let pendingHello: HelloOk | undefined;
-        const pendingClient = await connectNodeClient({
-          port: getStarted().port,
-          deviceIdentity: pairedNode.identity,
-          caps: ["canvas"],
-          commands: [],
-          onHelloOk: (hello) => {
-            pendingHello = hello;
-          },
-        });
-        await pendingClient.stopAndWait();
-
-        expect(pendingHello?.pluginSurfaceUrls).toBeUndefined();
-        const pending = (await listNodePairing()).pending.find(
-          (entry) => entry.nodeId === pairedNode.identity.deviceId,
-        );
-        expect(pending?.caps).toEqual(["canvas"]);
-        requireApprovedPairing(
-          await approveNodePairing(pending?.requestId ?? "", {
-            callerScopes: ["operator.pairing"],
-          }),
-        );
-
-        let approvedHello: HelloOk | undefined;
-        const approvedClient = await connectNodeClient({
-          port: getStarted().port,
-          deviceIdentity: pairedNode.identity,
-          caps: ["canvas"],
-          commands: [],
-          onHelloOk: (hello) => {
-            approvedHello = hello;
-          },
-        });
-        try {
-          expect(approvedHello?.pluginSurfaceUrls?.canvas).toMatch(
-            /^http:\/\/127\.0\.0\.1:\d+\/__openclaw__\/cap\/[^/]+$/,
-          );
-        } finally {
-          await approvedClient.stopAndWait();
-        }
-      } finally {
-        if (previousSkipCanvasHost === undefined) {
-          delete process.env.OPENCLAW_SKIP_CANVAS_HOST;
-        } else {
-          process.env.OPENCLAW_SKIP_CANVAS_HOST = previousSkipCanvasHost;
-        }
-      }
-    });
-
-    test("keeps iOS approval when a transient permission becomes unavailable", async () => {
-      const pairedNode = await pairDeviceIdentity({
-        name: "ios-transient-permission",
-        role: "node",
-        scopes: [],
-        clientId: GATEWAY_CLIENT_NAMES.IOS_APP,
-        clientMode: GATEWAY_CLIENT_MODES.NODE,
-      });
-      const initialPermissions = { camera: true, watchReachable: true };
-      const initial = await requestNodePairing({
-        nodeId: pairedNode.identity.deviceId,
-        platform: "ios",
-        deviceFamily: "iPhone",
-        commands: [],
-        permissions: initialPermissions,
-      });
-      await approveNodePairing(initial.request.requestId, {
-        callerScopes: ["operator.pairing", "operator.write"],
-      });
-
-      const nodeClient = await connectGatewayClient({
-        url: `ws://127.0.0.1:${getStarted().port}`,
-        token: "secret",
-        role: "node",
-        clientName: GATEWAY_CLIENT_NAMES.IOS_APP,
-        clientDisplayName: "iPhone",
-        clientVersion: "1.0.0",
-        platform: "ios",
-        deviceFamily: "iPhone",
-        mode: GATEWAY_CLIENT_MODES.NODE,
-        scopes: [],
-        commands: [],
-        permissions: { camera: true, watchReachable: false },
-        deviceIdentity: pairedNode.identity,
-      });
-      await nodeClient.stopAndWait();
-
-      const pairing = await listNodePairing();
-      expect(pairing.pending.some((entry) => entry.nodeId === pairedNode.identity.deviceId)).toBe(
-        false,
-      );
-      await expect(findPairedNode(pairedNode.identity.deviceId)).resolves.toMatchObject({
-        permissions: initialPermissions,
-      });
-    });
-
-    test("clears stale reapproval when a node returns to its approved surface", async () => {
-      const pairedNode = await pairDeviceIdentity({
-        name: "node-reverted-reapproval",
-        role: "node",
-        scopes: [],
-        clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
-        clientMode: GATEWAY_CLIENT_MODES.NODE,
-      });
-      const initial = await requestNodePairing({
-        nodeId: pairedNode.identity.deviceId,
-        platform: "macos",
-        deviceFamily: "Mac",
-        commands: ["screen.snapshot"],
-      });
-      await approveNodePairing(initial.request.requestId, {
-        callerScopes: ["operator.pairing", "operator.write"],
-      });
-
-      const upgraded = await connectNodeClient({
-        port: getStarted().port,
-        deviceIdentity: pairedNode.identity,
-        commands: ["screen.snapshot", "system.run"],
-      });
-      await upgraded.stopAndWait();
-      expect(
-        (await listNodePairing()).pending.some(
-          (entry) => entry.nodeId === pairedNode.identity.deviceId,
-        ),
-      ).toBe(true);
-
-      const reverted = await connectNodeClient({
-        port: getStarted().port,
-        deviceIdentity: pairedNode.identity,
-        commands: ["screen.snapshot"],
-      });
-      await reverted.stopAndWait();
-
-      await vi.waitFor(async () => {
-        expect(
-          (await listNodePairing()).pending.some(
-            (entry) => entry.nodeId === pairedNode.identity.deviceId,
-          ),
-        ).toBe(false);
-      });
-    });
-
-    test("refreshes a paired macOS app node version without a repair request", async () => {
-      const started = getStarted();
-      const pairedNode = await pairDeviceIdentity({
-        name: "macos-version-refresh",
-        role: "node",
-        scopes: [],
-        clientId: GATEWAY_CLIENT_NAMES.MACOS_APP,
-        clientMode: GATEWAY_CLIENT_MODES.NODE,
-        platform: "macOS 26.5.1",
-        deviceFamily: "Mac",
-      });
-      const nodeRequest = await requestNodePairing({
-        nodeId: pairedNode.identity.deviceId,
-        platform: "macOS 26.5.1",
-        deviceFamily: "Mac",
-        commands: ["system.info"],
-      });
-      requireApprovedPairing(
-        await approveNodePairing(nodeRequest.request.requestId, {
-          callerScopes: ["operator.pairing", "operator.write", "operator.admin"],
-        }),
-      );
-
-      const nodeClient = await connectNodeClient({
-        port: started.port,
-        deviceIdentity: pairedNode.identity,
-        commands: ["system.info"],
-        clientName: GATEWAY_CLIENT_NAMES.MACOS_APP,
-        platform: "macOS 26.5.2",
-        deviceFamily: "Mac",
-      });
-      try {
-        await vi.waitFor(async () => {
-          const pairedDevice = await getPairedDevice(pairedNode.identity.deviceId);
-          expect(pairedDevice?.platform).toBe("macOS 26.5.2");
-        });
-        const devicePairing = await listDevicePairing();
-        expect(
-          devicePairing.pending.find((entry) => entry.deviceId === pairedNode.identity.deviceId),
-        ).toBeUndefined();
-      } finally {
-        await nodeClient.stopAndWait();
-      }
-    });
-
-    test("requests re-pairing when a paired node reconnects with upgraded commands", async () => {
-      await expectRePairingRequest({
-        started: getStarted(),
-        pairedName: "node-command-pin",
-        initialCommands: ["screen.snapshot"],
-        reconnectCommands: ["screen.snapshot", "system.run"],
-        approvalScopes: ["operator.pairing", "operator.write"],
-        expectedVisibleCommands: ["screen.snapshot"],
-      });
-    });
-
-    test("requests re-pairing when a commandless paired node reconnects with system.run", async () => {
-      await expectRePairingRequest({
-        started: getStarted(),
-        pairedName: "node-command-empty",
-        reconnectCommands: ["screen.snapshot", "system.run"],
-        approvalScopes: ["operator.pairing"],
-        expectedVisibleCommands: [],
-      });
     });
   });
 });

--- a/src/gateway/server.node-pairing-reconnect.test.ts
+++ b/src/gateway/server.node-pairing-reconnect.test.ts
@@ -1,0 +1,370 @@
+// Node pairing reconnect tests cover capability approval, metadata refreshes,
+// and reapproval when a paired node changes its declared surface.
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { WebSocket } from "ws";
+import type { HelloOk } from "../../packages/gateway-protocol/src/index.js";
+import { getPairedDevice, listDevicePairing } from "../infra/device-pairing.js";
+import { approveNodePairing, listNodePairing, requestNodePairing } from "../infra/node-pairing.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { openTrackedWs, pairDeviceIdentity } from "./device-authz.test-helpers.js";
+import {
+  connectNodeClient,
+  createNodePairingTestState,
+  describeWithGatewayServer,
+  findPairedNode,
+  requireApprovedPairing,
+} from "./server.node-pairing.test-support.js";
+import { connectGatewayClient } from "./test-helpers.e2e.js";
+import {
+  connectOk,
+  installGatewayTestHooks,
+  rpcReq,
+  startServerWithClient,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const { cleanup: cleanupNodePairingTestState, setup: setupNodePairingTestState } =
+  createNodePairingTestState("openclaw-node-pair-reconnect-");
+
+async function expectRePairingRequest(params: {
+  started: Awaited<ReturnType<typeof startServerWithClient>>;
+  pairedName: string;
+  initialCommands?: string[];
+  reconnectCommands: string[];
+  approvalScopes: string[];
+  expectedVisibleCommands: string[];
+}) {
+  const pairedNode = await pairDeviceIdentity({
+    name: params.pairedName,
+    role: "node",
+    scopes: [],
+    clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+    clientMode: GATEWAY_CLIENT_MODES.NODE,
+  });
+
+  let controlWs: WebSocket | undefined;
+  let firstClient: Awaited<ReturnType<typeof connectNodeClient>> | undefined;
+  let nodeClient: Awaited<ReturnType<typeof connectNodeClient>> | undefined;
+  try {
+    controlWs = await openTrackedWs(params.started.port);
+    await connectOk(controlWs, { token: "secret" });
+
+    if (params.initialCommands) {
+      firstClient = await connectNodeClient({
+        port: params.started.port,
+        deviceIdentity: pairedNode.identity,
+        commands: params.initialCommands,
+      });
+      await firstClient.stopAndWait();
+    }
+
+    const request = await requestNodePairing({
+      nodeId: pairedNode.identity.deviceId,
+      platform: "macos",
+      deviceFamily: "Mac",
+      ...(params.initialCommands ? { commands: params.initialCommands } : {}),
+    });
+    await approveNodePairing(request.request.requestId, {
+      callerScopes: params.approvalScopes,
+    });
+
+    nodeClient = await connectNodeClient({
+      port: params.started.port,
+      deviceIdentity: pairedNode.identity,
+      commands: params.reconnectCommands,
+    });
+    const connectedControlWs = controlWs;
+
+    type NodeDiagnostics = {
+      nodeId: string;
+      connected?: boolean;
+      commands?: string[];
+      approvalState?: string;
+      pendingRequestId?: string;
+      pendingDeclaredCommands?: string[];
+    };
+    let lastNodes: NodeDiagnostics[] = [];
+    await vi.waitFor(async () => {
+      const list = await rpcReq<{
+        nodes?: NodeDiagnostics[];
+      }>(connectedControlWs, "node.list", {});
+      lastNodes = list.payload?.nodes ?? [];
+      const node = lastNodes.find(
+        (entry) => entry.nodeId === pairedNode.identity.deviceId && entry.connected,
+      );
+      if (
+        JSON.stringify(node?.commands?.toSorted() ?? []) ===
+        JSON.stringify(params.expectedVisibleCommands)
+      ) {
+        return;
+      }
+      throw new Error(`node commands not visible yet: ${JSON.stringify(lastNodes)}`);
+    });
+
+    expect(
+      lastNodes
+        .find((entry) => entry.nodeId === pairedNode.identity.deviceId && entry.connected)
+        ?.commands?.toSorted(),
+      JSON.stringify(lastNodes),
+    ).toEqual(params.expectedVisibleCommands);
+
+    const pairing = await listNodePairing();
+    const pending = pairing.pending?.find((entry) => entry.nodeId === pairedNode.identity.deviceId);
+    expect(pending?.nodeId).toBe(pairedNode.identity.deviceId);
+    expect(pending?.commands).toEqual(params.reconnectCommands);
+    const listedNode = lastNodes.find((entry) => entry.nodeId === pairedNode.identity.deviceId);
+    expect(listedNode).toMatchObject({
+      approvalState: "pending-reapproval",
+      pendingRequestId: pending?.requestId,
+      pendingDeclaredCommands: params.reconnectCommands,
+      commands: params.expectedVisibleCommands,
+    });
+
+    const described = await rpcReq<NodeDiagnostics>(connectedControlWs, "node.describe", {
+      nodeId: pairedNode.identity.deviceId,
+    });
+    expect(described.payload).toMatchObject({
+      approvalState: "pending-reapproval",
+      pendingRequestId: pending?.requestId,
+      pendingDeclaredCommands: params.reconnectCommands,
+      commands: params.expectedVisibleCommands,
+    });
+  } finally {
+    controlWs?.close();
+    await firstClient?.stopAndWait();
+    await nodeClient?.stopAndWait();
+  }
+}
+
+describe("gateway paired node reconnects", () => {
+  beforeAll(async () => {
+    await setupNodePairingTestState();
+  });
+
+  afterAll(async () => {
+    await cleanupNodePairingTestState();
+  });
+
+  describeWithGatewayServer("paired node reconnects", (getStarted) => {
+    test("withholds plugin surface URLs until the node capability is approved", async () => {
+      // The shared Gateway harness disables Canvas startup; expose its descriptor
+      // so this handshake test exercises production capability issuance.
+      const previousSkipCanvasHost = process.env.OPENCLAW_SKIP_CANVAS_HOST;
+      delete process.env.OPENCLAW_SKIP_CANVAS_HOST;
+      try {
+        const pairedNode = await pairDeviceIdentity({
+          name: "node-plugin-surface-approval",
+          role: "node",
+          scopes: [],
+          clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+          clientMode: GATEWAY_CLIENT_MODES.NODE,
+        });
+        let pendingHello: HelloOk | undefined;
+        const pendingClient = await connectNodeClient({
+          port: getStarted().port,
+          deviceIdentity: pairedNode.identity,
+          caps: ["canvas"],
+          commands: [],
+          onHelloOk: (hello) => {
+            pendingHello = hello;
+          },
+        });
+        await pendingClient.stopAndWait();
+
+        expect(pendingHello?.pluginSurfaceUrls).toBeUndefined();
+        const pending = (await listNodePairing()).pending.find(
+          (entry) => entry.nodeId === pairedNode.identity.deviceId,
+        );
+        expect(pending?.caps).toEqual(["canvas"]);
+        requireApprovedPairing(
+          await approveNodePairing(pending?.requestId ?? "", {
+            callerScopes: ["operator.pairing"],
+          }),
+        );
+
+        let approvedHello: HelloOk | undefined;
+        const approvedClient = await connectNodeClient({
+          port: getStarted().port,
+          deviceIdentity: pairedNode.identity,
+          caps: ["canvas"],
+          commands: [],
+          onHelloOk: (hello) => {
+            approvedHello = hello;
+          },
+        });
+        try {
+          expect(approvedHello?.pluginSurfaceUrls?.canvas).toMatch(
+            /^http:\/\/127\.0\.0\.1:\d+\/__openclaw__\/cap\/[^/]+$/,
+          );
+        } finally {
+          await approvedClient.stopAndWait();
+        }
+      } finally {
+        if (previousSkipCanvasHost === undefined) {
+          delete process.env.OPENCLAW_SKIP_CANVAS_HOST;
+        } else {
+          process.env.OPENCLAW_SKIP_CANVAS_HOST = previousSkipCanvasHost;
+        }
+      }
+    });
+
+    test("keeps iOS approval when a transient permission becomes unavailable", async () => {
+      const pairedNode = await pairDeviceIdentity({
+        name: "ios-transient-permission",
+        role: "node",
+        scopes: [],
+        clientId: GATEWAY_CLIENT_NAMES.IOS_APP,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+      });
+      const initialPermissions = { camera: true, watchReachable: true };
+      const initial = await requestNodePairing({
+        nodeId: pairedNode.identity.deviceId,
+        platform: "ios",
+        deviceFamily: "iPhone",
+        commands: [],
+        permissions: initialPermissions,
+      });
+      await approveNodePairing(initial.request.requestId, {
+        callerScopes: ["operator.pairing", "operator.write"],
+      });
+
+      const nodeClient = await connectGatewayClient({
+        url: `ws://127.0.0.1:${getStarted().port}`,
+        token: "secret",
+        role: "node",
+        clientName: GATEWAY_CLIENT_NAMES.IOS_APP,
+        clientDisplayName: "iPhone",
+        clientVersion: "1.0.0",
+        platform: "ios",
+        deviceFamily: "iPhone",
+        mode: GATEWAY_CLIENT_MODES.NODE,
+        scopes: [],
+        commands: [],
+        permissions: { camera: true, watchReachable: false },
+        deviceIdentity: pairedNode.identity,
+      });
+      await nodeClient.stopAndWait();
+
+      const pairing = await listNodePairing();
+      expect(pairing.pending.some((entry) => entry.nodeId === pairedNode.identity.deviceId)).toBe(
+        false,
+      );
+      await expect(findPairedNode(pairedNode.identity.deviceId)).resolves.toMatchObject({
+        permissions: initialPermissions,
+      });
+    });
+
+    test("clears stale reapproval when a node returns to its approved surface", async () => {
+      const pairedNode = await pairDeviceIdentity({
+        name: "node-reverted-reapproval",
+        role: "node",
+        scopes: [],
+        clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+      });
+      const initial = await requestNodePairing({
+        nodeId: pairedNode.identity.deviceId,
+        platform: "macos",
+        deviceFamily: "Mac",
+        commands: ["screen.snapshot"],
+      });
+      await approveNodePairing(initial.request.requestId, {
+        callerScopes: ["operator.pairing", "operator.write"],
+      });
+
+      const upgraded = await connectNodeClient({
+        port: getStarted().port,
+        deviceIdentity: pairedNode.identity,
+        commands: ["screen.snapshot", "system.run"],
+      });
+      await upgraded.stopAndWait();
+      expect(
+        (await listNodePairing()).pending.some(
+          (entry) => entry.nodeId === pairedNode.identity.deviceId,
+        ),
+      ).toBe(true);
+
+      const reverted = await connectNodeClient({
+        port: getStarted().port,
+        deviceIdentity: pairedNode.identity,
+        commands: ["screen.snapshot"],
+      });
+      await reverted.stopAndWait();
+
+      await vi.waitFor(async () => {
+        expect(
+          (await listNodePairing()).pending.some(
+            (entry) => entry.nodeId === pairedNode.identity.deviceId,
+          ),
+        ).toBe(false);
+      });
+    });
+
+    test("refreshes a paired macOS app node version without a repair request", async () => {
+      const started = getStarted();
+      const pairedNode = await pairDeviceIdentity({
+        name: "macos-version-refresh",
+        role: "node",
+        scopes: [],
+        clientId: GATEWAY_CLIENT_NAMES.MACOS_APP,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+        platform: "macOS 26.5.1",
+        deviceFamily: "Mac",
+      });
+      const nodeRequest = await requestNodePairing({
+        nodeId: pairedNode.identity.deviceId,
+        platform: "macOS 26.5.1",
+        deviceFamily: "Mac",
+        commands: ["system.info"],
+      });
+      requireApprovedPairing(
+        await approveNodePairing(nodeRequest.request.requestId, {
+          callerScopes: ["operator.pairing", "operator.write", "operator.admin"],
+        }),
+      );
+
+      const nodeClient = await connectNodeClient({
+        port: started.port,
+        deviceIdentity: pairedNode.identity,
+        commands: ["system.info"],
+        clientName: GATEWAY_CLIENT_NAMES.MACOS_APP,
+        platform: "macOS 26.5.2",
+        deviceFamily: "Mac",
+      });
+      try {
+        await vi.waitFor(async () => {
+          const pairedDevice = await getPairedDevice(pairedNode.identity.deviceId);
+          expect(pairedDevice?.platform).toBe("macOS 26.5.2");
+        });
+        const devicePairing = await listDevicePairing();
+        expect(
+          devicePairing.pending.find((entry) => entry.deviceId === pairedNode.identity.deviceId),
+        ).toBeUndefined();
+      } finally {
+        await nodeClient.stopAndWait();
+      }
+    });
+
+    test("requests re-pairing when a paired node reconnects with upgraded commands", async () => {
+      await expectRePairingRequest({
+        started: getStarted(),
+        pairedName: "node-command-pin",
+        initialCommands: ["screen.snapshot"],
+        reconnectCommands: ["screen.snapshot", "system.run"],
+        approvalScopes: ["operator.pairing", "operator.write"],
+        expectedVisibleCommands: ["screen.snapshot"],
+      });
+    });
+
+    test("requests re-pairing when a commandless paired node reconnects with system.run", async () => {
+      await expectRePairingRequest({
+        started: getStarted(),
+        pairedName: "node-command-empty",
+        reconnectCommands: ["screen.snapshot", "system.run"],
+        approvalScopes: ["operator.pairing"],
+        expectedVisibleCommands: [],
+      });
+    });
+  });
+});

--- a/src/gateway/server.node-pairing.test-support.ts
+++ b/src/gateway/server.node-pairing.test-support.ts
@@ -1,7 +1,60 @@
 import { afterAll, beforeAll, describe } from "vitest";
+import type { HelloOk } from "../../packages/gateway-protocol/src/index.js";
+import type { DeviceIdentity } from "../infra/device-identity.js";
 import { approveDevicePairing, requestDevicePairing } from "../infra/device-pairing.js";
+import { approveNodePairing, listNodePairing } from "../infra/node-pairing.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+  type GatewayClientName,
+} from "../utils/message-channel.js";
+import { connectGatewayClient } from "./test-helpers.e2e.js";
 import { startServerWithClient } from "./test-helpers.js";
+
+export async function findPairedNode(nodeId: string, baseDir?: string) {
+  const pairing = await listNodePairing(baseDir);
+  return pairing.paired.find((node) => node.nodeId === nodeId) ?? null;
+}
+
+export function requireApprovedPairing(
+  result: Awaited<ReturnType<typeof approveNodePairing>>,
+): Exclude<typeof result, null | { status: "forbidden"; missingScope: string }> {
+  if (!result || "status" in result) {
+    throw new Error(`Expected approved node pairing, got ${JSON.stringify(result)}`);
+  }
+  return result;
+}
+
+export async function connectNodeClient(params: {
+  port: number;
+  deviceIdentity: DeviceIdentity;
+  commands: string[];
+  clientName?: GatewayClientName;
+  displayName?: string;
+  platform?: string;
+  deviceFamily?: string;
+  caps?: string[];
+  onHelloOk?: (hello: HelloOk) => void;
+}) {
+  return await connectGatewayClient({
+    url: `ws://127.0.0.1:${params.port}`,
+    token: "secret",
+    role: "node",
+    clientName: params.clientName ?? GATEWAY_CLIENT_NAMES.NODE_HOST,
+    clientDisplayName: params.displayName ?? "node-command-pin",
+    clientVersion: "1.0.0",
+    platform: params.platform ?? "macos",
+    deviceFamily: params.deviceFamily ?? "Mac",
+    mode: GATEWAY_CLIENT_MODES.NODE,
+    scopes: [],
+    caps: params.caps,
+    commands: params.commands,
+    deviceIdentity: params.deviceIdentity,
+    onHelloOk: params.onHelloOk,
+    timeoutMessage: "timeout waiting for paired node to connect",
+  });
+}
 
 export function createNodePairingTestState(prefix: string) {
   const tempDirs = createSuiteTempRootTracker({ prefix });


### PR DESCRIPTION
## What Problem This Solves

Resolves a current-main CI failure where `src/gateway/server.node-pairing-authz.test.ts` exceeded the repository max-lines policy after approved-capability reconnect coverage was added. Any Node-relevant pull request consequently failed the full lint gate even when its own files were clean.

## Why This Change Was Made

The node-pairing reconnect lifecycle cases now live in a focused sibling suite, while three genuinely shared pairing helpers moved to the existing test-support owner. The split follows the test's behavior boundary—capability issuance, permission loss, stale reapproval, platform refresh, and command upgrades—and adds no lint suppression or production change.

## User Impact

No product behavior changes. Current-main CI and unrelated Node pull requests can pass the repository's existing max-lines policy again, while retaining the complete node-pairing coverage.

## Evidence

- Before: full oxlint failed because `server.node-pairing-authz.test.ts` had 1,060 effective lines against the 1,000-line limit.
- After: the original file is 768 physical lines; the focused reconnect sibling is 370; shared support is 100.
- The sorted pre/post test-name inventory is byte-identical; no test case was removed.
- Blacksmith Testbox `tbx_01kyt8jnh5m2zvm9ym2sa9tfn0`: 21/21 focused tests, full core/extensions/scripts oxlint, and remote changed gate passed in [run 30575724140](https://github.com/openclaw/openclaw/actions/runs/30575724140).
- Fresh Codex autoreview: clean, confidence 0.98.
- `git diff --check`: clean.
