### PR TITLE
fix(github-copilot): onboarding avoids unavailable default models

### DIFF
--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -31,7 +31,7 @@ provider or agent runtime in three different ways.
       </Step>
       <Step title="Set a default model">
         ```bash
-        openclaw models set github-copilot/claude-opus-5
+        openclaw models set github-copilot/claude-sonnet-4.6
         ```
 
         Or in config:
@@ -39,7 +39,7 @@ provider or agent runtime in three different ways.
         ```json5
         {
           agents: {
-            defaults: { model: { primary: "github-copilot/claude-opus-5" } },
+            defaults: { model: { primary: "github-copilot/claude-sonnet-4.6" } },
           },
         }
         ```
@@ -202,6 +202,14 @@ back to `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, then `GITHUB_TOKEN`. Use
 `--secret-input-mode ref` with `COPILOT_GITHUB_TOKEN` set to store an env-backed
 `tokenRef` instead of plaintext in `auth-profiles.json`.
 
+Fresh non-interactive setup validates the token before saving it. When setup
+must choose a default, it also checks the live Copilot model catalog. OpenClaw
+prefers the documented general-purpose Copilot CLI model when that model is
+enabled for the account; otherwise it chooses a deterministic eligible fallback.
+Setup fails without writing a new auth profile if the account has no
+picker-visible model that supports streaming and tool calls. An explicitly
+configured default model is never replaced.
+
 <AccordionGroup>
   <Accordion title="Interactive TTY required">
     The device-login flow requires an interactive TTY. Run it directly in a
@@ -209,8 +217,9 @@ back to `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, then `GITHUB_TOKEN`. Use
   </Accordion>
 
   <Accordion title="Model availability depends on your plan">
-    Copilot model availability depends on your GitHub plan. If a model is
-    rejected, try another ID (for example `github-copilot/gpt-5.6-sol`). See
+    Copilot model availability depends on your GitHub plan and organization
+    policy. Interactive onboarding uses the live catalog for its model picker,
+    while non-interactive onboarding selects an eligible model automatically. See
     GitHub's [supported models per Copilot plan](https://docs.github.com/en/copilot/reference/ai-models/supported-models#supported-ai-models-per-copilot-plan)
     for the current model list.
   </Accordion>
@@ -220,8 +229,11 @@ back to `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, then `GITHUB_TOKEN`. Use
     OpenClaw refreshes the model catalog on demand from `${baseUrl}/models`
     (the same endpoint VS Code Copilot uses) so the runtime tracks
     per-account entitlement and accurate context windows without manifest
-    churn. Newly published Copilot models become visible without an OpenClaw
-    upgrade, and context windows reflect the real per-model limits
+    churn. The visible live catalog excludes models hidden from GitHub's picker
+    or disabled by account policy. Automatic setup defaults additionally require
+    streaming and tool-call support.
+    Newly published Copilot models become visible without an OpenClaw upgrade,
+    and context windows reflect the real per-model limits
     (e.g. 400k for the gpt-5.x series, 1M for the internal
     `claude-opus-*-1m` variants).
 

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -31,7 +31,7 @@ provider or agent runtime in three different ways.
       </Step>
       <Step title="Set a default model">
         ```bash
-        openclaw models set github-copilot/claude-sonnet-4.6
+        openclaw models set github-copilot/claude-sonnet-5
         ```
 
         Or in config:
@@ -39,7 +39,7 @@ provider or agent runtime in three different ways.
         ```json5
         {
           agents: {
-            defaults: { model: { primary: "github-copilot/claude-sonnet-4.6" } },
+            defaults: { model: { primary: "github-copilot/claude-sonnet-5" } },
           },
         }
         ```
@@ -204,7 +204,7 @@ back to `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, then `GITHUB_TOKEN`. Use
 
 Fresh non-interactive setup validates the token before saving it. When setup
 must choose a default, it also checks the live Copilot model catalog. OpenClaw
-prefers the documented general-purpose Copilot CLI model when that model is
+prefers the provider's current general-purpose model when that model is
 enabled for the account; otherwise it chooses a deterministic eligible fallback.
 Setup fails without writing a new auth profile if the account has no
 picker-visible model that supports streaming and tool calls. An explicitly

--- a/extensions/github-copilot/dynamic-models.ts
+++ b/extensions/github-copilot/dynamic-models.ts
@@ -12,6 +12,7 @@ import { resolveGithubCopilotDomain } from "./domain.js";
 import {
   PROVIDER_ID,
   fetchCopilotModelCatalog,
+  isCopilotCatalogModelVisible,
   resolveCopilotForwardCompatModel,
 } from "./models.js";
 
@@ -96,7 +97,14 @@ export function createGithubCopilotDynamicModelHooks(params: {
 
   async function runCatalog(ctx: ProviderCatalogContext): Promise<ProviderCatalogResult> {
     const catalog = await resolveCatalog(ctx);
-    return catalog ? { provider: catalog } : null;
+    return catalog
+      ? {
+          provider: {
+            ...catalog,
+            models: catalog.models.filter(isCopilotCatalogModelVisible),
+          },
+        }
+      : null;
   }
 
   async function prepareDynamicModel(ctx: ProviderPrepareDynamicModelContext): Promise<void> {

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -29,7 +29,7 @@ const mocks = vi.hoisted(() => ({
     release: vi.fn(async () => {}),
   })),
   resolveCopilotRuntimeAuth: vi.fn(),
-  resolveCopilotStarterModel: vi.fn(async () => "github-copilot/claude-sonnet-4.6"),
+  resolveCopilotStarterModel: vi.fn(async () => "github-copilot/claude-sonnet-5"),
 }));
 
 function requireAuthMethod<T>(methods: readonly T[], index: number): T {
@@ -569,7 +569,7 @@ describe("github-copilot plugin", () => {
           },
         },
       ],
