### PR TITLE
fix(plugins): stop ambient source startup for external plugins

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -212,6 +212,16 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
       activation: { onStartup: true },
     },
     {
+      id: "source-external-startup",
+      enabledByDefault: true,
+      activation: { onStartup: true },
+      channels: ["source-external-channel"],
+      providers: ["source-external-provider"],
+      packageManifest: {
+        build: { bundledDist: false },
+      },
+    },
+    {
       id: "demo-config-startup",
       enabledByDefault: true,
       activation: {
@@ -314,6 +324,7 @@ function createInstalledPluginRecordFixture(
     origin: record.origin,
     enabled: true,
     ...(record.enabledByDefault === true ? { enabledByDefault: true } : {}),
+    ...(record.packageManifest?.build ? { packageBuild: record.packageManifest.build } : {}),
     startup: {
       sidecar: record.activation?.onStartup === true,
       memory,
@@ -1426,6 +1437,72 @@ describe("resolveGatewayStartupPluginIds", () => {
         memorySlot: "none",
       }),
       expected: ["demo-global-explicit-startup"],
+    });
+  });
+
+  it("does not ambient-start source-discovered external plugins from onStartup alone", () => {
+    expectStartupPluginIds({
+      config: createStartupConfig({
+        noConfiguredChannels: true,
+        memorySlot: "none",
+      }),
+      expected: ["browser"],
+    });
+  });
+
+  it.each([
+    [
+      "plugins.entries",
+      createStartupConfig({
+        enabledPluginIds: ["source-external-startup"],
+        noConfiguredChannels: true,
+        memorySlot: "none",
+      }),
+      ["browser", "source-external-startup"],
+    ],
+    [
+      "plugins.allow",
+      createStartupConfig({
+        allowPluginIds: ["source-external-startup"],
+        noConfiguredChannels: true,
+        memorySlot: "none",
+      }),
+      ["source-external-startup"],
+    ],
+  ])(
+    "starts source-discovered external plugins explicitly selected through %s",
+    (_name, config, expected) => {
+      expectStartupPluginIds({
+        config,
+        expected,
+      });
+    },
+  );
+
+  it.each([
+    [
+      "configured channel",
+      {
+        channels: {
+          "source-external-channel": { enabled: true },
+        },
+        plugins: {
+          slots: { memory: "none" },
+        },
+      } as OpenClawConfig,
+    ],
+    [
+      "selected provider",
+      createStartupConfig({
+        modelId: "source-external-provider/demo-model",
+        noConfiguredChannels: true,
+        memorySlot: "none",
+      }),
+    ],
+  ])("preserves %s activation for source-discovered external plugins", (_name, config) => {
+    expectStartupPluginIds({
+      config,
+      expected: ["browser", "source-external-startup"],
     });
   });
 

--- a/src/plugins/gateway-startup-plugin-plan.ts
+++ b/src/plugins/gateway-startup-plugin-plan.ts
@@ -418,9 +418,14 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
       pluginIds.push(plugin.pluginId);
       continue;
     }
+    const isSourceExternalPlugin =
+      plugin.origin === "bundled" && plugin.packageBuild?.bundledDist === false;
+    // Source checkout discovery still uses the bundled root, but source-only
+    // packages are externally owned and must keep the external explicit-startup policy.
+    const startupPolicyOrigin = isSourceExternalPlugin ? "workspace" : plugin.origin;
     const activationState = resolveEffectivePluginActivationState({
       id: plugin.pluginId,
-      origin: plugin.origin,
+      origin: startupPolicyOrigin,
       config: pluginsConfig,
       rootConfig: params.config,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin, params.platform),
@@ -430,7 +435,7 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
       continue;
     }
     if (
-      plugin.origin !== "bundled"
+      startupPolicyOrigin !== "bundled"
         ? activationState.explicitlyEnabled
         : activationState.source === "explicit" || activationState.source === "default"
     ) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where source-checkout gateways implicitly started externalized plugins as core-bundled startup plugins, forcing live TypeScript transforms and adding roughly 1.3-1.5 seconds to startup.

## Why This Change Was Made

Source discovery still exposes externalized plugin packages, but `bundledDist: false` packages now follow the external explicit-startup policy. Explicit plugin entries, allowlists, configured channels, and selected providers still activate them. Core-bundled plugins keep their existing default startup behavior.

Packaged users were not affected because these plugin trees are excluded from the core package and separately installed packages use compiled runtimes.

## User Impact

Developers running OpenClaw from a source checkout no longer pay ambient startup cost for externalized plugins they did not configure.

## Evidence

- Startup planner: 171/171 tests passed after rebase
- Source-checkout runtime and stale-dist focused tests: passed
- Oxlint and oxfmt: passed
- Build compilation and UI: passed
- Autoreview: no actionable findings
- `git diff --check`: clean
- Before-fix latest-main runs show Teams loading at 1.3-1.5 seconds:
  https://github.com/openclaw/openclaw/actions/runs/30621382626
