### PR TITLE
fix: stabilize session creator facets across row order

### DIFF
--- a/src/gateway/session-utils-creators.test.ts
+++ b/src/gateway/session-utils-creators.test.ts
@@ -15,10 +15,90 @@ const getUserProfileListItem = vi.hoisted(() =>
 );
 
 vi.mock("../state/user-profiles.js", () => ({ getUserProfileListItem }));
+vi.mock("./session-utils-row.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-utils-row.js")>();
+  return {
+    ...actual,
+    projectSessionActor: (
+      actor: Parameters<typeof actual.projectSessionActor>[0],
+      identities: Parameters<typeof actual.projectSessionActor>[1],
+    ) => {
+      if (actor?.id === "shared-id") {
+        return actor.type === "human"
+          ? { type: actor.type, id: actor.id, label: "Alpha" }
+          : { type: actor.type, id: actor.id, label: "Zulu", avatarUrl: "/avatar" };
+      }
+      if (actor?.id === "unicode-id") {
+        return {
+          type: actor.type,
+          id: actor.id,
+          label: actor.type === "human" ? "é" : "e\u0301",
+        };
+      }
+      return actual.projectSessionActor(actor, identities);
+    },
+  };
+});
 
 import { listSessionsFromStore, listSessionsFromStoreAsync } from "./session-utils.js";
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+  getUserProfileListItem.mockClear();
+});
+
+it("keeps creator labels and avatars stable across actor order", () => {
+  const actorOrders = [
+    ["human", "agent"],
+    ["agent", "human"],
+  ] as const;
+  for (const actorOrder of actorOrders) {
+    const store = Object.fromEntries(
+      actorOrder.map((type, index) => [
+        `agent:main:${index}`,
+        {
+          createdActor: { type, id: "shared-id" },
+          sessionId: `session-${index}`,
+          updatedAt: 2 - index,
+        } satisfies SessionEntry,
+      ]),
+    );
+    const result = listSessionsFromStore({
+      cfg: {} as OpenClawConfig,
+      storePath: "/tmp/openclaw-session-creator-order",
+      store,
+      opts: { archived: "all" },
+    });
+
+    expect(result.creators).toEqual([{ id: "shared-id", label: "Alpha", avatarUrl: "/avatar" }]);
+  }
+});
+
+it("breaks locale-equivalent creator label ties deterministically", () => {
+  for (const actorOrder of [
+    ["human", "agent"],
+    ["agent", "human"],
+  ] as const) {
+    const store = Object.fromEntries(
+      actorOrder.map((type, index) => [
+        `agent:main:unicode-${index}`,
+        {
+          createdActor: { type, id: "unicode-id" },
+          sessionId: `unicode-session-${index}`,
+          updatedAt: 2 - index,
+        } satisfies SessionEntry,
+      ]),
+    );
+    const result = listSessionsFromStore({
+      cfg: {} as OpenClawConfig,
+      storePath: "/tmp/openclaw-session-creator-unicode-order",
+      store,
+      opts: { archived: "all" },
+    });
+
+    expect(result.creators).toEqual([{ id: "unicode-id", label: "e\u0301" }]);
+  }
+});
 
 it("returns the complete deterministic creator facet independently of pagination", () => {
   const store: Record<string, SessionEntry> = {

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -82,6 +82,16 @@ type SessionEntrySelection = {
   hasMore: boolean;
 };
 
+function preferredCreatorIdentityValue(
+  current: string | undefined,
+  candidate: string | undefined,
+): string | undefined {
+  if (!current || !candidate) {
+    return current ?? candidate;
+  }
+  return candidate < current ? candidate : current;
+}
+
 function addSessionCreatorIdentity(
   creators: Map<string, { id: string; label?: string; avatarUrl?: string }>,
   entry: SessionEntry,
@@ -95,15 +105,13 @@ function addSessionCreatorIdentity(
   const label = normalizeOptionalString(actor?.label);
   const avatarUrl = normalizeOptionalString(actor?.avatarUrl);
   const existing = creators.get(id);
-  if (
-    !existing ||
-    (label && (!existing.label || label.localeCompare(existing.label) < 0)) ||
-    (avatarUrl && !existing.avatarUrl)
-  ) {
+  const preferredLabel = preferredCreatorIdentityValue(existing?.label, label);
+  const preferredAvatarUrl = preferredCreatorIdentityValue(existing?.avatarUrl, avatarUrl);
+  if (!existing || preferredLabel !== existing.label || preferredAvatarUrl !== existing.avatarUrl) {
     creators.set(id, {
       id,
-      ...(label ? { label } : existing?.label ? { label: existing.label } : {}),
-      ...(avatarUrl ? { avatarUrl } : existing?.avatarUrl ? { avatarUrl: existing.avatarUrl } : {}),
+      ...(preferredLabel ? { label: preferredLabel } : {}),
+      ...(preferredAvatarUrl ? { avatarUrl: preferredAvatarUrl } : {}),
     });
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where session creator facets could show a different label for the same creator when duplicate actor records arrived in a different order.

## Why This Change Was Made

Creator labels and avatar URLs now use independent deterministic total ordering. This keeps the preferred label when a different candidate wins only on avatar quality, without pulling in the larger session-storage train.

## User Impact

Session creator filters remain stable across refreshes and store iteration order.

## Evidence

- Focused Testbox on refreshed head: `pnpm test src/gateway/session-utils-creators.test.ts` — 5 tests passed; focused test time 1.31s; run 30598324784.
- Changed gate: `node scripts/check-changed.mjs` — passed on Blacksmith Testbox run 30597338857.
- Branch autoreview against `origin/main` — clean, no actionable findings.
- Regression coverage reverses actor order and includes distinct Unicode spellings that collate equally.

### ClawSweeper rank-up moves

- Applied: rebased onto current `origin/main` and refreshed focused proof plus branch autoreview.
- Runtime-output move skipped: the public Gateway resolves one cached profile projection per creator ID, so it cannot inject two conflicting projections for one ID without mocking the internal projection boundary. The focused regression exercises the exact duplicate-candidate merge contract instead.
