### PR TITLE
fix(edit): preserve original bytes outside fuzzy-match replacement span

### DIFF
--- a/src/agents/sessions/tools/edit-replacements.test.ts
+++ b/src/agents/sessions/tools/edit-replacements.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyReplacements,
+  applyReplacementsPreservingUnchangedLines,
+  type TextReplacement,
+} from "./edit-replacements.js";
+
+// The fuzzy-match pipeline normalizes content with NFKC before matching. NFKC
+// can expand characters (ligature ﬁ → "fi") or combine them (e + U+0301 → é),
+// so normalized-space offsets differ from original-space offsets within a line.
+// These tests ensure replacements applied on original content land on the
+// correct byte span even when an NFKC-expanding character precedes the match.
+
+function normalizeForFuzzyMatch(text: string): string {
+  return (
+    text
+      .normalize("NFKC")
+      // Strip trailing whitespace per line
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .join("\n")
+      // Smart single quotes → '
+      .replace(/[\u2018\u2019]/g, "'")
+      // Smart double quotes → "
+      .replace(/[\u201C\u201D]/g, '"')
+      // En/em dashes → -
+      .replace(/[\u2013\u2014]/g, "-")
+      // NBSP / figure space / narrow NBSP → regular space
+      .replace(/[\u00A0\u2007\u202F]/g, " ")
+  );
+}
+
+describe("applyReplacementsPreservingUnchangedLines — NFKC offset mapping", () => {
+  it("maps replacement offsets correctly when an NFKC-expanding ligature precedes the match on the same line", () => {
+    // original content: "ﬁ" (U+FB01) is 1 UTF-16 code unit; NFKC expands to "fi" (2).
+    const originalContent = 'const a = "ﬁrst value";\nconst b = "second";\n';
+    const baseContent = normalizeForFuzzyMatch(originalContent);
+
+    // The fuzzy matcher reports matchIndex/matchLength in normalized space.
+    // "value" begins at normalized offset 15 (after "const a = "ﬁrst " → "first ").
+    const matchIndex = baseContent.indexOf("value");
+    expect(originalContent[matchIndex]).not.toBe("v"); // proves offsets diverge
+
+    const replacements: TextReplacement[] = [
+      { matchIndex, matchLength: "value".length, newText: "replacement" },
+    ];
+
+    const result = applyReplacementsPreservingUnchangedLines(
+      originalContent,
+      baseContent,
+      replacements,
+    );
+
+    // The replacement must land on "value" in ORIGINAL space, preserving the
+    // ligature byte before it.
+    expect(result).toBe('const a = "ﬁrst replacement";\nconst b = "second";\n');
+  });
+
+  it("maps the match end offset correctly for multi-line matches spanning an NFKC-expanded line", () => {
+    const originalContent =
+      'const label = "ﬁnal";\nconst keep = "unchanged";\nconst next = "end";\n';
+    const baseContent = normalizeForFuzzyMatch(originalContent);
+
+    // Multi-line match: "final";\nconst keep = "unchanged";\nconst next = "end"
+    const oldText = 'final";\nconst keep = "unchanged";\nconst next = "end';
+    const matchIndex = baseContent.indexOf(oldText);
+    expect(matchIndex).toBeGreaterThanOrEqual(0);
+
+    const replacements: TextReplacement[] = [
+      {
+        matchIndex,
+        matchLength: oldText.length,
+        newText: 'replaced";\nconst keep = "unchanged";\nconst next = "end',
+      },
+    ];
+
+    const result = applyReplacementsPreservingUnchangedLines(
+      originalContent,
+      baseContent,
+      replacements,
+    );
+
+    // The fuzzy match for ASCII "final" targets the visually-equivalent
+    // ligature "ﬁnal" in original space, so the whole span (including the
+    // ligature) is replaced. The key assertion is that the multi-line match
+    // END maps correctly: no extra bytes from the untouched line are eaten.
+    expect(result).toBe(
+      'const label = "replaced";\nconst keep = "unchanged";\nconst next = "end";\n',
+    );
+  });
+
+  it("keeps untouched lines byte-identical when a preceding line contains NFKC expansions", () => {
+    const originalContent =
+      '// ﬁle header with ligature\nconst untouched = "bytes";\nconst target = "replace me";\n';
+    const baseContent = normalizeForFuzzyMatch(originalContent);
+
+    const matchIndex = baseContent.indexOf("replace me");
+    const replacements: TextReplacement[] = [
+      { matchIndex, matchLength: "replace me".length, newText: "done" },
+    ];
+
+    const result = applyReplacementsPreservingUnchangedLines(
+      originalContent,
+      baseContent,
+      replacements,
+    );
+
+    // The untouched line must retain its original "ﬁ" ligature byte.
+    expect(result).toBe(
+      '// ﬁle header with ligature\nconst untouched = "bytes";\nconst target = "done";\n',
+    );
+  });
+});
+
+describe("applyReplacements — basic behavior", () => {
+  it("applies replacements in reverse order so offsets stay stable", () => {
+    const content = "aaa bbb ccc";
+    const replacements: TextReplacement[] = [
+      { matchIndex: 0, matchLength: 3, newText: "XXX" },
+      { matchIndex: 8, matchLength: 3, newText: "YYY" },
+    ];
+    expect(applyReplacements(content, replacements)).toBe("XXX bbb YYY");
+  });
+});

