### PR TITLE
fix(telegram): preserve album captions, mentions, retries, and topics

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media-group.runtime.ts
@@ -16,7 +16,11 @@ import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { danger, warn } from "openclaw/plugin-sdk/runtime-env";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { firstDefined, type NormalizedAllowFrom } from "./bot-access.js";
-import { hasInboundMedia, isRecoverableMediaGroupError } from "./bot-handlers.media.js";
+import {
+  hasInboundMedia,
+  isDurablyRetryableInboundMediaError,
+  isRecoverableMediaGroupError,
+} from "./bot-handlers.media.js";
 import type { TelegramHandlerMessageRuntime } from "./bot-handlers.message.runtime.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
 import type { TelegramAmbientTranscriptWatermark } from "./bot-message-context.types.js";
@@ -24,7 +28,13 @@ import type { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import type { TelegramSpooledReplayDeferredParticipant } from "./bot-processing-outcome.js";
 import { MEDIA_GROUP_TIMEOUT_MS, type MediaGroupEntry } from "./bot-updates.js";
 import { resolveMedia } from "./bot/delivery.resolve-media.js";
-import { getTelegramTextParts, hasBotMention, resolveTelegramPrimaryMedia } from "./bot/helpers.js";
+import {
+  buildTelegramThreadParams,
+  getTelegramTextParts,
+  hasBotMention,
+  resolveTelegramPrimaryMedia,
+  resolveTelegramThreadSpec,
+} from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { isTelegramForumServiceMessage } from "./forum-service-message.js";
 import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
@@ -214,12 +224,56 @@ export function createTelegramInboundMediaGroupRuntime(
   const processMediaGroup = async (entry: BufferedMediaGroupEntry) => {
     try {
       entry.messages.sort((a, b) => a.msg.message_id - b.msg.message_id);
-      const primary =
+      let primary =
         entry.messages.find((item) => item.msg.caption || item.msg.text) ?? entry.messages[0];
       if (!primary) {
         releaseDispatchDedupeClaims(entry.dispatchDedupeClaims);
         settleSpooledReplayParticipants(entry.spooledReplayParticipants, { kind: "skipped" });
         return;
+      }
+      const captionParts = entry.messages
+        .map(({ msg }) => getTelegramTextParts(msg))
+        .filter(({ text }) => text.trim());
+      if (captionParts.length > 1) {
+        const botUsername = primary.ctx.me?.username;
+        const commandCaptionIndex = captionParts.findIndex(({ text }) =>
+          hasControlCommand(text, entry.authorizationCfg, {
+            botUsername,
+          }),
+        );
+        if (commandCaptionIndex > 0) {
+          // Command detection is prefix-based in both ingress and canonical message processing.
+          const [commandCaption] = captionParts.splice(commandCaptionIndex, 1);
+          if (commandCaption) {
+            captionParts.unshift(commandCaption);
+          }
+        }
+        let caption = "";
+        const captionEntities: NonNullable<Message["caption_entities"]> = [];
+        for (const { text, entities } of captionParts) {
+          if (caption) {
+            caption += "\n";
+          }
+          const offset = caption.length;
+          caption += text;
+          for (const entity of entities) {
+            captionEntities.push({ ...entity, offset: entity.offset + offset });
+          }
+        }
+        const combinedMessage = {
+          ...primary.msg,
+          text: undefined,
+          entities: undefined,
+          caption,
+          caption_entities: captionEntities.length ? captionEntities : undefined,
+        } as Message;
+        // Keep grammY context methods/getters while exposing the complete album to every owner.
+        const combinedContext = Object.create(primary.ctx) as TelegramContext;
+        Object.defineProperty(combinedContext, "message", {
+          value: combinedMessage,
+          enumerable: true,
+        });
+        primary = { ctx: combinedContext, msg: combinedMessage };
       }
       if (await shouldSkipMediaDownloadForUnaddressedMentionGroup({ ...entry, ...primary })) {
         releaseDispatchDedupeClaims(entry.dispatchDedupeClaims);
@@ -238,14 +292,16 @@ export function createTelegramInboundMediaGroupRuntime(
           media = await resolveMedia({ ctx, maxBytes: mediaMaxBytes, ...mediaRuntimeWithAbort });
         } catch (error) {
           if (
-            mediaRuntimeWithAbort.abortSignal?.aborted &&
-            entry.spooledReplayParticipants.length
+            entry.spooledReplayParticipants.length > 0 &&
+            (mediaRuntimeWithAbort.abortSignal?.aborted ||
+              isDurablyRetryableInboundMediaError(error))
           ) {
             throw error;
           }
           if (!isRecoverableMediaGroupError(error)) {
             throw error;
           }
+          // Classic polling cannot replay a failed album; retain its existing partial-delivery path.
           runtime.log?.(warn(`media group: skipping photo that failed to fetch: ${String(error)}`));
           allMedia.push({ kind: nativeKind, sourceMessageId });
           selection.set(sourceMessageId, "exclude");
@@ -278,6 +334,13 @@ export function createTelegramInboundMediaGroupRuntime(
               primary.msg.chat.id,
               `⚠️ Received ${materializedCount} of ${entry.messages.length} images — ${skippedCount} could not be fetched and ${verb} skipped.`,
               {
+                ...buildTelegramThreadParams(
+                  resolveTelegramThreadSpec({
+                    isGroup: entry.isGroup,
+                    isForum: entry.isForum,
+                    messageThreadId: entry.resolvedThreadId ?? entry.dmThreadId,
+                  }),
+                ),
                 reply_parameters: {
                   message_id: primary.msg.message_id,
                   allow_sending_without_reply: true,

--- a/extensions/telegram/src/bot-handlers.inbound.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.inbound.runtime.ts
@@ -32,7 +32,12 @@ import {
   recordTelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
 import { resolveMedia } from "./bot/delivery.resolve-media.js";
-import { getTelegramTextParts, resolveTelegramPrimaryMedia } from "./bot/helpers.js";
+import {
+  buildTelegramThreadParams,
+  getTelegramTextParts,
+  resolveTelegramPrimaryMedia,
+  resolveTelegramThreadSpec,
+} from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
 import type { TelegramMessageDispatchReplayClaim } from "./message-dispatch-dedupe.js";
@@ -230,6 +235,13 @@ export function createTelegramHandlerInboundRuntime(
       });
     } catch (mediaErr) {
       const replayingSpooledUpdate = isTelegramSpooledReplayUpdate(ctx.update);
+      const warningThreadParams = buildTelegramThreadParams(
+        resolveTelegramThreadSpec({
+          isGroup,
+          isForum,
+          messageThreadId: resolvedThreadId ?? dmThreadId,
+        }),
+      );
       if (
         mediaRuntimeWithAbort.abortSignal?.aborted &&
         isDurablyRetryableInboundMediaError(mediaErr)
@@ -252,6 +264,7 @@ export function createTelegramHandlerInboundRuntime(
             runtime,
             fn: () =>
               bot.api.sendMessage(chatId, `⚠️ File too large. Maximum size is ${limitMb}MB.`, {
+                ...warningThreadParams,
                 reply_parameters: {
                   message_id: msg.message_id,
                   allow_sending_without_reply: true,
@@ -273,6 +286,7 @@ export function createTelegramHandlerInboundRuntime(
           runtime,
           fn: () =>
             bot.api.sendMessage(chatId, "⚠️ Failed to download media. Please try again.", {
+              ...warningThreadParams,
               reply_parameters: {
                 message_id: msg.message_id,
                 allow_sending_without_reply: true,

--- a/extensions/telegram/src/bot-handlers.media.test.ts
+++ b/extensions/telegram/src/bot-handlers.media.test.ts
@@ -50,8 +50,21 @@ describe("isDurablyRetryableInboundMediaError", () => {
 });
 
 describe("isRecoverableMediaGroupError preserves album partial delivery (#55216)", () => {
-  it("still skips-and-warns transient and permanent album fetch failures", () => {
+  it("still skips-and-warns unclassified and permanent album fetch failures", () => {
     expect(isRecoverableMediaGroupError(new MediaFetchError("fetch_failed", "x"))).toBe(true);
     expect(isRecoverableMediaGroupError(new MediaFetchError("max_bytes", "x"))).toBe(true);
+  });
+
+  it("classifies transient album failures for durable retry while preserving live partial delivery", () => {
+    for (const status of [408, 429, 500, 502, 503, 504]) {
+      const error = new MediaFetchError("http_error", "temporary", { status });
+      expect(isDurablyRetryableInboundMediaError(error)).toBe(true);
+      expect(isRecoverableMediaGroupError(error)).toBe(true);
+    }
+    const networkError = new MediaFetchError("fetch_failed", "temporary", {
+      cause: Object.assign(new Error("connection reset"), { code: "ECONNRESET" }),
+    });
+    expect(isDurablyRetryableInboundMediaError(networkError)).toBe(true);
+    expect(isRecoverableMediaGroupError(networkError)).toBe(true);
   });
 });

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -849,15 +849,21 @@ describe("createTelegramBot channel_post media", () => {
     }
   });
 
-  it("durably retries every spooled album update when shutdown aborts a download", async () => {
+  it.each([
+    { failure: "shutdown aborts a download", shutdownAbort: true },
+    { failure: "Telegram temporarily throttles a download", shutdownAbort: false },
+  ])("durably retries every spooled album update when $failure", async ({ shutdownAbort }) => {
     setOpenChannelPostConfig();
     sendMessageSpy.mockClear();
     replySpy.mockClear();
 
     const shutdown = new AbortController();
     saveRemoteMedia.mockImplementationOnce(async () => {
-      shutdown.abort();
-      throw Object.assign(new Error("aborted"), { name: "AbortError" });
+      if (shutdownAbort) {
+        shutdown.abort();
+        throw Object.assign(new Error("aborted"), { name: "AbortError" });
+      }
+      throw new MediaFetchError("http_error", "rate limited", { status: 429 });
     });
 
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -4,6 +4,7 @@ import {
   readRemoteMediaBufferSpy,
   setNextSavedMediaPath,
   telegramBotDepsForTest,
+  telegramMediaHarnessSendMessageSpy,
 } from "./bot.media.e2e-harness.js";
 import {
   TELEGRAM_TEST_TIMINGS,
@@ -361,6 +362,147 @@ describe("telegram media groups", () => {
   const MEDIA_GROUP_TEST_TIMEOUT_MS = process.platform === "win32" ? 45_000 : 20_000;
   const MEDIA_GROUP_FLUSH_MS = TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs + 40;
   const MEDIA_GROUP_WAIT_TIMEOUT_MS = Math.max(2_000, MEDIA_GROUP_FLUSH_MS * 10);
+
+  it.each([
+    ["@openclaw_bot second album details", "mention"],
+    ["/status", "bot_command"],
+    ["/stop", "bot_command"],
+  ] as const)(
+    "preserves captions and later %s from every message in a forum album",
+    async (laterCaption, entityType) => {
+      const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;
+      telegramBotDepsForTest.getRuntimeConfig = (() => ({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupAllowFrom: ["777"],
+            groupPolicy: "open",
+            groups: {
+              "-10042": { allowFrom: ["777"], groupPolicy: "open", requireMention: true },
+            },
+          },
+        },
+      })) as typeof telegramBotDepsForTest.getRuntimeConfig;
+      const { handler, replySpy } = await createBotHandlerWithOptions({});
+      const fetchSpy = mockTelegramPngDownload();
+      const baseMessage = {
+        chat: { id: -10042, type: "supergroup" as const, is_forum: true },
+        from: { id: 777, is_bot: false, first_name: "Ada" },
+        message_thread_id: 101,
+        is_topic_message: true,
+        media_group_id: "album-all-captions",
+      };
+
+      try {
+        await Promise.all([
+          handler({
+            message: {
+              ...baseMessage,
+              message_id: 301,
+              date: 1736380800,
+              caption: "First album details 💙",
+              photo: [{ file_id: "album-caption-1" }],
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({ file_path: "photos/album-caption-1.jpg" }),
+          }),
+          handler({
+            message: {
+              ...baseMessage,
+              message_id: 302,
+              date: 1736380801,
+              caption: laterCaption,
+              caption_entities: [
+                { type: entityType, offset: 0, length: laterCaption.split(" ")[0]?.length ?? 0 },
+              ],
+              photo: [{ file_id: "album-caption-2" }],
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({ file_path: "photos/album-caption-2.jpg" }),
+          }),
+        ]);
+
+        await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1), {
+          timeout: MEDIA_GROUP_WAIT_TIMEOUT_MS,
+          interval: 2,
+        });
+        expect(replyPayload(replySpy).Body).toContain("First album details 💙");
+        expect(replyPayload(replySpy).Body).toContain(laterCaption);
+      } finally {
+        telegramBotDepsForTest.getRuntimeConfig = originalLoadConfig;
+        fetchSpy.mockRestore();
+      }
+    },
+    MEDIA_GROUP_TEST_TIMEOUT_MS,
+  );
+
+  it.each([
+    {
+      description: "forum topic",
+      chat: { id: -10042, type: "supergroup" as const, is_forum: true },
+      threadId: 202,
+    },
+    {
+      description: "bot DM topic",
+      chat: { id: 4242, type: "private" as const },
+      threadId: 303,
+    },
+  ])(
+    "sends a skipped-media warning into the originating $description",
+    async ({ chat, threadId }) => {
+      const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;
+      telegramBotDepsForTest.getRuntimeConfig = (() => ({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupAllowFrom: ["777"],
+            groupPolicy: "open",
+            groups: {
+              "-10042": { allowFrom: ["777"], groupPolicy: "open", requireMention: false },
+            },
+          },
+        },
+      })) as typeof telegramBotDepsForTest.getRuntimeConfig;
+      const { handler, replySpy } = await createBotHandlerWithOptions({});
+      telegramMediaHarnessSendMessageSpy.mockClear();
+      readRemoteMediaBufferSpy.mockRejectedValueOnce(
+        new Error("Telegram media exceeds 20 MB limit"),
+      );
+
+      try {
+        await handler({
+          message: {
+            chat,
+            from: { id: 777, is_bot: false, first_name: "Ada" },
+            message_id: 401,
+            message_thread_id: threadId,
+            is_topic_message: true,
+            caption: "Forum album",
+            date: 1736380800,
+            media_group_id: "album-warning-topic",
+            photo: [{ file_id: "album-warning" }],
+          },
+          me: { username: "openclaw_bot", has_topics_enabled: true },
+          getFile: async () => ({ file_path: "photos/album-warning.jpg" }),
+        });
+
+        await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1), {
+          timeout: MEDIA_GROUP_WAIT_TIMEOUT_MS,
+          interval: 2,
+        });
+        expect(telegramMediaHarnessSendMessageSpy).toHaveBeenCalledWith(
+          chat.id,
+          expect.stringContaining("could not be fetched"),
+          expect.objectContaining({ message_thread_id: threadId }),
+        );
+      } finally {
+        telegramBotDepsForTest.getRuntimeConfig = originalLoadConfig;
+      }
+    },
+    MEDIA_GROUP_TEST_TIMEOUT_MS,
+  );
 
   it(
     "uses custom apiRoot for buffered media-group downloads",

--- a/extensions/telegram/src/bot.media.e2e-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e-harness.ts
@@ -127,6 +127,8 @@ const apiStub: ApiStub = {
   setMyCommands: vi.fn(async () => undefined),
 };
 
+export const telegramMediaHarnessSendMessageSpy = apiStub.sendMessage;
+
 const throttlerSpy = vi.fn(() => "throttler");
 const defaultRuntimeConfig = (() =>
   ({

--- a/extensions/telegram/src/bot.media.warning-topics.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.warning-topics.e2e.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  readRemoteMediaBufferSpy,
+  telegramBotDepsForTest,
+  telegramMediaHarnessSendMessageSpy,
+} from "./bot.media.e2e-harness.js";
+import { createBotHandlerWithOptions } from "./bot.media.test-utils.js";
+
+describe("Telegram single-media warnings", () => {
+  it.each([
+    {
+      description: "forum topic",
+      chat: { id: -10042, type: "supergroup" as const, is_forum: true },
+      threadId: 202,
+      expectedThreadId: 202,
+      failure: new Error("Telegram media exceeds 20 MB limit"),
+      expectedWarning: "File too large",
+    },
+    {
+      description: "bot DM topic",
+      chat: { id: 4242, type: "private" as const },
+      threadId: 303,
+      expectedThreadId: 303,
+      failure: new Error("Telegram media exceeds 20 MB limit"),
+      expectedWarning: "File too large",
+    },
+    {
+      description: "forum General topic",
+      chat: { id: -10042, type: "supergroup" as const, is_forum: true },
+      threadId: 1,
+      expectedThreadId: undefined,
+      failure: new Error("Telegram media exceeds 20 MB limit"),
+      expectedWarning: "File too large",
+    },
+    {
+      description: "forum topic after an ordinary download failure",
+      chat: { id: -10042, type: "supergroup" as const, is_forum: true },
+      threadId: 404,
+      expectedThreadId: 404,
+      failure: new Error("permanent download failure"),
+      expectedWarning: "Failed to download media",
+    },
+  ])(
+    "keeps $description warnings in their originating Telegram thread",
+    async ({ chat, threadId, expectedThreadId, failure, expectedWarning }) => {
+      const originalLoadConfig = telegramBotDepsForTest.getRuntimeConfig;
+      telegramBotDepsForTest.getRuntimeConfig = (() => ({
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            groupAllowFrom: ["777"],
+            groupPolicy: "open",
+            groups: {
+              "-10042": { allowFrom: ["777"], groupPolicy: "open", requireMention: false },
+            },
+          },
+        },
+      })) as typeof telegramBotDepsForTest.getRuntimeConfig;
+
+      try {
+        const { handler } = await createBotHandlerWithOptions({});
+        telegramMediaHarnessSendMessageSpy.mockClear();
+        readRemoteMediaBufferSpy.mockRejectedValueOnce(failure);
+
+        await handler({
+          message: {
+            chat,
+            from: { id: 777, is_bot: false, first_name: "Ada" },
+            message_id: 901,
+            message_thread_id: threadId,
+            is_topic_message: true,
+            caption: "Topic attachment",
+            date: 1736380800,
+            photo: [{ file_id: "topic-attachment" }],
+          },
+          me: { username: "openclaw_bot", has_topics_enabled: true },
+          getFile: async () => ({ file_path: "photos/topic-attachment.jpg" }),
+        });
+
+        expect(telegramMediaHarnessSendMessageSpy).toHaveBeenCalledWith(
+          chat.id,
+          expect.stringContaining(expectedWarning),
+          expect.objectContaining({
+            reply_parameters: expect.objectContaining({ message_id: 901 }),
+          }),
+        );
+        const warning = telegramMediaHarnessSendMessageSpy.mock.calls.find(
+          ([, text]) => typeof text === "string" && text.includes(expectedWarning),
+        );
+        if (!warning) {
+          throw new Error(`Missing ${expectedWarning} Telegram media warning`);
+        }
+        const options = warning[2] as { message_thread_id?: number };
+        expect(options.message_thread_id).toBe(expectedThreadId);
+      } finally {
+        telegramBotDepsForTest.getRuntimeConfig = originalLoadConfig;
+      }
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Telegram albums currently discard captions and bot mentions/control commands supplied by later album messages. Temporary download failures are acknowledged as completed even for durably replayable albums, and media-failure warnings escape their originating forum or bot-DM topic.

## Why This Change Was Made

Keep inbound album assembly, durable retry decisions, and failure-message routing within their existing Telegram plugin owners. Merge every album caption and UTF-16 entity, prioritize a later authorized control-command caption so canonical command detection still works, retry transient failures only when durable replay participants exist, retain classic live-album partial delivery, and reuse the existing thread helper for both album and single-media warnings.

## Evidence

- Exact commit: `a13fae2481c92a62314fd23750e6b102a6c52b2a`.
- Branch: `codex/qa100-telegram-album-owner`.
- Frozen local main parent: `59e1d586147b98f0021fc9ff176d64214ad435c4`.
- Direct installed grammY proof: media-group messages independently own `caption` and `caption_entities`; Telegram entity offsets are UTF-16 code units; grammY `Context.message`/`Context.msg` getters preserve inherited context behavior; forum/bot-DM routing uses `message_thread_id`, distinct from unapproved direct-message-topic API fields.
- Real immutable-parent RED on dedicated Blacksmith Testbox `tbx_01kyw03xr6s939natq3977wyjq`: later-caption mention was silently skipped, album warning omitted its forum thread, and the frozen durable album owner settled HTTP 429 replay as `completed` instead of `failed-retryable`.
- Additional real RED after initial caption merge exposed that `/status` in a later caption still failed canonical prefix-only command detection; fixed by placing the first authorized command-bearing caption first while retaining all album captions/entities.
- Independent review caught the classic-polling abort compatibility boundary; the final fix retries temporary errors only for durable replay participants and preserves existing live partial delivery.
- Full real owner/sibling validation on the same dedicated Testbox: **46 tests passed across five files**, including later bot mentions, `/status`, `/stop`, astral-character UTF-16 entities, durable HTTP 429 and shutdown replay, classic polling partial delivery, permanent album warnings, forum-topic warnings, bot-DM warnings, General-topic thread omission, and ordinary single-media failure warnings.
- Targeted oxlint and committed whitespace checks passed; dedicated Testbox lease stopped.
- Exhaustive independent read-only owner/dependency review: **CLEAN**.
- Structured `gpt-5.6-sol` high autoreview: **CLEAN**, confidence **0.84**; genuine TruffleHog credential scan clean.
- No public SDK/configuration, authorization, direct-message-topic API/auth, rich-message preview, send-edit, or another agent-owned streaming production files changed.
