### PR TITLE
fix(ollama): stream native tool call lifecycle

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1747,7 +1747,7 @@ describe("createOllamaStreamFn streaming events", () => {
     );
   });
 
-  it("emits only done for tool-call-only responses (no text content)", async () => {
+  it("streams the complete lifecycle for tool-call-only responses", async () => {
     await withMockNdjsonFetch(
       [
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
@@ -1757,12 +1757,36 @@ describe("createOllamaStreamFn streaming events", () => {
         const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
         const events = await collectStreamEvents(stream);
 
-        // No text content means no start/text_start/text_delta/text_end events
         const types = events.map((e) => e.type);
-        expect(types).toEqual(["done"]);
-        const doneEvent = requireEntry(events, 0, "tool-call-only done event");
+        expect(types).toEqual([
+          "start",
+          "toolcall_start",
+          "toolcall_delta",
+          "toolcall_end",
+          "done",
+        ]);
+        expect(events[1]).toMatchObject({
+          type: "toolcall_start",
+          contentIndex: 0,
+          partial: { content: [{ type: "toolCall", name: "bash", arguments: {} }] },
+        });
+        expect(events[2]).toMatchObject({
+          type: "toolcall_delta",
+          contentIndex: 0,
+          delta: '{"command":"ls"}',
+        });
+        expect(events[3]).toMatchObject({
+          type: "toolcall_end",
+          contentIndex: 0,
+          toolCall: { name: "bash", arguments: { command: "ls" } },
+        });
+        const doneEvent = requireEntry(events, 4, "tool-call-only done event");
         if (doneEvent.type === "done") {
           expect(doneEvent.reason).toBe("toolUse");
+          expect(doneEvent.message.content[0]).toMatchObject({
+            type: "toolCall",
+            id: events[3]?.type === "toolcall_end" ? events[3].toolCall.id : undefined,
+          });
         }
       },
     );
@@ -1839,11 +1863,123 @@ describe("createOllamaStreamFn streaming events", () => {
         const events = await collectStreamEvents(stream);
 
         const types = events.map((e) => e.type);
-        expect(types).toEqual(["start", "text_start", "text_delta", "text_end", "done"]);
+        expect(types).toEqual([
+          "start",
+          "text_start",
+          "text_delta",
+          "text_end",
+          "toolcall_start",
+          "toolcall_delta",
+          "toolcall_end",
+          "done",
+        ]);
+        expect(events[5]).toMatchObject({
+          type: "toolcall_delta",
+          contentIndex: 1,
+          delta: '{"command":"ls"}',
+        });
         const doneEvent = events.at(-1);
         if (doneEvent?.type === "done") {
           expect(doneEvent.reason).toBe("toolUse");
         }
+      },
+    );
+  });
+
+  it("streams multiple native calls with stable provider ids across chunks", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"id":"call-read","function":{"name":"read","arguments":{"path":"/tmp/a"}}}]},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"id":"call-bash","function":{"name":"bash","arguments":"{\\"command\\":\\"ls\\"}"}}]},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
+      ],
+      async () => {
+        const events = await collectStreamEvents(
+          await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" }),
+        );
+
+        expect(events.map((event) => event.type)).toEqual([
+          "start",
+          "toolcall_start",
+          "toolcall_delta",
+          "toolcall_end",
+          "toolcall_start",
+          "toolcall_delta",
+          "toolcall_end",
+          "done",
+        ]);
+        const toolCallEnds = events.filter((event) => event.type === "toolcall_end");
+        expect(toolCallEnds).toMatchObject([
+          {
+            contentIndex: 0,
+            toolCall: { id: "call-read", name: "read", arguments: { path: "/tmp/a" } },
+          },
+          {
+            contentIndex: 1,
+            toolCall: { id: "call-bash", name: "bash", arguments: { command: "ls" } },
+          },
+        ]);
+        expect(events.filter((event) => event.type === "toolcall_delta")).toMatchObject([
+          { contentIndex: 0, delta: '{"path":"/tmp/a"}' },
+          { contentIndex: 1, delta: '{"command":"ls"}' },
+        ]);
+        expect(events.filter((event) => event.type === "toolcall_start")).toMatchObject([
+          { partial: { content: [{ arguments: {} }] } },
+          {
+            partial: {
+              content: [{ arguments: { path: "/tmp/a" } }, { arguments: {} }],
+            },
+          },
+        ]);
+        const done = events.at(-1);
+        if (done?.type !== "done") {
+          throw new Error("missing terminal Ollama message");
+        }
+        expect(done.message.content).toMatchObject([
+          { type: "toolCall", id: "call-read" },
+          { type: "toolCall", id: "call-bash" },
+        ]);
+      },
+    );
+  });
+
+  it("does not stream non-executable calls from a token-limited final chunk", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":true,"done_reason":"length"}',
+      ],
+      async () => {
+        const events = await collectStreamEvents(
+          await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" }),
+        );
+
+        expect(events.map((event) => event.type)).toEqual(["done"]);
+        expect(events[0]).toMatchObject({
+          type: "done",
+          reason: "length",
+          message: { content: [], stopReason: "length" },
+        });
+      },
+    );
+  });
+
+  it("never exposes an intermediate native call invalidated by a later length terminal", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"done_reason":"length"}',
+      ],
+      async () => {
+        const events = await collectStreamEvents(
+          await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" }),
+        );
+
+        expect(events.map((event) => event.type)).toEqual(["done"]);
+        expect(events[0]).toMatchObject({
+          type: "done",
+          reason: "length",
+          message: { content: [], stopReason: "length" },
+        });
       },
     );
   });
