### PR TITLE
fix(ci): remove dead browser config tests

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -210,13 +210,6 @@ describe("browser config", () => {
     });
   });
 
-  it("normalizes hex colors", () => {
-    const resolved = resolveBrowserConfig({
-      color: "ff4500",
-    });
-    expect(resolved.color).toBe("#FF4500");
-  });
-
   it("expands tilde-prefixed executablePath with the OS home directory", () => {
     const resolved = resolveBrowserConfig({
       executablePath: " ~/.local/bin/chromium ",
@@ -272,21 +265,6 @@ describe("browser config", () => {
     });
 
     expect(resolved.executablePath).toBe("/opt/~chromium/chrome");
-  });
-
-  it("falls back to default color for invalid hex", () => {
-    const resolved = resolveBrowserConfig({
-      color: "#GGGGGG",
-    });
-    expect(resolved.color).toBe("#FF4500");
-  });
-
-  it("treats non-loopback cdpUrl as remote", () => {
-    const resolved = resolveBrowserConfig({
-      cdpUrl: "http://example.com:9222",
-    });
-    const profile = resolveProfile(resolved, "openclaw");
-    expect(profile?.cdpIsLoopback).toBe(false);
   });
 
   it("supports explicit CDP URLs for the default profile", () => {
@@ -1067,62 +1045,17 @@ describe("browser config", () => {
     expect(getBrowserProfileCapabilities(work).usesChromeMcp).toBe(false);
   });
 
-  describe("default profile preference", () => {
-    it("defaults to openclaw profile when defaultProfile is not configured", () => {
-      const resolved = resolveBrowserConfig({
-        headless: false,
-        noSandbox: false,
-      });
-      expect(resolved.defaultProfile).toBe("openclaw");
+  it("resolves a configured custom default profile", () => {
+    const resolved = resolveBrowserConfig({
+      defaultProfile: "custom",
+      profiles: {
+        custom: { cdpPort: 19999 },
+      },
     });
 
-    it("keeps openclaw default when headless=true", () => {
-      const resolved = resolveBrowserConfig({
-        headless: true,
-      });
-      expect(resolved.defaultProfile).toBe("openclaw");
-    });
-
-    it("keeps openclaw default when noSandbox=true", () => {
-      const resolved = resolveBrowserConfig({
-        noSandbox: true,
-      });
-      expect(resolved.defaultProfile).toBe("openclaw");
-    });
-
-    it("keeps openclaw default when both headless and noSandbox are true", () => {
-      const resolved = resolveBrowserConfig({
-        headless: true,
-        noSandbox: true,
-      });
-      expect(resolved.defaultProfile).toBe("openclaw");
-    });
-
-    it("explicit defaultProfile config overrides defaults in headless mode", () => {
-      const resolved = resolveBrowserConfig({
-        headless: true,
-        defaultProfile: "user",
-      });
-      expect(resolved.defaultProfile).toBe("user");
-    });
-
-    it("explicit defaultProfile config overrides defaults in noSandbox mode", () => {
-      const resolved = resolveBrowserConfig({
-        noSandbox: true,
-        defaultProfile: "user",
-      });
-      expect(resolved.defaultProfile).toBe("user");
-    });
-
-    it("allows custom profile as default even in headless mode", () => {
-      const resolved = resolveBrowserConfig({
-        headless: true,
-        defaultProfile: "custom",
-        profiles: {
-          custom: { cdpPort: 19999, color: "#00FF00" },
-        },
-      });
-      expect(resolved.defaultProfile).toBe("custom");
-    });
+    const profile = resolveProfile(resolved, resolved.defaultProfile);
+    expect(resolved.defaultProfile).toBe("custom");
+    expect(profile?.name).toBe("custom");
+    expect(profile?.cdpPort).toBe(19999);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The browser config suite contained tests for retired color inputs, a duplicate remote-CDP assertion, and a profile-selection matrix for logic that no longer exists. Those cases spent CI time while documenting obsolete or already-covered contracts.

## Why This Change Was Made

The stale and duplicate cases are removed. The remaining custom-default coverage now verifies that the configured profile is both selected and resolved, without coupling the assertion to unrelated headless settings.

## User Impact

No runtime behavior changes. Browser config tests are smaller, faster, and aligned with the current supported configuration surface.

## Evidence

- `node scripts/run-vitest.mjs extensions/browser/src/browser/config.test.ts`
  - 69 passed, 1 legitimate Windows-only test skipped
- targeted `oxfmt --check`: passed
- `git diff --check`: passed
- fresh branch autoreview after rebase: clean, 0.91
- Blacksmith Testbox changed gate at pre-rebase head `f83d0775`: passed in 4m44s
  - https://github.com/openclaw/openclaw/actions/runs/30599385789
- exact-head changed gate: passed locally after two Testbox leases stopped before command dispatch
  - remote fallback used trusted source with the existing dependency tree; no dependency install or reconciliation ran
  - deadcode, extension test typecheck, targeted lint, formatting, boundaries, and policy guards passed
- net test cleanup: 77 lines removed, 10 lines added

## ClawSweeper Rank-up Move

- Confirmed removed coverage is retired or retained:
  - color inputs were removed by `edecdbd05e`; resolved browser and profile colors now use `DEFAULT_OPENCLAW_BROWSER_COLOR`, and the surviving default-config test asserts `#FF4500`
  - the deleted non-loopback CDP assertion used the same input as `supports explicit CDP URLs for the default profile`, which still verifies the URL and remote classification
  - `headless` and `noSandbox` no longer participate in default-profile selection; the replacement test verifies that a configured custom default is selected and resolved
