### PR TITLE
feat(providers): add llama-server integration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -368,6 +368,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/llama-cpp/**"
+"extensions: llama-server":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/llama-server/**"
 "extensions: memory-core":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1702,5 +1702,25 @@
   {
     "source": "Automations (cron)",
     "target": "自动化 (cron)"
+  },
+  {
+    "source": "Llama Server plugin",
+    "target": "Llama Server 插件"
+  },
+  {
+    "source": "llama-server",
+    "target": "llama-server"
+  },
+  {
+    "source": "llama.cpp in-process plugin",
+    "target": "llama.cpp 进程内插件"
+  },
+  {
+    "source": "Local model services",
+    "target": "本地模型服务"
+  },
+  {
+    "source": "LM Studio",
+    "target": "LM Studio"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1533,6 +1533,7 @@
                   "providers/inworld",
                   "providers/kilocode",
                   "providers/litellm",
+                  "providers/llama-server",
                   "providers/lmstudio",
                   "providers/longcat",
                   "providers/meta",

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -6914,6 +6914,15 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Default text model
   - H2: Related docs
 
+## plugins/reference/llama-server.md
+
+- Route: /plugins/reference/llama-server
+- Headings:
+  - H1: Llama Server plugin
+  - H2: Distribution
+  - H2: Surface
+  - H2: Related docs
+
 ## plugins/reference/llm-task.md
 
 - Route: /plugins/reference/llm-task
@@ -8404,6 +8413,24 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Configuration
   - H2: Image generation
   - H2: Advanced
+  - H2: Related
+
+## providers/llama-server.md
+
+- Route: /providers/llama-server
+- Headings:
+  - H2: Quick start
+  - H2: Non-interactive setup
+  - H2: Configuration
+  - H3: Runtime metadata
+  - H2: Router mode
+  - H2: Authentication and networking
+  - H2: Optional local process startup
+  - H2: Troubleshooting
+  - H3: Server is unavailable
+  - H3: Tools are disabled
+  - H3: Router discovery loaded a model
+  - H3: Authentication fails during inference
   - H2: Related
 
 ## providers/lmstudio.md

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-61 plugins
+62 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -104,6 +104,8 @@ Each entry lists the package, distribution route, and description.
 - **[linux-node](/plugins/reference/linux-node)** (`@openclaw/linux-node`) - included in OpenClaw. Desktop notifications, camera capture, and location for Linux node hosts.
 
 - **[litellm](/plugins/reference/litellm)** (`@openclaw/litellm-provider`) - included in OpenClaw. Adds LiteLLM model provider support to OpenClaw.
+
+- **[llama-server](/plugins/reference/llama-server)** (`@openclaw/llama-server-provider`) - included in OpenClaw. Connect OpenClaw to an existing llama.cpp server over HTTP.
 
 - **[llm-task](/plugins/reference/llm-task)** (`@openclaw/llm-task`) - included in OpenClaw. Generic JSON-only LLM tool for structured tasks callable from workflows.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 146
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 147
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/llama-server.md
+++ b/docs/plugins/reference/llama-server.md
@@ -1,0 +1,23 @@
+---
+summary: "Connect OpenClaw to an existing llama.cpp server over HTTP."
+read_when:
+  - You are installing, configuring, or auditing the llama-server plugin
+title: "Llama Server plugin"
+---
+
+# Llama Server plugin
+
+Connect OpenClaw to an existing llama.cpp server over HTTP.
+
+## Distribution
+
+- Package: `@openclaw/llama-server-provider`
+- Install route: included in OpenClaw
+
+## Surface
+
+providers: `llama-server`
+
+## Related docs
+
+- [llama-server](/providers/llama-server)

--- a/docs/providers/llama-server.md
+++ b/docs/providers/llama-server.md
@@ -1,0 +1,233 @@
+---
+summary: "Connect OpenClaw to an existing llama.cpp llama-server"
+read_when:
+  - You run llama-server locally or on a private model host
+  - You want automatic model, context, and tool-capability discovery
+  - You use llama-server router mode
+  - You are choosing between llama-server and the in-process llama-cpp plugin
+title: "llama-server"
+---
+
+`llama-server` is llama.cpp's standalone HTTP server. OpenClaw connects to its OpenAI-compatible chat API and discovers the models that the process exposes.
+
+The `llama-server` provider connects to an existing process. The separate [`llama-cpp` plugin](/plugins/llama-cpp) loads a GGUF model inside the OpenClaw process through `node-llama-cpp`.
+
+| Property         | Value                                 |
+| ---------------- | ------------------------------------- |
+| Provider ID      | `llama-server`                        |
+| API              | `openai-completions`                  |
+| Default base URL | `http://127.0.0.1:8080/v1`            |
+| Authentication   | Optional `LLAMA_SERVER_API_KEY`       |
+| Model discovery  | Model-list and property endpoints     |
+| Process owner    | Operator or configured `localService` |
+
+## Quick start
+
+<Steps>
+  <Step title="Start llama-server">
+    Start an official llama.cpp server with a stable model alias:
+
+    ```bash
+    llama-server \
+      --model /path/to/model.gguf \
+      --alias my-model \
+      --host 127.0.0.1 \
+      --port 8080
+    ```
+
+    Use the context, GPU, slot, batching, and chat-template flags that fit your deployment. OpenClaw does not choose or change them.
+
+  </Step>
+  <Step title="Run OpenClaw setup">
+    ```bash
+    openclaw onboard
+    ```
+
+    Choose `llama-server` and accept the default URL, or enter another local or private endpoint. Leave API-key authentication disabled unless the server or its reverse proxy requires it.
+
+  </Step>
+  <Step title="Select the discovered model">
+    ```bash
+    openclaw models list --provider llama-server
+    openclaw models set llama-server/my-model
+    ```
+  </Step>
+</Steps>
+
+The provider reads model IDs from the server. A stable `--alias` keeps the OpenClaw model reference independent of the GGUF file path.
+
+## Non-interactive setup
+
+An unauthenticated local server needs only its URL:
+
+```bash
+openclaw onboard \
+  --non-interactive \
+  --accept-risk \
+  --auth-choice llama-server \
+  --custom-base-url http://127.0.0.1:8080/v1
+```
+
+You can select one advertised model explicitly:
+
+```bash
+openclaw onboard \
+  --non-interactive \
+  --accept-risk \
+  --auth-choice llama-server \
+  --custom-base-url http://127.0.0.1:8080/v1 \
+  --custom-model-id my-model
+```
+
+For an authenticated server, set `LLAMA_SERVER_API_KEY` or pass `--llama-server-api-key`. `--custom-api-key` is also accepted for the shared self-hosted setup path.
+
+```bash
+export LLAMA_SERVER_API_KEY="your-server-key"
+
+openclaw onboard \
+  --non-interactive \
+  --accept-risk \
+  --auth-choice llama-server \
+  --custom-base-url https://models.example.com/v1 \
+  --custom-model-id my-model
+```
+
+OpenClaw stores no fake API key for an unauthenticated server. The provider uses an internal non-secret marker after model discovery so normal auth resolution can proceed.
+
+## Configuration
+
+Setup writes the endpoint and discovered model metadata:
+
+```json5
+{
+  models: {
+    providers: {
+      "llama-server": {
+        baseUrl: "http://127.0.0.1:8080/v1",
+        api: "openai-completions",
+        models: [
+          {
+            id: "my-model",
+            name: "my-model",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 32768,
+            contextTokens: 32768,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+  agents: {
+    defaults: {
+      model: { primary: "llama-server/my-model" },
+    },
+  },
+}
+```
+
+OpenClaw accepts the server origin or its `/v1` URL and stores the canonical `/v1` form. Explicit model rows override discovered rows with the same ID. This lets an operator supply compatibility values that the server cannot report, including reasoning and context limits.
+
+### Runtime metadata
+
+For a loaded model, the provider reads `/props` and uses the server's active `n_ctx` for `contextWindow` and `contextTokens`. This reflects the current KV-cache allocation instead of the larger training limit stored in GGUF metadata.
+
+The provider also reads llama.cpp's `chat_template_caps`. Tool use is enabled only when the template reports both tool-definition and tool-call support. Unknown capabilities stay disabled. All tools pass through OpenClaw's `llamacpp-gbnf` schema projection before the request reaches the server.
+
+Reasoning remains disabled unless you set it explicitly on the model row. llama-server reports reasoning output format but does not provide a stable per-model reasoning-capability field.
+
+## Router mode
+
+Starting `llama-server` without `--model` enables router mode. OpenClaw lists the IDs and states returned by `GET /models`, including loaded, sleeping, loading, downloading, failed, and unloaded models.
+
+Discovery is read-only. OpenClaw never calls `/models/load`, `/models/unload`, or `/models?reload=1`. Property requests include `autoload=false`, so catalog refresh does not load an unloaded model. If llama-server's own autoload setting is enabled, the first inference request can load the selected model.
+
+An unloaded router model has conservative OpenClaw capabilities until the server loads it and a later catalog refresh can read `/props`. You can add an explicit model row when OpenClaw needs known tool or reasoning metadata before that first load.
+
+## Authentication and networking
+
+Bind an unauthenticated server to loopback:
+
+```bash
+llama-server --host 127.0.0.1 --port 8080 --model /path/to/model.gguf
+```
+
+Use llama-server's API-key option or an authenticated reverse proxy when OpenClaw connects to another host. Protect remote traffic with TLS.
+
+The provider allows requests to its exact configured origin, including loopback and private addresses. Redirects and unrelated private origins remain subject to OpenClaw's SSRF policy. URLs containing embedded credentials are rejected.
+
+## Optional local process startup
+
+OpenClaw normally leaves llama-server lifecycle management to the operator. You can opt into the generic [`localService`](/gateway/local-model-services) process manager when OpenClaw should start one existing binary on demand:
+
+```json5
+{
+  models: {
+    providers: {
+      "llama-server": {
+        baseUrl: "http://127.0.0.1:8080/v1",
+        timeoutSeconds: 300,
+        localService: {
+          command: "/absolute/path/to/llama-server",
+          args: [
+            "--model",
+            "/absolute/path/to/model.gguf",
+            "--alias",
+            "my-model",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "8080",
+          ],
+          healthUrl: "http://127.0.0.1:8080/health",
+          readyTimeoutMs: 300000,
+          idleStopMs: 0,
+        },
+        models: [],
+      },
+    },
+  },
+}
+```
+
+`command` must be an absolute path. OpenClaw does not install, download, compile, or update llama-server.
+
+## Troubleshooting
+
+### Server is unavailable
+
+Check the public health and model endpoints:
+
+```bash
+curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:8080/models
+```
+
+A health response with HTTP 503 means the model is still loading. Increase `localService.readyTimeoutMs` for a managed cold start or wait for the externally managed process to become ready.
+
+### Tools are disabled
+
+Inspect the active model properties:
+
+```bash
+curl http://127.0.0.1:8080/props
+```
+
+Check `chat_template_caps.supports_tools` and `chat_template_caps.supports_tool_calls`. Start llama-server with Jinja enabled and a tool-capable template for the model. OpenClaw does not guess tool support from the model name.
+
+### Router discovery loaded a model
+
+OpenClaw's property requests include `autoload=false`, and model-list requests do not include `reload=1`. Check other clients and the server's `--models-autoload` setting if an unloaded model starts outside an inference request.
+
+### Authentication fails during inference
+
+Model-list and health endpoints may remain public even when chat inference requires a key. Set `LLAMA_SERVER_API_KEY` to the value configured by llama-server or its reverse proxy, then rerun setup or restart the gateway so the environment change is visible.
+
+## Related
+
+- [llama.cpp in-process plugin](/plugins/llama-cpp)
+- [Local model services](/gateway/local-model-services)
+- [Model providers](/concepts/model-providers)
+- [LM Studio](/providers/lmstudio)

--- a/extensions/llama-server/README.md
+++ b/extensions/llama-server/README.md
@@ -1,0 +1,7 @@
+# llama-server provider
+
+Bundled provider plugin for connecting OpenClaw to an existing llama.cpp `llama-server` process.
+
+The plugin uses OpenClaw's shared OpenAI completions transport. It owns endpoint normalization, read-only model discovery, runtime context and chat-template capability mapping, optional API-key setup, router status, and llama.cpp-safe tool schemas.
+
+See [the provider guide](../../docs/providers/llama-server.md).

--- a/extensions/llama-server/index.test.ts
+++ b/extensions/llama-server/index.test.ts
@@ -68,7 +68,7 @@ describe("llama-server plugin", () => {
     });
   });
 
-  it("uses synthetic auth only when no real credential is configured", () => {
+  it("uses synthetic auth unless a real API key is configured", () => {
     const { provider } = captureProvider();
     expect(
       provider.resolveSyntheticAuth?.({
@@ -77,7 +77,7 @@ describe("llama-server plugin", () => {
         providerConfig: configuredProvider(),
       }),
     ).toEqual({
-      apiKey: LLAMA_SERVER_LOCAL_AUTH_MARKER,
+      apiKey: CUSTOM_LOCAL_AUTH_MARKER,
       source: "models.providers.llama-server (synthetic local key)",
       mode: "api-key",
     });
@@ -97,7 +97,11 @@ describe("llama-server plugin", () => {
           headers: { Authorization: "Bearer proxy-key" },
         },
       }),
-    ).toBeUndefined();
+    ).toEqual({
+      apiKey: LLAMA_SERVER_LOCAL_AUTH_MARKER,
+      source: "models.providers.llama-server (synthetic local key)",
+      mode: "api-key",
+    });
   });
 
   it("defers both supported synthetic auth markers", () => {

--- a/extensions/llama-server/index.test.ts
+++ b/extensions/llama-server/index.test.ts
@@ -1,0 +1,126 @@
+import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { CUSTOM_LOCAL_AUTH_MARKER } from "openclaw/plugin-sdk/provider-auth";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+import { LLAMA_SERVER_LOCAL_AUTH_MARKER } from "./src/defaults.js";
+
+function captureProvider() {
+  const captured = capturePluginRegistration(plugin);
+  const provider = captured.providers[0];
+  if (!provider) {
+    throw new Error("expected llama-server provider registration");
+  }
+  return { captured, provider };
+}
+
+function configuredProvider() {
+  return {
+    baseUrl: "http://localhost:8080/v1",
+    api: "openai-completions" as const,
+    models: [
+      {
+        id: "model",
+        name: "model",
+        reasoning: false,
+        input: ["text" as const],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 2048,
+      },
+    ],
+  };
+}
+
+describe("llama-server plugin", () => {
+  it("registers the provider and unified live catalog", () => {
+    const { captured, provider } = captureProvider();
+
+    expect(provider.id).toBe("llama-server");
+    expect(provider.catalog).toBeDefined();
+    expect(captured.modelCatalogProviders).toEqual([
+      expect.objectContaining({ provider: "llama-server", kinds: ["text"] }),
+    ]);
+  });
+
+  it("registers llama.cpp GBNF schema projection", () => {
+    const { provider } = captureProvider();
+    expect(provider).toMatchObject({
+      normalizeToolSchemas: expect.any(Function),
+      inspectToolSchemas: expect.any(Function),
+    });
+  });
+
+  it("normalizes config onto the OpenAI completions transport", () => {
+    const { provider } = captureProvider();
+    expect(
+      provider.normalizeConfig?.({
+        provider: "llama-server",
+        providerConfig: {
+          ...configuredProvider(),
+          baseUrl: "localhost:8080/",
+          api: "openai-responses",
+        },
+      }),
+    ).toMatchObject({
+      baseUrl: "http://localhost:8080/v1",
+      api: "openai-completions",
+      request: { allowPrivateNetwork: true },
+    });
+  });
+
+  it("uses synthetic auth only when no real credential is configured", () => {
+    const { provider } = captureProvider();
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "llama-server",
+        config: {},
+        providerConfig: configuredProvider(),
+      }),
+    ).toEqual({
+      apiKey: LLAMA_SERVER_LOCAL_AUTH_MARKER,
+      source: "models.providers.llama-server (synthetic local key)",
+      mode: "api-key",
+    });
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "llama-server",
+        config: {},
+        providerConfig: { ...configuredProvider(), apiKey: "real-key" },
+      }),
+    ).toBeUndefined();
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "llama-server",
+        config: {},
+        providerConfig: {
+          ...configuredProvider(),
+          headers: { Authorization: "Bearer proxy-key" },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("defers both supported synthetic auth markers", () => {
+    const { provider } = captureProvider();
+    const context = {
+      provider: "llama-server",
+      config: {},
+      providerConfig: configuredProvider(),
+    };
+    expect(
+      provider.shouldDeferSyntheticProfileAuth?.({
+        ...context,
+        resolvedApiKey: LLAMA_SERVER_LOCAL_AUTH_MARKER,
+      }),
+    ).toBe(true);
+    expect(
+      provider.shouldDeferSyntheticProfileAuth?.({
+        ...context,
+        resolvedApiKey: CUSTOM_LOCAL_AUTH_MARKER,
+      }),
+    ).toBe(true);
+    expect(
+      provider.shouldDeferSyntheticProfileAuth?.({ ...context, resolvedApiKey: "real-key" }),
+    ).toBe(false);
+  });
+});

--- a/extensions/llama-server/index.ts
+++ b/extensions/llama-server/index.ts
@@ -26,6 +26,7 @@ import {
   runLlamaServerSetup,
   validateLlamaServerNonInteractive,
 } from "./src/setup.js";
+import { wrapLlamaServerStream } from "./src/stream.js";
 
 export default definePluginEntry({
   id: LLAMA_SERVER_PROVIDER_ID,
@@ -76,6 +77,7 @@ export default definePluginEntry({
       normalizeConfig: ({ providerConfig }) => normalizeLlamaServerProviderConfig(providerConfig),
       prepareDynamicModel: prepareLlamaServerDynamicModels,
       resolveDynamicModel: (ctx) => resolveLlamaServerDynamicModel(ctx),
+      wrapStreamFn: wrapLlamaServerStream,
       ...buildProviderToolCompatFamilyHooks("llamacpp-gbnf"),
       wizard: {
         setup: {

--- a/extensions/llama-server/index.ts
+++ b/extensions/llama-server/index.ts
@@ -5,7 +5,10 @@ import {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { CUSTOM_LOCAL_AUTH_MARKER } from "openclaw/plugin-sdk/provider-auth";
 import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
-import { shouldUseLlamaServerSyntheticAuth } from "./src/auth.js";
+import {
+  hasLlamaServerAuthorizationHeader,
+  shouldUseLlamaServerSyntheticAuth,
+} from "./src/auth.js";
 import {
   LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
   LLAMA_SERVER_LOCAL_AUTH_MARKER,
@@ -66,7 +69,9 @@ export default definePluginEntry({
       resolveSyntheticAuth: ({ providerConfig }) =>
         shouldUseLlamaServerSyntheticAuth(providerConfig)
           ? {
-              apiKey: LLAMA_SERVER_LOCAL_AUTH_MARKER,
+              apiKey: hasLlamaServerAuthorizationHeader(providerConfig?.headers)
+                ? LLAMA_SERVER_LOCAL_AUTH_MARKER
+                : CUSTOM_LOCAL_AUTH_MARKER,
               source: "models.providers.llama-server (synthetic local key)",
               mode: "api-key" as const,
             }

--- a/extensions/llama-server/index.ts
+++ b/extensions/llama-server/index.ts
@@ -1,0 +1,98 @@
+import {
+  definePluginEntry,
+  type OpenClawPluginApi,
+  type ProviderAuthMethodNonInteractiveContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { CUSTOM_LOCAL_AUTH_MARKER } from "openclaw/plugin-sdk/provider-auth";
+import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
+import { shouldUseLlamaServerSyntheticAuth } from "./src/auth.js";
+import {
+  LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
+  LLAMA_SERVER_LOCAL_AUTH_MARKER,
+  LLAMA_SERVER_PROVIDER_ID,
+  LLAMA_SERVER_PROVIDER_LABEL,
+} from "./src/defaults.js";
+import { normalizeLlamaServerProviderConfig } from "./src/endpoint.js";
+import {
+  discoverLlamaServerProvider,
+  listLlamaServerCatalog,
+  prepareLlamaServerDynamicModels,
+  resolveLlamaServerDynamicModel,
+} from "./src/provider.js";
+import {
+  configureLlamaServerNonInteractive,
+  detectLlamaServerSetup,
+  prepareLlamaServerSetup,
+  runLlamaServerSetup,
+  validateLlamaServerNonInteractive,
+} from "./src/setup.js";
+
+export default definePluginEntry({
+  id: LLAMA_SERVER_PROVIDER_ID,
+  name: "llama-server Provider",
+  description: "Connect OpenClaw to an existing llama.cpp server over HTTP",
+  register(api: OpenClawPluginApi) {
+    api.registerModelCatalogProvider({
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      kinds: ["text"],
+      liveCatalog: listLlamaServerCatalog,
+    });
+    api.registerProvider({
+      id: LLAMA_SERVER_PROVIDER_ID,
+      label: LLAMA_SERVER_PROVIDER_LABEL,
+      docsPath: "/providers/llama-server",
+      envVars: [LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR],
+      auth: [
+        {
+          id: "custom",
+          label: LLAMA_SERVER_PROVIDER_LABEL,
+          hint: "Existing local or private llama.cpp server",
+          kind: "custom",
+          appGuidedSetup: {
+            detect: detectLlamaServerSetup,
+            prepare: prepareLlamaServerSetup,
+          },
+          run: runLlamaServerSetup,
+          validateNonInteractive: validateLlamaServerNonInteractive,
+          runNonInteractive: async (ctx: ProviderAuthMethodNonInteractiveContext) =>
+            await configureLlamaServerNonInteractive(ctx),
+        },
+      ],
+      catalog: {
+        order: "late",
+        run: discoverLlamaServerProvider,
+      },
+      resolveSyntheticAuth: ({ providerConfig }) =>
+        shouldUseLlamaServerSyntheticAuth(providerConfig)
+          ? {
+              apiKey: LLAMA_SERVER_LOCAL_AUTH_MARKER,
+              source: "models.providers.llama-server (synthetic local key)",
+              mode: "api-key" as const,
+            }
+          : undefined,
+      shouldDeferSyntheticProfileAuth: ({ resolvedApiKey }) =>
+        resolvedApiKey?.trim() === LLAMA_SERVER_LOCAL_AUTH_MARKER ||
+        resolvedApiKey?.trim() === CUSTOM_LOCAL_AUTH_MARKER,
+      normalizeConfig: ({ providerConfig }) => normalizeLlamaServerProviderConfig(providerConfig),
+      prepareDynamicModel: prepareLlamaServerDynamicModels,
+      resolveDynamicModel: (ctx) => resolveLlamaServerDynamicModel(ctx),
+      ...buildProviderToolCompatFamilyHooks("llamacpp-gbnf"),
+      wizard: {
+        setup: {
+          choiceId: LLAMA_SERVER_PROVIDER_ID,
+          choiceLabel: LLAMA_SERVER_PROVIDER_LABEL,
+          choiceHint: "Existing local or private llama.cpp server",
+          groupId: LLAMA_SERVER_PROVIDER_ID,
+          groupLabel: LLAMA_SERVER_PROVIDER_LABEL,
+          groupHint: "Self-hosted llama.cpp models",
+          methodId: "custom",
+        },
+        modelPicker: {
+          label: `${LLAMA_SERVER_PROVIDER_LABEL} (self-hosted)`,
+          hint: "Discover models from an existing llama-server",
+          methodId: "custom",
+        },
+      },
+    });
+  },
+});

--- a/extensions/llama-server/llama-server.live.test.ts
+++ b/extensions/llama-server/llama-server.live.test.ts
@@ -1,0 +1,145 @@
+// Llama-server live tests exercise discovery and the shared OpenAI completions transport.
+import {
+  completeSimple,
+  type AssistantMessage,
+  type Model,
+  type Tool,
+} from "openclaw/plugin-sdk/llm";
+import { extractNonEmptyAssistantText, isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { discoverLlamaServer } from "./src/discovery.js";
+
+const LIVE_URL = process.env.LLAMA_SERVER_LIVE_URL?.trim() ?? "";
+const LIVE_KEY = process.env.LLAMA_SERVER_API_KEY?.trim() ?? "";
+const LIVE_MODEL_ID = process.env.LLAMA_SERVER_LIVE_MODEL_ID?.trim() ?? "";
+const LIVE = isLiveTestEnabled(["LLAMA_SERVER_LIVE_TEST"]) && LIVE_URL.length > 0;
+const describeLive = LIVE ? describe : describe.skip;
+
+async function resolveLiveModel(): Promise<{
+  model: Model<"openai-completions">;
+  supportsTools: boolean;
+}> {
+  const discovery = await discoverLlamaServer({
+    baseUrl: LIVE_URL,
+    apiKey: LIVE_KEY,
+    cacheTtlMs: 0,
+  });
+  if (discovery.kind !== "success") {
+    throw new Error(`llama-server discovery failed: ${discovery.kind}`);
+  }
+  const discovered = LIVE_MODEL_ID
+    ? discovery.models.find((entry) => entry.config.id === LIVE_MODEL_ID)
+    : (discovery.models.find((entry) => entry.status === "loaded") ?? discovery.models[0]);
+  if (!discovered) {
+    throw new Error("llama-server returned no models");
+  }
+  return {
+    model: {
+      ...discovered.config,
+      provider: "llama-server",
+      api: "openai-completions",
+      baseUrl: discovery.endpoint.inferenceBaseUrl,
+      input: discovered.config.input.filter(
+        (entry): entry is "text" | "image" => entry === "text" || entry === "image",
+      ),
+    } as Model<"openai-completions">,
+    supportsTools: discovered.config.compat?.supportsTools === true,
+  };
+}
+
+function echoTool(): Tool {
+  return {
+    name: "live_echo",
+    description: "Return the supplied value.",
+    parameters: Type.Object({ value: Type.String() }, { additionalProperties: false }),
+  };
+}
+
+function requireToolCall(message: AssistantMessage) {
+  const toolCall = message.content.find((block) => block.type === "toolCall");
+  if (toolCall?.type !== "toolCall") {
+    throw new Error(`llama-server model did not call a tool: ${message.stopReason}`);
+  }
+  return toolCall;
+}
+
+describeLive("llama-server live", () => {
+  it("discovers and completes through the OpenAI completions transport", async () => {
+    const { model } = await resolveLiveModel();
+    const responses = await Promise.all(
+      ["one", "two"].map((word) =>
+        completeSimple(
+          model,
+          {
+            messages: [
+              {
+                role: "user",
+                content: `Reply with exactly: ${word}`,
+                timestamp: Date.now(),
+              },
+            ],
+          },
+          { apiKey: LIVE_KEY || "llama-server-local", maxTokens: 32 },
+        ),
+      ),
+    );
+
+    for (const response of responses) {
+      if (response.stopReason === "error") {
+        throw new Error(response.errorMessage || "llama-server returned an error");
+      }
+      expect(extractNonEmptyAssistantText(response.content).length).toBeGreaterThan(0);
+    }
+  }, 120_000);
+
+  it("completes a tool-call round trip when the template advertises tools", async (ctx) => {
+    const { model, supportsTools } = await resolveLiveModel();
+    if (!supportsTools) {
+      ctx.skip();
+      return;
+    }
+    const tool = echoTool();
+    const user = {
+      role: "user" as const,
+      content: "Call live_echo with value llama-server. Do not answer directly.",
+      timestamp: Date.now() - 2,
+    };
+    const first = await completeSimple(
+      model,
+      { messages: [user], tools: [tool] },
+      { apiKey: LIVE_KEY || "llama-server-local", maxTokens: 256 },
+    );
+    if (first.stopReason === "error") {
+      throw new Error(first.errorMessage || "llama-server tool turn returned an error");
+    }
+    const toolCall = requireToolCall(first);
+    expect(toolCall.name).toBe("live_echo");
+    expect(toolCall.arguments).toEqual({ value: "llama-server" });
+
+    const second = await completeSimple(
+      model,
+      {
+        messages: [
+          user,
+          first,
+          {
+            role: "toolResult",
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: Date.now() - 1,
+          },
+          { role: "user", content: "Reply with exactly: ok", timestamp: Date.now() },
+        ],
+        tools: [tool],
+      },
+      { apiKey: LIVE_KEY || "llama-server-local", maxTokens: 64 },
+    );
+    if (second.stopReason === "error") {
+      throw new Error(second.errorMessage || "llama-server result turn returned an error");
+    }
+    expect(extractNonEmptyAssistantText(second.content)).toMatch(/^ok[.!]?$/iu);
+  }, 120_000);
+});

--- a/extensions/llama-server/llama-server.live.test.ts
+++ b/extensions/llama-server/llama-server.live.test.ts
@@ -1,20 +1,36 @@
 // Llama-server live tests exercise discovery and the shared OpenAI completions transport.
 import {
-  completeSimple,
+  streamSimple,
   type AssistantMessage,
+  type Context,
   type Model,
+  type SimpleStreamOptions,
   type Tool,
 } from "openclaw/plugin-sdk/llm";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { extractNonEmptyAssistantText, isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { discoverLlamaServer } from "./src/discovery.js";
+import { wrapLlamaServerStream } from "./src/stream.js";
 
 const LIVE_URL = process.env.LLAMA_SERVER_LIVE_URL?.trim() ?? "";
 const LIVE_KEY = process.env.LLAMA_SERVER_API_KEY?.trim() ?? "";
 const LIVE_MODEL_ID = process.env.LLAMA_SERVER_LIVE_MODEL_ID?.trim() ?? "";
 const LIVE = isLiveTestEnabled(["LLAMA_SERVER_LIVE_TEST"]) && LIVE_URL.length > 0;
 const describeLive = LIVE ? describe : describe.skip;
+const liveStream = wrapLlamaServerStream({
+  streamFn: streamSimple,
+} as unknown as ProviderWrapStreamFnContext);
+
+async function completeViaPlugin(
+  model: Model<"openai-completions">,
+  context: Context,
+  options: SimpleStreamOptions,
+): Promise<AssistantMessage> {
+  const stream = await liveStream(model, context, options);
+  return await stream.result();
+}
 
 async function resolveLiveModel(): Promise<{
   model: Model<"openai-completions">;
@@ -48,6 +64,23 @@ async function resolveLiveModel(): Promise<{
   };
 }
 
+function disableThinking(payload: unknown): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+  const record = payload as Record<string, unknown>;
+  const current =
+    record.chat_template_kwargs &&
+    typeof record.chat_template_kwargs === "object" &&
+    !Array.isArray(record.chat_template_kwargs)
+      ? (record.chat_template_kwargs as Record<string, unknown>)
+      : {};
+  return {
+    ...record,
+    chat_template_kwargs: { ...current, enable_thinking: false },
+  };
+}
+
 function echoTool(): Tool {
   return {
     name: "live_echo",
@@ -69,7 +102,7 @@ describeLive("llama-server live", () => {
     const { model } = await resolveLiveModel();
     const responses = await Promise.all(
       ["one", "two"].map((word) =>
-        completeSimple(
+        completeViaPlugin(
           model,
           {
             messages: [
@@ -80,7 +113,11 @@ describeLive("llama-server live", () => {
               },
             ],
           },
-          { apiKey: LIVE_KEY || "llama-server-local", maxTokens: 32 },
+          {
+            apiKey: LIVE_KEY || "llama-server-local",
+            maxTokens: 64,
+            onPayload: disableThinking,
+          },
         ),
       ),
     );
@@ -91,6 +128,64 @@ describeLive("llama-server live", () => {
       }
       expect(extractNonEmptyAssistantText(response.content).length).toBeGreaterThan(0);
     }
+  }, 120_000);
+
+  it("returns schema-constrained JSON", async () => {
+    const { model } = await resolveLiveModel();
+    expect(model).toMatchObject({ compat: { supportsJsonSchemaResponseFormat: true } });
+    const response = await completeViaPlugin(
+      model,
+      {
+        messages: [
+          {
+            role: "user",
+            content: "Return a JSON object with ok set to true.",
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      {
+        apiKey: LIVE_KEY || "llama-server-local",
+        maxTokens: 64,
+        responseFormat: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+          additionalProperties: false,
+        },
+        onPayload: disableThinking,
+      },
+    );
+    if (response.stopReason === "error") {
+      throw new Error(response.errorMessage || "llama-server JSON turn returned an error");
+    }
+    expect(JSON.parse(extractNonEmptyAssistantText(response.content))).toEqual({ ok: true });
+  }, 120_000);
+
+  it("cancels an in-flight generation", async () => {
+    const { model } = await resolveLiveModel();
+    const controller = new AbortController();
+    const pending = completeViaPlugin(
+      model,
+      {
+        messages: [
+          {
+            role: "user",
+            content: "Write a detailed 2000-word history of computing.",
+            timestamp: Date.now(),
+          },
+        ],
+      },
+      {
+        apiKey: LIVE_KEY || "llama-server-local",
+        maxTokens: 4096,
+        signal: controller.signal,
+        onPayload: disableThinking,
+      },
+    );
+    setTimeout(() => controller.abort(), 250);
+    const response = await pending;
+    expect(response.stopReason).toBe("aborted");
   }, 120_000);
 
   it("completes a tool-call round trip when the template advertises tools", async (ctx) => {
@@ -105,10 +200,14 @@ describeLive("llama-server live", () => {
       content: "Call live_echo with value llama-server. Do not answer directly.",
       timestamp: Date.now() - 2,
     };
-    const first = await completeSimple(
+    const first = await completeViaPlugin(
       model,
       { messages: [user], tools: [tool] },
-      { apiKey: LIVE_KEY || "llama-server-local", maxTokens: 256 },
+      {
+        apiKey: LIVE_KEY || "llama-server-local",
+        maxTokens: 256,
+        onPayload: disableThinking,
+      },
     );
     if (first.stopReason === "error") {
       throw new Error(first.errorMessage || "llama-server tool turn returned an error");
@@ -117,7 +216,7 @@ describeLive("llama-server live", () => {
     expect(toolCall.name).toBe("live_echo");
     expect(toolCall.arguments).toEqual({ value: "llama-server" });
 
-    const second = await completeSimple(
+    const second = await completeViaPlugin(
       model,
       {
         messages: [
@@ -135,7 +234,11 @@ describeLive("llama-server live", () => {
         ],
         tools: [tool],
       },
-      { apiKey: LIVE_KEY || "llama-server-local", maxTokens: 64 },
+      {
+        apiKey: LIVE_KEY || "llama-server-local",
+        maxTokens: 128,
+        onPayload: disableThinking,
+      },
     );
     if (second.stopReason === "error") {
       throw new Error(second.errorMessage || "llama-server result turn returned an error");

--- a/extensions/llama-server/openclaw.plugin.json
+++ b/extensions/llama-server/openclaw.plugin.json
@@ -1,0 +1,65 @@
+{
+  "id": "llama-server",
+  "name": "llama-server Provider",
+  "description": "Connect OpenClaw to an existing llama.cpp server over HTTP.",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["llama-server"],
+  "modelCatalog": {
+    "discovery": {
+      "llama-server": "refreshable"
+    }
+  },
+  "providerRequest": {
+    "providers": {
+      "llama-server": {
+        "family": "llama-server",
+        "openAICompletions": {
+          "supportsStreamingUsage": true
+        }
+      }
+    }
+  },
+  "modelPricing": {
+    "providers": {
+      "llama-server": {
+        "external": false
+      }
+    }
+  },
+  "nonSecretAuthMarkers": ["llama-server-local"],
+  "syntheticAuthRefs": ["llama-server"],
+  "setup": {
+    "providers": [
+      {
+        "id": "llama-server",
+        "envVars": ["LLAMA_SERVER_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "llama-server",
+      "method": "custom",
+      "choiceId": "llama-server",
+      "appGuidedDiscovery": true,
+      "appGuidedSecret": true,
+      "choiceLabel": "llama-server",
+      "choiceHint": "Existing local or private llama.cpp server",
+      "optionKey": "llamaServerApiKey",
+      "cliFlag": "--llama-server-api-key",
+      "cliOption": "--llama-server-api-key <key>",
+      "cliDescription": "llama-server API key",
+      "groupId": "llama-server",
+      "groupLabel": "llama-server",
+      "groupHint": "Self-hosted llama.cpp models"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/llama-server/package.json
+++ b/extensions/llama-server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/llama-server-provider",
+  "version": "2026.7.2",
+  "private": true,
+  "description": "OpenClaw llama-server provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/llama-server/src/auth.test.ts
+++ b/extensions/llama-server/src/auth.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLlamaServerAuthHeaders,
+  hasLlamaServerAuthorizationHeader,
+  resolveLlamaServerProviderHeaders,
+  shouldUseLlamaServerSyntheticAuth,
+} from "./auth.js";
+
+describe("llama-server auth", () => {
+  it("uses synthetic runtime auth for no-auth and header-only providers", () => {
+    expect(
+      shouldUseLlamaServerSyntheticAuth({ baseUrl: "http://localhost:8080/v1", models: [] }),
+    ).toBe(true);
+    expect(
+      shouldUseLlamaServerSyntheticAuth({
+        baseUrl: "http://localhost:8080/v1",
+        headers: { authorization: "Bearer proxy-token" },
+        models: [],
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseLlamaServerSyntheticAuth({
+        baseUrl: "http://localhost:8080/v1",
+        apiKey: "server-key",
+        models: [],
+      }),
+    ).toBe(false);
+    expect(hasLlamaServerAuthorizationHeader({ authorization: "Bearer proxy-token" })).toBe(true);
+  });
+
+  it("preserves configured headers unless a real API key replaces authorization", () => {
+    expect(
+      buildLlamaServerAuthHeaders(undefined, {
+        Authorization: "Bearer proxy-token",
+        "X-Tenant": "one",
+      }),
+    ).toEqual({
+      Accept: "application/json",
+      Authorization: "Bearer proxy-token",
+      "X-Tenant": "one",
+    });
+    expect(
+      buildLlamaServerAuthHeaders("server-key", {
+        authorization: "Bearer proxy-token",
+        "X-Tenant": "one",
+      }),
+    ).toEqual({
+      Accept: "application/json",
+      Authorization: "Bearer server-key",
+      "X-Tenant": "one",
+    });
+  });
+
+  it("resolves provider header templates for discovery", async () => {
+    const config = {
+      models: {
+        providers: {
+          "llama-server": {
+            baseUrl: "http://localhost:8080/v1",
+            headers: { "X-Proxy-Key": "${LLAMA_PROXY_TOKEN}" },
+            models: [],
+          },
+        },
+      },
+    };
+    await expect(
+      resolveLlamaServerProviderHeaders({
+        config,
+        env: { LLAMA_PROXY_TOKEN: "proxy-token" },
+        headers: config.models.providers["llama-server"].headers,
+      }),
+    ).resolves.toEqual({ "X-Proxy-Key": "proxy-token" });
+  });
+});

--- a/extensions/llama-server/src/auth.ts
+++ b/extensions/llama-server/src/auth.ts
@@ -1,0 +1,54 @@
+import {
+  CUSTOM_LOCAL_AUTH_MARKER,
+  hasConfiguredSecretInput,
+  isNonSecretApiKeyMarker,
+  normalizeOptionalSecretInput,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { LLAMA_SERVER_LOCAL_AUTH_MARKER, LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
+
+export function hasLlamaServerAuthorizationHeader(headers: unknown): boolean {
+  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+    return false;
+  }
+  return Object.entries(headers).some(
+    ([name, value]) =>
+      name.trim().toLowerCase() === "authorization" && hasConfiguredSecretInput(value),
+  );
+}
+
+export function shouldUseLlamaServerSyntheticAuth(
+  providerConfig: ModelProviderConfig | undefined,
+): boolean {
+  const apiKey = normalizeOptionalSecretInput(providerConfig?.apiKey)?.trim();
+  const hasRealApiKey =
+    hasConfiguredSecretInput(providerConfig?.apiKey) &&
+    apiKey !== LLAMA_SERVER_LOCAL_AUTH_MARKER &&
+    apiKey !== CUSTOM_LOCAL_AUTH_MARKER;
+  return !hasRealApiKey && !hasLlamaServerAuthorizationHeader(providerConfig?.headers);
+}
+
+export function buildLlamaServerAuthHeaders(apiKey?: string): Record<string, string> {
+  const normalized = apiKey?.trim();
+  return {
+    Accept: "application/json",
+    ...(normalized && !isNonSecretApiKeyMarker(normalized)
+      ? { Authorization: `Bearer ${normalized}` }
+      : {}),
+  };
+}
+
+export async function resolveLlamaServerRuntimeApiKey(params: {
+  config?: OpenClawConfig;
+  agentDir?: string;
+}): Promise<string | undefined> {
+  const auth = await resolveApiKeyForProvider({
+    provider: LLAMA_SERVER_PROVIDER_ID,
+    cfg: params.config,
+    agentDir: params.agentDir,
+  });
+  const apiKey = auth.apiKey?.trim();
+  return apiKey && !isNonSecretApiKeyMarker(apiKey) ? apiKey : undefined;
+}

--- a/extensions/llama-server/src/auth.ts
+++ b/extensions/llama-server/src/auth.ts
@@ -88,11 +88,14 @@ export async function resolveLlamaServerProviderHeaders(params: {
 export async function resolveLlamaServerRuntimeApiKey(params: {
   config?: OpenClawConfig;
   agentDir?: string;
+  profileId?: string;
 }): Promise<string | undefined> {
   const auth = await resolveApiKeyForProvider({
     provider: LLAMA_SERVER_PROVIDER_ID,
     cfg: params.config,
     agentDir: params.agentDir,
+    profileId: params.profileId,
+    lockedProfile: params.profileId !== undefined,
   });
   const apiKey = auth.apiKey?.trim();
   return apiKey && !isNonSecretApiKeyMarker(apiKey) ? apiKey : undefined;

--- a/extensions/llama-server/src/auth.ts
+++ b/extensions/llama-server/src/auth.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import { LLAMA_SERVER_LOCAL_AUTH_MARKER, LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
 
 export function hasLlamaServerAuthorizationHeader(headers: unknown): boolean {
@@ -27,17 +28,61 @@ export function shouldUseLlamaServerSyntheticAuth(
     hasConfiguredSecretInput(providerConfig?.apiKey) &&
     apiKey !== LLAMA_SERVER_LOCAL_AUTH_MARKER &&
     apiKey !== CUSTOM_LOCAL_AUTH_MARKER;
-  return !hasRealApiKey && !hasLlamaServerAuthorizationHeader(providerConfig?.headers);
+  return !hasRealApiKey;
 }
 
-export function buildLlamaServerAuthHeaders(apiKey?: string): Record<string, string> {
-  const normalized = apiKey?.trim();
-  return {
+export function buildLlamaServerAuthHeaders(
+  apiKey?: string,
+  configuredHeaders?: Record<string, string>,
+): Record<string, string> {
+  const headers: Record<string, string> = {
     Accept: "application/json",
-    ...(normalized && !isNonSecretApiKeyMarker(normalized)
-      ? { Authorization: `Bearer ${normalized}` }
-      : {}),
+    ...configuredHeaders,
   };
+  const normalized = apiKey?.trim();
+  if (normalized && !isNonSecretApiKeyMarker(normalized)) {
+    for (const name of Object.keys(headers)) {
+      if (name.trim().toLowerCase() === "authorization") {
+        delete headers[name];
+      }
+    }
+    headers.Authorization = `Bearer ${normalized}`;
+  }
+  return headers;
+}
+
+export async function resolveLlamaServerProviderHeaders(params: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  headers?: unknown;
+}): Promise<Record<string, string> | undefined> {
+  if (!params.headers || typeof params.headers !== "object" || Array.isArray(params.headers)) {
+    return undefined;
+  }
+  const resolved: Record<string, string> = {};
+  for (const [name, value] of Object.entries(params.headers)) {
+    if (!params.config) {
+      if (typeof value === "string" && value.trim()) {
+        resolved[name] = value.trim();
+      }
+      continue;
+    }
+    const path = `models.providers.${LLAMA_SERVER_PROVIDER_ID}.headers.${name}`;
+    const header = await resolveConfiguredSecretInputString({
+      config: params.config,
+      env: params.env ?? process.env,
+      value,
+      path,
+      unresolvedReasonStyle: "detailed",
+    });
+    if (header.unresolvedRefReason) {
+      throw new Error(`${path}: ${header.unresolvedRefReason}`);
+    }
+    if (header.value) {
+      resolved[name] = header.value;
+    }
+  }
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
 }
 
 export async function resolveLlamaServerRuntimeApiKey(params: {

--- a/extensions/llama-server/src/defaults.ts
+++ b/extensions/llama-server/src/defaults.ts
@@ -1,0 +1,8 @@
+export const LLAMA_SERVER_PROVIDER_ID = "llama-server";
+export const LLAMA_SERVER_PROVIDER_LABEL = "llama-server";
+export const LLAMA_SERVER_DEFAULT_ORIGIN = "http://127.0.0.1:8080";
+export const LLAMA_SERVER_DEFAULT_BASE_URL = `${LLAMA_SERVER_DEFAULT_ORIGIN}/v1`;
+export const LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR = "LLAMA_SERVER_API_KEY";
+export const LLAMA_SERVER_LOCAL_AUTH_MARKER = "llama-server-local";
+export const LLAMA_SERVER_DISCOVERY_TIMEOUT_MS = 5_000;
+export const LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS = 30_000;

--- a/extensions/llama-server/src/discovery.test.ts
+++ b/extensions/llama-server/src/discovery.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearLlamaServerDiscoveryCacheForTests,
+  discoverLlamaServer,
+  type LlamaServerFetchGuard,
+} from "./discovery.js";
+
+type RouteValue = Response | Error | (() => Response);
+
+function createFetchGuard(routes: Record<string, RouteValue>) {
+  const requests: string[] = [];
+  const guard = vi.fn(async (params: Parameters<LlamaServerFetchGuard>[0]) => {
+    requests.push(params.url);
+    const route = routes[params.url];
+    if (!route) {
+      throw new Error(`unexpected request: ${params.url}`);
+    }
+    if (route instanceof Error) {
+      throw route;
+    }
+    const response = typeof route === "function" ? route() : route;
+    return {
+      response,
+      finalUrl: params.url,
+      release: async () => undefined,
+    };
+  }) as unknown as LlamaServerFetchGuard;
+  return { guard, requests };
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("llama-server discovery", () => {
+  beforeEach(() => {
+    clearLlamaServerDiscoveryCacheForTests();
+  });
+
+  it("discovers a single model and reads runtime properties", async () => {
+    const { guard, requests } = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({
+        object: "list",
+        data: [{ id: "qwen/model:Q4_K_M", object: "model", owned_by: "llamacpp" }],
+      }),
+      "http://localhost:8080/props": json({
+        default_generation_settings: { n_ctx: 32768 },
+        chat_template_caps: { supports_tools: true, supports_tool_calls: true },
+      }),
+    });
+
+    const result = await discoverLlamaServer({
+      baseUrl: "http://localhost:8080/v1",
+      apiKey: "server-key",
+      fetchGuard: guard,
+      cacheTtlMs: 0,
+    });
+
+    expect(result).toMatchObject({
+      kind: "success",
+      health: "ready",
+      models: [
+        {
+          status: "unknown",
+          config: {
+            id: "qwen/model:Q4_K_M",
+            contextWindow: 32768,
+            compat: { supportsTools: true },
+          },
+        },
+      ],
+    });
+    expect(requests).toEqual([
+      "http://localhost:8080/health",
+      "http://localhost:8080/models",
+      "http://localhost:8080/props",
+    ]);
+    expect(guard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        init: {
+          headers: {
+            Accept: "application/json",
+            Authorization: "Bearer server-key",
+          },
+        },
+      }),
+    );
+  });
+
+  it("lists router models without loading an unloaded model", async () => {
+    const { guard, requests } = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({
+        data: [
+          { id: "loaded/model", object: "model", status: { value: "loaded" } },
+          { id: "sleeping:model", object: "model", status: { value: "sleeping" } },
+          { id: "unloaded/model", object: "model", status: { value: "unloaded" } },
+        ],
+      }),
+      "http://localhost:8080/props?model=loaded%2Fmodel&autoload=false": json({
+        default_generation_settings: { n_ctx: 16384 },
+      }),
+      "http://localhost:8080/props?model=sleeping%3Amodel&autoload=false": json({
+        default_generation_settings: { n_ctx: 8192 },
+        is_sleeping: true,
+      }),
+    });
+
+    const result = await discoverLlamaServer({
+      baseUrl: "http://localhost:8080",
+      fetchGuard: guard,
+      cacheTtlMs: 0,
+    });
+
+    expect(result.kind).toBe("success");
+    if (result.kind !== "success") {
+      throw new Error("expected successful discovery");
+    }
+    expect(result.models.map((model) => [model.config.id, model.status])).toEqual([
+      ["loaded/model", "loaded"],
+      ["sleeping:model", "sleeping"],
+      ["unloaded/model", "unloaded"],
+    ]);
+    expect(requests).not.toContain(
+      "http://localhost:8080/props?model=unloaded%2Fmodel&autoload=false",
+    );
+    expect(requests.every((url) => !url.includes("reload=1"))).toBe(true);
+  });
+
+  it("falls back to /v1/models for an older compatible server", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ error: "missing" }, 404),
+      "http://localhost:8080/v1/models": json({
+        data: [{ id: "model", object: "model" }],
+      }),
+      "http://localhost:8080/props": json({}),
+    });
+
+    await expect(
+      discoverLlamaServer({ baseUrl: "http://localhost:8080", fetchGuard: guard, cacheTtlMs: 0 }),
+    ).resolves.toMatchObject({ kind: "success", models: [{ config: { id: "model" } }] });
+  });
+
+  it("keeps a loading health state while listing available models", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": json({ error: "loading" }, 503),
+      "http://localhost:8080/models": json({ data: [] }),
+    });
+
+    await expect(
+      discoverLlamaServer({ baseUrl: "http://localhost:8080", fetchGuard: guard, cacheTtlMs: 0 }),
+    ).resolves.toMatchObject({ kind: "success", health: "loading", models: [] });
+  });
+
+  it("separates transport, HTTP, and malformed-response failures", async () => {
+    const unreachable = createFetchGuard({
+      "http://localhost:8080/health": new Error("connection refused"),
+    });
+    await expect(
+      discoverLlamaServer({
+        baseUrl: "http://localhost:8080",
+        fetchGuard: unreachable.guard,
+        cacheTtlMs: 0,
+      }),
+    ).resolves.toMatchObject({ kind: "unreachable" });
+
+    const unauthorized = createFetchGuard({
+      "http://localhost:8080/health": json({ error: "unauthorized" }, 401),
+    });
+    await expect(
+      discoverLlamaServer({
+        baseUrl: "http://localhost:8080",
+        fetchGuard: unauthorized.guard,
+        cacheTtlMs: 0,
+      }),
+    ).resolves.toMatchObject({ kind: "http-error", status: 401, path: "/health" });
+
+    const malformed = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": new Response("{", { status: 200 }),
+    });
+    await expect(
+      discoverLlamaServer({
+        baseUrl: "http://localhost:8080",
+        fetchGuard: malformed.guard,
+        cacheTtlMs: 0,
+      }),
+    ).resolves.toMatchObject({ kind: "invalid-response", path: "/models" });
+  });
+
+  it("reuses only successful cached discovery", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ data: [] }),
+    });
+
+    await discoverLlamaServer({ baseUrl: "http://localhost:8080", fetchGuard: guard });
+    await discoverLlamaServer({ baseUrl: "http://localhost:8080", fetchGuard: guard });
+    expect(guard).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/llama-server/src/discovery.test.ts
+++ b/extensions/llama-server/src/discovery.test.ts
@@ -193,14 +193,51 @@ describe("llama-server discovery", () => {
     ).resolves.toMatchObject({ kind: "invalid-response", path: "/models" });
   });
 
+  it("forwards configured headers and bypasses the shared cache for credentialed discovery", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": () => json({ status: "ok" }),
+      "http://localhost:8080/models": () => json({ data: [] }),
+    });
+
+    for (let index = 0; index < 2; index += 1) {
+      await discoverLlamaServer({
+        baseUrl: "http://localhost:8080",
+        headers: { "X-Proxy-Key": "proxy-token" },
+        fetchGuard: guard,
+      });
+    }
+
+    expect(guard).toHaveBeenCalledTimes(4);
+    for (const call of vi.mocked(guard).mock.calls) {
+      expect(call[0]).toEqual(
+        expect.objectContaining({
+          init: {
+            headers: {
+              Accept: "application/json",
+              "X-Proxy-Key": "proxy-token",
+            },
+          },
+        }),
+      );
+    }
+  });
+
   it("reuses only successful cached discovery", async () => {
     const { guard } = createFetchGuard({
       "http://localhost:8080/health": json({ status: "ok" }),
       "http://localhost:8080/models": json({ data: [] }),
     });
 
-    await discoverLlamaServer({ baseUrl: "http://localhost:8080", fetchGuard: guard });
-    await discoverLlamaServer({ baseUrl: "http://localhost:8080", fetchGuard: guard });
+    await discoverLlamaServer({
+      baseUrl: "http://localhost:8080",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+    });
+    await discoverLlamaServer({
+      baseUrl: "http://localhost:8080",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+    });
     expect(guard).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/llama-server/src/discovery.test.ts
+++ b/extensions/llama-server/src/discovery.test.ts
@@ -310,4 +310,35 @@ describe("llama-server discovery", () => {
     });
     expect(guard).toHaveBeenCalledTimes(2);
   });
+
+  it("bounds cached endpoint discovery", async () => {
+    const guard = vi.fn(async (params: Parameters<LlamaServerFetchGuard>[0]) => ({
+      response: params.url.endsWith("/health") ? json({ status: "ok" }) : json({ data: [] }),
+      finalUrl: params.url,
+      release: async () => undefined,
+    })) as unknown as LlamaServerFetchGuard;
+
+    for (let index = 0; index <= 100; index += 1) {
+      await discoverLlamaServer({
+        baseUrl: `http://localhost:${10_000 + index}`,
+        apiKey: "custom-local",
+        fetchGuard: guard,
+      });
+    }
+    expect(guard).toHaveBeenCalledTimes(202);
+
+    await discoverLlamaServer({
+      baseUrl: "http://localhost:10100",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+    });
+    expect(guard).toHaveBeenCalledTimes(202);
+
+    await discoverLlamaServer({
+      baseUrl: "http://localhost:10000",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+    });
+    expect(guard).toHaveBeenCalledTimes(204);
+  });
 });

--- a/extensions/llama-server/src/discovery.test.ts
+++ b/extensions/llama-server/src/discovery.test.ts
@@ -169,6 +169,38 @@ describe("llama-server discovery", () => {
     expect(maximumActive).toBeLessThanOrEqual(8);
   });
 
+  it("stops scheduling router property probes after the total budget", async () => {
+    const rows = Array.from({ length: 17 }, (_, index) => ({
+      id: `loaded/model-${index}`,
+      object: "model",
+      status: { value: "loaded" },
+    }));
+    const routes: Record<string, RouteValue> = {
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ data: rows }),
+    };
+    for (const row of rows) {
+      routes[`http://localhost:8080/props?model=${encodeURIComponent(row.id)}&autoload=false`] =
+        async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 20);
+          });
+          return json({ default_generation_settings: { n_ctx: 8192 } });
+        };
+    }
+    const { guard, requests } = createFetchGuard(routes);
+
+    const result = await discoverLlamaServer({
+      baseUrl: "http://localhost:8080",
+      fetchGuard: guard,
+      cacheTtlMs: 0,
+      timeoutMs: 10,
+    });
+
+    expect(result.kind === "success" ? result.models : []).toHaveLength(17);
+    expect(requests.filter((url) => url.includes("/props?"))).toHaveLength(8);
+  });
+
   it("falls back to /v1/models for an older compatible server", async () => {
     const { guard } = createFetchGuard({
       "http://localhost:8080/health": json({ status: "ok" }),

--- a/extensions/llama-server/src/discovery.test.ts
+++ b/extensions/llama-server/src/discovery.test.ts
@@ -5,7 +5,7 @@ import {
   type LlamaServerFetchGuard,
 } from "./discovery.js";
 
-type RouteValue = Response | Error | (() => Response);
+type RouteValue = Response | Error | (() => Response | Promise<Response>);
 
 function createFetchGuard(routes: Record<string, RouteValue>) {
   const requests: string[] = [];
@@ -18,7 +18,7 @@ function createFetchGuard(routes: Record<string, RouteValue>) {
     if (route instanceof Error) {
       throw route;
     }
-    const response = typeof route === "function" ? route() : route;
+    const response = typeof route === "function" ? await route() : route;
     return {
       response,
       finalUrl: params.url,
@@ -129,6 +129,44 @@ describe("llama-server discovery", () => {
       "http://localhost:8080/props?model=unloaded%2Fmodel&autoload=false",
     );
     expect(requests.every((url) => !url.includes("reload=1"))).toBe(true);
+  });
+
+  it("bounds concurrent router property probes", async () => {
+    const rows = Array.from({ length: 17 }, (_, index) => ({
+      id: `loaded/model-${index}`,
+      object: "model",
+      status: { value: "loaded" },
+    }));
+    let active = 0;
+    let maximumActive = 0;
+    const routes: Record<string, RouteValue> = {
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ data: rows }),
+    };
+    for (const row of rows) {
+      routes[`http://localhost:8080/props?model=${encodeURIComponent(row.id)}&autoload=false`] =
+        async () => {
+          active += 1;
+          maximumActive = Math.max(maximumActive, active);
+          await new Promise((resolve) => {
+            setTimeout(resolve, 5);
+          });
+          active -= 1;
+          return json({ default_generation_settings: { n_ctx: 8192 } });
+        };
+    }
+    const { guard } = createFetchGuard(routes);
+
+    const result = await discoverLlamaServer({
+      baseUrl: "http://localhost:8080",
+      fetchGuard: guard,
+      cacheTtlMs: 0,
+    });
+
+    expect(result).toMatchObject({ kind: "success", models: expect.any(Array) });
+    expect(result.kind === "success" ? result.models : []).toHaveLength(17);
+    expect(maximumActive).toBeGreaterThan(1);
+    expect(maximumActive).toBeLessThanOrEqual(8);
   });
 
   it("falls back to /v1/models for an older compatible server", async () => {

--- a/extensions/llama-server/src/discovery.ts
+++ b/extensions/llama-server/src/discovery.ts
@@ -275,6 +275,7 @@ export async function discoverLlamaServer(params: {
   }
   const routerMode = rows.some((row) => row.status !== undefined);
   const propsByRowIndex = new Map<number, LlamaServerPropsWire>();
+  const propsDeadline = Date.now() + Math.max(0, timeoutMs);
   const propsRowIndexes = rows
     .map((row, index) => (shouldReadProps(row) ? index : -1))
     .filter((index) => index >= 0)
@@ -284,6 +285,10 @@ export async function discoverLlamaServer(params: {
     offset < propsRowIndexes.length;
     offset += LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY
   ) {
+    const remainingMs = propsDeadline - Date.now();
+    if (remainingMs <= 0) {
+      break;
+    }
     const results = await Promise.all(
       propsRowIndexes
         .slice(offset, offset + LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY)
@@ -298,7 +303,7 @@ export async function discoverLlamaServer(params: {
             origin: endpoint.origin,
             apiKey: params.apiKey,
             headers: params.headers,
-            timeoutMs,
+            timeoutMs: Math.min(timeoutMs, remainingMs),
             signal: params.signal,
             fetchGuard,
           });

--- a/extensions/llama-server/src/discovery.ts
+++ b/extensions/llama-server/src/discovery.ts
@@ -1,3 +1,4 @@
+import { isNonSecretApiKeyMarker } from "openclaw/plugin-sdk/provider-auth";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   fetchWithSsrFGuard,
@@ -66,6 +67,7 @@ async function fetchJson(params: {
   url: string;
   origin: string;
   apiKey?: string;
+  headers?: Record<string, string>;
   timeoutMs: number;
   signal?: AbortSignal;
   readBody: boolean;
@@ -75,7 +77,7 @@ async function fetchJson(params: {
   try {
     guarded = await params.fetchGuard({
       url: params.url,
-      init: { headers: buildLlamaServerAuthHeaders(params.apiKey) },
+      init: { headers: buildLlamaServerAuthHeaders(params.apiKey, params.headers) },
       timeoutMs: params.timeoutMs,
       signal: params.signal,
       policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(params.origin),
@@ -135,6 +137,7 @@ async function readModelProps(params: {
   routerMode: boolean;
   origin: string;
   apiKey?: string;
+  headers?: Record<string, string>;
   timeoutMs: number;
   signal?: AbortSignal;
   fetchGuard: LlamaServerFetchGuard;
@@ -149,6 +152,7 @@ async function readModelProps(params: {
     url: `${params.origin}/props${query}`,
     origin: params.origin,
     apiKey: params.apiKey,
+    headers: params.headers,
     timeoutMs: params.timeoutMs,
     signal: params.signal,
     readBody: true,
@@ -163,15 +167,22 @@ async function readModelProps(params: {
 export async function discoverLlamaServer(params: {
   baseUrl?: string;
   apiKey?: string;
+  headers?: Record<string, string>;
   timeoutMs?: number;
   cacheTtlMs?: number;
   signal?: AbortSignal;
   fetchGuard?: LlamaServerFetchGuard;
 }): Promise<LlamaServerDiscoveryResult> {
   const endpoint = resolveLlamaServerEndpoint(params.baseUrl);
-  const cacheTtlMs = Math.max(0, params.cacheTtlMs ?? LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS);
+  const normalizedApiKey = params.apiKey?.trim();
+  const hasCredentialScope =
+    Boolean(normalizedApiKey && !isNonSecretApiKeyMarker(normalizedApiKey)) ||
+    Boolean(params.headers && Object.keys(params.headers).length > 0);
+  const cacheTtlMs = hasCredentialScope
+    ? 0
+    : Math.max(0, params.cacheTtlMs ?? LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS);
   const cached = discoveryCache.get(endpoint.origin);
-  if (cached && cached.expiresAt > Date.now()) {
+  if (cacheTtlMs > 0 && cached && cached.expiresAt > Date.now()) {
     return cached.result;
   }
 
@@ -181,6 +192,7 @@ export async function discoverLlamaServer(params: {
     url: `${endpoint.origin}/health`,
     origin: endpoint.origin,
     apiKey: params.apiKey,
+    headers: params.headers,
     timeoutMs,
     signal: params.signal,
     readBody: false,
@@ -214,6 +226,7 @@ export async function discoverLlamaServer(params: {
     url: `${endpoint.origin}${modelsPath}`,
     origin: endpoint.origin,
     apiKey: params.apiKey,
+    headers: params.headers,
     timeoutMs,
     signal: params.signal,
     readBody: true,
@@ -225,6 +238,7 @@ export async function discoverLlamaServer(params: {
       url: `${endpoint.origin}${modelsPath}`,
       origin: endpoint.origin,
       apiKey: params.apiKey,
+      headers: params.headers,
       timeoutMs,
       signal: params.signal,
       readBody: true,
@@ -265,6 +279,7 @@ export async function discoverLlamaServer(params: {
       routerMode,
       origin: endpoint.origin,
       apiKey: params.apiKey,
+      headers: params.headers,
       timeoutMs,
       signal: params.signal,
       fetchGuard,

--- a/extensions/llama-server/src/discovery.ts
+++ b/extensions/llama-server/src/discovery.ts
@@ -58,6 +58,8 @@ type CachedDiscovery = {
 };
 
 const discoveryCache = new Map<string, CachedDiscovery>();
+const LLAMA_SERVER_ROUTER_PROPS_MAX_MODELS = 200;
+const LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY = 8;
 
 export function clearLlamaServerDiscoveryCacheForTests(): void {
   discoveryCache.clear();
@@ -272,23 +274,47 @@ export async function discoverLlamaServer(params: {
     return { kind: "invalid-response", endpoint, path: modelsPath, error };
   }
   const routerMode = rows.some((row) => row.status !== undefined);
-  const models: LlamaServerDiscoveredModel[] = [];
-  for (const row of rows) {
-    const props = await readModelProps({
-      row,
-      routerMode,
-      origin: endpoint.origin,
-      apiKey: params.apiKey,
-      headers: params.headers,
-      timeoutMs,
-      signal: params.signal,
-      fetchGuard,
-    });
-    const model = mapLlamaServerModel(row, props);
-    if (model) {
-      models.push(model);
+  const propsByRowIndex = new Map<number, LlamaServerPropsWire>();
+  const propsRowIndexes = rows
+    .map((row, index) => (shouldReadProps(row) ? index : -1))
+    .filter((index) => index >= 0)
+    .slice(0, LLAMA_SERVER_ROUTER_PROPS_MAX_MODELS);
+  for (
+    let offset = 0;
+    offset < propsRowIndexes.length;
+    offset += LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY
+  ) {
+    const results = await Promise.all(
+      propsRowIndexes
+        .slice(offset, offset + LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY)
+        .map(async (index) => {
+          const row = rows[index];
+          if (!row) {
+            return undefined;
+          }
+          const props = await readModelProps({
+            row,
+            routerMode,
+            origin: endpoint.origin,
+            apiKey: params.apiKey,
+            headers: params.headers,
+            timeoutMs,
+            signal: params.signal,
+            fetchGuard,
+          });
+          return props ? ([index, props] as const) : undefined;
+        }),
+    );
+    for (const result of results) {
+      if (result) {
+        propsByRowIndex.set(...result);
+      }
     }
   }
+  const models = rows.flatMap((row, index) => {
+    const model = mapLlamaServerModel(row, propsByRowIndex.get(index));
+    return model ? [model] : [];
+  });
 
   const fetchedAt = Date.now();
   const result = { kind: "success", endpoint, health, models, fetchedAt } as const;

--- a/extensions/llama-server/src/discovery.ts
+++ b/extensions/llama-server/src/discovery.ts
@@ -1,0 +1,284 @@
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+import { buildLlamaServerAuthHeaders } from "./auth.js";
+import {
+  LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS,
+  LLAMA_SERVER_DISCOVERY_TIMEOUT_MS,
+} from "./defaults.js";
+import { resolveLlamaServerEndpoint } from "./endpoint.js";
+import {
+  mapLlamaServerModel,
+  type LlamaServerDiscoveredModel,
+  type LlamaServerModelWire,
+  type LlamaServerPropsWire,
+} from "./models.js";
+
+export type LlamaServerHealth = "ready" | "loading" | "unknown";
+
+export type LlamaServerDiscoveryResult =
+  | {
+      kind: "success";
+      endpoint: ReturnType<typeof resolveLlamaServerEndpoint>;
+      health: LlamaServerHealth;
+      models: LlamaServerDiscoveredModel[];
+      fetchedAt: number;
+    }
+  | {
+      kind: "unreachable";
+      endpoint: ReturnType<typeof resolveLlamaServerEndpoint>;
+      error: unknown;
+    }
+  | {
+      kind: "http-error";
+      endpoint: ReturnType<typeof resolveLlamaServerEndpoint>;
+      status: number;
+      path: string;
+    }
+  | {
+      kind: "invalid-response";
+      endpoint: ReturnType<typeof resolveLlamaServerEndpoint>;
+      path: string;
+      error: unknown;
+    };
+
+export type LlamaServerFetchGuard = typeof fetchWithSsrFGuard;
+
+type FetchJsonResult =
+  | { kind: "response"; status: number; ok: boolean; body?: unknown }
+  | { kind: "unreachable"; error: unknown }
+  | { kind: "invalid-response"; error: unknown };
+
+type CachedDiscovery = {
+  expiresAt: number;
+  result: Extract<LlamaServerDiscoveryResult, { kind: "success" }>;
+};
+
+const discoveryCache = new Map<string, CachedDiscovery>();
+
+export function clearLlamaServerDiscoveryCacheForTests(): void {
+  discoveryCache.clear();
+}
+
+async function fetchJson(params: {
+  url: string;
+  origin: string;
+  apiKey?: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+  readBody: boolean;
+  fetchGuard: LlamaServerFetchGuard;
+}): Promise<FetchJsonResult> {
+  let guarded: Awaited<ReturnType<LlamaServerFetchGuard>>;
+  try {
+    guarded = await params.fetchGuard({
+      url: params.url,
+      init: { headers: buildLlamaServerAuthHeaders(params.apiKey) },
+      timeoutMs: params.timeoutMs,
+      signal: params.signal,
+      policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(params.origin),
+      auditContext: "llama-server-discovery",
+    });
+  } catch (error) {
+    return { kind: "unreachable", error };
+  }
+
+  try {
+    if (!params.readBody || !guarded.response.ok) {
+      return {
+        kind: "response",
+        status: guarded.response.status,
+        ok: guarded.response.ok,
+      };
+    }
+    try {
+      return {
+        kind: "response",
+        status: guarded.response.status,
+        ok: true,
+        body: await readProviderJsonResponse(guarded.response, "llama-server discovery"),
+      };
+    } catch (error) {
+      return { kind: "invalid-response", error };
+    }
+  } finally {
+    if (!guarded.response.bodyUsed) {
+      await guarded.response.body?.cancel().catch(() => undefined);
+    }
+    await guarded.release();
+  }
+}
+
+function readModelRows(body: unknown): LlamaServerModelWire[] {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("llama-server model list must be an object");
+  }
+  const data = (body as { data?: unknown }).data;
+  if (!Array.isArray(data)) {
+    throw new Error("llama-server model list must contain data[]");
+  }
+  return data.filter(
+    (entry): entry is LlamaServerModelWire =>
+      Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+  );
+}
+
+function shouldReadProps(row: LlamaServerModelWire): boolean {
+  const status = row.status?.value;
+  return status === undefined || status === "loaded" || status === "sleeping";
+}
+
+async function readModelProps(params: {
+  row: LlamaServerModelWire;
+  routerMode: boolean;
+  origin: string;
+  apiKey?: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+  fetchGuard: LlamaServerFetchGuard;
+}): Promise<LlamaServerPropsWire | undefined> {
+  if (!shouldReadProps(params.row) || typeof params.row.id !== "string") {
+    return undefined;
+  }
+  const query = params.routerMode
+    ? `?model=${encodeURIComponent(params.row.id)}&autoload=false`
+    : "";
+  const result = await fetchJson({
+    url: `${params.origin}/props${query}`,
+    origin: params.origin,
+    apiKey: params.apiKey,
+    timeoutMs: params.timeoutMs,
+    signal: params.signal,
+    readBody: true,
+    fetchGuard: params.fetchGuard,
+  });
+  return result.kind === "response" && result.ok
+    ? (result.body as LlamaServerPropsWire)
+    : undefined;
+}
+
+/** Discovers llama-server models without loading, waking, or unloading them. */
+export async function discoverLlamaServer(params: {
+  baseUrl?: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  cacheTtlMs?: number;
+  signal?: AbortSignal;
+  fetchGuard?: LlamaServerFetchGuard;
+}): Promise<LlamaServerDiscoveryResult> {
+  const endpoint = resolveLlamaServerEndpoint(params.baseUrl);
+  const cacheTtlMs = Math.max(0, params.cacheTtlMs ?? LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS);
+  const cached = discoveryCache.get(endpoint.origin);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.result;
+  }
+
+  const timeoutMs = params.timeoutMs ?? LLAMA_SERVER_DISCOVERY_TIMEOUT_MS;
+  const fetchGuard = params.fetchGuard ?? fetchWithSsrFGuard;
+  const healthResult = await fetchJson({
+    url: `${endpoint.origin}/health`,
+    origin: endpoint.origin,
+    apiKey: params.apiKey,
+    timeoutMs,
+    signal: params.signal,
+    readBody: false,
+    fetchGuard,
+  });
+  if (healthResult.kind === "unreachable") {
+    return { kind: "unreachable", endpoint, error: healthResult.error };
+  }
+  const health: LlamaServerHealth =
+    healthResult.kind === "response" && healthResult.status === 200
+      ? "ready"
+      : healthResult.kind === "response" && healthResult.status === 503
+        ? "loading"
+        : "unknown";
+  if (
+    healthResult.kind === "response" &&
+    healthResult.status !== 200 &&
+    healthResult.status !== 404 &&
+    healthResult.status !== 503
+  ) {
+    return {
+      kind: "http-error",
+      endpoint,
+      status: healthResult.status,
+      path: "/health",
+    };
+  }
+
+  let modelsPath = "/models";
+  let modelsResult = await fetchJson({
+    url: `${endpoint.origin}${modelsPath}`,
+    origin: endpoint.origin,
+    apiKey: params.apiKey,
+    timeoutMs,
+    signal: params.signal,
+    readBody: true,
+    fetchGuard,
+  });
+  if (modelsResult.kind === "response" && modelsResult.status === 404) {
+    modelsPath = "/v1/models";
+    modelsResult = await fetchJson({
+      url: `${endpoint.origin}${modelsPath}`,
+      origin: endpoint.origin,
+      apiKey: params.apiKey,
+      timeoutMs,
+      signal: params.signal,
+      readBody: true,
+      fetchGuard,
+    });
+  }
+  if (modelsResult.kind === "unreachable") {
+    return { kind: "unreachable", endpoint, error: modelsResult.error };
+  }
+  if (modelsResult.kind === "invalid-response") {
+    return {
+      kind: "invalid-response",
+      endpoint,
+      path: modelsPath,
+      error: modelsResult.error,
+    };
+  }
+  if (!modelsResult.ok) {
+    return {
+      kind: "http-error",
+      endpoint,
+      status: modelsResult.status,
+      path: modelsPath,
+    };
+  }
+
+  let rows: LlamaServerModelWire[];
+  try {
+    rows = readModelRows(modelsResult.body);
+  } catch (error) {
+    return { kind: "invalid-response", endpoint, path: modelsPath, error };
+  }
+  const routerMode = rows.some((row) => row.status !== undefined);
+  const models: LlamaServerDiscoveredModel[] = [];
+  for (const row of rows) {
+    const props = await readModelProps({
+      row,
+      routerMode,
+      origin: endpoint.origin,
+      apiKey: params.apiKey,
+      timeoutMs,
+      signal: params.signal,
+      fetchGuard,
+    });
+    const model = mapLlamaServerModel(row, props);
+    if (model) {
+      models.push(model);
+    }
+  }
+
+  const fetchedAt = Date.now();
+  const result = { kind: "success", endpoint, health, models, fetchedAt } as const;
+  if (cacheTtlMs > 0) {
+    discoveryCache.set(endpoint.origin, { result, expiresAt: fetchedAt + cacheTtlMs });
+  }
+  return result;
+}

