### PR TITLE
fix(slack): preserve conversation context in group DM threads

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare-routing.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-routing.ts
@@ -232,7 +232,7 @@ export function resolveSlackRoutingContext(params: {
   const seedCandidateThreadId = threadContext.incomingThreadTs ?? threadContext.messageTs;
   const seededRoomThreadId =
     !isThreadReply &&
-    isRoom &&
+    isRoomish &&
     seedTopLevelRoomThread &&
     replyToMode !== "off" &&
     seedCandidateThreadId

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -2395,6 +2395,40 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.From).toBe("slack:group:G123");
   });
 
+  it("keeps an unmentioned MPIM thread root and reply in the same session", async () => {
+    const ctx = createReplyToAllSlackCtx();
+    const account = createSlackAccount({ replyToMode: "all" });
+    const rootTs = "1.000";
+    const root = await prepareMessageWith(
+      ctx,
+      account,
+      createSlackMessage({
+        channel: "G123",
+        channel_type: "mpim",
+        text: "what day is it?",
+        ts: rootTs,
+      }),
+    );
+    recordSlackThreadParticipation("default", "G123", rootTs);
+    const followUp = await prepareMessageWith(
+      ctx,
+      account,
+      createSlackMessage({
+        channel: "G123",
+        channel_type: "mpim",
+        text: "and the time?",
+        ts: "2.000",
+        thread_ts: rootTs,
+        parent_user_id: "U1",
+      }),
+    );
+
+    assertPrepared(root);
+    assertPrepared(followUp);
+    expect(root.ctxPayload.SessionKey).toBe(`agent:main:slack:group:g123:thread:${rootTs}`);
+    expect(followUp.ctxPayload.SessionKey).toBe(root.ctxPayload.SessionKey);
+  });
+
   it("blocks MPIM messages from senders outside the configured allowFrom", async () => {
     const ctx = createReplyToAllSlackCtx();
     ctx.allowFrom = ["U_OWNER"];
@@ -2464,7 +2498,12 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     assertPrepared(typelessPrepared);
     expect(typelessPrepared.ctxPayload.ChatType).toBe("group");
     expect(typelessPrepared.ctxPayload.From).toBe("slack:group:C0MPDM42");
-    expect(typelessPrepared.ctxPayload.SessionKey).toBe(humanPrepared.ctxPayload.SessionKey);
+    expect(humanPrepared.ctxPayload.SessionKey).toBe(
+      "agent:main:slack:group:c0mpdm42:thread:1.000",
+    );
+    expect(typelessPrepared.ctxPayload.SessionKey).toBe(
+      "agent:main:slack:group:c0mpdm42:thread:2.000",
+    );
     expect(conversationsInfo).toHaveBeenCalledTimes(2);
   });
 

--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -365,18 +365,19 @@ describe("thread-level session keys", () => {
     expect(routing.threadContext.replyToId).toBeUndefined();
   });
 
-  it("does not seed top-level group DM mentions into thread sessions", () => {
+  it("keeps a group DM thread root and its replies in the same session", () => {
     const ctx = buildCtx({ replyToMode: "all" });
     const account = buildAccount("all");
+    const rootTs = "1777244692.409919";
 
-    const routing = resolveSlackRoutingContext({
+    const root = resolveSlackRoutingContext({
       ctx,
       account,
       message: buildChannelMessage({
         channel: "G123",
         channel_type: "mpim",
         text: "<@B1> send a subagent",
-        ts: "1777244692.409919",
+        ts: rootTs,
       }),
       isDirectMessage: false,
       isGroupDm: true,
@@ -384,9 +385,29 @@ describe("thread-level session keys", () => {
       isRoomish: true,
       seedTopLevelRoomThread: true,
     });
+    const followUp = resolveSlackRoutingContext({
+      ctx,
+      account,
+      message: buildChannelMessage({
+        channel: "G123",
+        channel_type: "mpim",
+        user: "U2",
+        text: "what did you just do?",
+        ts: "1777244714.000100",
+        thread_ts: rootTs,
+        parent_user_id: "U1",
+      }),
+      isDirectMessage: false,
+      isGroupDm: true,
+      isRoom: false,
+      isRoomish: true,
+    });
 
-    expect(routing.sessionKey).toBe("agent:main:slack:group:g123");
-    expect(routing.sessionKey).not.toContain(":thread:");
+    const expectedSessionKey = `agent:main:slack:group:g123:thread:${rootTs}`;
+    expect(root.sessionKey).toBe(expectedSessionKey);
+    expect(followUp.sessionKey).toBe(expectedSessionKey);
+    expect(root.historyKey).toBe("G123");
+    expect(followUp.historyKey).toBe(expectedSessionKey);
   });
 
   it("routes a seeded thread root and replies with the same Slack thread_ts to one parent session", () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -853,7 +853,7 @@ export async function prepareSlackMessage(params: {
   const channelReplyToMode =
     channelConfig?.replyToMode ?? resolveSlackReplyToMode(account, channelChatType);
   const willImplicitlyThreadReply =
-    isRoom && !channelRequireMention && channelReplyToMode !== "off";
+    isRoomish && (isGroupDm || !channelRequireMention) && channelReplyToMode !== "off";
   const seedTopLevelRoomThreadBySource =
     opts.source === "app_mention" ||
     opts.wasMentioned === true ||


### PR DESCRIPTION
Refs #113449

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users who start a Slack group DM (MPIM) conversation at the top level and continue in the bot's reply thread would lose the original question, answer, and conversation context.

Reported and reproduced by @treez-admin.

## Why This Change Was Made

Seed group-DM thread roots through the existing Slack room-like routing boundary, and recognize that group DMs do not require a channel mention before an implicit threaded reply is expected. Keep existing channel mention policy, reply-to-off behavior, distinct top-level roots, and the already-correct flat 1:1 DM session contract unchanged.

## User Impact

Slack group-DM thread follow-ups continue the conversation that began in their parent message, including unmentioned messages under the default mention settings. Separate top-level group-DM conversations still receive separate thread sessions. Existing channel and 1:1 DM behavior does not change.

## Evidence

Before:

```text
MPIM root       agent:main:slack:group:g123
MPIM follow-up  agent:main:slack:group:g123:thread:1.000
```

After:

```text
MPIM root       agent:main:slack:group:g123:thread:1.000
MPIM follow-up  agent:main:slack:group:g123:thread:1.000

separate root 1 agent:main:slack:group:c0mpdm42:thread:1.000
separate root 2 agent:main:slack:group:c0mpdm42:thread:2.000
```

Focused regression coverage proves both the routing helper and the actual Slack message-preparation caller, including an unmentioned MPIM root/follow-up under default mention settings and independent root isolation.

Trusted hosted Testbox proof: https://github.com/openclaw/openclaw/actions/runs/30625994502

```text
pnpm test extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts
Test Files  2 passed (2)
Tests       154 passed (154)

node_modules/.bin/oxfmt --check <four changed Slack files>
All matched files use the correct format.

node scripts/run-oxlint.mjs <four changed Slack files>
exit 0

delegated Testbox result: exitCode=0, runStatus=succeeded
```

Mandatory verified-TruffleHog autoreview: clean. Separate independent Codex review: no introduced defects. Slack-plugin-only change; no Slack-specific CODEOWNERS entry, configuration/default changes, dependency changes, or production-LOC growth.
