### PR TITLE
fix(ollama): honor stop sequences and asynchronous payload hooks

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1595,15 +1595,7 @@ async function createOllamaTestStream(params: {
   defaultHeaders?: Record<string, string>;
   model?: Record<string, unknown>;
   context?: Record<string, unknown>;
-  options?: {
-    apiKey?: string;
-    maxTokens?: number;
-    temperature?: number;
-    signal?: AbortSignal;
-    timeoutMs?: number;
-    headers?: Record<string, string>;
-    responseFormat?: Record<string, unknown>;
-  };
+  options?: Parameters<ReturnType<typeof createOllamaStreamFn>>[2];
 }) {
   const streamFn = createOllamaStreamFn(params.baseUrl, params.defaultHeaders);
   return streamFn(
@@ -2352,6 +2344,112 @@ describe("createOllamaStreamFn", () => {
         expect(options.num_predict).toBe(123);
       },
     );
+  });
+
+  it.each([
+    {
+      name: "forwards request stop sequences as native Ollama options",
+      model: {},
+      stop: ["END", "DONE"],
+      expectedStop: ["END", "DONE"],
+    },
+    {
+      name: "lets request stop sequences override configured model stop sequences",
+      model: { params: { stop: ["MODEL"] } },
+      stop: ["REQUEST"],
+      expectedStop: ["REQUEST"],
+    },
+    {
+      name: "keeps configured model stop sequences when request stops are empty",
+      model: { params: { stop: ["MODEL"] } },
+      stop: [],
+      expectedStop: ["MODEL"],
+    },
+  ])("$name", async ({ model, stop, expectedStop }) => {
+    await expectSuccessfulOllamaRequest(
+      { baseUrl: "http://ollama-host:11434", model, options: { stop } },
+      ({ body }) =>
+        expect(requireRecord(body.options, "Ollama request options").stop).toEqual(expectedStop),
+    );
+  });
+
+  it("awaits asynchronous payload mutations before dispatching native Ollama requests", async () => {
+    await withSuccessfulOllamaFetch(async (fetchMock) => {
+      let releasePayload: (() => void) | undefined;
+      const payloadGate = new Promise<void>((resolve) => {
+        releasePayload = resolve;
+      });
+      const onPayload = vi.fn(async (payload: unknown) => {
+        await payloadGate;
+        requireRecord(payload, "Ollama request payload").model = "patched-model";
+      });
+      const stream = await createOllamaTestStream({
+        baseUrl: "http://ollama-host:11434",
+        options: { onPayload },
+      });
+
+      await vi.waitFor(() => expect(onPayload).toHaveBeenCalledTimes(1));
+      expect(fetchMock).not.toHaveBeenCalled();
+      expectDefined(releasePayload, "pending Ollama payload hook")();
+      const events = await collectStreamEvents(stream);
+
+      expect(events.at(-1)?.type).toBe("done");
+      expect(getGuardedFetchJsonBody(fetchMock).model).toBe("patched-model");
+    });
+  });
+
+  it("dispatches asynchronous payload replacements for native Ollama requests", async () => {
+    await expectSuccessfulOllamaRequest(
+      {
+        baseUrl: "http://ollama-host:11434",
+        options: {
+          onPayload: async (payload) => {
+            await Promise.resolve();
+            const current = requireRecord(payload, "Ollama request payload");
+            return {
+              ...current,
+              model: "replacement-model",
+              options: {
+                ...requireRecord(current.options, "Ollama request options"),
+                stop: ["REPLACEMENT"],
+              },
+            };
+          },
+        },
+      },
+      ({ body }) => {
+        expect(body.model).toBe("replacement-model");
+        expect(requireRecord(body.options, "Ollama request options").stop).toEqual(["REPLACEMENT"]);
+      },
+    );
+  });
+
+  it("surfaces asynchronous payload hook rejection without dispatching a request", async () => {
+    await withSuccessfulOllamaFetch(async (fetchMock) => {
+      const stream = await createOllamaTestStream({
+        baseUrl: "http://ollama-host:11434",
+        options: {
+          onPayload: async () => {
+            await Promise.resolve();
+            throw new Error("payload admission rejected");
+          },
+        },
+      });
+
+      const events = await collectStreamEvents(stream);
+
+      expect(events).toMatchObject([
+        {
+          type: "error",
+          reason: "error",
+          error: {
+            stopReason: "error",
+            errorMessage: "payload admission rejected",
+          },
+        },
+      ]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 
   it("maps responseFormat JSON Schema to native Ollama format", async () => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -1184,6 +1184,9 @@ function createRawOllamaStreamFn(
         if (typeof options?.maxTokens === "number") {
           ollamaOptions.num_predict = options.maxTokens;
         }
+        if (options?.stop && options.stop.length > 0) {
+          ollamaOptions.stop = options.stop;
+        }
         normalizeOllamaGreedySamplingOptions(ollamaOptions);
 
         // Structured-output grammars constrain the same token stream as tool
@@ -1209,7 +1212,8 @@ function createRawOllamaStreamFn(
           options: ollamaOptions,
           requestParams,
         });
-        options?.onPayload?.(body, model);
+        const replacement = await options?.onPayload?.(body, model);
+        const requestBody = replacement === undefined ? body : replacement;
         const headers: Record<string, string> = {
           "Content-Type": "application/json",
           ...defaultHeaders,
@@ -1227,7 +1231,7 @@ function createRawOllamaStreamFn(
           init: {
             method: "POST",
             headers,
-            body: JSON.stringify(body),
+            body: JSON.stringify(requestBody),
           },
           policy: ssrfPolicy,
           ...(options?.signal ? { signal: options.signal } : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where native Ollama requests ignore requested stop sequences and dispatch requests before asynchronous payload hooks can finish or replace the payload.

## Why This Change Was Made

The Ollama provider now applies the existing shared provider contract: nonempty request stop sequences override model defaults, asynchronous hooks finish before dispatch, replacement payloads are honored, and hook failures use the normal error lifecycle.

## User Impact

Local-model responses stop at requested boundaries and request customization, admission, and retry hooks reliably affect the actual request.

## Evidence

- Baseline: `12297b79471177f08a1959855d2998146c29537f`.
- Focused Ollama provider suite: **121 passing tests**, including six new stop-precedence and asynchronous-hook regressions.
- Independent full-module, caller, sibling-provider, and contract review: no actionable findings.
- Automated autoreview is unavailable because TruffleHog is not installed; an independent manual review verified the complete candidate instead.

