### PR TITLE
fix(qa-lab): support group conversations and scoped thread navigation

### DIFF
--- a/extensions/qa-lab/web/src/app.browser.test.ts
+++ b/extensions/qa-lab/web/src/app.browser.test.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Bootstrap, RunnerSelection } from "./ui-types.js";
+import type { Bootstrap, RunnerSelection, Snapshot } from "./ui-types.js";
 
 const httpMock = vi.hoisted(() => {
   class QaLabHttpError extends Error {
@@ -103,14 +103,17 @@ function createBootstrap(selection: RunnerSelection): Bootstrap {
   };
 }
 
-async function mountRunner(selection: RunnerSelection) {
+async function mountRunner(
+  selection: RunnerSelection,
+  snapshot: Snapshot = { conversations: [], events: [], messages: [], threads: [] },
+) {
   let bootstrap = createBootstrap(selection);
   httpMock.getJson.mockImplementation(async (url: string) => {
     if (url === "/api/bootstrap") {
       return bootstrap;
     }
     if (url === "/api/state") {
-      return { conversations: [], events: [], messages: [], threads: [] };
+      return snapshot;
     }
     if (url === "/api/report") {
       return { report: null };
@@ -195,6 +198,66 @@ afterEach(() => {
 });
 
 describe("QA Lab runner browser interactions", () => {
+  it("sends group conversation messages from the interactive chat composer", async () => {
+    const root = await mountRunner(
+      {
+        alternateModel: "mock-openai/gpt-5.6-luna-alt",
+        channel: null,
+        channelDriver: "qa-channel",
+        evidenceMode: "full",
+        fastMode: false,
+        primaryModel: "mock-openai/gpt-5.6-luna",
+        profile: "all",
+        providerMode: "mock-openai",
+        runtimePair: null,
+        runtimePairLane: null,
+        scenarioIds: ["dm-chat-baseline"],
+      },
+      {
+        conversations: [{ accountId: "default", id: "qa-room", kind: "channel" }],
+        events: [],
+        messages: [],
+        threads: [
+          {
+            accountId: "default",
+            conversationId: "qa-room",
+            id: "owned-thread",
+            title: "Owned thread",
+          },
+        ],
+      },
+    );
+    httpMock.postJson.mockResolvedValue({ message: { id: "group-message" } });
+
+    root.querySelector<HTMLButtonElement>("[data-thread-select='owned-thread']")?.click();
+    selectValue(root, "#conversation-kind", "group");
+    const conversationInput = root.querySelector<HTMLInputElement>("#conversation-id");
+    if (!conversationInput) {
+      throw new Error("missing group conversation input");
+    }
+    conversationInput.value = "qa-group";
+    conversationInput.dispatchEvent(new Event("input", { bubbles: true }));
+    const composer = root.querySelector<HTMLTextAreaElement>("#composer-text");
+    if (!composer) {
+      throw new Error("missing group message composer");
+    }
+    composer.value = "hello group";
+    composer.dispatchEvent(new Event("input", { bubbles: true }));
+    root.querySelector<HTMLButtonElement>("[data-action='send']")?.click();
+
+    await vi.waitFor(() => expect(httpMock.postJson).toHaveBeenCalledTimes(1));
+    expect(httpMock.postJson).toHaveBeenCalledWith(
+      "/api/inbound/message",
+      expect.objectContaining({
+        accountId: "default",
+        conversation: { id: "qa-group", kind: "group", title: "qa-group" },
+        text: "hello group",
+      }),
+    );
+    const submittedPayload = httpMock.postJson.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(submittedPayload).not.toHaveProperty("threadId");
+  });
+
   it("keeps scenario rows from collapsing inside the scrolling list", async () => {
     const root = await mountRunner({
       alternateModel: "mock-openai/gpt-5.6-luna-alt",

--- a/extensions/qa-lab/web/src/app.ts
+++ b/extensions/qa-lab/web/src/app.ts
@@ -579,23 +579,29 @@ export async function createQaLabApp(root: HTMLDivElement) {
         state.selectedConversationKey,
       );
       const accountId = selectedConversation?.accountId ?? "default";
+      const selectedThreadId =
+        selectedConversation?.id === conversationId &&
+        selectedConversation.kind === state.composer.conversationKind
+          ? state.selectedThreadId
+          : null;
       await postJson("/api/inbound/message", {
         accountId,
         conversation: {
           id: conversationId,
           kind: state.composer.conversationKind,
-          ...(state.composer.conversationKind === "channel" ? { title: conversationId } : {}),
+          ...(state.composer.conversationKind !== "direct" ? { title: conversationId } : {}),
         },
         senderId: state.composer.senderId.trim() || "alice",
         senderName: state.composer.senderName.trim() || undefined,
         text,
-        ...(state.selectedThreadId ? { threadId: state.selectedThreadId } : {}),
+        ...(selectedThreadId ? { threadId: selectedThreadId } : {}),
       });
       state.selectedConversationKey = conversationSelectionKey({
         accountId,
         id: conversationId,
         kind: state.composer.conversationKind,
       });
+      state.selectedThreadId = selectedThreadId;
       state.composer.text = "";
       chatScrollLocked = true;
       await refresh();
@@ -1737,8 +1743,9 @@ export async function createQaLabApp(root: HTMLDivElement) {
 
     /* Composer form */
     root.querySelector<HTMLSelectElement>("#conversation-kind")?.addEventListener("change", (e) => {
+      const selectedKind = (e.currentTarget as HTMLSelectElement).value;
       state.composer.conversationKind =
-        (e.currentTarget as HTMLSelectElement).value === "channel" ? "channel" : "direct";
+        selectedKind === "channel" || selectedKind === "group" ? selectedKind : "direct";
     });
     root.querySelector<HTMLInputElement>("#conversation-id")?.addEventListener("input", (e) => {
       state.composer.conversationId = (e.currentTarget as HTMLInputElement).value;

--- a/extensions/qa-lab/web/src/ui-render-content.ts
+++ b/extensions/qa-lab/web/src/ui-render-content.ts
@@ -69,6 +69,11 @@ function deriveSelectedThread(state: UiState): string | null {
 
 function filteredMessages(state: UiState) {
   const messages = state.snapshot?.messages ?? [];
+  const selectedConversationThreadIds = new Set(
+    (state.snapshot?.threads ?? [])
+      .filter((thread) => threadConversationSelectionKey(thread) === state.selectedConversationKey)
+      .map((thread) => thread.id),
+  );
   return messages.filter((message) => {
     if (
       state.selectedConversationKey &&
@@ -76,10 +81,12 @@ function filteredMessages(state: UiState) {
     ) {
       return false;
     }
-    if (state.selectedThreadId && message.threadId !== state.selectedThreadId) {
-      return false;
+    if (state.selectedThreadId) {
+      return message.threadId === state.selectedThreadId;
     }
-    return true;
+    // External thread ids have no sidebar record, even when the conversation
+    // also owns navigable threads, so keep their messages in the root view.
+    return !message.threadId || !selectedConversationThreadIds.has(message.threadId);
   });
 }
 
@@ -88,18 +95,28 @@ function formatConversationLabel(
   conversations: Conversation[],
 ): string {
   const label = conversation.title || conversation.id;
-  const hasAccountCollision = conversations.some(
+  const sidebarCollisions = conversations.filter(
     (candidate) =>
-      candidate.accountId !== conversation.accountId &&
-      candidate.kind === conversation.kind &&
-      candidate.id === conversation.id,
+      candidate !== conversation &&
+      candidate.id === conversation.id &&
+      (candidate.kind === "direct") === (conversation.kind === "direct"),
   );
-  return hasAccountCollision ? `${label} (${conversation.accountId})` : label;
+  const hasAccountCollision = sidebarCollisions.some(
+    (candidate) => candidate.accountId !== conversation.accountId,
+  );
+  const hasKindCollision = sidebarCollisions.some(
+    (candidate) => candidate.kind !== conversation.kind,
+  );
+  const disambiguators = [
+    ...(hasKindCollision ? [conversation.kind] : []),
+    ...(hasAccountCollision ? [conversation.accountId] : []),
+  ];
+  return disambiguators.length > 0 ? `${label} (${disambiguators.join(", ")})` : label;
 }
 
 export function renderChatView(state: UiState): string {
   const conversations = state.snapshot?.conversations ?? [];
-  const channels = conversations.filter((c) => c.kind === "channel");
+  const channels = conversations.filter((c) => c.kind === "channel" || c.kind === "group");
   const dms = conversations.filter((c) => c.kind === "direct");
   const threads = (state.snapshot?.threads ?? []).filter(
     (thread) =>
@@ -205,6 +222,7 @@ export function renderChatView(state: UiState): string {
             <select id="conversation-kind">
               <option value="direct"${state.composer.conversationKind === "direct" ? " selected" : ""}>DM</option>
               <option value="channel"${state.composer.conversationKind === "channel" ? " selected" : ""}>Channel</option>
+              <option value="group"${state.composer.conversationKind === "group" ? " selected" : ""}>Group</option>
             </select>
             <span>as</span>
             <input id="sender-name" value="${esc(state.composer.senderName)}" placeholder="Name" />

--- a/extensions/qa-lab/web/src/ui-render.test.ts
+++ b/extensions/qa-lab/web/src/ui-render.test.ts
@@ -158,6 +158,172 @@ describe("QA Lab UI evidence render", () => {
     expect(html).toContain(
       `data-conversation-key="${selectedConversationKey.replaceAll('"', "&quot;")}"`,
     );
+
+    const crossAccountKindHtml = renderQaLabUi(
+      evidenceState({
+        activeTab: "chat",
+        snapshot: {
+          conversations: [
+            { accountId: "account-a", id: "shared", kind: "group" },
+            { accountId: "account-b", id: "shared", kind: "channel" },
+          ],
+          events: [],
+          messages: [],
+          threads: [],
+        },
+      }),
+    );
+    expect(crossAccountKindHtml).toContain("shared (group, account-a)");
+    expect(crossAccountKindHtml).toContain("shared (channel, account-b)");
+  });
+
+  it("shows group conversations in the sidebar and composer without leaking same-id rooms", () => {
+    const selectedConversationKey = JSON.stringify(["account-a", "group", "shared"]);
+    const html = renderQaLabUi(
+      evidenceState({
+        activeTab: "chat",
+        selectedConversationKey,
+        composer: {
+          conversationId: "shared",
+          conversationKind: "group",
+          senderId: "alice",
+          senderName: "Alice",
+          text: "",
+        },
+        snapshot: {
+          conversations: [
+            { accountId: "account-a", id: "shared", kind: "group" },
+            { accountId: "account-b", id: "shared", kind: "group" },
+            { accountId: "account-a", id: "shared", kind: "channel" },
+            { accountId: "account-a", id: "shared", kind: "direct" },
+          ],
+          events: [],
+          messages: [
+            {
+              accountId: "account-a",
+              conversation: { id: "shared", kind: "group" },
+              direction: "inbound",
+              id: "selected-group-message",
+              reactions: [],
+              senderId: "alice",
+              text: "selected group message",
+              timestamp: 1,
+            },
+            {
+              accountId: "account-b",
+              conversation: { id: "shared", kind: "group" },
+              direction: "inbound",
+              id: "foreign-group-message",
+              reactions: [],
+              senderId: "bob",
+              text: "foreign group message",
+              timestamp: 2,
+            },
+            {
+              accountId: "account-a",
+              conversation: { id: "shared", kind: "channel" },
+              direction: "outbound",
+              id: "same-id-channel-message",
+              reactions: [],
+              senderId: "openclaw",
+              text: "same-id channel message",
+              timestamp: 3,
+            },
+          ],
+          threads: [],
+        },
+      }),
+    );
+
+    expect(html).toContain("shared (group, account-a)");
+    expect(html).toContain("shared (group, account-b)");
+    expect(html).toContain("shared (channel, account-a)");
+    expect(html).toContain("selected group message");
+    expect(html).not.toContain("foreign group message");
+    expect(html).not.toContain("same-id channel message");
+    expect(html).toContain('<option value="group" selected>Group</option>');
+    expect(html).toContain(
+      `data-conversation-key="${selectedConversationKey.replaceAll('"', "&quot;")}"`,
+    );
+  });
+
+  it("keeps thread replies out of the root timeline when thread navigation exists", () => {
+    const selectedConversationKey = JSON.stringify(["default", "channel", "qa-room"]);
+    const snapshot: NonNullable<UiState["snapshot"]> = {
+      conversations: [{ accountId: "default", id: "qa-room", kind: "channel" }],
+      events: [],
+      messages: [
+        {
+          accountId: "default",
+          conversation: { id: "qa-room", kind: "channel" },
+          direction: "outbound",
+          id: "root-message",
+          reactions: [],
+          senderId: "openclaw",
+          text: "root timeline message",
+          timestamp: 1,
+        },
+        {
+          accountId: "default",
+          conversation: { id: "qa-room", kind: "channel" },
+          direction: "outbound",
+          id: "thread-message",
+          reactions: [],
+          senderId: "openclaw",
+          text: "thread-only reply",
+          threadId: "owned-thread",
+          timestamp: 2,
+        },
+        {
+          accountId: "default",
+          conversation: { id: "qa-room", kind: "channel" },
+          direction: "outbound",
+          id: "external-thread-message",
+          reactions: [],
+          senderId: "openclaw",
+          text: "externally observed thread reply",
+          threadId: "external-thread",
+          timestamp: 3,
+        },
+      ],
+      threads: [
+        {
+          accountId: "default",
+          conversationId: "qa-room",
+          id: "owned-thread",
+          title: "Owned thread",
+        },
+      ],
+    };
+
+    const rootHtml = renderQaLabUi(
+      evidenceState({ activeTab: "chat", selectedConversationKey, snapshot }),
+    );
+    expect(rootHtml).toContain("Main timeline");
+    expect(rootHtml).toContain("root timeline message");
+    expect(rootHtml).not.toContain("thread-only reply");
+    expect(rootHtml).toContain("externally observed thread reply");
+
+    const threadHtml = renderQaLabUi(
+      evidenceState({
+        activeTab: "chat",
+        selectedConversationKey,
+        selectedThreadId: "owned-thread",
+        snapshot,
+      }),
+    );
+    expect(threadHtml).not.toContain("root timeline message");
+    expect(threadHtml).toContain("thread-only reply");
+    expect(threadHtml).not.toContain("externally observed thread reply");
+
+    const externalThreadHtml = renderQaLabUi(
+      evidenceState({
+        activeTab: "chat",
+        selectedConversationKey,
+        snapshot: { ...snapshot, threads: [] },
+      }),
+    );
+    expect(externalThreadHtml).toContain("thread-only reply");
   });
 
   it("renders capture startup commands without personal home paths", () => {

--- a/extensions/qa-lab/web/src/ui-types.ts
+++ b/extensions/qa-lab/web/src/ui-types.ts
@@ -18,7 +18,7 @@ import type {
 export type Conversation = {
   accountId: string;
   id: string;
-  kind: "direct" | "channel";
+  kind: "direct" | "channel" | "group";
   title?: string;
 };
 
@@ -371,7 +371,7 @@ export type UiState = {
   runnerDraftDirty: boolean;
   runnerPlanOverride: RunnerResolvedPlan | null;
   composer: {
-    conversationKind: "direct" | "channel";
+    conversationKind: "direct" | "channel" | "group";
     conversationId: string;
     senderId: string;
     senderName: string;


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where documented QA-channel group conversations were missing from the QA debugger sidebar and composer, and where the debugger mixed owned thread replies into the root timeline or carried a selected channel thread into another account/conversation target.

## Why This Change Was Made

Teach the private QA debugger's existing conversation types, sidebar, composer, and inbound-send flow about groups. Keep account/kind collision labels unambiguous, filter only navigable owned thread replies from the main timeline while retaining externally observed threads, and preserve selected thread IDs only when the composer still targets their owning conversation.

## User Impact

Operators can discover, distinguish, select, and send to group conversations directly in QA Lab. Account- and kind-colliding room names remain distinguishable, channel root timelines no longer contain replies from owned thread views, externally observed unowned threads remain visible, and switching from a selected channel thread to a group cannot leak the stale thread identifier.

## Evidence

- Branch: `codex/auto-qa-lab-groups`.
- Exact candidate SHA: `9d87f564690e9f9c296676e7788fa241e843daf0`.
- Frozen reviewed base: `82231b425b7f574e70c03bc32bb954a78bc3377b`.
- Focused private debugger render, real jsdom/browser interaction, and conversation-identity proof: **21 tests passed across three files**:
  `node scripts/run-vitest.mjs extensions/qa-lab/web/src/ui-render.test.ts extensions/qa-lab/web/src/app.browser.test.ts extensions/qa-lab/web/src/ui-conversation-key.test.ts`.
- Browser regression selects a real existing owned channel thread, switches the live composer to a group, sends the message, and verifies the actual inbound HTTP payload has group kind and **no stale thread ID**.
- Render regressions cover group sidebar visibility, direct/group/channel and account identity collisions, cross-account/cross-kind same-label disambiguation, owned root-versus-thread filtering, and unknown external thread visibility when owned threads coexist.
- Separate strict read-only whole-owner review and final follow-up: **CLEAN**.
- Final automated autoreview and secret scan: **CLEAN**; correctness confidence **0.89**.
- Targeted formatting, `git diff --check`, exact parent SHA, and clean committed worktree verified.

## Root Causes Fixed

**2 distinct conservative private-debugger roots:**

1. Group conversation support was absent from the debugger's private conversation types, discoverability, composer selection, and actual inbound-send flow.
2. Root/thread/account conversation scope was not preserved consistently across timeline filtering, sidebar identity, and selected-thread reuse during composer target changes.

## Authorized Scope And Non-Goals

User-authorized scope: bounded private QA debugger group/thread correctness only. No authentication, security, public configuration, plugin SDK, QA protocol/event schema, persistent store, database schema, migration, gateway acknowledgement, or reaction-contract changes. Delivery acknowledgement redesign and actual reaction removal remain explicitly outside this PR.
