### PR TITLE
fix(ci): stop upstream-only scheduled lanes from running in forks

### DIFF
--- a/.github/workflows/openclaw-scheduled-live-checks.yml
+++ b/.github/workflows/openclaw-scheduled-live-checks.yml
@@ -20,6 +20,9 @@ env:
 
 jobs:
   live_and_openwebui_checks:
+    # Live suites need org-only provider keys, so a nightly cron can only fail in
+    # a fork. Run it upstream only; manual dispatch stays open to forks with keys.
+    if: github.repository == 'openclaw/openclaw' || github.event_name == 'workflow_dispatch'
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pr-ci-sweeper.yml
+++ b/.github/workflows/pr-ci-sweeper.yml
@@ -26,6 +26,9 @@ permissions: {}
 
 jobs:
   sweep:
+    # The app token needs an org-only secret, so an hourly cron can only fail in a
+    # fork. Run it upstream only; manual dispatch stays open to forks with own app.
+    if: github.repository == 'openclaw/openclaw' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
     runs-on: ubuntu-24.04

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2814,6 +2814,22 @@ describe("ci workflow guards", () => {
     expect(buildStepCache.with["restore-keys"]).toContain("build-all-v4-");
   });
 
+  // These crons need an org-only app token or org-only provider keys, so a fork's
+  // scheduled run can only fail. The repository arm runs the cron upstream only;
+  // the dispatch arm keeps manual runs open to forks that supply own credentials.
+  it.each([
+    [".github/workflows/pr-ci-sweeper.yml", "sweep"],
+    [".github/workflows/openclaw-scheduled-live-checks.yml", "live_and_openwebui_checks"],
+  ])("limits the %s cron to upstream but keeps manual dispatch", (workflowPath, jobName) => {
+    const workflow = parse(readFileSync(workflowPath, "utf8"));
+    const guard = workflow.jobs[jobName].if;
+
+    expect(workflow.on.schedule).toBeDefined();
+    expect(workflow.on.workflow_dispatch).not.toBeUndefined();
+    expect(guard).toContain("github.repository == 'openclaw/openclaw'");
+    expect(guard).toContain("github.event_name == 'workflow_dispatch'");
+  });
+
   it("warms protected caches without main-run cancellation", () => {
     const warmerSource = readFileSync(".github/workflows/vitest-cache-warm.yml", "utf8");
     const warmer = parse(warmerSource);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a fork that has not supplied its own credentials still
runs two upstream-only scheduled lanes, so the fork owner collects repeated
failed Actions runs they cannot act on.

Two crons read secrets that only exist in `openclaw/openclaw`:

- **PR CI Sweeper** (`cron: "7 * * * *"`) mints a GitHub App token from
  `secrets.GH_APP_PRIVATE_KEY`. Without that secret the run dies at the
  token step, every time.
- **OpenClaw Scheduled Live And E2E Checks** (`cron: "23 4 * * *"`) passes the
  org provider keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, ...) into the live
  reusable workflow, where the credential-validation steps fail.

So in a fork these crons can only consume Actions minutes and produce failure
notifications — hourly, for `PR CI Sweeper`.

## Why This Change Was Made

Both jobs now carry the repository guard this repo already uses for
upstream-only lanes:

```yaml
if: github.repository == 'openclaw/openclaw' || github.event_name == 'workflow_dispatch'
```

The same idiom is already on `node22-compat.yml:14`; the plain form is on
`vitest-cache-warm.yml:20` and `control-ui-locale-refresh.yml:48`. Keeping the
`workflow_dispatch` arm means a fork that installs its own app or supplies its
own provider keys can still run either lane by hand — only the unattended cron
is gated.

Scope is limited to these two lanes: they are the ones that fail on missing
upstream secrets. `install-smoke.yml` is left alone because it does pass in a
fork, and lanes that queue on unavailable `blacksmith-*` runners fail through a
different mechanism and are not addressed here.

## User Impact

Fork owners stop receiving CI failure notifications they cannot act on, and stop
spending Actions minutes on lanes that cannot pass without upstream secrets.
Upstream behavior is unchanged: in `openclaw/openclaw` both guards evaluate
true, so the sweeper and the nightly live checks run exactly as before.

## Evidence

**Behavior addressed:** an upstream-only scheduled workflow fires in a fork,
fails on a secret the fork cannot have, and notifies the fork owner.

**Real environment tested:** `masatohoshino/openclaw`, a live fork of this repo
with Actions enabled. This PR's commit was cherry-picked onto that fork's
default branch (`cd76809d9ae` → `3d8e2454950`, pushed 2026-07-31T13:30Z) so the
patched workflow would be picked up by its own hourly schedule. PR head
`ab0771166f8a4b09348ea29f0a4717109be930df`.

**Before / after on the same workflow in the same fork.** The only difference
between these runs is the `if:` line this PR adds:

```
$ gh run list --repo masatohoshino/openclaw --workflow "PR CI Sweeper" --limit 6 \
    --json createdAt,event,conclusion,headSha,databaseId

  2026-07-31T14:31:17Z  schedule          skipped   3d8e2454950   30638942176   <- AFTER
  2026-07-31T13:31:19Z  workflow_dispatch failure   3d8e2454950   30634779728   <- AFTER
  2026-07-31T11:34:14Z  schedule          failure   cd76809d9ae   30627489189   <- BEFORE
  2026-07-31T08:08:20Z  schedule          failure   cd76809d9ae   30615248188   <- BEFORE
  2026-07-31T04:35:18Z  schedule          failure   cd76809d9ae   30604541604   <- BEFORE
  2026-07-31T00:13:06Z  schedule          failure   cd76809d9ae   30592901568   <- BEFORE

  3d8e2454950 = fork default branch WITH this PR's guard
  cd76809d9ae = the same branch WITHOUT it
```

**Exact steps or command run after this patch:**

```bash
# schedule arm — wait for the fork's own hourly cron on the patched default branch
gh api "/repos/masatohoshino/openclaw/actions/runs/30638942176" \
  --jq '"event=\(.event) branch=\(.head_branch) conclusion=\(.conclusion)"'
gh api "/repos/masatohoshino/openclaw/actions/runs/30638942176/jobs" \
  --jq '.jobs[] | "job=\(.name) conclusion=\(.conclusion) steps=\(.steps|length)"'

# workflow_dispatch arm — the manual path must stay eligible
gh workflow run "PR CI Sweeper" --repo masatohoshino/openclaw --ref main -f dry_run=true
gh api "/repos/masatohoshino/openclaw/actions/runs/30634779728/jobs" \
  --jq '.jobs[0].steps[] | "\(.number). \(.name) -> \(.conclusion)"'

# regression coverage
node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts
```

**Evidence after fix:**

```
# schedule arm
event=schedule branch=main conclusion=skipped
job=sweep conclusion=skipped steps=0

# workflow_dispatch arm
1. Set up job -> success
2. Run actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 -> success
3. Run actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 -> success
4. Run actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 -> failure
5. Sweep dropped PR CI runs -> skipped
8. Post Run actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 -> success
9. Post Run actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 -> success
10. Post Run actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 -> success
11. Complete job -> success

# regression coverage
Test Files  1 passed (1)
     Tests  95 passed (95)
```

**Observed result after fix:** on the patched default branch the scheduled run
skipped the job outright — **zero steps ran**, so there is no app-token step, no
failure and no notification. The same commit dispatched manually still ran the
job — 8 of the 9 listed steps executed. The one that did not is
`Sweep dropped PR CI runs`, skipped downstream of the token step, which failed
exactly as it does on the unguarded schedule. That is the intended escape hatch
for a fork with its own app.

Before the patch the same workflow on the same branch had failed **115 of 115**
scheduled runs, every one at the identical
`actions/create-github-app-token@bcd2ba49...` step:

```
Error: The 'private-key' input must be set to a non-empty string. If using a
secret or variable, ensure it is available in this workflow context.
```

Also clean: `git diff --check`, `oxfmt --check` on the touched test, and the
existing `test/scripts/check-workflows.test.ts` suite (7 tests, not modified by
this PR) against the edited workflow files.

**What was not tested:**

- **`OpenClaw Scheduled Live And E2E Checks` was not observed after the patch.**
  Its cron is `23 4 * * *`, so the next scheduled firing had not arrived. It
  receives the byte-identical guard expression on the workflow's only job, and
  the sweeper result above shows what that expression does to a fork schedule,
  but I am not claiming to have watched this one skip.
- I cannot run either cron inside `openclaw/openclaw`, so the upstream-side
  no-op rests on the guard expression plus the three lanes in this repo that
  already carry it (`control-ui-locale-refresh.yml`, `vitest-cache-warm.yml`,
  `node22-compat.yml` — 40 scheduled runs in this fork, all `skipped`, zero
  failures).
- The nightly lane's pre-patch failure attribution is partial: of 29 failed
  scheduled runs (2026-07-02 .. 2026-07-30), 25 contain at least one
  credential-validation step failure (`Validate provider credential`,
  `Validate Docker E2E credentials`, `Validate live cache credentials`) and 4
  record no failing step at all — a workflow-level failure I am not attributing
  to missing secrets. The sweeper attribution is complete (115/115).
