### PR TITLE
fix(plugins): hide cached tools after auth is removed

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -1729,6 +1729,67 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
+  it("rechecks cached optional tool availability when provider auth changes", () => {
+    const config = createContext().config;
+    const env = {};
+    installToolManifestSnapshot({
+      config,
+      env,
+      plugin: {
+        id: "multi",
+        origin: "bundled",
+        enabledByDefault: true,
+        channels: [],
+        providers: [],
+        setup: {
+          providers: [{ id: "xai", envVars: ["XAI_API_KEY"] }],
+        },
+        contracts: {
+          tools: ["other_tool", "optional_tool"],
+        },
+        toolMetadata: {
+          optional_tool: {
+            optional: true,
+            authSignals: [{ provider: "xai" }],
+          },
+        },
+      },
+    });
+    const factory = vi.fn(() => [makeTool("other_tool"), makeTool("optional_tool")]);
+    setActivePluginRegistry(
+      createToolRegistry([
+        {
+          pluginId: "multi",
+          optional: false,
+          source: "/tmp/multi.js",
+          names: ["other_tool", "optional_tool"],
+          declaredNames: ["other_tool", "optional_tool"],
+          factory,
+        },
+      ]) as never,
+      "test-tool-registry",
+      "gateway-bindable",
+      "/tmp",
+    );
+    const resolveWithAuth = (hasAuth: boolean) =>
+      resolvePluginTools({
+        ...createResolveToolsParams({
+          context: {
+            ...createContext(),
+            config,
+          },
+          env,
+          toolAllowlist: [DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY, "optional_tool"],
+        }),
+        hasAuthForProvider: (providerId) => providerId === "xai" && hasAuth,
+      });
+
+    expectResolvedToolNames(resolveWithAuth(true), ["other_tool", "optional_tool"]);
+    expectResolvedToolNames(resolveWithAuth(false), ["other_tool"]);
+    expectResolvedToolNames(resolveWithAuth(true), ["other_tool", "optional_tool"]);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
   it("does not materialize manifest-optional sibling tools from non-optional factories by default", async () => {
     const config = createContext().config;
     installToolManifestSnapshot({

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -958,7 +958,14 @@ function resolveCachedPluginTools(params: {
     const pluginTools: AnyAgentTool[] = [];
     let hasNameConflict = false;
     const localNormalizedNames = new Set<string>();
+    const availableNormalizedToolNames = new Set(availableToolNames.map(normalizeToolName));
     for (const cachedDescriptor of cached) {
+      const normalizedDescriptorName = normalizeToolName(cachedDescriptor.descriptor.name);
+      // Live auth is intentionally absent from the descriptor cache key, so re-project
+      // every cached name through current manifest availability before optional grants.
+      if (!availableNormalizedToolNames.has(normalizedDescriptorName)) {
+        continue;
+      }
       if (!hasRequiredClientCaps(cachedDescriptor.requiredClientCaps, params.clientCaps)) {
         continue;
       }
@@ -973,14 +980,6 @@ function resolveCachedPluginTools(params: {
         continue;
       }
       if (
-        !cachedDescriptor.optional &&
-        !availableToolNames.some(
-          (name) => normalizeToolName(name) === normalizeToolName(cachedDescriptor.descriptor.name),
-        )
-      ) {
-        continue;
-      }
-      if (
         cachedDescriptor.optional &&
         !isOptionalToolAllowed({
           toolName: cachedDescriptor.descriptor.name,
@@ -990,7 +989,6 @@ function resolveCachedPluginTools(params: {
       ) {
         continue;
       }
-      const normalizedDescriptorName = normalizeToolName(cachedDescriptor.descriptor.name);
       if (
         denylistBlocksPluginTool({
           pluginId: plugin.id,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an optional plugin tool that requires provider authentication could remain available after that authentication was removed. A previous authenticated resolution populated the descriptor cache, and a later cache hit could re-expose the optional tool even though current manifest availability rejected it.

## Why This Change Was Made

Cached descriptors are now filtered against the current `availableToolNames` set before optional allowlisting and client-capability projection. This preserves the existing bounded cache while making current config, environment, and auth availability authoritative for every descriptor.

## User Impact

Agents no longer see or attempt stale auth-gated plugin tools after credentials are revoked. Required tools and optional tools that remain both available and allowlisted are unchanged.

## Evidence

- Regression proves auth on → off → on with the same config/cache: required+optional → required only → required+optional, while the tool factory runs once.
- Exact-head real runtime proof: [Testbox run 30599405880](https://github.com/openclaw/openclaw/actions/runs/30599405880) started one isolated Gateway, loaded one external tool plugin, toggled only a synthetic env-backed manifest auth signal, and captured only tool names/counts from a loopback mock Responses provider.

  | Runtime phase | Agent-visible proof tools |
  | --- | --- |
  | auth on | `auth_cache_optional`, `auth_cache_required` |
  | auth off | `auth_cache_required` |
  | auth restored | `auth_cache_optional`, `auth_cache_required` |

  All runtime assertions passed on source `456964e56ff3762d85d0a884362a73e88a29bb15`: the Gateway PID stayed constant, the required tool was always present, the optional tool disappeared with auth off, and it returned with auth on. The external-plugin runtime invoked its factory per turn (`1,2,3`); this transcript intentionally does not claim a descriptor-cache hit. Same-cache behavior is proved separately by the focused regression above.
- Fresh current-main focused proof: 91/91 tests passed.
- Patch-identical Testbox proof passed 91/91 focused tests and the full remote changed gate in run `30595537805`.
- Fresh current-main Codex autoreview reported no actionable findings at 0.93 confidence.
- Targeted formatting and `git diff --check` are clean.

Risk is low and confined to cache-hit descriptor filtering. Release-note context: optional plugin tools now disappear immediately when their current authentication or manifest availability is removed.
