### PR TITLE
fix(config): reject incomplete escape sequences before mutations

### DIFF
--- a/src/cli/config-cli-path.ts
+++ b/src/cli/config-cli-path.ts
@@ -69,9 +69,10 @@ function parsePath(raw: string): PathSegment[] {
     const ch = trimmed[i];
     if (ch === "\\") {
       const next = trimmed[i + 1];
-      if (next) {
-        current += next;
+      if (next === undefined) {
+        throw new Error(`Invalid path (trailing escape): ${raw}`);
       }
+      current += next;
       i += 2;
       continue;
     }

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -3346,6 +3346,31 @@ describe("config cli", () => {
         args: ["config", "set", "gateway.[port]", "23456"],
         error: "Invalid path (empty segment): gateway.[port]",
       },
+      {
+        name: "rejects a trailing escape for config get before reading another key",
+        args: ["config", "get", "gateway.port\\"],
+        error: "Invalid path (trailing escape): gateway.port\\",
+      },
+      {
+        name: "rejects a trailing escape for config set before writing another key",
+        args: ["config", "set", "gateway.port\\", "23456"],
+        error: "Invalid path (trailing escape): gateway.port\\",
+      },
+      {
+        name: "rejects a trailing escape for config unset before deleting another key",
+        args: ["config", "unset", "gateway.port\\"],
+        error: "Invalid path (trailing escape): gateway.port\\",
+      },
+      {
+        name: "rejects a trailing escape for batch config set before writing another key",
+        args: [
+          "config",
+          "set",
+          "--batch-json",
+          JSON.stringify([{ path: "gateway.port\\", value: 23456 }]),
+        ],
+        error: "Invalid path (trailing escape): gateway.port\\",
+      },
     ])("$name", async ({ args, error, list }) => {
       if (list) {
         const resolved = { agents: { list } } as unknown as OpenClawConfig;
@@ -3357,6 +3382,15 @@ describe("config cli", () => {
       }
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
     });
+
+    it.each(["gateway.port\\", "gateway.port\\   "])(
+      "rejects a trailing escape in shared config path %s",
+      (configPath) => {
+        expect(() => parseConfigSetPath(configPath)).toThrow(
+          `Invalid path (trailing escape): ${configPath}`,
+        );
+      },
+    );
 
     it.each([
       "agents.list[0]id",
@@ -3396,6 +3430,12 @@ describe("config cli", () => {
       ["agents.list[0].id", ["agents", "list", "0", "id"]],
       ["agents.list[0][1]", ["agents", "list", "0", "1"]],
       ["[0]", ["0"]],
+      ["  gateway.port  ", ["gateway", "port"]],
+      ["channels.discord.guilds.prod\\.guild", ["channels", "discord", "guilds", "prod.guild"]],
+      [
+        "channels.discord.guilds.prod\\\\.channels",
+        ["channels", "discord", "guilds", "prod\\", "channels"],
+      ],
     ])("preserves valid bracket path %s", (configPath, expected) => {
       expect(parseConfigSetPath(configPath)).toEqual(expected);
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a malformed configuration path ending in a backslash silently accesses, overwrites, or deletes a different real configuration key.

## Why This Change Was Made

The shared configuration-path parser now rejects incomplete trailing escape sequences before any get, set, unset, batch, or system-agent configuration operation runs.

## User Impact

Malformed paths fail clearly without reading or mutating unintended configuration. Existing escaped dots, literal backslashes, bracket paths, and surrounding whitespace continue to work.

## Evidence

- Baseline: `12297b79471177f08a1959855d2998146c29537f`.
- Focused parser and command-boundary regressions: **14 passing tests**.
- Independent review of all parser callers and valid escape forms: no actionable findings.
- The automated autoreview helper cannot run because TruffleHog is unavailable; independent manual owner-boundary review was completed.

