### PR TITLE
fix(cli): keep Gateway auth failures parseable in JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway CLI JSON auth errors:** keep `health`, `gateway health`, and `gateway call` credential failures as parseable JSON with a nonzero exit instead of empty stdout or prose stderr.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway CLI JSON auth errors:** keep `health`, `gateway health`, and `gateway call` credential failures as parseable JSON with a nonzero exit instead of empty stdout or prose stderr.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.
 - **Linux gateway service ownership:** refuse user-scope systemd publication and activation when the same gateway unit name is already owned or cannot be verified in the system scope, including `--force`, with actionable recovery guidance instead of creating restart-looping dual managers. Fixes #116129.
 - **macOS remote tunnel lifecycle:** prevent cancelled or superseded restart backoffs from recreating SSH tunnels, and join a tunnel create that another caller started while the actor was suspended.

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -1,10 +1,11 @@
 // Process coverage for one-shot Gateway CLI output followed by clean exit.
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs/promises";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import { WebSocketServer } from "ws";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -15,8 +16,10 @@ import {
   sendMinimalGatewayConnectChallenge,
   sendMinimalGatewayResponse,
 } from "../gateway/minimal-gateway.test-helpers.js";
+import { getFreePort } from "../test-utils/ports.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const execFileAsync = promisify(execFile);
 const activeChildren = new Set<ChildProcessWithoutNullStreams>();
 const activeServers = new Set<WebSocketServer>();
 
@@ -73,6 +76,67 @@ async function startCronListGateway(token: string): Promise<{ url: string }> {
   await once(wss, "listening");
   const address = wss.address() as AddressInfo;
   return { url: `ws://127.0.0.1:${address.port}` };
+}
+
+async function runIsolatedGatewayCli(params: {
+  args: string[];
+  root: string;
+  stateDir: string;
+  configPath: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}> {
+  try {
+    const result = await execFileAsync(
+      process.execPath,
+      ["--import", "tsx", "src/entry.ts", ...params.args],
+      {
+        cwd: path.resolve("."),
+        env: {
+          ...process.env,
+          HOME: params.root,
+          USERPROFILE: params.root,
+          NODE_DISABLE_COMPILE_CACHE: "1",
+          NODE_ENV: undefined,
+          NODE_OPTIONS: undefined,
+          OPENCLAW_CONFIG_PATH: params.configPath,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_GATEWAY_PASSWORD: undefined,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_GATEWAY_URL: undefined,
+          OPENCLAW_HOME: params.root,
+          OPENCLAW_NO_RESPAWN: "1",
+          OPENCLAW_STATE_DIR: params.stateDir,
+          VITEST: undefined,
+          ...params.env,
+        },
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        timeout: 20_000,
+      },
+    );
+    return { code: 0, signal: null, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    const failure = error as Error & {
+      code?: number | string;
+      signal?: NodeJS.Signals;
+      stdout?: string;
+      stderr?: string;
+    };
+    if (typeof failure.code !== "number") {
+      throw error;
+    }
+    return {
+      code: failure.code,
+      signal: failure.signal ?? null,
+      stdout: failure.stdout ?? "",
+      stderr: failure.stderr ?? "",
+    };
+  }
 }
 
 describe("gateway-backed CLI process exit", () => {
@@ -162,4 +226,76 @@ describe("gateway-backed CLI process exit", () => {
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toMatchObject({ jobs: [], total: 0 });
   }, 20_000);
+
+  it("keeps gateway auth failures machine-readable across CLI entry points", async () => {
+    const root = tempDirs.make("openclaw-gateway-auth-json-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const port = await getFreePort();
+    await fs.mkdir(stateDir, { recursive: true });
+
+    const cases: Array<{ label: string; args: string[]; env?: NodeJS.ProcessEnv }> = [
+      { label: "health", args: ["health", "--json", "--timeout", "250"] },
+      {
+        label: "health explicit URL",
+        args: ["health", "--json", "--timeout", "250"],
+        env: { OPENCLAW_GATEWAY_URL: `ws://127.0.0.1:${port}` },
+      },
+      {
+        label: "gateway health",
+        args: ["gateway", "health", "--json", "--port", String(port), "--timeout", "250"],
+      },
+      {
+        label: "gateway call",
+        args: ["gateway", "call", "health", "--json", "--timeout", "250"],
+      },
+    ];
+    for (const testCase of cases) {
+      const result = await runIsolatedGatewayCli({
+        args: testCase.args,
+        root,
+        stateDir,
+        configPath,
+        env: { OPENCLAW_GATEWAY_PORT: String(port), ...testCase.env },
+      });
+      expect(result, `${testCase.label}: ${result.stderr}`).toMatchObject({
+        code: 1,
+        signal: null,
+        stderr: "",
+      });
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        ok: false,
+        error: {
+          type: "gateway_credentials_required",
+          message: expect.stringContaining("requires"),
+        },
+      });
+    }
+  }, 60_000);
+
+  it("preserves authenticated unreachable failures as transport errors", async () => {
+    const root = tempDirs.make("openclaw-gateway-transport-json-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const port = await getFreePort();
+    await fs.mkdir(stateDir, { recursive: true });
+
+    const result = await runIsolatedGatewayCli({
+      args: ["health", "--json", "--timeout", "250"],
+      root,
+      stateDir,
+      configPath,
+      env: {
+        OPENCLAW_GATEWAY_PORT: String(port),
+        OPENCLAW_GATEWAY_TOKEN: "test-token",
+      },
+    });
+
+    expect(result, result.stderr).toMatchObject({ code: 1, signal: null, stderr: "" });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      error: { type: "gateway_transport_error" },
+      gateway: { url: `ws://127.0.0.1:${port}` },
+    });
+  }, 30_000);
 });

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -15,6 +15,7 @@ type DiscoveredBeacon = Awaited<
 >[number];
 const defaultCallGateway = async (): Promise<unknown> => ({ ok: true });
 const callGateway = vi.fn<(opts: unknown) => Promise<unknown>>(defaultCallGateway);
