### PR TITLE
fix(cli): preserve config dry-run error and batch contracts

### DIFF
--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -2,6 +2,7 @@ import { uniqueValues } from "@openclaw/normalization-core/string-normalization"
 import { replaceConfigFile } from "../config/config.js";
 import { AUTO_MANAGED_CONFIG_META_PATHS } from "../config/io.meta.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
+import { resolveConfigPath } from "../config/paths.js";
 import { readBestEffortRuntimeConfigSchema } from "../config/runtime-schema.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { collectUnsupportedSecretRefPolicyIssues } from "../config/validation.js";
@@ -492,12 +493,25 @@ export function handleConfigMutationError(params: {
   runtime: RuntimeEnv;
   options: ConfigMutationOptions;
 }) {
-  if (
-    params.options.dryRun &&
-    params.options.json &&
-    params.err instanceof ConfigSetDryRunValidationError
-  ) {
-    writeRuntimeJson(params.runtime, params.err.result);
+  if (params.options.dryRun && params.options.json) {
+    if (params.err instanceof ConfigSetDryRunValidationError) {
+      writeRuntimeJson(params.runtime, params.err.result);
+      params.runtime.exit(1);
+      return;
+    }
+    const message = params.err instanceof Error ? params.err.message : String(params.err);
+    const result: ConfigSetDryRunResult = {
+      ok: false,
+      operations: 0,
+      configPath: resolveConfigPath(),
+      inputModes: [],
+      checks: { schema: false, resolvability: false, resolvabilityComplete: false },
+      refsChecked: 0,
+      skippedExecRefs: 0,
+      errors: [{ kind: "schema", message }],
+    };
+    writeRuntimeJson(params.runtime, result);
+    params.runtime.error(danger(String(params.err)));
     params.runtime.exit(1);
     return;
   }

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2269,6 +2269,33 @@ describe("config cli", () => {
       );
     });
 
+    it("rejects empty inline batches before reading or rewriting config", async () => {
+      await expect(runConfigCommand(["config", "set", "--batch-json", "[]"])).rejects.toThrow(
+        ExitError,
+      );
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockLog).not.toHaveBeenCalled();
+      expectErrorIncludes("--batch-json must contain at least one config update.");
+    });
+
+    it("rejects empty batch files before reading or rewriting config", async () => {
+      const pathname = writeTempJson5File("openclaw-config-batch-empty", []);
+      try {
+        await expect(runConfigCommand(["config", "set", "--batch-file", pathname])).rejects.toThrow(
+          ExitError,
+        );
+      } finally {
+        fs.rmSync(pathname, { force: true });
+      }
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockLog).not.toHaveBeenCalled();
+      expectErrorIncludes("--batch-file must contain at least one config update.");
+    });
+
     it("supports batch-file mode", async () => {
       const resolved: OpenClawConfig = { gateway: { port: 18789 } };
       setSnapshot(resolved, resolved);
@@ -3149,6 +3176,60 @@ describe("config cli", () => {
       expect(errorKinds).toContain("resolvability");
       const errorRefs = (payload.errors ?? []).map((entry) => entry.ref ?? "");
       expect(errorRefs).toContain("env:default:DISCORD_BOT_TOKEN");
+    });
+
+    it.each([
+      {
+        name: "a malformed batch payload",
+        args: ["config", "set", "--batch-json", "{}", "--dry-run", "--json"],
+        message: "--batch-json must be a JSON array.",
+      },
+      {
+        name: "an empty batch payload",
+        args: ["config", "set", "--batch-json", "[]", "--dry-run", "--json"],
+        message: "--batch-json must contain at least one config update.",
+      },
+      {
+        name: "an invalid set path",
+        args: ["config", "set", "gateway.port\\", "19000", "--dry-run", "--json"],
+        message: "Invalid path (trailing escape): gateway.port\\",
+      },
+      {
+        name: "an invalid unset path",
+        args: ["config", "unset", "gateway.port\\", "--dry-run", "--json"],
+        message: "Invalid path (trailing escape): gateway.port\\",
+      },
+      {
+        name: "a missing patch file",
+        args: [
+          "config",
+          "patch",
+          "--file",
+          "/nonexistent/openclaw-config-json-patch.json5",
+          "--dry-run",
+          "--json",
+        ],
+        message: "--file not found: /nonexistent/openclaw-config-json-patch.json5",
+      },
+    ])("emits structured JSON and actionable stderr for $name", async ({ args, message }) => {
+      await expect(runConfigCommand(args)).rejects.toThrow(ExitError);
+
+      expect(mockReadConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(parseLastLogPayload()).toMatchObject({
+        ok: false,
+        operations: 0,
+        inputModes: [],
+        checks: {
+          schema: false,
+          resolvability: false,
+          resolvabilityComplete: false,
+        },
+        refsChecked: 0,
+        skippedExecRefs: 0,
+        errors: [{ kind: "schema", message }],
+      });
+      expectErrorIncludes(message);
     });
 
     it("keeps distinct resolvability failures when messages are identical but refs differ", async () => {

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -60,6 +60,11 @@ describe("config set input parsing", () => {
   it.each([
     { name: "malformed payload", batchJson: "{", message: "Failed to parse --batch-json:" },
     {
+      name: "empty batch payload",
+      batchJson: "[]",
+      message: "--batch-json must contain at least one config update.",
+    },
+    {
       name: "non-array payload",
       batchJson: '{"path":"gateway.auth.mode","value":"token"}',
       message: "--batch-json must be a JSON array.",
@@ -114,6 +119,14 @@ describe("config set input parsing", () => {
     });
   });
 
+  it("rejects empty --batch-file payloads", () => {
+    withBatchFile("openclaw-config-set-input-empty-", "[]", (batchPath) => {
+      expect(() => parseBatchSource({ batchFile: batchPath })).toThrow(
+        "--batch-file must contain at least one config update.",
+      );
+    });
+  });
+
   it("rejects --batch-file payloads above the config mutation limit", () => {
     withBatchFile(
       "openclaw-config-set-input-oversized-",
@@ -127,10 +140,10 @@ describe("config set input parsing", () => {
   });
 
   it("accepts --batch-file at exactly the size limit", () => {
-    const content = "[]".padEnd(8 * 1024 * 1024, " ");
+    const content = '[{"path":"gateway.port","value":19000}]'.padEnd(8 * 1024 * 1024, " ");
     withBatchFile("openclaw-config-set-input-boundary-", content, (batchPath) => {
       const parsed = parseBatchSource({ batchFile: batchPath });
-      expect(parsed).toEqual([]);
+      expect(parsed).toEqual([{ path: "gateway.port", value: 19000 }]);
     });
   });
 });

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -116,6 +116,9 @@ function parseBatchEntries(raw: string, sourceLabel: string): ConfigSetBatchEntr
   if (!Array.isArray(parsed)) {
     throw new Error(`${sourceLabel} must be a JSON array.`);
   }
+  if (parsed.length === 0) {
+    throw new Error(`${sourceLabel} must contain at least one config update.`);
+  }
   const out: ConfigSetBatchEntry[] = [];
   for (const [index, entry] of parsed.entries()) {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) {


### PR DESCRIPTION
## Summary

- Fix dry-run machine-output failures at the existing config mutation error owner. Ordinary parse and mode errors from config set, config unset, and config patch now emit one complete documented JSON result while retaining actionable stderr and exit status 1. Existing structured validation errors remain unchanged.
- Reject empty inline and file-backed mutation batches at their canonical parser before configuration loading or writing. This prevents zero-operation rewrites, JSON5-comment loss, metadata churn, and misleading gateway restart hints; valid batches and the exact 8 MiB file boundary remain supported.

## Root causes fixed

**2 distinct canonical-owner defects:** missing JSON error visibility and zero-operation config writes.

## Verification

- Exact candidate: `a8f7d37c2203e657f929a9382ef1bb6abd420d94` on `codex/auto-qa-cli-config-json-errors`.
- Focused parser regressions: **4 Vitest tests passed**, covering valid inline operations, rejected empty inline batches, rejected empty files, and accepted nonempty files at exactly 8 MiB.
- Real public handlers: malformed/empty `runConfigSet`, invalid-path `runConfigUnset`, and missing-file `runConfigPatch` each produced exactly one structured stdout JSON result, actionable stderr, and exit status 1.
- Real operator-file proof: an empty batch preserved a commented JSON5 configuration byte-for-byte, preserved its modification time, and emitted no restart/success message.
- Existing `ConfigSetDryRunValidationError` compatibility proof: original JSON payload retained verbatim, exit status 1 retained, and no new stderr output introduced.
- Genuine TruffleHog-backed `gpt-5.6-sol` autoreview: **clean**.
- Separate strict read-only config-owner reviewer: **PASS** after inspecting changed owners, set/unset/patch callers, neighboring validation behavior, documented JSON contract, bounded file reads, and the exact-size acceptance boundary.
- No config schema changes, new flags, migrations, setup changes, fetch, push, or changes to canonical main.
