### PR TITLE
fix(ci): reduce Testbox hydration and teardown delays

### DIFF
--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -205,4 +205,4 @@ jobs:
           # run-testbox has no post hook. Close only Testbox client sockets so
           # Blacksmith's runner teardown does not wait for its 290-second grace.
           timeout --signal=KILL 5s sudo ss -K state established \
-            "( dport = :${runner_ssh_port} )" || true
+            "( sport = :${runner_ssh_port} )" || true

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Run Testbox
         uses: useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d
-        if: github.event_name == 'workflow_dispatch' && !cancelled()
+        if: github.event_name == 'workflow_dispatch' && always()
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -195,14 +195,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          runner_ssh_port="$(cat /tmp/.testbox/runner_ssh_port 2>/dev/null || true)"
-          if [[ ! "$runner_ssh_port" =~ ^[0-9]+$ ]] ||
-            (( runner_ssh_port < 1 || runner_ssh_port > 65535 )); then
-            echo "No valid Testbox SSH port found; skipping session cleanup"
+          # Testbox state stores Blacksmith's external forwarded port. Resolve
+          # sshd's VM-local listener because that is the sport visible to ss.
+          runner_ssh_local_port="$(sudo sshd -T 2>/dev/null | awk '$1 == "port" { print $2; exit }')"
+          if [[ ! "$runner_ssh_local_port" =~ ^[0-9]+$ ]] ||
+            (( runner_ssh_local_port < 1 || runner_ssh_local_port > 65535 )); then
+            echo "No valid local SSH listener port found; skipping session cleanup"
             exit 0
           fi
 
           # run-testbox has no post hook. Close only Testbox client sockets so
           # Blacksmith's runner teardown does not wait for its 290-second grace.
           timeout --signal=KILL 5s sudo ss -K state established \
-            "( sport = :${runner_ssh_port} )" || true
+            "( sport = :${runner_ssh_local_port} )" || true

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -185,6 +185,24 @@ jobs:
 
       - name: Run Testbox
         uses: useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d
-        if: github.event_name == 'workflow_dispatch' && always()
+        if: github.event_name == 'workflow_dispatch' && !cancelled()
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+      - name: Close Testbox SSH sessions
+        if: github.event_name == 'workflow_dispatch' && always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          runner_ssh_port="$(cat /tmp/.testbox/runner_ssh_port 2>/dev/null || true)"
+          if [[ ! "$runner_ssh_port" =~ ^[0-9]+$ ]] ||
+            (( runner_ssh_port < 1 || runner_ssh_port > 65535 )); then
+            echo "No valid Testbox SSH port found; skipping session cleanup"
+            exit 0
+          fi
+
+          # run-testbox has no post hook. Close only Testbox client sockets so
+          # Blacksmith's runner teardown does not wait for its 290-second grace.
+          timeout --signal=KILL 5s sudo ss -K state established \
+            "( sport = :${runner_ssh_port} )" || true

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -24,7 +24,6 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  PNPM_CONFIG_STORE_DIR: "/tmp/openclaw-pnpm-store"
   PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
 
 jobs:
@@ -99,6 +98,10 @@ jobs:
         with:
           install-bun: "false"
           install-trufflehog: "true"
+          # Real Testbox hydration reuses the protected dependency snapshot.
+          # Pull-request validation runs on GitHub-hosted runners instead.
+          sticky-disk: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
+          use-actions-cache: ${{ github.event_name == 'workflow_dispatch' && 'false' || 'true' }}
       - name: Prepare Testbox shell
         shell: bash
         run: |

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -205,4 +205,4 @@ jobs:
           # run-testbox has no post hook. Close only Testbox client sockets so
           # Blacksmith's runner teardown does not wait for its 290-second grace.
           timeout --signal=KILL 5s sudo ss -K state established \
