### PR TITLE
fix(channels): preserve bundled delivery contracts

### DIFF
--- a/extensions/discord/src/send.message-request.ts
+++ b/extensions/discord/src/send.message-request.ts
@@ -97,6 +97,13 @@ export function resolveDiscordMessageFlags(params: {
   return flags || undefined;
 }
 
+export function resolveDiscordSuppressEmbeds(params: {
+  configured?: boolean;
+  override?: boolean;
+}): boolean {
+  return params.override ?? params.configured ?? true;
+}
+
 type DiscordMessageRequestParams = {
   text: string;
   components?: TopLevelComponents[];

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -33,6 +33,7 @@ import {
   normalizeDiscordPollInput,
   normalizeStickerIds,
   resolveDiscordMessageFlags,
+  resolveDiscordSuppressEmbeds,
   resolveChannelId,
   resolveDiscordChannel,
   resolveDiscordSendComponents,
@@ -107,13 +108,6 @@ async function sendDiscordThreadTextChunks(params: {
       onResult: params.onResult,
     });
   }
-}
-
-function resolveDiscordSuppressEmbeds(params: {
-  configured?: boolean;
-  override?: boolean;
-}): boolean {
-  return params.override ?? params.configured ?? true;
 }
 
 /** Discord thread names are capped at 100 characters. */

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -48,6 +48,7 @@ export {
   buildDiscordMessageRequest,
   createDiscordMessageNonce,
   resolveDiscordMessageFlags,
+  resolveDiscordSuppressEmbeds,
   resolveDiscordSendComponents,
   resolveDiscordSendEmbeds,
   stripUndefinedFields,

--- a/extensions/discord/src/send.webhook-activity.test.ts
+++ b/extensions/discord/src/send.webhook-activity.test.ts
@@ -1,4 +1,5 @@
 // Discord tests cover send.webhook activity plugin behavior.
+import { MessageFlags } from "discord-api-types/v10";
 import { isRecentOutboundMessageIdentity } from "openclaw/plugin-sdk/channel-outbound";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -155,9 +156,72 @@ describe("sendWebhookMessageDiscord activity", () => {
         },
         body: JSON.stringify({
           content: "hello <@123456789012345678>",
+          flags: MessageFlags.SuppressEmbeds,
         }),
         signal: expect.any(AbortSignal),
       },
     ]);
   });
+
+  it.each([
+    {
+      name: "the default",
+      channelSuppressEmbeds: undefined,
+      accountSuppressEmbeds: undefined,
+      expectedFlags: MessageFlags.SuppressEmbeds,
+    },
+    {
+      name: "the channel opt-out",
+      channelSuppressEmbeds: false,
+      accountSuppressEmbeds: undefined,
+      expectedFlags: undefined,
+    },
+    {
+      name: "an account opt-out",
+      channelSuppressEmbeds: true,
+      accountSuppressEmbeds: false,
+      expectedFlags: undefined,
+    },
+    {
+      name: "an account opt-in",
+      channelSuppressEmbeds: false,
+      accountSuppressEmbeds: true,
+      expectedFlags: MessageFlags.SuppressEmbeds,
+    },
+  ])(
+    "applies $name for webhook link-preview suppression",
+    async ({ channelSuppressEmbeds, accountSuppressEmbeds, expectedFlags }) => {
+      const cfg = {
+        channels: {
+          discord: {
+            token: "resolved-token",
+            ...(channelSuppressEmbeds === undefined
+              ? {}
+              : { suppressEmbeds: channelSuppressEmbeds }),
+            accounts: {
+              runtime:
+                accountSuppressEmbeds === undefined
+                  ? {}
+                  : { suppressEmbeds: accountSuppressEmbeds },
+            },
+          },
+        },
+      };
+
+      await sendWebhookMessageDiscord("https://example.com", {
+        cfg,
+        webhookId: "wh-1",
+        webhookToken: "tok-1",
+        accountId: "runtime",
+        threadId: "thread-1",
+      });
+
+      const request = firstMockCall(vi.mocked(fetch), "fetch")[1] as RequestInit;
+      if (typeof request.body !== "string") {
+        throw new Error("expected webhook request body");
+      }
+      const body = JSON.parse(request.body) as { flags?: number };
+      expect(body.flags).toBe(expectedFlags);
+    },
+  );
 });

