### PR TITLE
fix(codex): forking an imported thread fails when the prompt had surrounding whitespace

### DIFF
--- a/extensions/codex/src/app-server/imported-history-text.ts
+++ b/extensions/codex/src/app-server/imported-history-text.ts
@@ -1,0 +1,53 @@
+import { Buffer } from "node:buffer";
+
+const CODEX_HISTORY_IMPORT_MAX_MESSAGE_BYTES = 64 * 1024;
+const CODEX_HISTORY_TRUNCATION_SUFFIX = "\n\n[Message truncated during Codex history import.]";
+
+function isUtf8ContinuationByte(byte: number | undefined): boolean {
+  return byte !== undefined && (byte & 0xc0) === 0x80;
+}
+
+function truncateUtf8Prefix(value: string, maxBytes: number): string {
+  const bytes = Buffer.from(value);
+  if (bytes.byteLength <= maxBytes) {
+    return value;
+  }
+  let end = Math.max(0, maxBytes);
+  while (end > 0 && isUtf8ContinuationByte(bytes[end])) {
+    end -= 1;
+  }
+  return bytes.subarray(0, end).toString("utf8");
+}
+
+/** How history import stores a single upstream text value: trimmed, and capped so one
+ * message cannot consume the whole import budget. Drift checks must compare against
+ * this projection rather than raw upstream text, or a stored entry reads as divergence. */
+export function normalizeImportedHistoryText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const text = value.trim();
+  if (!text) {
+    return undefined;
+  }
+  if (Buffer.byteLength(text, "utf8") <= CODEX_HISTORY_IMPORT_MAX_MESSAGE_BYTES) {
+    return text;
+  }
+  const suffixBytes = Buffer.byteLength(CODEX_HISTORY_TRUNCATION_SUFFIX, "utf8");
+  const contentLimitBytes = Math.max(0, CODEX_HISTORY_IMPORT_MAX_MESSAGE_BYTES - suffixBytes);
+  return `${truncateUtf8Prefix(text, contentLimitBytes)}${CODEX_HISTORY_TRUNCATION_SUFFIX}`;
+}
+
+/** Project the ordered parts of one upstream user message the way import stores it:
+ * each part normalized, empties dropped, joined, then normalized again so the joined
+ * result also respects the per-message cap. */
+export function projectImportedHistoryTextParts(rawParts: readonly string[]): string | undefined {
+  const parts: string[] = [];
+  for (const raw of rawParts) {
+    const text = normalizeImportedHistoryText(raw);
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return normalizeImportedHistoryText(parts.join("\n"));
+}

--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -26,7 +26,10 @@ import {
   importCodexThreadHistoryToTranscript,
   projectBoundedCodexThreadHistory,
 } from "./transcript-mirror.js";
-import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
+import {
+  attachCodexMirrorIdentity,
+  isImportedHistoryMessage,
+} from "./upstream-prompt-provenance.js";
 
 const mirrorCodexAppServerTranscript = codexTranscriptMirrorRuntime.mirror;
 const mirrorTranscriptBestEffort = codexTranscriptMirrorRuntime.mirrorBestEffort;
@@ -296,6 +299,52 @@ describe("importCodexThreadHistoryToTranscript", () => {
       }
     },
   );
