### PR TITLE
fix(discord): clean deleted threads and preserve reaction actors

### DIFF
--- a/extensions/discord/src/internal/entity-cache.test.ts
+++ b/extensions/discord/src/internal/entity-cache.test.ts
@@ -1,4 +1,5 @@
 // Discord tests cover entity cache plugin behavior.
+import { GatewayDispatchEvents } from "discord-api-types/v10";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DiscordEntityCache } from "./entity-cache.js";
 import type { RequestClient } from "./rest.js";
@@ -74,5 +75,21 @@ describe("DiscordEntityCache eviction", () => {
     await cache.fetchUser("u2");
 
     expect(cache.size).toBe(0);
+  });
+
+  it.each([
+    ["updated", GatewayDispatchEvents.ThreadUpdate],
+    ["deleted", GatewayDispatchEvents.ThreadDelete],
+  ])("invalidates cached channels when a thread is %s", async (_label, eventType) => {
+    const { cache, getCalls } = makeCache({ ttlMs: 60_000 });
+
+    await cache.fetchChannel("thread-42");
+    await cache.fetchChannel("thread-42");
+    expect(getCalls()).toBe(1);
+
+    cache.invalidateForGatewayEvent(eventType, { id: "thread-42" });
+    await cache.fetchChannel("thread-42");
+
+    expect(getCalls()).toBe(2);
   });
 });

