### PR TITLE
fix(gateway): reject invalid Chat token caps

### DIFF
--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -159,20 +159,20 @@ Security note: allowlisting a hostname does not bypass private/internal IP block
 
 ### Supported request fields
 
-| Field                      | Notes                                                                                                                                         |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tools`                    | Array of `{ "type": "function", "function": { ... } }`                                                                                        |
-| `tool_choice`              | `"auto"`, `"none"`, `"required"`, or `{ "type": "function", "function": { "name": "..." } }`                                                  |
-| `messages[*].role: "tool"` | Follow-up turns                                                                                                                               |
-| `messages[*].tool_call_id` | Binds a tool result back to a prior tool call                                                                                                 |
-| `max_completion_tokens`    | Number; per-call cap on total completion tokens (reasoning tokens included). Current field name; used when both it and `max_tokens` are sent. |
-| `max_tokens`               | Number; legacy alias, ignored when `max_completion_tokens` is also present.                                                                   |
-| `temperature`              | Number 0-2; best-effort, forwarded to the upstream provider. `400 invalid_request_error` if out of range.                                     |
-| `top_p`                    | Number 0-1; best-effort. `400 invalid_request_error` if out of range.                                                                         |
-| `frequency_penalty`        | Number -2.0 to 2.0; best-effort. `400 invalid_request_error` if out of range.                                                                 |
-| `presence_penalty`         | Number -2.0 to 2.0; best-effort. `400 invalid_request_error` if out of range.                                                                 |
-| `seed`                     | Integer; best-effort. `400 invalid_request_error` for non-integer values.                                                                     |
-| `stop`                     | String or array of up to 4 strings; best-effort. `400 invalid_request_error` for more than 4 sequences or non-string/empty entries.           |
+| Field                      | Notes                                                                                                                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `tools`                    | Array of `{ "type": "function", "function": { ... } }`                                                                                                                               |
+| `tool_choice`              | `"auto"`, `"none"`, `"required"`, or `{ "type": "function", "function": { "name": "..." } }`                                                                                         |
+| `messages[*].role: "tool"` | Follow-up turns                                                                                                                                                                      |
+| `messages[*].tool_call_id` | Binds a tool result back to a prior tool call                                                                                                                                        |
+| `max_completion_tokens`    | Positive safe integer; per-call cap on total completion tokens (reasoning tokens included). Current field name; used when both fields are non-null. Null or omitted leaves it unset. |
+| `max_tokens`               | Positive safe integer; legacy alias. It is still validated when `max_completion_tokens` is non-null, then ignored for precedence. Null or omitted leaves it unset.                   |
+| `temperature`              | Number 0-2; best-effort, forwarded to the upstream provider. `400 invalid_request_error` if out of range.                                                                            |
+| `top_p`                    | Number 0-1; best-effort. `400 invalid_request_error` if out of range.                                                                                                                |
+| `frequency_penalty`        | Number -2.0 to 2.0; best-effort. `400 invalid_request_error` if out of range.                                                                                                        |
+| `presence_penalty`         | Number -2.0 to 2.0; best-effort. `400 invalid_request_error` if out of range.                                                                                                        |
+| `seed`                     | Integer; best-effort. `400 invalid_request_error` for non-integer values.                                                                                                            |
+| `stop`                     | String or array of up to 4 strings; best-effort. `400 invalid_request_error` for more than 4 sequences or non-string/empty entries.                                                  |
 
 All sampling and token-cap fields ride the same agent stream-param channel and are forwarded best-effort:
 

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -102,6 +102,17 @@ async function postChatCompletions(port: number, body: unknown, headers?: Record
   return res;
 }
 
+async function postRawChatCompletions(port: number, body: string) {
+  return await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-openclaw-scopes": "operator.write",
+    },
+    body,
+  });
+}
+
 function createOpenAiChatClient(port: number): OpenAI {
   return new OpenAI({
     apiKey: "test",
@@ -1511,60 +1522,132 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     }
   });
 
-  it("forwards inbound max_completion_tokens and max_tokens into streamParams", async () => {
+  it("validates and forwards max_completion_tokens and max_tokens into streamParams", async () => {
     const port = enabledPort;
-    const mockAgentOnce = (payloads: Array<{ text: string }>) => {
+    const mockAgentOnce = () => {
       agentCommand.mockClear();
-      agentCommand.mockResolvedValueOnce({ payloads } as never);
+      agentCommand.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
     };
-    const getFirstAgentMaxTokens = () => firstAgentCommandOptions()?.streamParams?.maxTokens;
+    const getRecordedAgentMaxTokens = () => firstAgentCommandOptions()?.streamParams?.maxTokens;
 
-    {
-      mockAgentOnce([{ text: "hello" }]);
+    const validCases: Array<{
+      name: string;
+      body: Record<string, unknown>;
+      expected: number | undefined;
+    }> = [
+      { name: "current field", body: { max_completion_tokens: 256 }, expected: 256 },
+      { name: "legacy field", body: { max_tokens: 128 }, expected: 128 },
+      {
+        name: "current field precedence",
+        body: { max_completion_tokens: 64, max_tokens: 999 },
+        expected: 64,
+      },
+      {
+        name: "null current field leaves legacy active",
+        body: { max_completion_tokens: null, max_tokens: 32 },
+        expected: 32,
+      },
+      {
+        name: "null legacy field leaves current active",
+        body: { max_completion_tokens: 16, max_tokens: null },
+        expected: 16,
+      },
+      {
+        name: "largest safe integer",
+        body: { max_completion_tokens: Number.MAX_SAFE_INTEGER },
+        expected: Number.MAX_SAFE_INTEGER,
+      },
+      { name: "omitted fields", body: {}, expected: undefined },
+    ];
+
+    for (const testCase of validCases) {
+      mockAgentOnce();
       const res = await postChatCompletions(port, {
         model: "openclaw",
-        max_completion_tokens: 256,
+        ...testCase.body,
         messages: [{ role: "user", content: "hi" }],
       });
       expect(res.status).toBe(200);
-      expect(getFirstAgentMaxTokens()).toBe(256);
+      expect(agentCommand, testCase.name).toHaveBeenCalledTimes(1);
+      expect(getRecordedAgentMaxTokens(), testCase.name).toBe(testCase.expected);
       await res.text();
     }
 
-    {
-      mockAgentOnce([{ text: "hello" }]);
-      const res = await postChatCompletions(port, {
-        model: "openclaw",
-        max_tokens: 128,
-        messages: [{ role: "user", content: "hi" }],
-      });
-      expect(res.status).toBe(200);
-      expect(getFirstAgentMaxTokens()).toBe(128);
-      await res.text();
+    mockAgentOnce();
+    const client = createOpenAiChatClient(port);
+    await client.chat.completions.create({
+      model: "openclaw",
+      max_completion_tokens: null,
+      max_tokens: null,
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(agentCommand, "SDK null fields").toHaveBeenCalledTimes(1);
+    expect(getRecordedAgentMaxTokens(), "SDK null fields").toBeUndefined();
+  });
+
+  it("rejects malformed token caps before agent dispatch", async () => {
+    const port = enabledPort;
+    const invalidValues: Array<{ name: string; value: unknown }> = [
+      { name: "string", value: "32" },
+      { name: "object", value: {} },
+      { name: "array", value: [32] },
+      { name: "zero", value: 0 },
+      { name: "negative", value: -1 },
+      { name: "fractional", value: 1.5 },
+      { name: "unsafe integer", value: Number.MAX_SAFE_INTEGER + 1 },
+    ];
+
+    for (const field of ["max_completion_tokens", "max_tokens"] as const) {
+      for (const testCase of invalidValues) {
+        agentCommand.mockClear();
+        const res = await postChatCompletions(port, {
+          model: "openclaw",
+          [field]: testCase.value,
+          messages: [{ role: "user", content: "hi" }],
+        });
+        expect(res.status, `${field}: ${testCase.name}`).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error?.type).toBe("invalid_request_error");
+        expect(json.error?.message).toContain(field);
+        expect(agentCommand, `${field}: ${testCase.name}`).toHaveBeenCalledTimes(0);
+      }
+
+      agentCommand.mockClear();
+      const res = await postRawChatCompletions(
+        port,
+        `{"model":"openclaw","messages":[{"role":"user","content":"hi"}],"${field}":1e309}`,
+      );
+      expect(res.status, `${field}: non-finite raw number`).toBe(400);
+      const json = (await res.json()) as { error?: { type?: string; message?: string } };
+      expect(json.error?.type).toBe("invalid_request_error");
+      expect(json.error?.message).toContain(field);
+      expect(agentCommand, `${field}: non-finite raw number`).toHaveBeenCalledTimes(0);
     }
 
-    {
-      mockAgentOnce([{ text: "hello" }]);
+    const shadowedCases = [
+      {
+        name: "malformed current field with valid legacy field",
+        body: { max_completion_tokens: "64", max_tokens: 32 },
+        field: "max_completion_tokens",
+      },
+      {
+        name: "malformed legacy field with valid current field",
+        body: { max_completion_tokens: 64, max_tokens: "32" },
+        field: "max_tokens",
+      },
+    ];
+    for (const testCase of shadowedCases) {
+      agentCommand.mockClear();
       const res = await postChatCompletions(port, {
         model: "openclaw",
-        max_completion_tokens: 64,
-        max_tokens: 999,
+        ...testCase.body,
         messages: [{ role: "user", content: "hi" }],
       });
-      expect(res.status).toBe(200);
-      expect(getFirstAgentMaxTokens()).toBe(64);
-      await res.text();
-    }
-
-    {
-      mockAgentOnce([{ text: "hello" }]);
-      const res = await postChatCompletions(port, {
-        model: "openclaw",
-        messages: [{ role: "user", content: "hi" }],
-      });
-      expect(res.status).toBe(200);
-      expect(getFirstAgentMaxTokens()).toBeUndefined();
-      await res.text();
+      expect(res.status, testCase.name).toBe(400);
+      const json = (await res.json()) as { error?: { type?: string; message?: string } };
+      expect(json.error?.type).toBe("invalid_request_error");
+      expect(json.error?.message).toContain(testCase.field);
+      expect(agentCommand, testCase.name).toHaveBeenCalledTimes(0);
     }
   });
 

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -3,6 +3,7 @@
 import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
+import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -868,6 +869,17 @@ function resolveStopSequences(value: unknown): string[] | undefined {
   return sequences.length > 0 ? sequences : undefined;
 }
 
+function resolveChatCompletionTokenCap(value: unknown, field: string): number | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const maxTokens = asPositiveSafeInteger(value);
+  if (maxTokens === undefined) {
+    throw new Error(`${field} must be a positive safe integer`);
+  }
+  return maxTokens;
+}
+
 function resolveErrorMessage(err: unknown): string {
   if (err instanceof Error) {
     const message = err.message.trim();
@@ -913,12 +925,20 @@ export async function handleOpenAiHttpRequest(
   const streamIncludeUsage = stream && resolveIncludeUsageForStreaming(payload);
   const model = typeof payload.model === "string" ? payload.model : "openclaw";
   const user = typeof payload.user === "string" ? payload.user : undefined;
-  const maxTokens =
-    typeof payload.max_completion_tokens === "number"
-      ? payload.max_completion_tokens
-      : typeof payload.max_tokens === "number"
-        ? payload.max_tokens
-        : undefined;
+  let maxTokens: number | undefined;
+  try {
+    const maxCompletionTokens = resolveChatCompletionTokenCap(
+      payload.max_completion_tokens,
+      "max_completion_tokens",
+    );
+    const legacyMaxTokens = resolveChatCompletionTokenCap(payload.max_tokens, "max_tokens");
+    maxTokens = maxCompletionTokens ?? legacyMaxTokens;
+  } catch (err) {
+    sendJson(res, 400, {
+      error: { message: resolveErrorMessage(err), type: "invalid_request_error" },
+    });
+    return true;
+  }
   const temperature = typeof payload.temperature === "number" ? payload.temperature : undefined;
   const topP = typeof payload.top_p === "number" ? payload.top_p : undefined;
   const frequencyPenalty =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Chat Completions accepted malformed `max_completion_tokens` and legacy `max_tokens` values—including zero, negatives, fractions, non-finite numbers, strings, and arrays—and could dispatch provider work anyway. An invalid current field could also fall through to a valid legacy field, hiding the bad request.

## Why This Change Was Made

The Chat HTTP boundary now validates every supplied non-null cap as a positive safe integer before applying precedence. Omitted and SDK-compatible `null` values remain unset; when both valid values are supplied, `max_completion_tokens` wins. Invalid current or legacy fields return the existing canonical `400 invalid_request_error` before model dispatch.

The validation stays at the public HTTP owner, so intentional internal `maxTokens: 0` semantics are unchanged.

## User Impact

OpenAI-compatible clients get immediate actionable 400 responses for invalid token caps instead of silent fallback, fractional forwarding, or surprising provider execution. Existing omitted/null and valid positive-integer requests retain their behavior.

Release-note context: Chat Completions now rejects invalid token-cap values before provider dispatch while preserving valid current/legacy precedence.

## Evidence

- Before: authenticated real HTTP cases for malformed current/legacy values returned 200 and all dispatched upstream; fractional `1.5` reached the provider and invalid current input could fall through to legacy.
- After: 33/33 exact-head Chat HTTP tests cover omitted/null, safe integers, non-finite/raw overflow, arrays/objects/strings, shadowed malformed fields, both-field precedence, canonical 400 bodies, and zero provider dispatch on rejection.
- Exact rebased head: `8723503bbfff6cc69c247f8600e4072cf84213b6`.
- Blacksmith Testbox `tbx_01kytdstevy4t6jhn5p1nc3zd7`; focused proof and changed gate passed in [run 30582292933](https://github.com/openclaw/openclaw/actions/runs/30582292933).
- Final Codex autoreview: clean, confidence 0.98.
- `git diff --check`: clean; rebase patch ID unchanged.
