### PR TITLE
fix(pairing): ignore wildcard bindings during legacy migration

### DIFF
--- a/.agents/skills/openclaw-autonomous-issue-sweep/SKILL.md
+++ b/.agents/skills/openclaw-autonomous-issue-sweep/SKILL.md
@@ -67,6 +67,7 @@ subagents. Keep parent-thread updates to concise progress and clickable URLs.
    mutate the shared checkout while sibling workers are active. Once isolated
    worktrees exist, independent issue owners edit, inspect, and verify in
    parallel within their own checkout.
+
 6. Keep all **64** inherited high-effort agents available, but distinguish idle
    agents from active local tool users. Start with bounded waves of **4–8**
    concurrently active code/test workers and continuously reduce or expand that

--- a/src/infra/state-migrations.channel-pairing.test.ts
+++ b/src/infra/state-migrations.channel-pairing.test.ts
@@ -180,6 +180,27 @@ describe("legacy channel pairing state migration", () => {
     expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({});
   });
 
+  it("ignores invalid account candidates while resolving scoped filenames", async () => {
+    const { env, sourceDir } = await createFixture();
+    const filePath = path.join(sourceDir, "telegram-alerts-allowFrom.json");
+    writeJson(filePath, { version: 1, allowFrom: ["1003"] });
+
+    const detected = detectLegacyChannelPairingState({
+      sourceDir,
+      configuredAccountIds: { telegram: ["*", "alerts"] },
+    });
+    const result = migrateLegacyChannelPairingState({ detected, env });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated 1 telegram/alerts allowFrom entry → shared SQLite state",
+    ]);
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(readChannelPairingStateSnapshot("telegram", env).allowFrom).toEqual({
+      alerts: ["1003"],
+    });
+  });
+
   it("does not infer default accounts for external channels", async () => {
     const { env, sourceDir } = await createFixture();
     const filePath = path.join(sourceDir, "custom-channel-default-allowFrom.json");

--- a/src/infra/state-migrations.channel-pairing.ts
+++ b/src/infra/state-migrations.channel-pairing.ts
@@ -105,9 +105,15 @@ function parseAllowFromFilename(
       continue;
     }
     const accountKey = stem.slice(channel.length + 1);
-    const matchingAccountIds = (accountIds[channel] ?? []).filter(
-      (accountId) => safeAccountKey(accountId) === accountKey,
-    );
+    const matchingAccountIds = (accountIds[channel] ?? []).filter((accountId) => {
+      try {
+        return safeAccountKey(accountId) === accountKey;
+      } catch {
+        // One invalid configured candidate must not abort every legacy migration.
+        // With no valid match, the source remains in place as unresolved below.
+        return false;
+      }
+    });
     if (matchingAccountIds.length === 1 && matchingAccountIds[0]) {
       targets.push({ channel: channel as PairingChannel, accountId: matchingAccountIds[0] });
     } else if (matchingAccountIds.length > 1) {

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -307,6 +307,14 @@ function resolveDoctorStateMigrationAgentId(cfg: OpenClawConfig): string {
   }
 }
 
+function resolveConcreteBindingAccountId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const accountId = value.trim();
+  return accountId && accountId !== "*" ? accountId : undefined;
+}
+
 export async function detectLegacyStateMigrations(params: {
   cfg: OpenClawConfig;
   pluginDoctorConfig?: OpenClawConfig;
@@ -547,11 +555,13 @@ export async function detectLegacyStateMigrations(params: {
         ...(typeof channelConfig?.defaultAccount === "string"
           ? [channelConfig.defaultAccount]
           : []),
-        ...(params.cfg.bindings ?? []).flatMap((binding) =>
-          binding.match?.channel === channelId && typeof binding.match.accountId === "string"
-            ? [binding.match.accountId]
-            : [],
-        ),
+        ...(params.cfg.bindings ?? []).flatMap((binding) => {
+          const accountId =
+            binding.match?.channel === channelId
+              ? resolveConcreteBindingAccountId(binding.match.accountId)
+              : undefined;
+          return accountId ? [accountId] : [];
+        }),
       ];
       return [
         channelId,
@@ -568,10 +578,11 @@ export async function detectLegacyStateMigrations(params: {
           (binding) =>
             normalizeAgentId(binding.agentId) === targetAgentId &&
             binding.match?.channel === channelId &&
-            typeof binding.match.accountId === "string",
+            resolveConcreteBindingAccountId(binding.match.accountId) !== undefined,
         )?.match.accountId;
-        if (typeof boundAccountId === "string" && boundAccountId.trim()) {
-          return [[channelId, boundAccountId.trim()]];
+        const concreteBoundAccountId = resolveConcreteBindingAccountId(boundAccountId);
+        if (concreteBoundAccountId) {
+          return [[channelId, concreteBoundAccountId]];
         }
         const defaultAccount =
           value && typeof value === "object" && !Array.isArray(value)

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -691,6 +691,45 @@ describe("state migrations", () => {
     detectionCase = { ...detected, stateDir, env };
   });
 
+  it("does not treat wildcard route bindings as pairing account ids", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg = createConfig();
+    cfg.bindings = [
+      {
+        agentId: "worker-1",
+        match: { channel: "chatapp", accountId: "*" },
+      },
+    ];
+    const credentialsDir = path.join(stateDir, "credentials");
+    await fs.mkdir(credentialsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(credentialsDir, "chatapp-allowFrom.json"),
+      '["default-user"]\n',
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(credentialsDir, "chatapp-alpha-allowFrom.json"),
+      '["scoped-user"]\n',
+      "utf8",
+    );
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env,
+      homedir: () => root,
+    });
+    const result = await runLegacyStateMigrations({ detected, config: cfg, now: () => 1234 });
+
+    expect(result.warnings).toEqual([]);
+    expect(readChannelPairingStateSnapshot("chatapp", env).allowFrom).toEqual({
+      alpha: ["default-user", "scoped-user"],
+    });
+    await expectMissingPath(path.join(credentialsDir, "chatapp-allowFrom.json"));
+    await expectMissingPath(path.join(credentialsDir, "chatapp-alpha-allowFrom.json"));
+  });
+
   it("keeps automatic migration read-only when the shared schema is current", async () => {
     const root = await createTempDir();
     const stateDir = path.join(root, ".openclaw");


### PR DESCRIPTION
## What Problem This Solves

OpenClaw `2026.7.2-beta.5` can enter a gateway crash-restart loop while migrating legacy channel pairing state. A route binding with `accountId: "*"` is a wildcard selector, but migration detection treated it as a concrete account id and passed it to `safeAccountKey`. The sanitizer rejects `"*"`, so a normal scoped legacy allowlist file could abort startup with:

```text
invalid pairing account id: sanitized key is empty; got string length 1
```

The migration surface was introduced by https://github.com/openclaw/openclaw/pull/105802 (`024b7d5aa8603828776a1c537dcf17125c3d7ae1`) and shipped in the `2026.7.2` betas.

## Solution

- Exclude wildcard route bindings from concrete account discovery and default-account inference.
- Ignore invalid configured candidates while resolving a scoped legacy filename; valid candidates still match normally.
- Preserve strict `safeAccountKey` behavior and existing blocking warnings for genuinely ambiguous or unresolved legacy files.
- Add direct and end-to-end regressions covering wildcard routing, normal legacy allowlist files, SQLite import, and source cleanup.

Fixes https://github.com/openclaw/openclaw/issues/116582

## Red-Main CI Repair

Final exact-head validation exposed two unrelated current-main regressions from the newly tracked `openclaw-autonomous-issue-sweep` skill:

1. Missing `.gitignore` allowlist entries caused package-acceptance failure. That canonical repair landed separately in https://github.com/openclaw/openclaw/pull/116755 and is included in this branch's base.
2. The skill Markdown remained non-`oxfmt`-clean, causing the full lint lane to fail on unrelated PR merge refs. Per maintainer landing policy, this branch carries only the mechanical one-line `oxfmt` result for that file.

No pairing runtime, migration, config, or storage behavior was changed to repair red main.

## Evidence

### Real Doctor migration proof

Blacksmith Testbox ran the exact PR head `d4dcef8a5b0588a744f498c1958832fbfa276b8c` through the real CLI path with an isolated state/config directory. The fixture used a canonical Telegram config with concrete default account `alerts`, a wildcard route binding `{ channel: "telegram", accountId: "*" }`, and both unscoped and `alerts`-scoped legacy allowlist files.

Command:

```text
openclaw doctor --fix --yes --non-interactive
```

Redacted result:

```text
Doctor complete
exit=0
SQLite channel_pairing_allow_entries:
  telegram / alerts / scoped-user  / sort_order=0
  telegram / alerts / default-user / sort_order=1
wildcard account rows: 0
legacy pairing files remaining: 0
result: PASS
```

Run: https://github.com/openclaw/openclaw/actions/runs/30625010977

This proves the reported upgrade path reaches Doctor completion, assigns both legacy sources to the intended concrete account, never persists `"*"` as account identity, and cleans up the migrated source files.

### Regression coverage

The end-to-end test configures a concrete default account `alpha`, wildcard route binding `{ channel: "chatapp", accountId: "*" }`, and both scoped and unscoped legacy allowlist files. Both files migrate into shared SQLite state under `alpha` and are removed. The direct parser test proves an invalid candidate cannot prevent a valid account candidate from resolving.

### Final proof

Blacksmith Testbox `tbx_01kyvvx70has1gr836np0hamht` ran the exact previously failing lint/format lane equivalent followed by the pairing suites:

```text
oxlint core/extensions/scripts: passed
oxfmt --check (26,586 files): passed
src/infra/state-migrations.test.ts: 74 passed
src/infra/state-migrations.channel-pairing.test.ts: 7 passed
```

Run: https://github.com/openclaw/openclaw/actions/runs/30624094737

Package-acceptance proof after the canonical allowlist repair:

```text
test/scripts/package-acceptance-workflow.test.ts: 95 passed
```

Run: https://github.com/openclaw/openclaw/actions/runs/30623358646

The prior full scoped changed gate passed formatting, core/core-test typechecks, lint, import cycles, database migration guards, and the pairing account-scope guard: https://github.com/openclaw/openclaw/actions/runs/30619026126

Final merge-tree inspection is conflict-free and `git diff --check` is clean. Fresh final-diff autoreview is clean with no actionable findings; overall confidence `0.91`.

## User-visible Behavior

Upgrading an existing profile with wildcard account routing no longer crashes gateway startup or misidentifies `"*"` as the pairing account. Canonical legacy allowlist data migrates to the concrete account as intended.

## Security and Compatibility

- No new permissions, secrets handling, network calls, command execution, config, environment, or schema surface.
- The account-key sanitizer remains strict. Invalid candidates are not accepted or rebound.
- If no valid account resolves, the existing warning keeps the source file in place for operator repair.

## Best-Fix Verdict

Yes. The wildcard is routing policy, not account identity, so filtering it at migration discovery fixes the owner-boundary error. The parser guard prevents another malformed configured candidate from aborting the entire migration without weakening unresolved or ambiguous-state handling.

Rejected alternatives:

- Relax `safeAccountKey`: weakens the storage-key contract.
- Convert malformed files to nonfatal notices: broadens startup semantics and models a legacy filename the old writer could not create.
- Catch the whole migration step: hides unrelated failures and loses per-file resolution behavior.