### PR TITLE
fix(ui): restore mobile task navigation and accessible usage controls

### DIFF
--- a/ui/src/components/sessions-hub-header.browser.test.ts
+++ b/ui/src/components/sessions-hub-header.browser.test.ts
@@ -1,5 +1,5 @@
 import { html, render } from "lit";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../i18n/index.ts";
 import "../styles.css";
 import { renderSessionsHubHeader } from "./sessions-hub-header.ts";
@@ -11,7 +11,11 @@ async function useViewport(width: number, height = 800) {
   await page.viewport(width, height);
 }
 
-async function mount(active: "sessions" | "worktrees", withActions: boolean) {
+async function mount(
+  active: "sessions" | "worktrees",
+  withActions: boolean,
+  onSelect: (tab: "sessions" | "worktrees") => void = () => undefined,
+) {
   const container = document.createElement("div");
   container.style.width = "calc(100vw - 32px)";
   container.style.maxWidth = "1120px";
@@ -21,7 +25,7 @@ async function mount(active: "sessions" | "worktrees", withActions: boolean) {
       active,
       title: "Threads",
       actions: withActions ? html`<div style="width: 240px">Agent selector</div>` : undefined,
-      onSelect: () => undefined,
+      onSelect,
     }),
     container,
   );
@@ -79,10 +83,35 @@ describe.skipIf(!hasBrowserLayout)("Sessions hub header browser layout", () => {
     },
   );
 
-  it("keeps the page header hidden on mobile", async () => {
+  it("keeps session navigation and operational headers available on mobile", async () => {
     await useViewport(414, 800);
-    const sessions = await mount("sessions", true);
+    const onSelect = vi.fn();
+    const sessions = await mount("sessions", true, onSelect);
     const header = sessions.querySelector<HTMLElement>(".hub-page-header");
-    expect(getComputedStyle(header!).display).toBe("none");
+    const tabs = sessions.querySelector<HTMLElement>(".sessions-hub-tabs");
+    const actions = sessions.querySelector<HTMLElement>(".hub-page-header__actions");
+    expect(getComputedStyle(header!).display).toBe("grid");
+    expect(tabs?.getBoundingClientRect().width).toBeGreaterThan(0);
+    expect(actions?.getBoundingClientRect().width).toBeGreaterThan(0);
+
+    const worktreesTab = sessions.querySelector<HTMLElement>("#sessions-tab-worktrees");
+    expect(worktreesTab?.getBoundingClientRect().width).toBeGreaterThan(0);
+    worktreesTab?.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+    expect(onSelect).toHaveBeenCalledWith("worktrees");
+
+    const operationalHeader = document.createElement("section");
+    operationalHeader.className = "content-header";
+    operationalHeader.innerHTML = '<button type="button">Refresh</button>';
+    document.body.append(operationalHeader);
+    expect(getComputedStyle(operationalHeader).display).toBe("flex");
+    expect(
+      operationalHeader.querySelector("button")?.getBoundingClientRect().width,
+    ).toBeGreaterThan(0);
+
+    const chatContent = document.createElement("main");
+    chatContent.className = "content content--chat";
+    chatContent.innerHTML = '<section class="content-header"></section>';
+    document.body.append(chatContent);
+    expect(getComputedStyle(chatContent.querySelector(".content-header")!).display).toBe("none");
   });
 });

--- a/ui/src/pages/usage/metrics.test.ts
+++ b/ui/src/pages/usage/metrics.test.ts
@@ -358,6 +358,34 @@ describe("usage mosaic token buckets", () => {
     expect(container.querySelector(".usage-mosaic-total")?.textContent).toContain("10.0K");
   });
 