--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -20,6 +20,10 @@ import {
 import { rewriteDiscordKnownMentions } from "./mentions.js";
 import { DISCORD_REST_TIMEOUT_MS } from "./proxy-request-client.js";
 import { createDiscordRetryRunner } from "./retry.js";
+import {
+  resolveDiscordMessageFlags,
+  resolveDiscordSuppressEmbeds,
+} from "./send.message-request.js";
 import { createDiscordSendResult } from "./send.receipt.js";
 import type { DiscordSendResult } from "./send.types.js";
 
@@ -121,6 +125,9 @@ export async function sendWebhookMessageDiscord(
     accountId: account.accountId,
     mentionAliases: account.config.mentionAliases,
   });
+  const flags = resolveDiscordMessageFlags({
+    suppressEmbeds: resolveDiscordSuppressEmbeds({ configured: account.config.suppressEmbeds }),
+  });
   const threadConversationId = opts.threadId == null ? "" : String(opts.threadId).trim();
   if (threadConversationId) {
     // Reserve the webhook source before the request so an immediate gateway echo
@@ -156,6 +163,7 @@ export async function sendWebhookMessageDiscord(
             content: rewrittenText,
             username: normalizeOptionalString(opts.username),
             avatar_url: normalizeOptionalString(opts.avatarUrl),
+            ...(flags ? { flags } : {}),
             ...(messageReference ? { message_reference: messageReference } : {}),
           }),
           signal: deadline.signal,

