### PR TITLE
fix(synology-chat): deliver long messages without webhook rejection

### DIFF
--- a/extensions/synology-chat/src/channel.test-mocks.ts
+++ b/extensions/synology-chat/src/channel.test-mocks.ts
@@ -149,6 +149,7 @@ vi.mock("openclaw/plugin-sdk/webhook-ingress", async () => {
 });
 
 vi.mock("./client.js", () => ({
+  SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT: 2_000,
   sendMessage: vi.fn().mockResolvedValue(true),
   sendFileUrl: vi.fn().mockResolvedValue(true),
   resolveLegacyWebhookNameToChatUserId: vi.fn().mockResolvedValue(undefined),

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -452,6 +452,13 @@ describe("createSynologyChatPlugin", () => {
   });
 
   describe("outbound", () => {
+    it("declares bounded Markdown chunking for gateway text delivery", () => {
+      const plugin = synologyChatPlugin;
+      expect(plugin.outbound.chunkerMode).toBe("markdown");
+      expect(plugin.outbound.textChunkLimit).toBe(2_000);
+      expect(plugin.outbound.chunker("x".repeat(2_001), 2_000)).toEqual(["x".repeat(2_000), "x"]);
+    });
+
     it("declares message adapter durable text and media with receipt proofs", async () => {
       const plugin = synologyChatPlugin;
       const cfg = {

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -32,13 +32,14 @@ import {
   normalizeStringEntriesLower,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  chunkTextForOutbound,
   findCodeRegions,
   isInsideCode,
   sanitizeAssistantVisibleText,
 } from "openclaw/plugin-sdk/text-chunking";
 import { listAccountIds, resolveAccount } from "./accounts.js";
 import { synologyChatApprovalAuth } from "./approval-auth.js";
-import { sendMessage, sendFileUrl } from "./client.js";
+import { SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT, sendFileUrl, sendMessage } from "./client.js";
 import { SynologyChatChannelConfigSchema } from "./config-schema.js";
 import {
   collectSynologyGatewayRoutingWarnings,
@@ -187,6 +188,8 @@ type SynologyChatPlugin = Omit<
   };
   outbound: {
     deliveryMode: "gateway";
+    chunker: NonNullable<ChannelOutboundAdapter["chunker"]>;
+    chunkerMode: NonNullable<ChannelOutboundAdapter["chunkerMode"]>;
     textChunkLimit: number;
     sanitizeText: NonNullable<ChannelOutboundAdapter["sanitizeText"]>;
     sendText: (ctx: SynologyChannelSendTextContext) => Promise<SynologyChatOutboundResult>;
@@ -455,7 +458,9 @@ function createSynologyChatPlugin(): SynologyChatPlugin {
     },
     outbound: {
       deliveryMode: "gateway" as const,
-      textChunkLimit: 2000,
+      chunker: chunkTextForOutbound,
+      chunkerMode: "markdown" as const,
+      textChunkLimit: SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT,
       sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
       sendText: sendSynologyChatText,
       sendMedia: async (ctx) => {

--- a/extensions/synology-chat/src/client.loopback.test.ts
+++ b/extensions/synology-chat/src/client.loopback.test.ts
@@ -125,6 +125,47 @@ describe("Synology Chat user_list loopback", () => {
     }
   });
 
+  it("chunks long text before the Synology payload limit for every text adapter", async () => {
+    const receivedPayloads: Array<{ text: string; user_ids?: number[] }> = [];
+    const port = await listenLoopback((req, res) => {
+      let formBody = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk: string) => {
+        formBody += chunk;
+      });
+      req.on("end", () => {
+        const payload = JSON.parse(new URLSearchParams(formBody).get("payload") ?? "{}") as {
+          text?: string;
+          user_ids?: number[];
+        };
+        receivedPayloads.push({ text: payload.text ?? "", user_ids: payload.user_ids });
+        const accepted = (payload.text?.length ?? 0) <= 2_000;
+        res.writeHead(accepted ? 200 : 413, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ success: accepted }));
+      });
+    });
+    const incomingUrl = `http://127.0.0.1:${port}/webapi/entry.cgi`;
+    const cfg = {
+      channels: {
+        "synology-chat": {
+          enabled: true,
+          token: "loopback-token",
+          incomingUrl,
+        },
+      },
+    };
+    const text = "x".repeat(2_001);
+
+    await synologyChatPlugin.outbound.sendText({ cfg, text, to: "42" });
+    await synologyChatPlugin.message.send?.text?.({ cfg, text, to: "42" });
+    await sendMessage(incomingUrl, text, "42");
+
+    expect(receivedPayloads).toHaveLength(6);
+    expect(receivedPayloads.map(({ text: chunk }) => chunk).join("")).toBe(text + text + text);
+    expect(receivedPayloads.every(({ text: chunk }) => chunk.length <= 2_000)).toBe(true);
+    expect(receivedPayloads.every(({ user_ids }) => user_ids?.[0] === 42)).toBe(true);
+  });
+
   it("rejects unauthenticated webhook sends without fabricating delivery receipts", async () => {
     let rejectedRequests = 0;
     const port = await listenLoopback((_req, res) => {

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -14,9 +14,11 @@ import {
   resolvePinnedHostnameWithPolicy,
 } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 import { z } from "zod";
 
 const MIN_SEND_INTERVAL_MS = 500;
+export const SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT = 2_000;
 /** user_list JSON can be larger than inbound webhook pre-auth payloads. */
 const USER_LIST_RESPONSE_MAX_BYTES = 1 * 1024 * 1024;
 /** Wall-clock budget for user_list fetch including response body. */
@@ -94,6 +96,21 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
  * @returns true if sent successfully
  */
 export async function sendMessage(
+  incomingUrl: string,
+  text: string,
+  userId?: string | number,
+  allowInsecureSsl = false,
+): Promise<boolean> {
+  const chunks = chunkTextForOutbound(text, SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT);
+  for (const chunk of chunks.length > 0 ? chunks : [text]) {
+    if (!(await sendMessageChunk(incomingUrl, chunk, userId, allowInsecureSsl))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function sendMessageChunk(
   incomingUrl: string,
   text: string,
   userId?: string | number,


### PR DESCRIPTION
Related: #112041

Related: #112555

## What Problem This Solves

Fixes an issue where Synology Chat users lose OpenClaw replies longer than 2000 characters because the Synology webhook rejects the payload with `msg too long`.

## Why This Change Was Made

The channel now registers the standard Markdown-aware outbound chunker, and the Synology HTTP client enforces the same 2000-character limit at the transport boundary. Each chunk is sent in order through the existing rate-limit and retry path, so Gateway delivery, direct message/durable delivery, inbound agent replies, and pairing notifications share the same bound; a failed chunk still reports delivery failure.

## User Impact

Long Synology Chat replies are delivered as multiple ordered messages instead of being dropped as one oversized webhook request. Short messages and numeric recipients keep their existing behavior.

## Evidence

- Root cause: `extensions/synology-chat/src/channel.ts` declared `textChunkLimit` without a `chunker`, while direct text paths called `sendMessage` without any transport-level bound.
- Regression coverage: `extensions/synology-chat/src/channel.test.ts` verifies the gateway adapter declares bounded Markdown chunking; `extensions/synology-chat/src/client.loopback.test.ts` exercises outbound, durable/message, and direct client sends against a mock webhook that rejects payloads over 2000 characters and checks ordered chunks plus `user_ids`.
- Static checks run locally: `git diff --check`, `oxfmt --check` on all five changed files, and `oxlint --tsconfig config/tsconfig/oxlint.extensions.json` on all five changed files.
- `node scripts/check-changed.mjs --dry-run --base origin/main` classified the change as the extensions production and extension-tests lanes. The checkout has no local `node_modules`, so the focused Vitest and extension typecheck gates are delegated to CI.
- Real Synology NAS proof is not available in this environment; live-server behavior remains a CI/reviewer follow-up rather than a claimed pass.

## Parallel Repair Context

This is an independent repair of the same open issue. Existing PR #112555 remains open and was not modified, closed, assigned, force-pushed, or given additional commits. Its latest ClawSweeper review recorded an overall score of 2/6 (proof 2/6, patch quality 4/6) at head `a366e4e30e58bb4267e999cf4db2608dc0b800e8`; its author had no substantive update for more than 24 hours at the final pre-push refresh. No maintainer takeover or restricted-owner blocker was found. This branch was created from current `main` and additionally covers the direct text transport boundary that the earlier review identified for explicit checking.

## AI Assistance

This PR was prepared with AI-assisted tooling. The author reviewed and understands the changes and their verification limits.
