### PR TITLE
refactor(reply): simplify task-owned typing refresh

### DIFF
--- a/.agents/skills/openclaw-autonomous-issue-sweep/SKILL.md
+++ b/.agents/skills/openclaw-autonomous-issue-sweep/SKILL.md
@@ -67,6 +67,7 @@ subagents. Keep parent-thread updates to concise progress and clickable URLs.
    mutate the shared checkout while sibling workers are active. Once isolated
    worktrees exist, independent issue owners edit, inspect, and verify in
    parallel within their own checkout.
+
 6. Keep all **64** inherited high-effort agents available, but distinguish idle
    agents from active local tool users. Start with bounded waves of **4–8**
    concurrently active code/test workers and continuously reduce or expand that

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -467,7 +467,6 @@ describe("runReplyAgent active steering", () => {
 
     expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
     expect(taskTyping.startTypingLoop).toHaveBeenCalledOnce();
-    expect(taskTyping.refreshTypingTtl).toHaveBeenCalledOnce();
     expect(taskTyping.cleanup).not.toHaveBeenCalled();
     expect(typing.cleanup).toHaveBeenCalledOnce();
 

--- a/src/auto-reply/reply/reply-run-typing.ts
+++ b/src/auto-reply/reply/reply-run-typing.ts
@@ -25,12 +25,10 @@ export function bindReplyOperationTyping(
 export async function refreshReplyOperationTyping(
   operation: ReplyOperation,
   options: { startIfIdle: boolean },
-): Promise<boolean> {
+): Promise<void> {
   const typing = typingByReplyOperation.get(operation);
   if (!typing || operation.result || (!options.startIfIdle && !typing.isActive())) {
-    return false;
+    return;
   }
   await typing.startTypingLoop();
-  typing.refreshTypingTtl();
-  return true;
 }


### PR DESCRIPTION
Related: #116695
Follow-up to #116721

## What Problem This Solves

Keeps the recently landed Telegram task-owned typing fix easy to maintain by removing an unused result and duplicate timer refresh from its steering path.

## Why This Change Was Made

`TypingController.startTypingLoop()` already refreshes the controller TTL, and the sole caller of `refreshReplyOperationTyping()` never inspects a result. Return `Promise<void>` and rely on the controller's existing refresh so there is one canonical timer-update path.

## User Impact

No behavior change: long-running and steered Telegram tasks keep their typing indicator alive exactly as in #116721.

## Evidence

- `OPENCLAW_FS_SAFE_NATIVE_MODE=off OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/typing-persistence.test.ts`: **6 passed**.
- `OPENCLAW_FS_SAFE_NATIVE_MODE=off OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/channels/typing.test.ts`: **23 passed**, including the 132-second Telegram cadence regression.
- Existing steering E2E still asserts that the continuing task's typing loop starts once, the steer does not launch a replacement run, and terminal cleanup runs once. Fresh hosted CI owns this E2E because the existing local shared `@openclaw/fs-safe` install is stale.
- `git diff --check` and targeted `oxfmt --check` pass; production code shrinks.
- Current `main` independently failed the full formatting gate on `.agents/skills/openclaw-autonomous-issue-sweep/SKILL.md`; this PR also restores its single missing blank line so the required maintainer landing gate can pass.
