### PR TITLE
fix(ui): preserve session pages and coordinate scoped gateway refreshes

### DIFF
--- a/ui/src/components/session-data-controller-events.ts
+++ b/ui/src/components/session-data-controller-events.ts
@@ -1,0 +1,104 @@
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import type { RouteId } from "../app-route-paths.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { readPresenceEntries, type PresencePayload } from "../app/user-profile.ts";
+import { createSessionEventRefreshCoordinator } from "../lib/sessions/event-refresh-coordinator.ts";
+import { readSessionChangedEvent } from "../lib/sessions/reconcile.ts";
+import { normalizeAgentId, parseAgentSessionKey } from "../lib/sessions/session-key.ts";
+import type { SidebarSessionStatusFilter } from "./app-sidebar-session-types.ts";
+import type { SessionDataControllerHost } from "./session-data-controller-catalog.ts";
+
+type SessionGatewayEventOwner = {
+  presencePayload: PresencePayload | undefined;
+  readonly sessionScopeGeneration: number;
+  handleSessionCatalogHostEvent(payload: unknown): void;
+  handleSessionCatalogPresence(payload: unknown): void;
+  refreshSidebarSessions(agentId?: string): Promise<void>;
+  requestSessionDataUpdate(): void;
+};
+
+type FilteredSessionRefreshScope = {
+  agentId: string;
+  archivedFilter: SidebarSessionStatusFilter;
+  client: ApplicationContext<RouteId>["gateway"]["snapshot"]["client"];
+  generation: number;
+};
+
+export function subscribeSessionDataGatewayEvents(
+  gateway: ApplicationContext<RouteId>["gateway"],
+  owner: SessionGatewayEventOwner,
+  host: Pick<
+    SessionDataControllerHost,
+    "expandedAgentId" | "isConnected" | "sidebarSessionStatusFilter"
+  >,
+): () => void {
+  let subscribed = true;
+  let refreshScope: FilteredSessionRefreshScope | null = null;
+  const scopeIsCurrent = () =>
+    refreshScope !== null &&
+    subscribed &&
+    host.isConnected &&
+    gateway.snapshot.phase === "connected" &&
+    gateway.snapshot.client === refreshScope.client &&
+    owner.sessionScopeGeneration === refreshScope.generation &&
+    host.sidebarSessionStatusFilter() === refreshScope.archivedFilter &&
+    normalizeAgentId(host.expandedAgentId()) === refreshScope.agentId;
+  const refreshCoordinator = createSessionEventRefreshCoordinator({
+    canRefresh: scopeIsCurrent,
+    refresh: () =>
+      refreshScope ? owner.refreshSidebarSessions(refreshScope.agentId) : Promise.resolve(),
+  });
+  const unsubscribe = gateway.subscribeEvents((event) => {
+    if (event.event === "sessions.catalog.host") {
+      owner.handleSessionCatalogHostEvent(event.payload);
+      return;
+    }
+    if (event.event === "sessions.changed") {
+      const archivedFilter = host.sidebarSessionStatusFilter();
+      if (archivedFilter === "active") {
+        return;
+      }
+      const agentId = normalizeAgentId(host.expandedAgentId());
+      const sessionEvent = readSessionChangedEvent(event.payload);
+      const payloadAgentId = asNullableRecord(event.payload)?.agentId;
+      const eventAgentId =
+        sessionEvent?.agentId ??
+        parseAgentSessionKey(sessionEvent?.key)?.agentId ??
+        (typeof payloadAgentId === "string" ? payloadAgentId : undefined);
+      if (eventAgentId && normalizeAgentId(eventAgentId) !== agentId) {
+        return;
+      }
+      const nextScope: FilteredSessionRefreshScope = {
+        agentId,
+        archivedFilter,
+        client: gateway.snapshot.client,
+        generation: owner.sessionScopeGeneration,
+      };
+      if (
+        refreshScope &&
+        (refreshScope.agentId !== nextScope.agentId ||
+          refreshScope.archivedFilter !== nextScope.archivedFilter ||
+          refreshScope.client !== nextScope.client ||
+          refreshScope.generation !== nextScope.generation)
+      ) {
+        refreshCoordinator.reset();
+      }
+      refreshScope = nextScope;
+      // Canonical debounce/max-wait and single-flight behavior belong to one
+      // coordinator; scope checks retire stale agents, filters, and clients.
+      refreshCoordinator.schedule();
+      return;
+    }
+    if (event.event === "presence") {
+      const presence = readPresenceEntries(event.payload);
+      owner.presencePayload = presence ? { presence } : undefined;
+      owner.requestSessionDataUpdate();
+      owner.handleSessionCatalogPresence(event.payload);
+    }
+  });
+  return () => {
+    subscribed = false;
+    refreshCoordinator.dispose();
+    unsubscribe();
+  };
+}

