### PR TITLE
fix(browser): preserve doctor JSON failure status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Browser doctor JSON exit status:** exit nonzero when machine-readable doctor output reports failed checks while still emitting one complete JSON document.
 - **Control UI session refreshes:** preserve explicitly queued list filters and background hydration across later Gateway event invalidation, while keeping append pagination followed by a canonical refresh. Fixes #116697. Thanks @shakkernerd.
 - **Gateway device clock skew:** sign device proofs with the Gateway-issued challenge timestamp across TypeScript, Control UI, browser extension, Android, Apple, Linux, and watchOS clients so incorrect local clocks no longer block authentication, while retaining no-challenge compatibility for pre-challenge Control UI servers and older watch-node HTTP endpoints and keeping nonce binding and freshness checks enforced. Fixes #103455.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Browser doctor JSON exit status:** exit nonzero when machine-readable doctor output reports failed checks while still emitting one complete JSON document.
 - **Control UI session refreshes:** preserve explicitly queued list filters and background hydration across later Gateway event invalidation, while keeping append pagination followed by a canonical refresh. Fixes #116697. Thanks @shakkernerd.
 - **Gateway device clock skew:** sign device proofs with the Gateway-issued challenge timestamp across TypeScript, Control UI, browser extension, Android, Apple, Linux, and watchOS clients so incorrect local clocks no longer block authentication, while retaining no-challenge compatibility for pre-challenge Control UI servers and older watch-node HTTP endpoints and keeping nonce binding and freshness checks enforced. Fixes #103455.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.

