### PR TITLE
refactor(agents): route exec approvals through run hosts

### DIFF
--- a/packages/gateway-protocol/src/exec-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/exec-approvals-validators.test.ts
@@ -1,6 +1,7 @@
 // Gateway Protocol tests cover exec approvals validators behavior.
 import { describe, expect, it } from "vitest";
 import {
+  validateExecApprovalCancelParams,
   validateExecApprovalRequestParams,
   validateExecApprovalsNodeSnapshot,
   validateExecApprovalsNodeSetParams,
@@ -14,6 +15,15 @@ import {
  */
 
 describe("exec approvals protocol validators", () => {
+  it("requires one exact exec approval id for runtime cancellation", () => {
+    expect(validateExecApprovalCancelParams({ id: "approval-1" })).toBe(true);
+    expect(validateExecApprovalCancelParams({ id: "approval-1", timeoutMs: 5_000 })).toBe(true);
+    expect(validateExecApprovalCancelParams({})).toBe(false);
+    expect(validateExecApprovalCancelParams({ id: "" })).toBe(false);
+    expect(validateExecApprovalCancelParams({ id: "approval-1", timeoutMs: 0 })).toBe(false);
+    expect(validateExecApprovalCancelParams({ id: "approval-1", extra: true })).toBe(false);
+  });
+
   it("accepts runtime-owned allowlist metadata on gateway and node set payloads", () => {
     const file = {
       version: 1 as const,

--- a/packages/gateway-protocol/src/schema-export-registry.ts
+++ b/packages/gateway-protocol/src/schema-export-registry.ts
@@ -519,6 +519,7 @@ export {
   ExecApprovalsGetParamsSchema,
   ExecApprovalsSetParamsSchema,
   ExecApprovalGetParamsSchema,
+  ExecApprovalCancelParamsSchema,
   ExecApprovalRequestParamsSchema,
   ExecApprovalResolveParamsSchema,
   QuestionAnswersSchema,

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -313,6 +313,12 @@ export const ExecApprovalResolveParamsSchema = closedObject({
   decision: NonEmptyString,
 });
 
+/** Internal runtime cancellation for one exact exec approval request. */
+export const ExecApprovalCancelParamsSchema = closedObject({
+  id: NonEmptyString,
+  timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+});
+
 // Owner-local wire types derived directly from local schema consts so the
 // public plugin-sdk declaration graph never pulls in the ProtocolSchemas registry.
 export type ExecApprovalsGetParams = Static<typeof ExecApprovalsGetParamsSchema>;
@@ -322,5 +328,6 @@ export type ExecApprovalsNodeSnapshot = Static<typeof ExecApprovalsNodeSnapshotS
 export type ExecApprovalsNodeSetParams = Static<typeof ExecApprovalsNodeSetParamsSchema>;
 export type ExecApprovalsSnapshot = Static<typeof ExecApprovalsSnapshotSchema>;
 export type ExecApprovalGetParams = Static<typeof ExecApprovalGetParamsSchema>;
+export type ExecApprovalCancelParams = Static<typeof ExecApprovalCancelParamsSchema>;
 export type ExecApprovalRequestParams = Static<typeof ExecApprovalRequestParamsSchema>;
 export type ExecApprovalResolveParams = Static<typeof ExecApprovalResolveParamsSchema>;

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-approvals.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-approvals.ts
@@ -40,6 +40,7 @@ export const ApprovalProtocolSchemas = {
   ExecApprovalsNodeSetParams: execApprovals.ExecApprovalsNodeSetParamsSchema,
   ExecApprovalsSnapshot: execApprovals.ExecApprovalsSnapshotSchema,
   ExecApprovalGetParams: execApprovals.ExecApprovalGetParamsSchema,
+  ExecApprovalCancelParams: execApprovals.ExecApprovalCancelParamsSchema,
   ExecApprovalRequestParams: execApprovals.ExecApprovalRequestParamsSchema,
   ExecApprovalResolveParams: execApprovals.ExecApprovalResolveParamsSchema,
   QuestionOption: questions.QuestionOptionSchema,

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -267,6 +267,7 @@ import {
   ExecApprovalsGetParamsSchema,
   ExecApprovalsSetParamsSchema,
   ExecApprovalGetParamsSchema,
+  ExecApprovalCancelParamsSchema,
   ExecApprovalRequestParamsSchema,
   ExecApprovalResolveParamsSchema,
   QuestionRequestParamsSchema,
@@ -659,6 +660,7 @@ export const validateApprovalResolveParams = lazyCompile(ApprovalResolveParamsSc
 export const validateExecApprovalsGetParams = lazyCompile(ExecApprovalsGetParamsSchema);
 export const validateExecApprovalsSetParams = lazyCompile(ExecApprovalsSetParamsSchema);
 export const validateExecApprovalGetParams = lazyCompile(ExecApprovalGetParamsSchema);
+export const validateExecApprovalCancelParams = lazyCompile(ExecApprovalCancelParamsSchema);
 export const validateExecApprovalRequestParams = lazyCompile(ExecApprovalRequestParamsSchema);
 export const validateExecApprovalResolveParams = lazyCompile(ExecApprovalResolveParamsSchema);
 export const validateQuestionRequestParams = lazyCompile(QuestionRequestParamsSchema);

--- a/src/agents/agent-bundle-mcp-manager-admission.ts
+++ b/src/agents/agent-bundle-mcp-manager-admission.ts
@@ -1,0 +1,30 @@
+type PendingCreateTracker = {
+  run: <T>(sessionId: string, work: () => Promise<T>) => Promise<T>;
+  hasPending: (sessionId: string) => boolean;
+  totalPending: () => number;
+};
+
+export function createPendingCreateTracker(params: {
+  onSessionDrained: (sessionId: string) => void;
+}): PendingCreateTracker {
+  const countsBySessionId = new Map<string, number>();
+  return {
+    async run<T>(sessionId: string, work: () => Promise<T>): Promise<T> {
+      countsBySessionId.set(sessionId, (countsBySessionId.get(sessionId) ?? 0) + 1);
+      try {
+        return await work();
+      } finally {
+        const remaining = (countsBySessionId.get(sessionId) ?? 1) - 1;
+        if (remaining > 0) {
+          countsBySessionId.set(sessionId, remaining);
+        } else {
+          countsBySessionId.delete(sessionId);
+          params.onSessionDrained(sessionId);
+        }
+      }
+    },
+    hasPending: (sessionId) => (countsBySessionId.get(sessionId) ?? 0) > 0,
+    totalPending: () =>
+      Array.from(countsBySessionId.values()).reduce((total, count) => total + count, 0),
+  };
+}

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -1,6 +1,7 @@
 /** Session MCP runtime manager lifecycle: maps, idle sweep, dispose, advertised catalog. */
 import { logWarn } from "../logger.js";
 import { isCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
+import { createPendingCreateTracker } from "./agent-bundle-mcp-manager-admission.js";
 import {
   DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS,
   SESSION_MCP_MAX_IDLE_REQUESTER_RUNTIMES,
@@ -124,6 +125,9 @@ export type SessionMcpRuntimeManagerLifecycle = {
   runtimeKeysForSessionId: (sessionId: string) => string[];
   totalActiveLeasesForSessionId: (sessionId: string) => number;
   runExclusiveOnRuntimeKey: <T>(runtimeKey: string, work: () => Promise<T>) => Promise<T>;
+  runWithPendingCreate: <T>(sessionId: string, work: () => Promise<T>) => Promise<T>;
+  hasPendingCreate: (sessionId: string) => boolean;
+  totalPendingCreates: () => number;
   sweepIdleRuntimes: () => Promise<number>;
   enforceRequesterRuntimeCap: (sessionId: string, keepRuntimeKey: string) => Promise<void>;
   ensureIdleSweepTimer: () => void;
@@ -178,7 +182,6 @@ export function createSessionMcpRuntimeManagerLifecycle(
       }
     }
   };
-
   const runtimeKeysForSessionId = (sessionId: string): string[] => {
     const keys: string[] = [];
     for (const [runtimeKey, runtime] of store.runtimesBySessionId.entries()) {
@@ -189,6 +192,20 @@ export function createSessionMcpRuntimeManagerLifecycle(
     return keys;
   };
 
+  function pruneSessionState(sessionId: string): void {
+    const owned =
+      runtimeKeysForSessionId(sessionId).length > 0 ||
+      store.exactRetirementsBySessionId.has(sessionId) ||
+      pendingCreates.hasPending(sessionId);
+    if (owned) {
+      return;
+    }
+    store.deferredRetirementSessionIds.delete(sessionId);
+    store.advertisedScopedCatalogBySessionId.delete(sessionId);
+    forgetSessionKeysForSessionId(sessionId);
+  }
+
+  const pendingCreates = createPendingCreateTracker({ onSessionDrained: pruneSessionState });
   const totalActiveLeasesForSessionId = (sessionId: string): number => {
     let total = 0;
     for (const runtimeKey of runtimeKeysForSessionId(sessionId)) {
@@ -196,7 +213,6 @@ export function createSessionMcpRuntimeManagerLifecycle(
     }
     return total;
   };
-
   const runExclusiveOnRuntimeKey = <T>(runtimeKey: string, work: () => Promise<T>): Promise<T> => {
     const previous = store.requesterWorkChains.get(runtimeKey) ?? Promise.resolve();
     const run = previous.catch(() => undefined).then(() => work());
@@ -378,11 +394,7 @@ export function createSessionMcpRuntimeManagerLifecycle(
     } else {
       store.exactRetirementsBySessionId.delete(sessionId);
     }
-    if (remaining.length === 0 && runtimeKeysForSessionId(sessionId).length === 0) {
-      store.deferredRetirementSessionIds.delete(sessionId);
-      store.advertisedScopedCatalogBySessionId.delete(sessionId);
-      forgetSessionKeysForSessionId(sessionId);
-    }
+    pruneSessionState(sessionId);
   };
 
   const completeExactRetirement = async (
@@ -669,6 +681,9 @@ export function createSessionMcpRuntimeManagerLifecycle(
     runtimeKeysForSessionId,
     totalActiveLeasesForSessionId,
     runExclusiveOnRuntimeKey,
+    runWithPendingCreate: pendingCreates.run,
+    hasPendingCreate: pendingCreates.hasPending,
+    totalPendingCreates: pendingCreates.totalPending,
     sweepIdleRuntimes,
     enforceRequesterRuntimeCap,
     ensureIdleSweepTimer,

--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -54,7 +54,7 @@ export function createSessionMcpRuntimeManager(
   const lifecycle = createSessionMcpRuntimeManagerLifecycle(store);
   const install = createSessionMcpRuntimeManagerInstall(lifecycle);
 
-  const manager: SessionMcpRuntimeManager = {
+  const managerCore: SessionMcpRuntimeManager = {
     async getOrCreate(params) {
       const idleTtlMs = resolveSessionMcpRuntimeIdleTtlMs();
       await lifecycle.sweepIdleRuntimes();
@@ -344,23 +344,34 @@ export function createSessionMcpRuntimeManager(
       if (runtime !== undefined && runtime.sessionId !== sessionId) {
         return false;
       }
+      let completedExactRetirement = false;
       if (runtime !== undefined) {
         const runtimes = isCombinedSessionMcpRuntime(runtime) ? runtime.managedParts : [runtime];
+        completedExactRetirement = await lifecycle.completeExactRuntimeRetirement(
+          runtime,
+          runtimes,
+        );
         if (
-          (await lifecycle.completeExactRuntimeRetirement(runtime, runtimes)) &&
-          !store.requiredRetirementSessionIds.has(sessionId)
+          completedExactRetirement &&
+          !store.requiredRetirementSessionIds.has(sessionId) &&
+          !store.deferredRetirementSessionIds.has(sessionId)
         ) {
           return true;
         }
       }
       if (!store.deferredRetirementSessionIds.has(sessionId)) {
-        return false;
+        return completedExactRetirement;
+      }
+      if (lifecycle.hasPendingCreate(sessionId)) {
+        // The active run owns admitted creation. Keep required retirement armed;
+        // the run-end watcher will retire the runtime after creation or reuse settles.
+        return completedExactRetirement;
       }
       if (
         lifecycle.totalActiveLeasesForSessionId(sessionId) > 0 ||
         (runtime?.activeLeases ?? 0) > 0
       ) {
-        return false;
+        return completedExactRetirement;
       }
       if (store.requiredRetirementSessionIds.has(sessionId)) {
         await lifecycle.disposeManagedSession(sessionId, { preserveRequiredRetirement: true });
@@ -374,7 +385,7 @@ export function createSessionMcpRuntimeManager(
         return false;
       }
       const managedSet = new Set(managed);
-      if (runtime !== undefined) {
+      if (runtime !== undefined && !completedExactRetirement) {
         if (isCombinedSessionMcpRuntime(runtime)) {
           if (!runtime.managedParts.every((part) => managedSet.has(part))) {
             return false;
@@ -439,6 +450,15 @@ export function createSessionMcpRuntimeManager(
       return lifecycle.totalActiveLeasesForSessionId(sessionId);
     },
   };
+  const manager: SessionMcpRuntimeManager = {
+    ...managerCore,
+    getOrCreate: (params) =>
+      lifecycle.runWithPendingCreate(params.sessionId, () => managerCore.getOrCreate(params)),
+    getOrCreateRequesterScoped: (params) =>
+      lifecycle.runWithPendingCreate(params.sessionId, () =>
+        managerCore.getOrCreateRequesterScoped(params),
+      ),
+  };
   // Test-only bookkeeping snapshot for drain assertions.
   Object.assign(manager, {
     bookkeepingSizesForTest: () => ({
@@ -446,6 +466,7 @@ export function createSessionMcpRuntimeManager(
       connectionMeta: store.connectionMetaByRuntimeKey.size,
       createInFlight: store.createInFlight.size,
       requesterWorkChains: store.requesterWorkChains.size,
+      pendingCreates: lifecycle.totalPendingCreates(),
       sessionKeys: store.sessionIdBySessionKey.size,
       idleTtl: store.idleTtlMsBySessionId.size,
       deferredRetirement: store.deferredRetirementSessionIds.size,

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3197,6 +3197,213 @@ process.on("SIGINT", shutdown);`,
     await manager.disposeAll();
   });
 
+  it("continues an independently armed session retirement after exact retirement", async () => {
+    const disposeByWorkspace = new Map<string, ReturnType<typeof vi.fn>>();
+    const manager = testing.createSessionMcpRuntimeManager({
+      enableIdleSweepTimer: false,
+      createRuntime: (params) => {
+        const dispose = vi.fn<() => Promise<void>>().mockResolvedValue();
+        disposeByWorkspace.set(params.workspaceDir, dispose);
+        let activeLeases = 0;
+        return {
+          ...makeRuntime([{ toolName: "probe", description: "probe" }]),
+          sessionId: params.sessionId,
+          workspaceDir: params.workspaceDir,
+          configFingerprint: params.configFingerprint ?? "fingerprint",
+          get activeLeases() {
+            return activeLeases;
+          },
+          acquireLease: () => {
+            activeLeases += 1;
+            return () => {
+              activeLeases -= 1;
+            };
+          },
+          dispose,
+        };
+      },
+    });
+    const sessionId = "session-exact-and-session-retirement";
+    const runtimeA = await manager.getOrCreate({
+      sessionId,
+      workspaceDir: "/workspace-a",
+      cfg: { mcp: {} },
+    });
+    const release = runtimeA.acquireLease?.();
+
+    await expect(
+      manager.retireRuntimeInstance(runtimeA, { preserveActiveLeases: true }),
+    ).resolves.toBe(true);
+    const runtimeB = await manager.getOrCreate({
+      sessionId,
+      workspaceDir: "/workspace-b",
+      cfg: { mcp: {} },
+    });
+    expect(runtimeB).not.toBe(runtimeA);
+    expect(manager.deferRetirement(sessionId)).toBe(true);
+
+    release?.();
+    await expect(manager.completeDeferredRetirement(sessionId, runtimeA)).resolves.toBe(true);
+
+    expect(disposeByWorkspace.get("/workspace-a")).toHaveBeenCalledOnce();
+    expect(disposeByWorkspace.get("/workspace-b")).toHaveBeenCalledOnce();
+    expect(manager.peekSession({ sessionId })).toBeUndefined();
+    expect(testing.getBookkeepingSizes(manager).deferredRetirement).toBe(0);
+    await manager.disposeAll();
+  });
+
+  it("defers required retirement while replacement creation is admitted", async () => {
+    const disposeByWorkspace = new Map<string, ReturnType<typeof vi.fn>>();
+    let nowMs = 0;
+    let releaseBlockerDispose!: () => void;
+    const blockerDispose = new Promise<void>((resolve) => {
+      releaseBlockerDispose = resolve;
+    });
+    const manager = testing.createSessionMcpRuntimeManager({
+      enableIdleSweepTimer: false,
+      now: () => nowMs,
+      createRuntime: (params) => {
+        let activeLeases = 0;
+        const dispose =
+          params.workspaceDir === "/workspace-blocker"
+            ? vi.fn<() => Promise<void>>(() => blockerDispose)
+            : vi.fn<() => Promise<void>>().mockResolvedValue();
+        disposeByWorkspace.set(params.workspaceDir, dispose);
+        return {
+          ...makeRuntime([{ toolName: "probe", description: "probe" }]),
+          sessionId: params.sessionId,
+          workspaceDir: params.workspaceDir,
+          configFingerprint: params.configFingerprint ?? "fingerprint",
+          lastUsedAt: nowMs,
+          get activeLeases() {
+            return activeLeases;
+          },
+          acquireLease: () => {
+            activeLeases += 1;
+            return () => {
+              activeLeases -= 1;
+            };
+          },
+          dispose,
+        };
+      },
+    });
+    await manager.getOrCreate({
+      sessionId: "session-required-admission-blocker",
+      workspaceDir: "/workspace-blocker",
+      cfg: { mcp: {} },
+    });
+    const sessionId = "session-required-admission";
+    const sessionKey = "agent:test:session-required-admission";
+    const runtimeA = await manager.getOrCreate({
+      sessionId,
+      sessionKey,
+      workspaceDir: "/workspace-a",
+      cfg: { mcp: {} },
+    });
+    const releaseA = runtimeA.acquireLease?.();
+    await manager.retireRuntimeInstance(runtimeA, { preserveActiveLeases: true });
+    nowMs = 1_000_000_000_000;
+    const replacement = manager.getOrCreate({
+      sessionId,
+      sessionKey,
+      workspaceDir: "/workspace-b",
+      cfg: { mcp: {} },
+    });
+    expect(manager.deferRetirement(sessionId, { retainAcrossReuse: true })).toBe(true);
+
+    releaseA?.();
+    await expect(manager.completeDeferredRetirement(sessionId, runtimeA)).resolves.toBe(true);
+    expect(testing.getBookkeepingSizes(manager).pendingCreates).toBe(1);
+    expect(manager.resolveSessionId(sessionKey)).toBe(sessionId);
+
+    releaseBlockerDispose();
+    const runtimeB = await replacement;
+    expect(disposeByWorkspace.get("/workspace-a")).toHaveBeenCalledOnce();
+    expect(disposeByWorkspace.get("/workspace-b")).not.toHaveBeenCalled();
+    const releaseB = runtimeB.acquireLease?.();
+    await manager.retireRuntimeInstance(runtimeB, { preserveActiveLeases: true });
+    await expect(manager.completeDeferredRetirement(sessionId, runtimeB)).resolves.toBe(false);
+    releaseB?.();
+    await expect(manager.completeDeferredRetirement(sessionId, runtimeB)).resolves.toBe(true);
+    expect(disposeByWorkspace.get("/workspace-b")).toHaveBeenCalledOnce();
+    expect(manager.listSessionIds()).not.toContain(sessionId);
+    await manager.disposeSession(sessionId);
+    await manager.disposeAll();
+  });
+
+  it("cleans retained lookup state when the final admitted replacement fails", async () => {
+    let nowMs = 0;
+    let releaseBlockerDispose!: () => void;
+    const blockerDispose = new Promise<void>((resolve) => {
+      releaseBlockerDispose = resolve;
+    });
+    const manager = testing.createSessionMcpRuntimeManager({
+      enableIdleSweepTimer: false,
+      now: () => nowMs,
+      createRuntime: (params) => {
+        if (params.workspaceDir === "/workspace-failing-replacement") {
+          throw new Error("replacement failed");
+        }
+        let activeLeases = 0;
+        return {
+          ...makeRuntime([{ toolName: "probe", description: "probe" }]),
+          sessionId: params.sessionId,
+          workspaceDir: params.workspaceDir,
+          configFingerprint: params.configFingerprint ?? "fingerprint",
+          lastUsedAt: nowMs,
+          get activeLeases() {
+            return activeLeases;
+          },
+          acquireLease: () => {
+            activeLeases += 1;
+            return () => {
+              activeLeases -= 1;
+            };
+          },
+          dispose:
+            params.workspaceDir === "/workspace-blocker"
+              ? () => blockerDispose
+              : vi.fn<() => Promise<void>>().mockResolvedValue(),
+        };
+      },
+    });
+    await manager.getOrCreate({
+      sessionId: "session-failed-admission-blocker",
+      workspaceDir: "/workspace-blocker",
+      cfg: { mcp: {} },
+    });
+    const sessionId = "session-failed-admission";
+    const sessionKey = "agent:test:session-failed-admission";
+    const runtimeA = await manager.getOrCreate({
+      sessionId,
+      sessionKey,
+      workspaceDir: "/workspace-a",
+      cfg: { mcp: {} },
+    });
+    const releaseA = runtimeA.acquireLease?.();
+    await manager.retireRuntimeInstance(runtimeA, { preserveActiveLeases: true });
+    nowMs = 1_000_000_000_000;
+    const replacement = manager.getOrCreate({
+      sessionId,
+      sessionKey,
+      workspaceDir: "/workspace-failing-replacement",
+      cfg: { mcp: {} },
+    });
+
+    releaseA?.();
+    await expect(manager.completeDeferredRetirement(sessionId, runtimeA)).resolves.toBe(true);
+    expect(manager.resolveSessionId(sessionKey)).toBe(sessionId);
+    releaseBlockerDispose();
+    await expect(replacement).rejects.toThrow("replacement failed");
+    expect(manager.resolveSessionId(sessionKey)).toBeUndefined();
+    expect(testing.getBookkeepingSizes(manager)).toMatchObject({
+      exactRetirement: 0,
+      pendingCreates: 0,
+    });
+    await manager.disposeAll();
+  });
+
   it("retries exact runtime disposal without exposing the failed runtime for reuse", async () => {
     const dispose = vi.fn<() => Promise<void>>().mockRejectedValueOnce(new Error("dispose failed"));
     dispose.mockResolvedValueOnce();
@@ -4710,6 +4917,7 @@ describe("requester-scoped MCP connection resolution", () => {
       connectionMeta: 0,
       createInFlight: 0,
       requesterWorkChains: 0,
+      pendingCreates: 0,
       sessionKeys: 0,
       idleTtl: 0,
       deferredRetirement: 0,

--- a/src/agents/agent-run-approval.gateway.test.ts
+++ b/src/agents/agent-run-approval.gateway.test.ts
@@ -6,7 +6,11 @@ import {
   gatewayAgentRunApprovalHost,
   resolveGatewayAgentRunApprovalHost,
 } from "./agent-run-approval.gateway.js";
-import { noAgentRunApprovalHost } from "./agent-run-approval.js";
+import {
+  AgentRunExecApprovalRunAbortedError,
+  noAgentRunApprovalHost,
+} from "./agent-run-approval.js";
+import { DEFAULT_APPROVAL_TIMEOUT_MS } from "./bash-tools.exec-runtime.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 vi.mock("./tools/gateway.js", () => ({
@@ -59,6 +63,19 @@ function requestPayload() {
   };
 }
 
+function execRequestPayload() {
+  return {
+    id: "exec-approval-1",
+    command: "echo hi",
+    cwd: "/tmp",
+    host: "gateway" as const,
+    security: "allowlist" as const,
+    ask: "on-miss" as const,
+    runId: "run-1",
+    toolCallId: "tool-1",
+  };
+}
+
 describe("gatewayAgentRunApprovalHost", () => {
   beforeEach(() => {
     mockCallGatewayTool.mockReset();
@@ -100,6 +117,347 @@ describe("gatewayAgentRunApprovalHost", () => {
         instanceId: "approval-runtime-1",
         onSignalAbort: expect.any(Function),
       },
+    );
+  });
+
+  it("adapts exec registration and reviewer selection onto the Gateway wire", async () => {
+    const host = createGatewayAgentRunApprovalHost({
+      approvalReviewerDeviceIds: ["device-1"],
+      runtimeInstanceId: "approval-runtime-1",
+    });
+    const expiresAtMs = Date.now() + 120_000;
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "exec-approval-1",
+      expiresAtMs,
+      decision: "allow-once",
+    });
+
+    await expect(
+      host.exec!.request({
+        request: execRequestPayload(),
+        timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+      }),
+    ).resolves.toMatchObject({
+      id: "exec-approval-1",
+      expiresAtMs,
+      finalDecision: "allow-once",
+      wait: expect.any(Function),
+      resolveAutoReview: expect.any(Function),
+      cancel: expect.any(Function),
+    });
+    expect(mockCallGatewayTool).toHaveBeenCalledWith(
+      "exec.approval.request",
+      { timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS + 10_000 },
+      {
+        ...execRequestPayload(),
+        approvalReviewerDeviceIds: ["device-1"],
+        timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+        twoPhase: true,
+      },
+      {
+        expectFinal: false,
+        signal: undefined,
+        instanceId: "approval-runtime-1",
+        onSignalAbort: expect.any(Function),
+      },
+    );
+  });
+
+  it("keeps exec lease cancellation and auto-review bound to the runtime instance", async () => {
+    const host = createGatewayAgentRunApprovalHost({
+      runtimeInstanceId: "approval-runtime-1",
+    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "exec-approval-1" })
+      .mockResolvedValueOnce({ id: "exec-approval-1", decision: "deny" })
+      .mockResolvedValue({ ok: true });
+
+    const lease = await host.exec!.request({
+      request: execRequestPayload(),
+      timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    });
+    const registrationAbortRequest = vi.fn().mockResolvedValue({ ok: true });
+    await mockCallGatewayTool.mock.calls[0]?.[3]?.onSignalAbort?.(registrationAbortRequest);
+    expect(registrationAbortRequest).toHaveBeenCalledWith("exec.approval.cancel", {
+      id: "exec-approval-1",
+      timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    });
+
+    await expect(lease.wait()).resolves.toBe("deny");
+    const waitAbortRequest = vi.fn().mockResolvedValue({ ok: true });
+    await mockCallGatewayTool.mock.calls[1]?.[3]?.onSignalAbort?.(waitAbortRequest);
+    expect(waitAbortRequest).toHaveBeenCalledWith("exec.approval.cancel", {
+      id: "exec-approval-1",
+      timeoutMs: expect.any(Number),
+    });
+
+    await lease.resolveAutoReview();
+    await lease.cancel();
+    expect(mockCallGatewayTool).toHaveBeenNthCalledWith(
+      3,
+      "exec.approval.resolve",
+      { timeoutMs: 15_000 },
+      { id: "exec-approval-1", decision: "allow-once" },
+      {
+        scopes: ["operator.approvals"],
+        requireAgentRuntimeIdentity: true,
+        instanceId: "approval-runtime-1",
+      },
+    );
+    expect(mockCallGatewayTool).toHaveBeenNthCalledWith(
+      4,
+      "exec.approval.cancel",
+      { timeoutMs: 10_000 },
+      { id: "exec-approval-1", timeoutMs: expect.any(Number) },
+      { instanceId: "approval-runtime-1" },
+    );
+  });
+
+  it("cancels an exec approval when the run aborts after registration", async () => {
+    const controller = new AbortController();
+    const abortReason = new Error("run aborted");
+    const host = createGatewayAgentRunApprovalHost({
+      runtimeInstanceId: "approval-runtime-1",
+    });
+    mockCallGatewayTool
+      .mockImplementationOnce(async () => {
+        controller.abort(abortReason);
+        return { id: "exec-approval-1", decision: "allow-once" };
+      })
+      .mockResolvedValueOnce({ ok: true, cancelled: 1 });
+
+    await expect(
+      host.exec!.request({
+        request: execRequestPayload(),
+        timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(abortReason);
+    expect(mockCallGatewayTool).toHaveBeenNthCalledWith(
+      2,
+      "exec.approval.cancel",
+      { timeoutMs: 10_000 },
+      { id: "exec-approval-1", timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS },
+      { instanceId: "approval-runtime-1" },
+    );
+  });
+
+  it("cancels the requested exec approval after an ambiguous registration failure", async () => {
+    const host = createGatewayAgentRunApprovalHost({
+      runtimeInstanceId: "approval-runtime-1",
+    });
+    const transportError = new Error("gateway connection lost");
+    mockCallGatewayTool
+      .mockRejectedValueOnce(transportError)
+      .mockResolvedValueOnce({ ok: true, cancelled: 1 });
+
+    await expect(
+      host.exec!.request({
+        request: execRequestPayload(),
+        timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+      }),
+    ).rejects.toBe(transportError);
+    expect(mockCallGatewayTool).toHaveBeenNthCalledWith(
+      2,
+      "exec.approval.cancel",
+      { timeoutMs: 10_000 },
+      { id: "exec-approval-1", timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS },
+      { instanceId: "approval-runtime-1" },
+    );
+  });
+
+  it("rejects a mismatched exec registration id and cancels the requested lease", async () => {
+    const host = createGatewayAgentRunApprovalHost({
+      runtimeInstanceId: "approval-runtime-1",
+    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "different-approval" })
+      .mockResolvedValueOnce({ ok: true, cancelled: 1 });
+
+    await expect(
+      host.exec!.request({
+        request: execRequestPayload(),
+        timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+      }),
+    ).rejects.toThrow("mismatched approval id");
+    expect(mockCallGatewayTool).toHaveBeenNthCalledWith(
+      2,
+      "exec.approval.cancel",
+      { timeoutMs: 10_000 },
+      { id: "exec-approval-1", timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS },
+      { instanceId: "approval-runtime-1" },
+    );
+  });
+
+  it("cancels a registered exec approval before an already-aborted wait", async () => {
+    const controller = new AbortController();
+    const abortReason = new Error("run aborted");
+    const host = createGatewayAgentRunApprovalHost({
+      runtimeInstanceId: "approval-runtime-1",
+    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "exec-approval-1" })
+      .mockResolvedValueOnce({ ok: true, cancelled: 1 });
+    const lease = await host.exec!.request({
+      request: execRequestPayload(),
+      timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    });
+    controller.abort(abortReason);
+
+    await expect(lease.wait({ signal: controller.signal })).rejects.toBe(abortReason);
+    expect(mockCallGatewayTool).toHaveBeenNthCalledWith(
+      2,
+      "exec.approval.cancel",
+      { timeoutMs: 10_000 },
+      { id: "exec-approval-1", timeoutMs: expect.any(Number) },
+      { instanceId: "approval-runtime-1" },
+    );
+  });
+
+  it("bounds missing, invalid, and overly distant exec registration expiries", async () => {
+    const host = createGatewayAgentRunApprovalHost();
+    const nowMs = 1_800_000_000_000;
+    const requestedTimeoutMs = 5_000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "exec-approval-1" })
+      .mockResolvedValueOnce({ id: "exec-approval-1", expiresAtMs: Number.MAX_VALUE })
+      .mockResolvedValueOnce({
+        id: "exec-approval-1",
+        expiresAtMs: nowMs + requestedTimeoutMs + 60_000,
+      });
+
+    try {
+      await expect(
+        host.exec!.request({
+          request: execRequestPayload(),
+          timeoutMs: requestedTimeoutMs,
+        }),
+      ).resolves.toMatchObject({ expiresAtMs: nowMs + requestedTimeoutMs });
+      await expect(
+        host.exec!.request({
+          request: execRequestPayload(),
+          timeoutMs: requestedTimeoutMs,
+        }),
+      ).resolves.toMatchObject({ expiresAtMs: nowMs + requestedTimeoutMs });
+      await expect(
+        host.exec!.request({
+          request: execRequestPayload(),
+          timeoutMs: requestedTimeoutMs,
+        }),
+      ).resolves.toMatchObject({ expiresAtMs: nowMs + requestedTimeoutMs });
+      expect(mockCallGatewayTool).toHaveBeenNthCalledWith(
+        1,
+        "exec.approval.request",
+        { timeoutMs: requestedTimeoutMs + 10_000 },
+        expect.objectContaining({ timeoutMs: requestedTimeoutMs }),
+        expect.any(Object),
+      );
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("bounds exec decision waits to the remaining registration lifetime", async () => {
+    const host = createGatewayAgentRunApprovalHost();
+    const nowMs = 1_800_000_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "exec-approval-1", expiresAtMs: nowMs + 2_000 })
+      .mockResolvedValueOnce({ id: "exec-approval-1", decision: "allow-once" });
+
+    try {
+      const lease = await host.exec!.request({
+        request: execRequestPayload(),
+        timeoutMs: 5_000,
+      });
+      await expect(lease.wait()).resolves.toBe("allow-once");
+      expect(mockCallGatewayTool).toHaveBeenNthCalledWith(
+        2,
+        "exec.approval.waitDecision",
+        { timeoutMs: 12_000 },
+        { id: "exec-approval-1" },
+        expect.any(Object),
+      );
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("maps Gateway exec wait outcomes without hiding run cancellation", async () => {
+    const host = createGatewayAgentRunApprovalHost({
+      runtimeInstanceId: "approval-runtime-1",
+    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "exec-approval-1" })
+      .mockResolvedValueOnce({ id: "exec-aborted" })
+      .mockResolvedValueOnce({
+        id: "exec-approval-1",
+        decision: null,
+        terminalReason: "timeout",
+      })
+      .mockResolvedValueOnce({
+        id: "exec-aborted",
+        decision: null,
+        terminalReason: "run-aborted",
+      });
+    const timeoutLease = await host.exec!.request({
+      request: execRequestPayload(),
+      timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    });
+    const abortedLease = await host.exec!.request({
+      request: { ...execRequestPayload(), id: "exec-aborted" },
+      timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    });
+
+    await expect(timeoutLease.wait()).resolves.toBeNull();
+    await expect(abortedLease.wait()).rejects.toBeInstanceOf(AgentRunExecApprovalRunAbortedError);
+  });
+
+  it("cancels an exec approval when decision waiting loses the Gateway transport", async () => {
+    const host = createGatewayAgentRunApprovalHost({
+      runtimeInstanceId: "approval-runtime-1",
+    });
+    const transportError = new Error("gateway connection lost");
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "exec-approval-1" })
+      .mockRejectedValueOnce(transportError)
+      .mockResolvedValueOnce({ ok: true, cancelled: 1 });
+
+    const lease = await host.exec!.request({
+      request: execRequestPayload(),
+      timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    });
+    await expect(lease.wait()).rejects.toBe(transportError);
+    expect(mockCallGatewayTool).toHaveBeenNthCalledWith(
+      3,
+      "exec.approval.cancel",
+      { timeoutMs: 10_000 },
+      { id: "exec-approval-1", timeoutMs: expect.any(Number) },
+      { instanceId: "approval-runtime-1" },
+    );
+  });
+
+  it("rejects a mismatched exec wait id and cancels the registered lease", async () => {
+    const host = createGatewayAgentRunApprovalHost({
+      runtimeInstanceId: "approval-runtime-1",
+    });
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "exec-approval-1" })
+      .mockResolvedValueOnce({ id: "different-approval", decision: "allow-once" })
+      .mockResolvedValueOnce({ ok: true, cancelled: 1 });
+
+    const lease = await host.exec!.request({
+      request: execRequestPayload(),
+      timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    });
+    await expect(lease.wait()).rejects.toThrow("mismatched approval id");
+    expect(mockCallGatewayTool).toHaveBeenNthCalledWith(
+      3,
+      "exec.approval.cancel",
+      { timeoutMs: 10_000 },
+      { id: "exec-approval-1", timeoutMs: expect.any(Number) },
+      { instanceId: "approval-runtime-1" },
     );
   });
 

--- a/src/agents/agent-run-approval.gateway.ts
+++ b/src/agents/agent-run-approval.gateway.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { addTimerTimeoutGraceMs } from "@openclaw/normalization-core/number-coercion";
+import {
+  addTimerTimeoutGraceMs,
+  asDateTimestampMs,
+  resolveExpiresAtMsFromDurationMs,
+} from "@openclaw/normalization-core/number-coercion";
 import { ErrorCodes } from "../../packages/gateway-protocol/src/schema/error-codes.js";
 import type { CallGatewayOptions } from "../gateway/call.js";
 import { GatewayClientRequestError } from "../gateway/client.js";
@@ -8,10 +12,15 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS } from "../infra/plugin-approvals.js";
 import type {
   AgentRunApprovalHost,
+  AgentRunExecApprovalHost,
+  AgentRunExecApprovalLease,
   AgentRunPluginApprovalHost,
   AgentRunPluginApprovalResult,
 } from "./agent-run-approval.js";
-import { noAgentRunApprovalHost } from "./agent-run-approval.js";
+import {
+  AgentRunExecApprovalRunAbortedError,
+  noAgentRunApprovalHost,
+} from "./agent-run-approval.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 function resolveGatewayTimeoutMs(timeoutMs: number): number {
@@ -24,6 +33,171 @@ function readDecision(value: unknown): "allow-once" | "allow-always" | "deny" | 
     : value === null
       ? null
       : undefined;
+}
+
+function readExecRegistration(
+  value: unknown,
+  fallbackId: string,
+  timeoutMs: number,
+): Pick<AgentRunExecApprovalLease, "id" | "expiresAtMs" | "finalDecision"> {
+  const result = value && typeof value === "object" ? value : {};
+  const responseId = (result as { id?: unknown }).id;
+  if (typeof responseId === "string" && responseId !== fallbackId) {
+    throw new Error("Exec approval registration returned a mismatched approval id.");
+  }
+  const id = fallbackId;
+  const localExpiresAtMs = resolveExpiresAtMsFromDurationMs(timeoutMs) ?? 0;
+  const remoteExpiresAtMs = asDateTimestampMs((result as { expiresAtMs?: unknown }).expiresAtMs);
+  const expiresAtMs =
+    remoteExpiresAtMs === undefined
+      ? localExpiresAtMs
+      : Math.min(remoteExpiresAtMs, localExpiresAtMs);
+  if (!Object.hasOwn(result, "decision")) {
+    return { id, expiresAtMs };
+  }
+  const decision = readDecision((result as { decision?: unknown }).decision);
+  if (decision === undefined) {
+    throw new Error("Exec approval returned an invalid decision.");
+  }
+  return { id, expiresAtMs, finalDecision: decision };
+}
+
+function createGatewayExecApprovalHost(
+  approvalReviewerDeviceIds: readonly string[],
+  runtimeInstanceId: string,
+): AgentRunExecApprovalHost {
+  const cancelExecApproval = async (id: string, timeoutMs: number, bestEffort = false) => {
+    try {
+      await callGatewayTool(
+        "exec.approval.cancel",
+        { timeoutMs: 10_000 },
+        { id, timeoutMs },
+        { instanceId: runtimeInstanceId },
+      );
+    } catch (error) {
+      if (!bestEffort) {
+        throw error;
+      }
+    }
+  };
+  const throwIfRegisteredExecApprovalAborted = async (
+    id: string,
+    timeoutMs: number,
+    signal: AbortSignal | undefined,
+  ) => {
+    if (!signal?.aborted) {
+      return;
+    }
+    await cancelExecApproval(id, timeoutMs, true);
+    throw signal.reason ?? new Error("exec approval request aborted");
+  };
+  return Object.freeze({
+    supportsDetachedExecution: true,
+    request: async ({ request, timeoutMs, signal }) => {
+      signal?.throwIfAborted();
+      let result: unknown;
+      try {
+        result = await callGatewayTool(
+          "exec.approval.request",
+          { timeoutMs: resolveGatewayTimeoutMs(timeoutMs) },
+          {
+            ...request,
+            ...(approvalReviewerDeviceIds.length ? { approvalReviewerDeviceIds } : {}),
+            timeoutMs,
+            twoPhase: true,
+          },
+          {
+            expectFinal: false,
+            signal,
+            instanceId: runtimeInstanceId,
+            onSignalAbort: (requestGateway) =>
+              requestGateway("exec.approval.cancel", { id: request.id, timeoutMs }),
+          },
+        );
+      } catch (error) {
+        await cancelExecApproval(request.id, timeoutMs, true);
+        throw error;
+      }
+      let registration: Pick<AgentRunExecApprovalLease, "id" | "expiresAtMs" | "finalDecision">;
+      try {
+        registration = readExecRegistration(result, request.id, timeoutMs);
+      } catch (error) {
+        await cancelExecApproval(request.id, timeoutMs, true);
+        throw error;
+      }
+      const remainingTimeoutMs = () => Math.max(1, registration.expiresAtMs - Date.now());
+      await throwIfRegisteredExecApprovalAborted(registration.id, remainingTimeoutMs(), signal);
+      return Object.freeze<AgentRunExecApprovalLease>({
+        ...registration,
+        wait: async (waitParams) => {
+          await throwIfRegisteredExecApprovalAborted(
+            registration.id,
+            remainingTimeoutMs(),
+            waitParams?.signal,
+          );
+          try {
+            const waitResult = await callGatewayTool<{
+              id?: unknown;
+              decision?: unknown;
+              terminalReason?: unknown;
+            }>(
+              "exec.approval.waitDecision",
+              {
+                timeoutMs: resolveGatewayTimeoutMs(
+                  Math.max(0, registration.expiresAtMs - Date.now()),
+                ),
+              },
+              { id: registration.id },
+              {
+                signal: waitParams?.signal,
+                instanceId: runtimeInstanceId,
+                onSignalAbort: (requestGateway) =>
+                  requestGateway("exec.approval.cancel", {
+                    id: registration.id,
+                    timeoutMs: remainingTimeoutMs(),
+                  }),
+              },
+            );
+            await throwIfRegisteredExecApprovalAborted(
+              registration.id,
+              remainingTimeoutMs(),
+              waitParams?.signal,
+            );
+            if (waitResult?.id !== registration.id) {
+              throw new Error("Exec approval wait returned a mismatched approval id.");
+            }
+            if (waitResult?.terminalReason === "run-aborted") {
+              throw new AgentRunExecApprovalRunAbortedError();
+            }
+            const decision = readDecision(waitResult?.decision);
+            if (decision === undefined && waitResult) {
+              throw new Error("Exec approval returned an invalid decision.");
+            }
+            return decision ?? null;
+          } catch (error) {
+            if (isApprovalNotFoundError(error)) {
+              return null;
+            }
+            await cancelExecApproval(registration.id, remainingTimeoutMs(), true);
+            throw error;
+          }
+        },
+        resolveAutoReview: async () => {
+          await callGatewayTool(
+            "exec.approval.resolve",
+            { timeoutMs: 15_000 },
+            { id: registration.id, decision: "allow-once" },
+            {
+              scopes: ["operator.approvals"],
+              requireAgentRuntimeIdentity: true,
+              instanceId: runtimeInstanceId,
+            },
+          );
+        },
+        cancel: () => cancelExecApproval(registration.id, remainingTimeoutMs()),
+      });
+    },
+  });
 }
 
 function isGatewayInvalidRequestError(error: unknown): boolean {
@@ -147,10 +321,13 @@ async function requestGatewayPluginApproval(
       expectFinal: false,
       signal: params.signal,
       instanceId: runtimeInstanceId,
-      onSignalAbort: (request: Parameters<NonNullable<CallGatewayOptions["onSignalAbort"]>>[0]) =>
-        request("plugin.approval.cancel", {
+      onSignalAbort: async (
+        request: Parameters<NonNullable<CallGatewayOptions["onSignalAbort"]>>[0],
+      ) => {
+        await request("plugin.approval.cancel", {
           runtimeRequestId,
-        }),
+        });
+      },
     };
     try {
       requestResult = await callGatewayTool<{
@@ -285,6 +462,7 @@ export function createGatewayAgentRunApprovalHost(options?: {
   ]);
   const runtimeInstanceId = options?.runtimeInstanceId?.trim() || randomUUID();
   return Object.freeze({
+    exec: createGatewayExecApprovalHost(approvalReviewerDeviceIds, runtimeInstanceId),
     plugin: Object.freeze<AgentRunPluginApprovalHost>({
       request: (params) =>
         requestGatewayPluginApproval(params, approvalReviewerDeviceIds, runtimeInstanceId),

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -767,6 +767,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
         commandHighlighting: options?.exec?.commandHighlighting ?? execConfig.commandHighlighting,
         safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
         safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
+        approvalHost: options?.approvalHost,
         agentId,
         cwd: codingRoot,
         allowBackground,

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -1,10 +1,14 @@
 /**
  * Exec approval request tests.
- * Covers two-phase gateway registration, decision waiting, timeout fallback,
- * and lazy command highlighting for host/node approval payloads.
+ * Covers run-host registration, decision waiting, cancellation, and lazy
+ * command highlighting for host/node approval payloads.
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_APPROVAL_TIMEOUT_MS } from "./bash-tools.exec-runtime.js";
+import {
+  AgentRunExecApprovalRunAbortedError,
+  type AgentRunApprovalHost,
+  type AgentRunExecApprovalRequest,
+} from "./agent-run-approval.js";
 
 const commandExplainerMock = vi.hoisted(() => ({
   importCount: 0,
@@ -33,14 +37,25 @@ vi.mock("../infra/command-explainer/index.js", () => {
   };
 });
 
-vi.mock("./tools/gateway.js", () => ({
-  callGatewayTool: vi.fn(),
-}));
-
-let callGatewayTool: typeof import("./tools/gateway.js").callGatewayTool;
 let registerExecApprovalRequestForHostOrThrow: typeof import("./bash-tools.exec-approval-request.js").registerExecApprovalRequestForHostOrThrow;
 let resolveRegisteredExecApprovalDecision: typeof import("./bash-tools.exec-approval-request.js").resolveRegisteredExecApprovalDecision;
 let isExecApprovalRunAbortedError: typeof import("./bash-tools.exec-approval-request.js").isExecApprovalRunAbortedError;
+const registerApproval = vi.fn();
+const waitForDecision = vi.fn();
+const resolveAutoReview = vi.fn();
+const cancelApproval = vi.fn();
+const approvalLease = {
+  id: "approval-id",
+  expiresAtMs: 1234,
+  wait: waitForDecision,
+  resolveAutoReview,
+  cancel: cancelApproval,
+};
+const approvalHost: AgentRunApprovalHost = {
+  exec: {
+    request: registerApproval,
+  },
+};
 
 const initialProcessPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
@@ -58,27 +73,16 @@ function restoreProcessPlatformForTest(): void {
   }
 }
 
-type ApprovalRequestPayload = {
-  approvalReviewerDeviceIds?: string[];
-  commandSpans?: Array<{ startIndex: number; endIndex: number }>;
-  sessionId?: string;
-  runId?: string;
-  toolCallId?: string;
-};
-
-function requireApprovalRequestPayload(callIndex: number): ApprovalRequestPayload {
-  const call = vi.mocked(callGatewayTool).mock.calls[callIndex];
-  expect(call?.[0]).toBe("exec.approval.request");
-  const payload = call?.[2];
-  if (!payload || typeof payload !== "object") {
+function requireApprovalRequestPayload(callIndex: number): AgentRunExecApprovalRequest {
+  const payload = registerApproval.mock.calls[callIndex]?.[0]?.request;
+  if (!payload) {
     throw new Error(`expected approval request payload ${callIndex}`);
   }
-  return payload as ApprovalRequestPayload;
+  return payload as AgentRunExecApprovalRequest;
 }
 
 describe("exec approval requests", () => {
   beforeAll(async () => {
-    ({ callGatewayTool } = await import("./tools/gateway.js"));
     ({
       registerExecApprovalRequestForHostOrThrow,
       resolveRegisteredExecApprovalDecision,
@@ -87,7 +91,16 @@ describe("exec approval requests", () => {
   });
 
   beforeEach(() => {
-    vi.mocked(callGatewayTool).mockClear();
+    registerApproval.mockReset();
+    registerApproval.mockImplementation(async ({ request }) => ({
+      ...approvalLease,
+      id: request.id,
+    }));
+    waitForDecision.mockReset();
+    resolveAutoReview.mockReset();
+    cancelApproval.mockReset();
+    resolveAutoReview.mockResolvedValue(undefined);
+    cancelApproval.mockResolvedValue(undefined);
     commandExplainerMock.explainShellCommand.mockClear();
     commandExplainerMock.formatCommandSpans.mockClear();
     restoreProcessPlatformForTest();
@@ -102,9 +115,8 @@ describe("exec approval requests", () => {
   });
 
   it("binds approval registrations to their run and tool call", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id" });
-
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost,
       approvalId: "approval-id",
       command: "echo hi",
       workdir: "/tmp",
@@ -124,72 +136,104 @@ describe("exec approval requests", () => {
   });
 
   it("distinguishes run abort cancellation from unchanged timeout fallback", async () => {
-    vi.mocked(callGatewayTool)
-      .mockResolvedValueOnce({ decision: null, terminalReason: "timeout" })
-      .mockResolvedValueOnce({ decision: null, terminalReason: "run-aborted" });
+    waitForDecision
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new AgentRunExecApprovalRunAbortedError());
 
     await expect(
       resolveRegisteredExecApprovalDecision({
-        approvalId: "timeout-approval",
+        approval: { ...approvalLease, id: "timeout-approval" },
         preResolvedDecision: undefined,
       }),
     ).resolves.toBeNull();
     await expect(
       resolveRegisteredExecApprovalDecision({
-        approvalId: "aborted-approval",
+        approval: { ...approvalLease, id: "aborted-approval" },
         preResolvedDecision: undefined,
       }),
     ).rejects.toSatisfy(isExecApprovalRunAbortedError);
+    expect(cancelApproval).toHaveBeenCalledOnce();
   });
 
-  it("bounds missing registration expiries when the process clock is invalid", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id" });
-    const dateNow = vi.spyOn(Date, "now").mockReturnValue(Number.NaN);
+  it("cancels the lease when waiting for a decision fails", async () => {
+    const waitError = new Error("approval transport failed");
+    waitForDecision.mockRejectedValueOnce(waitError);
 
-    try {
-      await expect(
-        registerExecApprovalRequestForHostOrThrow({
-          approvalId: "approval-id",
-          command: "echo hi",
-          workdir: "/tmp",
-          host: "gateway",
-          security: "allowlist",
-          ask: "on-miss",
-        }),
-      ).resolves.toMatchObject({ expiresAtMs: 0 });
-    } finally {
-      dateNow.mockRestore();
-    }
+    await expect(
+      resolveRegisteredExecApprovalDecision({
+        approval: approvalLease,
+        preResolvedDecision: undefined,
+      }),
+    ).rejects.toBe(waitError);
+    expect(cancelApproval).toHaveBeenCalledOnce();
   });
 
-  it("replaces invalid gateway registration expiries with a bounded fallback", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({
-      id: "approval-id",
-      expiresAtMs: Number.MAX_VALUE,
+  it("lets run cancellation win over pre-resolved and concurrently resolved decisions", async () => {
+    const preResolvedAbort = new AbortController();
+    preResolvedAbort.abort(new AgentRunExecApprovalRunAbortedError());
+
+    await expect(
+      resolveRegisteredExecApprovalDecision({
+        approval: approvalLease,
+        preResolvedDecision: "allow-once",
+        signal: preResolvedAbort.signal,
+      }),
+    ).rejects.toSatisfy(isExecApprovalRunAbortedError);
+    expect(waitForDecision).not.toHaveBeenCalled();
+    expect(cancelApproval).toHaveBeenCalledOnce();
+
+    cancelApproval.mockClear();
+    const waitingAbort = new AbortController();
+    waitForDecision.mockImplementationOnce(async () => {
+      waitingAbort.abort(new AgentRunExecApprovalRunAbortedError());
+      return null;
     });
-    const nowMs = 1_800_000_000_000;
-    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    await expect(
+      resolveRegisteredExecApprovalDecision({
+        approval: approvalLease,
+        preResolvedDecision: undefined,
+        signal: waitingAbort.signal,
+      }),
+    ).rejects.toSatisfy(isExecApprovalRunAbortedError);
+    expect(cancelApproval).toHaveBeenCalledOnce();
+  });
 
-    try {
-      await expect(
-        registerExecApprovalRequestForHostOrThrow({
-          approvalId: "approval-id",
-          command: "echo hi",
-          workdir: "/tmp",
-          host: "gateway",
-          security: "allowlist",
-          ask: "on-miss",
-        }),
-      ).resolves.toMatchObject({ expiresAtMs: nowMs + DEFAULT_APPROVAL_TIMEOUT_MS });
-    } finally {
-      dateNow.mockRestore();
-    }
+  it("fails closed when the run has no exec approval capability", async () => {
+    await expect(
+      registerExecApprovalRequestForHostOrThrow({
+        approvalId: "approval-id",
+        command: "echo hi",
+        workdir: "/tmp",
+        host: "gateway",
+        security: "allowlist",
+        ask: "on-miss",
+      }),
+    ).rejects.toThrow("this run has no exec approval host");
+  });
+
+  it("cancels a mismatched host lease before failing registration", async () => {
+    registerApproval.mockResolvedValueOnce({
+      ...approvalLease,
+      id: "wrong-approval-id",
+    });
+
+    await expect(
+      registerExecApprovalRequestForHostOrThrow({
+        approvalHost,
+        approvalId: "approval-id",
+        command: "echo hi",
+        workdir: "/tmp",
+        host: "gateway",
+        security: "allowlist",
+        ask: "on-miss",
+      }),
+    ).rejects.toThrow("mismatched approval id");
+    expect(cancelApproval).toHaveBeenCalledOnce();
   });
 
   it("adds command spans to host approval registration payloads", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
-
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost,
       approvalId: "approval-id",
       command: 'ls | grep "stuff" | python -c \'print("hi")\'',
       commandHighlighting: true,
@@ -208,27 +252,9 @@ describe("exec approval requests", () => {
     ]);
   });
 
-  it("passes approval reviewer devices into host approval registration payloads", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
-
-    await registerExecApprovalRequestForHostOrThrow({
-      approvalId: "approval-id",
-      command: "echo hi",
-      approvalReviewerDeviceIds: ["device-ios-reviewer"],
-      workdir: "/tmp/project",
-      host: "node",
-      security: "allowlist",
-      ask: "always",
-    });
-
-    const payload = requireApprovalRequestPayload(0);
-    expect(payload?.approvalReviewerDeviceIds).toEqual(["device-ios-reviewer"]);
-  });
-
   it("does not generate command spans by default", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
-
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost,
       approvalId: "approval-id",
       command: 'ls | grep "stuff" | python -c \'print("hi")\'',
       workdir: "/tmp/project",
@@ -244,9 +270,8 @@ describe("exec approval requests", () => {
   });
 
   it("does not generate command spans when command highlighting is disabled", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
-
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost,
       approvalId: "approval-id",
       command: 'ls | grep "stuff" | python -c \'print("hi")\'',
       commandHighlighting: false,
@@ -263,9 +288,8 @@ describe("exec approval requests", () => {
   });
 
   it("uses system run plan command text for host approval explanations", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
-
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost,
       approvalId: "approval-id",
       systemRunPlan: {
         argv: ["node", "-e", "console.log(1)"],
@@ -286,9 +310,8 @@ describe("exec approval requests", () => {
   });
 
   it("omits generated command spans for unsupported shell wrapper languages", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
-
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost,
       approvalId: "approval-id-powershell",
       command: 'pwsh -Command "Get-ChildItem"',
       workdir: "/tmp/project",
@@ -297,6 +320,7 @@ describe("exec approval requests", () => {
       ask: "always",
     });
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost,
       approvalId: "approval-id-cmd",
       command: 'cmd.exe /d /s /c "dir"',
       workdir: "/tmp/project",
@@ -305,16 +329,16 @@ describe("exec approval requests", () => {
       ask: "always",
     });
 
-    expect(vi.mocked(callGatewayTool).mock.calls).toHaveLength(2);
+    expect(registerApproval.mock.calls).toHaveLength(2);
     expect(requireApprovalRequestPayload(0).commandSpans).toBeUndefined();
     expect(requireApprovalRequestPayload(1).commandSpans).toBeUndefined();
   });
 
   it("omits generated command spans for Windows gateway PowerShell commands", async () => {
     setProcessPlatformForTest("win32");
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
 
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost,
       approvalId: "approval-id-powershell",
       command:
         'Set-Content -Path "windows-agent-proof.txt" -Value "WINDOWS_AGENT_EXEC_OK" -NoNewline',
@@ -325,14 +349,13 @@ describe("exec approval requests", () => {
     });
 
     expect(commandExplainerMock.formatCommandSpans).not.toHaveBeenCalled();
-    expect(vi.mocked(callGatewayTool).mock.calls).toHaveLength(1);
+    expect(registerApproval.mock.calls).toHaveLength(1);
     expect(requireApprovalRequestPayload(0).commandSpans).toBeUndefined();
   });
 
   it("omits generated command spans for unsupported shell wrappers through system run carriers", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
-
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost,
       approvalId: "approval-id-carrier",
       systemRunPlan: {
         argv: ["timeout", "5", "pwsh", "-Command", "Get-ChildItem"],
@@ -348,14 +371,13 @@ describe("exec approval requests", () => {
     });
 
     expect(commandExplainerMock.formatCommandSpans).not.toHaveBeenCalled();
-    expect(vi.mocked(callGatewayTool).mock.calls).toHaveLength(1);
+    expect(registerApproval.mock.calls).toHaveLength(1);
     expect(requireApprovalRequestPayload(0).commandSpans).toBeUndefined();
   });
 
   it("keeps explicit command spans", async () => {
-    vi.mocked(callGatewayTool).mockResolvedValue({ id: "approval-id", expiresAtMs: 1234 });
-
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost,
       approvalId: "approval-id",
       command: "echo hi",
       commandSpans: [{ startIndex: 0, endIndex: 4 }],

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -1,14 +1,8 @@
 /**
  * Exec approval request client.
- * Registers two-phase approval requests with the gateway, waits for decisions,
- * and builds host/node payloads with optional command highlighting.
+ * Registers two-phase approval requests with the owning run host, waits for
+ * decisions, and builds host/node payloads with optional command highlighting.
  */
-import {
-  asDateTimestampMs,
-  resolveExpiresAtMsFromDurationMs,
-} from "@openclaw/normalization-core/number-coercion";
-import { normalizeOptionalString as parseString } from "@openclaw/normalization-core/string-coerce";
-import { isApprovalNotFoundError } from "../infra/approval-errors.js";
 import type {
   ExecApprovalCommandSpan,
   ExecApprovalUnavailableDecision,
@@ -23,11 +17,13 @@ import {
   resolveShellWrapperTransportArgv,
 } from "../infra/shell-wrapper-resolution.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
-import {
-  DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS,
-  DEFAULT_APPROVAL_TIMEOUT_MS,
-} from "./bash-tools.exec-runtime.js";
-import { callGatewayTool } from "./tools/gateway.js";
+import type {
+  AgentRunApprovalHost,
+  AgentRunExecApprovalLease,
+  AgentRunExecApprovalRequest,
+} from "./agent-run-approval.js";
+import { AgentRunExecApprovalRunAbortedError } from "./agent-run-approval.js";
+import { DEFAULT_APPROVAL_TIMEOUT_MS } from "./bash-tools.exec-runtime.js";
 
 const POSIX_COMMAND_HIGHLIGHT_SHELLS: ReadonlySet<string> = POSIX_PARSEABLE_SHELL_WRAPPERS;
 
@@ -36,173 +32,51 @@ const loadExecApprovalCommandSpansRuntime = createLazyPromise(
   { cacheRejections: true },
 );
 
-/** Gateway payload fields used to register or wait for an exec approval decision. */
-type RequestExecApprovalDecisionParams = {
-  id: string;
-  command?: string;
-  commandArgv?: string[];
-  systemRunPlan?: SystemRunApprovalPlan;
-  env?: Record<string, string>;
-  cwd: string | undefined;
-  nodeId?: string;
-  host: "gateway" | "node";
-  security: ExecSecurity;
-  ask: ExecAsk;
-  warningText?: string;
-  commandSpans?: ExecApprovalCommandSpan[];
-  unavailableDecisions?: readonly ExecApprovalUnavailableDecision[];
-  agentId?: string;
-  resolvedPath?: string;
-  sessionKey?: string;
-  sessionId?: string;
-  runId?: string;
-  toolCallId?: string;
-  turnSourceChannel?: string;
-  turnSourceTo?: string;
-  turnSourceAccountId?: string;
-  turnSourceThreadId?: string | number;
-  approvalReviewerDeviceIds?: string[];
-  requireDeliveryRoute?: boolean;
-  suppressDelivery?: boolean;
-};
-
-type ExecApprovalRequestToolParams = RequestExecApprovalDecisionParams & {
-  timeoutMs: number;
-  twoPhase: true;
-};
-
-function buildExecApprovalRequestToolParams(
-  params: RequestExecApprovalDecisionParams,
-): ExecApprovalRequestToolParams {
-  return {
-    id: params.id,
-    ...(params.command ? { command: params.command } : {}),
-    ...(params.commandArgv ? { commandArgv: params.commandArgv } : {}),
-    systemRunPlan: params.systemRunPlan,
-    env: params.env,
-    cwd: params.cwd,
-    nodeId: params.nodeId,
-    host: params.host,
-    security: params.security,
-    ask: params.ask,
-    warningText: params.warningText,
-    commandSpans: params.commandSpans,
-    ...(params.unavailableDecisions?.length
-      ? { unavailableDecisions: params.unavailableDecisions }
-      : {}),
-    agentId: params.agentId,
-    resolvedPath: params.resolvedPath,
-    sessionKey: params.sessionKey,
-    sessionId: params.sessionId,
-    runId: params.runId,
-    toolCallId: params.toolCallId,
-    turnSourceChannel: params.turnSourceChannel,
-    turnSourceTo: params.turnSourceTo,
-    turnSourceAccountId: params.turnSourceAccountId,
-    turnSourceThreadId: params.turnSourceThreadId,
-    approvalReviewerDeviceIds: params.approvalReviewerDeviceIds,
-    requireDeliveryRoute: params.requireDeliveryRoute,
-    suppressDelivery: params.suppressDelivery,
-    timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
-    twoPhase: true,
-  };
-}
-
-type ParsedDecision = { present: boolean; value: string | null };
-
-function parseDecision(value: unknown): ParsedDecision {
-  if (!value || typeof value !== "object") {
-    return { present: false, value: null };
-  }
-  // Distinguish "field missing" from "field present but null/invalid".
-  // Registration responses intentionally omit `decision`; decision waits can include it.
-  if (!Object.hasOwn(value, "decision")) {
-    return { present: false, value: null };
-  }
-  const decision = (value as { decision?: unknown }).decision;
-  return { present: true, value: typeof decision === "string" ? decision : null };
-}
-
-function parseExpiresAtMs(value: unknown): number | undefined {
-  return asDateTimestampMs(value);
-}
-
-function resolveDefaultExecApprovalExpiresAtMs(): number {
-  return resolveExpiresAtMsFromDurationMs(DEFAULT_APPROVAL_TIMEOUT_MS) ?? 0;
-}
-
 /** Registration result returned before an approval decision is available. */
-export type ExecApprovalRegistration = {
-  id: string;
-  expiresAtMs: number;
-  finalDecision?: string | null;
-};
-
-class ExecApprovalRunAbortedError extends Error {
-  constructor() {
-    super("Exec approval cancelled because its run was aborted");
-    this.name = "ExecApprovalRunAbortedError";
-  }
-}
+export type ExecApprovalRegistration = AgentRunExecApprovalLease;
 
 export function isExecApprovalRunAbortedError(error: unknown): boolean {
-  return error instanceof ExecApprovalRunAbortedError;
+  return error instanceof AgentRunExecApprovalRunAbortedError;
 }
 
-/** Registers a two-phase exec approval request with the gateway. */
-async function registerExecApprovalRequest(
-  params: RequestExecApprovalDecisionParams,
-): Promise<ExecApprovalRegistration> {
-  // Two-phase registration is critical: the ID must be registered server-side
-  // before exec returns `approval-pending`, otherwise `/approve` can race and orphan.
-  const registrationResult = await callGatewayTool(
-    "exec.approval.request",
-    { timeoutMs: DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS },
-    buildExecApprovalRequestToolParams(params),
-    { expectFinal: false },
-  );
-  const decision = parseDecision(registrationResult);
-  const id = parseString(registrationResult?.id) ?? params.id;
-  const expiresAtMs =
-    parseExpiresAtMs(registrationResult?.expiresAtMs) ?? resolveDefaultExecApprovalExpiresAtMs();
-  if (decision.present) {
-    return { id, expiresAtMs, finalDecision: decision.value };
+async function cancelExecApprovalBestEffort(approval: AgentRunExecApprovalLease): Promise<void> {
+  try {
+    await approval.cancel();
+  } catch {
+    // The approval is already being abandoned; cancellation is best effort.
   }
-  return { id, expiresAtMs };
 }
 
 /** Uses a pre-resolved decision or waits for the registered approval id. */
 export async function resolveRegisteredExecApprovalDecision(params: {
-  approvalId: string;
+  approval: AgentRunExecApprovalLease;
   preResolvedDecision: string | null | undefined;
+  signal?: AbortSignal;
 }): Promise<string | null> {
+  const throwIfAborted = async () => {
+    if (!params.signal?.aborted) {
+      return;
+    }
+    await cancelExecApprovalBestEffort(params.approval);
+    params.signal.throwIfAborted();
+  };
+  await throwIfAborted();
   if (params.preResolvedDecision !== undefined) {
     return params.preResolvedDecision ?? null;
   }
+  let decision: string | null;
   try {
-    const decisionResult = await callGatewayTool<{ decision: string }>(
-      "exec.approval.waitDecision",
-      { timeoutMs: DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS },
-      { id: params.approvalId },
-    );
-    if (
-      decisionResult &&
-      typeof decisionResult === "object" &&
-      (decisionResult as { terminalReason?: unknown }).terminalReason === "run-aborted"
-    ) {
-      throw new ExecApprovalRunAbortedError();
-    }
-    return parseDecision(decisionResult).value;
-  } catch (err) {
-    // Timeout/cleanup path: treat missing/expired as no decision so askFallback applies.
-    if (isApprovalNotFoundError(err)) {
-      return null;
-    }
-    throw err;
+    decision = await params.approval.wait({ signal: params.signal });
+  } catch (error) {
+    await cancelExecApprovalBestEffort(params.approval);
+    throw error;
   }
+  await throwIfAborted();
+  return decision;
 }
 
 type HostExecApprovalParams = {
+  approvalHost?: AgentRunApprovalHost;
   approvalId: string;
   command?: string;
   commandArgv?: string[];
@@ -227,9 +101,9 @@ type HostExecApprovalParams = {
   turnSourceTo?: string;
   turnSourceAccountId?: string;
   turnSourceThreadId?: string | number;
-  approvalReviewerDeviceIds?: string[];
   requireDeliveryRoute?: boolean;
   suppressDelivery?: boolean;
+  signal?: AbortSignal;
 };
 
 type ExecApprovalRequesterContext = {
@@ -307,7 +181,7 @@ function shouldSkipGeneratedCommandSpans(params: HostExecApprovalParams): boolea
 
 async function buildHostApprovalDecisionParams(
   params: HostExecApprovalParams,
-): Promise<RequestExecApprovalDecisionParams> {
+): Promise<AgentRunExecApprovalRequest> {
   const commandSpans =
     params.commandHighlighting === true
       ? (params.commandSpans ??
@@ -339,7 +213,6 @@ async function buildHostApprovalDecisionParams(
     toolCallId: params.toolCallId,
     requireDeliveryRoute: params.requireDeliveryRoute,
     suppressDelivery: params.suppressDelivery,
-    approvalReviewerDeviceIds: params.approvalReviewerDeviceIds,
     ...buildExecApprovalTurnSourceContext(params),
   };
 }
@@ -348,7 +221,20 @@ async function buildHostApprovalDecisionParams(
 async function registerExecApprovalRequestForHost(
   params: HostExecApprovalParams,
 ): Promise<ExecApprovalRegistration> {
-  return await registerExecApprovalRequest(await buildHostApprovalDecisionParams(params));
+  const approvalHost = params.approvalHost?.exec;
+  if (!approvalHost) {
+    throw new Error("Exec approval unavailable: this run has no exec approval host.");
+  }
+  const approval = await approvalHost.request({
+    request: await buildHostApprovalDecisionParams(params),
+    timeoutMs: DEFAULT_APPROVAL_TIMEOUT_MS,
+    signal: params.signal,
+  });
+  if (approval.id !== params.approvalId) {
+    await cancelExecApprovalBestEffort(approval);
+    throw new Error("Exec approval host returned a mismatched approval id.");
+  }
+  return approval;
 }
 
 /** Registers a host/node approval request and wraps failures for exec callers. */

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -163,6 +163,14 @@ const resolveApprovalDecisionOrUndefinedMock = vi.hoisted(() =>
   vi.fn(async (): Promise<string | null | undefined> => undefined),
 );
 const runAbortedApprovalError = vi.hoisted(() => new Error("run aborted"));
+const cancelApprovalLeaseMock = vi.hoisted(() => vi.fn(async () => undefined));
+const createApprovalLease = (id: string) => ({
+  id,
+  expiresAtMs: Date.now() + 60_000,
+  wait: vi.fn(),
+  resolveAutoReview: vi.fn(),
+  cancel: cancelApprovalLeaseMock,
+});
 const resolveExecHostApprovalContextMock = vi.hoisted(() =>
   vi.fn(
     (): MockExecHostApprovalContext => ({
@@ -354,6 +362,7 @@ describe("processGatewayAllowlist", () => {
       rationale: "allowed",
     });
     commitExecAuthorizationMock.mockReset();
+    cancelApprovalLeaseMock.mockReset();
     resolveApprovalDecisionOrUndefinedMock.mockReset();
     resolveApprovalDecisionOrUndefinedMock.mockResolvedValue(undefined);
     shouldResolveExecApprovalUnavailableInlineMock.mockReset();
@@ -382,6 +391,7 @@ describe("processGatewayAllowlist", () => {
     });
     createAndRegisterDefaultExecApprovalRequestMock.mockReset();
     createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
+      approval: createApprovalLease("req-1"),
       approvalId: "req-1",
       approvalSlug: "slug-1",
       warningText: "",
@@ -415,6 +425,12 @@ describe("processGatewayAllowlist", () => {
       approvalRunningNoticeMs: 0,
       maxOutput: 1000,
       pendingMaxOutput: 1000,
+      approvalHost: {
+        exec: {
+          supportsDetachedExecution: true,
+          request: vi.fn(),
+        },
+      } as never,
       ...rest,
     });
   }
@@ -699,6 +715,7 @@ describe("processGatewayAllowlist", () => {
   it("resolves a triggerless CLI no-route approval through the real gate", async () => {
     await useRealUnavailableApprovalGate();
     createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
+      approval: createApprovalLease("approval-cli-no-route"),
       approvalId: "approval-cli-no-route",
       approvalSlug: "slug",
       warningText: "",
@@ -746,6 +763,7 @@ describe("processGatewayAllowlist", () => {
   it("preserves a routed approval through the real gate", async () => {
     await useRealUnavailableApprovalGate();
     createAndRegisterDefaultExecApprovalRequestMock.mockResolvedValue({
+      approval: createApprovalLease("approval-routed"),
       approvalId: "approval-routed",
       approvalSlug: "slug",
       warningText: "",
@@ -770,7 +788,9 @@ describe("processGatewayAllowlist", () => {
     });
     expect(shouldResolveExecApprovalUnavailableInlineMock).toHaveReturnedWith(false);
     expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledWith(
-      expect.objectContaining({ approvalId: "approval-routed" }),
+      expect.objectContaining({
+        approval: expect.objectContaining({ id: "approval-routed" }),
+      }),
     );
   });
 
@@ -931,10 +951,11 @@ describe("processGatewayAllowlist", () => {
     fs.writeFileSync(shadowGit, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
     try {
       const command = "git status";
-      await configurePlanBackedCommand({
+      const { resolvedPath } = await configurePlanBackedCommand({
         command,
         env: { PATH: tempDir },
       });
+      expect(resolvedPath).toBeTruthy();
 
       const result = await runGatewayAllowlist({
         command,
@@ -944,9 +965,9 @@ describe("processGatewayAllowlist", () => {
       });
 
       expect(defaultExecAutoReviewerMock).toHaveBeenCalledWith(
-        expect.objectContaining({ resolvedPath: shadowGit }),
+        expect.objectContaining({ resolvedPath }),
       );
-      expect(result).toEqual({ execCommandOverride: `${shadowGit} status` });
+      expect(result).toEqual({ execCommandOverride: `${resolvedPath} status` });
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
@@ -1164,9 +1185,18 @@ describe("processGatewayAllowlist", () => {
     });
 
     const result = await runGatewayAllowlist({ command });
+    const enforced = buildAuthorizedShellCommandFromPlan({
+      plan: authorizationPlan,
+      mode: "enforced",
+      segmentSatisfiedBy: ["safeBuiltins"],
+    });
+    expect(enforced.ok).toBe(true);
+    if (!enforced.ok) {
+      throw new Error(enforced.reason);
+    }
 
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
-    expect(result).toEqual({ execCommandOverride: command });
+    expect(result).toEqual({ execCommandOverride: enforced.command });
     expect(commitExecAuthorizationMock).toHaveBeenCalledWith(
       expect.objectContaining({
         authorization: expect.objectContaining({
@@ -2447,6 +2477,7 @@ EOF`,
     expect(runExecProcessMock).not.toHaveBeenCalled();
     expect(markBackgroundedMock).not.toHaveBeenCalled();
     expect(getActiveGatewayRootWorkCount()).toBe(0);
+    expect(cancelApprovalLeaseMock).toHaveBeenCalledOnce();
   });
 
   it("keeps the fire-and-forget path for channels without native approval clients", async () => {
@@ -2524,6 +2555,30 @@ EOF`,
       turnSourceChannel: "feishu",
       runId: "run-aborted",
       toolCallId: "tool-aborted",
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(resolveApprovalDecisionOrUndefinedMock).toHaveBeenCalledOnce();
+    });
+    expect(commitExecAuthorizationMock).not.toHaveBeenCalled();
+    expect(runExecProcessMock).not.toHaveBeenCalled();
+    expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves ordinary aborts in detached gateway approval handling", async () => {
+    const abortController = new AbortController();
+    const abortReason = new Error("ordinary run abort");
+    abortController.abort(abortReason);
+    resolveApprovalDecisionOrUndefinedMock.mockRejectedValue(abortReason);
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+
+    const result = await runGatewayAllowlist({
+      command: "find . -maxdepth 1",
+      turnSourceChannel: "feishu",
+      runId: "run-ordinary-abort",
+      toolCallId: "tool-ordinary-abort",
+      signal: abortController.signal,
     });
 
     expect(result.pendingResult?.details.status).toBe("approval-pending");
@@ -2675,6 +2730,7 @@ EOF`,
       }),
     );
     expect(runExecProcessMock).not.toHaveBeenCalled();
+    expect(cancelApprovalLeaseMock).toHaveBeenCalledOnce();
   });
 
   it("binds explicit allow-always persistence to its evaluated policy snapshot", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -47,6 +47,7 @@ import {
   runWithGatewayIndependentRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import { isNativeApprovalChannel, normalizeMessageChannel } from "../utils/message-channel.js";
+import type { AgentRunApprovalHost } from "./agent-run-approval.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
 import { formatExecApprovalContinuationSourceOutput } from "./bash-tools.exec-approval-output.js";
 import {
@@ -97,6 +98,7 @@ type ProcessGatewayAllowlistParams = {
   ask: ExecAsk;
   autoReview?: boolean;
   autoReviewer?: ExecAutoReviewer;
+  approvalHost?: AgentRunApprovalHost;
   signal?: AbortSignal;
   safeBins: Set<string>;
   safeBinProfiles: Readonly<Record<string, SafeBinProfile>>;
@@ -134,6 +136,7 @@ type ProcessGatewayAllowlistParams = {
 type ProcessGatewayAllowlistResult = {
   execCommandOverride?: string;
   allowWithoutEnforcedCommand?: boolean;
+  cancelUnusedApproval?: () => Promise<void>;
   pendingResult?: AgentToolResult<ExecToolDetails>;
   deniedResult?: AgentToolResult<ExecToolDetails>;
 };
@@ -415,9 +418,13 @@ function buildGatewayExecApprovalFollowupSummary(params: {
 }
 
 function shouldAwaitGatewayApprovalInline(params: {
+  approvalHost?: AgentRunApprovalHost;
   turnSourceChannel?: string;
   approvalFollowupMode?: "agent" | "direct";
 }): boolean {
+  if (params.approvalHost?.exec?.supportsDetachedExecution !== true) {
+    return true;
+  }
   if (params.approvalFollowupMode !== undefined) {
     return false;
   }
@@ -878,6 +885,7 @@ export async function processGatewayAllowlist(
     });
     const registerGatewayApproval = async (approvalId: string) =>
       await registerExecApprovalRequestForHostOrThrow({
+        approvalHost: params.approvalHost,
         approvalId,
         command: params.command,
         env: params.requestedEnv,
@@ -895,16 +903,15 @@ export async function processGatewayAllowlist(
         sessionId: params.sessionId,
         runId: params.runId,
         toolCallId: params.toolCallId,
-        approvalReviewerDeviceIds: params.approvalReviewerDeviceId
-          ? [params.approvalReviewerDeviceId]
-          : undefined,
         resolvedPath: resolveApprovalAuditTrustPath(
           allowlistEval.segments[0]?.resolution ?? null,
           params.workdir,
         ),
         ...buildExecApprovalTurnSourceContext(params),
+        signal: params.signal,
       });
     const {
+      approval,
       approvalId,
       approvalSlug,
       warningText,
@@ -917,6 +924,13 @@ export async function processGatewayAllowlist(
       ...requestArgs,
       register: registerGatewayApproval,
     });
+    const cancelApprovalBestEffort = async () => {
+      try {
+        await approval.cancel();
+      } catch {
+        // The local execution path is already abandoning this lease.
+      }
+    };
     emitGatewayExecApprovalSecurityEvent({
       action: "exec.approval.requested",
       outcome: "success",
@@ -1014,11 +1028,15 @@ export async function processGatewayAllowlist(
     );
     const resolveApprovalForExecution = async (onFailure: () => void) => {
       const decision = await resolveApprovalDecisionOrUndefined({
-        approvalId,
+        approval,
         preResolvedDecision,
+        signal: params.signal,
         onFailure,
       }).catch((error: unknown) => {
         if (isExecApprovalRunAbortedError(error)) {
+          return "run-aborted" as const;
+        }
+        if (params.signal?.aborted) {
           return "run-aborted" as const;
         }
         throw error;
@@ -1112,6 +1130,7 @@ export async function processGatewayAllowlist(
       return {
         deniedReason,
         requestFailed: false,
+        cancelUnusedApproval: decision === "allow-once",
         authorizationSource:
           decision === null ? ("ask-fallback" as const) : ("explicit-approval" as const),
         allowAlwaysDecision:
@@ -1133,9 +1152,47 @@ export async function processGatewayAllowlist(
           data: { phase: "waiting-approval", approvalId, toolCallId: params.toolCallId },
         });
       }
-      let approvalDecision: Awaited<ReturnType<typeof resolveApprovalForExecution>>;
+      let approvalDecision: Awaited<ReturnType<typeof resolveApprovalForExecution>> | undefined;
+      let handedOffApproval = false;
       try {
         approvalDecision = await resolveApprovalForExecution(() => undefined);
+        // A run-abort cancellation must propagate as cancellation, not resolve
+        // into an ordinary denial the aborted run would keep processing. The
+        // abort owner cancels approvals before firing the controller, so the
+        // signal is aborted by the time the released waiter reaches us.
+        if (approvalDecision.runAborted) {
+          params.signal?.throwIfAborted();
+        }
+        if (approvalDecision.deniedReason) {
+          return {
+            deniedResult: buildGatewayExecApprovalDeniedToolResult({
+              approvalId,
+              deniedReason: approvalDecision.deniedReason,
+              command: params.command,
+              cwd: params.workdir,
+            }),
+          };
+        }
+
+        params.signal?.throwIfAborted();
+        await commitExecutionAuthorization({
+          source: approvalDecision.authorizationSource,
+          resolvedPath: resolvedPath ?? undefined,
+          ...(approvalDecision.allowAlwaysDecision
+            ? { allowAlwaysDecision: approvalDecision.allowAlwaysDecision }
+            : {}),
+        });
+        // The commit awaits: an abort that lands during it must not admit the
+        // process (mirrors the detached path's post-commit check).
+        params.signal?.throwIfAborted();
+        handedOffApproval = approvalDecision.cancelUnusedApproval === true;
+        return {
+          execCommandOverride: approvalDecision.execCommandOverride,
+          allowWithoutEnforcedCommand: approvalDecision.execCommandOverride === undefined,
+          ...(approvalDecision.cancelUnusedApproval
+            ? { cancelUnusedApproval: cancelApprovalBestEffort }
+            : {}),
+        };
       } finally {
         if (params.runId) {
           emitAgentEvent({
@@ -1146,40 +1203,10 @@ export async function processGatewayAllowlist(
             data: { phase: "approval-resolved", approvalId, toolCallId: params.toolCallId },
           });
         }
+        if (approvalDecision?.cancelUnusedApproval && !handedOffApproval) {
+          await cancelApprovalBestEffort();
+        }
       }
-      // A run-abort cancellation must propagate as cancellation, not resolve
-      // into an ordinary denial the aborted run would keep processing. The
-      // abort owner cancels approvals before firing the controller, so the
-      // signal is aborted by the time the released waiter reaches us.
-      if (approvalDecision.runAborted) {
-        params.signal?.throwIfAborted();
-      }
-      if (approvalDecision.deniedReason) {
-        return {
-          deniedResult: buildGatewayExecApprovalDeniedToolResult({
-            approvalId,
-            deniedReason: approvalDecision.deniedReason,
-            command: params.command,
-            cwd: params.workdir,
-          }),
-        };
-      }
-
-      params.signal?.throwIfAborted();
-      await commitExecutionAuthorization({
-        source: approvalDecision.authorizationSource,
-        resolvedPath: resolvedPath ?? undefined,
-        ...(approvalDecision.allowAlwaysDecision
-          ? { allowAlwaysDecision: approvalDecision.allowAlwaysDecision }
-          : {}),
-      });
-      // The commit awaits: an abort that lands during it must not admit the
-      // process (mirrors the detached path's post-commit check).
-      params.signal?.throwIfAborted();
-      return {
-        execCommandOverride: approvalDecision.execCommandOverride,
-        allowWithoutEnforcedCommand: approvalDecision.execCommandOverride === undefined,
-      };
     }
 
     const effectiveTimeout =
@@ -1216,147 +1243,156 @@ export async function processGatewayAllowlist(
     };
 
     void (async () => {
-      let approvalDecision: Awaited<ReturnType<typeof resolveApprovalForExecution>>;
+      let approvalDecision: Awaited<ReturnType<typeof resolveApprovalForExecution>> | undefined;
+      let approvalConsumed = false;
       try {
-        approvalDecision = await resolveApprovalForExecution(
-          () =>
-            void sendExecApprovalFollowupResult(
-              followupTarget,
-              `Exec denied (gateway id=${approvalId}, approval-request-failed): ${params.command}`,
-            ),
-        );
-      } catch {
-        await denyApprovalStateWriteFailure();
-        return;
-      }
-      if (approvalDecision.requestFailed) {
-        return;
-      }
-      if (approvalDecision.runAborted) {
-        return;
-      }
-      if (params.signal?.aborted) {
-        return;
-      }
+        try {
+          approvalDecision = await resolveApprovalForExecution(
+            () =>
+              void sendExecApprovalFollowupResult(
+                followupTarget,
+                `Exec denied (gateway id=${approvalId}, approval-request-failed): ${params.command}`,
+              ),
+          );
+        } catch {
+          await denyApprovalStateWriteFailure();
+          return;
+        }
+        if (approvalDecision.requestFailed) {
+          return;
+        }
+        if (approvalDecision.runAborted) {
+          return;
+        }
+        if (params.signal?.aborted) {
+          return;
+        }
 
-      if (approvalDecision.deniedReason) {
-        await sendExecApprovalFollowupResult(
-          followupTarget,
-          `Exec denied (gateway id=${approvalId}, ${approvalDecision.deniedReason}): ${params.command}`,
-        );
-        return;
-      }
-
-      let admitted:
-        | { status: "started"; run: Awaited<ReturnType<typeof runExecProcess>> }
-        | { status: "approval-state-write-failed" }
-        | { status: "run-aborted" }
-        | { status: "spawn-failed" };
-      try {
-        admitted = await runWithGatewayIndependentRootWorkAdmission(async () => {
-          // Admission can queue: recheck abort before writing authorization so
-          // an abort that wins while waiting cannot persist an allow-always.
-          if (params.signal?.aborted) {
-            return { status: "run-aborted" as const };
-          }
-          try {
-            await commitExecutionAuthorization({
-              source: approvalDecision.authorizationSource,
-              resolvedPath: resolvedPath ?? undefined,
-              ...(approvalDecision.allowAlwaysDecision
-                ? { allowAlwaysDecision: approvalDecision.allowAlwaysDecision }
-                : {}),
-            });
-          } catch {
-            return { status: "approval-state-write-failed" as const };
-          }
-          if (params.signal?.aborted) {
-            return { status: "run-aborted" as const };
-          }
-
-          let run: Awaited<ReturnType<typeof runExecProcess>>;
-          try {
-            run = await runExecProcess({
-              command: params.command,
-              execCommand: approvalDecision.execCommandOverride,
-              workdir: params.workdir,
-              env: params.env,
-              pathPrepend: params.pathPrepend,
-              sandbox: undefined,
-              containerWorkdir: null,
-              usePty: params.pty,
-              warnings: params.warnings,
-              maxOutput: params.maxOutput,
-              pendingMaxOutput: params.pendingMaxOutput,
-              notifyOnExit: false,
-              notifyOnExitEmptySuccess: false,
-              scopeKey: params.scopeKey,
-              sessionKey: params.notifySessionKey ?? params.sessionKey,
-              timeoutSec: effectiveTimeout,
-            });
-          } catch {
-            return { status: "spawn-failed" as const };
-          }
-
-          // Keep the admitted root until the registry owns the live process.
-          // Suspension must observe one side of this handoff at every instant.
-          markBackgrounded(run.session);
-          return { status: "started" as const, run };
-        });
-      } catch (error) {
-        if (
-          error instanceof GatewayDrainingError ||
-          (error instanceof Error && error.message === "gateway is draining for restart")
-        ) {
+        if (approvalDecision.deniedReason) {
           await sendExecApprovalFollowupResult(
             followupTarget,
-            `Exec denied (gateway id=${approvalId}, gateway-draining): ${params.command}`,
+            `Exec denied (gateway id=${approvalId}, ${approvalDecision.deniedReason}): ${params.command}`,
           );
           return;
         }
-        // Detached approval work must always settle through a follow-up. Treat
-        // any unexpected admission failure as a spawn failure, never an
-        // unhandled rejection from this fire-and-forget chain.
-        admitted = { status: "spawn-failed" };
-      }
+        const dispatchApprovalDecision = approvalDecision;
 
-      if (admitted.status === "approval-state-write-failed") {
-        await denyApprovalStateWriteFailure();
-        return;
-      }
-      if (admitted.status === "run-aborted") {
-        return;
-      }
-      if (admitted.status === "spawn-failed") {
-        await sendExecApprovalFollowupResult(
-          followupTarget,
-          `Exec denied (gateway id=${approvalId}, spawn-failed): ${params.command}`,
-        );
-        return;
-      }
+        let admitted:
+          | { status: "started"; run: Awaited<ReturnType<typeof runExecProcess>> }
+          | { status: "approval-state-write-failed" }
+          | { status: "run-aborted" }
+          | { status: "spawn-failed" };
+        try {
+          admitted = await runWithGatewayIndependentRootWorkAdmission(async () => {
+            // Admission can queue: recheck abort before writing authorization so
+            // an abort that wins while waiting cannot persist an allow-always.
+            if (params.signal?.aborted) {
+              return { status: "run-aborted" as const };
+            }
+            try {
+              await commitExecutionAuthorization({
+                source: dispatchApprovalDecision.authorizationSource,
+                resolvedPath: resolvedPath ?? undefined,
+                ...(dispatchApprovalDecision.allowAlwaysDecision
+                  ? { allowAlwaysDecision: dispatchApprovalDecision.allowAlwaysDecision }
+                  : {}),
+              });
+            } catch {
+              return { status: "approval-state-write-failed" as const };
+            }
+            if (params.signal?.aborted) {
+              return { status: "run-aborted" as const };
+            }
 
-      const { run } = admitted;
+            let run: Awaited<ReturnType<typeof runExecProcess>>;
+            try {
+              run = await runExecProcess({
+                command: params.command,
+                execCommand: dispatchApprovalDecision.execCommandOverride,
+                workdir: params.workdir,
+                env: params.env,
+                pathPrepend: params.pathPrepend,
+                sandbox: undefined,
+                containerWorkdir: null,
+                usePty: params.pty,
+                warnings: params.warnings,
+                maxOutput: params.maxOutput,
+                pendingMaxOutput: params.pendingMaxOutput,
+                notifyOnExit: false,
+                notifyOnExitEmptySuccess: false,
+                scopeKey: params.scopeKey,
+                sessionKey: params.notifySessionKey ?? params.sessionKey,
+                timeoutSec: effectiveTimeout,
+              });
+              approvalConsumed = true;
+            } catch {
+              return { status: "spawn-failed" as const };
+            }
 
-      const outcome = await run.promise;
-      const dynamicFollowupText = await resolveGatewayExecApprovalFollowupText({
-        approvalFollowup: params.approvalFollowup,
-        approvalId,
-        sessionId: run.session.id,
-        trigger: params.trigger,
-        outcome,
-      });
-      const approvalFollowupText = normalizeStringEntries([
-        params.approvalFollowupText ?? "",
-        dynamicFollowupText ?? "",
-      ]).join("\n\n");
-      const summary = buildGatewayExecApprovalFollowupSummary({
-        approvalId,
-        sessionId: run.session.id,
-        outcome,
-        trigger: params.trigger,
-        approvalFollowupText,
-      });
-      await sendExecApprovalFollowupResult(followupTarget, summary);
+            // Keep the admitted root until the registry owns the live process.
+            // Suspension must observe one side of this handoff at every instant.
+            markBackgrounded(run.session);
+            return { status: "started" as const, run };
+          });
+        } catch (error) {
+          if (
+            error instanceof GatewayDrainingError ||
+            (error instanceof Error && error.message === "gateway is draining for restart")
+          ) {
+            await sendExecApprovalFollowupResult(
+              followupTarget,
+              `Exec denied (gateway id=${approvalId}, gateway-draining): ${params.command}`,
+            );
+            return;
+          }
+          // Detached approval work must always settle through a follow-up. Treat
+          // any unexpected admission failure as a spawn failure, never an
+          // unhandled rejection from this fire-and-forget chain.
+          admitted = { status: "spawn-failed" };
+        }
+
+        if (admitted.status === "approval-state-write-failed") {
+          await denyApprovalStateWriteFailure();
+          return;
+        }
+        if (admitted.status === "run-aborted") {
+          return;
+        }
+        if (admitted.status === "spawn-failed") {
+          await sendExecApprovalFollowupResult(
+            followupTarget,
+            `Exec denied (gateway id=${approvalId}, spawn-failed): ${params.command}`,
+          );
+          return;
+        }
+
+        const { run } = admitted;
+
+        const outcome = await run.promise;
+        const dynamicFollowupText = await resolveGatewayExecApprovalFollowupText({
+          approvalFollowup: params.approvalFollowup,
+          approvalId,
+          sessionId: run.session.id,
+          trigger: params.trigger,
+          outcome,
+        });
+        const approvalFollowupText = normalizeStringEntries([
+          params.approvalFollowupText ?? "",
+          dynamicFollowupText ?? "",
+        ]).join("\n\n");
+        const summary = buildGatewayExecApprovalFollowupSummary({
+          approvalId,
+          sessionId: run.session.id,
+          outcome,
+          trigger: params.trigger,
+          approvalFollowupText,
+        });
+        await sendExecApprovalFollowupResult(followupTarget, summary);
+      } finally {
+        if (approvalDecision?.cancelUnusedApproval && !approvalConsumed) {
+          await cancelApprovalBestEffort();
+        }
+      }
     })();
 
     return {

--- a/src/agents/bash-tools.exec-host-node-dispatch-authority.ts
+++ b/src/agents/bash-tools.exec-host-node-dispatch-authority.ts
@@ -1,0 +1,58 @@
+import type { ExecAsk, ExecSecurity } from "../infra/exec-approvals.js";
+import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
+import { resolveExecHostApprovalContext } from "./bash-tools.exec-host-shared.js";
+
+export type NodeGatewayDispatchAuthority =
+  | "current-policy"
+  | "human-approval"
+  | "auto-review"
+  | "ask-fallback";
+
+export type NodeGatewayPolicyCheckpoint = {
+  hostSecurity: ExecSecurity;
+  hostAsk: ExecAsk;
+  askFallback: ExecSecurity;
+};
+
+export async function assertCurrentNodeGatewayPolicyAllowsDispatch(params: {
+  request: ExecuteNodeHostCommandParams;
+  authority: NodeGatewayDispatchAuthority;
+  currentPolicyAllows?: (policy: { hostSecurity: ExecSecurity; hostAsk: ExecAsk }) => boolean;
+  fallbackPolicy?: NodeGatewayPolicyCheckpoint;
+}): Promise<void> {
+  const current = await resolveExecHostApprovalContext({
+    agentId: params.request.agentId,
+    security: params.request.security,
+    ask: params.request.ask,
+    host: "node",
+  });
+  // A human grant may bypass ask/allowlist, but never a later deny. Auto-review
+  // additionally cannot stand in for a newly required human decision.
+  if (current.hostSecurity === "deny") {
+    throw new Error("exec denied: host=node security=deny");
+  }
+  if (params.authority === "human-approval") {
+    return;
+  }
+  if (params.authority === "auto-review") {
+    if (current.hostAsk === "always") {
+      throw new Error("exec denied: host=node ask=always requires human approval");
+    }
+    return;
+  }
+  if (params.authority === "ask-fallback") {
+    const expected = params.fallbackPolicy;
+    if (
+      !expected ||
+      current.hostSecurity !== expected.hostSecurity ||
+      current.hostAsk !== expected.hostAsk ||
+      current.askFallback !== expected.askFallback
+    ) {
+      throw new Error("exec denied: host=node fallback policy changed before dispatch");
+    }
+    return;
+  }
+  if (!params.currentPolicyAllows?.(current)) {
+    throw new Error("exec denied: host=node policy changed before dispatch");
+  }
+}

--- a/src/agents/bash-tools.exec-host-node.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node.cancellation.test.ts
@@ -8,21 +8,34 @@ type NodeApprovalPolicy = Awaited<
   ReturnType<typeof import("./bash-tools.exec-host-shared.js").resolveExecHostApprovalContext>
 >;
 
-const mocks = vi.hoisted(() => ({
-  analyzeNodeApprovalRequirement: vi.fn(),
-  callGatewayTool: vi.fn(
-    async (
-      _method: string,
-      _options: unknown,
-      _params?: { command?: string },
-      _extra?: { scopes?: string[]; signal?: AbortSignal },
-    ) => ({ payload: { success: true, stdout: "ok", exitCode: 0 } }),
-  ),
-  invokeNodeSystemRunDirect: vi.fn(),
-  registerNodeApproval: vi.fn(async () => undefined),
-  requiresExecApproval: vi.fn(),
-  resolveExecHostApprovalContext: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  const approvalLease = {
+    id: "approval",
+    expiresAtMs: Date.now() + 60_000,
+    wait: vi.fn(),
+    resolveAutoReview: vi.fn(async () => undefined),
+    cancel: vi.fn(async () => undefined),
+  };
+  return {
+    analyzeNodeApprovalRequirement: vi.fn(),
+    approvalLease,
+    callGatewayTool: vi.fn(
+      async (
+        _method: string,
+        _options: unknown,
+        _params?: { command?: string },
+        _extra?: { scopes?: string[]; signal?: AbortSignal },
+      ) => ({ payload: { success: true, stdout: "ok", exitCode: 0 } }),
+    ),
+    invokeNodeSystemRunDirect: vi.fn(),
+    registerNodeApproval: vi.fn(async (approvalId: string) => ({
+      ...approvalLease,
+      id: approvalId,
+    })),
+    requiresExecApproval: vi.fn(),
+    resolveExecHostApprovalContext: vi.fn(),
+  };
+});
 
 vi.mock("../infra/exec-approvals.js", () => ({
   maxAsk: (left: ExecAsk, right: ExecAsk) => {
@@ -201,6 +214,7 @@ describe("node-host dispatch cancellation", () => {
       ),
     ).toBe(false);
     expect(mocks.registerNodeApproval).toHaveBeenCalledTimes(scenario.autoReview ? 1 : 0);
+    expect(mocks.approvalLease.cancel).toHaveBeenCalledTimes(scenario.autoReview ? 1 : 0);
   });
 
   it("forwards cancellation without removing auto-reviewed execution scopes", async () => {
@@ -228,6 +242,34 @@ describe("node-host dispatch cancellation", () => {
       expect.objectContaining({ command: "system.run" }),
       { scopes: ["operator.write", "operator.approvals"], signal: controller.signal },
     );
+    expect(mocks.approvalLease.resolveAutoReview).toHaveBeenCalledOnce();
+    expect(mocks.approvalLease.cancel).not.toHaveBeenCalled();
+  });
+
+  it("cancels the lease when auto-review resolution fails", async () => {
+    mocks.resolveExecHostApprovalContext.mockResolvedValue(createPolicy("allowlist", "on-miss"));
+    mocks.approvalLease.resolveAutoReview.mockRejectedValueOnce(
+      new Error("auto-review resolution failed"),
+    );
+    const reviewer: ExecAutoReviewer = async () => ({
+      decision: "allow-once",
+      risk: "low",
+      rationale: "safe command",
+    });
+
+    await expect(
+      executeNodeHostCommand(
+        createRequest({
+          security: "allowlist",
+          ask: "on-miss",
+          autoReview: true,
+          autoReviewer: reviewer,
+        }),
+      ),
+    ).rejects.toThrow("auto-review resolution failed");
+
+    expect(mocks.approvalLease.cancel).toHaveBeenCalledOnce();
+    expect(mocks.callGatewayTool).not.toHaveBeenCalled();
   });
 
   it("forwards cancellation for prepared commands that need no approval", async () => {

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -14,6 +14,11 @@ import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.t
 
 type StrictInlineEvalBoundary =
   typeof import("./bash-tools.exec-host-shared.js").enforceStrictInlineEvalApprovalBoundary;
+type RegisterExecApprovalRequest =
+  typeof import("./bash-tools.exec-approval-request.js").registerExecApprovalRequestForHostOrThrow;
+type DefaultExecApprovalRegister = Parameters<
+  typeof import("./bash-tools.exec-host-shared.js").createAndRegisterDefaultExecApprovalRequest
+>[0]["register"];
 type ExecAutoReviewer = typeof import("../infra/exec-auto-review.js").defaultExecAutoReviewer;
 type ExecAutoReviewDecision = Awaited<ReturnType<ExecAutoReviewer>>;
 type ExecAsk = import("../infra/exec-approvals.js").ExecAsk;
@@ -220,8 +225,17 @@ const enforceStrictInlineEvalApprovalBoundaryMock = vi.hoisted(() =>
   })),
 );
 const registerExecApprovalRequestForHostOrThrowMock = vi.hoisted(() =>
-  vi.fn(async () => undefined),
+  vi.fn<RegisterExecApprovalRequest>(),
 );
+const resolveAutoReviewApprovalMock = vi.hoisted(() => vi.fn());
+const cancelApprovalLeaseMock = vi.hoisted(() => vi.fn(async () => undefined));
+const createApprovalLease = (id: string) => ({
+  id,
+  expiresAtMs: Date.now() + 60_000,
+  wait: vi.fn(),
+  resolveAutoReview: resolveAutoReviewApprovalMock,
+  cancel: cancelApprovalLeaseMock,
+});
 const detectInterpreterInlineEvalArgvMock = vi.hoisted(() =>
   vi.fn(
     (): {
@@ -347,6 +361,12 @@ function createNodeHostRequest(
     defaultTimeoutSec: 30,
     approvalRunningNoticeMs: 0,
     warnings: [],
+    approvalHost: {
+      exec: {
+        supportsDetachedExecution: true,
+        request: vi.fn(),
+      },
+    } as never,
     agentId: "requested-agent",
     sessionKey: "requested-session",
     ...overrides,
@@ -634,10 +654,11 @@ describe("executeNodeHostCommand", () => {
     createAndRegisterDefaultExecApprovalRequestMock.mockImplementation(async (args?: unknown) => {
       const register =
         args && typeof args === "object" && "register" in args
-          ? (args as { register?: (approvalId: string) => Promise<void> }).register
+          ? (args as { register?: DefaultExecApprovalRegister }).register
           : undefined;
-      await register?.("approval-1");
+      const approval = (await register?.("approval-1")) ?? createApprovalLease("approval-1");
       return {
+        approval,
         approvalId: "approval-1",
         approvalSlug: "slug-1",
         warningText: "",
@@ -672,6 +693,16 @@ describe("executeNodeHostCommand", () => {
     detectInterpreterInlineEvalArgvMock.mockReset();
     detectInterpreterInlineEvalArgvMock.mockReturnValue(null);
     registerExecApprovalRequestForHostOrThrowMock.mockReset();
+    resolveAutoReviewApprovalMock.mockReset();
+    cancelApprovalLeaseMock.mockReset();
+    cancelApprovalLeaseMock.mockResolvedValue(undefined);
+    registerExecApprovalRequestForHostOrThrowMock.mockImplementation(async (params) =>
+      createApprovalLease(
+        params && typeof params === "object" && "approvalId" in params
+          ? params.approvalId
+          : "approval-1",
+      ),
+    );
   });
 
   it("returns outcome-unknown for an ambiguous direct node timeout", async () => {
@@ -776,7 +807,8 @@ describe("executeNodeHostCommand", () => {
       },
     });
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
-    expect(callGatewayToolMock).toHaveBeenCalledTimes(4);
+    expect(resolveAutoReviewApprovalMock).toHaveBeenCalledOnce();
+    expect(callGatewayToolMock).toHaveBeenCalledTimes(3);
   });
 
   it("denies non-interactive approval requests without creating operator events", async () => {
@@ -1007,6 +1039,38 @@ describe("executeNodeHostCommand", () => {
     ).toBe(false);
   });
 
+  it("does not report a rejected detached approval after an ordinary run abort", async () => {
+    const abortController = new AbortController();
+    const abortReason = new Error("run aborted before approval wait rejected");
+    resolveApprovalDecisionOrUndefinedMock.mockImplementationOnce(async () => {
+      abortController.abort(abortReason);
+      throw abortReason;
+    });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "deny",
+    });
+
+    const result = await executeNodeHostCommand(
+      createNodeHostRequest({
+        signal: abortController.signal,
+      }),
+    );
+
+    expect(result.details?.status).toBe("approval-pending");
+    await setImmediate();
+    expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+    expect(
+      callGatewayToolMock.mock.calls.some(
+        ([method, , params]) =>
+          method === "node.invoke" &&
+          (params as MockNodeInvokeParams | undefined)?.command === "system.run",
+      ),
+    ).toBe(false);
+  });
+
   it("never reports a completed detached node command as denied when delivery fails", async () => {
     const unhandledRejections = captureProcessUnhandledRejections();
 
@@ -1066,6 +1130,7 @@ describe("executeNodeHostCommand", () => {
 
     expect(createExecApprovalDecisionStateMock).not.toHaveBeenCalled();
     expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+    expect(cancelApprovalLeaseMock).toHaveBeenCalledOnce();
     expect(
       callGatewayToolMock.mock.calls.some(
         ([method, , params]) =>
@@ -1108,6 +1173,7 @@ describe("executeNodeHostCommand", () => {
     await setImmediate();
 
     expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+    expect(cancelApprovalLeaseMock).toHaveBeenCalledOnce();
     expect(
       callGatewayToolMock.mock.calls.some(
         ([method, , params]) =>
@@ -1270,6 +1336,7 @@ describe("executeNodeHostCommand", () => {
 
       expect(unhandledRejections.reasons).toEqual([]);
       expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+      expect(cancelApprovalLeaseMock).toHaveBeenCalledOnce();
     } finally {
       unhandledRejections.restore();
     }
@@ -1819,12 +1886,7 @@ describe("executeNodeHostCommand", () => {
         suppressDelivery: true,
       }),
     );
-    expect(callGatewayToolMock).toHaveBeenCalledWith(
-      "exec.approval.resolve",
-      { timeoutMs: 15_000 },
-      { id: expect.any(String), decision: "allow-once" },
-      { scopes: ["operator.approvals"], requireAgentRuntimeIdentity: true },
-    );
+    expect(resolveAutoReviewApprovalMock).toHaveBeenCalledOnce();
   });
 
   it("does not invoke the node after cancellation wins during auto-review", async () => {

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -6,7 +6,6 @@
 import { randomUUID } from "node:crypto";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "../gateway/operator-scopes.js";
 import {
-  type ExecAsk,
   type ExecSecurity,
   maxAsk,
   minSecurity,
@@ -22,9 +21,15 @@ import { formatExecApprovalContinuationSourceOutput } from "./bash-tools.exec-ap
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
+  type ExecApprovalRegistration,
   isExecApprovalRunAbortedError,
   registerExecApprovalRequestForHostOrThrow,
 } from "./bash-tools.exec-approval-request.js";
+import {
+  assertCurrentNodeGatewayPolicyAllowsDispatch,
+  type NodeGatewayDispatchAuthority,
+  type NodeGatewayPolicyCheckpoint,
+} from "./bash-tools.exec-host-node-dispatch-authority.js";
 import {
   formatNodeInvokeFailureFollowup,
   formatNodeInvokeFailureToolResult,
@@ -45,64 +50,8 @@ import { createApprovalSlug } from "./bash-tools.exec-runtime.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import { abortable } from "./embedded-agent-runner/run/abortable.js";
 import type { AgentToolResult } from "./runtime/index.js";
-import { callGatewayTool } from "./tools/gateway.js";
 
 const APPROVED_NODE_INVOKE_SCOPES = [WRITE_SCOPE, APPROVALS_SCOPE];
-
-type NodeGatewayDispatchAuthority =
-  | "current-policy"
-  | "human-approval"
-  | "auto-review"
-  | "ask-fallback";
-
-type NodeGatewayPolicyCheckpoint = {
-  hostSecurity: ExecSecurity;
-  hostAsk: ExecAsk;
-  askFallback: ExecSecurity;
-};
-
-async function assertCurrentNodeGatewayPolicyAllowsDispatch(params: {
-  request: ExecuteNodeHostCommandParams;
-  authority: NodeGatewayDispatchAuthority;
-  currentPolicyAllows?: (policy: { hostSecurity: ExecSecurity; hostAsk: ExecAsk }) => boolean;
-  fallbackPolicy?: NodeGatewayPolicyCheckpoint;
-}): Promise<void> {
-  const current = await execHostShared.resolveExecHostApprovalContext({
-    agentId: params.request.agentId,
-    security: params.request.security,
-    ask: params.request.ask,
-    host: "node",
-  });
-  // A human grant may bypass ask/allowlist, but never a later deny. Auto-review
-  // additionally cannot stand in for a newly required human decision.
-  if (current.hostSecurity === "deny") {
-    throw new Error("exec denied: host=node security=deny");
-  }
-  if (params.authority === "human-approval") {
-    return;
-  }
-  if (params.authority === "auto-review") {
-    if (current.hostAsk === "always") {
-      throw new Error("exec denied: host=node ask=always requires human approval");
-    }
-    return;
-  }
-  if (params.authority === "ask-fallback") {
-    const expected = params.fallbackPolicy;
-    if (
-      !expected ||
-      current.hostSecurity !== expected.hostSecurity ||
-      current.hostAsk !== expected.hostAsk ||
-      current.askFallback !== expected.askFallback
-    ) {
-      throw new Error("exec denied: host=node fallback policy changed before dispatch");
-    }
-    return;
-  }
-  if (!params.currentPolicyAllows?.(current)) {
-    throw new Error("exec denied: host=node policy changed before dispatch");
-  }
-}
 
 /**
  * Executes a command on a remote node, requesting approval when policy requires it.
@@ -209,6 +158,7 @@ export async function executeNodeHostCommand(
     options: { requireDeliveryRoute?: boolean; suppressDelivery?: boolean } = {},
   ) =>
     await registerExecApprovalRequestForHostOrThrow({
+      approvalHost: params.approvalHost,
       approvalId,
       systemRunPlan: prepared.plan,
       env: target.env,
@@ -224,9 +174,7 @@ export async function executeNodeHostCommand(
         agentId: prepared.agentId,
         sessionKey: prepared.sessionKey,
       }),
-      approvalReviewerDeviceIds: params.approvalReviewerDeviceId
-        ? [params.approvalReviewerDeviceId]
-        : undefined,
+      signal: params.signal,
       ...(options.requireDeliveryRoute !== undefined
         ? { requireDeliveryRoute: options.requireDeliveryRoute }
         : {}),
@@ -311,6 +259,7 @@ export async function executeNodeHostCommand(
   let inlineApprovalDecision: "allow-once" | "allow-always" | null = null;
   let inlineApprovalSource: "ask-fallback" | undefined;
   let inlineApprovalId: string | undefined;
+  let inlineApprovalLease: ExecApprovalRegistration | undefined;
   let inlineDispatchAuthority: NodeGatewayDispatchAuthority = "current-policy";
   let inlineFallbackPolicy: NodeGatewayPolicyCheckpoint | undefined;
   if (requiresAsk) {
@@ -368,16 +317,17 @@ export async function executeNodeHostCommand(
       const autoReviewAllowed = decision.decision === "allow-once" && decision.risk === "low";
       if (autoReviewAllowed) {
         const approvalId = randomUUID();
-        await registerNodeApproval(approvalId, {
+        const approval = await registerNodeApproval(approvalId, {
           requireDeliveryRoute: false,
           suppressDelivery: true,
         });
-        await callGatewayTool(
-          "exec.approval.resolve",
-          { timeoutMs: 15_000 },
-          { id: approvalId, decision: "allow-once" },
-          { scopes: [APPROVALS_SCOPE], requireAgentRuntimeIdentity: true },
-        );
+        inlineApprovalLease = approval;
+        try {
+          await approval.resolveAutoReview();
+        } catch (error) {
+          await approval.cancel().catch(() => undefined);
+          throw error;
+        }
         inlineApprovedByAsk = true;
         inlineApprovalDecision = "allow-once";
         inlineApprovalId = approvalId;
@@ -401,6 +351,7 @@ export async function executeNodeHostCommand(
         turnSourceAccountId: params.turnSourceAccountId,
       });
       const {
+        approval,
         approvalId,
         approvalSlug,
         warningText,
@@ -413,18 +364,31 @@ export async function executeNodeHostCommand(
         ...requestArgs,
         register: registerNodeApproval,
       });
+      const awaitApprovalInline = params.approvalHost?.exec?.supportsDetachedExecution !== true;
       if (
+        awaitApprovalInline ||
         execHostShared.shouldResolveExecApprovalUnavailableInline({
           unavailableReason,
           preResolvedDecision,
         })
       ) {
+        const decision = awaitApprovalInline
+          ? await execHostShared.resolveApprovalDecisionOrUndefined({
+              approval,
+              preResolvedDecision,
+              signal: params.signal,
+              onFailure: () => undefined,
+            })
+          : preResolvedDecision;
+        if (decision === undefined) {
+          throw new Error("Exec approval request failed.");
+        }
         const {
           baseDecision,
           approvedByAsk: initialApprovedByAsk,
           deniedReason: initialDeniedReason,
         } = execHostShared.createExecApprovalDecisionState({
-          decision: preResolvedDecision,
+          decision,
           askFallback,
         });
         let approvedByAsk = initialApprovedByAsk;
@@ -456,7 +420,7 @@ export async function executeNodeHostCommand(
           );
         }
         inlineApprovedByAsk = strictInlineEvalDecision.approvedByAsk;
-        inlineApprovalSource = preResolvedDecision === null ? "ask-fallback" : undefined;
+        inlineApprovalSource = decision === null ? "ask-fallback" : undefined;
         if (inlineApprovalSource) {
           inlineDispatchAuthority = "ask-fallback";
           inlineFallbackPolicy = currentFallback ?? undefined;
@@ -469,6 +433,7 @@ export async function executeNodeHostCommand(
             ? "allow-once"
             : null;
         inlineApprovalId = approvalId;
+        inlineApprovalLease = approval;
       } else {
         const followupTarget = execHostShared.buildExecApprovalFollowupTarget({
           approvalId,
@@ -496,73 +461,77 @@ export async function executeNodeHostCommand(
           let decision: string | null | undefined;
           try {
             decision = await execHostShared.resolveApprovalDecisionOrUndefined({
-              approvalId,
+              approval,
               preResolvedDecision,
+              signal: params.signal,
               onFailure: () => void sendApprovalRequestFailedFollowup(),
             });
           } catch (error) {
             // Detached run cancellation has no awaiting tool caller to catch it.
-            if (isExecApprovalRunAbortedError(error)) {
+            if (isExecApprovalRunAbortedError(error) || params.signal?.aborted) {
               return;
             }
             await sendApprovalRequestFailedFollowup();
             return;
           }
-          if (decision === undefined || params.signal?.aborted) {
+          if (decision === undefined) {
             return;
           }
-
-          const {
-            baseDecision,
-            approvedByAsk: initialApprovedByAsk,
-            deniedReason: baseDeniedReason,
-          } = execHostShared.createExecApprovalDecisionState({
-            decision,
-            askFallback,
-          });
-          let approvedByAsk = initialApprovedByAsk;
-          let approvalDecision: "allow-once" | "allow-always" | null = null;
-          const approvalSource = decision === null ? "ask-fallback" : undefined;
-          let deniedReason = baseDeniedReason;
-          const currentFallback = baseDecision.timedOut
-            ? await resolveCurrentTimeoutFallback()
-            : null;
-
-          if (currentFallback) {
-            approvedByAsk = currentFallback.approvedByAsk;
-            deniedReason = currentFallback.deniedReason;
-            approvalDecision = approvedByAsk ? "allow-once" : null;
-          } else if (decision === "allow-once") {
-            approvedByAsk = true;
-            approvalDecision = "allow-once";
-          } else if (decision === "allow-always") {
-            approvedByAsk = true;
-            approvalDecision = "allow-always";
-          }
-
-          const strictBoundaryDecision = execHostShared.enforceStrictInlineEvalApprovalBoundary({
-            baseDecision,
-            approvedByAsk,
-            deniedReason,
-            requiresInlineEvalApproval:
-              currentFallback?.requiresExplicitApproval ?? inlineEvalHit !== null,
-            requiresAutoReviewHumanApproval: autoReviewRequiresHumanApproval,
-          });
-          approvedByAsk = strictBoundaryDecision.approvedByAsk;
-          deniedReason = strictBoundaryDecision.deniedReason;
-          if (deniedReason) {
-            approvalDecision = null;
-          }
-
-          if (deniedReason) {
-            await execHostShared.sendExecApprovalFollowupResult(
-              followupTarget,
-              `Exec denied (node=${target.nodeId} id=${approvalId}, ${deniedReason}): ${params.command}`,
-            );
-            return;
-          }
-
+          const cancelApprovalOnIncompleteDispatch = decision === "allow-once";
           try {
+            if (params.signal?.aborted) {
+              return;
+            }
+            const {
+              baseDecision,
+              approvedByAsk: initialApprovedByAsk,
+              deniedReason: baseDeniedReason,
+            } = execHostShared.createExecApprovalDecisionState({
+              decision,
+              askFallback,
+            });
+            let approvedByAsk = initialApprovedByAsk;
+            let approvalDecision: "allow-once" | "allow-always" | null = null;
+            const approvalSource = decision === null ? "ask-fallback" : undefined;
+            let deniedReason = baseDeniedReason;
+            const currentFallback = baseDecision.timedOut
+              ? await resolveCurrentTimeoutFallback()
+              : null;
+
+            if (currentFallback) {
+              approvedByAsk = currentFallback.approvedByAsk;
+              deniedReason = currentFallback.deniedReason;
+              approvalDecision = approvedByAsk ? "allow-once" : null;
+            } else if (decision === "allow-once") {
+              approvedByAsk = true;
+              approvalDecision = "allow-once";
+            } else if (decision === "allow-always") {
+              approvedByAsk = true;
+              approvalDecision = "allow-always";
+            }
+
+            const strictBoundaryDecision = execHostShared.enforceStrictInlineEvalApprovalBoundary({
+              baseDecision,
+              approvedByAsk,
+              deniedReason,
+              requiresInlineEvalApproval:
+                currentFallback?.requiresExplicitApproval ?? inlineEvalHit !== null,
+              requiresAutoReviewHumanApproval: autoReviewRequiresHumanApproval,
+            });
+            approvedByAsk = strictBoundaryDecision.approvedByAsk;
+            deniedReason = strictBoundaryDecision.deniedReason;
+            if (deniedReason) {
+              approvalDecision = null;
+            }
+
+            if (deniedReason) {
+              await execHostShared.sendExecApprovalFollowupResult(
+                followupTarget,
+                `Exec denied (node=${target.nodeId} id=${approvalId}, ${deniedReason}): ${params.command}`,
+              );
+              return;
+            }
+
             await assertCurrentNodeGatewayPolicyAllowsDispatch({
               request: params,
               authority: approvalSource ? "ask-fallback" : "human-approval",
@@ -601,8 +570,8 @@ export async function executeNodeHostCommand(
               scopes: APPROVED_NODE_INVOKE_SCOPES,
               signal: params.signal,
             });
-            nodeInvocationCompleted = true;
             if (!invocation.ok) {
+              nodeInvocationCompleted = invocation.failure.reason === "outcome-unknown";
               await execHostShared.sendExecApprovalFollowupResult(
                 followupTarget,
                 formatNodeInvokeFailureFollowup({
@@ -614,6 +583,7 @@ export async function executeNodeHostCommand(
               );
               return;
             }
+            nodeInvocationCompleted = true;
             const raw = invocation.raw as { payload?: unknown };
             const payload =
               raw?.payload && typeof raw.payload === "object"
@@ -643,6 +613,10 @@ export async function executeNodeHostCommand(
               followupTarget,
               `Exec denied (node=${target.nodeId} id=${approvalId}, invoke-failed): ${params.command}`,
             );
+          } finally {
+            if (cancelApprovalOnIncompleteDispatch && !nodeInvocationCompleted) {
+              await approval.cancel().catch(() => undefined);
+            }
           }
         })().catch(async (error: unknown): Promise<void> => {
           // Once dispatch starts, a delivery failure cannot mean execution was denied.
@@ -675,59 +649,68 @@ export async function executeNodeHostCommand(
   }
 
   const startedAt = Date.now();
-  params.signal?.throwIfAborted();
-  const invoke = buildNodeSystemRunInvoke({
-    target,
-    command: prepared.argv,
-    rawCommand: prepared.transportRawCommand,
-    cwd: prepared.cwd,
-    agentId: prepared.agentId,
-    sessionKey: prepared.sessionKey,
-    approved: inlineApprovalSource ? undefined : inlineApprovedByAsk,
-    approvalDecision: inlineApprovalSource ? null : inlineApprovalDecision,
-    approvalSource: inlineApprovalSource,
-    runId: inlineApprovalId,
-    notifyOnExit: params.notifyOnExit,
-    systemRunPlan: prepared.plan,
-  });
-  await assertCurrentNodeGatewayPolicyAllowsDispatch({
-    request: params,
-    authority: inlineDispatchAuthority,
-    fallbackPolicy: inlineFallbackPolicy,
-    currentPolicyAllows: (current) =>
-      !requiresExecApproval({
-        ask: current.hostAsk,
-        security: current.hostSecurity,
-        analysisOk,
-        allowlistSatisfied,
-        durableApprovalSatisfied,
-      }) &&
-      inlineEvalHit === null &&
-      !requiresSecurityAuditSuppressionApproval,
-  });
-  params.signal?.throwIfAborted();
-  const invocation = await invokeNodeSystemRun({
-    invokeWaitMs: target.invokeWaitMs,
-    invoke,
-    signal: params.signal,
-    ...((inlineApprovedByAsk || inlineApprovalSource) && inlineApprovalId
-      ? { scopes: APPROVED_NODE_INVOKE_SCOPES }
-      : {}),
-  });
-  if (!invocation.ok) {
-    return formatNodeInvokeFailureToolResult({
-      failure: invocation.failure,
-      nodeId: target.nodeId,
-      command: params.command,
+  let dispatchCompleted = false;
+  try {
+    params.signal?.throwIfAborted();
+    const invoke = buildNodeSystemRunInvoke({
+      target,
+      command: prepared.argv,
+      rawCommand: prepared.transportRawCommand,
+      cwd: prepared.cwd,
+      agentId: prepared.agentId,
+      sessionKey: prepared.sessionKey,
+      approved: inlineApprovalSource ? undefined : inlineApprovedByAsk,
+      approvalDecision: inlineApprovalSource ? null : inlineApprovalDecision,
+      approvalSource: inlineApprovalSource,
+      runId: inlineApprovalId,
+      notifyOnExit: params.notifyOnExit,
+      systemRunPlan: prepared.plan,
+    });
+    await assertCurrentNodeGatewayPolicyAllowsDispatch({
+      request: params,
+      authority: inlineDispatchAuthority,
+      fallbackPolicy: inlineFallbackPolicy,
+      currentPolicyAllows: (current) =>
+        !requiresExecApproval({
+          ask: current.hostAsk,
+          security: current.hostSecurity,
+          analysisOk,
+          allowlistSatisfied,
+          durableApprovalSatisfied,
+        }) &&
+        inlineEvalHit === null &&
+        !requiresSecurityAuditSuppressionApproval,
+    });
+    params.signal?.throwIfAborted();
+    const invocation = await invokeNodeSystemRun({
+      invokeWaitMs: target.invokeWaitMs,
+      invoke,
+      signal: params.signal,
+      ...((inlineApprovedByAsk || inlineApprovalSource) && inlineApprovalId
+        ? { scopes: APPROVED_NODE_INVOKE_SCOPES }
+        : {}),
+    });
+    if (!invocation.ok) {
+      dispatchCompleted = invocation.failure.reason === "outcome-unknown";
+      return formatNodeInvokeFailureToolResult({
+        failure: invocation.failure,
+        nodeId: target.nodeId,
+        command: params.command,
+        startedAt,
+        cwd: params.workdir,
+        warnings: [...params.warnings, ...(params.foregroundWarnings ?? [])],
+      });
+    }
+    dispatchCompleted = true;
+    return formatNodeRunToolResult({
+      raw: invocation.raw,
       startedAt,
       cwd: params.workdir,
       warnings: [...params.warnings, ...(params.foregroundWarnings ?? [])],
     });
+  } finally {
+    if (inlineApprovalLease && !dispatchCompleted) {
+      await inlineApprovalLease.cancel().catch(() => undefined);
+    }
   }
-  return formatNodeRunToolResult({
-    raw: invocation.raw,
-    startedAt,
-    cwd: params.workdir,
-    warnings: [...params.warnings, ...(params.foregroundWarnings ?? [])],
-  });
 }

--- a/src/agents/bash-tools.exec-host-node.types.ts
+++ b/src/agents/bash-tools.exec-host-node.types.ts
@@ -5,6 +5,7 @@
  */
 import type { ExecAsk, ExecSecurity } from "../infra/exec-approvals.js";
 import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
+import type { AgentRunApprovalHost } from "./agent-run-approval.js";
 import type { ExecElevatedDefaults } from "./bash-tools.exec-types.js";
 
 /** Full parameter bundle for Node-hosted exec command execution. */
@@ -34,6 +35,7 @@ export type ExecuteNodeHostCommandParams = {
   ask: ExecAsk;
   autoReview?: boolean;
   autoReviewer?: ExecAutoReviewer;
+  approvalHost?: AgentRunApprovalHost;
   signal?: AbortSignal;
   strictInlineEval?: boolean;
   commandHighlighting?: boolean;

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -15,6 +15,7 @@ import {
   createAndRegisterDefaultExecApprovalRequest,
   createExecApprovalDecisionState,
   enforceStrictInlineEvalApprovalBoundary,
+  resolveApprovalDecisionOrUndefined,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
   shouldResolveExecApprovalUnavailableInline,
@@ -46,6 +47,32 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
     ...mod,
     resolveExecApprovalsLocked: mocks.resolveExecApprovals,
   };
+});
+
+describe("resolveApprovalDecisionOrUndefined", () => {
+  it("preserves the run abort reason instead of reporting an approval failure", async () => {
+    const controller = new AbortController();
+    const abortReason = new Error("run aborted");
+    const onFailure = vi.fn();
+    const wait = vi.fn().mockRejectedValue(abortReason);
+    controller.abort(abortReason);
+
+    await expect(
+      resolveApprovalDecisionOrUndefined({
+        approval: {
+          id: "approval-1",
+          expiresAtMs: Date.now() + 60_000,
+          wait,
+          resolveAutoReview: vi.fn(),
+          cancel: vi.fn(async () => undefined),
+        },
+        preResolvedDecision: undefined,
+        signal: controller.signal,
+        onFailure,
+      }),
+    ).rejects.toBe(abortReason);
+    expect(onFailure).not.toHaveBeenCalled();
+  });
 });
 
 describe("sendExecApprovalFollowupResult", () => {
@@ -571,6 +598,9 @@ describe("buildExecApprovalPendingToolResult", () => {
         id: approvalId,
         expiresAtMs: Date.now() + 60_000,
         finalDecision: null,
+        wait: vi.fn(),
+        resolveAutoReview: vi.fn(),
+        cancel: vi.fn(async () => undefined),
       }),
     });
     expect(state.sentApproverDms).toBe(false);

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -86,6 +86,7 @@ type ExecApprovalUnavailableReason =
 
 /** Context returned after a default approval request is registered. */
 type RegisteredExecApprovalRequestContext = {
+  approval: ExecApprovalRegistration;
   approvalId: string;
   approvalSlug: string;
   warningText: string;
@@ -246,17 +247,19 @@ export async function resolveExecHostApprovalContext(params: {
 
 /** Waits for approval while converting wait failures to an undefined sentinel. */
 export async function resolveApprovalDecisionOrUndefined(params: {
-  approvalId: string;
+  approval: ExecApprovalRegistration;
   preResolvedDecision: string | null | undefined;
+  signal?: AbortSignal;
   onFailure: () => void;
 }): Promise<string | null | undefined> {
   try {
     return await resolveRegisteredExecApprovalDecision({
-      approvalId: params.approvalId,
+      approval: params.approval,
       preResolvedDecision: params.preResolvedDecision,
+      signal: params.signal,
     });
   } catch (error) {
-    if (isExecApprovalRunAbortedError(error)) {
+    if (params.signal?.aborted || isExecApprovalRunAbortedError(error)) {
       throw error;
     }
     params.onFailure();
@@ -326,6 +329,7 @@ export async function createAndRegisterDefaultExecApprovalRequest(params: {
     });
 
   return {
+    approval: registration,
     approvalId,
     approvalSlug,
     warningText,

--- a/src/agents/bash-tools.exec-request-preparation.ts
+++ b/src/agents/bash-tools.exec-request-preparation.ts
@@ -16,6 +16,7 @@ import {
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
 import { safeJsonStringify } from "../utils/safe-json.js";
+import type { AgentRunApprovalHost } from "./agent-run-approval.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
 import { stripMalformedXmlArgValueSuffixFromKeys } from "./agent-tools.params.js";
 import { DEFAULT_PATH, applyPathPrepend, applyShellPath } from "./bash-tools.exec-runtime.js";
@@ -51,6 +52,9 @@ type ResolvedExecWorkdirPreparedState = {
   inputWorkdir?: string;
   resolution: ExecWorkdirResolution;
 };
+type ExecApprovalHostPreparedState = {
+  approvalHost?: AgentRunApprovalHost;
+};
 
 const CHANNEL_CONTEXT_ENV_KEY = "OPENCLAW_CHANNEL_CONTEXT";
 const resolvedExecEnvPreparedStates = new WeakMap<ExecToolArgs, ResolvedExecEnvPreparedState>();
@@ -62,6 +66,7 @@ const resolvedExecWorkdirPreparedStates = new WeakMap<
   ExecToolArgs,
   ResolvedExecWorkdirPreparedState
 >();
+const execApprovalHostPreparedStates = new WeakMap<ExecToolArgs, ExecApprovalHostPreparedState>();
 const XML_ARG_VALUE_EXEC_PARAM_KEYS = [
   "command",
   "workdir",
@@ -163,6 +168,20 @@ function getResolvedExecWorkdirPreparedState(
   params: ExecToolArgs,
 ): ResolvedExecWorkdirPreparedState | undefined {
   return resolvedExecWorkdirPreparedStates.get(params);
+}
+
+function markExecApprovalHostPrepared<T extends ExecToolArgs>(
+  params: T,
+  state: ExecApprovalHostPreparedState,
+): T {
+  execApprovalHostPreparedStates.set(params, state);
+  return params;
+}
+
+function getExecApprovalHostPreparedState(
+  params: ExecToolArgs,
+): ExecApprovalHostPreparedState | undefined {
+  return execApprovalHostPreparedStates.get(params);
 }
 
 export function resolveNotifyOnExitEmptySuccess(defaults?: ExecToolDefaults): boolean {
@@ -274,34 +293,55 @@ export function createExecRequestPreparation(params: {
     context: { hookContext?: unknown },
   ): Promise<ExecToolArgs> => {
     const execParams = await prepareParamsWithResolvedExecWorkdir(args);
+    const hookContext =
+      context.hookContext !== null && typeof context.hookContext === "object"
+        ? (context.hookContext as HookContext)
+        : undefined;
+    const hasPreparedApprovalHost =
+      hookContext !== undefined && Object.hasOwn(hookContext, "approvalHost");
+    const finalizePreparedParams = (preparedParams: ExecToolArgs) =>
+      hasPreparedApprovalHost
+        ? markExecApprovalHostPrepared(preparedParams, {
+            approvalHost: hookContext.approvalHost,
+          })
+        : preparedParams;
     const workdirState = getResolvedExecWorkdirPreparedState(execParams);
     if (workdirState?.resolution.kind === "unavailable") {
-      return execParams;
+      return finalizePreparedParams(execParams);
     }
     if (!isExecToolArgsObject(execParams)) {
       return execParams;
     }
     if (shouldDeferResolveExecEnvUntilWorkdirValidated(execParams)) {
-      return markDeferredResolveExecEnvPrepared(execParams, {
-        hookContext: context.hookContext as HookContext | undefined,
-      });
+      return finalizePreparedParams(
+        markDeferredResolveExecEnvPrepared(execParams, {
+          hookContext,
+        }),
+      );
     }
-    return prepareParamsWithResolvedExecEnv(execParams, {
-      hookContext: context.hookContext as HookContext | undefined,
-    });
+    return finalizePreparedParams(
+      await prepareParamsWithResolvedExecEnv(execParams, {
+        hookContext,
+      }),
+    );
   };
 
   const finalizeBeforeToolCallParams = (rawParams: unknown, preparedParams: unknown) => {
     const envState = getResolvedExecEnvPreparedState(preparedParams as ExecToolArgs);
     const deferredEnvState = getDeferredResolveExecEnvPreparedState(preparedParams as ExecToolArgs);
     const workdirState = getResolvedExecWorkdirPreparedState(preparedParams as ExecToolArgs);
-    if (!envState && !deferredEnvState && !workdirState) {
+    const approvalHostState = getExecApprovalHostPreparedState(preparedParams as ExecToolArgs);
+    if (!envState && !deferredEnvState && !workdirState && !approvalHostState) {
       return rawParams;
     }
     if (!isExecToolArgsObject(rawParams)) {
       return rawParams;
     }
     const execParams = rawParams;
+    const preserveApprovalHost = (rewrittenParams: ExecToolArgs) =>
+      approvalHostState
+        ? markExecApprovalHostPrepared(rewrittenParams, approvalHostState)
+        : rewrittenParams;
     let host: ExecHost | undefined;
     const resolveFinalHost = () => {
       host ??= params.resolveHostForParams(execParams);
@@ -309,17 +349,17 @@ export function createExecRequestPreparation(params: {
     };
     try {
       if (envState?.host && execParams.command && resolveFinalHost() !== envState.host) {
-        return { ...execParams };
+        return preserveApprovalHost({ ...execParams });
       }
       if (
         workdirState &&
         (resolveFinalHost() !== workdirState.host ||
           execParams.workdir !== workdirState.inputWorkdir)
       ) {
-        return { ...execParams };
+        return preserveApprovalHost({ ...execParams });
       }
     } catch {
-      return { ...execParams };
+      return preserveApprovalHost({ ...execParams });
     }
     if (envState) {
       markResolveExecEnvPrepared(execParams, envState);
@@ -329,6 +369,9 @@ export function createExecRequestPreparation(params: {
     }
     if (workdirState) {
       markResolvedExecWorkdirPrepared(execParams, workdirState);
+    }
+    if (approvalHostState) {
+      markExecApprovalHostPrepared(execParams, approvalHostState);
     }
     return execParams;
   };
@@ -342,6 +385,7 @@ export function createExecRequestPreparation(params: {
     getDeferredResolveExecEnvPreparedState,
     getResolvedExecWorkdirPreparedState,
     getResolvedExecEnvPreparedState,
+    getExecApprovalHostPreparedState,
   };
 }
 

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -162,13 +162,18 @@ export function createExecTool(
           reviewer: resolveExecReviewerDefaults({ defaults, agentId }),
           signal,
         });
+      const preparedArgs = args as ExecToolArgs;
       let params = requestPreparation.normalizeParams(args);
-      const resolveExecEnvPrepared = requestPreparation.isResolveExecEnvPrepared(
-        args as ExecToolArgs,
-      );
+      const preparedApprovalHostState =
+        requestPreparation.getExecApprovalHostPreparedState(preparedArgs);
+      const approvalHost = preparedApprovalHostState
+        ? preparedApprovalHostState.approvalHost
+        : defaults?.approvalHost;
+      const resolveExecEnvPrepared = requestPreparation.isResolveExecEnvPrepared(preparedArgs);
       const deferredResolveExecEnvState =
-        requestPreparation.getDeferredResolveExecEnvPreparedState(params);
-      const preparedWorkdirState = requestPreparation.getResolvedExecWorkdirPreparedState(params);
+        requestPreparation.getDeferredResolveExecEnvPreparedState(preparedArgs);
+      const preparedWorkdirState =
+        requestPreparation.getResolvedExecWorkdirPreparedState(preparedArgs);
 
       const maxOutput = DEFAULT_MAX_OUTPUT;
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
@@ -180,6 +185,7 @@ export function createExecTool(
       }
       const startedAt = Date.now();
       let execCommandOverride: string | undefined;
+      let cancelUnusedGatewayApproval: (() => Promise<void>) | undefined;
       const backgroundRequested = params.background === true;
       const yieldRequested = typeof params.yieldMs === "number";
       const foregroundFallbackWarning =
@@ -417,6 +423,7 @@ export function createExecTool(
             ask,
             autoReview,
             autoReviewer,
+            approvalHost,
             signal,
             strictInlineEval: defaults?.strictInlineEval,
             commandHighlighting: defaults?.commandHighlighting,
@@ -450,6 +457,7 @@ export function createExecTool(
             ask,
             autoReview,
             autoReviewer,
+            approvalHost,
             signal,
             safeBins,
             safeBinProfiles,
@@ -486,6 +494,7 @@ export function createExecTool(
           if (gatewayResult.deniedResult) {
             return gatewayResult.deniedResult;
           }
+          cancelUnusedGatewayApproval = gatewayResult.cancelUnusedApproval;
           signal?.throwIfAborted();
           execCommandOverride = gatewayResult.execCommandOverride;
           if (gatewayResult.allowWithoutEnforcedCommand) {
@@ -540,8 +549,10 @@ export function createExecTool(
             finalizeBackgroundExecTask({ handle: backgroundTask, outcome });
           },
         });
+        cancelUnusedGatewayApproval = undefined;
         discardPreparedSandboxWorkdir = null;
       } catch (error) {
+        await cancelUnusedGatewayApproval?.();
         discardPreparedSandboxWorkdir?.();
         throw error;
       }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -106,8 +106,6 @@ const DEFAULT_NOTIFY_TAIL_CHARS = 400;
 const DEFAULT_NOTIFY_SNIPPET_CHARS = 180;
 /** Default time an approval can remain pending. */
 export const DEFAULT_APPROVAL_TIMEOUT_MS = DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
-/** Gateway request timeout for approval registration/wait calls. */
-export const DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS = DEFAULT_APPROVAL_TIMEOUT_MS + 10_000;
 const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
 const APPROVAL_SLUG_LENGTH = 8;
 

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -17,6 +17,7 @@ import type { ExecAutoReviewer } from "../infra/exec-auto-review.js";
 import type { SafeBinProfileFixture } from "../infra/exec-safe-bin-policy.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
 import type { TerminationReason } from "../process/supervisor/types.js";
+import type { AgentRunApprovalHost } from "./agent-run-approval.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import type { EmbeddedFullAccessBlockedReason } from "./embedded-agent-runner/types.js";
 import type { ExecReviewerConfig } from "./exec-auto-reviewer.js";
@@ -41,6 +42,8 @@ export type ExecToolDefaults = {
   reviewer?: ExecReviewerConfig;
   config?: OpenClawConfig;
   autoReviewer?: ExecAutoReviewer;
+  /** Exact process-local approval owner for this agent run. */
+  approvalHost?: AgentRunApprovalHost;
   agentId?: string;
   backgroundMs?: number;
   timeoutSec?: number;

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -5,6 +5,7 @@
  */
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentRunApprovalHost } from "./agent-run-approval.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import type { ExtensionContext } from "./sessions/index.js";
@@ -19,7 +20,7 @@ const CHANNEL_CONTEXT_ENV_KEY = "OPENCLAW_CHANNEL_CONTEXT";
 const OPENCLAW_CLI_ENV_VALUE = "1";
 type CapturedNodeHostParams = Pick<
   ExecuteNodeHostCommandParams,
-  "env" | "requestedEnv" | "workdir"
+  "approvalHost" | "env" | "requestedEnv" | "workdir"
 >;
 
 const mocks = vi.hoisted(() => ({
@@ -34,6 +35,7 @@ const mocks = vi.hoisted(() => ({
   gatewayParams: [] as Array<{
     env: Record<string, string>;
     requestedEnv?: Record<string, string>;
+    approvalHost?: AgentRunApprovalHost;
   }>,
   nodeHostParams: [] as CapturedNodeHostParams[],
   spawnInputs: [] as Array<{
@@ -56,10 +58,15 @@ vi.mock("../infra/shell-env.js", () => ({
 
 vi.mock("./bash-tools.exec-host-gateway.js", () => ({
   processGatewayAllowlist: vi.fn(
-    async (params: { env: Record<string, string>; requestedEnv?: Record<string, string> }) => {
+    async (params: {
+      env: Record<string, string>;
+      requestedEnv?: Record<string, string>;
+      approvalHost?: AgentRunApprovalHost;
+    }) => {
       mocks.gatewayParams.push({
         env: { ...params.env },
         requestedEnv: params.requestedEnv ? { ...params.requestedEnv } : undefined,
+        approvalHost: params.approvalHost,
       });
       return {};
     },
@@ -68,8 +75,14 @@ vi.mock("./bash-tools.exec-host-gateway.js", () => ({
 
 vi.mock("./bash-tools.exec-host-node.js", () => ({
   executeNodeHostCommand: vi.fn(
-    async (params: Pick<ExecuteNodeHostCommandParams, "env" | "requestedEnv" | "workdir">) => {
+    async (
+      params: Pick<
+        ExecuteNodeHostCommandParams,
+        "approvalHost" | "env" | "requestedEnv" | "workdir"
+      >,
+    ) => {
       mocks.nodeHostParams.push({
+        approvalHost: params.approvalHost,
         env: { ...params.env },
         requestedEnv: params.requestedEnv ? { ...params.requestedEnv } : undefined,
         workdir: params.workdir,
@@ -165,6 +178,53 @@ describe("exec resolve_exec_env hook wiring", () => {
     expect(mocks.spawnInputs[0]?.env?.[CHANNEL_CONTEXT_ENV_KEY]).toBe(
       mocks.gatewayParams[0]?.env[CHANNEL_CONTEXT_ENV_KEY],
     );
+  });
+
+  it("uses the prepared run approval host after parameter repair and finalization", async () => {
+    const fallbackHost: AgentRunApprovalHost = {
+      exec: { request: vi.fn() },
+    };
+    const runHost: AgentRunApprovalHost = {
+      exec: { request: vi.fn() },
+    };
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      approvalHost: fallbackHost,
+    });
+    const [definition] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      approvalHost: runHost,
+    });
+
+    await expectDefined(definition, "definition test invariant").execute(
+      "call-prepared-approval-host",
+      { command: "echo ok</arg_value>>", yieldMs: 120_000 },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
+
+    expect(mocks.gatewayParams[0]?.approvalHost).toBe(runHost);
+    expect(mocks.gatewayParams[0]?.approvalHost).not.toBe(fallbackHost);
+  });
+
+  it("treats a null hook context as absent during exec preparation", async () => {
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+    });
+    const prepareBeforeToolCallParams = expectDefined(
+      tool.prepareBeforeToolCallParams,
+      "exec preparation hook",
+    );
+
+    await expect(
+      prepareBeforeToolCallParams({ command: "echo ok", yieldMs: 120_000 }, { hookContext: null }),
+    ).resolves.toMatchObject({ command: "echo ok" });
   });
 
   it("merges filtered plugin env into gateway execution and approval-visible requested env", async () => {
@@ -739,6 +799,12 @@ describe("exec resolve_exec_env hook wiring", () => {
   });
 
   it("recomputes plugin env when before_tool_call changes exec host", async () => {
+    const fallbackHost: AgentRunApprovalHost = {
+      exec: { request: vi.fn() },
+    };
+    const runHost: AgentRunApprovalHost = {
+      exec: { request: vi.fn() },
+    };
     mocks.hookRunner = {
       hasHooks: vi.fn(
         (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
@@ -756,10 +822,12 @@ describe("exec resolve_exec_env hook wiring", () => {
       security: "full",
       ask: "off",
       sessionKey: "agent:main:telegram:chat-1",
+      approvalHost: fallbackHost,
     });
     const [definition] = toToolDefinitions([tool], {
       agentId: "main",
       sessionKey: "agent:main:telegram:chat-1",
+      approvalHost: runHost,
     });
 
     await expectDefined(definition, "definition test invariant").execute(
@@ -789,6 +857,8 @@ describe("exec resolve_exec_env hook wiring", () => {
       REQUEST_SAFE: "request",
     });
     expect(mocks.nodeHostParams[0]?.requestedEnv).not.toHaveProperty("GATEWAY_PLUGIN_SAFE");
+    expect(mocks.nodeHostParams[0]?.approvalHost).toBe(runHost);
+    expect(mocks.nodeHostParams[0]?.approvalHost).not.toBe(fallbackHost);
   });
 
   it("lets before_tool_call reroute gateway-invalid workdirs to node host execution", async () => {

--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -12,8 +12,16 @@ import { detectUnsafeExecControlShellCommand } from "../infra/exec-control-comma
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { createExecTool } from "./bash-tools.exec-run.js";
 
+const cancelUnusedApprovalMock = vi.hoisted(() => vi.fn(async () => undefined));
+const processGatewayAllowlistMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    allowWithoutEnforcedCommand: true,
+    cancelUnusedApproval: cancelUnusedApprovalMock,
+  })),
+);
+
 vi.mock("./bash-tools.exec-host-gateway.js", () => ({
-  processGatewayAllowlist: async () => ({ allowWithoutEnforcedCommand: true }),
+  processGatewayAllowlist: processGatewayAllowlistMock,
 }));
 
 vi.mock("./bash-tools.exec-host-node.js", () => ({
@@ -37,6 +45,12 @@ const runExecPreflight = (params: { command: string; workdir: string }) =>
 
 afterEach(() => {
   __setFsSafeTestHooksForTest();
+  cancelUnusedApprovalMock.mockClear();
+  processGatewayAllowlistMock.mockReset();
+  processGatewayAllowlistMock.mockResolvedValue({
+    allowWithoutEnforcedCommand: true,
+    cancelUnusedApproval: cancelUnusedApprovalMock,
+  });
 });
 
 async function expectSymlinkSwapDuringPreflightToAvoidErrors(params: {
@@ -120,6 +134,27 @@ describe("exec interactive OpenClaw channel login guard", () => {
 });
 
 describeNonWin("exec script preflight", () => {
+  it("cancels a foreground approval when the run aborts during lease handoff", async () => {
+    const controller = new AbortController();
+    const abortReason = new Error("run aborted");
+    processGatewayAllowlistMock.mockImplementationOnce(async () => {
+      controller.abort(abortReason);
+      return {
+        allowWithoutEnforcedCommand: true,
+        cancelUnusedApproval: cancelUnusedApprovalMock,
+      };
+    });
+
+    await expect(
+      createPreflightTool().execute(
+        "call-aborted-handoff",
+        { command: "pwd", workdir: process.cwd() },
+        controller.signal,
+      ),
+    ).rejects.toBe(abortReason);
+    expect(cancelUnusedApprovalMock).toHaveBeenCalledOnce();
+  });
+
   it("blocks shell env var injection tokens in python scripts before execution", async () => {
     await withTempDir("openclaw-exec-preflight-", async (tmp) => {
       const pyPath = path.join(tmp, "bad.py");
@@ -143,6 +178,7 @@ describeNonWin("exec script preflight", () => {
           workdir: tmp,
         }),
       ).rejects.toThrow(/exec preflight: detected likely shell variable injection \(\$DM_JSON\)/);
+      expect(cancelUnusedApprovalMock).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/agents/cli-runner/execute-node-claude.test.ts
+++ b/src/agents/cli-runner/execute-node-claude.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRunApprovalHost, AgentRunExecApprovalLease } from "../agent-run-approval.js";
+import { executeNodeClaudeRun } from "./execute-node-claude.js";
+import type { PreparedCliRunContext } from "./types.js";
+
+describe("executeNodeClaudeRun", () => {
+  it("uses the run-scoped exec approval lease for paired-node retries", async () => {
+    const approvalHost: AgentRunApprovalHost = {
+      exec: { request: vi.fn() },
+    };
+    const approvalLease: AgentRunExecApprovalLease = {
+      id: "approval-1",
+      expiresAtMs: Date.now() + 60_000,
+      wait: vi.fn(),
+      resolveAutoReview: vi.fn(async () => undefined),
+      cancel: vi.fn(async () => undefined),
+    };
+    const invokeNodeClaudeCliRun = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          approvalRequired: true,
+          systemRunPlan: {
+            argv: ["/bin/echo", "ok"],
+            cwd: "/tmp",
+            commandText: "/bin/echo ok",
+            agentId: "main",
+            sessionKey: "agent:main:main",
+          },
+          security: "allowlist",
+          ask: "always",
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          exitCode: 0,
+          stderrTail: "",
+          truncated: false,
+        },
+      });
+    const registerExecApprovalRequestForHostOrThrow = vi.fn().mockResolvedValue(approvalLease);
+    const resolveRegisteredExecApprovalDecision = vi.fn().mockResolvedValue("allow-once");
+    const context = {
+      params: {
+        timeoutMs: 30_000,
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        approvalHost,
+      },
+    } as unknown as PreparedCliRunContext;
+
+    await expect(
+      executeNodeClaudeRun({
+        context,
+        nodePlacement: { nodeId: "node-1", cwd: "/tmp" },
+        executionArgs: ["claude", "--print"],
+        stdinPayload: "hello",
+        noOutputTimeoutMs: 10_000,
+        consumeStdout: vi.fn(),
+        consumeStderr: vi.fn(),
+        deps: {
+          invokeNodeClaudeCliRun,
+          registerExecApprovalRequestForHostOrThrow,
+          resolveRegisteredExecApprovalDecision,
+        },
+      }),
+    ).resolves.toMatchObject({
+      result: {
+        reason: "exit",
+        exitCode: 0,
+      },
+    });
+
+    expect(registerExecApprovalRequestForHostOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        approvalHost,
+        approvalId: expect.any(String),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(resolveRegisteredExecApprovalDecision).toHaveBeenCalledWith({
+      approval: approvalLease,
+      preResolvedDecision: undefined,
+      signal: expect.any(AbortSignal),
+    });
+    expect(invokeNodeClaudeCliRun).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        approvalDecision: "allow-once",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(approvalLease.cancel).not.toHaveBeenCalled();
+  });
+
+  it("cancels the approval lease when the approved retry still requests approval", async () => {
+    const approvalLease: AgentRunExecApprovalLease = {
+      id: "approval-1",
+      expiresAtMs: Date.now() + 60_000,
+      wait: vi.fn(),
+      resolveAutoReview: vi.fn(async () => undefined),
+      cancel: vi.fn(async () => undefined),
+    };
+    const invokeNodeClaudeCliRun = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          approvalRequired: true,
+          systemRunPlan: {
+            argv: ["/bin/echo", "ok"],
+            cwd: "/tmp",
+            commandText: "/bin/echo ok",
+            agentId: "main",
+            sessionKey: "agent:main:main",
+          },
+          security: "allowlist",
+          ask: "always",
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        payload: {
+          approvalRequired: true,
+          systemRunPlan: {
+            argv: ["/bin/echo", "ok"],
+            cwd: "/tmp",
+            commandText: "/bin/echo ok",
+            agentId: "main",
+            sessionKey: "agent:main:main",
+          },
+          security: "allowlist",
+          ask: "always",
+        },
+      });
+    const context = {
+      params: {
+        timeoutMs: 30_000,
+        agentId: "main",
+        sessionKey: "agent:main:main",
+      },
+    } as unknown as PreparedCliRunContext;
+
+    await expect(
+      executeNodeClaudeRun({
+        context,
+        nodePlacement: { nodeId: "node-1", cwd: "/tmp" },
+        executionArgs: ["claude", "--print"],
+        stdinPayload: "hello",
+        noOutputTimeoutMs: 10_000,
+        consumeStdout: vi.fn(),
+        consumeStderr: vi.fn(),
+        deps: {
+          invokeNodeClaudeCliRun,
+          registerExecApprovalRequestForHostOrThrow: vi.fn().mockResolvedValue(approvalLease),
+          resolveRegisteredExecApprovalDecision: vi.fn().mockResolvedValue("allow-once"),
+        },
+      }),
+    ).rejects.toThrow("paired node returned an invalid Claude CLI result");
+
+    expect(approvalLease.cancel).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/cli-runner/execute-node-claude.ts
+++ b/src/agents/cli-runner/execute-node-claude.ts
@@ -257,6 +257,7 @@ export async function executeNodeClaudeRun(params: {
       const approvalId = crypto.randomUUID();
       const registration = await waitForNodeOperation({
         operation: params.deps.registerExecApprovalRequestForHostOrThrow({
+          approvalHost: contextParams.approvalHost,
           approvalId,
           command: approval.systemRunPlan.commandText,
           commandArgv: approval.systemRunPlan.argv,
@@ -269,21 +270,31 @@ export async function executeNodeClaudeRun(params: {
           unavailableDecisions: ["allow-always"],
           agentId: contextParams.agentId,
           sessionKey: contextParams.sessionKey,
-          ...(contextParams.approvalReviewerDeviceId
-            ? { approvalReviewerDeviceIds: [contextParams.approvalReviewerDeviceId] }
-            : {}),
+          signal: nodeAbortController.signal,
         }),
         signal: nodeAbortController.signal,
       });
       const decision = await waitForNodeOperation({
         operation: params.deps.resolveRegisteredExecApprovalDecision({
-          approvalId: registration.id,
+          approval: registration,
           preResolvedDecision: registration.finalDecision,
+          signal: nodeAbortController.signal,
         }),
         signal: nodeAbortController.signal,
       });
       if (decision === "allow-once" || decision === "allow-always") {
-        nodeResult = await invokeNode({ decision, plan: approval.systemRunPlan });
+        let dispatchSucceeded = false;
+        try {
+          nodeResult = await invokeNode({ decision, plan: approval.systemRunPlan });
+          if (nodeResult.ok) {
+            parseNodeClaudeResultPayload(nodeResult);
+            dispatchSucceeded = true;
+          }
+        } finally {
+          if (!dispatchSucceeded) {
+            await registration.cancel().catch(() => undefined);
+          }
+        }
       } else {
         nodeResult = {
           ok: false,

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -258,6 +258,27 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
     expect(inheritedCapture).not.toHaveBeenCalled();
   });
 
+  it("retires a cleanup-owned runtime when MCP materialization fails", async () => {
+    const runtime = { sessionId: "owned-session" };
+    mocks.getOrCreateSessionMcpRuntime.mockResolvedValue(runtime);
+    mocks.materializeBundleMcpToolsForRun.mockRejectedValue(new Error("materialization failed"));
+    const input = createInput([], []);
+    input.attempt.cleanupBundleMcpOnRunEnd = true;
+
+    await expect(prepareEmbeddedAttemptBundleTools(input)).rejects.toThrow(
+      "materialization failed",
+    );
+
+    expect(mocks.retireSessionMcpRuntimeInstance).toHaveBeenCalledOnce();
+    expect(mocks.retireSessionMcpRuntimeInstance).toHaveBeenCalledWith({
+      runtime,
+      reason: "embedded-run-end",
+      preserveActiveLeases: true,
+      onError: expect.any(Function),
+    });
+    expect(mocks.createBundleLspToolRuntime).not.toHaveBeenCalled();
+  });
+
   it("disposes prepared bundle runtimes when later policy setup fails", async () => {
     const disposeMcp = vi.fn(async () => {});
     const disposeLsp = vi.fn(async () => {});

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -131,20 +131,21 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
           });
         }
       : undefined;
-  const bundleMcpRuntime = bundleMcpSessionRuntime
-    ? await materializeBundleMcpToolsForRun({
-        runtime: bundleMcpSessionRuntime,
-        reservedToolNames: [
-          ...tools.map((tool) => tool.name),
-          ...(clientTools?.map((tool) => tool.function.name) ?? []),
-        ],
-        ...(disposeBundleMcpSessionRuntime
-          ? { disposeRuntime: disposeBundleMcpSessionRuntime }
-          : {}),
-      })
-    : undefined;
+  let bundleMcpRuntime: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>> | undefined;
   let bundleLspRuntime: Awaited<ReturnType<typeof createBundleLspToolRuntime>> | undefined;
   try {
+    bundleMcpRuntime = bundleMcpSessionRuntime
+      ? await materializeBundleMcpToolsForRun({
+          runtime: bundleMcpSessionRuntime,
+          reservedToolNames: [
+            ...tools.map((tool) => tool.name),
+            ...(clientTools?.map((tool) => tool.function.name) ?? []),
+          ],
+          ...(disposeBundleMcpSessionRuntime
+            ? { disposeRuntime: disposeBundleMcpSessionRuntime }
+            : {}),
+        })
+      : undefined;
     const bundleLspEnabled =
       !params.attempt.forceRestartSafeTools &&
       shouldCreateBundleLspRuntimeForAttempt({
@@ -261,7 +262,11 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
     };
   } catch (error) {
     try {
-      await bundleMcpRuntime?.dispose();
+      if (bundleMcpRuntime) {
+        await bundleMcpRuntime.dispose();
+      } else {
+        await disposeBundleMcpSessionRuntime?.();
+      }
     } catch {
       // Preserve the preparation error; cleanup is best-effort.
     }

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -206,6 +206,7 @@ export function resolveGatewayOptions(opts?: GatewayCallOptions) {
 }
 
 const APPROVAL_RUNTIME_METHODS = new Set<string>([
+  "exec.approval.cancel",
   "exec.approval.request",
   "exec.approval.resolve",
   "exec.approval.waitDecision",

--- a/src/gateway/exec-approval-manager.test.ts
+++ b/src/gateway/exec-approval-manager.test.ts
@@ -952,6 +952,49 @@ describe("ExecApprovalManager", () => {
     });
   });
 
+  it("invalidates resolved allow-once authority without erasing the winning decision", () => {
+    const { manager, databaseOptions } = createPersistentManager();
+    const record = manager.create({ command: "echo ok" }, 60_000, "approval-invalidated");
+    void manager.register(record, 60_000);
+    manager.resolveDetailed(record.id, "allow-once", { kind: "runtime", id: "runtime-owner" });
+
+    expect(manager.invalidateResolvedAllowOnce(record.id, "runtime-cancel:runtime-owner")).toBe(
+      true,
+    );
+    expect(manager.consumeAllowOnce(record.id, "system.run:approval-invalidated")).toBe(false);
+    expect(getOperatorApproval({ id: record.id, databaseOptions })).toMatchObject({
+      status: "allowed",
+      decision: "allow-once",
+      consumedBy: "runtime-cancel:runtime-owner",
+    });
+  });
+
+  it("invalidates allow-once authority when resolution wins a runtime cancellation race", () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create({ command: "echo ok" }, 60_000, "approval-cancel-race");
+    record.requestedByInstanceId = "runtime-owner";
+    void manager.register(record, 60_000);
+    const forceDeny = manager.forceDenyDetailed.bind(manager);
+    vi.spyOn(manager, "forceDenyDetailed").mockImplementation((...args) => {
+      expect(manager.resolveAutoReview(record.id, "runtime-owner")).toBe(true);
+      return forceDeny(...args);
+    });
+
+    expect(
+      manager.cancelForRuntime({
+        recordId: record.id,
+        runtimeInstanceId: "runtime-owner",
+        resolver: { kind: "runtime", id: "runtime-owner" },
+        resolvedBy: "runtime-owner",
+      }),
+    ).toMatchObject({
+      outcome: "invalidated",
+      record: { decision: "allow-once" },
+      liveRecord: { consumedDecision: "allow-once" },
+    });
+    expect(manager.consumeAllowOnce(record.id, "system.run:approval-cancel-race")).toBe(false);
+  });
+
   it("refuses allow-once redemption after the live grace window", () => {
     installTimerMocks();
     vi.spyOn(Date, "now").mockReturnValue(1_000);

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -68,6 +68,18 @@ export class InvalidApprovalIdError extends Error {
   }
 }
 
+/** Applies the canonical explicit approval-id contract before storage or lookup retention. */
+export function assertValidExplicitApprovalId(id: string): void {
+  if (
+    id.length > 128 ||
+    id === "." ||
+    id === ".." ||
+    EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN.test(id)
+  ) {
+    throw new InvalidApprovalIdError();
+  }
+}
+
 type ExecApprovalRequestPayload = InfraExecApprovalRequestPayload;
 
 // Distinguishes operator decisions from trusted auto-review resolutions.
@@ -145,6 +157,15 @@ type ExecApprovalForceDenyResult<TPayload = ExecApprovalRequestPayload> = WithLi
   ForceDenyOperatorApprovalResult,
   TPayload
 >;
+
+type ExecApprovalRuntimeCancelResult<TPayload = ExecApprovalRequestPayload> =
+  | ExecApprovalForceDenyResult<TPayload>
+  | { outcome: "not-owned" }
+  | {
+      outcome: "invalidated";
+      record: OperatorApprovalRecord;
+      liveRecord: ExecApprovalRecord<TPayload>;
+    };
 
 type ExecApprovalDurableLookup =
   | { outcome: "found"; record: OperatorApprovalRecord }
@@ -244,14 +265,8 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     }
     // Empty remains the caller-facing sentinel for manager-generated ids.
     const hasExplicitId = id !== null && id !== undefined && id.length > 0;
-    if (
-      hasExplicitId &&
-      (id.length > 128 ||
-        id === "." ||
-        id === ".." ||
-        EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN.test(id))
-    ) {
-      throw new InvalidApprovalIdError();
+    if (hasExplicitId) {
+      assertValidExplicitApprovalId(id);
     }
     const resolvedId = hasExplicitId ? id : randomUUID();
     const record: ExecApprovalRecord<TPayload> = {
@@ -585,6 +600,58 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       this.settleLocalStorageFailure(recordId);
     }
     return attachLiveRecord(result, localRecord) as ExecApprovalForceDenyResult<TPayload>;
+  }
+
+  /**
+   * Cancels one runtime-owned approval without leaving a resolved allow-once race redeemable.
+   * The manager transition is synchronous; durable resolution races are invalidated afterward.
+   */
+  cancelForRuntime(params: {
+    recordId: string;
+    runtimeInstanceId: string;
+    resolver: OperatorApprovalResolver;
+    resolvedBy: string | null;
+  }): ExecApprovalRuntimeCancelResult<TPayload> {
+    const liveRecord = this.pending.get(params.recordId)?.record;
+    if (!liveRecord) {
+      return { outcome: "not-found" };
+    }
+    if (liveRecord.requestedByInstanceId !== params.runtimeInstanceId) {
+      return { outcome: "not-owned" };
+    }
+    if (liveRecord.resolvedAtMs !== undefined) {
+      const record = this.projectLocalRecord(liveRecord);
+      if (!record) {
+        return { outcome: "corrupt" };
+      }
+      return this.invalidateResolvedAllowOnce(
+        params.recordId,
+        `runtime-cancel:${params.runtimeInstanceId}`,
+      )
+        ? { outcome: "invalidated", record, liveRecord }
+        : { outcome: "already-terminal", record, liveRecord };
+    }
+
+    const result = this.forceDenyDetailed(
+      params.recordId,
+      "run-aborted",
+      params.resolver,
+      "cancelled",
+      undefined,
+      false,
+      params.resolvedBy,
+    );
+    if (
+      (result.outcome === "already-terminal" || result.outcome === "expired") &&
+      result.liveRecord &&
+      this.invalidateResolvedAllowOnce(
+        params.recordId,
+        `runtime-cancel:${params.runtimeInstanceId}`,
+      )
+    ) {
+      return { outcome: "invalidated", record: result.record, liveRecord: result.liveRecord };
+    }
+    return result;
   }
 
   private settleLocalFromStore(
@@ -1092,6 +1159,14 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     }
     entry.record.consumedDecision = "allow-once";
     return true;
+  }
+
+  /**
+   * Invalidates live allow-once authority without rewriting the durable winning decision.
+   * Cancellation and redemption race through the same single-consumer transition.
+   */
+  invalidateResolvedAllowOnce(recordId: string, invalidatedBy: string): boolean {
+    return this.consumeAllowOnce(recordId, invalidatedBy);
   }
 
   /**

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -1105,6 +1105,24 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     return entry.record;
   }
 
+  /** Finds pending or briefly retained terminal records for one runtime request. */
+  listLiveRecordsForRuntimeRequest(params: {
+    runtimeInstanceId: string;
+    runtimeRequestId: string;
+  }): ExecApprovalRecord<TPayload>[] {
+    const matches: ExecApprovalRecord<TPayload>[] = [];
+    for (const entry of this.pending.values()) {
+      const record = this.getLiveSnapshot(entry.record.id);
+      if (
+        record?.requestedByInstanceId === params.runtimeInstanceId &&
+        record.requestedByRuntimeRequestId === params.runtimeRequestId
+      ) {
+        matches.push(record);
+      }
+    }
+    return matches;
+  }
+
   listPendingRecords(): ExecApprovalRecord<TPayload>[] {
     const nowMs = Date.now();
     for (const entry of this.pending.values()) {

--- a/src/gateway/methods/core-descriptors.since.test.ts
+++ b/src/gateway/methods/core-descriptors.since.test.ts
@@ -54,6 +54,7 @@ const CURRENT_TRAIN_METHODS = [
   "approval.get",
   "approval.resolve",
   "approval.history",
+  "exec.approval.cancel",
   "plugin.approval.cancel",
   "migrations.memory.plan",
   "openclaw.chat.history",

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -60,6 +60,12 @@ const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "exec.approvals.node.set", scope: "operator.admin", since: "<=2026.7" },
   { name: "exec.approval.get", scope: "operator.approvals", since: "<=2026.7" },
   { name: "exec.approval.list", scope: "operator.approvals", since: "<=2026.7" },
+  {
+    name: "exec.approval.cancel",
+    scope: "operator.approvals",
+    since: "2026.7",
+    advertise: false,
+  },
   { name: "exec.approval.request", scope: "operator.approvals", since: "<=2026.7" },
   { name: "exec.approval.waitDecision", scope: "operator.approvals", since: "<=2026.7" },
   { name: "exec.approval.resolve", scope: "operator.approvals", since: "<=2026.7" },

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -548,6 +548,7 @@ export function createGatewayAuxHandlers(params: {
     extraHandlers: {
       "exec.approval.get": createLazyHandler("exec.approval.get", loadExecApprovalHandlers),
       "exec.approval.list": createLazyHandler("exec.approval.list", loadExecApprovalHandlers),
+      "exec.approval.cancel": createLazyHandler("exec.approval.cancel", loadExecApprovalHandlers),
       "exec.approval.request": createLazyHandler("exec.approval.request", loadExecApprovalHandlers),
       "exec.approval.waitDecision": createLazyHandler(
         "exec.approval.waitDecision",

--- a/src/gateway/server-aux-methods.ts
+++ b/src/gateway/server-aux-methods.ts
@@ -4,6 +4,7 @@
 export const GATEWAY_AUX_METHODS = [
   "exec.approval.get",
   "exec.approval.list",
+  "exec.approval.cancel",
   "exec.approval.request",
   "exec.approval.waitDecision",
   "exec.approval.resolve",

--- a/src/gateway/server-methods/exec-approval-command-spans.test.ts
+++ b/src/gateway/server-methods/exec-approval-command-spans.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCommandSpans } from "./exec-approval-command-spans.js";
+
+describe("normalizeCommandSpans", () => {
+  it("orders valid non-overlapping spans and drops invalid or overlapping spans", () => {
+    expect(
+      normalizeCommandSpans(
+        [
+          { startIndex: 5, endIndex: 11 },
+          { startIndex: 0, endIndex: 2 },
+          { startIndex: 1, endIndex: 4 },
+          { startIndex: 12, endIndex: 999 },
+          { startIndex: 11, endIndex: 11 },
+        ],
+        26,
+      ),
+    ).toEqual([
+      { startIndex: 0, endIndex: 2 },
+      { startIndex: 5, endIndex: 11 },
+    ]);
+  });
+
+  it("returns undefined when no spans survive normalization", () => {
+    expect(
+      normalizeCommandSpans(
+        [
+          { startIndex: -1, endIndex: 2 },
+          { startIndex: 2, endIndex: 2 },
+        ],
+        10,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/gateway/server-methods/exec-approval-command-spans.ts
+++ b/src/gateway/server-methods/exec-approval-command-spans.ts
@@ -1,0 +1,33 @@
+type ExecApprovalCommandSpan = {
+  startIndex: number;
+  endIndex: number;
+};
+
+export function normalizeCommandSpans(
+  spans: ExecApprovalCommandSpan[] | undefined,
+  commandLength: number,
+): ExecApprovalCommandSpan[] | undefined {
+  if (!spans) {
+    return undefined;
+  }
+  const candidates = spans
+    .filter(
+      (span) =>
+        Number.isSafeInteger(span.startIndex) &&
+        Number.isSafeInteger(span.endIndex) &&
+        span.startIndex >= 0 &&
+        span.endIndex > span.startIndex &&
+        span.endIndex <= commandLength,
+    )
+    .toSorted((a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex);
+  const accepted: ExecApprovalCommandSpan[] = [];
+  let cursor = 0;
+  for (const span of candidates) {
+    if (span.startIndex < cursor) {
+      continue;
+    }
+    accepted.push({ startIndex: span.startIndex, endIndex: span.endIndex });
+    cursor = span.endIndex;
+  }
+  return accepted.length > 0 ? accepted : undefined;
+}

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -1,9 +1,11 @@
+import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 // Exec approval gateway methods create, list, inspect, and resolve command
 // approval requests, including iOS push delivery and requester visibility.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
   errorShape,
+  validateExecApprovalCancelParams,
   validateExecApprovalGetParams,
   validateExecApprovalRequestParams,
   validateExecApprovalResolveParams,
@@ -30,7 +32,12 @@ import {
 } from "../../infra/system-run-approval-binding.js";
 import { resolveSystemRunApprovalRequestContext } from "../../infra/system-run-approval-context.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
-import { InvalidApprovalIdError, type ExecApprovalManager } from "../exec-approval-manager.js";
+import {
+  assertValidExplicitApprovalId,
+  InvalidApprovalIdError,
+  type ExecApprovalManager,
+} from "../exec-approval-manager.js";
+import { publishAppliedApprovalResolution } from "./approval-publication.js";
 import { runApprovalRequestDeliveries } from "./approval-request-delivery.js";
 import {
   handleApprovalWaitDecision,
@@ -45,6 +52,7 @@ import {
   respondPendingApprovalLookupError,
   resolvePendingApprovalRecord,
 } from "./approval-shared.js";
+import { normalizeCommandSpans } from "./exec-approval-command-spans.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -52,6 +60,10 @@ const APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS = {
   reason: "APPROVAL_ALLOW_ALWAYS_UNAVAILABLE",
 } as const;
 const RESERVED_PLUGIN_APPROVAL_ID_PREFIX = "plugin:";
+const EXEC_APPROVAL_CANCELLATION_GRACE_MS = 30_000;
+const MAX_EXEC_APPROVAL_CANCELLATIONS_PER_RUNTIME = 1_024;
+const MAX_EXEC_APPROVAL_CANCELLATION_RUNTIMES = 1_024;
+const MAX_SATURATED_EXEC_APPROVAL_RUNTIMES = 1_024;
 
 type ExecApprovalIosPushDelivery = {
   handleRequested?: (
@@ -64,39 +76,105 @@ type ExecApprovalIosPushDelivery = {
   handleExpired?: (request: ExecApprovalRequest) => Promise<void>;
 };
 
-function normalizeCommandSpans(
-  spans: { startIndex: number; endIndex: number }[] | undefined,
-  commandLength: number,
-): { startIndex: number; endIndex: number }[] | undefined {
-  if (!spans) {
-    return undefined;
-  }
-  const candidates = spans
-    .filter(
-      (span) =>
-        Number.isSafeInteger(span.startIndex) &&
-        Number.isSafeInteger(span.endIndex) &&
-        span.startIndex >= 0 &&
-        span.endIndex > span.startIndex &&
-        span.endIndex <= commandLength,
-    )
-    .toSorted((a, b) => a.startIndex - b.startIndex || b.endIndex - a.endIndex);
-  const accepted: { startIndex: number; endIndex: number }[] = [];
-  let cursor = 0;
-  for (const span of candidates) {
-    if (span.startIndex < cursor) {
-      continue;
-    }
-    accepted.push({ startIndex: span.startIndex, endIndex: span.endIndex });
-    cursor = span.endIndex;
-  }
-  return accepted.length > 0 ? accepted : undefined;
-}
-
 export function createExecApprovalHandlers(
   manager: ExecApprovalManager,
   opts?: { forwarder?: ExecApprovalForwarder; iosPushDelivery?: ExecApprovalIosPushDelivery },
 ): GatewayRequestHandlers {
+  type CancellationRuntimeState = {
+    approvalIds: Map<string, number>;
+    rejectUntilMs?: number;
+  };
+  const cancellationRuntimeStates = new Map<string, CancellationRuntimeState>();
+  const saturatedCancellationRuntimeIds = new Map<string, number>();
+  let rejectUnknownRuntimeUntilMs = 0;
+  const pruneCancelledApprovalIds = (nowMs: number) => {
+    if (rejectUnknownRuntimeUntilMs <= nowMs) {
+      rejectUnknownRuntimeUntilMs = 0;
+    }
+    for (const [runtimeInstanceId, expiresAtMs] of saturatedCancellationRuntimeIds) {
+      if (expiresAtMs <= nowMs) {
+        saturatedCancellationRuntimeIds.delete(runtimeInstanceId);
+      }
+    }
+    for (const [runtimeInstanceId, state] of cancellationRuntimeStates) {
+      if ((state.rejectUntilMs ?? 0) <= nowMs) {
+        delete state.rejectUntilMs;
+      }
+      for (const [approvalId, expiresAtMs] of state.approvalIds) {
+        if (expiresAtMs <= nowMs) {
+          state.approvalIds.delete(approvalId);
+        }
+      }
+      if (state.approvalIds.size === 0 && state.rejectUntilMs === undefined) {
+        cancellationRuntimeStates.delete(runtimeInstanceId);
+      }
+    }
+  };
+  const rememberCancelledApprovalId = (
+    runtimeInstanceId: string,
+    approvalId: string,
+    timeoutMs?: number,
+  ) => {
+    const nowMs = Date.now();
+    pruneCancelledApprovalIds(nowMs);
+    const expiresAtMs =
+      nowMs +
+      resolveTimerTimeoutMs(timeoutMs, DEFAULT_EXEC_APPROVAL_TIMEOUT_MS) +
+      EXEC_APPROVAL_CANCELLATION_GRACE_MS;
+    let state = cancellationRuntimeStates.get(runtimeInstanceId);
+    if (!state) {
+      if (cancellationRuntimeStates.size >= MAX_EXEC_APPROVAL_CANCELLATION_RUNTIMES) {
+        const existingExpiry = saturatedCancellationRuntimeIds.get(runtimeInstanceId) ?? 0;
+        if (
+          existingExpiry > 0 ||
+          saturatedCancellationRuntimeIds.size < MAX_SATURATED_EXEC_APPROVAL_RUNTIMES
+        ) {
+          saturatedCancellationRuntimeIds.set(
+            runtimeInstanceId,
+            Math.max(existingExpiry, expiresAtMs),
+          );
+          return;
+        }
+        // Every bounded runtime slot is live. Preserve existing tombstones and
+        // fail closed only for previously unseen runtimes until the fence expires.
+        rejectUnknownRuntimeUntilMs = Math.max(rejectUnknownRuntimeUntilMs, expiresAtMs);
+        return;
+      }
+      state = { approvalIds: new Map() };
+      cancellationRuntimeStates.set(runtimeInstanceId, state);
+    }
+    if ((state.rejectUntilMs ?? 0) > nowMs) {
+      state.rejectUntilMs = Math.max(state.rejectUntilMs ?? 0, expiresAtMs);
+      return;
+    }
+    if (
+      !state.approvalIds.has(approvalId) &&
+      state.approvalIds.size >= MAX_EXEC_APPROVAL_CANCELLATIONS_PER_RUNTIME
+    ) {
+      let rejectUntilMs = expiresAtMs;
+      for (const cancelledUntilMs of state.approvalIds.values()) {
+        rejectUntilMs = Math.max(rejectUntilMs, cancelledUntilMs);
+      }
+      state.approvalIds.clear();
+      state.rejectUntilMs = rejectUntilMs;
+      return;
+    }
+    state.approvalIds.set(approvalId, expiresAtMs);
+  };
+  const isCancelledApprovalId = (runtimeInstanceId: string, approvalId: string) => {
+    const nowMs = Date.now();
+    pruneCancelledApprovalIds(nowMs);
+    const state = cancellationRuntimeStates.get(runtimeInstanceId);
+    return (
+      (saturatedCancellationRuntimeIds.get(runtimeInstanceId) ?? 0) > nowMs ||
+      (rejectUnknownRuntimeUntilMs > nowMs &&
+        state === undefined &&
+        !saturatedCancellationRuntimeIds.has(runtimeInstanceId)) ||
+      (state?.rejectUntilMs ?? 0) > nowMs ||
+      state?.approvalIds.has(approvalId) === true
+    );
+  };
+
   return {
     "exec.approval.get": async ({ params, respond, client }) => {
       if (!assertValidParams(params, validateExecApprovalGetParams, "exec.approval.get", respond)) {
@@ -133,6 +211,99 @@ export function createExecApprovalHandlers(
     },
     "exec.approval.list": async ({ respond, client }) => {
       respond(true, listVisiblePendingApprovalRequests({ manager, client }), undefined);
+    },
+    "exec.approval.cancel": async ({ params, respond, client, context }) => {
+      if (
+        !assertValidParams(
+          params,
+          validateExecApprovalCancelParams,
+          "exec.approval.cancel",
+          respond,
+        )
+      ) {
+        return;
+      }
+      if (client?.internal?.approvalRuntime !== true) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.FORBIDDEN, "exec approval cancellation is internal-only"),
+        );
+        return;
+      }
+      const runtimeInstanceId = normalizeOptionalString(client.connect?.client?.instanceId);
+      if (!runtimeInstanceId) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.FORBIDDEN, "exec approval runtime instance is required"),
+        );
+        return;
+      }
+      const { id: approvalId, timeoutMs } = params as { id: string; timeoutMs?: number };
+      try {
+        assertValidExplicitApprovalId(approvalId);
+      } catch (error) {
+        if (!(error instanceof InvalidApprovalIdError)) {
+          throw error;
+        }
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, error.message, {
+            details: { code: error.code, reason: error.reason },
+          }),
+        );
+        return;
+      }
+      let result: ReturnType<typeof manager.cancelForRuntime>;
+      try {
+        result = manager.cancelForRuntime({
+          recordId: approvalId,
+          runtimeInstanceId,
+          resolver: { kind: "runtime", id: client.connect?.client?.id ?? null },
+          resolvedBy: client.connect?.client?.displayName ?? client.connect?.client?.id ?? null,
+        });
+      } catch (error) {
+        context.logGateway?.error?.(
+          `exec approvals: cancellation failed for ${approvalId}: ${String(error)}`,
+        );
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, "exec approval storage unavailable"),
+        );
+        return;
+      }
+      if (result.outcome === "not-found" || result.outcome === "not-owned") {
+        rememberCancelledApprovalId(runtimeInstanceId, approvalId, timeoutMs);
+        respond(true, { ok: true, cancelled: 0 }, undefined);
+        return;
+      }
+      if (result.outcome === "corrupt") {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, "exec approval storage unavailable"),
+        );
+        return;
+      }
+      if (result.outcome === "invalidated") {
+        respond(true, { ok: true, cancelled: 1 }, undefined);
+        return;
+      }
+      if (result.outcome !== "denied" || !result.liveRecord) {
+        respond(true, { ok: true, cancelled: 0 }, undefined);
+        return;
+      }
+      await publishAppliedApprovalResolution({
+        record: result.record,
+        liveRecord: result.liveRecord,
+        context,
+        forwarder: opts?.forwarder,
+        iosPushDelivery: opts?.iosPushDelivery,
+      });
+      respond(true, { ok: true, cancelled: 1 }, undefined);
     },
     "exec.approval.request": async ({ params, respond, context, client }) => {
       if (
@@ -184,6 +355,10 @@ export function createExecApprovalHandlers(
       // IDs are opaque cross-surface handles. Preserve every supplied byte so
       // the manager can reject unsafe values instead of silently normalizing them.
       const explicitId = p.id ?? null;
+      const runtimeInstanceId =
+        client?.internal?.approvalRuntime === true
+          ? normalizeOptionalString(client.connect?.client?.instanceId)
+          : undefined;
       const host = normalizeOptionalString(p.host) ?? "";
       const nodeId = normalizeOptionalString(p.nodeId) ?? "";
       const approvalContext = resolveSystemRunApprovalRequestContext({
@@ -341,6 +516,19 @@ export function createExecApprovalHandlers(
           errorShape(ErrorCodes.INVALID_REQUEST, "approval run already aborted", {
             details: { reason: "EXEC_APPROVAL_RUN_ABORTED" },
           }),
+        );
+        return;
+      }
+      if (
+        explicitId &&
+        runtimeInstanceId &&
+        client &&
+        isCancelledApprovalId(runtimeInstanceId, explicitId)
+      ) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, "exec approval request cancelled"),
         );
         return;
       }

--- a/src/gateway/server-methods/plugin-approval.cancel.test.ts
+++ b/src/gateway/server-methods/plugin-approval.cancel.test.ts
@@ -489,6 +489,67 @@ describe("plugin.approval.cancel", () => {
     expect(manager.getSnapshot(record.id)?.resolvedAtMs).toBeUndefined();
   });
 
+  it("invalidates resolved allow-once authority without republishing the winning decision", async () => {
+    const handler = createPluginApprovalHandlers(manager)["plugin.approval.cancel"];
+    const record = registerApproval(manager, "plugin:cancel-resolved");
+    expect(manager.resolveAutoReview(record.id, "runtime-owner")).toBe(true);
+    const context = createContext();
+    const opts = createOptions(
+      { id: record.id },
+      {
+        client: createClient({
+          clientId: "approval-runtime",
+          instanceId: "runtime-owner",
+          approvalRuntime: true,
+        }),
+        context,
+      },
+    );
+
+    await expectDefined(handler, "plugin.approval.cancel handler")(opts);
+
+    expect(expectResponseOk(opts)).toEqual({ ok: true, cancelled: 1 });
+    expect(manager.consumeAllowOnce(record.id, "plugin:cancel-resolved")).toBe(false);
+    expect(manager.getSnapshot(record.id)).toMatchObject({
+      status: "allowed",
+      decision: "allow-once",
+    });
+    expect(context.broadcast).not.toHaveBeenCalled();
+  });
+
+  it("invalidates resolved allow-once authority by runtime request id", async () => {
+    const handler = createPluginApprovalHandlers(manager)["plugin.approval.cancel"];
+    const record = registerApproval(
+      manager,
+      "plugin:cancel-resolved-request",
+      "owner",
+      "request-resolved",
+    );
+    expect(manager.resolveAutoReview(record.id, "runtime-owner")).toBe(true);
+    const context = createContext();
+    const opts = createOptions(
+      { runtimeRequestId: "request-resolved" },
+      {
+        client: createClient({
+          clientId: "approval-runtime",
+          instanceId: "runtime-owner",
+          approvalRuntime: true,
+        }),
+        context,
+      },
+    );
+
+    await expectDefined(handler, "plugin.approval.cancel handler")(opts);
+
+    expect(expectResponseOk(opts)).toEqual({ ok: true, cancelled: 1 });
+    expect(manager.consumeAllowOnce(record.id, "plugin:cancel-resolved-request")).toBe(false);
+    expect(manager.getSnapshot(record.id)).toMatchObject({
+      status: "allowed",
+      decision: "allow-once",
+    });
+    expect(context.broadcast).not.toHaveBeenCalled();
+  });
+
   it("is idempotent after the approval is terminal", async () => {
     const handler = createPluginApprovalHandlers(manager)["plugin.approval.cancel"];
     const record = registerApproval(manager, "plugin:cancel-idempotent");

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -184,12 +184,10 @@ export function createPluginApprovalHandlers(
           : []
         : p.runtimeRequestId && runtimeInstanceId
           ? manager
-              .listPendingRecords()
-              .filter(
-                (record) =>
-                  record.requestedByInstanceId === runtimeInstanceId &&
-                  record.requestedByRuntimeRequestId === p.runtimeRequestId,
-              )
+              .listLiveRecordsForRuntimeRequest({
+                runtimeInstanceId,
+                runtimeRequestId: p.runtimeRequestId,
+              })
               .map((record) => record.id)
           : [];
       const cancelledRuntimeRequestId =
@@ -202,20 +200,21 @@ export function createPluginApprovalHandlers(
         // arrive later. Retain the logical request tombstone in both cases.
         rememberCancelledRuntimeRequest(runtimeInstanceId, cancelledRuntimeRequestId);
       }
+      if (!runtimeInstanceId) {
+        respond(true, { ok: true, cancelled: 0 }, undefined);
+        return;
+      }
       const resolvedBy = client.connect?.client?.displayName ?? client.connect?.client?.id ?? null;
       let cancelled = 0;
       for (const approvalId of approvalIds) {
-        let result: ReturnType<typeof manager.forceDenyDetailed>;
+        let result: ReturnType<typeof manager.cancelForRuntime>;
         try {
-          result = manager.forceDenyDetailed(
-            approvalId,
-            "run-aborted",
-            { kind: "runtime", id: client.connect?.client?.id ?? null },
-            "cancelled",
-            undefined,
-            false,
+          result = manager.cancelForRuntime({
+            recordId: approvalId,
+            runtimeInstanceId,
+            resolver: { kind: "runtime", id: client.connect?.client?.id ?? null },
             resolvedBy,
-          );
+          });
         } catch (error) {
           context.logGateway?.error?.(
             `plugin approvals: cancellation failed for ${approvalId}: ${String(error)}`,
@@ -234,6 +233,10 @@ export function createPluginApprovalHandlers(
             errorShape(ErrorCodes.UNAVAILABLE, "plugin approval storage unavailable"),
           );
           return;
+        }
+        if (result.outcome === "invalidated") {
+          cancelled += 1;
+          continue;
         }
         if (result.outcome !== "denied" || !result.liveRecord) {
           continue;

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -2557,6 +2557,7 @@ describe("exec approval handlers", () => {
   const execApprovalNoop = () => false;
   type ExecApprovalHandlers = ReturnType<typeof createExecApprovalHandlers>;
   type ExecApprovalGetArgs = Parameters<ExecApprovalHandlers["exec.approval.get"]>[0];
+  type ExecApprovalCancelArgs = Parameters<ExecApprovalHandlers["exec.approval.cancel"]>[0];
   type ExecApprovalRequestArgs = Parameters<ExecApprovalHandlers["exec.approval.request"]>[0];
   type ExecApprovalResolveArgs = Parameters<ExecApprovalHandlers["exec.approval.resolve"]>[0];
   type ExecApprovalWaitArgs = Parameters<ExecApprovalHandlers["exec.approval.waitDecision"]>[0];
@@ -2580,6 +2581,7 @@ describe("exec approval handlers", () => {
   function createExecApprovalClient(params: {
     connId: string;
     clientId: string;
+    instanceId?: string;
     deviceId?: string;
     scopes?: string[];
     approvalRuntime?: boolean;
@@ -2596,7 +2598,7 @@ describe("exec approval handlers", () => {
     return {
       connId: params.connId,
       connect: {
-        client: { id: params.clientId },
+        client: { id: params.clientId, instanceId: params.instanceId },
         device: params.deviceId ? { id: params.deviceId } : undefined,
         scopes: params.scopes,
       },
@@ -2714,6 +2716,30 @@ describe("exec approval handlers", () => {
     });
   }
 
+  async function cancelExecApproval(params: {
+    handlers: ExecApprovalHandlers;
+    id: string;
+    timeoutMs?: number;
+    respond: ReturnType<typeof vi.fn>;
+    context: object;
+    client?: ExecApprovalCancelArgs["client"];
+  }) {
+    return expectDefined(
+      params.handlers["exec.approval.cancel"],
+      'params.handlers["exec.approval.cancel"] test invariant',
+    )({
+      params: {
+        id: params.id,
+        ...(params.timeoutMs === undefined ? {} : { timeoutMs: params.timeoutMs }),
+      } as ExecApprovalCancelArgs["params"],
+      respond: params.respond as unknown as ExecApprovalCancelArgs["respond"],
+      context: params.context as ExecApprovalCancelArgs["context"],
+      client: params.client ?? null,
+      req: { id: "req-cancel", type: "req", method: "exec.approval.cancel" },
+      isWebchatConnect: execApprovalNoop,
+    });
+  }
+
   async function resolveExecApproval(params: {
     handlers: ExecApprovalHandlers;
     id: string;
@@ -2789,6 +2815,425 @@ describe("exec approval handlers", () => {
       request: payload.request ?? {},
     };
   }
+
+  it("rejects an exec approval whose exact id was cancelled before registration", async () => {
+    const { manager, handlers, broadcasts, context } = createExecApprovalFixture();
+    const client = createExecApprovalClient({
+      connId: "conn-runtime",
+      clientId: "runtime-client",
+      instanceId: "runtime-instance",
+      approvalRuntime: true,
+    });
+    const cancelRespond = vi.fn();
+    await cancelExecApproval({
+      handlers,
+      id: "approval-cancel-before-register",
+      respond: cancelRespond,
+      context,
+      client,
+    });
+    expect(cancelRespond).toHaveBeenCalledWith(true, { ok: true, cancelled: 0 }, undefined);
+
+    const requestRespond = vi.fn();
+    await requestExecApproval({
+      handlers,
+      respond: requestRespond,
+      context,
+      client,
+      params: {
+        id: "approval-cancel-before-register",
+        twoPhase: true,
+        host: "gateway",
+        nodeId: undefined,
+        systemRunPlan: undefined,
+      },
+    });
+
+    expect(mockCallArg(requestRespond)).toBe(false);
+    expectRecordFields(mockCallArg(requestRespond, 0, 2), {
+      code: "UNAVAILABLE",
+      message: "exec approval request cancelled",
+    });
+    expect(manager.getSnapshot("approval-cancel-before-register")).toBeNull();
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  it("rejects unsafe cancellation ids before retaining tombstones", async () => {
+    const { manager, handlers, context } = createExecApprovalFixture();
+    const respond = vi.fn();
+    await cancelExecApproval({
+      handlers,
+      id: "x".repeat(129),
+      respond,
+      context,
+      client: createExecApprovalClient({
+        connId: "conn-runtime",
+        clientId: "runtime-client",
+        instanceId: "runtime-instance",
+        approvalRuntime: true,
+      }),
+    });
+
+    expect(mockCallArg(respond)).toBe(false);
+    expectRecordFields(mockCallArg(respond, 0, 2), {
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("approval id must be 1-128 characters"),
+    });
+    expect(manager.listPendingRecords()).toHaveLength(0);
+  });
+
+  it("keeps cancellation tombstones for the requested approval lifetime", async () => {
+    const nowMs = 1_800_000_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const { manager, handlers, broadcasts, context } = createExecApprovalFixture();
+    const client = createExecApprovalClient({
+      connId: "conn-runtime",
+      clientId: "runtime-client",
+      instanceId: "runtime-instance",
+      approvalRuntime: true,
+    });
+
+    try {
+      await cancelExecApproval({
+        handlers,
+        id: "approval-long-cancel",
+        timeoutMs: 3_600_000,
+        respond: vi.fn(),
+        context,
+        client,
+      });
+      dateNow.mockReturnValue(nowMs + 2_000_000);
+
+      const requestRespond = vi.fn();
+      await requestExecApproval({
+        handlers,
+        respond: requestRespond,
+        context,
+        client,
+        params: {
+          id: "approval-long-cancel",
+          twoPhase: true,
+          host: "gateway",
+          nodeId: undefined,
+          systemRunPlan: undefined,
+        },
+      });
+
+      expect(mockCallArg(requestRespond)).toBe(false);
+      expectRecordFields(mockCallArg(requestRespond, 0, 2), {
+        code: "UNAVAILABLE",
+        message: "exec approval request cancelled",
+      });
+      expect(manager.getSnapshot("approval-long-cancel")).toBeNull();
+      expect(broadcasts).toHaveLength(0);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("does not shorten a saturated runtime cancellation fence", async () => {
+    const nowMs = 1_800_000_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    const { manager, handlers, broadcasts, context } = createExecApprovalFixture();
+    const client = createExecApprovalClient({
+      connId: "conn-runtime",
+      clientId: "runtime-client",
+      instanceId: "runtime-instance",
+      approvalRuntime: true,
+    });
+
+    try {
+      await cancelExecApproval({
+        handlers,
+        id: "approval-long-cancel",
+        timeoutMs: 3_600_000,
+        respond: vi.fn(),
+        context,
+        client,
+      });
+      for (let index = 1; index <= 1_024; index += 1) {
+        await cancelExecApproval({
+          handlers,
+          id: `approval-short-cancel-${index}`,
+          timeoutMs: 1,
+          respond: vi.fn(),
+          context,
+          client,
+        });
+      }
+      dateNow.mockReturnValue(nowMs + 60_000);
+
+      const requestRespond = vi.fn();
+      await requestExecApproval({
+        handlers,
+        respond: requestRespond,
+        context,
+        client,
+        params: {
+          id: "approval-late-registration",
+          twoPhase: true,
+          host: "gateway",
+          nodeId: undefined,
+          systemRunPlan: undefined,
+        },
+      });
+
+      expect(mockCallArg(requestRespond)).toBe(false);
+      expectRecordFields(mockCallArg(requestRespond, 0, 2), {
+        code: "UNAVAILABLE",
+        message: "exec approval request cancelled",
+      });
+      expect(manager.getSnapshot("approval-late-registration")).toBeNull();
+      expect(broadcasts).toHaveLength(0);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("preserves live tombstones and fails closed only for a saturated connection", async () => {
+    const { manager, handlers, context } = createExecApprovalFixture();
+    for (let index = 0; index < 1_024; index += 1) {
+      await cancelExecApproval({
+        handlers,
+        id: `approval-${index}`,
+        respond: vi.fn(),
+        context,
+        client: createExecApprovalClient({
+          connId: `conn-${index}`,
+          clientId: `runtime-${index}`,
+          instanceId: `runtime-instance-${index}`,
+          approvalRuntime: true,
+        }),
+      });
+    }
+
+    const overflowClient = createExecApprovalClient({
+      connId: "conn-overflow",
+      clientId: "runtime-overflow",
+      instanceId: "runtime-instance-overflow",
+      approvalRuntime: true,
+    });
+    const overflowCancelRespond = vi.fn();
+    await cancelExecApproval({
+      handlers,
+      id: "approval-overflow",
+      respond: overflowCancelRespond,
+      context,
+      client: overflowClient,
+    });
+    expect(overflowCancelRespond).toHaveBeenCalledWith(true, { ok: true, cancelled: 0 }, undefined);
+
+    const overflowRequestRespond = vi.fn();
+    await requestExecApproval({
+      handlers,
+      respond: overflowRequestRespond,
+      context,
+      client: overflowClient,
+      params: {
+        id: "approval-overflow",
+        twoPhase: true,
+        host: "gateway",
+        nodeId: undefined,
+        systemRunPlan: undefined,
+      },
+    });
+    expect(mockCallArg(overflowRequestRespond)).toBe(false);
+    expectRecordFields(mockCallArg(overflowRequestRespond, 0, 2), {
+      code: "UNAVAILABLE",
+      message: "exec approval request cancelled",
+    });
+
+    const reconnectedOverflowRespond = vi.fn();
+    await requestExecApproval({
+      handlers,
+      respond: reconnectedOverflowRespond,
+      context,
+      client: createExecApprovalClient({
+        connId: "conn-overflow-reconnected",
+        clientId: "runtime-overflow-reconnected",
+        instanceId: "runtime-instance-overflow",
+        approvalRuntime: true,
+      }),
+      params: {
+        id: "approval-overflow",
+        twoPhase: true,
+        host: "gateway",
+        nodeId: undefined,
+        systemRunPlan: undefined,
+      },
+    });
+    expect(mockCallArg(reconnectedOverflowRespond)).toBe(false);
+    expectRecordFields(mockCallArg(reconnectedOverflowRespond, 0, 2), {
+      code: "UNAVAILABLE",
+      message: "exec approval request cancelled",
+    });
+
+    const unrelatedClient = createExecApprovalClient({
+      connId: "conn-after-runtime-overflow",
+      clientId: "runtime-after-runtime-overflow",
+      instanceId: "runtime-instance-after-runtime-overflow",
+      approvalRuntime: true,
+    });
+    const unrelatedRespond = vi.fn();
+    const unrelatedRequest = requestExecApproval({
+      handlers,
+      respond: unrelatedRespond,
+      context,
+      client: unrelatedClient,
+      params: {
+        id: "approval-after-runtime-overflow",
+        twoPhase: true,
+        host: "gateway",
+        nodeId: undefined,
+        systemRunPlan: undefined,
+      },
+    });
+    await vi.waitFor(() => expect(unrelatedRespond).toHaveBeenCalled());
+    expect(mockCallArg(unrelatedRespond)).toBe(true);
+
+    expect(manager.resolve("approval-after-runtime-overflow", "deny")).toBe(true);
+    await unrelatedRequest;
+
+    const oldestCancelledRespond = vi.fn();
+    await requestExecApproval({
+      handlers,
+      respond: oldestCancelledRespond,
+      context,
+      client: createExecApprovalClient({
+        connId: "conn-0",
+        clientId: "runtime-0",
+        instanceId: "runtime-instance-0",
+        approvalRuntime: true,
+      }),
+      params: {
+        id: "approval-0",
+        twoPhase: true,
+        host: "gateway",
+        nodeId: undefined,
+        systemRunPlan: undefined,
+      },
+    });
+    expect(mockCallArg(oldestCancelledRespond)).toBe(false);
+    expectRecordFields(mockCallArg(oldestCancelledRespond, 0, 2), {
+      code: "UNAVAILABLE",
+      message: "exec approval request cancelled",
+    });
+  });
+
+  it("lets only the owning runtime cancel an exact pending exec approval", async () => {
+    const { manager, handlers, broadcasts, context } = createExecApprovalFixture();
+    const owner = createExecApprovalClient({
+      connId: "conn-owner",
+      clientId: "runtime-owner",
+      instanceId: "runtime-instance-owner",
+      approvalRuntime: true,
+    });
+    const other = createExecApprovalClient({
+      connId: "conn-other",
+      clientId: "runtime-other",
+      instanceId: "runtime-instance-other",
+      approvalRuntime: true,
+    });
+    const requestRespond = vi.fn();
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond: requestRespond,
+      context,
+      client: owner,
+      params: {
+        id: "approval-owned-cancel",
+        twoPhase: true,
+        host: "gateway",
+        nodeId: undefined,
+        systemRunPlan: undefined,
+      },
+    });
+    await vi.waitFor(() => expect(requestRespond).toHaveBeenCalled(), { timeout: 5_000 });
+    expect(mockCallArg(requestRespond)).toBe(true);
+    const registration = mockCallArg(requestRespond, 0, 1) as { id?: unknown };
+    expect(registration.id).toBe("approval-owned-cancel");
+    expect(manager.listPendingRecords().map((record) => record.id)).toContain(
+      "approval-owned-cancel",
+    );
+
+    const otherRespond = vi.fn();
+    await cancelExecApproval({
+      handlers,
+      id: "approval-owned-cancel",
+      respond: otherRespond,
+      context,
+      client: other,
+    });
+    expect(otherRespond).toHaveBeenCalledWith(true, { ok: true, cancelled: 0 }, undefined);
+    expect(manager.listPendingRecords().map((record) => record.id)).toContain(
+      "approval-owned-cancel",
+    );
+
+    const ownerRespond = vi.fn();
+    await cancelExecApproval({
+      handlers,
+      id: "approval-owned-cancel",
+      respond: ownerRespond,
+      context,
+      client: owner,
+    });
+    expect(ownerRespond).toHaveBeenCalledWith(true, { ok: true, cancelled: 1 }, undefined);
+    expect(manager.listPendingRecords().map((record) => record.id)).not.toContain(
+      "approval-owned-cancel",
+    );
+    expect(manager.getSnapshot("approval-owned-cancel")).toMatchObject({
+      terminalReason: "run-aborted",
+    });
+    expect(manager.getSnapshot("approval-owned-cancel")?.decision).toBeUndefined();
+    expect(
+      broadcasts.find((entry) => entry.event === "exec.approval.resolved")?.payload,
+    ).toMatchObject({
+      id: "approval-owned-cancel",
+      decision: "deny",
+    });
+    await requestPromise;
+  });
+
+  it("lets the owning runtime invalidate a resolved allow-once approval", async () => {
+    const { manager, handlers, context } = createExecApprovalFixture();
+    const owner = createExecApprovalClient({
+      connId: "conn-owner",
+      clientId: "runtime-owner",
+      instanceId: "runtime-instance-owner",
+      approvalRuntime: true,
+    });
+    const record = manager.create(
+      {
+        ...defaultExecApprovalRequestParams,
+        commandArgv: [...defaultExecApprovalRequestParams.commandArgv],
+        systemRunPlan: {
+          ...defaultExecApprovalRequestParams.systemRunPlan,
+          argv: [...defaultExecApprovalRequestParams.systemRunPlan.argv],
+        },
+      },
+      60_000,
+      "approval-resolved-cancel",
+    );
+    record.requestedByInstanceId = "runtime-instance-owner";
+    void manager.register(record, 60_000);
+    expect(manager.resolveAutoReview(record.id, "runtime-owner")).toBe(true);
+
+    const respond = vi.fn();
+    await cancelExecApproval({
+      handlers,
+      id: record.id,
+      respond,
+      context,
+      client: owner,
+    });
+
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, cancelled: 1 }, undefined);
+    expect(manager.getSnapshot(record.id)).toMatchObject({
+      decision: "allow-once",
+      consumedDecision: "allow-once",
+    });
+    expect(manager.consumeAllowOnce(record.id, "system.run:approval-resolved-cancel")).toBe(false);
+  });
 
   async function waitForRequestedExecApprovalPayload(
     broadcasts: Array<{ event: string; payload: unknown }>,


### PR DESCRIPTION
Related: #116402

Depends on #116620.

## What Problem This Solves

Exec approvals still crossed the Gateway directly after the other approval families became run-owned. That left a split authority path and made cancellation or policy changes race with remote node dispatch.

## Why This Change Was Made

Routes exec approval registration and resolution through the run host, carries approval leases through dispatch, revalidates node policy at the dispatch boundary, and cancels unused allow-once authority. Invoke failures distinguish definitely-not-dispatched commands from unknown outcomes to avoid duplicate execution.

## User Impact

No intended standalone UX change. Exec approval lifetime now follows the owning run and fails closed when policy or cancellation changes before dispatch.

## Stack

1. #116403
2. #116394
3. #116437
4. #116620
5. #116630
6. #116678
7. #116690

## Evidence

- rebased onto current `origin/main`
- exec-host cancellation and policy tests passed after the semantic merge
- stack-focused validation: 10 files, 346 tests
- `git diff --check`
- current changed gate: https://github.com/openclaw/openclaw/actions/runs/30729669450
