### PR TITLE
fix(ci): run Windows path regressions on every host

### DIFF
--- a/src/infra/exec-command-resolution.test.ts
+++ b/src/infra/exec-command-resolution.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 import { makeExecutable, makePathEnv, makeTempDir } from "./exec-approvals-test-helpers.js";
 import {
   evaluateExecAllowlist,
@@ -562,27 +563,25 @@ describe("exec-command-resolution", () => {
   });
 
   it("does not synthesize cwd-joined allowlist candidates from drive-less windows roots", () => {
-    if (process.platform !== "win32") {
-      return;
-    }
-
-    expect(
-      resolveAllowlistCandidatePath(
-        {
-          rawExecutable: String.raw`:\Users\demo\AI\system\openclaw`,
-          executableName: "openclaw",
-        },
-        String.raw`C:\Users\demo\AI\system\openclaw`,
-      ),
-    ).toBeUndefined();
-    expect(
-      resolveAllowlistCandidatePath(
-        {
-          rawExecutable: String.raw`:/Users/demo/AI/system/openclaw`,
-          executableName: "openclaw",
-        },
-        String.raw`C:\Users\demo\AI\system\openclaw`,
-      ),
-    ).toBeUndefined();
+    withMockedPlatform("win32", () => {
+      expect(
+        resolveAllowlistCandidatePath(
+          {
+            rawExecutable: String.raw`:\Users\demo\AI\system\openclaw`,
+            executableName: "openclaw",
+          },
+          String.raw`C:\Users\demo\AI\system\openclaw`,
+        ),
+      ).toBeUndefined();
+      expect(
+        resolveAllowlistCandidatePath(
+          {
+            rawExecutable: String.raw`:/Users/demo/AI/system/openclaw`,
+            executableName: "openclaw",
+          },
+          String.raw`C:\Users\demo\AI\system\openclaw`,
+        ),
+      ).toBeUndefined();
+    });
   });
 });

--- a/src/infra/executable-path.test.ts
+++ b/src/infra/executable-path.test.ts
@@ -195,20 +195,18 @@ describe("executable path helpers", () => {
   );
 
   it("does not treat drive-less rooted windows paths as cwd-relative executables", () => {
-    if (process.platform !== "win32") {
-      return;
-    }
-
-    expect(
-      resolveExecutablePath(String.raw`:\Users\demo\AI\system\openclaw\git.exe`, {
-        cwd: String.raw`C:\Users\demo\AI\system\openclaw`,
-      }),
-    ).toBeUndefined();
-    expect(
-      resolveExecutablePath(String.raw`:/Users/demo/AI/system/openclaw/git.exe`, {
-        cwd: String.raw`C:\Users\demo\AI\system\openclaw`,
-      }),
-    ).toBeUndefined();
+    withMockedPlatform("win32", () => {
+      expect(
+        resolveExecutablePath(String.raw`:\Users\demo\AI\system\openclaw\git.exe`, {
+          cwd: String.raw`C:\Users\demo\AI\system\openclaw`,
+        }),
+      ).toBeUndefined();
+      expect(
+        resolveExecutablePath(String.raw`:/Users/demo/AI/system/openclaw/git.exe`, {
+          cwd: String.raw`C:\Users\demo\AI\system\openclaw`,
+        }),
+      ).toBeUndefined();
+    });
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Two Windows path regression tests returned early on non-Windows hosts, so Linux and macOS CI reported them as passing without executing any assertions.

## Why This Change Was Made

The tests now mock the Windows platform for the guarded code path. This keeps production behavior unchanged while making the regression assertions execute on every test host.

## User Impact

No runtime behavior changes. CI can now detect regressions in malformed drive-less Windows path handling instead of recording false-positive passes.

## Evidence

- `node scripts/run-vitest.mjs src/infra/executable-path.test.ts src/infra/exec-command-resolution.test.ts`
  - 62 passed, 1 pre-existing native-Windows normalization test skipped
- targeted `oxfmt --check`: passed
- `git diff --check`: passed
- fresh branch autoreview: clean, 0.93
- Blacksmith Testbox changed gate at `d0e51a5197`: passed in 5m19, exit 0
  - https://github.com/openclaw/openclaw/actions/runs/30598584223

### ClawSweeper Rank-up Moves

- Confirmed `withMockedPlatform` delegates to `withRestoredMocks`, which restores the `process.platform` spy after synchronous callbacks and through `Promise.finally` for async callbacks.
- Reviewed the latest ClawSweeper comment. It reported no findings and requested no code changes.
