### PR TITLE
test(ios): remove duplicate deep-link coverage

### DIFF
--- a/apps/ios/Tests/DeepLinkParserTests.swift
+++ b/apps/ios/Tests/DeepLinkParserTests.swift
@@ -95,12 +95,6 @@ private func agentAction(
                     password: "def")))
     }
 
-    @Test func parseGatewayLinkRejectsInsecureNonLoopbackWs() {
-        let url = URL(
-            string: "openclaw://gateway?host=attacker.example&port=18789&tls=0&token=abc")!
-        #expect(DeepLinkParser.parse(url) == nil)
-    }
-
     @Test func parseGatewayLinkAllowsPrivateLanWs() {
         let url = URL(
             string: "openclaw://gateway?host=openclaw.local&port=18789&tls=0&token=abc")!
@@ -113,12 +107,6 @@ private func agentAction(
                     bootstrapToken: nil,
                     token: "abc",
                     password: nil)))
-    }
-
-    @Test func parseGatewayLinkRejectsInsecurePrefixBypassHost() {
-        let url = URL(
-            string: "openclaw://gateway?host=127.attacker.example&port=18789&tls=0&token=abc")!
-        #expect(DeepLinkParser.parse(url) == nil)
     }
 
     @Test func parseGatewayLinkRejectsInvalidPort() {
@@ -174,31 +162,6 @@ private func agentAction(
             host: "gateway.example.com",
             port: 443,
             tls: true,
-            bootstrapToken: "tok",
-            token: nil,
-            password: nil))
-    }
-
-    @Test func parseGatewaySetupCodeRejectsInsecureNonLoopbackWs() {
-        let payload = #"{"url":"ws://attacker.example:18789","bootstrapToken":"tok"}"#
-        let link = GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload))
-        #expect(link == nil)
-    }
-
-    @Test func parseGatewaySetupCodeRejectsInsecurePrefixBypassHost() {
-        let payload = #"{"url":"ws://127.attacker.example:18789","bootstrapToken":"tok"}"#
-        let link = GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload))
-        #expect(link == nil)
-    }
-
-    @Test func parseGatewaySetupCodeAllowsLoopbackWs() {
-        let payload = #"{"url":"ws://127.0.0.1:18789","bootstrapToken":"tok"}"#
-        let link = GatewayConnectDeepLink.fromSetupCode(setupCode(from: payload))
-
-        #expect(link == .init(
-            host: "127.0.0.1",
-            port: 18789,
-            tls: false,
             bootstrapToken: "tok",
             token: nil,
             password: nil))


### PR DESCRIPTION
## What Problem This Solves

The iOS deep-link suite repeated five security tests already owned by OpenClawKit, the module that implements `DeepLinkParser` and `GatewayConnectDeepLink`.

## Why This Change Was Made

- removes the two identical insecure gateway deep-link rejection cases
- removes the two identical insecure setup-code rejection cases
- removes the identical loopback setup-code acceptance case
- retains iOS-specific LAN, tailnet, invalid-port, setup-input, and agent-link coverage

All five removed cases were added to both suites by the same original security fix. Their retained owner assertions are in `apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeepLinksSecurityTests.swift`.

## User Impact

No runtime behavior changes. Security coverage remains at the implementation owner instead of running twice.

## Evidence

- `git diff --check`: passed
- fresh uncommitted autoreview: clean, 0.94
- local OpenClawKit test attempt: blocked because this Mac has Swift 6.1 while the package requires Swift 6.2
- required Xcode 26 iOS CI: passed, including OpenClawKit tests, simulator lifecycle tests, and screenshot evidence
  - https://github.com/openclaw/openclaw/actions/runs/30602782003

The legacy iOS test file has 52 pre-existing whole-file SwiftFormat findings; this patch adds no lines and does not expand that unrelated cleanup.
