### PR TITLE
fix(google): preserve stream terminals, diagnostics, usage, and signatures

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -543,6 +543,52 @@ describe("google transport stream", () => {
 
   it.each([
     {
+      name: "includes billed tool-result prompt tokens in input accounting",
+      usageMetadata: {
+        promptTokenCount: 10,
+        cachedContentTokenCount: 2,
+        candidatesTokenCount: 3,
+        thoughtsTokenCount: 1,
+        toolUsePromptTokenCount: 5,
+        totalTokenCount: 19,
+      },
+      expectedInput: 13,
+      expectedTotal: 19,
+    },
+    {
+      name: "derives the total when Google omits its optional aggregate",
+      usageMetadata: {
+        promptTokenCount: 10,
+        cachedContentTokenCount: 2,
+        candidatesTokenCount: 3,
+        thoughtsTokenCount: 1,
+      },
+      expectedInput: 8,
+      expectedTotal: 14,
+    },
+  ])("$name", async ({ usageMetadata, expectedInput, expectedTotal }) => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([{ candidates: [{ finishReason: "STOP" }], usageMetadata }]),
+    );
+
+    const result = await runGeminiStreamResult({
+      model: buildGeminiModel({
+        cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0 },
+      }),
+      options: { apiKey: "gemini-api-key" },
+    });
+
+    expect(result.usage).toMatchObject({
+      input: expectedInput,
+      output: 4,
+      cacheRead: 2,
+      totalTokens: expectedTotal,
+      cost: { input: expectedInput / 1_000_000 },
+    });
+  });
+
+  it.each([
+    {
       provider: "google",
       feedback: { blockReason: "SAFETY" },
       expectedCode: "SAFETY",
@@ -595,6 +641,90 @@ describe("google transport stream", () => {
       });
     },
   );
+
+  it.each(["google", "google-vertex"] as const)(
+    "rejects an unfinished %s stream instead of silently completing partial output",
+    async (provider) => {
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([{ candidates: [{ content: { parts: [{ text: "partial output" }] } }] }]),
+      );
+      if (provider === "google-vertex") {
+        vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
+        vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+        googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+      }
+
+      const result =
+        provider === "google-vertex"
+          ? await runGoogleVertexStreamResult({ fetch: guardedFetchMock })
+          : await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorCode: "STREAM_INCOMPLETE",
+        errorType: "google_incomplete_stream",
+        errorMessage: "Google stream ended before a terminal finish reason",
+      });
+    },
+  );
+
+  it.each(["SAFETY", "MALFORMED_FUNCTION_CALL"] as const)(
+    "preserves the actionable %s candidate finish message",
+    async (finishReason) => {
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [
+              {
+                finishReason,
+                finishMessage: "Provider rejected the generated response",
+              },
+            ],
+          },
+        ]),
+      );
+
+      const result = await runGeminiStreamResult({ options: { apiKey: "gemini-api-key" } });
+
+      expect(result).toMatchObject({
+        stopReason: "error",
+        errorCode: finishReason,
+        errorType: "google_generation_failed",
+        errorMessage: `Google generation stopped (${finishReason}): Provider rejected the generated response`,
+      });
+    },
+  );
+
+  it("closes partial text before reporting a failed candidate", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: { parts: [{ text: "partial output" }] },
+              finishReason: "SAFETY",
+              finishMessage: "Provider rejected the generated response",
+            },
+          ],
+        },
+      ]),
+    );
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel(),
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] } as never,
+        { apiKey: "gemini-api-key" } as never,
+      ),
+    );
+    const eventTypes: string[] = [];
+    for await (const event of stream as AsyncIterable<{ type: string }>) {
+      eventTypes.push(event.type);
+    }
+
+    expect(eventTypes).toEqual(["start", "text_start", "text_delta", "text_end", "error"]);
+    expect((await stream.result()).errorCode).toBe("SAFETY");
+  });
 
   it("rotates Gemini LLM API keys when a pre-stream request is rate limited", async () => {
     vi.stubEnv("OPENCLAW_LIVE_GEMINI_KEY", "");
@@ -729,7 +859,9 @@ describe("google transport stream", () => {
   });
 
   it("strips redundant google provider prefixes from Gemini API model paths", async () => {
-    guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([{ candidates: [{ finishReason: "STOP" }] }]),
+    );
 
     const model = buildGeminiModel({
       id: "google/gemini-3-flash-preview",
@@ -745,7 +877,7 @@ describe("google transport stream", () => {
         { apiKey: "gemini-api-key" } as Parameters<typeof streamFn>[2],
       ),
     );
-    await stream.result();
+    expect((await stream.result()).stopReason).toBe("stop");
 
     const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
     expect(guardedCall[0]).toBe(
@@ -1064,7 +1196,9 @@ describe("google transport stream", () => {
   });
 
   it("uses bearer auth when the Google api key is an OAuth JSON payload", async () => {
-    guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([{ candidates: [{ finishReason: "STOP" }] }]),
+    );
 
     const model = attachModelProviderRequestTransport(
       {
@@ -1122,7 +1256,9 @@ describe("google transport stream", () => {
       vi.stubEnv("GOOGLE_CLOUD_PROJECT", "demo");
       vi.stubEnv("GOOGLE_CLOUD_LOCATION", location);
       googleAuthGetAccessTokenMock.mockResolvedValueOnce("oauth-token");
-      guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([{ candidates: [{ finishReason: "STOP" }] }]),
+      );
       const streamFn = createGoogleVertexTransportStreamFn();
       const stream = await Promise.resolve(
         streamFn(
@@ -2108,7 +2244,9 @@ describe("google transport stream", () => {
   });
 
   it("sends stopSequences in the serialized Gemini request body via the guarded fetch transport", async () => {
-    guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([{ candidates: [{ finishReason: "STOP" }] }]),
+    );
 
     const model = attachModelProviderRequestTransport(
       {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -148,12 +148,14 @@ type GoogleSseChunk = {
       }>;
     };
     finishReason?: string;
+    finishMessage?: string;
   }>;
   usageMetadata?: {
     promptTokenCount?: number;
     cachedContentTokenCount?: number;
     candidatesTokenCount?: number;
     thoughtsTokenCount?: number;
+    toolUsePromptTokenCount?: number;
     totalTokenCount?: number;
   };
 };
@@ -1232,12 +1234,14 @@ function updateUsage(
   }
   const promptTokens = usage.promptTokenCount || 0;
   const cacheRead = usage.cachedContentTokenCount || 0;
+  const toolUsePromptTokens = usage.toolUsePromptTokenCount || 0;
+  const outputTokens = (usage.candidatesTokenCount || 0) + (usage.thoughtsTokenCount || 0);
   output.usage = {
-    input: Math.max(0, promptTokens - cacheRead),
-    output: (usage.candidatesTokenCount || 0) + (usage.thoughtsTokenCount || 0),
+    input: Math.max(0, promptTokens - cacheRead) + toolUsePromptTokens,
+    output: outputTokens,
     cacheRead,
     cacheWrite: 0,
-    totalTokens: usage.totalTokenCount || 0,
+    totalTokens: usage.totalTokenCount ?? promptTokens + outputTokens + toolUsePromptTokens,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
   };
   calculateCost(model, output.usage);
@@ -1332,6 +1336,8 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
             : await openSse(apiKey);
         stream.push({ type: "start", partial: output as never });
         let currentBlockIndex = -1;
+        let sawTerminalReason = false;
+        let terminalGenerationError: Error | undefined;
         const toolCallBlocksById = new Map<
           string,
           Extract<GoogleTransportContentBlock, { type: "toolCall" }>
@@ -1480,7 +1486,17 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
             }
           }
           if (typeof candidate?.finishReason === "string") {
+            sawTerminalReason = true;
             output.stopReason = mapStopReasonString(candidate.finishReason);
+            if (output.stopReason === "error") {
+              const finishMessage = normalizeOptionalString(candidate.finishMessage);
+              terminalGenerationError = Object.assign(
+                new Error(
+                  `Google generation stopped (${candidate.finishReason})${finishMessage ? `: ${finishMessage}` : ""}`,
+                ),
+                { code: candidate.finishReason, type: "google_generation_failed" },
+              );
+            }
             // MAX_TOKENS can leave a complete-looking partial call. Only a normal
             // Google stop may promote parsed calls into an executable tool-use turn.
             if (
@@ -1493,6 +1509,15 @@ function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): Strea
         }
         if (currentBlockIndex >= 0) {
           pushTextBlockEnd(stream, output, currentBlockIndex);
+        }
+        if (terminalGenerationError && !options?.signal?.aborted) {
+          throw terminalGenerationError;
+        }
+        if (!sawTerminalReason && !options?.signal?.aborted) {
+          throw Object.assign(new Error("Google stream ended before a terminal finish reason"), {
+            code: "STREAM_INCOMPLETE",
+            type: "google_incomplete_stream",
+          });
         }
         finalizeTransportStream({ stream, output, signal: options?.signal });
       } catch (error) {

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -1,6 +1,6 @@
 // Google shared provider tests cover response conversion and finish reasons.
-import { FinishReason, type GenerateContentResponse } from "@google/genai";
-import { describe, expect, it } from "vitest";
+import { FinishReason, GoogleGenAI, type GenerateContentResponse } from "@google/genai";
+import { describe, expect, it, vi } from "vitest";
 import type { AssistantMessage, Model } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
@@ -170,6 +170,56 @@ describe("consumeGoogleGenerateContentStream", () => {
     expect(output.usage.cost.total).toBeGreaterThan(0);
   });
 
+  it.each([
+    {
+      name: "includes billed tool-result prompt tokens in input accounting",
+      usageMetadata: {
+        promptTokenCount: 10,
+        cachedContentTokenCount: 2,
+        candidatesTokenCount: 3,
+        thoughtsTokenCount: 1,
+        toolUsePromptTokenCount: 5,
+        totalTokenCount: 19,
+      },
+      expectedInput: 13,
+      expectedTotal: 19,
+    },
+    {
+      name: "derives the total when Google omits its optional aggregate",
+      usageMetadata: {
+        promptTokenCount: 10,
+        cachedContentTokenCount: 2,
+        candidatesTokenCount: 3,
+        thoughtsTokenCount: 1,
+      },
+      expectedInput: 8,
+      expectedTotal: 14,
+    },
+  ])("$name", async ({ usageMetadata, expectedInput, expectedTotal }) => {
+    const output = createOutput();
+
+    await consumeGoogleGenerateContentStream({
+      chunks: chunks([
+        {
+          candidates: [{ finishReason: FinishReason.STOP }],
+          usageMetadata,
+        } as GenerateContentResponse,
+      ]),
+      model,
+      output,
+      stream: new AssistantMessageEventStream(),
+      nextToolCallId: () => "call_1",
+    });
+
+    expect(output.usage).toMatchObject({
+      input: expectedInput,
+      output: 4,
+      cacheRead: 2,
+      totalTokens: expectedTotal,
+      cost: { input: expectedInput / 1_000_000 },
+    });
+  });
+
   it("preserves MAX_TOKENS when the partial response contains a function call", async () => {
     const output = createOutput();
     const stream = new AssistantMessageEventStream();
@@ -261,9 +311,255 @@ describe("consumeGoogleGenerateContentStream", () => {
       },
     ]);
   });
+
+  it("attaches a standalone thought signature to the preceding canonical tool call", async () => {
+    const output = createOutput();
+
+    await consumeGoogleGenerateContentStream({
+      chunks: chunks([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { id: "call_1", name: "lookup", args: { query: "cats" } },
+                  },
+                ],
+              },
+            },
+          ],
+        } as unknown as GenerateContentResponse,
+        {
+          candidates: [
+            {
+              content: { parts: [{ thoughtSignature: "Y2FsbF9zaWc=" }] },
+              finishReason: FinishReason.STOP,
+            },
+          ],
+        } as GenerateContentResponse,
+      ]),
+      model,
+      output,
+      stream: new AssistantMessageEventStream(),
+      nextToolCallId: () => "generated-lookup",
+    });
+
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_1",
+        name: "lookup",
+        arguments: { query: "cats" },
+        thoughtSignature: "Y2FsbF9zaWc=",
+      },
+    ]);
+  });
 });
 
 describe("runGoogleGenerateContentLifecycle", () => {
+  it.each(["google-generative-ai", "google-vertex"] as const)(
+    "rejects an unfinished %s stream instead of silently completing partial output",
+    async (api) => {
+      const targetModel = {
+        ...model,
+        api,
+        provider: api === "google-vertex" ? "google-vertex" : "google",
+      } satisfies Model<"google-generative-ai" | "google-vertex">;
+      const output: AssistantMessage = {
+        ...createOutput(),
+        api: targetModel.api,
+        provider: targetModel.provider,
+      };
+      const stream = new AssistantMessageEventStream();
+
+      await runGoogleGenerateContentLifecycle({
+        stream,
+        model: targetModel,
+        output,
+        createClient: () => ({
+          models: {
+            generateContentStream: async () =>
+              chunks([
+                {
+                  candidates: [{ content: { parts: [{ text: "partial output" }] } }],
+                } as GenerateContentResponse,
+              ]),
+          },
+        }),
+        buildParams: () => ({ model: targetModel.id, contents: [] }),
+        nextToolCallId: () => "call_1",
+      });
+
+      expect(await stream.result()).toMatchObject({
+        stopReason: "error",
+        errorCode: "STREAM_INCOMPLETE",
+        errorType: "google_incomplete_stream",
+        errorMessage: "Google stream ended before a terminal finish reason",
+      });
+    },
+  );
+
+  it.each([FinishReason.SAFETY, FinishReason.MALFORMED_FUNCTION_CALL])(
+    "preserves the actionable %s candidate finish message",
+    async (finishReason) => {
+      const output = createOutput();
+      const stream = new AssistantMessageEventStream();
+
+      await runGoogleGenerateContentLifecycle({
+        stream,
+        model,
+        output,
+        createClient: () => ({
+          models: {
+            generateContentStream: async () =>
+              chunks([
+                {
+                  candidates: [
+                    {
+                      finishReason,
+                      finishMessage: "Provider rejected the generated response",
+                    },
+                  ],
+                } as GenerateContentResponse,
+              ]),
+          },
+        }),
+        buildParams: () => ({ model: model.id, contents: [] }),
+        nextToolCallId: () => "call_1",
+      });
+
+      expect(await stream.result()).toMatchObject({
+        stopReason: "error",
+        errorCode: finishReason,
+        errorType: "google_generation_failed",
+        errorMessage: `Google generation stopped (${finishReason}): Provider rejected the generated response`,
+      });
+    },
+  );
+
+  it("closes partial text before reporting a failed candidate", async () => {
+    const output = createOutput();
+    const stream = new AssistantMessageEventStream();
+    const eventTypes: string[] = [];
+    const collect = (async () => {
+      for await (const event of stream) {
+        eventTypes.push(event.type);
+      }
+    })();
+
+    await runGoogleGenerateContentLifecycle({
+      stream,
+      model,
+      output,
+      createClient: () => ({
+        models: {
+          generateContentStream: async () =>
+            chunks([
+              {
+                candidates: [
+                  {
+                    content: { parts: [{ text: "partial output" }] },
+                    finishReason: FinishReason.SAFETY,
+                    finishMessage: "Provider rejected the generated response",
+                  },
+                ],
+              } as GenerateContentResponse,
+            ]),
+        },
+      }),
+      buildParams: () => ({ model: model.id, contents: [] }),
+      nextToolCallId: () => "call_1",
+    });
+    await collect;
+
+    expect(eventTypes).toEqual(["start", "text_start", "text_delta", "text_end", "error"]);
+    expect((await stream.result()).errorCode).toBe("SAFETY");
+  });
+
+  it("preserves cancellation precedence over an observed candidate failure", async () => {
+    const controller = new AbortController();
+    const abortReason = Object.assign(new Error("Google run restarted"), {
+      code: "GATEWAY_RESTART",
+    });
+    const output = createOutput();
+    const stream = new AssistantMessageEventStream();
+
+    await runGoogleGenerateContentLifecycle({
+      stream,
+      model,
+      output,
+      options: { signal: controller.signal },
+      createClient: () => ({
+        models: {
+          generateContentStream: async () => ({
+            async *[Symbol.asyncIterator]() {
+              yield {
+                candidates: [
+                  {
+                    content: { parts: [{ text: "partial output" }] },
+                    finishReason: FinishReason.SAFETY,
+                  },
+                ],
+              } as GenerateContentResponse;
+              controller.abort(abortReason);
+            },
+          }),
+        },
+      }),
+      buildParams: () => ({ model: model.id, contents: [] }),
+      nextToolCallId: () => "call_1",
+    });
+
+    expect(await stream.result()).toMatchObject({
+      stopReason: "aborted",
+      errorMessage: "Google run restarted",
+    });
+    expect(output.errorCode).toBeUndefined();
+  });
+
+  it("preserves the typed Gemini finish reason when the official SDK omits finishMessage", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        `data: ${JSON.stringify({
+          candidates: [
+            {
+              finishReason: "SAFETY",
+              finishMessage: "Gemini Developer API strips this field",
+            },
+          ],
+        })}\n\n`,
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+    const output = createOutput();
+    const stream = new AssistantMessageEventStream();
+
+    try {
+      await runGoogleGenerateContentLifecycle({
+        stream,
+        model,
+        output,
+        createClient: () => new GoogleGenAI({ apiKey: "test-gemini-api-key" }),
+        buildParams: () => ({
+          model: model.id,
+          contents: [{ role: "user", parts: [{ text: "hello" }] }],
+        }),
+        nextToolCallId: () => "call_1",
+      });
+
+      expect(await stream.result()).toMatchObject({
+        stopReason: "error",
+        errorCode: "SAFETY",
+        errorType: "google_generation_failed",
+        errorMessage: "Google generation stopped (SAFETY)",
+      });
+      expect(fetchMock).toHaveBeenCalledOnce();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it.each([
     { api: "google-generative-ai", blockReason: "SAFETY" },
     { api: "google-generative-ai", blockReason: undefined },

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -747,6 +747,8 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
   params.stream.push({ type: "start", partial: params.output });
   let currentBlock: TextContent | ThinkingContent | null = null;
   const blocks = params.output.content;
+  let sawTerminalReason = false;
+  let terminalGenerationError: (Error & { code: string; type: string }) | undefined;
   const toolCallIds = new Set<string>();
   for (const block of blocks) {
     if (block.type === "toolCall") {
@@ -780,16 +782,19 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
   for await (const chunk of params.chunks) {
     params.output.responseId ||= chunk.responseId;
     if (chunk.usageMetadata) {
+      const promptTokens = chunk.usageMetadata.promptTokenCount || 0;
+      const cacheRead = chunk.usageMetadata.cachedContentTokenCount || 0;
+      const toolUsePromptTokens = chunk.usageMetadata.toolUsePromptTokenCount || 0;
+      const outputTokens =
+        (chunk.usageMetadata.candidatesTokenCount || 0) +
+        (chunk.usageMetadata.thoughtsTokenCount || 0);
       params.output.usage = {
-        input:
-          (chunk.usageMetadata.promptTokenCount || 0) -
-          (chunk.usageMetadata.cachedContentTokenCount || 0),
-        output:
-          (chunk.usageMetadata.candidatesTokenCount || 0) +
-          (chunk.usageMetadata.thoughtsTokenCount || 0),
-        cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
+        input: promptTokens - cacheRead + toolUsePromptTokens,
+        output: outputTokens,
+        cacheRead,
         cacheWrite: 0,
-        totalTokens: chunk.usageMetadata.totalTokenCount || 0,
+        totalTokens:
+          chunk.usageMetadata.totalTokenCount ?? promptTokens + outputTokens + toolUsePromptTokens,
         cost: {
           input: 0,
           output: 0,
@@ -813,6 +818,16 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
     }
     if (candidate?.content?.parts) {
       for (const part of candidate.content.parts) {
+        if (part.text === undefined && !part.functionCall && part.thought !== true) {
+          const latestBlock = blocks.at(-1);
+          if (latestBlock?.type === "toolCall" && part.thoughtSignature) {
+            latestBlock.thoughtSignature = retainThoughtSignature(
+              latestBlock.thoughtSignature,
+              part.thoughtSignature,
+            );
+            continue;
+          }
+        }
         if (part.text !== undefined) {
           const isThinking = isThinkingPart(part);
           if (
@@ -902,7 +917,17 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
     }
 
     if (candidate?.finishReason) {
+      sawTerminalReason = true;
       params.output.stopReason = mapStopReason(candidate.finishReason);
+      if (params.output.stopReason === "error") {
+        const finishMessage = candidate.finishMessage?.trim();
+        terminalGenerationError = Object.assign(
+          new Error(
+            `Google generation stopped (${candidate.finishReason})${finishMessage ? `: ${finishMessage}` : ""}`,
+          ),
+          { code: candidate.finishReason, type: "google_generation_failed" },
+        );
+      }
       // MAX_TOKENS can leave a complete-looking partial call. Only a normal
       // Google stop may promote parsed calls into an executable tool-use turn.
       if (
@@ -918,6 +943,18 @@ export async function consumeGoogleGenerateContentStream<T extends GoogleApiType
 
   if (params.signal?.aborted) {
     throw transportAbortError(params.signal);
+  }
+
+  if (terminalGenerationError) {
+    params.output.errorCode = terminalGenerationError.code;
+    params.output.errorType = terminalGenerationError.type;
+    throw terminalGenerationError;
+  }
+
+  if (!sawTerminalReason) {
+    params.output.errorCode = "STREAM_INCOMPLETE";
+    params.output.errorType = "google_incomplete_stream";
+    throw new Error("Google stream ended before a terminal finish reason");
   }
 
   if (params.output.stopReason === "aborted" || params.output.stopReason === "error") {


### PR DESCRIPTION
## Summary

- Require an actual terminal Google/Gemini/Vertex candidate finish reason and expose actionable typed generation failures after closing streamed partial blocks.
- Correct Google token/cost accounting for tool-result prompt tokens and absent optional aggregate totals.
- Preserve standalone thought signatures on the existing canonical streamed tool call without creating duplicate calls.
- Keep merged blocked-prompt PR #116756 solely in the immutable parent; this follow-up does not duplicate its changes.

## Root causes fixed

**5 independently evidenced roots:**

1. **Missing terminal candidate finish reason:** interrupted Gemini and Vertex streams previously completed partial output successfully; both owner and SDK-sibling regressions now require typed `STREAM_INCOMPLETE` / `google_incomplete_stream`.
2. **Lost actionable candidate diagnostics:** `SAFETY`, `MALFORMED_FUNCTION_CALL`, and available `finishMessage` previously degraded into generic/silent outcomes; owner and SDK-sibling regressions preserve typed failures, close partial blocks before the error, and retain caller-abort precedence. A real official `GoogleGenAI` client with mocked SSE additionally proves the Developer API converter can strip `finishMessage` while the typed reason remains visible.
3. **Omitted billed tool-result prompt tokens:** owner and SDK-sibling accounting regressions now include official `toolUsePromptTokenCount` in billed input and cost.
4. **Missing optional aggregate total:** separate owner and SDK-sibling regressions derive `usage.totalTokens` from prompt, candidate, thought, and tool-result token facts when official `totalTokenCount` is absent.
5. **Lost canonical tool-call thought signature:** the SDK-backed sibling now attaches a standalone `thoughtSignature` to the immediately preceding existing canonical tool call; owner regression verifies the equivalent direct-SSE behavior without duplicating calls.

## Verification

- `node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts packages/ai/src/providers/google-shared.test.ts` — **125 passed**: 102 plugin-owner + 23 shared SDK-sibling tests.
- Independently reviewed exact commit `7c0aaecee07003da626a24b67594a26b47cdf7bf`: **CLEAN**.
- Actual `gpt-5.6-sol` high autoreview with real TruffleHog 3.96 scanner: **CLEAN**, patch-correct confidence **0.94**.
- Targeted existing-binary `oxfmt --check`, `oxlint`, and `git diff --check`: **passed**.
- Exactly one follow-up commit above immutable merged parent `c52bc53745257557b3384eb96ca21a74934ab6b1`; no duplicate blocked-prompt prerequisite.

## Scope

`extensions/google/transport-stream.ts`, `extensions/google/transport-stream.test.ts`, `packages/ai/src/providers/google-shared.ts`, and `packages/ai/src/providers/google-shared.test.ts`. No auth, public SDK, config, or protocol changes; complex Vertex `partialArgs` continuation behavior remains out of scope.
