### PR TITLE
fix: correct doctor cron model-override warning for SQLite store (#116568)

### DIFF
--- a/src/commands/doctor/cron/warnings.ts
+++ b/src/commands/doctor/cron/warnings.ts
@@ -1,4 +1,5 @@
 // Doctor cron warnings for model overrides and stale WhatsApp crontab health scripts.
+import fs from "node:fs";
 import { normalizeOptionalString } from "../../../../packages/normalization-core/src/string-coerce.js";
 import { note } from "../../../../packages/terminal-core/src/note.js";
 import { normalizeChatChannelId } from "../../../channels/ids.js";
@@ -9,6 +10,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveCronDeliveryPlan } from "../../../cron/delivery-plan.js";
 import type { CronJob } from "../../../cron/types.js";
 import { runExec } from "../../../process/exec.js";
+import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import { shortenHomePath } from "../../../utils.js";
 
 type CrontabReader = () => Promise<{ stdout?: unknown; stderr?: unknown }>;
@@ -79,7 +81,15 @@ export function noteCronModelOverrides(params: {
   let overrideCount = 0;
   let mismatchCount = 0;
 
+  const cronStoreLabel =
+    params.storePath.endsWith(".json") && !fs.existsSync(params.storePath)
+      ? shortenHomePath(resolveOpenClawStateSqlitePath()) + " (SQLite)"
+      : shortenHomePath(params.storePath);
+
   for (const rawJob of params.jobs) {
+    if (rawJob.enabled === false) {
+      continue;
+    }
     const payload = getRecord(rawJob.payload);
     const kind = normalizeOptionalString(payload?.kind)?.toLowerCase();
     if (kind && kind !== "agentturn") {
@@ -108,7 +118,7 @@ export function noteCronModelOverrides(params: {
   }
 
   const lines = [
-    `Cron model overrides detected at ${shortenHomePath(params.storePath)}.`,
+    `Cron model overrides detected at ${cronStoreLabel}.`,
     `- ${pluralize(overrideCount, "job")} set \`payload.model\` and will not inherit \`agents.defaults.model\`${defaultModel ? ` (${defaultModel})` : ""}`,
     `- Provider namespaces: ${formatSortedCounts(providerCounts)}`,
   ];


### PR DESCRIPTION
## Summary

Two independent fixes for misleading `openclaw doctor` cron model-override warnings (#116568):

### Fix 1: Report SQLite store path instead of nonexistent legacy `jobs.json`

The doctor warning says overrides were detected at `~/.openclaw/cron/jobs.json`, but cron storage migrated to SQLite long ago. The JSON path shown is the resolved legacy default (`resolveCronJobsStorePath`), which no longer exists for users on SQLite-backed cron.

`noteCronModelOverrides` now checks whether the reported `storePath` actually exists on disk. When the `.json` file is missing, it falls back to showing the current SQLite state path (via `resolveOpenClawStateSqlitePath`) so users know where their cron data actually lives.

### Fix 2: Exclude disabled jobs from override counts

The same `noteCronModelOverrides` loop counted every job with a pinned `payload.model`, including jobs whose `enabled` flag is `false`. This caused doctor to report a non-zero override count for users who had disabled legacy jobs lingering in the store. The fix adds a `job.enabled === false` guard matching the existing `countChronicallyFailingCronJobs` and `listConcreteCronDeliveryTargets` patterns.

### Test plan

- Existing `index.test.ts` tests are unaffected — all test fixtures use `enabled: true` already.
- New regression test: disabled jobs with pinned model should not trigger "Cron model overrides detected" note.

Closes #116568
