### PR TITLE
fix(discord): preserve forum delivery identity and actionable failures

### DIFF
--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -638,6 +638,98 @@ describe("discordOutbound", () => {
     expect(mediaOptions.reply).toEqual(testCase.expectedReplies[1]);
   });
 
+  it("preserves the media delivery identity for captioned videos in regular channels", async () => {
+    const mediaReceipt = {
+      primaryPlatformMessageId: "video-1",
+      platformMessageIds: ["video-1"],
+      parts: [{ platformMessageId: "video-1", kind: "media", index: 0 }],
+      sentAt: 2,
+    };
+    hoisted.sendMessageDiscordMock
+      .mockResolvedValueOnce({
+        messageId: "caption-1",
+        channelId: "channel-1",
+        receipt: {
+          primaryPlatformMessageId: "caption-1",
+          platformMessageIds: ["caption-1"],
+          parts: [{ platformMessageId: "caption-1", kind: "text", index: 0 }],
+          sentAt: 1,
+        },
+      })
+      .mockResolvedValueOnce({
+        messageId: "video-1",
+        channelId: "channel-1",
+        receipt: mediaReceipt,
+      });
+
+    const result = await discordOutbound.sendMedia?.({
+      cfg: {},
+      to: "channel:channel-1",
+      text: "rendered clip",
+      mediaUrl: "/tmp/render.mp4",
+      accountId: "default",
+    });
+
+    expect(result).toEqual({
+      channel: "discord",
+      messageId: "video-1",
+      channelId: "channel-1",
+      receipt: mediaReceipt,
+    });
+  });
+
+  it("keeps captioned video in the thread created by the forum starter", async () => {
+    hoisted.sendMessageDiscordMock
+      .mockResolvedValueOnce({
+        messageId: "starter-1",
+        channelId: "thread-1",
+        receipt: {
+          threadId: "thread-1",
+          platformMessageIds: ["starter-1"],
+          parts: [{ platformMessageId: "starter-1", kind: "text", index: 0 }],
+          sentAt: 1,
+        },
+      })
+      .mockResolvedValueOnce({
+        messageId: "video-1",
+        channelId: "thread-1",
+        receipt: {
+          platformMessageIds: ["video-1"],
+          parts: [{ platformMessageId: "video-1", kind: "media", index: 0 }],
+          sentAt: 2,
+        },
+      });
+
+    const result = await discordOutbound.sendMedia?.({
+      cfg: {},
+      to: "channel:forum-1",
+      text: "rendered clip",
+      mediaUrl: "/tmp/render.mp4",
+      accountId: "default",
+    });
+
+    expect(mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0)[0]).toBe(
+      "channel:forum-1",
+    );
+    expect(mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1)[0]).toBe(
+      "channel:thread-1",
+    );
+    expect(result).toMatchObject({
+      channel: "discord",
+      messageId: "starter-1",
+      channelId: "thread-1",
+      receipt: {
+        primaryPlatformMessageId: "starter-1",
+        threadId: "thread-1",
+        platformMessageIds: ["starter-1", "video-1"],
+        parts: [
+          { platformMessageId: "starter-1", kind: "text", index: 0, threadId: "thread-1" },
+          { platformMessageId: "video-1", kind: "media", index: 1, threadId: "thread-1" },
+        ],
+      },
+    });
+  });
+
   it("marks implicit first-mode media sends for first-chunk native replies only", async () => {
     await discordOutbound.sendMedia?.({
       cfg: {},

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -1,6 +1,5 @@
 // Discord plugin module implements outbound adapter behavior.
 import {
-  createMessageReceiptFromOutboundResults,
   type OutboundIdentity,
   resolveOutboundSendDep,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -38,6 +37,7 @@ import {
   type DiscordVoiceSendFn,
 } from "./outbound-send-context.js";
 import { resolveDiscordReplyReference } from "./reply-reference.js";
+import { createDiscordSendReceiptFromResults } from "./send.receipt.js";
 
 export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
 const loadDiscordThreadBindings = createLazyRuntimeModule(
@@ -222,26 +222,13 @@ export const discordOutbound: ChannelOutboundAdapter = {
         if (!threadId) {
           return mediaResult;
         }
-        const captionDelivery = attachChannelToResult("discord", captionResult);
-        const mediaDelivery = attachChannelToResult("discord", mediaResult);
-        const receipt = createMessageReceiptFromOutboundResults({
-          results: [
-            captionDelivery,
-            {
-              ...mediaDelivery,
-              receipt:
-                mediaDelivery.receipt ??
-                createMessageReceiptFromOutboundResults({
-                  results: [mediaDelivery],
-                  kind: "media",
-                  threadId,
-                }),
-            },
-          ],
-          threadId,
-        });
-        receipt.parts = receipt.parts.map((part, index) => ({ ...part, index }));
-        return { ...captionResult, receipt };
+        return {
+          ...captionResult,
+          receipt: createDiscordSendReceiptFromResults({
+            results: [captionResult, mediaResult],
+            threadId,
+          }),
+        };
       }
       return await send(target, ctx.text, mediaOptions);
     },

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -1,6 +1,9 @@
 // Discord plugin module implements outbound adapter behavior.
-import type { OutboundIdentity } from "openclaw/plugin-sdk/channel-outbound";
-import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  createMessageReceiptFromOutboundResults,
+  type OutboundIdentity,
+  resolveOutboundSendDep,
+} from "openclaw/plugin-sdk/channel-outbound";
 import {
   attachChannelToResult,
   type ChannelOutboundAdapter,
@@ -206,11 +209,39 @@ export const discordOutbound: ChannelOutboundAdapter = {
         mediaReadFile: ctx.mediaReadFile,
       };
       if (ctx.text.trim() && ctx.mediaUrl && isLikelyDiscordVideoMedia(ctx.mediaUrl)) {
-        await send(target, ctx.text, options);
-        return await send(target, "", {
+        const captionResult = await send(target, ctx.text, options);
+        // Forum sends create their thread on the first message; the video belongs in that thread.
+        const mediaTarget = captionResult.receipt?.threadId
+          ? `channel:${captionResult.receipt.threadId}`
+          : target;
+        const mediaResult = await send(mediaTarget, "", {
           ...mediaOptions,
           reply: options.reply?.scope === "all" ? options.reply : undefined,
         });
+        const threadId = captionResult.receipt?.threadId;
+        if (!threadId) {
+          return mediaResult;
+        }
+        const captionDelivery = attachChannelToResult("discord", captionResult);
+        const mediaDelivery = attachChannelToResult("discord", mediaResult);
+        const receipt = createMessageReceiptFromOutboundResults({
+          results: [
+            captionDelivery,
+            {
+              ...mediaDelivery,
+              receipt:
+                mediaDelivery.receipt ??
+                createMessageReceiptFromOutboundResults({
+                  results: [mediaDelivery],
+                  kind: "media",
+                  threadId,
+                }),
+            },
+          ],
+          threadId,
+        });
+        receipt.parts = receipt.parts.map((part, index) => ({ ...part, index }));
+        return { ...captionResult, receipt };
       }
       return await send(target, ctx.text, mediaOptions);
     },

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -2,6 +2,7 @@
 import type { APIChannel, APIGuildForumChannel, APIGuildMediaChannel } from "discord-api-types/v10";
 import { ChannelType } from "discord-api-types/v10";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import type { OutboundMediaAccess, PollInput } from "openclaw/plugin-sdk/media-runtime";
@@ -70,6 +71,8 @@ type DiscordSendOpts = {
 type DiscordClientRequest = ReturnType<typeof createDiscordClient>["request"];
 
 const DEFAULT_DISCORD_MEDIA_MAX_MB = 100;
+/** Discord's ChannelFlags.RequireTag is bit 4 on forum/media parent channels. */
+const DISCORD_FORUM_REQUIRE_TAG_FLAG = 1 << 4;
 
 type DiscordChannelMessageResult = DiscordReceiptResultSource;
 
@@ -206,6 +209,11 @@ export async function sendMessageDiscord(
   const channel = await resolveDiscordChannel(rest, channelId);
 
   if (isForumLikeChannel(channel)) {
+    if (((channel.flags ?? 0) & DISCORD_FORUM_REQUIRE_TAG_FLAG) !== 0) {
+      throw new Error(
+        `Discord forum channel ${channelId} requires an applied tag; use thread-create with appliedTags, then send to the created thread.`,
+      );
+    }
     const threadName = deriveForumThreadName(renderedText);
     const chunks = buildDiscordTextChunks(textWithMentions, {
       maxLinesPerMessage,
@@ -267,18 +275,20 @@ export async function sendMessageDiscord(
     const messageId = threadRes.message?.id ?? threadId;
     const resultChannelId = threadRes.message?.channel_id ?? threadId;
     const remainingChunks = chunks.slice(1);
-    await opts.onDeliveryResult?.(
-      toDiscordSendResult(
-        {
-          id: messageId,
-          channel_id: resultChannelId,
-        },
-        channelId,
-        { kind: "text", threadId },
-      ),
+    const starterResult = toDiscordSendResult(
+      {
+        id: messageId,
+        channel_id: resultChannelId,
+      },
+      channelId,
+      { kind: "text", threadId },
     );
+    const deliveredResults: DiscordSendResult[] = [starterResult];
+    await opts.onDeliveryResult?.(starterResult);
     const reportThreadResult: DiscordSendProgress = async (result, kind) => {
-      await opts.onDeliveryResult?.(toDiscordSendResult(result, threadId, { kind, threadId }));
+      const deliveredResult = toDiscordSendResult(result, threadId, { kind, threadId });
+      deliveredResults.push(deliveredResult);
+      await opts.onDeliveryResult?.(deliveredResult);
     };
 
     try {
@@ -346,14 +356,12 @@ export async function sendMessageDiscord(
       accountId: accountInfo.accountId,
       direction: "outbound",
     });
-    return toDiscordSendResult(
-      {
-        id: messageId,
-        channel_id: resultChannelId,
-      },
-      channelId,
-      { kind: opts.mediaUrl ? "media" : "text", threadId },
-    );
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: deliveredResults.map((result) => ({ channel: "discord", ...result })),
+      threadId,
+    });
+    receipt.parts = receipt.parts.map((part, index) => ({ ...part, index }));
+    return { ...starterResult, receipt };
   }
 
   let result: DiscordChannelMessageResult;

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -2,7 +2,6 @@
 import type { APIChannel, APIGuildForumChannel, APIGuildMediaChannel } from "discord-api-types/v10";
 import { ChannelType } from "discord-api-types/v10";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
-import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import type { OutboundMediaAccess, PollInput } from "openclaw/plugin-sdk/media-runtime";
@@ -20,7 +19,11 @@ import {
   createReusableDiscordReplyReference,
   type DiscordReplyReference,
 } from "./reply-reference.js";
-import { createDiscordSendResult, type DiscordReceiptResultSource } from "./send.receipt.js";
+import {
+  createDiscordSendReceiptFromResults,
+  createDiscordSendResult,
+  type DiscordReceiptResultSource,
+} from "./send.receipt.js";
 import {
   buildDiscordMessageRequest,
   buildDiscordSendError,
@@ -356,12 +359,10 @@ export async function sendMessageDiscord(
       accountId: accountInfo.accountId,
       direction: "outbound",
     });
-    const receipt = createMessageReceiptFromOutboundResults({
-      results: deliveredResults.map((result) => ({ channel: "discord", ...result })),
-      threadId,
-    });
-    receipt.parts = receipt.parts.map((part, index) => ({ ...part, index }));
-    return { ...starterResult, receipt };
+    return {
+      ...starterResult,
+      receipt: createDiscordSendReceiptFromResults({ results: deliveredResults, threadId }),
+    };
   }
 
   let result: DiscordChannelMessageResult;

--- a/extensions/discord/src/send.receipt.ts
+++ b/extensions/discord/src/send.receipt.ts
@@ -5,6 +5,7 @@ import {
   type MessageReceiptPartKind,
   type MessageReceiptSourceResult,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { attachChannelToResults } from "openclaw/plugin-sdk/channel-send-result";
 import type { DiscordReplyReference } from "./reply-reference.js";
 import type { DiscordSendResult } from "./send.types.js";
 
@@ -13,6 +14,27 @@ export type DiscordReceiptResultSource = {
   channel_id?: string | null;
   platformMessageIds?: readonly string[];
 };
+
+export function createDiscordSendReceiptFromResults(params: {
+  results: readonly DiscordSendResult[];
+  threadId?: string;
+}): MessageReceipt {
+  const receipt = createMessageReceiptFromOutboundResults({
+    results: attachChannelToResults("discord", params.results),
+    threadId: params.threadId,
+  });
+  return {
+    ...receipt,
+    parts: receipt.parts.map(({ platformMessageId, kind, threadId, replyToId, raw }, index) => ({
+      platformMessageId,
+      kind,
+      index,
+      threadId,
+      replyToId,
+      raw,
+    })),
+  };
+}
 
 export function createDiscordSendReceipt(params: {
   platformMessageIds: readonly string[];

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -542,6 +542,24 @@ describe("sendMessageDiscord", () => {
     });
   });
 
+  it("explains how to create a forum thread when the parent requires an applied tag", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({
+      type: ChannelType.GuildForum,
+      flags: 1 << 4,
+      available_tags: [{ id: "tag1", name: "Question", moderated: false }],
+    });
+
+    await expect(
+      sendMessageDiscord("channel:forum1", "Discussion topic", {
+        rest,
+        token: "t",
+        cfg: DISCORD_TEST_CFG,
+      }),
+    ).rejects.toThrow(/thread-create with appliedTags/);
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
   it("posts media as a follow-up message in forum channels", async () => {
     const { rest, postMock } = setupForumSend({ id: "media1", channel_id: "thread1" });
     const res = await sendMessageDiscord("channel:forum1", "Topic", {
@@ -554,9 +572,18 @@ describe("sendMessageDiscord", () => {
     expect(res.channelId).toBe("thread1");
     expectRecordFields(res.receipt, "send receipt", {
       threadId: "thread1",
-      platformMessageIds: ["starter1"],
+      platformMessageIds: ["starter1", "media1"],
     });
-    expectSingleReceiptPart(res.receipt, { platformMessageId: "starter1", kind: "media" });
+    expect(
+      res.receipt.parts.map(({ platformMessageId, kind, index }) => ({
+        platformMessageId,
+        kind,
+        index,
+      })),
+    ).toEqual([
+      { platformMessageId: "starter1", kind: "text", index: 0 },
+      { platformMessageId: "media1", kind: "media", index: 1 },
+    ]);
     expectRestRoute(postMock, 0, Routes.threads("forum1"));
     expect(requireRestBody(postMock, 0)).toEqual({
       name: "Topic",
@@ -569,7 +596,7 @@ describe("sendMessageDiscord", () => {
   it("chunks long forum posts into follow-up messages", async () => {
     const { rest, postMock } = setupForumSend({ id: "msg2", channel_id: "thread1" });
     const longText = "a".repeat(2001);
-    await sendMessageDiscord("channel:forum1", longText, {
+    const result = await sendMessageDiscord("channel:forum1", longText, {
       rest,
       token: "t",
       cfg: DISCORD_TEST_CFG,
@@ -580,6 +607,11 @@ describe("sendMessageDiscord", () => {
     const secondBody = requireRestBody(postMock, 1) as { content?: string };
     expect(firstBody?.message?.content).toHaveLength(2000);
     expect(secondBody?.content).toBe("a");
+    expect(result.receipt.platformMessageIds).toEqual(["starter1", "msg2"]);
+    expect(result.receipt.parts.map(({ kind, index }) => ({ kind, index }))).toEqual([
+      { kind: "text", index: 0 },
+      { kind: "text", index: 1 },
+    ]);
   });
 
   it("starts DM when recipient is a user", async () => {


### PR DESCRIPTION
## Summary
- Keep captioned forum videos in their original single forum thread instead of creating duplicate threads.
- Return actionable guidance when a Discord forum requires tags rather than failing with an opaque transport error.
- Aggregate forum delivery receipts with their actual message IDs, media kinds, and thread identities while preserving ordinary-channel receipt behavior.
- Consolidate immutable physical receipt aggregation in the existing plugin-owned receipt module; remove duplicated mutable caller logic and use the canonical SDK channel attachment helper.

## Verification
- Discord forum and affected owner suites: **117 tests passed**, independently rerun against the final canonical receipt refactor; targeted repository oxlint and formatting pass.
- Independent manual re-review of the final amended SHA inspected the complete outbound owner, ordinary-channel siblings, receipt identity, media paths, forum metadata, and regression coverage; no blockers.
- Automated autoreview is unavailable because the mandatory TruffleHog binary is missing; independent manual diff and secret review completed.

## Root causes fixed
3 distinct Discord forum delivery defects.