--- a/src/agents/sessions/tools/edit-replacements.ts
+++ b/src/agents/sessions/tools/edit-replacements.ts
@@ -116,11 +116,70 @@ export function applyReplacementsPreservingUnchangedLines(
     if (!firstLine || !lastLine) {
       throw new Error("Replacement group is outside the base content.");
     }
-    const groupStartOffset = firstLine.start;
+
+    // Use the ORIGINAL content for this line group, mapping replacement indices
+    // from normalized space to original space. This ensures bytes outside the
+    // matched span (e.g. Unicode CJK characters in comments, unusual symbols)
+    // stay untouched instead of being silently NFKC-normalized.
+    const originalGroupContent = originalLines.slice(group.startLine, group.endLine).join("");
+
+    // Map replacements from normalized-space indices to original-space indices,
+    // accounting for trailing whitespace that normalizeForFuzzyMatch's trimEnd()
+    // removed from each line.
+    const originalReplacements = group.replacements.map((r) => {
+      const normLine = baseLines.findIndex(
+        (l, i) =>
+          i >= group.startLine &&
+          i < group.endLine &&
+          r.matchIndex >= l.start &&
+          r.matchIndex < l.end,
+      );
+      const withinLineOffset = r.matchIndex - baseLines[normLine].start;
+      const origLineStart = originalLines
+        .slice(0, normLine)
+        .reduce((sum, l) => sum + l.length, 0);
+
+      // Compute original-space match length by walking through lines.
+      const normMatchEnd = r.matchIndex + r.matchLength;
+      const endNormLine = baseLines.findIndex(
+        (l) => normMatchEnd > l.start && normMatchEnd <= l.end,
+      );
+      const matchEndsWithNewline =
+        r.matchLength > 0 && baseContent[r.matchIndex + r.matchLength - 1] === "\n";
+      let origMatchLen = r.matchLength;
+      if (endNormLine >= 0) {
+        let origEndOfMatch: number;
+        if (matchEndsWithNewline) {
+          // Match ends at line end — include full original line length
+          origEndOfMatch = originalLines
+            .slice(0, endNormLine + 1)
+            .reduce((sum, l) => sum + l.length, 0);
+        } else {
+          // Match ends mid-line — same within-line position
+          const lastLineOrigStart = originalLines
+            .slice(0, endNormLine)
+            .reduce((sum, l) => sum + l.length, 0);
+          const withinLastLine = normMatchEnd - baseLines[endNormLine].start;
+          origEndOfMatch = lastLineOrigStart + withinLastLine;
+        }
+        origMatchLen = origEndOfMatch - (origLineStart + withinLineOffset);
+      }
+
+      return {
+        ...r,
+        matchIndex: origLineStart + withinLineOffset,
+        matchLength: origMatchLen,
+      };
+    });
+
+    // Apply replacements on the ORIGINAL content with original-space offsets
+    const origGroupStart = originalLines
+      .slice(0, group.startLine)
+      .reduce((sum, l) => sum + l.length, 0);
     result += applyReplacements(
-      baseContent.slice(groupStartOffset, lastLine.end),
-      group.replacements,
-      groupStartOffset,
+      originalGroupContent,
+      originalReplacements,
+      origGroupStart,
     );
     originalLineIndex = group.endLine;
   }

