### PR TITLE
fix(commands): validate native settings and preserve Telegram ingress outcomes

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,3 +1,3 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it.
-518
+517

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -34,6 +34,7 @@ import {
 } from "./bot-message.js";
 import { registerTelegramNativeCommands } from "./bot-native-commands.js";
 import {
+  ensureTelegramMessageProcessingResult,
   getTelegramSpooledReplayDeferredParticipant,
   isTelegramSpooledReplayUpdate,
   runWithTelegramUpdateProcessingFrame,
@@ -186,6 +187,10 @@ export function createTelegramBotCore(
     try {
       const { result } = await runWithTelegramUpdateProcessingFrame(async () => {
         await next();
+        if (!getTelegramSpooledReplayDeferredParticipant()) {
+          // Accepted synchronous updates need one terminal fact at their middleware owner.
+          ensureTelegramMessageProcessingResult({ kind: "completed" });
+        }
       });
       const deferredWork = getTelegramSpooledReplayDeferredParticipant();
       if (deferredWork) {

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -732,14 +732,14 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(turnPlan?.record?.sessionKey).toBe(turnPlan?.ctxPayload.CommandTargetSessionKey);
   });
 
-  it("records a completed outcome after a native slash command", async () => {
+  it("leaves native-command outcomes to the update middleware owner", async () => {
     const { handler } = registerAndResolveStatusHandler({ cfg: {} });
 
     const { result } = await runWithTelegramUpdateProcessingFrame(async () => {
       await handler(createTelegramPrivateCommandContext());
     });
 
-    expect(result).toEqual({ kind: "completed" });
+    expect(result).toBeUndefined();
   });
 
   it("preserves every argument on native queue command turns", async () => {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -75,10 +75,7 @@ import {
   syncTelegramMenuCommands as syncTelegramMenuCommandsRuntime,
   type TelegramMenuCommand,
 } from "./bot-native-command-menu.js";
-import {
-  recordTelegramMessageProcessingResult,
-  type TelegramMessageProcessingResult,
-} from "./bot-processing-outcome.js";
+import type { TelegramMessageProcessingResult } from "./bot-processing-outcome.js";
 import type { TelegramUpdateKeyContext } from "./bot-updates.js";
 import type { TelegramBotOptions } from "./bot.types.js";
 import {
@@ -125,19 +122,6 @@ const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const activeTelegramCodexLoginFlows = new Map<string, { expiresAt: number }>();
 
 type TelegramNativeCommandContext = Context & { match?: string };
-
-function registerTelegramNativeCommandHandler(
-  bot: Bot,
-  command: string,
-  handler: (ctx: TelegramNativeCommandContext) => Promise<void>,
-): void {
-  bot.command(command, async (ctx: TelegramNativeCommandContext) => {
-    await handler(ctx);
-    // Native commands bypass processMessage, so their terminal outcome must be
-    // recorded here for every built-in, plugin, and direct-delivery branch.
-    recordTelegramMessageProcessingResult({ kind: "completed" });
-  });
-}
 
 type TelegramChunkMode = ReturnType<
   typeof import("openclaw/plugin-sdk/reply-dispatch-runtime").resolveChunkMode
@@ -1227,7 +1211,7 @@ export const registerTelegramNativeCommands = ({
   if (commandsToRegister.length > 0 || pluginCatalog.commands.length > 0) {
     for (const command of nativeCommands) {
       const normalizedCommandName = normalizeTelegramCommandName(command.name);
-      registerTelegramNativeCommandHandler(bot, normalizedCommandName, async (ctx) => {
+      bot.command(normalizedCommandName, async (ctx: TelegramNativeCommandContext) => {
         const msg = ctx.message;
         if (!msg) {
           return;
@@ -1817,7 +1801,7 @@ export const registerTelegramNativeCommands = ({
     }
 
     for (const pluginCommand of pluginCatalog.commands) {
-      registerTelegramNativeCommandHandler(bot, pluginCommand.command, async (ctx) => {
+      bot.command(pluginCommand.command, async (ctx: TelegramNativeCommandContext) => {
         const msg = ctx.message;
         if (!msg) {
           return;

--- a/extensions/telegram/src/bot-processing-outcome.test.ts
+++ b/extensions/telegram/src/bot-processing-outcome.test.ts
@@ -1,0 +1,46 @@
+/** Verifies Telegram update outcomes stay attached to their durable ingress owner. */
+import { describe, expect, it } from "vitest";
+import {
+  ensureTelegramMessageProcessingResult,
+  recordTelegramMessageProcessingResult,
+  runWithTelegramUpdateProcessingFrame,
+} from "./bot-processing-outcome.js";
+
+describe("Telegram update processing outcomes", () => {
+  it("reuses the ingress outcome frame across nested bot middleware", async () => {
+    const outer = await runWithTelegramUpdateProcessingFrame(async () => {
+      const inner = await runWithTelegramUpdateProcessingFrame(async () => {
+        ensureTelegramMessageProcessingResult({ kind: "completed" });
+        return "middleware-finished";
+      });
+
+      expect(inner).toEqual({ value: "middleware-finished", result: { kind: "completed" } });
+      return "update-finished";
+    });
+
+    expect(outer).toEqual({ value: "update-finished", result: { kind: "completed" } });
+  });
+
+  it.each([
+    { kind: "skipped" as const },
+    { kind: "failed-retryable" as const, error: new Error("retry") },
+  ])(
+    "does not replace an explicit $kind disposition with middleware completion",
+    async (expected) => {
+      const { result } = await runWithTelegramUpdateProcessingFrame(async () => {
+        recordTelegramMessageProcessingResult(expected);
+        ensureTelegramMessageProcessingResult({ kind: "completed" });
+      });
+
+      expect(result).toBe(expected);
+    },
+  );
+
+  it("keeps deferred owners outcome-free until their participant settles", async () => {
+    const { result } = await runWithTelegramUpdateProcessingFrame(async () => {
+      await runWithTelegramUpdateProcessingFrame(async () => {});
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/extensions/telegram/src/bot-processing-outcome.ts
+++ b/extensions/telegram/src/bot-processing-outcome.ts
@@ -56,9 +56,21 @@ export class TelegramSpooledReplayProcessingError extends Error {
 export async function runWithTelegramUpdateProcessingFrame<T>(
   fn: () => Promise<T>,
 ): Promise<{ value: T; result?: TelegramMessageProcessingResult }> {
-  const frame: TelegramUpdateProcessingFrame = {};
-  const value = await telegramUpdateProcessingFrames.run(frame, fn);
+  const inheritedFrame = telegramUpdateProcessingFrames.getStore();
+  // Durable ingress owns the outer frame; bot middleware must update that same fact.
+  const frame = inheritedFrame ?? {};
+  const value = inheritedFrame ? await fn() : await telegramUpdateProcessingFrames.run(frame, fn);
   return frame.result ? { value, result: frame.result } : { value };
+}
+
+/** Records a default only when a handler has not already chosen its terminal disposition. */
+export function ensureTelegramMessageProcessingResult(
+  result: TelegramMessageProcessingResult,
+): void {
+  const frame = telegramUpdateProcessingFrames.getStore();
+  if (frame && !frame.result) {
+    frame.result = result;
+  }
 }
 
 export function recordTelegramMessageProcessingResult(

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -84,6 +84,7 @@ const {
   createTelegramSpooledReplayDeferredParticipant,
   recordTelegramMessageProcessingResult,
   runWithTelegramSpooledReplayUpdate,
+  runWithTelegramUpdateProcessingFrame,
   TelegramSpooledReplayProcessingError,
 } = await import("./bot-processing-outcome.js");
 const { TELEGRAM_RICH_TEXT_LIMIT } = await import("./rich-message.js");
@@ -2796,6 +2797,28 @@ describe("createTelegramBot", () => {
     await p101;
 
     expect(onUpdateId.mock.calls.map((call) => call[0])).toEqual([102]);
+  });
+
+  it("records synchronous update completion on the shared ingress frame", async () => {
+    const { run: runMiddlewareChain } = setupUpdateOffsetTracker({ lastUpdateId: 150 });
+
+    const { result } = await runWithTelegramUpdateProcessingFrame(async () => {
+      await runMiddlewareChain({ update: { update_id: 151 } }, async () => {});
+    });
+
+    expect(result).toEqual({ kind: "completed" });
+  });
+
+  it("preserves an intentionally skipped update through middleware completion", async () => {
+    const { run: runMiddlewareChain } = setupUpdateOffsetTracker({ lastUpdateId: 160 });
+
+    const { result } = await runWithTelegramUpdateProcessingFrame(async () => {
+      await runMiddlewareChain({ update: { update_id: 161 } }, async () => {
+        recordTelegramMessageProcessingResult({ kind: "skipped" });
+      });
+    });
+
+    expect(result).toEqual({ kind: "skipped" });
   });
   it("logs and swallows update watermark persistence failures", async () => {
     const onUpdateId = vi.fn().mockRejectedValueOnce(new Error("disk boom"));

--- a/extensions/telegram/src/telegram-ingress-drain-factory.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain-factory.test.ts
@@ -1,0 +1,112 @@
+/** Verifies the grammY-to-durable-ingress terminal outcome handoff. */
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ensureTelegramMessageProcessingResult,
+  recordTelegramMessageProcessingResult,
+  runWithTelegramUpdateProcessingFrame,
+  type TelegramMessageProcessingResult,
+} from "./bot-processing-outcome.js";
+import type { TelegramIngressDrainLifecycle } from "./telegram-ingress-drain.js";
+
+const mocks = vi.hoisted(() => ({
+  createTelegramIngressMonitor: vi.fn((params: unknown) => params),
+  openTelegramIngressQueue: vi.fn(() => ({ kind: "test-queue" })),
+  resolveTelegramAdoptionStallTimeoutMs: vi.fn(() => 5_000),
+}));
+
+vi.mock("./telegram-ingress-drain.js", () => ({
+  createTelegramIngressMonitor: mocks.createTelegramIngressMonitor,
+  resolveTelegramAdoptionStallTimeoutMs: mocks.resolveTelegramAdoptionStallTimeoutMs,
+}));
+
+vi.mock("./telegram-ingress-spool.js", () => ({
+  openTelegramIngressQueue: mocks.openTelegramIngressQueue,
+}));
+
+const { createTelegramTransportIngressMonitor } =
+  await import("./telegram-ingress-drain-factory.js");
+
+type CapturedMonitor = {
+  dispatch: (
+    update: unknown,
+    lifecycle: TelegramIngressDrainLifecycle,
+  ) => Promise<TelegramMessageProcessingResult | void>;
+};
+
+describe("Telegram transport ingress outcome handoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    { kind: "completed" as const },
+    { kind: "skipped" as const },
+    { kind: "failed-retryable" as const, error: new Error("retry the update") },
+  ])(
+    "returns the middleware-owned $kind outcome despite grammY returning void",
+    async (outcome) => {
+      const bot = {
+        handleUpdate: vi.fn(async () => {
+          await runWithTelegramUpdateProcessingFrame(async () => {
+            recordTelegramMessageProcessingResult(outcome);
+          });
+        }),
+      };
+      createTelegramTransportIngressMonitor({
+        spoolDir: "/tmp/telegram-ingress-proof",
+        bot,
+        cfg: {} as OpenClawConfig,
+        accountId: "default",
+      });
+      const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;
+      const update = { update_id: 123 };
+
+      await expect(monitor.dispatch(update, {} as TelegramIngressDrainLifecycle)).resolves.toBe(
+        outcome,
+      );
+      expect(bot.handleUpdate).toHaveBeenCalledWith(update);
+    },
+  );
+
+  it("does not invent an outcome for deferred participant ownership", async () => {
+    const bot = {
+      handleUpdate: vi.fn(async () => {
+        await runWithTelegramUpdateProcessingFrame(async () => {});
+      }),
+    };
+    createTelegramTransportIngressMonitor({
+      spoolDir: "/tmp/telegram-ingress-proof",
+      bot,
+      cfg: {} as OpenClawConfig,
+      accountId: "default",
+    });
+    const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;
+
+    await expect(
+      monitor.dispatch({ update_id: 124 }, {} as TelegramIngressDrainLifecycle),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps an existing explicit skip when middleware applies its completion default", async () => {
+    const bot = {
+      handleUpdate: vi.fn(async () => {
+        await runWithTelegramUpdateProcessingFrame(async () => {
+          recordTelegramMessageProcessingResult({ kind: "skipped" });
+          ensureTelegramMessageProcessingResult({ kind: "completed" });
+        });
+      }),
+    };
+    createTelegramTransportIngressMonitor({
+      spoolDir: "/tmp/telegram-ingress-proof",
+      bot,
+      cfg: {} as OpenClawConfig,
+      accountId: "default",
+    });
+    const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;
+
+    await expect(
+      monitor.dispatch({ update_id: 125 }, {} as TelegramIngressDrainLifecycle),
+    ).resolves.toEqual({ kind: "skipped" });
+  });
+});

--- a/extensions/telegram/src/telegram-ingress-drain-factory.ts
+++ b/extensions/telegram/src/telegram-ingress-drain-factory.ts
@@ -1,7 +1,10 @@
 // Telegram plugin module builds transport-shared durable ingress monitors.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { TelegramBotInfo } from "./bot-info.js";
-import type { TelegramMessageProcessingResult } from "./bot-processing-outcome.js";
+import {
+  runWithTelegramUpdateProcessingFrame,
+  type TelegramMessageProcessingResult,
+} from "./bot-processing-outcome.js";
 import {
   createTelegramIngressMonitor,
   resolveTelegramAdoptionStallTimeoutMs,
@@ -60,9 +63,12 @@ export function createTelegramTransportIngressMonitor(
       if (params.dispatchUpdate) {
         return await params.dispatchUpdate(update, lifecycle);
       }
-      // Lifecycle is also on the spooled ALS frame (runWithTelegramSpooledReplayUpdate).
-      // bot-message merges it into turnAdoptionLifecycle for complete-at-adoption.
-      await params.bot.handleUpdate(update as never);
+      // grammY returns void, so carry its middleware-owned outcome back to durable ingress.
+      // The spooled lifecycle remains on its existing frame for complete-at-adoption.
+      const { result } = await runWithTelegramUpdateProcessingFrame(async () => {
+        await params.bot.handleUpdate(update as never);
+      });
+      return result;
     },
   });
 }

--- a/qa/scenarios/channels/telegram-queue-invalid-mode.yaml
+++ b/qa/scenarios/channels/telegram-queue-invalid-mode.yaml
@@ -1,4 +1,4 @@
-title: Telegram native queue command rejects ordinary prompt text
+title: Telegram native settings commands reject prose as command arguments
 
 scenario:
   id: telegram-queue-invalid-mode
@@ -9,14 +9,17 @@ scenario:
       - telegram.built-in-commands
   regressionRefs:
     - openclaw/openclaw#116688
-  objective: Verify a native Telegram queue command with ordinary trailing text returns its queue-mode validation error without invoking the model or synthesizing a model-failure fallback.
+  objective: Verify native Telegram settings commands validate their complete arguments without invoking the model or synthesizing a model-failure fallback.
   successCriteria:
     - Telegram accepts the native queue command with its complete trailing argument text.
     - The reply identifies the invalid queue mode and lists supported queue modes.
+    - Valid queue settings followed by unexpected prose produce an explicit argument error.
+    - Native thinking commands preserve and reject invalid multiword arguments.
     - The reply never blames the model, and a mock provider receives no request for the command.
   codeRefs:
     - extensions/telegram/src/bot-native-commands.ts
     - src/auto-reply/reply/get-reply-directives.ts
+    - src/auto-reply/reply/directive-handling.native.ts
     - src/auto-reply/reply/directive-handling.queue-validation.ts
   execution:
     kind: flow
@@ -67,3 +70,48 @@ flow:
             message:
               expr: "`native queue validation unexpectedly invoked the model ${String(scenarioRequests.length)} time(s)`"
       detailsExpr: reply.text
+
+    - name: valid native queue options reject unexpected trailing prose
+      actions:
+        - set: queueStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation: { id: telegram-command-room, kind: channel }
+            senderId: qa-command-operator
+            senderName: QA Command Operator
+            text: /queue collect please help
+            nativeCommand: { name: queue }
+        - waitForOutbound:
+            conversation: { id: telegram-command-room, kind: channel }
+            sinceIndex: { ref: queueStartIndex }
+            textIncludes: Unexpected argument "please" for /queue.
+            timeoutMs: 60000
+          saveAs: queueTrailingReply
+      detailsExpr: queueTrailingReply.text
+
+    - name: native thinking commands preserve invalid multiword arguments
+      actions:
+        - set: thinkStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation: { id: telegram-command-room, kind: channel }
+            senderId: qa-command-operator
+            senderName: QA Command Operator
+            text: /think about my deployment plan
+            nativeCommand: { name: think }
+        - waitForOutbound:
+            conversation: { id: telegram-command-room, kind: channel }
+            sinceIndex: { ref: thinkStartIndex }
+            textIncludes: Unrecognized thinking level "about".
+            timeoutMs: 60000
+          saveAs: thinkReply
+        - set: allScenarioRequests
+          value:
+            expr: "env.mock ? await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`) : []"
+        - assert:
+            expr: "!env.mock || allScenarioRequests.length === 0"
+            message:
+              expr: "`native settings validation unexpectedly invoked the model ${String(allScenarioRequests.length)} time(s)`"
+      detailsExpr: thinkReply.text

--- a/src/auto-reply/commands-registry.runtime.ts
+++ b/src/auto-reply/commands-registry.runtime.ts
@@ -1,2 +1,6 @@
 /** Runtime facade for command-registry helpers used across lazy boundaries. */
-export { listChatCommands, normalizeCommandBody } from "./commands-registry.js";
+export {
+  findCommandByNativeName,
+  listChatCommands,
+  normalizeCommandBody,
+} from "./commands-registry.js";

--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -352,3 +352,90 @@ describe("level directive preserves message text after an invalid level", () => 
     expect(res.rawLevel).toBe("maybe");
   });
 });
+
+describe("native directive commands own their complete argument boundary", () => {
+  it.each([
+    {
+      command: "think" as const,
+      body: "/think about my deployment plan",
+      rawKey: "rawThinkLevel" as const,
+      invalidArgument: "about",
+      trailingArguments: "my deployment plan",
+    },
+    {
+      command: "verbose" as const,
+      body: "/verbose explain quantum computing",
+      rawKey: "rawVerboseLevel" as const,
+      invalidArgument: "explain",
+      trailingArguments: "quantum computing",
+    },
+    {
+      command: "trace" as const,
+      body: "/trace banana please",
+      rawKey: "rawTraceLevel" as const,
+      invalidArgument: "banana",
+      trailingArguments: "please",
+    },
+    {
+      command: "fast" as const,
+      body: "/fast bananas please",
+      rawKey: "rawFastMode" as const,
+      invalidArgument: "bananas",
+      trailingArguments: "please",
+    },
+    {
+      command: "reasoning" as const,
+      body: "/reasoning nonsense please",
+      rawKey: "rawReasoningLevel" as const,
+      invalidArgument: "nonsense",
+      trailingArguments: "please",
+    },
+    {
+      command: "elevated" as const,
+      body: "/elevated perhaps explain",
+      rawKey: "rawElevatedLevel" as const,
+      invalidArgument: "perhaps",
+      trailingArguments: "explain",
+    },
+  ])(
+    "preserves the invalid first argument for native /$command",
+    ({ body, command, invalidArgument, rawKey, trailingArguments }) => {
+      const parsed = parseInlineDirectives(body, { nativeCommand: command });
+
+      expect(parsed[rawKey]).toBe(invalidArgument);
+      expect(parsed.cleaned).toBe(trailingArguments);
+      expect(parsed.nativeCommand).toEqual({
+        name: command,
+        unconsumedArguments: trailingArguments,
+      });
+    },
+  );
+
+  it("retains unexpected arguments after a valid native queue mode", () => {
+    const parsed = parseInlineDirectives("/queue collect please help", {
+      nativeCommand: "queue",
+    });
+
+    expect(parsed.queueMode).toBe("collect");
+    expect(parsed.nativeCommand).toEqual({
+      name: "queue",
+      unconsumedArguments: "please help",
+    });
+  });
+
+  it("does not interpret another directive inside native command arguments", () => {
+    const parsed = parseInlineDirectives("/queue /think high", { nativeCommand: "queue" });
+
+    expect(parsed.hasQueueDirective).toBe(true);
+    expect(parsed.rawQueueMode).toBe("/think");
+    expect(parsed.hasThinkDirective).toBe(false);
+  });
+
+  it("preserves the existing prose interpretation for ordinary inline directives", () => {
+    const parsed = parseInlineDirectives("/think about my deployment plan");
+
+    expect(parsed.rawThinkLevel).toBeUndefined();
+    expect(parsed.nativeCommand).toBeUndefined();
+    expect(parsed.cleaned).toBe("about my deployment plan");
+  });
+});

--- a/src/auto-reply/reply/directive-handling.directive-only.ts
+++ b/src/auto-reply/reply/directive-handling.directive-only.ts
@@ -27,6 +27,10 @@ export function isDirectiveOnly(params: {
   ) {
     return false;
   }
+  // Native arguments belong to their command even when the inline parser leaves invalid prose.
+  if (directives.nativeCommand) {
+    return true;
+  }
   const stripped = stripStructuralPrefixes(cleanedBody ?? "");
   // Group mentions are routing syntax, not meaningful agent body text.
   const noMentions = isGroup ? stripMentions(stripped, ctx, cfg, agentId) : stripped;

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -37,6 +37,7 @@ import {
 } from "./directive-handling.model-runtime.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
 import { maybeHandleModelDirectiveInfo } from "./directive-handling.model.js";
+import { maybeHandleUnexpectedNativeDirectiveArguments } from "./directive-handling.native.js";
 import type { HandleDirectiveOnlyParams } from "./directive-handling.params.js";
 import { maybeHandleQueueDirective } from "./directive-handling.queue-validation.js";
 import {
@@ -348,6 +349,10 @@ export async function handleDirectiveOnly(
         text: "Exec node requires a value.",
       };
     }
+    const unexpectedExecArguments = maybeHandleUnexpectedNativeDirectiveArguments(directives);
+    if (unexpectedExecArguments) {
+      return unexpectedExecArguments;
+    }
     if (!directives.hasExecOptions) {
       const execDefaults = resolveExecDefaults({
         cfg: params.cfg,
@@ -373,6 +378,11 @@ export async function handleDirectiveOnly(
   });
   if (queueAck) {
     return queueAck;
+  }
+
+  const unexpectedNativeArguments = maybeHandleUnexpectedNativeDirectiveArguments(directives);
+  if (unexpectedNativeArguments) {
+    return unexpectedNativeArguments;
   }
 
   if (

--- a/src/auto-reply/reply/directive-handling.native.ts
+++ b/src/auto-reply/reply/directive-handling.native.ts
@@ -1,0 +1,20 @@
+/** Validates argument boundaries for explicitly invoked native session directives. */
+import type { ReplyPayload } from "../types.js";
+import type { InlineDirectives } from "./directive-handling.parse.js";
+
+/** Rejects prose left over after canonical command-specific validation succeeds. */
+export function maybeHandleUnexpectedNativeDirectiveArguments(
+  directives: InlineDirectives,
+): ReplyPayload | undefined {
+  const nativeCommand = directives.nativeCommand;
+  const unconsumedArguments = nativeCommand?.unconsumedArguments;
+  if (!nativeCommand || !unconsumedArguments) {
+    return undefined;
+  }
+
+  // One token is enough to explain the rejected boundary without echoing an unbounded prompt.
+  const unexpectedArgument = unconsumedArguments.split(/\s+/, 1)[0] ?? unconsumedArguments;
+  return {
+    text: `Unexpected argument "${unexpectedArgument}" for /${nativeCommand.name}.`,
+  };
+}

--- a/src/auto-reply/reply/directive-handling.parse.ts
+++ b/src/auto-reply/reply/directive-handling.parse.ts
@@ -23,9 +23,40 @@ import {
 import { extractQueueDirective } from "./queue/directive.js";
 import type { QueueDropPolicy, QueueMode } from "./queue/types.js";
 
+const NATIVE_REPLY_DIRECTIVE_COMMANDS = {
+  think: true,
+  verbose: true,
+  trace: true,
+  fast: true,
+  reasoning: true,
+  elevated: true,
+  exec: true,
+  model: true,
+  queue: true,
+} as const;
+
+/** Canonical command-registry keys that share the session-directive execution pipeline. */
+type NativeReplyDirectiveCommand = keyof typeof NATIVE_REPLY_DIRECTIVE_COMMANDS;
+
+/** Resolves a registered command key without inferring directive ownership from slash text. */
+export function resolveNativeReplyDirectiveCommand(
+  commandKey: string | undefined,
+): NativeReplyDirectiveCommand | undefined {
+  return commandKey && Object.hasOwn(NATIVE_REPLY_DIRECTIVE_COMMANDS, commandKey)
+    ? (commandKey as NativeReplyDirectiveCommand)
+    : undefined;
+}
+
+type NativeDirectiveInvocation = {
+  name: NativeReplyDirectiveCommand;
+  unconsumedArguments?: string;
+};
+
 /** Parsed inline directives removed from a user message before agent execution. */
 export type InlineDirectives = {
   cleaned: string;
+  /** Explicit native command ownership prevents prose-oriented inline cleanup from eating args. */
+  nativeCommand?: NativeDirectiveInvocation;
   hasThinkDirective: boolean;
   thinkLevel?: ThinkLevel;
   rawThinkLevel?: string;
@@ -85,38 +116,58 @@ export function parseInlineDirectives(
     modelAliases?: string[];
     disableElevated?: boolean;
     allowStatusDirective?: boolean;
+    nativeCommand?: NativeReplyDirectiveCommand;
   },
 ): InlineDirectives {
+  const nativeCommand = options?.nativeCommand;
+  const parseScopedDirective = <T extends { cleaned: string; hasDirective: boolean }>(
+    currentBody: string,
+    commandName: NativeReplyDirectiveCommand,
+    extract: (value: string) => T,
+  ): T =>
+    !nativeCommand || nativeCommand === commandName
+      ? extract(currentBody)
+      : ({ cleaned: currentBody, hasDirective: false } as T);
   const {
     cleaned: thinkCleaned,
     thinkLevel,
     rawLevel: rawThinkLevel,
     hasDirective: hasThinkDirective,
-  } = extractThinkDirective(body);
+  } = parseScopedDirective(body, "think", (value) =>
+    extractThinkDirective(value, { strict: nativeCommand === "think" }),
+  );
   const {
     cleaned: verboseCleaned,
     verboseLevel,
     rawLevel: rawVerboseLevel,
     hasDirective: hasVerboseDirective,
-  } = extractVerboseDirective(thinkCleaned);
+  } = parseScopedDirective(thinkCleaned, "verbose", (value) =>
+    extractVerboseDirective(value, { strict: nativeCommand === "verbose" }),
+  );
   const {
     cleaned: traceCleaned,
     traceLevel,
     rawLevel: rawTraceLevel,
     hasDirective: hasTraceDirective,
-  } = extractTraceDirective(verboseCleaned);
+  } = parseScopedDirective(verboseCleaned, "trace", (value) =>
+    extractTraceDirective(value, { strict: nativeCommand === "trace" }),
+  );
   const {
     cleaned: fastCleaned,
     fastMode,
     rawLevel: rawFastMode,
     hasDirective: hasFastDirective,
-  } = extractFastDirective(traceCleaned);
+  } = parseScopedDirective(traceCleaned, "fast", (value) =>
+    extractFastDirective(value, { strict: nativeCommand === "fast" }),
+  );
   const {
     cleaned: reasoningCleaned,
     reasoningLevel,
     rawLevel: rawReasoningLevel,
     hasDirective: hasReasoningDirective,
-  } = extractReasoningDirective(fastCleaned);
+  } = parseScopedDirective(fastCleaned, "reasoning", (value) =>
+    extractReasoningDirective(value, { strict: nativeCommand === "reasoning" }),
+  );
   const {
     cleaned: elevatedCleaned,
     elevatedLevel,
@@ -129,7 +180,9 @@ export function parseInlineDirectives(
         rawLevel: undefined,
         hasDirective: false,
       }
-    : extractElevatedDirective(reasoningCleaned);
+    : parseScopedDirective(reasoningCleaned, "elevated", (value) =>
+        extractElevatedDirective(value, { strict: nativeCommand === "elevated" }),
+      );
   const {
     cleaned: execCleaned,
     execHost,
@@ -146,8 +199,8 @@ export function parseInlineDirectives(
     invalidAsk: invalidExecAsk,
     invalidNode: invalidExecNode,
     hasDirective: hasExecDirective,
-  } = extractExecDirective(elevatedCleaned);
-  const allowStatusDirective = options?.allowStatusDirective !== false;
+  } = parseScopedDirective(elevatedCleaned, "exec", extractExecDirective);
+  const allowStatusDirective = options?.allowStatusDirective !== false && !nativeCommand;
   const { cleaned: statusCleaned, hasDirective: hasStatusDirective } = allowStatusDirective
     ? extractStatusDirective(execCleaned)
     : { cleaned: execCleaned, hasDirective: false };
@@ -157,9 +210,11 @@ export function parseInlineDirectives(
     rawProfile,
     rawRuntime,
     hasDirective: hasModelDirective,
-  } = extractModelDirective(statusCleaned, {
-    aliases: options?.modelAliases,
-  });
+  } = parseScopedDirective(statusCleaned, "model", (value) =>
+    extractModelDirective(value, {
+      aliases: options?.modelAliases,
+    }),
+  );
   const {
     cleaned: queueCleaned,
     queueMode,
@@ -173,7 +228,7 @@ export function parseInlineDirectives(
     rawDrop,
     hasDirective: hasQueueDirective,
     hasOptions: hasQueueOptions,
-  } = extractQueueDirective(modelCleaned);
+  } = parseScopedDirective(modelCleaned, "queue", extractQueueDirective);
   const hasAnyDirective =
     hasThinkDirective ||
     hasVerboseDirective ||
@@ -188,6 +243,14 @@ export function parseInlineDirectives(
   // Later directives see text cleaned by earlier directives; preserve that ordering.
   return {
     cleaned: hasAnyDirective ? queueCleaned : body.trim(),
+    ...(nativeCommand && hasAnyDirective
+      ? {
+          nativeCommand: {
+            name: nativeCommand,
+            ...(queueCleaned ? { unconsumedArguments: queueCleaned } : {}),
+          },
+        }
+      : {}),
     hasThinkDirective,
     thinkLevel,
     rawThinkLevel,

--- a/src/auto-reply/reply/directives.ts
+++ b/src/auto-reply/reply/directives.ts
@@ -21,6 +21,10 @@ type ExtractedLevel<T> = {
   hasDirective: boolean;
 };
 
+type LevelDirectiveParseOptions = {
+  strict?: boolean;
+};
+
 const compileDirectivePattern = (names: readonly string[], suffix = ""): RegExp => {
   const namePattern = names.map(escapeRegExp).join("|");
   return new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)${suffix}`, "i");
@@ -38,6 +42,7 @@ const matchLevelDirective = (
   body: string,
   pattern: RegExp,
   normalize: (raw?: string) => unknown,
+  options?: LevelDirectiveParseOptions,
 ): { start: number; end: number; rawLevel?: string } | null => {
   const match = body.match(pattern);
   if (!match || match.index === undefined) {
@@ -56,13 +61,16 @@ const matchLevelDirective = (
     }
   }
   const argStart = i;
-  while (i < body.length && /[A-Za-z-]/.test(body.charAt(i))) {
+  while (
+    i < body.length &&
+    (options?.strict ? !/\s/.test(body.charAt(i)) : /[A-Za-z-]/.test(body.charAt(i)))
+  ) {
     i += 1;
   }
   const candidate = i > argStart ? body.slice(argStart, i) : undefined;
   if (
     candidate !== undefined &&
-    (normalize(candidate) !== undefined || body.slice(i).trim().length === 0)
+    (options?.strict || normalize(candidate) !== undefined || body.slice(i).trim().length === 0)
   ) {
     return { start, end: i, rawLevel: candidate };
   }
@@ -73,8 +81,9 @@ const extractLevelDirective = <T>(
   body: string,
   pattern: RegExp,
   normalize: (raw?: string) => T | undefined,
+  options?: LevelDirectiveParseOptions,
 ): ExtractedLevel<T> => {
-  const match = matchLevelDirective(body, pattern, normalize);
+  const match = matchLevelDirective(body, pattern, normalize, options);
   if (!match) {
     return { cleaned: body.trim(), hasDirective: false };
   }
@@ -106,7 +115,10 @@ const extractSimpleDirective = (
   };
 };
 
-export function extractThinkDirective(body?: string): {
+export function extractThinkDirective(
+  body?: string,
+  options?: LevelDirectiveParseOptions,
+): {
   cleaned: string;
   thinkLevel?: ThinkLevel;
   rawLevel?: string;
@@ -115,7 +127,12 @@ export function extractThinkDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, THINK_DIRECTIVE_PATTERN, normalizeThinkLevel);
+  const extracted = extractLevelDirective(
+    body,
+    THINK_DIRECTIVE_PATTERN,
+    normalizeThinkLevel,
+    options,
+  );
   return {
     cleaned: extracted.cleaned,
     thinkLevel: extracted.level,
@@ -124,7 +141,10 @@ export function extractThinkDirective(body?: string): {
   };
 }
 
-export function extractVerboseDirective(body?: string): {
+export function extractVerboseDirective(
+  body?: string,
+  options?: LevelDirectiveParseOptions,
+): {
   cleaned: string;
   verboseLevel?: VerboseLevel;
   rawLevel?: string;
@@ -133,7 +153,12 @@ export function extractVerboseDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, VERBOSE_DIRECTIVE_PATTERN, normalizeVerboseLevel);
+  const extracted = extractLevelDirective(
+    body,
+    VERBOSE_DIRECTIVE_PATTERN,
+    normalizeVerboseLevel,
+    options,
+  );
   return {
     cleaned: extracted.cleaned,
     verboseLevel: extracted.level,
@@ -142,7 +167,10 @@ export function extractVerboseDirective(body?: string): {
   };
 }
 
-export function extractTraceDirective(body?: string): {
+export function extractTraceDirective(
+  body?: string,
+  options?: LevelDirectiveParseOptions,
+): {
   cleaned: string;
   traceLevel?: TraceLevel;
   rawLevel?: string;
@@ -151,7 +179,12 @@ export function extractTraceDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, TRACE_DIRECTIVE_PATTERN, normalizeTraceLevel);
+  const extracted = extractLevelDirective(
+    body,
+    TRACE_DIRECTIVE_PATTERN,
+    normalizeTraceLevel,
+    options,
+  );
   return {
     cleaned: extracted.cleaned,
     traceLevel: extracted.level,
@@ -160,7 +193,10 @@ export function extractTraceDirective(body?: string): {
   };
 }
 
-export function extractFastDirective(body?: string): {
+export function extractFastDirective(
+  body?: string,
+  options?: LevelDirectiveParseOptions,
+): {
   cleaned: string;
   fastMode?: FastMode;
   rawLevel?: string;
@@ -169,7 +205,7 @@ export function extractFastDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, FAST_DIRECTIVE_PATTERN, normalizeFastMode);
+  const extracted = extractLevelDirective(body, FAST_DIRECTIVE_PATTERN, normalizeFastMode, options);
   return {
     cleaned: extracted.cleaned,
     fastMode: extracted.level,
@@ -178,7 +214,10 @@ export function extractFastDirective(body?: string): {
   };
 }
 
-export function extractElevatedDirective(body?: string): {
+export function extractElevatedDirective(
+  body?: string,
+  options?: LevelDirectiveParseOptions,
+): {
   cleaned: string;
   elevatedLevel?: ElevatedLevel;
   rawLevel?: string;
@@ -187,7 +226,12 @@ export function extractElevatedDirective(body?: string): {
   if (!body) {
     return { cleaned: "", hasDirective: false };
   }
-  const extracted = extractLevelDirective(body, ELEVATED_DIRECTIVE_PATTERN, normalizeElevatedLevel);
+  const extracted = extractLevelDirective(
+    body,
+    ELEVATED_DIRECTIVE_PATTERN,
+    normalizeElevatedLevel,
+    options,
+  );
   return {
     cleaned: extracted.cleaned,
     elevatedLevel: extracted.level,
@@ -196,7 +240,10 @@ export function extractElevatedDirective(body?: string): {
   };
 }
 
-export function extractReasoningDirective(body?: string): {
+export function extractReasoningDirective(
+  body?: string,
+  options?: LevelDirectiveParseOptions,
+): {
   cleaned: string;
   reasoningLevel?: ReasoningLevel;
   rawLevel?: string;
@@ -209,6 +256,7 @@ export function extractReasoningDirective(body?: string): {
     body,
     REASONING_DIRECTIVE_PATTERN,
     normalizeReasoningLevel,
+    options,
   );
   return {
     cleaned: extracted.cleaned,

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -14,6 +14,7 @@ import type { CommandContext } from "./commands-types.js";
 import { isDirectiveOnly } from "./directive-handling.directive-only.js";
 import { resolveModelRuntimeDirective } from "./directive-handling.model-runtime.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
+import { maybeHandleUnexpectedNativeDirectiveArguments } from "./directive-handling.native.js";
 import type { ApplyInlineDirectivesFastLaneParams } from "./directive-handling.params.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
@@ -314,6 +315,15 @@ export async function applyInlineDirectiveOverrides(params: {
     commandAuthorized: command.isAuthorizedSender,
     senderIsOwner: command.senderIsOwner,
   };
+
+  // Model-only directives have a focused persistence service; reject leftovers before that mutation.
+  if (directives.nativeCommand?.name === "model") {
+    const unexpectedNativeArguments = maybeHandleUnexpectedNativeDirectiveArguments(directives);
+    if (unexpectedNativeArguments) {
+      typing.cleanup();
+      return { kind: "reply", reply: unexpectedNativeArguments };
+    }
+  }
 
   if (
     isDirectiveOnly({

--- a/src/auto-reply/reply/get-reply-directives-utils.ts
+++ b/src/auto-reply/reply/get-reply-directives-utils.ts
@@ -22,6 +22,7 @@ const CLEARED_EXEC_FIELDS = {
 export function clearInlineDirectives(cleaned: string): InlineDirectives {
   return {
     cleaned,
+    nativeCommand: undefined,
     hasThinkDirective: false,
     thinkLevel: undefined,
     rawThinkLevel: undefined,

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -36,8 +36,11 @@ import {
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveBlockStreamingChunking } from "./block-streaming.js";
 import { buildCommandContext } from "./commands-context.js";
-import { type InlineDirectives, parseInlineDirectives } from "./directive-handling.parse.js";
-import { maybeHandleQueueDirective } from "./directive-handling.queue-validation.js";
+import {
+  type InlineDirectives,
+  parseInlineDirectives,
+  resolveNativeReplyDirectiveCommand,
+} from "./directive-handling.parse.js";
 import {
   reserveSkillCommandNames,
   resolveConfiguredDirectiveAliases,
@@ -273,29 +276,24 @@ export async function resolveReplyDirectives(params: {
     (alias) => !reservedCommands.has(normalizeLowercaseStringOrEmpty(alias)),
   );
   const allowStatusDirective = allowTextCommands && command.isAuthorizedSender;
+  const commandTurn = resolveCommandTurnContext(ctx);
+  const nativeDirectiveCommand =
+    command.isAuthorizedSender && isNativeCommandTurn(commandTurn) && commandTurn.commandName
+      ? resolveNativeReplyDirectiveCommand(
+          (await loadCommandsRegistry()).findCommandByNativeName(
+            commandTurn.commandName,
+            command.channel,
+            {
+              includeBundledChannelFallback: false,
+            },
+          )?.key,
+        )
+      : undefined;
   let parsedDirectives = parseInlineDirectives(commandText, {
     modelAliases: configuredAliases,
     allowStatusDirective,
+    nativeCommand: nativeDirectiveCommand,
   });
-  const commandTurn = resolveCommandTurnContext(ctx);
-  if (
-    command.isAuthorizedSender &&
-    isNativeCommandTurn(commandTurn) &&
-    commandTurn.commandName === "queue" &&
-    parsedDirectives.hasQueueDirective
-  ) {
-    // Native command arguments belong to the command, not to an inline prompt;
-    // validate them before mixed-text cleanup can erase an invalid queue mode.
-    const queueReply = maybeHandleQueueDirective({
-      directives: parsedDirectives,
-      cfg,
-      channel: command.channel,
-      sessionEntry: targetSessionEntry,
-    });
-    if (queueReply) {
-      return { kind: "reply", reply: markCommandReplyForDelivery(queueReply) };
-    }
-  }
   const hasInlineStatus =
     parsedDirectives.hasStatusDirective && parsedDirectives.cleaned.trim().length > 0;
   if (hasInlineStatus) {
@@ -329,7 +327,7 @@ export async function resolveReplyDirectives(params: {
     parsedDirectives.hasExecDirective ||
     parsedDirectives.hasModelDirective ||
     parsedDirectives.hasQueueDirective;
-  if (hasInlineDirective) {
+  if (hasInlineDirective && !parsedDirectives.nativeCommand) {
     const stripped = stripStructuralPrefixes(parsedDirectives.cleaned);
     const noMentions = isGroup ? stripMentions(stripped, ctx, cfg, agentId) : stripped;
     if (noMentions.trim().length > 0) {

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -43,10 +43,9 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     handleCommandsMock.mockReset();
   });
 
-  it("returns native queue validation instead of discarding trailing command arguments", async () => {
+  async function resolveNativeDirectiveCommand(body: string) {
     handleCommandsMock.mockResolvedValue({ shouldContinue: true });
-
-    const body = "/queue Can you diagnose this?";
+    const commandName = body.slice(1).split(/\s+/, 1)[0] ?? "";
     const typing = createTypingController();
     const result = await maybeResolveNativeSlashCommandFastReply({
       ctx: buildTestCtx({
@@ -58,19 +57,20 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
         CommandAuthorized: true,
         Provider: "telegram",
         Surface: "telegram",
+        GatewayClientScopes: ["operator.admin"],
         SessionKey: "telegram:slash:123",
         CommandTargetSessionKey: "agent:main:telegram:123",
         CommandTurn: {
           kind: "native",
           source: "native",
           authorized: true,
-          commandName: "queue",
+          commandName,
           body,
         },
       }),
       cfg: markCompleteReplyConfig({
         session: {
-          store: path.join(tempDirs.make("openclaw-native-queue-"), "sessions.json"),
+          store: path.join(tempDirs.make("openclaw-native-directive-"), "sessions.json"),
         },
       } as OpenClawConfig),
       agentId: "main",
@@ -86,6 +86,12 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
       typing,
     });
 
+    return { result, typing };
+  }
+
+  it("returns native queue validation instead of discarding trailing command arguments", async () => {
+    const { result, typing } = await resolveNativeDirectiveCommand("/queue Can you diagnose this?");
+
     expect(result).toEqual({
       handled: true,
       reply: expect.objectContaining({
@@ -94,6 +100,69 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
     });
     expect(handleCommandsMock).toHaveBeenCalledOnce();
     expect(typing.cleanup).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      command: "/think about my deployment plan",
+      expected: 'Unrecognized thinking level "about".',
+    },
+    {
+      command: "/verbose explain quantum computing",
+      expected: 'Unrecognized verbose level "explain".',
+    },
+    {
+      command: "/trace banana please",
+      expected: 'Unrecognized trace level "banana".',
+    },
+    {
+      command: "/fast bananas please",
+      expected: 'Unrecognized fast mode "bananas".',
+    },
+    {
+      command: "/reasoning nonsense please",
+      expected: 'Unrecognized reasoning level "nonsense".',
+    },
+  ])("validates every native directive argument: $command", async ({ command, expected }) => {
+    const { result } = await resolveNativeDirectiveCommand(command);
+
+    expect(result).toEqual({
+      handled: true,
+      reply: expect.objectContaining({ text: expect.stringContaining(expected) }),
+    });
+  });
+
+  it.each([
+    { command: "/queue collect please help", expected: 'Unexpected argument "please" for /queue.' },
+    { command: "/think high please", expected: 'Unexpected argument "please" for /think.' },
+    { command: "/verbose on please", expected: 'Unexpected argument "please" for /verbose.' },
+    { command: "/fast on please", expected: 'Unexpected argument "please" for /fast.' },
+    {
+      command: "/reasoning on please",
+      expected: 'Unexpected argument "please" for /reasoning.',
+    },
+    { command: "/exec host=node please", expected: 'Unexpected argument "please" for /exec.' },
+  ])(
+    "rejects trailing prose instead of dropping native command $command",
+    async ({ command, expected }) => {
+      const { result } = await resolveNativeDirectiveCommand(command);
+
+      expect(result).toEqual({
+        handled: true,
+        reply: expect.objectContaining({ text: expected }),
+      });
+    },
+  );
+
+  it("keeps recognized native settings commands isolated from nested directives", async () => {
+    const { result } = await resolveNativeDirectiveCommand("/queue /think high");
+
+    expect(result).toEqual({
+      handled: true,
+      reply: expect.objectContaining({
+        text: expect.stringContaining('Unrecognized queue mode "/think"'),
+      }),
+    });
   });
 
   it("marks native /compact terminal replies for delivery under message_tool_only (#90185)", async () => {

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -40,6 +40,7 @@ const createTypingController = (): TypingController => ({
 
 describe("maybeResolveNativeSlashCommandFastReply", () => {
   beforeEach(() => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     handleCommandsMock.mockReset();
   });
 

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -339,7 +339,7 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
     skillFilter: params.skillFilter,
   });
   if (directiveResult.kind === "reply") {
-    params.typing.cleanup();
+    // The canonical directive owner already finalizes typing for every terminal reply.
     return { handled: true, reply: markCommandReplyForDelivery(directiveResult.reply) };
   }
 


### PR DESCRIPTION
Related: #116688
Follow-up to #116726

## What Problem This Solves

Fixes an issue where Telegram, Discord, and Slack users invoking native session-settings commands with malformed or trailing arguments could lose those arguments, fall through to ordinary message handling, and receive misleading model-failure replies. Telegram's durable ingress also discarded each command's terminal processing outcome because grammY `handleUpdate` returns `void`.

## Why This Change Was Made

Resolve native directives from the existing command registry, parse only the explicitly invoked command in strict command mode, and route validation through the canonical directive-only pipeline without duplicating queue policy. Reuse the ingress-owned Telegram processing frame through bot middleware and return its recorded outcome to the durable drain while preserving skipped, retryable, and deferred-adoption semantics.

## User Impact

Native `/queue`, `/think`, `/verbose`, `/trace`, `/fast`, `/reasoning`, `/elevated`, `/exec`, and `/model` commands now either perform their documented setting change or return a precise argument error. Ordinary inline prose semantics remain unchanged. Telegram command updates now produce explicit durable processing outcomes.

## Evidence

- Blacksmith Testbox: 284 focused command/parser, Telegram replay/ingress, and QA-catalog tests passed.
- Blacksmith Testbox: the complete CI-equivalent auto-reply dispatch shard passed 992 tests across 31 files, including the reproduced cross-file fast-runtime interaction.
- Full `pnpm check:changed`: all-project TypeScript, core/plugin/script lint, dead-export, SDK ownership, import-cycle, and policy gates passed.
- `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`: production and private-QA bundles passed.
- Structured autoreview: clean; no accepted/actionable findings.
- Expanded `telegram-queue-invalid-mode` real Telegram QA scenario covers invalid queue modes, unexpected trailing queue arguments, and invalid thinking levels.
- Current production already contained 517 `OPENCLAW_*` variables while its checked-in ratchet still said 518; aligned the required budget with the verified source count.

## Live Telegram Proof

[Mantis Telegram Live run 30627149777](https://github.com/openclaw/openclaw/actions/runs/30627149777) passed the real Telegram scenario using Convex-leased credentials and AWS Crabbox. The exact final reviewed PR head `bb8d9dc0e9ebe67c8387c13ccd4a3d0e210c344c` passed the real Telegram scenario after merge.

- `/queue Can you diagnose this?` → `Unrecognized queue mode "Can". Valid modes: steer, followup, collect, interrupt.`
- `/queue collect please help` → `Unexpected argument "please" for /queue.`
- `/think about my deployment plan` → `Unrecognized thinking level "about". Valid levels: default, off, minimal, low, medium, high, xhigh, max, ultra.`
- Scenario outcome: 1 passed, 0 failed; all three command steps passed without a model-failure fallback.
- [Redacted Telegram screenshot](https://artifacts.openclaw.ai/mantis/telegram-live/pr-116773/run-30627149777-1/telegram-live-desktop.png)
- [Animated Telegram proof](https://artifacts.openclaw.ai/mantis/telegram-live/pr-116773/run-30627149777-1/telegram-live-preview.gif)
- [Full evidence artifact](https://github.com/openclaw/openclaw/actions/runs/30627149777/artifacts/8792471530)
