### PR TITLE
fix(backup): reclaim abandoned staging without touching live owners

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -360,6 +360,8 @@ OpenClaw does not enforce a built-in maximum backup size or per-file size limit.
 
 If final-directory durability confirmation fails after publication, the command reports failure but preserves the complete final entry rather than risk deleting a concurrent replacement.
 
+After a hard stop, a later `backup create` reclaims its marked temporary staging directories once they have been inactive for at least 24 hours. Active backups refresh their ownership every 30 minutes. Unmarked directories from older versions and artifacts owned by other operations are left alone.
+
 Large workspaces are usually the main driver of archive size. Use `--no-include-workspace` for a smaller/faster backup, or `--only-config` for the smallest archive.
 
 ## Related

--- a/src/infra/backup-archive-publication.test.ts
+++ b/src/infra/backup-archive-publication.test.ts
@@ -253,6 +253,43 @@ describe("backup archive publication", () => {
     }
   });
 
+  it.runIf(process.platform !== "win32")(
+    "reports the first cleanup sync failure without losing the committed archive",
+    async () => {
+      const { outputPath, plan } = await createPublication("openclaw-backup-cleanup-sync-");
+      const prepared = await prepareArchive(plan);
+      const log = vi.fn();
+      const originalOpen = fs.open.bind(fs);
+      let failedCleanupSync = false;
+      const openSpy = vi.spyOn(fs, "open").mockImplementation(async (target, flags, mode) => {
+        const handle = await originalOpen(target, flags, mode);
+        if (
+          path.resolve(String(target)) === plan.canonicalParentPath &&
+          !fsSync.existsSync(plan.stagingDir) &&
+          !failedCleanupSync
+        ) {
+          vi.spyOn(handle, "sync").mockImplementationOnce(async () => {
+            failedCleanupSync = true;
+            throw Object.assign(new Error("cleanup sync failed"), { code: "EIO" });
+          });
+        }
+        return handle;
+      });
+      try {
+        await publishPreparedBackupArchive({ plan, prepared, log });
+
+        expect(failedCleanupSync).toBe(true);
+        await expect(fs.readFile(outputPath, "utf8")).resolves.toBe("complete archive");
+        await expect(fs.lstat(plan.stagingDir)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(log).toHaveBeenCalledWith(
+          `Backup archiver could not sync cleanup in ${plan.canonicalParentPath}: EIO.`,
+        );
+      } finally {
+        openSpy.mockRestore();
+      }
+    },
+  );
+
   it("keeps the committed final archive when staging cleanup fails", async () => {
     const { outputPath, plan } = await createPublication("openclaw-backup-cleanup-failure-");
     const prepared = await prepareArchive(plan);
@@ -276,6 +313,20 @@ describe("backup archive publication", () => {
       await expect(fs.lstat(prepared.archivePath)).rejects.toMatchObject({ code: "ENOENT" });
       await expect(fs.lstat(plan.stagingDir)).rejects.toMatchObject({ code: "ENOENT" });
     }
+  });
+
+  it("preserves pending archive bytes when the ownership marker is replaced", async () => {
+    const { plan } = await createPublication("openclaw-backup-marker-replacement-");
+    const prepared = await prepareArchive(plan);
+    plan.pendingCleanupArchives.push(prepared);
+    const markerPath = path.join(plan.stagingDir, ".openclaw-backup-owner");
+    await fs.rename(markerPath, `${markerPath}.original`);
+    await fs.writeFile(markerPath, "replacement", { mode: 0o600 });
+
+    await cleanupBackupArchivePublication(plan);
+
+    await expect(fs.readFile(prepared.archivePath, "utf8")).resolves.toBe("complete archive");
+    await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("replacement");
   });
 
   it("retries cleanup when descriptor and pathname identity reads initially fail", async () => {

--- a/src/infra/backup-archive-publication.ts
+++ b/src/infra/backup-archive-publication.ts
@@ -7,6 +7,7 @@ import {
   type BackupArchiveCleanupReceipt,
   type PreparedBackupArchive,
 } from "./backup-create-stream.js";
+import { sweepStaleBackupTempDirectories } from "./backup-temp-sweep.js";
 import {
   getPublishFileExclusiveFailureDetails,
   isHardlinkFallbackError,
@@ -18,6 +19,11 @@ import {
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 
 type BackupArchiveLogger = (message: string) => void;
+
+// Publish staging is `.openclaw-backup-publish-<uuid>-<mkdtemp suffix>`.
+// Matching the whole shape keeps the sweep to directories this module made.
+const STALE_BACKUP_PUBLISH_DIRECTORY_PATTERN =
+  /^\.openclaw-backup-publish-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-[A-Za-z0-9]{6}$/u;
 
 export type BackupArchivePublication = {
   canonicalOutputPath: string;
@@ -79,6 +85,7 @@ async function removeStagingDirectoryIfOwned(plan: BackupArchivePublication): Pr
 
 export async function createBackupArchivePublication(
   outputPath: string,
+  log?: BackupArchiveLogger,
 ): Promise<BackupArchivePublication> {
   const requestedOutputPath = path.resolve(outputPath);
   const requestedParentPath = path.dirname(requestedOutputPath);
@@ -89,6 +96,11 @@ export async function createBackupArchivePublication(
   }
   const canonicalOutputPath = path.join(canonicalParentPath, path.basename(requestedOutputPath));
   await assertTargetAbsent(canonicalOutputPath);
+  await sweepStaleBackupTempDirectories({
+    directoryPath: canonicalParentPath,
+    entryPattern: STALE_BACKUP_PUBLISH_DIRECTORY_PATTERN,
+    log,
+  });
   const stagingDir = await fs.mkdtemp(
     path.join(canonicalParentPath, `.openclaw-backup-publish-${randomUUID()}-`),
   );

--- a/src/infra/backup-archive-publication.ts
+++ b/src/infra/backup-archive-publication.ts
@@ -7,7 +7,10 @@ import {
   type BackupArchiveCleanupReceipt,
   type PreparedBackupArchive,
 } from "./backup-create-stream.js";
-import { sweepStaleBackupTempDirectories } from "./backup-temp-sweep.js";
+import {
+  sweepStaleBackupTempArchiveFiles,
+  sweepStaleBackupTempDirectories,
+} from "./backup-temp-sweep.js";
 import {
   getPublishFileExclusiveFailureDetails,
   isHardlinkFallbackError,
@@ -24,6 +27,18 @@ type BackupArchiveLogger = (message: string) => void;
 // Matching the whole shape keeps the sweep to directories this module made.
 const STALE_BACKUP_PUBLISH_DIRECTORY_PATTERN =
   /^\.openclaw-backup-publish-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-[A-Za-z0-9]{6}$/u;
+
+// Pre-durable-publish releases (before #113302) staged the archive directly
+// as `<output>.<uuid>.tmp` beside the output, instead of inside a staging
+// directory. That shape is fully retired — nothing in current code still
+// writes it — so an operator who hit the leak on that release and later
+// upgraded past this fix would otherwise carry the orphan forever: the
+// directory-only sweep above never looks at loose files. Matching by the
+// UUID+`.tmp` suffix alone, rather than requiring today's specific output
+// basename, also reclaims an orphan left beside a *previous* day's output
+// filename, not only today's.
+const STALE_BACKUP_ARCHIVE_TEMP_FILE_PATTERN =
+  /\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.tmp$/u;
 
 export type BackupArchivePublication = {
   canonicalOutputPath: string;
@@ -99,6 +114,11 @@ export async function createBackupArchivePublication(
   await sweepStaleBackupTempDirectories({
     directoryPath: canonicalParentPath,
     entryPattern: STALE_BACKUP_PUBLISH_DIRECTORY_PATTERN,
+    log,
+  });
+  await sweepStaleBackupTempArchiveFiles({
+    directoryPath: canonicalParentPath,
+    entryPattern: STALE_BACKUP_ARCHIVE_TEMP_FILE_PATTERN,
     log,
   });
   const stagingDir = await fs.mkdtemp(

--- a/src/infra/backup-archive-publication.ts
+++ b/src/infra/backup-archive-publication.ts
@@ -7,10 +7,7 @@ import {
   type BackupArchiveCleanupReceipt,
   type PreparedBackupArchive,
 } from "./backup-create-stream.js";
-import {
-  sweepStaleBackupTempArchiveFiles,
-  sweepStaleBackupTempDirectories,
-} from "./backup-temp-sweep.js";
+import { sweepStaleBackupTempDirectories } from "./backup-temp-sweep.js";
 import {
   getPublishFileExclusiveFailureDetails,
   isHardlinkFallbackError,
@@ -27,18 +24,6 @@ type BackupArchiveLogger = (message: string) => void;
 // Matching the whole shape keeps the sweep to directories this module made.
 const STALE_BACKUP_PUBLISH_DIRECTORY_PATTERN =
   /^\.openclaw-backup-publish-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-[A-Za-z0-9]{6}$/u;
-
-// Pre-durable-publish releases (before #113302) staged the archive directly
-// as `<output>.<uuid>.tmp` beside the output, instead of inside a staging
-// directory. That shape is fully retired — nothing in current code still
-// writes it — so an operator who hit the leak on that release and later
-// upgraded past this fix would otherwise carry the orphan forever: the
-// directory-only sweep above never looks at loose files. Matching by the
-// UUID+`.tmp` suffix alone, rather than requiring today's specific output
-// basename, also reclaims an orphan left beside a *previous* day's output
-// filename, not only today's.
-const STALE_BACKUP_ARCHIVE_TEMP_FILE_PATTERN =
-  /\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.tmp$/u;
 
 export type BackupArchivePublication = {
   canonicalOutputPath: string;
@@ -114,11 +99,6 @@ export async function createBackupArchivePublication(
   await sweepStaleBackupTempDirectories({
     directoryPath: canonicalParentPath,
     entryPattern: STALE_BACKUP_PUBLISH_DIRECTORY_PATTERN,
-    log,
-  });
-  await sweepStaleBackupTempArchiveFiles({
-    directoryPath: canonicalParentPath,
-    entryPattern: STALE_BACKUP_ARCHIVE_TEMP_FILE_PATTERN,
     log,
   });
   const stagingDir = await fs.mkdtemp(

--- a/src/infra/backup-archive-publication.ts
+++ b/src/infra/backup-archive-publication.ts
@@ -9,6 +9,7 @@ import {
 } from "./backup-create-stream.js";
 import {
   keepBackupTempDirectoryAlive,
+  sameBackupTempIdentity,
   sweepStaleBackupTempDirectories,
 } from "./backup-temp-sweep.js";
 import {
@@ -71,7 +72,7 @@ async function removeDirectoryIfOwned(
   if (
     !currentIdentity ||
     !currentIdentity.isDirectory() ||
-    !sameFileIdentity(expectedIdentity, currentIdentity)
+    !sameBackupTempIdentity(expectedIdentity, currentIdentity)
   ) {
     return false;
   }

--- a/src/infra/backup-archive-publication.ts
+++ b/src/infra/backup-archive-publication.ts
@@ -8,6 +8,10 @@ import {
   type PreparedBackupArchive,
 } from "./backup-create-stream.js";
 import {
+  keepBackupTempDirectoryAlive,
+  sweepStaleBackupTempDirectories,
+} from "./backup-temp-sweep.js";
+import {
   getPublishFileExclusiveFailureDetails,
   isHardlinkFallbackError,
   publishFileExclusive,
@@ -19,6 +23,11 @@ import { sameFileIdentity } from "./fs-safe-advanced.js";
 
 type BackupArchiveLogger = (message: string) => void;
 
+// Publish staging is `.openclaw-backup-publish-<uuid>-<mkdtemp suffix>`.
+// Matching the whole shape keeps the sweep to directories this module made.
+const STALE_BACKUP_PUBLISH_DIRECTORY_PATTERN =
+  /^\.openclaw-backup-publish-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-[A-Za-z0-9]{6}$/u;
+
 export type BackupArchivePublication = {
   canonicalOutputPath: string;
   canonicalParentPath: string;
@@ -28,6 +37,7 @@ export type BackupArchivePublication = {
   requestedParentPath: string;
   stagingDir: string;
   stagingIdentity: Stats;
+  stopKeepAlive: () => boolean;
   tempArchivePath: string;
 };
 
@@ -73,12 +83,9 @@ async function removeDirectoryIfOwned(
   }
 }
 
-async function removeStagingDirectoryIfOwned(plan: BackupArchivePublication): Promise<boolean> {
-  return await removeDirectoryIfOwned(plan.stagingDir, plan.stagingIdentity);
-}
-
 export async function createBackupArchivePublication(
   outputPath: string,
+  log?: BackupArchiveLogger,
 ): Promise<BackupArchivePublication> {
   const requestedOutputPath = path.resolve(outputPath);
   const requestedParentPath = path.dirname(requestedOutputPath);
@@ -89,6 +96,11 @@ export async function createBackupArchivePublication(
   }
   const canonicalOutputPath = path.join(canonicalParentPath, path.basename(requestedOutputPath));
   await assertTargetAbsent(canonicalOutputPath);
+  await sweepStaleBackupTempDirectories({
+    directoryPath: canonicalParentPath,
+    entryPattern: STALE_BACKUP_PUBLISH_DIRECTORY_PATTERN,
+    log,
+  });
   const stagingDir = await fs.mkdtemp(
     path.join(canonicalParentPath, `.openclaw-backup-publish-${randomUUID()}-`),
   );
@@ -109,6 +121,7 @@ export async function createBackupArchivePublication(
       requestedParentPath,
       stagingDir,
       stagingIdentity,
+      stopKeepAlive: keepBackupTempDirectoryAlive(stagingDir, stagingIdentity),
       tempArchivePath: path.join(stagingDir, "archive.tar.gz.tmp"),
     };
   } catch (error) {
@@ -165,17 +178,24 @@ async function removePendingBackupArchive(
   });
 }
 
+async function removeOwnedPublicationStaging(plan: BackupArchivePublication): Promise<boolean> {
+  if (plan.stopKeepAlive()) {
+    const retainedArchives = plan.pendingCleanupArchives.splice(0);
+    for (const receipt of retainedArchives) {
+      if (!(await removePendingBackupArchive(plan, receipt))) {
+        retainArchiveForCleanup(plan, receipt);
+      }
+    }
+    return await removeDirectoryIfOwned(plan.stagingDir, plan.stagingIdentity);
+  }
+  return false;
+}
+
 export async function cleanupBackupArchivePublication(
   plan: BackupArchivePublication,
   log?: BackupArchiveLogger,
 ): Promise<void> {
-  const retainedArchives = plan.pendingCleanupArchives.splice(0);
-  for (const receipt of retainedArchives) {
-    if (!(await removePendingBackupArchive(plan, receipt))) {
-      retainArchiveForCleanup(plan, receipt);
-    }
-  }
-  if (await removeStagingDirectoryIfOwned(plan)) {
+  if (await removeOwnedPublicationStaging(plan)) {
     await syncDirectoryIfSupported(plan.canonicalParentPath).catch(() => undefined);
     return;
   }
@@ -233,11 +253,8 @@ export async function publishPreparedBackupArchive(params: {
       retainArchiveForCleanup(plan, prepared);
       params.log?.(`Backup archiver preserved changed staging file ${prepared.archivePath}.`);
     }
-    if (!(await removeStagingDirectoryIfOwned(plan))) {
-      params.log?.(
-        `Backup archiver preserved changed or non-empty staging directory ${plan.stagingDir}.`,
-      );
-    }
+    // The outer owner reports retention after its final cleanup attempt.
+    await removeOwnedPublicationStaging(plan);
     await syncDirectoryIfSupported(plan.canonicalParentPath).catch((error: unknown) => {
       params.log?.(
         `Backup archiver could not sync cleanup in ${plan.canonicalParentPath}: ${
@@ -255,7 +272,7 @@ export async function publishPreparedBackupArchive(params: {
       if (!removePreparedBackupArchive(prepared)) {
         retainArchiveForCleanup(plan, prepared);
       }
-      await removeStagingDirectoryIfOwned(plan);
+      await removeOwnedPublicationStaging(plan);
     }
     throw error;
   }

--- a/src/infra/backup-create-stream.ts
+++ b/src/infra/backup-create-stream.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import { Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sameBackupTempIdentity } from "./backup-temp-sweep.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 
 const BACKUP_ARCHIVE_IDLE_TIMEOUT_MS = 5 * 60_000;
@@ -57,7 +58,7 @@ export function removePreparedBackupArchive(prepared: PreparedBackupArchive): bo
   } catch {
     return false;
   }
-  if (!currentIdentity.isFile() || !sameFileIdentity(prepared.identity, currentIdentity)) {
+  if (!currentIdentity.isFile() || !sameBackupTempIdentity(prepared.identity, currentIdentity)) {
     return false;
   }
   try {

--- a/src/infra/backup-create.temp-sweep.test.ts
+++ b/src/infra/backup-create.temp-sweep.test.ts
@@ -31,15 +31,22 @@ async function directoryExists(directoryPath: string): Promise<boolean> {
 }
 
 async function withTempRootEnv<T>(tempRoot: string, run: () => Promise<T>): Promise<T> {
-  const previous = process.env.TMPDIR;
-  process.env.TMPDIR = tempRoot;
+  // os.tmpdir() reads TMPDIR on POSIX but TEMP/TMP on Windows, so override all
+  // three — otherwise this sweep test never redirects the temp root on Windows.
+  const names = ["TMPDIR", "TEMP", "TMP"] as const;
+  const previous = names.map((name) => [name, process.env[name]] as const);
+  for (const name of names) {
+    process.env[name] = tempRoot;
+  }
   try {
     return await run();
   } finally {
-    if (previous === undefined) {
-      delete process.env.TMPDIR;
-    } else {
-      process.env.TMPDIR = previous;
+    for (const [name, value] of previous) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
     }
   }
 }

--- a/src/infra/backup-create.temp-sweep.test.ts
+++ b/src/infra/backup-create.temp-sweep.test.ts
@@ -162,27 +162,23 @@ describe("createBackupArchive stale temp sweep", () => {
     );
   });
 
-  it("removes a legacy <output>.<uuid>.tmp archive file left beside the output", async () => {
+  it("preserves an aged Fleet archive temp file beside the output", async () => {
     await withOpenClawTestState(
       {
         layout: "state-only",
-        prefix: "openclaw-backup-sweep-legacy-file-",
+        prefix: "openclaw-backup-sweep-fleet-file-",
         scenario: "minimal",
       },
       async (state) => {
         const outputDir = state.path("backups");
         await fs.mkdir(outputDir, { recursive: true });
-        // Pre-durable-publish releases (before #113302) staged the archive as
-        // this loose file beside the output rather than inside a directory.
-        // A previous day's output filename, not today's, proves the sweep
-        // reclaims by suffix rather than by matching the current run's name.
-        const orphan = path.join(
-          outputDir,
-          `2026-05-08T00-00-00.000-00-00-openclaw-backup.tar.gz.${randomUUID()}.tmp`,
-        );
-        await fs.writeFile(orphan, "orphaned legacy payload\n");
+        // Fleet backup publishes through the same `<archive>.<uuid>.tmp`
+        // shape as the retired backup-create writer. Backup-create cannot
+        // prove ownership of this sibling artifact, even after it ages out.
+        const fleetTemp = path.join(outputDir, `fleet-backup.tar.gz.${randomUUID()}.tmp`);
+        await fs.writeFile(fleetTemp, "fleet payload\n");
         const aged = new Date(Date.now() - 48 * HOUR_MS);
-        await fs.utimes(orphan, aged, aged);
+        await fs.utimes(fleetTemp, aged, aged);
 
         await createBackupArchive({
           output: outputDir,
@@ -190,7 +186,7 @@ describe("createBackupArchive stale temp sweep", () => {
           nowMs: ARCHIVE_NOW_MS,
         });
 
-        expect(await pathExists(orphan)).toBe(false);
+        expect(await pathExists(fleetTemp)).toBe(true);
       },
     );
   });

--- a/src/infra/backup-create.temp-sweep.test.ts
+++ b/src/infra/backup-create.temp-sweep.test.ts
@@ -1,10 +1,16 @@
 // Covers reclaiming backup temp artifacts that a hard-killed run orphaned.
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createBackupArchive } from "./backup-create.js";
+import {
+  BACKUP_TEMP_KEEPALIVE_INTERVAL_MS,
+  keepBackupTempDirectoryAlive,
+  sweepStaleBackupTempDirectories,
+} from "./backup-temp-sweep.js";
 
 const HOUR_MS = 60 * 60_000;
 const ARCHIVE_NOW_MS = Date.UTC(2026, 4, 9, 8, 0, 0);
@@ -161,5 +167,66 @@ describe("createBackupArchive stale temp sweep", () => {
         expect(await directoryExists(unrelatedDir)).toBe(true);
       },
     );
+  });
+});
+
+describe("live-owner fence", () => {
+  // `tar` only reads the staging directory, so a backup whose archive stream
+  // runs longer than the orphan window would age out while still live.
+  const STAGING_PATTERN = /^openclaw-backup-[A-Za-z0-9]{6}$/u;
+
+  async function withAgedStagingRoot(
+    run: (params: { root: string; staging: string }) => Promise<void>,
+  ): Promise<void> {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fence-")));
+    try {
+      const staging = path.join(root, "openclaw-backup-liv001");
+      await fs.mkdir(staging);
+      await fs.writeFile(path.join(staging, "manifest.json"), "{}\n");
+      // Age past the window, as a long archive stream leaves the source dir.
+      const aged = new Date(Date.now() - 25 * HOUR_MS);
+      await fs.utimes(path.join(staging, "manifest.json"), aged, aged);
+      await fs.utimes(staging, aged, aged);
+      await run({ root, staging });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+
+  it("keeps an aged staging directory that a live run is still refreshing", async () => {
+    vi.useFakeTimers();
+    try {
+      await withAgedStagingRoot(async ({ root, staging }) => {
+        const stopKeepAlive = keepBackupTempDirectoryAlive(staging);
+        await vi.advanceTimersByTimeAsync(BACKUP_TEMP_KEEPALIVE_INTERVAL_MS);
+        stopKeepAlive();
+
+        await sweepStaleBackupTempDirectories({
+          directoryPath: root,
+          entryPattern: STAGING_PATTERN,
+        });
+
+        expect(await directoryExists(staging)).toBe(true);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reclaims the same directory once its owner stops refreshing", async () => {
+    vi.useFakeTimers();
+    try {
+      await withAgedStagingRoot(async ({ root, staging }) => {
+        // Negative control: identical fixture, no live owner (the hard-kill case).
+        await sweepStaleBackupTempDirectories({
+          directoryPath: root,
+          entryPattern: STAGING_PATTERN,
+        });
+
+        expect(await directoryExists(staging)).toBe(false);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/infra/backup-create.temp-sweep.test.ts
+++ b/src/infra/backup-create.temp-sweep.test.ts
@@ -1,0 +1,165 @@
+// Covers reclaiming backup temp artifacts that a hard-killed run orphaned.
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createBackupArchive } from "./backup-create.js";
+
+const HOUR_MS = 60 * 60_000;
+const ARCHIVE_NOW_MS = Date.UTC(2026, 4, 9, 8, 0, 0);
+
+async function writeAgedDirectory(directoryPath: string, ageMs: number): Promise<void> {
+  await fs.mkdir(directoryPath, { recursive: true });
+  await fs.writeFile(path.join(directoryPath, "archive.tar.gz.tmp"), "orphaned payload\n");
+  // Creating the file bumps the directory mtime, so age the directory last.
+  const stamp = new Date(Date.now() - ageMs);
+  await fs.utimes(path.join(directoryPath, "archive.tar.gz.tmp"), stamp, stamp);
+  await fs.utimes(directoryPath, stamp, stamp);
+}
+
+async function directoryExists(directoryPath: string): Promise<boolean> {
+  return await fs.stat(directoryPath).then(
+    () => true,
+    () => false,
+  );
+}
+
+async function withTempRootEnv<T>(tempRoot: string, run: () => Promise<T>): Promise<T> {
+  const previous = process.env.TMPDIR;
+  process.env.TMPDIR = tempRoot;
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.TMPDIR;
+    } else {
+      process.env.TMPDIR = previous;
+    }
+  }
+}
+
+describe("createBackupArchive stale temp sweep", () => {
+  it("removes a staging directory orphaned by an earlier hard-killed run", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-staging-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        const tempRoot = state.path("tmproot");
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.mkdir(tempRoot, { recursive: true });
+        const orphan = path.join(tempRoot, "openclaw-backup-a1b2c3");
+        await writeAgedDirectory(orphan, 48 * HOUR_MS);
+
+        await withTempRootEnv(tempRoot, async () => {
+          await createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: ARCHIVE_NOW_MS,
+          });
+        });
+
+        expect(await directoryExists(orphan)).toBe(false);
+      },
+    );
+  });
+
+  it("removes a publish staging directory orphaned beside the output archive", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-publish-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+        const orphan = path.join(outputDir, `.openclaw-backup-publish-${randomUUID()}-a1b2c3`);
+        await writeAgedDirectory(orphan, 48 * HOUR_MS);
+
+        await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: false,
+          nowMs: ARCHIVE_NOW_MS,
+        });
+
+        expect(await directoryExists(orphan)).toBe(false);
+      },
+    );
+  });
+
+  it("keeps a staging directory whose archive is still being written", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-active-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        const tempRoot = state.path("tmproot");
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.mkdir(tempRoot, { recursive: true });
+        // A long tar write never touches the parent directory, so a live run
+        // can carry a stale directory mtime alongside a fresh archive file.
+        const activeRun = path.join(tempRoot, "openclaw-backup-c3d4e5");
+        await writeAgedDirectory(activeRun, 48 * HOUR_MS);
+        const now = new Date();
+        await fs.utimes(path.join(activeRun, "archive.tar.gz.tmp"), now, now);
+
+        await withTempRootEnv(tempRoot, async () => {
+          await createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: ARCHIVE_NOW_MS,
+          });
+        });
+
+        expect(await directoryExists(activeRun)).toBe(true);
+      },
+    );
+  });
+
+  it("keeps recent, sibling-owned, and non-mkdtemp directories", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-scope-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        const tempRoot = state.path("tmproot");
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.mkdir(tempRoot, { recursive: true });
+        // `openclaw-backup-` prefixes `openclaw-backup-verify-sqlite-`, so a
+        // prefix-only match would delete a concurrent `backup verify` run.
+        const concurrentVerify = path.join(tempRoot, "openclaw-backup-verify-sqlite-a1b2c3");
+        const concurrentCreate = path.join(tempRoot, "openclaw-backup-b2c3d4");
+        const unrelatedName = path.join(tempRoot, "openclaw-backup-user-notes");
+        const unrelatedDir = path.join(tempRoot, "unrelated-data");
+        await writeAgedDirectory(concurrentVerify, 48 * HOUR_MS);
+        await writeAgedDirectory(concurrentCreate, 0);
+        await writeAgedDirectory(unrelatedName, 48 * HOUR_MS);
+        await writeAgedDirectory(unrelatedDir, 48 * HOUR_MS);
+
+        await withTempRootEnv(tempRoot, async () => {
+          await createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: ARCHIVE_NOW_MS,
+          });
+        });
+
+        expect(await directoryExists(concurrentVerify)).toBe(true);
+        expect(await directoryExists(concurrentCreate)).toBe(true);
+        expect(await directoryExists(unrelatedName)).toBe(true);
+        expect(await directoryExists(unrelatedDir)).toBe(true);
+      },
+    );
+  });
+});

--- a/src/infra/backup-create.temp-sweep.test.ts
+++ b/src/infra/backup-create.temp-sweep.test.ts
@@ -14,6 +14,14 @@ import {
 const HOUR_MS = 60 * 60_000;
 const ARCHIVE_NOW_MS = Date.UTC(2026, 4, 9, 8, 0, 0);
 
+// Mirrors the private `OWNER_MARKER_FILENAME` constant in backup-temp-sweep.ts.
+// Not exported from there — an export used only by this test file trips the
+// project's knip dead-export check — so fixtures below that need to prove a
+// directory *was* claimed write this marker directly instead of going
+// through `keepBackupTempDirectoryAlive`, whose stop function always removes
+// it as part of a clean finish (see that function's own comment).
+const OWNER_MARKER_FILENAME = ".openclaw-backup-owner";
+
 async function writeAgedDirectory(directoryPath: string, ageMs: number): Promise<void> {
   await fs.mkdir(directoryPath, { recursive: true });
   await fs.writeFile(path.join(directoryPath, "archive.tar.gz.tmp"), "orphaned payload\n");
@@ -23,8 +31,25 @@ async function writeAgedDirectory(directoryPath: string, ageMs: number): Promise
   await fs.utimes(directoryPath, stamp, stamp);
 }
 
-async function directoryExists(directoryPath: string): Promise<boolean> {
-  return await fs.stat(directoryPath).then(
+// Same fixture as `writeAgedDirectory`, but also carries the ownership
+// marker a real run writes immediately after `mkdtemp`. This models a
+// genuine orphan of *this* format (heartbeat-aware, hard-killed after
+// claiming ownership) rather than a pre-upgrade directory that never had the
+// chance to claim it.
+async function writeAgedOwnedDirectory(directoryPath: string, ageMs: number): Promise<void> {
+  await fs.mkdir(directoryPath, { recursive: true });
+  await fs.writeFile(path.join(directoryPath, OWNER_MARKER_FILENAME), "");
+  await fs.writeFile(path.join(directoryPath, "archive.tar.gz.tmp"), "orphaned payload\n");
+  const stamp = new Date(Date.now() - ageMs);
+  const entries = await fs.readdir(directoryPath);
+  for (const entry of entries) {
+    await fs.utimes(path.join(directoryPath, entry), stamp, stamp);
+  }
+  await fs.utimes(directoryPath, stamp, stamp);
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  return await fs.stat(targetPath).then(
     () => true,
     () => false,
   );
@@ -65,7 +90,7 @@ describe("createBackupArchive stale temp sweep", () => {
         await fs.mkdir(outputDir, { recursive: true });
         await fs.mkdir(tempRoot, { recursive: true });
         const orphan = path.join(tempRoot, "openclaw-backup-a1b2c3");
-        await writeAgedDirectory(orphan, 48 * HOUR_MS);
+        await writeAgedOwnedDirectory(orphan, 48 * HOUR_MS);
 
         await withTempRootEnv(tempRoot, async () => {
           await createBackupArchive({
@@ -75,7 +100,7 @@ describe("createBackupArchive stale temp sweep", () => {
           });
         });
 
-        expect(await directoryExists(orphan)).toBe(false);
+        expect(await pathExists(orphan)).toBe(false);
       },
     );
   });
@@ -91,7 +116,7 @@ describe("createBackupArchive stale temp sweep", () => {
         const outputDir = state.path("backups");
         await fs.mkdir(outputDir, { recursive: true });
         const orphan = path.join(outputDir, `.openclaw-backup-publish-${randomUUID()}-a1b2c3`);
-        await writeAgedDirectory(orphan, 48 * HOUR_MS);
+        await writeAgedOwnedDirectory(orphan, 48 * HOUR_MS);
 
         await createBackupArchive({
           output: outputDir,
@@ -99,7 +124,103 @@ describe("createBackupArchive stale temp sweep", () => {
           nowMs: ARCHIVE_NOW_MS,
         });
 
-        expect(await directoryExists(orphan)).toBe(false);
+        expect(await pathExists(orphan)).toBe(false);
+      },
+    );
+  });
+
+  it("leaves an aged staging directory alone when no run ever claimed it", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-legacy-staging-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        const tempRoot = state.path("tmproot");
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.mkdir(tempRoot, { recursive: true });
+        // Exact name shape a pre-upgrade (pre-heartbeat) build would also
+        // produce, but nothing ever wrote the ownership marker onto it. That
+        // could mean an orphan of this build, or a still-running backup from
+        // the older one — the two are indistinguishable by age alone, so the
+        // conservative sweep must leave it alone either way.
+        const possiblyLiveLegacyRun = path.join(tempRoot, "openclaw-backup-1eGacy");
+        await writeAgedDirectory(possiblyLiveLegacyRun, 48 * HOUR_MS);
+
+        await withTempRootEnv(tempRoot, async () => {
+          await createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: ARCHIVE_NOW_MS,
+          });
+        });
+
+        expect(await pathExists(possiblyLiveLegacyRun)).toBe(true);
+      },
+    );
+  });
+
+  it("removes a legacy <output>.<uuid>.tmp archive file left beside the output", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-legacy-file-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+        // Pre-durable-publish releases (before #113302) staged the archive as
+        // this loose file beside the output rather than inside a directory.
+        // A previous day's output filename, not today's, proves the sweep
+        // reclaims by suffix rather than by matching the current run's name.
+        const orphan = path.join(
+          outputDir,
+          `2026-05-08T00-00-00.000-00-00-openclaw-backup.tar.gz.${randomUUID()}.tmp`,
+        );
+        await fs.writeFile(orphan, "orphaned legacy payload\n");
+        const aged = new Date(Date.now() - 48 * HOUR_MS);
+        await fs.utimes(orphan, aged, aged);
+
+        await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: false,
+          nowMs: ARCHIVE_NOW_MS,
+        });
+
+        expect(await pathExists(orphan)).toBe(false);
+      },
+    );
+  });
+
+  it("keeps a legacy archive-temp file a live pre-durable-publish run is still writing", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-legacy-file-live-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+        const liveFile = path.join(
+          outputDir,
+          `2026-05-08T00-00-00.000-00-00-openclaw-backup.tar.gz.${randomUUID()}.tmp`,
+        );
+        // Unlike a staging directory, this file is the direct write target of
+        // `tar` in the retired scheme, so its own mtime already tracks an
+        // active writer with no extra fence needed.
+        await fs.writeFile(liveFile, "still streaming\n");
+
+        await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: false,
+          nowMs: ARCHIVE_NOW_MS,
+        });
+
+        expect(await pathExists(liveFile)).toBe(true);
       },
     );
   });
@@ -119,7 +240,7 @@ describe("createBackupArchive stale temp sweep", () => {
         // A long tar write never touches the parent directory, so a live run
         // can carry a stale directory mtime alongside a fresh archive file.
         const activeRun = path.join(tempRoot, "openclaw-backup-c3d4e5");
-        await writeAgedDirectory(activeRun, 48 * HOUR_MS);
+        await writeAgedOwnedDirectory(activeRun, 48 * HOUR_MS);
         const now = new Date();
         await fs.utimes(path.join(activeRun, "archive.tar.gz.tmp"), now, now);
 
@@ -131,7 +252,7 @@ describe("createBackupArchive stale temp sweep", () => {
           });
         });
 
-        expect(await directoryExists(activeRun)).toBe(true);
+        expect(await pathExists(activeRun)).toBe(true);
       },
     );
   });
@@ -167,10 +288,10 @@ describe("createBackupArchive stale temp sweep", () => {
           });
         });
 
-        expect(await directoryExists(concurrentVerify)).toBe(true);
-        expect(await directoryExists(concurrentCreate)).toBe(true);
-        expect(await directoryExists(unrelatedName)).toBe(true);
-        expect(await directoryExists(unrelatedDir)).toBe(true);
+        expect(await pathExists(concurrentVerify)).toBe(true);
+        expect(await pathExists(concurrentCreate)).toBe(true);
+        expect(await pathExists(unrelatedName)).toBe(true);
+        expect(await pathExists(unrelatedDir)).toBe(true);
       },
     );
   });
@@ -202,23 +323,32 @@ describe("live-owner fence", () => {
   it("keeps a staging directory alive across a full orphan window", async () => {
     await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
       const stopKeepAlive = keepBackupTempDirectoryAlive(staging);
-      // Models an archive stream that outlives the window: `tar` only reads
-      // staging, so the heartbeat is the sole thing keeping it claimed.
-      await vi.advanceTimersByTimeAsync(25 * HOUR_MS);
-      stopKeepAlive();
+      try {
+        // Models an archive stream that outlives the window: `tar` only reads
+        // staging, so the heartbeat is the sole thing keeping it claimed
+        // while this run — and its sweep against it — is still live.
+        await vi.advanceTimersByTimeAsync(25 * HOUR_MS);
 
-      await sweepStaleBackupTempDirectories({
-        directoryPath: root,
-        entryPattern: STAGING_PATTERN,
-      });
+        await sweepStaleBackupTempDirectories({
+          directoryPath: root,
+          entryPattern: STAGING_PATTERN,
+        });
 
-      expect(await directoryExists(staging)).toBe(true);
+        expect(await pathExists(staging)).toBe(true);
+      } finally {
+        stopKeepAlive();
+      }
     });
   });
 
-  it("reclaims the same directory when no owner refreshes it", async () => {
+  it("reclaims the same directory once its owner stops refreshing", async () => {
     await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
-      // Negative control: the hard-kill case, identical but with no live owner.
+      // The hard-kill case: ownership was established (the marker exists)
+      // but nothing refreshes it afterward. Written directly rather than via
+      // `keepBackupTempDirectoryAlive`, whose stop function always removes
+      // the marker as part of a clean finish — this models the marker
+      // outliving the process that wrote it, not a clean stop.
+      await fs.writeFile(path.join(staging, OWNER_MARKER_FILENAME), "");
       await vi.advanceTimersByTimeAsync(25 * HOUR_MS);
 
       await sweepStaleBackupTempDirectories({
@@ -226,7 +356,23 @@ describe("live-owner fence", () => {
         entryPattern: STAGING_PATTERN,
       });
 
-      expect(await directoryExists(staging)).toBe(false);
+      expect(await pathExists(staging)).toBe(false);
+    });
+  });
+
+  it("leaves the same directory alone when no run ever claimed it", async () => {
+    await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+      // Negative control for the marker itself: identical shape and age, but
+      // no run ever wrote the ownership marker — the pre-upgrade case, which
+      // must never be reclaimed no matter how idle it looks.
+      await vi.advanceTimersByTimeAsync(25 * HOUR_MS);
+
+      await sweepStaleBackupTempDirectories({
+        directoryPath: root,
+        entryPattern: STAGING_PATTERN,
+      });
+
+      expect(await pathExists(staging)).toBe(true);
     });
   });
 });

--- a/src/infra/backup-create.temp-sweep.test.ts
+++ b/src/infra/backup-create.temp-sweep.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, it, vi } from "vitest";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createBackupArchive } from "./backup-create.js";
 import {
-  BACKUP_TEMP_KEEPALIVE_INTERVAL_MS,
   keepBackupTempDirectoryAlive,
   sweepStaleBackupTempDirectories,
 } from "./backup-temp-sweep.js";
@@ -175,58 +174,52 @@ describe("live-owner fence", () => {
   // runs longer than the orphan window would age out while still live.
   const STAGING_PATTERN = /^openclaw-backup-[A-Za-z0-9]{6}$/u;
 
-  async function withAgedStagingRoot(
+  // Both cases share one fixture and one elapsed window; only the live owner
+  // differs, so the assertion isolates the fence itself.
+  async function withStagingRootPastOrphanWindow(
     run: (params: { root: string; staging: string }) => Promise<void>,
   ): Promise<void> {
     const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fence-")));
+    vi.useFakeTimers();
     try {
       const staging = path.join(root, "openclaw-backup-liv001");
       await fs.mkdir(staging);
       await fs.writeFile(path.join(staging, "manifest.json"), "{}\n");
-      // Age past the window, as a long archive stream leaves the source dir.
-      const aged = new Date(Date.now() - 25 * HOUR_MS);
-      await fs.utimes(path.join(staging, "manifest.json"), aged, aged);
-      await fs.utimes(staging, aged, aged);
       await run({ root, staging });
     } finally {
+      vi.useRealTimers();
       await fs.rm(root, { recursive: true, force: true }).catch(() => undefined);
     }
   }
 
-  it("keeps an aged staging directory that a live run is still refreshing", async () => {
-    vi.useFakeTimers();
-    try {
-      await withAgedStagingRoot(async ({ root, staging }) => {
-        const stopKeepAlive = keepBackupTempDirectoryAlive(staging);
-        await vi.advanceTimersByTimeAsync(BACKUP_TEMP_KEEPALIVE_INTERVAL_MS);
-        stopKeepAlive();
+  it("keeps a staging directory alive across a full orphan window", async () => {
+    await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+      const stopKeepAlive = keepBackupTempDirectoryAlive(staging);
+      // Models an archive stream that outlives the window: `tar` only reads
+      // staging, so the heartbeat is the sole thing keeping it claimed.
+      await vi.advanceTimersByTimeAsync(25 * HOUR_MS);
+      stopKeepAlive();
 
-        await sweepStaleBackupTempDirectories({
-          directoryPath: root,
-          entryPattern: STAGING_PATTERN,
-        });
-
-        expect(await directoryExists(staging)).toBe(true);
+      await sweepStaleBackupTempDirectories({
+        directoryPath: root,
+        entryPattern: STAGING_PATTERN,
       });
-    } finally {
-      vi.useRealTimers();
-    }
+
+      expect(await directoryExists(staging)).toBe(true);
+    });
   });
 
-  it("reclaims the same directory once its owner stops refreshing", async () => {
-    vi.useFakeTimers();
-    try {
-      await withAgedStagingRoot(async ({ root, staging }) => {
-        // Negative control: identical fixture, no live owner (the hard-kill case).
-        await sweepStaleBackupTempDirectories({
-          directoryPath: root,
-          entryPattern: STAGING_PATTERN,
-        });
+  it("reclaims the same directory when no owner refreshes it", async () => {
+    await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+      // Negative control: the hard-kill case, identical but with no live owner.
+      await vi.advanceTimersByTimeAsync(25 * HOUR_MS);
 
-        expect(await directoryExists(staging)).toBe(false);
+      await sweepStaleBackupTempDirectories({
+        directoryPath: root,
+        entryPattern: STAGING_PATTERN,
       });
-    } finally {
-      vi.useRealTimers();
-    }
+
+      expect(await directoryExists(staging)).toBe(false);
+    });
   });
 });

--- a/src/infra/backup-create.temp-sweep.test.ts
+++ b/src/infra/backup-create.temp-sweep.test.ts
@@ -1,0 +1,680 @@
+// Covers reclaiming backup temp artifacts that a hard-killed run orphaned.
+import { randomUUID } from "node:crypto";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createBackupArchive } from "./backup-create.js";
+import {
+  keepBackupTempDirectoryAlive,
+  sweepStaleBackupTempDirectories,
+} from "./backup-temp-sweep.js";
+
+const HOUR_MS = 60 * 60_000;
+const ARCHIVE_NOW_MS = Date.UTC(2026, 4, 9, 8, 0, 0);
+
+// Crash fixtures retain the marker that normal cleanup removes.
+const OWNER_MARKER_FILENAME = ".openclaw-backup-owner";
+
+async function writeAgedDirectory(directoryPath: string, ageMs: number): Promise<void> {
+  await fs.mkdir(directoryPath, { recursive: true });
+  await fs.writeFile(path.join(directoryPath, "archive.tar.gz.tmp"), "orphaned payload\n");
+  // Creating the file bumps the directory mtime, so age the directory last.
+  const stamp = new Date(Date.now() - ageMs);
+  await fs.utimes(path.join(directoryPath, "archive.tar.gz.tmp"), stamp, stamp);
+  await fs.utimes(directoryPath, stamp, stamp);
+}
+
+// Same fixture as `writeAgedDirectory`, but also carries the ownership
+// marker a real run writes immediately after `mkdtemp`. This models a
+// genuine orphan of *this* format (heartbeat-aware, hard-killed after
+// claiming ownership) rather than a pre-upgrade directory that never had the
+// chance to claim it.
+async function writeAgedOwnedDirectory(directoryPath: string, ageMs: number): Promise<void> {
+  await fs.mkdir(directoryPath, { recursive: true });
+  await fs.writeFile(path.join(directoryPath, OWNER_MARKER_FILENAME), "", { mode: 0o600 });
+  await fs.writeFile(path.join(directoryPath, "archive.tar.gz.tmp"), "orphaned payload\n");
+  const stamp = new Date(Date.now() - ageMs);
+  const entries = await fs.readdir(directoryPath);
+  for (const entry of entries) {
+    await fs.utimes(path.join(directoryPath, entry), stamp, stamp);
+  }
+  await fs.utimes(directoryPath, stamp, stamp);
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  return await fs.stat(targetPath).then(
+    () => true,
+    () => false,
+  );
+}
+
+async function withTempRootEnv<T>(tempRoot: string, run: () => Promise<T>): Promise<T> {
+  // os.tmpdir() reads TMPDIR on POSIX but TEMP/TMP on Windows, so override all
+  // three — otherwise this sweep test never redirects the temp root on Windows.
+  const names = ["TMPDIR", "TEMP", "TMP"] as const;
+  const previous = names.map((name) => [name, process.env[name]] as const);
+  for (const name of names) {
+    process.env[name] = tempRoot;
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+}
+
+describe("createBackupArchive stale temp sweep", () => {
+  it("removes a staging directory orphaned by an earlier hard-killed run", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-staging-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        const tempRoot = state.path("tmproot");
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.mkdir(tempRoot, { recursive: true });
+        const orphan = path.join(tempRoot, "openclaw-backup-a1b2c3");
+        await writeAgedOwnedDirectory(orphan, 48 * HOUR_MS);
+        const log = vi.fn();
+
+        await withTempRootEnv(tempRoot, async () => {
+          await createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: ARCHIVE_NOW_MS,
+            log,
+          });
+        });
+
+        expect(await pathExists(orphan)).toBe(false);
+        expect(log).not.toHaveBeenCalledWith(
+          expect.stringContaining("preserved changed or non-empty staging directory"),
+        );
+      },
+    );
+  });
+
+  it("removes a publish staging directory orphaned beside the output archive", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-publish-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+        const orphan = path.join(outputDir, `.openclaw-backup-publish-${randomUUID()}-a1b2c3`);
+        await writeAgedOwnedDirectory(orphan, 48 * HOUR_MS);
+
+        await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: false,
+          nowMs: ARCHIVE_NOW_MS,
+        });
+
+        expect(await pathExists(orphan)).toBe(false);
+      },
+    );
+  });
+
+  it("leaves an aged staging directory alone when no run ever claimed it", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-legacy-staging-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        const tempRoot = state.path("tmproot");
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.mkdir(tempRoot, { recursive: true });
+        // Exact name shape a pre-upgrade (pre-heartbeat) build would also
+        // produce, but nothing ever wrote the ownership marker onto it. That
+        // could mean an orphan of this build, or a still-running backup from
+        // the older one — the two are indistinguishable by age alone, so the
+        // conservative sweep must leave it alone either way.
+        const possiblyLiveLegacyRun = path.join(tempRoot, "openclaw-backup-1eGacy");
+        await writeAgedDirectory(possiblyLiveLegacyRun, 48 * HOUR_MS);
+
+        await withTempRootEnv(tempRoot, async () => {
+          await createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: ARCHIVE_NOW_MS,
+          });
+        });
+
+        expect(await pathExists(possiblyLiveLegacyRun)).toBe(true);
+      },
+    );
+  });
+
+  it("preserves an aged Fleet archive temp file beside the output", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-fleet-file-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+        // Fleet backup publishes through the same `<archive>.<uuid>.tmp`
+        // shape as the retired backup-create writer. Backup-create cannot
+        // prove ownership of this sibling artifact, even after it ages out.
+        const fleetTemp = path.join(outputDir, `fleet-backup.tar.gz.${randomUUID()}.tmp`);
+        await fs.writeFile(fleetTemp, "fleet payload\n");
+        const aged = new Date(Date.now() - 48 * HOUR_MS);
+        await fs.utimes(fleetTemp, aged, aged);
+
+        await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: false,
+          nowMs: ARCHIVE_NOW_MS,
+        });
+
+        expect(await pathExists(fleetTemp)).toBe(true);
+      },
+    );
+  });
+
+  it("keeps a legacy archive-temp file a live pre-durable-publish run is still writing", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-legacy-file-live-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+        const liveFile = path.join(
+          outputDir,
+          `2026-05-08T00-00-00.000-00-00-openclaw-backup.tar.gz.${randomUUID()}.tmp`,
+        );
+        // Unlike a staging directory, this file is the direct write target of
+        // `tar` in the retired scheme, so its own mtime already tracks an
+        // active writer with no extra fence needed.
+        await fs.writeFile(liveFile, "still streaming\n");
+
+        await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: false,
+          nowMs: ARCHIVE_NOW_MS,
+        });
+
+        expect(await pathExists(liveFile)).toBe(true);
+      },
+    );
+  });
+
+  it("keeps a staging directory whose archive is still being written", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-active-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        const tempRoot = state.path("tmproot");
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.mkdir(tempRoot, { recursive: true });
+        // A long tar write never touches the parent directory, so a live run
+        // can carry a stale directory mtime alongside a fresh archive file.
+        const activeRun = path.join(tempRoot, "openclaw-backup-c3d4e5");
+        await writeAgedOwnedDirectory(activeRun, 48 * HOUR_MS);
+        await fs.appendFile(path.join(activeRun, "archive.tar.gz.tmp"), "still streaming\n");
+
+        await withTempRootEnv(tempRoot, async () => {
+          await createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: ARCHIVE_NOW_MS,
+          });
+        });
+
+        expect(await pathExists(activeRun)).toBe(true);
+      },
+    );
+  });
+
+  it("keeps recent, sibling-owned, and non-mkdtemp directories", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-sweep-scope-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        const tempRoot = state.path("tmproot");
+        await fs.mkdir(outputDir, { recursive: true });
+        await fs.mkdir(tempRoot, { recursive: true });
+        // `openclaw-backup-` prefixes `openclaw-backup-verify-sqlite-`, so a
+        // prefix-only match would delete a concurrent `backup verify` run.
+        const concurrentVerify = path.join(tempRoot, "openclaw-backup-verify-sqlite-a1b2c3");
+        const concurrentCreate = path.join(tempRoot, "openclaw-backup-b2c3d4");
+        const unrelatedName = path.join(tempRoot, "openclaw-backup-user-notes");
+        const unrelatedDir = path.join(tempRoot, "unrelated-data");
+        const matchingFile = path.join(tempRoot, "openclaw-backup-file01");
+        await writeAgedOwnedDirectory(concurrentVerify, 48 * HOUR_MS);
+        await writeAgedOwnedDirectory(concurrentCreate, 0);
+        await writeAgedOwnedDirectory(unrelatedName, 48 * HOUR_MS);
+        await writeAgedOwnedDirectory(unrelatedDir, 48 * HOUR_MS);
+        await fs.writeFile(matchingFile, "unrelated file");
+
+        await withTempRootEnv(tempRoot, async () => {
+          await createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: ARCHIVE_NOW_MS,
+          });
+        });
+
+        expect(await pathExists(concurrentVerify)).toBe(true);
+        expect(await pathExists(concurrentCreate)).toBe(true);
+        expect(await pathExists(unrelatedName)).toBe(true);
+        expect(await pathExists(unrelatedDir)).toBe(true);
+        expect(await fs.readFile(matchingFile, "utf8")).toBe("unrelated file");
+      },
+    );
+  });
+});
+
+describe("live-owner fence", () => {
+  // `tar` only reads the staging directory, so a backup whose archive stream
+  // runs longer than the orphan window would age out while still live.
+  const STAGING_PATTERN = /^openclaw-backup-[A-Za-z0-9]{6}$/u;
+
+  // Both cases share one fixture and one elapsed window; only the live owner
+  // differs, so the assertion isolates the fence itself.
+  async function withStagingRootPastOrphanWindow(
+    run: (params: { root: string; staging: string }) => Promise<void>,
+  ): Promise<void> {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fence-")));
+    vi.useFakeTimers();
+    try {
+      const staging = path.join(root, "openclaw-backup-liv001");
+      await fs.mkdir(staging);
+      await fs.writeFile(path.join(staging, "manifest.json"), "{}\n");
+      await run({ root, staging });
+    } finally {
+      vi.useRealTimers();
+      await fs.rm(root, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+
+  it("keeps a staging directory alive across a full orphan window", async () => {
+    await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+      const stopKeepAlive = keepBackupTempDirectoryAlive(staging, await fs.lstat(staging));
+      try {
+        // Models an archive stream that outlives the window: `tar` only reads
+        // staging, so the heartbeat is the sole thing keeping it claimed
+        // while this run — and its sweep against it — is still live.
+        await vi.advanceTimersByTimeAsync(25 * HOUR_MS);
+
+        await sweepStaleBackupTempDirectories({
+          directoryPath: root,
+          entryPattern: STAGING_PATTERN,
+        });
+
+        expect(await pathExists(staging)).toBe(true);
+      } finally {
+        stopKeepAlive();
+      }
+    });
+  });
+
+  it("reclaims the same directory once its owner stops refreshing", async () => {
+    await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+      // The hard-kill case: ownership was established (the marker exists)
+      // but nothing refreshes it afterward. Written directly rather than via
+      // `keepBackupTempDirectoryAlive`, whose stop function always removes
+      // the marker as part of a clean finish — this models the marker
+      // outliving the process that wrote it, not a clean stop.
+      await fs.writeFile(path.join(staging, OWNER_MARKER_FILENAME), "", { mode: 0o600 });
+      await vi.advanceTimersByTimeAsync(25 * HOUR_MS);
+
+      await sweepStaleBackupTempDirectories({
+        directoryPath: root,
+        entryPattern: STAGING_PATTERN,
+      });
+
+      expect(await pathExists(staging)).toBe(false);
+    });
+  });
+
+  it("leaves the same directory alone when no run ever claimed it", async () => {
+    await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+      // Negative control for the marker itself: identical shape and age, but
+      // no run ever wrote the ownership marker — the pre-upgrade case, which
+      // must never be reclaimed no matter how idle it looks.
+      await vi.advanceTimersByTimeAsync(25 * HOUR_MS);
+
+      await sweepStaleBackupTempDirectories({
+        directoryPath: root,
+        entryPattern: STAGING_PATTERN,
+      });
+
+      expect(await pathExists(staging)).toBe(true);
+    });
+  });
+
+  it("creates a private marker and retires it without leaving a timer", async () => {
+    await withStagingRootPastOrphanWindow(async ({ staging }) => {
+      const marker = path.join(staging, OWNER_MARKER_FILENAME);
+      const stop = keepBackupTempDirectoryAlive(staging, await fs.lstat(staging));
+      try {
+        const identity = await fs.lstat(marker);
+        expect(identity.isFile()).toBe(true);
+        expect(identity.nlink).toBe(1);
+        if (process.platform !== "win32") {
+          expect(identity.mode & 0o777).toBe(0o600);
+        }
+        expect(stop()).toBe(true);
+        expect(stop()).toBe(true);
+        await expect(fs.lstat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        stop();
+      }
+    });
+  });
+
+  it.each(["before stop", "after stop"] as const)(
+    "preserves a marker replaced %s",
+    async (replacementTime) => {
+      await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+        const marker = path.join(staging, OWNER_MARKER_FILENAME);
+        const stop = keepBackupTempDirectoryAlive(staging, await fs.lstat(staging));
+        try {
+          if (replacementTime === "after stop") {
+            expect(stop()).toBe(true);
+          } else {
+            await fs.rename(marker, path.join(root, "original-owner"));
+          }
+          await fs.writeFile(marker, "replacement owner", { mode: 0o600 });
+          const beforeRefresh = await fs.lstat(staging);
+
+          await vi.advanceTimersByTimeAsync(HOUR_MS);
+
+          expect((await fs.lstat(staging)).mtimeMs).toBe(beforeRefresh.mtimeMs);
+          const retired = stop();
+          expect(await fs.readFile(marker, "utf8")).toBe("replacement owner");
+          expect(retired).toBe(false);
+          expect(vi.getTimerCount()).toBe(0);
+        } finally {
+          stop();
+        }
+      });
+    },
+  );
+
+  it("preserves a replacement directory during refresh and stop", async () => {
+    await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+      const stop = keepBackupTempDirectoryAlive(staging, await fs.lstat(staging));
+      try {
+        await fs.rename(staging, path.join(root, "original-staging"));
+        await writeAgedOwnedDirectory(staging, 48 * HOUR_MS);
+        const beforeRefresh = await fs.lstat(staging);
+
+        await vi.advanceTimersByTimeAsync(HOUR_MS);
+
+        expect((await fs.lstat(staging)).mtimeMs).toBe(beforeRefresh.mtimeMs);
+        expect(stop()).toBe(false);
+        expect(await fs.readFile(path.join(staging, "archive.tar.gz.tmp"), "utf8")).toBe(
+          "orphaned payload\n",
+        );
+        expect(await pathExists(path.join(staging, OWNER_MARKER_FILENAME))).toBe(true);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        stop();
+      }
+    });
+  });
+
+  it("rejects a changed directory before creating its ownership marker", async () => {
+    await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+      const identity = await fs.lstat(staging);
+      await fs.rename(staging, path.join(root, "original-staging"));
+      await fs.mkdir(staging);
+
+      expect(() => keepBackupTempDirectoryAlive(staging, identity)).toThrow();
+
+      expect(await fs.readdir(staging)).toEqual([]);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+
+  it.each(["file", "directory"] as const)(
+    "refuses an existing marker %s without starting a timer",
+    async (markerType) => {
+      await withStagingRootPastOrphanWindow(async ({ staging }) => {
+        const marker = path.join(staging, OWNER_MARKER_FILENAME);
+        const payload = markerType === "file" ? marker : path.join(marker, "foreign-data");
+        if (markerType === "directory") {
+          await fs.mkdir(marker);
+        }
+        await fs.writeFile(payload, "existing owner", { mode: 0o600 });
+        const identity = await fs.lstat(staging);
+
+        expect(() => keepBackupTempDirectoryAlive(staging, identity)).toThrow();
+
+        expect(await fs.readFile(payload, "utf8")).toBe("existing owner");
+        expect(vi.getTimerCount()).toBe(0);
+      });
+    },
+  );
+
+  it.each(["unchanged directory", "replaced marker", "replaced directory"] as const)(
+    "cleans only its own marker after close fails: %s",
+    async (ownerState) => {
+      await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+        const identity = await fs.lstat(staging);
+        const marker = path.join(staging, OWNER_MARKER_FILENAME);
+        const failure = Object.assign(new Error("Cannot close ownership marker"), { code: "EIO" });
+        const originalClose = fsSync.closeSync.bind(fsSync);
+        const closeSpy = vi.spyOn(fsSync, "closeSync").mockImplementationOnce((descriptor) => {
+          originalClose(descriptor);
+          if (ownerState === "replaced directory") {
+            fsSync.renameSync(staging, path.join(root, "original-staging"));
+            fsSync.mkdirSync(staging);
+          } else if (ownerState === "replaced marker") {
+            fsSync.renameSync(marker, path.join(root, "original-owner"));
+          }
+          if (ownerState !== "unchanged directory") {
+            fsSync.writeFileSync(marker, "replacement owner", { mode: 0o600 });
+          }
+          throw failure;
+        });
+        try {
+          expect(() => keepBackupTempDirectoryAlive(staging, identity)).toThrow(failure);
+        } finally {
+          closeSpy.mockRestore();
+        }
+
+        if (ownerState === "unchanged directory") {
+          await expect(fs.lstat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+          expect(await fs.readFile(path.join(staging, "manifest.json"), "utf8")).toBe("{}\n");
+        } else {
+          expect(await fs.readFile(marker, "utf8")).toBe("replacement owner");
+        }
+        expect(vi.getTimerCount()).toBe(0);
+      });
+    },
+  );
+
+  it.each(["directory replacement", "marker replacement", "refresh", "unreadable child"] as const)(
+    "preserves staging after %s during inspection",
+    async (change) => {
+      await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+        await fs.unlink(path.join(staging, "manifest.json"));
+        const stop =
+          change === "refresh"
+            ? keepBackupTempDirectoryAlive(staging, await fs.lstat(staging))
+            : undefined;
+        await writeAgedOwnedDirectory(staging, 48 * HOUR_MS);
+        const archive = path.join(staging, "archive.tar.gz.tmp");
+        const marker = path.join(staging, OWNER_MARKER_FILENAME);
+        const stamp = new Date(Date.now() - 48 * HOUR_MS);
+        const originalLstat = fsSync.lstatSync.bind(fsSync);
+        let changed = false;
+        const lstatSpy = vi.spyOn(fsSync, "lstatSync").mockImplementation((target, options) => {
+          const identity = originalLstat(target, options);
+          if (String(target) === archive && !changed) {
+            changed = true;
+            switch (change) {
+              case "directory replacement":
+                fsSync.renameSync(staging, path.join(root, "original-staging"));
+                fsSync.mkdirSync(staging);
+                fsSync.writeFileSync(archive, "orphaned payload\n");
+                fsSync.writeFileSync(marker, "replacement owner", { mode: 0o600 });
+                fsSync.utimesSync(archive, stamp, stamp);
+                fsSync.utimesSync(marker, stamp, stamp);
+                fsSync.utimesSync(staging, stamp, stamp);
+                break;
+              case "marker replacement":
+                fsSync.renameSync(marker, path.join(root, "original-owner"));
+                fsSync.writeFileSync(marker, "replacement owner", { mode: 0o600 });
+                fsSync.utimesSync(marker, stamp, stamp);
+                fsSync.utimesSync(staging, stamp, stamp);
+                break;
+              case "refresh":
+                vi.advanceTimersByTime(HOUR_MS);
+                break;
+              case "unreadable child":
+                throw Object.assign(new Error("Cannot inspect archive"), { code: "EIO" });
+            }
+          }
+          return identity;
+        });
+        try {
+          await sweepStaleBackupTempDirectories({
+            directoryPath: root,
+            entryPattern: STAGING_PATTERN,
+          });
+        } finally {
+          lstatSpy.mockRestore();
+          stop?.();
+        }
+
+        expect(changed).toBe(true);
+        expect(await fs.readFile(archive, "utf8")).toBe("orphaned payload\n");
+        if (change === "directory replacement" || change === "marker replacement") {
+          expect(await fs.readFile(marker, "utf8")).toBe("replacement owner");
+        }
+      });
+    },
+  );
+
+  it.each(["directory", "hardlink"] as const)(
+    "preserves an aged directory with a %s ownership marker",
+    async (markerType) => {
+      await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+        await writeAgedOwnedDirectory(staging, 48 * HOUR_MS);
+        const marker = path.join(staging, OWNER_MARKER_FILENAME);
+        const originalMarker = path.join(root, "original-owner");
+        await fs.rename(marker, originalMarker);
+        if (markerType === "directory") {
+          await fs.mkdir(marker);
+        } else {
+          await fs.link(originalMarker, marker);
+        }
+        const stamp = new Date(Date.now() - 48 * HOUR_MS);
+        await fs.utimes(marker, stamp, stamp);
+        await fs.utimes(staging, stamp, stamp);
+
+        await sweepStaleBackupTempDirectories({
+          directoryPath: root,
+          entryPattern: STAGING_PATTERN,
+        });
+
+        expect(await fs.readFile(path.join(staging, "archive.tar.gz.tmp"), "utf8")).toBe(
+          "orphaned payload\n",
+        );
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves an aged directory whose ownership marker is not private",
+    async () => {
+      await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+        await writeAgedOwnedDirectory(staging, 48 * HOUR_MS);
+        await fs.chmod(path.join(staging, OWNER_MARKER_FILENAME), 0o644);
+
+        await sweepStaleBackupTempDirectories({
+          directoryPath: root,
+          entryPattern: STAGING_PATTERN,
+        });
+
+        expect(await fs.readFile(path.join(staging, "archive.tar.gz.tmp"), "utf8")).toBe(
+          "orphaned payload\n",
+        );
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves symlinked staging, markers, and children without touching their targets",
+    async () => {
+      await withStagingRootPastOrphanWindow(async ({ root, staging }) => {
+        const foreign = path.join(root, "foreign-data");
+        await fs.writeFile(foreign, "foreign payload", { mode: 0o600 });
+        const stamp = new Date(Date.now() - 48 * HOUR_MS);
+        await fs.utimes(foreign, stamp, stamp);
+        const linkedMarker = path.join(root, "openclaw-backup-mark01");
+        const linkedChild = path.join(root, "openclaw-backup-link01");
+        const linkedDirectory = path.join(root, "openclaw-backup-link02");
+        for (const directory of [linkedMarker, linkedChild]) {
+          await writeAgedOwnedDirectory(directory, 48 * HOUR_MS);
+        }
+        await fs.unlink(path.join(linkedMarker, OWNER_MARKER_FILENAME));
+        await fs.symlink(foreign, path.join(linkedMarker, OWNER_MARKER_FILENAME));
+        await fs.symlink(foreign, path.join(linkedChild, "foreign-link"));
+        await fs.utimes(linkedMarker, stamp, stamp);
+        await fs.utimes(linkedChild, stamp, stamp);
+        await fs.symlink(linkedChild, linkedDirectory);
+        const stop = keepBackupTempDirectoryAlive(staging, await fs.lstat(staging));
+        try {
+          await fs.rename(staging, path.join(root, "original-staging"));
+          await fs.symlink(linkedChild, staging);
+          const beforeRefresh = await fs.lstat(linkedChild);
+
+          await vi.advanceTimersByTimeAsync(HOUR_MS);
+          expect(stop()).toBe(false);
+          await sweepStaleBackupTempDirectories({
+            directoryPath: root,
+            entryPattern: STAGING_PATTERN,
+          });
+
+          expect((await fs.lstat(linkedChild)).mtimeMs).toBe(beforeRefresh.mtimeMs);
+          expect((await fs.lstat(linkedDirectory)).isSymbolicLink()).toBe(true);
+          expect((await fs.lstat(staging)).isSymbolicLink()).toBe(true);
+          expect(
+            (await fs.lstat(path.join(linkedMarker, OWNER_MARKER_FILENAME))).isSymbolicLink(),
+          ).toBe(true);
+          expect(await fs.readFile(foreign, "utf8")).toBe("foreign payload");
+          expect(await pathExists(path.join(linkedChild, OWNER_MARKER_FILENAME))).toBe(true);
+        } finally {
+          stop();
+        }
+      });
+    },
+  );
+});

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -35,6 +35,7 @@ import {
   createBackupSqliteSnapshotPlan,
 } from "./backup-sqlite-snapshot.js";
 import { writeTarArchiveWithRetry } from "./backup-tar-retry.js";
+import { sweepStaleBackupTempDirectories } from "./backup-temp-sweep.js";
 import { isVolatileBackupPath } from "./backup-volatile-filter.js";
 import {
   createBackupLinkCache,
@@ -50,6 +51,11 @@ import {
 import { withLegacyAuditMigrationLease } from "./state-migrations.audit-coordination.js";
 
 const loadTarRuntime = createLazyRuntimeModule(() => import("tar"));
+
+// `fs.mkdtemp` appends exactly six alphanumeric characters. Matching that
+// shape rather than the bare prefix keeps the sweep from also claiming a
+// live `openclaw-backup-verify-sqlite-*` run, which shares the prefix.
+const STALE_BACKUP_STAGING_DIRECTORY_PATTERN = /^openclaw-backup-[A-Za-z0-9]{6}$/u;
 
 export type BackupCreateOptions = {
   output?: string;
@@ -412,11 +418,18 @@ export async function createBackupArchive(
   await prepareBackupOutputParent(outputPath);
   const tempRoot = await chooseBackupTempRoot({ assets: result.assets, outputPath });
   await fs.mkdir(tempRoot, { recursive: true });
+  // Staleness is wall-clock, not `opts.nowMs`: that timestamp names the
+  // archive and callers inject arbitrary values for it.
+  await sweepStaleBackupTempDirectories({
+    directoryPath: tempRoot,
+    entryPattern: STALE_BACKUP_STAGING_DIRECTORY_PATTERN,
+    log: opts.log,
+  });
   const tempDir = await fs.mkdtemp(path.join(tempRoot, "openclaw-backup-"));
   const manifestPath = path.join(tempDir, "manifest.json");
   let publication: BackupArchivePublication;
   try {
-    publication = await createBackupArchivePublication(outputPath);
+    publication = await createBackupArchivePublication(outputPath, opts.log);
   } catch (error) {
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
     throw formatBackupOutputFailure(error, outputPath, "publication");

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -35,7 +35,10 @@ import {
   createBackupSqliteSnapshotPlan,
 } from "./backup-sqlite-snapshot.js";
 import { writeTarArchiveWithRetry } from "./backup-tar-retry.js";
-import { sweepStaleBackupTempDirectories } from "./backup-temp-sweep.js";
+import {
+  keepBackupTempDirectoryAlive,
+  sweepStaleBackupTempDirectories,
+} from "./backup-temp-sweep.js";
 import { isVolatileBackupPath } from "./backup-volatile-filter.js";
 import {
   createBackupLinkCache,
@@ -426,14 +429,19 @@ export async function createBackupArchive(
     log: opts.log,
   });
   const tempDir = await fs.mkdtemp(path.join(tempRoot, "openclaw-backup-"));
+  // Claim both temp dirs for this run: `tar` only reads the staging directory,
+  // so a multi-hour archive would otherwise age it into another run's sweep.
+  const stopTempDirKeepAlive = keepBackupTempDirectoryAlive(tempDir);
   const manifestPath = path.join(tempDir, "manifest.json");
   let publication: BackupArchivePublication;
   try {
     publication = await createBackupArchivePublication(outputPath, opts.log);
   } catch (error) {
+    stopTempDirKeepAlive();
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
     throw formatBackupOutputFailure(error, outputPath, "publication");
   }
+  const stopPublishDirKeepAlive = keepBackupTempDirectoryAlive(publication.stagingDir);
   const tempArchivePath = publication.tempArchivePath;
   try {
     // Capture every legacy file first, including active and claimed sources.
@@ -655,6 +663,8 @@ export async function createBackupArchive(
       throw formatBackupOutputFailure(error, outputPath, "publication");
     }
   } finally {
+    stopPublishDirKeepAlive();
+    stopTempDirKeepAlive();
     await cleanupBackupArchivePublication(publication, opts.log);
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
   }

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -1,5 +1,5 @@
 // Creates backup archives while filtering volatile runtime state.
-import { realpathSync } from "node:fs";
+import { lstatSync, realpathSync, rmSync, rmdirSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -40,10 +40,15 @@ import {
 } from "./backup-sqlite-snapshot.js";
 import { writeTarArchiveWithRetry } from "./backup-tar-retry.js";
 import {
+  keepBackupTempDirectoryAlive,
+  sweepStaleBackupTempDirectories,
+} from "./backup-temp-sweep.js";
+import {
   createBackupLinkCache,
   createBackupVolatileStatCache,
 } from "./backup-volatile-stat-cache.js";
 import { isErrno } from "./errors.js";
+import { sameFileIdentity } from "./fs-safe-advanced.js";
 import { writeJson } from "./json-files.js";
 import {
   createLegacyAuditBackupCapture,
@@ -56,6 +61,11 @@ import {
 import { withLegacyAuditMigrationLease } from "./state-migrations.audit-coordination.js";
 
 const loadTarRuntime = createLazyRuntimeModule(() => import("tar"));
+
+// `fs.mkdtemp` appends exactly six alphanumeric characters. Matching that
+// shape rather than the bare prefix keeps the sweep from also claiming a
+// live `openclaw-backup-verify-sqlite-*` run, which shares the prefix.
+const STALE_BACKUP_STAGING_DIRECTORY_PATTERN = /^openclaw-backup-[A-Za-z0-9]{6}$/u;
 
 export type BackupCreateOptions = {
   output?: string;
@@ -520,16 +530,50 @@ export async function createBackupArchive(
   await prepareBackupOutputParent(outputPath);
   const tempRoot = await chooseBackupTempRoot({ assets: result.assets, outputPath });
   await fs.mkdir(tempRoot, { recursive: true });
+  // Staleness is wall-clock, not `opts.nowMs`: that timestamp names the
+  // archive and callers inject arbitrary values for it.
+  await sweepStaleBackupTempDirectories({
+    directoryPath: tempRoot,
+    entryPattern: STALE_BACKUP_STAGING_DIRECTORY_PATTERN,
+    log: opts.log,
+  });
   const tempDir = await fs.mkdtemp(path.join(tempRoot, "openclaw-backup-"));
+  const tempIdentity = await fs.lstat(tempDir);
+  let stopTempDirKeepAlive: () => boolean;
+  try {
+    stopTempDirKeepAlive = keepBackupTempDirectoryAlive(tempDir, tempIdentity);
+  } catch (error) {
+    try {
+      const current = lstatSync(tempDir);
+      if (current.isDirectory() && sameFileIdentity(tempIdentity, current)) {
+        rmdirSync(tempDir);
+      }
+    } catch {
+      // Preserve any changed or non-empty directory after failed ownership setup.
+    }
+    throw error;
+  }
+  const cleanupTempDir = (): void => {
+    if (!stopTempDirKeepAlive()) {
+      return;
+    }
+    try {
+      const current = lstatSync(tempDir);
+      if (current.isDirectory() && sameFileIdentity(tempIdentity, current)) {
+        rmSync(tempDir, { recursive: true });
+      }
+    } catch {
+      // Preserve staging when its identity cannot be verified or removal fails.
+    }
+  };
   const manifestPath = path.join(tempDir, "manifest.json");
   let publication: BackupArchivePublication;
   try {
-    publication = await createBackupArchivePublication(outputPath);
+    publication = await createBackupArchivePublication(outputPath, opts.log);
   } catch (error) {
-    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+    cleanupTempDir();
     throw formatBackupOutputFailure(error, outputPath, "publication");
   }
-  const tempArchivePath = publication.tempArchivePath;
   try {
     const { legacyAuditSnapshots, stateSqliteBackup } = await createConsistentStateSnapshotPlan({
       inventory: plan.inventory,
@@ -616,7 +660,7 @@ export async function createBackupArchive(
       return true;
     };
     const completedArchive = await writeTarArchiveWithRetry({
-      tempArchivePath,
+      tempArchivePath: publication.tempArchivePath,
       log: opts.log,
       runTar: async (attemptTempArchivePath) => {
         // tar.c re-walks the tree (and thus re-invokes tarFilter) on every
@@ -738,8 +782,11 @@ export async function createBackupArchive(
       throw formatBackupOutputFailure(error, outputPath, "publication");
     }
   } finally {
-    await cleanupBackupArchivePublication(publication, opts.log);
-    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+    try {
+      await cleanupBackupArchivePublication(publication, opts.log);
+    } finally {
+      cleanupTempDir();
+    }
   }
 
   return result;

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -41,6 +41,7 @@ import {
 import { writeTarArchiveWithRetry } from "./backup-tar-retry.js";
 import {
   keepBackupTempDirectoryAlive,
+  sameBackupTempIdentity,
   sweepStaleBackupTempDirectories,
 } from "./backup-temp-sweep.js";
 import {
@@ -48,7 +49,6 @@ import {
   createBackupVolatileStatCache,
 } from "./backup-volatile-stat-cache.js";
 import { isErrno } from "./errors.js";
-import { sameFileIdentity } from "./fs-safe-advanced.js";
 import { writeJson } from "./json-files.js";
 import {
   createLegacyAuditBackupCapture,
@@ -545,7 +545,7 @@ export async function createBackupArchive(
   } catch (error) {
     try {
       const current = lstatSync(tempDir);
-      if (current.isDirectory() && sameFileIdentity(tempIdentity, current)) {
+      if (current.isDirectory() && sameBackupTempIdentity(tempIdentity, current)) {
         rmdirSync(tempDir);
       }
     } catch {
@@ -559,7 +559,7 @@ export async function createBackupArchive(
     }
     try {
       const current = lstatSync(tempDir);
-      if (current.isDirectory() && sameFileIdentity(tempIdentity, current)) {
+      if (current.isDirectory() && sameBackupTempIdentity(tempIdentity, current)) {
         rmSync(tempDir, { recursive: true });
       }
     } catch {

--- a/src/infra/backup-temp-sweep.ts
+++ b/src/infra/backup-temp-sweep.ts
@@ -11,7 +11,7 @@ import path from "node:path";
 const BACKUP_TEMP_ORPHAN_MIN_AGE_MS = 24 * 60 * 60_000;
 
 // Derived so the heartbeat can never drift past the window it defends.
-export const BACKUP_TEMP_KEEPALIVE_INTERVAL_MS = BACKUP_TEMP_ORPHAN_MIN_AGE_MS / 48;
+const BACKUP_TEMP_KEEPALIVE_INTERVAL_MS = BACKUP_TEMP_ORPHAN_MIN_AGE_MS / 48;
 
 /**
  * Marks `directoryPath` as owned by the running backup until the returned stop

--- a/src/infra/backup-temp-sweep.ts
+++ b/src/infra/backup-temp-sweep.ts
@@ -1,5 +1,4 @@
-// Reclaims backup temp directories and legacy temp files that a hard-killed
-// run left behind.
+// Reclaims backup temp directories that a hard-killed run left behind.
 import { unlinkSync, utimesSync, writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -134,51 +133,6 @@ export async function sweepStaleBackupTempDirectories(params: {
     );
     if (removed) {
       params.log?.(`Backup removed stale temp directory ${entryPath}.`);
-    }
-  }
-}
-
-/**
- * Removes files in `directoryPath` whose name matches `entryPattern` and that
- * have been idle past the orphan window. Unlike the mkdtemp staging
- * directories above, this targets the pre-durable-publish `<output>.<uuid>.tmp`
- * archive shape that predates #113302: no shipped or current code still
- * writes that shape into a bare file, so a match here is always a leftover,
- * never a directory a concurrent run could still own — no ownership marker
- * is needed. A live writer, old or current, streams the archive bytes
- * straight into this same file for the run's whole duration, so its own
- * mtime already tracks that activity the way a directory's cannot.
- */
-export async function sweepStaleBackupTempArchiveFiles(params: {
-  directoryPath: string;
-  entryPattern: RegExp;
-  log?: (message: string) => void;
-}): Promise<void> {
-  const nowMs = Date.now();
-  const entries = await fs
-    .readdir(params.directoryPath, { withFileTypes: true })
-    .catch(() => undefined);
-  if (!entries) {
-    return;
-  }
-
-  for (const entry of entries) {
-    // Dirent.isFile() is false for symlinks, so a symlinked name that
-    // matches the pattern is skipped instead of followed.
-    if (!entry.isFile() || !params.entryPattern.test(entry.name)) {
-      continue;
-    }
-    const entryPath = path.join(params.directoryPath, entry.name);
-    const entryStat = await fs.stat(entryPath).catch(() => undefined);
-    if (!entryStat || nowMs - entryStat.mtimeMs < BACKUP_TEMP_ORPHAN_MIN_AGE_MS) {
-      continue;
-    }
-    const removed = await fs.rm(entryPath, { force: true }).then(
-      () => true,
-      () => false,
-    );
-    if (removed) {
-      params.log?.(`Backup removed stale temp archive file ${entryPath}.`);
     }
   }
 }

--- a/src/infra/backup-temp-sweep.ts
+++ b/src/infra/backup-temp-sweep.ts
@@ -1,0 +1,74 @@
+// Reclaims backup temp directories that a hard-killed run left behind.
+import fs from "node:fs/promises";
+import path from "node:path";
+
+// Backup stages into temp directories that are removed by an in-process
+// `finally`. SIGKILL, OOM, or a host reboot skips that block, and nothing
+// else reaps the leftovers, so each interrupted run permanently leaks a
+// full-size archive copy. Every owner sweeps its own artifacts before
+// staging a new run.
+const BACKUP_TEMP_ORPHAN_MIN_AGE_MS = 24 * 60 * 60_000;
+
+// A long tar write only touches the archive file, never its parent
+// directory, so directory mtime alone would age out a live run and delete
+// its staging directory mid-backup.
+async function resolveNewestActivityMs(directoryPath: string): Promise<number | undefined> {
+  const directoryStat = await fs.stat(directoryPath).catch(() => undefined);
+  if (!directoryStat) {
+    return undefined;
+  }
+  const childNames = await fs.readdir(directoryPath).catch(() => []);
+  let newestMs = directoryStat.mtimeMs;
+  for (const childName of childNames) {
+    const childStat = await fs.stat(path.join(directoryPath, childName)).catch(() => undefined);
+    if (childStat && childStat.mtimeMs > newestMs) {
+      newestMs = childStat.mtimeMs;
+    }
+  }
+  return newestMs;
+}
+
+/**
+ * Removes directories in `directoryPath` whose name matches `entryPattern`
+ * and that have been idle past the orphan window. That window is the only
+ * fence against deleting a concurrent run's staging directory, so callers
+ * must pass a pattern matching their own `mkdtemp` output exactly rather
+ * than a bare prefix. Never throws: a failed sweep must not take down the
+ * backup it was preparing for.
+ */
+export async function sweepStaleBackupTempDirectories(params: {
+  directoryPath: string;
+  entryPattern: RegExp;
+  log?: (message: string) => void;
+}): Promise<void> {
+  const nowMs = Date.now();
+  const entries = await fs
+    .readdir(params.directoryPath, { withFileTypes: true })
+    .catch(() => undefined);
+  if (!entries) {
+    return;
+  }
+
+  for (const entry of entries) {
+    // Dirent.isDirectory() is false for symlinks, so a symlinked name that
+    // matches the pattern is skipped instead of followed.
+    if (!entry.isDirectory() || !params.entryPattern.test(entry.name)) {
+      continue;
+    }
+    const entryPath = path.join(params.directoryPath, entry.name);
+    const newestActivityMs = await resolveNewestActivityMs(entryPath);
+    if (
+      newestActivityMs === undefined ||
+      nowMs - newestActivityMs < BACKUP_TEMP_ORPHAN_MIN_AGE_MS
+    ) {
+      continue;
+    }
+    const removed = await fs.rm(entryPath, { recursive: true, force: true }).then(
+      () => true,
+      () => false,
+    );
+    if (removed) {
+      params.log?.(`Backup removed stale temp directory ${entryPath}.`);
+    }
+  }
+}

--- a/src/infra/backup-temp-sweep.ts
+++ b/src/infra/backup-temp-sweep.ts
@@ -1,5 +1,6 @@
-// Reclaims backup temp directories that a hard-killed run left behind.
-import { utimesSync } from "node:fs";
+// Reclaims backup temp directories and legacy temp files that a hard-killed
+// run left behind.
+import { unlinkSync, utimesSync, writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -13,6 +14,17 @@ const BACKUP_TEMP_ORPHAN_MIN_AGE_MS = 24 * 60 * 60_000;
 // Derived so the heartbeat can never drift past the window it defends.
 const BACKUP_TEMP_KEEPALIVE_INTERVAL_MS = BACKUP_TEMP_ORPHAN_MIN_AGE_MS / 48;
 
+// A directory made by this (or a later) heartbeat-aware build carries this
+// marker. A directory from a pre-upgrade build shares the exact same
+// `mkdtemp` name shape but never writes it, because that build predates this
+// file. Idle time alone cannot tell a genuinely abandoned new-format
+// directory apart from a live pre-upgrade one still being written by `tar` —
+// both look identical after the orphan window elapses. Requiring the marker
+// makes the sweep opt in to only the format that can prove liveness at all;
+// an unmarked directory is left alone regardless of age rather than guessed
+// at, so an in-progress legacy backup can never be deleted out from under it.
+const OWNER_MARKER_FILENAME = ".openclaw-backup-owner";
+
 /**
  * Marks `directoryPath` as owned by the running backup until the returned stop
  * function is called. Idle time is the only signal the sweep has, and a long
@@ -21,6 +33,13 @@ const BACKUP_TEMP_KEEPALIVE_INTERVAL_MS = BACKUP_TEMP_ORPHAN_MIN_AGE_MS / 48;
  * A hard-killed run stops refreshing, which is exactly what makes it reclaimable.
  */
 export function keepBackupTempDirectoryAlive(directoryPath: string): () => void {
+  const markerPath = path.join(directoryPath, OWNER_MARKER_FILENAME);
+  // Written once, synchronously, immediately after this directory is created:
+  // the marker's mere presence — not its timestamp — is what proves
+  // ownership by heartbeat-aware code. See `OWNER_MARKER_FILENAME` above.
+  try {
+    writeFileSync(markerPath, "");
+  } catch {}
   const timer = setInterval(() => {
     // Sync: a floating promise in a timer can outlive the directory and reject
     // after cleanup. One utimes syscall is cheaper than that failure mode.
@@ -30,7 +49,18 @@ export function keepBackupTempDirectoryAlive(directoryPath: string): () => void 
     } catch {}
   }, BACKUP_TEMP_KEEPALIVE_INTERVAL_MS);
   timer.unref?.();
-  return () => clearInterval(timer);
+  return () => {
+    clearInterval(timer);
+    // A normal finish (success or a handled error) must leave the directory
+    // exactly as empty as it was before this call: cleanup only removes an
+    // empty directory outright (`removeStagingDirectoryIfOwned`), and a
+    // leftover marker would silently downgrade that to "preserved changed
+    // directory" on every run. Only a hard kill skips this, which is exactly
+    // when the marker must survive to prove ownership to the next sweep.
+    try {
+      unlinkSync(markerPath);
+    } catch {}
+  };
 }
 
 // A long tar write only touches the archive file, never its parent
@@ -53,13 +83,16 @@ async function resolveNewestActivityMs(directoryPath: string): Promise<number | 
 }
 
 /**
- * Removes directories in `directoryPath` whose name matches `entryPattern`
- * and that have been idle past the orphan window. Live runs stay out of reach
- * by refreshing their own directories via `keepBackupTempDirectoryAlive`, so
- * idle time means abandoned rather than merely slow. Callers must still pass a
- * pattern matching their own `mkdtemp` output exactly rather than a bare
- * prefix. Never throws: a failed sweep must not take down the backup it was
- * preparing for.
+ * Removes directories in `directoryPath` whose name matches `entryPattern`,
+ * that carry the `OWNER_MARKER_FILENAME` ownership marker, and that have been
+ * idle past the orphan window. Live runs stay out of reach by refreshing
+ * their own directories via `keepBackupTempDirectoryAlive`, so idle time
+ * means abandoned rather than merely slow — but only for directories that
+ * marker proves belong to heartbeat-aware code in the first place; see
+ * `OWNER_MARKER_FILENAME` for why an unmarked directory is skipped outright.
+ * Callers must still pass a pattern matching their own `mkdtemp` output
+ * exactly rather than a bare prefix. Never throws: a failed sweep must not
+ * take down the backup it was preparing for.
  */
 export async function sweepStaleBackupTempDirectories(params: {
   directoryPath: string;
@@ -81,6 +114,13 @@ export async function sweepStaleBackupTempDirectories(params: {
       continue;
     }
     const entryPath = path.join(params.directoryPath, entry.name);
+    const hasOwnerMarker = await fs.access(path.join(entryPath, OWNER_MARKER_FILENAME)).then(
+      () => true,
+      () => false,
+    );
+    if (!hasOwnerMarker) {
+      continue;
+    }
     const newestActivityMs = await resolveNewestActivityMs(entryPath);
     if (
       newestActivityMs === undefined ||
@@ -94,6 +134,51 @@ export async function sweepStaleBackupTempDirectories(params: {
     );
     if (removed) {
       params.log?.(`Backup removed stale temp directory ${entryPath}.`);
+    }
+  }
+}
+
+/**
+ * Removes files in `directoryPath` whose name matches `entryPattern` and that
+ * have been idle past the orphan window. Unlike the mkdtemp staging
+ * directories above, this targets the pre-durable-publish `<output>.<uuid>.tmp`
+ * archive shape that predates #113302: no shipped or current code still
+ * writes that shape into a bare file, so a match here is always a leftover,
+ * never a directory a concurrent run could still own — no ownership marker
+ * is needed. A live writer, old or current, streams the archive bytes
+ * straight into this same file for the run's whole duration, so its own
+ * mtime already tracks that activity the way a directory's cannot.
+ */
+export async function sweepStaleBackupTempArchiveFiles(params: {
+  directoryPath: string;
+  entryPattern: RegExp;
+  log?: (message: string) => void;
+}): Promise<void> {
+  const nowMs = Date.now();
+  const entries = await fs
+    .readdir(params.directoryPath, { withFileTypes: true })
+    .catch(() => undefined);
+  if (!entries) {
+    return;
+  }
+
+  for (const entry of entries) {
+    // Dirent.isFile() is false for symlinks, so a symlinked name that
+    // matches the pattern is skipped instead of followed.
+    if (!entry.isFile() || !params.entryPattern.test(entry.name)) {
+      continue;
+    }
+    const entryPath = path.join(params.directoryPath, entry.name);
+    const entryStat = await fs.stat(entryPath).catch(() => undefined);
+    if (!entryStat || nowMs - entryStat.mtimeMs < BACKUP_TEMP_ORPHAN_MIN_AGE_MS) {
+      continue;
+    }
+    const removed = await fs.rm(entryPath, { force: true }).then(
+      () => true,
+      () => false,
+    );
+    if (removed) {
+      params.log?.(`Backup removed stale temp archive file ${entryPath}.`);
     }
   }
 }

--- a/src/infra/backup-temp-sweep.ts
+++ b/src/infra/backup-temp-sweep.ts
@@ -1,4 +1,5 @@
 // Reclaims backup temp directories that a hard-killed run left behind.
+import { utimesSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -8,6 +9,29 @@ import path from "node:path";
 // full-size archive copy. Every owner sweeps its own artifacts before
 // staging a new run.
 const BACKUP_TEMP_ORPHAN_MIN_AGE_MS = 24 * 60 * 60_000;
+
+// Derived so the heartbeat can never drift past the window it defends.
+export const BACKUP_TEMP_KEEPALIVE_INTERVAL_MS = BACKUP_TEMP_ORPHAN_MIN_AGE_MS / 48;
+
+/**
+ * Marks `directoryPath` as owned by the running backup until the returned stop
+ * function is called. Idle time is the only signal the sweep has, and a long
+ * `tar` pass only reads the staging directory, so without this a multi-hour run
+ * ages past the orphan window and a second backup deletes its live source.
+ * A hard-killed run stops refreshing, which is exactly what makes it reclaimable.
+ */
+export function keepBackupTempDirectoryAlive(directoryPath: string): () => void {
+  const timer = setInterval(() => {
+    // Sync: a floating promise in a timer can outlive the directory and reject
+    // after cleanup. One utimes syscall is cheaper than that failure mode.
+    try {
+      const now = new Date();
+      utimesSync(directoryPath, now, now);
+    } catch {}
+  }, BACKUP_TEMP_KEEPALIVE_INTERVAL_MS);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
 
 // A long tar write only touches the archive file, never its parent
 // directory, so directory mtime alone would age out a live run and delete
@@ -30,11 +54,12 @@ async function resolveNewestActivityMs(directoryPath: string): Promise<number | 
 
 /**
  * Removes directories in `directoryPath` whose name matches `entryPattern`
- * and that have been idle past the orphan window. That window is the only
- * fence against deleting a concurrent run's staging directory, so callers
- * must pass a pattern matching their own `mkdtemp` output exactly rather
- * than a bare prefix. Never throws: a failed sweep must not take down the
- * backup it was preparing for.
+ * and that have been idle past the orphan window. Live runs stay out of reach
+ * by refreshing their own directories via `keepBackupTempDirectoryAlive`, so
+ * idle time means abandoned rather than merely slow. Callers must still pass a
+ * pattern matching their own `mkdtemp` output exactly rather than a bare
+ * prefix. Never throws: a failed sweep must not take down the backup it was
+ * preparing for.
  */
 export async function sweepStaleBackupTempDirectories(params: {
   directoryPath: string;

--- a/src/infra/backup-temp-sweep.ts
+++ b/src/infra/backup-temp-sweep.ts
@@ -1,0 +1,173 @@
+// Reclaims only marked backup staging whose owner stopped refreshing it.
+import fsSync, { type Stats } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { sameFileIdentity } from "./fs-safe-advanced.js";
+
+const BACKUP_TEMP_ORPHAN_MIN_AGE_MS = 24 * 60 * 60_000;
+const BACKUP_TEMP_KEEPALIVE_INTERVAL_MS = BACKUP_TEMP_ORPHAN_MIN_AGE_MS / 48;
+// Unmarked directories may belong to a live pre-upgrade backup.
+const OWNER_MARKER_FILENAME = ".openclaw-backup-owner";
+
+function readIdentity(filePath: string): Stats | undefined {
+  try {
+    return fsSync.lstatSync(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+function isOwnedDirectory(directoryPath: string, identity: Stats): boolean {
+  const current = readIdentity(directoryPath);
+  return Boolean(current?.isDirectory() && sameFileIdentity(identity, current));
+}
+
+function isPrivateMarker(identity: Stats): boolean {
+  return (
+    identity.isFile() &&
+    identity.nlink === 1 &&
+    (process.platform === "win32" || (identity.mode & 0o077) === 0)
+  );
+}
+
+export function keepBackupTempDirectoryAlive(
+  directoryPath: string,
+  expectedIdentity: Stats,
+): () => boolean {
+  if (!isOwnedDirectory(directoryPath, expectedIdentity)) {
+    throw new Error(`Backup staging directory changed before ownership: ${directoryPath}`);
+  }
+  const markerPath = path.join(directoryPath, OWNER_MARKER_FILENAME);
+  const descriptor = fsSync.openSync(markerPath, "wx", 0o600);
+  let markerIdentity: Stats;
+  try {
+    markerIdentity = fsSync.fstatSync(descriptor);
+  } catch (error) {
+    try {
+      fsSync.closeSync(descriptor);
+    } catch {
+      // Preserve the original identity-read failure.
+    }
+    throw error;
+  }
+  try {
+    fsSync.closeSync(descriptor);
+  } catch (error) {
+    if (isOwnedDirectory(directoryPath, expectedIdentity)) {
+      const marker = readIdentity(markerPath);
+      if (marker?.isFile() && sameFileIdentity(markerIdentity, marker)) {
+        try {
+          fsSync.unlinkSync(markerPath);
+        } catch {
+          // Preserve the setup failure when marker cleanup also fails.
+        }
+      }
+    }
+    throw error;
+  }
+  const ownsMarker = (): boolean => {
+    if (!isOwnedDirectory(directoryPath, expectedIdentity)) {
+      return false;
+    }
+    const marker = readIdentity(markerPath);
+    return Boolean(marker && isPrivateMarker(marker) && sameFileIdentity(markerIdentity, marker));
+  };
+  const timer = setInterval(() => {
+    // Keep checks and update together: a queued refresh must not touch a replacement.
+    if (ownsMarker()) {
+      try {
+        const now = new Date();
+        fsSync.utimesSync(directoryPath, now, now);
+      } catch {
+        // A failed refresh supplies no evidence of activity to the next sweep.
+      }
+    }
+  }, BACKUP_TEMP_KEEPALIVE_INTERVAL_MS);
+  timer.unref();
+  let markerRemoved = false;
+  return () => {
+    clearInterval(timer);
+    if (!isOwnedDirectory(directoryPath, expectedIdentity)) {
+      return false;
+    }
+    if (markerRemoved) {
+      try {
+        return fsSync.lstatSync(markerPath, { throwIfNoEntry: false }) === undefined;
+      } catch {
+        return false;
+      }
+    }
+    if (!ownsMarker()) {
+      return false;
+    }
+    try {
+      fsSync.unlinkSync(markerPath);
+      markerRemoved = true;
+      return true;
+    } catch {
+      return false;
+    }
+  };
+}
+
+function removeStaleDirectory(directoryPath: string, nowMs: number): boolean {
+  try {
+    const directory = fsSync.lstatSync(directoryPath);
+    if (!directory.isDirectory()) {
+      return false;
+    }
+    const markerPath = path.join(directoryPath, OWNER_MARKER_FILENAME);
+    const marker = fsSync.lstatSync(markerPath);
+    if (!isPrivateMarker(marker)) {
+      return false;
+    }
+    let newestMs = Math.max(directory.mtimeMs, marker.mtimeMs);
+    for (const name of fsSync.readdirSync(directoryPath)) {
+      const child = fsSync.lstatSync(path.join(directoryPath, name));
+      if (child.isSymbolicLink()) {
+        return false;
+      }
+      newestMs = Math.max(newestMs, child.mtimeMs);
+    }
+    const currentDirectory = fsSync.lstatSync(directoryPath);
+    const currentMarker = fsSync.lstatSync(markerPath);
+    if (
+      !currentDirectory.isDirectory() ||
+      !sameFileIdentity(directory, currentDirectory) ||
+      !isPrivateMarker(currentMarker) ||
+      !sameFileIdentity(marker, currentMarker) ||
+      nowMs - Math.max(newestMs, currentDirectory.mtimeMs, currentMarker.mtimeMs) <
+        BACKUP_TEMP_ORPHAN_MIN_AGE_MS
+    ) {
+      return false;
+    }
+    // No awaited work separates inspection from removal. This is a cooperative
+    // same-user fence, not isolation from hostile concurrent filesystem mutation.
+    fsSync.rmSync(directoryPath, { recursive: true });
+    return true;
+  } catch {
+    // Missing, changed or unreadable staging is not proved abandoned.
+    return false;
+  }
+}
+
+export async function sweepStaleBackupTempDirectories(params: {
+  directoryPath: string;
+  entryPattern: RegExp;
+  log?: (message: string) => void;
+}): Promise<void> {
+  const entries = await fs.readdir(params.directoryPath).catch(() => undefined);
+  if (!entries) {
+    return;
+  }
+  const nowMs = Date.now();
+  for (const name of entries) {
+    if (!params.entryPattern.test(name)) {
+      continue;
+    }
+    const entryPath = path.join(params.directoryPath, name);
+    if (removeStaleDirectory(entryPath, nowMs)) {
+      params.log?.(`Backup removed stale temp directory ${entryPath}.`);
+    }
+  }
+}

--- a/src/infra/backup-temp-sweep.ts
+++ b/src/infra/backup-temp-sweep.ts
@@ -9,6 +9,17 @@ const BACKUP_TEMP_KEEPALIVE_INTERVAL_MS = BACKUP_TEMP_ORPHAN_MIN_AGE_MS / 48;
 // Unmarked directories may belong to a live pre-upgrade backup.
 const OWNER_MARKER_FILENAME = ".openclaw-backup-owner";
 
+function hasBackupTempIdentity(identity: Stats): boolean {
+  return process.platform !== "win32" || (identity.dev !== 0 && identity.ino !== 0);
+}
+
+export function sameBackupTempIdentity(left: Stats, right: Stats): boolean {
+  // The general read comparator tolerates unknown Windows IDs; mutation cannot.
+  return (
+    hasBackupTempIdentity(left) && hasBackupTempIdentity(right) && sameFileIdentity(left, right)
+  );
+}
+
 function readIdentity(filePath: string): Stats | undefined {
   try {
     return fsSync.lstatSync(filePath);
@@ -19,7 +30,7 @@ function readIdentity(filePath: string): Stats | undefined {
 
 function isOwnedDirectory(directoryPath: string, identity: Stats): boolean {
   const current = readIdentity(directoryPath);
-  return Boolean(current?.isDirectory() && sameFileIdentity(identity, current));
+  return Boolean(current?.isDirectory() && sameBackupTempIdentity(identity, current));
 }
 
 function isPrivateMarker(identity: Stats): boolean {
@@ -55,7 +66,7 @@ export function keepBackupTempDirectoryAlive(
   } catch (error) {
     if (isOwnedDirectory(directoryPath, expectedIdentity)) {
       const marker = readIdentity(markerPath);
-      if (marker?.isFile() && sameFileIdentity(markerIdentity, marker)) {
+      if (marker?.isFile() && sameBackupTempIdentity(markerIdentity, marker)) {
         try {
           fsSync.unlinkSync(markerPath);
         } catch {
@@ -65,12 +76,17 @@ export function keepBackupTempDirectoryAlive(
     }
     throw error;
   }
+  if (!hasBackupTempIdentity(markerIdentity)) {
+    throw new Error(`Backup staging marker identity is unavailable: ${markerPath}`);
+  }
   const ownsMarker = (): boolean => {
     if (!isOwnedDirectory(directoryPath, expectedIdentity)) {
       return false;
     }
     const marker = readIdentity(markerPath);
-    return Boolean(marker && isPrivateMarker(marker) && sameFileIdentity(markerIdentity, marker));
+    return Boolean(
+      marker && isPrivateMarker(marker) && sameBackupTempIdentity(markerIdentity, marker),
+    );
   };
   const timer = setInterval(() => {
     // Keep checks and update together: a queued refresh must not touch a replacement.
@@ -133,9 +149,9 @@ function removeStaleDirectory(directoryPath: string, nowMs: number): boolean {
     const currentMarker = fsSync.lstatSync(markerPath);
     if (
       !currentDirectory.isDirectory() ||
-      !sameFileIdentity(directory, currentDirectory) ||
+      !sameBackupTempIdentity(directory, currentDirectory) ||
       !isPrivateMarker(currentMarker) ||
-      !sameFileIdentity(marker, currentMarker) ||
+      !sameBackupTempIdentity(marker, currentMarker) ||
       nowMs - Math.max(newestMs, currentDirectory.mtimeMs, currentMarker.mtimeMs) <
         BACKUP_TEMP_ORPHAN_MIN_AGE_MS
     ) {

--- a/src/infra/backup-temp-sweep.windows.test.ts
+++ b/src/infra/backup-temp-sweep.windows.test.ts
@@ -1,0 +1,287 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { removePreparedBackupArchive } from "./backup-create-stream.js";
+import {
+  keepBackupTempDirectoryAlive,
+  sweepStaleBackupTempDirectories,
+} from "./backup-temp-sweep.js";
+
+const HOUR_MS = 60 * 60_000;
+const OWNER_MARKER = ".openclaw-backup-owner";
+const STAGING_PATTERN = /^openclaw-backup-[A-Za-z0-9]{6}$/u;
+
+async function withWindowsMetadata(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-win-identity-"));
+  const platform = Object.getOwnPropertyDescriptor(process, "platform");
+  if (!platform) {
+    throw new Error("Missing process.platform descriptor");
+  }
+  vi.useFakeTimers();
+  Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+  try {
+    await run(root);
+  } finally {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    Object.defineProperty(process, "platform", platform);
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+function createStaging(root: string): { staging: string; marker: string; archive: string } {
+  const staging = path.join(root, "openclaw-backup-win001");
+  fsSync.mkdirSync(staging);
+  return {
+    staging,
+    marker: path.join(staging, OWNER_MARKER),
+    archive: path.join(staging, "archive.tar.gz.tmp"),
+  };
+}
+
+function ageStaging(staging: string): void {
+  const stamp = new Date(Date.now() - 48 * HOUR_MS);
+  for (const name of fsSync.readdirSync(staging)) {
+    fsSync.utimesSync(path.join(staging, name), stamp, stamp);
+  }
+  fsSync.utimesSync(staging, stamp, stamp);
+}
+
+describe("backup staging with simulated Windows identity metadata", () => {
+  it.each([
+    { observation: "initial", field: "dev" },
+    { observation: "initial", field: "ino" },
+    { observation: "current", field: "dev" },
+    { observation: "current", field: "ino" },
+  ] as const)(
+    "rejects a directory with unknown $observation $field before claiming it",
+    async ({ observation, field }) => {
+      await withWindowsMetadata(async (root) => {
+        const { staging, marker } = createStaging(root);
+        const identity = fsSync.lstatSync(staging);
+        if (observation === "initial") {
+          Object.defineProperty(identity, field, { value: 0 });
+        }
+        const originalLstat = fsSync.lstatSync.bind(fsSync);
+        vi.spyOn(fsSync, "lstatSync").mockImplementation((target, options) => {
+          const current = originalLstat(target, options);
+          if (observation === "current" && String(target) === staging && current) {
+            Object.defineProperty(current, field, { value: 0 });
+          }
+          return current;
+        });
+
+        expect(() => keepBackupTempDirectoryAlive(staging, identity)).toThrow();
+
+        expect(fsSync.existsSync(marker)).toBe(false);
+        expect(vi.getTimerCount()).toBe(0);
+      });
+    },
+  );
+
+  it.each(["dev", "ino"] as const)(
+    "rejects unknown initial marker %s without deleting the marker or starting a timer",
+    async (field) => {
+      await withWindowsMetadata(async (root) => {
+        const { staging, marker } = createStaging(root);
+        const identity = fsSync.lstatSync(staging);
+        const originalFstat = fsSync.fstatSync.bind(fsSync);
+        vi.spyOn(fsSync, "fstatSync").mockImplementationOnce((descriptor, options) => {
+          const markerIdentity = originalFstat(descriptor, options);
+          Object.defineProperty(markerIdentity, field, { value: 0 });
+          return markerIdentity;
+        });
+
+        expect(() => keepBackupTempDirectoryAlive(staging, identity)).toThrow();
+
+        expect(fsSync.readFileSync(marker, "utf8")).toBe("");
+        expect(vi.getTimerCount()).toBe(0);
+      });
+    },
+  );
+
+  it.each([
+    { owner: "directory", field: "dev" },
+    { owner: "directory", field: "ino" },
+    { owner: "marker", field: "dev" },
+    { owner: "marker", field: "ino" },
+  ] as const)(
+    "preserves an owner with unknown current $owner $field during refresh and stop",
+    async ({ owner, field }) => {
+      await withWindowsMetadata(async (root) => {
+        const { staging, marker, archive } = createStaging(root);
+        const stop = keepBackupTempDirectoryAlive(staging, fsSync.lstatSync(staging));
+        try {
+          if (field === "ino") {
+            if (owner === "directory") {
+              const displaced = path.join(root, "original-staging");
+              fsSync.renameSync(staging, displaced);
+              fsSync.mkdirSync(staging);
+              fsSync.renameSync(path.join(displaced, OWNER_MARKER), marker);
+            } else {
+              fsSync.renameSync(marker, path.join(root, "original-owner"));
+              fsSync.writeFileSync(marker, "replacement owner", { mode: 0o600 });
+            }
+          }
+          fsSync.writeFileSync(archive, "preserved archive");
+          const previousMtime = fsSync.lstatSync(staging).mtimeMs;
+          const originalLstat = fsSync.lstatSync.bind(fsSync);
+          const unknownPath = owner === "directory" ? staging : marker;
+          vi.spyOn(fsSync, "lstatSync").mockImplementation((target, options) => {
+            const current = originalLstat(target, options);
+            if (String(target) === unknownPath && current) {
+              Object.defineProperty(current, field, { value: 0 });
+            }
+            return current;
+          });
+
+          await vi.advanceTimersByTimeAsync(HOUR_MS);
+          const retired = stop();
+
+          expect(originalLstat(staging).mtimeMs).toBe(previousMtime);
+          expect(fsSync.readFileSync(archive, "utf8")).toBe("preserved archive");
+          expect(fsSync.readFileSync(marker, "utf8")).toBe(
+            owner === "marker" && field === "ino" ? "replacement owner" : "",
+          );
+          expect(retired).toBe(false);
+          expect(vi.getTimerCount()).toBe(0);
+        } finally {
+          stop();
+        }
+      });
+    },
+  );
+
+  it.each([
+    { owner: "directory", observation: "initial", field: "dev" },
+    { owner: "directory", observation: "initial", field: "ino" },
+    { owner: "directory", observation: "current", field: "dev" },
+    { owner: "directory", observation: "current", field: "ino" },
+    { owner: "marker", observation: "initial", field: "dev" },
+    { owner: "marker", observation: "initial", field: "ino" },
+    { owner: "marker", observation: "current", field: "dev" },
+    { owner: "marker", observation: "current", field: "ino" },
+  ] as const)(
+    "preserves stale staging with unknown $observation $owner $field",
+    async ({ owner, observation, field }) => {
+      await withWindowsMetadata(async (root) => {
+        const { staging, marker, archive } = createStaging(root);
+        fsSync.writeFileSync(marker, "", { mode: 0o600 });
+        fsSync.writeFileSync(archive, "preserved archive");
+        ageStaging(staging);
+        const originalLstat = fsSync.lstatSync.bind(fsSync);
+        const unknownPath = owner === "directory" ? staging : marker;
+        let inspectedArchive = false;
+        let obscuredIdentity = false;
+        vi.spyOn(fsSync, "lstatSync").mockImplementation((target, options) => {
+          const current = originalLstat(target, options);
+          if (String(target) === archive && !inspectedArchive) {
+            inspectedArchive = true;
+            if (observation === "current" && field === "ino") {
+              if (owner === "directory") {
+                const displaced = path.join(root, "original-staging");
+                fsSync.renameSync(staging, displaced);
+                fsSync.mkdirSync(staging);
+                fsSync.renameSync(path.join(displaced, OWNER_MARKER), marker);
+                fsSync.writeFileSync(archive, "preserved archive");
+              } else {
+                fsSync.renameSync(marker, path.join(root, "original-owner"));
+                fsSync.writeFileSync(marker, "replacement owner", { mode: 0o600 });
+              }
+              ageStaging(staging);
+            }
+          }
+          if (
+            String(target) === unknownPath &&
+            current &&
+            !obscuredIdentity &&
+            (observation === "initial" || inspectedArchive)
+          ) {
+            obscuredIdentity = true;
+            Object.defineProperty(current, field, { value: 0 });
+          }
+          return current;
+        });
+
+        await sweepStaleBackupTempDirectories({
+          directoryPath: root,
+          entryPattern: STAGING_PATTERN,
+        });
+
+        expect(obscuredIdentity).toBe(true);
+        expect(fsSync.readFileSync(archive, "utf8")).toBe("preserved archive");
+        expect(fsSync.readFileSync(marker, "utf8")).toBe(
+          owner === "marker" && observation === "current" && field === "ino"
+            ? "replacement owner"
+            : "",
+        );
+      });
+    },
+  );
+
+  it.each(["dev", "ino"] as const)(
+    "preserves prepared archive bytes when current %s is unknown",
+    async (field) => {
+      await withWindowsMetadata(async (root) => {
+        const { archive } = createStaging(root);
+        fsSync.writeFileSync(archive, "prepared archive");
+        const identity = fsSync.lstatSync(archive);
+        if (field === "ino") {
+          fsSync.renameSync(archive, path.join(root, "original-archive"));
+          fsSync.writeFileSync(archive, "replacement archive");
+        }
+        const originalLstat = fsSync.lstatSync.bind(fsSync);
+        vi.spyOn(fsSync, "lstatSync").mockImplementation((target, options) => {
+          const current = originalLstat(target, options);
+          if (String(target) === archive && current) {
+            Object.defineProperty(current, field, { value: 0 });
+          }
+          return current;
+        });
+
+        const removed = removePreparedBackupArchive({ archivePath: archive, identity });
+
+        expect(fsSync.readFileSync(archive, "utf8")).toBe(
+          field === "ino" ? "replacement archive" : "prepared archive",
+        );
+        expect(removed).toBe(false);
+      });
+    },
+  );
+
+  it("refreshes and retires known owners, then reclaims a known stale orphan", async () => {
+    await withWindowsMetadata(async (root) => {
+      const { staging, marker, archive } = createStaging(root);
+      const identity = fsSync.lstatSync(staging);
+      expect(identity.dev).not.toBe(0);
+      expect(identity.ino).not.toBe(0);
+      const stop = keepBackupTempDirectoryAlive(staging, identity);
+      try {
+        fsSync.writeFileSync(archive, "orphaned archive");
+        ageStaging(staging);
+        await vi.advanceTimersByTimeAsync(HOUR_MS);
+
+        await sweepStaleBackupTempDirectories({
+          directoryPath: root,
+          entryPattern: STAGING_PATTERN,
+        });
+
+        expect(fsSync.readFileSync(archive, "utf8")).toBe("orphaned archive");
+        expect(stop()).toBe(true);
+        expect(fsSync.existsSync(marker)).toBe(false);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        stop();
+      }
+      fsSync.writeFileSync(marker, "", { mode: 0o600 });
+      ageStaging(staging);
+
+      await sweepStaleBackupTempDirectories({ directoryPath: root, entryPattern: STAGING_PATTERN });
+
+      expect(fsSync.existsSync(staging)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Hard-killed backups leave preparation directories and incomplete archive copies behind. A later `openclaw backup create` now removes only exact backup staging names with a private ownership marker and at least 24 hours of inactivity.

Active backups refresh their staging directories every 30 minutes. Cleanup checks directory, marker, and prepared-archive identities, rejects unknown Windows file identities, and preserves replacements and unmarked legacy artifacts. It retires the marker before reporting final staging retention and keeps the existing cleanup-sync warning. Snapshot contents, verification, output paths, and no-overwrite publication retain their existing behavior.

## Evidence

- Real CLI hard-kill, owned-artifact aging, and verified retry on pinned main and repaired builds.
- A real 30-minute backup with observed refresh of both staging owners, a concurrent verified backup, and preservation of recent marked orphans; retained for unchanged known-identity behavior.
- 196 focused tests across six files on the final correction, including 21 simulated Windows metadata cases. Before the correction, 20 identity cases fail and the known-identity control passes. This is simulated metadata coverage, not native Windows execution.
- Native build, targeted formatting and syntax lint, applicable ratchets, and a fresh verified public backup smoke passed. The latest recovery run retains complete combined output; its per-event export was lost when the test environment ended. Earlier complete traces retain their original build identities.

Preserves the original contributor commits while integrating the repair with the newer backup owners. Unmarked leftovers from older versions remain untouched because their ownership and liveness cannot be proved safely.

Fixes #95582.
