### PR TITLE
fix(discord): prevent REST failures from exposing credentials

### DIFF
--- a/extensions/discord/src/internal/rest-errors.redaction.test.ts
+++ b/extensions/discord/src/internal/rest-errors.redaction.test.ts
@@ -103,7 +103,8 @@ describe("Discord REST error redaction", () => {
       expect(discordError.discordCode).toBe(10_065);
       expect(isUnknownDiscordVoiceStateError(discordError)).toBe(true);
 
-      const rateError = await captureError(client.get("/rate-limit"));
+      const webhookRateLimitPath = `/webhooks/app/${token}/rate-limit`;
+      const rateError = await captureError(client.get(webhookRateLimitPath));
       expect(rateError).toBeInstanceOf(RateLimitError);
       const rateLimitError = rateError as RateLimitError;
       const rateLimitDetails = JSON.stringify({
@@ -121,10 +122,11 @@ describe("Discord REST error redaction", () => {
 
       const bucketCount = client.getSchedulerMetrics().activeBuckets;
       expect(bucketCount).toBeGreaterThan(0);
-      const repeatedRateError = await captureError(client.get("/rate-limit"));
+      const repeatedRateError = await captureError(client.get(webhookRateLimitPath));
       expect(repeatedRateError).toBeInstanceOf(RateLimitError);
       expect((repeatedRateError as RateLimitError).bucket).toBe(rateLimitError.bucket);
       expect(client.getSchedulerMetrics().activeBuckets).toBe(bucketCount);
+      expect(JSON.stringify(client.getSchedulerMetrics())).not.toContain(token);
 
       const reflectedHeaderError = await captureError(client.get("/rate-limit-reflected-headers"));
       expect(reflectedHeaderError).toBeInstanceOf(RateLimitError);

--- a/extensions/discord/src/internal/rest-errors.redaction.test.ts
+++ b/extensions/discord/src/internal/rest-errors.redaction.test.ts
@@ -1,0 +1,279 @@
+// Discord tests cover REST error redaction behavior.
+import { createServer, type Server } from "node:http";
+import { describe, expect, it } from "vitest";
+import {
+  DiscordError,
+  isUnknownDiscordVoiceStateError,
+  RateLimitError,
+  RequestClient,
+} from "./rest.js";
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected request to fail");
+}
+
+describe("Discord REST error redaction", () => {
+  it("redacts reflected credentials while preserving Discord error metadata", async () => {
+    const token = ["MTAxMjM0NTY3ODkwMTIzNDU2", "discord", "credential", "fixture"].join(".");
+    const uniqueTokenFragment = "discord.credential";
+    const server = await new Promise<Server>((resolve, reject) => {
+      const srv = createServer((req, res) => {
+        const authorization = req.headers.authorization;
+        if (!authorization) {
+          res.writeHead(500).end();
+          return;
+        }
+        const isPlainText = req.url?.endsWith("/plain-text") ?? false;
+        if (isPlainText) {
+          res.writeHead(502, { "Content-Type": "text/plain" });
+          res.end(`Proxy rejected request; Authorization: ${authorization}`);
+          return;
+        }
+        const isSuccess = req.url?.endsWith("/success") ?? false;
+        const hasReflectedRateLimitHeaders =
+          req.url?.endsWith("/rate-limit-reflected-headers") ?? false;
+        const isRateLimit =
+          hasReflectedRateLimitHeaders || (req.url?.endsWith("/rate-limit") ?? false);
+        const responseBody = isSuccess
+          ? { ok: true, safe: "success diagnostic" }
+          : isRateLimit
+            ? {
+                message: `Rate limited; Authorization: ${authorization}`,
+                retry_after: 0.25,
+                global: false,
+                code: 20_028,
+              }
+            : {
+                message: `Voice request rejected; Authorization: ${authorization}`,
+                code: 10_065,
+                request: {
+                  headers: { authorization },
+                  numericAuthorization: { authorization: 812_345_678_901_234 },
+                  nestedAuthorization: {
+                    authorization: { value: authorization, [token]: "rejected token key" },
+                  },
+                  reflectedKeys: { [`Authorization: ${authorization}`]: "rejected" },
+                  url: `https://discord.example/callback?token=${token}`,
+                },
+                safe: "voice diagnostic",
+              };
+        res.writeHead(isSuccess ? 200 : isRateLimit ? 429 : 401, {
+          "Content-Type": "application/json",
+          "X-RateLimit-Bucket": hasReflectedRateLimitHeaders ? authorization : "test-bucket",
+          "X-RateLimit-Scope": hasReflectedRateLimitHeaders ? authorization : "user",
+        });
+        res.end(JSON.stringify(responseBody));
+      });
+      srv.once("error", reject);
+      srv.listen(0, "127.0.0.1", () => {
+        srv.off("error", reject);
+        resolve(srv);
+      });
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("test server did not bind to a TCP port");
+      }
+      const client = new RequestClient(token, {
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        apiVersion: 10,
+        scheduler: { maxRateLimitRetries: 0 },
+      });
+
+      const voiceError = await captureError(client.get("/voice-state"));
+      expect(voiceError).toBeInstanceOf(DiscordError);
+      const discordError = voiceError as DiscordError;
+      const voiceDetails = JSON.stringify({
+        message: discordError.message,
+        rawBody: discordError.rawBody,
+        rawError: discordError.rawError,
+      });
+      expect(voiceDetails).not.toContain(token);
+      expect(voiceDetails).not.toContain(`Bot ${token}`);
+      expect(voiceDetails).not.toContain(uniqueTokenFragment);
+      expect(voiceDetails).not.toContain("812345678901234");
+      expect(voiceDetails).toContain("voice diagnostic");
+      expect(discordError.discordCode).toBe(10_065);
+      expect(isUnknownDiscordVoiceStateError(discordError)).toBe(true);
+
+      const rateError = await captureError(client.get("/rate-limit"));
+      expect(rateError).toBeInstanceOf(RateLimitError);
+      const rateLimitError = rateError as RateLimitError;
+      const rateLimitDetails = JSON.stringify({
+        message: rateLimitError.message,
+        rawBody: rateLimitError.rawBody,
+        rawError: rateLimitError.rawError,
+      });
+      expect(rateLimitDetails).not.toContain(token);
+      expect(rateLimitDetails).not.toContain(`Bot ${token}`);
+      expect(rateLimitDetails).not.toContain(uniqueTokenFragment);
+      expect(rateLimitError.retryAfter).toBe(0.25);
+      expect(rateLimitError.discordCode).toBe(20_028);
+      expect(rateLimitError.scope).toBe("user");
+      expect(rateLimitError.bucket).toMatch(/^sha256:[a-f0-9]{32}$/);
+
+      const bucketCount = client.getSchedulerMetrics().activeBuckets;
+      expect(bucketCount).toBeGreaterThan(0);
+      const repeatedRateError = await captureError(client.get("/rate-limit"));
+      expect(repeatedRateError).toBeInstanceOf(RateLimitError);
+      expect((repeatedRateError as RateLimitError).bucket).toBe(rateLimitError.bucket);
+      expect(client.getSchedulerMetrics().activeBuckets).toBe(bucketCount);
+
+      const reflectedHeaderError = await captureError(client.get("/rate-limit-reflected-headers"));
+      expect(reflectedHeaderError).toBeInstanceOf(RateLimitError);
+      const reflectedRateLimitError = reflectedHeaderError as RateLimitError;
+      const reflectedHeaderDetails = JSON.stringify({
+        bucket: reflectedRateLimitError.bucket,
+        scope: reflectedRateLimitError.scope,
+        scheduler: client.getSchedulerMetrics(),
+      });
+      expect(reflectedHeaderDetails).not.toContain(token);
+      expect(reflectedHeaderDetails).not.toContain(uniqueTokenFragment);
+      expect(reflectedRateLimitError.scope).toBeNull();
+
+      const textError = await captureError(client.get("/plain-text"));
+      expect(textError).toBeInstanceOf(DiscordError);
+      const textDetails = JSON.stringify({
+        message: (textError as DiscordError).message,
+        rawBody: (textError as DiscordError).rawBody,
+        rawError: (textError as DiscordError).rawError,
+      });
+      expect(textDetails).not.toContain(token);
+      expect(textDetails).not.toContain(uniqueTokenFragment);
+      expect(textDetails).toContain("Proxy rejected request");
+
+      await expect(client.get("/success")).resolves.toEqual({
+        ok: true,
+        safe: "success diagnostic",
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("bounds recursive Discord error-body redaction", () => {
+    const circular: { message: string; self?: unknown } = { message: "safe diagnostic" };
+    circular.self = circular;
+    const circularError = new DiscordError(new Response(null, { status: 500 }), circular);
+    expect((circularError.rawBody as { self?: unknown }).self).toBe("[Circular]");
+
+    const token = "MTAxMjM0NTY3ODkwMTIzNDU2.deeply.nested.credential";
+    let nested: unknown = { authorization: token };
+    for (let depth = 0; depth < 70; depth += 1) {
+      nested = { child: nested };
+    }
+    const deepError = new DiscordError(new Response(null, { status: 500 }), {
+      message: "safe diagnostic",
+      nested,
+    });
+    const deepDetails = JSON.stringify(deepError.rawBody);
+    expect(deepDetails).not.toContain(token);
+    expect(deepDetails).toContain("[Discord error body redacted: maximum depth exceeded]");
+  });
+
+  it("preserves fields whose redacted error keys collide", () => {
+    const error = new DiscordError(new Response(null, { status: 500 }), {
+      message: "safe diagnostic",
+      reflectedKeys: {
+        "authorization=alpha-secret-value-123456": "first rejection",
+        "authorization=bravo-secret-value-123456": "second rejection",
+      },
+    });
+    const reflectedKeys = (error.rawBody as { reflectedKeys: Record<string, unknown> })
+      .reflectedKeys;
+
+    expect(reflectedKeys).toEqual({
+      "authorization=***": "first rejection",
+      "authorization=*** [2]": "second rejection",
+    });
+  });
+
+  it("redacts reflected credentials inside Discord validation arrays", () => {
+    const token = "MTAxMjM0NTY3ODkwMTIzNDU2.validation.array.credential";
+    const error = new DiscordError(new Response(null, { status: 400 }), {
+      message: "Invalid Form Body",
+      errors: {
+        content: {
+          _errors: [
+            {
+              code: "BASE_TYPE_BAD_LENGTH",
+              message: `Authorization: Bot ${token}`,
+            },
+          ],
+        },
+      },
+    });
+    const details = JSON.stringify(error.rawBody);
+
+    expect(details).not.toContain(token);
+    expect(details).toContain("BASE_TYPE_BAD_LENGTH");
+    expect(details).toContain("Invalid Form Body");
+  });
+
+  it("redacts low-entropy values solely from their sensitive field key", () => {
+    const error = new DiscordError(new Response(null, { status: 400 }), {
+      message: "Invalid Form Body",
+      authorization: {
+        note: "plain fixture",
+        attempt: 42,
+      },
+    });
+
+    expect(error.rawBody).toEqual({
+      message: "Invalid Form Body",
+      authorization: {
+        "***": "***",
+        "*** [2]": "***",
+      },
+    });
+  });
+
+  it("ignores empty Discord rate-limit bucket headers", () => {
+    const error = new RateLimitError(
+      new Response(null, {
+        status: 429,
+        headers: { "X-RateLimit-Bucket": "" },
+      }),
+      { message: "Rate limited", retry_after: 1, global: false },
+    );
+
+    expect(error.bucket).toBeNull();
+  });
+
+  it("marks a priority-only object that exhausts the redaction node budget", () => {
+    const marker = "[Discord error body redacted: node limit exceeded]";
+    const body = [...Array.from({ length: 9_998 }, () => null), { message: "truncated" }];
+    const error = new DiscordError(new Response(null, { status: 500 }), body);
+    const redactedBody = error.rawBody as unknown[];
+
+    expect(redactedBody).toHaveLength(9_999);
+    expect(redactedBody.at(-1)).toEqual({ [marker]: marker });
+  });
+
+  it("bounds wide Discord error-body redaction", () => {
+    const fields = Object.fromEntries(
+      Array.from({ length: 10_050 }, (_, index) => [`field-${index}`, index]),
+    );
+    const error = new DiscordError(new Response(null, { status: 500 }), {
+      fields,
+      message: "wide diagnostic",
+      code: 10_065,
+    });
+
+    expect(JSON.stringify(error.rawBody)).toContain(
+      "[Discord error body redacted: node limit exceeded]",
+    );
+    expect(error.rawBody).toMatchObject({ message: "wide diagnostic", code: 10_065 });
+    expect(error.message).toBe("wide diagnostic");
+    expect(error.discordCode).toBe(10_065);
+  });
+});

--- a/extensions/discord/src/internal/rest-errors.ts
+++ b/extensions/discord/src/internal/rest-errors.ts
@@ -190,7 +190,7 @@ export function readDiscordRateLimitBucket(response: Response): string | null {
   return value ? redactIdentifier(value, { len: 32 }) : null;
 }
 
-export function readDiscordRateLimitScope(response: Response): string | null {
+function readDiscordRateLimitScope(response: Response): string | null {
   const value = response.headers.get("X-RateLimit-Scope");
   return value && DISCORD_RATE_LIMIT_SCOPES.has(value) ? value : null;
 }

--- a/extensions/discord/src/internal/rest-errors.ts
+++ b/extensions/discord/src/internal/rest-errors.ts
@@ -1,10 +1,148 @@
 // Discord plugin module implements rest errors behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { redactIdentifier, redactSensitiveFieldValue } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { parseRetryAfterHeaderSeconds } from "openclaw/plugin-sdk/retry-runtime";
 import { parseDiscordRetryAfterBodySeconds } from "../retry-after.js";
 
 const DISCORD_UNKNOWN_VOICE_STATE = 10065;
+const DISCORD_ERROR_BODY_MAX_DEPTH = 64;
+const DISCORD_ERROR_BODY_MAX_NODES = 10_000;
+const DISCORD_ERROR_BODY_MAX_DEPTH_MARKER = "[Discord error body redacted: maximum depth exceeded]";
+const DISCORD_ERROR_BODY_MAX_NODES_MARKER = "[Discord error body redacted: node limit exceeded]";
+const DISCORD_ERROR_BODY_PRIORITY_KEYS = new Set(["message", "code", "retry_after", "global"]);
+const DISCORD_RATE_LIMIT_SCOPES = new Set(["user", "global", "shared"]);
+
+type DiscordErrorRedactionState = {
+  seen: WeakSet<object>;
+  remainingNodes: number;
+};
+
+function isSensitiveDiscordErrorKey(key: string): boolean {
+  // An empty value isolates structured key handling from configured value patterns.
+  return redactSensitiveFieldValue(key, "") !== "";
+}
+
+function reserveRedactedKey(
+  key: string,
+  usedKeys: Set<string>,
+  collisionCounts: Map<string, number>,
+): string {
+  let count = (collisionCounts.get(key) ?? 0) + 1;
+  let candidate = count === 1 ? key : `${key} [${count}]`;
+  while (usedKeys.has(candidate)) {
+    count += 1;
+    candidate = `${key} [${count}]`;
+  }
+  collisionCounts.set(key, count);
+  usedKeys.add(candidate);
+  return candidate;
+}
+
+function redactDiscordErrorBody(
+  body: unknown,
+  fieldKey = "",
+  sensitiveAncestorKey?: string,
+  state: DiscordErrorRedactionState = {
+    seen: new WeakSet<object>(),
+    remainingNodes: DISCORD_ERROR_BODY_MAX_NODES,
+  },
+  depth = 0,
+): unknown {
+  if (state.remainingNodes <= 0) {
+    return DISCORD_ERROR_BODY_MAX_NODES_MARKER;
+  }
+  state.remainingNodes -= 1;
+  if (typeof body === "string") {
+    return redactSensitiveFieldValue(sensitiveAncestorKey ?? fieldKey, body);
+  }
+  if (
+    sensitiveAncestorKey &&
+    (typeof body === "number" || typeof body === "boolean" || typeof body === "bigint")
+  ) {
+    return redactSensitiveFieldValue(sensitiveAncestorKey, String(body));
+  }
+  if (!body || typeof body !== "object") {
+    return body;
+  }
+  // Error bodies are external input; discard over-deep content so malformed
+  // nesting cannot escape redaction or replace DiscordError with a stack overflow.
+  if (depth >= DISCORD_ERROR_BODY_MAX_DEPTH) {
+    return DISCORD_ERROR_BODY_MAX_DEPTH_MARKER;
+  }
+  if (state.seen.has(body)) {
+    return "[Circular]";
+  }
+  state.seen.add(body);
+  let redacted: unknown;
+  if (Array.isArray(body)) {
+    const items: unknown[] = [];
+    for (const entry of body) {
+      if (state.remainingNodes <= 0) {
+        items.push(DISCORD_ERROR_BODY_MAX_NODES_MARKER);
+        break;
+      }
+      items.push(redactDiscordErrorBody(entry, fieldKey, sensitiveAncestorKey, state, depth + 1));
+    }
+    redacted = items;
+  } else {
+    const usedKeys = new Set<string>();
+    const collisionCounts = new Map<string, number>();
+    const entries: Array<[string, unknown]> = [];
+    const appendEntry = (nestedKey: string): boolean => {
+      if (state.remainingNodes <= 0) {
+        return false;
+      }
+      const redactedKey = redactSensitiveFieldValue(sensitiveAncestorKey ?? "", nestedKey);
+      const outputKey = reserveRedactedKey(redactedKey, usedKeys, collisionCounts);
+      const nestedSensitiveKey = isSensitiveDiscordErrorKey(nestedKey)
+        ? nestedKey
+        : sensitiveAncestorKey;
+      entries.push([
+        outputKey,
+        redactDiscordErrorBody(
+          (body as Record<string, unknown>)[nestedKey],
+          nestedKey,
+          nestedSensitiveKey,
+          state,
+          depth + 1,
+        ),
+      ]);
+      return true;
+    };
+    // Preserve canonical diagnostics before a verbose nested error tree can
+    // consume the shared traversal budget.
+    let truncated = false;
+    for (const priorityKey of DISCORD_ERROR_BODY_PRIORITY_KEYS) {
+      if (Object.hasOwn(body, priorityKey) && !appendEntry(priorityKey)) {
+        truncated = true;
+        break;
+      }
+    }
+    if (!truncated) {
+      for (const nestedKey in body) {
+        if (!Object.hasOwn(body, nestedKey) || DISCORD_ERROR_BODY_PRIORITY_KEYS.has(nestedKey)) {
+          continue;
+        }
+        if (!appendEntry(nestedKey)) {
+          truncated = true;
+          break;
+        }
+      }
+    }
+    if (truncated) {
+      const markerKey = reserveRedactedKey(
+        DISCORD_ERROR_BODY_MAX_NODES_MARKER,
+        usedKeys,
+        collisionCounts,
+      );
+      entries.push([markerKey, DISCORD_ERROR_BODY_MAX_NODES_MARKER]);
+    }
+    redacted = Object.fromEntries(entries);
+  }
+  state.seen.delete(body);
+  return redacted;
+}
 
 export function readDiscordCode(body: unknown): number | undefined {
   const value =
@@ -45,6 +183,18 @@ export function readRetryAfter(body: unknown, response: Response, fallbackSecond
   );
 }
 
+export function readDiscordRateLimitBucket(response: Response): string | null {
+  const value = response.headers.get("X-RateLimit-Bucket")?.trim();
+  // Response headers are untrusted and surface in diagnostics. Hash non-empty
+  // bucket ids while retaining the stable equality Discord routing requires.
+  return value ? redactIdentifier(value, { len: 32 }) : null;
+}
+
+export function readDiscordRateLimitScope(response: Response): string | null {
+  const value = response.headers.get("X-RateLimit-Scope");
+  return value && DISCORD_RATE_LIMIT_SCOPES.has(value) ? value : null;
+}
+
 export class DiscordError extends Error {
   readonly status: number;
   readonly statusCode: number;
@@ -53,12 +203,22 @@ export class DiscordError extends Error {
   discordCode?: number;
 
   constructor(response: Response, body: unknown) {
-    super(readDiscordMessage(body, `Discord API request failed (${response.status})`));
+    // Sanitize all user-visible/raw string fields at the shared boundary while
+    // preserving numeric metadata consumed by retry and voice-state handling.
+    const fallbackMessage = `Discord API request failed (${response.status})`;
+    const redactedMessage = redactSensitiveFieldValue(
+      "message",
+      readDiscordMessage(body, fallbackMessage),
+    );
+    const redactedBody = redactDiscordErrorBody(body);
+    super(redactedMessage);
     this.name = "DiscordError";
     this.status = response.status;
     this.statusCode = response.status;
-    this.rawBody = body;
-    this.rawError = body;
+    this.rawBody = redactedBody;
+    this.rawError = redactedBody;
+    // Classification consumes only a parsed non-negative integer and must not
+    // depend on diagnostic depth/node truncation in the sanitized raw body.
     this.discordCode = readDiscordCode(body);
   }
 }
@@ -75,7 +235,7 @@ export class RateLimitError extends DiscordError {
     super(response, body);
     this.name = "RateLimitError";
     this.retryAfter = readRetryAfter(body, response, 1);
-    this.scope = body.global ? "global" : response.headers.get("X-RateLimit-Scope");
-    this.bucket = response.headers.get("X-RateLimit-Bucket");
+    this.scope = body.global ? "global" : readDiscordRateLimitScope(response);
+    this.bucket = readDiscordRateLimitBucket(response);
   }
 }

--- a/extensions/discord/src/internal/rest-routes.ts
+++ b/extensions/discord/src/internal/rest-routes.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements rest routes behavior.
+import { redactIdentifier } from "openclaw/plugin-sdk/logging-core";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -7,9 +8,25 @@ import {
 type QueryValue = string | number | boolean;
 
 const RATE_LIMIT_HEADER_NUMBER_RE = /^\d+(?:\.\d+)?$/;
+const DISCORD_ROUTE_IDENTIFIER_HASH_LENGTH = 32;
+
+function redactWebhookTokenInPath(path: string): string {
+  const hasLeadingSlash = path.startsWith("/");
+  const segments = path.replace(/^\/+/, "").split("/");
+  if (segments[0] !== "webhooks" || !segments[1] || !segments[2]) {
+    return path;
+  }
+  // Webhook tokens are route identity, but they are also credentials. Keep
+  // stable grouping without retaining the raw token in scheduler diagnostics.
+  segments[2] = redactIdentifier(segments[2], {
+    len: DISCORD_ROUTE_IDENTIFIER_HASH_LENGTH,
+  });
+  return `${hasLeadingSlash ? "/" : ""}${segments.join("/")}`;
+}
 
 export function createRouteKey(method: string, path: string): string {
-  return `${method.toUpperCase()} ${path.split("?")[0] ?? path}`;
+  const pathname = path.split("?")[0] ?? path;
+  return `${method.toUpperCase()} ${redactWebhookTokenInPath(pathname)}`;
 }
 
 function readTopLevelRouteKey(path: string): string {
@@ -19,7 +36,11 @@ function readTopLevelRouteKey(path: string): string {
     return pathname;
   }
   if (first === "channels" || first === "guilds" || first === "webhooks") {
-    return first === "webhooks" && token ? `${first}/${id}/${token}` : `${first}/${id}`;
+    return first === "webhooks" && token
+      ? `${first}/${id}/${redactIdentifier(token, {
+          len: DISCORD_ROUTE_IDENTIFIER_HASH_LENGTH,
+        })}`
+      : `${first}/${id}`;
   }
   return first;
 }

--- a/extensions/discord/src/internal/rest-scheduler.ts
+++ b/extensions/discord/src/internal/rest-scheduler.ts
@@ -1,6 +1,6 @@
 // Discord plugin module implements rest scheduler behavior.
 import { resolveIntegerOption, resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
-import { RateLimitError, readRetryAfter } from "./rest-errors.js";
+import { RateLimitError, readDiscordRateLimitBucket, readRetryAfter } from "./rest-errors.js";
 import {
   createBucketKey,
   createRouteKey,
@@ -308,7 +308,7 @@ export class RestScheduler<TData> {
     response: Response,
     parsed: unknown,
   ): void {
-    const bucketHeader = response.headers.get("X-RateLimit-Bucket");
+    const bucketHeader = readDiscordRateLimitBucket(response);
     const bucket = bucketHeader
       ? this.bindRouteToBucket(routeKey, createBucketKey(bucketHeader, path))
       : this.getBucket(this.routeBuckets.get(routeKey) ?? routeKey);
@@ -352,7 +352,7 @@ export class RestScheduler<TData> {
     const now = Date.now();
     this.invalidRequestTimestamps.push({ at: now, status: response.status });
     this.pruneInvalidRequests(now);
-    const bucketHeader = response.headers.get("X-RateLimit-Bucket");
+    const bucketHeader = readDiscordRateLimitBucket(response);
     const bucketKey = bucketHeader
       ? createBucketKey(bucketHeader, path)
       : (this.routeBuckets.get(routeKey) ?? routeKey);


### PR DESCRIPTION
## What Problem This Solves

Discord REST failures could retain credentials reflected by Discord or an intermediary in error messages, structured response bodies, rate-limit headers, and scheduler diagnostic keys. Those values flow through the shared REST client used by normal sends, interaction webhooks, command deployment, and voice-message requests.

## Why This Change Was Made

The repair is owned at the shared Discord REST boundary:

- `DiscordError` sanitizes bounded text and structured diagnostics before retaining `message`, `rawBody`, or `rawError`.
- Discord error codes and retry metadata are still derived from the original parsed response, so classification and retry behavior do not depend on diagnostic truncation.
- Rate-limit bucket identifiers are stored as stable SHA-256 prefixes, while scope accepts only Discord's documented `user`, `global`, or `shared` values.
- Webhook-token route segments are hashed before scheduler identities or metrics retain them. The actual request URL is unchanged.

This is the best owner boundary because every REST failure consumer receives the same sanitized object and scheduler grouping stays deterministic without caller-specific cleanup.

Discord contract: https://docs.discord.com/developers/topics/rate-limits

## User Impact

Operators can inspect Discord REST failures and scheduler metrics without reflected bot or webhook credentials being retained. Successful requests, Discord error classification, retry timing, and route-to-bucket grouping remain unchanged.

## Evidence

### Production-path proof

The focused test starts a real loopback HTTP server and sends a synthetic credential through production `RequestClient`. The server reflects it through:

- JSON values and keys
- nested objects and validation arrays
- numeric values under sensitive ancestors
- URLs and plain text
- `X-RateLimit-Bucket` and `X-RateLimit-Scope`
- a credential-bearing `/webhooks/{id}/{token}` route

Assertions prove the credential is absent from retained errors and scheduler metrics, Discord codes and retry metadata remain available, repeated webhook requests retain stable bucket grouping, and successful responses are unchanged.

### Final head

- Exact head: `292f0a5a6f519f1b94cb8ba1f73ee4b6e0d84128`
- Contributor commits by Alix-007 were rebased byte-for-byte onto `383363e3623374db34c2b855f52f244caa688998`.
- Maintainer commit `292f0a5a6f51` closes the sibling webhook scheduler-key leak found during deep review.
- Current-main audit at `849dde12d0d0b16792ab5e8032bb37dab1afcf01`: no touched-path drift since the branch base; clean merge tree `a21c179399d2d4c9e0611c91f2d5c5f6b997e583`.

### Validation

- 7 focused Discord suites: 101 tests passed.
- Focused unrelated CI-flake reproduction: 1 test passed in 2.9 seconds.
- Extension production typecheck: passed.
- Extension test typecheck: passed.
- Typed changed-file oxlint: passed.
- `oxfmt --check`, plugin boundary, max-lines ratchet, conflict-marker, import-cycle, diff, and secret scans: passed.
- Exact-head Codex autoreview: clean, patch correct (0.98), no accepted/actionable findings.
- Exact-head ClawSweeper: 5/6 diamond, proof sufficient, no findings.
- Hosted exact-head CI: 95/95 latest checks terminal-success. Targeted reruns cleared an infrastructure-terminated lint job and one unrelated runner-load process-test flake.

Blacksmith Testbox's delegated command channel hung before producing test output on two fresh leases. Per repository fallback policy, the full focused proof ran in the trusted checkout; hosted exact-head CI is the independent remote gate.

Not tested: a real bot credential against Discord's public service. The proof deliberately uses a synthetic credential through the production client so no live secret is exposed.

## AI Assistance

This change was developed with AI assistance. The author and maintainer reviewed the code, tests, and evidence and remain responsible for the contribution.
