### PR TITLE
fix(agents): preserve tool-call pairing after mid-turn abort

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1668,6 +1668,201 @@ describe("agentLoop tool termination", () => {
     expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
 
+  it("emits aborted tool results for skipped tool calls on sequential abort (#116379)", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-first", name: "first_tool", arguments: {} },
+          { type: "toolCall", id: "call-second", name: "second_tool", arguments: {} },
+          { type: "toolCall", id: "call-third", name: "third_tool", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const firstTool: AgentTool = {
+      name: "first_tool",
+      label: "first_tool",
+      description: "Aborts the run mid-batch",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      executionMode: "sequential",
+      execute: async () => {
+        controller.abort(new Error("user aborted"));
+        return {
+          content: [{ type: "text", text: "first ran" }],
+          details: { aborted: true },
+        };
+      },
+    };
+    const skippedTool: AgentTool = {
+      name: "second_tool",
+      label: "second_tool",
+      description: "Should be skipped by abort",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      executionMode: "sequential",
+      execute: async () => {
+        throw new Error("second_tool should never execute");
+      },
+    };
+    const thirdTool: AgentTool = {
+      ...skippedTool,
+      name: "third_tool",
+      label: "third_tool",
+    };
+
+    // afterToolOutcome must observe every committed tool call, including the
+    // aborted tail the dispatch loop skipped — otherwise audit/redaction hooks
+    // silently miss the repaired calls (#116379).
+    const afterToolOutcome = vi.fn(async () => undefined);
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "abort mid-batch", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [firstTool, skippedTool, thirdTool],
+      },
+      { ...config, toolExecution: "sequential", afterToolOutcome },
+      () => {},
+      controller.signal,
+      streamFn,
+    );
+
+    // The assistant turn committed three tool_use blocks; every one must have a
+    // matching tool_result so the history has no orphaned tool_use.
+    const toolResultMessages = messages.filter((message) => message.role === "toolResult");
+    const toolResultIds = toolResultMessages.map(
+      (message) => (message as Extract<AgentMessage, { role: "toolResult" }>).toolCallId,
+    );
+    expect(toolResultIds).toEqual(["call-first", "call-second", "call-third"]);
+    // The first tool produced a real result; the skipped tail got aborted results.
+    expect(toolResultMessages[0]).toMatchObject({ toolCallId: "call-first", isError: false });
+    expect(toolResultMessages[1]).toMatchObject({ toolCallId: "call-second", isError: true });
+    expect(toolResultMessages[2]).toMatchObject({ toolCallId: "call-third", isError: true });
+    expect(
+      (toolResultMessages[1] as Extract<AgentMessage, { role: "toolResult" }>).content,
+    ).toContainEqual({ type: "text", text: "Operation aborted" });
+    // The outcome hook observed all three calls, including the two skipped tail
+    // calls, with the aborted marker.
+    expect(afterToolOutcome).toHaveBeenCalledTimes(3);
+    expect(afterToolOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCall: expect.objectContaining({ id: "call-second" }),
+        isError: true,
+        executionStarted: false,
+      }),
+      controller.signal,
+    );
+    expect(afterToolOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCall: expect.objectContaining({ id: "call-third" }),
+        isError: true,
+        executionStarted: false,
+      }),
+      controller.signal,
+    );
+  });
+
+  it("emits aborted tool results for skipped tool calls on parallel abort (#116379)", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "p-first", name: "p_first_tool", arguments: {} },
+          { type: "toolCall", id: "p-second", name: "p_second_tool", arguments: {} },
+          { type: "toolCall", id: "p-third", name: "p_third_tool", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const firstTool: AgentTool = {
+      name: "p_first_tool",
+      label: "p_first_tool",
+      description: "Aborts the run mid-batch",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort(new Error("user aborted"));
+        return {
+          content: [{ type: "text", text: "first ran" }],
+          details: { aborted: true },
+        };
+      },
+    };
+    const skippedTool: AgentTool = {
+      name: "p_second_tool",
+      label: "p_second_tool",
+      description: "Should be skipped by abort",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        throw new Error("p_second_tool should never execute");
+      },
+    };
+    const thirdTool: AgentTool = {
+      ...skippedTool,
+      name: "p_third_tool",
+      label: "p_third_tool",
+    };
+
+    // afterToolOutcome must observe every committed tool call, including the
+    // aborted tail the dispatch loop skipped — otherwise audit/redaction hooks
+    // silently miss the repaired calls (#116379).
+    const afterToolOutcome = vi.fn(async () => undefined);
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "abort mid-batch parallel", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [firstTool, skippedTool, thirdTool],
+      },
+      { ...config, toolExecution: "parallel", afterToolOutcome },
+      () => {},
+      controller.signal,
+      streamFn,
+    );
+
+    const toolResultMessages = messages.filter((message) => message.role === "toolResult");
+    const toolResultIds = toolResultMessages.map(
+      (message) => (message as Extract<AgentMessage, { role: "toolResult" }>).toolCallId,
+    );
+    expect(toolResultIds.toSorted()).toEqual(["p-first", "p-second", "p-third"]);
+    // Every tool_use is paired with a tool_result — no orphaned tool_use.
+    expect(toolResultMessages).toHaveLength(3);
+    // The outcome hook observed all three calls, including the two skipped tail
+    // calls, with the aborted marker.
+    expect(afterToolOutcome).toHaveBeenCalledTimes(3);
+    expect(afterToolOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCall: expect.objectContaining({ id: "p-second" }),
+        isError: true,
+        executionStarted: false,
+      }),
+      controller.signal,
+    );
+    expect(afterToolOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCall: expect.objectContaining({ id: "p-third" }),
+        isError: true,
+        executionStarted: false,
+      }),
+      controller.signal,
+    );
+  });
+
   it("skips interrupted-turn guidance when the abort reason marks a turn handoff", async () => {
     const controller = new AbortController();
     let streamCalls = 0;

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1722,6 +1722,7 @@ describe("agentLoop tool termination", () => {
     // aborted tail the dispatch loop skipped — otherwise audit/redaction hooks
     // silently miss the repaired calls (#116379).
     const afterToolOutcome = vi.fn(async () => undefined);
+    const events: AgentEvent[] = [];
     const messages = await runAgentLoop(
       [{ role: "user", content: "abort mid-batch", timestamp: 1 }],
       {
@@ -1730,7 +1731,9 @@ describe("agentLoop tool termination", () => {
         tools: [firstTool, skippedTool, thirdTool],
       },
       { ...config, toolExecution: "sequential", afterToolOutcome },
-      () => {},
+      (event) => {
+        events.push(event);
+      },
       controller.signal,
       streamFn,
     );
@@ -1768,6 +1771,29 @@ describe("agentLoop tool termination", () => {
       }),
       controller.signal,
     );
+    // Every skipped tail call emits a tool_execution_start before its
+    // tool_execution_end, preserving the lifecycle pairing every dispatched
+    // call already has — otherwise channel/client subscribers receive an end
+    // event for an unknown tool-call id (#116379).
+    for (const skippedId of ["call-second", "call-third"]) {
+      const startIdx = events.findIndex(
+        (event) =>
+          event.type === "tool_execution_start" &&
+          (event as Extract<AgentEvent, { type: "tool_execution_start" }>).toolCallId === skippedId,
+      );
+      const endIdx = events.findIndex(
+        (event) =>
+          event.type === "tool_execution_end" &&
+          (event as Extract<AgentEvent, { type: "tool_execution_end" }>).toolCallId === skippedId,
+      );
+      expect(startIdx).toBeGreaterThanOrEqual(0);
+      expect(endIdx).toBeGreaterThan(startIdx);
+      expect(
+        (events[endIdx] as Extract<AgentEvent, { type: "tool_execution_end" }>).executionStarted,
+      ).toBe(false);
+    }
+    expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(3);
+    expect(events.filter((event) => event.type === "tool_execution_end")).toHaveLength(3);
   });
 
   it("emits aborted tool results for skipped tool calls on parallel abort (#116379)", async () => {
@@ -1822,6 +1848,7 @@ describe("agentLoop tool termination", () => {
     // aborted tail the dispatch loop skipped — otherwise audit/redaction hooks
     // silently miss the repaired calls (#116379).
     const afterToolOutcome = vi.fn(async () => undefined);
+    const events: AgentEvent[] = [];
     const messages = await runAgentLoop(
       [{ role: "user", content: "abort mid-batch parallel", timestamp: 1 }],
       {
@@ -1830,7 +1857,9 @@ describe("agentLoop tool termination", () => {
         tools: [firstTool, skippedTool, thirdTool],
       },
       { ...config, toolExecution: "parallel", afterToolOutcome },
-      () => {},
+      (event) => {
+        events.push(event);
+      },
       controller.signal,
       streamFn,
     );
@@ -1861,6 +1890,26 @@ describe("agentLoop tool termination", () => {
       }),
       controller.signal,
     );
+    // Every tool call — dispatched or skipped — emits a tool_execution_start
+    // before its tool_execution_end, so channel/client subscribers never see an
+    // end event for an unknown tool-call id (#116379).
+    for (const toolCallId of ["p-first", "p-second", "p-third"]) {
+      const startIdx = events.findIndex(
+        (event) =>
+          event.type === "tool_execution_start" &&
+          (event as Extract<AgentEvent, { type: "tool_execution_start" }>).toolCallId ===
+            toolCallId,
+      );
+      const endIdx = events.findIndex(
+        (event) =>
+          event.type === "tool_execution_end" &&
+          (event as Extract<AgentEvent, { type: "tool_execution_end" }>).toolCallId === toolCallId,
+      );
+      expect(startIdx).toBeGreaterThanOrEqual(0);
+      expect(endIdx).toBeGreaterThan(startIdx);
+    }
+    expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(3);
+    expect(events.filter((event) => event.type === "tool_execution_end")).toHaveLength(3);
   });
 
   it("skips interrupted-turn guidance when the abort reason marks a turn handoff", async () => {

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1708,6 +1708,7 @@ describe("agentLoop tool termination", () => {
       description: "Should be skipped by abort",
       parameters: Type.Object({}, { additionalProperties: false }),
       executionMode: "sequential",
+      hideFromChannelProgress: true,
       execute: async () => {
         throw new Error("second_tool should never execute");
       },
@@ -1791,6 +1792,8 @@ describe("agentLoop tool termination", () => {
       expect(
         (events[endIdx] as Extract<AgentEvent, { type: "tool_execution_end" }>).executionStarted,
       ).toBe(false);
+      expect(events[startIdx]).toMatchObject({ hideFromChannelProgress: true });
+      expect(events[endIdx]).toMatchObject({ hideFromChannelProgress: true });
     }
     expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(3);
     expect(events.filter((event) => event.type === "tool_execution_end")).toHaveLength(3);
@@ -1834,6 +1837,7 @@ describe("agentLoop tool termination", () => {
       label: "p_second_tool",
       description: "Should be skipped by abort",
       parameters: Type.Object({}, { additionalProperties: false }),
+      hideFromChannelProgress: true,
       execute: async () => {
         throw new Error("p_second_tool should never execute");
       },
@@ -1907,6 +1911,10 @@ describe("agentLoop tool termination", () => {
       );
       expect(startIdx).toBeGreaterThanOrEqual(0);
       expect(endIdx).toBeGreaterThan(startIdx);
+      if (toolCallId !== "p-first") {
+        expect(events[startIdx]).toMatchObject({ hideFromChannelProgress: true });
+        expect(events[endIdx]).toMatchObject({ hideFromChannelProgress: true });
+      }
     }
     expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(3);
     expect(events.filter((event) => event.type === "tool_execution_end")).toHaveLength(3);

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -724,44 +724,24 @@ async function executeToolCallsSequential(
     messages.push(toolResultMessage);
 
     if (signal?.aborted) {
-      // The abort skipped the remaining tool calls. Emit aborted tool results
-      // for them so every tool_use in the committed assistant message keeps a
-      // paired tool_result — otherwise the conversation history is left with
-      // orphaned tool_use blocks that corrupt retries/continuation (#116379).
-      // Route through finalizeAbortedToolCall so afterToolOutcome hooks observe
-      // these skipped calls like any other outcome. Emit the matching
-      // tool_execution_start first so the aborted end/result keeps the same
-      // start→end lifecycle pairing every dispatched call already has —
-      // otherwise subscribers see tool_execution_end for an unknown id (#116379).
+      // Complete the skipped tail through the normal lifecycle and outcome hook
+      // so the committed tool-call turn stays paired and subscriber-safe.
       for (let i = finalizedCalls.length; i < toolCalls.length; i++) {
         const skippedToolCall = toolCalls[i];
         if (!skippedToolCall) {
           continue;
         }
-        const skippedHideFromChannelProgress = hidesToolCallFromChannelProgress(
-          currentContext,
-          skippedToolCall,
-          resolvedToolCalls,
-        );
-        await emit({
-          type: "tool_execution_start",
-          toolCallId: skippedToolCall.id,
-          toolName: skippedToolCall.name,
-          args: skippedToolCall.arguments,
-          ...(skippedHideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
-        });
-        const abortedFinalized = await finalizeAbortedToolCall(
+        const completed = await completeAbortedToolCall(
           currentContext,
           assistantMessage,
           skippedToolCall,
+          resolvedToolCalls,
           config,
           signal,
+          emit,
         );
-        await emitToolExecutionEnd(abortedFinalized, emit);
-        const abortedToolResultMessage = createToolResultMessage(abortedFinalized);
-        await emitToolResultMessage(abortedToolResultMessage, emit);
-        finalizedCalls.push(abortedFinalized);
-        messages.push(abortedToolResultMessage);
+        finalizedCalls.push(completed.finalized);
+        messages.push(completed.message);
       }
       break;
     }
@@ -866,45 +846,25 @@ async function executeToolCallsParallel(
     messages.push(toolResultMessage);
   }
 
-  // The abort broke out of the dispatch loop before every tool call was queued.
-  // Emit aborted tool results for the skipped tail so every tool_use in the
-  // committed assistant message keeps a paired tool_result — otherwise the
-  // conversation history is left with orphaned tool_use blocks that corrupt
-  // retries/continuation (#116379). Route through finalizeAbortedToolCall so
-  // afterToolOutcome hooks observe these skipped calls like any other outcome.
-  // Emit the matching tool_execution_start first so the aborted end/result
-  // keeps the same start→end lifecycle pairing every dispatched call already
-  // has — otherwise subscribers see tool_execution_end for an unknown id (#116379).
+  // Complete calls skipped before queueing through the same lifecycle contract
+  // as the sequential path.
   if (signal?.aborted && orderedFinalizedCalls.length < toolCalls.length) {
     for (let i = orderedFinalizedCalls.length; i < toolCalls.length; i++) {
       const skippedToolCall = toolCalls[i];
       if (!skippedToolCall) {
         continue;
       }
-      const hideFromChannelProgress = hidesToolCallFromChannelProgress(
-        currentContext,
-        skippedToolCall,
-        resolvedToolCalls,
-      );
-      await emit({
-        type: "tool_execution_start",
-        toolCallId: skippedToolCall.id,
-        toolName: skippedToolCall.name,
-        args: skippedToolCall.arguments,
-        ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
-      });
-      const abortedFinalized = await finalizeAbortedToolCall(
+      const completed = await completeAbortedToolCall(
         currentContext,
         assistantMessage,
         skippedToolCall,
+        resolvedToolCalls,
         config,
         signal,
+        emit,
       );
-      await emitToolExecutionEnd(abortedFinalized, emit);
-      const abortedToolResultMessage = createToolResultMessage(abortedFinalized);
-      await emitToolResultMessage(abortedToolResultMessage, emit);
-      orderedFinalizedCalls.push(abortedFinalized);
-      messages.push(abortedToolResultMessage);
+      orderedFinalizedCalls.push(completed.finalized);
+      messages.push(completed.message);
     }
   }
 
@@ -1302,22 +1262,28 @@ async function finalizeToolCallOutcome(
   }
 }
 
-/**
- * Finalizes a tool call that was skipped because the run aborted mid-batch.
- * Routes the synthetic aborted outcome through the standard
- * {@link finalizeToolCallOutcome} path so `config.afterToolOutcome` hooks
- * (audit, redaction, metadata, error-normalization) observe these calls just
- * like every immediate or executed outcome — otherwise the skipped tail would
- * silently bypass the outcome contract (#116379).
- */
-async function finalizeAbortedToolCall(
+async function completeAbortedToolCall(
   currentContext: AgentContext,
   assistantMessage: AssistantMessage,
   toolCall: AgentToolCall,
+  resolvedToolCalls: Map<AgentToolCall, ResolvedToolCallOutcome>,
   config: AgentLoopConfig,
   signal: AbortSignal | undefined,
-): Promise<FinalizedToolCallOutcome> {
-  return finalizeToolCallOutcome(
+  emit: AgentEventSink,
+): Promise<{ finalized: FinalizedToolCallOutcome; message: ToolResultMessage }> {
+  const hideFromChannelProgress = hidesToolCallFromChannelProgress(
+    currentContext,
+    toolCall,
+    resolvedToolCalls,
+  );
+  await emit({
+    type: "tool_execution_start",
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+    args: toolCall.arguments,
+    ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
+  });
+  const finalized = await finalizeToolCallOutcome(
     currentContext,
     assistantMessage,
     {
@@ -1325,11 +1291,16 @@ async function finalizeAbortedToolCall(
       result: createErrorToolResult("Operation aborted"),
       isError: true,
       executionStarted: false,
+      ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
     },
     toolCall.arguments,
     config,
     signal,
   );
+  await emitToolExecutionEnd(finalized, emit);
+  const message = createToolResultMessage(finalized);
+  await emitToolResultMessage(message, emit);
+  return { finalized, message };
 }
 
 function createErrorToolResult(message: string): AgentToolResult<unknown> {

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -724,6 +724,30 @@ async function executeToolCallsSequential(
     messages.push(toolResultMessage);
 
     if (signal?.aborted) {
+      // The abort skipped the remaining tool calls. Emit aborted tool results
+      // for them so every tool_use in the committed assistant message keeps a
+      // paired tool_result — otherwise the conversation history is left with
+      // orphaned tool_use blocks that corrupt retries/continuation (#116379).
+      // Route through finalizeAbortedToolCall so afterToolOutcome hooks observe
+      // these skipped calls like any other outcome.
+      for (let i = finalizedCalls.length; i < toolCalls.length; i++) {
+        const skippedToolCall = toolCalls[i];
+        if (!skippedToolCall) {
+          continue;
+        }
+        const abortedFinalized = await finalizeAbortedToolCall(
+          currentContext,
+          assistantMessage,
+          skippedToolCall,
+          config,
+          signal,
+        );
+        await emitToolExecutionEnd(abortedFinalized, emit);
+        const abortedToolResultMessage = createToolResultMessage(abortedFinalized);
+        await emitToolResultMessage(abortedToolResultMessage, emit);
+        finalizedCalls.push(abortedFinalized);
+        messages.push(abortedToolResultMessage);
+      }
       break;
     }
   }
@@ -825,6 +849,33 @@ async function executeToolCallsParallel(
     const toolResultMessage = createToolResultMessage(finalized);
     await emitToolResultMessage(toolResultMessage, emit);
     messages.push(toolResultMessage);
+  }
+
+  // The abort broke out of the dispatch loop before every tool call was queued.
+  // Emit aborted tool results for the skipped tail so every tool_use in the
+  // committed assistant message keeps a paired tool_result — otherwise the
+  // conversation history is left with orphaned tool_use blocks that corrupt
+  // retries/continuation (#116379). Route through finalizeAbortedToolCall so
+  // afterToolOutcome hooks observe these skipped calls like any other outcome.
+  if (signal?.aborted && orderedFinalizedCalls.length < toolCalls.length) {
+    for (let i = orderedFinalizedCalls.length; i < toolCalls.length; i++) {
+      const skippedToolCall = toolCalls[i];
+      if (!skippedToolCall) {
+        continue;
+      }
+      const abortedFinalized = await finalizeAbortedToolCall(
+        currentContext,
+        assistantMessage,
+        skippedToolCall,
+        config,
+        signal,
+      );
+      await emitToolExecutionEnd(abortedFinalized, emit);
+      const abortedToolResultMessage = createToolResultMessage(abortedFinalized);
+      await emitToolResultMessage(abortedToolResultMessage, emit);
+      orderedFinalizedCalls.push(abortedFinalized);
+      messages.push(abortedToolResultMessage);
+    }
   }
 
   return {
@@ -1219,6 +1270,36 @@ async function finalizeToolCallOutcome(
       isError: true,
     };
   }
+}
+
+/**
+ * Finalizes a tool call that was skipped because the run aborted mid-batch.
+ * Routes the synthetic aborted outcome through the standard
+ * {@link finalizeToolCallOutcome} path so `config.afterToolOutcome` hooks
+ * (audit, redaction, metadata, error-normalization) observe these calls just
+ * like every immediate or executed outcome — otherwise the skipped tail would
+ * silently bypass the outcome contract (#116379).
+ */
+async function finalizeAbortedToolCall(
+  currentContext: AgentContext,
+  assistantMessage: AssistantMessage,
+  toolCall: AgentToolCall,
+  config: AgentLoopConfig,
+  signal: AbortSignal | undefined,
+): Promise<FinalizedToolCallOutcome> {
+  return finalizeToolCallOutcome(
+    currentContext,
+    assistantMessage,
+    {
+      toolCall,
+      result: createErrorToolResult("Operation aborted"),
+      isError: true,
+      executionStarted: false,
+    },
+    toolCall.arguments,
+    config,
+    signal,
+  );
 }
 
 function createErrorToolResult(message: string): AgentToolResult<unknown> {

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -729,12 +729,27 @@ async function executeToolCallsSequential(
       // paired tool_result — otherwise the conversation history is left with
       // orphaned tool_use blocks that corrupt retries/continuation (#116379).
       // Route through finalizeAbortedToolCall so afterToolOutcome hooks observe
-      // these skipped calls like any other outcome.
+      // these skipped calls like any other outcome. Emit the matching
+      // tool_execution_start first so the aborted end/result keeps the same
+      // start→end lifecycle pairing every dispatched call already has —
+      // otherwise subscribers see tool_execution_end for an unknown id (#116379).
       for (let i = finalizedCalls.length; i < toolCalls.length; i++) {
         const skippedToolCall = toolCalls[i];
         if (!skippedToolCall) {
           continue;
         }
+        const skippedHideFromChannelProgress = hidesToolCallFromChannelProgress(
+          currentContext,
+          skippedToolCall,
+          resolvedToolCalls,
+        );
+        await emit({
+          type: "tool_execution_start",
+          toolCallId: skippedToolCall.id,
+          toolName: skippedToolCall.name,
+          args: skippedToolCall.arguments,
+          ...(skippedHideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
+        });
         const abortedFinalized = await finalizeAbortedToolCall(
           currentContext,
           assistantMessage,
@@ -857,12 +872,27 @@ async function executeToolCallsParallel(
   // conversation history is left with orphaned tool_use blocks that corrupt
   // retries/continuation (#116379). Route through finalizeAbortedToolCall so
   // afterToolOutcome hooks observe these skipped calls like any other outcome.
+  // Emit the matching tool_execution_start first so the aborted end/result
+  // keeps the same start→end lifecycle pairing every dispatched call already
+  // has — otherwise subscribers see tool_execution_end for an unknown id (#116379).
   if (signal?.aborted && orderedFinalizedCalls.length < toolCalls.length) {
     for (let i = orderedFinalizedCalls.length; i < toolCalls.length; i++) {
       const skippedToolCall = toolCalls[i];
       if (!skippedToolCall) {
         continue;
       }
+      const hideFromChannelProgress = hidesToolCallFromChannelProgress(
+        currentContext,
+        skippedToolCall,
+        resolvedToolCalls,
+      );
+      await emit({
+        type: "tool_execution_start",
+        toolCallId: skippedToolCall.id,
+        toolName: skippedToolCall.name,
+        args: skippedToolCall.arguments,
+        ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
+      });
       const abortedFinalized = await finalizeAbortedToolCall(
         currentContext,
         assistantMessage,

--- a/src/agents/embedded-agent-runner/run/code-mode-repair.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-repair.test.ts
@@ -403,6 +403,28 @@ describe("installCodeModeRepairHook", () => {
     });
   });
 
+  it("preserves a wait skipped by abort without spending the repair token", async () => {
+    const previous = vi.fn(async () => undefined);
+    const agent = createAgent(previous);
+    const controller = new AbortController();
+    controller.abort();
+    const context = outcome({
+      toolName: "wait",
+      result: { content: [{ type: "text", text: "Operation aborted" }], details: {} },
+      isError: true,
+      executionStarted: false,
+    });
+
+    await expect(agent.afterToolOutcome?.(context, controller.signal)).resolves.toBeUndefined();
+    expect(previous).toHaveBeenCalledWith(context, controller.signal);
+    await expect(
+      agent.afterToolOutcome?.(outcome({ result: failedResult() })),
+    ).resolves.toMatchObject({
+      terminate: false,
+      details: { repair: { allowed: true, remainingAttempts: 1 } },
+    });
+  });
+
   it("leaves non-Code-Mode tools with the previously installed outcome hook", async () => {
     const previous = vi.fn(async () => ({ details: { previous: true } }));
     const agent = createAgent(previous);

--- a/src/agents/embedded-agent-runner/run/code-mode-repair.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-repair.ts
@@ -224,6 +224,9 @@ export function installCodeModeRepairHook(params: { agent: Agent }): void {
     if (!codeModeTool) {
       return prior;
     }
+    if (signal?.aborted && !context.executionStarted) {
+      return prior;
+    }
     const effective = mergePriorOutcome(context, prior);
 
     const failure = preserveOriginalDispatchEvidence(


### PR DESCRIPTION
Fixes #116379

## What Problem This Solves

Fixes an issue where aborting an agent during a multi-tool turn could leave committed `tool_use` entries without matching `tool_result` entries. On non-synthesizing provider paths such as `openai-completions`, the malformed active transcript could make the next continuation or retry fail.

## Why This Change Was Made

The repair now happens at the Agent Core dispatch boundary where the orphaned tail is created. Sequential and parallel dispatch both complete every skipped call through one shared lifecycle path: start event, `afterToolOutcome`, end event, and aborted tool result.

The shared helper also preserves `hideFromChannelProgress` on both lifecycle events. Code Mode ignores aborted `wait` calls that never started, so a skipped hidden wait does not emit visible progress, get rewritten as a bridge-start failure, or consume its repair allowance.

Downstream provider transforms and replay repair remain unchanged. They should not need to infer or synthesize state that Agent Core can record correctly at the owning boundary.

## User Impact

After a mid-turn abort, every committed tool call has exactly one result. Retries and continuations receive a valid transcript, hidden Code Mode waits stay hidden, and skipped waits do not spend repair state.

## Evidence

Exact branch head: `080ade14209f48c1adc19fcaeaaea1baacb8dbbc`

Focused deterministic proof:

```console
node scripts/run-vitest.mjs \
  packages/agent-core/src/agent-loop.test.ts \
  src/agents/embedded-agent-runner/run/code-mode-repair.test.ts \
  src/agents/embedded-agent-subscribe.handlers.tools.test.ts \
  src/agents/transport-message-transform.test.ts --run

Test Files  4 passed (4)
Tests       223 passed (223)
```

The Agent Core tests cover both sequential and parallel aborts and assert:

- all committed `tool_use` IDs receive a `tool_result`;
- skipped calls never execute and report `executionStarted: false`;
- `afterToolOutcome` observes each skipped call;
- lifecycle start precedes end for every call;
- hidden skipped calls carry `hideFromChannelProgress: true` on both events.

The Code Mode regression proves an aborted `wait` with `executionStarted: false` preserves the prior outcome and leaves the repair token available.

A deterministic integration proof also drove the real `runAgentLoop` with a real `AbortController` in sequential and parallel modes, then passed its messages through the real `transformTransportMessages` using a non-synthesizing `openai-completions` model. Both scenarios passed with no orphaned tool calls (`2 passed`).

Static, remote, and hosted proof:

- `git diff --check`: passed.
- targeted `oxfmt --check`: passed.
- fresh branch autoreview: clean, no actionable findings (`0.98` correct).
- Blacksmith changed gate passed, including core/core-test typechecks, scoped lint, formatting, import-cycle, boundary, schema, dependency, dead-export, and repository guards: https://github.com/openclaw/openclaw/actions/runs/30656821369
- exact-head hosted CI passed on `080ade14209f48c1adc19fcaeaaea1baacb8dbbc`: https://github.com/openclaw/openclaw/actions/runs/30657370916
- the initial hosted `check-lint` runner was shut down with exit 143 and no lint diagnostic; the exact failed job alone was requested for retry, and attempt 2 passed `check-lint` plus `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/30657370916/job/91248197894
- all four changed-file blobs remain identical between the validated base `be93d44275263b205a6b405ebdfd49756fdd9c6f` and live `main` `f4f990a91bce895f0e700517442975439afe80c7`.
- terminal synthetic merge-tree proof against `f4f990a91bce895f0e700517442975439afe80c7` completed without conflicts (`7867f4777ea2b2b16385558d5885664c9be7db7a`).
- ClawSweeper reviewed the exact head at 5/6 overall, proof, and patch quality, with no findings. Its sole remaining item was exact-head CI, now complete.

## Risk

This changes abort-time transcript and lifecycle ordering. The behavior is bounded to calls skipped after an abort, and the regression suite covers both dispatch modes plus downstream subscriber and provider-transform siblings. No config, protocol, dependency, storage, network, or permission surface changes.

## Best-Fix Verdict

Yes. Agent Core commits the assistant tool-call turn before dispatch, so it owns completing the skipped tail when dispatch aborts. Repairing downstream in provider transforms would remain policy-dependent and leave subscribers and hooks with incomplete lifecycle state.

## Authorship

The contributor's two authored commits remain intact in the rewritten series. The maintainer follow-up consolidates the shared lifecycle helper and adds hidden-progress and Code Mode abort coverage.
