### PR TITLE
fix(onboarding): restore skill dependency consent

### DIFF
--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -246,7 +246,7 @@ describe("setupSkills", () => {
       const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
       await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
 
-      expect(prompter.multiselect).not.toHaveBeenCalled();
+      expect(prompter.multiselect).toHaveBeenCalled();
       expect(mocks.installSkill).toHaveBeenCalledWith(
         expect.objectContaining({ skillName: "video-frames", installId: "brew" }),
       );
@@ -255,7 +255,7 @@ describe("setupSkills", () => {
     });
   });
 
-  it("auto-installs ready bundled skill dependencies without running workspace skill recipes", async () => {
+  it("lets the user skip ready bundled dependencies without offering workspace recipes", async () => {
     mockMissingBrewStatus([
       createWorkspaceSkill({
         name: "repo-helper",
@@ -272,17 +272,49 @@ describe("setupSkills", () => {
       }),
     ]);
 
-    const { prompter, notes } = createPrompter({});
+    const { prompter } = createPrompter({});
     await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
 
-    expect(prompter.multiselect).not.toHaveBeenCalled();
+    expect(prompter.multiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.arrayContaining([
+          expect.objectContaining({ value: "__skip__" }),
+          expect.objectContaining({ value: "node-helper" }),
+        ]),
+      }),
+    );
+    const options = vi.mocked(prompter.multiselect).mock.calls[0]?.[0].options ?? [];
+    expect(options).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ value: "repo-helper" })]),
+    );
+    expect(mocks.installSkill).not.toHaveBeenCalled();
+  });
+
+  it("installs only the bundled dependencies selected by the user", async () => {
+    mockMissingBrewStatus([
+      createBundledSkill({
+        name: "node-helper",
+        description: "Node helper",
+        bins: ["node-helper"],
+        installLabel: "Install node-helper",
+        installKind: "node",
+      }),
+      createBundledSkill({
+        name: "other-helper",
+        description: "Other helper",
+        bins: ["other-helper"],
+        installLabel: "Install other-helper",
+        installKind: "node",
+      }),
+    ]);
+
+    const { prompter } = createPrompter({ multiselect: ["node-helper"] });
+    await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
     expect(mocks.installSkill).toHaveBeenCalledTimes(1);
     expect(mocks.installSkill).toHaveBeenCalledWith(
       expect.objectContaining({ skillName: "node-helper", installId: "node" }),
     );
-    const installNote = notes.find((n) => n.message.includes("node-helper"));
-    expect(installNote?.message).toContain("node-helper");
-    expect(installNote?.message).not.toContain("repo-helper");
   });
 
   it("rechecks persistent-effect authority immediately before each dependency install", async () => {
@@ -297,7 +329,7 @@ describe("setupSkills", () => {
     ]);
     const beforePersistentEffect = vi.fn(async () => {});
 
-    const { prompter } = createPrompter({});
+    const { prompter } = createPrompter({ multiselect: ["node-helper"] });
     await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter, {
       beforePersistentEffect,
     });
@@ -308,7 +340,7 @@ describe("setupSkills", () => {
     );
   });
 
