### PR TITLE
Add WRouter provider extension

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7570,6 +7570,14 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Surface
   - H2: Related docs
 
+## plugins/reference/wrouter.md
+
+- Route: /plugins/reference/wrouter
+- Headings:
+  - H1: Wrouter plugin
+  - H2: Distribution
+  - H2: Surface
+
 ## plugins/reference/xai.md
 
 - Route: /plugins/reference/xai

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-66 plugins
+67 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -180,6 +180,8 @@ Each entry lists the package, distribution route, and description.
 - **[webhooks](/plugins/reference/webhooks)** (`@openclaw/webhooks`) - included in OpenClaw. Authenticated inbound webhooks that bind external automation to OpenClaw TaskFlows.
 
 - **[workboard](/plugins/reference/workboard)** (`@openclaw/workboard`) - included in OpenClaw. Dashboard workboard for agent-owned issues and sessions.
+
+- **[wrouter](/plugins/reference/wrouter)** (`@openclaw/wrouter-provider`) - included in OpenClaw; npm; ClawHub: `clawhub:@openclaw/wrouter-provider`. Adds Wrouter model provider support to OpenClaw.
 
 - **[xai](/plugins/reference/xai)** (`@openclaw/xai-plugin`) - included in OpenClaw. Adds xAI model provider support to OpenClaw.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 146
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 147
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/wrouter.md
+++ b/docs/plugins/reference/wrouter.md
@@ -1,0 +1,19 @@
+---
+summary: "Adds Wrouter model provider support to OpenClaw."
+read_when:
+  - You are installing, configuring, or auditing the wrouter plugin
+title: "Wrouter plugin"
+---
+
+# Wrouter plugin
+
+Adds Wrouter model provider support to OpenClaw.
+
+## Distribution
+
+- Package: `@openclaw/wrouter-provider`
+- Install route: included in OpenClaw; npm; ClawHub: `clawhub:@openclaw/wrouter-provider`
+
+## Surface
+
+providers: `wrouter`

--- a/extensions/wrouter/README.md
+++ b/extensions/wrouter/README.md
@@ -1,0 +1,6 @@
+# @openclaw/wrouter-provider
+
+[WRouter](https://wrouter.ai) — OpenAI-compatible AI gateway aggregating
+Anthropic, OpenAI, Google and other upstreams behind a single `/v1` endpoint.
+
+Auth: `WROUTER_API_KEY`. Base URL: `https://wrouter.ai/v1`.

--- a/extensions/wrouter/api.ts
+++ b/extensions/wrouter/api.ts
@@ -1,0 +1,3 @@
+// WRouter API module exposes the plugin public contract.
+export { WROUTER_BASE_URL, WROUTER_MODEL_CATALOG } from "./models.js";
+export { buildWRouterProvider } from "./provider-catalog.js";

--- a/extensions/wrouter/index.ts
+++ b/extensions/wrouter/index.ts
@@ -1,0 +1,35 @@
+// WRouter plugin entrypoint registers its OpenClaw integration.
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { applyWRouterConfig } from "./onboard.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { buildWRouterProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "wrouter";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "WRouter Provider",
+  description: "Bundled WRouter provider plugin",
+  manifest,
+  provider: {
+    label: "WRouter",
+    docsPath: "/providers/wrouter",
+    manifestAuth: { applyConfig: applyWRouterConfig },
+    catalog: {
+      buildProvider: buildWRouterProvider,
+      buildStaticProvider: buildWRouterProvider,
+      liveModelDiscovery: true,
+    },
+    augmentModelCatalog: ({ config }) =>
+      readConfiguredProviderCatalogEntries({
+        config,
+        providerId: PROVIDER_ID,
+      }),
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+      dropReasoningFromHistory: false,
+    }),
+  },
+});

