### PR TITLE
fix(gateway): avoid false port-busy reports behind Tailscale Serve

### DIFF
--- a/src/cli/daemon-cli/restart-health-probe.ts
+++ b/src/cli/daemon-cli/restart-health-probe.ts
@@ -7,7 +7,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginHealthErrorSummary } from "../../gateway/health/types.js";
 import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../../gateway/probe-auth.js";
 import { probeGateway } from "../../gateway/probe.js";
-import { inspectPortUsage, type PortUsage } from "../../infra/ports.js";
+import { inspectPortUsage, LOOPBACK_PORT_PROBE_HOSTS, type PortUsage } from "../../infra/ports.js";
 import type { GatewayPortHealthSnapshot } from "./restart-health.types.js";
 import { allListenersOwnedByRuntimePid } from "./restart-port-ownership.js";
 
@@ -196,7 +196,9 @@ export async function inspectGatewayPortHealth(params: {
 }): Promise<GatewayPortHealthSnapshot> {
   let portUsage: PortUsage;
   try {
-    portUsage = await inspectPortUsage(params.port);
+    portUsage = await inspectPortUsage(params.port, {
+      probeHosts: LOOPBACK_PORT_PROBE_HOSTS,
+    });
   } catch (err) {
     portUsage = {
       port: params.port,

--- a/src/cli/daemon-cli/restart-health-wait.test.ts
+++ b/src/cli/daemon-cli/restart-health-wait.test.ts
@@ -35,7 +35,7 @@ describe("restart health", () => {
 
     const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
     const snapshot = await waitForGatewayHealthyRestart({
-      service: { readRuntime } as unknown as GatewayService,
+      service: { readRuntime, readCommand: vi.fn(async () => null) } as unknown as GatewayService,
       port: 18789,
       expectedVersion: "2026.4.24",
       requireRunningService: true,
@@ -284,6 +284,7 @@ describe("restart health", () => {
       readRuntime: vi.fn(async () =>
         ++runtimeReads >= 27 ? { status: "running", pid: 8000 } : { status: "stopped" },
       ),
+      readCommand: vi.fn(async () => null),
     } as unknown as GatewayService;
     inspectPortUsage.mockImplementation(async () =>
       ++portInspections >= 27

--- a/src/cli/daemon-cli/restart-health.test-helpers.ts
+++ b/src/cli/daemon-cli/restart-health.test-helpers.ts
@@ -5,7 +5,8 @@ import type { PortUsage } from "../../infra/ports.js";
 
 type PortListenerKind = ReturnType<typeof import("../../infra/ports.js").classifyPortListener>;
 
-export const inspectPortUsage = vi.fn<(port: number) => Promise<PortUsage>>();
+export const inspectPortUsage =
+  vi.fn<(port: number, options?: { probeHosts?: readonly string[] }) => Promise<PortUsage>>();
 export const monotonicClock = { nowMs: 0 };
 export const sleep = vi.fn(async (ms: number) => {
   monotonicClock.nowMs += ms;
@@ -25,7 +26,9 @@ export const readActiveGatewayLockIdentity = vi.fn();
 vi.mock("../../infra/ports.js", () => ({
   classifyPortListener: (listener: unknown, port: number) => classifyPortListener(listener, port),
   formatPortDiagnostics: vi.fn(() => []),
-  inspectPortUsage: (port: number) => inspectPortUsage(port),
+  inspectPortUsage: (port: number, options?: { probeHosts?: readonly string[] }) =>
+    inspectPortUsage(port, options),
+  LOOPBACK_PORT_PROBE_HOSTS: ["127.0.0.1"],
 }));
 
 vi.mock("../../gateway/probe.js", () => ({

--- a/src/cli/daemon-cli/restart-health.test-helpers.ts
+++ b/src/cli/daemon-cli/restart-health.test-helpers.ts
@@ -22,6 +22,9 @@ export const resolveGatewayProbeAuthSafeWithSecretInputs = vi.fn<
 >(async () => ({ auth: {} }));
 const hasActiveStartupMigrationLease = vi.fn<(_params?: unknown) => boolean>(() => false);
 export const readActiveGatewayLockIdentity = vi.fn();
+export const resolveGatewayServiceProbeHosts = vi.fn<
+  (_params?: unknown) => Promise<readonly string[]>
+>(async () => ["127.0.0.1"]);
 
 vi.mock("../../infra/ports.js", () => ({
   classifyPortListener: (listener: unknown, port: number) => classifyPortListener(listener, port),
@@ -62,6 +65,10 @@ vi.mock("../../infra/gateway-lock.js", () => ({
         previous.startTime === current.startTime,
 }));
 
+vi.mock("../../daemon/gateway-service-probe-hosts.js", () => ({
+  resolveGatewayServiceProbeHosts: (params: unknown) => resolveGatewayServiceProbeHosts(params),
+}));
+
 vi.mock("../../utils.js", async () => {
   const actual = await vi.importActual<typeof import("../../utils.js")>("../../utils.js");
   return {
@@ -77,6 +84,7 @@ export function makeGatewayService(
 ): GatewayService {
   return {
     readRuntime: vi.fn(async () => runtime),
+    readCommand: vi.fn(async () => null),
   } as unknown as GatewayService;
 }
 
@@ -118,6 +126,7 @@ export async function inspectGatewayRestartWithSnapshot(params: {
   return inspectGatewayRestart({
     service,
     port: 18789,
+    probeHosts: ["127.0.0.1"],
     ...(params.expectedVersion === undefined ? {} : { expectedVersion: params.expectedVersion }),
     ...(params.includeUnknownListenersAsStale === undefined
       ? {}
@@ -216,6 +225,8 @@ export function resetRestartHealthMocks() {
   hasActiveStartupMigrationLease.mockReturnValue(false);
   readActiveGatewayLockIdentity.mockReset();
   readActiveGatewayLockIdentity.mockResolvedValue(undefined);
+  resolveGatewayServiceProbeHosts.mockReset();
+  resolveGatewayServiceProbeHosts.mockResolvedValue(["127.0.0.1"]);
 }
 
 export function restoreRestartHealthMocks() {

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -34,6 +34,9 @@ describe("restart health", () => {
 
     expect(snapshot.healthy).toBe(true);
     expect(snapshot.staleGatewayPids).toStrictEqual([]);
+    expect(inspectPortUsage).toHaveBeenCalledWith(18789, {
+      probeHosts: ["127.0.0.1"],
+    });
   });
 
   it("marks non-owned gateway listener pids as stale while runtime is running", async () => {

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -13,6 +13,7 @@ import {
   probeGateway,
   readBestEffortConfig,
   resetRestartHealthMocks,
+  resolveGatewayServiceProbeHosts,
   resolveGatewayProbeAuthSafeWithSecretInputs,
   restoreRestartHealthMocks,
 } from "./restart-health.test-helpers.js";
@@ -36,6 +37,24 @@ describe("restart health", () => {
     expect(snapshot.staleGatewayPids).toStrictEqual([]);
     expect(inspectPortUsage).toHaveBeenCalledWith(18789, {
       probeHosts: ["127.0.0.1"],
+    });
+  });
+
+  it("uses the configured non-loopback host for restart-health port inspection", async () => {
+    resolveGatewayServiceProbeHosts.mockResolvedValue(["192.0.2.40"]);
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 7000, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+    const service = makeGatewayService({ status: "running", pid: 7000 });
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    await waitForGatewayHealthyRestart({ service, port: 18789, attempts: 1 });
+
+    expect(inspectPortUsage).toHaveBeenCalledWith(18789, {
+      probeHosts: ["192.0.2.40"],
     });
   });
 
@@ -296,7 +315,11 @@ describe("restart health", () => {
     });
 
     const { inspectGatewayRestart } = await import("./restart-health.js");
-    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
+    const snapshot = await inspectGatewayRestart({
+      service,
+      port: 18789,
+      probeHosts: ["127.0.0.1"],
+    });
 
     expect(snapshot.healthy).toBe(true);
     expect(probeGateway).not.toHaveBeenCalled();

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -315,13 +315,13 @@ describe("restart health", () => {
     });
 
     const { inspectGatewayRestart } = await import("./restart-health.js");
-    const snapshot = await inspectGatewayRestart({
-      service,
-      port: 18789,
-      probeHosts: ["127.0.0.1"],
-    });
+    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
 
     expect(snapshot.healthy).toBe(true);
     expect(probeGateway).not.toHaveBeenCalled();
+    expect(resolveGatewayServiceProbeHosts).toHaveBeenCalledWith({
+      env: process.env,
+      command: null,
+    });
   });
 });

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -3,7 +3,12 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import type { GatewayService } from "../../daemon/service.js";
 import type { PluginHealthErrorSummary } from "../../gateway/health/types.js";
-import { classifyPortListener, inspectPortUsage, type PortUsage } from "../../infra/ports.js";
+import {
+  classifyPortListener,
+  inspectPortUsage,
+  LOOPBACK_PORT_PROBE_HOSTS,
+  type PortUsage,
+} from "../../infra/ports.js";
 import {
   hasActiveStartupMigrationLease,
   STARTUP_MIGRATION_LEASE_TTL_MS,
@@ -114,7 +119,9 @@ export async function inspectGatewayRestart(params: {
 
   let portUsage: PortUsage;
   try {
-    portUsage = await inspectPortUsage(params.port);
+    portUsage = await inspectPortUsage(params.port, {
+      probeHosts: LOOPBACK_PORT_PROBE_HOSTS,
+    });
   } catch (err) {
     portUsage = {
       port: params.port,

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -87,9 +87,15 @@ export async function inspectGatewayRestart(params: {
   expectedVersion?: string | null;
   includeUnknownListenersAsStale?: boolean;
   probeAuth?: GatewayRestartProbeAuth;
-  probeHosts: readonly string[];
+  probeHosts?: readonly string[];
 }): Promise<GatewayRestartSnapshot> {
   const env = params.env ?? process.env;
+  const probeHosts =
+    params.probeHosts ??
+    (await resolveGatewayServiceProbeHosts({
+      env,
+      command: (await params.service.readCommand?.(env).catch(() => null)) ?? null,
+    }));
   const expectedVersion = normalizeOptionalString(params.expectedVersion);
   let reachability: GatewayReachability | null = null;
   let activatedPluginErrors: PluginHealthErrorSummary[] = [];
@@ -117,7 +123,7 @@ export async function inspectGatewayRestart(params: {
   let portUsage: PortUsage;
   try {
     portUsage = await inspectPortUsage(params.port, {
-      probeHosts: params.probeHosts,
+      probeHosts,
     });
   } catch (err) {
     portUsage = {

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -1,14 +1,10 @@
 // Restart health probes for gateway service restarts and port listener recovery.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveGatewayServiceProbeHosts } from "../../daemon/gateway-service-probe-hosts.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import type { GatewayService } from "../../daemon/service.js";
 import type { PluginHealthErrorSummary } from "../../gateway/health/types.js";
-import {
-  classifyPortListener,
-  inspectPortUsage,
-  LOOPBACK_PORT_PROBE_HOSTS,
-  type PortUsage,
-} from "../../infra/ports.js";
+import { classifyPortListener, inspectPortUsage, type PortUsage } from "../../infra/ports.js";
 import {
   hasActiveStartupMigrationLease,
   STARTUP_MIGRATION_LEASE_TTL_MS,
@@ -91,6 +87,7 @@ export async function inspectGatewayRestart(params: {
   expectedVersion?: string | null;
   includeUnknownListenersAsStale?: boolean;
   probeAuth?: GatewayRestartProbeAuth;
+  probeHosts: readonly string[];
 }): Promise<GatewayRestartSnapshot> {
   const env = params.env ?? process.env;
   const expectedVersion = normalizeOptionalString(params.expectedVersion);
@@ -120,7 +117,7 @@ export async function inspectGatewayRestart(params: {
   let portUsage: PortUsage;
   try {
     portUsage = await inspectPortUsage(params.port, {
-      probeHosts: LOOPBACK_PORT_PROBE_HOSTS,
+      probeHosts: params.probeHosts,
     });
   } catch (err) {
     portUsage = {
@@ -288,6 +285,7 @@ export async function waitForGatewayHealthyRestart(params: {
   requireRunningService?: boolean;
   supervisorKeepsAlive?: boolean;
   isStartupMigrationActive?: typeof hasActiveStartupMigrationLease;
+  probeHosts?: readonly string[];
 }): Promise<GatewayRestartSnapshot> {
   const startedAtMs = performance.now();
   const attempts = params.attempts ?? DEFAULT_RESTART_HEALTH_ATTEMPTS;
@@ -295,6 +293,12 @@ export async function waitForGatewayHealthyRestart(params: {
   const standardDeadlineMs = attempts * delayMs;
 
   const probeAuth = await resolveGatewayRestartProbeAuth(params.env).catch(() => undefined);
+  const probeHosts =
+    params.probeHosts ??
+    (await resolveGatewayServiceProbeHosts({
+      env: params.env,
+      command: await params.service.readCommand(params.env ?? process.env).catch(() => null),
+    }));
   let snapshot = await inspectGatewayRestart({
     service: params.service,
     port: params.port,
@@ -302,6 +306,7 @@ export async function waitForGatewayHealthyRestart(params: {
     expectedVersion: params.expectedVersion,
     includeUnknownListenersAsStale: params.includeUnknownListenersAsStale,
     probeAuth,
+    probeHosts,
   });
 
   let consecutiveStoppedFreeCount = 0;
@@ -389,6 +394,7 @@ export async function waitForGatewayHealthyRestart(params: {
       expectedVersion: params.expectedVersion,
       includeUnknownListenersAsStale: params.includeUnknownListenersAsStale,
       probeAuth,
+      probeHosts,
     });
   }
 }

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -231,6 +231,10 @@ vi.mock("../../daemon/service.js", () => ({
 vi.mock("../../gateway/net.js", () => ({
   resolveGatewayBindHost: (bindMode: string, customBindHost?: string) =>
     resolveGatewayBindHost(bindMode, customBindHost),
+  resolveGatewayRequiredListenHosts: (bindHost: string) =>
+    /^\d+\.\d+\.\d+\.\d+$/.test(bindHost) && bindHost !== "0.0.0.0" && bindHost !== "127.0.0.1"
+      ? [bindHost, "127.0.0.1"]
+      : [bindHost],
 }));
 
 vi.mock("../../gateway/control-ui-links.js", () => ({

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -47,16 +47,21 @@ type PortUsageTestSummary = {
   hints: string[];
 };
 
-const inspectPortUsage = vi.fn<(port: number) => Promise<PortUsageTestSummary>>(
-  async (port: number) => ({
-    port,
-    status: "free",
-    listeners: [],
-    hints: [],
-  }),
-);
+type PortUsageInspectionOptions = { probeHosts?: readonly string[] };
+
+const inspectPortUsage = vi.fn<
+  (port: number, options?: PortUsageInspectionOptions) => Promise<PortUsageTestSummary>
+>(async (port: number) => ({
+  port,
+  status: "free",
+  listeners: [],
+  hints: [],
+}));
 const inspectPortUsages = vi.fn<
-  (ports: readonly number[]) => Promise<Map<number, PortUsageTestSummary>>
+  (
+    ports: readonly number[],
+    options?: { probeHostsByPort?: ReadonlyMap<number, readonly string[]> },
+  ) => Promise<Map<number, PortUsageTestSummary>>
 >(
   async (ports) =>
     new Map(
@@ -247,8 +252,12 @@ vi.mock("../../gateway/probe-auth.js", async (importOriginal) => {
 
 vi.mock("../../infra/ports.js", () => ({
   inspectPortConnections: (port: number) => inspectPortConnections(port),
-  inspectPortUsage: (port: number) => inspectPortUsage(port),
-  inspectPortUsages: (ports: readonly number[]) => inspectPortUsages(ports),
+  inspectPortUsage: (port: number, options?: PortUsageInspectionOptions) =>
+    inspectPortUsage(port, options),
+  inspectPortUsages: (
+    ports: readonly number[],
+    options?: { probeHostsByPort?: ReadonlyMap<number, readonly string[]> },
+  ) => inspectPortUsages(ports, options),
   formatPortDiagnostics: () => [],
 }));
 
@@ -316,6 +325,10 @@ describe("gatherDaemonStatus", () => {
       httpUrl: "https://10.211.55.3:19001/",
       wsUrl: "wss://10.211.55.3:19001",
     });
+    resolveGatewayBindHost.mockClear();
+    resolveGatewayBindHost.mockImplementation(async (bindMode?: string) =>
+      bindMode === "loopback" ? "127.0.0.1" : "0.0.0.0",
+    );
     resolveGatewayProbeAuthSafeWithSecretInputsCalls.mockClear();
     createConfigIOCalls.mockClear();
     findStaleOpenClawUpdateLaunchdJobs.mockReset();
@@ -420,7 +433,12 @@ describe("gatherDaemonStatus", () => {
       deep: false,
     });
 
-    expect(inspectPortUsages).toHaveBeenCalledWith([19001, 18789]);
+    expect(inspectPortUsages).toHaveBeenCalledWith(
+      [19001, 18789],
+      expect.objectContaining({
+        probeHostsByPort: new Map([[19001, ["0.0.0.0"]]]),
+      }),
+    );
     expect(inspectPortUsage).not.toHaveBeenCalled();
   });
 
@@ -535,6 +553,12 @@ describe("gatherDaemonStatus", () => {
 
     expect(resolveGatewayBindHost).toHaveBeenCalledWith("loopback", undefined);
     expect(status.gateway?.bindMode).toBe("loopback");
+    expect(inspectPortUsages).toHaveBeenCalledWith(
+      [19001, 18789],
+      expect.objectContaining({
+        probeHostsByPort: new Map([[19001, ["127.0.0.1"]]]),
+      }),
+    );
   });
 
   it("does not force local TLS fingerprint when probe URL is explicitly overridden", async () => {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -495,17 +495,21 @@ function toPortStatusSummary(
 async function inspectDaemonPortStatuses(params: {
   daemonPort: number;
   cliPort: number;
+  daemonBindHost: string;
 }): Promise<{ portStatus?: PortStatusSummary; portCliStatus?: PortStatusSummary }> {
+  const daemonProbeHosts = [params.daemonBindHost];
   if (params.cliPort === params.daemonPort) {
-    const portDiagnostics = await inspectPortUsage(params.daemonPort).catch(() => null);
+    const portDiagnostics = await inspectPortUsage(params.daemonPort, {
+      probeHosts: daemonProbeHosts,
+    }).catch(() => null);
     return {
       portStatus: toPortStatusSummary(portDiagnostics),
       portCliStatus: undefined,
     };
   }
-  const portDiagnosticsByPort = await inspectPortUsages([params.daemonPort, params.cliPort]).catch(
-    () => new Map(),
-  );
+  const portDiagnosticsByPort = await inspectPortUsages([params.daemonPort, params.cliPort], {
+    probeHostsByPort: new Map([[params.daemonPort, daemonProbeHosts]]),
+  }).catch(() => new Map());
   return {
     portStatus: toPortStatusSummary(portDiagnosticsByPort.get(params.daemonPort) ?? null),
     portCliStatus: toPortStatusSummary(portDiagnosticsByPort.get(params.cliPort) ?? null),
@@ -624,6 +628,7 @@ export async function gatherDaemonStatus(
   const { portStatus, portCliStatus } = await inspectDaemonPortStatuses({
     daemonPort,
     cliPort,
+    daemonBindHost: gateway.bindHost,
   });
   const establishedClients = await inspectEstablishedGatewayClients({
     daemonPort,

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -25,6 +25,7 @@ import { resolveGatewayService } from "../../daemon/service.js";
 import { resolveAdvertisedControlUiLinks } from "../../gateway/control-ui-links.js";
 import { gatewaySecretInputPathCanWin } from "../../gateway/credentials-secret-inputs.js";
 import { trimToUndefined } from "../../gateway/credentials.js";
+import { resolveGatewayRequiredListenHosts } from "../../gateway/net.js";
 import { resolveGatewayProbeCredentialConfig } from "../../gateway/probe-auth.js";
 import {
   ALL_GATEWAY_SECRET_INPUT_PATHS,
@@ -497,7 +498,7 @@ async function inspectDaemonPortStatuses(params: {
   cliPort: number;
   daemonBindHost: string;
 }): Promise<{ portStatus?: PortStatusSummary; portCliStatus?: PortStatusSummary }> {
-  const daemonProbeHosts = [params.daemonBindHost];
+  const daemonProbeHosts = resolveGatewayRequiredListenHosts(params.daemonBindHost);
   if (params.cliPort === params.daemonPort) {
     const portDiagnostics = await inspectPortUsage(params.daemonPort, {
       probeHosts: daemonProbeHosts,
@@ -731,7 +732,7 @@ export async function gatherDaemonStatus(
               service,
               port: daemonPort,
               env: serviceEnv,
-              probeHosts: [gateway.bindHost],
+              probeHosts: resolveGatewayRequiredListenHosts(gateway.bindHost),
             }),
           )
           .catch(() => undefined)

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -731,6 +731,7 @@ export async function gatherDaemonStatus(
               service,
               port: daemonPort,
               env: serviceEnv,
+              probeHosts: [gateway.bindHost],
             }),
           )
           .catch(() => undefined)

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -36,6 +36,7 @@ const findSystemGatewayServices = vi.hoisted(() =>
 const buildGatewayRuntimeHints = vi.hoisted(() => vi.fn((): string[] => []));
 const formatGatewayRuntimeSummary = vi.hoisted(() => vi.fn((): string | null => null));
 const isDefaultInstallIdentity = vi.hoisted(() => vi.fn(() => true));
+const resolveGatewayBindHost = vi.hoisted(() => vi.fn(async () => "127.0.0.1"));
 
 vi.mock("../config/config.js", async () => {
   const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
@@ -95,6 +96,10 @@ vi.mock("../daemon/systemd.js", async () => {
     isSystemdUserServiceAvailable: vi.fn(async () => true),
   };
 });
+
+vi.mock("../gateway/net.js", () => ({
+  resolveGatewayBindHost,
+}));
 
 vi.mock("../infra/ports.js", () => ({
   inspectPortConnections,
@@ -170,6 +175,7 @@ describe("maybeRepairGatewayDaemon", () => {
     isDefaultInstallIdentity.mockReturnValue(true);
     readGatewayRestartHandoffSync.mockReturnValue(null);
     findSystemGatewayServices.mockResolvedValue([]);
+    resolveGatewayBindHost.mockResolvedValue("127.0.0.1");
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "free",
@@ -525,6 +531,10 @@ describe("maybeRepairGatewayDaemon", () => {
 
     await runNonInteractiveRepair();
 
+    expect(resolveGatewayBindHost).toHaveBeenCalledWith("loopback", undefined);
+    expect(inspectPortUsage).toHaveBeenCalledWith(18789, {
+      probeHosts: ["127.0.0.1"],
+    });
     expect(isExpectedGatewayListeners).toHaveBeenCalledWith(listeners, 18789);
     expect(formatPortDiagnostics).not.toHaveBeenCalled();
     expect(note.mock.calls.some(([, label]) => label === "Gateway port")).toBe(false);

--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -99,6 +99,8 @@ vi.mock("../daemon/systemd.js", async () => {
 
 vi.mock("../gateway/net.js", () => ({
   resolveGatewayBindHost,
+  resolveGatewayRequiredListenHosts: (bindHost: string) =>
+    bindHost === "100.64.0.40" ? [bindHost, "127.0.0.1"] : [bindHost],
 }));
 
 vi.mock("../infra/ports.js", () => ({

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -19,6 +19,7 @@ import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
 import { describeGatewayServiceRestart, resolveGatewayService } from "../daemon/service.js";
 import { renderSystemdUnavailableHints } from "../daemon/systemd-hints.js";
 import { isSystemdUserServiceAvailable } from "../daemon/systemd.js";
+import { resolveGatewayBindHost } from "../gateway/net.js";
 import { NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON } from "../infra/gateway-supervision.js";
 import {
   formatPortDiagnostics,
@@ -309,7 +310,11 @@ export async function maybeRepairGatewayDaemon(params: {
 
   if (params.cfg.gateway?.mode !== "remote") {
     const port = resolveGatewayPort(params.cfg, process.env);
-    const diagnostics = await inspectPortUsage(port);
+    const bindHost = await resolveGatewayBindHost(
+      params.cfg.gateway?.bind ?? "loopback",
+      params.cfg.gateway?.customBindHost,
+    );
+    const diagnostics = await inspectPortUsage(port, { probeHosts: [bindHost] });
     await maybeReportEstablishedGatewayClients({
       cfg: params.cfg,
       deep: params.options.deep ?? false,

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -19,7 +19,7 @@ import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
 import { describeGatewayServiceRestart, resolveGatewayService } from "../daemon/service.js";
 import { renderSystemdUnavailableHints } from "../daemon/systemd-hints.js";
 import { isSystemdUserServiceAvailable } from "../daemon/systemd.js";
-import { resolveGatewayBindHost } from "../gateway/net.js";
+import { resolveGatewayBindHost, resolveGatewayRequiredListenHosts } from "../gateway/net.js";
 import { NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON } from "../infra/gateway-supervision.js";
 import {
   formatPortDiagnostics,
@@ -314,7 +314,9 @@ export async function maybeRepairGatewayDaemon(params: {
       params.cfg.gateway?.bind ?? "loopback",
       params.cfg.gateway?.customBindHost,
     );
-    const diagnostics = await inspectPortUsage(port, { probeHosts: [bindHost] });
+    const diagnostics = await inspectPortUsage(port, {
+      probeHosts: resolveGatewayRequiredListenHosts(bindHost),
+    });
     await maybeReportEstablishedGatewayClients({
       cfg: params.cfg,
       deep: params.options.deep ?? false,

--- a/src/commands/status-all/report-data.test.ts
+++ b/src/commands/status-all/report-data.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(async () => ({ path: "/tmp/openclaw.json" })),
+  inspectPortUsage: vi.fn(async () => null),
+  resolveGatewayBindHost: vi.fn(async () => "127.0.0.1"),
 }));
 
 vi.mock("../../agents/exec-defaults.js", () => ({
@@ -15,7 +17,10 @@ vi.mock("../../config/config.js", () => ({
 vi.mock("../../daemon/diagnostics.js", () => ({
   readLastGatewayErrorLine: async () => null,
 }));
-vi.mock("../../infra/ports.js", () => ({ inspectPortUsage: async () => null }));
+vi.mock("../../gateway/net.js", () => ({
+  resolveGatewayBindHost: mocks.resolveGatewayBindHost,
+}));
+vi.mock("../../infra/ports.js", () => ({ inspectPortUsage: mocks.inspectPortUsage }));
 vi.mock("../../infra/restart-sentinel.js", () => ({ readRestartSentinel: async () => null }));
 vi.mock("../../plugins/status.js", () => ({ buildPluginCompatibilityNotices: () => [] }));
 vi.mock("../../skills/discovery/status.js", () => ({ buildWorkspaceSkillStatus: () => null }));
@@ -39,7 +44,7 @@ import { buildStatusAllReportData } from "./report-data.js";
 
 describe("buildStatusAllReportData", () => {
   beforeEach(() => {
-    mocks.readConfigFileSnapshot.mockClear();
+    vi.clearAllMocks();
   });
 
   it("keeps local config diagnosis non-observing", async () => {
@@ -69,5 +74,9 @@ describe("buildStatusAllReportData", () => {
 
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledOnce();
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledWith({ observe: false });
+    expect(mocks.resolveGatewayBindHost).toHaveBeenCalledWith("loopback", undefined);
+    expect(mocks.inspectPortUsage).toHaveBeenCalledWith(18789, {
+      probeHosts: ["127.0.0.1"],
+    });
   });
 });

--- a/src/commands/status-all/report-data.test.ts
+++ b/src/commands/status-all/report-data.test.ts
@@ -19,6 +19,8 @@ vi.mock("../../daemon/diagnostics.js", () => ({
 }));
 vi.mock("../../gateway/net.js", () => ({
   resolveGatewayBindHost: mocks.resolveGatewayBindHost,
+  resolveGatewayRequiredListenHosts: (bindHost: string) =>
+    bindHost === "100.64.0.40" ? [bindHost, "127.0.0.1"] : [bindHost],
 }));
 vi.mock("../../infra/ports.js", () => ({ inspectPortUsage: mocks.inspectPortUsage }));
 vi.mock("../../infra/restart-sentinel.js", () => ({ readRestartSentinel: async () => null }));

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -4,6 +4,7 @@
 import { resolveNodeExecEligibility } from "../../agents/exec-defaults.js";
 import { readConfigFileSnapshot, resolveGatewayPort } from "../../config/config.js";
 import { readLastGatewayErrorLine } from "../../daemon/diagnostics.js";
+import { resolveGatewayBindHost } from "../../gateway/net.js";
 import { inspectPortUsage } from "../../infra/ports.js";
 import { readRestartSentinel } from "../../infra/restart-sentinel.js";
 import { buildPluginCompatibilityNotices } from "../../plugins/status.js";
@@ -106,7 +107,11 @@ async function resolveStatusAllLocalDiagnosis(params: {
   const sentinel = await readRestartSentinel().catch(() => null);
   const lastErr = await readLastGatewayErrorLine(process.env).catch(() => null);
   const port = resolveGatewayPort(overview.cfg);
-  const portUsage = await inspectPortUsage(port).catch(() => null);
+  const bindHost = await resolveGatewayBindHost(
+    overview.cfg.gateway?.bind ?? "loopback",
+    overview.cfg.gateway?.customBindHost,
+  );
+  const portUsage = await inspectPortUsage(port, { probeHosts: [bindHost] }).catch(() => null);
   params.progress.tick();
 
   const defaultWorkspace =

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -4,7 +4,7 @@
 import { resolveNodeExecEligibility } from "../../agents/exec-defaults.js";
 import { readConfigFileSnapshot, resolveGatewayPort } from "../../config/config.js";
 import { readLastGatewayErrorLine } from "../../daemon/diagnostics.js";
-import { resolveGatewayBindHost } from "../../gateway/net.js";
+import { resolveGatewayBindHost, resolveGatewayRequiredListenHosts } from "../../gateway/net.js";
 import { inspectPortUsage } from "../../infra/ports.js";
 import { readRestartSentinel } from "../../infra/restart-sentinel.js";
 import { buildPluginCompatibilityNotices } from "../../plugins/status.js";
@@ -111,7 +111,9 @@ async function resolveStatusAllLocalDiagnosis(params: {
     overview.cfg.gateway?.bind ?? "loopback",
     overview.cfg.gateway?.customBindHost,
   );
-  const portUsage = await inspectPortUsage(port, { probeHosts: [bindHost] }).catch(() => null);
+  const portUsage = await inspectPortUsage(port, {
+    probeHosts: resolveGatewayRequiredListenHosts(bindHost),
+  }).catch(() => null);
   params.progress.tick();
 
   const defaultWorkspace =

--- a/src/daemon/gateway-service-probe-hosts.test.ts
+++ b/src/daemon/gateway-service-probe-hosts.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
     };
   },
   createConfigIO: vi.fn(),
-  defaultGatewayBindMode: vi.fn(() => "loopback" as const),
+  defaultGatewayBindMode: vi.fn<(_tailscaleMode?: string) => "loopback" | "auto">(() => "loopback"),
   isContainerEnvironment: vi.fn(() => false),
   pickPrimaryTailnetIPv4: vi.fn<() => string | undefined>(() => undefined),
 }));

--- a/src/daemon/gateway-service-probe-hosts.test.ts
+++ b/src/daemon/gateway-service-probe-hosts.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cfg: {} as {
+    gateway?: {
+      bind?: "auto" | "custom" | "lan" | "loopback" | "tailnet";
+      customBindHost?: string;
+      tailscale?: { mode?: "off" | "serve" | "funnel" };
+    };
+  },
+  createConfigIO: vi.fn(),
+  defaultGatewayBindMode: vi.fn(() => "loopback" as const),
+  isContainerEnvironment: vi.fn(() => false),
+  pickPrimaryTailnetIPv4: vi.fn<() => string | undefined>(() => undefined),
+}));
+
+vi.mock("../config/io.js", () => ({
+  createConfigIO: (options: unknown) => mocks.createConfigIO(options),
+}));
+
+vi.mock("../gateway/net.js", () => ({
+  defaultGatewayBindMode: (tailscaleMode?: string) => mocks.defaultGatewayBindMode(tailscaleMode),
+}));
+
+vi.mock("../infra/container-environment.js", () => ({
+  isContainerEnvironment: () => mocks.isContainerEnvironment(),
+}));
+
+vi.mock("../infra/tailnet.js", () => ({
+  pickPrimaryTailnetIPv4: () => mocks.pickPrimaryTailnetIPv4(),
+}));
+
+import { resolveGatewayServiceProbeHosts } from "./gateway-service-probe-hosts.js";
+
+describe("resolveGatewayServiceProbeHosts", () => {
+  beforeEach(() => {
+    mocks.cfg = {};
+    mocks.createConfigIO.mockReset();
+    mocks.createConfigIO.mockImplementation(() => ({
+      readBestEffortConfig: async () => mocks.cfg,
+    }));
+    mocks.defaultGatewayBindMode.mockReset();
+    mocks.defaultGatewayBindMode.mockReturnValue("loopback");
+    mocks.isContainerEnvironment.mockReset();
+    mocks.isContainerEnvironment.mockReturnValue(false);
+    mocks.pickPrimaryTailnetIPv4.mockReset();
+    mocks.pickPrimaryTailnetIPv4.mockReturnValue(undefined);
+  });
+
+  it.each([
+    {
+      name: "custom",
+      gateway: { bind: "custom" as const, customBindHost: "192.0.2.40" },
+      tailnetIPv4: undefined,
+      expected: ["192.0.2.40"],
+    },
+    {
+      name: "LAN wildcard",
+      gateway: { bind: "lan" as const },
+      tailnetIPv4: undefined,
+      expected: ["0.0.0.0"],
+    },
+    {
+      name: "tailnet",
+      gateway: { bind: "tailnet" as const },
+      tailnetIPv4: "100.64.0.40",
+      expected: ["100.64.0.40"],
+    },
+  ])(
+    "returns the configured $name endpoint without a bind-availability probe",
+    async (testCase) => {
+      mocks.cfg = { gateway: testCase.gateway };
+      mocks.pickPrimaryTailnetIPv4.mockReturnValue(testCase.tailnetIPv4);
+
+      await expect(
+        resolveGatewayServiceProbeHosts({
+          env: { OPENCLAW_STATE_DIR: "/tmp/cli-state" },
+          command: {
+            programArguments: ["node", "gateway.js"],
+            environment: { OPENCLAW_STATE_DIR: "/tmp/service-state" },
+          },
+        }),
+      ).resolves.toEqual(testCase.expected);
+
+      expect(mocks.createConfigIO).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: expect.objectContaining({ OPENCLAW_STATE_DIR: "/tmp/service-state" }),
+          pluginValidation: "skip",
+          suppressFutureVersionWarning: true,
+        }),
+      );
+    },
+  );
+});

--- a/src/daemon/gateway-service-probe-hosts.test.ts
+++ b/src/daemon/gateway-service-probe-hosts.test.ts
@@ -20,6 +20,8 @@ vi.mock("../config/io.js", () => ({
 
 vi.mock("../gateway/net.js", () => ({
   defaultGatewayBindMode: (tailscaleMode?: string) => mocks.defaultGatewayBindMode(tailscaleMode),
+  resolveGatewayRequiredListenHosts: (bindHost: string) =>
+    bindHost === "192.0.2.40" || bindHost === "100.64.0.40" ? [bindHost, "127.0.0.1"] : [bindHost],
 }));
 
 vi.mock("../infra/container-environment.js", () => ({
@@ -52,7 +54,7 @@ describe("resolveGatewayServiceProbeHosts", () => {
       name: "custom",
       gateway: { bind: "custom" as const, customBindHost: "192.0.2.40" },
       tailnetIPv4: undefined,
-      expected: ["192.0.2.40"],
+      expected: ["192.0.2.40", "127.0.0.1"],
     },
     {
       name: "LAN wildcard",
@@ -64,7 +66,7 @@ describe("resolveGatewayServiceProbeHosts", () => {
       name: "tailnet",
       gateway: { bind: "tailnet" as const },
       tailnetIPv4: "100.64.0.40",
-      expected: ["100.64.0.40"],
+      expected: ["100.64.0.40", "127.0.0.1"],
     },
   ])(
     "returns the configured $name endpoint without a bind-availability probe",

--- a/src/daemon/gateway-service-probe-hosts.ts
+++ b/src/daemon/gateway-service-probe-hosts.ts
@@ -1,0 +1,36 @@
+import { createConfigIO } from "../config/io.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { defaultGatewayBindMode } from "../gateway/net.js";
+import { isContainerEnvironment } from "../infra/container-environment.js";
+import { LOOPBACK_PORT_PROBE_HOSTS } from "../infra/ports-probe.js";
+import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
+import { mergeGatewayServiceEnv } from "./service-env-merge.js";
+import type { GatewayServiceCommandConfig, GatewayServiceEnv } from "./service-types.js";
+
+export async function resolveGatewayServiceProbeHosts(params: {
+  env?: GatewayServiceEnv;
+  command?: GatewayServiceCommandConfig | null;
+}): Promise<readonly string[]> {
+  const baseEnv = params.env ?? process.env;
+  const mergedEnv = mergeGatewayServiceEnv(baseEnv, params.command ?? null);
+  const cfg = await createConfigIO({
+    env: mergedEnv,
+    pluginValidation: "skip",
+    suppressFutureVersionWarning: true,
+  })
+    .readBestEffortConfig()
+    .catch((): OpenClawConfig => ({}));
+  const bindMode =
+    cfg.gateway?.bind ?? defaultGatewayBindMode(cfg.gateway?.tailscale?.mode ?? "off");
+  const bindHost =
+    bindMode === "lan"
+      ? "0.0.0.0"
+      : bindMode === "custom"
+        ? cfg.gateway?.customBindHost?.trim() || "0.0.0.0"
+        : bindMode === "tailnet"
+          ? (pickPrimaryTailnetIPv4() ?? LOOPBACK_PORT_PROBE_HOSTS[0])
+          : bindMode === "auto" && isContainerEnvironment()
+            ? "0.0.0.0"
+            : LOOPBACK_PORT_PROBE_HOSTS[0];
+  return [bindHost];
+}

--- a/src/daemon/gateway-service-probe-hosts.ts
+++ b/src/daemon/gateway-service-probe-hosts.ts
@@ -1,6 +1,6 @@
 import { createConfigIO } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { defaultGatewayBindMode } from "../gateway/net.js";
+import { defaultGatewayBindMode, resolveGatewayRequiredListenHosts } from "../gateway/net.js";
 import { isContainerEnvironment } from "../infra/container-environment.js";
 import { LOOPBACK_PORT_PROBE_HOSTS } from "../infra/ports-probe.js";
 import { pickPrimaryTailnetIPv4 } from "../infra/tailnet.js";
@@ -32,5 +32,5 @@ export async function resolveGatewayServiceProbeHosts(params: {
           : bindMode === "auto" && isContainerEnvironment()
             ? "0.0.0.0"
             : LOOPBACK_PORT_PROBE_HOSTS[0];
-  return [bindHost];
+  return resolveGatewayRequiredListenHosts(bindHost);
 }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -405,6 +405,7 @@ vi.mock("../infra/ports.js", () => ({
 }));
 
 vi.mock("../infra/ports-probe.js", () => ({
+  LOOPBACK_PORT_PROBE_HOSTS: ["127.0.0.1"],
   probePortUsage,
 }));
 
@@ -1921,7 +1922,9 @@ describe("launchd install", () => {
     await stopLaunchAgent({ env, stdout });
 
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19003);
-    expect(inspectPortUsage).toHaveBeenCalledWith(19003);
+    expect(inspectPortUsage).toHaveBeenCalledWith(19003, {
+      probeHosts: ["127.0.0.1"],
+    });
     expect(output).toContain("Stopped LaunchAgent");
   });
 
@@ -1940,7 +1943,7 @@ describe("launchd install", () => {
     await runStopLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() });
 
     expect(inspectPortUsage).toHaveBeenCalledTimes(1);
-    expect(probePortUsage).toHaveBeenCalledWith(19009);
+    expect(probePortUsage).toHaveBeenCalledWith(19009, ["127.0.0.1"]);
   });
 
   it("keeps waiting until a bind probe explicitly confirms port release", async () => {
@@ -1974,7 +1977,9 @@ describe("launchd install", () => {
     await stopLaunchAgent({ env, stdout: new PassThrough() });
 
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19006);
-    expect(inspectPortUsage).toHaveBeenCalledWith(19006);
+    expect(inspectPortUsage).toHaveBeenCalledWith(19006, {
+      probeHosts: ["127.0.0.1"],
+    });
   });
 
   it("fails stop when the verified gateway port remains busy after cleanup", async () => {
@@ -2003,7 +2008,9 @@ describe("launchd install", () => {
 
     expect(onMutation).toHaveBeenCalledWith({ mode: "bootout" });
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19004);
-    expect(inspectPortUsage).toHaveBeenCalledWith(19004);
+    expect(inspectPortUsage).toHaveBeenCalledWith(19004, {
+      probeHosts: ["127.0.0.1"],
+    });
     expect(output).not.toContain("Stopped LaunchAgent");
   });
 
@@ -2041,7 +2048,9 @@ describe("launchd install", () => {
     await stopLaunchAgent({ env, stdout, disable: true });
 
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19005);
-    expect(inspectPortUsage).toHaveBeenCalledWith(19005);
+    expect(inspectPortUsage).toHaveBeenCalledWith(19005, {
+      probeHosts: ["127.0.0.1"],
+    });
     expect(output).toContain("Stopped LaunchAgent");
   });
 
@@ -2605,7 +2614,9 @@ describe("launchd install", () => {
         resolveProtectedPid: expect.any(Function),
       }),
     );
-    expect(inspectPortUsage).toHaveBeenCalledWith(19007);
+    expect(inspectPortUsage).toHaveBeenCalledWith(19007, {
+      probeHosts: ["127.0.0.1"],
+    });
   });
 
   it("uses the final repeated LaunchAgent port flag for restart stale cleanup", async () => {
@@ -2629,7 +2640,9 @@ describe("launchd install", () => {
         resolveProtectedPid: expect.any(Function),
       }),
     );
-    expect(inspectPortUsage).toHaveBeenCalledWith(19008);
+    expect(inspectPortUsage).toHaveBeenCalledWith(19008, {
+      probeHosts: ["127.0.0.1"],
+    });
   });
 
   it("ignores invalid stored LaunchAgent environment ports for stale cleanup", async () => {
@@ -2696,7 +2709,9 @@ describe("launchd install", () => {
         expect.objectContaining({ resolveProtectedPid: expect.any(Function) }),
       );
       expect(state.cleanupProtectedPids).toEqual([managedPidAfterCleanup]);
-      expect(inspectPortUsage).toHaveBeenCalledWith(19002);
+      expect(inspectPortUsage).toHaveBeenCalledWith(19002, {
+        probeHosts: ["127.0.0.1"],
+      });
       expect(state.launchctlCalls).toEqual([
         ["print", serviceId],
         ["print", serviceId],
@@ -2764,7 +2779,9 @@ describe("launchd install", () => {
         expect.objectContaining({ resolveProtectedPid: expect.any(Function) }),
       );
       expect(state.cleanupProtectedPids).toEqual([4242]);
-      expect(inspectPortUsage).toHaveBeenCalledWith(19002);
+      expect(inspectPortUsage).toHaveBeenCalledWith(19002, {
+        probeHosts: ["127.0.0.1"],
+      });
       expect(state.launchctlCalls).toEqual([
         ["print", serviceId],
         ["print", serviceId],

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -103,6 +103,9 @@ const probePortUsage = vi.hoisted(() =>
   vi.fn<typeof import("../infra/ports-probe.js").probePortUsage>(async () => "free"),
 );
 const formatPortDiagnostics = vi.hoisted(() => vi.fn(() => ["Port 18789 is already in use."]));
+const resolveGatewayServiceProbeHosts = vi.hoisted(() =>
+  vi.fn(async () => ["127.0.0.1"] as readonly string[]),
+);
 const defaultProgramArguments = ["node", "-e", "process.exit(0)"];
 
 function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean): number {
@@ -409,6 +412,10 @@ vi.mock("../infra/ports-probe.js", () => ({
   probePortUsage,
 }));
 
+vi.mock("./gateway-service-probe-hosts.js", () => ({
+  resolveGatewayServiceProbeHosts: (params: unknown) => resolveGatewayServiceProbeHosts(params),
+}));
+
 vi.mock("node:fs/promises", async () => {
   const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
   const wrapped = {
@@ -532,6 +539,8 @@ beforeEach(() => {
   probePortUsage.mockResolvedValue("free");
   formatPortDiagnostics.mockReset();
   formatPortDiagnostics.mockReturnValue(["Port 18789 is already in use."]);
+  resolveGatewayServiceProbeHosts.mockReset();
+  resolveGatewayServiceProbeHosts.mockResolvedValue(["127.0.0.1"]);
   launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReset();
   launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff.mockReturnValue({
     ok: true,
@@ -1944,6 +1953,27 @@ describe("launchd install", () => {
 
     expect(inspectPortUsage).toHaveBeenCalledTimes(1);
     expect(probePortUsage).toHaveBeenCalledWith(19009, ["127.0.0.1"]);
+  });
+
+  it("waits on the configured non-loopback host before reporting the port released", async () => {
+    const env = {
+      ...createDefaultLaunchdEnv(),
+      OPENCLAW_GATEWAY_PORT: "19011",
+    };
+    resolveGatewayServiceProbeHosts.mockResolvedValue(["192.0.2.40"]);
+    inspectPortUsage.mockResolvedValueOnce({
+      port: 19011,
+      status: "busy",
+      listeners: [],
+      hints: [],
+    });
+
+    await runStopLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() });
+
+    expect(inspectPortUsage).toHaveBeenCalledWith(19011, {
+      probeHosts: ["192.0.2.40"],
+    });
+    expect(probePortUsage).toHaveBeenCalledWith(19011, ["192.0.2.40"]);
   });
 
   it("keeps waiting until a bind probe explicitly confirms port release", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -104,7 +104,7 @@ const probePortUsage = vi.hoisted(() =>
 );
 const formatPortDiagnostics = vi.hoisted(() => vi.fn(() => ["Port 18789 is already in use."]));
 const resolveGatewayServiceProbeHosts = vi.hoisted(() =>
-  vi.fn(async () => ["127.0.0.1"] as readonly string[]),
+  vi.fn<(_params?: unknown) => Promise<readonly string[]>>(async () => ["127.0.0.1"]),
 );
 const defaultProgramArguments = ["node", "-e", "process.exit(0)"];
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
-import { probePortUsage } from "../infra/ports-probe.js";
+import { LOOPBACK_PORT_PROBE_HOSTS, probePortUsage } from "../infra/ports-probe.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
 import { parseTcpPort, parseTcpPortFromArgs } from "../infra/tcp-port.js";
@@ -1044,7 +1044,7 @@ async function waitForGatewayPortRelease(port: number): Promise<boolean> {
   const deadline = Date.now() + LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS;
   while (Date.now() < deadline) {
     await sleep(Math.min(LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS, deadline - Date.now()));
-    const status = await probePortUsage(port);
+    const status = await probePortUsage(port, LOOPBACK_PORT_PROBE_HOSTS);
     if (status === "free") {
       return true;
     }
@@ -1058,7 +1058,9 @@ async function assertGatewayPortReleasedAfterStop(env: GatewayServiceEnv): Promi
     return;
   }
   cleanStaleGatewayProcessesSync(port);
-  const diagnostics = await inspectPortUsage(port).catch(() => null);
+  const diagnostics = await inspectPortUsage(port, {
+    probeHosts: LOOPBACK_PORT_PROBE_HOSTS,
+  }).catch(() => null);
   if (diagnostics?.status !== "busy") {
     return;
   }
@@ -1475,7 +1477,9 @@ export async function restartLaunchAgent({
       // during enumeration must be protected before candidate filtering/signals.
       resolveProtectedPid: () => readLaunchAgentPidForCleanupSync(serviceTarget),
     });
-    const diagnostics = await inspectPortUsage(cleanupPort).catch(() => null);
+    const diagnostics = await inspectPortUsage(cleanupPort, {
+      probeHosts: LOOPBACK_PORT_PROBE_HOSTS,
+    }).catch(() => null);
     if (diagnostics?.status === "busy") {
       const runtime = await readLaunchAgentRuntime(serviceEnv);
       const managedPid = runtime.pid;

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeEnvVarKey } from "../infra/host-env-security.js";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
-import { LOOPBACK_PORT_PROBE_HOSTS, probePortUsage } from "../infra/ports-probe.js";
+import { probePortUsage } from "../infra/ports-probe.js";
 import { formatPortDiagnostics, inspectPortUsage } from "../infra/ports.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
 import { parseTcpPort, parseTcpPortFromArgs } from "../infra/tcp-port.js";
@@ -19,6 +19,7 @@ import {
   resolveGatewayLaunchAgentLabel,
   resolveLegacyGatewayLaunchAgentLabels,
 } from "./constants.js";
+import { resolveGatewayServiceProbeHosts } from "./gateway-service-probe-hosts.js";
 import { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
 import {
   execLaunchctl,
@@ -558,17 +559,29 @@ export async function disableCurrentOpenClawUpdateLaunchdJob(
   });
 }
 
-async function resolveLaunchAgentGatewayPort(env: GatewayServiceEnv): Promise<number | null> {
+async function resolveLaunchAgentGatewayContext(env: GatewayServiceEnv): Promise<{
+  port: number | null;
+  probeHosts: readonly string[];
+}> {
   const command = await readLaunchAgentProgramArguments(env).catch(() => null);
   const fromArgs = parseTcpPortFromArgs(command?.programArguments);
   if (fromArgs !== null) {
-    return fromArgs;
+    return {
+      port: fromArgs,
+      probeHosts: await resolveGatewayServiceProbeHosts({ env, command }),
+    };
   }
   const fromServiceEnv = parseTcpPort(command?.environment?.OPENCLAW_GATEWAY_PORT ?? "");
   if (fromServiceEnv !== null) {
-    return fromServiceEnv;
+    return {
+      port: fromServiceEnv,
+      probeHosts: await resolveGatewayServiceProbeHosts({ env, command }),
+    };
   }
-  return parseTcpPort(env.OPENCLAW_GATEWAY_PORT ?? "");
+  return {
+    port: parseTcpPort(env.OPENCLAW_GATEWAY_PORT ?? ""),
+    probeHosts: await resolveGatewayServiceProbeHosts({ env, command }),
+  };
 }
 
 function resolveGuiDomain(): string {
@@ -1040,11 +1053,14 @@ async function waitForLaunchAgentStopped(serviceTarget: string): Promise<LaunchA
   return lastUnknown ?? { state: "running" };
 }
 
-async function waitForGatewayPortRelease(port: number): Promise<boolean> {
+async function waitForGatewayPortRelease(
+  port: number,
+  probeHosts: readonly string[],
+): Promise<boolean> {
   const deadline = Date.now() + LAUNCH_AGENT_STOP_PORT_RELEASE_TIMEOUT_MS;
   while (Date.now() < deadline) {
     await sleep(Math.min(LAUNCH_AGENT_STOP_PORT_RELEASE_POLL_MS, deadline - Date.now()));
-    const status = await probePortUsage(port, LOOPBACK_PORT_PROBE_HOSTS);
+    const status = await probePortUsage(port, probeHosts);
     if (status === "free") {
       return true;
     }
@@ -1053,18 +1069,18 @@ async function waitForGatewayPortRelease(port: number): Promise<boolean> {
 }
 
 async function assertGatewayPortReleasedAfterStop(env: GatewayServiceEnv): Promise<void> {
-  const port = await resolveLaunchAgentGatewayPort(env);
+  const { port, probeHosts } = await resolveLaunchAgentGatewayContext(env);
   if (port === null) {
     return;
   }
   cleanStaleGatewayProcessesSync(port);
   const diagnostics = await inspectPortUsage(port, {
-    probeHosts: LOOPBACK_PORT_PROBE_HOSTS,
+    probeHosts,
   }).catch(() => null);
   if (diagnostics?.status !== "busy") {
     return;
   }
-  if (await waitForGatewayPortRelease(port)) {
+  if (await waitForGatewayPortRelease(port, probeHosts)) {
     return;
   }
   throw new Error(
@@ -1470,7 +1486,7 @@ export async function restartLaunchAgent({
     return { outcome: "scheduled" };
   }
 
-  const cleanupPort = await resolveLaunchAgentGatewayPort(serviceEnv);
+  const { port: cleanupPort, probeHosts } = await resolveLaunchAgentGatewayContext(serviceEnv);
   if (cleanupPort !== null) {
     cleanStaleGatewayProcessesSync(cleanupPort, {
       // Resolve after lsof captures its listener snapshot. A KeepAlive respawn
@@ -1478,7 +1494,7 @@ export async function restartLaunchAgent({
       resolveProtectedPid: () => readLaunchAgentPidForCleanupSync(serviceTarget),
     });
     const diagnostics = await inspectPortUsage(cleanupPort, {
-      probeHosts: LOOPBACK_PORT_PROBE_HOSTS,
+      probeHosts,
     }).catch(() => null);
     if (diagnostics?.status === "busy") {
       const runtime = await readLaunchAgentRuntime(serviceEnv);

--- a/src/daemon/schtasks-control.ts
+++ b/src/daemon/schtasks-control.ts
@@ -1,8 +1,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { isGatewayArgv } from "../infra/gateway-process-argv.js";
-import { parseTcpPortFromArgs } from "../infra/tcp-port.js";
 import { sleep } from "../utils.js";
-import { parseCmdScriptCommandLine } from "./cmd-argv.js";
+import { resolveGatewayServiceProbeHosts } from "./gateway-service-probe-hosts.js";
 import { formatLine } from "./output.js";
 import { execSchtasks } from "./schtasks-exec.js";
 import {
@@ -15,10 +14,9 @@ import {
   isNodeHostArgv,
   readWindowsProcessSnapshot,
   resolveScheduledTaskCommandPort,
-  resolveScheduledTaskGatewayListenerPids,
-  resolveScheduledTaskPort,
+  resolveScheduledTaskGatewayContext,
+  resolveScheduledTaskOwnedGatewayPids,
   shouldManageGatewayListenerPort,
-  terminateBusyPortListeners,
   terminateGatewayProcessTree,
   terminateScheduledTaskGatewayListeners,
   terminateScheduledTaskNodeHost,
@@ -87,8 +85,13 @@ async function shouldFallbackScheduledTaskLaunch(params: {
     const taskPort = resolveScheduledTaskCommandPort(params.env, command);
     const manageGatewayPort = shouldManageGatewayListenerPort(params.env);
     if (manageGatewayPort && taskPort) {
-      const listenerPids = await resolveScheduledTaskGatewayListenerPids(taskPort);
-      if (listenerPids.length > 0) {
+      const probeHosts = await resolveGatewayServiceProbeHosts({ env: params.env, command });
+      const ownedPids = await resolveScheduledTaskOwnedGatewayPids(
+        params.env,
+        { port: taskPort, probeHosts },
+        command,
+      );
+      if (ownedPids.length > 0) {
         return true;
       }
     }
@@ -115,21 +118,19 @@ async function shouldFallbackScheduledTaskLaunch(params: {
     if (!taskPort) {
       return false;
     }
-    if (!manageGatewayPort) {
-      return installedArguments?.length
-        ? findInstalledProcessPid(entries, taskPort, installedArguments, isNodeHostArgv) != null
-        : false;
+    if (!installedArguments?.length) {
+      return false;
     }
-    return entries.some((entry) => {
-      const commandLine = normalizeLowercaseStringOrEmpty(entry.CommandLine ?? "");
-      if (!commandLine) {
-        return false;
-      }
-      const argv = parseCmdScriptCommandLine(entry.CommandLine ?? "");
-      return (
-        isGatewayArgv(argv, { allowGatewayBinary: true }) && parseTcpPortFromArgs(argv) === taskPort
-      );
-    });
+    return (
+      findInstalledProcessPid(
+        entries,
+        taskPort,
+        installedArguments,
+        manageGatewayPort
+          ? (argv) => isGatewayArgv(argv, { allowGatewayBinary: true })
+          : isNodeHostArgv,
+      ) != null
+    );
   };
 
   let previous = await readLaunchObservation();
@@ -282,21 +283,23 @@ export async function stopScheduledTask({
   }
   reportMutation("schtasks-stop");
   const manageGatewayPort = shouldManageGatewayListenerPort(effectiveEnv);
-  const stopPort = manageGatewayPort ? await resolveScheduledTaskPort(effectiveEnv) : null;
+  const stopContext = manageGatewayPort
+    ? await resolveScheduledTaskGatewayContext(effectiveEnv)
+    : null;
+  const stopPort = stopContext?.port ?? null;
   if (manageGatewayPort) {
-    await terminateScheduledTaskGatewayListeners(effectiveEnv);
+    await terminateScheduledTaskGatewayListeners(effectiveEnv, stopContext ?? undefined);
   } else {
     await terminateScheduledTaskNodeHost(effectiveEnv);
   }
   await terminateInstalledStartupRuntime(effectiveEnv);
   if (stopPort) {
-    const released = await waitForGatewayPortRelease(stopPort);
+    const probeHosts = stopContext?.probeHosts ?? [];
+    const released = await waitForGatewayPortRelease(stopPort, 5_000, { probeHosts });
     if (!released) {
-      await terminateBusyPortListeners(stopPort);
-      const releasedAfterForce = await waitForGatewayPortRelease(stopPort, 2_000);
-      if (!releasedAfterForce) {
-        throw new Error(`gateway port ${stopPort} is still busy after stop`);
-      }
+      throw new Error(
+        `gateway port ${stopPort} is still busy after stop; remaining listener ownership could not be verified`,
+      );
     }
   }
   stdout.write(`${formatLine("Stopped Scheduled Task", taskName)}\n`);
@@ -336,10 +339,13 @@ export async function restartRegisteredScheduledTask(params: {
     params.onEndMutation?.();
   }
   const manageGatewayPort = shouldManageGatewayListenerPort(params.env);
-  const restartPort = manageGatewayPort ? await resolveScheduledTaskPort(params.env) : null;
+  const restartContext = manageGatewayPort
+    ? await resolveScheduledTaskGatewayContext(params.env)
+    : null;
+  const restartPort = restartContext?.port ?? null;
   if (params.mode.kind === "standard") {
     if (manageGatewayPort) {
-      await terminateScheduledTaskGatewayListeners(params.env);
+      await terminateScheduledTaskGatewayListeners(params.env, restartContext ?? undefined);
     } else {
       await terminateScheduledTaskNodeHost(params.env);
     }
@@ -357,18 +363,17 @@ export async function restartRegisteredScheduledTask(params: {
     }
   }
   if (restartPort) {
-    const released = await waitForGatewayPortRelease(restartPort);
+    const probeHosts = restartContext?.probeHosts ?? [];
+    const released = await waitForGatewayPortRelease(restartPort, 5_000, { probeHosts });
     if (!released) {
       if (params.mode.kind === "fallback-takeover") {
         throw new Error(
           `replacement gateway port ${restartPort} is occupied by an unverified process`,
         );
       }
-      await terminateBusyPortListeners(restartPort);
-      const releasedAfterForce = await waitForGatewayPortRelease(restartPort, 2_000);
-      if (!releasedAfterForce) {
-        throw new Error(`gateway port ${restartPort} is still busy before restart`);
-      }
+      throw new Error(
+        `gateway port ${restartPort} is still busy before restart; remaining listener ownership could not be verified`,
+      );
     }
   }
   const activation = await runScheduledTaskOrThrow({

--- a/src/daemon/schtasks-process.ts
+++ b/src/daemon/schtasks-process.ts
@@ -1,7 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { isGatewayArgv } from "../infra/gateway-process-argv.js";
-import { findVerifiedGatewayListenerPidsOnPortSync } from "../infra/gateway-processes.js";
 import { inspectPortUsage, type PortListener } from "../infra/ports.js";
 import { parseTcpPort, parseTcpPortFromArgs } from "../infra/tcp-port.js";
 import {
@@ -12,9 +11,10 @@ import { killProcessTree } from "../process/kill-tree.js";
 import { sleep } from "../utils.js";
 import { parseCmdScriptCommandLine } from "./cmd-argv.js";
 import { NODE_SERVICE_KIND } from "./constants.js";
+import { resolveGatewayServiceProbeHosts } from "./gateway-service-probe-hosts.js";
 import { readScheduledTaskCommand } from "./schtasks-layout.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
-import type { GatewayServiceEnv } from "./service-types.js";
+import type { GatewayServiceCommandConfig, GatewayServiceEnv } from "./service-types.js";
 
 type WindowsProcessSnapshotEntry = {
   ProcessId?: number;
@@ -117,45 +117,19 @@ async function resolveScheduledTaskNodeHostProcess(
   return resolveScheduledTaskProcess(env, isNodeHostArgv);
 }
 
-async function resolveScheduledTaskGatewayProcess(
-  env: GatewayServiceEnv,
-): Promise<{ pid: number; port: number } | null> {
-  return resolveScheduledTaskProcess(env, (argv) =>
-    isGatewayArgv(argv, { allowGatewayBinary: true }),
-  );
-}
-
 export function shouldManageGatewayListenerPort(env: GatewayServiceEnv): boolean {
   return normalizeLowercaseStringOrEmpty(env.OPENCLAW_SERVICE_KIND) !== NODE_SERVICE_KIND;
 }
 
-export async function resolveScheduledTaskPort(env: GatewayServiceEnv): Promise<number | null> {
-  return resolveScheduledTaskCommandPort(
-    env,
-    await readScheduledTaskCommand(env).catch(() => null),
-  );
-}
-
-export async function resolveScheduledTaskGatewayListenerPids(port: number): Promise<number[]> {
-  const verified = findVerifiedGatewayListenerPidsOnPortSync(port);
-  if (verified.length > 0) {
-    return verified;
-  }
-  const diagnostics = await inspectPortUsage(port).catch(() => null);
-  if (diagnostics?.status !== "busy") {
-    return [];
-  }
-  const matchedGatewayPids = resolveGatewayListenerPids(diagnostics.listeners);
-  if (matchedGatewayPids.length > 0) {
-    return matchedGatewayPids;
-  }
-  return Array.from(
-    new Set(
-      diagnostics.listeners
-        .map((listener) => listener.pid)
-        .filter((pid): pid is number => typeof pid === "number" && Number.isFinite(pid) && pid > 0),
-    ),
-  );
+export async function resolveScheduledTaskGatewayContext(env: GatewayServiceEnv): Promise<{
+  port: number | null;
+  probeHosts: readonly string[];
+}> {
+  const command = await readScheduledTaskCommand(env).catch(() => null);
+  return {
+    port: resolveScheduledTaskCommandPort(env, command),
+    probeHosts: await resolveGatewayServiceProbeHosts({ env, command }),
+  };
 }
 
 export function resolveGatewayListenerPids(listeners: PortListener[]): number[] {
@@ -175,6 +149,63 @@ export function resolveGatewayListenerPids(listeners: PortListener[]): number[] 
   );
 }
 
+export async function resolveScheduledTaskOwnedGatewayPids(
+  env: GatewayServiceEnv,
+  context?: { port: number | null; probeHosts: readonly string[] },
+  installedCommand?: GatewayServiceCommandConfig | null,
+): Promise<number[]> {
+  const command =
+    installedCommand === undefined
+      ? await readScheduledTaskCommand(env).catch(() => null)
+      : installedCommand;
+  const installedArguments = command?.programArguments;
+  if (!installedArguments?.length) {
+    return [];
+  }
+  const resolvedContext = context ?? {
+    port: resolveScheduledTaskCommandPort(env, command),
+    probeHosts: await resolveGatewayServiceProbeHosts({ env, command }),
+  };
+  const port = resolvedContext.port;
+  if (!port) {
+    return [];
+  }
+
+  const ownedPids = new Set<number>();
+  const snapshot = readWindowsProcessSnapshot();
+  if (process.platform === "win32") {
+    if (!snapshot) {
+      return [];
+    }
+    const pid = findInstalledProcessPid(snapshot, port, installedArguments, () => true);
+    if (pid) {
+      // The task is single-instance; persisted argv identifies its process before it starts listening.
+      return [pid];
+    }
+    // A listener can be dual-stack or belong to another task; Windows control requires CIM argv proof.
+    return [];
+  }
+  // Portable tests use listener command lines because CIM process snapshots exist only on Windows.
+  const diagnostics = await inspectPortUsage(port, {
+    probeHosts: resolvedContext.probeHosts,
+  }).catch(() => null);
+  if (diagnostics?.status === "busy") {
+    for (const listener of diagnostics.listeners) {
+      if (typeof listener.pid !== "number" || !listener.commandLine) {
+        continue;
+      }
+      const argv = parseCmdScriptCommandLine(listener.commandLine);
+      if (
+        parseTcpPortFromArgs(argv) === port &&
+        matchesInstalledProgramArguments(argv, installedArguments)
+      ) {
+        ownedPids.add(listener.pid);
+      }
+    }
+  }
+  return Array.from(ownedPids);
+}
+
 export async function resolveListenerBackedScheduledTaskRuntime(
   env: GatewayServiceEnv,
 ): Promise<Pick<GatewayServiceRuntime, "status" | "pid" | "detail"> | null> {
@@ -188,24 +219,17 @@ export async function resolveListenerBackedScheduledTaskRuntime(
         }
       : null;
   }
-  const matched = await resolveScheduledTaskGatewayProcess(env);
-  if (matched) {
-    return {
-      status: "running",
-      pid: matched.pid,
-      detail: `Gateway process detected for gateway port ${matched.port}.`,
-    };
-  }
-  const port = await resolveScheduledTaskPort(env);
-  if (!port) {
-    return null;
-  }
-  const pids = findVerifiedGatewayListenerPidsOnPortSync(port);
+  const command = await readScheduledTaskCommand(env).catch(() => null);
+  const context = {
+    port: resolveScheduledTaskCommandPort(env, command),
+    probeHosts: await resolveGatewayServiceProbeHosts({ env, command }),
+  };
+  const pids = await resolveScheduledTaskOwnedGatewayPids(env, context, command);
   return pids.length > 0
     ? {
         status: "running",
         pid: pids[0],
-        detail: `Verified gateway listener detected on port ${port} even though schtasks did not report a running task.`,
+        detail: `Gateway process detected for gateway port ${context.port}.`,
       }
     : null;
 }
@@ -221,15 +245,17 @@ export async function terminateScheduledTaskNodeHost(env: GatewayServiceEnv): Pr
 
 export async function terminateScheduledTaskGatewayListeners(
   env: GatewayServiceEnv,
+  context?: { port: number | null; probeHosts: readonly string[] },
 ): Promise<number[]> {
   if (!shouldManageGatewayListenerPort(env)) {
     return [];
   }
-  const port = await resolveScheduledTaskPort(env);
+  const resolvedContext = context ?? (await resolveScheduledTaskGatewayContext(env));
+  const port = resolvedContext.port;
   if (!port) {
     return [];
   }
-  const pids = await resolveScheduledTaskGatewayListenerPids(port);
+  const pids = await resolveScheduledTaskOwnedGatewayPids(env, resolvedContext);
   for (const pid of pids) {
     await terminateGatewayProcessTree(pid, 300);
   }
@@ -305,34 +331,23 @@ export async function terminateGatewayProcessTree(pid: number, graceMs: number):
   }
 }
 
-export async function waitForGatewayPortRelease(port: number, timeoutMs = 5_000): Promise<boolean> {
+export async function waitForGatewayPortRelease(
+  port: number,
+  timeoutMs = 5_000,
+  options?: { probeHosts?: readonly string[] },
+): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const diagnostics = await inspectPortUsage(port).catch(() => null);
+    const diagnostics = await inspectPortUsage(
+      port,
+      options?.probeHosts ? { probeHosts: options.probeHosts } : undefined,
+    ).catch(() => null);
     if (diagnostics?.status === "free") {
       return true;
     }
     await sleep(250);
   }
   return false;
-}
-
-export async function terminateBusyPortListeners(port: number): Promise<number[]> {
-  const diagnostics = await inspectPortUsage(port).catch(() => null);
-  if (diagnostics?.status !== "busy") {
-    return [];
-  }
-  const pids = Array.from(
-    new Set(
-      diagnostics.listeners
-        .map((listener) => listener.pid)
-        .filter((pid): pid is number => typeof pid === "number" && Number.isFinite(pid) && pid > 0),
-    ),
-  );
-  for (const pid of pids) {
-    await terminateGatewayProcessTree(pid, 300);
-  }
-  return pids;
 }
 
 export function readWindowsProcessSnapshot(): WindowsProcessSnapshotEntry[] | null {
@@ -380,7 +395,22 @@ export async function assertReplacementPortAvailableForTakeover(params: {
   if (!port) {
     throw new Error("Could not verify the replacement Windows Scheduled Task port.");
   }
-  const diagnostics = await inspectPortUsage(port).catch(() => null);
+  const probeHosts = await resolveGatewayServiceProbeHosts({
+    env: params.env,
+    command: {
+      programArguments: params.programArguments,
+      ...(params.environment
+        ? {
+            environment: Object.fromEntries(
+              Object.entries(params.environment).filter(
+                (entry): entry is [string, string] => typeof entry[1] === "string",
+              ),
+            ),
+          }
+        : {}),
+    },
+  });
+  const diagnostics = await inspectPortUsage(port, { probeHosts }).catch(() => null);
   if (!diagnostics) {
     throw new Error(`Could not inspect replacement gateway port ${port}.`);
   }

--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -9,6 +9,7 @@ import {
   getWindowsPowerShellExePath,
 } from "../infra/windows-install-roots.js";
 import { sleep } from "../utils.js";
+import { resolveGatewayServiceProbeHosts } from "./gateway-service-probe-hosts.js";
 import { formatLine } from "./output.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import { execSchtasks } from "./schtasks-exec.js";
@@ -270,17 +271,9 @@ export async function resolveFallbackRuntime(
         detail: `Startup-folder login item installed; could not verify the installed process for gateway port ${port}.`,
       };
     }
-  } else {
-    const verifiedPids = findVerifiedGatewayListenerPidsOnPortSync(port);
-    if (verifiedPids.length > 0) {
-      return {
-        status: "running",
-        pid: verifiedPids[0],
-        detail: `Startup-folder login item installed; verified gateway listener detected on port ${port}.`,
-      };
-    }
   }
-  const diagnostics = await inspectPortUsage(port).catch(() => null);
+  const probeHosts = await resolveGatewayServiceProbeHosts({ env, command });
+  const diagnostics = await inspectPortUsage(port, { probeHosts }).catch(() => null);
   if (!diagnostics) {
     return {
       status: "unknown",
@@ -299,7 +292,12 @@ export async function resolveFallbackRuntime(
     };
   }
   const matchedGatewayPids = resolveGatewayListenerPids(diagnostics.listeners);
-  if (matchedGatewayPids.length > 0) {
+  const scopedListenerPids = new Set(diagnostics.listeners.map((listener) => listener.pid));
+  const verifiedGatewayPids = findVerifiedGatewayListenerPidsOnPortSync(port).filter((pid) =>
+    scopedListenerPids.has(pid),
+  );
+  const ownedGatewayPids = matchedGatewayPids.length > 0 ? matchedGatewayPids : verifiedGatewayPids;
+  if (ownedGatewayPids.length > 0) {
     return requireCommandOwnership
       ? {
           status: "unknown",
@@ -307,7 +305,7 @@ export async function resolveFallbackRuntime(
         }
       : {
           status: "running",
-          pid: matchedGatewayPids[0],
+          pid: ownedGatewayPids[0],
           detail: `Startup-folder login item installed; verified gateway listener detected on port ${port}.`,
         };
   }

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -27,6 +27,7 @@ import {
   inspectPortUsage,
   killProcessTree,
   resetSchtasksBaseMocks,
+  schtasksCalls,
   schtasksResponses,
   withWindowsEnv,
   writeGatewayScript,
@@ -755,10 +756,18 @@ describe("Windows startup fallback", () => {
       const startupEntryPath = await writeStartupFallbackEntry(env);
       await writeGatewayScript(env);
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      let portInspections = 0;
       inspectPortUsage.mockImplementation(async (port) => {
         schtasksResponses.length = 0;
         schtasksResponses.push({ code: 1, stdout: "", stderr: "restart denied" });
-        return { port, status: "free", listeners: [], hints: [] };
+        return portInspections++ === 0
+          ? {
+              port,
+              status: "busy",
+              listeners: [{ pid: 4242, command: "node.exe" }],
+              hints: [],
+            }
+          : { port, status: "free", listeners: [], hints: [] };
       });
       addStartupFallbackMissingResponses([
         { code: 0, stdout: "", stderr: "" },
@@ -810,7 +819,9 @@ describe("Windows startup fallback", () => {
 
       await installGatewayScheduledTask(env, new PassThrough(), "19433");
 
-      expect(inspectPortUsage).toHaveBeenCalledWith(18789);
+      expect(inspectPortUsage).toHaveBeenCalledWith(18789, {
+        probeHosts: ["127.0.0.1"],
+      });
       expectGatewayTermination(4242);
       await expect(fs.access(startupEntryPath)).rejects.toThrow();
     });
@@ -1260,6 +1271,23 @@ describe("Windows startup fallback", () => {
       const startupEntryPath = await writeStartupFallbackEntry(hiddenEnv);
       await writeGatewayScript(hiddenEnv);
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      inspectPortUsage.mockImplementation(async () =>
+        schtasksCalls.some((call) => call[0] === "/Run")
+          ? {
+              port: 18789,
+              status: "busy",
+              listeners: [
+                {
+                  pid: 4242,
+                  command: "node.exe",
+                  commandLine:
+                    '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\steipete\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js" gateway --port 18789',
+                },
+              ],
+              hints: [],
+            }
+          : { port: 18789, status: "free", listeners: [], hints: [] },
+      );
       addSuccessfulScheduledTaskRestartResponses(
         [cleanExitTaskQueryOutput()],
         cleanExitTaskQueryOutput(),
@@ -1408,7 +1436,24 @@ describe("Windows startup fallback", () => {
   it("does not fall back when a listener appears after the clean task exit", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       fastForwardTaskStartWait();
-      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValueOnce([]).mockReturnValue([4242]);
+      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      let portInspections = 0;
+      inspectPortUsage.mockImplementation(async (port) =>
+        portInspections++ === 0
+          ? { port, status: "free", listeners: [], hints: [] }
+          : {
+              port,
+              status: "busy",
+              listeners: [
+                {
+                  pid: 4242,
+                  command: "node.exe",
+                  commandLine: "node gateway.js --port 18789",
+                },
+              ],
+              hints: [],
+            },
+      );
       addAcceptedRunCleanExitResponses();
 
       await installGatewayScheduledTask(env);
@@ -1544,18 +1589,47 @@ describe("Windows startup fallback", () => {
     });
   });
 
-  it("reports a fallback-launched gateway as running even when schtasks still says not-yet-run", async () => {
+  it("does not attribute another gateway listener to the registered task", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       await writeGatewayScript(env);
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
+      inspectPortUsage.mockResolvedValue({
+        port: 18789,
+        status: "busy",
+        listeners: [
+          {
+            pid: 4242,
+            command: "node.exe",
+            commandLine:
+              '"C:\\Program Files\\nodejs\\node.exe" "C:\\other\\dist\\index.js" gateway --port 18789',
+          },
+        ],
+        hints: [],
+      });
+      spawnSync.mockImplementation((command, args) =>
+        command === getWindowsPowerShellExePath() &&
+        Array.isArray(args) &&
+        args.includes(NODE_PROCESS_QUERY)
+          ? makeSpawnSyncResult({
+              stdout: JSON.stringify([
+                {
+                  ProcessId: 4242,
+                  CommandLine:
+                    '"C:\\Program Files\\nodejs\\node.exe" "C:\\other\\dist\\index.js" gateway --port 18789',
+                },
+              ]),
+            })
+          : makeSpawnSyncResult(),
+      );
       schtasksResponses.push(
         { code: 0, stdout: "", stderr: "" },
         { code: 0, stdout: notYetRunTaskQueryOutput(), stderr: "" },
       );
 
       const runtime = await readScheduledTaskRuntime(env);
-      expect(runtime.status).toBe("running");
-      expect(runtime.pid).toBe(4242);
+      expect(runtime.status).toBe("stopped");
+      expect(runtime.pid).toBeUndefined();
       expect(runtime.state).toBe("Ready");
       expect(runtime.lastRunResult).toBe("267011");
     });

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -60,6 +60,8 @@ const {
 } = await import("./schtasks.js");
 const GATEWAY_PORT = 18789;
 const SUCCESS_RESPONSE = { code: 0, stdout: "", stderr: "" } as const;
+const INSTALLED_GATEWAY_COMMAND_LINE =
+  '"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\steipete\\AppData\\Roaming\\npm\\node_modules\\openclaw\\dist\\index.js" gateway --port 18789';
 
 function pushSuccessfulSchtasksResponses(count: number) {
   for (let i = 0; i < count; i += 1) {
@@ -90,6 +92,7 @@ function busyPortUsage(
       {
         pid,
         command: options.command ?? "node.exe",
+        address: `127.0.0.1:${GATEWAY_PORT}`,
         ...(options.commandLine ? { commandLine: options.commandLine } : {}),
       },
     ],
@@ -441,20 +444,23 @@ describe("Scheduled Task stop/restart cleanup", () => {
     },
   );
 
-  it("kills lingering verified gateway listeners after schtasks stop", async () => {
+  it("kills the lingering gateway process owned by the persisted task command", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
       const onMutation = vi.fn();
       pushSuccessfulSchtasksResponses(3);
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
       inspectPortUsage
-        .mockResolvedValueOnce(busyPortUsage(4242))
+        .mockResolvedValueOnce(busyPortUsage(4242, { commandLine: INSTALLED_GATEWAY_COMMAND_LINE }))
         .mockResolvedValueOnce(freePortUsage());
 
       await stopScheduledTask({ env, stdout, onMutation });
 
-      expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(GATEWAY_PORT);
+      expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
       expectGatewayTermination(4242);
       expect(inspectPortUsage).toHaveBeenCalledTimes(2);
+      expect(inspectPortUsage).toHaveBeenCalledWith(GATEWAY_PORT, {
+        probeHosts: ["127.0.0.1"],
+      });
       expect(onMutation).toHaveBeenCalledWith({ mode: "schtasks-stop" });
     });
   });
@@ -508,27 +514,27 @@ describe("Scheduled Task stop/restart cleanup", () => {
     });
   });
 
-  it("force-kills remaining busy port listeners when the first stop pass does not free the port", async () => {
+  it("does not kill an unrelated listener when the owned process leaves another required host busy", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
       pushSuccessfulSchtasksResponses(3);
-      findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4242]);
-      inspectPortUsage.mockResolvedValueOnce(busyPortUsage(4242));
-      for (let i = 0; i < 19; i += 1) {
-        inspectPortUsage.mockResolvedValueOnce(busyPortUsage(4242));
+      inspectPortUsage.mockResolvedValueOnce(
+        busyPortUsage(4242, { commandLine: INSTALLED_GATEWAY_COMMAND_LINE }),
+      );
+      for (let i = 0; i < 20; i += 1) {
+        inspectPortUsage.mockResolvedValueOnce(busyPortUsage(5252));
       }
-      inspectPortUsage
-        .mockResolvedValueOnce(busyPortUsage(5252))
-        .mockResolvedValueOnce(freePortUsage());
 
-      await stopScheduledTask({ env, stdout });
+      await expect(stopScheduledTask({ env, stdout })).rejects.toThrow(
+        "remaining listener ownership could not be verified",
+      );
 
       if (process.platform !== "win32") {
-        expect(killProcessTree).toHaveBeenNthCalledWith(1, 4242, { graceMs: 300 });
-        expect(killProcessTree).toHaveBeenNthCalledWith(2, 5252, { graceMs: 300 });
+        expect(killProcessTree).toHaveBeenCalledOnce();
+        expect(killProcessTree).toHaveBeenCalledWith(4242, { graceMs: 300 });
       } else {
         expect(killProcessTree).not.toHaveBeenCalled();
       }
-      expect(inspectPortUsage.mock.calls.length).toBeGreaterThanOrEqual(22);
+      expect(killProcessTree).not.toHaveBeenCalledWith(5252, { graceMs: 300 });
     });
   });
 
@@ -573,22 +579,25 @@ describe("Scheduled Task stop/restart cleanup", () => {
     });
   });
 
-  it("kills lingering verified gateway listeners and waits for port release before restart", async () => {
+  it("kills the owned gateway process and waits for port release before restart", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
       const onMutation = vi.fn();
       pushSuccessfulSchtasksResponses(4);
       findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([5151]);
       inspectPortUsage
-        .mockResolvedValueOnce(busyPortUsage(5151))
+        .mockResolvedValueOnce(busyPortUsage(5151, { commandLine: INSTALLED_GATEWAY_COMMAND_LINE }))
         .mockResolvedValueOnce(freePortUsage());
 
       await expect(restartScheduledTask({ env, stdout, onMutation })).resolves.toEqual({
         outcome: "completed",
       });
 
-      expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(GATEWAY_PORT);
+      expect(findVerifiedGatewayListenerPidsOnPortSync).not.toHaveBeenCalled();
       expectGatewayTermination(5151);
-      expect(inspectPortUsage).toHaveBeenCalledTimes(2);
+      expect(inspectPortUsage.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(inspectPortUsage).toHaveBeenCalledWith(GATEWAY_PORT, {
+        probeHosts: ["127.0.0.1"],
+      });
       expect(onMutation).toHaveBeenCalledWith({ mode: "schtasks-restart" });
       expect(schtasksCalls).toEqual([
         ["/Query"],

--- a/src/daemon/test-helpers/schtasks-base-mocks.ts
+++ b/src/daemon/test-helpers/schtasks-base-mocks.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 import {
   inspectPortUsage,
   killProcessTree,
+  resolveGatewayServiceProbeHosts,
   schtasksCalls,
   schtasksResponses,
 } from "./schtasks-fixtures.js";
@@ -16,7 +17,12 @@ vi.mock("../schtasks-exec.js", () => ({
 }));
 
 vi.mock("../../infra/ports.js", () => ({
-  inspectPortUsage: (port: number) => inspectPortUsage(port),
+  inspectPortUsage: (port: number, options?: { probeHosts?: readonly string[] }) =>
+    inspectPortUsage(port, options),
+}));
+
+vi.mock("../gateway-service-probe-hosts.js", () => ({
+  resolveGatewayServiceProbeHosts: () => resolveGatewayServiceProbeHosts(),
 }));
 
 vi.mock("../../process/kill-tree.js", () => ({

--- a/src/daemon/test-helpers/schtasks-fixtures.ts
+++ b/src/daemon/test-helpers/schtasks-fixtures.ts
@@ -11,7 +11,10 @@ import { resolveTaskScriptPath } from "../schtasks.js";
 export const schtasksResponses: Array<{ code: number; stdout: string; stderr: string }> = [];
 export const schtasksCalls: string[][] = [];
 
-export const inspectPortUsage: MockFn<(port: number) => Promise<PortUsage>> = vi.fn();
+export const inspectPortUsage: MockFn<
+  (port: number, options?: { probeHosts?: readonly string[] }) => Promise<PortUsage>
+> = vi.fn();
+export const resolveGatewayServiceProbeHosts: MockFn<() => Promise<readonly string[]>> = vi.fn();
 export const killProcessTree: MockFn<typeof killProcessTreeImpl> = vi.fn();
 
 /** Runs a test with Windows-like daemon environment paths and cleans the temp dir. */
@@ -37,6 +40,8 @@ export function resetSchtasksBaseMocks() {
   schtasksResponses.length = 0;
   schtasksCalls.length = 0;
   inspectPortUsage.mockReset();
+  resolveGatewayServiceProbeHosts.mockReset();
+  resolveGatewayServiceProbeHosts.mockResolvedValue(["127.0.0.1"]);
   killProcessTree.mockReset();
 }
 

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -20,6 +20,7 @@ import {
   resolveClientIp,
   resolveGatewayBindHost,
   resolveGatewayListenHosts,
+  resolveGatewayRequiredListenHosts,
   resolveHostName,
 } from "./net.js";
 
@@ -416,6 +417,17 @@ describe("resolveGatewayListenHosts", () => {
     const hosts = await resolveGatewayListenHosts("127.0.0.1", { canBindToHost });
     expect(hosts).toEqual(["127.0.0.1", "::1"]);
     expect(canBindToHost).toHaveBeenCalledWith("::1");
+  });
+});
+
+describe("resolveGatewayRequiredListenHosts", () => {
+  it.each([
+    ["127.0.0.1", ["127.0.0.1"]],
+    ["0.0.0.0", ["0.0.0.0"]],
+    ["::1", ["::1"]],
+    ["100.64.0.1", ["100.64.0.1", "127.0.0.1"]],
+  ])("returns required startup hosts for %s", (host, expected) => {
+    expect(resolveGatewayRequiredListenHosts(host)).toEqual(expected);
   });
 });
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -369,14 +369,9 @@ export async function resolveGatewayListenHosts(
   bindHost: string,
   opts?: { canBindToHost?: (host: string) => Promise<boolean> },
 ): Promise<string[]> {
+  const requiredHosts = resolveGatewayRequiredListenHosts(bindHost);
   if (bindHost !== "127.0.0.1") {
-    if (!isValidIPv4(bindHost) || bindHost === "0.0.0.0") {
-      return [bindHost];
-    }
-    // Same-host clients use the canonical loopback URL even when external access is
-    // pinned to one interface. Startup requires both listeners so a foreign loopback
-    // process cannot receive credentials intended for the local Gateway.
-    return [bindHost, "127.0.0.1"];
+    return requiredHosts;
   }
   // Windows: uv_tcp_bind6 creates a dual-stack socket (no UV_TCP_IPV6ONLY), which
   // also accepts ::ffff:127.0.0.1 connections. Binding both ::1 and 127.0.0.1 on
@@ -389,6 +384,16 @@ export async function resolveGatewayListenHosts(
     return [bindHost, "::1"];
   }
   return [bindHost];
+}
+
+/** Returns every address whose bind must succeed for Gateway startup to succeed. */
+export function resolveGatewayRequiredListenHosts(bindHost: string): string[] {
+  if (!isValidIPv4(bindHost) || bindHost === "0.0.0.0" || bindHost === "127.0.0.1") {
+    return [bindHost];
+  }
+  // Same-host clients use the canonical loopback URL even when external access is
+  // pinned to one interface. Lifecycle checks must therefore cover both listeners.
+  return [bindHost, "127.0.0.1"];
 }
 
 /**

--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -1,8 +1,8 @@
 // Formats port probe results for diagnostics and CLI output.
 import net from "node:net";
-import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { formatCliCommand } from "../cli/command-format.js";
+import { parseTcpListenerEndpoint } from "./ports-netstat.js";
 import type { PortListener, PortListenerKind, PortUsage } from "./ports-types.js";
 
 /** Classifies a listener as OpenClaw Gateway, SSH tunnel, known non-gateway, or unknown. */
@@ -42,35 +42,6 @@ export function classifyPortListener(listener: PortListener, _port: number): Por
   return "unknown";
 }
 
-function parseListenerAddress(address: string): { host: string; port: number } | null {
-  const trimmed = address.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const normalized = trimmed.replace(/^tcp6?\s+/i, "").replace(/\s*\(listen\)\s*$/i, "");
-  const bracketMatch = normalized.match(/^\[([^\]]+)\]:(\d+)$/);
-  if (bracketMatch) {
-    const port = Number.parseInt(
-      expectDefined(bracketMatch[2], "bracket match capture group 2"),
-      10,
-    );
-    return Number.isFinite(port)
-      ? { host: normalizeLowercaseStringOrEmpty(bracketMatch[1]), port }
-      : null;
-  }
-  const lastColon = normalized.lastIndexOf(":");
-  if (lastColon <= 0 || lastColon >= normalized.length - 1) {
-    return null;
-  }
-  const host = normalizeLowercaseStringOrEmpty(normalized.slice(0, lastColon));
-  const portToken = normalized.slice(lastColon + 1).trim();
-  if (!/^\d+$/.test(portToken)) {
-    return null;
-  }
-  const port = Number.parseInt(portToken, 10);
-  return Number.isFinite(port) ? { host, port } : null;
-}
-
 // Dual-stack listener output can include IPv4-mapped IPv6 addresses; keep them
 // in the IPv6 family so the benign loopback-pair detection stays conservative.
 function classifyLoopbackAddressFamily(host: string): "ipv4" | "ipv6" | null {
@@ -107,7 +78,7 @@ function parsePortListeners(
     if (typeof pid !== "number" || !Number.isFinite(pid) || typeof listener.address !== "string") {
       return null;
     }
-    const address = parseListenerAddress(listener.address);
+    const address = parseTcpListenerEndpoint(listener.address);
     if (!address || address.port !== port) {
       return null;
     }

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -1,4 +1,5 @@
 // Inspects gateway port listeners and connection state.
+import net from "node:net";
 import os from "node:os";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
@@ -12,7 +13,11 @@ import {
   type LsofListenerRecord,
 } from "./ports-lsof-listeners.js";
 import { resolveLsofCommand } from "./ports-lsof.js";
-import { parseTcpEndpoint, parseWindowsNetstatListeners } from "./ports-netstat.js";
+import {
+  parseTcpEndpoint,
+  parseTcpListenerEndpoint,
+  parseWindowsNetstatListeners,
+} from "./ports-netstat.js";
 import { probePortUsage } from "./ports-probe.js";
 import type {
   PortConnection,
@@ -644,9 +649,14 @@ async function buildPortUsage(
       : await probePortUsage(port);
   if (status !== "busy") {
     listeners = [];
+  } else if (probeHosts) {
+    listeners = listeners.filter((listener) =>
+      isListenerRelevantToProbeHosts(listener, port, probeHosts),
+    );
   }
   const hints = buildPortHints(listeners, port);
   if (status === "busy" && listeners.length === 0) {
+    // The bind probe is authoritative; filtered diagnostics must never turn busy into free.
     hints.push(
       "Port is in use but process details are unavailable (install lsof or run as an admin user).",
     );
@@ -659,6 +669,37 @@ async function buildPortUsage(
     detail: result.detail,
     errors: errors.length > 0 ? errors : undefined,
   };
+}
+
+function isWildcardTcpHost(host: string): boolean {
+  return host === "0.0.0.0" || host === "::" || host === "*";
+}
+
+function isSameTcpAddressFamily(leftHost: string, rightHost: string): boolean {
+  const leftFamily = net.isIP(leftHost);
+  const rightFamily = net.isIP(rightHost);
+  return leftFamily === 0 || rightFamily === 0 || leftFamily === rightFamily;
+}
+
+function isListenerRelevantToProbeHosts(
+  listener: PortListener,
+  port: number,
+  probeHosts: readonly string[],
+): boolean {
+  const endpoint = parseTcpListenerEndpoint(listener.address);
+  if (!endpoint || endpoint.port !== port) {
+    return false;
+  }
+  return probeHosts.some((probeHost) => {
+    const normalizedProbeHost = normalizeLowercaseStringOrEmpty(probeHost);
+    if (isWildcardTcpHost(endpoint.host)) {
+      return isSameTcpAddressFamily(endpoint.host, normalizedProbeHost);
+    }
+    if (isWildcardTcpHost(normalizedProbeHost)) {
+      return isSameTcpAddressFamily(normalizedProbeHost, endpoint.host);
+    }
+    return normalizedProbeHost === endpoint.host;
+  });
 }
 
 export async function inspectPortUsages(

--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -620,20 +620,28 @@ async function readWindowsEstablishedConnections(
   return { connections: result.entries, detail: result.detail, errors: result.errors };
 }
 
-export async function inspectPortUsage(port: number): Promise<PortUsage> {
+export async function inspectPortUsage(
+  port: number,
+  options?: { probeHosts?: readonly string[] },
+): Promise<PortUsage> {
   const result =
     process.platform === "win32" ? await readWindowsListeners(port) : await readUnixListeners(port);
-  return buildPortUsage(port, result);
+  return buildPortUsage(port, result, options?.probeHosts);
 }
 
-async function buildPortUsage(port: number, result: ListenerReadResult): Promise<PortUsage> {
+async function buildPortUsage(
+  port: number,
+  result: ListenerReadResult,
+  probeHosts?: readonly string[],
+): Promise<PortUsage> {
   const errors: string[] = [];
   errors.push(...result.errors);
   let listeners = result.listeners;
-  let status: PortUsageStatus = listeners.length > 0 ? "busy" : "unknown";
-  if (listeners.length === 0) {
-    status = await probePortUsage(port);
-  }
+  const status: PortUsageStatus = probeHosts
+    ? await probePortUsage(port, probeHosts)
+    : listeners.length > 0
+      ? "busy"
+      : await probePortUsage(port);
   if (status !== "busy") {
     listeners = [];
   }
@@ -653,11 +661,20 @@ async function buildPortUsage(port: number, result: ListenerReadResult): Promise
   };
 }
 
-export async function inspectPortUsages(ports: readonly number[]): Promise<Map<number, PortUsage>> {
+export async function inspectPortUsages(
+  ports: readonly number[],
+  options?: { probeHostsByPort?: ReadonlyMap<number, readonly string[]> },
+): Promise<Map<number, PortUsage>> {
   const uniquePorts = Array.from(new Set(ports));
   if (process.platform === "win32") {
     const entries = await Promise.all(
-      uniquePorts.map(async (port) => [port, await inspectPortUsage(port)] as const),
+      uniquePorts.map(async (port) => {
+        const probeHosts = options?.probeHostsByPort?.get(port);
+        return [
+          port,
+          await inspectPortUsage(port, probeHosts ? { probeHosts } : undefined),
+        ] as const;
+      }),
     );
     return new Map(entries);
   }
@@ -666,7 +683,14 @@ export async function inspectPortUsages(ports: readonly number[]): Promise<Map<n
   const entries = await Promise.all(
     uniquePorts.map(
       async (port) =>
-        [port, await buildPortUsage(port, await readUnixListeners(port, snapshot))] as const,
+        [
+          port,
+          await buildPortUsage(
+            port,
+            await readUnixListeners(port, snapshot),
+            options?.probeHostsByPort?.get(port),
+          ),
+        ] as const,
     ),
   );
   return new Map(entries);

--- a/src/infra/ports-netstat.ts
+++ b/src/infra/ports-netstat.ts
@@ -40,6 +40,18 @@ export function parseTcpEndpoint(raw: string): { host: string; port: number } | 
   return { host: normalizeTcpHost(endpoint.slice(0, lastColon)), port };
 }
 
+/** Parses the address field emitted for a TCP listener by lsof or netstat. */
+export function parseTcpListenerEndpoint(raw: string | undefined): {
+  host: string;
+  port: number;
+} | null {
+  const normalized = raw
+    ?.trim()
+    .replace(/^tcp6?\s+/i, "")
+    .replace(/\s*\(listen\)\s*$/i, "");
+  return normalized ? parseTcpEndpoint(normalized) : null;
+}
+
 function isWildcardEndpoint(raw: string | undefined): boolean {
   const endpoint = raw?.trim();
   if (!endpoint || endpoint === "*:*") {

--- a/src/infra/ports-probe.test.ts
+++ b/src/infra/ports-probe.test.ts
@@ -3,12 +3,15 @@ import net from "node:net";
 import { describe, expect, it } from "vitest";
 import { probePortUsage, tryListenOnPort } from "./ports-probe.js";
 
-async function withListeningServer(cb: (address: net.AddressInfo) => Promise<void>): Promise<void> {
+async function withListeningServer(
+  cb: (address: net.AddressInfo) => Promise<void>,
+  host = "127.0.0.1",
+): Promise<void> {
   const server = net.createServer();
   try {
     await new Promise<void>((resolve, reject) => {
       server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => resolve());
+      server.listen(0, host, () => resolve());
     });
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "EPERM") {
@@ -71,5 +74,12 @@ describe("probePortUsage", () => {
     await withListeningServer(async (address) => {
       await expect(probePortUsage(address.port)).resolves.toBe("busy");
     });
+  });
+
+  it("can scope a probe to a free loopback address when another address owns the port", async () => {
+    await withListeningServer(async (address) => {
+      await expect(probePortUsage(address.port)).resolves.toBe("busy");
+      await expect(probePortUsage(address.port, ["127.0.0.1"])).resolves.toBe("free");
+    }, "127.0.0.2");
   });
 });

--- a/src/infra/ports-probe.test.ts
+++ b/src/infra/ports-probe.test.ts
@@ -14,7 +14,10 @@ async function withListeningServer(
       server.listen(0, host, () => resolve());
     });
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "EPERM") {
+    if (
+      (err as NodeJS.ErrnoException).code === "EPERM" ||
+      (err as NodeJS.ErrnoException).code === "EADDRNOTAVAIL"
+    ) {
       return;
     }
     throw err;

--- a/src/infra/ports-probe.ts
+++ b/src/infra/ports-probe.ts
@@ -4,6 +4,7 @@ import { isErrno } from "./errors.js";
 import type { PortUsageStatus } from "./ports-types.js";
 
 const PORT_PROBE_HOSTS = ["127.0.0.1", "0.0.0.0", "::1", "::"];
+export const LOOPBACK_PORT_PROBE_HOSTS = ["127.0.0.1"] as const;
 
 /** Opens and closes a temporary listener to verify that a port can be bound. */
 export async function tryListenOnPort(params: {
@@ -48,10 +49,13 @@ async function probePortOnHost(port: number, host: string): Promise<PortUsageSta
   }
 }
 
-/** Checks all supported local address families without resolving listener diagnostics. */
-export async function probePortUsage(port: number): Promise<PortUsageStatus> {
+/** Checks selected local addresses without resolving listener diagnostics. */
+export async function probePortUsage(
+  port: number,
+  probeHosts: readonly string[] = PORT_PROBE_HOSTS,
+): Promise<PortUsageStatus> {
   let sawUnknown = false;
-  for (const host of PORT_PROBE_HOSTS) {
+  for (const host of probeHosts) {
     const result = await probePortOnHost(port, host);
     if (result === "busy") {
       return "busy";

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -134,6 +134,82 @@ describe("ports helpers", () => {
 });
 
 describeUnix("inspectPortUsage", () => {
+  it("keeps only listener rows that can block a scoped bind", async () => {
+    const server = net.createServer();
+    const address = await listenServer(server, 0, "127.0.0.1");
+    if (!address) {
+      return;
+    }
+    const port = address.port;
+
+    runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+      const command = argv[0];
+      if (typeof command === "string" && command.includes("lsof")) {
+        return {
+          stdout:
+            `p111\ncgateway\nnTCP 127.0.0.1:${port} (LISTEN)\n` +
+            `p222\ncother\nnTCP 127.0.0.2:${port} (LISTEN)\n`,
+          stderr: "",
+          code: 0,
+        };
+      }
+      return { stdout: "", stderr: "", code: 1 };
+    });
+
+    try {
+      const result = await inspectPortUsage(port, { probeHosts: ["127.0.0.1"] });
+
+      expect(result.status).toBe("busy");
+      expect(result.listeners).toHaveLength(1);
+      expect(result.listeners[0]).toMatchObject({
+        pid: 111,
+        address: `TCP 127.0.0.1:${port} (LISTEN)`,
+      });
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it.each([
+    { probeHost: "127.0.0.1", unrelatedWildcard: "[::]" },
+    { probeHost: "::1", unrelatedWildcard: "0.0.0.0" },
+  ])(
+    "does not attribute an opposite-family wildcard listener to $probeHost",
+    async ({ probeHost, unrelatedWildcard }) => {
+      const server = net.createServer();
+      const address = await listenServer(server, 0, probeHost);
+      if (!address) {
+        return;
+      }
+      const port = address.port;
+
+      runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+        const command = argv[0];
+        if (typeof command === "string" && command.includes("lsof")) {
+          return {
+            stdout: `p222\ncother\nnTCP ${unrelatedWildcard}:${port} (LISTEN)\n`,
+            stderr: "",
+            code: 0,
+          };
+        }
+        return { stdout: "", stderr: "", code: 1 };
+      });
+
+      try {
+        const result = await inspectPortUsage(port, { probeHosts: [probeHost] });
+
+        expect(result.status).toBe("busy");
+        expect(result.listeners).toEqual([]);
+      } finally {
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+      }
+    },
+  );
+
   it("ignores another interface when inspection is scoped to the gateway loopback", async () => {
     const server = net.createServer();
     const address = await listenServer(server, 0, "127.0.0.2");

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -134,6 +134,45 @@ describe("ports helpers", () => {
 });
 
 describeUnix("inspectPortUsage", () => {
+  it("ignores another interface when inspection is scoped to the gateway loopback", async () => {
+    const server = net.createServer();
+    const address = await listenServer(server, 0, "127.0.0.2");
+    if (!address) {
+      return;
+    }
+    const port = address.port;
+
+    runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+      const command = argv[0];
+      if (typeof command === "string" && command.includes("lsof")) {
+        return {
+          stdout: `p${process.pid}\ncnode\nnTCP 127.0.0.2:${port} (LISTEN)\n`,
+          stderr: "",
+          code: 0,
+        };
+      }
+      return { stdout: "", stderr: "", code: 1 };
+    });
+
+    try {
+      const allInterfaces = await inspectPortUsage(port);
+      const gatewayLoopback = await inspectPortUsage(port, {
+        probeHosts: ["127.0.0.1"],
+      });
+
+      expect(allInterfaces.status).toBe("busy");
+      expect(gatewayLoopback).toMatchObject({
+        status: "free",
+        listeners: [],
+        hints: [],
+      });
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
   it("reports busy when lsof is missing but loopback listener exists", async () => {
     const server = net.createServer();
     const address = await listenServer(server, 0, "127.0.0.1");

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -44,7 +44,7 @@ async function listenServer(
     });
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code === "EPERM" || code === "EACCES") {
+    if (code === "EPERM" || code === "EACCES" || code === "EADDRNOTAVAIL") {
       return null;
     }
     throw err;

--- a/src/infra/ports.ts
+++ b/src/infra/ports.ts
@@ -6,7 +6,7 @@ import { defaultRuntime } from "../runtime.js";
 import { isErrno } from "./errors.js";
 import { formatPortDiagnostics } from "./ports-format.js";
 import { inspectPortUsage } from "./ports-inspect.js";
-import { tryListenOnPort } from "./ports-probe.js";
+import { LOOPBACK_PORT_PROBE_HOSTS, tryListenOnPort } from "./ports-probe.js";
 import type { PortConnection, PortListener, PortUsage, PortUsageStatus } from "./ports-types.js";
 
 class PortInUseError extends Error {
@@ -95,4 +95,5 @@ export {
   isDualStackLoopbackGatewayListeners,
   isExpectedGatewayListeners,
 } from "./ports-format.js";
+export { LOOPBACK_PORT_PROBE_HOSTS };
 export { inspectPortConnections, inspectPortUsage, inspectPortUsages } from "./ports-inspect.js";


### PR DESCRIPTION
## What problem this solves

Fixes a false Gateway port-conflict result for users running a loopback-bound Gateway behind Tailscale Serve:

```text
Port 18789 is already in use.
- Port is in use but process details are unavailable (install lsof or run as an admin user).
```

Tailscale Serve legitimately owns the same numeric port on a tailnet address while proxying to the Gateway on `127.0.0.1`. The existing fallback probe checked loopback, wildcard IPv4, loopback IPv6, and wildcard IPv6 and classified the Gateway port as busy if *any* bind failed. A listener on an unrelated interface therefore made wildcard binding fail even though the configured Gateway endpoint was free. When `lsof` could not see the Network Extension listener, the diagnostic also incorrectly suggested that `lsof` was missing or privileges were insufficient.

## Why this matters

A TCP port is available or unavailable for a particular address/family tuple, not just as a machine-wide integer. Conflating those questions can:

- report a successful Gateway stop as a failure;
- block or confuse restart automation that waits for the configured endpoint to become free;
- send operators toward unnecessary privilege escalation or package installation;
- make `status` and Doctor contradict direct connectivity checks; and
- affect other VPNs, Network Extensions, local reverse proxies, or multi-address hosts, not only Tailscale.

The fix keeps generic all-interface inspection unchanged. Only Gateway-owned callers opt into the address-scoped question they actually need answered.

## Implementation

Port inspection now accepts an optional set of addresses that must be available.

- Generic callers retain the existing all-address probe.
- Gateway status and Doctor resolve the configured bind host.
- Local lifecycle and restart-health checks probe the Gateway's canonical loopback endpoint.
- When inspection is address-scoped, the bind probe governs the result. If the requested Gateway endpoint is free, unrelated listener metadata and misleading process-detail hints are discarded.
- A real listener that prevents the configured bind still reports as busy.

This changes no configuration schema or default and adds no dependency.

## Evidence

### Pre-implementation investigation: affected host, read-only

The initial diagnosis made no changes to OpenClaw, launchd, Tailscale, or configuration.

With the Gateway stopped, all of the following described the same state:

- LaunchAgent not loaded;
- former Gateway PID absent;
- `127.0.0.1:18789` refused connections;
- `lsof -nP -iTCP:18789 -sTCP:LISTEN` returned zero listeners;
- `netstat` still showed Tailscale's Network Extension listening on the same port on tailnet IPv4/IPv6 addresses;
- Tailscale Serve still proxied `https://<redacted-tailnet-host>:18789` to `http://127.0.0.1:18789`; and
- `openclaw gateway status` nevertheless printed the false port-busy/admin/lsof diagnostic.

The bind matrix isolated the mismatch:

```text
127.0.0.1:18789  FREE
0.0.0.0:18789    EADDRINUSE
::1:18789        FREE
:::18789         EADDRINUSE
```

In other words, the exact endpoint the Gateway needed was free, while wildcard binding was correctly blocked by a listener on another interface.

### Pre-apply live acceptance baseline

Live acceptance was performed only after explicit operator approval.

Baseline:

```text
Installed OpenClaw: 2026.7.2 (1eab16b)
Gateway bind:       loopback
Gateway port:       18789
Tailscale mode:     serve
Local HTTP:         200
Tailnet HTTPS:      200
```

On the unpatched build:

```text
$ openclaw gateway stop --force
[restart] killing 1 stale gateway process(es) before restart: <gateway-pid>
Gateway stop failed: Error: gateway port 18789 is still busy after LaunchAgent stop
Port 18789 is already in use.
- Port is in use but process details are unavailable (install lsof or run as an admin user).

exit: non-zero
```

Post-command state proved that the Gateway had actually stopped:

```text
LaunchAgent loaded:          no
Former Gateway PID present:  no
Direct loopback connection:  ECONNREFUSED
lsof-visible listeners:      0
127.0.0.1 bind:              FREE
0.0.0.0 bind:                EADDRINUSE
::1 bind:                    FREE
:: bind:                     EADDRINUSE
```

So the old command reported failure solely because another interface still owned the numeric port.

### Isolated build and focused validation

The branch was rebased onto:

```text
main: f4a7f2b553d3fd788552f3f3ae1004ecac8b2370
head: d94135639c8cefea0f78120fc1036cd6154399f8
```

Initial runtime validation ran in a disposable Linux container inside a Colima VM. The source worktree was mounted read-only, Docker used bridge networking, no host OpenClaw state was mounted, and the container had no `tailscale` binary.

The isolated reproduction used the same relevant socket geometry: a synthetic listener owned an ephemeral port on `127.0.0.2`, leaving the Gateway target `127.0.0.1` free while preventing a wildcard bind.

```json
{"syntheticOwner":"127.0.0.2:36653","target":"127.0.0.1","wildcard":"0.0.0.0","tailscaleInstalled":false}
{"host":"127.0.0.1","result":"FREE"}
{"host":"0.0.0.0","result":"EADDRINUSE"}
```

The integration coverage proves that generic inspection remains `busy`, while Gateway-scoped inspection is `free` with no unrelated listener rows or misleading hints.

Focused validation after the rebase:

```text
node scripts/run-vitest.mjs \
  src/infra/ports-probe.test.ts \
  src/infra/ports.test.ts \
  src/daemon/launchd.test.ts \
  src/cli/daemon-cli/restart-health.test.ts \
  src/cli/daemon-cli/restart-health-external.test.ts \
  src/cli/daemon-cli/status.gather.test.ts \
  src/commands/doctor-gateway-daemon-flow.test.ts \
  src/commands/status-all/report-data.test.ts

Result: 229 passed, 25 platform-specific skipped; all 5 Vitest shards passed.

pnpm tsgo:core
Result: passed.

pnpm docs:list
Result: passed.

oxfmt --check <17 changed files>
Result: passed.

git diff --check
Result: passed.
```

The official root-package staging helper then produced the exact live-acceptance artifact:

```text
Version:  2026.7.2
Commit:   d94135639c8cefea0f78120fc1036cd6154399f8
SHA-256:  f126c06643dc73fc1043cc4ebeb70de23e7b947dda37a3dba66199a276441181
Tarball integrity check with bundled workspace dependencies: passed
```

### Post-apply live acceptance: same host and listener geometry

The patched package was applied without changing Gateway, Tailscale, or LaunchAgent configuration. The configuration, LaunchAgent plist, and Tailscale Serve state were checked before and after; their recorded content hashes were unchanged for this comparison.

The patched build saw the same stopped-state geometry:

```text
LaunchAgent loaded:          no
Direct loopback connection:  ECONNREFUSED
lsof-visible listeners:      0
Tailnet listeners present:   yes
127.0.0.1 bind:              FREE
0.0.0.0 bind:                EADDRINUSE
::1 bind:                    FREE
:: bind:                     EADDRINUSE
```

But the lifecycle result was now correct:

```text
$ openclaw gateway stop --force
[restart] killing 1 stale gateway process(es) before restart: <gateway-pid>
Stopped LaunchAgent: gui/<redacted-uid>/ai.openclaw.gateway

exit: 0
```

Follow-up verification:

```text
launchd_loaded=no
direct_loopback=ECONNREFUSED
gateway_status_contains_false_busy=no
```

The final service was brought forward on the patched build:

```text
OpenClaw:              2026.7.2 (d941356)
Local Gateway HTTP:    200
Tailnet Gateway HTTPS: 200
Gateway connectivity:  ok
```

This is a direct before/after on the same Mac, port, bind mode, Tailscale Serve configuration, and external listener geometry:

| Result | Unpatched `1eab16b` | Patched `d941356` |
|---|---:|---:|
| Gateway process stopped | yes | yes |
| Loopback endpoint free | yes | yes |
| Tailnet listener remained | yes | yes |
| Stop command exit | non-zero | `0` |
| False port-busy diagnostic | yes | no |

Only highly identifying local username, computer, account, and tailnet names are redacted.

## AI assistance

- [x] AI-assisted implementation and investigation.
- [x] I reviewed the resulting diff and understand the behavior and ownership boundaries.
- [x] Prompt summary: investigate a false Gateway port-busy report under Tailscale Serve, reproduce without touching the installed system, implement the bind-aware fix, validate in isolation, and submit detailed evidence.
- The repository's `autoreview` skill was not available in this Codex environment; focused runtime, integration, caller, formatting, package-integrity, core type, and approved live acceptance checks were used instead.


## Follow-up: configured-bind lifecycle correction (`0885c1de1b`)

ClawSweeper correctly identified that head `d94135639c8cefea0f78120fc1036cd6154399f8` still supplied `LOOPBACK_PORT_PROBE_HOSTS` to two lifecycle decisions. That meant a custom, LAN, or tailnet Gateway could have a busy configured endpoint while free loopback was incorrectly treated as proof of release or restart health.

### Pre-implementation evidence

At the reviewed head:

```text
src/daemon/launchd.ts
  waitForGatewayPortRelease -> probePortUsage(port, [127.0.0.1])
  post-stop diagnostics      -> inspectPortUsage(port, [127.0.0.1])
  pre-restart diagnostics    -> inspectPortUsage(port, [127.0.0.1])

src/cli/daemon-cli/restart-health.ts
  restart inspection         -> inspectPortUsage(port, [127.0.0.1])
```

This was internally inconsistent with Status and Doctor, which already selected a configured bind endpoint. The false-release case followed directly: loopback `free` plus configured custom/tailnet endpoint `busy` produced a `free` lifecycle decision.

### Implementation

Commit `0885c1de1bdb9ba4d6b0b90dfbc8d39c9b783f1c` adds one service-profile-aware resolver and threads its result through both P1 paths:

- It reads configuration using the merged installed-service environment, so named profiles and service-specific state/config paths are respected.
- It returns the configured endpoint directly, without testing whether that endpoint is currently bindable. This matters because an occupied configured endpoint is exactly the condition lifecycle code must detect.
- Endpoint mapping is explicit: loopback -> `127.0.0.1`; LAN -> `0.0.0.0`; custom -> the configured `customBindHost`; tailnet -> the current primary tailnet IPv4 with loopback fallback; container auto -> `0.0.0.0`.
- Launchd resolves the port and probe host together, once per stop/restart operation. The same host is then used for initial diagnostics and every release-poll iteration.
- Managed restart health resolves once before polling and reuses the same host for every snapshot. Direct Status restart inspection passes its already-resolved `gateway.bindHost` explicitly.
- The existing loopback/Tailscale Serve behavior is retained; only the owner endpoint selection changes for non-loopback configurations.

### Post-implementation evidence

Focused regressions use documentation-only address `192.0.2.40` and assert exact call arguments:

```text
launchd post-stop inspection: inspectPortUsage(19011, { probeHosts: [192.0.2.40] })
launchd release polling:      probePortUsage(19011, [192.0.2.40])
restart-health inspection:    inspectPortUsage(18789, { probeHosts: [192.0.2.40] })
```

The resolver unit coverage separately proves custom (`192.0.2.40`), LAN wildcard (`0.0.0.0`), and tailnet (`100.64.0.40`) selection, including installed-service environment precedence. The socket-level secondary-loopback tests now treat `EADDRNOTAVAIL` as an environment skip, matching their existing permission skips; the explicit non-loopback argument assertions remain mandatory on every platform.

Exact isolated validation transcript (temporary source worktree only; no installed Gateway, LaunchAgent, Tailscale configuration, or live service was read, changed, stopped, or restarted):

```text
node scripts/run-vitest.mjs \
  src/daemon/gateway-service-probe-hosts.test.ts \
  src/daemon/launchd.test.ts \
  src/cli/daemon-cli/restart-health.test.ts \
  src/cli/daemon-cli/restart-health-external.test.ts \
  src/cli/daemon-cli/status.gather.test.ts \
  src/commands/doctor-gateway-daemon-flow.test.ts \
  src/infra/ports-probe.test.ts \
  src/infra/ports.test.ts

Result: 8 files, 258 tests passed, 5/5 Vitest shards passed.

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false
Result: exit 0.

oxfmt --check <10 touched files>
Result: all matched files use the correct format.

git diff --check
Result: exit 0.
```

This follow-up intentionally uses deterministic source-level proof rather than another live installation change. The prior same-host loopback/Tailscale evidence remains valid, and the new regressions cover the exact non-loopback conditions raised by review.


## Final-head proof and type-contract repair (`5c9c3393ad`)

This follow-up addresses both remaining July 31 review requirements on final head `5c9c3393ad079528909905b8c9e45753accb629f`.

### Exact type-gate diagnosis and repair

The failed `check-test-types` log on `0885c1de1b` reported two concrete mock-signature errors:

```text
src/daemon/gateway-service-probe-hosts.test.ts(22,84):
  TS2554: Expected 0 arguments, but got 1.

src/daemon/launchd.test.ts(416,89):
  TS2554: Expected 0 arguments, but got 1.
```

The final head gives both mocks their real argument signatures. It also restores exported-call compatibility by making `inspectGatewayRestart.probeHosts` optional. Omission does not restore the old loopback bug: the function resolves the configured service-profile endpoint itself, tolerates minimal test/service fixtures without `readCommand`, and then passes that endpoint to address-scoped inspection. Polling callers still resolve once and pass an explicit host for every snapshot.

Focused validation after the repair:

```text
node scripts/run-vitest.mjs \
  src/daemon/gateway-service-probe-hosts.test.ts \
  src/daemon/launchd.test.ts \
  src/cli/daemon-cli/restart-health.test.ts \
  src/cli/daemon-cli/restart-health-external.test.ts \
  src/cli/daemon-cli/status.gather.test.ts \
  src/commands/doctor-gateway-daemon-flow.test.ts \
  src/infra/ports-probe.test.ts \
  src/infra/ports.test.ts

Result: 8 files, 258 tests passed, 5/5 Vitest shards passed.

test/tsconfig/tsconfig.test.root.json
Result: exit 0.

git diff --check
Result: exit 0.
```

The authoritative pushed-head GitHub `check-test-types` shard passed on `5c9c3393ad` (CI run `30596468631`, job `91049913037`).

### Final-head real behavior proof: non-loopback lifecycle geometry

The proof ran in a disposable Linux/arm64 Docker container inside a Colima VM. The final-head source was copied into the container; no host OpenClaw state, config, service socket, credentials, account data, or Tailscale state was mounted. The container created its own temporary OpenClaw state and configuration, then deleted that state before exit.

The isolated config used custom bind address `127.0.0.2`. A real TCP listener held an ephemeral port on that configured address while `127.0.0.1` remained free. The proof executed the final-head config resolver and exported restart-health inspection path with `probeHosts` omitted, exercising the repaired default contract rather than injecting the expected result.

Exact terminal output:

```json
{"proof":"environment","head":"5c9c3393ad079528909905b8c9e45753accb629f","runtime":"linux/arm64","tailscaleInstalled":false,"hostOpenClawStateMounted":false}
{"proof":"live-socket-geometry","port":"<ephemeral>","loopbackHost":"127.0.0.1","configuredHost":"127.0.0.2","oldHardcodedLoopbackDecision":"free","directConfiguredDecision":"busy"}
{"proof":"final-head-config-resolution","resolvedProbeHosts":["127.0.0.2"]}
{"proof":"final-head-restart-health","portStatus":"busy","healthy":false,"staleGatewayPids":[]}
```

This is the requested final-head non-loopback counterexample: the former loopback-only rule would declare the numeric port free, while the final implementation resolves the configured custom endpoint and reports it busy. No Tailscale installation is needed to reproduce that address-ownership boundary.
