### PR TITLE
test(android): remove duplicate setup-code coverage

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -417,17 +417,6 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun resolveScannedSetupCodeResultFlagsInsecureRemoteGateway() {
-    val setupCode =
-      encodeSetupCode("""{"url":"ws://attacker.example:18789","bootstrapToken":"bootstrap-1"}""")
-
-    val resolved = resolveScannedSetupCodeResult(setupCode)
-
-    assertNull(resolved.setupCode)
-    assertEquals(GatewayEndpointValidationError.INSECURE_REMOTE_URL, resolved.error)
-  }
-
-  @Test
   fun resolveScannedSetupCodeResultPreservesIpv6ZoneError() {
     val setupCode =
       encodeSetupCode("""{"url":"wss://[fe80::1%25wlan0]:443","bootstrapToken":"bootstrap-1"}""")


### PR DESCRIPTION
## What Problem This Solves

`GatewayConfigResolverTest` contained two tests with the same insecure remote setup code and identical assertions.

## Why This Change Was Made

- keeps `resolveScannedSetupCodeResultRejectsNonLoopbackCleartextGateway` as the canonical security-boundary case
- removes the later byte-for-byte duplicate

## User Impact

No runtime behavior changes. The Android suite retains the insecure remote gateway rejection contract without running it twice.

## Evidence

- focused Blacksmith Testbox Gradle run: passed in 3m25s
  - https://github.com/openclaw/openclaw/actions/runs/30602679288
- `git diff --check`: passed
- fresh uncommitted autoreview: clean, 0.98