--- a/extensions/wrouter/models.ts
+++ b/extensions/wrouter/models.ts
@@ -1,0 +1,15 @@
+// WRouter plugin module builds model definitions from the manifest catalog.
+import { buildManifestModelDefinition } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const WROUTER_MANIFEST_CATALOG = manifest.modelCatalog.providers.wrouter;
+export const WROUTER_BASE_URL = WROUTER_MANIFEST_CATALOG.baseUrl;
+
+export const WROUTER_MODEL_CATALOG: ModelDefinitionConfig[] = WROUTER_MANIFEST_CATALOG.models.map(
+  buildManifestModelDefinition({
+    providerId: "wrouter",
+    catalog: WROUTER_MANIFEST_CATALOG,
+    decorate: (model) => ({ ...model, api: "openai-completions" }),
+  }),
+);

--- a/extensions/wrouter/onboard.ts
+++ b/extensions/wrouter/onboard.ts
@@ -1,0 +1,17 @@
+import { readManifestProviderDefaultModelRef } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { createModelCatalogPresetAppliers } from "openclaw/plugin-sdk/provider-onboard";
+import { WROUTER_BASE_URL, WROUTER_MODEL_CATALOG } from "./models.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const WROUTER_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(manifest, "wrouter")!;
+
+export const { applyConfig: applyWRouterConfig } = createModelCatalogPresetAppliers<[]>({
+  primaryModelRef: WROUTER_DEFAULT_MODEL_REF,
+  resolveParams: () => ({
+    providerId: "wrouter",
+    api: "openai-completions",
+    baseUrl: WROUTER_BASE_URL,
+    catalogModels: structuredClone(WROUTER_MODEL_CATALOG),
+    aliases: [{ modelRef: WROUTER_DEFAULT_MODEL_REF, alias: "WRouter" }],
+  }),
+});

--- a/extensions/wrouter/openclaw.plugin.json
+++ b/extensions/wrouter/openclaw.plugin.json
@@ -1,0 +1,250 @@
+{
+  "id": "wrouter",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providerCatalogEntry": "./provider-discovery.ts",
+  "providers": [
+    "wrouter"
+  ],
+  "providerEndpoints": [
+    {
+      "endpointClass": "wrouter",
+      "hosts": [
+        "wrouter.ai"
+      ]
+    }
+  ],
+  "providerRequest": {
+    "providers": {
+      "wrouter": {
+        "family": "openai-compatible"
+      }
+    }
+  },
+  "modelCatalog": {
+    "providers": {
+      "wrouter": {
+        "baseUrl": "https://wrouter.ai/v1",
+        "api": "openai-completions",
+        "defaultModel": "claude-sonnet-5",
+        "models": [
+          {
+            "id": "claude-sonnet-5",
+            "name": "Claude Sonnet 5",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 200000,
+            "maxTokens": 64000,
+            "cost": {
+              "input": 3,
+              "output": 15
+            }
+          },
+          {
+            "id": "claude-opus-4-8",
+            "name": "Claude Opus 4.8",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 200000,
+            "maxTokens": 32000,
+            "cost": {
+              "input": 5,
+              "output": 25
+            }
+          },
+          {
+            "id": "claude-haiku-4-5",
+            "name": "Claude Haiku 4.5",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 200000,
+            "maxTokens": 64000,
+            "cost": {
+              "input": 1,
+              "output": 5
+            }
+          },
+          {
+            "id": "gpt-5",
+            "name": "GPT-5",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 400000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 1.25,
+              "output": 10
+            }
+          },
+          {
+            "id": "gpt-5-mini",
+            "name": "GPT-5 mini",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 400000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.25,
+              "output": 2
+            }
+          },
+          {
+            "id": "gpt-5-nano",
+            "name": "GPT-5 nano",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 400000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.05,
+              "output": 0.4
+            }
+          },
+          {
+            "id": "gpt-4o",
+            "name": "GPT-4o",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+            "cost": {
+              "input": 2.5,
+              "output": 10
+            }
+          },
+          {
+            "id": "gpt-4o-mini",
+            "name": "GPT-4o mini",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+            "cost": {
+              "input": 0.15,
+              "output": 0.6
+            }
+          },
+          {
+            "id": "gpt-4.1",
+            "name": "GPT-4.1",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1047576,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 2,
+              "output": 8
+            }
+          },
+          {
+            "id": "gemini-2.5-pro",
+            "name": "Gemini 2.5 Pro",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.25,
+              "output": 5
+            }
+          },
+          {
+            "id": "gemini-2.5-flash",
+            "name": "Gemini 2.5 Flash",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.3,
+              "output": 2.5
+            }
+          },
+          {
+            "id": "gemini-2.5-flash-lite",
+            "name": "Gemini 2.5 Flash Lite",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.1,
+              "output": 0.4
+            }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "wrouter": "refreshable"
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "wrouter",
+        "envVars": [
+          "WROUTER_API_KEY"
+        ]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "wrouter",
+      "method": "api-key",
+      "choiceId": "wrouter-api-key",
+      "appGuidedSecret": true,
+      "choiceLabel": "WRouter API key",
+      "groupId": "wrouter",
+      "groupLabel": "WRouter",
+      "groupHint": "API key",
+      "optionKey": "wrouterApiKey",
+      "cliFlag": "--wrouter-api-key",
+      "cliOption": "--wrouter-api-key <key>",
+      "cliDescription": "WRouter API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/wrouter/package.json
+++ b/extensions/wrouter/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/wrouter-provider",
+  "version": "2026.7.2",
+  "description": "OpenClaw WRouter provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/wrouter-provider",
+      "npmSpec": "@openclaw/wrouter-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.6.8"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/wrouter/provider-catalog.ts
+++ b/extensions/wrouter/provider-catalog.ts
@@ -1,0 +1,11 @@
+// WRouter provider module implements model/runtime integration.
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { WROUTER_BASE_URL, WROUTER_MODEL_CATALOG } from "./models.js";
+
+export function buildWRouterProvider(): ModelProviderConfig {
+  return {
+    baseUrl: WROUTER_BASE_URL,
+    api: "openai-completions",
+    models: structuredClone(WROUTER_MODEL_CATALOG),
+  };
+}

