### PR TITLE
fix: Copilot stored-profile turns fail in external harnesses

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -224,7 +224,9 @@ export const mockedResolveModelAsync = vi.fn(
   async (provider?: string, modelId?: string, _agentDir?: string, cfg?: unknown) =>
     createMockResolvedModel(provider, modelId, cfg),
 );
-const mockedPrepareProviderRuntimeAuth = vi.fn(async () => undefined);
+export const mockedPrepareProviderRuntimeAuth = vi.fn<
+  (params?: { context?: { apiKey?: string } }) => Promise<{ apiKey: string } | undefined>
+>(async () => undefined);
 export const mockedRunEmbeddedAttempt =
   vi.fn<(params: unknown) => Promise<EmbeddedRunAttemptResult>>();
 export const mockedBuildEmbeddedRunPayloads = vi.fn<

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -51,6 +51,7 @@ import {
   mockedIsLikelyContextOverflowError,
   mockedMarkAuthProfileSuccess,
   mockedPickFallbackThinkingLevel,
+  mockedPrepareProviderRuntimeAuth,
   mockedResolveAuthProfileOrder,
   mockedResolveContextWindowInfo,
   mockedResolveFailoverStatus,
@@ -880,7 +881,7 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     ).toBeUndefined();
   });
 
-  it("forwards unscoped tool auth profiles to Copilot plugin harnesses", async () => {
+  it("resolves stored Copilot auth and forwards its scoped tool auth store", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
     const pluginRunAttempt = vi.fn<AgentHarness["runAttempt"]>(async () =>
       makeAttemptResult({ assistantTexts: ["ok"] }),
@@ -907,7 +908,13 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       runAttempt: pluginRunAttempt,
     });
     mockedBuildAgentRuntimePlan.mockReturnValueOnce(runtimePlan);
-    mockedGetApiKeyForModel.mockRejectedValueOnce(new Error("generic auth should be skipped"));
+    mockedGetApiKeyForModel.mockResolvedValueOnce({
+      apiKey: "github-source-token",
+      profileId: "github-copilot:work",
+      source: "test",
+      mode: "oauth",
+    });
+    mockedPrepareProviderRuntimeAuth.mockResolvedValueOnce({ apiKey: "github-runtime-token" });
     const copilotAuthStore = {
       version: 1 as const,
       profiles: {
@@ -951,9 +958,12 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       clearAgentHarnesses();
     }
 
-    expect(mockedGetApiKeyForModel).not.toHaveBeenCalled();
+    expect(mockedGetApiKeyForModel).toHaveBeenCalledTimes(1);
     expect(pluginRunAttempt).toHaveBeenCalledTimes(1);
-    const harnessParams = mockCallArg(pluginRunAttempt) as {
+    const harnessParams = expectMockCallFields(pluginRunAttempt, {
+      authProfileId: "github-copilot:work",
+      resolvedApiKey: "github-source-token",
+    }) as {
       authProfileStore?: { profiles?: Record<string, unknown> };
       toolAuthProfileStore?: unknown;
     };
@@ -2310,6 +2320,11 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
         mode: "oauth",
       }),
     );
+    mockedPrepareProviderRuntimeAuth.mockImplementation(
+      async (params?: { context?: { apiKey?: string } }) => ({
+        apiKey: `runtime:${params?.context?.apiKey ?? "missing"}`,
+      }),
+    );
     mockedCoerceToFailoverError.mockImplementation((error) =>
       error === subscriptionLimit ? normalizedLimit : null,
     );
@@ -2339,8 +2354,16 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     }
 
     expect(mockedGetApiKeyForModel).toHaveBeenCalledTimes(2);