--- a/ui/src/components/session-data-controller-pagination.ts
+++ b/ui/src/components/session-data-controller-pagination.ts
@@ -24,15 +24,27 @@ type SidebarSessionPaginationOwner = {
 export type SidebarSessionPaginationState = {
   listRequestToken: symbol | null;
   pageRequestToken: symbol | null;
+  loadedScope?: {
+    agentId: string;
+    archivedFilter: SidebarSessionStatusFilter;
+    generation: number;
+  };
 };
 
 function publishSidebarSessionResult(
   owner: SidebarSessionPaginationOwner,
   agentId: string,
   result: SessionsListResult | null,
+  archivedFilter: SidebarSessionStatusFilter,
+  generation: number,
 ) {
   owner.sessionsResult = result;
   owner.sessionsAgentId = agentId;
+  owner.sidebarSessionPaginationState.loadedScope = {
+    agentId: normalizeAgentId(agentId),
+    archivedFilter,
+    generation,
+  };
   if (result) {
     owner.sessionRowsByAgent[normalizeAgentId(agentId)] = result.sessions;
     for (const row of result.sessions) {
@@ -84,10 +96,19 @@ export async function refreshSidebarSessions(
   const state = owner.sidebarSessionPaginationState;
   state.pageRequestToken = null;
   const archivedFilter = statusFilter();
+  const loadedScope = state.loadedScope;
+  const preservesVisibleScope =
+    archivedFilter !== "active" &&
+    loadedScope?.generation === owner.sessionScopeGeneration &&
+    loadedScope.archivedFilter === archivedFilter &&
+    loadedScope.agentId === normalizeAgentId(agentId) &&
+    normalizeAgentId(owner.sessionsAgentId ?? "") === loadedScope.agentId;
   const options = {
     agentId,
     archivedFilter,
-    limit: SIDEBAR_AGENT_SESSION_LIST_LIMIT,
+    limit: preservesVisibleScope
+      ? Math.max(SIDEBAR_AGENT_SESSION_LIST_LIMIT, owner.sessionsResult?.sessions.length ?? 0)
+      : SIDEBAR_AGENT_SESSION_LIST_LIMIT,
     includeGlobal: true,
     includeUnknown: true,
     configuredAgentsOnly: true,
@@ -120,7 +141,7 @@ export async function refreshSidebarSessions(
   try {
     const result = await context.sessions.list(options);
     if (isCurrent()) {
-      publishSidebarSessionResult(owner, agentId, result);
+      publishSidebarSessionResult(owner, agentId, result, archivedFilter, generation);
     }
   } catch (error) {
     if (isCurrent()) {
@@ -204,7 +225,13 @@ export async function loadMoreSidebarSessions(
 
     const page = await context.sessions.list(options);
     if (page && isCurrent()) {
-      publishSidebarSessionResult(owner, agentId, appendSidebarSessionResults(previous, page));
+      publishSidebarSessionResult(
+        owner,
+        agentId,
+        appendSidebarSessionResults(previous, page),
+        archivedFilter,
+        generation,
+      );
     }
   } catch (error) {
     if (isCurrent()) {

--- a/ui/src/components/session-data-controller.event-refresh.test.ts
+++ b/ui/src/components/session-data-controller.event-refresh.test.ts
@@ -1,0 +1,308 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import type { SessionCapability } from "../lib/sessions/index.ts";
+import type { SessionDataControllerHost } from "./session-data-controller-catalog.ts";
+import { SessionDataController } from "./session-data-controller.ts";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+function createFilteredSessionController(statusFilter: "archived" | "all", rowCount = 1) {
+  vi.stubGlobal("document", {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    visibilityState: "visible",
+  });
+  vi.stubGlobal("addEventListener", vi.fn());
+  vi.stubGlobal("removeEventListener", vi.fn());
+
+  const rows = Array.from({ length: rowCount }, (_, index) => ({
+    key: index === 0 ? "agent:main:remote-change" : `agent:main:session-${index}`,
+    kind: "direct" as const,
+    updatedAt: index + 1,
+  }));
+  const list = vi.fn(async (options?: Parameters<SessionCapability["list"]>[0]) => {
+    const offset = options?.offset ?? 0;
+    const limit = options?.limit ?? 60;
+    const sessions = rows.slice(offset, offset + limit);
+    const nextOffset = offset + sessions.length;
+    const hasMore = nextOffset < rows.length;
+    return {
+      ts: 1,
+      path: "",
+      count: sessions.length,
+      totalCount: rows.length,
+      nextOffset: hasMore ? nextOffset : null,
+      hasMore,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions,
+    };
+  });
+  let eventListener: ((event: { event: string; payload: unknown }) => void) | undefined;
+  const sessions = {
+    state: {
+      result: null,
+      agentId: "main",
+      modelOverrides: {},
+      loading: false,
+      error: null,
+      deletedSessions: [],
+      groups: [],
+      sectionOrder: [],
+    },
+    canonicalListRevision: 1,
+    subscribe: () => () => undefined,
+    subscribeCreated: () => () => undefined,
+    groupsLoad: () => Promise.resolve(),
+    list,
+  } as unknown as SessionCapability;
+  const gateway = {
+    snapshot: {
+      phase: "connected",
+      client: {} as GatewayBrowserClient,
+      hello: null,
+      assistantAgentId: "main",
+      sessionKey: "agent:main:main",
+    },
+    subscribe: () => () => undefined,
+    subscribeEvents(listener: (event: { event: string; payload: unknown }) => void) {
+      eventListener = listener;
+      return () => {
+        eventListener = undefined;
+      };
+    },
+  };
+  const context = { gateway, sessions } as unknown as ApplicationContext;
+  let selectedAgentId = "main";
+  let selectedStatusFilter = statusFilter;
+  const host = {
+    isConnected: true,
+    connected: true,
+    sessionDataContext: context,
+    addController: () => undefined,
+    removeController: () => undefined,
+    requestUpdate: () => undefined,
+    updateComplete: Promise.resolve(true),
+    dismissTransientMenus: () => false,
+    expandedAgentId: () => selectedAgentId,
+    promoteCreatedSession: () => undefined,
+    selectedAgentIdForSessions: () => selectedAgentId,
+    sidebarSessionStatusFilter: () => selectedStatusFilter,
+    querySelector: () => null,
+  } satisfies SessionDataControllerHost;
+  const controller = new SessionDataController(host);
+
+  return {
+    controller,
+    list,
+    selectAgent: (agentId: string) => {
+      selectedAgentId = agentId;
+    },
+    selectStatusFilter: (nextStatusFilter: "archived" | "all") => {
+      selectedStatusFilter = nextStatusFilter;
+      controller.resetForStatusFilter(nextStatusFilter);
+    },
+    publishSessionChanged: (payload: Record<string, unknown> = {}) => {
+      eventListener?.({
+        event: "sessions.changed",
+        payload: {
+          sessionKey: "agent:main:remote-change",
+          agentId: "main",
+          reason: "archive",
+          ...payload,
+        },
+      });
+    },
+  };
+}
+
+describe("filtered sidebar session event refresh", () => {
+  it.each(["archived", "all"] as const)(
+    "refreshes the %s list once for duplicate remote session events",
+    async (statusFilter) => {
+      vi.useFakeTimers();
+      const { controller, list, publishSessionChanged } =
+        createFilteredSessionController(statusFilter);
+      controller.hostConnected();
+      await Promise.resolve();
+      await Promise.resolve();
+      list.mockClear();
+
+      publishSessionChanged();
+      publishSessionChanged();
+      await vi.advanceTimersByTimeAsync(199);
+      expect(list).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(list).toHaveBeenCalledTimes(1);
+      expect(list).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "main", archivedFilter: statusFilter }),
+      );
+      expect(controller.sessionsResult?.sessions[0]?.key).toBe("agent:main:remote-change");
+      controller.hostDisconnected();
+    },
+  );
+
+  it.each(["archived", "all"] as const)(
+    "preserves every loaded %s page when a remote event replaces the list",
+    async (statusFilter) => {
+      vi.useFakeTimers();
+      const { controller, list, publishSessionChanged } = createFilteredSessionController(
+        statusFilter,
+        120,
+      );
+      controller.hostConnected();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(controller.sessionsResult?.sessions).toHaveLength(60);
+
+      await controller.loadMoreSidebarSessions();
+      expect(controller.sessionsResult?.sessions).toHaveLength(120);
+      list.mockClear();
+
+      publishSessionChanged();
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(list).toHaveBeenCalledOnce();
+      expect(list).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "main", archivedFilter: statusFilter, limit: 120 }),
+      );
+      expect(controller.sessionsResult?.sessions).toHaveLength(120);
+      controller.hostDisconnected();
+    },
+  );
+
+  it("ignores session changes belonging to another agent", async () => {
+    vi.useFakeTimers();
+    const { controller, list, publishSessionChanged } = createFilteredSessionController("all");
+    controller.hostConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+    list.mockClear();
+
+    publishSessionChanged({ sessionKey: "agent:research:remote-change", agentId: "research" });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(list).not.toHaveBeenCalled();
+    controller.hostDisconnected();
+  });
+
+  it("retires queued refreshes when the selected agent changes", async () => {
+    vi.useFakeTimers();
+    const { controller, list, publishSessionChanged, selectAgent } =
+      createFilteredSessionController("archived");
+    controller.hostConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+    list.mockClear();
+
+    publishSessionChanged();
+    selectAgent("research");
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(list).not.toHaveBeenCalled();
+    controller.hostDisconnected();
+  });
+
+  it("does not carry another filtered list's page depth across a filter change", async () => {
+    const { controller, list, selectStatusFilter } = createFilteredSessionController(
+      "archived",
+      120,
+    );
+    controller.hostConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+    await controller.loadMoreSidebarSessions();
+    expect(controller.sessionsResult?.sessions).toHaveLength(120);
+    list.mockClear();
+
+    selectStatusFilter("all");
+    await controller.refreshSidebarSessions();
+
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", archivedFilter: "all", limit: 60 }),
+    );
+    expect(controller.sessionsResult?.sessions).toHaveLength(60);
+    controller.hostDisconnected();
+  });
+
+  it("bounds refresh latency while same-agent events continue arriving", async () => {
+    vi.useFakeTimers();
+    const { controller, list, publishSessionChanged } = createFilteredSessionController("all");
+    controller.hostConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+    list.mockClear();
+
+    publishSessionChanged();
+    for (let index = 0; index < 5; index += 1) {
+      await vi.advanceTimersByTimeAsync(199);
+      publishSessionChanged();
+    }
+    expect(list).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(5);
+
+    expect(list).toHaveBeenCalledOnce();
+    controller.hostDisconnected();
+  });
+
+  it("cancels a queued filtered refresh when its gateway subscription disconnects", async () => {
+    vi.useFakeTimers();
+    const { controller, list, publishSessionChanged } = createFilteredSessionController("archived");
+    controller.hostConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+    list.mockClear();
+
+    publishSessionChanged();
+    controller.hostDisconnected();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("serializes duplicate session events while a filtered refresh is in flight", async () => {
+    vi.useFakeTimers();
+    const { controller, list, publishSessionChanged } = createFilteredSessionController("archived");
+    controller.hostConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+    list.mockClear();
+    let resolveFirstRefresh!: (value: Awaited<ReturnType<typeof list>>) => void;
+    const firstRefresh = new Promise<Awaited<ReturnType<typeof list>>>((resolve) => {
+      resolveFirstRefresh = resolve;
+    });
+    const refreshedPage = {
+      ts: 2,
+      path: "",
+      count: 1,
+      totalCount: 1,
+      nextOffset: null,
+      hasMore: false,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [{ key: "agent:main:remote-change", kind: "direct" as const, updatedAt: 2 }],
+    };
+    list.mockImplementationOnce(async () => await firstRefresh).mockResolvedValue(refreshedPage);
+
+    publishSessionChanged();
+    await vi.advanceTimersByTimeAsync(200);
+    expect(list).toHaveBeenCalledOnce();
+
+    publishSessionChanged();
+    await Promise.resolve();
+    publishSessionChanged();
+    await vi.advanceTimersByTimeAsync(200);
+    expect(list).toHaveBeenCalledOnce();
+
+    resolveFirstRefresh(refreshedPage);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(controller.sessionsResult?.sessions[0]?.updatedAt).toBe(2);
+    controller.hostDisconnected();
+  });
+});

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -43,6 +43,7 @@ import {
   type SessionDataControllerHost,
   updateSessionCatalogData as updateSessionCatalogDataForHost,
 } from "./session-data-controller-catalog.ts";
+import { subscribeSessionDataGatewayEvents } from "./session-data-controller-events.ts";
 import {
   loadMoreSidebarSessions as loadMoreSidebarSessionPage,
   refreshSidebarSessions as refreshSidebarSessionPage,
@@ -133,19 +134,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       )
       .effect(
         () => this.context?.gateway,
-        (gateway) =>
-          gateway.subscribeEvents((event) => {
-            if (event.event === "sessions.catalog.host") {
-              this.handleSessionCatalogHostEvent(event.payload);
-              return;
-            }
-            if (event.event === "presence") {
-              const presence = readPresenceEntries(event.payload);
-              this.presencePayload = presence ? { presence } : undefined;
-              this.notify();
-              this.handleSessionCatalogPresence(event.payload);
-            }
-          }),
+        (gateway) => subscribeSessionDataGatewayEvents(gateway, this, host),
       )
       .watch(
         () => this.context?.agents,
@@ -688,6 +677,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   resetForStatusFilter(statusFilter: SidebarSessionStatusFilter): void {
     this.sidebarSessionPaginationState.listRequestToken = null;
     this.sidebarSessionPaginationState.pageRequestToken = null;
+    this.sidebarSessionPaginationState.loadedScope = undefined;
     this.sessionsLoading = false;
     this.visibleSessionLimits.clear();
     this.childSessionRowsByParent = {};

--- a/ui/src/lib/sessions/event-refresh-coordinator.ts
+++ b/ui/src/lib/sessions/event-refresh-coordinator.ts
@@ -1,0 +1,93 @@
+const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
+const SESSION_EVENT_REFRESH_MAX_WAIT_MS = 1_000;
+
+type SessionEventRefreshCoordinatorOptions = {
+  canRefresh: () => boolean;
+  refresh: () => Promise<void>;
+};
+
+/** Canonical bounded event refresh policy shared by session-list owners. */
+export function createSessionEventRefreshCoordinator(
+  options: SessionEventRefreshCoordinatorOptions,
+) {
+  let timer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  let deadline: number | null = null;
+  let inFlight: Promise<void> | null = null;
+  let trailing = false;
+  let generation = 0;
+  let disposed = false;
+
+  const clearTimer = () => {
+    if (timer !== null) {
+      globalThis.clearTimeout(timer);
+      timer = null;
+    }
+    deadline = null;
+  };
+
+  const start = () => {
+    if (disposed || !options.canRefresh()) {
+      return;
+    }
+    if (inFlight) {
+      trailing = true;
+      return;
+    }
+    const operationGeneration = generation;
+    const operation = options.refresh().catch(() => undefined);
+    const pending = operation.finally(() => {
+      if (generation !== operationGeneration || inFlight !== pending) {
+        return;
+      }
+      inFlight = null;
+      if (trailing) {
+        trailing = false;
+        start();
+      }
+    });
+    inFlight = pending;
+  };
+
+  return {
+    schedule() {
+      if (disposed || !options.canRefresh()) {
+        return;
+      }
+      const now = Date.now();
+      deadline ??= now + SESSION_EVENT_REFRESH_MAX_WAIT_MS;
+      if (timer !== null) {
+        globalThis.clearTimeout(timer);
+      }
+      const delay = Math.min(SESSION_EVENT_REFRESH_DEBOUNCE_MS, Math.max(0, deadline - now));
+      timer = globalThis.setTimeout(() => {
+        timer = null;
+        deadline = null;
+        start();
+      }, delay);
+    },
+    flush() {
+      if (timer === null) {
+        return;
+      }
+      clearTimer();
+      start();
+    },
+    absorb() {
+      clearTimer();
+      trailing = false;
+    },
+    reset() {
+      clearTimer();
+      trailing = false;
+      inFlight = null;
+      generation += 1;
+    },
+    dispose() {
+      clearTimer();
+      trailing = false;
+      inFlight = null;
+      generation += 1;
+      disposed = true;
+    },
+  };
+}

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -7,13 +7,16 @@ import { createSessionCapability } from "./index.ts";
 const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
 const SESSION_EVENT_REFRESH_MAX_WAIT_MS = 1_000;
 
-function sessionsResult(ts: number): SessionsListResult {
+function sessionsResult(
+  ts: number,
+  sessions: SessionsListResult["sessions"] = [],
+): SessionsListResult {
   return {
     ts,
     path: "",
-    count: 0,
+    count: sessions.length,
     defaults: { modelProvider: null, model: null, contextTokens: null },
-    sessions: [],
+    sessions,
   };
 }
 
@@ -56,6 +59,49 @@ function createHarness(request: GatewayBrowserClient["request"]) {
 }
 
 describe("event-driven session list refresh", () => {
+  it("retains every loaded page when a session event replaces the canonical list", async () => {
+    vi.useFakeTimers();
+    const rows = Array.from({ length: 120 }, (_, index) => ({
+      key: `agent:main:session-${index}`,
+      kind: "direct" as const,
+      updatedAt: index + 1,
+    }));
+    const request = vi.fn(async (method: string, params?: { limit?: number; offset?: number }) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      const offset = params?.offset ?? 0;
+      const limit = params?.limit ?? 50;
+      const page = rows.slice(offset, offset + limit);
+      const hasMore = offset + page.length < rows.length;
+      return {
+        ...sessionsResult(offset + 1, page),
+        totalCount: rows.length,
+        nextOffset: hasMore ? offset + page.length : null,
+        hasMore,
+      };
+    });
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      await sessions.refresh({ agentId: "main", limit: 60, force: true });
+      await sessions.refresh({ agentId: "main", limit: 60, offset: 60, append: true, force: true });
+      expect(sessions.state.result?.sessions).toHaveLength(120);
+
+      emitEvent(sessionChangedEvent("agent:main:session-0"));
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+
+      expect(request.mock.calls[2]?.[1]).toMatchObject({ agentId: "main", limit: 120 });
+      expect(request.mock.calls[2]?.[1]).not.toHaveProperty("offset");
+      expect(sessions.state.result?.sessions).toHaveLength(120);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("clears a recreated session's prior deletion before the debounced refresh", async () => {
     vi.useFakeTimers();
     const key = "agent:main:recreated-thread";

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -40,6 +40,7 @@ import {
   type SessionCreateParams,
 } from "./create.ts";
 import { readSessionCustomGroupNames, readSidebarSectionOrder } from "./custom-groups.ts";
+import { createSessionEventRefreshCoordinator } from "./event-refresh-coordinator.ts";
 import { scopedAgentListParamsForSession, type SessionArchivedFilter } from "./navigation.ts";
 import type { SessionPatch, SessionPatchOptions, SessionPatchRoute } from "./patch.ts";
 import {
@@ -105,9 +106,6 @@ export type SessionListOptions = {
 export const DEFAULT_SESSION_LIST_QUERY = {
   limit: 50,
 } as const satisfies SessionListOptions;
-
-const SESSION_EVENT_REFRESH_DEBOUNCE_MS = 200;
-const SESSION_EVENT_REFRESH_MAX_WAIT_MS = 1_000;
 
 type SessionRefreshOptions = SessionListOptions & {
   force?: boolean;
@@ -729,8 +727,6 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   let inFlight: Promise<void> | null = null;
   let queuedExplicitRefresh: SessionRefreshOptions | null = null;
   let eventRefreshQueued = false;
-  let eventRefreshTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
-  let eventRefreshDeadline: number | null = null;
   let canonicalListRevision = 0;
   let disposed = false;
   let connectionEpoch = 0;
@@ -922,6 +918,17 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         result && append && requestOptions.offset && state.result
           ? appendSessionResults(state.result, result)
           : result;
+      if (append && nextResult && !backgroundHydrate) {
+        // Event replacements restart at page one, so retain the visible page
+        // depth instead of silently dropping every previously appended row.
+        lastListOptions = {
+          ...durableListOptions,
+          limit: Math.max(
+            durableListOptions.limit ?? DEFAULT_SESSION_LIST_QUERY.limit,
+            nextResult.sessions.length,
+          ),
+        };
+      }
       if (backgroundHydrate && nextResult) {
         const currentKey = gateway.snapshot.sessionKey?.trim();
         if (currentKey) {
@@ -976,16 +983,8 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     }
   };
 
-  const clearEventRefreshTimer = () => {
-    if (eventRefreshTimer !== null) {
-      globalThis.clearTimeout(eventRefreshTimer);
-      eventRefreshTimer = null;
-    }
-    eventRefreshDeadline = null;
-  };
-
   const absorbPendingEventRefresh = () => {
-    clearEventRefreshTimer();
+    eventRefreshCoordinator.absorb();
     eventRefreshQueued = false;
   };
 
@@ -1062,30 +1061,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     return startRefresh({ ...lastListOptions, force: true });
   };
 
-  const flushEventRefresh = () => {
-    if (eventRefreshTimer === null) {
-      return;
-    }
-    clearEventRefreshTimer();
-    void refreshFromEvent();
-  };
-
-  const scheduleEventRefresh = () => {
-    const now = Date.now();
-    eventRefreshDeadline ??= now + SESSION_EVENT_REFRESH_MAX_WAIT_MS;
-    if (eventRefreshTimer !== null) {
-      globalThis.clearTimeout(eventRefreshTimer);
-    }
-    const delay = Math.min(
-      SESSION_EVENT_REFRESH_DEBOUNCE_MS,
-      Math.max(0, eventRefreshDeadline - now),
-    );
-    eventRefreshTimer = globalThis.setTimeout(() => {
-      eventRefreshTimer = null;
-      eventRefreshDeadline = null;
-      void refreshFromEvent();
-    }, delay);
-  };
+  const eventRefreshCoordinator = createSessionEventRefreshCoordinator({
+    canRefresh: () =>
+      gateway.snapshot.phase === "connected" && gateway.snapshot.client !== null && !disposed,
+    refresh: refreshFromEvent,
+  });
+  const flushEventRefresh = () => eventRefreshCoordinator.flush();
 
   const handleVisibilityChange = () => {
     if (document.visibilityState === "hidden") {
@@ -1848,7 +1829,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     connectionConnected = connected;
     if (connectionChanged) {
       const hadPullRequestSummaries = pullRequestSummaries.size > 0;
-      clearEventRefreshTimer();
+      eventRefreshCoordinator.reset();
       connectionEpoch += 1;
       if (previousClient) {
         resetGatewaySessionMessageSubscriptionCoordinator(previousClient);
@@ -1976,7 +1957,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       // Gateway lists are filtered and windowed. Events cannot preserve server
       // membership or ordering, so the coalesced refresh remains canonical. Only
       // events debounce, with a max wait; explicit refreshes and page exit flush it.
-      scheduleEventRefresh();
+      eventRefreshCoordinator.schedule();
     }
   });
 
@@ -2038,6 +2019,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       // Page teardown must start the trailing refresh synchronously before the
       // disposed guard makes the capability inert.
       flushEventRefresh();
+      eventRefreshCoordinator.dispose();
       if (observesPageLifecycle) {
         document.removeEventListener("visibilitychange", handleVisibilityChange);
         globalThis.removeEventListener("pagehide", flushEventRefresh);

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -21,6 +21,7 @@ import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
 import { renderBoardDockMenu, renderBoardFaceToggle } from "./board-session-surface.ts";
 import { ChatPaneContext } from "./chat-pane-context.ts";
 import { headerPlatformByClient } from "./chat-pane-shared.ts";
+import { patchChatSessionLabel } from "./chat-state-route.ts";
 import { renderCatalogTerminalButton } from "./components/catalog-terminal-button.ts";
 import {
   renderBackgroundTasksToggle,
@@ -258,13 +259,13 @@ export abstract class ChatPaneHeader extends ChatPaneContext {
     const unchangedLabel = label === this.headerRenameInitialLabel;
     this.headerEditing = false;
     this.headerRenameSessionKey = "";
-    if (!key || unchangedDerivedTitle || unchangedLabel) {
+    const state = this.state;
+    if (!key || !state || unchangedDerivedTitle || unchangedLabel) {
       return;
     }
-    const agentId = parseAgentSessionKey(key)?.agentId;
-    void this.context.sessions
-      .patch(key, { label }, agentId ? { agentId } : undefined)
-      .catch((error: unknown) => this.publishHeaderError(error));
+    void patchChatSessionLabel(state, this.context.sessions, key, label).catch((error: unknown) =>
+      this.publishHeaderError(error),
+    );
   }
 
   protected async loadHeaderMenuData(

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -140,6 +140,29 @@ describe("chat pane header state", () => {
     expect(patch).toHaveBeenLastCalledWith(session.key, { label: null }, { agentId: "main" });
   });
 
+  it("renames the selected agent's canonical global session", () => {
+    const patch = vi.fn(async () => ({}));
+    const sessions = { patch } as unknown as SessionCapability;
+    const { pane, state } = createTestChatPane({ client: {} as GatewayBrowserClient, sessions });
+    state.sessionKey = "global";
+    state.assistantAgentId = "research";
+    const session = {
+      key: "global",
+      kind: "global",
+      updatedAt: 0,
+    } satisfies GatewaySessionRow;
+
+    pane.beginHeaderRename(session);
+    pane.headerRenameValue = "Research thread";
+    pane.commitHeaderRename();
+
+    expect(patch).toHaveBeenCalledWith(
+      "global",
+      { label: "Research thread" },
+      { agentId: "research" },
+    );
+  });
+
   it("cancels and skips unchanged labels", () => {
     const patch = vi.fn(async () => ({}));
     const sessions = { patch } as unknown as SessionCapability;

--- a/ui/src/pages/chat/chat-state-route.ts
+++ b/ui/src/pages/chat/chat-state-route.ts
@@ -2,7 +2,7 @@ import { loadLocalAssistantIdentity } from "../../app/assistant-identity.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
 import { isRenderableControlUiAvatarUrl } from "../../lib/avatar.ts";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
-import { scopedAgentParamsForSession } from "../../lib/sessions/index.ts";
+import { scopedAgentParamsForSession, type SessionCapability } from "../../lib/sessions/index.ts";
 import {
   DEFAULT_MAIN_KEY,
   areUiSessionKeysEquivalent,
@@ -404,6 +404,15 @@ export function resolveChatAgentId(state: ChatPageHost) {
       scopedAgentParamsForSession(state, state.sessionKey).agentId ??
       resolveUiSelectedGlobalAgentId(state),
   );
+}
+
+export function patchChatSessionLabel(
+  state: ChatPageHost,
+  sessions: Pick<SessionCapability, "patch">,
+  sessionKey: string,
+  label: string | null,
+) {
+  return sessions.patch(sessionKey, { label }, { agentId: resolveChatAgentId(state) });
 }
 
 export function resolveChatAvatarUrl(state: ChatPageHost): string | null {

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -4,6 +4,7 @@ import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { INTERNAL_SESSION_PATH_PARAM } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { buildCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { prepareSessionNavigationHandoff } from "../../lib/sessions/navigation-handoff.ts";
 import {
   resolveSessionPreferredFaceForKey,
@@ -11,6 +12,8 @@ import {
   SESSION_NAVIGATION_KEY_PARAM,
   sessionNavigationTarget,
 } from "../../lib/sessions/route-navigation.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import { patchChatSessionLabel } from "./chat-state-route.ts";
 import { loadChatRoute } from "./route-loader.ts";
 
 const uuid = "12345678-90ab-cdef-1234-567890abcdef";
@@ -73,6 +76,26 @@ function targetLocation(target: ReturnType<typeof sessionNavigationTarget>) {
 }
 
 describe("gateway-backed session route resolution", () => {
+  it("patches a canonical global session on the selected agent", async () => {
+    const patch = vi.fn(async () => ({}));
+    const state = {
+      sessionKey: "global",
+      assistantAgentId: "research",
+      agentsList: null,
+      hello: null,
+    } as ChatPageHost;
+
+    const sessions = { patch } as unknown as Pick<SessionCapability, "patch">;
+
+    await patchChatSessionLabel(state, sessions, "global", "Research thread");
+
+    expect(patch).toHaveBeenCalledWith(
+      "global",
+      { label: "Research thread" },
+      { agentId: "research" },
+    );
+  });
+
   it("resolves a non-default agent's canonical global face from its scoped row", async () => {
     const globalRow = row({ key: "global", kind: "global", boardFace: "dashboard" });
     const { context, list } = contextFor(({ agentId, search }) =>

--- a/ui/src/test-helpers/app-sidebar-cases/session-pagination.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-pagination.ts
@@ -14,6 +14,93 @@ import "../../components/app-sidebar.ts";
 
 describe("AppSidebar gateway session pagination", () => {
   it.each(["archived", "all"] as const)(
+    "refreshes the %s sidebar once when another client changes sessions",
+    async (statusFilter) => {
+      const harness = createSessionsHarness("main", ["agent:main:canonical-active"]);
+      const firstResult = createSessionState("main", ["agent:main:before-remote-change"]).result;
+      const changedResult = createSessionState("main", ["agent:main:after-remote-change"]).result;
+      if (!firstResult || !changedResult) {
+        throw new Error("expected filtered session results");
+      }
+      harness.list.mockResolvedValue(firstResult);
+      const gateway = createGatewayHarness({} as GatewayBrowserClient);
+      const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
+      (sidebar as unknown as { sessionsStatusFilter: "archived" | "all" }).sessionsStatusFilter =
+        statusFilter;
+      sidebar.sessionData.resetForStatusFilter(statusFilter);
+      await sidebar.sessionData.refreshSidebarSessions("main");
+      harness.list.mockClear();
+      harness.list.mockResolvedValue(changedResult);
+
+      gateway.publishEvent("sessions.changed", {
+        sessionKey: "agent:main:after-remote-change",
+        reason: "archive",
+      });
+      gateway.publishEvent("sessions.changed", {
+        sessionKey: "agent:main:after-remote-change",
+        reason: "archive",
+      });
+
+      await waitForFast(() => {
+        expect(harness.list).toHaveBeenCalledTimes(1);
+        expect(sidebar.sessionData.sessionsResult?.sessions.map((row) => row.key)).toEqual([
+          "agent:main:after-remote-change",
+        ]);
+      });
+      expect(harness.list).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "main", archivedFilter: statusFilter }),
+      );
+    },
+  );
+
+  it.each(["archived", "all"] as const)(
+    "keeps every loaded %s sidebar page after another client's session event",
+    async (statusFilter) => {
+      const keys = Array.from({ length: 120 }, (_, index) => `agent:main:session-${index}`);
+      const harness = createSessionsHarness("main", ["agent:main:canonical-active"]);
+      harness.list.mockImplementation(async (options) => {
+        const offset = options?.offset ?? 0;
+        const limit = options?.limit ?? 60;
+        const sessions = createSessionState("main", keys.slice(offset, offset + limit)).result;
+        if (!sessions) {
+          throw new Error("expected a paginated filtered session result");
+        }
+        const nextOffset = offset + sessions.sessions.length;
+        const hasMore = nextOffset < keys.length;
+        return {
+          ...sessions,
+          totalCount: keys.length,
+          nextOffset: hasMore ? nextOffset : null,
+          hasMore,
+        };
+      });
+      const gateway = createGatewayHarness({} as GatewayBrowserClient);
+      const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
+      (sidebar as unknown as { sessionsStatusFilter: "archived" | "all" }).sessionsStatusFilter =
+        statusFilter;
+      sidebar.sessionData.resetForStatusFilter(statusFilter);
+      await sidebar.sessionData.refreshSidebarSessions("main");
+      await sidebar.sessionData.loadMoreSidebarSessions();
+      expect(sidebar.sessionData.sessionsResult?.sessions).toHaveLength(120);
+      harness.list.mockClear();
+
+      gateway.publishEvent("sessions.changed", {
+        sessionKey: keys[0],
+        agentId: "main",
+        reason: "archive",
+      });
+
+      await waitForFast(() => {
+        expect(harness.list).toHaveBeenCalledOnce();
+        expect(sidebar.sessionData.sessionsResult?.sessions).toHaveLength(120);
+      });
+      expect(harness.list).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "main", archivedFilter: statusFilter, limit: 120 }),
+      );
+    },
+  );
+
+  it.each(["archived", "all"] as const)(
     "keeps a pending %s first page across a stable same-client Gateway notification",
     async (statusFilter) => {
       const harness = createSessionsHarness("main", ["agent:main:canonical-active"]);


### PR DESCRIPTION
## Summary
- Preserve loaded archived/all session pages across matching Gateway refreshes; reset pagination only when the selected agent, filter, client, or generation actually changes.
- Route canonical and filtered session updates through one debounced, maximum-wait-bounded, single-flight event refresh coordinator.
- Ignore unrelated agents and stale/reconnected client events while retaining selected-agent global-session rename behavior.

## Verification
- Session owner, route, and scoped-controller suites: **47 tests passed**.
- Actual mounted sidebar pagination/filter/connection scenarios: **19 tests passed**, including retaining 120 loaded archived/all rows.
- Independent whole-owner review inspected debounce/max-wait/single-flight lifecycle, dispose/reconnect cleanup, agent/filter isolation, selected-session renaming, canonical/global siblings, and actual DOM proof; no blockers.
- Targeted oxlint, formatting, and `git diff --check` pass.
- Automated autoreview is unavailable because the mandatory TruffleHog binary is missing; equivalent independent manual diff and secret review completed.

## Root causes fixed
3 distinct session ownership, pagination, and concurrent event-refresh defects.
