### PR TITLE
fix(xai): prevent closed realtime sessions from retaining input

### DIFF
--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -502,6 +502,7 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
     this.pendingAudioBytes = 0;
     this.pendingToolResults = [];
     this.pendingUserMessages = [];
+    this.conversationId = null;
     this.resetRealtimeSessionState();
   }
 }

--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -478,14 +478,16 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
   }
 
   private enqueuePendingAudio(audio: Buffer): void {
+    const queuedAudio = Buffer.from(audio);
     if (
       this.pendingAudio.length >= XaiRealtimeVoiceBridge.MAX_PENDING_AUDIO_CHUNKS ||
-      this.pendingAudioBytes + audio.byteLength > XaiRealtimeVoiceBridge.MAX_PENDING_AUDIO_BYTES
+      this.pendingAudioBytes + queuedAudio.byteLength >
+        XaiRealtimeVoiceBridge.MAX_PENDING_AUDIO_BYTES
     ) {
       return;
     }
-    this.pendingAudio.push(audio);
-    this.pendingAudioBytes += audio.byteLength;
+    this.pendingAudio.push(queuedAudio);
+    this.pendingAudioBytes += queuedAudio.byteLength;
   }
 
   private enterTerminalState(): void {

--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -478,14 +478,13 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
   }
 
   private enqueuePendingAudio(audio: Buffer): void {
-    const queuedAudio = Buffer.from(audio);
     if (
       this.pendingAudio.length >= XaiRealtimeVoiceBridge.MAX_PENDING_AUDIO_CHUNKS ||
-      this.pendingAudioBytes + queuedAudio.byteLength >
-        XaiRealtimeVoiceBridge.MAX_PENDING_AUDIO_BYTES
+      this.pendingAudioBytes + audio.byteLength > XaiRealtimeVoiceBridge.MAX_PENDING_AUDIO_BYTES
     ) {
       return;
     }
+    const queuedAudio = Buffer.from(audio);
     this.pendingAudio.push(queuedAudio);
     this.pendingAudioBytes += queuedAudio.byteLength;
   }

