### PR TITLE
fix(ui): preserve chat command ownership and visible run outcomes

### DIFF
--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -853,6 +853,107 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatStreamSegments).toEqual([]);
   });
 
+  it.each([
+    {
+      name: "provider timeout",
+      event: {
+        state: "error",
+        errorKind: "timeout",
+        errorMessage: "agent provider timeout",
+      },
+      projectionStatus: "timeout",
+      sessionStatus: "timeout",
+      errorSummary: "Error: agent provider timeout",
+    },
+    {
+      name: "provider failure",
+      event: {
+        state: "error",
+        errorMessage: "agent provider failure",
+      },
+      projectionStatus: "error",
+      sessionStatus: "failed",
+      errorSummary: "Error: agent provider failure",
+    },
+    {
+      name: "operator cancellation",
+      event: { state: "aborted" },
+      projectionStatus: "aborted",
+      sessionStatus: "killed",
+      errorSummary: null,
+    },
+  ] as const)(
+    "projects the canonical $name status onto the selected session",
+    ({ event, projectionStatus, sessionStatus, errorSummary }) => {
+      vi.useFakeTimers();
+      try {
+        const state = createState({
+          sessionKey: "main",
+          chatRunId: "run-1",
+          chatStream: "Partial assistant reply",
+          chatStreamStartedAt: 100,
+        }) as ChatState & {
+          chatRunStatus?: { phase: string; runId: string | null; sessionKey: string } | null;
+          lastLocalTerminalReconcile?: { sessionStatus: string } | null;
+          sessionsResult?: {
+            ts: number;
+            path: string;
+            count: number;
+            defaults: Record<string, unknown>;
+            sessions: Array<Record<string, unknown>>;
+          };
+        };
+        state.sessionsResult = {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: {},
+          sessions: [
+            {
+              key: "main",
+              kind: "direct",
+              updatedAt: 1,
+              hasActiveRun: true,
+              activeRunIds: ["run-1"],
+              status: "running",
+              startedAt: 100,
+            },
+          ],
+        };
+
+        expect(
+          handleChatGatewayEvent(state, {
+            runId: "run-1",
+            sessionKey: "main",
+            ...event,
+          }),
+        ).toBe(event.state);
+
+        expect(
+          getChatSessionProjection(state, state.chatMessages, { sessionKey: "main" }).runs["run-1"]
+            ?.status,
+        ).toBe(projectionStatus);
+        expect(state.sessionsResult.sessions[0]).toMatchObject({
+          activeRunIds: [],
+          hasActiveRun: false,
+          status: sessionStatus,
+        });
+        expect(state.lastLocalTerminalReconcile?.sessionStatus).toBe(sessionStatus);
+        expect(state.chatRunStatus).toMatchObject({
+          phase: "interrupted",
+          runId: "run-1",
+          sessionKey: "main",
+        });
+        expect(state.chatRunError?.summary ?? null).toBe(errorSummary);
+        expect(state.chatRunId).toBeNull();
+        expect(state.chatStream).toBeNull();
+        expect(state.chatStreamStartedAt).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("reconciles cached run and indicator state on terminal events", () => {
     vi.useFakeTimers();
     try {
@@ -1950,7 +2051,7 @@ describe("handleChatGatewayEvent", () => {
     },
   );
 
-  it("does not let a completed run's late error interrupt a newer response", () => {
+  it("does not label a newer response with a completed run's late error", () => {
     const state = createState({ sessionKey: "main", chatRunId: "run-completed" });
 
     expect(
@@ -1982,7 +2083,7 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatStream).toBe("Newer response");
     expect(state.chatMessages).toHaveLength(1);
     expectTextChatMessage(state.chatMessages[0], "assistant", "Delivered once.");
-    expect(state.chatRunError).toEqual({ summary: "Error: late provider failure" });
+    expect(state.chatRunError).toBeNull();
   });
 
   it("upgrades an empty final to one authoritative assistant reply", () => {

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -273,11 +273,12 @@ function handleChatEvent(
     }
     if (payload.state === "error") {
       if (
+        (!state.chatRunId || state.chatRunId === payload.runId) &&
         payload.errorMessage?.trim() &&
         projectedRun.currentRun?.errorMessage !== previousTerminalRun.errorMessage
       ) {
-        // A completed transcript is immutable; retain provider guidance without
-        // adopting its old run or interrupting a newer in-flight response.
+        // Completed-run diagnostics belong to an idle composer or that same run;
+        // publishing them over a newer response falsely marks the new run failed.
         setChatRunError(state, resolveGatewayErrorText(payload, null));
       }
       return "error";
@@ -329,7 +330,7 @@ function handleChatEvent(
     });
   const reconcileTerminalRun = (
     outcome: "done" | "interrupted",
-    sessionStatus: "done" | "failed" | "killed",
+    sessionStatus: "done" | "failed" | "killed" | "timeout",
   ) =>
     reconcileChatRunLifecycle(state as unknown as Parameters<typeof reconcileChatRunLifecycle>[0], {
       outcome,
@@ -459,7 +460,12 @@ function handleChatEvent(
         state.chatMessages = materializeVisibleStream({ includeCurrent: true });
       }
     }
-    reconcileTerminalRun("interrupted", "failed");
+    // The shared Gateway projection owns timeout classification; preserve it
+    // when publishing selected-session and sidebar terminal status.
+    reconcileTerminalRun(
+      "interrupted",
+      projectedRun?.currentRun?.status === "timeout" ? "timeout" : "failed",
+    );
     setChatRunError(
       state,
       resolveGatewayErrorText(payload, projectedErrorMessage ? visiblePayloadMessage : null),

--- a/ui/src/pages/chat/chat-send-submit.test.ts
+++ b/ui/src/pages/chat/chat-send-submit.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import { createSessionCapability } from "../../lib/sessions/index.ts";
+import {
+  getChatAttachmentDataUrl,
+  registerChatAttachmentPayload,
+  releaseChatAttachmentPayloads,
+} from "./attachment-payload-store.ts";
+import type { ChatHost } from "./chat-send-contract.ts";
+import { handleSendChat } from "./chat-send-submit.ts";
+
+const attachmentsToRelease: ChatAttachment[] = [];
+const attachmentDataUrl = "data:application/pdf;base64,JVBERi0xLjQK";
+
+afterEach(() => {
+  releaseChatAttachmentPayloads(attachmentsToRelease);
+  attachmentsToRelease.length = 0;
+});
+
+function createStagedAttachment(id: string): ChatAttachment {
+  const file = new File(["%PDF-1.4\n"], "brief.pdf", { type: "application/pdf" });
+  const attachment = registerChatAttachmentPayload({
+    attachment: {
+      id,
+      mimeType: "application/pdf",
+      fileName: "brief.pdf",
+      sizeBytes: file.size,
+    },
+    dataUrl: attachmentDataUrl,
+    file,
+  });
+  attachmentsToRelease.push(attachment);
+  return attachment;
+}
+
+function createImmediateCommandHost(
+  command: string,
+  attachment: ChatAttachment,
+  overrides: Partial<ChatHost> = {},
+): ChatHost {
+  const host = {
+    sessions: createSessionCapability({
+      snapshot: { client: null, phase: "reconnecting", hello: null },
+      subscribe: () => () => undefined,
+      subscribeEvents: () => () => undefined,
+    }),
+    client: null,
+    connected: true,
+    sessionKey: "agent:main",
+    chatLoading: false,
+    chatMessage: command,
+    chatMessages: [],
+    chatLocalInputHistoryBySession: {},
+    chatInputHistorySessionKey: null,
+    chatInputHistoryItems: null,
+    chatInputHistoryIndex: -1,
+    chatDraftBeforeHistory: null,
+    chatAttachments: [attachment],
+    chatQueue: [],
+    chatRunId: null,
+    chatSending: false,
+    chatStream: null,
+    chatModelCatalog: [],
+    hello: null,
+    refreshSessionsAfterChat: new Map(),
+    ...overrides,
+  } satisfies Partial<ChatHost>;
+  return host as ChatHost;
+}
+
+describe("handleSendChat immediate local commands", () => {
+  it.each(["/export-session", "/export"])(
+    "preserves staged attachments while %s exports the chat",
+    async (command) => {
+      const attachment = createStagedAttachment("export-att");
+      const exportCurrentChat = vi.fn();
+      const host = createImmediateCommandHost(command, attachment, { exportCurrentChat });
+
+      await handleSendChat(host);
+
+      expect(exportCurrentChat).toHaveBeenCalledOnce();
+      expect(host.chatMessage).toBe("");
+      expect(host.chatAttachments).toEqual([attachment]);
+      expect(getChatAttachmentDataUrl(attachment)).toBe(attachmentDataUrl);
+      expect(host.chatQueue).toStrictEqual([]);
+    },
+  );
+
+  it("does not duplicate staged attachments into both old and new session composers", async () => {
+    const attachment = createStagedAttachment("new-session-att");
+    const attachmentsBySession = new Map<string, ChatAttachment[]>();
+    const host = createImmediateCommandHost("/new", attachment);
+    host.createChatSession = vi.fn(async () => {
+      const previousSessionKey = host.sessionKey;
+      const nextSessionKey = "agent:main:new";
+      // Session creation captures the next composer before route switching
+      // decides whether the old session's attachment needs a memory fallback.
+      const createdSessionAttachments = [...host.chatAttachments];
+      attachmentsBySession.set(previousSessionKey, [...host.chatAttachments]);
+      host.sessionKey = nextSessionKey;
+      host.chatAttachments = createdSessionAttachments;
+      attachmentsBySession.set(nextSessionKey, [...host.chatAttachments]);
+      return true;
+    });
+
+    await handleSendChat(host);
+
+    expect(host.createChatSession).toHaveBeenCalledOnce();
+    expect(attachmentsBySession.get("agent:main")).toStrictEqual([]);
+    expect(attachmentsBySession.get("agent:main:new")).toStrictEqual([]);
+    expect(host.chatAttachments).toStrictEqual([]);
+  });
+
+  it("restores staged attachments when creating a new session is cancelled", async () => {
+    const attachment = createStagedAttachment("cancelled-new-session-att");
+    const createChatSession = vi.fn(async () => false);
+    const host = createImmediateCommandHost("/new", attachment, { createChatSession });
+
+    await handleSendChat(host);
+
+    expect(createChatSession).toHaveBeenCalledOnce();
+    expect(host.chatMessage).toBe("/new");
+    expect(host.chatAttachments).toHaveLength(1);
+    expect(host.chatAttachments[0]).toMatchObject(attachment);
+    expect(getChatAttachmentDataUrl(host.chatAttachments[0]!)).toBe(attachmentDataUrl);
+  });
+});

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -380,7 +380,11 @@ export async function handleSendChat(
             ).previousDraft;
           } else {
             host.chatMessage = "";
-            host.chatAttachments = [];
+            // Export leaves the composer in its current session; /new must clear
+            // attachments before its handoff can capture them under both routes.
+            if (parsed.command.key !== "export-session") {
+              host.chatAttachments = [];
+            }
             resetChatInputHistoryNavigation(host);
           }
         }

--- a/ui/src/pages/chat/run-lifecycle.test.ts
+++ b/ui/src/pages/chat/run-lifecycle.test.ts
@@ -6,6 +6,7 @@ import type { SessionsListResult } from "../../api/types.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import {
   CHAT_RUN_STATUS_TOAST_DURATION_MS,
+  handleAbortChat,
   hasAbortableSessionRun,
   reconcileChatRunFromCurrentSessionRow,
   reconcileChatRunFromSessionRow,
@@ -61,6 +62,52 @@ function makeAbortHost(over: Partial<AbortHost> = {}): AbortHost {
     ...over,
   };
 }
+
+describe("handleAbortChat", () => {
+  it("shows reconnect guidance when an offline session run has no browser run identity", async () => {
+    const request = vi.fn();
+    const client = { request } as unknown as GatewayBrowserClient;
+    const host = makeAbortHost({
+      client,
+      connected: false,
+      chatMessage: "keep this draft",
+      sessionsResult: makeSessionsResult([
+        { key: "agent:main", hasActiveRun: true, status: "running" },
+      ]),
+    });
+
+    expect(hasAbortableSessionRun(host)).toBe(true);
+    await handleAbortChat(host, { preserveDraft: true });
+
+    expect(host.chatError).toBe("Not connected. Try again after reconnecting.");
+    expect(host.lastError).toBe(host.chatError);
+    expect(host.chatMessage).toBe("keep this draft");
+    expect(host.pendingAbort).toBeUndefined();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("keeps offline exact-run stops safely queued for reconnect", async () => {
+    const request = vi.fn();
+    const client = { request } as unknown as GatewayBrowserClient;
+    const host = makeAbortHost({
+      client,
+      connected: false,
+      chatRunId: "run-main",
+      chatMessage: "keep this draft",
+    });
+
+    await handleAbortChat(host, { preserveDraft: true });
+
+    expect(host.pendingAbort).toEqual({
+      sourceClient: client,
+      sessionKey: "agent:main",
+      runId: "run-main",
+    });
+    expect(host.chatMessage).toBe("keep this draft");
+    expect(host.chatError ?? null).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+});
 
 describe("replayPendingChatAbort", () => {
   it("dispatches a queued exact browser run stop through chat.abort", async () => {

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow, SessionRunStatus, SessionsListResult } from "../../api/types.ts";
+import { t } from "../../i18n/index.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import {
   reconcileSessionRunTerminal,
@@ -260,6 +261,9 @@ export async function handleAbortChat(host: ChatAbortHost, opts?: ChatAbortOptio
     : null;
   const pendingAbort = disconnectedIntent?.runId ? disconnectedIntent : null;
   if (!host.connected && !pendingAbort) {
+    // Session-only stops cannot be replayed safely against a later run.
+    // Explain the blocked action instead of leaving the visible Stop inert.
+    setChatError(host, t("chat.questions.disconnected"));
     return;
   }
   if (!opts?.preserveDraft) {


### PR DESCRIPTION
## Summary
- Keep attachments staged for session-export commands only; preserve `/new` ownership and restore staged content if session creation is canceled.
- Ignore stale completed-run errors when a newer run already owns the active composer, without hiding same-run diagnostics.
- Give disconnected runless Stop actions a visible, actionable outcome while preserving exact-run reconnect and cancellation behavior.

## Verification
- Chat send, gateway lifecycle, run lifecycle, and direct command owner suites: **434 tests passed**.
- Independent re-review of the final amended SHA inspected slash-command normalization, attachment transfer/restore, queued commands, active-run ownership, offline cancellation, and affected siblings; no blockers.
- Automated autoreview is unavailable because the mandatory TruffleHog binary is missing; independent manual diff and secret review completed.

## Root causes fixed
3 distinct chat command/run defects.
