### PR TITLE
fix(tui): release terminal after backend shutdown failures

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -696,6 +696,77 @@ describe("TUI shutdown safety", () => {
     expect(forceExit).not.toHaveBeenCalled();
   });
 
+  it("attempts terminal shutdown after transport teardown rejects", async () => {
+    vi.useFakeTimers();
+    const calls: string[] = [];
+    const transportError = new Error("transport stop failed");
+    let finishTuiStop: (() => void) | undefined;
+    const stopTui = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          calls.push("tui");
+          finishTuiStop = resolve;
+        }),
+    );
+    const clearTimeoutFn = vi.fn();
+    const requestFinish = vi.fn(() => calls.push("finish"));
+    const onError = vi.fn((error: unknown) => {
+      calls.push("error");
+      expect(error).toBe(transportError);
+    });
+
+    beginTestShutdown({
+      stopClient: async () => {
+        calls.push("client");
+        throw transportError;
+      },
+      stopTui,
+      requestFinish,
+      onError,
+      keepHardExitArmed: false,
+      clearTimeoutFn,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls).toEqual(["client", "tui"]);
+    expect(clearTimeoutFn).not.toHaveBeenCalled();
+    expect(requestFinish).not.toHaveBeenCalled();
+
+    finishTuiStop?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls).toEqual(["client", "tui", "error", "finish"]);
+    expect(stopTui).toHaveBeenCalledOnce();
+    expect(clearTimeoutFn).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledOnce();
+    expect(requestFinish).toHaveBeenCalledOnce();
+  });
+
+  it("reports transport and terminal shutdown errors in phase order", async () => {
+    vi.useFakeTimers();
+    const transportError = new Error("transport stop failed");
+    const terminalError = new Error("terminal stop failed");
+    const onError = vi.fn();
+    const requestFinish = vi.fn();
+
+    beginTestShutdown({
+      stopClient: async () => {
+        throw transportError;
+      },
+      stopTui: async () => {
+        throw terminalError;
+      },
+      onError,
+      requestFinish,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onError).toHaveBeenCalledOnce();
+    const error = onError.mock.calls[0]?.[0];
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([transportError, terminalError]);
+    expect(requestFinish).toHaveBeenCalledOnce();
+  });
+
   it("cancels the hard-exit deadline for embedded TUI callers after clean shutdown", async () => {
     vi.useFakeTimers();
     const forceExit = vi.fn();

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -430,8 +430,26 @@ export function beginTuiShutdown(params: {
   // Stop referenced animations before transport teardown can stall or redraw.
   params.disposeStatus();
   void Promise.resolve()
-    .then(params.stopClient)
-    .then(params.stopTui)
+    .then(async () => {
+      const errors: unknown[] = [];
+      try {
+        await params.stopClient();
+      } catch (error) {
+        errors.push(error);
+      }
+      // Terminal ownership must be released even when transport teardown fails.
+      try {
+        await params.stopTui();
+      } catch (error) {
+        errors.push(error);
+      }
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "TUI shutdown failed");
+      }
+    })
     .finally(() => {
       if (params.keepHardExitArmed !== true) {
         const clearTimeoutFn =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an embedded TUI could leave the terminal in raw/owned mode when backend transport shutdown rejected. The failed transport phase returned early, so terminal drain and stop never ran.

## Why This Change Was Made

Shutdown now treats transport teardown and terminal release as ordered, independently attempted phases. It preserves the original error when only one phase fails and reports both failures together when both fail, without changing the existing hard-exit path.

## User Impact

Operators regain a usable terminal even when the embedded Gateway or system-agent backend fails during shutdown, and teardown failures remain visible instead of being hidden by cleanup.

## Evidence

- Regression tests cover transport-only failure, terminal-only failure, ordered dual failure, and successful cleanup.
- Focused Testbox proof: 75/75 tests passed on `src/tui/tui.test.ts` using lease `tbx_01kyttv8mysb2whnf5k3yawatk`.
- Exact-tree remote changed gate passed on the same patch; formatting, typechecks, lint, boundary guards, import-cycle checks, and selected architecture guards were green.
- Fresh Codex autoreview reported no actionable findings at 0.98 confidence.
- `git diff --check` is clean.

Risk is low and confined to TUI teardown ordering. Release-note context: embedded TUI shutdown now always releases terminal ownership after backend teardown failures.
