### PR TITLE
feat(plugins): externalize Synthetic provider

### DIFF
--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-67 plugins
+66 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -159,8 +159,6 @@ Each entry lists the package, distribution route, and description.
 
 - **[sglang](/plugins/reference/sglang)** (`@openclaw/sglang-provider`) - included in OpenClaw. Adds SGLang model provider support to OpenClaw.
 
-- **[synthetic](/plugins/reference/synthetic)** (`@openclaw/synthetic-provider`) - included in OpenClaw. Adds Synthetic model provider support to OpenClaw.
-
 - **[telegram](/plugins/reference/telegram)** (`@openclaw/telegram`) - included in OpenClaw. Adds the Telegram channel surface for sending and receiving OpenClaw messages.
 
 - **[together](/plugins/reference/together)** (`@openclaw/together-provider`) - included in OpenClaw. Adds Together model provider support to OpenClaw.
@@ -189,7 +187,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-78 plugins
+79 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -318,6 +316,8 @@ Each entry lists the package, distribution route, and description.
 - **[stepfun](/plugins/reference/stepfun)** (`@openclaw/stepfun-provider`) - npm; ClawHub: `clawhub:@openclaw/stepfun-provider`. Adds StepFun, StepFun Plan model provider support to OpenClaw.
 
 - **[synology-chat](/plugins/reference/synology-chat)** (`@openclaw/synology-chat`) - npm; ClawHub. Synology Chat channel plugin for OpenClaw channels and direct messages.
+
+- **[synthetic](/plugins/reference/synthetic)** (`@openclaw/synthetic-provider`) - npm; ClawHub: `clawhub:@openclaw/synthetic-provider`. Adds Synthetic model provider support to OpenClaw.
 
 - **[tavily](/plugins/reference/tavily)** (`@openclaw/tavily-plugin`) - npm; ClawHub: `clawhub:@openclaw/tavily-plugin`. Adds agent-callable tools. Adds web search provider support.
 

--- a/docs/plugins/reference/synthetic.md
+++ b/docs/plugins/reference/synthetic.md
@@ -12,7 +12,7 @@ Adds Synthetic model provider support to OpenClaw.
 ## Distribution
 
 - Package: `@openclaw/synthetic-provider`
-- Install route: included in OpenClaw
+- Install route: npm; ClawHub: `clawhub:@openclaw/synthetic-provider`
 
 ## Surface
 

--- a/docs/providers/synthetic.md
+++ b/docs/providers/synthetic.md
@@ -7,8 +7,8 @@ title: "Synthetic"
 ---
 
 [Synthetic](https://synthetic.new) exposes Anthropic-compatible endpoints.
-OpenClaw bundles it as the `synthetic` provider and uses the Anthropic
-Messages API.
+OpenClaw provides it through the official `@openclaw/synthetic-provider`
+plugin and uses the Anthropic Messages API.
 
 | Property | Value                                 |
 | -------- | ------------------------------------- |
@@ -20,6 +20,12 @@ Messages API.
 ## Getting started
 
 <Steps>
+  <Step title="Install the plugin">
+    ```bash
+    openclaw plugins install @openclaw/synthetic-provider
+    openclaw gateway restart
+    ```
+  </Step>
   <Step title="Get an API key">
     Get a `SYNTHETIC_API_KEY` from your Synthetic account, or let onboarding
     prompt you for one.

--- a/extensions/synthetic/README.md
+++ b/extensions/synthetic/README.md
@@ -1,0 +1,16 @@
+# OpenClaw Synthetic Provider
+
+Official OpenClaw provider plugin for Synthetic's hosted Anthropic-compatible
+API.
+
+Install from OpenClaw:
+
+```bash
+openclaw plugins install @openclaw/synthetic-provider
+openclaw gateway restart
+```
+
+Configure `SYNTHETIC_API_KEY`, then select a `synthetic/<model-id>` model.
+
+See https://docs.openclaw.ai/providers/synthetic for model and configuration
+details.

--- a/extensions/synthetic/index.ts
+++ b/extensions/synthetic/index.ts
@@ -9,7 +9,7 @@ const PROVIDER_ID = "synthetic";
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "Synthetic Provider",
-  description: "Bundled Synthetic provider plugin",
+  description: "Synthetic provider plugin",
   manifest,
   provider: {
     label: "Synthetic",

--- a/extensions/synthetic/package.json
+++ b/extensions/synthetic/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@openclaw/synthetic-provider",
   "version": "2026.7.2",
-  "private": true,
-  "description": "OpenClaw Synthetic provider plugin",
+  "description": "OpenClaw Synthetic provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
@@ -10,6 +13,23 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/synthetic-provider",
+      "npmSpec": "@openclaw/synthetic-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.7.2"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -304,6 +304,7 @@
     "!dist/extensions/slack/**",
     "!dist/extensions/sms/**",
     "!dist/extensions/stepfun/**",
+    "!dist/extensions/synthetic/**",
     "!dist/extensions/synology-chat/**",
     "!dist/extensions/tavily/**",
     "!dist/extensions/teams-meetings/**",

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -1660,6 +1660,55 @@
       }
     },
     {
+      "name": "@openclaw/synthetic-provider",
+      "description": "OpenClaw Synthetic provider plugin.",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "synthetic",
+          "label": "Synthetic"
+        },
+        "providers": [
+          {
+            "id": "synthetic",
+            "name": "Synthetic",
+            "docs": "/providers/synthetic",
+            "categories": [
+              "cloud",
+              "llm"
+            ],
+            "envVars": [
+              "SYNTHETIC_API_KEY"
+            ],
+            "authChoices": [
+              {
+                "method": "api-key",
+                "choiceId": "synthetic-api-key",
+                "choiceLabel": "Synthetic API key",
+                "groupId": "synthetic",
+                "groupLabel": "Synthetic",
+                "groupHint": "Anthropic-compatible (multi-model)",
+                "optionKey": "syntheticApiKey",
+                "cliFlag": "--synthetic-api-key",
+                "cliOption": "--synthetic-api-key <key>",
+                "cliDescription": "Synthetic API key",
+                "onboardingScopes": [
+                  "text-inference"
+                ]
+              }
+            ]
+          }
+        ],
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/synthetic-provider",
+          "npmSpec": "@openclaw/synthetic-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.7.2"
+        }
+      }
+    },
+    {
       "name": "@openclaw/stepfun-provider",
       "description": "OpenClaw StepFun provider plugin.",
       "source": "official",

--- a/src/cli/plugins-location-bridges.test.ts
+++ b/src/cli/plugins-location-bridges.test.ts
@@ -165,6 +165,7 @@ describe("listPersistedBundledPluginLocationBridges", () => {
   });
 
   it.each([
+    ["synthetic", "@openclaw/synthetic-provider"],
     ["teams-meetings", "@openclaw/teams-meetings"],
     ["zoom-meetings", "@openclaw/zoom-meetings"],
   ])(

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1960,6 +1960,18 @@ describe("official external plugin catalog", () => {
     });
   });
 
