### PR TITLE
fix(ui): restore keyboard access to plugins and usage sessions

### DIFF
--- a/ui/src/e2e/usage-session-unicode.e2e.test.ts
+++ b/ui/src/e2e/usage-session-unicode.e2e.test.ts
@@ -166,7 +166,11 @@ describeControlUiE2e("Control UI usage session filter Unicode", () => {
 
       const row = page.locator(".session-bar-row").filter({ hasText: scenario.key });
       await expect.poll(() => row.count(), { timeout: 10_000 }).toBe(1);
-      await row.click();
+      const select = row.getByRole("button", { name: scenario.key, exact: true });
+      expect(await select.getAttribute("aria-pressed")).toBe("false");
+      await select.focus();
+      await page.keyboard.press("Shift+Enter");
+      await expect.poll(() => select.getAttribute("aria-pressed")).toBe("true");
 
       const chip = page.locator(".filter-chip").filter({ has: page.locator(".filter-chip-label") });
       const label = chip.locator(".filter-chip-label");

--- a/ui/src/pages/plugins/plugins.e2e.test.ts
+++ b/ui/src/pages/plugins/plugins.e2e.test.ts
@@ -405,8 +405,10 @@ describeControlUiE2e("Control UI Plugins mocked Gateway E2E", () => {
       await workboardCard.getByRole("button", { name: "Enable", exact: true }).waitFor();
       await captureScreenshot(page, "01-installed-desktop.png");
 
-      // Rows open a detail overlay; close it before continuing.
-      await workboardCard.click();
+      // The row's primary action is a real named button, so keyboard users can inspect plugins.
+      const detailsButton = workboardCard.getByRole("button", { name: "Workboard", exact: true });
+      await detailsButton.focus();
+      await page.keyboard.press("Enter");
       const detail = page.locator(".plugins-detail");
       await detail.waitFor({ state: "visible" });
       expect(await detail.textContent()).toContain("Workboard");

--- a/ui/src/pages/plugins/view.test.ts
+++ b/ui/src/pages/plugins/view.test.ts
@@ -335,8 +335,19 @@ describe("renderPlugins", () => {
   it("opens the detail overlay from a row and renders actions and metadata", () => {
     const onShowDetails = vi.fn();
     const clickable = mount(createProps({ onShowDetails }));
-    clickable.querySelector<HTMLElement>('[data-plugin-id="workboard"]')?.click();
+    const row = clickable.querySelector<HTMLElement>('[data-plugin-id="workboard"]');
+    const detailButton = row?.querySelector<HTMLButtonElement>(".plugins-item__detail-button");
+    expect(detailButton).toBeInstanceOf(HTMLButtonElement);
+    expect(detailButton?.type).toBe("button");
+    expect(detailButton?.getAttribute("aria-label")).toBe("Workboard");
+    detailButton?.focus();
+    expect(document.activeElement).toBe(detailButton);
+    detailButton?.click();
+    expect(onShowDetails).toHaveBeenCalledOnce();
     expect(onShowDetails).toHaveBeenCalledWith("workboard");
+
+    row?.click();
+    expect(onShowDetails).toHaveBeenCalledTimes(2);
 
     const onSetEnabled = vi.fn();
     const container = mount(
@@ -662,6 +673,7 @@ describe("renderPlugins", () => {
       install: undefined,
     });
     const onSetEnabled = vi.fn();
+    const onShowDetails = vi.fn();
     const container = mount(
       createProps({
         activeTab: "discover",
@@ -680,6 +692,7 @@ describe("renderPlugins", () => {
           },
         ],
         onSetEnabled,
+        onShowDetails,
       }),
     );
 
@@ -688,6 +701,13 @@ describe("renderPlugins", () => {
     expect(row.querySelector(".plugins-install")).toBeNull();
     actionButton(row, "Disable")?.click();
     expect(onSetEnabled).toHaveBeenCalledWith("calendar-runtime", false, clawHubKey(packageName));
+    expect(onShowDetails).not.toHaveBeenCalled();
+    const detailButton = row.querySelector<HTMLButtonElement>(".plugins-item__detail-button");
+    expect(detailButton).toBeInstanceOf(HTMLButtonElement);
+    expect(detailButton?.getAttribute("aria-label")).toBe("Calendar Plus");
+    detailButton?.click();
+    expect(onShowDetails).toHaveBeenCalledOnce();
+    expect(onShowDetails).toHaveBeenCalledWith("calendar-runtime");
   });
 
   it("does not present an empty catalog alongside an initial list failure", () => {

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -574,6 +574,32 @@ function renderInstalledFilter(props: PluginsViewProps) {
   });
 }
 
+function renderPluginHeading(params: {
+  name: string;
+  content: TemplateResult;
+  onShowDetails?: () => void;
+}): TemplateResult {
+  return html`
+    <h3 class="settings-row__title">
+      ${params.onShowDetails
+        ? html`
+            <button
+              type="button"
+              class="plugins-item__detail-button"
+              aria-label=${params.name}
+              @click=${(event: Event) => {
+                event.stopPropagation();
+                params.onShowDetails?.();
+              }}
+            >
+              ${params.content}
+            </button>
+          `
+        : params.content}
+    </h3>
+  `;
+}
+
 function renderPluginRow(
   plugin: PluginCatalogItem,
   props: PluginsViewProps,
@@ -598,14 +624,18 @@ function renderPluginRow(
         props.onIconError(plugin.id),
       )}
       <div class="settings-row__text">
-        <h3 class="settings-row__title">
-          ${plugin.name}
-          ${plugin.version
-            ? includePackageName
-              ? html`<span class="plugins-version">v${plugin.version}</span>`
-              : html`<span class="plugins-version">v${plugin.version}</span>`
-            : nothing}
-        </h3>
+        ${renderPluginHeading({
+          name: plugin.name,
+          content: html`
+            ${plugin.name}
+            ${plugin.version
+              ? includePackageName
+                ? html`<span class="plugins-version">v${plugin.version}</span>`
+                : html`<span class="plugins-version">v${plugin.version}</span>`
+              : nothing}
+          `,
+          onShowDetails: () => props.onShowDetails(plugin.id),
+        })}
         <span class="settings-row__desc">
           ${plugin.description || t("pluginsPage.optionalCapability")}
         </span>
@@ -859,12 +889,16 @@ function renderClawHubResult(item: PluginSearchResult, props: PluginsViewProps):
     >
       ${renderArtTile(artSlug, pkg.displayName)}
       <div class="settings-row__text">
-        <h3 class="settings-row__title">
-          ${pkg.displayName}
-          ${pkg.latestVersion
-            ? html`<span class="plugins-version">v${pkg.latestVersion}</span>`
-            : nothing}
-        </h3>
+        ${renderPluginHeading({
+          name: pkg.displayName,
+          content: html`
+            ${pkg.displayName}
+            ${pkg.latestVersion
+              ? html`<span class="plugins-version">v${pkg.latestVersion}</span>`
+              : nothing}
+          `,
+          onShowDetails: installed ? () => props.onShowDetails(installed.id) : undefined,
+        })}
         <span class="settings-row__desc">${pkg.summary || pkg.name}</span>
         ${renderMetaLine([
           pkg.isOfficial ? t("pluginsPage.official") : nothing,

--- a/ui/src/pages/usage/view-overview.test.ts
+++ b/ui/src/pages/usage/view-overview.test.ts
@@ -487,6 +487,67 @@ describe("renderCostWindowComparison", () => {
 describe("renderSessionsCard", () => {
   const noop = () => {};
 
+  it("renders named native session toggles while preserving shift selection and separate copy", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const onSelectSession = vi.fn<(key: string, shiftKey: boolean) => void>();
+    const sessions = [
+      {
+        key: "agent:main:selected",
+        label: "Selected thread",
+        updatedAt: 2,
+        usage: { ...totals, totalTokens: 200 },
+      },
+      {
+        key: "agent:main:next",
+        label: "Next thread",
+        updatedAt: 1,
+        usage: { ...totals, totalTokens: 100 },
+      },
+    ] as UsageSessionEntry[];
+
+    render(
+      renderSessionsCard(
+        sessions,
+        ["agent:main:selected"],
+        [],
+        true,
+        "tokens",
+        "desc",
+        [],
+        "all",
+        onSelectSession,
+        noop,
+        noop,
+        noop,
+        [],
+        sessions.length,
+        noop,
+      ),
+      container,
+    );
+
+    const rows = [...container.querySelectorAll<HTMLElement>(".session-bar-row")];
+    const selected = rows[0]?.querySelector<HTMLButtonElement>(".session-bar-selection");
+    const next = rows[1]?.querySelector<HTMLButtonElement>(".session-bar-selection");
+    expect(selected).toBeInstanceOf(HTMLButtonElement);
+    expect(selected?.type).toBe("button");
+    expect(selected?.getAttribute("aria-label")).toBe("Selected thread");
+    expect(selected?.getAttribute("aria-pressed")).toBe("true");
+    expect(next?.getAttribute("aria-label")).toBe("Next thread");
+    expect(next?.getAttribute("aria-pressed")).toBe("false");
+    next?.focus();
+    expect(document.activeElement).toBe(next);
+    next?.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+    expect(onSelectSession).toHaveBeenCalledOnce();
+    expect(onSelectSession).toHaveBeenCalledWith("agent:main:next", true);
+
+    rows[0]?.querySelector<HTMLButtonElement>(".session-bar-actions button")?.click();
+    expect(onSelectSession).toHaveBeenCalledOnce();
+    rows[0]?.querySelector<HTMLElement>(".session-bar-value")?.click();
+    expect(onSelectSession).toHaveBeenCalledWith("agent:main:selected", false);
+  });
+
   it("sorts cost by the selected day values when day filters are active", () => {
     const container = document.createElement("div");
     const sessions: UsageSessionEntry[] = [

--- a/ui/src/pages/usage/view-overview.ts
+++ b/ui/src/pages/usage/view-overview.ts
@@ -1009,17 +1009,31 @@ function renderSessionsCard(
     return html`
       <div
         class="session-bar-row ${isSelected ? "selected" : ""}"
-        @click=${(e: MouseEvent) => onSelectSession(s.key, e.shiftKey)}
+        @click=${(event: MouseEvent) => {
+          if ((event.target as Element | null)?.closest("button")) {
+            return;
+          }
+          onSelectSession(s.key, event.shiftKey);
+        }}
         title="${s.key}"
       >
-        <div class="session-bar-label">
-          <div class="session-bar-title">${displayLabel}</div>
-          ${meta.length > 0
-            ? html`<div class="session-bar-meta">${meta.join(" · ")}</div>`
-            : nothing}
-        </div>
+        <button
+          type="button"
+          class="session-bar-selection"
+          aria-label=${displayLabel}
+          aria-pressed=${isSelected ? "true" : "false"}
+          @click=${(event: MouseEvent) => onSelectSession(s.key, event.shiftKey)}
+        >
+          <span class="session-bar-label">
+            <span class="session-bar-title">${displayLabel}</span>
+            ${meta.length > 0
+              ? html`<span class="session-bar-meta">${meta.join(" · ")}</span>`
+              : nothing}
+          </span>
+        </button>
         <div class="session-bar-actions">
           <button
+            type="button"
             class="btn btn--sm btn--ghost"
             @click=${(e: MouseEvent) => {
               e.stopPropagation();

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -1582,21 +1582,45 @@ details.usage-filter-select summary::-webkit-details-marker,
 }
 
 .session-bar-label,
+.session-bar-selection,
 .session-bar-actions,
 .session-detail-header-left {
   min-width: 0;
 }
 
+.session-bar-selection {
+  flex: 1 1 auto;
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.session-bar-selection:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
 .session-bar-label {
+  display: block;
   flex: 1 1 auto;
 }
 
 .session-bar-title {
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: 600;
   color: var(--text-strong);
+}
+
+.session-bar-meta {
+  display: block;
 }
 
 .session-bar-actions {


### PR DESCRIPTION
## Summary

- Make installed plugin and installed ClawHub discovery details available through real, named keyboard-operable buttons while preserving clickable cards and isolating action bubbling.
- Replace inaccessible Usage session-row activation with a real, named toggle button that announces selected state, preserves Shift range selection, and leaves the separate Copy action independent.
- Preserve desktop and narrow-screen session layout without adding configuration, dependencies, compatibility paths, or new shared abstractions.

## Root causes fixed

Two distinct operator-access owner roots: Plugins detail disclosure and Usage session selection.

## Verification

- Plugins and Usage owner suites: **39 tests passed across two files**.
- Real Chrome and mocked Gateway: plugin details opened with keyboard Enter; **one end-to-end scenario passed**.
- Real Chrome and mocked Gateway: three Unicode session keys selected with keyboard Shift+Enter and `aria-pressed` state verified; **three end-to-end scenarios passed**.
- Seven changed files pass targeted `oxfmt --check` and `git diff --check`.
- Dedicated strict read-only independent owner review: **CLEAN**, immutable commit unchanged.
- Genuine TruffleHog 3.96-backed structured commit autoreview: **zero findings**, confidence 0.94.

Commit: `1aeb019285b5d0eb86c0c51cb75489fc9a5f9a37`.
