### PR TITLE
fix(talk): forward transcription provider models into talk.catalog

### DIFF
--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -338,6 +338,7 @@ describe("talk.catalog handler", () => {
         label: "OpenAI Realtime Transcription",
         aliases: ["openai-realtime"],
         defaultModel: "gpt-4o-transcribe",
+        models: ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"],
         resolveConfig: vi.fn(({ rawConfig }) => rawConfig),
         isConfigured: vi.fn(({ providerConfig }) => providerConfig.apiKey === "stt-key"),
       } as never,
@@ -456,6 +457,7 @@ describe("talk.catalog handler", () => {
               transports: ["gateway-relay"],
               brains: ["none"],
               defaultModel: "gpt-4o-transcribe",
+              models: ["gpt-4o-transcribe", "gpt-4o-mini-transcribe"],
             },
             {
               id: "deepgram",
@@ -567,6 +569,46 @@ describe("talk.catalog handler", () => {
         surface: "browser-session",
       }),
     );
+  });
+
+  it("forwards transcription provider models into the catalog", async () => {
+    mocks.listRealtimeTranscriptionProviders.mockReturnValue([
+      {
+        id: "deepgram",
+        label: "Deepgram Realtime Transcription",
+        defaultModel: "nova-3",
+        models: ["nova-3", "nova-3-medical", "enhanced"],
+        resolveConfig: vi.fn(({ rawConfig }: { rawConfig: Record<string, unknown> }) => rawConfig),
+        isConfigured: vi.fn(() => true),
+      } as never,
+    ]);
+    const respond = vi.fn();
+
+    await callTalkHandler("talk.catalog", {
+      params: {},
+      client: { connect: { scopes: ["operator.read"] } },
+      respond,
+      context: {
+        getRuntimeConfig: () =>
+          ({
+            talk: {
+              transcription: {
+                provider: "deepgram",
+                providers: { deepgram: { apiKey: "dg-key" } },
+              },
+            },
+            plugins: { entries: {} },
+          }) as OpenClawConfig,
+      },
+    });
+
+    const catalog = expectRespondOk(respond) as {
+      transcription: { providers: Array<Record<string, unknown>> };
+    };
+    expect(catalog.transcription.providers[0]).toMatchObject({
+      defaultModel: "nova-3",
+      models: ["nova-3", "nova-3-medical", "enhanced"],
+    });
   });
 
   it("uses the bridge surface for gateway-relay catalog resolution", async () => {

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -338,6 +338,9 @@ function buildTalkCatalog(config: OpenClawConfig) {
         if (provider.defaultModel) {
           entry.defaultModel = provider.defaultModel;
         }
+        if (provider.models?.length) {
+          entry.models = [...provider.models];
+        }
         if (provider.aliases?.length) {
           entry.aliases = [...provider.aliases];
         }


### PR DESCRIPTION
Related: #106020

## What Problem This Solves

The talk.catalog transcription projection silently drops provider-declared `models` even though `RealtimeTranscriptionProviderPlugin` already carries the field and `TalkCatalogProviderSchema` allows it on every entry. Speech and realtime entries already project models; transcription was the last projection that was missing it.

A transcription plugin that declares `models: ["nova-3", "nova-3-medical"]` never sees those models reach clients. The catalog entry only carries `defaultModel`, so Talk clients cannot offer a model picker for transcription providers.

This is the "transcription" half of the same gap that was patched for realtime entries in #115763 (commit `4a19f399be0` on 2026-07-29), which added voices + models projection to the realtime section but left transcription behind.

## Why This Change Was Made

The three catalog projections (speech, transcription, realtime) should project the same pick-list fields uniformly. Speech and realtime already do; transcription was the odd one out. The `RealtimeTranscriptionProviderPlugin` type has carried `models?: readonly string[]` since its introduction — the field just never reached the catalog.

## User Impact

**Before**: Transcription plugins that declare `models` have the list ignored. Talk clients see only `defaultModel` but no alternative model choices. Plugin authors cannot expose their model roster to the Talk UI.

**After**: Transcription plugins that declare `models` see them projected into the catalog response under `transcription.providers[].models`, matching the speech and realtime provider entries. Plugins that do not declare models are unaffected (the field is omitted for empty/absent lists).

## Files Changed

| File | Change |
|------|--------|
| `src/gateway/server-methods/talk.ts` | Add `provider.models` projection to transcription catalog entries (+3 lines, after `defaultModel`) |
| `src/gateway/server-methods/talk.test.ts` | Add `models` to existing transcription provider mock + expected response; add dedicated test "forwards transcription provider models into the catalog" (+42 lines) |

## Evidence

### Vitest — 61 tests pass (60 existing + 1 new), production catalog handler

The test exercises the real `callTalkHandler("talk.catalog", ...)` code path with real provider shapes:

```
$ node scripts/run-vitest.mjs src/gateway/server-methods/talk.test.ts
  ...
  ✓ returns safe speech, transcription, and realtime catalogs without provider secrets
  ✓ forwards transcription provider models into the catalog
  ✓ emits realtime models and voices and mirrors create-time configured inputs
  ...
  Tests  61 passed (61)
[exit=0]
```

### Before/after — catalog response shape

**Before** — transcription provider with `models: ["nova-3", "nova-3-medical", "enhanced"]`:
```json
{ "id": "deepgram", "configured": true, "defaultModel": "nova-3", ... }
```
🔴 `models` field missing — clients cannot discover supported models.

**After** — same provider:
```json
{ "id": "deepgram", "configured": true, "defaultModel": "nova-3",
  "models": ["nova-3", "nova-3-medical", "enhanced"], ... }
```
✅ `models` projected — matches speech and realtime provider entries.

### Cross-reference — all three projections now uniform

| Projection | defaultModel | models | voices | aliases |
|------------|:---:|:---:|:---:|:---:|
| speech | — | ✅ | ✅ | ✅ |
| transcription | ✅ | ✅ (this PR) | — | ✅ |
| realtime | ✅ | ✅ | ✅ | ✅ |

### Static checks

oxfmt, oxlint, and tsgo gateway types all pass clean.