### PR TITLE
fix(ios): keep attachments in composer when route is unavailable

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -39699,7 +39699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 934,
+      "line": 936,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode uses the primary Gateway window",
       "surface": "apple",
@@ -39707,7 +39707,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 936,
+      "line": 938,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode off",
       "surface": "apple",
@@ -39715,7 +39715,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 938,
+      "line": 940,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode paused",
       "surface": "apple",
@@ -39723,7 +39723,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 941,
+      "line": 943,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode ready",
       "surface": "apple",
@@ -39731,7 +39731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 942,
+      "line": 944,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Listening",
       "surface": "apple",
@@ -39739,7 +39739,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 943,
+      "line": 945,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -39747,7 +39747,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 944,
+      "line": 946,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Speaking",
       "surface": "apple",
@@ -39755,7 +39755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 948,
+      "line": 950,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -39763,7 +39763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 952,
+      "line": 954,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -39771,7 +39771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 953,
+      "line": 955,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -39779,7 +39779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 956,
+      "line": 958,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "What can you do?",
       "surface": "apple",
@@ -39787,7 +39787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 957,
+      "line": 959,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Show me what you can help with on this Mac right now.",
       "surface": "apple",
@@ -39795,7 +39795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 960,
+      "line": 962,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Catch me up",
       "surface": "apple",
@@ -39803,7 +39803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 961,
+      "line": 963,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Summarize what happened in my threads since yesterday.",
       "surface": "apple",
