### PR TITLE
fix(ui): restore settings search, media previews, clipboard, and native chat

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt
@@ -40,7 +40,12 @@ internal object ChatEventText {
       ?.takeIf { it.isNotEmpty() }
       ?.let { return it }
     val obj = part.asObjectOrNull() ?: return null
-    val type = obj["type"].asStringOrNull()?.trim()?.lowercase().orEmpty()
+    val type =
+      obj["type"]
+        .asStringOrNull()
+        ?.trim()
+        ?.lowercase()
+        .orEmpty()
     if (type !in visibleAssistantTextTypes) return null
     return obj["text"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/ChatEventText.kt
@@ -6,6 +6,8 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
 internal object ChatEventText {
+  private val visibleAssistantTextTypes = setOf("", "text", "input_text", "output_text")
+
   /** Extracts assistant reply text from a gateway chat event payload. */
   fun assistantTextFromPayload(payload: JsonObject): String? = assistantTextFromMessage(payload["message"])
 
@@ -38,8 +40,8 @@ internal object ChatEventText {
       ?.takeIf { it.isNotEmpty() }
       ?.let { return it }
     val obj = part.asObjectOrNull() ?: return null
-    val type = obj["type"].asStringOrNull()
-    if (type != null && type != "text") return null
+    val type = obj["type"].asStringOrNull()?.trim()?.lowercase().orEmpty()
+    if (type !in visibleAssistantTextTypes) return null
     return obj["text"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/ChatEventTextTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/ChatEventTextTest.kt
@@ -30,6 +30,32 @@ class ChatEventTextTest {
   }
 
   @Test
+  fun preservesResponsesTextAndIgnoresTypedNonTextBlocks() {
+    val payload =
+      payload(
+        """
+        {
+          "message": {
+            "role": "assistant",
+            "content": [
+              { "type": "thinking", "text": "private reasoning" },
+              { "type": "output_text", "text": "visible output" },
+              { "type": "input_text", "text": "visible input" },
+              { "type": "tool_result", "text": "tool payload" },
+              { "text": "legacy visible" }
+            ]
+          }
+        }
+        """,
+      )
+
+    assertEquals(
+      "visible output\nvisible input\nlegacy visible",
+      ChatEventText.assistantTextFromPayload(payload),
+    )
+  }
+
+  @Test
   fun extractsPlainStringContent() {
     val payload =
       payload(

--- a/apps/ios/Sources/Model/WatchReplyCoordinator.swift
+++ b/apps/ios/Sources/Model/WatchReplyCoordinator.swift
@@ -96,9 +96,11 @@ enum WatchChatPresentation {
 
     private nonisolated static func decodeMessage(_ raw: OpenClawKit.AnyCodable) -> MessageEntry? {
         guard let data = try? JSONEncoder().encode(raw),
-              let message = try? JSONDecoder().decode(OpenClawChatMessage.self, from: data),
-              let text = nonEmptyText(messageText(message))
+              let message = try? JSONDecoder().decode(OpenClawChatMessage.self, from: data)
         else { return nil }
+        let text = ChatMessageVisibleText.visibleText(in: message)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
         let metadata = try? JSONDecoder().decode(MetadataEnvelope.self, from: data)
         return MessageEntry(
             message: message,
@@ -114,29 +116,6 @@ enum WatchChatPresentation {
             .map { String(format: "%02x", $0) }
             .joined()
         return "\(entry.message.role)-\(digest)"
-    }
-
-    private nonisolated static func messageText(_ message: OpenClawChatMessage) -> String {
-        let parts = message.content.compactMap { content -> String? in
-            let kind = (content.type ?? "text").lowercased()
-            guard kind.isEmpty || kind == "text" || kind == "output_text" else { return nil }
-            if let text = Self.nonEmptyText(content.text) { return text }
-            if let text = Self.nonEmptyText(content.content?.value as? String) { return text }
-            if let values = content.content?.value as? [String: OpenClawKit.AnyCodable] {
-                return Self.nonEmptyText(values["text"]?.value as? String)
-            }
-            return nil
-        }
-        let contentText = parts.joined(separator: "\n")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return contentText.isEmpty
-            ? message.errorMessage?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            : contentText
-    }
-
-    private nonisolated static func nonEmptyText(_ text: String?) -> String? {
-        let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
     }
 
     private nonisolated static func truncatedText(_ text: String) -> String {

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -5377,18 +5377,28 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
         #expect(reply == "Update sent")
     }
 
-    @Test func `watch chat preview reads responses output text`() throws {
-        let rawMessages = try [
-            makeWatchChatRawMessage(
-                role: "assistant",
-                text: "Responses reply",
-                type: "output_text",
-                timestamp: 1000),
-        ]
+    @Test func `watch chat uses shared responses text projection`() throws {
+        for type in ["input_text", "output_text"] {
+            let runID = "watch-\(type)"
+            let rawMessages = try [
+                makeWatchChatRawMessage(
+                    role: "assistant",
+                    text: "Responses \(type)",
+                    type: type,
+                    timestamp: 1000,
+                    idempotencyKey: runID),
+            ]
 
-        let items = WatchChatPresentation.makeItems(from: rawMessages)
+            let items = WatchChatPresentation.makeItems(from: rawMessages)
+            let reply = WatchChatPresentation.replyText(
+                from: rawMessages,
+                runID: runID,
+                submittedText: "Question",
+                submittedAtMs: 500)
 
-        #expect(items.map(\.text) == ["Responses reply"])
+            #expect(items.map(\.text) == ["Responses \(type)"])
+            #expect(reply == "Responses \(type)")
+        }
     }
 
     @Test func `watch voice reply matches direct run instead of newest assistant`() throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatEventText.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatEventText.swift
@@ -50,8 +50,7 @@ public enum OpenClawChatEventText {
         guard let object = self.dictionary(from: value) else { return nil }
         guard ChatMessageVisibleText.isVisibleContentType(
             self.stringValue(object["type"]),
-            role: "assistant"
-        )
+            role: "assistant")
         else { return nil }
         return self.trimmed(self.stringValue(object["text"]) ?? "")
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatEventText.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatEventText.swift
@@ -48,6 +48,11 @@ public enum OpenClawChatEventText {
             return self.trimmed(text)
         }
         guard let object = self.dictionary(from: value) else { return nil }
+        guard ChatMessageVisibleText.isVisibleContentType(
+            self.stringValue(object["type"]),
+            role: "assistant"
+        )
+        else { return nil }
         return self.trimmed(self.stringValue(object["text"]) ?? "")
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageVisibleText.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageVisibleText.swift
@@ -11,7 +11,10 @@ public enum ChatMessageVisibleText {
             return true
         }
         let normalizedRole = role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return kind == "input_text" || (normalizedRole == "assistant" && kind == "output_text")
+        if kind == "input_text" {
+            return normalizedRole == "user" || normalizedRole == "assistant"
+        }
+        return normalizedRole == "assistant" && kind == "output_text"
     }
 
     static func copyText(in message: OpenClawChatMessage) -> String {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageVisibleText.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageVisibleText.swift
@@ -5,6 +5,15 @@ import Foundation
 /// transcript exporter and the Listen action so exported and spoken text
 /// always match the visible transcript.
 public enum ChatMessageVisibleText {
+    static func isVisibleContentType(_ type: String?, role: String) -> Bool {
+        let kind = type?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        if kind.isEmpty || kind == "text" {
+            return true
+        }
+        let normalizedRole = role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return kind == "input_text" || (normalizedRole == "assistant" && kind == "output_text")
+    }
+
     static func copyText(in message: OpenClawChatMessage) -> String {
         let role = message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return role == "assistant" ? self.visibleText(in: message) : self.primaryText(in: message)
@@ -29,8 +38,8 @@ public enum ChatMessageVisibleText {
         let isAssistant = message.role.trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased() == "assistant"
         let parts = message.content.compactMap { content -> String? in
-            let kind = (content.type ?? "text").lowercased()
-            if kind == "text" || kind.isEmpty {
+            let kind = content.type?.lowercased() ?? ""
+            if self.isVisibleContentType(kind, role: message.role) {
                 return content.text
             }
             guard

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatEventTextTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatEventTextTests.swift
@@ -1,7 +1,7 @@
 import Foundation
+@testable import OpenClawChatUI
 import OpenClawKit
 import Testing
-@testable import OpenClawChatUI
 
 struct ChatEventTextTests {
     @Test func `decodes v3 and v4 chat delta payloads`() throws {
@@ -16,7 +16,8 @@ struct ChatEventTextTests {
 
         #expect(
             decoded.map { OpenClawChatEventText.assistantText(from: $0) } ==
-                ["v3 reply", "v4 reply"])
+                ["v3 reply", "v4 reply"]
+        )
     }
 
     @Test func `extracts assistant text from final chat event message`() {
@@ -31,9 +32,53 @@ struct ChatEventTextTests {
                     ["type": "text", "text": "world"],
                 ],
             ]),
-            errorMessage: nil)
+            errorMessage: nil
+        )
 
         #expect(OpenClawChatEventText.assistantText(from: event) == "hello\nworld")
+    }
+
+    @Test func `keeps responses text and ignores typed non text blocks`() {
+        let event = OpenClawChatEventPayload(
+            runId: "run-mixed",
+            sessionKey: "main",
+            state: "final",
+            message: AnyCodable([
+                "role": "assistant",
+                "content": [
+                    ["type": "thinking", "text": "private reasoning"],
+                    ["type": "output_text", "text": "visible output"],
+                    ["type": "input_text", "text": "visible input"],
+                    ["type": "tool_result", "text": "tool payload"],
+                    ["type": "image", "text": "image caption"],
+                    ["text": "legacy visible"],
+                ],
+            ]),
+            errorMessage: nil
+        )
+
+        #expect(
+            OpenClawChatEventText.assistantText(from: event) ==
+                "visible output\nvisible input\nlegacy visible"
+        )
+    }
+
+    @Test func `returns nil for typed non text content`() {
+        let event = OpenClawChatEventPayload(
+            runId: "run-non-text",
+            sessionKey: "main",
+            state: "delta",
+            message: AnyCodable([
+                "role": "assistant",
+                "content": [
+                    ["type": "thinking", "text": "private reasoning"],
+                    ["type": "tool_result", "text": "tool payload"],
+                ],
+            ]),
+            errorMessage: nil
+        )
+
+        #expect(OpenClawChatEventText.assistantText(from: event) == nil)
     }
 
     @Test func `ignores user messages`() {
@@ -45,7 +90,8 @@ struct ChatEventTextTests {
                 "role": "user",
                 "content": [["type": "text", "text": "ignore me"]],
             ]),
-            errorMessage: nil)
+            errorMessage: nil
+        )
 
         #expect(OpenClawChatEventText.assistantText(from: event) == nil)
     }
@@ -59,7 +105,8 @@ struct ChatEventTextTests {
                 "role": "assistant",
                 "content": "plain reply",
             ]),
-            errorMessage: nil)
+            errorMessage: nil
+        )
 
         #expect(OpenClawChatEventText.assistantText(from: event) == "plain reply")
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMessageVisibleTextTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMessageVisibleTextTests.swift
@@ -113,6 +113,24 @@ struct ChatMessageVisibleTextTests {
         )
     }
 
+    @Test func `responses text visibility follows the chat role contract`() {
+        let cases: [(role: String, type: String, expected: Bool)] = [
+            ("user", "input_text", true),
+            ("assistant", "input_text", true),
+            ("assistant", "output_text", true),
+            ("user", "output_text", false),
+            ("developer", "input_text", false),
+            ("toolResult", "input_text", false),
+        ]
+
+        for entry in cases {
+            #expect(
+                ChatMessageVisibleText.isVisibleContentType(entry.type, role: entry.role)
+                    == entry.expected
+            )
+        }
+    }
+
     @Test func `history decode retains transcript identity and truncation signals`() throws {
         let metadata = try JSONDecoder().decode(
             OpenClawChatMessage.self,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMessageVisibleTextTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMessageVisibleTextTests.swift
@@ -1,9 +1,13 @@
 import Foundation
-import Testing
 @testable import OpenClawChatUI
+import Testing
 
 private func textContent(_ text: String) -> OpenClawChatMessageContent {
     OpenClawChatMessageContent(type: "text", text: text, mimeType: nil, fileName: nil, content: nil)
+}
+
+private func typedTextContent(_ type: String?, _ text: String) -> OpenClawChatMessageContent {
+    OpenClawChatMessageContent(type: type, text: text, mimeType: nil, fileName: nil, content: nil)
 }
 
 private func toolCallContent(name: String) -> OpenClawChatMessageContent {
@@ -14,7 +18,8 @@ private func toolCallContent(name: String) -> OpenClawChatMessageContent {
         fileName: nil,
         content: nil,
         id: "call-1",
-        name: name)
+        name: name
+    )
 }
 
 private func thinkingContent(_ thinking: String) -> OpenClawChatMessageContent {
@@ -24,7 +29,8 @@ private func thinkingContent(_ thinking: String) -> OpenClawChatMessageContent {
         thinking: thinking,
         mimeType: nil,
         fileName: nil,
-        content: nil)
+        content: nil
+    )
 }
 
 @Suite("ChatMessageVisibleText")
@@ -37,7 +43,8 @@ struct ChatMessageVisibleTextTests {
                 toolCallContent(name: "exec"),
                 textContent("And a follow-up."),
             ],
-            timestamp: 1)
+            timestamp: 1
+        )
 
         #expect(ChatMessageVisibleText.visibleText(in: message)
             == "Here is the answer.\nAnd a follow-up.")
