### PR TITLE
chore(skills): restore autonomous sweep formatting

### DIFF
--- a/.agents/skills/openclaw-autonomous-issue-sweep/SKILL.md
+++ b/.agents/skills/openclaw-autonomous-issue-sweep/SKILL.md
@@ -67,6 +67,7 @@ subagents. Keep parent-thread updates to concise progress and clickable URLs.
    mutate the shared checkout while sibling workers are active. Once isolated
    worktrees exist, independent issue owners edit, inspect, and verify in
    parallel within their own checkout.
+
 6. Keep all **64** inherited high-effort agents available, but distinguish idle
    agents from active local tool users. Start with bounded waves of **4–8**
    concurrently active code/test workers and continuously reduce or expand that


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the repository-wide formatting gate fails on current `main`, blocking unrelated pull requests that run the full formatter.

## Why This Change Was Made

Adds the missing Markdown section separator required by the canonical formatter. No skill behavior or instructions change.

## User Impact

No user-visible product behavior changes. Maintainer CI can complete the format gate again.

## Evidence

- `oxfmt .agents/skills/openclaw-autonomous-issue-sweep/SKILL.md`
- `git diff --check`
- Fresh autoreview: clean, 0.99 confidence
- Before: PR #116764 `check-lint` run 30624043426 reports this file as the only format failure inherited from `main`
