### PR TITLE
fix(audit): keep execution attribution generation-aware

### DIFF
--- a/packages/gateway-protocol/src/schema/nodes.test.ts
+++ b/packages/gateway-protocol/src/schema/nodes.test.ts
@@ -19,6 +19,11 @@ describe("node protocol schemas", () => {
     expect(Value.Check(NodeInvokeRequestEventSchema, { ...request, sessionKey: null })).toBe(true);
     expect(Value.Check(NodeInvokeRequestEventSchema, { ...request, sessionKey: "" })).toBe(false);
     expect(Value.Check(NodeInvokeRequestEventSchema, { ...request, extra: true })).toBe(false);
+    for (const forbidden of ["attribution", "passportId", "principalId", "instanceId"]) {
+      expect(Value.Check(NodeInvokeRequestEventSchema, { ...request, [forbidden]: "forged" })).toBe(
+        false,
+      );
+    }
   });
 
   it("accepts bounded progress chunks and rejects extra fields", () => {

--- a/scripts/lib/state-schema-inline-plugin.d.mts
+++ b/scripts/lib/state-schema-inline-plugin.d.mts
@@ -1,9 +1,25 @@
 export const STATE_SCHEMA_INLINE_PLUGIN_NAME: string;
 
-export function createStateSchemaInlinePlugin(rootDir?: string): {
+export type StateSchemaInlinePluginOptions = {
+  vitestFsModuleCache?: boolean;
+};
+
+export type VitestCacheKeyGenerator = (context: {
+  id: string;
+  sourceCode: string;
+  environment: unknown;
+}) => string | undefined | null | false;
+
+export function createStateSchemaInlinePlugin(
+  rootDir?: string,
+  options?: StateSchemaInlinePluginOptions,
+): {
   name: string;
   load(
     this: { addWatchFile(id: string): void },
     id: string,
   ): { code: string; moduleType: "js" } | null;
+  configureVitest?: (context: {
+    experimental_defineCacheKeyGenerator(callback: VitestCacheKeyGenerator): void;
+  }) => void;
 };

--- a/scripts/lib/state-schema-inline-plugin.mjs
+++ b/scripts/lib/state-schema-inline-plugin.mjs
@@ -17,12 +17,12 @@ const STATE_SCHEMA_MODULES = [
 ];
 
 /** Inline canonical schema bytes so bundled consumers need no SQL asset. */
-export function createStateSchemaInlinePlugin(rootDir = process.cwd()) {
+export function createStateSchemaInlinePlugin(rootDir = process.cwd(), options = {}) {
   const schemasByModulePath = new Map(
     STATE_SCHEMA_MODULES.map((schema) => [path.resolve(rootDir, schema.modulePath), schema]),
   );
 
-  return {
+  const plugin = {
     name: STATE_SCHEMA_INLINE_PLUGIN_NAME,
     load(id) {
       const schema = schemasByModulePath.get(path.resolve(id));
@@ -37,4 +37,15 @@ export function createStateSchemaInlinePlugin(rootDir = process.cwd()) {
       };
     },
   };
+  if (options.vitestFsModuleCache) {
+    plugin.configureVitest = ({ experimental_defineCacheKeyGenerator }) => {
+      experimental_defineCacheKeyGenerator(({ id }) => {
+        const schema = schemasByModulePath.get(path.resolve(id));
+        return schema
+          ? fs.readFileSync(path.resolve(rootDir, schema.schemaPath), "utf8")
+          : undefined;
+      });
+    };
+  }
+  return plugin;
 }

--- a/src/agents/agent-execution-attribution-architecture.guardrail.test.ts
+++ b/src/agents/agent-execution-attribution-architecture.guardrail.test.ts
@@ -1,0 +1,104 @@
+/** Guardrails keeping execution attribution private to host-owned runtime wiring. */
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, extname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const SOURCE_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".mjs", ".mts", ".ts", ".tsx"]);
+const SKIPPED_DIRECTORIES = new Set([".git", "dist", "node_modules", "vendor"]);
+
+const ALLOWED_PRODUCTION_IMPORTERS = [
+  "src/agents/agent-command-execution-identity.ts",
+  "src/agents/agent-tools.before-tool-call.attribution.ts",
+  "src/agents/agent-tools.ts",
+  "src/agents/btw.ts",
+  "src/agents/cli-runner/types.ts",
+  "src/agents/command/acp-execution.ts",
+  "src/agents/command/attempt-execution.ts",
+  "src/agents/command/run-embedded-attempt.ts",
+  "src/agents/command/types.ts",
+  "src/agents/embedded-agent-runner/run/attempt-execution-attribution.ts",
+  "src/agents/embedded-agent-runner/run/internal-params.ts",
+  "src/agents/embedded-agent-runner/run/lane-controller.ts",
+  "src/agents/harness/side-question-execution-attribution.ts",
+  "src/auto-reply/reply/agent-runner-cli-candidate.ts",
+  "src/auto-reply/reply/agent-runner-execution-identity.ts",
+  "src/auto-reply/reply/agent-runner-execution.types.ts",
+  "src/gateway/server-methods/agent-run-admission-phase.ts",
+  "src/infra/agent-run-registry.ts",
+] as const;
+
+const FORBIDDEN_PUBLIC_ROOTS = [
+  "apps",
+  "extensions",
+  "packages/gateway-protocol",
+  "src/plugin-sdk",
+  "ui",
+] as const;
+
+function listSourceFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    if (SKIPPED_DIRECTORIES.has(entry.name)) {
+      return [];
+    }
+    const path = resolve(root, entry.name);
+    if (entry.isDirectory()) {
+      return listSourceFiles(path);
+    }
+    return SOURCE_EXTENSIONS.has(extname(entry.name)) ? [path] : [];
+  });
+}
+
+function repoPath(path: string): string {
+  return relative(REPO_ROOT, path).replaceAll("\\", "/");
+}
+
+function isProductionSource(path: string): boolean {
+  return !/\.test(?:-support)?\.[cm]?[jt]sx?$|\.spec\.[cm]?[jt]sx?$/.test(path);
+}
+
+describe("agent execution attribution architecture guardrails", () => {
+  it("limits the private primitive to the reviewed host-owned wiring", () => {
+    const actualImporters = listSourceFiles(resolve(REPO_ROOT, "src"))
+      .filter(isProductionSource)
+      .filter((path) => readFileSync(path, "utf8").includes("agent-execution-attribution.js"))
+      .map(repoPath)
+      .toSorted();
+
+    expect(actualImporters).toEqual(ALLOWED_PRODUCTION_IMPORTERS.toSorted());
+  });
+
+  it("keeps the private primitive out of public SDK, protocol, plugin, app, and UI roots", () => {
+    const leaks = FORBIDDEN_PUBLIC_ROOTS.flatMap((root) =>
+      listSourceFiles(resolve(REPO_ROOT, root))
+        .filter((path) => {
+          const text = readFileSync(path, "utf8");
+          return (
+            text.includes("AgentExecutionAttribution") ||
+            text.includes("agent-execution-attribution")
+          );
+        })
+        .map(repoPath),
+    );
+
+    expect(leaks).toEqual([]);
+  });
+
+  it("keeps undecided identity fields out of the node protocol and public tool options", () => {
+    const nodeSchema = readFileSync(
+      resolve(REPO_ROOT, "packages/gateway-protocol/src/schema/nodes.ts"),
+      "utf8",
+    );
+    for (const field of ["attribution", "passportId", "principalId", "instanceId"]) {
+      expect(nodeSchema).not.toMatch(new RegExp(`\\b${field}\\s*:`));
+    }
+
+    const agentTools = readFileSync(resolve(REPO_ROOT, "src/agents/agent-tools.ts"), "utf8");
+    const publicOptions = agentTools.slice(
+      agentTools.indexOf("type OpenClawCodingToolsOptions ="),
+      agentTools.indexOf("type OpenClawCodingToolsInternalOptions ="),
+    );
+    expect(publicOptions).not.toMatch(/\battribution\s*\??:/);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
@@ -266,6 +266,33 @@ describe("prompt-cache byte-identity (issue #3658)", () => {
     );
   });
 
+  it("does not copy host-owned identity metadata into provider payloads", async () => {
+    const message = currentUserMsg("Provider payload identity sentinel", TS_TURN1) as AgentMsg & {
+      attribution?: unknown;
+      passportId?: string;
+      principalId?: string;
+    };
+    message.attribution = {
+      runId: "private-run-sentinel",
+      sessionKey: "private-session-key-sentinel",
+    };
+    message.passportId = "private-passport-sentinel";
+    message.principalId = "private-principal-sentinel";
+
+    const payloads = await Promise.all([
+      captureOpenAICompletionsPayload([message]),
+      captureOpenAIResponsesPayload([message]),
+    ]);
+
+    for (const payload of payloads) {
+      const wireBytes = JSON.stringify(payload);
+      expect(wireBytes).not.toContain("private-run-sentinel");
+      expect(wireBytes).not.toContain("private-session-key-sentinel");
+      expect(wireBytes).not.toContain("private-passport-sentinel");
+      expect(wireBytes).not.toContain("private-principal-sentinel");
+    }
+  });
+
   it("stamp derives from message timestamp, not wall-clock — repeated calls are byte-stable", () => {
     // Same message object (fixed timestamp) → identical serialization regardless
     // of when normalize is called. Guards against any "now"-based drift.

--- a/src/audit/agent-event-audit-attempt-state.ts
+++ b/src/audit/agent-event-audit-attempt-state.ts
@@ -1,0 +1,57 @@
+import type {
+  AgentAuditPendingTerminalWithOwnership,
+  AgentAuditSettledRun,
+} from "./agent-event-audit-terminal.js";
+
+function moveMapValue<T>(map: Map<string, T>, from: string, to: string): void {
+  const value = map.get(from);
+  if (value === undefined || map.has(to)) {
+    return;
+  }
+  map.delete(from);
+  map.set(to, value);
+}
+
+function moveSetValue(set: Set<string>, from: string, to: string): void {
+  if (set.delete(from)) {
+    set.add(to);
+  }
+}
+
+function movePendingTerminal(
+  pendingTerminals: Map<string, AgentAuditPendingTerminalWithOwnership>,
+  from: string,
+  to: string,
+): void {
+  const pending = pendingTerminals.get(from);
+  if (!pending || pendingTerminals.has(to)) {
+    return;
+  }
+  pendingTerminals.delete(from);
+  pending.flushTarget.attemptStateKey = to;
+  pendingTerminals.set(to, pending);
+}
+
+export function adoptAgentAuditAttemptState(params: {
+  from: string;
+  to: string;
+  openAttempts: Set<string>;
+  unownedAttempts: Set<string>;
+  rejectedStarts: Set<string>;
+  pendingTerminals: Map<string, AgentAuditPendingTerminalWithOwnership>;
+  settledAttempts: Map<string, AgentAuditSettledRun>;
+  attemptEpochs: Map<string, number>;
+  attemptStartSequences: Map<string, number>;
+}): boolean {
+  if (params.from === params.to || !params.openAttempts.has(params.from)) {
+    return false;
+  }
+  moveSetValue(params.openAttempts, params.from, params.to);
+  params.unownedAttempts.delete(params.from);
+  moveSetValue(params.rejectedStarts, params.from, params.to);
+  movePendingTerminal(params.pendingTerminals, params.from, params.to);
+  moveMapValue(params.settledAttempts, params.from, params.to);
+  moveMapValue(params.attemptEpochs, params.from, params.to);
+  moveMapValue(params.attemptStartSequences, params.from, params.to);
+  return true;
+}

--- a/src/audit/agent-event-audit-lifecycle-projection.ts
+++ b/src/audit/agent-event-audit-lifecycle-projection.ts
@@ -1,0 +1,168 @@
+import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
+import {
+  buildAgentRunTerminalOutcomeFromLifecycleEvent,
+  classifyAgentRunTerminalOutcome,
+  type AgentRunTerminalOutcome,
+} from "../agents/agent-run-terminal-outcome.js";
+import { getAgentEventContextLifecycleToken } from "../infra/agent-event-execution-context.js";
+import {
+  isAgentEventLifecycleGenerationCurrent,
+  type AgentEventPayload,
+} from "../infra/agent-events.js";
+import { getAgentRunContext } from "../infra/agent-run-registry.js";
+import {
+  buildRunInstance,
+  deriveProvenance,
+  getAuthoritativeRunContextToken,
+  hasAuthoritativeRunContext,
+  nonEmptyString,
+  rememberRunStart,
+  rememberRunTerminal,
+  resolveProvenance,
+  type AgentAuditProjectionState,
+} from "./agent-event-audit-provenance.js";
+import { auditSourceIdentity } from "./agent-event-audit-source.js";
+import type { AgentAuditProjection } from "./agent-event-audit-terminal.js";
+import type { AgentRunFinishedAuditTerminal } from "./audit-event-types.js";
+
+const AUDIT_TERMINAL_BY_CLASSIFICATION = {
+  success: { status: "succeeded" as const },
+  timeout: { status: "timed_out" as const, errorCode: "run_timed_out" as const },
+  cancellation: { status: "cancelled" as const, errorCode: "run_cancelled" as const },
+  failure: { status: "failed" as const, errorCode: "run_failed" as const },
+};
+
+function classifyRunTerminal(
+  data: Record<string, unknown>,
+  phase: "end" | "error",
+): {
+  outcome: AgentRunTerminalOutcome;
+} & AgentRunFinishedAuditTerminal {
+  const outcome = buildAgentRunTerminalOutcomeFromLifecycleEvent({ phase, data });
+  if (outcome.reason === "blocked") {
+    return { outcome, status: "blocked", errorCode: "run_blocked" };
+  }
+  const terminal = AUDIT_TERMINAL_BY_CLASSIFICATION[classifyAgentRunTerminalOutcome(outcome)];
+  return { outcome, ...terminal };
+}
+
+export function projectAgentEvent(
+  state: AgentAuditProjectionState,
+  event: AgentEventPayload,
+): AgentAuditProjection | undefined {
+  const runId = nonEmptyString(event.runId);
+  const phase = nonEmptyString(event.data.phase);
+  if (!runId || !phase) {
+    return undefined;
+  }
+  const runInstance = buildRunInstance(runId, event.lifecycleGeneration);
+  const contextLifecycleToken = getAgentEventContextLifecycleToken(event);
+  const isLifecycleTerminal =
+    event.stream === "lifecycle" && (phase === "end" || phase === "error");
+  const authoritativeToken = getAuthoritativeRunContextToken(
+    runInstance,
+    runId,
+    contextLifecycleToken,
+  );
+  const isTrackedStaleRetry =
+    event.stream === "lifecycle" &&
+    phase === "start" &&
+    authoritativeToken !== undefined &&
+    state.authoritativeOpenProvenance.has(authoritativeToken);
+  const isAuthoritativeLifecycleTerminal =
+    isLifecycleTerminal &&
+    (state.openRunProvenance.has(runInstance) ||
+      hasAuthoritativeRunContext(runInstance, runId, contextLifecycleToken));
+  if (
+    event.lifecycleGeneration &&
+    !isAgentEventLifecycleGenerationCurrent(event.lifecycleGeneration) &&
+    !isAuthoritativeLifecycleTerminal &&
+    !isTrackedStaleRetry
+  ) {
+    // Only the exact still-owned pre-rotation instance may retry or close,
+    // including after bounded provenance tracking evicts its local entry.
+    return undefined;
+  }
+  if (event.stream === "lifecycle" && phase === "start") {
+    // Retry starts may reopen a completed instance. rememberRunStart reuses its
+    // admitted provenance so replayed identity fields cannot replace authority.
+    const provenance = rememberRunStart(
+      state,
+      runInstance,
+      runId,
+      hasAuthoritativeRunContext(runInstance, runId, contextLifecycleToken)
+        ? resolveProvenance(state, runInstance, event, contextLifecycleToken)
+        : deriveProvenance(event),
+      event.lifecycleGeneration !== undefined,
+      contextLifecycleToken,
+    );
+    const occurredAt = asDateTimestampMs(event.data.startedAt) ?? event.ts;
+    const action = "agent.run.started" as const;
+    return {
+      input: {
+        ...auditSourceIdentity({
+          runId,
+          sourceSequence: event.seq,
+          occurredAt,
+          action,
+          lifecycleGeneration: event.lifecycleGeneration,
+        }),
+        sourceSequence: event.seq,
+        occurredAt,
+        kind: "agent_run",
+        action,
+        status: "started",
+        actorType: provenance.actorType,
+        actorId: provenance.agentId,
+        agentId: provenance.agentId,
+        ...(provenance.sessionKey ? { sessionKey: provenance.sessionKey } : {}),
+        ...(provenance.sessionId ? { sessionId: provenance.sessionId } : {}),
+        runId,
+      },
+    };
+  }
+  if (isLifecycleTerminal) {
+    const activeRunInstance = state.activeRunInstanceByRunId.get(runId);
+    const registeredLifecycleGeneration = getAgentRunContext(runId)?.lifecycleGeneration;
+    if (
+      !event.lifecycleGeneration &&
+      !state.openRunProvenance.has(runInstance) &&
+      (registeredLifecycleGeneration !== undefined ||
+        (activeRunInstance && activeRunInstance !== runInstance))
+    ) {
+      // Gateway lifecycle emitters always stamp a generation. A legacy
+      // terminal cannot be safely attached to a generated admission, so reject
+      // it unless a generation-less start established its own run instance.
+      return undefined;
+    }
+    const provenance = resolveProvenance(state, runInstance, event, contextLifecycleToken);
+    rememberRunTerminal(state, runInstance, runId, provenance, contextLifecycleToken);
+    const { outcome, ...terminal } = classifyRunTerminal(event.data, phase);
+    const occurredAt = asDateTimestampMs(event.data.endedAt) ?? event.ts;
+    const action = "agent.run.finished" as const;
+    return {
+      input: {
+        ...auditSourceIdentity({
+          runId,
+          sourceSequence: event.seq,
+          occurredAt,
+          action,
+          lifecycleGeneration: event.lifecycleGeneration,
+        }),
+        sourceSequence: event.seq,
+        occurredAt,
+        kind: "agent_run",
+        action,
+        ...terminal,
+        actorType: provenance.actorType,
+        actorId: provenance.agentId,
+        agentId: provenance.agentId,
+        ...(provenance.sessionKey ? { sessionKey: provenance.sessionKey } : {}),
+        ...(provenance.sessionId ? { sessionId: provenance.sessionId } : {}),
+        runId,
+      },
+      terminal: { outcome, phase },
+    };
+  }
+  return undefined;
+}

--- a/src/audit/agent-event-audit-provenance.ts
+++ b/src/audit/agent-event-audit-provenance.ts
@@ -1,0 +1,389 @@
+import {
+  getAgentRunContext,
+  getAgentRunContextLifecycleToken,
+} from "../infra/agent-run-registry.js";
+import type { TrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+
+type RunProvenance = {
+  actorType: "agent" | "system";
+  agentId: string;
+  sessionKey?: string;
+  sessionId?: string;
+};
+
+export type AgentAuditProjectionState = {
+  runProvenance: Map<string, RunProvenance>;
+  openRunProvenance: Map<string, RunProvenance>;
+  authoritativeOpenProvenance: WeakMap<object, RunProvenance>;
+  activeRunInstanceByRunId: Map<string, string>;
+  seenRunInstances: Set<string>;
+};
+
+export const MAX_TRACKED_RUN_PROVENANCE = 1_024;
+const MAX_TRACKED_ACTIVE_RUN_INSTANCES = MAX_TRACKED_RUN_PROVENANCE * 3;
+
+export function buildRunInstance(runId: string, lifecycleGeneration?: string): string {
+  return `${lifecycleGeneration ?? "unknown"}\0${runId}`;
+}
+
+export function createAgentAuditProjectionState(): AgentAuditProjectionState {
+  return {
+    runProvenance: new Map(),
+    openRunProvenance: new Map(),
+    authoritativeOpenProvenance: new WeakMap(),
+    activeRunInstanceByRunId: new Map(),
+    seenRunInstances: new Set(),
+  };
+}
+
+function trimRunProvenance(state: AgentAuditProjectionState): void {
+  while (state.runProvenance.size > MAX_TRACKED_RUN_PROVENANCE) {
+    const oldestRunInstance = state.runProvenance.keys().next().value;
+    if (oldestRunInstance === undefined) {
+      break;
+    }
+    state.runProvenance.delete(oldestRunInstance);
+    if (!state.openRunProvenance.has(oldestRunInstance)) {
+      state.seenRunInstances.delete(oldestRunInstance);
+    }
+    for (const [trackedRunId, activeRunInstance] of state.activeRunInstanceByRunId) {
+      if (
+        activeRunInstance === oldestRunInstance &&
+        !state.openRunProvenance.has(oldestRunInstance)
+      ) {
+        state.activeRunInstanceByRunId.delete(trackedRunId);
+      }
+    }
+  }
+}
+
+function trimActiveRunInstances(state: AgentAuditProjectionState): void {
+  while (state.activeRunInstanceByRunId.size > MAX_TRACKED_ACTIVE_RUN_INSTANCES) {
+    const oldestRunId = state.activeRunInstanceByRunId.keys().next().value;
+    if (oldestRunId === undefined) {
+      break;
+    }
+    state.activeRunInstanceByRunId.delete(oldestRunId);
+  }
+}
+
+function canActivateRunInstance(
+  state: AgentAuditProjectionState,
+  activeRunInstance: string | undefined,
+  runInstance: string,
+  hasLifecycleGeneration: boolean,
+): boolean {
+  // Generation-less starts cannot displace a live generated admission. Once
+  // that admission closes, they must replace its retained delayed-tool pointer.
+  return (
+    hasLifecycleGeneration ||
+    !activeRunInstance ||
+    activeRunInstance === runInstance ||
+    !state.openRunProvenance.has(activeRunInstance)
+  );
+}
+
+export function rememberRunStart(
+  state: AgentAuditProjectionState,
+  runInstance: string,
+  runId: string,
+  provenance: RunProvenance,
+  hasLifecycleGeneration: boolean,
+  contextLifecycleToken?: object,
+): RunProvenance {
+  const authoritativeToken = getAuthoritativeRunContextToken(
+    runInstance,
+    runId,
+    contextLifecycleToken,
+  );
+  if (authoritativeToken) {
+    const remembered = state.authoritativeOpenProvenance.get(authoritativeToken) ?? provenance;
+    state.authoritativeOpenProvenance.set(authoritativeToken, remembered);
+    state.openRunProvenance.delete(runInstance);
+    state.runProvenance.delete(runInstance);
+    state.seenRunInstances.delete(runInstance);
+    state.activeRunInstanceByRunId.delete(runId);
+    state.activeRunInstanceByRunId.set(runId, runInstance);
+    trimActiveRunInstances(state);
+    return remembered;
+  }
+  if (state.seenRunInstances.has(runInstance)) {
+    const remembered =
+      state.openRunProvenance.get(runInstance) ??
+      state.runProvenance.get(runInstance) ??
+      provenance;
+    state.openRunProvenance.set(runInstance, remembered);
+    const activeRunInstance = state.activeRunInstanceByRunId.get(runId);
+    if (canActivateRunInstance(state, activeRunInstance, runInstance, hasLifecycleGeneration)) {
+      state.activeRunInstanceByRunId.delete(runId);
+      state.activeRunInstanceByRunId.set(runId, runInstance);
+      trimActiveRunInstances(state);
+    }
+    return remembered;
+  }
+  state.runProvenance.delete(runInstance);
+  state.openRunProvenance.set(runInstance, provenance);
+  state.seenRunInstances.add(runInstance);
+  const activeRunInstance = state.activeRunInstanceByRunId.get(runId);
+  if (canActivateRunInstance(state, activeRunInstance, runInstance, hasLifecycleGeneration)) {
+    state.activeRunInstanceByRunId.delete(runId);
+    state.activeRunInstanceByRunId.set(runId, runInstance);
+    trimActiveRunInstances(state);
+  }
+  return provenance;
+}
+
+export function rememberRunTerminal(
+  state: AgentAuditProjectionState,
+  runInstance: string,
+  runId: string,
+  provenance: RunProvenance,
+  contextLifecycleToken?: object,
+): void {
+  const authoritativeToken = getAuthoritativeRunContextToken(
+    runInstance,
+    runId,
+    contextLifecycleToken,
+  );
+  const remembered =
+    authoritativeToken !== undefined
+      ? (state.authoritativeOpenProvenance.get(authoritativeToken) ?? provenance)
+      : (state.openRunProvenance.get(runInstance) ??
+        state.runProvenance.get(runInstance) ??
+        provenance);
+  if (authoritativeToken) {
+    state.authoritativeOpenProvenance.set(authoritativeToken, remembered);
+  }
+  state.runProvenance.delete(runInstance);
+  state.runProvenance.set(runInstance, remembered);
+  const activeRunInstance = state.activeRunInstanceByRunId.get(runId);
+  if (!activeRunInstance || activeRunInstance === runInstance) {
+    // Refresh completed generated runs so their ambiguity guard survives
+    // context retirement until the bounded completed-history entry expires.
+    state.activeRunInstanceByRunId.delete(runId);
+    state.activeRunInstanceByRunId.set(runId, runInstance);
+    trimActiveRunInstances(state);
+  }
+  trimRunProvenance(state);
+}
+
+export function forgetOpenRun(
+  state: AgentAuditProjectionState,
+  runInstance: string,
+  runId: string,
+): void {
+  state.openRunProvenance.delete(runInstance);
+  if (
+    !state.runProvenance.has(runInstance) &&
+    state.activeRunInstanceByRunId.get(runId) === runInstance
+  ) {
+    state.activeRunInstanceByRunId.delete(runId);
+  }
+  if (!state.runProvenance.has(runInstance)) {
+    state.seenRunInstances.delete(runInstance);
+  }
+}
+
+export function forgetAuthoritativeOpenRun(
+  state: AgentAuditProjectionState,
+  runInstance: string,
+  runId: string,
+  contextLifecycleToken?: object,
+): void {
+  const token = getAuthoritativeRunContextToken(runInstance, runId, contextLifecycleToken);
+  if (token) {
+    state.authoritativeOpenProvenance.delete(token);
+  }
+}
+
+export function retainAuthoritativeOpenRunForRetirement(
+  state: AgentAuditProjectionState,
+  runInstance: string,
+  runId: string,
+  contextLifecycleToken?: object,
+): boolean {
+  const token = contextLifecycleToken ?? getAuthoritativeRunContextToken(runInstance, runId);
+  const provenance = token ? state.authoritativeOpenProvenance.get(token) : undefined;
+  if (!token || !provenance) {
+    return false;
+  }
+  // The recorder synchronously enrolls this strong fallback in its bounded
+  // retired-run set; callers must not retain it without applying that cap.
+  state.openRunProvenance.set(runInstance, provenance);
+  state.seenRunInstances.add(runInstance);
+  state.activeRunInstanceByRunId.delete(runId);
+  state.activeRunInstanceByRunId.set(runId, runInstance);
+  trimActiveRunInstances(state);
+  return true;
+}
+
+export function adoptAuthoritativeOpenRunProvenance(
+  state: AgentAuditProjectionState,
+  runInstance: string,
+  contextLifecycleToken: object,
+): void {
+  const provenance = state.openRunProvenance.get(runInstance);
+  if (provenance && !state.authoritativeOpenProvenance.has(contextLifecycleToken)) {
+    state.authoritativeOpenProvenance.set(contextLifecycleToken, provenance);
+  }
+}
+
+export function hasAuthoritativeRunContext(
+  runInstance: string,
+  runId: string,
+  contextLifecycleToken?: object,
+): boolean {
+  return getAuthoritativeRunContextToken(runInstance, runId, contextLifecycleToken) !== undefined;
+}
+
+export function getAuthoritativeRunContextToken(
+  runInstance: string,
+  runId: string,
+  contextLifecycleToken?: object,
+): object | undefined {
+  if (contextLifecycleToken) {
+    return contextLifecycleToken;
+  }
+  const separator = runInstance.indexOf("\0");
+  const lifecycleGeneration = separator >= 0 ? runInstance.slice(0, separator) : "unknown";
+  return lifecycleGeneration === "unknown"
+    ? undefined
+    : getAgentRunContextLifecycleToken(runId, lifecycleGeneration);
+}
+
+export function deriveProvenance(event: {
+  agentId?: unknown;
+  sessionKey?: unknown;
+  sessionId?: unknown;
+}): RunProvenance {
+  const sessionKey = nonEmptyString(event.sessionKey);
+  const sessionId = nonEmptyString(event.sessionId);
+  const eventAgentId = nonEmptyString(event.agentId);
+  const sessionAgentId = sessionKey ? parseAgentSessionKey(sessionKey)?.agentId : undefined;
+  const agentId = eventAgentId ?? sessionAgentId ?? "unknown";
+  const actorType = eventAgentId || sessionAgentId ? "agent" : "system";
+  return { actorType, agentId, sessionKey, sessionId };
+}
+
+export function resolveProvenance(
+  state: AgentAuditProjectionState,
+  runInstance: string,
+  event: { agentId?: unknown; sessionKey?: unknown; sessionId?: unknown },
+  contextLifecycleToken?: object,
+): RunProvenance {
+  const separator = runInstance.indexOf("\0");
+  const lifecycleGeneration = separator >= 0 ? runInstance.slice(0, separator) : "unknown";
+  const runId = separator >= 0 ? runInstance.slice(separator + 1) : runInstance;
+  const context = getAgentRunContext(runId);
+  const authoritativeToken = getAuthoritativeRunContextToken(
+    runInstance,
+    runId,
+    contextLifecycleToken,
+  );
+  const registered =
+    lifecycleGeneration !== "unknown" && context?.lifecycleGeneration === lifecycleGeneration
+      ? deriveProvenance({
+          agentId: context.attribution?.agentId ?? context.agentId,
+          sessionKey: context.attribution?.sessionKey ?? context.sessionKey,
+          sessionId: context.attribution?.sessionId ?? context.sessionId,
+        })
+      : undefined;
+  if (authoritativeToken) {
+    return (
+      state.authoritativeOpenProvenance.get(authoritativeToken) ??
+      registered ??
+      deriveProvenance(event)
+    );
+  }
+  return (
+    state.openRunProvenance.get(runInstance) ??
+    state.runProvenance.get(runInstance) ??
+    registered ??
+    deriveProvenance(event)
+  );
+}
+
+export function resolveToolProvenance(
+  state: AgentAuditProjectionState,
+  runId: string,
+  event: TrustedToolExecutionEvent,
+  lifecycleGeneration?: string,
+  contextLifecycleToken?: object,
+): { provenance: RunProvenance; lifecycleGeneration?: string } {
+  const registeredLifecycleGeneration = getAgentRunContext(runId)?.lifecycleGeneration;
+  const activeRunInstance = state.activeRunInstanceByRunId.get(runId);
+  const activeOpenRunInstance =
+    activeRunInstance && state.openRunProvenance.has(activeRunInstance)
+      ? activeRunInstance
+      : undefined;
+  const runInstance = lifecycleGeneration
+    ? buildRunInstance(runId, lifecycleGeneration)
+    : (activeOpenRunInstance ??
+      (registeredLifecycleGeneration
+        ? buildRunInstance(runId, registeredLifecycleGeneration)
+        : (activeRunInstance ?? buildRunInstance(runId))));
+  const separator = runInstance.indexOf("\0");
+  const resolvedLifecycleGeneration =
+    separator >= 0 && runInstance.slice(0, separator) !== "unknown"
+      ? runInstance.slice(0, separator)
+      : undefined;
+  const observed = resolveProvenance(state, runInstance, event, contextLifecycleToken);
+  const authoritativeToken = getAuthoritativeRunContextToken(
+    runInstance,
+    runId,
+    contextLifecycleToken,
+  );
+  const remembered =
+    authoritativeToken !== undefined
+      ? state.authoritativeOpenProvenance.get(authoritativeToken)
+      : (state.openRunProvenance.get(runInstance) ?? state.runProvenance.get(runInstance));
+  // Lifecycle start owns canonical run identity. Once remembered, tool
+  // diagnostics cannot fill unknown fields or replace the admitted principal.
+  return {
+    provenance: remembered ?? observed,
+    lifecycleGeneration: resolvedLifecycleGeneration,
+  };
+}
+
+export function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function trimUnownedOpenRuns(params: {
+  state: AgentAuditProjectionState;
+  runInstances: Set<string>;
+  pendingTerminals: ReadonlyMap<string, unknown>;
+  rejectedRunInstances: ReadonlyMap<string, unknown>;
+  rejectedTerminals: ReadonlyMap<string, { runInstance: string }>;
+  openRunInstances: Set<string>;
+  rejectedStartRunInstances: Set<string>;
+  attemptStartSequences: Map<string, number>;
+  attemptEpochs: Map<string, number>;
+  clearPending: (runInstance: string) => void;
+  forgetRejectedAttempt: (attemptKey: string) => void;
+}): void {
+  while (params.runInstances.size > MAX_TRACKED_RUN_PROVENANCE) {
+    const runInstance =
+      [...params.runInstances].find(
+        (candidate) =>
+          !params.pendingTerminals.has(candidate) && !params.rejectedRunInstances.has(candidate),
+      ) ?? params.runInstances.values().next().value;
+    if (runInstance === undefined) {
+      return;
+    }
+    const runId = runInstance.slice(runInstance.indexOf("\0") + 1);
+    params.clearPending(runInstance);
+    for (const [attemptKey, rejected] of params.rejectedTerminals) {
+      if (rejected.runInstance === runInstance) {
+        params.forgetRejectedAttempt(attemptKey);
+      }
+    }
+    params.runInstances.delete(runInstance);
+    forgetOpenRun(params.state, runInstance, runId);
+    params.openRunInstances.delete(runInstance);
+    params.rejectedStartRunInstances.delete(runInstance);
+    params.attemptStartSequences.delete(runInstance);
+    params.attemptEpochs.delete(runInstance);
+  }
+}

--- a/src/audit/agent-event-audit-source.ts
+++ b/src/audit/agent-event-audit-source.ts
@@ -1,0 +1,22 @@
+function legacyAuditSourceId(params: {
+  runId: string;
+  sourceSequence: number;
+  occurredAt: number;
+  action: string;
+}): string {
+  // Preserve the original store-owned identity byte-for-byte so replayed
+  // run/tool events still deduplicate after the versioned contract refactor.
+  return `${params.runId}:${params.sourceSequence}:${params.occurredAt}:${params.action}`;
+}
+
+export function auditSourceIdentity(
+  params: Parameters<typeof legacyAuditSourceId>[0] & { lifecycleGeneration?: string },
+): { sourceId: string; legacySourceId?: string } {
+  const legacySourceId = legacyAuditSourceId(params);
+  return params.lifecycleGeneration
+    ? {
+        sourceId: `lifecycle:${params.lifecycleGeneration}:${legacySourceId}`,
+        legacySourceId,
+      }
+    : { sourceId: legacySourceId };
+}

--- a/src/audit/agent-event-audit-terminal.ts
+++ b/src/audit/agent-event-audit-terminal.ts
@@ -1,0 +1,155 @@
+import {
+  mergeAgentRunTerminalOutcome,
+  type AgentRunTerminalOutcome,
+} from "../agents/agent-run-terminal-outcome.js";
+import type { AuditEventInput } from "./audit-event-types.js";
+
+export type AgentAuditProjection = {
+  input: AuditEventInput;
+  terminal?: { outcome: AgentRunTerminalOutcome; phase: "end" | "error" };
+};
+
+export type AgentAuditTerminalCandidate = {
+  attemptKey: string;
+  input: AuditEventInput;
+  observedThroughSequence: number;
+  outcome: AgentRunTerminalOutcome;
+  phase: "end" | "error";
+};
+
+type AgentAuditPendingTerminal = AgentAuditTerminalCandidate & {
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export type AgentAuditPendingTerminalWithOwnership = AgentAuditPendingTerminal & {
+  flushTarget: { attemptStateKey: string };
+  runInstance: string;
+  contextLifecycleToken?: object;
+};
+
+export type AgentAuditSettledRun = {
+  terminalSequence: number;
+  reopenedStartSequence?: number;
+};
+
+export type AgentAuditOpenAttempt = {
+  attemptEpoch: number;
+  open: boolean;
+  startSequence: number;
+  startAccepted: boolean;
+};
+
+export function createAgentAuditPendingTerminal(params: {
+  attemptStateKey: string;
+  candidate: AgentAuditTerminalCandidate;
+  contextLifecycleToken?: object;
+  flush: (attemptStateKey: string) => void;
+  runInstance: string;
+  settleMs: number;
+}): AgentAuditPendingTerminalWithOwnership {
+  const flushTarget = { attemptStateKey: params.attemptStateKey };
+  const timer = setTimeout(() => params.flush(flushTarget.attemptStateKey), params.settleMs);
+  timer.unref?.();
+  return {
+    ...params.candidate,
+    flushTarget,
+    timer,
+    runInstance: params.runInstance,
+    ...(params.contextLifecycleToken
+      ? { contextLifecycleToken: params.contextLifecycleToken }
+      : {}),
+  };
+}
+
+export function createAgentAuditSettledAttemptRecorder(
+  settledAttempts: Map<string, AgentAuditSettledRun>,
+  maxTracked: number,
+) {
+  return (attemptStateKey: string, observedThroughSequence: number): void => {
+    settledAttempts.delete(attemptStateKey);
+    settledAttempts.set(attemptStateKey, { terminalSequence: observedThroughSequence });
+    while (settledAttempts.size > maxTracked) {
+      const oldest = settledAttempts.keys().next().value;
+      if (oldest === undefined) {
+        return;
+      }
+      settledAttempts.delete(oldest);
+    }
+  };
+}
+
+export function agentAuditAttemptKey(runInstance: string, attemptEpoch: number): string {
+  return `${runInstance}\0${attemptEpoch}`;
+}
+
+export function createAgentAuditAttemptStateKeyResolver() {
+  const keyByContext = new WeakMap<object, string>();
+  let nextId = 0;
+  return (runInstance: string, contextLifecycleToken?: object): string => {
+    if (!contextLifecycleToken) {
+      return runInstance;
+    }
+    const existing = keyByContext.get(contextLifecycleToken);
+    if (existing) {
+      return existing;
+    }
+    const created = `${runInstance}\0context:${++nextId}`;
+    keyByContext.set(contextLifecycleToken, created);
+    return created;
+  };
+}
+
+export function agentAuditRunInstanceFromAttemptStateKey(attemptStateKey: string): string {
+  const contextSeparator = attemptStateKey.lastIndexOf("\0context:");
+  return contextSeparator >= 0 ? attemptStateKey.slice(0, contextSeparator) : attemptStateKey;
+}
+
+export function matchingRetiredAgentAuditAttemptStates(
+  retiredAttemptStates: ReadonlySet<string>,
+  runInstance: string,
+  currentAttemptState: string,
+): string[] {
+  return [...retiredAttemptStates].filter(
+    (attemptState) =>
+      attemptState !== currentAttemptState &&
+      agentAuditRunInstanceFromAttemptStateKey(attemptState) === runInstance,
+  );
+}
+
+export function settledAgentAuditAttemptFloor(
+  settled: AgentAuditSettledRun | undefined,
+): number | undefined {
+  return settled?.reopenedStartSequence === undefined
+    ? undefined
+    : Math.max(settled.terminalSequence, settled.reopenedStartSequence);
+}
+
+export function selectAgentAuditTerminalCandidate(
+  existing: AgentAuditTerminalCandidate,
+  incoming: AgentAuditTerminalCandidate,
+): AgentAuditTerminalCandidate {
+  // A bare cleanup end can follow a definitive error without a retry start.
+  // Otherwise use the shared sticky timeout/cancellation merge contract.
+  const cleanupAfterError =
+    existing.phase === "error" &&
+    incoming.phase === "end" &&
+    incoming.outcome.reason === "completed";
+  if (cleanupAfterError) {
+    return {
+      ...existing,
+      observedThroughSequence: Math.max(
+        existing.observedThroughSequence,
+        incoming.observedThroughSequence,
+      ),
+    };
+  }
+  const merged = mergeAgentRunTerminalOutcome(existing.outcome, incoming.outcome);
+  const selected = merged === existing.outcome ? existing : incoming;
+  return {
+    ...selected,
+    observedThroughSequence: Math.max(
+      existing.observedThroughSequence,
+      incoming.observedThroughSequence,
+    ),
+  };
+}

--- a/src/audit/agent-event-audit-tool-identity.ts
+++ b/src/audit/agent-event-audit-tool-identity.ts
@@ -1,0 +1,23 @@
+import { createHash } from "node:crypto";
+import { isAllowedToolCallName } from "../agents/tool-call-shared.js";
+import { nonEmptyString } from "./agent-event-audit-provenance.js";
+
+export function auditToolName(value: unknown): string | undefined {
+  const toolName = nonEmptyString(value)?.trim();
+  if (!toolName) {
+    return undefined;
+  }
+  // Tool lifecycle producers include provider-controlled streams. Preserve
+  // only the compact model-facing name contract at the durable boundary.
+  return isAllowedToolCallName(toolName, null) ? toolName : "unknown";
+}
+
+export function auditToolCallId(value: unknown): string | undefined {
+  const toolCallId = nonEmptyString(value);
+  if (!toolCallId) {
+    return undefined;
+  }
+  // Call ids remain useful for correlation, but their provider-owned bytes
+  // are not operator metadata and must never enter the ledger verbatim.
+  return `sha256:${createHash("sha256").update(toolCallId).digest("hex")}`;
+}

--- a/src/audit/agent-event-audit-tool-projection.ts
+++ b/src/audit/agent-event-audit-tool-projection.ts
@@ -1,0 +1,121 @@
+import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import type { TrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
+import {
+  getTrustedToolExecutionContextLifecycleToken,
+  getTrustedToolExecutionLifecycleGeneration,
+} from "../infra/trusted-tool-execution-context.js";
+import {
+  nonEmptyString,
+  resolveToolProvenance,
+  type AgentAuditProjectionState,
+} from "./agent-event-audit-provenance.js";
+import { auditSourceIdentity } from "./agent-event-audit-source.js";
+import { auditToolCallId, auditToolName } from "./agent-event-audit-tool-identity.js";
+import type { ToolActionAuditEventInput } from "./audit-event-types.js";
+
+/** Project the complete trusted tool-execution lifecycle without private diagnostic content. */
+export function projectToolExecutionEventToAudit(
+  state: AgentAuditProjectionState,
+  event: TrustedToolExecutionEvent,
+): ToolActionAuditEventInput | undefined {
+  // Schema quarantine describes tool availability before invocation. Without
+  // a call identity it must not become a durable tool-action claim.
+  if (
+    event.type === "tool.execution.blocked" &&
+    event.deniedReason === "unsupported_tool_schema" &&
+    !nonEmptyString(event.toolCallId)
+  ) {
+    return undefined;
+  }
+  const runId = nonEmptyString(event.runId);
+  const toolName = auditToolName(event.toolName);
+  if (!runId || !toolName) {
+    return undefined;
+  }
+  const toolCallId = auditToolCallId(event.toolCallId);
+  const capturedLifecycleGeneration = getTrustedToolExecutionLifecycleGeneration(event);
+  const contextLifecycleToken = getTrustedToolExecutionContextLifecycleToken(event);
+  const { provenance, lifecycleGeneration } = resolveToolProvenance(
+    state,
+    runId,
+    event,
+    capturedLifecycleGeneration,
+    contextLifecycleToken,
+  );
+  const occurredAt = asDateTimestampMs(event.sourceTimestampMs) ?? event.ts;
+  const attribution = {
+    sourceSequence: event.seq,
+    occurredAt,
+    kind: "tool_action" as const,
+    actorType: provenance.actorType,
+    actorId: provenance.agentId,
+    agentId: provenance.agentId,
+    ...(provenance.sessionKey ? { sessionKey: provenance.sessionKey } : {}),
+    ...(provenance.sessionId ? { sessionId: provenance.sessionId } : {}),
+    runId,
+    ...(toolCallId ? { toolCallId } : {}),
+    toolName,
+  };
+  if (event.type === "tool.execution.started") {
+    const action = "tool.action.started" as const;
+    return {
+      ...auditSourceIdentity({
+        runId,
+        sourceSequence: event.seq,
+        occurredAt,
+        action,
+        lifecycleGeneration,
+      }),
+      ...attribution,
+      action,
+      status: "started",
+    };
+  }
+  const errorCategory =
+    event.type === "tool.execution.error"
+      ? normalizeOptionalLowercaseString(event.errorCategory)
+      : undefined;
+  const terminalReason = event.type === "tool.execution.error" ? event.terminalReason : undefined;
+  const diagnosticErrorCode =
+    event.type === "tool.execution.error"
+      ? normalizeOptionalLowercaseString(event.errorCode)
+      : undefined;
+  // Modern producers set terminalReason explicitly; errorCategory is only a
+  // legacy fallback and must not override a definitive timeout or failure.
+  const toolCancelled =
+    terminalReason === "cancelled" ||
+    (terminalReason === undefined &&
+      (errorCategory === "aborted" ||
+        errorCategory === "aborterror" ||
+        errorCategory === "cancelled" ||
+        errorCategory === "canceled"));
+  const toolTimedOut = terminalReason === "timed_out";
+  // Unknown is an explicit dependency boundary, not a failed-run inference.
+  // Keep it authoritative when enclosing run provenance says cancel or timeout.
+  const terminal =
+    event.type === "tool.execution.completed"
+      ? { status: "succeeded" as const }
+      : event.type === "tool.execution.blocked"
+        ? { status: "blocked" as const, errorCode: "tool_blocked" as const }
+        : diagnosticErrorCode === "tool_outcome_unknown"
+          ? { status: "unknown" as const, errorCode: "tool_outcome_unknown" as const }
+          : toolCancelled
+            ? { status: "cancelled" as const, errorCode: "tool_cancelled" as const }
+            : toolTimedOut
+              ? { status: "timed_out" as const, errorCode: "tool_timed_out" as const }
+              : { status: "failed" as const, errorCode: "tool_failed" as const };
+  const action = "tool.action.finished" as const;
+  return {
+    ...auditSourceIdentity({
+      runId,
+      sourceSequence: event.seq,
+      occurredAt,
+      action,
+      lifecycleGeneration,
+    }),
+    ...attribution,
+    action,
+    ...terminal,
+  };
+}

--- a/src/audit/agent-event-audit-types.ts
+++ b/src/audit/agent-event-audit-types.ts
@@ -1,0 +1,8 @@
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import type { TrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
+
+export type AgentEventAuditRecorder = {
+  record: (event: AgentEventPayload) => void;
+  recordTool: (event: TrustedToolExecutionEvent) => void;
+  stop: () => Promise<void>;
+};

--- a/src/audit/agent-event-audit.generation-order.test.ts
+++ b/src/audit/agent-event-audit.generation-order.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getAgentEventLifecycleGeneration,
+  resetAgentEventsForTest,
+  type AgentEventPayload,
+} from "../infra/agent-events.js";
+import { registerAgentRunContext } from "../infra/agent-run-registry.js";
+import type { TrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
+import { createAgentEventAuditRecorder } from "./agent-event-audit.js";
+import type { AuditEventInput } from "./audit-event-types.js";
+import type { AuditEventWriter } from "./audit-event-writer.js";
+
+function agentEvent(overrides: Partial<AgentEventPayload>): AgentEventPayload {
+  return {
+    runId: "run-duplicate-start-order",
+    seq: 1,
+    stream: "lifecycle",
+    ts: Date.now(),
+    data: { phase: "start" },
+    sessionKey: "agent:coder:main",
+    sessionId: "session-1",
+    agentId: "coder",
+    ...overrides,
+  };
+}
+
+function captureAuditWriter(inputs: AuditEventInput[]): AuditEventWriter {
+  return {
+    ready: Promise.resolve(),
+    record: (input) => {
+      inputs.push(input);
+      return true;
+    },
+    recordExecutionIdentity: () => true,
+    stop: async () => {},
+  };
+}
+
+function toolEvent(overrides: Partial<TrustedToolExecutionEvent>): TrustedToolExecutionEvent {
+  return {
+    type: "tool.execution.started",
+    seq: 1,
+    ts: Date.now(),
+    runId: "run-duplicate-start-order",
+    sessionKey: "agent:coder:main",
+    sessionId: "session-1",
+    toolName: "exec",
+    toolCallId: "call-1",
+    ...overrides,
+  } as TrustedToolExecutionEvent;
+}
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+});
+
+describe("agent audit lifecycle generation ordering", () => {
+  it("promotes a generation-less start after the generated run closes", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-generated-then-generationless";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:generated:main",
+      sessionId: "session-generated",
+      agentId: "generated",
+    });
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        sessionKey: "agent:generated:main",
+        sessionId: "session-generated",
+        agentId: "generated",
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        data: { phase: "end" },
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: undefined,
+        seq: 3,
+        sessionKey: "agent:legacy:main",
+        sessionId: "session-legacy",
+        agentId: "legacy",
+      }),
+    );
+    recorder.recordTool(toolEvent({ runId, seq: 4 }));
+    await recorder.stop();
+
+    expect(inputs.filter((input) => input.kind === "tool_action")).toEqual([
+      expect.objectContaining({
+        actorId: "legacy",
+        agentId: "legacy",
+        sessionKey: "agent:legacy:main",
+        sessionId: "session-legacy",
+      }),
+    ]);
+  });
+
+  it("does not reorder open instances for a duplicate start", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const generatedStart = agentEvent({
+      lifecycleGeneration,
+      sessionKey: "agent:generated:main",
+      agentId: "generated",
+    });
+
+    recorder.record(generatedStart);
+    recorder.record(
+      agentEvent({
+        lifecycleGeneration: undefined,
+        seq: 2,
+        sessionKey: "agent:legacy:main",
+        agentId: "legacy",
+      }),
+    );
+    recorder.record(generatedStart);
+    recorder.record(
+      agentEvent({
+        lifecycleGeneration: undefined,
+        seq: 3,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.at(-1)).toMatchObject({
+      action: "agent.run.finished",
+      actorId: "legacy",
+      agentId: "legacy",
+    });
+  });
+});

--- a/src/audit/agent-event-audit.generations.test.ts
+++ b/src/audit/agent-event-audit.generations.test.ts
@@ -1,0 +1,998 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  getAgentEventLifecycleGeneration,
+  resetAgentEventsForTest,
+  rotateAgentEventLifecycleGeneration,
+  type AgentEventPayload,
+  withAgentRunLifecycleGeneration,
+} from "../infra/agent-events.js";
+import { claimAgentRunContext, registerAgentRunContext } from "../infra/agent-run-registry.js";
+import {
+  emitTrustedDiagnosticEvent,
+  onTrustedToolExecutionEvent,
+  resetDiagnosticEventsForTest,
+  type TrustedToolExecutionEvent,
+} from "../infra/diagnostic-events.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { createAgentEventAuditRecorder } from "./agent-event-audit.js";
+import { listAuditEvents } from "./audit-event-store.js";
+import type { AuditEventInput } from "./audit-event-types.js";
+import type { AuditEventWriter } from "./audit-event-writer.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let testRunSequence = 0;
+let currentRunId = "generation-run-0";
+
+function createDatabaseOptions() {
+  return { env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-audit-generation-") } };
+}
+
+function agentEvent(overrides: Partial<AgentEventPayload>): AgentEventPayload {
+  return {
+    runId: currentRunId,
+    seq: 1,
+    stream: "lifecycle",
+    ts: Date.now(),
+    data: { phase: "start" },
+    sessionKey: "agent:coder:main",
+    sessionId: "session-1",
+    agentId: "coder",
+    ...overrides,
+  };
+}
+
+function toolEvent(overrides: Partial<TrustedToolExecutionEvent> = {}): TrustedToolExecutionEvent {
+  return {
+    type: "tool.execution.started",
+    seq: 1,
+    ts: Date.now(),
+    runId: currentRunId,
+    sessionKey: "agent:coder:main",
+    sessionId: "session-1",
+    toolName: "exec",
+    toolCallId: "call-1",
+    ...overrides,
+  } as TrustedToolExecutionEvent;
+}
+
+function captureAuditWriter(inputs: AuditEventInput[]): AuditEventWriter {
+  return {
+    ready: Promise.resolve(),
+    record: (input) => {
+      inputs.push(input);
+      return true;
+    },
+    recordExecutionIdentity: () => true,
+    stop: async () => {},
+  };
+}
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+  currentRunId = `generation-run-${++testRunSequence}`;
+});
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  resetDiagnosticEventsForTest();
+});
+
+describe("agent audit lifecycle generations", () => {
+  it("seeds authoritative starts from registry provenance before event fallback", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-authoritative-start-provenance";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:registered:main",
+      sessionId: "session-registered",
+      agentId: "registered",
+    });
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        sessionKey: "agent:forged:main",
+        sessionId: "session-forged",
+        agentId: "forged",
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.find((input) => input.action === "agent.run.started")).toMatchObject({
+      actorId: "registered",
+      agentId: "registered",
+      sessionKey: "agent:registered:main",
+      sessionId: "session-registered",
+    });
+  });
+
+  it("keeps reused run ids isolated by lifecycle generation", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-reused-across-generations";
+    const occurredAt = 1_786_000_000_000;
+    const firstGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: firstGeneration,
+        sessionKey: "agent:first:main",
+        sessionId: "session-first",
+        agentId: "first",
+      }),
+    );
+    recorder.recordTool(
+      toolEvent({ runId, seq: 2, ts: occurredAt, sourceTimestampMs: occurredAt }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: firstGeneration,
+        seq: 3,
+        data: { phase: "end" },
+      }),
+    );
+    const secondGeneration = rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: secondGeneration,
+        seq: 1,
+        sessionKey: "agent:second:main",
+        sessionId: "session-second",
+        agentId: "second",
+      }),
+    );
+    recorder.recordTool(
+      toolEvent({ runId, seq: 2, ts: occurredAt, sourceTimestampMs: occurredAt }),
+    );
+    await recorder.stop();
+
+    const toolInputs = inputs.filter((input) => input.kind === "tool_action");
+    expect(
+      toolInputs.map((input) => ({
+        actorId: input.actorId,
+        sessionKey: input.sessionKey,
+        sessionId: input.sessionId,
+      })),
+    ).toEqual([
+      {
+        actorId: "first",
+        sessionKey: "agent:first:main",
+        sessionId: "session-first",
+      },
+      {
+        actorId: "second",
+        sessionKey: "agent:second:main",
+        sessionId: "session-second",
+      },
+    ]);
+    expect(toolInputs.map((input) => input.sourceId)).toEqual([
+      `lifecycle:${firstGeneration}:${runId}:2:${occurredAt}:tool.action.started`,
+      `lifecycle:${secondGeneration}:${runId}:2:${occurredAt}:tool.action.started`,
+    ]);
+  });
+
+  it("persists colliding tool tuples with registry-resolved generations", async () => {
+    const database = createDatabaseOptions();
+    const recorder = createAgentEventAuditRecorder({
+      stateDir: database.env.OPENCLAW_STATE_DIR,
+      terminalSettleMs: 0,
+    });
+    const runId = "run-reused-tool-registry";
+    const occurredAt = 1_786_000_000_000;
+    const firstGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration: firstGeneration,
+      sessionKey: "agent:first:main",
+      agentId: "first",
+    });
+
+    recorder.recordTool(
+      toolEvent({ runId, seq: 2, ts: occurredAt, sourceTimestampMs: occurredAt }),
+    );
+    const secondGeneration = rotateAgentEventLifecycleGeneration();
+    claimAgentRunContext(runId, {
+      lifecycleGeneration: secondGeneration,
+      sessionKey: "agent:second:main",
+      agentId: "second",
+    });
+    recorder.recordTool(
+      toolEvent({ runId, seq: 2, ts: occurredAt, sourceTimestampMs: occurredAt }),
+    );
+    await recorder.stop();
+
+    const persisted = listAuditEvents({ database, limit: 10 }).events.filter(
+      (event) => event.runId === runId && event.action === "tool.action.started",
+    );
+    expect(persisted.map((event) => event.actorId)).toEqual(["second", "first"]);
+    const { db } = openOpenClawStateDatabase(database);
+    const sourceIds = db
+      .prepare(
+        "SELECT source_id FROM audit_events WHERE run_id = ? AND action = ? ORDER BY sequence",
+      )
+      .all(runId, "tool.action.started")
+      .map((row) => (row as { source_id: string }).source_id);
+    expect(new Set(sourceIds)).toEqual(
+      new Set([
+        `lifecycle:${firstGeneration}:${runId}:2:${occurredAt}:tool.action.started`,
+        `lifecycle:${secondGeneration}:${runId}:2:${occurredAt}:tool.action.started`,
+      ]),
+    );
+  });
+
+  it("persists colliding run tuples from distinct lifecycle generations", async () => {
+    const database = createDatabaseOptions();
+    const recorder = createAgentEventAuditRecorder({
+      stateDir: database.env.OPENCLAW_STATE_DIR,
+      terminalSettleMs: 0,
+    });
+    const runId = "run-reused-persisted";
+    const occurredAt = 1_786_000_000_000;
+    const firstGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        seq: 1,
+        ts: occurredAt,
+        data: { phase: "start", startedAt: occurredAt },
+        lifecycleGeneration: firstGeneration,
+        sessionKey: "agent:first:main",
+        sessionId: "session-first",
+        agentId: "first",
+      }),
+    );
+    const secondGeneration = rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        seq: 1,
+        ts: occurredAt,
+        data: { phase: "start", startedAt: occurredAt },
+        lifecycleGeneration: secondGeneration,
+        sessionKey: "agent:second:main",
+        sessionId: "session-second",
+        agentId: "second",
+      }),
+    );
+    await recorder.stop();
+
+    const persisted = listAuditEvents({ database, limit: 10 }).events.filter(
+      (event) => event.runId === runId && event.action === "agent.run.started",
+    );
+    expect(persisted.map((event) => event.actorId)).toEqual(["second", "first"]);
+    const { db } = openOpenClawStateDatabase(database);
+    const sourceIds = db
+      .prepare(
+        "SELECT source_id FROM audit_events WHERE run_id = ? AND action = ? ORDER BY sequence",
+      )
+      .all(runId, "agent.run.started")
+      .map((row) => (row as { source_id: string }).source_id);
+    expect(new Set(sourceIds)).toEqual(
+      new Set([
+        `lifecycle:${firstGeneration}:${runId}:1:${occurredAt}:agent.run.started`,
+        `lifecycle:${secondGeneration}:${runId}:1:${occurredAt}:agent.run.started`,
+      ]),
+    );
+  });
+
+  it("does not let a late old-generation terminal reactivate provenance", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-late-old-terminal";
+    const oldGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration: oldGeneration,
+      sessionKey: "agent:old:main",
+      agentId: "old",
+    });
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        sessionKey: "agent:old:main",
+        agentId: "old",
+      }),
+    );
+    const newGeneration = rotateAgentEventLifecycleGeneration();
+    claimAgentRunContext(runId, {
+      lifecycleGeneration: newGeneration,
+      sessionKey: "agent:new:main",
+      agentId: "new",
+    });
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: newGeneration,
+        seq: 1,
+        sessionKey: "agent:new:main",
+        agentId: "new",
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        seq: 2,
+        data: { phase: "error" },
+      }),
+    );
+    recorder.recordTool(toolEvent({ runId, seq: 2 }));
+    await recorder.stop();
+
+    expect(
+      inputs.find(
+        (input) =>
+          input.action === "agent.run.finished" &&
+          input.sourceSequence === 2 &&
+          input.actorId === "old",
+      ),
+    ).toBeDefined();
+    expect(inputs.findLast((input) => input.kind === "tool_action")).toMatchObject({
+      actorId: "new",
+      agentId: "new",
+      sessionKey: "agent:new:main",
+    });
+  });
+
+  it("keeps delayed tool diagnostics on their originating lifecycle generation", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-delayed-tool-generation";
+    const oldGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        sessionKey: "agent:old:main",
+        sessionId: "session-old",
+        agentId: "old",
+      }),
+    );
+    const newGeneration = rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: newGeneration,
+        sessionKey: "agent:new:main",
+        sessionId: "session-new",
+        agentId: "new",
+      }),
+    );
+    const stop = onTrustedToolExecutionEvent((event) => recorder.recordTool(event));
+    withAgentRunLifecycleGeneration(oldGeneration, () => {
+      emitTrustedDiagnosticEvent({
+        type: "tool.execution.started",
+        runId,
+        sessionKey: "agent:old:main",
+        sessionId: "session-old",
+        agentId: "old",
+        toolName: "exec",
+        toolCallId: "call-delayed-old",
+      });
+    });
+    stop();
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.kind === "tool_action")).toMatchObject({
+      actorId: "old",
+      agentId: "old",
+      sessionKey: "agent:old:main",
+      sessionId: "session-old",
+    });
+  });
+
+  it("retains terminal provenance for delayed tools under cache pressure", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-terminal-retention";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        sessionKey: "agent:retained:main",
+        sessionId: "session-retained",
+        agentId: "retained",
+      }),
+    );
+    for (let index = 0; index < 1_023; index += 1) {
+      recorder.record(
+        agentEvent({
+          runId: `retention-pressure-${index}`,
+          lifecycleGeneration,
+        }),
+      );
+    }
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        data: { phase: "error" },
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId: "retention-pressure-tail-1",
+        lifecycleGeneration,
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId: "retention-pressure-tail-2",
+        lifecycleGeneration,
+      }),
+    );
+    const stop = onTrustedToolExecutionEvent((event) => recorder.recordTool(event));
+    withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+      emitTrustedDiagnosticEvent({
+        type: "tool.execution.started",
+        runId,
+        toolName: "exec",
+        toolCallId: "call-delayed-retained",
+      });
+    });
+    stop();
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.kind === "tool_action")).toMatchObject({
+      actorId: "retained",
+      agentId: "retained",
+      sessionKey: "agent:retained:main",
+      sessionId: "session-retained",
+    });
+  });
+
+  it("derives evicted live provenance from the authoritative run registry", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const retainedRunId = "active-run-0";
+
+    for (let index = 0; index < 1_025; index += 1) {
+      const runId = `active-run-${index}`;
+      registerAgentRunContext(runId, {
+        lifecycleGeneration,
+        sessionKey: `agent:active-${index}:main`,
+        sessionId: `session-active-${index}`,
+        agentId: `active-${index}`,
+      });
+      recorder.record(
+        agentEvent({
+          runId,
+          lifecycleGeneration,
+          sessionKey: `agent:active-${index}:main`,
+          sessionId: `session-active-${index}`,
+          agentId: `active-${index}`,
+        }),
+      );
+    }
+
+    recorder.recordTool(
+      toolEvent({
+        runId: retainedRunId,
+        seq: 2,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        toolCallId: "call-active-evicted",
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.kind === "tool_action")).toMatchObject({
+      runId: retainedRunId,
+      actorId: "active-0",
+      agentId: "active-0",
+      sessionKey: "agent:active-0:main",
+      sessionId: "session-active-0",
+    });
+  });
+
+  it("keeps an admitted pre-rotation terminal after provenance cache pressure", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-open-through-cache-pressure";
+    const oldGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration: oldGeneration,
+      sessionKey: "agent:retained:main",
+      sessionId: "session-retained",
+      agentId: "retained",
+    });
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        sessionKey: "agent:retained:main",
+        sessionId: "session-retained",
+        agentId: "retained",
+      }),
+    );
+    for (let index = 0; index < 1_025; index += 1) {
+      recorder.record(
+        agentEvent({
+          runId: `terminal-pressure-${index}`,
+          lifecycleGeneration: oldGeneration,
+          sessionKey: `agent:pressure-${index}:main`,
+          sessionId: `session-pressure-${index}`,
+          agentId: `pressure-${index}`,
+        }),
+      );
+    }
+    rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        seq: 2,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(
+      inputs.find(
+        (input) =>
+          input.kind === "agent_run" &&
+          input.action === "agent.run.finished" &&
+          input.runId === runId &&
+          input.sourceSequence === 2,
+      ),
+    ).toMatchObject({
+      actorId: "retained",
+      agentId: "retained",
+      sessionKey: "agent:retained:main",
+      sessionId: "session-retained",
+    });
+  });
+
+  it("does not let a duplicate old-generation start reactivate provenance", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-duplicate-old-start";
+    const oldGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        sessionKey: "agent:old:main",
+        agentId: "old",
+      }),
+    );
+    const newGeneration = rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: newGeneration,
+        seq: 1,
+        sessionKey: "agent:new:main",
+        agentId: "new",
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        seq: 2,
+        sessionKey: "agent:old:main",
+        agentId: "old",
+      }),
+    );
+    recorder.recordTool(toolEvent({ runId, seq: 2 }));
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.kind === "tool_action")).toMatchObject({
+      actorId: "new",
+      agentId: "new",
+      sessionKey: "agent:new:main",
+    });
+  });
+
+  it("lets an authoritative pre-rotation retry cancel its provisional terminal", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-authoritative-old-retry";
+    const oldGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration: oldGeneration,
+      sessionKey: "agent:old:main",
+      agentId: "old",
+    });
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration: oldGeneration }));
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        seq: 2,
+        data: { phase: "error" },
+      }),
+    );
+    rotateAgentEventLifecycleGeneration();
+    recorder.record(agentEvent({ runId, lifecycleGeneration: oldGeneration, seq: 3 }));
+    await recorder.stop();
+
+    expect(inputs.filter((input) => input.action === "agent.run.started")).toHaveLength(1);
+    expect(inputs.filter((input) => input.action === "agent.run.finished")).toEqual([]);
+  });
+
+  it("rejects an evicted old-generation start after newer admission", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-evicted-old-start";
+    const oldGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        sessionKey: "agent:old:main",
+        agentId: "old",
+      }),
+    );
+    const newGeneration = rotateAgentEventLifecycleGeneration();
+    for (let index = 0; index < 1_025; index += 1) {
+      recorder.record(
+        agentEvent({
+          runId: `pressure-${index}`,
+          lifecycleGeneration: newGeneration,
+          data: { phase: "end" },
+        }),
+      );
+    }
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: newGeneration,
+        sessionKey: "agent:new:main",
+        agentId: "new",
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        seq: 2,
+        sessionKey: "agent:old:main",
+        agentId: "old",
+      }),
+    );
+    recorder.recordTool(
+      toolEvent({
+        runId,
+        seq: 2,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.kind === "tool_action")).toMatchObject({
+      actorId: "new",
+      agentId: "new",
+      sessionKey: "agent:new:main",
+    });
+  });
+
+  it("lets a lifecycle start replace provisional terminal provenance", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-terminal-before-start";
+    const oldGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: oldGeneration,
+        sessionKey: "agent:old:main",
+        agentId: "old",
+      }),
+    );
+    const lifecycleGeneration = rotateAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 1,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "error" },
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        sessionKey: "agent:admitted:main",
+        sessionId: "session-admitted",
+        agentId: "admitted",
+      }),
+    );
+    recorder.recordTool(toolEvent({ runId, seq: 3 }));
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.kind === "tool_action")).toMatchObject({
+      actorId: "admitted",
+      agentId: "admitted",
+      sessionKey: "agent:admitted:main",
+      sessionId: "session-admitted",
+    });
+  });
+
+  it("does not let a generation-less start replace current admission", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-generationless-start";
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: getAgentEventLifecycleGeneration(),
+        sessionKey: "agent:current:main",
+        agentId: "current",
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: undefined,
+        seq: 2,
+        sessionKey: "agent:legacy:main",
+        agentId: "legacy",
+      }),
+    );
+    recorder.recordTool(
+      toolEvent({
+        runId,
+        seq: 3,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.kind === "tool_action")).toMatchObject({
+      actorId: "current",
+      agentId: "current",
+      sessionKey: "agent:current:main",
+    });
+  });
+
+  it("rejects a generation-less terminal for a generated admission", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-generationless-terminal";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const admitted = {
+      runId,
+      lifecycleGeneration,
+      sessionKey: "agent:admitted:main",
+      sessionId: "session-admitted",
+      agentId: "admitted",
+    };
+
+    recorder.record(agentEvent({ ...admitted, seq: 1 }));
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: undefined,
+        seq: 2,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    recorder.record(agentEvent({ ...admitted, seq: 3 }));
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: undefined,
+        seq: 4,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(
+      inputs
+        .filter((input) => input.kind === "agent_run")
+        .map(({ action, status, actorId, sessionKey, sessionId }) => ({
+          action,
+          status,
+          actorId,
+          sessionKey,
+          sessionId,
+        })),
+    ).toEqual([
+      {
+        action: "agent.run.started",
+        status: "started",
+        actorId: "admitted",
+        sessionKey: "agent:admitted:main",
+        sessionId: "session-admitted",
+      },
+    ]);
+  });
+
+  it("keeps a generation-less start and terminal isolated from generated provenance", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-generated-then-legacy";
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: getAgentEventLifecycleGeneration(),
+        sessionKey: "agent:generated:main",
+        sessionId: "session-generated",
+        agentId: "generated",
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: undefined,
+        seq: 2,
+        sessionKey: "agent:legacy:main",
+        sessionId: "session-legacy",
+        agentId: "legacy",
+      }),
+    );
+    const latestTerminal = agentEvent({
+      runId,
+      lifecycleGeneration: undefined,
+      seq: 3,
+      sessionKey: undefined,
+      sessionId: undefined,
+      agentId: undefined,
+      data: { phase: "end" },
+    });
+    recorder.record(latestTerminal);
+    recorder.record(latestTerminal);
+    await recorder.stop();
+
+    expect(inputs.at(-1)).toMatchObject({
+      action: "agent.run.finished",
+      actorId: "legacy",
+      agentId: "legacy",
+      sessionKey: "agent:legacy:main",
+      sessionId: "session-legacy",
+    });
+  });
+
+  it("uses explicit generations in persistent terminal identity", async () => {
+    const database = createDatabaseOptions();
+    const recorder = createAgentEventAuditRecorder({
+      stateDir: database.env.OPENCLAW_STATE_DIR,
+      terminalSettleMs: 0,
+    });
+    const runId = "run-reused-generationless-terminal";
+    const occurredAt = 1_786_000_000_000;
+    const firstGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: firstGeneration,
+        seq: 1,
+        ts: occurredAt - 1,
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: firstGeneration,
+        seq: 2,
+        ts: occurredAt,
+        data: { phase: "end", endedAt: occurredAt },
+      }),
+    );
+    const secondGeneration = rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: secondGeneration,
+        seq: 1,
+        ts: occurredAt - 1,
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: secondGeneration,
+        seq: 3,
+        ts: occurredAt + 1,
+        data: { phase: "end", endedAt: occurredAt + 1 },
+      }),
+    );
+    await recorder.stop();
+
+    const terminals = listAuditEvents({ database, limit: 10 }).events.filter(
+      (event) => event.runId === runId && event.action === "agent.run.finished",
+    );
+    expect(terminals).toHaveLength(2);
+    const { db } = openOpenClawStateDatabase(database);
+    const sourceIds = db
+      .prepare(
+        "SELECT source_id FROM audit_events WHERE run_id = ? AND action = ? ORDER BY sequence",
+      )
+      .all(runId, "agent.run.finished")
+      .map((row) => (row as { source_id: string }).source_id);
+    expect(new Set(sourceIds)).toEqual(
+      new Set([
+        `lifecycle:${firstGeneration}:${runId}:2:${occurredAt}:agent.run.finished`,
+        `lifecycle:${secondGeneration}:${runId}:3:${occurredAt + 1}:agent.run.finished`,
+      ]),
+    );
+  });
+});

