### PR TITLE
fix(media): prevent OOM on oversized local attachments

### DIFF
--- a/src/agents/sandbox-media-paths.test.ts
+++ b/src/agents/sandbox-media-paths.test.ts
@@ -1,5 +1,6 @@
 // Verifies sandbox media paths resolve through bridge and workspace-only guards.
 import { describe, expect, it, vi } from "vitest";
+import { readOutboundMediaFile } from "../media/bounded-read-file.js";
 import {
   createSandboxBridgeReadFile,
   resolveSandboxedBridgeMediaPath,
@@ -17,10 +18,13 @@ describe("createSandboxBridgeReadFile", () => {
         } as unknown as SandboxFsBridge,
       },
     });
-    await expect(scopedRead("media/inbound/example.png")).resolves.toEqual(Buffer.from("ok"));
+    await expect(
+      readOutboundMediaFile(scopedRead, "media/inbound/example.png", { maxBytes: 1024 }),
+    ).resolves.toEqual(Buffer.from("ok"));
     expect(readFile).toHaveBeenCalledWith({
       filePath: "media/inbound/example.png",
       cwd: "/tmp/sandbox-root",
+      maxBytes: 1024,
     });
   });
 

--- a/src/agents/sandbox-media-paths.ts
+++ b/src/agents/sandbox-media-paths.ts
@@ -4,6 +4,8 @@
  * Bridges media references through sandbox filesystems while enforcing workspace-only boundaries when required.
  */
 import path from "node:path";
+import { createBoundedOutboundMediaReadFile } from "../media/bounded-read-file.js";
+import type { OutboundMediaReadFile } from "../media/load-options.js";
 import { resolveMediaReferenceSandboxPath } from "../media/media-reference.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge, SandboxResolvedPath } from "./sandbox/fs-bridge.js";
