### PR TITLE
fix(whatsapp): render quoted self-chat replies with cached LIDs

### DIFF
--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -815,6 +815,26 @@ describe("createWebSendApi", () => {
       id: "quoted-1",
     });
   });
+
+  it("aligns a lookup-proven LID quote with the final PN destination", async () => {
+    await api.sendMessage("+1555", "hello", undefined, undefined, {
+      quotedMessageKey: {
+        id: "quoted-self",
+        remoteJid: "277038292303944@lid",
+        fromMe: true,
+        lookupTargetJid: "1555@s.whatsapp.net",
+        messageText: "quoted body",
+      },
+    });
+
+    expectFirstSendJid("1555@s.whatsapp.net");
+    const quoted = requireRecord(requireSendOptions().quoted, "quoted message");
+    expectRecordFields(requireRecord(quoted.key, "quoted key"), {
+      remoteJid: "1555@s.whatsapp.net",
+      id: "quoted-self",
+      fromMe: true,
+    });
+  });
 });
 
 // Integration tests for issue #67378: createWebSendApi must route outbound

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -177,6 +177,9 @@ export function createWebSendApi(params: {
         remoteJid: sendOptions?.quotedMessageKey?.remoteJid,
         fromMe: sendOptions?.quotedMessageKey?.fromMe,
         participant: sendOptions?.quotedMessageKey?.participant,
+        destinationJid: jid,
+        requestedJid: toWhatsappJid(to),
+        lookupTargetJid: sendOptions?.quotedMessageKey?.lookupTargetJid,
         messageText: sendOptions?.quotedMessageKey?.messageText,
         media: sendOptions?.quotedMessageKey?.media,
       });

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -2,6 +2,7 @@
 import type { AnyMessageContent, MiscMessageGenerationOptions } from "baileys";
 import type {
   ChannelInboundMediaInput,
+  MediaPlaceholderTextFact,
   NormalizedLocation,
 } from "openclaw/plugin-sdk/channel-inbound";
 import type { PollInput } from "openclaw/plugin-sdk/poll-runtime";

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -2,11 +2,11 @@
 import type { AnyMessageContent, MiscMessageGenerationOptions } from "baileys";
 import type {
   ChannelInboundMediaInput,
-  MediaPlaceholderTextFact,
   NormalizedLocation,
 } from "openclaw/plugin-sdk/channel-inbound";
 import type { PollInput } from "openclaw/plugin-sdk/poll-runtime";
 import type { WhatsAppIdentity, WhatsAppReplyContext, WhatsAppSelfIdentity } from "../identity.js";
+import type { WhatsAppQuotedMessageKey } from "../quoted-message.js";
 import type { DeprecatedWebInboundAdmissionTopLevelFields } from "./admission-types.js";
 import type { WhatsAppInboundAdmission } from "./admission.js";
 import type { WhatsAppSendResult } from "./send-result.js";
@@ -20,14 +20,7 @@ export type WebListenerCloseReason = {
 };
 
 export type ActiveWebSendOptions = {
-  quotedMessageKey?: {
-    id: string;
-    remoteJid: string;
-    fromMe: boolean;
-    participant?: string;
-    messageText?: string;
-    media?: MediaPlaceholderTextFact;
-  };
+  quotedMessageKey?: WhatsAppQuotedMessageKey;
   gifPlayback?: boolean;
   accountId?: string;
   fileName?: string;

--- a/extensions/whatsapp/src/outbound-base.test.ts
+++ b/extensions/whatsapp/src/outbound-base.test.ts
@@ -365,6 +365,7 @@ describe("createWhatsAppOutboundBase", () => {
       remoteJid: "277038292303944@lid",
       fromMe: true,
       participant: "5511976136970@s.whatsapp.net",
+      lookupTargetJid: "5511976136970@s.whatsapp.net",
       messageText: "quoted from lid chat",
     });
   });

--- a/extensions/whatsapp/src/outbound-base.ts
+++ b/extensions/whatsapp/src/outbound-base.ts
@@ -14,7 +14,10 @@ import {
   normalizeWhatsAppPayloadText,
 } from "./outbound-media-contract.js";
 import { WHATSAPP_LEGACY_OUTBOUND_SEND_DEP_KEYS } from "./outbound-send-deps.js";
