### PR TITLE
improve(cli): reduce status memory on constrained systems

### DIFF
--- a/src/commands/status.scan.fast-json-cold-imports.test.ts
+++ b/src/commands/status.scan.fast-json-cold-imports.test.ts
@@ -1,0 +1,24 @@
+// Status JSON cold-import tests guard the default route from optional memory runtime imports.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("status.scan.fast-json cold imports", () => {
+  afterEach(() => {
+    vi.doUnmock("../agents/memory-search.js");
+    vi.doUnmock("./status.scan-memory.js");
+    vi.resetModules();
+  });
+
+  it("keeps optional memory runtime modules cold at command import time", async () => {
+    vi.resetModules();
+    vi.doMock("../agents/memory-search.js", () => {
+      throw new Error("default status JSON must not import the memory search runtime");
+    });
+    vi.doMock("./status.scan-memory.js", () => {
+      throw new Error("default status JSON must not import the optional memory scan");
+    });
+
+    const module = await import("./status.scan.fast-json.js");
+
+    expect(module.scanStatusJsonFast).toBeTypeOf("function");
+  });
+});

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -4,14 +4,15 @@
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "../config/bundled-channel-config-metadata.generated.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { isRecord } from "../utils.js";
 import { executeStatusScanFromOverview } from "./status.scan-execute.ts";
-import {
-  resolveDefaultMemoryDatabasePath,
-  resolveStatusMemoryStatusSnapshot,
-} from "./status.scan-memory.ts";
 import { collectStatusScanOverview } from "./status.scan-overview.ts";
 import type { StatusScanResult } from "./status.scan-result.ts";
+
+const statusScanMemoryModuleLoader = createLazyImportLoader(
+  () => import("./status.scan-memory.js"),
+);
 
 const IGNORED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
 const STATUS_JSON_CHANNEL_ENV_PREFIXES = GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.filter(
@@ -130,14 +131,18 @@ export async function scanStatusJsonFast(
     includeLocalStatusRpcFallback: opts.all === true,
     gatewayProbeTimeoutMs: opts.all === true ? undefined : () => opts.timeoutMs ?? 1000,
     resolveHasConfiguredChannels: (cfg) => hasPotentialConfiguredChannelsForStatusJson(cfg),
-    resolveMemory: async ({ cfg, agentStatus, memoryPlugin }) =>
-      opts.all
-        ? await resolveStatusMemoryStatusSnapshot({
-            cfg,
-            agentStatus,
-            memoryPlugin,
-            requireDefaultDatabasePath: resolveDefaultMemoryDatabasePath,
-          })
-        : null,
+    resolveMemory: async ({ cfg, agentStatus, memoryPlugin }) => {
+      if (!opts.all) {
+        return null;
+      }
+      const { resolveDefaultMemoryDatabasePath, resolveStatusMemoryStatusSnapshot } =
+        await statusScanMemoryModuleLoader.load();
+      return await resolveStatusMemoryStatusSnapshot({
+        cfg,
+        agentStatus,
+        memoryPlugin,
+        requireDefaultDatabasePath: resolveDefaultMemoryDatabasePath,
+      });
+    },
   });
 }

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -19,12 +19,7 @@ import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
 import { resolveGatewayProbeTarget } from "../gateway/probe-target.js";
 import type { GatewayProbeResult, probeGateway as probeGatewayFn } from "../gateway/probe.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import {
-  MEMORY_INDEX_CHUNKS_TABLE,
-  MEMORY_INDEX_META_TABLE,
-  MEMORY_INDEX_SOURCES_TABLE,
-  type MemoryProviderStatus,
-} from "../memory-host-sdk/engine-storage.js";
+import type { MemoryProviderStatus } from "../memory-host-sdk/engine-storage.js";
 import { defaultSlotIdForKey } from "../plugins/slots.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
@@ -35,6 +30,9 @@ import { isProbeReachable } from "./gateway-status/helpers.js";
 const gatewayProbeModuleLoader = createLazyImportLoader(() => import("./status.gateway-probe.js"));
 const probeGatewayModuleLoader = createLazyImportLoader(() => import("../gateway/probe.js"));
 const gatewayCallModuleLoader = createLazyImportLoader(() => import("../gateway/call.js"));
