### PR TITLE
fix(qa-lab): fail closed on invalid summaries and enforce process timeouts

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -314,12 +314,12 @@ describe("qa cli runtime", () => {
       watchUrl: "http://127.0.0.1:43124",
     });
     runQaMultipass.mockResolvedValue({
-      outputDir: "/tmp/multipass",
-      reportPath: "/tmp/multipass/qa-suite-report.md",
-      summaryPath: "/tmp/multipass/qa-suite-summary.json",
-      hostLogPath: "/tmp/multipass/multipass-host.log",
-      bootstrapLogPath: "/tmp/multipass/multipass-guest-bootstrap.log",
-      guestScriptPath: "/tmp/multipass/multipass-guest-run.sh",
+      outputDir: suiteArtifactsDir,
+      reportPath: suiteReportPath,
+      summaryPath: suiteSummaryPath,
+      hostLogPath: path.join(suiteArtifactsDir, "multipass-host.log"),
+      bootstrapLogPath: path.join(suiteArtifactsDir, "multipass-guest-bootstrap.log"),
+      guestScriptPath: path.join(suiteArtifactsDir, "multipass-guest-run.sh"),
       vmName: "openclaw-qa-test",
       scenarioIds: ["channel-chat-baseline"],
     });
@@ -464,9 +464,7 @@ describe("qa cli runtime", () => {
     }
   });
 
