### PR TITLE
docs: add widget sandbox proxy/tunnel section to dashboard

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -856,7 +856,7 @@ Direct Gateway connections need access to both ports. If a reverse proxy or TLS 
 }
 ```
 
-The sandbox origin must differ from the Control UI origin. Do not host other authenticated or sensitive content on it.
+The sandbox origin must differ from the Control UI origin. Do not host other authenticated or sensitive content on it. For proxies and tunnels, see [Widget sandbox behind proxies and tunnels](/web/dashboard#widget-sandbox-behind-proxies-and-tunnels).
 
 For example, the official basic React demo can be configured as:
 

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -93,7 +93,7 @@ When the Control UI is served behind a reverse proxy or tunnel, Apps/Widgets may
 
 ### What the sandbox listener is
 
-When `mcp.apps.enabled` is true, OpenClaw starts a second HTTP(S) listener on the Gateway port plus one (default: `18790`). This listener serves only a static, contentless shim at `/mcp-app-sandbox`. It never serves the Control UI, authenticated Gateway routes, or user data.
+OpenClaw starts a second HTTP(S) listener on the Gateway port plus one (default: `18790`) when an admitted HTML widget needs sandbox isolation. This listener serves only a static, contentless shim at `/mcp-app-sandbox`. It never serves the Control UI, authenticated Gateway routes, or user data. `mcp.apps.enabled` is not required for dashboard widgets.
 
 Configure the port with `mcp.apps.sandboxPort`.
 
@@ -109,13 +109,14 @@ If you expose the Control UI through a tunnel (e.g., Cloudflare Tunnel), add a s
 {
   mcp: {
     apps: {
-      enabled: true,
       sandboxOrigin: "https://mcp-apps.example.com",
       sandboxPort: 18790,
     },
   },
 }
 ```
+
+> `mcp.apps.enabled` is only required for MCP Apps. Dashboard widgets can use the sandbox listener with just `sandboxOrigin` and `sandboxPort`.
 
 Then configure your tunnel/proxy to route `https://mcp-apps.example.com` to `127.0.0.1:18790`.
 

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -85,6 +85,48 @@ Non-goals for v1:
 - In the dashboard settings, paste the token or password into the auth field, then connect.
 - The UI language picker lives in **Settings → Appearance → Language**.
 
+## Widget sandbox behind proxies and tunnels
+
+When the Control UI is served behind a reverse proxy or tunnel, Apps/Widgets may fail with:
+
+> Widget authorization failed after repeated refresh attempts. If the gateway runs behind a reverse proxy or tunnel that does not route the widget sandbox port, set `mcp.apps.sandboxOrigin` to a dedicated public origin routed to the sandbox listener.
+
+### What the sandbox listener is
+
+When `mcp.apps.enabled` is true, OpenClaw starts a second HTTP(S) listener on the Gateway port plus one (default: `18790`). This listener serves only a static, contentless shim at `/mcp-app-sandbox`. It never serves the Control UI, authenticated Gateway routes, or user data.
+
+Configure the port with `mcp.apps.sandboxPort`.
+
+### Trust model
+
+The sandbox origin is intentionally unauthenticated. Widget content is delivered from the authenticated Control UI origin via short-lived HMAC view tickets and `postMessage`. Origin isolation is the security boundary: the sandbox is safe to expose publicly because it cannot read or write authenticated Gateway data on its own.
+
+### Worked example: tunneled deployment
+
+If you expose the Control UI through a tunnel (e.g., Cloudflare Tunnel), add a second public hostname that routes only to the sandbox listener:
+
+```json5
+{
+  mcp: {
+    apps: {
+      enabled: true,
+      sandboxOrigin: "https://mcp-apps.example.com",
+      sandboxPort: 18790,
+    },
+  },
+}
+```
+
+Then configure your tunnel/proxy to route `https://mcp-apps.example.com` to `127.0.0.1:18790`.
+
+### Important caveats
+
+- The sandbox origin **must differ** from the Control UI origin.
+- Do **not** put the sandbox origin behind an interactive auth wall (e.g., Cloudflare Access, Basic Auth). An interstitial login cannot complete inside a cross-origin iframe, and widget rendering will break.
+- Do not host other authenticated or sensitive content on the sandbox origin.
+
+For CLI reference, see [`mcp.apps.sandboxOrigin`](/cli/mcp#mcpapps).
+
 ## Related
 
 - [Control UI](/web/control-ui)

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -125,7 +125,7 @@ Then configure your tunnel/proxy to route `https://mcp-apps.example.com` to `127
 - Do **not** put the sandbox origin behind an interactive auth wall (e.g., Cloudflare Access, Basic Auth). An interstitial login cannot complete inside a cross-origin iframe, and widget rendering will break.
 - Do not host other authenticated or sensitive content on the sandbox origin.
 
-For CLI reference, see [`mcp.apps.sandboxOrigin`](/cli/mcp#mcpapps).
+For CLI reference, see [`mcp.apps.sandboxOrigin`](/cli/mcp#mcp-apps).
 
 ## Related
 


### PR DESCRIPTION
Fixes #116680.

## What Problem This Solves

When the Control UI is served behind a reverse proxy or tunnel, dashboard widgets may fail with a widget authorization error because the sandbox listener port is not routed. Operators need clear guidance on exposing the sandbox origin without enabling the broader MCP Apps bridge.

## Evidence

- Docs changes in `docs/web/dashboard.md` and `docs/cli/mcp.md`
- Cross-linked CLI reference to the new dashboard section
- Review feedback from ClawSweeper addressed: clarified that `mcp.apps.enabled` is not required for dashboard widgets