### PR TITLE
docs(locks): correct stale fs-safe 0.4 reentrancy comments

### DIFF
--- a/extensions/whatsapp/src/connection-owner.ts
+++ b/extensions/whatsapp/src/connection-owner.ts
@@ -134,8 +134,10 @@ async function acquireOwnerLease(params: {
   const resolvedOwnerPath = resolveUserPath(params.authDir);
   await fs.mkdir(resolvedOwnerPath, { recursive: true });
   const ownerPath = await fs.realpath(resolvedOwnerPath);
-  // Reserve before awaiting the filesystem so concurrent callers cannot use the
-  // underlying file lock's intentionally re-entrant mode for two sockets.
+  // Reserve before awaiting the filesystem so concurrent local callers queue
+  // here instead of contending on the sidecar. The file lock (fs-safe 0.5) is
+  // non-reentrant without an owner key: a second same-process acquire would
+  // retry against our own hold until file_lock_timeout, not fail fast.
   const processOwner = await reserveProcessOwner({
     authDir: params.authDir,
     ownerPath,

--- a/src/plugin-sdk/memory-host-core.ts
+++ b/src/plugin-sdk/memory-host-core.ts
@@ -261,8 +261,12 @@ async function materializeMemoryHostEventExport(params: {
   });
   const workspaceKey = workspaceRoot.rootReal;
   const owner = await resolveMemoryHostEventExportOwner(workspaceKey);
-  // The queue handles re-entrant calls in this process; the sidecar lock makes
-  // snapshot, cleanup, and replacement one ordered operation across processes.
+  // The queue serializes concurrent exporters in this process; the sidecar
+  // lock makes snapshot, cleanup, and replacement one ordered operation across
+  // processes. Neither is re-entrant: a same-key enqueue from inside the task
+  // awaits its own tail forever, and the file lock (fs-safe 0.5) spins to
+  // file_lock_timeout without a matching reentrantOwner — never re-enter the
+  // export path from inside this callback.
   // State-qualified paths keep different profiles from replacing each other's export.
   return memoryHostEventExportQueue.enqueue(owner.queueKey, async () => {
     const absolutePath = path.join(workspaceKey, ...owner.relativePath.split("/"));


### PR DESCRIPTION
## Problem

`refactor(fs): adopt fs-safe 0.5 core primitives` (#113705) removed `allowReentrant` from the file-lock primitive. Two comments in the tree still describe the deleted semantics, and both sit directly above the guard that is now the *only* thing preventing a same-process self-deadlock — so a reader who trusts the comment would reasonably conclude the guard is a nicety and remove or bypass it.

**`src/plugin-sdk/memory-host-core.ts:261`** claimed "The queue handles re-entrant calls in this process." It does not. `memoryHostEventExportQueue` is a keyed serializer: a same-key `enqueue` issued from *inside* a running task awaits its own tail and never resolves. The file lock underneath no longer has a re-entrant mode either — without a matching `reentrantOwner` it spins to `file_lock_timeout`.

**`extensions/whatsapp/src/connection-owner.ts:134`** referenced the file lock's "intentionally re-entrant mode" as the hazard the reservation guards against. That mode no longer exists; the actual behavior a second same-process acquire gets today is a retry loop against our own hold until `file_lock_timeout`, not a fast failure and not a shared re-entrant hold.

Both comments now state the contract the guard actually protects, and name the failure mode a reader would otherwise have to discover the hard way.

## Change

Comment-only. Two files, +10/−4. No behavior change, no API change, no test change.

## Real behavior proof

Not applicable, and I would rather say so than manufacture one: this diff contains no executable change, so there is no runtime behavior to prove. The claim being corrected is verifiable statically — `allowReentrant` is absent from the fs-safe 0.5 surface adopted in #113705, and `KeyedQueue.enqueue` has no re-entrancy escape.

The substantive finding behind it came from an fs-safe 0.5 lock-reentrancy audit prompted by a real production deadlock: a reentrant write path re-acquired a binding file lock and produced `file lock timeout` failovers at 75–106 s, several hundred per hour, on a live gateway. That fix is separate; this PR is the documentation debt the audit surfaced along the way, split out so the behavioral change and the comment correction can be reviewed independently.

## Validation

`pnpm tsgo:core`, `pnpm tsgo:extensions` clean. `oxlint` clean on both files. `git diff --check` clean. No tests touched — none exercise these comments.

---

*Written by Tank (Claude), an AI agent operated by Eddie Abrams (zeroaltitude).*
