### PR TITLE
fix(openai): preserve GPT-Live broker ownership

### DIFF
--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -185,6 +185,36 @@ describe("openai plugin", () => {
     );
   });
 
+  it("only cleans up the GPT-Live broker on plugin disable, not session reset/delete/restart", () => {
+    const registerRuntimeLifecycle = vi.fn();
+    plugin.register(
+      createTestPluginApi({
+        id: "openai",
+        name: "OpenAI Provider",
+        source: "test",
+        config: {},
+        runtime: { config: { current: vi.fn(() => ({})) } } as never,
+        registerHttpRoute: vi.fn(),
+        registerRuntimeLifecycle,
+      }),
+    );
+
+    const lifecycle = registerRuntimeLifecycle.mock.calls[0]?.[0] as {
+      cleanup: (ctx: { reason: string }) => Promise<void> | void;
+    };
+    expect(lifecycle).toBeDefined();
+
+    // Session reset/delete/restart must NOT trigger broker cleanup
+    for (const reason of ["reset", "delete", "restart"]) {
+      const result = lifecycle.cleanup({ reason });
+      expect(result).toBeUndefined();
+    }
+
+    // Plugin disable MUST trigger broker cleanup
+    const disableResult = lifecycle.cleanup({ reason: "disable" });
+    expect(disableResult).toBeDefined();
+  });
+
   it("generates PNG buffers from the OpenAI Images API", async () => {
     const { resolveApiKeySpy, postJsonRequestSpy } = mockOpenAIImageApiResponse({
       finalUrl: "https://api.openai.com/v1/images/generations",

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -156,7 +156,7 @@ describe("openai plugin", () => {
     vi.restoreAllMocks();
   });
 
-  it("registers the native GPT-Live offer route and cleanup lifecycle", () => {
+  it("registers the native GPT-Live offer route and cleanup lifecycle", async () => {
     const registerHttpRoute = vi.fn();
     const registerRuntimeLifecycle = vi.fn();
     plugin.register(
@@ -183,9 +183,47 @@ describe("openai plugin", () => {
         cleanup: expect.any(Function),
       }),
     );
+    await registerRuntimeLifecycle.mock.calls[0]?.[0].cleanup({ reason: "disable" });
   });
 
-  it("only cleans up the GPT-Live broker on plugin disable, not session reset/delete/restart", () => {
+  it("shares one GPT-Live broker across full registrations and ignores late old cleanup", async () => {
+    const register = () => {
+      const registerHttpRoute = vi.fn();
+      const registerRuntimeLifecycle = vi.fn();
+      plugin.register(
+        createTestPluginApi({
+          id: "openai",
+          name: "OpenAI Provider",
+          source: "test",
+          config: {},
+          runtime: { config: { current: vi.fn(() => ({})) } } as never,
+          registerHttpRoute,
+          registerRuntimeLifecycle,
+        }),
+      );
+      return {
+        handler: registerHttpRoute.mock.calls[0]?.[0].handler as unknown,
+        cleanup: registerRuntimeLifecycle.mock.calls[0]?.[0].cleanup as (ctx: {
+          reason: string;
+        }) => Promise<void> | void,
+      };
+    };
+
+    const first = register();
+    const second = register();
+    expect(second.handler).toBe(first.handler);
+
+    await first.cleanup({ reason: "disable" });
+    const replacement = register();
+    expect(replacement.handler).not.toBe(first.handler);
+
+    await second.cleanup({ reason: "disable" });
+    const afterLateCleanup = register();
+    expect(afterLateCleanup.handler).toBe(replacement.handler);
+    await replacement.cleanup({ reason: "disable" });
+  });
+
+  it("only cleans up the GPT-Live broker on plugin disable, not session reset/delete/restart", async () => {
     const registerRuntimeLifecycle = vi.fn();
     plugin.register(
       createTestPluginApi({
@@ -204,15 +242,13 @@ describe("openai plugin", () => {
     };
     expect(lifecycle).toBeDefined();
 
-    // Session reset/delete/restart must NOT trigger broker cleanup
     for (const reason of ["reset", "delete", "restart"]) {
       const result = lifecycle.cleanup({ reason });
       expect(result).toBeUndefined();
     }
 
-    // Plugin disable MUST trigger broker cleanup
     const disableResult = lifecycle.cleanup({ reason: "disable" });
-    expect(disableResult).toBeDefined();
+    await expect(disableResult).resolves.toBeUndefined();
   });
 
   it("generates PNG buffers from the OpenAI Images API", async () => {

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -42,7 +42,14 @@ export default definePluginEntry({
       api.lifecycle.registerRuntimeLifecycle({
         id: "openai-quicksilver-realtime-browser-session",
         description: "Close GPT-Live browser sidebands when the OpenAI plugin stops",
-        cleanup: () => quicksilverSession.cleanup(),
+        cleanup: (ctx) => {
+          // Only tear down the process-wide broker when the plugin is actually
+          // being disabled. Session reset/delete/restart cleanup must not close
+          // the shared broker — it remains usable for later GPT-Live sessions.
+          if (ctx.reason === "disable") {
+            return quicksilverSession.cleanup();
+          }
+        },
       });
     }
     const openAIToolCompatHooks = buildProviderToolCompatFamilyHooks("openai");

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -49,6 +49,7 @@ export default definePluginEntry({
           if (ctx.reason === "disable") {
             return quicksilverSession.cleanup();
           }
+          return undefined;
         },
       });
     }

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -12,9 +12,10 @@ import {
   resolveOpenAISystemPromptContribution,
 } from "./prompt-overlay.js";
 import {
-  createOpenAIQuicksilverBrowserSessionBroker,
-  OPENAI_QUICKSILVER_OFFER_PATH,
-} from "./realtime-quicksilver-session.js";
+  acquireOpenAIQuicksilverBrowserSessionBroker,
+  releaseOpenAIQuicksilverBrowserSessionBroker,
+} from "./realtime-quicksilver-session-owner.js";
+import { OPENAI_QUICKSILVER_OFFER_PATH } from "./realtime-quicksilver-session.js";
 import { buildOpenAIRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
 import { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 import { buildOpenAISpeechProvider } from "./speech-provider.js";
@@ -27,7 +28,7 @@ export default definePluginEntry({
   register(api) {
     const quicksilverSession =
       api.registrationMode === "full"
-        ? createOpenAIQuicksilverBrowserSessionBroker({
+        ? acquireOpenAIQuicksilverBrowserSessionBroker({
             getConfig: () => api.runtime.config.current() as OpenClawConfig,
             logger: api.logger,
           })
@@ -43,13 +44,10 @@ export default definePluginEntry({
         id: "openai-quicksilver-realtime-browser-session",
         description: "Close GPT-Live browser sidebands when the OpenAI plugin stops",
         cleanup: (ctx) => {
-          // Only tear down the process-wide broker when the plugin is actually
-          // being disabled. Session reset/delete/restart cleanup must not close
-          // the shared broker — it remains usable for later GPT-Live sessions.
-          if (ctx.reason === "disable") {
-            return quicksilverSession.cleanup();
+          if (ctx.reason !== "disable") {
+            return undefined;
           }
-          return undefined;
+          return releaseOpenAIQuicksilverBrowserSessionBroker(quicksilverSession);
         },
       });
     }

--- a/extensions/openai/realtime-quicksilver-session-owner.ts
+++ b/extensions/openai/realtime-quicksilver-session-owner.ts
@@ -1,0 +1,55 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveGlobalSingleton } from "openclaw/plugin-sdk/global-singleton";
+import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
+import { createOpenAIQuicksilverBrowserSessionBroker } from "./realtime-quicksilver-session.js";
+
+const OPENAI_QUICKSILVER_SESSION_OWNER_KEY = Symbol.for(
+  "openclaw.openai.quicksilverBrowserSessionOwner.v1",
+);
+
+type BrokerSession = ReturnType<typeof createOpenAIQuicksilverBrowserSessionBroker>;
+
+type BrokerParams = {
+  getConfig: () => OpenClawConfig | undefined;
+  logger: Pick<PluginLogger, "debug" | "warn">;
+};
+
+type BrokerOwner = {
+  current?: {
+    params: BrokerParams;
+    session: BrokerSession;
+  };
+};
+
+function resolveBrokerOwner(): BrokerOwner {
+  return resolveGlobalSingleton<BrokerOwner>(OPENAI_QUICKSILVER_SESSION_OWNER_KEY, () => ({}));
+}
+
+export function acquireOpenAIQuicksilverBrowserSessionBroker(params: BrokerParams): BrokerSession {
+  const owner = resolveBrokerOwner();
+  if (owner.current) {
+    owner.current.params.getConfig = params.getConfig;
+    owner.current.params.logger = params.logger;
+    return owner.current.session;
+  }
+
+  // Full plugin registration can run more than once in one process. The provider and
+  // HTTP route must share one reservation map or an offer reserved by one rejects at another.
+  const mutableParams = { ...params };
+  const session = createOpenAIQuicksilverBrowserSessionBroker(mutableParams);
+  owner.current = { params: mutableParams, session };
+  return session;
+}
+
+export async function releaseOpenAIQuicksilverBrowserSessionBroker(
+  session: BrokerSession,
+): Promise<void> {
+  const owner = resolveBrokerOwner();
+  if (owner.current?.session !== session) {
+    return;
+  }
+
+  // Release ownership before async teardown so a later registration can install a replacement.
+  owner.current = undefined;
+  await session.cleanup();
+}

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -347,8 +347,11 @@ function describeIndentation(line: string): string {
 
 function firstDifferenceIndex(left: string, right: string): number {
   const sharedLength = Math.min(left.length, right.length);
-  for (let index = 0; index < sharedLength; index++) {
-    if (left.charAt(index) !== right.charAt(index)) {
+  for (const [index, leftChar] of [...left].entries()) {
+    if (index >= sharedLength) {
+      break;
+    }
+    if (leftChar !== right.charAt(index)) {
       return index;
     }
   }

--- a/src/agents/sessions/tools/edit-diff.ts
+++ b/src/agents/sessions/tools/edit-diff.ts
@@ -347,11 +347,8 @@ function describeIndentation(line: string): string {
 
 function firstDifferenceIndex(left: string, right: string): number {
   const sharedLength = Math.min(left.length, right.length);
-  for (const [index, leftChar] of [...left].entries()) {
-    if (index >= sharedLength) {
-      break;
-    }
-    if (leftChar !== right.charAt(index)) {
+  for (let index = 0; index < sharedLength; index++) {
+    if (left.charAt(index) !== right.charAt(index)) {
       return index;
     }
   }


### PR DESCRIPTION
Fixes #116525

## What Problem This Solves

Fixes an issue where Browser Talk could report OpenAI realtime as ready but fail to start after ordinary session cleanup or repeated full OpenAI plugin registration.

Session `reset`/`delete`/`restart` cleanup permanently stopped the process-wide GPT-Live broker. Repeated full registration also created independent brokers, allowing `talk.client.create` to reserve a token in one broker while the HTTP offer route validated it against another.

## Why This Change Was Made

The OpenAI plugin now acquires one process-wide GPT-Live browser broker through the existing `openclaw/plugin-sdk/global-singleton` owner primitive. Full registrations share the same reservation and HTTP-handler state.

Only actual plugin disable releases the broker. Ownership is cleared before asynchronous teardown, and cleanup is identity-checked so a late callback from an older registration cannot tear down a replacement broker.

The unrelated `edit-diff.ts` loop change was removed from the PR; its Unicode code-point iteration broke the existing UTF-16 offset contract.

## User Impact

- Session reset, deletion, and restart no longer make Browser Talk unavailable.
- Repeated full OpenAI registrations retain one reservation store and offer handler.
- Disabling the OpenAI plugin remains idempotent and allows a later registration to create a fresh broker.
- No new config, provider, or environment-variable surface.

## Evidence

### Focused OpenAI and Gateway tests

Blacksmith Testbox `tbx_01kyvjx4kakj12z6cxj7wkr22e`:

```text
extensions/openai/index.test.ts                              16 passed
extensions/openai/realtime-gpt-live-session.test.ts       37 passed
extensions/openai/realtime-gpt-live-gateway-bridge.test.ts 27 passed, 1 skipped
Test Files 3 passed
Tests 79 passed, 1 skipped
```

The registration regression verifies:

- two full registrations expose the same real HTTP handler;
- disable releases the captured broker and a later registration installs a replacement;
- a late cleanup callback from an older registration does not clear that replacement;
- reset/delete/restart remain no-ops.

### Changed gate

The checkout-owned Testbox changed gate passed, including extension production/test typechecks, formatting, lint, plugin boundaries, dead exports, runtime import cycles, and package guards.

```text
blacksmith run summary command=5m58.443s exit=0
```

### Live OpenAI voice proof

Live-key smoke on the repaired checkout:

```text
openai-backend-bridge: ok
model: gpt-realtime-2.1
connected: true

openai-backend-audio-roundtrip: ok
cycles: 2
cycle 1: input transcript &#34;Please reply with the single word: glacier.&#34;
cycle 1: assistant transcript &#34;glacier&#34;
cycle 2: input transcript &#34;Please reply with the single word Glacier.&#34;
cycle 2: assistant transcript &#34;glacier&#34;
lateAudioBytes: 0

openai-webrtc-browser: ok
answerHasAudio: true
remoteDescriptionApplied: true
connectionState: connected
```

### Live Gateway broker lifecycle proof

A live Platform-key run registered the actual OpenAI plugin in full mode, reserved sessions from the plugin-owned process broker, sent real Chromium SDP offers through the registered `/plugins/openai/realtime/calls` handler, and applied OpenAI's SDP answers in the browser. This exercises the exact broker owner, route, reservation map, and lifecycle callbacks changed by this PR.

```text
{"label":"after-reset","model":"gpt-realtime-2.1","transport":"webrtc","offerPath":"/plugins/openai/realtime/calls","httpStatus":201,"answerHasAudio":true,"remoteDescriptionApplied":true}
{"label":"after-delete","model":"gpt-realtime-2.1","transport":"webrtc","offerPath":"/plugins/openai/realtime/calls","httpStatus":201,"answerHasAudio":true,"remoteDescriptionApplied":true}
{"label":"after-restart","model":"gpt-realtime-2.1","transport":"webrtc","offerPath":"/plugins/openai/realtime/calls","httpStatus":201,"answerHasAudio":true,"remoteDescriptionApplied":true}
{"label":"after-disable-reregister","model":"gpt-realtime-2.1","transport":"webrtc","offerPath":"/plugins/openai/realtime/calls","httpStatus":201,"answerHasAudio":true,"remoteDescriptionApplied":true}
gateway-lifecycle-live-proof: ok
```

The same owner and handler serve GPT-Live and GA realtime reservations. The available Platform key is waitlist-gated for `/v1/live`, and no current local ChatGPT OAuth profile was available, so the exact GPT-Live upstream call could not be repeated. The separate GPT-Live OAuth Testbox lane reached OpenAI but its hydrated credential was stale (`invalid_jwt`), and the Testbox image lacked the requested Playwright browser. No secret values were logged or persisted.

### Review

`autoreview --mode branch --base origin/main` reported no accepted/actionable findings and rated the patch correct at 0.9 confidence.