@@ -47,7 +54,8 @@ struct ChatMessageVisibleTextTests {
         let message = OpenClawChatMessage(
             role: "user",
             content: [textContent("What is <final>up</final>?")],
-            timestamp: 1)
+            timestamp: 1
+        )
 
         #expect(ChatMessageVisibleText.visibleText(in: message) == "What is <final>up</final>?")
     }
@@ -56,11 +64,13 @@ struct ChatMessageVisibleTextTests {
         let assistant = OpenClawChatMessage(
             role: "assistant",
             content: [textContent("<think>private reasoning</think>\nVisible **answer**")],
-            timestamp: 1)
+            timestamp: 1
+        )
         let user = OpenClawChatMessage(
             role: "user",
             content: [textContent("Keep <think>this literal tag</think>")],
-            timestamp: 1)
+            timestamp: 1
+        )
 
         #expect(ChatMessageVisibleText.copyText(in: assistant) == "Visible **answer**")
         #expect(ChatMessageVisibleText.copyText(in: user) == "Keep <think>this literal tag</think>")
@@ -74,7 +84,8 @@ struct ChatMessageVisibleTextTests {
                 textContent("Here is the answer."),
                 toolCallContent(name: "read"),
             ],
-            timestamp: 1)
+            timestamp: 1
+        )
 
         #expect(ChatMessageVisibleText.displayText(in: message, includeThinking: false)
             == "Here is the answer.")
