### PR TITLE
fix(testing): restore realtime Talk relay live smoke

### DIFF
--- a/scripts/dev/realtime-talk-live-smoke.ts
+++ b/scripts/dev/realtime-talk-live-smoke.ts
@@ -903,7 +903,8 @@ async function smokeGatewayRelayBrowser(browser: Browser): Promise<SmokeResult> 
   const dir = await mkdtemp(path.join(tmpdir(), "openclaw-realtime-talk-"));
   try {
     const { createServer } = await import("vite");
-    const relayModulePath = JSON.stringify(resolveGatewayRelayModulePath());
+    const repoRoot = process.cwd();
+    const relayModulePath = JSON.stringify(resolveGatewayRelayModulePath(repoRoot));
     await writeFile(
       path.join(dir, "index.html"),
       '<!doctype html><meta charset="utf-8"><script type="module" src="/main.ts"></script>',
@@ -911,8 +912,6 @@ async function smokeGatewayRelayBrowser(browser: Browser): Promise<SmokeResult> 
     await writeFile(
       path.join(dir, "main.ts"),
       `
-const { GatewayRelayRealtimeTalkTransport } = await import(${relayModulePath});
-
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const listeners = new Set();
 const requests = [];
@@ -952,6 +951,7 @@ const client = {
 };
 
 try {
+  const { GatewayRelayRealtimeTalkTransport } = await import(${relayModulePath});
   const transport = new GatewayRelayRealtimeTalkTransport(
     {
       provider: "smoke",
@@ -1014,9 +1014,14 @@ try {
 `,
     );
     server = await createServer({
+      configFile: path.join(repoRoot, "ui/vite.config.ts"),
       root: dir,
       logLevel: "silent",
-      server: { host: "127.0.0.1", port: 0 },
+      server: {
+        host: "127.0.0.1",
+        port: 0,
+        fs: { allow: [dir, repoRoot] },
+      },
     });
     await server.listen();
     const address = server.httpServer?.address();

--- a/scripts/dev/realtime-talk-live-smoke.ts
+++ b/scripts/dev/realtime-talk-live-smoke.ts
@@ -213,6 +213,10 @@ function transcriptIncludesMarker(transcripts: string[], marker: string): boolea
   return normalizeTranscript(transcripts.join(" ")).includes(normalizeTranscript(marker));
 }
 
+function resolveGatewayRelayModulePath(repoRoot = process.cwd()): string {
+  return `/@fs/${repoRoot.replaceAll("\\", "/")}/ui/src/pages/chat/realtime-talk-gateway-relay.ts`;
+}
+
 async function sendPcmAudioInChunks(
   bridge: RealtimeVoiceBridge,
   audio: Buffer,
@@ -899,10 +903,7 @@ async function smokeGatewayRelayBrowser(browser: Browser): Promise<SmokeResult> 
   const dir = await mkdtemp(path.join(tmpdir(), "openclaw-realtime-talk-"));
   try {
     const { createServer } = await import("vite");
-    const repoRoot = process.cwd().replaceAll("\\", "/");
-    const relayModulePath = JSON.stringify(
-      `/@fs/${repoRoot}/ui/src/ui/chat/realtime-talk-gateway-relay.ts`,
-    );
+    const relayModulePath = JSON.stringify(resolveGatewayRelayModulePath());
     await writeFile(
       path.join(dir, "index.html"),
       '<!doctype html><meta charset="utf-8"><script type="module" src="/main.ts"></script>',
@@ -1154,6 +1155,7 @@ export const testing = {
   parseRealtimeSmokeArgs,
   readOpenAIRealtimeBrowserResponseText,
   readBoundedText,
+  resolveGatewayRelayModulePath,
   resolveOpenAIHttpTimeoutMs,
   sendPcmAudioInChunks,
   transcriptIncludesMarker,

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -699,6 +699,13 @@ describe("script-specific dev tooling hardening", () => {
     expect(realtimeSmokeTesting.transcriptIncludesMarker(["ocean"], "glacier")).toBe(false);
   });
 
+  it("resolves the realtime relay smoke to an existing Control UI module", () => {
+    const modulePath = realtimeSmokeTesting.resolveGatewayRelayModulePath(process.cwd());
+
+    expect(modulePath.endsWith("/ui/src/pages/chat/realtime-talk-gateway-relay.ts")).toBe(true);
+    expect(existsSync(modulePath.slice("/@fs/".length))).toBe(true);
+  });
+
   it("bounds OpenAI realtime smoke response body reads by content-length", async () => {
     const maxBytes = realtimeSmokeTesting.OPENAI_HTTP_RESPONSE_MAX_BYTES;
     const response = new Response("{}", {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running the documented realtime Talk live smoke would always see the Gateway relay browser adapter time out after the Control UI module moved from `ui/src/ui/chat` to `ui/src/pages/chat`.

## Why This Change Was Made

The smoke now resolves the current relay module path, loads it through the canonical Control UI Vite configuration, and explicitly allows the temporary fixture root plus repository root. The generated browser module also catches import failures directly instead of hiding them behind a 15-second timeout.

## User Impact

No production Talk behavior changes. Maintainers can use the existing live smoke to validate OpenAI realtime audio/WebRTC and the Gateway relay browser adapter in one run again.

## Evidence

- Before: two consecutive relay smoke runs on `main` ended with `gateway-relay-browser-adapter: failed { error: 'page.waitForFunction: Timeout 15000ms exceeded.' }`.
- Exact-head relay proof: adapter passed with `talk.session.appendAudio`, tool call/result, close, listening/thinking status, and user/assistant transcripts.
- Current-main recheck: after Talk microphone-uplink PR #116696 merged, the branch was rebased onto `0f3125423094` and the relay adapter plus focused regression test passed again at `6d132b93b6af`.
- Real OpenAI combined proof: backend WebSocket connected; PCM24 roundtrip sent 201,600 input bytes in 210 chunks, received 48,000 output bytes, transcribed `glacier` on both sides, completed `response.done`, and received zero late audio bytes; browser WebRTC connected; relay adapter passed. Google was not run because no Gemini API key was available.
- Focused regression test: `node scripts/run-vitest.mjs test/scripts/dev-tooling-safety.test.ts -t 'resolves the realtime relay smoke to an existing Control UI module'` (1 passed).
- Changed-file gate: `node scripts/check-changed.mjs -- scripts/dev/realtime-talk-live-smoke.ts test/scripts/dev-tooling-safety.test.ts` passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/30616146979)).
- Autoreview: clean, no actionable findings, correctness 0.97.

AI-assisted: yes.
