### PR TITLE
fix(ci): stabilize Codex websocket heartbeat tests

### DIFF
--- a/extensions/codex/src/app-server/transport-websocket.test.ts
+++ b/extensions/codex/src/app-server/transport-websocket.test.ts
@@ -84,7 +84,7 @@ describe("Codex app-server websocket transport", () => {
   });
 
   it("keeps an idle remote websocket healthy with protocol-level ping frames", async () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
     servers.push(server);
     let resolveConnected: (() => void) | undefined;
@@ -116,6 +116,9 @@ describe("Codex app-server websocket transport", () => {
     });
     transports.push(transport);
     await connected;
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
 
     await vi.advanceTimersByTimeAsync(20_000);
     await expect(receivedPing).resolves.toBeUndefined();
@@ -125,7 +128,7 @@ describe("Codex app-server websocket transport", () => {
   });
 
   it("closes a remote websocket only after five consecutive unanswered pings", async () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const server = new WebSocketServer({ host: "127.0.0.1", port: 0, autoPong: false });
     servers.push(server);
     let resolveConnected: (() => void) | undefined;
@@ -160,6 +163,9 @@ describe("Codex app-server websocket transport", () => {
       transport.once("exit", (code) => resolve(code));
     });
     await connected;
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
 
     await vi.advanceTimersByTimeAsync(20_000);
     await expect(receivedPing).resolves.toBeUndefined();


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where the Codex WebSocket heartbeat tests could wait for 120 seconds and time out when the server accepted a connection before the client scheduled its heartbeat timer.

## Why This Change Was Made

The tests now fake only the heartbeat timeout APIs and yield one real event-loop turn after the server connection so the client `open` handler schedules the heartbeat before the clock advances. Production heartbeat behavior is unchanged.

## User Impact

No runtime behavior change. Release and plugin-prerelease validation no longer hangs on this test race.

## Evidence

- Failing plugin prerelease run: https://github.com/openclaw/openclaw/actions/runs/30595447850
- Both isolated heartbeat tests pass in 13–14 ms.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/transport-websocket.test.ts` passed 3/3 bounded runs (8 tests each).
- `git diff --check`
- Upstream Codex contract checked in `codex-rs/app-server-transport/src/transport/websocket.rs`: ping payloads receive matching pong frames.
