### PR TITLE
fix(browser): allow page extraction in tab-bound runs

### DIFF
--- a/extensions/browser/src/browser-tool-binding.test.ts
+++ b/extensions/browser/src/browser-tool-binding.test.ts
@@ -29,6 +29,61 @@ describe("browser tab tool binding", () => {
     });
   });
 
+  it("pins page extraction to the trusted tab and browser route", () => {
+    expect(
+      applyBrowserTabToolBinding(
+        { action: "extract", query: "When does the release ship?" },
+        binding,
+      ),
+    ).toEqual({
+      action: "extract",
+      query: "When does the release ship?",
+      target: "node",
+      node: "desktop",
+      profile: "chrome",
+      targetId: "target-a",
+    });
+  });
+
+  it.each([
+    {
+      name: "foreign tab",
+      input: { targetId: "target-b" },
+      error: "cannot override its run-bound tab target",
+    },
+    {
+      name: "foreign profile",
+      input: { profile: "other" },
+      error: "cannot override its run-bound profile",
+    },
+    {
+      name: "foreign node",
+      input: { node: "other" },
+      error: "cannot override its run-bound node",
+    },
+    {
+      name: "foreign target",
+      input: { target: "host" },
+      error: "cannot override its run-bound target",
+    },
+  ])("rejects page extraction on a $name", ({ input, error }) => {
+    expect(() =>
+      applyBrowserTabToolBinding(
+        { action: "extract", query: "When does the release ship?", ...input },
+        binding,
+      ),
+    ).toThrow(error);
+  });
+
+  it.each(["open", "start", "profiles"])(
+    "keeps the browser-wide %s action unavailable to bound runs",
+    (action) => {
+      expect(() => applyBrowserTabToolBinding({ action }, binding)).toThrow(
+        "unavailable in a tab-bound run",
+      );
+    },
+  );
+
   it("rejects route, tab, and browser-wide action escapes", () => {
     expect(() =>
       applyBrowserTabToolBinding({ action: "snapshot", targetId: "target-b" }, binding),

--- a/extensions/browser/src/browser-tool-binding.test.ts
+++ b/extensions/browser/src/browser-tool-binding.test.ts
@@ -45,52 +45,20 @@ describe("browser tab tool binding", () => {
     });
   });
 
-  it.each([
-    {
-      name: "foreign tab",
-      input: { targetId: "target-b" },
-      error: "cannot override its run-bound tab target",
-    },
-    {
-      name: "foreign profile",
-      input: { profile: "other" },
-      error: "cannot override its run-bound profile",
-    },
-    {
-      name: "foreign node",
-      input: { node: "other" },
-      error: "cannot override its run-bound node",
-    },
-    {
-      name: "foreign target",
-      input: { target: "host" },
-      error: "cannot override its run-bound target",
-    },
-  ])("rejects page extraction on a $name", ({ input, error }) => {
-    expect(() =>
-      applyBrowserTabToolBinding(
-        { action: "extract", query: "When does the release ship?", ...input },
-        binding,
-      ),
-    ).toThrow(error);
-  });
-
-  it.each(["open", "start", "profiles"])(
-    "keeps the browser-wide %s action unavailable to bound runs",
-    (action) => {
-      expect(() => applyBrowserTabToolBinding({ action }, binding)).toThrow(
-        "unavailable in a tab-bound run",
-      );
-    },
-  );
-
-  it("rejects route, tab, and browser-wide action escapes", () => {
-    expect(() =>
-      applyBrowserTabToolBinding({ action: "snapshot", targetId: "target-b" }, binding),
-    ).toThrow("cannot override its run-bound tab target");
-    expect(() =>
-      applyBrowserTabToolBinding({ action: "snapshot", node: "other" }, binding),
-    ).toThrow("cannot override its run-bound node");
+  it("rejects page extraction route escapes and browser-wide actions", () => {
+    for (const [input, error] of [
+      [{ targetId: "target-b" }, "cannot override its run-bound tab target"],
+      [{ profile: "other" }, "cannot override its run-bound profile"],
+      [{ node: "other" }, "cannot override its run-bound node"],
+      [{ target: "host" }, "cannot override its run-bound target"],
+    ] as const) {
+      expect(() =>
+        applyBrowserTabToolBinding(
+          { action: "extract", query: "When does the release ship?", ...input },
+          binding,
+        ),
+      ).toThrow(error);
+    }
     expect(() => applyBrowserTabToolBinding({ action: "open" }, binding)).toThrow(
       "unavailable in a tab-bound run",
     );

--- a/extensions/browser/src/browser-tool-binding.ts
+++ b/extensions/browser/src/browser-tool-binding.ts
@@ -52,6 +52,7 @@ const TAB_BOUND_ACTIONS = new Set([
   "console",
   "dialog",
   "download",
+  "extract",
   "focus",
   "navigate",
   "pdf",

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -3353,37 +3353,16 @@ describe("browser tool extract", () => {
     });
   });
 
-  it.each([
-    {
-      name: "foreign tab",
-      input: { targetId: "target-b" },
-      error: "cannot override its run-bound tab target",
-    },
-    {
-      name: "foreign profile",
-      input: { profile: "other" },
-      error: "cannot override its run-bound profile",
-    },
-    {
-      name: "foreign node",
-      input: { node: "other" },
-      error: "cannot override its run-bound node",
-    },
-    {
-      name: "foreign target",
-      input: { target: "node" },
-      error: "cannot override its run-bound target",
-    },
-  ])("rejects extraction on a $name before browser or model access", async ({ input, error }) => {
+  it("rejects extraction from a foreign tab before browser or model access", async () => {
     const tool = createBrowserTool({ agentId: "work", runToolBinding });
 
     await expect(
       tool.execute?.("call-bound-extract-escape", {
         action: "extract",
         query: "When does the release ship?",
-        ...input,
+        targetId: "target-b",
       }),
-    ).rejects.toThrow(error);
+    ).rejects.toThrow("cannot override its run-bound tab target");
 
     expect(browserActionsMocks.browserPageContent).not.toHaveBeenCalled();
     expect(toolCommonMocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -3318,6 +3318,78 @@ describe("browser tool extract", () => {
   beforeEach(resetBrowserToolMocks);
   afterEach(() => vi.restoreAllMocks());
 
+  const runToolBinding = {
+    kind: "tab" as const,
+    tabId: 17,
+    target: "host" as const,
+    profile: "openclaw",
+    targetId: "target-a",
+  };
+
+  it("extracts from the trusted tab in a tab-bound run", async () => {
+    const tool = createBrowserTool({ agentId: "work", runToolBinding });
+
+    const result = await tool.execute?.("call-bound-extract", {
+      action: "extract",
+      query: "When does the release ship?",
+    });
+
+    expect(browserActionsMocks.browserPageContent).toHaveBeenCalledWith(undefined, {
+      targetId: "target-a",
+      profile: "openclaw",
+      timeoutMs: 60_000,
+      signal: undefined,
+    });
+    expect(toolCommonMocks.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "work",
+        useUtilityModel: true,
+        allowMissingApiKeyModes: ["aws-sdk"],
+      }),
+    );
+    expect(result?.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("Friday."),
+    });
+  });
+
+  it.each([
+    {
+      name: "foreign tab",
+      input: { targetId: "target-b" },
+      error: "cannot override its run-bound tab target",
+    },
+    {
+      name: "foreign profile",
+      input: { profile: "other" },
+      error: "cannot override its run-bound profile",
+    },
+    {
+      name: "foreign node",
+      input: { node: "other" },
+      error: "cannot override its run-bound node",
+    },
+    {
+      name: "foreign target",
+      input: { target: "node" },
+      error: "cannot override its run-bound target",
+    },
+  ])("rejects extraction on a $name before browser or model access", async ({ input, error }) => {
+    const tool = createBrowserTool({ agentId: "work", runToolBinding });
+
+    await expect(
+      tool.execute?.("call-bound-extract-escape", {
+        action: "extract",
+        query: "When does the release ship?",
+        ...input,
+      }),
+    ).rejects.toThrow(error);
+
+    expect(browserActionsMocks.browserPageContent).not.toHaveBeenCalled();
+    expect(toolCommonMocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(toolCommonMocks.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+  });
+
   it("captures, converts, and answers with the configured agent model", async () => {
     toolCommonMocks.sanitizeHtml.mockResolvedValueOnce("<main>Ships Friday.</main>");
     toolCommonMocks.htmlToMarkdown.mockReturnValueOnce({ text: "Ships **Friday**." });


### PR DESCRIPTION
Closes #116746

## What Problem This Solves

The Browser tool tells agents to use `action=extract` for page questions, but tab-bound Browser Copilot runs rejected that action before dispatch. Users could share a tab, ask about its contents, and receive:

`browser action "extract" is unavailable in a tab-bound run`

## Why This Change Was Made

The browser plugin's tab-bound action allowlist omitted the existing read-only, page-scoped `extract` action.

This adds `extract` at the plugin-owned authorization boundary. The existing binding code then pins the trusted target, node, profile, and tab before page capture or model access. No fallback path, new configuration, protocol change, or wider browser authority is introduced.

The adjacent binding-propagation defect from #116745 is no longer a prerequisite: #116778 merged as `66d5410171a717000356fcc6b375b31b1629490a` and now carries the validated request binding through tool registration.

Rejected alternatives:

- A downstream extraction exception would bypass or duplicate the central authorization gate.
- Allowing browser-wide actions would exceed the capability granted by the shared tab.
- Caching or reconstructing bindings would create a second source of truth for a security-sensitive capability.

## User Impact

Tab-bound Browser Copilot runs can extract and answer questions from the shared page. Attempts to redirect extraction to another tab, profile, node, or browser target are rejected before browser capture or model execution.

## Evidence

- Exact head: `ca8b3daad065c3f7c484ba08f4b20a61f73e3db5`
- Rebased onto `main` at `623c738d1ea9db7d3ff86c466030b04ddf65708c`
- Production delta: `+1/-0`
- Test delta: `+81/-7`; the rework removed 70 duplicated test lines while retaining every route-escape axis
- Focused proof: 155 tests passed across:
  - `extensions/browser/src/browser-tool-binding.test.ts`
  - `extensions/browser/src/browser-tool.test.ts`
  - `extensions/browser/index.test.ts`
- Security-boundary coverage proves:
  - trusted extraction is pinned to the bound target, node, profile, and tab
  - foreign tab, profile, node, and target overrides fail at the binding owner
  - a hostile foreign-tab extraction reaches neither page capture nor model preparation
  - plugin registration preserves the browser-owned run binding
- Targeted `oxfmt`, direct `oxlint`, and `git diff --check` passed
- Branch-mode autoreview: clean, no accepted/actionable findings
- Secret/private-data diff scrub: clean
- AI-assisted: yes

## Real Browser Proof

Exact-head unpacked-extension proof passed on August 3, 2026:

- Playwright 1.62.0 launched pinned Chrome 151.0.7922.34 with unpacked OpenClaw extension 2.1.0.
- Two shared tabs received distinct Chrome tab and CDP target IDs.
- Production `applyBrowserTabToolBinding` pinned extraction to alpha.
- Production extraction captured alpha exactly once and returned `ALPHA_TRUSTED_CONTENT`.
- An alpha-bound extraction targeting beta failed with `browser action cannot override its run-bound tab target`.
- The denied sibling attempt caused no second capture.
- Exact-merge focused suite: 137 tests passed across the binding and browser-tool files.

The checked-in side-panel harness still has pre-existing Chrome 151 launch-argument and `/var` path canonicalization defects. The proof harness corrected only those fixture defects while exercising the real unpacked extension relay and production binding/extraction paths.
