### PR TITLE
fix(ui): prevent new-chat controls overlapping on mobile

### DIFF
--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -31,7 +31,7 @@ suite.define(() => {
       const footer = page.locator(".new-session-page__composer .agent-chat__composer-footer");
       const incognito = page.getByRole("switch", { name: "Incognito" });
       const model = page.locator(".new-session-page__composer .chat-composer-model-control");
-      await model.waitFor();
+      await Promise.all([footer.waitFor(), incognito.waitFor(), model.waitFor()]);
 
       const [footerBox, incognitoBox, modelBox] = await Promise.all([
         footer.boundingBox(),

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -16,6 +16,45 @@ import {
 const suite = createNewSessionPageE2eSuite();
 
 suite.define(() => {
+  it("keeps the mobile incognito and model controls separated", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 568, width: 320 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      models: [{ id: "gpt-5.6-sol", name: "GPT 5.6 Sol", provider: "openai" }],
+    });
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      const footer = page.locator(".new-session-page__composer .agent-chat__composer-footer");
+      const incognito = page.getByRole("switch", { name: "Incognito" });
+      const model = page.locator(".new-session-page__composer .chat-composer-model-control");
+      await model.waitFor();
+
+      const [footerBox, incognitoBox, modelBox] = await Promise.all([
+        footer.boundingBox(),
+        incognito.boundingBox(),
+        model.boundingBox(),
+      ]);
+      expect(footerBox).not.toBeNull();
+      expect(incognitoBox).not.toBeNull();
+      expect(modelBox).not.toBeNull();
+      expect((incognitoBox?.x ?? 0) + (incognitoBox?.width ?? 0)).toBeLessThanOrEqual(
+        modelBox?.x ?? 0,
+      );
+      for (const control of [incognitoBox, modelBox]) {
+        expect(control?.x ?? 0).toBeGreaterThanOrEqual(footerBox?.x ?? 0);
+        expect((control?.x ?? 0) + (control?.width ?? 0)).toBeLessThanOrEqual(
+          (footerBox?.x ?? 0) + (footerBox?.width ?? 0),
+        );
+      }
+    } finally {
+      await context.close();
+    }
+  });
+
   it("selects the model for a plain new session", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -575,6 +575,21 @@ wa-popover.new-session-page__place-popover::part(body) {
     gap: 4px 2px;
   }
 
+  /* The shared chat footer becomes a three-column grid on mobile, but a new
+     session has visibility pills instead of the chat settings slot. Keep
+     those pills intrinsic and let the model picker use the remaining width. */
+  .new-session-page__composer .agent-chat__composer-controls {
+    display: flex;
+    gap: 4px;
+  }
+
+  .new-session-page__composer .chat-composer-model-control {
+    flex: 1 1 auto;
+    width: auto;
+    max-width: 100%;
+    margin-left: auto;
+  }
+
   .new-session-page__select {
     position: static;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a new chat on a narrow mobile viewport would see the Incognito control overlap the model selector.

## Why This Change Was Made

The new-session composer now uses a mobile-only flex layout for its visibility controls and model picker. The controls remain in the existing bottom footer, Incognito keeps its intrinsic width, and the model picker uses the remaining space without changing desktop or active-chat behavior.

## User Impact

Mobile users can read and use both the Incognito and model controls when starting a new chat, including at a 320px viewport width.

## Evidence

Before/after screenshots use the mocked Gateway E2E page with synthetic data only.

| Before | After |
| --- | --- |
| ![Before: Incognito overlaps the model selector at 320px](https://raw.githubusercontent.com/Solvely-Colin/openclaw/pr-assets-116607/mobile-new-session-controls-before.png) | ![After: Incognito and model selector remain separated at 320px](https://raw.githubusercontent.com/Solvely-Colin/openclaw/pr-assets-116607/mobile-new-session-controls-after.png) |

Validation:

- `new-session-page.workspace-memory.e2e.test.ts`: 8 tests passed
- 320×568 regression assertion verifies the controls do not overlap or escape the footer
- `oxfmt --check`: passed
- `git diff --check`: passed
- `pnpm ui:build`: passed, including precompressed-asset and performance checks

## Real Control UI proof — 7bfe11f1ac

The candidate production UI build was served by a real, isolated OpenClaw Gateway and opened at `/new` in Chromium at 320×568. The Gateway used a synthetic configured model solely to render the picker; no provider request was sent.

![Real Gateway after-fix proof at 320×568](https://raw.githubusercontent.com/Solvely-Colin/openclaw/pr-assets-116607/mobile-new-session-controls-after-real-gateway.png)

Machine-readable verdict: [JSON](https://raw.githubusercontent.com/Solvely-Colin/openclaw/pr-assets-116607/mobile-new-session-controls-after-real-gateway.json)

```json
{
  "candidateSha": "7bfe11f1acc7ad9c200cad100dfffc4d860267df",
  "baseSha": "29a92e98acce194e6a7f6692e45097db6ee04060",
  "gateway": "real isolated OpenClaw gateway",
  "viewport": { "width": 320, "height": 568 },
  "separated": true,
  "withinFooter": true
}
```

Measured bounds: footer `x=29, width=262`; Incognito `x=33, width=77.65625`; model picker `x=114.65625, width=172.34375`.

Additional validation on the rebased head (`29a92e98ac`):

- Blacksmith Testbox: `new-session-page.workspace-memory.e2e.test.ts` — 8/8 passed
- `oxfmt --check` on both changed files: passed
- `git diff --check`: passed
- `pnpm ui:build`: passed, including precompressed-asset and performance checks
- Mantis full Control UI chat proof: candidate passed at `2db2c2a423`; [run 30598874195](https://github.com/openclaw/openclaw/actions/runs/30598874195)
- Mantis proof execution and evidence publication passed; the workflow conclusion is failure only because its final cleanup step received a 403 while removing the command reaction