### PR TITLE
fix: media-bearing replies lose code indentation and blank lines

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -287,4 +287,55 @@ describe("splitMediaFromOutput", () => {
       extractMarkdownImages,
     );
   });
+
+  describe("preserves code-block whitespace when media is present (#116458)", () => {
+    const yamlReply = [
+      "Here is the config you asked for.",
+      "",
+      "```yaml",
+      "server:",
+      "  host: 0.0.0.0",
+      "  ports:",
+      "    - 80",
+      "    - 443",
+      "```",
+    ].join("\n");
+
+    it("keeps fenced code indentation and blank lines when a MEDIA: line is present", () => {
+      const input = `${yamlReply}\n\nMEDIA:/tmp/generated.png`;
+      expectParsedMediaOutputCase(input, {
+        text: yamlReply,
+        mediaUrls: ["/tmp/generated.png"],
+      });
+    });
+
+    it("keeps fenced code indentation and blank lines when a markdown image is extracted", () => {
+      const pythonReply = [
+        "Rendered the chart, and here is the code behind it.",
+        "",
+        "```python",
+        "def summarize(results):",
+        "    total = 0",
+        "    for r in results:",
+        '        total += r["value"]',
+        "",
+        "    return total",
+        "```",
+      ].join("\n");
+      const input = `${pythonReply}\n\n![chart](https://example.com/chart.png)`;
+      expectParsedMediaOutputCase(
+        input,
+        {
+          text: pythonReply,
+          mediaUrls: ["https://example.com/chart.png"],
+        },
+        extractMarkdownImages,
+      );
+    });
+
+    it("delivers the media-free control reply byte-for-byte", () => {
+      const input = `${yamlReply}\n`;
+      expectParsedMediaOutputCase(input, { text: yamlReply, mediaUrls: undefined });
+    });
+  });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -12,6 +12,7 @@ import {
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { expectDefined } from "@openclaw/normalization-core";
 import { parseFenceSpans } from "../../packages/markdown-core/src/fences.js";
+import { normalizeDirectiveWhitespace } from "../utils/directive-tags.js";
 import { parseAudioTag } from "./audio-tags.js";
 
 /** Captures legacy MEDIA: attachment directives from model/tool output. */
@@ -687,12 +688,10 @@ export function splitMediaFromOutput(
     lineOffset += line.length + 1; // +1 for newline
   }
 
-  let cleanedText = keptLines
-    .join("\n")
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/[ \t]{2,}/g, " ")
-    .replace(/\n{2,}/g, "\n")
-    .trim();
+  // Reuse the code-block-aware normalizer from directive-tags instead of the
+  // prose-only collapse below (which flattened indentation inside fenced blocks
+  // and deleted every blank line whenever a media token was present).
+  let cleanedText = normalizeDirectiveWhitespace(keptLines.join("\n"));
 
   // Detect and strip [[audio_as_voice]] tag
   const audioTagResult = parseAudioTag(cleanedText);

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -40,7 +40,7 @@ function createBlockSentinel(text: string): string {
   return sentinel;
 }
 
-function normalizeDirectiveWhitespace(text: string): string {
+export function normalizeDirectiveWhitespace(text: string): string {
   // Extract → normalize prose → restore:
   // Stash every code block (fenced ``` / ~~~ and indent-code 4-space/tab)
   // under a sentinel-delimited placeholder so the prose regexes never touch them.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users whose assistant reply also carries media — an image/voice attachment via the `MEDIA:` directive on any channel, or a markdown image on Telegram — would receive mangled visible text: every indent level inside fenced code blocks collapses to a single space and every blank line is deleted, so Python/YAML/JSON snippets become semantically different and are no longer runnable or pasteable. The byte-identical reply without media is delivered untouched, which is why this regression survived the April fixes (#41215 / #41222). See #116458.

## Why This Change Was Made

`splitMediaFromOutput` reassembled the visible text with a prose-only normalizer that had no code-block awareness — four `.replace()` calls that collapse runs of 2+ spaces and 2+ newlines. The repo already owns the correct code-block-aware normalizer: `normalizeDirectiveWhitespace` in `src/utils/directive-tags.ts` masks fenced (``` / ~~~) and indent-code (4-space/tab) blocks behind sentinels, only collapses horizontal runs between non-space characters, and folds `\n{3,}` to `\n\n` so paragraph breaks survive. This change exports that function and calls it in place of the four `.replace()` calls — delete-plus-reuse rather than new logic, matching the intent of the dropped media-parser half of PR #41222.

## User Impact

Media-bearing replies now deliver their visible text with code-block indentation and blank lines intact, exactly like the no-media control. Replies containing fenced code plus an image/voice attachment are runnable and pasteable on every channel and in the persisted gateway chat transcript, instead of being silently flattened.

## Evidence

### Inline verification — real `splitMediaFromOutput` runs, before vs after

`````text
=== BEFORE (origin/main 23dbee9e3, buggy) ===
===== CASE A: MEDIA: directive reply (extractMediaDirectives defaults on) =====
INPUT  lines=11 blank=2
OUTPUT lines=8 blank=0
yaml indent preserved: false
--- delivered payload.text ---
Here is the config you asked for.
```yaml
server:
 host: 0.0.0.0
 ports:
 - 80
 - 443
```

===== CASE B: Telegram markdown-image reply (extractMarkdownImages: true) =====
INPUT  lines=12 blank=3
OUTPUT lines=8 blank=0
python indent preserved: false
--- delivered payload.text ---
Rendered the chart, and here is the code behind it.
```python
def summarize(results):
 total = 0
 for r in results:
 total += r["value"]
 return total
```

===== CASE C: no-media control (byte-identical reply without media) =====
PRESERVED BYTE-FOR-BYTE: true
`````

`````text
=== AFTER (this fix) ===
===== CASE A: MEDIA: directive reply =====
INPUT  lines=11 blank=2
OUTPUT lines=9 blank=1
yaml indent preserved: true
--- delivered payload.text ---
Here is the config you asked for.

```yaml
server:
  host: 0.0.0.0
  ports:
    - 80
    - 443
```

===== CASE B: Telegram markdown-image reply =====
INPUT  lines=12 blank=3
OUTPUT lines=10 blank=2
python indent preserved: true
--- delivered payload.text ---
Rendered the chart, and here is the code behind it.

```python
def summarize(results):
    total = 0
    for r in results:
        total += r["value"]

    return total
```

===== CASE C: no-media control =====
PRESERVED BYTE-FOR-BYTE: true
`````

### Unit tests (project runner)

`````text
$ node scripts/run-vitest.mjs src/media/parse.test.ts src/utils/directive-tags.test.ts
 ✓ |unit-fast| src/media/parse.test.ts (64 tests) 30ms
 ✓ |unit-fast| src/utils/directive-tags.test.ts (32 tests) 8ms
 Test Files  2 passed (2)
      Tests  96 passed (96)

$ node scripts/run-vitest.mjs src/agents/tools/image-generate-tool.test.ts
 ✓ |agents-tools| src/agents/tools/image-generate-tool.test.ts (57 tests)
 Test Files  1 passed (1)
      Tests  57 passed (57)
`````

New regression tests in `src/media/parse.test.ts` cover: fenced YAML block + `MEDIA:` line, fenced Python block + extracted markdown image, and the no-media byte-for-byte control.

[AI-assisted]
