### PR TITLE
fix(plugins): clean up failed service starts and deduplicate shutdown

### DIFF
--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -169,6 +169,72 @@ describe("startPluginServices", () => {
     expectServiceLifecycleState({ starts, stops, contexts, config });
   });
 
+  it("rolls back partially started services before starting their siblings", async () => {
+    const acquired = new Set<string>();
+    const received = vi.fn();
+    const siblingStart = vi.fn();
+    const rollback = vi.fn((ctx: OpenClawPluginServiceContext) => {
+      acquired.delete("failed-service");
+      ctx.gatewayEvents?.emit("rolled-back", {}, { scope: "operator.read" });
+    });
+    const broadcastPluginEvent = vi.fn();
+
+    const handle = await startPluginServices({
+      registry: createRegistry([
+        {
+          id: "failed-service",
+          start: (ctx) => {
+            acquired.add("failed-service");
+            ctx.gatewayEvents?.onSessionsChanged(received);
+            throw new Error("start failed after acquiring resources");
+          },
+          stop: rollback,
+        },
+        { id: "sibling-service", start: siblingStart },
+      ]),
+      config: createServiceConfig(),
+      broadcastPluginEvent,
+    });
+
+    expect(rollback).toHaveBeenCalledOnce();
+    expect(acquired.size).toBe(0);
+    expect(siblingStart).toHaveBeenCalledOnce();
+    expect(broadcastPluginEvent).toHaveBeenCalledWith(
+      "plugin.plugin:test.rolled-back",
+      {},
+      "operator.read",
+    );
+
+    queuePluginSessionsChanged({ sessionKey: "agent:main:main" });
+    await Promise.resolve();
+    expect(received).not.toHaveBeenCalled();
+
+    await handle.stop();
+    expect(rollback).toHaveBeenCalledOnce();
+  });
+
+  it("runs concurrent and repeated shutdowns through one cleanup operation", async () => {
+    let releaseStop: (() => void) | undefined;
+    const stopping = new Promise<void>((resolve) => {
+      releaseStop = resolve;
+    });
+    const stop = vi.fn(() => stopping);
+    const handle = await startTrackingServices({
+      services: [{ id: "service", start: () => {}, stop }],
+    });
+
+    const firstStop = handle.stop();
+    const secondStop = handle.stop();
+    releaseStop?.();
+    await Promise.all([firstStop, secondStop]);
+
+    expect(firstStop).toBe(secondStop);
+    expect(stop).toHaveBeenCalledOnce();
+
+    await handle.stop();
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
   it("binds gateway events to the owning plugin namespace and scope", async () => {
     const broadcastPluginEvent = vi.fn();
     await startPluginServices({
@@ -443,6 +509,35 @@ describe("startPluginServices", () => {
     ]);
     expect(stopOk).toHaveBeenCalledOnce();
     expect(stopThrows).toHaveBeenCalledOnce();
+  });
+
+  it("continues starting siblings when rollback also fails", async () => {
+    const rollback = vi.fn(() => {
+      throw new Error("rollback failed");
+    });
+    const siblingStart = vi.fn();
+
+    const handle = await startTrackingServices({
+      services: [
+        {
+          id: "failed-service",
+          start: () => {
+            throw new Error("start failed");
+          },
+          stop: rollback,
+        },
+        { id: "sibling-service", start: siblingStart },
+      ],
+    });
+
+    expect(rollback).toHaveBeenCalledOnce();
+    expect(siblingStart).toHaveBeenCalledOnce();
+    expect(mockedLogger.warn).toHaveBeenCalledWith(
+      "plugin service stop failed (failed-service): Error: rollback failed",
+    );
+
+    await handle.stop();
+    expect(rollback).toHaveBeenCalledOnce();
   });
 
   it("emits per-service startup trace spans and summary", async () => {

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -174,6 +174,17 @@ export async function startPluginServices(params: {
     stop?: () => void | Promise<void>;
     revokeGatewayEvents: () => void;
   }> = [];
+  const stopService = async (entry: (typeof running)[number]) => {
+    try {
+      if (entry.stop) {
+        await withPluginHttpRouteRegistry(params.registry, () => entry.stop?.());
+      }
+    } catch (err) {
+      log.warn(`plugin service stop failed (${entry.id}): ${String(err)}`);
+    } finally {
+      entry.revokeGatewayEvents();
+    }
+  };
   let failedCount = 0;
   for (const entry of params.registry.services) {
     const service = entry.service;
@@ -189,6 +200,11 @@ export async function startPluginServices(params: {
       service: entry,
       gatewayEvents: scopedGatewayEvents.gatewayEvents,
     });
+    const runningService = {
+      id: service.id,
+      stop: service.stop ? () => service.stop?.(serviceContext) : undefined,
+      revokeGatewayEvents: scopedGatewayEvents.revoke,
+    };
     try {
       const startService = () =>
         withPluginHttpRouteRegistry(params.registry, () => service.start(serviceContext));
@@ -197,18 +213,15 @@ export async function startPluginServices(params: {
       } else {
         await startService();
       }
-      running.push({
-        id: service.id,
-        stop: service.stop ? () => service.stop?.(serviceContext) : undefined,
-        revokeGatewayEvents: scopedGatewayEvents.revoke,
-      });
+      running.push(runningService);
     } catch (err) {
-      scopedGatewayEvents.revoke();
       failedCount += 1;
       const error = err as Error;
       log.error(
         `plugin service failed (${service.id}, plugin=${entry.pluginId}, root=${entry.rootDir ?? "unknown"}): ${error?.message ?? String(err)}`,
       );
+      // A failed start can already own resources; revoke events only after its cleanup runs.
+      await stopService(runningService);
     }
   }
   params.startupTrace?.detail?.("sidecars.plugin-services.summary", [
@@ -217,19 +230,14 @@ export async function startPluginServices(params: {
     ["failedCount", failedCount],
   ]);
 
+  let stopPromise: Promise<void> | undefined;
   return {
-    stop: async () => {
-      for (const entry of running.toReversed()) {
-        try {
-          if (entry.stop) {
-            await withPluginHttpRouteRegistry(params.registry, () => entry.stop?.());
-          }
-        } catch (err) {
-          log.warn(`plugin service stop failed (${entry.id}): ${String(err)}`);
-        } finally {
-          entry.revokeGatewayEvents();
+    stop: () =>
+      // Store the shared promise before plugin cleanup runs so shutdown cannot start twice.
+      (stopPromise ??= Promise.resolve().then(async () => {
+        for (const entry of running.toReversed()) {
+          await stopService(entry);
         }
-      }
-    },
+      })),
   };
 }


### PR DESCRIPTION
## Summary

- Roll back partially started plugin services through the existing owner cleanup path, keeping the plugin HTTP registry and event facade available until cleanup completes and then revoking subscriptions.
- Make concurrent and repeated plugin-service shutdown calls share one cleanup operation while preserving reverse-order shutdown, failure isolation, and existing cleanup ownership.
- Preserve plugin contracts without adding configuration, timeout policy, public SDK surface, authentication changes, or persistent state.

## Verification

- Frozen implementation base: `b4e10e8a90f4e9d0d7adffff83a229cd83d9c8fc`.
- Exact branch: `codex/autoqa-plugin-service-lifecycle`.
- Exact reviewed commit: `e24c13a116681b958364d24ec3a7eb4933141ee8`.
- Deterministic baseline: **3 regression tests failed and 15 existing tests passed** before the owner fix.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree /Users/steipete/.local/bin/node scripts/run-vitest.mjs src/plugins/services.test.ts`: **18 plugin-service owner tests passed** after the fix.
- Regression coverage proves acquired resources are released, rollback can emit events before its subscriptions are revoked, rollback failures remain visible without blocking sibling startup, failed services are not stopped twice, and concurrent plus repeated shutdown calls return the same cleanup promise.
- Existing coverage retains reverse-order cleanup, Gateway event revocation, HTTP registry ownership, startup tracing, and shutdown failure isolation.
- Independent strict read-only owner review inspected the complete service owner, production device-pair service, Gateway startup/reload/shutdown callers, event subscription ownership, registry context, and sibling tests: **approved; no actionable findings**.
- Fresh independent Codex autoreview (`gpt-5.6-sol`, high reasoning): **clean, confidence 0.97**. Real TruffleHog 3.96 credential scan: **clean**.
- Targeted `oxfmt --check`, targeted `oxlint`, `git diff --check`, and final worktree cleanliness checks passed.

## Root causes fixed

1. **Partial-start rollback:** a service that acquired resources before throwing was previously omitted from owner cleanup.
2. **Shutdown single-flight:** concurrent or repeated shutdown calls previously executed the same service cleanup more than once.
