### PR TITLE
fix(agents): compact session status change text

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -579,6 +579,25 @@ describe("session_status tool", () => {
     listSessionStateEventsSinceMock.mockReturnValue({
       events: [
         {
+          sequence: 11,
+          sessionKey: "main",
+          sessionId: "s1",
+          agentId: "main",
+          kind: "run_failed",
+          actorType: "agent",
+          actorId: "worker-1",
+          runId: "run-11",
+          occurredAt: 90,
+          summary: "child run timed out",
+          payload: {
+            outcome: "timeout",
+            channel: "codex",
+            turns: 2,
+            catalogId: "internal-catalog",
+            nested: { drop: true },
+          },
+        },
+        {
           sequence: 12,
           sessionKey: "main",
           sessionId: "s1",
@@ -591,7 +610,7 @@ describe("session_status tool", () => {
         },
       ],
       truncated: false,
-      earliestAvailableSequence: 12,
+      earliestAvailableSequence: 11,
       historyGap: true,
     });
 
@@ -603,9 +622,18 @@ describe("session_status tool", () => {
     expect(getSessionStateVersionMock).toHaveBeenCalledWith("main", "main");
     expect(listSessionStateEventsSinceMock).toHaveBeenCalledWith("main", "main", 3, 200);
     expect(details.stateVersion).toBe(12);
-    expect(details.stateChanges).toMatchObject({
-      historyGap: true,
+    const expectedStateChanges = {
       events: [
+        {
+          sequence: 11,
+          kind: "run_failed",
+          actorType: "agent",
+          occurredAt: 90,
+          summary: "child run timed out",
+          actorId: "worker-1",
+          runId: "run-11",
+          payload: { outcome: "timeout", channel: "codex", turns: 2 },
+        },
         {
           sequence: 12,
           kind: "upstream_missing",
@@ -615,11 +643,35 @@ describe("session_status tool", () => {
           payload: { channel: "codex" },
         },
       ],
-    });
+      truncated: false,
+      earliestAvailableSequence: 11,
+      historyGap: true,
+    };
+    expect(details.stateChanges).toEqual(expectedStateChanges);
     expect(Value.Check(tool.outputSchema!, result.details)).toBe(true);
-    expect(JSON.stringify(details.stateChanges)).not.toContain("internal-catalog");
-    expect(text).toContain("Session state changes:");
-    expect(text).toContain('"kind": "upstream_missing"');
+    expect(details.statusText).toBe(text);
+    const stateChangesMarker = "Session state changes:\n```json\n";
+    const stateChangesStart = text.indexOf(stateChangesMarker);
+    expect(stateChangesStart).toBeGreaterThanOrEqual(0);
+    const stateChangesJsonStart = stateChangesStart + stateChangesMarker.length;
+    const stateChangesJsonEnd = text.indexOf("\n```", stateChangesJsonStart);
+    expect(stateChangesJsonEnd).toBeGreaterThan(stateChangesJsonStart);
+    const visibleStateChangesText = text.slice(stateChangesJsonStart, stateChangesJsonEnd);
+    expect(JSON.parse(visibleStateChangesText)).toEqual({
+      stateVersion: 12,
+      stateChanges: expectedStateChanges,
+    });
+    for (const omittedField of [
+      '"sessionKey"',
+      '"sessionId"',
+      '"agentId"',
+      '"catalogId"',
+      '"nested"',
+      "internal-catalog",
+    ]) {
+      expect(visibleStateChangesText).not.toContain(omittedField);
+      expect(String(details.statusText)).not.toContain(omittedField);
+    }
   });
 
   it("returns watched group changesSince under tree visibility", async () => {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -363,7 +363,7 @@ ${JSON.stringify(details, null, 2)}
 
 function formatSessionStateChanges(details: {
   stateVersion: number;
-  stateChanges: ReturnType<typeof listSessionStateEventsSince>;
+  stateChanges: ReturnType<typeof compactSessionStateChanges>;
 }): string {
   return `Session state changes:
 \`\`\`json
@@ -1085,9 +1085,7 @@ export function createSessionStatusTool(opts?: {
             : undefined;
           const extraBlocks = [
             routeContextText,
-            rawStateChanges
-              ? formatSessionStateChanges({ stateVersion, stateChanges: rawStateChanges })
-              : undefined,
+            stateChanges ? formatSessionStateChanges({ stateVersion, stateChanges }) : undefined,
           ].filter((block): block is string => Boolean(block));
           const visibleStatusText =
             extraBlocks.length > 0


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `session_status(changesSince)` returned a compact structured state-change projection but embedded raw database events in the model-visible text. Internal session identifiers and nested catalog/host payload fields could therefore bypass the tool's declared compact output contract.

## Why This Change Was Made

The tool now renders the same compact projection it returns in structured details. The state-event owner, cursor semantics, ordering, and persistence remain unchanged.

## User Impact

Agents receive one consistent, bounded-shape session-status result without redundant internal identifiers or undeclared nested event data in the text view.

## Evidence

- Before: structured details omitted `sessionKey`, `sessionId`, `agentId`, `catalogId`, and nested payload fields, while the visible JSON block still included them.
- After: regression coverage parses the visible JSON and proves it exactly matches the compact structured projection, retaining allowed actor/run/payload facts, ordering, version, truncation, and history-gap metadata.
- Focused Testbox proof passed 67/67 tests on run `30619561033`.
- The first changed gate reached formatting and found one formatter-only issue; repo `oxfmt` corrected it and targeted formatting plus `git diff --check` are clean. A fresh Testbox retry was blocked before allocation by external Blacksmith workflow-fetch HTTP 429.
- Exact-head hosted CI run `30620288531` is green on attempt 2. Attempt 1's only failure was a checkout-history fetch timeout in `security-fast`; the isolated rerun passed, as did every code, type, lint, test, and guard job.
- Final autoreview: clean, no accepted/actionable findings, confidence 0.97.

No protocol, schema, persistence, cursor, visibility, or state-event behavior changes.