+const formatGatewayAuthErrorJson = vi.fn();
 const formatGatewayClientRequestErrorJson = vi.fn();
 const formatGatewayTransportErrorJson = vi.fn();
 const startGatewayServer = vi.fn<
@@ -58,6 +59,7 @@ vi.mock(
       url: "ws://127.0.0.1:18789",
     }),
     callGateway: (opts: unknown) => callGateway(opts),
+    formatGatewayAuthErrorJson: (error: unknown) => formatGatewayAuthErrorJson(error),
     formatGatewayClientRequestErrorJson: (error: unknown) =>
       formatGatewayClientRequestErrorJson(error),
     formatGatewayTransportErrorJson: (error: unknown) => formatGatewayTransportErrorJson(error),
@@ -170,6 +172,8 @@ describe("gateway-cli coverage", () => {
     startGatewayServer.mockClear();
     inspectPortUsage.mockClear();
     formatPortDiagnostics.mockClear();
+    formatGatewayAuthErrorJson.mockReset();
+    formatGatewayAuthErrorJson.mockReturnValue(null);
     formatGatewayClientRequestErrorJson.mockReset();
     formatGatewayClientRequestErrorJson.mockReturnValue(null);
     formatGatewayTransportErrorJson.mockReset();
@@ -433,6 +437,27 @@ describe("gateway-cli coverage", () => {
     expect(formatGatewayClientRequestErrorJson).toHaveBeenCalledWith(error);
     expect(defaultRuntime.writeJson).toHaveBeenCalledWith(payload);
     expect(runtimeErrors.join("\n")).not.toContain("unauthorized role");
+  });
+
+  it("writes JSON for gateway call auth failures in JSON mode", async () => {
+    const error = new Error("gateway health requires credentials");
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_credentials_required",
+        message: "gateway health requires credentials",
+      },
+    };
+    callGateway.mockRejectedValueOnce(error);
+    formatGatewayAuthErrorJson.mockReturnValueOnce(payload);
+
+    await expectGatewayExit(["gateway", "call", "health", "--json"]);
+
+    expect(formatGatewayAuthErrorJson).toHaveBeenCalledWith(error);
+    expect(formatGatewayClientRequestErrorJson).not.toHaveBeenCalled();
+    expect(formatGatewayTransportErrorJson).not.toHaveBeenCalled();
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(payload);
+    expect(runtimeErrors.join("\n")).not.toContain("gateway health requires credentials");
   });
 
   it("prints the latest stability bundle without calling Gateway", async () => {

--- a/src/cli/gateway-cli/health-route.test.ts
+++ b/src/cli/gateway-cli/health-route.test.ts
@@ -18,6 +18,7 @@ describe("runGatewayHealthJsonRoute", () => {
     const callGateway = vi.fn(async () => ({ ok: true, durationMs: 6 }));
     const readBestEffortConfig = vi.fn(async () => ({}));
     const emitReachableGatewayAuthDiagnostic = vi.fn(async () => false);
+    const formatGatewayAuthErrorJson = vi.fn();
     const formatGatewayClientRequestErrorJson = vi.fn();
     const formatGatewayTransportErrorJson = vi.fn();
 
@@ -30,6 +31,7 @@ describe("runGatewayHealthJsonRoute", () => {
         callGateway,
         readBestEffortConfig,
         emitReachableGatewayAuthDiagnostic: emitReachableGatewayAuthDiagnostic as never,
+        formatGatewayAuthErrorJson: formatGatewayAuthErrorJson as never,
         formatGatewayClientRequestErrorJson: formatGatewayClientRequestErrorJson as never,
         formatGatewayTransportErrorJson: formatGatewayTransportErrorJson as never,
       },
@@ -39,6 +41,7 @@ describe("runGatewayHealthJsonRoute", () => {
     expect(runtime.writeJson).toHaveBeenCalledWith({ ok: true, durationMs: 6 }, 2);
     expect(readBestEffortConfig).not.toHaveBeenCalled();
     expect(emitReachableGatewayAuthDiagnostic).not.toHaveBeenCalled();
+    expect(formatGatewayAuthErrorJson).not.toHaveBeenCalled();
     expect(formatGatewayClientRequestErrorJson).not.toHaveBeenCalled();
     expect(formatGatewayTransportErrorJson).not.toHaveBeenCalled();
   });
@@ -107,10 +110,44 @@ describe("runGatewayHealthJsonRoute", () => {
       callGateway,
       readBestEffortConfig: async () => ({}),
       emitReachableGatewayAuthDiagnostic: vi.fn(async () => false) as never,
+      formatGatewayAuthErrorJson: vi.fn(() => null) as never,
       formatGatewayClientRequestErrorJson: vi.fn(() => null) as never,
       formatGatewayTransportErrorJson: vi.fn(() => payload) as never,
     });
 
+    expect(runtime.writeJson).toHaveBeenCalledWith(payload, 2);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("preserves structured auth errors when reachability is unknown", async () => {
+    const runtime = createRuntime();
+    const error = new Error("gateway health requires credentials");
+    const callGateway = vi.fn(async () => {
+      throw error;
+    });
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_credentials_required",
+        message: "gateway health requires credentials",
+      },
+    };
+    const formatGatewayAuthErrorJson = vi.fn(() => payload);
+    const formatGatewayClientRequestErrorJson = vi.fn(() => null);
+    const formatGatewayTransportErrorJson = vi.fn(() => null);
+
+    await runGatewayHealthJsonRoute({ rpc: { json: true, timeout: "10000" } }, runtime as never, {
+      callGateway,
+      readBestEffortConfig: async () => ({}),
+      emitReachableGatewayAuthDiagnostic: vi.fn(async () => false) as never,
+      formatGatewayAuthErrorJson: formatGatewayAuthErrorJson as never,
+      formatGatewayClientRequestErrorJson: formatGatewayClientRequestErrorJson as never,
+      formatGatewayTransportErrorJson: formatGatewayTransportErrorJson as never,
+    });
+
+    expect(formatGatewayAuthErrorJson).toHaveBeenCalledWith(error);
+    expect(formatGatewayClientRequestErrorJson).not.toHaveBeenCalled();
+    expect(formatGatewayTransportErrorJson).not.toHaveBeenCalled();
     expect(runtime.writeJson).toHaveBeenCalledWith(payload, 2);
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });

--- a/src/cli/gateway-cli/health-route.ts
+++ b/src/cli/gateway-cli/health-route.ts
@@ -12,6 +12,7 @@ type GatewayHealthRouteDependencies = {
   callGateway?: typeof import("./call.js").callGatewayCli;
   readBestEffortConfig?: () => Promise<OpenClawConfig>;
   emitReachableGatewayAuthDiagnostic?: typeof import("../../commands/health.js").emitReachableGatewayAuthDiagnostic;
+  formatGatewayAuthErrorJson?: typeof import("../../gateway/call.js").formatGatewayAuthErrorJson;
   formatGatewayClientRequestErrorJson?: typeof import("../../gateway/call.js").formatGatewayClientRequestErrorJson;
   formatGatewayTransportErrorJson?: typeof import("../../gateway/call.js").formatGatewayTransportErrorJson;
 };
@@ -63,7 +64,9 @@ export async function runGatewayHealthJsonRoute(
       deps.readBestEffortConfig
         ? undefined
         : import("../../config/read-best-effort-config.runtime.js"),
-      deps.formatGatewayClientRequestErrorJson && deps.formatGatewayTransportErrorJson
+      deps.formatGatewayAuthErrorJson &&
+      deps.formatGatewayClientRequestErrorJson &&
+      deps.formatGatewayTransportErrorJson
         ? undefined
         : import("../../gateway/call.js"),
     ]);
@@ -86,12 +89,16 @@ export async function runGatewayHealthJsonRoute(
     if (handled) {
       return;
     }
+    const formatGatewayAuthErrorJson =
+      deps.formatGatewayAuthErrorJson ?? callModule?.formatGatewayAuthErrorJson;
     const formatGatewayClientRequestErrorJson =
       deps.formatGatewayClientRequestErrorJson ?? callModule?.formatGatewayClientRequestErrorJson;
     const formatGatewayTransportErrorJson =
       deps.formatGatewayTransportErrorJson ?? callModule?.formatGatewayTransportErrorJson;
     const payload =
-      formatGatewayClientRequestErrorJson?.(error) ?? formatGatewayTransportErrorJson?.(error);
+      formatGatewayAuthErrorJson?.(error) ??
+      formatGatewayClientRequestErrorJson?.(error) ??
+      formatGatewayTransportErrorJson?.(error);
     if (payload) {
       writeRuntimeJson(runtime, payload);
       runtime.exit(1);

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -191,10 +191,15 @@ async function runGatewayCommand(
     await action();
   } catch (err) {
     if (opts?.json) {
-      const { formatGatewayClientRequestErrorJson, formatGatewayTransportErrorJson } =
-        await import("../../gateway/call.js");
+      const {
+        formatGatewayAuthErrorJson,
+        formatGatewayClientRequestErrorJson,
+        formatGatewayTransportErrorJson,
+      } = await import("../../gateway/call.js");
       const payload =
-        formatGatewayClientRequestErrorJson(err) ?? formatGatewayTransportErrorJson(err);
+        formatGatewayAuthErrorJson(err) ??
+        formatGatewayClientRequestErrorJson(err) ??
+        formatGatewayTransportErrorJson(err);
       if (payload) {
         defaultRuntime.writeJson(payload);
         defaultRuntime.exit(1);

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -80,6 +80,7 @@ const buildGatewayProbeConnectionDetailsMock = vi.fn(() => ({
   tlsFingerprint: TEST_TLS_FINGERPRINT,
   url: TEST_GATEWAY_URL,
 }));
+const formatGatewayAuthErrorJsonMock = vi.fn();
 const formatGatewayTransportErrorJsonMock = vi.fn();
 const probeGatewayStatusMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
@@ -88,6 +89,7 @@ vi.mock("../gateway/call.js", () => ({
     Reflect.apply(buildGatewayConnectionDetailsMock, undefined, args),
   buildGatewayProbeConnectionDetails: (...args: [unknown, ...unknown[]]) =>
     Reflect.apply(buildGatewayProbeConnectionDetailsMock, undefined, args),
+  formatGatewayAuthErrorJson: (...args: unknown[]) => formatGatewayAuthErrorJsonMock(...args),
   formatGatewayTransportErrorJson: (...args: unknown[]) =>
     formatGatewayTransportErrorJsonMock(...args),
   isGatewayCredentialsRequiredError: (value: unknown) =>
@@ -144,6 +146,8 @@ describe("healthCommand", () => {
       tlsFingerprint: TEST_TLS_FINGERPRINT,
       url: TEST_GATEWAY_URL,
     });
+    formatGatewayAuthErrorJsonMock.mockReset();
+    formatGatewayAuthErrorJsonMock.mockReturnValue(null);
     formatGatewayTransportErrorJsonMock.mockReturnValue(null);
     isGatewayCredentialsRequiredErrorMock.mockReturnValue(false);
     isGatewaySecretRefUnavailableErrorMock.mockReturnValue(false);
@@ -423,6 +427,53 @@ describe("healthCommand", () => {
       }
     },
   );
+
+  it("keeps credential failures machine-readable when the gateway is unreachable", async () => {
+    const error = new Error("gateway health requires credentials");
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_credentials_required",
+        message: "gateway health requires credentials",
+      },
+    };
+    callGatewayMock.mockRejectedValueOnce(error);
+    isGatewayCredentialsRequiredErrorMock.mockReturnValue(true);
+    probeGatewayStatusMock.mockResolvedValueOnce({
+      ok: false,
+      kind: "connect",
+      error: "connect ECONNREFUSED 127.0.0.1:18789",
+    });
+    formatGatewayAuthErrorJsonMock.mockReturnValueOnce(payload);
+
+    await healthCommand({ json: true, timeoutMs: 5000, config: {} }, runtime as never);
+
+    expect(formatGatewayAuthErrorJsonMock).toHaveBeenCalledWith(error);
+    expect(formatGatewayTransportErrorJsonMock).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(JSON.parse(requireFirstRuntimeLog())).toEqual(payload);
+  });
+
+  it("keeps explicit URL auth failures machine-readable", async () => {
+    const error = new Error("gateway url override requires explicit credentials");
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_credentials_required",
+        message: "gateway url override requires explicit credentials",
+      },
+    };
+    callGatewayMock.mockRejectedValueOnce(error);
+    formatGatewayAuthErrorJsonMock.mockReturnValueOnce(payload);
+
+    await healthCommand({ json: true, timeoutMs: 5000, config: {} }, runtime as never);
+
+    expect(probeGatewayStatusMock).not.toHaveBeenCalled();
+    expect(formatGatewayAuthErrorJsonMock).toHaveBeenCalledWith(error);
+    expect(formatGatewayTransportErrorJsonMock).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(JSON.parse(requireFirstRuntimeLog())).toEqual(payload);
+  });
 
   it("reports reachable gateway diagnostics when configured auth SecretRefs are unavailable", async () => {
     const error = new Error("gateway.auth.password is unavailable");

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -12,6 +12,7 @@ import {
   buildGatewayConnectionDetails,
   buildGatewayProbeConnectionDetails,
   callGateway,
+  formatGatewayAuthErrorJson,
   formatGatewayTransportErrorJson,
   isGatewayCredentialsRequiredError,
 } from "../gateway/call.js";
@@ -240,11 +241,8 @@ export async function healthCommand(
     ) {
       return;
     }
-    if (isGatewayHealthAuthUnavailableError(error)) {
-      throw error;
-    }
     if (opts.json) {
-      const payload = formatGatewayTransportErrorJson(error);
+      const payload = formatGatewayAuthErrorJson(error) ?? formatGatewayTransportErrorJson(error);
       if (payload) {
         writeRuntimeJson(runtime, payload);
         runtime.exit(1);

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -209,10 +209,14 @@ const {
   buildGatewayProbeConnectionDetails,
   callGateway,
   callGatewayCli,
+  formatGatewayAuthErrorJson,
   formatGatewayClientRequestErrorJson,
   formatGatewayTransportErrorJson,
+  GatewayCredentialsRequiredError,
+  GatewayExplicitAuthRequiredError,
   isGatewayTransportError,
 } = await import("./call.js");
+const { GatewaySecretRefUnavailableError } = await import("./credentials.js");
 
 class StubGatewayClient {
   constructor(opts: {
@@ -1801,6 +1805,39 @@ describe("callGateway error details", () => {
         }),
       ),
     ).toBeNull();
+  });
+
+  it.each([
+    [
+      "configured credentials",
+      new GatewayCredentialsRequiredError({
+        method: "health",
+        configPath: "/tmp/openclaw.json",
+      }),
+      "gateway health requires credentials before opening a websocket",
+    ],
+    [
+      "explicit URL credentials",
+      new GatewayExplicitAuthRequiredError("gateway url override requires explicit credentials"),
+      "gateway url override requires explicit credentials",
+    ],
+    [
+      "unavailable SecretRef credentials",
+      new GatewaySecretRefUnavailableError("gateway.auth.token"),
+      "gateway.auth.token is configured as a secret reference but is unavailable",
+    ],
+  ])("formats %s as the shipped auth error envelope", (_label, error, message) => {
+    expect(formatGatewayAuthErrorJson(error)).toEqual({
+      ok: false,
+      error: {
+        type: "gateway_credentials_required",
+        message: expect.stringContaining(message),
+      },
+    });
+  });
+
+  it("does not turn unrelated failures into gateway auth errors", () => {
+    expect(formatGatewayAuthErrorJson(new Error("config unavailable"))).toBeNull();
   });
 
   it("charges event-loop readiness against the wrapper timeout", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -49,6 +49,7 @@ import {
 } from "./connection-details.js";
 import { resolveGatewayCredentialsWithSecretInputs } from "./credentials-secret-inputs.js";
 import {
+  isGatewaySecretRefUnavailableError,
   trimToUndefined,
   type ExplicitGatewayAuth,
   type GatewayCredentialMode,
@@ -224,6 +225,14 @@ export type GatewayClientRequestErrorJson = {
   };
 };
 
+export type GatewayAuthErrorJson = {
+  ok: false;
+  error: {
+    type: "gateway_credentials_required";
+    message: string;
+  };
+};
+
 export type GatewayProbeConnectionDetails = GatewayConnectionDetails & {
   tlsFingerprint?: string;
   preauthHandshakeTimeoutMs?: number;
@@ -295,6 +304,24 @@ export function formatGatewayClientRequestErrorJson(
       ...(requestError.retryAfterMs !== undefined
         ? { retryAfterMs: requestError.retryAfterMs }
         : {}),
+    },
+  };
+}
+
+/** Preserve machine-readable output for auth failures raised before transport startup. */
+export function formatGatewayAuthErrorJson(value: unknown): GatewayAuthErrorJson | null {
+  if (
+    !isGatewayCredentialsRequiredError(value) &&
+    !isGatewayExplicitAuthRequiredError(value) &&
+    !isGatewaySecretRefUnavailableError(value)
+  ) {
+    return null;
+  }
+  return {
+    ok: false,
+    error: {
+      type: "gateway_credentials_required",
+      message: value.message,
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway-backed CLI commands requested in JSON mode could fail before transport startup with empty stdout or prose stderr when credentials were missing or unavailable. Automation calling `health`, routed `gateway health`, or `gateway call` could not reliably parse the failure.

## Why This Change Was Made

A shared Gateway auth-error formatter now maps only the recognized pre-transport credential failures into the existing `gateway_credentials_required` JSON envelope. All three CLI entry points apply it before request/transport formatters, while reachable-Gateway diagnostics and authenticated transport failures retain their existing distinct envelopes.

No authentication policy, credential lookup, Gateway protocol, config, or human-readable command behavior changes.

## User Impact

JSON callers always receive one parseable failure object and a nonzero exit for missing Gateway credentials. Authenticated connection failures still report `gateway_transport_error`, so automation can distinguish setup from reachability.

## Evidence

- Before-fix real-process reproduction: missing-auth JSON invocations exited 1 with empty stdout or prose stderr across top-level health, routed Gateway health, and Gateway call.
- Focused Testbox proof passed 191 CLI-process, CLI-route, health-command, and Gateway-call tests, including authenticated-unreachable preservation ([run 30589260750](https://github.com/openclaw/openclaw/actions/runs/30589260750)).
- The same Testbox completed the full production build successfully.
- Source-blind built-CLI validation on Testbox `tbx_01kytm93xjqqw9ncpczm3qkh0r` passed all 5 contract clauses: three credential-failure entry points, explicit-URL auth failure, and authenticated unreachable transport failure. Every case exited 1, emitted zero stderr bytes, and parsed the complete stdout JSON as the expected error type.
- Final rebased exact-head changed gate and Codex autoreview are recorded in the branch/PR checks.
- `git diff --check` is clean.