--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -27,6 +27,8 @@ import { XaiRealtimeMalformedAudioError, XaiRealtimeVoiceEvents } from "./realti
 import { xaiUserAgentHeaderFor } from "./src/xai-user-agent.js";
 
 export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements RealtimeVoiceBridge {
+  private static readonly MAX_PENDING_AUDIO_CHUNKS = 320;
+  private static readonly MAX_PENDING_AUDIO_BYTES = 1024 * 1024;
   readonly supportsToolResultContinuation = false;
 
   private ws: WebSocket | null = null;
@@ -36,6 +38,7 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
   private terminalError: Error | null = null;
   private reconnectAttempts = 0;
   private pendingAudio: Buffer[] = [];
+  private pendingAudioBytes = 0;
   private pendingToolResults: Array<{
     callId: string;
     result: unknown;
@@ -60,10 +63,11 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
   }
 
   sendAudio(audio: Buffer): void {
+    if (this.intentionallyClosed) {
+      return;
+    }
     if (!this.connected || !this.sessionConfigured || this.ws?.readyState !== WebSocket.OPEN) {
-      if (this.pendingAudio.length < 320) {
-        this.pendingAudio.push(audio);
-      }
+      this.enqueuePendingAudio(audio);
       return;
     }
     this.sendEvent({
@@ -77,6 +81,9 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
   }
 
   sendUserMessage(text: string): void {
+    if (this.intentionallyClosed) {
+      return;
+    }
     if (!this.canSubmitInput()) {
       if (this.pendingUserMessages.length < XAI_REALTIME_MAX_PENDING_USER_MESSAGES) {
         this.pendingUserMessages.push(text);
@@ -101,6 +108,9 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
     result: unknown,
     options?: RealtimeVoiceToolResultOptions,
   ): void {
+    if (this.intentionallyClosed) {
+      return;
+    }
     if (!this.canSubmitToolResult()) {
       if (this.pendingToolResults.length < XAI_REALTIME_MAX_PENDING_TOOL_RESULTS) {
         this.pendingToolResults.push({ callId, result, ...(options ? { options } : {}) });
@@ -121,7 +131,7 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
     this.reconnectAbortController.abort();
     this.connected = false;
     this.sessionConfigured = false;
-    this.pendingToolResultAcks.clear();
+    this.resetTerminalState();
     if (this.ws) {
       this.ws.close(1000, "Bridge closed");
       this.ws = null;
@@ -213,7 +223,7 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
         this.reconnectAbortController.abort();
         this.connected = false;
         this.sessionConfigured = false;
-        this.pendingToolResultAcks.clear();
+        this.resetTerminalState();
         try {
           this.config.onError?.(error);
         } finally {
@@ -352,6 +362,7 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
         type: "session.reconnect.blocked",
         detail: `reason=${reason} ${blocked}`,
       });
+      this.enterTerminalState();
       this.config.onClose?.("error");
       return;
     }
@@ -361,6 +372,7 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
         type: "session.reconnect.exhausted",
         detail: `reason=${reason} attempts=${this.reconnectAttempts}`,
       });
+      this.enterTerminalState();
       this.config.onClose?.("error");
       return;
     }
@@ -418,7 +430,9 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
   protected onSessionUpdated(): void {
     this.sessionConfigured = true;
     this.reconnectAttempts = 0;
-    for (const chunk of this.pendingAudio.splice(0)) {
+    const pendingAudio = this.pendingAudio.splice(0);
+    this.pendingAudioBytes = 0;
+    for (const chunk of pendingAudio) {
       this.sendAudio(chunk);
     }
     for (const pending of this.pendingToolResults.splice(0)) {
@@ -461,5 +475,32 @@ export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements Re
 
   private canSubmitInput(): boolean {
     return this.connected && this.sessionConfigured && this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  private enqueuePendingAudio(audio: Buffer): void {
+    if (
+      this.pendingAudio.length >= XaiRealtimeVoiceBridge.MAX_PENDING_AUDIO_CHUNKS ||
+      this.pendingAudioBytes + audio.byteLength > XaiRealtimeVoiceBridge.MAX_PENDING_AUDIO_BYTES
+    ) {
+      return;
+    }
+    this.pendingAudio.push(audio);
+    this.pendingAudioBytes += audio.byteLength;
+  }
+
+  private enterTerminalState(): void {
+    this.intentionallyClosed = true;
+    this.reconnectAbortController.abort();
+    this.connected = false;
+    this.sessionConfigured = false;
+    this.resetTerminalState();
+  }
+
+  private resetTerminalState(): void {
+    this.pendingAudio = [];
+    this.pendingAudioBytes = 0;
+    this.pendingToolResults = [];
+    this.pendingUserMessages = [];
+    this.resetRealtimeSessionState();
   }
 }

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -260,6 +260,59 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     expect(requireSession(socket).resumption).toBeUndefined();
   });
 
+  it("bounds pending realtime audio by aggregate bytes before session setup", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    bridge.sendAudio(Buffer.alloc(512 * 1024, 0x7f));
+    bridge.sendAudio(Buffer.alloc(512 * 1024, 0x7f));
+    bridge.sendAudio(Buffer.alloc(1, 0x7f));
+
+    const { connecting, socket } = await openRealtimeBridge(bridge);
+    await connecting;
+
+    expect(
+      parseSent(socket).filter((event) => event.type === "input_audio_buffer.append"),
+    ).toHaveLength(2);
+    bridge.close();
+  });
+
+  it("drops queued realtime input on close and ignores late input until reconnect", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    bridge.sendAudio(Buffer.from([0x01]));
+    bridge.sendUserMessage?.("queued before close");
+    bridge.submitToolResult("call-before-close", { ok: true });
+    bridge.close();
+    bridge.sendAudio(Buffer.from([0x02]));
+    bridge.sendUserMessage?.("late after close");
+    bridge.submitToolResult("call-after-close", { ok: true });
+
+    const { connecting, socket } = await openRealtimeBridge(bridge);
+    await connecting;
+
+    expect(
+      parseSent(socket).filter(
+        (event) =>
+          event.type === "input_audio_buffer.append" ||
+          event.type === "conversation.item.create" ||
+          event.type === "response.create",
+      ),
+    ).toEqual([]);
+    bridge.close();
+  });
+
   it("rejects generic response modes that xAI server VAD cannot disable", () => {
     const provider = buildXaiRealtimeVoiceProvider();
     const callbacks = { onAudio: vi.fn(), onClearAudio: vi.fn() };

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -282,6 +282,29 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     bridge.close();
   });
 
+  it("copies pending realtime audio views without retaining their backing allocation", async () => {
+    vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
+    const provider = buildXaiRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+    const backing = Buffer.alloc(2 * 1024 * 1024, 0x7f);
+    const view = backing.subarray(0, 1);
+
+    bridge.sendAudio(view);
+    backing[0] = 0;
+
+    const { connecting, socket } = await openRealtimeBridge(bridge);
+    await connecting;
+
+    expect(
+      parseSent(socket).filter((event) => event.type === "input_audio_buffer.append"),
+    ).toEqual([{ type: "input_audio_buffer.append", audio: "fw==" }]);
+    bridge.close();
+  });
+
   it("drops queued realtime input on close and ignores late input until reconnect", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
     const provider = buildXaiRealtimeVoiceProvider();

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -316,11 +316,11 @@ describe("buildXaiRealtimeVoiceProvider", () => {
 
     bridge.sendAudio(Buffer.from([0x01]));
     bridge.sendUserMessage?.("queued before close");
-    bridge.submitToolResult("call-before-close", { ok: true });
+    void bridge.submitToolResult("call-before-close", { ok: true });
     bridge.close();
     bridge.sendAudio(Buffer.from([0x02]));
     bridge.sendUserMessage?.("late after close");
-    bridge.submitToolResult("call-after-close", { ok: true });
+    void bridge.submitToolResult("call-after-close", { ok: true });
 
     const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -299,9 +299,9 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     const { connecting, socket } = await openRealtimeBridge(bridge);
     await connecting;
 
-    expect(
-      parseSent(socket).filter((event) => event.type === "input_audio_buffer.append"),
-    ).toEqual([{ type: "input_audio_buffer.append", audio: "fw==" }]);
+    expect(parseSent(socket).filter((event) => event.type === "input_audio_buffer.append")).toEqual(
+      [{ type: "input_audio_buffer.append", audio: "fw==" }],
+    );
     bridge.close();
   });
 
@@ -1407,6 +1407,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     const reconnecting = bridge.connect();
     await waitForRealtimeState(() => expect(FakeWebSocket.instances.length).toBe(2));
     const reconnectedSocket = requireSocket(1);
+    expect(String(reconnectedSocket.args[0])).not.toContain("conversation_id=");
     reconnectedSocket.readyState = FakeWebSocket.OPEN;
     reconnectedSocket.emit("open");
     reconnectedSocket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where xAI realtime voice sessions could retain queued audio, user messages, and tool results after close or terminal reconnect failure. Queued audio was bounded only by chunk count, and small Buffer views could retain much larger backing allocations. Late input after close could also refill terminal queues.

## Why This Change Was Made

The xAI bridge now bounds pending audio by both chunk count and one aggregate byte budget, copies accepted views, clears all queued/session state at terminal boundaries, and ignores post-close input until an explicit reconnect. Terminal reset also drops the old conversation id so cleared tool-call dedupe state cannot resume and replay prior side effects. Normal provider-owned reconnect behavior remains unchanged.

## User Impact

Closed or unrecoverable xAI realtime sessions no longer retain stale input indefinitely or replay it into a later session. Pending audio memory is bounded without adding provider, configuration, or environment-variable surface.

## Evidence

- Exact-head `pnpm test:extension xai`: 362 tests passed.
- Exact-head `pnpm check:changed`: passed in Blacksmith Testbox.
- Exact-head focused provider suite: 41 tests passed locally.
- Exact-head autoreview: no accepted/actionable findings.
- Live `grok-voice-latest` terminal proof on `aaf41220969`: three cycles returned audio; the close-before-connect replacement emitted zero audio/transcript before the real prompt, proving queued and late input were dropped.
- Current-head live provider flow reached synthesized voice input, audio talkback, server-VAD barge-in, tool execution, and forced reconnect. Its final resumed marker-recall assertion timed out; the identical timeout reproduced on frozen current `main` (`007fdb1f7c1`), so that existing resumption defect is not introduced by this PR and will be handled separately.