--- a/extensions/wrouter/provider-discovery.ts
+++ b/extensions/wrouter/provider-discovery.ts
@@ -1,0 +1,18 @@
+// WRouter provider discovery entry.
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildWRouterProvider } from "./provider-catalog.js";
+
+const wrouterProviderDiscovery: ProviderPlugin = {
+  id: "wrouter",
+  label: "WRouter",
+  docsPath: "/providers/wrouter",
+  auth: [],
+  staticCatalog: {
+    order: "simple",
+    run: async () => ({
+      provider: buildWRouterProvider(),
+    }),
+  },
+};
+
+export default wrouterProviderDiscovery;

--- a/extensions/wrouter/tsconfig.json
+++ b/extensions/wrouter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2080,6 +2080,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/wrouter:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/xai:
     dependencies:
       typebox:


### PR DESCRIPTION
Adds [WRouter](https://wrouter.ai), an OpenAI-compatible AI gateway, as a bundled provider extension (enabled by default).

## What
- `extensions/wrouter/` — mirrors the existing OpenAI-compatible provider extensions (deepseek shape), stripped of provider-specific stream/thinking logic since WRouter is a plain passthrough gateway.
- `openclaw.plugin.json`: `enabledByDefault: true`, `modelCatalog` with 12 headline models (Claude / GPT / Gemini) and WRouter's per-model pricing, `api: openai-completions`, base URL `https://wrouter.ai/v1`, `WROUTER_API_KEY` auth.
- Thin `index.ts` / `provider-catalog.ts` / `onboard.ts` / `models.ts` over the plugin SDK.
- Regenerated plugin inventory, reference docs, and docs map.

## Validation
Ran locally against the workspace after `pnpm install`:
- `pnpm plugins:inventory:check` ✅
- `pnpm plugins:sync:check` ✅
- `pnpm docs:map:check` ✅

Manifest and generated docs are in sync. Structure mirrors the bundled deepseek provider.

## Usage
`WROUTER_API_KEY` + select a WRouter model; models are discovered live from `/v1/models`.

*Note: AI-assisted contribution.*