### PR TITLE
fix: prevent stale sharing updates after connection switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI sharing connection isolation:** discard stale visibility and membership mutation results after switching gateways or accounts so previous-connection refreshes and errors cannot update the replacement connection. Fixes #116800. Thanks @shakkernerd.
 - **Control UI session refreshes:** preserve explicitly queued list filters and background hydration across later Gateway event invalidation, while keeping append pagination followed by a canonical refresh. Fixes #116697. Thanks @shakkernerd.
 - **Gateway device clock skew:** sign device proofs with the Gateway-issued challenge timestamp across TypeScript, Control UI, browser extension, Android, Apple, Linux, and watchOS clients so incorrect local clocks no longer block authentication, while retaining no-challenge compatibility for pre-challenge Control UI servers and older watch-node HTTP endpoints and keeping nonce binding and freshness checks enforced. Fixes #103455.
 - **Control UI dynamic deep links:** reuse the initial route loader result when publishing real agent, session, dashboard, Workboard, Memory, and Plugins paths, avoiding redundant route-loader work during startup. Thanks @shakkernerd.

--- a/ui/src/pages/chat/chat-pane-sharing.test.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.test.ts
@@ -1,0 +1,249 @@
+/* @vitest-environment jsdom */
+/* @vitest-environment-options {"url":"http://chat-pane-sharing.test/"} */
+
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type {
+  GatewaySessionRow,
+  SessionMembersListResult,
+  SessionVisibility,
+} from "../../api/types.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import {
+  createSessionContext,
+  createTestChatPane,
+  type TestChatPane,
+} from "./chat-pane.test-support.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import type { ChatSessionSharingState } from "./components/chat-session-sharing.ts";
+
+type SharingPane = TestChatPane & {
+  sessionSharingCacheKey: (sessionKey: string) => string;
+  sessionSharingStates: Map<string, ChatSessionSharingState>;
+  setSessionMember: (
+    row: GatewaySessionRow,
+    identityId: string,
+    member: boolean,
+  ) => Promise<void>;
+  setSessionVisibility: (
+    row: GatewaySessionRow,
+    visibility: SessionVisibility,
+  ) => Promise<void>;
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  reject: (error: unknown) => void;
+  resolve: (value: T) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}
+
+function sessionRow(): GatewaySessionRow {
+  return {
+    key: "agent:main:current",
+    kind: "direct",
+    updatedAt: 1,
+    visibility: "draft",
+    sharingRole: "owner",
+  };
+}
+
+function sharingResult(row: GatewaySessionRow): SessionMembersListResult {
+  return {
+    sessionKey: row.key,
+    members: [],
+    identities: [],
+    role: "owner",
+    allowedVisibilities: ["shared", "draft"],
+  };
+}
+
+function replaceConnection(
+  pane: SharingPane,
+  state: ChatPageHost,
+  client: GatewayBrowserClient,
+  sessions: SessionCapability,
+): void {
+  pane.connectionGeneration += 1;
+  pane.context = createSessionContext(client, sessions);
+  pane.state = state;
+  state.client = client;
+  state.connected = true;
+  state.connectionEpoch = pane.connectionGeneration;
+  pane.connectedClient = client;
+}
+
+const mutations = [
+  {
+    name: "visibility",
+    method: "session.visibility.set",
+    invoke: (pane: SharingPane, row: GatewaySessionRow) =>
+      pane.setSessionVisibility(row, "shared"),
+  },
+  {
+    name: "member",
+    method: "session.members.add",
+    invoke: (pane: SharingPane, row: GatewaySessionRow) =>
+      pane.setSessionMember(row, "identity-alice", true),
+  },
+] as const;
+
+describe.each(mutations)("chat pane $name mutation connection ownership", (mutation) => {
+  it.each(["resolve", "reject"] as const)(
+    "drops a stale mutation when the previous connection later %s",
+    async (completion) => {
+      const response = createDeferred<unknown>();
+      const oldRequest = vi.fn((method: string) => {
+        if (method !== mutation.method) {
+          throw new Error(`unexpected old-connection request: ${method}`);
+        }
+        return response.promise;
+      });
+      const oldSessions = {
+        refreshReplacement: vi.fn(),
+      } as unknown as SessionCapability;
+      const { pane: testPane, state } = createTestChatPane({
+        client: { request: oldRequest } as unknown as GatewayBrowserClient,
+        sessions: oldSessions,
+      });
+      const pane = testPane as SharingPane;
+      const row = sessionRow();
+      const pending = mutation.invoke(pane, row);
+      expect(oldRequest).toHaveBeenCalledWith(
+        mutation.method,
+        expect.objectContaining({ sessionKey: row.key }),
+      );
+
+      const nextRequest = vi.fn();
+      const nextSessions = {
+        refreshReplacement: vi.fn(),
+      } as unknown as SessionCapability;
+      replaceConnection(
+        pane,
+        state,
+        { request: nextRequest } as unknown as GatewayBrowserClient,
+        nextSessions,
+      );
+      const cacheKey = pane.sessionSharingCacheKey(row.key);
+      const replacementState: ChatSessionSharingState = {
+        loading: false,
+        result: sharingResult(row),
+      };
+      pane.sessionSharingStates = new Map([[cacheKey, replacementState]]);
+
+      if (completion === "resolve") {
+        response.resolve({});
+      } else {
+        response.reject(new Error("old connection failed"));
+      }
+      await pending;
+
+      expect(nextRequest).not.toHaveBeenCalled();
+      expect(nextSessions.refreshReplacement).not.toHaveBeenCalled();
+      expect(pane.sessionSharingStates.get(cacheKey)).toBe(replacementState);
+    },
+  );
+
+  it("preserves the current connection failure in the sharing cache", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === mutation.method) {
+        throw new Error(`${mutation.name} failed`);
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    const sessions = {
+      refreshReplacement: vi.fn(),
+    } as unknown as SessionCapability;
+    const { pane: testPane } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions,
+    });
+    const pane = testPane as SharingPane;
+    const row = sessionRow();
+
+    await mutation.invoke(pane, row);
+
+    expect(pane.sessionSharingStates.get(pane.sessionSharingCacheKey(row.key))).toMatchObject({
+      loading: false,
+      error: `Error: ${mutation.name} failed`,
+    });
+    expect(sessions.refreshReplacement).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat pane current sharing mutation refresh order", () => {
+  it("refreshes sessions before sharing after a visibility change", async () => {
+    const row = sessionRow();
+    const calls: string[] = [];
+    const request = vi.fn(async (method: string) => {
+      calls.push(method);
+      if (method === "session.members.list") {
+        return sharingResult(row);
+      }
+      return {};
+    });
+    const sessions = {
+      refreshReplacement: vi.fn(async () => {
+        calls.push("sessions.refreshReplacement");
+      }),
+    } as unknown as SessionCapability;
+    const { pane: testPane } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions,
+    });
+    const pane = testPane as SharingPane;
+
+    await pane.setSessionVisibility(row, "shared");
+
+    expect(calls).toEqual([
+      "session.visibility.set",
+      "sessions.refreshReplacement",
+      "session.members.list",
+    ]);
+    expect(pane.sessionSharingStates.get(pane.sessionSharingCacheKey(row.key))?.result).toEqual(
+      sharingResult(row),
+    );
+  });
+
+  it("refreshes sharing before sessions after a member change", async () => {
+    const row = sessionRow();
+    const calls: string[] = [];
+    const request = vi.fn(async (method: string) => {
+      calls.push(method);
+      if (method === "session.members.list") {
+        return sharingResult(row);
+      }
+      return {};
+    });
+    const sessions = {
+      refreshReplacement: vi.fn(async () => {
+        calls.push("sessions.refreshReplacement");
+      }),
+    } as unknown as SessionCapability;
+    const { pane: testPane } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions,
+    });
+    const pane = testPane as SharingPane;
+
+    await pane.setSessionMember(row, "identity-alice", true);
+
+    expect(calls).toEqual([
+      "session.members.add",
+      "session.members.list",
+      "sessions.refreshReplacement",
+    ]);
+    expect(pane.sessionSharingStates.get(pane.sessionSharingCacheKey(row.key))?.result).toEqual(
+      sharingResult(row),
+    );
+  });
+});

