### PR TITLE
fix(doctor): exclude disabled automation overrides and report SQLite storage

### DIFF
--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -15,6 +15,7 @@ import {
 import { cronStoreKey } from "../../../cron/store/key.js";
 import { readCronTaskRunHistoryPage } from "../../../cron/task-run-history.js";
 import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import { withRestoredMocks } from "../../../test-utils/vitest-spies.js";
 import {
   collectLegacyCronStoreHealthFindings,
@@ -246,7 +247,7 @@ describe("collectLegacyCronStoreHealthFindings", () => {
         expect.objectContaining({
           checkId: "core/doctor/legacy-cron-store",
           severity: "warning",
-          path: storePath,
+          path: resolveOpenClawStateSqlitePath(),
           requirement: "legacy-notify-fallback",
         }),
       ]),
@@ -292,6 +293,21 @@ describe("collectLegacyCronStoreHealthFindings", () => {
       }),
     ]);
     await expect(readPersistedJobs(storePath)).resolves.toEqual([]);
+  });
+
+  it("attributes SQLite-only cron findings to the canonical state database", async () => {
+    const storePath = await makeTempStorePath();
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.dirname(path.dirname(storePath)));
+    await writeCurrentCronStore(storePath, [createCurrentCronJob({ notify: true })]);
+
+    const findings = await collectLegacyCronStoreHealthFindings({ cfg: {} });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        path: resolveOpenClawStateSqlitePath(),
+        requirement: "legacy-notify-fallback",
+      }),
+    ]);
   });
 
   it("returns no findings for an already-normalized empty cron store", async () => {
@@ -389,6 +405,11 @@ describe("maybeRepairLegacyCronStore", () => {
         },
         state: {},
       },
+      createCurrentCronJob({
+        id: "disabled-pinned",
+        enabled: false,
+        payload: { kind: "agentTurn", message: "Dormant job", model: "ollama/qwen3" },
+      }),
     ]);
     const prompter = makePrompter(true);
 