+  it("lists Synthetic as an official external provider", () => {
+    const synthetic = expectCatalogEntry("synthetic");
+
+    expect(resolveOfficialExternalPluginId(synthetic)).toBe("synthetic");
+    expect(resolveOfficialExternalPluginInstall(synthetic)).toEqual({
+      clawhubSpec: "clawhub:@openclaw/synthetic-provider",
+      npmSpec: "@openclaw/synthetic-provider",
+      defaultChoice: "npm",
+      minHostVersion: ">=2026.7.2",
+    });
+  });
+
   it.each([
     ["teams-meetings", "@openclaw/teams-meetings", "teams_meetings", "teams"],
     ["zoom-meetings", "@openclaw/zoom-meetings", "zoom_meetings", "zoom"],

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -359,6 +359,14 @@ describe("bundled plugin build entries", () => {
     }
   });
 
+  it("excludes the externalized Synthetic provider from bundled artifacts", () => {
+    const entries = listBundledPluginBuildEntries();
+    const artifacts = listBundledPluginPackArtifacts();
+
+    expectNoPrefixMatches(Object.keys(entries), "extensions/synthetic/");
+    expectNoPrefixMatches(artifacts, "dist/extensions/synthetic/");
+  });
+
   it("keeps bundled channel secret contracts on packed top-level sidecars", () => {
     const artifacts = listBundledPluginPackArtifacts();
     const excludedPackageDirs = collectRootPackageExcludedExtensionDirs();


### PR DESCRIPTION
## What Problem This Solves

Synthetic is still shipped inside the core OpenClaw package even though it is
an optional provider with a clean plugin boundary. That keeps its release and
distribution coupled to core for every operator.

## Why This Change Was Made

This makes `@openclaw/synthetic-provider` an official external npm and ClawHub
plugin, removes its runtime artifacts from the core package, and registers its
install and provider metadata in the official catalog. The persisted bundled
plugin bridge preserves default enablement and installs the external package
during upgrades from a bundled release.

## User Impact

New users install Synthetic with:

```bash
openclaw plugins install @openclaw/synthetic-provider
openclaw gateway restart
```

Existing users upgrading from a release that bundled Synthetic retain the
enabled provider through the standard externalization bridge.

## Evidence

- Plugin npm and ClawHub release metadata checks pass for
  `@openclaw/synthetic-provider@2026.7.2`.
- Plugin npm and ClawHub release suites: 95 tests passed.
- Generated plugin inventory check and `git diff --check` pass.
- Exact-head branch autoreview: clean, no actionable findings (0.96 confidence).
- Focused bundled-artifact tests: 25 tests passed.

AI-assisted: yes. The maintainer reviewed the implementation and validation.
