### PR TITLE
fix(voice-call): realtime consults stop with their calls

### DIFF
--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -164,6 +164,81 @@ describe("RealtimeCallHandler lifecycle", () => {
     }
   });
 
+  it("tolerates provider close during bridge creation", async () => {
+    const bridgeConnect = vi.fn(async () => {});
+    const createBridgeForCall = vi.fn(
+      (request: { onClose?: (reason: "completed" | "error") => void }) => {
+        request.onClose?.("completed");
+        return createBridge(vi.fn(), { connect: bridgeConnect });
+      },
+    );
+    const call: CallRecord = {
+      callId: "call-synchronous-close",
+      providerCallId: "CA-synchronous-close",
+      provider: "twilio",
+      direction: "inbound",
+      state: "ringing",
+      from: "+15550001111",
+      to: "+15550002222",
+      startedAt: Date.now(),
+      transcript: [],
+      processedEventIds: [],
+    };
+    const handler = new RealtimeCallHandler(
+      createRealtimeConfig(),
+      {
+        processEvent: vi.fn(),
+        getCallByProviderCallId: vi.fn(() => call),
+      } as unknown as CallManager,
+      {
+        name: "twilio",
+        verifyWebhook: vi.fn(),
+        parseWebhookEvent: vi.fn(),
+        initiateCall: vi.fn(),
+        hangupCall: vi.fn(),
+        playTts: vi.fn(),
+        startListening: vi.fn(),
+        stopListening: vi.fn(),
+        getCallStatus: vi.fn(),
+      } as unknown as VoiceCallProvider,
+      {
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: () => true,
+        createBridge: createBridgeForCall,
+      },
+      { apiKey: "test-key" },
+      "/voice/webhook",
+    );
+    const { streamUrl } = handler.issueStreamSession();
+    const server = await startUpgradeWsServer({
+      urlPath: new URL(streamUrl).pathname,
+      onUpgrade: (request, socket, head) => {
+        handler.handleWebSocketUpgrade(request, socket, head);
+      },
+    });
+    const ws = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-synchronous-close", callSid: "CA-synchronous-close" },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(createBridgeForCall).toHaveBeenCalledTimes(1);
+        expect(bridgeConnect).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
   it("releases a hung native consult and ignores its late result after stream teardown", async () => {
     let onToolCall:
       | ((event: { itemId: string; callId: string; name: string; args: unknown }) => void)

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -35,7 +35,10 @@ function createRealtimeConfig(): VoiceCallRealtimeConfig {
   };
 }
 
-function createBridge(close: () => void): RealtimeVoiceBridge {
+function createBridge(
+  close: () => void,
+  overrides: Partial<RealtimeVoiceBridge> = {},
+): RealtimeVoiceBridge {
   return {
     connect: async () => {},
     sendAudio: () => {},
@@ -45,6 +48,7 @@ function createBridge(close: () => void): RealtimeVoiceBridge {
     close,
     isConnected: () => true,
     triggerGreeting: () => {},
+    ...overrides,
   };
 }
 
@@ -153,6 +157,136 @@ describe("RealtimeCallHandler lifecycle", () => {
     } finally {
       releaseShutdownBarrier?.();
       if (ws && ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
+  it("releases a hung native consult and ignores its late result after stream teardown", async () => {
+    let onToolCall:
+      | ((event: { itemId: string; callId: string; name: string; args: unknown }) => void)
+      | undefined;
+    let resolveConsult: ((result: unknown) => void) | undefined;
+    const submitToolResult = vi.fn();
+    const createBridgeForCall = vi.fn(
+      (request: {
+        onToolCall?: (event: {
+          itemId: string;
+          callId: string;
+          name: string;
+          args: unknown;
+        }) => void;
+      }) => {
+        onToolCall = request.onToolCall;
+        return createBridge(vi.fn(), {
+          supportsToolResultContinuation: true,
+          submitToolResult,
+        });
+      },
+    );
+    const call: CallRecord = {
+      callId: "call-consult",
+      providerCallId: "CA-consult",
+      provider: "twilio",
+      direction: "inbound",
+      state: "ringing",
+      from: "+15550001111",
+      to: "+15550002222",
+      startedAt: Date.now(),
+      transcript: [],
+      processedEventIds: [],
+    };
+    const handler = new RealtimeCallHandler(
+      createRealtimeConfig(),
+      {
+        processEvent: vi.fn(),
+        getCallByProviderCallId: vi.fn(() => call),
+      } as unknown as CallManager,
+      {
+        name: "twilio",
+        verifyWebhook: vi.fn(),
+        parseWebhookEvent: vi.fn(),
+        initiateCall: vi.fn(),
+        hangupCall: vi.fn(),
+        playTts: vi.fn(),
+        startListening: vi.fn(),
+        stopListening: vi.fn(),
+        getCallStatus: vi.fn(),
+      } as unknown as VoiceCallProvider,
+      {
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: () => true,
+        createBridge: createBridgeForCall,
+      },
+      { apiKey: "test-key" },
+      "/voice/webhook",
+    );
+    handler.registerToolHandler(
+      "openclaw_agent_consult",
+      async () =>
+        await new Promise<unknown>((resolve) => {
+          resolveConsult = resolve;
+        }),
+    );
+    const { streamUrl } = handler.issueStreamSession();
+    const server = await startUpgradeWsServer({
+      urlPath: new URL(streamUrl).pathname,
+      onUpgrade: (request, socket, head) => {
+        handler.handleWebSocketUpgrade(request, socket, head);
+      },
+    });
+    const ws = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-consult", callSid: "CA-consult" },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(createBridgeForCall).toHaveBeenCalledTimes(1);
+      });
+
+      onToolCall?.({
+        itemId: "item-consult",
+        callId: "tool-consult",
+        name: "openclaw_agent_consult",
+        args: { question: "Check the deployment." },
+      });
+      await vi.waitFor(() => {
+        expect(resolveConsult).toBeTypeOf("function");
+      });
+
+      const consults = (
+        handler as unknown as {
+          nativeConsultsInFlightByCallId: Map<string, unknown>;
+        }
+      ).nativeConsultsInFlightByCallId;
+      expect(consults.size).toBe(1);
+
+      const closed = waitForClose(ws);
+      ws.close();
+      await closed;
+      await vi.waitFor(() => {
+        expect(consults.size).toBe(0);
+      });
+
+      resolveConsult?.({ text: "Deployment is healthy." });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(submitToolResult).toHaveBeenCalledTimes(1);
+      expect(submitToolResult).not.toHaveBeenCalledWith(
+        "tool-consult",
+        { text: "Deployment is healthy." },
+        undefined,
+      );
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED) {
         ws.terminate();
       }
       await handler.close();

--- a/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.lifecycle.test.ts
@@ -239,6 +239,131 @@ describe("RealtimeCallHandler lifecycle", () => {
     }
   });
 
+  it("does not start a native consult after teardown during transcript settling", async () => {
+    let onToolCall:
+      | ((event: { itemId: string; callId: string; name: string; args: unknown }) => void)
+      | undefined;
+    let onTranscript:
+      | ((role: "user" | "assistant", text: string, isFinal: boolean) => void)
+      | undefined;
+    const submitToolResult = vi.fn();
+    const createBridgeForCall = vi.fn(
+      (request: {
+        onToolCall?: (event: {
+          itemId: string;
+          callId: string;
+          name: string;
+          args: unknown;
+        }) => void;
+        onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+      }) => {
+        onToolCall = request.onToolCall;
+        onTranscript = request.onTranscript;
+        return createBridge(vi.fn(), {
+          supportsToolResultContinuation: true,
+          submitToolResult,
+        });
+      },
+    );
+    const call: CallRecord = {
+      callId: "call-settling-consult",
+      providerCallId: "CA-settling-consult",
+      provider: "twilio",
+      direction: "inbound",
+      state: "ringing",
+      from: "+15550001111",
+      to: "+15550002222",
+      startedAt: Date.now(),
+      transcript: [],
+      processedEventIds: [],
+    };
+    const handler = new RealtimeCallHandler(
+      createRealtimeConfig(),
+      {
+        processEvent: vi.fn(),
+        getCallByProviderCallId: vi.fn(() => call),
+      } as unknown as CallManager,
+      {
+        name: "twilio",
+        verifyWebhook: vi.fn(),
+        parseWebhookEvent: vi.fn(),
+        initiateCall: vi.fn(),
+        hangupCall: vi.fn(),
+        playTts: vi.fn(),
+        startListening: vi.fn(),
+        stopListening: vi.fn(),
+        getCallStatus: vi.fn(),
+      } as unknown as VoiceCallProvider,
+      {
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: () => true,
+        createBridge: createBridgeForCall,
+      },
+      { apiKey: "test-key" },
+      "/voice/webhook",
+    );
+    const consult = vi.fn(async () => ({ text: "This should not run." }));
+    handler.registerToolHandler("openclaw_agent_consult", consult);
+    const { streamUrl } = handler.issueStreamSession();
+    const server = await startUpgradeWsServer({
+      urlPath: new URL(streamUrl).pathname,
+      onUpgrade: (request, socket, head) => {
+        handler.handleWebSocketUpgrade(request, socket, head);
+      },
+    });
+    const ws = await connectWs(server.url);
+
+    try {
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-settling-consult", callSid: "CA-settling-consult" },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(createBridgeForCall).toHaveBeenCalledTimes(1);
+      });
+
+      onTranscript?.("user", "Check the deployment", false);
+      onToolCall?.({
+        itemId: "item-settling-consult",
+        callId: "tool-settling-consult",
+        name: "openclaw_agent_consult",
+        args: { question: "Check the deployment." },
+      });
+      const consults = (
+        handler as unknown as {
+          nativeConsultsInFlightByCallId: Map<string, unknown>;
+        }
+      ).nativeConsultsInFlightByCallId;
+      await vi.waitFor(() => {
+        expect(consults.size).toBe(1);
+        expect(submitToolResult).toHaveBeenCalledTimes(1);
+        expect(consult).not.toHaveBeenCalled();
+      });
+
+      const closed = waitForClose(ws);
+      ws.close();
+      await closed;
+      await vi.waitFor(() => {
+        expect(consults.size).toBe(0);
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 400);
+      });
+
+      expect(consult).not.toHaveBeenCalled();
+      expect(submitToolResult).toHaveBeenCalledTimes(1);
+    } finally {
+      if (ws.readyState !== WebSocket.CLOSED) {
+        ws.terminate();
+      }
+      await handler.close();
+      await server.close();
+    }
+  });
+
   it("releases a hung native consult and ignores its late result after stream teardown", async () => {
     let onToolCall:
       | ((event: { itemId: string; callId: string; name: string; args: unknown }) => void)

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -277,6 +277,7 @@ type NativeConsultState = {
   startedAt: number;
   promise: Promise<unknown>;
   cancellation: Promise<void>;
+  cancelled: boolean;
   cancel: () => void;
   partialUserTranscript?: string;
 };
@@ -1078,6 +1079,7 @@ export class RealtimeCallHandler {
     if (!state || state.owner !== owner) {
       return;
     }
+    state.cancelled = true;
     this.nativeConsultsInFlightByCallId.delete(callId);
     state.cancel();
   }
@@ -1457,12 +1459,23 @@ export class RealtimeCallHandler {
         startedAt,
         promise: Promise.resolve(),
         cancellation,
+        cancelled: false,
         cancel,
       };
-      const workingSubmission = submitWorkingResponse();
-      state.promise = workingSubmission.then(async () => {
+      this.nativeConsultsInFlightByCallId.set(callId, state);
+      state.promise = Promise.resolve().then(async () => {
         try {
-          await this.waitForConsultTranscriptSettle(callId, startedAt);
+          await submitWorkingResponse();
+          if (state.cancelled) {
+            return;
+          }
+          await Promise.race([
+            this.waitForConsultTranscriptSettle(callId, startedAt),
+            state.cancellation,
+          ]);
+          if (state.cancelled) {
+            return;
+          }
           const context = {
             partialUserTranscript: this.resolveUserTranscriptContext(callId),
           };
@@ -1480,7 +1493,6 @@ export class RealtimeCallHandler {
           };
         }
       });
-      this.nativeConsultsInFlightByCallId.set(callId, state);
       try {
         const outcome = await waitForNativeConsult(state);
         if (outcome.kind === "cancelled") {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -1471,14 +1471,14 @@ export class RealtimeCallHandler {
         try {
           await submitWorkingResponse();
           if (state.cancelled) {
-            return;
+            return undefined;
           }
           await Promise.race([
             this.waitForConsultTranscriptSettle(callId, startedAt),
             state.cancellation,
           ]);
           if (state.cancelled) {
-            return;
+            return undefined;
           }
           const context = {
             partialUserTranscript: this.resolveUserTranscriptContext(callId),

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -1454,16 +1454,20 @@ export class RealtimeCallHandler {
       const cancellation = new Promise<void>((resolve) => {
         cancel = resolve;
       });
+      let completeConsult = (_result: unknown) => {};
+      const consult = new Promise<unknown>((resolve) => {
+        completeConsult = resolve;
+      });
       const state: NativeConsultState = {
         owner: bridge,
         startedAt,
-        promise: Promise.resolve(),
+        promise: consult,
         cancellation,
         cancelled: false,
         cancel,
       };
       this.nativeConsultsInFlightByCallId.set(callId, state);
-      state.promise = Promise.resolve().then(async () => {
+      void (async () => {
         try {
           await submitWorkingResponse();
           if (state.cancelled) {
@@ -1492,7 +1496,7 @@ export class RealtimeCallHandler {
             error: formatErrorMessage(error),
           };
         }
-      });
+      })().then(completeConsult);
       try {
         const outcome = await waitForNativeConsult(state);
         if (outcome.kind === "cancelled") {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -753,7 +753,7 @@ export class RealtimeCallHandler {
         ? this.providerConfig.interruptResponseOnInputAudio
         : undefined;
     // Providers may close synchronously before createBridge returns; no consult can exist yet.
-    let nativeConsultOwner: ActiveRealtimeVoiceBridge | undefined;
+    const nativeConsultOwner: { current?: ActiveRealtimeVoiceBridge } = {};
     const session = harness.createBridge({
       provider: this.realtimeProvider,
       cfg: this.coreConfig,
@@ -937,8 +937,8 @@ export class RealtimeCallHandler {
         this.activeBridgesByCallId.delete(callSid);
         this.activeTelephonyClosersByCallId.delete(callId);
         this.activeTelephonyClosersByCallId.delete(callSid);
-        if (nativeConsultOwner) {
-          this.cancelNativeConsult(callId, nativeConsultOwner);
+        if (nativeConsultOwner.current) {
+          this.cancelNativeConsult(callId, nativeConsultOwner.current);
         }
         this.clearUserTranscriptState(callId);
         harness.finishOutputAudio(reason);
@@ -965,7 +965,7 @@ export class RealtimeCallHandler {
           });
       },
     });
-    nativeConsultOwner = session;
+    nativeConsultOwner.current = session;
     providerHandlesInputAudioBargeIn =
       session.bridge.handlesInputAudioBargeIn ?? providerHandlesInputAudioBargeIn;
     const closeTelephony = (reason: TelephonyCloseReason) => {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -273,12 +273,24 @@ type ForcedConsultState = {
 };
 
 type NativeConsultState = {
+  owner: ActiveRealtimeVoiceBridge;
   startedAt: number;
   promise: Promise<unknown>;
+  cancellation: Promise<void>;
+  cancel: () => void;
   partialUserTranscript?: string;
 };
 
+type NativeConsultOutcome = { kind: "completed"; result: unknown } | { kind: "cancelled" };
+
 type TelephonyCloseReason = "completed" | "error";
+
+async function waitForNativeConsult(state: NativeConsultState): Promise<NativeConsultOutcome> {
+  return await Promise.race([
+    state.promise.then((result) => ({ kind: "completed", result }) as const),
+    state.cancellation.then(() => ({ kind: "cancelled" }) as const),
+  ]);
+}
 
 function appendRecentTalkEventMetadata(
   call: CallRecord | null | undefined,
@@ -923,6 +935,7 @@ export class RealtimeCallHandler {
         this.activeBridgesByCallId.delete(callSid);
         this.activeTelephonyClosersByCallId.delete(callId);
         this.activeTelephonyClosersByCallId.delete(callSid);
+        this.cancelNativeConsult(callId, session);
         this.clearUserTranscriptState(callId);
         harness.finishOutputAudio(reason);
         harness.emit({
@@ -992,6 +1005,7 @@ export class RealtimeCallHandler {
         this.activeBridgesByCallId.delete(callSid);
         this.activeTelephonyClosersByCallId.delete(callId);
         this.activeTelephonyClosersByCallId.delete(callSid);
+        this.cancelNativeConsult(callId, session);
         this.clearUserTranscriptState(callId);
         this.forcedConsultsByCallId.delete(callId);
         harness.close();
@@ -1052,6 +1066,15 @@ export class RealtimeCallHandler {
   private clearUserTranscriptState(callId: string): void {
     this.clearPartialUserTranscript(callId);
     this.clearRecentFinalUserTranscript(callId);
+  }
+
+  private cancelNativeConsult(callId: string, owner: ActiveRealtimeVoiceBridge): void {
+    const state = this.nativeConsultsInFlightByCallId.get(callId);
+    if (!state || state.owner !== owner) {
+      return;
+    }
+    this.nativeConsultsInFlightByCallId.delete(callId);
+    state.cancel();
   }
 
   private resolveUserTranscriptContext(callId: string): string | undefined {
@@ -1412,13 +1435,24 @@ export class RealtimeCallHandler {
           `[voice-call] realtime tool call sharing in-flight agent consult callId=${callId} ageMs=${Date.now() - existingNativeConsult.startedAt}`,
         );
         await submitWorkingResponse();
-        await submitFinalToolResult(await existingNativeConsult.promise);
+        const outcome = await waitForNativeConsult(existingNativeConsult);
+        if (outcome.kind === "cancelled") {
+          return;
+        }
+        await submitFinalToolResult(outcome.result);
         return;
       }
 
+      let cancel = () => {};
+      const cancellation = new Promise<void>((resolve) => {
+        cancel = resolve;
+      });
       const state: NativeConsultState = {
+        owner: bridge,
         startedAt,
         promise: Promise.resolve(),
+        cancellation,
+        cancel,
       };
       const workingSubmission = submitWorkingResponse();
       state.promise = workingSubmission.then(async () => {
@@ -1443,7 +1477,11 @@ export class RealtimeCallHandler {
       });
       this.nativeConsultsInFlightByCallId.set(callId, state);
       try {
-        const result = await state.promise;
+        const outcome = await waitForNativeConsult(state);
+        if (outcome.kind === "cancelled") {
+          return;
+        }
+        const result = outcome.result;
         const status =
           result && typeof result === "object" && !Array.isArray(result) && "error" in result
             ? "error"

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -752,6 +752,8 @@ export class RealtimeCallHandler {
       typeof this.providerConfig.interruptResponseOnInputAudio === "boolean"
         ? this.providerConfig.interruptResponseOnInputAudio
         : undefined;
+    // Providers may close synchronously before createBridge returns; no consult can exist yet.
+    let nativeConsultOwner: ActiveRealtimeVoiceBridge | undefined;
     const session = harness.createBridge({
       provider: this.realtimeProvider,
       cfg: this.coreConfig,
@@ -935,7 +937,9 @@ export class RealtimeCallHandler {
         this.activeBridgesByCallId.delete(callSid);
         this.activeTelephonyClosersByCallId.delete(callId);
         this.activeTelephonyClosersByCallId.delete(callSid);
-        this.cancelNativeConsult(callId, session);
+        if (nativeConsultOwner) {
+          this.cancelNativeConsult(callId, nativeConsultOwner);
+        }
         this.clearUserTranscriptState(callId);
         harness.finishOutputAudio(reason);
         harness.emit({
@@ -961,6 +965,7 @@ export class RealtimeCallHandler {
           });
       },
     });
+    nativeConsultOwner = session;
     providerHandlesInputAudioBargeIn =
       session.bridge.handlesInputAudioBargeIn ?? providerHandlesInputAudioBargeIn;
     const closeTelephony = (reason: TelephonyCloseReason) => {


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes native realtime voice consult work surviving telephony teardown. A hung or delayed consult could remain retained after its stream closed, start after teardown while transcript context was settling, or submit a late result to a bridge that no longer owned the call.

## Why This Change Was Made

Native consult state is now owned by the exact realtime bridge session and cancelled during provider close or explicit session close. Consult execution observes cancellation before the handler starts, races transcript settlement against teardown, releases the in-flight map entry immediately, and ignores late results without affecting a replacement session for the same call.

The existing synchronous working-response handshake remains unchanged. Provider close during bridge creation is also tolerated without a temporal-dead-zone failure.

No provider, configuration, protocol, or environment-variable surface changes.

## User Impact

Realtime voice calls release native consult state when the call ends. Closed calls cannot start delayed consult work or deliver late tool results, while active calls retain the existing consult sharing and continuation behavior.

## Evidence

- Red/green lifecycle regression: before the fix, closing a stream during partial-transcript settlement still started `openclaw_agent_consult`; after the fix, the handler never starts and only the initial working response is emitted.
- Red/green synchronous-close regression: provider close during bridge creation previously threw a temporal-dead-zone `ReferenceError`; the bridge now connects without that failure.
- Late-result regression: a never-settling consult is removed from the in-flight map on stream close and cannot submit its eventual result.
- Focused lifecycle validation on final head: 3 files, 30 tests passed.
- Full voice-call Testbox validation on final head: 57 files, 577 tests passed.
- Exact-head `pnpm check:changed`: passed for `0723190a577feb51c3c382444786c31ae147e479...fde738706b0cefc711374315df6d930a36b5b300` in Testbox `tbx_01kytdydhzw9qb755pjytb58a1`.
- Final Codex autoreview: clean, no accepted/actionable findings.
- GitHub collision check on July 30, 2026: no open PR or issue matched native consult teardown or `openclaw_agent_consult`; #116201 remains the canonical tracker.

AI-assisted: yes. I reviewed the implementation and validation evidence.
