### PR TITLE
fix(codex): show the delivered answer, not a trailing NO_REPLY, in Activity

### DIFF
--- a/extensions/codex/src/app-server/event-projector-assistant-delivered-answer.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant-delivered-answer.ts
@@ -1,0 +1,43 @@
+// Item-id mirror of the assistant projector's collectAssistantTexts(): the Activity
+// "selected answer" must name the item whose text delivery actually chooses. Without
+// this, a trailing silent token shadows the real answer in the operator UI while the
+// channel correctly receives the audible reply.
+import { isSilentReplyPayloadText } from "openclaw/plugin-sdk/reply-chunking";
+
+export type DeliveredAnswerItemLookup = {
+  assistantItemOrder: readonly string[];
+  assistantPhaseByItem: ReadonlyMap<string, string>;
+  assistantTextByItem: ReadonlyMap<string, string>;
+  persistableAssistantBarrier: number;
+  isToolProgressEchoText: (itemId: string, text: string) => boolean;
+  resolveFinalAssistantTextItemId: () => string | undefined;
+};
+
+/** Resolves the item id delivery would pick, skipping commentary and silent tokens. */
+export function resolveDeliveredAnswerItemId(
+  lookup: DeliveredAnswerItemLookup,
+): string | undefined {
+  const pickLast = (minIndex: number, audibleOnly: boolean): string | undefined => {
+    for (let i = lookup.assistantItemOrder.length - 1; i >= minIndex; i -= 1) {
+      const itemId = lookup.assistantItemOrder[i];
+      if (!itemId || lookup.assistantPhaseByItem.get(itemId) === "commentary") {
+        continue;
+      }
+      const text = lookup.assistantTextByItem.get(itemId)?.trim();
+      if (!text || lookup.isToolProgressEchoText(itemId, text)) {
+        continue;
+      }
+      if (audibleOnly && isSilentReplyPayloadText(text)) {
+        continue;
+      }
+      return itemId;
+    }
+    return undefined;
+  };
+  return (
+    pickLast(lookup.persistableAssistantBarrier, true) ??
+    pickLast(lookup.persistableAssistantBarrier, false) ??
+    pickLast(0, true) ??
+    lookup.resolveFinalAssistantTextItemId()
+  );
+}

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -2,6 +2,7 @@ import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "ope
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { isSilentReplyPayloadText } from "openclaw/plugin-sdk/reply-chunking";
 import { readStringField as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveDeliveredAnswerItemId } from "./event-projector-assistant-delivered-answer.js";
 import {
   createAssistantAsyncMessage as buildAssistantAsyncMessage,
   createAssistantCommentaryMessage as buildAssistantCommentaryMessage,
@@ -658,33 +659,14 @@ export class CodexAssistantProjection {
   }
 
   private resolveDeliveredAnswerItemId(): string | undefined {
-    // Item-id mirror of collectAssistantTexts(): the Activity "selected answer" must
-    // name the item whose text delivery actually chooses. Without this, a trailing
-    // silent token shadows the real answer in the operator UI while the channel
-    // correctly receives the audible reply.
-    const pickLast = (minIndex: number, audibleOnly: boolean): string | undefined => {
-      for (let i = this.assistantItemOrder.length - 1; i >= minIndex; i -= 1) {
-        const itemId = this.assistantItemOrder[i];
-        if (!itemId || this.assistantPhaseByItem.get(itemId) === "commentary") {
-          continue;
-        }
-        const text = this.assistantTextByItem.get(itemId)?.trim();
-        if (!text || this.isToolProgressEchoText(itemId, text)) {
-          continue;
-        }
-        if (audibleOnly && isSilentReplyPayloadText(text)) {
-          continue;
-        }
-        return itemId;
-      }
-      return undefined;
-    };
-    return (
-      pickLast(this.persistableAssistantBarrier, true) ??
-      pickLast(this.persistableAssistantBarrier, false) ??
-      pickLast(0, true) ??
-      this.resolveFinalAssistantTextItem()?.itemId
-    );
+    return resolveDeliveredAnswerItemId({
+      assistantItemOrder: this.assistantItemOrder,
+      assistantPhaseByItem: this.assistantPhaseByItem,
+      assistantTextByItem: this.assistantTextByItem,
+      persistableAssistantBarrier: this.persistableAssistantBarrier,
+      isToolProgressEchoText: (itemId, text) => this.isToolProgressEchoText(itemId, text),
+      resolveFinalAssistantTextItemId: () => this.resolveFinalAssistantTextItem()?.itemId,
+    });
   }
 
   private resolveFinalAssistantTextItem(): { itemId: string; text: string } | undefined {

--- a/extensions/codex/src/app-server/event-projector-assistant.ts
+++ b/extensions/codex/src/app-server/event-projector-assistant.ts
@@ -464,7 +464,16 @@ export class CodexAssistantProjection {
       this.supersedeVisibleAnswerCandidate();
       return;
     }
-    const itemId = authoritative?.id ?? this.visibleAnswerCandidateItemId;
+    let itemId = authoritative?.id ?? this.visibleAnswerCandidateItemId;
+    // turn/completed.items is a last-wins last_agent_message summary (codex-rs
+    // thread_state.rs track_current_turn_event), so a trailing silent token shadows
+    // the real answer here even though collectAssistantTexts() delivers it. Re-derive
+    // the selected item from the same precedence delivery uses.
+    const authoritativeText =
+      typeof authoritative?.text === "string" ? authoritative.text.trim() : undefined;
+    if (authoritativeText && isSilentReplyPayloadText(authoritativeText)) {
+      itemId = this.resolveDeliveredAnswerItemId() ?? itemId;
+    }
     if (!itemId) {
       return;
     }
@@ -646,6 +655,36 @@ export class CodexAssistantProjection {
     this.latestTerminalAssistantCandidateCanReleaseAfterToolHandoff = false;
     this.terminalAssistantCandidateEarlierActiveItemIds.clear();
     this.supersedeVisibleAnswerCandidate();
+  }
+
+  private resolveDeliveredAnswerItemId(): string | undefined {
+    // Item-id mirror of collectAssistantTexts(): the Activity "selected answer" must
+    // name the item whose text delivery actually chooses. Without this, a trailing
+    // silent token shadows the real answer in the operator UI while the channel
+    // correctly receives the audible reply.
+    const pickLast = (minIndex: number, audibleOnly: boolean): string | undefined => {
+      for (let i = this.assistantItemOrder.length - 1; i >= minIndex; i -= 1) {
+        const itemId = this.assistantItemOrder[i];
+        if (!itemId || this.assistantPhaseByItem.get(itemId) === "commentary") {
+          continue;
+        }
+        const text = this.assistantTextByItem.get(itemId)?.trim();
+        if (!text || this.isToolProgressEchoText(itemId, text)) {
+          continue;
+        }
+        if (audibleOnly && isSilentReplyPayloadText(text)) {
+          continue;
+        }
+        return itemId;
+      }
+      return undefined;
+    };
+    return (
+      pickLast(this.persistableAssistantBarrier, true) ??
+      pickLast(this.persistableAssistantBarrier, false) ??
+      pickLast(0, true) ??
+      this.resolveFinalAssistantTextItem()?.itemId
+    );
   }
 
   private resolveFinalAssistantTextItem(): { itemId: string; text: string } | undefined {

--- a/extensions/codex/src/app-server/event-projector.assistant.test.ts
+++ b/extensions/codex/src/app-server/event-projector.assistant.test.ts
@@ -401,6 +401,57 @@ describe("CodexAppServerEventProjector assistant projection", () => {
     expect(projector.buildSteeringTranscriptPrefix()).toEqual([]);
   });
 
+  it("selects the delivered answer, not a trailing silent token, as the Activity answer (#116604)", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+    });
+    const summary = "The real review summary the operator should see.";
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta(summary, "answer-1"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: { type: "agentMessage", id: "answer-1", phase: "final_answer", text: summary },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "" },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("NO_REPLY", "answer-2"));
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "NO_REPLY" },
+      }),
+    );
+    // turn/completed.items is a last-wins last_agent_message summary, so only the
+    // trailing silent item arrives here even though delivery keeps the real answer.
+    await projector.handleNotification(
+      turnCompleted([
+        { type: "agentMessage", id: "answer-2", phase: "final_answer", text: "NO_REPLY" },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual([summary]);
+
+    const selectedEvents = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.stream === "item" && event.data.kind === "answer_candidate")
+      .map((event) => event.data)
+      .filter((data) => data.status === "selected");
+    expect(selectedEvents).toEqual([
+      expect.objectContaining({ itemId: "answer-1", progressText: summary }),
+    ]);
+  });
+
   it("drops a pre-sleep final after a later sleep handoff", async () => {
     const projector = await createProjector(await createParams());
     const sleepItem = { type: "sleep", id: "sleep-1", durationMs: 250 };


### PR DESCRIPTION
Closes #112468
Related: #123993

## What Problem This Solves

Completes the last user-visible piece of #112468. The delivery half — a trailing `NO_REPLY` coda swallowing the turn's real answer in the channel reply — was fixed on `main` by #123993 (thanks @obviyus), whose persistable-assistant barrier now correctly ships the audible answer. This PR was originally the broader fix for that issue; it has been **narrowed** to the one vector #123993 does not cover:

**Control UI Activity still shows `NO_REPLY` as the "Selected answer."** `turn/completed.items` is a last-wins `last_agent_message` summary, so when the trailing silent token is the last completed agent message, `finalizeAnswerCandidate` selects the silent item. The operator sees `NO_REPLY` in Activity while the channel receives the real reply — the two surfaces disagree about what the turn said.

## Why This Change Was Made

Verified against the pinned `@openai/codex` 0.147.0 source (`extensions/codex/package.json:11`), per the Codex dependency gate:

- `codex-rs/app-server/src/bespoke_event_handling.rs:1276-1285` — the only production constructor of `turn/completed` builds `items` as `[last_agent_message]` or `[]`: never more than one item, never a tool item.
- `codex-rs/app-server/src/thread_state.rs:158-169` — `last_agent_message` is overwritten by every completed `AgentMessage` final (last-wins, no silence awareness), so a trailing `NO_REPLY` always shadows the real answer in the snapshot.

The fix re-derives the selected item when the snapshot-authoritative item is a silent payload: `resolveDeliveredAnswerItemId()` is an item-id mirror of `collectAssistantTexts()`'s merged precedence (audible post-barrier → any post-barrier persistable → pre-barrier audible → final text item), so Activity names exactly the item whose text delivery chose. It reuses the existing `persistableAssistantBarrier` — no parallel delivery path is introduced, and `collectAssistantTexts()` remains the single owner of delivered text.

**Dropped from the original scope, with reasons:**
- The delivered-text override and its tests (~8 scenarios: JSON-envelope/quoted/reasoning-prefixed silent tokens, pre-tool answer revival, raw synthetic-id items) — redundant; traced to pass on current `main` via #123993's barrier.
- A cross-turn snapshot filter for `finalizeAnswerCandidate` — dead code by construction; `turn.items` cannot carry a cross-turn or tool item (citation above), and no `ThreadItem` variant carries a `turnId` field (`codex-rs/app-server-protocol/src/protocol/v2/item.rs:226-397`).
- A silence-aware timeout-recovery gate (`hasCompletedTerminalAssistantText`) — would actively break legitimate silent-turn recovery; every real tool call produces live item notifications that already drive the supersession path, so the "tool appears only in the snapshot" premise is unreachable.

## User Impact

Operators watching a run in Control UI Activity see the actual answer the user received, instead of `NO_REPLY`, whenever a late-injected event (typically a duplicate subagent completion notice) draws a contract-mandated silent coda after the real answer. Channel delivery is unchanged (already correct on `main`).

## Evidence

Regression test: `extensions/codex/src/app-server/event-projector.assistant.test.ts` — "selects the delivered answer, not a trailing silent token, as the Activity answer (#116604)". Real answer completes, trailing `NO_REPLY` final completes, `turn/completed` carries only the silent item (matching the Rust summary semantics).

Red on unmodified `main` — the selected Activity event names the silent item:

```
AssertionError: expected [ { itemId: 'answer-2', …(7) } ] to deeply equal [ ObjectContaining{…} ]
- "itemId": "answer-1",
- "progressText": "The real review summary the operator should see.",
+ "itemId": "answer-2",
+ "progressText": "NO_REPLY",
+ "status": "selected",
```

Green with the fix:

```
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.assistant.test.ts
 Test Files  1 passed (1)
      Tests  22 passed (22)
```

Sibling suites (`event-projector.commentary`, `.native-finalization`, `.native-audit`, `run-attempt.turn-watches`): 172/172 pass. `oxfmt --check` and `oxlint` clean on touched files; `git diff --check` clean.

Production LOC: +40/−1 (one private helper + silent-payload branch in `finalizeAnswerCandidate`); tests +51. Cross-model review: default Codex pass clean; gpt-5.6-sol max-effort pass run before publication.

Proof gap (unchanged from prior reviews, stated honestly): no real Codex app-server session trace — that requires live credentials against a pinned server. The projector-level red/green above drives the same notification sequence the server emits per the cited `codex-rs` source.

---
🤖 This PR was prepared with AI assistance (Claude); the analysis, narrowing decision, and final diff were reviewed end-to-end.
