### PR TITLE
fix(outbound): recognize current-source message-tool sends

### DIFF
--- a/extensions/discord/src/actions/handle-action.adopted-thread.test.ts
+++ b/extensions/discord/src/actions/handle-action.adopted-thread.test.ts
@@ -114,6 +114,47 @@ describe("handleDiscordMessageAction adopted thread delivery", () => {
     }
   });
 
+  it("keeps the source fallback eligible when a matching-thread send reports failure", async () => {
+    const sessionKey = "agent:main:discord:channel:channel-1";
+    const onThreadReplyDelivered = vi.fn();
+    const endRoute = beginDiscordActiveTurnThreadRoute(sessionKey, {
+      accountId: "account-1",
+      sourceChannelId: "channel-1",
+      sourceMessageId: "message-1",
+      onThreadAdopted: vi.fn(),
+      onThreadReplyDelivered,
+    });
+    try {
+      await notifyDiscordActiveTurnThreadCreated({
+        sessionKey,
+        accountId: "account-1",
+        sourceChannelId: "channel-1",
+        sourceMessageId: "message-1",
+        threadId: "thread-1",
+      });
+      handleDiscordActionMock.mockResolvedValueOnce({
+        content: [],
+        details: { ok: false, error: "delivery failed" },
+      });
+
+      const result = await handleDiscordMessageAction({
+        action: "send",
+        params: {
+          to: "channel:thread-1",
+          message: "done",
+        },
+        cfg: discordConfig(),
+        accountId: "account-1",
+        sessionKey,
+      });
+
+      expect(result.details).toEqual({ ok: false, error: "delivery failed" });
+      expect(onThreadReplyDelivered).not.toHaveBeenCalled();
+    } finally {
+      endRoute();
+    }
+  });
+
   it("preserves a successful send when route-only target parsing rejects the target", async () => {
     const result = await handleDiscordMessageAction({
       action: "send",

--- a/extensions/discord/src/actions/handle-action.adopted-thread.test.ts
+++ b/extensions/discord/src/actions/handle-action.adopted-thread.test.ts
@@ -1,0 +1,129 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeModule = await import("./runtime.js");
+const handleDiscordActionMock = vi
+  .spyOn(runtimeModule, "handleDiscordAction")
+  .mockResolvedValue({ content: [], details: { ok: true } });
+const { handleDiscordMessageAction } = await import("./handle-action.js");
+const { beginDiscordActiveTurnThreadRoute, notifyDiscordActiveTurnThreadCreated } =
+  await import("../active-turn-thread-route.js");
+
+function discordConfig(): OpenClawConfig {
+  return {
+    channels: { discord: { token: "tok" } },
+  } as OpenClawConfig;
+}
+
+describe("handleDiscordMessageAction adopted thread delivery", () => {
+  beforeEach(() => {
+    handleDiscordActionMock.mockClear();
+  });
+
+  it("classifies generic sends only when targeting the active adopted thread", async () => {
+    const sessionKey = "agent:main:discord:channel:channel-1";
+    const onThreadReplyDelivered = vi.fn();
+    const endRoute = beginDiscordActiveTurnThreadRoute(sessionKey, {
+      accountId: "account-1",
+      sourceChannelId: "channel-1",
+      sourceMessageId: "message-1",
+      onThreadAdopted: vi.fn(),
+      onThreadReplyDelivered,
+    });
+    try {
+      await notifyDiscordActiveTurnThreadCreated({
+        sessionKey,
+        accountId: "account-1",
+        sourceChannelId: "channel-1",
+        sourceMessageId: "message-1",
+        threadId: "thread-1",
+      });
+
+      const unrelatedResult = await handleDiscordMessageAction({
+        action: "send",
+        params: {
+          to: "channel:thread-2",
+          message: "unrelated",
+        },
+        cfg: discordConfig(),
+        accountId: "account-1",
+        sessionKey,
+      });
+
+      expect(unrelatedResult.details).toEqual({ ok: true });
+      expect(onThreadReplyDelivered).not.toHaveBeenCalled();
+
+      const result = await handleDiscordMessageAction({
+        action: "send",
+        params: {
+          to: "channel:thread-1",
+          message: "done",
+        },
+        cfg: discordConfig(),
+        accountId: "account-1",
+        sessionKey,
+      });
+
+      expect(result.details).toEqual({
+        ok: true,
+        sourceReplyRoute: "current-source",
+      });
+      expect(onThreadReplyDelivered).toHaveBeenCalledWith("thread-1");
+    } finally {
+      endRoute();
+    }
+  });
+
+  it("classifies upload-file to the active adopted thread as current-source delivery", async () => {
+    const sessionKey = "agent:main:discord:channel:channel-1";
+    const onThreadReplyDelivered = vi.fn();
+    const endRoute = beginDiscordActiveTurnThreadRoute(sessionKey, {
+      accountId: "account-1",
+      sourceChannelId: "channel-1",
+      sourceMessageId: "message-1",
+      onThreadAdopted: vi.fn(),
+      onThreadReplyDelivered,
+    });
+    try {
+      await notifyDiscordActiveTurnThreadCreated({
+        sessionKey,
+        accountId: "account-1",
+        sourceChannelId: "channel-1",
+        sourceMessageId: "message-1",
+        threadId: "thread-1",
+      });
+
+      const result = await handleDiscordMessageAction({
+        action: "upload-file",
+        params: {
+          to: "channel:thread-1",
+          filePath: "/tmp/report.md",
+        },
+        cfg: discordConfig(),
+        accountId: "account-1",
+        sessionKey,
+      });
+
+      expect(result.details).toEqual({
+        ok: true,
+        sourceReplyRoute: "current-source",
+      });
+      expect(onThreadReplyDelivered).toHaveBeenCalledWith("thread-1");
+    } finally {
+      endRoute();
+    }
+  });
+
+  it("preserves a successful send when route-only target parsing rejects the target", async () => {
+    const result = await handleDiscordMessageAction({
+      action: "send",
+      params: {
+        to: "@alice",
+        message: "hello",
+      },
+      cfg: discordConfig(),
+    });
+
+    expect(result.details).toEqual({ ok: true });
+  });
+});

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -29,7 +29,7 @@ import {
   buildDiscordInteractiveComponents,
   buildDiscordPresentationComponents,
 } from "../shared-interactive.js";
-import { resolveDiscordChannelId } from "../targets.js";
+import { parseDiscordTarget, resolveDiscordChannelId } from "../targets.js";
 import { tryHandleDiscordMessageActionGuildAdmin } from "./handle-action.guild-admin.js";
 import type { DiscordMessagingActionOptions } from "./runtime.messaging.shared.js";
 import { readDiscordAutoArchiveDurationParam } from "./runtime.shared.js";
@@ -111,6 +111,31 @@ export async function handleDiscordMessageAction(
       accountId,
       inboundEventKind: ctx.inboundEventKind,
     });
+  const withAdoptedThreadReplyRoute = (
+    result: AgentToolResult<unknown>,
+    to: string,
+    fallbackSessionKey?: string,
+  ) => {
+    let target;
+    try {
+      target = parseDiscordTarget(to, { defaultKind: "channel" });
+    } catch {
+      // Route classification runs after delivery and must not turn a
+      // successfully resolved Discord target into a failed tool result.
+      return result;
+    }
+    if (
+      target?.kind === "channel" &&
+      notifyDiscordActiveTurnThreadReplyDelivered({
+        sessionKey: ctx.sessionKey ?? fallbackSessionKey,
+        accountId,
+        threadId: target.id,
+      })
+    ) {
+      return withCurrentSourceReplyRoute(result);
+    }
+    return result;
+  };
 
   const readTarget = () => {
     const target =
@@ -215,7 +240,7 @@ export async function handleDiscordMessageAction(
       actionOptions,
     );
     notifyVisibleOutbound(to, sessionKey);
-    return result;
+    return withAdoptedThreadReplyRoute(result, to, sessionKey);
   }
 
   if (action === "upload-file") {
@@ -254,7 +279,7 @@ export async function handleDiscordMessageAction(
       actionOptions,
     );
     notifyVisibleOutbound(to, sessionKey);
-    return result;
+    return withAdoptedThreadReplyRoute(result, to, sessionKey);
   }
 
   if (action === "poll") {

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -116,6 +116,15 @@ export async function handleDiscordMessageAction(
     to: string,
     fallbackSessionKey?: string,
   ) => {
+    const details =
+      result.details && typeof result.details === "object" && !Array.isArray(result.details)
+        ? (result.details as { ok?: unknown })
+        : undefined;
+    // Only a positive runtime receipt may suppress the source fallback. A
+    // resolved failure must leave the turn eligible for visible error delivery.
+    if (details?.ok !== true) {
+      return result;
+    }
     let target;
     try {
       target = parseDiscordTarget(to, { defaultKind: "channel" });
@@ -505,15 +514,7 @@ export async function handleDiscordMessageAction(
     if (action === "thread-reply") {
       const threadId = readStringParam(params, "threadId") ?? readTarget();
       notifyVisibleOutbound(threadId);
-      if (
-        notifyDiscordActiveTurnThreadReplyDelivered({
-          sessionKey: ctx.sessionKey,
-          accountId,
-          threadId,
-        })
-      ) {
-        return withCurrentSourceReplyRoute(adminResult);
-      }
+      return withAdoptedThreadReplyRoute(adminResult, threadId);
     }
     return adminResult;
   }

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -175,10 +175,10 @@ export async function prepareReplyAgentPayloads(state: {
     });
     return recovery.kind === "diagnostic" ? recovery.payload : undefined;
   };
-  // Route-aware message-tool delivery attests observed delivery in every mode:
-  // an automatic-mode turn answered via the message tool plus NO_REPLY must not
-  // draw the no-visible-reply fallback into the source conversation. The dedupe
-  // route matcher keeps unrelated-target tool sends from counting as the reply.
+  // Structured source-reply delivery evidence is the canonical owner for current
+  // runtimes. The route matcher remains only for legacy results that recorded
+  // successful target/text/media aggregates before structured receipts existed.
+  // It still keeps unrelated-target tool sends from counting as the source reply.
   const sourceRoutedMessagingToolDelivery =
     completedSourceReplyDelivery ||
     ((runResult.messagingToolSentTargets?.length ?? 0) > 0 &&

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -1,5 +1,52 @@
 import { describe, expect, it } from "vitest";
 import { sanitizeChatHistoryMessages } from "./chat-display-projection.js";
+import { mirrorMessageToolVisibleReplies } from "./chat-display-projection.message-tool.js";
+
+describe("chat display message-tool projection", () => {
+  it("mirrors an automatic-mode send confirmed for the current source", () => {
+    const sourceReply = "Visible reply delivered to Slack.";
+    const projected = mirrorMessageToolVisibleReplies([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-message-current-source",
+            name: "message",
+            arguments: {
+              action: "send",
+              channel: "slack",
+              target: "channel:C123",
+              message: sourceReply,
+            },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolName: "message",
+        toolCallId: "call-message-current-source",
+        content: { ok: true, messageId: "slack-242" },
+        details: {
+          ok: true,
+          messageId: "slack-242",
+          sourceReplyRoute: "current-source",
+        },
+      },
+      { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+    ]);
+
+    expect(projected).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: [{ type: "text", text: sourceReply }],
+        openclawMessageToolMirror: expect.objectContaining({
+          toolCallId: "call-message-current-source",
+        }),
+      }),
+    );
+  });
+});
 
 describe("chat display tool-result detail projection", () => {
   it("keeps authoritative write booleans and strips unrelated details", () => {

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -660,6 +660,35 @@ describe("runMessageAction core send routing", () => {
     expect(result.payload).toMatchObject({ sourceReplyRoute: "current-source" });
   });
 
+  it("marks automatic-mode Slack sends to the trusted current source conversation", async () => {
+    registerSlackTextPlugin();
+
+    const result = await runMessageAction({
+      cfg: slackConfig,
+      action: "send",
+      params: {
+        channel: "slack",
+        target: "channel:C123",
+        message: "visible source reply",
+      },
+      messageActionAuthorization: {
+        requesterAccountId: "default",
+        toolContext: {
+          currentChannelProvider: "slack",
+          currentChannelId: "channel:C123",
+          currentSourceTurnId: "source-turn-1",
+        },
+      },
+      sessionKey: "agent:main:slack:channel:C123",
+      defaultAccountId: "default",
+      sourceReplyDeliveryMode: "automatic",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(result.payload).toMatchObject({ sourceReplyRoute: "current-source" });
+  });
+
   it("does not mark a message-scoped reply that enters a new thread as current-source", async () => {
     registerSlackTextPlugin();
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -291,7 +291,9 @@ function markDeliveredCurrentSourceReply<T extends MessageActionRunResult>(
     replyToIsExplicit: boolean;
   },
 ): T {
-  if (result.kind !== "send" || params.input.sourceReplyDeliveryMode !== "message_tool_only") {
+  // Current-source identity comes from the authorized route and delivery receipt,
+  // not the reply mode; automatic runs also use this marker to avoid false fallbacks.
+  if (result.kind !== "send") {
     return result;
   }
   const authorization = params.input.messageActionAuthorization;


### PR DESCRIPTION
## What Problem This Solves

Fixes false no-visible-reply fallbacks after the message tool already delivered the response to the exact source conversation. The missing delivery classification affected shared automatic-mode sends, including reported Slack cases, as well as Discord threads created and adopted during the active turn.

## Why This Change Was Made

The shared outbound runner now records successful, authorized sends to the exact current source in every reply mode. This is channel-agnostic: core and plugin-backed `message.send` transports use the same route and receipt classifier, while unrelated channels, accounts, and threads remain unrelated.

Discord keeps a narrow adapter for its unique mid-turn adopted-thread transition because that newly created route does not exist in the original turn context. Generic Discord send, upload, and thread-reply actions reuse that active route only after a positive runtime delivery receipt.

This is intentionally delivery-based rather than relying on a final `NO_REPLY` token. A failed or unrelated send must leave the source fallback eligible.

## User Impact

Slack and other channels no longer append a misleading no-reply failure after a successful message-tool response to the current conversation. Discord adopted-thread workflows receive the same behavior. Failed sends and sends elsewhere still retain the fallback.

A confirmed automatic-mode current-source send is intentionally mirrored into Control UI chat history. The structured route receipt is authoritative for current runtimes; the target/text/media matcher remains only as a legacy-evidence fallback.

## Evidence

- Exact reviewed head: `5fa72a7ef2cdfb8801b5f075cc501fae8096a85b`.
- Shared Slack reproduction: automatic-mode `message.send` to the trusted current conversation was red before the shared change (1 failed, 26 passed) and green after it (27/27).
- Projection-level regression proves a successful automatic-mode Slack current-source receipt is visible in Control UI history.
- Shared downstream source-reply classifier: 25/25 passed.
- Discord adopted-thread and action suites: 36/36 passed.
- Negative controls cover another account, another thread, a newly entered thread, an unrelated target, a matching adopted-thread result with `ok: false`, and suppressed/unconfirmed projection routes.
- Latest focused Blacksmith Testbox proof: 54/54 passed; `tbx_01kytghtyt26tyxn08y3g8yq01`; https://github.com/openclaw/openclaw/actions/runs/30585410621.
- Targeted formatting and `git diff --check` passed.
- Fresh structured Codex autoreview reported no actionable findings (correctness 0.93).

## Related PR Comparison

#116548 addresses the separate semantic question of preserving explicit `NO_REPLY` silence. It is not a substitute for this delivery-accounting repair: delivery evidence is required so failed or unrelated sends cannot suppress the fallback.
