### PR TITLE
fix(browser): keep Browser Copilot locked to its shared tab

### DIFF
--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -489,11 +489,15 @@ describe("createCopilotToolBridge", () => {
 
     it("forwards identity, owner/policy, and channel/routing fields from attemptParams", async () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
+      const toolBindings = {
+        browser: { kind: "tab", tabId: 7, target: "host", profile: "chrome", targetId: "target-7" },
+      };
 
       await createCopilotToolBridge({
         agentId: "agent-1",
         attemptParams: {
           agentAccountId: "acct-1",
+          toolBindings,
           senderId: "sender-1",
           senderName: "Ada",
           senderUsername: "ada",
@@ -529,6 +533,7 @@ describe("createCopilotToolBridge", () => {
       const opts = getOpts();
       expect(opts).toMatchObject({
         agentAccountId: "acct-1",
+        toolBindings,
         senderId: "sender-1",
         senderName: "Ada",
         senderUsername: "ada",

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -378,6 +378,7 @@ function buildOpenClawCodingToolsOptions(
       elevated: a.bashElevated,
     },
     messageProvider: a.messageProvider ?? a.messageChannel,
+    toolBindings: a.toolBindings,
     chatType: a.chatType,
     agentAccountId: a.agentAccountId,
     messageTo: a.messageTo,

--- a/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts
@@ -237,14 +237,18 @@ describe("runEmbeddedAgent before_agent_reply seam", () => {
     },
   );
 
-  it("forwards one-shot auxiliary-run flags into the embedded attempt", async () => {
+  it("forwards one-shot auxiliary-run flags and tool bindings into the embedded attempt", async () => {
     // Auxiliary-run flags are request-scoped; they must pass through to the
     // first attempt without becoming persistent session settings.
+    const toolBindings = {
+      browser: { kind: "tab", tabId: 7, target: "host", profile: "chrome", targetId: "target-7" },
+    };
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult());
 
     await runEmbeddedAgent({
       ...overflowBaseRunParams,
       trigger: "user",
+      toolBindings,
       disableTrajectory: true,
       modelRun: true,
       promptMode: "none",
@@ -254,6 +258,7 @@ describe("runEmbeddedAgent before_agent_reply seam", () => {
     expect(attemptParams.disableTrajectory).toBe(true);
     expect(attemptParams.modelRun).toBe(true);
     expect(attemptParams.promptMode).toBe("none");
+    expect(attemptParams).toMatchObject({ toolBindings });
   });
 
   it("forwards one-shot bundle MCP cleanup into the embedded attempt", async () => {

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -190,6 +190,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     messageChannel: params.messageChannel,
     messageProvider: params.messageProvider,
     clientCaps: params.clientCaps,
+    toolBindings: params.toolBindings,
     chatType: params.chatType,
     agentAccountId: params.agentAccountId,
     messageTo: params.messageTo,


### PR DESCRIPTION
Related: #116745

## What Problem This Solves

Users asking Chrome's tab-bound Browser Copilot about a shared page could receive an unrestricted browser tool. The selected tab disappeared before the model's tools were registered, allowing browser-wide actions such as `profiles` and making the assistant incorrectly report that no page was shared.

## Why This Change Was Made

Preserve the already validated, request-scoped browser capability through both the canonical embedded-attempt boundary and the GitHub Copilot agent-runtime bridge. This restores the existing per-tab authorization contract without caching bindings, introducing configuration, widening permissions, or changing the protocol.

## User Impact

Browser Copilot stays pinned to the page the user shared, and unsupported browser-wide actions remain unavailable across supported agent runtimes.

## Evidence

- Exact root cause: Gateway and reply orchestration already carry `GatewayRunToolBindings`, but `dispatchEmbeddedRunAttempt` dropped the field when constructing `EmbeddedRunAttemptParams`; GitHub Copilot's tool bridge independently omitted the same field.
- Regression coverage augments the existing real embedded-runner forwarding test and the existing GitHub Copilot tool-bridge context-parity test.
- Production delta: +2 lines; focused test delta: +10 net lines.
- `git diff --check`: clean.
- Structured autoreview: no actionable findings.
- Independent read-only review: original supported-runtime bypass identified and repaired; remaining findings independently verified as pre-existing, separately scoped issues.
- Trusted Blacksmith Testbox `tbx_01kyvvvzb4mtztay2vpbcwxv92`: 91 focused tests passed (13 embedded-runner, 78 GitHub Copilot); exact run https://github.com/openclaw/openclaw/actions/runs/30624055628.
- Targeted oxfmt and oxlint: four changed files passed; 0 warnings or errors.
- Reporter: @RothElektronik.
