### PR TITLE
fix(whatsapp): preserve interactive selections and media MIME ownership

### DIFF
--- a/extensions/whatsapp/src/inbound/extract.test.ts
+++ b/extensions/whatsapp/src/inbound/extract.test.ts
@@ -1,7 +1,12 @@
 // Whatsapp tests cover extract plugin behavior.
 import type { proto } from "baileys";
 import { describe, expect, it } from "vitest";
-import { describeReplyContext, extractMentionedJids, hasInboundUserContent } from "./extract.js";
+import {
+  describeReplyContext,
+  extractMentionedJids,
+  extractText,
+  hasInboundUserContent,
+} from "./extract.js";
 
 describe("extractMentionedJids", () => {
   const botJid = "5511999999999@s.whatsapp.net";
@@ -150,6 +155,121 @@ describe("describeReplyContext", () => {
         },
       }),
     ).toBeNull();
+  });
+});
+
+describe("extractText", () => {
+  it.each([
+    {
+      name: "button display text",
+      message: {
+        buttonsResponseMessage: { selectedButtonId: "yes", selectedDisplayText: "Yes" },
+      },
+      expected: "Yes",
+    },
+    {
+      name: "button identifier when display text is unavailable",
+      message: { buttonsResponseMessage: { selectedButtonId: "yes" } },
+      expected: "yes",
+    },
+    {
+      name: "button identifier when display text is blank",
+      message: {
+        buttonsResponseMessage: { selectedButtonId: "yes", selectedDisplayText: "   " },
+      },
+      expected: "yes",
+    },
+    {
+      name: "list selection title",
+      message: {
+        listResponseMessage: { title: "Option A", singleSelectReply: { selectedRowId: "a" } },
+      },
+      expected: "Option A",
+    },
+    {
+      name: "list row identifier when its title is unavailable",
+      message: { listResponseMessage: { singleSelectReply: { selectedRowId: "a" } } },
+      expected: "a",
+    },
+    {
+      name: "template button display text",
+      message: {
+        templateButtonReplyMessage: { selectedId: "button-1", selectedDisplayText: "Confirm" },
+      },
+      expected: "Confirm",
+    },
+    {
+      name: "template button identifier when display text is unavailable",
+      message: { templateButtonReplyMessage: { selectedId: "button-1" } },
+      expected: "button-1",
+    },
+    {
+      name: "interactive response body",
+      message: {
+        interactiveResponseMessage: {
+          body: { text: "Continue" },
+          nativeFlowResponseMessage: { name: "single_select", paramsJson: "{}" },
+        },
+      },
+      expected: "Continue",
+    },
+    {
+      name: "native-flow selection title when the interactive body is unavailable",
+      message: {
+        interactiveResponseMessage: {
+          nativeFlowResponseMessage: {
+            name: "single_select",
+            paramsJson: '{"id":"shipping-express","title":"Express shipping"}',
+          },
+        },
+      },
+      expected: "Express shipping",
+    },
+    {
+      name: "native-flow selection identifier when its title is unavailable",
+      message: {
+        interactiveResponseMessage: {
+          nativeFlowResponseMessage: {
+            name: "single_select",
+            paramsJson: '{"id":"shipping-express"}',
+          },
+        },
+      },
+      expected: "shipping-express",
+    },
+    {
+      name: "ephemeral button response",
+      message: {
+        ephemeralMessage: {
+          message: {
+            buttonsResponseMessage: { selectedButtonId: "ok", selectedDisplayText: "OK" },
+          },
+        },
+      },
+      expected: "OK",
+    },
+  ])("preserves $name as inbound message text", ({ message, expected }) => {
+    expect(extractText(message as proto.IMessage)).toBe(expected);
+  });
+
+  it("ignores malformed native-flow response JSON", () => {
+    expect(
+      extractText({
+        interactiveResponseMessage: {
+          nativeFlowResponseMessage: { name: "single_select", paramsJson: "{" },
+        },
+      } as proto.IMessage),
+    ).toBeUndefined();
+  });
+
+  it("ignores non-record native-flow response JSON", () => {
+    expect(
+      extractText({
+        interactiveResponseMessage: {
+          nativeFlowResponseMessage: { name: "single_select", paramsJson: "[]" },
+        },
+      } as proto.IMessage),
+    ).toBeUndefined();
   });
 });
 

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -7,7 +7,7 @@ import {
   type NormalizedLocation,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isRecord, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveComparableIdentity, type WhatsAppReplyContext } from "../identity.js";
 import { jidToE164 } from "../text-runtime.js";
 import { parseVcard } from "../vcard.js";
