### PR TITLE
fix(daemon): report real service removal failures across platforms

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1,4 +1,5 @@
 // Launchd tests cover macOS service plist generation and command handling.
+import fs from "node:fs/promises";
 import { PassThrough } from "node:stream";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -25,6 +26,7 @@ import {
   stageLaunchAgent,
   startLaunchAgent,
   stopLaunchAgent,
+  uninstallLaunchAgent,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -422,10 +424,26 @@ vi.mock("node:fs/promises", async () => {
     ...actual,
     access: vi.fn(async (p: string) => {
       const key = p;
-      if (state.files.has(key) || state.dirs.has(key)) {
+      if (
+        (state.files.has(key) && state.files.get(key) !== "dangling-launchagent-symlink") ||
+        state.dirs.has(key)
+      ) {
         return;
       }
-      throw new Error(`ENOENT: no such file or directory, access '${key}'`);
+      throw Object.assign(new Error(`ENOENT: no such file or directory, access '${key}'`), {
+        code: "ENOENT",
+      });
+    }),
+    lstat: vi.fn(async (p: string) => {
+      const key = p;
+      if (state.files.has(key) || state.dirs.has(key)) {
+        return {
+          isSymbolicLink: () => state.files.get(key) === "dangling-launchagent-symlink",
+        };
+      }
+      throw Object.assign(new Error(`ENOENT: no such file or directory, lstat '${key}'`), {
+        code: "ENOENT",
+      });
     }),
     mkdir: vi.fn(async (p: string, opts?: { mode?: number }) => {
       const key = p;
@@ -1355,6 +1373,87 @@ describe("launchd bootstrap repair", () => {
       status: "kickstart-failed",
       detail: "launchctl kickstart failed: permission denied",
     });
+  });
+});
+
+describe("launchd uninstall", () => {
+  it("reports a surviving LaunchAgent when moving its plist to Trash is denied", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.files.set(plistPath, "RunAtLoad=true");
+    vi.mocked(fs.rename).mockRejectedValueOnce(
+      Object.assign(new Error(`EACCES: permission denied, rename '${plistPath}'`), {
+        code: "EACCES",
+      }),
+    );
+
+    const uninstall = uninstallLaunchAgent({ env, stdout: new PassThrough() });
+
+    await expect(uninstall).rejects.toThrow("LaunchAgent removal failed (EACCES)");
+    await expect(uninstall).rejects.not.toThrow(plistPath);
+    expect(state.files.has(plistPath)).toBe(true);
+  });
+
+  it("reports inaccessible LaunchAgents instead of claiming they are missing", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    vi.mocked(fs.lstat).mockRejectedValueOnce(
+      Object.assign(new Error(`EACCES: permission denied, lstat '${plistPath}'`), {
+        code: "EACCES",
+      }),
+    );
+
+    const uninstall = uninstallLaunchAgent({ env, stdout: new PassThrough() });
+
+    await expect(uninstall).rejects.toThrow("LaunchAgent removal failed (EACCES)");
+    await expect(uninstall).rejects.not.toThrow(plistPath);
+  });
+
+  it("keeps missing LaunchAgent removal idempotent", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    await expect(uninstallLaunchAgent({ env, stdout: new PassThrough() })).resolves.toBeUndefined();
+  });
+
+  it("removes dangling LaunchAgent symlinks instead of treating their targets as missing", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.files.set(plistPath, "dangling-launchagent-symlink");
+
+    await expect(uninstallLaunchAgent({ env, stdout: new PassThrough() })).resolves.toBeUndefined();
+    expect(state.files.has(plistPath)).toBe(false);
+  });
+
+  it("keeps concurrently removed LaunchAgent removal idempotent", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.files.set(plistPath, "RunAtLoad=true");
+    vi.mocked(fs.rename).mockImplementationOnce(async () => {
+      state.files.delete(plistPath);
+      throw Object.assign(new Error(`ENOENT: no such file, rename '${plistPath}'`), {
+        code: "ENOENT",
+      });
+    });
+
+    await expect(uninstallLaunchAgent({ env, stdout: new PassThrough() })).resolves.toBeUndefined();
+    expect(state.files.has(plistPath)).toBe(false);
+  });
+
+  it("reports a missing Trash destination while the LaunchAgent still exists", async () => {
+    const env = createDefaultLaunchdEnv();
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    state.files.set(plistPath, "RunAtLoad=true");
+    vi.mocked(fs.rename).mockRejectedValueOnce(
+      Object.assign(new Error(`ENOENT: missing destination for '${plistPath}'`), {
+        code: "ENOENT",
+      }),
+    );
+
+    const uninstall = uninstallLaunchAgent({ env, stdout: new PassThrough() });
+
+    await expect(uninstall).rejects.toThrow("LaunchAgent removal failed (ENOENT)");
+    await expect(uninstall).rejects.not.toThrow(plistPath);
+    expect(state.files.has(plistPath)).toBe(true);
   });
 });
 

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -956,8 +956,11 @@ export async function uninstallLaunchAgent({
   await execLaunchctl(["unload", plistPath]);
 
   try {
-    await fs.access(plistPath);
-  } catch {
+    await fs.lstat(plistPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw createLaunchAgentRemovalError(error);
+    }
     stdout.write(`LaunchAgent not found at ${plistPath}\n`);
     return;
   }
@@ -969,9 +972,27 @@ export async function uninstallLaunchAgent({
     await fs.mkdir(trashDir, { recursive: true });
     await fs.rename(plistPath, dest);
     stdout.write(`${formatLine("Moved LaunchAgent to Trash", dest)}\n`);
-  } catch {
-    stdout.write(`LaunchAgent remains at ${plistPath} (could not move)\n`);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      try {
+        await fs.lstat(plistPath);
+      } catch (accessError) {
+        if ((accessError as NodeJS.ErrnoException).code === "ENOENT") {
+          stdout.write(`LaunchAgent not found at ${plistPath}\n`);
+          return;
+        }
+        throw createLaunchAgentRemovalError(accessError);
+      }
+    }
+    throw createLaunchAgentRemovalError(error);
   }
+}
+
+function createLaunchAgentRemovalError(error: unknown): Error {
+  const code = (error as NodeJS.ErrnoException).code;
+  return new Error(
+    `LaunchAgent removal failed${code ? ` (${code})` : ""}. Check permissions and retry.`,
+  );
 }
 
 function isUnsupportedGuiDomain(detail: string): boolean {

--- a/src/daemon/schtasks-runtime.ts
+++ b/src/daemon/schtasks-runtime.ts
@@ -133,8 +133,22 @@ export async function removeStartupEntries(
     try {
       await fs.unlink(startupEntryPath);
       stdout.write(`${formatLine("Removed Windows login item", startupEntryPath)}\n`);
-    } catch {}
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        throw createStartupEntryRemovalError(error);
+      }
+    }
   }
