### PR TITLE
fix(ui): preserve provider mutation ownership and visible outcomes

### DIFF
--- a/ui/src/pages/model-providers/config-mutation.ts
+++ b/ui/src/pages/model-providers/config-mutation.ts
@@ -1,0 +1,103 @@
+import { t } from "../../i18n/index.ts";
+import type { RuntimeConfigCapability } from "../../lib/config/index.ts";
+import type { ModelProviderRowMessage } from "./view.ts";
+
+export type ModelProviderConfigMutation = {
+  key: string;
+  raw: Record<string, unknown>;
+  note: string;
+  success: string;
+  replacePaths?: string[];
+};
+
+export type ModelProviderConfigMutationResult =
+  | { ok: false }
+  | { ok: true; agentEpoch: number; warning: string | null };
+
+type ModelProviderConfigMutationOwner = {
+  runtimeConfig: RuntimeConfigCapability;
+  agentEpoch: number;
+  isCurrentClient: () => boolean;
+  isCurrentAgent: () => boolean;
+  refreshProviders: () => Promise<void>;
+  setBusy: (busy: boolean) => void;
+  setMessage: (message: ModelProviderRowMessage | null) => void;
+};
+
+export function modelProviderErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return typeof error === "string" && error.trim() ? error : t("modelProviders.requestFailed");
+}
+
+/**
+ * Config patches are global; the initiating agent owns only busy/message UI.
+ * Refresh warnings must preserve an already acknowledged mutation.
+ */
+export async function runModelProviderConfigMutation(
+  owner: ModelProviderConfigMutationOwner,
+  params: ModelProviderConfigMutation,
+): Promise<ModelProviderConfigMutationResult> {
+  const { agentEpoch, runtimeConfig } = owner;
+  owner.setBusy(true);
+  owner.setMessage(null);
+  try {
+    await runtimeConfig.ensureLoaded();
+    if (!owner.isCurrentClient()) {
+      return { ok: false };
+    }
+    const patched = await runtimeConfig.patch({
+      raw: params.raw,
+      note: params.note,
+      ...(params.replacePaths ? { replacePaths: params.replacePaths } : {}),
+    });
+    if (!owner.isCurrentClient()) {
+      return { ok: false };
+    }
+    if (!patched) {
+      if (owner.isCurrentAgent()) {
+        owner.setMessage({
+          kind: "error",
+          text: runtimeConfig.state.lastError ?? t("modelProviders.configUnavailable"),
+        });
+      }
+      return { ok: false };
+    }
+
+    let warning: string | null = null;
+    try {
+      await runtimeConfig.refresh();
+      // The config owner records ordinary config.get failures in lastError
+      // and resolves refresh(), so rejection alone cannot detect them.
+      warning = runtimeConfig.state.lastError;
+      if (!warning && owner.isCurrentClient()) {
+        await owner.refreshProviders();
+      }
+    } catch (error) {
+      // An acknowledged config patch is already committed; a later refresh
+      // failure must not turn it into a failed credential edit.
+      warning = modelProviderErrorMessage(error);
+    }
+    if (!owner.isCurrentClient()) {
+      return { ok: false };
+    }
+    if (owner.isCurrentAgent()) {
+      owner.setMessage({
+        kind: "success",
+        text: params.success,
+        ...(warning ? { warning } : {}),
+      });
+    }
+    return { ok: true, agentEpoch, warning };
+  } catch (error) {
+    if (owner.isCurrentClient() && owner.isCurrentAgent()) {
+      owner.setMessage({ kind: "error", text: modelProviderErrorMessage(error) });
+    }
+    return { ok: false };
+  } finally {
+    if (owner.isCurrentClient() && owner.isCurrentAgent()) {
+      owner.setBusy(false);
+    }
+  }
+}

