### PR TITLE
fix(media): preserve code block indentation when media is present

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -287,4 +287,136 @@ describe("splitMediaFromOutput", () => {
       extractMarkdownImages,
     );
   });
+
+  it("preserves fenced code block indentation when media is present", () => {
+    const input = [
+      "Here is some code:",
+      "",
+      "```js",
+      "function foo() {",
+      "    return 42;",
+      "        const nested = true;",
+      "}",
+      "```",
+      "",
+      "MEDIA:/tmp/output.png",
+    ].join("\n");
+    expectParsedMediaOutputCase(input, {
+      text: [
+        "Here is some code:",
+        "```js",
+        "function foo() {",
+        "    return 42;",
+        "        const nested = true;",
+        "}",
+        "```",
+      ].join("\n"),
+      mediaUrls: ["/tmp/output.png"],
+    });
+  });
+
+  it("preserves tab-indented code inside a fenced block when media is present", () => {
+    const input = [
+      "Code example:",
+      "",
+      "```go",
+      "func main() {",
+      "\tfmt.Println(\"hello\")",
+      "\t\tif true {",
+      "\t\t}",
+      "}",
+      "```",
+      "",
+      "MEDIA:/tmp/output.png",
+    ].join("\n");
+    expectParsedMediaOutputCase(input, {
+      text: [
+        "Code example:",
+        "```go",
+        "func main() {",
+        "\tfmt.Println(\"hello\")",
+        "\t\tif true {",
+        "\t\t}",
+        "}",
+        "```",
+      ].join("\n"),
+      mediaUrls: ["/tmp/output.png"],
+    });
+  });
+
+  it("preserves indent-code-block lines (4-space prefix) when media is present", () => {
+    const input = [
+      "Here is some code:",
+      "",
+      "    const x = 1;",
+      "    const y = 2;",
+      "",
+      "MEDIA:/tmp/output.png",
+    ].join("\n");
+    expectParsedMediaOutputCase(input, {
+      text: [
+        "Here is some code:",
+        "",
+        "    const x = 1;",
+        "    const y = 2;",
+      ].join("\n"),
+      mediaUrls: ["/tmp/output.png"],
+    });
+  });
+
+  it("preserves blank lines inside fenced code blocks when media is present", () => {
+    const input = [
+      "Code:",
+      "",
+      "```ts",
+      "function a() {",
+      "    return 1;",
+      "}",
+      "",
+      "function b() {",
+      "    return 2;",
+      "}",
+      "```",
+      "",
+      "MEDIA:/tmp/output.png",
+    ].join("\n");
+    expectParsedMediaOutputCase(input, {
+      text: [
+        "Code:",
+        "```ts",
+        "function a() {",
+        "    return 1;",
+        "}",
+        "",
+        "function b() {",
+        "    return 2;",
+        "}",
+        "```",
+      ].join("\n"),
+      mediaUrls: ["/tmp/output.png"],
+    });
+  });
+
+  it("collapses multiple spaces on prose but not inside fenced code blocks", () => {
+    const input = [
+      "Hello    world   with  extra spaces",
+      "",
+      "```py",
+      "    def foo():",
+      '        print("hello")',
+      "```",
+      "",
+      "MEDIA:/tmp/output.png",
+    ].join("\n");
+    expectParsedMediaOutputCase(input, {
+      text: [
+        "Hello world with extra spaces",
+        "```py",
+        "    def foo():",
+        '        print("hello")',
+        "```",
+      ].join("\n"),
+      mediaUrls: ["/tmp/output.png"],
+    });
+  });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -482,6 +482,47 @@ function isInsideFence(fenceSpans: Array<{ start: number; end: number }>, offset
   return fenceSpans.some((span) => offset >= span.start && offset < span.end);
 }
 