-      defaultModel: "github-copilot/claude-sonnet-4.6",
+      defaultModel: "github-copilot/claude-sonnet-5",
     });
     expect(mocks.resolveCopilotStarterModel).toHaveBeenCalledWith({
       githubToken: "existing-token",
@@ -1366,11 +1366,9 @@ describe("github-copilot plugin", () => {
       mode: "token",
     });
     expect(result?.agents?.defaults?.model).toEqual({
-      primary: "github-copilot/claude-sonnet-4.6",
+      primary: "github-copilot/claude-sonnet-5",
     });
-    expect(result?.agents?.defaults?.models?.["github-copilot/claude-sonnet-4.6"]).toStrictEqual(
-      {},
-    );
+    expect(result?.agents?.defaults?.models?.["github-copilot/claude-sonnet-5"]).toStrictEqual({});
 
     const profile = ensureAuthProfileStore(agentDir).profiles["github-copilot:github"];
     expect(profile).toEqual({
@@ -1494,7 +1492,7 @@ describe("github-copilot plugin", () => {
     expect(runtime.error).not.toHaveBeenCalled();
     expect(result?.agents?.defaults?.model).toEqual({
       fallbacks: ["openai/gpt-5.4"],
-      primary: "github-copilot/claude-sonnet-4.6",
+      primary: "github-copilot/claude-sonnet-5",
     });
 
     const profile = ensureAuthProfileStore(agentDir).profiles["github-copilot:github"];

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
     release: vi.fn(async () => {}),
   })),
   resolveCopilotRuntimeAuth: vi.fn(),
+  resolveCopilotStarterModel: vi.fn(async () => "github-copilot/claude-sonnet-4.6"),
 }));
 
 function requireAuthMethod<T>(methods: readonly T[], index: number): T {
@@ -48,6 +49,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
 vi.mock("./register.runtime.js", () => ({
   DEFAULT_COPILOT_API_BASE_URL: "https://api.githubcopilot.test",
   resolveCopilotRuntimeAuth: mocks.resolveCopilotRuntimeAuth,
+  resolveCopilotStarterModel: mocks.resolveCopilotStarterModel,
   githubCopilotLoginCommand: mocks.githubCopilotLoginCommand,
   fetchCopilotUsage: vi.fn(),
 }));
@@ -414,6 +416,79 @@ describe("github-copilot plugin", () => {
     });
   });
 
