### PR TITLE
fix(cron): align list ordering and visible-name search

### DIFF
--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createMockCronStateForJobs } from "./service.test-harness.js";
-import { listPage } from "./service/ops-read.js";
+import { list, listPage } from "./service/ops-read.js";
 import type { CronJob } from "./types.js";
 
 function createBaseJob(overrides?: Partial<CronJob>): CronJob {
@@ -85,6 +85,62 @@ describe("cron listPage sort guards", () => {
       expect(secondPage.snapshotRevision).toBe(firstPage.snapshotRevision);
     },
   );
+
+  it("keeps unscheduled jobs after scheduled jobs in the unpaginated list", async () => {
+    const jobs = [
+      createBaseJob({ id: "paused-z", enabled: false, state: {} }),
+      createBaseJob({ id: "later", state: { nextRunAtMs: 200 } }),
+      createBaseJob({ id: "paused-a", enabled: false, state: {} }),
+      createBaseJob({ id: "earlier", state: { nextRunAtMs: 100 } }),
+    ];
+    const state = createMockCronStateForJobs({ jobs });
+
+    const unpaginated = await list(state, { includeDisabled: true });
+    const page = await listPage(state, { enabled: "all", sortBy: "nextRunAtMs" });
+
+    expect(unpaginated.map((job) => job.id)).toEqual(["earlier", "later", "paused-a", "paused-z"]);
+    expect(unpaginated.map((job) => job.id)).toEqual(page.jobs.map((job) => job.id));
+  });
+
+  it("applies the same stable id tiebreaker to unpaginated cron jobs", async () => {
+    const nextRunAtMs = Date.parse("2026-02-27T15:30:00.000Z");
+    const jobs = [
+      createBaseJob({ id: "scheduled-z", state: { nextRunAtMs } }),
+      createBaseJob({ id: "scheduled-a", state: { nextRunAtMs } }),
+    ];
+    const state = createMockCronStateForJobs({ jobs });
+
+    const unpaginated = await list(state);
+
+    expect(unpaginated.map((job) => job.id)).toEqual(["scheduled-a", "scheduled-z"]);
+  });
+
+  it("matches the operator-visible display name when filtering cron jobs", async () => {
+    const job = createBaseJob({
+      id: "report-job",
+      name: "internal-report-name",
+      displayName: "Daily summary",
+    });
+    const state = createMockCronStateForJobs({ jobs: [job] });
+
+    const page = await listPage(state, { query: "Daily summary" });
+
+    expect(page.jobs.map((entry) => entry.id)).toEqual(["report-job"]);
+  });
+
+  it("preserves phrase searches across existing cron job fields", async () => {
+    const job = createBaseJob({
+      id: "report-job",
+      name: "Daily report",
+      description: "Quarterly summary",
+      displayName: "Executive overview",
+    });
+    const state = createMockCronStateForJobs({ jobs: [job] });
+
+    const page = await listPage(state, { query: "report Quarterly" });
+
+    expect(page.jobs.map((entry) => entry.id)).toEqual(["report-job"]);
+  });
 
   it("normalizes requested agent ids before filtering", async () => {
     const jobs = [

--- a/src/cron/service/ops-read.ts
+++ b/src/cron/service/ops-read.ts
@@ -50,7 +50,7 @@ export async function list(state: CronServiceState, opts?: { includeDisabled?: b
     await ensureLoadedForRead(state);
     const includeDisabled = opts?.includeDisabled === true;
     const jobs = (state.store?.jobs ?? []).filter((j) => includeDisabled || isJobEnabled(j));
-    return jobs.toSorted((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0));
+    return sortCronJobs(jobs, "nextRunAtMs", "asc");
   });
 }
 
@@ -289,7 +289,13 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
         return true;
       }
       const haystack = normalizeLowercaseStringOrEmpty(
-        [job.id, job.name, job.description ?? "", job.agentId ?? ""].join(" "),
+        [
+          job.id,
+          job.name,
+          job.description ?? "",
+          job.agentId ?? "",
+          ...(job.displayName ? [job.displayName] : []),
+        ].join(" "),
       );
       return haystack.includes(query);
     });


### PR DESCRIPTION
# fix(cron): align list ordering and visible-name search

## Summary

- Route the plugin-facing, unpaginated cron list through the existing canonical paginated-list sorter. Runnable jobs now appear before paused jobs, and jobs with identical next-run times use the same deterministic ID tiebreaker.
- Make Gateway cron search match the operator-visible `displayName` already shown by the CLI. Append that label after the existing searchable fields so established cross-field phrase searches remain unchanged.
- Keep the repair inside the existing cron read owner; do not change configuration, storage, schema, security, protocol, timezones, DST, or Croner behavior.

## Independently proven root causes

1. **Plugin-facing list ordering:** `cron.list({ includeDisabled: true })` sorted a missing next-run time as zero, placing paused jobs ahead of runnable jobs and preserving insertion order for timestamp ties instead of using the canonical stable ID tiebreaker.
2. **Visible-name search:** the Gateway list filter omitted `displayName`, although the CLI presents `displayName ?? name` as the operator-facing job name; searching the visible label therefore returned no matching job.

## Verification

- RED: focused scheduled-versus-paused ordering and stable-ID tie regressions both failed against pinned base `b4e10e8a90f4e9d0d7adffff83a229cd83d9c8fc`; an independent current-base product probe returned the visible display-name query as zero results.
- GREEN: `node scripts/run-vitest.mjs src/cron/service.list-page-sort-guards.test.ts src/cron/service/ops.update.disable-and-list.test.ts` — **2 files passed, 18 tests passed**.
- Four focused regressions cover scheduled-first ordering, canonical stable ID ties, the exact operator-visible display-name query, and unchanged phrase searches spanning the original job fields.
- Separate strict read-only owner review: **CLEAN**, including the plugin-facing API, canonical sorter, Gateway forwarding, CLI-visible label, existing plugin callers, and search compatibility.
- Mandatory structured autoreview: **CLEAN** (`gpt-5.6-sol`, confidence **0.98**); genuine TruffleHog credential scan **CLEAN**.
- Targeted `oxfmt --check` and `git diff --check`: **CLEAN**.

## Landing identity

- Branch: `codex/auto-qa-cron-list-order`
- Commit: `d226fae9ad84f620c15cdf821afb5065774bcda0`
- Pinned base: `b4e10e8a90f4e9d0d7adffff83a229cd83d9c8fc`
- Independently fixed root causes: **2**.
- Changed paths: `src/cron/service/ops-read.ts`; `src/cron/service.list-page-sort-guards.test.ts`.
- No fetch, push, or modification to `main`.