-  it("keeps direct-suite zero-work validation disabled with --allow-failures", async () => {
-    const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+  it("rejects direct-suite zero-work summaries even with --allow-failures", async () => {
     const optionalScenario = {
       name: "Runtime tool fixture — image_generate",
       status: "skip" as const,
@@ -490,13 +488,107 @@ describe("qa cli runtime", () => {
       }),
     );
 
-    try {
-      await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo", allowFailures: true });
-      expect(process.exitCode).toBeUndefined();
-    } finally {
-      process.exitCode = priorExitCode;
-    }
+    await expect(
+      runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo", allowFailures: true }),
+    ).rejects.toThrow("did not include any executed scenarios");
   });
+
+  it.each([
+    { runner: "host" as const, summary: "missing" as const, expected: "Could not read QA summary" },
+    {
+      runner: "host" as const,
+      summary: "malformed" as const,
+      expected: "Could not parse QA summary",
+    },
+    {
+      runner: "multipass" as const,
+      summary: "missing" as const,
+      expected: "Could not read QA summary",
+    },
+    {
+      runner: "multipass" as const,
+      summary: "malformed" as const,
+      expected: "Could not parse QA summary",
+    },
+    {
+      runner: "multipass" as const,
+      summary: "zero-work" as const,
+      expected: "did not include any executed scenarios",
+    },
+    ...(["host", "flow", "multipass"] as const).flatMap((runner) => [
+      {
+        runner,
+        summary: "required-skip" as const,
+        expected: "did not include any executed scenarios",
+      },
+      {
+        runner,
+        summary: "blocked" as const,
+        expected: "did not include any executed scenarios",
+      },
+    ]),
+  ])(
+    "rejects $summary $runner summaries even with --allow-failures",
+    async ({ runner, summary, expected }) => {
+      if (summary === "missing") {
+        await fs.rm(suiteSummaryPath);
+      } else if (summary === "malformed") {
+        await fs.writeFile(suiteSummaryPath, "{not-json", "utf8");
+      } else if (summary === "zero-work") {
+        await fs.writeFile(
+          suiteSummaryPath,
+          JSON.stringify({
+            counts: { total: 0, passed: 0, failed: 0, skipped: 0 },
+            scenarios: [],
+          }),
+          "utf8",
+        );
+      } else {
+        await fs.writeFile(
+          suiteSummaryPath,
+          JSON.stringify({
+            counts: {
+              total: 1,
+              passed: 0,
+              failed: 0,
+              skipped: summary === "required-skip" ? 1 : 0,
+            },
+            scenarios: [
+              {
+                name: "Required channel scenario",
+                status: summary === "required-skip" ? "skip" : "blocked",
+                details: "Required transport unavailable",
+              },
+            ],
+          }),
+          "utf8",
+        );
+      }
+      if (runner === "host" || runner === "flow") {
+        runQaSuite.mockResolvedValueOnce(
+          runner === "flow"
+            ? flowSuiteRuntimeResult({
+                reportPath: suiteReportPath,
+                summaryPath: suiteSummaryPath,
+              })
+            : unifiedSuiteRuntimeResult({
+                outputDir: suiteArtifactsDir,
+                reportPath: suiteReportPath,
+                summaryPath: suiteSummaryPath,
+                evidencePath: suiteEvidencePath,
+              }),
+        );
+      }
+
+      await expect(
+        runQaSuiteCommand({
+          repoRoot: "/tmp/openclaw-repo",
+          ...(runner === "multipass" ? { runner } : {}),
+          allowFailures: true,
+        }),
+      ).rejects.toThrow(expected);
+    },
+  );
 
   it("rejects host-only resource options for Playwright scenarios", async () => {
     await expect(

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -368,6 +368,7 @@ async function runQaParityPreflight(params: {
   process.stdout.write(`QA parity preflight summary: ${result.summaryPath}\n`);
   const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
     result.summaryPath,
+    { requireExecutedScenario: params.allowFailures === true },
   );
   if (blockingScenarioCount > 0) {
     if (params.allowFailures === true) {
@@ -978,19 +979,18 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
     process.stdout.write(`QA Multipass summary: ${result.summaryPath}\n`);
     process.stdout.write(`QA Multipass host log: ${result.hostLogPath}\n`);
     process.stdout.write(`QA Multipass bootstrap log: ${result.bootstrapLogPath}\n`);
-    if (!allowFailures) {
-      const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
-        result.summaryPath,
-        {
-          optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
-            scenarioIds,
-            explicitScenarioSelection: opts.explicitScenarioSelection,
-          }),
-        },
-      );
-      if (blockingScenarioCount > 0) {
-        process.exitCode = 1;
-      }
+    const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
+      result.summaryPath,
+      {
+        optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
+          scenarioIds,
+          explicitScenarioSelection: opts.explicitScenarioSelection,
+        }),
+        requireExecutedScenario: allowFailures,
+      },
+    );
+    if (!allowFailures && blockingScenarioCount > 0) {
+      process.exitCode = 1;
     }
     return result;
   }
@@ -1051,19 +1051,18 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
       process.stdout.write(`QA suite report: ${result.reportPath}\n`);
       process.stdout.write(`QA suite evidence: ${result.evidencePath}\n`);
       process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
-      if (!allowFailures) {
-        const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
-          result.summaryPath,
-          {
-            optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
-              scenarioIds,
-              explicitScenarioSelection: opts.explicitScenarioSelection,
-            }),
-          },
-        );
-        if (blockingScenarioCount > 0) {
-          process.exitCode = 1;
-        }
+      const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
+        result.summaryPath,
+        {
+          optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
+            scenarioIds,
+            explicitScenarioSelection: opts.explicitScenarioSelection,
+          }),
+          requireExecutedScenario: allowFailures,
+        },
+      );
+      if (!allowFailures && blockingScenarioCount > 0) {
+        process.exitCode = 1;
       }
       return result;
     }
@@ -1080,6 +1079,7 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
             scenarioIds,
             explicitScenarioSelection: opts.explicitScenarioSelection,
           }),