+
+  it("persists import provenance so drift checks can tell imported rows from live ones", async () => {
+    const target = await createSqliteMirrorTarget("openclaw-codex-history-provenance-", {
+      sessionId: "session-history-provenance",
+    });
+    const thread = {
+      id: "thread-provenance",
+      turns: [
+        {
+          id: "turn-1",
+          status: "completed",
+          startedAt: 1_700_000_000,
+          completedAt: 1_700_000_001,
+          items: [
+            {
+              id: "user-1",
+              type: "userMessage",
+              content: [{ type: "text", text: "  refactor the parser  " }],
+            },
+            { id: "assistant-1", type: "agentMessage", text: "done", phase: "final_answer" },
+          ],
+        },
+      ],
+    } as unknown as CodexThread;
+
+    await expect(
+      importCodexThreadHistoryToTranscript({
+        thread,
+        throughTurnId: "turn-1",
+        storePath: target.storePath,
+        sessionId: target.sessionId,
+        sessionKey: target.sessionKey,
+        agentId: target.agentId,
+      }),
+    ).resolves.toEqual({ importedMessages: 2, omittedMessages: 0 });
+
+    // The mark has to survive serialization: fork drift checks read it back from the
+    // store to decide whether the stored text is the lossy import projection. Read the
+    // stored event, not readMirrorMessages, which projects away message metadata.
+    const events = (await readMirrorEvents(target)) as Array<{ message?: AgentMessage }>;
+    const userMessage = events
+      .map((event) => event.message)
+      .find((message) => message?.role === "user");
+    expect(isImportedHistoryMessage(userMessage)).toBe(true);
+    expect(userMessage).toMatchObject({ content: "refactor the parser" });
+  });
 
   it("imports only bounded user-visible conversation items with stable identities", async () => {
     const target = await createSqliteMirrorTarget("openclaw-codex-history-", {

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -29,6 +29,7 @@ import {
 } from "./transcript-mirror-attestation.js";
 import {
   attachCodexMirrorIdentity,
+  attachImportedHistoryProvenance,
   attachUpstreamUserText,
   readMirrorIdentity,
   readUpstreamUserText,
@@ -205,7 +206,12 @@ function projectCodexThreadHistory(params: {
               } satisfies AssistantMessage,
               identity,
             )
-          : attachCodexMirrorIdentity({ role, content: text, timestamp } as AgentMessage, identity);
+          : attachImportedHistoryProvenance(
+              attachCodexMirrorIdentity(
+                { role, content: text, timestamp } as AgentMessage,
+                identity,
+              ),
+            );
       const phase =
         item.phase === "commentary" || item.phase === "final_answer" ? item.phase : undefined;
       projected.push({

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -17,6 +17,10 @@ import {
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import {
+  normalizeImportedHistoryText,
+  projectImportedHistoryTextParts,
+} from "./imported-history-text.js";
 import type { CodexThread, JsonValue } from "./protocol.js";
 import {
   attachCodexMirrorAttestation,
@@ -50,8 +54,6 @@ function isMirroredAgentMessage(message: AgentMessage): message is MirroredAgent
 
 const CODEX_HISTORY_IMPORT_MAX_MESSAGES = 200;
 const CODEX_HISTORY_IMPORT_MAX_BYTES = 512 * 1024;
-const CODEX_HISTORY_IMPORT_MAX_MESSAGE_BYTES = 64 * 1024;
-const CODEX_HISTORY_TRUNCATION_SUFFIX = "\n\n[Message truncated during Codex history import.]";
 const CODEX_HISTORY_ASSISTANT_API = "openai-chatgpt-responses" as const;
 const CODEX_HISTORY_ASSISTANT_PROVIDER = "openai";
 const CODEX_HISTORY_ASSISTANT_MODEL = "native-history";
@@ -80,38 +82,6 @@ type ProjectedCodexHistoryMessage = {
   textBytes: number;
 };
 
-function isUtf8ContinuationByte(byte: number | undefined): boolean {
-  return byte !== undefined && (byte & 0xc0) === 0x80;
-}
-
-function truncateUtf8Prefix(value: string, maxBytes: number): string {
-  const bytes = Buffer.from(value);
-  if (bytes.byteLength <= maxBytes) {
-    return value;
-  }
-  let end = Math.max(0, maxBytes);
-  while (end > 0 && isUtf8ContinuationByte(bytes[end])) {
-    end -= 1;
-  }
-  return bytes.subarray(0, end).toString("utf8");
-}
-
-function normalizeImportedHistoryText(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const text = value.trim();
-  if (!text) {
-    return undefined;
-  }
-  if (Buffer.byteLength(text, "utf8") <= CODEX_HISTORY_IMPORT_MAX_MESSAGE_BYTES) {
-    return text;
-  }
-  const suffixBytes = Buffer.byteLength(CODEX_HISTORY_TRUNCATION_SUFFIX, "utf8");
-  const contentLimitBytes = Math.max(0, CODEX_HISTORY_IMPORT_MAX_MESSAGE_BYTES - suffixBytes);
-  return `${truncateUtf8Prefix(text, contentLimitBytes)}${CODEX_HISTORY_TRUNCATION_SUFFIX}`;
-}
-
 function projectCodexUserItemText(item: Record<string, unknown>): string | undefined {
   if (!Array.isArray(item.content)) {
     return undefined;
@@ -123,9 +93,8 @@ function projectCodexUserItemText(item: Record<string, unknown>): string | undef
     }
     const input = value as Record<string, unknown>;
     if (input.type === "text") {
-      const text = normalizeImportedHistoryText(input.text);
-      if (text) {
-        parts.push(text);
+      if (typeof input.text === "string") {
+        parts.push(input.text);
       }
       continue;
     }
@@ -143,7 +112,7 @@ function projectCodexUserItemText(item: Record<string, unknown>): string | undef
       }
     }
   }
-  return normalizeImportedHistoryText(parts.join("\n"));
+  return projectImportedHistoryTextParts(parts);
 }
 
 function selectTurnsThroughBoundary(

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -199,6 +199,32 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     });
   });
 
+  // Documented widening, pinned deliberately: past the retained prefix the local mirror
+  // holds nothing to compare against, so a changed tail on an oversized message is
+  // accepted. main rejected it, but only by rejecting every oversized message.
+  it("accepts an oversized message whose discarded tail differs", async () => {
+    const suffix = "\n\n[Message truncated during Codex history import.]";
+    const retained = "x".repeat(64 * 1024 - Buffer.byteLength(suffix, "utf8"));
+    const importedFromAnEarlierTail = `${retained}${suffix}`;
+
+    const result = await resolveFromTurns({
+      // The tail must exceed the suffix length, or the total stays under the cap and
+      // nothing is truncated.
+      turns: [turn("turn-1", [user(`${retained}${"a tail that differs. ".repeat(20)}`)])],
+      userMessageOrdinal: 0,
+      localPrefixTexts: [importedFromAnEarlierTail],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      boundary: {
+        beforeTurnId: "turn-1",
+        targetTurnId: "turn-1",
+        retainedMarker: { turnId: null, userMessageCount: 0 },
+      },
+    });
+  });
+
   it("still rejects drift that trimming cannot explain", async () => {
     const result = await resolveFromTurns({
       turns: [turn("turn-1", [user("  upstream  ")])],

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -3,6 +3,7 @@ import type { SessionTranscriptMessageEntry } from "openclaw/plugin-sdk/session-
 import { describe, expect, it, vi } from "vitest";
 import type { CodexThreadItem, CodexTurn } from "./protocol.js";
 import { resolveCodexUpstreamForkBoundary } from "./upstream-fork-boundary.js";
+import { attachImportedHistoryProvenance } from "./upstream-prompt-provenance.js";
 
 const transcriptMocks = vi.hoisted(() => ({
   readVisibleEntries: vi.fn(),
@@ -28,18 +29,28 @@ async function resolveFromTurns(params: {
   turns: readonly CodexTurn[];
   userMessageOrdinal: number;
   localPrefixTexts: readonly (string | undefined)[];
+  /** Which prefix rows came from bounded history import. Defaults to all of them, since
+   * most cases here model an adopted thread; pass false to model a live local row. */
+  localPrefixImported?: readonly boolean[];
 }) {
-  const entries: SessionTranscriptMessageEntry[] = params.localPrefixTexts.map((text, index) => ({
-    entryId: `entry-${index}`,
-    parentId: index > 0 ? `entry-${index - 1}` : null,
-    seq: index,
-    role: "user",
-    message: {
-      role: "user",
+  const entries: SessionTranscriptMessageEntry[] = params.localPrefixTexts.map((text, index) => {
+    const message = {
+      role: "user" as const,
       content: text ?? [{ type: "image", data: "", mimeType: "image/png" }],
       timestamp: index,
-    },
-  }));
+    };
+    return {
+      entryId: `entry-${index}`,
+      parentId: index > 0 ? `entry-${index - 1}` : null,
+      seq: index,
+      role: "user",
+      // Mark through the real producer so this cannot drift from what import writes.
+      message:
+        (params.localPrefixImported?.[index] ?? true)
+          ? attachImportedHistoryProvenance(message as never)
+          : message,
+    } as SessionTranscriptMessageEntry;
+  });
   transcriptMocks.readVisibleEntries.mockResolvedValue(entries);
   const result = await resolveCodexUpstreamForkBoundary({
     agentId: "main",
@@ -223,6 +234,17 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
         retainedMarker: { turnId: null, userMessageCount: 0 },
       },
     });
+  });
+
+  it("keeps exact matching for a live row that history import did not write", async () => {
+    const result = await resolveFromTurns({
+      turns: [turn("turn-1", [user("  deploy  ")])],
+      userMessageOrdinal: 0,
+      localPrefixTexts: ["deploy"],
+      localPrefixImported: [false],
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
   });
 
   it("still rejects drift that trimming cannot explain", async () => {

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import type { SessionTranscriptMessageEntry } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { CodexThreadItem, CodexTurn } from "./protocol.js";
@@ -138,6 +139,71 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
       turns: [turn("turn-1", [user("persisted")])],
       userMessageOrdinal: 0,
       localPrefixTexts: ["local mirror"],
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
+  });
+
+  it("forks when history import trimmed the stored copy of the upstream prompt", async () => {
+    const result = await resolveFromTurns({
+      turns: [turn("turn-1", [user(" \n  prompt  \n ")])],
+      userMessageOrdinal: 0,
+      localPrefixTexts: ["prompt"],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      boundary: {
+        beforeTurnId: "turn-1",
+        targetTurnId: "turn-1",
+        retainedMarker: { turnId: null, userMessageCount: 0 },
+      },
+    });
+  });
+
+  it("keeps forking past a trimmed prefix message", async () => {
+    const result = await resolveFromTurns({
+      turns: [turn("turn-1", [user("  one  ")]), turn("turn-2", [user("two")])],
+      userMessageOrdinal: 1,
+      localPrefixTexts: ["one", "two"],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      boundary: {
+        beforeTurnId: "turn-2",
+        targetTurnId: "turn-2",
+        retainedMarker: { turnId: "turn-1", userMessageCount: 1 },
+      },
+    });
+  });
+
+  it("forks when history import truncated an oversized upstream prompt", async () => {
+    const oversized = "x".repeat(64 * 1024 + 10);
+    const suffix = "\n\n[Message truncated during Codex history import.]";
+    const stored = `${oversized.slice(0, 64 * 1024 - Buffer.byteLength(suffix, "utf8"))}${suffix}`;
+
+    const result = await resolveFromTurns({
+      turns: [turn("turn-1", [user(oversized)])],
+      userMessageOrdinal: 0,
+      localPrefixTexts: [stored],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      boundary: {
+        beforeTurnId: "turn-1",
+        targetTurnId: "turn-1",
+        retainedMarker: { turnId: null, userMessageCount: 0 },
+      },
+    });
+  });
+
+  it("still rejects drift that trimming cannot explain", async () => {
+    const result = await resolveFromTurns({
+      turns: [turn("turn-1", [user("  upstream  ")])],
+      userMessageOrdinal: 0,
+      localPrefixTexts: ["local"],
     });
 
     expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -2,6 +2,7 @@ import { readVisibleSessionTranscriptMessageEntries } from "openclaw/plugin-sdk/
 import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
 import { projectImportedHistoryTextParts } from "./imported-history-text.js";
 import type { CodexThreadItem, CodexTurn } from "./protocol.js";
+import { isImportedHistoryMessage } from "./upstream-prompt-provenance.js";
 
 type CodexUpstreamForkBoundaryFailureCode =
   | "steer-message"
@@ -123,6 +124,9 @@ function resolveCodexUpstreamForkBoundaryFromTurns(params: {
   /** Canonical text for every visible local user message through the target ordinal;
    * undefined marks content (images/attachments) whose identity cannot be verified. */
   localPrefixTexts: readonly (string | undefined)[];
+  /** Whether each prefix row was written by bounded history import, which stores a
+   * lossy projection of the upstream text. Only those rows may match the projection. */
+  localPrefixImported: readonly boolean[];
 }): CodexUpstreamForkBoundaryResult {
   let visibleUserMessagesSeen = 0;
   let reviewMode = false;
@@ -171,11 +175,14 @@ function resolveCodexUpstreamForkBoundaryFromTurns(params: {
           "A message before the fork point contains images or attachments that cannot be verified across OpenClaw and Codex. Fork from a text-only span instead.",
         );
       }
-      // Accept the raw upstream text or the projection history import would have stored
-      // (trim + per-message cap). The transcript does not guarantee one stored shape for
-      // user text, and comparing raw alone makes an imported prefix read as divergence,
-      // failing this fork point and every later one.
-      if (localText !== display.text && localText !== display.importProjectedText) {
+      // Rows written by history import store a lossy projection (trim + per-message cap),
+      // so comparing them raw reads as divergence and fails this fork point and every
+      // later one. Every other row is stored as-is and must still match exactly, or a
+      // locally altered row could pass this fail-closed drift check.
+      const matches = params.localPrefixImported[ordinal]
+        ? localText === display.text || localText === display.importProjectedText
+        : localText === display.text;
+      if (!matches) {
         return failure(
           "drift-mismatch",
           "The local conversation no longer matches the Codex thread. Refresh the session and try again.",
@@ -287,16 +294,19 @@ export async function resolveCodexUpstreamForkBoundary(params: {
         "The local message could not be mapped to the Codex thread. Refresh the session and try again.",
       );
     }
-    const localPrefixTexts = visibleUserEntries
-      .slice(0, userMessageOrdinal + 1)
-      .map((entry) =>
-        localMessageText("content" in entry.message ? entry.message.content : undefined),
-      );
+    const prefixEntries = visibleUserEntries.slice(0, userMessageOrdinal + 1);
+    const localPrefixTexts = prefixEntries.map((entry) =>
+      localMessageText("content" in entry.message ? entry.message.content : undefined),
+    );
+    const localPrefixImported = prefixEntries.map((entry) =>
+      isImportedHistoryMessage(entry.message),
+    );
     const turns = await listCodexUpstreamTurns(params.control, params.threadId);
     const resolved = resolveCodexUpstreamForkBoundaryFromTurns({
       turns,
       userMessageOrdinal,
       localPrefixTexts,
+      localPrefixImported,
     });
     return resolved.ok
       ? { ...resolved, editorText: localPrefixTexts[userMessageOrdinal] }

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -171,10 +171,10 @@ function resolveCodexUpstreamForkBoundaryFromTurns(params: {
           "A message before the fork point contains images or attachments that cannot be verified across OpenClaw and Codex. Fork from a text-only span instead.",
         );
       }
-      // The transcript stores the same upstream text two ways: history import normalizes
-      // it (trim + per-message cap), while a message authored in this session is stored
-      // verbatim. Accept either form, or an imported prefix reads as divergence and
-      // fails this fork point and every later one.
+      // Accept the raw upstream text or the projection history import would have stored
+      // (trim + per-message cap). The transcript does not guarantee one stored shape for
+      // user text, and comparing raw alone makes an imported prefix read as divergence,
+      // failing this fork point and every later one.
       if (localText !== display.text && localText !== display.importProjectedText) {
         return failure(
           "drift-mismatch",

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -1,5 +1,6 @@
 import { readVisibleSessionTranscriptMessageEntries } from "openclaw/plugin-sdk/session-transcript-runtime";
 import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
+import { projectImportedHistoryTextParts } from "./imported-history-text.js";
 import type { CodexThreadItem, CodexTurn } from "./protocol.js";
 
 type CodexUpstreamForkBoundaryFailureCode =
@@ -44,12 +45,14 @@ function asInputs(item: CodexThreadItem): UserInput[] {
 
 function userMessageDisplay(item: CodexThreadItem): {
   text: string;
+  importProjectedText: string | undefined;
   visible: boolean;
   hasUnverifiableInput: boolean;
 } {
   let text = "";
   let hasTextElement = false;
   let hasImage = false;
+  const textParts: string[] = [];
   // Any non-text input (images, skills, mentions, future variants) has no canonical
   // cross-system identity; its presence makes the message unverifiable for drift checks.
   let hasUnverifiableInput = false;
@@ -57,6 +60,7 @@ function userMessageDisplay(item: CodexThreadItem): {
     if (input.type === "text") {
       if (typeof input.text === "string") {
         text += input.text;
+        textParts.push(input.text);
       }
       hasTextElement ||= Array.isArray(input.textElements) && input.textElements.length > 0;
     } else {
@@ -66,6 +70,7 @@ function userMessageDisplay(item: CodexThreadItem): {
   }
   return {
     text,
+    importProjectedText: projectImportedHistoryTextParts(textParts),
     visible: Boolean(text.trim()) || hasTextElement || hasImage,
     hasUnverifiableInput,
   };
@@ -166,7 +171,11 @@ function resolveCodexUpstreamForkBoundaryFromTurns(params: {
           "A message before the fork point contains images or attachments that cannot be verified across OpenClaw and Codex. Fork from a text-only span instead.",
         );
       }
-      if (display.text !== localText) {
+      // The transcript stores the same upstream text two ways: history import normalizes
+      // it (trim + per-message cap), while a message authored in this session is stored
+      // verbatim. Accept either form, or an imported prefix reads as divergence and
+      // fails this fork point and every later one.
+      if (localText !== display.text && localText !== display.importProjectedText) {
         return failure(
           "drift-mismatch",
           "The local conversation no longer matches the Codex thread. Refresh the session and try again.",

--- a/extensions/codex/src/app-server/upstream-prompt-provenance.ts
+++ b/extensions/codex/src/app-server/upstream-prompt-provenance.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 
 const UPSTREAM_USER_TEXT_META_KEY = "upstreamUserText" as const;
 const MIRROR_IDENTITY_META_KEY = "mirrorIdentity" as const;
+const IMPORTED_HISTORY_META_KEY = "importedHistory" as const;
 
 export function attachCodexMirrorIdentity<T extends AgentMessage>(message: T, identity: string): T {
   const record = message as unknown as Record<string, unknown>;
@@ -47,4 +48,29 @@ export function readUpstreamUserText(message: AgentMessage | undefined): string 
   }
   const text = (meta as Record<string, unknown>)[UPSTREAM_USER_TEXT_META_KEY];
   return typeof text === "string" && text ? text : undefined;
+}
+
+/** Mark a row written by bounded history import, whose text went through the import
+ * projection (trim + per-message cap). Drift checks need this to know the stored text is
+ * lossy; without it they must compare exactly, because a live row is not projected. */
+export function attachImportedHistoryProvenance<T extends AgentMessage>(message: T): T {
+  const record = message as unknown as Record<string, unknown>;
+  const existing = record["__openclaw"];
+  const baseMeta =
+    existing && typeof existing === "object" && !Array.isArray(existing)
+      ? (existing as Record<string, unknown>)
+      : {};
+  return {
+    ...record,
+    __openclaw: { ...baseMeta, [IMPORTED_HISTORY_META_KEY]: true },
+  } as unknown as T;
+}
+
+export function isImportedHistoryMessage(message: AgentMessage | undefined): boolean {
+  const record = message as unknown as { __openclaw?: unknown } | undefined;
+  const meta = record?.["__openclaw"];
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
+    return false;
+  }
+  return (meta as Record<string, unknown>)[IMPORTED_HISTORY_META_KEY] === true;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who continue (adopt) an existing Codex thread in OpenClaw
cannot fork or rewind it: the fork fails with *"The local conversation no longer
matches the Codex thread. Refresh the session and try again."* even though nothing
diverged.

The trigger is ordinary — a prompt that carried a leading or trailing newline or
space, which is what a pasted prompt usually looks like. Because fork resolution
requires **every** message before the cut point to match, one affected early message
blocks that fork point and every later one in the thread. The suggested remedy does
not help: refreshing re-imports the thread through the same path and reproduces the
same mismatch.

## Why This Change Was Made

Adopted threads are mirrored into the local transcript through a normalizing
projection: `normalizeImportedHistoryText()` trims each message and caps it at 64 KiB
with a truncation marker, so a single upstream message cannot consume the import
budget. Fork resolution then compared that stored copy against the **raw** upstream
text, so the mirror's own normalization read as user divergence.

The two behaviors were introduced separately — the import projection in `f94a7dc183`
(#104045) and the fork comparison later in `ea54060223` (#111149) — so this is an
unaccounted-for interaction rather than an intentional strictness choice. No existing
test pins raw-versus-mirrored byte equality.

The fix compares through the same projection the mirror applied. The projection now
lives in one module (`imported-history-text.ts`) imported by both the write path and the
fork comparison, so a change to trimming or the cap lands on both at once. That removes the
duplicated implementation; it does not by itself guarantee the two call sites keep asking
for the same thing, which is what the regression cases below pin.

The projected form is accepted **only for rows that history import wrote**. Import now
marks those rows (`attachImportedHistoryProvenance`), and the boundary check reads that
mark: a marked row may match either the raw upstream text or the import projection, and
every other row must still match exactly. That keeps the fail-closed drift guard intact
for live rows — a locally altered row cannot pass by happening to equal the projection —
while repairing the one case where the stored text is knowingly lossy.

Provenance is recorded rather than inferred on purpose. There is no reliable way to tell
an imported row from a live one after the fact: `upstreamUserText` is attached only when
an upstream text was available, and `before_message_write` plugin hooks can rewrite
persisted user content (`transcript-mirror.test.ts` pins exactly that), so neither the
stored shape nor the absence of other metadata proves how a row was written.

**Mark lifecycle, stated exactly, because the ordering matters.** The mark is attached in
`projectBoundedCodexThreadHistory` while the row is being built, and
`runAgentHarnessBeforeMessageWriteHook` runs *after* it, inside `mirror()` — import does not
pass `skipBeforeMessageWriteHooks`. So a plugin hook **can** rewrite the text of a row that
already carries the mark. A hook rewrite passes only if it lands on the raw upstream text or
on the projection of it, and is rejected as `drift-mismatch` otherwise — but that is an
equivalence class, not a single value, and the next section states exactly how wide it is. The
`a live (unmarked) row must still match exactly` case pins the other half: an unmarked row
gets no widening at all.

Images, skills, and mentions remain unverifiable and fail closed exactly as before.

Preserving canonical upstream text at import was considered and rejected: it would
break the 64 KiB / 512 KiB import budgets that projection exists to enforce, and would
require migrating already-stored transcripts.

**Why the oversized case is in this PR and not a follow-up.** The projection is lossy in two
ways — it trims, and it truncates at 64 KiB — and both losses produce the identical false
`drift-mismatch` through the identical comparison. Fixing only the trim would leave the fork
broken for any thread containing one long pasted message, with the same symptom and the same
root cause, so the split would be along the input's shape rather than along the defect. The
widening it requires is bounded and pinned by its own case: for a marked row whose upstream
text exceeds the cap, the retained prefix must match, and only the discarded tail may differ
— a tail that has to be longer than the truncation suffix to exist at all. Shorter
differences are still caught by exact comparison. It is commented at the call site as a
deliberate widening so it reads as a decision, not an oversight.

### Known tradeoff: what this stops catching

Accepting the projected form widens what counts as "no drift", but **only on rows marked
as history-imported**:

- **A marked row equal to the projection of the upstream text is no longer drift.**
  This is directional: local `"deploy"` against upstream `" deploy "` resolves, because
  the projection of the upstream text is `"deploy"`. The reverse — local `" deploy "`
  against upstream `"deploy"` — still fails. Unmarked rows fail in both directions.
- **On a marked row, differences past the retained prefix are no longer drift.** For an
  oversized message the stored value is `P + truncationSuffix`, where `P` is the upstream
  text truncated to 64 KiB *minus* the suffix
  (`contentLimitBytes = CODEX_HISTORY_IMPORT_MAX_MESSAGE_BYTES - suffixBytes`). It matches
  upstream `P + <any tail>`, because the projection of that upstream text is again
  `P + truncationSuffix`. If the suffix constant itself changed, previously stored rows
  would stop matching and fail closed.

**This is a real weakening of the drift guard, so state it as one.** For a marked row the
comparison is no longer byte equality with the upstream text; it is equality with the
*projection* of the upstream text. That accepts an equivalence class: any upstream edit that
projects to the same value — a whitespace-only change, or any change confined to the discarded
tail of an oversized message — is now invisible.

The justification is that this class is exactly the information the stored copy no longer
contains. The mirror wrote `trim(raw)` capped at 64 KiB; the bytes distinguishing those
upstream variants were discarded at import and are not recoverable from the local transcript.
`main` cannot detect it either — it has no more information than this branch does, because the
bytes are gone from the store in both. What `main` does instead is report drift for every row
the projection *changed* (anything trimmed, anything truncated), whether or not the upstream
text actually moved. Rows the projection left untouched still pass on `main`, so the fix is
narrower than "the fork is always broken": it is broken exactly for threads containing at least
one normalized message.

So the choice is not "exact detection versus weakened detection"; it is "a guard that reports
drift on unchanged normalized rows" versus "a guard that is exact up to what was stored".
Detecting the discarded bytes would require persisting a digest of the raw upstream text at
import time — a storage change this PR deliberately does not make, and the natural follow-up if
maintainers want that guarantee.

**Maintainer decision this PR is asking for, made explicit.** The trim widening is
uncontroversial: the stored copy is trimmed, so comparing it against untrimmed text is simply
wrong. The truncation widening is the one that needs a call, so here is the threat model rather
than an assurance.

- *What an attacker or a mistake could hide:* an edit to an adopted thread confined entirely to
  the discarded tail of a single message — the message must still exceed the cap afterwards, and
  the retained prefix must be byte-identical. An edit that pulls the message back under the cap,
  or that shifts the truncation boundary, changes the projection and is still reported.
- *What it cannot hide:* any change within the first ~64 KiB of any message, any change to any
  message under the cap, any change on an unmarked (live) row, and any added or removed message
  — the ordinal walk is untouched.
- *What `main` does with the same input:* reports drift, but reports it for every imported row
  regardless, so the signal carries no information and the fork is unusable.
- *Cost of the strict alternative:* persisting a digest of the raw upstream text per imported
  message. That is a storage/format change with a migration, which is why it is not here.

If the answer is "not acceptable", the clean split is to keep the trim fix and drop the
oversized case — the trim half stands alone, and the truncation half can follow separately with
the digest design instead of the widening. They are together here because both losses come from
the same projection and produce the identical false `drift-mismatch`, but the split is
mechanical.

Both widenings are pinned by tests, alongside a test asserting that an unmarked row
still requires an exact match.

## User Impact

**Scope of the repair, stated before the benefit:** this fixes forking for sessions adopted
**after** this ships. It does not repair sessions already adopted — their rows carry no import
mark, so they keep failing exactly as they do today until the thread is adopted again. There is
no backfill in this PR, and adding one is a storage-touching change I did not want to bundle
with the comparison fix.

With that bound: for a newly adopted thread, forking or rewinding now works when prompts
carried surrounding whitespace or exceeded the 64 KiB import cap — the two cases where the
mirror's own normalization was being read as user divergence.

The repair applies to rows carrying the new import mark, so
sessions adopted **before** this ships keep failing until the thread is adopted again. The
mark is written by `createImportedCodexSession`, which runs when a thread is adopted into a
new session — there is no in-place backfill of an existing session's rows, and this PR does
not add one. Marking is the price of keeping the drift guard exact for live rows; inferring
import-ness from existing rows is not reliable (see above).

No config or protocol changes, **and no database migration**: the mark rides in the existing
`__openclaw` message metadata object, which is already persisted per message. Rows written
before this change carry no `importedHistory` key, and `isImportedHistoryMessage` returns
`false` for a missing key — the pre-change comparison behavior. That direction (newer reader,
older row) is the one this PR exercises and the one the regression cases cover. The reverse
direction, an older build reading a row that carries the new key, rests on `__openclaw` being
an open metadata object that existing readers index by key rather than validate as a closed
shape; I have not added a test pinning that, so treat it as a design property of the existing
container rather than a verified claim.

## Evidence

**Behavior addressed:** forking an adopted Codex thread fails with `drift-mismatch`
when the imported prompt carried surrounding whitespace, blocking that fork point and
every later one in the thread.

**Real environment tested:** a real history import through
`importCodexThreadHistoryToTranscript()` writing to a real SQLite transcript, then the
real `resolveCodexUpstreamForkBoundary()` reading it back. Only the Codex service is
stubbed (a control returning the same upstream thread); the import, the persistence,
the visible-entry read, and the comparison are all real code paths.

**Exact steps or command run after this patch:** import a thread whose single user
message is `" \n  refactor the parser  \n "`, then resolve the fork boundary for the
stored entry. Captured at head `1f2a722eec4` (base `cad499d7ca0`). The "before" capture below was
taken in the same worktree by restoring only the files this PR changes to
`upstream/main` `cad499d7ca0`, so it is current-main behavior under the same harness
and the same input rather than an older pinned base.

**Observed result after fix:** the fork resolves, returning the boundary and
`editorText`, despite the stored text differing from the upstream text.

**What was not tested:** a live Codex app-server round trip (the upstream contract is
cited from source instead, below), and the behavior of threads adopted before this change
ships, whose rows carry no import mark.

**Evidence after fix:** the captured runs below — the "before" block is the
unpatched baseline for contrast, the "after" block is the result of this patch.

Before, with the changed files restored to `upstream/main` `cad499d7ca0`:

```
imported messages: 2
upstream raw text : " \n  refactor the parser  \n "
stored in SQLite  : "refactor the parser"
identical?        : false

fork resolution:
{
  "ok": false,
  "code": "drift-mismatch",
  "message": "The local conversation no longer matches the Codex thread. Refresh the session and try again."
}
```

After, same harness and same input, at head `1f2a722eec4`:

```
imported messages: 2
upstream raw text : " \n  refactor the parser  \n "
stored in SQLite  : "refactor the parser"
identical?        : false

fork resolution:
{
  "ok": true,
  "boundary": {
    "beforeTurnId": "turn-1",
    "targetTurnId": "turn-1",
    "retainedMarker": { "turnId": null, "userMessageCount": 0 }
  },
  "editorText": "refactor the parser"
}
```

Focused tests — `node scripts/run-vitest.mjs extensions/codex/src/app-server/upstream-fork-boundary`
→ 16 passed. Six cases were added beside the existing ones: a trimmed prompt, a trimmed
prefix message followed by a later fork point, an oversized truncated prompt, the widened
acceptance described above, **a live (unmarked) row that must still match exactly**, and a
negative case asserting that drift trimming cannot explain still fails.

The mark's persistence is covered end to end in the repo, not only by the harness above:
`persists import provenance so drift checks can tell imported rows from live ones`
imports through the real `importCodexThreadHistoryToTranscript()` into a real SQLite
store and reads the stored event back, asserting both the mark and the trimmed text.
`transcript-mirror` suites are green (35 passed), including the pre-existing mixed
text+image case pinning `"Review this image\n[Image attachment]"`, which is what shows
the projection refactor is behavior-neutral for placeholder parts.

Teeth checks — reverting the fork-boundary comparison fails the trimmed/oversized cases
with exactly `drift-mismatch` while the negative cases still pass; removing
`attachImportedHistoryProvenance` from the import path fails the persistence test above.
Both were run rather than assumed.

The widened acceptance is pinned by its own test rather than only described:
`accepts an oversized message whose discarded tail differs` asserts that an oversized
upstream message whose retained prefix matches the stored copy resolves even when the
discarded tail differs. It is commented at the call site as a deliberate widening so it
reads as a decision, not an oversight. Writing it also sharpened the boundary — the tail
has to be longer than the truncation suffix for the message to exceed the cap at all,
so shorter differences are still caught by exact comparison.

Upstream Codex contract, read directly from the sibling `openai/codex` checkout at
`78df1237d1`, confirming the whitespace round trip is real rather than assumed:

- `codex-rs/app-server-protocol/src/protocol/thread_history.rs:1410-1419` —
  `build_user_inputs()` uses `payload.message.trim()` only as an emptiness test and
  stores `text: payload.message.clone()`, so the untrimmed text is what Codex returns.
- `codex-rs/app-server-protocol/src/protocol/v2/item.rs:826-830` —
  `From<CoreTurnItem> for ThreadItem` passes `user.content` through verbatim.

Scope note: `UserMessageItem.content` is a `Vec<UserInput>`
(`codex-rs/protocol/src/items.rs:64`), so a multi-part text message would also mismatch
today — import joins parts with `"\n"` while the fork side concatenates without a
separator. The shared projection handles that case too, but I found no non-test
producer of multiple text parts, so it is not claimed as a user-reachable trigger.

Static checks on the changed files: `./node_modules/.bin/oxfmt --check` and
`node scripts/run-oxlint.mjs` both exit 0, and the extensions typecheck lane
(`tsgo -p test/tsconfig/tsconfig.extensions.test.json`) is clean. The `check:changed` gate
delegates typecheck/lint fan-out to a remote runner that was unavailable in this environment
(`selected binary failed basic --version/--help sanity checks`), so those lanes were run
directly instead of through the gate. Stating it because it changes who ran the check, not
whether it ran.

## Proof harness

The capture above is not reproducible from the test commands alone, so the harness is inlined
here. It is **not part of this PR's diff**. Save it at the repo root and run it against a
checkout of this branch:

```
./node_modules/.bin/tsx cf1-full-real-proof.mts
```

For the "before" arm, put every behavior-bearing file this PR touches back to the merge
base. Two are modifications and two are additions, so they need different treatment:

```
BASE=$(git merge-base HEAD upstream/main)
# modified upstream: restore
git checkout "$BASE" -- extensions/codex/src/app-server/transcript-mirror.ts \
                        extensions/codex/src/app-server/upstream-fork-boundary.ts
# added by this PR: move aside (they do not exist at $BASE)
mv extensions/codex/src/app-server/imported-history-text.ts /tmp/
mv extensions/codex/src/app-server/upstream-prompt-provenance.ts /tmp/
```

With the two restored files back at base neither added module is referenced, so moving them
aside is what proves that rather than assuming it — if anything still imported them the run
would fail to resolve instead of quietly producing a "before" that is really an "after".
Restore with `git checkout HEAD -- <the two paths>` and move the two files back.

This is a **merge-base baseline**, not a checkout of `main`: only the files this PR touches
are reverted, inside the same worktree, so the surrounding tree stays at the PR head.

<details>
<summary><code>cf1-full-real-proof.mts</code> — real import → real SQLite → real fork resolver</summary>

```ts
// CF-1 full-real proof: real history import -> real SQLite transcript -> real fork resolver.
// Only the Codex service is stubbed (a control returning the same raw thread).
import { mkdtemp } from "node:fs/promises";
import { tmpdir } from "node:os";
import path from "node:path";
import { realpath } from "node:fs/promises";
import { importCodexThreadHistoryToTranscript } from "./extensions/codex/src/app-server/transcript-mirror.js";
import { resolveCodexUpstreamForkBoundary } from "./extensions/codex/src/app-server/upstream-fork-boundary.js";
import { readVisibleSessionTranscriptMessageEntries } from "./src/plugin-sdk/session-transcript-runtime.js";

const RAW_PROMPT = " \n  refactor the parser  \n ";

async function main() {
  const base = await realpath(await mkdtemp(path.join(tmpdir(), "cf1-proof-")));
  process.env.OPENCLAW_STATE_DIR = path.join(base, "openclaw-state");
  const storePath = path.join(base, "state");
  const sessionId = "session-cf1";
  const sessionKey = "agent:main:upstream";

  const thread = {
    id: "thread-cf1",
    turns: [
      {
        id: "turn-1",
        status: "completed",
        startedAt: 1,
        completedAt: 2,
        items: [
          {
            id: "u1",
            type: "userMessage",
            content: [{ type: "text", text: RAW_PROMPT, textElements: [] }],
          },
          { id: "a1", type: "agentMessage", text: "done", phase: "final_answer" },
        ],
      },
    ],
  } as never;

  const imported = await importCodexThreadHistoryToTranscript({
    thread,
    throughTurnId: "turn-1",
    storePath,
    sessionId,
    sessionKey,
    agentId: "main",
  });
  console.log(`imported messages: ${imported.importedMessages}`);

  const entries = await readVisibleSessionTranscriptMessageEntries({
    agentId: "main",
    sessionId,
    sessionKey,
    storePath,
  });
  const userEntry = entries.find((e) => e.role === "user");
  const storedRaw = (userEntry?.message as { content?: unknown })?.content;
  console.log(`upstream raw text : ${JSON.stringify(RAW_PROMPT)}`);
  console.log(`stored in SQLite  : ${JSON.stringify(storedRaw)}`);
  console.log(`identical?        : ${JSON.stringify(RAW_PROMPT) === JSON.stringify(storedRaw)}`);

  const result = await resolveCodexUpstreamForkBoundary({
    agentId: "main",
    sessionId,
    sessionKey,
    storePath,
    entryId: userEntry!.entryId,
    threadId: "thread-cf1",
    control: {
      readThread: async () => thread,
      listTurnPage: async () => ({ data: (thread as never as { turns: unknown[] }).turns }),
    } as never,
  });

  console.log("");
  console.log("fork resolution:");
  console.log(JSON.stringify(result, null, 2));
}

main().catch((error) => {
  console.error(error);
  process.exit(1);
});
```

</details>

