### PR TITLE
fix(ci): validate frozen targets with supported startup cases

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -708,20 +708,27 @@ jobs:
             pnpm build
           fi
 
+          supported_startup_cases="$(
+            node --import tsx scripts/bench-gateway-startup.ts --help |
+              sed -n 's/^  \([[:alnum:]_-][[:alnum:]_-]*\) (.*/\1/p'
+          )"
+          startup_case_args=()
+          for startup_case in default skipChannels preparedRuntimeCatalogStall preparedRuntimeScaleOne preparedRuntimeScaleMany oneInternalHook allInternalHooks fiftyPlugins fiftyStartupLazyPlugins; do
+            if grep -Fxq "$startup_case" <<<"$supported_startup_cases"; then
+              startup_case_args+=(--startup-case "$startup_case")
+            fi
+          done
+          if [[ " ${startup_case_args[*]} " != *" --startup-case default "* ]]; then
+            echo "The target startup benchmark did not advertise its required default case." >&2
+            exit 1
+          fi
+
           pnpm test:gateway:cpu-scenarios \
             --output-dir "$SOURCE_PERF_DIR/gateway-cpu" \
             --runs "$source_runs" \
             --warmup 1 \
             --skip-qa \
-            --startup-case default \
-            --startup-case skipChannels \
-            --startup-case preparedRuntimeCatalogStall \
-            --startup-case preparedRuntimeScaleOne \
-            --startup-case preparedRuntimeScaleMany \
-            --startup-case oneInternalHook \
-            --startup-case allInternalHooks \
-            --startup-case fiftyPlugins \
-            --startup-case fiftyStartupLazyPlugins
+            "${startup_case_args[@]}"
 
           pnpm test:extensions:memory \
             -- --json "$SOURCE_PERF_DIR/extension-memory.json"

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -211,6 +211,15 @@ describe("OpenClaw performance workflow", () => {
     expect(run.indexOf("pnpm build")).toBeLessThan(run.indexOf("pnpm test:gateway:cpu-scenarios"));
   });
 
+  it("runs only gateway startup cases advertised by the frozen target", () => {
+    const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
+
+    expect(run).toContain("scripts/bench-gateway-startup.ts --help");
+    expect(run).toContain('grep -Fxq "$startup_case"');
+    expect(run).toContain('"${startup_case_args[@]}"');
+    expect(run).toContain("required default case");
+  });
+
   it("keeps source gateway health waits within one startup budget", () => {
     const run = findStep("Run OpenClaw source performance probes", "source_performance").run ?? "";
     const deadline = "gateway_ready_deadline=$((SECONDS + gateway_ready_timeout_seconds))";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation fails before collecting performance evidence when its trusted workflow passes startup benchmark cases that an older frozen release target does not support.

## Why This Change Was Made

The source-performance lane asks the target benchmark for its established `--help` case list and runs the intersection with the release probe set. It still requires the baseline `default` case, so an invalid or incompatible benchmark cannot silently pass.

## User Impact

Release validation retains every benchmark supported by each frozen target while newer targets automatically receive the additional coverage they advertise.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts` (31 passing)
- Verified the current target case list includes all nine requested cases; the 2026.6.34 candidate advertises the older supported six.
- `git diff --check` and targeted formatting passed.
- `pnpm check:workflows` was attempted but local zizmor bootstrap is blocked by Python 3.9; it requires Python 3.10 or newer.
- Fresh `autoreview --mode local`: no accepted/actionable findings.
- AI-assisted: Codex.