### PR TITLE
fix(voice-call): prevent late forced consults after teardown

### DIFF
--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1727,6 +1727,124 @@ describe("RealtimeCallHandler path routing", () => {
     }
   });
 
+  it("does not share a native consult with a replacement realtime session", async () => {
+    const callbacks: RealtimeBridgeRequest[] = [];
+    const oldSubmitToolResult = vi.fn();
+    const replacementSubmitToolResult = vi.fn();
+    const bridges = [
+      makeBridge({
+        supportsToolResultContinuation: true,
+        submitToolResult: oldSubmitToolResult,
+      }),
+      makeBridge({
+        supportsToolResultContinuation: true,
+        submitToolResult: replacementSubmitToolResult,
+      }),
+    ];
+    const createBridge = vi.fn((request: RealtimeBridgeRequest) => {
+      callbacks.push(request);
+      const bridge = bridges[callbacks.length - 1];
+      if (!bridge) {
+        throw new Error("unexpected replacement bridge");
+      }
+      return bridge;
+    });
+    const handler = makeHandler(undefined, {
+      manager: {
+        getCallByProviderCallId: vi.fn((providerCallId: string) => makeCallRecord(providerCallId)),
+      },
+      realtimeProvider: makeRealtimeProvider(createBridge),
+    });
+    const oldResult = createDeferred<{ text: string }>();
+    const replacementResult = createDeferred<{ text: string }>();
+    const consult = vi
+      .fn()
+      .mockImplementationOnce(() => oldResult.promise)
+      .mockImplementationOnce(() => replacementResult.promise);
+    handler.registerToolHandler("openclaw_agent_consult", consult);
+    const oldServer = await startRealtimeServer(handler);
+    let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
+    let oldWs: WebSocket | undefined;
+
+    try {
+      oldWs = await connectWs(oldServer.url);
+      oldWs.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-native-old", callSid: "CA-native-old" },
+        }),
+      );
+      await waitForRealtimeTest(() => {
+        expect(callbacks).toHaveLength(1);
+      });
+      callbacks[0]?.onToolCall?.({
+        itemId: "item-native-old",
+        callId: "native-old",
+        name: "openclaw_agent_consult",
+        args: { question: "Check the old deployment." },
+      });
+      await waitForRealtimeTest(() => {
+        expect(consult).toHaveBeenCalledTimes(1);
+        expect(oldSubmitToolResult).toHaveBeenCalledTimes(1);
+      });
+
+      replacementServer = await startRealtimeServer(handler);
+      const replacementWs = await connectWs(replacementServer.url);
+      try {
+        replacementWs.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-native-replacement", callSid: "CA-native-replacement" },
+          }),
+        );
+        await waitForRealtimeTest(() => {
+          expect(callbacks).toHaveLength(2);
+        });
+        callbacks[1]?.onToolCall?.({
+          itemId: "item-native-replacement",
+          callId: "native-replacement",
+          name: "openclaw_agent_consult",
+          args: { question: "Check the new deployment." },
+        });
+        await waitForRealtimeTest(() => {
+          expect(consult).toHaveBeenCalledTimes(2);
+        });
+
+        oldResult.resolve({ text: "The old deployment is healthy." });
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
+        expect(oldSubmitToolResult).toHaveBeenCalledTimes(1);
+
+        replacementResult.resolve({ text: "The new deployment is healthy." });
+        await waitForRealtimeTest(() => {
+          expect(replacementSubmitToolResult).toHaveBeenLastCalledWith(
+            "native-replacement",
+            { text: "The new deployment is healthy." },
+            undefined,
+          );
+        });
+      } finally {
+        if (
+          replacementWs.readyState !== WebSocket.CLOSED &&
+          replacementWs.readyState !== WebSocket.CLOSING
+        ) {
+          replacementWs.close();
+        }
+      }
+    } finally {
+      if (
+        oldWs &&
+        oldWs.readyState !== WebSocket.CLOSED &&
+        oldWs.readyState !== WebSocket.CLOSING
+      ) {
+        oldWs.close();
+      }
+      await replacementServer?.close();
+      await oldServer.close();
+    }
+  });
+
   it("does not carry a final transcript into the next direct voice turn", async () => {
     let callbacks:
       | {

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1644,6 +1644,13 @@ describe("RealtimeCallHandler path routing", () => {
       );
       const stalePendingRun = vi.fn();
       oldCoordinator.schedule(stalePendingHandle, 60_000, stalePendingRun);
+      callbacks[0]?.onToolCall?.({
+        itemId: "item-old-native",
+        callId: "old-native-consult",
+        name: "openclaw_agent_consult",
+        args: { question: "Check the old deployment." },
+      });
+      expect(consult).toHaveBeenCalledTimes(1);
 
       replacementServer = await startRealtimeServer(handler);
       const replacementWs = await connectWs(replacementServer.url);

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1561,15 +1561,18 @@ describe("RealtimeCallHandler path routing", () => {
   });
 
   it("keeps a replacement session's forced consult when the old result resolves late", async () => {
-    const callbacks: Array<{
-      onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
-    }> = [];
+    const callbacks: RealtimeBridgeRequest[] = [];
     const oldSendUserMessage = vi.fn();
     const replacementSendUserMessage = vi.fn();
+    const oldSubmitToolResult = vi.fn();
     const oldCloseBridge = vi.fn();
     const replacementCloseBridge = vi.fn();
     const bridges = [
-      makeBridge({ close: oldCloseBridge, sendUserMessage: oldSendUserMessage }),
+      makeBridge({
+        close: oldCloseBridge,
+        sendUserMessage: oldSendUserMessage,
+        submitToolResult: oldSubmitToolResult,
+      }),
       makeBridge({
         close: replacementCloseBridge,
         sendUserMessage: replacementSendUserMessage,
@@ -1641,6 +1644,24 @@ describe("RealtimeCallHandler path routing", () => {
           expect(consult).toHaveBeenCalledTimes(2);
         });
         expect(clearAudio).toHaveBeenCalledTimes(2);
+
+        callbacks[0]?.onToolCall?.({
+          itemId: "item-stale-native",
+          callId: "stale-native-consult",
+          name: "openclaw_agent_consult",
+          args: { question: "Check the old deployment." },
+        });
+        await waitForRealtimeTest(() => {
+          expect(oldSubmitToolResult).toHaveBeenCalledWith(
+            "stale-native-consult",
+            {
+              status: "cancelled",
+              message: "OpenClaw cancelled this consult before completion. Do not restart it.",
+            },
+            undefined,
+          );
+        });
+        expect(consult).toHaveBeenCalledTimes(2);
 
         const oldClosed = waitForClose(oldWs);
         oldWs.close();

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -14,6 +14,7 @@ import type { CallManager } from "../manager.js";
 import type { VoiceCallProvider } from "../providers/base.js";
 import type { CallRecord, NormalizedEvent } from "../types.js";
 import { connectWs, startUpgradeWsServer, waitForClose } from "../websocket-test-support.js";
+import { RealtimeAudioPacer } from "./realtime-audio-pacer.js";
 import { RealtimeCallHandler } from "./realtime-handler.js";
 
 const realtimeVoiceHarnessTestHooks = vi.hoisted(() => ({
@@ -199,6 +200,17 @@ function requireFirstMockCall(calls: readonly unknown[][], label: string): unkno
     throw new Error(`expected ${label} call`);
   }
   return call;
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 type RealtimeBridgeRequest = Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0];
@@ -1477,6 +1489,197 @@ describe("RealtimeCallHandler path routing", () => {
       }
     } finally {
       await server.close();
+    }
+  });
+
+  it("does not deliver a forced consult after its realtime session closes", async () => {
+    let callbacks:
+      | {
+          onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+        }
+      | undefined;
+    const sendUserMessage = vi.fn();
+    const closeBridge = vi.fn();
+    const bridge = makeBridge({ close: closeBridge, sendUserMessage });
+    const createBridge = vi.fn(
+      (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
+        callbacks = request;
+        return bridge;
+      },
+    );
+    const handler = makeHandler(
+      { consultPolicy: "always" },
+      {
+        manager: {
+          getCallByProviderCallId: vi.fn(() => makeCallRecord("CA-forced-close")),
+        },
+        realtimeProvider: makeRealtimeProvider(createBridge),
+      },
+    );
+    const consultResult = createDeferred<{ text: string }>();
+    const consult = vi.fn(() => consultResult.promise);
+    handler.registerToolHandler("openclaw_agent_consult", consult);
+    const clearAudio = vi.spyOn(RealtimeAudioPacer.prototype, "clearAudio");
+    const server = await startRealtimeServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-forced-close", callSid: "CA-forced-close" },
+        }),
+      );
+      await waitForRealtimeTest(() => {
+        expect(createBridge).toHaveBeenCalledTimes(1);
+      });
+
+      callbacks?.onTranscript?.("user", "Check the deployment.", true);
+      await waitForRealtimeTest(() => {
+        expect(consult).toHaveBeenCalledTimes(1);
+      });
+      expect(clearAudio).toHaveBeenCalledTimes(1);
+
+      const closed = waitForClose(ws);
+      ws.close();
+      await closed;
+      await waitForRealtimeTest(() => {
+        expect(closeBridge).toHaveBeenCalledTimes(1);
+      });
+
+      consultResult.resolve({ text: "The deployment is healthy." });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      expect(clearAudio).toHaveBeenCalledTimes(1);
+      expect(sendUserMessage).not.toHaveBeenCalled();
+    } finally {
+      clearAudio.mockRestore();
+      await server.close();
+    }
+  });
+
+  it("keeps a replacement session's forced consult when the old result resolves late", async () => {
+    const callbacks: Array<{
+      onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+    }> = [];
+    const oldSendUserMessage = vi.fn();
+    const replacementSendUserMessage = vi.fn();
+    const oldCloseBridge = vi.fn();
+    const replacementCloseBridge = vi.fn();
+    const bridges = [
+      makeBridge({ close: oldCloseBridge, sendUserMessage: oldSendUserMessage }),
+      makeBridge({
+        close: replacementCloseBridge,
+        sendUserMessage: replacementSendUserMessage,
+      }),
+    ];
+    const createBridge = vi.fn(
+      (request: Parameters<RealtimeVoiceProviderPlugin["createBridge"]>[0]) => {
+        callbacks.push(request);
+        const bridge = bridges[callbacks.length - 1];
+        if (!bridge) {
+          throw new Error("unexpected replacement bridge");
+        }
+        return bridge;
+      },
+    );
+    const handler = makeHandler(
+      { consultPolicy: "always" },
+      {
+        manager: {
+          getCallByProviderCallId: vi.fn((providerCallId: string) =>
+            makeCallRecord(providerCallId),
+          ),
+        },
+        realtimeProvider: makeRealtimeProvider(createBridge),
+      },
+    );
+    const oldResult = createDeferred<{ text: string }>();
+    const replacementResult = createDeferred<{ text: string }>();
+    const consult = vi
+      .fn()
+      .mockImplementationOnce(() => oldResult.promise)
+      .mockImplementationOnce(() => replacementResult.promise);
+    handler.registerToolHandler("openclaw_agent_consult", consult);
+    const clearAudio = vi.spyOn(RealtimeAudioPacer.prototype, "clearAudio");
+    const oldServer = await startRealtimeServer(handler);
+    let replacementServer: Awaited<ReturnType<typeof startRealtimeServer>> | undefined;
+    let oldWs: WebSocket | undefined;
+
+    try {
+      oldWs = await connectWs(oldServer.url);
+      oldWs.send(
+        JSON.stringify({
+          event: "start",
+          start: { streamSid: "MZ-forced-old", callSid: "CA-forced-old" },
+        }),
+      );
+      await waitForRealtimeTest(() => {
+        expect(callbacks).toHaveLength(1);
+      });
+      callbacks[0]?.onTranscript?.("user", "Check the old deployment.", true);
+      await waitForRealtimeTest(() => {
+        expect(consult).toHaveBeenCalledTimes(1);
+      });
+
+      replacementServer = await startRealtimeServer(handler);
+      const replacementWs = await connectWs(replacementServer.url);
+      try {
+        replacementWs.send(
+          JSON.stringify({
+            event: "start",
+            start: { streamSid: "MZ-forced-replacement", callSid: "CA-forced-replacement" },
+          }),
+        );
+        await waitForRealtimeTest(() => {
+          expect(callbacks).toHaveLength(2);
+        });
+        callbacks[1]?.onTranscript?.("user", "Check the new deployment.", true);
+        await waitForRealtimeTest(() => {
+          expect(consult).toHaveBeenCalledTimes(2);
+        });
+        expect(clearAudio).toHaveBeenCalledTimes(2);
+
+        const oldClosed = waitForClose(oldWs);
+        oldWs.close();
+        await oldClosed;
+        await waitForRealtimeTest(() => {
+          expect(oldCloseBridge).toHaveBeenCalledTimes(1);
+        });
+
+        oldResult.resolve({ text: "The old deployment is healthy." });
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
+        expect(clearAudio).toHaveBeenCalledTimes(2);
+        expect(oldSendUserMessage).not.toHaveBeenCalled();
+
+        replacementResult.resolve({ text: "The new deployment is healthy." });
+        await waitForRealtimeTest(() => {
+          expect(replacementSendUserMessage).toHaveBeenCalledTimes(1);
+        });
+        expect(clearAudio).toHaveBeenCalledTimes(3);
+      } finally {
+        if (
+          replacementWs.readyState !== WebSocket.CLOSED &&
+          replacementWs.readyState !== WebSocket.CLOSING
+        ) {
+          replacementWs.close();
+        }
+      }
+    } finally {
+      if (
+        oldWs &&
+        oldWs.readyState !== WebSocket.CLOSED &&
+        oldWs.readyState !== WebSocket.CLOSING
+      ) {
+        oldWs.close();
+      }
+      clearAudio.mockRestore();
+      await replacementServer?.close();
+      await oldServer.close();
     }
   });
 

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -1561,6 +1561,10 @@ describe("RealtimeCallHandler path routing", () => {
   });
 
   it("keeps a replacement session's forced consult when the old result resolves late", async () => {
+    const sessionHarnesses: RealtimeVoiceSessionHarness[] = [];
+    realtimeVoiceHarnessTestHooks.onCreate = (harness) => {
+      sessionHarnesses.push(harness);
+    };
     const callbacks: RealtimeBridgeRequest[] = [];
     const oldSendUserMessage = vi.fn();
     const replacementSendUserMessage = vi.fn();
@@ -1626,6 +1630,20 @@ describe("RealtimeCallHandler path routing", () => {
       await waitForRealtimeTest(() => {
         expect(consult).toHaveBeenCalledTimes(1);
       });
+      const oldCoordinator = expectDefined(
+        sessionHarnesses[0],
+        "old voice-call realtime session harness",
+      ).forcedConsults;
+      const oldForcedHandle = expectDefined(
+        oldCoordinator.handles().find((handle) => handle.question === "Check the old deployment."),
+        "old forced consult handle",
+      );
+      const stalePendingHandle = expectDefined(
+        oldCoordinator.prepare("Pending work from the old session."),
+        "stale pending forced consult handle",
+      );
+      const stalePendingRun = vi.fn();
+      oldCoordinator.schedule(stalePendingHandle, 60_000, stalePendingRun);
 
       replacementServer = await startRealtimeServer(handler);
       const replacementWs = await connectWs(replacementServer.url);
@@ -1639,6 +1657,8 @@ describe("RealtimeCallHandler path routing", () => {
         await waitForRealtimeTest(() => {
           expect(callbacks).toHaveLength(2);
         });
+        expect(oldCoordinator.handles()).not.toContainEqual(stalePendingHandle);
+        expect(stalePendingRun).not.toHaveBeenCalled();
         callbacks[1]?.onTranscript?.("user", "Check the new deployment.", true);
         await waitForRealtimeTest(() => {
           expect(consult).toHaveBeenCalledTimes(2);
@@ -1651,24 +1671,11 @@ describe("RealtimeCallHandler path routing", () => {
           name: "openclaw_agent_consult",
           args: { question: "Check the old deployment." },
         });
-        await waitForRealtimeTest(() => {
-          expect(oldSubmitToolResult).toHaveBeenCalledWith(
-            "stale-native-consult",
-            {
-              status: "cancelled",
-              message: "OpenClaw cancelled this consult before completion. Do not restart it.",
-            },
-            undefined,
-          );
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
         });
+        expect(oldSubmitToolResult).not.toHaveBeenCalled();
         expect(consult).toHaveBeenCalledTimes(2);
-
-        const oldClosed = waitForClose(oldWs);
-        oldWs.close();
-        await oldClosed;
-        await waitForRealtimeTest(() => {
-          expect(oldCloseBridge).toHaveBeenCalledTimes(1);
-        });
 
         oldResult.resolve({ text: "The old deployment is healthy." });
         await new Promise<void>((resolve) => {
@@ -1676,6 +1683,15 @@ describe("RealtimeCallHandler path routing", () => {
         });
         expect(clearAudio).toHaveBeenCalledTimes(2);
         expect(oldSendUserMessage).not.toHaveBeenCalled();
+        expect(oldCoordinator.handles()).toContainEqual(oldForcedHandle);
+        expect(oldCoordinator.isCancelled(oldForcedHandle)).toBe(true);
+
+        const oldClosed = waitForClose(oldWs);
+        oldWs.close();
+        await oldClosed;
+        await waitForRealtimeTest(() => {
+          expect(oldCloseBridge).toHaveBeenCalledTimes(1);
+        });
 
         replacementResult.resolve({ text: "The new deployment is healthy." });
         await waitForRealtimeTest(() => {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -271,6 +271,7 @@ type ForcedConsultState = {
   promise: Promise<unknown>;
   sendSpeechPrompt: boolean;
   cancelled: boolean;
+  cancel: () => void;
   completedAt?: number;
 };
 
@@ -1092,6 +1093,7 @@ export class RealtimeCallHandler {
     }
     state.cancelled = true;
     state.sendSpeechPrompt = false;
+    state.cancel();
     this.forcedConsultsByCallId.delete(callId);
   }
 
@@ -1246,6 +1248,7 @@ export class RealtimeCallHandler {
       owner: params.session,
       sendSpeechPrompt: true,
       cancelled: false,
+      cancel: () => coordinator.markCancelled(params.handle),
       promise: Promise.resolve().then(() =>
         params.handler(
           {
@@ -1443,7 +1446,11 @@ export class RealtimeCallHandler {
           coordinator.remove(pending);
         }
       }
-      const forcedConsult = this.forcedConsultsByCallId.get(callId);
+      const forcedConsultState = this.forcedConsultsByCallId.get(callId);
+      const forcedConsult =
+        forcedConsultState?.owner === bridge && !forcedConsultState.cancelled
+          ? forcedConsultState
+          : undefined;
       if (forcedMatch.kind === "already_delivered" && coordinator.isCancelled(forcedMatch.handle)) {
         if (forcedConsult) {
           forcedConsult.sendSpeechPrompt = false;

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -275,7 +275,7 @@ type ForcedConsultState = {
   completedAt?: number;
 };
 
-type ForcedConsultSession = {
+type RealtimeConsultSession = {
   owner: ActiveRealtimeVoiceBridge;
   coordinator: RealtimeVoiceSessionHarness["forcedConsults"];
 };
@@ -350,7 +350,7 @@ export class RealtimeCallHandler {
     ReturnType<typeof setTimeout>
   >();
   private readonly forcedConsultsByCallId = new Map<string, ForcedConsultState>();
-  private readonly forcedConsultSessionsByCallId = new Map<string, ForcedConsultSession>();
+  private readonly consultSessionsByCallId = new Map<string, RealtimeConsultSession>();
   private readonly nativeConsultsInFlightByCallId = new Map<string, NativeConsultState>();
   private closePromise: Promise<void> | null = null;
   private closing = false;
@@ -945,8 +945,7 @@ export class RealtimeCallHandler {
       onClose: (reason) => {
         if (nativeConsultOwner.current) {
           this.clearActiveBridgeMappings(callId, callSid, nativeConsultOwner.current);
-          this.cancelNativeConsult(callId, nativeConsultOwner.current);
-          this.cancelForcedConsultSession(callId, nativeConsultOwner.current);
+          this.cancelConsultSession(callId, nativeConsultOwner.current);
         }
         this.clearUserTranscriptState(callId);
         harness.finishOutputAudio(reason);
@@ -983,11 +982,11 @@ export class RealtimeCallHandler {
         emitCallEnd(reason);
       }
     };
-    const previousForcedConsultSession = this.forcedConsultSessionsByCallId.get(callId);
-    if (previousForcedConsultSession && previousForcedConsultSession.owner !== session) {
-      this.cancelForcedConsultSession(callId, previousForcedConsultSession.owner);
+    const previousConsultSession = this.consultSessionsByCallId.get(callId);
+    if (previousConsultSession && previousConsultSession.owner !== session) {
+      this.cancelConsultSession(callId, previousConsultSession.owner);
     }
-    this.forcedConsultSessionsByCallId.set(callId, {
+    this.consultSessionsByCallId.set(callId, {
       owner: session,
       coordinator: harness.forcedConsults,
     });
@@ -1023,8 +1022,7 @@ export class RealtimeCallHandler {
         closeSession();
       } finally {
         this.clearActiveBridgeMappings(callId, callSid, session);
-        this.cancelNativeConsult(callId, session);
-        this.cancelForcedConsultSession(callId, session);
+        this.cancelConsultSession(callId, session);
         this.clearUserTranscriptState(callId);
         harness.close();
         audioPacer.close();
@@ -1107,20 +1105,20 @@ export class RealtimeCallHandler {
     this.forcedConsultsByCallId.delete(callId);
   }
 
-  private cancelForcedConsultSession(
-    callId: string,
-    owner: ActiveRealtimeVoiceBridge | undefined,
-  ): void {
+  private cancelConsultSession(callId: string, owner: ActiveRealtimeVoiceBridge | undefined): void {
     if (!owner) {
       return;
     }
-    const session = this.forcedConsultSessionsByCallId.get(callId);
+    const session = this.consultSessionsByCallId.get(callId);
     if (!session || session.owner !== owner) {
       return;
     }
+    // Forced and native consults share bridge ownership. Replacement or close
+    // must invalidate both before a newer bridge can observe call-scoped state.
     session.coordinator.clearPending();
     this.cancelForcedConsult(callId, owner);
-    this.forcedConsultSessionsByCallId.delete(callId);
+    this.cancelNativeConsult(callId, owner);
+    this.consultSessionsByCallId.delete(callId);
   }
 
   private clearActiveBridgeMappings(

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -275,6 +275,11 @@ type ForcedConsultState = {
   completedAt?: number;
 };
 
+type ForcedConsultSession = {
+  owner: ActiveRealtimeVoiceBridge;
+  coordinator: RealtimeVoiceSessionHarness["forcedConsults"];
+};
+
 type NativeConsultState = {
   owner: ActiveRealtimeVoiceBridge;
   startedAt: number;
@@ -345,6 +350,7 @@ export class RealtimeCallHandler {
     ReturnType<typeof setTimeout>
   >();
   private readonly forcedConsultsByCallId = new Map<string, ForcedConsultState>();
+  private readonly forcedConsultSessionsByCallId = new Map<string, ForcedConsultSession>();
   private readonly nativeConsultsInFlightByCallId = new Map<string, NativeConsultState>();
   private closePromise: Promise<void> | null = null;
   private closing = false;
@@ -940,7 +946,7 @@ export class RealtimeCallHandler {
         if (nativeConsultOwner.current) {
           this.clearActiveBridgeMappings(callId, callSid, nativeConsultOwner.current);
           this.cancelNativeConsult(callId, nativeConsultOwner.current);
-          this.cancelForcedConsult(callId, nativeConsultOwner.current);
+          this.cancelForcedConsultSession(callId, nativeConsultOwner.current);
         }
         this.clearUserTranscriptState(callId);
         harness.finishOutputAudio(reason);
@@ -977,10 +983,14 @@ export class RealtimeCallHandler {
         emitCallEnd(reason);
       }
     };
-    const previousSession = this.activeBridgesByCallId.get(callId);
-    if (previousSession && previousSession !== session) {
-      this.cancelForcedConsult(callId, previousSession);
+    const previousForcedConsultSession = this.forcedConsultSessionsByCallId.get(callId);
+    if (previousForcedConsultSession && previousForcedConsultSession.owner !== session) {
+      this.cancelForcedConsultSession(callId, previousForcedConsultSession.owner);
     }
+    this.forcedConsultSessionsByCallId.set(callId, {
+      owner: session,
+      coordinator: harness.forcedConsults,
+    });
     this.activeBridgesByCallId.set(callId, session);
     this.activeBridgesByCallId.set(callSid, session);
     this.activeTelephonyClosersByCallId.set(callId, closeTelephony);
@@ -1014,7 +1024,7 @@ export class RealtimeCallHandler {
       } finally {
         this.clearActiveBridgeMappings(callId, callSid, session);
         this.cancelNativeConsult(callId, session);
-        this.cancelForcedConsult(callId, session);
+        this.cancelForcedConsultSession(callId, session);
         this.clearUserTranscriptState(callId);
         harness.close();
         audioPacer.close();
@@ -1095,6 +1105,22 @@ export class RealtimeCallHandler {
     state.sendSpeechPrompt = false;
     state.cancel();
     this.forcedConsultsByCallId.delete(callId);
+  }
+
+  private cancelForcedConsultSession(
+    callId: string,
+    owner: ActiveRealtimeVoiceBridge | undefined,
+  ): void {
+    if (!owner) {
+      return;
+    }
+    const session = this.forcedConsultSessionsByCallId.get(callId);
+    if (!session || session.owner !== owner) {
+      return;
+    }
+    session.coordinator.clearPending();
+    this.cancelForcedConsult(callId, owner);
+    this.forcedConsultSessionsByCallId.delete(callId);
   }
 
   private clearActiveBridgeMappings(
@@ -1188,7 +1214,10 @@ export class RealtimeCallHandler {
     transcript: string;
     clearAudio: () => void;
   }): void {
-    if (this.config.consultPolicy !== "always") {
+    if (
+      this.config.consultPolicy !== "always" ||
+      this.activeBridgesByCallId.get(params.callId) !== params.session
+    ) {
       return;
     }
     const question = params.transcript.trim();
@@ -1290,16 +1319,18 @@ export class RealtimeCallHandler {
         `[voice-call] realtime forced agent consult failed callId=${params.callId} providerCallId=${params.callSid} error=${formatErrorMessage(error)}`,
       );
     } finally {
-      if (state.cancelled || this.forcedConsultsByCallId.get(params.callId) !== state) {
-        coordinator.remove(params.handle);
-      } else {
-        const cleanupTimer = setTimeout(() => {
-          if (this.forcedConsultsByCallId.get(params.callId) === state) {
-            this.forcedConsultsByCallId.delete(params.callId);
-            coordinator.remove(params.handle);
-          }
-        }, FORCED_CONSULT_NATIVE_DEDUPE_MS);
-        cleanupTimer.unref?.();
+      if (!state.cancelled) {
+        if (this.forcedConsultsByCallId.get(params.callId) !== state) {
+          coordinator.remove(params.handle);
+        } else {
+          const cleanupTimer = setTimeout(() => {
+            if (this.forcedConsultsByCallId.get(params.callId) === state) {
+              this.forcedConsultsByCallId.delete(params.callId);
+              coordinator.remove(params.handle);
+            }
+          }, FORCED_CONSULT_NATIVE_DEDUPE_MS);
+          cleanupTimer.unref?.();
+        }
       }
     }
   }
@@ -1438,6 +1469,9 @@ export class RealtimeCallHandler {
       }
     };
     if (name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
+      if (this.activeBridgesByCallId.get(callId) !== bridge) {
+        return;
+      }
       const coordinator = harness.forcedConsults;
       const forcedMatch = coordinator.recordNativeConsult(args, bridgeCallId);
       if (forcedMatch.kind === "none") {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -267,8 +267,10 @@ type RealtimeSpeakResult = {
 };
 
 type ForcedConsultState = {
+  owner: ActiveRealtimeVoiceBridge;
   promise: Promise<unknown>;
   sendSpeechPrompt: boolean;
+  cancelled: boolean;
   completedAt?: number;
 };
 
@@ -934,12 +936,10 @@ export class RealtimeCallHandler {
         });
       },
       onClose: (reason) => {
-        this.activeBridgesByCallId.delete(callId);
-        this.activeBridgesByCallId.delete(callSid);
-        this.activeTelephonyClosersByCallId.delete(callId);
-        this.activeTelephonyClosersByCallId.delete(callSid);
         if (nativeConsultOwner.current) {
+          this.clearActiveBridgeMappings(callId, callSid, nativeConsultOwner.current);
           this.cancelNativeConsult(callId, nativeConsultOwner.current);
+          this.cancelForcedConsult(callId, nativeConsultOwner.current);
         }
         this.clearUserTranscriptState(callId);
         harness.finishOutputAudio(reason);
@@ -976,6 +976,10 @@ export class RealtimeCallHandler {
         emitCallEnd(reason);
       }
     };
+    const previousSession = this.activeBridgesByCallId.get(callId);
+    if (previousSession && previousSession !== session) {
+      this.cancelForcedConsult(callId, previousSession);
+    }
     this.activeBridgesByCallId.set(callId, session);
     this.activeBridgesByCallId.set(callSid, session);
     this.activeTelephonyClosersByCallId.set(callId, closeTelephony);
@@ -1007,13 +1011,10 @@ export class RealtimeCallHandler {
       try {
         closeSession();
       } finally {
-        this.activeBridgesByCallId.delete(callId);
-        this.activeBridgesByCallId.delete(callSid);
-        this.activeTelephonyClosersByCallId.delete(callId);
-        this.activeTelephonyClosersByCallId.delete(callSid);
+        this.clearActiveBridgeMappings(callId, callSid, session);
         this.cancelNativeConsult(callId, session);
+        this.cancelForcedConsult(callId, session);
         this.clearUserTranscriptState(callId);
-        this.forcedConsultsByCallId.delete(callId);
         harness.close();
         audioPacer.close();
       }
@@ -1082,6 +1083,30 @@ export class RealtimeCallHandler {
     state.cancelled = true;
     this.nativeConsultsInFlightByCallId.delete(callId);
     state.cancel();
+  }
+
+  private cancelForcedConsult(callId: string, owner: ActiveRealtimeVoiceBridge): void {
+    const state = this.forcedConsultsByCallId.get(callId);
+    if (!state || state.owner !== owner) {
+      return;
+    }
+    state.cancelled = true;
+    state.sendSpeechPrompt = false;
+    this.forcedConsultsByCallId.delete(callId);
+  }
+
+  private clearActiveBridgeMappings(
+    callId: string,
+    callSid: string,
+    owner: ActiveRealtimeVoiceBridge,
+  ): void {
+    for (const key of [callId, callSid]) {
+      if (this.activeBridgesByCallId.get(key) !== owner) {
+        continue;
+      }
+      this.activeBridgesByCallId.delete(key);
+      this.activeTelephonyClosersByCallId.delete(key);
+    }
   }
 
   private resolveUserTranscriptContext(callId: string): string | undefined {
@@ -1218,7 +1243,9 @@ export class RealtimeCallHandler {
     );
     params.clearAudio();
     const state: ForcedConsultState = {
+      owner: params.session,
       sendSpeechPrompt: true,
+      cancelled: false,
       promise: Promise.resolve().then(() =>
         params.handler(
           {
@@ -1232,6 +1259,9 @@ export class RealtimeCallHandler {
     this.forcedConsultsByCallId.set(params.callId, state);
     try {
       const result = await state.promise;
+      if (state.cancelled || this.forcedConsultsByCallId.get(params.callId) !== state) {
+        return;
+      }
       state.completedAt = Date.now();
       coordinator.markDelivered(params.handle);
       const text = readSpeakableRealtimeVoiceToolResult(result, {
@@ -1257,13 +1287,17 @@ export class RealtimeCallHandler {
         `[voice-call] realtime forced agent consult failed callId=${params.callId} providerCallId=${params.callSid} error=${formatErrorMessage(error)}`,
       );
     } finally {
-      const cleanupTimer = setTimeout(() => {
-        if (this.forcedConsultsByCallId.get(params.callId) === state) {
-          this.forcedConsultsByCallId.delete(params.callId);
-          coordinator.remove(params.handle);
-        }
-      }, FORCED_CONSULT_NATIVE_DEDUPE_MS);
-      cleanupTimer.unref?.();
+      if (state.cancelled || this.forcedConsultsByCallId.get(params.callId) !== state) {
+        coordinator.remove(params.handle);
+      } else {
+        const cleanupTimer = setTimeout(() => {
+          if (this.forcedConsultsByCallId.get(params.callId) === state) {
+            this.forcedConsultsByCallId.delete(params.callId);
+            coordinator.remove(params.handle);
+          }
+        }, FORCED_CONSULT_NATIVE_DEDUPE_MS);
+        cleanupTimer.unref?.();
+      }
     }
   }
 

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -1507,6 +1507,13 @@ export class RealtimeCallHandler {
         const result = await forcedConsult.promise.catch((error: unknown) => ({
           error: formatErrorMessage(error),
         }));
+        if (
+          forcedConsult.cancelled ||
+          forcedConsult.owner !== bridge ||
+          this.forcedConsultsByCallId.get(callId) !== forcedConsult
+        ) {
+          return;
+        }
         await submitFinalToolResult(result);
         return;
       }


### PR DESCRIPTION
Related: #116201

## What Problem This Solves

Fixes an issue where a realtime voice call using agent consultation could clear audio, speak a completed result, or share an in-flight native consult after its owning session had closed or been replaced.

## Why This Change Was Made

Consult state is now owned by the realtime bridge that created it. One bridge-scoped lifecycle helper cancels pending forced-consult coordination, running forced consults, and native consult waiters on close or replacement. Awaited results recheck bridge ownership before delivery, so stale callbacks are ignored. Forced and native consultation intentionally share this ownership because both can outlive the provider callback that started them and both deliver into the same bridge.

This remains inside the voice-call lifecycle. It adds no provider, protocol, config, or environment surface.

## User Impact

Closed or replaced realtime voice calls no longer emit late consultation speech, clear active audio, or consume a replacement session's consult result. Repeated cancellation and close remain idempotent.

## Evidence

- Exact head: `1629cbe5607ccc6c27c4863311980511350cf42c`.
- Rebased onto `640b4ac5996ed4f99b1bde35a706e5e43f31d587`; both touched files have zero drift through current `origin/main`.
- Focused realtime handler and lifecycle tests: 2 files, 32/32 passed.
- Full voice-call extension suite: 57 files, 580/580 passed.
- Targeted `oxfmt --check` and `git diff --check`: clean.
- Fresh autoreview: clean, no accepted/actionable findings; correctness confidence 0.88.
- Exact-head hosted CI passed: `openclaw/ci-gate`, `check-test-types`, `check-prod-types`, lint, changed tests, build artifacts, CodeQL, OpenGrep, dependency guards, and security guards.
- Live OpenAI realtime smoke passed on the exact head using an existing configured API key without a carrier call: backend session connected, three synthesized-audio roundtrips produced the expected user/assistant transcript and response audio, duplicate close remained clean, every cycle recorded zero late audio bytes, and browser WebRTC connected with an audio answer.
- Local changed-gate fallback also passed repository guards, formatting, plugin boundaries, SDK checks, and production extension typecheck. Blacksmith Testbox could not schedule because GitHub returned HTTP 429; hosted `check-test-types` superseded the interrupted resource-heavy local test-type lane.
- Regression coverage includes late forced-consult completion, pending fallback replacement, stale native callbacks, native waiters crossing teardown, and replacement sessions not sharing an in-flight native consult.

AI-assisted: yes. I reviewed the implementation and validation results.