### PR TITLE
fix(cron): preserve failure notification thread ownership

### DIFF
--- a/src/cron/service/failure-alerts.account-routing.test.ts
+++ b/src/cron/service/failure-alerts.account-routing.test.ts
@@ -14,6 +14,7 @@ describe("cron failure alert account routing", () => {
         channel: "telegram",
         to: "telegram:19098680",
         accountId: "telegram-bot",
+        threadId: 42,
       },
     },
     {
@@ -24,6 +25,7 @@ describe("cron failure alert account routing", () => {
         channel: "telegram",
         to: "telegram:19098680",
         accountId: "alert-bot",
+        threadId: undefined,
       },
     },
     {
@@ -73,6 +75,7 @@ describe("cron failure alert account routing", () => {
         channel: "telegram",
         to: "telegram:19098680",
         accountId: "telegram-bot",
+        threadId: 42,
       },
       ...(jobAlert ? { failureAlert: jobAlert } : {}),
       state: {},
@@ -119,5 +122,54 @@ describe("cron failure alert account routing", () => {
 
     expect(sendCronFailureAlert).toHaveBeenCalledWith(expect.objectContaining({ runAtMs }));
     expect(job.state.lastFailureAlertAtMs).toBe(endedAt);
+  });
+
+  it("keeps the primary topic on same-account failure alerts", () => {
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const state = createCronServiceState({
+      storePath: "/tmp/openclaw-cron-failure-alert-thread-routing.json",
+      cronEnabled: true,
+      cronConfig: { failureAlert: { enabled: true, after: 1 } },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      sendCronFailureAlert,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const job: CronJob = {
+      id: "topic-routed-job",
+      name: "Topic-routed job",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "report" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+        threadId: 42,
+      },
+      state: {},
+    };
+
+    applyJobResult(state, job, {
+      status: "error",
+      error: "provider unavailable",
+      startedAt: 1,
+      endedAt: 2,
+    });
+
+    expect(sendCronFailureAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+        threadId: 42,
+      }),
+    );
   });
 });

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -16,6 +16,7 @@ type ResolvedFailureAlert = {
   to?: string;
   mode?: "announce" | "webhook";
   accountId?: string;
+  threadId?: string | number;
   includeSkipped: boolean;
 };
 
@@ -111,6 +112,17 @@ export function resolveFailureAlert(
     mode !== "webhook" && !explicitTo && inheritsDeliveryChannel
       ? job.delivery?.accountId
       : undefined;
+  const accountId =
+    jobConfig?.accountId ??
+    (inheritsGlobalRoute ? globalConfig?.accountId : undefined) ??
+    inheritedDeliveryAccountId;
+  // A topic belongs to its channel, peer, and account; never attach the
+  // primary topic to an independently routed failure destination.
+  const inheritsDeliveryThread =
+    mode !== "webhook" &&
+    inheritsDeliveryChannel &&
+    (explicitTo === undefined || explicitTo === deliveryTo) &&
+    accountId === job.delivery?.accountId;
 
   // Announce alerts inherit the job delivery target; webhook alerts require an
   // explicit alert target so chat recipients are not reused as URLs.
@@ -123,10 +135,8 @@ export function resolveFailureAlert(
     channel,
     to: mode === "webhook" ? explicitTo : (explicitTo ?? compatibleDeliveryTo),
     mode,
-    accountId:
-      jobConfig?.accountId ??
-      (inheritsGlobalRoute ? globalConfig?.accountId : undefined) ??
-      inheritedDeliveryAccountId,
+    accountId,
+    threadId: inheritsDeliveryThread ? job.delivery?.threadId : undefined,
     includeSkipped: jobConfig?.includeSkipped ?? globalConfig?.includeSkipped ?? false,
   };
 }
@@ -143,6 +153,7 @@ function emitFailureAlert(
     to?: string;
     mode?: "announce" | "webhook";
     accountId?: string;
+    threadId?: string | number;
     status: "error" | "skipped";
   },
 ) {
@@ -169,6 +180,7 @@ function emitFailureAlert(
         to: params.to,
         mode: params.mode,
         accountId: params.accountId,
+        threadId: params.threadId,
       })
       .catch((err: unknown) => {
         state.deps.log.warn(
@@ -241,6 +253,7 @@ export function maybeEmitFailureAlert(
       to: params.alertConfig.to,
       mode: params.alertConfig.mode,
       accountId: params.alertConfig.accountId,
+      threadId: params.alertConfig.threadId,
       status: params.status,
     });
   }

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -224,6 +224,7 @@ export type CronServiceDeps = {
     to?: string;
     mode?: "announce" | "webhook";
     accountId?: string;
+    threadId?: string | number;
   }) => Promise<void>;
   onEvent?: (evt: CronEvent) => void;
 };

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -290,6 +290,40 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     );
   });
 
