### PR TITLE
fix(test): keep memory FD repro config valid

### DIFF
--- a/scripts/check-memory-fd-repro.mjs
+++ b/scripts/check-memory-fd-repro.mjs
@@ -353,11 +353,6 @@ export function writeConfig({ homeDir, workspaceDir, port, token }) {
         store: {
           vector: { enabled: false },
         },
-        sync: {
-          watch: true,
-          onSessionStart: false,
-          onSearch: false,
-        },
       },
     },
     plugins: { allow: ["memory-core"] },

--- a/test/scripts/check-memory-fd-repro.test.ts
+++ b/test/scripts/check-memory-fd-repro.test.ts
@@ -22,6 +22,7 @@ import {
   waitForGatewayReady,
   writeConfig,
 } from "../../scripts/check-memory-fd-repro.mjs";
+import { validateConfigObject } from "../../src/config/validation.js";
 import { withEnv } from "../../src/test-utils/env.js";
 
 async function listen(server: Server): Promise<number> {
@@ -202,16 +203,13 @@ describe("check-memory-fd-repro", () => {
       const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
       const memorySearch = config.memory.search;
 
+      expect(validateConfigObject(config)).toMatchObject({ ok: true });
       expect(memorySearch.store).toEqual({ vector: { enabled: false } });
       expect(memorySearch).toMatchObject({
         provider: "none",
         model: "",
-        sync: {
-          onSearch: false,
-          onSessionStart: false,
-          watch: true,
-        },
       });
+      expect(memorySearch).not.toHaveProperty("sync");
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the memory file-descriptor repro exited before indexing because its generated config still contained the retired `memory.search.sync` surface.

## Why This Change Was Made

Generate only the current canonical offline FTS configuration and validate the complete fixture against the config schema in the focused test.

Provenance: the config consolidation in https://github.com/openclaw/openclaw/pull/111527 moved this fixture to `memory.search` while retaining the `sync` block that the same consolidation retired from the public schema.

## User Impact

Developers can run `scripts/check-memory-fd-repro.mjs` on current builds and get the intended memory/FD evidence instead of an invalid-config error.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/check-memory-fd-repro.test.ts` - 23 tests passed
- `oxfmt --check` - passed for both touched files
- autoreview - clean, 0.96 confidence
- live repro with 2,048 synthetic memory files - passed in fixed mode; one workspace Markdown FD at baseline, during search, and after settling; `memory_search` returned one result in 930 ms

AI-assisted: yes. The diff and runtime behavior were manually verified.