--- a/src/audit/agent-event-audit.legacy-source.test.ts
+++ b/src/audit/agent-event-audit.legacy-source.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  getAgentEventLifecycleGeneration,
+  resetAgentEventsForTest,
+  rotateAgentEventLifecycleGeneration,
+  type AgentEventPayload,
+} from "../infra/agent-events.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { createAgentEventAuditRecorder } from "./agent-event-audit.js";
+import { recordAuditEvent } from "./audit-event-store.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createDatabaseOptions() {
+  return { env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-audit-legacy-source-") } };
+}
+
+function agentEvent(overrides: Partial<AgentEventPayload>): AgentEventPayload {
+  return {
+    runId: "legacy-source-run",
+    seq: 1,
+    stream: "lifecycle",
+    ts: Date.now(),
+    data: { phase: "start" },
+    sessionKey: "agent:coder:main",
+    sessionId: "session-1",
+    agentId: "coder",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+});
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("agent audit legacy source ids", () => {
+  it("keeps a shipped legacy row immutable while separating later generations", async () => {
+    const database = createDatabaseOptions();
+    const runId = "run-shipped-legacy-replay";
+    const occurredAt = 1_786_000_000_000;
+    const legacySourceId = `${runId}:1:${occurredAt}:agent.run.started`;
+    recordAuditEvent(
+      {
+        sourceId: legacySourceId,
+        sourceSequence: 1,
+        occurredAt,
+        kind: "agent_run",
+        action: "agent.run.started",
+        status: "started",
+        actorType: "agent",
+        actorId: "legacy",
+        agentId: "legacy",
+        sessionKey: "agent:legacy:main",
+        sessionId: "session-legacy",
+        runId,
+      },
+      database,
+    );
+    const recorder = createAgentEventAuditRecorder({
+      stateDir: database.env.OPENCLAW_STATE_DIR,
+      terminalSettleMs: 0,
+    });
+    const firstGeneration = getAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        ts: occurredAt,
+        data: { phase: "start", startedAt: occurredAt },
+        lifecycleGeneration: firstGeneration,
+        agentId: "first",
+        sessionKey: "agent:first:main",
+        sessionId: "session-first",
+      }),
+    );
+    const secondGeneration = rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        ts: occurredAt,
+        data: { phase: "start", startedAt: occurredAt },
+        lifecycleGeneration: secondGeneration,
+        agentId: "second",
+        sessionKey: "agent:second:main",
+        sessionId: "session-second",
+      }),
+    );
+    await recorder.stop();
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(
+      db.prepare("SELECT * FROM audit_events WHERE run_id = ? ORDER BY sequence").all(runId),
+    ).toMatchObject([
+      {
+        source_id: legacySourceId,
+        actor_id: "legacy",
+        agent_id: "legacy",
+        session_key: "agent:legacy:main",
+        session_id: "session-legacy",
+        status: "started",
+      },
+      {
+        source_id: `lifecycle:${firstGeneration}:${legacySourceId}`,
+        actor_id: "first",
+        agent_id: "first",
+        session_key: "agent:first:main",
+        session_id: "session-first",
+        status: "started",
+      },
+      {
+        source_id: `lifecycle:${secondGeneration}:${legacySourceId}`,
+        actor_id: "second",
+        agent_id: "second",
+        session_key: "agent:second:main",
+        session_id: "session-second",
+        status: "started",
+      },
+    ]);
+  });
+
+  it("deduplicates a generation-qualified replay against equivalent shipped provenance", () => {
+    const database = createDatabaseOptions();
+    const runId = "run-equivalent-shipped-replay";
+    const occurredAt = 1_786_000_000_000;
+    const legacySourceId = `${runId}:1:${occurredAt}:agent.run.started`;
+    const provenance = {
+      sourceSequence: 1,
+      occurredAt,
+      kind: "agent_run" as const,
+      action: "agent.run.started" as const,
+      status: "started" as const,
+      actorType: "agent" as const,
+      actorId: "coder",
+      agentId: "coder",
+      sessionKey: "agent:coder:main",
+      sessionId: "session-coder",
+      runId,
+    };
+    recordAuditEvent({ ...provenance, sourceId: legacySourceId }, database);
+    recordAuditEvent(
+      {
+        ...provenance,
+        sourceId: `lifecycle:generation-current:${legacySourceId}`,
+        legacySourceId,
+      },
+      database,
+    );
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(
+      db
+        .prepare("SELECT source_id FROM audit_events WHERE run_id = ? ORDER BY sequence")
+        .all(runId)
+        .map((row) => (row as { source_id: string }).source_id),
+    ).toEqual([legacySourceId]);
+  });
+});

