### PR TITLE
fix(qa): keep Anthropic parity scenarios working in Code Mode

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -123,6 +123,7 @@ export type MockOpenAiRequestSnapshot = {
   imageInputCount: number;
   plannedToolCallId?: string;
   plannedToolName?: string;
+  plannedWireToolName?: string;
   plannedToolArgs?: Record<string, unknown>;
   toolOutputCallId?: string;
   toolOutputStructuredError?: true;
@@ -280,6 +281,7 @@ export const QA_MCP_CODE_MODE_API_FILE_PROMPT_RE = /mcp code mode api file qa ch
 
 export type MockScenarioState = {
   anthropicThinkingErrorScenarioKeys: Set<string>;
+  subagentFanoutCompletedWorkers: Set<"alpha" | "beta">;
   subagentFanoutPhase: number;
   subagentHandoffSpawned: boolean;
   toolLoopReadAttempts: number;

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -5264,6 +5264,514 @@ describe("qa mock openai server", () => {
     expect(debugPayload.plannedToolName).toBe("read");
   });
 
+  it("routes Anthropic hidden tools through Code Mode and preserves scenario evidence", async () => {
+    const server = await startMockServer();
+    const prompt =
+      "Repo contract followthrough check. Read AGENT.md, SOUL.md, and FOLLOWTHROUGH_INPUT.md first. Then follow the repo contract exactly, write ./repo-contract-summary.txt, and reply with three labeled lines: Read, Wrote, Status.";
+    const tools = [
+      {
+        name: "exec",
+        input_schema: {
+          type: "object",
+          properties: {
+            language: { type: "string" },
+            code: { type: "string" },
+          },
+          required: ["code"],
+        },
+      },
+      {
+        name: "wait",
+        input_schema: {
+          type: "object",
+          properties: { runId: { type: "string" } },
+          required: ["runId"],
+        },
+      },
+    ];
+    const messages: Array<Record<string, unknown>> = [
+      {
+        role: "user",
+        content: [{ type: "text", text: prompt }],
+      },
+    ];
+
+    const request = async () => {
+      const response = await postJson(server, "/v1/messages", {
+        model: "claude-opus-4-8",
+        max_tokens: 256,
+        tools,
+        messages,
+      });
+      expect(response.status).toBe(200);
+      return (await response.json()) as {
+        stop_reason: string;
+        content: Array<Record<string, unknown>>;
+      };
+    };
+    const readToolUse = (body: {
+      stop_reason: string;
+      content: Array<Record<string, unknown>>;
+    }) => {
+      expect(body.stop_reason).toBe("tool_use");
+      const toolUse = body.content.find((block) => block.type === "tool_use");
+      if (!toolUse || typeof toolUse.id !== "string" || typeof toolUse.name !== "string") {
+        throw new Error("Expected Anthropic tool_use block");
+      }
+      return toolUse;
+    };
+    const appendToolResult = (
+      toolUse: Record<string, unknown>,
+      result: Record<string, unknown>,
+    ) => {
+      messages.push(
+        { role: "assistant", content: [toolUse] },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: toolUse.id,
+              content: JSON.stringify(result),
+            },
+          ],
+        },
+      );
+    };
+    const expectPlan = async (name: string, args: Record<string, unknown>, wireName = "exec") => {
+      const debugResponse = await fetch(`${server.baseUrl}/debug/last-request`);
+      expect(debugResponse.status).toBe(200);
+      const debug = requireRecord(await debugResponse.json(), "debug request");
+      expect(debug.plannedToolName).toBe(name);
+      expect(debug.plannedWireToolName).toBe(wireName);
+      expect(debug.plannedToolArgs).toEqual(args);
+    };
+
+    const readAgent = readToolUse(await request());
+    expect(readAgent.name).toBe("exec");
+    const readAgentCode = String(requireRecord(readAgent.input, "exec input").code);
+    expect(readAgentCode).toContain("tools.callValue(target.id, targetArgs)");
+    expect(readAgentCode).toContain("value.content.slice(0, 2048)");
+    await expectPlan("read", { path: "AGENT.md" });
+
+    appendToolResult(readAgent, { status: "waiting", runId: "qa-code-mode-read-agent" });
+    const waitForAgent = readToolUse(await request());
+    expect(waitForAgent.name).toBe("wait");
+    const waitDebug = requireRecord(
+      await fetch(`${server.baseUrl}/debug/last-request`).then((response) => response.json()),
+      "wait debug request",
+    );
+    expect(waitDebug.plannedToolName).toBe("wait");
+    expect(waitDebug).not.toHaveProperty("plannedWireToolName");
+    expect(waitDebug.plannedToolArgs).toEqual({ runId: "qa-code-mode-read-agent" });
+
+    appendToolResult(waitForAgent, {
+      status: "completed",
+      value: { kind: "text", content: "# Repo contract\nDo not stop after planning." },
+    });
+    const readSoul = readToolUse(await request());
+    expect(readSoul.name).toBe("exec");
+    await expectPlan("read", { path: "SOUL.md" });
+
+    appendToolResult(readSoul, {
+      status: "completed",
+      value: { kind: "text", content: "# Execution style\nStay action-first." },
+    });
+    const readInput = readToolUse(await request());
+    expect(readInput.name).toBe("exec");
+    await expectPlan("read", { path: "FOLLOWTHROUGH_INPUT.md" });
+
+    appendToolResult(readInput, {
+      status: "completed",
+      value: {
+        kind: "text",
+        content:
+          "Mission: prove you followed the repo contract.\nEvidence path: AGENT.md -> SOUL.md -> FOLLOWTHROUGH_INPUT.md -> repo-contract-summary.txt",
+      },
+    });
+    const writeSummary = readToolUse(await request());
+    expect(writeSummary.name).toBe("exec");
+    await expectPlan("write", {
+      path: "repo-contract-summary.txt",
+      content:
+        "Mission: prove you followed the repo contract.\nEvidence: AGENT.md -> SOUL.md -> FOLLOWTHROUGH_INPUT.md\nStatus: complete",
+    });
+
+    appendToolResult(writeSummary, {
+      status: "completed",
+      value: "Successfully wrote 146 bytes to repo-contract-summary.txt.",
+    });
+    const final = await request();
+    expect(final.stop_reason).toBe("end_turn");
+    const text = final.content.find((block) => block.type === "text")?.text;
+    expect(text).toBe(
+      "Read: AGENT.md, SOUL.md, FOLLOWTHROUGH_INPUT.md\nWrote: repo-contract-summary.txt\nStatus: complete",
+    );
+  });
+
+  it("routes Anthropic image generation through Code Mode when only exec and wait are visible", async () => {
+    const server = await startMockServer();
+    const response = await postJson(server, "/v1/messages", {
+      model: "claude-opus-4-8",
+      max_tokens: 256,
+      tools: [
+        {
+          name: "exec",
+          input_schema: {
+            type: "object",
+            properties: { code: { type: "string" } },
+            required: ["code"],
+          },
+        },
+        {
+          name: "wait",
+          input_schema: {
+            type: "object",
+            properties: { runId: { type: "string" } },
+            required: ["runId"],
+          },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Capability flip image check: generate a QA lighthouse image in this turn right now.",
+            },
+          ],
+        },
+      ],
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      stop_reason: string;
+      content: Array<Record<string, unknown>>;
+    };
+    expect(body.stop_reason).toBe("tool_use");
+    expect(body.content.find((block) => block.type === "tool_use")?.name).toBe("exec");
+
+    const debug = requireRecord(
+      await fetch(`${server.baseUrl}/debug/last-request`).then((result) => result.json()),
+      "debug request",
+    );
+    expect(debug.plannedToolName).toBe("image_generate");
+    expect(debug.plannedWireToolName).toBe("exec");
+  });
+
+  it("does not route hidden capabilities through ordinary shell exec", async () => {
+    const server = await startMockServer();
+    const response = await postJson(server, "/v1/messages", {
+      model: "claude-opus-4-8",
+      max_tokens: 256,
+      tools: [
+        {
+          name: "exec",
+          input_schema: {
+            type: "object",
+            properties: { command: { type: "string" } },
+            required: ["command"],
+          },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Capability flip image check: generate a QA lighthouse image in this turn right now.",
+            },
+          ],
+        },
+      ],
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      stop_reason: string;
+      content: Array<Record<string, unknown>>;
+    };
+    expect(body.stop_reason).toBe("end_turn");
+    expect(body.content.some((block) => block.type === "tool_use")).toBe(false);
+  });
+
+  it("does not interpret ordinary tool results as Code Mode control envelopes", async () => {
+    const server = await startMockServer();
+    const prompt = "Read the seeded docs and report worked, failed, blocked, and follow-up items.";
+    const tools = [
+      {
+        name: "read",
+        input_schema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+        },
+      },
+      {
+        name: "wait",
+        input_schema: {
+          type: "object",
+          properties: { runId: { type: "string" } },
+          required: ["runId"],
+        },
+      },
+    ];
+    const messages: Array<Record<string, unknown>> = [
+      { role: "user", content: [{ type: "text", text: prompt }] },
+    ];
+    const firstResponse = await postJson(server, "/v1/messages", {
+      model: "claude-opus-4-8",
+      max_tokens: 256,
+      tools,
+      messages,
+    });
+    const firstBody = (await firstResponse.json()) as {
+      content: Array<Record<string, unknown>>;
+    };
+    const readToolUse = firstBody.content.find((block) => block.type === "tool_use");
+    if (!readToolUse || typeof readToolUse.id !== "string") {
+      throw new Error("Expected Anthropic read tool_use block");
+    }
+    messages.push(
+      { role: "assistant", content: [readToolUse] },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: readToolUse.id,
+            content: JSON.stringify({ status: "waiting", runId: "ordinary-read" }),
+          },
+        ],
+      },
+    );
+
+    const response = await postJson(server, "/v1/messages", {
+      model: "claude-opus-4-8",
+      max_tokens: 256,
+      tools,
+      messages,
+    });
+    const body = (await response.json()) as {
+      stop_reason: string;
+      content: Array<Record<string, unknown>>;
+    };
+    expect(body.stop_reason).toBe("end_turn");
+    expect(body.content.some((block) => block.type === "tool_use")).toBe(false);
+  });
+
+  it("does not interpret unmarked direct exec results as Code Mode control envelopes", async () => {
+    const server = await startMockServer();
+    const response = await postJson(server, "/v1/messages", {
+      model: "claude-opus-4-8",
+      max_tokens: 256,
+      tools: [
+        {
+          name: "exec",
+          input_schema: {
+            type: "object",
+            properties: { code: { type: "string" } },
+            required: ["code"],
+          },
+        },
+        {
+          name: "wait",
+          input_schema: {
+            type: "object",
+            properties: { runId: { type: "string" } },
+            required: ["runId"],
+          },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Direct exec envelope isolation check." }],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_direct_exec",
+              name: "exec",
+              input: { language: "javascript", code: "return 1;" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_direct_exec",
+              content: JSON.stringify({ status: "waiting", runId: "direct-exec" }),
+            },
+          ],
+        },
+      ],
+    });
+    const body = (await response.json()) as {
+      stop_reason: string;
+      content: Array<Record<string, unknown>>;
+    };
+    expect(body.stop_reason).toBe("end_turn");
+    expect(body.content.some((block) => block.type === "tool_use")).toBe(false);
+  });
+
+  it("finishes Anthropic Code Mode fanout after the second wrapped spawn result", async () => {
+    const server = await startMockServer();
+    const prompt =
+      "Subagent fanout synthesis check: delegate exactly two bounded subagents sequentially using sessions_spawn, not ACP.";
+    const messages: Array<Record<string, unknown>> = [
+      { role: "user", content: [{ type: "text", text: prompt }] },
+    ];
+    const request = async () => {
+      const response = await postJson(server, "/v1/messages", {
+        model: "claude-opus-4-8",
+        max_tokens: 256,
+        tools: [
+          {
+            name: "exec",
+            input_schema: {
+              type: "object",
+              properties: { code: { type: "string" } },
+              required: ["code"],
+            },
+          },
+          {
+            name: "wait",
+            input_schema: {
+              type: "object",
+              properties: { runId: { type: "string" } },
+              required: ["runId"],
+            },
+          },
+        ],
+        messages,
+      });
+      expect(response.status).toBe(200);
+      return (await response.json()) as {
+        stop_reason: string;
+        content: Array<Record<string, unknown>>;
+      };
+    };
+    const appendCompletedResult = (
+      toolUse: Record<string, unknown>,
+      value: Record<string, unknown>,
+    ) => {
+      messages.push(
+        { role: "assistant", content: [toolUse] },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: toolUse.id,
+              content: JSON.stringify({ status: "completed", value }),
+            },
+          ],
+        },
+      );
+    };
+    const requireToolUse = (
+      body: {
+        stop_reason: string;
+        content: Array<Record<string, unknown>>;
+      },
+      expectedName: string,
+    ) => {
+      expect(body.stop_reason).toBe("tool_use");
+      const toolUse = body.content.find((block) => block.type === "tool_use");
+      if (!toolUse || typeof toolUse.id !== "string") {
+        throw new Error("Expected Anthropic tool_use block");
+      }
+      expect(toolUse.name).toBe(expectedName);
+      return toolUse;
+    };
+    const alpha = requireToolUse(await request(), "exec");
+    appendCompletedResult(alpha, { status: "accepted", childSessionKey: "alpha" });
+    const beta = requireToolUse(await request(), "exec");
+    appendCompletedResult(beta, { status: "accepted", childSessionKey: "beta" });
+    const firstYield = requireToolUse(await request(), "exec");
+    appendCompletedResult(firstYield, { status: "yielded" });
+    messages.push({
+      role: "user",
+      content: [{ type: "text", text: "[Inter-session message]\nALPHA-OK" }],
+    });
+    const secondYield = requireToolUse(await request(), "exec");
+    appendCompletedResult(secondYield, { status: "yielded" });
+    messages.push({
+      role: "user",
+      content: [{ type: "text", text: "[Inter-session message]\nBETA-OK" }],
+    });
+
+    const final = await request();
+    expect(final.stop_reason).toBe("end_turn");
+    expect(final.content.find((block) => block.type === "text")?.text).toBe(
+      "subagent-1: ok\nsubagent-2: ok",
+    );
+  });
+
+  it("finishes Anthropic fanout without sessions_yield when Code Mode is unavailable", async () => {
+    const server = await startMockServer();
+    const prompt =
+      "Subagent fanout synthesis check: delegate exactly two bounded subagents sequentially using sessions_spawn, not ACP.";
+    const messages: Array<Record<string, unknown>> = [
+      { role: "user", content: [{ type: "text", text: prompt }] },
+    ];
+    const request = async () => {
+      const response = await postJson(server, "/v1/messages", {
+        model: "claude-opus-4-8",
+        max_tokens: 256,
+        tools: [
+          {
+            name: "sessions_spawn",
+            input_schema: { type: "object", properties: {} },
+          },
+        ],
+        messages,
+      });
+      return (await response.json()) as {
+        stop_reason: string;
+        content: Array<Record<string, unknown>>;
+      };
+    };
+    const appendResult = (toolUse: Record<string, unknown>, childSessionKey: string) => {
+      messages.push(
+        { role: "assistant", content: [toolUse] },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: toolUse.id,
+              content: JSON.stringify({ status: "accepted", childSessionKey }),
+            },
+          ],
+        },
+      );
+    };
+
+    const alpha = (await request()).content.find((block) => block.type === "tool_use");
+    if (!alpha || typeof alpha.id !== "string") {
+      throw new Error("Expected first Anthropic sessions_spawn tool_use block");
+    }
+    appendResult(alpha, "alpha");
+    const beta = (await request()).content.find((block) => block.type === "tool_use");
+    if (!beta || typeof beta.id !== "string") {
+      throw new Error("Expected second Anthropic sessions_spawn tool_use block");
+    }
+    appendResult(beta, "beta");
+
+    const final = await request();
+    expect(final.stop_reason).toBe("end_turn");
+    expect(final.content.find((block) => block.type === "text")?.text).toBe(
+      "subagent-1: ok\nsubagent-2: ok",
+    );
+  });
+
   it("preserves Anthropic /v1/messages declared tools for explicit sessions_spawn prompts", async () => {
     const server = await startMockServer();
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -146,7 +146,7 @@ import {
   readTargetFromPrompt,
   execCommandFromToolProgressPrompt,
   buildCustomToolCallEventsWithInput,
-  buildToolCallEventsWithArgs,
+  buildToolCallEventsWithArgs as buildRawToolCallEventsWithArgs,
   extractOrbitCode,
   extractToolSearchTarget,
   buildQaToolSearchArgs,
@@ -159,6 +159,7 @@ const QA_STREAMING_TOOL_PROGRESS_FAMILY_PROMPT_RE =
   /(?:partial|quiet) streaming qa check|final-only marker streaming qa check|block streaming qa check|tool progress(?: error)? qa check/i;
 const QA_STREAMING_TOOL_PROGRESS_CONTINUATION_RE =
   /^Continue with (?:the current Matrix QA scenario|the QA scenario plan and report worked, failed, and blocked items)\.$/i;
+const QA_CODE_MODE_TARGET_MARKER = "qa-code-mode-target:";
 
 function isStreamingToolProgressContinuationText(text: string) {
   const trimmed = text.trim();
@@ -193,6 +194,227 @@ function extractLatestScenarioFamilyPrompt(texts: string[]) {
   return latestIndex < 0 ? "" : envelope.slice(latestIndex);
 }
 
+function stringifyScenarioToolOutput(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === undefined) {
+    return "";
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function encodeCodeModeTarget(name: string, args: Record<string, unknown>) {
+  return Buffer.from(JSON.stringify({ name, args }), "utf8").toString("base64url");
+}
+
+function decodeCodeModeTarget(code: string | undefined) {
+  const marker = code
+    ?.split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith(`// ${QA_CODE_MODE_TARGET_MARKER}`));
+  if (!marker) {
+    return null;
+  }
+  try {
+    const encoded = marker.slice(`// ${QA_CODE_MODE_TARGET_MARKER}`.length).trim();
+    const parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    const record = parsed as Record<string, unknown>;
+    if (
+      typeof record.name !== "string" ||
+      !record.args ||
+      typeof record.args !== "object" ||
+      Array.isArray(record.args)
+    ) {
+      return null;
+    }
+    return {
+      name: record.name,
+      args: record.args as Record<string, unknown>,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function findNamedToolDefinition(
+  value: unknown,
+  name: string,
+  depth = 0,
+): Record<string, unknown> | null {
+  if (depth > 6 || !value || typeof value !== "object") {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const match = findNamedToolDefinition(item, name, depth + 1);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.name === name || record.tool === name || record.functionName === name) {
+    return record;
+  }
+  for (const item of Object.values(record)) {
+    const match = findNamedToolDefinition(item, name, depth + 1);
+    if (match) {
+      return match;
+    }
+  }
+  return null;
+}
+
+function hasCodeModeExecSurface(body: Record<string, unknown>) {
+  const tools = [
+    ...(Array.isArray(body.tools) ? body.tools : []),
+    ...(Array.isArray(body.dynamicTools) ? body.dynamicTools : []),
+  ];
+  const execDefinition = findNamedToolDefinition(tools, "exec");
+  if (!execDefinition || !hasToolDefinition(body, "wait")) {
+    return false;
+  }
+  const schema =
+    (execDefinition.input_schema as Record<string, unknown> | undefined) ??
+    (execDefinition.parameters as Record<string, unknown> | undefined);
+  if (!schema) {
+    return false;
+  }
+  const properties = schema.properties;
+  const required = schema.required;
+  return (
+    properties !== null &&
+    typeof properties === "object" &&
+    !Array.isArray(properties) &&
+    Object.hasOwn(properties, "code") &&
+    Array.isArray(required) &&
+    required.includes("code")
+  );
+}
+
+function findToolCallByCallId(input: ResponsesInputItem[], callId: string) {
+  return input.toReversed().find((item) => {
+    const type = item.type;
+    return (type === "function_call" || type === "custom_tool_call") && item.call_id === callId;
+  });
+}
+
+function parseToolCallArguments(toolCall: ResponsesInputItem) {
+  if (typeof toolCall.arguments !== "string") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(toolCall.arguments) as unknown;
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isGeneratedCodeModeExecCall(toolCall: ResponsesInputItem | undefined) {
+  if (!toolCall || toolCall.name !== "exec") {
+    return false;
+  }
+  const args = parseToolCallArguments(toolCall);
+  return typeof args?.code === "string" && decodeCodeModeTarget(args.code) !== null;
+}
+
+function isGeneratedCodeModeWaitCall(input: ResponsesInputItem[], toolCall: ResponsesInputItem) {
+  if (toolCall.name !== "wait") {
+    return false;
+  }
+  const runId = parseToolCallArguments(toolCall)?.runId;
+  if (typeof runId !== "string") {
+    return false;
+  }
+  return input.some((item) => {
+    if (
+      (item.type !== "function_call_output" && item.type !== "custom_tool_call_output") ||
+      typeof item.call_id !== "string"
+    ) {
+      return false;
+    }
+    const output = stringifyScenarioToolOutput(item.output);
+    const parsed = parseToolOutputJson(output);
+    return (
+      parsed?.status === "waiting" &&
+      parsed.runId === runId &&
+      isGeneratedCodeModeExecCall(findToolCallByCallId(input, item.call_id))
+    );
+  });
+}
+
+function isCodeModeControlToolOutput(body: Record<string, unknown>, input: ResponsesInputItem[]) {
+  if (!hasCodeModeExecSurface(body)) {
+    return false;
+  }
+  const toolOutputCallId = extractToolOutputCallId(input);
+  if (!toolOutputCallId) {
+    return false;
+  }
+  const toolCall = findToolCallByCallId(input, toolOutputCallId);
+  return (
+    isGeneratedCodeModeExecCall(toolCall) ||
+    (toolCall ? isGeneratedCodeModeWaitCall(input, toolCall) : false)
+  );
+}
+
+function buildScenarioToolCallEvents(
+  body: Record<string, unknown>,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  // Code Mode hides catalog capabilities behind exec/wait. Route through that
+  // visible surface while retaining the nested capability as debug evidence.
+  if (
+    name === "exec" ||
+    name === "wait" ||
+    hasToolDefinition(body, name) ||
+    !hasCodeModeExecSurface(body)
+  ) {
+    return buildRawToolCallEventsWithArgs(name, args);
+  }
+  const encodedTarget = encodeCodeModeTarget(name, args);
+  return buildRawToolCallEventsWithArgs("exec", {
+    language: "javascript",
+    code: [
+      `// ${QA_CODE_MODE_TARGET_MARKER}${encodedTarget}`,
+      `const targetName = ${JSON.stringify(name)};`,
+      `const targetArgs = ${JSON.stringify(args)};`,
+      "const target = ALL_TOOLS.find((entry) => entry.name === targetName);",
+      "if (!target) throw new Error(`QA mock target tool unavailable: ${targetName}`);",
+      "const value = await tools.callValue(target.id, targetArgs);",
+      'if (targetName === "read" && value?.kind === "text" && typeof value.content === "string") {',
+      "  return { ...value, content: value.content.slice(0, 2048) };",
+      "}",
+      "return value;",
+    ].join("\n"),
+  });
+}
+
+function extractScenarioPlannedTool(events: StreamEvent[]) {
+  const wireName = extractPlannedToolName(events);
+  const wireArgs = extractPlannedToolArgs(events);
+  if (wireName !== "exec" || typeof wireArgs?.code !== "string") {
+    return { name: wireName, args: wireArgs, wireName };
+  }
+  const target = decodeCodeModeTarget(wireArgs.code);
+  return target
+    ? { name: target.name, args: target.args, wireName }
+    : { name: wireName, args: wireArgs, wireName };
+}
+
 async function buildResponsesPayload(
   body: Record<string, unknown>,
   scenarioState: MockScenarioState,
@@ -202,7 +424,16 @@ async function buildResponsesPayload(
   );
   const input = Array.isArray(body.input) ? (body.input as ResponsesInputItem[]) : [];
   const prompt = extractLastUserText(input);
-  const toolOutput = extractToolOutput(input);
+  const rawToolOutput = extractToolOutput(input);
+  const codeModeControlJson = isCodeModeControlToolOutput(body, input)
+    ? parseToolOutputJson(rawToolOutput)
+    : null;
+  const toolOutput =
+    codeModeControlJson?.status === "completed" && Object.hasOwn(codeModeControlJson, "value")
+      ? stringifyScenarioToolOutput(codeModeControlJson.value)
+      : rawToolOutput;
+  const buildToolCallEventsWithArgs = (name: string, args: Record<string, unknown>) =>
+    buildScenarioToolCallEvents(body, name, args);
   const allInputText = extractAllRequestTexts(input, body);
   const scenarioToolOutput =
     toolOutput ||
@@ -212,6 +443,13 @@ async function buildResponsesPayload(
       ? extractLatestToolOutput(input)
       : "");
   const toolJson = parseToolOutputJson(scenarioToolOutput);
+  if (
+    codeModeControlJson?.status === "waiting" &&
+    typeof codeModeControlJson.runId === "string" &&
+    hasToolDefinition(body, "wait")
+  ) {
+    return buildRawToolCallEventsWithArgs("wait", { runId: codeModeControlJson.runId });
+  }
   const memoryToolUnavailable =
     toolJson?.unavailable === true ||
     toolJson?.disabled === true ||
@@ -1204,7 +1442,7 @@ async function buildResponsesPayload(
   if (
     QA_IMAGE_GENERATION_PROMPT_RE.test(allInputText) &&
     !toolOutput &&
-    hasToolDefinition(body, "image_generate")
+    (hasToolDefinition(body, "image_generate") || hasCodeModeExecSurface(body))
   ) {
     return buildToolCallEventsWithArgs("image_generate", {
       prompt: "A QA lighthouse on a dark sea with a tiny protocol droid silhouette.",
@@ -1212,7 +1450,16 @@ async function buildResponsesPayload(
       size: "1024x1024",
     });
   }
-  if (canCallSessionsSpawn && /subagent fanout synthesis check/i.test(allInputText)) {
+  const isSubagentFanoutPrompt = /subagent fanout synthesis check/i.test(allInputText);
+  if (
+    !toolOutput &&
+    /subagent fanout synthesis check/i.test(prompt) &&
+    scenarioState.subagentFanoutPhase !== 0
+  ) {
+    scenarioState.subagentFanoutPhase = 0;
+    scenarioState.subagentFanoutCompletedWorkers.clear();
+  }
+  if (canCallSessionsSpawn && isSubagentFanoutPrompt) {
     if (!toolOutput && scenarioState.subagentFanoutPhase === 0) {
       scenarioState.subagentFanoutPhase = 1;
       return buildToolCallEventsWithArgs("sessions_spawn", {
@@ -1230,9 +1477,26 @@ async function buildResponsesPayload(
       });
     }
   }
-  if (scenarioState.subagentFanoutPhase === 2 && prompt) {
-    scenarioState.subagentFanoutPhase = 3;
-    return buildAssistantEvents("subagent-1: ok\nsubagent-2: ok");
+  if (scenarioState.subagentFanoutPhase === 2) {
+    if (/\bALPHA-OK\b/i.test(allInputText)) {
+      scenarioState.subagentFanoutCompletedWorkers.add("alpha");
+    }
+    if (/\bBETA-OK\b/i.test(allInputText)) {
+      scenarioState.subagentFanoutCompletedWorkers.add("beta");
+    }
+    if (scenarioState.subagentFanoutCompletedWorkers.size === 2) {
+      scenarioState.subagentFanoutPhase = 3;
+      return buildAssistantEvents("subagent-1: ok\nsubagent-2: ok");
+    }
+    if (hasToolDefinition(body, "sessions_yield") || hasCodeModeExecSurface(body)) {
+      return buildToolCallEventsWithArgs("sessions_yield", {
+        message: "Waiting for both QA fanout workers to finish.",
+      });
+    }
+    if (toolOutput) {
+      scenarioState.subagentFanoutPhase = 3;
+      return buildAssistantEvents("subagent-1: ok\nsubagent-2: ok");
+    }
   }
   const explicitSessionsSpawnArgs = buildExplicitSessionsSpawnArgs(prompt);
   if (explicitSessionsSpawnArgs && !toolOutput) {
@@ -1382,6 +1646,7 @@ export async function startQaMockOpenAiServer(params?: {
   const finalOnlyMarkerPauseMs = params?.finalOnlyMarkerPauseMs ?? 1_500;
   const scenarioState: MockScenarioState = {
     anthropicThinkingErrorScenarioKeys: new Set<string>(),
+    subagentFanoutCompletedWorkers: new Set<"alpha" | "beta">(),
     subagentFanoutPhase: 0,
     subagentHandoffSpawned: false,
     toolLoopReadAttempts: 0,
@@ -1422,6 +1687,7 @@ export async function startQaMockOpenAiServer(params?: {
       inflightRequests.delete(inflightRequestId);
     }
     const resolvedModel = typeof request.body.model === "string" ? request.body.model : "";
+    const plannedTool = extractScenarioPlannedTool(events);
     recordRequest({
       raw: request.raw,
       body: request.body,
@@ -1433,8 +1699,11 @@ export async function startQaMockOpenAiServer(params?: {
       providerVariant: resolveProviderVariant(resolvedModel),
       imageInputCount: countImageInputs(input),
       plannedToolCallId: extractPlannedToolCallId(events),
-      plannedToolName: extractPlannedToolName(events),
-      plannedToolArgs: extractPlannedToolArgs(events),
+      plannedToolName: plannedTool.name,
+      ...(plannedTool.wireName && plannedTool.wireName !== plannedTool.name
+        ? { plannedWireToolName: plannedTool.wireName }
+        : {}),
+      plannedToolArgs: plannedTool.args,
       toolOutputCallId: extractToolOutputCallId(input) || undefined,
       ...(extractToolOutputStructuredError(input) ? { toolOutputStructuredError: true } : {}),
     });
@@ -1642,6 +1911,7 @@ export async function startQaMockOpenAiServer(params?: {
           streamEvents,
           model: normalizedModel,
         } = await buildMessagesPayload(body, scenarioState, buildResponsesPayload);
+        const plannedTool = extractScenarioPlannedTool(events);
         // Record the adapted request snapshot so /debug/requests gives the QA
         // suite the same plannedToolName / allInputText / toolOutput signals
         // on the Anthropic route that the OpenAI route already exposes. This
@@ -1658,8 +1928,11 @@ export async function startQaMockOpenAiServer(params?: {
           providerVariant: resolveProviderVariant(normalizedModel),
           imageInputCount: countImageInputs(input),
           plannedToolCallId: extractPlannedToolCallId(events),
-          plannedToolName: extractPlannedToolName(events),
-          plannedToolArgs: extractPlannedToolArgs(events),
+          plannedToolName: plannedTool.name,
+          ...(plannedTool.wireName && plannedTool.wireName !== plannedTool.name
+            ? { plannedWireToolName: plannedTool.wireName }
+            : {}),
+          plannedToolArgs: plannedTool.args,
           toolOutputCallId: extractToolOutputCallId(input) || undefined,
           ...(extractToolOutputStructuredError(input) ? { toolOutputStructuredError: true } : {}),
         });


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation problem where Anthropic parity scenarios could fail when capabilities hidden behind Code Mode were invoked as direct tools, and where the fanout scenario could finalize before both workers settled.

## Why This Change Was Made

The mock provider now routes hidden capabilities through the declared Code Mode `exec` control while preserving the semantic tool name and arguments used by scenario logic and evidence. Fanout waits for both worker completion markers before producing its synthesis, so transcript settlement races cannot turn a valid run into a generic early response.

Owner contract decision: retain the marker encoding as QA-only correlation inside the `code` string. The production Code Mode contract exposes `exec` with required `code`, optional `language`/`restartSafe`, and `wait(runId)`; guest code receives `ALL_TOOLS` plus `tools.callValue`, while control results use `{status:"waiting",runId}` and `{status:"completed",value}`. The mock matches those observable request/result semantics without adding a provider-visible field.

## User Impact

No production runtime behavior changes. Release QA can reliably exercise Anthropic Code Mode parity, including source reads, image generation after config restart, and subagent fanout.

## Evidence

- Focused mock-provider unit suite: 166/166 passed, including ordinary shell/direct `exec` isolation, marker-bound Code Mode result correlation, and no-yield fanout fallback.
- Fanout live QA scenario: 3 independent runs passed.
- Full Anthropic agentic parity pack: 12/12 scenarios passed.
- Exact-head `oxlint`: passed.
- Exact-head extension production typecheck: passed.
- Exact-head extension-test typecheck: passed.
- Hosted PR checks, including Real behavior proof: passed on the final head.
- Remote `check:changed` passed every lane before identifying the `Object.hasOwn` style correction; final remote allocation was unavailable, so the equivalent exact-head lint and typecheck lanes were rerun locally with the existing worktree dependencies.
