### PR TITLE
fix(skills): enforce canonical ownership, prompt bounds, and tool visibility

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -126,7 +126,7 @@ describe("buildAgentSystemPrompt", () => {
       skillsPrompt:
         "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
       heartbeatPrompt: "ping",
-      toolNames: ["message", "memory_search"],
+      toolNames: ["message", "memory_search", "read"],
       docsPath: "/tmp/openclaw/docs",
       extraSystemPrompt: "Subagent details",
       ttsHint: "Voice (TTS) is enabled.",
@@ -215,6 +215,7 @@ describe("buildAgentSystemPrompt", () => {
       workspaceDir: "/tmp/openclaw",
       promptMode: "minimal",
       skillsPrompt,
+      toolNames: ["read"],
     });
 
     expect(prompt).toContain("## Skills");
@@ -839,6 +840,7 @@ describe("buildAgentSystemPrompt", () => {
   it("includes skills guidance when skills prompt is present", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      toolNames: ["read"],
       skillsPrompt:
         "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
     });
@@ -852,10 +854,43 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Several: most specific");
   });
 
+  it("omits skills guidance when the actual visible tools cannot read skill instructions", () => {
+    const skillsPrompt =
+      "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>";
+
+    for (const toolNames of [[], ["message"], ["tool_search"]]) {
+      const prompt = buildAgentSystemPrompt({
+        workspaceDir: "/tmp/openclaw",
+        toolNames,
+        capabilityToolNames: ["read"],
+        skillsPrompt,
+      });
+
+      expect(prompt).not.toContain("## Skills");
+      expect(prompt).not.toContain("<available_skills>");
+      expect(prompt).not.toContain("read exact <location>");
+    }
+  });
+
+  it("keeps CLI-backend skill guidance when file tools are owned by the external harness", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptSurface: "cli_backend",
+      toolNames: [],
+      skillsPrompt:
+        "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
+    });
+
+    expect(prompt).toContain("## Skills");
+    expect(prompt).toContain("<name>demo</name>");
+    expect(prompt).toContain("read exact <location>");
+  });
+
   it("switches skills access guidance under code mode", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
       codeModeActive: true,
+      toolNames: ["exec"],
       skillsPrompt:
         "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
     });