@@ -42147,7 +42147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 744,
+      "line": 746,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -42155,7 +42155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 744,
+      "line": 746,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "queued after route change",
       "surface": "apple",

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -44,7 +44,9 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             ifCurrentRoute: route)
         else { return .unavailable(reason: nil) }
         guard supportsRoutingContract else {
-            return .unavailable(reason: OpenClawChatTransportUpgradeMessage.routingContract)
+            return .unavailable(
+                reason: OpenClawChatTransportUpgradeMessage.routingContract,
+                allowsLiveSend: true)
         }
         let transport = self
         guard let routingContract = try? await transport.sessionRoutingContract(ifCurrentRoute: route)

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -519,7 +519,9 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             ifCurrentRoute: route)
         else { return .unavailable(reason: nil) }
         guard supportsRoutingContract else {
-            return .unavailable(reason: OpenClawChatTransportUpgradeMessage.routingContract)
+            return .unavailable(
+                reason: OpenClawChatTransportUpgradeMessage.routingContract,
+                allowsLiveSend: true)
         }
         guard let routingIdentity = try? await connection.sessionRoutingIdentity(
             ifCurrentRoute: route)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -289,7 +289,7 @@ public struct OpenClawChatTransportRouteLease: Sendable {
 
 public enum OpenClawChatTransportRouteLeaseResult: Sendable {
     case available(OpenClawChatTransportRouteLease)
-    case unavailable(reason: String?)
+    case unavailable(reason: String?, allowsLiveSend: Bool = false)
 }
 
 /// One physical gateway connection captured before a settings mutation waits

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -776,7 +776,7 @@ extension OpenClawChatViewModel {
             // The store owner no longer matches the active gateway route.
             // Leave every row queued; the replacement view model owns the
             // new gateway and a later matching reconnect can resume this one.
-            if case let .unavailable(reason) = routeResult, let reason {
+            if case let .unavailable(reason, _) = routeResult, let reason {
                 self.errorText = reason
             }
             self.applyTransportHealth(false)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
@@ -515,10 +515,12 @@ extension OpenClawChatViewModel {
         }
         let routeResult = await transport.acquireOutboxRouteLease()
         guard isCurrentSession(draft.session) else { return .stop }
-        guard case let .unavailable(reason) = routeResult,
-              reason == OpenClawChatTransportUpgradeMessage.routingContract
-        else {
+        guard case let .unavailable(reason, allowsLiveSend) = routeResult else {
             return .persistIfAvailable
+        }
+        guard allowsLiveSend else {
+            errorText = "Could not verify this attachment's delivery route. Reconnect, then try again."
+            return .stop
         }
         guard hasRestoredOutboxMessages else {
             errorText = "Restoring queued messages. Try again in a moment."
@@ -527,7 +529,7 @@ extension OpenClawChatViewModel {
         guard !mustPreserveOutboxOrder else {
             // A legacy gateway cannot drain the existing durable rows, so keep
             // this new attachment in the composer behind them.
-            errorText = reason
+            errorText = reason ?? OpenClawChatTransportUpgradeMessage.routingContract
             return .stop
         }
         // Older healthy gateways can send attachments live but cannot safely

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -8,17 +8,44 @@ import XCTest
 
 private actor AttachmentSendCapture {
     private(set) var attachments: [OpenClawChatAttachmentPayload] = []
+    private(set) var sends = 0
 
     func store(_ attachments: [OpenClawChatAttachmentPayload]) {
         self.attachments = attachments
+        self.sends += 1
     }
 
     func count() -> Int {
         self.attachments.count
     }
 
+    func sendCount() -> Int {
+        self.sends
+    }
+
     func first() -> OpenClawChatAttachmentPayload? {
         self.attachments.first
+    }
+}
+
+private enum AttachmentRouteLeaseAvailability: Sendable {
+    case available
+    case unsupported
+    case indeterminate
+}
+
+private actor AttachmentRouteLeasePlan {
+    private var availability: [AttachmentRouteLeaseAvailability]
+
+    init(_ availability: [AttachmentRouteLeaseAvailability]) {
+        self.availability = availability
+    }
+
+    func next() -> AttachmentRouteLeaseAvailability {
+        guard self.availability.count > 1 else {
+            return self.availability.first ?? .available
+        }
+        return self.availability.removeFirst()
     }
 }
 
@@ -58,6 +85,7 @@ private struct AttachmentProcessingTransport: OpenClawChatTransport {
     let responseStatus: String
     let returnsEmptyHistory: Bool
     let durableOutboxAvailable: Bool
+    let routeLeasePlan: AttachmentRouteLeasePlan?
 
     init(
         capture: AttachmentSendCapture? = nil,
@@ -65,7 +93,8 @@ private struct AttachmentProcessingTransport: OpenClawChatTransport {
         failsAmbiguously: Bool = false,
         responseStatus: String = "started",
         returnsEmptyHistory: Bool = false,
-        durableOutboxAvailable: Bool = true)
+        durableOutboxAvailable: Bool = true,
+        routeLeasePlan: AttachmentRouteLeasePlan? = nil)
     {
         self.capture = capture
         self.healthGate = healthGate
@@ -73,6 +102,7 @@ private struct AttachmentProcessingTransport: OpenClawChatTransport {
         self.responseStatus = responseStatus
         self.returnsEmptyHistory = returnsEmptyHistory
         self.durableOutboxAvailable = durableOutboxAvailable
+        self.routeLeasePlan = routeLeasePlan
     }
 
     func requestHistory(sessionKey _: String) async throws -> OpenClawChatHistoryPayload {
@@ -117,8 +147,20 @@ private struct AttachmentProcessingTransport: OpenClawChatTransport {
     }
 
     func acquireOutboxRouteLease() async -> OpenClawChatTransportRouteLeaseResult {
-        guard self.durableOutboxAvailable else {
-            return .unavailable(reason: OpenClawChatTransportUpgradeMessage.routingContract)
+        let availability: AttachmentRouteLeaseAvailability = if let routeLeasePlan {
+            await routeLeasePlan.next()
+        } else {
+            self.durableOutboxAvailable ? .available : .unsupported
+        }
+        switch availability {
+        case .indeterminate:
+            return .unavailable(reason: nil)
+        case .unsupported:
+            return .unavailable(
+                reason: OpenClawChatTransportUpgradeMessage.routingContract,
+                allowsLiveSend: true)
+        case .available:
+            break
         }
         let transport = self
         return .available(OpenClawChatTransportRouteLease(
@@ -583,6 +625,78 @@ final class ChatViewModelAttachmentTests: XCTestCase {
 
         let commands = await outbox.loadCommands()
         XCTAssertTrue(commands.isEmpty)
+    }
+
+    func testIndeterminateOutboxRouteRetainsAttachmentAndRetriesOnceAvailable() async throws {
+        let capture = AttachmentSendCapture()
+        let routeLeasePlan = AttachmentRouteLeasePlan([
+            .indeterminate,
+            .available,
+            .available,
+        ])
+        let outbox = try makeAttachmentOutbox()
+        let attachmentData = Data("retry-image".utf8)
+        let viewModel = await MainActor.run {
+            makeDurableAttachmentViewModel(
+                transport: AttachmentProcessingTransport(
+                    capture: capture,
+                    returnsEmptyHistory: true,
+                    routeLeasePlan: routeLeasePlan),
+                outbox: outbox)
+        }
+        await MainActor.run { viewModel.load() }
+        try await waitUntil("attachment outbox bootstrap completed") {
+            await MainActor.run {
+                viewModel.healthOK && !viewModel.isLoading && viewModel.hasRestoredOutboxMessages
+            }
+        }
+        let attachmentID = await MainActor.run {
+            let attachment = OpenClawPendingAttachment(
+                url: nil,
+                data: attachmentData,
+                fileName: "retry.jpg",
+                mimeType: "image/jpeg",
+                preview: nil)
+            viewModel.input = "retry caption"
+            viewModel.attachments = [attachment]
+            viewModel.send()
+            return attachment.id
+        }
+
+        let routeError =
+            "Could not verify this attachment's delivery route. Reconnect, then try again."
+        try await waitUntil("indeterminate attachment route is visible") {
+            await MainActor.run { viewModel.errorText == routeError }
+        }
+        let retainedState = await MainActor.run {
+            (viewModel.input, viewModel.attachments.map(\.id))
+        }
+        XCTAssertEqual(retainedState.0, "retry caption")
+        XCTAssertEqual(retainedState.1, [attachmentID])
+        let retainedCommands = await outbox.loadCommands()
+        let initialSendCount = await capture.sendCount()
+        XCTAssertTrue(retainedCommands.isEmpty)
+        XCTAssertEqual(initialSendCount, 0)
+
+        await MainActor.run { viewModel.send() }
+        try await waitUntil("attachment retry sent") {
+            await capture.sendCount() == 1
+        }
+        try await Task.sleep(for: .milliseconds(100))
+
+        let capturedPayload = await capture.first()
+        let payload = try XCTUnwrap(capturedPayload)
+        XCTAssertEqual(payload.fileName, "retry.jpg")
+        XCTAssertEqual(payload.mimeType, "image/jpeg")
+        XCTAssertEqual(payload.content, attachmentData.base64EncodedString())
+        let finalSendCount = await capture.sendCount()
+        XCTAssertEqual(finalSendCount, 1)
+        let sentState = await MainActor.run {
+            (viewModel.input, viewModel.attachments.isEmpty, viewModel.errorText)
+        }
+        XCTAssertEqual(sentState.0, "")
+        XCTAssertTrue(sentState.1)
+        XCTAssertNil(sentState.2)
     }
 
     func testLegacyGatewayRetainsAttachmentUntilOutboxRestoreCompletes() async throws {


### PR DESCRIPTION
Closes #116724

## What Problem This Solves

iOS attachment sends could clear the composer and create a durable outbox row when the app could not verify a Gateway delivery route. That row had no authoritative route and could remain queued indefinitely.

## Root Cause And Owner

`OpenClawChatTransportRouteLeaseResult.unavailable` represented two different facts:

- a healthy older Gateway that can still send the attachment live;
- an indeterminate route caused by missing route, capability, identity, or connection state.

The shared composer inferred those facts from the human-readable error string. That was brittle and let an indeterminate route fall into durable persistence.

The transport producer now records whether live send is known to be safe. The shared attachment decision consumes that fact:

- available route: persist to the durable outbox;
- confirmed older Gateway: preserve the existing live attachment path;
- indeterminate route: retain the caption and attachment, show reconnect-and-retry guidance, create no outbox row, and send nothing.

iOS and macOS producers use the same semantic contract. Existing outbox restore and FIFO checks remain in front of the legacy live-send path, so a new attachment cannot overtake durable work.

## Scope

- 6 files.
- Production: +14/-8, net +6.
- Tests: +117/-3.
- No Gateway protocol, storage schema, config, or media serialization changes.

## Current Main

- Reworked branch head: `4e0535056ad7cb41dc349c1b3a6d63dedd669bd3`.
- Rebased onto: `27f5691d29378d1db863885ff28b23d2e6381720`.
- Exact-merge proof was refreshed against `623c738d1ea9db7d3ff86c466030b04ddf65708c`.
- Commit signature verified as good.

## Evidence

- `swift test --package-path apps/shared/OpenClawKit --filter ChatViewModelAttachmentTests`: 20 tests passed.
- The focused indeterminate-route test verifies retained caption and attachment, visible recovery text, no durable row, no initial send, and exactly one successful retry after route availability.
- `swift test --package-path apps/shared/OpenClawKit --filter ChatViewModelOutboxTests`: 51 tests passed, including durable FIFO and legacy-Gateway behavior.
- `node --import tsx scripts/native-app-i18n.ts verify`: 5,395 entries, no inventory drift. Signed follow-up `4e0535056ad` updates only `apps/.i18n/native-source.json`.
- iPhone 16 Pro / iOS 18.6 simulator, `IOSGatewayChatTransportTests`: 20 tests passed with the app build and repository SwiftLint build phase succeeding.
- `pnpm lint:swift` under Node 26.4.0 and pnpm 11.15.1: 0 violations across 706 Swift files.
- SwiftFormat: clean. `git diff --check`: clean. Conflict, attribution, export, duplicate, dependency-pin, and package-patch guards: passed.
- Final scoped autoreview: no findings; patch correct at 0.94 confidence.
- Public-data scrub: clean.

The delegated changed-check lane could not start because no Crabbox provider was ready. Its local fallback's Swift-lint invocation selected unsupported Node/pnpm binaries; the exact failed lint surface was rerun directly with the supported versions above.

## Remaining Proof Blockers

- Signed physical-device proof is unavailable: the host has 0 valid code-signing identities.
- Live-Gateway proof is unavailable: the simulator app reported that it was not connected, and the installed CLI cannot query Gateway status because the local config currently fails validation at `meta`.

No signed-device or live-Gateway success is claimed. The verified evidence is focused shared behavior plus the real iOS simulator build/test boundary.
