### PR TITLE
fix(auth-profiles): scope model_not_found cooldown to the failing model

### DIFF
--- a/src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts
+++ b/src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts
@@ -120,6 +120,26 @@ describe("getSoonestCooldownExpiry", () => {
     ).toBe(now + 10_000);
   });
 
+  it("uses the earliest matching model_not_found cooldown for the requested model", () => {
+    const now = 1_700_000_000_000;
+    const store = makeStore({
+      "openai:p1": {
+        cooldownUntil: now + 10_000,
+        cooldownReason: "model_not_found",
+        cooldownModel: "gpt-5.4",
+      },
+      "openai:p2": {
+        cooldownUntil: now + 30_000,
+        cooldownReason: "model_not_found",
+        cooldownModel: "gpt-5.4",
+      },
+    });
+
+    expect(
+      getSoonestCooldownExpiry(store, ["openai:p1", "openai:p2"], { now, forModel: "gpt-5.4" }),
+    ).toBe(now + 10_000);
+  });
+
   it("still counts profile-wide disables for other models", () => {
     const now = 1_700_000_000_000;
     const store = makeStore({

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -13,12 +13,14 @@ export function isAuthCooldownBypassedForProvider(provider: string | undefined):
   return normalized === "openrouter" || normalized === "kilocode";
 }
 
-// Per-attempt transient failures (#87462): block only the failing model so
-// fallback models on the same auth profile can still try. Other reasons (auth,
-// billing, format, server_error) remain profile-wide.
+// Per-attempt transient failures (#87462, #116464): block only the failing
+// model so fallback models on the same auth profile can still try. A model that
+// the provider does not serve (model_not_found) says nothing about sibling
+// models, so it stays model-scoped too. Other reasons (auth, billing, format,
+// server_error) remain profile-wide.
 /** Returns true when a failure should only cool down the failing model. */
 export function isModelScopedCooldownReason(reason: AuthProfileFailureReason | undefined): boolean {
-  return reason === "rate_limit" || reason === "timeout";
+  return reason === "rate_limit" || reason === "timeout" || reason === "model_not_found";
 }
 
 /** Resolves the latest active blocked/cooldown/disabled timestamp for a profile. */
@@ -150,7 +152,7 @@ export function getSoonestCooldownExpiry(
     }
     const matchingModelScopedCooldown =
       options?.forModel &&
-      stats.cooldownReason === "rate_limit" &&
+      isModelScopedCooldownReason(stats.cooldownReason) &&
       stats.cooldownModel === options.forModel &&
       !isBlockedWindowActiveForModel(stats, ts, options.forModel) &&
       !isActiveUnusableWindow(stats.disabledUntil, ts);

--- a/src/agents/auth-profiles/usage-state.ts
+++ b/src/agents/auth-profiles/usage-state.ts
@@ -152,7 +152,7 @@ export function getSoonestCooldownExpiry(
     }
     const matchingModelScopedCooldown =
       options?.forModel &&
-      isModelScopedCooldownReason(stats.cooldownReason) &&
+      stats.cooldownReason === "rate_limit" &&
       stats.cooldownModel === options.forModel &&
       !isBlockedWindowActiveForModel(stats, ts, options.forModel) &&
       !isActiveUnusableWindow(stats.disabledUntil, ts);

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -11,6 +11,7 @@ import { resolveProfileUnusableUntil } from "./usage-state.js";
 import {
   clearAuthProfileCooldown,
   clearExpiredCooldowns,
+  getSoonestCooldownExpiry,
   isProfileInCooldown,
   markAuthProfileBlockedUntil,
   markAuthProfileFailure,
@@ -298,6 +299,24 @@ describe("isProfileInCooldown", () => {
     );
   });
 
+  it("returns false for a different model when cooldown is model-scoped (model_not_found) — #116464", () => {
+    const store = makeStore({
+      "github-copilot:github": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "model_not_found",
+        cooldownModel: "claude-sonnet-4.6",
+      },
+    });
+    // A healthy sibling model on the same auth profile bypasses the cooldown
+    expect(isProfileInCooldown(store, "github-copilot:github", undefined, "gpt-4.1")).toBe(false);
+    // The failed model itself stays blocked
+    expect(
+      isProfileInCooldown(store, "github-copilot:github", undefined, "claude-sonnet-4.6"),
+    ).toBe(true);
+    // No model specified — blocked (conservative)
+    expect(isProfileInCooldown(store, "github-copilot:github")).toBe(true);
+  });
+
   it("does not bypass model-scoped cooldown when disabledUntil is active", () => {
     const store = makeStore({
       "github-copilot:github": {
@@ -340,6 +359,47 @@ describe("isProfileInCooldown", () => {
     });
 
     expect(isProfileInCooldown(store, "google:default", now, "gemini-3.1-flash-lite")).toBe(true);
+  });
+});
+
+describe("getSoonestCooldownExpiry", () => {
+  it("treats a model_not_found cooldown for the requested model as model-scoped — #116464", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "github-copilot:github": {
+        cooldownUntil: now + 60_000,
+        cooldownReason: "model_not_found",
+        cooldownModel: "claude-sonnet-4.6",
+      },
+    });
+    // Same model: expiry is tracked as the matching model-scoped cooldown
+    const sameModel = getSoonestCooldownExpiry(store, ["github-copilot:github"], {
+      now,
+      forModel: "claude-sonnet-4.6",
+    });
+    expect(sameModel).toBe(now + 60_000);
+    // Different model bypasses the cooldown entirely
+    const sibling = getSoonestCooldownExpiry(store, ["github-copilot:github"], {
+      now,
+      forModel: "gpt-4.1",
+    });
+    expect(sibling).toBeNull();
+  });
+
+  it("keeps profile-wide cooldowns visible to all models", () => {
+    const now = Date.now();
+    const store = makeStore({
+      "github-copilot:github": {
+        cooldownUntil: now + 60_000,
+        cooldownReason: "model_not_found",
+        cooldownModel: undefined,
+      },
+    });
+    const soonest = getSoonestCooldownExpiry(store, ["github-copilot:github"], {
+      now,
+      forModel: "gpt-4.1",
+    });
+    expect(soonest).toBe(now + 60_000);
   });
 });
 
