### PR TITLE
fix(telegram): preserve edit previews, message cache, and group history

### DIFF
--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -136,6 +136,8 @@ export async function recordOutboundMessageForPromptContext(params: {
   successfulSendThread?: TelegramThreadSpec;
   promptContextTimestampMs?: number;
   promptContextProjection?: TelegramPromptContextProjection;
+  /** Edits refresh an existing cache entry without inserting another self-history turn. */
+  recordGroupHistory?: boolean;
 }): Promise<boolean> {
   try {
     const providerGeneralTopicId =
@@ -169,14 +171,16 @@ export async function recordOutboundMessageForPromptContext(params: {
       ...(providerObservedThreadId !== undefined ? { providerObservedThreadId } : {}),
       ...(messageThreadId !== undefined ? { threadId: messageThreadId } : {}),
     });
-    const timestamp = resolveOutboundCacheMessageTimestamp(cacheMessage);
-    outboundGroupHistoryRecorders.get(params.account.accountId)?.({
-      chatId: params.chatId,
-      messageId: params.messageId,
-      text: params.text ?? cacheMessage.text ?? cacheMessage.caption,
-      ...(messageThreadId !== undefined ? { messageThreadId } : {}),
-      ...(timestamp !== undefined ? { timestamp } : {}),
-    });
+    if (params.recordGroupHistory !== false) {
+      const timestamp = resolveOutboundCacheMessageTimestamp(cacheMessage);
+      outboundGroupHistoryRecorders.get(params.account.accountId)?.({
+        chatId: params.chatId,
+        messageId: params.messageId,
+        text: params.text ?? cacheMessage.text ?? cacheMessage.caption,
+        ...(messageThreadId !== undefined ? { messageThreadId } : {}),
+        ...(timestamp !== undefined ? { timestamp } : {}),
+      });
+    }
     return true;
   } catch (error) {
     logVerbose(`telegram: failed to record outbound message context: ${String(error)}`);

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -2,6 +2,7 @@ import type { Bot } from "grammy";
 import type {
   ForceReply,
   InlineKeyboardMarkup,
+  LinkPreviewOptions,
   Message,
   ReplyKeyboardMarkup,
   ReplyKeyboardRemove,
@@ -82,6 +83,7 @@ export type TelegramEditRichMessageTextParams = {
   message_id?: number;
   inline_message_id?: string;
   rich_message: TelegramInputRichMessage;
+  link_preview_options?: LinkPreviewOptions;
   reply_markup?: InlineKeyboardMarkup;
 };
 

--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -325,6 +325,7 @@ async function editMessageTelegramWithContext(
       chatId,
       message: editedMessage,
       messageId: editedMessage.message_id,
+      recordGroupHistory: false,
       ...(botUserId !== undefined ? { botUserId } : {}),
       ...(editedMessage.message_thread_id !== undefined
         ? { messageThreadId: editedMessage.message_thread_id }

--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -5,6 +5,10 @@ import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./forma
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 import { isRecoverableTelegramNetworkError, isTelegramServerError } from "./network-errors.js";
 import {
+  recordOutboundMessageForPromptContext,
+  type TelegramOutboundPromptContextMessage,
+} from "./outbound-message-context.js";
+import {
   buildTelegramRichMarkdownPlan,
   getTelegramRichRawApi,
   type TelegramEditRichMessageTextParams,
@@ -26,6 +30,7 @@ import {
 import { prepareTelegramOutbound } from "./send-outbound.js";
 import type { OpenClawConfig } from "./send.runtime.js";
 import { resolveMarkdownTableMode } from "./send.runtime.js";
+import { resolveTelegramBotUserIdFromToken } from "./token.js";
 
 type TelegramEditMessageTextParams = Parameters<TelegramApiContext["api"]["editMessageText"]>[3];
 type TelegramEditMessageCaptionParams = Parameters<
@@ -148,6 +153,7 @@ async function editMessageTelegramWithContext(
   ) => request(fn, label, shouldLog ? { shouldLog } : undefined);
 
   const textMode = opts.textMode ?? "markdown";
+  const linkPreviewEnabled = opts.linkPreview ?? account.config.linkPreview ?? true;
   // Caller-authored HTML edits keep legacy parse_mode HTML semantics too.
   const useRichMessages = account.config.richMessages === true && textMode !== "html";
   const tableMode = resolveMarkdownTableMode({
@@ -161,7 +167,7 @@ async function editMessageTelegramWithContext(
   const richRawApi = useRichMessages ? getTelegramRichRawApi(api) : undefined;
   const richMessagePlan = useRichMessages
     ? buildTelegramRichMarkdownPlan(text, {
-        skipEntityDetection: opts.linkPreview === false,
+        skipEntityDetection: !linkPreviewEnabled,
         tableMode,
       })
     : undefined;
@@ -177,14 +183,14 @@ async function editMessageTelegramWithContext(
   const textEditParams: TelegramEditMessageTextParams = {
     parse_mode: "HTML",
   };
-  if (opts.linkPreview === false) {
+  if (!linkPreviewEnabled) {
     textEditParams.link_preview_options = { is_disabled: true };
   }
   if (replyMarkup !== undefined) {
     textEditParams.reply_markup = replyMarkup;
   }
   const plainTextParams: TelegramEditMessageTextParams = {};
-  if (opts.linkPreview === false) {
+  if (!linkPreviewEnabled) {
     plainTextParams.link_preview_options = { is_disabled: true };
   }
   if (replyMarkup !== undefined) {
@@ -206,8 +212,13 @@ async function editMessageTelegramWithContext(
 
   const performTextEdit = () => {
     if (richRawApi && richMessagePlan) {
-      const richEditParams: Pick<TelegramEditRichMessageTextParams, "reply_markup"> =
-        replyMarkup === undefined ? {} : { reply_markup: replyMarkup };
+      const richEditParams: Pick<
+        TelegramEditRichMessageTextParams,
+        "link_preview_options" | "reply_markup"
+      > = {
+        ...(linkPreviewEnabled ? {} : { link_preview_options: { is_disabled: true } }),
+        ...(replyMarkup === undefined ? {} : { reply_markup: replyMarkup }),
+      };
       warnTelegramRichBlocksDegradations({
         context: "editMessage",
         reasons: richMessagePlan.degradationReasons,
@@ -282,16 +293,17 @@ async function editMessageTelegramWithContext(
         ),
     });
 
+  let editedMessage: TelegramOutboundPromptContextMessage | true | undefined;
   try {
     const editMode = opts.editMode ?? "text";
     if (editMode === "caption") {
-      await performCaptionEdit();
+      editedMessage = await performCaptionEdit();
     } else {
       try {
-        await performTextEdit();
+        editedMessage = await performTextEdit();
       } catch (err) {
         if (editMode === "auto" && isTelegramMessageHasNoTextError(err)) {
-          await performCaptionEdit();
+          editedMessage = await performCaptionEdit();
         } else {
           throw err;
         }
@@ -303,6 +315,21 @@ async function editMessageTelegramWithContext(
     } else {
       throw err;
     }
+  }
+
+  if (editedMessage && editedMessage !== true && typeof editedMessage.message_id === "number") {
+    const botUserId = resolveTelegramBotUserIdFromToken(opts.token || account.token);
+    await recordOutboundMessageForPromptContext({
+      cfg,
+      account,
+      chatId,
+      message: editedMessage,
+      messageId: editedMessage.message_id,
+      ...(botUserId !== undefined ? { botUserId } : {}),
+      ...(editedMessage.message_thread_id !== undefined
+        ? { messageThreadId: editedMessage.message_thread_id }
+        : {}),
+    });
   }
 
   logVerbose(`[telegram] Edited message ${messageId} in chat ${chatId}`);

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -4583,6 +4583,120 @@ describe("editMessageTelegram", () => {
     );
     expect(botRawApi.editMessageText).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      name: "inherits the disabled account default",
+      accountLinkPreview: false,
+      linkPreview: undefined,
+      expectedDisabled: true,
+    },
+    {
+      name: "lets an explicit enabled value override the account default",
+      accountLinkPreview: false,
+      linkPreview: true,
+      expectedDisabled: false,
+    },
+    {
+      name: "lets an explicit disabled value override the account default",
+      accountLinkPreview: true,
+      linkPreview: false,
+      expectedDisabled: true,
+    },
+  ])("$name for edited Telegram messages", async (testCase) => {
+    botApi.editMessageText.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "https://example.com", {
+      token: "tok",
+      cfg: { channels: { telegram: { linkPreview: testCase.accountLinkPreview } } },
+      ...(testCase.linkPreview !== undefined ? { linkPreview: testCase.linkPreview } : {}),
+    });
+
+    const params = requireRecord(
+      firstMockCall(botApi.editMessageText, "editMessageText preview call")[3],
+      "edited Telegram preview params",
+    );
+    if (testCase.expectedDisabled) {
+      expect(params.link_preview_options).toEqual({ is_disabled: true });
+    } else {
+      expect(params).not.toHaveProperty("link_preview_options");
+    }
+  });
+
+  it("preserves disabled previews when editing rich Telegram messages", async () => {
+    botRawApi.editMessageText.mockResolvedValue({
+      message_id: 1,
+      chat: { id: "123", type: "private" },
+      text: "https://example.com",
+    });
+
+    await editMessageTelegram("123", 1, "https://example.com", {
+      token: "tok",
+      cfg: { channels: { telegram: { richMessages: true } } },
+      linkPreview: false,
+    });
+
+    expect(botRawApi.editMessageText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chat_id: "123",
+        message_id: 1,
+        link_preview_options: { is_disabled: true },
+      }),
+    );
+  });
+
+  it.each([
+    { name: "text", editMode: "text" as const, field: "text" as const },
+    { name: "caption", editMode: "caption" as const, field: "caption" as const },
+  ])("refreshes cached $name from Telegram's authoritative edit response", async (testCase) => {
+    const storePath = `/tmp/openclaw-telegram-edited-context-${process.pid}-${Date.now()}-${testCase.name}.json`;
+    const cfg = { session: { store: storePath } };
+    const chat = { id: -100123, type: "supergroup" as const, title: "Ops" };
+    const cache = createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    });
+    await cache.record({
+      accountId: "default",
+      chatId: chat.id,
+      threadId: 77,
+      msg: {
+        chat,
+        message_id: 902,
+        message_thread_id: 77,
+        date: 1_779_394_740,
+        from: { id: 42, is_bot: true, first_name: "OpenClaw" },
+        [testCase.field]: "outdated content",
+      },
+    });
+    const editedMessage = {
+      chat,
+      message_id: 902,
+      message_thread_id: 77,
+      date: 1_779_394_740,
+      edit_date: 1_779_394_750,
+      from: { id: 42, is_bot: true, first_name: "OpenClaw" },
+      [testCase.field]: "authoritative edited content",
+    };
+    if (testCase.editMode === "caption") {
+      botApi.editMessageCaption.mockResolvedValue(editedMessage);
+    } else {
+      botApi.editMessageText.mockResolvedValue(editedMessage);
+    }
+
+    await editMessageTelegram(chat.id, 902, "authoritative edited content", {
+      token: "42:test-token",
+      cfg,
+      editMode: testCase.editMode,
+    });
+
+    const cached = await cache.get({
+      accountId: "default",
+      chatId: chat.id,
+      messageId: "902",
+    });
+    expect(cached?.body).toBe("authoritative edited content");
+    expect(hasProviderObservedTelegramThreadBinding(cached, 77)).toBe(true);
+  });
 });
 
 describe("sendPollTelegram", () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -11,11 +11,16 @@ import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { markdownToTelegramHtml, telegramHtmlToPlainTextFallback } from "./format.js";
 import {
+  recordTelegramGroupHistoryEntry,
+  selectTelegramGroupHistoryAfterLastSelf,
+} from "./group-history-window.js";
+import {
   buildTelegramConversationContext,
   createTelegramMessageCache,
   hasProviderObservedTelegramThreadBinding,
   resolveTelegramMessageCacheScope,
 } from "./message-cache.js";
+import { registerTelegramOutboundGroupHistoryRecorder } from "./outbound-message-context.js";
 import { createTelegramPromptContextProjectionCursor } from "./prompt-context-projection.js";
 import { inputRichBlocksToPlainText, type InputRichBlock } from "./rich-block-model.js";
 import { setTelegramRuntime } from "./runtime.js";
@@ -4696,6 +4701,84 @@ describe("editMessageTelegram", () => {
     });
     expect(cached?.body).toBe("authoritative edited content");
     expect(hasProviderObservedTelegramThreadBinding(cached, 77)).toBe(true);
+  });
+
+  it("refreshes edited group messages without duplicating self history or hiding later replies", async () => {
+    const storePath = `/tmp/openclaw-telegram-edit-history-${process.pid}-${Date.now()}.json`;
+    const cfg = { session: { store: storePath } };
+    const chat = { id: -100123, type: "supergroup" as const, title: "Ops" };
+    const historyKey = `${chat.id}:topic:77`;
+    const groupHistory = new Map<
+      string,
+      Array<{ sender: string; body: string; messageId: string; timestamp: number }>
+    >();
+    recordTelegramGroupHistoryEntry({
+      historyMap: groupHistory,
+      historyKey,
+      limit: 50,
+      entry: {
+        sender: "OpenClaw (you)",
+        body: "original response",
+        messageId: "902",
+        timestamp: 1_779_394_740_000,
+      },
+    });
+    recordTelegramGroupHistoryEntry({
+      historyMap: groupHistory,
+      historyKey,
+      limit: 50,
+      entry: {
+        sender: "Teammate",
+        body: "context that must remain visible",
+        messageId: "903",
+        timestamp: 1_779_394_741_000,
+      },
+    });
+    const unregister = registerTelegramOutboundGroupHistoryRecorder({
+      accountId: "default",
+      recorder: (record) =>
+        recordTelegramGroupHistoryEntry({
+          historyMap: groupHistory,
+          historyKey,
+          limit: 50,
+          entry: {
+            sender: "OpenClaw (you)",
+            body: record.text ?? "<media>",
+            messageId: String(record.messageId),
+            timestamp: record.timestamp ?? 0,
+          },
+        }),
+    });
+    botApi.editMessageText.mockResolvedValue({
+      chat,
+      message_id: 902,
+      message_thread_id: 77,
+      date: 1_779_394_740,
+      from: { id: 42, is_bot: true, first_name: "OpenClaw" },
+      text: "authoritative edited response",
+    });
+
+    try {
+      await editMessageTelegram(chat.id, 902, "authoritative edited response", {
+        token: "42:test-token",
+        cfg,
+      });
+    } finally {
+      unregister();
+    }
+
+    const entries = groupHistory.get(historyKey) ?? [];
+    expect(entries.map((entry) => entry.messageId)).toEqual(["902", "903"]);
+    expect(selectTelegramGroupHistoryAfterLastSelf(entries)).toEqual([
+      expect.objectContaining({
+        sender: "Teammate",
+        body: "context that must remain visible",
+      }),
+    ]);
+    const cached = await createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    }).get({ accountId: "default", chatId: chat.id, messageId: "902" });
+    expect(cached?.body).toBe("authoritative edited response");
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Telegram message edits had three independently observable owner-boundary defects:

1. Edits ignored the account-level link-preview default, and native rich-message edits omitted Telegram's supported link-preview options.
2. Successful text and caption edits left the Telegram prompt-context cache holding the pre-edit message rather than Telegram's authoritative returned message.
3. Recording that authoritative edit through the existing outbound owner inserted a duplicate self-history entry, advancing the group-history watermark and silently hiding teammate messages that arrived after the original reply.

## Why This Change Was Made

Resolve preview policy once in the Telegram edit owner using explicit request > account default > enabled. Apply the same result to normal HTML edits, plain-text fallbacks, rich-entity detection, and the native rich-message edit payload.

Refresh prompt context only when Telegram returns an actual edited Message; preserve inline true responses, MESSAGE_NOT_MODIFIED handling, provider-observed topic bindings, sender identity, and existing projection metadata. Add one private, backwards-compatible outbound-owner switch so edits update the canonical message cache without being recorded as new group-history turns. Ordinary outbound sends retain their existing history behavior.

## Evidence

- Exact commit: e7ef5cfe2a2986eaa7f5c408e0703e62f35f8dd9.
- Branch: codex/qa100-telegram-edit-owner.
- Immutable base: 25bb1da3a7314f027c477d8c14d6d95d058fa00d.
- Distinct independently reproduced roots fixed: 3 — link-preview precedence/rich parity, stale authoritative edit cache, and duplicate self-history watermark.
- Real immutable-base RED on Blacksmith Testbox: four targeted edit regressions failed, covering disabled account-default inheritance, native rich-preview suppression, and authoritative text/caption cache refresh.
- Final exact-head GREEN on Blacksmith Testbox tbx_01kyw042z8ddczsqd4b0nz2x6b: 225 tests passed across extensions/telegram/src/send.test.ts (183), extensions/telegram/src/message-cache.test.ts (18), extensions/telegram/src/bot-message-dispatch.reply-targets.test.ts (16), and extensions/telegram/src/outbound-message-context.test.ts (8).
- Exact command: OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test extensions/telegram/src/send.test.ts extensions/telegram/src/outbound-message-context.test.ts extensions/telegram/src/message-cache.test.ts extensions/telegram/src/bot-message-dispatch.reply-targets.test.ts.
- Remote proof workflow: https://github.com/openclaw/openclaw/actions/runs/30628391078. The one-shot Testbox lease stopped after success.
- A genuinely independent strict read-only owner review inspected all callers, cache/projection merging, group-history watermark consumers, account precedence, and the installed grammY editMessageText/LinkPreviewOptions contract; CLEAN with no actionable findings.
- Structured Codex gpt-5.6-sol high-reasoning autoreview CLEAN; genuine TruffleHog credential scan CLEAN; oxfmt, committed git diff --check, immutable final SHA, and clean worktree guards passed.
- No authorization, authentication, topic-routing, public SDK, configuration-schema, shared-main, push, or merge changes.