--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -11,7 +11,7 @@ type DefaultModelsViewProps = {
   mutationBlockedReason: string | null;
   dirty: boolean;
   busy: Record<string, boolean>;
-  message?: { kind: "success" | "error"; text: string };
+  message?: { kind: "success" | "error"; text: string; warning?: string };
   onPrimaryChange: (model: string) => void;
   onFallbackAdd: (model: string) => void;
   onFallbackRemove: (index: number) => void;
@@ -164,7 +164,15 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
         </label>
       </div>
       ${props.message
-        ? html`<div class="callout ${props.message.kind}" role="status">${props.message.text}</div>`
+        ? html`<div
+            class="callout ${props.message.kind}"
+            role=${props.message.kind === "error" ? "alert" : "status"}
+          >
+            ${props.message.text}
+          </div>`
+        : nothing}
+      ${props.message?.warning
+        ? html`<div class="callout warning" role="status">${props.message.warning}</div>`
         : nothing}
     </div>
   `;

--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelsProbeResult } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import type { DefaultModelSelection, ModelProviderLogoutTarget } from "./data.ts";
 import { EMPTY_MODEL_PROVIDERS_DATA, type ModelProvidersData } from "./load.ts";
 import type { ModelProvidersRouteData } from "./model-providers-page.ts";
 import "./model-providers-page.ts";
@@ -13,9 +14,21 @@ type ModelProvidersPageTestElement = HTMLElement & {
   updateComplete: Promise<boolean>;
   busy: Record<string, boolean>;
   data: ModelProvidersData | null;
+  addProvider: () => Promise<void>;
+  addProviderId: string;
+  addProviderKey: string;
+  addProviderOpen: boolean;
+  defaultsDraft: DefaultModelSelection | null;
+  keyDraft: string;
+  keyEditorProvider: string | null;
+  logout: (cardId: string, targets: ModelProviderLogoutTarget[]) => Promise<void>;
+  messages: Record<string, { kind: "success" | "error"; text: string; warning?: string }>;
+  pendingLogoutProvider: string | null;
   probe: (cardId: string, providers: string[]) => Promise<void>;
   probeResults: Record<string, ModelsProbeResult>;
   routeData: ModelProvidersRouteData | undefined;
+  saveDefaultModels: () => Promise<void>;
+  saveKey: (provider: string, configKey: string) => Promise<void>;
   selectedAgentId: string;
 };
 
@@ -96,9 +109,12 @@ function createHarness(initialScopeId: string) {
       configFormMode: "form",
       configFormDirty: false,
       configAutoSaveStatus: "idle",
+      lastError: null as string | null,
     },
-    ensureLoaded: vi.fn(async () => undefined),
+    ensureLoaded: vi.fn(async (): Promise<void> => undefined),
+    patch: vi.fn(async () => true),
     patchForm: vi.fn(),
+    refresh: vi.fn(async () => undefined),
     save: vi.fn(async () => true),
     apply: vi.fn(async () => true),
     discardDraft: vi.fn(async () => undefined),
@@ -188,6 +204,226 @@ describe("ModelProvidersPage agent scope", () => {
       ["agents", "defaults", "fastModeDefault"],
       false,
     );
+  });
+
+  it("keeps a committed provider-key save successful when config refresh fails", async () => {
+    const { context, runtimeConfig } = createHarness("main");
+    runtimeConfig.refresh.mockImplementationOnce(async () => {
+      runtimeConfig.state.lastError = "config.get failed after provider-key commit";
+    });
+    const page = appendPage(context);
+    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    page.keyEditorProvider = "openai";
+    page.keyDraft = "replacement";
+
+    await page.saveKey("openai", "openai");
+
+    expect(runtimeConfig.patch).toHaveBeenCalledOnce();
+    expect(page.keyEditorProvider).toBeNull();
+    expect(page.messages.openai).toEqual({
+      kind: "success",
+      text: "Secret saved.",
+      warning: "config.get failed after provider-key commit",
+    });
+  });
+
+  it("keeps committed provider-add feedback visible when its refresh fails", async () => {
+    const { context, runtimeConfig } = createHarness("main");
+    runtimeConfig.refresh.mockImplementationOnce(async () => {
+      runtimeConfig.state.lastError = "config.get failed after provider add";
+    });
+    const page = appendPage(context);
+    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    page.addProviderOpen = true;
+    page.addProviderId = "anthropic";
+    page.addProviderKey = "new-provider-key";
+
+    await page.addProvider();
+    await page.updateComplete;
+
+    expect(runtimeConfig.patch).toHaveBeenCalledOnce();
+    expect(page.addProviderOpen).toBe(true);
+    expect(page.addProviderKey).toBe("");
+    const form = page.querySelector(".model-providers__add-form")?.parentElement;
+    expect(
+      [...form!.querySelectorAll('[role="status"]')].map((message) => message.textContent?.trim()),
+    ).toEqual(["Provider anthropic added.", "config.get failed after provider add"]);
+  });
+
+  it("keeps committed default models visible until their authoritative refresh succeeds", async () => {
+    const { context, runtimeConfig } = createHarness("main");
+    runtimeConfig.refresh.mockImplementationOnce(async () => {
+      runtimeConfig.state.lastError = "config.get failed after saving default models";
+    });
+    const page = appendPage(context);
+    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    const selection: DefaultModelSelection = {
+      primary: "openai/gpt-5",
+      fallbacks: [],
+      utilityModel: null,
+    };
+    page.defaultsDraft = selection;
+
+    await page.saveDefaultModels();
+
+    expect(runtimeConfig.patch).toHaveBeenCalledOnce();
+    expect(page.defaultsDraft).toBe(selection);
+    expect(page.messages.defaults).toEqual({
+      kind: "success",
+      text: "Default models saved.",
+      warning: "config.get failed after saving default models",
+    });
+  });
+
+  it("keeps a replacement agent's default-model draft after a global model write", async () => {
+    const { agentSelection, context, notifySelection, runtimeConfig } = createHarness("main");
+    const gate = deferred<void>();
+    runtimeConfig.ensureLoaded.mockImplementationOnce(async () => gate.promise);
+    const page = appendPage(context);
+    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    const selection: DefaultModelSelection = {
+      primary: "openai/gpt-5",
+      fallbacks: [],
+      utilityModel: null,
+    };
+    page.defaultsDraft = selection;
+
+    const saving = page.saveDefaultModels();
+    await vi.waitFor(() => expect(runtimeConfig.ensureLoaded).toHaveBeenCalledOnce());
+    agentSelection.state.scopeId = "writer";
+    notifySelection();
+    await vi.waitFor(() => expect(page.selectedAgentId).toBe("writer"));
+    gate.resolve();
+    await saving;
+
+    expect(runtimeConfig.patch).toHaveBeenCalledOnce();
+    expect(page.defaultsDraft).toBe(selection);
+    expect(page.messages.defaults).toBeUndefined();
+  });
+
+  it("keeps global provider writes without clearing a replacement agent's credential draft", async () => {
+    const { agentSelection, context, notifySelection, runtimeConfig } = createHarness("main");
+    const gate = deferred<void>();
+    runtimeConfig.ensureLoaded.mockImplementationOnce(async () => gate.promise);
+    const page = appendPage(context);
+    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    page.keyEditorProvider = "openai";
+    page.keyDraft = "main-agent-key";
+
+    const saving = page.saveKey("openai", "openai");
+    await vi.waitFor(() => expect(runtimeConfig.ensureLoaded).toHaveBeenCalledOnce());
+    agentSelection.state.scopeId = "writer";
+    notifySelection();
+    await vi.waitFor(() => expect(page.selectedAgentId).toBe("writer"));
+    page.keyEditorProvider = "anthropic";
+    page.keyDraft = "writer-agent-unsaved-key";
+    gate.resolve();
+    await saving;
+
+    expect(runtimeConfig.patch).toHaveBeenCalledOnce();
+    expect(runtimeConfig.patch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        raw: { models: { providers: { openai: { apiKey: "main-agent-key" } } } },
+      }),
+    );
+    expect(page.keyEditorProvider).toBe("anthropic");
+    expect(page.keyDraft).toBe("writer-agent-unsaved-key");
+    expect(page.messages.openai).toBeUndefined();
+  });
+
+  it("keeps a replacement agent's matching add-provider draft after a global write", async () => {
+    const { agentSelection, context, notifySelection, runtimeConfig } = createHarness("main");
+    const gate = deferred<void>();
+    runtimeConfig.ensureLoaded.mockImplementationOnce(async () => gate.promise);
+    const page = appendPage(context);
+    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    page.addProviderOpen = true;
+    page.addProviderId = "anthropic";
+    page.addProviderKey = "shared-provider-key";
+
+    const adding = page.addProvider();
+    await vi.waitFor(() => expect(runtimeConfig.ensureLoaded).toHaveBeenCalledOnce());
+    agentSelection.state.scopeId = "writer";
+    notifySelection();
+    await vi.waitFor(() => expect(page.selectedAgentId).toBe("writer"));
+    page.addProviderOpen = true;
+    page.addProviderId = "anthropic";
+    page.addProviderKey = "shared-provider-key";
+    gate.resolve();
+    await adding;
+
+    expect(runtimeConfig.patch).toHaveBeenCalledOnce();
+    expect(page.addProviderOpen).toBe(true);
+    expect(page.addProviderId).toBe("anthropic");
+    expect(page.addProviderKey).toBe("shared-provider-key");
+    expect(page.messages.add).toBeUndefined();
+  });
+
+  it("stops queued agent-scoped logouts after the selected agent changes", async () => {
+    const { agentSelection, context, notifySelection, request } = createHarness("main");
+    const page = appendPage(context);
+    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    request.mockClear();
+    const firstLogout = deferred<unknown>();
+    request.mockImplementationOnce(async () => firstLogout.promise);
+
+    const loggingOut = page.logout("openai", [
+      { provider: "openai", profileIds: ["openai:first"] },
+      { provider: "alias", profileIds: ["openai:second"] },
+    ]);
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("models.authLogout", {
+        provider: "openai",
+        profileIds: ["openai:first"],
+        agentId: "main",
+      }),
+    );
+    agentSelection.state.scopeId = "writer";
+    notifySelection();
+    await vi.waitFor(() => expect(page.selectedAgentId).toBe("writer"));
+    agentSelection.state.scopeId = "main";
+    notifySelection();
+    await vi.waitFor(() => expect(page.selectedAgentId).toBe("main"));
+    firstLogout.resolve({});
+    await loggingOut;
+
+    expect(request.mock.calls.filter(([method]) => method === "models.authLogout")).toHaveLength(1);
+  });
+
+  it("stops queued agent-scoped logouts when route data changes the selected agent", async () => {
+    const { agentSelection, context, request, snapshot } = createHarness("main");
+    const page = appendPage(context);
+    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    request.mockClear();
+    const firstLogout = deferred<unknown>();
+    request.mockImplementationOnce(async () => firstLogout.promise);
+
+    const loggingOut = page.logout("openai", [
+      { provider: "openai", profileIds: ["openai:first"] },
+      { provider: "alias", profileIds: ["openai:second"] },
+    ]);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    page.pendingLogoutProvider = "openai";
+    page.messages = { openai: { kind: "error", text: "Previous agent failure" } };
+    page.probeResults = {
+      openai: { provider: "openai", status: "ok", results: [] },
+    };
+    agentSelection.state.scopeId = "writer";
+    page.routeData = {
+      data: { ...EMPTY_MODEL_PROVIDERS_DATA, config: {}, updatedAt: 1 },
+      client: snapshot.client,
+      agentId: "writer",
+    };
+    await page.updateComplete;
+    expect(page.selectedAgentId).toBe("writer");
+    expect(page.busy).toEqual({});
+    expect(page.pendingLogoutProvider).toBeNull();
+    expect(page.messages).toEqual({});
+    expect(page.probeResults).toEqual({});
+    firstLogout.resolve({});
+    await loggingOut;
+
+    expect(request.mock.calls.filter(([method]) => method === "models.authLogout")).toHaveLength(1);
   });
 
   it("reloads credential status when the agent selector changes", async () => {

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -18,6 +18,12 @@ import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import {
+  modelProviderErrorMessage,
+  runModelProviderConfigMutation,
+  type ModelProviderConfigMutation,
+  type ModelProviderConfigMutationResult,
+} from "./config-mutation.ts";
+import {
   buildModelProviderCards,
   buildSelectableDefaultModels,
   buildUnconfiguredProviderOptions,
@@ -48,15 +54,10 @@ export type ModelProvidersRouteData = {
   agentId: string;
 };
 
-function errorMessage(error: unknown): string {
-  if (error instanceof Error && error.message.trim()) {
-    return error.message;
-  }
-  return typeof error === "string" && error.trim() ? error : t("modelProviders.requestFailed");
-}
-
 function isMissingMethodError(error: unknown): boolean {
-  return /method (?:not found|not supported)|unknown method/iu.test(errorMessage(error));
+  return /method (?:not found|not supported)|unknown method/iu.test(
+    modelProviderErrorMessage(error),
+  );
 }
 
 const PROBE_FAILURE_PRIORITY: readonly ModelsProbeResult["status"][] = [
@@ -116,6 +117,8 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
   private dataClient: GatewayBrowserClient | null = null;
   private observedClient: GatewayBrowserClient | null = null;
   private clientEpoch = 0;
+  // Global config writes survive agent switches; their card state does not.
+  private agentEpoch = 0;
   private probeEpochs = new Map<string, number>();
   private readonly refreshTask = new Task(this, {
     autoRun: false,
@@ -177,7 +180,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
   override willUpdate(changed: PropertyValues) {
     if (changed.has("routeData") && this.routeData) {
       const selectedAgentId = this.resolveSelectedAgentId();
-      this.selectedAgentId = selectedAgentId;
+      this.setSelectedAgent(selectedAgentId);
       if (this.routeData.agentId === selectedAgentId) {
         this.data = this.routeData.data;
         this.dataClient = this.routeData.client;
@@ -249,18 +252,26 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     return normalizeAgentId(agentsList?.defaultId ?? agentsList?.agents[0]?.id ?? "main");
   }
 
-  private syncSelectedAgent() {
-    const agentId = this.resolveSelectedAgentId();
+  private setSelectedAgent(agentId: string): boolean {
     if (agentId === this.selectedAgentId) {
-      return;
+      return false;
     }
     this.selectedAgentId = agentId;
-    void this.refreshTask.run([null, agentId, false]);
-    this.data = null;
+    this.agentEpoch += 1;
     this.busy = {};
     this.pendingLogoutProvider = null;
     this.messages = {};
     this.probeResults = {};
+    return true;
+  }
+
+  private syncSelectedAgent() {
+    const agentId = this.resolveSelectedAgentId();
+    if (!this.setSelectedAgent(agentId)) {
+      return;
+    }
+    void this.refreshTask.run([null, agentId, false]);
+    this.data = null;
     // probeEpochs stays: per-card counters must remain monotonic across agent
     // switches, or an in-flight probe from the old agent can reuse an epoch
     // and clobber a newer probe's state (A->B->A ABA race).
@@ -290,7 +301,19 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
   }
 
   private canMutate(): boolean {
-    return this.mutationBlockedReason() === null;
+    return this.mutationBlockedReason() === null && !this.configBusy();
+  }
+
+  private configBusy(): boolean {
+    const runtimeState = this.context.runtimeConfig.state;
+    const update = this.context.overlays.snapshot;
+    return (
+      runtimeState.configLoading ||
+      runtimeState.configSaving ||
+      runtimeState.configApplying ||
+      update.updateRunning ||
+      update.updateReconciliationPending
+    );
   }
 
   private setBusy(key: string, value: boolean) {
@@ -321,64 +344,30 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     this.probeResults = next;
   }
 
-  private async patchConfig(params: {
-    key: string;
-    raw: Record<string, unknown>;
-    note: string;
-    success: string;
-    replacePaths?: string[];
-  }): Promise<boolean> {
+  private async patchConfig(
+    params: ModelProviderConfigMutation,
+  ): Promise<ModelProviderConfigMutationResult> {
     if (!this.canMutate() || this.busy[params.key]) {
-      return false;
+      return { ok: false };
     }
     const client = this.context.gateway.snapshot.client;
     if (!client) {
-      return false;
+      return { ok: false };
     }
     const clientEpoch = this.clientEpoch;
-    const runtimeConfig = this.context.runtimeConfig;
-    this.setBusy(params.key, true);
-    this.setMessage(params.key, null);
-    try {
-      await runtimeConfig.ensureLoaded();
-      if (!this.isCurrentClient(client, clientEpoch)) {
-        return false;
-      }
-      const patched = await runtimeConfig.patch({
-        raw: params.raw,
-        note: params.note,
-        ...(params.replacePaths ? { replacePaths: params.replacePaths } : {}),
-      });
-      if (!this.isCurrentClient(client, clientEpoch)) {
-        return false;
-      }
-      if (!patched) {
-        this.setMessage(params.key, {
-          kind: "error",
-          text: runtimeConfig.state.lastError ?? t("modelProviders.configUnavailable"),
-        });
-        return false;
-      }
-      await runtimeConfig.refresh();
-      if (!this.isCurrentClient(client, clientEpoch)) {
-        return false;
-      }
-      await this.refresh({ force: true });
-      if (!this.isCurrentClient(client, clientEpoch)) {
-        return false;
-      }
-      this.setMessage(params.key, { kind: "success", text: params.success });
-      return true;
-    } catch (error) {
-      if (this.isCurrentClient(client, clientEpoch)) {
-        this.setMessage(params.key, { kind: "error", text: errorMessage(error) });
-      }
-      return false;
-    } finally {
-      if (this.isCurrentClient(client, clientEpoch)) {
-        this.setBusy(params.key, false);
-      }
-    }
+    const agentEpoch = this.agentEpoch;
+    return runModelProviderConfigMutation(
+      {
+        runtimeConfig: this.context.runtimeConfig,
+        agentEpoch,
+        isCurrentClient: () => this.isCurrentClient(client, clientEpoch),
+        isCurrentAgent: () => this.agentEpoch === agentEpoch,
+        refreshProviders: () => this.refresh({ force: true }),
+        setBusy: (busy) => this.setBusy(params.key, busy),
+        setMessage: (message) => this.setMessage(params.key, message),
+      },
+      params,
+    );
   }
 
   private openKeyEditor(provider: string) {
@@ -400,16 +389,22 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     this.clearProbe(provider);
     this.setMessage(provider, null);
     this.setMessage(`key:${provider}`, null);
-    const ok = await this.patchConfig({
+    const result = await this.patchConfig({
       key: `key:${provider}`,
       raw: buildProviderApiKeyPatch(configKey, apiKey),
       note: t("modelProviders.notes.saveKey", { provider }),
       success: t("modelProviders.apiKey.saved"),
     });
-    if (ok) {
+    if (result.ok && this.agentEpoch === result.agentEpoch) {
       this.setMessage(`key:${provider}`, null);
-      this.closeKeyEditor();
-      this.setMessage(provider, { kind: "success", text: t("modelProviders.apiKey.saved") });
+      if (this.keyEditorProvider === provider && this.keyDraft.trim() === apiKey) {
+        this.closeKeyEditor();
+      }
+      this.setMessage(provider, {
+        kind: "success",
+        text: t("modelProviders.apiKey.saved"),
+        ...(result.warning ? { warning: result.warning } : {}),
+      });
     }
   }
 
@@ -417,16 +412,22 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     this.clearProbe(provider);
     this.setMessage(provider, null);
     this.setMessage(`key:${provider}`, null);
-    const ok = await this.patchConfig({
+    const result = await this.patchConfig({
       key: `key:${provider}`,
       raw: buildProviderApiKeyPatch(configKey, null),
       note: t("modelProviders.notes.removeKey", { provider }),
       success: t("modelProviders.apiKey.removed"),
     });
-    if (ok) {
+    if (result.ok && this.agentEpoch === result.agentEpoch) {
       this.setMessage(`key:${provider}`, null);
-      this.closeKeyEditor();
-      this.setMessage(provider, { kind: "success", text: t("modelProviders.apiKey.removed") });
+      if (this.keyEditorProvider === provider) {
+        this.closeKeyEditor();
+      }
+      this.setMessage(provider, {
+        kind: "success",
+        text: t("modelProviders.apiKey.removed"),
+        ...(result.warning ? { warning: result.warning } : {}),
+      });
     }
   }
 
@@ -474,7 +475,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
           text: t("modelProviders.probe.unavailable"),
         });
       } else {
-        this.setMessage(cardId, { kind: "error", text: errorMessage(error) });
+        this.setMessage(cardId, { kind: "error", text: modelProviderErrorMessage(error) });
       }
     } finally {
       if (
@@ -494,37 +495,43 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     }
     const clientEpoch = this.clientEpoch;
     const agentId = this.selectedAgentId;
+    const agentEpoch = this.agentEpoch;
     this.clearProbe(cardId);
     this.setBusy(key, true);
     this.setMessage(cardId, null);
     try {
       let firstError: unknown;
       for (const target of targets) {
+        // OAuth profiles are agent-owned; stop undispatched targets after any
+        // scope change, including a switch away from and back to this agent.
+        if (!this.isCurrentClient(client, clientEpoch) || this.agentEpoch !== agentEpoch) {
+          return;
+        }
         try {
           await client.request("models.authLogout", { ...target, agentId });
         } catch (error) {
           firstError ??= error;
         }
       }
-      if (!this.isCurrentClient(client, clientEpoch) || this.selectedAgentId !== agentId) {
+      if (!this.isCurrentClient(client, clientEpoch) || this.agentEpoch !== agentEpoch) {
         return;
       }
       await this.refresh({ force: true });
-      if (!this.isCurrentClient(client, clientEpoch) || this.selectedAgentId !== agentId) {
+      if (!this.isCurrentClient(client, clientEpoch) || this.agentEpoch !== agentEpoch) {
         return;
       }
       if (firstError) {
-        this.setMessage(cardId, { kind: "error", text: errorMessage(firstError) });
+        this.setMessage(cardId, { kind: "error", text: modelProviderErrorMessage(firstError) });
         return;
       }
       this.pendingLogoutProvider = null;
       this.setMessage(cardId, { kind: "success", text: t("modelProviders.logout.done") });
     } catch (error) {
-      if (this.isCurrentClient(client, clientEpoch) && this.selectedAgentId === agentId) {
-        this.setMessage(cardId, { kind: "error", text: errorMessage(error) });
+      if (this.isCurrentClient(client, clientEpoch) && this.agentEpoch === agentEpoch) {
+        this.setMessage(cardId, { kind: "error", text: modelProviderErrorMessage(error) });
       }
     } finally {
-      if (this.isCurrentClient(client, clientEpoch) && this.selectedAgentId === agentId) {
+      if (this.isCurrentClient(client, clientEpoch) && this.agentEpoch === agentEpoch) {
         this.setBusy(key, false);
       }
     }
@@ -536,19 +543,26 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     if (!provider || !apiKey) {
       return;
     }
-    const ok = await this.patchConfig({
+    const result = await this.patchConfig({
       key: "add",
       raw: buildProviderApiKeyPatch(provider, apiKey),
       note: t("modelProviders.notes.addProvider", { provider }),
       success: t("modelProviders.add.saved", { provider }),
     });
-    if (ok) {
-      this.addProviderOpen = false;
-      this.addProviderId = "";
-      this.addProviderKey = "";
+    if (result.ok && this.agentEpoch === result.agentEpoch) {
+      if (this.addProviderId === provider && this.addProviderKey.trim() === apiKey) {
+        // A failed refresh leaves a new provider without a card. Keep its
+        // success + warning visible in the open form instead of losing both.
+        this.addProviderOpen = Boolean(result.warning);
+        if (!result.warning) {
+          this.addProviderId = "";
+        }
+        this.addProviderKey = "";
+      }
       this.setMessage(provider, {
         kind: "success",
         text: t("modelProviders.add.saved", { provider }),
+        ...(result.warning ? { warning: result.warning } : {}),
       });
     }
   }
@@ -558,14 +572,21 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     if (!selection?.primary) {
       return;
     }
-    const ok = await this.patchConfig({
+    const result = await this.patchConfig({
       key: "defaults",
       raw: buildDefaultModelsPatch(selection.primary, selection.fallbacks, selection.utilityModel),
       note: t("modelProviders.notes.defaultModel"),
       success: t("modelProviders.defaults.saved"),
       replacePaths: DEFAULT_MODELS_REPLACE_PATHS,
     });
-    if (ok) {
+    // Without fresh provider data, clearing this committed draft would show
+    // the old default models beside a contradictory success message.
+    if (
+      result.ok &&
+      !result.warning &&
+      this.agentEpoch === result.agentEpoch &&
+      this.defaultsDraft === selection
+    ) {
       this.defaultsDraft = null;
     }
   }
@@ -589,16 +610,10 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       typeof agentsDefaults?.thinkingDefault === "string" ? agentsDefaults.thinkingDefault : "off";
     const fastValue = agentsDefaults?.fastModeDefault;
     const fastMode = fastValue === "auto" || typeof fastValue === "boolean" ? fastValue : false;
-    const update = this.context.overlays.snapshot;
     // The overlay update states replace General's old configUpdating prop,
     // which config-page derived from this same snapshot (isUpdateBusy); the
     // busy gate is behavior-identical to the pre-move General controls.
-    const configBusy =
-      runtimeState.configLoading ||
-      runtimeState.configSaving ||
-      runtimeState.configApplying ||
-      update.updateRunning ||
-      update.updateReconciliationPending;
+    const configBusy = this.configBusy();
     const cards = buildModelProviderCards({
       ...data,
       configProviderIds: config.providerIds,

--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -167,6 +167,181 @@ describe("renderModelProviders", () => {
     expect([...groups].every((group) => group.disabled)).toBe(true);
   });
 
+  it("locks provider and default-model mutations while shared config work is pending", () => {
+    const container = mount(
+      props({
+        configBusy: true,
+        defaultModelsDirty: true,
+        defaultModels: {
+          primary: "openai/gpt-5",
+          fallbacks: ["anthropic/claude"],
+          utilityModel: null,
+        },
+        configuredModels: [
+          { id: "openai/gpt-5", provider: "openai", name: "GPT-5", available: true },
+          { id: "anthropic/claude", provider: "anthropic", name: "Claude", available: true },
+        ],
+        cards: [
+          card({
+            hasConfigApiKey: true,
+            apiKey: { source: "config" },
+            logoutTargets: [{ provider: "openai", profileIds: ["openai:oauth"] }],
+          }),
+        ],
+        keyEditorProvider: "openai",
+        keyDraft: "replacement",
+        addProviderOpen: true,
+        addProviderId: "anthropic",
+        addProviderKey: "new-provider-key",
+      }),
+    );
+
+    const defaults = container.querySelector(".model-providers__defaults");
+    const defaultControls = [
+      ...(defaults?.querySelectorAll<HTMLSelectElement | HTMLButtonElement>(
+        "select, .model-providers__fallback-row button",
+      ) ?? []),
+      button(container, "Save"),
+    ];
+    expect(defaultControls.map((control) => control?.disabled)).toEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+
+    const provider = container.querySelector('[data-provider-id="openai"]');
+    expect(
+      provider?.querySelector<HTMLInputElement>(".model-providers__inline-form input")?.disabled,
+    ).toBe(true);
+    expect(button(provider!, "Replace key")?.disabled).toBe(true);
+    expect(button(provider!, "Remove key")?.disabled).toBe(true);
+    expect(button(provider!, "Log out")?.disabled).toBe(true);
+
+    const addForm = container.querySelector(".model-providers__add-form");
+    expect(
+      [
+        ...(addForm?.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLButtonElement>(
+          "select, input, button",
+        ) ?? []),
+      ].map((control) => control.disabled),
+    ).toEqual([true, true, true]);
+  });
+
+  it("locks an already-open provider form after mutation access is revoked", () => {
+    const onAddProvider = vi.fn();
+    const onAddProviderToggle = vi.fn();
+    const container = mount(
+      props({
+        addProviderOpen: true,
+        addProviderId: "anthropic",
+        addProviderKey: "new-provider-key",
+        canMutate: false,
+        mutationBlockedReason: "Operator admin access required",
+        onAddProvider,
+        onAddProviderToggle,
+      }),
+    );
+    const addForm = container.querySelector(".model-providers__add-form");
+    const controls = [
+      ...(addForm?.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLButtonElement>(
+        "select, input, button",
+      ) ?? []),
+    ];
+
+    expect(controls.map((control) => control.disabled)).toEqual([true, true, true]);
+    addForm?.querySelector<HTMLButtonElement>("button")?.click();
+    expect(onAddProvider).not.toHaveBeenCalled();
+
+    const cancel = button(addForm!.closest(".settings-section")!, "Cancel");
+    expect(cancel?.disabled).toBe(false);
+    cancel?.click();
+    expect(onAddProviderToggle).toHaveBeenCalledOnce();
+  });
+
+  it("freezes provider and credential fields while adding a provider", () => {
+    const container = mount(
+      props({
+        addProviderOpen: true,
+        addProviderId: "anthropic",
+        addProviderKey: "new-provider-key",
+        busy: { add: true },
+      }),
+    );
+    const addForm = container.querySelector(".model-providers__add-form");
+
+    expect(
+      [
+        ...(addForm?.querySelectorAll<HTMLInputElement | HTMLSelectElement>("select, input") ?? []),
+      ].map((control) => control.disabled),
+    ).toEqual([true, true]);
+  });
+
+  it("keeps committed credential success visible beside its refresh warning", () => {
+    const container = mount(
+      props({
+        messages: {
+          openai: {
+            kind: "success",
+            text: "Secret saved.",
+            warning: "Config refresh failed after the secret was committed.",
+          },
+        },
+      }),
+    );
+    const provider = container.querySelector('[data-provider-id="openai"]');
+    const messages = [...(provider?.querySelectorAll('[role="status"]') ?? [])];
+
+    expect(messages.map((message) => text(message))).toEqual([
+      "Secret saved.",
+      "Config refresh failed after the secret was committed.",
+    ]);
+    expect(messages[0]?.classList.contains("success")).toBe(true);
+    expect(messages[1]?.classList.contains("warning")).toBe(true);
+  });
+
+  it("keeps committed default-model success visible beside its refresh warning", () => {
+    const container = mount(
+      props({
+        messages: {
+          defaults: {
+            kind: "success",
+            text: "Default models saved.",
+            warning: "Config refresh failed after the model defaults were committed.",
+          },
+        },
+      }),
+    );
+    const defaults = container.querySelector(".model-providers__defaults");
+    const messages = [...(defaults?.querySelectorAll('[role="status"]') ?? [])];
+
+    expect(messages.map((message) => text(message))).toEqual([
+      "Default models saved.",
+      "Config refresh failed after the model defaults were committed.",
+    ]);
+    expect(messages[0]?.classList.contains("success")).toBe(true);
+    expect(messages[1]?.classList.contains("warning")).toBe(true);
+  });
+
+  it("announces provider and default-model mutation failures as accessible alerts", () => {
+    const container = mount(
+      props({
+        messages: {
+          openai: { kind: "error", text: "Provider credential could not be saved." },
+          defaults: { kind: "error", text: "Default models could not be saved." },
+        },
+      }),
+    );
+
+    expect(text(container.querySelector('[data-provider-id="openai"] [role="alert"]'))).toBe(
+      "Provider credential could not be saved.",
+    );
+    expect(text(container.querySelector('.model-providers__defaults [role="alert"]'))).toBe(
+      "Default models could not be saved.",
+    );
+  });
+
   it("keeps model behavior available while provider data loads", () => {
     const container = mount(props({ loading: true, thinkingLevel: "high", fastMode: true }));
     const behavior = container.querySelector("#settings-model-behavior");

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -30,7 +30,11 @@ import type {
 } from "./data.ts";
 import { renderDefaultModels } from "./default-models-view.ts";
 
-export type ModelProviderRowMessage = { kind: "success" | "error"; text: string };
+export type ModelProviderRowMessage = {
+  kind: "success" | "error";
+  text: string;
+  warning?: string;
+};
 
 type ModelProvidersViewProps = {
   connected: boolean;
@@ -91,6 +95,24 @@ const THINKING_LEVELS = BASE_THINKING_LEVELS.filter((level) => level !== "minima
 
 function fastModeOptionValue(value: "auto" | "on" | "off"): FastMode {
   return value === "auto" ? "auto" : value === "on";
+}
+
+function configMutationDisabled(props: ModelProvidersViewProps): boolean {
+  return !props.canMutate || props.configBusy;
+}
+
+function renderMutationMessage(message: ModelProviderRowMessage | undefined) {
+  if (!message) {
+    return nothing;
+  }
+  return html`
+    <div class="callout ${message.kind}" role=${message.kind === "error" ? "alert" : "status"}>
+      ${message.text}
+    </div>
+    ${message.warning
+      ? html`<div class="callout warning" role="status">${message.warning}</div>`
+      : nothing}
+  `;
 }
 
 function renderModelBehavior(props: ModelProvidersViewProps) {
@@ -317,6 +339,7 @@ function renderKeyEditor(card: ModelProviderCard, props: ModelProvidersViewProps
   const authModeBlocked =
     card.apiKeySupported === false ||
     Boolean(card.configAuthMode && card.configAuthMode !== "api-key");
+  const mutationDisabled = configMutationDisabled(props);
   return html`
     <div class="model-providers__inline-form">
       <label class="field">
@@ -328,7 +351,7 @@ function renderKeyEditor(card: ModelProviderCard, props: ModelProvidersViewProps
             ? t("modelProviders.apiKey.replacePlaceholder")
             : t("modelProviders.apiKey.placeholder")}
           .value=${props.keyDraft}
-          ?disabled=${busy || !props.canMutate || authModeBlocked}
+          ?disabled=${busy || mutationDisabled || authModeBlocked}
           @input=${(event: Event) =>
             props.onKeyDraftChange((event.target as HTMLInputElement).value)}
         />
@@ -336,7 +359,7 @@ function renderKeyEditor(card: ModelProviderCard, props: ModelProvidersViewProps
       <div class="model-providers__form-actions">
         <button
           class="btn primary btn--sm"
-          ?disabled=${busy || !props.canMutate || authModeBlocked || !props.keyDraft.trim()}
+          ?disabled=${busy || mutationDisabled || authModeBlocked || !props.keyDraft.trim()}
           @click=${() => props.onSaveKey(card.id, card.configKey ?? card.id)}
         >
           ${busy ? t("modelProviders.saving") : t("common.save")}
@@ -361,6 +384,7 @@ function renderProviderActions(card: ModelProviderCard, props: ModelProvidersVie
   const blocked = props.mutationBlockedReason ?? "";
   const authModeBlocked = Boolean(card.configAuthMode && card.configAuthMode !== "api-key");
   const apiKeyUnsupported = card.apiKeySupported === false;
+  const mutationDisabled = configMutationDisabled(props);
   const keyBlocked = authModeBlocked
     ? t("modelProviders.apiKey.authModeBlocked", { mode: card.configAuthMode ?? "" })
     : blocked;
@@ -383,7 +407,7 @@ function renderProviderActions(card: ModelProviderCard, props: ModelProvidersVie
         : html`
             <button
               class="btn btn--sm"
-              ?disabled=${keyBusy || !props.canMutate || authModeBlocked}
+              ?disabled=${keyBusy || mutationDisabled || authModeBlocked}
               title=${keyBlocked}
               @click=${() => props.onOpenKeyEditor(card.id)}
             >
@@ -396,7 +420,7 @@ function renderProviderActions(card: ModelProviderCard, props: ModelProvidersVie
         ? html`
             <button
               class="btn btn--sm danger"
-              ?disabled=${keyBusy || !props.canMutate || authModeBlocked}
+              ?disabled=${keyBusy || mutationDisabled || authModeBlocked}
               title=${keyBlocked}
               @click=${() => props.onRemoveKey(card.id, card.configKey ?? card.id)}
             >
@@ -408,7 +432,7 @@ function renderProviderActions(card: ModelProviderCard, props: ModelProvidersVie
         ? html`
             <button
               class="btn btn--sm"
-              ?disabled=${logoutBusy || !props.canMutate}
+              ?disabled=${logoutBusy || mutationDisabled}
               title=${blocked}
               @click=${() => props.onRequestLogout(card.id)}
             >
@@ -424,7 +448,7 @@ function renderProviderActions(card: ModelProviderCard, props: ModelProvidersVie
             <div class="model-providers__form-actions">
               <button
                 class="btn danger btn--sm"
-                ?disabled=${logoutBusy}
+                ?disabled=${logoutBusy || mutationDisabled}
                 @click=${() => props.onLogout(card.id, card.logoutTargets)}
               >
                 ${logoutBusy
@@ -473,15 +497,14 @@ function renderProviderRow(card: ModelProviderCard, props: ModelProvidersViewPro
         ${renderLocalCost(card, props.costDays)}
       </div>
       ${renderProviderActions(card, props)} ${renderKeyEditor(card, props)}
-      ${renderProbeResult(props.probeResults[card.id])}
-      ${message
-        ? html`<div class="callout ${message.kind}" role="status">${message.text}</div>`
-        : nothing}
+      ${renderProbeResult(props.probeResults[card.id])} ${renderMutationMessage(message)}
     </div>
   `;
 }
 
 function renderAddProvider(props: ModelProvidersViewProps) {
+  const busy = Boolean(props.busy.add);
+  const disabled = configMutationDisabled(props) || busy;
   const rows = html`
     ${props.unconfiguredProviders.length === 0
       ? renderSettingsEmpty(t("modelProviders.add.none"))
@@ -495,6 +518,7 @@ function renderAddProvider(props: ModelProvidersViewProps) {
                 <select
                   class="settings-select"
                   .value=${props.addProviderId}
+                  ?disabled=${disabled}
                   @change=${(event: Event) =>
                     props.onAddProviderIdChange((event.target as HTMLSelectElement).value)}
                 >
@@ -512,25 +536,20 @@ function renderAddProvider(props: ModelProvidersViewProps) {
                   autocomplete="off"
                   placeholder=${t("modelProviders.apiKey.placeholder")}
                   .value=${props.addProviderKey}
+                  ?disabled=${disabled}
                   @input=${(event: Event) =>
                     props.onAddProviderKeyChange((event.target as HTMLInputElement).value)}
                 />
               </label>
               <button
                 class="btn primary"
-                ?disabled=${Boolean(props.busy.add) ||
-                !props.addProviderId ||
-                !props.addProviderKey.trim()}
+                ?disabled=${disabled || !props.addProviderId || !props.addProviderKey.trim()}
                 @click=${props.onAddProvider}
               >
                 ${props.busy.add ? t("modelProviders.saving") : t("modelProviders.add.save")}
               </button>
             </div>
-            ${props.messages.add
-              ? html`<div class="callout ${props.messages.add.kind}" role="status">
-                  ${props.messages.add.text}
-                </div>`
-              : nothing}
+            ${renderMutationMessage(props.messages.add)}
           </div>
         `
       : nothing}
@@ -542,7 +561,9 @@ function renderAddProvider(props: ModelProvidersViewProps) {
       actions: html`
         <button
           class="btn btn--sm"
-          ?disabled=${!props.canMutate || props.unconfiguredProviders.length === 0}
+          ?disabled=${busy ||
+          (!props.addProviderOpen &&
+            (configMutationDisabled(props) || props.unconfiguredProviders.length === 0))}
           title=${props.mutationBlockedReason ?? ""}
           @click=${props.onAddProviderToggle}
         >
@@ -620,7 +641,7 @@ export function renderModelProviders(props: ModelProvidersViewProps) {
           models: props.configuredModels,
           selection: props.defaultModels,
           dirty: props.defaultModelsDirty,
-          canMutate: props.canMutate,
+          canMutate: !configMutationDisabled(props),
           mutationBlockedReason: props.mutationBlockedReason,
           busy: props.busy,
           message: props.messages.defaults,


### PR DESCRIPTION
## Summary

- Give Model Provider settings one canonical, provider-owned configuration mutation coordinator.
- Apply actual administrator, updater/config-busy, and in-flight disabled semantics to provider forms, default-model controls, and OAuth logout actions while keeping an already-open credential form cancellable.
- Preserve committed provider/default-model changes and visible success-plus-warning feedback when authoritative configuration refresh fails.
- Allow intentionally global configuration writes to complete across agent switches without letting their stale completion clear another agent's credential, Add-provider, or default-model draft.
- Stop truly agent-scoped queued OAuth logout targets after an agent switch, including A→B→A and route-data-driven selection changes.

## Root causes fixed

**5 independently reproduced provider-owner defects:**

1. **Revoked/in-flight Add-provider form admission.** Once opened, provider and password inputs remained interactive after mutation permission was revoked or the Add write was in flight; the enabled Save button still dispatched its callback. Lock native controls while preserving Cancel except during the form's own in-flight mutation.
2. **Shared configuration/update busy state ignored.** Default-model selectors, fallback actions, provider key editors, Add-provider actions, and logout controls ignored the existing shared configuration/updater write lock while adjacent model-behavior controls respected it.
3. **Committed mutations reported or displayed incorrectly after refresh failure.** The configuration owner resolves ordinary refresh failures while recording `state.lastError`; treating rejection alone as failure detection hid committed-success warnings. New providers also had no rendered card after a failed refresh, causing success and warnings to disappear; default-model drafts reverted to stale loaded selections. Preserve committed success, show accessible warnings, keep Add feedback visible while clearing its password, and retain committed default selections until authoritative refresh succeeds.
4. **Global mutation completions contaminated replacement-agent UI.** Provider keys, provider additions, and default models are intentionally global configuration writes and must still commit after the selected agent changes, but their previous completion paths cleared another agent's credential/default drafts or published stale busy/messages. Monotonic agent epochs now gate only agent-local UI effects while preserving global writes.
5. **Agent-owned OAuth logout continued into a stale scope.** A grouped logout awaited its first RPC, then dispatched remaining OAuth targets for the former agent after selection changed. Stop undispatched targets on every scope transition, including A→B→A and route-data selection changes, and clear old scoped busy/messages/probe/confirmation state.

## Red-to-green owner evidence

- Existing owner baseline: **30 passing tests**.
- Added first-pass actual Lit DOM/controller regressions: **6 failing, 30 passing**, proving revoked/in-flight Add controls, ignored config-busy controls, committed-refresh failure, stale replacement-agent draft cleanup, and queued old-agent logout.
- Added independent-review regressions for truthful `refresh()`/`state.lastError` behavior, persistently visible Add/default warnings, cancellable locked credential forms, assertive accessible error alerts, agent-switch ABA, route-data scope reset, and all three global mutation completion paths.
- Final exact-commit focused DOM/controller proof:

```sh
node scripts/run-vitest.mjs \
  ui/src/pages/model-providers/view.test.ts \
  ui/src/pages/model-providers/model-providers-page.test.ts
```

Result: **44 tests passed across 2 files**.

- Adjacent provider owner/serialization/load proof:

```sh
node scripts/run-vitest.mjs \
  ui/src/pages/model-providers/data.test.ts \
  ui/src/pages/model-providers/load.test.ts \
  ui/src/pages/model-providers/mutations.test.ts
```

Result: **19 tests passed across 3 files**.

**Total: 63 passing provider-owner and sibling tests.**

## Full remote changed-file gate

Trusted Blacksmith Testbox `tbx_01kyw0rj16bksrzy71pp6vpzxb` passed the exact six-file gate:

```sh
node scripts/check-changed.mjs --base origin/main --head HEAD -- \
  ui/src/pages/model-providers/config-mutation.ts \
  ui/src/pages/model-providers/default-models-view.ts \
  ui/src/pages/model-providers/model-providers-page.test.ts \
  ui/src/pages/model-providers/model-providers-page.ts \
  ui/src/pages/model-providers/view.test.ts \
  ui/src/pages/model-providers/view.ts
```

- Result: **exit 0**, **341.241 seconds** command time, **343.133 seconds** total.
- Passed conflict markers, strict maximum-line ratchet, changelog and package-policy guards, wildcard/export checks, dependency pins, six-file formatting, zero-dead-export scans, Control UI i18n verification, core-test TypeScript, UI TypeScript, and changed-file oxlint (**0 warnings, 0 errors**).
- The sparse isolated checkout was safely materialized into a temporary full sync checkout; changed-gate comparison remained anchored at immutable merge base `59e1d586147b98f0021fc9ff176d64214ad435c4`.
- Workflow: https://github.com/openclaw/openclaw/actions/runs/30629044283. The one-shot Testbox was stopped after success; its delegated Actions step may display cancelled after successful lease cleanup.
- Real **TruffleHog 3.96.0** secret scan: clean.
- Commit-specific structured isolated Codex autoreview (`gpt-5.6-sol`, high reasoning): **CLEAN**, zero actionable findings, confidence **0.95**.
- Separate strict read-only provider-owner review: **CLEAN**, including global-vs-agent ownership, route-data/ABA races, genuine refresh failure semantics, native disabled controls, and accessibility.

## Candidate

- Branch: `codex/qa100-model-provider-mutation-owner`.
- Commit: `ee0a71c522795729868a7e28e9fe66639ba47d2f`.
- Immutable parent: `59e1d586147b98f0021fc9ff176d64214ad435c4`.
- Scope: exactly six internal Control UI provider-owner files; no Skills/#116749 overlap, no configuration/schema/API/auth surface, no fetch, no push, and no shared-`main` modification.
- Known separate owner limitation intentionally untouched: legacy hash-only `RuntimeConfigCapability.patch` acknowledgements collapse committed-refresh failure into `false`; correcting that requires separately approved shared-configuration-owner contract work.
