### PR TITLE
fix(qa-channel): isolate account evidence and exclude deleted messages

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1259,8 +1259,7 @@ Preferred generic helpers for new scenarios:
 - `waitForChannelReady`
 - `injectInboundMessage`
 - `injectOutboundMessage`
-- `waitForTransportOutboundMessage`
-- `waitForChannelOutboundMessage`
+- `waitForOutboundMessage`
 - `waitForNoTransportOutbound`
 - `getTransportSnapshot`
 - `readTransportMessage`
@@ -1269,10 +1268,10 @@ Preferred generic helpers for new scenarios:
 - `resetTransport`
 
 Compatibility aliases remain available for existing scenarios -
-`waitForQaChannelReady`, `waitForOutboundMessage`, `waitForNoOutbound`,
-`formatConversationTranscript`, `resetBus` - but new scenario authoring
-should use the generic names. The aliases exist to avoid a flag-day
-migration, not as the model going forward.
+`waitForQaChannelReady`, `waitForNoOutbound`, `formatConversationTranscript`,
+and `resetBus` - but new scenario authoring should use the generic names.
+Use the canonical `waitForOutboundMessage` for outbound checks instead of
+adding transport- or channel-specific outbound wait aliases.
 
 ## Reporting
 

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -399,6 +399,7 @@ class QaCrablineTransport extends QaStateBackedTransportAdapter {
       };
       this.waitForOutboundSequence = async (input) =>
         await waitForQaTransportOutboundSequence({
+          accountId: this.accountId,
           input,
           readEvents: () => this.#state.getOutboundEvents(),
         });

--- a/extensions/qa-lab/src/qa-channel-transport.test.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.test.ts
@@ -158,6 +158,70 @@ describe("qa channel transport", () => {
     expect(transport.state.getSnapshot().messages).toEqual([]);
   });
 
