### PR TITLE
fix(browser): wake page shares when heartbeat is disabled

### DIFF
--- a/extensions/browser/src/browser/extension-relay/page-share.test.ts
+++ b/extensions/browser/src/browser/extension-relay/page-share.test.ts
@@ -8,12 +8,21 @@ import {
 function createSink() {
   const enqueueSystemEvent = vi.fn();
   const requestHeartbeat = vi.fn();
+  const resolveDefaultAgentId = vi.fn(() => "main");
+  const resolveMainSessionKey = vi.fn(() => "agent:main:main");
   const sink = {
     enqueueSystemEvent,
     requestHeartbeat,
-    resolveMainSessionKey: () => "agent:main:main",
+    resolveDefaultAgentId,
+    resolveMainSessionKey,
   };
-  return { enqueueSystemEvent, requestHeartbeat, sink };
+  return {
+    enqueueSystemEvent,
+    requestHeartbeat,
+    resolveDefaultAgentId,
+    resolveMainSessionKey,
+    sink,
+  };
 }
 
 afterEach(() => {
@@ -22,7 +31,13 @@ afterEach(() => {
 
 describe("page share delivery", () => {
   it("formats metadata, keeps the note trusted, and wraps selected page text", async () => {
-    const { enqueueSystemEvent, requestHeartbeat, sink } = createSink();
+    const {
+      enqueueSystemEvent,
+      requestHeartbeat,
+      resolveDefaultAgentId,
+      resolveMainSessionKey,
+      sink,
+    } = createSink();
     setPageShareSink(sink);
 
     await deliverPageShare({
@@ -34,6 +49,8 @@ describe("page share delivery", () => {
     });
 
     expect(enqueueSystemEvent).toHaveBeenCalledOnce();
+    expect(resolveDefaultAgentId).toHaveBeenCalledOnce();
+    expect(resolveMainSessionKey).toHaveBeenCalledOnce();
     const [text, options] = enqueueSystemEvent.mock.calls[0] as [string, { sessionKey: string }];
     expect(options).toEqual({ sessionKey: "agent:main:main" });
     expect(text).toContain(
@@ -50,10 +67,13 @@ describe("page share delivery", () => {
     const boundaryStart = text.indexOf("<<<EXTERNAL_UNTRUSTED_CONTENT");
     expect(text.indexOf("Title: Example article")).toBeGreaterThan(boundaryStart);
     expect(text.indexOf("URL: https://example.com/article")).toBeGreaterThan(boundaryStart);
-    expect(requestHeartbeat).toHaveBeenCalledWith({
-      source: "other",
+    expect(requestHeartbeat).toHaveBeenCalledExactlyOnceWith({
+      source: "notifications-event",
       intent: "immediate",
-      reason: "browser-page-share",
+      reason: "wake",
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      heartbeat: { target: "last" },
     });
   });
 

--- a/extensions/browser/src/browser/extension-relay/page-share.test.ts
+++ b/extensions/browser/src/browser/extension-relay/page-share.test.ts
@@ -5,11 +5,11 @@ import {
   setPageShareSink,
 } from "./page-share.js";
 
-function createSink() {
+function createSink(sessionKey = "agent:main:main") {
   const enqueueSystemEvent = vi.fn();
   const requestHeartbeat = vi.fn();
   const resolveDefaultAgentId = vi.fn(() => "main");
-  const resolveMainSessionKey = vi.fn(() => "agent:main:main");
+  const resolveMainSessionKey = vi.fn(() => sessionKey);
   const sink = {
     enqueueSystemEvent,
     requestHeartbeat,
@@ -30,14 +30,14 @@ afterEach(() => {
 });
 
 describe("page share delivery", () => {
-  it("formats metadata, keeps the note trusted, and wraps selected page text", async () => {
+  it("formats metadata, keeps the note trusted, and wakes a scoped session", async () => {
     const {
       enqueueSystemEvent,
       requestHeartbeat,
       resolveDefaultAgentId,
       resolveMainSessionKey,
       sink,
-    } = createSink();
+    } = createSink("agent:ops:main");
     setPageShareSink(sink);
 
     await deliverPageShare({
@@ -49,10 +49,10 @@ describe("page share delivery", () => {
     });
 
     expect(enqueueSystemEvent).toHaveBeenCalledOnce();
-    expect(resolveDefaultAgentId).toHaveBeenCalledOnce();
+    expect(resolveDefaultAgentId).not.toHaveBeenCalled();
     expect(resolveMainSessionKey).toHaveBeenCalledOnce();
     const [text, options] = enqueueSystemEvent.mock.calls[0] as [string, { sessionKey: string }];
-    expect(options).toEqual({ sessionKey: "agent:main:main" });
+    expect(options).toEqual({ sessionKey: "agent:ops:main" });
     expect(text).toContain(
       "Page shared from the OpenClaw Chrome extension.\nNote: Summarize for me",
     );
@@ -71,8 +71,28 @@ describe("page share delivery", () => {
       source: "notifications-event",
       intent: "immediate",
       reason: "wake",
+      sessionKey: "agent:ops:main",
+      heartbeat: { target: "last" },
+    });
+  });
+
+  it("supplies the default agent for the global session", async () => {
+    const { requestHeartbeat, resolveDefaultAgentId, sink } = createSink("global");
+    setPageShareSink(sink);
+
+    await deliverPageShare({
+      url: "https://example.com",
+      title: "Example",
+      content: "full page content",
+    });
+
+    expect(resolveDefaultAgentId).toHaveBeenCalledOnce();
+    expect(requestHeartbeat).toHaveBeenCalledExactlyOnceWith({
+      source: "notifications-event",
+      intent: "immediate",
+      reason: "wake",
       agentId: "main",
-      sessionKey: "agent:main:main",
+      sessionKey: "global",
       heartbeat: { target: "last" },
     });
   });

--- a/extensions/browser/src/browser/extension-relay/page-share.ts
+++ b/extensions/browser/src/browser/extension-relay/page-share.ts
@@ -17,7 +17,7 @@ type PageShareSink = {
     source: "notifications-event";
     intent: "immediate";
     reason: "wake";
-    agentId: string;
+    agentId?: string;
     sessionKey: string;
     heartbeat: { target: "last" };
   }): unknown;
@@ -62,16 +62,13 @@ export async function deliverPageShare(payload: PageSharePayload): Promise<void>
   ].join("\n");
   const text = `${header}\n\n${wrapped}`;
 
-  // Enqueue and wake the same session. The targeted system-event shape remains
-  // resolvable in global scope when periodic heartbeats are intentionally disabled.
-  const agentId = sink.resolveDefaultAgentId();
   const sessionKey = sink.resolveMainSessionKey();
   await sink.enqueueSystemEvent(text, { sessionKey });
   await sink.requestHeartbeat({
     source: "notifications-event",
     intent: "immediate",
     reason: "wake",
-    agentId,
+    ...(sessionKey === "global" ? { agentId: sink.resolveDefaultAgentId() } : {}),
     sessionKey,
     heartbeat: { target: "last" },
   });

--- a/extensions/browser/src/browser/extension-relay/page-share.ts
+++ b/extensions/browser/src/browser/extension-relay/page-share.ts
@@ -1,9 +1,11 @@
+import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { requestHeartbeat } from "openclaw/plugin-sdk/heartbeat-runtime";
 import { wrapExternalContent } from "openclaw/plugin-sdk/security-runtime";
 import {
   enqueueSystemEvent,
   resolveMainSessionKeyFromConfig,
 } from "openclaw/plugin-sdk/system-event-runtime";
+import { getRuntimeConfig } from "../../sdk-config.js";
 import type { PageSharePayload } from "./relay-protocol.js";
 
 export const PAGE_SHARE_GATEWAY_REQUIRED_ERROR =
@@ -11,7 +13,15 @@ export const PAGE_SHARE_GATEWAY_REQUIRED_ERROR =
 
 type PageShareSink = {
   enqueueSystemEvent(text: string, opts: { sessionKey: string }): unknown;
-  requestHeartbeat(opts: { source: "other"; intent: "immediate"; reason: string }): unknown;
+  requestHeartbeat(opts: {
+    source: "notifications-event";
+    intent: "immediate";
+    reason: "wake";
+    agentId: string;
+    sessionKey: string;
+    heartbeat: { target: "last" };
+  }): unknown;
+  resolveDefaultAgentId(): string;
   resolveMainSessionKey(): string;
 };
 
@@ -27,6 +37,7 @@ export function createGatewayPageShareSink(): PageShareSink {
   return {
     enqueueSystemEvent,
     requestHeartbeat,
+    resolveDefaultAgentId: () => resolveDefaultAgentId(getRuntimeConfig()),
     resolveMainSessionKey: resolveMainSessionKeyFromConfig,
   };
 }
@@ -51,10 +62,17 @@ export async function deliverPageShare(payload: PageSharePayload): Promise<void>
   ].join("\n");
   const text = `${header}\n\n${wrapped}`;
 
-  await sink.enqueueSystemEvent(text, { sessionKey: sink.resolveMainSessionKey() });
+  // Enqueue and wake the same session. The targeted system-event shape remains
+  // resolvable in global scope when periodic heartbeats are intentionally disabled.
+  const agentId = sink.resolveDefaultAgentId();
+  const sessionKey = sink.resolveMainSessionKey();
+  await sink.enqueueSystemEvent(text, { sessionKey });
   await sink.requestHeartbeat({
-    source: "other",
+    source: "notifications-event",
     intent: "immediate",
-    reason: "browser-page-share",
+    reason: "wake",
+    agentId,
+    sessionKey,
+    heartbeat: { target: "last" },
   });
 }

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -986,37 +986,49 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
-  it("runs a targeted notification wake for an agent without a heartbeat schedule", async () => {
+  it.each([
+    {
+      name: "an agent without a heartbeat schedule",
+      cfg: {
+        agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
+      } as OpenClawConfig,
+      agentId: "ops",
+      sessionKey: "agent:ops:main",
+      heartbeat: { target: "last" },
+    },
+    {
+      name: "the global main session when periodic heartbeats are disabled",
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+        session: { scope: "global" },
+      } as OpenClawConfig,
+      agentId: "main",
+      sessionKey: "global",
+      heartbeat: { every: "0m", target: "last" },
+    },
+  ])("runs one targeted notification wake for $name", async (testCase) => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
-    const runner = startHeartbeatRunner({
-      cfg: {
-        agents: {
-          list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }],
-        },
-      } as OpenClawConfig,
-      runOnce: runSpy,
-      stableSchedulerSeed: TEST_SCHEDULER_SEED,
-    });
-
-    requestHeartbeat({
-      source: "notifications-event",
-      intent: "immediate",
-      reason: "wake",
-      sessionKey: "agent:ops:main",
-      heartbeat: { target: "last" },
-      coalesceMs: 0,
-    });
-    await vi.advanceTimersByTimeAsync(1);
-
-    expect(runSpy).toHaveBeenCalledTimes(1);
-    expectRunCallFields(runSpy, 0, {
-      agentId: "ops",
-      source: "notifications-event",
-      intent: "immediate",
-      reason: "wake",
-      sessionKey: "agent:ops:main",
-      heartbeat: { target: "last" },
+    const runner = await expectWakeDispatch({
+      cfg: testCase.cfg,
+      runSpy,
+      wake: {
+        source: "notifications-event",
+        intent: "immediate",
+        reason: "wake",
+        ...(testCase.sessionKey === "global" ? { agentId: testCase.agentId } : {}),
+        sessionKey: testCase.sessionKey,
+        heartbeat: { target: "last" },
+        coalesceMs: 0,
+      },
+      expectedCall: {
+        agentId: testCase.agentId,
+        source: "notifications-event",
+        intent: "immediate",
+        reason: "wake",
+        sessionKey: testCase.sessionKey,
+        heartbeat: testCase.heartbeat,
+      },
     });
     runner.stop();
   });


### PR DESCRIPTION
Closes #116729

## What Problem This Solves

Fixes the Chrome extension page-share path when periodic heartbeats are disabled with `heartbeat.every: "0m"`.

The initial branch patch sent every wake with the configured default agent. That was wrong for scoped sessions: a share queued for `agent:ops:main` could wake `main` instead of allowing the scheduler to derive `ops` from the session key.

## Canonical Fix

The Browser owner resolves one session key and uses it for both enqueue and wake:

- scoped keys omit `agentId`, preserving scheduler session-key inference;
- literal `global` supplies the configured default agent, which has no agent identity to infer;
- both retain the canonical targeted wake shape: `notifications-event`, immediate `wake`, resolved session key, and `target: "last"`.

No Browser-specific heartbeat exception or fallback was added.

## Evidence

- Exact head: `e6fa12cebd32b1b2be524897f02cf6cf28f63401`
- Rebased onto `main` at `2dc8553247504b06d46c25818efc9d2e352e6ce7`
- Production delta: `+19/-4` (net `+15`)
- Test delta: `+87/-35`
- Focused Node 24.18 proof passed:
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/page-share.test.ts src/infra/heartbeat-runner.scheduler.test.ts`
  - 2 shards, 37 tests passed
  - Covers scoped `agent:ops:main` wake without default-agent leakage and global-session default-agent routing with `heartbeat.every: "0m"`.
- Targeted lint passed:
  - `node scripts/run-oxlint.mjs extensions/browser/src/browser/extension-relay/page-share.ts extensions/browser/src/browser/extension-relay/page-share.test.ts src/infra/heartbeat-runner.scheduler.test.ts`
- Targeted formatting and `git diff --check` passed.
- Local autoreview completed clean with no actionable findings. This was review cycle 1; no second cycle was needed because scope did not widen.

## Real Browser And Gateway Proof

Exact-head proof passed on August 3, 2026 using the real unpacked extension toolbar action and a real Gateway with `heartbeat.every: "0m"`:

- scoped mode touched only `agent:ops:main`;
- global mode touched only `global` in the `ops` store;
- each mode produced exactly one model request containing the shared page marker;
- each popup reached `Sent ✓`;
- no second run appeared after a two-second stability window;
- Gateway logs confirmed heartbeat scheduling disabled, extension relay connected, and clean shutdown.

The runtime/plugin build phases completed. The later umbrella declaration phase stopped on an unrelated missing generated SDK declaration; it is outside the exercised page-share/Gateway path.