--- a/ui/src/pages/chat/chat-pane-sharing.test.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.test.ts
@@ -75,6 +75,25 @@ function replaceConnection(
   pane.connectedClient = client;
 }
 
+function installReplacementConnection(
+  pane: SharingPane,
+  state: ChatPageHost,
+  row: GatewaySessionRow,
+) {
+  const request = vi.fn();
+  const sessions = {
+    refreshReplacement: vi.fn(),
+  } as unknown as SessionCapability;
+  replaceConnection(pane, state, { request } as unknown as GatewayBrowserClient, sessions);
+  const cacheKey = pane.sessionSharingCacheKey(row.key);
+  const sharingState: ChatSessionSharingState = {
+    loading: false,
+    result: sharingResult(row),
+  };
+  pane.sessionSharingStates = new Map([[cacheKey, sharingState]]);
+  return { cacheKey, request, sessions, sharingState };
+}
+
 const mutations = [
   {
     name: "visibility",
@@ -115,22 +134,7 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
         expect.objectContaining({ sessionKey: row.key }),
       );
 
-      const nextRequest = vi.fn();
-      const nextSessions = {
-        refreshReplacement: vi.fn(),
-      } as unknown as SessionCapability;
-      replaceConnection(
-        pane,
-        state,
-        { request: nextRequest } as unknown as GatewayBrowserClient,
-        nextSessions,
-      );
-      const cacheKey = pane.sessionSharingCacheKey(row.key);
-      const replacementState: ChatSessionSharingState = {
-        loading: false,
-        result: sharingResult(row),
-      };
-      pane.sessionSharingStates = new Map([[cacheKey, replacementState]]);
+      const replacement = installReplacementConnection(pane, state, row);
 
       if (completion === "resolve") {
         response.resolve({});
@@ -139,9 +143,9 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
       }
       await pending;
 
-      expect(nextRequest).not.toHaveBeenCalled();
-      expect(nextSessions.refreshReplacement).not.toHaveBeenCalled();
-      expect(pane.sessionSharingStates.get(cacheKey)).toBe(replacementState);
+      expect(replacement.request).not.toHaveBeenCalled();
+      expect(replacement.sessions.refreshReplacement).not.toHaveBeenCalled();
+      expect(pane.sessionSharingStates.get(replacement.cacheKey)).toBe(replacement.sharingState);
     },
   );
 
