### PR TITLE
fix(whatsapp): declare runDispatchLifecycle when turnAdoptionLifecycle is present

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
@@ -616,6 +616,39 @@ describe("processMessage group system prompt wiring", () => {
     expect(runParams.raw).not.toHaveProperty("admission");
   });
 
+  it("declares runDispatchLifecycle when turnAdoptionLifecycle is present", async () => {
+    resolvePolicyMock.mockReturnValue(makePolicy(makeAccount()));
+    buildContextMock.mockImplementationOnce(() => ({
+      Body: "hi",
+      RawBody: "hi",
+      CommandBody: "hi",
+      SessionKey: baseRoute.sessionKey,
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+    }));
+    const lifecycle = {
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(async () => undefined),
+      onDeferred: vi.fn(),
+      onAbandoned: vi.fn(async () => undefined),
+    };
+    const msg = attachWhatsAppIngressLifecycle(makeBaseMsg(), lifecycle as never);
+
+    await callProcessMessage({ msg });
+
+    const runParams = mockCallArg(runChannelInboundEventParamsMock, "runChannelInboundEvent") as {
+      turnAdoptionLifecycle?: unknown;
+      adapter?: {
+        resolveTurn?: () => { runDispatchLifecycle?: unknown };
+      };
+    };
+    expect(runParams.turnAdoptionLifecycle).toBeDefined();
+    // The resolveTurn result must include runDispatchLifecycle so
+    // assertPreparedDispatchLifecycle does not throw.
+    const resolved = runParams.adapter?.resolveTurn?.();
+    expect(resolved?.runDispatchLifecycle).toBeDefined();
+  });
+
   it("drops blocked admission before session record and reply dispatch", async () => {
     resolvePolicyMock.mockReturnValue(makePolicy(makeAccount()));
     buildContextMock.mockImplementationOnce(() => ({

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -607,6 +607,14 @@ export async function processMessage(params: {
               trackBackgroundTask(params.backgroundTasks, task);
             },
           },
+          ...(turnAdoptionLifecycle
+            ? {
+                runDispatchLifecycle: {
+                  turnAdoptionLifecycle,
+                  onDispatchSkipped: async () => await turnAdoptionLifecycle.onAdopted(),
+                },
+              }
+            : {}),
           ...replyPlan,
         };
       },


### PR DESCRIPTION
## What Problem This Solves

The WhatsApp `resolveTurn` returned an object with `runDispatch` (from `replyPlan`) but without `runDispatchLifecycle`. When `turnAdoptionLifecycle` was present, `assertPreparedDispatchLifecycle` threw:

```
runDispatchLifecycle prepared turns must declare runDispatchLifecycle when creating runDispatch
```

This crashed the first inbound message on WhatsApp self-chat mode.

## Fix

`resolveTurn` now includes `runDispatchLifecycle` with the `turnAdoptionLifecycle` and an `onDispatchSkipped` handler, matching the shape expected by `runChannelInboundEvent`.

## Evidence

- **Regression test:** `declares runDispatchLifecycle when turnAdoptionLifecycle is present` — verifies `resolveTurn` returns `runDispatchLifecycle` when `turnAdoptionLifecycle` is present.
- **Automated verification:** `npx vitest run extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts` — **11/11 tests passed**

Fixes #116453