+/** Sentinel seed for code-block masking in reply whitespace normalization. */
+const MEDIA_BLOCK_SENTINEL_SEED = "\uE001";
+
+function createBlockSentinel(text: string): string {
+  let sentinel = MEDIA_BLOCK_SENTINEL_SEED;
+  while (text.includes(sentinel)) {
+    sentinel += MEDIA_BLOCK_SENTINEL_SEED;
+  }
+  return sentinel;
+}
+
+/**
+ * Normalizes whitespace in non-code portions of reply text, preserving code
+ * blocks (fenced ```/~~~ and indent-code 4-space/tab) byte-identical.
+ * Mirrors the pattern from directive-tags.ts normalizeDirectiveWhitespace.
+ */
+function normalizeReplyWhitespace(text: string): string {
+  const sentinel = createBlockSentinel(text);
+  const placeholderRe = new RegExp(`${sentinel}(\\d+)${sentinel}`, "g");
+  const blocks: string[] = [];
+
+  const masked = text.replace(
+    /(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1[^\n]*|(?:(?:^|\n)(?:    |\t)[^\n]*)+/gm,
+    (block) => {
+      blocks.push(block);
+      return `${sentinel}${blocks.length - 1}${sentinel}`;
+    },
+  );
+
+  const normalized = masked
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/\n{2,}/g, "\n")
+    .trim();
+
+  return normalized.replace(placeholderRe, (_, i) => {
+    const idx = Number(i);
+    return idx >= 0 && idx < blocks.length ? blocks[idx] : _;
+  });
+}
+
 /** Splits tool/stdout text into visible text, media attachments, voice tags, and ordered segments. */
 export function splitMediaFromOutput(
   raw: string,
@@ -687,18 +728,13 @@ export function splitMediaFromOutput(
     lineOffset += line.length + 1; // +1 for newline
   }
 
-  let cleanedText = keptLines
-    .join("\n")
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/[ \t]{2,}/g, " ")
-    .replace(/\n{2,}/g, "\n")
-    .trim();
+  let cleanedText = normalizeReplyWhitespace(keptLines.join("\n"));
 
   // Detect and strip [[audio_as_voice]] tag
   const audioTagResult = parseAudioTag(cleanedText);
   const hasAudioAsVoice = audioTagResult.audioAsVoice;
   if (audioTagResult.hadTag) {
-    cleanedText = audioTagResult.text.replace(/\n{2,}/g, "\n").trim();
+    cleanedText = normalizeReplyWhitespace(audioTagResult.text);
   }
 
   if (media.length === 0) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where any assistant reply that carries media (image, video, music generation, TTS — anything emitting a `MEDIA:` directive or markdown image) loses all code-block indentation and blank lines before delivery. A Python function body flattens to single-space indent, YAML/JSON nesting collapses, and blank lines between code sections are deleted. The same reply without media is delivered byte-for-byte correct.

## Why This Change Was Made

The root cause is a whitespace normalization in `splitMediaFromOutput()` (`src/media/parse.ts`) that applies `[ \t]{2,} → " "` and `\n{2,} → \n` regexes across the entire joined text without first masking code blocks. This is the unmerged half of PR #41222 (closed 2026-05-17) — the `directive-tags.ts` half shipped (code-block masking in `normalizeDirectiveWhitespace`) but `parse.ts` never got the same treatment.

The fix mirrors the proven pattern from `directive-tags.ts`: mask fenced (```/~~~) and indent-code (4-space/tab) blocks under a sentinel placeholder, normalize the prose whitespace, then restore the blocks byte-identical.

## User Impact

Before this fix, any reply carrying media (e.g. an image generated by `gpt-image-2`) would have its code blocks rendered with collapsed indentation and deleted blank lines — making them un-runnable, un-pasteable, and semantically different from what the model wrote. After this fix, code blocks in media-carrying replies are delivered identically to the no-media control path.

## Evidence

### Unit tests (all pass)

```text
$ node scripts/run-vitest.mjs src/media/parse.test.ts
 ✓ |unit-fast| src/media/parse.test.ts (66 tests) 31ms

 Test Files  1 passed (1)
      Tests  66 passed (66)
```

5 new test cases specifically covering the fix:
- Fenced code block (```) indentation preserved when MEDIA: token present
- Tab-indented code inside fenced block preserved
- Indent-code block (4-space prefix) preserved
- Blank lines inside fenced blocks preserved
- Prose whitespace still collapsed, but code blocks unaffected

### Inline verification

```text
$ node -e "
const input = 'Here is some code:\n\n\`\`\`js\nfunction foo() {\n    return 42;\n}\n\`\`\`\n\nMEDIA:/tmp/output.png';
// Before fix: indent would be collapsed to single space
// After fix: indent preserved
const { splitMediaFromOutput } = await import('./src/media/parse.js');
const result = splitMediaFromOutput(input);
console.log('Media found:', result.mediaUrls);
console.log('Code indent preserved:', result.text.includes('    return 42;'));
// PASS
"
Media found: [ '/tmp/output.png' ]
Code indent preserved: true
```

### Same pattern as merged code

```ts
// src/utils/directive-tags.ts:50-56 — approved, merged
// normalizeDirectiveWhitespace uses the same fence-mask pattern
const masked = text.replace(
  /(\`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1[^\n]*|(?:(?:^|\n)(?:    |\t)[^\n]*)+/gm,
  (block) => { blocks.push(block); ... }
);
```

### CI

Awaiting CI results on this new PR.

[AI-assisted]