@@ -864,6 +899,19 @@ describe("buildAgentSystemPrompt", () => {
       'Scan <available_skills>. Clear match: use `skills.read("<name>")` inside `exec`; obey.',
     );
     expect(prompt).not.toContain("read exact <location> with `read`");
+  });
+
+  it("omits code-mode skill guidance when the actual exec tool is unavailable", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      codeModeActive: true,
+      toolNames: ["message"],
+      skillsPrompt:
+        "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
+    });
+
+    expect(prompt).not.toContain("## Skills");
+    expect(prompt).not.toContain("skills.read");
   });
 
   it("instructs models to use skill_workshop only when the tool is available", () => {
@@ -896,6 +944,7 @@ describe("buildAgentSystemPrompt", () => {
   it("appends available skills when provided", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      toolNames: ["read"],
       skillsPrompt:
         "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
     });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1070,11 +1070,18 @@ export function buildAgentSystemPrompt(params: {
     "Never copy self or change prompts/safety/tool policy unless user explicitly requests.",
     "",
   ];
-  const skillsSection = buildSkillsSection({
-    skillsPrompt,
-    readToolName,
-    codeModeActive: params.codeModeActive,
-  });
+  // CLI backends own native file tools outside OpenClaw's projected tool list.
+  // Keep their skill catalog visible while embedded runs require a real read tool.
+  const canAccessSkills = params.codeModeActive
+    ? visibleTools.has("exec")
+    : visibleTools.has("read") || promptSurface === "cli_backend";
+  const skillsSection = canAccessSkills
+    ? buildSkillsSection({
+        skillsPrompt,
+        readToolName,
+        codeModeActive: params.codeModeActive,
+      })
+    : [];
   const skillWorkshopSection = availableTools.has(SKILL_WORKSHOP_TOOL_NAME)
     ? buildSkillWorkshopPromptSection()
     : [];

--- a/src/skills/discovery/agent-filter.ts
+++ b/src/skills/discovery/agent-filter.ts
@@ -45,9 +45,10 @@ export function isSessionSkillEnabled(
   skillName: string,
   baseFilter: readonly string[] | undefined,
   overrides: Readonly<Record<string, boolean>> | undefined,
+  skillKey = skillName,
 ): boolean {
   const override =
-    overrides && Object.hasOwn(overrides, skillName) ? overrides[skillName] : undefined;
+    overrides && Object.hasOwn(overrides, skillKey) ? overrides[skillKey] : undefined;
   const baseAllows = baseFilter === undefined || baseFilter.includes(skillName);
   return override === true || (baseAllows && override !== false);
 }

--- a/src/skills/discovery/filter.test.ts
+++ b/src/skills/discovery/filter.test.ts
@@ -6,6 +6,7 @@ import { matchesSkillFilter, normalizeSkillFilter } from "./filter.js";
 const sessionSkillCases: Array<{
   name: string;
   skill: string;
+  skillKey?: string;
   base: string[];
   overrides?: Record<string, boolean>;
   expected: boolean;
@@ -30,6 +31,14 @@ const sessionSkillCases: Array<{
     base: ["github"],
     expected: true,
   },
+  {
+    name: "applies canonical skill-key overrides without changing name-based agent filters",
+    skill: "friendly-skill-name",
+    skillKey: "canonical-skill-key",
+    base: ["friendly-skill-name"],
+    overrides: { "canonical-skill-key": false },
+    expected: false,
+  },
 ];
 
 describe("skills/filter", () => {
@@ -53,7 +62,7 @@ describe("skills/filter", () => {
     expect(matchesSkillFilter([], undefined)).toBe(false);
   });
 
-  it.each(sessionSkillCases)("$name", ({ skill, base, overrides, expected }) => {
-    expect(isSessionSkillEnabled(skill, base, overrides)).toBe(expected);
+  it.each(sessionSkillCases)("$name", ({ skill, skillKey, base, overrides, expected }) => {
+    expect(isSessionSkillEnabled(skill, base, overrides, skillKey)).toBe(expected);
   });
 });

--- a/src/skills/loading/compact-format.test.ts
+++ b/src/skills/loading/compact-format.test.ts
@@ -266,9 +266,42 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     const skills = [makeSkill("only-one", "desc")];
     // Budget so small that even one compact skill can't fit
     const prompt = buildPrompt(skills, { maxChars: 10 });
-    expect(prompt).not.toContain("only-one");
-    const [included] = requireIncludedCounts(prompt);
-    expect(included).toBe(0);
+    expect(prompt).toBe("");
+    expect(prompt.length).toBeLessThanOrEqual(10);
+  });
+
+  it.each([0, 1, 10, 64])("never exceeds a tiny configured prompt budget of %i", (maxChars) => {
+    const prompt = buildPrompt([makeSkill("only-one", "desc")], { maxChars });
+
+    expect(prompt.length).toBeLessThanOrEqual(maxChars);
+    expect(prompt).toBe("");
+  });
+
+  it("drops an oversized optional remote note before discarding a complete fitting skill catalog", () => {
+    const skill = makeSkill("weather", "Get weather data");
+    const maxChars = formatSkillsForPrompt([skill]).length;
+    const remoteNote = `REMOTE_NOTE_${"x".repeat(maxChars + 512)}`;
+    const prompt = buildWorkspaceSkillsPrompt("/fake", {
+      entries: [makeEntry(skill)],
+      config: {
+        skills: {
+          limits: { maxSkillsPromptChars: maxChars },
+        },
+      } satisfies OpenClawConfig,
+      eligibility: {
+        remote: {
+          platforms: [],
+          hasBin: () => false,
+          hasAnyBin: () => false,
+          note: remoteNote,
+        },
+      },
+    });
+
+    expect(prompt.length).toBeLessThanOrEqual(maxChars);
+    expect(prompt).toContain("<name>weather</name>");
+    expect(prompt).toContain("</available_skills>");
+    expect(prompt).not.toContain("REMOTE_NOTE_");
   });
 
   it("budgets the final rendered prompt including versions and limit notices", () => {

--- a/src/skills/loading/workspace-precedence.test.ts
+++ b/src/skills/loading/workspace-precedence.test.ts
@@ -175,4 +175,23 @@ describe("buildWorkspaceSkillsPrompt", () => {
     );
     expect(prompt).not.toContain("alias-skill");
   });
+
+  it("uses the canonical skillKey for session overrides while filtering agents by skill name", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("workspace");
+    const prompt = withEnv({ HOME: workspaceDir, PATH: "" }, () =>
+      buildWorkspaceSkillsPrompt(workspaceDir, {
+        entries: [
+          createSkillEntry({
+            name: "alias-skill",
+            metadata: { skillKey: "canonical-alias" },
+          }),
+        ],
+        managedSkillsDir: path.join(workspaceDir, ".managed"),
+        skillFilter: ["alias-skill"],
+        skillOverrides: { "canonical-alias": false },
+      }),
+    );
+
+    expect(prompt).not.toContain("alias-skill");
+  });
 });

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -215,7 +215,12 @@ function filterSkillEntries(
     skillsLogger.debug(`Applying skill filter: ${label}`);
     const resolvedFilter = skillFilter === undefined ? undefined : normalized;
     filtered = filtered.filter((entry) =>
-      isSessionSkillEnabled(entry.skill.name, resolvedFilter, skillOverrides),
+      isSessionSkillEnabled(
+        entry.skill.name,
+        resolvedFilter,
+        skillOverrides,
+        resolveSkillKey(entry.skill, entry),
+      ),
     );
     skillsLogger.debug(
       `After skill filter: ${filtered.map((entry) => entry.skill.name).join(", ") || "(none)"}`,
@@ -1416,16 +1421,20 @@ function buildRenderedSkillsPrompt(params: {
   skills: Skill[];
   total: number;
   format: SkillsPromptFormat;
+  includeLimitNote?: boolean;
 }): string {
   // resolveCodeModeSkills in src/agents/code-mode-skills.ts parses this exact format; update both together.
   // The production-renderer parity test in src/agents/code-mode.test.ts enforces this coupling.
   const truncated = params.skills.length < params.total;
-  const limitNote = buildSkillsLimitNote({
-    truncated,
-    format: params.format,
-    included: params.skills.length,
-    total: params.total,
-  });
+  const limitNote =
+    params.includeLimitNote === false
+      ? ""
+      : buildSkillsLimitNote({
+          truncated,
+          format: params.format,
+          included: params.skills.length,
+          total: params.total,
+        });
   const catalog =
     params.format.kind === "compact"
       ? formatSkillsCompact(params.skills, {
@@ -1440,31 +1449,45 @@ function applySkillsPromptLimits(params: {
   config?: OpenClawConfig;
   agentId?: string;
   remoteNote?: string;
-}): {
-  skillsForPrompt: Skill[];
-  format: SkillsPromptFormat;
-} {
+}): string {
   const limits = resolveSkillsLimits(params.config, params.agentId);
   const total = params.skills.length;
   const byCount = params.skills.slice(0, Math.max(0, limits.maxSkillsInPrompt));
 
   let skillsForPrompt = byCount;
 
-  const fitsFull = (skills: Skill[]): boolean =>
-    buildRenderedSkillsPrompt({
-      remoteNote: params.remoteNote,
-      skills,
-      total,
-      format: { kind: "full" },
-    }).length <= limits.maxSkillsPromptChars;
+  const renderWithinLimit = (
+    skills: Skill[],
+    format: SkillsPromptFormat,
+    includeLimitNote = true,
+  ): string | undefined => {
+    // Optional context must disappear whole; clipping it could corrupt skill guidance or XML.
+    const remoteNotes = params.remoteNote ? [params.remoteNote, undefined] : [undefined];
+    for (const remoteNote of remoteNotes) {
+      const prompt = buildRenderedSkillsPrompt({
+        remoteNote,
+        skills,
+        total,
+        format,
+        includeLimitNote,
+      });
+      if (prompt.length <= limits.maxSkillsPromptChars) {
+        return prompt;
+      }
+    }
+    return undefined;
+  };
 
-  const fitsCompact = (skills: Skill[], descriptionMaxChars: number): boolean =>
-    buildRenderedSkillsPrompt({
-      remoteNote: params.remoteNote,
-      skills,
-      total,
-      format: { kind: "compact", descriptionMaxChars },
-    }).length <= limits.maxSkillsPromptChars;
+  const fitsFull = (skills: Skill[], includeLimitNote = true): boolean =>
+    renderWithinLimit(skills, { kind: "full" }, includeLimitNote) !== undefined;
+
+  const fitsCompact = (
+    skills: Skill[],
+    descriptionMaxChars: number,
+    includeLimitNote = true,
+  ): boolean =>
+    renderWithinLimit(skills, { kind: "compact", descriptionMaxChars }, includeLimitNote) !==
+    undefined;
 
   if (!fitsFull(skillsForPrompt)) {
     // Identity coverage takes priority over descriptions. Find the same largest
@@ -1484,13 +1507,39 @@ function applySkillsPromptLimits(params: {
       skillsForPrompt = skillsForPrompt.slice(0, lo);
     }
 
+    if (skillsForPrompt.length === 0 && byCount.length > 0) {
+      // Keep complete skill instructions ahead of a notice when only one can fit.
+      const fullWithoutNotice = renderWithinLimit(byCount, { kind: "full" }, false);
+      if (fullWithoutNotice !== undefined) {
+        return fullWithoutNotice;
+      }
+
+      let lo = 0;
+      let hi = byCount.length;
+      while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        if (fitsCompact(byCount.slice(0, mid), 0, false)) {
+          lo = mid;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      if (lo > 0) {
+        skillsForPrompt = byCount.slice(0, lo);
+      }
+    }
+
+    const includeLimitNote = fitsCompact(skillsForPrompt, 0);
     let descriptionMaxChars = 0;
-    if (skillsForPrompt.length > 0 && fitsCompact(skillsForPrompt, COMPACT_DESCRIPTION_MIN_CHARS)) {
+    if (
+      skillsForPrompt.length > 0 &&
+      fitsCompact(skillsForPrompt, COMPACT_DESCRIPTION_MIN_CHARS, includeLimitNote)
+    ) {
       let lo = COMPACT_DESCRIPTION_MIN_CHARS;
       let hi = COMPACT_DESCRIPTION_MAX_CHARS;
       while (lo < hi) {
         const mid = Math.ceil((lo + hi) / 2);
-        if (fitsCompact(skillsForPrompt, mid)) {
+        if (fitsCompact(skillsForPrompt, mid, includeLimitNote)) {
           lo = mid;
         } else {
           hi = mid - 1;
@@ -1498,10 +1547,16 @@ function applySkillsPromptLimits(params: {
       }
       descriptionMaxChars = lo;
     }
-    return { skillsForPrompt, format: { kind: "compact", descriptionMaxChars } };
+    return (
+      renderWithinLimit(
+        skillsForPrompt,
+        { kind: "compact", descriptionMaxChars },
+        includeLimitNote,
+      ) ?? ""
+    );
   }
 
-  return { skillsForPrompt, format: { kind: "full" } };
+  return renderWithinLimit(skillsForPrompt, { kind: "full" }) ?? "";
 }
 
 export function buildWorkspaceSkillSnapshot(
@@ -1596,17 +1651,11 @@ function resolveWorkspaceSkillPromptState(
   const promptSkills = compactSkillPaths(resolvedSkills).toSorted((a, b) =>
     a.name.localeCompare(b.name, "en"),
   );
-  const { skillsForPrompt, format } = applySkillsPromptLimits({
+  const prompt = applySkillsPromptLimits({
     skills: promptSkills,
     config: opts?.config,
     agentId: opts?.agentId,
     remoteNote,
-  });
-  const prompt = buildRenderedSkillsPrompt({
-    remoteNote,
-    skills: skillsForPrompt,
-    total: resolvedSkills.length,
-    format,
   });
   return { eligible, prompt, resolvedSkills };
 }


### PR DESCRIPTION
## Summary

- Honor session skill overrides by canonical metadata `skillKey` while preserving existing skill-name-based agent allowlists.
- Enforce the configured character budget on the entire rendered skills prompt, including zero/tiny limits and oversized remote notes, without truncating complete skill guidance or catalog XML.
- Show skills instructions only when the model actually has a visible `read` tool, or a visible `exec` tool under Code Mode.

## Root causes fixed

**3 distinct owner defects:**

1. Session overrides were stored under canonical skill keys but applied using display names.
2. Oversized warning/remote-note blocks escaped the final prompt character cap after the skill catalog was reduced.
3. System prompts advertised skill-reading capabilities even when tool policy removed the actual readable tool.

The separate globally disabled-skill override precedence and slash-command authorization questions remain explicitly unchanged.

## Red-to-green evidence

- Canonical-key owner regression: `expected false`, received `true` before the fix.
- Prompt-budget owner regressions: six failures, including a 114-character warning for budgets of 0, 1, 10, and 64, plus a 1,242-character remote-note prompt for a 603-character budget.
- Actual remote system-prompt regression: an unavailable-read session still included `## Skills` and instructed the model to call `read`.
- Final focused proof: **149 tests passed** across `src/skills/discovery/filter.test.ts`, `src/skills/loading/compact-format.test.ts`, `src/skills/loading/workspace-precedence.test.ts`, and `src/agents/system-prompt.test.ts` (**116 + 33** across the two owner shards).

## Full changed-file proof

The following exact scoped gate passed on trusted Blacksmith Testbox `tbx_01kyvza9570egzy6qm7z5dh98h`:

```sh
OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 \
OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_MAX_WORKERS=1 \
pnpm check:changed -- \
  src/agents/system-prompt.ts \
  src/agents/system-prompt.test.ts \
  src/skills/discovery/agent-filter.ts \
  src/skills/discovery/filter.test.ts \
  src/skills/loading/workspace.ts \
  src/skills/loading/compact-format.test.ts \
  src/skills/loading/workspace-precedence.test.ts
```

- Result: **exit 0** after **314.665 seconds**; both core and core-test TypeScript lanes, changed-file lint, formatting, ownership/import-cycle checks, database-first guards, and repository policy guards passed.
- Focused remote test command:

```sh
OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 \
OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_MAX_WORKERS=1 \
pnpm test \
  src/skills/discovery/filter.test.ts \
  src/skills/loading/compact-format.test.ts \
  src/skills/loading/workspace-precedence.test.ts \
  src/agents/system-prompt.test.ts \
  --reporter=dot
```

- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/30627559437. The lease was stopped after verification.
- Existing-binary `oxfmt --check`, `git diff --check`, and clean committed-worktree checks passed.
- Real **TruffleHog 3.96.0** secret scan: clean.
- Structured isolated Codex autoreview (`gpt-5.6-sol`, high reasoning): **CLEAN**, zero actionable findings, confidence **0.94**.
- Separate strict read-only whole-owner review: **CLEAN**, zero actionable correctness or compatibility findings.

## Candidate

- Branch: `codex/qa100-skills-owner-invariants`.
- Commit: `5bb11ef8ee0e61845d930c328a734a7ff2416ebc`.
- Immutable parent: `95df2dfd6a61c8fc2edd62fd993694ade0cb1160`.
- No push, public configuration/schema changes, fetch, or shared-main mutations.
