### PR TITLE
fix(exec): size approved continuations at resumed attempt

### DIFF
--- a/packages/gateway-protocol/src/schema/agent.test.ts
+++ b/packages/gateway-protocol/src/schema/agent.test.ts
@@ -81,6 +81,35 @@ describe("AgentParamsSchema", () => {
     ).toBe(true);
   });
 
+  it("accepts a backend-issued approved exec continuation range", () => {
+    expect(
+      Value.Check(AgentParamsSchema, {
+        message: "resume from approved exec output",
+        sessionKey: "agent:main:main",
+        internalRuntimeHandoffId: "handoff-1",
+        execApprovalContinuationPromptRange: { start: 16, end: 128 },
+        idempotencyKey: "exec-followup-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects malformed approved exec continuation ranges", () => {
+    for (const execApprovalContinuationPromptRange of [
+      { start: -1, end: 128 },
+      { start: 16.5, end: 128 },
+      { start: 16, end: "128" },
+      { start: 16, end: 128, extra: true },
+    ]) {
+      expect(
+        Value.Check(AgentParamsSchema, {
+          message: "resume from approved exec output",
+          execApprovalContinuationPromptRange,
+          idempotencyKey: "exec-followup-invalid",
+        }),
+      ).toBe(false);
+    }
+  });
+
   it("rejects host-owned delivery media constraints from public requests", () => {
     expect(
       Value.Check(AgentParamsSchema, {

--- a/packages/gateway-protocol/src/schema/agent.ts
+++ b/packages/gateway-protocol/src/schema/agent.ts
@@ -322,6 +322,12 @@ export const AgentParamsSchema = closedObject({
   acpTurnSource: Type.Optional(Type.Literal("manual_spawn")),
   internalRuntimeHandoffId: Type.Optional(NonEmptyString),
   execApprovalFollowupExpectedSessionId: Type.Optional(NonEmptyString),
+  execApprovalContinuationPromptRange: Type.Optional(
+    closedObject({
+      start: Type.Integer({ minimum: 0 }),
+      end: Type.Integer({ minimum: 0 }),
+    }),
+  ),
   internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
   inputProvenance: Type.Optional(InputProvenanceSchema),
   suppressPromptPersistence: Type.Optional(Type.Boolean()),

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -126,8 +126,14 @@ describe("exec approval followup", () => {
       resultText,
     });
 
-    const prompt = expectGatewayAgentFollowup({ sessionKey: "agent:main:main" }).message;
+    const params = expectGatewayAgentFollowup({ sessionKey: "agent:main:main" });
+    const prompt = params.message;
     expect(prompt).toContain(`Exact completion details:\n${resultText}\n\nContinue the task`);
+    const range = requireRecord(
+      params.execApprovalContinuationPromptRange,
+      "exec approval continuation prompt range",
+    );
+    expect(String(prompt).slice(Number(range.start), Number(range.end))).toBe(resultText);
   });
 
   it("trims denial details before classification and rendering", async () => {
@@ -141,6 +147,9 @@ describe("exec approval followup", () => {
     expect(prompt).toContain("did not run");
     expect(prompt).not.toContain("\r\n  Exec denied");
     expect(prompt).not.toContain("already approved has completed");
+    expect(expectGatewayAgentFollowup({ sessionKey: "agent:main:main" })).not.toHaveProperty(
+      "execApprovalContinuationPromptRange",
+    );
   });
 
   it("delivers successful result text to the agent without trimming it", async () => {

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -24,12 +24,17 @@ import {
   buildExecApprovalFollowupIdempotencyKey,
   isExecApprovalFollowupSessionRebound,
 } from "./bash-tools.exec-approval-followup-state.js";
+import {
+  resizeExecApprovalContinuationPrompt,
+  type ExecApprovalContinuationPromptRange,
+} from "./bash-tools.exec-approval-output.js";
 import { sanitizeUserFacingText } from "./embedded-agent-helpers/sanitize-user-facing-text.js";
 import {
   formatExecDeniedUserMessage,
   isExecDeniedResultText,
   parseExecApprovalResultText,
 } from "./exec-approval-result.js";
+import { DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS } from "./tool-result-limits.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 const log = createSubsystemLogger("agents/exec-approval-followup");
@@ -89,24 +94,36 @@ function formatUnknownError(error: unknown): string {
  * a successful result is emitted verbatim so trailing output whitespace, blank
  * lines and indentation survive into the continuation.
  */
-function buildExecApprovalFollowupPrompt(resultText: string): string {
+function buildExecApprovalFollowupPrompt(resultText: string): {
+  message: string;
+  resultRange?: ExecApprovalContinuationPromptRange;
+} {
   const trimmed = resultText.trim();
   if (isExecDeniedResultText(trimmed)) {
-    return buildExecDeniedFollowupPrompt(trimmed);
+    return { message: buildExecDeniedFollowupPrompt(trimmed) };
   }
-  return [
+  const prefix = [
     "An async command the user already approved has completed.",
     "Do not run the command again.",
     "If the task requires more steps, continue from this result before replying to the user.",
     "Only ask the user for help if you are actually blocked.",
     "",
     "Exact completion details:",
-    trimmed ? resultText : "",
-    "",
+  ].join("\n");
+  const suffix = [
     "Continue the task if needed, then reply to the user in a helpful way.",
     "If it succeeded, share the relevant output.",
     "If it failed, explain what went wrong.",
   ].join("\n");
+  const completionDetails = trimmed ? resultText : "";
+  const resultStart = prefix.length + 1;
+  return {
+    message: `${prefix}\n${completionDetails}\n\n${suffix}`,
+    resultRange: {
+      start: resultStart,
+      end: resultStart + completionDetails.length,
+    },
+  };
 }
 
 function shouldSuppressExecDeniedFollowup(sessionKey: string | undefined): boolean {
@@ -156,7 +173,12 @@ function formatDirectExecApprovalFollowupText(
   resultText: string,
   opts: { allowDenied?: boolean } = {},
 ): string | null {
-  const parsed = parseExecApprovalResultText(resultText);
+  const boundedResultText = resizeExecApprovalContinuationPrompt({
+    prompt: resultText,
+    range: { start: 0, end: resultText.length },
+    maxOutputUtf16Units: DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
+  });
+  const parsed = parseExecApprovalResultText(boundedResultText);
   if (parsed.kind === "other" && !parsed.raw) {
     return null;
   }
@@ -272,13 +294,17 @@ function buildAgentFollowupArgs(params: {
   idempotencyKey?: string;
 }) {
   const { deliveryTarget, sessionOnlyOriginChannel } = params;
+  const followupPrompt = buildExecApprovalFollowupPrompt(params.resultText);
   // When the followup run has no deliverable route and no gateway-internal channel,
   // preserve the raw turnSourceChannel so the spawned agent inherits messageProvider.
   // Without this, tools.elevated.allowFrom.<provider> checks fail with provider=null.
   const fallbackChannel = sessionOnlyOriginChannel ?? params.turnSourceChannel;
   return {
     sessionKey: params.sessionKey,
-    message: buildExecApprovalFollowupPrompt(params.resultText),
+    message: followupPrompt.message,
+    ...(followupPrompt.resultRange
+      ? { execApprovalContinuationPromptRange: followupPrompt.resultRange }
+      : {}),
     deliver: deliveryTarget.deliver,
     ...(deliveryTarget.deliver ? { bestEffortDeliver: true as const } : {}),
     channel: deliveryTarget.deliver ? deliveryTarget.channel : fallbackChannel,

--- a/src/agents/bash-tools.exec-approval-output.test.ts
+++ b/src/agents/bash-tools.exec-approval-output.test.ts
@@ -5,7 +5,10 @@
  * accounting above the cap.
  */
 import { describe, expect, it } from "vitest";
-import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval-output.js";
+import {
+  formatExecApprovalContinuationSourceOutput,
+  resizeExecApprovalContinuationPrompt,
+} from "./bash-tools.exec-approval-output.js";
 
 // Pinned rather than imported: the module keeps its budget private, and pinning
 // the resolved numbers makes any change to the cap or the head/tail split a
@@ -21,6 +24,17 @@ const TAIL = 3_974;
 const HEAD_LABELED = 11_903;
 const TAIL_LABELED = 3_968;
 const HEADER = "[stdout]\n".length;
+
+function formatExecApprovalContinuationOutput(
+  streams: Parameters<typeof formatExecApprovalContinuationSourceOutput>[0],
+): string {
+  const source = formatExecApprovalContinuationSourceOutput(streams);
+  return resizeExecApprovalContinuationPrompt({
+    prompt: source,
+    range: { start: 0, end: source.length },
+    maxOutputUtf16Units: MAX,
+  });
+}
 
 function marker(
   omitted: number,
@@ -117,10 +131,10 @@ describe("formatExecApprovalContinuationOutput", () => {
     expect(formatted.length).toBeLessThanOrEqual(MAX);
   });
 
-  it("holds the cap when the omitted count needs more digits than the cap itself", () => {
-    // The omitted count scales with the input, so a fixed five-digit marker
-    // reserve would overflow the cap once the input passes ~1M units.
-    for (const total of [100_000, 1_016_000, 12_000_000]) {
+  it("holds the cap when the omitted count grows beyond five digits", () => {
+    // The omitted count scales with the input, so the marker reserve must
+    // account for every digit available within the host transport bound.
+    for (const total of [100_000, 200_000]) {
       const formatted = formatExecApprovalContinuationOutput([
         { label: "output", value: "z".repeat(total) },
       ]);
@@ -205,5 +219,56 @@ describe("formatExecApprovalContinuationOutput", () => {
         "b".repeat(TAIL_LABELED),
     );
     expect(formatted.length).toBeLessThanOrEqual(MAX);
+  });
+
+  it("keeps valid host output intact until the resumed attempt resolves its cap", () => {
+    const stdout = "a".repeat(100_000);
+    const stderr = "b".repeat(100_000);
+
+    const formatted = formatExecApprovalContinuationSourceOutput([
+      { label: "stdout", value: stdout },
+      { label: "stderr", value: stderr },
+    ]);
+
+    expect(formatted).toBe(`[stdout]\n${stdout}\n[stderr]\n${stderr}`);
+  });
+
+  it("retains an absolute source cap before model resolution", () => {
+    const formatted = formatExecApprovalContinuationSourceOutput([
+      { label: "output", value: "z".repeat(300_000) },
+    ]);
+
+    expect(formatted.length).toBeLessThanOrEqual(256_000);
+    expect(formatted).toMatch(/UTF-16 code units omitted from approved exec output/);
+  });
+
+  it("resizes only the marked completion span for the resolved attempt", () => {
+    const prefix = "trusted continuation instructions\n";
+    const resultText = `Exec finished (code 1)\n[stdout]\n${"a".repeat(20_000)}\n[stderr]\n${"b".repeat(20_000)}`;
+    const suffix = "\ncontinue the task";
+    const prompt = `${prefix}${resultText}${suffix}`;
+
+    const resized = resizeExecApprovalContinuationPrompt({
+      prompt,
+      range: { start: prefix.length, end: prefix.length + resultText.length },
+      maxOutputUtf16Units: 8_000,
+    });
+
+    expect(resized.startsWith(prefix)).toBe(true);
+    expect(resized.endsWith(suffix)).toBe(true);
+    expect(resized.length).toBeLessThanOrEqual(prefix.length + 8_000 + suffix.length);
+    expect(resized).toMatch(/tail resumes in stderr/);
+    expect(resized).not.toMatch(/\[std(?!out\]\n|err\]\n)/);
+  });
+
+  it("ignores an invalid continuation span", () => {
+    const prompt = "unchanged";
+    expect(
+      resizeExecApprovalContinuationPrompt({
+        prompt,
+        range: { start: 2, end: 99 },
+        maxOutputUtf16Units: 4,
+      }),
+    ).toBe(prompt);
   });
 });

--- a/src/agents/bash-tools.exec-approval-output.ts
+++ b/src/agents/bash-tools.exec-approval-output.ts
@@ -8,6 +8,7 @@
  * whitespace are preserved verbatim and the budget is the model-facing one.
  */
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS } from "./tool-result-limits.js";
 
 /** One named output stream supplied by an exec host. */
 type ExecApprovalOutputStream = {
@@ -16,16 +17,18 @@ type ExecApprovalOutputStream = {
 };
 
 /**
- * Hard cap for continuation output, mirroring
- * `DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS` (tool-result-limits.ts): the floor every
- * exec tool result is truncated to when the model context window is unknown.
- * The host builds this text before the resuming agent's model is resolved, and
- * the text re-enters as a user follow-up that bypasses the tool-result guard,
- * so it needs its own bound. Head-weighted because command output front-loads
- * the failure and back-loads the summary.
+ * The exec host still needs an absolute transport bound before the resumed
+ * attempt resolves its model. Gateway aggregate output and node combined
+ * output are capped at 200k units, so 256k preserves every valid payload plus
+ * stream headers while bounding malformed or future sources.
  */
-const MAX_UTF16_UNITS = 16_000;
+const MAX_SOURCE_UTF16_UNITS = 256_000;
 const HEAD_SHARE = 0.75;
+
+export type ExecApprovalContinuationPromptRange = {
+  start: number;
+  end: number;
+};
 
 function buildOmissionMarker(params: {
   omitted: number;
@@ -55,15 +58,16 @@ function buildOmissionMarker(params: {
 function resolveCutBudget(
   totalUnits: number,
   longestLabelUnits: number,
+  maxUtf16Units: number,
 ): { head: number; tail: number } {
   const markerReserve =
     buildOmissionMarker({
       omitted: totalUnits,
-      headUnits: MAX_UTF16_UNITS,
-      tailUnits: MAX_UTF16_UNITS,
+      headUnits: maxUtf16Units,
+      tailUnits: maxUtf16Units,
       resumingLabel: "x".repeat(longestLabelUnits),
     }).length + 2;
-  const content = MAX_UTF16_UNITS - markerReserve;
+  const content = Math.max(0, maxUtf16Units - markerReserve);
   const head = Math.floor(content * HEAD_SHARE);
   return { head, tail: content - head };
 }
@@ -111,6 +115,27 @@ function renderExecOutputStreams(streams: ExecApprovalOutputStream[]): RenderedE
   return { text, headerRanges, streamRanges };
 }
 
+function readRenderedExecOutput(text: string): RenderedExecOutput {
+  const headers = Array.from(text.matchAll(/(?:^|\n)\[(stdout|stderr|error)\]\n/g), (match) => {
+    const leadingNewlineUnits = match[0].startsWith("\n") ? 1 : 0;
+    const start = (match.index ?? 0) + leadingNewlineUnits;
+    return {
+      label: match[1] ?? "",
+      start,
+      end: start + match[0].length - leadingNewlineUnits,
+    };
+  });
+  return {
+    text,
+    headerRanges: headers.map(({ start, end }) => ({ start, end })),
+    streamRanges: headers.map((header, index) => ({
+      label: header.label,
+      contentStart: header.end,
+      end: headers[index + 1]?.start ?? text.length,
+    })),
+  };
+}
+
 /**
  * Pushes a cut off the interior of a generated header so a partial `[stde`
  * never reaches the model. Both directions shrink what is retained, which keeps
@@ -150,9 +175,15 @@ function resolveResumingStreamLabel(params: {
  * Renders approved exec output for the agent continuation, preserving exact
  * bytes under the cap and reporting an exact omitted-unit count above it.
  */
-export function formatExecApprovalContinuationOutput(streams: ExecApprovalOutputStream[]): string {
-  const rendered = renderExecOutputStreams(streams);
-  if (rendered.text.length <= MAX_UTF16_UNITS) {
+function formatRenderedExecApprovalContinuationOutput(
+  rendered: RenderedExecOutput,
+  maxUtf16Units: number,
+): string {
+  const requestedMax = Number.isFinite(maxUtf16Units)
+    ? Math.floor(maxUtf16Units)
+    : DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
+  const boundedMax = Math.max(1, Math.min(requestedMax, MAX_SOURCE_UTF16_UNITS));
+  if (rendered.text.length <= boundedMax) {
     return rendered.text;
   }
 
@@ -160,7 +191,7 @@ export function formatExecApprovalContinuationOutput(streams: ExecApprovalOutput
     (widest, range) => Math.max(widest, range.label.length),
     0,
   );
-  const budget = resolveCutBudget(rendered.text.length, longestLabelUnits);
+  const budget = resolveCutBudget(rendered.text.length, longestLabelUnits, boundedMax);
   const headEnd = moveCutOutsideHeader(budget.head, rendered.headerRanges, "head");
   const tailStart = moveCutOutsideHeader(
     rendered.text.length - budget.tail,
@@ -180,5 +211,51 @@ export function formatExecApprovalContinuationOutput(streams: ExecApprovalOutput
       streamRanges: rendered.streamRanges,
     }),
   });
-  return `${head}\n${marker}\n${tail}`;
+  const formatted = `${head}\n${marker}\n${tail}`;
+  if (formatted.length <= boundedMax) {
+    return formatted;
+  }
+  return sliceUtf16Safe(
+    `[... ${rendered.text.length} UTF-16 code units omitted from approved exec output ...]`,
+    0,
+    boundedMax,
+  );
+}
+
+/**
+ * Formats the host-owned stream structure without imposing the model-specific
+ * cap. The resolved attempt applies that final cap before persistence and
+ * provider submission.
+ */
+export function formatExecApprovalContinuationSourceOutput(
+  streams: ExecApprovalOutputStream[],
+): string {
+  return formatRenderedExecApprovalContinuationOutput(
+    renderExecOutputStreams(streams),
+    MAX_SOURCE_UTF16_UNITS,
+  );
+}
+
+/** Applies the resolved attempt's output allowance to the marked prompt span. */
+export function resizeExecApprovalContinuationPrompt(params: {
+  prompt: string;
+  range: ExecApprovalContinuationPromptRange;
+  maxOutputUtf16Units: number;
+}): string {
+  const { prompt, range } = params;
+  if (
+    !Number.isSafeInteger(range.start) ||
+    !Number.isSafeInteger(range.end) ||
+    range.start < 0 ||
+    range.end < range.start ||
+    range.end > prompt.length
+  ) {
+    return prompt;
+  }
+  const resultText = prompt.slice(range.start, range.end);
+  const resized = formatRenderedExecApprovalContinuationOutput(
+    readRenderedExecOutput(resultText),
+    params.maxOutputUtf16Units,
+  );
+  return `${prompt.slice(0, range.start)}${resized}${prompt.slice(range.end)}`;
 }

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -48,7 +48,7 @@ import {
 } from "../process/gateway-work-admission.js";
 import { isNativeApprovalChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
-import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval-output.js";
+import { formatExecApprovalContinuationSourceOutput } from "./bash-tools.exec-approval-output.js";
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
@@ -404,7 +404,7 @@ function buildGatewayExecApprovalFollowupSummary(params: {
     const body = [diagnosticsText, followupText].filter(Boolean).join("\n\n");
     summary = `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${body}`;
   } else {
-    const output = formatExecApprovalContinuationOutput([
+    const output = formatExecApprovalContinuationSourceOutput([
       { label: "output", value: params.outcome.aggregated },
     ]);
     summary = output

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -18,7 +18,7 @@ import {
   defaultExecAutoReviewer,
   resolveExecAutoReviewDecision,
 } from "../infra/exec-auto-review.js";
-import { formatExecApprovalContinuationOutput } from "./bash-tools.exec-approval-output.js";
+import { formatExecApprovalContinuationSourceOutput } from "./bash-tools.exec-approval-output.js";
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
@@ -610,7 +610,7 @@ export async function executeNodeHostCommand(
                     timedOut?: boolean;
                   })
                 : {};
-            const output = formatExecApprovalContinuationOutput([
+            const output = formatExecApprovalContinuationSourceOutput([
               { label: "stdout", value: payload.stdout },
               { label: "stderr", value: payload.stderr },
               { label: "error", value: payload.error },

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2702,6 +2702,82 @@ describe("CLI attempt execution", () => {
     });
   });
 
+  it("keeps approved exec continuation output bounded for CLI runtimes", async () => {
+    const sessionKey = "agent:main:direct:claude-exec-followup";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session-cli-exec-followup",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    const prefix = "resume approved exec\n";
+    const completion = `Exec finished (code 0)\n${"x".repeat(80_000)}`;
+    const suffix = "\ncontinue the task";
+    const body = `${prefix}${completion}${suffix}`;
+    const execApprovalContinuationPromptRange = {
+      start: prefix.length,
+      end: prefix.length + completion.length,
+    };
+    const userTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
+      input: { text: body },
+      target: createTestUserTurnTranscriptTarget({
+        sessionId: sessionEntry.sessionId,
+        sessionKey,
+        sessionEntry,
+        agentId: "main",
+        cwd: tmpDir,
+        storePath,
+      }),
+    });
+    await writeSessionStoreSeed(sessionStore);
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("bounded cli"));
+
+    await runAgentAttempt({
+      providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
+      modelOverride: "opus",
+      cfg: {} as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body,
+      transcriptBody: body,
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-cli-exec-followup",
+      opts: {
+        execApprovalContinuationPromptRange,
+      } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: "telegram",
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "claude-cli",
+      sessionStore,
+      storePath,
+      sessionHasHistory: false,
+      userTurnTranscriptRecorder,
+    });
+
+    const cliArgs = firstRunCliAgentArg();
+    expect(cliArgs.prompt).toContain(prefix);
+    expect(cliArgs.prompt).toContain(suffix);
+    expect(cliArgs.prompt).toMatch(/UTF-16 code units omitted from approved exec output/);
+    expect(cliArgs.transcriptPrompt).toBeTypeOf("string");
+    expect(String(cliArgs.transcriptPrompt).length).toBeLessThanOrEqual(
+      prefix.length + 16_000 + suffix.length,
+    );
+    await expect(userTurnTranscriptRecorder.resolveMessage()).resolves.toMatchObject({
+      content: cliArgs.transcriptPrompt,
+    });
+  });
+
   it("routes canonical Anthropic models through the configured Claude CLI runtime", async () => {
     const sessionKey = "agent:main:direct:canonical-claude-cli";
     const sessionEntry: SessionEntry = {
@@ -3230,7 +3306,7 @@ describe("CLI attempt execution", () => {
     expect(firstEmbeddedAgentArg().prompt).not.toContain("[Inter-session message]");
   });
 
-  it("forwards trusted elevated defaults to embedded agent runs", async () => {
+  it("forwards trusted elevated defaults and rebases continuation spans for fallback prompts", async () => {
     const sessionKey = "agent:main:telegram:direct:123";
     const sessionEntry: SessionEntry = {
       sessionId: "openclaw-session-elevated-followup",
@@ -3242,6 +3318,8 @@ describe("CLI attempt execution", () => {
       allowed: true,
       defaultLevel: "on" as const,
     };
+    const body = "follow up after approved exec";
+    const execApprovalContinuationPromptRange = { start: 8, end: 20 };
     await writeSessionStoreSeed(sessionStore);
     runEmbeddedAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
@@ -3258,13 +3336,14 @@ describe("CLI attempt execution", () => {
       sessionAgentId: "main",
       sessionFile: path.join(tmpDir, "session.jsonl"),
       workspaceDir: tmpDir,
-      body: "follow up after approved exec",
-      isFallbackRetry: false,
+      body,
+      isFallbackRetry: true,
       resolvedThinkLevel: "medium",
       timeoutMs: 1_000,
       runId: "run-elevated-followup",
       opts: {
         bashElevated,
+        execApprovalContinuationPromptRange,
       } as Parameters<typeof runAgentAttempt>[0]["opts"],
       runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
       spawnedBy: undefined,
@@ -3276,13 +3355,21 @@ describe("CLI attempt execution", () => {
       authProfileProvider: "openai",
       sessionStore,
       storePath,
-      sessionHasHistory: false,
+      sessionHasHistory: true,
     });
 
+    const retryPrefix = "[Retry after the previous model attempt failed or timed out]\n\n";
     expectMockArgFields(runEmbeddedAgentMock, {
       provider: "openai",
       model: "gpt-5.4",
       bashElevated,
+      prompt: `${retryPrefix}${body}`,
+      execApprovalContinuationPromptRange: {
+        start: retryPrefix.length + execApprovalContinuationPromptRange.start,
+        end: retryPrefix.length + execApprovalContinuationPromptRange.end,
+      },
+      execApprovalContinuationTranscriptPromptRange: execApprovalContinuationPromptRange,
+      transcriptPrompt: body,
     });
   });
 

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -51,6 +51,10 @@ import { resolveUserPath } from "../../utils.js";
 import { resolveMessageChannel } from "../../utils/message-channel.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
 import { ensureAuthProfileStore } from "../auth-profiles/store.js";
+import {
+  resizeExecApprovalContinuationPrompt,
+  type ExecApprovalContinuationPromptRange,
+} from "../bash-tools.exec-approval-output.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../bootstrap-budget.js";
 import { resolveCliBackendConfig } from "../cli-backends.js";
 import {
@@ -83,6 +87,7 @@ import {
 } from "../session-write-lock.js";
 import { buildUsageWithNoCost } from "../stream-message-shared.js";
 import { isSubagentAnnounceCompletionHandoff } from "../subagent-announce-handoff.js";
+import { DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS } from "../tool-result-limits.js";
 import {
   buildClaudeCliFallbackContextPrelude,
   claudeCliSessionTranscriptHasContent,
@@ -103,6 +108,26 @@ export {
 } from "./attempt-execution.helpers.js";
 
 const log = createSubsystemLogger("agents/agent-command");
+
+function rebaseExecApprovalContinuationPromptRange(params: {
+  body: string;
+  prompt: string;
+  range?: ExecApprovalContinuationPromptRange;
+}): ExecApprovalContinuationPromptRange | undefined {
+  if (!params.range) {
+    return undefined;
+  }
+  // Retry and provenance context are prefix-only transformations. Carry the
+  // resulting offset forward so attempt-time sizing cannot cut that context.
+  if (!params.prompt.endsWith(params.body)) {
+    return undefined;
+  }
+  const offset = params.prompt.length - params.body.length;
+  return {
+    start: offset + params.range.start,
+    end: offset + params.range.end,
+  };
+}
 
 function normalizeTranscriptMirrorText(value: string): string {
   return value.trim().replace(/\s+/gu, " ");
@@ -574,6 +599,17 @@ export function runAgentAttempt(params: {
   const effectivePrompt = isRawModelRun
     ? resolvedPrompt
     : annotateInterSessionPromptText(resolvedPrompt, params.opts.inputProvenance);
+  const embeddedExecApprovalContinuationPromptRange = rebaseExecApprovalContinuationPromptRange({
+    body: params.body,
+    prompt: effectivePrompt,
+    range: params.opts.execApprovalContinuationPromptRange,
+  });
+  const continuationTranscriptBody = params.opts.execApprovalContinuationPromptRange
+    ? (params.transcriptBody ?? params.body)
+    : params.transcriptBody;
+  const continuationTranscriptPromptRange =
+    params.opts.execApprovalContinuationTranscriptPromptRange ??
+    params.opts.execApprovalContinuationPromptRange;
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,
   );
@@ -686,10 +722,39 @@ export function runAgentAttempt(params: {
   if (!isRawModelRun && isCliExecutionProvider) {
     const cliSessionBinding = getCliSessionBinding(params.sessionEntry, cliExecutionProvider);
     const cliProcessCwd = params.cwd ? resolveUserPath(params.cwd) : params.workspaceDir;
+    const cliContinuationBody = params.opts.execApprovalContinuationPromptRange
+      ? resizeExecApprovalContinuationPrompt({
+          prompt: params.body,
+          range: params.opts.execApprovalContinuationPromptRange,
+          maxOutputUtf16Units: DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
+        })
+      : params.body;
+    const cliResolvedPrompt = params.opts.execApprovalContinuationPromptRange
+      ? resolveFallbackRetryPrompt({
+          body: cliContinuationBody,
+          isFallbackRetry: params.isFallbackRetry,
+          sessionHasHistory: params.sessionHasHistory,
+          priorContextPrelude: claudeCliFallbackPrelude,
+        })
+      : resolvedPrompt;
+    const cliEffectivePrompt = params.opts.execApprovalContinuationPromptRange
+      ? annotateInterSessionPromptText(cliResolvedPrompt, params.opts.inputProvenance)
+      : effectivePrompt;
+    const cliTranscriptPrompt =
+      continuationTranscriptBody === undefined || !continuationTranscriptPromptRange
+        ? continuationTranscriptBody
+        : resizeExecApprovalContinuationPrompt({
+            prompt: continuationTranscriptBody,
+            range: continuationTranscriptPromptRange,
+            maxOutputUtf16Units: DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
+          });
+    params.userTurnTranscriptRecorder?.replaceTextBeforePersistence?.(
+      cliTranscriptPrompt ?? cliContinuationBody,
+    );
     const cliPrompt =
       params.opts.inputProvenance?.kind === "inter_session"
-        ? effectivePrompt
-        : injectTimestamp(effectivePrompt, timestampOptsFromConfig(params.cfg));
+        ? cliEffectivePrompt
+        : injectTimestamp(cliEffectivePrompt, timestampOptsFromConfig(params.cfg));
     const mutableCliSessionStore =
       params.sessionKey && params.sessionStore && params.storePath
         ? {
@@ -783,7 +848,7 @@ export function runAgentAttempt(params: {
             cwd: params.cwd,
             config: params.cfg,
             prompt: cliPrompt,
-            transcriptPrompt: params.transcriptBody,
+            transcriptPrompt: cliTranscriptPrompt,
             modelProvider: params.providerOverride,
             provider: cliExecutionProvider,
             model: params.modelOverride,
@@ -998,7 +1063,7 @@ export function runAgentAttempt(params: {
     agentHarnessRuntimeOverride: embeddedAgentHarnessOverride,
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
-    transcriptPrompt: params.transcriptBody,
+    transcriptPrompt: continuationTranscriptBody,
     // CLI-origin retries cannot rely on transcript replay: orphan-user repair
     // removes the persisted CLI turn before the embedded prompt is submitted.
     images: shouldForwardImagesToEmbedded ? params.opts.images : undefined,
@@ -1017,6 +1082,8 @@ export function runAgentAttempt(params: {
     isFinalFallbackAttempt: params.isFinalFallbackAttempt,
     verboseLevel: params.resolvedVerboseLevel,
     bashElevated: params.opts.bashElevated,
+    execApprovalContinuationPromptRange: embeddedExecApprovalContinuationPromptRange,
+    execApprovalContinuationTranscriptPromptRange: continuationTranscriptPromptRange,
     approvalReviewerDeviceId: params.opts.approvalReviewerDeviceId,
     timeoutMs: params.timeoutMs,
     runTimeoutOverrideMs: params.runTimeoutOverrideMs,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -16,6 +16,7 @@ import type {
   UserTurnInput,
   UserTurnTranscriptRecorder,
 } from "../../sessions/user-turn-transcript.types.js";
+import type { ExecApprovalContinuationPromptRange } from "../bash-tools.exec-approval-output.js";
 import type { ExecElevatedDefaults } from "../bash-tools.exec-types.js";
 import type { BootstrapContextRunKind } from "../bootstrap-mode.js";
 import type { CliSessionBindingFacts } from "../cli-runner/types.js";
@@ -106,6 +107,10 @@ export type AgentCommandOpts = {
   approvalReviewerDeviceId?: string;
   /** Internal trusted exec approval follow-up elevated defaults. */
   bashElevated?: ExecElevatedDefaults;
+  /** Trusted span whose final cap is resolved with the selected model. */
+  execApprovalContinuationPromptRange?: ExecApprovalContinuationPromptRange;
+  /** Corresponding span in the undecorated transcript message. */
+  execApprovalContinuationTranscriptPromptRange?: ExecApprovalContinuationPromptRange;
   /** Trusted sender identity bit for command/channel-action auth; defaults true for local CLI calls. */
   senderIsOwner?: boolean;
   /** Whether this caller is authorized to use provider/model per-run overrides. */

--- a/src/agents/embedded-agent-runner/run/attempt-exec-approval-continuation.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-exec-approval-continuation.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
+import { prepareExecApprovalContinuationForAttempt } from "./attempt-exec-approval-continuation.js";
+
+function buildPrompt() {
+  const prefix = "resume approved exec\n";
+  const result = `Exec finished (code 1)\n[stdout]\n${"a".repeat(50_000)}\n[stderr]\n${"b".repeat(50_000)}`;
+  const suffix = "\ncontinue the task";
+  return {
+    prompt: `${prefix}${result}${suffix}`,
+    range: { start: prefix.length, end: prefix.length + result.length },
+    prefix,
+    suffix,
+  };
+}
+
+describe("prepareExecApprovalContinuationForAttempt", () => {
+  it("uses the resolved attempt context to size only the completion span", () => {
+    const fixture = buildPrompt();
+    const replaceTextBeforePersistence = vi.fn();
+
+    const result = prepareExecApprovalContinuationForAttempt({
+      prompt: fixture.prompt,
+      transcriptPrompt: fixture.prompt,
+      promptRange: fixture.range,
+      contextTokenBudget: 128_000,
+      modelContextWindow: 200_000,
+      userTurnTranscriptRecorder: {
+        replaceTextBeforePersistence,
+      } as unknown as UserTurnTranscriptRecorder,
+    });
+
+    expect(result.prompt.startsWith(fixture.prefix)).toBe(true);
+    expect(result.prompt.endsWith(fixture.suffix)).toBe(true);
+    expect(result.prompt.length).toBeLessThanOrEqual(
+      fixture.prefix.length + 32_000 + fixture.suffix.length,
+    );
+    expect(result.prompt).toMatch(/tail resumes in stderr/);
+    expect(result.transcriptPrompt).toBe(result.prompt);
+    expect(replaceTextBeforePersistence).toHaveBeenCalledWith(result.prompt);
+  });
+
+  it("raises the allowance for an XL resolved context", () => {
+    const fixture = buildPrompt();
+
+    const result = prepareExecApprovalContinuationForAttempt({
+      prompt: fixture.prompt,
+      promptRange: fixture.range,
+      modelContextWindow: 200_000,
+    });
+
+    expect(result.prompt.length).toBeGreaterThan(fixture.prefix.length + 32_000);
+    expect(result.prompt.length).toBeLessThanOrEqual(
+      fixture.prefix.length + 64_000 + fixture.suffix.length,
+    );
+  });
+
+  it("uses distinct runtime and transcript spans after prompt decoration", () => {
+    const fixture = buildPrompt();
+    const retryPrefix = "[Retry after the previous model attempt failed]\n\n";
+    const runtimePrompt = `${retryPrefix}${fixture.prompt}`;
+
+    const result = prepareExecApprovalContinuationForAttempt({
+      prompt: runtimePrompt,
+      transcriptPrompt: fixture.prompt,
+      promptRange: {
+        start: retryPrefix.length + fixture.range.start,
+        end: retryPrefix.length + fixture.range.end,
+      },
+      transcriptPromptRange: fixture.range,
+      contextTokenBudget: 128_000,
+    });
+
+    expect(result.prompt.startsWith(`${retryPrefix}${fixture.prefix}`)).toBe(true);
+    expect(result.prompt.endsWith(fixture.suffix)).toBe(true);
+    expect(result.transcriptPrompt?.startsWith(fixture.prefix)).toBe(true);
+    expect(result.transcriptPrompt?.endsWith(fixture.suffix)).toBe(true);
+    expect(result.prompt.length).toBe(retryPrefix.length + result.transcriptPrompt!.length);
+    expect(result.prompt).toMatch(/UTF-16 code units omitted from approved exec output/);
+  });
+
+  it("leaves ordinary prompts and transcript ownership untouched", () => {
+    const replaceTextBeforePersistence = vi.fn();
+
+    const result = prepareExecApprovalContinuationForAttempt({
+      prompt: "ordinary turn",
+      transcriptPrompt: "ordinary transcript",
+      modelContextWindow: 200_000,
+      userTurnTranscriptRecorder: {
+        replaceTextBeforePersistence,
+      } as unknown as UserTurnTranscriptRecorder,
+    });
+
+    expect(result).toEqual({
+      prompt: "ordinary turn",
+      transcriptPrompt: "ordinary transcript",
+    });
+    expect(replaceTextBeforePersistence).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-exec-approval-continuation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-exec-approval-continuation.ts
@@ -1,0 +1,47 @@
+import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
+import type { ExecApprovalContinuationPromptRange } from "../../bash-tools.exec-approval-output.js";
+import { resizeExecApprovalContinuationPrompt } from "../../bash-tools.exec-approval-output.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
+import { resolveLiveToolResultMaxChars } from "../../tool-result-limits.js";
+
+export function prepareExecApprovalContinuationForAttempt(params: {
+  prompt: string;
+  transcriptPrompt?: string;
+  promptRange?: ExecApprovalContinuationPromptRange;
+  transcriptPromptRange?: ExecApprovalContinuationPromptRange;
+  contextTokenBudget?: number;
+  modelContextWindow?: number;
+  modelMaxTokens?: number;
+  userTurnTranscriptRecorder?: UserTurnTranscriptRecorder;
+}): { prompt: string; transcriptPrompt?: string } {
+  if (!params.promptRange) {
+    return { prompt: params.prompt, transcriptPrompt: params.transcriptPrompt };
+  }
+  const contextTokenBudget = Math.max(
+    1,
+    Math.floor(
+      params.contextTokenBudget ??
+        params.modelContextWindow ??
+        params.modelMaxTokens ??
+        DEFAULT_CONTEXT_TOKENS,
+    ),
+  );
+  const maxOutputUtf16Units = resolveLiveToolResultMaxChars({
+    contextWindowTokens: contextTokenBudget,
+  });
+  const prompt = resizeExecApprovalContinuationPrompt({
+    prompt: params.prompt,
+    range: params.promptRange,
+    maxOutputUtf16Units,
+  });
+  const transcriptPrompt =
+    params.transcriptPrompt === undefined
+      ? undefined
+      : resizeExecApprovalContinuationPrompt({
+          prompt: params.transcriptPrompt,
+          range: params.transcriptPromptRange ?? params.promptRange,
+          maxOutputUtf16Units,
+        });
+  params.userTurnTranscriptRecorder?.replaceTextBeforePersistence?.(transcriptPrompt ?? prompt);
+  return { prompt, transcriptPrompt };
+}

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -29,6 +29,7 @@ import type {
   SkillWorkshopProposalMutationBudget,
   SkillWorkshopRunOptions,
 } from "../../../skills/workshop/types.js";
+import type { ExecApprovalContinuationPromptRange } from "../../bash-tools.exec-approval-output.js";
 import type { ExecElevatedDefaults, ExecToolDefaults } from "../../bash-tools.exec-types.js";
 import type { BootstrapContextRunKind } from "../../bootstrap-mode.js";
 import type { AgentStreamParams, ClientToolDefinition } from "../../command/shared-types.js";
@@ -257,6 +258,10 @@ export type RunEmbeddedAgentParams = {
     "host" | "security" | "ask" | "node" | "nodeCwd" | "notifyOnExit" | "notifyOnExitEmptySuccess"
   >;
   bashElevated?: ExecElevatedDefaults;
+  /** Trusted approved-exec runtime prompt span awaiting the resolved attempt cap. */
+  execApprovalContinuationPromptRange?: ExecApprovalContinuationPromptRange;
+  /** Corresponding span in the undecorated transcript prompt. */
+  execApprovalContinuationTranscriptPromptRange?: ExecApprovalContinuationPromptRange;
   timeoutMs: number;
   /**
    * Explicit per-run timeout override, in milliseconds, when the caller knows

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -9,6 +9,7 @@ import { applyAuthHeaderOverride, applyLocalNoAuthHeaderOverride } from "../../m
 import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
 import { createToolTerminalObserver } from "../../tool-terminal-outcome.js";
 import type { SystemAgentToolOptions } from "../../tools/system-agent-tool.js";
+import { prepareExecApprovalContinuationForAttempt } from "./attempt-exec-approval-continuation.js";
 import { runEmbeddedAttemptWithBackend } from "./backend.js";
 import {
   EMBEDDED_RUN_LANE_HEARTBEAT_MS,
@@ -173,6 +174,16 @@ export async function dispatchEmbeddedRunAttempt(input: {
   };
 
   let cancellationRequested = false;
+  const preparedExecApprovalContinuation = prepareExecApprovalContinuationForAttempt({
+    prompt: runtime.prompt,
+    transcriptPrompt: params.transcriptPrompt,
+    promptRange: params.execApprovalContinuationPromptRange,
+    transcriptPromptRange: params.execApprovalContinuationTranscriptPromptRange,
+    contextTokenBudget: runtime.contextTokenBudget,
+    modelContextWindow: runtime.model.contextWindow,
+    modelMaxTokens: runtime.model.maxTokens,
+    userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
+  });
   const promptMedia = await preparePluginHarnessPromptImages({
     runParams: params,
     runtime,
@@ -236,8 +247,8 @@ export async function dispatchEmbeddedRunAttempt(input: {
         }
       : {}),
     skillsSnapshot: params.skillsSnapshot,
-    prompt: runtime.prompt,
-    transcriptPrompt: params.transcriptPrompt,
+    prompt: preparedExecApprovalContinuation.prompt,
+    transcriptPrompt: preparedExecApprovalContinuation.transcriptPrompt,
     userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
     skipPreparedUserTurnMessage: runtime.skipPreparedUserTurnMessage,
     currentInboundEventKind: params.currentInboundEventKind,

--- a/src/gateway/server-methods/agent-request-types.ts
+++ b/src/gateway/server-methods/agent-request-types.ts
@@ -1,3 +1,4 @@
+import type { ExecApprovalContinuationPromptRange } from "../../agents/bash-tools.exec-approval-output.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 
@@ -38,6 +39,8 @@ export type AgentRunRequest = {
   acpTurnSource?: "manual_spawn";
   internalRuntimeHandoffId?: string;
   execApprovalFollowupExpectedSessionId?: string;
+  /** Backend-issued span containing approved exec completion details. */
+  execApprovalContinuationPromptRange?: ExecApprovalContinuationPromptRange;
   internalEvents?: AgentInternalEvent[];
   suppressPromptPersistence?: boolean;
   sessionEffects?: "visible" | "internal";

--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -1,6 +1,7 @@
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import type { AgentRunTerminalOutcome } from "../../agents/agent-run-terminal-outcome.js";
 import { consumeExecApprovalFollowupRuntimeHandoff } from "../../agents/bash-tools.exec-approval-followup-state.js";
+import type { ExecApprovalContinuationPromptRange } from "../../agents/bash-tools.exec-approval-output.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "../../agents/harness/hook-helpers.js";
 import { scheduleMainSessionRecoveryPendingTarget } from "../../agents/main-session-recovery-owner-release.js";
 import {
@@ -55,6 +56,21 @@ import { resolveSessionRuntimeCwd } from "./agent-session-reset.js";
 import { gatewayClientSenderFields } from "./gateway-client-identity.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
+
+function rebaseExecApprovalContinuationRange(params: {
+  source: string;
+  target: string;
+  range: ExecApprovalContinuationPromptRange;
+}): ExecApprovalContinuationPromptRange | undefined {
+  const sourceOffset = params.target.lastIndexOf(params.source);
+  if (sourceOffset < 0) {
+    return undefined;
+  }
+  return {
+    start: sourceOffset + params.range.start,
+    end: sourceOffset + params.range.end,
+  };
+}
 
 export function startAgentRunExecution(params: {
   prepared: PreparedAgentRunDispatch;
@@ -270,6 +286,38 @@ export function startAgentRunExecution(params: {
           sessionKey: params.requestedSessionKeyRaw,
         });
       }
+      const requestedExecApprovalRange = execApprovalFollowupRuntimeHandoff
+        ? params.request.execApprovalContinuationPromptRange
+        : undefined;
+      const requestMessage = params.request.message ?? "";
+      const requestTranscriptOffset = requestMessage.lastIndexOf(
+        params.effectiveTranscriptInputText,
+      );
+      const execApprovalContinuationTranscriptPromptRange =
+        requestedExecApprovalRange &&
+        Number.isSafeInteger(requestedExecApprovalRange.start) &&
+        Number.isSafeInteger(requestedExecApprovalRange.end) &&
+        requestedExecApprovalRange.start >= 0 &&
+        requestedExecApprovalRange.end >= requestedExecApprovalRange.start &&
+        requestedExecApprovalRange.end <= requestMessage.length &&
+        requestTranscriptOffset >= 0 &&
+        requestedExecApprovalRange.start >= requestTranscriptOffset &&
+        requestedExecApprovalRange.end <=
+          requestTranscriptOffset + params.effectiveTranscriptInputText.length
+          ? {
+              start: requestedExecApprovalRange.start - requestTranscriptOffset,
+              end: requestedExecApprovalRange.end - requestTranscriptOffset,
+            }
+          : undefined;
+      // Provenance annotation changes runtime offsets but leaves transcript
+      // bytes undecorated. Carry an exact range for each representation.
+      const execApprovalContinuationPromptRange = execApprovalContinuationTranscriptPromptRange
+        ? rebaseExecApprovalContinuationRange({
+            source: params.effectiveTranscriptInputText,
+            target: message,
+            range: execApprovalContinuationTranscriptPromptRange,
+          })
+        : undefined;
       // Plugin-owned additive grants stay internal to the authenticated in-process run.
       // Public agent params cannot supply them, and normal tool policy still filters them.
       const runtimePluginToolGrant =
@@ -331,6 +379,13 @@ export function startAgentRunExecution(params: {
           runContext,
           ...(execApprovalFollowupRuntimeHandoff?.bashElevated
             ? { bashElevated: execApprovalFollowupRuntimeHandoff.bashElevated }
+            : {}),
+          ...(execApprovalContinuationPromptRange ? { execApprovalContinuationPromptRange } : {}),
+          ...(execApprovalContinuationTranscriptPromptRange
+            ? {
+                execApprovalContinuationTranscriptPromptRange,
+                transcriptMessage: params.effectiveTranscriptInputText,
+              }
             : {}),
           groupId: params.groupId,
           groupChannel: params.groupChannel,

--- a/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
+++ b/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
@@ -1037,12 +1037,32 @@ describe("gateway agent handler", () => {
         channel: "telegram",
         idempotencyKey: registration.idempotencyKey,
         internalRuntimeHandoffId: registration.handoffId,
+        execApprovalContinuationPromptRange: { start: 0, end: 4 },
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:telegram:direct:source",
+          sourceTool: "exec_approval_followup",
+        },
       },
       { reqId: "exec-followup-elevated", client: backendGatewayClient() },
     );
 
-    const callArgs = await waitForAgentCommandCall<{ bashElevated?: unknown }>();
+    const callArgs = await waitForAgentCommandCall<{
+      bashElevated?: unknown;
+      message?: string;
+      transcriptMessage?: string;
+      execApprovalContinuationPromptRange?: unknown;
+      execApprovalContinuationTranscriptPromptRange?: unknown;
+    }>();
     expect(callArgs.bashElevated).toEqual(bashElevated);
+    expect(callArgs.transcriptMessage).toBe("exec followup");
+    expect(callArgs.execApprovalContinuationTranscriptPromptRange).toEqual({ start: 0, end: 4 });
+    const runtimeResultStart = callArgs.message?.lastIndexOf("exec followup");
+    expect(runtimeResultStart).toBeTypeOf("number");
+    expect(callArgs.execApprovalContinuationPromptRange).toEqual({
+      start: runtimeResultStart,
+      end: runtimeResultStart! + 4,
+    });
   });
 
   it("dedupes elevated exec approval followups across nonce idempotency keys", async () => {
@@ -1414,12 +1434,17 @@ describe("gateway agent handler", () => {
         channel: "telegram",
         idempotencyKey: "exec-approval-followup:req-elevated-75832:nonce:forged-nonce",
         internalRuntimeHandoffId: "forged-handoff",
+        execApprovalContinuationPromptRange: { start: 0, end: 4 },
       },
       { reqId: "exec-followup-forged", client: backendGatewayClient() },
     );
 
-    const callArgs = await waitForAgentCommandCall<{ bashElevated?: unknown }>();
+    const callArgs = await waitForAgentCommandCall<{
+      bashElevated?: unknown;
+      execApprovalContinuationPromptRange?: unknown;
+    }>();
     expect(callArgs).not.toHaveProperty("bashElevated");
+    expect(callArgs).not.toHaveProperty("execApprovalContinuationPromptRange");
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -252,6 +252,62 @@ describe("user turn transcript persistence", () => {
   });
 
   describe("createUserTurnTranscriptRecorder", () => {
+    it("replaces generated text before runtime persistence", async () => {
+      const recorder = createUserTurnTranscriptRecorder({
+        input: {
+          text: "oversized generated continuation",
+          timestamp: 123,
+          idempotencyKey: "exec-followup:user",
+        },
+        target: unusedRecorderTarget,
+      });
+
+      recorder.replaceTextBeforePersistence?.("context-sized continuation");
+
+      await expect(recorder.resolveMessage()).resolves.toMatchObject({
+        content: "context-sized continuation",
+        timestamp: 123,
+        idempotencyKey: "exec-followup:user",
+      });
+      expect(recorder.message?.content).toBe("context-sized continuation");
+    });
+
+    it("does not replace text after provider submission", async () => {
+      const recorder = createUserTurnTranscriptRecorder({
+        input: {
+          text: "submitted continuation",
+          timestamp: 123,
+        },
+        target: unusedRecorderTarget,
+      });
+
+      recorder.markSentToProvider?.();
+      recorder.replaceTextBeforePersistence?.("too late");
+
+      await expect(recorder.resolveMessage()).resolves.toMatchObject({
+        content: "submitted continuation",
+      });
+    });
+
+    it("applies replacement text to input resolved after sizing", async () => {
+      const recorder = createUserTurnTranscriptRecorder({
+        resolveInput: async () => ({
+          text: "deferred oversized continuation",
+          timestamp: 123,
+          idempotencyKey: "exec-followup:deferred:user",
+        }),
+        target: unusedRecorderTarget,
+      });
+
+      recorder.replaceTextBeforePersistence?.("context-sized deferred continuation");
+
+      await expect(recorder.resolveMessage()).resolves.toMatchObject({
+        content: "context-sized deferred continuation",
+        timestamp: 123,
+        idempotencyKey: "exec-followup:deferred:user",
+      });
+    });
+
     it("accepts and normalizes provider-defined persisted media kinds", () => {
       const input: UserTurnInput = {
         text: "inspect this attachment",

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -442,7 +442,7 @@ async function resolveUserTurnTranscriptTarget(
 export function createUserTurnTranscriptRecorder(
   params: CreateUserTurnTranscriptRecorderParams,
 ): UserTurnTranscriptRecorder {
-  const message = resolvePersistedUserTurnMessage(params);
+  let message = resolvePersistedUserTurnMessage(params);
   let blocked = false;
   let persisted = false;
   let runtimePersisted = false;
@@ -454,6 +454,19 @@ export function createUserTurnTranscriptRecorder(
   let runtimePersistedMessage: PersistedUserTurnMessage | undefined;
   let sentToProvider = false;
   let resolvedBeforeProvider = false;
+  let replacementText: string | undefined;
+
+  const applyReplacementText = (
+    candidate: PersistedUserTurnMessage | undefined,
+  ): PersistedUserTurnMessage | undefined => {
+    if (!candidate || replacementText === undefined) {
+      return candidate;
+    }
+    return {
+      ...candidate,
+      content: replacementText,
+    };
+  };
 
   const handlePersistenceError = (error: unknown) => {
     if (params.onPersistenceError) {
@@ -470,11 +483,8 @@ export function createUserTurnTranscriptRecorder(
   };
 
   const resolveMessageForPersistence = async (): Promise<PersistedUserTurnMessage | undefined> => {
-    if (params.message) {
-      return params.message;
-    }
-    if (!params.resolveInput) {
-      return message;
+    if (params.message || !params.resolveInput) {
+      return applyReplacementText(message);
     }
     if (!resolvedMessagePromise) {
       resolvedMessagePromise = (async () => {
@@ -486,10 +496,10 @@ export function createUserTurnTranscriptRecorder(
               input: resolvedInput ?? params.input,
             }) ?? message;
           resolvedBeforeProvider = !sentToProvider;
-          return resolvedMessage;
+          return applyReplacementText(resolvedMessage);
         } catch (error) {
           handlePersistenceError(error);
-          return message;
+          return applyReplacementText(message);
         }
       })();
     }
@@ -641,8 +651,18 @@ export function createUserTurnTranscriptRecorder(
     }
   };
   return {
-    message,
+    get message() {
+      return message;
+    },
     resolveMessage: resolveMessageForPersistence,
+    replaceTextBeforePersistence: (text) => {
+      if (persisted || runtimePersisted || sentToProvider) {
+        return;
+      }
+      replacementText = text;
+      message = applyReplacementText(message);
+      resolvedMessagePromise = undefined;
+    },
     getPersistedMessage: () => runtimePersistedMessage ?? persistedResult?.message,
     markSentToProvider: () => {
       sentToProvider = true;

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -144,6 +144,8 @@ export type CreateUserTurnTranscriptRecorderParams = {
 export type UserTurnTranscriptRecorder = {
   readonly message: PersistedUserTurnMessage | undefined;
   resolveMessage: () => Promise<PersistedUserTurnMessage | undefined>;
+  /** Replaces generated current-turn text before runtime persistence/provider submission. */
+  replaceTextBeforePersistence?: (text: string) => void;
   getPersistedMessage?: () => PersistedUserTurnMessage | undefined;
   markSentToProvider?: () => void;
   markRuntimePersistencePending: (pending: Promise<void>) => void;


### PR DESCRIPTION
Stacked on #116616.

## Summary

- carry a trusted approved-exec completion span through gateway annotation, retry decoration, CLI and embedded runtimes, and transcript persistence
- keep an absolute 256K host transport bound, then apply the existing context-aware 16K, 32K, or 64K model-facing allowance after the resumed attempt resolves its model
- preserve the existing 16K cap for CLI-backed attempts
- keep runtime and transcript ranges separate so generated provenance and retry prefixes are neither truncated nor persisted as user content

## Why

#116616 preserves approved async exec output, but its fixed host-side cap is selected before the resumed attempt knows which model and context window it will use. That can discard useful output for large-context models while still being too large for smaller ones.

This change carries the exact output span as authenticated internal metadata and sizes only that span at the attempt boundary where the effective model context is available. Forged or malformed ranges are rejected, and the host retains a separate absolute transport cap.

## Validation

- focused Vitest coverage for output formatting, gateway protocol validation, authenticated handoff gating, retry and provenance rebasing, CLI behavior, model-aware embedded sizing, and deferred transcript persistence
- `node scripts/check-changed.mjs --base origin/omarshahine-preserve-approved-exec-continuation-outp --timed`
- autoreview clean with no actionable findings
- `git diff --check`

### Direct real-behavior proof

Proof ran against exact head `60b74993fe80fa4dbcc342d4ddb4262b0be8be2d` and exited 0:

```console
env CI=1 NODE_ENV=test ./node_modules/.bin/tsx test/helpers/exec-approval-continuation-product-proof.ts
```

The temporary proof runner exercised an ephemeral real Gateway, an approval-capable operator WebSocket, the real `createExecTool` approval and follow-up path, a real spawned command producing 120,000 UTF-16 units of output, the embedded OpenAI Responses runner against a local mock HTTP provider, the bundled Google Gemini CLI backend through its real process runner and JSONL parser against a local executable fixture, and the real per-agent SQLite transcript store. It waited for each resumed turn's final assistant row before shutting down every Gateway cleanly.

| Runtime | Resolved model context | Expected allowance | Provider completion | SQLite completion |
|---|---:|---:|---:|---:|
| embedded | 64K | 16,000 | 15,999 | 15,999 |
| embedded | 128K | 32,000 | 31,998 | 31,998 |
| embedded | 200K | 64,000 | 63,999 | 63,999 |
| Google Gemini CLI backend | CLI fixed cap | 16,000 | 15,999 | 15,999 |

For all four cases:

- the resumed provider or CLI process received the continuation
- the persisted SQLite user turn contained the same resized completion span
- provider and transcript completion spans matched exactly
- generated prefix and suffix framing remained intact
- the output head and tail were retained
- the middle marker was removed and the omission marker was present
- the completed resumed turn produced its final assistant row

Redacted verdict JSON:

```json
{
  "schema": "openclaw.exec-approval-continuation-proof.v1",
  "ok": true,
  "headSha": "60b74993fe80fa4dbcc342d4ddb4262b0be8be2d",
  "commandOutputChars": 120000,
  "cases": [
    { "runtime": "embedded", "model": "openai/proof-small", "capChars": 16000, "providerChars": 15999, "transcriptChars": 15999, "transcriptMatchesProvider": true },
    { "runtime": "embedded", "model": "openai/proof-large", "capChars": 32000, "providerChars": 31998, "transcriptChars": 31998, "transcriptMatchesProvider": true },
    { "runtime": "embedded", "model": "openai/proof-xl", "capChars": 64000, "providerChars": 63999, "transcriptChars": 63999, "transcriptMatchesProvider": true },
    { "runtime": "cli", "model": "google-gemini-cli/proof-model", "capChars": 16000, "providerChars": 15999, "transcriptChars": 15999, "transcriptMatchesProvider": true }
  ]
}
```

The first remote attempt is not counted as proof: AWS Crabbox run `run_e7beee94d688` failed during dependency hydration before executing the runner because the postinstall process could not import `typescript`. Per the trusted-source validation policy, the proof then ran in the ready local checkout.

The stacked dependency remains explicit: #116616 is open at head `5e0dfe12ff1a7885a9ef83f09faea199d0137ceb`. This PR should be reviewed with that parent and should not land first.

Closes #116672