+  it("publishes only picker-visible, policy-enabled tool models in the live catalog", async () => {
+    mocks.resolveCopilotRuntimeAuth.mockResolvedValueOnce({
+      apiKey: "catalog-policy-token",
+      baseUrl: "https://api.githubcopilot.policy-test",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  id: "eligible",
+                  name: "Eligible",
+                  model_picker_enabled: true,
+                  model_picker_category: "versatile",
+                  policy: { state: "enabled" },
+                  capabilities: {
+                    type: "chat",
+                    limits: { max_context_window_tokens: 200_000, max_output_tokens: 64_000 },
+                    supports: { streaming: true, tool_calls: true },
+                  },
+                },
+                {
+                  id: "disabled",
+                  name: "Disabled",
+                  model_picker_enabled: true,
+                  policy: { state: "disabled" },
+                  capabilities: {
+                    type: "chat",
+                    supports: { streaming: true, tool_calls: true },
+                  },
+                },
+                {
+                  id: "hidden",
+                  name: "Hidden",
+                  model_picker_enabled: false,
+                  policy: { state: "enabled" },
+                  capabilities: {
+                    type: "chat",
+                    supports: { streaming: true, tool_calls: true },
+                  },
+                },
+                {
+                  id: "chat-only",
+                  name: "Chat only",
+                  model_picker_enabled: true,
+                  policy: { state: "enabled" },
+                  capabilities: {
+                    type: "chat",
+                    supports: { streaming: false, tool_calls: false },
+                  },
+                },
+              ],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    );
+    const provider = registerProviderWithPluginConfig({});
+
+    const result = await provider.catalog.run({
+      config: {},
+      agentDir: "/tmp/agent",
+      env: { GH_TOKEN: "catalog-source-token" },
+    } as never);
+
+    expect(
+      result && "provider" in result ? result.provider.models.map((model) => model.id) : [],
+    ).toEqual(["eligible", "chat-only"]);
+  });
+
   it("dual-publishes unified live catalog rows with existing discovery semantics", async () => {
     mocks.resolveCopilotRuntimeAuth.mockResolvedValueOnce({
       apiKey: "gh_test_token",
@@ -494,8 +569,51 @@ describe("github-copilot plugin", () => {
           },
         },
       ],
-      defaultModel: "github-copilot/claude-opus-5",
+      defaultModel: "github-copilot/claude-sonnet-4.6",
     });
+    expect(mocks.resolveCopilotStarterModel).toHaveBeenCalledWith({
+      githubToken: "existing-token",
+      env: {},
+      githubDomain: "github.com",
+      config: {},
+    });
+  });
+
+  it("keeps valid interactive auth when live starter-model discovery is unavailable", async () => {
+    mocks.resolveCopilotStarterModel.mockRejectedValueOnce(new Error("catalog unavailable"));
+    const provider = registerProviderWithPluginConfig({});
+    const method = requireAuthMethod(provider.auth, 0);
+    const agentDir = await createAgentDir();
+    writeExistingCopilotTokenProfile(agentDir);
+
+    const result = await method.run({
+      config: {},
+      env: {},
+      agentDir,
+      workspaceDir: "/tmp/workspace",
+      prompter: {
+        confirm: vi.fn(async () => false),
+        note: vi.fn(),
+      },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      opts: {},
+      secretInputMode: "plaintext",
+      allowSecretRefPrompt: false,
+      isRemote: false,
+      openUrl: vi.fn(),
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as never);
+
+    expect(result).toMatchObject({
+      profiles: [
+        {
+          profileId: "github-copilot:github",
+          credential: { type: "token", provider: "github-copilot", token: "existing-token" },
+        },
+      ],
+      notes: [expect.stringContaining("authentication succeeded")],
+    });
+    expect(result?.defaultModel).toBeUndefined();
   });
 
   describe("github-copilot dynamic model resolution", () => {
@@ -1248,9 +1366,11 @@ describe("github-copilot plugin", () => {
       mode: "token",
     });
     expect(result?.agents?.defaults?.model).toEqual({
-      primary: "github-copilot/claude-opus-5",
+      primary: "github-copilot/claude-sonnet-4.6",
     });
-    expect(result?.agents?.defaults?.models?.["github-copilot/claude-opus-5"]).toStrictEqual({});
+    expect(result?.agents?.defaults?.models?.["github-copilot/claude-sonnet-4.6"]).toStrictEqual(
+      {},
+    );
 
     const profile = ensureAuthProfileStore(agentDir).profiles["github-copilot:github"];
     expect(profile).toEqual({
@@ -1258,6 +1378,31 @@ describe("github-copilot plugin", () => {
       provider: "github-copilot",
       token: "ghu_test123",
     });
+  });
+
+  it("does not persist a new token when non-interactive starter-model discovery fails", async () => {
+    mocks.resolveCopilotStarterModel.mockRejectedValueOnce(new Error("no eligible models"));
+    const provider = registerProviderWithPluginConfig({});
+    const method = requireAuthMethod(provider.auth, 0);
+    const agentDir = await createAgentDir();
+
+    await expect(
+      method.runNonInteractive({
+        authChoice: "github-copilot",
+        config: {},
+        baseConfig: {},
+        opts: { githubCopilotToken: "ghu_invalid_for_catalog" },
+        runtime: { error: vi.fn(), exit: vi.fn() },
+        agentDir,
+        resolveApiKey: vi.fn(async () => ({
+          key: "ghu_invalid_for_catalog",
+          source: "flag" as const,
+        })),
+        toApiKeyCredential: vi.fn(),
+      }),
+    ).rejects.toThrow("no eligible models");
+
+    expect(ensureAuthProfileStore(agentDir).profiles["github-copilot:github"]).toBeUndefined();
   });
 
   it("persists COPILOT_GITHUB_DOMAIN during non-interactive onboarding", async () => {
@@ -1349,7 +1494,7 @@ describe("github-copilot plugin", () => {
     expect(runtime.error).not.toHaveBeenCalled();
     expect(result?.agents?.defaults?.model).toEqual({
       fallbacks: ["openai/gpt-5.4"],
-      primary: "github-copilot/claude-opus-5",
+      primary: "github-copilot/claude-sonnet-4.6",
     });
 
     const profile = ensureAuthProfileStore(agentDir).profiles["github-copilot:github"];
@@ -1424,6 +1569,10 @@ describe("github-copilot plugin", () => {
   });
 
   it("preserves an existing primary model during non-interactive onboarding", async () => {
+    mocks.resolveCopilotRuntimeAuth.mockResolvedValueOnce({
+      apiKey: "ghu_test",
+      baseUrl: "https://api.individual.githubcopilot.com",
+    });
     const provider = registerProviderWithPluginConfig({});
     const method = requireAuthMethod(provider.auth, 0);
     const agentDir = await createAgentDir();
@@ -1462,6 +1611,53 @@ describe("github-copilot plugin", () => {
     });
     expect(result?.agents?.defaults?.models).toEqual({
       "github-copilot/gpt-5.4": { label: "Existing" },
+    });
+    expect(mocks.resolveCopilotStarterModel).not.toHaveBeenCalled();
+    expect(mocks.resolveCopilotRuntimeAuth).toHaveBeenCalledWith({
+      githubToken: "ghu_test",
+      env: process.env,
+      githubDomain: "github.com",
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "github-copilot/gpt-5.4",
+              fallbacks: ["openai/gpt-5.4"],
+            },
+            models: {
+              "github-copilot/gpt-5.4": { label: "Existing" },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("does not overwrite stored auth when a fresh token fails explicit-model validation", async () => {
+    mocks.resolveCopilotRuntimeAuth.mockRejectedValueOnce(new Error("invalid credential"));
+    const provider = registerProviderWithPluginConfig({});
+    const method = requireAuthMethod(provider.auth, 0);
+    const agentDir = await createAgentDir();
+    writeExistingCopilotTokenProfile(agentDir);
+
+    await expect(
+      method.runNonInteractive({
+        authChoice: "github-copilot",
+        config: { agents: { defaults: { model: { primary: "github-copilot/gpt-5.4" } } } },
+        baseConfig: {},
+        opts: { githubCopilotToken: "fresh-invalid-token" },
+        runtime: { error: vi.fn(), exit: vi.fn() },
+        agentDir,
+        resolveApiKey: vi.fn(async () => ({
+          key: "fresh-invalid-token",
+          source: "flag" as const,
+        })),
+        toApiKeyCredential: vi.fn(),
+      }),
+    ).rejects.toThrow("invalid credential");
+
+    expect(ensureAuthProfileStore(agentDir).profiles["github-copilot:github"]).toMatchObject({
+      token: "existing-token",
     });
   });
 

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -19,6 +19,7 @@ import {
   resolveDefaultSecretProviderAlias,
   upsertAuthProfileWithLock,
 } from "openclaw/plugin-sdk/provider-auth";
+import { resolveFirstGithubToken } from "./auth.js";
 import { PUBLIC_GITHUB_COPILOT_DOMAIN, resolveGithubCopilotDomain } from "./domain.js";
 import { createGithubCopilotDynamicModelHooks } from "./dynamic-models.js";
 import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
@@ -48,18 +49,22 @@ async function loadGithubCopilotRuntime() {
   return await import("./register.runtime.js");
 }
 
-function applyCopilotDefaultModel(cfg: OpenClawConfig): OpenClawConfig {
+function resolveCopilotConfiguredPrimary(cfg: OpenClawConfig): string {
   const defaults = cfg.agents?.defaults;
   const existingModel = defaults?.model;
-  const existingPrimary =
-    typeof existingModel === "string"
-      ? existingModel.trim()
-      : typeof existingModel === "object" && typeof existingModel?.primary === "string"
-        ? existingModel.primary.trim()
-        : "";
-  if (existingPrimary) {
+  return typeof existingModel === "string"
+    ? existingModel.trim()
+    : typeof existingModel === "object" && typeof existingModel?.primary === "string"
+      ? existingModel.primary.trim()
+      : "";
+}
+
+function applyCopilotDefaultModel(cfg: OpenClawConfig, modelRef: string): OpenClawConfig {
+  if (resolveCopilotConfiguredPrimary(cfg)) {
     return cfg;
   }
+  const defaults = cfg.agents?.defaults;
+  const existingModel = defaults?.model;
   const fallbacks =
     typeof existingModel === "object" && existingModel !== null && "fallbacks" in existingModel
       ? (existingModel as { fallbacks?: string[] }).fallbacks
@@ -72,11 +77,11 @@ function applyCopilotDefaultModel(cfg: OpenClawConfig): OpenClawConfig {
         ...defaults,
         model: {
           ...(fallbacks ? { fallbacks } : undefined),
-          primary: DEFAULT_COPILOT_MODEL,
+          primary: modelRef,
         },
         models: {
           ...defaults?.models,
-          [DEFAULT_COPILOT_MODEL]: defaults?.models?.[DEFAULT_COPILOT_MODEL] ?? {},
+          [modelRef]: defaults?.models?.[modelRef] ?? {},
         },
       },
     },
@@ -117,8 +122,34 @@ function resolveExistingCopilotAuthResult(agentDir?: string): ProviderAuthResult
         credential,
       },
     ],
-    defaultModel: DEFAULT_COPILOT_MODEL,
   };
+}
+
+async function resolveInteractiveCopilotStarterModel(params: {
+  ctx: ProviderAuthContext;
+  githubToken: string;
+  githubDomain: string;
+}): Promise<Pick<ProviderAuthResult, "defaultModel" | "notes">> {
+  try {
+    const { resolveCopilotStarterModel } = await loadGithubCopilotRuntime();
+    return {
+      defaultModel: await resolveCopilotStarterModel({
+        githubToken: params.githubToken,
+        env: params.ctx.env ?? process.env,
+        githubDomain: params.githubDomain,
+        config: params.ctx.config,
+      }),
+    };
+  } catch {
+    // Interactive auth must not discard a valid durable credential when live
+    // discovery is transiently unavailable. The following model picker can
+    // retry discovery or let the user retain an explicit model selection.
+    return {
+      notes: [
+        "GitHub Copilot authentication succeeded, but no eligible live model could be selected. Choose a model after checking your Copilot plan and organization policy.",
+      ],
+    };
+  }
 }
 
 // Persists the chosen enterprise Copilot host under the provider's free-form
@@ -265,6 +296,7 @@ async function runGitHubCopilotNonInteractiveAuth(
   const resolved = await resolveCopilotNonInteractiveToken(ctx, flagValue);
 
   let profileId = DEFAULT_COPILOT_PROFILE_ID;
+  let githubToken = resolved?.key ?? "";
   if (resolved) {
     const useTokenRef = ctx.opts.secretInputMode === "ref" && resolved.source === "env";
     if (useTokenRef && !resolved.envVarName) {
@@ -277,6 +309,62 @@ async function runGitHubCopilotNonInteractiveAuth(
       ctx.runtime.exit(1);
       return null;
     }
+  } else {
+    if (flagValue && ctx.opts.secretInputMode === "ref") {
+      return null;
+    }
+    const existingProfileId = resolveExistingCopilotTokenProfileId(ctx.agentDir);
+    if (!existingProfileId) {
+      ctx.runtime.error(
+        "Missing --github-copilot-token (or COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN env var) for --auth-choice github-copilot.",
+      );
+      ctx.runtime.exit(1);
+      return null;
+    }
+    profileId = existingProfileId;
+    const existing = await resolveFirstGithubToken({
+      agentDir: ctx.agentDir,
+      config: ctx.config,
+      env: process.env,
+      profileId,
+    });
+    githubToken = existing.githubToken;
+  }
+
+  const resolvedDomain = resolveGithubCopilotDomain({ config: ctx.config });
+  const previousDomain = resolveGithubCopilotDomain({ env: {}, config: ctx.config });
+  const configWithDomain = applyGithubCopilotDomainToConfig(
+    ctx.config,
+    resolvedDomain,
+    previousDomain,
+  );
+
+  let starterModel: string | undefined;
+  if (!resolveCopilotConfiguredPrimary(configWithDomain)) {
+    const { resolveCopilotStarterModel } = await loadGithubCopilotRuntime();
+    starterModel = await resolveCopilotStarterModel({
+      githubToken,
+      env: process.env,
+      githubDomain: resolvedDomain,
+      config: configWithDomain,
+    });
+  } else if (resolved) {
+    // An explicit model does not need starter selection, but a newly supplied
+    // credential must still be validated before it can replace stored auth.
+    const { resolveCopilotRuntimeAuth } = await loadGithubCopilotRuntime();
+    await resolveCopilotRuntimeAuth({
+      githubToken,
+      env: process.env,
+      githubDomain: resolvedDomain,
+      config: configWithDomain,
+    });
+  }
+
+  // Validate the credential and its account-visible default before persisting
+  // a newly supplied token. A failed unattended setup must not leave partial
+  // auth state that appears usable on the next run.
+  if (resolved) {
+    const useTokenRef = ctx.opts.secretInputMode === "ref" && resolved.source === "env";
     await upsertAuthProfileWithLock({
       profileId,
       credential: {
@@ -296,36 +384,14 @@ async function runGitHubCopilotNonInteractiveAuth(
       },
       agentDir: ctx.agentDir,
     });
-  } else {
-    if (flagValue && ctx.opts.secretInputMode === "ref") {
-      return null;
-    }
-    const existingProfileId = resolveExistingCopilotTokenProfileId(ctx.agentDir);
-    if (!existingProfileId) {
-      ctx.runtime.error(
-        "Missing --github-copilot-token (or COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN env var) for --auth-choice github-copilot.",
-      );
-      ctx.runtime.exit(1);
-      return null;
-    }
-    profileId = existingProfileId;
   }
 
-  const resolvedDomain = resolveGithubCopilotDomain({ config: ctx.config });
-  const previousDomain = resolveGithubCopilotDomain({ env: {}, config: ctx.config });
-  const configWithDomain = applyGithubCopilotDomainToConfig(
-    ctx.config,
-    resolvedDomain,
-    previousDomain,
-  );
-
-  return applyCopilotDefaultModel(
-    applyAuthProfileConfig(configWithDomain, {
-      profileId,
-      provider: PROVIDER_ID,
-      mode: "token",
-    }),
-  );
+  const configWithAuth = applyAuthProfileConfig(configWithDomain, {
+    profileId,
+    provider: PROVIDER_ID,
+    mode: "token",
+  });
+  return starterModel ? applyCopilotDefaultModel(configWithAuth, starterModel) : configWithAuth;
 }
 
 export default definePluginEntry({
@@ -444,7 +510,19 @@ export default definePluginEntry({
           initialValue: false,
         });
         if (!runLogin) {
-          return { ...existing, ...(configPatch ? { configPatch } : {}) };
+          const profileId = existing.profiles[0]?.profileId;
+          const { githubToken } = await resolveFirstGithubToken({
+            agentDir: ctx.agentDir,
+            config: ctx.config,
+            env: ctx.env ?? process.env,
+            ...(profileId ? { profileId } : {}),
+          });
+          const starter = await resolveInteractiveCopilotStarterModel({
+            ctx,
+            githubToken,
+            githubDomain: normalizedDomain,
+          });
+          return { ...existing, ...starter, ...(configPatch ? { configPatch } : {}) };
         }
       } else if (existing && domainChanged) {
         await ctx.prompter.note(
@@ -511,6 +589,11 @@ export default definePluginEntry({
         return { profiles: [] };
       }
 
+      const starter = await resolveInteractiveCopilotStarterModel({
+        ctx,
+        githubToken: result.accessToken,
+        githubDomain: normalizedDomain,
+      });
       return {
         profiles: [
           {
@@ -522,7 +605,7 @@ export default definePluginEntry({
             },
           },
         ],
-        defaultModel: DEFAULT_COPILOT_MODEL,
+        ...starter,
         ...(configPatch ? { configPatch } : {}),
       };
     }

--- a/extensions/github-copilot/model-metadata.ts
+++ b/extensions/github-copilot/model-metadata.ts
@@ -8,7 +8,9 @@ type CopilotReasoningCompat = {
   supportedReasoningEfforts?: readonly string[] | null;
 };
 
-export const DEFAULT_COPILOT_MODEL = "github-copilot/claude-opus-5";
+// GitHub Copilot CLI's documented general-purpose default. Setup treats this
+// as a preference only and verifies it against the authenticated live catalog.
+export const DEFAULT_COPILOT_MODEL = "github-copilot/claude-sonnet-4.6";
 
 const COPILOT_CHAT_COMPLETIONS_COMPAT: ModelDefinitionConfig["compat"] = {
   supportsStore: false,

--- a/extensions/github-copilot/model-metadata.ts
+++ b/extensions/github-copilot/model-metadata.ts
@@ -8,9 +8,9 @@ type CopilotReasoningCompat = {
   supportedReasoningEfforts?: readonly string[] | null;
 };
 
-// GitHub Copilot CLI's documented general-purpose default. Setup treats this
-// as a preference only and verifies it against the authenticated live catalog.
-export const DEFAULT_COPILOT_MODEL = "github-copilot/claude-sonnet-4.6";
+// Provider-owned general-purpose preference. Setup verifies it against the
+// authenticated live catalog instead of assuming every account can use it.
+export const DEFAULT_COPILOT_MODEL = "github-copilot/claude-sonnet-5";
 
 const COPILOT_CHAT_COMPLETIONS_COMPAT: ModelDefinitionConfig["compat"] = {
   supportsStore: false,

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -21,7 +21,11 @@ vi.mock("openclaw/plugin-sdk/state-paths", () => ({
 }));
 
 import type { ProviderResolveDynamicModelContext } from "openclaw/plugin-sdk/core";
-import { fetchCopilotModelCatalog, resolveCopilotForwardCompatModel } from "./models.js";
+import {
+  fetchCopilotModelCatalog,
+  resolveCopilotForwardCompatModel,
+  selectCopilotStarterModel,
+} from "./models.js";
 
 function createMockCtx(
   modelId: string,
@@ -604,6 +608,82 @@ describe("fetchCopilotModelCatalog", () => {
       },
     ],
   };
+
+  function selectableModelEntry(params: {
+    id: string;
+    category?: string;
+    contextWindow?: number;
+    maxTokens?: number;
+    pickerEnabled?: boolean;
+    policyState?: string;
+    preview?: boolean;
+    streaming?: boolean;
+    toolCalls?: boolean;
+  }) {
+    return {
+      id: params.id,
+      name: params.id,
+      object: "model",
+      model_picker_enabled: params.pickerEnabled ?? true,
+      model_picker_category: params.category ?? "versatile",
+      policy: { state: params.policyState ?? "enabled" },
+      preview: params.preview ?? false,
+      capabilities: {
+        type: "chat",
+        limits: {
+          max_context_window_tokens: params.contextWindow ?? 200_000,
+          max_output_tokens: params.maxTokens ?? 64_000,
+        },
+        supports: {
+          streaming: params.streaming ?? true,
+          tool_calls: params.toolCalls ?? true,
+        },
+      },
+    };
+  }
+
+  async function fetchSelectionFixture(data: unknown[]) {
+    return await fetchCopilotModelCatalog({
+      copilotApiToken: "tid=test",
+      baseUrl: "https://api.githubcopilot.com",
+      fetchImpl: vi.fn().mockResolvedValue(makeResponse(200, { data })) as unknown as typeof fetch,
+    });
+  }
+
+  it("selects the preferred model only when the authenticated catalog marks it eligible", async () => {
+    const models = await fetchSelectionFixture([
+      selectableModelEntry({ id: "fallback", contextWindow: 1_000_000 }),
+      selectableModelEntry({ id: "preferred", category: "powerful" }),
+    ]);
+
+    expect(selectCopilotStarterModel(models, "preferred")?.id).toBe("preferred");
+  });
+
+  it("uses a deterministic eligible fallback when the preferred model is policy-disabled", async () => {
+    const entries = [
+      selectableModelEntry({ id: "preferred", policyState: "disabled" }),
+      selectableModelEntry({ id: "preview", preview: true, contextWindow: 1_000_000 }),
+      selectableModelEntry({ id: "powerful", category: "powerful", contextWindow: 1_000_000 }),
+      selectableModelEntry({ id: "versatile-b", contextWindow: 400_000 }),
+      selectableModelEntry({ id: "versatile-a", contextWindow: 400_000 }),
+    ];
+    const forward = await fetchSelectionFixture(entries);
+    const reversed = await fetchSelectionFixture(entries.toReversed());
+
+    expect(selectCopilotStarterModel(forward, "preferred")?.id).toBe("versatile-a");
+    expect(selectCopilotStarterModel(reversed, "preferred")?.id).toBe("versatile-a");
+  });
+
+  it("rejects hidden, unconfigured, non-streaming, and tool-less setup candidates", async () => {
+    const models = await fetchSelectionFixture([
+      selectableModelEntry({ id: "hidden", pickerEnabled: false }),
+      selectableModelEntry({ id: "unconfigured", policyState: "unconfigured" }),
+      selectableModelEntry({ id: "no-stream", streaming: false }),
+      selectableModelEntry({ id: "no-tools", toolCalls: false }),
+    ]);
+
+    expect(selectCopilotStarterModel(models, "hidden")).toBeUndefined();
+  });
 
   it("maps Copilot /models entries to ModelDefinitionConfig with real context windows", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(makeResponse(200, sampleApiResponse));

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -617,7 +617,7 @@ describe("fetchCopilotModelCatalog", () => {
     pickerEnabled?: boolean;
     policyState?: string;
     preview?: boolean;
-    streaming?: boolean;
+    streaming?: boolean | "omit";
     toolCalls?: boolean;
   }) {
     return {
@@ -635,7 +635,7 @@ describe("fetchCopilotModelCatalog", () => {
           max_output_tokens: params.maxTokens ?? 64_000,
         },
         supports: {
-          streaming: params.streaming ?? true,
+          ...(params.streaming === "omit" ? {} : { streaming: params.streaming ?? true }),
           tool_calls: params.toolCalls ?? true,
         },
       },
@@ -683,6 +683,14 @@ describe("fetchCopilotModelCatalog", () => {
     ]);
 
     expect(selectCopilotStarterModel(models, "hidden")).toBeUndefined();
+  });
+
+  it("does not treat omitted streaming metadata as an explicit lack of support", async () => {
+    const models = await fetchSelectionFixture([
+      selectableModelEntry({ id: "omitted-streaming", streaming: "omit" }),
+    ]);
+
+    expect(selectCopilotStarterModel(models, "omitted-streaming")?.id).toBe("omitted-streaming");
   });
 
   it("maps Copilot /models entries to ModelDefinitionConfig with real context windows", async () => {

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -128,7 +128,7 @@ type CopilotModelSelectionMetadata = {
   pickerEnabled: boolean;
   policyState?: string;
   preview: boolean;
-  streaming: boolean;
+  streaming?: boolean;
   toolCalls: boolean;
 };
 
@@ -151,7 +151,9 @@ export function isCopilotCatalogModelVisible(model: CopilotCatalogModel): boolea
 
 function isCopilotCatalogModelSelectable(model: CopilotCatalogModel): boolean {
   const metadata = readCopilotModelSelectionMetadata(model);
-  return Boolean(isCopilotCatalogModelVisible(model) && metadata?.streaming && metadata.toolCalls);
+  return Boolean(
+    isCopilotCatalogModelVisible(model) && metadata?.streaming !== false && metadata?.toolCalls,
+  );
 }
 
 const COPILOT_STARTER_CATEGORY_RANK = new Map<string, number>([
@@ -306,7 +308,7 @@ function mapCopilotApiModelToDefinition(
     pickerEnabled: entry.model_picker_enabled === true,
     policyState: normalizeOptionalLowercaseString(entry.policy?.state),
     preview: entry.preview === true,
-    streaming: supports?.streaming === true,
+    streaming: supports?.streaming,
     toolCalls: supports?.tool_calls === true,
   });
   return definition;

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -101,6 +101,10 @@ type CopilotApiModelEntry = {
   vendor?: string;
   preview?: boolean;
   model_picker_enabled?: boolean;
+  model_picker_category?: string;
+  policy?: {
+    state?: string;
+  };
   capabilities?: {
     type?: string;
     family?: string;
@@ -118,6 +122,82 @@ type CopilotApiModelEntry = {
     };
   };
 };
+
+type CopilotModelSelectionMetadata = {
+  category?: string;
+  pickerEnabled: boolean;
+  policyState?: string;
+  preview: boolean;
+  streaming: boolean;
+  toolCalls: boolean;
+};
+
+const copilotModelSelectionMetadata = new WeakMap<object, CopilotModelSelectionMetadata>();
+
+function readCopilotModelSelectionMetadata(
+  model: CopilotCatalogModel,
+): CopilotModelSelectionMetadata | undefined {
+  return copilotModelSelectionMetadata.get(model);
+}
+
+export function isCopilotCatalogModelVisible(model: CopilotCatalogModel): boolean {
+  const metadata = readCopilotModelSelectionMetadata(model);
+  return Boolean(
+    metadata?.pickerEnabled &&
+    metadata.policyState !== "disabled" &&
+    metadata.policyState !== "unconfigured",
+  );
+}
+
+function isCopilotCatalogModelSelectable(model: CopilotCatalogModel): boolean {
+  const metadata = readCopilotModelSelectionMetadata(model);
+  return Boolean(isCopilotCatalogModelVisible(model) && metadata?.streaming && metadata.toolCalls);
+}
+
+const COPILOT_STARTER_CATEGORY_RANK = new Map<string, number>([
+  ["versatile", 0],
+  ["lightweight", 1],
+  ["powerful", 2],
+]);
+
+function compareCopilotStarterCandidates(
+  left: CopilotCatalogModel,
+  right: CopilotCatalogModel,
+): number {
+  const leftMetadata = readCopilotModelSelectionMetadata(left);
+  const rightMetadata = readCopilotModelSelectionMetadata(right);
+  const previewDelta =
+    Number(leftMetadata?.preview === true) - Number(rightMetadata?.preview === true);
+  if (previewDelta !== 0) {
+    return previewDelta;
+  }
+  const categoryDelta =
+    (COPILOT_STARTER_CATEGORY_RANK.get(leftMetadata?.category ?? "") ?? Number.MAX_SAFE_INTEGER) -
+    (COPILOT_STARTER_CATEGORY_RANK.get(rightMetadata?.category ?? "") ?? Number.MAX_SAFE_INTEGER);
+  if (categoryDelta !== 0) {
+    return categoryDelta;
+  }
+  const contextDelta = right.contextWindow - left.contextWindow;
+  if (contextDelta !== 0) {
+    return contextDelta;
+  }
+  const outputDelta = right.maxTokens - left.maxTokens;
+  if (outputDelta !== 0) {
+    return outputDelta;
+  }
+  return left.id.localeCompare(right.id);
+}
+
+export function selectCopilotStarterModel(
+  models: readonly CopilotCatalogModel[],
+  preferredModelId: string,
+): CopilotCatalogModel | undefined {
+  const selectable = models.filter(isCopilotCatalogModelSelectable);
+  return (
+    selectable.find((model) => model.id === preferredModelId) ??
+    selectable.toSorted(compareCopilotStarterCandidates)[0]
+  );
+}
 
 const COPILOT_MODELS_LIST_DEFAULT_TIMEOUT_MS = 10_000;
 const COPILOT_ROUTER_ID_PREFIX = "accounts/";
@@ -221,6 +301,14 @@ function mapCopilotApiModelToDefinition(
     ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
     ...(compat ? { compat } : {}),
   };
+  copilotModelSelectionMetadata.set(definition, {
+    category: normalizeOptionalLowercaseString(entry.model_picker_category),
+    pickerEnabled: entry.model_picker_enabled === true,
+    policyState: normalizeOptionalLowercaseString(entry.policy?.state),
+    preview: entry.preview === true,
+    streaming: supports?.streaming === true,
+    toolCalls: supports?.tool_calls === true,
+  });
   return definition;
 }
 

--- a/extensions/github-copilot/register.runtime.ts
+++ b/extensions/github-copilot/register.runtime.ts
@@ -7,6 +7,7 @@ import {
 import { githubCopilotLoginCommand } from "./login.js";
 import { PROVIDER_ID, resolveCopilotForwardCompatModel } from "./models.js";
 import { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotRuntimeAuth } from "./runtime-auth.js";
+import { resolveCopilotStarterModel } from "./starter-model.js";
 import { wrapCopilotAnthropicStream, wrapCopilotProviderStream } from "./stream.js";
 import { fetchCopilotUsage } from "./usage.js";
 
@@ -19,6 +20,7 @@ export {
   listProfilesForProvider,
   PROVIDER_ID,
   resolveCopilotRuntimeAuth,
+  resolveCopilotStarterModel,
   resolveCopilotForwardCompatModel,
   wrapCopilotAnthropicStream,
   wrapCopilotProviderStream,

--- a/extensions/github-copilot/starter-model.ts
+++ b/extensions/github-copilot/starter-model.ts
@@ -1,0 +1,37 @@
+// Resolves a safe setup default from the authenticated Copilot model catalog.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { DEFAULT_COPILOT_MODEL } from "./model-metadata.js";
+import { fetchCopilotModelCatalog, PROVIDER_ID, selectCopilotStarterModel } from "./models.js";
+import { resolveCopilotRuntimeAuth } from "./runtime-auth.js";
+
+function preferredCopilotStarterModelId(): string {
+  const prefix = `${PROVIDER_ID}/`;
+  return DEFAULT_COPILOT_MODEL.startsWith(prefix)
+    ? DEFAULT_COPILOT_MODEL.slice(prefix.length)
+    : DEFAULT_COPILOT_MODEL;
+}
+
+export async function resolveCopilotStarterModel(params: {
+  githubToken: string;
+  env?: NodeJS.ProcessEnv;
+  githubDomain?: string;
+  config?: OpenClawConfig;
+}): Promise<string> {
+  const auth = await resolveCopilotRuntimeAuth({
+    githubToken: params.githubToken,
+    ...(params.env ? { env: params.env } : {}),
+    ...(params.githubDomain ? { githubDomain: params.githubDomain } : {}),
+    ...(params.config ? { config: params.config } : {}),
+  });
+  const models = await fetchCopilotModelCatalog({
+    copilotApiToken: auth.apiKey,
+    baseUrl: auth.baseUrl,
+  });
+  const selected = selectCopilotStarterModel(models, preferredCopilotStarterModelId());
+  if (!selected) {
+    throw new Error(
+      "GitHub Copilot did not return an enabled, picker-visible chat model with streaming and tool-call support.",
+    );
+  }
+  return `${PROVIDER_ID}/${selected.id}`;
+}

--- a/src/plugin-sdk/test-helpers/provider-auth-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-auth-contract.ts
@@ -314,8 +314,66 @@ export function describeGithubCopilotProviderAuthContract(
       return requireProvider(await registerProviders(githubCopilotPlugin), "github-copilot");
     }
 
+    function buildCopilotSetupResponse(target: string): Response | undefined {
+      if (target === "https://api.github.com/copilot_internal/user") {
+        return new Response(
+          JSON.stringify({ endpoints: { api: "https://api.individual.githubcopilot.com" } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (target === "https://api.individual.githubcopilot.com/models") {
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: defaultModel.replace("github-copilot/", ""),
+                name: "Contract starter model",
+                model_picker_enabled: true,
+                model_picker_category: "versatile",
+                policy: { state: "enabled" },
+                capabilities: {
+                  type: "chat",
+                  limits: {
+                    max_context_window_tokens: 200_000,
+                    max_output_tokens: 64_000,
+                  },
+                  supports: { streaming: true, tool_calls: true },
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return undefined;
+    }
+
+    function resolveFetchTarget(input: unknown): string {
+      return typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input instanceof Request
+            ? input.url
+            : String(input);
+    }
+
+    function stubGitHubCatalogFetch() {
+      const fetchMock = vi.fn(async (input: unknown) => {
+        const target = resolveFetchTarget(input);
+        const response = buildCopilotSetupResponse(target);
+        if (response) {
+          return response;
+        }
+        throw new Error(`unexpected fetch in github-copilot catalog stub: ${target}`);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      return fetchMock;
+    }
+
     it("keeps existing device auth results provider-owned", async () => {
       const provider = await getProvider();
+      stubGitHubCatalogFetch();
       state.authStore.profiles["github-copilot:github"] = {
         type: "token",
         provider: "github-copilot",
@@ -359,14 +417,7 @@ export function describeGithubCopilotProviderAuthContract(
       outcome: { accessToken: string } | { error: "access_denied" | "expired_token" },
     ) {
       const fetchMock = vi.fn(async (input: unknown) => {
-        const target =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.toString()
-              : input instanceof Request
-                ? input.url
-                : String(input);
+        const target = resolveFetchTarget(input);
         if (target === "https://github.com/login/device/code") {
           return new Response(
             JSON.stringify({
@@ -388,6 +439,10 @@ export function describeGithubCopilotProviderAuthContract(
             status: 200,
             headers: { "Content-Type": "application/json" },
           });
+        }
+        const setupResponse = buildCopilotSetupResponse(target);
+        if (setupResponse) {
+          return setupResponse;
         }
         throw new Error(`unexpected fetch in github-copilot device flow stub: ${target}`);
       });

--- a/src/system-agent/setup-inference-plan.ts
+++ b/src/system-agent/setup-inference-plan.ts
@@ -591,9 +591,41 @@ async function runProviderManualSecretMethod(params: {
       throw new Error(methodError || `Provider setup exited with code ${code}.`);
     },
   };
+  const existingPrimary = resolveAgentModelPrimaryValue(params.config.agents?.defaults?.model);
+  const existingProvider = existingPrimary ? parseRef(existingPrimary).provider : undefined;
+  let providerSetupConfig = params.config;
+  if (
+    existingProvider &&
+    normalizeProviderId(existingProvider) !== normalizeProviderId(params.choice.providerId)
+  ) {
+    const agents = params.config.agents;
+    const defaults = agents?.defaults;
+    const model = defaults?.model;
+    if (defaults && model !== undefined) {
+      const { model: _model, ...defaultsWithoutModel } = defaults;
+      let modelWithoutPrimary: Exclude<typeof model, string> | undefined;
+      if (typeof model === "object" && model !== null) {
+        const { primary: _primary, ...remainingModelConfig } = model;
+        modelWithoutPrimary = remainingModelConfig;
+      }
+      // App-guided setup needs this provider's verified candidate, not an
+      // unrelated current default. The original config remains the merge base.
+      providerSetupConfig = {
+        ...params.config,
+        agents: {
+          ...agents,
+          defaults:
+            modelWithoutPrimary && Object.keys(modelWithoutPrimary).length > 0
+              ? { ...defaultsWithoutModel, model: modelWithoutPrimary }
+              : defaultsWithoutModel,
+        },
+      };
+    }
+  }
+
   const configured = await runNonInteractive({
     authChoice: params.choice.choiceId,
-    config: params.config,
+    config: providerSetupConfig,
     baseConfig: params.baseConfig,
     opts: { [optionKey]: params.apiKey, secretInputMode: "plaintext" },
     runtime: isolatedRuntime,

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -15,6 +15,7 @@ import {
   type AgentExecutionAuthBinding,
 } from "../agents/execution-auth-binding.js";
 import { detectInferenceBackends } from "../commands/onboard-inference.js";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { withoutPluginInstallRecords } from "../plugins/installed-plugin-index-records.js";
@@ -3669,16 +3670,19 @@ describe("activateSetupInference", () => {
 
   it.each([
     {
-      name: "uses a provider starter model instead of an unrelated existing default",
+      name: "requests a dynamic provider model instead of using a static starter",
       existingModel: "openai/gpt-5.2",
-      starterModel: "github-copilot/claude-sonnet-4.5",
+      starterModel: "github-copilot/static-should-not-win",
+      expectedSetupInputModel: undefined,
     },
     {
       name: "accepts an unchanged provider-owned dynamic model",
       existingModel: "github-copilot/claude-sonnet-4.5",
       starterModel: undefined,
+      expectedSetupInputModel: "github-copilot/claude-sonnet-4.5",
     },
-  ])("$name without starting interactive login", async ({ existingModel, starterModel }) => {
+  ])("$name without starting interactive login", async (testCase) => {
+    const { existingModel, starterModel, expectedSetupInputModel } = testCase;
     const stateDir = await makeTempDir();
     const agentDir = path.join(stateDir, "agent");
     const runInteractive = vi.fn();
@@ -3787,6 +3791,10 @@ describe("activateSetupInference", () => {
         expect.objectContaining({
           opts: expect.objectContaining({ githubCopilotToken: "github-token" }),
         }),
+      );
+      const setupInputConfig = runNonInteractive.mock.calls[0]?.[0].config;
+      expect(resolveAgentModelPrimaryValue(setupInputConfig?.agents?.defaults?.model)).toBe(
+        expectedSetupInputModel,
       );
       const activatedProfileId = runEmbeddedAgent.mock.calls[0]?.[0].authProfileId;
       if (!activatedProfileId) {


### PR DESCRIPTION
Closes #116581

## What Problem This Solves

Fixes an issue where users onboarding GitHub Copilot could receive a policy-disabled static default model, causing the first ordinary agent turn to fail with HTTP 400 `model_not_supported` even though their credential and subscription exposed other usable models.

## Why This Change Was Made

The GitHub Copilot provider now treats its current general-purpose model as a preference and verifies it against the authenticated account catalog. If necessary, it selects a deterministic eligible fallback; fresh unattended setup validates before persisting auth, while existing explicit model choices remain untouched.

The visible live catalog now honors GitHub picker and policy metadata. Streaming and tool-call support constrain automatic defaults only, so explicit chat-only model choices remain available. SDK `auto` is intentionally not used because live dependency proof showed that it requires an SDK session token and SDK-selected wire protocol rather than acting as a direct-provider model id.

## User Impact

Fresh Copilot onboarding selects a model the authenticated account can actually use. Users with retained auth continue working without ambient token variables, and re-running onboarding no longer replaces an explicit model selection.

Interactive login retains a valid GitHub credential if catalog discovery is transiently unavailable, allowing the following picker or manual model selection to recover. Non-interactive setup fails before writing a new profile when it must choose a default but the account exposes no eligible one.

## Evidence

- Current-main baseline at `2b639649b317c2866edc37b274981581d8284c1a`: onboarding selected policy-disabled `github-copilot/claude-opus-5`; two ordinary turns failed with HTTP 400 `model_not_supported`.
- Fix-head live proof:
  - fresh onboarding selected `github-copilot/claude-sonnet-5`;
  - ordinary inference returned the exact requested success marker;
  - retained-auth inference passed after removing `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN`;
  - explicit `github-copilot/gpt-5.4` survived re-onboarding and completed an ordinary turn.
- Focused tests: 82 passed across Copilot model, provider, and shared auth-contract suites.
- Post-review focused tests: 121 system-agent tests and 83 Copilot provider/auth tests passed.
- Local ClawSweeper found three actionable gaps; all were addressed: app-guided setup now consumes the dynamic provider candidate, omitted streaming metadata is not treated as explicit lack of support, and the preferred model is the current non-deprecated Sonnet 5.
- Final post-fix autoreview: clean; no accepted/actionable findings (0.91 confidence).
- Changed-surface Testbox gate: all selected core, extension, tests, docs, SDK, typecheck, lint, dead-code, boundary, and policy lanes passed ([run](https://github.com/openclaw/openclaw/actions/runs/30591803898)). The delegated backing step may show cancelled after the successful one-shot lease cleanup; the command completed with exit 0.
- No credential or account-identifying response payload was retained.
- Post-fix expanded changed-surface Testbox gate passed ([run](https://github.com/openclaw/openclaw/actions/runs/30593354824)).

<details>
<summary>Redacted live terminal transcript</summary>

Credential injection used a targeted 1Password reference. Token values, account identifiers, response bodies, private endpoints, IP addresses, and temporary state paths are omitted.

```text
# Current-main baseline (2b639649b317)
$ openclaw onboard --non-interactive --accept-risk --auth-choice github-copilot --skip-channels --skip-health
BASE_PRIMARY=github-copilot/claude-opus-5
$ openclaw agent --local --agent main --json --timeout 120 --message "Reply with exactly BASELINE-OK"
HTTP 400 model_not_supported
BASELINE_TURN=FAIL

# Final PR head (57f01da2f254)
$ openclaw onboard --non-interactive --accept-risk --auth-choice github-copilot --skip-channels --skip-health
FRESH_PRIMARY=github-copilot/claude-sonnet-5
$ openclaw agent --local --agent main --json --timeout 120 --message "Reply with exactly COPILOT-SONNET5-OK"
provider=github-copilot api=anthropic-messages model=claude-sonnet-5 status=200
FRESH_TURN=PASS

$ unset COPILOT_GITHUB_TOKEN GH_TOKEN GITHUB_TOKEN
$ openclaw agent --local --agent main --json --timeout 120 --message "Reply with exactly COPILOT-SONNET5-RETAINED-OK"
provider=github-copilot api=anthropic-messages model=claude-sonnet-5 status=200
RETAINED_TURN=PASS

# Explicit-model preservation on the same implementation
$ openclaw models set github-copilot/gpt-5.4
$ openclaw onboard --non-interactive --accept-risk --auth-choice github-copilot --skip-channels --skip-health
EXPLICIT_PRIMARY=github-copilot/gpt-5.4
$ openclaw agent --local --agent main --json --timeout 120 --message "Reply with exactly COPILOT-EXPLICIT-OK"
provider=github-copilot api=openai-responses model=gpt-5.4 status=200
EXPLICIT_TURN=PASS
```

All runs used isolated temporary state that was removed at command exit. The credential-reference file was also deleted after proof.

</details>

The fail-before-persist boundary is intentional for unattended setup: success means OpenClaw has both valid Copilot auth and a viable automatic agent model. Interactive login retains the credential and offers picker/manual recovery when catalog discovery is transiently unavailable.
