### PR TITLE
fix: make Telegram Codex login codes tap-to-copy

### DIFF
--- a/extensions/openai/openai-chatgpt-provider.test.ts
+++ b/extensions/openai/openai-chatgpt-provider.test.ts
@@ -85,6 +85,58 @@ describe("OpenAI provider Codex transport hooks", () => {
     });
   });
 
+  it("presents the OpenAI user code through structured device-code UI", async () => {
+    const provider = buildOpenAIProvider();
+    const deviceCodeMethod = provider.auth?.find((method) => method.id === "device-code");
+    const deviceCode = vi.fn(async () => {});
+    const note = vi.fn(async () => {});
+    const openUrl = vi.fn(async () => {});
+    loginOpenAICodexDeviceCodeMock.mockImplementationOnce(
+      async (params: {
+        onVerification: (prompt: {
+          verificationUrl: string;
+          userCode: string;
+          expiresInMs: number;
+        }) => Promise<void>;
+      }) => {
+        await params.onVerification({
+          verificationUrl: "https://auth.openai.com/codex/device",
+          userCode: "ABCD-EFGH",
+          expiresInMs: 15 * 60_000,
+        });
+        return {
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: 1_700_000_000_000,
+        };
+      },
+    );
+
+    await deviceCodeMethod?.run({
+      isRemote: true,
+      openUrl,
+      prompter: {
+        deviceCode,
+        note,
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+      runtime: { log: vi.fn(), error: vi.fn() },
+      config: {},
+      oauth: {},
+    } as never);
+
+    expect(deviceCode).toHaveBeenCalledWith({
+      title: "OpenAI Codex device code",
+      code: "ABCD-EFGH",
+      expiresInMinutes: 15,
+      message: [
+        "Open this URL in your LOCAL browser and enter the code below.",
+        "URL: https://auth.openai.com/codex/device",
+      ].join("\n"),
+    });
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("routes Codex-backed OpenAI models through the Codex Responses transport", () => {
     const provider = buildOpenAIProvider();
 

--- a/extensions/openai/openai-chatgpt-provider.ts
+++ b/extensions/openai/openai-chatgpt-provider.ts
@@ -513,23 +513,37 @@ async function runOpenAICodexDeviceCode(ctx: ProviderAuthContext) {
       onProgress: (message) => spin.update(message),
       onVerification: async ({ verificationUrl, userCode, expiresInMs }) => {
         const expiresInMinutes = Math.max(1, Math.round(expiresInMs / 60_000));
+        const deviceCodeMessage = [
+          ctx.isRemote
+            ? "Open this URL in your LOCAL browser and enter the code below."
+            : "Open this URL in your browser and enter the code below.",
+          `URL: ${verificationUrl}`,
+        ].join("\n");
         if (ctx.isRemote) {
           await ctx.openUrl(verificationUrl);
         }
-        // The prompter note is the user-facing TTY surface, so remote/headless
-        // users need the code there; keep the persistent runtime log URL-only.
-        await ctx.prompter.note(
-          [
-            ctx.isRemote
-              ? "Open this URL in your LOCAL browser and enter the code below."
-              : "Open this URL in your browser and enter the code below.",
-            `URL: ${verificationUrl}`,
-            `Code: ${userCode}`,
-            `Code expires in ${expiresInMinutes} minutes. Never share it.`,
-          ].join("\n"),
-          "OpenAI Codex device code",
-        );
+        if (ctx.prompter.deviceCode) {
+          await ctx.prompter.deviceCode({
+            title: "OpenAI Codex device code",
+            code: userCode,
+            expiresInMinutes,
+            message: deviceCodeMessage,
+          });
+        } else {
+          // The prompter note is the user-facing TTY fallback, so
+          // remote/headless users need the code in its plain-text body.
+          await ctx.prompter.note(
+            [
+              deviceCodeMessage,
+              `Code: ${userCode}`,
+              `Code expires in ${expiresInMinutes} minutes. Never share it.`,
+            ].join("\n"),
+            "OpenAI Codex device code",
+          );
+        }
         if (ctx.isRemote) {
+          // Keep the persistent runtime log URL-only; the short-lived code
+          // belongs on the interactive surface that requested authorization.
           ctx.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${verificationUrl}\n`);
           return;
         }

--- a/extensions/telegram/src/bot-native-commands.login.test.ts
+++ b/extensions/telegram/src/bot-native-commands.login.test.ts
@@ -68,20 +68,27 @@ describe("registerTelegramNativeCommands /login", () => {
         provider?: string;
         method?: string;
         agent?: string;
-        prompter: { note: (message: string, title?: string) => Promise<void> };
+        prompter: {
+          deviceCode?: (params: {
+            title: string;
+            code: string;
+            expiresInMinutes?: number;
+            message?: string;
+          }) => Promise<void>;
+        };
       }) => {
         expect(params.provider).toBe("openai");
         expect(params.method).toBe("device-code");
         expect(params.agent).toBe("main");
-        await params.prompter.note(
-          [
+        await params.prompter.deviceCode?.({
+          title: "OpenAI Codex device code",
+          code: "ABCD-EFGH",
+          expiresInMinutes: 15,
+          message: [
             "Open this URL in your LOCAL browser and enter the code below.",
             "URL: https://auth.openai.com/codex/device",
-            "Code: ABCD-EFGH",
-            "Code expires in 15 minutes. Never share it.",
           ].join("\n"),
-          "OpenAI Codex device code",
-        );
+        });
         return {
           providerId: "openai",
           methodId: "device-code",
@@ -110,8 +117,9 @@ describe("registerTelegramNativeCommands /login", () => {
 
     const texts = sendMessage.mock.calls.map((call) => String(call[1]));
     expect(texts[0]).toContain("URL: https://auth.openai.com/codex/device");
-    expect(texts[0]).toContain("Code: ABCD-EFGH");
+    expect(texts[0]).toContain("Code: <code>ABCD-EFGH</code>");
     expect(texts[0]).toContain("Never share it.");
+    expect(sendMessage.mock.calls[0]?.[2]).toEqual(expect.objectContaining({ parse_mode: "HTML" }));
     expect(texts.at(-1)).toContain("Codex login complete. Try your request again now.");
   });
 

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -53,6 +53,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { escapeHtml } from "openclaw/plugin-sdk/text-utility-runtime";
 import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
 import { resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -159,6 +160,27 @@ type TelegramNativeCommandThreadContext = {
   threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
   threadParams: ReturnType<typeof buildTelegramThreadParams>;
 };
+
+type TelegramLoginDeviceCode = {
+  title: string;
+  code: string;
+  expiresInMinutes?: number;
+  message?: string;
+};
+
+// Telegram's inline-code entity provides the tap-to-copy affordance needed for
+// short-lived device codes; plain text and literal backticks do not.
+function formatTelegramLoginDeviceCode(params: TelegramLoginDeviceCode): string {
+  return [
+    `<b>${escapeHtml(params.title)}</b>`,
+    "",
+    ...(params.message ? [escapeHtml(params.message)] : []),
+    `Code: <code>${escapeHtml(params.code)}</code>`,
+    ...(params.expiresInMinutes
+      ? [`Code expires in ${params.expiresInMinutes} minutes. Never share it.`]
+      : []),
+  ].join("\n");
+}
 
 function resolveTelegramCodexLoginProviderInput(commandArgs: CommandArgs | undefined): string {
   const providerValue = commandArgs?.values?.provider;
@@ -1268,6 +1290,17 @@ export const registerTelegramNativeCommands = ({
               fn: () => bot.api.sendMessage(chatId, text, threadParams),
             });
           };
+          const sendLoginDeviceCode = async (params: TelegramLoginDeviceCode) => {
+            await withTelegramApiErrorLogging({
+              operation: "sendMessage",
+              runtime,
+              fn: () =>
+                bot.api.sendMessage(chatId, formatTelegramLoginDeviceCode(params), {
+                  ...threadParams,
+                  parse_mode: "HTML",
+                }),
+            });
+          };
           if (
             !senderIsOwner ||
             !codexChannelLoginRuntime.hasConfiguredCommandOwnerAllowlist(runtimeCfg)
@@ -1336,6 +1369,7 @@ export const registerTelegramNativeCommands = ({
               config: runtimeCfg,
               runtime,
               sendMessage: sendLoginMessage,
+              sendDeviceCode: sendLoginDeviceCode,
               unsupportedPromptMessage:
                 "Telegram /login supports only fixed Codex device-code auth.",
             });

--- a/src/plugin-sdk/provider-auth-login-flow-runtime.ts
+++ b/src/plugin-sdk/provider-auth-login-flow-runtime.ts
@@ -99,6 +99,7 @@ function releaseCodexLoginFlow(params: {
 
 function buildCodexDeviceLoginPrompter(params: {
   sendMessage: (message: string) => Promise<void>;
+  sendDeviceCode?: NonNullable<ModelsAuthLoginFlowOptions["prompter"]["deviceCode"]>;
   unsupportedPromptMessage: string;
 }): ModelsAuthLoginFlowOptions["prompter"] {
   const sendCleanMessage = async (message: string) => {
@@ -116,6 +117,7 @@ function buildCodexDeviceLoginPrompter(params: {
     note: async (message, title) => {
       await sendCleanMessage([title?.trim(), message.trim()].filter(Boolean).join("\n\n"));
     },
+    ...(params.sendDeviceCode ? { deviceCode: params.sendDeviceCode } : {}),
     plain: sendCleanMessage,
     select: unsupportedPrompt as ModelsAuthLoginFlowOptions["prompter"]["select"],
     multiselect: unsupportedPrompt as ModelsAuthLoginFlowOptions["prompter"]["multiselect"],
@@ -180,6 +182,7 @@ async function runCodexDeviceLoginFlow(params: {
   config: OpenClawConfig;
   runtime: RuntimeEnv;
   sendMessage: (message: string) => Promise<void>;
+  sendDeviceCode?: NonNullable<ModelsAuthLoginFlowOptions["prompter"]["deviceCode"]>;
   unsupportedPromptMessage: string;
   runLoginFlow?: RunModelsAuthLoginFlow;
 }): Promise<ModelsAuthLoginFlowResult> {
@@ -192,6 +195,7 @@ async function runCodexDeviceLoginFlow(params: {
     runtime: params.runtime,
     prompter: buildCodexDeviceLoginPrompter({
       sendMessage: params.sendMessage,
+      sendDeviceCode: params.sendDeviceCode,
       unsupportedPromptMessage: params.unsupportedPromptMessage,
     }),
     isRemote: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting `/login codex` in Telegram received the one-time device authorization code as plain text, so Telegram did not offer its tap-to-copy affordance on mobile.

## Why This Change Was Made

The OpenAI device-code flow now presents the user code through the existing structured device-code prompt when the caller supports it, while preserving the plain-text note fallback for other callers. Telegram maps that structured value to an escaped inline-code entity instead of inferring or scraping a code from display text.

## User Impact

Telegram users can tap the Codex authorization code to copy it, making the mobile login flow easier and less error-prone. Existing terminal and non-Telegram device-code login behavior is unchanged.

## Evidence

- Added provider coverage for the structured device-code prompt.
- Added Telegram coverage asserting `<code>ABCD-EFGH</code>` with HTML parse mode.
- Focused OpenAI and Telegram tests: 17 passed.
- Full changed-surface formatting, lint, typecheck, plugin-boundary, and SDK checks passed via `node scripts/check-changed.mjs`.
- Independent autoreview reported no actionable findings.
- Real Telegram behavior passed on Phaedrus with exact PR head `49c4222d9c6907ef39b57e5e2ab28442fb313d96`: the gateway was healthy, both Telegram polling ingresses were active, and maintainer testing confirmed that `/login codex` rendered the authorization code with the intended tap-to-copy behavior.