+const memoryEngineStorageModuleLoader = createLazyImportLoader(
+  () => import("../memory-host-sdk/engine-storage.js"),
+);
 const MEMORY_INDEX_META_KEY = "memory_index_meta_v1";
 
 function loadGatewayProbeModule() {
@@ -49,10 +47,12 @@ function loadGatewayCallModule() {
   return gatewayCallModuleLoader.load();
 }
 
-function hasBuiltInMemoryState(databasePath: string): boolean {
+async function hasBuiltInMemoryState(databasePath: string): Promise<boolean> {
   if (!existsSync(databasePath)) {
     return false;
   }
+  const { MEMORY_INDEX_CHUNKS_TABLE, MEMORY_INDEX_META_TABLE, MEMORY_INDEX_SOURCES_TABLE } =
+    await memoryEngineStorageModuleLoader.load();
   let db: DatabaseSync | undefined;
   try {
     db = openNodeSqliteDatabase(databasePath, { readOnly: true });
@@ -401,7 +401,11 @@ export async function resolveSharedMemoryStatusSnapshot(params: {
 
   const hasExplicitConfig = hasExplicitMemorySearchConfig(cfg, agentId);
   const defaultDatabasePath = params.requireDefaultDatabasePath?.(agentId);
-  if (defaultDatabasePath && !hasExplicitConfig && !hasBuiltInMemoryState(defaultDatabasePath)) {
+  if (
+    defaultDatabasePath &&
+    !hasExplicitConfig &&
+    !(await hasBuiltInMemoryState(defaultDatabasePath))
+  ) {
     // Avoid instantiating built-in memory for users who never created the default store.
     return null;
   }
@@ -410,7 +414,7 @@ export async function resolveSharedMemoryStatusSnapshot(params: {
     return null;
   }
   const shouldInspectStore =
-    hasExplicitConfig || hasBuiltInMemoryState(resolvedMemory.store.databasePath);
+    hasExplicitConfig || (await hasBuiltInMemoryState(resolvedMemory.store.databasePath));
   if (!shouldInspectStore) {
     return null;
   }

--- a/src/plugins/status-snapshot.cold-imports.test.ts
+++ b/src/plugins/status-snapshot.cold-imports.test.ts
@@ -1,0 +1,20 @@
+// Plugin snapshot cold-import tests keep metadata inventory off the mutable runtime registry.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("status-snapshot cold imports", () => {
+  afterEach(() => {
+    vi.doUnmock("./registry.js");
+    vi.resetModules();
+  });
+
+  it("does not import the mutable plugin registry barrel", async () => {
+    vi.resetModules();
+    vi.doMock("./registry.js", () => {
+      throw new Error("plugin status snapshots must use the lightweight registry owner");
+    });
+
+    const module = await import("./status-snapshot.js");
+
+    expect(module.buildPluginRegistrySnapshotReport).toBeTypeOf("function");
+  });
+});

--- a/src/plugins/status-snapshot.ts
+++ b/src/plugins/status-snapshot.ts
@@ -7,7 +7,8 @@ import {
   type PluginRegistrySnapshotDiagnostic,
   type PluginRegistrySnapshotSource,
 } from "./plugin-registry.js";
-import { createEmptyPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginRecord, PluginRegistry } from "./registry-types.js";
 import { buildPluginDependencyStatus } from "./status-dependencies-core.js";
 import type { PluginLogger } from "./types.js";
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where common status and plugin inventory commands imported optional memory and mutable plugin-runtime barrels during cold startup, adding avoidable memory pressure on constrained systems.

## Why This Change Was Made

Default JSON status now loads memory diagnostics only for `--all`, and the built-in memory storage facade is loaded only when an existing database actually needs inspection. Plugin inventory uses the lightweight empty-registry owner plus type-only contracts. The historical storage facade and full status behavior remain unchanged.

## User Impact

Operators on low-memory hosts get a smaller cold-start footprint for routine status and plugin inventory commands without losing full `status --all` diagnostics.

## Evidence

- Current PR head: `cad50d67240aa217f17224313fce08ce5bbbc0f3`, based on merged media commit `fa13cf4f2f007f160573809b5b6abe20b495d1a6`.
- Packaged proof commit: `ccef32605db0540c84163ddab7871d16adde6483`. Restacking changed only the parent; both commits have stable patch ID `9b97b28ad049722c4328022576adeaf07881d0a6`.
- Exact-head packaged Docker proof at 256 MiB RAM, swap disabled, 1 CPU, and 128 PIDs:
  - `status --json`: `158,408,704` bytes peak (151.1 MiB)
  - `plugins list --json`: `100,827,136` bytes peak (96.2 MiB)
  - `status --json --all`: `213,704,704` bytes peak (203.8 MiB)
  - every command produced valid JSON, exited 0, and reported zero OOM events
- Same-base packaged Docker measurements at 256 MiB RAM, swap disabled, 1 CPU, and 128 PIDs:
  - `status --json`, five-run median: 142.2 MiB before, 139.6 MiB after (1.8% lower)
  - `plugins list --json`, five-run median: 117.7 MiB before, 92.7 MiB after (21.2% lower)
  - `status --json --all`, three-run median: 187.6 MiB before, 188.6 MiB after (effectively flat; full path remains functional)
- The controlled before/after medians were recorded during development; the final head preserves those import boundaries while keeping the historical storage facade intact.
- Exact-head package build, CLI bootstrap import guard, all 148 plugin SDK export checks, and package tarball integrity passed.
- 33 focused status and plugin cold-import tests passed on the packaged patch; the restacked head is patch-identical.
- Lint, dead-export checks, and `git diff --check` passed.
- Fresh autoreview of the restacked head against current `main` returned no accepted/actionable findings.

AI-assisted: yes. I reviewed the implementation, focused tests, package artifact, and constrained-memory runtime proof.