--- a/extensions/qqbot/src/engine/messaging/target-parser.test.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.test.ts
@@ -27,6 +27,11 @@ describe("normalizeTarget", () => {
     ["qqbot:Group:GroupOpenId", "qqbot:group:GroupOpenId"],
     ["C2C:OpenId", "qqbot:c2c:OpenId"],
     ["qqbot:channel:ChannelId", "qqbot:channel:ChannelId"],
+    ["qqbot:0123456789abcdef0123456789abcdef", "qqbot:c2c:0123456789abcdef0123456789abcdef"],
+    [
+      "QQBOT:01234567-89ab-cdef-0123-456789abcdef",
+      "qqbot:c2c:01234567-89ab-cdef-0123-456789abcdef",
+    ],
   ])("normalizes %s to %s", (to, normalized) => {
     expect(looksLikeQQBotTarget(to)).toBe(true);
     expect(normalizeTarget(to)).toBe(normalized);

--- a/extensions/qqbot/src/engine/messaging/target-parser.ts
+++ b/extensions/qqbot/src/engine/messaging/target-parser.ts
@@ -89,12 +89,5 @@ export function normalizeTarget(target: string): string | undefined {
  * Return true when the string looks like a QQ Bot target ID.
  */
 export function looksLikeQQBotTarget(id: string): boolean {
-  const unqualifiedId = id.replace(/^qqbot:/i, "");
-  if (parseTypedTarget(unqualifiedId)) {
-    return true;
-  }
-  if (/^[0-9a-fA-F]{32}$/.test(id)) {
-    return true;
-  }
-  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
+  return normalizeTarget(id) !== undefined;
 }

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1178,6 +1178,18 @@ describe("resolveSlackAttachmentContent", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("preserves forwarded file identities when downloads fail", async () => {
+    const file = { id: "FFORWARD", name: "forwarded-report.pdf" };
+    const result = await resolveSlackAttachmentContent({
+      attachments: [{ is_share: true, files: [file] }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).toEqual({ text: "", media: [], files: [file] });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("skips forwarded image URLs on non-Slack hosts", async () => {
     const result = await resolveSlackAttachmentContent({
       attachments: [{ is_share: true, image_url: "https://example.com/forwarded.jpg" }],

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -411,7 +411,7 @@ export async function resolveSlackAttachmentContent(params: {
   readIdleTimeoutMs?: number;
   totalTimeoutMs?: number;
   abortSignal?: AbortSignal;
-}): Promise<{ text: string; media: SlackMediaResult[] } | null> {
+}): Promise<{ text: string; media: SlackMediaResult[]; files?: SlackFile[] } | null> {
   const attachments = params.attachments;
   if (!attachments || attachments.length === 0) {
     return null;
@@ -426,6 +426,7 @@ export async function resolveSlackAttachmentContent(params: {
 
   const textBlocks: string[] = [];
   const allMedia: SlackMediaResult[] = [];
+  const allFiles = forwardedAttachments.flatMap((attachment) => attachment.files ?? []);
   const govSlack = isGovSlackClient(params.client);
 
   for (const att of forwardedAttachments) {
@@ -485,8 +486,12 @@ export async function resolveSlackAttachmentContent(params: {
   }
 
   const combinedText = textBlocks.join("\n\n");
-  if (!combinedText && allMedia.length === 0) {
+  if (!combinedText && allMedia.length === 0 && allFiles.length === 0) {
     return null;
   }
-  return { text: combinedText, media: allMedia };
+  return {
+    text: combinedText,
+    media: allMedia,
+    ...(allFiles.length > 0 ? { files: allFiles } : {}),
+  };
 }

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -136,7 +136,20 @@ export async function resolveSlackMessageContent(params: {
     ? effectiveDirectMedia.map((item) => item.placeholder).join(" ")
     : undefined;
 
-  const fallbackFiles = ownFiles ?? [];
+  const fallbackFileIds = new Set<string>();
+  const fallbackFiles = [...(ownFiles ?? []), ...(attachmentContent?.files ?? [])].filter(
+    (file) => {
+      const fileId = normalizeOptionalString(file.id);
+      if (!fileId) {
+        return true;
+      }
+      if (fallbackFileIds.has(fileId)) {
+        return false;
+      }
+      fallbackFileIds.add(fileId);
+      return true;
+    },
+  );
   const fileOnlyFallback =
     !mediaPlaceholder && fallbackFiles.length > 0
       ? fallbackFiles

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1766,6 +1766,52 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.RawBody).toContain("photo.jpg (fileId: FPHOTO)");
   });
 
+  it("delivers forwarded file-only messages with metadata when media download fails", async () => {
+    const prepared = await prepareWithDefaultCtx(
+      createSlackMessage({
+        text: "",
+        files: [],
+        attachments: [
+          {
+            is_share: true,
+            files: [{ id: "FFORWARD", name: "forwarded-report.pdf" }],
+          },
+        ],
+      }),
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.RawBody).toContain(
+      "[Slack file: forwarded-report.pdf (fileId: FFORWARD)]",
+    );
+  });
+
+  it("preserves direct and forwarded files without duplicating shared identities", async () => {
+    const prepared = await prepareWithDefaultCtx(
+      createSlackMessage({
+        text: "",
+        files: [
+          { id: "FDIRECT", name: "direct-report.pdf" },
+          { id: "FSHARED", name: "shared-report.pdf" },
+        ],
+        attachments: [
+          {
+            is_share: true,
+            files: [
+              { id: "FSHARED", name: "shared-report.pdf" },
+              { id: "FFORWARD", name: "forwarded-report.pdf" },
+            ],
+          },
+        ],
+      }),
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.RawBody).toContain(
+      "[Slack file: direct-report.pdf (fileId: FDIRECT), shared-report.pdf (fileId: FSHARED), forwarded-report.pdf (fileId: FFORWARD)]",
+    );
+  });
+
   it("falls back to generic file label when a Slack file name is empty", async () => {
     const prepared = await prepareWithDefaultCtx(
       createSlackMessage({

--- a/extensions/telegram/src/telegram-ingress-supersede.test.ts
+++ b/extensions/telegram/src/telegram-ingress-supersede.test.ts
@@ -233,6 +233,52 @@ describe("telegram ingress supersede policy", () => {
     ).toBe(true);
   });
 
+  it("does not supersede when a bot_command entity appears inside ordinary text", async () => {
+    const ourBotAuth = {
+      ...auth,
+      botUsername: "mybot",
+    };
+    const shouldSupersedeOurBot = createShouldSupersedeTelegramSpooledPending(ourBotAuth);
+    const commandText = "/deploy@mybot";
+    const ordinaryText = `Please run ${commandText} after this finishes`;
+    const ordinaryMessage = messageUpdate({
+      updateId: 2,
+      text: ordinaryText,
+      senderId: OWNER_ID,
+      entities: [
+        {
+          type: "bot_command",
+          offset: ordinaryText.indexOf(commandText),
+          length: commandText.length,
+        },
+      ],
+    });
+    const ordinaryCaption = {
+      update_id: 3,
+      message: {
+        caption: ordinaryText,
+        caption_entities: [
+          {
+            type: "bot_command",
+            offset: ordinaryText.indexOf(commandText),
+            length: commandText.length,
+          },
+        ],
+        from: { id: Number(OWNER_ID) },
+        chat: { id: Number(OWNER_ID), type: "private" },
+      },
+    };
+
+    for (const update of [ordinaryMessage, ordinaryCaption]) {
+      expect(
+        await shouldSupersedeOurBot(
+          record(String(update.update_id), update),
+          claim("1", messageUpdate({ updateId: 1, text: "prior", senderId: OWNER_ID })),
+        ),
+      ).toBe(false);
+    }
+  });
+
   it("does not supersede bot_command entities addressed to another bot", async () => {
     const ourBotAuth = {
       ...auth,

--- a/extensions/telegram/src/telegram-ingress-supersede.ts
+++ b/extensions/telegram/src/telegram-ingress-supersede.ts
@@ -89,7 +89,8 @@ function updateHasBotCommandEntityForBot(update: unknown, botUsername?: string):
         if (ent.type !== "bot_command") {
           continue;
         }
-        if (typeof ent.offset !== "number" || typeof ent.length !== "number") {
+        // Telegram command handlers only accept entities at the start of a message.
+        if (ent.offset !== 0 || typeof ent.length !== "number") {
           continue;
         }
         const commandText = body.slice(ent.offset, ent.offset + ent.length);


### PR DESCRIPTION
## What this fixes

- Telegram: ordinary text containing `/command@bot` no longer cancels an earlier pending reply.
- Slack: forwarded file-only messages keep useful file metadata when download fails.
- Discord: webhook sends honor the existing link-preview suppression setting.
- QQBot: prefixed bare openids and UUIDs are recognized as valid targets.

## Scope

Rebuilt on current `main` around four reproduced failures. Matrix, Teams, SMS, and WhatsApp changes were removed because equivalent fixes already landed. The OpenAI speech change was removed because production already normalizes the base URL. The Google Meet change was removed because the mocked cancelled event is outside the current Calendar request contract; that behavior needs separate proof before changing production.

Production delta: +42/-20. Tests: +173/-0. No config or default surfaces added, changed, or removed; Discord applies an existing setting to the webhook path.

## Evidence

- OpenClaw-org Blacksmith Testbox: exact-head `pnpm check:changed` passed, including extension/test typechecks, lint, formatting, dead-code, boundary, and import-cycle gates.
- Focused tests: 240 passed across Discord, QQBot, Slack, and Telegram.
- Full `pnpm build` passed.
- Telegram real-user E2E: a delayed reply completed while inline `/status@bot` text started its own turn; 3 sends, 1 edit, 0 pending updates.
- Discord real-user E2E: one clean `OPENCLAW_E2E_OK` reply.
- Distill, greybeard, and Codex autoreview: no actionable findings.

```json
{"scenario":"telegram inline command during pending reply","driver":"telegram-e2e-userbot","result":"pass","messages":3,"edits":1,"pendingAfter":0}
```