-import { lookupInboundMessageMetaForTarget } from "./quoted-message.js";
+import {
+  lookupInboundMessageMetaForTarget,
+  type WhatsAppQuotedMessageKey,
+} from "./quoted-message.js";
 import { toWhatsappJid } from "./text-runtime.js";
 
 type WhatsAppChunker = NonNullable<ChannelOutboundAdapter["chunker"]>;
@@ -32,13 +35,7 @@ type WhatsAppSendTextOptions = {
   audioAsVoice?: boolean;
   forceDocument?: boolean;
   accountId?: string;
-  quotedMessageKey?: {
-    id: string;
-    remoteJid: string;
-    fromMe: boolean;
-    participant?: string;
-    messageText?: string;
-  };
+  quotedMessageKey?: WhatsAppQuotedMessageKey;
   preserveLeadingWhitespace?: boolean;
   /** Report each accepted internal platform send before the next fallible send. */
   onDeliveryResult?: (result: { messageId: string; toJid: string }) => Promise<void> | void;
@@ -126,6 +123,7 @@ export function createWhatsAppOutboundBase({
       remoteJid: cachedMeta?.remoteJid ?? targetJid,
       fromMe: cachedMeta?.fromMe ?? false,
       participant: cachedMeta?.participant,
+      ...(cachedMeta && cachedMeta.remoteJid !== targetJid ? { lookupTargetJid: targetJid } : {}),
       messageText: cachedMeta?.body,
       media: cachedMeta?.media,
     };

--- a/extensions/whatsapp/src/quoted-message.test.ts
+++ b/extensions/whatsapp/src/quoted-message.test.ts
@@ -106,6 +106,71 @@ describe("quoted message metadata cache", () => {
     });
   });
 