@@ -410,6 +431,8 @@ describe("maybeRepairLegacyCronStore", () => {
     expectNoteContaining("2 jobs set `payload.model`", "Cron");
     expectNoteContaining("Provider namespaces: anthropic=1, openai=1", "Cron");
     expectNoteContaining("2 jobs use a different model than `agents.defaults.model`", "Cron");
+    expectNoNoteContaining("ollama", "Cron");
+    expectNoNoteContaining("jobs.json", "Cron");
 
     const jobs = await readPersistedJobs(storePath);
     const job = requirePersistedJob(jobs, 0);
@@ -1400,6 +1423,7 @@ describe("maybeRepairLegacyCronStore", () => {
     expectNoNoteContaining("Legacy cron job storage detected", "Cron");
     expectNoteContaining("Cron store issues detected", "Cron");
     expectNoteContaining("1 job still uses legacy", "Cron");
+    expectNoNoteContaining("jobs.json", "Cron");
   });
 
   it("advises on isolated shell-prompt jobs without a non-actionable --fix repair note (#94655)", async () => {

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { loadCronQuarantineFile, resolveCronJobsStorePath } from "../../../cron/store.js";
 import type { HealthFinding } from "../../../flows/health-checks.js";
 import { formatErrorMessage as errorMessage } from "../../../infra/errors.js";
+import { resolveOpenClawStateSqlitePath } from "../../../state/openclaw-state-db.paths.js";
 import { shortenHomePath } from "../../../utils.js";
 import type { DoctorPrompter, DoctorOptions } from "../../doctor-prompter.js";
 import { countStaleDreamingJobs } from "./dreaming-payload-migration.js";
@@ -189,12 +190,13 @@ export async function collectLegacyCronStoreHealthFindings(params: {
     return findings;
   }
 
+  const sqliteStorePath = resolveOpenClawStateSqlitePath();
   const normalized = normalizeStoredCronJobs(rawJobs);
   for (const line of formatLegacyIssuePreview(normalized.issues)) {
     findings.push(
       legacyCronStoreFinding({
         message: line.replace(/^- /u, ""),
-        path: storePath,
+        path: sqliteStorePath,
         requirement: "legacy-cron-store-shape",
       }),
     );
@@ -215,7 +217,7 @@ export async function collectLegacyCronStoreHealthFindings(params: {
       findings.push(
         legacyCronStoreFinding({
           message: `${pluralize(names.length, "tool-bearing automation")} ${description}.`,
-          path: storePath,
+          path: sqliteStorePath,
           requirement,
           fixHint: `Review with ${formatCliCommand("openclaw automations list")} and reauthorize with ${formatCliCommand("openclaw automations edit <id> --tools <tool,...>")}.`,
         }),
@@ -227,7 +229,7 @@ export async function collectLegacyCronStoreHealthFindings(params: {
     findings.push(
       legacyCronStoreFinding({
         message: `${pluralize(sqliteProjectionBackfillCount, "SQLite cron row")} will be backfilled from stored config JSON into split columns.`,
-        path: storePath,
+        path: sqliteStorePath,
         requirement: "sqlite-projection-backfill",
       }),
     );
@@ -238,7 +240,7 @@ export async function collectLegacyCronStoreHealthFindings(params: {
     findings.push(
       legacyCronStoreFinding({
         message: `${pluralize(notifyCount, "job")} still uses legacy notify webhook fallback.`,
-        path: storePath,
+        path: sqliteStorePath,
         requirement: "legacy-notify-fallback",
       }),
     );
@@ -249,7 +251,7 @@ export async function collectLegacyCronStoreHealthFindings(params: {
     findings.push(
       legacyCronStoreFinding({
         message: `${pluralize(dreamingStaleCount, "managed dreaming job")} still has the legacy heartbeat-coupled shape.`,
-        path: storePath,
+        path: sqliteStorePath,
         requirement: "legacy-dreaming-payload",
       }),
     );
@@ -352,8 +354,8 @@ export async function maybeRepairLegacyCronStore(params: {
     noteLegacyCronRepairResult(await applyLegacyCronStoreRepair({ cfg: params.cfg, state }));
     return;
   }
-  noteCronModelOverrides({ cfg: params.cfg, jobs: rawJobs, storePath });
-  noteCronDeliveryTargetAdvisory({ cfg: params.cfg, jobs: rawJobs, storePath });
+  noteCronModelOverrides({ cfg: params.cfg, jobs: rawJobs });
+  noteCronDeliveryTargetAdvisory({ cfg: params.cfg, jobs: rawJobs });
 
   const inFlightCount = countInFlightCronJobs(rawJobs);
   if (inFlightCount > 0) {
@@ -436,7 +438,7 @@ export async function maybeRepairLegacyCronStore(params: {
 
   const noteHeading = legacyStoreDetected
     ? `Legacy cron job storage detected at ${shortenHomePath(storePath)}.`
-    : `Cron store issues detected at ${shortenHomePath(storePath)}.`;
+    : `Cron store issues detected at ${shortenHomePath(resolveOpenClawStateSqlitePath())}.`;
 
   note(
     [

--- a/src/commands/doctor/cron/warnings.test.ts
+++ b/src/commands/doctor/cron/warnings.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   collectLegacyWhatsAppCrontabHealthWarning,
   noteCronDeliveryTargetAdvisory,
+  noteCronModelOverrides,
 } from "./warnings.js";
 
 const mocks = vi.hoisted(() => ({
@@ -21,8 +22,6 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-const STORE_PATH = "/tmp/openclaw/cron/jobs.sqlite";
-
 function job(overrides: Record<string, unknown>): Record<string, unknown> {
   return { id: "job", schedule: "0 * * * *", ...overrides };
 }
@@ -34,7 +33,6 @@ function availableChannels(...ids: string[]) {
 
 function collectCronDeliveryTargetAdvisory(params: {
   jobs: Array<Record<string, unknown>>;
-  storePath: string;
   resolveAvailableChannelIds: () => string[];
 }): string | null {
   mocks.note.mockClear();
@@ -44,17 +42,38 @@ function collectCronDeliveryTargetAdvisory(params: {
   noteCronDeliveryTargetAdvisory({
     cfg: {},
     jobs: params.jobs,
-    storePath: params.storePath,
   });
   const body = mocks.note.mock.calls.at(-1)?.[0];
   return typeof body === "string" ? body : null;
 }
 
+describe("noteCronModelOverrides", () => {
+  it("describes enabled overrides without claiming a specific backing store", () => {
+    noteCronModelOverrides({
+      cfg: {},
+      jobs: [job({ enabled: true, payload: { kind: "agentTurn", model: "ollama/qwen3" } })],
+    });
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringMatching(/^Automation model overrides detected\.\n/u),
+      "Cron",
+    );
+  });
+
+  it("does not warn for disabled model-pinned jobs", () => {
+    noteCronModelOverrides({
+      cfg: {},
+      jobs: [job({ enabled: false, payload: { kind: "agentTurn", model: "ollama/qwen3" } })],
+    });
+
+    expect(mocks.note).not.toHaveBeenCalled();
+  });
+});
+
 describe("collectCronDeliveryTargetAdvisory", () => {
   it("advises when a concrete delivery channel has no active plugin", () => {
     const advisory = collectCronDeliveryTargetAdvisory({
       jobs: [job({ id: "report", delivery: { mode: "announce", channel: "missing-channel" } })],
-      storePath: STORE_PATH,
       resolveAvailableChannelIds: availableChannels("slack", "telegram"),
     });
     expect(advisory).not.toBeNull();
@@ -68,7 +87,6 @@ describe("collectCronDeliveryTargetAdvisory", () => {
     // Omitting `mode` defaults to announce, so a bare channel still counts as a concrete target.
     const advisory = collectCronDeliveryTargetAdvisory({
       jobs: [job({ delivery: { channel: "slack" } })],
-      storePath: STORE_PATH,
       resolveAvailableChannelIds: availableChannels("slack", "telegram"),
     });
     expect(advisory).toBeNull();
@@ -78,7 +96,6 @@ describe("collectCronDeliveryTargetAdvisory", () => {
     // "gchat" canonicalizes to "googlechat"; an alias target must not look unavailable.
     const advisory = collectCronDeliveryTargetAdvisory({
       jobs: [job({ delivery: { mode: "announce", channel: "gchat" } })],
-      storePath: STORE_PATH,
       resolveAvailableChannelIds: availableChannels("googlechat"),
     });
     expect(advisory).toBeNull();
@@ -92,7 +109,6 @@ describe("collectCronDeliveryTargetAdvisory", () => {
     const resolve = availableChannels("slack");
     const advisory = collectCronDeliveryTargetAdvisory({
       jobs: [job({ delivery })],
-      storePath: STORE_PATH,
       resolveAvailableChannelIds: resolve,
     });
     expect(advisory).toBeNull();
@@ -105,7 +121,6 @@ describe("collectCronDeliveryTargetAdvisory", () => {
     });
     const advisory = collectCronDeliveryTargetAdvisory({
       jobs: [job({ id: "implicit" }), job({ id: "weblike", delivery: { mode: "webhook" } })],
-      storePath: STORE_PATH,
       resolveAvailableChannelIds: resolve,
     });
     expect(advisory).toBeNull();
@@ -121,7 +136,6 @@ describe("collectCronDeliveryTargetAdvisory", () => {
           delivery: { mode: "announce", channel: "missing-channel" },
         }),
       ],
-      storePath: STORE_PATH,
       resolveAvailableChannelIds: resolve,
     });
     expect(advisory).toBeNull();
@@ -131,7 +145,6 @@ describe("collectCronDeliveryTargetAdvisory", () => {
   it("flags a concrete target even when no channels are active (only channel removed)", () => {
     const advisory = collectCronDeliveryTargetAdvisory({
       jobs: [job({ id: "report", delivery: { mode: "announce", channel: "slack" } })],
-      storePath: STORE_PATH,
       resolveAvailableChannelIds: availableChannels(),
     });
     expect(advisory).toContain("Channels: slack=1");
@@ -146,7 +159,6 @@ describe("collectCronDeliveryTargetAdvisory", () => {
         job({ id: "g3", delivery: { mode: "announce", channel: "ghost-b" } }),
         job({ id: "g4", delivery: { mode: "announce", channel: "ghost-b" } }),
       ],
-      storePath: STORE_PATH,
       resolveAvailableChannelIds: availableChannels("slack"),
     });
     expect(advisory).toContain("4 jobs announce");
@@ -168,7 +180,6 @@ describe("collectCronDeliveryTargetAdvisory", () => {
         }),
         job({ id: undefined, name: undefined, delivery: { mode: "announce", channel: "ghost" } }),
       ],
-      storePath: STORE_PATH,
       resolveAvailableChannelIds: availableChannels("slack"),
     });
     expect(advisory).toContain("Nightly digest -> ghost");

--- a/src/commands/doctor/cron/warnings.ts
+++ b/src/commands/doctor/cron/warnings.ts
@@ -1,4 +1,5 @@
 // Doctor cron warnings for model overrides and stale WhatsApp crontab health scripts.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "../../../../packages/normalization-core/src/string-coerce.js";
 import { note } from "../../../../packages/terminal-core/src/note.js";
 import { normalizeChatChannelId } from "../../../channels/ids.js";
@@ -9,7 +10,6 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveCronDeliveryPlan } from "../../../cron/delivery-plan.js";
 import type { CronJob } from "../../../cron/types.js";
 import { runExec } from "../../../process/exec.js";
-import { shortenHomePath } from "../../../utils.js";
 
 type CrontabReader = () => Promise<{ stdout?: unknown; stderr?: unknown }>;
 
@@ -53,12 +53,6 @@ function normalizeModelMismatchKey(value: unknown): string | undefined {
   return normalizeModelRef(value) ?? normalizeOptionalString(value)?.toLowerCase();
 }
 
-function getRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
 function formatSortedCounts(counts: Map<string, number>): string {
   return [...counts.entries()]
     .toSorted(([left], [right]) => left.localeCompare(right))
@@ -70,7 +64,6 @@ function formatSortedCounts(counts: Map<string, number>): string {
 export function noteCronModelOverrides(params: {
   cfg: OpenClawConfig;
   jobs: Array<Record<string, unknown>>;
-  storePath: string;
 }) {
   const defaultModel = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model);
   const defaultKey = normalizeModelMismatchKey(defaultModel);
@@ -80,7 +73,10 @@ export function noteCronModelOverrides(params: {
   let mismatchCount = 0;
 
   for (const rawJob of params.jobs) {
-    const payload = getRecord(rawJob.payload);
+    if (rawJob.enabled === false) {
+      continue;
+    }
+    const payload = isRecord(rawJob.payload) ? rawJob.payload : undefined;
     const kind = normalizeOptionalString(payload?.kind)?.toLowerCase();
     if (kind && kind !== "agentturn") {
       continue;
@@ -108,7 +104,7 @@ export function noteCronModelOverrides(params: {
   }
 
   const lines = [
-    `Automation model overrides detected at ${shortenHomePath(params.storePath)}.`,
+    "Automation model overrides detected.",
     `- ${pluralize(overrideCount, "job")} set \`payload.model\` and will not inherit \`agents.defaults.model\`${defaultModel ? ` (${defaultModel})` : ""}`,
     `- Provider namespaces: ${formatSortedCounts(providerCounts)}`,
   ];
@@ -145,7 +141,7 @@ function listConcreteCronDeliveryTargets(
     }
     // Only an explicit delivery object pins a concrete channel; without one the plan resolves
     // to the pseudo "last" route decided at run time, which doctor cannot validate ahead of time.
-    if (!getRecord(job.delivery)) {
+    if (!isRecord(job.delivery)) {
       continue;
     }
     const plan = resolveCronDeliveryPlan(job as unknown as CronJob);
@@ -168,7 +164,6 @@ function listConcreteCronDeliveryTargets(
  */
 function collectCronDeliveryTargetAdvisory(params: {
   jobs: Array<Record<string, unknown>>;
-  storePath: string;
   resolveAvailableChannelIds: () => Iterable<string>;
 }): string | null {
   const concreteTargets = listConcreteCronDeliveryTargets(params.jobs);
@@ -206,7 +201,7 @@ function collectCronDeliveryTargetAdvisory(params: {
   }
 
   return [
-    `Automation delivery targets unavailable channels at ${shortenHomePath(params.storePath)}.`,
+    "Automation delivery targets unavailable channels.",
     `- ${pluralize(unavailableCount, "job")} ${unavailableCount === 1 ? "announces" : "announce"} to a channel whose plugin is not active; the next scheduled run will fail to deliver`,
     `- Channels: ${formatSortedCounts(channelCounts)}`,
     `- Examples: ${examples.join(", ")}`,
@@ -218,13 +213,11 @@ function collectCronDeliveryTargetAdvisory(params: {
 export function noteCronDeliveryTargetAdvisory(params: {
   cfg: OpenClawConfig;
   jobs: Array<Record<string, unknown>>;
-  storePath: string;
 }): void {
   let advisory: string | null;
   try {
     advisory = collectCronDeliveryTargetAdvisory({
       jobs: params.jobs,
-      storePath: params.storePath,
       // Mirror the doctor channel lookup: setup-fallback materializes configured channels even
       // when no gateway is running, so configured targets are not mistaken for unavailable ones.
       resolveAvailableChannelIds: () =>


### PR DESCRIPTION
Refs #116568

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor` saw inactive automation jobs counted as active model overrides and were directed to a nonexistent retired `cron/jobs.json` file.

## Why This Change Was Made

Automation rows are stored in the shared SQLite state database; the old JSON path now identifies only a legacy migration source or internal partition. Keep general advisories storage-neutral, attribute SQLite-owned repair findings to the actual state database, preserve genuine legacy-file locations, and exclude disabled jobs. Reuse the canonical record guard and remove obsolete warning-path plumbing.

## User Impact

Doctor reports only active model overrides, no longer names hidden disabled jobs or phantom storage files, and directs operators to the correct canonical database without changing cron configuration, migrations, public APIs, or runtime behavior.

## Evidence

- Exact current head: `d3b4057389ef7b669f8bea751260c5dedb2a3ccc`.
- Trusted remote Testbox: [focused proof](https://github.com/openclaw/openclaw/actions/runs/30623555120); 72/72 tests passed (58 cron integration, 14 warning tests) using `OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test src/commands/doctor/cron/warnings.test.ts src/commands/doctor/cron/index.test.ts`. The reviewed/tested head `42ecda8adbfa6a38a256e7db71d59e6d28ccd2c0` was cleanly rebased onto the formatted current main; both immutable commits have identical stable patch ID `4b02e79c41300bb7381e73d0c2239267edfb328c`.
- `git diff --check` passed.
- Production LOC: -5.
- Mandatory autoreview and signed TruffleHog scan clean; separate independent read-only Codex review clean.
- Credits: reported by @mattmiesnieks; informed by prior contributor investigations #116706 (@RerankerGuo) and #116707 (@lsr911). This focused replacement preserves those contributions without inheriting their conflicting or unrelated changes.
- AI-assisted; transcript omitted because not explicitly approved.