--- a/src/audit/agent-event-audit.rejected-start.test.ts
+++ b/src/audit/agent-event-audit.rejected-start.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getAgentEventLifecycleGeneration,
+  resetAgentEventsForTest,
+  type AgentEventPayload,
+} from "../infra/agent-events.js";
+import { claimAgentRunContext } from "../infra/agent-run-registry.js";
+import { createAgentEventAuditRecorder } from "./agent-event-audit.js";
+import type { AuditEventInput } from "./audit-event-types.js";
+import type { AuditEventWriter } from "./audit-event-writer.js";
+
+let runSequence = 0;
+
+function agentEvent(overrides: Partial<AgentEventPayload>): AgentEventPayload {
+  return {
+    runId: `rejected-start-${runSequence}`,
+    seq: 1,
+    stream: "lifecycle",
+    ts: Date.now(),
+    data: { phase: "start" },
+    sessionKey: "agent:coder:main",
+    sessionId: "session-1",
+    agentId: "coder",
+    ...overrides,
+  };
+}
+
+function createRejectingStartWriter(
+  recordAttempts: AuditEventInput[],
+  onStop: (inputs: readonly AuditEventInput[]) => void,
+): AuditEventWriter {
+  return {
+    ready: Promise.resolve(),
+    record: (input) => {
+      recordAttempts.push(input);
+      return input.action !== "agent.run.started";
+    },
+    recordExecutionIdentity: () => true,
+    stop: async (inputs = []) => onStop(inputs),
+  };
+}
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+  runSequence += 1;
+});
+
+describe("agent event audit rejected starts", () => {
+  it("does not persist a terminal when the attempt start was rejected", async () => {
+    const recordAttempts: AuditEventInput[] = [];
+    let finalInputs: readonly AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: createRejectingStartWriter(recordAttempts, (inputs) => {
+        finalInputs = inputs;
+      }),
+      terminalSettleMs: 0,
+    });
+
+    recorder.record(agentEvent({ seq: 1 }));
+    recorder.record(agentEvent({ seq: 2, data: { phase: "end" } }));
+    await recorder.stop();
+
+    expect(recordAttempts.map((input) => input.action)).toEqual(["agent.run.started"]);
+    expect(finalInputs).toEqual([]);
+  });
+
+  it("preserves rejected-start state when an open attempt gains an owner", async () => {
+    const recordAttempts: AuditEventInput[] = [];
+    let finalInputs: readonly AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: createRejectingStartWriter(recordAttempts, (inputs) => {
+        finalInputs = inputs;
+      }),
+      terminalSettleMs: 0,
+    });
+    const runId = `rejected-start-promoted-${runSequence}`;
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    claimAgentRunContext(runId, { lifecycleGeneration });
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 2 }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3, data: { phase: "end" } }));
+    await recorder.stop();
+
+    expect(recordAttempts.map((input) => input.action)).toEqual(["agent.run.started"]);
+    expect(finalInputs).toEqual([]);
+  });
+});

--- a/src/audit/agent-event-audit.same-generation-token.test.ts
+++ b/src/audit/agent-event-audit.same-generation-token.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+import {
+  emitAgentAuditEvent,
+  getAgentEventLifecycleGeneration,
+  onAgentAuditEvent,
+  resetAgentEventsForTest,
+  type AgentEventPayload,
+  withAgentRunLifecycleGeneration,
+} from "../infra/agent-events.js";
+import {
+  claimAgentRunContext,
+  clearAgentRunContext,
+  getAgentRunContext,
+  registerAgentRunContext,
+} from "../infra/agent-run-registry.js";
+import {
+  emitTrustedDiagnosticEvent,
+  onTrustedToolExecutionEvent,
+  resetDiagnosticEventsForTest,
+} from "../infra/diagnostic-events.js";
+import { createAgentEventAuditRecorder } from "./agent-event-audit.js";
+import type { AuditEventInput } from "./audit-event-types.js";
+import type { AuditEventWriter } from "./audit-event-writer.js";
+
+function captureAuditWriter(inputs: AuditEventInput[]): AuditEventWriter {
+  return {
+    ready: Promise.resolve(),
+    record: (input) => {
+      inputs.push(input);
+      return true;
+    },
+    recordExecutionIdentity: () => true,
+    stop: async () => {},
+  };
+}
+
+function agentEvent(overrides: Partial<AgentEventPayload>): AgentEventPayload {
+  return {
+    runId: "run-same-generation",
+    seq: 1,
+    stream: "lifecycle",
+    ts: Date.now(),
+    data: { phase: "start" },
+    sessionKey: "agent:coder:main",
+    sessionId: "session-1",
+    agentId: "coder",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+});
+
+afterEach(() => {
+  resetDiagnosticEventsForTest();
+});
+
+it("uses a newly claimed same-generation context after the prior token retires", async () => {
+  const inputs: AuditEventInput[] = [];
+  const recorder = createAgentEventAuditRecorder({
+    writer: captureAuditWriter(inputs),
+    terminalSettleMs: 0,
+  });
+  const runId = "run-same-generation-rebound";
+  const lifecycleGeneration = getAgentEventLifecycleGeneration();
+  claimAgentRunContext(runId, {
+    lifecycleGeneration,
+    sessionKey: "agent:first:main",
+    sessionId: "session-first",
+    agentId: "first",
+  });
+  recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+
+  clearAgentRunContext(runId, lifecycleGeneration);
+  claimAgentRunContext(runId, {
+    lifecycleGeneration,
+    sessionKey: "agent:second:main",
+    sessionId: "session-second",
+    agentId: "second",
+  });
+  recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 2 }));
+  recorder.recordTool({
+    type: "tool.execution.started",
+    runId,
+    seq: 3,
+    ts: Date.now(),
+    toolName: "exec",
+    toolCallId: "call-second",
+  });
+  await recorder.stop();
+
+  expect(
+    inputs
+      .filter((input) => input.action === "agent.run.started")
+      .map(({ actorId, sessionKey, sessionId }) => ({ actorId, sessionKey, sessionId })),
+  ).toEqual([
+    { actorId: "first", sessionKey: "agent:first:main", sessionId: "session-first" },
+    { actorId: "second", sessionKey: "agent:second:main", sessionId: "session-second" },
+  ]);
+  expect(inputs.findLast((input) => input.kind === "tool_action")).toMatchObject({
+    actorId: "second",
+    agentId: "second",
+    sessionKey: "agent:second:main",
+    sessionId: "session-second",
+  });
+});
+
+it("settles a retired pending terminal before a same-generation rebound", async () => {
+  const inputs: AuditEventInput[] = [];
+  const recorder = createAgentEventAuditRecorder({
+    writer: captureAuditWriter(inputs),
+    terminalSettleMs: 60_000,
+  });
+  const runId = "run-same-generation-pending-rebound";
+  const lifecycleGeneration = getAgentEventLifecycleGeneration();
+  claimAgentRunContext(runId, {
+    lifecycleGeneration,
+    sessionKey: "agent:first:main",
+    agentId: "first",
+  });
+  recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+  recorder.record(
+    agentEvent({
+      runId,
+      lifecycleGeneration,
+      seq: 2,
+      data: { phase: "error" },
+    }),
+  );
+
+  clearAgentRunContext(runId, lifecycleGeneration);
+  claimAgentRunContext(runId, {
+    lifecycleGeneration,
+    sessionKey: "agent:second:main",
+    agentId: "second",
+  });
+  recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3 }));
+  await recorder.stop();
+
+  expect(inputs.map(({ action, actorId, status }) => ({ action, actorId, status }))).toEqual([
+    { action: "agent.run.started", actorId: "first", status: "started" },
+    { action: "agent.run.finished", actorId: "first", status: "failed" },
+    { action: "agent.run.started", actorId: "second", status: "started" },
+  ]);
+});
+
+it("cancels a pending unowned terminal after the attempt gains an owner", async () => {
+  const inputs: AuditEventInput[] = [];
+  const recorder = createAgentEventAuditRecorder({
+    writer: captureAuditWriter(inputs),
+    terminalSettleMs: 60_000,
+  });
+  const runId = "run-unowned-pending-adoption";
+  const lifecycleGeneration = getAgentEventLifecycleGeneration();
+  recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+  recorder.record(
+    agentEvent({
+      runId,
+      lifecycleGeneration,
+      seq: 2,
+      data: { phase: "error" },
+    }),
+  );
+
+  claimAgentRunContext(runId, {
+    lifecycleGeneration,
+    sessionKey: "agent:owned:main",
+    agentId: "owned",
+  });
+  recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3 }));
+  await recorder.stop();
+
+  expect(inputs.map(({ action, status }) => ({ action, status }))).toEqual([
+    { action: "agent.run.started", status: "started" },
+  ]);
+});
+
+it("keeps delayed same-generation events on the retired execution token", async () => {
+  const inputs: AuditEventInput[] = [];
+  const recorder = createAgentEventAuditRecorder({
+    writer: captureAuditWriter(inputs),
+    terminalSettleMs: 0,
+  });
+  const stopAudit = onAgentAuditEvent((event) => recorder.record(event));
+  const stopTool = onTrustedToolExecutionEvent((event) => recorder.recordTool(event));
+  const runId = "run-same-generation-delayed-retired";
+  const lifecycleGeneration = getAgentEventLifecycleGeneration();
+  let releaseOldExecution!: () => void;
+  const oldExecutionGate = new Promise<void>((resolve) => {
+    releaseOldExecution = resolve;
+  });
+
+  const oldExecution = withAgentRunLifecycleGeneration(lifecycleGeneration, async () => {
+    claimAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:first:main",
+      sessionId: "session-first",
+      agentId: "first",
+    });
+    emitAgentAuditEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    await oldExecutionGate;
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      verboseLevel: "full",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.started",
+      runId,
+      toolName: "exec",
+      toolCallId: "call-first-delayed",
+    });
+    emitAgentAuditEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 3_000 },
+    });
+  });
+
+  clearAgentRunContext(runId, lifecycleGeneration);
+  withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+    claimAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:second:main",
+      sessionId: "session-second",
+      agentId: "second",
+    });
+    emitAgentAuditEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 2_000 },
+    });
+  });
+
+  releaseOldExecution();
+  await oldExecution;
+
+  withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.started",
+      runId,
+      toolName: "exec",
+      toolCallId: "call-second",
+    });
+    emitAgentAuditEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 4_000 },
+    });
+  });
+  stopAudit();
+  stopTool();
+  await recorder.stop();
+
+  expect(
+    inputs.filter((input) => input.action === "agent.run.started").map((input) => input.actorId),
+  ).toEqual(["first", "second"]);
+  expect(
+    inputs.filter((input) => input.action === "agent.run.finished").map((input) => input.actorId),
+  ).toEqual(["first", "second"]);
+  expect(
+    inputs.filter((input) => input.kind === "tool_action").map((input) => input.actorId),
+  ).toEqual(["first", "second"]);
+});
+
+it("does not let a retired synthetic terminal release the rebound owner", async () => {
+  const runId = "run-same-generation-synthetic-rebound";
+  const lifecycleGeneration = getAgentEventLifecycleGeneration();
+  let finishFirst!: () => void;
+  let emitDuplicateTerminal!: () => void;
+  let signalFirstFinished!: () => void;
+  const finishFirstGate = new Promise<void>((resolve) => {
+    finishFirst = resolve;
+  });
+  const duplicateTerminalGate = new Promise<void>((resolve) => {
+    emitDuplicateTerminal = resolve;
+  });
+  const firstFinished = new Promise<void>((resolve) => {
+    signalFirstFinished = resolve;
+  });
+
+  const oldExecution = withAgentRunLifecycleGeneration(lifecycleGeneration, async () => {
+    emitAgentAuditEvent({
+      runId,
+      sessionKey: "agent:first:main",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    await finishFirstGate;
+    emitAgentAuditEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 2_000 },
+    });
+    signalFirstFinished();
+    await duplicateTerminalGate;
+    emitAgentAuditEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 3_000 },
+    });
+  });
+
+  finishFirst();
+  await firstFinished;
+  expect(getAgentRunContext(runId)).toBeUndefined();
+
+  withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+    emitAgentAuditEvent({
+      runId,
+      sessionKey: "agent:second:main",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 2_500 },
+    });
+  });
+  emitDuplicateTerminal();
+  await oldExecution;
+
+  expect(getAgentRunContext(runId)?.sessionKey).toBe("agent:second:main");
+  emitAgentAuditEvent({
+    runId,
+    stream: "lifecycle",
+    data: { phase: "end", endedAt: 4_000 },
+  });
+  expect(getAgentRunContext(runId)).toBeUndefined();
+});

--- a/src/audit/agent-event-audit.terminal-replay.test.ts
+++ b/src/audit/agent-event-audit.terminal-replay.test.ts
@@ -1,0 +1,733 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getAgentEventLifecycleGeneration,
+  resetAgentEventsForTest,
+  rotateAgentEventLifecycleGeneration,
+  type AgentEventPayload,
+} from "../infra/agent-events.js";
+import { retireAgentRunContext } from "../infra/agent-run-context-retirement.js";
+import {
+  claimAgentRunContext,
+  clearAgentRunContext,
+  registerAgentRunContext,
+} from "../infra/agent-run-registry.js";
+import { createAgentEventAuditRecorder } from "./agent-event-audit.js";
+import type { AuditEventInput } from "./audit-event-types.js";
+import type { AuditEventWriter } from "./audit-event-writer.js";
+
+function agentEvent(overrides: Partial<AgentEventPayload>): AgentEventPayload {
+  return {
+    runId: "run-terminal-replay",
+    seq: 1,
+    stream: "lifecycle",
+    ts: Date.now(),
+    data: { phase: "start" },
+    sessionKey: "agent:coder:main",
+    sessionId: "session-1",
+    agentId: "coder",
+    ...overrides,
+  };
+}
+
+function captureAuditWriter(inputs: AuditEventInput[]): AuditEventWriter {
+  return {
+    ready: Promise.resolve(),
+    record: (input) => {
+      inputs.push(input);
+      return true;
+    },
+    recordExecutionIdentity: () => true,
+    stop: async () => {},
+  };
+}
+
+beforeEach(() => {
+  resetAgentEventsForTest();
+});
+
+describe("agent audit terminal replay", () => {
+  it("does not reopen a settled instance for an exact lifecycle replay", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-exact-lifecycle-replay";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const start = agentEvent({ runId, lifecycleGeneration, seq: 1 });
+    const terminal = agentEvent({
+      runId,
+      lifecycleGeneration,
+      seq: 2,
+      data: { phase: "end" },
+    });
+
+    recorder.record(start);
+    recorder.record(terminal);
+    recorder.record(start);
+    recorder.record(terminal);
+    await recorder.stop();
+
+    expect(inputs.map((input) => input.action)).toEqual([
+      "agent.run.started",
+      "agent.run.finished",
+    ]);
+  });
+
+  it("rejects a higher-sequence terminal when no start reopened the settled instance", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-higher-terminal-after-settlement";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 2, data: { phase: "end" } }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3, data: { phase: "error" } }));
+    await recorder.stop();
+
+    expect(
+      inputs
+        .filter((input) => input.action === "agent.run.finished")
+        .map((input) => input.sourceSequence),
+    ).toEqual([2]);
+  });
+
+  it("does not let a delayed settled terminal close a newer attempt", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-delayed-terminal-replay";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 2, data: { phase: "end" } }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3 }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 2, data: { phase: "end" } }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 4, data: { phase: "end" } }));
+    await recorder.stop();
+
+    expect(
+      inputs
+        .filter((input) => input.action === "agent.run.finished")
+        .map((input) => input.sourceSequence),
+    ).toEqual([2, 4]);
+  });
+
+  it("does not let a stale start cancel a newer provisional terminal", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-stale-start-after-terminal";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3, data: { phase: "error" } }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    await recorder.stop();
+
+    expect(
+      inputs
+        .filter((input) => input.runId === runId && input.action === "agent.run.finished")
+        .map((input) => input.sourceSequence),
+    ).toEqual([3]);
+  });
+
+  it("does not infer reopened-attempt closure from bounded open tracking", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-reopened-before-cache-pressure";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 2, data: { phase: "end" } }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3 }));
+    for (let index = 0; index < 1_025; index += 1) {
+      recorder.record(
+        agentEvent({
+          runId: `run-cache-pressure-${index}`,
+          lifecycleGeneration,
+          seq: 1,
+        }),
+      );
+    }
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 4, data: { phase: "end" } }));
+    await recorder.stop();
+
+    expect(
+      inputs
+        .filter((input) => input.runId === runId && input.action === "agent.run.finished")
+        .map((input) => input.sourceSequence),
+    ).toEqual([2, 4]);
+  });
+
+  it("keeps an authoritative open attempt single-started after cache pressure", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-authoritative-open-cache-pressure";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:retained:main",
+      agentId: "retained",
+    });
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    for (let index = 0; index < 1_025; index += 1) {
+      const pressureRunId = `run-authoritative-open-pressure-${index}`;
+      registerAgentRunContext(pressureRunId, {
+        lifecycleGeneration,
+        sessionKey: `agent:pressure-${index}:main`,
+        agentId: `pressure-${index}`,
+      });
+      recorder.record(
+        agentEvent({
+          runId: pressureRunId,
+          lifecycleGeneration,
+          seq: 1,
+        }),
+      );
+    }
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        data: { phase: "error" },
+      }),
+    );
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3 }));
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        data: { phase: "error" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(
+      inputs.filter((input) => input.runId === runId && input.action === "agent.run.started"),
+    ).toHaveLength(1);
+    expect(inputs.filter((input) => input.action === "agent.run.started")).toHaveLength(1_026);
+    expect(
+      inputs.filter((input) => input.runId === runId && input.action === "agent.run.finished"),
+    ).toEqual([]);
+  });
+
+  it("retains unowned provenance and pending retry state at the open-run bound", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-unowned-open-cache-pressure";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 1,
+        sessionKey: "agent:retained:main",
+        agentId: "retained",
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        data: { phase: "error" },
+      }),
+    );
+    for (let index = 0; index < 1_025; index += 1) {
+      recorder.record(
+        agentEvent({
+          runId: `run-unowned-open-pressure-${index}`,
+          lifecycleGeneration,
+          seq: 1,
+          sessionKey: `agent:pressure-${index}:main`,
+          agentId: `pressure-${index}`,
+        }),
+      );
+    }
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 3,
+        sessionKey: "agent:replayed:main",
+        agentId: "replayed",
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 4,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(
+      inputs.filter((input) => input.runId === runId && input.action === "agent.run.started"),
+    ).toHaveLength(1);
+    expect(
+      inputs.find((input) => input.runId === runId && input.action === "agent.run.finished"),
+    ).toMatchObject({
+      actorId: "retained",
+      agentId: "retained",
+      sessionKey: "agent:retained:main",
+    });
+  });
+
+  it("starts a new attempt after a terminal write is rejected under cache pressure", async () => {
+    const inputs: AuditEventInput[] = [];
+    const runId = "run-rejected-terminal-cache-pressure";
+    const recorder = createAgentEventAuditRecorder({
+      writer: {
+        ...captureAuditWriter(inputs),
+        record: (input) => {
+          inputs.push(input);
+          return !(input.runId === runId && input.action === "agent.run.finished");
+        },
+      },
+      terminalSettleMs: 0,
+    });
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:retained:main",
+      agentId: "retained",
+    });
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    for (let index = 0; index < 1_025; index += 1) {
+      const pressureRunId = `run-rejected-terminal-pressure-${index}`;
+      registerAgentRunContext(pressureRunId, {
+        lifecycleGeneration,
+        sessionKey: `agent:pressure-${index}:main`,
+        agentId: `pressure-${index}`,
+      });
+      recorder.record(
+        agentEvent({
+          runId: pressureRunId,
+          lifecycleGeneration,
+          seq: 1,
+        }),
+      );
+    }
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        data: { phase: "end" },
+      }),
+    );
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3 }));
+    await recorder.stop();
+
+    expect(
+      inputs.filter((input) => input.runId === runId && input.action === "agent.run.started"),
+    ).toHaveLength(2);
+  });
+
+  it("records a start and cancels its provisional terminal when unowned capacity is full", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    for (let index = 0; index < 1_024; index += 1) {
+      recorder.record(
+        agentEvent({
+          runId: `run-unowned-capacity-${index}`,
+          lifecycleGeneration,
+          seq: 1,
+        }),
+      );
+    }
+    const runId = "run-terminal-before-capped-start";
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 1,
+        data: { phase: "error" },
+      }),
+    );
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 2 }));
+    await recorder.stop();
+
+    expect(
+      inputs.filter((input) => input.runId === runId && input.action === "agent.run.started"),
+    ).toHaveLength(1);
+    expect(
+      inputs.filter((input) => input.runId === runId && input.action === "agent.run.finished"),
+    ).toEqual([]);
+  });
+
+  it("records an authoritative pre-rotation start after a provisional terminal", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-authoritative-terminal-before-start";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:retained:main",
+      agentId: "retained",
+    });
+    rotateAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 1,
+        data: { phase: "error" },
+      }),
+    );
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 2 }));
+    await recorder.stop();
+
+    expect(
+      inputs
+        .filter((input) => input.runId === runId && input.action === "agent.run.started")
+        .map((input) => input.sourceSequence),
+    ).toEqual([2]);
+    expect(
+      inputs.filter((input) => input.runId === runId && input.action === "agent.run.finished"),
+    ).toEqual([]);
+  });
+
+  it("keeps a pending terminal after retired provenance is evicted", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-pending-after-retired-eviction";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:retained:main",
+      agentId: "retained",
+    });
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        data: { phase: "error" },
+      }),
+    );
+    claimAgentRunContext(runId, {
+      lifecycleGeneration: "replacement-generation",
+      sessionKey: "agent:replacement:main",
+      agentId: "replacement",
+    });
+    const currentGeneration = rotateAgentEventLifecycleGeneration();
+    for (let index = 0; index < 1_025; index += 1) {
+      const pressureRunId = `run-retired-pending-pressure-${index}`;
+      recorder.record(
+        agentEvent({
+          runId: pressureRunId,
+          lifecycleGeneration: currentGeneration,
+          seq: 1,
+        }),
+      );
+      retireAgentRunContext(pressureRunId, currentGeneration, "replaced");
+    }
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3 }));
+    await recorder.stop();
+
+    expect(
+      inputs.filter((input) => input.runId === runId && input.action === "agent.run.started"),
+    ).toHaveLength(1);
+    expect(
+      inputs
+        .filter((input) => input.runId === runId && input.action === "agent.run.finished")
+        .map((input) => input.sourceSequence),
+    ).toEqual([2]);
+  });
+
+  it("advances the epoch after a pending authoritative context is cleared", async () => {
+    const inputs: AuditEventInput[] = [];
+    let rejectedTerminal = false;
+    const recorder = createAgentEventAuditRecorder({
+      writer: {
+        ...captureAuditWriter(inputs),
+        record: (input) => {
+          inputs.push(input);
+          if (input.action === "agent.run.finished" && !rejectedTerminal) {
+            rejectedTerminal = true;
+            return false;
+          }
+          return true;
+        },
+      },
+      terminalSettleMs: 0,
+    });
+    const runId = "run-cleared-pending-epoch";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:retained:main",
+      agentId: "retained",
+    });
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        data: { phase: "error" },
+      }),
+    );
+    clearAgentRunContext(runId, lifecycleGeneration);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 5);
+    });
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 3 }));
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 4,
+        data: { phase: "end" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.action === "agent.run.finished")).toMatchObject({
+      sourceSequence: 4,
+      status: "succeeded",
+    });
+  });
+
+  it("retains authoritative provenance for a delayed terminal after context clear", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-delayed-terminal-after-clear";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:retained:main",
+      agentId: "retained",
+    });
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 1,
+        sessionKey: "agent:retained:main",
+        agentId: "retained",
+      }),
+    );
+    clearAgentRunContext(runId, lifecycleGeneration);
+    rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(
+      inputs.find((input) => input.runId === runId && input.action === "agent.run.finished"),
+    ).toMatchObject({
+      actorId: "retained",
+      agentId: "retained",
+      sessionKey: "agent:retained:main",
+    });
+  });
+
+  it("rejects ambiguous generation-less terminals for overlapping generated runs", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-overlapping-generations";
+    const firstGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: firstGeneration,
+        sessionKey: "agent:first:main",
+        sessionId: "session-first",
+        agentId: "first",
+      }),
+    );
+    const secondGeneration = rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: secondGeneration,
+        seq: 2,
+        sessionKey: "agent:second:main",
+        sessionId: "session-second",
+        agentId: "second",
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: undefined,
+        seq: 3,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: undefined,
+        seq: 4,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.filter((input) => input.action === "agent.run.finished")).toEqual([]);
+  });
+
+  it("does not let generation-less terminals close later generated starts", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-terminal-replay-after-start";
+    const firstGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: firstGeneration,
+        sessionKey: "agent:first:main",
+        agentId: "first",
+      }),
+    );
+    const firstTerminal = agentEvent({
+      runId,
+      lifecycleGeneration: undefined,
+      seq: 2,
+      ts: 1_786_000_000_000,
+      sessionKey: undefined,
+      sessionId: undefined,
+      agentId: undefined,
+      data: { phase: "end", endedAt: 1_786_000_000_000 },
+    });
+    recorder.record(firstTerminal);
+    const secondGeneration = rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: secondGeneration,
+        seq: 1,
+        sessionKey: "agent:second:main",
+        agentId: "second",
+      }),
+    );
+    recorder.record(firstTerminal);
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: undefined,
+        seq: 3,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.filter((input) => input.action === "agent.run.finished")).toEqual([]);
+  });
+
+  it("rejects a generation-less terminal after generated context retirement", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-generationless-after-retirement";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:retained:main",
+      agentId: "retained",
+    });
+
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 1 }));
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 2,
+        data: { phase: "end" },
+      }),
+    );
+    clearAgentRunContext(runId, lifecycleGeneration);
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration: undefined,
+        seq: 3,
+        data: { phase: "end" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(
+      inputs
+        .filter((input) => input.runId === runId && input.action === "agent.run.finished")
+        .map((input) => input.sourceSequence),
+    ).toEqual([2]);
+  });
+});

--- a/src/audit/agent-event-audit.ts
+++ b/src/audit/agent-event-audit.ts
@@ -1,306 +1,46 @@
 /** Redaction-safe projection from live agent events into durable audit metadata. */
