### PR TITLE
fix(ui): coalesce profile identity refresh

### DIFF
--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -406,9 +406,7 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
       expect(await refresh.ariaSnapshot()).toContain('button "Refreshing…" [disabled]');
 
       await refresh.evaluate((element) => {
-        (element as HTMLButtonElement).dispatchEvent(
-          new MouseEvent("click", { bubbles: true }),
-        );
+        (element as HTMLButtonElement).dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });
       await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
 

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -365,4 +365,61 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
       await context.close();
     }
   });
+
+  it("keeps identity refresh single-flight and retries after a failed request", async () => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["users.self"],
+      presenceUsers: testPresenceUsers,
+      methodResponses: {
+        "users.self": { profile: testProfile },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/profile`);
+      expect(response?.status()).toBe(200);
+
+      const refresh = page.locator(".profile-refresh");
+      await gateway.waitForRequest("users.self");
+      await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(1);
+      await expect.poll(() => refresh.isDisabled()).toBe(true);
+      expect(await refresh.ariaSnapshot()).toContain('button "Refreshing…" [disabled]');
+
+      await refresh.evaluate((element) => {
+        const button = element as HTMLButtonElement;
+        button.click();
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(1);
+
+      await gateway.rejectDeferred("users.self", { message: "identity unavailable" });
+      await page.getByText("identity unavailable", { exact: true }).waitFor({ timeout: 10_000 });
+      await expect.poll(() => refresh.isEnabled()).toBe(true);
+      expect(await refresh.ariaSnapshot()).toContain('button "Refresh"');
+
+      await gateway.deferNext("users.self");
+      await refresh.click();
+      await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
+      await expect.poll(() => refresh.isDisabled()).toBe(true);
+      expect(await refresh.ariaSnapshot()).toContain('button "Refreshing…" [disabled]');
+
+      await refresh.evaluate((element) => {
+        (element as HTMLButtonElement).dispatchEvent(
+          new MouseEvent("click", { bubbles: true }),
+        );
+      });
+      await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
+
+      await gateway.resolveDeferred("users.self", { profile: testProfile });
+      const displayName = page.locator('.identity-name-control input[type="text"]');
+      await displayName.waitFor({ timeout: 10_000 });
+      await expect(displayName.inputValue()).resolves.toBe(testProfile.displayName);
+      await expect.poll(() => refresh.isEnabled()).toBe(true);
+      expect(await refresh.ariaSnapshot()).toContain('button "Refresh"');
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -317,6 +317,125 @@ it("retries the identity bootstrap when users.self returns no profile", async ()
   );
 });
 
+it("keeps identity refresh single-flight and allows retry after settlement", async () => {
+  const profile: UserProfile = {
+    id: "profile-1",
+    displayName: "Ada",
+    avatarMime: null,
+    mergedInto: null,
+    createdAt: 1,
+    updatedAt: 2,
+    emails: ["ada@example.test"],
+    hasAvatar: false,
+  };
+  let rejectIdentity: ((reason: Error) => void) | undefined;
+  const firstIdentity = new Promise<never>((_resolve, reject) => {
+    rejectIdentity = reject;
+  });
+  const request = vi.fn(async (method: string) => {
+    if (method !== "users.self") {
+      throw new Error(`unexpected method: ${method}`);
+    }
+    if (request.mock.calls.length === 1) {
+      return await firstIdentity;
+    }
+    return { profile };
+  });
+  const harness = createConnectedContext(request as GatewayBrowserClient["request"], {
+    id: profile.id,
+    email: profile.emails[0],
+    name: profile.displayName ?? undefined,
+  });
+  const provider = createApplicationContextProvider(harness.context);
+  const page = document.createElement(PROFILE_PAGE_TEST_TAG) as ProfilePageElement;
+  provider.append(page);
+  document.body.append(provider);
+
+  await waitForFast(() =>
+    expect(request.mock.calls.filter(([method]) => method === "users.self")).toHaveLength(1),
+  );
+  await page.updateComplete;
+  const refresh = page.querySelector<HTMLButtonElement>(".profile-refresh")!;
+  expect(refresh.disabled).toBe(true);
+  expect(refresh.textContent?.trim()).toBe(t("common.refreshing"));
+
+  const pageWithIdentity = page as unknown as { loadIdentity: () => Promise<void> };
+  await Promise.all([pageWithIdentity.loadIdentity(), pageWithIdentity.loadIdentity()]);
+  expect(request.mock.calls.filter(([method]) => method === "users.self")).toHaveLength(1);
+
+  rejectIdentity?.(new Error("identity unavailable"));
+  await waitForFast(() => expect(refresh.disabled).toBe(false));
+  expect(refresh.textContent?.trim()).toBe(t("common.refresh"));
+  expect(page.textContent).toContain("identity unavailable");
+
+  refresh.click();
+  await waitForFast(() =>
+    expect(request.mock.calls.filter(([method]) => method === "users.self")).toHaveLength(2),
+  );
+  await waitForFast(() =>
+    expect(page.querySelector<HTMLInputElement>(".identity-name-control input")?.value).toBe("Ada"),
+  );
+});
+
+it("replaces an in-flight identity request after a same-client reconnect", async () => {
+  const staleProfile: UserProfile = {
+    id: "profile-1",
+    displayName: "Stale identity",
+    avatarMime: null,
+    mergedInto: null,
+    createdAt: 1,
+    updatedAt: 2,
+    emails: ["ada@example.test"],
+    hasAvatar: false,
+  };
+  const freshProfile = { ...staleProfile, displayName: "Fresh identity", updatedAt: 3 };
+  let resolveStale: ((value: { profile: UserProfile }) => void) | undefined;
+  let resolveFresh: ((value: { profile: UserProfile }) => void) | undefined;
+  const staleRequest = new Promise<{ profile: UserProfile }>((resolve) => {
+    resolveStale = resolve;
+  });
+  const freshRequest = new Promise<{ profile: UserProfile }>((resolve) => {
+    resolveFresh = resolve;
+  });
+  const request = vi.fn(async (method: string) => {
+    if (method !== "users.self") {
+      throw new Error(`unexpected method: ${method}`);
+    }
+    return await (request.mock.calls.length === 1 ? staleRequest : freshRequest);
+  });
+  const harness = createConnectedContext(request as GatewayBrowserClient["request"], {
+    id: staleProfile.id,
+    email: staleProfile.emails[0],
+    name: staleProfile.displayName ?? undefined,
+  });
+  const provider = createApplicationContextProvider(harness.context);
+  const page = document.createElement(PROFILE_PAGE_TEST_TAG) as ProfilePageElement;
+  provider.append(page);
+  document.body.append(provider);
+
+  await waitForFast(() => expect(request).toHaveBeenCalledTimes(1));
+  harness.emitConnected(false);
+  await page.updateComplete;
+  harness.emitConnected(true);
+  await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+
+  resolveFresh?.({ profile: freshProfile });
+  await waitForFast(() =>
+    expect(page.querySelector<HTMLInputElement>(".identity-name-control input")?.value).toBe(
+      "Fresh identity",
+    ),
+  );
+  resolveStale?.({ profile: staleProfile });
+  await staleRequest;
+  await Promise.resolve();
+  await page.updateComplete;
+
+  expect(page.querySelector<HTMLInputElement>(".identity-name-control input")?.value).toBe(
+    "Fresh identity",
+  );
+  expect(request).toHaveBeenCalledTimes(2);
+});
+
 it("bootstraps and refreshes the connected user's profile through users.self", async () => {
   let profile: UserProfile = {
     id: "profile-1",

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -85,19 +85,21 @@ export class ProfilePage extends OpenClawLightDomElement {
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot) {
     const clientChanged = snapshot.client !== this.client;
-    const nextSelfUser =
-      snapshot.phase === "connected"
-        ? resolveCurrentSelfUser({ snapshotUser: snapshot.selfUser })
-        : null;
+    const nextConnected = snapshot.phase === "connected";
+    const connectionChanged = nextConnected !== this.connected;
+    const nextSelfUser = nextConnected
+      ? resolveCurrentSelfUser({ snapshotUser: snapshot.selfUser })
+      : null;
     const selfProfileChanged = nextSelfUser?.id !== this.selfUser?.id;
+    const identitySourceChanged = clientChanged || connectionChanged || selfProfileChanged;
     this.client = snapshot.client;
-    this.connected = snapshot.phase === "connected";
+    this.connected = nextConnected;
     this.selfUser = nextSelfUser;
     // connected/client are plain fields; an unidentified (token-auth) connect or
     // disconnect changes no @state, so the render branch must be invalidated
     // explicitly or the page sticks on the stale offline/connected view.
     this.requestUpdate();
-    if (clientChanged || selfProfileChanged) {
+    if (identitySourceChanged) {
       this.identityRequestId += 1;
       this.ownProfile = null;
       this.displayName = "";
@@ -105,10 +107,10 @@ export class ProfilePage extends OpenClawLightDomElement {
       this.identityBusy = null;
       this.identityError = null;
     }
-    if (snapshot.phase !== "connected" || !snapshot.client) {
+    if (!nextConnected || !snapshot.client) {
       return;
     }
-    if (nextSelfUser && (clientChanged || selfProfileChanged)) {
+    if (nextSelfUser && identitySourceChanged) {
       void this.loadIdentity();
     }
     void this.context.agents.ensureList().then((list) => {
@@ -120,7 +122,9 @@ export class ProfilePage extends OpenClawLightDomElement {
 
   private async loadIdentity() {
     const client = this.client;
-    if (!client || !this.connected) {
+    // One active request owns the generation; reconnects clear loading before
+    // starting their replacement so stale responses cannot win out of order.
+    if (!client || !this.connected || this.identityLoading) {
       return;
     }
     const requestId = ++this.identityRequestId;
@@ -300,7 +304,7 @@ export class ProfilePage extends OpenClawLightDomElement {
   }
 
   private refreshManually() {
-    if (this.selfUser && !this.identityBusy) {
+    if (this.selfUser && !this.identityBusy && !this.identityLoading) {
       void this.loadIdentity();
     }
   }
@@ -380,7 +384,11 @@ export class ProfilePage extends OpenClawLightDomElement {
           </div>
         </div>
         ${this.selfUser
-          ? html`<button class="btn profile-refresh" @click=${() => this.refreshManually()}>
+          ? html`<button
+              class="btn profile-refresh"
+              ?disabled=${this.identityLoading || this.identityBusy !== null}
+              @click=${() => this.refreshManually()}
+            >
               ${this.identityLoading ? t("common.refreshing") : t("common.refresh")}
             </button>`
           : nothing}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repeated Profile Refresh activation could fan out concurrent `users.self` requests, and a same-client reconnect could leave stale identity request ownership behind.

## Why This Change Was Made

Profile identity loading now has one explicit owner per connected Gateway generation. Pending loads coalesce, reconnect transitions invalidate the old generation and start one replacement, and manual Refresh is disabled while identity loading or mutation work is active.

## User Impact

Profile Refresh now gives immediate visible pending state, cannot accidentally create duplicate requests, recovers visibly after failure, and keeps the fresh profile authoritative across reconnects.

## Evidence

- Focused Testbox proof passed 9/9 Profile tests, including same-client reconnect where the fresh response renders before a stale response resolves and remains authoritative.
- Full changed gate passed on Testbox `tbx_01kyvskps3d1hrv8fpwhqrjyyd` after repo formatting, including UI/core typechecks, lint, i18n, dead-code scans, and guards.
- Mocked-Gateway Chromium E2E passed 4/4 on Testbox `tbx_01kyvtcwndte0hsksstd2txx1c`, run `30622560964`: one bootstrap RPC, disabled accessible `Refreshing…`, duplicate normal/synthetic activation suppression, visible failure recovery, one retry, rendered profile, and restored `Refresh`.
- Dedicated reconnect proof passed 1/1 on Testbox `tbx_01kyvtm7ad27nrv83e1sg7gpa3`, run `30622803120`.
- Real trusted-proxy Gateway + Chromium proof passed 1/1 at exact head `1fd58e2e7841767c61243c3aabdf77258db301e0` on Testbox `tbx_01kyvyq9vpd0m75d6vf3kkn5c3`, run `30626950938`. Observable result: `initialRequests=1`, twelve same-tick Refresh activations produced `refreshRequests=1`, a real Gateway restart produced `reconnectRequests=1`, `totalRequests=3`, the linked synthetic identity remained visible, and Refresh re-enabled.
- After rebasing the patch onto current `main`, exact head `fc9147b22b9f0fc5bcdfa1ed1fa6ad833cb16b4e` passed 9/9 focused tests, 4/4 mocked-Gateway Chromium cases, and the complete changed gate on Testbox `tbx_01kyvz8ncycm1kwt043axsq6k0`, run `30627506335`.
- Source-blind behavior validation passed all 14 in-scope contract clauses with confidence 0.99; no blockers.
- Final rebased-head autoreview: clean, no accepted/actionable findings, confidence 0.87.

Visual proof note: this change intentionally does not alter layout or styling. Browser accessibility snapshots, visible state assertions, and Gateway request counts are more diagnostic than static before/after images for the transient single-flight behavior.

No protocol, configuration, persistence, authentication, or identity data-shape changes.
