### PR TITLE
test(qa-lab): preserve Matrix fault proxy identity

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
@@ -291,6 +291,7 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
       driverUserId: params.provisioning.driver.userId,
       faultProxyObserver: params.harness.recording,
       faultProxyTargetBaseUrl: params.harness.upstreamBaseUrl,
+      installFaultRule: (rule) => params.harness.recording.installFaultRule(rule),
       observedEvents: params.observedEvents,
       observerAccessToken: params.provisioning.observer.accessToken,
       observerDeviceId: params.provisioning.observer.deviceId,

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-messages.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-messages.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MATRIX_QA_SYNC_STATE_AFTER_FAULT_RULE_ID } from "./scenario-runtime-e2ee-shared.js";
+import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
+
+const mocks = vi.hoisted(() => ({
+  runMatrixQaE2eeTopLevelScenario: vi.fn(),
+}));
+
+vi.mock("./scenario-runtime-e2ee-room.js", () => ({
+  buildMatrixE2eeReplyArtifact: vi.fn(),
+  buildSyncStateAfterMissingEncryptionFaultRule: (accessToken: string) => ({
+    id: "sync-state-after-missing-encryption",
+    match: (request: { bearerToken?: string }) => request.bearerToken === accessToken,
+  }),
+  runMatrixQaE2eeTopLevelScenario: mocks.runMatrixQaE2eeTopLevelScenario,
+  runMatrixQaE2eeTopLevelWithClient: vi.fn(),
+  withMatrixQaE2eeDriver: vi.fn(),
+  withMatrixQaIsolatedE2eeDriverRoom: vi.fn(),
+}));
+
+import { runMatrixQaE2eeStateAfterMissingEncryptionScenario } from "./scenario-runtime-e2ee-messages.js";
+
+describe("runMatrixQaE2eeStateAfterMissingEncryptionScenario", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.runMatrixQaE2eeTopLevelScenario.mockResolvedValue({
+      driverEventId: "$driver",
+      driverUserId: "@driver:matrix-qa.test",
+      reply: {
+        eventId: "$reply",
+        sender: "@sut:matrix-qa.test",
+        tokenMatched: true,
+      },
+      roomId: "!room:matrix-qa.test",
+      roomKey: "state-after",
+      since: "sync-1",
+      token: "MATRIX_QA_E2EE_STATE_AFTER",
+    });
+  });
+
+  it("restarts through an in-place rule without changing the canonical homeserver", async () => {
+    const order: string[] = [];
+    const remove = vi.fn(() => order.push("remove"));
+    const installFaultRule = vi.fn(() => {
+      order.push("install");
+      return { hits: () => [], remove };
+    });
+    const restartGatewayAfterStateMutation = vi.fn(
+      async (mutateState: (context: { stateDir: string }) => Promise<void>) => {
+        order.push("restart");
+        await mutateState({ stateDir: "/tmp/matrix-qa-state" });
+      },
+    );
+    mocks.runMatrixQaE2eeTopLevelScenario.mockImplementationOnce(async () => {
+      order.push("run");
+      return {
+        driverEventId: "$driver",
+        driverUserId: "@driver:matrix-qa.test",
+        reply: {
+          eventId: "$reply",
+          sender: "@sut:matrix-qa.test",
+          tokenMatched: true,
+        },
+        roomId: "!room:matrix-qa.test",
+        roomKey: "state-after",
+        since: "sync-1",
+        token: "MATRIX_QA_E2EE_STATE_AFTER",
+      };
+    });
+    const context = {
+      baseUrl: "http://127.0.0.1:28123",
+      installFaultRule,
+      restartGatewayAfterStateMutation,
+      sutAccessToken: "sut-token",
+      sutAccountId: "sut",
+      timeoutMs: 30_000,
+    } as unknown as MatrixQaScenarioContext;
+
+    const result = await runMatrixQaE2eeStateAfterMissingEncryptionScenario(context);
+
+    expect(order).toEqual(["install", "restart", "run", "remove"]);
+    expect(restartGatewayAfterStateMutation).toHaveBeenCalledOnce();
+    expect(installFaultRule).toHaveBeenCalledWith(
+      expect.objectContaining({ id: MATRIX_QA_SYNC_STATE_AFTER_FAULT_RULE_ID }),
+    );
+    expect(result.artifacts).toMatchObject({
+      faultProxyBaseUrl: context.baseUrl,
+      stateAfterFaultHitCount: 0,
+      strippedSyncStateAfterParam: true,
+    });
+  });
+
+  it("removes the in-place rule when the encrypted turn fails", async () => {
+    const remove = vi.fn();
+    mocks.runMatrixQaE2eeTopLevelScenario.mockRejectedValueOnce(new Error("turn failed"));
+    const context = {
+      baseUrl: "http://127.0.0.1:28123",
+      installFaultRule: () => ({ hits: () => [], remove }),
+      restartGatewayAfterStateMutation: async (
+        mutateState: (context: { stateDir: string }) => Promise<void>,
+      ) => {
+        await mutateState({ stateDir: "/tmp/matrix-qa-state" });
+      },
+      sutAccessToken: "sut-token",
+      timeoutMs: 30_000,
+    } as unknown as MatrixQaScenarioContext;
+
+    await expect(runMatrixQaE2eeStateAfterMissingEncryptionScenario(context)).rejects.toThrow(
+      "turn failed",
+    );
+    expect(remove).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-messages.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-messages.ts
@@ -1,17 +1,11 @@
 // Qa Matrix plugin module implements message scenario runtime E2EE behavior.
 import { randomUUID } from "node:crypto";
-import { startMatrixQaFaultProxy } from "../substrate/fault-proxy.js";
 import {
   buildMatrixQaImageUnderstandingPrompt,
   createMatrixQaSplitColorImagePng,
   hasMatrixQaExpectedColorReply,
   MATRIX_QA_IMAGE_ATTACHMENT_FILENAME,
 } from "./scenario-media-fixtures.js";
-import {
-  patchMatrixQaGatewayMatrixAccount,
-  readMatrixQaGatewayMatrixAccount,
-  replaceMatrixQaGatewayMatrixAccount,
-} from "./scenario-runtime-config.js";
 import {
   buildMatrixE2eeReplyArtifact,
   buildSyncStateAfterMissingEncryptionFaultRule,
@@ -24,7 +18,6 @@ import {
   MATRIX_QA_SYNC_STATE_AFTER_FAULT_RULE_ID,
   MATRIX_QA_SYNC_STATE_AFTER_PARAM,
   isMatrixQaE2eeNoticeTriggeredSutReply,
-  requireMatrixQaGatewayConfigPath,
   resolveMatrixQaE2eeScenarioGroupRoom,
 } from "./scenario-runtime-e2ee-shared.js";
 import {
@@ -67,43 +60,25 @@ export async function runMatrixQaE2eeStateAfterMissingEncryptionScenario(
   if (!context.restartGatewayAfterStateMutation) {
     throw new Error("Matrix E2EE state_after QA scenario requires hard gateway restart support");
   }
+  if (!context.installFaultRule) {
+    throw new Error("Matrix E2EE state_after QA scenario requires in-place fault injection");
+  }
   const accountId = context.sutAccountId ?? "sut";
-  const configPath = requireMatrixQaGatewayConfigPath(context);
-  const originalAccountConfig = await readMatrixQaGatewayMatrixAccount({
-    accountId,
-    configPath,
-  });
-  const proxy = await startMatrixQaFaultProxy({
-    targetBaseUrl: context.faultProxyTargetBaseUrl ?? context.baseUrl,
-    ...context.faultProxyObserver,
-    rules: [buildSyncStateAfterMissingEncryptionFaultRule(context.sutAccessToken)],
-  });
-  let gatewayPatched = false;
+  const faultRule = context.installFaultRule(
+    buildSyncStateAfterMissingEncryptionFaultRule(context.sutAccessToken),
+  );
   try {
-    await context.restartGatewayAfterStateMutation(
-      async () => {
-        await patchMatrixQaGatewayMatrixAccount({
-          accountId,
-          accountPatch: {
-            homeserver: proxy.baseUrl,
-            network: {
-              dangerouslyAllowPrivateNetwork: true,
-            },
-          },
-          configPath,
-        });
-        gatewayPatched = true;
-      },
-      {
-        timeoutMs: context.timeoutMs,
-        waitAccountId: accountId,
-      },
-    );
+    // Keep the configured homeserver URL stable so the Matrix client reuses
+    // its existing crypto identity while every post-restart /sync crosses the fault rule.
+    await context.restartGatewayAfterStateMutation(async () => undefined, {
+      timeoutMs: context.timeoutMs,
+      waitAccountId: accountId,
+    });
     const result = await runMatrixQaE2eeTopLevelScenario(context, {
       scenarioId: "matrix-e2ee-state-after-missing-encryption",
       tokenPrefix: "MATRIX_QA_E2EE_STATE_AFTER",
     });
-    const stateAfterHits = proxy
+    const stateAfterHits = faultRule
       .hits()
       .filter((hit) => hit.ruleId === MATRIX_QA_SYNC_STATE_AFTER_FAULT_RULE_ID);
     if (stateAfterHits.length > 0) {
@@ -114,7 +89,7 @@ export async function runMatrixQaE2eeStateAfterMissingEncryptionScenario(
     return {
       artifacts: {
         driverEventId: result.driverEventId,
-        faultProxyBaseUrl: proxy.baseUrl,
+        faultProxyBaseUrl: context.baseUrl,
         reply: result.reply,
         roomKey: result.roomKey,
         roomId: result.roomId,
@@ -126,30 +101,13 @@ export async function runMatrixQaE2eeStateAfterMissingEncryptionScenario(
         `encrypted room key: ${result.roomKey}`,
         `encrypted room id: ${result.roomId}`,
         `driver event: ${result.driverEventId}`,
-        `fault proxy: ${proxy.baseUrl}`,
+        `fault proxy: ${context.baseUrl}`,
         `state_after sync opt-in hits: ${stateAfterHits.length}`,
         ...buildMatrixReplyDetails("E2EE state_after reply", result.reply),
       ].join("\n"),
     };
   } finally {
-    if (gatewayPatched) {
-      await context
-        .restartGatewayAfterStateMutation(
-          async () => {
-            await replaceMatrixQaGatewayMatrixAccount({
-              accountConfig: originalAccountConfig,
-              accountId,
-              configPath,
-            });
-          },
-          {
-            timeoutMs: context.timeoutMs,
-            waitAccountId: accountId,
-          },
-        )
-        .catch(() => undefined);
-    }
-    await proxy.stop().catch(() => undefined);
+    faultRule.remove();
   }
 }
 

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-shared.ts
@@ -2,7 +2,11 @@
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createMatrixQaClient, type MatrixQaRoomObserver } from "../substrate/client.js";
 import type { MatrixQaObservedEvent } from "../substrate/events.js";
-import type { MatrixQaFaultProxyObserver } from "../substrate/fault-proxy.js";
+import type {
+  MatrixQaFaultProxyObserver,
+  MatrixQaFaultProxyRule,
+  MatrixQaFaultProxyRuleHandle,
+} from "../substrate/fault-proxy.js";
 import { createMatrixQaRoomObserver } from "../substrate/sync.js";
 import type { MatrixQaProvisionedTopology } from "../substrate/topology.js";
 import { resolveMatrixQaScenarioRoomId } from "./scenario-contract.js";
@@ -31,6 +35,7 @@ export type MatrixQaScenarioContext = {
   driverUserId: string;
   faultProxyObserver?: MatrixQaFaultProxyObserver;
   faultProxyTargetBaseUrl?: string;
+  installFaultRule?: (rule: MatrixQaFaultProxyRule) => MatrixQaFaultProxyRuleHandle;
   observedEvents: MatrixQaObservedEvent[];
   observerAccessToken: string;
   observerDeviceId?: string;

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.test.ts
@@ -229,6 +229,40 @@ describe("Matrix QA fault proxy", () => {
     ]);
   });
 
+  it("installs and removes scenario-local rules without changing the proxy origin", async () => {
+    const target = await startTargetServer();
+    proxy = await startMatrixQaFaultProxy({ targetBaseUrl: target.baseUrl, rules: [] });
+    const baseUrl = proxy.baseUrl;
+    const handle = proxy.installRule({
+      id: "scenario-local-sync-fault",
+      match: (proxyRequest) =>
+        proxyRequest.path === "/_matrix/client/v3/sync" && proxyRequest.bearerToken === "sut-token",
+      response: () => ({ body: { errcode: "M_QA_FAULT" }, status: 503 }),
+    });
+
+    const faulted = await fetch(`${proxy.baseUrl}/_matrix/client/v3/sync`, {
+      headers: { authorization: "Bearer sut-token" },
+    });
+    expect(faulted.status).toBe(503);
+    expect(proxy.baseUrl).toBe(baseUrl);
+    expect(handle.hits()).toEqual([
+      {
+        method: "GET",
+        path: "/_matrix/client/v3/sync",
+        ruleId: "scenario-local-sync-fault",
+      },
+    ]);
+
+    handle.remove();
+    handle.remove();
+    const forwarded = await fetch(`${proxy.baseUrl}/_matrix/client/v3/sync`, {
+      headers: { authorization: "Bearer sut-token" },
+    });
+    expect(forwarded.status).toBe(200);
+    expect(handle.hits()).toHaveLength(1);
+    expect(proxy.hits()).toHaveLength(1);
+  });
+
   it("rejects oversized forwarded request bodies before contacting the target", async () => {
     const target = await startTargetServer();
     proxy = await startMatrixQaFaultProxy({

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.ts
@@ -82,12 +82,35 @@ export type MatrixQaFaultProxyHit = {
   ruleId: string;
 };
 
+export type MatrixQaFaultProxyRuleHandle = {
+  hits(): MatrixQaFaultProxyHit[];
+  remove(): void;
+};
+
 type MatrixQaFaultProxy = {
   baseUrl: string;
   hits(): MatrixQaFaultProxyHit[];
+  installRule(rule: MatrixQaFaultProxyRule): MatrixQaFaultProxyRuleHandle;
   setTargetBaseUrl(targetBaseUrl: string): void;
   stop(): Promise<void>;
 };
+
+type MatrixQaRegisteredFaultProxyRule = {
+  registrationId: number;
+  rule: MatrixQaFaultProxyRule;
+};
+
+type MatrixQaRegisteredFaultProxyHit = MatrixQaFaultProxyHit & {
+  registrationId: number;
+};
+
+function toMatrixQaFaultProxyHit(hit: MatrixQaRegisteredFaultProxyHit): MatrixQaFaultProxyHit {
+  return {
+    method: hit.method,
+    path: hit.path,
+    ruleId: hit.ruleId,
+  };
+}
 
 function normalizeHeaderValue(value: string | string[] | undefined) {
   if (Array.isArray(value)) {
@@ -330,7 +353,12 @@ export async function startMatrixQaFaultProxy(
   let targetBaseUrl = new URL(params.targetBaseUrl);
   const maxRequestBytes = params.maxRequestBytes ?? DEFAULT_FAULT_PROXY_REQUEST_MAX_BYTES;
   const maxResponseBytes = params.maxResponseBytes ?? DEFAULT_FAULT_PROXY_RESPONSE_MAX_BYTES;
-  const hits: MatrixQaFaultProxyHit[] = [];
+  let nextRuleRegistrationId = 0;
+  const registeredRules: MatrixQaRegisteredFaultProxyRule[] = params.rules.map((rule) => ({
+    registrationId: nextRuleRegistrationId++,
+    rule,
+  }));
+  const hits: MatrixQaRegisteredFaultProxyHit[] = [];
   const activeAbortControllers = new Set<AbortController>();
   const server = createServer((req, res) => {
     const abortController = new AbortController();
@@ -369,11 +397,13 @@ export async function startMatrixQaFaultProxy(
         observedRequest = request;
         const context = params.createExchangeContext?.(request);
         observedContext = context;
-        const rule = params.rules.find((candidate) => candidate.match(request));
-        if (rule) {
+        const registeredRule = registeredRules.find((candidate) => candidate.rule.match(request));
+        const rule = registeredRule?.rule;
+        if (rule && registeredRule) {
           hits.push({
             method: request.method,
             path: request.path,
+            registrationId: registeredRule.registrationId,
             ruleId: rule.id,
           });
           if (rule.response) {
@@ -461,7 +491,27 @@ export async function startMatrixQaFaultProxy(
 
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
-    hits: () => [...hits],
+    hits: () => hits.map(toMatrixQaFaultProxyHit),
+    installRule(rule) {
+      const registrationId = nextRuleRegistrationId++;
+      const registeredRule = { registrationId, rule };
+      registeredRules.push(registeredRule);
+      let removed = false;
+      return {
+        hits: () =>
+          hits.filter((hit) => hit.registrationId === registrationId).map(toMatrixQaFaultProxyHit),
+        remove() {
+          if (removed) {
+            return;
+          }
+          removed = true;
+          const index = registeredRules.indexOf(registeredRule);
+          if (index !== -1) {
+            registeredRules.splice(index, 1);
+          }
+        },
+      };
+    },
     setTargetBaseUrl(nextTargetBaseUrl) {
       targetBaseUrl = new URL(nextTargetBaseUrl);
     },

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/harness.runtime.test.ts
@@ -41,6 +41,7 @@ async function withStartedMatrixHarness(
         ({
           baseUrl: targetBaseUrl,
           buildManifest: vi.fn(),
+          installFaultRule: vi.fn(() => ({ hits: () => [], remove: vi.fn() })),
           records: () => [],
           setScenarioId: vi.fn(),
           setTargetBaseUrl: vi.fn(),
@@ -211,6 +212,7 @@ describe("matrix harness runtime", () => {
           baseUrl: targetBaseUrl,
           buildManifest: vi.fn(),
           createExchangeContext: vi.fn(),
+          installFaultRule: vi.fn(() => ({ hits: () => [], remove: vi.fn() })),
           onExchange: vi.fn(),
           records: () => [],
           setScenarioId: vi.fn(),

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/recording-proxy.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/recording-proxy.test.ts
@@ -402,6 +402,37 @@ describe("Matrix QA recording proxy", () => {
     expect(JSON.stringify(record)).not.toContain("secret-fault-message");
   });
 
+  it("records in-place scenario faults without changing the canonical proxy URL", async () => {
+    const targetBaseUrl = await startRecordingTarget();
+    const recording = await startMatrixQaRecordingProxy({ targetBaseUrl });
+    closeCallbacks.push(() => recording.stop());
+    recording.setScenarioId("matrix-in-place-fault-recording-test");
+    const baseUrl = recording.baseUrl;
+    const handle = recording.installFaultRule({
+      id: "in-place-backup-unavailable",
+      match: (request) => request.path.endsWith("/room_keys/version"),
+      response: () => ({
+        body: { errcode: "M_NOT_FOUND", error: "secret-in-place-fault" },
+        status: 404,
+      }),
+    });
+
+    const response = await fetch(`${recording.baseUrl}/_matrix/client/v3/room_keys/version`);
+    expect(response.status).toBe(404);
+    expect(recording.baseUrl).toBe(baseUrl);
+    expect(handle.hits()).toHaveLength(1);
+    expect(recording.records().at(-1)?.response).toMatchObject({
+      errcode: "M_NOT_FOUND",
+      status: 404,
+    });
+    expect(JSON.stringify(recording.records().at(-1))).not.toContain("secret-in-place-fault");
+
+    handle.remove();
+    const forwarded = await fetch(`${recording.baseUrl}/_matrix/client/v3/room_keys/version`);
+    expect(forwarded.status).toBe(401);
+    expect(handle.hits()).toHaveLength(1);
+  });
+
   it("records proxy-generated upstream failures", async () => {
     const recording = await startMatrixQaRecordingProxy({
       targetBaseUrl: "http://127.0.0.1:1",

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/recording-proxy.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/recording-proxy.ts
@@ -5,6 +5,8 @@ import {
   startMatrixQaFaultProxy,
   type MatrixQaFaultProxyExchange,
   type MatrixQaFaultProxyObserver,
+  type MatrixQaFaultProxyRule,
+  type MatrixQaFaultProxyRuleHandle,
 } from "./fault-proxy.js";
 import { normalizeMatrixQaRoute } from "./recording-proxy-internals.js";
 
@@ -109,6 +111,7 @@ export type MatrixQaRecordingProxy = MatrixQaFaultProxyObserver & {
     scenarioIds: string[];
     substrate: MatrixQaRouteStateManifest["substrate"];
   }): MatrixQaRouteStateManifest;
+  installFaultRule(rule: MatrixQaFaultProxyRule): MatrixQaFaultProxyRuleHandle;
   records(): MatrixQaRecordedExchange[];
   setScenarioId(scenarioId: string): void;
   setTargetBaseUrl(targetBaseUrl: string): void;
@@ -618,6 +621,7 @@ export async function startMatrixQaRecordingProxy(params: {
         substrate,
       };
     },
+    installFaultRule: (rule) => proxy.installRule(rule),
     records: () =>
       structuredClone(
         records


### PR DESCRIPTION
## Summary

- Add scenario-local Matrix fault rules to the existing recording proxy.
- Keep the configured homeserver URL stable across fault-injection restarts.
- Remove installed rules deterministically after each scenario.
- Cover registration, recording, cleanup, stable-URL restart behavior, and harness wiring.

## Why

The Matrix QA scenario for a missing encryption `state_after` response previously created a second proxy and rewrote the configured homeserver URL. Matrix crypto storage is keyed to that URL, so the hard restart invalidated the scenario's existing crypto identity before it could exercise the intended fault.

This keeps fault injection on the canonical proxy and preserves the Matrix storage identity.

## Validation

- Focused Matrix fault, recording, and scenario tests: 25/25 passed.
- Changed-surface tests: 44/44 passed.
- Full Matrix QA catalog: all 91 scenarios passed.
  - Seven deterministic shards covered the complete catalog.
  - One cumulative-only thread-shape variance was superseded by a clean standalone pass.
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`: passed.
- `pnpm check:changed`: passed.
- Mandatory local autoreview: clean.
- Local ClawSweeper review: A/A/A with no findings or rank-up moves.
- PR CI: settled with no pending or failing checks.
- `git diff --check`: passed.

### Reviewer-inspectable Matrix proof

The retained candidate was executed on Blacksmith Testbox through the production Matrix plugin against a disposable Tuwunel homeserver. Its ordered changed-file digest matches the files committed at the exact PR HEAD.

```text
PR HEAD:                         4793b062604260af130efa1ff4f19c0fcd7e463d
candidate changed-file digest:  a2fcd6b2ca8637fe129c6523358d6dbaa509048e25dff9d748ba5fdf3287d440
HEAD changed-file digest:       a2fcd6b2ca8637fe129c6523358d6dbaa509048e25dff9d748ba5fdf3287d440

live scenario:                  matrix-e2ee-state-after-missing-encryption
production Matrix plugin:       true
disposable Tuwunel fixture:     true
hard Gateway restart:           observed
canonical proxy origin changed: false
encrypted reply verified:       true
state_after tripwire hits:       0 (expected)
standalone result:               PASS
bounded shard result:            PASS
complete Matrix catalog:         91/91 PASS

focused cleanup proof on HEAD:   25/25 PASS
rule-specific hit accounting:    PASS
idempotent rule removal:         PASS
post-removal forwarding:         PASS
failure-path cleanup:             PASS
```

The temporary rule is a tripwire for a forbidden `org.matrix.msc4222.use_state_after=true` sync request. A matched rule and injected response would be a scenario failure; the required live result is zero hits while the encrypted reply succeeds after the hard restart.

Live run provenance: Blacksmith Testbox run `30586789278`, lease `tbx_01kythtq30hcycev1qqfhma3cw`. Cleanup was refreshed at the exact PR HEAD with the three focused fault-proxy, recording-proxy, and scenario suites.
