### PR TITLE
fix(cron): resolve false-positive CronSessionLifecycleClaimError race

### DIFF
--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -98,6 +98,8 @@ export function projectCronOwnershipFields(entry: SessionEntry): Partial<Session
   delete projected.label;
   delete projected.pinnedAt;
   delete projected.updatedAt;
+  delete projected.observerDigest;
+  delete projected.compactionCount;
   return projected;
 }
 

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -157,8 +157,12 @@ export function resolveCronSession(params: {
     );
   const sourceSessionKey = params.sourceSessionKey?.trim();
   const sourceSessionDiffers = Boolean(sourceSessionKey && sourceSessionKey !== params.sessionKey);
-  const targetEntry = store[params.sessionKey];
-  const entry = store[sourceSessionKey || params.sessionKey];
+  const targetEntry = params.store
+    ? store[params.sessionKey]
+    : loadCronSessionEntryLatest(storePath, params.sessionKey);
+  const entry = params.store
+    ? store[sourceSessionKey || params.sessionKey]
+    : (loadCronSessionEntryLatest(storePath, sourceSessionKey || params.sessionKey) ?? targetEntry);
   // Guard the run's target row: archived sessions stay read-only even when a
   // differing source session seeds the carried preferences.
   const archivedSessionError = resolveSessionWorkStartError(params.sessionKey, targetEntry);


### PR DESCRIPTION
## What Problem This Solves

Isolated cron sessions with `wakeMode: "now"` intermittently fail with `CronSessionLifecycleClaimError`. The error fires on every run (13+ consecutive failures observed), though the cron still partially completes work before the lifecycle error kills the session.

The root cause is a race between `resolveCronSession` reading a cached session snapshot and `assertAllowed` re-reading with `readConsistency: "latest"`. A concurrent write (observer digest, transcript touch, previous run cleanup) landing between the two reads causes a false-positive ownership mismatch.

## Evidence

- 13+ consecutive `CronSessionLifecycleClaimError` failures on a single isolated cron (`3657755a`) across gateway restart, disable/enable, thinking mode changes, and full cron deletion + recreation
- The cron partially completes work (sends Slack health checks, dispatches Linear tasks to Alfred) before the lifecycle error fires, confirming the session starts successfully but crashes during admission cleanup
- After applying the fix, the cron completes all phases without the lifecycle error
- No regressions observed in other cron jobs

## Fix

1. **`session.ts`** — Read the target and source entries with `loadCronSessionEntryLatest` when no in-memory store is provided, matching the freshness guarantee used by `assertAllowed`.

2. **`run-session-state.ts`** — Strip `observerDigest` and `compactionCount` from `projectCronOwnershipFields`. These fields can be updated by concurrent non-lifecycle writes and should not trigger a lifecycle claim conflict.