### PR TITLE
fix(discord): bound realtime voice playback

### DIFF
--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -2977,11 +2977,13 @@ describe("DiscordVoiceManager", () => {
 
     bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
 
-    expect(realtimeSessionMock.handleBargeIn).toHaveBeenCalledWith({
-      audioPlaybackActive: true,
-      force: true,
-    });
     expect(player.stop).toHaveBeenCalledWith(true);
+    await vi.waitFor(() =>
+      expect(realtimeSessionMock.handleBargeIn).toHaveBeenCalledWith({
+        audioPlaybackActive: true,
+        force: true,
+      }),
+    );
 
     bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
     expect(createAudioResourceMock).toHaveBeenCalledTimes(1);
@@ -2992,6 +2994,58 @@ describe("DiscordVoiceManager", () => {
       bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
     }
 
+    expect(createAudioResourceMock).toHaveBeenCalledTimes(2);
+    expect(player.play).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["response cancellation", { direction: "server", type: "response.cancelled" }],
+    [
+      "cancellation race",
+      {
+        direction: "server",
+        type: "error",
+        detail: "Cancellation failed: no active response found",
+      },
+    ],
+  ] as const)("does not let a deferred backpressure cancel cross %s", async (_label, terminal) => {
+    const manager = createAgentProxyManager();
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+
+    const player = getLastAudioPlayer();
+    const entry = getSessionEntry(manager);
+    const bridgeParams = lastRealtimeBridgeParams();
+
+    for (let index = 0; index < 50; index += 1) {
+      bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    }
+
+    const realtime = entry.realtime as unknown as { outputStream?: PassThrough };
+    const stream = realtime.outputStream;
+    if (!stream) {
+      throw new Error("expected realtime output stream");
+    }
+    vi.spyOn(stream, "write").mockReturnValueOnce(false);
+
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    bridgeParams?.onEvent?.(terminal);
+    for (let index = 0; index < 50; index += 1) {
+      bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    }
+    await Promise.resolve();
+
+    const stopCallCount = player.stop.mock.calls.length;
+    bridgeParams?.onEvent?.({
+      direction: "server",
+      type: "error",
+      detail: "Cancellation failed: no active response found",
+    });
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+
+    expect(realtimeSessionMock.handleBargeIn).not.toHaveBeenCalled();
+    expect(player.stop).toHaveBeenCalledWith(true);
+    expect(player.stop).toHaveBeenCalledTimes(stopCallCount);
     expect(createAudioResourceMock).toHaveBeenCalledTimes(2);
     expect(player.play).toHaveBeenCalledTimes(2);
   });

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -2955,6 +2955,47 @@ describe("DiscordVoiceManager", () => {
     bridgeParams?.onEvent?.({ direction: "server", type: "response.done" });
   });
 
+  it("cancels realtime output when Discord playback backpressures", async () => {
+    const manager = createAgentProxyManager();
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+
+    const player = getLastAudioPlayer();
+    const entry = getSessionEntry(manager);
+    const bridgeParams = lastRealtimeBridgeParams();
+
+    for (let index = 0; index < 50; index += 1) {
+      bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    }
+
+    const realtime = entry.realtime as unknown as { outputStream?: PassThrough };
+    const stream = realtime.outputStream;
+    if (!stream) {
+      throw new Error("expected realtime output stream");
+    }
+    vi.spyOn(stream, "write").mockReturnValueOnce(false);
+
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+
+    expect(realtimeSessionMock.handleBargeIn).toHaveBeenCalledWith({
+      audioPlaybackActive: true,
+      force: true,
+    });
+    expect(player.stop).toHaveBeenCalledWith(true);
+
+    bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    expect(createAudioResourceMock).toHaveBeenCalledTimes(1);
+    expect(player.play).toHaveBeenCalledTimes(1);
+
+    bridgeParams?.onEvent?.({ direction: "server", type: "response.cancelled" });
+    for (let index = 0; index < 50; index += 1) {
+      bridgeParams?.audioSink?.sendAudio(Buffer.alloc(480));
+    }
+
+    expect(createAudioResourceMock).toHaveBeenCalledTimes(2);
+    expect(player.play).toHaveBeenCalledTimes(2);
+  });
+
   it("discards prebuffered realtime output when the response is cancelled", async () => {
     const manager = createAgentProxyManager();
 

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -87,6 +87,7 @@ const DISCORD_REALTIME_FORCED_CONSULT_FALLBACK_DELAY_MS = 200;
 const DISCORD_REALTIME_DUPLICATE_ERROR_SUPPRESS_MS = 60_000;
 const DISCORD_REALTIME_CONTROL_SPEECH_DEDUPE_MS = 5_000;
 const DISCORD_REALTIME_OUTPUT_PLAYBACK_WATCHDOG_MARGIN_MS = 1_500;
+const DISCORD_REALTIME_CANCELLATION_RACE_DETAIL = "Cancellation failed: no active response found";
 const DISCORD_REALTIME_WAKE_ACKS = ["Yeah.", "Mm-hmm.", "Got it.", "One sec."];
 const discordRealtimeTalkPayload = () => ({});
 const REALTIME_PCM16_BYTES_PER_SAMPLE = 2;
@@ -160,10 +161,7 @@ function formatRealtimeInterruptionLog(event: RealtimeVoiceBridgeEvent): string 
     if (event.type === "response.done" && event.detail?.includes("status=cancelled")) {
       return `discord voice: realtime model interrupt confirmed ${event.direction}:${event.type}${detail}`;
     }
-    if (
-      event.type === "error" &&
-      event.detail === "Cancellation failed: no active response found"
-    ) {
+    if (event.type === "error" && event.detail === DISCORD_REALTIME_CANCELLATION_RACE_DETAIL) {
       return `discord voice: realtime model interrupt raced ${event.direction}:${event.type}${detail}`;
     }
   }
@@ -183,6 +181,14 @@ function isRealtimeResponseCancelled(event: RealtimeVoiceBridgeEvent): boolean {
     event.direction === "server" &&
     (event.type === "response.cancelled" ||
       (event.type === "response.done" && event.detail?.includes("status=cancelled") === true))
+  );
+}
+
+function isRealtimeResponseCancellationRace(event: RealtimeVoiceBridgeEvent): boolean {
+  return (
+    event.direction === "server" &&
+    event.type === "error" &&
+    event.detail === DISCORD_REALTIME_CANCELLATION_RACE_DETAIL
   );
 }
 
@@ -336,6 +342,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   );
   private outputPlaybackWatchdog: ReturnType<typeof setTimeout> | undefined;
   private outputPacedBuffer: Buffer = Buffer.alloc(0);
+  private outputBackpressure: { token: symbol } | undefined;
   private realtimeProviderId: string | undefined;
   private queuedExactSpeechMessages: string[] = [];
   private exactSpeechResponseActive = false;
@@ -519,12 +526,19 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
         const responseEnded =
           event.direction === "server" &&
           (event.type === "response.done" || event.type === "response.cancelled");
-        if (responseEnded) {
-          if (this.exactSpeechResponseActive && !this.exactSpeechAudioStarted) {
+        const responseCancellationRaced =
+          this.outputBackpressure !== undefined && isRealtimeResponseCancellationRace(event);
+        if (responseEnded || responseCancellationRaced) {
+          const outputBackpressured = this.outputBackpressure !== undefined;
+          this.outputBackpressure = undefined;
+          if (
+            this.exactSpeechResponseActive &&
+            (outputBackpressured || !this.exactSpeechAudioStarted)
+          ) {
             this.completeExactSpeechResponse(event.type);
           }
           this.finishOutputAudioStream(event.type, {
-            playBuffered: !isRealtimeResponseCancelled(event),
+            playBuffered: responseEnded && !isRealtimeResponseCancelled(event),
           });
         }
         const interruptionLog = formatRealtimeInterruptionLog(event);
@@ -564,6 +578,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
 
   close(): void {
     this.stopped = true;
+    this.outputBackpressure = undefined;
     this.flushSuppressedRealtimeErrors();
     this.harness.close();
     this.speakerTurns.clear();
@@ -718,6 +733,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
   }
 
   private sendOutputAudio(realtimePcm24kMono: Buffer): void {
+    if (this.stopped || this.outputBackpressure) {
+      return;
+    }
     const discordPcm = convertRealtimePcm24kMonoToDiscordPcm48kStereo(realtimePcm24kMono);
     if (discordPcm.length === 0) {
       return;
@@ -780,7 +798,9 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
 
   private queueOutputAudio(stream: PassThrough, discordPcm: Buffer): void {
     if (this.harness.outputActivity.snapshot().playbackStarted) {
-      stream.write(discordPcm);
+      if (!stream.write(discordPcm)) {
+        this.handleOutputBackpressure(stream);
+      }
       return;
     }
     this.outputPacedBuffer =
@@ -793,6 +813,25 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     ) {
       this.startOutputPlayback(stream);
     }
+  }
+
+  private handleOutputBackpressure(stream: PassThrough): void {
+    if (this.outputBackpressure || this.outputStream !== stream) {
+      return;
+    }
+    const token = Symbol("discord-realtime-output-backpressure");
+    this.outputBackpressure = { token };
+    const bufferedBytes = stream.writableLength + stream.readableLength;
+    logger.warn(
+      `discord voice: realtime audio playback backpressured guild=${this.params.entry.guildId} channel=${this.params.entry.channelId} bufferedBytes=${bufferedBytes}`,
+    );
+    this.clearOutputAudio("output-backpressure");
+    queueMicrotask(() => {
+      if (this.stopped || this.outputBackpressure?.token !== token) {
+        return;
+      }
+      this.harness.handleBargeIn({ audioPlaybackActive: true, force: true }, () => {});
+    });
   }
 
   private startOutputPlayback(stream: PassThrough): void {


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where Discord realtime voice sessions could retain unbounded raw PCM when provider audio arrived faster than the Discord player consumed it or playback stalled.

## Why This Change Was Made

Discord now treats the first raw playback backpressure signal as response-terminal work: it clears the local stream immediately, defers a forced provider cancellation until the current audio callback finishes, and ignores later deltas until the owned response ends. Cancellation-race errors release only the matching backpressure state, so stale provider errors cannot stop the next response.

This stays local to the Discord realtime session. It does not change provider, config, environment-variable, or shared realtime sink contracts.

## User Impact

Discord realtime voice playback remains bounded during provider bursts or stalled playback instead of allowing raw audio memory to grow for the session lifetime. Normal playback, cancellation, exact-speech queuing, and the next response continue to use the existing behavior.

## Evidence

- Red/green focused regression: `node scripts/test-projects-serial.mjs extensions/discord/src/voice/manager.e2e.test.ts` — 159 tests passed.
- Full Discord extension lane in Blacksmith Testbox `tbx_01kythkh8zt8krdbwqsnk199a9`: `CI=true pnpm test:extension discord` — 206 files / 2,386 tests passed.
- Exact-head changed gate in the same Testbox: `CI=true pnpm check:changed` — passed.
- Live OpenAI audio validation with the existing authorized OAuth-backed profile: `node scripts/test-live.mjs -- extensions/openai/openai.live.test.ts` — 8 tests passed.
- Exact-head protected Discord QA: https://github.com/openclaw/openclaw/actions/runs/30587793342 — 6/6 live scenarios passed, including `discord-voice-autojoin` with the SUT bot joining the voice channel.
- Dependency/runtime proof: `@discordjs/voice@0.19.2` pulls one Opus packet approximately every 20 ms; a matching stalled-stream probe reached backpressure at frame 273 and retained 37,843,200 writable bytes when 10,000 raw PCM frames ignored the signal.
- Final branch-wide Codex autoreview: clean, no accepted/actionable findings.

AI-assisted; the implementation, provider callback ordering, dependency behavior, and regression coverage were manually verified.

No public or personal secrets, paths, hostnames, or credentials are included in this change.
