### PR TITLE
fix(telegram): keep queued tool progress in one message

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -280,10 +280,14 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
     await queuedReplyOptions?.onQueuedFollowupAdmitted?.();
     await queuedReplyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+    await queuedReplyOptions?.onToolResult?.({ text: "📄 Web Fetch: working" });
 
     expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(draftStream.updatePreview).toHaveBeenCalledWith(
-      telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
+      telegramProgressPreview(
+        "Shelling\n\n🛠️ Exec\n📄 Web Fetch: working",
+        "<b>Shelling</b>\n<b>🛠️ Exec</b>\n📄 Web Fetch: working",
+      ),
     );
 
     await queuedReplyOptions?.onQueuedFollowupSettled?.();

--- a/src/auto-reply/reply/followup-turn-execution.test.ts
+++ b/src/auto-reply/reply/followup-turn-execution.test.ts
@@ -262,9 +262,10 @@ describe("executeFollowupTurn", () => {
     expect(onNarrationUpdate).not.toHaveBeenCalled();
   });
 
-  it("honors channel-forced tool progress when verbosity is off", async () => {
+  it("routes channel-forced tool progress through the channel when verbosity is off", async () => {
     const onToolStart = vi.fn(async () => {});
-    const onToolResult = vi.fn(async () => {});
+    const onChannelToolResult = vi.fn(async () => {});
+    const onDurableToolResult = vi.fn(async () => {});
     const turn = createTurn({
       session: {
         kind: "session",
@@ -276,7 +277,7 @@ describe("executeFollowupTurn", () => {
     });
     state.execute.mockImplementation(async (params: AgentTurnParams) => {
       await params.opts?.onToolStart?.({ name: "read", phase: "start" });
-      await params.opts?.onToolResult?.({ text: "working" });
+      await params.opts?.onToolResult?.({ text: "📄 Web Fetch: working" });
       return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
     });
 
@@ -286,15 +287,86 @@ describe("executeFollowupTurn", () => {
         typing: createTypingController(),
         typingMode: "never",
         defaultModel: "claude",
-        opts: { forceToolResultProgress: true, onToolStart },
+        opts: {
+          forceToolResultProgress: true,
+          onToolStart,
+          onToolResult: onChannelToolResult,
+        },
       },
-      onToolResult,
+      onToolResult: onDurableToolResult,
       onCompactionNoticePayload: vi.fn(async () => {}),
     });
     await result.progress.drain();
 
     expect(onToolStart).toHaveBeenCalledOnce();
-    expect(onToolResult).toHaveBeenCalledWith({ text: "working" }, { runId: "run-1" });
+    expect(onChannelToolResult).toHaveBeenCalledWith({ text: "📄 Web Fetch: working" });
+    expect(onDurableToolResult).not.toHaveBeenCalled();
+  });
+
+  it("keeps verbose tool results durable when channel progress is available", async () => {
+    const onChannelToolResult = vi.fn(async () => {});
+    const onDurableToolResult = vi.fn(async () => {});
+    state.execute.mockImplementation(async (params: AgentTurnParams) => {
+      await params.opts?.onToolResult?.({ text: "📄 Web Fetch: working" });
+      return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
+    });
+
+    const result = await executeFollowupTurn({
+      turn: createTurn(),
+      defaults: {
+        typing: createTypingController(),
+        typingMode: "never",
+        defaultModel: "claude",
+        opts: {
+          forceToolResultProgress: true,
+          onToolResult: onChannelToolResult,
+        },
+      },
+      onToolResult: onDurableToolResult,
+      onCompactionNoticePayload: vi.fn(async () => {}),
+    });
+    await result.progress.drain();
+
+    expect(onChannelToolResult).not.toHaveBeenCalled();
+    expect(onDurableToolResult).toHaveBeenCalledWith(
+      { text: "📄 Web Fetch: working" },
+      { runId: "run-1" },
+    );
+  });
+
+  it("keeps forced tool results durable when channel progress is unavailable", async () => {
+    const onDurableToolResult = vi.fn(async () => {});
+    const turn = createTurn({
+      session: {
+        kind: "session",
+        key: "main",
+        current: () => ({ sessionId: "session", updatedAt: 1, verboseLevel: "off" }),
+        publish: () => undefined,
+        adopt: () => undefined,
+      },
+    });
+    state.execute.mockImplementation(async (params: AgentTurnParams) => {
+      await params.opts?.onToolResult?.({ text: "📄 Web Fetch: working" });
+      return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
+    });
+
+    const result = await executeFollowupTurn({
+      turn,
+      defaults: {
+        typing: createTypingController(),
+        typingMode: "never",
+        defaultModel: "claude",
+        opts: { forceToolResultProgress: true },
+      },
+      onToolResult: onDurableToolResult,
+      onCompactionNoticePayload: vi.fn(async () => {}),
+    });
+    await result.progress.drain();
+
+    expect(onDurableToolResult).toHaveBeenCalledWith(
+      { text: "📄 Web Fetch: working" },
+      { runId: "run-1" },
+    );
   });
 
   it("allows explicitly opted-in tool lifecycle while ordinary progress is hidden", async () => {

--- a/src/auto-reply/reply/followup-turn-execution.ts
+++ b/src/auto-reply/reply/followup-turn-execution.ts
@@ -66,6 +66,7 @@ export async function executeFollowupTurn(params: {
   onCompactionNoticePayload: (payload: ReplyPayload, execution: { runId: string }) => Promise<void>;
 }): Promise<FollowupExecutionResult> {
   const { turn, defaults } = params;
+  const sourceOpts = defaults.opts;
   const roomEvent = turn.queued.currentInboundEventKind === "room_event";
   const progressAllowed = () => turn.sendPolicy === "allow" && !roomEvent;
   const currentVerboseLevel = (): VerboseLevel => {
@@ -96,11 +97,14 @@ export async function executeFollowupTurn(params: {
     const level = session.current()?.verboseLevel ?? turn.queued.run.verboseLevel;
     return level === "on" || level === "full" ? level : "off";
   };
+  const forceToolResultProgress = sourceOpts?.forceToolResultProgress === true;
+  const channelToolResultProgress = forceToolResultProgress ? sourceOpts.onToolResult : undefined;
+  const shouldEmitVerboseToolResult = () => {
+    const level = currentVerboseLevel();
+    return level === "on" || level === "full";
+  };
   const shouldEmitToolResult = () =>
-    progressAllowed() &&
-    (defaults.opts?.forceToolResultProgress === true ||
-      currentVerboseLevel() === "on" ||
-      currentVerboseLevel() === "full");
+    progressAllowed() && (forceToolResultProgress || shouldEmitVerboseToolResult());
   const shouldEmitToolOutput = () => progressAllowed() && currentVerboseLevel() === "full";
   const shouldEmitToolLifecycle = () =>
     progressAllowed() &&
@@ -147,7 +151,6 @@ export async function executeFollowupTurn(params: {
         baseTypingSignals.signalExecutionActivity ?? baseTypingSignals.signalRunStart,
       ),
   };
-  const sourceOpts = defaults.opts;
   const progressOpts: InternalGetReplyOptions = {
     ...sourceOpts,
     runId: turn.runId,
@@ -226,14 +229,19 @@ export async function executeFollowupTurn(params: {
         if (!progressAllowed()) {
           return;
         }
-        const toolResultProgressVisible = shouldEmitToolResult();
+        const verboseToolResult = shouldEmitVerboseToolResult();
+        const toolResultProgressVisible = Boolean(channelToolResultProgress) || verboseToolResult;
         if (
           turn.queued.run.sourceReplyDeliveryMode === "message_tool_only" &&
           !toolResultProgressVisible
         ) {
           return;
         }
-        await params.onToolResult(payload, { runId: turn.runId });
+        if (channelToolResultProgress && !verboseToolResult) {
+          await channelToolResultProgress(payload);
+        } else {
+          await params.onToolResult(payload, { runId: turn.runId });
+        }
         if (payload.isError === true) {
           visibleToolError = true;
         }


### PR DESCRIPTION
## What Problem This Solves

Queued Telegram follow-ups in progress mode treated `forceToolResultProgress` as permission to send every tool result through durable reply delivery. With verbose mode off, Web Search and Web Fetch updates became separate bot messages instead of revisions of the existing progress message. The regression came from #114590.

## Fix

Route forced, quiet queued tool results through the channel-owned `onToolResult` callback. Keep durable delivery for explicit verbose mode and as the fallback when no channel progress callback exists. Add core routing/fallback coverage and Telegram draft accumulation coverage.

## Evidence

- Focused Vitest: 43 passed across follow-up execution and Telegram progress dispatch.
- Typecheck: `tsgo:core` and `tsgo:extensions:test` passed.
- Targeted core and Telegram Oxlint passed; `git diff --check` passed.
- Distill: no further structural simplification. Greybeard: no performance findings. Autoreview: clean after both implementation passes, 0.99 confidence; TruffleHog clean.

### Real Telegram E2E

Exact tested tree before the clean rebase: `4fca6007941`. Rebased head: `14d792a295f`; the three-file patch is unchanged. Real TDLib user, mock provider, queue mode `followup`, Telegram streaming mode `progress`, commentary enabled. Private chat, user, and raw Telegram identifiers are redacted. Bot API message IDs are consistently mapped below.

```text
+8.2s  message  first-turn   OPENCLAW_E2E_OK
+9.2s  message  progress-p1 Working / Checking the workspace before answering.
+10.2s message  final-f1    OPENCLAW_E2E_DRAFTPROOF
+11.2s edit     progress-p1 same message; appended commentary and Exec tool rows

SUT totals: message=3, edit=1
Assertion: the only tool-progress revision is an edit of progress-p1. No per-tool message was created. The final answer is the separate persistent final-f1 message.
```

A preceding run on runtime-identical parent `e9090b3dbb0` additionally recorded the queued cleanup deletion of that same progress message after its edit: message=3, edit=1, delete=1. The only parent-to-head source change removed the release-owned changelog line.

Command shape, secrets and paths omitted:

```text
MOCK_RESPONSE_CHUNK_DELAY_MS=6000
messages.queue.mode=followup
channels.telegram.streaming.mode=progress
pre-send: Reply with the configured success marker.
send: Run the OPENCLAW_E2E_DRAFTPROOF scenario.
record events.ndjson and summary.json
```

Full `check:changed` delegation was unavailable because this checkout has no Crabbox or Blacksmith executable. Local `tsgo:core:test` fallback reached a pre-existing missing `@openclaw/session-url-contract/parse` package in the borrowed dependency tree; focused runtime tests passed and PR CI remains authoritative.