### PR TITLE
fix(ci): settle custodian mobile layout assertions

### DIFF
--- a/ui/src/e2e/custodian-channel-onboarding.e2e.test.ts
+++ b/ui/src/e2e/custodian-channel-onboarding.e2e.test.ts
@@ -149,21 +149,35 @@ describeControlUiE2e("Control UI Custodian channel onboarding mocked Gateway E2E
       });
 
       await page.setViewportSize({ height: 844, width: 390 });
-      const mobileNudgeBox = await channelNudge.boundingBox();
-      const mobileCtaBox = await page
-        .getByRole("button", { name: "Set up a channel" })
-        .boundingBox();
-      expect(mobileNudgeBox).not.toBeNull();
-      expect(mobileCtaBox).not.toBeNull();
-      expect(mobileNudgeBox!.x).toBeGreaterThanOrEqual(0);
-      expect(mobileNudgeBox!.x + mobileNudgeBox!.width).toBeLessThanOrEqual(390);
-      expect(mobileCtaBox!.x).toBeGreaterThanOrEqual(mobileNudgeBox!.x);
-      expect(mobileCtaBox!.x + mobileCtaBox!.width).toBeLessThanOrEqual(
-        mobileNudgeBox!.x + mobileNudgeBox!.width,
-      );
-      expect(
-        await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth),
-      ).toBe(false);
+      await expect
+        .poll(() =>
+          channelNudge.evaluate((nudge) => {
+            const cta = nudge.querySelector<HTMLElement>(".custodian__nudge-cta");
+            if (!cta) {
+              return null;
+            }
+            const nudgeBox = nudge.getBoundingClientRect();
+            const ctaBox = cta.getBoundingClientRect();
+            return {
+              ctaVisible: ctaBox.width > 0 && ctaBox.height > 0,
+              mobileMediaQuery: window.matchMedia("(max-width: 640px)").matches,
+              noHorizontalOverflow: document.documentElement.scrollWidth <= window.innerWidth,
+              nudgeVisible: nudgeBox.width > 0 && nudgeBox.height > 0,
+              nudgeWithinViewport: nudgeBox.left >= 0 && nudgeBox.right <= window.innerWidth,
+              ctaWithinNudge: ctaBox.left >= nudgeBox.left && ctaBox.right <= nudgeBox.right,
+              viewportWidth: window.innerWidth,
+            };
+          }),
+        )
+        .toEqual({
+          ctaVisible: true,
+          mobileMediaQuery: true,
+          noHorizontalOverflow: true,
+          nudgeVisible: true,
+          nudgeWithinViewport: true,
+          ctaWithinNudge: true,
+          viewportWidth: 390,
+        });
       await page.screenshot({
         animations: "disabled",
         path: path.join(artifactDir, "02b-after-custodian-channel-nudge-mobile.png"),


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI flake where the Custodian channel-onboarding E2E sampled the nudge and its CTA from different responsive-layout frames immediately after switching Chromium to a 390px viewport. The same unchanged head failed twice with mutually inconsistent geometry, first mixing a desktop nudge with a mobile CTA and then the reverse.

## Why This Change Was Made

Polls one atomic in-page geometry snapshot until the mobile media query, viewport width, nonzero visibility, containment, and horizontal-overflow invariants agree. This preserves the existing UI contract without weakening the assertions or adding sleeps.

## User Impact

No runtime behavior changes. The Control UI mobile-layout regression check now waits for the responsive layout it intends to measure instead of failing on an intermediate frame.

## Evidence

- Failure 1: https://github.com/openclaw/openclaw/actions/runs/30594481207/job/91043843823 reported CTA x `31` against stale nudge x `302`.
- Failure 2: https://github.com/openclaw/openclaw/actions/runs/30594481207/job/91046757368 reported CTA right `425.15625` against nudge right `376`.
- Exact-head CI on `98d0be3e7e`: `checks-ui-e2e (1/4)` passed, all four UI E2E shards passed, and `openclaw/ci-gate` passed: https://github.com/openclaw/openclaw/actions/runs/30596326052
- Fresh branch autoreview: no accepted or actionable findings; patch correct at 0.95 confidence.
- Blacksmith Testbox changed gate: exit 0 in 5m03s, including formatting, Knip, Control UI i18n verification, test typecheck, and focused lint.
- Local focused Chromium execution was unavailable because the Playwright Chromium binary is not installed on this Mac; exact PR CI supplies the browser proof.
