### PR TITLE
fix(status): show stopped channel runtimes in status and doctor

### DIFF
--- a/src/infra/channels-status-issues.test.ts
+++ b/src/infra/channels-status-issues.test.ts
@@ -143,6 +143,31 @@ describe("collectChannelStatusIssues", () => {
     });
   });
 
+  it("reports stopped configured accounts without treating unknown runtime state as stopped", () => {
+    mocks.listChannelPlugins.mockReturnValue([createPlugin("discord")]);
+
+    expect(
+      collectChannelStatusIssues({
+        channelAccounts: {
+          discord: [
+            { accountId: "stopped", enabled: true, configured: true, running: false },
+            { accountId: "unknown", enabled: true, configured: true },
+            { accountId: "disabled", enabled: false, configured: true, running: false },
+            { accountId: "unconfigured", enabled: true, configured: false, running: false },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        channel: "discord",
+        accountId: "stopped",
+        kind: "runtime",
+        message: "Channel is enabled and configured, but its runtime is not running.",
+        fix: "restart the channel or gateway",
+      },
+    ]);
+  });
+
   it("reports dead ingress even while a restart is pending", () => {
     mocks.listChannelPlugins.mockReturnValue([createPlugin("slack")]);
 

--- a/src/infra/channels-status-issues.ts
+++ b/src/infra/channels-status-issues.ts
@@ -63,36 +63,35 @@ function collectGenericRuntimeStatusIssues(
     if (health.healthy) {
       continue;
     }
-    if (health.reason === "disconnected") {
-      issues.push({
-        channel,
-        accountId,
-        kind: "runtime",
-        message: "Channel reports running, but the runtime is disconnected.",
-        fix: "restart the channel or gateway",
-      });
-      continue;
+    let message: string;
+    switch (health.reason) {
+      case "not-running":
+        // Older status snapshots can omit running; absence is not a stopped runtime.
+        if (account.running !== false) {
+          continue;
+        }
+        message = "Channel is enabled and configured, but its runtime is not running.";
+        break;
+      case "disconnected":
+        message = "Channel reports running, but the runtime is disconnected.";
+        break;
+      case "stale-socket":
+        message =
+          "Channel reports connected, but transport activity is stale; inbound delivery may be broken.";
+        break;
+      case "stuck":
+        message = "Channel runtime appears stuck with stale run activity.";
+        break;
+      default:
+        continue;
     }
-    if (health.reason === "stale-socket") {
-      issues.push({
-        channel,
-        accountId,
-        kind: "runtime",
-        message:
-          "Channel reports connected, but transport activity is stale; inbound delivery may be broken.",
-        fix: "restart the channel or gateway",
-      });
-      continue;
-    }
-    if (health.reason === "stuck") {
-      issues.push({
-        channel,
-        accountId,
-        kind: "runtime",
-        message: "Channel runtime appears stuck with stale run activity.",
-        fix: "restart the channel or gateway",
-      });
-    }
+    issues.push({
+      channel,
+      accountId,
+      kind: "runtime",
+      message,
+      fix: "restart the channel or gateway",
+    });
   }
   return issues;
 }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Related: #115326

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw channels status`, `openclaw doctor`,
or the main status overview would see no channel issue when an enabled,
configured channel runtime had stopped. This hid channels suppressed after
repeated restart failures behind a misleading healthy status.

Reported by @robingutsche in #115326.

## Why This Change Was Made

Use the existing shared channel-health decision to report explicitly stopped
runtimes and consolidate the existing runtime warning paths. Snapshots without a
known `running` value remain unchanged, and disabled or unconfigured channels
still produce no warning. Restart policy, crash-loop suppression, channel
lifecycle control, and recovery RPC behavior are intentionally outside this fix.

## User Impact

Operators now see an actionable warning to restart the affected channel or
Gateway instead of an unexplained all-clear in channel status, doctor, and the
general status overview. Existing disconnected, stale-transport, stuck-runtime,
and pending-restart warnings keep their previous behavior.

## Evidence

- Trusted Blacksmith Testbox proof:
  https://github.com/openclaw/openclaw/actions/runs/30624550345
- Focused runtime regression: `pnpm test src/infra/channels-status-issues.test.ts`
  — **1 file, 6 tests passed**, including stopped, unknown, disabled, and
  unconfigured channel accounts.
- Targeted formatting: `pnpm format:check src/infra/channels-status-issues.ts
  src/infra/channels-status-issues.test.ts` — both files passed.
- Targeted lint: `node scripts/run-oxlint.mjs
  src/infra/channels-status-issues.ts src/infra/channels-status-issues.test.ts`
  — **0 warnings, 0 errors**.
- Structured autoreview, separate independent read-only review, and secret scan
  all passed.
- Production code decreases by one line while preserving existing diagnostics.