@@ -169,6 +173,132 @@ describe.each(mutations)("chat pane $name mutation connection ownership", (mutat
       error: `Error: ${mutation.name} failed`,
     });
     expect(sessions.refreshReplacement).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat pane sharing mutation phase ownership", () => {
+  it.each(["resolve", "reject"] as const)(
+    "drops a stale visibility session refresh when it later %s",
+    async (completion) => {
+      const refreshed = createDeferred<void>();
+      const request = vi.fn(async (method: string) => {
+        if (method === "session.visibility.set") {
+          return {};
+        }
+        throw new Error(`unexpected old-connection request: ${method}`);
+      });
+      const oldSessions = {
+        refreshReplacement: vi.fn(() => refreshed.promise),
+      } as unknown as SessionCapability;
+      const { pane: testPane, state } = createTestChatPane({
+        client: { request } as unknown as GatewayBrowserClient,
+        sessions: oldSessions,
+      });
+      const pane = testPane as SharingPane;
+      const row = sessionRow();
+      const pending = pane.setSessionVisibility(row, "shared");
+      await vi.waitFor(() => {
+        expect(oldSessions.refreshReplacement).toHaveBeenCalledWith("main");
+      });
+
+      const replacement = installReplacementConnection(pane, state, row);
+      if (completion === "resolve") {
+        refreshed.resolve();
+      } else {
+        refreshed.reject(new Error("old session refresh failed"));
+      }
+      await pending;
+
+      expect(replacement.request).not.toHaveBeenCalled();
+      expect(replacement.sessions.refreshReplacement).not.toHaveBeenCalled();
+      expect(pane.sessionSharingStates.get(replacement.cacheKey)).toBe(replacement.sharingState);
+    },
+  );
+
+  it.each(
+    mutations.flatMap((mutation) =>
+      (["resolve", "reject"] as const).map((completion) => ({
+        ...mutation,
+        completion,
+      })),
+    ),
+  )(
+    "drops a stale $name sharing reload when it later $completion",
+    async ({ completion, invoke, method, name }) => {
+      const listed = createDeferred<SessionMembersListResult>();
+      const request = vi.fn((requestMethod: string) => {
+        if (requestMethod === method) {
+          return Promise.resolve({});
+        }
+        if (requestMethod === "session.members.list") {
+          return listed.promise;
+        }
+        throw new Error(`unexpected old-connection request: ${requestMethod}`);
+      });
+      const oldSessions = {
+        refreshReplacement: vi.fn(async () => undefined),
+      } as unknown as SessionCapability;
+      const { pane: testPane, state } = createTestChatPane({
+        client: { request } as unknown as GatewayBrowserClient,
+        sessions: oldSessions,
+      });
+      const pane = testPane as SharingPane;
+      const row = sessionRow();
+      const pending = invoke(pane, row);
+      await vi.waitFor(() => {
+        expect(request).toHaveBeenCalledWith(
+          "session.members.list",
+          expect.objectContaining({ sessionKey: row.key }),
+        );
+      });
+
+      const replacement = installReplacementConnection(pane, state, row);
+      if (completion === "resolve") {
+        listed.resolve(sharingResult(row));
+      } else {
+        listed.reject(new Error(`old ${name} sharing reload failed`));
+      }
+      await pending;
+
+      expect(oldSessions.refreshReplacement).toHaveBeenCalledTimes(name === "visibility" ? 1 : 0);
+      expect(replacement.request).not.toHaveBeenCalled();
+      expect(replacement.sessions.refreshReplacement).not.toHaveBeenCalled();
+      expect(pane.sessionSharingStates.get(replacement.cacheKey)).toBe(replacement.sharingState);
+    },
+  );
+
+  it("drops a stale member session refresh failure", async () => {
+    const refreshed = createDeferred<void>();
+    const row = sessionRow();
+    const request = vi.fn(async (method: string) => {
+      if (method === "session.members.list") {
+        return sharingResult(row);
+      }
+      if (method === "session.members.add") {
+        return {};
+      }
+      throw new Error(`unexpected old-connection request: ${method}`);
+    });
+    const oldSessions = {
+      refreshReplacement: vi.fn(() => refreshed.promise),
+    } as unknown as SessionCapability;
+    const { pane: testPane, state } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: oldSessions,
+    });
+    const pane = testPane as SharingPane;
+    const pending = pane.setSessionMember(row, "identity-alice", true);
+    await vi.waitFor(() => {
+      expect(oldSessions.refreshReplacement).toHaveBeenCalledWith("main");
+    });
+
+    const replacement = installReplacementConnection(pane, state, row);
+    refreshed.reject(new Error("old member session refresh failed"));
+    await pending;
+
+    expect(replacement.request).not.toHaveBeenCalled();
+    expect(replacement.sessions.refreshReplacement).not.toHaveBeenCalled();
+    expect(pane.sessionSharingStates.get(replacement.cacheKey)).toBe(replacement.sharingState);
   });
 });
 

