### PR TITLE
fix(update): accept concrete versions selected by ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Package update version verification:** accept concrete versions selected by npm ranges or dist-tags during staged global updates while retaining exact-version mismatch checks.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Package update version verification:** accept concrete versions selected by npm ranges or dist-tags during staged global updates while retaining exact-version mismatch checks.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -393,6 +393,63 @@ describe("runGlobalPackageUpdateSteps", () => {
     });
   });
 
+  it.each([
+    { installSpec: "openclaw@^2.0.0", installedVersion: "2.4.1" },
+    { installSpec: "openclaw@nightly", installedVersion: "3.0.0-beta.2" },
+  ])(
+    "accepts concrete version $installedVersion staged from $installSpec",
+    async ({ installSpec, installedVersion }) => {
+      await withTempDir({ prefix: "openclaw-package-update-moving-spec-" }, async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+        const postVerifyStep = vi.fn(async () => null);
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec,
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep: async ({ name, argv, cwd }) => {
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const stagePrefix = argv[argv.indexOf("--prefix") + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            await writePackageRoot(
+              path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+              installedVersion,
+            );
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+          timeoutMs: 1000,
+          postVerifyStep,
+        });
+
+        expect(result.failedStep).toBeNull();
+        expect(result.afterVersion).toBe(installedVersion);
+        expect(result.steps.map((step) => step.name)).toEqual([
+          "global update",
+          "global install swap",
+        ]);
+        expect(postVerifyStep).toHaveBeenCalledWith(packageRoot);
+        await expect(
+          fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+        ).resolves.toContain(`"version":"${installedVersion}"`);
+      });
+    },
+  );
+
   it("packs npm GitHub specs before installing into the staged prefix", async () => {
     await withTempDir({ prefix: "openclaw-package-update-npm-pack-" }, async (base) => {
       const prefix = path.join(base, "prefix");

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -27,6 +27,7 @@ import {
   createGlobalInstallEnv,
   globalInstallArgs,
   globalInstallFallbackArgs,
+  resolveExpectedInstalledVersionFromSpec,
   resolveGlobalInstallTarget,
   resolveGlobalInstallSpec,
   resolveNpmGlobalPrefixLayoutFromGlobalRoot,
@@ -128,6 +129,41 @@ describe("update global helpers", () => {
         tag: "https://example.com/openclaw-main.tgz",
       }),
     ).toBe("https://example.com/openclaw-main.tgz");
+  });
+
+  it.each([
+    { packageName: "openclaw", spec: "openclaw@1.2.3", expected: "1.2.3" },
+    { packageName: "openclaw", spec: "openclaw@v1.2.3", expected: "1.2.3" },
+    { packageName: "openclaw", spec: "openclaw@=1.2.3", expected: "1.2.3" },
+    { packageName: "openclaw", spec: "openclaw@=v1.2.3", expected: "1.2.3" },
+    {
+      packageName: "@openclaw/core",
+      spec: "@openclaw/core@2026.7.30-beta.1",
+      expected: "2026.7.30-beta.1",
+    },
+    { packageName: "openclaw", spec: "openclaw@^1.2.3", expected: null },
+    { packageName: "openclaw", spec: "openclaw@~1.2.3", expected: null },
+    { packageName: "openclaw", spec: "openclaw@>=1.2.3", expected: null },
+    { packageName: "openclaw", spec: "openclaw@1.2.x", expected: null },
+    { packageName: "openclaw", spec: "openclaw@1.2", expected: null },
+    { packageName: "openclaw", spec: "openclaw@*", expected: null },
+    { packageName: "openclaw", spec: "openclaw@latest", expected: null },
+    { packageName: "openclaw", spec: "openclaw@beta", expected: null },
+    { packageName: "openclaw", spec: "openclaw@next", expected: null },
+    { packageName: "openclaw", spec: "openclaw@main", expected: null },
+    { packageName: "openclaw", spec: "openclaw@nightly", expected: null },
+    { packageName: "openclaw", spec: "openclaw@V1.2.3", expected: null },
+    { packageName: "openclaw", spec: "openclaw@npm:@vendor/openclaw@1.2.3", expected: null },
+    { packageName: "openclaw", spec: "openclaw@file:../candidate", expected: null },
+    { packageName: "openclaw", spec: "openclaw@../candidate", expected: null },
+    { packageName: "openclaw", spec: "openclaw@https://example.test/openclaw.tgz", expected: null },
+    { packageName: "openclaw", spec: "openclaw@github:openclaw/openclaw#main", expected: null },
+    { packageName: "openclaw", spec: "other@1.2.3", expected: null },
+    { packageName: "openclaw", spec: "1.2.3", expected: null },
+  ])("derives an expected installed version only for an exact npm spec: $spec", (testCase) => {
+    expect(resolveExpectedInstalledVersionFromSpec(testCase.packageName, testCase.spec)).toBe(
+      testCase.expected,
+    );
   });
 
   it("identifies package targets that support registry version resolution", () => {

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { valid as validSemver } from "semver";
 import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../plugins/runtime-sidecar-paths.js";
 import { pathExists } from "../utils.js";
 import {
@@ -200,16 +201,9 @@ export function resolveExpectedInstalledVersionFromSpec(
     return null;
   }
   const rawVersion = normalizedSpec.slice(normalizedPackageName.length + 1).trim();
-  if (
-    !rawVersion ||
-    rawVersion.includes("/") ||
-    rawVersion.includes(":") ||
-    rawVersion.includes("#") ||
-    /^(latest|beta|next|main)$/i.test(rawVersion)
-  ) {
-    return null;
-  }
-  return normalizePackageVersionForComparison(rawVersion);
+  // npm-package-arg classifies registry specs as exact versions with the same
+  // loose SemVer check. Everything else may resolve to a different version.
+  return validSemver(rawVersion, true);
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where global updates requested through an npm semver range or nonstandard dist-tag could install a valid concrete package in staging, then reject it because OpenClaw compared that concrete version literally with the moving selector. The verified candidate was discarded and the old installation stayed active.

## Why This Change Was Made

Post-install equality is now enforced only when the requested npm selector is an exact version. The implementation uses the same loose SemVer classification as npm 12's bundled `npm-package-arg`: exact `v` and `=` forms canonicalize to a version, while ranges, wildcards, tags, aliases, paths, URLs, and git specs remain moving targets and skip literal equality.

No update source, staging, swap, rollback, configuration, or dependency contract changes.

## User Impact

Operators can use supported npm ranges and dist-tags for staged global updates without a successfully installed concrete version being falsely rejected. Exact-version updates still fail closed on a real mismatch.

## Evidence

- Before-fix staged reproductions with `openclaw@^2.0.0` and `openclaw@nightly` installed concrete candidates but failed `global install verify`, leaving the old package live.
- Exact-head focused Testbox proof: 81/81 update helper and staged-swap tests passed ([run 30589076594](https://github.com/openclaw/openclaw/actions/runs/30589076594)).
- Patch-identical changed gate passed every selected guard, typecheck, lint, and architecture check on Testbox ([run 30590019203](https://github.com/openclaw/openclaw/actions/runs/30590019203)).
- Direct dependency proof: npm 12.0.1 bundles `npm-package-arg` 14.0.0, whose registry classifier uses `semver.valid(spec, true)` for exact versions before considering ranges and tags; this patch uses the same installed SemVer 7.8.5 contract.
- Fresh Codex autoreview on the implementation reported no accepted/actionable findings; final rebased-head review is recorded in the branch evidence.
- `git diff --check` is clean.
