### PR TITLE
fix(gateway): admit standalone MCP app work

### DIFF
--- a/src/gateway/server-http.mcp-app-admission.test.ts
+++ b/src/gateway/server-http.mcp-app-admission.test.ts
@@ -1,0 +1,166 @@
+// Proves standalone MCP App HTTP work participates in Gateway suspension admission.
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  getActiveGatewayRootWorkCount,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+  tryBeginGatewaySuspendAdmission,
+  waitForActiveGatewayRootWork,
+} from "../process/gateway-work-admission.js";
+
+const mocks = vi.hoisted(() => ({
+  handleMcpAppStandaloneHttpRequest: vi.fn(),
+}));
+
+vi.mock("./mcp-app-standalone.js", () => ({
+  handleMcpAppStandaloneHttpRequest: mocks.handleMcpAppStandaloneHttpRequest,
+}));
+
+import {
+  AUTH_NONE,
+  createRequest,
+  createResponse,
+  dispatchRequest,
+  withGatewayServer,
+} from "./server-http.test-harness.js";
+
+const MCP_APP_PATH = "/__openclaw__/mcp-app";
+
+function deferred() {
+  let resolve = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function mcpAppsConfig(): OpenClawConfig {
+  return {
+    gateway: { trustedProxies: [] },
+    mcp: { apps: { enabled: true } },
+  };
+}
+
+async function withMcpAppServer(
+  run: (server: Parameters<typeof dispatchRequest>[0]) => Promise<void>,
+): Promise<void> {
+  await withGatewayServer({
+    prefix: "mcp-app-http-admission",
+    resolvedAuth: AUTH_NONE,
+    overrides: { getRuntimeConfig: mcpAppsConfig },
+    run,
+  });
+}
+
+beforeEach(() => {
+  resetGatewayWorkAdmission();
+  mocks.handleMcpAppStandaloneHttpRequest.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetGatewayWorkAdmission();
+});
+
+describe("standalone MCP App HTTP admission", () => {
+  it("rejects new requests with the canonical 503 after admission closes", async () => {
+    mocks.handleMcpAppStandaloneHttpRequest.mockImplementation(
+      (_req: IncomingMessage, res: ServerResponse) => {
+        res.statusCode = 204;
+        res.end();
+        return true;
+      },
+    );
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    expect(suspension?.commit()).toBe(true);
+
+    await withMcpAppServer(async (server) => {
+      const response = createResponse();
+      await dispatchRequest(server, createRequest({ path: MCP_APP_PATH }), response.res);
+
+      expect(mocks.handleMcpAppStandaloneHttpRequest).not.toHaveBeenCalled();
+      expect(response.res.statusCode).toBe(503);
+      expect(response.setHeader).toHaveBeenCalledWith("Retry-After", "1");
+      expect(JSON.parse(response.getBody())).toMatchObject({
+        error: { code: "gateway_unavailable" },
+      });
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+    });
+
+    expect(suspension?.release()).toBe(true);
+  });
+
+  it("keeps deferred handler work visible until it settles", async () => {
+    const started = deferred();
+    const finish = deferred();
+    mocks.handleMcpAppStandaloneHttpRequest.mockImplementation(
+      async (_req: IncomingMessage, res: ServerResponse) => {
+        started.resolve();
+        await finish.promise;
+        res.statusCode = 200;
+        res.end("ok");
+        return true;
+      },
+    );
+
+    await withMcpAppServer(async (server) => {
+      const response = createResponse();
+      const pending = dispatchRequest(server, createRequest({ path: MCP_APP_PATH }), response.res);
+      await started.promise;
+
+      try {
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        markGatewayRestartDraining();
+        await expect(waitForActiveGatewayRootWork(0)).resolves.toEqual({
+          drained: false,
+          active: 1,
+        });
+      } finally {
+        finish.resolve();
+      }
+      await pending;
+      expect(response.res.statusCode).toBe(200);
+      // The response mock resolves from res.end(), immediately before the
+      // admission wrapper's finally block releases the request root.
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      await expect(waitForActiveGatewayRootWork(0)).resolves.toEqual({
+        drained: true,
+        active: 0,
+      });
+    });
+  });
+
+  it("releases admission when the standalone handler fails", async () => {
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.handleMcpAppStandaloneHttpRequest.mockRejectedValue(new Error("standalone failed"));
+
+    await withMcpAppServer(async (server) => {
+      const response = createResponse();
+      await dispatchRequest(server, createRequest({ path: MCP_APP_PATH }), response.res);
+
+      expect(response.res.statusCode).toBe(500);
+      expect(response.getBody()).toBe("Internal Server Error");
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+      expect(errorLog).toHaveBeenCalledWith(
+        "[gateway-http] unhandled error in request handler:",
+        expect.objectContaining({ message: "standalone failed" }),
+      );
+    });
+  });
+
+  it("releases admission and preserves fallthrough when the handler declines", async () => {
+    mocks.handleMcpAppStandaloneHttpRequest.mockResolvedValue(false);
+
+    await withMcpAppServer(async (server) => {
+      const response = createResponse();
+      await dispatchRequest(server, createRequest({ path: MCP_APP_PATH }), response.res);
+
+      expect(mocks.handleMcpAppStandaloneHttpRequest).toHaveBeenCalledOnce();
+      expect(response.res.statusCode).toBe(404);
+      expect(response.getBody()).toBe("Not Found");
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+    });
+  });
+});

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -876,13 +876,14 @@ export function createGatewayHttpServer(opts: {
       if (configSnapshot.mcp?.apps?.enabled === true && isMcpAppStandalonePath(scopedRequestPath)) {
         requestStages.push({
           name: "mcp-app-standalone",
-          run: async () => {
-            const standalone = await getMcpAppStandaloneModule();
-            return await standalone.handleMcpAppStandaloneHttpRequest(req, res, {
-              sandboxPort: configSnapshot.mcp?.apps?.sandboxPort,
-              sandboxOrigin: configSnapshot.mcp?.apps?.sandboxOrigin,
-            });
-          },
+          run: async () =>
+            await runWithGatewayHttpWorkAdmission(res, async () => {
+              const standalone = await getMcpAppStandaloneModule();
+              return await standalone.handleMcpAppStandaloneHttpRequest(req, res, {
+                sandboxPort: configSnapshot.mcp?.apps?.sandboxPort,
+                sandboxOrigin: configSnapshot.mcp?.apps?.sandboxOrigin,
+              });
+            }),
         });
       }
       // Plugin routes run before the general Control UI SPA catch-all so


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where standalone MCP App HTTP operations could continue outside Gateway suspend/restart admission. A Gateway could report itself prepared while an MCP resource or tool operation was still running, and could accept new standalone operations after admission had closed.

## Why This Change Was Made

The standalone MCP App stage now uses the same root HTTP work-admission owner as Gateway tool, model, session, and media routes. The admission lease covers lazy module loading and the complete asynchronous handler, and releases on success, failure, or fallthrough.

## User Impact

Gateway suspension and restart now wait for admitted standalone MCP App work to settle, while new app operations receive the canonical retryable 503 during the closed phase.

## Evidence

- Before: the standalone request stage invoked its handler directly, so active root-work count stayed zero and closed admission did not reject the request.
- After: exact-head server-boundary regressions prove canonical 503 rejection, one visible root blocker for a deferred operation, drain completion after settlement, failure cleanup, and declined-handler fallthrough.
- Focused Testbox proof: 4/4 tests passed on `tbx_01kyvn333j7fw1parddtjjat8r` after rebasing to current `main`.
- Full changed gate passed on the same exact-head Testbox lease, including core typechecks, lint, formatting, boundary guards, dead-code scans, and import-cycle checks.
- Final-head autoreview: clean, no accepted/actionable findings, confidence 0.99.

No protocol, configuration, authorization, persistence, or MCP App operation semantics change.