--- a/ui/src/pages/chat/chat-pane-sharing.test.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.test.ts
@@ -215,57 +215,52 @@ describe("chat pane sharing mutation phase ownership", () => {
     },
   );
 
-  it.each(
-    mutations.flatMap((mutation) =>
-      (["resolve", "reject"] as const).map((completion) => ({
-        ...mutation,
-        completion,
-      })),
-    ),
-  )(
-    "drops a stale $name sharing reload when it later $completion",
-    async ({ completion, invoke, method, name }) => {
-      const listed = createDeferred<SessionMembersListResult>();
-      const request = vi.fn((requestMethod: string) => {
-        if (requestMethod === method) {
-          return Promise.resolve({});
-        }
-        if (requestMethod === "session.members.list") {
-          return listed.promise;
-        }
-        throw new Error(`unexpected old-connection request: ${requestMethod}`);
-      });
-      const oldSessions = {
-        refreshReplacement: vi.fn(async () => undefined),
-      } as unknown as SessionCapability;
-      const { pane: testPane, state } = createTestChatPane({
-        client: { request } as unknown as GatewayBrowserClient,
-        sessions: oldSessions,
-      });
-      const pane = testPane as SharingPane;
-      const row = sessionRow();
-      const pending = invoke(pane, row);
-      await vi.waitFor(() => {
-        expect(request).toHaveBeenCalledWith(
-          "session.members.list",
-          expect.objectContaining({ sessionKey: row.key }),
-        );
-      });
+  describe.each(mutations)("$name sharing reload", ({ invoke, method, name }) => {
+    it.each(["resolve", "reject"] as const)(
+      "drops a stale sharing reload when it later %s",
+      async (completion) => {
+        const listed = createDeferred<SessionMembersListResult>();
+        const request = vi.fn((requestMethod: string) => {
+          if (requestMethod === method) {
+            return Promise.resolve({});
+          }
+          if (requestMethod === "session.members.list") {
+            return listed.promise;
+          }
+          throw new Error(`unexpected old-connection request: ${requestMethod}`);
+        });
+        const oldSessions = {
+          refreshReplacement: vi.fn(async () => undefined),
+        } as unknown as SessionCapability;
+        const { pane: testPane, state } = createTestChatPane({
+          client: { request } as unknown as GatewayBrowserClient,
+          sessions: oldSessions,
+        });
+        const pane = testPane as SharingPane;
+        const row = sessionRow();
+        const pending = invoke(pane, row);
+        await vi.waitFor(() => {
+          expect(request).toHaveBeenCalledWith(
+            "session.members.list",
+            expect.objectContaining({ sessionKey: row.key }),
+          );
+        });
 
-      const replacement = installReplacementConnection(pane, state, row);
-      if (completion === "resolve") {
-        listed.resolve(sharingResult(row));
-      } else {
-        listed.reject(new Error(`old ${name} sharing reload failed`));
-      }
-      await pending;
+        const replacement = installReplacementConnection(pane, state, row);
+        if (completion === "resolve") {
+          listed.resolve(sharingResult(row));
+        } else {
+          listed.reject(new Error(`old ${name} sharing reload failed`));
+        }
+        await pending;
 
-      expect(oldSessions.refreshReplacement).toHaveBeenCalledTimes(name === "visibility" ? 1 : 0);
-      expect(replacement.request).not.toHaveBeenCalled();
-      expect(replacement.sessions.refreshReplacement).not.toHaveBeenCalled();
-      expect(pane.sessionSharingStates.get(replacement.cacheKey)).toBe(replacement.sharingState);
-    },
-  );
+        expect(oldSessions.refreshReplacement).toHaveBeenCalledTimes(name === "visibility" ? 1 : 0);
+        expect(replacement.request).not.toHaveBeenCalled();
+        expect(replacement.sessions.refreshReplacement).not.toHaveBeenCalled();
+        expect(pane.sessionSharingStates.get(replacement.cacheKey)).toBe(replacement.sharingState);
+      },
+    );
+  });
 
   it("drops a stale member session refresh failure", async () => {
     const refreshed = createDeferred<void>();

--- a/ui/src/pages/chat/chat-pane-sharing.test.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.test.ts
@@ -20,15 +20,8 @@ import type { ChatSessionSharingState } from "./components/chat-session-sharing.
 type SharingPane = TestChatPane & {
   sessionSharingCacheKey: (sessionKey: string) => string;
   sessionSharingStates: Map<string, ChatSessionSharingState>;
-  setSessionMember: (
-    row: GatewaySessionRow,
-    identityId: string,
-    member: boolean,
-  ) => Promise<void>;
-  setSessionVisibility: (
-    row: GatewaySessionRow,
-    visibility: SessionVisibility,
-  ) => Promise<void>;
+  setSessionMember: (row: GatewaySessionRow, identityId: string, member: boolean) => Promise<void>;
+  setSessionVisibility: (row: GatewaySessionRow, visibility: SessionVisibility) => Promise<void>;
 };
 
 type Deferred<T> = {
@@ -86,8 +79,7 @@ const mutations = [
   {
     name: "visibility",
     method: "session.visibility.set",
-    invoke: (pane: SharingPane, row: GatewaySessionRow) =>
-      pane.setSessionVisibility(row, "shared"),
+    invoke: (pane: SharingPane, row: GatewaySessionRow) => pane.setSessionVisibility(row, "shared"),
   },
   {
     name: "member",

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -85,22 +85,30 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     row: GatewaySessionRow,
     visibility: SessionVisibility,
   ): Promise<void> {
-    const state = this.state;
-    if (!state?.connected || !state.client || visibility === row.visibility) {
+    const scope = this.captureConnectionScope();
+    if (!scope || visibility === row.visibility) {
       return;
     }
+    const agentId = this.sessionSharingAgentId(row.key);
+    const cacheKey = this.sessionSharingCacheKey(row.key);
     try {
-      await state.client.request("session.visibility.set", {
+      await scope.client.request("session.visibility.set", {
         sessionKey: row.key,
         visibility,
-        ...(this.sessionSharingAgentId(row.key)
-          ? { agentId: this.sessionSharingAgentId(row.key) }
-          : {}),
+        ...(agentId ? { agentId } : {}),
       });
-      await this.context.sessions.refreshReplacement(this.sessionSharingAgentId(row.key));
+      if (!this.isConnectionScopeCurrent(scope)) {
+        return;
+      }
+      await scope.sessions.refreshReplacement(agentId);
+      if (!this.isConnectionScopeCurrent(scope)) {
+        return;
+      }
       await this.loadSessionSharing(row, true);
     } catch (error) {
-      const cacheKey = this.sessionSharingCacheKey(row.key);
+      if (!this.isConnectionScopeCurrent(scope)) {
+        return;
+      }
       this.setSessionSharingState(cacheKey, {
         ...(this.sessionSharingStates.get(cacheKey) ?? { loading: false }),
         loading: false,
@@ -114,22 +122,30 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     identityId: string,
     member: boolean,
   ): Promise<void> {
-    const state = this.state;
-    if (!state?.connected || !state.client) {
+    const scope = this.captureConnectionScope();
+    if (!scope) {
       return;
     }
+    const agentId = this.sessionSharingAgentId(row.key);
+    const cacheKey = this.sessionSharingCacheKey(row.key);
     try {
-      await state.client.request(member ? "session.members.add" : "session.members.remove", {
+      await scope.client.request(member ? "session.members.add" : "session.members.remove", {
         sessionKey: row.key,
         identityId,
-        ...(this.sessionSharingAgentId(row.key)
-          ? { agentId: this.sessionSharingAgentId(row.key) }
-          : {}),
+        ...(agentId ? { agentId } : {}),
       });
+      if (!this.isConnectionScopeCurrent(scope)) {
+        return;
+      }
       await this.loadSessionSharing(row, true);
-      await this.context.sessions.refreshReplacement(this.sessionSharingAgentId(row.key));
+      if (!this.isConnectionScopeCurrent(scope)) {
+        return;
+      }
+      await scope.sessions.refreshReplacement(agentId);
     } catch (error) {
-      const cacheKey = this.sessionSharingCacheKey(row.key);
+      if (!this.isConnectionScopeCurrent(scope)) {
+        return;
+      }
       this.setSessionSharingState(cacheKey, {
         ...(this.sessionSharingStates.get(cacheKey) ?? { loading: false }),
         loading: false,


### PR DESCRIPTION
Closes #116800

## What Problem This Solves

Fixes an issue where users changing session visibility or membership could see stale sharing state or errors when the Control UI switched to another gateway or account while the mutation was still in flight.

## Why This Change Was Made

Sharing mutations now remain bound to the gateway connection that initiated them and discard stale results after every asynchronous mutation, refresh, and reload phase. Existing success ordering and current-connection error behavior remain unchanged.

## User Impact

Operators can switch gateways or accounts without an earlier connection's sharing mutation refreshing or overwriting the replacement connection's session state.

## Evidence

- Focused Control UI tests: 15/15 passed on AWS Crabbox run `run_62e5c5e1a70b`.
- Changed-surface gate passed on AWS Crabbox run `run_a31c9183ad82`.
- Fresh autoreview reported no accepted or actionable findings.
- Independent Workloop review reported no correctness, performance, compatibility, or missing-proof findings.
