### PR TITLE
fix(doctor): isolate channel failures and preserve diagnostics

### DIFF
--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -82,9 +82,49 @@ describe("checkGatewayHealth", () => {
       method: "channels.status",
       params: { probe: true, timeoutMs: 5000 },
       timeoutMs: 6000,
+      config: cfg,
     });
     expect(runtime.error).not.toHaveBeenCalled();
     expect(note.mock.calls.map(([, title]) => title)).not.toContain("OpenClaw version mismatch");
+  });
+
+  it("reports failed channel diagnostics without marking a reachable gateway unhealthy", async () => {
+    callGateway
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce(new Error("channel probe timed out"));
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await expect(
+      checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 }),
+    ).resolves.toEqual({ authenticated: true, healthOk: true, status: { ok: true } });
+
+    expect(note).toHaveBeenCalledWith(
+      [
+        "Channel status probe failed: channel probe timed out",
+        "Retry: openclaw channels status --probe",
+      ].join("\n"),
+      "Channel warnings",
+    );
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("redacts credentials and terminal controls in channel probe failures", async () => {
+    const token = "sk-abcdefghijklmnopqrstuv";
+    callGateway
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce(
+        new Error(`\u001B[31mchannel probe failed\nAuthorization: Bearer ${token}`),
+      );
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await checkGatewayHealth({ runtime: runtime as never, cfg });
+
+    const [message, title] = note.mock.calls.at(-1) ?? [];
+    expect(title).toBe("Channel warnings");
+    expect(message).toContain("channel probe failed\\nAuthorization: Bearer");
+    expect(message).not.toContain(token);
+    expect(message).not.toContain("\u001B");
+    expect(message.split("\n")).toHaveLength(2);
   });
 
   it("notes CLI and gateway version mismatch when the gateway reports another runtime version", async () => {

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -1,5 +1,7 @@
 /** Gateway health probes used by doctor before deeper daemon and memory diagnostics. */
 import { note } from "../../packages/terminal-core/src/note.js";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { formatCliCommand } from "../cli/command-format.js";
 import { probeGatewayStatus } from "../cli/daemon-cli/probe.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -115,6 +117,7 @@ export async function checkGatewayHealth(params: {
         method: "channels.status",
         params: { probe: true, timeoutMs: 5000 },
         timeoutMs: 6000,
+        config: params.cfg,
       });
       const issues = collectChannelStatusIssues(statusLocal);
       if (issues.length > 0) {
@@ -130,8 +133,14 @@ export async function checkGatewayHealth(params: {
           "Channel warnings",
         );
       }
-    } catch {
-      // ignore: doctor already reported gateway health
+    } catch (error) {
+      note(
+        [
+          `Channel status probe failed: ${sanitizeTerminalText(formatErrorMessage(error))}`,
+          `Retry: ${formatCliCommand("openclaw channels status --probe")}`,
+        ].join("\n"),
+        "Channel warnings",
+      );
     }
     return { healthOk, authenticated: true, status };
   } catch (err) {

--- a/src/flows/channel-setup.status.test.ts
+++ b/src/flows/channel-setup.status.test.ts
@@ -14,6 +14,7 @@ type FormatChannelPrimerLine = typeof import("../channels/registry.js").formatCh
 type FormatChannelSelectionLine =
   typeof import("../channels/registry.js").formatChannelSelectionLine;
 type IsChannelConfigured = typeof import("../config/channel-configured.js").isChannelConfigured;
+type ChannelSetupPlugin = import("../channels/plugins/setup-wizard-types.js").ChannelSetupPlugin;
 type NoteChannelPrimerChannels = Parameters<
   typeof import("./channel-setup.status.js").noteChannelPrimer
 >[1];
@@ -258,6 +259,111 @@ describe("resolveChannelSetupSelectionContributions", () => {
       "Matrix\\nPlugin: installed",
       "Zalo\\nPlugin: install plugin to enable",
     ]);
+  });
+
+  it.each(["rejected status check", "synchronous status check", "adapter resolution"] as const)(
+    "keeps healthy channels selectable after a %s failure",
+    async (failurePoint) => {
+      const installedPlugins = [
+        {
+          id: "matrix",
+          meta: makeMeta("matrix", "Matrix"),
+          capabilities: { chatTypes: [] },
+          config: {} as ChannelSetupPlugin["config"],
+        },
+        {
+          id: "telegram",
+          meta: makeMeta("telegram", "Telegram"),
+          capabilities: { chatTypes: [] },
+          config: {} as ChannelSetupPlugin["config"],
+        },
+      ] satisfies ChannelSetupPlugin[];
+      listChatChannels.mockReturnValue([
+        makeMeta("matrix", "Matrix"),
+        makeMeta("telegram", "Telegram"),
+      ]);
+      isChannelConfigured.mockImplementation((_, channelId) => channelId === "matrix");
+
+      const failure = new Error("lazy Matrix setup module unavailable");
+      const summary = await collectChannelStatus({
+        cfg: {} as never,
+        accountOverrides: {},
+        installedPlugins,
+        resolveAdapter: (channel) => {
+          if (channel === "matrix" && failurePoint === "adapter resolution") {
+            throw failure;
+          }
+          return {
+            channel,
+            getStatus:
+              channel === "matrix"
+                ? failurePoint === "synchronous status check"
+                  ? () => {
+                      throw failure;
+                    }
+                  : async () => {
+                      throw failure;
+                    }
+                : async () => ({
+                    channel: "telegram",
+                    configured: true,
+                    statusLines: ["Telegram: configured"],
+                    selectionHint: "configured",
+                    quickstartScore: 5,
+                  }),
+          } as never;
+        },
+      });
+
+      expect(summary.statusByChannel.get("matrix")).toEqual({
+        channel: "matrix",
+        configured: true,
+        statusLines: ["Matrix: status unavailable (lazy Matrix setup module unavailable)"],
+        selectionHint: "status unavailable",
+      });
+      expect(summary.statusByChannel.get("telegram")).toEqual({
+        channel: "telegram",
+        configured: true,
+        statusLines: ["Telegram: configured"],
+        selectionHint: "configured",
+        quickstartScore: 5,
+      });
+      expect(summary.statusLines).toEqual([
+        "Matrix: status unavailable (lazy Matrix setup module unavailable)",
+        "Telegram: configured",
+      ]);
+    },
+  );
+
+  it("redacts credentials and terminal controls in failed channel status checks", async () => {
+    const token = "sk-abcdefghijklmnopqrstuv";
+    const summary = await collectChannelStatus({
+      cfg: {} as never,
+      accountOverrides: {},
+      installedPlugins: [
+        {
+          id: "matrix",
+          meta: makeMeta("matrix", "Matrix"),
+          capabilities: { chatTypes: [] },
+          config: {} as ChannelSetupPlugin["config"],
+        },
+      ],
+      resolveAdapter: (channel) =>
+        ({
+          channel,
+          getStatus: async () => {
+            throw new Error(`\u001B[31mloader failed\nAuthorization: Bearer ${token}`);
+          },
+        }) as never,
+    });
+
+    const statusLine = summary.statusLines[0];
+    expect(statusLine).toContain(
+      "Matrix: status unavailable (loader failed\\nAuthorization: Bearer",
+    );
+    expect(statusLine).not.toContain(token);
+    expect(statusLine).not.toContain("\u001B");
+    expect(statusLine).not.toContain("\n");
   });
 
   it("localizes channel status note labels", async () => {

--- a/src/flows/channel-setup.status.ts
+++ b/src/flows/channel-setup.status.ts
@@ -20,6 +20,7 @@ import { resolveChannelSetupWizardAdapterForPlugin } from "../commands/channel-s
 import type { ChannelChoice } from "../commands/onboard-types.js";
 import { isChannelConfigured } from "../config/channel-configured.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   findBundledPluginSourceInMap,
   resolveBundledPluginSources,
@@ -355,22 +356,35 @@ export async function collectChannelStatus(params: {
       resolveChannelSetupWizardAdapterForPlugin(
         installedPlugins.find((plugin) => plugin.id === channel),
       ));
-  const statusEntries = await Promise.all(
-    installedPlugins.flatMap((plugin) => {
-      if (!shouldShowChannelInSetup(plugin.meta)) {
-        return [];
-      }
-      const adapter = resolveAdapter(plugin.id);
-      if (!adapter) {
-        return [];
-      }
-      return adapter.getStatus({
-        cfg: params.cfg,
-        options: params.options,
-        accountOverrides: params.accountOverrides,
-      });
-    }),
-  );
+  const statusEntries = (
+    await Promise.all(
+      installedPlugins
+        .filter((plugin) => shouldShowChannelInSetup(plugin.meta))
+        .map(async (plugin): Promise<ChannelSetupStatus | undefined> => {
+          try {
+            const adapter = resolveAdapter(plugin.id);
+            if (!adapter) {
+              return undefined;
+            }
+            return await adapter.getStatus({
+              cfg: params.cfg,
+              options: params.options,
+              accountOverrides: params.accountOverrides,
+            });
+          } catch (error) {
+            const detail = formatSetupFreeText(formatErrorMessage(error));
+            return {
+              channel: plugin.id,
+              configured: isChannelConfigured(params.cfg, plugin.id),
+              statusLines: [
+                `${formatSetupSelectionLabel(plugin.meta.label, plugin.id)}: status unavailable (${detail})`,
+              ],
+              selectionHint: "status unavailable",
+            };
+          }
+        }),
+    )
+  ).filter((status): status is ChannelSetupStatus => status !== undefined);
   const statusByChannel = new Map(
     statusEntries.map((entry: ChannelSetupStatus) => [entry.channel, entry]),
   );


### PR DESCRIPTION
## What Problem This Solves

One rejected or synchronously failing channel-plugin setup adapter aborted setup's entire channel picker, preventing healthy channels from being configured. Doctor also sent its follow-up `channels.status` RPC without the authoritative gateway configuration and silently discarded any resulting diagnostic failure while reporting the gateway healthy.

## Why This Change Was Made

The canonical channel setup status collector is responsible for representing every installed channel, including a degraded plugin. It now isolates resolver, synchronous adapter, and asynchronous status failures per plugin while preserving the configured owner, original order, healthy siblings, and quickstart metadata. Doctor's existing gateway-health owner now forwards the same configuration to both RPC calls and emits one sanitized warning plus its existing retry command when the optional channel probe fails.

## User Impact

A broken plugin no longer blocks setup of unrelated healthy channels; its visible picker entry explains the degraded status. Doctor targets the intended gateway and reports unavailable channel diagnostics without falsely declaring a reachable gateway unhealthy. Credential values and terminal control sequences remain redacted or sanitized.

## Evidence

- Exact branch: `codex/qa100-doctor-setup-channels`.
- Exact commit: `2741b19324f47c42052ccccddef41243fe60fc98`.
- Immutable local-main parent: `25bb1da3a7314f027c477d8c14d6d95d058fa00d`.
- Two independent production roots: plugin status collection at `src/flows/channel-setup.status.ts:360` and doctor follow-up diagnostics at `src/commands/doctor-gateway-health.ts:117`.
- Actual dependency contract: setup adapters return asynchronous plugin-owned status at `src/channels/plugins/setup-wizard-types.ts:424`, and the Matrix wizard dynamically loads its implementation at `extensions/matrix/src/setup-core.ts:26`.
- Immutable-parent RED reproduced a rejected plugin aborting healthy siblings, a missing authoritative doctor configuration, and a silently swallowed channel-probe failure.
- GREEN: `PATH=/Users/steipete/.local/bin:$PATH node scripts/run-vitest.mjs src/flows/channel-setup.status.test.ts src/commands/doctor-gateway-health.test.ts` passed **32/32 focused owner tests** across both Vitest projects.
- Focused regressions cover rejected promises, synchronous status calls, synchronous adapter-resolution failures, failed configured-plugin visibility, stable healthy order/scoring, exact RPC configuration, visible retry diagnostics, bearer-secret redaction, and terminal-control/newline sanitization.
- Independent strict whole-owner and dependency-contract review: **CLEAN**, no actionable findings.
- Structured default Codex `gpt-5.6-sol` high-reasoning autoreview: **CLEAN**, correctness confidence **0.95**; approved TruffleHog preflight clean.
- Targeted existing-binary formatting checks, `git diff --check`, exact immutable parent, and final clean committed worktree passed.
- No authentication, security policy, SQLite, persistent state, migration, configuration shape, service behavior, public plugin SDK, or public setup contract changes.