+  it("preserves the primary topic on immediate failure alerts", async () => {
+    const job = createWebhookJob({
+      mode: "announce",
+      channel: "telegram",
+      to: "-1001234567890",
+      accountId: "bot-a",
+      threadId: 42,
+    });
+
+    await sendGatewayCronFailureAlert({
+      deps: {} as CliDeps,
+      logger: { warn: vi.fn() },
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+      job,
+      text: "cron failed",
+      channel: "telegram",
+      to: "-1001234567890",
+      accountId: "bot-a",
+      threadId: 42,
+      mode: "announce",
+    });
+
+    expect(mocks.sendCronAnnouncePayloadStrict).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({
+          channel: "telegram",
+          to: "-1001234567890",
+          accountId: "bot-a",
+          threadId: 42,
+        }),
+      }),
+    );
+  });
+
   it("keeps immediate failure webhook messages stable and adds structured runAtMs", async () => {
     const runAtMs = Date.parse("2026-01-15T15:30:00.000Z");
     const job = createWebhookJob({
@@ -771,6 +805,38 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       sessionKey: "agent:main:telegram:group:-1001234567890:thread:42",
       inheritSessionThread: false,
     });
+  });
+
+  it("preserves the primary topic when a failed run falls back to its delivery route", () => {
+    const job = createWebhookJob({
+      mode: "announce",
+      channel: "telegram",
+      to: "-1001234567890",
+      accountId: "bot-a",
+      threadId: 42,
+    });
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: { jobId: job.id, action: "finished", status: "error", error: "boom" },
+      job,
+      deps: {} as CliDeps,
+      logger: { warn: vi.fn() },
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "main",
+      job.id,
+      expect.objectContaining({
+        channel: "telegram",
+        to: "-1001234567890",
+        accountId: "bot-a",
+        threadId: 42,
+      }),
+      expect.any(String),
+    );
   });
 
   it("announces channel-shaped failure destinations without mode under a global webhook default (#102235)", () => {

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -54,6 +54,7 @@ type CronFailureAlertParams = {
   to?: string;
   mode?: "announce" | "webhook";
   accountId?: string;
+  threadId?: string | number;
 };
 
 function redactWebhookUrl(url: string): string {
@@ -353,6 +354,7 @@ async function sendGatewayCronFailureAlertUnderAdmission(
           channel: params.channel,
           to: params.to,
           accountId: params.accountId,
+          threadId: params.threadId,
           sessionKey: resolveCronDeliverySessionKey(params.job),
         },
         message: appendCronRunStarted(params.text, params.runAtMs, runtimeConfig),
@@ -553,6 +555,7 @@ function dispatchCronFailureDestinationNotifications(params: {
           channel: primaryPlan.channel,
           to: primaryPlan.to,
           accountId: primaryPlan.accountId,
+          threadId: primaryPlan.threadId,
           sessionKey: deliverySessionKey,
         },
         appendCronRunStarted(`⚠️ ${failurePayload.message}`, params.evt.runAtMs, runtimeConfig),

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -987,7 +987,7 @@ export function buildGatewayCronService(params: {
         "cron: isolated agent setup timed out before runner start; backing off job without gateway restart",
       );
     },
-    sendCronFailureAlert: async ({ job, text, runAtMs, channel, to, mode, accountId }) =>
+    sendCronFailureAlert: async ({ job, text, runAtMs, channel, to, mode, accountId, threadId }) =>
       await sendGatewayCronFailureAlert({
         deps: params.deps,
         logger: cronLogger,
@@ -1000,6 +1000,7 @@ export function buildGatewayCronService(params: {
         to,
         mode,
         accountId,
+        threadId,
       }),
     log: getChildLogger({ module: "cron", storePath }),
     onEvent: (evt) => {


### PR DESCRIPTION
# fix(cron): preserve failure-notification topic routing

## Summary

- Keep completion-time primary failure fallbacks in the configured destination thread instead of posting into the parent channel.
- Keep threshold/global failure alerts in that same thread when their resolved channel, recipient, and account all match the primary delivery route.
- Preserve explicit failure-destination routing, alternate accounts/channels/recipients, webhook behavior, and numeric thread ID `0`.

## Root causes

1. The Gateway completion owner omitted the resolved primary delivery plan's `threadId` while creating its primary failure fallback.
2. The threshold-alert owner and its private Gateway transport contract dropped the matching primary thread before delivery.

These are two independently exercised decision surfaces: completion-time fallback routing and threshold/global failure-alert routing.

## Verification

- RED: focused regressions reproduced both wrong-thread routes against immutable base `25bb1da3a7314f027c477d8c14d6d95d058fa00d`.
- GREEN: **34 focused tests pass** across `src/cron/service/failure-alerts.account-routing.test.ts` and `src/gateway/server-cron-notifications.test.ts`.
- Separate strict read-only review: **CLEAN**, including a fresh independent 34-test rerun and direct probes for same-route topics, numeric `0`, alternate routes/accounts, webhook exclusion, and explicit failure-destination isolation.
- Structured autoreview: **CLEAN**, with a verified clean TruffleHog credential scan.
- Targeted formatting, clean branch status, and `git diff --check`: **CLEAN**.

## Landing identity

- Branch: `codex/auto-qa-cron-failure-thread-routing`.
- Commit: `6987d3a7a867a19a78baf7fb97a9470c27fbde3d`.
- Immutable parent: `25bb1da3a7314f027c477d8c14d6d95d058fa00d`.
- Root causes fixed: **2 independent wrong-thread routing defects**.
- No public SDK, Gateway protocol, configuration, SQLite schema/version, security, fetch, push, or `main` changes.
