### PR TITLE
feat(plugins): externalize DuckDuckGo search

### DIFF
--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-66 plugins
+65 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -84,8 +84,6 @@ Each entry lists the package, distribution route, and description.
 - **[deepgram](/plugins/reference/deepgram)** (`@openclaw/deepgram-provider`) - included in OpenClaw. Adds media understanding provider support. Adds realtime transcription provider support.
 
 - **[document-extract](/plugins/reference/document-extract)** (`@openclaw/document-extract-plugin`) - included in OpenClaw. Extract text and fallback page images from local document attachments.
-
-- **[duckduckgo](/plugins/reference/duckduckgo)** (`@openclaw/duckduckgo-plugin`) - included in OpenClaw. Adds web search provider support.
 
 - **[elevenlabs](/plugins/reference/elevenlabs)** (`@openclaw/elevenlabs-speech`) - included in OpenClaw. Adds media understanding provider support. Adds realtime transcription provider support. Adds text-to-speech provider support.
 
@@ -187,7 +185,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-79 plugins
+80 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -232,6 +230,8 @@ Each entry lists the package, distribution route, and description.
 - **[diffs-language-pack](/plugins/reference/diffs-language-pack)** (`@openclaw/diffs-language-pack`) - npm; ClawHub: `clawhub:@openclaw/diffs-language-pack`. Adds syntax highlighting for languages outside the default diffs viewer set.
 
 - **[discord](/plugins/reference/discord)** (`@openclaw/discord`) - npm; ClawHub. OpenClaw Discord channel plugin for channels, DMs, commands, and app events.
+
+- **[duckduckgo](/plugins/reference/duckduckgo)** (`@openclaw/duckduckgo-plugin`) - npm; ClawHub: `clawhub:@openclaw/duckduckgo-plugin`. Adds web search provider support.
 
 - **[exa](/plugins/reference/exa)** (`@openclaw/exa-plugin`) - npm; ClawHub: `clawhub:@openclaw/exa-plugin`. Adds web search provider support.
 

--- a/docs/plugins/reference/duckduckgo.md
+++ b/docs/plugins/reference/duckduckgo.md
@@ -12,7 +12,7 @@ Adds web search provider support.
 ## Distribution
 
 - Package: `@openclaw/duckduckgo-plugin`
-- Install route: included in OpenClaw
+- Install route: npm; ClawHub: `clawhub:@openclaw/duckduckgo-plugin`
 
 ## Surface
 

--- a/docs/tools/duckduckgo-search.md
+++ b/docs/tools/duckduckgo-search.md
@@ -18,6 +18,12 @@ OpenClaw supports DuckDuckGo as a **key-free** `web_search` provider. No API key
 DuckDuckGo is never auto-selected, since auto-detection only considers providers with usable credentials. Set it explicitly:
 
 <Steps>
