### PR TITLE
fix(agents): unblock channel turns after repeated gateway restarts

### DIFF
--- a/src/agents/main-session-recovery-lifecycle.ts
+++ b/src/agents/main-session-recovery-lifecycle.ts
@@ -102,8 +102,15 @@ export function projectMainSessionRecoveryLifecycle(params: {
     lifecycleGeneration &&
     runs?.some((run) => run.runId === runId && run.lifecycleGeneration === lifecycleGeneration),
   );
+  // The current owner retires stale generations of its own run id. An older
+  // delayed event consumes only its matching fence and cannot settle its replacement.
   const remaining = matchesFence
-    ? runs?.filter((run) => run.runId !== runId || run.lifecycleGeneration !== lifecycleGeneration)
+    ? runs?.filter(
+        (run) =>
+          run.runId !== runId ||
+          (lifecycleGeneration !== params.currentLifecycleGeneration &&
+            run.lifecycleGeneration !== lifecycleGeneration),
+      )
     : runs;
   if (settlesRecovery) {
     const foregroundClaims = params.entry?.mainRestartRecovery?.foregroundClaims;

--- a/src/agents/main-session-recovery-run-ownership.test.ts
+++ b/src/agents/main-session-recovery-run-ownership.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js";
+import { projectMainSessionRecoveryLifecycle } from "./main-session-recovery-lifecycle.js";
+
+function recoveryEntry(params?: { hasCurrentOwner?: boolean }): SessionEntry {
+  return {
+    sessionId: "session-1",
+    updatedAt: 100,
+    status: "running",
+    abortedLastRun: false,
+    restartRecoveryRuns: [
+      { runId: "recovery", lifecycleGeneration: "generation-old" },
+      { runId: "recovery", lifecycleGeneration: "generation-current" },
+    ],
+    mainRestartRecovery: {
+      cycleId: "cycle-1",
+      revision: 5,
+      chargedAttempts: 2,
+      ...(params?.hasCurrentOwner
+        ? {
+            foregroundClaims: {
+              lifecycleGeneration: "generation-current",
+              tokens: ["current-owner"],
+            },
+          }
+        : {}),
+    },
+  };
+}
+
+describe("main-session recovery run ownership", () => {
+  it("settles a resumed run once when older generations retain the same run id", () => {
+    expect(
+      projectMainSessionRecoveryLifecycle({
+        currentLifecycleGeneration: "generation-current",
+        entry: recoveryEntry(),
+        event: {
+          runId: "recovery",
+          lifecycleGeneration: "generation-current",
+          data: { phase: "end" },
+        },
+        snapshotPatch: { status: "done", abortedLastRun: false },
+      }),
+    ).toEqual({
+      action: "apply",
+      patch: {
+        status: "done",
+        abortedLastRun: false,
+        restartRecoveryRuns: undefined,
+        mainRestartRecovery: undefined,
+      },
+    });
+  });
+
+  it("does not let an older same-id terminal settle its replacement generation", () => {
+    expect(
+      projectMainSessionRecoveryLifecycle({
+        currentLifecycleGeneration: "generation-current",
+        entry: recoveryEntry({ hasCurrentOwner: true }),
+        event: {
+          runId: "recovery",
+          lifecycleGeneration: "generation-old",
+          data: { phase: "end" },
+        },
+        snapshotPatch: { status: "done", abortedLastRun: false },
+      }),
+    ).toEqual({
+      action: "apply",
+      patch: {
+        restartRecoveryRuns: [{ runId: "recovery", lifecycleGeneration: "generation-current" }],
+        restartRecoveryTerminalRunIds: ["recovery"],
+      },
+    });
+  });
+});

--- a/src/agents/main-session-recovery-state.test.ts
+++ b/src/agents/main-session-recovery-state.test.ts
@@ -92,7 +92,7 @@ describe("main session recovery state", () => {
     expect(entry).toEqual(before);
   });
 
-  it("marks without charging and preserves generation-scoped lifecycle fences", () => {
+  it("marks without charging and replaces an older lifecycle owner for the same run", () => {
     const entry = interruptedEntry({
       restartRecoveryRuns: [
         { runId: "older-run", lifecycleGeneration: "generation-old" },
@@ -123,7 +123,6 @@ describe("main session recovery state", () => {
     expect(entry.restartRecoveryRuns).toEqual([
       { runId: "new-run", lifecycleGeneration: "generation-2" },
       { runId: "older-run", lifecycleGeneration: "generation-old" },
-      { runId: "shared-run", lifecycleGeneration: "generation-1" },
       { runId: "shared-run", lifecycleGeneration: "generation-2" },
     ]);
   });
@@ -422,6 +421,7 @@ describe("main session recovery state", () => {
       pendingFinalDelivery: { kind: "replayable", text: " captured reply ", createdAt: 1 },
       restartRecoveryDeliveryRunId: "recovery-1",
       restartRecoveryDeliverySourceRunId: "source-1",
+      restartRecoveryRuns: [{ runId: "recovery-1", lifecycleGeneration: "generation-old" }],
       mainRestartRecovery: recoveryState({
         revision: 2,
         chargedAttempts: 1,

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -102,18 +102,26 @@ function validateRecoveryAdmission(
   return hasCurrentForegroundClaim(state, command.lifecycleGeneration) ? "foreground_active" : null;
 }
 
-function recordLifecycleFence(entry: SessionEntry, run: RestartRecoveryRun): void {
-  // Lifecycle fences can overlap and are consumed independently by their matching events.
-  const runs = new Map<string, RestartRecoveryRun>();
-  for (const existing of entry.restartRecoveryRuns ?? []) {
-    runs.set(`${existing.runId}\u0000${existing.lifecycleGeneration}`, existing);
+/** Keeps distinct concurrent runs while transferring each run id to its newest lifecycle owner. */
+export function normalizeMainSessionRecoveryRunFences(
+  runs: Iterable<RestartRecoveryRun>,
+): RestartRecoveryRun[] {
+  const ownersByRunId = new Map<string, RestartRecoveryRun>();
+  for (const run of runs) {
+    ownersByRunId.set(run.runId, run);
   }
-  runs.set(`${run.runId}\u0000${run.lifecycleGeneration}`, run);
-  entry.restartRecoveryRuns = [...runs.values()].toSorted((a, b) =>
-    a.runId === b.runId
-      ? a.lifecycleGeneration.localeCompare(b.lifecycleGeneration)
-      : a.runId.localeCompare(b.runId),
+  return [...ownersByRunId.values()].toSorted((left, right) =>
+    left.runId.localeCompare(right.runId),
   );
+}
+
+function recordLifecycleFence(entry: SessionEntry, run: RestartRecoveryRun): void {
+  // A resumed run keeps its id across Gateway generations. Leaving its old fence
+  // behind makes terminal settlement preserve a dead owner and blocks every later turn.
+  entry.restartRecoveryRuns = normalizeMainSessionRecoveryRunFences([
+    ...(entry.restartRecoveryRuns ?? []),
+    run,
+  ]);
 }
 
 function hasLifecycleFence(entry: SessionEntry, run: RestartRecoveryRun): boolean {

--- a/src/agents/main-session-recovery-store.test.ts
+++ b/src/agents/main-session-recovery-store.test.ts
@@ -241,6 +241,35 @@ describe("main session recovery store", () => {
     expect(readStore()[legacyKey]).toMatchObject({ abortedLastRun: true });
   });
 
+  it("transfers a resumed recovery run to one durable lifecycle owner", async () => {
+    await write(
+      interruptedEntry({
+        restartRecoveryRuns: [{ runId: "recovery-1", lifecycleGeneration: "generation-old" }],
+        mainRestartRecovery: {
+          cycleId: "cycle-1",
+          revision: 2,
+          chargedAttempts: 1,
+          reservation: { runId: "recovery-1", attempt: 1, lifecycleGeneration },
+        },
+      }),
+    );
+
+    const admitted = await commitMainSessionRecovery({
+      command: {
+        kind: "admit_recovery",
+        lifecycleGeneration,
+        now: 300,
+        runId: "recovery-1",
+        sessionId: "session-1",
+      },
+      target: { sessionKey, storePath },
+    });
+
+    expect(admitted.transition).toEqual({ kind: "admitted_recovery" });
+    expect(read().restartRecoveryRuns).toEqual([{ runId: "recovery-1", lifecycleGeneration }]);
+    expect(read().abortedLastRun).toBe(false);
+  });
+
   it("rejects an observation after the session is replaced", async () => {
     await write({
       sessionId: "session-2",

--- a/src/agents/main-session-restart-recovery-marking.ts
+++ b/src/agents/main-session-restart-recovery-marking.ts
@@ -20,7 +20,10 @@ import {
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
 } from "./embedded-agent-runner/run-state.js";
-import { transitionMainSessionRecovery } from "./main-session-recovery-state.js";
+import {
+  normalizeMainSessionRecoveryRunFences,
+  transitionMainSessionRecovery,
+} from "./main-session-recovery-state.js";
 import {
   hasCurrentProcessOwner,
   log,
@@ -189,34 +192,16 @@ export async function markRestartAbortedMainSessions(params: {
             continue;
           }
           const wasRunning = entry.status === "running";
-          const recoveryRuns = new Map<string, RestartRecoveryRun>();
-          for (const run of entry.restartRecoveryRuns ?? []) {
-            if (run.lifecycleGeneration === currentLifecycleGeneration) {
-              recoveryRuns.set(`${run.runId}\u0000${run.lifecycleGeneration}`, run);
-            }
-          }
-          const replaceActiveRunMarker = (run: RestartRecoveryRun) => {
-            for (const [key, existingRun] of recoveryRuns) {
-              if (existingRun.runId === run.runId) {
-                recoveryRuns.delete(key);
-              }
-            }
-            recoveryRuns.set(`${run.runId}\u0000${run.lifecycleGeneration}`, run);
-          };
-          for (const run of registeredActiveRuns) {
-            replaceActiveRunMarker(run);
-          }
-          for (const run of matchingActiveRuns) {
-            replaceActiveRunMarker({
-              runId: run.runId,
-              lifecycleGeneration: run.lifecycleGeneration,
-            });
-          }
-          entry.restartRecoveryRuns = [...recoveryRuns.values()].toSorted((a, b) =>
-            a.runId === b.runId
-              ? a.lifecycleGeneration.localeCompare(b.lifecycleGeneration)
-              : a.runId.localeCompare(b.runId),
-          );
+          entry.restartRecoveryRuns = normalizeMainSessionRecoveryRunFences([
+            ...(entry.restartRecoveryRuns ?? []).filter(
+              (run) => run.lifecycleGeneration === currentLifecycleGeneration,
+            ),
+            ...registeredActiveRuns,
+            ...matchingActiveRuns.map(({ runId, lifecycleGeneration }) => ({
+              runId,
+              lifecycleGeneration,
+            })),
+          ]);
           transitionMainSessionRecovery(entry, {
             kind: "mark_interrupted",
             cycleId: randomUUID(),

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -397,6 +397,43 @@ describe("session lifecycle state", () => {
     expect(persisted.mainRestartRecovery).toBeUndefined();
   });
 
+  it("clears every generation of a resumed run when its current owner completes", async () => {
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const persisted = await persistLifecycle(
+      {
+        sessionId: "session-id",
+        updatedAt: 1_000,
+        startedAt: 1_050,
+        status: "running",
+        abortedLastRun: false,
+        restartRecoveryRuns: [
+          { runId: "recovery-run", lifecycleGeneration: "pre-restart" },
+          { runId: "recovery-run", lifecycleGeneration },
+        ],
+        mainRestartRecovery: {
+          cycleId: "cycle-1",
+          revision: 5,
+          chargedAttempts: 2,
+        },
+      },
+      {
+        ts: 2_000,
+        sessionId: "session-id",
+        runId: "recovery-run",
+        lifecycleGeneration,
+        data: { phase: "end", endedAt: 1_800 },
+      },
+    );
+
+    expect(persisted).toMatchObject({
+      status: "done",
+      endedAt: 1_800,
+      abortedLastRun: false,
+    });
+    expect(persisted.restartRecoveryRuns).toBeUndefined();
+    expect(persisted.mainRestartRecovery).toBeUndefined();
+  });
+
   it("does not settle a foreground owner from a stale lifecycle generation", async () => {
     const persisted = await persistLifecycle(
       {


### PR DESCRIPTION
Closes #116694

## What problem this solves

Fixes channel-backed main sessions that stop accepting new Telegram or heartbeat turns after repeated Gateway restarts, even though the resumed recovery run and Gateway remain healthy.

## Root cause and fix

Recovery admission indexed lifecycle ownership by `(runId, lifecycleGeneration)`, while restart recovery already treated the run ID as the owner. A resumed run could therefore retain both its old and replacement lifecycle fences; when the current generation completed, its stale same-run fence survived and poisoned every subsequent turn with `Session changed while starting work. Retry.`

- Give each recovery run one canonical lifecycle-generation owner and share that normalization with restart recovery marking.
- Clear legacy same-run fences when the current generation completes, while keeping delayed terminals from older generations fenced away from the replacement owner.
- Cover admission, persisted recovery state, Gateway lifecycle persistence, restart recovery, and older-generation terminal ordering.

## Verification

- Reproduced both regressions against the previous code: duplicate same-run generations and stale recovery ownership after current-generation completion.
- **279 focused tests passed** across recovery ownership, the SQLite-backed recovery store, Gateway lifecycle persistence, restart recovery, and reply admission.
- Full changed-code gate passed: production/test typechecks, typed lint, formatting, max-lines ratchet, boundary checks, dead-export scans, and policy guards.
- Structured autoreview: clean; no actionable findings.
- Upstream Codex thread/turn ownership verified directly in `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:315-325`, `codex-rs/app-server/src/request_processors/thread_processor.rs:3074-3133`, and `codex-rs/app-server/src/request_processors/turn_processor.rs:1418-1458`.
- Post-merge protected Telegram validation ran twice against exact landed main commit `f1cd165075b60b730c1037732f963ee8eb9a84ed`: **15/18 real Telegram scenarios passed in each attempt**, including exact reply delivery and post-write recovery. The three failures exactly match earlier unchanged `main` baseline failures.

## User impact

Recovered channel conversations settle cleanly and accept subsequent messages instead of indefinitely retaining or retrying them.


## Real Gateway/channel behavior proof

The exact PR head `38d9638da270f382e63010aa45a59f0075c32596` passed the hosted QA Smoke profile against a real ephemeral Gateway and Matrix channel adapter: [CI run 30617493014, profile 4/4](https://github.com/openclaw/openclaw/actions/runs/30617493014).

```json
{
  "head": "38d9638da270f382e63010aa45a59f0075c32596",
  "channel": "matrix",
  "gateway": "real ephemeral Gateway",
  "provider": "mock-openai",
  "passed": 3,
  "failed": 0,
  "scenarios": [
    {
      "name": "Matrix room continues after restart recovery",
      "result": "pass",
      "observed": "MATRIX_QA_RESTART_FIRST_3F6AD5C0 -> restart -> MATRIX_QA_RESTART_SECOND_3E1FCF9C -> MATRIX_QA_RESTART_THIRD_20BA425D"
    },
    {
      "name": "Matrix restart replay dedupe",
      "result": "pass",
      "observed": "MATRIX_QA_REPLAY_DEDUPE_61E78FBB -> restart -> MATRIX_QA_REPLAY_DEDUPE_FRESH_CAE198CC"
    },
    {
      "name": "Matrix lane resumes after Gateway restart",
      "result": "pass",
      "observed": "MATRIX_QA_RESTART_BEFORE_CC49D99C -> restart -> MATRIX_QA_RESTART_AFTER_7BFCBF59"
    }
  ]
}
```

Post-merge real Telegram proof: [protected live run 30619452176](https://github.com/openclaw/openclaw/actions/runs/30619452176). Both attempts passed 15 scenarios, including `telegram-reply-chain-exact-marker` (`QA-TELEGRAM-REPLY-CHAIN-OK`) and `telegram-empty-response-after-write-recovery` (`TELEGRAM-EMPTY-WRITE-RECOVERED-OK`; `requests=3 writes=1 continuations=1`). The overall batch remains red because the same three unrelated scenarios also failed against [earlier main baseline](https://github.com/openclaw/openclaw/actions/runs/30617612182): `channel-message-flows`, `native-command-session-target`, and `telegram-assistant-transcript-role-boundary`.

Optional Mantis Desktop visual recording could not run its requested restart sequence because the burner Telegram user lacks Gateway-restart permission; no product failure was observed. The optional broader parity run independently hit the same unrelated `subagent-fanout-synthesis` 30-second timeout on **both** unchanged baseline and candidate; the PR's complete required hosted CI remains green.
