### PR TITLE
fix(codex): /steer hangs indefinitely when the app-server does not answer turn/steer

### DIFF
--- a/extensions/codex/src/app-server/attempt-steering.test.ts
+++ b/extensions/codex/src/app-server/attempt-steering.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover attempt steering plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCodexSteeringQueue } from "./attempt-steering.js";
+import { createClientHarness } from "./test-support.js";
 
 const PNG_1X1 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Z0V8AAAAASUVORK5CYII=";
@@ -27,10 +28,13 @@ describe("Codex app-server steering queue", () => {
       client: { request } as never,
       threadId: "thread-1",
       turnId: "turn-1",
+      requestTimeoutMs: 60_000,
       claimPendingUserInput: options.claimPendingUserInput ?? (() => undefined),
       signal: options.signal ?? new AbortController().signal,
     });
   }
+
+  const steerRequestOptions = { timeoutMs: 60_000, signal: expect.any(AbortSignal) };
 
   it("resolves only after the matching Codex user message completes", async () => {
     const request = vi.fn(async (_method: string, _params: unknown) => ({ turnId: "turn-1" }));
@@ -49,12 +53,46 @@ describe("Codex app-server steering queue", () => {
     expect(queue.confirmConsumed("unrelated-user-message")).toBe(false);
     expect(queue.confirmConsumed(requestParams.clientUserMessageId ?? "")).toBe(true);
     await queued;
-    expect(request).toHaveBeenCalledWith("turn/steer", {
+    expect(request).toHaveBeenCalledWith(
+      "turn/steer",
+      {
+        threadId: "thread-1",
+        expectedTurnId: "turn-1",
+        input: [{ type: "text", text: "accepted", text_elements: [] }],
+        clientUserMessageId: "openclaw:turn-1:steer:1",
+      },
+      steerRequestOptions,
+    );
+  });
+
+  it("fails the steer when the app-server never answers turn/steer", async () => {
+    // Real client over an in-memory transport: only the app-server process is faked,
+    // so this exercises the production request deadline rather than a stub.
+    const harness = createClientHarness();
+    const queue = createCodexSteeringQueue({
+      client: harness.client,
       threadId: "thread-1",
-      expectedTurnId: "turn-1",
-      input: [{ type: "text", text: "accepted", text_elements: [] }],
-      clientUserMessageId: "openclaw:turn-1:steer:1",
+      turnId: "turn-1",
+      requestTimeoutMs: 1_000,
+      claimPendingUserInput: () => undefined,
+      signal: new AbortController().signal,
     });
+
+    const outcomes: string[] = [];
+    void queue.queue("steer me", { debounceMs: 0 }).then(
+      () => outcomes.push("resolved"),
+      (error: unknown) => outcomes.push(`rejected: ${(error as Error).message}`),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect((JSON.parse(harness.writes[0] ?? "{}") as { method?: string }).method).toBe(
+      "turn/steer",
+    );
+
+    // Codex accepted the frame but never responds: the caller must not wait forever.
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(outcomes).toEqual(["rejected: turn/steer timed out"]);
+    harness.client.close();
   });
 
   it("handles user-message completion before the steer response", async () => {
@@ -93,17 +131,21 @@ describe("Codex app-server steering queue", () => {
 
     expect(queue.confirmConsumed("openclaw:turn-1:steer:1")).toBe(true);
     await Promise.all([first, second]);
-    expect(request).toHaveBeenCalledWith("turn/steer", {
-      threadId: "thread-1",
-      expectedTurnId: "turn-1",
-      input: [
-        { type: "text", text: "first", text_elements: [] },
-        { type: "image", url: `data:image/png;base64,${PNG_1X1}` },
-        { type: "text", text: "second", text_elements: [] },
-        { type: "image", url: `data:image/png;base64,${PNG_1X1}` },
-      ],
-      clientUserMessageId: "openclaw:turn-1:steer:1",
-    });
+    expect(request).toHaveBeenCalledWith(
+      "turn/steer",
+      {
+        threadId: "thread-1",
+        expectedTurnId: "turn-1",
+        input: [
+          { type: "text", text: "first", text_elements: [] },
+          { type: "image", url: `data:image/png;base64,${PNG_1X1}` },
+          { type: "text", text: "second", text_elements: [] },
+          { type: "image", url: `data:image/png;base64,${PNG_1X1}` },
+        ],
+        clientUserMessageId: "openclaw:turn-1:steer:1",
+      },
+      steerRequestOptions,
+    );
   });
 
   it("rejects the batch when Codex rejects turn/steer", async () => {
@@ -245,16 +287,20 @@ describe("Codex app-server steering queue", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(answerPendingUserInput).not.toHaveBeenCalled();
-    expect(request).toHaveBeenCalledWith("turn/steer", {
-      threadId: "thread-1",
-      expectedTurnId: "turn-1",
-      input: [
-        { type: "text", text: "compare these", text_elements: [] },
-        { type: "image", url: `data:image/png;base64,${PNG_1X1}` },
-        { type: "image", url: `data:image/png;base64,${PNG_1X1}` },
-      ],
-      clientUserMessageId: "openclaw:turn-1:steer:1",
-    });
+    expect(request).toHaveBeenCalledWith(
+      "turn/steer",
+      {
+        threadId: "thread-1",
+        expectedTurnId: "turn-1",
+        input: [
+          { type: "text", text: "compare these", text_elements: [] },
+          { type: "image", url: `data:image/png;base64,${PNG_1X1}` },
+          { type: "image", url: `data:image/png;base64,${PNG_1X1}` },
+        ],
+        clientUserMessageId: "openclaw:turn-1:steer:1",
+      },
+      steerRequestOptions,
+    );
     expect(cancelPendingUserInput).toHaveBeenCalledOnce();
     expect(request.mock.invocationCallOrder[0]!).toBeLessThan(
       cancelPendingUserInput.mock.invocationCallOrder[0]!,

--- a/extensions/codex/src/app-server/attempt-steering.test.ts
+++ b/extensions/codex/src/app-server/attempt-steering.test.ts
@@ -95,6 +95,33 @@ describe("Codex app-server steering queue", () => {
     harness.client.close();
   });
 
+  it("aborts the in-flight steer request and removes its client pending entry", async () => {
+    const harness = createClientHarness();
+    const controller = new AbortController();
+    const queue = createCodexSteeringQueue({
+      client: harness.client,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestTimeoutMs: 60_000,
+      claimPendingUserInput: () => undefined,
+      signal: controller.signal,
+    });
+    const pendingRequests = (
+      harness.client as unknown as { pending: Map<number | string, unknown> }
+    ).pending;
+
+    const queued = queue.queue("steer me", { debounceMs: 0 });
+    const rejected = expect(queued).rejects.toThrow("steering queue aborted");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(pendingRequests.size).toBe(1);
+
+    controller.abort();
+
+    await rejected;
+    expect(pendingRequests.size).toBe(0);
+    harness.client.close();
+  });
+
   it("handles user-message completion before the steer response", async () => {
     let acceptSteer: (() => void) | undefined;
     const steerAccepted = new Promise<void>((resolve) => {

--- a/extensions/codex/src/app-server/attempt-steering.ts
+++ b/extensions/codex/src/app-server/attempt-steering.ts
@@ -26,6 +26,7 @@ export function createCodexSteeringQueue(params: {
   client: CodexAppServerClient;
   threadId: string;
   turnId: string;
+  requestTimeoutMs: number;
   claimPendingUserInput: () =>
     | {
         answer: (text: string) => boolean;
@@ -117,12 +118,20 @@ export function createCodexSteeringQueue(params: {
     // Keep the batch unsettled until Codex echoes this id on userMessage completion.
     dispatchedBatches.set(clientUserMessageId, batch);
     try {
-      await params.client.request("turn/steer", {
-        threadId: params.threadId,
-        expectedTurnId: params.turnId,
-        input: liveItems.flatMap((item) => buildCodexUserInput(item.text, item.images)),
-        clientUserMessageId,
-      });
+      // turn/steer is an ack, but Codex answers it under the active-turn lock, so a
+      // busy turn can hold it open indefinitely. Without a deadline and the run
+      // signal the caller only unblocks when the app-server client closes, which
+      // strands whichever channel handler is awaiting delivery.
+      await params.client.request(
+        "turn/steer",
+        {
+          threadId: params.threadId,
+          expectedTurnId: params.turnId,
+          input: liveItems.flatMap((item) => buildCodexUserInput(item.text, item.images)),
+          clientUserMessageId,
+        },
+        { timeoutMs: params.requestTimeoutMs, signal: params.signal },
+      );
     } catch (error) {
       dispatchedBatches.delete(clientUserMessageId);
       for (const item of liveItems) {

--- a/extensions/codex/src/app-server/attempt-steering.ts
+++ b/extensions/codex/src/app-server/attempt-steering.ts
@@ -118,10 +118,10 @@ export function createCodexSteeringQueue(params: {
     // Keep the batch unsettled until Codex echoes this id on userMessage completion.
     dispatchedBatches.set(clientUserMessageId, batch);
     try {
-      // turn/steer is an ack, but Codex answers it under the active-turn lock, so a
-      // busy turn can hold it open indefinitely. Without a deadline and the run
-      // signal the caller only unblocks when the app-server client closes, which
-      // strands whichever channel handler is awaiting delivery.
+      // turn/steer is an ack, but nothing guarantees the app-server answers it.
+      // Without a deadline and the run signal the caller only unblocks when the
+      // app-server client closes, which strands whichever channel handler is
+      // awaiting delivery and wedges every later steer behind sendChain.
       await params.client.request(
         "turn/steer",
         {

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -163,6 +163,7 @@ export async function activateCodexAttemptTurn(
     client: resourceState.client,
     threadId: resourceState.thread.threadId,
     turnId: activeTurnId,
+    requestTimeoutMs: connection.appServer.requestTimeoutMs,
     claimPendingUserInput: () => userInputBridgeRef.current?.claimPendingRequest(),
     signal: runAbortController.signal,
   });


### PR DESCRIPTION
Closes #115917

## What Problem This Solves

Fixes an issue where users who send `/steer` to a busy Codex app-server turn would have the command hang instead of steering or failing. The `/steer` handler stayed blocked for over six minutes in the reported incident, holding the Telegram control lane through its five-minute spool adoption timeout, and only finished once the Codex app-server client closed — by which time its spool claim had expired. Aborting the reply did not release it either.

## Why This Change Was Made

The embedded steering queue sent `turn/steer` with no deadline and no abort signal:

```ts
// extensions/codex/src/app-server/attempt-steering.ts (before)
await params.client.request("turn/steer", { threadId, expectedTurnId, input, clientUserMessageId });
```

`CodexAppServerClient` only arms a timer when a caller supplies one (`client.ts:628`), and it only wires an abort listener when a caller supplies a signal (`client.ts:638`). With neither, the promise can settle only on a response or on client close — exactly the reported behavior.

Codex can legitimately take arbitrarily long to answer. `turn/steer` is an acknowledgement (`TurnSteerResponse { turn_id }`, `codex-rs/app-server/src/request_processors/turn_processor.rs:919-1024`), but it is produced by `Session::steer_input`, whose first statement is `self.active_turn.lock().await` (`codex-rs/core/src/session/mod.rs:3848`), so it can contend for that lock. How long a busy turn holds it I could not confirm — every `active_turn.lock()` site in that file is a short scoped block — and the client should not depend on the answer either way: whatever the reason the app-server does not answer, an unbounded wait strands the caller.

The sibling call site already does. `steerCodexConversationTurn` issues the same method with `{ timeoutMs: runtime.requestTimeoutMs }` (`extensions/codex/src/conversation-control.ts:168-176`), so this aligns the two `turn/steer` paths on one contract rather than inventing a new one. `requestTimeoutMs` is the operator-configured app-server request timeout (default 60s, `config-runtime.ts:294`) — the same value the reporter set to 120000 and expected to be honored.

The failure is already handled downstream: `queueEmbeddedAgentMessageWithOutcomeAsync` catches a rejected steer and returns a typed `runtime_rejected` outcome (`src/agents/embedded-agent-runner/runs.ts:465-469`), and `queueReplyRunMessage` logs it (`src/auto-reply/reply/reply-run-registry.ts:1279-1282`). So an indefinite hang becomes a reported outcome instead of silence.

Scope: `turn/steer` from the embedded run steering queue was the only unbounded one. The other `turn/steer` was already bounded; both `turn/interrupt` paths are either bounded (`bounded-turn.ts:194-197`) or fire-and-forget (`attempt-client-cleanup.ts:96`).

## User Impact

`/steer` against a busy Codex turn now fails within the configured app-server request timeout instead of hanging, and aborting the run cancels the in-flight steering RPC. The channel handler is released, so the control lane is not guarded until the app-server client closes.

## Evidence

### Real-behavior proof: real `codex app-server`, made genuinely unresponsive

The harness drives the **real** `codex app-server` binary shipped with the plugin
(`@openai/codex` 0.146.0) over **real** stdio, through the **real**
`CodexAppServerClient` and the **real** `createCodexSteeringQueue`. Nothing about
the server is faked: it is made unresponsive with `SIGSTOP`, so it genuinely never
answers `turn/steer`. The client is built with `CodexAppServerClient.start({...,
commandSource: "config"})` — the same path an operator uses to pin a binary.

`appServer.requestTimeoutMs` is set to 1500ms to keep the run short; hang budget 6000ms.

**Before (upstream sources, `f6b888772af~1`)**

```text
[A] PASS real app-server answered initialize in 71ms
[A] app-server pid = 54353
[B] SIGSTOP -> app-server 54353 is stopped; it will not answer turn/steer
[B] RED  /steer STILL PENDING after 6002ms (budget 6000ms)
[B] RED  the control lane is stranded; only an app-server close would release it
[C] RED  lane still guarded: follow-up never settled within 6000ms
```

**After (this branch)**

```text
[A] PASS real app-server answered initialize in 902ms
[A] app-server pid = 56082
[B] SIGSTOP -> app-server 56082 is stopped; it will not answer turn/steer
   [req#1] issue turn/steer stage=B-steer timeoutMs=1500 hasSignal=true
   [req#1] rejected: CodexAppServerLocalRequestCancellationError: turn/steer timed out
[B] GREEN /steer settled in 1507ms -> rejected
[C] GREEN follow-up settled instead of hanging
[D] GREEN pending steer settled 152ms after abort
```

`[A]` is the positive control: the same process answers `initialize` normally
before it is stopped, so `[B]` measures the client's bound and not a dead server.

`[C]` is the user-visible half of the bug. Exactly one `turn/steer` is ever issued
(`req#1`): once it fails, `sendChain` deliberately carries the rejection forward so
later messages fall back rather than overtaking the failed one. Before the fix that
chain never settles, so every later steer waits behind it and the Telegram control
handler stays guarded. After the fix it settles, and later steers fail fast.

### Abort path

Isolated against the real client with no steering queue involved:

```text
[probe/timeout-only]   rejected: CodexAppServerLocalRequestCancellationError: turn/steer timed out
[probe/timeout-only]   unhandled so far = 0
[probe/timeout+signal] rejected: CodexAppServerLocalRequestCancellationError: turn/steer aborted
[probe] unhandledRejections observed = 0
```

Passing `signal` cancels the in-flight RPC at abort (`aborted` at ~150ms) instead of
leaving it pending until the deadline (`timed out` at ~1200ms).

### Honest limits

- **`[D]` is green before and after.** The caller-facing settle on abort already
  worked, because `closeQueue` rejects pending items. What `signal` adds is
  cancelling the in-flight RPC itself, shown in the probe above. The patch does not
  fix `[D]`; it stops the request outliving it.
- **The upstream lock-contention cause is not reproduced.** `steer_input` does take
  the lock (`codex-rs/core/src/session/mod.rs:3848`), but all 16
  `active_turn.lock()` sites in that file are short scoped blocks — none held across
  a model round-trip — so a busy turn cannot be made to hold it locally, and
  producing a genuinely busy turn needs a live provider. `SIGSTOP` reproduces the
  observable contract this patch changes (app-server does not answer → the client
  must not wait forever), not the upstream reason it stopped answering.
- No unhandled rejections in either run. An earlier spurious one was a harness
  defect (an observer attached a tick late, which only shows on the branch because
  there the promise actually settles), not a behaviour of the patch.
- Harness is local and uncommitted; it is not added to the test suite.

### Unit tests

```text
node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-steering.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

_AI-assisted._
### Maintainer verification (July 31, 2026)

- Rebased candidate `983b9ea6a7bfced3bdb0fd5f174feb0eb098ca3a` onto current `origin/main` `88876f780b81d77bc41d13b29efb42b7992aac6e`.
- Added a queue-level abort regression that observes the real `CodexAppServerClient` pending map: one in-flight `turn/steer` request before abort, zero immediately after the run signal aborts.
- Fresh branch autoreview: no accepted/actionable findings (`patch is correct`, confidence 0.93).
- Direct dependency check at `openai/codex@4642370542739d5dd080b0c87a9de06a6435d3db`: `turn/steer` is serialized per thread (`codex-rs/app-server-protocol/src/protocol/common.rs:840-849`), the request processor awaits `steer_input` before returning the ack (`codex-rs/app-server/src/request_processors/turn_processor.rs:922-1028`), and core enqueues the input under the active-turn lock before returning the active turn id (`codex-rs/core/src/session/mod.rs:3984-4056`).
- The real app-server `SIGSTOP` proof establishes the no-ack timeout contract. It does not claim to reproduce upstream busy-lock contention.