+          requireExecutedScenario: allowFailures,
         },
       );
       if (!allowFailures && blockingScenarioCount > 0) {

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
@@ -60,6 +60,8 @@ describe("Telegram live QA scenario gate", () => {
       summaryPath,
       JSON.stringify({
         counts: {
+          total: 1,
+          passed: status === "pass" ? 1 : 0,
           failed: status === "fail" ? 1 : 0,
           skipped: status === "skip" || status === "skipped" ? 1 : 0,
         },
@@ -76,6 +78,7 @@ describe("Telegram live QA scenario gate", () => {
     delete process.env[SUT_COMMAND_ENV];
     tempRoot = mkdtempSync(path.join(tmpdir(), "openclaw-qa-telegram-gate-"));
     summaryPath = path.join(tempRoot, "qa-suite-summary.json");
+    writeSummary("pass");
     mocks.resolveTelegramQaScenarioIds.mockReturnValue(["channel-canary"]);
     mocks.runQaFlowSuiteFromRuntime.mockResolvedValue({
       reportPath: ".artifacts/qa-e2e/telegram/qa-suite-report.md",
@@ -121,7 +124,8 @@ describe("Telegram live QA scenario gate", () => {
     expect(process.exitCode).toBeUndefined();
   });
 
-  it("does not read the summary when failures are explicitly allowed", async () => {
+  it("permits genuinely executed failed scenarios when failures are explicitly allowed", async () => {
+    writeSummary("fail");
     await runQaTelegramSuite({
       repoRoot: "/repo",
       providerMode: "mock-openai",
@@ -130,6 +134,43 @@ describe("Telegram live QA scenario gate", () => {
 
     expect(process.exitCode).toBeUndefined();
   });
+
+  it.each([
+    { summary: "missing", expected: "Could not read QA summary" },
+    { summary: "malformed", expected: "Could not parse QA summary" },
+    { summary: "zero-work", expected: "did not include any executed scenarios" },
+    { summary: "required-skip", expected: "did not include any executed scenarios" },
+    { summary: "blocked", expected: "did not include any executed scenarios" },
+  ])(
+    "rejects $summary Telegram summaries even with --allow-failures",
+    async ({ summary, expected }) => {
+      if (summary === "missing") {
+        rmSync(summaryPath);
+      } else if (summary === "malformed") {
+        writeFileSync(summaryPath, "{not-json", "utf8");
+      } else if (summary === "zero-work") {
+        writeFileSync(
+          summaryPath,
+          JSON.stringify({
+            counts: { total: 0, passed: 0, failed: 0, skipped: 0 },
+            scenarios: [],
+          }),
+          "utf8",
+        );
+      } else {
+        writeSummary(summary === "required-skip" ? "skip" : "blocked");
+      }
+
+      await expect(
+        runQaTelegramSuite({
+          repoRoot: "/repo",
+          providerMode: "mock-openai",
+          allowFailures: true,
+        }),
+      ).rejects.toThrow(expected);
+      expect(process.exitCode).toBeUndefined();
+    },
+  );
 
   it("lists only scenarios accepted by its flow runner", async () => {
     const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.ts
@@ -199,13 +199,12 @@ export async function runQaTelegramSuite(opts: TelegramQaSuiteOptions) {
     report: result.reportPath,
     summary: result.summaryPath,
   });
-  if (!runOptions.allowFailures) {
-    const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
-      result.summaryPath,
-    );
-    if (blockingScenarioCount > 0) {
-      process.exitCode = 1;
-    }
+  const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
+    result.summaryPath,
+    { requireExecutedScenario: runOptions.allowFailures === true },
+  );
+  if (!runOptions.allowFailures && blockingScenarioCount > 0) {
+    process.exitCode = 1;
   }
   return result;
 }

--- a/extensions/qa-lab/src/suite-summary.test.ts
+++ b/extensions/qa-lab/src/suite-summary.test.ts
@@ -94,6 +94,60 @@ describe("qa suite summary helpers", () => {
     ).resolves.toBe(1);
   });
 
+  it.each([
+    {
+      name: "required skip",
+      summary: {
+        counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+        scenarios: [{ name: "required scenario", status: "skip" }],
+      },
+    },
+    {
+      name: "required skipped",
+      summary: {
+        counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+        scenarios: [{ name: "required scenario", status: "skipped" }],
+      },
+    },
+    {
+      name: "blocked scenario",
+      summary: {
+        counts: { total: 1, passed: 0, failed: 0, skipped: 0 },
+        scenarios: [{ name: "required scenario", status: "blocked" }],
+      },
+    },
+    {
+      name: "blocked evidence",
+      summary: {
+        counts: { total: 1, passed: 0, failed: 0, skipped: 0 },
+        entries: [{ result: { status: "blocked" } }],
+      },
+    },
+  ])("requires a completed scenario before tolerating $name", async ({ summary }) => {
+    await expect(
+      readSummary(summary, (summaryPath) =>
+        readQaSuiteFailedOrSkippedScenarioCountFromFile(summaryPath, {
+          requireExecutedScenario: true,
+        }),
+      ),
+    ).rejects.toThrow("did not include any executed scenarios");
+  });
+
+  it("still permits a genuinely executed failed scenario in failure-tolerant gates", async () => {
+    await expect(
+      readSummary(
+        {
+          counts: { total: 1, passed: 0, failed: 1, skipped: 0 },
+          scenarios: [{ name: "required scenario", status: "fail" }],
+        },
+        (summaryPath) =>
+          readQaSuiteFailedOrSkippedScenarioCountFromFile(summaryPath, {
+            requireExecutedScenario: true,
+          }),
+      ),
+    ).resolves.toBe(1);
+  });
+
   it("rejects a suite containing only catalog-confirmed report-only skips", async () => {
     await expect(
       readSummary(

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -118,6 +118,7 @@ function assertQaSuiteSummaryHasExecutedScenarios(
   summaryPath: string,
   errorCode: "summary_failure_count_missing" | "summary_blocking_count_missing",
   optionalScenarioNames?: ReadonlySet<string>,
+  requireExecutedScenario = false,
 ): void {
   if (!summary || typeof summary !== "object") {
     return;
@@ -137,14 +138,15 @@ function assertQaSuiteSummaryHasExecutedScenarios(
   const entries = Array.isArray(payload.entries)
     ? (payload.entries as QaEvidenceEntryStatus[])
     : undefined;
-  const hasExecutedScenario =
+  const hasCompletedScenario =
     scenarios?.some((scenario) => scenario.status === "pass" || scenario.status === "fail") ===
       true ||
     entries?.some((entry) => entry.result?.status === "pass" || entry.result?.status === "fail") ===
       true ||
     (passed ?? 0) > 0 ||
-    (failed ?? 0) > 0 ||
-    (total !== null && total > 0 && (skipped === null || total > skipped));
+    (failed ?? 0) > 0;
+  const hasExecutedScenario =
+    hasCompletedScenario || (total !== null && total > 0 && (skipped === null || total > skipped));
   const hasBlockingNonOptionalSkip =
     errorCode === "summary_blocking_count_missing" &&
     scenarios?.some(
@@ -169,6 +171,8 @@ function assertQaSuiteSummaryHasExecutedScenarios(
   if (
     total === 0 ||
     scenarios?.length === 0 ||
+    // A tolerated blocking result cannot authenticate a campaign that never completed a scenario.
+    (requireExecutedScenario && !hasCompletedScenario) ||
     (!hasExecutedScenario &&
       !hasBlockingUnknownOrFailedScenario &&
       !hasBlockingNonOptionalSkip &&
@@ -309,7 +313,7 @@ export async function readQaSuiteFailedScenarioCountFromFile(summaryPath: string
 
 export async function readQaSuiteFailedOrSkippedScenarioCountFromFile(
   summaryPath: string,
-  options?: { optionalScenarioNames?: ReadonlySet<string> },
+  options?: { optionalScenarioNames?: ReadonlySet<string>; requireExecutedScenario?: boolean },
 ): Promise<number> {
   const payload = await readQaSuiteSummaryFile(summaryPath);
   assertQaSuiteSummaryHasExecutedScenarios(
@@ -317,6 +321,7 @@ export async function readQaSuiteFailedOrSkippedScenarioCountFromFile(
     summaryPath,
     "summary_blocking_count_missing",
     options?.optionalScenarioNames,
+    options?.requireExecutedScenario,
   );
   const blockingScenarioCount = readQaSuiteFailedOrSkippedScenarioCountFromSummary(payload);
   if (blockingScenarioCount !== null) {

--- a/extensions/qa-lab/src/test-file-scenario-runner.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test.ts
@@ -258,7 +258,7 @@ describe("qa test file scenario runner", () => {
         "sends a chat turn through the GUI",
       ],
     ]);
-    expect(commands.map((command) => command.timeoutMs)).toEqual([undefined, undefined]);
+    expect(commands.map((command) => command.timeoutMs)).toEqual([1_800_000, 1_800_000]);
     const evidence = validateQaEvidenceSummaryJson(
       JSON.parse(await fs.readFile(result.evidencePath, "utf8")),
     );
@@ -366,7 +366,7 @@ describe("qa test file scenario runner", () => {
         )}`,
       ],
     ]);
-    expect(commands.map((command) => command.timeoutMs)).toEqual([undefined]);
+    expect(commands.map((command) => command.timeoutMs)).toEqual([1_800_000]);
     const evidence = validateQaEvidenceSummaryJson(
       JSON.parse(await fs.readFile(result.evidencePath, "utf8")),
     );
@@ -884,6 +884,78 @@ describe("qa test file scenario runner", () => {
 
     expect(commands.map((command) => command.timeoutMs)).toEqual([3 * 60 * 60_000]);
   });
+
+  it.each([
+    { executionKind: "vitest" as const, commandCount: 1 },
+    { executionKind: "playwright" as const, commandCount: 2 },
+  ])(
+    "applies the resolved command timeout to every $executionKind subprocess",
+    async ({ commandCount, executionKind }) => {
+      const repoRoot = await makeTempRepo(`qa-${executionKind}-command-timeout-`);
+      const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", `scenario-${executionKind}`);
+      const commands: QaScenarioCommandExecution[] = [];
+
+      await runQaTestFileScenarios({
+        repoRoot,
+        outputDir,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        scenarios: [
+          makeTestFileScenario(
+            executionKind,
+            executionKind === "playwright"
+              ? "ui/src/e2e/chat-flow.e2e.test.ts"
+              : "extensions/qa-lab/src/coverage-report.test.ts",
+          ),
+        ],
+        commandTimeoutMs: 321,
+        runCommand: async (command) => {
+          commands.push(command);
+          await writeNativeVitestReport(command, { passed: 1 });
+          return { exitCode: 0, stdout: "native pass\n", stderr: "" };
+        },
+      });
+
+      expect(commands).toHaveLength(commandCount);
+      expect(commands.map((command) => command.timeoutMs)).toEqual(
+        Array.from({ length: commandCount }, () => 321),
+      );
+    },
+  );
+
+  it.each(["vitest", "playwright"] as const)(
+    "terminates a hanging $executionKind subprocess with failure evidence",
+    async (executionKind) => {
+      const repoRoot = await makeTempRepo(`qa-${executionKind}-hung-command-`);
+      const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", `scenario-${executionKind}`);
+      const result = await runQaTestFileScenarios({
+        repoRoot,
+        outputDir,
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        scenarios: [
+          makeTestFileScenario(
+            executionKind,
+            executionKind === "playwright"
+              ? "ui/src/e2e/chat-flow.e2e.test.ts"
+              : "extensions/qa-lab/src/coverage-report.test.ts",
+          ),
+        ],
+        commandTimeoutMs: 100,
+        runCommand: (execution) =>
+          runQaScenarioCommandLifecycle({
+            ...execution,
+            args: ["-e", "setInterval(() => {}, 1_000)"],
+          }),
+      });
+
+      expect(result.results[0]).toMatchObject({
+        failureMessage: expect.stringContaining("timed out after 100ms"),
+        status: "fail",
+      });
+      expect(result.evidence.entries[0]?.result.status).toBe("fail");
+    },
+  );
 
   describe.skipIf(process.platform === "win32")("script timeout process groups", () => {
     const commandTimeoutMs = 1_500;

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -295,13 +295,13 @@ async function runScenarioCommandSteps(params: {
       const timeoutMs =
         params.scenario.execution.kind === "script"
           ? (params.scenario.execution.timeoutMs ?? params.commandTimeoutMs)
-          : undefined;
+          : params.commandTimeoutMs;
       const result = await params.runCommand({
         command: step.command,
         args: step.args,
         cwd: params.repoRoot,
         env: params.env,
-        ...(timeoutMs === undefined ? {} : { timeoutMs }),
+        timeoutMs,
       });
       if (result.stdout) {
         logChunks.push(result.stdout);


### PR DESCRIPTION
## Summary
- Reject missing, malformed, empty, skipped-only, and blocked-only QA summaries even when failure allowance is requested; cover generic and Telegram scenario families.
- Enforce the already configured execution timeout for native Vitest, Playwright, and Chromium scenario processes.

## Verification
- Focused owner and affected suites: **227 tests passed**; two documented unrelated baseline Crabline package tests excluded.
- Independent whole-surface re-review of the final amended SHA inspected every scenario family, summary classification, native process ownership, timeouts, callers, and sibling adapters; no blockers.
- Automated autoreview is unavailable because the mandatory TruffleHog binary is missing; independent manual diff and secret review completed.

## Root causes fixed
2 distinct QA Lab execution/verification defects.