@@ -83,13 +94,34 @@ struct ChatMessageVisibleTextTests {
         #expect(ChatMessageVisibleText.copyText(in: message) == "Here is the answer.")
     }
 
+    @Test func `assistant display preserves responses text types`() {
+        let message = OpenClawChatMessage(
+            role: "assistant",
+            content: [
+                typedTextContent("thinking", "private"),
+                typedTextContent("output_text", "visible output"),
+                typedTextContent("input_text", "visible input"),
+                typedTextContent("tool_result", "tool payload"),
+                typedTextContent(nil, "legacy visible"),
+            ],
+            timestamp: 1
+        )
+
+        #expect(
+            ChatMessageVisibleText.displayText(in: message, includeThinking: false) ==
+                "visible output\nvisible input\nlegacy visible"
+        )
+    }
+
     @Test func `history decode retains transcript identity and truncation signals`() throws {
         let metadata = try JSONDecoder().decode(
             OpenClawChatMessage.self,
-            from: Data(#"{"role":"assistant","content":"short","__openclaw":{"id":"msg-1","truncated":true}}"#.utf8))
+            from: Data(#"{"role":"assistant","content":"short","__openclaw":{"id":"msg-1","truncated":true}}"#.utf8)
+        )
         let marker = try JSONDecoder().decode(
             OpenClawChatMessage.self,
-            from: Data(#"{"role":"assistant","content":"short\n...(truncated)...","__openclaw":{"id":"msg-2"}}"#.utf8))
+            from: Data(#"{"role":"assistant","content":"short\n...(truncated)...","__openclaw":{"id":"msg-2"}}"#.utf8)
+        )
 
         #expect(metadata.transcriptMessageID == "msg-1")
         #expect(metadata.isTruncated)
@@ -103,11 +135,13 @@ struct ChatMessageVisibleTextTests {
             content: [textContent("short\n...(truncated)...")],
             timestamp: 1,
             transcriptMessageID: "msg-round-trip",
-            isTruncated: true)
+            isTruncated: true
+        )
 
         let decoded = try JSONDecoder().decode(
             OpenClawChatMessage.self,
-            from: JSONEncoder().encode(original))
+            from: JSONEncoder().encode(original)
+        )
 
         #expect(decoded.transcriptMessageID == "msg-round-trip")
         #expect(decoded.isTruncated)
@@ -123,19 +157,23 @@ struct ChatMessageVisibleTextTests {
         let toolOnly = OpenClawChatMessage(
             role: "assistant",
             content: [toolCallContent(name: "exec")],
-            timestamp: 1)
+            timestamp: 1
+        )
         let blank = OpenClawChatMessage(
             role: "assistant",
             content: [textContent("   ")],
-            timestamp: 1)
+            timestamp: 1
+        )
         let spoken = OpenClawChatMessage(
             role: "assistant",
             content: [textContent("Say this")],
-            timestamp: 1)
+            timestamp: 1
+        )
         let thinkingOnly = OpenClawChatMessage(
             role: "assistant",
             content: [textContent("<think>Do not speak this</think>")],
-            timestamp: 1)
+            timestamp: 1
+        )
 
         #expect(!ChatMessageVisibleText.hasVisibleText(in: toolOnly))
         #expect(!ChatMessageVisibleText.hasVisibleText(in: blank))