@@ -17,12 +19,15 @@ export type SandboxedBridgeMediaPathConfig = {
 
 export function createSandboxBridgeReadFile(params: {
   sandbox: Pick<SandboxedBridgeMediaPathConfig, "root" | "bridge">;
-}): (filePath: string) => Promise<Buffer> {
-  return async (filePath: string) =>
-    await params.sandbox.bridge.readFile({
-      filePath,
-      cwd: params.sandbox.root,
-    });
+}): OutboundMediaReadFile {
+  return createBoundedOutboundMediaReadFile(
+    async (filePath, options) =>
+      await params.sandbox.bridge.readFile({
+        filePath,
+        cwd: params.sandbox.root,
+        maxBytes: options?.maxBytes,
+      }),
+  );
 }
 
 export async function resolveSandboxedBridgeMediaPath(params: {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -12,6 +12,7 @@ import type { ChannelId, ChannelMessageActionName } from "../../channels/plugins
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { root } from "../../infra/fs-safe.js";
 import { basenameFromMediaSource } from "../../infra/local-file-access.js";
+import { createBoundedOutboundMediaReadFile } from "../../media/bounded-read-file.js";
 import { resolveChannelAccountMediaMaxMb } from "../../media/configured-max-bytes.js";
 import {
   buildOutboundMediaLoadOptions,
@@ -460,10 +461,11 @@ function buildAttachmentMediaLoadOptions(params: {
   if (params.policy.mode === "sandbox") {
     const sandboxRoot = params.policy.sandboxRoot.trim();
     let sandboxFsPromise: ReturnType<typeof root> | undefined;
-    const readSandboxFile = async (filePath: string): Promise<Buffer> => {
+    const readSandboxFile = createBoundedOutboundMediaReadFile(async (filePath, options) => {
       sandboxFsPromise ??= root(sandboxRoot);
-      return await (await sandboxFsPromise).readBytes(filePath);
-    };
+      const sandboxFs = await sandboxFsPromise;
+      return await sandboxFs.readBytes(filePath, { maxBytes: options?.maxBytes });
+    });
     return {
       maxBytes: params.maxBytes,
       ...(params.optimizeImages !== undefined ? { optimizeImages: params.optimizeImages } : {}),

--- a/src/media/bounded-read-file.ts
+++ b/src/media/bounded-read-file.ts
@@ -1,0 +1,34 @@
+import type { OutboundMediaReadFile } from "./load-options.js";
+
+type BoundedOutboundMediaReadFile = (
+  filePath: string,
+  options?: { maxBytes: number },
+) => Promise<Buffer>;
+
+const BOUNDED_OUTBOUND_MEDIA_READ_FILE = Symbol("boundedOutboundMediaReadFile");
+
+type MarkedOutboundMediaReadFile = OutboundMediaReadFile & {
+  [BOUNDED_OUTBOUND_MEDIA_READ_FILE]?: BoundedOutboundMediaReadFile;
+};
+
+/** Marks an owned reader that can reject oversized files before buffering them. */
+export function createBoundedOutboundMediaReadFile(
+  readFile: BoundedOutboundMediaReadFile,
+): OutboundMediaReadFile {
+  const wrapped = (async (filePath: string) =>
+    await readFile(filePath)) as MarkedOutboundMediaReadFile;
+  Object.defineProperty(wrapped, BOUNDED_OUTBOUND_MEDIA_READ_FILE, { value: readFile });
+  return wrapped;
+}
+
+/** Passes source limits only to owned readers; public callbacks keep their one-argument contract. */
+export async function readOutboundMediaFile(
+  readFile: OutboundMediaReadFile,
+  filePath: string,
+  options: { maxBytes: number },
+): Promise<Buffer> {
+  const boundedReadFile = (readFile as MarkedOutboundMediaReadFile)[
+    BOUNDED_OUTBOUND_MEDIA_READ_FILE
+  ];
+  return boundedReadFile ? await boundedReadFile(filePath, options) : await readFile(filePath);
+}

--- a/src/media/read-capability.test.ts
+++ b/src/media/read-capability.test.ts
@@ -1,6 +1,10 @@
 // Media read capability tests cover allowed roots and blocked file access.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
+import { readOutboundMediaFile } from "./bounded-read-file.js";
 import { getDefaultMediaLocalRoots } from "./local-roots.js";
 import { resolveAgentScopedOutboundMediaAccess } from "./read-capability.js";
 
@@ -182,6 +186,28 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
     });
 
     expect(result.readFile).toBeTypeOf("function");
+  });
+
+  it("enforces the caller byte cap before buffering host media", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-cap-"));
+    try {
+      const filePath = path.join(workspaceDir, "oversized.bin");
+      await fs.writeFile(filePath, Buffer.alloc(2));
+      const result = resolveAgentScopedOutboundMediaAccess({
+        cfg: {
+          tools: {
+            allow: ["read"],
+          },
+        } as OpenClawConfig,
+        workspaceDir,
+      });
+
+      await expect(
+        readOutboundMediaFile(result.readFile!, filePath, { maxBytes: 1 }),
+      ).rejects.toThrow(/exceeds.*1 byte/i);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps host reads enabled for DM sender when no group context exists", () => {

--- a/src/media/read-capability.ts
+++ b/src/media/read-capability.ts
@@ -8,6 +8,7 @@ import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
 import { resolveWorkspaceRoot } from "../agents/workspace-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readLocalFileSafely } from "../infra/fs-safe.js";
+import { createBoundedOutboundMediaReadFile } from "./bounded-read-file.js";
 import type { OutboundMediaAccess, OutboundMediaReadFile } from "./load-options.js";
 import {
   getAgentScopedMediaLocalRoots,
@@ -76,10 +77,15 @@ function createAgentScopedHostMediaReadFile(
     params.workspaceDir ??
     (params.agentId ? resolveAgentWorkspaceDir(params.cfg, params.agentId) : undefined);
   const workspaceRoot = resolveWorkspaceRoot(inferredWorkspaceDir);
-  return async (filePath: string) => {
+  return createBoundedOutboundMediaReadFile(async (filePath, options) => {
     const resolvedPath = resolvePathFromInput(filePath, workspaceRoot);
-    return (await readLocalFileSafely({ filePath: resolvedPath })).buffer;
-  };
+    return (
+      await readLocalFileSafely({
+        filePath: resolvedPath,
+        maxBytes: options?.maxBytes,
+      })
+    ).buffer;
+  });
 }
 
 function appendWorkspaceDirToLocalRoots(

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -3,9 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { expectDefined } from "@openclaw/normalization-core";
 import JSZip from "jszip";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
@@ -82,6 +83,10 @@ afterAll(async () => {
   } finally {
     vi.resetModules();
   }
+});
+
+afterEach(() => {
+  __setFsSafeTestHooksForTest(undefined);
 });
 
 describe("loadWebMedia", () => {
@@ -571,6 +576,46 @@ describe("loadWebMedia", () => {
     });
     expect(result.kind).toBe("image");
     expect(result.buffer.length).toBeGreaterThan(0);
+  });
+
+  it("rejects oversized local media before an unbounded file-handle read", async () => {
+    const maxBytes = 1024 * 1024;
+    const oversizedFile = path.join(fixtureRoot, "oversized.bin");
+    await fs.writeFile(oversizedFile, Buffer.alloc(maxBytes + 1));
+    let unboundedReadCalled = false;
+    __setFsSafeTestHooksForTest({
+      afterOpen: (filePath, handle) => {
+        if (filePath !== oversizedFile) {
+          return;
+        }
+        vi.spyOn(handle, "readFile").mockImplementation(async () => {
+          unboundedReadCalled = true;
+          throw new Error("unbounded read invoked");
+        });
+      },
+    });
+
+    await expect(
+      loadWebMediaRaw(oversizedFile, {
+        maxBytes,
+        localRoots: [fixtureRoot],
+      }),
+    ).rejects.toThrow("Media exceeds 1MB limit");
+    expect(unboundedReadCalled).toBe(false);
+  });
+
+  it("keeps the one-argument contract for custom local readers", async () => {
+    const maxBytes = 1024 * 1024;
+    const readFile = vi.fn(async (_filePath: string) => Buffer.from(TINY_PNG_BASE64, "base64"));
+
+    await loadWebMediaRaw("/sandbox/image.png", {
+      maxBytes,
+      sandboxValidated: true,
+      readFile,
+    });
+
+    expect(readFile).toHaveBeenCalledWith("/sandbox/image.png");
+    expect(readFile.mock.calls[0]).toHaveLength(1);
   });
 
   it("does not treat image-named generic container bytes as local image media", async () => {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -35,7 +35,9 @@ import {
 } from "../state/openclaw-state-db.js";
 import { resolveUserPath } from "../utils.js";
 import { chunkItems } from "../utils/chunk-items.js";
+import { readOutboundMediaFile } from "./bounded-read-file.js";
 import { readRemoteMediaBuffer } from "./fetch.js";
+import type { OutboundMediaReadFile } from "./load-options.js";
 import {
   assertLocalMediaAllowed,
   getDefaultLocalRoots,
@@ -80,7 +82,7 @@ type WebMediaOptions = {
   inboundRoots?: readonly string[];
   /** Caller already validated the local path (sandbox/other guards); requires readFile override. */
   sandboxValidated?: boolean;
-  readFile?: (filePath: string) => Promise<Buffer>;
+  readFile?: OutboundMediaReadFile;
   /** Host-local fs-policy read piggyback; rejects plaintext-like document sends. */
   hostReadCapability?: boolean;
 };
@@ -1133,16 +1135,17 @@ async function loadWebMediaInternal(
     };
   };
 
+  // Bound source reads before buffering. Optimized images may exceed their
+  // delivery cap because they are compressed before the final size check.
+  const defaultSourceReadCap = maxBytesForKind("document");
+  const sourceReadCap =
+    maxBytes === undefined
+      ? defaultSourceReadCap
+      : optimizeImages
+        ? Math.max(maxBytes, defaultSourceReadCap)
+        : maxBytes;
+
   if (hasHttpUrlPrefix(mediaUrl)) {
-    // Enforce a download cap during fetch to avoid unbounded memory usage.
-    // For optimized images, allow fetching larger payloads before compression.
-    const defaultFetchCap = maxBytesForKind("document");
-    const fetchCap =
-      maxBytes === undefined
-        ? defaultFetchCap
-        : optimizeImages
-          ? Math.max(maxBytes, defaultFetchCap)
-          : maxBytes;
     const dispatcherPolicy: PinnedDispatcherPolicy | undefined = proxyUrl
       ? {
           mode: "explicit-proxy",
@@ -1155,7 +1158,7 @@ async function loadWebMediaInternal(
       fetchImpl,
       requestInit,
       readIdleTimeoutMs,
-      maxBytes: fetchCap,
+      maxBytes: sourceReadCap,
       ssrfPolicy,
       dispatcherPolicy,
       trustExplicitProxyDns,
@@ -1206,12 +1209,22 @@ async function loadWebMediaInternal(
   // Local path
   let data: Buffer;
   if (readFileOverride) {
-    data = await readFileOverride(mediaUrl);
+    data = await readOutboundMediaFile(readFileOverride, mediaUrl, { maxBytes: sourceReadCap });
   } else {
     try {
-      data = (await readLocalFileSafely({ filePath: mediaUrl })).buffer;
+      data = (
+        await readLocalFileSafely({
+          filePath: mediaUrl,
+          maxBytes: sourceReadCap,
+        })
+      ).buffer;
     } catch (err) {
       if (err instanceof FsSafeError) {
+        if (err.code === "too-large") {
+          throw new Error(`Media exceeds ${formatMb(sourceReadCap, 0)}MB limit`, {
+            cause: err,
+          });
+        }
         if (err.code === "not-found") {
           throw new LocalMediaAccessError("not-found", `Local media file not found: ${mediaUrl}`, {
             cause: err,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where oversized local outbound attachments could be fully buffered before the configured delivery cap was checked, causing the OpenClaw process to be OOM-killed on constrained systems.

## Why This Change Was Made

The source byte cap now reaches every owned local-read path before allocation: direct filesystem reads, sandbox bridge reads, and agent-scoped host reads. A private capability marker identifies readers that can enforce the cap. The public one-argument plugin callback contract is unchanged and custom callbacks are invoked exactly as before. Image optimization keeps its larger source allowance.

## User Impact

Oversized local attachments fail with the existing size-limit error instead of exhausting process memory. Normal media and image optimization behavior remain unchanged.

## Evidence

- Baseline reproduction: a 300 MiB sparse local file with a 1 MiB delivery cap under a hard 256 MiB cgroup exited 137 with `OOMKilled=true`.
- Current PR head: `283177986470889788aa9142fb2a9a38e4210042`.
- Packaged Docker proof at 256 MiB RAM, 256 MiB memory+swap limit, 1 CPU, and 128 PIDs:
  - output: `Media exceeds 1MB limit`
  - exit: `0`
  - peak memory: `46,264,320` bytes (44.1 MiB)
  - `oom=0`, `oom_kill=0`, `OOMKilled=false`
- Package tarball integrity and dist import graph passed.
- Exact combined stack `ccef32605db0540c84163ddab7871d16adde6483` passed the full package build, CLI bootstrap import guard, and all 148 public plugin SDK export checks.
- 132 post-repair focused media, sandbox, and outbound tests passed.
- SDK baseline, lint, dead-export checks, and `git diff --check` passed.
- Fresh autoreview against `origin/main` returned no accepted/actionable findings.

AI-assisted: yes. I reviewed the implementation, focused tests, package artifact, and constrained-memory runtime proof.
