### PR TITLE
fix(exec): preserve approved exec continuation output

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -24,7 +24,10 @@ import {
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
 import { sendMessage } from "../infra/outbound/message.js";
-import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
+import {
+  buildExecApprovalFollowupPrompt,
+  sendExecApprovalFollowup,
+} from "./bash-tools.exec-approval-followup.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 const tempStoreDirs: string[] = [];
@@ -116,6 +119,50 @@ function expectDirectSend(expected: Record<string, unknown>) {
 }
 
 describe("exec approval followup", () => {
+  it("keeps successful completion details verbatim in the continuation prompt", () => {
+    const details =
+      "Exec finished (gateway id=req-verbatim, code 0)\r\nfirst\r\n\tindented\n\n  spaced   \n  \t";
+
+    const prompt = buildExecApprovalFollowupPrompt(details);
+
+    expect(prompt).toContain(`Exact completion details:\n${details}\n\nContinue the task`);
+  });
+
+  it("trims denial details before classification and rendering", () => {
+    const prompt = buildExecApprovalFollowupPrompt(
+      "\r\n  Exec denied (gateway id=req-denied, user-denied): uname -a  \t",
+    );
+
+    expect(prompt).toContain("did not run");
+    expect(prompt).not.toContain("\r\n  Exec denied");
+    expect(prompt).not.toContain("already approved has completed");
+  });
+
+  it("delivers successful result text to the agent without trimming it", async () => {
+    const resultText = "Exec finished (gateway id=req-raw, code 0)\nline one\nline two\n  \t";
+
+    await sendExecApprovalFollowup({
+      approvalId: "req-raw",
+      sessionKey: "agent:main:main",
+      resultText,
+    });
+
+    const prompt = expectGatewayAgentFollowup({ sessionKey: "agent:main:main" }).message;
+    expect(prompt).toContain(`Exact completion details:\n${resultText}\n\nContinue the task`);
+  });
+
+  it("suppresses whitespace-only result text", async () => {
+    await expect(
+      sendExecApprovalFollowup({
+        approvalId: "req-whitespace-only",
+        resultText: " \r\n\t",
+      }),
+    ).resolves.toBe(false);
+
+    expect(callGatewayTool).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("uses an explicit denial prompt when the command did not run", async () => {
     await sendExecApprovalFollowup({
       approvalId: "req-1",

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -24,10 +24,7 @@ import {
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
 import { sendMessage } from "../infra/outbound/message.js";
-import {
-  buildExecApprovalFollowupPrompt,
-  sendExecApprovalFollowup,
-} from "./bash-tools.exec-approval-followup.js";
+import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 const tempStoreDirs: string[] = [];
@@ -119,20 +116,28 @@ function expectDirectSend(expected: Record<string, unknown>) {
 }
 
 describe("exec approval followup", () => {
-  it("keeps successful completion details verbatim in the continuation prompt", () => {
-    const details =
+  it("keeps successful completion details verbatim in the continuation prompt", async () => {
+    const resultText =
       "Exec finished (gateway id=req-verbatim, code 0)\r\nfirst\r\n\tindented\n\n  spaced   \n  \t";
 
-    const prompt = buildExecApprovalFollowupPrompt(details);
+    await sendExecApprovalFollowup({
+      approvalId: "req-verbatim",
+      sessionKey: "agent:main:main",
+      resultText,
+    });
 
-    expect(prompt).toContain(`Exact completion details:\n${details}\n\nContinue the task`);
+    const prompt = expectGatewayAgentFollowup({ sessionKey: "agent:main:main" }).message;
+    expect(prompt).toContain(`Exact completion details:\n${resultText}\n\nContinue the task`);
   });
 
-  it("trims denial details before classification and rendering", () => {
-    const prompt = buildExecApprovalFollowupPrompt(
-      "\r\n  Exec denied (gateway id=req-denied, user-denied): uname -a  \t",
-    );
+  it("trims denial details before classification and rendering", async () => {
+    await sendExecApprovalFollowup({
+      approvalId: "req-denied",
+      sessionKey: "agent:main:main",
+      resultText: "\r\n  Exec denied (gateway id=req-denied, user-denied): uname -a  \t",
+    });
 
+    const prompt = expectGatewayAgentFollowup({ sessionKey: "agent:main:main" }).message;
     expect(prompt).toContain("did not run");
     expect(prompt).not.toContain("\r\n  Exec denied");
     expect(prompt).not.toContain("already approved has completed");

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -89,7 +89,7 @@ function formatUnknownError(error: unknown): string {
  * a successful result is emitted verbatim so trailing output whitespace, blank
  * lines and indentation survive into the continuation.
  */
-export function buildExecApprovalFollowupPrompt(resultText: string): string {
+function buildExecApprovalFollowupPrompt(resultText: string): string {
   const trimmed = resultText.trim();
   if (isExecDeniedResultText(trimmed)) {
     return buildExecDeniedFollowupPrompt(trimmed);

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -83,8 +83,13 @@ function formatUnknownError(error: unknown): string {
   }
 }
 
-/** Builds the prompt used to resume an agent after an approved async exec completes. */
-function buildExecApprovalFollowupPrompt(resultText: string): string {
+/**
+ * Builds the prompt used to resume an agent after an approved async exec
+ * completes. Denied results are classified and rendered from trimmed text, but
+ * a successful result is emitted verbatim so trailing output whitespace, blank
+ * lines and indentation survive into the continuation.
+ */
+export function buildExecApprovalFollowupPrompt(resultText: string): string {
   const trimmed = resultText.trim();
   if (isExecDeniedResultText(trimmed)) {
     return buildExecDeniedFollowupPrompt(trimmed);
@@ -96,7 +101,7 @@ function buildExecApprovalFollowupPrompt(resultText: string): string {
     "Only ask the user for help if you are actually blocked.",
     "",
     "Exact completion details:",
-    trimmed,
+    trimmed ? resultText : "",
     "",
     "Continue the task if needed, then reply to the user in a helpful way.",
     "If it succeeded, share the relevant output.",
@@ -331,11 +336,14 @@ export async function sendExecApprovalFollowup(
   params: ExecApprovalFollowupParams,
 ): Promise<boolean> {
   const sessionKey = params.sessionKey?.trim();
-  const resultText = params.resultText.trim();
-  if (!resultText) {
+  const trimmedResultText = params.resultText.trim();
+  if (!trimmedResultText) {
     return false;
   }
-  const isDenied = isExecDeniedResultText(resultText);
+  const isDenied = isExecDeniedResultText(trimmedResultText);
+  // Denied text is a generated one-liner, but a successful result carries the
+  // command's own output; keep it verbatim so the agent sees what ran.
+  const resultText = isDenied ? trimmedResultText : params.resultText;
 
   const deliveryTarget = resolveExternalBestEffortDeliveryTarget({
     channel: params.turnSourceChannel,

--- a/src/agents/bash-tools.exec-approval-output.test.ts
+++ b/src/agents/bash-tools.exec-approval-output.test.ts
@@ -5,14 +5,14 @@
  * accounting above the cap.
  */
 import { describe, expect, it } from "vitest";
-import {
-  EXEC_APPROVAL_CONTINUATION_OUTPUT_LIMITS as LIMITS,
-  formatExecApprovalContinuationOutput,
-} from "./bash-tools.exec-approval-output.js";
+import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval-output.js";
 
-const MAX = LIMITS.maxUtf16Units;
-const HEAD = LIMITS.headUtf16Units;
-const TAIL = LIMITS.tailUtf16Units;
+// Pinned rather than imported: the module keeps its budget private, and pinning
+// the resolved numbers makes any change to the cap or the head/tail split a
+// deliberate edit here instead of a silent drift.
+const MAX = 16_000;
+const HEAD = 11_921;
+const TAIL = 3_974;
 const HEADER = "[stdout]\n".length;
 
 function marker(omitted: number, headUnits: number, tailUnits: number): string {

--- a/src/agents/bash-tools.exec-approval-output.test.ts
+++ b/src/agents/bash-tools.exec-approval-output.test.ts
@@ -9,17 +9,29 @@ import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval
 
 // Pinned rather than imported: the module keeps its budget private, and pinning
 // the resolved numbers makes any change to the cap or the head/tail split a
-// deliberate edit here instead of a silent drift. HEAD/TAIL hold for inputs
-// whose length is at most five digits; larger inputs widen the marker reserve.
+// deliberate edit here instead of a silent drift. These hold for inputs whose
+// length is at most five digits and whose widest stream label is at most six
+// UTF-16 units (`stdout`/`stderr`/`output`/`error`); larger inputs or longer
+// labels widen the marker reserve.
 const MAX = 16_000;
 const HEAD = 11_921;
 const TAIL = 3_974;
+// Generated headers make a `tail resumes in <label>` suffix possible, which
+// widens the reserved marker width and narrows the retained budget.
+const HEAD_LABELED = 11_903;
+const TAIL_LABELED = 3_968;
 const HEADER = "[stdout]\n".length;
 
-function marker(omitted: number, headUnits: number, tailUnits: number): string {
+function marker(
+  omitted: number,
+  headUnits: number,
+  tailUnits: number,
+  resumingLabel?: string,
+): string {
+  const resuming = resumingLabel ? `; tail resumes in ${resumingLabel}` : "";
   return (
     `[... ${omitted} UTF-16 code units omitted from approved exec output; ` +
-    `showing first ${headUnits} and last ${tailUnits} ...]`
+    `showing first ${headUnits} and last ${tailUnits}${resuming} ...]`
   );
 }
 
@@ -139,7 +151,7 @@ describe("formatExecApprovalContinuationOutput", () => {
 
   it("moves a head cut that lands inside a generated header", () => {
     // Places `[stderr]\n` so the raw head budget falls in its middle.
-    const stdout = "a".repeat(HEAD - HEADER - 1 - 4);
+    const stdout = "a".repeat(HEAD_LABELED - HEADER - 1 - 4);
     const stderr = "b".repeat(60_000);
 
     const formatted = formatExecApprovalContinuationOutput([
@@ -148,12 +160,10 @@ describe("formatExecApprovalContinuationOutput", () => {
     ]);
 
     const total = HEADER + stdout.length + 1 + HEADER + stderr.length;
-    const headUnits = HEAD - 4 - HEADER;
-    const omitted = total - headUnits - TAIL - HEADER;
+    const head = `[stdout]\n${stdout}\n`;
+    const omitted = total - head.length - TAIL_LABELED;
     expect(formatted).toBe(
-      `[stdout]\n${"a".repeat(headUnits - HEADER)}\n` +
-        `${marker(omitted, headUnits, TAIL)}\n` +
-        `[stderr]\n${"b".repeat(TAIL)}`,
+      `${head}\n${marker(omitted, head.length, TAIL_LABELED, "stderr")}\n${"b".repeat(TAIL_LABELED)}`,
     );
     expect(formatted).not.toMatch(/\[std(?!out\]\n|err\]\n)/);
     expect(formatted.length).toBeLessThanOrEqual(MAX);
@@ -161,8 +171,8 @@ describe("formatExecApprovalContinuationOutput", () => {
 
   it("moves a tail cut that lands inside a generated header", () => {
     // Places `[stderr]\n` so the raw tail cut falls in its middle.
-    const stdout = "a".repeat(12_013);
-    const stderr = "b".repeat(TAIL - 5);
+    const stdout = "a".repeat(13_000);
+    const stderr = "b".repeat(TAIL_LABELED - 5);
 
     const formatted = formatExecApprovalContinuationOutput([
       { label: "stdout", value: stdout },
@@ -170,18 +180,16 @@ describe("formatExecApprovalContinuationOutput", () => {
     ]);
 
     const total = HEADER + stdout.length + 1 + HEADER + stderr.length;
-    const headUnits = HEAD - HEADER;
-    const omitted = total - headUnits - stderr.length - HEADER;
+    const head = `[stdout]\n${"a".repeat(HEAD_LABELED - HEADER)}`;
+    const omitted = total - head.length - stderr.length;
     expect(formatted).toBe(
-      `[stdout]\n${"a".repeat(headUnits - HEADER)}\n` +
-        `${marker(omitted, headUnits, stderr.length)}\n` +
-        `[stderr]\n${stderr}`,
+      `${head}\n${marker(omitted, head.length, stderr.length, "stderr")}\n${stderr}`,
     );
     expect(formatted).not.toMatch(/\[std(?!out\]\n|err\]\n)/);
     expect(formatted.length).toBeLessThanOrEqual(MAX);
   });
 
-  it("omits the retained tail label when the head already showed that header", () => {
+  it("omits the resuming label when the head already showed that header", () => {
     const stdout = "a".repeat(4);
     const stderr = "b".repeat(MAX * 2);
 
@@ -192,8 +200,9 @@ describe("formatExecApprovalContinuationOutput", () => {
 
     const total = HEADER + stdout.length + 1 + HEADER + stderr.length;
     expect(formatted).toBe(
-      `[stdout]\naaaa\n[stderr]\n${"b".repeat(HEAD - 2 * HEADER - stdout.length - 1)}\n` +
-        `${marker(total - HEAD - TAIL, HEAD, TAIL)}\n${"b".repeat(TAIL)}`,
+      `[stdout]\naaaa\n[stderr]\n${"b".repeat(HEAD_LABELED - 2 * HEADER - stdout.length - 1)}\n` +
+        `${marker(total - HEAD_LABELED - TAIL_LABELED, HEAD_LABELED, TAIL_LABELED)}\n` +
+        "b".repeat(TAIL_LABELED),
     );
     expect(formatted.length).toBeLessThanOrEqual(MAX);
   });

--- a/src/agents/bash-tools.exec-approval-output.test.ts
+++ b/src/agents/bash-tools.exec-approval-output.test.ts
@@ -9,7 +9,8 @@ import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval
 
 // Pinned rather than imported: the module keeps its budget private, and pinning
 // the resolved numbers makes any change to the cap or the head/tail split a
-// deliberate edit here instead of a silent drift.
+// deliberate edit here instead of a silent drift. HEAD/TAIL hold for inputs
+// whose length is at most five digits; larger inputs widen the marker reserve.
 const MAX = 16_000;
 const HEAD = 11_921;
 const TAIL = 3_974;
@@ -102,6 +103,25 @@ describe("formatExecApprovalContinuationOutput", () => {
     const [, omitted = 0, headUnits = 0, tailUnits = 0] = match!.map(Number);
     expect(omitted + headUnits + tailUnits).toBe(value.length);
     expect(formatted.length).toBeLessThanOrEqual(MAX);
+  });
+
+  it("holds the cap when the omitted count needs more digits than the cap itself", () => {
+    // The omitted count scales with the input, so a fixed five-digit marker
+    // reserve would overflow the cap once the input passes ~1M units.
+    for (const total of [100_000, 1_016_000, 12_000_000]) {
+      const formatted = formatExecApprovalContinuationOutput([
+        { label: "output", value: "z".repeat(total) },
+      ]);
+
+      const match =
+        /\[\.\.\. (\d+) UTF-16 code units omitted[^\]]+first (\d+) and last (\d+) \.\.\.\]/.exec(
+          formatted,
+        );
+      expect(match).not.toBeNull();
+      const [, omitted = 0, headUnits = 0, tailUnits = 0] = match!.map(Number);
+      expect(omitted + headUnits + tailUnits).toBe(total);
+      expect(formatted.length).toBeLessThanOrEqual(MAX);
+    }
   });
 
   it("never splits a surrogate pair at either cut", () => {

--- a/src/agents/bash-tools.exec-approval-output.test.ts
+++ b/src/agents/bash-tools.exec-approval-output.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Approved exec continuation output formatting tests.
+ * Covers verbatim preservation under the cap, deterministic stream labeling,
+ * surrogate-safe head/tail cuts, header-boundary handling, and exact omission
+ * accounting above the cap.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  EXEC_APPROVAL_CONTINUATION_OUTPUT_LIMITS as LIMITS,
+  formatExecApprovalContinuationOutput,
+} from "./bash-tools.exec-approval-output.js";
+
+const MAX = LIMITS.maxUtf16Units;
+const HEAD = LIMITS.headUtf16Units;
+const TAIL = LIMITS.tailUtf16Units;
+const HEADER = "[stdout]\n".length;
+
+function marker(omitted: number, headUnits: number, tailUnits: number): string {
+  return (
+    `[... ${omitted} UTF-16 code units omitted from approved exec output; ` +
+    `showing first ${headUnits} and last ${tailUnits} ...]`
+  );
+}
+
+describe("formatExecApprovalContinuationOutput", () => {
+  it("returns an empty string when no stream carries content", () => {
+    expect(formatExecApprovalContinuationOutput([])).toBe("");
+    expect(
+      formatExecApprovalContinuationOutput([
+        { label: "stdout", value: "" },
+        { label: "stderr", value: " \r\n\t " },
+        { label: "error", value: null },
+      ]),
+    ).toBe("");
+  });
+
+  it("emits a lone stream verbatim without a label", () => {
+    for (const label of ["stdout", "stderr", "error", "output"]) {
+      expect(formatExecApprovalContinuationOutput([{ label, value: "only" }])).toBe("only");
+    }
+  });
+
+  it("preserves newlines, tabs, indentation, and trailing whitespace", () => {
+    const value = "first\r\n\tindented\n\n  spaced   \nlast\r\n  \t";
+    expect(formatExecApprovalContinuationOutput([{ label: "output", value }])).toBe(value);
+  });
+
+  it("keeps an existing source-side truncation marker visible", () => {
+    const value = `line one\nline two\n[source output truncated after 200000 bytes]\n`;
+    expect(formatExecApprovalContinuationOutput([{ label: "stdout", value }])).toBe(value);
+  });
+
+  it("labels multiple streams in stdout, stderr, error order", () => {
+    expect(
+      formatExecApprovalContinuationOutput([
+        { label: "stdout", value: "alpha\r\n  beta\t" },
+        { label: "stderr", value: "warn\n\nnext" },
+        { label: "error", value: "boom" },
+      ]),
+    ).toBe("[stdout]\nalpha\r\n  beta\t\n[stderr]\nwarn\n\nnext\n[error]\nboom");
+  });
+
+  it("skips blank streams when deciding whether to label", () => {
+    expect(
+      formatExecApprovalContinuationOutput([
+        { label: "stdout", value: "  \n" },
+        { label: "stderr", value: "only stderr" },
+        { label: "error", value: null },
+      ]),
+    ).toBe("only stderr");
+  });
+
+  it("returns under-limit and exact-limit output unchanged", () => {
+    for (const length of [1, MAX - 1, MAX]) {
+      const value = "x".repeat(length);
+      expect(formatExecApprovalContinuationOutput([{ label: "output", value }])).toBe(value);
+    }
+  });
+
+  it("splits one over-limit stream into a marked head and tail", () => {
+    const omittedCount = 500;
+    const value = `${"h".repeat(HEAD)}${"m".repeat(omittedCount)}${"t".repeat(TAIL)}`;
+
+    const formatted = formatExecApprovalContinuationOutput([{ label: "output", value }]);
+
+    expect(formatted).toBe(
+      `${"h".repeat(HEAD)}\n${marker(omittedCount, HEAD, TAIL)}\n${"t".repeat(TAIL)}`,
+    );
+    expect(formatted.length).toBeLessThanOrEqual(MAX);
+  });
+
+  it("accounts for every omitted unit and stays inside the cap", () => {
+    const value = "z".repeat(MAX * 3 + 7);
+
+    const formatted = formatExecApprovalContinuationOutput([{ label: "output", value }]);
+
+    const match =
+      /\[\.\.\. (\d+) UTF-16 code units omitted[^\]]+first (\d+) and last (\d+) \.\.\.\]/.exec(
+        formatted,
+      );
+    expect(match).not.toBeNull();
+    const [, omitted = 0, headUnits = 0, tailUnits = 0] = match!.map(Number);
+    expect(omitted + headUnits + tailUnits).toBe(value.length);
+    expect(formatted.length).toBeLessThanOrEqual(MAX);
+  });
+
+  it("never splits a surrogate pair at either cut", () => {
+    const middle = 1_000;
+    const value = `${"h".repeat(HEAD - 1)}😀${"m".repeat(middle)}😀${"t".repeat(TAIL - 1)}`;
+
+    const formatted = formatExecApprovalContinuationOutput([{ label: "output", value }]);
+
+    expect(formatted).toBe(
+      `${"h".repeat(HEAD - 1)}\n${marker(middle + 4, HEAD - 1, TAIL - 1)}\n${"t".repeat(TAIL - 1)}`,
+    );
+    expect(formatted).not.toContain("\ud83d\n");
+    expect(formatted.length).toBeLessThanOrEqual(MAX);
+  });
+
+  it("moves a head cut that lands inside a generated header", () => {
+    // Places `[stderr]\n` so the raw head budget falls in its middle.
+    const stdout = "a".repeat(HEAD - HEADER - 1 - 4);
+    const stderr = "b".repeat(60_000);
+
+    const formatted = formatExecApprovalContinuationOutput([
+      { label: "stdout", value: stdout },
+      { label: "stderr", value: stderr },
+    ]);
+
+    const total = HEADER + stdout.length + 1 + HEADER + stderr.length;
+    const headUnits = HEAD - 4 - HEADER;
+    const omitted = total - headUnits - TAIL - HEADER;
+    expect(formatted).toBe(
+      `[stdout]\n${"a".repeat(headUnits - HEADER)}\n` +
+        `${marker(omitted, headUnits, TAIL)}\n` +
+        `[stderr]\n${"b".repeat(TAIL)}`,
+    );
+    expect(formatted).not.toMatch(/\[std(?!out\]\n|err\]\n)/);
+    expect(formatted.length).toBeLessThanOrEqual(MAX);
+  });
+
+  it("moves a tail cut that lands inside a generated header", () => {
+    // Places `[stderr]\n` so the raw tail cut falls in its middle.
+    const stdout = "a".repeat(12_013);
+    const stderr = "b".repeat(TAIL - 5);
+
+    const formatted = formatExecApprovalContinuationOutput([
+      { label: "stdout", value: stdout },
+      { label: "stderr", value: stderr },
+    ]);
+
+    const total = HEADER + stdout.length + 1 + HEADER + stderr.length;
+    const headUnits = HEAD - HEADER;
+    const omitted = total - headUnits - stderr.length - HEADER;
+    expect(formatted).toBe(
+      `[stdout]\n${"a".repeat(headUnits - HEADER)}\n` +
+        `${marker(omitted, headUnits, stderr.length)}\n` +
+        `[stderr]\n${stderr}`,
+    );
+    expect(formatted).not.toMatch(/\[std(?!out\]\n|err\]\n)/);
+    expect(formatted.length).toBeLessThanOrEqual(MAX);
+  });
+
+  it("omits the retained tail label when the head already showed that header", () => {
+    const stdout = "a".repeat(4);
+    const stderr = "b".repeat(MAX * 2);
+
+    const formatted = formatExecApprovalContinuationOutput([
+      { label: "stdout", value: stdout },
+      { label: "stderr", value: stderr },
+    ]);
+
+    const total = HEADER + stdout.length + 1 + HEADER + stderr.length;
+    expect(formatted).toBe(
+      `[stdout]\naaaa\n[stderr]\n${"b".repeat(HEAD - 2 * HEADER - stdout.length - 1)}\n` +
+        `${marker(total - HEAD - TAIL, HEAD, TAIL)}\n${"b".repeat(TAIL)}`,
+    );
+    expect(formatted.length).toBeLessThanOrEqual(MAX);
+  });
+});

--- a/src/agents/bash-tools.exec-approval-output.ts
+++ b/src/agents/bash-tools.exec-approval-output.ts
@@ -31,10 +31,15 @@ function buildOmissionMarker(params: {
   omitted: number;
   headUnits: number;
   tailUnits: number;
+  resumingLabel?: string;
 }): string {
+  // Naming the stream the tail resumes in keeps label information intact
+  // without splicing synthetic header bytes into the retained content, so the
+  // three counts below always sum to the exact input length.
+  const resuming = params.resumingLabel ? `; tail resumes in ${params.resumingLabel}` : "";
   return (
     `[... ${params.omitted} UTF-16 code units omitted from approved exec output; ` +
-    `showing first ${params.headUnits} and last ${params.tailUnits} ...]`
+    `showing first ${params.headUnits} and last ${params.tailUnits}${resuming} ...]`
   );
 }
 
@@ -43,15 +48,20 @@ function buildOmissionMarker(params: {
  * input length rather than from `MAX_UTF16_UNITS`, because the omitted count
  * scales with the input and a fixed five-digit reserve would let a megabyte of
  * output push the result past the hard cap. `omitted` can never exceed the
- * input length and each retained side can never exceed the cap, so this is the
- * widest marker the cut can produce for this input.
+ * input length, each retained side can never exceed the cap, and no stream
+ * label is longer than `longestLabelUnits`, so this is the widest marker the
+ * cut can produce for this input.
  */
-function resolveCutBudget(totalUnits: number): { head: number; tail: number } {
+function resolveCutBudget(
+  totalUnits: number,
+  longestLabelUnits: number,
+): { head: number; tail: number } {
   const markerReserve =
     buildOmissionMarker({
       omitted: totalUnits,
       headUnits: MAX_UTF16_UNITS,
       tailUnits: MAX_UTF16_UNITS,
+      resumingLabel: "x".repeat(longestLabelUnits),
     }).length + 2;
   const content = MAX_UTF16_UNITS - markerReserve;
   const head = Math.floor(content * HEAD_SHARE);
@@ -118,19 +128,22 @@ function moveCutOutsideHeader(
   return direction === "head" ? containing.start : containing.end;
 }
 
-/** Re-emits the tail stream's header when the omitted middle swallowed it. */
-function resolveRetainedTailLabel(params: {
+/**
+ * Names the stream the retained tail belongs to when the omitted middle
+ * swallowed that stream's header, so no label information is lost.
+ */
+function resolveResumingStreamLabel(params: {
   tailStart: number;
   headEnd: number;
   streamRanges: StreamRange[];
-}): string {
+}): string | undefined {
   const tailStream = params.streamRanges.find(
     (range) => range.contentStart <= params.tailStart && params.tailStart < range.end,
   );
   if (!tailStream || params.headEnd >= tailStream.contentStart) {
-    return "";
+    return undefined;
   }
-  return `[${tailStream.label}]\n`;
+  return tailStream.label;
 }
 
 /**
@@ -143,30 +156,29 @@ export function formatExecApprovalContinuationOutput(streams: ExecApprovalOutput
     return rendered.text;
   }
 
-  const budget = resolveCutBudget(rendered.text.length);
-  let headEnd = moveCutOutsideHeader(budget.head, rendered.headerRanges, "head");
+  const longestLabelUnits = rendered.streamRanges.reduce(
+    (widest, range) => Math.max(widest, range.label.length),
+    0,
+  );
+  const budget = resolveCutBudget(rendered.text.length, longestLabelUnits);
+  const headEnd = moveCutOutsideHeader(budget.head, rendered.headerRanges, "head");
   const tailStart = moveCutOutsideHeader(
     rendered.text.length - budget.tail,
     rendered.headerRanges,
     "tail",
   );
-  const tailLabel = resolveRetainedTailLabel({
-    tailStart,
-    headEnd,
-    streamRanges: rendered.streamRanges,
-  });
-  if (tailLabel) {
-    // The re-added header is paid for out of the head so the total stays capped.
-    headEnd = moveCutOutsideHeader(headEnd - tailLabel.length, rendered.headerRanges, "head");
-  }
 
   const head = sliceUtf16Safe(rendered.text, 0, headEnd);
   const tail = sliceUtf16Safe(rendered.text, tailStart);
-  const omitted = rendered.text.length - head.length - tail.length - tailLabel.length;
   const marker = buildOmissionMarker({
-    omitted,
+    omitted: rendered.text.length - head.length - tail.length,
     headUnits: head.length,
     tailUnits: tail.length,
+    resumingLabel: resolveResumingStreamLabel({
+      tailStart,
+      headEnd,
+      streamRanges: rendered.streamRanges,
+    }),
   });
-  return `${head}\n${marker}\n${tailLabel}${tail}`;
+  return `${head}\n${marker}\n${tail}`;
 }

--- a/src/agents/bash-tools.exec-approval-output.ts
+++ b/src/agents/bash-tools.exec-approval-output.ts
@@ -38,17 +38,25 @@ function buildOmissionMarker(params: {
   );
 }
 
-// Widest marker the cut can produce, so headers, marker and both newlines are
-// budgeted inside MAX_UTF16_UNITS instead of pushing the result over it.
-const MARKER_RESERVE_UNITS =
-  buildOmissionMarker({
-    omitted: MAX_UTF16_UNITS,
-    headUnits: MAX_UTF16_UNITS,
-    tailUnits: MAX_UTF16_UNITS,
-  }).length + 2;
-const CONTENT_BUDGET_UNITS = MAX_UTF16_UNITS - MARKER_RESERVE_UNITS;
-const HEAD_BUDGET_UNITS = Math.floor(CONTENT_BUDGET_UNITS * HEAD_SHARE);
-const TAIL_BUDGET_UNITS = CONTENT_BUDGET_UNITS - HEAD_BUDGET_UNITS;
+/**
+ * Head/tail budget for one input. The marker reserve is derived from the actual
+ * input length rather than from `MAX_UTF16_UNITS`, because the omitted count
+ * scales with the input and a fixed five-digit reserve would let a megabyte of
+ * output push the result past the hard cap. `omitted` can never exceed the
+ * input length and each retained side can never exceed the cap, so this is the
+ * widest marker the cut can produce for this input.
+ */
+function resolveCutBudget(totalUnits: number): { head: number; tail: number } {
+  const markerReserve =
+    buildOmissionMarker({
+      omitted: totalUnits,
+      headUnits: MAX_UTF16_UNITS,
+      tailUnits: MAX_UTF16_UNITS,
+    }).length + 2;
+  const content = MAX_UTF16_UNITS - markerReserve;
+  const head = Math.floor(content * HEAD_SHARE);
+  return { head, tail: content - head };
+}
 
 type HeaderRange = { start: number; end: number };
 type StreamRange = { label: string; contentStart: number; end: number };
@@ -135,9 +143,10 @@ export function formatExecApprovalContinuationOutput(streams: ExecApprovalOutput
     return rendered.text;
   }
 
-  let headEnd = moveCutOutsideHeader(HEAD_BUDGET_UNITS, rendered.headerRanges, "head");
+  const budget = resolveCutBudget(rendered.text.length);
+  let headEnd = moveCutOutsideHeader(budget.head, rendered.headerRanges, "head");
   const tailStart = moveCutOutsideHeader(
-    rendered.text.length - TAIL_BUDGET_UNITS,
+    rendered.text.length - budget.tail,
     rendered.headerRanges,
     "tail",
   );

--- a/src/agents/bash-tools.exec-approval-output.ts
+++ b/src/agents/bash-tools.exec-approval-output.ts
@@ -10,7 +10,7 @@
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 /** One named output stream supplied by an exec host. */
-export type ExecApprovalOutputStream = {
+type ExecApprovalOutputStream = {
   label: string;
   value?: string | null;
 };
@@ -49,13 +49,6 @@ const MARKER_RESERVE_UNITS =
 const CONTENT_BUDGET_UNITS = MAX_UTF16_UNITS - MARKER_RESERVE_UNITS;
 const HEAD_BUDGET_UNITS = Math.floor(CONTENT_BUDGET_UNITS * HEAD_SHARE);
 const TAIL_BUDGET_UNITS = CONTENT_BUDGET_UNITS - HEAD_BUDGET_UNITS;
-
-/** Continuation output budget, exported so tests assert against one source. */
-export const EXEC_APPROVAL_CONTINUATION_OUTPUT_LIMITS = {
-  maxUtf16Units: MAX_UTF16_UNITS,
-  headUtf16Units: HEAD_BUDGET_UNITS,
-  tailUtf16Units: TAIL_BUDGET_UNITS,
-} as const;
 
 type HeaderRange = { start: number; end: number };
 type StreamRange = { label: string; contentStart: number; end: number };

--- a/src/agents/bash-tools.exec-approval-output.ts
+++ b/src/agents/bash-tools.exec-approval-output.ts
@@ -1,0 +1,170 @@
+/**
+ * Output formatting for approved async exec continuations.
+ *
+ * This is deliberately NOT the compact background-notification formatter
+ * (`normalizeNotifyOutput` + `DEFAULT_NOTIFY_TAIL_CHARS`, exec-runtime.ts). A
+ * notification is one chat line; a continuation is the model's only view of a
+ * command it already approved, so newlines, indentation and trailing
+ * whitespace are preserved verbatim and the budget is the model-facing one.
+ */
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
+/** One named output stream supplied by an exec host. */
+export type ExecApprovalOutputStream = {
+  label: string;
+  value?: string | null;
+};
+
+/**
+ * Hard cap for continuation output, mirroring
+ * `DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS` (tool-result-limits.ts): the floor every
+ * exec tool result is truncated to when the model context window is unknown.
+ * The host builds this text before the resuming agent's model is resolved, and
+ * the text re-enters as a user follow-up that bypasses the tool-result guard,
+ * so it needs its own bound. Head-weighted because command output front-loads
+ * the failure and back-loads the summary.
+ */
+const MAX_UTF16_UNITS = 16_000;
+const HEAD_SHARE = 0.75;
+
+function buildOmissionMarker(params: {
+  omitted: number;
+  headUnits: number;
+  tailUnits: number;
+}): string {
+  return (
+    `[... ${params.omitted} UTF-16 code units omitted from approved exec output; ` +
+    `showing first ${params.headUnits} and last ${params.tailUnits} ...]`
+  );
+}
+
+// Widest marker the cut can produce, so headers, marker and both newlines are
+// budgeted inside MAX_UTF16_UNITS instead of pushing the result over it.
+const MARKER_RESERVE_UNITS =
+  buildOmissionMarker({
+    omitted: MAX_UTF16_UNITS,
+    headUnits: MAX_UTF16_UNITS,
+    tailUnits: MAX_UTF16_UNITS,
+  }).length + 2;
+const CONTENT_BUDGET_UNITS = MAX_UTF16_UNITS - MARKER_RESERVE_UNITS;
+const HEAD_BUDGET_UNITS = Math.floor(CONTENT_BUDGET_UNITS * HEAD_SHARE);
+const TAIL_BUDGET_UNITS = CONTENT_BUDGET_UNITS - HEAD_BUDGET_UNITS;
+
+/** Continuation output budget, exported so tests assert against one source. */
+export const EXEC_APPROVAL_CONTINUATION_OUTPUT_LIMITS = {
+  maxUtf16Units: MAX_UTF16_UNITS,
+  headUtf16Units: HEAD_BUDGET_UNITS,
+  tailUtf16Units: TAIL_BUDGET_UNITS,
+} as const;
+
+type HeaderRange = { start: number; end: number };
+type StreamRange = { label: string; contentStart: number; end: number };
+
+type RenderedExecOutput = {
+  text: string;
+  headerRanges: HeaderRange[];
+  streamRanges: StreamRange[];
+};
+
+function renderExecOutputStreams(streams: ExecApprovalOutputStream[]): RenderedExecOutput {
+  const present = streams.filter(
+    (stream): stream is { label: string; value: string } =>
+      typeof stream.value === "string" && /\S/.test(stream.value),
+  );
+  if (present.length === 0) {
+    return { text: "", headerRanges: [], streamRanges: [] };
+  }
+  // A lone stream is emitted verbatim: the gateway supplies one already
+  // interleaved aggregate, and a header there would imply a split that the
+  // payload does not actually carry.
+  const [only] = present;
+  if (present.length === 1 && only) {
+    return { text: only.value, headerRanges: [], streamRanges: [] };
+  }
+
+  let text = "";
+  const headerRanges: HeaderRange[] = [];
+  const streamRanges: StreamRange[] = [];
+  for (const stream of present) {
+    if (text) {
+      text += "\n";
+    }
+    const header = `[${stream.label}]\n`;
+    const headerStart = text.length;
+    text += header;
+    headerRanges.push({ start: headerStart, end: text.length });
+    const contentStart = text.length;
+    text += stream.value;
+    streamRanges.push({ label: stream.label, contentStart, end: text.length });
+  }
+  return { text, headerRanges, streamRanges };
+}
+
+/**
+ * Pushes a cut off the interior of a generated header so a partial `[stde`
+ * never reaches the model. Both directions shrink what is retained, which keeps
+ * the budget arithmetic below valid.
+ */
+function moveCutOutsideHeader(
+  cut: number,
+  headerRanges: HeaderRange[],
+  direction: "head" | "tail",
+): number {
+  const containing = headerRanges.find((range) => range.start < cut && cut < range.end);
+  if (!containing) {
+    return cut;
+  }
+  return direction === "head" ? containing.start : containing.end;
+}
+
+/** Re-emits the tail stream's header when the omitted middle swallowed it. */
+function resolveRetainedTailLabel(params: {
+  tailStart: number;
+  headEnd: number;
+  streamRanges: StreamRange[];
+}): string {
+  const tailStream = params.streamRanges.find(
+    (range) => range.contentStart <= params.tailStart && params.tailStart < range.end,
+  );
+  if (!tailStream || params.headEnd >= tailStream.contentStart) {
+    return "";
+  }
+  return `[${tailStream.label}]\n`;
+}
+
+/**
+ * Renders approved exec output for the agent continuation, preserving exact
+ * bytes under the cap and reporting an exact omitted-unit count above it.
+ */
+export function formatExecApprovalContinuationOutput(streams: ExecApprovalOutputStream[]): string {
+  const rendered = renderExecOutputStreams(streams);
+  if (rendered.text.length <= MAX_UTF16_UNITS) {
+    return rendered.text;
+  }
+
+  let headEnd = moveCutOutsideHeader(HEAD_BUDGET_UNITS, rendered.headerRanges, "head");
+  const tailStart = moveCutOutsideHeader(
+    rendered.text.length - TAIL_BUDGET_UNITS,
+    rendered.headerRanges,
+    "tail",
+  );
+  const tailLabel = resolveRetainedTailLabel({
+    tailStart,
+    headEnd,
+    streamRanges: rendered.streamRanges,
+  });
+  if (tailLabel) {
+    // The re-added header is paid for out of the head so the total stays capped.
+    headEnd = moveCutOutsideHeader(headEnd - tailLabel.length, rendered.headerRanges, "head");
+  }
+
+  const head = sliceUtf16Safe(rendered.text, 0, headEnd);
+  const tail = sliceUtf16Safe(rendered.text, tailStart);
+  const omitted = rendered.text.length - head.length - tail.length - tailLabel.length;
+  const marker = buildOmissionMarker({
+    omitted,
+    headUnits: head.length,
+    tailUnits: tail.length,
+  });
+  return `${head}\n${marker}\n${tailLabel}${tail}`;
+}

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -239,7 +239,6 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
 }));
 
 vi.mock("./bash-tools.exec-runtime.js", () => ({
-  DEFAULT_NOTIFY_TAIL_CHARS: 1000,
   createApprovalSlug: vi.fn(() => "slug"),
   normalizeNotifyOutput: vi.fn((value) => value),
   runExecProcess: runExecProcessMock,
@@ -2078,6 +2077,47 @@ EOF`,
     });
     expect(requireSentFollowupTarget(0)?.direct).toBe(false);
     expect(requireSentFollowupText(0)).toContain("done");
+  });
+
+  it("keeps approved gateway followup output multiline instead of compacting it", async () => {
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    const aggregated = "first\r\n\tindented\n\n  spaced   \n[source output truncated]\n  \t";
+    runExecProcessMock.mockResolvedValue({
+      session: { id: "sess-1" },
+      promise: Promise.resolve({
+        status: "completed",
+        exitCode: 0,
+        timedOut: false,
+        aggregated,
+      }),
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "openclaw sessions export-trajectory --json",
+      approvalFollowupMode: "agent",
+      turnSourceChannel: "webchat",
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(1);
+    });
+    // The aggregate is already interleaved, so it is emitted verbatim and unlabeled.
+    expect(requireSentFollowupText(0)).toBe(
+      `Exec finished (gateway id=req-1, session=sess-1, code 0)\n${aggregated}`,
+    );
   });
 
   it("fails closed when detached approval metadata cannot be persisted", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -48,6 +48,7 @@ import {
 } from "../process/gateway-work-admission.js";
 import { isNativeApprovalChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
+import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval-output.js";
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
@@ -69,7 +70,6 @@ import {
 } from "./bash-tools.exec-host-shared.js";
 import { appendExecTimeoutRetryGuidance } from "./bash-tools.exec-output.js";
 import {
-  DEFAULT_NOTIFY_TAIL_CHARS,
   createApprovalSlug,
   normalizeNotifyOutput,
   runExecProcess,
@@ -404,9 +404,9 @@ function buildGatewayExecApprovalFollowupSummary(params: {
     const body = [diagnosticsText, followupText].filter(Boolean).join("\n\n");
     summary = `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${body}`;
   } else {
-    const output = normalizeNotifyOutput(
-      tail(params.outcome.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
-    );
+    const output = formatExecApprovalContinuationOutput([
+      { label: "output", value: params.outcome.aggregated },
+    ]);
     summary = output
       ? `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${output}`
       : `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})`;

--- a/src/agents/bash-tools.exec-host-node.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node.cancellation.test.ts
@@ -85,12 +85,8 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
   resolveExecHostApprovalContext: mocks.resolveExecHostApprovalContext,
 }));
 
-vi.mock("./bash-process-registry.js", () => ({ tail: vi.fn((text: string) => text) }));
-
 vi.mock("./bash-tools.exec-runtime.js", () => ({
-  DEFAULT_NOTIFY_TAIL_CHARS: 1_000,
   createApprovalSlug: vi.fn(() => "approval"),
-  normalizeNotifyOutput: vi.fn((text: string) => text),
 }));
 
 vi.mock("./embedded-agent-runner/run/abortable.js", () => ({

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -291,9 +291,7 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
 }));
 
 vi.mock("./bash-tools.exec-runtime.js", () => ({
-  DEFAULT_NOTIFY_TAIL_CHARS: 1000,
   createApprovalSlug: vi.fn(() => "slug"),
-  normalizeNotifyOutput: vi.fn((value: string) => value),
 }));
 
 vi.mock("./tools/gateway.js", () => ({
@@ -1495,7 +1493,48 @@ describe("executeNodeHostCommand", () => {
     const loneSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
     expect(message).not.toMatch(loneSurrogate);
     expect(message).not.toContain("�");
-    expect(message).toContain(`Exec finished (node=node-1 id=approval-1, code 0)\n${tailHead}`);
+    expect(message).toBe(`Exec finished (node=node-1 id=approval-1, code 0)\n${stdout}`);
+  });
+
+  it("keeps approved node follow-up output multiline instead of compacting it", async () => {
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+    const stdout = "first\r\n\tindented\n\n  spaced   \n[source output truncated]\n  \t";
+    const stderr = "warn one\nwarn two";
+    callGatewayToolMock.mockImplementation(
+      async (method: string, _options: unknown, params: MockNodeInvokeParams | undefined) => {
+        if (method === "exec.approvals.node.get") {
+          return { file: { version: 1, agents: {} } };
+        }
+        if (method !== "node.invoke") {
+          throw new Error(`unexpected gateway method: ${method}`);
+        }
+        if (params?.command === "system.run.prepare") {
+          return { payload: { plan: preparedPlan } };
+        }
+        if (params?.command === "system.run") {
+          return {
+            payload: { success: true, stdout, stderr, exitCode: 0, timedOut: false },
+          };
+        }
+        throw new Error(`unexpected node invoke command: ${String(params?.command)}`);
+      },
+    );
+
+    const result = await executeNodeHostCommand(createNodeHostRequest({}));
+
+    expect(result.details?.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalled();
+    });
+    expect(sendExecApprovalFollowupResultMock.mock.calls[0]?.[1]).toBe(
+      "Exec finished (node=node-1 id=approval-1, code 0)\n" +
+        `[stdout]\n${stdout}\n[stderr]\n${stderr}`,
+    );
   });
 
   it("does not build a human approval prompt for node auto-review allows", async () => {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -18,7 +18,7 @@ import {
   defaultExecAutoReviewer,
   resolveExecAutoReviewDecision,
 } from "../infra/exec-auto-review.js";
-import { tail } from "./bash-process-registry.js";
+import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval-output.js";
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
@@ -36,11 +36,7 @@ import {
 } from "./bash-tools.exec-host-node-phases.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
 import * as execHostShared from "./bash-tools.exec-host-shared.js";
-import {
-  DEFAULT_NOTIFY_TAIL_CHARS,
-  createApprovalSlug,
-  normalizeNotifyOutput,
-} from "./bash-tools.exec-runtime.js";
+import { createApprovalSlug } from "./bash-tools.exec-runtime.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { abortable } from "./embedded-agent-runner/run/abortable.js";
 import type { AgentToolResult } from "./runtime/index.js";
@@ -614,10 +610,11 @@ export async function executeNodeHostCommand(
                     timedOut?: boolean;
                   })
                 : {};
-            const combined = [payload.stdout, payload.stderr, payload.error]
-              .filter(Boolean)
-              .join("\n");
-            const output = normalizeNotifyOutput(tail(combined, DEFAULT_NOTIFY_TAIL_CHARS));
+            const output = formatExecApprovalContinuationOutput([
+              { label: "stdout", value: payload.stdout },
+              { label: "stderr", value: payload.stderr },
+              { label: "error", value: payload.error },
+            ]);
             const exitLabel = payload.timedOut ? "timeout" : `code ${payload.exitCode ?? "?"}`;
             const summary = output
               ? `Exec finished (node=${target.nodeId} id=${approvalId}, ${exitLabel})\n${output}`

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -515,6 +515,17 @@ describe("exec notifyOnExit suppression", () => {
     expect(heartbeat.sessionKey).toBe("agent:main:main");
   });
 
+  it("still compacts multiline background notifications to one line", async () => {
+    await runBackgroundedExit({
+      reason: "manual-cancel",
+      stdout: "first line\n\tindented\n\n  spaced   \n",
+    });
+
+    const [message] = requireSystemEventCall();
+    expect(message).toContain("first line indented spaced");
+    expect(message.split("\n")).toHaveLength(1);
+  });
+
   it("still notifies for no-output background exec timeouts", async () => {
     await runBackgroundedExit({ reason: "overall-timeout" });
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -102,7 +102,7 @@ export const DEFAULT_PENDING_MAX_OUTPUT = clampWithDefault(
 export const DEFAULT_PATH =
   process.env.PATH ?? "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 /** Tail length used in background completion notifications. */
-export const DEFAULT_NOTIFY_TAIL_CHARS = 400;
+const DEFAULT_NOTIFY_TAIL_CHARS = 400;
 const DEFAULT_NOTIFY_SNIPPET_CHARS = 180;
 /** Default time an approval can remain pending. */
 export const DEFAULT_APPROVAL_TIMEOUT_MS = DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -499,6 +499,55 @@ describe("exec approvals", () => {
     expect(agent.sessionKey).toBe("agent:main:main");
   });
 
+  it("carries multiline approved node output into the agent continuation", async () => {
+    const stdout = "first\r\n\tindented\n\n  spaced   \n[source output truncated]\n  \t";
+    const stderr = "warn one\nwarn two";
+    let agentParams: unknown;
+
+    mockAcceptedApprovalFlow({
+      onAgent: (params) => {
+        agentParams = params;
+      },
+      onNodeInvoke: (params) => {
+        const invoke = params as { command?: string };
+        if (invoke.command === "system.run.prepare") {
+          return buildPreparedSystemRunPayload(params);
+        }
+        if (invoke.command === "system.run") {
+          return {
+            payload: { success: true, stdout, stderr, error: null, exitCode: 0, timedOut: false },
+          };
+        }
+        return undefined;
+      },
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+      sessionKey: "agent:main:main",
+    });
+
+    const result = await tool.execute("call-multiline", { command: "print-streams" });
+    const details = expectPendingApprovalText(result, {
+      command: "print-streams",
+      host: "node",
+      nodeId: "node-1",
+      interactive: true,
+      allowedDecisions: "allow-once|deny",
+      cwdText: "(node default)",
+    });
+
+    await expect.poll(() => agentParams !== undefined, { timeout: 3000, interval: 1 }).toBe(true);
+    const message = String(requireRecord(agentParams, "agent followup params").message);
+    expect(message).toContain(
+      "Exact completion details:\n" +
+        `Exec finished (node=node-1 id=${details.approvalId}, code 0)\n` +
+        `[stdout]\n${stdout}\n[stderr]\n${stderr}\n\nContinue the task if needed`,
+    );
+  });
+
   it("skips approval when node allowlist is satisfied", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-bin-"));
     const binDir = path.join(tempDir, "bin");


### PR DESCRIPTION
Closes #41152

## What Problem This Solves

Fixes an issue where users who approve an async exec request would see the agent resume with a mangled, heavily truncated view of the command it just ran. Only the last ~400 characters survived, every newline, tab, indent and blank line was collapsed into single spaces, the front of the output was silently dropped, and nothing told the agent that anything had been cut.

This affects both exec hosts:

- `host=node` approvals (`src/agents/bash-tools.exec-host-node.ts`)
- `host=gateway` approvals (`buildGatewayExecApprovalFollowupSummary` in `src/agents/bash-tools.exec-host-gateway.ts`)

In practice: approve a long build, test run, or `git diff`, and the agent comes back reasoning about a single unreadable line of the tail. Structured output — stack traces, compiler errors, diffs, tables — is destroyed, and because there is no truncation marker the agent treats the fragment as the complete result.

There is a second, quieter loss on the same path: `sendExecApprovalFollowup` trimmed the result text and `buildExecApprovalFollowupPrompt` trimmed it again, so trailing output whitespace never survived even once the cap was lifted.

## Why This Change Was Made

Both call sites were reusing the **compact background-notification** formatter for **model continuation**. `DEFAULT_NOTIFY_TAIL_CHARS = 400` and `normalizeNotifyOutput` (`value.replace(/\s+/g, " ").trim()`) were introduced in `07a3db153dc` ("feat: notify on exec exit") to render a *one-line chat notification*. #37233 (merged as `de49a8b72c1`) later wired the approval-continuation path through those same helpers — `git log -L 620,620:src/agents/bash-tools.exec-host-node.ts` bottoms out there. That was accidental policy reuse, not a deliberate continuation limit. A notification is one chat line; a continuation is the model's only view of a command it already approved.

The fix adds one shared, pure formatter (`src/agents/bash-tools.exec-approval-output.ts`) used by both hosts:

- **No whitespace normalization.** LF, CRLF, tabs, indentation, blank lines and trailing whitespace are preserved byte-for-byte. Existing source-side truncation markers ride through untouched.
- **Deterministic stream order**, `stdout` → `stderr` → `error`, labelled `[stdout]` / `[stderr]` / `[error]` only when more than one stream has content. A single stream is emitted verbatim and unlabelled, because the gateway supplies one already-interleaved aggregate and a header there would imply a split the payload does not carry. This deliberately makes **no** claim of chronological stdout/stderr interleaving — the node payload supplies separate fields.
- **Under-limit and exact-limit output is byte-identical to the input.**
- **Over-limit output** gets a head/tail split with an exact, marker-inclusive omission count: `[... N UTF-16 code units omitted from approved exec output; showing first H and last T ...]`. Generated labels and the marker are budgeted *inside* the hard cap, so the returned string is always `<= MAX`.
- **Unicode-safe cuts** via `sliceUtf16Safe` from `@openclaw/normalization-core/utf16-slice`, building directly on the contract from #98721 rather than hand-rolling Unicode boundaries.
- **Complete stream labels.** A cut landing inside a generated header is pushed to the header boundary (head cut → header start, tail cut → header end). When the omitted middle swallowed the tail stream's header, the marker names it (`; tail resumes in stderr`) rather than splicing a synthetic header into the retained content, so `omitted + head + tail` always sums to the exact input length. A partial `[stde` never reaches the model.
- `sendExecApprovalFollowup` now classifies empty/denied results on the **trimmed** text but passes the **raw** successful result text into `buildExecApprovalFollowupPrompt` and the agent continuation.

### Budget: 16,000 UTF-16 units (nominal 12,000 head / 4,000 tail)

This is the one real design call, so here is the reasoning:

- **Not 400.** `DEFAULT_NOTIFY_TAIL_CHARS` is a one-line chat-notification budget. It stays exactly as-is for `notifyOnExit`, and this PR does not widen ordinary background notifications.
- **Not 200,000.** `DEFAULT_MAX_OUTPUT` (`bash-tools.exec-runtime.ts:88`) is a *retained storage* cap for poll-back, not a model-injection cap. Reusing it here would put a fifth of a megabyte straight into the model's context.
- **16,000 is the shipped model-facing floor.** `DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS = 16_000` (`src/agents/tool-result-limits.ts:5`) is what every exec tool result is truncated to when the context window is unknown or small (`resolveLiveToolResultMaxChars`). An approved async exec should hand the agent roughly what the same command would have handed it inline. The exec host builds this text *before* the resuming agent's model and context window are resolved, so the conservative floor is the only defensible default.
- The continuation re-enters as a **user follow-up** and therefore bypasses the tool-result guard entirely — which is exactly why it needs its own explicit bound, per the root `AGENTS.md` rule that every injected context item is bounded with a hard cap.
- **3:1 head/tail** because command output front-loads the interesting failure (first compiler error, first stack frame) and back-loads the summary and exit context.
- **No new config knob.** Root `AGENTS.md` sets a high bar for new config/env surface and asks that existing product behavior solve it first. The constant derives from an existing shipped limit; a knob would be a second spelling of the same policy.

### Non-goals / boundaries

- `DEFAULT_NOTIFY_TAIL_CHARS` and `normalizeNotifyOutput` are **completely unchanged** and still own compact `notifyOnExit` notifications, poll output and retained aggregate storage.
- The gateway `diagnostics` trigger branch (`formatDiagnosticsExportFailure`, 4000-char tail) is untouched.
- Direct and detached execution paths are untouched.

### Security

Exec output stays **untrusted**. This truncation is a context-budget device, **not** a sanitization or prompt-injection boundary — widening it does not change the trust model, and it was never providing a security property. The existing `parseExecApprovalResultText` CWE-841 approval-metadata spoofing guard (`APPROVAL_METADATA_SOURCE_RE` in `exec-approval-result.ts`) is untouched, and direct human-facing delivery still runs through `sanitizeUserFacingText`.

### Prior art

- #41170 and #92185 both attempted gateway-only fixes and were closed unmerged. This is fresh work covering **both** hosts with a single shared formatter, but credit to both for surfacing the gateway half.
- #98721 ("fix(agents): keep bounded exec output UTF-16 safe") made this same node cut surrogate-safe while explicitly preserving the caps. That contract is reused here, not reverted — the new formatter cuts through `sliceUtf16Safe` and the UTF-16 boundary test from that PR is retained (updated to assert the now-complete output).
- #37233 / `de49a8b72c1` is the provenance of the accidental helper reuse.

## User Impact

Approving an async exec now gives the agent the actual output of the command it approved: multi-line, correctly indented, in a readable form, with `stdout` / `stderr` / `error` clearly separated when more than one is present. Stack traces, compiler errors, test output and diffs stay legible instead of being flattened into one 400-character line.

When output genuinely exceeds the budget, the agent gets the beginning *and* the end plus an explicit, factual marker naming exactly how many UTF-16 code units were dropped, so it can decide to re-run or narrow the command instead of silently reasoning about a fragment.

No configuration change is required and no existing setting changes meaning. Chat notifications (`notifyOnExit`), polling, and retained output are byte-for-byte identical to before.

## Evidence

### Remote real-scenario proof (Crabbox, AWS `c7a.8xlarge`, Ubuntu, Node 24.18.1)

Not a copied unit-test run. A harness imported the real `runExecProcess` from `bash-tools.exec-runtime.ts`, executed real child processes, and built the real follow-up text both hosts now produce, comparing it against the pre-fix compact formatter.

`crabbox` lease `cbx_7e90bd3b966e` / run `run_71031fda82d2`, final timing JSON `exitCode: 0`, `runStatus: "succeeded"`.

**Gateway host, real 900,042-unit build log** (`printf` loop over 20,000 lines with tabs, indentation, a blank line and emoji):

| | pre-fix | post-fix |
|---|---|---|
| UTF-16 units delivered | 356 | 15,999 |
| lines | 1 | 357 |
| tabs preserved | no | yes |
| blank lines preserved | no | yes |
| units silently dropped with no signal | 899,686 | 0 (marker states the count) |

Post-fix marker: `[... 884148 UTF-16 code units omitted from approved exec output; showing first 11920 and last 3974 ...]` — `884148 + 11920 + 3974 == 900042` exactly. Result length 15,999 ≤ 16,000.

**Node host, under cap, two real processes (stdout + stderr):**

```
pre-fix : "step one indented final ✅ warning: deprecated flag warning: retrying 🔁"
post-fix: "[stdout]\nstep one\r\n\tindented   \n\nfinal ✅\n[stderr]\nwarning: deprecated flag\nwarning: retrying 🔁"
```

Both streams byte-identical to the raw process output; CRLF, tab, trailing spaces, blank line and both emoji survive; labels complete; order deterministic.

**Node host, over cap** (89,999 units stdout + 89,999 units stderr, 180,017 rendered):

- result 15,999 units, within the 16,000 cap
- `[... 164147 UTF-16 code units omitted from approved exec output; showing first 11902 and last 3968; tail resumes in stderr ...]` — `164147 + 11902 + 3968 == 180017` exactly
- head cut lands mid-line inside `[stdout]`, tail cut lands inside `[stderr]` content: no partial header emitted, no lone surrogate anywhere in the result (emoji on every line)

**Background notifications unchanged** in the same run: `notifyOnExit` output still collapses to a single line.

### Autoreview

`.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (codex, `gpt-5.6-sol`, `high`).

Two cycles produced findings, both real and both fixed rather than patched around:

1. **Cap violation on very large input.** The marker reserve was derived from `MAX_UTF16_UNITS`, budgeting only a five-digit omitted count. At ~1M units the count needs seven digits and the result reached 16,001 — over the documented hard cap. Fixed by deriving the reserve from the actual input length (`resolveCutBudget`), which is a strict upper bound because `omitted <= totalUnits`. Regression test loops `[100_000, 1_016_000, 12_000_000]`.
2. **Inexact omission accounting.** Re-emitting the tail stream's header spliced synthetic bytes into the retained content, so `omitted + head + tail` fell short of the input length by the header width. Fixed by naming the resuming stream in the marker instead — no fabricated content, exact accounting, label information still complete. This deleted `resolveRetainedTailLabel` and its budget-juggling.

Final run: `autoreview clean: no accepted/actionable findings reported` — `overall: patch is correct (0.95)`.

### Tests

`node scripts/run-vitest.mjs` over the touched files, all green:

- `bash-tools.exec-approval-output.test.ts` — 14 tests (empty/blank, single-stream verbatim, multi-stream labelling and order, whitespace/CRLF/tab preservation, source-truncation-marker survival, under/exact/over limit, surrogate boundaries at both cuts, head cut and tail cut each inside a generated header, exact omission accounting, cap held for 7- and 8-digit omitted counts)
- `bash-tools.exec-approval-followup.test.ts`, `bash-tools.exec.approval-id.test.ts`, `bash-tools.exec-runtime.test.ts`, `bash-tools.exec-host-node.test.ts`, `bash-tools.exec-host-node.cancellation.test.ts` — 182 tests
- `bash-tools.exec-host-gateway.test.ts` — **90/90 pass on the Crabbox box**

### Previously reported local failures — resolved

The earlier evidence listed two `bash-tools.exec-host-gateway.test.ts` failures and one e2e timeout as local artifacts. Settled on the remote box rather than deferred to CI:

- The two gateway unit failures (`execCommandOverride` receiving `/usr/bin/cd .` instead of `cd .`, and a `shadowGit` resolved-path mismatch) **do not reproduce**: the full suite is 90/90 on Linux. They were macOS-local `PATH`/`realpath` artifacts.
- `bash-tools.exec-gateway-approval.e2e.test.ts` fails on the box too, but with the four touched prod files reverted to their `origin/main` contents in place it fails **identically** at `processGatewayAllowlist` (`Headless runs cannot wait for interactive exec approval`). It is pre-existing and environmental: the denial happens at exec dispatch, strictly before any approval resolves or any follow-up text is formatted.

### Lint / typecheck / format

`oxfmt`, `scripts/run-oxlint.mjs`, `run-tsgo.mjs -p tsconfig.core.json`, `run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json`, and `scripts/check-deadcode-exports.mjs` all clean.
