### PR TITLE
chore(release): refresh 2026.6.34 plugin SDK baseline

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f8903b8bef7c9ba8b9077ed2cd5fa8650a50eb4b805bfeb2003c89cda184eb84  plugin-sdk-api-baseline.json
-33073fd2ca4e8804c7a8b5579cb846880df1392d509e31d161c005136f2e6112  plugin-sdk-api-baseline.jsonl
+65d076e75378a41b99387e8e63688791b59fd0b8c32c8ba43ae1d73373db364c  plugin-sdk-api-baseline.json
+f7cbee9e03763aa559d8ac0f6c8e8bf8cfb2d23301eb66cf84df93360bc99c83  plugin-sdk-api-baseline.jsonl


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the 2026.6.34 candidate’s npm preflight rejects its intentional plugin SDK catalog-contract change because the committed generated baseline hash is stale.

## Why This Change Was Made

Regenerates only the release branch’s checked-in plugin SDK API baseline from the candidate source. This PR does not change the SDK implementation; it records the contract already introduced by the GPT-5.6 backport.

## User Impact

Release operators can run npm preflight for 2026.6.34 without a false baseline-drift failure.

## Evidence

- `NODE_OPTIONS=--max-old-space-size=8192 pnpm plugin-sdk:api:gen`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm plugin-sdk:api:check`
- Fresh `autoreview --mode local`: no accepted/actionable findings.
- AI-assisted: Codex.