### PR TITLE
fix(skills): allow autonomous sweep sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,8 @@ USER.md
 !.agents/skills/graincrawl/**
 !.agents/skills/notcrawl/
 !.agents/skills/notcrawl/**
+!.agents/skills/openclaw-autonomous-issue-sweep/
+!.agents/skills/openclaw-autonomous-issue-sweep/**
 !.agents/skills/openclaw-changelog-update/
 !.agents/skills/openclaw-changelog-update/**
 !.agents/skills/openclaw-ci-limits/


### PR DESCRIPTION
## What changed

- allow the tracked `openclaw-autonomous-issue-sweep` skill through the repository skill ignore boundary

## Why

Commit `6fbe39eed11` added the tracked skill but omitted its two `.gitignore` exceptions. The package-acceptance invariant therefore fails on current `main` and on unrelated pull-request merge refs.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts`
  - 1 file passed
  - 95 tests passed
- `git check-ignore --no-index .agents/skills/openclaw-autonomous-issue-sweep/SKILL.md` returns status 1 with no output
- `git diff --check`