--- a/extensions/discord/src/internal/entity-cache.ts
+++ b/extensions/discord/src/internal/entity-cache.ts
@@ -67,9 +67,16 @@ export class DiscordEntityCache {
     const raw = data && typeof data === "object" ? (data as Record<string, unknown>) : {};
     const channelUpdate: string = GatewayDispatchEvents.ChannelUpdate;
     const channelDelete: string = GatewayDispatchEvents.ChannelDelete;
+    const threadUpdate: string = GatewayDispatchEvents.ThreadUpdate;
+    const threadDelete: string = GatewayDispatchEvents.ThreadDelete;
     const guildUpdate: string = GatewayDispatchEvents.GuildUpdate;
     const guildMemberUpdate: string = GatewayDispatchEvents.GuildMemberUpdate;
-    if (type === channelUpdate || type === channelDelete) {
+    if (
+      type === channelUpdate ||
+      type === channelDelete ||
+      type === threadUpdate ||
+      type === threadDelete
+    ) {
       this.deleteId("channel", raw.id);
     }
     if (type === guildUpdate) {

--- a/extensions/discord/src/internal/listeners.ts
+++ b/extensions/discord/src/internal/listeners.ts
@@ -8,6 +8,7 @@ import {
   type GatewayGuildCreateDispatchData,
   type GatewayGuildDeleteDispatchData,
   type GatewayPresenceUpdateDispatchData,
+  type GatewayThreadDeleteDispatchData,
   type GatewayThreadUpdateDispatchData,
 } from "discord-api-types/v10";
 import type { Client } from "./client.js";
@@ -106,6 +107,14 @@ export abstract class ThreadUpdateListener extends BaseListener {
   readonly type = GatewayDispatchEvents.ThreadUpdate;
   abstract override handle(
     data: GatewayThreadUpdateDispatchData,
+    client: Client,
+  ): Promise<void> | void;
+}
+
+export abstract class ThreadDeleteListener extends BaseListener {
+  readonly type = GatewayDispatchEvents.ThreadDelete;
+  abstract override handle(
+    data: GatewayThreadDeleteDispatchData,
     client: Client,
   ): Promise<void> | void;
 }

--- a/extensions/discord/src/monitor.test.ts
+++ b/extensions/discord/src/monitor.test.ts
@@ -928,8 +928,12 @@ vi.spyOn(channelRuntimeModule, "enqueueSystemEvent").mockImplementation(enqueueS
 const routingModule = await import("openclaw/plugin-sdk/routing");
 vi.spyOn(routingModule, "resolveAgentRoute").mockImplementation(resolveAgentRouteMock);
 
-const { DiscordMessageListener, DiscordReactionListener, registerDiscordListener } =
-  await import("./monitor/listeners.js");
+const {
+  DiscordMessageListener,
+  DiscordReactionListener,
+  DiscordReactionRemoveListener,
+  registerDiscordListener,
+} = await import("./monitor/listeners.js");
 
 type MockWithCalls = { mock: { calls: unknown[][] } };
 
@@ -956,6 +960,7 @@ function makeReactionEvent(overrides?: {
   guildId?: string;
   channelId?: string;
   userId?: string;
+  username?: string;
   messageId?: string;
   emojiName?: string;
   botAsAuthor?: boolean;
@@ -986,7 +991,7 @@ function makeReactionEvent(overrides?: {
     user: {
       id: userId,
       bot: false,
-      username: "testuser",
+      username: overrides?.username ?? "testuser",
       discriminator: "0",
     },
     message: {
@@ -1096,6 +1101,18 @@ describe("discord DM reaction handling", () => {
         "discord:acc-1:dm:user-1",
       );
     }
+  });
+
+  it("keeps the actor id when a reaction removal does not include a Discord username", async () => {
+    const data = makeReactionEvent({ userId: "user-42", username: "", botAsAuthor: true });
+    const client = makeReactionClient({ channelType: ChannelType.DM });
+    const listener = new DiscordReactionRemoveListener(makeReactionListenerParams());
+
+    await listener.handle(data, client);
+
+    expect(enqueueSystemEventSpy).toHaveBeenCalledOnce();
+    const text = firstMockArg(enqueueSystemEventSpy, "enqueueSystemEvent");
+    expect(text).toContain("Discord reaction removed: 👍 by user-42 on");
   });
 
   it("blocks DM reactions when dmPolicy is disabled", async () => {

--- a/extensions/discord/src/monitor/listeners.reactions.ts
+++ b/extensions/discord/src/monitor/listeners.reactions.ts
@@ -469,7 +469,8 @@ async function handleDiscordReactionEvent(
         return reactionBase;
       }
       const emojiLabel = formatDiscordReactionEmoji(data.emoji);
-      const actorLabel = formatDiscordUserTag(user);
+      // Reaction removals do not include member/user details in Discord's gateway payload.
+      const actorLabel = formatDiscordUserTag(user) || user.id;
       const guildSlug =
         guildInfo?.slug ||
         (data.guild?.name

--- a/extensions/discord/src/monitor/listeners.thread-delete.test.ts
+++ b/extensions/discord/src/monitor/listeners.thread-delete.test.ts
@@ -1,0 +1,102 @@
+import { ChannelType, type GatewayThreadDeleteDispatchData } from "discord-api-types/v10";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const lifecycleMocks = vi.hoisted(() => {
+  const unbindThread = vi.fn();
+  return {
+    closeDiscordThreadSessions: vi.fn(async () => 1),
+    getThreadBindingManager: vi.fn<() => { unbindThread: typeof unbindThread } | null>(() => ({
+      unbindThread,
+    })),
+    unbindThread,
+  };
+});
+
+vi.mock("./thread-session-close.js", () => ({
+  closeDiscordThreadSessions: lifecycleMocks.closeDiscordThreadSessions,
+}));
+
+vi.mock("./thread-bindings.manager.js", () => ({
+  getThreadBindingManager: lifecycleMocks.getThreadBindingManager,
+}));
+
+async function createThreadDeleteListener() {
+  const listeners = await import("./listeners.js");
+  expect(listeners).toHaveProperty("DiscordThreadDeleteListener");
+  const Listener = (
+    listeners as unknown as {
+      DiscordThreadDeleteListener: new (
+        cfg: OpenClawConfig,
+        accountId: string,
+        logger: { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> },
+      ) => { handle: (event: GatewayThreadDeleteDispatchData) => Promise<void> };
+    }
+  ).DiscordThreadDeleteListener;
+  const cfg = {} as OpenClawConfig;
+  const logger = { info: vi.fn(), error: vi.fn() };
+  const listener = new Listener(cfg, "account-2", logger);
+  const deletedThread: GatewayThreadDeleteDispatchData = {
+    id: "thread-42",
+    guild_id: "guild-1",
+    parent_id: "channel-1",
+    type: ChannelType.PublicThread,
+  };
+  return { cfg, deletedThread, listener, logger };
+}
+
+describe("DiscordThreadDeleteListener", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("immediately unbinds deleted threads and archives their sessions without a farewell", async () => {
+    const { cfg, deletedThread, listener, logger } = await createThreadDeleteListener();
+
+    await listener.handle(deletedThread);
+
+    expect(lifecycleMocks.getThreadBindingManager).toHaveBeenCalledWith("account-2");
+    expect(lifecycleMocks.unbindThread).toHaveBeenCalledWith({
+      threadId: "thread-42",
+      reason: "thread-delete",
+      sendFarewell: false,
+    });
+    expect(lifecycleMocks.closeDiscordThreadSessions).toHaveBeenCalledWith({
+      cfg,
+      accountId: "account-2",
+      threadId: "thread-42",
+    });
+    expect(logger.info).toHaveBeenCalledWith("Discord thread deleted — reset sessions", {
+      threadId: "thread-42",
+      count: 1,
+    });
+  });
+
+  it("archives deleted-thread sessions when no account binding manager exists", async () => {
+    lifecycleMocks.getThreadBindingManager.mockReturnValueOnce(null);
+    const { cfg, deletedThread, listener } = await createThreadDeleteListener();
+
+    await listener.handle(deletedThread);
+
+    expect(lifecycleMocks.unbindThread).not.toHaveBeenCalled();
+    expect(lifecycleMocks.closeDiscordThreadSessions).toHaveBeenCalledWith({
+      cfg,
+      accountId: "account-2",
+      threadId: "thread-42",
+    });
+  });
+
+  it("reports session-close failures without claiming deleted-thread cleanup succeeded", async () => {
+    lifecycleMocks.closeDiscordThreadSessions.mockRejectedValueOnce(
+      new Error("session close failed"),
+    );
+    const { deletedThread, listener, logger } = await createThreadDeleteListener();
+
+    await expect(listener.handle(deletedThread)).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("discord thread-delete handler failed"),
+    );
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -14,6 +14,7 @@ import {
   MessageCreateListener,
   PresenceUpdateListener,
   ReadyListener,
+  ThreadDeleteListener,
   ThreadUpdateListener,
 } from "../internal/discord.js";
 import { canViewDiscordGuildChannel } from "../send.permissions.js";
@@ -34,6 +35,7 @@ import {
 } from "./presence-events.js";
 import { DiscordPresenceBaselineCache } from "./presence-transition-cache.js";
 import { isThreadArchived } from "./thread-bindings.discord-api.js";
+import { getThreadBindingManager } from "./thread-bindings.manager.js";
 import { closeDiscordThreadSessions } from "./thread-session-close.js";
 
 type Logger = ReturnType<typeof import("openclaw/plugin-sdk/runtime-env").createSubsystemLogger>;
@@ -509,6 +511,47 @@ export class DiscordThreadUpdateListener extends ThreadUpdateListener {
       onError: (err) => {
         const logger = this.logger ?? discordEventQueueLog;
         logger.error(danger(`discord thread-update handler failed: ${String(err)}`));
+      },
+    });
+  }
+}
+
+type ThreadDeleteEvent = Parameters<ThreadDeleteListener["handle"]>[0];
+
+export class DiscordThreadDeleteListener extends ThreadDeleteListener {
+  constructor(
+    private cfg: OpenClawConfig,
+    private accountId: string,
+    private logger?: Logger,
+  ) {
+    super();
+  }
+
+  async handle(data: ThreadDeleteEvent) {
+    await runDiscordListenerWithSlowLog({
+      logger: this.logger,
+      listener: this.constructor.name,
+      event: this.type,
+      run: async () => {
+        const threadId = data.id;
+        getThreadBindingManager(this.accountId)?.unbindThread({
+          threadId,
+          reason: "thread-delete",
+          sendFarewell: false,
+        });
+        const count = await closeDiscordThreadSessions({
+          cfg: this.cfg,
+          accountId: this.accountId,
+          threadId,
+        });
+        if (count > 0) {
+          const logger = this.logger ?? discordEventQueueLog;
+          logger.info("Discord thread deleted — reset sessions", { threadId, count });
+        }
+      },
+      onError: (err) => {
+        const logger = this.logger ?? discordEventQueueLog;
+        logger.error(danger(`discord thread-delete handler failed: ${String(err)}`));
       },
     });
   }

--- a/extensions/discord/src/monitor/provider.startup.test.ts
+++ b/extensions/discord/src/monitor/provider.startup.test.ts
@@ -92,6 +92,9 @@ vi.mock("./listeners.js", () => ({
   DiscordReactionRemoveListener: function DiscordReactionRemoveListener() {
     return { type: "reaction-remove" };
   },
+  DiscordThreadDeleteListener: function DiscordThreadDeleteListener() {
+    return { type: "thread-delete" };
+  },
   DiscordThreadUpdateListener: function DiscordThreadUpdateListener() {
     return { type: "thread-update" };
   },
@@ -397,7 +400,12 @@ describe("registerDiscordMonitorListeners", () => {
   it("skips reaction listeners when every configured guild disables reactions and DMs are off", () => {
     registerDiscordMonitorListeners(createListenerParams());
 
-    expect(registeredListenerTypes()).toEqual(["interaction", "message", "thread-update"]);
+    expect(registeredListenerTypes()).toEqual([
+      "interaction",
+      "message",
+      "thread-update",
+      "thread-delete",
+    ]);
   });
 
   it("keeps reaction listeners when direct messages can emit reaction notifications", () => {
@@ -440,6 +448,7 @@ describe("registerDiscordMonitorListeners", () => {
       "interaction",
       "message",
       "thread-update",
+      "thread-delete",
       "presence",
       "presence-guild-create",
       "presence-guild-delete",

--- a/extensions/discord/src/monitor/provider.startup.ts
+++ b/extensions/discord/src/monitor/provider.startup.ts
@@ -35,6 +35,7 @@ import {
   DiscordPresenceReadyListener,
   DiscordReactionListener,
   DiscordReactionRemoveListener,
+  DiscordThreadDeleteListener,
   DiscordThreadUpdateListener,
   registerDiscordListener,
 } from "./listeners.js";
@@ -286,6 +287,10 @@ export function registerDiscordMonitorListeners(params: {
   registerDiscordListener(
     params.client.listeners,
     new DiscordThreadUpdateListener(params.cfg, params.accountId, params.logger),
+  );
+  registerDiscordListener(
+    params.client.listeners,
+    new DiscordThreadDeleteListener(params.cfg, params.accountId, params.logger),
   );
 
   if (params.discordConfig.intents?.presence) {


### PR DESCRIPTION
Branch: `codex/qa100-discord-gateway-lifecycle`
Commit: `5c037ef0d3439926768906d24d94dbd92026033f`
Frozen base: `59e1d586147b98f0021fc9ff176d64214ad435c4`

## Summary

- Handle Discord `THREAD_DELETE` immediately in the existing plugin-owned gateway lifecycle instead of waiting for the periodic sweeper.
- Unbind only the deleted thread's account-owned binding, suppress farewell delivery to the deleted channel, and archive its associated sessions through the canonical thread-session owner.
- Invalidate cached thread channels on both `THREAD_UPDATE` and `THREAD_DELETE`, preventing deleted or changed threads from surviving the existing 30-second entity-cache TTL.
- Preserve the actual reaction actor id when Discord reaction-removal gateway payloads omit member/user names.
- Keep missing-manager cleanup and failure reporting explicit; preserve sibling presence behavior and avoid auth, role, config, SDK, or public API changes.

## Root causes fixed

1. Discord `THREAD_DELETE` had no lifecycle listener, leaving account bindings and sessions alive while stale deleted/updated thread data remained cached.
2. Reaction-removal gateway payloads expose `user_id` without member/user names, but display formatting trusted an empty synthetic username and emitted a blank actor.

## Verification

- Frozen pre-fix lifecycle/display RED: **4 failed / 50 passed**; separate entity-cache RED reproduced **2 stale-cache failures** for thread update and deletion.
- Remote Blacksmith Testbox focused owner and sibling suites: **100 tests passed**, including startup registration, account-2 scoping, no-farewell unbinding, session archival, missing managers, failure logging, cache invalidation, reaction display, presence, and canonical session-close siblings.
- Exact final remote `pnpm check:changed`: all repository guards, plugin boundaries, extension and extension-test TypeScript lanes, formatting, runtime import cycles, and lint passed; **0 lint warnings/errors**.
- Genuine final structured Codex autoreview with verified TruffleHog: **clean**, 0.93 confidence; separate strict read-only owner/dependency review: **clean**.
- Direct dependency proof: `discord-api-types/gateway/v10.d.ts` defines `GatewayThreadDeleteDispatchData` and reaction-removal `user_id` without member/user display details.

## Root causes fixed

**2 distinct Discord gateway lifecycle/display defects.**
