### PR TITLE
feat(acp): run OpenClaw as a native stdio agent

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -155,6 +155,7 @@ jobs:
             which openclaw-acp &&
             test -x /app/openclaw-acp.mjs &&
             openclaw --version &&
+            openclaw-acp --help | grep -F "Run OpenClaw as a self-contained ACP agent" &&
             node -e "
               const fs = require(\"node:fs\");
               const path = require(\"node:path\");
@@ -486,6 +487,7 @@ jobs:
             which openclaw-acp &&
             test -x /app/openclaw-acp.mjs &&
             openclaw --version &&
+            openclaw-acp --help | grep -F "Run OpenClaw as a self-contained ACP agent" &&
             node -e "
               const fs = require(\"node:fs\");
               const path = require(\"node:path\");

--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -152,6 +152,8 @@ jobs:
         run: |
           timeout --kill-after=30s 20m docker run --rm --entrypoint sh openclaw-dockerfile-smoke:local -lc '
             which openclaw &&
+            which openclaw-acp &&
+            test -x /app/openclaw-acp.mjs &&
             openclaw --version &&
             node -e "
               const fs = require(\"node:fs\");
@@ -481,6 +483,8 @@ jobs:
         run: |
           timeout --kill-after=30s 20m docker run --rm --entrypoint sh "$IMAGE_REF" -lc '
             which openclaw &&
+            which openclaw-acp &&
+            test -x /app/openclaw-acp.mjs &&
             openclaw --version &&
             node -e "
               const fs = require(\"node:fs\");

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN corepack enable
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
-COPY openclaw.mjs ./
+COPY openclaw.mjs openclaw-acp.mjs ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
 COPY scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/npm-runner.mjs scripts/windows-cmd-helpers.mjs scripts/prepare-git-hooks.mjs ./scripts/
@@ -236,6 +236,7 @@ COPY --from=runtime-assets --chown=node:node /app/package.json .
 COPY --from=runtime-assets --chown=node:node /app/pnpm-workspace.yaml .
 COPY --from=runtime-assets --chown=node:node /app/patches ./patches
 COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
+COPY --from=runtime-assets --chown=node:node /app/openclaw-acp.mjs .
 COPY --from=runtime-assets --chown=node:node /app/src/agents/templates ./src/agents/templates
 COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR} ./${OPENCLAW_BUNDLED_PLUGIN_DIR}
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
@@ -344,7 +345,8 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 
 # Expose the CLI binary without requiring npm global writes as non-root.
 RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
- && chmod 755 /app/openclaw.mjs
+ && ln -sf /app/openclaw-acp.mjs /usr/local/bin/openclaw-acp \
+ && chmod 755 /app/openclaw.mjs /app/openclaw-acp.mjs
 
 # Pre-create default named-volume mount points so first-run Docker volumes copy
 # node ownership from the image instead of starting as root-owned directories.

--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -1,316 +1,203 @@
 ---
-summary: "Run the ACP bridge for IDE integrations"
+summary: "Run OpenClaw through ACP over stdio"
 read_when:
-  - Setting up ACP-based IDE integrations
-  - Debugging ACP session routing to the Gateway
+  - Setting up ACP clients such as Buzz or an IDE
+  - Debugging OpenClaw ACP execution or permissions
 title: "ACP"
 ---
 
-Run the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) bridge that talks to an OpenClaw Gateway.
+OpenClaw exposes two [Agent Client Protocol (ACP)](https://agentclientprotocol.com/)
+stdio runtimes.
 
-`openclaw acp` speaks ACP over stdio for IDEs and forwards prompts to the Gateway over WebSocket, keeping ACP sessions mapped to Gateway session keys. It is a Gateway-backed ACP bridge, not a full ACP-native editor runtime: it focuses on session routing, prompt delivery, and streaming updates.
-
-If you want an external MCP client to talk directly to OpenClaw channel conversations instead of hosting an ACP harness session, use [`openclaw mcp serve`](/cli/mcp) instead.
-
-## What this is not
-
-`openclaw acp` means OpenClaw acts as an ACP server: an IDE or ACP client connects to OpenClaw, and OpenClaw forwards that work into a Gateway session.
-
-This is different from [ACP Agents](/tools/acp-agents), where OpenClaw runs an external harness such as Codex or Claude Code through `acpx`.
-
-Quick rule:
-
-- editor/client wants to talk ACP to OpenClaw: use `openclaw acp`
-- OpenClaw should launch Codex/Claude/Gemini as an ACP harness: use `/acp spawn` and [ACP Agents](/tools/acp-agents)
-
-## Compatibility matrix
-
-| ACP area                                                              | Status      | Notes                                                                                                                                                                                                                                 |
-| --------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `initialize`, `newSession`, `prompt`, `cancel`                        | Implemented | Core bridge flow over stdio to Gateway chat/send + abort.                                                                                                                                                                             |
-| `listSessions`, slash commands                                        | Implemented | Session list works against Gateway session state with bounded cursor pagination and `cwd` filtering where Gateway session rows carry workspace metadata; commands are advertised via `available_commands_update`.                     |
-| Session lineage metadata                                              | Implemented | Session listings and session info snapshots include OpenClaw parent and child lineage in `_meta` so ACP clients can render subagent graphs without private Gateway side channels.                                                     |
-| `resumeSession`, `closeSession`                                       | Implemented | Resume rebinds an ACP session to an existing Gateway session without replaying history. Close cancels active bridge work, resolves pending prompts as cancelled, and releases bridge session state.                                   |
-| `loadSession`                                                         | Partial     | Rebinds the ACP session to a Gateway session key and replays ACP event-ledger history for bridge-created sessions. Older/no-ledger sessions fall back to stored user/assistant text.                                                  |
-| Prompt content (`text`, embedded `resource`, images)                  | Partial     | Text/resources flatten into chat input; images become Gateway attachments.                                                                                                                                                            |
-| Session modes                                                         | Partial     | `session/set_mode` is supported; the bridge exposes Gateway-backed session controls for thought level, tool verbosity, reasoning, usage detail, and elevated actions. Broader ACP-native mode/config surfaces are still out of scope. |
-| Thought streaming                                                     | Implemented | Model thinking content streams as `agent_thought_chunk` session updates. ACP-native session plans are not emitted.                                                                                                                    |
-| Session info and usage updates                                        | Partial     | The bridge emits `session_info_update` and best-effort `usage_update` notifications from cached Gateway session snapshots. Usage is approximate and only sent when Gateway token totals are marked fresh.                             |
-| Tool streaming                                                        | Partial     | `tool_call`/`tool_call_update` events include raw I/O, text content, and best-effort file locations when Gateway tool args/results expose them. Embedded terminals and richer diff-native output are not exposed.                     |
-| Exec approvals                                                        | Partial     | Gateway exec approval prompts during active ACP prompt turns relay to the ACP client with `session/request_permission`.                                                                                                               |
-| Per-session MCP servers (`mcpServers`)                                | Unsupported | Bridge mode rejects per-session MCP server requests. Configure MCP on the OpenClaw Gateway or agent instead.                                                                                                                          |
-| Client filesystem methods (`fs/read_text_file`, `fs/write_text_file`) | Unsupported | The bridge does not call ACP client filesystem methods.                                                                                                                                                                               |
-| Client terminal methods (`terminal/*`)                                | Unsupported | The bridge does not create ACP client terminals or stream terminal ids through tool calls.                                                                                                                                            |
-
-## Known limitations
-
-- `loadSession` replays complete ACP event-ledger history only for bridge-created sessions. Older/no-ledger sessions use transcript fallback and do not reconstruct historic tool calls or system notices.
-- If multiple ACP clients share the same Gateway session key, event and cancel routing are best-effort rather than strictly isolated per client. Prefer the default isolated `acp-bridge:<uuid>` sessions when you need clean editor-local turns.
-- Gateway stop states translate into ACP stop reasons, but that mapping is less expressive than a fully ACP-native runtime.
-- Session controls surface a focused subset of Gateway knobs: thought level, tool verbosity, reasoning, usage detail, and elevated actions. Model selection and exec-host controls are not exposed as ACP config options.
-- `session_info_update` and `usage_update` derive from Gateway session snapshots, not live ACP-native runtime accounting. Usage is approximate, carries no cost data, and is only emitted when the Gateway marks total token data as fresh.
-- Tool follow-along data is best-effort: the bridge surfaces file paths that appear in known tool args/results, but does not emit ACP terminals or structured file diffs.
-- Exec approval relay is scoped to the active ACP prompt turn; approvals from other Gateway sessions are ignored.
-
-## Usage
+The existing command remains a bridge to an already-running Gateway:
 
 ```bash
 openclaw acp
+```
 
+ACP hosts that need a self-contained process should launch:
+
+```bash
+openclaw-acp
+# equivalent:
+openclaw acp native
+```
+
+The distinct executable is the native-capability marker. Older OpenClaw
+releases may provide `openclaw acp`, but they do not provide `openclaw-acp`.
+
+Native ACP creates OpenClaw agent turns in the ACP process by using the same
+configured models, sessions, tools, workspace, and execution policy as other
+local OpenClaw surfaces. It does not connect to or start a Gateway.
+
+This process ownership matters for ACP hosts such as Buzz: environment supplied
+to the child process remains available to the tools that run the turn.
+
+## Contract
+
+`openclaw-acp` implements this runtime contract:
+
+- transport: ACP over stdio
+- agent execution: in process
+- Gateway required: no
+- sessions: one OpenClaw session per ACP session
+- tools: normal local OpenClaw tool policy
+- exec approvals: relayed through ACP `session/request_permission`
+- plugin approvals: relayed through ACP `session/request_permission`
+- model authentication: normal OpenClaw model configuration
+- delivery: ACP returns protocol output; tools may use credentials inherited by
+  the ACP process for external delivery
+
+Hosts can inspect the contract without starting the ACP server:
+
+```bash
+openclaw acp info
+```
+
+Example output:
+
+```json
+{
+  "schemaVersion": 1,
+  "protocol": "acp",
+  "transport": "stdio",
+  "execution": "in-process",
+  "gatewayRequired": false
+}
+```
+
+## Model setup
+
+Configure and authenticate an OpenClaw model before starting a session:
+
+```bash
+openclaw-acp --configure-model
+```
+
+ACP clients that support terminal authentication receive this setup flow as an
+advertised authentication method.
+
+## Supported ACP surface
+
+| ACP area                               | Status      | Notes                                                                                         |
+| -------------------------------------- | ----------- | --------------------------------------------------------------------------------------------- |
+| `initialize`                           | Implemented | Advertises text, image, embedded context, session close, and terminal model setup.            |
+| `session/new`                          | Implemented | Creates an isolated session for the configured default OpenClaw agent.                        |
+| `session/prompt`                       | Implemented | Runs the canonical OpenClaw agent loop in the ACP process and streams assistant/thought text. |
+| `session/cancel`                       | Implemented | Aborts the active OpenClaw turn for the ACP session.                                          |
+| `session/close`                        | Implemented | Cancels active work and releases the ACP session binding.                                     |
+| Prompt text/resources/images           | Implemented | Text and embedded resources become prompt text; images use normal multimodal input.           |
+| Exec and plugin permissions            | Implemented | Requests are sent to the ACP client and fail closed when unavailable or expired.              |
+| Client-supplied MCP servers            | Unsupported | Configure MCP through OpenClaw instead.                                                       |
+| Additional client workspace roots      | Unsupported | The ACP session uses its absolute `cwd`.                                                      |
+| Session list/load/resume               | Unsupported | Native v1 owns sessions created by the current ACP process.                                   |
+| ACP client filesystem/terminal methods | Unsupported | OpenClaw tools execute locally in the ACP process.                                            |
+
+## Gateway bridge
+
+The shipped Gateway-backed behavior remains the default:
+
+```bash
+openclaw acp
+```
+
+Use this mode only when the ACP client should attach to an existing local or
+remote OpenClaw Gateway. The bridge does not start a Gateway.
+
+```bash
 # Remote Gateway
-openclaw acp --url wss://gateway-host:18789 --token <token>
+openclaw acp \
+  --url wss://gateway-host:18789 \
+  --token-file ~/.openclaw/gateway.token
 
-# Remote Gateway (token from file)
-openclaw acp --url wss://gateway-host:18789 --token-file ~/.openclaw/gateway.token
-
-# Attach to an existing session key
+# Existing Gateway session
 openclaw acp --session agent:main:main
-
-# Attach by label (must already exist)
-openclaw acp --session-label "support inbox"
-
-# Reset the session key before the first prompt
-openclaw acp --session agent:main:main --reset-session
 ```
 
-## ACP client (debug)
+`openclaw acp gateway` is an explicit alias for the same bridge.
 
-Use the built-in ACP client to sanity-check the bridge without an IDE. It spawns the ACP bridge and lets you type prompts interactively.
+Gateway bridge options:
+
+- `--url <url>`
+- `--token <token>` / `--token-file <path>`
+- `--password <password>` / `--password-file <path>`
+- `--session <key>` / `--session-label <label>`
+- `--require-existing`
+- `--reset-session`
+- `--no-prefix-cwd`
+- `--provenance <off|meta|meta+receipt>`
+- `--verbose`
+
+Prefer secret files or `OPENCLAW_GATEWAY_*` environment variables over inline
+credentials. Inline values may be visible in process listings.
+
+## ACP client debug
+
+Use the built-in client for an interactive protocol check:
 
 ```bash
-openclaw acp client
-
-# Point the spawned bridge at a remote Gateway
-openclaw acp client --server-args --url wss://gateway-host:18789 --token-file ~/.openclaw/gateway.token
-
-# Override the server command (default: openclaw)
-openclaw acp client --server "node" --server-args openclaw.mjs acp --url ws://127.0.0.1:19001
+openclaw acp client --cwd /path/to/project
 ```
 
-Permission model (client debug mode):
-
-- Auto-approval is allowlist-based and applies only to trusted core tool IDs.
-- `read` auto-approval is scoped to the current working directory (`--cwd` when set).
-- ACP only auto-approves narrow readonly classes: scoped `read` calls under the active cwd, plus readonly search tools (`search`, `web_search`, `memory_search`). Unknown/non-core tools, out-of-scope reads, exec-capable tools, control-plane tools, mutating tools, and interactive flows always require explicit prompt approval.
-- Server-provided `toolCall.kind` is treated as untrusted metadata, not an authorization source.
-- This ACP bridge policy is separate from ACPX harness permissions. If you run OpenClaw through the `acpx` backend, `plugins.entries.acpx.config.permissionMode=approve-all` is the break-glass "yolo" switch for that harness session.
-
-## Protocol smoke testing
-
-For protocol-level debugging, start a Gateway with isolated state and drive `openclaw acp` over stdio with an ACP JSON-RPC client. Cover `initialize`, `session/new`, `session/list` with an absolute `cwd`, `session/resume`, `session/close`, duplicate close, and missing resume.
-
-The proof should include the advertised lifecycle capabilities, a Gateway-backed session row, update notifications, and the Gateway `sessions.list` log:
-
-```json
-{
-  "initialize": {
-    "protocolVersion": 1,
-    "agentCapabilities": {
-      "sessionCapabilities": {
-        "list": {},
-        "resume": {},
-        "close": {}
-      }
-    }
-  },
-  "listSessions": {
-    "sessions": [
-      {
-        "sessionId": "agent:main:acp-smoke",
-        "cwd": "/path/to/workspace",
-        "_meta": {
-          "sessionKey": "agent:main:acp-smoke",
-          "kind": "direct"
-        }
-      }
-    ],
-    "nextCursor": null
-  },
-  "notifications": ["session_info_update", "available_commands_update", "usage_update"],
-  "gatewayLogTail": ["[gateway] ready", "[ws] ⇄ res ✓ sessions.list 305ms"]
-}
-```
-
-Avoid using `openclaw gateway call sessions.list` as the only ACP proof. That CLI path may request a fresh-token operator scope upgrade; ACP bridge correctness is proven by ACP stdio frames plus the Gateway `sessions.list` log.
-
-## How to use this
-
-Use ACP when an IDE (or other client) speaks Agent Client Protocol and you want it to drive an OpenClaw Gateway session.
-
-1. Ensure the Gateway is running (local or remote).
-2. Configure the Gateway target (config or flags).
-3. Point your IDE to run `openclaw acp` over stdio.
-
-Example config (persisted):
+To test the explicit Gateway bridge:
 
 ```bash
-openclaw config set gateway.remote.url wss://gateway-host:18789
-openclaw config set gateway.remote.token <token>
+openclaw acp client \
+  --server-args gateway --url ws://127.0.0.1:18789
 ```
 
-Example direct run (no config write):
+The debug client applies a narrow auto-approval policy for trusted read-only
+tools. Exec-capable, mutating, unknown, and interactive tools still require a
+permission response.
 
-```bash
-openclaw acp --url wss://gateway-host:18789 --token <token>
-# preferred for local process safety
-openclaw acp --url wss://gateway-host:18789 --token-file ~/.openclaw/gateway.token
-```
+## Buzz
 
-## Selecting agents
+Buzz can register `openclaw-acp` as a first-class ACP runtime. Buzz launches
+the command with the dedicated agent's `BUZZ_*` environment; OpenClaw tools run
+in that same process and can use the Buzz CLI to publish the signed reply.
 
-ACP does not pick agents directly. It routes by the Gateway session key. Use agent-scoped session keys to target a specific agent:
+No Gateway URL, Gateway token, companion node, or separately managed Gateway is
+part of this path.
 
-```bash
-openclaw acp --session agent:main:main
-openclaw acp --session agent:design:main
-openclaw acp --session agent:qa:bug-123
-```
+Keep unattended ACP agents owner-only unless the host exposes a reviewed
+permission policy. ACP hosts may answer permission requests without presenting
+an interactive human prompt. Native ACP turns are always treated as non-owner
+input, so owner-only tools remain unavailable; approving a tool call authorizes
+only that call and does not attest the prompt sender's identity.
 
-Each ACP session maps to a single Gateway session key. One agent can have many sessions; ACP defaults to an isolated `acp-bridge:<uuid>` session unless you override the key or label.
+## IDE example
 
-Per-session `mcpServers` are not supported in bridge mode. If an ACP client sends them during `newSession` or `loadSession`, the bridge returns a clear error instead of silently ignoring them.
-
-If you want ACPX-backed sessions to see OpenClaw plugin tools or selected built-in tools such as `cron`, enable the gateway-side ACPX MCP bridges instead of trying to pass per-session `mcpServers`. See [ACP Agents](/tools/acp-agents-setup#plugin-tools-mcp-bridge) and [OpenClaw tools MCP bridge](/tools/acp-agents-setup#openclaw-tools-mcp-bridge).
-
-## Use from `acpx` (Codex, Claude, other ACP clients)
-
-If you want a coding agent such as Codex or Claude Code to talk to your OpenClaw bot over ACP, use `acpx` with its built-in `openclaw` target.
-
-Typical flow:
-
-1. Run the Gateway and make sure the ACP bridge can reach it.
-2. Point `acpx openclaw` at `openclaw acp`.
-3. Target the OpenClaw session key you want the coding agent to use.
-
-Examples:
-
-```bash
-# One-shot request into your default OpenClaw ACP session
-acpx openclaw exec "Summarize the active OpenClaw session state."
-
-# Persistent named session for follow-up turns
-acpx openclaw sessions ensure --name codex-bridge
-acpx openclaw -s codex-bridge --cwd /path/to/repo \
-  "Ask my OpenClaw work agent for recent context relevant to this repo."
-```
-
-If you want `acpx openclaw` to target a specific Gateway and session key every time, override the `openclaw` agent command in `~/.acpx/config.json`:
-
-```json
-{
-  "agents": {
-    "openclaw": {
-      "command": "env OPENCLAW_HIDE_BANNER=1 OPENCLAW_SUPPRESS_NOTES=1 openclaw acp --url ws://127.0.0.1:18789 --token-file ~/.openclaw/gateway.token --session agent:main:main"
-    }
-  }
-}
-```
-
-For a repo-local OpenClaw checkout, use the direct CLI entrypoint instead of the dev runner so the ACP stream stays clean:
-
-```bash
-env OPENCLAW_HIDE_BANNER=1 OPENCLAW_SUPPRESS_NOTES=1 node openclaw.mjs acp ...
-```
-
-This is the easiest way to let Codex, Claude Code, or another ACP-aware client pull contextual information from an OpenClaw agent without scraping a terminal.
-
-## Zed editor setup
-
-Add a custom ACP agent in `~/.config/zed/settings.json` (or use Zed's Settings UI):
+For Zed, add a custom ACP agent:
 
 ```json
 {
   "agent_servers": {
     "OpenClaw ACP": {
       "type": "custom",
-      "command": "openclaw",
-      "args": ["acp"],
+      "command": "openclaw-acp",
+      "args": [],
       "env": {}
     }
   }
 }
 ```
 
-To target a specific Gateway or agent:
+For a source checkout, invoke the direct CLI entrypoint so stdout remains a
+clean ACP stream:
 
-```json
-{
-  "agent_servers": {
-    "OpenClaw ACP": {
-      "type": "custom",
-      "command": "openclaw",
-      "args": [
-        "acp",
-        "--url",
-        "wss://gateway-host:18789",
-        "--token",
-        "<token>",
-        "--session",
-        "agent:design:main"
-      ],
-      "env": {}
-    }
-  }
-}
+```bash
+node openclaw.mjs acp native
 ```
 
-In Zed, open the Agent panel and select "OpenClaw ACP" to start a thread.
+## ACP versus ACP agents
 
-## Session mapping
-
-By default, ACP bridge sessions get an isolated Gateway session key with an `acp-bridge:` prefix. These normal-model bridge sessions are synthetic and disposable: they are subject to stale-entry pruning and are not treated as protected human conversation surfaces. To reuse a known session, pass a session key or label:
-
-- `--session <key>`: use a specific Gateway session key.
-- `--session-label <label>`: resolve an existing session by label.
-- `--reset-session`: mint a fresh session id for that key (same key, new transcript).
-
-If your ACP client supports metadata, you can override per session:
-
-```json
-{
-  "_meta": {
-    "sessionKey": "agent:main:main",
-    "sessionLabel": "support inbox",
-    "resetSession": true
-  }
-}
-```
-
-Learn more about session keys at [/concepts/session](/concepts/session).
-
-## Options
-
-- `--url <url>`: Gateway WebSocket URL (defaults to `gateway.remote.url` when configured).
-- `--token <token>`: Gateway auth token.
-- `--token-file <path>`: read Gateway auth token from file.
-- `--password <password>`: Gateway auth password.
-- `--password-file <path>`: read Gateway auth password from file.
-- `--session <key>`: default session key.
-- `--session-label <label>`: default session label to resolve.
-- `--require-existing`: fail if the session key/label does not exist.
-- `--reset-session`: reset the session key before first use.
-- `--no-prefix-cwd`: do not prefix prompts with the working directory.
-- `--provenance <off|meta|meta+receipt>`: include ACP provenance metadata or receipts.
-- `--verbose, -v`: verbose logging to stderr.
-
-Security note:
-
-- `--token` and `--password` can be visible in local process listings on some systems. Prefer `--token-file`/`--password-file` or environment variables (`OPENCLAW_GATEWAY_TOKEN`, `OPENCLAW_GATEWAY_PASSWORD`).
-- Gateway auth resolution follows the shared contract used by other Gateway clients:
-  - local mode: `gateway.auth.*` then env (`OPENCLAW_GATEWAY_*`), falling back to `gateway.remote.*` only when `gateway.auth.*` is unset (a configured-but-unresolved local SecretRef fails closed instead of silently falling back)
-  - remote mode: `gateway.remote.*` with env/config fallback per remote precedence rules
-  - `--url` is override-safe and does not reuse implicit config/env credentials; pass explicit `--token`/`--password` (or file variants)
-
-### `acp client` options
-
-- `--cwd <dir>`: working directory for the ACP session.
-- `--server <command>`: ACP server command (default: `openclaw`).
-- `--server-args <args...>`: extra arguments passed to the ACP server.
-- `--server-verbose`: enable verbose logging on the ACP server.
-- `--verbose, -v`: verbose client logging.
-- `openclaw acp client` sets `OPENCLAW_SHELL=acp-client` on the spawned bridge process, which can be used for context-specific shell/profile rules.
+- An ACP client wants OpenClaw to perform the turn: `openclaw-acp`.
+- An ACP client wants an existing Gateway session: `openclaw acp`.
+- OpenClaw should launch Codex, Claude, Gemini, or another external ACP
+  harness: use `/acp spawn` and [ACP agents](/tools/acp-agents).
 
 ## Related
 
 - [CLI reference](/cli)
 - [ACP agents](/tools/acp-agents)
+- [ACP agents setup](/tools/acp-agents-setup)

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -19,7 +19,7 @@ sidebarTitle: "MCP"
   `list`, `show`, `set`, and `unset` only read and write OpenClaw-managed `mcp.servers` entries in OpenClaw config. They do not include mcporter servers from `config/mcporter.json`; use `mcporter list` for that registry.
 </Note>
 
-Use [`openclaw acp`](/cli/acp) when OpenClaw should host a coding harness session itself and route that runtime through ACP.
+Use [`openclaw-acp`](/cli/acp) when an ACP client should run OpenClaw's local agent runtime and tools.
 
 ## Choose the right MCP path
 
@@ -30,7 +30,7 @@ Use [`openclaw acp`](/cli/acp) when OpenClaw should host a coding harness sessio
 | Check a saved server without running an agent turn                  | `openclaw mcp status`, `doctor`, `probe`                             | `status` and `doctor` inspect config; `probe` opens a live MCP connection and lists capabilities.               |
 | Edit MCP config from a browser                                      | Control UI `/settings/mcp` (`/mcp` alias)                            | The page shows inventory, enablement, OAuth/filter summaries, command hints, and a scoped `mcp` editor.         |
 | Give Codex app-server a scoped native MCP server                    | `mcp.servers.<name>.codex`                                           | The `codex` block only affects Codex app-server thread projection and is stripped before native config handoff. |
-| Run ACP-hosted harness sessions                                     | [`openclaw acp`](/cli/acp) and [ACP Agents](/tools/acp-agents-setup) | ACP bridge mode does not accept per-session MCP server injection; configure gateway/plugin bridges instead.     |
+| Run OpenClaw through an ACP host                                    | [`openclaw-acp`](/cli/acp) and [ACP Agents](/tools/acp-agents-setup) | Native ACP does not accept client-supplied per-session MCP servers.                                             |
 
 <Tip>
 If you are not sure which path you need, start with `openclaw mcp status --verbose`. It shows what OpenClaw has saved without starting any MCP servers.
@@ -48,7 +48,7 @@ Use `openclaw mcp serve` when:
 - you already have a local or remote OpenClaw Gateway with routed sessions
 - you want one MCP server that works across OpenClaw's channel backends instead of running separate per-channel bridges
 
-Use [`openclaw acp`](/cli/acp) instead when OpenClaw should host the coding runtime itself and keep the agent session inside OpenClaw.
+Use [`openclaw-acp`](/cli/acp) instead when OpenClaw should host the coding runtime itself and keep the agent session inside OpenClaw.
 
 ### How it works
 

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -44,7 +44,6 @@ Built-in acpx harness aliases (from the pinned `acpx` dependency):
 | `kiro`       | [Kiro CLI](https://kiro.dev)                                                                           |
 | `mux`        | [Mux](https://mux.coder.com)                                                                           |
 | `opencode`   | [OpenCode](https://opencode.ai)                                                                        |
-| `openclaw`   | OpenClaw ACP bridge (native `openclaw acp`)                                                            |
 | `pi`         | [Pi Coding Agent](https://github.com/earendil-works/pi)                                                |
 | `qoder`      | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                            |
 | `qwen`       | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                       |
@@ -85,7 +84,6 @@ Core ACP baseline:
       "kilocode",
       "kimi",
       "kiro",
-      "openclaw",
       "opencode",
       "qwen",
     ],

--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -44,6 +44,7 @@ Built-in acpx harness aliases (from the pinned `acpx` dependency):
 | `kiro`       | [Kiro CLI](https://kiro.dev)                                                                           |
 | `mux`        | [Mux](https://mux.coder.com)                                                                           |
 | `opencode`   | [OpenCode](https://opencode.ai)                                                                        |
+| `openclaw`   | OpenClaw Gateway bridge (`openclaw acp`)                                                               |
 | `pi`         | [Pi Coding Agent](https://github.com/earendil-works/pi)                                                |
 | `qoder`      | [Qoder CLI](https://docs.qoder.com/cli/acp)                                                            |
 | `qwen`       | [Qwen Code](https://github.com/QwenLM/qwen-code)                                                       |
@@ -84,6 +85,7 @@ Core ACP baseline:
       "kilocode",
       "kimi",
       "kiro",
+      "openclaw",
       "opencode",
       "qwen",
     ],

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -33,7 +33,7 @@ existing OpenClaw channel conversations, use
 | ----------------------------------------------------------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Bind or control Codex in the current conversation                                               | `/codex bind`, `/codex threads`       | Native Codex app-server path when the `codex` plugin is enabled: bound chat replies, image forwarding, model/fast/permissions, stop, and steer. ACP is an explicit fallback |
 | Run Claude Code, Gemini CLI, explicit Codex ACP, or another external harness _through_ OpenClaw | This page                             | Chat-bound sessions, `/acp spawn`, `sessions_spawn({ runtime: "acp" })`, background tasks, runtime controls                                                                 |
-| Expose an OpenClaw Gateway session _as_ an ACP server for an editor or client                   | [`openclaw acp`](/cli/acp)            | Bridge mode: an IDE/client speaks ACP to OpenClaw over stdio/WebSocket                                                                                                      |
+| Run OpenClaw _as_ an ACP agent for an editor or client                                          | [`openclaw-acp`](/cli/acp)            | Native mode: the ACP process owns the OpenClaw turn and local tools                                                                                                         |
 | Reuse a local AI CLI as a text-only fallback model                                              | [CLI Backends](/gateway/cli-backends) | Not ACP: no OpenClaw tools, no ACP controls, no harness runtime                                                                                                             |
 
 ## Does this work out of the box?
@@ -92,25 +92,24 @@ call those tools directly.
 With the `acpx` backend, use these ids as `/acp spawn <id>` or
 `sessions_spawn({ runtime: "acp", agentId: "<id>" })` targets:
 
-| Harness id   | Typical backend                                | Notes                                                                               |
-| ------------ | ---------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `claude`     | Claude Code ACP adapter                        | Requires Claude Code auth on the host.                                              |
-| `codex`      | Codex ACP adapter                              | Explicit ACP fallback only when native `/codex` is unavailable or ACP is requested. |
-| `copilot`    | GitHub Copilot ACP adapter                     | Requires Copilot CLI/runtime auth.                                                  |
-| `cursor`     | Cursor CLI ACP (`cursor-agent acp`)            | Override the acpx command if a local install exposes a different ACP entrypoint.    |
-| `droid`      | Factory Droid CLI                              | Requires Factory/Droid auth or `FACTORY_API_KEY` in the harness environment.        |
-| `fast-agent` | fast-agent-mcp ACP adapter                     | Fetched on demand with `uvx`.                                                       |
-| `gemini`     | Gemini CLI ACP adapter                         | Requires Gemini CLI auth or API key setup.                                          |
-| `iflow`      | iFlow CLI                                      | Adapter availability and model control depend on the installed CLI.                 |
-| `kilocode`   | Kilo Code CLI                                  | Adapter availability and model control depend on the installed CLI.                 |
-| `kimi`       | Kimi/Moonshot CLI                              | Requires Kimi/Moonshot auth on the host.                                            |
-| `kiro`       | Kiro CLI                                       | Adapter availability and model control depend on the installed CLI.                 |
-| `mux`        | Mux CLI ACP adapter                            | Fetched on demand with `npx`.                                                       |
-| `opencode`   | OpenCode ACP adapter                           | Requires OpenCode CLI/provider auth.                                                |
-| `openclaw`   | OpenClaw Gateway bridge through `openclaw acp` | Lets an ACP-aware harness talk back to an OpenClaw Gateway session.                 |
-| `qoder`      | Qoder CLI                                      | Adapter availability and model control depend on the installed CLI.                 |
-| `qwen`       | Qwen Code / Qwen CLI                           | Requires Qwen-compatible auth on the host.                                          |
-| `trae`       | Trae CLI ACP adapter                           | Adapter availability and model control depend on the installed CLI.                 |
+| Harness id   | Typical backend                     | Notes                                                                               |
+| ------------ | ----------------------------------- | ----------------------------------------------------------------------------------- |
+| `claude`     | Claude Code ACP adapter             | Requires Claude Code auth on the host.                                              |
+| `codex`      | Codex ACP adapter                   | Explicit ACP fallback only when native `/codex` is unavailable or ACP is requested. |
+| `copilot`    | GitHub Copilot ACP adapter          | Requires Copilot CLI/runtime auth.                                                  |
+| `cursor`     | Cursor CLI ACP (`cursor-agent acp`) | Override the acpx command if a local install exposes a different ACP entrypoint.    |
+| `droid`      | Factory Droid CLI                   | Requires Factory/Droid auth or `FACTORY_API_KEY` in the harness environment.        |
+| `fast-agent` | fast-agent-mcp ACP adapter          | Fetched on demand with `uvx`.                                                       |
+| `gemini`     | Gemini CLI ACP adapter              | Requires Gemini CLI auth or API key setup.                                          |
+| `iflow`      | iFlow CLI                           | Adapter availability and model control depend on the installed CLI.                 |
+| `kilocode`   | Kilo Code CLI                       | Adapter availability and model control depend on the installed CLI.                 |
+| `kimi`       | Kimi/Moonshot CLI                   | Requires Kimi/Moonshot auth on the host.                                            |
+| `kiro`       | Kiro CLI                            | Adapter availability and model control depend on the installed CLI.                 |
+| `mux`        | Mux CLI ACP adapter                 | Fetched on demand with `npx`.                                                       |
+| `opencode`   | OpenCode ACP adapter                | Requires OpenCode CLI/provider auth.                                                |
+| `qoder`      | Qoder CLI                           | Adapter availability and model control depend on the installed CLI.                 |
+| `qwen`       | Qwen Code / Qwen CLI                | Requires Qwen-compatible auth on the host.                                          |
+| `trae`       | Trae CLI ACP adapter                | Adapter availability and model control depend on the installed CLI.                 |
 
 `pi` (pi-acp) is also registered in the acpx backend but is not a coding
 harness in the same sense as the others above.
@@ -863,5 +862,5 @@ instead of repeating `/new`. See
 - [Codex harness](/plugins/codex-harness)
 - [Codex harness runtime](/plugins/codex-harness-runtime)
 - [Multi-agent sandbox tools](/tools/multi-agent-sandbox-tools)
-- [`openclaw acp` (bridge mode)](/cli/acp)
+- [`openclaw-acp`](/cli/acp)
 - [Sub-agents](/tools/subagents)

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -33,6 +33,7 @@ existing OpenClaw channel conversations, use
 | ----------------------------------------------------------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Bind or control Codex in the current conversation                                               | `/codex bind`, `/codex threads`       | Native Codex app-server path when the `codex` plugin is enabled: bound chat replies, image forwarding, model/fast/permissions, stop, and steer. ACP is an explicit fallback |
 | Run Claude Code, Gemini CLI, explicit Codex ACP, or another external harness _through_ OpenClaw | This page                             | Chat-bound sessions, `/acp spawn`, `sessions_spawn({ runtime: "acp" })`, background tasks, runtime controls                                                                 |
+| Expose an OpenClaw Gateway session _as_ an ACP server for an editor or client                   | [`openclaw acp`](/cli/acp)            | Bridge mode: an IDE/client speaks ACP to an existing OpenClaw Gateway session                                                                                               |
 | Run OpenClaw _as_ an ACP agent for an editor or client                                          | [`openclaw-acp`](/cli/acp)            | Native mode: the ACP process owns the OpenClaw turn and local tools                                                                                                         |
 | Reuse a local AI CLI as a text-only fallback model                                              | [CLI Backends](/gateway/cli-backends) | Not ACP: no OpenClaw tools, no ACP controls, no harness runtime                                                                                                             |
 
@@ -107,6 +108,7 @@ With the `acpx` backend, use these ids as `/acp spawn <id>` or
 | `kiro`       | Kiro CLI                            | Adapter availability and model control depend on the installed CLI.                 |
 | `mux`        | Mux CLI ACP adapter                 | Fetched on demand with `npx`.                                                       |
 | `opencode`   | OpenCode ACP adapter                | Requires OpenCode CLI/provider auth.                                                |
+| `openclaw`   | OpenClaw Gateway bridge             | Launches `openclaw acp`; a Gateway must already be running.                         |
 | `qoder`      | Qoder CLI                           | Adapter availability and model control depend on the installed CLI.                 |
 | `qwen`       | Qwen Code / Qwen CLI                | Requires Qwen-compatible auth on the host.                                          |
 | `trae`       | Trae CLI ACP adapter                | Adapter availability and model control depend on the installed CLI.                 |
@@ -862,5 +864,6 @@ instead of repeating `/new`. See
 - [Codex harness](/plugins/codex-harness)
 - [Codex harness runtime](/plugins/codex-harness-runtime)
 - [Multi-agent sandbox tools](/tools/multi-agent-sandbox-tools)
+- [`openclaw acp` (Gateway bridge)](/cli/acp)
 - [`openclaw-acp`](/cli/acp)
 - [Sub-agents](/tools/subagents)

--- a/openclaw-acp.mjs
+++ b/openclaw-acp.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+process.argv.splice(2, 0, "acp", "native");
+await import("./openclaw.mjs");

--- a/openclaw-acp.mjs
+++ b/openclaw-acp.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
 
-process.argv.splice(2, 0, "acp", "native");
+if (process.argv[2] !== "acp" || process.argv[3] !== "native") {
+  process.argv.splice(2, 0, "acp", "native");
+}
 await import("./openclaw.mjs");

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "url": "git+https://github.com/openclaw/openclaw.git"
   },
   "bin": {
-    "openclaw": "openclaw.mjs"
+    "openclaw": "openclaw.mjs",
+    "openclaw-acp": "openclaw-acp.mjs"
   },
   "directories": {
     "doc": "docs",
@@ -29,6 +30,7 @@
   "files": [
     "CHANGELOG.md",
     "LICENSE",
+    "openclaw-acp.mjs",
     "openclaw.mjs",
     "pnpm-workspace.yaml",
     "README.md",

--- a/scripts/check-duplicates.mjs
+++ b/scripts/check-duplicates.mjs
@@ -22,6 +22,7 @@ const targets = [
   "skills",
   "config",
   "openclaw.mjs",
+  "openclaw-acp.mjs",
   "tsdown.ai.config.ts",
   "tsdown.config.ts",
   "vitest.config.ts",

--- a/scripts/e2e/cli-installer-distribution-docker.sh
+++ b/scripts/e2e/cli-installer-distribution-docker.sh
@@ -60,7 +60,9 @@ test "$(command -v openclaw-acp)" = "$prefix_acp"
 test "$(git -C /tmp/openclaw-source rev-parse HEAD)" = "$OPENCLAW_SOURCE_SHA"
 openclaw_version="$(openclaw --version)"
 openclaw --help >/tmp/openclaw-help
+openclaw-acp --help >/tmp/openclaw-acp-help
 test -s /tmp/openclaw-help
+grep -Fq "Run OpenClaw as a self-contained ACP agent" /tmp/openclaw-acp-help
 status_json="$(openclaw update status --json)"
 STATUS_JSON="$status_json" node -e "
   const status = JSON.parse(process.env.STATUS_JSON);
@@ -111,7 +113,9 @@ docker_e2e_docker_run_cmd run -d \
     node_version="$(node --version)"
     openclaw_version="$(openclaw --version)"
     openclaw --help >/tmp/openclaw-help
+    openclaw-acp --help >/tmp/openclaw-acp-help
     test -s /tmp/openclaw-help
+    grep -Fq "Run OpenClaw as a self-contained ACP agent" /tmp/openclaw-acp-help
     printf "hostedNode=%s@%s\n" "$node_path" "$node_version"
     printf "hostedOpenClaw=%s@%s\n" "$openclaw_path" "$openclaw_version"
     printf "hostedOpenClawAcp=%s\n" "$openclaw_acp_path"

--- a/scripts/e2e/cli-installer-distribution-docker.sh
+++ b/scripts/e2e/cli-installer-distribution-docker.sh
@@ -46,12 +46,17 @@ bash /tmp/openclaw-source/scripts/install-cli.sh \
 
 prefix_node=/tmp/openclaw-prefix/tools/node/bin/node
 prefix_cli=/tmp/openclaw-prefix/bin/openclaw
+prefix_acp=/tmp/openclaw-prefix/bin/openclaw-acp
 test -x "$prefix_node"
 test -x "$prefix_cli"
+test -x "$prefix_acp"
 grep -Fq "exec \"$prefix_node\"" "$prefix_cli"
+grep -Fq "exec \"$prefix_node\"" "$prefix_acp"
 grep -Fq "/tmp/openclaw-source/dist/entry.js" "$prefix_cli"
+grep -Fq "/tmp/openclaw-source/openclaw-acp.mjs" "$prefix_acp"
 export PATH="/tmp/openclaw-prefix/bin:$PATH"
 test "$(command -v openclaw)" = "$prefix_cli"
+test "$(command -v openclaw-acp)" = "$prefix_acp"
 test "$(git -C /tmp/openclaw-source rev-parse HEAD)" = "$OPENCLAW_SOURCE_SHA"
 openclaw_version="$(openclaw --version)"
 openclaw --help >/tmp/openclaw-help
@@ -99,7 +104,9 @@ docker_e2e_docker_run_cmd run -d \
     source "$HOME/.bashrc"
     hash -r
     openclaw_path="$(command -v openclaw)"
+    openclaw_acp_path="$(command -v openclaw-acp)"
     test -n "$openclaw_path"
+    test -n "$openclaw_acp_path"
     node_path="$(command -v node)"
     node_version="$(node --version)"
     openclaw_version="$(openclaw --version)"
@@ -107,6 +114,7 @@ docker_e2e_docker_run_cmd run -d \
     test -s /tmp/openclaw-help
     printf "hostedNode=%s@%s\n" "$node_path" "$node_version"
     printf "hostedOpenClaw=%s@%s\n" "$openclaw_path" "$openclaw_version"
+    printf "hostedOpenClawAcp=%s\n" "$openclaw_acp_path"
     printf "hostedOnboard=disabled\n"
     touch /tmp/openclaw-proof-ready
     exec sleep infinity

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1120,12 +1120,22 @@ install_openclaw() {
   fi
 
   mkdir -p "${PREFIX}/bin"
-  rm -f "${PREFIX}/bin/openclaw"
+  rm -f "${PREFIX}/bin/openclaw" "${PREFIX}/bin/openclaw-acp"
   cat > "${PREFIX}/bin/openclaw" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 exec "${PREFIX}/tools/node/bin/node" "$(node_dir)/lib/node_modules/openclaw/dist/entry.js" "\$@"
 EOF
+  local acp_entry
+  acp_entry="$(node_dir)/lib/node_modules/openclaw/openclaw-acp.mjs"
+  if [[ -f "$acp_entry" ]]; then
+    cat > "${PREFIX}/bin/openclaw-acp" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${PREFIX}/tools/node/bin/node" "${acp_entry}" "\$@"
+EOF
+    chmod +x "${PREFIX}/bin/openclaw-acp"
+  fi
   chmod +x "${PREFIX}/bin/openclaw"
   emit_json "{\"event\":\"step\",\"name\":\"openclaw\",\"status\":\"ok\",\"version\":\"${requested}\"}"
 }
@@ -1231,6 +1241,15 @@ install_openclaw_from_git() {
 set -euo pipefail
 exec "${PREFIX}/tools/node/bin/node" "${repo_dir}/dist/entry.js" "\$@"
 EOF
+  rm -f "${PREFIX}/bin/openclaw-acp"
+  if [[ -f "${repo_dir}/openclaw-acp.mjs" ]]; then
+    cat > "${PREFIX}/bin/openclaw-acp" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${PREFIX}/tools/node/bin/node" "${repo_dir}/openclaw-acp.mjs" "\$@"
+EOF
+    chmod +x "${PREFIX}/bin/openclaw-acp"
+  fi
   chmod +x "${PREFIX}/bin/openclaw"
   emit_json "{\"event\":\"step\",\"name\":\"openclaw\",\"status\":\"ok\",\"method\":\"git\"}"
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1593,6 +1593,13 @@ function Install-OpenClawFromGit {
     $cmdPath = Join-Path $binDir "openclaw.cmd"
     $cmdContents = "@echo off`r`nnode ""$entryPath"" %*`r`n"
     Set-Content -Path $cmdPath -Value $cmdContents -NoNewline
+    $acpCmdPath = Join-Path $binDir "openclaw-acp.cmd"
+    $acpEntryPath = Join-Path $RepoDir "openclaw-acp.mjs"
+    Remove-Item -Force $acpCmdPath -ErrorAction SilentlyContinue
+    if (Test-Path $acpEntryPath) {
+        $acpCmdContents = "@echo off`r`nnode ""$acpEntryPath"" %*`r`n"
+        Set-Content -Path $acpCmdPath -Value $acpCmdContents -NoNewline
+    }
 
     if (Add-ToUserPath $binDir) {
         Write-Host "[!] Added $binDir to user PATH (restart terminal if command not found)" -ForegroundColor Yellow
@@ -1736,9 +1743,11 @@ function Main {
             return (Fail-Install)
         }
     } else {
-        $gitWrapper = Join-Path (Join-Path $env:USERPROFILE ".local\\bin") "openclaw.cmd"
-        if (Test-Path $gitWrapper) {
-            Remove-Item -Force $gitWrapper
+        $gitBinDir = Join-Path $env:USERPROFILE ".local\\bin"
+        $gitWrapper = Join-Path $gitBinDir "openclaw.cmd"
+        $gitAcpWrapper = Join-Path $gitBinDir "openclaw-acp.cmd"
+        if ((Test-Path $gitWrapper) -or (Test-Path $gitAcpWrapper)) {
+            Remove-Item -Force $gitWrapper, $gitAcpWrapper -ErrorAction SilentlyContinue
             Write-Host "[OK] Removed git wrapper (switching to npm)" -ForegroundColor Green
         }
         $npmInstallResults = @(Install-OpenClaw)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2199,6 +2199,18 @@ ensure_openclaw_bin_link() {
         ln -sf "$npm_root/openclaw/dist/entry.js" "${npm_bin}/openclaw"
         ui_info "Created openclaw bin link at ${npm_bin}/openclaw"
     fi
+    if [[ -f "$npm_root/openclaw/openclaw-acp.mjs" ]]; then
+        if [[ ! -x "${npm_bin}/openclaw-acp" ]]; then
+            ln -sf "$npm_root/openclaw/openclaw-acp.mjs" "${npm_bin}/openclaw-acp"
+            ui_info "Created openclaw-acp bin link at ${npm_bin}/openclaw-acp"
+        fi
+    elif [[ -L "${npm_bin}/openclaw-acp" ]]; then
+        local acp_target=""
+        acp_target="$(readlink "${npm_bin}/openclaw-acp" 2>/dev/null || true)"
+        if [[ "$acp_target" == *"/node_modules/openclaw/"* ]]; then
+            rm -f "${npm_bin}/openclaw-acp"
+        fi
+    fi
     return 0
 }
 
@@ -2917,7 +2929,7 @@ install_openclaw_from_git() {
 
     ensure_user_local_bin_on_path
 
-    local node_bin="" node_bin_quoted="" entry_path_quoted=""
+    local node_bin="" node_bin_quoted="" entry_path_quoted="" acp_entry_path_quoted=""
     node_bin="$(type -P node 2>/dev/null || true)"
     if [[ -n "$node_bin" && "$node_bin" != /* ]]; then
         local node_dir=""
@@ -2932,6 +2944,7 @@ install_openclaw_from_git() {
     fi
     printf -v node_bin_quoted "%q" "$node_bin"
     printf -v entry_path_quoted "%q" "${repo_dir}/dist/entry.js"
+    printf -v acp_entry_path_quoted "%q" "${repo_dir}/openclaw-acp.mjs"
 
     cat > "$HOME/.local/bin/openclaw" <<EOF
 #!/usr/bin/env bash
@@ -2939,6 +2952,15 @@ set -euo pipefail
 exec ${node_bin_quoted} ${entry_path_quoted} "\$@"
 EOF
     chmod +x "$HOME/.local/bin/openclaw"
+    rm -f "$HOME/.local/bin/openclaw-acp"
+    if [[ -f "${repo_dir}/openclaw-acp.mjs" ]]; then
+        cat > "$HOME/.local/bin/openclaw-acp" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+exec ${node_bin_quoted} ${acp_entry_path_quoted} "\$@"
+EOF
+        chmod +x "$HOME/.local/bin/openclaw-acp"
+    fi
     ui_success "OpenClaw wrapper installed to \$HOME/.local/bin/openclaw"
     ui_info "This checkout uses pnpm — run pnpm install (or corepack pnpm install) for deps"
 }
@@ -3389,9 +3411,9 @@ main() {
         install_openclaw_from_git "$repo_dir"
     else
         # Clean up git wrapper if switching to npm
-        if [[ -x "$HOME/.local/bin/openclaw" ]]; then
+        if [[ -x "$HOME/.local/bin/openclaw" || -e "$HOME/.local/bin/openclaw-acp" ]]; then
             ui_info "Removing git wrapper (switching to npm)"
-            rm -f "$HOME/.local/bin/openclaw"
+            rm -f "$HOME/.local/bin/openclaw" "$HOME/.local/bin/openclaw-acp"
             ui_success "git wrapper removed"
         fi
 

--- a/src/acp/native-agent-result.ts
+++ b/src/acp/native-agent-result.ts
@@ -1,0 +1,66 @@
+import type { agentCommandFromIngress } from "../agents/agent-command.js";
+import { stripInternalRuntimeContext } from "../agents/internal-runtime-context.js";
+import { isSilentReplyPayloadText } from "../auto-reply/tokens.js";
+import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
+
+export type AgentResult = Awaited<ReturnType<typeof agentCommandFromIngress>>;
+
+function payloadText(parts: unknown): string {
+  if (!Array.isArray(parts)) {
+    return "";
+  }
+  return parts
+    .flatMap((part) => {
+      if (!part || typeof part !== "object") {
+        return [];
+      }
+      const payload = part as {
+        isCommentary?: unknown;
+        isError?: unknown;
+        isReasoning?: unknown;
+        text?: unknown;
+        visible?: unknown;
+      };
+      return payload.isCommentary !== true &&
+        payload.isError !== true &&
+        payload.isReasoning !== true &&
+        payload.visible !== false &&
+        typeof payload.text === "string"
+        ? [payload.text]
+        : [];
+    })
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+export function finalVisibleText(result: AgentResult | undefined): string {
+  const text = result?.meta.finalAssistantVisibleText ?? payloadText(result?.payloads);
+  const normalized = stripInternalRuntimeContext(stripInlineDirectiveTagsForDisplay(text).text);
+  return isSilentReplyPayloadText(normalized) ? "" : normalized;
+}
+
+export function agentResultError(result: AgentResult | undefined): Error | undefined {
+  if (!result) {
+    return new Error("OpenClaw agent returned no result");
+  }
+  const errorPayload = result.payloads?.find(
+    (payload) => (payload as { isError?: unknown }).isError === true,
+  ) as { text?: unknown } | undefined;
+  const message =
+    result.meta.error?.message ??
+    (typeof errorPayload?.text === "string" && errorPayload.text.trim()
+      ? errorPayload.text.trim()
+      : undefined);
+  if (result.meta.stopReason === "timeout" || result.meta.timeoutPhase !== undefined) {
+    return new Error(message ?? "OpenClaw agent timed out");
+  }
+  if (
+    result.meta.aborted === true ||
+    result.meta.stopReason === "error" ||
+    result.meta.error !== undefined ||
+    errorPayload
+  ) {
+    return new Error(message ?? "OpenClaw agent run failed");
+  }
+  return undefined;
+}

--- a/src/acp/native-agent.test.ts
+++ b/src/acp/native-agent.test.ts
@@ -1,0 +1,339 @@
+import { PROTOCOL_VERSION, type AgentSideConnection } from "@agentclientprotocol/sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  registerExecApprovalRequestForHostOrThrow,
+  resolveRegisteredExecApprovalDecision,
+} from "../agents/bash-tools.exec-approval-request.js";
+import type { AgentCommandIngressOpts } from "../agents/command/types.js";
+import { runWithLocalExecApprovalHandler } from "../agents/local-exec-approval-broker.js";
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import { isEmbeddedMode } from "../infra/embedded-mode.js";
+import { AcpNativeAgent } from "./native-agent.js";
+
+function createHarness(
+  executeAgent: (...args: never[]) => Promise<unknown>,
+  requestPermission = vi.fn(async () => ({
+    outcome: { outcome: "selected" as const, optionId: "allow-once" },
+  })),
+  deps: {
+    sessionCreateRateLimit?: {
+      maxRequests?: number;
+      windowMs?: number;
+    };
+  } = {},
+) {
+  const updates: unknown[] = [];
+  let listener: ((event: AgentEventPayload) => void) | undefined;
+  const connection = {
+    requestPermission,
+    sessionUpdate: vi.fn(async (update: unknown) => {
+      updates.push(update);
+    }),
+  } as unknown as AgentSideConnection;
+  let id = 0;
+  const agent = new AcpNativeAgent(connection, {
+    executeAgent: executeAgent as never,
+    createId: () => `id-${++id}`,
+    resolveAgentId: () => "main",
+    subscribeAgentEvents: (next) => {
+      listener = next;
+      return () => {
+        listener = undefined;
+      };
+    },
+    ...deps,
+  });
+  agent.start();
+  return {
+    agent,
+    connection,
+    requestPermission,
+    updates,
+    emit: (event: AgentEventPayload) => listener?.(event),
+  };
+}
+
+afterEach(() => {
+  delete process.env.BUZZ_PRIVATE_KEY;
+});
+
+describe("AcpNativeAgent", () => {
+  it("runs the canonical agent in-process with the inherited environment", async () => {
+    process.env.BUZZ_PRIVATE_KEY = "test-buzz-key";
+    const harnessRef: { current?: ReturnType<typeof createHarness> } = {};
+    const executeAgent = vi.fn(async (opts: { runId: string }) => {
+      expect(process.env.BUZZ_PRIVATE_KEY).toBe("test-buzz-key");
+      harnessRef.current?.emit({
+        runId: opts.runId,
+        seq: 1,
+        stream: "assistant",
+        ts: Date.now(),
+        data: { delta: "raw internal stream" },
+      });
+      return {
+        payloads: [{ text: "fallback reply" }],
+        meta: { finalAssistantVisibleText: "[[reply_to_current]]local reply" },
+      };
+    });
+    const harness = createHarness(executeAgent);
+    harnessRef.current = harness;
+
+    expect(
+      harness.agent.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      }),
+    ).toMatchObject({
+      protocolVersion: PROTOCOL_VERSION,
+      agentCapabilities: {
+        promptCapabilities: { image: true, embeddedContext: true },
+        sessionCapabilities: { close: {} },
+      },
+      authMethods: [],
+    });
+    const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+
+    await expect(
+      harness.agent.prompt({
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "reply through Buzz" }],
+      }),
+    ).resolves.toEqual({ stopReason: "end_turn" });
+
+    expect(executeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "reply through Buzz",
+        sessionKey: `agent:main:acp:${session.sessionId}`,
+        cwd: "/tmp/project",
+        deliver: false,
+        senderIsOwner: false,
+        allowModelOverride: false,
+        channel: "webchat",
+      }),
+      expect.any(Object),
+    );
+    expect(harness.updates).toContainEqual({
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "local reply" },
+      },
+    });
+    expect(JSON.stringify(harness.updates)).not.toContain("raw internal stream");
+    await harness.agent.shutdown();
+    expect(isEmbeddedMode()).toBe(false);
+  });
+
+  it("suppresses silent replies and rejects failed agent results", async () => {
+    const silentHarness = createHarness(
+      vi.fn(async () => ({
+        payloads: [{ text: "fallback must not leak" }],
+        meta: { finalAssistantVisibleText: "NO_REPLY" },
+      })),
+    );
+    const silentSession = silentHarness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+
+    await expect(
+      silentHarness.agent.prompt({
+        sessionId: silentSession.sessionId,
+        prompt: [{ type: "text", text: "stay silent" }],
+      }),
+    ).resolves.toEqual({ stopReason: "end_turn" });
+    expect(silentHarness.updates).toEqual([]);
+    await silentHarness.agent.shutdown();
+
+    const failedHarness = createHarness(
+      vi.fn(async () => ({
+        payloads: [{ text: "provider exploded", isError: true }],
+        meta: { stopReason: "error", error: { message: "provider exploded" } },
+      })),
+    );
+    const failedSession = failedHarness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+
+    await expect(
+      failedHarness.agent.prompt({
+        sessionId: failedSession.sessionId,
+        prompt: [{ type: "text", text: "fail" }],
+      }),
+    ).rejects.toThrow("provider exploded");
+    expect(failedHarness.updates).toEqual([]);
+    await failedHarness.agent.shutdown();
+  });
+
+  it("advertises model setup to ACP clients with terminal authentication", async () => {
+    const harness = createHarness(vi.fn(async () => ({ payloads: [], meta: {} })));
+
+    expect(
+      harness.agent.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: { auth: { terminal: true } },
+      }),
+    ).toMatchObject({
+      authMethods: [
+        {
+          id: "openclaw-model-setup",
+          type: "terminal",
+          args: ["--configure-model"],
+        },
+      ],
+    });
+
+    await harness.agent.shutdown();
+  });
+
+  it("relays exec approvals through ACP instead of calling a Gateway", async () => {
+    const executeAgent = vi.fn(
+      async (opts: AgentCommandIngressOpts) =>
+        await runWithLocalExecApprovalHandler({
+          handler: opts.localExecApprovalHandler,
+          signal: opts.abortSignal,
+          run: async () => {
+            const registration = await registerExecApprovalRequestForHostOrThrow({
+              approvalId: "approval-1",
+              command: "buzz messages send --message hello",
+              env: { BUZZ_PRIVATE_KEY: "must-not-leak" },
+              workdir: "/tmp/project",
+              host: "gateway",
+              security: "allowlist",
+              ask: "always",
+              commandHighlighting: false,
+            });
+            const decision = await resolveRegisteredExecApprovalDecision({
+              approvalId: registration.id,
+              preResolvedDecision: registration.finalDecision,
+            });
+            return { payloads: [{ text: decision }], meta: {} };
+          },
+        }),
+    );
+    const harness = createHarness(executeAgent);
+    const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+
+    await harness.agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "send a reply" }],
+    });
+
+    expect(harness.requestPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: session.sessionId,
+        toolCall: expect.objectContaining({
+          kind: "execute",
+          rawInput: expect.objectContaining({
+            command: "buzz messages send --message hello",
+          }),
+        }),
+      }),
+    );
+    expect(JSON.stringify(harness.requestPermission.mock.calls)).not.toContain("must-not-leak");
+    await harness.agent.shutdown();
+  });
+
+  it("cancels an active prompt and closes its session deterministically", async () => {
+    const executeAgent = vi.fn(
+      async (opts: { abortSignal?: AbortSignal }) =>
+        await new Promise((resolve) => {
+          opts.abortSignal?.addEventListener("abort", () => resolve({ payloads: [], meta: {} }), {
+            once: true,
+          });
+        }),
+    );
+    const harness = createHarness(executeAgent);
+    const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+    const prompt = harness.agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "wait" }],
+    });
+    await vi.waitFor(() => expect(executeAgent).toHaveBeenCalledOnce());
+
+    harness.agent.cancel({ sessionId: session.sessionId });
+
+    await expect(prompt).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(harness.agent.closeSession({ sessionId: session.sessionId })).resolves.toEqual({});
+    await expect(
+      harness.agent.prompt({
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "again" }],
+      }),
+    ).rejects.toMatchObject({ code: -32602 });
+    await harness.agent.shutdown();
+  });
+
+  it.each(["close", "shutdown"] as const)(
+    "does not start a queued prompt after session %s teardown begins",
+    async (teardown) => {
+      let releaseFirst: (() => void) | undefined;
+      const executeAgent = vi.fn(
+        async () =>
+          await new Promise<{ payloads: never[]; meta: Record<string, never> }>((resolve) => {
+            releaseFirst = () => resolve({ payloads: [], meta: {} });
+          }),
+      );
+      const harness = createHarness(executeAgent);
+      const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+      const first = harness.agent.prompt({
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "first" }],
+      });
+      await vi.waitFor(() => expect(executeAgent).toHaveBeenCalledOnce());
+
+      const second = harness.agent.prompt({
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "second" }],
+      });
+      const secondResult = expect(second).rejects.toMatchObject({ code: -32602 });
+      const teardownResult =
+        teardown === "close"
+          ? harness.agent.closeSession({ sessionId: session.sessionId })
+          : harness.agent.shutdown();
+
+      releaseFirst?.();
+
+      await expect(first).resolves.toEqual({ stopReason: "cancelled" });
+      await secondResult;
+      await teardownResult;
+      expect(executeAgent).toHaveBeenCalledTimes(1);
+      if (teardown === "close") {
+        await harness.agent.shutdown();
+      }
+    },
+  );
+
+  it("rate limits excessive native session creation bursts", async () => {
+    const harness = createHarness(
+      vi.fn(async () => ({ payloads: [], meta: {} })),
+      undefined,
+      {
+        sessionCreateRateLimit: {
+          maxRequests: 1,
+          windowMs: 60_000,
+        },
+      },
+    );
+
+    expect(() => harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] })).not.toThrow();
+    expect(() => harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] })).toThrow(
+      /session creation rate limit exceeded/i,
+    );
+
+    await harness.agent.shutdown();
+  });
+
+  it("rejects unsupported client-owned runtime surfaces", async () => {
+    const harness = createHarness(vi.fn(async () => ({ payloads: [], meta: {} })));
+
+    expect(() =>
+      harness.agent.newSession({
+        cwd: "relative",
+        mcpServers: [],
+      }),
+    ).toThrow("cwd must be an absolute path");
+    expect(() =>
+      harness.agent.newSession({
+        cwd: "/tmp/project",
+        mcpServers: [{ name: "extra", command: "server", args: [], env: [] }],
+      }),
+    ).toThrow("client-supplied MCP servers are not supported");
+    await harness.agent.shutdown();
+  });
+});

--- a/src/acp/native-agent.test.ts
+++ b/src/acp/native-agent.test.ts
@@ -1,4 +1,4 @@
-import { PROTOCOL_VERSION, type AgentSideConnection } from "@agentclientprotocol/sdk";
+import { PROTOCOL_VERSION, RequestError, type AgentSideConnection } from "@agentclientprotocol/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   registerExecApprovalRequestForHostOrThrow,
@@ -153,14 +153,45 @@ describe("AcpNativeAgent", () => {
     );
     const failedSession = failedHarness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
 
-    await expect(
-      failedHarness.agent.prompt({
+    const failure = await failedHarness.agent
+      .prompt({
         sessionId: failedSession.sessionId,
         prompt: [{ type: "text", text: "fail" }],
-      }),
-    ).rejects.toThrow("provider exploded");
+      })
+      .catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(RequestError);
+    expect(failure).toMatchObject({
+      code: -32603,
+      data: { kind: "agent_execution_failed" },
+    });
+    expect((failure as Error).message).toContain("agent prompt failed: provider exploded");
     expect(failedHarness.updates).toEqual([]);
     await failedHarness.agent.shutdown();
+  });
+
+  it("redacts and bounds native prompt failures before returning them over ACP", async () => {
+    const secret = `sk-${"a".repeat(48)}`; // pragma: allowlist secret
+    const harness = createHarness(
+      vi.fn(async () => {
+        throw new Error(`provider\u001b[2K failed with token ${secret} ${"x".repeat(2_000)}`);
+      }),
+    );
+    const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+
+    const failure = await harness.agent
+      .prompt({
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "fail safely" }],
+      })
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(RequestError);
+    expect((failure as RequestError).code).toBe(-32603);
+    expect((failure as Error).message).toContain("agent prompt failed: provider failed");
+    expect((failure as Error).message).not.toContain(secret);
+    expect((failure as Error).message).not.toContain("\u001b");
+    expect((failure as Error).message.length).toBeLessThanOrEqual(1_100);
+    await harness.agent.shutdown();
   });
 
   it("advertises model setup to ACP clients with terminal authentication", async () => {

--- a/src/acp/native-agent.test.ts
+++ b/src/acp/native-agent.test.ts
@@ -10,6 +10,7 @@ import type { AgentEventPayload } from "../infra/agent-events.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
 import { getEmbeddedPluginApprovalBroker } from "../infra/embedded-plugin-approval-broker.js";
 import { PLUGIN_APPROVAL_DETAIL_MAX_LENGTH } from "../infra/plugin-approvals.js";
+import { isAcpSessionKey } from "../sessions/session-key-utils.js";
 import { AcpNativeAgent } from "./native-agent.js";
 
 function createHarness(
@@ -106,7 +107,7 @@ describe("AcpNativeAgent", () => {
     expect(executeAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "reply through Buzz",
-        sessionKey: `agent:main:acp:${session.sessionId}`,
+        sessionKey: `agent:main:native-acp:${session.sessionId}`,
         cwd: "/tmp/project",
         deliver: false,
         senderIsOwner: false,
@@ -115,6 +116,8 @@ describe("AcpNativeAgent", () => {
       }),
       expect.any(Object),
     );
+    const ingress = executeAgent.mock.calls[0]?.[0] as AgentCommandIngressOpts;
+    expect(isAcpSessionKey(ingress.sessionKey)).toBe(false);
     expect(harness.updates).toContainEqual({
       sessionId: session.sessionId,
       update: {

--- a/src/acp/native-agent.test.ts
+++ b/src/acp/native-agent.test.ts
@@ -8,6 +8,8 @@ import type { AgentCommandIngressOpts } from "../agents/command/types.js";
 import { runWithLocalExecApprovalHandler } from "../agents/local-exec-approval-broker.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
+import { getEmbeddedPluginApprovalBroker } from "../infra/embedded-plugin-approval-broker.js";
+import { PLUGIN_APPROVAL_DETAIL_MAX_LENGTH } from "../infra/plugin-approvals.js";
 import { AcpNativeAgent } from "./native-agent.js";
 
 function createHarness(
@@ -229,6 +231,82 @@ describe("AcpNativeAgent", () => {
     );
     expect(JSON.stringify(harness.requestPermission.mock.calls)).not.toContain(commandSecret);
     expect(JSON.stringify(harness.requestPermission.mock.calls)).not.toContain("must-not-leak");
+    await harness.agent.shutdown();
+  });
+
+  it("projects plugin approvals through the canonical safe presentation", async () => {
+    const secret = `ghp_${"a".repeat(100)}`; // pragma: allowlist secret
+    let decision: string | null | undefined;
+    const executeAgent = vi.fn(async (opts: AgentCommandIngressOpts) => {
+      await Promise.resolve();
+      const broker = getEmbeddedPluginApprovalBroker();
+      if (!broker) {
+        throw new Error("expected embedded plugin approval broker");
+      }
+      decision = (
+        await broker.request({
+          request: {
+            title: `Deploy\u202Eprod ${secret}`,
+            description: `Review\u0000\n${secret}`,
+            detail: `${"x".repeat(PLUGIN_APPROVAL_DETAIL_MAX_LENGTH + 1)}\u202E`,
+            pluginId: `plugin\u202E${secret}`,
+            toolName: `tool\n${secret}`,
+            toolCallId: "plugin-tool-1",
+          },
+          timeoutMs: 1_000,
+          signal: opts.abortSignal,
+        })
+      ).decision;
+      return { payloads: [], meta: {} };
+    });
+    const harness = createHarness(executeAgent);
+    const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+
+    await harness.agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "run plugin tool" }],
+    });
+
+    expect(decision).toBe("allow-once");
+    const serialized = JSON.stringify(harness.requestPermission.mock.calls);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain("\u202E");
+    expect(serialized).not.toContain("\u0000");
+    expect(serialized).toContain("\\\\u{202E}");
+    expect(serialized).toContain("[truncated]");
+    await harness.agent.shutdown();
+  });
+
+  it("denies plugin approvals that exceed canonical presentation limits", async () => {
+    let decision: string | null | undefined;
+    const executeAgent = vi.fn(async (opts: AgentCommandIngressOpts) => {
+      await Promise.resolve();
+      const broker = getEmbeddedPluginApprovalBroker();
+      if (!broker) {
+        throw new Error("expected embedded plugin approval broker");
+      }
+      decision = (
+        await broker.request({
+          request: {
+            title: "x".repeat(81),
+            description: "bounded description",
+          },
+          timeoutMs: 1_000,
+          signal: opts.abortSignal,
+        })
+      ).decision;
+      return { payloads: [], meta: {} };
+    });
+    const harness = createHarness(executeAgent);
+    const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+
+    await harness.agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "run oversized plugin tool" }],
+    });
+
+    expect(decision).toBe("deny");
+    expect(harness.requestPermission).not.toHaveBeenCalled();
     await harness.agent.shutdown();
   });
 

--- a/src/acp/native-agent.test.ts
+++ b/src/acp/native-agent.test.ts
@@ -20,6 +20,7 @@ function createHarness(
       maxRequests?: number;
       windowMs?: number;
     };
+    abortSettleTimeoutMs?: number;
   } = {},
 ) {
   const updates: unknown[] = [];
@@ -182,6 +183,7 @@ describe("AcpNativeAgent", () => {
   });
 
   it("relays exec approvals through ACP instead of calling a Gateway", async () => {
+    const commandSecret = "sk-abcdefghijklmnopqrstuv"; // pragma: allowlist secret
     const executeAgent = vi.fn(
       async (opts: AgentCommandIngressOpts) =>
         await runWithLocalExecApprovalHandler({
@@ -190,7 +192,7 @@ describe("AcpNativeAgent", () => {
           run: async () => {
             const registration = await registerExecApprovalRequestForHostOrThrow({
               approvalId: "approval-1",
-              command: "buzz messages send --message hello",
+              command: `buzz messages send --token ${commandSecret} --message hello`,
               env: { BUZZ_PRIVATE_KEY: "must-not-leak" },
               workdir: "/tmp/project",
               host: "gateway",
@@ -220,11 +222,12 @@ describe("AcpNativeAgent", () => {
         toolCall: expect.objectContaining({
           kind: "execute",
           rawInput: expect.objectContaining({
-            command: "buzz messages send --message hello",
+            command: expect.stringContaining("buzz messages send"),
           }),
         }),
       }),
     );
+    expect(JSON.stringify(harness.requestPermission.mock.calls)).not.toContain(commandSecret);
     expect(JSON.stringify(harness.requestPermission.mock.calls)).not.toContain("must-not-leak");
     await harness.agent.shutdown();
   });
@@ -293,6 +296,30 @@ describe("AcpNativeAgent", () => {
       await secondResult;
       await teardownResult;
       expect(executeAgent).toHaveBeenCalledTimes(1);
+      if (teardown === "close") {
+        await harness.agent.shutdown();
+      }
+    },
+  );
+
+  it.each(["close", "shutdown"] as const)(
+    "bounds session %s when the executor ignores abort",
+    async (teardown) => {
+      const executeAgent = vi.fn(async () => await new Promise<never>(() => {}));
+      const harness = createHarness(executeAgent, undefined, { abortSettleTimeoutMs: 5 });
+      const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+      void harness.agent.prompt({
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "wait forever" }],
+      });
+      await vi.waitFor(() => expect(executeAgent).toHaveBeenCalledOnce());
+
+      const teardownResult =
+        teardown === "close"
+          ? harness.agent.closeSession({ sessionId: session.sessionId })
+          : harness.agent.shutdown();
+
+      await expect(teardownResult).resolves.toEqual(teardown === "close" ? {} : undefined);
       if (teardown === "close") {
         await harness.agent.shutdown();
       }

--- a/src/acp/native-agent.test.ts
+++ b/src/acp/native-agent.test.ts
@@ -245,6 +245,7 @@ describe("AcpNativeAgent", () => {
       }
       decision = (
         await broker.request({
+          runId: opts.runId,
           request: {
             title: `Deploy\u202Eprod ${secret}`,
             description: `Review\u0000\n${secret}`,
@@ -287,6 +288,7 @@ describe("AcpNativeAgent", () => {
       }
       decision = (
         await broker.request({
+          runId: opts.runId,
           request: {
             title: "x".repeat(81),
             description: "bounded description",
@@ -307,6 +309,53 @@ describe("AcpNativeAgent", () => {
 
     expect(decision).toBe("deny");
     expect(harness.requestPermission).not.toHaveBeenCalled();
+    await harness.agent.shutdown();
+  });
+
+  it("denies plugin approvals retained from an earlier native run", async () => {
+    const runIds: string[] = [];
+    let releaseSecond: (() => void) | undefined;
+    const executeAgent = vi.fn(async (opts: AgentCommandIngressOpts) => {
+      runIds.push(opts.runId ?? "");
+      if (runIds.length === 2) {
+        await new Promise<void>((resolve) => {
+          releaseSecond = resolve;
+        });
+      }
+      return { payloads: [], meta: {} };
+    });
+    const harness = createHarness(executeAgent);
+    const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+
+    await harness.agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "first" }],
+    });
+    const second = harness.agent.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: "second" }],
+    });
+    await vi.waitFor(() => expect(executeAgent).toHaveBeenCalledTimes(2));
+    const broker = getEmbeddedPluginApprovalBroker();
+    if (!broker) {
+      throw new Error("expected embedded plugin approval broker");
+    }
+
+    await expect(
+      broker.request({
+        runId: runIds[0],
+        request: {
+          title: "stale approval",
+          description: "must not reach the host",
+          sessionKey: `agent:main:acp:${session.sessionId}`,
+        },
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toMatchObject({ decision: "deny" });
+    expect(harness.requestPermission).not.toHaveBeenCalled();
+
+    releaseSecond?.();
+    await second;
     await harness.agent.shutdown();
   });
 
@@ -377,6 +426,65 @@ describe("AcpNativeAgent", () => {
       if (teardown === "close") {
         await harness.agent.shutdown();
       }
+    },
+  );
+
+  it("bounds prompt replacement when the superseded executor ignores abort", async () => {
+    const executeAgent = vi.fn(async () => await new Promise<never>(() => {}));
+    const harness = createHarness(executeAgent, undefined, { abortSettleTimeoutMs: 5 });
+    const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+    void harness.agent
+      .prompt({
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "first" }],
+      })
+      .catch(() => {});
+    await vi.waitFor(() => expect(executeAgent).toHaveBeenCalledOnce());
+
+    await expect(
+      harness.agent.prompt({
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "replacement" }],
+      }),
+    ).resolves.toEqual({ stopReason: "cancelled" });
+    expect(executeAgent).toHaveBeenCalledOnce();
+    await harness.agent.shutdown();
+  });
+
+  it.each(["cancel", "close"] as const)(
+    "drops late thought events after native session %s",
+    async (teardown) => {
+      let runId = "";
+      const executeAgent = vi.fn(async (opts: AgentCommandIngressOpts) => {
+        runId = opts.runId ?? "";
+        return await new Promise<never>(() => {});
+      });
+      const harness = createHarness(executeAgent, undefined, { abortSettleTimeoutMs: 5 });
+      const session = harness.agent.newSession({ cwd: "/tmp/project", mcpServers: [] });
+      void harness.agent
+        .prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "wait" }],
+        })
+        .catch(() => {});
+      await vi.waitFor(() => expect(executeAgent).toHaveBeenCalledOnce());
+
+      if (teardown === "cancel") {
+        harness.agent.cancel({ sessionId: session.sessionId });
+      } else {
+        await harness.agent.closeSession({ sessionId: session.sessionId });
+      }
+      harness.emit({
+        runId,
+        seq: 1,
+        stream: "assistant",
+        ts: Date.now(),
+        data: { delta: "late thought" },
+      });
+      await Promise.resolve();
+
+      expect(harness.updates).toEqual([]);
+      await harness.agent.shutdown();
     },
   );
 

--- a/src/acp/native-agent.ts
+++ b/src/acp/native-agent.ts
@@ -24,9 +24,7 @@ import {
 import { agentCommandFromIngress } from "../agents/agent-command.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { resolveEmbeddedAbortSettleTimeoutMs } from "../agents/embedded-agent-runner/run/attempt.abort-settle-timeout.js";
-import { stripInternalRuntimeContext } from "../agents/internal-runtime-context.js";
 import type { LocalExecApprovalRequest } from "../agents/local-exec-approval-broker.js";
-import { isSilentReplyPayloadText } from "../auto-reply/tokens.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { type AgentEventPayload, onAgentEvent } from "../infra/agent-events.js";
 import { buildApprovalPresentation } from "../infra/approval-presentation.js";
@@ -50,9 +48,9 @@ import type {
 } from "../infra/plugin-approvals.js";
 import { toAgentStoreSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import { extractAttachmentsFromPrompt, extractTextFromPrompt } from "./event-mapper.js";
+import { agentResultError, finalVisibleText, type AgentResult } from "./native-agent-result.js";
 import {
   buildAcpPermissionRequest,
   resolveGatewayDecisionFromPermissionOutcome,
@@ -72,7 +70,6 @@ const silentRuntime: RuntimeEnv = {
 };
 
 type AgentExecutor = typeof agentCommandFromIngress;
-type AgentResult = Awaited<ReturnType<AgentExecutor>>;
 
 type NativeSession = {
   id: string;
@@ -99,66 +96,6 @@ type NativeAgentDependencies = {
   };
   abortSettleTimeoutMs?: number;
 };
-
-function payloadText(parts: unknown): string {
-  if (!Array.isArray(parts)) {
-    return "";
-  }
-  return parts
-    .flatMap((part) => {
-      if (!part || typeof part !== "object") {
-        return [];
-      }
-      const payload = part as {
-        isCommentary?: unknown;
-        isError?: unknown;
-        isReasoning?: unknown;
-        text?: unknown;
-        visible?: unknown;
-      };
-      return payload.isCommentary !== true &&
-        payload.isError !== true &&
-        payload.isReasoning !== true &&
-        payload.visible !== false &&
-        typeof payload.text === "string"
-        ? [payload.text]
-        : [];
-    })
-    .filter(Boolean)
-    .join("\n\n");
-}
-
-function finalVisibleText(result: AgentResult | undefined): string {
-  const text = result?.meta.finalAssistantVisibleText ?? payloadText(result?.payloads);
-  const normalized = stripInternalRuntimeContext(stripInlineDirectiveTagsForDisplay(text).text);
-  return isSilentReplyPayloadText(normalized) ? "" : normalized;
-}
-
-function agentResultError(result: AgentResult | undefined): Error | undefined {
-  if (!result) {
-    return new Error("OpenClaw agent returned no result");
-  }
-  const errorPayload = result.payloads?.find(
-    (payload) => (payload as { isError?: unknown }).isError === true,
-  ) as { text?: unknown } | undefined;
-  const message =
-    result.meta.error?.message ??
-    (typeof errorPayload?.text === "string" && errorPayload.text.trim()
-      ? errorPayload.text.trim()
-      : undefined);
-  if (result.meta.stopReason === "timeout" || result.meta.timeoutPhase !== undefined) {
-    return new Error(message ?? "OpenClaw agent timed out");
-  }
-  if (
-    result.meta.aborted === true ||
-    result.meta.stopReason === "error" ||
-    result.meta.error !== undefined ||
-    errorPayload
-  ) {
-    return new Error(message ?? "OpenClaw agent run failed");
-  }
-  return undefined;
-}
 
 function permissionOptions(decisions: readonly ExecApprovalDecision[]): PermissionOption[] {
   return decisions.map((decision) => ({

--- a/src/acp/native-agent.ts
+++ b/src/acp/native-agent.ts
@@ -29,6 +29,7 @@ import type { LocalExecApprovalRequest } from "../agents/local-exec-approval-bro
 import { isSilentReplyPayloadText } from "../auto-reply/tokens.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { type AgentEventPayload, onAgentEvent } from "../infra/agent-events.js";
+import { buildApprovalPresentation } from "../infra/approval-presentation.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import {
   clearEmbeddedPluginApprovalBroker,
@@ -178,23 +179,32 @@ function permissionOptions(decisions: readonly ExecApprovalDecision[]): Permissi
 function pluginPermissionRequest(
   sessionId: string,
   approval: PluginApprovalRequest,
-): RequestPermissionRequest {
+): RequestPermissionRequest | null {
   const request = approval.request;
-  const toolName = request.toolName ?? request.pluginId ?? "plugin";
-  const options = permissionOptions(resolveCanonicalPluginApprovalRequestAllowedDecisions(request));
+  const allowedDecisions = resolveCanonicalPluginApprovalRequestAllowedDecisions(request);
+  const presentation = buildApprovalPresentation({
+    kind: "plugin",
+    request,
+    allowedDecisions,
+  });
+  if (!presentation || presentation.kind !== "plugin") {
+    return null;
+  }
+  const toolName = presentation.toolName ?? presentation.pluginId ?? "plugin";
+  const options = permissionOptions(allowedDecisions);
   return {
     sessionId,
     toolCall: {
       toolCallId: request.toolCallId ?? approval.id,
-      title: request.title,
+      title: presentation.title,
       kind: "other",
       status: "pending",
       rawInput: {
         name: toolName,
         approvalId: approval.id,
-        description: request.description,
-        ...(request.detail ? { detail: request.detail } : {}),
-        ...(request.pluginId ? { pluginId: request.pluginId } : {}),
+        description: presentation.description,
+        ...(presentation.detail ? { detail: presentation.detail } : {}),
+        ...(presentation.pluginId ? { pluginId: presentation.pluginId } : {}),
       },
       _meta: {
         toolName,
@@ -691,6 +701,10 @@ export class AcpNativeAgent implements Agent {
       return;
     }
     const permission = pluginPermissionRequest(session.id, approval);
+    if (!permission) {
+      this.pluginApprovalBroker.resolve(approval.id, "deny");
+      return;
+    }
     const controller = new AbortController();
     const timeout = setTimeout(
       () => controller.abort(new Error(`Plugin approval "${approval.id}" expired`)),

--- a/src/acp/native-agent.ts
+++ b/src/acp/native-agent.ts
@@ -23,6 +23,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import { agentCommandFromIngress } from "../agents/agent-command.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import { resolveEmbeddedAbortSettleTimeoutMs } from "../agents/embedded-agent-runner/run/attempt.abort-settle-timeout.js";
 import { stripInternalRuntimeContext } from "../agents/internal-runtime-context.js";
 import type { LocalExecApprovalRequest } from "../agents/local-exec-approval-broker.js";
 import { isSilentReplyPayloadText } from "../auto-reply/tokens.js";
@@ -93,6 +94,7 @@ type NativeAgentDependencies = {
     maxRequests?: number;
     windowMs?: number;
   };
+  abortSettleTimeoutMs?: number;
 };
 
 function payloadText(parts: unknown): string {
@@ -252,6 +254,7 @@ export class AcpNativeAgent implements Agent {
   private readonly resolveAgentId: () => string;
   private readonly runtime: RuntimeEnv;
   private readonly sessionCreateRateLimiter: FixedWindowRateLimiter;
+  private readonly abortSettleTimeoutMs: number;
   private readonly sessions = new Map<string, NativeSession>();
   private readonly activeTurns = new Map<string, ActiveTurn>();
   private readonly admittedPrompts = new Map<string, Set<Promise<PromptResponse>>>();
@@ -270,6 +273,7 @@ export class AcpNativeAgent implements Agent {
     this.subscribeAgentEvents = deps.subscribeAgentEvents ?? onAgentEvent;
     this.resolveAgentId = deps.resolveAgentId ?? (() => resolveDefaultAgentId(getRuntimeConfig()));
     this.runtime = deps.runtime ?? silentRuntime;
+    this.abortSettleTimeoutMs = deps.abortSettleTimeoutMs ?? resolveEmbeddedAbortSettleTimeoutMs();
     this.sessionCreateRateLimiter = createFixedWindowRateLimiter({
       maxRequests: resolveFixedWindowRateLimitInteger(
         deps.sessionCreateRateLimit?.maxRequests,
@@ -463,6 +467,30 @@ export class AcpNativeAgent implements Agent {
     return completions;
   }
 
+  private async waitForAdmittedPrompts(sessionId?: string): Promise<void> {
+    const completions = this.collectAdmittedPrompts(sessionId);
+    if (completions.length === 0) {
+      return;
+    }
+    let timeout: NodeJS.Timeout | undefined;
+    const outcome = await Promise.race([
+      Promise.allSettled(completions).then(() => "settled" as const),
+      new Promise<"timed_out">((resolve) => {
+        timeout = setTimeout(() => resolve("timed_out"), this.abortSettleTimeoutMs);
+        timeout.unref?.();
+      }),
+    ]);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    if (outcome === "timed_out") {
+      this.runtime.error(
+        `ACP native abort settle timed out after ${this.abortSettleTimeoutMs}ms` +
+          (sessionId ? ` for session ${sessionId}` : ""),
+      );
+    }
+  }
+
   async closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
     this.closingSessions.add(params.sessionId);
     const session = this.sessions.get(params.sessionId);
@@ -471,8 +499,9 @@ export class AcpNativeAgent implements Agent {
     }
     try {
       this.activeTurns.get(params.sessionId)?.controller.abort(new Error("ACP session closed"));
-      await Promise.allSettled(this.collectAdmittedPrompts(params.sessionId));
+      await this.waitForAdmittedPrompts(params.sessionId);
       this.activeTurns.delete(params.sessionId);
+      this.admittedPrompts.delete(params.sessionId);
       this.sessions.delete(params.sessionId);
       return {};
     } finally {
@@ -488,7 +517,7 @@ export class AcpNativeAgent implements Agent {
     for (const turn of this.activeTurns.values()) {
       turn.controller.abort(reason);
     }
-    await Promise.allSettled(this.collectAdmittedPrompts());
+    await this.waitForAdmittedPrompts();
     this.activeTurns.clear();
     this.admittedPrompts.clear();
     this.closingSessions.clear();

--- a/src/acp/native-agent.ts
+++ b/src/acp/native-agent.ts
@@ -21,6 +21,8 @@ import {
   type RequestPermissionRequest,
   type RequestPermissionResponse,
 } from "@agentclientprotocol/sdk";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { agentCommandFromIngress } from "../agents/agent-command.js";
 import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { resolveEmbeddedAbortSettleTimeoutMs } from "../agents/embedded-agent-runner/run/attempt.abort-settle-timeout.js";
@@ -35,6 +37,7 @@ import {
   EmbeddedPluginApprovalBroker,
   setEmbeddedPluginApprovalBroker,
 } from "../infra/embedded-plugin-approval-broker.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
 import {
   createFixedWindowRateLimiter,
@@ -58,6 +61,7 @@ import {
 import { ACP_AGENT_INFO } from "./types.js";
 
 const MAX_PROMPT_BYTES = 2 * 1024 * 1024;
+const MAX_ACP_PROMPT_ERROR_CHARS = 1_000;
 const SESSION_CREATE_RATE_LIMIT_DEFAULT_MAX_REQUESTS = 120;
 const SESSION_CREATE_RATE_LIMIT_DEFAULT_WINDOW_MS = 10_000;
 
@@ -68,6 +72,20 @@ const silentRuntime: RuntimeEnv = {
     throw new Error(`unexpected agent runtime exit ${code}`);
   },
 };
+
+function toAcpPromptRequestError(error: unknown): RequestError {
+  if (error instanceof RequestError) {
+    return error;
+  }
+  const detail = truncateUtf16Safe(
+    sanitizeTerminalText(formatErrorMessage(error)).trim(),
+    MAX_ACP_PROMPT_ERROR_CHARS,
+  );
+  return RequestError.internalError(
+    { kind: "agent_execution_failed" },
+    `agent prompt failed: ${detail || "unknown error"}`,
+  );
+}
 
 type AgentExecutor = typeof agentCommandFromIngress;
 
@@ -331,7 +349,9 @@ export class AcpNativeAgent implements Agent {
   }
 
   prompt(params: PromptRequest): Promise<PromptResponse> {
-    const completion = this.runAdmittedPrompt(params);
+    const completion = this.runAdmittedPrompt(params).catch((error: unknown) => {
+      throw toAcpPromptRequestError(error);
+    });
     const admitted = this.admittedPrompts.get(params.sessionId) ?? new Set();
     admitted.add(completion);
     this.admittedPrompts.set(params.sessionId, admitted);

--- a/src/acp/native-agent.ts
+++ b/src/acp/native-agent.ts
@@ -1,0 +1,690 @@
+/** Self-contained ACP agent backed by OpenClaw's canonical in-process runner. */
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import {
+  PROTOCOL_VERSION,
+  RequestError,
+  type Agent,
+  type AgentSideConnection,
+  type AuthenticateRequest,
+  type AuthenticateResponse,
+  type CancelNotification,
+  type CloseSessionRequest,
+  type CloseSessionResponse,
+  type InitializeRequest,
+  type InitializeResponse,
+  type NewSessionRequest,
+  type NewSessionResponse,
+  type PermissionOption,
+  type PromptRequest,
+  type PromptResponse,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+} from "@agentclientprotocol/sdk";
+import { agentCommandFromIngress } from "../agents/agent-command.js";
+import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import { stripInternalRuntimeContext } from "../agents/internal-runtime-context.js";
+import type { LocalExecApprovalRequest } from "../agents/local-exec-approval-broker.js";
+import { isSilentReplyPayloadText } from "../auto-reply/tokens.js";
+import { getRuntimeConfig } from "../config/config.js";
+import { type AgentEventPayload, onAgentEvent } from "../infra/agent-events.js";
+import { setEmbeddedMode } from "../infra/embedded-mode.js";
+import {
+  clearEmbeddedPluginApprovalBroker,
+  EmbeddedPluginApprovalBroker,
+  setEmbeddedPluginApprovalBroker,
+} from "../infra/embedded-plugin-approval-broker.js";
+import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
+import {
+  createFixedWindowRateLimiter,
+  resolveFixedWindowRateLimitInteger,
+  type FixedWindowRateLimiter,
+} from "../infra/fixed-window-rate-limit.js";
+import { resolveCanonicalPluginApprovalRequestAllowedDecisions } from "../infra/plugin-approval-canonical-decisions.js";
+import type {
+  PluginApprovalRequest,
+  PluginApprovalRequestPayload,
+} from "../infra/plugin-approvals.js";
+import { toAgentStoreSessionKey } from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
+import { extractAttachmentsFromPrompt, extractTextFromPrompt } from "./event-mapper.js";
+import {
+  buildAcpPermissionRequest,
+  resolveGatewayDecisionFromPermissionOutcome,
+} from "./permission-relay.js";
+import { ACP_AGENT_INFO } from "./types.js";
+
+const MAX_PROMPT_BYTES = 2 * 1024 * 1024;
+const SESSION_CREATE_RATE_LIMIT_DEFAULT_MAX_REQUESTS = 120;
+const SESSION_CREATE_RATE_LIMIT_DEFAULT_WINDOW_MS = 10_000;
+
+const silentRuntime: RuntimeEnv = {
+  log: () => {},
+  error: () => {},
+  exit: (code) => {
+    throw new Error(`unexpected agent runtime exit ${code}`);
+  },
+};
+
+type AgentExecutor = typeof agentCommandFromIngress;
+type AgentResult = Awaited<ReturnType<AgentExecutor>>;
+
+type NativeSession = {
+  id: string;
+  key: string;
+  cwd: string;
+  promptGeneration: number;
+};
+
+type ActiveTurn = {
+  controller: AbortController;
+  completion: Promise<PromptResponse>;
+};
+
+type NativeAgentDependencies = {
+  executeAgent?: AgentExecutor;
+  createId?: () => string;
+  subscribeAgentEvents?: typeof onAgentEvent;
+  resolveAgentId?: () => string;
+  runtime?: RuntimeEnv;
+  sessionCreateRateLimit?: {
+    maxRequests?: number;
+    windowMs?: number;
+  };
+};
+
+function payloadText(parts: unknown): string {
+  if (!Array.isArray(parts)) {
+    return "";
+  }
+  return parts
+    .flatMap((part) => {
+      if (!part || typeof part !== "object") {
+        return [];
+      }
+      const payload = part as {
+        isCommentary?: unknown;
+        isError?: unknown;
+        isReasoning?: unknown;
+        text?: unknown;
+        visible?: unknown;
+      };
+      return payload.isCommentary !== true &&
+        payload.isError !== true &&
+        payload.isReasoning !== true &&
+        payload.visible !== false &&
+        typeof payload.text === "string"
+        ? [payload.text]
+        : [];
+    })
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function finalVisibleText(result: AgentResult | undefined): string {
+  const text = result?.meta.finalAssistantVisibleText ?? payloadText(result?.payloads);
+  const normalized = stripInternalRuntimeContext(stripInlineDirectiveTagsForDisplay(text).text);
+  return isSilentReplyPayloadText(normalized) ? "" : normalized;
+}
+
+function agentResultError(result: AgentResult | undefined): Error | undefined {
+  if (!result) {
+    return new Error("OpenClaw agent returned no result");
+  }
+  const errorPayload = result.payloads?.find(
+    (payload) => (payload as { isError?: unknown }).isError === true,
+  ) as { text?: unknown } | undefined;
+  const message =
+    result.meta.error?.message ??
+    (typeof errorPayload?.text === "string" && errorPayload.text.trim()
+      ? errorPayload.text.trim()
+      : undefined);
+  if (result.meta.stopReason === "timeout" || result.meta.timeoutPhase !== undefined) {
+    return new Error(message ?? "OpenClaw agent timed out");
+  }
+  if (
+    result.meta.aborted === true ||
+    result.meta.stopReason === "error" ||
+    result.meta.error !== undefined ||
+    errorPayload
+  ) {
+    return new Error(message ?? "OpenClaw agent run failed");
+  }
+  return undefined;
+}
+
+function permissionOptions(decisions: readonly ExecApprovalDecision[]): PermissionOption[] {
+  return decisions.map((decision) => ({
+    optionId: decision,
+    name:
+      decision === "allow-once"
+        ? "Allow once"
+        : decision === "allow-always"
+          ? "Allow always"
+          : "Deny",
+    kind:
+      decision === "allow-once"
+        ? "allow_once"
+        : decision === "allow-always"
+          ? "allow_always"
+          : "reject_once",
+  }));
+}
+
+function pluginPermissionRequest(
+  sessionId: string,
+  approval: PluginApprovalRequest,
+): RequestPermissionRequest {
+  const request = approval.request;
+  const toolName = request.toolName ?? request.pluginId ?? "plugin";
+  const options = permissionOptions(resolveCanonicalPluginApprovalRequestAllowedDecisions(request));
+  return {
+    sessionId,
+    toolCall: {
+      toolCallId: request.toolCallId ?? approval.id,
+      title: request.title,
+      kind: "other",
+      status: "pending",
+      rawInput: {
+        name: toolName,
+        approvalId: approval.id,
+        description: request.description,
+        ...(request.detail ? { detail: request.detail } : {}),
+        ...(request.pluginId ? { pluginId: request.pluginId } : {}),
+      },
+      _meta: {
+        toolName,
+        approvalId: approval.id,
+      },
+    },
+    options,
+  };
+}
+
+async function requestPermissionWithSignal(params: {
+  connection: AgentSideConnection;
+  request: RequestPermissionRequest;
+  signal: AbortSignal;
+}): Promise<RequestPermissionResponse | undefined> {
+  if (params.signal.aborted) {
+    return undefined;
+  }
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<undefined>((resolve) => {
+    onAbort = () => resolve(undefined);
+    params.signal.addEventListener("abort", onAbort, { once: true });
+    if (params.signal.aborted) {
+      onAbort();
+    }
+  });
+  try {
+    return await Promise.race([params.connection.requestPermission(params.request), aborted]);
+  } catch {
+    return undefined;
+  } finally {
+    if (onAbort) {
+      params.signal.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
+function resolveSessionForPluginApproval(
+  sessions: Iterable<NativeSession>,
+  request: PluginApprovalRequestPayload,
+): NativeSession | undefined {
+  if (request.sessionKey) {
+    for (const session of sessions) {
+      if (session.key === request.sessionKey) {
+        return session;
+      }
+    }
+  }
+  const candidates = [...sessions];
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
+export class AcpNativeAgent implements Agent {
+  private readonly executeAgent: AgentExecutor;
+  private readonly createId: () => string;
+  private readonly subscribeAgentEvents: typeof onAgentEvent;
+  private readonly resolveAgentId: () => string;
+  private readonly runtime: RuntimeEnv;
+  private readonly sessionCreateRateLimiter: FixedWindowRateLimiter;
+  private readonly sessions = new Map<string, NativeSession>();
+  private readonly activeTurns = new Map<string, ActiveTurn>();
+  private readonly admittedPrompts = new Map<string, Set<Promise<PromptResponse>>>();
+  private readonly closingSessions = new Set<string>();
+  private readonly pluginApprovalBroker = new EmbeddedPluginApprovalBroker();
+  private unsubscribePluginApprovals?: () => void;
+  private started = false;
+  private stopping = false;
+
+  constructor(
+    private readonly connection: AgentSideConnection,
+    deps: NativeAgentDependencies = {},
+  ) {
+    this.executeAgent = deps.executeAgent ?? agentCommandFromIngress;
+    this.createId = deps.createId ?? randomUUID;
+    this.subscribeAgentEvents = deps.subscribeAgentEvents ?? onAgentEvent;
+    this.resolveAgentId = deps.resolveAgentId ?? (() => resolveDefaultAgentId(getRuntimeConfig()));
+    this.runtime = deps.runtime ?? silentRuntime;
+    this.sessionCreateRateLimiter = createFixedWindowRateLimiter({
+      maxRequests: resolveFixedWindowRateLimitInteger(
+        deps.sessionCreateRateLimit?.maxRequests,
+        SESSION_CREATE_RATE_LIMIT_DEFAULT_MAX_REQUESTS,
+        { min: 1 },
+      ),
+      windowMs: resolveFixedWindowRateLimitInteger(
+        deps.sessionCreateRateLimit?.windowMs,
+        SESSION_CREATE_RATE_LIMIT_DEFAULT_WINDOW_MS,
+        { min: 1_000 },
+      ),
+    });
+  }
+
+  start(): void {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+    this.stopping = false;
+    setEmbeddedMode(true);
+    setEmbeddedPluginApprovalBroker(this.pluginApprovalBroker);
+    this.unsubscribePluginApprovals = this.pluginApprovalBroker.subscribe((event) => {
+      if (event.event !== "plugin.approval.requested") {
+        return;
+      }
+      void this.relayPluginApproval(event.payload);
+    });
+  }
+
+  initialize(params: InitializeRequest): InitializeResponse {
+    const terminalAuth = params.clientCapabilities?.auth?.terminal === true;
+    return {
+      protocolVersion: PROTOCOL_VERSION,
+      agentCapabilities: {
+        promptCapabilities: {
+          image: true,
+          audio: false,
+          embeddedContext: true,
+        },
+        mcpCapabilities: {
+          http: false,
+          sse: false,
+        },
+        sessionCapabilities: {
+          close: {},
+        },
+      },
+      agentInfo: ACP_AGENT_INFO,
+      authMethods: terminalAuth
+        ? [
+            {
+              id: "openclaw-model-setup",
+              name: "Configure OpenClaw model",
+              description: "Authenticate a model provider and choose OpenClaw model defaults.",
+              type: "terminal",
+              args: ["--configure-model"],
+            },
+          ]
+        : [],
+    };
+  }
+
+  authenticate(params: AuthenticateRequest): AuthenticateResponse {
+    if (params.methodId !== "openclaw-model-setup") {
+      throw RequestError.invalidParams(
+        { methodId: params.methodId },
+        `authentication method "${params.methodId}" is not supported`,
+      );
+    }
+    return {};
+  }
+
+  newSession(params: NewSessionRequest): NewSessionResponse {
+    if (!path.isAbsolute(params.cwd)) {
+      throw RequestError.invalidParams({ cwd: params.cwd }, "cwd must be an absolute path");
+    }
+    if (params.mcpServers.length > 0) {
+      throw RequestError.invalidParams(
+        { mcpServers: params.mcpServers },
+        "client-supplied MCP servers are not supported",
+      );
+    }
+    if ((params.additionalDirectories?.length ?? 0) > 0) {
+      throw RequestError.invalidParams(
+        { additionalDirectories: params.additionalDirectories },
+        "additional directories are not supported",
+      );
+    }
+    const budget = this.sessionCreateRateLimiter.consume();
+    if (!budget.allowed) {
+      throw new Error(
+        `ACP session creation rate limit exceeded for newSession; retry after ${Math.ceil(budget.retryAfterMs / 1_000)}s.`,
+      );
+    }
+    const id = this.createId();
+    const agentId = this.resolveAgentId();
+    const session: NativeSession = {
+      id,
+      key: toAgentStoreSessionKey({ agentId, requestKey: `acp:${id}` }),
+      cwd: params.cwd,
+      promptGeneration: 0,
+    };
+    this.sessions.set(id, session);
+    return { sessionId: id };
+  }
+
+  prompt(params: PromptRequest): Promise<PromptResponse> {
+    const completion = this.runAdmittedPrompt(params);
+    const admitted = this.admittedPrompts.get(params.sessionId) ?? new Set();
+    admitted.add(completion);
+    this.admittedPrompts.set(params.sessionId, admitted);
+    const release = () => {
+      admitted.delete(completion);
+      if (admitted.size === 0) {
+        this.admittedPrompts.delete(params.sessionId);
+      }
+    };
+    void completion.then(release, release);
+    return completion;
+  }
+
+  private async runAdmittedPrompt(params: PromptRequest): Promise<PromptResponse> {
+    if (this.stopping) {
+      throw RequestError.invalidParams(
+        { sessionId: params.sessionId },
+        "ACP agent is shutting down",
+      );
+    }
+    const session = this.sessions.get(params.sessionId);
+    if (!session || this.closingSessions.has(params.sessionId)) {
+      throw RequestError.invalidParams(
+        { sessionId: params.sessionId },
+        `unknown ACP session "${params.sessionId}"`,
+      );
+    }
+    const promptGeneration = ++session.promptGeneration;
+    const previous = this.activeTurns.get(session.id);
+    if (previous) {
+      previous.controller.abort(new Error("ACP prompt superseded"));
+      await previous.completion.catch(() => {});
+    }
+    // Waiting prompts are admitted work but are not active turns yet. Recheck
+    // teardown and supersession fences before they can touch runtime state.
+    if (
+      this.stopping ||
+      this.closingSessions.has(session.id) ||
+      this.sessions.get(session.id) !== session
+    ) {
+      throw RequestError.invalidParams(
+        { sessionId: params.sessionId },
+        `unknown ACP session "${params.sessionId}"`,
+      );
+    }
+    if (session.promptGeneration !== promptGeneration) {
+      return { stopReason: "cancelled" };
+    }
+
+    const controller = new AbortController();
+    const completion = this.runPrompt(session, params, controller);
+    this.activeTurns.set(session.id, { controller, completion });
+    try {
+      return await completion;
+    } finally {
+      if (this.activeTurns.get(session.id)?.completion === completion) {
+        this.activeTurns.delete(session.id);
+      }
+    }
+  }
+
+  cancel(params: CancelNotification): void {
+    const session = this.sessions.get(params.sessionId);
+    if (session) {
+      session.promptGeneration += 1;
+    }
+    this.activeTurns.get(params.sessionId)?.controller.abort(new Error("ACP prompt cancelled"));
+  }
+
+  private collectAdmittedPrompts(sessionId?: string): Promise<PromptResponse>[] {
+    const completions: Promise<PromptResponse>[] = [];
+    const groups = sessionId
+      ? [this.admittedPrompts.get(sessionId)].filter(
+          (group): group is Set<Promise<PromptResponse>> => group !== undefined,
+        )
+      : this.admittedPrompts.values();
+    for (const group of groups) {
+      for (const completion of group) {
+        completions.push(completion);
+      }
+    }
+    return completions;
+  }
+
+  async closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
+    this.closingSessions.add(params.sessionId);
+    const session = this.sessions.get(params.sessionId);
+    if (session) {
+      session.promptGeneration += 1;
+    }
+    try {
+      this.activeTurns.get(params.sessionId)?.controller.abort(new Error("ACP session closed"));
+      await Promise.allSettled(this.collectAdmittedPrompts(params.sessionId));
+      this.activeTurns.delete(params.sessionId);
+      this.sessions.delete(params.sessionId);
+      return {};
+    } finally {
+      this.closingSessions.delete(params.sessionId);
+    }
+  }
+
+  async shutdown(reason: unknown = new Error("ACP agent stopped")): Promise<void> {
+    this.stopping = true;
+    for (const session of this.sessions.values()) {
+      session.promptGeneration += 1;
+    }
+    for (const turn of this.activeTurns.values()) {
+      turn.controller.abort(reason);
+    }
+    await Promise.allSettled(this.collectAdmittedPrompts());
+    this.activeTurns.clear();
+    this.admittedPrompts.clear();
+    this.closingSessions.clear();
+    this.sessions.clear();
+    clearEmbeddedPluginApprovalBroker(this.pluginApprovalBroker);
+    this.unsubscribePluginApprovals?.();
+    this.unsubscribePluginApprovals = undefined;
+    this.pluginApprovalBroker.stop(reason);
+    setEmbeddedMode(false);
+    this.started = false;
+  }
+
+  private async runPrompt(
+    session: NativeSession,
+    params: PromptRequest,
+    controller: AbortController,
+  ): Promise<PromptResponse> {
+    const text = extractTextFromPrompt(params.prompt, MAX_PROMPT_BYTES);
+    const attachments = extractAttachmentsFromPrompt(params.prompt);
+    const decodedImageBytes = attachments.reduce(
+      (total, attachment) => total + Buffer.byteLength(attachment.content, "base64"),
+      0,
+    );
+    if (Buffer.byteLength(text, "utf8") + decodedImageBytes > MAX_PROMPT_BYTES) {
+      throw new Error(`Prompt exceeds maximum allowed size of ${MAX_PROMPT_BYTES} bytes`);
+    }
+
+    const runId = this.createId();
+    let sentThought = "";
+    let updateTail = Promise.resolve();
+    const enqueueUpdate = (
+      update: Parameters<AgentSideConnection["sessionUpdate"]>[0]["update"],
+    ) => {
+      updateTail = updateTail.then(() =>
+        this.connection.sessionUpdate({ sessionId: session.id, update }),
+      );
+    };
+    const unsubscribe = this.subscribeAgentEvents((event) => {
+      if (event.runId !== runId) {
+        return;
+      }
+      const projected = this.projectThoughtEvent(event, sentThought);
+      if (!projected) {
+        return;
+      }
+      sentThought += projected;
+      enqueueUpdate({
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: projected },
+      });
+    });
+
+    let result: AgentResult | undefined;
+    try {
+      result = await this.executeAgent(
+        {
+          message: text,
+          transcriptMessage: text,
+          images: attachments.map((attachment) => ({
+            type: "image" as const,
+            data: attachment.content,
+            mimeType: attachment.mimeType,
+          })),
+          sessionKey: session.key,
+          cwd: session.cwd,
+          deliver: false,
+          channel: INTERNAL_MESSAGE_CHANNEL,
+          messageChannel: INTERNAL_MESSAGE_CHANNEL,
+          messageProvider: INTERNAL_MESSAGE_CHANNEL,
+          runContext: {
+            messageChannel: INTERNAL_MESSAGE_CHANNEL,
+            currentChannelId: INTERNAL_MESSAGE_CHANNEL,
+          },
+          runId,
+          abortSignal: controller.signal,
+          allowModelOverride: false,
+          senderIsOwner: false,
+          localExecApprovalHandler: async (request, signal) =>
+            await this.requestExecApproval(session.id, request, signal),
+          inputProvenance: {
+            kind: "external_user",
+            sourceChannel: "acp",
+          },
+        },
+        this.runtime,
+      );
+    } catch (error) {
+      if (controller.signal.aborted) {
+        return { stopReason: "cancelled" };
+      }
+      throw error;
+    } finally {
+      unsubscribe();
+      await updateTail;
+    }
+
+    if (controller.signal.aborted) {
+      return { stopReason: "cancelled" };
+    }
+    const resultError = agentResultError(result);
+    if (resultError) {
+      throw resultError;
+    }
+    const finalText = finalVisibleText(result);
+    if (finalText) {
+      await this.connection.sessionUpdate({
+        sessionId: session.id,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: finalText },
+        },
+      });
+    }
+    return { stopReason: "end_turn" };
+  }
+
+  private projectThoughtEvent(event: AgentEventPayload, sentThought: string): string | undefined {
+    if (event.stream !== "thinking") {
+      return undefined;
+    }
+    const data = event.data as { delta?: unknown; text?: unknown };
+    if (typeof data.delta === "string" && data.delta) {
+      return data.delta;
+    }
+    if (typeof data.text !== "string") {
+      return undefined;
+    }
+    if (!data.text.startsWith(sentThought) || data.text.length <= sentThought.length) {
+      return undefined;
+    }
+    return data.text.slice(sentThought.length);
+  }
+
+  private async requestExecApproval(
+    sessionId: string,
+    request: LocalExecApprovalRequest,
+    signal: AbortSignal,
+  ): Promise<ExecApprovalDecision | null> {
+    const permission = buildAcpPermissionRequest({
+      sessionId,
+      event: {
+        approvalId: request.id,
+        command: request.commandPreview ?? request.command,
+        host: request.host,
+        toolCallId: request.toolCallId,
+      },
+      details: {
+        allowedDecisions: request.allowedDecisions,
+        commandText: request.command,
+        commandPreview: request.commandPreview,
+        host: request.host,
+      },
+    });
+    const response = await requestPermissionWithSignal({
+      connection: this.connection,
+      request: permission,
+      signal,
+    });
+    return resolveGatewayDecisionFromPermissionOutcome(response, permission.options) ?? "deny";
+  }
+
+  private async relayPluginApproval(approval: PluginApprovalRequest): Promise<void> {
+    const session = resolveSessionForPluginApproval(this.sessions.values(), approval.request);
+    if (!session) {
+      this.pluginApprovalBroker.resolve(approval.id, "deny");
+      return;
+    }
+    const activeTurn = this.activeTurns.get(session.id);
+    if (!activeTurn) {
+      this.pluginApprovalBroker.resolve(approval.id, "deny");
+      return;
+    }
+    const permission = pluginPermissionRequest(session.id, approval);
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(new Error(`Plugin approval "${approval.id}" expired`)),
+      Math.max(1, approval.expiresAtMs - Date.now()),
+    );
+    timeout.unref?.();
+    const onAbort = () => controller.abort(activeTurn.controller.signal.reason);
+    activeTurn.controller.signal.addEventListener("abort", onAbort, { once: true });
+    if (activeTurn.controller.signal.aborted) {
+      onAbort();
+    }
+    try {
+      const response = await requestPermissionWithSignal({
+        connection: this.connection,
+        request: permission,
+        signal: controller.signal,
+      });
+      const decision =
+        resolveGatewayDecisionFromPermissionOutcome(response, permission.options) ?? "deny";
+      this.pluginApprovalBroker.resolve(approval.id, decision);
+    } finally {
+      clearTimeout(timeout);
+      activeTurn.controller.signal.removeEventListener("abort", onAbort);
+    }
+  }
+}

--- a/src/acp/native-agent.ts
+++ b/src/acp/native-agent.ts
@@ -115,6 +115,16 @@ type NativeAgentDependencies = {
   abortSettleTimeoutMs?: number;
 };
 
+function buildNativeSessionKey(params: { agentId: string; sessionId: string }): string {
+  // The `acp:` namespace is reserved for sessions backed by an external ACP
+  // runtime. Native ACP already owns the model loop, so using it would reroute
+  // this in-process turn through the ACP session manager.
+  return toAgentStoreSessionKey({
+    agentId: params.agentId,
+    requestKey: `native-acp:${params.sessionId}`,
+  });
+}
+
 function permissionOptions(decisions: readonly ExecApprovalDecision[]): PermissionOption[] {
   return decisions.map((decision) => ({
     optionId: decision,
@@ -340,7 +350,7 @@ export class AcpNativeAgent implements Agent {
     const agentId = this.resolveAgentId();
     const session: NativeSession = {
       id,
-      key: toAgentStoreSessionKey({ agentId, requestKey: `acp:${id}` }),
+      key: buildNativeSessionKey({ agentId, sessionId: id }),
       cwd: params.cwd,
       promptGeneration: 0,
     };

--- a/src/acp/native-agent.ts
+++ b/src/acp/native-agent.ts
@@ -33,6 +33,7 @@ import { buildApprovalPresentation } from "../infra/approval-presentation.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import {
   clearEmbeddedPluginApprovalBroker,
+  type EmbeddedPluginApprovalRequest,
   EmbeddedPluginApprovalBroker,
   setEmbeddedPluginApprovalBroker,
 } from "../infra/embedded-plugin-approval-broker.js";
@@ -81,6 +82,7 @@ type NativeSession = {
 };
 
 type ActiveTurn = {
+  runId: string;
   controller: AbortController;
   completion: Promise<PromptResponse>;
 };
@@ -424,7 +426,10 @@ export class AcpNativeAgent implements Agent {
     const previous = this.activeTurns.get(session.id);
     if (previous) {
       previous.controller.abort(new Error("ACP prompt superseded"));
-      await previous.completion.catch(() => {});
+      const settled = await this.waitForPromptCompletions([previous.completion], session.id);
+      if (!settled) {
+        return { stopReason: "cancelled" };
+      }
     }
     // Waiting prompts are admitted work but are not active turns yet. Recheck
     // teardown and supersession fences before they can touch runtime state.
@@ -443,8 +448,9 @@ export class AcpNativeAgent implements Agent {
     }
 
     const controller = new AbortController();
-    const completion = this.runPrompt(session, params, controller);
-    this.activeTurns.set(session.id, { controller, completion });
+    const runId = this.createId();
+    const completion = this.runPrompt(session, params, controller, runId, promptGeneration);
+    this.activeTurns.set(session.id, { runId, controller, completion });
     try {
       return await completion;
     } finally {
@@ -479,8 +485,15 @@ export class AcpNativeAgent implements Agent {
 
   private async waitForAdmittedPrompts(sessionId?: string): Promise<void> {
     const completions = this.collectAdmittedPrompts(sessionId);
+    await this.waitForPromptCompletions(completions, sessionId);
+  }
+
+  private async waitForPromptCompletions(
+    completions: Promise<PromptResponse>[],
+    sessionId?: string,
+  ): Promise<boolean> {
     if (completions.length === 0) {
-      return;
+      return true;
     }
     let timeout: NodeJS.Timeout | undefined;
     const outcome = await Promise.race([
@@ -499,6 +512,7 @@ export class AcpNativeAgent implements Agent {
           (sessionId ? ` for session ${sessionId}` : ""),
       );
     }
+    return outcome === "settled";
   }
 
   async closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
@@ -544,6 +558,8 @@ export class AcpNativeAgent implements Agent {
     session: NativeSession,
     params: PromptRequest,
     controller: AbortController,
+    runId: string,
+    promptGeneration: number,
   ): Promise<PromptResponse> {
     const text = extractTextFromPrompt(params.prompt, MAX_PROMPT_BYTES);
     const attachments = extractAttachmentsFromPrompt(params.prompt);
@@ -555,18 +571,25 @@ export class AcpNativeAgent implements Agent {
       throw new Error(`Prompt exceeds maximum allowed size of ${MAX_PROMPT_BYTES} bytes`);
     }
 
-    const runId = this.createId();
     let sentThought = "";
     let updateTail = Promise.resolve();
+    const isPromptCurrent = () =>
+      !controller.signal.aborted &&
+      !this.stopping &&
+      !this.closingSessions.has(session.id) &&
+      this.sessions.get(session.id) === session &&
+      session.promptGeneration === promptGeneration;
     const enqueueUpdate = (
       update: Parameters<AgentSideConnection["sessionUpdate"]>[0]["update"],
     ) => {
-      updateTail = updateTail.then(() =>
-        this.connection.sessionUpdate({ sessionId: session.id, update }),
-      );
+      updateTail = updateTail.then(async () => {
+        if (isPromptCurrent()) {
+          await this.connection.sessionUpdate({ sessionId: session.id, update });
+        }
+      });
     };
     const unsubscribe = this.subscribeAgentEvents((event) => {
-      if (event.runId !== runId) {
+      if (event.runId !== runId || !isPromptCurrent()) {
         return;
       }
       const projected = this.projectThoughtEvent(event, sentThought);
@@ -689,14 +712,14 @@ export class AcpNativeAgent implements Agent {
     return resolveGatewayDecisionFromPermissionOutcome(response, permission.options) ?? "deny";
   }
 
-  private async relayPluginApproval(approval: PluginApprovalRequest): Promise<void> {
+  private async relayPluginApproval(approval: EmbeddedPluginApprovalRequest): Promise<void> {
     const session = resolveSessionForPluginApproval(this.sessions.values(), approval.request);
     if (!session) {
       this.pluginApprovalBroker.resolve(approval.id, "deny");
       return;
     }
     const activeTurn = this.activeTurns.get(session.id);
-    if (!activeTurn) {
+    if (!activeTurn || !approval.runId || approval.runId !== activeTurn.runId) {
       this.pluginApprovalBroker.resolve(approval.id, "deny");
       return;
     }

--- a/src/acp/native-server.test.ts
+++ b/src/acp/native-server.test.ts
@@ -1,0 +1,48 @@
+import { AGENT_METHODS, PROTOCOL_VERSION } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import { normalizeAcpInitializeProtocolVersion } from "./protocol-version.js";
+
+describe("normalizeAcpInitializeProtocolVersion", () => {
+  it("normalizes date-style client versions before SDK validation", () => {
+    expect(
+      normalizeAcpInitializeProtocolVersion({
+        jsonrpc: "2.0",
+        id: 1,
+        method: AGENT_METHODS.initialize,
+        params: { protocolVersion: "2026-01-01", clientCapabilities: {} },
+      }),
+    ).toMatchObject({
+      params: { protocolVersion: PROTOCOL_VERSION },
+    });
+  });
+
+  it("leaves valid versions and unrelated messages unchanged", () => {
+    const valid = {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      method: AGENT_METHODS.initialize,
+      params: { protocolVersion: PROTOCOL_VERSION, clientCapabilities: {} },
+    };
+    const unrelated = { jsonrpc: "2.0" as const, method: "session/cancel", params: {} };
+    const newerNumericVersion = {
+      ...valid,
+      params: { ...valid.params, protocolVersion: 2 },
+    };
+
+    expect(normalizeAcpInitializeProtocolVersion(valid)).toBe(valid);
+    expect(normalizeAcpInitializeProtocolVersion(newerNumericVersion)).toBe(newerNumericVersion);
+    expect(normalizeAcpInitializeProtocolVersion(unrelated)).toBe(unrelated);
+  });
+
+  it("leaves malformed non-date versions for SDK validation", () => {
+    for (const protocolVersion of [1.5, "not-a-date", null]) {
+      const message = {
+        jsonrpc: "2.0" as const,
+        id: 1,
+        method: AGENT_METHODS.initialize,
+        params: { protocolVersion, clientCapabilities: {} },
+      };
+      expect(normalizeAcpInitializeProtocolVersion(message)).toBe(message);
+    }
+  });
+});

--- a/src/acp/native-server.ts
+++ b/src/acp/native-server.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/** Self-contained ACP stdio server backed by the process-local OpenClaw runtime. */
+import { Readable, Writable } from "node:stream";
+import {
+  AgentSideConnection,
+  ndJsonStream,
+  type Agent,
+  type AnyMessage,
+} from "@agentclientprotocol/sdk";
+import { routeLogsToStderr } from "../logging/console.js";
+import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { AcpNativeAgent } from "./native-agent.js";
+import { normalizeAcpInitializeProtocolVersion } from "./protocol-version.js";
+
+type NativeRuntimeAgent = Agent & {
+  start?: () => void;
+  shutdown: (reason?: unknown) => Promise<void>;
+};
+
+type NativeServerDependencies = {
+  input?: ReadableStream<Uint8Array>;
+  output?: WritableStream<Uint8Array>;
+  createAgent?: (connection: AgentSideConnection) => NativeRuntimeAgent;
+  closeStateDatabase?: () => void;
+  installSignalHandlers?: boolean;
+};
+
+/** Starts the self-contained OpenClaw ACP agent over stdio. */
+export async function serveAcpNative(deps: NativeServerDependencies = {}): Promise<void> {
+  routeLogsToStderr();
+  const input =
+    deps.input ?? (Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>);
+  const output = deps.output ?? Writable.toWeb(process.stdout);
+  const stream = ndJsonStream(output, input);
+  const readable = stream.readable.pipeThrough(
+    new TransformStream<AnyMessage, AnyMessage>({
+      transform(message, controller) {
+        controller.enqueue(normalizeAcpInitializeProtocolVersion(message));
+      },
+    }),
+  );
+
+  let agent: NativeRuntimeAgent | undefined;
+  let shutdownPromise: Promise<void> | undefined;
+  const closeStateDatabase = deps.closeStateDatabase ?? closeOpenClawStateDatabase;
+  const shutdown = (reason?: unknown) => {
+    shutdownPromise ??= (async () => {
+      await agent?.shutdown(reason);
+      closeStateDatabase();
+    })();
+    return shutdownPromise;
+  };
+
+  const connection = new AgentSideConnection(
+    (conn) => {
+      agent = deps.createAgent?.(conn) ?? new AcpNativeAgent(conn);
+      agent.start?.();
+      return agent;
+    },
+    { ...stream, readable },
+  );
+  const onSignal = () => {
+    process.stdin.destroy();
+    void shutdown(new Error("ACP process shutting down"));
+  };
+  const installSignalHandlers = deps.installSignalHandlers !== false;
+  if (installSignalHandlers) {
+    process.once("SIGINT", onSignal);
+    process.once("SIGTERM", onSignal);
+  }
+  try {
+    await connection.closed;
+  } finally {
+    if (installSignalHandlers) {
+      process.off("SIGINT", onSignal);
+      process.off("SIGTERM", onSignal);
+    }
+    await shutdown(connection.signal.reason);
+  }
+}

--- a/src/acp/protocol-version.ts
+++ b/src/acp/protocol-version.ts
@@ -1,0 +1,39 @@
+/** ACP handshake normalization shared by stdio server entrypoints. */
+import { AGENT_METHODS, PROTOCOL_VERSION, type AnyMessage } from "@agentclientprotocol/sdk";
+
+type JsonObject = Record<string, unknown>;
+
+/**
+ * Normalizes date-style client versions before the ACP SDK validates them.
+ *
+ * The ACP SDK validates this uint16 before the agent handler runs; some editors
+ * send MCP date strings here, so normalize only this handshake field.
+ */
+export function normalizeAcpInitializeProtocolVersion(message: AnyMessage): AnyMessage {
+  if (!isJsonObject(message)) {
+    return message;
+  }
+  const object = message as JsonObject;
+  if (object.method !== AGENT_METHODS.initialize) {
+    return message;
+  }
+  const params = object.params;
+  if (
+    !isJsonObject(params) ||
+    typeof params.protocolVersion !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}$/.test(params.protocolVersion)
+  ) {
+    return message;
+  }
+  return {
+    ...message,
+    params: {
+      ...params,
+      protocolVersion: PROTOCOL_VERSION,
+    },
+  } as AnyMessage;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/acp/runtime-info.test.ts
+++ b/src/acp/runtime-info.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { ACP_RUNTIME_INFO } from "./runtime-info.js";
+
+describe("ACP_RUNTIME_INFO", () => {
+  it("declares a self-contained stdio runtime without a Gateway dependency", () => {
+    expect(ACP_RUNTIME_INFO).toEqual({
+      schemaVersion: 1,
+      protocol: "acp",
+      transport: "stdio",
+      execution: "in-process",
+      gatewayRequired: false,
+    });
+  });
+});

--- a/src/acp/runtime-info.ts
+++ b/src/acp/runtime-info.ts
@@ -1,0 +1,8 @@
+/** Machine-readable contract used by ACP hosts before launching OpenClaw. */
+export const ACP_RUNTIME_INFO = {
+  schemaVersion: 1,
+  protocol: "acp",
+  transport: "stdio",
+  execution: "in-process",
+  gatewayRequired: false,
+} as const;

--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -750,7 +750,7 @@ describe("serveAcpGateway startup", () => {
     ]);
   });
 
-  it("coerces non-integer numeric initialize protocol versions", async () => {
+  it("passes malformed numeric initialize protocol versions through for SDK validation", async () => {
     const initializeRequest = {
       jsonrpc: "2.0",
       id: 1,
@@ -761,15 +761,8 @@ describe("serveAcpGateway startup", () => {
       },
     };
 
-    await expect(captureAcpMessagesAfterStartup([initializeRequest])).resolves.toEqual([
-      {
-        ...initializeRequest,
-        params: {
-          ...initializeRequest.params,
-          protocolVersion: mockState.acpProtocolVersion,
-        },
-      },
-    ]);
+    const [message] = await captureAcpMessagesAfterStartup([initializeRequest]);
+    expect(message).toBe(initializeRequest);
   });
 
   it("passes uint16 numeric initialize protocol versions through unchanged", async () => {

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -2,13 +2,7 @@
 /** ACP stdio server that bridges Agent Client Protocol clients to the OpenClaw Gateway. */
 import { Readable, Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
-import {
-  AGENT_METHODS,
-  AgentSideConnection,
-  PROTOCOL_VERSION,
-  ndJsonStream,
-  type AnyMessage,
-} from "@agentclientprotocol/sdk";
+import { AgentSideConnection, ndJsonStream, type AnyMessage } from "@agentclientprotocol/sdk";
 import type { AcpServerOptions } from "@openclaw/acp-core/types";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -24,11 +18,10 @@ import { isMainModule } from "../infra/is-main.js";
 import { routeLogsToStderr } from "../logging/console.js";
 import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { createSqliteAcpEventLedger } from "./event-ledger.js";
+import { normalizeAcpInitializeProtocolVersion } from "./protocol-version.js";
 import { readSecretFromFile } from "./secret-file.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { normalizeAcpProvenanceMode } from "./types.js";
-
-type JsonObject = Record<string, unknown>;
 
 const MAX_STARTUP_ACP_BUFFER_BYTES = 1024 * 1024;
 
@@ -262,38 +255,6 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   void connection.closed.then(shutdown, shutdown);
 
   return closed;
-}
-
-function normalizeAcpInitializeProtocolVersion(message: AnyMessage): AnyMessage {
-  if (!isJsonObject(message)) {
-    return message;
-  }
-  const messageObject: JsonObject = message;
-  if (messageObject.method !== AGENT_METHODS.initialize) {
-    return message;
-  }
-  const params = messageObject.params;
-  if (!isJsonObject(params) || isUint16Integer(params.protocolVersion)) {
-    return message;
-  }
-
-  // ACP SDK 0.22 validates this uint16 before the agent handler runs; some
-  // editors send MCP date strings here, so normalize only this handshake field.
-  return {
-    ...message,
-    params: {
-      ...params,
-      protocolVersion: PROTOCOL_VERSION,
-    },
-  } as AnyMessage;
-}
-
-function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isUint16Integer(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 0xffff;
 }
 
 function parseArgs(args: string[]): AcpServerOptions {

--- a/src/acp/types.ts
+++ b/src/acp/types.ts
@@ -5,6 +5,6 @@ import { VERSION } from "../version.js";
 /** ACP agent identity advertised during protocol initialization. */
 export const ACP_AGENT_INFO = {
   name: "openclaw-acp",
-  title: "OpenClaw ACP Gateway",
+  title: "OpenClaw ACP",
   version: VERSION,
 };

--- a/src/agents/agent-tools.before-tool-call.approval.ts
+++ b/src/agents/agent-tools.before-tool-call.approval.ts
@@ -196,6 +196,7 @@ async function requestPluginToolApproval(params: {
     const embeddedApprovalBroker = isEmbeddedMode() ? getEmbeddedPluginApprovalBroker() : null;
     if (embeddedApprovalBroker) {
       const result = await embeddedApprovalBroker.request({
+        runId: params.ctx?.runId,
         request: {
           pluginId: approval.pluginId,
           title: approval.title,

--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -176,6 +176,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       params: { action: "apply", proposal_id: "weather" },
       toolCallId: "call-skill-local",
       ctx: {
+        runId: "run-skill-local",
         agentId: "main",
         sessionKey: "agent:main:main",
         config: {
@@ -195,6 +196,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       "broker.listPending()[0] test invariant",
     );
     expect(approval?.request.toolName).toBe("skill_workshop");
+    expect(approval?.runId).toBe("run-skill-local");
     expect(broker.resolve(approval?.id, "allow-once")).toBe(true);
 
     await expect(resultPromise).resolves.toEqual({

--- a/src/agents/bash-tools.exec-host-node.cancellation.test.ts
+++ b/src/agents/bash-tools.exec-host-node.cancellation.test.ts
@@ -48,8 +48,10 @@ vi.mock("../infra/exec-auto-review.js", () => ({
 vi.mock("./bash-tools.exec-approval-request.js", () => ({
   buildExecApprovalRequesterContext: vi.fn(() => ({})),
   buildExecApprovalTurnSourceContext: vi.fn(() => ({})),
+  hasLocalExecApprovalHost: vi.fn(() => false),
   isExecApprovalRunAbortedError: vi.fn(() => false),
   registerExecApprovalRequestForHostOrThrow: mocks.registerNodeApproval,
+  registerResolvedLocalExecApprovalForHostOrThrow: vi.fn(),
 }));
 
 vi.mock("./bash-tools.exec-host-node-phases.js", () => ({

--- a/src/cli/acp-cli-exit.process.test.ts
+++ b/src/cli/acp-cli-exit.process.test.ts
@@ -5,7 +5,7 @@ import {
   spawnSync,
   type ChildProcessWithoutNullStreams,
 } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -96,6 +96,38 @@ function rawDataToText(data: RawData): string {
 }
 
 describe("ACP CLI process exit", () => {
+  it.each([
+    { name: "initial launch", args: [] },
+    { name: "startup respawn", args: ["acp", "native"] },
+  ])("routes the dedicated executable exactly once on $name", ({ args }) => {
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "openclaw-acp-wrapper-"));
+    try {
+      copyFileSync("openclaw-acp.mjs", path.join(fixtureDir, "openclaw-acp.mjs"));
+      writeFileSync(
+        path.join(fixtureDir, "openclaw.mjs"),
+        "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        [path.join(fixtureDir, "openclaw-acp.mjs"), ...args],
+        {
+          cwd: path.resolve("."),
+          encoding: "utf8",
+          killSignal: "SIGKILL",
+          timeout: CHILD_PROCESS_TIMEOUT_MS,
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(JSON.parse(result.stdout)).toEqual(["acp", "native"]);
+    } finally {
+      rmSync(fixtureDir, { force: true, recursive: true });
+    }
+  });
+
   it("prints only the runtime contract from fresh state", () => {
     const stateDir = mkdtempSync(path.join(tmpdir(), "openclaw-acp-info-"));
     try {

--- a/src/cli/acp-cli-exit.process.test.ts
+++ b/src/cli/acp-cli-exit.process.test.ts
@@ -96,6 +96,37 @@ function rawDataToText(data: RawData): string {
 }
 
 describe("ACP CLI process exit", () => {
+  it("prints only the runtime contract from fresh state", () => {
+    const stateDir = mkdtempSync(path.join(tmpdir(), "openclaw-acp-info-"));
+    try {
+      const result = spawnSync(
+        process.execPath,
+        ["--import", "tsx", "src/entry.ts", "acp", "info"],
+        {
+          cwd: path.resolve("."),
+          encoding: "utf8",
+          env: createAcpProcessEnv(stateDir),
+          killSignal: "SIGKILL",
+          timeout: CHILD_PROCESS_TIMEOUT_MS,
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(JSON.parse(result.stdout)).toEqual({
+        schemaVersion: 1,
+        protocol: "acp",
+        transport: "stdio",
+        execution: "in-process",
+        gatewayRequired: false,
+      });
+      expect(result.stdout).toBe(`${JSON.stringify(JSON.parse(result.stdout))}\n`);
+    } finally {
+      rmSync(stateDir, { force: true, recursive: true });
+    }
+  });
+
   it.each([
     { args: ["acp", "--help"], usage: "Usage: openclaw acp [options] [command]" },
     { args: ["acp", "client", "--help"], usage: "Usage: openclaw acp client [options]" },

--- a/src/cli/acp-cli.option-collisions.test.ts
+++ b/src/cli/acp-cli.option-collisions.test.ts
@@ -17,6 +17,7 @@ type AcpGatewayOptions = {
 
 const mocks = vi.hoisted(() => ({
   runAcpClientInteractive: vi.fn(async (_opts: AcpClientOptions) => {}),
+  serveAcpNative: vi.fn(async () => {}),
   serveAcpGateway: vi.fn(async (_opts: AcpGatewayOptions) => {}),
   defaultRuntime: {
     log: vi.fn(),
@@ -27,7 +28,7 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-const { runAcpClientInteractive, serveAcpGateway, defaultRuntime } = mocks;
+const { runAcpClientInteractive, serveAcpNative, serveAcpGateway, defaultRuntime } = mocks;
 
 const passwordKey = () => ["pass", "word"].join("");
 
@@ -37,6 +38,10 @@ vi.mock("../acp/client.js", () => ({
 
 vi.mock("../acp/server.js", () => ({
   serveAcpGateway: (opts: AcpGatewayOptions) => mocks.serveAcpGateway(opts),
+}));
+
+vi.mock("../acp/native-server.js", () => ({
+  serveAcpNative: () => mocks.serveAcpNative(),
 }));
 
 vi.mock("../runtime.js", () => ({
@@ -72,6 +77,7 @@ describe("acp cli option collisions", () => {
 
   beforeEach(() => {
     runAcpClientInteractive.mockClear();
+    serveAcpNative.mockClear();
     serveAcpGateway.mockClear();
     defaultRuntime.log.mockClear();
     defaultRuntime.error.mockClear();
@@ -91,24 +97,37 @@ describe("acp cli option collisions", () => {
     expect(clientOptions?.verbose).toBe(true);
   });
 
-  it("forwards --no-prefix-cwd to the ACP bridge", async () => {
-    await parseAcp(["--no-prefix-cwd"]);
+  it("preserves the Gateway-backed `openclaw acp` contract", async () => {
+    await parseAcp([]);
+
+    expect(serveAcpGateway).toHaveBeenCalledTimes(1);
+    expect(serveAcpNative).not.toHaveBeenCalled();
+  });
+
+  it("runs the self-contained ACP agent through the native subcommand", async () => {
+    await parseAcp(["native"]);
+
+    expect(serveAcpNative).toHaveBeenCalledTimes(1);
+    expect(serveAcpGateway).not.toHaveBeenCalled();
+  });
+
+  it("describes both ACP runtimes without advertising a no-op native verbose flag", () => {
+    const program = createAcpProgram();
+    const acp = program.commands.find((command) => command.name() === "acp");
+    const native = acp?.commands.find((command) => command.name() === "native");
+
+    expect(acp?.description()).toBe("Run OpenClaw ACP runtimes and Gateway bridge tools");
+    expect(native?.options.map((option) => option.long)).not.toContain("--verbose");
+  });
+
+  it("forwards --no-prefix-cwd to the explicit Gateway bridge", async () => {
+    await parseAcp(["gateway", "--no-prefix-cwd"]);
 
     expect(serveAcpGateway).toHaveBeenCalledTimes(1);
     const gatewayOptions = requireFirstMockArg(serveAcpGateway) as {
       prefixCwd?: boolean;
     };
     expect(gatewayOptions?.prefixCwd).toBe(false);
-  });
-
-  it("defaults to prefixing the working directory", async () => {
-    await parseAcp([]);
-
-    expect(serveAcpGateway).toHaveBeenCalledTimes(1);
-    const gatewayOptions = requireFirstMockArg(serveAcpGateway) as {
-      prefixCwd?: boolean;
-    };
-    expect(gatewayOptions?.prefixCwd).toBe(true);
   });
 
   it("loads gateway token/password from files", async () => {

--- a/src/cli/acp-cli.ts
+++ b/src/cli/acp-cli.ts
@@ -1,17 +1,16 @@
-// Commander registration for ACP bridge and interactive ACP client commands.
+// Commander registration for native ACP, the explicit Gateway bridge, and ACP clients.
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
+import { ACP_RUNTIME_INFO } from "../acp/runtime-info.js";
 import { normalizeAcpProvenanceMode } from "../acp/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { defaultRuntime } from "../runtime.js";
 import { inheritOptionFromParent } from "./command-options.js";
 import { resolveGatewayAuthOptions } from "./gateway-secret-options.js";
 
-export function registerAcpCli(program: Command) {
-  const acp = program.command("acp").description("Run an ACP bridge backed by the Gateway");
-
-  acp
+function configureGatewayCommand(command: Command): Command {
+  return command
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
     .option("--token <token>", "Gateway token (if required)")
     .option("--token-file <path>", "Read gateway token from file")
@@ -24,39 +23,87 @@ export function registerAcpCli(program: Command) {
     .option("--no-prefix-cwd", "Do not prefix prompts with the working directory")
     .option("--provenance <mode>", "ACP provenance mode: off, meta, or meta+receipt")
     .option("-v, --verbose", "Verbose logging to stderr", false)
-    .addHelpText(
-      "after",
-      () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/acp", "docs.openclaw.ai/cli/acp")}\n`,
-    )
-    .action(async (opts) => {
+    .action(async (opts, actionCommand) => {
       try {
-        const { gatewayToken, gatewayPassword } = resolveGatewayAuthOptions(opts);
-        const provenanceMode = normalizeAcpProvenanceMode(opts.provenance as string | undefined);
-        if (opts.provenance && !provenanceMode) {
+        const option = (name: string): unknown =>
+          inheritOptionFromParent(actionCommand, name) ?? opts[name];
+        const gatewayOptions = {
+          token: option("token") as string | undefined,
+          tokenFile: option("tokenFile") as string | undefined,
+          password: option("password") as string | undefined,
+          passwordFile: option("passwordFile") as string | undefined,
+        };
+        const { gatewayToken, gatewayPassword } = resolveGatewayAuthOptions(gatewayOptions);
+        const provenance = option("provenance") as string | undefined;
+        const provenanceMode = normalizeAcpProvenanceMode(provenance);
+        if (provenance && !provenanceMode) {
           throw new Error('Invalid --provenance. Use "off", "meta", or "meta+receipt".');
         }
         const { serveAcpGateway } = await import("../acp/server.js");
         await serveAcpGateway({
-          gatewayUrl: opts.url as string | undefined,
+          gatewayUrl: option("url") as string | undefined,
           gatewayToken,
           gatewayPassword,
-          defaultSessionKey: opts.session as string | undefined,
-          defaultSessionLabel: opts.sessionLabel as string | undefined,
-          requireExistingSession: Boolean(opts.requireExisting),
-          resetSession: Boolean(opts.resetSession),
-          prefixCwd: opts.prefixCwd !== false,
+          defaultSessionKey: option("session") as string | undefined,
+          defaultSessionLabel: option("sessionLabel") as string | undefined,
+          requireExistingSession: Boolean(option("requireExisting")),
+          resetSession: Boolean(option("resetSession")),
+          prefixCwd: option("prefixCwd") !== false,
           provenanceMode,
-          verbose: Boolean(opts.verbose),
+          verbose: Boolean(option("verbose")),
         });
       } catch (err) {
-        defaultRuntime.error(`ACP bridge failed: ${formatErrorMessage(err)}`);
+        defaultRuntime.error(`ACP Gateway bridge failed: ${formatErrorMessage(err)}`);
         defaultRuntime.exit(1);
       }
     });
+}
+
+function configureNativeCommand(command: Command): Command {
+  return command
+    .option("--configure-model", "Configure model authentication and exit", false)
+    .action(async (opts) => {
+      try {
+        if (opts.configureModel) {
+          const { configureCommandFromSectionsArg } = await import("../commands/configure.js");
+          await configureCommandFromSectionsArg(["model"], defaultRuntime);
+          return;
+        }
+        const { serveAcpNative } = await import("../acp/native-server.js");
+        await serveAcpNative();
+      } catch (err) {
+        defaultRuntime.error(`ACP native agent failed: ${formatErrorMessage(err)}`);
+        defaultRuntime.exit(1);
+      }
+    });
+}
+
+export function registerAcpCli(program: Command) {
+  const acp = configureGatewayCommand(
+    program.command("acp").description("Run OpenClaw ACP runtimes and Gateway bridge tools"),
+  ).addHelpText(
+    "after",
+    () => `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/acp", "docs.openclaw.ai/cli/acp")}\n`,
+  );
+
+  configureNativeCommand(
+    acp.command("native").description("Run OpenClaw as a self-contained ACP agent"),
+  );
+
+  acp
+    .command("info")
+    .description("Print the ACP runtime compatibility contract")
+    .action(() => {
+      defaultRuntime.writeJson(ACP_RUNTIME_INFO, 0);
+    });
+
+  configureGatewayCommand(
+    acp.command("gateway").description("Alias for the existing Gateway-backed ACP bridge"),
+  );
 
   acp
     .command("client")
-    .description("Run an interactive ACP client against the local ACP bridge")
+    .description("Run an interactive ACP client against an ACP agent")
     .option("--cwd <dir>", "Working directory for the ACP session")
     .option("--server <command>", "ACP server command (default: openclaw)")
     .option("--server-args <args...>", "Extra arguments for the ACP server")

--- a/src/cli/acp-output-mode.test.ts
+++ b/src/cli/acp-output-mode.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { isAcpMachineOutput } from "./acp-output-mode.js";
+
+describe("isAcpMachineOutput", () => {
+  it("recognizes acp info after root options", () => {
+    expect(isAcpMachineOutput(["node", "openclaw", "acp", "info"])).toBe(true);
+    expect(isAcpMachineOutput(["node", "openclaw", "--profile", "qa", "acp", "info"])).toBe(true);
+  });
+
+  it("does not classify ACP protocol or client commands as one-shot JSON", () => {
+    expect(isAcpMachineOutput(["node", "openclaw", "acp"])).toBe(false);
+    expect(isAcpMachineOutput(["node", "openclaw", "acp", "native"])).toBe(false);
+    expect(isAcpMachineOutput(["node", "openclaw", "acp", "client"])).toBe(false);
+  });
+});

--- a/src/cli/acp-output-mode.ts
+++ b/src/cli/acp-output-mode.ts
@@ -1,0 +1,7 @@
+import { getMachineOutputCommandPath } from "./machine-output-argv.js";
+
+/** Reserve stdout for the unconditional JSON emitted by `openclaw acp info`. */
+export function isAcpMachineOutput(argv: readonly string[]): boolean {
+  const [root, command] = getMachineOutputCommandPath(argv, 2);
+  return root === "acp" && command === "info";
+}

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -365,6 +365,16 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     exact: true,
     policy: { ownsProtocolStdout: true },
   },
+  {
+    commandPath: ["acp", "native"],
+    exact: true,
+    policy: { hideBanner: true, ownsProtocolStdout: true },
+  },
+  {
+    commandPath: ["acp", "info"],
+    exact: true,
+    policy: { configGuard: "skip", hideBanner: true, loadPlugins: "never" },
+  },
   { commandPath: ["approvals"], policy: { networkProxy: "bypass" } },
   {
     commandPath: ["approvals", "pending"],

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -368,7 +368,12 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
     commandPath: ["acp", "native"],
     exact: true,
-    policy: { hideBanner: true, ownsProtocolStdout: true },
+    policy: {
+      hideBanner: true,
+      loadPlugins: "always",
+      pluginRegistry: { scope: "all" },
+      ownsProtocolStdout: true,
+    },
   },
   {
     commandPath: ["acp", "info"],

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -386,6 +386,22 @@ describe("command-startup-policy", () => {
     expect(resolvePolicy({ commandPath: ["acp"] }).suppressDoctorStdout).toBe(true);
   });
 
+  it("reserves stdout for the native acp protocol", () => {
+    const policy = resolvePolicy({ commandPath: ["acp", "native"] });
+
+    expect(policy.hideBanner).toBe(true);
+    expect(policy.suppressDoctorStdout).toBe(true);
+  });
+
+  it("keeps acp info independent from local configuration", () => {
+    const policy = resolvePolicy({ commandPath: ["acp", "info"], jsonOutputMode: true });
+
+    expect(policy.hideBanner).toBe(true);
+    expect(policy.loadPlugins).toBe(false);
+    expect(policy.skipConfigGuard).toBe(true);
+    expect(policy.suppressDoctorStdout).toBe(true);
+  });
+
   it("keeps startup stdout for non-protocol commands", () => {
     expect(resolvePolicy({ commandPath: ["mcp", "list"] }).suppressDoctorStdout).toBe(false);
     expect(resolvePolicy({ commandPath: ["acp", "client"] }).suppressDoctorStdout).toBe(false);

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -390,6 +390,8 @@ describe("command-startup-policy", () => {
     const policy = resolvePolicy({ commandPath: ["acp", "native"] });
 
     expect(policy.hideBanner).toBe(true);
+    expect(policy.loadPlugins).toBe(true);
+    expect(policy.pluginRegistry).toEqual({ scope: "all" });
     expect(policy.suppressDoctorStdout).toBe(true);
   });
 

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -117,6 +117,8 @@ const JSON_NOT_APPLICABLE = {
     reason: "long-running server, worker, or live stream does not terminate with one JSON document",
     commands: [
       "acp",
+      "acp native",
+      "acp gateway",
       "gateway",
       "gateway run",
       "mcp serve",
@@ -216,6 +218,9 @@ const JSON_OUTPUT_INHERITED_FROM_PARENT = new Set([
 // Route-first parsing accepts JSON before Commander registration is reached.
 const JSON_OUTPUT_ROUTE_FIRST = new Set(["agents"]);
 
+// These commands always emit one JSON document and do not need a mode flag.
+const JSON_OUTPUT_UNCONDITIONAL = new Set(["acp info"]);
+
 async function registerAllBuiltInCommands(): Promise<Command> {
   const program = new Command().name("openclaw");
   const ctx = createProgramContext();
@@ -252,7 +257,8 @@ function supportsJsonOutput(path: string, command: Command): boolean {
   return (
     hasOwnJsonOption(command) ||
     (JSON_OUTPUT_INHERITED_FROM_PARENT.has(path) && hasAncestorJsonOption(command)) ||
-    JSON_OUTPUT_ROUTE_FIRST.has(path)
+    JSON_OUTPUT_ROUTE_FIRST.has(path) ||
+    JSON_OUTPUT_UNCONDITIONAL.has(path)
   );
 }
 
@@ -417,6 +423,15 @@ describe("root command descriptions", () => {
     expect(
       staleRouteFirstSupport,
       "route-first JSON entries must exist and remain absent from Commander options",
+    ).toEqual([]);
+
+    const staleUnconditionalSupport = [...JSON_OUTPUT_UNCONDITIONAL].filter((path) => {
+      const command = registered.get(path);
+      return !command || hasOwnJsonOption(command);
+    });
+    expect(
+      staleUnconditionalSupport,
+      "unconditional JSON entries must exist and remain absent from Commander options",
     ).toEqual([]);
   });
 });

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -1,4 +1,5 @@
 // Sub-CLI descriptor catalog used for root help placeholders and lazy registration.
+import { isAcpMachineOutput } from "../acp-output-mode.js";
 import { isCronMachineOutput } from "../cron-cli/output-mode.js";
 import { isDevicesMachineOutput } from "../devices-output-mode.js";
 import { isGatewayMachineOutput } from "../gateway-cli/output-mode.js";
@@ -19,6 +20,7 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     name: "acp",
     description: "Run OpenClaw ACP runtimes and Gateway bridge tools",
     hasSubcommands: true,
+    machineOutput: ({ argv }) => isAcpMachineOutput(argv),
   },
   {
     name: "gateway",

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -15,7 +15,11 @@ import { isPrivateQaCliEnabled } from "./private-qa-cli.js";
 export type SubCliDescriptor = NamedCommandDescriptor;
 
 const subCliCommandCatalog = defineCommandDescriptorCatalog([
-  { name: "acp", description: "Run an ACP bridge backed by the Gateway", hasSubcommands: true },
+  {
+    name: "acp",
+    description: "Run OpenClaw ACP runtimes and Gateway bridge tools",
+    hasSubcommands: true,
+  },
   {
     name: "gateway",
     description: "Run, inspect, and query the WebSocket Gateway",

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -34,6 +34,7 @@ import { defaultRuntime } from "./runtime.js";
 
 const ENTRY_WRAPPER_PAIRS = [
   { wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" },
+  { wrapperBasename: "openclaw-acp.mjs", entryBasename: "entry.js" },
   { wrapperBasename: "openclaw.js", entryBasename: "entry.js" },
 ] as const;
 

--- a/src/infra/embedded-plugin-approval-broker.ts
+++ b/src/infra/embedded-plugin-approval-broker.ts
@@ -9,15 +9,19 @@ import type {
   PluginApprovalResolved,
 } from "./plugin-approvals.js";
 
+export type EmbeddedPluginApprovalRequest = PluginApprovalRequest & {
+  runId?: string;
+};
+
 type PendingApproval = {
-  record: PluginApprovalRequest;
+  record: EmbeddedPluginApprovalRequest;
   timer: ReturnType<typeof setTimeout>;
   resolve: (decision: ExecApprovalDecision | null) => void;
   reject: (error: unknown) => void;
 };
 
 type ApprovalEvent =
-  | { event: "plugin.approval.requested"; payload: PluginApprovalRequest }
+  | { event: "plugin.approval.requested"; payload: EmbeddedPluginApprovalRequest }
   | { event: "plugin.approval.resolved"; payload: PluginApprovalResolved }
   | { event: "plugin.approval.removed"; payload: { id: string } };
 
@@ -34,12 +38,13 @@ export class EmbeddedPluginApprovalBroker {
     };
   }
 
-  listPending(): PluginApprovalRequest[] {
+  listPending(): EmbeddedPluginApprovalRequest[] {
     return [...this.pending.values()].map((entry) => entry.record);
   }
 
   async request(params: {
     request: PluginApprovalRequestPayload;
+    runId?: string;
     timeoutMs: number;
     signal?: AbortSignal;
   }): Promise<{ id: string; decision: ExecApprovalDecision | null }> {
@@ -48,9 +53,10 @@ export class EmbeddedPluginApprovalBroker {
     }
     const id = `plugin:${randomUUID()}`;
     const createdAtMs = Date.now();
-    const record: PluginApprovalRequest = {
+    const record: EmbeddedPluginApprovalRequest = {
       id,
       request: params.request,
+      runId: params.runId,
       createdAtMs,
       expiresAtMs: createdAtMs + params.timeoutMs,
     };

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3573,6 +3573,8 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
       'test -r "$0"',
       'test -x "$0"',
       'grep -Fq "/tmp/openclaw-source/dist/entry.js" "$prefix_cli"',
+      'grep -Fq "/tmp/openclaw-source/openclaw-acp.mjs" "$prefix_acp"',
+      'test "$(command -v openclaw-acp)" = "$prefix_acp"',
       "openclaw update status --json",
       "expected git install kind",
     ]);

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -41,6 +41,35 @@ function linkRequiredShellTools(bin: string) {
 describe("install-cli.sh", () => {
   const script = readFileSync(SCRIPT_PATH, "utf8");
 
+  it("installs dedicated-prefix launchers for the CLI and native ACP runtime", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      PREFIX="$tmp/prefix"
+      OPENCLAW_VERSION=2026.8.1
+      SET_NPM_PREFIX=0
+      node_dir() { printf '%s\n' "$tmp/node"; }
+      npm_bin() { printf '/usr/bin/true\n'; }
+      mkdir -p "$tmp/node/lib/node_modules/openclaw"
+      touch "$tmp/node/lib/node_modules/openclaw/openclaw-acp.mjs"
+
+      install_openclaw
+
+      test -x "$PREFIX/bin/openclaw"
+      test -x "$PREFIX/bin/openclaw-acp"
+      grep -Fq "$tmp/node/lib/node_modules/openclaw/dist/entry.js" "$PREFIX/bin/openclaw"
+      grep -Fq "$tmp/node/lib/node_modules/openclaw/openclaw-acp.mjs" "$PREFIX/bin/openclaw-acp"
+
+      rm "$tmp/node/lib/node_modules/openclaw/openclaw-acp.mjs"
+      install_openclaw
+      test ! -e "$PREFIX/bin/openclaw-acp"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(script).toContain('exec "${PREFIX}/tools/node/bin/node" "${repo_dir}/openclaw-acp.mjs"');
+  });
+
   it("rejects a git checkout without a commit before updating it", () => {
     const result = runInstallCliShell(`
       set -euo pipefail

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -968,6 +968,9 @@ describe("install.ps1 failure handling", () => {
     expect(gitInstallBody).toContain("Test-Path $entryPath");
     expect(gitInstallBody).toContain('Write-Host "[!] OpenClaw build did not produce $entryPath"');
     expect(gitInstallBody).toContain('node ""$entryPath"" %*');
+    expect(gitInstallBody).toContain('$acpEntryPath = Join-Path $RepoDir "openclaw-acp.mjs"');
+    expect(gitInstallBody).toContain('node ""$acpEntryPath"" %*');
+    expect(gitInstallBody).toContain("Test-Path $acpEntryPath");
     expect(gitInstallBody).not.toContain("& $pnpmCommand -C $RepoDir install");
     expect(gitInstallBody).not.toContain('node ""$RepoDir\\\\dist\\\\entry.js"" %*');
   });

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -297,7 +297,7 @@ describe("install.sh", () => {
       node_dir="node-bin"
       cd "$tmp"
       mkdir -p "$repo/.git" "$repo/dist" "$node_dir"
-      touch "$repo/dist/entry.js"
+      touch "$repo/dist/entry.js" "$repo/openclaw-acp.mjs"
       cat > "$node_dir/node" <<'NODE'
 #!/usr/bin/env bash
 printf 'fake-node:%s\\n' "$*"
@@ -335,9 +335,12 @@ NODE
 
       install_openclaw_from_git "$repo"
       wrapper="$HOME/.local/bin/openclaw"
+      acp_wrapper="$HOME/.local/bin/openclaw-acp"
       grep -F "$tmp/$node_dir/node" "$wrapper"
+      grep -F "$tmp/$node_dir/node" "$acp_wrapper"
       cd /
       PATH="/usr/bin:/bin" "$wrapper" --version
+      PATH="/usr/bin:/bin" "$acp_wrapper" --version
     `);
 
     expect(result.status).toBe(0);
@@ -345,6 +348,7 @@ NODE
     expect(result.stdout).toContain("/node-bin/node");
     expect(result.stdout).toContain("fake-node:");
     expect(result.stdout).toContain("/repo/dist/entry.js --version");
+    expect(result.stdout).toContain("/repo/openclaw-acp.mjs --version");
   });
 
   it("rejects a git checkout without a commit without modifying it", () => {

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -195,6 +195,15 @@ describe("install smoke no-push root image transport", () => {
     expect(verify.run).not.toContain("PUSH_RESULT");
   });
 
+  it("proves the native ACP launcher in the root Docker image", () => {
+    const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
+    for (const jobName of ["install-smoke-fast", "root_dockerfile_smokes"]) {
+      const smoke = step(job(workflow, jobName), "Run root Dockerfile CLI smoke");
+      expect(smoke.run, jobName).toContain("which openclaw-acp");
+      expect(smoke.run, jobName).toContain("test -x /app/openclaw-acp.mjs");
+    }
+  });
+
   it("verifies and loads the immutable artifact in every consumer", () => {
     const workflow = readWorkflow(INSTALL_SMOKE_REUSABLE);
     for (const jobName of [

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -201,6 +201,9 @@ describe("install smoke no-push root image transport", () => {
       const smoke = step(job(workflow, jobName), "Run root Dockerfile CLI smoke");
       expect(smoke.run, jobName).toContain("which openclaw-acp");
       expect(smoke.run, jobName).toContain("test -x /app/openclaw-acp.mjs");
+      expect(smoke.run, jobName).toContain(
+        'openclaw-acp --help | grep -F "Run OpenClaw as a self-contained ACP agent"',
+      );
     }
   });
 

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -921,6 +921,11 @@ printf 'status=%s\\n' "$status"
     expect(dockerfile).toContain(
       'OPENCLAW_RUN_NODE_SKIP_DTS_BUILD="$OPENCLAW_DOCKER_BUILD_SKIP_DTS" OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB="$OPENCLAW_DOCKER_BUILD_TSDOWN_MAX_OLD_SPACE_MB" NODE_OPTIONS="$OPENCLAW_DOCKER_BUILD_NODE_OPTIONS" pnpm_config_verify_deps_before_run=false pnpm build:docker',
     );
+    expect(dockerfile).toContain("COPY openclaw.mjs openclaw-acp.mjs ./");
+    expect(dockerfile).toContain(
+      "COPY --from=runtime-assets --chown=node:node /app/openclaw-acp.mjs .",
+    );
+    expect(dockerfile).toContain("ln -sf /app/openclaw-acp.mjs /usr/local/bin/openclaw-acp");
   });
 
   it("exports the Playwright browser cache installed by the root Dockerfile", () => {


### PR DESCRIPTION
Related: #116310

Stacked on https://github.com/openclaw/openclaw/pull/116394.

Buzz integration: https://github.com/block/buzz/pull/3868.

## What Problem This Solves

Buzz and similar ACP hosts launch a self-contained stdio child and inject the agent identity into that process. Existing `openclaw acp` is a Gateway bridge: the model loop and tools execute in another process, so a fresh Buzz install has no Gateway lifecycle owner and its inherited `BUZZ_*` environment does not reach tool execution.

## Compatibility

- `openclaw acp` remains the shipped Gateway-backed bridge
- `openclaw acp gateway` is an explicit alias for that bridge
- the pinned ACPX `openclaw` alias remains documented as the Gateway bridge
- `openclaw acp native` starts the new self-contained runtime
- `openclaw-acp` is the dedicated native executable ACP hosts should discover
- supported shell, npm-prefix, git, and PowerShell installer paths expose the capability executable only when its entry exists and remove stale managed wrappers on downgrade or install-method changes

The distinct executable is an additive capability marker. Older OpenClaw releases do not expose it and therefore cannot be mistaken for native-capable installs.

## Native ACP Contract

- ACP transport over stdio
- the ACP process runs OpenClaw's canonical ingress agent loop and tools
- ACP prompts are non-owner ingress; owner-only core tools remain unavailable without a separate host-attestation contract
- permission responses authorize only the requested call and do not attest prompt identity
- inherited environment reaches permitted local tool execution
- one canonical OpenClaw session key per ACP session
- exec approval hosts receive only sanitized reviewer text and environment key names, never env values, raw argv, or execution plans
- exec and plugin approvals use canonical presentation and request-specific decisions, then fail closed on invalid, expired, cancelled, or oversized requests
- embedded plugin approvals carry their originating run identity and cannot be authorized by a later turn in the same session
- approval expiry may use configured fallback; turn cancellation and session interruption remain run-aborted and cannot authorize fallback execution
- prompt replacement uses the same bounded abort-settle budget as close and shutdown, including executors that ignore abort
- close and shutdown fence queued prompts, abort active work, and use the established bounded abort-settle budget before runtime/state teardown
- thought delivery is fenced by session identity, prompt generation, active run, abort state, and shutdown state
- native session creation uses the same 120-per-10-second burst guard as the Gateway bridge
- delivery is disabled; the host receives only canonical final user-visible text
- raw assistant event deltas, internal directives, and `NO_REPLY` are not emitted as successful final replies
- failed, timed-out, or cancelled turns reject or return the matching ACP stop reason
- model setup is advertised through ACP terminal authentication

There is no managed Gateway, connection-failure fallback, companion node, port, token, or second agent runtime.

## User Impact

After normal OpenClaw model authentication, an ACP host can launch `openclaw-acp` and receive a real OpenClaw turn without asking the user to configure or operate a Gateway.

## Evidence

- native ACP and installer tests: 332 passed
- focused approval tests: 26 passed
- teardown regressions cover abort-ignoring executors during session close and process shutdown
- approval regressions cover canonical plugin presentation, secret/control-text redaction, truncation, and fail-closed oversized requests
- installer regressions cover package/source capability wrappers and stale-wrapper cleanup
- latest native authority/lifecycle and image-contract regressions: 127 passed
- official root Docker image smoke jobs resolve `openclaw-acp` and verify the shipped launcher is executable
- exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30896617000
- exact head: `481a74ba6b1825ba7e77dde0bdfb2c25a1752d52`
- direct dependency proof: `@agentclientprotocol/sdk` 1.3.0 accepts numeric uint16 negotiation; Buzz sends protocol version 2 and accepts the negotiated response
- formatting and `git diff --check`: clean
- TruffleHog pre-review scan: clean
- autoreview infrastructure blocker: the required `gpt-5.6-sol` subprocess was SIGKILLed with exit `-9` before producing findings

The final head closes the exact-review findings around canonical plugin approval presentation, per-run plugin authority, bounded prompt replacement, late-event fencing, and distribution of the public `openclaw-acp` capability executable.

The result/error projection was moved into a focused ACP helper to keep the runtime owner below the repository's production max-lines limit; this is behavior-neutral.

## Remaining Live Proof

A clean Testbox has no usable OpenAI authentication. The built OpenClaw CLI reported the selected `openai/gpt-5.6-sol` route as missing OpenAI authentication. A real Buzz mention/signed-reply round trip remains required on an authenticated Crabbox before release.
