### PR TITLE
test(extensions): remove duplicate coverage

### DIFF
--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -115,17 +115,6 @@ function normalizeClaudeArgs(
 }
 
 describe("Claude backend permission args", () => {
-  it("leaves args alone when they omit permission flags", () => {
-    expect(normalizeClaudeArgs(["-p", "--output-format", "stream-json", "--verbose"])).toEqual([
-      "-p",
-      "--output-format",
-      "stream-json",
-      "--verbose",
-      "--setting-sources",
-      "user",
-    ]);
-  });
-
   it("removes legacy skip-permissions without adding bypassPermissions", () => {
     expect(normalizeClaudeArgs(["-p", "--dangerously-skip-permissions", "--verbose"])).toEqual([
       "-p",

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -1841,41 +1841,6 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
   });
 
-  it("archives legacy vector sidecars when memory search provider is none", async () => {
-    const stateDir = path.join(rootDir, "state");
-    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
-    const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
-    await writeLegacyMemorySidecar(legacyPath, { vector: "vec0" });
-    const config: OpenClawConfig = {
-      memory: {
-        search: {
-          provider: "none",
-          store: {
-            vector: {
-              extensionPath: path.join(rootDir, "missing-sqlite-vec.so"),
-            },
-          },
-        },
-      },
-
-      agents: {
-        defaults: {},
-        list: [{ id: "main", workspace: workspaceDir }],
-      },
-    };
-
-    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams(config));
-
-    expect(result.warnings).toEqual([]);
-    expect(result.changes).toEqual([
-      "Migrated Memory Core legacy memory index for agent main -> per-agent SQLite (1 source(s), 1 chunk(s), 1 cache row(s))",
-      expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
-    ]);
-    const keywordRows = await searchMigratedKeywordRows(agentPath, "remember");
-    expect(keywordRows.map((row) => row.id)).toEqual(["chunk-1"]);
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
-  });
-
   it("copies custom vector sidecars to the canonical retry path when sqlite-vec cannot load", async () => {
     const stateDir = path.join(rootDir, "state");
     const legacyPath = path.join(rootDir, "custom-memory", "main.sqlite");

--- a/extensions/qqbot/src/engine/group/history.test.ts
+++ b/extensions/qqbot/src/engine/group/history.test.ts
@@ -38,11 +38,6 @@ describe("engine/group/history", () => {
   });
 
   describe("formatAttachmentTags", () => {
-    it("returns empty string for empty input", () => {
-      expect(formatAttachmentTags()).toBe("");
-      expect(formatAttachmentTags([])).toBe("");
-    });
-
     it("renders bracketed source tags for entries with a source", () => {
       expect(formatAttachmentTags([{ type: "image", localPath: "/tmp/a.png" }])).toBe(
         "[image: /tmp/a.png]",
@@ -56,27 +51,6 @@ describe("engine/group/history", () => {
       expect(
         formatAttachmentTags([{ type: "voice", localPath: "/tmp/v.wav", transcript: "hi" }]),
       ).toBe('[voice: /tmp/v.wav] (transcript: "hi")');
-    });
-
-    it("uses descriptive tags when no source is available", () => {
-      expect(formatAttachmentTags([{ type: "image" }])).toBe("[image]");
-      expect(formatAttachmentTags([{ type: "image", filename: "a.png" }])).toBe("[image: a.png]");
-      expect(formatAttachmentTags([{ type: "voice" }])).toBe("[voice]");
-      expect(formatAttachmentTags([{ type: "voice", transcript: "t" }])).toBe(
-        '[voice (transcript: "t")]',
-      );
-      expect(formatAttachmentTags([{ type: "video" }])).toBe("[video]");
-      expect(formatAttachmentTags([{ type: "file", filename: "b.pdf" }])).toBe("[file: b.pdf]");
-      expect(formatAttachmentTags([{ type: "unknown" }])).toBe("[attachment]");
-    });
-
-    it("joins multiple entries with newline", () => {
-      expect(
-        formatAttachmentTags([
-          { type: "image", localPath: "/tmp/a.png" },
-          { type: "voice", transcript: "hi" },
-        ]),
-      ).toBe('[image: /tmp/a.png]\n[voice (transcript: "hi")]');
     });
   });
 

--- a/extensions/reef/src/transport.test.ts
+++ b/extensions/reef/src/transport.test.ts
@@ -937,41 +937,6 @@ async function deliverInboxFrame(frame: string): Promise<{
   return { entries, states };
 }
 
-describe("createReefWebSocket handshake deadline", () => {
-  it("errors when the relay accepts TCP but never completes the upgrade", async () => {
-    const peers = new Set<import("node:net").Socket>();
-    const server = http.createServer();
-    server.on("connection", (socket) => {
-      peers.add(socket);
-      socket.once("close", () => peers.delete(socket));
-    });
-    server.on("upgrade", () => {
-      // Leave the HTTP upgrade pending until the client deadline aborts it.
-    });
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => resolve());
-    });
-
-    try {
-      const { port } = server.address() as AddressInfo;
-      const socket = createReefWebSocket(`ws://127.0.0.1:${port}`, {
-        handshakeTimeoutMs: 50,
-      }) as WebSocket;
-      const [error] = await once(socket, "error");
-
-      expect(error).toMatchObject({ message: "Opening handshake has timed out" });
-    } finally {
-      for (const peer of peers) {
-        peer.destroy();
-      }
-      await new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      });
-    }
-  });
-});
-
 describe("ReefInboxConnection response frame bounds", () => {
   it("accepts a relay frame exactly at the payload limit", async () => {
     const frame = inboxFrameAtSize(INBOX_WEBSOCKET_MAX_PAYLOAD_BYTES);


### PR DESCRIPTION
## What Problem This Solves

Four extension suites repeated coverage already owned by the implementation's canonical test module.

## Why This Change Was Made

- removes a byte-for-byte duplicate Reef WebSocket handshake deadline test
- removes a duplicate Memory Core `provider: "none"` migration case
- removes an Anthropic permission-suite case already covered by the setting-sources suite
- removes three QQBot attachment-format cases already covered by the attachment-tags owner suite

## Retained Coverage

| Removed case | Retained owner assertion |
| --- | --- |
| Anthropic permission args with no permission flags | `extensions/anthropic/cli-shared.test.ts:161` uses the same args and expects the same appended `--setting-sources user` bytes. |
| Memory Core vector sidecar with `provider: "none"` | `extensions/memory-core/doctor-contract-api.test.ts:1809` uses the same sidecar, config, migration call, warnings, changes, keyword row, and archived path assertions. |
| QQBot empty, source-less, and multi-entry attachment tags | `extensions/qqbot/src/engine/utils/attachment-tags.test.ts:10`, `:37`, and `:49` own the same helper inputs and exact output strings; `group/history.ts` only re-exports that helper. |
| Reef stalled WebSocket upgrade deadline | `extensions/reef/src/transport.test.ts:962` retains the byte-for-byte identical server, timeout, error, and cleanup test. |

## User Impact

No runtime behavior changes. The extension suite removes 107 lines without dropping a distinct contract.

## Evidence

- focused Vitest across the touched and owner suites: 152 passed
- targeted `oxfmt --check`: passed
- `git diff --check`: passed
- fresh branch autoreview: clean, 0.96
- Blacksmith Testbox changed gate at `34d0cb0529`: passed in 5m21s
  - https://github.com/openclaw/openclaw/actions/runs/30601261904