+  it("renders named, focusable hour toggles and preserves shift selection", () => {
+    const session = makeSessionWithTokenBuckets([
+      { date: "2026-02-01", quarterIndex: 40, totalTokens: 10_000 },
+    ]);
+    const onSelectHour = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(renderUsageMosaic([session], "utc", [10], onSelectHour), container);
+
+    const cells = container.querySelectorAll<HTMLButtonElement>(".usage-hour-cell");
+    const selectedHour = cells[10];
+    const unselectedHour = cells[11];
+    expect(selectedHour).toBeInstanceOf(HTMLButtonElement);
+    expect(selectedHour?.type).toBe("button");
+    expect(selectedHour?.getAttribute("aria-label")).toBe("10:00 · 10.0K tokens");
+    expect(selectedHour?.getAttribute("aria-pressed")).toBe("true");
+    expect(unselectedHour?.getAttribute("aria-pressed")).toBe("false");
+
+    selectedHour?.focus();
+    expect(document.activeElement).toBe(selectedHour);
+    selectedHour?.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+    expect(onSelectHour).toHaveBeenCalledWith(10, true);
+    unselectedHour?.click();
+    expect(onSelectHour).toHaveBeenCalledWith(11, false);
+
+    container.remove();
+  });
+
   it("renders precise UTC buckets in their local hour", () => {
     vi.spyOn(Date.prototype, "getHours").mockImplementation(function (this: Date) {
       return (this.getUTCHours() + 8) % 24;

--- a/ui/src/pages/usage/metrics.ts
+++ b/ui/src/pages/usage/metrics.ts
@@ -425,12 +425,15 @@ function renderUsageMosaic(
                     : "color-mix(in srgb, var(--accent) 24%, transparent)";
                 const selected = selectedHours.includes(hour);
                 return html`
-                  <div
+                  <button
+                    type="button"
                     class="usage-hour-cell ${selected ? "selected" : ""}"
                     style="background: ${bg}; border-color: ${border};"
                     title="${title}"
+                    aria-label=${title}
+                    aria-pressed=${selected ? "true" : "false"}
                     @click=${(e: MouseEvent) => onSelectHour(hour, e.shiftKey)}
-                  ></div>
+                  ></button>
                 `;
               })}
             </div>

--- a/ui/src/styles/hub-tabs.css
+++ b/ui/src/styles/hub-tabs.css
@@ -120,11 +120,7 @@ wa-tab.hub-tab:focus-visible::part(base) {
 }
 
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
-  .content-header.sessions-hub-header {
-    display: none;
-  }
-
-  .content-header.hub-page-header:not(.sessions-hub-header) {
+  .content-header.hub-page-header {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
@@ -136,20 +132,20 @@ wa-tab.hub-tab:focus-visible::part(base) {
     max-height: none;
   }
 
-  .hub-page-header:not(.sessions-hub-header) .hub-page-header__title {
+  .hub-page-header .hub-page-header__title {
     grid-area: intro;
     justify-self: stretch;
   }
 
-  .hub-page-header:not(.sessions-hub-header) .page-title {
+  .hub-page-header .page-title {
     display: none;
   }
 
-  .hub-page-header:not(.sessions-hub-header) .hub-page-header__tabs {
+  .hub-page-header .hub-page-header__tabs {
     grid-area: tabs;
   }
 
-  .hub-page-header:not(.sessions-hub-header) .hub-page-header__actions {
+  .hub-page-header .hub-page-header__actions {
     grid-area: actions;
     justify-self: center;
   }

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -338,11 +338,6 @@ html.openclaw-native-macos body .shell--mobile-nav .topnav-shell__actions {
     font-size: 12px;
   }
 
-  /* Content */
-  .content-header {
-    display: none;
-  }
-
   /* Hide the entire content-header on mobile chat — controls are in mobile gear menu */
   .content--chat .content-header {
     display: none;

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -1158,6 +1158,9 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .usage-hour-cell {
   min-height: 46px;
+  padding: 0;
+  cursor: pointer;
+  appearance: none;
   transition:
     transform 0.18s var(--ease-out),
     border-color 0.18s var(--ease-out),
@@ -1167,6 +1170,11 @@ details.usage-filter-select summary::-webkit-details-marker,
 .usage-hour-cell:hover {
   transform: translateY(-1px);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.usage-hour-cell:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  outline-offset: 2px;
 }
 
 .usage-hour-cell.selected {


### PR DESCRIPTION
## Summary
- Restore mobile operational page headers and their controls without changing the intentional chat-header exception.
- Restore mobile Sessions/Worktrees navigation so the complete task surface remains reachable.
- Render hourly usage filters as native, focusable buttons with keyboard activation and accurate accessible pressed-state semantics.

## Verification
- Focused owner suites: **23 tests passed**.
- Real Chromium mobile/tablet/desktop scenarios: **3 browser tests passed**, including 414px mobile navigation.
- Independent whole-surface manual review inspected mobile layouts, chat-specific rules, hub/tab ownership, pointer/keyboard activation, focus styling, and accessibility semantics; no blockers.
- Automated autoreview is unavailable because the mandatory TruffleHog binary is missing; independent manual diff and secret review completed.

## Root causes fixed
3 distinct mobile/accessibility defects.
