### PR TITLE
fix(daemon): verify service startup and installation outcomes

### DIFF
--- a/src/cli/daemon-cli.coverage.test.ts
+++ b/src/cli/daemon-cli.coverage.test.ts
@@ -296,7 +296,7 @@ describe("daemon-cli coverage", () => {
 
   it("installs the daemon (json output)", async () => {
     runtimeLogs.length = 0;
-    serviceIsLoaded.mockResolvedValueOnce(false);
+    serviceIsLoaded.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     serviceInstall.mockClear();
 
     await runDaemonCommand([
@@ -322,7 +322,7 @@ describe("daemon-cli coverage", () => {
 
   it("passes the existing service environment into the install plan on forced reinstall", async () => {
     runtimeLogs.length = 0;
-    serviceIsLoaded.mockResolvedValueOnce(true);
+    serviceIsLoaded.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
     serviceReadCommand.mockResolvedValueOnce({
       programArguments: ["/bin/node", "cli", "gateway", "--port", "18789"],
       environment: {
@@ -353,7 +353,7 @@ describe("daemon-cli coverage", () => {
 
   it("passes an explicit service wrapper into the install plan", async () => {
     runtimeLogs.length = 0;
-    serviceIsLoaded.mockResolvedValueOnce(false);
+    serviceIsLoaded.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
     await runDaemonCommand([
       "daemon",

--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -174,6 +174,7 @@ describe("runDaemonInstall integration", () => {
       ),
     );
     clearConfigCache();
+    serviceMock.isLoaded.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
     await runDaemonInstall({ json: true });
 

--- a/src/cli/daemon-cli/response.test.ts
+++ b/src/cli/daemon-cli/response.test.ts
@@ -1,7 +1,8 @@
 // Daemon response tests cover normalized daemon command response shapes.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayService } from "../../daemon/service.js";
 import { defaultRuntime } from "../../runtime.js";
-import { createDaemonActionContext } from "./response.js";
+import { createDaemonActionContext, installDaemonServiceAndEmit } from "./response.js";
 
 describe("daemon action JSON hints", () => {
   afterEach(() => {
@@ -48,6 +49,67 @@ describe("daemon action JSON hints", () => {
             text: "WSL2 needs systemd enabled: edit /etc/wsl.conf with [boot]\\nsystemd=true",
           },
         ],
+      }),
+    );
+  });
+});
+
+describe("daemon install verification", () => {
+  function createInstallParams(isLoaded: GatewayService["isLoaded"]) {
+    const service = {
+      label: "systemd user",
+      loadedText: "enabled",
+      notLoadedText: "disabled",
+      isLoaded,
+    } as GatewayService;
+    return {
+      serviceNoun: "Gateway",
+      service,
+      warnings: [],
+      emit: vi.fn(),
+      fail: vi.fn(),
+      install: vi.fn(async () => {}),
+    };
+  }
+
+  it("fails install when service-manager verification throws", async () => {
+    const params = createInstallParams(
+      vi.fn(async () => {
+        throw new Error("manager access denied");
+      }),
+    );
+
+    await installDaemonServiceAndEmit(params);
+
+    expect(params.fail).toHaveBeenCalledWith(
+      "Gateway install verification failed: Error: manager access denied",
+      undefined,
+    );
+    expect(params.emit).not.toHaveBeenCalled();
+  });
+
+  it("fails install when the service is not loaded after installation", async () => {
+    const params = createInstallParams(vi.fn(async () => false));
+
+    await installDaemonServiceAndEmit(params);
+
+    expect(params.fail).toHaveBeenCalledWith(
+      "Gateway install verification failed: service is not enabled.",
+    );
+    expect(params.emit).not.toHaveBeenCalled();
+  });
+
+  it("emits success only after the service-manager verification succeeds", async () => {
+    const params = createInstallParams(vi.fn(async () => true));
+
+    await installDaemonServiceAndEmit(params);
+
+    expect(params.fail).not.toHaveBeenCalled();
+    expect(params.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: true,
+        result: "installed",
+        service: expect.objectContaining({ loaded: true }),
       }),
     );
   });

--- a/src/cli/daemon-cli/response.ts
+++ b/src/cli/daemon-cli/response.ts
@@ -241,11 +241,21 @@ export async function installDaemonServiceAndEmit(params: {
     return;
   }
 
-  let installed;
+  let installed: boolean;
   try {
     installed = await params.service.isLoaded({ env: process.env });
-  } catch {
-    installed = true;
+  } catch (err) {
+    params.fail(
+      `${params.serviceNoun} install verification failed: ${String(err)}`,
+      await buildInstallFailureHints(err),
+    );
+    return;
+  }
+  if (!installed) {
+    params.fail(
+      `${params.serviceNoun} install verification failed: service is not ${params.service.loadedText}.`,
+    );
+    return;
   }
   params.emit({
     ok: true,

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -232,6 +232,69 @@ describe("startGatewayService", () => {
     expect(result.state.running).toBe(true);
   });
 
+  it("reports an explicit post-start process failure instead of claiming success", async () => {
+    const service = createService({
+      readCommand: vi.fn(async () => ({
+        programArguments: ["openclaw", "gateway", "run"],
+      })),
+      isLoaded: vi.fn(async () => true),
+      readRuntime: vi
+        .fn<GatewayService["readRuntime"]>()
+        .mockResolvedValueOnce({ status: "stopped" })
+        .mockResolvedValueOnce({ status: "stopped", lastExitStatus: 78 }),
+    });
+
+    await expect(startGatewayService(service, { env: {}, stdout: process.stdout })).rejects.toThrow(
+      "Service failed to start (exit 78)",
+    );
+    expect(service.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an explicit post-start failed manager state instead of claiming success", async () => {
+    const service = createService({
+      readCommand: vi.fn(async () => ({
+        programArguments: ["openclaw", "gateway", "run"],
+      })),
+      isLoaded: vi.fn(async () => true),
+      readRuntime: vi
+        .fn<GatewayService["readRuntime"]>()
+        .mockResolvedValueOnce({ status: "stopped" })
+        .mockResolvedValueOnce({ status: "stopped", state: "failed" }),
+    });
+
+    await expect(startGatewayService(service, { env: {}, stdout: process.stdout })).rejects.toThrow(
+      "Service failed to start (state failed)",
+    );
+  });
+
+  it("allows asynchronously starting services without terminal failure evidence", async () => {
+    const service = createService({
+      readCommand: vi.fn(async () => ({
+        programArguments: ["openclaw", "gateway", "run"],
+      })),
+      isLoaded: vi.fn(async () => true),
+      readRuntime: vi.fn(async () => ({ status: "stopped" })),
+    });
+
+    await expect(
+      startGatewayService(service, { env: {}, stdout: process.stdout }),
+    ).resolves.toMatchObject({ outcome: "started" });
+  });
+
+  it("does not mistake a previous exit code for a new asynchronous start failure", async () => {
+    const service = createService({
+      readCommand: vi.fn(async () => ({
+        programArguments: ["openclaw", "gateway", "run"],
+      })),
+      isLoaded: vi.fn(async () => true),
+      readRuntime: vi.fn(async () => ({ status: "stopped", lastExitStatus: 78 })),
+    });
+
+    await expect(
+      startGatewayService(service, { env: {}, stdout: process.stdout }),
+    ).resolves.toMatchObject({ outcome: "started" });
+  });
+
   it("returns already-running without starting a loaded running service", async () => {
     const service = createService({
       readCommand: vi.fn(async () => ({

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -234,23 +234,37 @@ export async function startGatewayService(
     };
   }
 
+  let nextState: GatewayServiceState;
   try {
     await service.start({ ...args, env: state.env });
-    const nextState = await readGatewayServiceState(service, { env: state.env });
-    return {
-      outcome: "started",
-      state: nextState,
-    };
+    nextState = await readGatewayServiceState(service, { env: state.env });
   } catch (err) {
-    const nextState = await readGatewayServiceState(service, { env: state.env });
-    if (!nextState.installed) {
+    const recoveryState = await readGatewayServiceState(service, { env: state.env });
+    if (!recoveryState.installed) {
       return {
         outcome: "missing-install",
-        state: nextState,
+        state: recoveryState,
       };
     }
     throw err;
   }
+
+  const runtime = nextState.runtime;
+  const failedState = normalizeLowercaseStringOrEmpty(runtime?.state) === "failed";
+  const newFailedExit =
+    runtime?.status === "stopped" &&
+    typeof runtime.lastExitStatus === "number" &&
+    runtime.lastExitStatus !== 0 &&
+    runtime.lastExitStatus !== state.runtime?.lastExitStatus;
+  if (failedState || newFailedExit) {
+    const failure = failedState ? "state failed" : `exit ${runtime?.lastExitStatus}`;
+    throw new Error(`Service failed to start (${failure}). Check the service logs and retry.`);
+  }
+
+  return {
+    outcome: "started",
+    state: nextState,
+  };
 }
 
 export function describeGatewayServiceRestart(


### PR DESCRIPTION
## Summary

- Reject definitive post-start failures when the shared service owner observes a failed manager state or a newly recorded nonzero process exit.
- Preserve asynchronous startup by accepting ordinary stopped/pending observations and historical exit codes that did not change during the new start attempt.
- Make daemon installation fail when post-install service-manager verification throws or confirms the service is not loaded; preserve existing platform-specific repair hints and successful response shapes.

## Root causes fixed

**2 distinct canonical owner bugs:**

1. Shared `startGatewayService` returned `started` even after its own post-start snapshot contained a definitive failed state or new failing exit.
2. CLI `installDaemonServiceAndEmit` reported a successful installation when verification threw or explicitly returned not loaded.

## Verification

- Immutable local-main parent: `25bb1da3a7314f027c477d8c14d6d95d058fa00d`.
- Branch: `codex/auto-qa-service-verification`.
- Commit: `4d1a40b1e9b373ed0fe513a5a63d621550265d37`.
- Before fixes: **4 authentic owner regressions failed**: explicit failed post-start state, newly observed nonzero post-start exit, thrown install verification, and not-loaded install verification.
- After fixes: **88 tests passed** across `src/daemon/service.test.ts`, `src/cli/daemon-cli/response.test.ts`, `src/cli/daemon-cli/install.test.ts`, and `src/cli/daemon-cli/lifecycle-core.test.ts` on Blacksmith Testbox `tbx_01kyw00y8swq12ckskkt80h798`.
- Remote proof: [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/30628293126); owned lease stopped after validation.
- Independent strict read-only owner/caller/platform-contract review: **CLEAN**, including asynchronous startup, unchanged historical exit status, manager exceptions, actionable hints, existing successful installation responses, and lifecycle callers.
- Structured Codex `gpt-5.6-sol` high-reasoning autoreview: **CLEAN**, correctness confidence **0.94**; approved TruffleHog preflight clean.
- Targeted existing-binary formatting, `git diff --check`, exact immutable parent, and clean committed worktree verified.
- No polling, public flags, configuration/schema, authentication, persistent storage, provider behavior, real service operations, fetch, or push.