@@ -1898,6 +2034,20 @@ describe("createOllamaStreamFn streaming events", () => {
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":10,"eval_count":5}',
       );
       controlledFetch.close();
+
+      const toolCallStartEvent = await nextEventWithin(iterator);
+      const toolCallDeltaEvent = await nextEventWithin(iterator);
+      const toolCallEndEvent = await nextEventWithin(iterator);
+      expect(toolCallStartEvent).not.toBe("timeout");
+      expect(toolCallDeltaEvent).not.toBe("timeout");
+      expect(toolCallEndEvent).not.toBe("timeout");
+      expectIteratorEvent(toolCallStartEvent, { type: "toolcall_start", done: false });
+      expectIteratorEvent(toolCallDeltaEvent, {
+        type: "toolcall_delta",
+        delta: '{"command":"ls"}',
+        done: false,
+      });
+      expectIteratorEvent(toolCallEndEvent, { type: "toolcall_end", done: false });
 
       const doneEvent = await nextEventWithin(iterator);
       expect(doneEvent).not.toBe("timeout");
@@ -2343,7 +2493,14 @@ describe("createOllamaStreamFn streaming events", () => {
         });
         const events = await collectStreamEvents(stream);
 
-        expect(events.map((e) => e.type)).toEqual(["done"]);
+        expect(events.map((event) => event.type)).toEqual([
+          "start",
+          "toolcall_start",
+          "toolcall_delta",
+          "toolcall_end",
+          "done",
+        ]);
+        expect(JSON.stringify(events)).not.toContain("I should think privately");
         const doneEvent = events.at(-1);
         expect(doneEvent?.type).toBe("done");
         if (doneEvent?.type === "done") {
@@ -2357,6 +2514,84 @@ describe("createOllamaStreamFn streaming events", () => {
           ]);
           expect(JSON.stringify(doneEvent)).not.toContain("I should think privately");
         }
+      },
+    );
+  });
+
+  it("flushes buffered visible Kimi text before streaming its native tool call", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":"Visible answer"},"done":false}',
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]},"done":false}',
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
+      ],
+      async () => {
+        const events = await collectStreamEvents(
+          await createOllamaTestStream({
+            baseUrl: "http://ollama-host:11434",
+            model: { id: "kimi-k2.6:cloud", provider: "ollama" },
+          }),
+        );
+
+        expect(events.map((event) => event.type)).toEqual([
+          "start",
+          "text_start",
+          "text_delta",
+          "text_end",
+          "toolcall_start",
+          "toolcall_delta",
+          "toolcall_end",
+          "done",
+        ]);
+        expect(events[2]).toMatchObject({ type: "text_delta", delta: "Visible answer" });
+        expect(events[4]).toMatchObject({ type: "toolcall_start", contentIndex: 1 });
+        expect(events[6]).toMatchObject({ type: "toolcall_end", contentIndex: 1 });
+        expect(events.at(-1)).toMatchObject({
+          type: "done",
+          message: {
+            content: [
+              { type: "text", text: "Visible answer" },
+              { type: "toolCall", name: "bash" },
+            ],
+          },
+        });
+      },
+    );
+  });
+
+  it("does not reveal buffered Kimi reasoning for an empty tool-call chunk", async () => {
+    const hiddenPrefix =
+      "I should think privately and not leak this planning text in the answer. " +
+      "I need to keep deciding what to say next.";
+    await withMockNdjsonFetch(
+      [
+        JSON.stringify({
+          model: "kimi-k2.6:cloud",
+          created_at: "t",
+          message: { role: "assistant", content: hiddenPrefix },
+          done: false,
+        }),
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":"","tool_calls":[]},"done":false}',
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":" ️ Visible answer"},"done":false}',
+        '{"model":"kimi-k2.6:cloud","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
+      ],
+      async () => {
+        const events = await collectStreamEvents(
+          await createOllamaTestStream({
+            baseUrl: "http://ollama-host:11434",
+            model: { id: "kimi-k2.6:cloud", provider: "ollama" },
+          }),
+        );
+
+        expect(events.map((event) => event.type)).toEqual([
+          "start",
+          "text_start",
+          "text_delta",
+          "text_end",
+          "done",
+        ]);
+        expect(events[2]).toMatchObject({ type: "text_delta", delta: "Visible answer" });
+        expect(JSON.stringify(events)).not.toContain("I should think privately");
       },
     );
   });