--- a/ui/src/components/config-form.analyze.ts
+++ b/ui/src/components/config-form.analyze.ts
@@ -1,6 +1,7 @@
 // Control UI view renders config form.analyze screen content.
 import {
   arrayItemSchema,
+  arrayItemSchemaIndexes,
   objectAdditionalPropertiesSchema,
   objectPropertyKeys,
   objectPropertySchema,
@@ -175,28 +176,6 @@ function schemaAllowsNull(schema: JsonSchema, seen = new Set<JsonSchema>()): boo
   }
   seen.delete(schema);
   return allowsNull;
-}
-
-function effectiveArrayItemIndexes(schema: JsonSchema): number[] {
-  const pending = [schema];
-  const seen = new Set<JsonSchema>();
-  let maxTupleLength = 0;
-  let hasRepeatedItems = false;
-  while (pending.length > 0) {
-    const current = pending.pop();
-    if (!current || seen.has(current)) {
-      continue;
-    }
-    seen.add(current);
-    if (Array.isArray(current.items)) {
-      maxTupleLength = Math.max(maxTupleLength, current.items.length);
-    } else if (current.items) {
-      hasRepeatedItems = true;
-    }
-    pending.push(...(current.allOf ?? []));
-  }
-  const count = Math.max(maxTupleLength, hasRepeatedItems ? 1 : 0);
-  return Array.from({ length: count }, (_, index) => index);
 }
 
 function hasUnrepresentableComposedAdditionalProperties(schema: JsonSchema): boolean {
@@ -452,7 +431,7 @@ function normalizeSchemaNode(
       }
     }
     if (schema.allOf) {
-      for (const index of effectiveArrayItemIndexes(schema)) {
+      for (const index of arrayItemSchemaIndexes(schema)) {
         const effectiveSchema = arrayItemSchema(schema, index);
         if (!effectiveSchema) {
           continue;

--- a/ui/src/components/config-form.analyze.ts
+++ b/ui/src/components/config-form.analyze.ts
@@ -1,7 +1,6 @@
+import { arrayItemSchema, arrayItemSchemaIndexes } from "./config-form.array-items.ts";
 // Control UI view renders config form.analyze screen content.
 import {
-  arrayItemSchema,
-  arrayItemSchemaIndexes,
   objectAdditionalPropertiesSchema,
   objectPropertyKeys,
   objectPropertySchema,

--- a/ui/src/components/config-form.array-items.ts
+++ b/ui/src/components/config-form.array-items.ts
@@ -1,0 +1,65 @@
+import { schemaType, type JsonSchema } from "./config-form.shared.ts";
+
+export function collectAllOfSchemas(schema: JsonSchema): JsonSchema[] {
+  const result: JsonSchema[] = [];
+  const pending = [schema];
+  const seen = new Set<JsonSchema>();
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    result.push(current);
+    for (let index = (current.allOf?.length ?? 0) - 1; index >= 0; index -= 1) {
+      const entry = current.allOf?.[index];
+      if (entry) {
+        pending.push(entry);
+      }
+    }
+  }
+  return result;
+}
+
+export function combinedSchema(candidates: JsonSchema[]): JsonSchema | undefined {
+  const base = candidates.find((candidate) => schemaType(candidate) !== undefined) ?? candidates[0];
+  return !base || candidates.length === 1
+    ? base
+    : {
+        ...base,
+        allOf: [...(base.allOf ?? []), ...candidates.filter((candidate) => candidate !== base)],
+      };
+}
+
+export function arrayItemSchema(schema: JsonSchema, index: number): JsonSchema | undefined {
+  const candidates: JsonSchema[] = [];
+  for (const entry of collectAllOfSchemas(schema)) {
+    if (Array.isArray(entry.items)) {
+      const item =
+        entry.items[index] ??
+        (entry.additionalItems && typeof entry.additionalItems === "object"
+          ? entry.additionalItems
+          : undefined);
+      if (item) {
+        candidates.push(item);
+      }
+    } else if (entry.items) {
+      candidates.push(entry.items);
+    }
+  }
+  return combinedSchema(candidates);
+}
+
+export function arrayItemSchemaIndexes(schema: JsonSchema): number[] {
+  let count = 0;
+  for (const entry of collectAllOfSchemas(schema)) {
+    if (Array.isArray(entry.items)) {
+      const hasTypedTail =
+        entry.additionalItems !== null && typeof entry.additionalItems === "object";
+      count = Math.max(count, entry.items.length + (hasTypedTail ? 1 : 0));
+    } else if (entry.items) {
+      count = Math.max(count, 1);
+    }
+  }
+  return Array.from({ length: count }, (_, index) => index);
+}

--- a/ui/src/components/config-form.array-items.ts
+++ b/ui/src/components/config-form.array-items.ts
@@ -52,14 +52,21 @@ export function arrayItemSchema(schema: JsonSchema, index: number): JsonSchema |
 
 export function arrayItemSchemaIndexes(schema: JsonSchema): number[] {
   let count = 0;
+  let closedLength: number | undefined;
   for (const entry of collectAllOfSchemas(schema)) {
     if (Array.isArray(entry.items)) {
       const hasTypedTail =
         entry.additionalItems !== null && typeof entry.additionalItems === "object";
       count = Math.max(count, entry.items.length + (hasTypedTail ? 1 : 0));
+      if (entry.additionalItems === false) {
+        closedLength = Math.min(closedLength ?? Number.POSITIVE_INFINITY, entry.items.length);
+      }
     } else if (entry.items) {
       count = Math.max(count, 1);
     }
+  }
+  if (closedLength !== undefined) {
+    count = Math.min(count, closedLength);
   }
   return Array.from({ length: count }, (_, index) => index);
 }

--- a/ui/src/components/config-form.constraints.ts
+++ b/ui/src/components/config-form.constraints.ts
@@ -4,6 +4,7 @@ import {
   jsonSchemaValuesEqual,
 } from "@openclaw/normalization-core/json-schema";
 import { asFiniteNumber as finiteNumber } from "@openclaw/normalization-core/number-coercion";
+import { arrayItemSchema, collectAllOfSchemas, combinedSchema } from "./config-form.array-items.ts";
 import { decimalRational } from "./config-form.numeric.ts";
 import { schemaType, type JsonSchema } from "./config-form.shared.ts";
 
@@ -109,27 +110,6 @@ type EffectiveNumericBound = {
   value?: number;
   exclusive: boolean;
 };
-
-function collectAllOfSchemas(schema: JsonSchema): JsonSchema[] {
-  const result: JsonSchema[] = [];
-  const pending = [schema];
-  const seen = new Set<JsonSchema>();
-  while (pending.length > 0) {
-    const current = pending.pop();
-    if (!current || seen.has(current)) {
-      continue;
-    }
-    seen.add(current);
-    result.push(current);
-    for (let index = (current.allOf?.length ?? 0) - 1; index >= 0; index -= 1) {
-      const entry = current.allOf?.[index];
-      if (entry) {
-        pending.push(entry);
-      }
-    }
-  }
-  return result;
-}
 
 function effectiveNumericBound(
   schemas: JsonSchema[],
@@ -239,16 +219,6 @@ export function objectPropertyKeys(schema: JsonSchema): string[] {
   );
 }
 
-function combinedSchema(candidates: JsonSchema[]): JsonSchema | undefined {
-  const base = candidates.find((candidate) => schemaType(candidate) !== undefined) ?? candidates[0];
-  return !base || candidates.length === 1
-    ? base
-    : {
-        ...base,
-        allOf: [...(base.allOf ?? []), ...candidates.filter((candidate) => candidate !== base)],
-      };
-}
-
 export function objectAdditionalPropertiesSchema(
   schema: JsonSchema,
 ): JsonSchema | false | undefined {
@@ -319,39 +289,6 @@ export function objectPropertySchema(schema: JsonSchema, key: string): JsonSchem
       .map((entry) => ownPropertySchema(entry, key))
       .filter((property): property is JsonSchema => property !== undefined),
   );
-}
-
-export function arrayItemSchema(schema: JsonSchema, index: number): JsonSchema | undefined {
-  const candidates: JsonSchema[] = [];
-  for (const entry of collectAllOfSchemas(schema)) {
-    if (Array.isArray(entry.items)) {
-      const item =
-        entry.items[index] ??
-        (entry.additionalItems && typeof entry.additionalItems === "object"
-          ? entry.additionalItems
-          : undefined);
-      if (item) {
-        candidates.push(item);
-      }
-    } else if (entry.items) {
-      candidates.push(entry.items);
-    }
-  }
-  return combinedSchema(candidates);
-}
-
-export function arrayItemSchemaIndexes(schema: JsonSchema): number[] {
-  let count = 0;
-  for (const entry of collectAllOfSchemas(schema)) {
-    if (Array.isArray(entry.items)) {
-      const hasTypedTail =
-        entry.additionalItems !== null && typeof entry.additionalItems === "object";
-      count = Math.max(count, entry.items.length + (hasTypedTail ? 1 : 0));
-    } else if (entry.items) {
-      count = Math.max(count, 1);
-    }
-  }
-  return Array.from({ length: count }, (_, index) => index);
 }
 
 export function arrayConstraintCandidates(

--- a/ui/src/components/config-form.constraints.ts
+++ b/ui/src/components/config-form.constraints.ts
@@ -340,6 +340,20 @@ export function arrayItemSchema(schema: JsonSchema, index: number): JsonSchema |
   return combinedSchema(candidates);
 }
 
+export function arrayItemSchemaIndexes(schema: JsonSchema): number[] {
+  let count = 0;
+  for (const entry of collectAllOfSchemas(schema)) {
+    if (Array.isArray(entry.items)) {
+      const hasTypedTail =
+        entry.additionalItems !== null && typeof entry.additionalItems === "object";
+      count = Math.max(count, entry.items.length + (hasTypedTail ? 1 : 0));
+    } else if (entry.items) {
+      count = Math.max(count, 1);
+    }
+  }
+  return Array.from({ length: count }, (_, index) => index);
+}
+
 export function arrayConstraintCandidates(
   schema: JsonSchema,
   seen = new Set<JsonSchema>(),

--- a/ui/src/components/config-form.node.collection.ts
+++ b/ui/src/components/config-form.node.collection.ts
@@ -16,9 +16,9 @@ import {
   type ConfigFormCollectionDraftProps,
 } from "./config-form-collection-draft.ts";
 import { copyWithPathPatch } from "./config-form-copy-on-write.ts";
+import { arrayItemSchema } from "./config-form.array-items.ts";
 import {
   arrayInputConstraints,
-  arrayItemSchema,
   canApplyArrayCandidate,
   canApplyObjectCandidate,
   configValuesEqual,

--- a/ui/src/components/config-form.search.node.test.ts
+++ b/ui/src/components/config-form.search.node.test.ts
@@ -139,6 +139,29 @@ describe("config form search", () => {
     },
   );
 
+  it("does not search tuple positions forbidden by an allOf branch", () => {
+    const matched = matchesNodeSearch({
+      schema: {
+        type: "array",
+        allOf: [
+          {
+            items: [{ type: "string", description: "Reachable endpoint" }],
+            additionalItems: false,
+          },
+          {
+            items: [{}, { type: "string", description: "Impossible endpoint" }],
+          },
+        ],
+      },
+      value: [],
+      path: ["endpoints"],
+      hints: {},
+      criteria: parseConfigSearchQuery("impossible endpoint"),
+    });
+
+    expect(matched).toBe(false);
+  });
+
   it("searches additional-property schemas before entries exist", () => {
     const matched = matchesNodeSearch({
       schema: {

--- a/ui/src/components/config-form.search.node.test.ts
+++ b/ui/src/components/config-form.search.node.test.ts
@@ -91,6 +91,30 @@ describe("config form search", () => {
     expect(matched).toBe(true);
   });
 
+  it.each([
+    { values: [], query: "secondary endpoint" },
+    { values: ["primary"], query: "secondary endpoint" },
+    { values: [], query: "overflow endpoint" },
+    { values: ["primary"], query: "overflow endpoint" },
+  ])("searches positional and typed-tail schemas for $values", ({ values, query }) => {
+    const matched = matchesNodeSearch({
+      schema: {
+        type: "array",
+        items: [
+          { type: "string", description: "Primary endpoint" },
+          { type: "string", description: "Secondary endpoint" },
+        ],
+        additionalItems: { type: "string", description: "Overflow endpoint" },
+      },
+      value: values,
+      path: ["endpoints"],
+      hints: {},
+      criteria: parseConfigSearchQuery(query),
+    });
+
+    expect(matched).toBe(true);
+  });
+
   it("searches additional-property schemas before entries exist", () => {
     const matched = matchesNodeSearch({
       schema: {

--- a/ui/src/components/config-form.search.node.test.ts
+++ b/ui/src/components/config-form.search.node.test.ts
@@ -115,6 +115,30 @@ describe("config form search", () => {
     expect(matched).toBe(true);
   });
 
+  it.each(["composed secondary", "composed overflow"])(
+    "searches %s array schemas declared through allOf",
+    (query) => {
+      const matched = matchesNodeSearch({
+        schema: {
+          type: "array",
+          items: [{ type: "string", description: "Outer endpoint" }],
+          allOf: [
+            {
+              items: [{}, { type: "string", description: "Composed secondary endpoint" }],
+              additionalItems: { type: "string", description: "Composed overflow endpoint" },
+            },
+          ],
+        },
+        value: [],
+        path: ["endpoints"],
+        hints: {},
+        criteria: parseConfigSearchQuery(query),
+      });
+
+      expect(matched).toBe(true);
+    },
+  );
+
   it("searches additional-property schemas before entries exist", () => {
     const matched = matchesNodeSearch({
       schema: {

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -1,6 +1,6 @@
 import type { ConfigUiHints } from "../api/types.ts";
 import { normalizeLowercaseStringOrEmpty } from "../lib/string-coerce.ts";
-import { arrayItemSchema, arrayItemSchemaIndexes } from "./config-form.constraints.ts";
+import { arrayItemSchema, arrayItemSchemaIndexes } from "./config-form.array-items.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 
 export type ConfigSearchCriteria = {

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -1,5 +1,6 @@
 import type { ConfigUiHints } from "../api/types.ts";
 import { normalizeLowercaseStringOrEmpty } from "../lib/string-coerce.ts";
+import { arrayItemSchema } from "./config-form.constraints.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 
 export type ConfigSearchCriteria = {
@@ -205,31 +206,33 @@ export function matchesNodeSearch(params: {
   if (type !== "array") {
     return false;
   }
-  const itemsSchema = Array.isArray(schema.items) ? schema.items[0] : schema.items;
-  if (!itemsSchema) {
+  if (!schema.items) {
     return false;
   }
   const values = Array.isArray(value) ? value : Array.isArray(schema.default) ? schema.default : [];
-  if (values.length === 0) {
-    return matchesNodeSearch({
-      schema: itemsSchema,
-      value: undefined,
-      path: [...path, 0],
-      hints,
-      criteria,
-      textMatcher,
-    });
+  const tupleLength = Array.isArray(schema.items) ? schema.items.length : 1;
+  const typedTail =
+    Array.isArray(schema.items) &&
+    schema.additionalItems !== null &&
+    typeof schema.additionalItems === "object";
+  const searchLength = Math.max(values.length, tupleLength + (typedTail ? 1 : 0));
+  for (let index = 0; index < searchLength; index += 1) {
+    const itemSchema = arrayItemSchema(schema, index);
+    if (
+      itemSchema &&
+      matchesNodeSearch({
+        schema: itemSchema,
+        value: values[index],
+        path: [...path, index],
+        hints,
+        criteria,
+        textMatcher,
+      })
+    ) {
+      return true;
+    }
   }
-  return values.some((entry, index) =>
-    matchesNodeSearch({
-      schema: itemsSchema,
-      value: entry,
-      path: [...path, index],
-      hints,
-      criteria,
-      textMatcher,
-    }),
-  );
+  return false;
 }
 
 export function matchesConfigSectionSearch(params: {

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -1,6 +1,6 @@
 import type { ConfigUiHints } from "../api/types.ts";
 import { normalizeLowercaseStringOrEmpty } from "../lib/string-coerce.ts";
-import { arrayItemSchema } from "./config-form.constraints.ts";
+import { arrayItemSchema, arrayItemSchemaIndexes } from "./config-form.constraints.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 
 export type ConfigSearchCriteria = {
@@ -206,16 +206,8 @@ export function matchesNodeSearch(params: {
   if (type !== "array") {
     return false;
   }
-  if (!schema.items) {
-    return false;
-  }
   const values = Array.isArray(value) ? value : Array.isArray(schema.default) ? schema.default : [];
-  const tupleLength = Array.isArray(schema.items) ? schema.items.length : 1;
-  const typedTail =
-    Array.isArray(schema.items) &&
-    schema.additionalItems !== null &&
-    typeof schema.additionalItems === "object";
-  const searchLength = Math.max(values.length, tupleLength + (typedTail ? 1 : 0));
+  const searchLength = Math.max(values.length, arrayItemSchemaIndexes(schema).length);
   for (let index = 0; index < searchLength; index += 1) {
     const itemSchema = arrayItemSchema(schema, index);
     if (

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -582,6 +582,36 @@ describe("message-normalizer", () => {
       ]);
     });
 
+    it("classifies signed same-origin MEDIA image and audio routes", () => {
+      const imageUrl = "/media/inbound/photo.png?mediaTicket=signed#preview";
+      const audioUrl = "/__openclaw__/media/voice%2Eogg?mediaTicket=signed";
+      const result = normalizeMessage({
+        role: "assistant",
+        content: `MEDIA:${imageUrl}\nMEDIA:${audioUrl}`,
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "attachment",
+          attachment: {
+            url: imageUrl,
+            kind: "image",
+            label: "photo.png?mediaTicket=signed#preview",
+            mimeType: "image/png",
+          },
+        },
+        {
+          type: "attachment",
+          attachment: {
+            url: audioUrl,
+            kind: "audio",
+            label: "voice%2Eogg?mediaTicket=signed",
+            mimeType: "audio/ogg",
+          },
+        },
+      ]);
+    });
+
     it("keeps valid local MEDIA paths as assistant attachments", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/lib/media-file-extension.test.ts
+++ b/ui/src/lib/media-file-extension.test.ts
@@ -10,6 +10,8 @@ describe("getMediaFileExtension", () => {
     { value: "/media/inbound/photo.png?mediaTicket=signed#preview", expected: "png" },
     { value: "/__openclaw__/media/voice%2Eogg?mediaTicket=signed", expected: "ogg" },
     { value: "/media/inbound/photo.png?preview=.jpg", expected: "png" },
+    { value: "/tmp/recording?download=.mp3", expected: "mp3" },
+    { value: "/tmp/clip#final.mp4", expected: "mp4" },
     { value: "https://cdn.example/bad%ZZ/render%2Emp4", expected: "mp4" },
     { value: "https://cdn.example/archive%2Fclip%2Emp4", expected: "mp4" },
     { value: "https://cdn.example/archive%5Cclip%2Emp4", expected: "mp4" },

--- a/ui/src/lib/media-file-extension.test.ts
+++ b/ui/src/lib/media-file-extension.test.ts
@@ -7,6 +7,9 @@ describe("getMediaFileExtension", () => {
   it.each([
     { value: "https://cdn.example/render%2Emp4?download=1#preview", expected: "mp4" },
     { value: "https://cdn.example/render%2Em%70%34", expected: "mp4" },
+    { value: "/media/inbound/photo.png?mediaTicket=signed#preview", expected: "png" },
+    { value: "/__openclaw__/media/voice%2Eogg?mediaTicket=signed", expected: "ogg" },
+    { value: "/media/inbound/photo.png?preview=.jpg", expected: "png" },
     { value: "https://cdn.example/bad%ZZ/render%2Emp4", expected: "mp4" },
     { value: "https://cdn.example/archive%2Fclip%2Emp4", expected: "mp4" },
     { value: "https://cdn.example/archive%5Cclip%2Emp4", expected: "mp4" },

--- a/ui/src/lib/media-file-extension.ts
+++ b/ui/src/lib/media-file-extension.ts
@@ -1,5 +1,21 @@
 // Browser-safe media filename extension parsing shared by Control UI renderers.
 
+const SAME_ORIGIN_MEDIA_ROUTE_MARKERS = [
+  "/__openclaw__/assistant-media",
+  "/__openclaw__/media/",
+  "/api/chat/media/outgoing/",
+  "/media/inbound/",
+];
+
+function isSameOriginMediaRoute(value: string): boolean {
+  return (
+    value.startsWith("/") &&
+    SAME_ORIGIN_MEDIA_ROUTE_MARKERS.some(
+      (marker) => value.startsWith(marker) || value.includes(marker),
+    )
+  );
+}
+
 /** Returns a lowercase extension without the leading dot. */
 export function getMediaFileExtension(value: string): string | undefined {
   const trimmed = value.trim();
@@ -8,8 +24,7 @@ export function getMediaFileExtension(value: string): string | undefined {
   }
   let filename: string;
   try {
-    const rootRelativeUrl = /^\/(?!\/)/u.test(trimmed);
-    if (/^https?:\/\//i.test(trimmed) || rootRelativeUrl) {
+    if (/^https?:\/\//i.test(trimmed) || isSameOriginMediaRoute(trimmed)) {
       const pathname = new URL(trimmed, "https://openclaw.invalid").pathname;
       filename = pathname.slice(pathname.lastIndexOf("/") + 1);
       try {

--- a/ui/src/lib/media-file-extension.ts
+++ b/ui/src/lib/media-file-extension.ts
@@ -8,8 +8,9 @@ export function getMediaFileExtension(value: string): string | undefined {
   }
   let filename: string;
   try {
-    if (/^https?:\/\//i.test(trimmed)) {
-      const pathname = new URL(trimmed).pathname;
+    const rootRelativeUrl = /^\/(?!\/)/u.test(trimmed);
+    if (/^https?:\/\//i.test(trimmed) || rootRelativeUrl) {
+      const pathname = new URL(trimmed, "https://openclaw.invalid").pathname;
       filename = pathname.slice(pathname.lastIndexOf("/") + 1);
       try {
         // Match media-core: decode only the filename and keep encoded path


### PR DESCRIPTION
## What Problem This Solves

Three current-main defects remained from the original combined report:

1. Settings search collapsed positional tuples to slot zero and missed typed tails, including declarations composed through `allOf`.
2. Signed same-origin media routes kept query/hash text in the filename, so image/audio attachments were misclassified as documents.
3. Native chat projections leaked thinking/tool/image text, dropped valid Responses text in some clients, and diverged between shared Apple, Watch, and Android paths.

The clipboard race is already fixed by #118651 and is intentionally not revived.

## Why This Change Was Made

Array topology and per-index resolution now share one lightweight composition owner used by analyzer, renderer, constraints, and search. Keeping that owner separate prevents Settings search from pulling the full numeric/validation constraints graph into the startup chunk. Closed tuple branches intersect the searchable index range, so `allOf` cannot surface impossible fields.

Media classification URL-parses only HTTP(S) URLs and recognized same-origin media routes; arbitrary slash-prefixed local paths retain literal query/hash filename characters. `ChatMessageVisibleText` is the sole Apple visible-text projector; Watch's duplicate parser was deleted and Android voice mirrors the same role/type contract.

Legacy untyped/text blocks remain visible. `input_text` is visible only for user/assistant chat roles, `output_text` only for assistant, and typed thinking/tool/image blocks remain excluded.

The production surface is +141/-129 (net +12). The additions are required by two ownership boundaries: one cross-platform native visible-text contract and one browser-safe schema-composition module shared without importing the heavyweight constraints graph into startup.

## User Impact

Operators can find tuple/`allOf`-backed settings before values exist without seeing impossible closed-tuple fields; signed same-origin image/audio attachments classify correctly while literal local filenames remain intact; and native transcript/speech/Watch surfaces agree on visible Responses text without leaking internal typed payloads. Clipboard behavior is unchanged.

## Evidence

- UI focused proof: 151/151 tests passed across search/composition/array constraints, media extension parsing, and chat normalization.
- Native focused proof: `swift test --package-path apps/shared/OpenClawKit --filter 'Chat(EventText|MessageVisibleText)Tests'` passed 16/16 in two suites.
- Native formatting proof: SwiftFormat reports 0/361 files requiring formatting; Android `:app:ktlintCheck` passed.
- Regression red/green proof: without the closed-tuple cap, search matched an impossible second slot; without route-prefix restriction, `/tmp/recording?download=.mp3` and `/tmp/clip#final.mp4` lost their literal extensions. All three assertions pass after the owner fixes.
- Watch coverage asserts both preview and direct run-correlated replies for `input_text` and `output_text`.
- `node scripts/check-changed.mjs` passed every selected check in 24m23s on Testbox `tbx_01kzmtz26er5jdjwg3mxh5gk4b`; Actions run https://github.com/openclaw/openclaw/actions/runs/31352327597.
- Fresh full-branch Codex autoreview: clean, no accepted/actionable findings, confidence 0.99.
- Production/test delta: production +141/-129 (net +12); tests +278/-33 (net +245).
- ClawSweeper findings and rank-up moves addressed: shared Watch projection, restricted role visibility, canonical `allOf` tuple/tail enumeration, closed-tuple intersection, local-path media preservation, direct Codex inspection, and exact-head native CI required before merge.
- Codex contract personally checked at sibling revision `57f42a81131c`: `codex-rs/codex-api/src/endpoint/realtime_websocket/methods_frameless_bidi.rs:81-92`, `codex-rs/rollout-trace/src/reducer/conversation/normalize.rs:386-410`, `codex-rs/core/src/stream_events_utils.rs:60-73`, and `codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs:1326-1347`.
- Exact-head iOS/Android and startup-budget CI remains required before merge.
