### PR TITLE
improve(agents): index swarm scheduler runs

### DIFF
--- a/src/agents/swarm-scheduler.test.ts
+++ b/src/agents/swarm-scheduler.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   activateSwarmRun,
   enqueueSwarmRun,
+  isSwarmRunQueued,
   releaseSwarmRun,
   removeQueuedSwarmRun,
   reserveSwarmRun,
@@ -125,6 +126,66 @@ describe("swarm scheduler", () => {
     await vi.waitFor(() => expect(started).toEqual(["one"]));
     releaseSwarmRun("one");
     await vi.waitFor(() => expect(started).toEqual(["one", "three"]));
+  });
+
+  it("tracks restored active and queued runs across independent groups", () => {
+    expect(
+      reserveSwarmRun({
+        groupId: "restored-group",
+        runId: "queued",
+        maxConcurrent: 1,
+        activeRunIds: ["restored-active"],
+      }),
+    ).toBe(true);
+    expect(
+      reserveSwarmRun({
+        groupId: "other-group",
+        runId: "other-queued",
+        maxConcurrent: 1,
+        activeRunIds: [],
+      }),
+    ).toBe(true);
+
+    expect(isSwarmRunQueued("queued")).toBe(true);
+    expect(isSwarmRunQueued("other-queued")).toBe(true);
+    expect(releaseSwarmRun("restored-active")).toBe(true);
+    expect(removeQueuedSwarmRun("other-queued")).toBe(true);
+    expect(isSwarmRunQueued("queued")).toBe(true);
+    expect(isSwarmRunQueued("other-queued")).toBe(false);
+    expect(removeQueuedSwarmRun("queued")).toBe(true);
+  });
+
+  it("keeps a live reservation queued when a later snapshot reports it active", async () => {
+    expect(
+      reserveSwarmRun({
+        groupId: "group",
+        runId: "queued",
+        maxConcurrent: 1,
+        activeRunIds: [],
+      }),
+    ).toBe(true);
+    expect(
+      reserveSwarmRun({
+        groupId: "group",
+        runId: "next",
+        maxConcurrent: 1,
+        activeRunIds: ["queued"],
+      }),
+    ).toBe(true);
+
+    const started: string[] = [];
+    expect(
+      activateSwarmRun({
+        groupId: "group",
+        runId: "queued",
+        start: async () => {
+          started.push("queued");
+        },
+        onStartFailure: vi.fn(() => true),
+      }),
+    ).toBe("started");
+    await vi.waitFor(() => expect(started).toEqual(["queued"]));
+    expect(isSwarmRunQueued("next")).toBe(true);
   });
 
   it("retries the same queued run when failure persistence throws", async () => {
@@ -272,6 +333,140 @@ describe("swarm scheduler", () => {
     expect(started).toEqual(["one", "two"]);
     releaseSwarmRun("two");
     await vi.waitFor(() => expect(started).toEqual(["one", "two", "three"]));
+  });
+
+  it("refreshes the lane limit before rejecting a duplicate reservation", async () => {
+    const started: string[] = [];
+    const enqueue = (runId: string) =>
+      enqueueSwarmRun({
+        groupId: "group",
+        runId,
+        maxConcurrent: 2,
+        activeRunIds: [],
+        start: async () => {
+          started.push(runId);
+        },
+        onStartFailure: vi.fn(() => true),
+      });
+
+    enqueue("one");
+    enqueue("two");
+    enqueue("three");
+    await vi.waitFor(() => expect(started).toEqual(["one", "two"]));
+
+    expect(
+      reserveSwarmRun({
+        groupId: "group",
+        runId: "one",
+        maxConcurrent: 1,
+        activeRunIds: ["one", "two"],
+      }),
+    ).toBe(false);
+    expect(releaseSwarmRun("one")).toBe(true);
+    await Promise.resolve();
+    expect(started).toEqual(["one", "two"]);
+    expect(releaseSwarmRun("two")).toBe(true);
+    await vi.waitFor(() => expect(started).toEqual(["one", "two", "three"]));
+  });
+
+  it("does not retry a failed start after its scheduler slot was released", async () => {
+    vi.useFakeTimers();
+    let finishCleanup: (() => void) | undefined;
+    const cleanup = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    let failedAttempts = 0;
+    const started: string[] = [];
+    enqueueSwarmRun({
+      groupId: "group",
+      runId: "failed",
+      maxConcurrent: 1,
+      activeRunIds: [],
+      start: async () => {
+        failedAttempts += 1;
+        throw new Error("launch failed");
+      },
+      onStartFailure: async () => {
+        await cleanup;
+        throw new Error("persistence failed");
+      },
+    });
+    await flushMicrotasks();
+    expect(failedAttempts).toBe(1);
+    expect(releaseSwarmRun("failed")).toBe(true);
+
+    enqueueSwarmRun({
+      groupId: "group",
+      runId: "replacement",
+      maxConcurrent: 1,
+      activeRunIds: [],
+      start: async () => {
+        started.push("replacement");
+      },
+      onStartFailure: vi.fn(() => true),
+    });
+    await flushMicrotasks();
+    expect(started).toEqual(["replacement"]);
+
+    finishCleanup?.();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(failedAttempts).toBe(1);
+  });
+
+  it("does not let stale failed-start cleanup mutate a reused run id", async () => {
+    vi.useFakeTimers();
+    let finishCleanup: (() => void) | undefined;
+    const cleanup = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    let reusedAttempts = 0;
+    enqueueSwarmRun({
+      groupId: "group",
+      runId: "reused",
+      maxConcurrent: 2,
+      activeRunIds: [],
+      start: async () => {
+        reusedAttempts += 1;
+        throw new Error("launch failed");
+      },
+      onStartFailure: async () => {
+        await cleanup;
+        throw new Error("persistence failed");
+      },
+    });
+    enqueueSwarmRun({
+      groupId: "group",
+      runId: "holder",
+      maxConcurrent: 2,
+      activeRunIds: [],
+      start: async () => {},
+      onStartFailure: vi.fn(() => true),
+    });
+    await flushMicrotasks();
+    expect(reusedAttempts).toBe(1);
+    expect(releaseSwarmRun("reused")).toBe(true);
+
+    expect(
+      enqueueSwarmRun({
+        groupId: "group",
+        runId: "reused",
+        maxConcurrent: 2,
+        activeRunIds: [],
+        start: async () => {
+          reusedAttempts += 1;
+        },
+        onStartFailure: vi.fn(() => true),
+      }),
+    ).toBe("started");
+    await flushMicrotasks();
+    expect(reusedAttempts).toBe(2);
+
+    finishCleanup?.();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(reusedAttempts).toBe(2);
+    expect(releaseSwarmRun("reused")).toBe(true);
   });
 
   it("fills increased capacity from the existing FIFO queue", async () => {

--- a/src/agents/swarm-scheduler.ts
+++ b/src/agents/swarm-scheduler.ts
@@ -10,12 +10,18 @@ type QueuedSwarmRun = {
 };
 
 type SwarmGroupLane = {
+  groupId: string;
   limit: number;
   active: Set<string>;
   queue: QueuedSwarmRun[];
 };
 
 const lanes = new Map<string, SwarmGroupLane>();
+const runLocations = new Map<
+  string,
+  | { lane: SwarmGroupLane; state: "active"; item?: QueuedSwarmRun }
+  | { lane: SwarmGroupLane; state: "queued"; item: QueuedSwarmRun }
+>();
 
 function startQueuedRun(lane: SwarmGroupLane, item: QueuedSwarmRun) {
   const start = item.start;
@@ -24,6 +30,7 @@ function startQueuedRun(lane: SwarmGroupLane, item: QueuedSwarmRun) {
     return;
   }
   lane.active.add(item.runId);
+  runLocations.set(item.runId, { lane, state: "active", item });
   queueMicrotask(() => {
     void start().catch(async (error: unknown) => {
       let failurePersisted = false;
@@ -32,6 +39,15 @@ function startQueuedRun(lane: SwarmGroupLane, item: QueuedSwarmRun) {
       } catch {
         // A durable queued row still owns this work; retry after a short backoff.
       }
+      const location = runLocations.get(item.runId);
+      if (
+        !location ||
+        location.state !== "active" ||
+        location.lane !== lane ||
+        location.item !== item
+      ) {
+        return;
+      }
       if (failurePersisted) {
         releaseSwarmRun(item.runId);
         return;
@@ -39,6 +55,7 @@ function startQueuedRun(lane: SwarmGroupLane, item: QueuedSwarmRun) {
       lane.active.delete(item.runId);
       item.retryReady = false;
       lane.queue.unshift(item);
+      runLocations.set(item.runId, { lane, state: "queued", item });
       const timer = setTimeout(
         () => {
           item.retryReady = true;
@@ -68,6 +85,7 @@ function ensureLane(params: {
   activeRunIds: readonly string[];
 }): SwarmGroupLane {
   const lane = lanes.get(params.groupId) ?? {
+    groupId: params.groupId,
     limit: params.maxConcurrent,
     active: new Set<string>(),
     queue: [],
@@ -75,9 +93,21 @@ function ensureLane(params: {
   lanes.set(params.groupId, lane);
   lane.limit = params.maxConcurrent;
   for (const runId of params.activeRunIds) {
+    // A live reservation is newer than a restored active snapshot. Reclassifying
+    // it here would leave its queue node behind and block FIFO admission.
+    if (runLocations.has(runId)) {
+      continue;
+    }
     lane.active.add(runId);
+    runLocations.set(runId, { lane, state: "active" });
   }
   return lane;
+}
+
+function deleteLaneIfIdle(lane: SwarmGroupLane): void {
+  if (lanes.get(lane.groupId) === lane && lane.active.size === 0 && lane.queue.length === 0) {
+    lanes.delete(lane.groupId);
+  }
 }
 
 /** Reserve FIFO position before asynchronous spawn preparation begins. */
@@ -88,10 +118,13 @@ export function reserveSwarmRun(params: {
   activeRunIds: readonly string[];
 }): boolean {
   const lane = ensureLane(params);
-  if (lane.active.has(params.runId) || lane.queue.some((item) => item.runId === params.runId)) {
+  if (runLocations.has(params.runId)) {
+    deleteLaneIfIdle(lane);
     return false;
   }
-  lane.queue.push({ runId: params.runId, ready: false, retryReady: true });
+  const item = { runId: params.runId, ready: false, retryReady: true };
+  lane.queue.push(item);
+  runLocations.set(params.runId, { lane, state: "queued", item });
   return true;
 }
 
@@ -102,11 +135,11 @@ export function activateSwarmRun(params: {
   start: () => Promise<void>;
   onStartFailure: (error: unknown) => boolean | Promise<boolean>;
 }): "started" | "queued" {
-  const lane = lanes.get(params.groupId);
-  const item = lane?.queue.find((candidate) => candidate.runId === params.runId);
-  if (!lane || !item) {
+  const location = runLocations.get(params.runId);
+  if (!location || location.state !== "queued" || location.lane.groupId !== params.groupId) {
     throw new Error(`swarm scheduler reservation missing for run ${params.runId}`);
   }
+  const { lane, item } = location;
   item.start = params.start;
   item.onStartFailure = params.onStartFailure;
   item.ready = true;
@@ -141,47 +174,40 @@ export function enqueueSwarmRun(params: {
 }
 
 export function releaseSwarmRun(runId: string): boolean {
-  for (const [groupId, lane] of lanes) {
-    if (!lane.active.delete(runId)) {
-      continue;
-    }
-    pumpLane(lane);
-    if (lane.active.size === 0 && lane.queue.length === 0) {
-      lanes.delete(groupId);
-    }
-    return true;
+  const location = runLocations.get(runId);
+  if (!location || location.state !== "active" || !location.lane.active.delete(runId)) {
+    return false;
   }
-  return false;
+  runLocations.delete(runId);
+  pumpLane(location.lane);
+  deleteLaneIfIdle(location.lane);
+  return true;
 }
 
 export function removeQueuedSwarmRun(runId: string): boolean {
-  for (const [groupId, lane] of lanes) {
-    const index = lane.queue.findIndex((item) => item.runId === runId);
-    if (index < 0) {
-      continue;
-    }
-    lane.queue.splice(index, 1);
-    pumpLane(lane);
-    if (lane.active.size === 0 && lane.queue.length === 0) {
-      lanes.delete(groupId);
-    }
-    return true;
+  const location = runLocations.get(runId);
+  if (!location || location.state !== "queued") {
+    return false;
   }
-  return false;
+  const index = location.lane.queue.indexOf(location.item);
+  if (index < 0) {
+    return false;
+  }
+  location.lane.queue.splice(index, 1);
+  runLocations.delete(runId);
+  pumpLane(location.lane);
+  deleteLaneIfIdle(location.lane);
+  return true;
 }
 
 export function isSwarmRunQueued(runId: string): boolean {
-  for (const lane of lanes.values()) {
-    if (lane.queue.some((item) => item.runId === runId)) {
-      return true;
-    }
-  }
-  return false;
+  return runLocations.get(runId)?.state === "queued";
 }
 
 const testing = {
   reset() {
     lanes.clear();
+    runLocations.clear();
   },
 };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where completing or cancelling swarm runs scanned every live swarm group to find the owning lane. Teardown across many independent groups therefore grew quadratically and added avoidable gateway work.

## Why This Change Was Made

The scheduler now maintains a process-local `runId` index containing the owning lane, scheduler state, and reservation identity. Release, queued removal, queued checks, and activation use that canonical location directly. FIFO order and per-group queue removal remain unchanged.

The index is updated across reservation, activation, restored active runs, failed-start retry, release, cancellation, and test reset. Reservation identity prevents delayed failure cleanup from mutating a newer run that reuses the same deterministic ID.

## User Impact

Large multi-group swarms complete and cancel with substantially lower scheduler overhead. There is no configuration, protocol, or persistence change.

## Evidence

Benchmark harness: one active or queued run per independent group, torn down in reverse group order.

| Operation | Groups | `origin/main` baseline | This branch |
|---|---:|---:|---:|
| release active runs | 1,000 | 9.455 ms | 0.351 ms |
| remove queued runs | 1,000 | 3.480 ms | 0.208 ms |
| release active runs | 2,500 | 33.527 ms | 0.981 ms |
| remove queued runs | 2,500 | 20.452 ms | 0.646 ms |

At 2,500 groups, release is about 34x faster and queued removal about 32x faster. RSS remained effectively flat.

- `node scripts/run-vitest.mjs src/agents/swarm-scheduler.test.ts` - 13/13 passed.
- Blacksmith Testbox delegated changed gate passed: core production/test typechecks, changed-file lint, format, dead-export checks, plugin boundaries, import cycles, and repository guards.
- `oxfmt --check` passed for both changed files.
- `git diff --check` passed.
- Structured Codex autoreview: clean, no actionable findings, correctness confidence 0.94.

Baseline: `32036c473dec656b16c315581280cc807da2a6aa`  
Reviewed branch head: `6791bcca16c83bdee6d67ca811f37068f2153baf`
