### PR TITLE
test(auto-reply): run dispatch suite on Windows

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts
@@ -1,5 +1,6 @@
 // Imported by dispatch-from-config.test.ts to keep its mocked suite in one Vitest module graph.
 import { AsyncResource } from "node:async_hooks";
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
@@ -1484,7 +1485,7 @@ describe("dispatchReplyFromConfig", () => {
         remoteMediaMode?: string;
       };
       expect(params.sessionKey).toBe("agent:main:imessage:direct:user");
-      expect(params.workspaceDir).toContain(".openclaw/workspace");
+      expect(params.workspaceDir).toContain(path.join(".openclaw", "workspace"));
       expect(params.remoteMediaMode).toBe("cache");
       params.ctx.media = [{ path: stagedPath, url: stagedPath, contentType: "image/jpeg" }];
       params.sessionCtx.media = params.ctx.media;

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle-and-bindings.test-utils.ts
@@ -1,5 +1,6 @@
 // Imported by dispatch-from-config.test.ts to keep its mocked suite in one Vitest module graph.
 import { AsyncResource } from "node:async_hooks";
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
@@ -1483,7 +1484,7 @@ describe("dispatchReplyFromConfig", () => {
         remoteMediaMode?: string;
       };
       expect(params.sessionKey).toBe("agent:main:imessage:direct:user");
-      expect(params.workspaceDir).toContain(".openclaw/workspace");
+      expect(params.workspaceDir).toContain(path.join(".openclaw", "workspace"));
       expect(params.remoteMediaMode).toBe("cache");
       params.ctx.media = [{ path: stagedPath, url: stagedPath, contentType: "image/jpeg" }];
       params.sessionCtx.media = params.ctx.media;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where contributors developing on Windows cannot get a clean baseline run of the auto-reply dispatch suite (`dispatch-from-config.test.ts`): two tests fail out of the box — `stages remote iMessage media before plugin-bound inbound claim metadata reaches Codex` and `routes Discord thread plugin-owned bindings by raw thread id` — and the second failure reports missing claim metadata that has nothing to do with the actual problem, sending the reader down the wrong path. Because the suite is red before any local change, genuine regressions in these two tests are invisible to a Windows contributor until Linux CI catches them.

## Why This Change Was Made

One staging assertion expects the workspace path to contain the POSIX-only string `.openclaw/workspace`, which can never match Windows separators; the expectation now goes through `path.join(".openclaw", "workspace")`, the same platform-native expectation idiom the suite's neighbors already use (`tts-audio-store.test.ts`, `managed-image-attachments.test.ts`, `entry.compile-cache.test.ts`, among others). On POSIX `path.join` produces the byte-identical string, so what Linux CI verifies does not change. The second failure is collateral from the first: the iMessage test throws inside the `stageSandboxMedia` mock before its `runInboundClaimForPluginOutcome` `mockImplementationOnce` is consumed, and the leaked one-shot mock then fires inside the Discord test that runs next — fixing the one assertion clears both. Rejected alternative: normalizing `workspaceDir` with `replaceAll("\\", "/")` before asserting — works, but diverges from the established `path.join`-expectation idiom. Intentionally out of scope: adding this suite to the curated `test:windows:ci` lane — which is also why the failure survived: Linux CI always matches the separator, and the Windows lane never runs this suite.

## User Impact

No runtime behavior change — test-only. Contributors on Windows get a green dispatch-suite baseline, so a failure in it once again means a real regression instead of platform noise. The green run below shows the remaining 309 tests in this suite are already Windows-clean — this one assertion was the suite's only blocker.

## Evidence

Behavior addressed: `dispatch-from-config.test.ts` failing 2/311 on Windows, with the second failure misattributed to claim metadata.
Real environment tested: Windows 11, Node v24.18.0, pnpm; before-run on unpatched `origin/main` `0f312542309`; the touched file is byte-identical through the PR base `27fa5a8950f` (`git log 0f312542309..27fa5a8950f -- <file>` is empty).
Before evidence: unpatched main, same command as below:

```
 FAIL  |auto-reply-reply| src/auto-reply/reply/dispatch-from-config.test.ts > dispatchReplyFromConfig > stages remote iMessage media before plugin-bound inbound claim metadata reaches Codex
AssertionError: expected 'C:\Users\Eden\AppData\Local\Temp\open…' to contain '.openclaw/workspace'
Expected: ".openclaw/workspace"
Received: "C:\Users\Eden\AppData\Local\Temp\openclaw-test-home-ZwQMXg\.openclaw\workspace"

 FAIL  |auto-reply-reply| src/auto-reply/reply/dispatch-from-config.test.ts > dispatchReplyFromConfig > routes Discord thread plugin-owned bindings by raw thread id
AssertionError: expected undefined to be '/tmp/openclaw-proof/.openclaw/media/r…'
- Expected: "/tmp/openclaw-proof/.openclaw/media/remote-cache/agent-main-imessage/photo.jpg"
+ Received: undefined

      Tests  2 failed | 309 passed (311)
```

Exact steps or command run after this patch:

```
pnpm exec vitest run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts
```

Evidence after fix:

```
 Test Files  1 passed (1)
      Tests  311 passed (311)
```

Observed result after fix: both Windows failures gone, no other test in the suite changed outcome; `oxfmt --check`, targeted oxlint, and `tsgo:core:test` pass on the touched file. The before block doubles as the red control — the change is a single test expectation, and reverting it reproduces the two failures verbatim.
What was not tested: a local POSIX run of the suite — on POSIX the expected substring is byte-identical (`path.join(".openclaw", "workspace")` evaluates to `.openclaw/workspace`), and Linux CI runs this suite on every PR.