-  it("uses the requested node manager for node-backed auto installs", async () => {
+  it("uses the requested node manager for selected node-backed installs", async () => {
     mockMissingBrewStatus([
       createBundledSkill({
         name: "node-helper",
@@ -319,7 +351,7 @@ describe("setupSkills", () => {
       }),
     ]);
 
-    const { prompter } = createPrompter({});
+    const { prompter } = createPrompter({ multiselect: ["node-helper"] });
     const next = await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter, {
       nodeManager: "pnpm",
     });
@@ -436,7 +468,7 @@ describe("setupSkills", () => {
         kind === "go" || kind === "uv" ? { ready: false, reason: kind } : { ready: true },
       );
 
-      const { prompter, notes } = createPrompter({});
+      const { prompter, notes } = createPrompter({ multiselect: ["mcporter"] });
       await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
 
       expect(mocks.installSkill).toHaveBeenCalledTimes(1);
@@ -470,7 +502,7 @@ describe("setupSkills", () => {
         skipReason: "go",
       });
 
-      const { prompter, notes } = createPrompter({});
+      const { prompter, notes } = createPrompter({ multiselect: ["blogwatcher"] });
       await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
 
       expect(mocks.installSkill).toHaveBeenCalledTimes(1);
@@ -512,7 +544,7 @@ describe("setupSkills", () => {
 
       const brewNote = notes.find((n) => n.title === "Homebrew recommended");
       expect(brewNote).toBeUndefined();
-      expect(prompter.multiselect).not.toHaveBeenCalled();
+      expect(prompter.multiselect).toHaveBeenCalled();
       expect(mocks.detectBinary).not.toHaveBeenCalledWith("brew");
     });
   });

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -290,6 +290,82 @@ describe("setupSkills", () => {
     expect(mocks.installSkill).not.toHaveBeenCalled();
   });
 
+  it("installs explicitly selected dependencies when Skip for now is also selected", async () => {
+    mockMissingBrewStatus([
+      createBundledSkill({
+        name: "node-helper",
+        description: "Node helper",
+        bins: ["node-helper"],
+        installLabel: "Install node-helper",
+        installKind: "node",
+      }),
+    ]);
+
+    const { prompter } = createPrompter({ multiselect: ["__skip__", "node-helper"] });
+    await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+    expect(mocks.installSkill).toHaveBeenCalledOnce();
+    expect(mocks.installSkill).toHaveBeenCalledWith(
+      expect.objectContaining({ skillName: "node-helper", installId: "node" }),
+    );
+  });
+
+  it("offers unavailable bundled dependencies and explains selected prerequisites afterward", async () => {
+    await withPlatform("linux", async () => {
+      mockMissingBrewStatus([
+        createWorkspaceSkill({
+          name: "repo-helper",
+          description: "Workspace helper",
+          bins: ["repo-helper"],
+          installLabel: "Install repo-helper",
+          installKind: "node",
+        }),
+        createBundledSkill({
+          name: "node-helper",
+          description: "Node helper",
+          bins: ["node-helper"],
+          installLabel: "Install node-helper",
+          installKind: "node",
+        }),
+        createBundledSkill({
+          name: "nano-pdf",
+          description: "PDF helper",
+          bins: ["nano-pdf"],
+          installLabel: "Install nano-pdf (uv)",
+          installKind: "uv",
+        }),
+      ]);
+      mocks.resolveInstallerKindReadiness.mockImplementation(async (kind: string) =>
+        kind === "uv" ? { ready: false, reason: "uv" } : { ready: true },
+      );
+
+      const { prompter, notes } = createPrompter({ multiselect: ["nano-pdf"] });
+      await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+      const options = vi.mocked(prompter.multiselect).mock.calls[0]?.[0].options ?? [];
+      expect(options).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ value: "__skip__" }),
+          expect.objectContaining({ value: "node-helper" }),
+          expect.objectContaining({ value: "nano-pdf" }),
+        ]),
+      );
+      expect(options).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ value: "repo-helper" })]),
+      );
+      expect(mocks.installSkill).not.toHaveBeenCalled();
+      expect(notes.find((note) => note.title === "Manual skill prerequisites")?.message).toContain(
+        "uv: nano-pdf",
+      );
+      const manualNoteCall = vi
+        .mocked(prompter.note)
+        .mock.calls.findIndex(([, title]) => title === "Manual skill prerequisites");
+      expect(vi.mocked(prompter.note).mock.invocationCallOrder[manualNoteCall]).toBeGreaterThan(
+        vi.mocked(prompter.multiselect).mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+      );
+    });
+  });
+
   it("installs only the bundled dependencies selected by the user", async () => {
     mockMissingBrewStatus([
       createBundledSkill({
@@ -370,7 +446,7 @@ describe("setupSkills", () => {
     );
   });
 
-  it("recommends Homebrew and skips brew-backed deps when brew is missing", async () => {
+  it("does not show Homebrew guidance when a missing brew dependency is not selected", async () => {
     if (!supportsHomebrewPrompt) {
       return;
     }
@@ -406,12 +482,14 @@ describe("setupSkills", () => {
       ].join("\n"),
     });
 
-    const brewNote = notes.find((n) => n.title === "Homebrew recommended");
-    expect(brewNote).toBeDefined();
-    expect(prompter.multiselect).not.toHaveBeenCalled();
+    expect(prompter.multiselect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.arrayContaining([expect.objectContaining({ value: "video-frames" })]),
+      }),
+    );
     expect(mocks.installSkill).not.toHaveBeenCalled();
-    const manualNote = notes.find((n) => n.title === "Manual skill prerequisites");
-    expect(manualNote?.message).toContain("Homebrew: video-frames");
+    expect(notes.find((n) => n.title === "Homebrew recommended")).toBeUndefined();
+    expect(notes.find((n) => n.title === "Manual skill prerequisites")).toBeUndefined();
   });
 
   it("does not run brew-backed installs when brew is missing", async () => {
@@ -468,7 +546,9 @@ describe("setupSkills", () => {
         kind === "go" || kind === "uv" ? { ready: false, reason: kind } : { ready: true },
       );
 
-      const { prompter, notes } = createPrompter({ multiselect: ["mcporter"] });
+      const { prompter, notes } = createPrompter({
+        multiselect: ["blogwatcher", "nano-pdf", "mcporter"],
+      });
       await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
 
       expect(mocks.installSkill).toHaveBeenCalledTimes(1);

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -211,12 +211,7 @@ export async function setupSkills(
     }
   }
   const candidateInstallable = installable;
-  const needsBrewPrompt =
-    supportsHomebrewPrompt(process.platform) &&
-    candidateInstallable.some((skill) => skill.install.some((option) => option.kind === "brew")) &&
-    !(await detectBrewOnce());
-  const readyInstallable: typeof installable = [];
-  const skippedInstallable: SkippedInstall[] = [];
+  const readinessBySkillName = new Map<string, SkillInstallReadiness>();
   for (const skill of candidateInstallable) {
     // Onboarding intentionally executes only the primary recipe below. Keep
     // readiness aligned with that recipe instead of silently changing methods.
@@ -225,33 +220,10 @@ export async function setupSkills(
       continue;
     }
     const readiness = await resolveKindReadinessOnce(primaryInstall.kind);
-    if (readiness.ready) {
-      readyInstallable.push(skill);
-    } else {
-      skippedInstallable.push({ skill, reason: readiness.reason });
-    }
-  }
-  installable = readyInstallable;
-  if (needsBrewPrompt) {
-    await prompter.note(
-      [
-        "Many skill dependencies are shipped via Homebrew.",
-        "Without brew, you'll need to build from source or download releases manually.",
-        "",
-        "Install Homebrew:",
-        '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"',
-      ].join("\n"),
-      t("wizard.skills.homebrewRecommendedTitle"),
-    );
-  }
-  if (skippedInstallable.length > 0) {
-    await prompter.note(
-      formatSkippedInstallNote(skippedInstallable),
-      t("wizard.skills.manualPrereqsTitle"),
-    );
+    readinessBySkillName.set(skill.name, readiness);
   }
   let next: OpenClawConfig = cfg;
-  if (installable.length === 0 && missing.length === 0) {
+  if (candidateInstallable.length === 0 && missing.length === 0) {
     await prompter.note(
       [
         "No missing skill dependencies to install.",
@@ -262,7 +234,7 @@ export async function setupSkills(
     );
     return next;
   }
-  if (installable.length > 0) {
+  if (candidateInstallable.length > 0) {
     const selected = await prompter.multiselect({
       message: t("wizard.skills.installDeps"),
       options: [
@@ -271,19 +243,29 @@ export async function setupSkills(
           label: t("common.skipForNow"),
           hint: t("wizard.skills.skipDepsHint"),
         },
-        ...installable.map((skill) => ({
+        ...candidateInstallable.map((skill) => ({
           value: skill.name,
           label: `${skill.emoji ?? "🧩"} ${skill.name}`,
           hint: formatSkillHint(skill),
         })),
       ],
     });
-    const selectedNames = selected.includes("__skip__") ? [] : selected;
+    const selectedNames = selected.filter((name) => name !== "__skip__");
     const selectedSkills = selectedNames
-      .map((name) => installable.find((skill) => skill.name === name))
-      .filter((skill): skill is (typeof installable)[number] => skill !== undefined);
+      .map((name) => candidateInstallable.find((skill) => skill.name === name))
+      .filter((skill): skill is (typeof candidateInstallable)[number] => skill !== undefined);
+    const selectedReadySkills: typeof selectedSkills = [];
+    const selectedSkippedInstallable: SkippedInstall[] = [];
+    for (const skill of selectedSkills) {
+      const readiness = readinessBySkillName.get(skill.name);
+      if (readiness?.ready !== false) {
+        selectedReadySkills.push(skill);
+      } else {
+        selectedSkippedInstallable.push({ skill, reason: readiness.reason });
+      }
+    }
 
-    const needsNodeManagerPrompt = selectedSkills.some((skill) =>
+    const needsNodeManagerPrompt = selectedReadySkills.some((skill) =>
       skill.install.some((option) => option.kind === "node"),
     );
     if (needsNodeManagerPrompt) {
@@ -303,7 +285,7 @@ export async function setupSkills(
     }
 
     const deferredSkippedInstallable: SkippedInstall[] = [];
-    for (const target of selectedSkills) {
+    for (const target of selectedReadySkills) {
       if (target.install.length === 0) {
         continue;
       }
@@ -369,8 +351,26 @@ export async function setupSkills(
       runtime.log(t("wizard.skills.docsLine"));
     }
     if (deferredSkippedInstallable.length > 0) {
+      selectedSkippedInstallable.push(...deferredSkippedInstallable);
+    }
+    if (
+      supportsHomebrewPrompt(process.platform) &&
+      selectedSkippedInstallable.some((item) => item.reason === "brew")
+    ) {
       await prompter.note(
-        formatSkippedInstallNote(deferredSkippedInstallable),
+        [
+          "Many skill dependencies are shipped via Homebrew.",
+          "Without brew, you'll need to build from source or download releases manually.",
+          "",
+          "Install Homebrew:",
+          '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"',
+        ].join("\n"),
+        t("wizard.skills.homebrewRecommendedTitle"),
+      );
+    }
+    if (selectedSkippedInstallable.length > 0) {
+      await prompter.note(
+        formatSkippedInstallNote(selectedSkippedInstallable),
         t("wizard.skills.manualPrereqsTitle"),
       );
     }

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -118,8 +118,8 @@ function isBrewOnlyInstallableSkill(skill: {
 }
 
 function isTrustedAutoInstallableSkill(skill: { bundled: boolean; source: string }): boolean {
-  // Onboarding can auto-run bundled recipes without another prompt. Workspace
-  // skill metadata is mutable project input, so those installs stay explicit.
+  // Onboarding can offer bundled recipes in its explicit consent prompt. Workspace
+  // skill metadata is mutable project input, so those installs stay excluded.
   return skill.bundled && skill.source === "openclaw-bundled";
 }
 
@@ -263,11 +263,25 @@ export async function setupSkills(
     return next;
   }
   if (installable.length > 0) {
-    await prompter.note(
-      installable.map((skill) => `${skill.name}: ${formatSkillHint(skill)}`).join("\n"),
-      t("wizard.skills.installDeps"),
-    );
-    const selectedSkills = installable;
+    const selected = await prompter.multiselect({
+      message: t("wizard.skills.installDeps"),
+      options: [
+        {
+          value: "__skip__",
+          label: t("common.skipForNow"),
+          hint: t("wizard.skills.skipDepsHint"),
+        },
+        ...installable.map((skill) => ({
+          value: skill.name,
+          label: `${skill.emoji ?? "🧩"} ${skill.name}`,
+          hint: formatSkillHint(skill),
+        })),
+      ],
+    });
+    const selectedNames = selected.includes("__skip__") ? [] : selected;
+    const selectedSkills = selectedNames
+      .map((name) => installable.find((skill) => skill.name === name))
+      .filter((skill): skill is (typeof installable)[number] => skill !== undefined);
 
     const needsNodeManagerPrompt = selectedSkills.some((skill) =>
       skill.install.some((option) => option.kind === "node"),


### PR DESCRIPTION
## Summary

- restore the pre-June 30 interaction: one multiselect containing all trusted bundled skill dependencies with install recipes, plus **Skip for now**
- keep current installer-readiness checks, but apply them after consent: install only selected ready dependencies and show prerequisite guidance only for selected unavailable dependencies
- preserve workspace-recipe exclusion, Linux-container handling, persistent-effect authority checks, and existing install error handling
- preserve the old mixed-selection behavior: if **Skip for now** and dependencies are both selected, the explicit dependency selections still run

## Validation

- `pnpm test src/commands/onboard-skills.test.ts` — 16/16 passed on Blacksmith Testbox `tbx_01kyv3xmp71jq374szt8bxgagh` ([run](https://github.com/openclaw/openclaw/actions/runs/30602011707))
- `pnpm check:changed` — passed on Blacksmith Testbox `tbx_01kyv3zcejb430bq2q73awtmr9` ([run](https://github.com/openclaw/openclaw/actions/runs/30602049450))

## Proof gap

- No accepted real-behavior proof is currently attached. The prior Crabdrop link was removed because a Drop is an explanatory artifact, not PR proof.

## Review notes

- The ClawSweeper mixed-selection finding is covered by a focused regression test.
