### PR TITLE
fix(auth-profiles): make model_not_found cooldown model-scoped, not profile-wide

### DIFF
--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -386,7 +386,7 @@ function shouldBypassModelScopedCooldown(
 ): boolean {
   return !!(
     forModel &&
-    stats.cooldownReason === "rate_limit" &&
+    (stats.cooldownReason === "rate_limit" || stats.cooldownReason === "model_not_found") &&
     stats.cooldownModel &&
     stats.cooldownModel !== forModel &&
     !isActiveUnusableWindow(stats.disabledUntil, now)
@@ -713,8 +713,8 @@ function computeNextProfileUsageStats(params: {
         // Unknown originating model during an active model-scoped cooldown:
         // widen scope conservatively so no model can bypass on stale metadata.
         updatedStats.cooldownModel = undefined;
-      } else if (params.reason !== "rate_limit") {
-        // Non-rate-limit failures are profile-wide — clear model scope even
+      } else if (params.reason !== "rate_limit" && params.reason !== "model_not_found") {
+        // Non-rate-limit, non-model_not_found failures are profile-wide — clear model scope even
         // when the same model fails, so that no model can bypass.
         updatedStats.cooldownModel = undefined;
       } else {
@@ -722,7 +722,7 @@ function computeNextProfileUsageStats(params: {
       }
     } else {
       updatedStats.cooldownReason = params.reason;
-      updatedStats.cooldownModel = params.reason === "rate_limit" ? params.modelId : undefined;
+      updatedStats.cooldownModel = (params.reason === "rate_limit" || params.reason === "model_not_found") ? params.modelId : undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

Previously, a `model_not_found` failure on one model would put the entire auth profile into cooldown for up to 5 minutes, blocking healthy fallback models on the same profile.

This change treats `model_not_found` similarly to `rate_limit` - the cooldown is scoped to the specific model that failed, allowing other models on the same profile to be used for fallback.

## Changes

1. `shouldBypassModelScopedCooldown`: Now allows bypass for `model_not_found` failures (same logic as `rate_limit`)
2. `computeNextProfileUsageStats`: `model_not_found` now preserves `cooldownModel` instead of clearing it, making the cooldown model-scoped

## Fixes

Fixes #116464

## Testing

The existing test at line 162 in `usage.test.ts` covers the model-scoped bypass pattern for `rate_limit`; a similar pattern should be added for `model_not_found`.