### PR TITLE
fix: resolve explicit main aliases to the configured session

### DIFF
--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -15,6 +15,7 @@ import {
   resolveSessionLifecycleTimestamps,
 } from "../../config/sessions/lifecycle.js";
 import {
+  canonicalizeMainSessionAlias,
   resolveAgentIdFromSessionKey,
   resolveExplicitAgentSessionKey,
 } from "../../config/sessions/main-session.js";
@@ -264,7 +265,13 @@ export function resolveSessionKeyForRequest(opts: {
 
   const ctx: MsgContext | undefined = opts.to?.trim() ? { From: opts.to } : undefined;
   let sessionKey: string | undefined =
-    explicitSessionKey ?? (ctx ? resolveSessionKey(scope, ctx, mainKey, storeAgentId) : undefined);
+    (explicitSessionKey
+      ? canonicalizeMainSessionAlias({
+          cfg: opts.cfg,
+          agentId: storeAgentId,
+          sessionKey: explicitSessionKey,
+        })
+      : undefined) ?? (ctx ? resolveSessionKey(scope, ctx, mainKey, storeAgentId) : undefined);
 
   // Entrypoint migration owners canonicalize legacy state before runtime reads. A missing target
   // row is not evidence that another agent's main session belongs to the configured default agent.

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -145,7 +145,7 @@ describe("agent session resolution", () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");
       await writeSessionStoreSeed(store, {
-        main: {
+        "agent:main:main": {
           sessionId: "origin-provider-reset",
           updatedAt: Date.now() - 30 * 60_000,
           delivery: normalizeSessionDeliveryState({
@@ -175,35 +175,40 @@ describe("agent session resolution", () => {
       {
         label: "canonical done main",
         mainKey: "main",
-        sessionKey: "agent:main:main",
+        requestedSessionKey: "agent:main:main",
+        storedSessionKey: "agent:main:main",
         status: "done" as const,
         expectNewSession: false,
       },
       {
         label: "raw done main alias",
         mainKey: "main",
-        sessionKey: "main",
+        requestedSessionKey: "main",
+        storedSessionKey: "agent:main:main",
         status: "done" as const,
         expectNewSession: false,
       },
       {
         label: "custom done main alias",
         mainKey: "work",
-        sessionKey: "agent:main:main",
+        requestedSessionKey: "agent:main:main",
+        storedSessionKey: "agent:main:work",
         status: "done" as const,
         expectNewSession: false,
       },
       {
         label: "killed main",
         mainKey: "main",
-        sessionKey: "agent:main:main",
+        requestedSessionKey: "agent:main:main",
+        storedSessionKey: "agent:main:main",
         status: "killed" as const,
         expectNewSession: true,
       },
       {
         label: "endedAt-only main",
         mainKey: "main",
-        sessionKey: "agent:main:main",
+        requestedSessionKey: "agent:main:main",
+        storedSessionKey: "agent:main:main",
         status: undefined,
         expectNewSession: true,
       },
@@ -215,7 +220,7 @@ describe("agent session resolution", () => {
         const sessionId = `stale-terminal-${scenario.label.replaceAll(" ", "-")}`;
         const registryUpdatedAt = Date.now() - 10_000;
         await writeSessionStoreSeed(store, {
-          [scenario.sessionKey]: {
+          [scenario.storedSessionKey]: {
             sessionId,
             sessionFile,
             updatedAt: registryUpdatedAt,
@@ -239,7 +244,7 @@ describe("agent session resolution", () => {
           {
             agentId: "main",
             sessionId,
-            sessionKey: scenario.sessionKey,
+            sessionKey: scenario.storedSessionKey,
             storePath: store,
           },
           { type: "custom", timestamp: "1970-01-01T00:00:00.001Z" },
@@ -247,8 +252,9 @@ describe("agent session resolution", () => {
         const cfg = mockConfig(home, store);
         cfg.session = { ...cfg.session, mainKey: scenario.mainKey };
 
-        const resolution = resolveSession({ cfg, sessionKey: scenario.sessionKey });
+        const resolution = resolveSession({ cfg, sessionKey: scenario.requestedSessionKey });
 
+        expect(resolution.sessionKey).toBe(scenario.storedSessionKey);
         expect(resolution.isNewSession).toBe(scenario.expectNewSession);
         if (!scenario.expectNewSession) {
           expect(resolution.sessionId).toBe(sessionId);

--- a/src/commands/agent/session.test.ts
+++ b/src/commands/agent/session.test.ts
@@ -127,6 +127,25 @@ describe("resolveSessionKeyForRequest", () => {
     expect(result.storePath).toBe(MYBOT_STORE_PATH);
   });
 
+  it("canonicalizes an explicit main alias for the selected agent", () => {
+    setupMainAndMybotStorePaths();
+    mockStoresByPath({
+      [MAIN_STORE_PATH]: {},
+      [MYBOT_STORE_PATH]: {},
+    });
+
+    const result = resolveSessionKeyForRequest({
+      cfg: {
+        agents: { list: [{ id: "mybot", default: true }] },
+        session: { mainKey: "work" },
+      } satisfies OpenClawConfig,
+      sessionKey: "main",
+    });
+
+    expect(result.sessionKey).toBe("agent:mybot:work");
+    expect(result.storePath).toBe(MYBOT_STORE_PATH);
+  });
+
   it("does not adopt another agent's main session for a default-agent request", () => {
     setupMainAndMybotStorePaths();
     const mainStore = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where commands that supplied the explicit `main` session alias could target the raw alias instead of the configured agent's canonical main session, especially when the default agent or main key was customized.

## Why This Change Was Made

The command resolver now passes explicit keys through the existing main-session canonicalization owner after selecting the backing agent store. This keeps one alias policy and leaves non-main explicit session keys unchanged.

## User Impact

Explicit main-session commands consistently resume the configured agent's canonical main session instead of opening or looking up an alias-shaped key.

## Evidence

- Blacksmith Testbox focused run [30600444291](https://github.com/openclaw/openclaw/actions/runs/30600444291): 24 tests passed across the command integration and resolver suites.
- Blacksmith Testbox changed gate [30600504998](https://github.com/openclaw/openclaw/actions/runs/30600504998): formatting, typechecks, lint, architecture, database-first, and related guards passed.
- The first CI head exposed two integration fixtures that still persisted raw alias keys. They now persist canonical keys while issuing alias-form requests, preserving coverage for default and custom main keys.
- Exact-head CI [30600863799](https://github.com/openclaw/openclaw/actions/runs/30600863799) attempt 2 passed. The SQLite flip-proof flake from attempt 1 also passed independently on the same head in Testbox run [30600996164](https://github.com/openclaw/openclaw/actions/runs/30600996164).
- Uncommitted and final rebased branch autoreview: no accepted/actionable findings.

### ClawSweeper moves

- The maintainer work order explicitly confirms that `main` is an alias and that persisted canonical keys are authoritative. All command entry points in scope converge on `resolveSessionKeyForRequest`, so the existing canonicalization owner now applies consistently.
- The branch remains mergeable, exact-head CI is green, and no files changed on `main` since the reviewed merge base overlap this PR's three files. I am leaving the head stable so the repository landing wrapper can perform its current-main test-merge check instead of invalidating the completed exact-head matrix for unrelated drift.