-import { createHash } from "node:crypto";
-import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import {
-  AGENT_RUN_TERMINAL_RETRY_GRACE_MS,
-  buildAgentRunTerminalOutcomeFromLifecycleEvent,
-  classifyAgentRunTerminalOutcome,
-  mergeAgentRunTerminalOutcome,
-  type AgentRunTerminalOutcome,
-} from "../agents/agent-run-terminal-outcome.js";
-import { isAllowedToolCallName } from "../agents/tool-call-shared.js";
-import type { AgentEventPayload } from "../infra/agent-events.js";
-import type { TrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
-import { pruneMapToMaxSize } from "../infra/map-size.js";
+import { AGENT_RUN_TERMINAL_RETRY_GRACE_MS } from "../agents/agent-run-terminal-outcome.js";
+import { getAgentEventContextLifecycleToken } from "../infra/agent-event-execution-context.js";
+import { isAgentEventLifecycleGenerationCurrent } from "../infra/agent-events.js";
+import { onAgentRunContextRetired } from "../infra/agent-run-context-retirement.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { parseAgentSessionKey } from "../routing/session-key.js";
-import type {
-  AuditEventInput,
-  AgentRunFinishedAuditTerminal,
-  ToolActionAuditEventInput,
-} from "./audit-event-types.js";
+import { adoptAgentAuditAttemptState } from "./agent-event-audit-attempt-state.js";
+import { projectAgentEvent } from "./agent-event-audit-lifecycle-projection.js";
+import {
+  adoptAuthoritativeOpenRunProvenance,
+  buildRunInstance,
+  createAgentAuditProjectionState,
+  forgetAuthoritativeOpenRun,
+  forgetOpenRun,
+  getAuthoritativeRunContextToken,
+  hasAuthoritativeRunContext,
+  MAX_TRACKED_RUN_PROVENANCE,
+  nonEmptyString,
+  retainAuthoritativeOpenRunForRetirement,
+  trimUnownedOpenRuns,
+} from "./agent-event-audit-provenance.js";
+import {
+  agentAuditAttemptKey,
+  agentAuditRunInstanceFromAttemptStateKey,
+  createAgentAuditPendingTerminal,
+  createAgentAuditAttemptStateKeyResolver,
+  createAgentAuditSettledAttemptRecorder,
+  matchingRetiredAgentAuditAttemptStates,
+  selectAgentAuditTerminalCandidate,
+  settledAgentAuditAttemptFloor,
+  type AgentAuditOpenAttempt,
+  type AgentAuditPendingTerminalWithOwnership,
+  type AgentAuditSettledRun,
+  type AgentAuditTerminalCandidate,
+} from "./agent-event-audit-terminal.js";
+import { projectToolExecutionEventToAudit } from "./agent-event-audit-tool-projection.js";
+import type { AgentEventAuditRecorder } from "./agent-event-audit-types.js";
 import { createAuditEventWriter, type AuditEventWriter } from "./audit-event-writer.js";
 
-const runProvenance = new Map<
-  string,
-  { actorType: "agent" | "system"; agentId: string; sessionKey?: string; sessionId?: string }
->();
-const MAX_TRACKED_RUN_PROVENANCE = 1_024;
 const log = createSubsystemLogger("audit/events");
 let persistenceFailureWarned = false;
 
-export type AgentEventAuditRecorder = {
-  record: (event: AgentEventPayload) => void;
-  recordTool: (event: TrustedToolExecutionEvent) => void;
-  stop: () => Promise<void>;
-};
-
-function nonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-function auditToolName(value: unknown): string | undefined {
-  const toolName = nonEmptyString(value)?.trim();
-  if (!toolName) {
-    return undefined;
-  }
-  // Tool lifecycle producers include provider-controlled streams. Preserve
-  // only the compact model-facing name contract at the durable boundary.
-  return isAllowedToolCallName(toolName, null) ? toolName : "unknown";
-}
-
-function auditToolCallId(value: unknown): string | undefined {
-  const toolCallId = nonEmptyString(value);
-  if (!toolCallId) {
-    return undefined;
-  }
-  // Call ids remain useful for correlation, but their provider-owned bytes
-  // are not operator metadata and must never enter the ledger verbatim.
-  return `sha256:${createHash("sha256").update(toolCallId).digest("hex")}`;
-}
-
-function legacyAuditSourceId(params: {
-  runId: string;
-  sourceSequence: number;
-  occurredAt: number;
-  action: string;
-}): string {
-  // Preserve the original store-owned identity byte-for-byte so replayed
-  // run/tool events still deduplicate after the versioned contract refactor.
-  return `${params.runId}:${params.sourceSequence}:${params.occurredAt}:${params.action}`;
-}
-
-function rememberRunProvenance(
-  runId: string,
-  provenance: {
-    actorType: "agent" | "system";
-    agentId: string;
-    sessionKey?: string;
-    sessionId?: string;
-  },
-): void {
-  runProvenance.delete(runId);
-  runProvenance.set(runId, provenance);
-  pruneMapToMaxSize(runProvenance, MAX_TRACKED_RUN_PROVENANCE);
-}
-
-function resolveProvenance(
-  runId: string,
-  event: { agentId?: unknown; sessionKey?: unknown; sessionId?: unknown },
-) {
-  const remembered = runProvenance.get(runId);
-  const sessionKey = nonEmptyString(event.sessionKey) ?? remembered?.sessionKey;
-  const sessionId = nonEmptyString(event.sessionId) ?? remembered?.sessionId;
-  const eventAgentId = nonEmptyString(event.agentId);
-  const sessionAgentId = sessionKey ? parseAgentSessionKey(sessionKey)?.agentId : undefined;
-  const agentId = eventAgentId ?? sessionAgentId ?? remembered?.agentId ?? "unknown";
-  const actorType = eventAgentId || sessionAgentId ? "agent" : (remembered?.actorType ?? "system");
-  return { actorType, agentId, sessionKey, sessionId };
-}
-
-function resolveToolProvenance(
-  runId: string,
-  event: { agentId?: unknown; sessionKey?: unknown; sessionId?: unknown },
-) {
-  const observed = resolveProvenance(runId, event);
-  const remembered = runProvenance.get(runId);
-  if (!remembered) {
-    return observed;
-  }
-  // Tool diagnostics may use an execution sandbox key. Lifecycle start owns
-  // the canonical run identity; tool metadata only fills missing session fields.
-  return {
-    ...remembered,
-    sessionKey: remembered.sessionKey ?? observed.sessionKey,
-    sessionId: remembered.sessionId ?? observed.sessionId,
-  };
-}
-
-const AUDIT_TERMINAL_BY_CLASSIFICATION = {
-  success: { status: "succeeded" as const },
-  timeout: { status: "timed_out" as const, errorCode: "run_timed_out" as const },
-  cancellation: { status: "cancelled" as const, errorCode: "run_cancelled" as const },
-  failure: { status: "failed" as const, errorCode: "run_failed" as const },
-};
-
-function classifyRunTerminal(
-  data: Record<string, unknown>,
-  phase: "end" | "error",
-): {
-  outcome: AgentRunTerminalOutcome;
-} & AgentRunFinishedAuditTerminal {
-  const outcome = buildAgentRunTerminalOutcomeFromLifecycleEvent({ phase, data });
-  if (outcome.reason === "blocked") {
-    return { outcome, status: "blocked", errorCode: "run_blocked" };
-  }
-  const terminal = AUDIT_TERMINAL_BY_CLASSIFICATION[classifyAgentRunTerminalOutcome(outcome)];
-  return { outcome, ...terminal };
-}
-
-type AgentAuditProjection = {
-  input: AuditEventInput;
-  terminal?: { outcome: AgentRunTerminalOutcome; phase: "end" | "error" };
-};
-
-function projectAgentEvent(event: AgentEventPayload): AgentAuditProjection | undefined {
-  const runId = nonEmptyString(event.runId);
-  const phase = nonEmptyString(event.data.phase);
-  if (!runId || !phase) {
-    return undefined;
-  }
-  const provenance = resolveProvenance(runId, event);
-  if (event.stream === "lifecycle" && phase === "start") {
-    rememberRunProvenance(runId, provenance);
-    const occurredAt = asDateTimestampMs(event.data.startedAt) ?? event.ts;
-    const action = "agent.run.started" as const;
-    return {
-      input: {
-        sourceId: legacyAuditSourceId({
-          runId,
-          sourceSequence: event.seq,
-          occurredAt,
-          action,
-        }),
-        sourceSequence: event.seq,
-        occurredAt,
-        kind: "agent_run",
-        action,
-        status: "started",
-        actorType: provenance.actorType,
-        actorId: provenance.agentId,
-        agentId: provenance.agentId,
-        ...(provenance.sessionKey ? { sessionKey: provenance.sessionKey } : {}),
-        ...(provenance.sessionId ? { sessionId: provenance.sessionId } : {}),
-        runId,
-      },
-    };
-  }
-  if (event.stream === "lifecycle" && (phase === "end" || phase === "error")) {
-    rememberRunProvenance(runId, provenance);
-    const { outcome, ...terminal } = classifyRunTerminal(event.data, phase);
-    const occurredAt = asDateTimestampMs(event.data.endedAt) ?? event.ts;
-    const action = "agent.run.finished" as const;
-    return {
-      input: {
-        sourceId: legacyAuditSourceId({
-          runId,
-          sourceSequence: event.seq,
-          occurredAt,
-          action,
-        }),
-        sourceSequence: event.seq,
-        occurredAt,
-        kind: "agent_run",
-        action,
-        ...terminal,
-        actorType: provenance.actorType,
-        actorId: provenance.agentId,
-        agentId: provenance.agentId,
-        ...(provenance.sessionKey ? { sessionKey: provenance.sessionKey } : {}),
-        ...(provenance.sessionId ? { sessionId: provenance.sessionId } : {}),
-        runId,
-      },
-      terminal: { outcome, phase },
-    };
-  }
-  return undefined;
-}
-
-/** Project the complete trusted tool-execution lifecycle without private diagnostic content. */
-function projectToolExecutionEventToAudit(
-  event: TrustedToolExecutionEvent,
-): ToolActionAuditEventInput | undefined {
-  // Schema quarantine describes tool availability before invocation. Without
-  // a call identity it must not become a durable tool-action claim.
-  if (
-    event.type === "tool.execution.blocked" &&
-    event.deniedReason === "unsupported_tool_schema" &&
-    !nonEmptyString(event.toolCallId)
-  ) {
-    return undefined;
-  }
-  const runId = nonEmptyString(event.runId);
-  const toolName = auditToolName(event.toolName);
-  if (!runId || !toolName) {
-    return undefined;
-  }
-  const toolCallId = auditToolCallId(event.toolCallId);
-  const provenance = resolveToolProvenance(runId, event);
-  const occurredAt = asDateTimestampMs(event.sourceTimestampMs) ?? event.ts;
-  const attribution = {
-    sourceSequence: event.seq,
-    occurredAt,
-    kind: "tool_action" as const,
-    actorType: provenance.actorType,
-    actorId: provenance.agentId,
-    agentId: provenance.agentId,
-    ...(provenance.sessionKey ? { sessionKey: provenance.sessionKey } : {}),
-    ...(provenance.sessionId ? { sessionId: provenance.sessionId } : {}),
-    runId,
-    ...(toolCallId ? { toolCallId } : {}),
-    toolName,
-  };
-  if (event.type === "tool.execution.started") {
-    const action = "tool.action.started" as const;
-    return {
-      sourceId: legacyAuditSourceId({
-        runId,
-        sourceSequence: event.seq,
-        occurredAt,
-        action,
-      }),
-      ...attribution,
-      action,
-      status: "started",
-    };
-  }
-  const errorCategory =
-    event.type === "tool.execution.error"
-      ? normalizeOptionalLowercaseString(event.errorCategory)
-      : undefined;
-  const terminalReason = event.type === "tool.execution.error" ? event.terminalReason : undefined;
-  const diagnosticErrorCode =
-    event.type === "tool.execution.error"
-      ? normalizeOptionalLowercaseString(event.errorCode)
-      : undefined;
-  // Modern producers set terminalReason explicitly; errorCategory is only a
-  // legacy fallback and must not override a definitive timeout or failure.
-  const toolCancelled =
-    terminalReason === "cancelled" ||
-    (terminalReason === undefined &&
-      (errorCategory === "aborted" ||
-        errorCategory === "aborterror" ||
-        errorCategory === "cancelled" ||
-        errorCategory === "canceled"));
-  const toolTimedOut = terminalReason === "timed_out";
-  // Unknown is an explicit dependency boundary, not a failed-run inference.
-  // Keep it authoritative when enclosing run provenance says cancel or timeout.
-  const terminal =
-    event.type === "tool.execution.completed"
-      ? { status: "succeeded" as const }
-      : event.type === "tool.execution.blocked"
-        ? { status: "blocked" as const, errorCode: "tool_blocked" as const }
-        : diagnosticErrorCode === "tool_outcome_unknown"
-          ? { status: "unknown" as const, errorCode: "tool_outcome_unknown" as const }
-          : toolCancelled
-            ? { status: "cancelled" as const, errorCode: "tool_cancelled" as const }
-            : toolTimedOut
-              ? { status: "timed_out" as const, errorCode: "tool_timed_out" as const }
-              : { status: "failed" as const, errorCode: "tool_failed" as const };
-  const action = "tool.action.finished" as const;
-  return {
-    sourceId: legacyAuditSourceId({
-      runId,
-      sourceSequence: event.seq,
-      occurredAt,
-      action,
-    }),
-    ...attribution,
-    action,
-    ...terminal,
-  };
-}
+export type { AgentEventAuditRecorder } from "./agent-event-audit-types.js";
 
 /** Create the Gateway-owned non-blocking audit projection and persistence handle. */
 export function createAgentEventAuditRecorder(options?: {
@@ -308,6 +48,7 @@ export function createAgentEventAuditRecorder(options?: {
   stateDir?: string;
   terminalSettleMs?: number;
 }): AgentEventAuditRecorder {
+  const projectionState = createAgentAuditProjectionState();
   const writer =
     options?.writer ??
     createAuditEventWriter({
@@ -319,69 +60,152 @@ export function createAgentEventAuditRecorder(options?: {
         }
       },
     });
-  type PendingTerminal = NonNullable<AgentAuditProjection["terminal"]> & {
-    input: AuditEventInput;
-    timer: ReturnType<typeof setTimeout>;
+  const requestedTerminalSettleMs = options?.terminalSettleMs ?? AGENT_RUN_TERMINAL_RETRY_GRACE_MS;
+  const terminalSettleMs = Math.max(0, Math.floor(requestedTerminalSettleMs));
+  const pendingTerminals = new Map<string, AgentAuditPendingTerminalWithOwnership>();
+  const getAttemptStateKey = createAgentAuditAttemptStateKeyResolver();
+  const rejectedTerminalsByAttempt = new Map<
+    string,
+    AgentAuditTerminalCandidate & { attemptStateKey: string; runInstance: string }
+  >();
+  const rejectedCountByAttemptState = new Map<string, number>();
+  const openAttemptStates = new Set<string>();
+  const openAuthoritativeRunContexts = new WeakMap<object, AgentAuditOpenAttempt>();
+  const retiredOpenAttemptStates = new Set<string>();
+  const unownedOpenAttemptStates = new Set<string>();
+  const rejectedStartAttemptStates = new Set<string>();
+  const settledRunInstances = new Map<string, AgentAuditSettledRun>();
+  const attemptEpochByState = new Map<string, number>();
+  const attemptStartSequenceByState = new Map<string, number>();
+  const adoptOpenAttemptState = (from: string, to: string) =>
+    adoptAgentAuditAttemptState({
+      from,
+      to,
+      openAttempts: openAttemptStates,
+      unownedAttempts: unownedOpenAttemptStates,
+      rejectedStarts: rejectedStartAttemptStates,
+      pendingTerminals,
+      settledAttempts: settledRunInstances,
+      attemptEpochs: attemptEpochByState,
+      attemptStartSequences: attemptStartSequenceByState,
+    });
+  const discardAttemptState = (attemptStateKey: string) => {
+    openAttemptStates.delete(attemptStateKey);
+    retiredOpenAttemptStates.delete(attemptStateKey);
+    unownedOpenAttemptStates.delete(attemptStateKey);
+    rejectedStartAttemptStates.delete(attemptStateKey);
+    attemptStartSequenceByState.delete(attemptStateKey);
   };
-  const terminalSettleMs = Math.max(
-    0,
-    Math.floor(options?.terminalSettleMs ?? AGENT_RUN_TERMINAL_RETRY_GRACE_MS),
+  const rememberSettled = createAgentAuditSettledAttemptRecorder(
+    settledRunInstances,
+    MAX_TRACKED_RUN_PROVENANCE,
   );
-  const pendingTerminals = new Map<string, PendingTerminal>();
-  const openRunInstances = new Set<string>();
-  const settledRunInstances = new Set<string>();
-
-  const rememberSettled = (runInstance: string) => {
-    settledRunInstances.delete(runInstance);
-    settledRunInstances.add(runInstance);
-    if (settledRunInstances.size > MAX_TRACKED_RUN_PROVENANCE) {
-      const oldest = settledRunInstances.values().next().value;
-      if (oldest !== undefined) {
-        settledRunInstances.delete(oldest);
+  const forgetRejectedAttempt = (attemptKey: string) => {
+    const rejected = rejectedTerminalsByAttempt.get(attemptKey);
+    if (!rejected) {
+      return;
+    }
+    rejectedTerminalsByAttempt.delete(attemptKey);
+    const rejectedCount = (rejectedCountByAttemptState.get(rejected.attemptStateKey) ?? 1) - 1;
+    if (rejectedCount > 0) {
+      rejectedCountByAttemptState.set(rejected.attemptStateKey, rejectedCount);
+    } else {
+      rejectedCountByAttemptState.delete(rejected.attemptStateKey);
+      if (!openAttemptStates.has(rejected.attemptStateKey)) {
+        attemptEpochByState.delete(rejected.attemptStateKey);
       }
     }
   };
-  const clearPending = (runInstance: string) => {
-    const pending = pendingTerminals.get(runInstance);
+  const rememberRejectedTerminal = (
+    attemptStateKey: string,
+    runInstance: string,
+    incoming: AgentAuditTerminalCandidate,
+  ) => {
+    const existing = rejectedTerminalsByAttempt.get(incoming.attemptKey);
+    const selected = existing ? selectAgentAuditTerminalCandidate(existing, incoming) : incoming;
+    if (!existing) {
+      rejectedCountByAttemptState.set(
+        attemptStateKey,
+        (rejectedCountByAttemptState.get(attemptStateKey) ?? 0) + 1,
+      );
+    }
+    rejectedTerminalsByAttempt.delete(incoming.attemptKey);
+    rejectedTerminalsByAttempt.set(incoming.attemptKey, {
+      ...selected,
+      attemptStateKey,
+      runInstance,
+    });
+    if (rejectedTerminalsByAttempt.size > MAX_TRACKED_RUN_PROVENANCE) {
+      const oldest = rejectedTerminalsByAttempt.keys().next().value;
+      if (oldest !== undefined) {
+        forgetRejectedAttempt(oldest);
+      }
+    }
+  };
+  const clearPending = (attemptStateKey: string) => {
+    const pending = pendingTerminals.get(attemptStateKey);
     if (!pending) {
       return;
     }
     clearTimeout(pending.timer);
-    pendingTerminals.delete(runInstance);
+    pendingTerminals.delete(attemptStateKey);
   };
-  const flushPending = (runInstance: string) => {
-    const pending = pendingTerminals.get(runInstance);
+  const flushPending = (attemptStateKey: string) => {
+    const pending = pendingTerminals.get(attemptStateKey);
     if (!pending) {
       return;
     }
-    clearPending(runInstance);
-    openRunInstances.delete(runInstance);
-    if (writer.record(pending.input)) {
-      rememberSettled(runInstance);
+    const { contextLifecycleToken, runInstance } = pending;
+    clearPending(attemptStateKey);
+    openAttemptStates.delete(attemptStateKey);
+    const runId = nonEmptyString(pending.input.runId);
+    const authoritativeContext = runId
+      ? getAuthoritativeRunContextToken(runInstance, runId, contextLifecycleToken)
+      : undefined;
+    if (authoritativeContext && runId) {
+      const attempt = openAuthoritativeRunContexts.get(authoritativeContext);
+      if (attempt) {
+        openAuthoritativeRunContexts.set(authoritativeContext, { ...attempt, open: false });
+      }
+      forgetAuthoritativeOpenRun(projectionState, runInstance, runId, contextLifecycleToken);
+    }
+    const rejected = rejectedTerminalsByAttempt.get(pending.attemptKey);
+    const selected = rejected ? selectAgentAuditTerminalCandidate(rejected, pending) : pending;
+    if (writer.record(selected.input)) {
+      forgetRejectedAttempt(selected.attemptKey);
+      if (runId) {
+        forgetOpenRun(projectionState, runInstance, runId);
+      }
+      discardAttemptState(attemptStateKey);
+      rememberSettled(attemptStateKey, selected.observedThroughSequence);
+      if (!rejectedCountByAttemptState.has(attemptStateKey)) {
+        attemptEpochByState.delete(attemptStateKey);
+      }
+    } else {
+      rememberRejectedTerminal(attemptStateKey, runInstance, selected);
     }
   };
-  const scheduleTerminal = (runInstance: string, incoming: Omit<PendingTerminal, "timer">) => {
-    const existing = pendingTerminals.get(runInstance);
-    let selected = incoming;
+  const scheduleTerminal = (
+    attemptStateKey: string,
+    runInstance: string,
+    contextLifecycleToken: object | undefined,
+    incoming: AgentAuditTerminalCandidate,
+  ) => {
+    const existing = pendingTerminals.get(attemptStateKey);
+    const selected = existing ? selectAgentAuditTerminalCandidate(existing, incoming) : incoming;
     if (existing) {
-      // A bare cleanup end can follow a definitive error without a retry start.
-      // Otherwise use the shared sticky timeout/cancellation merge contract.
-      const cleanupAfterError =
-        existing.phase === "error" &&
-        incoming.phase === "end" &&
-        incoming.outcome.reason === "completed";
-      if (cleanupAfterError) {
-        selected = existing;
-      } else {
-        const merged = mergeAgentRunTerminalOutcome(existing.outcome, incoming.outcome);
-        selected = merged === existing.outcome ? existing : incoming;
-      }
       clearTimeout(existing.timer);
     }
-    const timer = setTimeout(() => flushPending(runInstance), terminalSettleMs);
-    timer.unref?.();
-    pendingTerminals.delete(runInstance);
-    pendingTerminals.set(runInstance, { ...selected, timer });
+    const pending = createAgentAuditPendingTerminal({
+      attemptStateKey,
+      candidate: selected,
+      flush: flushPending,
+      runInstance,
+      settleMs: terminalSettleMs,
+      ...(contextLifecycleToken ? { contextLifecycleToken } : {}),
+    });
+    pendingTerminals.delete(attemptStateKey);
+    pendingTerminals.set(attemptStateKey, pending);
     if (pendingTerminals.size > MAX_TRACKED_RUN_PROVENANCE) {
       const oldest = pendingTerminals.keys().next().value;
       if (oldest !== undefined) {
@@ -389,44 +213,356 @@ export function createAgentEventAuditRecorder(options?: {
       }
     }
   };
-
+  const unsubscribeRunContextRetirement = onAgentRunContextRetired(
+    ({ runId, lifecycleGeneration, contextLifecycleToken }) => {
+      const runInstance = buildRunInstance(runId, lifecycleGeneration);
+      const authoritativeContext =
+        contextLifecycleToken ?? getAuthoritativeRunContextToken(runInstance, runId);
+      const attemptStateKey = getAttemptStateKey(runInstance, authoritativeContext);
+      const authoritativeAttempt = authoritativeContext
+        ? openAuthoritativeRunContexts.get(authoritativeContext)
+        : undefined;
+      if (
+        authoritativeContext &&
+        attemptStateKey !== runInstance &&
+        pendingTerminals.has(runInstance)
+      ) {
+        flushPending(runInstance);
+      }
+      if (
+        authoritativeContext &&
+        attemptStateKey !== runInstance &&
+        !retiredOpenAttemptStates.has(runInstance) &&
+        adoptOpenAttemptState(runInstance, attemptStateKey)
+      ) {
+        adoptAuthoritativeOpenRunProvenance(projectionState, runInstance, authoritativeContext);
+      }
+      const authoritativeOpenAttempt = authoritativeAttempt?.open
+        ? authoritativeAttempt
+        : undefined;
+      if (
+        authoritativeAttempt &&
+        (pendingTerminals.has(attemptStateKey) || rejectedCountByAttemptState.has(attemptStateKey))
+      ) {
+        attemptEpochByState.set(attemptStateKey, authoritativeAttempt.attemptEpoch);
+      }
+      const retainedAuthoritativeRun = retainAuthoritativeOpenRunForRetirement(
+        projectionState,
+        runInstance,
+        runId,
+        authoritativeContext,
+      );
+      if (retainedAuthoritativeRun || projectionState.openRunProvenance.has(runInstance)) {
+        // Context retirement can precede the final lifecycle event for every
+        // registry removal path. Keep only open attempts in the bounded
+        // retired set so delayed terminals retain their admitted provenance.
+        if (authoritativeOpenAttempt) {
+          attemptEpochByState.set(attemptStateKey, authoritativeOpenAttempt.attemptEpoch);
+          attemptStartSequenceByState.set(attemptStateKey, authoritativeOpenAttempt.startSequence);
+          if (authoritativeOpenAttempt.startAccepted) {
+            rejectedStartAttemptStates.delete(attemptStateKey);
+          } else {
+            rejectedStartAttemptStates.add(attemptStateKey);
+          }
+          openAttemptStates.add(attemptStateKey);
+        }
+        retiredOpenAttemptStates.delete(attemptStateKey);
+        retiredOpenAttemptStates.add(attemptStateKey);
+        unownedOpenAttemptStates.delete(attemptStateKey);
+        if (retiredOpenAttemptStates.size > MAX_TRACKED_RUN_PROVENANCE) {
+          const oldest = retiredOpenAttemptStates.values().next().value;
+          if (oldest !== undefined) {
+            const oldestRunInstance = agentAuditRunInstanceFromAttemptStateKey(oldest);
+            const separator = oldestRunInstance.indexOf("\0");
+            const retiredRunId =
+              separator >= 0 ? oldestRunInstance.slice(separator + 1) : oldestRunInstance;
+            retiredOpenAttemptStates.delete(oldest);
+            forgetOpenRun(projectionState, oldestRunInstance, retiredRunId);
+            openAttemptStates.delete(oldest);
+            rejectedStartAttemptStates.delete(oldest);
+            attemptStartSequenceByState.delete(oldest);
+            if (!pendingTerminals.has(oldest) && !rejectedCountByAttemptState.has(oldest)) {
+              attemptEpochByState.delete(oldest);
+            }
+          }
+        }
+        return;
+      }
+      forgetOpenRun(projectionState, runInstance, runId);
+      discardAttemptState(attemptStateKey);
+      if (
+        !pendingTerminals.has(attemptStateKey) &&
+        !rejectedCountByAttemptState.has(attemptStateKey)
+      ) {
+        attemptEpochByState.delete(attemptStateKey);
+      }
+    },
+  );
   return {
     record: (event) => {
-      const projection = projectAgentEvent(event);
+      const runInstance = buildRunInstance(event.runId, event.lifecycleGeneration);
+      const contextLifecycleToken = getAgentEventContextLifecycleToken(event);
+      const phase = nonEmptyString(event.data.phase);
+      const authoritativeContext = getAuthoritativeRunContextToken(
+        runInstance,
+        event.runId,
+        contextLifecycleToken,
+      );
+      const attemptStateKey = getAttemptStateKey(runInstance, authoritativeContext);
+      const authoritativeAttempt = authoritativeContext
+        ? openAuthoritativeRunContexts.get(authoritativeContext)
+        : undefined;
+      if (event.stream === "lifecycle" && phase === "start" && authoritativeContext) {
+        // A rebound token flushes retired attempts but adopts a still-open unowned attempt.
+        for (const retiredAttemptState of matchingRetiredAgentAuditAttemptStates(
+          retiredOpenAttemptStates,
+          runInstance,
+          attemptStateKey,
+        )) {
+          flushPending(retiredAttemptState);
+          discardAttemptState(retiredAttemptState);
+        }
+        if (
+          !retiredOpenAttemptStates.has(runInstance) &&
+          adoptOpenAttemptState(runInstance, attemptStateKey)
+        ) {
+          adoptAuthoritativeOpenRunProvenance(projectionState, runInstance, authoritativeContext);
+        }
+        forgetOpenRun(projectionState, runInstance, event.runId);
+      }
+      const settled = settledRunInstances.get(attemptStateKey);
+      const authoritativeOpenAttempt = authoritativeAttempt?.open
+        ? authoritativeAttempt
+        : undefined;
+      if (event.stream === "lifecycle") {
+        if (phase === "start") {
+          if (settled && event.seq <= settled.terminalSequence) {
+            return;
+          }
+          const attemptEpoch =
+            authoritativeAttempt?.attemptEpoch ?? attemptEpochByState.get(attemptStateKey) ?? 0;
+          const rejectedAttempt = rejectedTerminalsByAttempt.get(
+            agentAuditAttemptKey(attemptStateKey, attemptEpoch),
+          );
+          if (rejectedAttempt && event.seq <= rejectedAttempt.observedThroughSequence) {
+            return;
+          }
+          const pendingTerminal = pendingTerminals.get(attemptStateKey);
+          if (pendingTerminal && event.seq <= pendingTerminal.observedThroughSequence) {
+            return;
+          }
+          const cancelsPendingTerminal = pendingTerminal !== undefined;
+          const hasOpenAttempt =
+            openAttemptStates.has(attemptStateKey) || authoritativeOpenAttempt !== undefined;
+          const canReplacePendingWithoutOpen =
+            event.lifecycleGeneration === undefined ||
+            isAgentEventLifecycleGenerationCurrent(event.lifecycleGeneration) ||
+            authoritativeContext !== undefined;
+          if (cancelsPendingTerminal && !hasOpenAttempt && !canReplacePendingWithoutOpen) {
+            return;
+          }
+          if (hasOpenAttempt) {
+            if (cancelsPendingTerminal) {
+              clearPending(attemptStateKey);
+            }
+            const startSequence = Math.max(
+              event.seq,
+              authoritativeOpenAttempt?.startSequence ??
+                attemptStartSequenceByState.get(attemptStateKey) ??
+                event.seq,
+            );
+            if (authoritativeContext) {
+              const startAccepted =
+                authoritativeOpenAttempt?.startAccepted ??
+                !rejectedStartAttemptStates.has(attemptStateKey);
+              openAuthoritativeRunContexts.set(authoritativeContext, {
+                attemptEpoch:
+                  authoritativeOpenAttempt?.attemptEpoch ??
+                  attemptEpochByState.get(attemptStateKey) ??
+                  1,
+                open: true,
+                startSequence,
+                startAccepted,
+              });
+              rejectedStartAttemptStates.delete(attemptStateKey);
+            } else {
+              openAttemptStates.add(attemptStateKey);
+              attemptStartSequenceByState.set(attemptStateKey, startSequence);
+            }
+            return;
+          }
+          if (cancelsPendingTerminal) {
+            clearPending(attemptStateKey);
+          }
+        } else if (phase === "end" || phase === "error") {
+          const attemptStartSequence =
+            authoritativeOpenAttempt?.startSequence ??
+            attemptStartSequenceByState.get(attemptStateKey);
+          const settledAttemptFloor = settledAgentAuditAttemptFloor(settled);
+          if (
+            (settled && settled.reopenedStartSequence === undefined) ||
+            (attemptStartSequence !== undefined && event.seq <= attemptStartSequence) ||
+            (settledAttemptFloor !== undefined && event.seq <= settledAttemptFloor)
+          ) {
+            return;
+          }
+        }
+      }
+      const projection = projectAgentEvent(projectionState, event);
       if (!projection) {
         return;
       }
-      const runInstance = `${event.lifecycleGeneration ?? "unknown"}\0${event.runId}`;
       if (!projection.terminal) {
-        const alreadyOpen = openRunInstances.has(runInstance);
-        clearPending(runInstance);
-        settledRunInstances.delete(runInstance);
-        if (alreadyOpen) {
-          return;
-        }
         // Retry starts cancel a provisional terminal for the same logical run.
-        // Keep the original start so one run cannot acquire unmatched starts.
-        openRunInstances.add(runInstance);
-        writer.record(projection.input);
+        // A writer-rejected terminal already crossed the settle boundary and
+        // remains a prior attempt; queue pressure must not rewrite that history.
+        const startAccepted = writer.record(projection.input);
+        if (authoritativeContext) {
+          // Registry-owned weak identity carries authoritative live attempt
+          // state without retaining completed run contexts.
+          openAuthoritativeRunContexts.set(authoritativeContext, {
+            attemptEpoch: (authoritativeAttempt?.attemptEpoch ?? 0) + 1,
+            open: true,
+            startSequence: event.seq,
+            startAccepted,
+          });
+        } else {
+          attemptEpochByState.set(
+            attemptStateKey,
+            (attemptEpochByState.get(attemptStateKey) ?? 0) + 1,
+          );
+          openAttemptStates.add(attemptStateKey);
+          attemptStartSequenceByState.set(attemptStateKey, event.seq);
+          if (startAccepted) {
+            rejectedStartAttemptStates.delete(attemptStateKey);
+          } else {
+            rejectedStartAttemptStates.add(attemptStateKey);
+          }
+        }
+        if (settled) {
+          settledRunInstances.delete(attemptStateKey);
+          settledRunInstances.set(attemptStateKey, {
+            ...settled,
+            reopenedStartSequence: event.seq,
+          });
+        }
+        if (hasAuthoritativeRunContext(runInstance, event.runId, contextLifecycleToken)) {
+          unownedOpenAttemptStates.delete(attemptStateKey);
+        } else {
+          // Supported event-bus producers receive a registry owner before this
+          // callback. Bound malformed direct inputs that bypass that contract.
+          unownedOpenAttemptStates.delete(attemptStateKey);
+          unownedOpenAttemptStates.add(attemptStateKey);
+          trimUnownedOpenRuns({
+            state: projectionState,
+            runInstances: unownedOpenAttemptStates,
+            pendingTerminals,
+            rejectedRunInstances: rejectedCountByAttemptState,
+            rejectedTerminals: rejectedTerminalsByAttempt,
+            openRunInstances: openAttemptStates,
+            rejectedStartRunInstances: rejectedStartAttemptStates,
+            attemptStartSequences: attemptStartSequenceByState,
+            attemptEpochs: attemptEpochByState,
+            clearPending,
+            forgetRejectedAttempt,
+          });
+        }
         return;
       }
-      if (settledRunInstances.has(runInstance)) {
+      const startWasRejected =
+        authoritativeAttempt?.startAccepted === false ||
+        (authoritativeAttempt === undefined && rejectedStartAttemptStates.has(attemptStateKey));
+      if (startWasRejected) {
+        openAttemptStates.delete(attemptStateKey);
+        if (authoritativeContext && authoritativeAttempt) {
+          openAuthoritativeRunContexts.set(authoritativeContext, {
+            ...authoritativeAttempt,
+            open: false,
+          });
+        }
+        if (authoritativeContext) {
+          forgetAuthoritativeOpenRun(
+            projectionState,
+            runInstance,
+            event.runId,
+            contextLifecycleToken,
+          );
+        }
+        forgetOpenRun(projectionState, runInstance, event.runId);
+        discardAttemptState(attemptStateKey);
+        rememberSettled(attemptStateKey, event.seq);
+        if (!rejectedCountByAttemptState.has(attemptStateKey)) {
+          attemptEpochByState.delete(attemptStateKey);
+        }
         return;
       }
       if (
         projection.terminal.outcome.reason === "completed" &&
-        !pendingTerminals.has(runInstance)
+        !pendingTerminals.has(attemptStateKey)
       ) {
-        openRunInstances.delete(runInstance);
-        if (writer.record(projection.input)) {
-          rememberSettled(runInstance);
+        const attemptKey = agentAuditAttemptKey(
+          attemptStateKey,
+          authoritativeAttempt?.attemptEpoch ?? attemptEpochByState.get(attemptStateKey) ?? 0,
+        );
+        const incoming = {
+          attemptKey,
+          input: projection.input,
+          observedThroughSequence: event.seq,
+          ...projection.terminal,
+        };
+        const rejected = rejectedTerminalsByAttempt.get(attemptKey);
+        const selected = rejected
+          ? selectAgentAuditTerminalCandidate(rejected, incoming)
+          : incoming;
+        openAttemptStates.delete(attemptStateKey);
+        const terminalAuthoritativeContext = getAuthoritativeRunContextToken(
+          runInstance,
+          event.runId,
+          contextLifecycleToken,
+        );
+        if (terminalAuthoritativeContext) {
+          // The terminal has crossed the settle boundary even when the writer
+          // queues it for stop(); a later start therefore owns a new attempt.
+          if (authoritativeAttempt) {
+            openAuthoritativeRunContexts.set(terminalAuthoritativeContext, {
+              ...authoritativeAttempt,
+              open: false,
+            });
+          }
+          forgetAuthoritativeOpenRun(
+            projectionState,
+            runInstance,
+            event.runId,
+            contextLifecycleToken,
+          );
+        }
+        if (writer.record(selected.input)) {
+          forgetRejectedAttempt(attemptKey);
+          forgetOpenRun(projectionState, runInstance, event.runId);
+          retiredOpenAttemptStates.delete(attemptStateKey);
+          unownedOpenAttemptStates.delete(attemptStateKey);
+          attemptStartSequenceByState.delete(attemptStateKey);
+          rememberSettled(attemptStateKey, selected.observedThroughSequence);
+          if (!rejectedCountByAttemptState.has(attemptStateKey)) {
+            attemptEpochByState.delete(attemptStateKey);
+          }
+        } else {
+          rememberRejectedTerminal(attemptStateKey, runInstance, selected);
         }
         return;
       }
-      scheduleTerminal(runInstance, { input: projection.input, ...projection.terminal });
+      scheduleTerminal(attemptStateKey, runInstance, contextLifecycleToken, {
+        attemptKey: agentAuditAttemptKey(
+          attemptStateKey,
+          authoritativeAttempt?.attemptEpoch ?? attemptEpochByState.get(attemptStateKey) ?? 0,
+        ),
+        input: projection.input,
+        observedThroughSequence: event.seq,
+        ...projection.terminal,
+      });
     },
     recordTool: (event) => {
-      const input = projectToolExecutionEventToAudit(event);
+      const input = projectToolExecutionEventToAudit(projectionState, event);
       if (input) {
         writer.record(input);
       }
@@ -435,7 +571,28 @@ export function createAgentEventAuditRecorder(options?: {
       for (const runInstance of pendingTerminals.keys()) {
         flushPending(runInstance);
       }
-      await writer.stop();
+      try {
+        await writer.stop(
+          [...rejectedTerminalsByAttempt.values()].map((rejected) => rejected.input),
+        );
+      } finally {
+        unsubscribeRunContextRetirement();
+        // The registry remains authoritative when bounded projection entries
+        // are evicted. Shutdown releases every local projection.
+        projectionState.openRunProvenance.clear();
+        projectionState.runProvenance.clear();
+        projectionState.activeRunInstanceByRunId.clear();
+        projectionState.seenRunInstances.clear();
+        rejectedTerminalsByAttempt.clear();
+        rejectedCountByAttemptState.clear();
+        openAttemptStates.clear();
+        retiredOpenAttemptStates.clear();
+        unownedOpenAttemptStates.clear();
+        rejectedStartAttemptStates.clear();
+        settledRunInstances.clear();
+        attemptEpochByState.clear();
+        attemptStartSequenceByState.clear();
+      }
     },
   };
 }

--- a/src/audit/audit-event-source-adoption.test.ts
+++ b/src/audit/audit-event-source-adoption.test.ts
@@ -9,9 +9,18 @@ import type { AuditEventInput } from "./audit-event-types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const AUDIT_EVENT_RETENTION_MS_CONTRACT = 30 * 24 * 60 * 60_000;
+const ADOPTION_TABLE_QUERY =
+  "SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = 'audit_event_source_adoptions'";
 
 function createDatabaseOptions() {
   return { env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-audit-adoption-") } };
+}
+
+function expectAdoptionTableAbsent(database: ReturnType<typeof createDatabaseOptions>): void {
+  expect(
+    openOpenClawStateDatabase(database).db.prepare(ADOPTION_TABLE_QUERY).get(),
+  ).toBeUndefined();
+  closeOpenClawStateDatabaseForTest();
 }
 
 function auditInput(overrides: Partial<AuditEventInput> = {}): AuditEventInput {
@@ -52,9 +61,7 @@ describe("audit event source adoption", () => {
         database,
       ),
     ).toBeDefined();
-    const { db: legacyDb } = openOpenClawStateDatabase(database);
-    legacyDb.exec("DROP TABLE audit_event_source_adoptions");
-    closeOpenClawStateDatabaseForTest();
+    expectAdoptionTableAbsent(database);
 
     expect(
       recordAuditEvent(
@@ -123,9 +130,7 @@ describe("audit event source adoption", () => {
       toolCallId: "call-1",
     });
     expect(recordAuditEvent(legacyInput, database)).toBeDefined();
-    const { db: legacyDb } = openOpenClawStateDatabase(database);
-    legacyDb.exec("DROP TABLE audit_event_source_adoptions");
-    closeOpenClawStateDatabaseForTest();
+    expectAdoptionTableAbsent(database);
 
     const replayInput = {
       ...legacyInput,
@@ -151,9 +156,7 @@ describe("audit event source adoption", () => {
         database,
       ),
     ).toBeDefined();
-    const { db: legacyDb } = openOpenClawStateDatabase(database);
-    legacyDb.exec("DROP TABLE audit_event_source_adoptions");
-    closeOpenClawStateDatabaseForTest();
+    expectAdoptionTableAbsent(database);
 
     const firstVersionedSourceId = `lifecycle:generation-1:${legacySourceId}`;
     expect(
@@ -232,16 +235,10 @@ describe("audit event source adoption", () => {
 
   it("does not materialize the lazy adoption table during cleanup", () => {
     const database = createDatabaseOptions();
-    const tableQuery =
-      "SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = 'audit_event_source_adoptions'";
-    const { db } = openOpenClawStateDatabase(database);
-    db.exec("DROP TABLE audit_event_source_adoptions");
-    closeOpenClawStateDatabaseForTest();
-    expect(openOpenClawStateDatabase(database).db.prepare(tableQuery).get()).toBeUndefined();
-    closeOpenClawStateDatabaseForTest();
+    expectAdoptionTableAbsent(database);
 
     pruneExpiredAuditEvents({ database });
 
-    expect(openOpenClawStateDatabase(database).db.prepare(tableQuery).get()).toBeUndefined();
+    expectAdoptionTableAbsent(database);
   });
 });

--- a/src/audit/audit-event-source-adoption.test.ts
+++ b/src/audit/audit-event-source-adoption.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { pruneExpiredAuditEvents, recordAuditEvent } from "./audit-event-store.js";
+import type { AuditEventInput } from "./audit-event-types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const AUDIT_EVENT_RETENTION_MS_CONTRACT = 30 * 24 * 60 * 60_000;
+
+function createDatabaseOptions() {
+  return { env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-audit-adoption-") } };
+}
+
+function auditInput(overrides: Partial<AuditEventInput> = {}): AuditEventInput {
+  const input = {
+    sourceSequence: 1,
+    occurredAt: Date.now(),
+    kind: "agent_run",
+    action: "agent.run.started",
+    status: "started",
+    actorType: "agent",
+    actorId: "main",
+    agentId: "main",
+    sessionKey: "agent:main:main",
+    sessionId: "session-1",
+    runId: "run-1",
+    ...overrides,
+  };
+  return {
+    ...input,
+    sourceId:
+      overrides.sourceId ??
+      `${input.runId}:${input.sourceSequence}:${input.occurredAt}:${input.action}`,
+  } as AuditEventInput;
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("audit event source adoption", () => {
+  it("adopts one equivalent generation-aware replay against a shipped legacy source key", () => {
+    const database = createDatabaseOptions();
+    const occurredAt = Date.now();
+    const legacySourceId = `run-legacy:1:${occurredAt}:agent.run.started`;
+    expect(
+      recordAuditEvent(
+        auditInput({ sourceId: legacySourceId, sourceSequence: 1, occurredAt }),
+        database,
+      ),
+    ).toBeDefined();
+    const { db: legacyDb } = openOpenClawStateDatabase(database);
+    legacyDb.exec("DROP TABLE audit_event_source_adoptions");
+    closeOpenClawStateDatabaseForTest();
+
+    expect(
+      recordAuditEvent(
+        auditInput({
+          sourceId: `lifecycle:generation-1:${legacySourceId}`,
+          legacySourceId,
+          sourceSequence: 1,
+          occurredAt,
+        }),
+        database,
+      ),
+    ).toBeUndefined();
+    expect(
+      recordAuditEvent(
+        auditInput({
+          sourceId: `lifecycle:generation-1:${legacySourceId}`,
+          legacySourceId,
+          sourceSequence: 1,
+          occurredAt,
+          actorId: "changed-after-adoption",
+        }),
+        database,
+      ),
+    ).toBeUndefined();
+    closeOpenClawStateDatabaseForTest();
+    expect(
+      recordAuditEvent(
+        auditInput({
+          sourceId: `lifecycle:generation-2:${legacySourceId}`,
+          legacySourceId,
+          sourceSequence: 1,
+          occurredAt,
+        }),
+        database,
+      ),
+    ).toBeDefined();
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(
+      db
+        .prepare("SELECT source_id FROM audit_events ORDER BY sequence")
+        .all()
+        .map((row) => (row as { source_id: string }).source_id),
+    ).toEqual([legacySourceId, `lifecycle:generation-2:${legacySourceId}`]);
+    expect(db.prepare("SELECT * FROM audit_event_source_adoptions").all()).toEqual([
+      {
+        legacy_source_id: legacySourceId,
+        adopted_source_id: `lifecycle:generation-1:${legacySourceId}`,
+      },
+    ]);
+  });
+
+  it("adopts an equivalent tool replay when the tool name is absent", () => {
+    const database = createDatabaseOptions();
+    const occurredAt = Date.now();
+    const legacySourceId = `run-tool:1:${occurredAt}:tool.action.started`;
+    // Recreate the shipped row shape that allowed tool_name to remain NULL
+    // before current producers enforced a normalized tool name.
+    const legacyInput = auditInput({
+      sourceId: legacySourceId,
+      sourceSequence: 1,
+      occurredAt,
+      kind: "tool_action",
+      action: "tool.action.started",
+      status: "started",
+      toolCallId: "call-1",
+    });
+    expect(recordAuditEvent(legacyInput, database)).toBeDefined();
+    const { db: legacyDb } = openOpenClawStateDatabase(database);
+    legacyDb.exec("DROP TABLE audit_event_source_adoptions");
+    closeOpenClawStateDatabaseForTest();
+
+    const replayInput = {
+      ...legacyInput,
+      sourceId: `tool:generation-1:${legacySourceId}`,
+      legacySourceId,
+      toolName: "bash",
+    } as AuditEventInput;
+    expect(recordAuditEvent(replayInput, database)).toBeUndefined();
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(db.prepare("SELECT source_id FROM audit_events").all()).toEqual([
+      { source_id: legacySourceId },
+    ]);
+  });
+
+  it("reserves a legacy source for the first non-equivalent versioned event", () => {
+    const database = createDatabaseOptions();
+    const occurredAt = Date.now();
+    const legacySourceId = `run-reserved:1:${occurredAt}:agent.run.started`;
+    expect(
+      recordAuditEvent(
+        auditInput({ sourceId: legacySourceId, sourceSequence: 1, occurredAt }),
+        database,
+      ),
+    ).toBeDefined();
+    const { db: legacyDb } = openOpenClawStateDatabase(database);
+    legacyDb.exec("DROP TABLE audit_event_source_adoptions");
+    closeOpenClawStateDatabaseForTest();
+
+    const firstVersionedSourceId = `lifecycle:generation-1:${legacySourceId}`;
+    expect(
+      recordAuditEvent(
+        auditInput({
+          sourceId: firstVersionedSourceId,
+          legacySourceId,
+          sourceSequence: 1,
+          occurredAt,
+          actorId: "generation-1",
+          agentId: "generation-1",
+        }),
+        database,
+      ),
+    ).toBeDefined();
+    const secondVersionedSourceId = `lifecycle:generation-2:${legacySourceId}`;
+    expect(
+      recordAuditEvent(
+        auditInput({
+          sourceId: secondVersionedSourceId,
+          legacySourceId,
+          sourceSequence: 1,
+          occurredAt,
+        }),
+        database,
+      ),
+    ).toBeDefined();
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(
+      db
+        .prepare("SELECT source_id FROM audit_events ORDER BY sequence")
+        .all()
+        .map((row) => (row as { source_id: string }).source_id),
+    ).toEqual([legacySourceId, firstVersionedSourceId, secondVersionedSourceId]);
+    expect(db.prepare("SELECT * FROM audit_event_source_adoptions").all()).toEqual([
+      {
+        legacy_source_id: legacySourceId,
+        adopted_source_id: firstVersionedSourceId,
+      },
+    ]);
+  });
+
+  it("prunes orphaned source adoptions after a process restart", () => {
+    const database = createDatabaseOptions();
+    const occurredAt = Date.now();
+    const legacySourceId = `run-expired:1:${occurredAt}:agent.run.started`;
+    expect(
+      recordAuditEvent(
+        auditInput({ sourceId: legacySourceId, sourceSequence: 1, occurredAt }),
+        database,
+      ),
+    ).toBeDefined();
+    expect(
+      recordAuditEvent(
+        auditInput({
+          sourceId: `lifecycle:generation-1:${legacySourceId}`,
+          legacySourceId,
+          sourceSequence: 1,
+          occurredAt,
+        }),
+        database,
+      ),
+    ).toBeUndefined();
+    closeOpenClawStateDatabaseForTest();
+
+    pruneExpiredAuditEvents({
+      database,
+      now: occurredAt + AUDIT_EVENT_RETENTION_MS_CONTRACT + 1,
+    });
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(db.prepare("SELECT source_id FROM audit_events").all()).toEqual([]);
+    expect(db.prepare("SELECT * FROM audit_event_source_adoptions").all()).toEqual([]);
+  });
+
+  it("does not materialize the lazy adoption table during cleanup", () => {
+    const database = createDatabaseOptions();
+    const tableQuery =
+      "SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = 'audit_event_source_adoptions'";
+    const { db } = openOpenClawStateDatabase(database);
+    db.exec("DROP TABLE audit_event_source_adoptions");
+    closeOpenClawStateDatabaseForTest();
+    expect(openOpenClawStateDatabase(database).db.prepare(tableQuery).get()).toBeUndefined();
+    closeOpenClawStateDatabaseForTest();
+
+    pruneExpiredAuditEvents({ database });
+
+    expect(openOpenClawStateDatabase(database).db.prepare(tableQuery).get()).toBeUndefined();
+  });
+});

--- a/src/audit/audit-event-source-adoption.ts
+++ b/src/audit/audit-event-source-adoption.ts
@@ -1,0 +1,156 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { normalizeSqliteNumber } from "../infra/sqlite-number.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import type { AuditEventInput } from "./audit-event-types.js";
+
+type AuditDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "audit_events" | "audit_event_source_adoptions"
+>;
+
+const schemaEnsured = new WeakSet<DatabaseSync>();
+
+function getAuditKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<AuditDatabase>(db);
+}
+
+function pruneOrphanedSourceAdoptions(db: DatabaseSync): void {
+  const kysely = getAuditKysely(db);
+  executeSqliteQuerySync(
+    db,
+    kysely
+      .deleteFrom("audit_event_source_adoptions")
+      .where((expression) =>
+        expression.not(
+          expression.exists(
+            expression
+              .selectFrom("audit_events")
+              .select("sequence")
+              .whereRef(
+                "audit_events.source_id",
+                "=",
+                "audit_event_source_adoptions.legacy_source_id",
+              ),
+          ),
+        ),
+      ),
+  );
+}
+
+export function ensureAuditEventSourceAdoptionSchema(options: OpenClawStateDatabaseOptions): void {
+  const database = openOpenClawStateDatabase(options);
+  if (schemaEnsured.has(database.db)) {
+    return;
+  }
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      db.exec(/* sqlite-allow-raw -- Feature-local additive schema DDL; rows use Kysely. */ `
+        CREATE TABLE IF NOT EXISTS audit_event_source_adoptions (
+          legacy_source_id TEXT NOT NULL PRIMARY KEY,
+          adopted_source_id TEXT NOT NULL
+        ) STRICT
+      `);
+      pruneOrphanedSourceAdoptions(db);
+    },
+    options,
+    { operationLabel: "audit-event-source-adoptions.schema.ensure" },
+  );
+  schemaEnsured.add(database.db);
+}
+
+export function pruneAuditEventSourceAdoptions(db: DatabaseSync): void {
+  if (!schemaEnsured.has(db)) {
+    if (!tableExists(db, "audit_event_source_adoptions")) {
+      return;
+    }
+    schemaEnsured.add(db);
+  }
+  pruneOrphanedSourceAdoptions(db);
+}
+
+export function adoptsEquivalentLegacyAuditEvent(
+  db: DatabaseSync,
+  input: AuditEventInput,
+): boolean {
+  if (input.kind === "message") {
+    return false;
+  }
+  const legacySourceId = input.legacySourceId;
+  if (!legacySourceId || legacySourceId === input.sourceId) {
+    return false;
+  }
+  const legacy = executeSqliteQueryTakeFirstSync(
+    db,
+    getAuditKysely(db)
+      .selectFrom("audit_events")
+      .selectAll()
+      .where("source_id", "=", legacySourceId)
+      .limit(1),
+  );
+  if (!legacy) {
+    return false;
+  }
+  const kysely = getAuditKysely(db);
+  const existing = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely
+      .selectFrom("audit_event_source_adoptions")
+      .select("adopted_source_id")
+      .where("legacy_source_id", "=", legacySourceId)
+      .limit(1),
+  );
+  if (existing) {
+    return existing.adopted_source_id === input.sourceId;
+  }
+  const toolNameEquivalent =
+    input.kind === "tool_action"
+      ? legacy.tool_name === null || legacy.tool_name === (input.toolName ?? null)
+      : legacy.tool_name === null;
+  const equivalent =
+    normalizeSqliteNumber(legacy.source_sequence) === input.sourceSequence &&
+    normalizeSqliteNumber(legacy.occurred_at) === input.occurredAt &&
+    legacy.kind === input.kind &&
+    legacy.action === input.action &&
+    legacy.status === input.status &&
+    legacy.error_code === (input.errorCode ?? null) &&
+    legacy.actor_type === input.actorType &&
+    legacy.actor_id === input.actorId &&
+    legacy.agent_id === input.agentId &&
+    legacy.session_key === (input.sessionKey ?? null) &&
+    legacy.session_id === (input.sessionId ?? null) &&
+    legacy.run_id === input.runId &&
+    legacy.tool_call_id === (input.kind === "tool_action" ? (input.toolCallId ?? null) : null) &&
+    toolNameEquivalent;
+  // Reserve the legacy key for the first versioned claimant even when it differs.
+  // Otherwise a later generation that happens to match the old row could be dropped.
+  const adopted = executeSqliteQuerySync(
+    db,
+    kysely
+      .insertInto("audit_event_source_adoptions")
+      .values({ legacy_source_id: legacySourceId, adopted_source_id: input.sourceId })
+      .onConflict((conflict) => conflict.column("legacy_source_id").doNothing()),
+  );
+  if (Number(adopted.numAffectedRows ?? 0n) > 0) {
+    return equivalent;
+  }
+  const raced = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely
+      .selectFrom("audit_event_source_adoptions")
+      .select("adopted_source_id")
+      .where("legacy_source_id", "=", legacySourceId)
+      .limit(1),
+  );
+  return raced?.adopted_source_id === input.sourceId;
+}

--- a/src/audit/audit-event-store.ts
+++ b/src/audit/audit-event-store.ts
@@ -15,6 +15,11 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import {
+  adoptsEquivalentLegacyAuditEvent,
+  ensureAuditEventSourceAdoptionSchema,
+  pruneAuditEventSourceAdoptions,
+} from "./audit-event-source-adoption.js";
+import {
   AUDIT_EVENT_SCHEMA_VERSION,
   AUDIT_INBOUND_MESSAGE_COMPLETED_REASONS,
   AUDIT_INBOUND_MESSAGE_SKIPPED_REASONS,
@@ -551,6 +556,9 @@ function pruneAuditEventsAfterInsert(
       : Math.max(0, cachedCount + 1 - Number(expired.numAffectedRows ?? 0n));
   if (rowCount <= limits.maxRows) {
     auditEventRowCounts.set(db, rowCount);
+    if (expired.numAffectedRows) {
+      pruneAuditEventSourceAdoptions(db);
+    }
     return;
   }
   const retainedRows = Math.max(0, limits.maxRows - limits.pruneBatchRows);
@@ -572,6 +580,7 @@ function pruneAuditEventsAfterInsert(
     rowCount = Math.max(0, rowCount - Number(pruned.numAffectedRows ?? 0n));
   }
   auditEventRowCounts.set(db, rowCount);
+  pruneAuditEventSourceAdoptions(db);
 }
 
 /** Persist one projected event idempotently and prune fixed retention bounds. */
@@ -581,8 +590,17 @@ export function recordAuditEvent(
 ): AuditEventRecord | undefined {
   let countCacheDatabase: DatabaseSync | undefined;
   try {
+    if (input.kind !== "message" && input.legacySourceId) {
+      ensureAuditEventSourceAdoptionSchema(options);
+    }
     return runOpenClawStateWriteTransaction(({ db }) => {
       countCacheDatabase = db;
+      // The shipped row remains immutable. The first versioned claimant reserves
+      // its legacy key; equivalent input adopts the old row, while non-equivalent
+      // input persists normally without letting a later generation claim it.
+      if (adoptsEquivalentLegacyAuditEvent(db, input)) {
+        return undefined;
+      }
       const insert = executeSqliteQuerySync(
         db,
         getAuditKysely(db)
@@ -690,6 +708,7 @@ export function pruneExpiredAuditEvents(
         .deleteFrom("audit_events")
         .where("occurred_at", "<", (params.now ?? Date.now()) - AUDIT_EVENT_RETENTION_MS),
     );
+    pruneAuditEventSourceAdoptions(db);
     auditEventRowCounts.delete(db);
   }, params.database);
 }

--- a/src/audit/audit-event-types.ts
+++ b/src/audit/audit-event-types.ts
@@ -57,6 +57,8 @@ export type AuditOutboundMessageSuppressedReasonCode =
 type AuditEventInputBase = {
   /** Stable trusted-source identity used only for local replay deduplication. */
   sourceId: string;
+  /** Shipped generation-less identity adopted by the first versioned replay. */
+  legacySourceId?: string;
   sourceSequence: number;
   occurredAt: number;
 };

--- a/src/audit/audit-event-writer.test.ts
+++ b/src/audit/audit-event-writer.test.ts
@@ -550,4 +550,30 @@ describe("audit event worker", () => {
       inspectExecutionIdentityRun({ runId: "after-key-loss" }, database).identity,
     ).toMatchObject({ state: "unknown", reasonCode: "run_not_found" });
   });
+
+  it("accepts bounded final records after the live queue fills", async () => {
+    const stateDir = tempDirs.make("openclaw-audit-writer-final-");
+    const database = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const errors: string[] = [];
+    const writer = createAuditEventWriter({
+      stateDir,
+      maxPending: 1,
+      onError: (error) => errors.push(error),
+    });
+    await writer.ready;
+    const { db } = openOpenClawStateDatabase(database);
+    const finalInput = input();
+    finalInput.sourceId = "run-2:2:started";
+    finalInput.sourceSequence = 2;
+    finalInput.runId = "run-2";
+    db.exec("BEGIN IMMEDIATE");
+    expect(writer.record(input())).toBe(true);
+    expect(writer.record(finalInput)).toBe(false);
+    const stopped = writer.stop([finalInput]);
+    db.exec("ROLLBACK");
+
+    await stopped;
+    expect(errors).toEqual(["audit event queue is full (1); dropping metadata"]);
+    expect(listAuditEvents({ database, limit: 10 }).events).toHaveLength(2);
+  });
 });

--- a/src/audit/audit-event-writer.ts
+++ b/src/audit/audit-event-writer.ts
@@ -21,12 +21,18 @@ type AuditWriterMessage =
   | { type: "maintenance-error"; error: string }
   | { type: "stopped" };
 
+type AuditWriterWorkMessage =
+  | { type: "record-event"; input: AuditEventInput }
+  | { type: "record-execution-identity"; work: ExecutionIdentityAdmissionWork };
+
+type AuditWriterCommand = AuditWriterWorkMessage | { type: "stop" };
+
 export type AuditEventWriter = {
   ready: Promise<void>;
   record: (input: AuditEventInput) => boolean;
   /** Reports only queue acceptance; persistence succeeds or fails asynchronously. */
   recordExecutionIdentity: (work: ExecutionIdentityAdmissionWork) => boolean;
-  stop: () => Promise<void>;
+  stop: (finalInputs?: readonly AuditEventInput[]) => Promise<void>;
 };
 
 function formatAuditWriterError(error: unknown): string {
@@ -107,12 +113,13 @@ export function createAuditEventWriter(
   const fail = (error: unknown) => {
     options.onError?.(formatAuditWriterError(error));
   };
+  const postToWorker = (message: AuditWriterCommand) => {
+    // Node Worker.postMessage is not the browser Window API and has no targetOrigin.
+    // oxlint-disable-next-line unicorn/require-post-message-target-origin
+    worker.postMessage(message);
+  };
 
-  const enqueue = (
-    message:
-      | { type: "record-event"; input: AuditEventInput }
-      | { type: "record-execution-identity"; work: ExecutionIdentityAdmissionWork },
-  ): boolean => {
+  const enqueue = (message: AuditWriterWorkMessage): boolean => {
     if (stopped || unavailable || pending >= maxPending) {
       if (!stopped) {
         fail(
@@ -125,9 +132,7 @@ export function createAuditEventWriter(
     }
     pending += 1;
     try {
-      // Node Worker.postMessage is not the browser Window API and has no targetOrigin.
-      // oxlint-disable-next-line unicorn/require-post-message-target-origin
-      worker.postMessage(message);
+      postToWorker(message);
       return true;
     } catch (error) {
       pending -= 1;
@@ -140,6 +145,9 @@ export function createAuditEventWriter(
       }
       return false;
     }
+  };
+  const postFinalRecord = (input: AuditEventInput) => {
+    postToWorker({ type: "record-event", input });
   };
 
   worker.on("message", (message: AuditWriterMessage) => {
@@ -182,13 +190,26 @@ export function createAuditEventWriter(
     ready,
     record: (input) => enqueue({ type: "record-event", input }),
     recordExecutionIdentity: (work) => enqueue({ type: "record-execution-identity", work }),
-    stop: async () => {
+    stop: async (finalInputs = []) => {
       if (stopped) {
         return;
       }
       stopped = true;
       if (unavailable) {
         return;
+      }
+      for (const input of finalInputs) {
+        pending += 1;
+        try {
+          // Shutdown records bypass the live queue cap but retain worker message
+          // ordering, so the following stop drains them before exit.
+          postFinalRecord(input);
+        } catch (error) {
+          pending -= 1;
+          unavailable = true;
+          fail(error);
+          return;
+        }
       }
       await new Promise<void>((resolve) => {
         resolveStop = resolve;
@@ -198,9 +219,7 @@ export function createAuditEventWriter(
           finishStop();
         }, AUDIT_WRITER_SHUTDOWN_TIMEOUT_MS);
         try {
-          // Node Worker.postMessage is not the browser Window API and has no targetOrigin.
-          // oxlint-disable-next-line unicorn/require-post-message-target-origin
-          worker.postMessage({ type: "stop" });
+          postToWorker({ type: "stop" });
         } catch (error) {
           fail(error);
           finishStop();

--- a/src/audit/audit-events.test.ts
+++ b/src/audit/audit-events.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
-import type { AgentEventPayload } from "../infra/agent-events.js";
+import {
+  getAgentEventLifecycleGeneration,
+  resetAgentEventsForTest,
+  rotateAgentEventLifecycleGeneration,
+  type AgentEventPayload,
+} from "../infra/agent-events.js";
+import { retireAgentRunContext } from "../infra/agent-run-context-retirement.js";
 import {
   emitTrustedDiagnosticEvent,
   onTrustedToolExecutionEvent,
@@ -113,6 +119,7 @@ function projectToolExecutionEventToAudit(
 }
 
 beforeEach(() => {
+  resetAgentEventsForTest();
   currentAuditTestRunId = `run-test-${++auditTestRunSequence}`;
 });
 
@@ -302,12 +309,15 @@ describe("agent activity audit projection", () => {
     });
   });
 
-  it("keeps a valid unknown agent id distinct from missing provenance", () => {
+  it("keeps a valid unknown agent id distinct from missing provenance", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
     const runId = "run-agent-named-unknown";
-    const started = projectAgentEventToAudit(
-      agentEvent({ runId, sessionKey: "global", agentId: "unknown" }),
-    );
-    const finished = projectAgentEventToAudit(
+    recorder.record(agentEvent({ runId, sessionKey: "global", agentId: "unknown" }));
+    recorder.record(
       agentEvent({
         runId,
         seq: 2,
@@ -317,7 +327,7 @@ describe("agent activity audit projection", () => {
         data: { phase: "end" },
       }),
     );
-    const tool = projectToolExecutionEventToAudit(
+    recorder.recordTool(
       toolEvent({
         runId,
         seq: 3,
@@ -326,7 +336,7 @@ describe("agent activity audit projection", () => {
         agentId: undefined,
       }),
     );
-    const missing = projectAgentEventToAudit(
+    recorder.record(
       agentEvent({
         runId: "run-missing-provenance",
         sessionKey: undefined,
@@ -334,6 +344,15 @@ describe("agent activity audit projection", () => {
         agentId: undefined,
       }),
     );
+    await recorder.stop();
+    const started = inputs.find(
+      (input) => input.runId === runId && input.action === "agent.run.started",
+    );
+    const finished = inputs.find(
+      (input) => input.runId === runId && input.action === "agent.run.finished",
+    );
+    const tool = inputs.find((input) => input.runId === runId && input.kind === "tool_action");
+    const missing = inputs.find((input) => input.runId === "run-missing-provenance");
 
     expect([started, finished, tool]).toEqual([
       expect.objectContaining({ actorType: "agent", actorId: "unknown", agentId: "unknown" }),
@@ -348,8 +367,10 @@ describe("agent activity audit projection", () => {
   });
 
   it("keeps tool actions on the canonical lifecycle session", () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({ writer: captureAuditWriter(inputs) });
     const runId = "run-channel-routed";
-    projectAgentEventToAudit(
+    recorder.record(
       agentEvent({
         runId,
         sessionKey: "agent:support:channel:customer",
@@ -358,7 +379,7 @@ describe("agent activity audit projection", () => {
       }),
     );
 
-    const projected = projectToolExecutionEventToAudit(
+    recorder.recordTool(
       toolEvent({
         runId,
         sessionKey: "agent:main:sandbox:temporary",
@@ -366,12 +387,71 @@ describe("agent activity audit projection", () => {
         agentId: "main",
       }),
     );
+    void recorder.stop();
+    const projected = inputs.find((input) => input.kind === "tool_action");
 
     expect(projected).toMatchObject({
       actorId: "support",
       agentId: "support",
       sessionKey: "agent:support:channel:customer",
       sessionId: "session-canonical",
+    });
+  });
+
+  it("keeps admitted provenance when a completed instance starts again", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({ writer: captureAuditWriter(inputs) });
+    const runId = "run-completed-start-replay";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        sessionKey: "agent:admitted:main",
+        agentId: "admitted",
+      }),
+    );
+    recorder.record(agentEvent({ runId, lifecycleGeneration, seq: 2, data: { phase: "end" } }));
+    expect(inputs.filter((input) => input.action === "agent.run.finished")).toHaveLength(1);
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 3,
+        sessionKey: "agent:replay:main",
+        agentId: "replay",
+      }),
+    );
+    rotateAgentEventLifecycleGeneration();
+    recorder.record(
+      agentEvent({
+        runId,
+        lifecycleGeneration,
+        seq: 4,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    recorder.recordTool(
+      toolEvent({
+        runId,
+        seq: 5,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.filter((input) => input.action === "agent.run.started")).toHaveLength(2);
+    expect(inputs.filter((input) => input.action === "agent.run.finished")).toHaveLength(2);
+    expect(inputs.findLast((input) => input.kind === "tool_action")).toMatchObject({
+      actorId: "admitted",
+      agentId: "admitted",
+      sessionKey: "agent:admitted:main",
     });
   });
 
@@ -413,12 +493,12 @@ describe("agent activity audit projection", () => {
   });
 
   it("omits prompt, arguments, results, and raw errors from run and tool records", () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({ writer: captureAuditWriter(inputs) });
     const secret = "super-secret-payload";
-    projectAgentEventToAudit(agentEvent({ data: { phase: "start", prompt: secret }, seq: 1 }));
-    const started = projectToolExecutionEventToAudit(
-      toolEvent({ seq: 2, sessionKey: undefined, sessionId: undefined }),
-    );
-    const failed = projectToolExecutionEventToAudit(
+    recorder.record(agentEvent({ data: { phase: "start", prompt: secret }, seq: 1 }));
+    recorder.recordTool(toolEvent({ seq: 2, sessionKey: undefined, sessionId: undefined }));
+    recorder.recordTool(
       toolEvent({
         type: "tool.execution.error",
         seq: 3,
@@ -428,6 +508,10 @@ describe("agent activity audit projection", () => {
         errorCategory: secret,
         errorCode: secret,
       }),
+    );
+    void recorder.stop();
+    const [started, failed] = inputs.filter(
+      (input): input is ToolActionAuditEventInput => input.kind === "tool_action",
     );
 
     expect(started).toMatchObject({
@@ -640,7 +724,7 @@ describe("agent activity audit projection", () => {
       stop: async () => {},
     };
     const recorder = createAgentEventAuditRecorder({ writer });
-    const lifecycleGeneration = "gateway-1";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
 
     recorder.record(agentEvent({ lifecycleGeneration, seq: 1 }));
     recorder.record(
@@ -659,6 +743,274 @@ describe("agent activity audit projection", () => {
     ]);
   });
 
+  it("preserves settled attempts rejected by the writer across later starts", async () => {
+    const inputs: AuditEventInput[] = [];
+    let rejectedTerminalCount = 0;
+    const writer: AuditEventWriter = {
+      ready: Promise.resolve(),
+      record: (input) => {
+        if (input.action === "agent.run.finished") {
+          rejectedTerminalCount += 1;
+          return false;
+        }
+        inputs.push(input);
+        return true;
+      },
+      recordExecutionIdentity: () => true,
+      stop: async (finalInputs = []) => {
+        inputs.push(...finalInputs);
+      },
+    };
+    const recorder = createAgentEventAuditRecorder({ writer });
+
+    recorder.record(agentEvent({ seq: 1 }));
+    recorder.record(agentEvent({ seq: 2, data: { phase: "end" } }));
+    expect(rejectedTerminalCount).toBe(1);
+    recorder.record(agentEvent({ seq: 3 }));
+    recorder.record(agentEvent({ seq: 4, data: { phase: "end" } }));
+    expect(rejectedTerminalCount).toBe(2);
+    await recorder.stop();
+
+    expect(inputs.map((input) => input.action)).toEqual([
+      "agent.run.started",
+      "agent.run.started",
+      "agent.run.finished",
+      "agent.run.finished",
+    ]);
+    expect(
+      inputs
+        .filter((input) => input.action === "agent.run.finished")
+        .map((input) => input.sourceSequence),
+    ).toEqual([2, 4]);
+  });
+
+  it("drops rejected retries after the same attempt settles", async () => {
+    const inputs: AuditEventInput[] = [];
+    let rejectFirstTerminal = true;
+    const writer: AuditEventWriter = {
+      ready: Promise.resolve(),
+      record: (input) => {
+        if (input.action === "agent.run.finished" && rejectFirstTerminal) {
+          rejectFirstTerminal = false;
+          return false;
+        }
+        inputs.push(input);
+        return true;
+      },
+      recordExecutionIdentity: () => true,
+      stop: async (finalInputs = []) => {
+        inputs.push(...finalInputs);
+      },
+    };
+    const recorder = createAgentEventAuditRecorder({ writer });
+
+    recorder.record(agentEvent({ seq: 1 }));
+    recorder.record(agentEvent({ seq: 2, data: { phase: "end" } }));
+    recorder.record(agentEvent({ seq: 3, data: { phase: "end" } }));
+    await recorder.stop();
+
+    expect(
+      inputs
+        .filter((input) => input.action === "agent.run.finished")
+        .map((input) => input.sourceSequence),
+    ).toEqual([3]);
+  });
+
+  it("keeps terminal arbitration stable across queue rejection", async () => {
+    const inputs: AuditEventInput[] = [];
+    let rejectFirstTerminal = true;
+    const writer: AuditEventWriter = {
+      ready: Promise.resolve(),
+      record: (input) => {
+        if (input.action === "agent.run.finished" && rejectFirstTerminal) {
+          rejectFirstTerminal = false;
+          return false;
+        }
+        inputs.push(input);
+        return true;
+      },
+      recordExecutionIdentity: () => true,
+      stop: async (finalInputs = []) => {
+        inputs.push(...finalInputs);
+      },
+    };
+    const recorder = createAgentEventAuditRecorder({ writer, terminalSettleMs: 0 });
+
+    recorder.record(agentEvent({ seq: 1 }));
+    recorder.record(agentEvent({ seq: 2, data: { phase: "error" } }));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 5);
+    });
+    recorder.record(agentEvent({ seq: 3, data: { phase: "end" } }));
+    await recorder.stop();
+
+    expect(inputs.filter((input) => input.action === "agent.run.finished")).toEqual([
+      expect.objectContaining({
+        sourceSequence: 2,
+        status: "failed",
+        errorCode: "run_failed",
+      }),
+    ]);
+  });
+
+  it("bounds rejected immediate terminals before shutdown handoff", async () => {
+    let finalInputs: readonly AuditEventInput[] = [];
+    const writer: AuditEventWriter = {
+      ready: Promise.resolve(),
+      record: () => false,
+      recordExecutionIdentity: () => true,
+      stop: async (inputs = []) => {
+        finalInputs = inputs;
+      },
+    };
+    const recorder = createAgentEventAuditRecorder({ writer, terminalSettleMs: 0 });
+
+    for (let index = 0; index < 1_025; index += 1) {
+      recorder.record(
+        agentEvent({
+          runId: `rejected-immediate-${index}`,
+          data: { phase: "end" },
+        }),
+      );
+    }
+    await recorder.stop();
+
+    expect(finalInputs).toHaveLength(1_024);
+    expect(finalInputs[0]?.runId).toBe("rejected-immediate-1");
+  });
+
+  it("bounds provenance retained for malformed direct starts without an owner", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const runId = "run-unowned-synthetic";
+
+    recorder.record(
+      agentEvent({
+        runId,
+        sessionKey: "agent:synthetic:main",
+        agentId: "synthetic",
+      }),
+    );
+    for (let index = 0; index < 1_024; index += 1) {
+      recorder.record(agentEvent({ runId: `run-unowned-pressure-${index}` }));
+    }
+    recorder.record(
+      agentEvent({
+        runId,
+        seq: 2,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "end" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.runId === runId)).toMatchObject({
+      action: "agent.run.finished",
+      actorType: "system",
+      actorId: "unknown",
+      agentId: "unknown",
+    });
+  });
+
+  it("keeps pending terminals at the unowned open-run bound", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 60_000,
+    });
+    const runId = "run-pending-under-provenance-pressure";
+
+    recorder.record(agentEvent({ runId, seq: 1 }));
+    recorder.record(agentEvent({ runId, seq: 2, data: { phase: "error" } }));
+    for (let index = 0; index < 1_024; index += 1) {
+      recorder.record(agentEvent({ runId: `run-pending-pressure-${index}` }));
+    }
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.runId === runId)).toMatchObject({
+      action: "agent.run.finished",
+      sourceSequence: 2,
+      status: "failed",
+    });
+  });
+
+  it("bounds unowned provenance when every candidate has terminal state", async () => {
+    const inputs: AuditEventInput[] = [];
+    let rejectTerminals = true;
+    const writer: AuditEventWriter = {
+      ready: Promise.resolve(),
+      record: (input) => {
+        if (input.action === "agent.run.finished" && rejectTerminals) {
+          return false;
+        }
+        inputs.push(input);
+        return true;
+      },
+      recordExecutionIdentity: () => true,
+      stop: async (finalInputs = []) => {
+        inputs.push(...finalInputs);
+      },
+    };
+    const recorder = createAgentEventAuditRecorder({ writer, terminalSettleMs: 60_000 });
+
+    for (let index = 0; index < 1_024; index += 1) {
+      const runId = `run-protected-pending-${index}`;
+      recorder.record(agentEvent({ runId, seq: 1 }));
+      recorder.record(agentEvent({ runId, seq: 2, data: { phase: "error" } }));
+    }
+    recorder.record(
+      agentEvent({ runId: "run-protected-rejected", seq: 1, data: { phase: "end" } }),
+    );
+    recorder.record(agentEvent({ runId: "run-protected-rejected", seq: 2 }));
+
+    rejectTerminals = false;
+    recorder.record(
+      agentEvent({
+        runId: "run-protected-pending-0",
+        seq: 3,
+        sessionKey: undefined,
+        sessionId: undefined,
+        agentId: undefined,
+        data: { phase: "error" },
+      }),
+    );
+    await recorder.stop();
+
+    expect(inputs.findLast((input) => input.runId === "run-protected-pending-0")).toMatchObject({
+      action: "agent.run.finished",
+      actorType: "system",
+      actorId: "unknown",
+      agentId: "unknown",
+    });
+  });
+
+  it("fully evicts retired open runs when the tombstone cap is exceeded", async () => {
+    const inputs: AuditEventInput[] = [];
+    const recorder = createAgentEventAuditRecorder({
+      writer: captureAuditWriter(inputs),
+      terminalSettleMs: 0,
+    });
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const firstRunId = "run-retired-cap-0";
+
+    for (let index = 0; index < 1_025; index += 1) {
+      const runId = `run-retired-cap-${index}`;
+      recorder.record(agentEvent({ runId, lifecycleGeneration }));
+      retireAgentRunContext(runId, lifecycleGeneration, "replaced");
+    }
+    recorder.record(agentEvent({ runId: firstRunId, lifecycleGeneration, seq: 2 }));
+    await recorder.stop();
+
+    expect(
+      inputs.filter((input) => input.runId === firstRunId && input.action === "agent.run.started"),
+    ).toHaveLength(2);
+  });
+
   it("keeps one start when a retry cancels a pending terminal", async () => {
     const inputs: AuditEventInput[] = [];
     const writer: AuditEventWriter = {
@@ -671,7 +1023,7 @@ describe("agent activity audit projection", () => {
       stop: async () => {},
     };
     const recorder = createAgentEventAuditRecorder({ writer, terminalSettleMs: 60_000 });
-    const lifecycleGeneration = "gateway-retry";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
 
     recorder.record(agentEvent({ lifecycleGeneration, seq: 1 }));
     recorder.record(agentEvent({ lifecycleGeneration, seq: 2, data: { phase: "error" } }));

--- a/src/auto-reply/reply/agent-runner-execution-runtime.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-runtime.test.ts
@@ -105,36 +105,6 @@ describe("executeAgentTurn: runtime selection", () => {
     });
   });
 
-  it("preserves one admission attribution across model fallback candidates", async () => {
-    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
-      await params.run("openai", "gpt-5.4");
-      const result = await params.run("anthropic", "claude-opus-4-7");
-      return {
-        result,
-        provider: "anthropic",
-        model: "claude-opus-4-7",
-        attempts: [],
-      };
-    });
-    state.runEmbeddedAgentMock
-      .mockResolvedValueOnce({ payloads: [{ text: "retry" }], meta: {} })
-      .mockResolvedValueOnce({ payloads: [{ text: "final" }], meta: {} });
-
-    const executeAgentTurn = await getExecuteAgentTurnForTest();
-    await executeAgentTurn(
-      createMinimalRunAgentTurnParams({ opts: { runId: "fallback-attribution" } }),
-    );
-
-    const firstAttribution = state.runEmbeddedAgentMock.mock.calls[0]?.[0]?.attribution;
-    expect(firstAttribution).toMatchObject({
-      runId: "fallback-attribution",
-      sessionKey: "main",
-      sessionId: "session",
-    });
-    expect(Object.isFrozen(firstAttribution)).toBe(true);
-    expect(state.runEmbeddedAgentMock.mock.calls[1]?.[0]?.attribution).toBe(firstAttribution);
-  });
-
   it("resolves CLI messageProvider from the live session surface when no origin channel is set", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
@@ -415,6 +385,36 @@ describe("executeAgentTurn: runtime selection", () => {
     } finally {
       uninstallPlacement();
     }
+  });
+
+  it("preserves one admission attribution across model fallback candidates", async () => {
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
+      await params.run("openai", "gpt-5.4");
+      const result = await params.run("anthropic", "claude-opus-4-7");
+      return {
+        result,
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        attempts: [],
+      };
+    });
+    state.runEmbeddedAgentMock
+      .mockResolvedValueOnce({ payloads: [{ text: "retry" }], meta: {} })
+      .mockResolvedValueOnce({ payloads: [{ text: "final" }], meta: {} });
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    await executeAgentTurn(
+      createMinimalRunAgentTurnParams({ opts: { runId: "fallback-attribution" } }),
+    );
+
+    const firstAttribution = state.runEmbeddedAgentMock.mock.calls[0]?.[0]?.attribution;
+    expect(firstAttribution).toMatchObject({
+      runId: "fallback-attribution",
+      sessionKey: "main",
+      sessionId: "session",
+    });
+    expect(Object.isFrozen(firstAttribution)).toBe(true);
+    expect(state.runEmbeddedAgentMock.mock.calls[1]?.[0]?.attribution).toBe(firstAttribution);
   });
 
   it("does not pass CLI runtime overrides as embedded harness ids for fallback providers", async () => {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -788,6 +788,73 @@ describe("tryDispatchAcpReply", () => {
     clearAgentRunContext(runId, replacementGeneration);
   });
 
+  it("captures caller-owned ACP lifecycle before lazy dispatch setup yields", async () => {
+    setReadyAcpResolution();
+    const runId = "caller-reused-during-setup";
+    const admittedGeneration = getAgentEventLifecycleGeneration();
+    claimAgentRunContext(runId, {
+      agentId: "caller",
+      lifecycleGeneration: admittedGeneration,
+      sessionKey,
+    });
+    const admittedToken = getAgentRunContextLifecycleToken(runId, admittedGeneration);
+    let startGeneration: string | undefined;
+    let startToken: object | undefined;
+    let callbackGeneration: string | undefined;
+    let callbackToken: object | undefined;
+    let terminalGeneration: string | undefined;
+    let terminalToken: object | undefined;
+
+    auditMocks.emitAcpLifecycleStart.mockImplementationOnce(
+      (params: { lifecycleGeneration?: string }) => {
+        startGeneration = params.lifecycleGeneration;
+        startToken = getAgentRunExecutionContextLifecycleToken(runId);
+      },
+    );
+    auditMocks.emitAcpRuntimeEvent.mockImplementationOnce(() => {
+      callbackGeneration = getAgentRunExecutionLifecycleGeneration();
+      callbackToken = getAgentRunExecutionContextLifecycleToken(runId);
+    });
+    auditMocks.emitAcpLifecycleEnd.mockImplementationOnce(() => {
+      terminalGeneration = getAgentRunExecutionLifecycleGeneration();
+      terminalToken = getAgentRunExecutionContextLifecycleToken(runId);
+    });
+    managerMocks.runTurn.mockImplementationOnce(
+      async ({ onEvent }: { onEvent?: (event: unknown) => Promise<void> }) => {
+        if (onEvent) {
+          await emitToolLifecycleEvents(onEvent, "tool-after-setup-reuse");
+        }
+      },
+    );
+
+    const dispatch = runDispatch({ bodyForAgent: "audit setup race", runId });
+    const replacementGeneration = rotateAgentEventLifecycleGeneration();
+    claimAgentRunContext(runId, {
+      agentId: "replacement",
+      lifecycleGeneration: replacementGeneration,
+      sessionKey: "agent:replacement:main",
+    });
+    const replacementToken = getAgentRunContextLifecycleToken(runId, replacementGeneration);
+
+    await dispatch;
+
+    expect(admittedToken).toBeTypeOf("object");
+    expect(replacementToken).toBeTypeOf("object");
+    expect(replacementToken).not.toBe(admittedToken);
+    expect(startGeneration).toBe(admittedGeneration);
+    expect(startToken).toBe(admittedToken);
+    expect(callbackGeneration).toBe(admittedGeneration);
+    expect(callbackToken).toBe(admittedToken);
+    expect(terminalGeneration).toBe(admittedGeneration);
+    expect(terminalToken).toBe(admittedToken);
+    expect(getAgentRunContext(runId)).toMatchObject({
+      agentId: "replacement",
+      lifecycleGeneration: replacementGeneration,
+      sessionKey: "agent:replacement:main",
+    });
+    clearAgentRunContext(runId, replacementGeneration);
+  });
+
   it("keeps audit run ids unique when channel message ids repeat", async () => {
     setReadyAcpResolution();
 

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -717,6 +717,77 @@ describe("tryDispatchAcpReply", () => {
     );
   });
 
+  it("keeps delayed caller-owned ACP callbacks on their admitted lifecycle", async () => {
+    setReadyAcpResolution();
+    const runId = "caller-reused-run";
+    const admittedGeneration = getAgentEventLifecycleGeneration();
+    claimAgentRunContext(runId, {
+      agentId: "caller",
+      lifecycleGeneration: admittedGeneration,
+      sessionKey,
+    });
+    const admittedToken = getAgentRunContextLifecycleToken(runId, admittedGeneration);
+    let callbackGeneration: string | undefined;
+    let callbackToken: object | undefined;
+    let terminalGeneration: string | undefined;
+    let terminalToken: object | undefined;
+    let replacementGeneration: string | undefined;
+    let replacementToken: object | undefined;
+
+    auditMocks.emitAcpLifecycleStart.mockImplementationOnce(
+      (params: { lifecycleGeneration?: string; runId: string }) => {
+        if (params.lifecycleGeneration && admittedToken) {
+          captureAgentRunExecutionContextLifecycleToken(
+            params.runId,
+            params.lifecycleGeneration,
+            admittedToken,
+          );
+        }
+      },
+    );
+    auditMocks.emitAcpRuntimeEvent.mockImplementationOnce((params: { runId: string }) => {
+      callbackGeneration = getAgentRunExecutionLifecycleGeneration();
+      callbackToken = getAgentRunExecutionContextLifecycleToken(params.runId);
+    });
+    auditMocks.emitAcpLifecycleEnd.mockImplementationOnce((params: { runId: string }) => {
+      terminalGeneration = getAgentRunExecutionLifecycleGeneration();
+      terminalToken = getAgentRunExecutionContextLifecycleToken(params.runId);
+    });
+    managerMocks.runTurn.mockImplementationOnce(
+      async ({ onEvent }: { onEvent?: (event: unknown) => Promise<void> }) => {
+        replacementGeneration = rotateAgentEventLifecycleGeneration();
+        claimAgentRunContext(runId, {
+          agentId: "replacement",
+          lifecycleGeneration: replacementGeneration,
+          sessionKey: "agent:replacement:main",
+        });
+        replacementToken = getAgentRunContextLifecycleToken(runId, replacementGeneration);
+        if (onEvent) {
+          await emitToolLifecycleEvents(onEvent, "tool-delayed-caller");
+        }
+      },
+    );
+
+    await runDispatch({ bodyForAgent: "audit delayed caller callback", runId });
+
+    expect(auditMocks.emitAcpLifecycleStart).toHaveBeenCalledWith(
+      expect.objectContaining({ runId, lifecycleGeneration: admittedGeneration, auditOnly: false }),
+    );
+    expect(admittedToken).toBeTypeOf("object");
+    expect(replacementToken).toBeTypeOf("object");
+    expect(replacementToken).not.toBe(admittedToken);
+    expect(callbackGeneration).toBe(admittedGeneration);
+    expect(callbackToken).toBe(admittedToken);
+    expect(terminalGeneration).toBe(admittedGeneration);
+    expect(terminalToken).toBe(admittedToken);
+    expect(getAgentRunContext(runId)).toMatchObject({
+      agentId: "replacement",
+      lifecycleGeneration: replacementGeneration,
+      sessionKey: "agent:replacement:main",
+    });
+    clearAgentRunContext(runId, replacementGeneration);
+  });
+
   it("keeps audit run ids unique when channel message ids repeat", async () => {
     setReadyAcpResolution();
 

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -9,6 +9,11 @@ import type { MediaUnderstandingSkipError } from "../../../packages/media-unders
 import { AcpRuntimeError } from "../../acp/runtime/errors.js";
 import type { AcpSessionStoreEntry } from "../../acp/runtime/session-meta.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import {
+  getAgentEventLifecycleGeneration,
+  rotateAgentEventLifecycleGeneration,
+} from "../../infra/agent-events.js";
+import { getAgentRunContext } from "../../infra/agent-run-registry.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import type { ApplyMediaUnderstandingResult } from "../../media-understanding/apply.js";
 import { isImageAttachment } from "../../media-understanding/attachments.normalize.js";
@@ -568,6 +573,54 @@ describe("tryDispatchAcpReply", () => {
       expect.objectContaining({ runId: expect.any(String), sessionKey, auditOnly: true }),
     );
     expect(auditMocks.emitAcpLifecycleError).not.toHaveBeenCalled();
+  });
+
+  it("owns generated audit runs until the ACP turn settles", async () => {
+    setReadyAcpResolution();
+    let observedRunId: string | undefined;
+    let observedContext: ReturnType<typeof getAgentRunContext>;
+    managerMocks.runTurn.mockImplementationOnce(
+      async ({ onEvent }: { onEvent?: (event: unknown) => Promise<void> }) => {
+        observedRunId = (
+          mockArg(auditMocks.emitAcpLifecycleStart, 0, 0, "audit start") as { runId: string }
+        ).runId;
+        observedContext = getAgentRunContext(observedRunId);
+        await onEvent?.({ type: "done", status: "completed" });
+      },
+    );
+
+    await runDispatch({ bodyForAgent: "audit owned turn" });
+
+    expect(observedContext).toMatchObject({
+      agentId: "codex-acp",
+      isControlUiVisible: false,
+      projectSessionActive: false,
+      projectSessionLifecycle: false,
+      sessionKey,
+      attribution: {
+        runId: observedRunId,
+        agentId: "codex-acp",
+        sessionKey,
+      },
+    });
+    expect(observedRunId).toBeTypeOf("string");
+    expect(getAgentRunContext(observedRunId ?? "")).toBeUndefined();
+  });
+
+  it("captures generated audit ownership after asynchronous runtime loading", async () => {
+    setReadyAcpResolution();
+
+    const dispatch = runDispatch({ bodyForAgent: "audit rotation turn" });
+    const lifecycleGeneration = rotateAgentEventLifecycleGeneration();
+    await dispatch;
+
+    expect(lifecycleGeneration).toBe(getAgentEventLifecycleGeneration());
+    expect(auditMocks.emitAcpLifecycleStart).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycleGeneration }),
+    );
+    expect(auditMocks.emitAcpLifecycleEnd).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycleGeneration }),
+    );
   });
 
   it("keeps caller-owned run ids on the shared lifecycle path", async () => {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -13,7 +13,17 @@ import {
   getAgentEventLifecycleGeneration,
   rotateAgentEventLifecycleGeneration,
 } from "../../infra/agent-events.js";
-import { getAgentRunContext } from "../../infra/agent-run-registry.js";
+import {
+  captureAgentRunExecutionContextLifecycleToken,
+  getAgentRunExecutionContextLifecycleToken,
+  getAgentRunExecutionLifecycleGeneration,
+} from "../../infra/agent-run-execution-context.js";
+import {
+  claimAgentRunContext,
+  clearAgentRunContext,
+  getAgentRunContext,
+  getAgentRunContextLifecycleToken,
+} from "../../infra/agent-run-registry.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import type { ApplyMediaUnderstandingResult } from "../../media-understanding/apply.js";
 import { isImageAttachment } from "../../media-understanding/attachments.normalize.js";
@@ -621,6 +631,77 @@ describe("tryDispatchAcpReply", () => {
     expect(auditMocks.emitAcpLifecycleEnd).toHaveBeenCalledWith(
       expect.objectContaining({ lifecycleGeneration }),
     );
+  });
+
+  it("keeps delayed ACP audit callbacks on the admitted run after lifecycle reuse", async () => {
+    setReadyAcpResolution();
+    let admittedGeneration: string | undefined;
+    let admittedToken: object | undefined;
+    let callbackGeneration: string | undefined;
+    let callbackToken: object | undefined;
+    let terminalGeneration: string | undefined;
+    let terminalToken: object | undefined;
+    let observedRunId: string | undefined;
+    let replacementGeneration: string | undefined;
+    let replacementToken: object | undefined;
+
+    auditMocks.emitAcpLifecycleStart.mockImplementationOnce(
+      (params: { lifecycleGeneration?: string; runId: string }) => {
+        admittedGeneration = params.lifecycleGeneration;
+        admittedToken = admittedGeneration
+          ? getAgentRunContextLifecycleToken(params.runId, admittedGeneration)
+          : undefined;
+        if (admittedGeneration && admittedToken) {
+          captureAgentRunExecutionContextLifecycleToken(
+            params.runId,
+            admittedGeneration,
+            admittedToken,
+          );
+        }
+      },
+    );
+    auditMocks.emitAcpRuntimeEvent.mockImplementationOnce((params: { runId: string }) => {
+      callbackGeneration = getAgentRunExecutionLifecycleGeneration();
+      callbackToken = getAgentRunExecutionContextLifecycleToken(params.runId);
+    });
+    auditMocks.emitAcpLifecycleEnd.mockImplementationOnce((params: { runId: string }) => {
+      terminalGeneration = getAgentRunExecutionLifecycleGeneration();
+      terminalToken = getAgentRunExecutionContextLifecycleToken(params.runId);
+    });
+    managerMocks.runTurn.mockImplementationOnce(
+      async ({ onEvent }: { onEvent?: (event: unknown) => Promise<void> }) => {
+        observedRunId = (
+          mockArg(auditMocks.emitAcpLifecycleStart, 0, 0, "audit start") as { runId: string }
+        ).runId;
+        replacementGeneration = rotateAgentEventLifecycleGeneration();
+        claimAgentRunContext(observedRunId, {
+          agentId: "replacement",
+          lifecycleGeneration: replacementGeneration,
+          sessionKey: "agent:replacement:main",
+        });
+        replacementToken = getAgentRunContextLifecycleToken(observedRunId, replacementGeneration);
+        if (onEvent) {
+          await emitToolLifecycleEvents(onEvent, "tool-delayed");
+        }
+      },
+    );
+
+    await runDispatch({ bodyForAgent: "audit delayed callback" });
+
+    expect(admittedGeneration).toBeTypeOf("string");
+    expect(admittedToken).toBeTypeOf("object");
+    expect(replacementToken).toBeTypeOf("object");
+    expect(replacementToken).not.toBe(admittedToken);
+    expect(callbackGeneration).toBe(admittedGeneration);
+    expect(callbackToken).toBe(admittedToken);
+    expect(terminalGeneration).toBe(admittedGeneration);
+    expect(terminalToken).toBe(admittedToken);
+    expect(getAgentRunContext(observedRunId ?? "")).toMatchObject({
+      agentId: "replacement",
+      lifecycleGeneration: replacementGeneration,
+      sessionKey: "agent:replacement:main",
+    });
+    clearAgentRunContext(observedRunId ?? "", replacementGeneration);
   });
 
   it("keeps caller-owned run ids on the shared lifecycle path", async () => {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -650,12 +650,13 @@ export async function tryDispatchAcpReply(params: {
   };
   const runWithAuditLifecycle = <T>(run: () => T): T => {
     claimAuditContext();
-    return auditLifecycleGeneration
-      ? withAgentRunLifecycleGeneration(auditLifecycleGeneration, () => {
+    const lifecycleGeneration = auditLifecycleGeneration;
+    return lifecycleGeneration
+      ? withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
           if (admittedAuditContextLifecycleToken) {
             captureAgentRunExecutionContextLifecycleToken(
               auditRunId,
-              auditLifecycleGeneration,
+              lifecycleGeneration,
               admittedAuditContextLifecycleToken,
             );
           }

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -22,8 +22,10 @@ import {
   captureAgentRunLifecycleGeneration,
   withAgentRunLifecycleGeneration,
 } from "../../infra/agent-events.js";
+import { captureAgentRunExecutionContextLifecycleToken } from "../../infra/agent-run-execution-context.js";
 import {
   claimAgentRunContext,
+  getAgentRunContextLifecycleToken,
   releaseAgentRunContext,
   retainActiveAgentRunContext,
 } from "../../infra/agent-run-registry.js";
@@ -455,6 +457,17 @@ export async function tryDispatchAcpReply(params: {
     return null;
   }
 
+  const existingRunId = normalizeOptionalString(params.runId);
+  // Lazy ACP setup can yield while a caller-owned run id is rotated and reused.
+  // Snapshot both ownership identities now so later audit callbacks cannot rebound.
+  const admittedAuditLifecycleGeneration = existingRunId
+    ? captureAgentRunLifecycleGeneration(existingRunId)
+    : undefined;
+  const admittedAuditContextLifecycleToken =
+    existingRunId && admittedAuditLifecycleGeneration
+      ? getAgentRunContextLifecycleToken(existingRunId, admittedAuditLifecycleGeneration)
+      : undefined;
+
   const { getAcpSessionManager } = await loadDispatchAcpManagerRuntime();
   const acpManager = getAcpSessionManager();
   const acpResolution = acpManager.resolveSession({
@@ -581,14 +594,13 @@ export async function tryDispatchAcpReply(params: {
       markIdle: params.markIdle,
     });
   const requestId = resolveAcpRequestId(params.ctx);
-  const existingRunId = normalizeOptionalString(params.runId);
   const auditOnly = existingRunId === undefined;
   const auditRunId = existingRunId ?? generateSecureUuid();
   const auditRuntime = await loadDispatchAcpAuditRuntime();
   const auditToolTracker = auditRuntime.createAcpToolLifecycleTracker();
   let auditStarted = false;
   let auditFinished = false;
-  let auditLifecycleGeneration: string | undefined;
+  let auditLifecycleGeneration = admittedAuditLifecycleGeneration;
   let auditContextOwnerToken: string | undefined;
   let releaseAuditContextLease: (() => void) | undefined;
   let auditTerminalOutcome: "blocked" | undefined;
@@ -639,7 +651,16 @@ export async function tryDispatchAcpReply(params: {
   const runWithAuditLifecycle = <T>(run: () => T): T => {
     claimAuditContext();
     return auditLifecycleGeneration
-      ? withAgentRunLifecycleGeneration(auditLifecycleGeneration, run)
+      ? withAgentRunLifecycleGeneration(auditLifecycleGeneration, () => {
+          if (admittedAuditContextLifecycleToken) {
+            captureAgentRunExecutionContextLifecycleToken(
+              auditRunId,
+              auditLifecycleGeneration,
+              admittedAuditContextLifecycleToken,
+            );
+          }
+          return run();
+        })
       : run();
   };
   const releaseAuditContext = () => {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -18,7 +18,10 @@ import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
-import { captureAgentRunLifecycleGeneration } from "../../infra/agent-events.js";
+import {
+  captureAgentRunLifecycleGeneration,
+  withAgentRunLifecycleGeneration,
+} from "../../infra/agent-events.js";
 import {
   claimAgentRunContext,
   releaseAgentRunContext,
@@ -633,6 +636,12 @@ export async function tryDispatchAcpReply(params: {
       releaseAuditContextLease = retainActiveAgentRunContext(auditRunId, auditLifecycleGeneration);
     }
   };
+  const runWithAuditLifecycle = <T>(run: () => T): T => {
+    claimAuditContext();
+    return auditLifecycleGeneration
+      ? withAgentRunLifecycleGeneration(auditLifecycleGeneration, run)
+      : run();
+  };
   const releaseAuditContext = () => {
     releaseAuditContextLease?.();
     releaseAuditContextLease = undefined;
@@ -731,6 +740,40 @@ export async function tryDispatchAcpReply(params: {
         )}`,
       );
     }
+  };
+  const finishWithError = async (err: unknown): Promise<AcpDispatchAttemptResult> => {
+    const acpError = toAcpRuntimeError({
+      error: err,
+      fallbackCode: "ACP_TURN_FAILED",
+      fallbackMessage: "ACP turn failed before completion.",
+    });
+    emitAuditError(acpError);
+    await projector.flush(true);
+    queuedFinal = (await deliverDeferredTextFallback()) || queuedFinal;
+    await maybeUnbindStaleBoundConversations({
+      targetSessionKey: canonicalSessionKey,
+      error: acpError,
+    });
+    const errorText = formatAcpRuntimeErrorText(acpError);
+    // Snapshot streamed output before delivering the error: delivery accumulates
+    // what it sends, so reading after would fold the error text in twice.
+    const partialText = delivery.getAccumulatedTranscriptText();
+    const delivered = await delivery.deliver("final", {
+      text: errorText,
+      isError: true,
+    });
+    // Record what the channel actually showed. Without this a failed bound turn
+    // leaves the ACP transcript empty while the user sees the reply, and the next
+    // turn resumes from history that never mentions it. Setup failures before
+    // dispatch have no user turn to attach the error to.
+    if (turnDispatched) {
+      await persistTranscript(partialText ? `${partialText}\n\n${errorText}` : errorText);
+    }
+    queuedFinal = queuedFinal || delivered;
+    return finishAttempt({
+      queuedFinal,
+      outcome: { kind: "error", error: acpError },
+    });
   };
   try {
     const dispatchPolicyError = resolveAcpDispatchPolicyError(params.cfg);
@@ -840,117 +883,94 @@ export async function tryDispatchAcpReply(params: {
       return { queuedFinal: false, counts };
     }
 
-    emitAuditStart();
-    try {
-      await delivery.startReplyLifecycle();
-    } catch (error) {
-      logVerbose(`dispatch-acp: start reply lifecycle failed: ${formatErrorMessage(error)}`);
-    }
+    // Keep delayed ACP callbacks and the terminal event on the admitted run instance.
+    // A lifecycle rotation may reuse the run id before the old turn settles.
+    return await runWithAuditLifecycle(async () => {
+      emitAuditStart();
+      try {
+        await delivery.startReplyLifecycle();
+      } catch (error) {
+        logVerbose(`dispatch-acp: start reply lifecycle failed: ${formatErrorMessage(error)}`);
+      }
 
-    turnDispatched = true;
-    await acpManager.runTurn({
-      cfg: params.cfg,
-      sessionKey: canonicalSessionKey,
-      provenance: classifySessionStateActor({
-        inputProvenance: params.ctx.InputProvenance,
-        sessionEffects: params.ctx.InboundEventKind === "room_event" ? "internal" : "visible",
-      }).actorType,
-      text: resolveAcpTurnText({
-        promptText: turnPromptText,
-        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-      }),
-      attachments: attachments.length > 0 ? attachments : undefined,
-      mode: "prompt",
-      requestId,
-      ...(params.abortSignal ? { signal: params.abortSignal } : {}),
-      onEvent: async (event) => {
-        auditRuntime.emitAcpRuntimeEvent({
-          runId: auditRunId,
-          toolTracker: auditToolTracker,
+      try {
+        turnDispatched = true;
+        await acpManager.runTurn({
+          cfg: params.cfg,
           sessionKey: canonicalSessionKey,
-          agentId: acpAgentId,
-          ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
-          auditOnly,
-          event,
+          provenance: classifySessionStateActor({
+            inputProvenance: params.ctx.InputProvenance,
+            sessionEffects: params.ctx.InboundEventKind === "room_event" ? "internal" : "visible",
+          }).actorType,
+          text: resolveAcpTurnText({
+            promptText: turnPromptText,
+            sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+          }),
+          attachments: attachments.length > 0 ? attachments : undefined,
+          mode: "prompt",
+          requestId,
+          ...(params.abortSignal ? { signal: params.abortSignal } : {}),
+          onEvent: async (event) => {
+            auditRuntime.emitAcpRuntimeEvent({
+              runId: auditRunId,
+              toolTracker: auditToolTracker,
+              sessionKey: canonicalSessionKey,
+              agentId: acpAgentId,
+              ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+              auditOnly,
+              event,
+            });
+            if (event.type === "done") {
+              auditStopReason = event.stopReason;
+              auditResultStatus = event.status;
+              runtimeTurnWasCancelled = event.status === "cancelled";
+            }
+            await projector.onEvent(event);
+          },
         });
-        if (event.type === "done") {
-          auditStopReason = event.stopReason;
-          auditResultStatus = event.status;
-          runtimeTurnWasCancelled = event.status === "cancelled";
+
+        await projector.flush(true);
+        if (runtimeTurnWasCancelled || params.abortSignal?.aborted) {
+          queuedFinal = (await deliverDeferredTextFallback()) || queuedFinal;
+          await persistTranscript(await delivery.resolveAccumulatedDeliveredTranscriptText());
+          queuedFinal = delivery.hasDeliveredFinalReply() || queuedFinal;
+          const counts = params.dispatcher.getQueuedCounts();
+          delivery.applyRoutedCounts(counts);
+          params.recordProcessed("completed", { reason: "acp_aborted" });
+          params.markIdle("message_aborted");
+          emitAuditEnd();
+          return { queuedFinal, counts };
         }
-        await projector.onEvent(event);
-      },
+        queuedFinal =
+          (await finalizeAcpTurnOutput({
+            cfg: params.cfg,
+            sessionKey: canonicalSessionKey,
+            agentId: acpAgentId,
+            delivery,
+            inboundAudio: params.inboundAudio,
+            sessionTtsAuto: params.sessionTtsAuto,
+            ttsChannel: params.ttsChannel,
+            ttsAccountId: effectiveDispatchAccountId,
+            shouldDeferVisibleTextForTts,
+            shouldEmitResolvedIdentityNotice,
+          })) || queuedFinal;
+
+        // Persist once the turn's outcome is settled. Writing before finalization
+        // would leave a finalizer failure recorded as a clean success.
+        await persistTranscript(delivery.getAccumulatedTranscriptText());
+
+        const result = finishAttempt({
+          queuedFinal,
+          outcome: { kind: "ok" },
+        });
+        emitAuditEnd();
+        return result;
+      } catch (err) {
+        return finishWithError(err);
+      }
     });
-
-    await projector.flush(true);
-    if (runtimeTurnWasCancelled || params.abortSignal?.aborted) {
-      queuedFinal = (await deliverDeferredTextFallback()) || queuedFinal;
-      await persistTranscript(await delivery.resolveAccumulatedDeliveredTranscriptText());
-      queuedFinal = delivery.hasDeliveredFinalReply() || queuedFinal;
-      const counts = params.dispatcher.getQueuedCounts();
-      delivery.applyRoutedCounts(counts);
-      params.recordProcessed("completed", { reason: "acp_aborted" });
-      params.markIdle("message_aborted");
-      emitAuditEnd();
-      return { queuedFinal, counts };
-    }
-    queuedFinal =
-      (await finalizeAcpTurnOutput({
-        cfg: params.cfg,
-        sessionKey: canonicalSessionKey,
-        agentId: acpAgentId,
-        delivery,
-        inboundAudio: params.inboundAudio,
-        sessionTtsAuto: params.sessionTtsAuto,
-        ttsChannel: params.ttsChannel,
-        ttsAccountId: effectiveDispatchAccountId,
-        shouldDeferVisibleTextForTts,
-        shouldEmitResolvedIdentityNotice,
-      })) || queuedFinal;
-
-    // Persist once the turn's outcome is settled. Writing before finalization
-    // would leave a finalizer failure recorded as a clean success.
-    await persistTranscript(delivery.getAccumulatedTranscriptText());
-
-    const result = finishAttempt({
-      queuedFinal,
-      outcome: { kind: "ok" },
-    });
-    emitAuditEnd();
-    return result;
   } catch (err) {
-    const acpError = toAcpRuntimeError({
-      error: err,
-      fallbackCode: "ACP_TURN_FAILED",
-      fallbackMessage: "ACP turn failed before completion.",
-    });
-    emitAuditError(acpError);
-    await projector.flush(true);
-    queuedFinal = (await deliverDeferredTextFallback()) || queuedFinal;
-    await maybeUnbindStaleBoundConversations({
-      targetSessionKey: canonicalSessionKey,
-      error: acpError,
-    });
-    const errorText = formatAcpRuntimeErrorText(acpError);
-    // Snapshot streamed output before delivering the error: delivery accumulates
-    // what it sends, so reading after would fold the error text in twice.
-    const partialText = delivery.getAccumulatedTranscriptText();
-    const delivered = await delivery.deliver("final", {
-      text: errorText,
-      isError: true,
-    });
-    // Record what the channel actually showed. Without this a failed bound turn
-    // leaves the ACP transcript empty while the user sees the reply, and the next
-    // turn resumes from history that never mentions it. Setup failures before
-    // dispatch have no user turn to attach the error to.
-    if (turnDispatched) {
-      await persistTranscript(partialText ? `${partialText}\n\n${errorText}` : errorText);
-    }
-    queuedFinal = queuedFinal || delivered;
-    return finishAttempt({
-      queuedFinal,
-      outcome: { kind: "error", error: acpError },
-    });
+    return runWithAuditLifecycle(() => finishWithError(err));
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -596,10 +596,10 @@ export async function tryDispatchAcpReply(params: {
   let auditResultStatus: "completed" | "cancelled" | undefined;
   let runtimeTurnWasCancelled = false;
   const claimAuditContext = () => {
+    auditLifecycleGeneration ??= captureAgentRunLifecycleGeneration(auditRunId);
     if (!auditOnly || auditContextOwnerToken) {
       return;
     }
-    auditLifecycleGeneration ??= captureAgentRunLifecycleGeneration(auditRunId);
     const attribution = admitAutoReplyExecutionAttribution({
       config: params.cfg,
       lifecycleGeneration: auditLifecycleGeneration,

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -18,6 +18,12 @@ import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
+import { captureAgentRunLifecycleGeneration } from "../../infra/agent-events.js";
+import {
+  claimAgentRunContext,
+  releaseAgentRunContext,
+  retainActiveAgentRunContext,
+} from "../../infra/agent-run-registry.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
@@ -37,6 +43,7 @@ import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import { markReplyPayloadAsTtsSupplement } from "../reply-payload.js";
 import type { FinalizedRuntimeMsgContext } from "../templating.js";
 import { createAcpReplyProjector } from "./acp-projector.js";
+import { admitAutoReplyExecutionAttribution } from "./agent-runner-execution-identity.js";
 import {
   loadAgentTurnMediaRuntime,
   resolveAgentTurnAttachments,
@@ -578,20 +585,74 @@ export async function tryDispatchAcpReply(params: {
   const auditToolTracker = auditRuntime.createAcpToolLifecycleTracker();
   let auditStarted = false;
   let auditFinished = false;
+  let auditLifecycleGeneration: string | undefined;
+  let auditContextOwnerToken: string | undefined;
+  let releaseAuditContextLease: (() => void) | undefined;
   let auditTerminalOutcome: "blocked" | undefined;
   let auditStopReason: string | undefined;
   let auditResultStatus: "completed" | "cancelled" | undefined;
   let runtimeTurnWasCancelled = false;
+  const claimAuditContext = () => {
+    if (!auditOnly || auditContextOwnerToken) {
+      return;
+    }
+    auditLifecycleGeneration ??= captureAgentRunLifecycleGeneration(auditRunId);
+    const attribution = admitAutoReplyExecutionAttribution({
+      config: params.cfg,
+      lifecycleGeneration: auditLifecycleGeneration,
+      runId: auditRunId,
+      context: {
+        accountId: effectiveDispatchAccountId,
+        agentId: acpAgentId,
+        chatId: params.ctx.ChatId ?? params.ctx.NativeChannelId,
+        channel: params.ctx.OriginatingChannel ?? params.ctx.Surface ?? params.ctx.Provider,
+        inputProvenance: params.ctx.InputProvenance,
+        isHeartbeat: false,
+        messageId: params.ctx.MessageSidFull ?? params.ctx.MessageSid,
+        senderId: params.ctx.SenderId,
+        senderIsBot: params.ctx.SenderIsBot,
+        senderLabel: params.ctx.SenderName ?? params.ctx.SenderUsername,
+        sessionKey: canonicalSessionKey,
+        threadId: params.ctx.MessageThreadId ?? params.ctx.TransportThreadId,
+      },
+    });
+    auditContextOwnerToken = claimAgentRunContext(
+      auditRunId,
+      {
+        attribution,
+        agentId: acpAgentId,
+        isControlUiVisible: false,
+        lifecycleGeneration: auditLifecycleGeneration,
+        projectSessionActive: false,
+        projectSessionLifecycle: false,
+        sessionKey: canonicalSessionKey,
+      },
+      { ownsContext: true, trackOwner: true },
+    );
+    if (auditContextOwnerToken) {
+      releaseAuditContextLease = retainActiveAgentRunContext(auditRunId, auditLifecycleGeneration);
+    }
+  };
+  const releaseAuditContext = () => {
+    releaseAuditContextLease?.();
+    releaseAuditContextLease = undefined;
+    if (auditContextOwnerToken) {
+      releaseAgentRunContext(auditRunId, auditContextOwnerToken);
+      auditContextOwnerToken = undefined;
+    }
+  };
   const emitAuditStart = () => {
     if (auditStarted) {
       return;
     }
+    claimAuditContext();
     auditStarted = true;
     auditRuntime.emitAcpLifecycleStart({
       runId: auditRunId,
       sessionKey: canonicalSessionKey,
       agentId: acpAgentId,
       startedAt: Date.now(),
+      ...(auditLifecycleGeneration ? { lifecycleGeneration: auditLifecycleGeneration } : {}),
       auditOnly,
     });
   };
@@ -601,16 +662,21 @@ export async function tryDispatchAcpReply(params: {
     }
     emitAuditStart();
     auditFinished = true;
-    auditRuntime.emitAcpLifecycleEnd({
-      runId: auditRunId,
-      toolTracker: auditToolTracker,
-      sessionKey: canonicalSessionKey,
-      agentId: acpAgentId,
-      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
-      ...(auditStopReason ? { stopReason: auditStopReason } : {}),
-      ...(auditResultStatus ? { resultStatus: auditResultStatus } : {}),
-      auditOnly,
-    });
+    try {
+      auditRuntime.emitAcpLifecycleEnd({
+        runId: auditRunId,
+        toolTracker: auditToolTracker,
+        sessionKey: canonicalSessionKey,
+        agentId: acpAgentId,
+        ...(auditLifecycleGeneration ? { lifecycleGeneration: auditLifecycleGeneration } : {}),
+        ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+        ...(auditStopReason ? { stopReason: auditStopReason } : {}),
+        ...(auditResultStatus ? { resultStatus: auditResultStatus } : {}),
+        auditOnly,
+      });
+    } finally {
+      releaseAuditContext();
+    }
   };
   const emitAuditError = (error: unknown) => {
     if (auditFinished) {
@@ -618,16 +684,21 @@ export async function tryDispatchAcpReply(params: {
     }
     emitAuditStart();
     auditFinished = true;
-    auditRuntime.emitAcpLifecycleError({
-      runId: auditRunId,
-      toolTracker: auditToolTracker,
-      sessionKey: canonicalSessionKey,
-      agentId: acpAgentId,
-      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
-      ...(auditTerminalOutcome ? { terminalOutcome: auditTerminalOutcome } : {}),
-      auditOnly,
-      error,
-    });
+    try {
+      auditRuntime.emitAcpLifecycleError({
+        runId: auditRunId,
+        toolTracker: auditToolTracker,
+        sessionKey: canonicalSessionKey,
+        agentId: acpAgentId,
+        ...(auditLifecycleGeneration ? { lifecycleGeneration: auditLifecycleGeneration } : {}),
+        ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+        ...(auditTerminalOutcome ? { terminalOutcome: auditTerminalOutcome } : {}),
+        auditOnly,
+        error,
+      });
+    } finally {
+      releaseAuditContext();
+    }
   };
   // Hoisted so the failure path can persist the same user turn the success path
   // records: a bound ACP session must not silently diverge from the channel.

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -589,6 +589,7 @@ vi.mock("../../infra/agent-events.js", () => ({
   isAgentEventLifecycleGenerationCurrent: (generation: string) => generation === "test-generation",
   onAgentEvent: (listener: unknown) => agentEventMocks.onAgentEvent(listener),
   registerAgentEventLifecycleRotationHandler: vi.fn(),
+  withAgentRunLifecycleGeneration: <T>(_: string, run: () => T): T => run(),
 }));
 vi.mock("../../plugins/conversation-binding.js", () => ({
   buildPluginBindingDeclinedText: () => "Plugin binding request was declined.",

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -582,6 +582,7 @@ vi.mock("../../bindings/records.js", () => ({
     sessionBindingMocks.touch(...args),
 }));
 vi.mock("../../infra/agent-events.js", () => ({
+  captureAgentRunLifecycleGeneration: () => "test-generation",
   emitAgentAuditEvent: (params: unknown) => agentEventMocks.emitAgentAuditEvent(params),
   emitAgentEvent: (params: unknown) => agentEventMocks.emitAgentEvent(params),
   getAgentEventLifecycleGeneration: () => "test-generation",

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -10,8 +10,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 import { NODE_INVOKE_SESSION_KEY_ENVELOPE_PROTOCOL_FEATURE } from "../../packages/gateway-protocol/src/schema/nodes.js";
+import { buildNodeSystemRunInvoke } from "../agents/bash-tools.exec-host-node-phases.js";
 import { getCurrentActiveNodeContext, setActiveNodeContext } from "../infra/active-node-context.js";
 import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
+import { coerceNodeInvokePayload } from "../node-host/invoke-payload.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { listConnectedNodePluginTools } from "./node-plugin-tool-snapshot.js";
 import { NodeRegistry, serializeEventPayload } from "./node-registry.js";
@@ -1269,23 +1271,45 @@ describe("gateway/node-registry", () => {
     expect(onDispatchReady).not.toHaveBeenCalled();
   });
 
-  it("forwards the agent session that owns a stateful node invoke", async () => {
+  it("preserves producer-owned session attribution through the node request envelope", async () => {
     const registry = createNodeRegistry();
     const frames = registerNode(registry);
-    const invoke = registry.invoke({
-      nodeId: "node-1",
-      command: "debug.ping",
-      timeoutMs: 0,
+    const producerEnvelope = buildNodeSystemRunInvoke({
+      target: {
+        nodeId: "node-1",
+        argv: ["echo", "ok"],
+        env: undefined,
+        invokeDeadlineMs: 30_000,
+        invokeWaitMs: 35_000,
+        runTimeoutSec: 30,
+        supportsSystemRunPrepare: true,
+      },
+      command: ["echo", "ok"],
+      rawCommand: "echo ok",
+      cwd: undefined,
+      agentId: "main",
       sessionKey: "agent:main:canvas",
     });
+    const invoke = registry.invoke({
+      nodeId: producerEnvelope.nodeId as string,
+      command: producerEnvelope.command as string,
+      params: producerEnvelope.params,
+      timeoutMs: 0,
+      sessionKey: producerEnvelope.sessionKey as string,
+    });
     const request = JSON.parse(frames[0] ?? "{}") as {
-      payload?: { id?: string; sessionKey?: string };
+      payload?: unknown;
     };
+    const decoded = coerceNodeInvokePayload(request.payload);
 
-    expect(request.payload?.sessionKey).toBe("agent:main:canvas");
+    expect(decoded).toMatchObject({
+      nodeId: "node-1",
+      command: "system.run",
+      sessionKey: "agent:main:canvas",
+    });
     expect(
       registry.handleInvokeResult({
-        id: request.payload?.id ?? "",
+        id: decoded?.id ?? "",
         nodeId: "node-1",
         connId: "conn-1",
         ok: true,

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -8,8 +8,12 @@ import {
 import {
   emitAgentAuditEvent,
   emitAgentEvent,
+  getAgentEventLifecycleGeneration,
   resetAgentEventsForTest,
+  rotateAgentEventLifecycleGeneration,
+  withAgentRunLifecycleGeneration,
 } from "../infra/agent-events.js";
+import { registerAgentRunContext } from "../infra/agent-run-registry.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import {
@@ -201,6 +205,35 @@ describe("startGatewayEventSubscriptions", () => {
     await unsubs.agentUnsub();
     expect(auditTestState.stopped).toBe(1);
     expect(hasExecutionIdentityAdmissionSink()).toBe(false);
+  });
+
+  it("records an authoritative pre-rotation retry through the private subscription", async () => {
+    unsubs = startGatewayEventSubscriptions(createParams());
+    const runId = "pre-rotation-audit-retry";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:main:main",
+      agentId: "main",
+    });
+
+    withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+    });
+    rotateAgentEventLifecycleGeneration();
+    withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+    });
+
+    expect(auditTestState.recorded).toBe(2);
   });
 
   it("keeps retention maintenance but creates no producers when audit.enabled is false", async () => {

--- a/src/infra/agent-event-execution-context.ts
+++ b/src/infra/agent-event-execution-context.ts
@@ -1,0 +1,12 @@
+const contextLifecycleTokenByEvent = new WeakMap<object, object>();
+
+export function captureAgentEventContextLifecycleToken(
+  event: object,
+  contextLifecycleToken: object,
+): void {
+  contextLifecycleTokenByEvent.set(event, contextLifecycleToken);
+}
+
+export function getAgentEventContextLifecycleToken(event: object): object | undefined {
+  return contextLifecycleTokenByEvent.get(event);
+}

--- a/src/infra/agent-events.attribution.test.ts
+++ b/src/infra/agent-events.attribution.test.ts
@@ -1,0 +1,497 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createAgentExecutionAttribution } from "../agents/agent-execution-attribution.js";
+import {
+  type AgentEventPayload,
+  emitAgentAuditEvent,
+  emitAgentEvent,
+  getAgentEventLifecycleGeneration,
+  onAgentAuditEvent,
+  onAgentEvent,
+  resetAgentEventsForTest,
+  rotateAgentEventLifecycleGeneration,
+  withAgentRunLifecycleGeneration,
+} from "./agent-events.js";
+import { onAgentRunContextRetired } from "./agent-run-context-retirement.js";
+import {
+  claimAgentRunContext,
+  clearAgentRunContext,
+  getAgentRunContext,
+  registerAgentRunContext,
+  sweepStaleRunContexts,
+} from "./agent-run-registry.js";
+
+describe("agent event execution attribution", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  test("keeps the first same-generation attribution private and immutable", () => {
+    const attribution = createAgentExecutionAttribution({
+      runId: "run-ctx",
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      sessionKey: "agent:main:main",
+      sessionId: "session-1",
+      agentId: "main",
+    });
+    const replacement = createAgentExecutionAttribution({
+      runId: "run-ctx",
+      lifecycleGeneration: attribution.lifecycleGeneration,
+      sessionKey: "agent:main:other",
+      sessionId: "session-2",
+      agentId: "main",
+    });
+    registerAgentRunContext("run-ctx", {
+      attribution,
+      lifecycleGeneration: attribution.lifecycleGeneration,
+    });
+    registerAgentRunContext("run-ctx", {
+      attribution: replacement,
+      lifecycleGeneration: attribution.lifecycleGeneration,
+      verboseLevel: "full",
+    });
+
+    expect(getAgentRunContext("run-ctx")?.attribution).toBe(attribution);
+    expect(getAgentRunContext("run-ctx")?.verboseLevel).toBe("full");
+    expect(Reflect.set(getAgentRunContext("run-ctx")!, "attribution", replacement)).toBe(false);
+
+    let received: AgentEventPayload | undefined;
+    const stop = onAgentEvent((event) => {
+      received = event;
+    });
+    emitAgentEvent({ runId: "run-ctx", stream: "lifecycle", data: { phase: "end" } });
+    stop();
+
+    expect(JSON.stringify(received)).not.toContain("attribution");
+  });
+
+  test("projects admission attribution only onto private audit events", () => {
+    const attribution = createAgentExecutionAttribution({
+      runId: "run-audit-attribution",
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      sessionKey: "agent:main:admitted",
+      sessionId: "session-admitted",
+      agentId: "main",
+    });
+    registerAgentRunContext(attribution.runId, {
+      attribution,
+      lifecycleGeneration: attribution.lifecycleGeneration,
+    });
+    let received: AgentEventPayload | undefined;
+    const stop = onAgentAuditEvent((event) => {
+      received = event;
+    });
+
+    emitAgentAuditEvent({
+      runId: attribution.runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+      sessionKey: "agent:forged:event",
+      sessionId: "session-forged",
+      agentId: "forged",
+    });
+    stop();
+
+    expect(received).toMatchObject({
+      runId: attribution.runId,
+      sessionKey: attribution.sessionKey,
+      sessionId: attribution.sessionId,
+      agentId: attribution.agentId,
+    });
+    expect(received?.lifecycleGeneration).toBe(getAgentEventLifecycleGeneration());
+    expect(received).not.toHaveProperty("attribution");
+    expect(JSON.stringify(received)).not.toContain("lifecycleGeneration");
+  });
+
+  test("does not erase context provenance when admission attribution is sparse", () => {
+    const attribution = createAgentExecutionAttribution({
+      runId: "run-sparse-attribution",
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+    });
+    registerAgentRunContext(attribution.runId, {
+      attribution,
+      lifecycleGeneration: attribution.lifecycleGeneration,
+      sessionKey: "agent:main:context",
+      sessionId: "session-context",
+      agentId: "main",
+    });
+    let received: AgentEventPayload | undefined;
+    const stop = onAgentAuditEvent((event) => {
+      received = event;
+    });
+
+    emitAgentAuditEvent({
+      runId: attribution.runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    stop();
+
+    expect(received).toMatchObject({
+      sessionKey: "agent:main:context",
+      sessionId: "session-context",
+      agentId: "main",
+    });
+  });
+
+  test("does not project attribution across lifecycle generations", () => {
+    const attribution = createAgentExecutionAttribution({
+      runId: "run-stale-attribution",
+      lifecycleGeneration: "generation-old",
+      sessionKey: "agent:main:admitted",
+      sessionId: "session-admitted",
+      agentId: "main",
+    });
+    registerAgentRunContext(attribution.runId, {
+      attribution,
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+    });
+    let received: AgentEventPayload | undefined;
+    const stop = onAgentAuditEvent((event) => {
+      received = event;
+    });
+
+    emitAgentAuditEvent({
+      runId: attribution.runId,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+      sessionKey: "agent:new:event",
+      sessionId: "session-new",
+      agentId: "new",
+    });
+    stop();
+
+    expect(received).toMatchObject({
+      runId: attribution.runId,
+      sessionKey: "agent:new:event",
+      sessionId: "session-new",
+      agentId: "new",
+    });
+  });
+
+  test("owns context-free audit lifecycle events until terminal notification", () => {
+    const observedContexts: Array<string | undefined> = [];
+    const stop = onAgentAuditEvent((event) => {
+      if (event.runId === "synthetic-audit-run") {
+        observedContexts.push(getAgentRunContext(event.runId)?.sessionKey);
+      }
+    });
+
+    emitAgentAuditEvent({
+      runId: "synthetic-audit-run",
+      sessionKey: "agent:main:acp:session",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    expect(getAgentRunContext("synthetic-audit-run")).toMatchObject({
+      sessionKey: "agent:main:acp:session",
+    });
+    emitAgentAuditEvent({
+      runId: "synthetic-audit-run",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    stop();
+
+    expect(observedContexts).toEqual(["agent:main:acp:session", "agent:main:acp:session"]);
+    expect(getAgentRunContext("synthetic-audit-run")).toBeUndefined();
+  });
+
+  test("owns context-free shared lifecycle events until terminal notification", () => {
+    const observedContexts: Array<string | undefined> = [];
+    const stop = onAgentEvent((event) => {
+      if (event.runId === "synthetic-shared-run") {
+        observedContexts.push(getAgentRunContext(event.runId)?.sessionKey);
+      }
+    });
+
+    emitAgentEvent({
+      runId: "synthetic-shared-run",
+      sessionKey: "agent:plugin:main",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    expect(getAgentRunContext("synthetic-shared-run")).toMatchObject({
+      sessionKey: "agent:plugin:main",
+    });
+    emitAgentEvent({
+      runId: "synthetic-shared-run",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    stop();
+
+    expect(observedContexts).toEqual(["agent:plugin:main", "agent:plugin:main"]);
+    expect(getAgentRunContext("synthetic-shared-run")).toBeUndefined();
+  });
+
+  test("retires context-free lifecycle ownership at gateway rotation", () => {
+    emitAgentAuditEvent({
+      runId: "synthetic-rotated-run",
+      sessionKey: "agent:main:acp:session",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+    expect(getAgentRunContext("synthetic-rotated-run")).toBeDefined();
+
+    rotateAgentEventLifecycleGeneration();
+
+    expect(getAgentRunContext("synthetic-rotated-run")).toBeUndefined();
+  });
+
+  test("keeps synthetic lifecycle ownership live until terminal cleanup", () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(100);
+    emitAgentAuditEvent({
+      runId: "synthetic-long-run",
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 1_000 },
+    });
+
+    clock.mockReturnValue(1_000);
+    expect(sweepStaleRunContexts(500)).toBe(0);
+    expect(getAgentRunContext("synthetic-long-run")).toBeDefined();
+
+    emitAgentAuditEvent({
+      runId: "synthetic-long-run",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+    expect(getAgentRunContext("synthetic-long-run")).toBeUndefined();
+    clock.mockRestore();
+  });
+
+  test("bounds abandoned synthetic lifecycle ownership", () => {
+    for (let index = 0; index < 4_097; index += 1) {
+      emitAgentEvent({
+        runId: `synthetic-abandoned-${index}`,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+    }
+
+    expect(getAgentRunContext("synthetic-abandoned-0")).toBeUndefined();
+    expect(getAgentRunContext("synthetic-abandoned-4096")).toBeDefined();
+  });
+
+  test("delivers an owned pre-rotation retry only to the private audit bus", () => {
+    const attribution = createAgentExecutionAttribution({
+      runId: "run-stale-audit-retry",
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      sessionKey: "agent:main:admitted",
+      sessionId: "session-admitted",
+      agentId: "main",
+    });
+    registerAgentRunContext(attribution.runId, {
+      attribution,
+      lifecycleGeneration: attribution.lifecycleGeneration,
+    });
+    const audit: AgentEventPayload[] = [];
+    const shared: AgentEventPayload[] = [];
+    const stopAudit = onAgentAuditEvent((event) => audit.push(event));
+    const stopShared = onAgentEvent((event) => shared.push(event));
+
+    withAgentRunLifecycleGeneration(attribution.lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId: attribution.runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+    });
+    rotateAgentEventLifecycleGeneration();
+    withAgentRunLifecycleGeneration(attribution.lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId: attribution.runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+    });
+    stopAudit();
+    stopShared();
+
+    expect(shared).toEqual([]);
+    expect(audit.map((event) => event.seq)).toEqual([1, 2]);
+    expect(audit[1]).toMatchObject({
+      runId: attribution.runId,
+      sessionKey: attribution.sessionKey,
+      sessionId: attribution.sessionId,
+      agentId: attribution.agentId,
+    });
+    expect(audit[1]?.lifecycleGeneration).toBe(attribution.lifecycleGeneration);
+  });
+
+  test("continues audit sequencing after context cleanup and lifecycle rotation", () => {
+    const runId = "run-delayed-audit-terminal";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:main:main",
+      agentId: "main",
+    });
+    const audit: AgentEventPayload[] = [];
+    const stop = onAgentAuditEvent((event) => audit.push(event));
+
+    withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+    });
+    clearAgentRunContext(runId, lifecycleGeneration);
+    rotateAgentEventLifecycleGeneration();
+    withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end" },
+      });
+    });
+    stop();
+
+    expect(audit.map((event) => event.seq)).toEqual([1, 2]);
+  });
+
+  test("continues audit sequencing after same-generation context cleanup", () => {
+    const runId = "run-same-generation-delayed-terminal";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:main:main",
+      agentId: "main",
+    });
+    const audit: AgentEventPayload[] = [];
+    const stop = onAgentAuditEvent((event) => audit.push(event));
+
+    withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+    });
+    clearAgentRunContext(runId, lifecycleGeneration);
+    withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end" },
+      });
+    });
+    stop();
+
+    expect(audit.map((event) => event.seq)).toEqual([1, 2]);
+  });
+
+  test("preserves retired sequencing across a second same-generation cleanup", () => {
+    const runId = "run-same-generation-rebound-delayed-terminal";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:first:main",
+      agentId: "first",
+    });
+    const audit: AgentEventPayload[] = [];
+    const stop = onAgentAuditEvent((event) => audit.push(event));
+
+    withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+    });
+    clearAgentRunContext(runId, lifecycleGeneration);
+    registerAgentRunContext(runId, {
+      lifecycleGeneration,
+      sessionKey: "agent:second:main",
+      agentId: "second",
+    });
+    withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 2_000 },
+      });
+    });
+    clearAgentRunContext(runId, lifecycleGeneration);
+    withAgentRunLifecycleGeneration(lifecycleGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end" },
+      });
+    });
+    stop();
+
+    expect(audit.map((event) => event.seq)).toEqual([1, 2, 3]);
+  });
+
+  test("delivers an old-generation terminal after the run id is rebound", () => {
+    const runId = "run-rebound-before-terminal";
+    const oldGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext(runId, {
+      lifecycleGeneration: oldGeneration,
+      sessionKey: "agent:old:main",
+      agentId: "old",
+    });
+    const audit: AgentEventPayload[] = [];
+    const stop = onAgentAuditEvent((event) => audit.push(event));
+
+    withAgentRunLifecycleGeneration(oldGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      });
+    });
+    const newGeneration = rotateAgentEventLifecycleGeneration();
+    claimAgentRunContext(runId, {
+      lifecycleGeneration: newGeneration,
+      sessionKey: "agent:new:main",
+      agentId: "new",
+    });
+    withAgentRunLifecycleGeneration(oldGeneration, () => {
+      emitAgentAuditEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "end" },
+      });
+    });
+    stop();
+
+    expect(audit.map((event) => event.seq)).toEqual([1, 2]);
+    expect(audit[1]?.lifecycleGeneration).toBe(oldGeneration);
+  });
+
+  test("notifies internal projections when run contexts retire", () => {
+    const retired: Array<{
+      runId: string;
+      lifecycleGeneration: string;
+      reason: string;
+    }> = [];
+    const unsubscribe = onAgentRunContextRetired((event) => {
+      retired.push({
+        runId: event.runId,
+        lifecycleGeneration: event.lifecycleGeneration,
+        reason: event.reason,
+      });
+    });
+    const firstGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext("run-replaced", {
+      sessionKey: "session-first",
+      lifecycleGeneration: firstGeneration,
+    });
+
+    const secondGeneration = rotateAgentEventLifecycleGeneration();
+    claimAgentRunContext("run-replaced", {
+      sessionKey: "session-second",
+      lifecycleGeneration: secondGeneration,
+    });
+    clearAgentRunContext("run-replaced", secondGeneration);
+
+    expect(retired).toEqual([
+      { runId: "run-replaced", lifecycleGeneration: firstGeneration, reason: "replaced" },
+      { runId: "run-replaced", lifecycleGeneration: secondGeneration, reason: "cleared" },
+    ]);
+    unsubscribe();
+  });
+});

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -1,6 +1,5 @@
 // Covers agent event sequencing and run context cleanup.
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { createAgentExecutionAttribution } from "../agents/agent-execution-attribution.js";
 import {
   type AgentEventPayload,
   captureAgentRunLifecycleGeneration,
@@ -24,6 +23,7 @@ import {
   listAgentRunsForSession,
   readAgentRunIndexVersion,
   registerAgentRunContext,
+  retainActiveAgentRunContext,
   releaseAgentRunContext,
   retainQueuedAgentRunContext,
   sweepStaleRunContexts,
@@ -898,45 +898,6 @@ describe("agent-events sequencing", () => {
     expect(context?.lastActiveAt).toBe(12_345);
   });
 
-  test("keeps the first same-generation attribution private and immutable", () => {
-    const attribution = createAgentExecutionAttribution({
-      runId: "run-ctx",
-      lifecycleGeneration: getAgentEventLifecycleGeneration(),
-      sessionKey: "agent:main:main",
-      sessionId: "session-1",
-      agentId: "main",
-    });
-    const replacement = createAgentExecutionAttribution({
-      runId: "run-ctx",
-      lifecycleGeneration: attribution.lifecycleGeneration,
-      sessionKey: "agent:main:other",
-      sessionId: "session-2",
-      agentId: "main",
-    });
-    registerAgentRunContext("run-ctx", {
-      attribution,
-      lifecycleGeneration: attribution.lifecycleGeneration,
-    });
-    registerAgentRunContext("run-ctx", {
-      attribution: replacement,
-      lifecycleGeneration: attribution.lifecycleGeneration,
-      verboseLevel: "full",
-    });
-
-    expect(getAgentRunContext("run-ctx")?.attribution).toBe(attribution);
-    expect(getAgentRunContext("run-ctx")?.verboseLevel).toBe("full");
-    expect(Reflect.set(getAgentRunContext("run-ctx")!, "attribution", replacement)).toBe(false);
-
-    let received: AgentEventPayload | undefined;
-    const stop = onAgentEvent((event) => {
-      received = event;
-    });
-    emitAgentEvent({ runId: "run-ctx", stream: "lifecycle", data: { phase: "end" } });
-    stop();
-
-    expect(JSON.stringify(received)).not.toContain("attribution");
-  });
-
   test("falls back to registered sessionKey when event sessionKey is blank", () => {
     registerAgentRunContext("run-ctx", { sessionKey: "session-main" });
 
@@ -1054,7 +1015,7 @@ describe("agent-events sequencing", () => {
     ]);
   });
 
-  test("protects only active queue leases while stale tracked and abandoned owners expire", () => {
+  test("protects explicit live leases while stale tracked and abandoned owners expire", () => {
     const clock = vi.spyOn(Date, "now").mockReturnValue(100);
     const lifecycleGeneration = getAgentEventLifecycleGeneration();
     registerAgentRunContext("queued-run", { lifecycleGeneration, registeredAt: 100 });
@@ -1064,6 +1025,15 @@ describe("agent-events sequencing", () => {
       { lifecycleGeneration, registeredAt: 100 },
       { exclusive: true, ownsContext: true, trackOwner: true },
     );
+    claimAgentRunContext(
+      "active-worker-run",
+      { lifecycleGeneration, registeredAt: 100 },
+      { exclusive: true, ownsContext: true, trackOwner: true },
+    );
+    const activeLease = retainActiveAgentRunContext("active-worker-run", lifecycleGeneration);
+    expect(activeLease).toBeTypeOf("function");
+    expect(retainActiveAgentRunContext("missing-run", lifecycleGeneration)).toBeUndefined();
+    expect(retainActiveAgentRunContext("active-worker-run", "stale-generation")).toBeUndefined();
     const versionBeforeLease = readAgentRunIndexVersion();
 
     const firstLease = retainQueuedAgentRunContext("queued-run", lifecycleGeneration);
@@ -1080,6 +1050,7 @@ describe("agent-events sequencing", () => {
     expect(getAgentRunContext("queued-run")).toBeDefined();
     expect(getAgentRunContext("abandoned-run")).toBeUndefined();
     expect(getAgentRunContext("tracked-worker-run")).toBeUndefined();
+    expect(getAgentRunContext("active-worker-run")).toBeDefined();
 
     const versionAfterSweep = readAgentRunIndexVersion();
     firstLease?.("admitted");
@@ -1092,6 +1063,8 @@ describe("agent-events sequencing", () => {
     expect(readAgentRunIndexVersion()).toBe(versionAfterSweep);
     secondLease?.("abandoned");
     expect(readAgentRunIndexVersion()).toBe(versionAfterSweep);
+    expect(sweepStaleRunContexts(500)).toBe(1);
+    activeLease?.();
     expect(sweepStaleRunContexts(500)).toBe(1);
     expect(readAgentRunIndexVersion()).toBeGreaterThan(versionAfterSweep);
     expect(getAgentRunContext("queued-run")).toBeUndefined();

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -1,14 +1,28 @@
 // Stores and broadcasts agent lifecycle and streaming events.
-import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { notifyListeners, registerListener } from "../shared/listeners.js";
+import {
+  captureAgentEventContextLifecycleToken,
+  getAgentEventContextLifecycleToken,
+} from "./agent-event-execution-context.js";
 import { hasInvalidLifecycleStartTimestamp } from "./agent-event-lifecycle.js";
 import { createAgentRunStaleLifecycleError } from "./agent-lifecycle-error.js";
 import {
+  captureAgentRunExecutionContextLifecycleToken,
+  getAgentRunExecutionContextLifecycleToken,
+  getAgentRunExecutionLifecycleGeneration,
+  runOncePerAgentRun,
+  withAgentRunLifecycleGeneration,
+} from "./agent-run-execution-context.js";
+import {
+  claimAgentRunContext,
   getAgentRunContext,
+  getAgentRunContextLifecycleToken,
   getAgentRunContextOwnership,
   getAgentRunLifecycleGeneration,
   registerAgentRunSequenceResetHandler,
+  releaseAgentRunContext,
+  retainActiveAgentRunContext,
   resetAgentRunRegistryForTest,
   rotateAgentRunRegistryLifecycleGeneration,
 } from "./agent-run-registry.js";
@@ -82,62 +96,82 @@ export type AgentEventRuntimePayload = AgentEventPayload & {
 
 type AgentEventState = {
   seqByRun: Map<string, number>;
+  retiredSeqByRunInstance: Map<string, number>;
   listeners: Set<(evt: AgentEventRuntimePayload) => void>;
   auditListeners: Set<(evt: AgentEventPayload) => void>;
+  syntheticRunClaims?: Map<
+    string,
+    {
+      claimId: string;
+      contextLifecycleToken?: object;
+      lifecycleGeneration: string;
+      releaseLease: () => void;
+    }
+  >;
   lifecycleRotationHandlers?: Map<string, (lifecycleGeneration: string) => void>;
 };
 
 const AGENT_EVENT_STATE_KEY = Symbol.for("openclaw.agentEvents.state");
-const AGENT_EVENT_EXECUTION_CONTEXT_KEY = Symbol.for("openclaw.agentEvents.executionContext");
+const MAX_RETIRED_AGENT_EVENT_SEQUENCES = 4_096;
+const MAX_SYNTHETIC_AGENT_RUN_CLAIMS = 4_096;
 
-type AgentEventExecutionContext = {
-  lifecycleGeneration: string;
-  onceByRun: Map<string, Promise<unknown>>;
-};
+function buildAgentRunInstanceKey(runId: string, lifecycleGeneration: string): string {
+  return `${lifecycleGeneration}\0${runId}`;
+}
 
 function getAgentEventState(): AgentEventState {
   return resolveGlobalSingleton<AgentEventState>(AGENT_EVENT_STATE_KEY, () => ({
     seqByRun: new Map<string, number>(),
+    retiredSeqByRunInstance: new Map<string, number>(),
     listeners: new Set<(evt: AgentEventRuntimePayload) => void>(),
     auditListeners: new Set<(evt: AgentEventPayload) => void>(),
   }));
 }
 
-registerAgentRunSequenceResetHandler((runId) => {
-  getAgentEventState().seqByRun.delete(runId);
+function retainRetiredAgentEventSequence(
+  state: AgentEventState,
+  runInstance: string,
+  sequence: number,
+): void {
+  state.retiredSeqByRunInstance.delete(runInstance);
+  state.retiredSeqByRunInstance.set(runInstance, sequence);
+  while (state.retiredSeqByRunInstance.size > MAX_RETIRED_AGENT_EVENT_SEQUENCES) {
+    const oldest = state.retiredSeqByRunInstance.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    state.retiredSeqByRunInstance.delete(oldest);
+  }
+}
+
+registerAgentRunSequenceResetHandler((runId, lifecycleGeneration) => {
+  const state = getAgentEventState();
+  const runInstance = lifecycleGeneration
+    ? buildAgentRunInstanceKey(runId, lifecycleGeneration)
+    : undefined;
+  const sequence =
+    (runInstance ? state.retiredSeqByRunInstance.get(runInstance) : undefined) ??
+    state.seqByRun.get(runId);
+  state.seqByRun.delete(runId);
+  const syntheticClaim = state.syntheticRunClaims?.get(runId);
+  if (!lifecycleGeneration || syntheticClaim?.lifecycleGeneration === lifecycleGeneration) {
+    syntheticClaim?.releaseLease();
+    state.syntheticRunClaims?.delete(runId);
+  }
+  if (!runInstance) {
+    return;
+  }
+  // Same-generation rebounds continue directly from the retired-instance map,
+  // so a later clear must carry that exact counter forward instead of erasing it.
+  state.retiredSeqByRunInstance.delete(runInstance);
+  if (sequence !== undefined) {
+    // Context cleanup can precede an old generation's final audit event.
+    // Retain only its ordering, bounded above, so the terminal cannot replay at seq 1.
+    retainRetiredAgentEventSequence(state, runInstance, sequence);
+  }
 });
 
-function getAgentEventExecutionContext() {
-  return resolveGlobalSingleton<AsyncLocalStorage<AgentEventExecutionContext>>(
-    AGENT_EVENT_EXECUTION_CONTEXT_KEY,
-    () => new AsyncLocalStorage<AgentEventExecutionContext>(),
-  );
-}
-
-/** Runs one execution with immutable ownership inherited by every emitted stream event. */
-export function withAgentRunLifecycleGeneration<T>(lifecycleGeneration: string, run: () => T): T {
-  const storage = getAgentEventExecutionContext();
-  const parent = storage.getStore();
-  const onceByRun =
-    parent?.lifecycleGeneration === lifecycleGeneration ? parent.onceByRun : new Map();
-  return storage.run({ lifecycleGeneration, onceByRun }, run);
-}
-
-/** Shares one operation across fallback attempts that belong to the same admitted run. */
-export function runOncePerAgentRun<T>(runId: string, operation: string, run: () => Promise<T>) {
-  const context = getAgentEventExecutionContext().getStore();
-  if (!context) {
-    return run();
-  }
-  const key = `${operation}:${runId}`;
-  const existing = context.onceByRun.get(key);
-  if (existing) {
-    return existing as Promise<T>;
-  }
-  const pending = Promise.resolve().then(run);
-  context.onceByRun.set(key, pending);
-  return pending;
-}
+export { runOncePerAgentRun, withAgentRunLifecycleGeneration };
 
 export function getAgentEventLifecycleGeneration(): string {
   return getAgentRunLifecycleGeneration();
@@ -170,16 +204,35 @@ export function assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration: st
 /** Captures immutable lifecycle ownership for one admitted execution. */
 export function captureAgentRunLifecycleGeneration(runId: string): string {
   return (
-    getAgentEventExecutionContext().getStore()?.lifecycleGeneration ??
+    getAgentRunExecutionLifecycleGeneration() ??
     getAgentRunContext(runId)?.lifecycleGeneration ??
     getAgentRunLifecycleGeneration()
   );
+}
+
+function captureAgentRunEventContextLifecycleToken(
+  runId: string,
+  lifecycleGeneration: string | undefined,
+): object | undefined {
+  const inherited = getAgentRunExecutionContextLifecycleToken(runId);
+  if (inherited || !lifecycleGeneration) {
+    return inherited;
+  }
+  const registered = getAgentRunContextLifecycleToken(runId, lifecycleGeneration);
+  if (registered) {
+    captureAgentRunExecutionContextLifecycleToken(runId, lifecycleGeneration, registered);
+  }
+  return registered;
 }
 
 /** Starts a new ownership generation before an in-process gateway restart. */
 export function rotateAgentEventLifecycleGeneration(): string {
   const state = getAgentEventState();
   const lifecycleGeneration = rotateAgentRunRegistryLifecycleGeneration();
+  const syntheticRunClaims = [...(state.syntheticRunClaims?.entries() ?? [])];
+  for (const [runId, syntheticClaim] of syntheticRunClaims) {
+    releaseSyntheticAgentRunClaim(runId, syntheticClaim.claimId);
+  }
   // Rotation is the liveness choke point: after it returns, no prior-generation
   // owner is operationally reachable. Recovery and runtime consumers therefore
   // agree that only current-generation owners can drive or receive work.
@@ -196,6 +249,7 @@ export function rotateAgentEventLifecycleGeneration(): string {
 function enrichAgentEvent(
   event: Omit<AgentEventPayload, "seq" | "ts">,
   claimId?: string,
+  continueRetiredSequence = false,
 ): AgentEventRuntimePayload | undefined {
   const state = getAgentEventState();
   const currentLifecycleGeneration = getAgentRunLifecycleGeneration();
@@ -217,8 +271,20 @@ function enrichAgentEvent(
   }
   const context = getAgentRunContext(event.runId);
   const executionLifecycleGeneration =
-    event.lifecycleGeneration ?? getAgentEventExecutionContext().getStore()?.lifecycleGeneration;
+    event.lifecycleGeneration ?? getAgentRunExecutionLifecycleGeneration();
   const ownedLifecycleGeneration = executionLifecycleGeneration ?? context?.lifecycleGeneration;
+  const contextLifecycleToken = captureAgentRunEventContextLifecycleToken(
+    event.runId,
+    ownedLifecycleGeneration,
+  );
+  const registeredContextLifecycleToken =
+    context?.lifecycleGeneration === ownedLifecycleGeneration && ownedLifecycleGeneration
+      ? getAgentRunContextLifecycleToken(event.runId, ownedLifecycleGeneration)
+      : undefined;
+  const contextMatchesExecution =
+    !contextLifecycleToken ||
+    !registeredContextLifecycleToken ||
+    contextLifecycleToken === registeredContextLifecycleToken;
   if (
     executionLifecycleGeneration &&
     context?.lifecycleGeneration &&
@@ -229,31 +295,50 @@ function enrichAgentEvent(
   if (ownedLifecycleGeneration && ownedLifecycleGeneration !== currentLifecycleGeneration) {
     return undefined;
   }
+  if (!contextMatchesExecution && !continueRetiredSequence) {
+    return undefined;
+  }
   if (hasInvalidLifecycleStartTimestamp(event.stream, event.data)) {
     return undefined;
   }
+  const matchingContext = contextMatchesExecution ? context : undefined;
+  const lifecycleGeneration =
+    event.stream === "lifecycle"
+      ? (ownedLifecycleGeneration ?? currentLifecycleGeneration)
+      : ownedLifecycleGeneration;
+  const retiredRunInstance =
+    continueRetiredSequence && lifecycleGeneration
+      ? buildAgentRunInstanceKey(event.runId, lifecycleGeneration)
+      : undefined;
+  const retiredSequence = retiredRunInstance
+    ? state.retiredSeqByRunInstance.get(retiredRunInstance)
+    : undefined;
   let data = event.data;
-  if (context && event.stream === "lifecycle") {
+  if (matchingContext && event.stream === "lifecycle") {
     if (data.phase === "start") {
-      context.lifecycleStartedAt = data.startedAt as number;
+      matchingContext.lifecycleStartedAt = data.startedAt as number;
     } else if (
       (data.phase === "end" || data.phase === "error") &&
       data.startedAt === undefined &&
-      context.lifecycleStartedAt !== undefined
+      matchingContext.lifecycleStartedAt !== undefined
     ) {
       // Preserve this run's identity after a newer run takes over its session.
-      data = { ...data, startedAt: context.lifecycleStartedAt };
+      data = { ...data, startedAt: matchingContext.lifecycleStartedAt };
     }
   }
-  const nextSeq = (state.seqByRun.get(event.runId) ?? 0) + 1;
-  state.seqByRun.set(event.runId, nextSeq);
-  if (context) {
-    context.lastActiveAt = Date.now();
+  const nextSeq = (retiredSequence ?? state.seqByRun.get(event.runId) ?? 0) + 1;
+  if (retiredRunInstance && retiredSequence !== undefined) {
+    retainRetiredAgentEventSequence(state, retiredRunInstance, nextSeq);
+  } else {
+    state.seqByRun.set(event.runId, nextSeq);
   }
-  const isControlUiVisible = context?.isControlUiVisible ?? true;
+  if (matchingContext) {
+    matchingContext.lastActiveAt = Date.now();
+  }
+  const isControlUiVisible = matchingContext?.isControlUiVisible ?? true;
   const eventSessionKey =
     typeof event.sessionKey === "string" && event.sessionKey.trim() ? event.sessionKey : undefined;
-  const deliverySessionKey = eventSessionKey ?? context?.sessionKey;
+  const deliverySessionKey = eventSessionKey ?? matchingContext?.sessionKey;
   // Hidden channel-routed runs should not leak live assistant/tool traffic into
   // Control UI, but lifecycle events still need the session key so gateway
   // listeners can persist terminal session state even if run-context lookup is
@@ -261,16 +346,16 @@ function enrichAgentEvent(
   // emitted on the lifecycle stream with `phase: "error"`; the separate error
   // stream remains redacted for hidden runs because it is observational only.
   const preserveSessionKey = isControlUiVisible || event.stream === "lifecycle";
-  const sessionKey = preserveSessionKey ? (eventSessionKey ?? context?.sessionKey) : undefined;
+  const sessionKey = preserveSessionKey
+    ? (eventSessionKey ?? matchingContext?.sessionKey)
+    : undefined;
   // Stamp lifecycle events with the owning sessionId (see AgentEventPayload) at
   // emit time, since the run context can be cleared before the terminal persists.
   const sessionId =
-    event.stream === "lifecycle" ? (event.sessionId ?? context?.sessionId) : event.sessionId;
-  const lifecycleGeneration =
     event.stream === "lifecycle"
-      ? (ownedLifecycleGeneration ?? currentLifecycleGeneration)
-      : ownedLifecycleGeneration;
-  const agentId = event.agentId ?? context?.agentId;
+      ? (event.sessionId ?? matchingContext?.sessionId)
+      : event.sessionId;
+  const agentId = event.agentId ?? matchingContext?.agentId;
   const enriched: AgentEventRuntimePayload = {
     ...event,
     data,
@@ -288,15 +373,18 @@ function enrichAgentEvent(
       enumerable: false,
     });
   }
-  if (context?.isControlUiVisible !== undefined) {
+  if (contextLifecycleToken) {
+    captureAgentEventContextLifecycleToken(enriched, contextLifecycleToken);
+  }
+  if (matchingContext?.isControlUiVisible !== undefined) {
     Object.defineProperty(enriched, "controlUiVisible", {
-      value: context.isControlUiVisible,
+      value: matchingContext.isControlUiVisible,
       enumerable: false,
     });
   }
-  if (context?.projectSessionLifecycle !== undefined) {
+  if (matchingContext?.projectSessionLifecycle !== undefined) {
     Object.defineProperty(enriched, "projectSessionLifecycle", {
-      value: context.projectSessionLifecycle,
+      value: matchingContext.projectSessionLifecycle,
       enumerable: false,
     });
   }
@@ -315,13 +403,176 @@ function enrichAgentEvent(
   return enriched;
 }
 
+function enrichOwnedStaleAgentAuditEvent(
+  event: Omit<AgentEventPayload, "seq" | "ts">,
+): AgentEventPayload | undefined {
+  if (
+    event.stream !== "lifecycle" ||
+    (event.data.phase !== "start" && event.data.phase !== "end" && event.data.phase !== "error")
+  ) {
+    return undefined;
+  }
+  const state = getAgentEventState();
+  const inheritedLifecycleGeneration = getAgentRunExecutionLifecycleGeneration();
+  const lifecycleGeneration = event.lifecycleGeneration ?? inheritedLifecycleGeneration;
+  const currentLifecycleGeneration = getAgentRunLifecycleGeneration();
+  if (!lifecycleGeneration || lifecycleGeneration === currentLifecycleGeneration) {
+    return undefined;
+  }
+  const context = getAgentRunContext(event.runId);
+  const runInstance = buildAgentRunInstanceKey(event.runId, lifecycleGeneration);
+  const retiredSequence = state.retiredSeqByRunInstance.get(runInstance);
+  const matchingContext =
+    context?.lifecycleGeneration === lifecycleGeneration ? context : undefined;
+  if (
+    (context && !matchingContext && retiredSequence === undefined) ||
+    (!context && inheritedLifecycleGeneration !== lifecycleGeneration) ||
+    hasInvalidLifecycleStartTimestamp(event.stream, event.data)
+  ) {
+    return undefined;
+  }
+  const nextSeq =
+    (retiredSequence ?? (matchingContext ? state.seqByRun.get(event.runId) : undefined) ?? 0) + 1;
+  if (retiredSequence !== undefined || !matchingContext) {
+    retainRetiredAgentEventSequence(state, runInstance, nextSeq);
+  } else {
+    state.seqByRun.set(event.runId, nextSeq);
+  }
+  const sessionKey =
+    (typeof event.sessionKey === "string" && event.sessionKey.trim()
+      ? event.sessionKey
+      : undefined) ?? matchingContext?.sessionKey;
+  const sessionId = event.sessionId ?? matchingContext?.sessionId;
+  const agentId = event.agentId ?? matchingContext?.agentId;
+  const enriched: AgentEventPayload = {
+    ...event,
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(agentId ? { agentId } : {}),
+    seq: nextSeq,
+    ts: Date.now(),
+  };
+  // This route is audit-only: a still-owned pre-rotation execution may finish
+  // its durable ordering, but stale lifecycle never reaches public listeners.
+  Object.defineProperty(enriched, "lifecycleGeneration", {
+    value: lifecycleGeneration,
+    enumerable: false,
+  });
+  const contextLifecycleToken = captureAgentRunEventContextLifecycleToken(
+    event.runId,
+    lifecycleGeneration,
+  );
+  if (contextLifecycleToken) {
+    captureAgentEventContextLifecycleToken(enriched, contextLifecycleToken);
+  }
+  return enriched;
+}
+
+function claimSyntheticAgentRunContext(
+  event: Omit<AgentEventPayload, "seq" | "ts">,
+): string | undefined {
+  const lifecycleGeneration =
+    event.lifecycleGeneration ??
+    getAgentRunExecutionLifecycleGeneration() ??
+    getAgentRunLifecycleGeneration();
+  if (
+    event.stream !== "lifecycle" ||
+    event.data.phase !== "start" ||
+    lifecycleGeneration !== getAgentRunLifecycleGeneration() ||
+    getAgentRunContext(event.runId) ||
+    hasInvalidLifecycleStartTimestamp(event.stream, event.data)
+  ) {
+    return undefined;
+  }
+  const claimId = claimAgentRunContext(
+    event.runId,
+    {
+      agentId: event.agentId,
+      lifecycleGeneration,
+      sessionId: event.sessionId,
+      sessionKey: event.sessionKey,
+    },
+    { ownsContext: true, trackOwner: true },
+  );
+  if (!claimId) {
+    return undefined;
+  }
+  const releaseLease = retainActiveAgentRunContext(event.runId, lifecycleGeneration);
+  if (!releaseLease) {
+    releaseAgentRunContext(event.runId, claimId);
+    return undefined;
+  }
+  const state = getAgentEventState();
+  const syntheticRunClaims = (state.syntheticRunClaims ??= new Map());
+  const contextLifecycleToken = getAgentRunContextLifecycleToken(event.runId, lifecycleGeneration);
+  syntheticRunClaims.set(event.runId, {
+    claimId,
+    ...(contextLifecycleToken ? { contextLifecycleToken } : {}),
+    lifecycleGeneration,
+    releaseLease,
+  });
+  while (syntheticRunClaims.size > MAX_SYNTHETIC_AGENT_RUN_CLAIMS) {
+    const oldestRunId = syntheticRunClaims.keys().next().value;
+    if (oldestRunId === undefined) {
+      break;
+    }
+    const oldestClaim = syntheticRunClaims.get(oldestRunId);
+    if (oldestClaim) {
+      releaseSyntheticAgentRunClaim(oldestRunId, oldestClaim.claimId);
+    }
+  }
+  return claimId;
+}
+
+function releaseSyntheticAgentRunClaim(runId: string, claimId: string): void {
+  const state = getAgentEventState();
+  const syntheticRunClaims = state.syntheticRunClaims;
+  const syntheticClaim = syntheticRunClaims?.get(runId);
+  if (syntheticRunClaims && syntheticClaim?.claimId === claimId) {
+    syntheticRunClaims.delete(runId);
+    syntheticClaim.releaseLease();
+  }
+  releaseAgentRunContext(runId, claimId);
+}
+
+function releaseSyntheticAgentRunContext(event: AgentEventPayload): void {
+  if (
+    event.stream !== "lifecycle" ||
+    (event.data.phase !== "end" && event.data.phase !== "error")
+  ) {
+    return;
+  }
+  const state = getAgentEventState();
+  const syntheticClaim = state.syntheticRunClaims?.get(event.runId);
+  const contextLifecycleToken = getAgentEventContextLifecycleToken(event);
+  if (
+    !syntheticClaim ||
+    (event.lifecycleGeneration &&
+      syntheticClaim.lifecycleGeneration !== event.lifecycleGeneration) ||
+    (contextLifecycleToken &&
+      syntheticClaim.contextLifecycleToken &&
+      contextLifecycleToken !== syntheticClaim.contextLifecycleToken)
+  ) {
+    return;
+  }
+  releaseSyntheticAgentRunClaim(event.runId, syntheticClaim.claimId);
+}
+
 /** Emits an event only when its run ownership is still current. */
 export function emitAgentEventIfCurrent(event: Omit<AgentEventPayload, "seq" | "ts">): boolean {
+  const syntheticClaimId = claimSyntheticAgentRunContext(event);
   const enriched = enrichAgentEvent(event);
   if (!enriched) {
+    if (syntheticClaimId) {
+      releaseSyntheticAgentRunClaim(event.runId, syntheticClaimId);
+    }
     return false;
   }
-  notifyListeners(getAgentEventState().listeners, enriched);
+  try {
+    notifyListeners(getAgentEventState().listeners, enriched);
+  } finally {
+    releaseSyntheticAgentRunContext(enriched);
+  }
   return true;
 }
 
@@ -343,15 +594,65 @@ export function emitAgentEventForOwner(
 /** Emits run metadata only to the Gateway-owned durable audit projection. */
 export function emitAgentAuditEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
   const state = getAgentEventState();
-  const enriched = enrichAgentEvent(event);
+  const syntheticClaimId = claimSyntheticAgentRunContext(event);
+  const enriched =
+    enrichAgentEvent(event, undefined, true) ?? enrichOwnedStaleAgentAuditEvent(event);
   if (enriched) {
-    notifyListeners(state.auditListeners, enriched);
-    const phase = event.stream === "lifecycle" ? event.data.phase : undefined;
-    if ((phase === "end" || phase === "error") && !getAgentRunContext(event.runId)) {
-      // Private synthetic runs bypass public terminal cleanup. Release sequence state only
-      // after synchronous audit listeners consume the terminal event and its final ordering.
-      state.seqByRun.delete(event.runId);
+    const contextLifecycleToken = getAgentEventContextLifecycleToken(enriched);
+    const registeredContextLifecycleToken = enriched.lifecycleGeneration
+      ? getAgentRunContextLifecycleToken(event.runId, enriched.lifecycleGeneration)
+      : undefined;
+    const attribution =
+      !contextLifecycleToken ||
+      !registeredContextLifecycleToken ||
+      contextLifecycleToken === registeredContextLifecycleToken
+        ? getAgentRunContext(event.runId)?.attribution
+        : undefined;
+    const matchingAttribution =
+      attribution?.lifecycleGeneration === enriched.lifecycleGeneration ? attribution : undefined;
+    const auditEvent = matchingAttribution
+      ? {
+          ...enriched,
+          ...(matchingAttribution.sessionKey ? { sessionKey: matchingAttribution.sessionKey } : {}),
+          ...(matchingAttribution.sessionId ? { sessionId: matchingAttribution.sessionId } : {}),
+          ...(matchingAttribution.agentId ? { agentId: matchingAttribution.agentId } : {}),
+        }
+      : enriched;
+    if (enriched.lifecycleGeneration) {
+      Object.defineProperty(auditEvent, "lifecycleGeneration", {
+        value: enriched.lifecycleGeneration,
+        enumerable: false,
+      });
     }
+    if (contextLifecycleToken) {
+      captureAgentEventContextLifecycleToken(auditEvent, contextLifecycleToken);
+    }
+    try {
+      notifyListeners(state.auditListeners, auditEvent);
+    } finally {
+      releaseSyntheticAgentRunContext(enriched);
+      const phase = event.stream === "lifecycle" ? event.data.phase : undefined;
+      const completesRegisteredContext =
+        !contextLifecycleToken ||
+        !registeredContextLifecycleToken ||
+        contextLifecycleToken === registeredContextLifecycleToken;
+      if (
+        (phase === "end" || phase === "error") &&
+        enriched.lifecycleGeneration &&
+        completesRegisteredContext
+      ) {
+        state.retiredSeqByRunInstance.delete(
+          buildAgentRunInstanceKey(event.runId, enriched.lifecycleGeneration),
+        );
+      }
+      if ((phase === "end" || phase === "error") && !getAgentRunContext(event.runId)) {
+        // Private synthetic runs bypass public terminal cleanup. Release sequence state only
+        // after synchronous audit listeners consume the terminal event and its final ordering.
+        state.seqByRun.delete(event.runId);
+      }
+    }
+  } else if (syntheticClaimId) {
+    releaseSyntheticAgentRunClaim(event.runId, syntheticClaimId);
   }
 }
 
@@ -375,6 +676,11 @@ export function onAgentAuditEvent(listener: (evt: AgentEventPayload) => void) {
 export function resetAgentEventsForTest(options?: { preserveListeners?: boolean }) {
   const state = getAgentEventState();
   state.seqByRun.clear();
+  state.retiredSeqByRunInstance.clear();
+  for (const syntheticClaim of state.syntheticRunClaims?.values() ?? []) {
+    syntheticClaim.releaseLease();
+  }
+  state.syntheticRunClaims?.clear();
   resetAgentRunRegistryForTest();
   if (!options?.preserveListeners) {
     state.listeners.clear();

--- a/src/infra/agent-run-context-retirement.ts
+++ b/src/infra/agent-run-context-retirement.ts
@@ -1,0 +1,46 @@
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { notifyListeners, registerListener } from "../shared/listeners.js";
+
+type AgentRunContextRetirementEvent = {
+  runId: string;
+  lifecycleGeneration: string;
+  reason: "cleared" | "replaced" | "reset" | "swept";
+  contextLifecycleToken?: object;
+};
+
+const AGENT_RUN_CONTEXT_RETIREMENT_LISTENERS_KEY = Symbol.for(
+  "openclaw.agentRunContextRetirement.listeners",
+);
+
+function getAgentRunContextRetirementListeners() {
+  return resolveGlobalSingleton<Set<(event: AgentRunContextRetirementEvent) => void>>(
+    AGENT_RUN_CONTEXT_RETIREMENT_LISTENERS_KEY,
+    () => new Set(),
+  );
+}
+
+function notifyAgentRunContextRetired(event: AgentRunContextRetirementEvent): void {
+  notifyListeners(getAgentRunContextRetirementListeners(), event);
+}
+
+export function retireAgentRunContext(
+  runId: string,
+  lifecycleGeneration: string | undefined,
+  reason: AgentRunContextRetirementEvent["reason"],
+  contextLifecycleToken?: object,
+): void {
+  if (lifecycleGeneration) {
+    notifyAgentRunContextRetired({
+      runId,
+      lifecycleGeneration,
+      reason,
+      ...(contextLifecycleToken ? { contextLifecycleToken } : {}),
+    });
+  }
+}
+
+export function onAgentRunContextRetired(
+  listener: (event: AgentRunContextRetirementEvent) => void,
+) {
+  return registerListener(getAgentRunContextRetirementListeners(), listener);
+}

--- a/src/infra/agent-run-execution-context.ts
+++ b/src/infra/agent-run-execution-context.ts
@@ -1,0 +1,67 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+
+const AGENT_RUN_EXECUTION_CONTEXT_KEY = Symbol.for("openclaw.agentRunExecutionContext");
+
+type AgentRunExecutionContext = {
+  lifecycleGeneration: string;
+  contextLifecycleTokenByRun: Map<string, object>;
+  onceByRun: Map<string, Promise<unknown>>;
+};
+
+function getAgentRunExecutionContext() {
+  return resolveGlobalSingleton<AsyncLocalStorage<AgentRunExecutionContext>>(
+    AGENT_RUN_EXECUTION_CONTEXT_KEY,
+    () => new AsyncLocalStorage<AgentRunExecutionContext>(),
+  );
+}
+
+export function getAgentRunExecutionLifecycleGeneration(): string | undefined {
+  return getAgentRunExecutionContext().getStore()?.lifecycleGeneration;
+}
+
+export function captureAgentRunExecutionContextLifecycleToken(
+  runId: string,
+  lifecycleGeneration: string,
+  contextLifecycleToken: object,
+): void {
+  const context = getAgentRunExecutionContext().getStore();
+  if (
+    context?.lifecycleGeneration === lifecycleGeneration &&
+    !context.contextLifecycleTokenByRun.has(runId)
+  ) {
+    context.contextLifecycleTokenByRun.set(runId, contextLifecycleToken);
+  }
+}
+
+export function getAgentRunExecutionContextLifecycleToken(runId: string): object | undefined {
+  return getAgentRunExecutionContext().getStore()?.contextLifecycleTokenByRun.get(runId);
+}
+
+/** Runs one execution with immutable ownership inherited by every emitted event. */
+export function withAgentRunLifecycleGeneration<T>(lifecycleGeneration: string, run: () => T): T {
+  const storage = getAgentRunExecutionContext();
+  const parent = storage.getStore();
+  const sameLifecycle = parent?.lifecycleGeneration === lifecycleGeneration;
+  const onceByRun = sameLifecycle ? parent.onceByRun : new Map();
+  const contextLifecycleTokenByRun = sameLifecycle
+    ? new Map(parent.contextLifecycleTokenByRun)
+    : new Map<string, object>();
+  return storage.run({ lifecycleGeneration, contextLifecycleTokenByRun, onceByRun }, run);
+}
+
+/** Shares one operation across fallback attempts that belong to the same admitted run. */
+export function runOncePerAgentRun<T>(runId: string, operation: string, run: () => Promise<T>) {
+  const context = getAgentRunExecutionContext().getStore();
+  if (!context) {
+    return run();
+  }
+  const key = `${operation}:${runId}`;
+  const existing = context.onceByRun.get(key);
+  if (existing) {
+    return existing as Promise<T>;
+  }
+  const pending = Promise.resolve().then(run);
+  context.onceByRun.set(key, pending);
+  return pending;
+}

--- a/src/infra/agent-run-registry.ts
+++ b/src/infra/agent-run-registry.ts
@@ -3,6 +3,8 @@ import { randomUUID } from "node:crypto";
 import type { AgentExecutionAttribution } from "../agents/agent-execution-attribution.js";
 import type { VerboseLevel } from "../auto-reply/thinking.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { retireAgentRunContext } from "./agent-run-context-retirement.js";
+import { captureAgentRunExecutionContextLifecycleToken } from "./agent-run-execution-context.js";
 import { clearAgentRunUsage, resetAgentRunUsageForTest } from "./agent-run-usage.js";
 
 /** Per-run metadata used to stamp events and gate Control UI visibility. */
@@ -45,13 +47,17 @@ type AgentRunContextOwnership = {
 type AgentRunRegistryState = {
   contexts: Map<string, AgentRunContext>;
   owners: Map<string, AgentRunContextOwnership>;
+  activeRunContextLeases?: WeakMap<AgentRunContext, number>;
   queuedRunContextLeases?: WeakMap<AgentRunContext, number>;
   lifecycleGeneration: string;
-  sequenceResetHandler?: (runId: string) => void;
+  sequenceResetHandler?: (runId: string, lifecycleGeneration?: string) => void;
   version: number;
 };
 
 const AGENT_RUN_REGISTRY_STATE_KEY = Symbol.for("openclaw.agentRunRegistry.state");
+const AGENT_RUN_CONTEXT_LIFECYCLE_TOKEN = Symbol.for(
+  "openclaw.agentRunRegistry.contextLifecycleToken",
+);
 
 export class AgentRunAttributionCollisionError extends TypeError {}
 
@@ -163,6 +169,12 @@ function createAgentRunContext(
     lifecycleGeneration,
     registeredAt: context.registeredAt ?? Date.now(),
   };
+  Object.defineProperty(stored, AGENT_RUN_CONTEXT_LIFECYCLE_TOKEN, {
+    value: Object.freeze({}),
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
   attachAgentExecutionAttribution(stored, attribution);
   return stored;
 }
@@ -184,7 +196,9 @@ export function rotateAgentRunRegistryLifecycleGeneration(): string {
 }
 
 /** Connects registry cleanup to the event sequencer without reversing ownership. */
-export function registerAgentRunSequenceResetHandler(handler: (runId: string) => void): void {
+export function registerAgentRunSequenceResetHandler(
+  handler: (runId: string, lifecycleGeneration?: string) => void,
+): void {
   getAgentRunRegistryState().sequenceResetHandler = handler;
 }
 
@@ -209,7 +223,9 @@ export function registerAgentRunContext(
   }
   const existing = state.contexts.get(runId);
   if (!existing) {
-    state.contexts.set(runId, createAgentRunContext(context, lifecycleGeneration));
+    const stored = createAgentRunContext(context, lifecycleGeneration);
+    state.contexts.set(runId, stored);
+    captureAgentRunContextLifecycleToken(runId, lifecycleGeneration, stored);
     bumpAgentRunIndexVersion();
     return;
   }
@@ -267,6 +283,7 @@ export function registerAgentRunContext(
   if (runIndexChanged) {
     bumpAgentRunIndexVersion();
   }
+  captureAgentRunContextLifecycleToken(runId, lifecycleGeneration, existing);
 }
 
 /** Claims a run id for a newly admitted execution, replacing stale ownership. */
@@ -342,8 +359,20 @@ export function claimAgentRunContext(
     }
     return claimId;
   }
-  state.contexts.set(runId, createAgentRunContext(context, lifecycleGeneration));
-  state.sequenceResetHandler?.(runId);
+  state.sequenceResetHandler?.(runId, existing?.lifecycleGeneration);
+  if (existing) {
+    retireAgentRunContext(
+      runId,
+      existing.lifecycleGeneration,
+      "replaced",
+      existing.lifecycleGeneration
+        ? getAgentRunContextLifecycleToken(runId, existing.lifecycleGeneration)
+        : undefined,
+    );
+  }
+  const stored = createAgentRunContext(context, lifecycleGeneration);
+  state.contexts.set(runId, stored);
+  captureAgentRunContextLifecycleToken(runId, lifecycleGeneration, stored);
   clearAgentRunUsage(runId);
   bumpAgentRunIndexVersion();
   return claimId;
@@ -352,6 +381,46 @@ export function claimAgentRunContext(
 /** Returns the currently registered context for a run, if it has not been cleared or swept. */
 export function getAgentRunContext(runId: string): AgentRunContext | undefined {
   return getAgentRunRegistryState().contexts.get(runId);
+}
+
+/** Opaque identity for one stored run/lifecycle context; same-generation merges preserve it. */
+export function getAgentRunContextLifecycleToken(
+  runId: string,
+  lifecycleGeneration: string,
+): object | undefined {
+  const context = getAgentRunContext(runId);
+  if (context?.lifecycleGeneration !== lifecycleGeneration) {
+    return undefined;
+  }
+  return getOrCreateAgentRunContextLifecycleToken(context);
+}
+
+function getOrCreateAgentRunContextLifecycleToken(context: AgentRunContext): object {
+  const existing = Reflect.get(context, AGENT_RUN_CONTEXT_LIFECYCLE_TOKEN) as object | undefined;
+  if (existing) {
+    return existing;
+  }
+  // Supports process-local contexts created before this module revision loaded.
+  const token = Object.freeze({});
+  Object.defineProperty(context, AGENT_RUN_CONTEXT_LIFECYCLE_TOKEN, {
+    value: token,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return token;
+}
+
+function captureAgentRunContextLifecycleToken(
+  runId: string,
+  lifecycleGeneration: string,
+  context: AgentRunContext,
+): void {
+  captureAgentRunExecutionContextLifecycleToken(
+    runId,
+    lifecycleGeneration,
+    getOrCreateAgentRunContextLifecycleToken(context),
+  );
 }
 
 /** Holds an existing run context only while its current execution awaits lane admission. */
@@ -393,6 +462,40 @@ export function retainQueuedAgentRunContext(
       state.lifecycleGeneration === lifecycleGeneration
     ) {
       context.lastActiveAt = Date.now();
+    }
+  };
+}
+
+/**
+ * Keeps a currently executing run context live until its runtime owner settles.
+ * The caller must release the lease from its terminal/finally boundary.
+ */
+export function retainActiveAgentRunContext(
+  runId: string,
+  lifecycleGeneration: string,
+): (() => void) | undefined {
+  const state = getAgentRunRegistryState();
+  const context = state.contexts.get(runId);
+  if (
+    !context ||
+    context.lifecycleGeneration !== lifecycleGeneration ||
+    state.lifecycleGeneration !== lifecycleGeneration
+  ) {
+    return undefined;
+  }
+  const leases = (state.activeRunContextLeases ??= new WeakMap<AgentRunContext, number>());
+  leases.set(context, (leases.get(context) ?? 0) + 1);
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const remaining = (leases.get(context) ?? 0) - 1;
+    if (remaining > 0) {
+      leases.set(context, remaining);
+    } else {
+      leases.delete(context);
     }
   };
 }
@@ -544,9 +647,17 @@ export function clearAgentRunContext(
     return;
   }
   const removed = state.contexts.delete(runId);
-  state.sequenceResetHandler?.(runId);
+  state.sequenceResetHandler?.(runId, existing?.lifecycleGeneration);
   clearAgentRunUsage(runId, lifecycleGeneration ?? existing?.lifecycleGeneration);
   if (removed) {
+    retireAgentRunContext(
+      runId,
+      existing?.lifecycleGeneration,
+      "cleared",
+      existing?.lifecycleGeneration
+        ? getOrCreateAgentRunContextLifecycleToken(existing)
+        : undefined,
+    );
     bumpAgentRunIndexVersion();
   }
 }
@@ -585,10 +696,11 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
   const now = Date.now();
   let swept = 0;
   for (const [runId, context] of state.contexts) {
-    // Queue capacity waits are live ownership, but never protect a retired lifecycle.
+    // Explicit runtime and queue leases are live ownership, but never protect a retired lifecycle.
     if (
       context.lifecycleGeneration === state.lifecycleGeneration &&
-      (state.queuedRunContextLeases?.get(context) ?? 0) > 0
+      ((state.activeRunContextLeases?.get(context) ?? 0) > 0 ||
+        (state.queuedRunContextLeases?.get(context) ?? 0) > 0)
     ) {
       continue;
     }
@@ -598,9 +710,15 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
     const age = lastSeen ? now - lastSeen : Infinity;
     if (age > maxAgeMs) {
       state.contexts.delete(runId);
-      state.sequenceResetHandler?.(runId);
+      state.sequenceResetHandler?.(runId, context.lifecycleGeneration);
       clearAgentRunUsage(runId, context.lifecycleGeneration);
       state.owners.delete(runId);
+      retireAgentRunContext(
+        runId,
+        context.lifecycleGeneration,
+        "swept",
+        getOrCreateAgentRunContextLifecycleToken(context),
+      );
       swept += 1;
     }
   }
@@ -614,8 +732,17 @@ export function resetAgentRunRegistryForTest(): void {
   const state = getAgentRunRegistryState();
   const hadRunContexts = state.contexts.size > 0;
   resetAgentRunUsageForTest();
+  for (const [runId, context] of state.contexts) {
+    retireAgentRunContext(
+      runId,
+      context.lifecycleGeneration,
+      "reset",
+      getOrCreateAgentRunContextLifecycleToken(context),
+    );
+  }
   state.contexts.clear();
   state.owners.clear();
+  state.activeRunContextLeases = undefined;
   state.queuedRunContextLeases = undefined;
   if (hadRunContexts) {
     bumpAgentRunIndexVersion();

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -3,6 +3,10 @@ import { randomUUID } from "node:crypto";
 import type { EmbeddedAgentExecutionPhase } from "../agents/embedded-agent-runner/execution-phase.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { TalkBrain, TalkEventType, TalkMode, TalkTransport } from "../talk/talk-events.js";
+import {
+  getAgentRunExecutionContextLifecycleToken,
+  getAgentRunExecutionLifecycleGeneration,
+} from "./agent-run-execution-context.js";
 import { setInternalDiagnosticEventListenerCounts } from "./diagnostic-event-listener-presence.js";
 import { isTrustedOtelDiagnosticListener } from "./diagnostic-otel-listener-provenance.js";
 import { consumeHostPluginUsageDiagnosticEvent } from "./diagnostic-plugin-usage-provenance.js";
@@ -17,6 +21,7 @@ import {
   shouldPrepareDiagnosticTracePropagation,
 } from "./diagnostic-trace-propagation.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
+import { captureTrustedToolExecutionContext } from "./trusted-tool-execution-context.js";
 
 export type DiagnosticSessionState = "idle" | "processing" | "waiting";
 
@@ -1387,6 +1392,14 @@ function dispatchTrustedToolExecutionEvent(
       `[diagnostic-events] tool execution clone error type=${event.type}: ${String(error)}`,
     );
     return;
+  }
+  const lifecycleGeneration = getAgentRunExecutionLifecycleGeneration();
+  if (typeof event.runId === "string" && event.runId.length > 0 && lifecycleGeneration) {
+    captureTrustedToolExecutionContext(
+      enriched,
+      lifecycleGeneration,
+      getAgentRunExecutionContextLifecycleToken(event.runId),
+    );
   }
   for (const listener of state.toolExecutionListeners) {
     try {

--- a/src/infra/trusted-tool-execution-context.ts
+++ b/src/infra/trusted-tool-execution-context.ts
@@ -1,0 +1,25 @@
+type TrustedToolExecutionContext = {
+  lifecycleGeneration: string;
+  contextLifecycleToken?: object;
+};
+
+const executionContextByEvent = new WeakMap<object, TrustedToolExecutionContext>();
+
+export function captureTrustedToolExecutionContext(
+  event: object,
+  lifecycleGeneration: string,
+  contextLifecycleToken?: object,
+): void {
+  executionContextByEvent.set(event, {
+    lifecycleGeneration,
+    ...(contextLifecycleToken ? { contextLifecycleToken } : {}),
+  });
+}
+
+export function getTrustedToolExecutionLifecycleGeneration(event: object): string | undefined {
+  return executionContextByEvent.get(event)?.lifecycleGeneration;
+}
+
+export function getTrustedToolExecutionContextLifecycleToken(event: object): object | undefined {
+  return executionContextByEvent.get(event)?.contextLifecycleToken;
+}

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -128,6 +128,34 @@ describe("tsdown config", () => {
     expect(watchedPaths).toEqual([schemaPath]);
   });
 
+  it("includes canonical schema bytes in the Vitest filesystem cache key", () => {
+    const rootDir = process.cwd();
+    const plugin = createStateSchemaInlinePlugin(rootDir, { vitestFsModuleCache: true });
+    let cacheKeyGenerator:
+      | ((context: { id: string; sourceCode: string; environment: unknown }) => unknown)
+      | undefined;
+    plugin.configureVitest?.({
+      experimental_defineCacheKeyGenerator(callback) {
+        cacheKeyGenerator = callback;
+      },
+    });
+
+    expect(
+      cacheKeyGenerator?.({
+        id: path.resolve(rootDir, "src/state/openclaw-state-schema.ts"),
+        sourceCode: "",
+        environment: {},
+      }),
+    ).toBe(readFileSync(path.resolve(rootDir, "src/state/openclaw-state-schema.sql"), "utf8"));
+    expect(
+      cacheKeyGenerator?.({
+        id: path.resolve(rootDir, "src/state/openclaw-state-db.ts"),
+        sourceCode: "",
+        environment: {},
+      }),
+    ).toBeUndefined();
+  });
+
   it("installs schema inlining only on the unified runtime graph", () => {
     const unifiedGraph = requireUnifiedDistGraph();
     const inlinePlugins = asConfigArray(tsdownConfig).flatMap(

--- a/src/node-host/invoke.test.ts
+++ b/src/node-host/invoke.test.ts
@@ -793,10 +793,11 @@ describe("node host invoke", () => {
             id: "invoke-suppress-notify-prepare",
             nodeId: "node-1",
             command: "system.run.prepare",
+            sessionKey: "agent:main:main",
             paramsJSON: JSON.stringify({
               command: [process.execPath, scriptPath],
               cwd: tempHome,
-              sessionKey: "agent:main:main",
+              sessionKey: "agent:forged:prepare",
             }),
           },
           { request } as unknown as GatewayClient,
@@ -816,12 +817,16 @@ describe("node host invoke", () => {
             id: "invoke-suppress-notify",
             nodeId: "node-1",
             command: "system.run",
+            sessionKey: "agent:main:main",
             paramsJSON: JSON.stringify({
               command: prepared.plan?.argv,
               rawCommand: prepared.plan?.commandText,
               cwd: prepared.plan?.cwd,
-              sessionKey: "agent:main:main",
-              systemRunPlan: prepared.plan,
+              sessionKey: "agent:forged:run",
+              systemRunPlan: {
+                ...prepared.plan,
+                sessionKey: "agent:forged:plan",
+              },
               approved: true,
               approvalDecision: "allow-once",
               suppressNotifyOnExit: true,
@@ -837,6 +842,7 @@ describe("node host invoke", () => {
             (params as { event?: string } | undefined)?.event === "exec.finished",
         )?.[1] as { payloadJSON?: string | null } | undefined;
         expect(JSON.parse(event?.payloadJSON ?? "{}")).toMatchObject({
+          sessionKey: "agent:main:main",
           suppressNotifyOnExit: true,
         });
       });

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -7,13 +7,15 @@ export const OPENCLAW_STATE_SCHEMA_VERSION = 6;
 export const OPENCLAW_STATE_STRICT_SCHEMA_VERSION = 3;
 // Privacy-sensitive feature tables remain absent even in fresh databases until
 // their feature-local first write. The canonical SQL still owns their shape.
-export const FIRST_USE_STATE_TABLES = ["execution_identity_contexts"] as const;
+export const FIRST_USE_STATE_TABLES = [
+  "audit_event_source_adoptions",
+  "execution_identity_contexts",
+] as const;
 export const FIRST_USE_STATE_INDEXES = ["execution_identity_contexts_run_created_idx"] as const;
 // Added after v6 shipped. These tables stay optional until their feature-local
 // lazy ensures run; fold them into the next natural schema-version bump.
 export const LAZY_ADDITIVE_STATE_TABLES = [
   ...FIRST_USE_STATE_TABLES,
-  "audit_event_source_adoptions",
   "model_catalog_remote",
   "sidebar_sections",
   "skill_workshop_proposal_events",

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -13,6 +13,7 @@ export const FIRST_USE_STATE_INDEXES = ["execution_identity_contexts_run_created
 // lazy ensures run; fold them into the next natural schema-version bump.
 export const LAZY_ADDITIVE_STATE_TABLES = [
   ...FIRST_USE_STATE_TABLES,
+  "audit_event_source_adoptions",
   "model_catalog_remote",
   "sidebar_sections",
   "skill_workshop_proposal_events",

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -110,6 +110,11 @@ export interface ApnsRegistrations {
   updated_at_ms: number;
 }
 
+export interface AuditEventSourceAdoptions {
+  adopted_source_id: string;
+  legacy_source_id: string;
+}
+
 export interface AuditEvents {
   account_ref: string | null;
   action: string;
@@ -1564,6 +1569,7 @@ export interface DB {
   android_notification_recent_packages: AndroidNotificationRecentPackages;
   apns_registration_tombstones: ApnsRegistrationTombstones;
   apns_registrations: ApnsRegistrations;
+  audit_event_source_adoptions: AuditEventSourceAdoptions;
   audit_events: AuditEvents;
   audit_identity_keys: AuditIdentityKeys;
   auth_profile_state: AuthProfileState;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -68,6 +68,16 @@ function createInitialStateSchemaShape() {
   return shape;
 }
 
+function expectFirstUseStateTablesAbsent(database: DatabaseSync): void {
+  for (const tableName of FIRST_USE_STATE_TABLES) {
+    expect(
+      database
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get(tableName),
+    ).toBeUndefined();
+  }
+}
+
 function expectStateSchemaMigrationRequired(
   run: () => unknown,
   expected: {
@@ -1091,11 +1101,7 @@ describe("openclaw state database", () => {
     });
 
     expect(collectSqliteSchemaShape(database.db)).toEqual(createInitialStateSchemaShape());
-    expect(
-      database.db
-        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
-        .get("execution_identity_contexts"),
-    ).toBeUndefined();
+    expectFirstUseStateTablesAbsent(database.db);
     expect(database.path).toBe(path.join(stateDir, "state", "openclaw.sqlite"));
     expect(
       database.db
@@ -3324,6 +3330,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
           requester_agent_id: "main",
         });
         expect(collectSqliteSchemaShape(db)).toEqual(expectedShape);
+        expectFirstUseStateTablesAbsent(db);
       } finally {
         db.close();
       }
@@ -3349,6 +3356,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
           db.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get(),
         ).toEqual({ schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
         expect(collectSqliteSchemaShape(db)).toEqual(expectedShape);
+        expectFirstUseStateTablesAbsent(db);
       } finally {
         db.close();
       }

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -189,6 +189,11 @@ CREATE INDEX IF NOT EXISTS idx_audit_events_channel_sequence
 CREATE INDEX IF NOT EXISTS idx_audit_events_direction_sequence
   ON audit_events(direction, sequence DESC);
 
+CREATE TABLE IF NOT EXISTS audit_event_source_adoptions (
+  legacy_source_id TEXT NOT NULL PRIMARY KEY,
+  adopted_source_id TEXT NOT NULL
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS audit_identity_keys (
   id INTEGER NOT NULL PRIMARY KEY CHECK (id = 1),
   key_id TEXT NOT NULL,

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -202,7 +202,7 @@ describe("production lint suppressions", () => {
         "src/agents/agent-bundle-mcp-runtime.ts|unicorn/prefer-add-event-listener|1",
         "src/agents/agent-tools.abort.ts|typescript/prefer-promise-reject-errors|1",
         "src/agents/sessions/session-manager-entries.ts|unicorn/prefer-structured-clone|1",
-        "src/audit/audit-event-writer.ts|unicorn/require-post-message-target-origin|2",
+        "src/audit/audit-event-writer.ts|unicorn/require-post-message-target-origin|1",
         "src/channels/plugins/channel-runtime-surface.types.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/contracts/test-helpers.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/types.plugin.ts|typescript/no-explicit-any|1",

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -160,7 +160,7 @@ if (!isCI && localScheduling.throttledBySystem && shouldPrintVitestThrottle(proc
 export const sharedVitestConfig = {
   root: repoRoot,
   envDir: false as const,
-  plugins: [createStateSchemaInlinePlugin(repoRoot)],
+  plugins: [createStateSchemaInlinePlugin(repoRoot, { vitestFsModuleCache: true })],
   resolve: {
     alias: [
       {


### PR DESCRIPTION
Related: #116528, #117034

Stack: 5 of 5. Previous: https://github.com/openclaw/openclaw/pull/116795

## What Problem This Solves

Durable audit projection could conflate reused run IDs, lose exact attribution after lifecycle rotation, persist terminal-only attempts, or mishandle replay of pre-generation audit rows.

## Why This Change Was Made

Projects private execution attribution into generation-aware audit provenance, owns delayed lifecycle/tool events through bounded leases, and adopts equivalent shipped generation-less source IDs without mutating historical rows.

## Relationship To Execution Identity Inspection

#117034 owns opt-in persistence and operator inspection. This PR consumes the private runtime attribution produced by the earlier stack layers and preserves #117034's config gate. It adds no competing config, public schema, prompt field, model input, app payload, or plugin SDK contract.

## User Impact

When execution-identity audit logging is enabled, run/tool provenance remains exact across retries, rotation, delayed terminals, and legacy replay. Disabled logging remains disabled.

## Evidence

- Exact head: `449bc4ad182`, stacked on repaired PR4 head `b00535e91cb`; full stack base is `c245cfc19c7`.
- PR5's replay patch is byte-equivalent to the previously reviewed `bbd812a3e84f98668eacfdd31ed10abbdc5f54b3` patch; only its ancestry changed to include PR3's run-ID authority repair and PR4's package-validator repair.
- Final exact-head proof passes all 21 changed test files: 476 tests across 9 shards.
- Stack-focused proof covers generation ordering, delayed tools/terminals, rejected starts, terminal replay, legacy adoption, and same-generation ownership transitions.
- Exact-checkout changed gate passed on Testbox `tbx_01kzap6xa5a99fhbby7vthcft4`, Actions `31072111830`.
- Exact-checkout full build passed on Testbox `tbx_01kzaq1essq9e8fdfb18ztbws4`, Actions `31072786125`.
- `git diff --check` is clean.

## ClawSweeper Resolution

- Rejected starts cannot produce terminal-only durable audit rows; pending unowned terminals migrate or cancel when an attempt gains an owner.
- Legacy source adoption survives restart and prunes orphaned rows only after checking the existing audit table.
- Same-generation context cleanup retains retired sequencing and ownership-token audit correctness.
- PR5 is restacked over PR4's owner-restricted authority-runtime and package-validator repairs; its audit logic is unchanged.
- No schema-version bump, competing config, or public inspection surface is introduced.

AI-assisted: yes; implementation, review decisions, and verification are maintainer-directed.