--- a/src/agents/sessions/tools/edit-replacements.ts
+++ b/src/agents/sessions/tools/edit-replacements.ts
@@ -21,6 +21,31 @@ function splitLinesWithEndings(content: string): string[] {
   return content.match(/[^\n]*\n|[^\n]+/g) ?? [];
 }
 
+/**
+ * Map a normalized-space offset within a line back to the original-space
+ * offset of the same line. NFKC normalization can expand or combine
+ * characters (e.g. ligature ﬁ → "fi", or "e" + combining acute → "é"),
+ * so normalized and original UTF-16 offsets diverge within a line. This
+ * returns the largest original prefix whose NFKC length is <= normOffset,
+ * which places the mapping at the start of the original character(s) that
+ * produced the normalized character at normOffset.
+ */
+function mapNormOffsetToOriginal(originalLine: string, normOffset: number): number {
+  let lo = 0;
+  let hi = originalLine.length;
+  // Find the largest i such that originalLine.slice(0, i).normalize("NFKC").length <= normOffset.
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    const prefixNormLen = originalLine.slice(0, mid).normalize("NFKC").length;
+    if (prefixNormLen <= normOffset) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo;
+}
+
 function getLineSpans(content: string): LineSpan[] {
   let offset = 0;
   return splitLinesWithEndings(content).map((line) => {
@@ -135,6 +160,12 @@ export function applyReplacementsPreservingUnchangedLines(
           r.matchIndex < l.end,
       );
       const withinLineOffset = r.matchIndex - baseLines[normLine].start;
+      // Map the normalized-space in-line offset back to original space:
+      // NFKC-expanding characters earlier in the same line shift offsets.
+      const origWithinLineOffset = mapNormOffsetToOriginal(
+        originalLines[normLine]!,
+        withinLineOffset,
+      );
       const origLineStart = originalLines
         .slice(0, normLine)
         .reduce((sum, l) => sum + l.length, 0);
@@ -155,19 +186,23 @@ export function applyReplacementsPreservingUnchangedLines(
             .slice(0, endNormLine + 1)
             .reduce((sum, l) => sum + l.length, 0);
         } else {
-          // Match ends mid-line — same within-line position
+          // Match ends mid-line — same within-line position, mapped to original space
           const lastLineOrigStart = originalLines
             .slice(0, endNormLine)
             .reduce((sum, l) => sum + l.length, 0);
           const withinLastLine = normMatchEnd - baseLines[endNormLine].start;
-          origEndOfMatch = lastLineOrigStart + withinLastLine;
+          const origWithinLastLine = mapNormOffsetToOriginal(
+            originalLines[endNormLine]!,
+            withinLastLine,
+          );
+          origEndOfMatch = lastLineOrigStart + origWithinLastLine;
         }
-        origMatchLen = origEndOfMatch - (origLineStart + withinLineOffset);
+        origMatchLen = origEndOfMatch - (origLineStart + origWithinLineOffset);
       }
 
       return {
         ...r,
-        matchIndex: origLineStart + withinLineOffset,
+        matchIndex: origLineStart + origWithinLineOffset,
         matchLength: origMatchLen,
       };
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the edit tool's fuzzy matching silently normalizes Unicode characters (CJK full-width punctuation, half-width katakana, em dashes, smart quotes, non-breaking spaces) on non-targeted parts of the same line. When any edit in a call falls back to fuzzy matching, the tool rewrites the entire matched line from a Unicode-normalized copy — characters outside the requested `oldText` span get NFKC-normalized and their special characters replaced with ASCII equivalents.

Reported in #116459.

## Why This Change Was Made

The prior fix (#99949) narrowed the blast radius from the whole file down to the touched lines, but still at LINE granularity — the entire line group was taken from the normalized content. The correct approach is to normalize only the matched substring and leave untouched bytes identical.

This fix maps replacement indices from the normalized coordinate space to the original coordinate space using per-line boundary alignment. Trailing whitespace removed by `normalizeForFuzzyMatch`'s `trimEnd()` is accounted for by extending the match length past whitespace on lines where the match includes the line boundary.

## User Impact

Before: editing a TypeScript file with CJK comments on the same line causes `（最大３回）ｱｲｳ — 設定` to become `(最大3回)アイウ - 設定` even though no part of the edit touched those characters.

After: non-targeted bytes on the same line stay byte-identical — `（最大３回）ｱｲｳ — 設定` remains `（最大３回）ｱｲｳ — 設定`.

## Evidence

### Inline verification (CJK comment preservation)

```text
=== TEST 1: Preserve CJK/Unicode on fuzzy edit line ===
OLD (normalized): "export const RETRY_MAX = 5; // 再試行(最大3回)アイウ - 設定\n"
NEW (original):   "export const RETRY_MAX = 5; // 再試行（最大３回）ｱｲｳ — 設定\n"
CJK comment preserved: true

=== TEST 2: Duplicate line after fuzzy replacement ===
Expected: "after\nafter   \n"
Got:      "after\nafter   \n"
Test 2 pass: true

=== TEST 3: Fuzzy multi-edits (preserve untouched lines) ===
Expected: "keep before  \nFIRST\nFIRST2\nkeep middle   \nSECOND\nSECOND2\nkeep after  \n"
Got:      "keep before  \nFIRST\nFIRST2\nkeep middle   \nSECOND\nSECOND2\nkeep after  \n"
Test 3 pass: true
```

### NFKC offset-mapping fix (ClawSweeper finding, commit 43fa8656)

ClawSweeper identified that the line-boundary alignment still treated a normalized UTF-16 offset as an original-file offset within a line. NFKC-expanding characters (ligature ﬁ → "fi") before a fuzzy match shift the span and can corrupt adjacent bytes. Fixed by mapping both match start and end offsets through an NFKC prefix-length mapping (`mapNormOffsetToOriginal`).

Regression test added in `edit-replacements.test.ts` — first asserts the offsets actually diverge, then that the replacement lands on the correct original span:

```text
$ vitest run src/agents/sessions/tools/edit-replacements.test.ts

 ✓  agents-core  ../../src/agents/sessions/tools/edit-replacements.test.ts (4 tests) 560ms
     ✓ maps replacement offsets correctly when an NFKC-expanding ligature precedes the match on the same line  554ms
     ✓ maps the match end offset correctly for multi-line matches spanning an NFKC-expanded line
     ✓ keeps untouched lines byte-identical when a preceding line contains NFKC expansions
     ✓ applies replacements in reverse order so offsets stay stable

 Test Files  3 passed (3)
      Tests  22 passed (22)
```

The new same-line ligature test fails against the pre-fix code (normalized offset applied directly to original content):

```text
$ git stash push src/agents/sessions/tools/edit-replacements.ts && vitest run edit-replacements.test.ts
 ❯  agents-core  ../../src/agents/sessions/tools/edit-replacements.test.ts (4 tests | 1 failed)
     × maps replacement offsets correctly when an NFKC-expanding ligature precedes the match on the same line
 Test Files  2 failed (2)
      Tests  2 failed | 6 passed (8)
```

### Full edit tool suite (no regressions)

```text
$ vitest run src/agents/sessions/tools/edit.test.ts src/agents/sessions/tools/edit-diff.test.ts src/agents/sessions/tools/edit-replacements.test.ts

 Test Files  5 passed (5)
      Tests  114 passed (114)
```

### Code change

`edit-replacements.ts` is functionally changed (the `applyReplacementsPreservingUnchangedLines` group mapping now converts in-line offsets from normalized to original space via `mapNormOffsetToOriginal`), plus a new regression test file `edit-replacements.test.ts`.

### CI

CI will run on push to verify.

[AI-assisted]
