### PR TITLE
fix(agents): keep resumed turns active after stale terminal events

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -1,3 +1,3 @@
 # Distinct OPENCLAW_* names in production source under src, packages, and extensions.
 # Ratchet: lower this number when cleanup removes names; never raise it.
-518
+517

--- a/src/agents/main-session-recovery-lifecycle.ts
+++ b/src/agents/main-session-recovery-lifecycle.ts
@@ -113,6 +113,18 @@ export function projectMainSessionRecoveryLifecycle(params: {
       )
     : runs;
   if (settlesRecovery) {
+    if (
+      matchesFence &&
+      lifecycleGeneration !== params.currentLifecycleGeneration &&
+      remaining?.some(
+        (run) =>
+          run.runId === runId && run.lifecycleGeneration === params.currentLifecycleGeneration,
+      )
+    ) {
+      // Older generations share the live owner's run id. Consume only their
+      // fence; recording that id as terminal would also tombstone its replacement.
+      return { action: "apply", patch: { restartRecoveryRuns: remaining } };
+    }
     const foregroundClaims = params.entry?.mainRestartRecovery?.foregroundClaims;
     const foregroundOwnerClaimId =
       runId &&

--- a/src/agents/main-session-recovery-run-ownership.test.ts
+++ b/src/agents/main-session-recovery-run-ownership.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from "vitest";
 import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js";
 import { projectMainSessionRecoveryLifecycle } from "./main-session-recovery-lifecycle.js";
 
-function recoveryEntry(params?: { hasCurrentOwner?: boolean }): SessionEntry {
+function recoveryEntry(params?: {
+  hasCurrentOwner?: boolean;
+  ownsDelivery?: boolean;
+}): SessionEntry {
   return {
     sessionId: "session-1",
     updatedAt: 100,
     status: "running",
     abortedLastRun: false,
+    ...(params?.ownsDelivery ? { restartRecoveryDeliveryRunId: "recovery" } : {}),
     restartRecoveryRuns: [
       { runId: "recovery", lifecycleGeneration: "generation-old" },
       { runId: "recovery", lifecycleGeneration: "generation-current" },
@@ -52,11 +56,14 @@ describe("main-session recovery run ownership", () => {
     });
   });
 
-  it("does not let an older same-id terminal settle its replacement generation", () => {
+  it.each([
+    { name: "admitted delivery owner", params: { ownsDelivery: true } },
+    { name: "foreground owner", params: { hasCurrentOwner: true, ownsDelivery: true } },
+  ])("does not let an older same-id terminal settle or tombstone its $name", ({ params }) => {
     expect(
       projectMainSessionRecoveryLifecycle({
         currentLifecycleGeneration: "generation-current",
-        entry: recoveryEntry({ hasCurrentOwner: true }),
+        entry: recoveryEntry(params),
         event: {
           runId: "recovery",
           lifecycleGeneration: "generation-old",
@@ -68,8 +75,25 @@ describe("main-session recovery run ownership", () => {
       action: "apply",
       patch: {
         restartRecoveryRuns: [{ runId: "recovery", lifecycleGeneration: "generation-current" }],
-        restartRecoveryTerminalRunIds: ["recovery"],
       },
     });
+  });
+
+  it("suppresses a duplicate older terminal after its fence has been consumed", () => {
+    const entry = recoveryEntry({ ownsDelivery: true });
+    entry.restartRecoveryRuns = [{ runId: "recovery", lifecycleGeneration: "generation-current" }];
+
+    expect(
+      projectMainSessionRecoveryLifecycle({
+        currentLifecycleGeneration: "generation-current",
+        entry,
+        event: {
+          runId: "recovery",
+          lifecycleGeneration: "generation-old",
+          data: { phase: "end" },
+        },
+        snapshotPatch: { status: "done", abortedLastRun: false },
+      }),
+    ).toEqual({ action: "suppress" });
   });
 });

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -434,6 +434,45 @@ describe("session lifecycle state", () => {
     expect(persisted.mainRestartRecovery).toBeUndefined();
   });
 
+  it("keeps an active recovery when an older same-run terminal arrives", async () => {
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const persisted = await persistLifecycle(
+      {
+        sessionId: "session-id",
+        updatedAt: 1_000,
+        startedAt: 1_050,
+        status: "running",
+        abortedLastRun: false,
+        restartRecoveryDeliveryRunId: "recovery-run",
+        restartRecoveryRuns: [
+          { runId: "recovery-run", lifecycleGeneration: "pre-restart" },
+          { runId: "recovery-run", lifecycleGeneration },
+        ],
+        mainRestartRecovery: {
+          cycleId: "cycle-1",
+          revision: 5,
+          chargedAttempts: 2,
+        },
+      },
+      {
+        ts: 2_000,
+        sessionId: "session-id",
+        runId: "recovery-run",
+        lifecycleGeneration: "pre-restart",
+        data: { phase: "end", endedAt: 1_800 },
+      },
+    );
+
+    expect(persisted).toMatchObject({
+      status: "running",
+      abortedLastRun: false,
+      restartRecoveryDeliveryRunId: "recovery-run",
+      restartRecoveryRuns: [{ runId: "recovery-run", lifecycleGeneration }],
+      mainRestartRecovery: { cycleId: "cycle-1" },
+    });
+    expect(persisted.restartRecoveryTerminalRunIds).toBeUndefined();
+  });
+
   it("does not settle a foreground owner from a stale lifecycle generation", async () => {
     const persisted = await persistLifecycle(
       {


### PR DESCRIPTION
## What Problem This Solves

A delayed terminal event from an older Gateway lifecycle generation can carry the same logical run ID as the recovery currently running in the replacement generation. The existing recovery projection then either clears the active delivery owner and marks its session done, or records that same run ID as terminal while a foreground owner is still active.

Both outcomes silently invalidate a live recovery after a restart.

Follow-up to #116728 and the residual lifecycle race reported in #116694.

## Why This Change Was Made

- Fence terminal settlement by lifecycle generation before terminal IDs or recovery-owner cleanup are projected.
- Consume only the matching stale-generation fence when a current-generation fence still owns the same logical run ID.
- Preserve the existing paths for different run IDs, current-generation terminals, reservations, foreground claims, and normal owner cleanup.
- Add both owner-level red-before-green regressions and a Gateway session-persistence regression that proves the active SQLite-backed session remains running and is not tombstoned.
- Correct the independently reproduced pre-existing `main` environment-variable ratchet from 518 to the actual 517 production names. Without this mechanical baseline correction, every source-touching changed-code gate fails before lint or type checking.

## User Impact

Telegram and other recovered channel turns continue after a Gateway restart even when an old listener delivers a late terminal event for the same logical run. The recovered turn is no longer silently marked complete or deduplicated as terminal while it is still active.

## Verification

- Red before fix: both same-run-ID stale-generation cases fail against current `main` (admitted delivery owner clears live recovery; foreground owner falsely records the live run ID as terminal).
- Duplicate stale-terminal regression: after the first stale fence is consumed, the pre-existing unmatched-fence branch suppresses repeated stale terminal deliveries instead of settling the active owner.
- Remote Blacksmith Testbox: **151 passing tests across six files / five Vitest projects**, covering recovery ownership, recovery state, recovery store, Gateway persistence, session snapshot merging, and reply admission. Lease `tbx_01kyvvvzy7phyjc0q37j7mwyqg`; proof run: https://github.com/openclaw/openclaw/actions/runs/30624056003
- Structured Codex autoreview: no actionable findings; the stale-generation fix is narrowly scoped and preserves distinct-run/current-generation behavior.
- Environment guard: `OPENCLAW_* count 517/517` after ratcheting the stale pre-existing budget.
- Gateway persistence regression: `src/gateway/session-lifecycle-state.test.ts` confirms the older-generation terminal preserves `status: "running"`, delivery ownership, the current fence, and the active recovery aggregate without writing a terminal tombstone.
- Upstream Codex contract inspected directly: `codex-rs/app-server/src/thread_state.rs:91-131` and `:154-176` separate listener generation from logical terminal turn identity; `codex-rs/app-server/src/request_processors/turn_processor.rs:1418-1458` validates the logical active turn; `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:306-324` documents rejoining an already-running logical thread.

## After-Fix Real Gateway Behavior Proof

Exact-head CI passed on `39674d9d70d4eadda9d825ffe5e0a124d2fbff0b`: https://github.com/openclaw/openclaw/actions/runs/30624520254. All four `QA Smoke CI` profiles passed using real ephemeral Gateways, real channel adapters, and Crabline local provider servers.

The downloadable `qa-smoke-profile-profile-4-of-4-30624520254-1` artifact includes `matrix/qa-suite-report.md` with these **three passing real-Gateway restart scenarios**:

```text
Matrix room continues after restart recovery:
  MATRIX_QA_RESTART_FIRST_197A595D
  -> Gateway restart
  -> MATRIX_QA_RESTART_SECOND_8541AC05
  -> MATRIX_QA_RESTART_THIRD_C08A88BA

Matrix restart replay dedupe:
  MATRIX_QA_REPLAY_DEDUPE_CE5B2EE8
  -> Gateway restart
  -> MATRIX_QA_REPLAY_DEDUPE_FRESH_891A3980

Matrix lane resumes after Gateway restart:
  MATRIX_QA_RESTART_BEFORE_A1EA794B
  -> Gateway restart
  -> MATRIX_QA_RESTART_AFTER_0058FF29
```

These after-fix traces prove that a real Gateway restarts, the real Matrix channel adapter recovers the session, fresh subsequent channel turns are admitted, multiple post-restart replies complete, and replayed input is deduplicated. The targeted Gateway persistence regression separately drives the exact older-generation/same-run-ID terminal ordering and verifies the active session remains running without a terminal tombstone.

Machine-readable changed-path verdict:

```json
{
  "head": "39674d9d70d4eadda9d825ffe5e0a124d2fbff0b",
  "gateway": "real ephemeral OpenClaw Gateway",
  "channel": "real Matrix channel adapter with Crabline local provider API",
  "restartScenarios": 3,
  "freshPostRestartTurnsAdmitted": true,
  "multipleFollowUpRepliesComplete": true,
  "restartReplayDeduplicated": true,
  "sameRunOlderGenerationTerminalPersistsActiveReplacement": true,
  "terminalTombstoneWrittenForActiveReplacement": false,
  "status": "pass"
}
```

Current-base decision: the PR remains GitHub-mergeable and the complete CI matrix passed on the exact reviewed head. A documentation-only `main` advance is advisory; repository landing policy explicitly prohibits rebasing solely because `main` advanced, so no unnecessary head/CI churn is introduced.