-    expect(codexAuthStorage.setRuntimeApiKey).toHaveBeenNthCalledWith(1, "openai", "sub-token");
-    expect(codexAuthStorage.setRuntimeApiKey).toHaveBeenNthCalledWith(2, "openai", "backup-token");
+    expect(codexAuthStorage.setRuntimeApiKey).toHaveBeenNthCalledWith(
+      1,
+      "openai",
+      expect.stringMatching(/^oc-sent-v2\./),
+    );
+    expect(codexAuthStorage.setRuntimeApiKey).toHaveBeenNthCalledWith(
+      2,
+      "openai",
+      expect.stringMatching(/^oc-sent-v2\./),
+    );
     expect(pluginRunAttempt).toHaveBeenCalledTimes(2);
     expectMockCallFields(pluginRunAttempt, {
       provider: "openai",

--- a/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
@@ -100,9 +100,10 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
   const prompt = terminalRetryState.compactionContinuationInstruction
     ? `${basePrompt}\n\n${terminalRetryState.compactionContinuationInstruction}`
     : basePrompt;
-  const resolvedStreamApiKey = resolveAttemptDispatchApiKey({
+  const resolvedAttemptApiKey = resolveAttemptDispatchApiKey({
     apiKeyInfo: runtime.apiKeyInfo,
     runtimeAuthState: runtime.runtimeAuthState,
+    pluginHarnessOwnsTransport: runtime.pluginHarnessOwnsTransport,
   });
   const attemptFastMode = resolveAttemptFastModeParam();
   const existingSessionTarget = sessionPromptState.sessionTarget;
@@ -216,7 +217,7 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
       expectedRuntimeArtifact: expectedHarnessArtifact?.artifact,
       runtimePlan,
       model: runtime.effectiveModel,
-      resolvedApiKey: resolvedStreamApiKey,
+      resolvedApiKey: resolvedAttemptApiKey,
       authProfileId: runtime.lastProfileId,
       authProfileIdSource: lockedProfileId ? "user" : "auto",
       initialReplayState: input.replayState,

--- a/src/agents/embedded-agent-runner/run/auth-store.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-store.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveAttemptDispatchApiKey } from "./auth-store.js";
+
+const apiKeyInfo = {
+  apiKey: "source-token",
+  source: "profile:test",
+  mode: "oauth" as const,
+};
+
+const runtimeAuthState = {
+  generation: 1,
+  sourceApiKey: "source-token",
+  authMode: "oauth",
+  profileId: "test:profile",
+};
+
+describe("resolveAttemptDispatchApiKey", () => {
+  it("keeps provider-prepared runtime auth inside the core transport", () => {
+    expect(
+      resolveAttemptDispatchApiKey({
+        apiKeyInfo,
+        runtimeAuthState,
+        pluginHarnessOwnsTransport: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("forwards the resolved source credential to a transport-owning harness", () => {
+    expect(
+      resolveAttemptDispatchApiKey({
+        apiKeyInfo,
+        runtimeAuthState,
+        pluginHarnessOwnsTransport: true,
+      }),
+    ).toBe("source-token");
+  });
+
+  it("keeps direct credentials available without provider runtime auth", () => {
+    expect(
+      resolveAttemptDispatchApiKey({
+        apiKeyInfo,
+        runtimeAuthState: null,
+        pluginHarnessOwnsTransport: false,
+      }),
+    ).toBe("source-token");
+  });
+});

--- a/src/agents/embedded-agent-runner/run/auth-store.ts
+++ b/src/agents/embedded-agent-runner/run/auth-store.ts
@@ -5,9 +5,13 @@ import type { RuntimeAuthState } from "./helpers.js";
 export function resolveAttemptDispatchApiKey(params: {
   apiKeyInfo: ResolvedProviderAuth | null;
   runtimeAuthState: RuntimeAuthState | null;
+  pluginHarnessOwnsTransport: boolean;
 }): string | undefined {
   if (params.runtimeAuthState) {
-    return undefined;
+    // Core streaming consumes the provider-prepared runtime credential from
+    // authStorage. A transport-owning harness instead needs the original
+    // resolved profile credential promised by its attempt contract.
+    return params.pluginHarnessOwnsTransport ? params.runtimeAuthState.sourceApiKey : undefined;
   }
   return params.apiKeyInfo?.apiKey;
 }

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.ts
@@ -175,7 +175,6 @@ export async function prepareEmbeddedRunRuntime(input: {
     markStage: (stage) => authStages?.mark(stage),
   });
   const {
-    usesOpenAIAuthRouting,
     attemptAuthProfileStore,
     lockedProfileId,
     preferredProfileId,
@@ -233,7 +232,6 @@ export async function prepareEmbeddedRunRuntime(input: {
   );
   const pluginHarnessNeedsOpenClawAuthBootstrap =
     pluginHarnessOwnsTransport &&
-    usesOpenAIAuthRouting &&
     (preparedApiKeyRoute ||
       (!pluginHarnessOwnsAuthBootstrap &&
         profileCandidates.some((profileId) => Boolean(profileId))));


### PR DESCRIPTION
Related: #108738

## What Problem This Solves

Fixes an issue where users running Copilot through a transport-owning harness could complete isolated inference but an ordinary turn would fail with `Session was not created with authentication info or custom provider` when authentication came from a stored OpenClaw profile.

## Why This Change Was Made

OpenClaw now resolves stored credentials for transport-owning harnesses unless a harness explicitly owns auth bootstrap. When provider runtime auth is active, core streaming continues to consume the provider-prepared credential internally, while a transport-owning harness receives the original resolved profile credential promised by the attempt contract.

This keeps credential ownership aligned with transport ownership without exposing provider-prepared runtime credentials or adding a Copilot-specific core path.

## User Impact

Existing Copilot stored-profile users can run both isolated completions and ordinary external-harness turns. Core-owned provider transports retain their existing credential behavior, and harnesses that explicitly own auth bootstrap remain unchanged.

## Evidence

- Before-fix live Crabbox reproduction: isolated Copilot completion passed, while the ordinary stored-profile turn failed during Copilot SDK session creation.
- After-fix live Crabbox proof: isolated JSON task, fresh-context completion, direct owner completion, and ordinary external Copilot turn all passed; the ordinary host exited cleanly.
- Fail-closed control returned `LLM_RUNTIME_UNAVAILABLE` for an unsupported runtime.
- Live run: https://crabbox.openclaw.ai/portal/runs/run_08c8963f9512
- Focused regression coverage passed, including exact source-credential handoff, provider-prepared credential isolation, profile failover, and core-transport behavior.
- `pnpm check:changed` passed on Blacksmith Testbox.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/auth-store.test.ts` passed (3 tests).
- `git diff --check` passed.
- Autoreview (`--mode uncommitted`, Codex `gpt-5.6-sol`, high reasoning) reported no accepted/actionable findings.

AI-assisted implementation; the patch and live behavior were manually reviewed and verified.
