### PR TITLE
fix(auto-reply): keep explicit NO_REPLY silent

### DIFF
--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -97,6 +97,10 @@ export async function prepareReplyAgentPayloads(state: {
     verboseEnabled,
   } = accounting;
   let { activeSessionEntry, didLogHeartbeatStrip } = accounting;
+  const deliberateSilentTerminalReply = hasDeliberateSilentTerminalReply(runResult);
+  if (deliberateSilentTerminalReply) {
+    opts?.onDeliberateSilentTerminalReply?.();
+  }
 
   const successfulSourceReplyDelivery = hasSuccessfulSourceReplyDelivery({
     blockReplyPipeline,
@@ -142,7 +146,7 @@ export async function prepareReplyAgentPayloads(state: {
           "message_tool_only",
         hasPendingContinuation:
           runResult.meta?.yielded === true || (runResult.meta?.pendingToolCalls?.length ?? 0) > 0,
-        hasExplicitSilentReply: hasDeliberateSilentTerminalReply(runResult),
+        hasExplicitSilentReply: deliberateSilentTerminalReply,
         hasCommittedDelivery: successfulTerminalDelivery,
         sessionCtx,
         cfg,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -3313,6 +3313,7 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
     strandedReplyRetry?: boolean;
     sendPolicyDenied?: boolean;
     isHeartbeat?: boolean;
+    onDeliberateSilentTerminalReply?: () => void;
     onObservedReplyDelivery?: () => Promise<void> | void;
     replyOperation?: ReturnType<typeof createReplyOperation>;
     turnAdoptionLifecycle?: FollowupRun["turnAdoptionLifecycle"];
@@ -3428,10 +3429,17 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
       typingMode: "instant",
-      ...(params.isHeartbeat || params.onObservedReplyDelivery
+      ...(params.isHeartbeat ||
+      params.onDeliberateSilentTerminalReply ||
+      params.onObservedReplyDelivery
         ? {
             opts: {
               ...(params.isHeartbeat ? { isHeartbeat: true } : {}),
+              ...(params.onDeliberateSilentTerminalReply
+                ? {
+                    onDeliberateSilentTerminalReply: params.onDeliberateSilentTerminalReply,
+                  }
+                : {}),
               ...(params.onObservedReplyDelivery
                 ? { onObservedReplyDelivery: params.onObservedReplyDelivery }
                 : {}),
@@ -3614,10 +3622,13 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
     // Assistant went silent (NO_REPLY), but a verbose/usage metadata payload
     // survives in finalPayloads. The warn must key off the assistant text, not
     // the payload bundle, so no private-final warning should fire.
+    const onDeliberateSilentTerminalReply = vi.fn();
     await runPrivateFinalCase({
       finalAssistantText: "no_reply",
+      onDeliberateSilentTerminalReply,
       payloadText: "Auto-compaction complete (count 1).",
     });
+    expect(onDeliberateSilentTerminalReply).toHaveBeenCalledOnce();
     expect(warnPrivateFinalSpy).not.toHaveBeenCalled();
     expect(vi.mocked(enqueueFollowupRun)).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/dispatch-from-config.events.ts
+++ b/src/auto-reply/reply/dispatch-from-config.events.ts
@@ -3,6 +3,7 @@ import type { CommandSessionMetadataChange } from "./command-session-metadata.js
 import type { ReplySessionBinding } from "./get-reply.types.js";
 
 export type InternalReplyResolverOptions = {
+  onDeliberateSilentTerminalReply?: () => void;
   onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
   onSessionPrepared?: (binding: ReplySessionBinding) => void;
 };

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -117,6 +117,7 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     waitForPendingDirectBlockReplyDelivery,
     wrapProgressCallback,
   } = state;
+  let deliberateSilentTerminalReply = false;
   const replyResult = await runWithDispatchLifecycleAdmission(
     async () =>
       await runWithDispatchAbortSignal(
@@ -131,6 +132,9 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
                 sourceReplyDeliveryMode,
                 sessionPromptSourceReplyDeliveryMode: sessionStableSourceReplyDeliveryMode,
                 ...({
+                  onDeliberateSilentTerminalReply: () => {
+                    deliberateSilentTerminalReply = true;
+                  },
                   onSessionMetadataChanges: notifySessionMetadataChanges,
                   onSessionPrepared: notePreparedSession,
                 } satisfies InternalReplyResolverOptions),
@@ -650,7 +654,11 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
       }
     }
   }
-  const nextState = extendPreparedDispatchState(state, { replyResult }, {});
+  const nextState = extendPreparedDispatchState(
+    state,
+    { deliberateSilentTerminalReply, replyResult },
+    {},
+  );
   return { status: "ready" as const, state: nextState };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -8,6 +8,7 @@ import {
   markReplyPayloadAsTtsSupplement,
   type ReplyPayload,
 } from "../reply-payload.js";
+import { isSilentReplyPayloadText } from "../tokens.js";
 import { isDispatchReplyOperationAbortedError } from "./dispatch-from-config.abort.js";
 import type { ExecuteDispatchReadyState } from "./dispatch-from-config.execute.js";
 import {
@@ -68,6 +69,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     waitForPendingDirectBlockReplyDelivery,
   } = state;
   const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
+  const hasExplicitSilentReply = replies.some((reply) => isSilentReplyPayloadText(reply.text));
   const pendingFinalDelivery = {
     storePath: sessionStoreEntry.storePath,
     sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
@@ -291,6 +293,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     !sendPolicyDenied &&
     sourceReplyDeliveryMode !== "message_tool_only" &&
     !emptyFinalAllowedAsSilent &&
+    !hasExplicitSilentReply &&
     !getObservedReplyDelivery() &&
     !replyAcceptedByActiveRun &&
     !turnLedger.hasVisibleDelivery() &&
@@ -306,8 +309,8 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   }
   let counts = dispatcher.getQueuedCounts();
   let noVisibleReplyFallbackDelivered = false;
-  // Visible agent turns must never end silently: empty model completions get a
-  // core fallback final. emptyFinalAllowedAsSilent is the only sanctioned silence.
+  // Visible agent turns with genuinely empty model completions get a core
+  // fallback final. An explicit NO_REPLY is intentional silence, not emptiness.
   // An aborted or timed-out settle leaves delivery state unknown; admission
   // then keeps its legacy trust and the turn ends without a fallback.
   if (queuedSettleResult === "settled" && noVisibleReplyFallbackAllowed()) {
@@ -390,7 +393,8 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       !noVisibleReplyFallbackDelivered &&
       !getObservedReplyDelivery() &&
       !replyAcceptedByActiveRun &&
-      !emptyFinalAllowedAsSilent
+      !emptyFinalAllowedAsSilent &&
+      !hasExplicitSilentReply
         ? { noVisibleReplyFallbackEligible: true }
         : {}),
       ...(noVisibleReplyFallbackDelivered ? { noVisibleReplyFallbackDelivered: true } : {}),

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -8,7 +8,6 @@ import {
   markReplyPayloadAsTtsSupplement,
   type ReplyPayload,
 } from "../reply-payload.js";
-import { isSilentReplyPayloadText } from "../tokens.js";
 import { isDispatchReplyOperationAbortedError } from "./dispatch-from-config.abort.js";
 import type { ExecuteDispatchReadyState } from "./dispatch-from-config.execute.js";
 import {
@@ -35,6 +34,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     ctx,
     deliveryChannel,
     deliverySuppressionReason,
+    deliberateSilentTerminalReply,
     dispatcher,
     emptyFinalAllowedAsSilent,
     explicitCommandTurnCtx,
@@ -69,7 +69,6 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     waitForPendingDirectBlockReplyDelivery,
   } = state;
   const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
-  const hasExplicitSilentReply = replies.some((reply) => isSilentReplyPayloadText(reply.text));
   const pendingFinalDelivery = {
     storePath: sessionStoreEntry.storePath,
     sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
@@ -293,7 +292,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     !sendPolicyDenied &&
     sourceReplyDeliveryMode !== "message_tool_only" &&
     !emptyFinalAllowedAsSilent &&
-    !hasExplicitSilentReply &&
+    !deliberateSilentTerminalReply &&
     !getObservedReplyDelivery() &&
     !replyAcceptedByActiveRun &&
     !turnLedger.hasVisibleDelivery() &&
@@ -309,8 +308,8 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   }
   let counts = dispatcher.getQueuedCounts();
   let noVisibleReplyFallbackDelivered = false;
-  // Visible agent turns with genuinely empty model completions get a core
-  // fallback final. An explicit NO_REPLY is intentional silence, not emptiness.
+  // The agent-result classifier owns terminal silence; carry that fact here
+  // because reply payloads are filtered projections and cannot safely rederive it.
   // An aborted or timed-out settle leaves delivery state unknown; admission
   // then keeps its legacy trust and the turn ends without a fallback.
   if (queuedSettleResult === "settled" && noVisibleReplyFallbackAllowed()) {
@@ -394,7 +393,7 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       !getObservedReplyDelivery() &&
       !replyAcceptedByActiveRun &&
       !emptyFinalAllowedAsSilent &&
-      !hasExplicitSilentReply
+      !deliberateSilentTerminalReply
         ? { noVisibleReplyFallbackEligible: true }
         : {}),
       ...(noVisibleReplyFallbackDelivered ? { noVisibleReplyFallbackDelivered: true } : {}),

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -436,6 +436,42 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
   });
 
+  it("keeps explicit NO_REPLY silent for mentioned group turns", async () => {
+    setNoAbort();
+    const deliver = vi.fn(async () => {});
+    const dispatcher = createReplyDispatcher({ deliver });
+    const replyResolver = vi.fn(async () => ({ text: "NO_REPLY" }) satisfies ReplyPayload);
+    const ctx = buildTestCtx({
+      ChatType: "group",
+      Surface: "feishu",
+      Provider: "feishu",
+      SessionKey: "agent:main:feishu:group:oc_group",
+      WasMentioned: true,
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              group: "disallow",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
+    expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
   it("delivers core no-visible-reply fallback for disallowed empty mentioned group turns", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -31,6 +31,7 @@ import {
   describe1BeforeEach0,
   describe2BeforeEach0,
 } from "./dispatch-from-config.test-harness.js";
+import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import { PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE } from "./provider-request-error-classifier.js";
 import { createReplyDispatcher } from "./reply-dispatcher.js";
 import { resolveReplyOperationRunState } from "./reply-operation-run-state.js";
@@ -470,7 +471,10 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     setNoAbort();
     const deliver = vi.fn(async () => {});
     const dispatcher = createReplyDispatcher({ deliver });
-    const replyResolver = vi.fn(async () => ({ text: "NO_REPLY" }) satisfies ReplyPayload);
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      (opts as InternalGetReplyOptions | undefined)?.onDeliberateSilentTerminalReply?.();
+      return undefined;
+    });
 
     const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
     dispatcher.markComplete();
@@ -480,6 +484,34 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
     expect(result.noVisibleReplyFallbackDelivered).toBeUndefined();
     expect(result.noVisibleReplyFallbackEligible).toBeUndefined();
+  });
+
+  it("does not infer terminal silence from a sibling NO_REPLY payload", async () => {
+    setNoAbort();
+    const deliveredTexts: string[] = [];
+    const dispatcher = createReplyDispatcher({
+      deliver: vi.fn(async (payload) => {
+        deliveredTexts.push(payload.text ?? "");
+      }),
+      beforeDeliver: async (payload) =>
+        payload.text === NO_VISIBLE_REPLY_FALLBACK_TEXT ? payload : null,
+    });
+    const replyResolver = vi.fn(
+      async () => [{ text: "visible reply" }, { text: "NO_REPLY" }] satisfies ReplyPayload[],
+    );
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ ChatType: "direct" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(deliveredTexts).not.toContain("visible reply");
+    expect(deliveredTexts).toContain(NO_VISIBLE_REPLY_FALLBACK_TEXT);
+    expect(result.noVisibleReplyFallbackDelivered).toBe(true);
   });
 
   it("delivers core no-visible-reply fallback for disallowed empty mentioned group turns", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -436,21 +436,26 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
   });
 
-  it("keeps explicit NO_REPLY silent for mentioned group turns", async () => {
-    setNoAbort();
-    const deliver = vi.fn(async () => {});
-    const dispatcher = createReplyDispatcher({ deliver });
-    const replyResolver = vi.fn(async () => ({ text: "NO_REPLY" }) satisfies ReplyPayload);
-    const ctx = buildTestCtx({
-      ChatType: "group",
-      Surface: "feishu",
-      Provider: "feishu",
-      SessionKey: "agent:main:feishu:group:oc_group",
-      WasMentioned: true,
-    });
-
-    const result = await dispatchReplyFromConfig({
-      ctx,
+  it.each([
+    {
+      name: "direct turns",
+      ctx: buildTestCtx({
+        ChatType: "direct",
+        Surface: "feishu",
+        Provider: "feishu",
+        SessionKey: "agent:main:feishu:direct:ou_user",
+      }),
+      cfg: emptyConfig,
+    },
+    {
+      name: "mentioned group turns",
+      ctx: buildTestCtx({
+        ChatType: "group",
+        Surface: "feishu",
+        Provider: "feishu",
+        SessionKey: "agent:main:feishu:group:oc_group",
+        WasMentioned: true,
+      }),
       cfg: {
         agents: {
           defaults: {
@@ -460,9 +465,14 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
           },
         },
       } as OpenClawConfig,
-      dispatcher,
-      replyResolver,
-    });
+    },
+  ])("treats explicit NO_REPLY as intentional silence in $name", async ({ ctx, cfg }) => {
+    setNoAbort();
+    const deliver = vi.fn(async () => {});
+    const dispatcher = createReplyDispatcher({ deliver });
+    const replyResolver = vi.fn(async () => ({ text: "NO_REPLY" }) satisfies ReplyPayload);
+
+    const result = await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
     dispatcher.markComplete();
     await dispatcher.waitForIdle();
 

--- a/src/auto-reply/reply/get-reply.types.ts
+++ b/src/auto-reply/reply/get-reply.types.ts
@@ -17,6 +17,7 @@ export type ReplySessionBinding = {
 
 type InternalReplySessionOptions = {
   expectedExistingSessionId?: string;
+  onDeliberateSilentTerminalReply?: () => void;
   onSessionPrepared?: (binding: ReplySessionBinding) => void;
   /** Prevent implicit rollover after a caller has durably admitted this exact session. */
   pinExpectedExistingSession?: boolean;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users addressing an agent could receive a generic no-visible-reply failure message when the model explicitly returned `NO_REPLY`.

`NO_REPLY` is a non-empty control response. OpenClaw intentionally removes it before transport, but finalization could then mistake the lack of visible delivery for a genuinely empty model completion.

## Why This Change Was Made

Preserve the canonical deliberate-terminal-silence classification when deciding whether the no-visible-reply fallback is allowed. The existing `hasDeliberateSilentTerminalReply` classifier owns this fact from the raw/visible agent result and also covers `hook_block`; the dispatcher now carries that fact forward instead of re-deriving it from filtered reply payloads.

This is deliberately narrower than allowing arbitrary empty output to stay silent: an absent or empty completion still receives the fallback when the turn is otherwise eligible. A sibling `NO_REPLY` payload without canonical terminal-silence classification also cannot suppress recovery.

The change is in shared core auto-reply dispatch, not a Discord, Slack, or other transport adapter, so it applies to every channel using the common path.

The upstream Codex app-server carries agent-message text through unchanged when it converts a completed turn item ([agent-message conversion](https://github.com/openai/codex/blob/acd540f1581bf30f963fccbcce43ac494102242c/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L820-L833)) and emits the converted item in `item/completed` ([notification mapping](https://github.com/openai/codex/blob/acd540f1581bf30f963fccbcce43ac494102242c/codex-rs/app-server-protocol/src/protocol/event_mapping.rs#L412-L418)). The silent-token interpretation therefore belongs in OpenClaw.

## User Impact

An intentional terminal `NO_REPLY` remains silent everywhere. Truly empty directed completions continue to surface the existing fallback message.

<img width="977" height="1610" alt="Screenshot 2026-07-30 at 13 20 15-redacted-v3" src="https://github.com/user-attachments/assets/ffda1b04-9d76-4a51-9cc0-1adced449268" />

## Evidence

- Real agent-run result coverage proves `NO_REPLY` invokes the canonical internal silence signal before payload projection.
- Direct and mentioned-group dispatch regressions prove the carried signal produces no delivery and no fallback eligibility.
- A negative control proves a sibling `NO_REPLY` payload alone does not suppress recovery after a visible final is cancelled.
- The adjacent genuinely empty directed-turn regression continues to require the fallback.
- Focused Testbox proof on a synthetic merge with current `upstream/main` `43156fe482f` (including #116560): 407/407 tests passed across dispatch, agent runner, and the result fallback classifier ([run](https://github.com/openclaw/openclaw/actions/runs/30588368573)).
- `pnpm check:changed` passed the core/coreTests typecheck, lint, formatting, boundary, dead-code, and repository guard lanes.
- Targeted formatting, `git diff --check`, and fresh autoreview passed; autoreview reported no accepted/actionable findings.

## Relationship to #116560

#116560 and this PR are complementary. #116560 repairs channel-agnostic message-tool delivery accounting; this PR repairs channel-agnostic deliberate-silence policy. The combined-main proof above exercises both together.