+  it("keeps outbound verdicts bound to the selected account", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+    const conversation = { id: "alice", kind: "direct" as const };
+
+    state.addOutboundMessage({
+      accountId: "other",
+      to: "dm:alice",
+      text: "QA-ACCOUNT-OK",
+    });
+    state.addOutboundMessage({
+      accountId: "other",
+      to: "dm:alice",
+      text: "⚠️ agent failed before reply: foreign account failure",
+    });
+    const expected = state.addOutboundMessage({
+      accountId: "default",
+      to: "dm:alice",
+      text: "QA-ACCOUNT-OK",
+    });
+
+    await expect(
+      transport.waitForOutbound({ conversation, textIncludes: "QA-ACCOUNT-OK", timeoutMs: 50 }),
+    ).resolves.toMatchObject({ accountId: "default", id: expected.id });
+  });
+
+  it("does not accept deleted previews as visible outbound replies", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+    const preview = state.addOutboundMessage({
+      to: "dm:alice",
+      text: "QA-VISIBLE-FINAL-OK",
+    });
+    state.deleteMessage({ messageId: preview.id });
+    const final = state.addOutboundMessage({
+      to: "dm:alice",
+      text: "QA-VISIBLE-FINAL-OK",
+    });
+
+    await expect(
+      transport.waitForOutbound({
+        conversation: { id: "alice", kind: "direct" },
+        textIncludes: "QA-VISIBLE-FINAL-OK",
+        timeoutMs: 50,
+      }),
+    ).resolves.toMatchObject({ id: final.id });
+  });
+
+  it("ignores another account's failure while waiting for a condition", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+
+    await expect(
+      transport.waitForCondition(async () => {
+        state.addOutboundMessage({
+          accountId: "other",
+          to: "dm:alice",
+          text: "⚠️ agent failed before reply: foreign account failure",
+        });
+        return "owned condition completed";
+      }, 50),
+    ).resolves.toBe("owned condition completed");
+  });
+
   it("injects native commands with transport metadata", async () => {
     const transport = createQaChannelTransport(createQaBusState());
 

--- a/extensions/qa-lab/src/qa-channel-transport.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.ts
@@ -184,6 +184,7 @@ class QaChannelTransport extends QaStateBackedTransportAdapter {
   }
   async waitForOutboundSequence(input: QaTransportOutboundSequenceMatch) {
     return await waitForQaTransportOutboundSequence({
+      accountId: this.accountId,
       input,
       readEvents: () => this.state.getSnapshot().events,
     });

--- a/extensions/qa-lab/src/qa-transport.test.ts
+++ b/extensions/qa-lab/src/qa-transport.test.ts
@@ -69,6 +69,7 @@ describe("waitForQaTransportOutboundSequence", () => {
 
     await expect(
       waitForQaTransportOutboundSequence({
+        accountId: "default",
         input: {
           conversationId: "qa-room",
           finalSettleMs: 0,
@@ -104,6 +105,7 @@ describe("waitForQaTransportOutboundSequence", () => {
 
     await expect(
       waitForQaTransportOutboundSequence({
+        accountId: "default",
         input: {
           conversationId: "alice",
           finalSettleMs: 20,
@@ -132,6 +134,7 @@ describe("waitForQaTransportOutboundSequence", () => {
 
     await expect(
       waitForQaTransportOutboundSequence({
+        accountId: "default",
         input: {
           conversationId: "alice",
           finalSettleMs: 0,
@@ -142,5 +145,64 @@ describe("waitForQaTransportOutboundSequence", () => {
         readEvents: () => state.getSnapshot().events,
       }),
     ).rejects.toThrow("timed out after 20ms");
+  });
+
+  it("ignores foreign-account and inbound edit events when proving a final reply", async () => {
+    const state = createQaBusState();
+    const expected = state.addOutboundMessage({
+      accountId: "default",
+      to: "dm:alice",
+      text: "owned preview",
+    });
+    state.editMessage({
+      accountId: "default",
+      messageId: expected.id,
+      text: "final marker",
+    });
+
+    const foreign = state.addOutboundMessage({
+      accountId: "other",
+      to: "dm:alice",
+      text: "foreign preview",
+    });
+    state.editMessage({
+      accountId: "other",
+      messageId: foreign.id,
+      text: "final marker",
+    });
+
+    const inbound = state.addInboundMessage({
+      accountId: "default",
+      conversation: { id: "alice", kind: "direct" },
+      senderId: "alice",
+      text: "inbound original",
+    });
+    state.editMessage({
+      accountId: "default",
+      messageId: inbound.id,
+      text: "inbound preview",
+    });
+    state.editMessage({
+      accountId: "default",
+      messageId: inbound.id,
+      text: "final marker",
+    });
+
+    await expect(
+      waitForQaTransportOutboundSequence({
+        accountId: "default",
+        input: {
+          conversationId: "alice",
+          finalSettleMs: 0,
+          finalTextIncludes: "final marker",
+          minimumPreviewEvents: 1,
+          timeoutMs: 50,
+        },
+        readEvents: () => state.getSnapshot().events,
+      }),
+    ).resolves.toMatchObject({
+      events: [{ kind: "sent" }, { kind: "edited" }],
+      final: { accountId: "default", direction: "outbound", id: expected.id },
+    });
   });
 });

--- a/extensions/qa-lab/src/qa-transport.ts
+++ b/extensions/qa-lab/src/qa-transport.ts
@@ -61,6 +61,7 @@ export type QaTransportState = {
 type QaTransportFailureCursorSpace = "all" | "outbound";
 
 type QaTransportFailureAssertionOptions = {
+  accountId?: string;
   sinceIndex?: number;
   cursorSpace?: QaTransportFailureCursorSpace;
 };
@@ -142,7 +143,9 @@ export function findFailureOutboundMessage(
           .slice(options?.sinceIndex ?? 0);
   return observedMessages.find(
     (message) =>
-      message.direction === "outbound" && Boolean(extractQaFailureReplyText(message.text)),
+      message.direction === "outbound" &&
+      (!options?.accountId || message.accountId === options.accountId) &&
+      Boolean(extractQaFailureReplyText(message.text)),
   );
 }
 
@@ -156,7 +159,7 @@ function assertNoFailureReplies(
   }
 }
 
-function createFailureAwareTransportWaitForCondition(state: QaTransportState) {
+function createFailureAwareTransportWaitForCondition(state: QaTransportState, accountId: string) {
   return async function waitForTransportCondition<T>(
     check: () => T | Promise<T | null | undefined> | null | undefined,
     timeoutMs = 15_000,
@@ -166,11 +169,13 @@ function createFailureAwareTransportWaitForCondition(state: QaTransportState) {
     return await waitForQaTransportCondition(
       async () => {
         assertNoFailureReplies(state, {
+          accountId,
           sinceIndex,
           cursorSpace: "all",
         });
         const value = await check();
         assertNoFailureReplies(state, {
+          accountId,
           sinceIndex,
           cursorSpace: "all",
         });
@@ -227,7 +232,10 @@ export abstract class QaStateBackedTransportAdapter implements QaTransportAdapte
     this.supportedActions = params.supportedActions ?? [];
     this.state = params.state;
     this.assertTransportHealthy = params.assertTransportHealthy ?? (() => undefined);
-    const waitForCondition = createFailureAwareTransportWaitForCondition(this.state);
+    const waitForCondition = createFailureAwareTransportWaitForCondition(
+      this.state,
+      this.accountId,
+    );
     this.waitForCondition = async (check, timeoutMs, intervalMs) =>
       await waitForCondition(
         async () => {
@@ -274,6 +282,7 @@ export abstract class QaStateBackedTransportAdapter implements QaTransportAdapte
     await sleep(quietMs);
     this.assertTransportHealthy();
     assertNoFailureReplies(this.state, {
+      accountId: this.accountId,
       sinceIndex: input.sinceIndex,
       cursorSpace: "outbound",
     });
@@ -288,10 +297,14 @@ export abstract class QaStateBackedTransportAdapter implements QaTransportAdapte
     return await waitForQaTransportCondition(() => {
       this.assertTransportHealthy();
       assertNoFailureReplies(this.state, {
+        accountId: this.accountId,
         sinceIndex: input.sinceIndex,
         cursorSpace: "outbound",
       });
       return this.outboundSince(input.sinceIndex).find((message) => {
+        if (message.deleted) {
+          return false;
+        }
         if (input.conversation && message.conversation.id !== input.conversation.id) {
           return false;
         }
@@ -313,7 +326,8 @@ export abstract class QaStateBackedTransportAdapter implements QaTransportAdapte
     return this.state
       .getSnapshot()
       .messages.filter((message) => message.direction === "outbound")
-      .slice(sinceIndex);
+      .slice(sinceIndex)
+      .filter((message) => message.accountId === this.accountId);
   }
 }
 
@@ -349,6 +363,7 @@ export function createQaStateBackedTransportAdapter(
       params.waitForOutboundSequence ??
       (async (input: QaTransportOutboundSequenceMatch) =>
         await waitForQaTransportOutboundSequence({
+          accountId: params.accountId,
           input,
           readEvents: () => {
             params.assertTransportHealthy?.();
@@ -387,6 +402,7 @@ function isQaTransportOutboundEvent(
 }
 
 export async function waitForQaTransportOutboundSequence(params: {
+  accountId: string;
   input: QaTransportOutboundSequenceMatch;
   readEvents: () =>
     | readonly (QaBusEvent | QaTransportOutboundEvent)[]
@@ -404,6 +420,9 @@ export async function waitForQaTransportOutboundSequence(params: {
       )
       .filter((event): event is QaTransportOutboundEvent => event !== null)
       .filter(({ message }) => {
+        if (message.accountId !== params.accountId || message.direction !== "outbound") {
+          return false;
+        }
         if (
           params.input.conversationId &&
           message.conversation.id !== params.input.conversationId
@@ -414,7 +433,9 @@ export async function waitForQaTransportOutboundSequence(params: {
       });
     const finalIndex = events.findLastIndex(
       ({ kind, message }) =>
-        kind !== "deleted" && message.text.includes(params.input.finalTextIncludes),
+        kind !== "deleted" &&
+        !message.deleted &&
+        message.text.includes(params.input.finalTextIncludes),
     );
     if (finalIndex < 0) {
       return undefined;
@@ -428,6 +449,7 @@ export async function waitForQaTransportOutboundSequence(params: {
     if (
       !latest ||
       latest.kind === "deleted" ||
+      latest.message.deleted ||
       !latest.message.text.includes(params.input.finalTextIncludes)
     ) {
       stableCursor = null;

--- a/extensions/qa-lab/src/scenario-runtime-api.test.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.test.ts
@@ -20,8 +20,6 @@ function createDeps(overrides?: Partial<QaScenarioRuntimeDeps>): QaScenarioRunti
     randomUUID,
     runScenario: fn,
     waitForOutboundMessage: fn,
-    waitForTransportOutboundMessage: fn,
-    waitForChannelOutboundMessage: fn,
     waitForNoOutbound: fn,
     waitForNoTransportOutbound: fn,
     recentOutboundSummary: fn,

--- a/extensions/qa-lab/src/scenario-runtime-api.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.ts
@@ -32,8 +32,6 @@ type QaScenarioRuntimeDeps = {
   randomUUID: () => string;
   runScenario: QaScenarioRuntimeFunction;
   waitForOutboundMessage: QaScenarioRuntimeFunction;
-  waitForTransportOutboundMessage: QaScenarioRuntimeFunction;
-  waitForChannelOutboundMessage: QaScenarioRuntimeFunction;
   waitForNoOutbound: QaScenarioRuntimeFunction;
   waitForNoTransportOutbound: QaScenarioRuntimeFunction;
   recentOutboundSummary: QaScenarioRuntimeFunction;
@@ -127,8 +125,6 @@ type QaScenarioRuntimeApi<
   runScenario: TDeps["runScenario"];
   waitForCondition: TEnv["transport"]["waitForCondition"];
   waitForOutboundMessage: TDeps["waitForOutboundMessage"];
-  waitForTransportOutboundMessage: TDeps["waitForTransportOutboundMessage"];
-  waitForChannelOutboundMessage: TDeps["waitForChannelOutboundMessage"];
   waitForNoOutbound: TDeps["waitForNoOutbound"];
   waitForNoTransportOutbound: TDeps["waitForNoTransportOutbound"];
   recentOutboundSummary: TDeps["recentOutboundSummary"];
@@ -240,8 +236,6 @@ export function createQaScenarioRuntimeApi<
     runScenario: params.deps.runScenario,
     waitForCondition: transport.waitForCondition,
     waitForOutboundMessage: params.deps.waitForOutboundMessage,
-    waitForTransportOutboundMessage: params.deps.waitForTransportOutboundMessage,
-    waitForChannelOutboundMessage: params.deps.waitForChannelOutboundMessage,
     waitForNoOutbound: params.deps.waitForNoOutbound,
     waitForNoTransportOutbound: params.deps.waitForNoTransportOutbound,
     recentOutboundSummary: params.deps.recentOutboundSummary,

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -303,7 +303,15 @@ describe("qa suite runtime flow", () => {
     expect(call.scenario).toBe(scenario);
     expect(call.deps.runScenario).toBe(runScenario);
     expect(call.deps.waitForQaChannelReady).toBe(waitForQaChannelReady);
-    expect(call.deps.waitForOutboundMessage).toBe(waitForOutboundMessage);
+    expect(call.deps.waitForOutboundMessage).toBeTypeOf("function");
+    const outboundPredicate = vi.fn();
+    call.deps.waitForOutboundMessage(env.transport.state, outboundPredicate, 123);
+    expect(waitForOutboundMessage).toHaveBeenCalledWith(
+      env.transport.state,
+      outboundPredicate,
+      123,
+      { accountId: "qa-channel" },
+    );
     expect(call.deps.markGatewayLogCursor()).toBe(0);
     expect(() => call.deps.assertNoGatewayLogSentinels()).not.toThrow();
     expect(call.deps.readSessionTranscriptSummary).toBe(readSessionTranscriptSummary);

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -4,8 +4,6 @@ import { describe, expect, it, vi } from "vitest";
 const createQaScenarioRuntimeApi = vi.hoisted(() => vi.fn());
 const runScenarioFlow = vi.hoisted(() => vi.fn(async (params: { api: unknown }) => params.api));
 const waitForOutboundMessage = vi.hoisted(() => vi.fn());
-const waitForTransportOutboundMessage = vi.hoisted(() => vi.fn());
-const waitForChannelOutboundMessage = vi.hoisted(() => vi.fn());
 const waitForNoOutbound = vi.hoisted(() => vi.fn());
 const waitForNoTransportOutbound = vi.hoisted(() => vi.fn());
 const recentOutboundSummary = vi.hoisted(() => vi.fn());
@@ -73,8 +71,6 @@ vi.mock("./scenario-flow-runner.js", () => ({
 
 vi.mock("./suite-runtime-transport.js", () => ({
   waitForOutboundMessage,
-  waitForTransportOutboundMessage,
-  waitForChannelOutboundMessage,
   waitForNoOutbound,
   waitForNoTransportOutbound,
   recentOutboundSummary,

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -71,11 +71,9 @@ import {
   formatTransportTranscript,
   readTransportTranscript,
   recentOutboundSummary,
-  waitForChannelOutboundMessage,
   waitForNoOutbound,
   waitForNoTransportOutbound,
   waitForOutboundMessage,
-  waitForTransportOutboundMessage,
 } from "./suite-runtime-transport.js";
 import type { QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
 import {
@@ -201,15 +199,25 @@ type QaSuiteScenarioFlowApiParams = QaSuiteScenarioDepsParams & {
 };
 
 function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
+  const waitForAccountOutboundMessage: typeof waitForOutboundMessage = (
+    state,
+    predicate,
+    timeoutMs,
+    options,
+  ) =>
+    waitForOutboundMessage(state, predicate, timeoutMs, {
+      ...options,
+      accountId: params.env.transport.accountId,
+    });
   return {
     fs,
     path,
     sleep,
     randomUUID,
     runScenario: params.runScenario,
-    waitForOutboundMessage,
-    waitForTransportOutboundMessage,
-    waitForChannelOutboundMessage,
+    waitForOutboundMessage: waitForAccountOutboundMessage,
+    waitForTransportOutboundMessage: waitForAccountOutboundMessage,
+    waitForChannelOutboundMessage: waitForAccountOutboundMessage,
     waitForNoOutbound,
     waitForNoTransportOutbound,
     recentOutboundSummary,

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -216,8 +216,6 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
     randomUUID,
     runScenario: params.runScenario,
     waitForOutboundMessage: waitForAccountOutboundMessage,
-    waitForTransportOutboundMessage: waitForAccountOutboundMessage,
-    waitForChannelOutboundMessage: waitForAccountOutboundMessage,
     waitForNoOutbound,
     waitForNoTransportOutbound,
     recentOutboundSummary,

--- a/extensions/qa-lab/src/suite-runtime-transport.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-transport.test.ts
@@ -124,6 +124,48 @@ describe("qa suite transport helpers", () => {
     );
   });
 
+  it("waits for a live final instead of accepting a deleted matching preview", async () => {
+    const state = createQaBusState();
+    const preview = state.addOutboundMessage({
+      to: "dm:qa-operator",
+      text: "QA-VISIBLE-FINAL-OK",
+    });
+    state.deleteMessage({ messageId: preview.id });
+    const final = state.addOutboundMessage({
+      to: "dm:qa-operator",
+      text: "QA-VISIBLE-FINAL-OK",
+    });
+
+    await expect(
+      waitForOutboundMessage(state, (message) => message.text.includes("QA-VISIBLE-FINAL-OK"), 50),
+    ).resolves.toMatchObject({ id: final.id });
+  });
+
+  it("filters foreign account replies and failures from account-scoped waits", async () => {
+    const state = createQaBusState();
+    state.addOutboundMessage({
+      accountId: "other",
+      to: "dm:qa-operator",
+      text: "QA-ACCOUNT-OK",
+    });
+    state.addOutboundMessage({
+      accountId: "other",
+      to: "dm:qa-operator",
+      text: "⚠️ agent failed before reply: foreign account failure",
+    });
+    const expected = state.addOutboundMessage({
+      accountId: "default",
+      to: "dm:qa-operator",
+      text: "QA-ACCOUNT-OK",
+    });
+
+    await expect(
+      waitForOutboundMessage(state, (message) => message.text.includes("QA-ACCOUNT-OK"), 50, {
+        accountId: "default",
+      }),
+    ).resolves.toMatchObject({ accountId: "default", id: expected.id });
+  });
+
   it("fails raw scenario waitForCondition calls when a classified failure reply arrives", async () => {
     const state = createQaBusState();
     const waitForCondition = createQaChannelTransport(state).waitForCondition;

--- a/extensions/qa-lab/src/suite-runtime-transport.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-transport.test.ts
@@ -8,7 +8,6 @@ import {
   readTransportTranscript,
   waitForNoOutbound,
   waitForOutboundMessage,
-  waitForTransportOutboundMessage,
 } from "./suite-runtime-transport.js";
 
 describe("qa suite transport helpers", () => {
@@ -278,22 +277,27 @@ describe("qa suite transport helpers", () => {
     expect(formatted).toContain("ASSISTANT OpenClaw QA: working on it");
   });
 
-  it("waits for outbound replies through the generic transport alias", async () => {
+  it("applies account filtering after the global outbound cursor", async () => {
     const state = createQaBusState();
-    const pending = waitForTransportOutboundMessage(
-      state,
-      (candidate) => candidate.conversation.id === "qa-operator" && candidate.text.includes("done"),
-      5_000,
-    );
-
     state.addOutboundMessage({
+      accountId: "other",
+      to: "dm:qa-operator",
+      text: "previous account reply",
+    });
+    const sinceIndex = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound").length;
+    const expected = state.addOutboundMessage({
+      accountId: "default",
       to: "dm:qa-operator",
       text: "done",
-      senderId: "openclaw",
-      senderName: "OpenClaw QA",
     });
 
-    const message = await pending;
-    expect(message.text).toBe("done");
+    await expect(
+      waitForOutboundMessage(state, (candidate) => candidate.text === "done", 50, {
+        accountId: "default",
+        sinceIndex,
+      }),
+    ).resolves.toMatchObject({ accountId: "default", id: expected.id });
   });
 });

--- a/extensions/qa-lab/src/suite-runtime-transport.ts
+++ b/extensions/qa-lab/src/suite-runtime-transport.ts
@@ -14,7 +14,7 @@ type WaitForNoOutboundOptions = {
 
 function findFailureOutboundMessage(
   state: QaTransportState,
-  options?: { sinceIndex?: number; cursorSpace?: "all" | "outbound" },
+  options?: { accountId?: string; sinceIndex?: number; cursorSpace?: "all" | "outbound" },
 ) {
   return findTransportFailureOutboundMessage(state, options);
 }
@@ -23,7 +23,7 @@ async function waitForOutboundMessage(
   state: QaTransportState,
   predicate: (message: QaBusMessage) => boolean,
   timeoutMs = 15_000,
-  options?: { sinceIndex?: number },
+  options?: { accountId?: string; sinceIndex?: number },
 ) {
   return await waitForQaTransportCondition(() => {
     const failureMessage = findFailureOutboundMessage(state, options);
@@ -34,7 +34,12 @@ async function waitForOutboundMessage(
       .getSnapshot()
       .messages.filter((message: QaBusMessage) => message.direction === "outbound")
       .slice(options?.sinceIndex ?? 0)
-      .find(predicate);
+      .find(
+        (message) =>
+          !message.deleted &&
+          (!options?.accountId || message.accountId === options.accountId) &&
+          predicate(message),
+      );
     if (!match) {
       return undefined;
     }

--- a/extensions/qa-lab/src/suite-runtime-transport.ts
+++ b/extensions/qa-lab/src/suite-runtime-transport.ts
@@ -141,22 +141,6 @@ function formatConversationTranscript(
   return formatTransportTranscript(state, params);
 }
 
-async function waitForTransportOutboundMessage(
-  state: QaTransportState,
-  predicate: (message: QaBusMessage) => boolean,
-  timeoutMs?: number,
-) {
-  return await waitForOutboundMessage(state, predicate, timeoutMs);
-}
-
-async function waitForChannelOutboundMessage(
-  state: QaTransportState,
-  predicate: (message: QaBusMessage) => boolean,
-  timeoutMs?: number,
-) {
-  return await waitForTransportOutboundMessage(state, predicate, timeoutMs);
-}
-
 async function waitForNoTransportOutbound(
   state: QaTransportState,
   timeoutMs = 1_200,
@@ -170,9 +154,7 @@ export {
   formatTransportTranscript,
   readTransportTranscript,
   recentOutboundSummary,
-  waitForChannelOutboundMessage,
   waitForNoOutbound,
   waitForNoTransportOutbound,
   waitForOutboundMessage,
-  waitForTransportOutboundMessage,
 };


### PR DESCRIPTION
## Summary
- Scope QA transport success and failure evidence to the intended account and message direction.
- Keep sequence expectations account/direction-aware so another transport stream cannot satisfy an unrelated scenario.
- Exclude deleted previews and tombstoned messages from live delivery evidence.
- Remove obsolete duplicate transport helper aliases across the complete committed tree; update published QA authoring documentation to identify the retained canonical helper.

## Verification
- QA transport owner suite: **34 tests passed**.
- Affected Crabline integration regression: **1 test passed**.
- Final transport/runtime API owner suite after the canonical cleanup: **35 tests passed**; full-tree retired-symbol scan and Markdown formatting pass.
- Independent manual review inspected transport adapters, scenario consumers, sibling evidence paths, account isolation, and deletion semantics; no blockers.
- Automated autoreview is unavailable because its mandatory TruffleHog binary is missing; independent manual diff and secret review completed.

## Root causes fixed
3 distinct QA transport evidence defects.