+}
+
+function createStartupEntryRemovalError(error: unknown): Error {
+  const code = (error as NodeJS.ErrnoException).code;
+  // Native filesystem errors include the private Startup-folder path in their messages.
+  return new Error(
+    `Windows login item removal failed${code ? ` (${code})` : ""}. Check permissions and retry.`,
+    { cause: code ? { code } : undefined },
+  );
 }
 
 export async function hasScheduledTaskRunningEvidence(env: GatewayServiceEnv): Promise<boolean> {

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -93,6 +93,7 @@ const {
   stopScheduledTask,
   uninstallScheduledTask,
 } = await import("./schtasks.js");
+const { removeStartupEntries } = await import("./schtasks-runtime.js");
 
 function resolveStartupEntryPath(env: Record<string, string>, extension = "cmd") {
   const taskName = env.OPENCLAW_WINDOWS_TASK_NAME ?? "OpenClaw Gateway";
@@ -367,6 +368,38 @@ afterEach(() => {
 });
 
 describe("Windows startup fallback", () => {
+  it("reports login item removal failures without leaking the item path", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      const startupEntryPath = await writeStartupFallbackEntry(env);
+      const removalError = Object.assign(
+        new Error(`EACCES: permission denied, unlink '${startupEntryPath}'`),
+        { code: "EACCES", path: startupEntryPath },
+      );
+      vi.spyOn(fs, "unlink").mockRejectedValueOnce(removalError);
+
+      const removal = removeStartupEntries(env, new PassThrough());
+
+      await expect(removal).rejects.toThrow("Windows login item removal failed (EACCES)");
+      await expect(removal).rejects.not.toThrow(startupEntryPath);
+      const sanitizedError = await removal.catch((error: unknown) => error);
+      expect(sanitizedError).toBeInstanceOf(Error);
+      if (!(sanitizedError instanceof Error)) {
+        throw new Error("expected sanitized Windows login item removal failure");
+      }
+      expect(sanitizedError).not.toBe(removalError);
+      expect(sanitizedError.cause).toEqual({ code: "EACCES" });
+      expect(sanitizedError).not.toHaveProperty("path");
+      expect(sanitizedError.stack).not.toContain(startupEntryPath);
+      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+    });
+  });
+
+  it("keeps missing Startup-folder login item removal idempotent", async () => {
+    await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
+      await expect(removeStartupEntries(env, new PassThrough())).resolves.toBeUndefined();
+    });
+  });
+
   it("skips task ownership probes when no Startup fallback exists", async () => {
     await withWindowsEnv("openclaw-win-startup-", async ({ env }) => {
       await expect(readWindowsStartupFallbackRuntimeForUpdate(env)).resolves.toBeNull();

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -2448,6 +2448,63 @@ describe("systemd service install and uninstall", () => {
     });
   });
 
+  it.each([
+    "Access denied",
+    "Unit openclaw-node.service is not loaded properly: Invalid argument.",
+    "Failed to disable unit: Access denied.\nUnit openclaw-node.service is not active.",
+    "Unit is not loaded.",
+    "Unit inactive.",
+    "Unit unrelated.service is not active.",
+  ])("refuses to remove the unit when systemctl disable fails: %s", async (detail) => {
+    await withNodeSystemdFixture(async ({ env, unitPath, nodeEnvFilePath }) => {
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Node\n", "utf8");
+      await fs.writeFile(nodeEnvFilePath, "OPENCLAW_GATEWAY_TOKEN=preserved-token\n", "utf8");
+      execFileMock
+        .mockImplementationOnce((_cmd, args, _opts, cb) => {
+          assertUserSystemctlArgs(args, "status");
+          cb(null, "", "");
+        })
+        .mockImplementationOnce((_cmd, args, _opts, cb) => {
+          assertUserSystemctlArgs(args, "disable", "--now", NODE_SERVICE);
+          cb(createExecFileError(detail), "", detail);
+        });
+
+      const { stdout } = createWritableStreamMock();
+
+      await expect(uninstallSystemdService({ env, stdout })).rejects.toThrow(
+        `systemctl disable failed: ${detail}`,
+      );
+      await expect(fs.readFile(unitPath, "utf8")).resolves.toContain("OpenClaw Node");
+      await expect(fs.readFile(nodeEnvFilePath, "utf8")).resolves.toContain("preserved-token");
+    });
+  });
+
+  it.each([
+    "Unit file openclaw-node.service does not exist.",
+    "Failed to disable unit: Unit file openclaw-node.service does not exist.",
+    "Unit openclaw-node.service could not be found.",
+    "Failed to stop openclaw-node.service: Unit openclaw-node.service not loaded.",
+    "Failed to stop openclaw-node.service: Unit openclaw-node.service is not active.",
+  ])("keeps missing or inactive systemd unit removal idempotent: %s", async (detail) => {
+    await withNodeSystemdFixture(async ({ env }) => {
+      execFileMock
+        .mockImplementationOnce((_cmd, args, _opts, cb) => {
+          assertUserSystemctlArgs(args, "status");
+          cb(null, "", "");
+        })
+        .mockImplementationOnce((_cmd, args, _opts, cb) => {
+          assertUserSystemctlArgs(args, "disable", "--now", NODE_SERVICE);
+          cb(createExecFileError(detail), "", detail);
+        });
+
+      const { write, stdout } = createWritableStreamMock();
+
+      await expect(uninstallSystemdService({ env, stdout })).resolves.toBeUndefined();
+      expect(requireFirstWrite(write)).toContain("Systemd service not found");
+    });
+  });
+
   it("disables the OPENCLAW_SYSTEMD_UNIT override during uninstall", async () => {
     await withNodeSystemdFixture(async ({ env, unitPath, nodeEnvFilePath }) => {
       await fs.mkdir(path.dirname(unitPath), { recursive: true });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -18,6 +18,7 @@ import {
   parseStrictNonNegativeInteger,
   parseStrictPositiveInteger,
 } from "../infra/parse-finite-number.js";
+import { escapeRegExp } from "../shared/regexp.js";
 import { splitArgsPreservingQuotes } from "./arg-split.js";
 import {
   LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
@@ -1545,7 +1546,21 @@ export async function uninstallSystemdService({
   await assertSystemdAvailable(env);
   const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
-  await execSystemctlUser(env, ["disable", "--now", unitName]);
+  const disabled = await execSystemctlUser(env, ["disable", "--now", unitName]);
+  if (disabled.code !== 0) {
+    const detail = readSystemctlDetail(disabled);
+    const escapedUnitName = escapeRegExp(normalizeLowercaseStringOrEmpty(unitName));
+    const alreadyMissingOrInactive = new RegExp(
+      `^(?:failed to (?:disable unit|stop\\s+${escapedUnitName}):\\s*)?` +
+        `(?:unit file\\s+${escapedUnitName}\\s+does not exist|` +
+        `unit\\s+${escapedUnitName}(?:\\s+is)?\\s+` +
+        `(?:inactive|not\\s+active|not\\s+loaded|not-found|could not be found))[.!]?$`,
+      "u",
+    ).test(normalizeLowercaseStringOrEmpty(detail));
+    if (!alreadyMissingOrInactive) {
+      throw new Error(`systemctl disable failed: ${detail || "unknown error"}`);
+    }
+  }
 
   const unitPath = resolveSystemdUnitPath(env);
   let removed = false;


### PR DESCRIPTION
## Summary

- Make Linux systemd uninstall fail before deleting the unit or managed environment whenever `systemctl disable --now` fails for anything except a complete, exact-unit missing/inactive diagnostic.
- Make macOS LaunchAgent uninstall report real access, Trash-directory, and rename failures without exposing filesystem paths; remove dangling plist symlinks and preserve concurrent-removal idempotency.
- Make Windows Startup-folder cleanup ignore only genuinely missing login items and report all other removal failures without exposing filesystem paths.

## Root causes fixed

**3 distinct canonical owner bugs:**

1. Linux `uninstallSystemdService` ignored the service-manager disable/stop exit code and could delete the unit plus managed credentials while the operation failed.
2. macOS `uninstallLaunchAgent` silently accepted surviving or inaccessible LaunchAgent plists and incorrectly treated dangling symlinks as already removed.
3. Windows `removeStartupEntries` swallowed all filesystem failures, including denied removal of persistent login items.

## Verification

- Immutable local-main parent: `25bb1da3a7314f027c477d8c14d6d95d058fa00d`.
- Branch: `codex/auto-qa-service-removal`.
- Commit: `1caf9da1e2f8fa96e9b0a301db13e2195d27bc6c`.
- Before fixes: authentic owner regressions reproduced false success for Linux manager rejection, macOS surviving/inaccessible plists, and Windows denied login-item removal; follow-up RED regressions reproduced concurrent removal, malformed/compound/wrong-unit systemd diagnostics, and dangling LaunchAgent symlinks.
- After fixes: `src/daemon/systemd.test.ts`, `src/daemon/launchd.test.ts`, and `src/daemon/schtasks.startup-fallback.test.ts`: **309 passed, 24 existing skips** on Blacksmith Testbox `tbx_01kyvyjd78gxn1nmgy45s9mwy3`.
- Remote proof: [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/30626796585); owned lease stopped after validation.
- Independent strict read-only owner/caller/sibling review: **CLEAN**, including exact selected-unit matching, persisted environment preservation, dangling links, concurrent removal, inactive/not-found idempotency, and sensitive-path redaction.
- Structured Codex `gpt-5.6-sol` high-reasoning autoreview: **CLEAN**, correctness confidence **0.96**; approved TruffleHog preflight clean.
- Targeted existing-binary formatting, `git diff --check`, exact immutable parent, and clean committed worktree verified.
- No public CLI flags, configuration/schema, authentication, persistent storage, service operations, fetch, or push.