--- a/extensions/llama-server/src/discovery.ts
+++ b/extensions/llama-server/src/discovery.ts
@@ -58,8 +58,26 @@ type CachedDiscovery = {
 };
 
 const discoveryCache = new Map<string, CachedDiscovery>();
+const LLAMA_SERVER_DISCOVERY_CACHE_MAX_ENTRIES = 100;
 const LLAMA_SERVER_ROUTER_PROPS_MAX_MODELS = 200;
 const LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY = 8;
+
+function cacheDiscovery(key: string, entry: CachedDiscovery, now: number): void {
+  for (const [cachedKey, cached] of discoveryCache) {
+    if (cached.expiresAt <= now) {
+      discoveryCache.delete(cachedKey);
+    }
+  }
+  discoveryCache.delete(key);
+  discoveryCache.set(key, entry);
+  while (discoveryCache.size > LLAMA_SERVER_DISCOVERY_CACHE_MAX_ENTRIES) {
+    const oldest = discoveryCache.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    discoveryCache.delete(oldest.value);
+  }
+}
 
 export function clearLlamaServerDiscoveryCacheForTests(): void {
   discoveryCache.clear();
@@ -184,8 +202,11 @@ export async function discoverLlamaServer(params: {
     ? 0
     : Math.max(0, params.cacheTtlMs ?? LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS);
   const cached = discoveryCache.get(endpoint.origin);
-  if (cacheTtlMs > 0 && cached && cached.expiresAt > Date.now()) {
-    return cached.result;
+  if (cacheTtlMs > 0 && cached) {
+    if (cached.expiresAt > Date.now()) {
+      return cached.result;
+    }
+    discoveryCache.delete(endpoint.origin);
   }
 
   const timeoutMs = params.timeoutMs ?? LLAMA_SERVER_DISCOVERY_TIMEOUT_MS;
@@ -324,7 +345,7 @@ export async function discoverLlamaServer(params: {
   const fetchedAt = Date.now();
   const result = { kind: "success", endpoint, health, models, fetchedAt } as const;
   if (cacheTtlMs > 0) {
-    discoveryCache.set(endpoint.origin, { result, expiresAt: fetchedAt + cacheTtlMs });
+    cacheDiscovery(endpoint.origin, { result, expiresAt: fetchedAt + cacheTtlMs }, fetchedAt);
   }
   return result;
 }

--- a/extensions/llama-server/src/endpoint.test.ts
+++ b/extensions/llama-server/src/endpoint.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLlamaServerProviderConfig, resolveLlamaServerEndpoint } from "./endpoint.js";
+
+describe("llama-server endpoint", () => {
+  it.each([
+    ["http://127.0.0.1:8080", "http://127.0.0.1:8080", "http://127.0.0.1:8080/v1"],
+    ["http://127.0.0.1:8080/v1/", "http://127.0.0.1:8080", "http://127.0.0.1:8080/v1"],
+    ["localhost:8010/v1", "http://localhost:8010", "http://localhost:8010/v1"],
+    [
+      "https://models.example.com/llama/v1",
+      "https://models.example.com/llama",
+      "https://models.example.com/llama/v1",
+    ],
+  ])("normalizes %s", (input, origin, inferenceBaseUrl) => {
+    expect(resolveLlamaServerEndpoint(input)).toEqual({ origin, inferenceBaseUrl });
+  });
+
+  it("rejects embedded credentials", () => {
+    const endpoint = new URL("http://localhost:8080/v1");
+    endpoint.username = "user";
+    endpoint.password = "secret";
+    expect(() => resolveLlamaServerEndpoint(endpoint.toString())).toThrow(
+      "must not contain credentials",
+    );
+  });
+
+  it("rejects non-HTTP schemes", () => {
+    expect(() => resolveLlamaServerEndpoint("ftp://localhost:8080/v1")).toThrow(
+      "Unsupported llama-server protocol",
+    );
+  });
+
+  it("normalizes provider transport and private-network request policy", () => {
+    expect(
+      normalizeLlamaServerProviderConfig({
+        baseUrl: "http://localhost:8080/",
+        api: "openai-responses",
+        models: [],
+      }),
+    ).toEqual({
+      baseUrl: "http://localhost:8080/v1",
+      api: "openai-completions",
+      models: [],
+      request: { allowPrivateNetwork: true },
+    });
+  });
+});

--- a/extensions/llama-server/src/endpoint.ts
+++ b/extensions/llama-server/src/endpoint.ts
@@ -1,0 +1,54 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { LLAMA_SERVER_DEFAULT_ORIGIN } from "./defaults.js";
+
+export type LlamaServerEndpoint = {
+  origin: string;
+  inferenceBaseUrl: string;
+};
+
+function toFetchableBaseUrl(value: string): string {
+  if (/^[a-z][a-z\d+.-]*:\/\//iu.test(value)) {
+    return value;
+  }
+  return `http://${value}`;
+}
+
+/** Resolves the server origin and its OpenAI-compatible `/v1` inference base. */
+export function resolveLlamaServerEndpoint(configuredBaseUrl?: string): LlamaServerEndpoint {
+  const configured = configuredBaseUrl?.trim() || LLAMA_SERVER_DEFAULT_ORIGIN;
+  const parsed = new URL(toFetchableBaseUrl(configured));
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new TypeError(`Unsupported llama-server protocol: ${parsed.protocol}`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new TypeError("llama-server base URL must not contain credentials");
+  }
+
+  const pathname = parsed.pathname.replace(/\/+$/u, "").replace(/\/v1$/iu, "");
+  parsed.pathname = pathname || "/";
+  parsed.search = "";
+  parsed.hash = "";
+  const origin = parsed.toString().replace(/\/$/u, "");
+  return {
+    origin,
+    inferenceBaseUrl: `${origin}/v1`,
+  };
+}
+
+/** Canonicalizes persisted provider config for the shared OpenAI transport. */
+export function normalizeLlamaServerProviderConfig(
+  provider: ModelProviderConfig,
+): ModelProviderConfig {
+  const endpoint = resolveLlamaServerEndpoint(provider.baseUrl);
+  const request = provider.request ?? {};
+  const normalizedRequest =
+    typeof request.allowPrivateNetwork === "boolean"
+      ? request
+      : { ...request, allowPrivateNetwork: true };
+  return {
+    ...provider,
+    baseUrl: endpoint.inferenceBaseUrl,
+    api: "openai-completions",
+    request: normalizedRequest,
+  };
+}

--- a/extensions/llama-server/src/models.test.ts
+++ b/extensions/llama-server/src/models.test.ts
@@ -54,6 +54,22 @@ describe("llama-server model mapping", () => {
     });
   });
 
+  it("preserves image input advertised by router rows or runtime properties", () => {
+    expect(
+      mapLlamaServerModel({
+        id: "router-vision",
+        object: "model",
+        architecture: { input_modalities: ["text", "image"] },
+      })?.config.input,
+    ).toEqual(["text", "image"]);
+    expect(
+      mapLlamaServerModel(
+        { id: "server-vision", object: "model" },
+        { modalities: { vision: true } },
+      )?.config.input,
+    ).toEqual(["text", "image"]);
+  });
+
   it("defaults unknown capabilities conservatively", () => {
     expect(mapLlamaServerModel({ id: "model", object: "model" })?.config.compat).toMatchObject({
       supportsTools: false,

--- a/extensions/llama-server/src/models.test.ts
+++ b/extensions/llama-server/src/models.test.ts
@@ -44,6 +44,16 @@ describe("llama-server model mapping", () => {
     });
   });
 
+  it("uses an older server's top-level runtime context limit", () => {
+    expect(
+      mapLlamaServerModel({ id: "model", object: "model" }, { n_ctx: 8192 })?.config,
+    ).toMatchObject({
+      contextWindow: 8192,
+      contextTokens: 8192,
+      maxTokens: 8192,
+    });
+  });
+
   it("defaults unknown capabilities conservatively", () => {
     expect(mapLlamaServerModel({ id: "model", object: "model" })?.config.compat).toMatchObject({
       supportsTools: false,

--- a/extensions/llama-server/src/models.test.ts
+++ b/extensions/llama-server/src/models.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { buildLlamaServerProviderConfig, mapLlamaServerModel } from "./models.js";
+
+describe("llama-server model mapping", () => {
+  it("maps runtime context and chat-template capabilities", () => {
+    expect(
+      mapLlamaServerModel(
+        {
+          id: "ggml-org/model:Q4_K_M",
+          object: "model",
+          status: { value: "loaded" },
+        },
+        {
+          default_generation_settings: {
+            n_ctx: 65536,
+            params: { max_tokens: 4096 },
+          },
+          total_slots: 2,
+          build_info: "b10000-deadbeef",
+          chat_template_caps: {
+            supports_tools: true,
+            supports_tool_calls: true,
+            supports_typed_content: true,
+          },
+        },
+      ),
+    ).toMatchObject({
+      status: "loaded",
+      buildInfo: "b10000-deadbeef",
+      totalSlots: 2,
+      config: {
+        id: "ggml-org/model:Q4_K_M",
+        contextWindow: 65536,
+        contextTokens: 65536,
+        maxTokens: 4096,
+        compat: {
+          supportsTools: true,
+          supportsUsageInStreaming: true,
+          supportsJsonSchemaResponseFormat: true,
+          requiresStringContent: false,
+          maxTokensField: "max_tokens",
+        },
+      },
+    });
+  });
+
+  it("defaults unknown capabilities conservatively", () => {
+    expect(mapLlamaServerModel({ id: "model", object: "model" })?.config.compat).toMatchObject({
+      supportsTools: false,
+      requiresStringContent: true,
+    });
+  });
+
+  it("rejects malformed and non-model rows", () => {
+    expect(mapLlamaServerModel({ id: " " })).toBeNull();
+    expect(mapLlamaServerModel({ id: "model", object: "collection" })).toBeNull();
+  });
+
+  it("keeps explicit model rows ahead of discovered rows", () => {
+    const explicit = {
+      id: "model",
+      name: "Configured model",
+      reasoning: true,
+      input: ["text"] as Array<"text" | "image">,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32768,
+      maxTokens: 2048,
+    };
+    const discovered = mapLlamaServerModel({ id: "model", object: "model" });
+    const second = mapLlamaServerModel({ id: "other", object: "model" });
+    if (!discovered || !second) {
+      throw new Error("expected model fixtures to map");
+    }
+
+    const provider = buildLlamaServerProviderConfig({
+      configured: {
+        baseUrl: "http://localhost:8080/v1",
+        models: [explicit],
+      },
+      discoveredModels: [discovered, second],
+    });
+
+    expect(provider.models).toHaveLength(2);
+    expect(provider.models[0]).toBe(explicit);
+    expect(provider.models[1]?.id).toBe("other");
+  });
+});

--- a/extensions/llama-server/src/models.ts
+++ b/extensions/llama-server/src/models.ts
@@ -1,0 +1,191 @@
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  SELF_HOSTED_DEFAULT_CONTEXT_WINDOW,
+  SELF_HOSTED_DEFAULT_COST,
+  SELF_HOSTED_DEFAULT_MAX_TOKENS,
+} from "openclaw/plugin-sdk/provider-setup";
+import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveLlamaServerEndpoint } from "./endpoint.js";
+
+export type LlamaServerModelStatus =
+  | "unloaded"
+  | "loading"
+  | "loaded"
+  | "sleeping"
+  | "downloading"
+  | "unknown";
+
+export type LlamaServerModelWire = {
+  id?: unknown;
+  object?: unknown;
+  owned_by?: unknown;
+  status?: {
+    value?: unknown;
+    failed?: unknown;
+    exit_code?: unknown;
+  };
+  architecture?: {
+    input_modalities?: unknown;
+    output_modalities?: unknown;
+  };
+  meta?: {
+    n_ctx_train?: unknown;
+  } | null;
+};
+
+export type LlamaServerPropsWire = {
+  default_generation_settings?: {
+    n_ctx?: unknown;
+    params?: {
+      max_tokens?: unknown;
+      n_predict?: unknown;
+    };
+  };
+  total_slots?: unknown;
+  chat_template_caps?: Record<string, unknown>;
+  modalities?: Record<string, unknown>;
+  build_info?: unknown;
+  is_sleeping?: unknown;
+};
+
+export type LlamaServerDiscoveredModel = {
+  config: ModelDefinitionConfig;
+  status: LlamaServerModelStatus;
+  failed: boolean;
+  exitCode?: number;
+  buildInfo?: string;
+  totalSlots?: number;
+};
+
+function readBoolean(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): boolean | undefined {
+  const value = record?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function normalizeStatus(value: unknown): LlamaServerModelStatus {
+  switch (value) {
+    case "unloaded":
+    case "loading":
+    case "loaded":
+    case "sleeping":
+    case "downloading":
+      return value;
+    default:
+      return "unknown";
+  }
+}
+
+function resolveContextWindow(props: LlamaServerPropsWire | undefined): number {
+  return (
+    asPositiveSafeInteger(props?.default_generation_settings?.n_ctx) ??
+    SELF_HOSTED_DEFAULT_CONTEXT_WINDOW
+  );
+}
+
+function resolveMaxTokens(props: LlamaServerPropsWire | undefined, contextWindow: number): number {
+  const params = props?.default_generation_settings?.params;
+  const advertised =
+    asPositiveSafeInteger(params?.max_tokens) ?? asPositiveSafeInteger(params?.n_predict);
+  return Math.min(advertised ?? SELF_HOSTED_DEFAULT_MAX_TOKENS, contextWindow);
+}
+
+function buildCompat(
+  props: LlamaServerPropsWire | undefined,
+): NonNullable<ModelDefinitionConfig["compat"]> {
+  const caps = props?.chat_template_caps;
+  const supportsTools =
+    readBoolean(caps, "supports_tools") === true &&
+    readBoolean(caps, "supports_tool_calls") === true;
+  const supportsTypedContent = readBoolean(caps, "supports_typed_content") === true;
+  return {
+    supportsStore: false,
+    supportsDeveloperRole: false,
+    supportsReasoningEffort: false,
+    supportsTemperature: true,
+    supportsUsageInStreaming: true,
+    supportsTools,
+    supportsStrictMode: false,
+    supportsJsonSchemaResponseFormat: true,
+    requiresStringContent: !supportsTypedContent,
+    maxTokensField: "max_tokens",
+  };
+}
+
+/** Maps one llama-server model row plus optional runtime properties into OpenClaw config. */
+export function mapLlamaServerModel(
+  row: LlamaServerModelWire,
+  props?: LlamaServerPropsWire,
+): LlamaServerDiscoveredModel | null {
+  const id = typeof row.id === "string" ? row.id.trim() : "";
+  if (!id || (row.object !== undefined && row.object !== "model")) {
+    return null;
+  }
+  const contextWindow = resolveContextWindow(props);
+  const buildInfo = typeof props?.build_info === "string" ? props.build_info.trim() : "";
+  const exitCode = asPositiveSafeInteger(row.status?.exit_code);
+  return {
+    config: {
+      id,
+      name: id,
+      reasoning: false,
+      input: ["text"],
+      cost: { ...SELF_HOSTED_DEFAULT_COST },
+      contextWindow,
+      contextTokens: contextWindow,
+      maxTokens: resolveMaxTokens(props, contextWindow),
+      compat: buildCompat(props),
+    },
+    status: normalizeStatus(row.status?.value),
+    failed: row.status?.failed === true,
+    ...(exitCode !== undefined ? { exitCode } : {}),
+    ...(buildInfo ? { buildInfo } : {}),
+    ...(asPositiveSafeInteger(props?.total_slots) !== undefined
+      ? { totalSlots: asPositiveSafeInteger(props?.total_slots) }
+      : {}),
+  };
+}
+
+/** Keeps explicit rows first and appends models discovered from the server. */
+export function mergeLlamaServerModels(params: {
+  explicitModels?: ModelDefinitionConfig[];
+  discoveredModels: readonly LlamaServerDiscoveredModel[];
+}): ModelDefinitionConfig[] {
+  const explicit = Array.isArray(params.explicitModels) ? params.explicitModels : [];
+  const merged = [...explicit];
+  const seen = new Set(explicit.map((model) => model.id));
+  for (const discovered of params.discoveredModels) {
+    if (seen.has(discovered.config.id)) {
+      continue;
+    }
+    seen.add(discovered.config.id);
+    merged.push(discovered.config);
+  }
+  return merged;
+}
+
+export function buildLlamaServerProviderConfig(params: {
+  configured?: ModelProviderConfig;
+  discoveredModels: readonly LlamaServerDiscoveredModel[];
+}): ModelProviderConfig {
+  const endpoint = resolveLlamaServerEndpoint(params.configured?.baseUrl);
+  const request = params.configured?.request ?? {};
+  return {
+    ...params.configured,
+    baseUrl: endpoint.inferenceBaseUrl,
+    api: "openai-completions",
+    request:
+      typeof request.allowPrivateNetwork === "boolean"
+        ? request
+        : { ...request, allowPrivateNetwork: true },
+    models: mergeLlamaServerModels({
+      explicitModels: params.configured?.models,
+      discoveredModels: params.discoveredModels,
+    }),
+  };
+}

--- a/extensions/llama-server/src/models.ts
+++ b/extensions/llama-server/src/models.ts
@@ -97,6 +97,17 @@ function resolveMaxTokens(props: LlamaServerPropsWire | undefined, contextWindow
   return Math.min(advertised ?? SELF_HOSTED_DEFAULT_MAX_TOKENS, contextWindow);
 }
 
+function resolveInput(
+  row: LlamaServerModelWire,
+  props: LlamaServerPropsWire | undefined,
+): Array<"text" | "image"> {
+  const advertised = row.architecture?.input_modalities;
+  const supportsImage =
+    (Array.isArray(advertised) && advertised.includes("image")) ||
+    props?.modalities?.vision === true;
+  return supportsImage ? ["text", "image"] : ["text"];
+}
+
 function buildCompat(
   props: LlamaServerPropsWire | undefined,
 ): NonNullable<ModelDefinitionConfig["compat"]> {
@@ -136,7 +147,7 @@ export function mapLlamaServerModel(
       id,
       name: id,
       reasoning: false,
-      input: ["text"],
+      input: resolveInput(row, props),
       cost: { ...SELF_HOSTED_DEFAULT_COST },
       contextWindow,
       contextTokens: contextWindow,

--- a/extensions/llama-server/src/models.ts
+++ b/extensions/llama-server/src/models.ts
@@ -37,6 +37,7 @@ export type LlamaServerModelWire = {
 };
 
 export type LlamaServerPropsWire = {
+  n_ctx?: unknown;
   default_generation_settings?: {
     n_ctx?: unknown;
     params?: {
@@ -84,6 +85,7 @@ function normalizeStatus(value: unknown): LlamaServerModelStatus {
 function resolveContextWindow(props: LlamaServerPropsWire | undefined): number {
   return (
     asPositiveSafeInteger(props?.default_generation_settings?.n_ctx) ??
+    asPositiveSafeInteger(props?.n_ctx) ??
     SELF_HOSTED_DEFAULT_CONTEXT_WINDOW
   );
 }

--- a/extensions/llama-server/src/provider.test.ts
+++ b/extensions/llama-server/src/provider.test.ts
@@ -1,0 +1,161 @@
+import type {
+  ProviderCatalogContext,
+  ProviderPrepareDynamicModelContext,
+  UnifiedModelCatalogProviderContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearLlamaServerDynamicModelsForTests,
+  discoverLlamaServerProvider,
+  listLlamaServerCatalog,
+  prepareLlamaServerDynamicModels,
+  resolveLlamaServerDynamicModel,
+} from "./provider.js";
+
+const discoverMock = vi.hoisted(() => vi.fn());
+const runtimeApiKeyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./discovery.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./discovery.js")>()),
+  discoverLlamaServer: discoverMock,
+}));
+
+vi.mock("./auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./auth.js")>()),
+  resolveLlamaServerRuntimeApiKey: runtimeApiKeyMock,
+}));
+
+function model() {
+  return {
+    config: {
+      id: "org/model:Q4",
+      name: "org/model:Q4",
+      reasoning: false,
+      input: ["text" as const],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 16384,
+      contextTokens: 16384,
+      maxTokens: 4096,
+      compat: { supportsTools: true },
+    },
+    status: "sleeping" as const,
+    failed: false,
+    buildInfo: "b10000-test",
+    totalSlots: 2,
+  };
+}
+
+function success() {
+  return {
+    kind: "success" as const,
+    endpoint: {
+      origin: "http://localhost:8080",
+      inferenceBaseUrl: "http://localhost:8080/v1",
+    },
+    health: "ready" as const,
+    models: [model()],
+    fetchedAt: 1000,
+  };
+}
+
+function catalogContext(): ProviderCatalogContext {
+  return {
+    config: {},
+    env: {},
+    resolveProviderApiKey: vi.fn(() => ({ apiKey: undefined })),
+    resolveProviderAuth: vi.fn(() => ({
+      apiKey: undefined,
+      mode: "none" as const,
+      source: "none" as const,
+    })),
+  };
+}
+
+describe("llama-server provider catalog", () => {
+  beforeEach(() => {
+    discoverMock.mockReset();
+    runtimeApiKeyMock.mockReset();
+    runtimeApiKeyMock.mockResolvedValue(undefined);
+    clearLlamaServerDynamicModelsForTests();
+  });
+
+  it("builds the legacy runtime provider from live discovery", async () => {
+    discoverMock.mockResolvedValue(success());
+
+    await expect(discoverLlamaServerProvider(catalogContext())).resolves.toMatchObject({
+      provider: {
+        baseUrl: "http://localhost:8080/v1",
+        api: "openai-completions",
+        models: [expect.objectContaining({ id: "org/model:Q4" })],
+      },
+    });
+  });
+
+  it("preserves explicit models when the server is unavailable", async () => {
+    discoverMock.mockResolvedValue({
+      kind: "unreachable",
+      endpoint: { origin: "http://localhost:8080", inferenceBaseUrl: "http://localhost:8080/v1" },
+      error: new Error("offline"),
+    });
+    const ctx = catalogContext();
+    ctx.config.models = {
+      providers: {
+        "llama-server": {
+          baseUrl: "http://localhost:8080/v1",
+          models: [model().config],
+        },
+      },
+    };
+
+    await expect(discoverLlamaServerProvider(ctx)).resolves.toMatchObject({
+      provider: { models: [expect.objectContaining({ id: "org/model:Q4" })] },
+    });
+  });
+
+  it("projects router state into unified catalog warnings", async () => {
+    discoverMock.mockResolvedValue(success());
+    const ctx = {
+      ...catalogContext(),
+      includeLive: true,
+    } as UnifiedModelCatalogProviderContext;
+
+    await expect(listLlamaServerCatalog(ctx)).resolves.toEqual([
+      expect.objectContaining({
+        kind: "text",
+        provider: "llama-server",
+        model: "org/model:Q4",
+        source: "live",
+        warnings: ["llama-server model is sleeping"],
+        capabilities: expect.objectContaining({
+          contextWindow: 16384,
+          status: "sleeping",
+          buildInfo: "b10000-test",
+          totalSlots: 2,
+        }),
+      }),
+    ]);
+  });
+
+  it("refreshes and resolves dynamic model ids containing slashes", async () => {
+    discoverMock.mockResolvedValue(success());
+    const ctx = {
+      config: {},
+      provider: "llama-server",
+      modelId: "org/model:Q4",
+      modelRegistry: {},
+      providerConfig: {
+        baseUrl: "http://localhost:8080/v1",
+        api: "openai-completions",
+      },
+    } as unknown as ProviderPrepareDynamicModelContext;
+
+    await prepareLlamaServerDynamicModels(ctx);
+
+    expect(resolveLlamaServerDynamicModel(ctx)).toMatchObject({
+      provider: "llama-server",
+      id: "org/model:Q4",
+      baseUrl: "http://localhost:8080/v1",
+      api: "openai-completions",
+    });
+  });
+});

--- a/extensions/llama-server/src/provider.test.ts
+++ b/extensions/llama-server/src/provider.test.ts
@@ -136,6 +136,46 @@ describe("llama-server provider catalog", () => {
     ]);
   });
 
+  it("scopes dynamic catalogs by agent runtime and auth profile", async () => {
+    const first = success();
+    const second = {
+      ...success(),
+      models: [
+        {
+          ...model(),
+          config: { ...model().config, name: "second scope" },
+        },
+      ],
+    };
+    discoverMock.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    const base = {
+      config: {},
+      provider: "llama-server",
+      modelId: "org/model:Q4",
+      modelRegistry: {},
+      providerConfig: {
+        baseUrl: "http://localhost:8080/v1",
+        api: "openai-completions",
+      },
+    };
+    const firstCtx = {
+      ...base,
+      agentRuntimeId: "runtime-one",
+      authProfileId: "profile-one",
+    } as unknown as ProviderPrepareDynamicModelContext;
+    const secondCtx = {
+      ...base,
+      agentRuntimeId: "runtime-two",
+      authProfileId: "profile-two",
+    } as unknown as ProviderPrepareDynamicModelContext;
+
+    await prepareLlamaServerDynamicModels(firstCtx);
+    await prepareLlamaServerDynamicModels(secondCtx);
+
+    expect(resolveLlamaServerDynamicModel(firstCtx)?.name).toBe("org/model:Q4");
+    expect(resolveLlamaServerDynamicModel(secondCtx)?.name).toBe("second scope");
+  });
+
   it("refreshes and resolves dynamic model ids containing slashes", async () => {
     discoverMock.mockResolvedValue(success());
     const ctx = {

--- a/extensions/llama-server/src/provider.test.ts
+++ b/extensions/llama-server/src/provider.test.ts
@@ -91,6 +91,33 @@ describe("llama-server provider catalog", () => {
     });
   });
 
+  it("prefers configured Authorization over ambient API-key discovery auth", async () => {
+    discoverMock.mockResolvedValue(success());
+    const ctx = catalogContext();
+    ctx.config.models = {
+      providers: {
+        "llama-server": {
+          baseUrl: "http://localhost:8080/v1",
+          headers: { Authorization: "Bearer proxy-key" },
+          models: [],
+        },
+      },
+    };
+    ctx.resolveProviderApiKey = vi.fn(() => ({
+      apiKey: "LLAMA_SERVER_API_KEY",
+      discoveryApiKey: "ambient-key",
+    }));
+
+    await discoverLlamaServerProvider(ctx);
+
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: undefined,
+        headers: { Authorization: "Bearer proxy-key" },
+      }),
+    );
+  });
+
   it("preserves explicit models when the server is unavailable", async () => {
     discoverMock.mockResolvedValue({
       kind: "unreachable",

--- a/extensions/llama-server/src/provider.test.ts
+++ b/extensions/llama-server/src/provider.test.ts
@@ -211,6 +211,34 @@ describe("llama-server provider catalog", () => {
     expect(resolveLlamaServerDynamicModel(secondCtx)?.name).toBe("second scope");
   });
 
+  it("bounds dynamic model snapshots by scope", async () => {
+    discoverMock.mockResolvedValue(success());
+    const contexts = Array.from(
+      { length: 101 },
+      (_, index) =>
+        ({
+          config: {},
+          provider: "llama-server",
+          modelId: "org/model:Q4",
+          modelRegistry: {},
+          agentRuntimeId: `runtime-${index}`,
+          providerConfig: {
+            baseUrl: "http://localhost:8080/v1",
+            api: "openai-completions",
+          },
+        }) as unknown as ProviderPrepareDynamicModelContext,
+    );
+
+    for (const ctx of contexts) {
+      await prepareLlamaServerDynamicModels(ctx);
+    }
+
+    expect(resolveLlamaServerDynamicModel(contexts[0]!)).toBeUndefined();
+    expect(resolveLlamaServerDynamicModel(contexts.at(-1)!)).toMatchObject({
+      id: "org/model:Q4",
+    });
+  });
+
   it("refreshes and resolves dynamic model ids containing slashes", async () => {
     discoverMock.mockResolvedValue(success());
     const ctx = {

--- a/extensions/llama-server/src/provider.test.ts
+++ b/extensions/llama-server/src/provider.test.ts
@@ -172,6 +172,14 @@ describe("llama-server provider catalog", () => {
     await prepareLlamaServerDynamicModels(firstCtx);
     await prepareLlamaServerDynamicModels(secondCtx);
 
+    expect(runtimeApiKeyMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ profileId: "profile-one" }),
+    );
+    expect(runtimeApiKeyMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ profileId: "profile-two" }),
+    );
     expect(resolveLlamaServerDynamicModel(firstCtx)?.name).toBe("org/model:Q4");
     expect(resolveLlamaServerDynamicModel(secondCtx)?.name).toBe("second scope");
   });

--- a/extensions/llama-server/src/provider.ts
+++ b/extensions/llama-server/src/provider.ts
@@ -1,18 +1,32 @@
 import type {
   ProviderCatalogContext,
   ProviderPrepareDynamicModelContext,
+  ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
   UnifiedModelCatalogEntry,
   UnifiedModelCatalogProviderContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
-import { resolveLlamaServerRuntimeApiKey } from "./auth.js";
+import { resolveLlamaServerProviderHeaders, resolveLlamaServerRuntimeApiKey } from "./auth.js";
 import { LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
 import { discoverLlamaServer, type LlamaServerDiscoveryResult } from "./discovery.js";
 import { resolveLlamaServerEndpoint } from "./endpoint.js";
 import { buildLlamaServerProviderConfig, type LlamaServerDiscoveredModel } from "./models.js";
 
 const dynamicModels = new Map<string, ProviderRuntimeModel[]>();
+
+function dynamicModelScopeKey(
+  ctx: Pick<
+    ProviderResolveDynamicModelContext,
+    "agentRuntimeId" | "agentDir" | "authProfileId" | "providerConfig"
+  >,
+): string {
+  return [
+    ctx.agentRuntimeId ?? ctx.agentDir ?? "",
+    ctx.authProfileId ?? "",
+    ctx.providerConfig?.baseUrl ?? "",
+  ].join("\u0000");
+}
 
 function toRuntimeModel(
   model: LlamaServerDiscoveredModel,
@@ -74,9 +88,15 @@ async function discoverFromCatalogContext(
 ): Promise<LlamaServerDiscoveryResult> {
   const providerConfig = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
   const auth = ctx.resolveProviderApiKey(LLAMA_SERVER_PROVIDER_ID);
+  const headers = await resolveLlamaServerProviderHeaders({
+    config: ctx.config,
+    env: ctx.env,
+    headers: providerConfig?.headers,
+  });
   return await discoverLlamaServer({
     baseUrl: providerConfig?.baseUrl,
     apiKey: auth.discoveryApiKey ?? auth.apiKey,
+    headers,
     signal: "signal" in ctx ? ctx.signal : undefined,
     timeoutMs: "timeoutMs" in ctx ? ctx.timeoutMs : undefined,
   });
@@ -130,12 +150,18 @@ export async function prepareLlamaServerDynamicModels(
     config: ctx.config,
     agentDir: ctx.agentDir,
   });
+  const headers = await resolveLlamaServerProviderHeaders({
+    config: ctx.config,
+    env: process.env,
+    headers: ctx.providerConfig?.headers,
+  });
   const discovery = await discoverLlamaServer({
     baseUrl: ctx.providerConfig?.baseUrl,
     apiKey,
+    headers,
     cacheTtlMs: 0,
   });
-  const key = ctx.providerConfig?.baseUrl ?? "";
+  const key = dynamicModelScopeKey(ctx);
   dynamicModels.set(
     key,
     discovery.kind === "success"
@@ -144,12 +170,11 @@ export async function prepareLlamaServerDynamicModels(
   );
 }
 
-export function resolveLlamaServerDynamicModel(params: {
-  modelId: string;
-  providerConfig?: { baseUrl?: string };
-}): ProviderRuntimeModel | undefined {
+export function resolveLlamaServerDynamicModel(
+  params: ProviderResolveDynamicModelContext,
+): ProviderRuntimeModel | undefined {
   return dynamicModels
-    .get(params.providerConfig?.baseUrl ?? "")
+    .get(dynamicModelScopeKey(params))
     ?.find((model) => model.id === params.modelId);
 }
 

--- a/extensions/llama-server/src/provider.ts
+++ b/extensions/llama-server/src/provider.ts
@@ -1,0 +1,158 @@
+import type {
+  ProviderCatalogContext,
+  ProviderPrepareDynamicModelContext,
+  ProviderRuntimeModel,
+  UnifiedModelCatalogEntry,
+  UnifiedModelCatalogProviderContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { resolveLlamaServerRuntimeApiKey } from "./auth.js";
+import { LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
+import { discoverLlamaServer, type LlamaServerDiscoveryResult } from "./discovery.js";
+import { resolveLlamaServerEndpoint } from "./endpoint.js";
+import { buildLlamaServerProviderConfig, type LlamaServerDiscoveredModel } from "./models.js";
+
+const dynamicModels = new Map<string, ProviderRuntimeModel[]>();
+
+function toRuntimeModel(
+  model: LlamaServerDiscoveredModel,
+  providerConfig: {
+    baseUrl?: string;
+    api?: ProviderRuntimeModel["api"];
+  },
+): ProviderRuntimeModel {
+  return {
+    ...model.config,
+    provider: LLAMA_SERVER_PROVIDER_ID,
+    api: providerConfig.api ?? "openai-completions",
+    baseUrl: resolveLlamaServerEndpoint(providerConfig.baseUrl).inferenceBaseUrl,
+    input: model.config.input.filter(
+      (entry): entry is "text" | "image" => entry === "text" || entry === "image",
+    ),
+  };
+}
+
+function statusWarning(model: LlamaServerDiscoveredModel): string | undefined {
+  if (model.failed) {
+    return model.exitCode
+      ? `llama-server model process failed with exit code ${model.exitCode}`
+      : "llama-server model process failed";
+  }
+  return model.status === "loaded" || model.status === "unknown"
+    ? undefined
+    : `llama-server model is ${model.status}`;
+}
+
+function toUnifiedCatalogEntry(
+  model: LlamaServerDiscoveredModel,
+  fetchedAt: number,
+): UnifiedModelCatalogEntry {
+  const warning = statusWarning(model);
+  return {
+    kind: "text",
+    provider: LLAMA_SERVER_PROVIDER_ID,
+    model: model.config.id,
+    label: model.config.name,
+    source: "live",
+    fetchedAt,
+    capabilities: {
+      input: model.config.input,
+      reasoning: model.config.reasoning,
+      contextWindow: model.config.contextWindow,
+      contextTokens: model.config.contextTokens,
+      maxTokens: model.config.maxTokens,
+      status: model.status,
+      buildInfo: model.buildInfo,
+      totalSlots: model.totalSlots,
+    },
+    ...(warning ? { warnings: [warning] } : {}),
+  };
+}
+
+async function discoverFromCatalogContext(
+  ctx: ProviderCatalogContext | UnifiedModelCatalogProviderContext,
+): Promise<LlamaServerDiscoveryResult> {
+  const providerConfig = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const auth = ctx.resolveProviderApiKey(LLAMA_SERVER_PROVIDER_ID);
+  return await discoverLlamaServer({
+    baseUrl: providerConfig?.baseUrl,
+    apiKey: auth.discoveryApiKey ?? auth.apiKey,
+    signal: "signal" in ctx ? ctx.signal : undefined,
+    timeoutMs: "timeoutMs" in ctx ? ctx.timeoutMs : undefined,
+  });
+}
+
+/** Legacy text runtime catalog until the unified loader owns model resolution. */
+export async function discoverLlamaServerProvider(
+  ctx: ProviderCatalogContext,
+): Promise<{ provider: ModelProviderConfig } | null> {
+  const configured = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const discovery = await discoverFromCatalogContext(ctx);
+  if (discovery.kind !== "success") {
+    return configured
+      ? {
+          provider: buildLlamaServerProviderConfig({
+            configured,
+            discoveredModels: [],
+          }),
+        }
+      : null;
+  }
+  return {
+    provider: buildLlamaServerProviderConfig({
+      configured: {
+        ...configured,
+        baseUrl: discovery.endpoint.inferenceBaseUrl,
+        models: configured?.models ?? [],
+      },
+      discoveredModels: discovery.models,
+    }),
+  };
+}
+
+/** Live rows for model pickers and other unified catalog consumers. */
+export async function listLlamaServerCatalog(
+  ctx: UnifiedModelCatalogProviderContext,
+): Promise<UnifiedModelCatalogEntry[]> {
+  if (ctx.includeLive === false) {
+    return [];
+  }
+  const discovery = await discoverFromCatalogContext(ctx);
+  return discovery.kind === "success"
+    ? discovery.models.map((model) => toUnifiedCatalogEntry(model, discovery.fetchedAt))
+    : [];
+}
+
+export async function prepareLlamaServerDynamicModels(
+  ctx: ProviderPrepareDynamicModelContext,
+): Promise<void> {
+  const apiKey = await resolveLlamaServerRuntimeApiKey({
+    config: ctx.config,
+    agentDir: ctx.agentDir,
+  });
+  const discovery = await discoverLlamaServer({
+    baseUrl: ctx.providerConfig?.baseUrl,
+    apiKey,
+    cacheTtlMs: 0,
+  });
+  const key = ctx.providerConfig?.baseUrl ?? "";
+  dynamicModels.set(
+    key,
+    discovery.kind === "success"
+      ? discovery.models.map((model) => toRuntimeModel(model, ctx.providerConfig ?? {}))
+      : [],
+  );
+}
+
+export function resolveLlamaServerDynamicModel(params: {
+  modelId: string;
+  providerConfig?: { baseUrl?: string };
+}): ProviderRuntimeModel | undefined {
+  return dynamicModels
+    .get(params.providerConfig?.baseUrl ?? "")
+    ?.find((model) => model.id === params.modelId);
+}
+
+export function clearLlamaServerDynamicModelsForTests(): void {
+  dynamicModels.clear();
+}

--- a/extensions/llama-server/src/provider.ts
+++ b/extensions/llama-server/src/provider.ts
@@ -7,7 +7,11 @@ import type {
   UnifiedModelCatalogProviderContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
-import { resolveLlamaServerProviderHeaders, resolveLlamaServerRuntimeApiKey } from "./auth.js";
+import {
+  hasLlamaServerAuthorizationHeader,
+  resolveLlamaServerProviderHeaders,
+  resolveLlamaServerRuntimeApiKey,
+} from "./auth.js";
 import { LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
 import { discoverLlamaServer, type LlamaServerDiscoveryResult } from "./discovery.js";
 import { resolveLlamaServerEndpoint } from "./endpoint.js";
@@ -95,7 +99,9 @@ async function discoverFromCatalogContext(
   });
   return await discoverLlamaServer({
     baseUrl: providerConfig?.baseUrl,
-    apiKey: auth.discoveryApiKey ?? auth.apiKey,
+    apiKey: hasLlamaServerAuthorizationHeader(headers)
+      ? undefined
+      : (auth.discoveryApiKey ?? auth.apiKey),
     headers,
     signal: "signal" in ctx ? ctx.signal : undefined,
     timeoutMs: "timeoutMs" in ctx ? ctx.timeoutMs : undefined,
@@ -158,7 +164,7 @@ export async function prepareLlamaServerDynamicModels(
   });
   const discovery = await discoverLlamaServer({
     baseUrl: ctx.providerConfig?.baseUrl,
-    apiKey,
+    apiKey: hasLlamaServerAuthorizationHeader(headers) ? undefined : apiKey,
     headers,
     cacheTtlMs: 0,
   });

--- a/extensions/llama-server/src/provider.ts
+++ b/extensions/llama-server/src/provider.ts
@@ -18,6 +18,19 @@ import { resolveLlamaServerEndpoint } from "./endpoint.js";
 import { buildLlamaServerProviderConfig, type LlamaServerDiscoveredModel } from "./models.js";
 
 const dynamicModels = new Map<string, ProviderRuntimeModel[]>();
+const LLAMA_SERVER_DYNAMIC_MODEL_MAX_SCOPES = 100;
+
+function cacheDynamicModels(key: string, models: ProviderRuntimeModel[]): void {
+  dynamicModels.delete(key);
+  dynamicModels.set(key, models);
+  while (dynamicModels.size > LLAMA_SERVER_DYNAMIC_MODEL_MAX_SCOPES) {
+    const oldest = dynamicModels.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    dynamicModels.delete(oldest.value);
+  }
+}
 
 function dynamicModelScopeKey(
   ctx: Pick<
@@ -169,7 +182,7 @@ export async function prepareLlamaServerDynamicModels(
     cacheTtlMs: 0,
   });
   const key = dynamicModelScopeKey(ctx);
-  dynamicModels.set(
+  cacheDynamicModels(
     key,
     discovery.kind === "success"
       ? discovery.models.map((model) => toRuntimeModel(model, ctx.providerConfig ?? {}))

--- a/extensions/llama-server/src/provider.ts
+++ b/extensions/llama-server/src/provider.ts
@@ -149,6 +149,7 @@ export async function prepareLlamaServerDynamicModels(
   const apiKey = await resolveLlamaServerRuntimeApiKey({
     config: ctx.config,
     agentDir: ctx.agentDir,
+    profileId: ctx.authProfileId,
   });
   const headers = await resolveLlamaServerProviderHeaders({
     config: ctx.config,

--- a/extensions/llama-server/src/setup.test.ts
+++ b/extensions/llama-server/src/setup.test.ts
@@ -14,6 +14,12 @@ import {
 
 const discoverMock = vi.hoisted(() => vi.fn());
 const runtimeApiKeyMock = vi.hoisted(() => vi.fn());
+const removeProviderAuthProfilesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>()),
+  removeProviderAuthProfilesWithLock: removeProviderAuthProfilesMock,
+}));
 
 vi.mock("./discovery.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./discovery.js")>()),
@@ -80,6 +86,8 @@ describe("llama-server setup", () => {
     discoverMock.mockReset();
     runtimeApiKeyMock.mockReset();
     runtimeApiKeyMock.mockResolvedValue(undefined);
+    removeProviderAuthProfilesMock.mockReset();
+    removeProviderAuthProfilesMock.mockResolvedValue({ version: 1, profiles: {} });
   });
 
   it("detects a running local server without writing config", async () => {
@@ -161,7 +169,14 @@ describe("llama-server setup", () => {
       confirm: vi.fn(async () => false),
     };
     const result = await runLlamaServerSetup({
-      config: {},
+      config: {
+        auth: {
+          profiles: {
+            "llama-server:default": { provider: "llama-server", mode: "api_key" },
+          },
+          order: { "llama-server": ["llama-server:default"] },
+        },
+      },
       env: {},
       prompter,
       runtime: runtime(),
@@ -175,6 +190,14 @@ describe("llama-server setup", () => {
       result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.apiKey,
     ).toBeUndefined();
     expect(result.defaultModel).toBe("llama-server/qwen/model:Q4_K_M");
+    expect(removeProviderAuthProfilesMock).toHaveBeenCalledWith({
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      agentDir: undefined,
+    });
+    expect(result.configPatch?.auth).toEqual({
+      profiles: { "llama-server:default": undefined },
+      order: { "llama-server": undefined },
+    });
   });
 
   it("returns an API-key profile when the operator enables auth", async () => {
@@ -228,6 +251,14 @@ describe("llama-server setup", () => {
   it("validates and configures non-interactively without requiring an API key", async () => {
     discoverMock.mockResolvedValue(successfulDiscovery());
     const ctx = nonInteractiveContext({ customBaseUrl: "http://localhost:8080/v1" });
+    ctx.config = {
+      auth: {
+        profiles: {
+          "llama-server:default": { provider: "llama-server", mode: "api_key" },
+        },
+        order: { "llama-server": ["llama-server:default"] },
+      },
+    };
 
     await expect(validateLlamaServerNonInteractive(ctx)).resolves.toBe(true);
     const configured = await configureLlamaServerNonInteractive(ctx);
@@ -242,6 +273,11 @@ describe("llama-server setup", () => {
     expect(configured?.agents?.defaults?.model).toEqual(
       expect.objectContaining({ primary: "llama-server/qwen/model:Q4_K_M" }),
     );
+    expect(removeProviderAuthProfilesMock).toHaveBeenCalledWith({
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      agentDir: undefined,
+    });
+    expect(configured?.auth).toEqual({ profiles: {}, order: undefined });
   });
 
   it("removes stale Authorization when non-interactive setup selects an API key", async () => {

--- a/extensions/llama-server/src/setup.test.ts
+++ b/extensions/llama-server/src/setup.test.ts
@@ -14,11 +14,11 @@ import {
 
 const discoverMock = vi.hoisted(() => vi.fn());
 const runtimeApiKeyMock = vi.hoisted(() => vi.fn());
-const removeProviderAuthProfilesMock = vi.hoisted(() => vi.fn());
+const removeAuthProfilesMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>()),
-  removeProviderAuthProfilesWithLock: removeProviderAuthProfilesMock,
+  removeAuthProfilesWithLock: removeAuthProfilesMock,
 }));
 
 vi.mock("./discovery.js", async (importOriginal) => ({
@@ -86,8 +86,8 @@ describe("llama-server setup", () => {
     discoverMock.mockReset();
     runtimeApiKeyMock.mockReset();
     runtimeApiKeyMock.mockResolvedValue(undefined);
-    removeProviderAuthProfilesMock.mockReset();
-    removeProviderAuthProfilesMock.mockResolvedValue({ version: 1, profiles: {} });
+    removeAuthProfilesMock.mockReset();
+    removeAuthProfilesMock.mockResolvedValue({ version: 1, profiles: {} });
   });
 
   it("detects a running local server without writing config", async () => {
@@ -173,8 +173,9 @@ describe("llama-server setup", () => {
         auth: {
           profiles: {
             "llama-server:default": { provider: "llama-server", mode: "api_key" },
+            "llama-server:custom": { provider: "llama-server", mode: "api_key" },
           },
-          order: { "llama-server": ["llama-server:default"] },
+          order: { "llama-server": ["llama-server:default", "llama-server:custom"] },
         },
       },
       env: {},
@@ -190,13 +191,13 @@ describe("llama-server setup", () => {
       result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.apiKey,
     ).toBeUndefined();
     expect(result.defaultModel).toBe("llama-server/qwen/model:Q4_K_M");
-    expect(removeProviderAuthProfilesMock).toHaveBeenCalledWith({
-      provider: LLAMA_SERVER_PROVIDER_ID,
+    expect(removeAuthProfilesMock).toHaveBeenCalledWith({
+      profileIds: ["llama-server:default"],
       agentDir: undefined,
     });
     expect(result.configPatch?.auth).toEqual({
       profiles: { "llama-server:default": undefined },
-      order: { "llama-server": undefined },
+      order: { "llama-server": ["llama-server:custom"] },
     });
   });
 
@@ -314,8 +315,8 @@ describe("llama-server setup", () => {
     expect(configured?.agents?.defaults?.model).toEqual(
       expect.objectContaining({ primary: "llama-server/qwen/model:Q4_K_M" }),
     );
-    expect(removeProviderAuthProfilesMock).toHaveBeenCalledWith({
-      provider: LLAMA_SERVER_PROVIDER_ID,
+    expect(removeAuthProfilesMock).toHaveBeenCalledWith({
+      profileIds: ["llama-server:default"],
       agentDir: undefined,
     });
     expect(configured?.auth).toEqual({ profiles: {}, order: undefined });

--- a/extensions/llama-server/src/setup.test.ts
+++ b/extensions/llama-server/src/setup.test.ts
@@ -200,6 +200,47 @@ describe("llama-server setup", () => {
     });
   });
 
+  it("does not send stored credentials to a replacement endpoint", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    runtimeApiKeyMock.mockResolvedValue("stored-profile-key");
+    const prompter = {
+      text: vi.fn(async () => "http://replacement.example:8080"),
+      confirm: vi.fn(async () => false),
+    };
+    const result = await runLlamaServerSetup({
+      config: {
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              apiKey: "stored-provider-key",
+              headers: { Authorization: "Bearer stored-header-key", "X-Tenant": "one" },
+              models: [],
+            },
+          },
+        },
+      },
+      env: { LLAMA_SERVER_API_KEY: "ambient-key" },
+      prompter,
+      runtime: runtime(),
+      isRemote: false,
+      openUrl: vi.fn(),
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as unknown as ProviderAuthContext);
+
+    expect(runtimeApiKeyMock).not.toHaveBeenCalled();
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "http://replacement.example:8080/v1",
+        apiKey: undefined,
+        headers: undefined,
+      }),
+    );
+    const provider = result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+    expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.headers).toBeUndefined();
+  });
+
   it("returns an API-key profile when the operator enables auth", async () => {
     discoverMock.mockResolvedValue(successfulDiscovery());
     const prompter = {
@@ -278,6 +319,37 @@ describe("llama-server setup", () => {
       agentDir: undefined,
     });
     expect(configured?.auth).toEqual({ profiles: {}, order: undefined });
+  });
+
+  it("does not reuse ambient or configured credentials for a replacement endpoint non-interactively", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const ctx = nonInteractiveContext({ customBaseUrl: "http://replacement.example:8080/v1" });
+    ctx.config = {
+      models: {
+        providers: {
+          "llama-server": {
+            baseUrl: "http://localhost:8080/v1",
+            apiKey: "stored-provider-key",
+            headers: { Authorization: "Bearer stored-header-key" },
+            models: [],
+          },
+        },
+      },
+    };
+    ctx.resolveApiKey = vi.fn(async () => ({ key: "ambient-key", source: "env" as const }));
+
+    const configured = await configureLlamaServerNonInteractive(ctx);
+
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "http://replacement.example:8080/v1",
+        apiKey: undefined,
+        headers: undefined,
+      }),
+    );
+    const provider = configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+    expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.headers).toBeUndefined();
   });
 
   it("removes stale Authorization when non-interactive setup selects an API key", async () => {

--- a/extensions/llama-server/src/setup.test.ts
+++ b/extensions/llama-server/src/setup.test.ts
@@ -14,11 +14,11 @@ import {
 
 const discoverMock = vi.hoisted(() => vi.fn());
 const runtimeApiKeyMock = vi.hoisted(() => vi.fn());
-const removeAuthProfilesMock = vi.hoisted(() => vi.fn());
+const updateAuthProfileStoreMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>()),
-  removeAuthProfilesWithLock: removeAuthProfilesMock,
+  updateAuthProfileStoreWithLock: updateAuthProfileStoreMock,
 }));
 
 vi.mock("./discovery.js", async (importOriginal) => ({
@@ -86,8 +86,8 @@ describe("llama-server setup", () => {
     discoverMock.mockReset();
     runtimeApiKeyMock.mockReset();
     runtimeApiKeyMock.mockResolvedValue(undefined);
-    removeAuthProfilesMock.mockReset();
-    removeAuthProfilesMock.mockResolvedValue({ version: 1, profiles: {} });
+    updateAuthProfileStoreMock.mockReset();
+    updateAuthProfileStoreMock.mockResolvedValue({ version: 1, profiles: {} });
   });
 
   it("detects a running local server without writing config", async () => {
@@ -191,9 +191,9 @@ describe("llama-server setup", () => {
       result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.apiKey,
     ).toBeUndefined();
     expect(result.defaultModel).toBe("llama-server/qwen/model:Q4_K_M");
-    expect(removeAuthProfilesMock).toHaveBeenCalledWith({
-      profileIds: ["llama-server:default"],
+    expect(updateAuthProfileStoreMock).toHaveBeenCalledWith({
       agentDir: undefined,
+      updater: expect.any(Function),
     });
     expect(result.configPatch?.auth).toEqual({
       profiles: { "llama-server:default": undefined },
@@ -257,6 +257,8 @@ describe("llama-server setup", () => {
           providers: {
             "llama-server": {
               baseUrl: "http://localhost:8080/v1",
+              auth: "api-key",
+              apiKey: "stale-inline-key",
               headers: { authorization: "Bearer stale-key", "X-Tenant": "one" },
               models: [],
             },
@@ -285,9 +287,10 @@ describe("llama-server setup", () => {
     expect(discoverMock).toHaveBeenCalledWith(
       expect.objectContaining({ apiKey: "secret-key", cacheTtlMs: 0 }),
     );
-    expect(result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.headers).toEqual({
-      "X-Tenant": "one",
-    });
+    const provider = result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+    expect(provider?.auth).toBeUndefined();
+    expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.headers).toEqual({ "X-Tenant": "one" });
   });
 
   it("validates and configures non-interactively without requiring an API key", async () => {
@@ -315,9 +318,9 @@ describe("llama-server setup", () => {
     expect(configured?.agents?.defaults?.model).toEqual(
       expect.objectContaining({ primary: "llama-server/qwen/model:Q4_K_M" }),
     );
-    expect(removeAuthProfilesMock).toHaveBeenCalledWith({
-      profileIds: ["llama-server:default"],
+    expect(updateAuthProfileStoreMock).toHaveBeenCalledWith({
       agentDir: undefined,
+      updater: expect.any(Function),
     });
     expect(configured?.auth).toEqual({ profiles: {}, order: undefined });
   });
@@ -361,6 +364,8 @@ describe("llama-server setup", () => {
         providers: {
           "llama-server": {
             baseUrl: "http://localhost:8080/v1",
+            auth: "api-key",
+            apiKey: "stale-inline-key",
             headers: { Authorization: "Bearer stale-key", "X-Tenant": "one" },
             models: [],
           },
@@ -376,9 +381,10 @@ describe("llama-server setup", () => {
 
     const configured = await configureLlamaServerNonInteractive(ctx);
 
-    expect(configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.headers).toEqual({
-      "X-Tenant": "one",
-    });
+    const provider = configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+    expect(provider?.auth).toBeUndefined();
+    expect(provider?.apiKey).toBeUndefined();
+    expect(provider?.headers).toEqual({ "X-Tenant": "one" });
   });
 
   it("preserves Authorization when non-interactive auth came from the environment", async () => {

--- a/extensions/llama-server/src/setup.test.ts
+++ b/extensions/llama-server/src/setup.test.ts
@@ -91,6 +91,34 @@ describe("llama-server setup", () => {
     });
   });
 
+  it("prefers configured Authorization over ambient auth during guided detection", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    runtimeApiKeyMock.mockResolvedValue("ambient-key");
+
+    await detectLlamaServerSetup({
+      config: {
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              headers: { Authorization: "Bearer proxy-key" },
+              models: [],
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(runtimeApiKeyMock).not.toHaveBeenCalled();
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: undefined,
+        headers: { Authorization: "Bearer proxy-key" },
+      }),
+    );
+  });
+
   it("skips guided detection when configured auth cannot be resolved", async () => {
     runtimeApiKeyMock.mockRejectedValue(new Error("unresolved SecretRef"));
 
@@ -241,6 +269,36 @@ describe("llama-server setup", () => {
 
     expect(configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.headers).toEqual({
       "X-Tenant": "one",
+    });
+  });
+
+  it("preserves Authorization when non-interactive auth came from the environment", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const ctx = nonInteractiveContext();
+    ctx.config = {
+      models: {
+        providers: {
+          "llama-server": {
+            baseUrl: "http://localhost:8080/v1",
+            headers: { Authorization: "Bearer proxy-key" },
+            models: [],
+          },
+        },
+      },
+    };
+    ctx.resolveApiKey = vi.fn(async () => ({ key: "ambient-key", source: "env" as const }));
+
+    const configured = await configureLlamaServerNonInteractive(ctx);
+
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: undefined,
+        headers: { Authorization: "Bearer proxy-key" },
+      }),
+    );
+    expect(ctx.toApiKeyCredential).not.toHaveBeenCalled();
+    expect(configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.headers).toEqual({
+      Authorization: "Bearer proxy-key",
     });
   });
 

--- a/extensions/llama-server/src/setup.test.ts
+++ b/extensions/llama-server/src/setup.test.ts
@@ -1,0 +1,216 @@
+import type {
+  ProviderAuthContext,
+  ProviderAuthMethodNonInteractiveContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
+import {
+  configureLlamaServerNonInteractive,
+  detectLlamaServerSetup,
+  prepareLlamaServerSetup,
+  runLlamaServerSetup,
+  validateLlamaServerNonInteractive,
+} from "./setup.js";
+
+const discoverMock = vi.hoisted(() => vi.fn());
+const runtimeApiKeyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./discovery.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./discovery.js")>()),
+  discoverLlamaServer: discoverMock,
+}));
+
+vi.mock("./auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./auth.js")>()),
+  resolveLlamaServerRuntimeApiKey: runtimeApiKeyMock,
+}));
+
+function successfulDiscovery() {
+  return {
+    kind: "success" as const,
+    endpoint: {
+      origin: "http://localhost:8080",
+      inferenceBaseUrl: "http://localhost:8080/v1",
+    },
+    health: "ready" as const,
+    fetchedAt: 123,
+    models: [
+      {
+        config: {
+          id: "qwen/model:Q4_K_M",
+          name: "qwen/model:Q4_K_M",
+          reasoning: false,
+          input: ["text" as const],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 32768,
+          contextTokens: 32768,
+          maxTokens: 8192,
+        },
+        status: "loaded" as const,
+        failed: false,
+      },
+    ],
+  };
+}
+
+function runtime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn() as never,
+  };
+}
+
+function nonInteractiveContext(
+  opts: Record<string, unknown> = {},
+): ProviderAuthMethodNonInteractiveContext {
+  return {
+    authChoice: LLAMA_SERVER_PROVIDER_ID,
+    config: {},
+    baseConfig: {},
+    opts,
+    runtime: runtime(),
+    resolveApiKey: vi.fn(async () => null),
+    toApiKeyCredential: vi.fn(() => null),
+  };
+}
+
+describe("llama-server setup", () => {
+  beforeEach(() => {
+    discoverMock.mockReset();
+    runtimeApiKeyMock.mockReset();
+    runtimeApiKeyMock.mockResolvedValue(undefined);
+  });
+
+  it("detects a running local server without writing config", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+
+    await expect(detectLlamaServerSetup({ config: {}, env: {} })).resolves.toEqual({
+      modelRef: "llama-server/qwen/model:Q4_K_M",
+      detail: "qwen/model:Q4_K_M at http://localhost:8080",
+    });
+  });
+
+  it("skips guided detection when configured auth cannot be resolved", async () => {
+    runtimeApiKeyMock.mockRejectedValue(new Error("unresolved SecretRef"));
+
+    await expect(detectLlamaServerSetup({ config: {}, env: {} })).resolves.toBeNull();
+    expect(discoverMock).not.toHaveBeenCalled();
+  });
+
+  it("prepares only the exact discovered model", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+
+    await expect(
+      prepareLlamaServerSetup({
+        config: {},
+        env: {},
+        modelRef: "llama-server/qwen/model:Q4_K_M",
+      }),
+    ).resolves.toMatchObject({
+      profiles: [],
+      defaultModel: "llama-server/qwen/model:Q4_K_M",
+      configPatch: {
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              api: "openai-completions",
+            },
+          },
+        },
+      },
+    });
+    await expect(
+      prepareLlamaServerSetup({ config: {}, env: {}, modelRef: "llama-server/missing" }),
+    ).resolves.toBeNull();
+  });
+
+  it("configures an unauthenticated server without persisting a fake key", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const prompter = {
+      text: vi.fn(async () => "http://localhost:8080"),
+      confirm: vi.fn(async () => false),
+    };
+    const result = await runLlamaServerSetup({
+      config: {},
+      env: {},
+      prompter,
+      runtime: runtime(),
+      isRemote: false,
+      openUrl: vi.fn(),
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as unknown as ProviderAuthContext);
+
+    expect(result.profiles).toEqual([]);
+    expect(
+      result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.apiKey,
+    ).toBeUndefined();
+    expect(result.defaultModel).toBe("llama-server/qwen/model:Q4_K_M");
+  });
+
+  it("returns an API-key profile when the operator enables auth", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const prompter = {
+      text: vi
+        .fn()
+        .mockResolvedValueOnce("http://localhost:8080")
+        .mockResolvedValueOnce("secret-key"),
+      confirm: vi.fn(async () => true),
+    };
+    const result = await runLlamaServerSetup({
+      config: {},
+      env: {},
+      prompter,
+      runtime: runtime(),
+      secretInputMode: "plaintext",
+      isRemote: false,
+      openUrl: vi.fn(),
+      oauth: { createVpsAwareHandlers: vi.fn() },
+    } as unknown as ProviderAuthContext);
+
+    expect(result.profiles).toEqual([
+      {
+        profileId: "llama-server:default",
+        credential: {
+          type: "api_key",
+          provider: "llama-server",
+          key: "secret-key",
+        },
+      },
+    ]);
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: "secret-key", cacheTtlMs: 0 }),
+    );
+  });
+
+  it("validates and configures non-interactively without requiring an API key", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const ctx = nonInteractiveContext({ customBaseUrl: "http://localhost:8080/v1" });
+
+    await expect(validateLlamaServerNonInteractive(ctx)).resolves.toBe(true);
+    const configured = await configureLlamaServerNonInteractive(ctx);
+
+    expect(ctx.resolveApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({ required: false, envVar: "LLAMA_SERVER_API_KEY" }),
+    );
+    expect(configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]).toMatchObject({
+      baseUrl: "http://localhost:8080/v1",
+      models: [expect.objectContaining({ id: "qwen/model:Q4_K_M" })],
+    });
+    expect(configured?.agents?.defaults?.model).toEqual(
+      expect.objectContaining({ primary: "llama-server/qwen/model:Q4_K_M" }),
+    );
+  });
+
+  it("rejects a requested model absent from discovery", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const ctx = nonInteractiveContext({ customModelId: "missing" });
+
+    await expect(validateLlamaServerNonInteractive(ctx)).resolves.toBe(false);
+    expect(ctx.runtime.error).toHaveBeenCalledWith(
+      "llama-server model missing was not found. Available models: qwen/model:Q4_K_M",
+    );
+    expect(ctx.runtime.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/extensions/llama-server/src/setup.test.ts
+++ b/extensions/llama-server/src/setup.test.ts
@@ -159,7 +159,17 @@ describe("llama-server setup", () => {
       confirm: vi.fn(async () => true),
     };
     const result = await runLlamaServerSetup({
-      config: {},
+      config: {
+        models: {
+          providers: {
+            "llama-server": {
+              baseUrl: "http://localhost:8080/v1",
+              headers: { authorization: "Bearer stale-key", "X-Tenant": "one" },
+              models: [],
+            },
+          },
+        },
+      },
       env: {},
       prompter,
       runtime: runtime(),
@@ -182,6 +192,9 @@ describe("llama-server setup", () => {
     expect(discoverMock).toHaveBeenCalledWith(
       expect.objectContaining({ apiKey: "secret-key", cacheTtlMs: 0 }),
     );
+    expect(result.configPatch?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.headers).toEqual({
+      "X-Tenant": "one",
+    });
   });
 
   it("validates and configures non-interactively without requiring an API key", async () => {
@@ -201,6 +214,34 @@ describe("llama-server setup", () => {
     expect(configured?.agents?.defaults?.model).toEqual(
       expect.objectContaining({ primary: "llama-server/qwen/model:Q4_K_M" }),
     );
+  });
+
+  it("removes stale Authorization when non-interactive setup selects an API key", async () => {
+    discoverMock.mockResolvedValue(successfulDiscovery());
+    const ctx = nonInteractiveContext({ llamaServerApiKey: "new-key" });
+    ctx.config = {
+      models: {
+        providers: {
+          "llama-server": {
+            baseUrl: "http://localhost:8080/v1",
+            headers: { Authorization: "Bearer stale-key", "X-Tenant": "one" },
+            models: [],
+          },
+        },
+      },
+    };
+    ctx.resolveApiKey = vi.fn(async () => ({ key: "new-key", source: "flag" as const }));
+    ctx.toApiKeyCredential = vi.fn(() => ({
+      type: "api_key" as const,
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      key: "new-key",
+    }));
+
+    const configured = await configureLlamaServerNonInteractive(ctx);
+
+    expect(configured?.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.headers).toEqual({
+      "X-Tenant": "one",
+    });
   });
 
   it("rejects a requested model absent from discovery", async () => {

--- a/extensions/llama-server/src/setup.ts
+++ b/extensions/llama-server/src/setup.ts
@@ -1,0 +1,332 @@
+import type {
+  ProviderAppGuidedSetupContext,
+  ProviderAuthContext,
+  ProviderAuthMethodNonInteractiveContext,
+  ProviderAuthResult,
+} from "openclaw/plugin-sdk/plugin-entry";
+import {
+  applyAuthProfileConfig,
+  buildApiKeyCredential,
+  ensureApiKeyFromEnvOrPrompt,
+  normalizeOptionalSecretInput,
+  upsertAuthProfileWithLock,
+  type OpenClawConfig,
+  type SecretInput,
+} from "openclaw/plugin-sdk/provider-auth";
+import { selectPreferredLocalModelId } from "openclaw/plugin-sdk/provider-model-shared";
+import { applyProviderDefaultModel } from "openclaw/plugin-sdk/provider-setup";
+import { resolveLlamaServerRuntimeApiKey } from "./auth.js";
+import {
+  LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
+  LLAMA_SERVER_DEFAULT_ORIGIN,
+  LLAMA_SERVER_PROVIDER_ID,
+  LLAMA_SERVER_PROVIDER_LABEL,
+} from "./defaults.js";
+import { discoverLlamaServer, type LlamaServerDiscoveryResult } from "./discovery.js";
+import { resolveLlamaServerEndpoint } from "./endpoint.js";
+import { buildLlamaServerProviderConfig } from "./models.js";
+
+const PROFILE_ID = `${LLAMA_SERVER_PROVIDER_ID}:default`;
+
+function selectSetupModelId(discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>) {
+  const ordered = discovery.models.toSorted((left, right) => {
+    const leftLoaded = left.status === "loaded" || left.status === "sleeping";
+    const rightLoaded = right.status === "loaded" || right.status === "sleeping";
+    return Number(rightLoaded) - Number(leftLoaded);
+  });
+  const ids = ordered.map((model) => model.config.id);
+  return selectPreferredLocalModelId(ids) ?? ids[0];
+}
+
+function describeDiscoveryFailure(
+  result: Exclude<LlamaServerDiscoveryResult, { kind: "success" }>,
+): string {
+  switch (result.kind) {
+    case "unreachable":
+      return `llama-server could not be reached at ${result.endpoint.origin}.`;
+    case "http-error":
+      return `llama-server returned HTTP ${result.status} for ${result.path} at ${result.endpoint.origin}.`;
+    case "invalid-response":
+      return `llama-server returned an invalid response from ${result.path} at ${result.endpoint.origin}.`;
+    default:
+      throw new Error("Unexpected llama-server discovery result");
+  }
+}
+
+function buildSetupResult(params: {
+  config: OpenClawConfig;
+  discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>;
+  modelId: string;
+  credentialInput?: SecretInput;
+}): ProviderAuthResult {
+  const existingProvider = params.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  return {
+    profiles: params.credentialInput
+      ? [
+          {
+            profileId: PROFILE_ID,
+            credential: buildApiKeyCredential(
+              LLAMA_SERVER_PROVIDER_ID,
+              params.credentialInput,
+              undefined,
+              { config: params.config },
+            ),
+          },
+        ]
+      : [],
+    defaultModel: `${LLAMA_SERVER_PROVIDER_ID}/${params.modelId}`,
+    configPatch: {
+      models: {
+        mode: params.config.models?.mode ?? "merge",
+        providers: {
+          [LLAMA_SERVER_PROVIDER_ID]: buildLlamaServerProviderConfig({
+            configured: {
+              ...existingProvider,
+              baseUrl: params.discovery.endpoint.inferenceBaseUrl,
+              models: existingProvider?.models ?? [],
+            },
+            discoveredModels: params.discovery.models,
+          }),
+        },
+      },
+    },
+  };
+}
+
+async function discoverForSetup(params: {
+  config: OpenClawConfig;
+  baseUrl: string;
+  agentDir?: string;
+  apiKey?: string;
+  signal?: AbortSignal;
+}): Promise<LlamaServerDiscoveryResult> {
+  const resolvedApiKey =
+    params.apiKey ??
+    (await resolveLlamaServerRuntimeApiKey({
+      config: params.config,
+      agentDir: params.agentDir,
+    }));
+  return await discoverLlamaServer({
+    baseUrl: params.baseUrl,
+    apiKey: resolvedApiKey,
+    signal: params.signal,
+    cacheTtlMs: 0,
+  });
+}
+
+/** Read-only discovery for the guided local-provider setup ladder. */
+export async function detectLlamaServerSetup(
+  ctx: ProviderAppGuidedSetupContext,
+): Promise<{ modelRef: string; detail?: string } | null> {
+  const provider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const baseUrl = provider?.baseUrl ?? LLAMA_SERVER_DEFAULT_ORIGIN;
+  let discovery: LlamaServerDiscoveryResult;
+  try {
+    discovery = await discoverForSetup({
+      config: ctx.config,
+      baseUrl,
+      signal: ctx.signal,
+    });
+  } catch {
+    return null;
+  }
+  if (discovery.kind !== "success") {
+    return null;
+  }
+  const modelId = selectSetupModelId(discovery);
+  if (!modelId) {
+    return null;
+  }
+  return {
+    modelRef: `${LLAMA_SERVER_PROVIDER_ID}/${modelId}`,
+    detail: `${modelId} at ${discovery.endpoint.origin}`,
+  };
+}
+
+/** Rechecks one guided candidate and returns the config needed for a live probe. */
+export async function prepareLlamaServerSetup(
+  ctx: ProviderAppGuidedSetupContext & { modelRef: string },
+): Promise<ProviderAuthResult | null> {
+  const provider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  let discovery: LlamaServerDiscoveryResult;
+  try {
+    discovery = await discoverForSetup({
+      config: ctx.config,
+      baseUrl: provider?.baseUrl ?? LLAMA_SERVER_DEFAULT_ORIGIN,
+      signal: ctx.signal,
+    });
+  } catch {
+    return null;
+  }
+  if (discovery.kind !== "success") {
+    return null;
+  }
+  const prefix = `${LLAMA_SERVER_PROVIDER_ID}/`;
+  const modelId = ctx.modelRef.startsWith(prefix) ? ctx.modelRef.slice(prefix.length) : "";
+  if (!modelId || !discovery.models.some((model) => model.config.id === modelId)) {
+    return null;
+  }
+  return buildSetupResult({ config: ctx.config, discovery, modelId });
+}
+
+/** Interactive setup for an existing llama-server endpoint. */
+export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
+  const existing = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const defaultOrigin = resolveLlamaServerEndpoint(existing?.baseUrl).origin;
+  const baseUrl = await ctx.prompter.text({
+    message: `${LLAMA_SERVER_PROVIDER_LABEL} URL`,
+    initialValue: defaultOrigin,
+    placeholder: LLAMA_SERVER_DEFAULT_ORIGIN,
+    validate: (value) => (value?.trim() ? undefined : "Required"),
+  });
+  const endpoint = resolveLlamaServerEndpoint(baseUrl);
+
+  let credentialInput: SecretInput | undefined;
+  let apiKey = ctx.env?.[LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR]?.trim();
+  const usesApiKey =
+    Boolean(apiKey) ||
+    (await ctx.prompter.confirm({
+      message: "Does this llama-server require an API key?",
+      initialValue: false,
+    }));
+  if (usesApiKey && !apiKey) {
+    apiKey = await ensureApiKeyFromEnvOrPrompt({
+      config: ctx.config,
+      env: ctx.env,
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      envLabel: LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
+      promptMessage: "Enter the llama-server API key",
+      normalize: (value) => value.trim(),
+      validate: (value) => (value.trim() ? undefined : "Required"),
+      prompter: ctx.prompter,
+      secretInputMode: ctx.secretInputMode,
+      setCredential: async (input) => {
+        credentialInput = input;
+      },
+    });
+  }
+
+  const discovery = await discoverForSetup({
+    config: ctx.config,
+    agentDir: ctx.agentDir,
+    baseUrl: endpoint.inferenceBaseUrl,
+    apiKey,
+    signal: ctx.signal,
+  });
+  if (discovery.kind !== "success") {
+    throw new Error(describeDiscoveryFailure(discovery));
+  }
+  const modelId = selectSetupModelId(discovery);
+  if (!modelId) {
+    throw new Error(`No llama-server text models were found at ${discovery.endpoint.origin}.`);
+  }
+  return buildSetupResult({
+    config: ctx.config,
+    discovery,
+    modelId,
+    credentialInput,
+  });
+}
+
+async function validateNonInteractiveDiscovery(
+  ctx: Omit<ProviderAuthMethodNonInteractiveContext, "toApiKeyCredential">,
+): Promise<{
+  discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>;
+  modelId: string;
+  resolvedApiKey: Awaited<ReturnType<typeof ctx.resolveApiKey>>;
+} | null> {
+  const baseUrl =
+    normalizeOptionalSecretInput(ctx.opts.customBaseUrl) ?? LLAMA_SERVER_DEFAULT_ORIGIN;
+  const providerApiKey = normalizeOptionalSecretInput(ctx.opts.llamaServerApiKey);
+  const customApiKey = normalizeOptionalSecretInput(ctx.opts.customApiKey);
+  const resolvedApiKey = await ctx.resolveApiKey({
+    provider: LLAMA_SERVER_PROVIDER_ID,
+    flagValue: providerApiKey ?? customApiKey,
+    flagName: providerApiKey === undefined ? "--custom-api-key" : "--llama-server-api-key",
+    envVar: LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
+    envVarName: LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
+    required: false,
+  });
+  const discovery = await discoverLlamaServer({
+    baseUrl,
+    apiKey: resolvedApiKey?.key,
+    cacheTtlMs: 0,
+  });
+  if (discovery.kind !== "success") {
+    ctx.runtime.error(describeDiscoveryFailure(discovery));
+    ctx.runtime.exit(1);
+    return null;
+  }
+  const requestedModelId = normalizeOptionalSecretInput(ctx.opts.customModelId);
+  const modelId = requestedModelId ?? selectSetupModelId(discovery);
+  if (!modelId || !discovery.models.some((model) => model.config.id === modelId)) {
+    const available = discovery.models.map((model) => model.config.id).join(", ");
+    ctx.runtime.error(
+      requestedModelId
+        ? `llama-server model ${requestedModelId} was not found. Available models: ${available}`
+        : `No llama-server text models were found at ${discovery.endpoint.origin}.`,
+    );
+    ctx.runtime.exit(1);
+    return null;
+  }
+  return { discovery, modelId, resolvedApiKey };
+}
+
+export async function validateLlamaServerNonInteractive(
+  ctx: Omit<ProviderAuthMethodNonInteractiveContext, "toApiKeyCredential">,
+): Promise<boolean> {
+  return Boolean(await validateNonInteractiveDiscovery(ctx));
+}
+
+/** Non-interactive setup with optional API-key persistence. */
+export async function configureLlamaServerNonInteractive(
+  ctx: ProviderAuthMethodNonInteractiveContext,
+): Promise<OpenClawConfig | null> {
+  const validated = await validateNonInteractiveDiscovery(ctx);
+  if (!validated) {
+    return null;
+  }
+  const existingProvider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const providerConfig = buildLlamaServerProviderConfig({
+    configured: {
+      ...existingProvider,
+      baseUrl: validated.discovery.endpoint.inferenceBaseUrl,
+      models: existingProvider?.models ?? [],
+    },
+    discoveredModels: validated.discovery.models,
+  });
+  let config: OpenClawConfig = {
+    ...ctx.config,
+    models: {
+      ...ctx.config.models,
+      mode: ctx.config.models?.mode ?? "merge",
+      providers: {
+        ...ctx.config.models?.providers,
+        [LLAMA_SERVER_PROVIDER_ID]: providerConfig,
+      },
+    },
+  };
+
+  if (validated.resolvedApiKey) {
+    const credential = ctx.toApiKeyCredential({
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      resolved: validated.resolvedApiKey,
+    });
+    if (!credential) {
+      return null;
+    }
+    await upsertAuthProfileWithLock({
+      profileId: PROFILE_ID,
+      credential,
+      agentDir: ctx.agentDir,
+    });
+    config = applyAuthProfileConfig(config, {
+      profileId: PROFILE_ID,
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      mode: "api_key",
+    });
+  }
+
+  ctx.runtime.log(`Default ${LLAMA_SERVER_PROVIDER_LABEL} model: ${validated.modelId}`);
+  return applyProviderDefaultModel(config, `${LLAMA_SERVER_PROVIDER_ID}/${validated.modelId}`);
+}

--- a/extensions/llama-server/src/setup.ts
+++ b/extensions/llama-server/src/setup.ts
@@ -9,6 +9,7 @@ import {
   buildApiKeyCredential,
   ensureApiKeyFromEnvOrPrompt,
   normalizeOptionalSecretInput,
+  removeProviderAuthProfilesWithLock,
   upsertAuthProfileWithLock,
   type OpenClawConfig,
   type SecretInput,
@@ -75,12 +76,62 @@ function stripAuthorizationHeader(
   };
 }
 
+function removeLlamaServerAuthProfileConfig(config: OpenClawConfig): OpenClawConfig {
+  const profiles = Object.fromEntries(
+    Object.entries(config.auth?.profiles ?? {}).filter(([id]) => id !== PROFILE_ID),
+  );
+  const order = Object.entries(config.auth?.order ?? {}).reduce<Record<string, string[]>>(
+    (nextOrder, [providerId, providerOrder]) => {
+      const next = providerOrder.filter((id) => id !== PROFILE_ID);
+      if (next.length > 0 || next.length === providerOrder.length) {
+        nextOrder[providerId] = next;
+      }
+      return nextOrder;
+    },
+    {},
+  );
+  return {
+    ...config,
+    auth: {
+      ...config.auth,
+      profiles,
+      order: Object.keys(order).length > 0 ? order : undefined,
+    },
+  };
+}
+
+function buildAuthProfileRemovalPatch(config: OpenClawConfig): Partial<OpenClawConfig> {
+  const profiles = config.auth?.profiles;
+  const order = config.auth?.order;
+  const profileExists = profiles ? Object.hasOwn(profiles, PROFILE_ID) : false;
+  const referencedOrders = Object.entries(order ?? {}).filter(([, ids]) =>
+    ids.includes(PROFILE_ID),
+  );
+  if (!profileExists && referencedOrders.length === 0) {
+    return {};
+  }
+  const profilePatch = profileExists ? { [PROFILE_ID]: undefined } : undefined;
+  const orderPatch = Object.fromEntries(
+    referencedOrders.map(([providerId, ids]) => {
+      const next = ids.filter((id) => id !== PROFILE_ID);
+      return [providerId, next.length > 0 ? next : undefined];
+    }),
+  );
+  return {
+    auth: {
+      ...(profilePatch ? { profiles: profilePatch } : {}),
+      ...(referencedOrders.length > 0 ? { order: orderPatch } : {}),
+    },
+  } as Partial<OpenClawConfig>;
+}
+
 function buildSetupResult(params: {
   config: OpenClawConfig;
   discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>;
   modelId: string;
   credentialInput?: SecretInput;
   useApiKey?: boolean;
+  clearStoredProfile?: boolean;
 }): ProviderAuthResult {
   const configuredProvider = params.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
   const existingProvider = params.useApiKey
@@ -102,6 +153,7 @@ function buildSetupResult(params: {
       : [],
     defaultModel: `${LLAMA_SERVER_PROVIDER_ID}/${params.modelId}`,
     configPatch: {
+      ...(params.clearStoredProfile ? buildAuthProfileRemovalPatch(params.config) : {}),
       models: {
         mode: params.config.models?.mode ?? "merge",
         providers: {
@@ -259,12 +311,19 @@ export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<Pro
   if (!modelId) {
     throw new Error(`No llama-server text models were found at ${discovery.endpoint.origin}.`);
   }
+  if (!credentialInput) {
+    await removeProviderAuthProfilesWithLock({
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      agentDir: ctx.agentDir,
+    });
+  }
   return buildSetupResult({
     config: ctx.config,
     discovery,
     modelId,
     credentialInput,
     useApiKey: Boolean(apiKey),
+    clearStoredProfile: !credentialInput,
   });
 }
 
@@ -378,6 +437,12 @@ export async function configureLlamaServerNonInteractive(
       provider: LLAMA_SERVER_PROVIDER_ID,
       mode: "api_key",
     });
+  } else {
+    await removeProviderAuthProfilesWithLock({
+      provider: LLAMA_SERVER_PROVIDER_ID,
+      agentDir: ctx.agentDir,
+    });
+    config = removeLlamaServerAuthProfileConfig(config);
   }
 
   ctx.runtime.log(`Default ${LLAMA_SERVER_PROVIDER_LABEL} model: ${validated.modelId}`);

--- a/extensions/llama-server/src/setup.ts
+++ b/extensions/llama-server/src/setup.ts
@@ -76,6 +76,29 @@ function stripAuthorizationHeader(
   };
 }
 
+function stripEndpointCredentials(
+  provider: ModelProviderConfig | undefined,
+): ModelProviderConfig | undefined {
+  return provider
+    ? {
+        ...provider,
+        apiKey: undefined,
+        headers: undefined,
+      }
+    : undefined;
+}
+
+function hasEndpointChanged(provider: ModelProviderConfig | undefined, baseUrl: string): boolean {
+  if (!provider) {
+    return false;
+  }
+  const configuredBaseUrl = provider.baseUrl ?? LLAMA_SERVER_DEFAULT_ORIGIN;
+  return (
+    resolveLlamaServerEndpoint(configuredBaseUrl).inferenceBaseUrl !==
+    resolveLlamaServerEndpoint(baseUrl).inferenceBaseUrl
+  );
+}
+
 function removeLlamaServerAuthProfileConfig(config: OpenClawConfig): OpenClawConfig {
   const profiles = Object.fromEntries(
     Object.entries(config.auth?.profiles ?? {}).filter(([id]) => id !== PROFILE_ID),
@@ -132,11 +155,15 @@ function buildSetupResult(params: {
   credentialInput?: SecretInput;
   useApiKey?: boolean;
   clearStoredProfile?: boolean;
+  clearEndpointCredentials?: boolean;
 }): ProviderAuthResult {
   const configuredProvider = params.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
-  const existingProvider = params.useApiKey
-    ? stripAuthorizationHeader(configuredProvider)
+  const endpointSafeProvider = params.clearEndpointCredentials
+    ? stripEndpointCredentials(configuredProvider)
     : configuredProvider;
+  const existingProvider = params.useApiKey
+    ? stripAuthorizationHeader(endpointSafeProvider)
+    : endpointSafeProvider;
   return {
     profiles: params.credentialInput
       ? [
@@ -178,21 +205,25 @@ async function discoverForSetup(params: {
   env?: NodeJS.ProcessEnv;
   apiKey?: string;
   signal?: AbortSignal;
+  reuseStoredAuth?: boolean;
 }): Promise<LlamaServerDiscoveryResult> {
+  const reuseStoredAuth = params.reuseStoredAuth !== false;
   const providerConfig = params.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
-  const headers = await resolveLlamaServerProviderHeaders({
-    config: params.config,
-    env: params.env,
-    headers: providerConfig?.headers,
-  });
+  const headers = reuseStoredAuth
+    ? await resolveLlamaServerProviderHeaders({
+        config: params.config,
+        env: params.env,
+        headers: providerConfig?.headers,
+      })
+    : undefined;
   const resolvedApiKey =
     params.apiKey ??
-    (hasLlamaServerAuthorizationHeader(headers)
-      ? undefined
-      : await resolveLlamaServerRuntimeApiKey({
+    (reuseStoredAuth && !hasLlamaServerAuthorizationHeader(headers)
+      ? await resolveLlamaServerRuntimeApiKey({
           config: params.config,
           agentDir: params.agentDir,
-        }));
+        })
+      : undefined);
   return await discoverLlamaServer({
     baseUrl: params.baseUrl,
     apiKey: resolvedApiKey,
@@ -270,9 +301,12 @@ export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<Pro
     validate: (value) => (value?.trim() ? undefined : "Required"),
   });
   const endpoint = resolveLlamaServerEndpoint(baseUrl);
+  const endpointChanged = hasEndpointChanged(existing, endpoint.inferenceBaseUrl);
 
   let credentialInput: SecretInput | undefined;
-  let apiKey = ctx.env?.[LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR]?.trim();
+  let apiKey = endpointChanged
+    ? undefined
+    : ctx.env?.[LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR]?.trim();
   const usesApiKey =
     Boolean(apiKey) ||
     (await ctx.prompter.confirm({
@@ -303,6 +337,7 @@ export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<Pro
     env: ctx.env,
     apiKey,
     signal: ctx.signal,
+    reuseStoredAuth: !endpointChanged,
   });
   if (discovery.kind !== "success") {
     throw new Error(describeDiscoveryFailure(discovery));
@@ -324,6 +359,7 @@ export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<Pro
     credentialInput,
     useApiKey: Boolean(apiKey),
     clearStoredProfile: !credentialInput,
+    clearEndpointCredentials: endpointChanged,
   });
 }
 
@@ -333,9 +369,14 @@ async function validateNonInteractiveDiscovery(
   discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>;
   modelId: string;
   resolvedApiKey: Awaited<ReturnType<typeof ctx.resolveApiKey>>;
+  endpointChanged: boolean;
 } | null> {
+  const configuredProvider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
   const baseUrl =
-    normalizeOptionalSecretInput(ctx.opts.customBaseUrl) ?? LLAMA_SERVER_DEFAULT_ORIGIN;
+    normalizeOptionalSecretInput(ctx.opts.customBaseUrl) ??
+    configuredProvider?.baseUrl ??
+    LLAMA_SERVER_DEFAULT_ORIGIN;
+  const endpointChanged = hasEndpointChanged(configuredProvider, baseUrl);
   const providerApiKey = normalizeOptionalSecretInput(ctx.opts.llamaServerApiKey);
   const customApiKey = normalizeOptionalSecretInput(ctx.opts.customApiKey);
   const resolvedApiKey = await ctx.resolveApiKey({
@@ -346,13 +387,18 @@ async function validateNonInteractiveDiscovery(
     envVarName: LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
     required: false,
   });
-  const headers = await resolveLlamaServerProviderHeaders({
-    config: ctx.config,
-    env: process.env,
-    headers: ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.headers,
-  });
-  const selectedApiKey =
-    hasLlamaServerAuthorizationHeader(headers) && resolvedApiKey?.source !== "flag"
+  const headers = endpointChanged
+    ? undefined
+    : await resolveLlamaServerProviderHeaders({
+        config: ctx.config,
+        env: process.env,
+        headers: configuredProvider?.headers,
+      });
+  const selectedApiKey = endpointChanged
+    ? resolvedApiKey?.source === "flag"
+      ? resolvedApiKey
+      : null
+    : hasLlamaServerAuthorizationHeader(headers) && resolvedApiKey?.source !== "flag"
       ? null
       : resolvedApiKey;
   const discovery = await discoverLlamaServer({
@@ -378,7 +424,7 @@ async function validateNonInteractiveDiscovery(
     ctx.runtime.exit(1);
     return null;
   }
-  return { discovery, modelId, resolvedApiKey: selectedApiKey };
+  return { discovery, modelId, resolvedApiKey: selectedApiKey, endpointChanged };
 }
 
 export async function validateLlamaServerNonInteractive(
@@ -396,9 +442,12 @@ export async function configureLlamaServerNonInteractive(
     return null;
   }
   const configuredProvider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
-  const existingProvider = validated.resolvedApiKey
-    ? stripAuthorizationHeader(configuredProvider)
+  const endpointSafeProvider = validated.endpointChanged
+    ? stripEndpointCredentials(configuredProvider)
     : configuredProvider;
+  const existingProvider = validated.resolvedApiKey
+    ? stripAuthorizationHeader(endpointSafeProvider)
+    : endpointSafeProvider;
   const providerConfig = buildLlamaServerProviderConfig({
     configured: {
       ...existingProvider,

--- a/extensions/llama-server/src/setup.ts
+++ b/extensions/llama-server/src/setup.ts
@@ -18,7 +18,11 @@ import {
   selectPreferredLocalModelId,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { applyProviderDefaultModel } from "openclaw/plugin-sdk/provider-setup";
-import { resolveLlamaServerProviderHeaders, resolveLlamaServerRuntimeApiKey } from "./auth.js";
+import {
+  hasLlamaServerAuthorizationHeader,
+  resolveLlamaServerProviderHeaders,
+  resolveLlamaServerRuntimeApiKey,
+} from "./auth.js";
 import {
   LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
   LLAMA_SERVER_DEFAULT_ORIGIN,
@@ -123,18 +127,20 @@ async function discoverForSetup(params: {
   apiKey?: string;
   signal?: AbortSignal;
 }): Promise<LlamaServerDiscoveryResult> {
-  const resolvedApiKey =
-    params.apiKey ??
-    (await resolveLlamaServerRuntimeApiKey({
-      config: params.config,
-      agentDir: params.agentDir,
-    }));
   const providerConfig = params.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
   const headers = await resolveLlamaServerProviderHeaders({
     config: params.config,
     env: params.env,
     headers: providerConfig?.headers,
   });
+  const resolvedApiKey =
+    params.apiKey ??
+    (hasLlamaServerAuthorizationHeader(headers)
+      ? undefined
+      : await resolveLlamaServerRuntimeApiKey({
+          config: params.config,
+          agentDir: params.agentDir,
+        }));
   return await discoverLlamaServer({
     baseUrl: params.baseUrl,
     apiKey: resolvedApiKey,
@@ -286,9 +292,13 @@ async function validateNonInteractiveDiscovery(
     env: process.env,
     headers: ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.headers,
   });
+  const selectedApiKey =
+    hasLlamaServerAuthorizationHeader(headers) && resolvedApiKey?.source !== "flag"
+      ? null
+      : resolvedApiKey;
   const discovery = await discoverLlamaServer({
     baseUrl,
-    apiKey: resolvedApiKey?.key,
+    apiKey: selectedApiKey?.key,
     headers,
     cacheTtlMs: 0,
   });
@@ -309,7 +319,7 @@ async function validateNonInteractiveDiscovery(
     ctx.runtime.exit(1);
     return null;
   }
-  return { discovery, modelId, resolvedApiKey };
+  return { discovery, modelId, resolvedApiKey: selectedApiKey };
 }
 
 export async function validateLlamaServerNonInteractive(

--- a/extensions/llama-server/src/setup.ts
+++ b/extensions/llama-server/src/setup.ts
@@ -13,7 +13,10 @@ import {
   type OpenClawConfig,
   type SecretInput,
 } from "openclaw/plugin-sdk/provider-auth";
-import { selectPreferredLocalModelId } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  type ModelProviderConfig,
+  selectPreferredLocalModelId,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import { applyProviderDefaultModel } from "openclaw/plugin-sdk/provider-setup";
 import { resolveLlamaServerProviderHeaders, resolveLlamaServerRuntimeApiKey } from "./auth.js";
 import {
@@ -53,13 +56,32 @@ function describeDiscoveryFailure(
   }
 }
 
+function stripAuthorizationHeader(
+  provider: ModelProviderConfig | undefined,
+): ModelProviderConfig | undefined {
+  if (!provider?.headers) {
+    return provider;
+  }
+  const headers = Object.fromEntries(
+    Object.entries(provider.headers).filter(([name]) => name.toLowerCase() !== "authorization"),
+  );
+  return {
+    ...provider,
+    headers: Object.keys(headers).length > 0 ? headers : undefined,
+  };
+}
+
 function buildSetupResult(params: {
   config: OpenClawConfig;
   discovery: Extract<LlamaServerDiscoveryResult, { kind: "success" }>;
   modelId: string;
   credentialInput?: SecretInput;
+  useApiKey?: boolean;
 }): ProviderAuthResult {
-  const existingProvider = params.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const configuredProvider = params.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const existingProvider = params.useApiKey
+    ? stripAuthorizationHeader(configuredProvider)
+    : configuredProvider;
   return {
     profiles: params.credentialInput
       ? [
@@ -236,6 +258,7 @@ export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<Pro
     discovery,
     modelId,
     credentialInput,
+    useApiKey: Boolean(apiKey),
   });
 }
 
@@ -303,7 +326,10 @@ export async function configureLlamaServerNonInteractive(
   if (!validated) {
     return null;
   }
-  const existingProvider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const configuredProvider = ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const existingProvider = validated.resolvedApiKey
+    ? stripAuthorizationHeader(configuredProvider)
+    : configuredProvider;
   const providerConfig = buildLlamaServerProviderConfig({
     configured: {
       ...existingProvider,

--- a/extensions/llama-server/src/setup.ts
+++ b/extensions/llama-server/src/setup.ts
@@ -9,7 +9,7 @@ import {
   buildApiKeyCredential,
   ensureApiKeyFromEnvOrPrompt,
   normalizeOptionalSecretInput,
-  removeAuthProfilesWithLock,
+  updateAuthProfileStoreWithLock,
   upsertAuthProfileWithLock,
   type OpenClawConfig,
   type SecretInput,
@@ -61,17 +61,21 @@ function describeDiscoveryFailure(
   }
 }
 
-function stripAuthorizationHeader(
+function stripCredentialOverrides(
   provider: ModelProviderConfig | undefined,
 ): ModelProviderConfig | undefined {
-  if (!provider?.headers) {
+  if (!provider) {
     return provider;
   }
   const headers = Object.fromEntries(
-    Object.entries(provider.headers).filter(([name]) => name.toLowerCase() !== "authorization"),
+    Object.entries(provider.headers ?? {}).filter(
+      ([name]) => name.toLowerCase() !== "authorization",
+    ),
   );
   return {
     ...provider,
+    auth: undefined,
+    apiKey: undefined,
     headers: Object.keys(headers).length > 0 ? headers : undefined,
   };
 }
@@ -162,7 +166,7 @@ function buildSetupResult(params: {
     ? stripEndpointCredentials(configuredProvider)
     : configuredProvider;
   const existingProvider = params.useApiKey
-    ? stripAuthorizationHeader(endpointSafeProvider)
+    ? stripCredentialOverrides(endpointSafeProvider)
     : endpointSafeProvider;
   return {
     profiles: params.credentialInput
@@ -199,9 +203,47 @@ function buildSetupResult(params: {
 }
 
 async function removeDefaultAuthProfile(agentDir?: string): Promise<void> {
-  const updated = await removeAuthProfilesWithLock({
-    profileIds: [PROFILE_ID],
+  const updated = await updateAuthProfileStoreWithLock({
     agentDir,
+    updater: (store) => {
+      let changed = false;
+      if (store.profiles[PROFILE_ID]) {
+        delete store.profiles[PROFILE_ID];
+        changed = true;
+      }
+      if (store.usageStats?.[PROFILE_ID]) {
+        delete store.usageStats[PROFILE_ID];
+        changed = true;
+      }
+      for (const [provider, order] of Object.entries(store.order ?? {})) {
+        const next = order.filter((profileId) => profileId !== PROFILE_ID);
+        if (next.length === order.length) {
+          continue;
+        }
+        changed = true;
+        if (next.length > 0) {
+          store.order![provider] = next;
+        } else {
+          delete store.order![provider];
+        }
+      }
+      for (const [provider, profileId] of Object.entries(store.lastGood ?? {})) {
+        if (profileId === PROFILE_ID) {
+          delete store.lastGood![provider];
+          changed = true;
+        }
+      }
+      if (store.order && Object.keys(store.order).length === 0) {
+        store.order = undefined;
+      }
+      if (store.lastGood && Object.keys(store.lastGood).length === 0) {
+        store.lastGood = undefined;
+      }
+      if (store.usageStats && Object.keys(store.usageStats).length === 0) {
+        store.usageStats = undefined;
+      }
+      return changed;
+    },
   });
   if (!updated) {
     throw new Error(
@@ -455,7 +497,7 @@ export async function configureLlamaServerNonInteractive(
     ? stripEndpointCredentials(configuredProvider)
     : configuredProvider;
   const existingProvider = validated.resolvedApiKey
-    ? stripAuthorizationHeader(endpointSafeProvider)
+    ? stripCredentialOverrides(endpointSafeProvider)
     : endpointSafeProvider;
   const providerConfig = buildLlamaServerProviderConfig({
     configured: {

--- a/extensions/llama-server/src/setup.ts
+++ b/extensions/llama-server/src/setup.ts
@@ -9,7 +9,7 @@ import {
   buildApiKeyCredential,
   ensureApiKeyFromEnvOrPrompt,
   normalizeOptionalSecretInput,
-  removeProviderAuthProfilesWithLock,
+  removeAuthProfilesWithLock,
   upsertAuthProfileWithLock,
   type OpenClawConfig,
   type SecretInput,
@@ -198,6 +198,18 @@ function buildSetupResult(params: {
   };
 }
 
+async function removeDefaultAuthProfile(agentDir?: string): Promise<void> {
+  const updated = await removeAuthProfilesWithLock({
+    profileIds: [PROFILE_ID],
+    agentDir,
+  });
+  if (!updated) {
+    throw new Error(
+      "Failed to remove the previous llama-server auth profile; wait a moment and retry.",
+    );
+  }
+}
+
 async function discoverForSetup(params: {
   config: OpenClawConfig;
   baseUrl: string;
@@ -347,10 +359,7 @@ export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<Pro
     throw new Error(`No llama-server text models were found at ${discovery.endpoint.origin}.`);
   }
   if (!credentialInput) {
-    await removeProviderAuthProfilesWithLock({
-      provider: LLAMA_SERVER_PROVIDER_ID,
-      agentDir: ctx.agentDir,
-    });
+    await removeDefaultAuthProfile(ctx.agentDir);
   }
   return buildSetupResult({
     config: ctx.config,
@@ -487,10 +496,7 @@ export async function configureLlamaServerNonInteractive(
       mode: "api_key",
     });
   } else {
-    await removeProviderAuthProfilesWithLock({
-      provider: LLAMA_SERVER_PROVIDER_ID,
-      agentDir: ctx.agentDir,
-    });
+    await removeDefaultAuthProfile(ctx.agentDir);
     config = removeLlamaServerAuthProfileConfig(config);
   }
 

--- a/extensions/llama-server/src/setup.ts
+++ b/extensions/llama-server/src/setup.ts
@@ -15,7 +15,7 @@ import {
 } from "openclaw/plugin-sdk/provider-auth";
 import { selectPreferredLocalModelId } from "openclaw/plugin-sdk/provider-model-shared";
 import { applyProviderDefaultModel } from "openclaw/plugin-sdk/provider-setup";
-import { resolveLlamaServerRuntimeApiKey } from "./auth.js";
+import { resolveLlamaServerProviderHeaders, resolveLlamaServerRuntimeApiKey } from "./auth.js";
 import {
   LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
   LLAMA_SERVER_DEFAULT_ORIGIN,
@@ -97,6 +97,7 @@ async function discoverForSetup(params: {
   config: OpenClawConfig;
   baseUrl: string;
   agentDir?: string;
+  env?: NodeJS.ProcessEnv;
   apiKey?: string;
   signal?: AbortSignal;
 }): Promise<LlamaServerDiscoveryResult> {
@@ -106,9 +107,16 @@ async function discoverForSetup(params: {
       config: params.config,
       agentDir: params.agentDir,
     }));
+  const providerConfig = params.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID];
+  const headers = await resolveLlamaServerProviderHeaders({
+    config: params.config,
+    env: params.env,
+    headers: providerConfig?.headers,
+  });
   return await discoverLlamaServer({
     baseUrl: params.baseUrl,
     apiKey: resolvedApiKey,
+    headers,
     signal: params.signal,
     cacheTtlMs: 0,
   });
@@ -125,6 +133,7 @@ export async function detectLlamaServerSetup(
     discovery = await discoverForSetup({
       config: ctx.config,
       baseUrl,
+      env: ctx.env,
       signal: ctx.signal,
     });
   } catch {
@@ -153,6 +162,7 @@ export async function prepareLlamaServerSetup(
     discovery = await discoverForSetup({
       config: ctx.config,
       baseUrl: provider?.baseUrl ?? LLAMA_SERVER_DEFAULT_ORIGIN,
+      env: ctx.env,
       signal: ctx.signal,
     });
   } catch {
@@ -210,6 +220,7 @@ export async function runLlamaServerSetup(ctx: ProviderAuthContext): Promise<Pro
     config: ctx.config,
     agentDir: ctx.agentDir,
     baseUrl: endpoint.inferenceBaseUrl,
+    env: ctx.env,
     apiKey,
     signal: ctx.signal,
   });
@@ -247,9 +258,15 @@ async function validateNonInteractiveDiscovery(
     envVarName: LLAMA_SERVER_DEFAULT_API_KEY_ENV_VAR,
     required: false,
   });
+  const headers = await resolveLlamaServerProviderHeaders({
+    config: ctx.config,
+    env: process.env,
+    headers: ctx.config.models?.providers?.[LLAMA_SERVER_PROVIDER_ID]?.headers,
+  });
   const discovery = await discoverLlamaServer({
     baseUrl,
     apiKey: resolvedApiKey?.key,
+    headers,
     cacheTtlMs: 0,
   });
   if (discovery.kind !== "success") {

--- a/extensions/llama-server/src/stream.test.ts
+++ b/extensions/llama-server/src/stream.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLlamaServerPayload } from "./stream.js";
+
+describe("llama-server stream payload", () => {
+  it("maps OpenAI nested JSON Schema to llama-server's direct schema field", () => {
+    expect(
+      normalizeLlamaServerPayload({
+        model: "model",
+        response_format: {
+          type: "json_schema",
+          json_schema: {
+            name: "openclaw_response",
+            schema: {
+              type: "object",
+              properties: { ok: { type: "boolean" } },
+              required: ["ok"],
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      model: "model",
+      response_format: {
+        type: "json_schema",
+        schema: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+        },
+      },
+    });
+  });
+
+  it("keeps llama-server's direct JSON Schema shape stable", () => {
+    const payload = {
+      response_format: {
+        type: "json_schema",
+        schema: { type: "object", properties: { ok: { type: "boolean" } } },
+      },
+    };
+    expect(normalizeLlamaServerPayload(payload)).toEqual(payload);
+  });
+
+  it("injects a requested schema when the shared transport omits it", () => {
+    expect(
+      normalizeLlamaServerPayload(
+        { model: "model" },
+        {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+        },
+      ),
+    ).toEqual({
+      model: "model",
+      response_format: {
+        type: "json_schema",
+        schema: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+        },
+      },
+    });
+  });
+
+  it("keeps non-schema response formats unchanged", () => {
+    const payload = { response_format: { type: "json_object" } };
+    expect(normalizeLlamaServerPayload(payload)).toEqual(payload);
+  });
+});

--- a/extensions/llama-server/src/stream.test.ts
+++ b/extensions/llama-server/src/stream.test.ts
@@ -20,25 +20,25 @@ describe("llama-server stream payload", () => {
       }),
     ).toEqual({
       model: "model",
-      response_format: {
-        type: "json_schema",
-        schema: {
-          type: "object",
-          properties: { ok: { type: "boolean" } },
-          required: ["ok"],
-        },
+      json_schema: {
+        type: "object",
+        properties: { ok: { type: "boolean" } },
+        required: ["ok"],
       },
     });
   });
 
-  it("keeps llama-server's direct JSON Schema shape stable", () => {
-    const payload = {
-      response_format: {
-        type: "json_schema",
-        schema: { type: "object", properties: { ok: { type: "boolean" } } },
-      },
-    };
-    expect(normalizeLlamaServerPayload(payload)).toEqual(payload);
+  it("maps llama-server's direct response-format schema to its top-level field", () => {
+    expect(
+      normalizeLlamaServerPayload({
+        response_format: {
+          type: "json_schema",
+          schema: { type: "object", properties: { ok: { type: "boolean" } } },
+        },
+      }),
+    ).toEqual({
+      json_schema: { type: "object", properties: { ok: { type: "boolean" } } },
+    });
   });
 
   it("injects a requested schema when the shared transport omits it", () => {
@@ -53,13 +53,10 @@ describe("llama-server stream payload", () => {
       ),
     ).toEqual({
       model: "model",
-      response_format: {
-        type: "json_schema",
-        schema: {
-          type: "object",
-          properties: { ok: { type: "boolean" } },
-          required: ["ok"],
-        },
+      json_schema: {
+        type: "object",
+        properties: { ok: { type: "boolean" } },
+        required: ["ok"],
       },
     });
   });

--- a/extensions/llama-server/src/stream.test.ts
+++ b/extensions/llama-server/src/stream.test.ts
@@ -20,15 +20,18 @@ describe("llama-server stream payload", () => {
       }),
     ).toEqual({
       model: "model",
-      json_schema: {
-        type: "object",
-        properties: { ok: { type: "boolean" } },
-        required: ["ok"],
+      response_format: {
+        type: "json_object",
+        schema: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+        },
       },
     });
   });
 
-  it("maps llama-server's direct response-format schema to its top-level field", () => {
+  it("maps llama-server's direct response-format schema to json_object", () => {
     expect(
       normalizeLlamaServerPayload({
         response_format: {
@@ -37,7 +40,10 @@ describe("llama-server stream payload", () => {
         },
       }),
     ).toEqual({
-      json_schema: { type: "object", properties: { ok: { type: "boolean" } } },
+      response_format: {
+        type: "json_object",
+        schema: { type: "object", properties: { ok: { type: "boolean" } } },
+      },
     });
   });
 
@@ -53,10 +59,13 @@ describe("llama-server stream payload", () => {
       ),
     ).toEqual({
       model: "model",
-      json_schema: {
-        type: "object",
-        properties: { ok: { type: "boolean" } },
-        required: ["ok"],
+      response_format: {
+        type: "json_object",
+        schema: {
+          type: "object",
+          properties: { ok: { type: "boolean" } },
+          required: ["ok"],
+        },
       },
     });
   });

--- a/extensions/llama-server/src/stream.ts
+++ b/extensions/llama-server/src/stream.ts
@@ -35,10 +35,12 @@ export function normalizeLlamaServerPayload(
   if (!isRecord(schema)) {
     return payload;
   }
-  const { response_format: _responseFormat, ...rest } = payload;
   return {
-    ...rest,
-    json_schema: schema,
+    ...payload,
+    response_format: {
+      type: "json_object",
+      schema,
+    },
   };
 }
 

--- a/extensions/llama-server/src/stream.ts
+++ b/extensions/llama-server/src/stream.ts
@@ -21,7 +21,7 @@ export function normalizeLlamaServerPayload(
   if (!responseFormat) {
     return payload;
   }
-  if (responseFormat.type === "json_object" || responseFormat.type === "text") {
+  if (responseFormat.type === "text") {
     return { ...payload, response_format: responseFormat };
   }
   const schema =
@@ -29,16 +29,16 @@ export function normalizeLlamaServerPayload(
       ? isRecord(responseFormat.json_schema)
         ? responseFormat.json_schema.schema
         : responseFormat.schema
-      : responseFormat;
+      : responseFormat.type === "json_object"
+        ? responseFormat.schema
+        : responseFormat;
   if (!isRecord(schema)) {
     return payload;
   }
+  const { response_format: _responseFormat, ...rest } = payload;
   return {
-    ...payload,
-    response_format: {
-      type: "json_schema",
-      schema,
-    },
+    ...rest,
+    json_schema: schema,
   };
 }
 

--- a/extensions/llama-server/src/stream.ts
+++ b/extensions/llama-server/src/stream.ts
@@ -1,0 +1,61 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { streamSimple } from "openclaw/plugin-sdk/llm";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Maps the requested response format to the shape llama-server accepts. */
+export function normalizeLlamaServerPayload(
+  payload: unknown,
+  requestedResponseFormat?: Record<string, unknown>,
+): unknown {
+  if (!isRecord(payload)) {
+    return payload;
+  }
+  const responseFormat = isRecord(payload.response_format)
+    ? payload.response_format
+    : requestedResponseFormat;
+  if (!responseFormat) {
+    return payload;
+  }
+  if (responseFormat.type === "json_object" || responseFormat.type === "text") {
+    return { ...payload, response_format: responseFormat };
+  }
+  const schema =
+    responseFormat.type === "json_schema"
+      ? isRecord(responseFormat.json_schema)
+        ? responseFormat.json_schema.schema
+        : responseFormat.schema
+      : responseFormat;
+  if (!isRecord(schema)) {
+    return payload;
+  }
+  return {
+    ...payload,
+    response_format: {
+      type: "json_schema",
+      schema,
+    },
+  };
+}
+
+/** Keeps the shared OpenAI transport and adjusts only llama-server payload quirks. */
+export function wrapLlamaServerStream(ctx: ProviderWrapStreamFnContext): StreamFn {
+  const underlying = ctx.streamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (model.provider !== LLAMA_SERVER_PROVIDER_ID) {
+      return underlying(model, context, options);
+    }
+    const onPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: async (payload, requestModel) => {
+        const customized = (await onPayload?.(payload, requestModel)) ?? payload;
+        return normalizeLlamaServerPayload(customized, options?.responseFormat);
+      },
+    });
+  };
+}

--- a/extensions/llama-server/tsconfig.json
+++ b/extensions/llama-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1118,6 +1118,12 @@ importers:
         specifier: 3.19.1
         version: 3.19.1(supports-color@10.2.2)(typescript@7.0.2)
 
+  extensions/llama-server:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/llm-task:
     dependencies:
       typebox:

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -53,7 +53,6 @@ export {
 } from "../agents/auth-profiles/store.js";
 export {
   listProfilesForProvider,
-  removeAuthProfilesWithLock,
   removeProviderAuthProfilesWithLock,
   upsertAuthProfile,
   upsertAuthProfileWithLock,

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -53,6 +53,7 @@ export {
 } from "../agents/auth-profiles/store.js";
 export {
   listProfilesForProvider,
+  removeAuthProfilesWithLock,
   removeProviderAuthProfilesWithLock,
   upsertAuthProfile,
   upsertAuthProfileWithLock,


### PR DESCRIPTION
OpenClaw users can point a custom provider at llama-server today, but they must maintain model metadata and llama.cpp-specific compatibility settings by hand.
This change adds a bundled `llama-server` provider that discovers models and runtime capabilities while reusing the shared OpenAI completions transport.
The operator still owns the server process, model files, launch flags, and router policy.

Closes #116765

## What Problem This Solves

Operators running llama.cpp's standalone HTTP server currently have no first-party provider owner for discovery, router state, context limits, chat-template capabilities, or llama.cpp-safe tool schemas.
The manual custom-provider path duplicates configuration and can send tool schemas that llama.cpp rejects.

## Why This Change Was Made

A separate `llama-server` provider keeps the external HTTP process boundary distinct from the in-process `llama-cpp` plugin.
It reuses OpenClaw's existing transport and setup contracts instead of adding server lifecycle or inference code to core.

- Adds interactive, non-interactive, and guided setup with optional API-key or SecretRef authentication.
- Normalizes the configured endpoint and applies exact-origin SSRF policy.
- Performs bounded, read-only discovery through `/health`, `/models`, `/v1/models`, and `/props?...&autoload=false`.
- Maps active context size, slot state, build metadata, router status, and advertised tool capabilities.
- Preserves model IDs containing `/`, `:`, and quantization suffixes.
- Applies the `llamacpp-gbnf` tool-schema family and maps JSON Schema response formats to llama-server's request shape.
- Adds legacy and unified catalogs, dynamic model resolution, generated plugin metadata, and provider documentation.

## User Impact

Operators can select models as `llama-server/<model-id>` after setup without duplicating metadata that the server already exposes.
Catalog refreshes do not load or wake router models, and OpenClaw does not download, build, update, or implicitly start llama-server.

## Evidence

The provider has focused tests, repository contract coverage, package-boundary coverage, documentation checks, and a successful full build.

- `node scripts/run-vitest.mjs extensions/llama-server` — 42 tests passed.
- `pnpm tsgo:extensions:test`
- `pnpm lint:extensions`
- `pnpm test:contracts:plugins` — 994 tests passed.
- `pnpm test:extensions:package-boundary:compile` — all 126 plugins compiled.
- `pnpm plugin-sdk:api:check`
- `pnpm plugin-sdk:surface:check`
- `pnpm plugins:inventory:check`
- `pnpm plugins:sync:check`
- Documentation formatting, MDX, link, map, and glossary checks passed against `upstream/main`.
- `pnpm build`

Live discovery, two concurrent text generations, cancellation, and a tool-call round trip passed against official llama.cpp build `b10156` (`91f8c9c5fb038c086e13e9cd823c29b33b07ba54`) using `unsloth/Qwen3.6-35B-A3B-GGUF` revision `a483e9e6cbd595906af30beda3187c2663a1118c` on the observed CUDA backend with full layer offload and flash attention. Speculative decoding was disabled.
A live structured-output attempt exposed the missing response-format mapping; a raw request confirmed llama-server's accepted schema shape, and four focused stream tests now cover the mapping. The mapped structured-output path was not re-run live because later guarded server restarts did not become ready.

`pnpm check:changed --base upstream/main` currently stops at the repository's unrelated environment-variable ratchet because the measured count is 517 while the checked-in budget is 518. The directly relevant lanes above were run separately.
