### PR TITLE
fix(gateway): retain HTTP disconnect and stream error ownership

### DIFF
--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -1,7 +1,7 @@
 // HTTP common tests cover JSON/text response helpers, auth failures, security
 // headers, SSE headers, body parsing, and disconnect diagnostics.
 import { EventEmitter } from "node:events";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { ServerResponse, type IncomingMessage } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   onDiagnosticEvent,
@@ -335,6 +335,103 @@ describe("watchClientDisconnect", () => {
     socket.emit("close");
     expect(onDisconnect).toHaveBeenCalledTimes(1);
     expect(controller.signal.aborted).toBe(true);
+  });
+
+  it("immediately aborts when the request socket was already destroyed", () => {
+    const socket = Object.assign(new EventEmitter(), { destroyed: true });
+    const { req, res } = makeMockHttpReqRes(socket, socket);
+    const controller = new AbortController();
+    const onDisconnect = vi.fn();
+
+    const cleanup = watchClientDisconnect(req, res, controller, onDisconnect);
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+    expect(socket.listenerCount("close")).toBe(0);
+    expect(res.listenerCount("error")).toBe(1);
+    cleanup();
+    res.emit("close");
+    expect(res.listenerCount("error")).toBe(0);
+  });
+
+  it("immediately aborts when the response was already destroyed", () => {
+    const socket = new EventEmitter();
+    const { req, res } = makeMockHttpReqRes(socket, socket);
+    Object.assign(res, { destroyed: true });
+    const controller = new AbortController();
+    const onDisconnect = vi.fn();
+
+    const cleanup = watchClientDisconnect(req, res, controller, onDisconnect);
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+    expect(socket.listenerCount("close")).toBe(0);
+    expect(res.listenerCount("error")).toBe(1);
+    cleanup();
+    res.emit("close");
+    expect(res.listenerCount("error")).toBe(0);
+  });
+
+  it("handles response stream errors as client disconnects", () => {
+    const socket = new EventEmitter();
+    const { req, res } = makeMockHttpReqRes(socket, socket);
+    const controller = new AbortController();
+    const onDisconnect = vi.fn();
+    const cleanup = watchClientDisconnect(req, res, controller, onDisconnect);
+
+    expect(() => res.emit("error", new Error("response stream failed"))).not.toThrow();
+    expect(controller.signal.aborted).toBe(true);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    res.emit("close");
+    expect(res.listenerCount("error")).toBe(0);
+  });
+
+  it("keeps real response errors handled after cleanup until the response closes", async () => {
+    const socket = new EventEmitter();
+    const req = { socket } as IncomingMessage;
+    const res = new ServerResponse({ method: "POST" } as IncomingMessage);
+    const controller = new AbortController();
+    const onDisconnect = vi.fn();
+    const cleanup = watchClientDisconnect(req, res, controller, onDisconnect);
+
+    expect(res.listenerCount("error")).toBeGreaterThan(0);
+    cleanup();
+    res.end();
+    res.write("late SSE frame");
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+
+    res.emit("close");
+    expect(res.listenerCount("error")).toBe(0);
+  });
+
+  it("keeps deferred errors handled when a real response was already destroyed", async () => {
+    const socket = new EventEmitter();
+    const req = { socket } as IncomingMessage;
+    const res = new ServerResponse({ method: "POST" } as IncomingMessage);
+    const controller = new AbortController();
+    const deferredError = new Promise<void>((resolve) => {
+      process.nextTick(() => {
+        res.emit("error", new Error("destroyed response failed during cleanup"));
+        resolve();
+      });
+    });
+    res.destroy();
+
+    const cleanup = watchClientDisconnect(req, res, controller);
+    expect(controller.signal.aborted).toBe(true);
+    expect(res.listenerCount("error")).toBe(1);
+
+    await deferredError;
+    cleanup();
+    res.emit("close");
+    expect(res.listenerCount("error")).toBe(0);
   });
 
   it("does not double-abort when the controller is already aborted", () => {

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -182,6 +182,18 @@ export function watchClientDisconnect(
       abortController.abort(new ClientDisconnectError());
     }
   };
+  const stopWatchingResponseErrors = () => {
+    res.off("error", handleClose);
+    res.off("close", stopWatchingResponseErrors);
+  };
+  // Finalizers release socket watchers before res.end(); keep its error
+  // listener until close so a failed flush cannot become process-fatal.
+  res.on("error", handleClose);
+  res.once("close", stopWatchingResponseErrors);
+  if (res.destroyed || sockets.some((socket) => socket.destroyed)) {
+    handleClose();
+    return () => {};
+  }
   for (const socket of sockets) {
     socket.on("close", handleClose);
   }

--- a/src/gateway/test-http-response.ts
+++ b/src/gateway/test-http-response.ts
@@ -1,6 +1,6 @@
 // Gateway HTTP test helpers build minimal request/response doubles and collect
 // client response bodies.
-import type { EventEmitter } from "node:events";
+import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { PassThrough } from "node:stream";
 import { vi } from "vitest";
@@ -37,7 +37,7 @@ export function makeMockHttpReqRes(
 ): { req: IncomingMessage; res: ServerResponse } {
   return {
     req: { socket: reqSocket } as unknown as IncomingMessage,
-    res: { socket: resSocket } as unknown as ServerResponse,
+    res: Object.assign(new EventEmitter(), { socket: resSocket }) as unknown as ServerResponse,
   };
 }
 


### PR DESCRIPTION
## Summary

- Abort Gateway Chat, Responses, and tool-invocation work immediately when the request socket or response was already destroyed before disconnect watching begins.
- Keep the canonical shared HTTP owner's response-error listener alive until the real response closes, including deferred write-after-end and destroy errors after callers release socket watchers.
- Upgrade the shared HTTP response test double to an actual event emitter and preserve all existing distinct-socket, cleanup, and deterministic fuzz contracts.

## Verification

- Base: `acdb284314114ccae24cb0be2e4b93d934404ac7`.
- Branch: `codex/auto-qa-gateway-http-lifecycle`.
- Commit: `69a3b09c9f9b5b5086caabf05324791bb7ee807b`.
- Before fix: four focused lifecycle regressions failed, including a real Node `ServerResponse` write-after-end error.
- After fix: `src/gateway/http-common.test.ts` and `src/gateway/http-common.fuzz.test.ts`: **50 tests passed**.
- Targeted oxlint, oxfmt, and `git diff --check`: clean.
- Independent structured autoreview: clean.
- Separate strict read-only owner review: clean; inspected all five production callers, sibling session-history stream ownership, deterministic fuzz coverage, and Node's `_http_outgoing` deferred-error implementation.

## Root causes fixed

**2 distinct bugs:** pre-destroyed transports never aborted agent work; unowned response-stream errors could terminate the Gateway process.