--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -325,9 +325,7 @@ describe("createOllamaStreamFn thinking events", () => {
     };
     expect(done.reason).toBe("length");
     expect(done.message?.stopReason).toBe("length");
-    expect(done.message?.content).toEqual([
-      expect.objectContaining({ type: "toolCall", name: "read" }),
-    ]);
+    expect(done.message?.content).toEqual([]);
   });
 
   it("uses generic stream timeout for Ollama request timeout", async () => {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -1262,6 +1262,7 @@ function createRawOllamaStreamFn(
           let accumulatedThinking = "";
           let suppressedThinking = "";
           const accumulatedToolCalls: OllamaToolCall[] = [];
+          const streamedToolCalls: ToolCall[] = [];
           let finalResponse: OllamaChatResponse | undefined;
           let pendingFinalVisibleContent: string | undefined;
           const modelInfo = {
@@ -1291,7 +1292,22 @@ function createRawOllamaStreamFn(
             if (accumulatedVisibleContent) {
               parts.push({ type: "text", text: accumulatedVisibleContent });
             }
+            parts.push(...streamedToolCalls);
             return parts;
+          };
+
+          const ensureStreamStarted = () => {
+            if (streamStarted) {
+              return;
+            }
+            streamStarted = true;
+            const emptyPartial = buildStreamAssistantMessage({
+              model: modelInfo,
+              content: [],
+              stopReason: "stop",
+              usage: buildUsageWithNoCost({}),
+            });
+            stream.push({ type: "start", partial: emptyPartial });
           };
 
           const closeThinkingBlock = () => {
@@ -1345,16 +1361,7 @@ function createRawOllamaStreamFn(
               closeThinkingBlock();
             }
 
-            if (!streamStarted) {
-              streamStarted = true;
-              const emptyPartial = buildStreamAssistantMessage({
-                model: modelInfo,
-                content: [],
-                stopReason: "stop",
-                usage: buildUsageWithNoCost({}),
-              });
-              stream.push({ type: "start", partial: emptyPartial });
-            }
+            ensureStreamStarted();
             if (!textBlockStarted) {
               textBlockStarted = true;
               const partial = buildStreamAssistantMessage({
@@ -1392,16 +1399,7 @@ function createRawOllamaStreamFn(
             refreshTimeout?.();
             const thinkingDelta = chunk.message?.thinking ?? chunk.message?.reasoning;
             if (thinkingDelta && shouldEmitThinking) {
-              if (!streamStarted) {
-                streamStarted = true;
-                const emptyPartial = buildStreamAssistantMessage({
-                  model: modelInfo,
-                  content: [],
-                  stopReason: "stop",
-                  usage: buildUsageWithNoCost({}),
-                });
-                stream.push({ type: "start", partial: emptyPartial });
-              }
+              ensureStreamStarted();
               if (!thinkingStarted) {
                 thinkingStarted = true;
                 const partial = buildStreamAssistantMessage({
@@ -1435,10 +1433,18 @@ function createRawOllamaStreamFn(
               accumulatedRawContent += rawDelta;
               flushVisibleText(resolveVisibleContent(false));
             }
-            if (chunk.message?.tool_calls) {
+            if (chunk.message?.tool_calls?.length) {
+              // Kimi holds short visible prefixes until a terminal boundary;
+              // settle them now so later tool indices cannot overwrite text.
+              flushVisibleText(resolveVisibleContent(true));
               closeThinkingBlock();
               closeTextBlock();
-              accumulatedToolCalls.push(...chunk.message.tool_calls);
+              for (const rawToolCall of chunk.message.tool_calls) {
+                // Ollama can report a length stop in a later chunk, so no call
+                // becomes executable until its authoritative terminal arrives.
+                const id = readOllamaToolCallId(rawToolCall.id) ?? `ollama_call_${randomUUID()}`;
+                accumulatedToolCalls.push({ ...rawToolCall, id });
+              }
             }
             if (chunk.done) {
               pendingFinalVisibleContent = resolveVisibleContent(true);
@@ -1473,7 +1479,11 @@ function createRawOllamaStreamFn(
           if (accumulatedThinking) {
             finalResponse.message.thinking = accumulatedThinking;
           }
-          if (accumulatedToolCalls.length > 0) {
+          if (finalResponse.done_reason === "length") {
+            // All consumers inspect terminal content, not only lifecycle events;
+            // a token-limit stop must never retain an executable-looking call.
+            delete finalResponse.message.tool_calls;
+          } else if (accumulatedToolCalls.length > 0) {
             finalResponse.message.tool_calls = accumulatedToolCalls;
           }
 
@@ -1491,9 +1501,45 @@ function createRawOllamaStreamFn(
           closeThinkingBlock();
           closeTextBlock();
 
+          const reason = resolveOllamaStopReason(finalResponse);
+          if (reason === "toolUse") {
+            for (const completedToolCall of assistantMessage.content) {
+              if (completedToolCall.type !== "toolCall") {
+                continue;
+              }
+              ensureStreamStarted();
+              const placeholder: ToolCall = { ...completedToolCall, arguments: {} };
+              streamedToolCalls.push(placeholder);
+              const contentIndex = buildCurrentContent().length - 1;
+              const partial = () =>
+                buildStreamAssistantMessage({
+                  model: modelInfo,
+                  content: buildCurrentContent(),
+                  stopReason: "stop",
+                  usage: buildUsageWithNoCost({}),
+                });
+              stream.push({ type: "toolcall_start", contentIndex, partial: partial() });
+              // Replace the placeholder instead of mutating it: queued start
+              // snapshots must not see arguments before their delta arrives.
+              streamedToolCalls[streamedToolCalls.length - 1] = completedToolCall;
+              stream.push({
+                type: "toolcall_delta",
+                contentIndex,
+                delta: JSON.stringify(completedToolCall.arguments),
+                partial: partial(),
+              });
+              stream.push({
+                type: "toolcall_end",
+                contentIndex,
+                toolCall: completedToolCall,
+                partial: partial(),
+              });
+            }
+          }
+
           stream.push({
             type: "done",
-            reason: resolveOllamaStopReason(finalResponse),
+            reason,
             message: assistantMessage,
           });
         } finally {


### PR DESCRIPTION
## Summary
- Stream start, toolcall_start, toolcall_delta, and toolcall_end events as native Ollama calls arrive, with stable provider IDs and immutable partial snapshots.
- Preserve visible text/thinking ordering, parallel native calls, Kimi reasoning sanitization, and the existing plaintext compatibility wrapper.
- Keep token-limited terminal calls non-executable and ignore empty tool-call arrays before finalizing buffered Kimi text.

## Verification
- `/Users/steipete/.local/bin/node scripts/run-vitest.mjs run extensions/ollama/src/stream-runtime.test.ts extensions/ollama/src/stream.test.ts --config=test/vitest/vitest.extension-providers.config.ts` (158 tests passed).
- Existing oxfmt binary checked both changed files; `git diff --check` passed.
- Independent read-only owner review: CLEAN.