+  it.each([
+    {
+      name: "lookup-proven LID self-chat quote",
+      destinationJid: "15551112222@s.whatsapp.net",
+      requestedJid: "15551112222@s.whatsapp.net",
+      remoteJid: "277038292303944@lid",
+      lookupTargetJid: "15551112222@s.whatsapp.net",
+    },
+    {
+      name: "PN quote routed through its mapped LID",
+      destinationJid: "277038292303944@lid",
+      requestedJid: "15551112222@s.whatsapp.net",
+      remoteJid: "15551112222@s.whatsapp.net",
+      lookupTargetJid: undefined,
+    },
+  ])("keeps $name in the destination conversation", (input) => {
+    const quoteOptions = buildQuotedMessageOptions({
+      messageId: "alias-quote",
+      remoteJid: input.remoteJid,
+      fromMe: true,
+      destinationJid: input.destinationJid,
+      requestedJid: input.requestedJid,
+      lookupTargetJid: input.lookupTargetJid,
+      messageText: "quoted body",
+    });
+    if (!quoteOptions) {
+      throw new Error("expected quote options");
+    }
+
+    const encoded = generateWAMessageFromContent(
+      input.destinationJid,
+      { extendedTextMessage: { text: "reply" } },
+      { ...quoteOptions, userJid: input.requestedJid },
+    );
+
+    expect(quoteOptions.quoted?.key.remoteJid).toBe(input.destinationJid);
+    expect(encoded.message?.extendedTextMessage?.contextInfo?.remoteJid).toBeUndefined();
+  });
+
+  it("preserves unrelated direct and cross-conversation quote JIDs", () => {
+    const quoteOptions = buildQuotedMessageOptions({
+      messageId: "cross-chat-quote",
+      remoteJid: "277038292303944@lid",
+      fromMe: false,
+      destinationJid: "15551112222@s.whatsapp.net",
+      requestedJid: "15551112222@s.whatsapp.net",
+      participant: "19998887777@s.whatsapp.net",
+      messageText: "other chat",
+    });
+    if (!quoteOptions) {
+      throw new Error("expected quote options");
+    }
+
+    const encoded = generateWAMessageFromContent(
+      "15551112222@s.whatsapp.net",
+      { extendedTextMessage: { text: "reply" } },
+      { ...quoteOptions, userJid: "15551112222@s.whatsapp.net" },
+    );
+
+    expect(quoteOptions.quoted?.key.remoteJid).toBe("277038292303944@lid");
+    expect(encoded.message?.extendedTextMessage?.contextInfo?.remoteJid).toBe(
+      "277038292303944@lid",
+    );
+  });
+
   it("renders a cached structured media fact into the quote preview", () => {
     const remoteJid = "15551112222@s.whatsapp.net";
     cacheInboundMessageMeta("account-media", remoteJid, "media-msg-1", {

--- a/extensions/whatsapp/src/quoted-message.ts
+++ b/extensions/whatsapp/src/quoted-message.ts
@@ -1,5 +1,11 @@
 // Whatsapp plugin module implements quoted message behavior.
-import type { MiscMessageGenerationOptions } from "baileys";
+import {
+  isHostedLidUser,
+  isHostedPnUser,
+  isLidUser,
+  isPnUser,
+  type MiscMessageGenerationOptions,
+} from "baileys";
 import {
   formatMediaPlaceholderText,
   type MediaPlaceholderTextFact,
@@ -21,6 +27,17 @@ type QuotedMeta = {
 };
 type CacheEntry = QuotedMeta & { ts: number };
 type QuotedMetaLookup = QuotedMeta & { remoteJid: string };
+
+export type WhatsAppQuotedMessageKey = {
+  id: string;
+  remoteJid: string;
+  fromMe: boolean;
+  participant?: string;
+  /** Target JID against which quote lookup proved the cached conversation equivalent. */
+  lookupTargetJid?: string;
+  messageText?: string;
+  media?: MediaPlaceholderTextFact;
+};
 
 const CACHE_TTL_MS = 10 * 60 * 1000;
 const MAX_ENTRIES = 500;
@@ -166,20 +183,60 @@ export function lookupInboundMessageMetaForTarget(
   return matched;
 }
 
+function resolveQuotedRemoteJid(params: {
+  destinationJid: string | undefined;
+  lookupTargetJid: string | undefined;
+  quotedRemoteJid: string;
+  requestedJid: string | undefined;
+}): string {
+  const destinationJid = params.destinationJid?.trim();
+  const requestedJid = params.requestedJid?.trim();
+  const lookupTargetJid = params.lookupTargetJid?.trim();
+  if (!destinationJid || !requestedJid) {
+    return params.quotedRemoteJid;
+  }
+
+  // Reconcile only a quote tied to this requested conversation. Other JIDs can
+  // intentionally represent status, group, or cross-conversation replies.
+  if (
+    params.quotedRemoteJid !== requestedJid &&
+    (!lookupTargetJid || lookupTargetJid !== requestedJid)
+  ) {
+    return params.quotedRemoteJid;
+  }
+
+  const destinationIsPn = isPnUser(destinationJid) || isHostedPnUser(destinationJid);
+  const destinationIsLid = isLidUser(destinationJid) || isHostedLidUser(destinationJid);
+  const quotedIsPn = isPnUser(params.quotedRemoteJid) || isHostedPnUser(params.quotedRemoteJid);
+  const quotedIsLid = isLidUser(params.quotedRemoteJid) || isHostedLidUser(params.quotedRemoteJid);
+  return (destinationIsPn && quotedIsLid) || (destinationIsLid && quotedIsPn)
+    ? destinationJid
+    : params.quotedRemoteJid;
+}
+
 export function buildQuotedMessageOptions(params: {
   messageId?: string | null;
   remoteJid?: string | null;
   fromMe?: boolean;
   participant?: string;
+  destinationJid?: string;
+  requestedJid?: string;
+  lookupTargetJid?: string;
   /** Original message text — shown in the quote preview bubble. */
   messageText?: string;
   media?: MediaPlaceholderTextFact;
 }): MiscMessageGenerationOptions | undefined {
   const id = params.messageId?.trim();
-  const remoteJid = params.remoteJid?.trim();
-  if (!id || !remoteJid) {
+  const quotedRemoteJid = params.remoteJid?.trim();
+  if (!id || !quotedRemoteJid) {
     return undefined;
   }
+  const remoteJid = resolveQuotedRemoteJid({
+    destinationJid: params.destinationJid,
+    lookupTargetJid: params.lookupTargetJid,
+    quotedRemoteJid,
+    requestedJid: params.requestedJid,
+  });
   const previewText = [
     params.messageText,
     formatMediaPlaceholderText(params.media ? [params.media] : []),

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -30,6 +30,7 @@ import {
   prepareWhatsAppOutboundMedia,
   resolveAdditiveWhatsAppMediaUrls,
 } from "./outbound-media-contract.js";
+import type { WhatsAppQuotedMessageKey } from "./quoted-message.js";
 import { markdownToWhatsAppChunks, toWhatsappJid } from "./text-runtime.js";
 
 const outboundLog = createSubsystemLogger("gateway/channels/whatsapp").child("outbound");
@@ -147,14 +148,7 @@ export async function sendMessageWhatsApp(
     audioAsVoice?: boolean;
     forceDocument?: boolean;
     accountId?: string;
-    quotedMessageKey?: {
-      id: string;
-      remoteJid: string;
-      fromMe: boolean;
-      participant?: string;
-      messageText?: string;
-      media?: import("openclaw/plugin-sdk/channel-inbound").MediaPlaceholderTextFact;
-    };
+    quotedMessageKey?: WhatsAppQuotedMessageKey;
     preserveLeadingWhitespace?: boolean;
     /** Report each accepted internal platform send before the next fallible send. */
     onDeliveryResult?: (result: { messageId: string; toJid: string }) => Promise<void> | void;


### PR DESCRIPTION
Closes #115915

## What Problem This Solves

WhatsApp self-chat replies could be accepted by the Web socket but never render when the cached quoted message used the account's LID JID while the final send destination resolved to its phone-number JID.

## Root Cause And Owner Boundary

Baileys treats a quoted key whose `remoteJid` differs from the outer destination as cross-conversation context and emits `contextInfo.remoteJid`. The inbound quote cache correctly retained the observed LID, while the shared Web send boundary could later resolve the same direct conversation to PN.

The repair keeps alias knowledge at its owner:

- quote lookup records the requested target only when lookup proved that a cached PN/LID message belongs to that conversation;
- the shared Web send boundary compares that proof with the final resolved destination;
- quote construction aligns only opposite PN/LID-family JIDs for that proven conversation;
- group, status, unrelated direct, and cross-conversation quote JIDs remain unchanged.

No broad transport rewrite or unconditional PN policy was added.

## Change Shape

- Base: `27f5691d29378d1db863885ff28b23d2e6381720`
- Exact head: `ade8e2fe31dad9344b7dd75518a89e41dffbd1bd`
- Production LOC: `+73/-28` (net `+45`)
- Tests: `+86/-0`
- Files: 8, all under `extensions/whatsapp/src/`

The positive production delta adds the explicit lookup-proof contract, one canonical quote-key type, and the narrow PN/LID reconciliation boundary. Duplicate quote-key type declarations were removed.

## Evidence

- Node `24.18.0`: 145 tests passed across quote metadata/encoding, outbound adapter, Web send API, channel outbound, payload contract, and shared send behavior.
- Rebased exact-merge suite: 83 tests passed across the three changed WhatsApp test files.
- Signed follow-up `ade8e2fe31d` preserves the current-main `MediaPlaceholderTextFact` import after CI exposed the stale-base integration error.
- The focused encoder tests call Baileys `generateWAMessageFromContent` directly. Proven PN/LID self-chat aliases emit no cross-conversation `contextInfo.remoteJid`; unrelated quote JIDs retain it.
- Direct Baileys source inspection confirmed the dependency behavior: differing outer and quoted JIDs populate quoted `contextInfo.remoteJid`.
- Targeted Node 24 oxlint passed for all changed files.
- `oxfmt --check` and `git diff --check` passed.
- Two bounded autoreview cycles were clean; the final exact-base review reported no actionable findings.
- Secret/personal-data scrub and autoreview TruffleHog scan were clean.

## Remaining Proof And Infrastructure

- Real-device self-chat proof is not attached: the dedicated WhatsApp Convex QA credentials were unavailable from the current 1Password session, and no personal WhatsApp account was used.
- The supported changed-check router could not acquire a Crabbox provider. Its local fallback then requested dependency reconciliation, which is prohibited in this linked Codex worktree; targeted supported wrappers above completed instead.
- The full extension lint wrapper is blocked before touched-file lint by a current-main declaration-artifact error at `packages/terminal-core/src/ansi.ts:194` against the shared install. The same wrapper with artifact preparation skipped passed the changed WhatsApp files.
- Exact-head GitHub checks are running after the force-with-lease update.