+  <Step title="Install the plugin">
+    ```bash
+    openclaw plugins install @openclaw/duckduckgo-plugin
+    openclaw gateway restart
+    ```
+  </Step>
   <Step title="Configure">
     ```bash
     openclaw configure --section web

--- a/extensions/duckduckgo/README.md
+++ b/extensions/duckduckgo/README.md
@@ -1,0 +1,12 @@
+# OpenClaw DuckDuckGo Plugin
+
+Official OpenClaw plugin for DuckDuckGo web search.
+
+Install from OpenClaw:
+
+```bash
+openclaw plugins install @openclaw/duckduckgo-plugin
+openclaw gateway restart
+```
+
+See <https://docs.openclaw.ai/tools/duckduckgo-search> for setup and configuration.

--- a/extensions/duckduckgo/index.ts
+++ b/extensions/duckduckgo/index.ts
@@ -5,7 +5,7 @@ import { createDuckDuckGoWebSearchProvider } from "./src/ddg-search-provider.js"
 export default definePluginEntry({
   id: "duckduckgo",
   name: "DuckDuckGo Plugin",
-  description: "Bundled DuckDuckGo web search plugin",
+  description: "Official DuckDuckGo web search plugin",
   register(api) {
     api.registerWebSearchProvider(createDuckDuckGoWebSearchProvider());
   },

--- a/extensions/duckduckgo/package.json
+++ b/extensions/duckduckgo/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@openclaw/duckduckgo-plugin",
   "version": "2026.7.2",
-  "private": true,
-  "description": "OpenClaw DuckDuckGo plugin",
+  "description": "OpenClaw DuckDuckGo plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
@@ -10,6 +13,23 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/duckduckgo-plugin",
+      "npmSpec": "@openclaw/duckduckgo-plugin",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.7.2"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
     "!dist/extensions/diffs/**",
     "!dist/extensions/diffs-language-pack/**",
     "!dist/extensions/discord/**",
+    "!dist/extensions/duckduckgo/**",
     "!dist/extensions/exa/**",
     "!dist/extensions/feishu/**",
     "!dist/extensions/featherless/**",

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -170,6 +170,46 @@
       }
     },
     {
+      "name": "@openclaw/duckduckgo-plugin",
+      "description": "OpenClaw DuckDuckGo plugin.",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "duckduckgo",
+          "label": "DuckDuckGo"
+        },
+        "contracts": {
+          "webSearchProviders": [
+            "duckduckgo"
+          ]
+        },
+        "webSearchProviders": [
+          {
+            "id": "duckduckgo",
+            "label": "DuckDuckGo Search (experimental)",
+            "hint": "Free web search fallback with no API key required",
+            "onboardingScopes": [
+              "text-inference"
+            ],
+            "requiresCredential": false,
+            "envVars": [],
+            "placeholder": "(no key needed)",
+            "signupUrl": "https://duckduckgo.com/",
+            "docsUrl": "https://docs.openclaw.ai/tools/duckduckgo-search",
+            "credentialPath": "",
+            "autoDetectOrder": 100
+          }
+        ],
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/duckduckgo-plugin",
+          "npmSpec": "@openclaw/duckduckgo-plugin",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.7.2"
+        }
+      }
+    },
+    {
       "name": "@openclaw/exa-plugin",
       "description": "OpenClaw Exa plugin.",
       "source": "official",

--- a/src/cli/plugins-location-bridges.test.ts
+++ b/src/cli/plugins-location-bridges.test.ts
@@ -165,12 +165,13 @@ describe("listPersistedBundledPluginLocationBridges", () => {
   });
 
   it.each([
-    ["synthetic", "@openclaw/synthetic-provider"],
-    ["teams-meetings", "@openclaw/teams-meetings"],
-    ["zoom-meetings", "@openclaw/zoom-meetings"],
-  ])(
-    "externalizes the shipped bundled %s plugin while preserving default enablement",
-    async (pluginId, npmSpec) => {
+    ["duckduckgo", "@openclaw/duckduckgo-plugin", false],
+    ["synthetic", "@openclaw/synthetic-provider", true],
+    ["teams-meetings", "@openclaw/teams-meetings", true],
+    ["zoom-meetings", "@openclaw/zoom-meetings", true],
+  ] as const)(
+    "externalizes the shipped bundled %s plugin using official install metadata",
+    async (pluginId, npmSpec, enabledByDefault) => {
       readPersistedInstalledPluginIndexMock.mockResolvedValue(
         makeIndex({
           pluginId,
@@ -180,7 +181,7 @@ describe("listPersistedBundledPluginLocationBridges", () => {
           rootDir: `/app/dist/extensions/${pluginId}`,
           origin: "bundled",
           enabled: true,
-          enabledByDefault: true,
+          ...(enabledByDefault ? { enabledByDefault: true } : {}),
           startup: startupInfo,
           compat: [],
           packageInstall: {
@@ -197,7 +198,7 @@ describe("listPersistedBundledPluginLocationBridges", () => {
           preferredSource: "npm",
           npmSpec,
           clawhubSpec: `clawhub:${npmSpec}`,
-          enabledByDefault: true,
+          ...(enabledByDefault ? { enabledByDefault: true } : {}),
         },
       ]);
     },

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1972,6 +1972,34 @@ describe("official external plugin catalog", () => {
     });
   });
 
+  it("preserves DuckDuckGo's keyless web search setup contract", () => {
+    const duckduckgo = expectCatalogEntry("duckduckgo");
+    const manifest = getOfficialExternalPluginCatalogManifest(duckduckgo);
+
+    expect(resolveOfficialExternalPluginInstall(duckduckgo)).toEqual({
+      clawhubSpec: "clawhub:@openclaw/duckduckgo-plugin",
+      npmSpec: "@openclaw/duckduckgo-plugin",
+      defaultChoice: "npm",
+      minHostVersion: ">=2026.7.2",
+    });
+    expect(manifest?.contracts?.webSearchProviders).toEqual(["duckduckgo"]);
+    expect(manifest?.webSearchProviders).toEqual([
+      {
+        id: "duckduckgo",
+        label: "DuckDuckGo Search (experimental)",
+        hint: "Free web search fallback with no API key required",
+        onboardingScopes: ["text-inference"],
+        requiresCredential: false,
+        envVars: [],
+        placeholder: "(no key needed)",
+        signupUrl: "https://duckduckgo.com/",
+        docsUrl: "https://docs.openclaw.ai/tools/duckduckgo-search",
+        credentialPath: "",
+        autoDetectOrder: 100,
+      },
+    ]);
+  });
+
   it.each([
     ["teams-meetings", "@openclaw/teams-meetings", "teams_meetings", "teams"],
     ["zoom-meetings", "@openclaw/zoom-meetings", "zoom_meetings", "zoom"],

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -367,6 +367,14 @@ describe("bundled plugin build entries", () => {
     expectNoPrefixMatches(artifacts, "dist/extensions/synthetic/");
   });
 
+  it("excludes the externalized DuckDuckGo plugin from bundled artifacts", () => {
+    const artifacts = listBundledPluginPackArtifacts();
+
+    expect(artifacts).not.toContain("dist/extensions/duckduckgo/index.js");
+    expect(artifacts).not.toContain("dist/extensions/duckduckgo/openclaw.plugin.json");
+    expect(artifacts).not.toContain("dist/extensions/duckduckgo/package.json");
+  });
+
   it("keeps bundled channel secret contracts on packed top-level sidecars", () => {
     const artifacts = listBundledPluginPackArtifacts();
     const excludedPackageDirs = collectRootPackageExcludedExtensionDirs();


### PR DESCRIPTION
## What Problem This Solves

DuckDuckGo web search is optional, but its plugin currently ships inside every core OpenClaw package. Operators who never use this keyless experimental provider still receive its runtime, while plugin installation and release ownership remain split between bundled and external paths.

## Why This Change Was Made

This makes `@openclaw/duckduckgo-plugin` an official external package distributed through npm and ClawHub. The official catalog preserves the existing keyless web-search descriptor and setup metadata, while the generic bundled-to-external update bridge migrates enabled installations using the persisted plugin registry.

The core package now excludes DuckDuckGo artifacts. Package metadata, generated inventory, plugin reference docs, and setup instructions all describe the on-demand install route.

AI-assisted: yes.

## User Impact

New users install DuckDuckGo only when they choose it:

```bash
openclaw plugins install @openclaw/duckduckgo-plugin
openclaw gateway restart
```

Existing users who had the bundled plugin enabled retain the same plugin id, configuration, explicit-selection behavior, and keyless credential contract during an OpenClaw update.

## Evidence

- 209 focused tests passed across DuckDuckGo behavior, official catalog resolution, update relocation, bundled artifact exclusion, and npm/ClawHub release tooling.
- `plugin-npm-release-check` and `plugin-clawhub-release-check` accept `@openclaw/duckduckgo-plugin@2026.7.2`.
- Generated plugin inventory check, targeted `oxfmt`, JSON parsing, and `git diff --check` passed.
- Exact-head Codex autoreview reported no findings and rated the patch correct with 0.87 confidence.
- Reviewed head: `3b61eb139346dbce9418cc70c5de6462e2b65160`.
