### PR TITLE
fix(cli): one-shot Claude command exits after result

### DIFF
--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -46,6 +46,10 @@ const closeActiveMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {
 const hasMemoryRuntimeMock = vi.hoisted(() => vi.fn(() => false));
 const listRegisteredAgentHarnessesMock = vi.hoisted(() => vi.fn((): unknown[] => []));
 const disposeRegisteredAgentHarnessesMock = vi.hoisted(() => vi.fn(async () => {}));
+const getActiveMcpLoopbackRuntimeMock = vi.hoisted(() =>
+  vi.fn<() => { port: number } | undefined>(() => undefined),
+);
+const closeMcpLoopbackServerMock = vi.hoisted(() => vi.fn(async () => {}));
 const ensureTaskRegistryReadyMock = vi.hoisted(() => vi.fn());
 const startTaskRegistryMaintenanceMock = vi.hoisted(() => vi.fn());
 const outputRootHelpMock = vi.hoisted(() => vi.fn());
@@ -276,6 +280,14 @@ vi.mock("../plugins/memory-state.js", () => ({
 vi.mock("../agents/harness/registry.js", () => ({
   listRegisteredAgentHarnesses: listRegisteredAgentHarnessesMock,
   disposeRegisteredAgentHarnesses: disposeRegisteredAgentHarnessesMock,
+}));
+
+vi.mock("../gateway/mcp-http.loopback-runtime.js", () => ({
+  getActiveMcpLoopbackRuntime: getActiveMcpLoopbackRuntimeMock,
+}));
+
+vi.mock("../gateway/mcp-http.js", () => ({
+  closeMcpLoopbackServer: closeMcpLoopbackServerMock,
 }));
 
 vi.mock("../tasks/task-registry.js", () => ({
@@ -524,6 +536,10 @@ describe("runCli exit behavior", () => {
     disposeRegisteredAgentHarnessesMock.mockImplementationOnce(async () => {
       order.push("harnesses");
     });
+    getActiveMcpLoopbackRuntimeMock.mockReturnValueOnce({ port: 1234 });
+    closeMcpLoopbackServerMock.mockImplementationOnce(async () => {
+      order.push("mcp-loopback");
+    });
     hasMemoryRuntimeMock.mockReturnValueOnce(true);
     closeActiveMemorySearchManagersMock.mockImplementationOnce(async () => {
       order.push("memory");
@@ -532,8 +548,18 @@ describe("runCli exit behavior", () => {
 
     await runCli(["node", "openclaw", "models", "status", "--probe"]);
 
-    expect(order).toEqual(["harnesses", "memory"]);
+    expect(order).toEqual(["harnesses", "mcp-loopback", "memory"]);
     expect(flushExitAfterOneShotOutputMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fail the command when MCP loopback cleanup fails", async () => {
+    tryRouteCliMock.mockResolvedValueOnce(true);
+    getActiveMcpLoopbackRuntimeMock.mockReturnValueOnce({ port: 1234 });
+    closeMcpLoopbackServerMock.mockRejectedValueOnce(new Error("listener cleanup failed"));
+
+    await expect(runCli(["node", "openclaw", "status"])).resolves.toBeUndefined();
+
+    expect(closeMcpLoopbackServerMock).toHaveBeenCalledTimes(1);
   });
 
   it("shows the standard spinner while loading the full CLI", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -287,6 +287,20 @@ async function disposeCliAgentHarnesses(): Promise<void> {
   }
 }
 
+async function closeCliMcpLoopbackServer(): Promise<void> {
+  try {
+    const { getActiveMcpLoopbackRuntime } = await import("../gateway/mcp-http.loopback-runtime.js");
+    if (!getActiveMcpLoopbackRuntime()) {
+      return;
+    }
+    const { closeMcpLoopbackServer } = await import("../gateway/mcp-http.js");
+    await closeMcpLoopbackServer();
+  } catch {
+    // Best-effort teardown for short-lived CLI commands. A command result is
+    // already final, so cleanup must not replace its outcome.
+  }
+}
+
 function isUnconfiguredConfigSnapshot(
   snapshot: Pick<ConfigFileSnapshot, "exists" | "valid" | "sourceConfig">,
 ): boolean {
@@ -1579,6 +1593,7 @@ async function runCliWithPreparedOutputMode(
     uninstallGatewayRunRuntimeHooks?.();
     await stopStartedProxy();
     await disposeCliAgentHarnesses();
+    await closeCliMcpLoopbackServer();
     await closeCliMemoryManagers();
     pauseNonTtyStdinForCliExit();
   }


### PR DESCRIPTION
Related: #108738

## What Problem This Solves

Fixes an issue where users running a one-shot local agent turn through Claude CLI would receive the completed result, but the `openclaw agent --local` process would remain alive indefinitely.

## Why This Change Was Made

The disposable CLI process now closes its process-owned MCP loopback listener during orderly finalization, after harness cleanup and before memory cleanup. The close path first checks lightweight active-runtime state, preserving lazy loading for commands that never start MCP, and remains best-effort so cleanup cannot replace the command's real outcome.

Long-lived Gateway ownership, Claude session reuse, provider pooling, and process-exit policy are unchanged.

## User Impact

Successful one-shot Claude CLI commands now return control to the shell promptly after output, transcript, provider-child, and MCP cleanup complete. Long-lived Gateway turns continue to retain same-session CLI context.

AI-assisted: yes. I understand the change and validated both the short-lived CLI and long-lived Gateway lifecycle boundaries.

## Evidence

- Fresh `origin/main` reproduction isolated the remaining ref'ed handle to the MCP loopback server after the Claude child had exited: [Crabbox run `run_c46e445469f6`](https://crabbox.openclaw.ai/portal/runs/run_c46e445469f6).
- Exact candidate head returned the requested Claude marker, closed the provider child and MCP listener, reached `beforeExit` with no active handles, and changed host exit from bounded timeout to clean: [Crabbox run `run_88c9bcaa991f`](https://crabbox.openclaw.ai/portal/runs/run_88c9bcaa991f).
- Long-lived Gateway regression proof completed two same-session Claude turns, resumed the retained CLI session, stayed live between turns, and shut down gracefully: [Crabbox run `run_2e0973dbc115`](https://crabbox.openclaw.ai/portal/runs/run_2e0973dbc115).
- Focused CLI lifecycle suite: 194 tests passed on exact head: [Crabbox run `run_dcf6705c1c02`](https://crabbox.openclaw.ai/portal/runs/run_dcf6705c1c02).
- Complete changed-surface gate passed core and core-test formatting, typecheck, lint, boundary, dependency, dead-code, schema, and database guards: [GitHub Actions run `30587348868`](https://github.com/openclaw/openclaw/actions/runs/30587348868).
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean, no accepted/actionable findings.
