### PR TITLE
fix(qa-channel): preserve thread, tombstone, and reaction ownership

### DIFF
--- a/extensions/qa-channel/src/channel-actions.ts
+++ b/extensions/qa-channel/src/channel-actions.ts
@@ -163,6 +163,9 @@ export const qaChannelMessageActions: ChannelMessageActionAdapter = {
       // QA evidence must not validate a host target while the bus acts on a
       // foreign immutable message owner.
       assertQaMessageMatchesTarget(message, target);
+      if (message.deleted) {
+        throw new Error(`qa-channel message was deleted: ${message.id}`);
+      }
       return message;
     };
 

--- a/extensions/qa-channel/src/channel.test.ts
+++ b/extensions/qa-channel/src/channel.test.ts
@@ -706,6 +706,121 @@ describe("qa-channel plugin", () => {
     }
   });
 
+  it("keeps deleted messages out of channel actions and makes reactions idempotent", async () => {
+    installQaChannelTestRegistry();
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+
+    try {
+      const cfg = createQaChannelConfig({ baseUrl: bus.baseUrl });
+      const handleAction = requireQaActionHandler();
+      const live = state.addOutboundMessage({ to: "channel:qa-room", text: "needle live" });
+      const deleted = state.addOutboundMessage({ to: "channel:qa-room", text: "needle deleted" });
+      const actionContext = {
+        channel: "qa-channel" as const,
+        cfg,
+        accountId: "default",
+      };
+      const reactionParams = {
+        to: "channel:qa-room",
+        messageId: deleted.id,
+        emoji: "eyes",
+      };
+
+      await handleAction({ ...actionContext, action: "react", params: reactionParams });
+      const cursorAfterReaction = state.getSnapshot().cursor;
+      await handleAction({ ...actionContext, action: "react", params: reactionParams });
+      expect(state.getSnapshot().cursor).toBe(cursorAfterReaction);
+      expect(state.readMessage({ messageId: deleted.id }).reactions).toHaveLength(1);
+
+      await handleAction({
+        ...actionContext,
+        action: "delete",
+        params: { to: "channel:qa-room", messageId: deleted.id },
+      });
+
+      for (const action of ["read", "reactions", "react", "edit", "delete"] as const) {
+        await expect(
+          handleAction({
+            ...actionContext,
+            action,
+            params: {
+              to: "channel:qa-room",
+              messageId: deleted.id,
+              ...(action === "react" ? { emoji: "eyes" } : {}),
+              ...(action === "edit" ? { text: "edited after deletion" } : {}),
+            },
+          }),
+        ).rejects.toThrow("qa-channel message was deleted");
+      }
+
+      const result = await handleAction({
+        ...actionContext,
+        action: "search",
+        params: { query: "needle", channelId: "qa-room" },
+      });
+      const payload = extractToolPayload(result) as { messages: Array<{ id: string }> };
+      expect(payload.messages.map((message) => message.id)).toEqual([live.id]);
+      expect(state.readMessage({ messageId: deleted.id }).deleted).toBe(true);
+    } finally {
+      await bus.stop();
+    }
+  });
+
+  it("rejects thread replies outside the owning account and conversation", async () => {
+    installQaChannelTestRegistry();
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+
+    try {
+      const cfg = {
+        channels: {
+          "qa-channel": {
+            baseUrl: bus.baseUrl,
+            accounts: { other: { baseUrl: bus.baseUrl } },
+          },
+        },
+      };
+      const handleAction = requireQaActionHandler();
+      const thread = state.createThread({ conversationId: "qa-room", title: "Owned thread" });
+
+      for (const attempt of [
+        { accountId: "other", channelId: "qa-room" },
+        { accountId: "default", channelId: "other-room" },
+      ]) {
+        await expect(
+          handleAction({
+            channel: "qa-channel",
+            action: "thread-reply",
+            cfg,
+            accountId: attempt.accountId,
+            params: {
+              channelId: attempt.channelId,
+              threadId: thread.id,
+              text: "foreign reply",
+            },
+          }),
+        ).rejects.toThrow("qa-bus thread not found in selected account and conversation");
+      }
+      expect(state.getSnapshot().messages).toEqual([]);
+      expect(state.getSnapshot().conversations).toEqual([
+        { accountId: "default", id: "qa-room", kind: "channel" },
+      ]);
+
+      const result = await handleAction({
+        channel: "qa-channel",
+        action: "thread-reply",
+        cfg,
+        accountId: "default",
+        params: { channelId: "qa-room", threadId: thread.id, text: "owned reply" },
+      });
+      const payload = extractToolPayload(result) as { message: { threadId: string } };
+      expect(payload.message.threadId).toBe(thread.id);
+    } finally {
+      await bus.stop();
+    }
+  });
+
   it("binds message-id actions and searches to the selected account and conversation", async () => {
     installQaChannelTestRegistry();
     const state = createQaBusState();

--- a/extensions/qa-lab/src/bus-queries.ts
+++ b/extensions/qa-lab/src/bus-queries.ts
@@ -115,7 +115,7 @@ export function searchQaBusMessages(params: {
   const limit = Math.max(1, Math.min(params.input.limit ?? 20, 100));
   const query = normalizeOptionalLowercaseString(params.input.query);
   return Array.from(params.messages.values())
-    .filter((message) => message.accountId === accountId)
+    .filter((message) => message.accountId === accountId && !message.deleted)
     .filter((message) =>
       params.input.conversationId !== undefined
         ? message.conversation.id === params.input.conversationId

--- a/extensions/qa-lab/src/bus-state.test.ts
+++ b/extensions/qa-lab/src/bus-state.test.ts
@@ -113,6 +113,110 @@ describe("qa-bus state", () => {
     expect(typeof snapshot.messages[0]?.reactions[0]?.timestamp).toBe("number");
   });
 
+  it("keeps deleted messages inspectable but removes them from mutations and search", () => {
+    const state = createQaBusState();
+    const live = state.addOutboundMessage({ to: "channel:qa-room", text: "needle live" });
+    const deleted = state.addOutboundMessage({ to: "channel:qa-room", text: "needle deleted" });
+
+    state.deleteMessage({ messageId: deleted.id });
+    const cursorAfterDelete = state.getSnapshot().cursor;
+
+    expect(state.readMessage({ messageId: deleted.id }).deleted).toBe(true);
+    expect(state.getSnapshot().messages.map((message) => message.id)).toEqual([
+      live.id,
+      deleted.id,
+    ]);
+    expect(state.searchMessages({ query: "needle", limit: 1 })).toEqual([
+      expect.objectContaining({ id: live.id }),
+    ]);
+
+    expect(() =>
+      state.editMessage({ messageId: deleted.id, text: "edited after deletion" }),
+    ).toThrow("qa-bus message was deleted");
+    expect(() => state.reactToMessage({ messageId: deleted.id, emoji: "eyes" })).toThrow(
+      "qa-bus message was deleted",
+    );
+    expect(() => state.deleteMessage({ messageId: deleted.id })).toThrow(
+      "qa-bus message was deleted",
+    );
+    expect(state.getSnapshot().cursor).toBe(cursorAfterDelete);
+  });
+
+  it("adds each sender and emoji reaction at most once", () => {
+    const state = createQaBusState();
+    const message = state.addOutboundMessage({ to: "channel:qa-room", text: "react once" });
+
+    state.reactToMessage({ messageId: message.id, emoji: "eyes", senderId: " alice " });
+    const cursorAfterReaction = state.getSnapshot().cursor;
+
+    const repeated = state.reactToMessage({
+      messageId: message.id,
+      emoji: "eyes",
+      senderId: "alice",
+    });
+    expect(repeated.reactions).toHaveLength(1);
+    expect(state.getSnapshot().cursor).toBe(cursorAfterReaction);
+
+    state.reactToMessage({ messageId: message.id, emoji: "eyes", senderId: "bob" });
+    state.reactToMessage({ messageId: message.id, emoji: "wave", senderId: "alice" });
+    expect(state.readMessage({ messageId: message.id }).reactions).toEqual([
+      expect.objectContaining({ emoji: "eyes", senderId: "alice" }),
+      expect.objectContaining({ emoji: "eyes", senderId: "bob" }),
+      expect.objectContaining({ emoji: "wave", senderId: "alice" }),
+    ]);
+    expect(state.getSnapshot().cursor).toBe(cursorAfterReaction + 2);
+  });
+
+  it("keeps owned threads scoped to their account, channel, and conversation", () => {
+    const state = createQaBusState();
+    const thread = state.createThread({
+      accountId: "account-a",
+      conversationId: "qa-room",
+      title: "Owned thread",
+    });
+    const originalSnapshot = state.getSnapshot();
+
+    expect(() =>
+      state.addOutboundMessage({
+        accountId: "account-b",
+        to: `thread:qa-room/${thread.id}`,
+        text: "cross-account reply",
+      }),
+    ).toThrow("qa-bus thread not found in selected account and conversation");
+    expect(() =>
+      state.addOutboundMessage({
+        accountId: "account-a",
+        to: `thread:other-room/${thread.id}`,
+        text: "wrong-room reply",
+      }),
+    ).toThrow("qa-bus thread not found in selected account and conversation");
+    for (const kind of ["direct", "group"] as const) {
+      expect(() =>
+        state.addInboundMessage({
+          accountId: "account-a",
+          conversation: { id: "qa-room", kind },
+          senderId: "alice",
+          text: "wrong-kind reply",
+          threadId: thread.id,
+        }),
+      ).toThrow("qa-bus thread not found in selected account and conversation");
+    }
+    expect(state.getSnapshot()).toEqual(originalSnapshot);
+
+    const reply = state.addOutboundMessage({
+      accountId: "account-a",
+      to: `thread:qa-room/${thread.id}`,
+      text: "owned reply",
+    });
+    const external = state.addOutboundMessage({
+      accountId: "account-b",
+      to: "thread:other-room/external-thread",
+      text: "externally observed reply",
+    });
+    expect(reply.threadId).toBe(thread.id);
+    expect(external.threadId).toBe("external-thread");
+  });
+
   it("rejects cross-account message reads and mutations", () => {
     const state = createQaBusState();
     const message = state.addOutboundMessage({

--- a/extensions/qa-lab/src/bus-state.ts
+++ b/extensions/qa-lab/src/bus-state.ts
@@ -122,6 +122,16 @@ export function createQaBusState() {
     return created;
   };
 
+  const requireActiveMessageForAccount = (
+    input: Pick<QaBusReadMessageInput, "accountId" | "messageId">,
+  ): QaBusMessage => {
+    const message = requireQaBusMessageForAccount({ messages, input });
+    if (message.deleted) {
+      throw new Error(`qa-bus message was deleted: ${input.messageId}`);
+    }
+    return message;
+  };
+
   const createMessage = (params: {
     direction: QaBusMessage["direction"];
     accountId: string;
@@ -137,6 +147,17 @@ export function createQaBusState() {
     nativeCommand?: QaBusInboundMessageInput["nativeCommand"];
     toolCalls?: QaBusToolCall[];
   }): QaBusMessage => {
+    const thread = params.threadId ? threads.get(params.threadId) : undefined;
+    if (
+      thread &&
+      (thread.accountId !== params.accountId ||
+        thread.conversationId !== params.conversation.id ||
+        params.conversation.kind !== "channel")
+    ) {
+      // Unknown ids can represent externally observed threads; owned records
+      // must never cross account, conversation, or channel-kind boundaries.
+      throw new Error("qa-bus thread not found in selected account and conversation");
+    }
     const storedConversation = ensureConversation(params.accountId, params.conversation);
     const toolCalls = sanitizeQaBusToolCalls(params.toolCalls);
     const message: QaBusMessage = {
@@ -257,12 +278,20 @@ export function createQaBusState() {
     },
     reactToMessage(input: QaBusReactToMessageInput) {
       const accountId = normalizeAccountId(input.accountId);
-      const message = requireQaBusMessageForAccount({ messages, input });
+      const message = requireActiveMessageForAccount(input);
       const reaction = {
         emoji: input.emoji,
         senderId: input.senderId?.trim() || DEFAULT_BOT_ID,
         timestamp: input.timestamp ?? Date.now(),
       };
+      if (
+        message.reactions.some(
+          (existing) =>
+            existing.emoji === reaction.emoji && existing.senderId === reaction.senderId,
+        )
+      ) {
+        return cloneMessage(message);
+      }
       message.reactions.push(reaction);
       pushEvent({
         kind: "reaction-added",
@@ -275,7 +304,7 @@ export function createQaBusState() {
     },
     editMessage(input: QaBusEditMessageInput) {
       const accountId = normalizeAccountId(input.accountId);
-      const message = requireQaBusMessageForAccount({ messages, input });
+      const message = requireActiveMessageForAccount(input);
       message.text = input.text;
       message.editedAt = input.timestamp ?? Date.now();
       pushEvent({
@@ -287,7 +316,7 @@ export function createQaBusState() {
     },
     deleteMessage(input: QaBusDeleteMessageInput) {
       const accountId = normalizeAccountId(input.accountId);
-      const message = requireQaBusMessageForAccount({ messages, input });
+      const message = requireActiveMessageForAccount(input);
       message.deleted = true;
       pushEvent({
         kind: "message-deleted",

--- a/extensions/qa-lab/src/self-check.test.ts
+++ b/extensions/qa-lab/src/self-check.test.ts
@@ -125,6 +125,13 @@ describe("createQaSelfCheckScenario", () => {
       "thread:qa-room/thread-1",
       "thread:qa-room/thread-1",
     ]);
-    expect(state.searchMessages({ query: "inside thread" }).at(-1)?.deleted).toBe(true);
+    const deletedMessage = state.getSnapshot().messages.find((message) => message.deleted);
+    if (!deletedMessage) {
+      throw new Error("self-check did not preserve its deleted message tombstone");
+    }
+    expect(state.readMessage({ messageId: deletedMessage.id }).deleted).toBe(true);
+    expect(
+      state.searchMessages({ query: "inside thread" }).map((message) => message.id),
+    ).not.toContain(deletedMessage.id);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where QA-channel users could reply to a synthetic thread belonging to another account or conversation, continue reading or changing deleted messages through normal channel actions, and create duplicate reactions and events by applying the same reaction repeatedly.

## Why This Change Was Made

Enforce all three invariants in their existing QA bus and channel-action owners. Validate known synthetic thread records before creating any conversation, message, or event; retain unknown externally observed thread IDs; preserve deleted-message tombstones for diagnostic snapshots and direct owner reads while excluding them from canonical search and user actions; and make repeated additions of the same sender/emoji pair a no-op without advancing the event cursor.

## User Impact

QA scenarios cannot cross account, channel-kind, or conversation ownership through a known thread. Deleted messages no longer appear as live search results or accept reads, edits, reactions, or repeated deletion through channel actions, while maintainers can still inspect diagnostic tombstones. Replaying an identical reaction no longer duplicates evidence or wakes cursor-based consumers.

## Evidence

- Branch: `codex/auto-qa-channel-lifecycle`.
- Exact candidate SHA: `52c18095c6a1a61d8d0cb0b3461e2f271d861d83`.
- Frozen reviewed base: `82231b425b7f574e70c03bc32bb954a78bc3377b`.
- Focused owner and real HTTP channel-action proof: **44 tests passed across three files**:
  `node scripts/run-vitest.mjs extensions/qa-lab/src/bus-state.test.ts extensions/qa-lab/src/self-check.test.ts extensions/qa-channel/src/channel.test.ts`.
- Regressions cover foreign account, wrong room, wrong conversation kind, no failed-write side effects, valid owned threads, unknown external thread IDs, diagnostic tombstone retention, deleted-action rejection, search filtering before limits, normalized sender/emoji idempotence, unchanged cursors, distinct reactions, and the existing self-check scenario.
- Separate strict read-only whole-owner review: **CLEAN**.
- Final automated autoreview and secret scan: **CLEAN**; correctness confidence **0.93**.
- Targeted formatting, `git diff --check`, exact parent SHA, and clean committed worktree verified.

## Root Causes Fixed

**3 distinct conservative owner roots:**

1. Known synthetic threads had no account/conversation/channel ownership check at message creation.
2. Diagnostic deletion tombstones leaked into canonical search and live user-action/mutation surfaces.
3. Reaction insertion lacked sender-and-emoji idempotence and emitted duplicate events.

## Authorized Scope And Non-Goals

User-authorized scope: bounded QA-channel and QA-bus owner correctness only. No authentication, security, public configuration, plugin SDK, QA protocol/event schema, persistent store, database schema, migration, gateway acknowledgement, or product-policy changes. Delivery acknowledgement redesign and actual reaction removal remain explicitly outside this PR.
