### PR TITLE
fix(openai): gate GPT-Live broker cleanup on plugin-disable reason (#116525)

### DIFF
--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -24,6 +24,15 @@ const runtimeMocks = vi.hoisted(() => ({
   refreshOpenAICodexToken: vi.fn(),
 }));
 
+const quicksilverBrokerMocks = vi.hoisted(() => ({
+  cleanup: vi.fn(),
+  create: vi.fn(() => ({
+    handler: vi.fn(),
+    cleanup: quicksilverBrokerMocks.cleanup,
+    broker: {},
+  })),
+}));
+
 vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
     "openclaw/plugin-sdk/runtime-env",
@@ -37,6 +46,16 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
 vi.mock("./openai-chatgpt-oauth-flow.runtime.js", () => ({
   refreshOpenAICodexToken: runtimeMocks.refreshOpenAICodexToken,
 }));
+
+vi.mock("./realtime-quicksilver-session.js", async () => {
+  const actual = await vi.importActual<typeof import("./realtime-quicksilver-session.js")>(
+    "./realtime-quicksilver-session.js",
+  );
+  return {
+    ...actual,
+    createOpenAIQuicksilverBrowserSessionBroker: quicksilverBrokerMocks.create,
+  };
+});
 
 import { createOpenAICodexProviderRuntime } from "./openai-chatgpt-provider-runtime.factory.js";
 async function registerOpenAIPluginWithHook(params?: { pluginConfig?: Record<string, unknown> }) {
@@ -183,6 +202,40 @@ describe("openai plugin", () => {
         cleanup: expect.any(Function),
       }),
     );
+  });
+
+  it("only tears down the GPT-Live broker on plugin disable, not session reset/delete/restart", () => {
+    quicksilverBrokerMocks.cleanup.mockClear();
+    quicksilverBrokerMocks.create.mockClear();
+    const registerRuntimeLifecycle = vi.fn();
+    plugin.register(
+      createTestPluginApi({
+        id: "openai",
+        name: "OpenAI Provider",
+        source: "test",
+        config: {},
+        runtime: { config: { current: vi.fn(() => ({})) } } as never,
+        registerRuntimeLifecycle,
+      }),
+    );
+
+    const registration = registerRuntimeLifecycle.mock.calls.find(
+      (call) => call[0]?.id === "openai-quicksilver-realtime-browser-session",
+    );
+    expectDefined(registration, "quicksilver runtime lifecycle registration");
+    const cleanup = registration[0].cleanup as (ctx: {
+      reason: "disable" | "reset" | "delete" | "restart";
+    }) => void;
+
+    // Unrelated session cleanup must not stop the shared process-wide broker.
+    for (const reason of ["reset", "delete", "restart"] as const) {
+      cleanup({ reason });
+    }
+    expect(quicksilverBrokerMocks.cleanup).not.toHaveBeenCalled();
+
+    // Plugin disable tears the broker down.
+    cleanup({ reason: "disable" });
+    expect(quicksilverBrokerMocks.cleanup).toHaveBeenCalledTimes(1);
   });
 
   it("generates PNG buffers from the OpenAI Images API", async () => {

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -13,7 +13,7 @@ import {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
-import plugin from "./index.js";
+import plugin, { __resetSharedQuicksilverSessionForTests } from "./index.js";
 
 const OPENAI_FRIENDLY_PROMPT_OVERLAY = GPT5_FRIENDLY_CHAT_PROMPT_OVERLAY;
 const OPENAI_GPT5_BEHAVIOR_CONTRACT = GPT5_BEHAVIOR_CONTRACT;
@@ -168,6 +168,7 @@ function expectNoRequestUrl(mocked: unknown, url: string): void {
 describe("openai plugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetSharedQuicksilverSessionForTests();
   });
 
   afterEach(() => {
@@ -238,6 +239,30 @@ describe("openai plugin", () => {
     // Plugin disable tears the broker down.
     cleanup({ reason: "disable" });
     expect(quicksilverBrokerMocks.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses one GPT-Live broker across repeated full registrations", () => {
+    quicksilverBrokerMocks.create.mockClear();
+    const register = () =>
+      plugin.register(
+        createTestPluginApi({
+          id: "openai",
+          name: "OpenAI Provider",
+          source: "test",
+          config: {},
+          runtime: { config: { current: vi.fn(() => ({})) } } as never,
+          registerRuntimeLifecycle: vi.fn(),
+        }),
+      );
+
+    // First full registration creates the shared broker.
+    register();
+    expect(quicksilverBrokerMocks.create).toHaveBeenCalledTimes(1);
+
+    // A second full registration reuses it instead of splitting a new broker
+    // (which would leave reservation and offer-handler state out of sync).
+    register();
+    expect(quicksilverBrokerMocks.create).toHaveBeenCalledTimes(1);
   });
 
   it("generates PNG buffers from the OpenAI Images API", async () => {

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -222,7 +222,9 @@ describe("openai plugin", () => {
     const registration = registerRuntimeLifecycle.mock.calls.find(
       (call) => call[0]?.id === "openai-quicksilver-realtime-browser-session",
     );
-    expectDefined(registration, "quicksilver runtime lifecycle registration");
+    if (!registration) {
+      throw new Error("quicksilver runtime lifecycle not registered");
+    }
     const cleanup = registration[0].cleanup as (ctx: {
       reason: "disable" | "reset" | "delete" | "restart";
     }) => void;

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -13,7 +13,7 @@ import {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIImageGenerationProvider } from "./image-generation-provider.js";
-import plugin, { __resetSharedQuicksilverSessionForTests } from "./index.js";
+import plugin, { resetSharedQuicksilverSessionForTests } from "./index.js";
 
 const OPENAI_FRIENDLY_PROMPT_OVERLAY = GPT5_FRIENDLY_CHAT_PROMPT_OVERLAY;
 const OPENAI_GPT5_BEHAVIOR_CONTRACT = GPT5_BEHAVIOR_CONTRACT;
@@ -168,7 +168,7 @@ function expectNoRequestUrl(mocked: unknown, url: string): void {
 describe("openai plugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    __resetSharedQuicksilverSessionForTests();
+    resetSharedQuicksilverSessionForTests();
   });
 
   afterEach(() => {

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -51,6 +51,7 @@ export default definePluginEntry({
           if (ctx.reason === "disable") {
             return quicksilverSession.cleanup();
           }
+          return undefined;
         },
       });
     }

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -20,6 +20,18 @@ import { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 import { buildOpenAISpeechProvider } from "./speech-provider.js";
 import { buildOpenAIVideoGenerationProvider } from "./video-generation-provider.js";
 
+// The GPT-Live browser broker is process-wide shared state. Reuse one broker
+// across repeated full OpenAI plugin registrations so reservation and offer
+// state stay together; only disable tears it down and allows the next full
+// registration to create a fresh one (#116525).
+type QuicksilverSession = ReturnType<typeof createOpenAIQuicksilverBrowserSessionBroker>;
+let sharedQuicksilverSession: QuicksilverSession | undefined;
+
+/** Test-only: drop the shared broker so repeated-registration tests start clean. */
+export function __resetSharedQuicksilverSessionForTests(): void {
+  sharedQuicksilverSession = undefined;
+}
+
 export default definePluginEntry({
   id: "openai",
   name: "OpenAI Provider",
@@ -27,10 +39,11 @@ export default definePluginEntry({
   register(api) {
     const quicksilverSession =
       api.registrationMode === "full"
-        ? createOpenAIQuicksilverBrowserSessionBroker({
+        ? (sharedQuicksilverSession ??
+          (sharedQuicksilverSession = createOpenAIQuicksilverBrowserSessionBroker({
             getConfig: () => api.runtime.config.current() as OpenClawConfig,
             logger: api.logger,
-          })
+          })))
         : undefined;
     if (quicksilverSession) {
       api.registerHttpRoute({
@@ -49,7 +62,9 @@ export default definePluginEntry({
           // restart), and cleanup() permanently stops the broker for the whole
           // process, so session cleanup must not trigger it (#116525).
           if (ctx.reason === "disable") {
-            return quicksilverSession.cleanup();
+            const session = sharedQuicksilverSession;
+            sharedQuicksilverSession = undefined;
+            return session?.cleanup();
           }
           return undefined;
         },

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -28,7 +28,7 @@ type QuicksilverSession = ReturnType<typeof createOpenAIQuicksilverBrowserSessio
 let sharedQuicksilverSession: QuicksilverSession | undefined;
 
 /** Test-only: drop the shared broker so repeated-registration tests start clean. */
-export function __resetSharedQuicksilverSessionForTests(): void {
+export function resetSharedQuicksilverSessionForTests(): void {
   sharedQuicksilverSession = undefined;
 }
 

--- a/extensions/openai/index.ts
+++ b/extensions/openai/index.ts
@@ -42,7 +42,16 @@ export default definePluginEntry({
       api.lifecycle.registerRuntimeLifecycle({
         id: "openai-quicksilver-realtime-browser-session",
         description: "Close GPT-Live browser sidebands when the OpenAI plugin stops",
-        cleanup: () => quicksilverSession.cleanup(),
+        cleanup: (ctx) => {
+          // The broker is process-wide shared state; only tear it down when the
+          // OpenAI plugin itself is disabled. host-hook-cleanup.ts invokes this
+          // callback for every reason (including unrelated session reset/delete/
+          // restart), and cleanup() permanently stops the broker for the whole
+          // process, so session cleanup must not trigger it (#116525).
+          if (ctx.reason === "disable") {
+            return quicksilverSession.cleanup();
+          }
+        },
       });
     }
     const openAIToolCompatHooks = buildProviderToolCompatFamilyHooks("openai");


### PR DESCRIPTION
## What Problem This Solves

The shared GPT-Live browser broker (GPT-Live) was permanently stopped when plugin host cleanup ran for an **unrelated** agent session. `talk.catalog` still reported realtime ready, but `talk.client.create` failed: `"OpenAI GPT-Live sessions are stopping; restart Gateway and try again"`. Introduced by #115226.

Fixes #116525

## Why This Change Was Made

`extensions/openai/index.ts` registered the broker cleanup as an **unconditional** runtime lifecycle callback. `src/plugins/host-hook-cleanup.ts` invokes every registered lifecycle callback during session reset/delete/restart (passing `{ reason, sessionKey, runId }`), but the callback ignored `ctx` and ran `gptLiveSession.cleanup()` for every reason. `cleanup()` sets a closure-scoped `cleanedUp = true` and aborts the `shutdownController` — process-lifetime state of the single shared broker — so one unrelated session reset permanently killed the broker for the whole process.

The fix reads `ctx.reason` and only runs the broker shutdown when `reason === "disable"`. The `reason` is already plumbed through to the callback by `host-hook-cleanup.ts` (lines 299-303); the plugin-disable path already emits `reason: "disable"` (`registry.ts:57`, `host-hook-cleanup.ts:443`). No core changes needed. This matches the issue's verified resolution: "Restricting broker cleanup to actual plugin disable kept the broker usable."



**Broker singleton (repeated-registration fix):** beyond the cleanup gate, each full plugin registration previously created a *new* `createOpenAIGptLiveBrowserSessionBroker`, so a plugin reload split reservation state from the offer handler. The broker is now held in a module-level singleton (`sharedGptLiveSession`), reused across full registrations, and only cleared on `disable` (so the next full registration creates a fresh one). This addresses ClawSweeper's P1 that the cleanup gate alone left the repeated-registration broker split open.

## User Impact

- **Before:** any session reset/delete/restart permanently stopped the GPT-Live broker for the whole Gateway process; Browser Talk could not start until a Gateway restart (which itself restarted the broker, masking the cause).
- **After:** only disabling the OpenAI plugin tears down the broker. Session reset/delete/restart leave it intact. Process exit still cleans up sockets/timers naturally.

## Evidence

**Behavior addressed:** the registered lifecycle cleanup no longer calls `gptLiveSession.cleanup()` for `reset`/`delete`/`restart`; only `disable` triggers it.

**Validation (trusted source, local checkout on Node 24.18.0):**

```
node scripts/run-vitest.mjs extensions/openai/index.test.ts
# Test Files 1 passed (1) | Tests 15 passed (15)
```

New regression test `only tears down the GPT-Live broker on plugin disable, not session reset/delete/restart`:
- mocks `createOpenAIGptLiveBrowserSessionBroker` so `cleanup` is a spy;
- captures the registered lifecycle callback;
- calls it with `reason: "reset"`, `"delete"`, `"restart"` → asserts `cleanup` spy **not** called (broker survives);
- calls it with `reason: "disable"` → asserts `cleanup` spy called once (broker shuts down).

The existing `registers the native GPT-Live offer route and cleanup lifecycle` test still passes (registration shape unchanged; only the callback body now checks `reason`).

- `reuses one GPT-Live broker across repeated full registrations` — two full registrations call `createOpenAIGptLiveBrowserSessionBroker` only once (singleton reuse); the shared session is reset between tests via `__resetSharedGptLiveSessionForTests`.

**Boundary:** change is internal to `extensions/openai/index.ts` (callback body) + test. No changes to `host-hook-cleanup.ts`, the `PluginHostCleanupReason` enum, or the broker state machine. `ctx.reason` already existed on `PluginRuntimeLifecycleRegistration` (`src/plugins/host-hooks.ts:153-161`). Per `src/plugins/CLAUDE.md` "honor plugin disablement", this precisely implements that semantic for the broker.


