### PR TITLE
fix(llama-cpp): execute model-generated plaintext tool calls

### DIFF
--- a/extensions/llama-cpp/src/inference-provider.test.ts
+++ b/extensions/llama-cpp/src/inference-provider.test.ts
@@ -364,6 +364,100 @@ describe("llama.cpp inference provider", () => {
     expect(mocks.llama.createGrammarForJsonSchema).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      format: "Harmony",
+      text: '<|channel|>commentary to=weather code<|message|>{"city":"Paris"}<|call|>',
+    },
+    {
+      format: "bracketed",
+      text: '[weather]\n{"city":"Paris"}\n[END_TOOL_REQUEST]',
+    },
+  ])("promotes $format plaintext tool calls into native tool events", async ({ text }) => {
+    mocks.generateResponse.mockImplementationOnce(async (_history, options) => {
+      options.onTextChunk(text.slice(0, 12));
+      options.onTextChunk(text.slice(12));
+      return {
+        response: text,
+        functionCalls: undefined,
+        metadata: { stopReason: "eogToken" },
+      };
+    });
+
+    const stream = await createLlamaCppStreamFn({})(model, {
+      messages: [{ role: "user", content: "Weather?", timestamp: 1 }],
+      tools: [
+        {
+          name: "weather",
+          description: "Get weather",
+          parameters: { type: "object", properties: { city: { type: "string" } } },
+        },
+      ],
+    });
+
+    const events = await collectEvents(stream);
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "toolcall_start",
+      "toolcall_delta",
+      "toolcall_end",
+      "done",
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      reason: "toolUse",
+      message: {
+        stopReason: "toolUse",
+        content: [
+          {
+            type: "toolCall",
+            name: "weather",
+            arguments: { city: "Paris" },
+          },
+        ],
+      },
+    });
+  });
+
+  it("preserves plaintext calls for tools that are not registered", async () => {
+    const text = '[tool:calendar] {"city":"Paris"}';
+    mocks.generateResponse.mockImplementationOnce(async (_history, options) => {
+      options.onTextChunk(text);
+      return {
+        response: text,
+        functionCalls: undefined,
+        metadata: { stopReason: "eogToken" },
+      };
+    });
+
+    const stream = await createLlamaCppStreamFn({})(model, {
+      messages: [{ role: "user", content: "Weather?", timestamp: 1 }],
+      tools: [
+        {
+          name: "weather",
+          description: "Get weather",
+          parameters: { type: "object", properties: { city: { type: "string" } } },
+        },
+      ],
+    });
+
+    const events = await collectEvents(stream);
+
+    expect(events.map((event) => event.type)).toEqual([
+      "start",
+      "text_start",
+      "text_delta",
+      "text_end",
+      "done",
+    ]);
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      reason: "stop",
+      message: { content: [{ type: "text", text }] },
+    });
+  });
+
   it("lets tools win when responseFormat is also present", async () => {
     const stream = await createLlamaCppStreamFn({})(
       model,

--- a/extensions/llama-cpp/src/inference-provider.ts
+++ b/extensions/llama-cpp/src/inference-provider.ts
@@ -17,6 +17,7 @@ import type {
 } from "openclaw/plugin-sdk/llm";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { createPlainTextToolCallCompatWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
 import {
   DEFAULT_LLAMA_CPP_CONTEXT_SIZE,
   resolveLlamaCppModelCacheDir,
@@ -293,7 +294,7 @@ async function clearLlamaCppInferenceCacheForTests(): Promise<void> {
 }
 
 export function createLlamaCppStreamFn(params: { providerConfig?: ModelProviderConfig }): StreamFn {
-  return (model, context, options) => {
+  return createPlainTextToolCallCompatWrapper((model, context, options) => {
     const stream = createAssistantMessageEventStream();
     let streamedText = "";
     let generationAborted = false;
@@ -453,7 +454,7 @@ export function createLlamaCppStreamFn(params: { providerConfig?: ModelProviderC
       queueMicrotask(() => void serialize(run));
     }
     return stream;
-  };
+  });
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where llama.cpp users receive model-generated tool calls as plain assistant text instead of having the requested tool executed.

## Why This Change Was Made

The llama.cpp provider now uses the same bounded plaintext tool-call recovery already applied by the Ollama and LM Studio providers. Native structured calls, unknown tools, errors, and cancellations retain their existing behavior.

## User Impact

Local llama.cpp models can execute registered tools when they emit supported Harmony or bracketed textual call formats.

## Evidence

- Baseline: `12297b79471177f08a1959855d2998146c29537f`.
- Focused provider regressions: **20 passing tests**, including Harmony calls, bracketed calls, native structured calls, and unregistered-tool passthrough.
- Independent full-module and sibling-provider review: no actionable findings.
- Automated autoreview could not start because its required TruffleHog executable is unavailable; an independent source-level review covered the equivalent owner, callers, SDK wrapper, upstream contract, and regressions.