@@ -136,6 +136,26 @@ export function extractMentionedJids(rawMessage: proto.IMessage | undefined): st
   return uniqueStrings(flattened);
 }
 
+function extractNativeFlowResponseText(
+  response: proto.Message.IInteractiveResponseMessage | null | undefined,
+): string | undefined {
+  const paramsJson = response?.nativeFlowResponseMessage?.paramsJson;
+  if (!paramsJson) {
+    return undefined;
+  }
+  try {
+    const params: unknown = JSON.parse(paramsJson);
+    if (!isRecord(params)) {
+      return undefined;
+    }
+    return [params.title, params.id].find(
+      (value): value is string => typeof value === "string" && Boolean(value.trim()),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 export function extractText(rawMessage: proto.IMessage | undefined): string | undefined {
   const message = unwrapMessage(rawMessage);
   if (!message) {
@@ -160,6 +180,19 @@ export function extractText(rawMessage: proto.IMessage | undefined): string | un
       candidate.documentMessage?.caption;
     if (caption?.trim()) {
       return caption.trim();
+    }
+    const interactiveSelection = [
+      candidate.buttonsResponseMessage?.selectedDisplayText,
+      candidate.buttonsResponseMessage?.selectedButtonId,
+      candidate.listResponseMessage?.title,
+      candidate.listResponseMessage?.singleSelectReply?.selectedRowId,
+      candidate.templateButtonReplyMessage?.selectedDisplayText,
+      candidate.templateButtonReplyMessage?.selectedId,
+      candidate.interactiveResponseMessage?.body?.text,
+      extractNativeFlowResponseText(candidate.interactiveResponseMessage),
+    ].find((value) => Boolean(value?.trim()));
+    if (interactiveSelection) {
+      return interactiveSelection.trim();
     }
   }
   const contactPlaceholder =

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { AnyMessageContent, MiscMessageGenerationOptions, WAMessage } from "baileys";
 import { listMessageReceiptPlatformIds } from "openclaw/plugin-sdk/channel-outbound";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { prepareWhatsAppOutboundMedia } from "../outbound-media-contract.js";
 import { resolveWhatsAppOutboundMentions } from "./outbound-mentions.js";
 import { createWebSendApi } from "./send-api.js";
 import type { WhatsAppSendResult } from "./send-result.js";
@@ -328,6 +329,25 @@ describe("createWebSendApi", () => {
       mimetype: "image/jpeg",
     });
   });
+
+  it.each([
+    { kind: "image", contentType: " Image/PNG; charset=binary ", mimetype: "image/png" },
+    { kind: "video", contentType: " Video/MP4; charset=binary ", mimetype: "video/mp4" },
+  ])(
+    "preserves the native $kind payload after canonicalizing mixed-case media MIME",
+    async ({ kind, contentType, mimetype }) => {
+      const payload = Buffer.from(kind);
+      const media = await prepareWhatsAppOutboundMedia({ buffer: payload, contentType });
+
+      await api.sendMessage("+1555", "cap", media.buffer, media.mimetype);
+
+      expectSendContentFields(0, {
+        [kind]: payload,
+        caption: "cap",
+        mimetype,
+      });
+    },
+  );
 
   it("prepopulates image thumbnails and dimensions before Baileys media upload", async () => {
     const payload = Buffer.from("img");

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -152,8 +152,8 @@ function normalizeWhatsAppLoadedMedia(
   const normalizedContentType = normalizeMimeType(media.contentType);
   const resolvedContentType =
     !normalizedContentType || normalizedContentType === "application/octet-stream"
-      ? (filenameMimeType ?? media.contentType)
-      : media.contentType;
+      ? (filenameMimeType ?? normalizedContentType)
+      : normalizedContentType;
   const kind = inferWhatsAppMediaKind(media, resolvedContentType);
   // Match the existing URL/filename voice rule used by the transcode decision;
   // otherwise native .ogg/.opus uploads carry an inconsistent payload MIME.

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -409,7 +409,7 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenNthCalledWith(2, "+1555", "voice note", undefined, undefined);
   });
 
-  it("normalizes MIME parameters when inferring media kind", async () => {
+  it("normalizes MIME parameters before handing media to the socket transport", async () => {
     const buf = Buffer.from("image");
     loadWebMediaMock.mockResolvedValueOnce({
       buffer: buf,
@@ -422,12 +422,7 @@ describe("web outbound", () => {
       mediaUrl: "/tmp/image.png",
     });
 
-    expect(sendMessage).toHaveBeenLastCalledWith(
-      "+1555",
-      "caption",
-      buf,
-      " Image/PNG; charset=binary ",
-    );
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "caption", buf, "image/png");
   });
 
   it("reports the accepted voice send before a caption failure", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes two independently reproducible WhatsApp delivery defects:

1. Existing inbound admission accepts button, list, template-button, and native-flow interactive responses, but text extraction ignores their selected display text, title, or identifier. Responses without media are subsequently discarded, so an operator receives no agent reply.
2. Mixed-case or parameterized image/video MIME types are classified correctly during media preparation but forwarded in their original noncanonical form. The socket transport uses case-sensitive native image/video checks, so those attachments are incorrectly sent as documents.

## Why This Change Was Made

Keep both repairs within their existing WhatsApp owners. Extract admitted interactive selections from their documented Baileys response fields, unwrap ephemeral envelopes, prefer user-visible display text or titles before identifiers, and safely parse body-less native-flow JSON. Normalize MIME once in the canonical outbound media owner before native image/video payload selection.

Existing admission, authorization, document forcing, filename inference, audio transcoding, Opus voice notes, and public plugin surfaces remain unchanged.

## User Impact

Buttons, list entries, template buttons, and body-less native-flow selections now reach agents as meaningful inbound text. Parameterized or mixed-case image/video attachments remain native WhatsApp images/videos instead of unexpectedly appearing as documents.

## Evidence

- Branch: `codex/auto-qa-whatsapp-round2`.
- Exact candidate SHA: `c7c3d05b2bc85ed5eb4e0d247c14a2181dfbed67`.
- Immutable reviewed parent: `718e9c88204772c496e8f625cd63be8106cfa106`.
- Actual immutable-parent RED: admitted button/list/template responses produced no extracted text; mixed-case image media reached the socket as a document instead of an image.
- Final Blacksmith Testbox `tbx_01kyvz8mcf02tkh90b46j8vmxa`: **125 tests passed across all three complete changed owner suites**:

  ```text
  pnpm test extensions/whatsapp/src/inbound/extract.test.ts \
    extensions/whatsapp/src/inbound/send-api.test.ts \
    extensions/whatsapp/src/send.test.ts
  ```

  Breakdown: **45 extraction**, **40 socket-boundary**, and **40 outbound-send** tests. Native image and native video are each verified at the actual Baileys socket payload boundary. A pre-existing unrelated logging-write race appeared once and passed on an unchanged full-suite rerun.
- Fresh strict read-only whole-owner/dependency review: **CLEAN**; no files, processes, or remote leases were modified by that reviewer.
- Final structured Codex autoreview: **CLEAN**, correctness confidence **0.93**; genuine TruffleHog **3.96.0** secret scan clean.
- Direct installed contracts checked: Baileys interactive-response protobuf fields and native image/video discriminated payloads; shared media-core MIME normalization; existing audio/document sibling behavior.
- Blacksmith lease stopped after proof; committed worktree and `git diff --check` are clean.

## Root Causes Fixed

**2 distinct transport-owner roots:**

1. WhatsApp interactive inbound selections were admitted but omitted by text extraction before enrichment.
2. WhatsApp outbound media MIME was used for inference but not canonicalized before case-sensitive native payload selection.

## Authorized Scope And Non-Goals

Bounded WhatsApp transport-owner correctness only. No admission/authentication changes, persistent state, config or database schema, provider routes, public APIs, or unrelated channel behavior.
