### PR TITLE
test(agents): remove redundant path coverage

### DIFF
--- a/src/agents/agent-tools.workspace-paths.test.ts
+++ b/src/agents/agent-tools.workspace-paths.test.ts
@@ -164,53 +164,10 @@ describe("workspace path resolution", () => {
     });
   });
 
-  it("supports multi-edit edits[] payloads", async () => {
-    await withTempDir("openclaw-ws-", async (workspaceDir) => {
-      await withTempDir("openclaw-cwd-", async (otherDir) => {
-        const testFile = "batch.txt";
-        await fs.writeFile(path.join(workspaceDir, testFile), "alpha beta gamma delta", "utf8");
-
-        const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(otherDir);
-        try {
-          const tools = createOpenClawCodingTools({ workspaceDir });
-          const { editTool } = expectReadWriteEditTools(tools);
-
-          await editTool.execute("ws-edit-batch", {
-            path: testFile,
-            edits: [
-              { oldText: "alpha", newText: "ALPHA" },
-              { oldText: "delta", newText: "DELTA" },
-            ],
-          });
-
-          expect(await fs.readFile(path.join(workspaceDir, testFile), "utf8")).toBe(
-            "ALPHA beta gamma DELTA",
-          );
-        } finally {
-          cwdSpy.mockRestore();
-        }
-      });
-    });
-  });
-
   it("defaults exec cwd to workspaceDir when workdir is omitted", async () => {
     await withTempDir("openclaw-ws-", async (workspaceDir) => {
       const execTool = createExecTool(workspaceDir);
       await expectExecCwdResolvesTo(execTool, "ws-exec", { command: "echo ok" }, workspaceDir);
-    });
-  });
-
-  it("lets exec workdir override the workspace default", async () => {
-    await withTempDir("openclaw-ws-", async (workspaceDir) => {
-      await withTempDir("openclaw-override-", async (overrideDir) => {
-        const execTool = createExecTool(workspaceDir);
-        await expectExecCwdResolvesTo(
-          execTool,
-          "ws-exec-override",
-          { command: "echo ok", workdir: overrideDir },
-          overrideDir,
-        );
-      });
     });
   });
 

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -184,28 +184,6 @@ describe("assertSandboxPath", () => {
     },
   );
 
-  it.runIf(process.platform === "win32")(
-    "pins Win32 junction-then-dot-dot to lexical traversal semantics",
-    async () => {
-      const parent = await fs.mkdtemp(path.join(os.tmpdir(), "sandbox-junction-dotdot-"));
-      const root = path.join(parent, "workspace");
-      const outside = path.join(parent, "outside");
-      try {
-        await fs.mkdir(path.join(root, "sub"), { recursive: true });
-        await fs.mkdir(outside);
-        await fs.symlink(root, path.join(root, "sub", "up"), "junction");
-        await fs.writeFile(path.join(outside, "secret.txt"), "outside", "utf8");
-        const attemptedEscape = `${root}\\sub\\up\\..\\outside\\secret.txt`;
-
-        await expect(fs.readFile(attemptedEscape, "utf8")).rejects.toMatchObject({
-          code: "ENOENT",
-        });
-      } finally {
-        await fs.rm(parent, { recursive: true, force: true });
-      }
-    },
-  );
-
   it("accepts not-yet-created and symlinked roots", async () => {
     const parent = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "sandbox-missing-root-")),


### PR DESCRIPTION
## What Problem This Solves

Three agent path tests consumed CI time without adding distinct production coverage: one Windows-only case exercised Node filesystem semantics but never called OpenClaw code, while multi-edit and explicit exec-workdir behavior were already covered by their owning suites.

## Why This Change Was Made

The no-op and redundant cases are removed. Workspace tool assembly still retains focused coverage for relative filesystem paths and the default exec cwd, while edit batching and explicit workdir resolution remain covered directly by the edit and exec-workdir suites.

## User Impact

No runtime behavior changes. The agent test suite is smaller and its remaining cases map more clearly to production contracts.

## Removed Scenario Map

- Windows junction traversal: the removed test only called Node `fs` APIs and never called `assertSandboxPath`. The production Win32 path intentionally returns lexical resolution in `src/agents/sandbox-paths.ts`; the remaining non-Windows `assertSandboxPath` cases exercise OpenClaw's containment checks.
- Multi-edit payloads: direct owner coverage remains in `src/agents/sessions/tools/edit.test.ts` through `preserves real sibling edits beside a fuzzy no-op` and `keeps untouched lines between two separate edits`. The workspace-path suite still covers relative edit assembly.
- Explicit exec workdirs: direct owner coverage remains in `src/agents/bash-tools.exec-workdir.test.ts` through `resolves valid explicit local workdirs` and `uses configured local cwd when workdir is omitted`. The workspace-path suite still covers default workspace cwd wiring.

## Evidence

- rebased onto `origin/main` at `8dd575f986`
- `node scripts/run-vitest.mjs src/agents/agent-tools.workspace-paths.test.ts src/agents/sandbox-paths.test.ts`
  - 50 passed, 1 existing platform-specific test skipped
- targeted `oxfmt --check`: passed
- `git diff --check`: passed
- fresh branch autoreview at `d877f4def0`: clean, 0.94
- Blacksmith Testbox changed gate at `d877f4def0`: passed in 5m12s
  - https://github.com/openclaw/openclaw/actions/runs/30600431665
- net test cleanup: 65 lines removed
