### PR TITLE
fix(gateway): preserve Responses streaming terminal ownership

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -10,7 +10,7 @@ import { FailoverError } from "../agents/failover-error.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
-import { emitAgentEvent } from "../infra/agent-events.js";
+import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { enqueueCommandInLane } from "../process/command-queue.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { createDeferred } from "../test-utils/deferred.js";
@@ -1279,6 +1279,203 @@ describe("OpenResponses HTTP API (e2e)", () => {
     } finally {
       // shared server
     }
+  });
+
+  it("flushes same-turn assistant microtasks before completing an official SDK stream", async () => {
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce(((opts: unknown) => {
+      const runId = (opts as { runId?: string }).runId;
+      if (!runId) {
+        throw new Error("expected a streaming response run ID");
+      }
+      emitAgentEvent({ runId, stream: "assistant", data: { delta: "start " } });
+      const result = Promise.resolve({ payloads: [{ text: "start finish!" }] });
+      void result.then(() => {
+        emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+        void Promise.resolve().then(() => {
+          emitAgentEvent({ runId, stream: "assistant", data: { delta: "finish" } });
+          void Promise.resolve().then(() => {
+            emitAgentEvent({ runId, stream: "assistant", data: { delta: "!" } });
+          });
+        });
+      });
+      return result;
+    }) as never);
+
+    const client = new OpenAI({
+      apiKey: "test",
+      baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+      defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+      maxRetries: 0,
+    });
+    const stream = client.responses.stream({
+      model: "openclaw",
+      input: "Finish the streamed response.",
+    });
+    const deltas: string[] = [];
+    stream.on("response.output_text.delta", (event) => {
+      deltas.push(event.delta);
+    });
+
+    const response = await stream.finalResponse();
+    expect(deltas.join("")).toBe("start finish!");
+    expect(response.status).toBe("completed");
+    expect(response.output_text).toBe("start finish!");
+    expect(agentCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes post-lifecycle assistant microtasks after usage is already available", async () => {
+    let unsubscribe = () => {};
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce(((opts: unknown) => {
+      const runId = (opts as { runId?: string }).runId;
+      if (!runId) {
+        throw new Error("expected a streaming response run ID");
+      }
+      emitAgentEvent({ runId, stream: "assistant", data: { delta: "start " } });
+      unsubscribe = onAgentEvent((event) => {
+        if (event.runId !== runId || event.stream !== "lifecycle" || event.data?.phase !== "end") {
+          return;
+        }
+        unsubscribe();
+        void Promise.resolve().then(() => {
+          emitAgentEvent({ runId, stream: "assistant", data: { delta: "finish" } });
+        });
+      });
+      return Promise.resolve({ payloads: [{ text: "start finish" }] });
+    }) as never);
+
+    try {
+      const client = new OpenAI({
+        apiKey: "test",
+        baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+        defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+        maxRetries: 0,
+      });
+      const response = await client.responses
+        .stream({ model: "openclaw", input: "Flush the final assistant microtask." })
+        .finalResponse();
+
+      expect(response.output_text).toBe("start finish");
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("fails conflicting assistant replacements queued after lifecycle completion", async () => {
+    let unsubscribe = () => {};
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce(((opts: unknown) => {
+      const runId = (opts as { runId?: string }).runId;
+      if (!runId) {
+        throw new Error("expected a streaming response run ID");
+      }
+      emitAgentEvent({ runId, stream: "assistant", data: { delta: "draft answer" } });
+      unsubscribe = onAgentEvent((event) => {
+        if (event.runId !== runId || event.stream !== "lifecycle" || event.data?.phase !== "end") {
+          return;
+        }
+        unsubscribe();
+        void Promise.resolve().then(() => {
+          emitAgentEvent({
+            runId,
+            stream: "assistant",
+            data: { text: "rewritten answer", replace: true, phase: "commentary" },
+          });
+        });
+      });
+      return Promise.resolve({ payloads: [{ text: "rewritten answer" }] });
+    }) as never);
+
+    try {
+      const client = new OpenAI({
+        apiKey: "test",
+        baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+        defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+        maxRetries: 0,
+      });
+      const stream = client.responses.stream({
+        model: "openclaw",
+        input: "Reject a late incompatible assistant replacement.",
+      });
+      let completedEvents = 0;
+      let failedEvents = 0;
+      stream.on("response.completed", () => {
+        completedEvents += 1;
+      });
+      stream.on("response.failed", () => {
+        failedEvents += 1;
+      });
+
+      const response = await stream.finalResponse();
+      expect(completedEvents).toBe(0);
+      expect(failedEvents).toBe(1);
+      expect(response.status).toBe("failed");
+      expect(response.error?.code).toBe("server_error");
+      expect(response.error?.message).toContain("append-only response stream");
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("fails an official SDK stream when an error lifecycle precedes a resolved run", async () => {
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string }).runId;
+      if (!runId) {
+        throw new Error("expected a streaming response run ID");
+      }
+      emitAgentEvent({ runId, stream: "assistant", data: { delta: "partial answer" } });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "error", error: "All model fallback candidates failed" },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "lifecycle",
+        data: { phase: "error", error: "A later lifecycle event must not replace the failure" },
+      });
+      return {
+        payloads: [{ text: "partial answer" }],
+        meta: { agentMeta: { usage: { input: 11, output: 7, total: 18 } } },
+      };
+    }) as never);
+
+    const client = new OpenAI({
+      apiKey: "test",
+      baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+      defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+      maxRetries: 0,
+    });
+    const stream = client.responses.stream({
+      model: "openclaw",
+      input: "Report the provider failure.",
+    });
+    let completedEvents = 0;
+    let failedEvents = 0;
+    stream.on("response.completed", () => {
+      completedEvents += 1;
+    });
+    stream.on("response.failed", () => {
+      failedEvents += 1;
+    });
+
+    const response = await stream.finalResponse();
+    expect(completedEvents).toBe(0);
+    expect(failedEvents).toBe(1);
+    expect(response.status).toBe("failed");
+    expect(response.error).toEqual({
+      code: "server_error",
+      message: "All model fallback candidates failed",
+    });
+    expect(response.usage).toMatchObject({
+      input_tokens: 11,
+      output_tokens: 7,
+      total_tokens: 18,
+    });
+    expect(agentCommand).toHaveBeenCalledTimes(1);
   });
 
   it("maps provider format failures to OpenResponses 400 failed responses", async () => {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -930,9 +930,11 @@ export async function handleOpenResponsesHttpRequest(
   let finalUsage: Usage | undefined;
   let finalizeStatus: ResponseResource["status"] | null = null;
   let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
+  let finalizeScheduled = false;
+  let finalizeErrorMessage: string | undefined;
 
   const maybeFinalize = () => {
-    if (closed) {
+    if (closed || finalizeScheduled) {
       return;
     }
     if (!finalizeRequested) {
@@ -941,60 +943,90 @@ export async function handleOpenResponsesHttpRequest(
     if (!finalUsage) {
       return;
     }
-    const usage = finalUsage;
+    // Lifecycle listeners can queue assistant flushes after this listener runs;
+    // the next turn preserves all same-turn deltas before the terminal snapshot.
+    finalizeScheduled = true;
+    setImmediate(() => {
+      if (closed || !finalizeRequested || !finalUsage) {
+        return;
+      }
+      if (unrepresentableAssistantReplacement) {
+        finalizeUnrepresentableAssistantReplacement();
+        return;
+      }
+      const usage = finalUsage;
+      const finalText =
+        accumulatedText || bufferedReplaceableAssistantContent || finalizeRequested.text;
 
-    closed = true;
-    stopWatchingDisconnect();
-    unsubscribe();
+      closed = true;
+      stopWatchingDisconnect();
+      unsubscribe();
 
-    writeSseEvent(res, {
-      type: "response.output_text.done",
-      item_id: outputItemId,
-      output_index: 0,
-      content_index: 0,
-      text: finalizeRequested.text,
+      writeSseEvent(res, {
+        type: "response.output_text.done",
+        item_id: outputItemId,
+        output_index: 0,
+        content_index: 0,
+        text: finalText,
+      });
+
+      writeSseEvent(res, {
+        type: "response.content_part.done",
+        item_id: outputItemId,
+        output_index: 0,
+        content_index: 0,
+        part: { type: "output_text", text: finalText },
+      });
+
+      const completedItem = createAssistantOutputItem({
+        id: outputItemId,
+        text: finalText,
+        phase: finalizeRequested.status === "completed" ? "final_answer" : "commentary",
+        status: "completed",
+      });
+
+      writeSseEvent(res, {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: completedItem,
+      });
+
+      const finalResponse = createResponseResource({
+        id: responseId,
+        model,
+        status: finalizeRequested.status,
+        output: [completedItem],
+        usage,
+        ...(finalizeRequested.status === "failed"
+          ? {
+              error: {
+                code: "server_error",
+                message: finalizeErrorMessage || "Agent run failed",
+              },
+            }
+          : {}),
+      });
+
+      rememberResponseSession();
+      writeSseEvent(res, {
+        type: finalizeRequested.status === "failed" ? "response.failed" : "response.completed",
+        response: finalResponse,
+      });
+      writeDone(res);
+      res.end();
     });
-
-    writeSseEvent(res, {
-      type: "response.content_part.done",
-      item_id: outputItemId,
-      output_index: 0,
-      content_index: 0,
-      part: { type: "output_text", text: finalizeRequested.text },
-    });
-
-    const completedItem = createAssistantOutputItem({
-      id: outputItemId,
-      text: finalizeRequested.text,
-      phase: finalizeRequested.status === "completed" ? "final_answer" : "commentary",
-      status: "completed",
-    });
-
-    writeSseEvent(res, {
-      type: "response.output_item.done",
-      output_index: 0,
-      item: completedItem,
-    });
-
-    const finalResponse = createResponseResource({
-      id: responseId,
-      model,
-      status: finalizeRequested.status,
-      output: [completedItem],
-      usage,
-    });
-
-    rememberResponseSession();
-    writeSseEvent(res, { type: "response.completed", response: finalResponse });
-    writeDone(res);
-    res.end();
   };
 
-  const requestFinalize = (status: ResponseResource["status"], text: string) => {
+  const requestFinalize = (
+    status: ResponseResource["status"],
+    text: string,
+    errorMessage?: string,
+  ) => {
     if (finalizeRequested) {
       return;
     }
     finalizeStatus = status;
+    finalizeErrorMessage = errorMessage;
     finalizeRequested = { status, text };
     maybeFinalize();
   };
@@ -1010,6 +1042,27 @@ export async function handleOpenResponsesHttpRequest(
     writeSseEvent(res, { type: "response.failed", response });
     writeDone(res);
     res.end();
+  };
+
+  const finalizeUnrepresentableAssistantReplacement = () => {
+    const usage = finalUsage;
+    if (!usage) {
+      return;
+    }
+    rememberResponseSession();
+    finalizeFailedResponse(
+      createResponseResource({
+        id: responseId,
+        model,
+        status: "failed",
+        output: [],
+        error: {
+          code: "server_error",
+          message: "Assistant output cannot be represented as an append-only response stream.",
+        },
+        usage,
+      }),
+    );
   };
 
   // Send initial events
@@ -1126,7 +1179,11 @@ export async function handleOpenResponsesHttpRequest(
         const finalText =
           accumulatedText || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
         const finalStatus = phase === "error" ? "failed" : "completed";
-        requestFinalize(finalStatus, finalText);
+        const errorMessage =
+          phase === "error" && typeof evt.data?.error === "string"
+            ? evt.data.error.trim()
+            : undefined;
+        requestFinalize(finalStatus, finalText, errorMessage);
       }
     }
   });
@@ -1160,20 +1217,7 @@ export async function handleOpenResponsesHttpRequest(
       finalUsage = extractUsageFromResult(result);
 
       if (unrepresentableAssistantReplacement) {
-        rememberResponseSession();
-        finalizeFailedResponse(
-          createResponseResource({
-            id: responseId,
-            model,
-            status: "failed",
-            output: [],
-            error: {
-              code: "server_error",
-              message: "Assistant output cannot be represented as an append-only response stream.",
-            },
-            usage: finalUsage,
-          }),
-        );
+        finalizeUnrepresentableAssistantReplacement();
         return;
       }
 


### PR DESCRIPTION
## Summary

- Preserve all same-turn assistant text before an OpenAI Responses stream emits its final `done` and terminal response, including producer callbacks queued after lifecycle completion.
- Reject append-incompatible assistant replacements even when they arrive during deferred finalization, using one canonical failure owner.
- Emit the official SDK's `response.failed` terminal event and `server_error` payload when an agent publishes a failed lifecycle but resolves its result normally; preserve the first failure message and usage.

## Verification

- Base: `acdb284314114ccae24cb0be2e4b93d934404ac7`.
- Branch: `codex/auto-qa-gateway-responses-terminal`.
- Commit: `34f4ca3680728a814111d8fc15ffec1c8f6b79a7`.
- Official OpenAI SDK regressions first reproduced truncated final text, post-lifecycle text loss, successful completion for a failed run, duplicate failure-message ownership, and conflicting late replacements.
- Dedicated Blacksmith Testbox `tbx_01kyvxyppg15nqzhrjqjvejrrc`: full `src/gateway/openresponses-http.test.ts` and `src/gateway/openai-http.test.ts`: **92 tests passed**.
- Exact-snapshot remote `pnpm check:changed`: passed, including core/core-test typechecks, lint, formatting, import-cycle, owner-boundary, and repository guards.
- Independent structured autoreview and separate strict read-only Gateway owner review: clean.
- No auth, image handling, public protocol/schema, configuration, or unrelated tool-stream surfaces changed.

## Root causes fixed

**2 distinct bugs:** premature terminal snapshots silently dropped valid same-turn assistant output; lifecycle failures followed by normally resolved runs emitted successful completion events without actionable SDK-compatible failure details.
