### PR TITLE
refactor(agents): bind tool policy to execution attribution

### DIFF
--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -33,6 +33,11 @@ type CodexAppServerAgentHarness = AgentHarness & {
   ): Promise<AgentHarnessCompactResult | undefined>;
 };
 
+type CodexAgentHarnessToolAuthority = {
+  createForAttempt: (typeof import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))["createOpenClawCodingToolsForAgentHarness"];
+  createForSideQuestion: (typeof import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))["createOpenClawCodingToolsForAgentHarnessSideQuestion"];
+};
+
 async function disposeSharedCodexAppServerClients(): Promise<void> {
   const dispose = (
     globalThis as typeof globalThis & {
@@ -56,6 +61,7 @@ export function createCodexAppServerAgentHarness(options: {
   runtime?: PluginRuntime;
   bindingStore: CodexAppServerBindingStore;
   sessionCatalogControl?: CodexSessionCatalogControl;
+  toolAuthority?: CodexAgentHarnessToolAuthority;
 }): AgentHarness {
   const harnessRuntimeId = options?.id ?? "codex";
   const normalizedHarnessRuntimeId = harnessRuntimeId.trim().toLowerCase();
@@ -180,6 +186,7 @@ export function createCodexAppServerAgentHarness(options: {
       // cold provider catalog reads do not pull in the whole Codex runtime.
       const { runCodexAppServerAttempt } = await import("./src/app-server/run-attempt.js");
       return runCodexAppServerAttempt(params, {
+        agentHarnessCodingToolsFactory: options.toolAuthority?.createForAttempt,
         bindingStore: options.bindingStore,
         pluginConfig: options?.resolvePluginConfig?.() ?? options?.pluginConfig,
         nativeHookRelay: { enabled: true },
@@ -221,6 +228,7 @@ export function createCodexAppServerAgentHarness(options: {
     runSideQuestion: async (params) => {
       const { runCodexAppServerSideQuestion } = await import("./src/app-server/side-question.js");
       return runCodexAppServerSideQuestion(params, {
+        agentHarnessCodingToolsFactory: options.toolAuthority?.createForSideQuestion,
         bindingStore: options.bindingStore,
         pluginConfig: options?.resolvePluginConfig?.() ?? options?.pluginConfig,
         nativeHookRelay: { enabled: true },

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -852,6 +852,7 @@ describe("codex plugin", () => {
     expect(runCodexAppServerAttemptMock).toHaveBeenCalledWith(
       { prompt: "hello" },
       {
+        agentHarnessCodingToolsFactory: undefined,
         bindingStore: testCodexAppServerBindingStore,
         pluginConfig: { appServer: {} },
         nativeHookRelay: { enabled: true },
@@ -917,6 +918,7 @@ describe("codex plugin", () => {
     expect(runCodexAppServerAttemptMock).toHaveBeenCalledWith(
       { prompt: "calendar" },
       {
+        agentHarnessCodingToolsFactory: expect.any(Function),
         bindingStore: expect.any(Object),
         pluginConfig: liveConfig.plugins.entries.codex.config,
         nativeHookRelay: { enabled: true },

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -2,6 +2,10 @@
  * Bundled Codex plugin entry: app-server harness, media understanding,
  * migration provider, CLI-session commands, and binding hooks.
  */
+import {
+  createOpenClawCodingToolsForAgentHarness,
+  createOpenClawCodingToolsForAgentHarnessSideQuestion,
+} from "openclaw/plugin-sdk/agent-harness-tool-authority-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { mutateConfigFile } from "openclaw/plugin-sdk/config-mutation";
 import {
@@ -166,6 +170,10 @@ export default definePluginEntry({
       createCodexAppServerAgentHarness({
         bindingStore,
         sessionCatalogControl,
+        toolAuthority: {
+          createForAttempt: createOpenClawCodingToolsForAgentHarness,
+          createForSideQuestion: createOpenClawCodingToolsForAgentHarnessSideQuestion,
+        },
         resolveConfig: resolveCurrentConfig,
         resolvePluginConfig: resolveCurrentPluginConfig,
         runtime: api.runtime,

--- a/extensions/codex/src/app-server/dynamic-tool-build-state.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build-state.ts
@@ -1,7 +1,10 @@
 type OpenClawCodingToolsFactory =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
+type AgentHarnessCodingToolsFactory =
+  (typeof import("openclaw/plugin-sdk/agent-harness-tool-runtime"))["createOpenClawCodingToolsForAgentHarness"];
 
 /** Mutable dependency seam shared by dynamic-tool construction and its behavioral tests. */
 export const dynamicToolBuildState: {
   openClawCodingToolsFactory?: OpenClawCodingToolsFactory;
+  agentHarnessCodingToolsFactory?: AgentHarnessCodingToolsFactory;
 } = {};

--- a/extensions/codex/src/app-server/dynamic-tool-build-state.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build-state.ts
@@ -1,7 +1,7 @@
 type OpenClawCodingToolsFactory =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
 type AgentHarnessCodingToolsFactory =
-  (typeof import("openclaw/plugin-sdk/agent-harness-tool-runtime"))["createOpenClawCodingToolsForAgentHarness"];
+  (typeof import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))["createOpenClawCodingToolsForAgentHarness"];
 
 /** Mutable dependency seam shared by dynamic-tool construction and its behavioral tests. */
 export const dynamicToolBuildState: {

--- a/extensions/codex/src/app-server/dynamic-tool-build-state.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build-state.ts
@@ -1,6 +1,6 @@
 type OpenClawCodingToolsFactory =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
-type AgentHarnessCodingToolsFactory =
+export type AgentHarnessCodingToolsFactory =
   (typeof import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))["createOpenClawCodingToolsForAgentHarness"];
 
 /** Mutable dependency seam shared by dynamic-tool construction and its behavioral tests. */

--- a/extensions/codex/src/app-server/dynamic-tool-build.lazy-import.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.lazy-import.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.doUnmock("openclaw/plugin-sdk/agent-harness-tool-runtime");
+  vi.resetModules();
+});
+
+it("does not load the private tool builder before a tool-capable turn", async () => {
+  let toolBuilderImports = 0;
+  vi.doMock("openclaw/plugin-sdk/agent-harness-tool-runtime", () => {
+    toolBuilderImports += 1;
+    return {
+      createOpenClawCodingToolsForAgentHarness: vi.fn(() => []),
+    };
+  });
+
+  const { buildDynamicTools } = await import("./dynamic-tool-build.js");
+  await import("./side-question.js");
+  expect(toolBuilderImports).toBe(0);
+
+  await expect(
+    buildDynamicTools({
+      attributionAttempt: {} as never,
+      params: { disableTools: true } as never,
+    } as never),
+  ).resolves.toEqual([]);
+  expect(toolBuilderImports).toBe(0);
+
+  await expect(
+    buildDynamicTools({
+      attributionAttempt: {} as never,
+      params: {
+        disableTools: false,
+        model: { compat: { supportsTools: false } },
+      } as never,
+    } as never),
+  ).resolves.toEqual([]);
+  expect(toolBuilderImports).toBe(0);
+});

--- a/extensions/codex/src/app-server/dynamic-tool-build.lazy-import.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.lazy-import.test.ts
@@ -1,33 +1,21 @@
-import { afterEach, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
+import { buildDynamicTools } from "./dynamic-tool-build.js";
 
-afterEach(() => {
-  vi.doUnmock("openclaw/plugin-sdk/agent-harness-tool-authority-runtime");
-  vi.resetModules();
-});
-
-it("does not load the private tool builder before a tool-capable turn", async () => {
-  let toolBuilderImports = 0;
-  vi.doMock("openclaw/plugin-sdk/agent-harness-tool-authority-runtime", () => {
-    toolBuilderImports += 1;
-    return {
-      createOpenClawCodingToolsForAgentHarness: vi.fn(() => []),
-    };
-  });
-
-  const { buildDynamicTools } = await import("./dynamic-tool-build.js");
-  await import("./side-question.js");
-  expect(toolBuilderImports).toBe(0);
+it("does not invoke host tool authority before a tool-capable turn", async () => {
+  const agentHarnessCodingToolsFactory = vi.fn(async () => []);
 
   await expect(
     buildDynamicTools({
+      agentHarnessCodingToolsFactory,
       attributionAttempt: {} as never,
       params: { disableTools: true } as never,
     } as never),
   ).resolves.toEqual([]);
-  expect(toolBuilderImports).toBe(0);
+  expect(agentHarnessCodingToolsFactory).not.toHaveBeenCalled();
 
   await expect(
     buildDynamicTools({
+      agentHarnessCodingToolsFactory,
       attributionAttempt: {} as never,
       params: {
         disableTools: false,
@@ -35,5 +23,5 @@ it("does not load the private tool builder before a tool-capable turn", async ()
       } as never,
     } as never),
   ).resolves.toEqual([]);
-  expect(toolBuilderImports).toBe(0);
+  expect(agentHarnessCodingToolsFactory).not.toHaveBeenCalled();
 });

--- a/extensions/codex/src/app-server/dynamic-tool-build.lazy-import.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.lazy-import.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, expect, it, vi } from "vitest";
 
 afterEach(() => {
-  vi.doUnmock("openclaw/plugin-sdk/agent-harness-tool-runtime");
+  vi.doUnmock("openclaw/plugin-sdk/agent-harness-tool-authority-runtime");
   vi.resetModules();
 });
 
 it("does not load the private tool builder before a tool-capable turn", async () => {
   let toolBuilderImports = 0;
-  vi.doMock("openclaw/plugin-sdk/agent-harness-tool-runtime", () => {
+  vi.doMock("openclaw/plugin-sdk/agent-harness-tool-authority-runtime", () => {
     toolBuilderImports += 1;
     return {
       createOpenClawCodingToolsForAgentHarness: vi.fn(() => []),

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -63,6 +63,7 @@ function setOpenClawCodingToolsFactoryForTests(
 
 function resetOpenClawCodingToolsFactoryForTests(): void {
   dynamicToolBuildState.openClawCodingToolsFactory = undefined;
+  dynamicToolBuildState.agentHarnessCodingToolsFactory = undefined;
 }
 
 type RuntimeDynamicToolForTest = Parameters<
@@ -141,6 +142,7 @@ async function buildDynamicToolsForTest(
     throw new Error("createParams must provide a sessionKey for Codex dynamic tool tests.");
   }
   return buildDynamicTools({
+    attributionAttempt: params,
     params,
     resolvedWorkspace: workspaceDir,
     effectiveWorkspace: workspaceDir,
@@ -156,6 +158,26 @@ async function buildDynamicToolsForTest(
 }
 
 describe("Codex app-server dynamic tool build", () => {
+  it("uses the exact host-admitted attempt for private tool attribution", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const admittedAttempt = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    admittedAttempt.disableTools = false;
+    admittedAttempt.runtimePlan = createCodexRuntimePlanFixture();
+    const runtimeParams = { ...admittedAttempt };
+    const factory = vi.fn<NonNullable<typeof dynamicToolBuildState.agentHarnessCodingToolsFactory>>(
+      () => [],
+    );
+    dynamicToolBuildState.agentHarnessCodingToolsFactory = factory;
+
+    await buildDynamicToolsForTest(runtimeParams, workspaceDir, {
+      attributionAttempt: admittedAttempt,
+    });
+
+    expect(factory).toHaveBeenCalledOnce();
+    expect(factory.mock.calls[0]?.[0]).toBe(admittedAttempt);
+    expect(factory.mock.calls[0]?.[0]).not.toBe(runtimeParams);
+  });
+
   it("removes account-wide app access when native tools are restricted", () => {
     expect(
       disableCodexPluginThreadConfig({

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -165,7 +165,7 @@ describe("Codex app-server dynamic tool build", () => {
     admittedAttempt.runtimePlan = createCodexRuntimePlanFixture();
     const runtimeParams = { ...admittedAttempt };
     const factory = vi.fn<NonNullable<typeof dynamicToolBuildState.agentHarnessCodingToolsFactory>>(
-      () => [],
+      async () => [],
     );
     dynamicToolBuildState.agentHarnessCodingToolsFactory = factory;
 

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -235,7 +235,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   const agentHarnessCodingToolsFactory = injectedOpenClawCodingToolsFactory
     ? undefined
     : (dynamicToolBuildState.agentHarnessCodingToolsFactory ??
-      (await import("openclaw/plugin-sdk/agent-harness-tool-runtime"))
+      (await import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))
         .createOpenClawCodingToolsForAgentHarness);
   const createOpenClawCodingTools =
     injectedOpenClawCodingToolsFactory ??

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -21,7 +21,10 @@ import {
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
 import { readCodexPluginConfig, type CodexPluginConfig } from "./config.js";
-import { dynamicToolBuildState } from "./dynamic-tool-build-state.js";
+import {
+  dynamicToolBuildState,
+  type AgentHarnessCodingToolsFactory,
+} from "./dynamic-tool-build-state.js";
 import {
   filterCodexDynamicTools,
   filterCodexDynamicToolsWithOpenClawShell,
@@ -83,6 +86,7 @@ function preserveRingZeroSystemAgentTool<T extends { name: string; catalogMode?:
 }
 /** Runtime inputs needed to derive the exact Codex dynamic tool surface for a turn. */
 type DynamicToolBuildParams = {
+  agentHarnessCodingToolsFactory?: AgentHarnessCodingToolsFactory;
   attributionAttempt: EmbeddedRunAttemptParams;
   params: EmbeddedRunAttemptParams;
   resolvedWorkspace: string;
@@ -232,11 +236,11 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   let agentHarnessModule: typeof import("openclaw/plugin-sdk/agent-harness") | undefined;
   const loadAgentHarnessModule = async () =>
     (agentHarnessModule ??= await import("openclaw/plugin-sdk/agent-harness"));
-  const agentHarnessCodingToolsFactory = injectedOpenClawCodingToolsFactory
-    ? undefined
-    : (dynamicToolBuildState.agentHarnessCodingToolsFactory ??
-      (await import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))
-        .createOpenClawCodingToolsForAgentHarness);
+  const agentHarnessCodingToolsFactory =
+    input.agentHarnessCodingToolsFactory ?? dynamicToolBuildState.agentHarnessCodingToolsFactory;
+  if (!injectedOpenClawCodingToolsFactory && !agentHarnessCodingToolsFactory) {
+    throw new Error("[codex] host tool authority is unavailable");
+  }
   const createOpenClawCodingTools =
     injectedOpenClawCodingToolsFactory ??
     ((options: OpenClawCodingToolsOptions) =>
@@ -244,7 +248,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   toolBuildStages.mark("load-agent-harness-tools");
   const sessionKeys = resolveOpenClawCodingToolsSessionKeys(params, input.sandboxSessionKey);
   const nativeExecutionPolicy = resolveCodexNativeExecutionPolicyForDynamicTools(input);
-  const allTools = createOpenClawCodingTools({
+  const allTools = await createOpenClawCodingTools({
     agentId: input.sessionAgentId,
     ...buildEmbeddedAttemptToolRunContext(params),
     exec: {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -83,6 +83,7 @@ function preserveRingZeroSystemAgentTool<T extends { name: string; catalogMode?:
 }
 /** Runtime inputs needed to derive the exact Codex dynamic tool surface for a turn. */
 type DynamicToolBuildParams = {
+  attributionAttempt: EmbeddedRunAttemptParams;
   params: EmbeddedRunAttemptParams;
   resolvedWorkspace: string;
   effectiveWorkspace: string;
@@ -231,9 +232,15 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   let agentHarnessModule: typeof import("openclaw/plugin-sdk/agent-harness") | undefined;
   const loadAgentHarnessModule = async () =>
     (agentHarnessModule ??= await import("openclaw/plugin-sdk/agent-harness"));
+  const agentHarnessCodingToolsFactory = injectedOpenClawCodingToolsFactory
+    ? undefined
+    : (dynamicToolBuildState.agentHarnessCodingToolsFactory ??
+      (await import("openclaw/plugin-sdk/agent-harness-tool-runtime"))
+        .createOpenClawCodingToolsForAgentHarness);
   const createOpenClawCodingTools =
     injectedOpenClawCodingToolsFactory ??
-    (await loadAgentHarnessModule()).createOpenClawCodingTools;
+    ((options: OpenClawCodingToolsOptions) =>
+      agentHarnessCodingToolsFactory!(input.attributionAttempt, options));
   toolBuildStages.mark("load-agent-harness-tools");
   const sessionKeys = resolveOpenClawCodingToolsSessionKeys(params, input.sandboxSessionKey);
   const nativeExecutionPolicy = resolveCodexNativeExecutionPolicyForDynamicTools(input);

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -159,6 +159,12 @@ export function runCodexAppServerAttempt(
   };
   const promise = runCodexAppServerAttemptImpl(trackedParams, {
     ...options,
+    agentHarnessCodingToolsFactory:
+      options.agentHarnessCodingToolsFactory ??
+      (async (_attempt, toolOptions) => {
+        const factory = dynamicToolBuildState.openClawCodingToolsFactory;
+        return factory ? await factory(toolOptions) : [];
+      }),
     bindingStore: options.bindingStore ?? testCodexAppServerBindingStore,
     ...(clientFactory ? { clientFactory } : {}),
   }).finally(() => {

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -163,7 +163,7 @@ export function runCodexAppServerAttempt(
       options.agentHarnessCodingToolsFactory ??
       (async (_attempt, toolOptions) => {
         const factory = dynamicToolBuildState.openClawCodingToolsFactory;
-        return factory ? await factory(toolOptions) : [];
+        return factory ? factory(toolOptions) : [];
       }),
     bindingStore: options.bindingStore ?? testCodexAppServerBindingStore,
     ...(clientFactory ? { clientFactory } : {}),

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -109,6 +109,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     frameImageIdentity?: string;
   } = { value: 0 };
   const commonToolParams = {
+    agentHarnessCodingToolsFactory: connection.options.agentHarnessCodingToolsFactory,
     // Private attribution is bound to the exact host-admitted object. Codex
     // runtime/tool clones carry behavior only and must not replace this owner.
     attributionAttempt: params,

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -109,6 +109,9 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     frameImageIdentity?: string;
   } = { value: 0 };
   const commonToolParams = {
+    // Private attribution is bound to the exact host-admitted object. Codex
+    // runtime/tool clones carry behavior only and must not replace this owner.
+    attributionAttempt: params,
     params: dynamicToolParams,
     resolvedWorkspace,
     effectiveWorkspace,

--- a/extensions/codex/src/app-server/run-attempt-types.ts
+++ b/extensions/codex/src/app-server/run-attempt-types.ts
@@ -6,6 +6,7 @@ import type { CodexAppServerBindingStore } from "./session-binding.js";
 import type { CodexAppServerClientFactory } from "./shared-client.js";
 
 export type CodexRunAttemptOptions = {
+  agentHarnessCodingToolsFactory?: (typeof import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))["createOpenClawCodingToolsForAgentHarness"];
   bindingStore: CodexAppServerBindingStore;
   pluginConfig?: unknown;
   startupTimeoutFloorMs?: number;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -394,6 +394,7 @@ async function buildDynamicToolsForTest(
     throw new Error("createParams must provide a sessionKey for Codex dynamic tool tests.");
   }
   return testing.buildDynamicTools({
+    attributionAttempt: params,
     params,
     resolvedWorkspace: workspaceDir,
     effectiveWorkspace: workspaceDir,
@@ -498,6 +499,7 @@ async function startThreadWithDisabledNativeSurfaceForTest(
   }
   const nativeToolSurfaceEnabled = testing.shouldEnableCodexAppServerNativeToolSurface(params);
   const dynamicTools = await testing.buildDynamicTools({
+    attributionAttempt: params,
     params,
     resolvedWorkspace: workspaceDir,
     effectiveWorkspace: workspaceDir,
@@ -1120,6 +1122,7 @@ describe("runCodexAppServerAttempt", () => {
       sandbox,
     );
     const dynamicTools = await testing.buildDynamicTools({
+      attributionAttempt: params,
       params,
       resolvedWorkspace: workspaceDir,
       effectiveWorkspace: workspaceDir,
@@ -1223,6 +1226,7 @@ describe("runCodexAppServerAttempt", () => {
         { sandboxExecServerEnabled: true },
       );
       const dynamicTools = await testing.buildDynamicTools({
+        attributionAttempt: params,
         params,
         resolvedWorkspace: workspaceDir,
         effectiveWorkspace: "/workspace",

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -32,6 +32,11 @@ const isCodexAppServerNativeAuthProfileMock = vi.fn();
 const getSharedCodexAppServerClientMock = vi.fn();
 const refreshCodexAppServerAuthTokensMock = vi.fn();
 const createOpenClawCodingToolsMock = vi.fn();
+let sideQuestionToolParams: unknown;
+const createOpenClawCodingToolsForSideQuestionMock = vi.fn((params: unknown, options: unknown) => {
+  sideQuestionToolParams = params;
+  return createOpenClawCodingToolsMock(options);
+});
 const toolExecuteMock = vi.fn();
 const handleCodexAppServerApprovalRequestMock = vi.fn();
 const resolveCodexProviderWebSearchSupportForClientMock = vi.fn();
@@ -95,8 +100,9 @@ vi.mock("./provider-capabilities.js", () => ({
     resolveCodexProviderWebSearchSupportForClientMock(...args),
 }));
 
-vi.mock("openclaw/plugin-sdk/agent-harness", () => ({
-  createOpenClawCodingTools: (...args: unknown[]) => createOpenClawCodingToolsMock(...args),
+vi.mock("openclaw/plugin-sdk/agent-harness-tool-runtime", () => ({
+  createOpenClawCodingToolsForAgentHarnessSideQuestion: (params: unknown, options: unknown) =>
+    createOpenClawCodingToolsForSideQuestionMock(params, options),
 }));
 
 const { runCodexAppServerSideQuestion: runCodexAppServerSideQuestionImpl } =
@@ -474,6 +480,8 @@ describe("runCodexAppServerSideQuestion", () => {
     getSharedCodexAppServerClientMock.mockReset();
     refreshCodexAppServerAuthTokensMock.mockReset();
     createOpenClawCodingToolsMock.mockReset();
+    createOpenClawCodingToolsForSideQuestionMock.mockClear();
+    sideQuestionToolParams = undefined;
     toolExecuteMock.mockReset();
     handleCodexAppServerApprovalRequestMock.mockReset();
     resolveCodexProviderWebSearchSupportForClientMock.mockReset();
@@ -536,33 +544,34 @@ describe("runCodexAppServerSideQuestion", () => {
   it("forks an ephemeral side thread and returns the completed assistant text", async () => {
     const client = createFakeClient();
     getSharedCodexAppServerClientMock.mockResolvedValue(client);
+    const params = sideParams({
+      messageChannel: "discord",
+      messageProvider: "discord-voice",
+      chatId: "discord-native-room",
+      chatType: "channel",
+      sessionKey: "agent:main:conversation",
+      sandboxSessionKey: "agent:main:runtime-policy",
+      messageActionTurnCapability: "turn-capability-1",
+      currentChannelId: "voice-room",
+      agentAccountId: "account-1",
+      messageTo: "channel-1",
+      messageThreadId: "thread-1",
+      groupId: "group-1",
+      groupChannel: "#ops",
+      groupSpace: "workspace-1",
+      spawnedBy: "agent:main:parent",
+      senderId: "sender-1",
+      senderName: "Rosita",
+      senderUsername: "rosita",
+      senderE164: "+15550001",
+      senderIsOwner: true,
+    });
 
-    const result = await runCodexAppServerSideQuestion(
-      sideParams({
-        messageChannel: "discord",
-        messageProvider: "discord-voice",
-        chatId: "discord-native-room",
-        chatType: "channel",
-        sessionKey: "agent:main:conversation",
-        sandboxSessionKey: "agent:main:runtime-policy",
-        messageActionTurnCapability: "turn-capability-1",
-        currentChannelId: "voice-room",
-        agentAccountId: "account-1",
-        messageTo: "channel-1",
-        messageThreadId: "thread-1",
-        groupId: "group-1",
-        groupChannel: "#ops",
-        groupSpace: "workspace-1",
-        spawnedBy: "agent:main:parent",
-        senderId: "sender-1",
-        senderName: "Rosita",
-        senderUsername: "rosita",
-        senderE164: "+15550001",
-        senderIsOwner: true,
-      }),
-    );
+    const result = await runCodexAppServerSideQuestion(params);
 
     expect(result).toEqual({ text: "Side answer." });
+    expect(sideQuestionToolParams).toBe(params);
+    expect(params).not.toHaveProperty("attribution");
     expect(mockCall(getSharedCodexAppServerClientMock)[0]).toMatchObject({
       preparedAuth: {
         kind: "profile",

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -115,9 +115,17 @@ const bindingStore: CodexAppServerBindingStore = {
 
 function runCodexAppServerSideQuestion(
   params: Parameters<typeof runCodexAppServerSideQuestionImpl>[0],
-  options: Omit<Parameters<typeof runCodexAppServerSideQuestionImpl>[1], "bindingStore"> = {},
+  options: Omit<
+    Parameters<typeof runCodexAppServerSideQuestionImpl>[1],
+    "agentHarnessCodingToolsFactory" | "bindingStore"
+  > = {},
 ) {
-  return runCodexAppServerSideQuestionImpl(params, { ...options, bindingStore });
+  return runCodexAppServerSideQuestionImpl(params, {
+    ...options,
+    agentHarnessCodingToolsFactory: (attributionParams, toolOptions) =>
+      createOpenClawCodingToolsForSideQuestionMock(attributionParams, toolOptions),
+    bindingStore,
+  });
 }
 
 function createFakeClient() {

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -100,7 +100,7 @@ vi.mock("./provider-capabilities.js", () => ({
     resolveCodexProviderWebSearchSupportForClientMock(...args),
 }));
 
-vi.mock("openclaw/plugin-sdk/agent-harness-tool-runtime", () => ({
+vi.mock("openclaw/plugin-sdk/agent-harness-tool-authority-runtime", () => ({
   createOpenClawCodingToolsForAgentHarnessSideQuestion: (params: unknown, options: unknown) =>
     createOpenClawCodingToolsForSideQuestionMock(params, options),
 }));

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -161,6 +161,7 @@ Do not modify files, source, git state, permissions, configuration, workspace st
 export async function runCodexAppServerSideQuestion(
   params: AgentHarnessSideQuestionParams,
   options: {
+    agentHarnessCodingToolsFactory?: (typeof import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))["createOpenClawCodingToolsForAgentHarnessSideQuestion"];
     bindingStore: CodexAppServerBindingStore;
     pluginConfig?: unknown;
     nativeHookRelay?: {
@@ -413,6 +414,7 @@ export async function runCodexAppServerSideQuestion(
           })
         : "unsupported";
     const { toolBridge, webSearchPlan } = await createCodexSideToolBridge({
+      agentHarnessCodingToolsFactory: options.agentHarnessCodingToolsFactory,
       attributionParams: params,
       params: effectiveParams,
       cwd,
@@ -921,6 +923,7 @@ function buildSideRunAttemptParams(
 }
 
 async function createCodexSideToolBridge(input: {
+  agentHarnessCodingToolsFactory?: (typeof import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))["createOpenClawCodingToolsForAgentHarnessSideQuestion"];
   attributionParams: AgentHarnessSideQuestionParams;
   params: AgentHarnessSideQuestionParams;
   cwd: string;
@@ -937,8 +940,9 @@ async function createCodexSideToolBridge(input: {
   const messageToolProvider = resolveCodexMessageToolProvider(input.params);
   let tools: AnyAgentTool[] = [];
   if (supportsModelTools(runtimeModel)) {
-    const { createOpenClawCodingToolsForAgentHarnessSideQuestion } =
-      await import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime");
+    if (!input.agentHarnessCodingToolsFactory) {
+      throw new Error("[codex] host side-question tool authority is unavailable");
+    }
     const sandboxSessionKey =
       input.params.sandboxSessionKey?.trim() ||
       input.params.sessionKey?.trim() ||
@@ -949,7 +953,7 @@ async function createCodexSideToolBridge(input: {
       sessionKey: sandboxSessionKey,
       workspaceDir: input.cwd,
     });
-    const allTools = createOpenClawCodingToolsForAgentHarnessSideQuestion(input.attributionParams, {
+    const allTools = await input.agentHarnessCodingToolsFactory(input.attributionParams, {
       agentId: input.sessionAgentId,
       sessionKey: sandboxSessionKey,
       runSessionKey:

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -938,7 +938,7 @@ async function createCodexSideToolBridge(input: {
   let tools: AnyAgentTool[] = [];
   if (supportsModelTools(runtimeModel)) {
     const { createOpenClawCodingToolsForAgentHarnessSideQuestion } =
-      await import("openclaw/plugin-sdk/agent-harness-tool-runtime");
+      await import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime");
     const sandboxSessionKey =
       input.params.sandboxSessionKey?.trim() ||
       input.params.sessionKey?.trim() ||

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -413,6 +413,7 @@ export async function runCodexAppServerSideQuestion(
           })
         : "unsupported";
     const { toolBridge, webSearchPlan } = await createCodexSideToolBridge({
+      attributionParams: params,
       params: effectiveParams,
       cwd,
       pluginConfig,
@@ -920,6 +921,7 @@ function buildSideRunAttemptParams(
 }
 
 async function createCodexSideToolBridge(input: {
+  attributionParams: AgentHarnessSideQuestionParams;
   params: AgentHarnessSideQuestionParams;
   cwd: string;
   pluginConfig: ReturnType<typeof readCodexPluginConfig>;
@@ -935,8 +937,8 @@ async function createCodexSideToolBridge(input: {
   const messageToolProvider = resolveCodexMessageToolProvider(input.params);
   let tools: AnyAgentTool[] = [];
   if (supportsModelTools(runtimeModel)) {
-    const createOpenClawCodingTools = (await import("openclaw/plugin-sdk/agent-harness"))
-      .createOpenClawCodingTools;
+    const { createOpenClawCodingToolsForAgentHarnessSideQuestion } =
+      await import("openclaw/plugin-sdk/agent-harness-tool-runtime");
     const sandboxSessionKey =
       input.params.sandboxSessionKey?.trim() ||
       input.params.sessionKey?.trim() ||
@@ -947,7 +949,7 @@ async function createCodexSideToolBridge(input: {
       sessionKey: sandboxSessionKey,
       workspaceDir: input.cwd,
     });
-    const allTools = createOpenClawCodingTools({
+    const allTools = createOpenClawCodingToolsForAgentHarnessSideQuestion(input.attributionParams, {
       agentId: input.sessionAgentId,
       sessionKey: sandboxSessionKey,
       runSessionKey:

--- a/extensions/copilot/harness.ts
+++ b/extensions/copilot/harness.ts
@@ -39,6 +39,7 @@ type AgentHarnessIsolatedCompletionResult = Awaited<ReturnType<AgentHarnessIsola
 const COPILOT_PROVIDER_IDS: ReadonlySet<string> = new Set(["github-copilot"]);
 
 interface CreateCopilotAgentHarnessOptions {
+  agentHarnessCodingToolsFactory?: (typeof import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))["createOpenClawCodingToolsForAgentHarness"];
   id?: string;
   label?: string;
   pluginConfig?: unknown;
@@ -691,7 +692,10 @@ export function createCopilotAgentHarness(
         // uncaught harness rejection. Finalization cannot safely create a new
         // incompatible session and therefore keeps the failure closed.
         if (operation === "attempt" && isCopilotByokUnsupportedProviderError(error)) {
-          return runCopilotAttempt(params, { pool });
+          return runCopilotAttempt(params, {
+            pool,
+            createOpenClawCodingToolsForAgentHarness: options?.agentHarnessCodingToolsFactory,
+          });
         }
         throw error;
       }
@@ -765,6 +769,7 @@ export function createCopilotAgentHarness(
 
       const result = await runCopilotAttempt(effectiveParams, {
         pool,
+        createOpenClawCodingToolsForAgentHarness: options?.agentHarnessCodingToolsFactory,
         ...(operation === "settled-tool-finalization" ? { operation } : {}),
         onSessionEstablished:
           operation === "attempt" && openclawSessionId

--- a/extensions/copilot/index.ts
+++ b/extensions/copilot/index.ts
@@ -1,4 +1,5 @@
 // Copilot plugin entrypoint registers its OpenClaw integration.
+import { createOpenClawCodingToolsForAgentHarness } from "openclaw/plugin-sdk/agent-harness-tool-authority-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { createCopilotAgentHarness, type CopilotSessionBinding } from "./harness.js";
@@ -42,6 +43,7 @@ export default definePluginEntry({
 
     api.registerAgentHarness(
       createCopilotAgentHarness({
+        agentHarnessCodingToolsFactory: createOpenClawCodingToolsForAgentHarness,
         ...(poolOptions ? { poolOptions } : {}),
         sessionStore,
       }),

--- a/extensions/copilot/src/attempt-execution.ts
+++ b/extensions/copilot/src/attempt-execution.ts
@@ -272,7 +272,9 @@ export async function runCopilotExecution(context: {
           sandbox,
           spawnWorkspaceDir: sandboxAwareSpawnWorkspaceDir,
           abortSignal: params.abortSignal,
-          attemptParams: observeToolTerminal ? { ...input, observeToolTerminal } : input,
+          admittedAttempt: input,
+          attemptParams: input,
+          observeToolTerminal,
           computerContextEpoch,
           sessionRef,
           onYieldDetected: () => {

--- a/extensions/copilot/src/attempt-execution.ts
+++ b/extensions/copilot/src/attempt-execution.ts
@@ -260,6 +260,7 @@ export async function runCopilotExecution(context: {
     if (!settledToolFinalization) {
       try {
         const toolBridge = await createToolBridge({
+          agentHarnessCodingToolsFactory: deps.createOpenClawCodingToolsForAgentHarness,
           allowModelTools: poolAcquire.provider.mode === "byok",
           modelProvider: modelRef.provider,
           modelId: modelRef.id,

--- a/extensions/copilot/src/attempt-types.ts
+++ b/extensions/copilot/src/attempt-types.ts
@@ -12,7 +12,7 @@ import type { OnAssistantDeltaPayload } from "./event-bridge.js";
 import type { CopilotHooksConfig } from "./hooks-bridge.js";
 import type { CopilotPermissionPolicy } from "./permission-bridge.js";
 import type { CopilotClientPool, PooledClient } from "./runtime.js";
-import type { createCopilotToolBridge } from "./tool-bridge.js";
+import type { AgentHarnessCodingToolsFactory, createCopilotToolBridge } from "./tool-bridge.js";
 export const BACKGROUND_COMPACTION_CANCEL_TIMEOUT_MS = 5_000;
 export const COPILOT_ASK_USER_AVAILABLE_TOOLS = ["builtin:ask_user"] as const;
 export const COPILOT_SETTLED_FINALIZATION_SYSTEM_MESSAGE =
@@ -144,6 +144,7 @@ export interface CopilotAttemptDeps {
   operation?: CopilotAttemptOperation;
   now?: () => number;
   createToolBridge?: typeof createCopilotToolBridge;
+  createOpenClawCodingToolsForAgentHarness?: AgentHarnessCodingToolsFactory;
   isHostScopedToolActive?: (toolName: string) => boolean;
   resolveSandboxContextOverride?: ResolveSandboxContextFn;
   onSessionEstablished?: (info: {

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -507,14 +507,14 @@ describe("runCopilotAttempt", () => {
         };
       });
     const createToolBridge = vi.fn(async (input: CopilotToolBridgeInput) => {
-      input.attemptParams?.observeToolTerminal?.({
+      input.observeToolTerminal?.({
         toolCallId: "send-1",
         toolName: "message",
         arguments: { action: "send", message: "hello", target: "room-1" },
         outcome: "failure",
         failure: { error: "delivery failed" },
       });
-      input.attemptParams?.observeToolTerminal?.({
+      input.observeToolTerminal?.({
         toolCallId: "heartbeat-1",
         toolName: "heartbeat_respond",
         arguments: { summary: "ok" },
@@ -596,14 +596,14 @@ describe("runCopilotAttempt", () => {
       });
     const createToolBridge = vi.fn(async (input: CopilotToolBridgeInput) => {
       const args = { action: "send", message: "hello", target: "room-1" };
-      input.attemptParams?.observeToolTerminal?.({
+      input.observeToolTerminal?.({
         toolCallId: "send-1",
         toolName: "message",
         arguments: args,
         outcome: "failure",
         failure: { error: "delivery failed" },
       });
-      input.attemptParams?.observeToolTerminal?.({
+      input.observeToolTerminal?.({
         toolCallId: "send-2",
         toolName: "message",
         arguments: args,
@@ -1676,9 +1676,11 @@ describe("runCopilotAttempt", () => {
     // bridge can build PI-parity tool context and wire onYield to the
     // live SDK session once it exists. See tool-bridge.ts.
     const bridgeCall = (createToolBridge.mock.calls[0] as unknown[] | undefined)?.[0] as {
+      admittedAttempt?: unknown;
       attemptParams?: unknown;
       sessionRef?: { current?: unknown };
     };
+    expect(bridgeCall.admittedAttempt).toBeDefined();
     expect(bridgeCall.attemptParams).toBeDefined();
     expect(bridgeCall.sessionRef).toBeDefined();
     expect(
@@ -1792,11 +1794,13 @@ describe("runCopilotAttempt", () => {
   it("F6: attemptParams carries the full input so the bridge can derive PI-parity tool context", async () => {
     const sdk = makeFakeSdk();
     const pool = makeFakePool(sdk);
-    let capturedParams: unknown;
-    const createToolBridge = vi.fn(async (input: { attemptParams?: unknown }) => {
-      capturedParams = input.attemptParams;
-      return { sdkTools: [], sourceTools: [] };
-    });
+    let capturedInput: { admittedAttempt?: unknown; attemptParams?: unknown } | undefined;
+    const createToolBridge = vi.fn(
+      async (input: { admittedAttempt?: unknown; attemptParams?: unknown }) => {
+        capturedInput = input;
+        return { sdkTools: [], sourceTools: [] };
+      },
+    );
 
     const params = makeParams({
       senderIsOwner: true,
@@ -1807,7 +1811,8 @@ describe("runCopilotAttempt", () => {
 
     // The bridge receives the same params object so it can read every
     // identity/policy/channel field the wrapped-tool layer needs.
-    expect(capturedParams).toBe(params);
+    expect(capturedInput?.attemptParams).toBe(params);
+    expect(capturedInput?.admittedAttempt).toBe(params);
   });
 
   it("F7: result.yieldDetected is true when the tool bridge fires onYieldDetected during the attempt", async () => {

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { CopilotClient, Tool as SdkTool } from "@github/copilot-sdk";
 import { expectDefined } from "@openclaw/normalization-core";
+import { createOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
 import {
   abortAgentHarnessRun,
   attachModelProviderRequestTransport,
@@ -552,7 +553,11 @@ describe("runCopilotAttempt", () => {
         disableTools: false,
         config: { tools: { codeMode: true } },
       } as never),
-      { pool: makeFakePool(sdk) },
+      {
+        createOpenClawCodingToolsForAgentHarness: async (_attempt, options) =>
+          createOpenClawCodingTools(options),
+        pool: makeFakePool(sdk),
+      },
     );
 
     expect(result.codeModeEngaged).toBe(true);

--- a/extensions/copilot/src/tool-bridge.lazy-import.test.ts
+++ b/extensions/copilot/src/tool-bridge.lazy-import.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.doUnmock("openclaw/plugin-sdk/agent-harness-tool-authority-runtime");
+  vi.resetModules();
+});
+
+it("loads the private tool builder only after the tool-construction guard", async () => {
+  let toolBuilderImports = 0;
+  vi.doMock("openclaw/plugin-sdk/agent-harness-tool-authority-runtime", () => {
+    toolBuilderImports += 1;
+    return {
+      createOpenClawCodingToolsForAgentHarness: vi.fn(() => []),
+    };
+  });
+
+  const { createCopilotToolBridge } = await import("./tool-bridge.js");
+  expect(toolBuilderImports).toBe(0);
+
+  await expect(
+    createCopilotToolBridge({
+      admittedAttempt: {} as never,
+      agentId: "agent-1",
+      attemptParams: { disableTools: true } as never,
+      modelId: "gpt-4o",
+      modelProvider: "github-copilot",
+      sessionId: "session-1",
+    }),
+  ).resolves.toEqual({ codeModeEngaged: false, sdkTools: [], sourceTools: [] });
+  expect(toolBuilderImports).toBe(0);
+
+  await expect(
+    createCopilotToolBridge({
+      admittedAttempt: {} as never,
+      agentId: "agent-1",
+      attemptParams: {} as never,
+      modelId: "gpt-4o",
+      modelProvider: "github-copilot",
+      sessionId: "session-1",
+    }),
+  ).resolves.toMatchObject({ sdkTools: [], sourceTools: [] });
+  expect(toolBuilderImports).toBe(1);
+});

--- a/extensions/copilot/src/tool-bridge.lazy-import.test.ts
+++ b/extensions/copilot/src/tool-bridge.lazy-import.test.ts
@@ -1,24 +1,12 @@
-import { afterEach, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
+import { createCopilotToolBridge } from "./tool-bridge.js";
 
-afterEach(() => {
-  vi.doUnmock("openclaw/plugin-sdk/agent-harness-tool-authority-runtime");
-  vi.resetModules();
-});
-
-it("loads the private tool builder only after the tool-construction guard", async () => {
-  let toolBuilderImports = 0;
-  vi.doMock("openclaw/plugin-sdk/agent-harness-tool-authority-runtime", () => {
-    toolBuilderImports += 1;
-    return {
-      createOpenClawCodingToolsForAgentHarness: vi.fn(() => []),
-    };
-  });
-
-  const { createCopilotToolBridge } = await import("./tool-bridge.js");
-  expect(toolBuilderImports).toBe(0);
+it("invokes host tool authority only after the tool-construction guard", async () => {
+  const agentHarnessCodingToolsFactory = vi.fn(async () => []);
 
   await expect(
     createCopilotToolBridge({
+      agentHarnessCodingToolsFactory,
       admittedAttempt: {} as never,
       agentId: "agent-1",
       attemptParams: { disableTools: true } as never,
@@ -27,10 +15,11 @@ it("loads the private tool builder only after the tool-construction guard", asyn
       sessionId: "session-1",
     }),
   ).resolves.toEqual({ codeModeEngaged: false, sdkTools: [], sourceTools: [] });
-  expect(toolBuilderImports).toBe(0);
+  expect(agentHarnessCodingToolsFactory).not.toHaveBeenCalled();
 
   await expect(
     createCopilotToolBridge({
+      agentHarnessCodingToolsFactory,
       admittedAttempt: {} as never,
       agentId: "agent-1",
       attemptParams: {} as never,
@@ -39,5 +28,5 @@ it("loads the private tool builder only after the tool-construction guard", asyn
       sessionId: "session-1",
     }),
   ).resolves.toMatchObject({ sdkTools: [], sourceTools: [] });
-  expect(toolBuilderImports).toBe(1);
+  expect(agentHarnessCodingToolsFactory).toHaveBeenCalledOnce();
 });

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -22,7 +22,10 @@ import {
   resolveModelAuthMode,
   sanitizeToolResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { createAgentHarnessToolSurfaceRuntime } from "openclaw/plugin-sdk/agent-harness-tool-runtime";
+import {
+  createAgentHarnessToolSurfaceRuntime,
+  createOpenClawCodingToolsForAgentHarness,
+} from "openclaw/plugin-sdk/agent-harness-tool-runtime";
 
 type CreateOpenClawCodingTools =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
@@ -104,6 +107,8 @@ interface CopilotToolBridgeInput {
    */
   spawnWorkspaceDir?: string;
   abortSignal?: AbortSignal;
+  /** Exact core-admitted attempt object used only as a private identity capability. */
+  admittedAttempt?: EmbeddedRunAttemptParams;
   /**
    * Full PI-parity attempt parameters. When set, the bridge forwards
    * identity, channel, owner/policy, auth-profile, message-routing,
@@ -133,6 +138,7 @@ interface CopilotToolBridgeInput {
    */
   onYieldDetected?: (message?: string) => void;
   onToolCompleted?: (completion: CopilotToolCompletion) => void | Promise<void>;
+  observeToolTerminal?: CopilotToolTerminalObserver;
   createOpenClawCodingTools?: (opts: unknown) => AnyAgentTool[] | Promise<AnyAgentTool[]>;
   beforeExecute?: (ctx: {
     toolName: string;
@@ -194,9 +200,13 @@ export async function createCopilotToolBridge(
     return { codeModeEngaged: false, sdkTools: [], sourceTools: [] };
   }
 
+  const admittedAttempt = input.admittedAttempt;
   const createOpenClawCodingTools =
     input.createOpenClawCodingTools ??
-    (await import("openclaw/plugin-sdk/agent-harness")).createOpenClawCodingTools;
+    (admittedAttempt
+      ? (options: OpenClawCodingToolsOptions) =>
+          createOpenClawCodingToolsForAgentHarness(admittedAttempt, options)
+      : (await import("openclaw/plugin-sdk/agent-harness")).createOpenClawCodingTools);
 
   const toolSurfaceRuntime = createAgentHarnessToolSurfaceRuntime({
     abortSignal: input.abortSignal,
@@ -284,7 +294,7 @@ export async function createCopilotToolBridge(
         beforeExecute: input.beforeExecute,
         onAgentToolResult: input.attemptParams?.onAgentToolResult,
         onToolCompleted: input.onToolCompleted,
-        observeToolTerminal: input.attemptParams?.observeToolTerminal,
+        observeToolTerminal: input.observeToolTerminal ?? input.attemptParams?.observeToolTerminal,
       }),
     ),
     sourceTools: filteredTools,
@@ -703,7 +713,7 @@ async function executeCatalogTool(
       ? (extractToolErrorMessage(sanitizedResult) ?? "tool returned an error")
       : undefined;
     terminalObserved = true;
-    input.attemptParams?.observeToolTerminal?.({
+    (input.observeToolTerminal ?? input.attemptParams?.observeToolTerminal)?.({
       toolCallId: params.toolCallId,
       toolName: params.toolName,
       arguments: preparedArgs,
@@ -730,7 +740,7 @@ async function executeCatalogTool(
     // Completion hooks can throw after the tool terminal outcome. Do not
     // rewrite that recorded outcome as a second, contradictory tool failure.
     if (!terminalObserved) {
-      input.attemptParams?.observeToolTerminal?.({
+      (input.observeToolTerminal ?? input.attemptParams?.observeToolTerminal)?.({
         toolCallId: params.toolCallId,
         toolName: params.toolName,
         arguments: preparedArgs,

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -22,10 +22,7 @@ import {
   resolveModelAuthMode,
   sanitizeToolResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import {
-  createAgentHarnessToolSurfaceRuntime,
-  createOpenClawCodingToolsForAgentHarness,
-} from "openclaw/plugin-sdk/agent-harness-tool-runtime";
+import { createAgentHarnessToolSurfaceRuntime } from "openclaw/plugin-sdk/agent-harness-tool-runtime";
 
 type CreateOpenClawCodingTools =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
@@ -204,8 +201,11 @@ export async function createCopilotToolBridge(
   const createOpenClawCodingTools =
     input.createOpenClawCodingTools ??
     (admittedAttempt
-      ? (options: OpenClawCodingToolsOptions) =>
-          createOpenClawCodingToolsForAgentHarness(admittedAttempt, options)
+      ? async (options: OpenClawCodingToolsOptions) => {
+          const { createOpenClawCodingToolsForAgentHarness } =
+            await import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime");
+          return createOpenClawCodingToolsForAgentHarness(admittedAttempt, options);
+        }
       : (await import("openclaw/plugin-sdk/agent-harness")).createOpenClawCodingTools);
 
   const toolSurfaceRuntime = createAgentHarnessToolSurfaceRuntime({

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -27,6 +27,8 @@ import { createAgentHarnessToolSurfaceRuntime } from "openclaw/plugin-sdk/agent-
 type CreateOpenClawCodingTools =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
 type OpenClawCodingToolsOptions = NonNullable<Parameters<CreateOpenClawCodingTools>[0]>;
+export type AgentHarnessCodingToolsFactory =
+  (typeof import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime"))["createOpenClawCodingToolsForAgentHarness"];
 type AgentHarnessToolSurfaceRuntime = ReturnType<typeof createAgentHarnessToolSurfaceRuntime>;
 type CatalogExecuteParams = Parameters<
   NonNullable<AgentHarnessToolSurfaceRuntime["toolSearchCatalogExecutor"]>
@@ -71,6 +73,7 @@ type CopilotToolCompletion = {
 };
 
 interface CopilotToolBridgeInput {
+  agentHarnessCodingToolsFactory?: AgentHarnessCodingToolsFactory;
   allowModelTools?: boolean;
   /** Invalidates screenshot-bound computer actions after context compaction. */
   computerContextEpoch?: {
@@ -136,7 +139,9 @@ interface CopilotToolBridgeInput {
   onYieldDetected?: (message?: string) => void;
   onToolCompleted?: (completion: CopilotToolCompletion) => void | Promise<void>;
   observeToolTerminal?: CopilotToolTerminalObserver;
-  createOpenClawCodingTools?: (opts: unknown) => AnyAgentTool[] | Promise<AnyAgentTool[]>;
+  createOpenClawCodingTools?: (
+    options: OpenClawCodingToolsOptions,
+  ) => AnyAgentTool[] | Promise<AnyAgentTool[]>;
   beforeExecute?: (ctx: {
     toolName: string;
     toolCallId: string;
@@ -198,15 +203,16 @@ export async function createCopilotToolBridge(
   }
 
   const admittedAttempt = input.admittedAttempt;
-  const createOpenClawCodingTools =
-    input.createOpenClawCodingTools ??
-    (admittedAttempt
-      ? async (options: OpenClawCodingToolsOptions) => {
-          const { createOpenClawCodingToolsForAgentHarness } =
-            await import("openclaw/plugin-sdk/agent-harness-tool-authority-runtime");
-          return createOpenClawCodingToolsForAgentHarness(admittedAttempt, options);
-        }
-      : (await import("openclaw/plugin-sdk/agent-harness")).createOpenClawCodingTools);
+  let createOpenClawCodingTools = input.createOpenClawCodingTools;
+  if (!createOpenClawCodingTools && admittedAttempt) {
+    if (!input.agentHarnessCodingToolsFactory) {
+      throw new Error("[copilot-tool-bridge] host tool authority is unavailable");
+    }
+    createOpenClawCodingTools = (options: OpenClawCodingToolsOptions) =>
+      input.agentHarnessCodingToolsFactory!(admittedAttempt, options);
+  }
+  createOpenClawCodingTools ??= (await import("openclaw/plugin-sdk/agent-harness"))
+    .createOpenClawCodingTools;
 
   const toolSurfaceRuntime = createAgentHarnessToolSurfaceRuntime({
     abortSignal: input.abortSignal,

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -134,6 +134,9 @@
       "openclaw/plugin-sdk/agent-harness-exec-review-runtime": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/agent-harness-exec-review-runtime.d.ts"
       ],
+      "openclaw/plugin-sdk/agent-harness-tool-authority-runtime": [
+        "../packages/plugin-sdk/dist/src/plugin-sdk/agent-harness-tool-authority-runtime.d.ts"
+      ],
       "openclaw/plugin-sdk/agent-harness-tool-runtime": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/agent-harness-tool-runtime.d.ts"
       ],

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -131,6 +131,9 @@
       "openclaw/plugin-sdk/agent-harness-exec-review-runtime": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/agent-harness-exec-review-runtime.d.ts"
       ],
+      "openclaw/plugin-sdk/agent-harness-tool-authority-runtime": [
+        "../../packages/plugin-sdk/dist/src/plugin-sdk/agent-harness-tool-authority-runtime.d.ts"
+      ],
       "openclaw/plugin-sdk/agent-harness-tool-runtime": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/agent-harness-tool-runtime.d.ts"
       ],

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "!dist/plugin-sdk/agent-core.d.ts",
     "!dist/plugin-sdk/agent-harness-exec-review-runtime.d.ts",
     "!dist/plugin-sdk/agent-harness-task-runtime.d.ts",
+    "!dist/plugin-sdk/agent-harness-tool-authority-runtime.d.ts",
     "!dist/plugin-sdk/agent-harness-tool-runtime.d.ts",
     "!dist/plugin-sdk/agent-runtime-test-contracts.js",
     "!dist/plugin-sdk/agent-runtime-test-contracts.d.ts",

--- a/scripts/lib/plugin-npm-runtime-build.d.mts
+++ b/scripts/lib/plugin-npm-runtime-build.d.mts
@@ -33,7 +33,7 @@ export type PluginNpmRuntimeBuildPlan = {
 };
 /** Resolve the package-local runtime build plan for one publishable plugin package. */
 export function resolvePluginNpmRuntimeBuildPlan(params: unknown): PluginNpmRuntimeBuildPlan | null;
-/** List built host SDK imports that are absent from the OpenClaw package exports. */
+/** List built host SDK imports unavailable through package exports or owner-restricted aliases. */
 export function listMissingPluginNpmRuntimeHostExports(plan: PluginNpmRuntimeBuildPlan): string[];
 /** Build package-local runtime files and static assets for one plugin package. */
 export function buildPluginNpmRuntime(params: unknown): Promise<

--- a/scripts/lib/plugin-npm-runtime-build.mjs
+++ b/scripts/lib/plugin-npm-runtime-build.mjs
@@ -93,6 +93,10 @@ function createNeverBundleDependencyMatcher(packageJson) {
 
 const HOST_PLUGIN_SDK_IMPORT_RE =
   /(?:\bfrom\s+|\bimport\s*(?:\(\s*)?|\b(?:require|_+require\d*)\(\s*)["'](openclaw\/plugin-sdk\/[^"']+)["']/gu;
+const OWNER_RESTRICTED_HOST_IMPORTS_BY_PACKAGE_NAME = new Map([
+  ["@openclaw/codex", new Set(["openclaw/plugin-sdk/agent-harness-tool-authority-runtime"])],
+  ["@openclaw/copilot", new Set(["openclaw/plugin-sdk/agent-harness-tool-authority-runtime"])],
+]);
 
 function listRuntimeJavaScriptFiles(rootDir) {
   if (!fs.existsSync(rootDir)) {
@@ -111,8 +115,8 @@ function listRuntimeJavaScriptFiles(rootDir) {
 }
 
 /**
- * List host SDK imports emitted by a built plugin runtime but absent from package exports.
- * @param {{ repoRoot: string; outDir: string }} plan
+ * List host SDK imports emitted by a built plugin runtime but unavailable to its package owner.
+ * @param {{ repoRoot: string; outDir: string; packageJson?: { name?: unknown } }} plan
  */
 export function listMissingPluginNpmRuntimeHostExports(plan) {
   const hostImports = new Set();
@@ -131,8 +135,16 @@ export function listMissingPluginNpmRuntimeHostExports(plan) {
 
   const hostPackageJson = readJsonFile(path.join(plan.repoRoot, "package.json"));
   const hostExports = new Set(Object.keys(hostPackageJson.exports ?? {}));
+  const packageName =
+    typeof plan.packageJson?.name === "string" ? plan.packageJson.name.trim() : "";
+  const ownerRestrictedHostImports =
+    OWNER_RESTRICTED_HOST_IMPORTS_BY_PACKAGE_NAME.get(packageName) ?? new Set();
   return [...hostImports]
-    .filter((specifier) => !hostExports.has(specifier.replace(/^openclaw/u, ".")))
+    .filter(
+      (specifier) =>
+        !hostExports.has(specifier.replace(/^openclaw/u, ".")) &&
+        !ownerRestrictedHostImports.has(specifier),
+    )
     .toSorted((left, right) => left.localeCompare(right));
 }
 

--- a/scripts/lib/plugin-sdk-entries.mjs
+++ b/scripts/lib/plugin-sdk-entries.mjs
@@ -84,6 +84,10 @@ export const packagedPrivatePluginSdkRuntimeEntrypoints =
     productionPluginSdkEntrypointSet.has(entry),
   );
 
+const ownerRestrictedPrivatePluginSdkRuntimeEntrypointSet = new Set([
+  "agent-harness-tool-authority-runtime",
+]);
+
 /** Private entrypoints reserved for local tests and QA builds. */
 const nonProductionPrivatePluginSdkEntrypoints = privateLocalOnlyPluginSdkEntrypoints.filter(
   (entry) => !productionPluginSdkEntrypointSet.has(entry),
@@ -131,7 +135,10 @@ export function buildPluginSdkPackageExports() {
           ],
         ];
       }
-      if (packagedPrivatePluginSdkRuntimeEntrypoints.includes(entry)) {
+      if (
+        packagedPrivatePluginSdkRuntimeEntrypoints.includes(entry) &&
+        !ownerRestrictedPrivatePluginSdkRuntimeEntrypointSet.has(entry)
+      ) {
         // Official plugins ship separately but execute against the host's private runtime.
         // Their declarations stay pack-excluded by listUnpackagedPrivatePluginSdkDistArtifacts.
         return [

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -107,6 +107,7 @@
   "agent-harness",
   "agent-harness-exec-review-runtime",
   "agent-harness-runtime",
+  "agent-harness-tool-authority-runtime",
   "agent-harness-tool-runtime",
   "hook-runtime",
   "html-entity-runtime",

--- a/scripts/lib/plugin-sdk-private-local-only-subpaths.json
+++ b/scripts/lib/plugin-sdk-private-local-only-subpaths.json
@@ -8,6 +8,7 @@
   "agent-core",
   "agent-harness-exec-review-runtime",
   "agent-harness-task-runtime",
+  "agent-harness-tool-authority-runtime",
   "agent-harness-tool-runtime",
   "agent-runtime-test-contracts",
   "agent-sessions",

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -7,6 +7,7 @@ import { createHash } from "node:crypto";
 import { logDebug, logError } from "../logger.js";
 import { redactToolDetail } from "../logging/redact.js";
 import { isPlainObject } from "../utils.js";
+import { resolveToolExecutionCorrelation } from "./agent-tools.before-tool-call.attribution.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
 import {
   buildBlockedToolResult,
@@ -332,6 +333,7 @@ export function toToolDefinitions(
   tools: AnyAgentTool[],
   hookContext?: HookContext,
 ): ToolDefinition[] {
+  const correlation = resolveToolExecutionCorrelation(hookContext);
   return tools.map((tool) => {
     const name = tool.name || "tool";
     const normalizedName = normalizeToolName(name);
@@ -347,7 +349,7 @@ export function toToolDefinitions(
       executionMode: tool.executionMode,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
-        recordStructuredReplayTrustForToolCall(toolCallId, tool, hookContext?.runId);
+        recordStructuredReplayTrustForToolCall(toolCallId, tool, correlation.runId);
         let executeParams = params;
         try {
           if (!beforeHookWrapped) {
@@ -380,7 +382,7 @@ export function toToolDefinitions(
                   reason: hookOutcome.reason,
                   deniedReason: hookOutcome.deniedReason,
                   toolCallId,
-                  runId: hookContext?.runId,
+                  runId: correlation.runId,
                 });
               }
               throw new Error(hookOutcome.reason);
@@ -404,10 +406,10 @@ export function toToolDefinitions(
                 reason: voiceConfirmation.reason,
                 deniedReason: "client-voice-confirmation",
                 toolCallId,
-                runId: hookContext?.runId,
+                runId: correlation.runId,
               });
             }
-            recordAdjustedParamsForToolCall(toolCallId, executeParams, hookContext?.runId);
+            recordAdjustedParamsForToolCall(toolCallId, executeParams, correlation.runId);
           }
           const rawResult = await tool.execute(toolCallId, executeParams, signal, onUpdate);
           const result = normalizeToolExecutionResult({
@@ -424,7 +426,7 @@ export function toToolDefinitions(
             return buildBlockedToolResult({
               reason: err.reason,
               toolCallId,
-              runId: hookContext?.runId,
+              runId: correlation.runId,
             });
           }
           const described = describeToolExecutionError(err);
@@ -500,6 +502,7 @@ export function toClientToolDefinitions(
   onClientToolCall?: ClientToolCallRecorder,
   hookContext?: HookContext,
 ): ToolDefinition[] {
+  const correlation = resolveToolExecutionCorrelation(hookContext);
   return tools.map((tool) => {
     const func = tool.function;
     return {
@@ -530,7 +533,7 @@ export function toClientToolDefinitions(
                 reason: outcome.reason,
                 deniedReason: outcome.deniedReason,
                 toolCallId,
-                runId: hookContext?.runId,
+                runId: correlation.runId,
               });
             }
             throw new Error(outcome.reason);
@@ -552,7 +555,7 @@ export function toClientToolDefinitions(
               reason: voiceConfirmation.reason,
               deniedReason: "client-voice-confirmation",
               toolCallId,
-              runId: hookContext?.runId,
+              runId: correlation.runId,
             });
           }
           // Notify handler that a client tool was called.

--- a/src/agents/agent-tools-internal.ts
+++ b/src/agents/agent-tools-internal.ts
@@ -1,0 +1,54 @@
+import { createOpenClawCodingTools, createOpenClawCodingToolsInternal } from "./agent-tools.js";
+import { resolveEmbeddedAttemptExecutionAttribution } from "./embedded-agent-runner/run/attempt-execution-attribution.js";
+import type { EmbeddedRunAttemptParams } from "./embedded-agent-runner/run/types.js";
+import { resolveAgentHarnessSideQuestionExecutionAttribution } from "./harness/side-question-execution-attribution.js";
+import type { AgentHarnessSideQuestionParams } from "./harness/types.js";
+
+type OpenClawCodingToolsInternalOptions = NonNullable<
+  Parameters<typeof createOpenClawCodingToolsInternal>[0]
+>;
+type OpenClawCodingToolsOptions = NonNullable<Parameters<typeof createOpenClawCodingTools>[0]>;
+
+function stripUntrustedAttribution(
+  options: OpenClawCodingToolsOptions | undefined,
+): OpenClawCodingToolsOptions {
+  const { attribution: _untrustedAttribution, ...publicOptions } = (options ??
+    {}) as OpenClawCodingToolsInternalOptions;
+  return publicOptions;
+}
+
+export function createOpenClawCodingToolsForRuntime(
+  options?: OpenClawCodingToolsInternalOptions,
+): ReturnType<typeof createOpenClawCodingToolsInternal> {
+  return createOpenClawCodingToolsInternal(options);
+}
+
+/**
+ * Construct tools for a core-admitted harness attempt. The attempt object is
+ * the capability: unbound plugin-created objects receive no trusted identity.
+ */
+export function createOpenClawCodingToolsForAgentHarness(
+  attempt: EmbeddedRunAttemptParams,
+  options?: OpenClawCodingToolsOptions,
+): ReturnType<typeof createOpenClawCodingToolsInternal> {
+  const attribution = resolveEmbeddedAttemptExecutionAttribution(attempt);
+  return createOpenClawCodingToolsInternal({
+    ...stripUntrustedAttribution(options),
+    ...(attribution ? { attribution } : {}),
+  });
+}
+
+/**
+ * Construct tools for the exact host-admitted side-question request. The
+ * public request object is the capability; its fields contain no attribution.
+ */
+export function createOpenClawCodingToolsForAgentHarnessSideQuestion(
+  params: AgentHarnessSideQuestionParams,
+  options?: OpenClawCodingToolsOptions,
+): ReturnType<typeof createOpenClawCodingToolsInternal> {
+  const attribution = resolveAgentHarnessSideQuestionExecutionAttribution(params);
+  return createOpenClawCodingToolsInternal({
+    ...stripUntrustedAttribution(options),
+    ...(attribution ? { attribution } : {}),
+  });
+}

--- a/src/agents/agent-tools.before-tool-call.approval.ts
+++ b/src/agents/agent-tools.before-tool-call.approval.ts
@@ -26,6 +26,7 @@ import {
 } from "../plugins/types.js";
 import { resolveSkillWorkshopToolApproval } from "../skills/workshop/policy.js";
 import { isPlainObject } from "../utils.js";
+import { resolveToolExecutionCorrelation } from "./agent-tools.before-tool-call.attribution.js";
 import { resolveToolErrorDiagnostic } from "./agent-tools.before-tool-call.diagnostics.js";
 import type {
   DeferredPluginToolApproval,
@@ -188,6 +189,7 @@ async function requestPluginToolApproval(params: {
   overrideParams?: unknown;
 }): Promise<HookOutcome> {
   const approval = params.approval;
+  const correlation = resolveToolExecutionCorrelation(params.ctx);
   const timeoutMs = resolvePluginToolApprovalTimeoutMs(approval);
   const gatewayTimeoutMs = resolvePluginToolApprovalGatewayTimeoutMs(timeoutMs);
   const allowedDecisions = resolveCanonicalPluginApprovalRequestAllowedDecisions(approval);
@@ -204,8 +206,8 @@ async function requestPluginToolApproval(params: {
           allowedDecisions: approval.allowedDecisions,
           toolName: params.toolName,
           toolCallId: params.toolCallId,
-          agentId: params.ctx?.agentId,
-          sessionKey: params.ctx?.sessionKey,
+          agentId: correlation.agentId,
+          sessionKey: correlation.sessionKey,
           turnSourceChannel: params.ctx?.turnSourceChannel,
           turnSourceTo: params.ctx?.turnSourceTo,
           turnSourceAccountId: params.ctx?.turnSourceAccountId,
@@ -289,8 +291,8 @@ async function requestPluginToolApproval(params: {
         allowedDecisions: approval.allowedDecisions,
         toolName: params.toolName,
         toolCallId: params.toolCallId,
-        agentId: params.ctx?.agentId,
-        sessionKey: params.ctx?.sessionKey,
+        agentId: correlation.agentId,
+        sessionKey: correlation.sessionKey,
         ...(params.ctx?.approvalReviewerDeviceId
           ? { approvalReviewerDeviceIds: [params.ctx.approvalReviewerDeviceId] }
           : {}),

--- a/src/agents/agent-tools.before-tool-call.attribution.test.ts
+++ b/src/agents/agent-tools.before-tool-call.attribution.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { createAgentExecutionAttribution } from "./agent-execution-attribution.js";
+import {
+  bindToolExecutionAttribution,
+  resolveToolExecutionCorrelation,
+} from "./agent-tools.before-tool-call.attribution.js";
+
+describe("tool execution attribution", () => {
+  it("keeps exact execution identity in the host-only correlation", () => {
+    const attribution = createAgentExecutionAttribution({
+      runId: "run-1",
+      lifecycleGeneration: "generation-1",
+      sessionKey: "session-1",
+      sessionId: "session-id-1",
+      agentId: "agent-1",
+    });
+    const hookContext = bindToolExecutionAttribution(
+      {
+        runId: "flat-run",
+        sessionKey: "flat-session",
+        sessionId: "flat-session-id",
+        agentId: "flat-agent",
+      },
+      attribution,
+    );
+
+    expect(resolveToolExecutionCorrelation(hookContext)).toEqual({
+      runId: attribution.runId,
+      contextId: attribution.contextId,
+      executionId: attribution.executionId,
+      lifecycleGeneration: attribution.lifecycleGeneration,
+      sessionKey: attribution.sessionKey,
+      sessionId: attribution.sessionId,
+      agentId: attribution.agentId,
+    });
+    expect(hookContext).not.toHaveProperty("attribution");
+    expect(hookContext).not.toHaveProperty("executionId");
+    expect(hookContext).not.toHaveProperty("contextId");
+  });
+
+  it("ignores forged exact identity fields on an unbound hook context", () => {
+    expect(
+      resolveToolExecutionCorrelation({
+        runId: "public-run",
+        sessionKey: "public-session",
+        contextId: "forged-context",
+        executionId: "forged-execution",
+        lifecycleGeneration: "forged-generation",
+      } as never),
+    ).toEqual({
+      runId: "public-run",
+      sessionKey: "public-session",
+    });
+  });
+
+  it("treats absent bound identity fields as authoritative", () => {
+    const attribution = createAgentExecutionAttribution({
+      runId: "run-sparse",
+      lifecycleGeneration: "generation-sparse",
+    });
+    const hookContext = bindToolExecutionAttribution(
+      {
+        runId: "flat-run",
+        sessionKey: "flat-session",
+        sessionId: "flat-session-id",
+        agentId: "flat-agent",
+      },
+      attribution,
+    );
+
+    expect(resolveToolExecutionCorrelation(hookContext)).toEqual({
+      runId: attribution.runId,
+      contextId: attribution.contextId,
+      executionId: attribution.executionId,
+      lifecycleGeneration: attribution.lifecycleGeneration,
+    });
+  });
+});

--- a/src/agents/agent-tools.before-tool-call.attribution.ts
+++ b/src/agents/agent-tools.before-tool-call.attribution.ts
@@ -1,0 +1,61 @@
+import type { AgentExecutionAttribution } from "./agent-execution-attribution.js";
+import type { HookContext } from "./agent-tools.before-tool-call.types.js";
+
+type ToolExecutionCorrelation = Readonly<{
+  agentId?: string;
+  contextId?: string;
+  executionId?: string;
+  lifecycleGeneration?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+}>;
+
+const attributionByHookContext = new WeakMap<HookContext, AgentExecutionAttribution>();
+
+/**
+ * Bind admission attribution to a core-owned hook context without exposing a
+ * forgeable property at the public SDK boundary.
+ */
+export function bindToolExecutionAttribution(
+  ctx: HookContext,
+  attribution: AgentExecutionAttribution | undefined,
+): HookContext {
+  if (attribution) {
+    attributionByHookContext.set(ctx, attribution);
+  }
+  return ctx;
+}
+
+/** Preserve a private binding when a core owner must clone a hook context. */
+export function inheritToolExecutionAttribution(
+  source: HookContext | undefined,
+  target: HookContext,
+): HookContext {
+  const attribution = source ? attributionByHookContext.get(source) : undefined;
+  return bindToolExecutionAttribution(target, attribution);
+}
+
+/** Bound admission attribution is the only source of exact execution identity. */
+export function resolveToolExecutionCorrelation(ctx?: HookContext): ToolExecutionCorrelation {
+  const attribution = ctx ? attributionByHookContext.get(ctx) : undefined;
+  if (!attribution) {
+    return {
+      ...(ctx?.agentId ? { agentId: ctx.agentId } : {}),
+      ...(ctx?.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
+      ...(ctx?.sessionId ? { sessionId: ctx.sessionId } : {}),
+      ...(ctx?.runId ? { runId: ctx.runId } : {}),
+    };
+  }
+  return {
+    ...(attribution.agentId ? { agentId: attribution.agentId } : {}),
+    ...(attribution.contextId ? { contextId: attribution.contextId } : {}),
+    ...(attribution.executionId ? { executionId: attribution.executionId } : {}),
+    ...(attribution.lifecycleGeneration
+      ? { lifecycleGeneration: attribution.lifecycleGeneration }
+      : {}),
+    ...(attribution.sessionKey ? { sessionKey: attribution.sessionKey } : {}),
+    ...(attribution.sessionId ? { sessionId: attribution.sessionId } : {}),
+    ...(attribution.runId ? { runId: attribution.runId } : {}),
+  };
+}

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -37,6 +37,7 @@ import {
 } from "../skills/loading/source.js";
 import type { SkillSnapshot, SkillTelemetrySource, SkillUsagePath } from "../skills/types.js";
 import { isPlainObject, truncateUtf16Safe } from "../utils.js";
+import { resolveToolExecutionCorrelation } from "./agent-tools.before-tool-call.attribution.js";
 import { buildAdjustedParamsKey } from "./agent-tools.before-tool-call.state.js";
 import type {
   HookBlockedReason,
@@ -109,8 +110,9 @@ export function rememberPendingTerminalPresentation(params: {
   if (!params.toolCallId || !params.ctx?.onToolOutcome) {
     return;
   }
+  const correlation = resolveToolExecutionCorrelation(params.ctx);
   const key = buildAdjustedParamsKey({
-    runId: params.ctx.runId,
+    runId: correlation.runId,
     toolCallId: params.toolCallId,
   });
   pendingTerminalPresentationByToolCall.set(key, {
@@ -431,6 +433,7 @@ export function emitSkillUsedDiagnostic(params: {
   toolName: string;
   toolCallId?: string;
 }): void {
+  const correlation = resolveToolExecutionCorrelation(params.ctx);
   const trace = params.ctx?.trace
     ? freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(params.ctx.trace))
     : undefined;
@@ -439,10 +442,10 @@ export function emitSkillUsedDiagnostic(params: {
   emitTrustedSkillUsedDiagnosticEvent(
     {
       type: "skill.used",
-      ...(params.ctx?.runId && { runId: params.ctx.runId }),
-      ...(params.ctx?.sessionKey && { sessionKey: params.ctx.sessionKey }),
-      ...(params.ctx?.sessionId && { sessionId: params.ctx.sessionId }),
-      ...(params.ctx?.agentId && { agentId: params.ctx.agentId }),
+      ...(correlation.runId && { runId: correlation.runId }),
+      ...(correlation.sessionKey && { sessionKey: correlation.sessionKey }),
+      ...(correlation.sessionId && { sessionId: correlation.sessionId }),
+      ...(correlation.agentId && { agentId: correlation.agentId }),
       ...(trace && { trace }),
       skillName: params.match.skillName,
       skillSource: params.match.skillSource,
@@ -587,7 +590,11 @@ export async function reconcileLoopCallExecutionParams(args: {
   toolParams: unknown;
   toolCallId?: string;
 }): Promise<void> {
-  if ((!args.ctx?.sessionKey && !args.ctx?.sessionId) || args.ctx.loopDetection?.enabled !== true) {
+  const correlation = resolveToolExecutionCorrelation(args.ctx);
+  if (
+    (!correlation.sessionKey && !correlation.sessionId) ||
+    args.ctx?.loopDetection?.enabled !== true
+  ) {
     return;
   }
   try {
@@ -598,20 +605,20 @@ export async function reconcileLoopCallExecutionParams(args: {
       resolveToolLoopWarningThreshold,
     } = await loadBeforeToolCallRuntime();
     const sessionState = getDiagnosticSessionState({
-      sessionKey: args.ctx.sessionKey,
-      sessionId: args.ctx.sessionId,
+      sessionKey: correlation.sessionKey,
+      sessionId: correlation.sessionId,
     });
     const churn = reconcileToolCallExecutionParams(sessionState, {
       toolName: args.toolName,
       toolParams: args.toolParams,
       toolCallId: args.toolCallId,
-      runId: args.ctx.runId,
+      runId: correlation.runId,
       warningThreshold: resolveToolLoopWarningThreshold(),
     });
     markDiagnosticArgumentChurnObservation({
-      sessionKey: args.ctx.sessionKey,
-      sessionId: args.ctx.sessionId,
-      runId: args.ctx.runId,
+      sessionKey: correlation.sessionKey,
+      sessionId: correlation.sessionId,
+      runId: correlation.runId,
       active: churn.active,
     });
   } catch (err) {
@@ -632,11 +639,15 @@ export async function recordLoopOutcome(args: {
   toolCallOrdinal?: number;
   terminalPresentation?: string;
 }): Promise<void> {
-  if (!args.ctx?.sessionKey && !args.ctx?.sessionId) {
+  const correlation = resolveToolExecutionCorrelation(args.ctx);
+  if (!correlation.sessionKey && !correlation.sessionId) {
     return;
   }
   let recordedOutcome: ToolOutcomeObservation | undefined;
+  let onToolOutcome: HookContext["onToolOutcome"];
   try {
+    const loopDetection = args.ctx?.loopDetection;
+    onToolOutcome = args.ctx?.onToolOutcome;
     const {
       getArgumentChurnNoProgressStreak,
       getDiagnosticSessionState,
@@ -644,8 +655,8 @@ export async function recordLoopOutcome(args: {
       recordToolCallOutcome,
     } = await loadBeforeToolCallRuntime();
     const sessionState = getDiagnosticSessionState({
-      sessionKey: args.ctx.sessionKey,
-      sessionId: args.ctx.sessionId,
+      sessionKey: correlation.sessionKey,
+      sessionId: correlation.sessionId,
     });
     const record = recordToolCallOutcome(sessionState, {
       toolName: args.toolName,
@@ -653,8 +664,8 @@ export async function recordLoopOutcome(args: {
       toolCallId: args.toolCallId,
       result: args.result,
       error: args.error,
-      config: args.ctx.loopDetection,
-      ...(args.ctx.runId && { runId: args.ctx.runId }),
+      config: loopDetection,
+      ...(correlation.runId && { runId: correlation.runId }),
     });
     const churnContinues =
       record !== undefined &&
@@ -664,13 +675,13 @@ export async function recordLoopOutcome(args: {
         record.argsHash,
       ).count > 0;
     markDiagnosticArgumentChurnObservation({
-      sessionKey: args.ctx.sessionKey,
-      sessionId: args.ctx.sessionId,
-      runId: args.ctx.runId,
+      sessionKey: correlation.sessionKey,
+      sessionId: correlation.sessionId,
+      runId: correlation.runId,
       active: churnContinues,
       existingOnly: true,
     });
-    if (record?.resultHash && args.ctx.onToolOutcome) {
+    if (record?.resultHash && onToolOutcome) {
       recordedOutcome = {
         toolName: record.toolName,
         argsHash: record.argsHash,
@@ -684,7 +695,7 @@ export async function recordLoopOutcome(args: {
     log.warn(`tool loop outcome tracking failed: tool=${args.toolName} error=${String(err)}`);
   }
   if (recordedOutcome) {
-    args.ctx.onToolOutcome?.(recordedOutcome);
+    onToolOutcome?.(recordedOutcome);
   }
 }
 

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -31,6 +31,10 @@ import {
   resetDiagnosticSessionStateForTest,
 } from "../logging/diagnostic-session-state.js";
 import {
+  runBeforeToolCallHook as runSdkBeforeToolCallHook,
+  wrapToolWithBeforeToolCallHook as wrapSdkToolWithBeforeToolCallHook,
+} from "../plugin-sdk/agent-harness-runtime.js";
+import {
   PluginApprovalResolutions,
   type PluginApprovalResolution,
 } from "../plugins/hook-before-tool-call-result.js";
@@ -41,6 +45,8 @@ import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import { createCanonicalFixtureSkill } from "../skills/test-support/test-helpers.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { createAgentExecutionAttribution } from "./agent-execution-attribution.js";
+import { bindToolExecutionAttribution } from "./agent-tools.before-tool-call.attribution.js";
 import {
   getBeforeToolCallFailureDisposition,
   getBeforeToolCallPolicyDiagnosticState,
@@ -2076,6 +2082,76 @@ describe("before_tool_call requireApproval handling", () => {
     setActivePluginRegistry(createEmptyPluginRegistry());
   });
 
+  it("ignores forged attribution passed to the public hook policy API", async () => {
+    const ctx = {
+      agentId: "public-agent",
+      sessionKey: "public-session",
+      sessionId: "public-session-id",
+      runId: "public-run",
+      attribution: createAgentExecutionAttribution({
+        agentId: "forged-agent",
+        sessionKey: "forged-session",
+        sessionId: "forged-session-id",
+        runId: "forged-run",
+        lifecycleGeneration: "forged-generation",
+      }),
+    } as never;
+
+    await runSdkBeforeToolCallHook({
+      toolName: "read",
+      params: { path: "/tmp/note.txt" },
+      ctx,
+    });
+
+    const [event, context] = requireHookCall(0);
+    expectRecordFields(event, { runId: "public-run" });
+    expectRecordFields(context, {
+      agentId: "public-agent",
+      sessionKey: "public-session",
+      sessionId: "public-session-id",
+      runId: "public-run",
+    });
+    expect(event).not.toHaveProperty("attribution");
+    expect(context).not.toHaveProperty("attribution");
+    expect(context).not.toHaveProperty("lifecycleGeneration");
+  });
+
+  it("ignores forged attribution passed to the public tool wrapper API", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const ctx = {
+      agentId: "public-agent",
+      sessionKey: "public-session",
+      sessionId: "public-session-id",
+      runId: "public-run",
+      attribution: createAgentExecutionAttribution({
+        agentId: "forged-agent",
+        sessionKey: "forged-session",
+        sessionId: "forged-session-id",
+        runId: "forged-run",
+        lifecycleGeneration: "forged-generation",
+      }),
+    } as never;
+    const tool = wrapSdkToolWithBeforeToolCallHook(
+      { name: "read", execute } as unknown as AnyAgentTool,
+      ctx,
+    );
+
+    await tool.execute("public-wrapper-call", { path: "/tmp/note.txt" }, undefined, undefined);
+
+    const [event, context] = requireHookCall(0);
+    expectRecordFields(event, { runId: "public-run", toolCallId: "public-wrapper-call" });
+    expectRecordFields(context, {
+      agentId: "public-agent",
+      sessionKey: "public-session",
+      sessionId: "public-session-id",
+      runId: "public-run",
+    });
+    expect(event).not.toHaveProperty("attribution");
+    expect(context).not.toHaveProperty("attribution");
+    expect(context).not.toHaveProperty("lifecycleGeneration");
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
   async function runAbortDuringApprovalWait(options?: {
     abortReason?: unknown;
     onResolution?: (decision: PluginApprovalResolution) => void | Promise<void>;
@@ -2192,6 +2268,49 @@ describe("before_tool_call requireApproval handling", () => {
     expect(toolContext.trace).toEqual(trace);
     expect(toolContext.trace).not.toBe(trace);
     expect(Object.isFrozen(toolContext.trace)).toBe(true);
+  });
+
+  it("projects immutable admission attribution without exposing it to plugins", async () => {
+    const attribution = createAgentExecutionAttribution({
+      runId: "run-admitted",
+      lifecycleGeneration: "generation-1",
+      sessionKey: "session-admitted",
+      sessionId: "session-id-admitted",
+      agentId: "agent-admitted",
+    });
+    const contexts: Record<string, unknown>[] = [];
+    hookRunner.runBeforeToolCall.mockImplementation(async (_event, context) => {
+      const mutableContext = context as unknown as Record<string, unknown>;
+      contexts.push({ ...mutableContext });
+      mutableContext.runId = "plugin-forged";
+      return undefined;
+    });
+
+    const ctx = bindToolExecutionAttribution(
+      {
+        runId: "run-flat",
+        sessionKey: "session-flat",
+        sessionId: "session-id-flat",
+        agentId: "agent-flat",
+        requester: { senderId: "sender-1" },
+      },
+      attribution,
+    );
+    await runBeforeToolCallHook({ toolName: "bash", params: { command: "pwd" }, ctx });
+    await runBeforeToolCallHook({ toolName: "bash", params: { command: "pwd" }, ctx });
+
+    expect(contexts).toHaveLength(2);
+    for (const context of contexts) {
+      expect(context).toMatchObject({
+        runId: "run-admitted",
+        sessionKey: "session-admitted",
+        sessionId: "session-id-admitted",
+        agentId: "agent-admitted",
+        requester: { senderId: "sender-1" },
+      });
+      expect(context).not.toHaveProperty("attribution");
+      expect(context).not.toHaveProperty("lifecycleGeneration");
+    }
   });
 
   it("passes host-derived apply_patch paths to before_tool_call hooks", async () => {

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -34,8 +34,10 @@ import {
 } from "../talk/client-voice-confirmation.js";
 import { resetClientVoiceConfirmationStateForTest } from "../talk/client-voice-confirmation.test-support.js";
 import * as clientVoiceSession from "../talk/client-voice-session.js";
+import { createAgentExecutionAttribution } from "./agent-execution-attribution.js";
 import { toClientToolDefinitions, toToolDefinitions } from "./agent-tool-definition-adapter.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
+import { bindToolExecutionAttribution } from "./agent-tools.before-tool-call.attribution.js";
 import {
   consumeAdjustedParamsForToolCall,
   consumePreExecutionBlockedToolCall,
@@ -1656,7 +1658,9 @@ describe("before_tool_call adapter and client tool integration", () => {
       approveVoiceToolParams(runId, toolParams);
       const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
       const preparedState = new WeakMap<object, string>();
-      const prepareBeforeToolCallParams = vi.fn((params: unknown) => {
+      const preparationContexts: Array<Record<string, unknown>> = [];
+      const prepareBeforeToolCallParams = vi.fn((params: unknown, context: unknown) => {
+        preparationContexts.push(context as Record<string, unknown>);
         const prepared = { ...(params as Record<string, unknown>) };
         preparedState.set(prepared, "prepared");
         return prepared;
@@ -1673,7 +1677,21 @@ describe("before_tool_call adapter and client tool integration", () => {
         prepareBeforeToolCallParams,
         finalizeBeforeToolCallParams,
       } as unknown as AnyAgentTool;
-      const hookContext = { runId, agentId: "main", sessionKey: "agent:main:voice" };
+      const hookContext = bindToolExecutionAttribution(
+        {
+          runId: "run-flat-forged",
+          agentId: "flat-forged",
+          sessionKey: "agent:flat:forged",
+          sessionId: "session-flat-forged",
+        },
+        createAgentExecutionAttribution({
+          runId,
+          lifecycleGeneration: "generation-private",
+          agentId: "main",
+          sessionKey: "agent:main:voice",
+          sessionId: "session-voice",
+        }),
+      );
       const tool =
         pathKind === "wrapped"
           ? wrapToolWithBeforeToolCallHook(sourceTool, hookContext)
@@ -1706,6 +1724,16 @@ describe("before_tool_call adapter and client tool integration", () => {
       });
       expect(execute).toHaveBeenCalledOnce();
       expect(prepareBeforeToolCallParams).toHaveBeenCalledTimes(2);
+      for (const context of preparationContexts) {
+        expect(context.hookContext).toMatchObject({
+          runId,
+          agentId: "main",
+          sessionKey: "agent:main:voice",
+          sessionId: "session-voice",
+        });
+        expect(context.hookContext).not.toHaveProperty("attribution");
+        expect(context.hookContext).not.toHaveProperty("lifecycleGeneration");
+      }
       expect(finalizeBeforeToolCallParams).toHaveBeenCalledOnce();
       expect(execute).toHaveBeenCalledWith(
         `call-voice-unchanged-${pathKind}-1`,

--- a/src/agents/agent-tools.before-tool-call.policy.ts
+++ b/src/agents/agent-tools.before-tool-call.policy.ts
@@ -34,6 +34,7 @@ import {
   resolveBeforeToolCallApprovalOutcome,
   resolveSkillWorkshopApprovalForFinalParams,
 } from "./agent-tools.before-tool-call.approval.js";
+import { resolveToolExecutionCorrelation } from "./agent-tools.before-tool-call.attribution.js";
 import {
   beforeToolCallLog as log,
   loadBeforeToolCallRuntime,
@@ -76,11 +77,12 @@ export function consumeFinalClientVoiceToolConfirmation(args: {
   params: unknown;
   ctx?: HookContext;
 }) {
-  const voiceRun = resolveClientVoiceRunBinding(args.ctx?.runId);
+  const correlation = resolveToolExecutionCorrelation(args.ctx);
+  const voiceRun = resolveClientVoiceRunBinding(correlation.runId);
   return consumeClientVoiceToolConfirmationPolicy({
     agentId: voiceRun?.agentId,
     voiceSessionId: voiceRun?.voiceSessionId,
-    runId: args.ctx?.runId,
+    runId: correlation.runId,
     toolName: normalizeToolName(args.toolName || "tool"),
     toolParams: args.params,
     ...(voiceRun ? { isConfirmable: () => isClientVoiceSessionConfirmable(voiceRun) } : {}),
@@ -99,19 +101,32 @@ export async function runBeforeToolCallHook(args: {
 }): Promise<HookOutcome> {
   const toolName = normalizeToolName(args.toolName || "tool");
   const params = args.params;
+  const correlation = resolveToolExecutionCorrelation(args.ctx);
   let releaseArgumentChurnPolicyWait: (() => void) | undefined;
 
   try {
-    if (args.ctx?.sessionKey) {
-      if (args.ctx.loopDetection?.enabled === true) {
+    if (correlation.sessionKey) {
+      const {
+        sessionKey: _flatSessionKey,
+        sessionId: _flatSessionId,
+        runId: _flatRunId,
+        ...loopContextBase
+      } = args.ctx ?? {};
+      const loopContext: HookContext = {
+        ...loopContextBase,
+        sessionKey: correlation.sessionKey,
+        ...(correlation.sessionId ? { sessionId: correlation.sessionId } : {}),
+        ...(correlation.runId ? { runId: correlation.runId } : {}),
+      };
+      if (loopContext.loopDetection?.enabled === true) {
         const { markDiagnosticArgumentChurnObservation } = await loadBeforeToolCallRuntime();
         // Each concurrent policy/approval wait owns a token. Releasing one call
         // must not expose the churn clock while a sibling is still pending.
         const policyWaitToken = Symbol("before-tool-call-policy-wait");
         const policyWaitRef = {
-          sessionKey: args.ctx.sessionKey,
-          sessionId: args.ctx.sessionId,
-          runId: args.ctx.runId,
+          sessionKey: loopContext.sessionKey,
+          sessionId: loopContext.sessionId,
+          runId: loopContext.runId,
           policyWaitToken,
         };
         markDiagnosticArgumentChurnObservation({
@@ -126,11 +141,11 @@ export async function runBeforeToolCallHook(args: {
       }
       const batchAdmitted =
         args.toolCallId !== undefined &&
-        consumeBatchAdmittedToolCall(args.toolCallId, args.ctx.runId);
+        consumeBatchAdmittedToolCall(args.toolCallId, correlation.runId);
       if (!batchAdmitted) {
         const intervention = await admitSingleToolCallLoop(
           { toolName, params, toolCallId: args.toolCallId },
-          args.ctx,
+          loopContext,
         );
         if (intervention) {
           return {
@@ -155,11 +170,11 @@ export async function runBeforeToolCallHook(args: {
       ...(args.ctx?.config ? { config: args.ctx.config } : {}),
       ...(args.ctx?.workspaceDir ? { workspaceDir: args.ctx.workspaceDir } : {}),
     });
-    const voiceRun = resolveClientVoiceRunBinding(args.ctx?.runId);
+    const voiceRun = resolveClientVoiceRunBinding(correlation.runId);
     const voiceConfirmation = checkClientVoiceToolConfirmationPolicy({
       agentId: voiceRun?.agentId,
       voiceSessionId: voiceRun?.voiceSessionId,
-      runId: args.ctx?.runId,
+      runId: correlation.runId,
       toolName,
       toolParams: normalizedParams,
       ...(voiceRun ? { isConfirmable: () => isClientVoiceSessionConfirmable(voiceRun) } : {}),
@@ -195,10 +210,10 @@ export async function runBeforeToolCallHook(args: {
     const buildToolContext = (identity: typeof toolIdentity) => ({
       toolName,
       ...identity,
-      ...(args.ctx?.agentId && { agentId: args.ctx.agentId }),
-      ...(args.ctx?.sessionKey && { sessionKey: args.ctx.sessionKey }),
-      ...(args.ctx?.sessionId && { sessionId: args.ctx.sessionId }),
-      ...(args.ctx?.runId && { runId: args.ctx.runId }),
+      ...(correlation.agentId && { agentId: correlation.agentId }),
+      ...(correlation.sessionKey && { sessionKey: correlation.sessionKey }),
+      ...(correlation.sessionId && { sessionId: correlation.sessionId }),
+      ...(correlation.runId && { runId: correlation.runId }),
       ...(args.signal ? { abortSignal: args.signal } : {}),
       ...(args.ctx?.trace && { trace: freezeDiagnosticTraceContext(args.ctx.trace) }),
       ...(args.toolCallId && { toolCallId: args.toolCallId }),
@@ -212,7 +227,7 @@ export async function runBeforeToolCallHook(args: {
             toolName,
             params: normalizedParams,
             ...toolIdentity,
-            ...(args.ctx?.runId && { runId: args.ctx.runId }),
+            ...(correlation.runId && { runId: correlation.runId }),
             ...(args.toolCallId && { toolCallId: args.toolCallId }),
             ...(derivedToolParams.derivedPaths
               ? { derivedPaths: derivedToolParams.derivedPaths }
@@ -319,7 +334,7 @@ export async function runBeforeToolCallHook(args: {
         toolName,
         params: hookEventParams,
         ...policyAdjustedToolIdentity,
-        ...(args.ctx?.runId && { runId: args.ctx.runId }),
+        ...(correlation.runId && { runId: correlation.runId }),
         ...(args.toolCallId && { toolCallId: args.toolCallId }),
         ...(policyAdjustedDerivedToolParams.derivedPaths
           ? { derivedPaths: policyAdjustedDerivedToolParams.derivedPaths }

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -14,6 +14,7 @@ import {
 } from "../infra/diagnostic-trace-context.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { copyPluginToolMeta, getPluginToolMeta } from "../plugins/tools.js";
+import { resolveToolExecutionCorrelation } from "./agent-tools.before-tool-call.attribution.js";
 import {
   buildToolContentPrivateData,
   emitSkillUsedDiagnostic,
@@ -79,6 +80,25 @@ type BeforeToolCallWrapperOptions = {
 type ForwardedToolExecution = (...args: unknown[]) => ReturnType<AnyAgentTool["execute"]>;
 const MAX_TRACKED_ADJUSTED_PARAMS = 1024;
 
+function buildToolPreparationHookContext(ctx: HookContext): HookContext {
+  const correlation = resolveToolExecutionCorrelation(ctx);
+  const {
+    attribution: _untrustedAttribution,
+    agentId: _flatAgentId,
+    sessionKey: _flatSessionKey,
+    sessionId: _flatSessionId,
+    runId: _flatRunId,
+    ...toolHookContext
+  } = ctx as HookContext & { attribution?: unknown };
+  return {
+    ...toolHookContext,
+    ...(correlation.runId ? { runId: correlation.runId } : {}),
+    ...(correlation.agentId ? { agentId: correlation.agentId } : {}),
+    ...(correlation.sessionKey ? { sessionKey: correlation.sessionKey } : {}),
+    ...(correlation.sessionId ? { sessionId: correlation.sessionId } : {}),
+  };
+}
+
 /** Run tool-owned preparation while retaining the exact prepared object. */
 export async function prepareBeforeToolCallExecutionParams(params: {
   tool: AnyAgentTool;
@@ -91,7 +111,7 @@ export async function prepareBeforeToolCallExecutionParams(params: {
   return prepare
     ? await prepare(params.params, {
         ...(params.toolCallId ? { toolCallId: params.toolCallId } : {}),
-        ...(params.ctx ? { hookContext: params.ctx } : {}),
+        ...(params.ctx ? { hookContext: buildToolPreparationHookContext(params.ctx) } : {}),
         ...(params.signal ? { signal: params.signal } : {}),
       })
     : params.params;
@@ -279,6 +299,7 @@ export function wrapToolWithBeforeToolCallHook(
     ...(options.approvalMode ? { approvalMode: options.approvalMode } : {}),
     emitDiagnostics: options.emitDiagnostics !== false,
   };
+  const correlation = resolveToolExecutionCorrelation(ctx);
   const toolContentPolicy = resolveDiagnosticModelContentCapturePolicy(ctx?.config);
   const wrappedTool: AnyAgentTool = {
     ...tool,
@@ -291,10 +312,10 @@ export function wrapToolWithBeforeToolCallHook(
           ? freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(ctx.trace))
           : undefined;
       const buildEventBase = (toolParams: unknown) => ({
-        ...(ctx?.runId && { runId: ctx.runId }),
-        ...(ctx?.sessionKey && { sessionKey: ctx.sessionKey }),
-        ...(ctx?.sessionId && { sessionId: ctx.sessionId }),
-        ...(ctx?.agentId && { agentId: ctx.agentId }),
+        ...(correlation.runId && { runId: correlation.runId }),
+        ...(correlation.sessionKey && { sessionKey: correlation.sessionKey }),
+        ...(correlation.sessionId && { sessionId: correlation.sessionId }),
+        ...(correlation.agentId && { agentId: correlation.agentId }),
         ...(trace && { trace }),
         toolName: normalizedToolName,
         ...diagnosticIdentity,
@@ -307,7 +328,7 @@ export function wrapToolWithBeforeToolCallHook(
         toolParams: unknown,
         errorCategory?: string,
       ) => {
-        recordPreExecutionBlockedToolCall(toolCallId, ctx?.runId);
+        recordPreExecutionBlockedToolCall(toolCallId, correlation.runId);
         if (!hookOptions.emitDiagnostics) {
           return;
         }
@@ -324,7 +345,7 @@ export function wrapToolWithBeforeToolCallHook(
         errorCategory: string,
         deniedReason?: HookBlockedReason,
       ) => {
-        recordPreExecutionBlockedToolCall(toolCallId, ctx?.runId);
+        recordPreExecutionBlockedToolCall(toolCallId, correlation.runId);
         if (!hookOptions.emitDiagnostics) {
           return;
         }
@@ -373,7 +394,7 @@ export function wrapToolWithBeforeToolCallHook(
           reason: blockedCall.reason,
           deniedReason: blockedCall.deniedReason,
           toolCallId,
-          runId: ctx?.runId,
+          runId: correlation.runId,
         });
         await recordLoopOutcome({
           ctx,
@@ -469,9 +490,9 @@ export function wrapToolWithBeforeToolCallHook(
         recordPreExecutionError(error, outcome.params ?? hookParams, "tool_preparation");
         throw tagBeforeToolCallFailure(error, signal);
       }
-      recordAdjustedParamsForToolCall(toolCallId, executeParams, ctx?.runId);
+      recordAdjustedParamsForToolCall(toolCallId, executeParams, correlation.runId);
       const eventBase = buildEventBase(executeParams);
-      recordToolExecutionStarted(toolCallId, ctx?.runId);
+      recordToolExecutionStarted(toolCallId, correlation.runId);
       if (hookOptions.emitDiagnostics) {
         emitTrustedDiagnosticEvent({
           type: "tool.execution.started",
@@ -585,7 +606,7 @@ export function wrapToolWithBeforeToolCallHook(
     onUpdate,
     ...executionArgs: unknown[]
   ) => {
-    recordToolExecutionTracked(toolCallId, ctx?.runId);
+    recordToolExecutionTracked(toolCallId, correlation.runId);
     try {
       return await (executeWithHooks as ForwardedToolExecution)(
         toolCallId,
@@ -598,7 +619,7 @@ export function wrapToolWithBeforeToolCallHook(
       // Timeout observers may consume this while the call is still pending. The
       // wrapper owns final cleanup; every pre-body settle records the separate
       // blocked fact, so direct callers cannot retain settled ids.
-      clearTrackedToolExecution(toolCallId, ctx?.runId);
+      clearTrackedToolExecution(toolCallId, correlation.runId);
     }
   };
   copyPluginToolMeta(tool, wrappedTool);

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -32,6 +32,11 @@ import "./test-helpers/fast-bash-tools.js";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
 import { isPluginToolAllowed } from "../plugins/tool-grant-allowlist.js";
+import { createAgentExecutionAttribution } from "./agent-execution-attribution.js";
+import {
+  createOpenClawCodingToolsForAgentHarness,
+  createOpenClawCodingToolsForAgentHarnessSideQuestion,
+} from "./agent-tools-internal.js";
 import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
 import { filterToolsByMessageProvider } from "./agent-tools.message-provider-policy.js";
@@ -43,6 +48,8 @@ import {
 import { runWithAgentRingZeroTools } from "./agent-tools.ring-zero-context.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveConversationCapabilityProfile } from "./conversation-capability-profile.js";
+import { bindEmbeddedAttemptExecutionAttribution } from "./embedded-agent-runner/run/attempt-execution-attribution.js";
+import { bindAgentHarnessSideQuestionExecutionAttribution } from "./harness/side-question-execution-attribution.js";
 import * as openClawPluginTools from "./openclaw-plugin-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import { expectReadWriteEditTools } from "./test-helpers/agent-tools-fs-helpers.js";
@@ -291,6 +298,155 @@ describe("createOpenClawCodingTools", () => {
         },
       }),
     );
+  });
+
+  it("does not accept host-owned attribution through the public tool builder", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const tmpDir = tempDirs.make("openclaw-hook-attribution-");
+    await fs.writeFile(path.join(tmpDir, "note.txt"), "hello");
+    const forgedAttribution = createAgentExecutionAttribution({
+      runId: "forged-run",
+      lifecycleGeneration: "forged-generation",
+      sessionKey: "forged-session",
+      sessionId: "forged-session-id",
+      agentId: "forged-agent",
+    });
+    const tools = createOpenClawCodingTools({
+      workspaceDir: tmpDir,
+      runId: "public-run",
+      sessionKey: "public-session",
+      sessionId: "public-session-id",
+      agentId: "public-agent",
+      attribution: forgedAttribution,
+    } as never);
+
+    await requireToolExecute(requireTool(tools, "read"))("tool-public-attribution", {
+      path: "note.txt",
+    });
+
+    expect(beforeToolCall.mock.calls[0]?.[1]).toMatchObject({
+      runId: "public-run",
+      sessionKey: "public-session",
+      sessionId: "public-session-id",
+      agentId: "public-agent",
+    });
+    expect(beforeToolCall.mock.calls[0]?.[1]).not.toHaveProperty("lifecycleGeneration");
+  });
+
+  it("binds exact host attribution for a core-admitted harness attempt", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const tmpDir = tempDirs.make("openclaw-harness-attribution-");
+    await fs.writeFile(path.join(tmpDir, "note.txt"), "hello");
+    const attribution = createAgentExecutionAttribution({
+      runId: "admitted-run",
+      lifecycleGeneration: "admitted-generation",
+      sessionKey: "admitted-session",
+      sessionId: "admitted-session-id",
+      agentId: "admitted-agent",
+    });
+    const attempt = {} as Parameters<typeof bindEmbeddedAttemptExecutionAttribution>[0];
+    bindEmbeddedAttemptExecutionAttribution(attempt, attribution);
+
+    const tools = createOpenClawCodingToolsForAgentHarness(attempt, {
+      workspaceDir: tmpDir,
+      runId: "flat-run",
+      sessionKey: "flat-session",
+      sessionId: "flat-session-id",
+      agentId: "flat-agent",
+    });
+    await requireToolExecute(requireTool(tools, "read"))("tool-harness-attribution", {
+      path: "note.txt",
+    });
+
+    expect(beforeToolCall.mock.calls[0]?.[1]).toMatchObject({
+      runId: attribution.runId,
+      sessionKey: attribution.sessionKey,
+      sessionId: attribution.sessionId,
+      agentId: attribution.agentId,
+    });
+    expect(beforeToolCall.mock.calls[0]?.[1]).not.toHaveProperty("executionId");
+    expect(beforeToolCall.mock.calls[0]?.[1]).not.toHaveProperty("contextId");
+    expect(beforeToolCall.mock.calls[0]?.[1]).not.toHaveProperty("attribution");
+
+    beforeToolCall.mockClear();
+    const unboundTools = createOpenClawCodingToolsForAgentHarness(
+      {} as Parameters<typeof bindEmbeddedAttemptExecutionAttribution>[0],
+      {
+        workspaceDir: tmpDir,
+        runId: "unbound-run",
+        sessionKey: "unbound-session",
+        attribution,
+      } as never,
+    );
+    await requireToolExecute(requireTool(unboundTools, "read"))("tool-unbound-attribution", {
+      path: "note.txt",
+    });
+    expect(beforeToolCall.mock.calls[0]?.[1]).toMatchObject({
+      runId: "unbound-run",
+      sessionKey: "unbound-session",
+    });
+    expect(beforeToolCall.mock.calls[0]?.[1]).not.toHaveProperty("lifecycleGeneration");
+  });
+
+  it("binds exact host attribution for the admitted side-question request only", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const tmpDir = tempDirs.make("openclaw-side-question-attribution-");
+    await fs.writeFile(path.join(tmpDir, "note.txt"), "hello");
+    const attribution = createAgentExecutionAttribution({
+      runId: "side-run",
+      lifecycleGeneration: "side-generation",
+      sessionKey: "side-session",
+      sessionId: "side-session-id",
+      agentId: "side-agent",
+    });
+    const sideQuestion = bindAgentHarnessSideQuestionExecutionAttribution(
+      {} as Parameters<typeof bindAgentHarnessSideQuestionExecutionAttribution>[0],
+      attribution,
+    );
+
+    const tools = createOpenClawCodingToolsForAgentHarnessSideQuestion(sideQuestion, {
+      workspaceDir: tmpDir,
+      runId: "flat-run",
+      sessionKey: "flat-session",
+      sessionId: "flat-session-id",
+      agentId: "flat-agent",
+    });
+    await requireToolExecute(requireTool(tools, "read"))("tool-side-attribution", {
+      path: "note.txt",
+    });
+
+    expect(beforeToolCall.mock.calls[0]?.[1]).toMatchObject({
+      runId: attribution.runId,
+      sessionKey: attribution.sessionKey,
+      sessionId: attribution.sessionId,
+      agentId: attribution.agentId,
+    });
+    expect(sideQuestion).not.toHaveProperty("attribution");
+
+    beforeToolCall.mockClear();
+    const cloneTools = createOpenClawCodingToolsForAgentHarnessSideQuestion({ ...sideQuestion }, {
+      workspaceDir: tmpDir,
+      runId: "clone-run",
+      sessionKey: "clone-session",
+      attribution,
+    } as never);
+    await requireToolExecute(requireTool(cloneTools, "read"))("tool-side-clone", {
+      path: "note.txt",
+    });
+    expect(beforeToolCall.mock.calls[0]?.[1]).toMatchObject({
+      runId: "clone-run",
+      sessionKey: "clone-session",
+    });
+    expect(beforeToolCall.mock.calls[0]?.[1]).not.toHaveProperty("lifecycleGeneration");
   });
 
   it("re-wraps existing before_tool_call hooks once with the current context", async () => {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -29,6 +29,8 @@ import type { InputProvenance } from "../sessions/input-provenance.js";
 import type { SkillSnapshot, SkillUsagePath } from "../skills/types.js";
 import type { SkillWorkshopRunOptions } from "../skills/workshop/types.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
+import type { AgentExecutionAttribution } from "./agent-execution-attribution.js";
+import { bindToolExecutionAttribution } from "./agent-tools.before-tool-call.attribution.js";
 import type { ToolOutcomeObserver } from "./agent-tools.before-tool-call.js";
 import { finalizeAgentTools } from "./agent-tools.finalize.js";
 import { filterToolsByMessageProvider } from "./agent-tools.message-provider-policy.js";
@@ -374,7 +376,14 @@ type OpenClawCodingToolsOptions = {
   scheduledToolPolicy?: ScheduledToolPolicyContext;
 };
 
-function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions): AnyAgentTool[] {
+type OpenClawCodingToolsInternalOptions = OpenClawCodingToolsOptions & {
+  /** Admission-owned correlation; intentionally absent from the plugin SDK options. */
+  attribution?: AgentExecutionAttribution;
+};
+
+export function createOpenClawCodingToolsInternal(
+  options?: OpenClawCodingToolsInternalOptions,
+): AnyAgentTool[] {
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
   const isMemoryFlushRun = options?.trigger === "memory";
   if (isMemoryFlushRun && !options?.memoryFlushWritePath) {
@@ -741,6 +750,11 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             allowHostBrowserControl: sandbox ? sandbox.browserAllowHostControl : true,
             agentSessionKey: options?.sessionKey,
             runId: options?.runId,
+            ...(options?.attribution
+              ? {
+                  beforeToolCallHookContext: bindToolExecutionAttribution({}, options.attribution),
+                }
+              : {}),
             runSessionKey: options?.runSessionKey,
             agentChannel: resolveGatewayMessageChannel(
               options?.messageChannel ?? options?.messageProvider,
@@ -933,32 +947,35 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     ...(options?.memberRoleIds?.length ? { roleIds: [...options.memberRoleIds] } : {}),
   } satisfies PluginHookToolRequesterContext;
   const hasRequester = Object.keys(requester).length > 0;
-  const hookContext = {
-    agentId,
-    ...(options?.config ? { config: options.config } : {}),
-    cwd: codingRoot,
-    workspaceDir: workspaceRoot,
-    ...(options?.skillsSnapshot ? { skillsSnapshot: options.skillsSnapshot } : {}),
-    ...(options?.skillUsagePaths ? { skillUsagePaths: options.skillUsagePaths } : {}),
-    ...(sandboxRoot && allowWorkspaceWrites
-      ? { sandbox: { root: sandboxRoot, bridge: sandboxFsBridge! } }
-      : {}),
-    sessionKey: options?.sessionKey,
-    sessionId: options?.sessionId,
-    runId: options?.runId,
-    trigger: options?.trigger,
-    approvalReviewerDeviceId: options?.approvalReviewerDeviceId,
-    channelId: options?.hookChannelId ?? options?.currentChannelId,
-    ...(hasRequester ? { requester } : {}),
-    ...(turnSourceChannel ? { turnSourceChannel } : {}),
-    ...(turnSourceTo ? { turnSourceTo } : {}),
-    ...(options?.agentAccountId ? { turnSourceAccountId: options.agentAccountId } : {}),
-    ...(options?.currentThreadTs ? { turnSourceThreadId: options.currentThreadTs } : {}),
-    ...(options?.trace ? { trace: options.trace } : {}),
-    loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
-    onToolOutcome: options?.onToolOutcome,
-    allocateToolOutcomeOrdinal: options?.allocateToolOutcomeOrdinal,
-  };
+  const hookContext = bindToolExecutionAttribution(
+    {
+      agentId,
+      ...(options?.config ? { config: options.config } : {}),
+      cwd: codingRoot,
+      workspaceDir: workspaceRoot,
+      ...(options?.skillsSnapshot ? { skillsSnapshot: options.skillsSnapshot } : {}),
+      ...(options?.skillUsagePaths ? { skillUsagePaths: options.skillUsagePaths } : {}),
+      ...(sandboxRoot && allowWorkspaceWrites
+        ? { sandbox: { root: sandboxRoot, bridge: sandboxFsBridge! } }
+        : {}),
+      sessionKey: options?.sessionKey,
+      sessionId: options?.sessionId,
+      runId: options?.runId,
+      trigger: options?.trigger,
+      approvalReviewerDeviceId: options?.approvalReviewerDeviceId,
+      channelId: options?.hookChannelId ?? options?.currentChannelId,
+      ...(hasRequester ? { requester } : {}),
+      ...(turnSourceChannel ? { turnSourceChannel } : {}),
+      ...(turnSourceTo ? { turnSourceTo } : {}),
+      ...(options?.agentAccountId ? { turnSourceAccountId: options.agentAccountId } : {}),
+      ...(options?.currentThreadTs ? { turnSourceThreadId: options.currentThreadTs } : {}),
+      ...(options?.trace ? { trace: options.trace } : {}),
+      loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
+      onToolOutcome: options?.onToolOutcome,
+      allocateToolOutcomeOrdinal: options?.allocateToolOutcomeOrdinal,
+    },
+    options?.attribution,
+  );
   // NOTE: Keep canonical (lowercase) tool names here. Provider transports remap on the wire.
   return finalizeAgentTools({
     tools: authorizedTools,
@@ -977,6 +994,13 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
 
 /** Build the runtime tool list exposed through the public agent harness SDK. */
 export function createOpenClawCodingTools(options?: OpenClawCodingToolsOptions): AnyAgentTool[] {
-  return createOpenClawCodingToolsInternal(options);
+  if (!options) {
+    return createOpenClawCodingToolsInternal();
+  }
+  // The SDK is a JavaScript boundary. Untyped plugins cannot stamp trusted
+  // execution correlation onto the host-owned tool hook context.
+  const { attribution: _attribution, ...publicOptions } = options as OpenClawCodingToolsOptions &
+    Pick<OpenClawCodingToolsInternalOptions, "attribution">;
+  return createOpenClawCodingToolsInternal(publicOptions);
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -10,6 +10,7 @@ import {
   resolveSecretSentinel,
 } from "../secrets/sentinel.js";
 import { createAgentExecutionAttribution } from "./agent-execution-attribution.js";
+import { resolveAgentHarnessSideQuestionExecutionAttribution } from "./harness/side-question-execution-attribution.js";
 import type { AgentHarness } from "./harness/types.js";
 import type { AgentRuntimeAuthPlan } from "./runtime-plan/types.js";
 
@@ -855,7 +856,13 @@ describe("runBtwSideQuestion", () => {
 
     expect(result).toEqual({ text: "Codex side answer." });
     expect(codexSideQuestionMock).toHaveBeenCalledTimes(1);
-    expect(mockArg(codexSideQuestionMock, 0, 0)).not.toHaveProperty("attribution");
+    const sideQuestionParams = mockArg(codexSideQuestionMock, 0, 0) as Parameters<
+      typeof resolveAgentHarnessSideQuestionExecutionAttribution
+    >[0];
+    expect(sideQuestionParams).not.toHaveProperty("attribution");
+    expect(resolveAgentHarnessSideQuestionExecutionAttribution(sideQuestionParams)).toBe(
+      attribution,
+    );
     expect(codexSideQuestionMock).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "openai",

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -44,6 +44,7 @@ import {
   selectAgentHarnessForPreparedModelProviders,
   type AgentHarnessPreparedModelProvider,
 } from "./harness/selection.js";
+import { bindAgentHarnessSideQuestionExecutionAttribution } from "./harness/side-question-execution-attribution.js";
 import {
   resolveAgentHarnessPreparedAuthSupport,
   resolveAgentHarnessPreparedRouteSupport,
@@ -972,42 +973,46 @@ export async function runBtwSideQuestion(
         ? resolvedAttempt.auth.apiKey?.trim()
         : undefined;
     const { attribution: _attribution, ...publicParams } = params;
-    const result = await selectedHarness.runSideQuestion({
-      ...publicParams,
-      provider: runtimeModel.provider,
-      model: runtimeModel.id,
-      runtimeModel,
-      preparedRuntimeAuth: {
-        plan: runtimeAuthPlan,
-        authProfileStore: scopeAuthProfileStoreToPreparedPlan(
-          selectedAuthProfileStore,
-          runtimeAuthPlan,
-        ),
-        authStorage: runtime.authStorage,
-        modelRegistry: runtime.modelRegistry,
-        ...(resolvedApiKey
-          ? {
-              resolvedApiKey: unwrapSecretSentinelsForProviderEgress(
-                resolvedApiKey,
-                "BTW harness handoff",
-              ),
-            }
-          : {}),
+    const sideQuestionParams = bindAgentHarnessSideQuestionExecutionAttribution(
+      {
+        ...publicParams,
+        provider: runtimeModel.provider,
+        model: runtimeModel.id,
+        runtimeModel,
+        preparedRuntimeAuth: {
+          plan: runtimeAuthPlan,
+          authProfileStore: scopeAuthProfileStoreToPreparedPlan(
+            selectedAuthProfileStore,
+            runtimeAuthPlan,
+          ),
+          authStorage: runtime.authStorage,
+          modelRegistry: runtime.modelRegistry,
+          ...(resolvedApiKey
+            ? {
+                resolvedApiKey: unwrapSecretSentinelsForProviderEgress(
+                  resolvedApiKey,
+                  "BTW harness handoff",
+                ),
+              }
+            : {}),
+        },
+        sessionId,
+        sessionFile,
+        agentId: sessionAgentId,
+        workspaceDir,
+        ...(toolsAllow ? { toolsAllow } : {}),
+        authProfileId:
+          runtimeAuthPlan.modelRoute?.authRequirement === "api-key"
+            ? undefined
+            : runtimeAuthPlan.forwardedAuthProfileId,
+        authProfileIdSource:
+          runtimeAuthPlan.modelRoute?.authRequirement === "api-key"
+            ? undefined
+            : runtimeAuthPlan.forwardedAuthProfileSource,
       },
-      sessionId,
-      sessionFile,
-      agentId: sessionAgentId,
-      workspaceDir,
-      ...(toolsAllow ? { toolsAllow } : {}),
-      authProfileId:
-        runtimeAuthPlan.modelRoute?.authRequirement === "api-key"
-          ? undefined
-          : runtimeAuthPlan.forwardedAuthProfileId,
-      authProfileIdSource:
-        runtimeAuthPlan.modelRoute?.authRequirement === "api-key"
-          ? undefined
-          : runtimeAuthPlan.forwardedAuthProfileSource,
-    });
+      params.attribution,
+    );
+    const result = await selectedHarness.runSideQuestion(sideQuestionParams);
     return { kind: "handled", payload: { text: result.text } };
   };
   if (harness.runSideQuestion) {

--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
@@ -1,13 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../../../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../../../plugins/hooks.test-fixtures.js";
+import { createAgentExecutionAttribution } from "../../agent-execution-attribution.js";
+import {
+  bindToolExecutionAttribution,
+  resolveToolExecutionCorrelation,
+} from "../../agent-tools.before-tool-call.attribution.js";
+import type { HookContext } from "../../agent-tools.before-tool-call.js";
 import { applyCodeModeCatalog, createCodeModeTools } from "../../code-mode.js";
+import { resolveConversationCapabilityProfile } from "../../conversation-capability-profile.js";
+import type { ExtensionContext } from "../../sessions/index.js";
 import { createStubTool } from "../../test-helpers/agent-tool-stubs.js";
 import {
   applyToolSearchCatalog,
   createToolSearchCatalogRef,
+  resolveToolSearchConfig,
   TOOL_SEARCH_RAW_TOOL_NAME,
 } from "../../tool-search.js";
 import { prepareEmbeddedAttemptClientTools } from "./attempt-client-tools.js";
+import { bindEmbeddedAttemptExecutionAttribution } from "./attempt-execution-attribution.js";
+import { prepareEmbeddedAttemptToolCatalog } from "./attempt-tool-catalog.js";
 
 const CODE_MODE_CONFIG: OpenClawConfig = { tools: { codeMode: true, toolSearch: false } };
 const TOOL_SEARCH_CONFIG: OpenClawConfig = {
@@ -63,6 +79,7 @@ function prepare(input: {
   attemptConfig: OpenClawConfig;
   toolSearchRuntimeConfig: OpenClawConfig;
   catalogRef: ReturnType<typeof createToolSearchCatalogRef>;
+  catalogToolHookContext?: HookContext;
 }) {
   return prepareEmbeddedAttemptClientTools({
     attempt: {
@@ -70,7 +87,7 @@ function prepare(input: {
       sessionId: "session",
       runId: "run",
     },
-    catalogToolHookContext: undefined,
+    catalogToolHookContext: input.catalogToolHookContext,
     codeModeControlsEnabledForRun: input.codeModeControlsEnabledForRun,
     deferredDirectoryToolsCallable: false,
     effectiveTools: [],
@@ -85,7 +102,61 @@ function prepare(input: {
   } as unknown as Parameters<typeof prepareEmbeddedAttemptClientTools>[0]);
 }
 
+function prepareCatalogHookContext(
+  attribution: ReturnType<typeof createAgentExecutionAttribution>,
+) {
+  const attempt = {
+    config: CATALOGS_DISABLED_CONFIG,
+    model: { api: "openai-responses" },
+    modelId: "test-model",
+    provider: "openai",
+    runId: "flat-run",
+    runtimePlan: { tools: { logDiagnostics: () => {} } },
+    sessionId: "flat-session-id",
+  } as unknown as Parameters<typeof bindEmbeddedAttemptExecutionAttribution>[0];
+  bindEmbeddedAttemptExecutionAttribution(attempt, attribution);
+
+  return prepareEmbeddedAttemptToolCatalog({
+    attempt,
+    preparedToolBase: {
+      codeModeControlsEnabledForRun: false,
+      codeModeSkills: [],
+      effectiveToolsAllow: undefined,
+      forceDirectMessageTool: false,
+      localModelLeanPreserveToolNames: [],
+      runtimeCapabilityProfile: resolveConversationCapabilityProfile({
+        config: CATALOGS_DISABLED_CONFIG,
+        agentId: "flat-agent",
+        sessionKey: "flat-session",
+        sessionId: "flat-session-id",
+        runId: "flat-run",
+      }),
+      toolSearchConfig: resolveToolSearchConfig(CATALOGS_DISABLED_CONFIG),
+      toolSearchControlsEnabledForRun: false,
+      toolSearchRuntimeConfig: CATALOGS_DISABLED_CONFIG,
+      toolsEnabled: false,
+    },
+    bundleTools: {
+      clientTools: [clientTool("client_probe")],
+      uncompactedEffectiveTools: [],
+    },
+    effectiveCwd: "/tmp/workspace",
+    effectiveWorkspace: "/tmp/workspace",
+    sessionAgentId: "flat-agent",
+    sandboxSessionKey: "flat-session",
+    runTrace: {},
+    abortSignal: new AbortController().signal,
+    executeCodeModeTool: async () => ({ content: [], details: {} }),
+    getProviderRuntimeHandle: () => undefined,
+    markStage: () => {},
+  } as unknown as Parameters<typeof prepareEmbeddedAttemptToolCatalog>[0]).catalogToolHookContext;
+}
+
 describe("prepareEmbeddedAttemptClientTools", () => {
+  afterEach(() => {
+    resetGlobalHookRunner();
+  });
+
   it("hides client tools behind the code-mode catalog when code mode is engaged", () => {
     const catalogRef = seedCatalog("code-mode", CODE_MODE_CONFIG);
 
@@ -127,5 +198,70 @@ describe("prepareEmbeddedAttemptClientTools", () => {
     });
 
     expect(result.clientToolDefs.map((tool) => tool.name)).toEqual(["client_probe"]);
+  });
+
+  it("binds admitted attribution privately in the attempt tool catalog", () => {
+    const attribution = createAgentExecutionAttribution({
+      runId: "admitted-run",
+      lifecycleGeneration: "admitted-generation",
+      sessionKey: "admitted-session",
+      sessionId: "admitted-session-id",
+      agentId: "admitted-agent",
+    });
+    const catalogToolHookContext = prepareCatalogHookContext(attribution);
+
+    expect(catalogToolHookContext).not.toHaveProperty("attribution");
+    expect(resolveToolExecutionCorrelation(catalogToolHookContext)).toEqual({
+      runId: attribution.runId,
+      contextId: attribution.contextId,
+      executionId: attribution.executionId,
+      lifecycleGeneration: attribution.lifecycleGeneration,
+      sessionKey: attribution.sessionKey,
+      sessionId: attribution.sessionId,
+      agentId: attribution.agentId,
+    });
+  });
+
+  it("uses admitted attribution for direct client-tool hook correlation", async () => {
+    const beforeToolCall = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const attribution = createAgentExecutionAttribution({
+      runId: "admitted-run",
+      lifecycleGeneration: "admitted-generation",
+      sessionKey: "admitted-session",
+      sessionId: "admitted-session-id",
+      agentId: "admitted-agent",
+    });
+    const result = prepare({
+      codeModeControlsEnabledForRun: false,
+      attemptConfig: TOOL_SEARCH_CONFIG,
+      toolSearchRuntimeConfig: CATALOGS_DISABLED_CONFIG,
+      catalogRef: seedCatalog("tool-search", TOOL_SEARCH_CONFIG),
+      catalogToolHookContext: bindToolExecutionAttribution(
+        {
+          runId: "flat-run",
+          sessionKey: "flat-session",
+          sessionId: "flat-session-id",
+          agentId: "flat-agent",
+        },
+        attribution,
+      ),
+    });
+    const directClientTool = result.clientToolDefs[0];
+    if (!directClientTool) {
+      throw new Error("expected direct client tool");
+    }
+
+    await directClientTool.execute("client-call", {}, undefined, undefined, {} as ExtensionContext);
+
+    expect(beforeToolCall.mock.calls[0]?.[1]).toMatchObject({
+      runId: "admitted-run",
+      sessionKey: "admitted-session",
+      sessionId: "admitted-session-id",
+      agentId: "admitted-agent",
+    });
+    expect(beforeToolCall.mock.calls[0]?.[1]).not.toHaveProperty("lifecycleGeneration");
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
@@ -4,6 +4,7 @@ import {
   findClientToolNameConflicts,
   toClientToolDefinitions,
 } from "../../agent-tool-definition-adapter.js";
+import { inheritToolExecutionAttribution } from "../../agent-tools.before-tool-call.attribution.js";
 import { resolveToolLoopDetectionConfig } from "../../agent-tools.js";
 import { addClientToolsToCodeModeCatalog } from "../../code-mode.js";
 import type { AgentTool } from "../../runtime/index.js";
@@ -88,6 +89,17 @@ export function prepareEmbeddedAttemptClientTools(params: {
     throw createClientToolNameConflictError(clientToolNameConflicts);
   }
 
+  const clientToolHookContext = inheritToolExecutionAttribution(params.catalogToolHookContext, {
+    ...params.catalogToolHookContext,
+    agentId: params.sessionAgentId,
+    sessionKey: params.sandboxSessionKey,
+    config: params.toolSearchRuntimeConfig,
+    sessionId: params.attempt.sessionId,
+    runId: params.attempt.runId,
+    loopDetection: clientToolLoopDetection,
+    onToolOutcome: params.attempt.onToolOutcome,
+    allocateToolOutcomeOrdinal: params.attempt.allocateToolOutcomeOrdinal,
+  });
   let clientToolDefs = params.clientTools
     ? toClientToolDefinitions(
         params.clientTools,
@@ -119,16 +131,7 @@ export function prepareEmbeddedAttemptClientTools(params: {
             }
           },
         },
-        {
-          agentId: params.sessionAgentId,
-          sessionKey: params.sandboxSessionKey,
-          config: params.toolSearchRuntimeConfig,
-          sessionId: params.attempt.sessionId,
-          runId: params.attempt.runId,
-          loopDetection: clientToolLoopDetection,
-          onToolOutcome: params.attempt.onToolOutcome,
-          allocateToolOutcomeOrdinal: params.attempt.allocateToolOutcomeOrdinal,
-        },
+        clientToolHookContext,
       )
     : [];
   const addClientToolsToCatalog = params.codeModeControlsEnabledForRun

--- a/src/agents/embedded-agent-runner/run/attempt-execution-attribution.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-attribution.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { createAgentExecutionAttribution } from "../../agent-execution-attribution.js";
+import {
+  bindEmbeddedAttemptExecutionAttribution,
+  resolveEmbeddedAttemptExecutionAttribution,
+} from "./attempt-execution-attribution.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+describe("embedded attempt execution attribution", () => {
+  it("keeps the host snapshot off the plugin-visible attempt object", () => {
+    const attempt = { runId: "run-1" } as EmbeddedRunAttemptParams;
+    const attribution = createAgentExecutionAttribution({
+      runId: "run-1",
+      lifecycleGeneration: "generation-1",
+    });
+
+    bindEmbeddedAttemptExecutionAttribution(attempt, attribution);
+
+    expect(resolveEmbeddedAttemptExecutionAttribution(attempt)).toBe(attribution);
+    expect(attempt).not.toHaveProperty("attribution");
+    expect(JSON.stringify(attempt)).not.toContain("lifecycleGeneration");
+  });
+
+  it("leaves unattributed maintenance attempts unset", () => {
+    const attempt = { runId: "maintenance" } as EmbeddedRunAttemptParams;
+
+    bindEmbeddedAttemptExecutionAttribution(attempt, undefined);
+
+    expect(resolveEmbeddedAttemptExecutionAttribution(attempt)).toBeUndefined();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-execution-attribution.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-execution-attribution.ts
@@ -1,0 +1,32 @@
+import type { AgentExecutionAttribution } from "../../agent-execution-attribution.js";
+import type { EmbeddedRunAttemptParams } from "./types.js";
+
+const attributionByAttempt = new WeakMap<EmbeddedRunAttemptParams, AgentExecutionAttribution>();
+
+/** Keep host-only execution correlation off the plugin-visible attempt object. */
+export function bindEmbeddedAttemptExecutionAttribution(
+  attempt: EmbeddedRunAttemptParams,
+  attribution: AgentExecutionAttribution | undefined,
+): void {
+  if (attribution) {
+    attributionByAttempt.set(attempt, attribution);
+  }
+}
+
+export function resolveEmbeddedAttemptExecutionAttribution(
+  attempt: EmbeddedRunAttemptParams,
+): AgentExecutionAttribution | undefined {
+  return attributionByAttempt.get(attempt);
+}
+
+/** Preserve host-only attribution when the host rewrites a plugin handoff object. */
+export function transferEmbeddedAttemptExecutionAttribution<T extends EmbeddedRunAttemptParams>(
+  source: EmbeddedRunAttemptParams,
+  target: T,
+): T {
+  bindEmbeddedAttemptExecutionAttribution(
+    target,
+    resolveEmbeddedAttemptExecutionAttribution(source),
+  );
+  return target;
+}

--- a/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
@@ -3,7 +3,7 @@ import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-con
 import { extractModelCompat } from "../../../plugins/provider-model-compat.js";
 import { getPluginToolMeta } from "../../../plugins/tools.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
-import { createOpenClawCodingTools } from "../../agent-tools.js";
+import { createOpenClawCodingToolsForRuntime } from "../../agent-tools-internal.js";
 import { getChannelAgentToolMeta } from "../../channel-tools.js";
 import type { CodeModeSkill } from "../../code-mode-skills.js";
 import { resolveConversationCapabilityProfile } from "../../conversation-capability-profile.js";
@@ -24,6 +24,7 @@ import { resolveAgentToolSurfacePlan } from "../../tool-surface-plan.js";
 import type { ComputerContextEpoch } from "../../tools/computer-tool.js";
 import type { CronCreatorToolAllowlistEntry } from "../../tools/cron-tool.js";
 import { log } from "../logger.js";
+import { resolveEmbeddedAttemptExecutionAttribution } from "./attempt-execution-attribution.js";
 import {
   applyEmbeddedAttemptToolsAllow,
   mergeForcedEmbeddedAttemptToolsAllow,
@@ -35,7 +36,9 @@ import { buildEmbeddedAttemptToolRunContext } from "./attempt.tool-run-context.j
 import { TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES } from "./attempt.tool-search-run-plan.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
-type OpenClawCodingToolsOptions = NonNullable<Parameters<typeof createOpenClawCodingTools>[0]>;
+type OpenClawCodingToolsOptions = NonNullable<
+  Parameters<typeof createOpenClawCodingToolsForRuntime>[0]
+>;
 type SkillUsagePaths = OpenClawCodingToolsOptions["skillUsagePaths"];
 
 export function prepareEmbeddedAttemptToolBase(params: {
@@ -57,6 +60,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
   toolSearchCatalogExecutor: ToolSearchCatalogToolExecutor;
 }) {
   const { attempt } = params;
+  const attribution = resolveEmbeddedAttemptExecutionAttribution(attempt);
   const forceDirectMessageTool = messageToolOwnsVisibleReply(attempt);
   const toolsAllowWithForcedRuntimeTools = mergeForcedEmbeddedAttemptToolsAllow(
     attempt.toolsAllow,
@@ -199,7 +203,8 @@ export function prepareEmbeddedAttemptToolBase(params: {
   const constructedToolsRaw = !shouldConstructTools
     ? []
     : (() => {
-        const allTools = createOpenClawCodingTools({
+        const allTools = createOpenClawCodingToolsForRuntime({
+          ...(attribution ? { attribution } : {}),
           agentId: params.sessionAgentId,
           ...buildEmbeddedAttemptToolRunContext({ ...attempt, trace: params.runTrace }),
           messageChannel: attempt.messageChannel,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -2,6 +2,7 @@
  * Prepares the attempt-local tool catalog, schema projection, and diagnostics.
  */
 import type { DiagnosticTraceContext } from "../../../infra/diagnostic-trace-context.js";
+import { bindToolExecutionAttribution } from "../../agent-tools.before-tool-call.attribution.js";
 import { resolveToolLoopDetectionConfig } from "../../agent-tools.js";
 import {
   CODE_MODE_EXEC_TOOL_NAME,
@@ -22,6 +23,7 @@ import {
 import { applyAgentToolSurfaceCatalog } from "../../tool-surface-plan.js";
 import { log } from "../logger.js";
 import type { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
+import { resolveEmbeddedAttemptExecutionAttribution } from "./attempt-execution-attribution.js";
 import { collectAttemptExplicitToolAllowlistSources } from "./attempt-tool-allowlist.js";
 import type { prepareEmbeddedAttemptToolBase } from "./attempt-tool-base-prepare.js";
 import { buildToolSearchRunPlan } from "./attempt.tool-search-run-plan.js";
@@ -59,23 +61,27 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
   } = preparedToolBase;
   const { clientTools, uncompactedEffectiveTools } = input.bundleTools;
   let effectiveTools = uncompactedEffectiveTools;
-  const catalogToolHookContext = {
-    agentId: input.sessionAgentId,
-    config: attempt.config,
-    cwd: input.effectiveCwd,
-    sessionKey: input.sandboxSessionKey,
-    sessionId: attempt.sessionId,
-    runId: attempt.runId,
-    approvalReviewerDeviceId: attempt.approvalReviewerDeviceId,
-    channelId: attempt.currentChannelId,
-    trace: input.runTrace,
-    loopDetection: resolveToolLoopDetectionConfig({
-      cfg: attempt.config,
+  const attribution = resolveEmbeddedAttemptExecutionAttribution(attempt);
+  const catalogToolHookContext = bindToolExecutionAttribution(
+    {
       agentId: input.sessionAgentId,
-    }),
-    onToolOutcome: attempt.onToolOutcome,
-    allocateToolOutcomeOrdinal: attempt.allocateToolOutcomeOrdinal,
-  };
+      config: attempt.config,
+      cwd: input.effectiveCwd,
+      sessionKey: input.sandboxSessionKey,
+      sessionId: attempt.sessionId,
+      runId: attempt.runId,
+      approvalReviewerDeviceId: attempt.approvalReviewerDeviceId,
+      channelId: attempt.currentChannelId,
+      trace: input.runTrace,
+      loopDetection: resolveToolLoopDetectionConfig({
+        cfg: attempt.config,
+        agentId: input.sessionAgentId,
+      }),
+      onToolOutcome: attempt.onToolOutcome,
+      allocateToolOutcomeOrdinal: attempt.allocateToolOutcomeOrdinal,
+    },
+    attribution,
+  );
   const codeModeTools = codeModeControlsEnabledForRun
     ? createCodeModeTools({
         config: attempt.config,

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -687,6 +687,10 @@ vi.mock("../../cache-trace.js", () => ({
 vi.mock("../../agent-tools.js", () => ({
   createOpenClawCodingTools: (options?: { workspaceDir?: string; spawnWorkspaceDir?: string }) =>
     hoisted.createOpenClawCodingToolsMock(options),
+  createOpenClawCodingToolsInternal: (options?: {
+    workspaceDir?: string;
+    spawnWorkspaceDir?: string;
+  }) => hoisted.createOpenClawCodingToolsMock(options),
   resolveProcessToolScopeKey: ({
     scopeKey,
     sessionKey,

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -10,6 +10,7 @@ import type { AgentRuntimePlan } from "../../runtime-plan/types.js";
 import { createToolTerminalObserver } from "../../tool-terminal-outcome.js";
 import type { SystemAgentToolOptions } from "../../tools/system-agent-tool.js";
 import { prepareExecApprovalContinuationForAttempt } from "./attempt-exec-approval-continuation.js";
+import { bindEmbeddedAttemptExecutionAttribution } from "./attempt-execution-attribution.js";
 import { applyResolvedToolPromptFinalizer } from "./attempt-prompt-tool-policy.js";
 import { runEmbeddedAttemptWithBackend } from "./backend.js";
 import type { RunEmbeddedAgentInternalParams } from "./internal-params.js";
@@ -426,6 +427,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     onUserMessagePersistenceInvalidated: control.onUserMessagePersistenceInvalidated,
     onAssistantErrorMessagePersisted: params.onAssistantErrorMessagePersisted,
   };
+  bindEmbeddedAttemptExecutionAttribution(attemptParams, params.attribution);
   const rawAttempt = await runEmbeddedAttemptWithBackend(attemptParams)
     .catch((err: unknown): never => {
       throw control.getPostCompactionAbortError() ?? err;

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -6,8 +6,13 @@ import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host
 import type { ContextEngine } from "../../context-engine/types.js";
 import { createOpenClawCodingTools } from "../../plugin-sdk/agent-harness.js";
 import { mintSecretSentinel } from "../../secrets/sentinel.js";
+import { createAgentExecutionAttribution } from "../agent-execution-attribution.js";
 import { isHostScopedAgentToolActive } from "../agent-tools.ring-zero-context.js";
 import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
+import {
+  bindEmbeddedAttemptExecutionAttribution,
+  resolveEmbeddedAttemptExecutionAttribution,
+} from "../embedded-agent-runner/run/attempt-execution-attribution.js";
 import type {
   EmbeddedRunAttemptParams,
   EmbeddedRunAttemptResult,
@@ -631,7 +636,7 @@ describe("runAgentHarnessAttempt", () => {
     expect(isHostScopedAgentToolActive("openclaw")).toBe(false);
   });
 
-  it("unwraps sentinels only at the plugin harness handoff", async () => {
+  it("preserves private attribution across sanitized and policy-rewritten handoff clones", async () => {
     const pluginRunAttempt = vi.fn<AgentHarness["runAttempt"]>(async () =>
       createAttemptResult("codex"),
     );
@@ -647,11 +652,20 @@ describe("runAgentHarnessAttempt", () => {
     const secret = "plugin-provider-secret";
     const sentinel = mintSecretSentinel(secret, { label: "model-auth:codex" });
     const params = createAttemptParams(providerRuntimeConfig("codex", "codex"));
+    params.config = { tools: { deny: ["*"] } };
     params.resolvedApiKey = sentinel;
     params.model = {
       ...params.model,
       headers: { Authorization: `Bearer ${sentinel}`, "X-Optional": null } as never,
     };
+    const attribution = createAgentExecutionAttribution({
+      runId: params.runId,
+      lifecycleGeneration: "test-generation",
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+    });
+    bindEmbeddedAttemptExecutionAttribution(params, attribution);
 
     await runAgentHarnessAttempt(params);
 
@@ -659,6 +673,9 @@ describe("runAgentHarnessAttempt", () => {
     expect(handedOff?.resolvedApiKey).toBe(secret);
     expect(handedOff?.model.headers?.Authorization).toBe(`Bearer ${secret}`);
     expect(handedOff?.model.headers?.["X-Optional"]).toBeNull();
+    expect(handedOff?.toolsAllow).toEqual([]);
+    expect(resolveEmbeddedAttemptExecutionAttribution(handedOff!)).toBe(attribution);
+    expect(handedOff).not.toHaveProperty("attribution");
     expect(params.resolvedApiKey).toBe(sentinel);
   });
 

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -19,6 +19,7 @@ import {
   runWithAgentRingZeroTools,
 } from "../agent-tools.ring-zero-context.js";
 import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
+import { transferEmbeddedAttemptExecutionAttribution } from "../embedded-agent-runner/run/attempt-execution-attribution.js";
 import type {
   EmbeddedRunAttemptParams,
   EmbeddedRunAttemptResult,
@@ -589,7 +590,7 @@ function withoutInternalHarnessAuthority(
     return params;
   }
   const { systemAgentTool: _systemAgentTool, ...pluginParams } = params;
-  return pluginParams;
+  return transferEmbeddedAttemptExecutionAttribution(params, pluginParams);
 }
 
 function preparePluginHarnessParams(params: EmbeddedRunAttemptParams): EmbeddedRunAttemptParams {
@@ -601,11 +602,13 @@ function preparePluginHarnessParams(params: EmbeddedRunAttemptParams): EmbeddedR
   if (model === params.model && resolvedApiKey === params.resolvedApiKey) {
     return applyPluginHarnessDenyAllToolPolicy(params);
   }
-  return applyPluginHarnessDenyAllToolPolicy({
-    ...params,
-    model,
-    resolvedApiKey,
-  });
+  return applyPluginHarnessDenyAllToolPolicy(
+    transferEmbeddedAttemptExecutionAttribution(params, {
+      ...params,
+      model,
+      resolvedApiKey,
+    }),
+  );
 }
 
 function applyPluginHarnessDenyAllToolPolicy(
@@ -622,11 +625,11 @@ function applyPluginHarnessDenyAllToolPolicy(
   if (!prompt) {
     return params;
   }
-  return {
+  return transferEmbeddedAttemptExecutionAttribution(params, {
     ...params,
     toolsAllow: [],
     extraSystemPrompt: appendPluginHarnessToolPolicyPrompt(params.extraSystemPrompt, prompt),
-  };
+  });
 }
 
 export function resolvePluginHarnessPolicyToolsAllow(

--- a/src/agents/harness/side-question-execution-attribution.ts
+++ b/src/agents/harness/side-question-execution-attribution.ts
@@ -1,0 +1,27 @@
+import type { AgentExecutionAttribution } from "../agent-execution-attribution.js";
+import type { AgentHarnessSideQuestionParams } from "./types.js";
+
+const attributionBySideQuestion = new WeakMap<
+  AgentHarnessSideQuestionParams,
+  AgentExecutionAttribution
+>();
+
+/**
+ * Bind host attribution to the exact side-question request handed to a harness.
+ * Clones and plugin-created request objects intentionally receive no identity.
+ */
+export function bindAgentHarnessSideQuestionExecutionAttribution(
+  params: AgentHarnessSideQuestionParams,
+  attribution: AgentExecutionAttribution | undefined,
+): AgentHarnessSideQuestionParams {
+  if (attribution) {
+    attributionBySideQuestion.set(params, attribution);
+  }
+  return params;
+}
+
+export function resolveAgentHarnessSideQuestionExecutionAttribution(
+  params: AgentHarnessSideQuestionParams,
+): AgentExecutionAttribution | undefined {
+  return attributionBySideQuestion.get(params);
+}

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -22,6 +22,7 @@ import { resolveTranscriptsConfig } from "../transcripts/config.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
+import { inheritToolExecutionAttribution } from "./agent-tools.before-tool-call.attribution.js";
 import {
   type HookContext,
   isToolWrappedWithBeforeToolCallHook,
@@ -754,10 +755,10 @@ export function createOpenClawTools(
     ...(options?.currentChannelId ? { channelId: options.currentChannelId } : {}),
     loopDetection: resolveToolLoopDetectionConfig({ cfg: resolvedConfig, agentId: hookAgentId }),
   };
-  const hookContext = {
+  const hookContext = inheritToolExecutionAttribution(options?.beforeToolCallHookContext, {
     ...defaultHookContext,
     ...options?.beforeToolCallHookContext,
-  };
+  });
   options?.recordToolPrepStage?.("openclaw-tools:tool-hooks");
   return allTools
     .map((tool) =>

--- a/src/plugin-sdk/agent-harness-tool-authority-runtime.ts
+++ b/src/plugin-sdk/agent-harness-tool-authority-runtime.ts
@@ -1,7 +1,3 @@
-import {
-  createOpenClawCodingToolsForAgentHarness as createCoreOpenClawCodingToolsForAgentHarness,
-  createOpenClawCodingToolsForAgentHarnessSideQuestion as createCoreOpenClawCodingToolsForAgentHarnessSideQuestion,
-} from "../agents/agent-tools-internal.js";
 import type {
   AgentHarnessSideQuestionParams,
   EmbeddedRunAttemptParams,
@@ -15,10 +11,16 @@ type OpenClawCodingToolsOptions = NonNullable<
  * Build tools for the exact host-admitted attempt without exposing its private
  * execution attribution to plugin code.
  */
-export function createOpenClawCodingToolsForAgentHarness(
+export async function createOpenClawCodingToolsForAgentHarness(
   attempt: EmbeddedRunAttemptParams,
   options?: OpenClawCodingToolsOptions,
-): ReturnType<typeof createCoreOpenClawCodingToolsForAgentHarness> {
+): Promise<
+  ReturnType<
+    typeof import("../agents/agent-tools-internal.js").createOpenClawCodingToolsForAgentHarness
+  >
+> {
+  const { createOpenClawCodingToolsForAgentHarness: createCoreOpenClawCodingToolsForAgentHarness } =
+    await import("../agents/agent-tools-internal.js");
   return createCoreOpenClawCodingToolsForAgentHarness(attempt, options);
 }
 
@@ -26,9 +28,17 @@ export function createOpenClawCodingToolsForAgentHarness(
  * Build tools for the exact host-admitted side-question request without
  * exposing its private execution attribution to plugin code.
  */
-export function createOpenClawCodingToolsForAgentHarnessSideQuestion(
+export async function createOpenClawCodingToolsForAgentHarnessSideQuestion(
   params: AgentHarnessSideQuestionParams,
   options?: OpenClawCodingToolsOptions,
-): ReturnType<typeof createCoreOpenClawCodingToolsForAgentHarnessSideQuestion> {
+): Promise<
+  ReturnType<
+    typeof import("../agents/agent-tools-internal.js").createOpenClawCodingToolsForAgentHarnessSideQuestion
+  >
+> {
+  const {
+    createOpenClawCodingToolsForAgentHarnessSideQuestion:
+      createCoreOpenClawCodingToolsForAgentHarnessSideQuestion,
+  } = await import("../agents/agent-tools-internal.js");
   return createCoreOpenClawCodingToolsForAgentHarnessSideQuestion(params, options);
 }

--- a/src/plugin-sdk/agent-harness-tool-authority-runtime.ts
+++ b/src/plugin-sdk/agent-harness-tool-authority-runtime.ts
@@ -1,0 +1,34 @@
+import {
+  createOpenClawCodingToolsForAgentHarness as createCoreOpenClawCodingToolsForAgentHarness,
+  createOpenClawCodingToolsForAgentHarnessSideQuestion as createCoreOpenClawCodingToolsForAgentHarnessSideQuestion,
+} from "../agents/agent-tools-internal.js";
+import type {
+  AgentHarnessSideQuestionParams,
+  EmbeddedRunAttemptParams,
+} from "./agent-harness-runtime.js";
+
+type OpenClawCodingToolsOptions = NonNullable<
+  Parameters<typeof import("./agent-harness.js").createOpenClawCodingTools>[0]
+>;
+
+/**
+ * Build tools for the exact host-admitted attempt without exposing its private
+ * execution attribution to plugin code.
+ */
+export function createOpenClawCodingToolsForAgentHarness(
+  attempt: EmbeddedRunAttemptParams,
+  options?: OpenClawCodingToolsOptions,
+): ReturnType<typeof createCoreOpenClawCodingToolsForAgentHarness> {
+  return createCoreOpenClawCodingToolsForAgentHarness(attempt, options);
+}
+
+/**
+ * Build tools for the exact host-admitted side-question request without
+ * exposing its private execution attribution to plugin code.
+ */
+export function createOpenClawCodingToolsForAgentHarnessSideQuestion(
+  params: AgentHarnessSideQuestionParams,
+  options?: OpenClawCodingToolsOptions,
+): ReturnType<typeof createCoreOpenClawCodingToolsForAgentHarnessSideQuestion> {
+  return createCoreOpenClawCodingToolsForAgentHarnessSideQuestion(params, options);
+}

--- a/src/plugin-sdk/agent-harness-tool-runtime.ts
+++ b/src/plugin-sdk/agent-harness-tool-runtime.ts
@@ -1,13 +1,21 @@
+import {
+  createOpenClawCodingToolsForAgentHarness as createCoreOpenClawCodingToolsForAgentHarness,
+  createOpenClawCodingToolsForAgentHarnessSideQuestion as createCoreOpenClawCodingToolsForAgentHarnessSideQuestion,
+} from "../agents/agent-tools-internal.js";
 /**
- * Focused runtime SDK subpath for native harness tool-surface routing.
+ * Packaged private runtime facade for official harness plugins.
  *
- * Keep tool-search and code-mode dependencies out of the lightweight harness
- * lifecycle facade used during plugin startup.
+ * This subpath is local-only and declaration-excluded. Keep tool-search and
+ * code-mode dependencies out of the lightweight startup lifecycle facade.
  */
 import {
   createAgentHarnessToolSurfaceRuntime as createCoreAgentHarnessToolSurfaceRuntime,
   type AgentHarnessToolSurfaceRuntime as CoreAgentHarnessToolSurfaceRuntime,
 } from "../agents/harness/tool-surface-bridge.js";
+import type {
+  AgentHarnessSideQuestionParams,
+  EmbeddedRunAttemptParams,
+} from "./agent-harness-runtime.js";
 
 type OpenClawCodingToolsOptions = NonNullable<
   Parameters<typeof import("./agent-harness.js").createOpenClawCodingTools>[0]
@@ -32,4 +40,26 @@ export function createAgentHarnessToolSurfaceRuntime(
   params: AgentHarnessToolSurfaceRuntimeParams,
 ): AgentHarnessToolSurfaceRuntime {
   return createCoreAgentHarnessToolSurfaceRuntime(params);
+}
+
+/**
+ * Build tools for the exact host-admitted attempt without exposing its private
+ * execution attribution to plugin code.
+ */
+export function createOpenClawCodingToolsForAgentHarness(
+  attempt: EmbeddedRunAttemptParams,
+  options?: OpenClawCodingToolsOptions,
+): ReturnType<typeof createCoreOpenClawCodingToolsForAgentHarness> {
+  return createCoreOpenClawCodingToolsForAgentHarness(attempt, options);
+}
+
+/**
+ * Build tools for the exact host-admitted side-question request without
+ * exposing its private execution attribution to plugin code.
+ */
+export function createOpenClawCodingToolsForAgentHarnessSideQuestion(
+  params: AgentHarnessSideQuestionParams,
+  options?: OpenClawCodingToolsOptions,
+): ReturnType<typeof createCoreOpenClawCodingToolsForAgentHarnessSideQuestion> {
+  return createCoreOpenClawCodingToolsForAgentHarnessSideQuestion(params, options);
 }

--- a/src/plugin-sdk/agent-harness-tool-runtime.ts
+++ b/src/plugin-sdk/agent-harness-tool-runtime.ts
@@ -1,21 +1,13 @@
-import {
-  createOpenClawCodingToolsForAgentHarness as createCoreOpenClawCodingToolsForAgentHarness,
-  createOpenClawCodingToolsForAgentHarnessSideQuestion as createCoreOpenClawCodingToolsForAgentHarnessSideQuestion,
-} from "../agents/agent-tools-internal.js";
 /**
- * Packaged private runtime facade for official harness plugins.
+ * Focused runtime SDK subpath for native harness tool-surface routing.
  *
- * This subpath is local-only and declaration-excluded. Keep tool-search and
- * code-mode dependencies out of the lightweight startup lifecycle facade.
+ * Keep tool-search and code-mode dependencies out of the lightweight harness
+ * lifecycle facade used during plugin startup.
  */
 import {
   createAgentHarnessToolSurfaceRuntime as createCoreAgentHarnessToolSurfaceRuntime,
   type AgentHarnessToolSurfaceRuntime as CoreAgentHarnessToolSurfaceRuntime,
 } from "../agents/harness/tool-surface-bridge.js";
-import type {
-  AgentHarnessSideQuestionParams,
-  EmbeddedRunAttemptParams,
-} from "./agent-harness-runtime.js";
 
 type OpenClawCodingToolsOptions = NonNullable<
   Parameters<typeof import("./agent-harness.js").createOpenClawCodingTools>[0]
@@ -40,26 +32,4 @@ export function createAgentHarnessToolSurfaceRuntime(
   params: AgentHarnessToolSurfaceRuntimeParams,
 ): AgentHarnessToolSurfaceRuntime {
   return createCoreAgentHarnessToolSurfaceRuntime(params);
-}
-
-/**
- * Build tools for the exact host-admitted attempt without exposing its private
- * execution attribution to plugin code.
- */
-export function createOpenClawCodingToolsForAgentHarness(
-  attempt: EmbeddedRunAttemptParams,
-  options?: OpenClawCodingToolsOptions,
-): ReturnType<typeof createCoreOpenClawCodingToolsForAgentHarness> {
-  return createCoreOpenClawCodingToolsForAgentHarness(attempt, options);
-}
-
-/**
- * Build tools for the exact host-admitted side-question request without
- * exposing its private execution attribution to plugin code.
- */
-export function createOpenClawCodingToolsForAgentHarnessSideQuestion(
-  params: AgentHarnessSideQuestionParams,
-  options?: OpenClawCodingToolsOptions,
-): ReturnType<typeof createCoreOpenClawCodingToolsForAgentHarnessSideQuestion> {
-  return createCoreOpenClawCodingToolsForAgentHarnessSideQuestion(params, options);
 }

--- a/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
@@ -817,6 +817,26 @@ describe("plugin-sdk package contract guardrails", () => {
     });
   });
 
+  it("keeps the agent harness tool authority runtime owner-restricted", () => {
+    const entrypoint = "agent-harness-tool-authority-runtime";
+    const localOnly = new Set(privateLocalOnlyPluginSdkEntrypoints);
+    const packageExports = new Set(collectPluginSdkPackageExports());
+    const typedExports = collectTypedPluginSdkPackageExports();
+    const excludedDeclarations = collectPackExcludedPluginSdkDeclarations();
+
+    expect({
+      localOnly: localOnly.has(entrypoint),
+      packageExport: packageExports.has(entrypoint),
+      typedExport: typedExports.has(entrypoint),
+      declarationExcluded: excludedDeclarations.has(entrypoint),
+    }).toEqual({
+      localOnly: true,
+      packageExport: false,
+      typedExport: false,
+      declarationExcluded: true,
+    });
+  });
+
   it("keeps configured local-origin fetch helpers out of deprecated infra-runtime", () => {
     const source = fs.readFileSync(resolve(REPO_ROOT, "src/plugin-sdk/infra-runtime.ts"), "utf8");
 

--- a/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
@@ -800,6 +800,23 @@ describe("plugin-sdk package contract guardrails", () => {
     ).toBe(true);
   });
 
+  it("keeps the agent harness tool runtime out of the typed public SDK", () => {
+    const entrypoint = "agent-harness-tool-runtime";
+    const localOnly = new Set(privateLocalOnlyPluginSdkEntrypoints);
+    const typedExports = collectTypedPluginSdkPackageExports();
+    const excludedDeclarations = collectPackExcludedPluginSdkDeclarations();
+
+    expect({
+      localOnly: localOnly.has(entrypoint),
+      typedExport: typedExports.has(entrypoint),
+      declarationExcluded: excludedDeclarations.has(entrypoint),
+    }).toEqual({
+      localOnly: true,
+      typedExport: false,
+      declarationExcluded: true,
+    });
+  });
+
   it("keeps configured local-origin fetch helpers out of deprecated infra-runtime", () => {
     const source = fs.readFileSync(resolve(REPO_ROOT, "src/plugin-sdk/infra-runtime.ts"), "utf8");
 

--- a/src/plugins/loader-channel-runtime.ts
+++ b/src/plugins/loader-channel-runtime.ts
@@ -119,7 +119,13 @@ export function loadSetupRuntimeChannelCandidate(params: {
       runtimeMod = withProfile(
         { pluginId: record.id, source: safeRuntimeSource },
         "load-setup-runtime-entry",
-        () => params.loadPluginModule(safeRuntimeSource) as OpenClawPluginModule,
+        () =>
+          params.loadPluginModule(
+            safeRuntimeSource,
+            manifestRecord.trustedOfficialInstall
+              ? { trustedInstalledPrivateSdkOwner: manifestRecord.id }
+              : undefined,
+          ) as OpenClawPluginModule,
       );
     } catch (error) {
       recordPluginError({

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -240,7 +240,13 @@ export async function loadOpenClawPluginCliRegistry(
       mod = withProfile(
         { pluginId: record.id, source: safeSource },
         "cli-metadata",
-        () => loadPluginModule(safeSource) as OpenClawPluginModule,
+        () =>
+          loadPluginModule(
+            safeSource,
+            manifestRecord.trustedOfficialInstall
+              ? { trustedInstalledPrivateSdkOwner: manifestRecord.id }
+              : undefined,
+          ) as OpenClawPluginModule,
       );
     } catch (error) {
       recordPluginError({

--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -20,6 +20,10 @@ import {
 } from "./sdk-alias.js";
 import type { OpenClawPluginApi, OpenClawPluginDefinition } from "./types.js";
 
+export type PluginModuleLoadAuthority = {
+  trustedInstalledPrivateSdkOwner?: string;
+};
+
 const LAZY_RUNTIME_REFLECTION_KEYS = [
   "version",
   "gateway",
@@ -115,7 +119,7 @@ export function createPluginModuleLoader(options: {
   installNativeSdkResolver?: boolean;
 }) {
   const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
-  const createLoaderForModule = (modulePath: string) => {
+  const createLoaderForModule = (modulePath: string, authority?: PluginModuleLoadAuthority) => {
     if (options.installNativeSdkResolver !== false && options.tryNative !== false) {
       installOpenClawPluginSdkNativeResolver({
         argv1: process.argv[1],
@@ -123,6 +127,11 @@ export function createPluginModuleLoader(options: {
         pluginModulePath: modulePath,
         devSourceRoot: options.devSourceRoot,
         pluginSdkResolution: options.pluginSdkResolution,
+        ...(authority?.trustedInstalledPrivateSdkOwner
+          ? {
+              trustedInstalledPrivateSdkOwner: authority.trustedInstalledPrivateSdkOwner,
+            }
+          : {}),
       });
     }
     const defaultAliasMap = buildPluginLoaderAliasMap(
@@ -131,6 +140,7 @@ export function createPluginModuleLoader(options: {
       import.meta.url,
       options.pluginSdkResolution,
       options.devSourceRoot,
+      authority?.trustedInstalledPrivateSdkOwner,
     );
     const aliasMap = options.aliasOverrides
       ? { ...defaultAliasMap, ...options.aliasOverrides }
@@ -146,8 +156,8 @@ export function createPluginModuleLoader(options: {
       ...(options.tryNative !== undefined ? { tryNative: options.tryNative } : {}),
     });
   };
-  return (modulePath: string): unknown =>
-    createLoaderForModule(modulePath)(toSafeImportPath(modulePath));
+  return (modulePath: string, authority?: PluginModuleLoadAuthority): unknown =>
+    createLoaderForModule(modulePath, authority)(toSafeImportPath(modulePath));
 }
 
 function formatPluginRuntimeModuleResolutionError(params: {

--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -20,7 +20,7 @@ import {
 } from "./sdk-alias.js";
 import type { OpenClawPluginApi, OpenClawPluginDefinition } from "./types.js";
 
-export type PluginModuleLoadAuthority = {
+type PluginModuleLoadAuthority = {
   trustedInstalledPrivateSdkOwner?: string;
 };
 

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -396,7 +396,13 @@ export function loadRuntimePluginCandidate(params: {
     mod = withProfile(
       { pluginId: record.id, source: safeSource },
       registrationPlan.mode,
-      () => params.loadPluginModule(safeSource) as OpenClawPluginModule,
+      () =>
+        params.loadPluginModule(
+          safeSource,
+          manifestRecord.trustedOfficialInstall
+            ? { trustedInstalledPrivateSdkOwner: manifestRecord.id }
+            : undefined,
+        ) as OpenClawPluginModule,
     );
   } catch (error) {
     recordPluginError({

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -1,7 +1,7 @@
 // Verifies native plugin SDK resolver behavior and import aliases.
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
-import { createRequire } from "node:module";
+import Module, { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -635,6 +635,37 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
     expect(installedAliases).not.toContain("openclaw/plugin-sdk/source-only");
     const requireFromPlugin = createRequire(externalPluginEntry);
     expect(() => requireFromPlugin.resolve("openclaw/plugin-sdk/source-only")).toThrow();
+  });
+
+  it("keeps harness tool authority out of the forgeable native resolver", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-authority-"));
+    const { loaderModulePath } = writeFakeOpenClawPackage(root);
+    addFakePluginSdkDistExport(root, "agent-harness-tool-authority-runtime");
+    const installedCodexEntry = writeExternalPluginEntry(
+      fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-installed-codex-")),
+    );
+
+    const installedAliases = installOpenClawPluginSdkNativeResolver({
+      modulePath: loaderModulePath,
+      pluginModulePath: installedCodexEntry,
+      pluginSdkResolution: "dist",
+      trustedInstalledPrivateSdkOwner: "codex",
+    });
+
+    const authoritySpecifier = "openclaw/plugin-sdk/agent-harness-tool-authority-runtime";
+    expect(installedAliases).not.toContain(authoritySpecifier);
+    const resolveFilename = (
+      Module as unknown as {
+        _resolveFilename: (request: string, parent: NodeJS.Module, isMain: boolean) => string;
+      }
+    )._resolveFilename;
+    expect(() =>
+      resolveFilename(
+        authoritySpecifier,
+        { filename: installedCodexEntry } as NodeJS.Module,
+        false,
+      ),
+    ).toThrow();
   });
 
   it("scopes private SSRF SDK aliases to bundled local IPC native parents", () => {

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -654,11 +654,11 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
 
     const authoritySpecifier = "openclaw/plugin-sdk/agent-harness-tool-authority-runtime";
     expect(installedAliases).not.toContain(authoritySpecifier);
-    const resolveFilename = (
-      Module as unknown as {
-        _resolveFilename: (request: string, parent: NodeJS.Module, isMain: boolean) => string;
-      }
-    )._resolveFilename;
+    const resolveFilename = Reflect.get(Module, "_resolveFilename") as (
+      request: string,
+      parent: NodeJS.Module,
+      isMain: boolean,
+    ) => string;
     expect(() =>
       resolveFilename(
         authoritySpecifier,

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -311,6 +311,13 @@ function listPluginSdkNativeAliases(
   }
   const aliases = Object.entries(aliasMap)
     .filter(([specifier]) => isPluginSdkAliasSpecifier(specifier))
+    // This capability is injected through the owner-scoped plugin loader.
+    // A process-global resolver cannot authenticate caller-supplied parent metadata.
+    .filter(
+      ([specifier]) =>
+        specifier !== "openclaw/plugin-sdk/agent-harness-tool-authority-runtime" &&
+        specifier !== "openclaw/plugin-sdk/agent-harness-tool-authority-runtime.js",
+    )
     .filter(([, target]) => isNativeLoadableSdkTarget(target))
     .flatMap(([specifier, target]) => {
       if (specifier.endsWith(".js")) {

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -48,6 +48,7 @@ type InstallOpenClawPluginSdkNativeResolverOptions = {
   moduleUrl?: string;
   devSourceRoot?: string | null;
   pluginSdkResolution?: PluginSdkResolutionPreference;
+  trustedInstalledPrivateSdkOwner?: string;
 };
 
 const moduleWithResolver = Module as ModuleWithResolver;
@@ -302,6 +303,7 @@ function listPluginSdkNativeAliases(
     // plugin loader itself is configured to prefer source imports.
     "dist",
     options.devSourceRoot,
+    options.trustedInstalledPrivateSdkOwner,
   );
   const cached = pluginSdkNativeAliasesByMap.get(aliasMap);
   if (cached) {

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -712,6 +712,9 @@ describe("plugin sdk alias helpers", () => {
     const sourceCodexAliases = buildPluginLoaderAliasMap(sourceCodexEntry);
     const sourceCopilotAliases = buildPluginLoaderAliasMap(sourceCopilotEntry);
     const sourceOtherAliases = buildPluginLoaderAliasMap(sourceOtherEntry);
+    const sourceOtherPrivateQaAliases = withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1" }, () =>
+      buildPluginLoaderAliasMap(sourceOtherEntry),
+    );
     const installedCodexAliases = withCwd(installedCodexRoot, () =>
       buildPluginLoaderAliasMap(
         installedCodexEntry,
@@ -736,6 +739,16 @@ describe("plugin sdk alias helpers", () => {
         "dist",
       ),
     );
+    const installedOtherPrivateQaAliases = withCwd(installedOtherRoot, () =>
+      withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1" }, () =>
+        buildPluginLoaderAliasMap(
+          installedOtherEntry,
+          path.join(fixture.root, "openclaw.mjs"),
+          undefined,
+          "dist",
+        ),
+      ),
+    );
     const specifier = `openclaw/plugin-sdk/${authoritySubpath}`;
 
     expect(fs.realpathSync(sourceCodexAliases[specifier] ?? "")).toBe(
@@ -751,7 +764,9 @@ describe("plugin sdk alias helpers", () => {
       fs.realpathSync(distAuthorityPath),
     );
     expect(sourceOtherAliases[specifier]).toBeUndefined();
+    expect(sourceOtherPrivateQaAliases[specifier]).toBeUndefined();
     expect(installedOtherAliases[specifier]).toBeUndefined();
+    expect(installedOtherPrivateQaAliases[specifier]).toBeUndefined();
   });
 
   it("does not reuse a non-private cached subpath list after private qa gets enabled", () => {

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -654,6 +654,106 @@ describe("plugin sdk alias helpers", () => {
     expect(shadowCodexSubpaths).toEqual(["core"]);
   });
 
+  it("aliases harness tool authority only for trusted official harness plugins", () => {
+    const fixture = createPluginSdkAliasFixture({
+      packageExports: {
+        "./plugin-sdk/core": { default: "./dist/plugin-sdk/core.js" },
+      },
+    });
+    const authoritySubpath = "agent-harness-tool-authority-runtime";
+    const sourceAuthorityPath = path.join(
+      fixture.root,
+      "src",
+      "plugin-sdk",
+      `${authoritySubpath}.ts`,
+    );
+    const distAuthorityPath = path.join(
+      fixture.root,
+      "dist",
+      "plugin-sdk",
+      `${authoritySubpath}.js`,
+    );
+    fs.writeFileSync(
+      path.join(fixture.root, "scripts", "lib", "plugin-sdk-private-local-only-subpaths.json"),
+      JSON.stringify([authoritySubpath], null, 2),
+      "utf-8",
+    );
+    fs.writeFileSync(sourceAuthorityPath, "export const authority = true;\n", "utf-8");
+    fs.writeFileSync(distAuthorityPath, "export const authority = true;\n", "utf-8");
+
+    const sourceCodexEntry = writePluginEntry(
+      fixture.root,
+      bundledPluginFile("codex", "src/index.ts"),
+    );
+    const sourceCopilotEntry = writePluginEntry(
+      fixture.root,
+      bundledPluginFile("copilot", "src/index.ts"),
+    );
+    const sourceOtherEntry = writePluginEntry(
+      fixture.root,
+      bundledPluginFile("demo", "src/index.ts"),
+    );
+    const { packageRoot: installedCodexRoot, pluginEntry: installedCodexEntry } =
+      writeInstalledPluginEntry({
+        installRoot: path.join(makeTempDir(), ".openclaw", "npm"),
+        packageName: "@openclaw/codex",
+      });
+    const { packageRoot: installedCopilotRoot, pluginEntry: installedCopilotEntry } =
+      writeInstalledPluginEntry({
+        installRoot: path.join(makeTempDir(), ".openclaw", "npm"),
+        packageName: "@openclaw/copilot",
+      });
+    const { packageRoot: installedOtherRoot, pluginEntry: installedOtherEntry } =
+      writeInstalledPluginEntry({
+        installRoot: path.join(makeTempDir(), ".openclaw", "npm"),
+        packageName: "@openclaw/demo",
+      });
+
+    const sourceCodexAliases = buildPluginLoaderAliasMap(sourceCodexEntry);
+    const sourceCopilotAliases = buildPluginLoaderAliasMap(sourceCopilotEntry);
+    const sourceOtherAliases = buildPluginLoaderAliasMap(sourceOtherEntry);
+    const installedCodexAliases = withCwd(installedCodexRoot, () =>
+      buildPluginLoaderAliasMap(
+        installedCodexEntry,
+        path.join(fixture.root, "openclaw.mjs"),
+        undefined,
+        "dist",
+      ),
+    );
+    const installedCopilotAliases = withCwd(installedCopilotRoot, () =>
+      buildPluginLoaderAliasMap(
+        installedCopilotEntry,
+        path.join(fixture.root, "openclaw.mjs"),
+        undefined,
+        "dist",
+      ),
+    );
+    const installedOtherAliases = withCwd(installedOtherRoot, () =>
+      buildPluginLoaderAliasMap(
+        installedOtherEntry,
+        path.join(fixture.root, "openclaw.mjs"),
+        undefined,
+        "dist",
+      ),
+    );
+    const specifier = `openclaw/plugin-sdk/${authoritySubpath}`;
+
+    expect(fs.realpathSync(sourceCodexAliases[specifier] ?? "")).toBe(
+      fs.realpathSync(sourceAuthorityPath),
+    );
+    expect(fs.realpathSync(sourceCopilotAliases[specifier] ?? "")).toBe(
+      fs.realpathSync(sourceAuthorityPath),
+    );
+    expect(fs.realpathSync(installedCodexAliases[specifier] ?? "")).toBe(
+      fs.realpathSync(distAuthorityPath),
+    );
+    expect(fs.realpathSync(installedCopilotAliases[specifier] ?? "")).toBe(
+      fs.realpathSync(distAuthorityPath),
+    );
+    expect(sourceOtherAliases[specifier]).toBeUndefined();
+    expect(installedOtherAliases[specifier]).toBeUndefined();
+  });
+
   it("does not reuse a non-private cached subpath list after private qa gets enabled", () => {
     const fixture = createPluginSdkAliasFixture({
       packageExports: {

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -413,6 +413,7 @@ function listPluginSdkExportedSubpaths(params: {
   moduleUrl?: string;
   devSourceRoot?: string | null;
   pluginSdkResolution?: PluginSdkResolutionPreference;
+  trustedInstalledPrivateSdkOwner?: string;
 }): string[] {
   return Object.keys(
     buildPluginLoaderAliasMap(
@@ -421,6 +422,7 @@ function listPluginSdkExportedSubpaths(params: {
       params.moduleUrl,
       params.pluginSdkResolution,
       params.devSourceRoot,
+      params.trustedInstalledPrivateSdkOwner,
     ),
   )
     .filter((key) => key.startsWith("openclaw/plugin-sdk/"))
@@ -630,6 +632,15 @@ describe("plugin sdk alias helpers", () => {
         }),
       ),
     );
+    const trustedInstalledCodexSubpaths = withCwd(installedCodexRoot, () =>
+      withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: undefined }, () =>
+        listPluginSdkExportedSubpaths({
+          modulePath: installedCodexEntry,
+          argv1: path.join(fixture.root, "openclaw.mjs"),
+          trustedInstalledPrivateSdkOwner: "codex",
+        }),
+      ),
+    );
     const installedOtherSubpaths = withCwd(installedOtherRoot, () =>
       withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: undefined }, () =>
         listPluginSdkExportedSubpaths({
@@ -648,13 +659,14 @@ describe("plugin sdk alias helpers", () => {
     );
 
     expect(codexSubpaths).toEqual(["codex-mcp-projection", "core"]);
-    expect(installedCodexSubpaths).toEqual(["codex-mcp-projection", "core"]);
+    expect(installedCodexSubpaths).toEqual(["core"]);
+    expect(trustedInstalledCodexSubpaths).toEqual(["codex-mcp-projection", "core"]);
     expect(otherSubpaths).toEqual(["core"]);
     expect(installedOtherSubpaths).toEqual(["core"]);
     expect(shadowCodexSubpaths).toEqual(["core"]);
   });
 
-  it("aliases harness tool authority only for trusted official harness plugins", () => {
+  it("aliases harness tool authority only for host-verified official harness plugins", () => {
     const fixture = createPluginSdkAliasFixture({
       packageExports: {
         "./plugin-sdk/core": { default: "./dist/plugin-sdk/core.js" },
@@ -715,12 +727,30 @@ describe("plugin sdk alias helpers", () => {
     const sourceOtherPrivateQaAliases = withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1" }, () =>
       buildPluginLoaderAliasMap(sourceOtherEntry),
     );
+    const spoofedCodexAliases = withCwd(installedCodexRoot, () =>
+      buildPluginLoaderAliasMap(
+        installedCodexEntry,
+        path.join(fixture.root, "openclaw.mjs"),
+        undefined,
+        "dist",
+      ),
+    );
+    const spoofedCopilotAliases = withCwd(installedCopilotRoot, () =>
+      buildPluginLoaderAliasMap(
+        installedCopilotEntry,
+        path.join(fixture.root, "openclaw.mjs"),
+        undefined,
+        "dist",
+      ),
+    );
     const installedCodexAliases = withCwd(installedCodexRoot, () =>
       buildPluginLoaderAliasMap(
         installedCodexEntry,
         path.join(fixture.root, "openclaw.mjs"),
         undefined,
         "dist",
+        undefined,
+        "codex",
       ),
     );
     const installedCopilotAliases = withCwd(installedCopilotRoot, () =>
@@ -729,6 +759,8 @@ describe("plugin sdk alias helpers", () => {
         path.join(fixture.root, "openclaw.mjs"),
         undefined,
         "dist",
+        undefined,
+        "copilot",
       ),
     );
     const installedOtherAliases = withCwd(installedOtherRoot, () =>
@@ -763,6 +795,8 @@ describe("plugin sdk alias helpers", () => {
     expect(fs.realpathSync(installedCopilotAliases[specifier] ?? "")).toBe(
       fs.realpathSync(distAuthorityPath),
     );
+    expect(spoofedCodexAliases[specifier]).toBeUndefined();
+    expect(spoofedCopilotAliases[specifier]).toBeUndefined();
     expect(sourceOtherAliases[specifier]).toBeUndefined();
     expect(sourceOtherPrivateQaAliases[specifier]).toBeUndefined();
     expect(installedOtherAliases[specifier]).toBeUndefined();
@@ -1033,6 +1067,16 @@ describe("plugin sdk alias helpers", () => {
           devFixture.root,
         ),
     );
+    const spoofedInstalledAliases = withCwd(installedCodexRoot, () =>
+      withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: undefined, NODE_ENV: undefined }, () =>
+        buildPluginLoaderAliasMap(
+          installedCodexEntry,
+          path.join(fixture.root, "openclaw.mjs"),
+          undefined,
+          "dist",
+        ),
+      ),
+    );
     const installedAliases = withCwd(installedCodexRoot, () =>
       withEnv({ OPENCLAW_ENABLE_PRIVATE_QA_CLI: undefined, NODE_ENV: undefined }, () =>
         buildPluginLoaderAliasMap(
@@ -1040,6 +1084,8 @@ describe("plugin sdk alias helpers", () => {
           path.join(fixture.root, "openclaw.mjs"),
           undefined,
           "dist",
+          undefined,
+          "codex",
         ),
       ),
     );
@@ -1070,6 +1116,7 @@ describe("plugin sdk alias helpers", () => {
     expect(
       fs.realpathSync(installedAliases["openclaw/plugin-sdk/codex-mcp-projection"] ?? ""),
     ).toBe(fs.realpathSync(distCodexMcpProjectionPath));
+    expect(spoofedInstalledAliases["openclaw/plugin-sdk/codex-mcp-projection"]).toBeUndefined();
     expect(fs.realpathSync(devRootAliases["openclaw/plugin-sdk/codex-mcp-projection"] ?? "")).toBe(
       fs.realpathSync(devCodexMcpProjectionPath),
     );

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -449,14 +449,17 @@ const PRIVATE_QA_ONLY_PLUGIN_SDK_SUBPATHS = new Set([
 type PrivatePluginSdkSubpathOwner = {
   bundledPluginId: string;
   officialInstalledPackageName?: string;
-  allowPrivateQaCli: boolean;
+  privateQaCliSubpaths?: readonly string[];
   subpaths: readonly string[];
 };
 const PRIVATE_PLUGIN_SDK_SUBPATH_OWNERS: readonly PrivatePluginSdkSubpathOwner[] = [
   {
     bundledPluginId: "codex",
     officialInstalledPackageName: "@openclaw/codex",
-    allowPrivateQaCli: true,
+    privateQaCliSubpaths: [
+      CODEX_MCP_PROJECTION_PLUGIN_SDK_SUBPATH,
+      CODEX_SESSION_TRANSCRIPT_PLUGIN_SDK_SUBPATH,
+    ],
     subpaths: [
       AGENT_HARNESS_TOOL_AUTHORITY_PLUGIN_SDK_SUBPATH,
       CODEX_MCP_PROJECTION_PLUGIN_SDK_SUBPATH,
@@ -466,17 +469,14 @@ const PRIVATE_PLUGIN_SDK_SUBPATH_OWNERS: readonly PrivatePluginSdkSubpathOwner[]
   {
     bundledPluginId: "copilot",
     officialInstalledPackageName: "@openclaw/copilot",
-    allowPrivateQaCli: false,
     subpaths: [AGENT_HARNESS_TOOL_AUTHORITY_PLUGIN_SDK_SUBPATH],
   },
   {
     bundledPluginId: "ollama",
-    allowPrivateQaCli: false,
     subpaths: [OLLAMA_CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH],
   },
   {
     bundledPluginId: "browser",
-    allowPrivateQaCli: false,
     subpaths: [OLLAMA_CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH],
   },
 ];
@@ -1094,7 +1094,8 @@ function shouldIncludePrivateLocalOnlyPluginSdkSubpath(params: {
   return owners.some(
     (owner) =>
       isTrustedPrivatePluginSdkOwnerPath({ ...params, owner }) ||
-      (owner.allowPrivateQaCli && shouldIncludePrivateLocalOnlyPluginSdkSubpaths()),
+      (owner.privateQaCliSubpaths?.includes(params.subpath) === true &&
+        shouldIncludePrivateLocalOnlyPluginSdkSubpaths()),
   );
 }
 

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -419,6 +419,7 @@ const cachedWorkspacePackageAliasMaps = new PluginLruCache<Record<string, string
 const PLUGIN_SDK_PACKAGE_NAMES = ["openclaw/plugin-sdk", "@openclaw/plugin-sdk"] as const;
 const CODEX_MCP_PROJECTION_PLUGIN_SDK_SUBPATH = "codex-mcp-projection";
 const CODEX_SESSION_TRANSCRIPT_PLUGIN_SDK_SUBPATH = "codex-session-transcript-runtime";
+const AGENT_HARNESS_TOOL_AUTHORITY_PLUGIN_SDK_SUBPATH = "agent-harness-tool-authority-runtime";
 const OLLAMA_CONFIGURED_LOCAL_ORIGIN_RUNTIME_PLUGIN_SDK_SUBPATH = "ssrf-runtime-internal";
 const PRIVATE_QA_ONLY_PLUGIN_SDK_SUBPATHS = new Set([
   "agent-runtime-test-contracts",
@@ -457,9 +458,16 @@ const PRIVATE_PLUGIN_SDK_SUBPATH_OWNERS: readonly PrivatePluginSdkSubpathOwner[]
     officialInstalledPackageName: "@openclaw/codex",
     allowPrivateQaCli: true,
     subpaths: [
+      AGENT_HARNESS_TOOL_AUTHORITY_PLUGIN_SDK_SUBPATH,
       CODEX_MCP_PROJECTION_PLUGIN_SDK_SUBPATH,
       CODEX_SESSION_TRANSCRIPT_PLUGIN_SDK_SUBPATH,
     ],
+  },
+  {
+    bundledPluginId: "copilot",
+    officialInstalledPackageName: "@openclaw/copilot",
+    allowPrivateQaCli: false,
+    subpaths: [AGENT_HARNESS_TOOL_AUTHORITY_PLUGIN_SDK_SUBPATH],
   },
   {
     bundledPluginId: "ollama",

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -1029,6 +1029,7 @@ function isTrustedPrivatePluginSdkOwnerPath(params: {
   packageRoot: string;
   modulePath: string;
   owner: PrivatePluginSdkSubpathOwner;
+  trustedInstalledPrivateSdkOwner?: string;
 }) {
   if (
     isBundledPluginModulePath({
@@ -1039,7 +1040,10 @@ function isTrustedPrivatePluginSdkOwnerPath(params: {
   ) {
     return true;
   }
-  return params.owner.officialInstalledPackageName
+  // Installed package metadata is attacker-controlled. Require the host manifest
+  // registry to authenticate this exact official plugin ID before granting aliases.
+  return params.trustedInstalledPrivateSdkOwner === params.owner.bundledPluginId &&
+    params.owner.officialInstalledPackageName
     ? isOfficialInstalledPluginModulePath({
         modulePath: params.modulePath,
         packageName: params.owner.officialInstalledPackageName,
@@ -1056,6 +1060,7 @@ function findPrivatePluginSdkSubpathOwners(
 function listTrustedPrivatePluginSdkOwnerKeys(params: {
   packageRoot: string;
   modulePath: string;
+  trustedInstalledPrivateSdkOwner?: string;
 }): string[] {
   return PRIVATE_PLUGIN_SDK_SUBPATH_OWNERS.filter((owner) =>
     isTrustedPrivatePluginSdkOwnerPath({ ...params, owner }),
@@ -1081,6 +1086,7 @@ function shouldIncludePrivateLocalOnlyPluginSdkSubpath(params: {
   packageRoot: string;
   modulePath: string;
   subpath: string;
+  trustedInstalledPrivateSdkOwner?: string;
 }) {
   if (PRIVATE_QA_ONLY_PLUGIN_SDK_SUBPATHS.has(params.subpath)) {
     return shouldIncludePrivateLocalOnlyPluginSdkSubpaths();
@@ -1128,6 +1134,7 @@ function listPrivateLocalOnlyPluginSdkSubpaths(params: {
   packageRoot: string;
   ownerPackageRoot: string;
   modulePath: string;
+  trustedInstalledPrivateSdkOwner?: string;
 }): string[] {
   return readPrivateLocalOnlyPluginSdkSubpaths(params.packageRoot).filter(
     (subpath) =>
@@ -1135,6 +1142,7 @@ function listPrivateLocalOnlyPluginSdkSubpaths(params: {
         packageRoot: params.ownerPackageRoot,
         modulePath: params.modulePath,
         subpath,
+        trustedInstalledPrivateSdkOwner: params.trustedInstalledPrivateSdkOwner,
       }) && hasPluginSdkSubpathArtifact(params.packageRoot, subpath),
   );
 }
@@ -1146,6 +1154,7 @@ function listPluginSdkExportedSubpaths(
     moduleUrl?: string;
     devSourceRoot?: string | null;
     pluginSdkResolution?: PluginSdkResolutionPreference;
+    trustedInstalledPrivateSdkOwner?: string;
   } = {},
 ): string[] {
   const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
@@ -1167,6 +1176,7 @@ function listPluginSdkExportedSubpaths(
   const trustedPrivateOwners = listTrustedPrivatePluginSdkOwnerKeys({
     packageRoot: ownerPackageRoot,
     modulePath,
+    trustedInstalledPrivateSdkOwner: params.trustedInstalledPrivateSdkOwner,
   });
   const cacheKey = `${packageRoot}::privateQa=${shouldIncludePrivateLocalOnlyPluginSdkSubpaths() ? "1" : "0"}::privateOwners=${trustedPrivateOwners.join(",")}`;
   const cached = cachedPluginSdkExportedSubpaths.get(cacheKey);
@@ -1176,7 +1186,12 @@ function listPluginSdkExportedSubpaths(
   const subpaths = [
     ...new Set([
       ...(readPluginSdkSubpathsFromPackageRoot(packageRoot) ?? []),
-      ...listPrivateLocalOnlyPluginSdkSubpaths({ packageRoot, ownerPackageRoot, modulePath }),
+      ...listPrivateLocalOnlyPluginSdkSubpaths({
+        packageRoot,
+        ownerPackageRoot,
+        modulePath,
+        trustedInstalledPrivateSdkOwner: params.trustedInstalledPrivateSdkOwner,
+      }),
     ]),
   ].toSorted();
   cachedPluginSdkExportedSubpaths.set(cacheKey, subpaths);
@@ -1190,6 +1205,7 @@ function resolvePluginSdkScopedAliasMap(
     moduleUrl?: string;
     devSourceRoot?: string | null;
     pluginSdkResolution?: PluginSdkResolutionPreference;
+    trustedInstalledPrivateSdkOwner?: string;
   } = {},
 ): Record<string, string> {
   const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
@@ -1216,6 +1232,7 @@ function resolvePluginSdkScopedAliasMap(
   const trustedPrivateOwners = listTrustedPrivatePluginSdkOwnerKeys({
     packageRoot: ownerPackageRoot,
     modulePath,
+    trustedInstalledPrivateSdkOwner: params.trustedInstalledPrivateSdkOwner,
   });
   const cacheKey = `${packageRoot}::${orderedKinds.join(",")}::privateQa=${shouldIncludePrivateLocalOnlyPluginSdkSubpaths() ? "1" : "0"}::privateOwners=${trustedPrivateOwners.join(",")}`;
   const cached = cachedPluginSdkScopedAliasMaps.get(cacheKey);
@@ -1232,6 +1249,7 @@ function resolvePluginSdkScopedAliasMap(
     moduleUrl: params.moduleUrl,
     devSourceRoot: params.devSourceRoot,
     pluginSdkResolution: params.pluginSdkResolution,
+    trustedInstalledPrivateSdkOwner: params.trustedInstalledPrivateSdkOwner,
   })) {
     for (const kind of orderedKinds) {
       if (kind === "dist") {
@@ -1439,6 +1457,7 @@ function buildPluginLoaderAliasMapCacheKey(params: {
   moduleUrl?: string;
   pluginSdkResolution: PluginSdkResolutionPreference;
   devSourceRoot?: string | null;
+  trustedInstalledPrivateSdkOwner?: string;
 }) {
   const devSourceRoot = resolveDevSourceRootParam(params);
   return [
@@ -1450,6 +1469,7 @@ function buildPluginLoaderAliasMapCacheKey(params: {
     devSourceRoot ?? "",
     process.env.NODE_ENV === "production" ? "production" : "non-production",
     shouldIncludePrivateLocalOnlyPluginSdkSubpaths() ? "private-qa" : "public",
+    params.trustedInstalledPrivateSdkOwner ?? "",
   ].join("\0");
 }
 
@@ -1479,6 +1499,7 @@ export function buildPluginLoaderAliasMap(
   moduleUrl?: string,
   pluginSdkResolution: PluginSdkResolutionPreference = "auto",
   devSourceRoot?: string | null,
+  trustedInstalledPrivateSdkOwner?: string,
 ): Record<string, string> {
   const cacheKey = buildPluginLoaderAliasMapCacheKey({
     modulePath,
@@ -1486,6 +1507,7 @@ export function buildPluginLoaderAliasMap(
     moduleUrl,
     pluginSdkResolution,
     devSourceRoot,
+    trustedInstalledPrivateSdkOwner,
   });
   const cached = aliasMapCache.get(cacheKey);
   if (cached) {
@@ -1513,6 +1535,7 @@ export function buildPluginLoaderAliasMap(
       moduleUrl,
       pluginSdkResolution,
       devSourceRoot,
+      trustedInstalledPrivateSdkOwner,
     }),
   );
   // Different plugin entrypoints commonly resolve the same process-stable SDK surface.

--- a/test/plugin-npm-runtime-build.test.ts
+++ b/test/plugin-npm-runtime-build.test.ts
@@ -240,16 +240,19 @@ describe("plugin npm runtime build planning", () => {
     expect(plan.runtimeBuildOutputs).toContain("./dist/setup-api.js");
   });
 
-  it("keeps published Codex runtime imports resolvable from the host package", async () => {
-    const result = await buildPluginNpmRuntime({
-      repoRoot,
-      packageDir: "extensions/codex",
-      logLevel: "silent",
-    });
-    const plan = expectPluginNpmRuntimeBuildPlan(result);
+  it.each(["codex", "copilot"])(
+    "keeps published %s runtime imports resolvable from the host package",
+    async (pluginId) => {
+      const result = await buildPluginNpmRuntime({
+        repoRoot,
+        packageDir: `extensions/${pluginId}`,
+        logLevel: "silent",
+      });
+      const plan = expectPluginNpmRuntimeBuildPlan(result);
 
-    expect(listMissingPluginNpmRuntimeHostExports(plan)).toEqual([]);
-  });
+      expect(listMissingPluginNpmRuntimeHostExports(plan)).toEqual([]);
+    },
+  );
 
   it("detects unresolved side-effect host imports in built plugin runtimes", () => {
     const outDir = tempDirs.make("openclaw-plugin-runtime-host-import-");
@@ -272,6 +275,45 @@ describe("plugin npm runtime build planning", () => {
     expect(listMissingPluginNpmRuntimeHostExports({ ...plan, outDir })).toEqual([
       "openclaw/plugin-sdk/not-exported",
       "openclaw/plugin-sdk/not-exported-from-require",
+    ]);
+  });
+
+  it("allows private harness authority imports only for their official package owners", () => {
+    const outDir = tempDirs.make("openclaw-plugin-runtime-private-owner-import-");
+    writeFileSync(
+      path.join(outDir, "index.js"),
+      [
+        'import "openclaw/plugin-sdk/agent-harness-tool-authority-runtime";',
+        'import "openclaw/plugin-sdk/not-owner-restricted";',
+        "",
+      ].join("\n"),
+    );
+    const plan = expectPluginNpmRuntimeBuildPlan(
+      resolvePluginNpmRuntimeBuildPlan({
+        repoRoot,
+        packageDir: path.join(repoRoot, "extensions", "codex"),
+      }),
+    );
+
+    expect(listMissingPluginNpmRuntimeHostExports({ ...plan, outDir })).toEqual([
+      "openclaw/plugin-sdk/not-owner-restricted",
+    ]);
+    expect(
+      listMissingPluginNpmRuntimeHostExports({
+        ...plan,
+        outDir,
+        packageJson: { ...plan.packageJson, name: "@openclaw/copilot" },
+      }),
+    ).toEqual(["openclaw/plugin-sdk/not-owner-restricted"]);
+    expect(
+      listMissingPluginNpmRuntimeHostExports({
+        ...plan,
+        outDir,
+        packageJson: { ...plan.packageJson, name: "@openclaw/demo" },
+      }),
+    ).toEqual([
+      "openclaw/plugin-sdk/agent-harness-tool-authority-runtime",
+      "openclaw/plugin-sdk/not-owner-restricted",
     ]);
   });
 


### PR DESCRIPTION
Related: #116528, #117034

Stack: 4 of 5. Previous: https://github.com/openclaw/openclaw/pull/116794. Next: https://github.com/openclaw/openclaw/pull/116796

## What Problem This Solves

Tool policy, approvals, diagnostics, and replay correlation could fall back to copied flat fields instead of the exact admitted execution identity, especially through Codex dynamic-tool construction.

## Why This Change Was Made

Binds tools to the original immutable attribution through private host-owned carriers and preserves that carrier across Codex and Copilot tool construction.

## Relationship To Execution Identity Inspection

#117034 owns persisted inspection. This PR adds no public attribution constructor or package-exported contract. The privileged authority runtime is absent from package exports and generated declarations, and the loader aliases it only for the official Codex and Copilot runtimes. Other bundled or installed plugins cannot resolve it.

## User Impact

Tool policy and approval decisions stay correlated to the admitted execution across dynamic tool paths without changing model-facing schemas or plugin APIs. Copilot's no-tool path remains lazy and does not load the full tool graph.

## Evidence

- Exact head: `b00535e91cb`, stacked on repaired PR3 head `ac5dc8d4825`; full stack base is `c245cfc19c7`.
- Focused authority repair proof: 420 tests passed with one existing unrelated skip, covering Codex/Copilot lazy loading, tool construction, SDK aliases, package contracts, and plugin boundaries.
- Packaging-validator repair proof: 104 tests passed with one existing skip across plugin npm runtime builds, SDK aliases, and package contract guardrails; all 252 script declaration contracts match.
- The npm runtime planner recognizes the package-unexported authority alias only for `@openclaw/codex` and `@openclaw/copilot`; an arbitrary package still fails validation, matching the runtime loader's owner restriction.
- Generated Plugin SDK API and package exports contain no attribution authority runtime or `AgentExecutionAttribution` construction surface.
- Exact-checkout changed gate passed on Testbox `tbx_01kzap6xa5a99fhbby7vthcft4`, Actions `31072111830`.
- Exact-checkout full build passed on Testbox `tbx_01kzaq1essq9e8fdfb18ztbws4`, Actions `31072786125`.
- Plugin SDK subpath export and generated-export checks pass; formatting, script declarations, and `git diff --check` are clean.
- Required local autoreview was attempted twice on the final packaging repair; both TruffleHog scans were clean, but the Codex engine was killed with exit `-9` before producing findings.

- Post-rebase attribution, loop-admission, and before-tool-call E2E proof: 109 focused tests passed.
- Fresh exact-delta autoreview was attempted after rebase; TruffleHog passed, but the Codex review engine was killed with exit `-9` before producing a verdict.

## ClawSweeper Resolution

- The private attribution carrier survives harness and Codex dynamic-tool clone chains.
- The privileged builder is not package-exported and is loader-aliased only for official Codex/Copilot owners; arbitrary harness plugins cannot invoke it.
- Codex and Copilot import the authority runtime lazily; Copilot's disabled-tool path does not load the full tool graph.
- The package-build validator now models that exact owner restriction instead of requiring a public package export.
- End-to-end tests cover policy, approvals, diagnostics, clone retention, exact-attempt binding, alias ownership, package-boundary denial, and npm build validation.

AI-assisted: yes; implementation, review decisions, and verification are maintainer-directed.