-            "( sport = :${runner_ssh_port} )" || true
+            "( dport = :${runner_ssh_port} )" || true

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1027,7 +1027,7 @@ describe("ci workflow guards", () => {
       with: { testbox_id: "${{ inputs.testbox_id }}" },
     });
     expect(runStep).toMatchObject({
-      if: "github.event_name == 'workflow_dispatch' && !cancelled()",
+      if: "github.event_name == 'workflow_dispatch' && always()",
     });
   });
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1027,7 +1027,7 @@ describe("ci workflow guards", () => {
       with: { testbox_id: "${{ inputs.testbox_id }}" },
     });
     expect(runStep).toMatchObject({
-      if: "github.event_name == 'workflow_dispatch' && always()",
+      if: "github.event_name == 'workflow_dispatch' && !cancelled()",
     });
   });
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2415,7 +2415,7 @@ describe("package artifact reuse", () => {
     expect(runTestboxStep.if).toBe("github.event_name == 'workflow_dispatch' && !cancelled()");
     expect(closeTestboxSshStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
     expect(closeTestboxSshStep.run).toContain(
-      'ss -K state established \\\n  "( sport = :${runner_ssh_port} )"',
+      'ss -K state established \\\n  "( dport = :${runner_ssh_port} )"',
     );
     expect(checkTestboxJob.steps.indexOf(closeTestboxSshStep)).toBe(
       checkTestboxJob.steps.indexOf(runTestboxStep) + 1,

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2417,7 +2417,7 @@ describe("package artifact reuse", () => {
     expect(runTestboxStep.if).toBe("github.event_name == 'workflow_dispatch' && !cancelled()");
     expect(closeTestboxSshStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
     expect(closeTestboxSshStep.run).toContain(
-      'ss -K state established \\\n  "( dport = :${runner_ssh_port} )"',
+      'ss -K state established \\\n  "( sport = :${runner_ssh_port} )"',
     );
     expect(checkTestboxSteps.indexOf(closeTestboxSshStep)).toBe(
       checkTestboxSteps.indexOf(runTestboxStep) + 1,

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2414,7 +2414,7 @@ describe("package artifact reuse", () => {
       "${{ fromJSON(inputs.timeout_minutes || '120') }}",
     );
     expect(runTestboxStep.uses).toContain("useblacksmith/run-testbox@");
-    expect(runTestboxStep.if).toBe("github.event_name == 'workflow_dispatch' && !cancelled()");
+    expect(runTestboxStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
     expect(closeTestboxSshStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
     expect(closeTestboxSshStep.run).toContain(
       'ss -K state established \\\n  "( sport = :${runner_ssh_port} )"',

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2385,6 +2385,7 @@ describe("package artifact reuse", () => {
     const checkTestboxJob = workflowJob(CI_CHECK_TESTBOX_WORKFLOW, "check");
     const setupNodeStep = workflowStep(checkTestboxJob, "Setup Node environment");
     const runTestboxStep = workflowStep(checkTestboxJob, "Run Testbox");
+    const closeTestboxSshStep = workflowStep(checkTestboxJob, "Close Testbox SSH sessions");
     const runArmTestboxStep = workflowStep(
       workflowJob(CI_CHECK_ARM_TESTBOX_WORKFLOW, "check-arm"),
       "Run Testbox",
@@ -2411,7 +2412,14 @@ describe("package artifact reuse", () => {
       "${{ fromJSON(inputs.timeout_minutes || '120') }}",
     );
     expect(runTestboxStep.uses).toContain("useblacksmith/run-testbox@");
-    expect(runTestboxStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
+    expect(runTestboxStep.if).toBe("github.event_name == 'workflow_dispatch' && !cancelled()");
+    expect(closeTestboxSshStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
+    expect(closeTestboxSshStep.run).toContain(
+      'ss -K state established \\\n  "( sport = :${runner_ssh_port} )"',
+    );
+    expect(checkTestboxJob.steps.indexOf(closeTestboxSshStep)).toBe(
+      checkTestboxJob.steps.indexOf(runTestboxStep) + 1,
+    );
     expect(runArmTestboxStep.if).toBe("always()");
     expect(runBuildArtifactsTestboxStep.if).toBe("always()");
     expect(runWindowsTestboxStep.if).toBe("always()");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2386,6 +2386,8 @@ describe("package artifact reuse", () => {
     const setupNodeStep = workflowStep(checkTestboxJob, "Setup Node environment");
     const runTestboxStep = workflowStep(checkTestboxJob, "Run Testbox");
     const closeTestboxSshStep = workflowStep(checkTestboxJob, "Close Testbox SSH sessions");
+    const setupNodeWith = setupNodeStep.with ?? {};
+    const checkTestboxSteps = checkTestboxJob.steps ?? [];
     const runArmTestboxStep = workflowStep(
       workflowJob(CI_CHECK_ARM_TESTBOX_WORKFLOW, "check-arm"),
       "Run Testbox",
@@ -2402,10 +2404,10 @@ describe("package artifact reuse", () => {
     expect(workflow).not.toContain('PNPM_CONFIG_STORE_DIR: "/tmp/openclaw-pnpm-store"');
     expect(workflow).not.toContain("PNPM_CONFIG_MODULES_DIR");
     expect(workflow).not.toContain("PNPM_CONFIG_VIRTUAL_STORE_DIR");
-    expect(setupNodeStep.with["sticky-disk"]).toBe(
+    expect(setupNodeWith["sticky-disk"]).toBe(
       "${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}",
     );
-    expect(setupNodeStep.with["use-actions-cache"]).toBe(
+    expect(setupNodeWith["use-actions-cache"]).toBe(
       "${{ github.event_name == 'workflow_dispatch' && 'false' || 'true' }}",
     );
     expect(checkTestboxJob["timeout-minutes"]).toBe(
@@ -2417,8 +2419,8 @@ describe("package artifact reuse", () => {
     expect(closeTestboxSshStep.run).toContain(
       'ss -K state established \\\n  "( dport = :${runner_ssh_port} )"',
     );
-    expect(checkTestboxJob.steps.indexOf(closeTestboxSshStep)).toBe(
-      checkTestboxJob.steps.indexOf(runTestboxStep) + 1,
+    expect(checkTestboxSteps.indexOf(closeTestboxSshStep)).toBe(
+      checkTestboxSteps.indexOf(runTestboxStep) + 1,
     );
     expect(runArmTestboxStep.if).toBe("always()");
     expect(runBuildArtifactsTestboxStep.if).toBe("always()");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2417,7 +2417,10 @@ describe("package artifact reuse", () => {
     expect(runTestboxStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
     expect(closeTestboxSshStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
     expect(closeTestboxSshStep.run).toContain(
-      'ss -K state established \\\n  "( sport = :${runner_ssh_port} )"',
+      `sudo sshd -T 2>/dev/null | awk '$1 == "port" { print $2; exit }'`,
+    );
+    expect(closeTestboxSshStep.run).toContain(
+      'ss -K state established \\\n  "( sport = :${runner_ssh_local_port} )"',
     );
     expect(checkTestboxSteps.indexOf(closeTestboxSshStep)).toBe(
       checkTestboxSteps.indexOf(runTestboxStep) + 1,

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2383,6 +2383,7 @@ describe("package artifact reuse", () => {
   it("finalizes dispatched Testbox delegation even when setup or the remote command fails", () => {
     const workflow = readFileSync(CI_CHECK_TESTBOX_WORKFLOW, "utf8");
     const checkTestboxJob = workflowJob(CI_CHECK_TESTBOX_WORKFLOW, "check");
+    const setupNodeStep = workflowStep(checkTestboxJob, "Setup Node environment");
     const runTestboxStep = workflowStep(checkTestboxJob, "Run Testbox");
     const runArmTestboxStep = workflowStep(
       workflowJob(CI_CHECK_ARM_TESTBOX_WORKFLOW, "check-arm"),
@@ -2397,9 +2398,15 @@ describe("package artifact reuse", () => {
       "Run Testbox",
     );
 
-    expect(workflow).toContain('PNPM_CONFIG_STORE_DIR: "/tmp/openclaw-pnpm-store"');
+    expect(workflow).not.toContain('PNPM_CONFIG_STORE_DIR: "/tmp/openclaw-pnpm-store"');
     expect(workflow).not.toContain("PNPM_CONFIG_MODULES_DIR");
     expect(workflow).not.toContain("PNPM_CONFIG_VIRTUAL_STORE_DIR");
+    expect(setupNodeStep.with["sticky-disk"]).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}",
+    );
+    expect(setupNodeStep.with["use-actions-cache"]).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && 'false' || 'true' }}",
+    );
     expect(checkTestboxJob["timeout-minutes"]).toBe(
       "${{ fromJSON(inputs.timeout_minutes || '120') }}",
     );


### PR DESCRIPTION
Related: #116783

## What Problem This Solves

Fixes an issue where Blacksmith Testbox validation repeatedly rebuilt dependency state and retained SSH sessions after jobs stopped, making the fast path slower and leaving dead lease artifacts behind.

## Why This Change Was Made

Reuses the sticky dependency snapshot only for delegated workflow-dispatch Testboxes, preserves normal Actions cache behavior for pull requests, skips remote execution after cancellation, and closes task-owned SSH server and client sessions during teardown.

## User Impact

Maintainers should see faster repeated Testbox checks and fewer retained dead sessions without changing contributor pull-request cache behavior or broadening cleanup beyond the current Testbox.

## Evidence

- Blacksmith Actions run `30629315071`: 95 focused lifecycle tests passed.
- Workflow syntax/actionlint and `git diff --check origin/main...HEAD` passed.
- TruffleHog clean in autoreview.
- Final branch autoreview clean with no accepted/actionable findings.
