### PR TITLE
fix(gateway): return valid upgrade rate-limit responses

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -330,22 +330,22 @@ function writeUpgradeAuthFailure(
   if (auth.rateLimited) {
     const retryAfterSeconds =
       auth.retryAfterMs && auth.retryAfterMs > 0 ? Math.ceil(auth.retryAfterMs / 1000) : undefined;
+    const body = JSON.stringify({
+      error: {
+        message: "Too many failed authentication attempts. Please try again later.",
+        type: "rate_limited",
+      },
+    });
     socket.write(
       [
         "HTTP/1.1 429 Too Many Requests",
-        retryAfterSeconds ? `Retry-After: ${retryAfterSeconds}` : undefined,
+        ...(retryAfterSeconds ? [`Retry-After: ${retryAfterSeconds}`] : []),
         "Content-Type: application/json; charset=utf-8",
+        `Content-Length: ${Buffer.byteLength(body, "utf8")}`,
         "Connection: close",
         "",
-        JSON.stringify({
-          error: {
-            message: "Too many failed authentication attempts. Please try again later.",
-            type: "rate_limited",
-          },
-        }),
-      ]
-        .filter(Boolean)
-        .join("\r\n"),
+        body,
+      ].join("\r\n"),
     );
     return;
   }

--- a/src/gateway/server.plugin-node-capability-auth.test.ts
+++ b/src/gateway/server.plugin-node-capability-auth.test.ts
@@ -1,6 +1,6 @@
 // Plugin node capability auth tests cover scoped canvas/A2UI HTTP and WebSocket
 // routes, preauth budgets, capability paths, and unauthorized upgrade handling.
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { request, type IncomingMessage, type ServerResponse } from "node:http";
 import { connect, type Socket } from "node:net";
 import type { Duplex } from "node:stream";
 import { describe, expect, test } from "vitest";
@@ -115,6 +115,53 @@ async function expectWsRejected(
       clearTimeout(timer);
       resolve();
     });
+  });
+}
+
+async function requestWsUpgradeResponse(params: {
+  port: number;
+  path: string;
+  headers: Record<string, string>;
+}): Promise<{
+  statusCode: number;
+  headers: IncomingMessage["headers"];
+  body: string;
+  complete: boolean;
+}> {
+  return await new Promise((resolve, reject) => {
+    const req = request({
+      host: "127.0.0.1",
+      port: params.port,
+      path: params.path,
+      headers: {
+        ...params.headers,
+        connection: "Upgrade",
+        upgrade: "websocket",
+        "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+        "sec-websocket-version": "13",
+      },
+    });
+    req.setTimeout(WS_REJECT_TIMEOUT_MS, () => {
+      req.destroy(new Error("timeout"));
+    });
+    req.once("response", (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.once("end", () => {
+        resolve({
+          statusCode: res.statusCode ?? 0,
+          headers: res.headers,
+          body: Buffer.concat(chunks).toString("utf8"),
+          complete: res.complete,
+        });
+      });
+    });
+    req.once("upgrade", (_res, socket) => {
+      socket.destroy();
+      reject(new Error("expected upgrade to reject"));
+    });
+    req.once("error", reject);
+    req.end();
   });
 }
 
@@ -660,7 +707,24 @@ describe("gateway plugin node capability auth", () => {
           const second = await expectRepeatedCanvasAuthAttemptsRateLimited(listener, headers);
           expect(second.headers.get("retry-after")).toMatch(/^\d+$/);
 
-          await expectWsRejected(`ws://127.0.0.1:${listener.port}${CANVAS_WS_PATH}`, headers, 429);
+          const upgradeResponse = await requestWsUpgradeResponse({
+            port: listener.port,
+            path: CANVAS_WS_PATH,
+            headers,
+          });
+          const expectedBody = JSON.stringify({
+            error: {
+              message: "Too many failed authentication attempts. Please try again later.",
+              type: "rate_limited",
+            },
+          });
+          expect(upgradeResponse.statusCode).toBe(429);
+          expect(upgradeResponse.headers["retry-after"]).toMatch(/^\d+$/);
+          expect(upgradeResponse.headers["content-length"]).toBe(
+            String(Buffer.byteLength(expectedBody, "utf8")),
+          );
+          expect(upgradeResponse.body).toBe(expectedBody);
+          expect(upgradeResponse.complete).toBe(true);
         },
       });
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where rate-limited WebSocket and protected plugin/node-capability upgrades emitted malformed HTTP bytes. Clients saw a parser/protocol error instead of a usable `429 Too Many Requests` response, losing the JSON error and `Retry-After` backoff signal.

## Why This Change Was Made

The upgrade-auth failure owner now builds the JSON body once, emits its exact UTF-8 `Content-Length`, includes `Retry-After` only when present, and appends the mandatory HTTP header/body separator explicitly. The change preserves the existing auth limiter, status, body shape, socket close behavior, and ordinary 401/503 siblings.

## User Impact

Rate-limited upgrade clients can parse the 429 status and back off correctly instead of treating the lockout response as corrupted transport data or reconnecting aggressively.

Release-note context: Gateway WebSocket and plugin upgrade rate limits now return valid parseable HTTP 429 responses with retry guidance.

## Evidence

- Before: the real upgrade handler removed its empty separator with `.filter(Boolean)`; Node's standard HTTP parser rejected the wire response with `HPE_INVALID_HEADER_TOKEN`.
- After: the real rate-limited path parses as 429, exposes `Retry-After`, reads the complete JSON body, and completes normally; 9/9 focused Gateway tests pass on exact rebased head `bd599daab55a2eb8e2b499557f8f17372207efd1`.
- Blacksmith Testbox `tbx_01kytc70xks2wc99jzhsrnfgr6`; focused proof and remote changed gate succeeded in [run 30580327867](https://github.com/openclaw/openclaw/actions/runs/30580327867).
- Final Codex autoreview: clean, confidence 0.98.
- `git diff --check`: clean; rebase patch ID unchanged.
