### PR TITLE
fix(exec): arm the gateway node invoke deadline from exec host=node

### DIFF
--- a/src/agents/bash-tools.exec-host-node-phases.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.cancellation.test.ts
@@ -29,7 +29,8 @@ function createDirectNodeRun(signal?: AbortSignal): DirectNodeRun {
       nodeId: "node-1",
       argv: ["tool", "--version"],
       env: undefined,
-      invokeTimeoutMs: 30_000,
+      invokeDeadlineMs: 30_000,
+      invokeWaitMs: 35_000,
       runTimeoutSec: 30,
       supportsSystemRunPrepare: true,
     },
@@ -48,7 +49,7 @@ describe("direct node run cancellation", () => {
 
     expect(callGatewayTool).toHaveBeenCalledWith(
       "node.invoke",
-      { timeoutMs: 30_000 },
+      { timeoutMs: 35_000 },
       expect.objectContaining({ command: "system.run" }),
       { signal: controller.signal },
     );
@@ -59,7 +60,7 @@ describe("direct node run cancellation", () => {
 
     expect(callGatewayTool).toHaveBeenCalledWith(
       "node.invoke",
-      { timeoutMs: 30_000 },
+      { timeoutMs: 35_000 },
       expect.objectContaining({ command: "system.run" }),
     );
   });

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -49,7 +49,8 @@ type NodeExecutionTarget = {
   platform?: string | null;
   argv: string[];
   env: Record<string, string> | undefined;
-  invokeTimeoutMs: number;
+  invokeDeadlineMs: number;
+  invokeWaitMs: number;
   runTimeoutSec: number;
   supportsSystemRunPrepare: boolean;
 };
@@ -88,13 +89,23 @@ function resolveNodeRunTimeoutSec(
     : defaultTimeoutSec;
 }
 
-function resolveNodeInvokeTimeoutMs(runTimeoutSec: number, defaultTimeoutSec: number): number {
+// Gateway invocation deadline: the node program budget plus transport grace. A
+// `timeout: 0` run keeps no program timer, so the deadline falls back to the
+// default budget instead of becoming unbounded.
+function resolveNodeInvokeDeadlineMs(runTimeoutSec: number, defaultTimeoutSec: number): number {
   const baseTimeoutSec =
     Number.isFinite(runTimeoutSec) && runTimeoutSec > 0 ? runTimeoutSec : defaultTimeoutSec;
   if (!Number.isFinite(baseTimeoutSec) || baseTimeoutSec <= 0) {
     return 10_000;
   }
   return Math.max(10_000, addSafeTimeoutDelayGraceMs(baseTimeoutSec * 1000, 5_000));
+}
+
+// Caller wait must outlast the Gateway deadline so the deadline expiry answer
+// wins the race instead of the caller giving up first. Both saturate together at
+// MAX_SAFE_TIMEOUT_DELAY_MS, where the ordering degenerates by design.
+function resolveNodeInvokeWaitMs(invokeDeadlineMs: number): number {
+  return addSafeTimeoutDelayGraceMs(invokeDeadlineMs, 5_000);
 }
 
 function resolveNodeRunTimeoutMs(runTimeoutSec: number): number {
@@ -327,12 +338,14 @@ export async function resolveNodeExecutionTarget(
   }
 
   const runTimeoutSec = resolveNodeRunTimeoutSec(params.timeoutSec, params.defaultTimeoutSec);
+  const invokeDeadlineMs = resolveNodeInvokeDeadlineMs(runTimeoutSec, params.defaultTimeoutSec);
   return {
     nodeId,
     platform: nodeInfo?.platform,
     argv: buildNodeShellCommand(params.command, nodeInfo?.platform),
     env: params.requestedEnv ? { ...params.requestedEnv } : undefined,
-    invokeTimeoutMs: resolveNodeInvokeTimeoutMs(runTimeoutSec, params.defaultTimeoutSec),
+    invokeDeadlineMs,
+    invokeWaitMs: resolveNodeInvokeWaitMs(invokeDeadlineMs),
     runTimeoutSec,
     supportsSystemRunPrepare: declaredCommands.includes("system.run.prepare"),
   };
@@ -363,6 +376,10 @@ export function buildNodeSystemRunInvoke(params: {
   return {
     nodeId: params.target.nodeId,
     command: "system.run",
+    // Top-level timeout arms the Gateway invocation deadline; the nested value is
+    // the node program timer. Without this the Gateway falls back to a fixed 30s
+    // pending-invoke timer and discards a later node result as `ignored`.
+    timeoutMs: params.target.invokeDeadlineMs,
     params: {
       command: params.command,
       rawCommand: params.rawCommand,
@@ -408,10 +425,10 @@ export async function invokeNodeSystemRunDirect(params: {
   });
   params.request.signal?.throwIfAborted();
   const raw = params.request.signal
-    ? await callGatewayTool("node.invoke", { timeoutMs: params.target.invokeTimeoutMs }, invoke, {
+    ? await callGatewayTool("node.invoke", { timeoutMs: params.target.invokeWaitMs }, invoke, {
         signal: params.request.signal,
       })
-    : await callGatewayTool("node.invoke", { timeoutMs: params.target.invokeTimeoutMs }, invoke);
+    : await callGatewayTool("node.invoke", { timeoutMs: params.target.invokeWaitMs }, invoke);
   return formatNodeRunToolResult({
     raw,
     startedAt,

--- a/src/agents/bash-tools.exec-host-node.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node.cancellation.test.ts
@@ -72,7 +72,8 @@ vi.mock("./bash-tools.exec-host-node-phases.js", () => ({
   resolveNodeExecutionTarget: vi.fn(async () => ({
     nodeId: "node-1",
     argv: ["tool", "--version"],
-    invokeTimeoutMs: 30_000,
+    invokeDeadlineMs: 30_000,
+    invokeWaitMs: 35_000,
     supportsSystemRunPrepare: true,
   })),
   shouldSkipNodeApprovalPrepare: vi.fn(
@@ -223,7 +224,7 @@ describe("node-host dispatch cancellation", () => {
 
     expect(mocks.callGatewayTool).toHaveBeenCalledWith(
       "node.invoke",
-      { timeoutMs: 30_000 },
+      { timeoutMs: 35_000 },
       expect.objectContaining({ command: "system.run" }),
       { scopes: ["operator.write", "operator.approvals"], signal: controller.signal },
     );
@@ -243,7 +244,7 @@ describe("node-host dispatch cancellation", () => {
 
     expect(mocks.callGatewayTool).toHaveBeenCalledWith(
       "node.invoke",
-      { timeoutMs: 30_000 },
+      { timeoutMs: 35_000 },
       expect.objectContaining({ command: "system.run" }),
       { signal: controller.signal },
     );

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -355,6 +355,7 @@ function createNodeHostRequest(
 
 type MockNodeInvokeParams = {
   command?: string;
+  timeoutMs?: number;
   params?: Record<string, unknown>;
 };
 
@@ -417,10 +418,21 @@ function requireRegisteredApprovalRequest(): Record<string, unknown> {
   return firstCall[0];
 }
 
-function expectSystemRunInvoke(params: { invokeTimeoutMs: number; runTimeoutMs: number }) {
+function expectSystemRunInvoke(params: {
+  invokeDeadlineMs: number;
+  invokeWaitMs: number;
+  runTimeoutMs: number;
+}) {
   const call = requireGatewayCommand("system.run");
-  expect(call.options.timeoutMs).toBe(params.invokeTimeoutMs);
+  // Three ordered budgets: node program runtime < Gateway invocation deadline <
+  // caller wait, so the Gateway deadline answer wins over a caller giving up.
   expect(requireRunParams(call).timeoutMs).toBe(params.runTimeoutMs);
+  expect(call.params?.timeoutMs).toBe(params.invokeDeadlineMs);
+  expect(call.options.timeoutMs).toBe(params.invokeWaitMs);
+  expect(params.runTimeoutMs).toBeLessThanOrEqual(params.invokeDeadlineMs);
+  expect(params.invokeDeadlineMs).toBeLessThanOrEqual(params.invokeWaitMs);
+  expect(params.invokeDeadlineMs).toBeGreaterThan(0);
+  expect(Number.isFinite(params.invokeWaitMs)).toBe(true);
 }
 
 function mockGatewayInvokesWithNodeApprovals(file: Record<string, unknown>) {
@@ -952,7 +964,8 @@ describe("executeNodeHostCommand", () => {
     });
 
     const call = requireGatewayCall(2);
-    expect(call.options.timeoutMs).toBe(35_000);
+    expect(call.options.timeoutMs).toBe(40_000);
+    expect(call.params?.timeoutMs).toBe(35_000);
     expect(call.callOptions).toEqual({ scopes: ["operator.write", "operator.approvals"] });
     const runParams = requireRunParams(call);
     expect(runParams.approved).toBe(true);
@@ -1867,7 +1880,7 @@ describe("executeNodeHostCommand", () => {
     expect(resolveExecApprovalsFromFileMock).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "prepared-agent" }),
     );
-    expectSystemRunInvoke({ invokeTimeoutMs: 35_000, runTimeoutMs: 30_000 });
+    expectSystemRunInvoke({ invokeDeadlineMs: 35_000, invokeWaitMs: 40_000, runTimeoutMs: 30_000 });
   });
 
   it("does not let transport wrapper allowlist matches approve shell payloads", async () => {
@@ -2036,7 +2049,7 @@ describe("executeNodeHostCommand", () => {
 
     expect(result.details?.status).toBe("completed");
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
-    expectSystemRunInvoke({ invokeTimeoutMs: 35_000, runTimeoutMs: 30_000 });
+    expectSystemRunInvoke({ invokeDeadlineMs: 35_000, invokeWaitMs: 40_000, runTimeoutMs: 30_000 });
   });
 
   it.each(["bash", "sh", "/bin/sh"])(
@@ -2252,7 +2265,7 @@ describe("executeNodeHostCommand", () => {
 
     expect(result.details?.status).toBe("completed");
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
-    expectSystemRunInvoke({ invokeTimeoutMs: 35_000, runTimeoutMs: 30_000 });
+    expectSystemRunInvoke({ invokeDeadlineMs: 35_000, invokeWaitMs: 40_000, runTimeoutMs: 30_000 });
   });
 
   it("requests human approval when node auto-review asks on an approval miss", async () => {
@@ -3562,7 +3575,8 @@ describe("executeNodeHostCommand", () => {
 
     expect(callGatewayToolMock).toHaveBeenCalledTimes(1);
     const call = requireGatewayCall(0);
-    expect(call.options.timeoutMs).toBe(35_000);
+    expect(call.options.timeoutMs).toBe(40_000);
+    expect(call.params?.timeoutMs).toBe(35_000);
     const runParams = requireRunParams(call);
     expect(runParams.command).toEqual(["/bin/sh", "-lc", "bun ./script.ts"]);
     expect(runParams.rawCommand).toBe("bun ./script.ts");
@@ -3676,7 +3690,7 @@ describe("executeNodeHostCommand", () => {
       }),
     );
 
-    expectSystemRunInvoke({ invokeTimeoutMs: 17_000, runTimeoutMs: 12_000 });
+    expectSystemRunInvoke({ invokeDeadlineMs: 17_000, invokeWaitMs: 22_000, runTimeoutMs: 12_000 });
   });
 
   it("normalizes unsafe explicit timeouts before invoking node system.run", async () => {
@@ -3686,7 +3700,7 @@ describe("executeNodeHostCommand", () => {
       }),
     );
 
-    expectSystemRunInvoke({ invokeTimeoutMs: 35_000, runTimeoutMs: 30_000 });
+    expectSystemRunInvoke({ invokeDeadlineMs: 35_000, invokeWaitMs: 40_000, runTimeoutMs: 30_000 });
 
     callGatewayToolMock.mockClear();
 
@@ -3697,7 +3711,8 @@ describe("executeNodeHostCommand", () => {
     );
 
     expectSystemRunInvoke({
-      invokeTimeoutMs: MAX_SAFE_TIMEOUT_DELAY_MS,
+      invokeDeadlineMs: MAX_SAFE_TIMEOUT_DELAY_MS,
+      invokeWaitMs: MAX_SAFE_TIMEOUT_DELAY_MS,
       runTimeoutMs: MAX_SAFE_TIMEOUT_DELAY_MS,
     });
 
@@ -3710,7 +3725,8 @@ describe("executeNodeHostCommand", () => {
     );
 
     expectSystemRunInvoke({
-      invokeTimeoutMs: MAX_SAFE_TIMEOUT_DELAY_MS,
+      invokeDeadlineMs: MAX_SAFE_TIMEOUT_DELAY_MS,
+      invokeWaitMs: MAX_SAFE_TIMEOUT_DELAY_MS,
       runTimeoutMs: MAX_SAFE_TIMEOUT_DELAY_MS,
     });
   });
@@ -3722,7 +3738,54 @@ describe("executeNodeHostCommand", () => {
       }),
     );
 
-    expectSystemRunInvoke({ invokeTimeoutMs: 35_000, runTimeoutMs: 0 });
+    expectSystemRunInvoke({ invokeDeadlineMs: 35_000, invokeWaitMs: 40_000, runTimeoutMs: 0 });
+    const call = requireGatewayCommand("system.run");
+    // Zero means "no program-runtime timer" on the node and must never be
+    // rewritten into a finite process timeout, but the Gateway deadline and the
+    // caller wait still have to stay positive and finite.
+    expect(requireRunParams(call).timeoutMs).toBe(0);
+    expect(call.params?.timeoutMs).toBeGreaterThan(0);
+    expect(Number.isFinite(call.params?.timeoutMs)).toBe(true);
+  });
+
+  it("arms the gateway invocation deadline for a budget longer than the 30s registry fallback", async () => {
+    await executeNodeHostCommand(
+      createNodeHostRequest({
+        timeoutSec: 120,
+      }),
+    );
+
+    // A 120s program budget must not be cut short by the registry's fixed 30s
+    // pending-invoke fallback in resolveTimerTimeoutMs(params.timeoutMs, 30_000, 0).
+    expectSystemRunInvoke({
+      invokeDeadlineMs: 125_000,
+      invokeWaitMs: 130_000,
+      runTimeoutMs: 120_000,
+    });
+  });
+
+  it("leaves system.run.prepare without a gateway invocation deadline", async () => {
+    mockGatewayInvokesWithNodeApprovals({ version: 1, agents: {} });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "on-miss",
+      askFallback: "deny",
+    });
+
+    await executeNodeHostCommand(
+      createNodeHostRequest({
+        security: "allowlist",
+        ask: "on-miss",
+        timeoutSec: 120,
+      }),
+    ).catch(() => undefined);
+
+    // The short prepare round-trip keeps the registry default; only the actual
+    // system.run dispatch carries the command budget.
+    const prepare = requireGatewayCommand("system.run.prepare");
+    expect(prepare.params?.timeoutMs).toBeUndefined();
+    expect(prepare.options.timeoutMs).toBe(15_000);
   });
 
   it("allows exec when requestedNode is display name matching boundNode's device", async () => {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -570,7 +570,7 @@ export async function executeNodeHostCommand(
             nodeInvocationStarted = true;
             const raw = await callGatewayTool(
               "node.invoke",
-              { timeoutMs: target.invokeTimeoutMs },
+              { timeoutMs: target.invokeWaitMs },
               buildNodeSystemRunInvoke({
                 target,
                 command: prepared.argv,
@@ -693,15 +693,15 @@ export async function executeNodeHostCommand(
   params.signal?.throwIfAborted();
   const raw =
     (inlineApprovedByAsk || inlineApprovalSource) && inlineApprovalId
-      ? await callGatewayTool("node.invoke", { timeoutMs: target.invokeTimeoutMs }, invoke, {
+      ? await callGatewayTool("node.invoke", { timeoutMs: target.invokeWaitMs }, invoke, {
           scopes: APPROVED_NODE_INVOKE_SCOPES,
           ...(params.signal ? { signal: params.signal } : {}),
         })
       : params.signal
-        ? await callGatewayTool("node.invoke", { timeoutMs: target.invokeTimeoutMs }, invoke, {
+        ? await callGatewayTool("node.invoke", { timeoutMs: target.invokeWaitMs }, invoke, {
             signal: params.signal,
           })
-        : await callGatewayTool("node.invoke", { timeoutMs: target.invokeTimeoutMs }, invoke);
+        : await callGatewayTool("node.invoke", { timeoutMs: target.invokeWaitMs }, invoke);
   return formatNodeRunToolResult({
     raw,
     startedAt,


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #115248. That PR landed the Gateway-side invocation deadline machinery (`awaitNodeInvokeWithinDeadline`, `NODE_INVOKE_DEADLINE_EXPIRED`, typed dispatch provenance), but the `exec host=node` path never arms it.

`buildNodeSystemRunInvoke()` emits `nodeId` / `command` / `params` / `idempotencyKey` and puts the command budget only in nested `params.timeoutMs`. There is no top-level `timeoutMs`, which is exactly what `src/gateway/server-methods/nodes.invoke.ts` reads to derive `invokeDeadlineAtMs`:

```ts
const invokeDeadlineAtMs =
  typeof p.timeoutMs === "number" && p.timeoutMs > 0 ? Date.now() + p.timeoutMs : undefined;
```

With it undefined, `src/gateway/node-registry.ts` falls back to a fixed timer:

```ts
const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 30_000, 0);
```

So every `exec host=node` invocation gets a 30s Gateway deadline no matter what the caller asked for. The pending invoke is deleted at 30s, and the node's later success is acknowledged and thrown away as `{ ok: true, ignored: true }` in `nodes.handlers.invoke-result.ts`.

The longer budget was only ever used as the *caller's* websocket wait (`callGatewayTool("node.invoke", { timeoutMs: target.invokeTimeoutMs }, invoke)`), which does not control the server-side registry deadline.

### Repro

An approval-required `exec host=node` command that runs a bit over 30s:

- **Before:** the command completes successfully on the paired node, but the Gateway already dropped the pending invoke at 30s. The result arrives, is logged as `ignored`, and the caller never receives a terminal outcome.
- **After:** the Gateway deadline matches the command budget (35s for a 30s program budget, 125s for a 120s one), the pending invoke is still registered when the node answers, and the result is delivered normally.

Approval wall-clock makes this worse: the 30s registry timer starts at dispatch, so an approval that takes 20s leaves 10s of usable runtime.

## Why This Change Was Made

Serialize the resolved invocation deadline as a **top-level** `timeoutMs` on the `node.invoke` payload, so the existing machinery is armed instead of dormant. This is the same top-level shape `src/cli/nodes-cli/register.location.ts` already uses.

Three ordered budgets, all derived in `resolveNodeExecutionTarget` from values that already exist — no new config knob, no new constants:

| Budget | Meaning | Value |
| --- | --- | --- |
| program runtime | node-side process timer | nested `params.timeoutMs` (unchanged) |
| gateway deadline | `invokeDeadlineAtMs` | `runtime + 5s` transport grace (the existing helper, just renamed) |
| caller wait | websocket wait | `deadline + 5s` (same grace convention) |

`runtime < deadline < caller wait` holds for every finite positive budget, so the Gateway's deadline-expiry answer wins the race rather than the caller giving up first. Both upper budgets saturate together at `MAX_SAFE_TIMEOUT_DELAY_MS`, where the ordering degenerates by design.

`timeout: 0` semantics are preserved exactly: the nested value stays `0` (no program-runtime timer on the node) and is never rewritten to a default or a finite process timeout, while the deadline and caller wait fall back to the default budget so neither the Gateway nor the caller can hang forever.

The `NodeExecutionTarget.invokeTimeoutMs` field is split into `invokeDeadlineMs` and `invokeWaitMs` so the two are not confusable at the call sites.

## User Impact

`exec host=node` commands with a budget longer than 30s now complete instead of silently producing no terminal outcome. Shorter commands are unaffected apart from a 5s longer caller-side wait. No config surface, no new flags, no behavior change for `system.run.prepare` (still a 15s round-trip with no deadline) or for any non-exec node path.

## Evidence

`src/agents/bash-tools.exec-host-node.test.ts` previously asserted only the caller option and the nested `params.timeoutMs`, which is precisely why this gap went uncovered. `expectSystemRunInvoke` now asserts the top-level payload value too and checks the budget ordering. New/extended coverage:

- direct invoke, default budget: `30_000 / 35_000 / 40_000`
- explicit `timeoutSec: 12`: `12_000 / 17_000 / 22_000`
- **new** `timeoutSec: 120` regression test — proves the budget is not clipped to the 30s registry fallback
- `timeout: 0` — nested stays `0`; deadline and caller wait stay positive and finite
- oversized budgets clamp to `MAX_SAFE_TIMEOUT_DELAY_MS` without producing a zero/undefined deadline
- approved continuation dispatch and inline/prepared dispatch both carry the top-level deadline
- **new** `system.run.prepare` test pins that the short prepare round-trip gains no deadline

Reverting only the payload line fails 9 tests in this suite, so the coverage is real rather than tautological.

```
node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-node.test.ts \
  src/agents/bash-tools.exec-host-node.cancellation.test.ts \
  src/agents/bash-tools.exec-host-node-phases.cancellation.test.ts
# Test Files 3 passed (3) | Tests 86 passed (86)
```

`tsgo --noEmit` reports no errors in the touched files; remaining output is pre-existing and unrelated (`openai-transport-stream.test-support.ts`, `ui/src/e2e/*`). `oxfmt` clean.

### Runtime behavior proof (before/after)

Test assertions alone only prove the payload shape, so this drives the **real `NodeRegistry`** with a fake node connection over a 120s budget, where the node finishes at **35s** — past the registry's 30s fallback, well inside the requested budget. Run in a Crabbox lease against a fresh remote checkout of this PR's head (provider `local-container`, `node:24-bookworm`; lease `cbx_90564ed15345`, run `run_30359597aed5`, exit 0).

**Before** — no top-level `timeoutMs`:

```json
{
  "armedTimeoutMs": 30000,
  "resultAccepted": false,
  "gatewayAckToNode": { "ok": true, "ignored": true },
  "callerResult": { "ok": false, "error": { "code": "TIMEOUT", "message": "node invoke timed out" } }
}
```

The registry arms 30s instead of the requested 125s, deletes the pending invoke, and `handleInvokeResult()` returns `false` for the node's success at 35s — which `nodes.handlers.invoke-result.ts` acknowledges as `{ ok: true, ignored: true }`. The command really did succeed on the node; the caller is told it timed out.

**After** — deadline serialized on the payload:

```json
{
  "armedTimeoutMs": 125000,
  "resultAccepted": true,
  "gatewayAckToNode": { "ok": true },
  "callerResult": { "ok": true, "payload": { "exitCode": 0, "aggregated": "done" } }
}
```

The pending invoke is still registered at 35s and the node's result reaches the caller.

Same-checkout suite contrast, where the revert phase deletes exactly one line (`timeoutMs: params.target.invokeDeadlineMs,`):

```
CRABBOX_PHASE:gateway-deadline-proof   20.2s   2 passed
CRABBOX_PHASE:payload-shape-after       0.1s   payload emits top-level timeoutMs: true
CRABBOX_PHASE:tests-after              12.2s   86 passed (3 files)
CRABBOX_PHASE:revert-payload-line       0.0s   reverted the single payload line
CRABBOX_PHASE:tests-before              9.9s   9 failed | 70 passed
```

### Physical paired-node proof (macOS)

Verified end to end on exact PR head `809a73433fbd7acf4da437e69f1c6aeb9f04a9a0` using a fresh build of that revision. The Gateway and node host ran as separate processes with separate state directories and separate signed device identities. No shared Gateway token or password was supplied.

The isolated Gateway used loopback `gateway.auth.mode=none`. In that supported no-shared-secret configuration, first-time physical device identity pairing was **silently auto-approved** by the Gateway (`approvedVia: silent`); it was not manually approved. SSH verification was disabled. The distinct node command-surface pairing request was then manually approved. Final status reported:

```json
{
  "displayName": "ProofNode-116591-809a7343",
  "version": "2026.7.2",
  "approvalState": "approved",
  "paired": true,
  "connected": true,
  "commands": ["system.run"]
}
```

The real `executeNodeHostCommand` caller then dispatched unique 35-second `system.run` commands through that paired node:

| Case | nested node runtime | Gateway invocation deadline | caller wait | elapsed | terminal result |
| --- | ---: | ---: | ---: | ---: | --- |
| `timeoutSec: 45` | 45,000ms | 50,000ms | 55,000ms | 35,347ms | completed; unique marker delivered exactly once |
| `timeoutSec: 0` | `0` (unbounded node process timer) | 50,000ms | 55,000ms | 35,062ms | completed; unique marker delivered exactly once |

Gateway transport timing independently confirms that both results crossed the old 30-second boundary and reached the originating caller:

```text
bounded:  [ws] res ✓ node.invoke 35044ms at 18:31:40.766Z
timeout:0 [ws] res ✓ node.invoke 35026ms at 18:32:15.831Z
```

There was no timeout or ignored result in either PR-head run. This also directly verifies that `timeout: 0` preserves nested `params.timeoutMs: 0` while still arming finite Gateway and caller budgets.

For contrast, current `main` at `a1c689e375ec9daf1b6522e8a0aee1ff9805c1fe` ran the same separate-node 35-second path and returned `TIMEOUT: node invoke timed out` after **30,004ms**; the unique completion marker never reached the caller. That control was canceled at timeout, so it did not emit a later ignored-result log line.

### Rebased on current `main`

Branch refreshed onto `fd343ca8cc95` and the focused suites re-run on exact head `809a73433fbd`: 3 files, 87 passed. Core production and test type checks, targeted Oxlint/Oxfmt, Knip unused-export scans, `git diff --check`, `pnpm build`, and fresh structured autoreview all passed. The delegated changed-check failed before execution during Daytona sync prune, so the same repository-planned gates ran through the documented trusted-source local fallback.

## Out of scope

No typed unknown-execution outcome or `failureKind` enum; no stricter timeout validation (rejecting null/negative/sub-millisecond/oversized values is a separate compatibility-affecting change); no `gateway.nodes.invokeTimeoutMs` style config knob; no changes to `src/agents/tools/nodes-tool.ts`.

`system.run.prepare` is intentionally excluded because it is a short, non-execution preflight and retains its existing 15s caller wait / registry-default behavior; aligning prepare deadlines is separate follow-up scope.
