### PR TITLE
test(ui): remove duplicate avatar route coverage

### DIFF
--- a/ui/src/lib/identity-avatar.test.ts
+++ b/ui/src/lib/identity-avatar.test.ts
@@ -50,12 +50,6 @@ describe("resolveAvatar", () => {
       expect(first).toBe(resolved.colorSeed % 360);
     }
   });
-
-  it("lets an already-resolved profile avatar win", () => {
-    expect(
-      resolveAvatar({ id: "alice@example.com", profileAvatarUrl: "/api/users/p1/avatar" }),
-    ).toEqual({ kind: "profile", url: "/api/users/p1/avatar" });
-  });
 });
 
 describe("resolveAvatar profile URL origin restriction", () => {
@@ -104,12 +98,6 @@ describe("resolveAvatar profile URL origin restriction", () => {
 });
 
 describe("resolveAvatar gateway origin trust", () => {
-  it("keeps relative avatar paths relative when no gateway origin is set", () => {
-    expect(
-      resolveAvatar({ id: "alice@example.com", profileAvatarUrl: "/api/users/p1/avatar" }),
-    ).toEqual({ kind: "profile", url: "/api/users/p1/avatar" });
-  });
-
   it("resolves relative paths against the configured gateway origin", () => {
     setAvatarGatewayOrigin("wss://gw.example.com/ws");
     expect(


### PR DESCRIPTION
## What Problem This Solves

The identity-avatar suite asserted the same canonical relative profile-avatar route three times in separate describe blocks.

## Why This Change Was Made

- keeps the route assertion at the profile URL origin-restriction boundary
- removes two byte-for-byte duplicate assertions from broader avatar and gateway-origin groups

## User Impact

No runtime behavior changes. The UI suite keeps the security-owner coverage without repeating identical cases.

## Evidence

- focused Vitest: 25 passed
- targeted `oxfmt --check`: passed
- `git diff --check`: passed
- fresh uncommitted autoreview: clean, 0.99