--- a/extensions/browser/src/cli/browser-cli-manage.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test.ts
@@ -564,13 +564,15 @@ describe("browser manage output", () => {
     const program = createBrowserManageProgram();
     await program.parseAsync(["browser", "--json", "doctor"], { from: "user" });
 
-    expect(parseSingleRuntimeJson()).toMatchObject({
-      ok: false,
-      checks: [
-        { name: "gateway", ok: true },
-        { name: "plugin", ok: false },
-      ],
-    });
+    expect(parseSingleRuntimeJson()).toEqual(
+      expect.objectContaining({
+        ok: false,
+        checks: expect.arrayContaining([
+          expect.objectContaining({ name: "gateway", ok: true }),
+          expect.objectContaining({ name: "plugin", ok: false }),
+        ]),
+      }),
+    );
     expect(getBrowserCliRuntimeCapture().runtimeErrors).toEqual([]);
     expect(getBrowserCliRuntime().writeJson).toHaveBeenCalledTimes(1);
     expect(getBrowserCliRuntime().exit).not.toHaveBeenCalled();
@@ -597,9 +599,7 @@ describe("browser manage output", () => {
     });
 
     const program = createBrowserManageProgram();
-    await expect(
-      program.parseAsync(["browser", "--json", "doctor"], { from: "user" }),
-    ).resolves.toBeUndefined();
+    await program.parseAsync(["browser", "--json", "doctor"], { from: "user" });
 
     expect(parseSingleRuntimeJson()).toMatchObject({ ok: true });
     expect(getBrowserCliRuntimeCapture().runtimeErrors).toEqual([]);

--- a/extensions/browser/src/cli/browser-cli-manage.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test.ts
@@ -1,5 +1,5 @@
 // Browser tests cover browser cli manage plugin behavior.
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createBrowserManageProgram,
   getBrowserManageCallBrowserRequestMock,
@@ -22,11 +22,19 @@ function parseSingleRuntimeJson(): unknown {
 }
 
 describe("browser manage output", () => {
+  let previousExitCode: typeof process.exitCode;
+
   beforeEach(() => {
+    previousExitCode = process.exitCode;
+    process.exitCode = undefined;
     getBrowserManageCallBrowserRequestMock().mockClear();
     getBrowserCliRuntimeCapture().resetRuntimeCapture();
     getBrowserCliRuntime().exit.mockClear();
     getBrowserCliRuntime().writeJson.mockClear();
+  });
+
+  afterEach(() => {
+    process.exitCode = previousExitCode;
   });
 
   it("shows chrome-mcp transport for existing-session status without fake CDP fields", async () => {
@@ -534,9 +542,10 @@ describe("browser manage output", () => {
     expect(output).toContain("OK tabs: 1 visible, use tab reference t1");
     expect(getBrowserCliRuntime().writeJson).not.toHaveBeenCalled();
     expect(getBrowserCliRuntime().exit).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
   });
 
-  it("prints one complete JSON browser doctor failure before exiting nonzero", async () => {
+  it("prints one complete JSON browser doctor failure before setting exit status", async () => {
     getBrowserManageCallBrowserRequestMock().mockImplementation(async (_opts: unknown, req) => {
       if (req.path === "/") {
         return {
@@ -553,9 +562,7 @@ describe("browser manage output", () => {
     });
 
     const program = createBrowserManageProgram();
-    await expect(
-      program.parseAsync(["browser", "--json", "doctor"], { from: "user" }),
-    ).rejects.toThrow("__exit__:1");
+    await program.parseAsync(["browser", "--json", "doctor"], { from: "user" });
 
     expect(parseSingleRuntimeJson()).toMatchObject({
       ok: false,
@@ -564,7 +571,10 @@ describe("browser manage output", () => {
         { name: "plugin", ok: false },
       ],
     });
+    expect(getBrowserCliRuntimeCapture().runtimeErrors).toEqual([]);
     expect(getBrowserCliRuntime().writeJson).toHaveBeenCalledTimes(1);
+    expect(getBrowserCliRuntime().exit).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 
   it("prints one JSON browser doctor report and succeeds when every check passes", async () => {
@@ -595,6 +605,7 @@ describe("browser manage output", () => {
     expect(getBrowserCliRuntimeCapture().runtimeErrors).toEqual([]);
     expect(getBrowserCliRuntime().writeJson).toHaveBeenCalledTimes(1);
     expect(getBrowserCliRuntime().exit).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
   });
 
   it("prints a readable browser doctor failure when gateway auth SecretRefs are unavailable", async () => {
@@ -605,9 +616,7 @@ describe("browser manage output", () => {
     getBrowserManageCallBrowserRequestMock().mockRejectedValueOnce(error);
 
     const program = createBrowserManageProgram();
-    await expect(program.parseAsync(["browser", "doctor"], { from: "user" })).rejects.toThrow(
-      "__exit__:1",
-    );
+    await program.parseAsync(["browser", "doctor"], { from: "user" });
 
     const output = lastRuntimeLog();
     expect(output).toContain(
@@ -616,5 +625,7 @@ describe("browser manage output", () => {
     expect(output).toContain("OPENCLAW_GATEWAY_TOKEN");
     expect(output).not.toContain("GatewaySecretRefUnavailableError");
     expect(getBrowserCliRuntime().writeJson).not.toHaveBeenCalled();
+    expect(getBrowserCliRuntime().exit).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/extensions/browser/src/cli/browser-cli-manage.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test.ts
@@ -15,10 +15,18 @@ function lastRuntimeLog(): string {
   return value;
 }
 
+function parseSingleRuntimeJson(): unknown {
+  const logs = getBrowserCliRuntimeCapture().runtimeLogs;
+  expect(logs).toHaveLength(1);
+  return JSON.parse(logs[0] ?? "");
+}
+
 describe("browser manage output", () => {
   beforeEach(() => {
     getBrowserManageCallBrowserRequestMock().mockClear();
     getBrowserCliRuntimeCapture().resetRuntimeCapture();
+    getBrowserCliRuntime().exit.mockClear();
+    getBrowserCliRuntime().writeJson.mockClear();
   });
 
   it("shows chrome-mcp transport for existing-session status without fake CDP fields", async () => {
@@ -524,6 +532,69 @@ describe("browser manage output", () => {
     expect(output).toContain("OK gateway: browser control endpoint reachable");
     expect(output).toContain("OK graphics: software");
     expect(output).toContain("OK tabs: 1 visible, use tab reference t1");
+    expect(getBrowserCliRuntime().writeJson).not.toHaveBeenCalled();
+    expect(getBrowserCliRuntime().exit).not.toHaveBeenCalled();
+  });
+
+  it("prints one complete JSON browser doctor failure before exiting nonzero", async () => {
+    getBrowserManageCallBrowserRequestMock().mockImplementation(async (_opts: unknown, req) => {
+      if (req.path === "/") {
+        return {
+          enabled: false,
+          profile: "openclaw",
+          transport: "cdp",
+          running: false,
+        };
+      }
+      if (req.path === "/profiles") {
+        return { profiles: [] };
+      }
+      return {};
+    });
+
+    const program = createBrowserManageProgram();
+    await expect(
+      program.parseAsync(["browser", "--json", "doctor"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(parseSingleRuntimeJson()).toMatchObject({
+      ok: false,
+      checks: [
+        { name: "gateway", ok: true },
+        { name: "plugin", ok: false },
+      ],
+    });
+    expect(getBrowserCliRuntime().writeJson).toHaveBeenCalledTimes(1);
+  });
+
+  it("prints one JSON browser doctor report and succeeds when every check passes", async () => {
+    getBrowserManageCallBrowserRequestMock().mockImplementation(async (_opts: unknown, req) => {
+      if (req.path === "/") {
+        return {
+          enabled: true,
+          profile: "openclaw",
+          transport: "cdp",
+          running: true,
+        };
+      }
+      if (req.path === "/profiles") {
+        return { profiles: [{ name: "openclaw", running: true }] };
+      }
+      if (req.path === "/tabs") {
+        return { running: true, tabs: [] };
+      }
+      return {};
+    });
+
+    const program = createBrowserManageProgram();
+    await expect(
+      program.parseAsync(["browser", "--json", "doctor"], { from: "user" }),
+    ).resolves.toBeUndefined();
+
+    expect(parseSingleRuntimeJson()).toMatchObject({ ok: true });
+    expect(getBrowserCliRuntimeCapture().runtimeErrors).toEqual([]);
+    expect(getBrowserCliRuntime().writeJson).toHaveBeenCalledTimes(1);
+    expect(getBrowserCliRuntime().exit).not.toHaveBeenCalled();
   });
 
   it("prints a readable browser doctor failure when gateway auth SecretRefs are unavailable", async () => {
@@ -544,5 +615,6 @@ describe("browser manage output", () => {
     );
     expect(output).toContain("OPENCLAW_GATEWAY_TOKEN");
     expect(output).not.toContain("GatewaySecretRefUnavailableError");
+    expect(getBrowserCliRuntime().writeJson).not.toHaveBeenCalled();
   });
 });

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -417,7 +417,7 @@ export function registerBrowserManageCommands(
           defaultRuntime.log(result.checks.map(formatDoctorLine).join("\n"));
         }
         if (!result.ok) {
-          defaultRuntime.exit(1);
+          process.exitCode = 1;
         }
       });
     });

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -413,10 +413,9 @@ export function registerBrowserManageCommands(
       const profile = parent?.browserProfile;
       await runBrowserCommand(async () => {
         const result = await runBrowserDoctor(parent, profile, opts.deep === true);
-        if (printJsonResult(parent, result)) {
-          return;
+        if (!printJsonResult(parent, result)) {
+          defaultRuntime.log(result.checks.map(formatDoctorLine).join("\n"));
         }
-        defaultRuntime.log(result.checks.map(formatDoctorLine).join("\n"));
         if (!result.ok) {
           defaultRuntime.exit(1);
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw browser --json doctor` could emit a failed `{ "ok": false }` report but still exit with status 0, causing shell automation and CI to treat an unhealthy Browser setup as successful.

## Why This Change Was Made

Browser doctor now renders exactly one selected output mode first, then applies the shared readiness result once. Failed reports set `process.exitCode = 1` so JSON/text output drains completely; successful reports retain status 0. Human output behavior is unchanged.

## User Impact

Operators can reliably use Browser doctor JSON in scripts: unhealthy reports are still complete and parseable, but now fail the process as expected.

## Evidence

- Focused Browser CLI suite passed 17/17 on Testbox `tbx_01kyvzp771zhrcsz55yd2sksv5`, run `30627943361`.
- The full changed gate passed on the same exact head, including extension typechecks, lint, format, dependency, boundary, dead-code, database-first, media, sidecar, and import-cycle guards.
- A full production build passed. A real built CLI invocation with isolated state emitted one JSON document, exited 1, and parsed as `ok:false`: `BROWSER_DOCTOR_JSON_PROOF status=1 ok=false checks=1`.
- Source-blind behavior validation passed the parseability, single-document, `ok:false`, and exit-status clauses at 0.99 confidence.
- Final branch autoreview was clean at 0.94. Independent re-review confirmed the earlier hard-exit truncation risk and release-owned changelog finding are resolved, with no new findings at 0.98 confidence.

No protocol, configuration, dependency, Browser readiness policy, or human-readable report shape changes.
