### PR TITLE
fix(telegram): explain invalid native queue arguments instead of model failure

### DIFF
--- a/extensions/qa-lab/src/live-transports/telegram/profiles.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/profiles.test.ts
@@ -56,6 +56,16 @@ describe("Telegram QA profiles", () => {
     ).toThrow("execution.kind=flow");
   });
 
+  it("selects the native queue-validation regression as an explicit live scenario", () => {
+    expect(
+      resolveTelegramQaScenarioIds({
+        profile: "release",
+        providerMode: "live-frontier",
+        scenarioIds: ["telegram-queue-invalid-mode"],
+      }),
+    ).toEqual(["telegram-queue-invalid-mode"]);
+  });
+
   it("rejects unknown profiles and channel-ineligible explicit scenarios", () => {
     expect(() =>
       resolveTelegramQaScenarioIds({ providerMode: "live-frontier", profile: "transport" }),

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -15,6 +15,7 @@ import {
   type NativeCommandTestParams,
 } from "./bot-native-commands.fixture-test-support.js";
 import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
+import { runWithTelegramUpdateProcessingFrame } from "./bot-processing-outcome.js";
 
 // All mocks scoped to this file only — does not affect bot-native-commands.test.ts
 
@@ -729,6 +730,39 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(call?.ctx?.Provider).toBe("telegram");
     expect(call?.sessionKey).toBe(turnPlan?.ctxPayload.CommandTargetSessionKey);
     expect(turnPlan?.record?.sessionKey).toBe(turnPlan?.ctxPayload.CommandTargetSessionKey);
+  });
+
+  it("records a completed outcome after a native slash command", async () => {
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+
+    const { result } = await runWithTelegramUpdateProcessingFrame(async () => {
+      await handler(createTelegramPrivateCommandContext());
+    });
+
+    expect(result).toEqual({ kind: "completed" });
+  });
+
+  it("preserves every argument on native queue command turns", async () => {
+    const { handler } = registerAndResolveCommandHandler({
+      commandName: "queue",
+      cfg: {},
+      allowFrom: ["*"],
+    });
+
+    await handler(createTelegramPrivateCommandContext({ match: "Can you diagnose this?" }));
+
+    expect(dispatchChannelInboundTurnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctxPayload: expect.objectContaining({
+          Body: "/queue Can you diagnose this?",
+          CommandBody: "/queue Can you diagnose this?",
+          CommandTurn: expect.objectContaining({
+            kind: "native",
+            body: "/queue Can you diagnose this?",
+          }),
+        }),
+      }),
+    );
   });
 
   it("keeps one live config snapshot through native command execution", async () => {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -75,7 +75,10 @@ import {
   syncTelegramMenuCommands as syncTelegramMenuCommandsRuntime,
   type TelegramMenuCommand,
 } from "./bot-native-command-menu.js";
-import type { TelegramMessageProcessingResult } from "./bot-processing-outcome.js";
+import {
+  recordTelegramMessageProcessingResult,
+  type TelegramMessageProcessingResult,
+} from "./bot-processing-outcome.js";
 import type { TelegramUpdateKeyContext } from "./bot-updates.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import {
@@ -122,6 +125,20 @@ const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const activeTelegramCodexLoginFlows = new Map<string, { expiresAt: number }>();
 
 type TelegramNativeCommandContext = Context & { match?: string };
+
+function registerTelegramNativeCommandHandler(
+  bot: Bot,
+  command: string,
+  handler: (ctx: TelegramNativeCommandContext) => Promise<void>,
+): void {
+  bot.command(command, async (ctx: TelegramNativeCommandContext) => {
+    await handler(ctx);
+    // Native commands bypass processMessage, so their terminal outcome must be
+    // recorded here for every built-in, plugin, and direct-delivery branch.
+    recordTelegramMessageProcessingResult({ kind: "completed" });
+  });
+}
+
 type TelegramChunkMode = ReturnType<
   typeof import("openclaw/plugin-sdk/reply-dispatch-runtime").resolveChunkMode
 >;
@@ -1210,7 +1227,7 @@ export const registerTelegramNativeCommands = ({
   if (commandsToRegister.length > 0 || pluginCatalog.commands.length > 0) {
     for (const command of nativeCommands) {
       const normalizedCommandName = normalizeTelegramCommandName(command.name);
-      bot.command(normalizedCommandName, async (ctx: TelegramNativeCommandContext) => {
+      registerTelegramNativeCommandHandler(bot, normalizedCommandName, async (ctx) => {
         const msg = ctx.message;
         if (!msg) {
           return;
@@ -1800,7 +1817,7 @@ export const registerTelegramNativeCommands = ({
     }
 
     for (const pluginCommand of pluginCatalog.commands) {
-      bot.command(pluginCommand.command, async (ctx: TelegramNativeCommandContext) => {
+      registerTelegramNativeCommandHandler(bot, pluginCommand.command, async (ctx) => {
         const msg = ctx.message;
         if (!msg) {
           return;

--- a/qa/scenarios/channels/telegram-queue-invalid-mode.yaml
+++ b/qa/scenarios/channels/telegram-queue-invalid-mode.yaml
@@ -1,0 +1,69 @@
+title: Telegram native queue command rejects ordinary prompt text
+
+scenario:
+  id: telegram-queue-invalid-mode
+  surface: channels
+  category: channels.channel-actions-commands-and-approvals
+  coverage:
+    primary:
+      - telegram.built-in-commands
+  regressionRefs:
+    - openclaw/openclaw#116688
+  objective: Verify a native Telegram queue command with ordinary trailing text returns its queue-mode validation error without invoking the model or synthesizing a model-failure fallback.
+  successCriteria:
+    - Telegram accepts the native queue command with its complete trailing argument text.
+    - The reply identifies the invalid queue mode and lists supported queue modes.
+    - The reply never blames the model, and a mock provider receives no request for the command.
+  codeRefs:
+    - extensions/telegram/src/bot-native-commands.ts
+    - src/auto-reply/reply/get-reply-directives.ts
+    - src/auto-reply/reply/directive-handling.queue-validation.ts
+  execution:
+    kind: flow
+    channel: telegram
+    summary: Send the reported native queue command and verify its explicit validation reply.
+    config:
+      commandText: /queue Can you diagnose this?
+      invalidModeNeedle: Unrecognized queue mode "Can"
+      validModesNeedle: "Valid modes: steer, followup, collect, interrupt."
+      falseFallbackNeedle: temporary model failure
+
+flow:
+  steps:
+    - name: invalid native queue arguments produce a visible command error
+      actions:
+        - resetTransport: true
+        - set: requestCursorBefore
+          value:
+            expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
+        - set: startIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation: { id: telegram-command-room, kind: channel }
+            senderId: qa-command-operator
+            senderName: QA Command Operator
+            text: { ref: config.commandText }
+            nativeCommand: { name: queue }
+        - waitForOutbound:
+            conversation: { id: telegram-command-room, kind: channel }
+            sinceIndex: { ref: startIndex }
+            textIncludes: { ref: config.invalidModeNeedle }
+            timeoutMs: 60000
+          saveAs: reply
+        - assert:
+            expr: "reply.text.includes(config.validModesNeedle)"
+            message:
+              expr: "`queue validation reply omitted the valid modes: ${reply.text}`"
+        - assert:
+            expr: "!reply.text.includes(config.falseFallbackNeedle)"
+            message:
+              expr: "`queue validation emitted the false model fallback: ${reply.text}`"
+        - set: scenarioRequests
+          value:
+            expr: "env.mock ? await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`) : []"
+        - assert:
+            expr: "!env.mock || scenarioRequests.length === 0"
+            message:
+              expr: "`native queue validation unexpectedly invoked the model ${String(scenarioRequests.length)} time(s)`"
+      detailsExpr: reply.text

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -18,6 +18,7 @@ import { normalizeAgentId } from "../../routing/session-key.js";
 import { ModelSelectionLockedError } from "../../sessions/model-overrides.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SkillCommandSpec } from "../../skills/types.js";
+import { isNativeCommandTurn, resolveCommandTurnContext } from "../command-turn-context.js";
 import { shouldHandleTextCommands } from "../commands-text-routing.js";
 import { markCommandReplyForDelivery } from "../reply-payload.js";
 import type {
@@ -36,6 +37,7 @@ import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveBlockStreamingChunking } from "./block-streaming.js";
 import { buildCommandContext } from "./commands-context.js";
 import { type InlineDirectives, parseInlineDirectives } from "./directive-handling.parse.js";
+import { maybeHandleQueueDirective } from "./directive-handling.queue-validation.js";
 import {
   reserveSkillCommandNames,
   resolveConfiguredDirectiveAliases,
@@ -275,6 +277,25 @@ export async function resolveReplyDirectives(params: {
     modelAliases: configuredAliases,
     allowStatusDirective,
   });
+  const commandTurn = resolveCommandTurnContext(ctx);
+  if (
+    command.isAuthorizedSender &&
+    isNativeCommandTurn(commandTurn) &&
+    commandTurn.commandName === "queue" &&
+    parsedDirectives.hasQueueDirective
+  ) {
+    // Native command arguments belong to the command, not to an inline prompt;
+    // validate them before mixed-text cleanup can erase an invalid queue mode.
+    const queueReply = maybeHandleQueueDirective({
+      directives: parsedDirectives,
+      cfg,
+      channel: command.channel,
+      sessionEntry: targetSessionEntry,
+    });
+    if (queueReply) {
+      return { kind: "reply", reply: markCommandReplyForDelivery(queueReply) };
+    }
+  }
   const hasInlineStatus =
     parsedDirectives.hasStatusDirective && parsedDirectives.cleaned.trim().length > 0;
   if (hasInlineStatus) {

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -43,6 +43,59 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     handleCommandsMock.mockReset();
   });
 
+  it("returns native queue validation instead of discarding trailing command arguments", async () => {
+    handleCommandsMock.mockResolvedValue({ shouldContinue: true });
+
+    const body = "/queue Can you diagnose this?";
+    const typing = createTypingController();
+    const result = await maybeResolveNativeSlashCommandFastReply({
+      ctx: buildTestCtx({
+        Body: body,
+        BodyForAgent: body,
+        RawBody: body,
+        CommandBody: body,
+        CommandSource: "native",
+        CommandAuthorized: true,
+        Provider: "telegram",
+        Surface: "telegram",
+        SessionKey: "telegram:slash:123",
+        CommandTargetSessionKey: "agent:main:telegram:123",
+        CommandTurn: {
+          kind: "native",
+          source: "native",
+          authorized: true,
+          commandName: "queue",
+          body,
+        },
+      }),
+      cfg: markCompleteReplyConfig({
+        session: {
+          store: path.join(tempDirs.make("openclaw-native-queue-"), "sessions.json"),
+        },
+      } as OpenClawConfig),
+      agentId: "main",
+      agentDir: "/tmp/agent",
+      agentCfg: undefined,
+      commandAuthorized: true,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.5",
+      aliasIndex: { byKey: new Map(), byAlias: new Map() },
+      provider: "openai",
+      model: "gpt-5.5",
+      workspaceDir: "/tmp/workspace",
+      typing,
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      reply: expect.objectContaining({
+        text: 'Unrecognized queue mode "Can". Valid modes: steer, followup, collect, interrupt.',
+      }),
+    });
+    expect(handleCommandsMock).toHaveBeenCalledOnce();
+    expect(typing.cleanup).toHaveBeenCalledOnce();
+  });
+
   it("marks native /compact terminal replies for delivery under message_tool_only (#90185)", async () => {
     handleCommandsMock.mockResolvedValueOnce({
       shouldContinue: false,


### PR DESCRIPTION
Closes #116688.

## What Problem This Solves

Telegram users sending `/queue Can you diagnose this?` received a misleading temporary model-failure fallback even though no model request was made, and native-command ingress completed without a recorded outcome.

## Why This Change Was Made

- Validate explicit native `/queue` arguments before generic mixed-inline cleanup can erase an invalid queue mode.
- Route built-in and plugin Telegram native handlers through one terminal-outcome recording boundary.
- Cover the exact reported command in focused core and Telegram tests plus a reusable real-channel QA scenario.

## User Impact

Invalid native queue arguments immediately return `Unrecognized queue mode "Can". Valid modes: steer, followup, collect, interrupt.` without invoking a model. Telegram native-command updates now consistently record a terminal processing outcome.

## Verification

- Reproduced the original failure on current `main`: native `/queue Can you diagnose this?` returned `{ handled: false }` before the fix.
- `src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts`: 10 passing.
- `src/auto-reply/reply/directive-handling.queue-validation.test.ts`: 4 passing.
- `src/auto-reply/reply/get-reply-directives.target-session.test.ts`: 29 passing.
- `extensions/telegram/src/bot-native-commands.session-meta.test.ts`: 47 passing.
- `extensions/telegram/src/bot-native-commands.test.ts`: 30 passing.
- `extensions/telegram/src/sequential-key.test.ts`: 47 passing.
- `extensions/qa-lab/src/live-transports/telegram/profiles.test.ts`: 8 passing.
- `extensions/qa-lab/src/scenario-catalog-channels.test.ts`: 8 passing.
- Focused oxlint, six-file formatting check, and `git diff --check` pass.
- The `telegram-queue-invalid-mode` scenario exercises the exact Telegram message, validates the visible error, rejects the false fallback, and confirms zero mock-provider requests.

## Real Telegram Proof

The credentialed Mantis Telegram Live workflow passed against exact PR head `22a64446fca1cffce6cce87724dc8f2e92aa0fa5` using real Telegram credentials and a Crabbox desktop recording.

```text
Telegram message: /queue Can you diagnose this?
Telegram reply:   Unrecognized queue mode "Can". Valid modes: steer, followup, collect, interrupt.
Scenario:         telegram-queue-invalid-mode
Result:           PASS (1 passed, 0 failed)
```

- [Successful live workflow](https://github.com/openclaw/openclaw/actions/runs/30617093371)
- [Redacted Telegram Desktop screenshot](https://artifacts.openclaw.ai/mantis/telegram-live/pr-116726/run-30617093371-1/telegram-live-desktop.png)
- [Telegram desktop recording](https://artifacts.openclaw.ai/mantis/telegram-live/pr-116726/run-30617093371-1/telegram-live-change.mp4)
- [Full live scenario report](https://artifacts.openclaw.ai/mantis/telegram-live/pr-116726/run-30617093371-1/report.md)

The mock-provider scenario independently asserts zero model requests, and the Telegram outcome regression asserts the completed terminal processing result.
