### PR TITLE
fix: prevent configured models from stalling startup

### DIFF
--- a/src/agents/embedded-agent-runner/model.static-catalog.snapshot-cache.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.snapshot-cache.test.ts
@@ -179,7 +179,16 @@ describe("bundled static model catalog snapshot cache", () => {
 
   it("pins lifecycle lookups to the supplied plugin generation", () => {
     const cfg = {};
-    const capturedPlugin = createMistralManifestPlugin();
+    const capturedPlugin = {
+      ...createMistralManifestPlugin(),
+      modelIdNormalization: {
+        providers: {
+          mistral: {
+            aliases: { latest: "mistral-medium-3-5" },
+          },
+        },
+      },
+    };
     const capturedSnapshot = {
       plugins: [capturedPlugin],
       manifestRegistry: { plugins: [capturedPlugin] },
@@ -189,7 +198,16 @@ describe("bundled static model catalog snapshot cache", () => {
       metadataSnapshot: capturedSnapshot,
     });
 
-    const replacementPlugin = createMistralManifestPlugin();
+    const replacementPlugin = {
+      ...createMistralManifestPlugin(),
+      modelIdNormalization: {
+        providers: {
+          mistral: {
+            aliases: { latest: "mistral-medium-next" },
+          },
+        },
+      },
+    };
     replacementPlugin.modelCatalog.providers.mistral.models =
       replacementPlugin.modelCatalog.providers.mistral.models.map((model) => ({
         ...model,
@@ -201,7 +219,9 @@ describe("bundled static model catalog snapshot cache", () => {
     expect(resolveModel({ provider: "mistral", modelId: "mistral-medium-3-5" })?.id).toBe(
       "mistral-medium-3-5",
     );
+    expect(resolveModel({ provider: "mistral", modelId: "latest" })?.id).toBe("mistral-medium-3-5");
     expect(resolveModel({ provider: "mistral", modelId: "mistral-medium-next" })).toBeUndefined();
+    expect(manifestMocks.getCurrentPluginMetadataSnapshot).not.toHaveBeenCalled();
     expect(manifestMocks.listOpenClawPluginManifestMetadata).not.toHaveBeenCalled();
     expect(manifestMocks.loadPluginManifest).not.toHaveBeenCalled();
   });

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -27,7 +27,11 @@ import {
 } from "../../plugins/providers.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildInlineProviderModels } from "./model.inline-provider.js";
-import { staticModelIdMatches } from "./model.static-id.js";
+import {
+  createStaticModelIdMatcher,
+  staticModelIdMatches,
+  type StaticModelIdMatcher,
+} from "./model.static-id.js";
 
 export { resolveManifestModelCatalogProviderAliasMetadata } from "./model.manifest-alias.js";
 export type { ManifestModelCatalogProviderAliasMetadata } from "./model.manifest-alias.js";
@@ -39,8 +43,9 @@ function rowMatchesModel(params: {
   row: NormalizedModelCatalogRow;
   provider: string;
   modelId: string;
+  matchesStaticModelId: StaticModelIdMatcher;
 }): boolean {
-  return staticModelIdMatches({
+  return params.matchesStaticModelId({
     candidateId: params.row.id,
     provider: params.provider,
     modelId: params.modelId,
@@ -302,6 +307,9 @@ export function createBundledStaticCatalogModelResolver(params?: {
     ...(params?.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
     workspaceDir: params?.workspaceDir,
   };
+  const matchesStaticModelId = params?.metadataSnapshot
+    ? createStaticModelIdMatcher({ manifestPlugins: params.metadataSnapshot.plugins })
+    : staticModelIdMatches;
   let standaloneState: BundledStaticCatalogState | undefined;
   return (lookup) => {
     const provider = normalizeProviderId(lookup.provider);
@@ -342,6 +350,7 @@ export function createBundledStaticCatalogModelResolver(params?: {
           row: candidate,
           provider,
           modelId: lookup.modelId,
+          matchesStaticModelId,
         }),
       );
       if (row) {
@@ -554,6 +563,9 @@ function createScopedBundledProviderStaticCatalogModelResolver(
   scopedPluginIds?: string[],
 ) => Promise<ProviderRuntimeModel | undefined> {
   const env = params.env ?? process.env;
+  const matchesStaticModelId = params.metadataSnapshot
+    ? createStaticModelIdMatcher({ manifestPlugins: params.metadataSnapshot.plugins })
+    : staticModelIdMatches;
   const pluginCatalogs = new Map<string, Promise<Map<string, ProviderRuntimeModel[]>>>();
   const providerPluginIds = new Map<string, string[]>();
   return async (lookup, scopedPluginIds) => {
@@ -589,7 +601,7 @@ function createScopedBundledProviderStaticCatalogModelResolver(
       pluginCatalogs.set(catalogKey, catalog);
     }
     return ((await catalog).get(provider) ?? []).find((candidate) =>
-      staticModelIdMatches({
+      matchesStaticModelId({
         candidateId: candidate.id,
         provider,
         modelId: lookup.modelId,

--- a/src/agents/embedded-agent-runner/model.static-id.ts
+++ b/src/agents/embedded-agent-runner/model.static-id.ts
@@ -1,18 +1,41 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { normalizeStaticProviderModelId } from "../model-ref-shared.js";
+import {
+  createStaticProviderModelIdNormalizer,
+  normalizeStaticProviderModelId,
+  type ProviderModelIdNormalizationOptions,
+} from "../model-ref-shared.js";
 
-export function staticModelIdMatches(params: {
+type StaticModelIdMatchParams = {
   candidateId: string;
   provider: string;
   modelId: string;
   rowProvider?: string;
-}): boolean {
+};
+
+export type StaticModelIdMatcher = (params: StaticModelIdMatchParams) => boolean;
+
+function matchesStaticModelId(
+  params: StaticModelIdMatchParams,
+  normalizeModelId: (provider: string, model: string) => string,
+): boolean {
   const normalizedProvider = normalizeProviderId(params.provider);
   if (params.rowProvider && normalizeProviderId(params.rowProvider) !== normalizedProvider) {
     return false;
   }
   return (
-    normalizeStaticProviderModelId(normalizedProvider, params.candidateId).trim().toLowerCase() ===
-    normalizeStaticProviderModelId(normalizedProvider, params.modelId).trim().toLowerCase()
+    normalizeModelId(normalizedProvider, params.candidateId).trim().toLowerCase() ===
+    normalizeModelId(normalizedProvider, params.modelId).trim().toLowerCase()
   );
+}
+
+export function staticModelIdMatches(params: StaticModelIdMatchParams): boolean {
+  return matchesStaticModelId(params, normalizeStaticProviderModelId);
+}
+
+/** Builds a matcher pinned to one prepared manifest-policy generation. */
+export function createStaticModelIdMatcher(
+  options: ProviderModelIdNormalizationOptions = {},
+): StaticModelIdMatcher {
+  const normalizeModelId = createStaticProviderModelIdNormalizer(options);
+  return (params) => matchesStaticModelId(params, normalizeModelId);
 }

--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -99,6 +99,25 @@ export function normalizeStaticProviderModelId(
   return normalizeBuiltInProviderModelId(normalizedProvider, manifestModelId);
 }
 
+/**
+ * Captures manifest policies once for repeated static model-id comparisons.
+ * Lifecycle-prepared callers must not rediscover plugin metadata inside model loops.
+ */
+export function createStaticProviderModelIdNormalizer(
+  options: ProviderModelIdNormalizationOptions = {},
+): (provider: string, model: string) => string {
+  if (options.allowManifestNormalization === false) {
+    return (provider, model) =>
+      normalizeBuiltInProviderModelId(normalizeProviderId(provider), model);
+  }
+  if (options.manifestPlugins) {
+    const policies = collectManifestModelIdNormalizationPolicies(options.manifestPlugins);
+    return (provider, model) =>
+      normalizeStaticProviderModelIdWithPolicies(normalizeProviderId(provider), model, policies);
+  }
+  return (provider, model) => normalizeStaticProviderModelId(provider, model, options);
+}
+
 /** Normalize a configured catalog model ID for comparisons against provider catalogs. */
 export function normalizeConfiguredProviderCatalogModelId(
   provider: string,

--- a/src/agents/prepared-model-runtime.configured.ts
+++ b/src/agents/prepared-model-runtime.configured.ts
@@ -13,7 +13,7 @@ import {
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { resolveAgentEntry } from "./agent-scope-config.js";
 import { buildInlineProviderModels } from "./embedded-agent-runner/model.inline-provider.js";
-import { staticModelIdMatches } from "./embedded-agent-runner/model.static-id.js";
+import type { StaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
 import type { AuthStorageData } from "./sessions/auth-storage.js";
 
@@ -98,12 +98,13 @@ function hasConfiguredInlineProviderModel(
   config: OpenClawConfig,
   provider: string,
   modelId: string,
+  matchesStaticModelId: StaticModelIdMatcher,
 ): boolean {
   return Object.entries(config.models?.providers ?? {}).some(
     ([providerId, providerConfig]) =>
       normalizeProviderId(providerId) === provider &&
       (providerConfig.models ?? []).some((model) =>
-        staticModelIdMatches({
+        matchesStaticModelId({
           candidateId: model.id,
           rowProvider: providerId,
           provider,
@@ -120,6 +121,7 @@ export function collectConfiguredProviderIdsNeedingStaticCatalog(params: {
     provider: string;
     modelId: string;
   }) => ProviderRuntimeModel | undefined;
+  matchesStaticModelId: StaticModelIdMatcher;
 }): string[] {
   const providerIds = new Set<string>();
   for (const { value } of params.configuredModelRefs ?? collectConfiguredModelRefs(params.config)) {
@@ -132,7 +134,12 @@ export function collectConfiguredProviderIdsNeedingStaticCatalog(params: {
     if (
       !provider ||
       !modelId ||
-      hasConfiguredInlineProviderModel(params.config, provider, modelId) ||
+      hasConfiguredInlineProviderModel(
+        params.config,
+        provider,
+        modelId,
+        params.matchesStaticModelId,
+      ) ||
       params.resolveStaticCatalogModel({ provider, modelId })
     ) {
       continue;
@@ -152,6 +159,7 @@ export function prepareConfiguredRuntimeModels(params: {
     provider: string;
     modelId: string;
   }) => ProviderRuntimeModel | undefined;
+  matchesStaticModelId: StaticModelIdMatcher;
 }): PreparedConfiguredRuntimeModel[] {
   const prepared: PreparedConfiguredRuntimeModel[] = [];
   const seen = new Set<string>();
@@ -179,9 +187,10 @@ export function prepareConfiguredRuntimeModels(params: {
         metadataSnapshot: params.metadataSnapshot,
         provider,
         modelId,
+        matchesStaticModelId: params.matchesStaticModelId,
       }) ??
       params.providerStaticModels.find((candidate) =>
-        staticModelIdMatches({
+        params.matchesStaticModelId({
           candidateId: candidate.id,
           rowProvider: candidate.provider,
           provider,
@@ -200,6 +209,7 @@ function findPreparedProviderStaticCatalogModel(params: {
   metadataSnapshot: PluginMetadataSnapshot;
   provider: string;
   modelId: string;
+  matchesStaticModelId: StaticModelIdMatcher;
 }): ProviderRuntimeModel | undefined {
   if (!params.prepared) {
     return undefined;
@@ -209,7 +219,7 @@ function findPreparedProviderStaticCatalogModel(params: {
       normalizePluginDiscoveryResult({ provider, result }),
     )) {
       const model = (providerConfig.models ?? []).find((candidate) =>
-        staticModelIdMatches({
+        params.matchesStaticModelId({
           candidateId: candidate.id,
           rowProvider: providerId,
           provider: params.provider,

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -32,6 +32,7 @@ import {
   createBundledStaticCatalogModelResolver,
   loadBundledProviderStaticCatalogContextModels,
 } from "./embedded-agent-runner/model.static-catalog.js";
+import { createStaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
 import { buildPreparedModelCatalogSnapshot, type ModelCatalogEntry } from "./model-catalog.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
@@ -227,6 +228,9 @@ export async function prepareWorkspaceBuildGroup(
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
   });
   const pluginMetadataMs = performance.now() - pluginMetadataStartedAt;
+  const matchesStaticModelId = createStaticModelIdMatcher({
+    manifestPlugins: pluginMetadataSnapshot.plugins,
+  });
   const mediaCapabilityProviders =
     input.readOnly || !runtimePluginRegistry
       ? undefined
@@ -260,6 +264,7 @@ export async function prepareWorkspaceBuildGroup(
   const configuredProviderIds = collectPreparedModelRuntimeProviderIds(input.config, {}, false);
   const staticCatalogProviderIds = collectConfiguredProviderIdsNeedingStaticCatalog({
     config: input.config,
+    matchesStaticModelId,
     resolveStaticCatalogModel: resolveConfiguredManifestModel,
   });
   const staticProviderCatalogStartedAt = performance.now();
@@ -337,6 +342,7 @@ export async function prepareWorkspaceBuildGroup(
       metadataSnapshot: pluginMetadataSnapshot,
       ...(preparedStaticProviderCatalog ? { preparedStaticProviderCatalog } : {}),
       providerStaticModels,
+      matchesStaticModelId,
       resolveStaticCatalogModel: resolveConfiguredManifestModel,
     });
     const configuredEntryKeys = new Set(configuredCatalogEntries.map(modelCatalogEntryKey));

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => {
     authStorage,
     modelRegistry,
     metadataSnapshot,
+    resolvePluginMetadataSnapshot: vi.fn(() => metadataSnapshot),
     resolveAmbientCredentials: vi.fn((..._args: unknown[]) => ({})),
     discoverAuthStorage: vi.fn(() => authStorage),
     discoverModels: vi.fn(() => modelRegistry),
@@ -98,7 +99,7 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
   loadPluginMetadataSnapshot: () => mocks.metadataSnapshot,
-  resolvePluginMetadataSnapshot: () => mocks.metadataSnapshot,
+  resolvePluginMetadataSnapshot: mocks.resolvePluginMetadataSnapshot,
 }));
 
 vi.mock("./agent-auth-discovery.js", () => ({
@@ -274,6 +275,7 @@ describe("prepared model runtime Gateway catalog mode", () => {
     );
     expect(mocks.buildPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
     expect(mocks.loadStaticCatalog).not.toHaveBeenCalled();
+    expect(mocks.resolvePluginMetadataSnapshot).toHaveBeenCalledOnce();
     expect(configuredRuntimeModelCount).toBe(1);
     expect(generatedCatalogReadCount).toBe(0);
     const snapshot = getPreparedModelRuntimeSnapshot({


### PR DESCRIPTION
Closes #116552

## What Problem This Solves

Fixes an issue where gateways with multiple agents and many configured model references could spend tens of seconds in prepared model publication during cold startup, delaying readiness and causing early health probes to time out.

## Why This Change Was Made

Prepared workspace facts now compile one static model-ID matcher from the lifecycle-owned plugin metadata snapshot and carry it through configured-model and bundled static-catalog lookups. This preserves manifest normalization semantics while preventing model comparison loops from rediscovering plugin metadata.

## User Impact

Gateway startup no longer grows by repeatedly scanning plugin metadata for each agent/model comparison. On the reproduced 12-agent, 312-model configuration, configured projection dropped from 49.1 seconds to 17.9 milliseconds while all 312 configured models remained available.

## Evidence

- Red reproduction on unmodified canonical main: 98.5 seconds total prepared publication, including 49.1 seconds in `configuredProjectionMs`.
- Source-blind head validation: `configuredProjectionMs=17.88`, `agentCount=12`, `configuredRuntimeModelCount=312`.
- Focused tests: 24/24 passed across `prepared-model-runtime.startup-static`, `model.static-catalog.snapshot-cache`, and `model-ref-shared`.
- Remote changed gate on Blacksmith Testbox: core production/test typechecks, lint, dead exports, format, boundaries, import cycles, and runtime guards passed.
- Structured autoreview: clean; no accepted/actionable findings.
- Duplicate search on July 30, 2026 found no open issue or PR covering this configured-model/plugin-metadata rescan. PR #116319 is diagnostics-only and does not touch this runtime path.

AI-assisted: Codex was used for investigation, implementation, testing, and review. The change and evidence were inspected before submission.