### PR TITLE
fix: remove hardlink guard that breaks skill loading on NixOS (#116594)

### DIFF
--- a/src/skills/lifecycle/skill-tree-digest.ts
+++ b/src/skills/lifecycle/skill-tree-digest.ts
@@ -31,9 +31,6 @@ async function collectEntries(root: string, relativeDir = ""): Promise<SkillTree
       collected.push(...(await collectEntries(root, relativePath)));
       continue;
     }
-    if (stat.nlink > 1) {
-      throw new Error(`Skill tree contains hard-linked file ${JSON.stringify(portablePath)}.`);
-    }
     const content = await fs.readFile(path.join(root, relativePath));
     collected.push({
       path: portablePath,


### PR DESCRIPTION
## Summary

**Root cause**: `skills.load.extraDirs` points into the Nix store on NixOS systems with `nix.settings.auto-optimise-store = true`, causing all skills to be silently rejected and `openclaw skills check` reports `Total: 0`.

**Why it fails**: Nix's store optimiser deduplicates identical files across the entire Nix store using hardlinks. The skill tree digest function (`digestClawHubSkillTree` in `skill-tree-digest.ts`) had a defensive check that rejected any file with `stat.nlink > 1` as a "hard-linked file", treating NixOS's legitimate store optimisation as corruption.

**Fix**: Remove the `stat.nlink > 1` guard entirely. The guard was intended to detect duplicate skill loading when a file is referenced by multiple paths, but:
1. The `sha256` digest already covers content — hardlinks share the same inode and content, so they hash identically and cannot cause duplicate entries
2. On NixOS, `nlink >= 2` is the normal state for most files in the Nix store, not an error condition
3. The guard was overly conservative and prevented legitimate skill loading on any system using hardlink-based deduplication

**Files changed**:
- `src/skills/lifecycle/skill-tree-digest.ts` — removed 3 lines (the nlink guard)

Closes #116594
