### PR TITLE
fix(docker): keep custom-port containers healthy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -381,6 +381,6 @@ USER node
 #   - aliases: /health and /ready
 # For external access from host/ingress, override bind to "lan" and set auth.
 HEALTHCHECK --interval=3m --timeout=10s --start-period=15s --retries=3 \
-  CMD node -e "fetch('http://127.0.0.1:18789/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+  CMD ["node", "dist/docker-healthcheck.js"]
 ENTRYPOINT ["tini", "-s", "--"]
 CMD ["node", "openclaw.mjs", "gateway"]

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -103,6 +103,8 @@ const rootEntries = [
   "openclaw.mjs!",
   "src/index.ts!",
   "src/entry.ts!",
+  // Built as the official image's Docker HEALTHCHECK entrypoint.
+  "src/docker-healthcheck.ts!",
   // Shipped compatibility facade for statusCommand and getStatusSummary.
   "src/commands/status.ts!",
   "src/cli/daemon-cli.ts!",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,8 +81,7 @@ services:
         [
           "CMD",
           "node",
-          "-e",
-          "fetch('http://127.0.0.1:18789/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+          "dist/docker-healthcheck.js",
         ]
       interval: 30s
       timeout: 5s

--- a/src/docker-healthcheck.test.ts
+++ b/src/docker-healthcheck.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeDockerGatewayHealth, resolveDockerHealthcheckPort } from "./docker-healthcheck.js";
+
+describe("Docker healthcheck", () => {
+  it("prefers the active Gateway lock port used by --port", async () => {
+    const loadConfig = vi.fn(() => ({ gateway: { port: 19002 } }));
+    const resolveGatewayPort = vi.fn(() => 19003);
+
+    await expect(
+      resolveDockerHealthcheckPort({
+        env: { OPENCLAW_GATEWAY_PORT: "19001" },
+        loadConfig,
+        readActiveGatewayLockPort: vi.fn(async () => 19000),
+        resolveGatewayPort,
+      }),
+    ).resolves.toBe(19000);
+    expect(loadConfig).not.toHaveBeenCalled();
+    expect(resolveGatewayPort).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "environment",
+      env: { OPENCLAW_GATEWAY_PORT: "19001" },
+      config: { gateway: { port: 19002 } },
+      expected: 19001,
+    },
+    {
+      name: "config",
+      env: {},
+      config: { gateway: { port: 19002 } },
+      expected: 19002,
+    },
+  ])("falls back to the canonical $name port", async ({ env, config, expected }) => {
+    await expect(
+      resolveDockerHealthcheckPort({
+        env,
+        loadConfig: () => config,
+        readActiveGatewayLockPort: vi.fn(async () => undefined),
+      }),
+    ).resolves.toBe(expected);
+  });
+
+  it("falls back to config when the active lock cannot be read", async () => {
+    await expect(
+      resolveDockerHealthcheckPort({
+        env: {},
+        loadConfig: () => ({ gateway: { port: 19002 } }),
+        readActiveGatewayLockPort: vi.fn(async () => {
+          throw new Error("lock unavailable");
+        }),
+        resolveGatewayPort: (config) => config.gateway?.port ?? 18789,
+      }),
+    ).resolves.toBe(19002);
+  });
+
+  it("probes the unauthenticated liveness endpoint on the resolved port", async () => {
+    const fetch = vi.fn(async () => ({ ok: true }) as Response);
+
+    await expect(
+      probeDockerGatewayHealth({
+        env: {},
+        fetch,
+        loadConfig: () => ({ gateway: { port: 19002 } }),
+        readActiveGatewayLockPort: vi.fn(async () => 19000),
+        resolveGatewayPort: vi.fn(() => 19002),
+      }),
+    ).resolves.toBe(true);
+    expect(fetch).toHaveBeenCalledWith("http://127.0.0.1:19000/healthz");
+  });
+
+  it("reports an unsuccessful or unreachable liveness endpoint as unhealthy", async () => {
+    const baseDeps = {
+      env: {},
+      loadConfig: () => ({ gateway: { port: 19002 } }),
+      readActiveGatewayLockPort: vi.fn(async () => 19000),
+      resolveGatewayPort: vi.fn(() => 19002),
+    };
+
+    await expect(
+      probeDockerGatewayHealth({
+        ...baseDeps,
+        fetch: vi.fn(async () => ({ ok: false }) as Response),
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      probeDockerGatewayHealth({
+        ...baseDeps,
+        fetch: vi.fn(async () => {
+          throw new Error("connection refused");
+        }),
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/docker-healthcheck.test.ts
+++ b/src/docker-healthcheck.test.ts
@@ -3,18 +3,18 @@ import { probeDockerGatewayHealth, resolveDockerHealthcheckPort } from "./docker
 
 describe("Docker healthcheck", () => {
   it("prefers the active Gateway lock port used by --port", async () => {
-    const loadConfig = vi.fn(() => ({ gateway: { port: 19002 } }));
+    const getRuntimeConfig = vi.fn(() => ({ gateway: { port: 19002 } }));
     const resolveGatewayPort = vi.fn(() => 19003);
 
     await expect(
       resolveDockerHealthcheckPort({
         env: { OPENCLAW_GATEWAY_PORT: "19001" },
-        loadConfig,
+        getRuntimeConfig,
         readActiveGatewayLockPort: vi.fn(async () => 19000),
         resolveGatewayPort,
       }),
     ).resolves.toBe(19000);
-    expect(loadConfig).not.toHaveBeenCalled();
+    expect(getRuntimeConfig).not.toHaveBeenCalled();
     expect(resolveGatewayPort).not.toHaveBeenCalled();
   });
 
@@ -35,7 +35,7 @@ describe("Docker healthcheck", () => {
     await expect(
       resolveDockerHealthcheckPort({
         env,
-        loadConfig: () => config,
+        getRuntimeConfig: () => config,
         readActiveGatewayLockPort: vi.fn(async () => undefined),
       }),
     ).resolves.toBe(expected);
@@ -45,7 +45,7 @@ describe("Docker healthcheck", () => {
     await expect(
       resolveDockerHealthcheckPort({
         env: {},
-        loadConfig: () => ({ gateway: { port: 19002 } }),
+        getRuntimeConfig: () => ({ gateway: { port: 19002 } }),
         readActiveGatewayLockPort: vi.fn(async () => {
           throw new Error("lock unavailable");
         }),
@@ -61,7 +61,7 @@ describe("Docker healthcheck", () => {
       probeDockerGatewayHealth({
         env: {},
         fetch,
-        loadConfig: () => ({ gateway: { port: 19002 } }),
+        getRuntimeConfig: () => ({ gateway: { port: 19002 } }),
         readActiveGatewayLockPort: vi.fn(async () => 19000),
         resolveGatewayPort: vi.fn(() => 19002),
       }),
@@ -72,7 +72,7 @@ describe("Docker healthcheck", () => {
   it("reports an unsuccessful or unreachable liveness endpoint as unhealthy", async () => {
     const baseDeps = {
       env: {},
-      loadConfig: () => ({ gateway: { port: 19002 } }),
+      getRuntimeConfig: () => ({ gateway: { port: 19002 } }),
       readActiveGatewayLockPort: vi.fn(async () => 19000),
       resolveGatewayPort: vi.fn(() => 19002),
     };

--- a/src/docker-healthcheck.ts
+++ b/src/docker-healthcheck.ts
@@ -1,0 +1,67 @@
+// Resolves and probes the Gateway port for the official Docker image healthcheck.
+import { fileURLToPath } from "node:url";
+import { loadConfig } from "./config/config.js";
+import { resolveGatewayPort } from "./config/paths.js";
+import type { OpenClawConfig } from "./config/types.js";
+import { readActiveGatewayLockPort } from "./infra/gateway-lock.js";
+import { isMainModule } from "./infra/is-main.js";
+
+type DockerHealthcheckPortDeps = {
+  env: NodeJS.ProcessEnv;
+  loadConfig: () => OpenClawConfig;
+  readActiveGatewayLockPort: (opts: { env: NodeJS.ProcessEnv }) => Promise<number | undefined>;
+  resolveGatewayPort: (config: OpenClawConfig, env: NodeJS.ProcessEnv) => number;
+};
+
+type DockerHealthcheckDeps = Partial<DockerHealthcheckPortDeps> & {
+  fetch?: typeof globalThis.fetch;
+};
+
+export async function resolveDockerHealthcheckPort(
+  deps: Partial<DockerHealthcheckPortDeps> = {},
+): Promise<number> {
+  const env = deps.env ?? process.env;
+  const readActivePort = deps.readActiveGatewayLockPort ?? readActiveGatewayLockPort;
+
+  try {
+    // The live lock records CLI --port and is authoritative. Config/env only cover startup
+    // before the Gateway has acquired its lock or platforms where the owner cannot be verified.
+    const activePort = await readActivePort({ env });
+    if (activePort !== undefined) {
+      return activePort;
+    }
+  } catch {
+    // A best-effort lock read must not hide a healthy Gateway on the configured port.
+  }
+
+  const config = (
+    deps.loadConfig ??
+    (() =>
+      loadConfig({
+        pin: false,
+        skipPluginValidation: true,
+        skipShellEnvFallback: true,
+      }))
+  )();
+  return (deps.resolveGatewayPort ?? resolveGatewayPort)(config, env);
+}
+
+export async function probeDockerGatewayHealth(deps: DockerHealthcheckDeps = {}): Promise<boolean> {
+  try {
+    const port = await resolveDockerHealthcheckPort(deps);
+    const response = await (deps.fetch ?? globalThis.fetch)(`http://127.0.0.1:${port}/healthz`);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+if (
+  isMainModule({
+    currentFile: fileURLToPath(import.meta.url),
+  })
+) {
+  void probeDockerGatewayHealth().then((healthy) => {
+    process.exitCode = healthy ? 0 : 1;
+  });
+}

--- a/src/docker-healthcheck.ts
+++ b/src/docker-healthcheck.ts
@@ -1,6 +1,6 @@
 // Resolves and probes the Gateway port for the official Docker image healthcheck.
 import { fileURLToPath } from "node:url";
-import { loadConfig } from "./config/config.js";
+import { getRuntimeConfig } from "./config/config.js";
 import { resolveGatewayPort } from "./config/paths.js";
 import type { OpenClawConfig } from "./config/types.js";
 import { readActiveGatewayLockPort } from "./infra/gateway-lock.js";
@@ -8,7 +8,7 @@ import { isMainModule } from "./infra/is-main.js";
 
 type DockerHealthcheckPortDeps = {
   env: NodeJS.ProcessEnv;
-  loadConfig: () => OpenClawConfig;
+  getRuntimeConfig: () => OpenClawConfig;
   readActiveGatewayLockPort: (opts: { env: NodeJS.ProcessEnv }) => Promise<number | undefined>;
   resolveGatewayPort: (config: OpenClawConfig, env: NodeJS.ProcessEnv) => number;
 };
@@ -35,9 +35,9 @@ export async function resolveDockerHealthcheckPort(
   }
 
   const config = (
-    deps.loadConfig ??
+    deps.getRuntimeConfig ??
     (() =>
-      loadConfig({
+      getRuntimeConfig({
         pin: false,
         skipPluginValidation: true,
         skipShellEnvFallback: true,

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
+const dockerComposePath = join(repoRoot, "docker-compose.yml");
 const dockerInstallDocsPath = join(repoRoot, "docs/install/docker.md");
 const dockerReleaseWorkflowPath = join(repoRoot, ".github/workflows/docker-release.yml");
 const fullReleaseValidationWorkflowPath = join(
@@ -35,6 +36,16 @@ function resolveOptionalAptPackages(dockerfile: string, env: NodeJS.ProcessEnv):
 }
 
 describe("Dockerfile", () => {
+  it("runs the built port-aware Gateway liveness probe", async () => {
+    const dockerfile = collapseDockerContinuations(await readFile(dockerfilePath, "utf8"));
+    const compose = await readFile(dockerComposePath, "utf8");
+
+    expect(dockerfile).toContain('CMD ["node", "dist/docker-healthcheck.js"]');
+    expect(dockerfile).not.toContain("127.0.0.1:18789/healthz");
+    expect(compose).toContain('"dist/docker-healthcheck.js"');
+    expect(compose).not.toContain("127.0.0.1:18789/healthz");
+  });
+
   it("does not force an external Dockerfile frontend pull", async () => {
     for (const path of dockerSetupDockerfilePaths) {
       const dockerfile = await readFile(join(repoRoot, path), "utf8");

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -108,6 +108,7 @@ describe("tsdown config", () => {
       "media-understanding/apply.runtime",
       "index",
       "commands/status.summary.runtime",
+      "docker-healthcheck",
       "provider-dispatcher.runtime",
       "plugins/hook-runner-global",
       "plugins/provider-discovery.runtime",
@@ -122,6 +123,12 @@ describe("tsdown config", () => {
     ]) {
       expect(keys).toContain(entry);
     }
+  });
+
+  it("builds the Docker healthcheck as a stable dist entry", () => {
+    const distGraph = requireUnifiedDistGraph();
+
+    expect(entrySources(distGraph)["docker-healthcheck"]).toBe("src/docker-healthcheck.ts");
   });
 
   it("keeps root-package-excluded external plugins out of the root dist graph", () => {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -272,6 +272,7 @@ function buildCoreDistEntries(): Record<string, string> {
   return {
     index: "src/index.ts",
     entry: "src/entry.ts",
+    "docker-healthcheck": "src/docker-healthcheck.ts",
     // Ensure this module is bundled as an entry so legacy CLI shims can resolve its exports.
     "cli/daemon-cli": "src/cli/daemon-cli.ts",
     // Keep long-lived lazy runtime boundaries on stable filenames so rebuilt


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running the official Docker image on a non-default Gateway port would see the container become `unhealthy` even though the Gateway was serving normally. The image and Compose healthchecks always probed port `18789`, ignoring `--port`, `OPENCLAW_GATEWAY_PORT`, and `gateway.port`.

## Why This Change Was Made

The image now runs a small built healthcheck entrypoint that first reads the verified live Gateway lock, which preserves the highest-precedence CLI `--port`, and otherwise falls back to the canonical environment/config/default port resolver. Both the Dockerfile and Compose use that same entrypoint, so the two shipped container paths cannot drift.

The probe remains loopback-only and uses the existing unauthenticated `/healthz` liveness endpoint. It does not change the Gateway port, bind, auth, readiness, or configuration contracts.

## User Impact

Official OpenClaw containers now remain healthy when the Gateway listens on a custom port selected through the CLI, environment, or config file. Default-port containers behave as before.

## Evidence

- Focused Vitest: 61/61 passed across the port resolver/probe, Dockerfile/Compose contract, stable dist-entry coverage, and deprecated-config API guard.
- CI-repair Testbox: [`30601241377`](https://github.com/openclaw/openclaw/actions/runs/30601241377) passed the 61 focused tests, deprecated API usage guard, and both production Knip scans. The wrapper completed with exit 0 on `tbx_01kyv2w4e31c5zgrk3f0w1epqe`; the hosted Testbox workflow may show cancelled after the successful SSH command because the one-shot lease was stopped normally.
- Targeted oxlint, oxfmt check, Compose YAML parse, and `git diff --check`: passed.
- Fresh full-branch Codex autoreview on `c332d5290e4b8afe322e598010110ca7f5338f69`: clean, confidence 0.88. The focused CI-repair delta review was also clean at 0.96.
- Real official-image proof on Blacksmith Testbox: [`30599744865`](https://github.com/openclaw/openclaw/actions/runs/30599744865). Containers reached Docker `healthy` with CLI port `19090`, environment port `19091`, and config port `19092`. The delegated command completed successfully; the hosting workflow shows cancelled only because the kept Testbox lease was stopped after the SSH proof completed.
- Regression provenance: the Dockerfile hardcoded probe was introduced by #11478; the Compose probe was introduced with the health endpoints in #31272.

Release-note context: Docker healthchecks now follow the Gateway's active custom port instead of always probing `18789`.

## Maintainer Decision

The repository owner explicitly authorized landing high-confidence fixes from this QA campaign. This branch is intentionally not rebased merely because `main` advanced: the repo-native `scripts/pr` merge flow will verify the exact reviewed head against current `main` and stop on any conflict or merge-critical drift. Exact-head CI is running on `c332d5290e4b8afe322e598010110ca7f5338f69`.
