### PR TITLE
fix(googlechat): record canonical receipt thread

### DIFF
--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -48,6 +48,7 @@ const loadGoogleChatChannelRuntime = createLazyRuntimeNamedExport(
 function createGoogleChatSendReceipt(params: {
   messageId?: string;
   chatId: string;
+  threadId?: string;
   kind: MessageReceiptPartKind;
 }) {
   const messageId = params.messageId?.trim();
@@ -62,7 +63,7 @@ function createGoogleChatSendReceipt(params: {
           },
         ]
       : [],
-    threadId: params.chatId,
+    threadId: params.threadId,
     kind: params.kind,
   });
 }
@@ -251,7 +252,12 @@ export const googlechatOutboundAdapter = {
       return {
         messageId,
         chatId: space,
-        receipt: createGoogleChatSendReceipt({ messageId, chatId: space, kind: "text" }),
+        receipt: createGoogleChatSendReceipt({
+          messageId,
+          chatId: space,
+          threadId: result?.threadName ?? thread,
+          kind: "text",
+        }),
       };
     },
   },

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -229,6 +229,49 @@ describe("googlechatPlugin outbound", () => {
     ]);
   });
 
+  it("records the API thread separately from the containing space", async () => {
+    const cfg = createGoogleChatCfg();
+    sendGoogleChatMessageMock.mockResolvedValueOnce({
+      messageName: "spaces/AAA/messages/msg-canonical",
+      threadName: "spaces/AAA/threads/canonical",
+    });
+
+    const canonical = await googlechatOutboundAdapter.attachedResults.sendText({
+      cfg,
+      to: "spaces/AAA",
+      text: "canonical",
+      threadId: "threads/requested",
+    });
+
+    expect(canonical.receipt.threadId).toBe("spaces/AAA/threads/canonical");
+    expect(canonical.receipt.parts[0]?.threadId).toBe("spaces/AAA/threads/canonical");
+    expect(canonical.receipt.raw?.[0]).toMatchObject({
+      chatId: "spaces/AAA",
+      conversationId: "spaces/AAA",
+    });
+
+    sendGoogleChatMessageMock.mockResolvedValueOnce({
+      messageName: "spaces/AAA/messages/msg-fallback",
+    });
+    const fallback = await googlechatOutboundAdapter.attachedResults.sendText({
+      cfg,
+      to: "spaces/AAA",
+      text: "fallback",
+      threadId: "threads/requested",
+    });
+    expect(fallback.receipt.threadId).toBe("threads/requested");
+
+    sendGoogleChatMessageMock.mockResolvedValueOnce({
+      messageName: "spaces/AAA/messages/msg-top-level",
+    });
+    const topLevel = await googlechatOutboundAdapter.attachedResults.sendText({
+      cfg,
+      to: "spaces/AAA",
+      text: "top level",
+    });
+    expect(topLevel.receipt.threadId).toBeUndefined();
+  });
+
   it("renders and chunks outbound text without requiring Google Chat runtime initialization", () => {
     const chunker = googlechatOutboundAdapter.base.chunker;
 

--- a/src/infra/outbound/source-reply-mirror.test.ts
+++ b/src/infra/outbound/source-reply-mirror.test.ts
@@ -1,9 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { reconcileTerminalSourceReplyDelivery } from "./source-reply-mirror.js";
+import {
+  isDeliveredCurrentSourceReply,
+  reconcileTerminalSourceReplyDelivery,
+} from "./source-reply-mirror.js";
 
 const receiptMocks = vi.hoisted(() => ({
   cancel: vi.fn(),
   complete: vi.fn(),
+}));
+const channelPluginMocks = vi.hoisted(() => ({
+  getChannelPlugin: vi.fn(),
+  getLoadedChannelPlugin: vi.fn(),
 }));
 
 vi.mock("../../config/sessions/restart-recovery-receipt.js", () => ({
@@ -11,6 +18,7 @@ vi.mock("../../config/sessions/restart-recovery-receipt.js", () => ({
   cancelRestartRecoveryTerminalDelivery: receiptMocks.cancel,
   completeRestartRecoveryTerminalDelivery: receiptMocks.complete,
 }));
+vi.mock("../../channels/plugins/index.js", () => channelPluginMocks);
 
 describe("reconcileTerminalSourceReplyDelivery", () => {
   const receipt = {
@@ -30,6 +38,8 @@ describe("reconcileTerminalSourceReplyDelivery", () => {
   beforeEach(() => {
     receiptMocks.cancel.mockReset();
     receiptMocks.complete.mockReset();
+    channelPluginMocks.getChannelPlugin.mockReset();
+    channelPluginMocks.getLoadedChannelPlugin.mockReset();
   });
 
   it("cancels a receipt after an unambiguous explicit failure", async () => {
@@ -57,5 +67,37 @@ describe("reconcileTerminalSourceReplyDelivery", () => {
 
     expect(receiptMocks.cancel).not.toHaveBeenCalled();
     expect(receiptMocks.complete).not.toHaveBeenCalled();
+  });
+});
+
+describe("isDeliveredCurrentSourceReply", () => {
+  it("matches a canonical Google Chat thread receipt to its inbound source thread", () => {
+    const params = {
+      action: "send",
+      channel: "googlechat",
+      actionParams: { target: "spaces/AAA", message: "answer" },
+      cfg: {},
+      sessionKey: "agent:main:googlechat:channel:spaces/AAA",
+      toolContext: {
+        currentChannelProvider: "googlechat",
+        currentChannelId: "spaces/AAA",
+        currentThreadTs: "spaces/AAA/threads/canonical",
+      },
+    };
+
+    expect(
+      isDeliveredCurrentSourceReply({
+        ...params,
+        deliveredPayload: {
+          receipt: { threadId: "spaces/AAA/threads/canonical" },
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isDeliveredCurrentSourceReply({
+        ...params,
+        deliveredPayload: { receipt: { threadId: "spaces/AAA" } },
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where successful Google Chat sends recorded the containing space as the receipt's thread identity. Threaded delivery reached the right destination, but durable delivery evidence could not distinguish the space from the actual thread.

## Why This Change Was Made

Google Chat's send response already returns the canonical thread name. The outbound adapter now records that authoritative value, falls back to the requested thread when the API omits it, and leaves top-level receipts without a fabricated thread. The space remains the conversation identity.

## User Impact

Thread-aware reconciliation and follow-up routing now receive the actual Google Chat thread identity instead of the parent space.

## Evidence

- Before: a send to `spaces/AAA` / `threads/requested` produced a receipt whose `threadId` was `spaces/AAA`.
- After: the receipt records the API response `spaces/AAA/threads/canonical`, falls back to `threads/requested` when needed, and does not invent a thread for a top-level send.
- Focused Testbox proof: 18/18 adapter tests passed on `tbx_01kyvktc8486qcgn2t5v66pwbc`, run `30615610080`; 3/3 downstream source-reply integration tests passed on `tbx_01kyvnyepn0fm479khm2tvaphf`, run `30617792701`.
- Full changed gate passed on the same Testbox lease, including formatting, extension typechecks, lint, boundaries, dead-code scans, and import-cycle checks.
- Final autoreview: clean, no accepted/actionable findings, confidence 0.97.

### Provider and consumer contract proof

- Live Google Chat v1 discovery on 2026-07-31 declares `Message.thread` as a `Thread` whose `name` is the identifier `spaces/{space}/threads/{thread}`: `https://chat.googleapis.com/$discovery/rest?version=v1`.
- The production API boundary parses that exact response field as `threadName` in `extensions/googlechat/src/api.ts`; the adapter consumes it directly without deriving or rewriting it.
- Google Chat inbound context stores the same canonical `message.thread.name` as `ReplyToId`/`ReplyToIdFull`, which the threading adapter exposes as `currentThreadTs`. The only production receipt-thread consumer, source-reply mirroring, compares those two canonical values. This changes the old guaranteed mismatch (`space` versus canonical thread) into the intended match.
- The new downstream integration regression calls the real source-reply decision owner and proves the canonical receipt is accepted as the current source while the prior space-as-thread receipt is rejected.
- Generic delivery settlement consumes platform message IDs and treats `MessageReceipt.threadId` as optional. Existing top-level and fallback branches therefore retain their established behavior.
- A live Google Chat app/space target was not available in the isolated campaign environment, so no external message was sent. The exact-head mock channel-API trace and live official discovery contract are the strongest non-destructive proof available.

Maintainer owner decision: accept the corrected canonical identity and the low-risk lack of a live-send prerequisite for this metadata-only change.

No protocol, configuration, persistence schema, or send-routing behavior changes.