@@ -1629,6 +1689,114 @@ describe("markAuthProfileFailure — per-model cooldown metadata", () => {
     const stats = store.usageStats?.["github-copilot:github"];
     expect(stats?.cooldownReason).toBe("rate_limit");
     expect(stats?.cooldownModel).toBe("claude-sonnet-4.6");
+  });
+
+  it("records cooldownModel on first model_not_found failure — #116464", async () => {
+    const now = 1_000_000;
+    const store = makeStoreWithCopilot({});
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mockLockedUpdateForStore(store);
+    try {
+      await markAuthProfileFailure({
+        store,
+        profileId: "github-copilot:github",
+        reason: "model_not_found",
+        modelId: "claude-sonnet-4.6",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    const stats = store.usageStats?.["github-copilot:github"];
+    expect(stats?.cooldownReason).toBe("model_not_found");
+    expect(stats?.cooldownModel).toBe("claude-sonnet-4.6");
+  });
+
+  it("widens cooldownModel to undefined when a different model fails during active model_not_found cooldown", async () => {
+    const now = 1_000_000;
+    const store = makeStoreWithCopilot({
+      "github-copilot:github": {
+        cooldownUntil: now + 30_000,
+        cooldownReason: "model_not_found",
+        cooldownModel: "claude-sonnet-4.6",
+        errorCount: 1,
+        lastFailureAt: now - 1000,
+      },
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mockLockedUpdateForStore(store);
+    try {
+      await markAuthProfileFailure({
+        store,
+        profileId: "github-copilot:github",
+        reason: "model_not_found",
+        modelId: "gpt-4.1",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    const stats = store.usageStats?.["github-copilot:github"];
+    // Scope widened to all models so the sibling failure cannot bypass stale metadata
+    expect(stats?.cooldownModel).toBeUndefined();
+    expect(stats?.cooldownReason).toBe("model_not_found");
+  });
+
+  it("preserves cooldownModel when the same model fails again during active model_not_found cooldown", async () => {
+    const now = 1_000_000;
+    const store = makeStoreWithCopilot({
+      "github-copilot:github": {
+        cooldownUntil: now + 30_000,
+        cooldownReason: "model_not_found",
+        cooldownModel: "claude-sonnet-4.6",
+        errorCount: 1,
+        lastFailureAt: now - 1000,
+      },
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mockLockedUpdateForStore(store);
+    try {
+      await markAuthProfileFailure({
+        store,
+        profileId: "github-copilot:github",
+        reason: "model_not_found",
+        modelId: "claude-sonnet-4.6",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    const stats = store.usageStats?.["github-copilot:github"];
+    expect(stats?.cooldownModel).toBe("claude-sonnet-4.6");
+  });
+
+  it("widens cooldownModel when model_not_found failure during active cooldown has no modelId", async () => {
+    const now = 1_000_000;
+    const store = makeStoreWithCopilot({
+      "github-copilot:github": {
+        cooldownUntil: now + 30_000,
+        cooldownReason: "model_not_found",
+        cooldownModel: "claude-sonnet-4.6",
+        errorCount: 1,
+        lastFailureAt: now - 1000,
+      },
+    });
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mockLockedUpdateForStore(store);
+    try {
+      await markAuthProfileFailure({
+        store,
+        profileId: "github-copilot:github",
+        reason: "model_not_found",
+        modelId: undefined,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    const stats = store.usageStats?.["github-copilot:github"];
+    expect(stats?.cooldownReason).toBe("model_not_found");
+    expect(stats?.cooldownModel).toBeUndefined();
   });
 
   it("widens cooldownModel to undefined when a different model fails during active cooldown", async () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -317,6 +317,22 @@ describe("isProfileInCooldown", () => {
     expect(isProfileInCooldown(store, "github-copilot:github")).toBe(true);
   });
 
+  it("blocks all models when a model_not_found cooldown has no cooldownModel (profile-wide) — #116464", () => {
+    const store = makeStore({
+      "github-copilot:github": {
+        cooldownUntil: Date.now() + 60_000,
+        cooldownReason: "model_not_found",
+        cooldownModel: undefined,
+      },
+    });
+    // Without a scoped model, the cooldown stays profile-wide so neither a
+    // sibling model nor the originally failing model can bypass it.
+    expect(isProfileInCooldown(store, "github-copilot:github", undefined, "gpt-4.1")).toBe(true);
+    expect(
+      isProfileInCooldown(store, "github-copilot:github", undefined, "claude-sonnet-4.6"),
+    ).toBe(true);
+  });
+
   it("does not bypass model-scoped cooldown when disabledUntil is active", () => {
     const store = makeStore({
       "github-copilot:github": {
@@ -1797,6 +1813,30 @@ describe("markAuthProfileFailure — per-model cooldown metadata", () => {
     const stats = store.usageStats?.["github-copilot:github"];
     expect(stats?.cooldownReason).toBe("model_not_found");
     expect(stats?.cooldownModel).toBeUndefined();
+  });
+
+  it("keeps a healthy sibling model available after a model_not_found failure on the same profile — #116464", async () => {
+    const now = 1_000_000;
+    const store = makeStoreWithCopilot({});
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    mockLockedUpdateForStore(store);
+    try {
+      await markAuthProfileFailure({
+        store,
+        profileId: "github-copilot:github",
+        reason: "model_not_found",
+        modelId: "claude-sonnet-4.6",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    // The failed model stays blocked, but a sibling fallback on the same auth
+    // profile remains available — the exact fallback scenario from #116464.
+    expect(isProfileInCooldown(store, "github-copilot:github", now, "claude-sonnet-4.6")).toBe(
+      true,
+    );
+    expect(isProfileInCooldown(store, "github-copilot:github", now, "gpt-4.1")).toBe(false);
   });
 
   it("widens cooldownModel to undefined when a different model fails during active cooldown", async () => {


### PR DESCRIPTION
## What Problem This Solves

A `model_not_found` failure on one model puts the entire auth profile into cooldown for up to 5 minutes, blocking healthy sibling fallback models on the same profile even though model existence is per-model.

- **Problem**: `isModelScopedCooldownReason()` only treats `rate_limit`/`timeout` as model-scoped. A primary model 404 (`model_not_found`) records a profile-wide cooldown, so the fallback gate `isProfileInCooldown(store, id, now, forModel=candidate)` rejects the healthy fallback model with a synthetic "Auth profile temporarily unavailable" error.
- **Solution**: Treat `model_not_found` as model-scoped in the shared classifier, matching the existing per-model design for `rate_limit` (#49834) and `timeout` (#87462/#87538). The `getSoonestCooldownExpiry` matching-bucket condition intentionally stays scoped to `rate_limit`: routing `timeout`/`model_not_found` into the `latestMatchingModelCooldown` (max) bucket regresses the "earliest matching timeout cooldown" contract (`auth-profiles.getsoonestcooldownexpiry.test.ts:103-121`). `model_not_found` is still handled correctly there — siblings bypass via `shouldBypassModelScopedCooldown` (which uses the classifier) and the same model reports through the `soonest` (min) bucket.
- **What changed**: `src/agents/auth-profiles/usage-state.ts` (`isModelScopedCooldownReason` now includes `model_not_found`; `getSoonestCooldownExpiry` left unchanged — see Solution), `src/agents/auth-profiles/usage.test.ts` (9 tests covering `isProfileInCooldown`, `getSoonestCooldownExpiry`, and `markAuthProfileFailure` model-scoped metadata, including the `cooldownModel: undefined` profile-wide case and an end-to-end sibling-availability assertion after a real `markAuthProfileFailure`), and `src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts` (multi-profile regression pinning `model_not_found` to earliest matching expiry semantics)
- **What did NOT change**: Profile-wide reasons (`auth`, `billing`, `format`, `server_error`, …) stay profile-wide; blocked/disabled windows still override model scoping; fallback selection and failure classification are untouched

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #116464
- Related #116561 (earlier fork PR with the same intent, duplicated conditions instead of the shared classifier, no tests/proof)
- Related #116762 (concurrent PR with the same classifier fix; this PR additionally provides real Gateway runtime proof and regression tests)
- [x] This PR fixes a bug or regression

## Motivation

Fixes #116464. The issue's own logs show the identical profile hash on both the primary's real `model_not_found` and the fallback's synthetic one — the cooldown gate does not distinguish models for this reason. `model_not_found` is inherently per-model: the provider not serving model A says nothing about model B's availability. The fix is one condition in the shared `isModelScopedCooldownReason()` classifier, so both the failure-recording path and the fallback-bypass path agree.

## Evidence

- **Behavior addressed**: A `model_not_found` failure on `mock/mock-primary-v1` must not block the healthy fallback `mock/mock-fallback-v1` on the same auth profile
- **Real environment tested**: Linux x86_64, Node.js (real OpenClaw 2026.7.2 build), branch `fix/model-not-found-model-scoped-cooldown-116464`; real Gateway + CLI run against a local mock OpenAI-compatible provider (primary → HTTP 404, fallback → HTTP 200) with an auth profile (`mock:manual`) and isolated `OPENCLAW_HOME`/`OPENCLAW_STATE_DIR`
- **Exact steps or command run after this patch**:

```bash
node openclaw.mjs gateway --port 19002 --force   # real Gateway, auth profile mock:manual
openclaw agent --agent main --message "ping" --verbose on --json   # primary mock/mock-primary-v1 -> 404, fallback mock/mock-fallback-v1
```

- **Evidence after fix** (Gateway log + client result):

```console
[model-fetch] response provider=mock model=mock-primary-v1 status=404
auth profile failure state updated: profile=sha256:dbc11556aae9 provider=mock reason=model_not_found window=cooldown reused=false
model fallback decision: decision=candidate_failed requested=mock/mock-primary-v1 candidate=mock/mock-primary-v1 reason=model_not_found next=mock/mock-fallback-v1 detail=404 The model 'mock-primary-v1' does not exist or you do not have access to it.
[model-fetch] start provider=mock model=mock-fallback-v1 ...
[model-fetch] response provider=mock model=mock-fallback-v1 status=200
model fallback decision: decision=candidate_succeeded requested=mock/mock-primary-v1 candidate=mock/mock-fallback-v1 reason=unknown next=none
hello from mock-fallback-v1
finalAssistantVisibleText: "hello from mock-fallback-v1", "result": "success"
```

- **Evidence before fix** (same setup, main branch):

```console
[model-fetch] response provider=mock model=mock-primary-v1 status=404
auth profile failure state updated: profile=sha256:dbc11556aae9 provider=mock reason=model_not_found window=cooldown reused=false
model fallback decision: decision=candidate_failed requested=mock/mock-primary-v1 candidate=mock/mock-primary-v1 reason=model_not_found next=mock/mock-fallback-v1
Error: Auth profile "mock:manual" is temporarily unavailable for mock/mock-fallback-v1.
[ws] res ✗ agent errorCode=UNAVAILABLE errorMessage=Error: Auth profile "mock:manual" is temporarily unavailable for mock/mock-fallback-v1.
```

- **Behavior matrix**:

| Step | Before (main) | After (this branch) |
|---|---|---|
| Primary request | 404 model_not_found | 404 model_not_found |
| Profile failure state | profile=sha256:dbc11556aae9 reason=model_not_found window=cooldown | same |
| Fallback candidate | mock/mock-fallback-v1 | mock/mock-fallback-v1 |
| Fallback request fired? | NO — blocked by shared cooldown | YES — status=200 |
| Run result | errorCode=UNAVAILABLE "Auth profile mock:manual is temporarily unavailable for mock/mock-fallback-v1" | success, text="hello from mock-fallback-v1" |

- **Observed result after fix**: 1) The same `model_not_found` cooldown is recorded, but now scoped to the failed model (`cooldownModel` set); 2) the healthy fallback candidate is actually attempted (real provider request fired) and returns HTTP 200; 3) the run completes successfully with the fallback's reply instead of failing with `UNAVAILABLE`
- **What was not tested**: OAuth/WHAM profiles (the fix path is shared, but live OAuth providers were not exercised); real Ollama; gateway hot-reload of an existing cooldown row (migration semantics unchanged)

## Root Cause

The shared `isModelScopedCooldownReason()` classifier in `src/agents/auth-profiles/usage-state.ts` was introduced by #87538 in commit `582fea942b09` on May 31, 2026, extending the earlier per-model cooldown design from #87462. The classifier change was authored by @openperf and merged by @steipete; `model_not_found` was omitted, so it fell into the profile-wide branch in both `computeNextProfileUsageStats` (records `cooldownModel: undefined`) and `shouldBypassModelScopedCooldown` (no bypass for sibling models). Confidence: clear.

## Regression Test Plan

1. `src/agents/auth-profiles/usage.test.ts` — new tests for `isProfileInCooldown` (sibling bypass / same-model block / no-model conservative / `cooldownModel: undefined` profile-wide), `markAuthProfileFailure` (first failure records `cooldownModel`; same-model repeat preserves; different-model widens; missing modelId widens; end-to-end sibling stays available after a real `model_not_found` failure), `getSoonestCooldownExpiry` (model-scoped vs profile-wide)
2. Focused post-rebase proof: `src/agents/auth-profiles.getsoonestcooldownexpiry.test.ts` (9), `src/agents/model-fallback.probe.test.ts` (20), and `src/agents/auth-profiles/usage.test.ts` (98) — 127/127 passed. The multi-profile expiry case confirms `model_not_found` keeps earliest matching expiry semantics rather than the shared max-expiry behavior used by rate limits.

## User-visible / Behavior Changes

Users with a primary model the provider no longer serves now get their healthy fallback models used immediately instead of waiting up to 5 minutes for the profile-wide cooldown to expire. No other user-visible change.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Repro + Verification

- **Environment**: OS: Linux x86_64; Runtime: Node.js, OpenClaw 2026.7.2 build; Model/provider: local mock OpenAI-compatible provider (`api: openai-completions`); Integration/channel: none (CLI → Gateway); Relevant config: `models.providers.mock.baseUrl=http://127.0.0.1:18334/v1`, `agents.defaults.model.primary=mock/mock-primary-v1`, `fallbacks=[mock/mock-fallback-v1]`, auth profile `mock:manual`
- **Steps**: 1) start mock provider; 2) start gateway; 3) `openclaw agent --agent main --message "ping" --verbose on --json`
- **Expected**: primary 404 → fallback used → reply delivered
- **Actual (before)**: fallback blocked with `UNAVAILABLE`; **Actual (after)**: fallback returns 200 and reply delivered

## Human Verification

- **Verified scenarios**: primary `model_not_found` + healthy sibling fallback on the same auth profile (before vs after), same-model still blocked, no-model conservative block, profile-wide reasons (`auth`) still block all models (existing tests)
- **Edge cases checked**: different-model failure during active `model_not_found` cooldown widens scope; missing `modelId` widens scope; `disabledUntil` still overrides model bypass; `getSoonestCooldownExpiry` consistent for `model_not_found`
- **What you did NOT verify**: live OAuth provider profiles; real Ollama model serve/unshelve flow

## Compatibility / Migration

- [x] Backward compatible? Yes — cooldown semantics only narrow from profile-wide to model-scoped for `model_not_found`; persisted rows remain valid
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — the shared classifier `isModelScopedCooldownReason()` is the single boundary both the failure-recording path and the fallback-bypass path already depend on; adding `model_not_found` there fixes both consistently
- **Refactor needed**: No
- **Alternative considered**: Patching the two inline conditions (as PR #116561 did) — rejected because it duplicates the classifier logic at call sites and drifts from the shared design. Also considered swapping `getSoonestCooldownExpiry`'s `rate_limit` check to the shared classifier for "consistency", but rejected: it routes `timeout` into the max bucket and breaks the earliest-timeout contract (caught by @ManyaS-Git on #116768).

## AI Assistance

- **AI-assisted**: Yes
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Analysis and implementation performed under the open-source-pr skill workflow (issue selection → provenance → design → implementation → real runtime evidence)

## Maintainer Policy Decision

Accepted for this PR: a model-specific 404 may immediately try a sibling model sharing the same auth profile. If a second distinct model also returns `model_not_found`, the existing persistence path widens the cooldown to profile-wide; the regression suite covers that transition. Missing model identity remains conservatively profile-wide.

**Rank-up moves resolved:** maintainer policy for sibling-model retry is confirmed; separate tests prove a second distinct `model_not_found` failure widens the cooldown to profile-wide and that missing model identity remains profile-wide.

## Independent Maintainer Validation

- Frozen reviewed head: `9537577486f5c47086242d984ef8273bbce72326`
- Focused Vitest proof: 127/127 passed across expiry, fallback-probe, and usage-state suites
- Blacksmith Testbox changed gate: passed in 9m12s, including core/core-test typechecks, changed-file lint, formatting, boundary checks, dead-code scans, database/state guards, and import-cycle checks ([run](https://github.com/openclaw/openclaw/actions/runs/30649597381))
- Fresh Codex autoreview: clean, no actionable findings, confidence 0.93
- Current `origin/main` merge-tree: clean with no touched-file drift at validation time

## Risks and Mitigations

- Highest risk: a sibling model that is also broken could now be attempted during a `model_not_found` cooldown (previously blocked). Mitigation: attempts remain subject to the provider's real response — a genuinely broken sibling still fails and, per `computeNextProfileUsageStats`, widens the scope to profile-wide on the second distinct model failure; `disabledUntil`/blocked windows still block all models
- Compatibility: no breaking change; existing persisted cooldown rows are read with the same schema (fields unchanged)
- Test risk: CI shard had pre-existing `git init -b` environment failures in `src/agents/worktrees/*` on this machine only; CI's own runner uses a modern git

