### PR TITLE
fix(qa): lease credentials for Telegram startup proof

### DIFF
--- a/extensions/qa-lab/src/runtime-api.ts
+++ b/extensions/qa-lab/src/runtime-api.ts
@@ -6,6 +6,10 @@ export { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
 export type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 export { defaultQaRuntimeModelForMode } from "./model-selection.runtime.js";
 export {
+  acquireQaCredentialLease,
+  startQaCredentialLeaseHeartbeat,
+} from "./live-transports/shared/credential-lease.runtime.js";
+export {
   buildQaTarget,
   createQaBusThread,
   deleteQaBusMessage,

--- a/extensions/qa-lab/src/runtime-api.ts
+++ b/extensions/qa-lab/src/runtime-api.ts
@@ -6,10 +6,6 @@ export { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
 export type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 export { defaultQaRuntimeModelForMode } from "./model-selection.runtime.js";
 export {
-  acquireQaCredentialLease,
-  startQaCredentialLeaseHeartbeat,
-} from "./live-transports/shared/credential-lease.runtime.js";
-export {
   buildQaTarget,
   createQaBusThread,
   deleteQaBusMessage,

--- a/src/plugin-sdk/qa-runtime.ts
+++ b/src/plugin-sdk/qa-runtime.ts
@@ -31,7 +31,6 @@ type QaRuntimeSurface = {
     kind: string;
     parsePayload: (payload: unknown) => TPayload;
     resolveEnvPayload: () => TPayload;
-    role?: string;
     source?: string;
   }) => Promise<{
     heartbeat(): Promise<void>;

--- a/src/plugin-sdk/qa-runtime.ts
+++ b/src/plugin-sdk/qa-runtime.ts
@@ -26,6 +26,21 @@ export type {
 } from "./qa-runner-runtime.js";
 
 type QaRuntimeSurface = {
+  acquireQaCredentialLease: <TPayload>(options: {
+    env?: NodeJS.ProcessEnv;
+    kind: string;
+    parsePayload: (payload: unknown) => TPayload;
+    resolveEnvPayload: () => TPayload;
+    role?: string;
+    source?: string;
+  }) => Promise<{
+    heartbeat(): Promise<void>;
+    heartbeatIntervalMs: number;
+    kind: string;
+    payload: TPayload;
+    release(): Promise<void>;
+    source: "convex" | "env";
+  }>;
   defaultQaRuntimeModelForMode: (
     mode: string,
     options?: {
@@ -34,6 +49,15 @@ type QaRuntimeSurface = {
     },
   ) => string;
   startQaLiveLaneGateway: (...args: unknown[]) => Promise<unknown>;
+  startQaCredentialLeaseHeartbeat: (lease: {
+    heartbeat(): Promise<void>;
+    heartbeatIntervalMs: number;
+    kind: string;
+    source: "convex" | "env";
+  }) => {
+    stop(): Promise<void>;
+    throwIfFailed(): void;
+  };
 };
 
 function isMissingQaRuntimeError(error: unknown) {

--- a/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.test.ts
@@ -6,6 +6,29 @@ import { runTelegramBotTokenRuntime, testing } from "./telegram-bot-token-runtim
 
 const tempDirs: string[] = [];
 
+function createCredentialDependencies(token: string, source: "convex" | "env" = "env") {
+  const release = vi.fn(async () => undefined);
+  const stop = vi.fn(async () => undefined);
+  return {
+    dependencies: {
+      acquireCredential: async () => ({
+        heartbeat: async () => undefined,
+        heartbeatIntervalMs: source === "convex" ? 30_000 : 0,
+        kind: "telegram",
+        payload: { sutToken: token },
+        release,
+        source,
+      }),
+      startCredentialHeartbeat: () => ({
+        stop,
+        throwIfFailed: () => undefined,
+      }),
+    },
+    release,
+    stop,
+  };
+}
+
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
 });
@@ -26,7 +49,7 @@ describe("telegram bot token runtime evidence", () => {
     tempDirs.push(artifactBase);
     const evidence = await runTelegramBotTokenRuntime(
       { artifactBase, repoRoot: process.cwd(), startupTimeoutMs: 100 },
-      { TELEGRAM_BOT_TOKEN: "generic-token" },
+      { OPENCLAW_QA_CREDENTIAL_SOURCE: "env", TELEGRAM_BOT_TOKEN: "generic-token" },
     );
 
     expect(evidence.entries[0]?.result.status).toBe("blocked");
@@ -44,12 +67,14 @@ describe("telegram bot token runtime evidence", () => {
     const leasedToken = "123456:leased-secret";
     const cleanup = vi.fn(async () => undefined);
     const startGateway = vi.fn(async () => undefined);
+    const credential = createCredentialDependencies(leasedToken);
     let instanceOptions: Record<string, unknown> | undefined;
 
     const evidence = await runTelegramBotTokenRuntime(
       { artifactBase, repoRoot: process.cwd(), startupTimeoutMs: 100 },
       { OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN: leasedToken },
       {
+        ...credential.dependencies,
         createInstance: async (options) => {
           instanceOptions = options as unknown as Record<string, unknown>;
           return {
@@ -66,6 +91,8 @@ describe("telegram bot token runtime evidence", () => {
     expect(evidence.entries[0]?.result.status).toBe("pass");
     expect(startGateway).toHaveBeenCalledOnce();
     expect(cleanup).toHaveBeenCalledOnce();
+    expect(credential.stop).toHaveBeenCalledOnce();
+    expect(credential.release).toHaveBeenCalledOnce();
     expect(instanceOptions).toMatchObject({
       config: {
         channels: {
@@ -108,11 +135,13 @@ describe("telegram bot token runtime evidence", () => {
     const artifactBase = await fs.mkdtemp(path.join(os.tmpdir(), "telegram-startup-failure-"));
     tempDirs.push(artifactBase);
     const leasedToken = "123456:leased-secret";
+    const credential = createCredentialDependencies(leasedToken);
 
     const evidence = await runTelegramBotTokenRuntime(
       { artifactBase, repoRoot: process.cwd(), startupTimeoutMs: 100 },
       { OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN: leasedToken },
       {
+        ...credential.dependencies,
         createInstance: async () => ({
           cleanup: async () => undefined,
           logs: () => "",
@@ -132,5 +161,31 @@ describe("telegram bot token runtime evidence", () => {
       "utf8",
     );
     expect(log).not.toContain(leasedToken);
+    expect(credential.release).toHaveBeenCalledOnce();
+  });
+
+  it("uses the configured shared lease when no dedicated token env is present", async () => {
+    const artifactBase = await fs.mkdtemp(path.join(os.tmpdir(), "telegram-bot-lease-"));
+    tempDirs.push(artifactBase);
+    const leasedToken = "123456:convex-secret";
+    const credential = createCredentialDependencies(leasedToken, "convex");
+    const createInstance = vi.fn(async () => ({
+      cleanup: async () => undefined,
+      startGateway: async () => undefined,
+      logs: () =>
+        `[qa-live] starting provider (@qa_test_bot) token=${leasedToken}\n` +
+        "[telegram][diag] polling cycle started\n",
+    }));
+
+    const evidence = await runTelegramBotTokenRuntime(
+      { artifactBase, repoRoot: process.cwd(), startupTimeoutMs: 100 },
+      { OPENCLAW_QA_CREDENTIAL_SOURCE: "convex" },
+      { ...credential.dependencies, createInstance },
+    );
+
+    expect(evidence.entries[0]?.result.status).toBe("pass");
+    expect(createInstance).toHaveBeenCalledOnce();
+    expect(credential.stop).toHaveBeenCalledOnce();
+    expect(credential.release).toHaveBeenCalledOnce();
   });
 });

--- a/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.ts
+++ b/test/e2e/qa-lab/runtime/telegram-bot-token-runtime.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
+import { loadQaRuntimeModule } from "../../../../src/plugin-sdk/qa-runtime.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -30,13 +31,45 @@ type TelegramProductStartupInstance = Pick<
 >;
 
 type TelegramRuntimeDependencies = {
+  acquireCredential: (env: NodeJS.ProcessEnv) => Promise<TelegramCredentialLease>;
   createInstance: (
     options: Parameters<typeof createOpenClawTestInstance>[0],
   ) => Promise<TelegramProductStartupInstance>;
+  startCredentialHeartbeat: (lease: TelegramCredentialLease) => TelegramCredentialLeaseHeartbeat;
+};
+
+type TelegramCredentialLease = {
+  heartbeat(): Promise<void>;
+  heartbeatIntervalMs: number;
+  kind: string;
+  payload: { sutToken: string };
+  release(): Promise<void>;
+  source: "convex" | "env";
+};
+
+type TelegramCredentialLeaseHeartbeat = {
+  stop(): Promise<void>;
+  throwIfFailed(): void;
 };
 
 const defaultDependencies: TelegramRuntimeDependencies = {
+  acquireCredential: async (env) => {
+    const directCredential = resolveLeasedToken(env);
+    return await loadQaRuntimeModule().acquireQaCredentialLease({
+      env,
+      kind: "telegram",
+      source: directCredential ? "env" : env.OPENCLAW_QA_CREDENTIAL_SOURCE,
+      resolveEnvPayload: () => {
+        if (!directCredential) {
+          throw new Error(`none of ${TOKEN_ENV_KEYS.join(", ")} is set`);
+        }
+        return { sutToken: directCredential.token };
+      },
+      parsePayload: parseTelegramCredentialPayload,
+    });
+  },
   createInstance: createOpenClawTestInstance,
+  startCredentialHeartbeat: (lease) => loadQaRuntimeModule().startQaCredentialLeaseHeartbeat(lease),
 };
 
 const wait = (durationMs: number) =>
@@ -116,6 +149,17 @@ function resolveLeasedToken(env: NodeJS.ProcessEnv = process.env) {
   return undefined;
 }
 
+function parseTelegramCredentialPayload(payload: unknown) {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Telegram credential payload must be an object");
+  }
+  const sutToken = (payload as { sutToken?: unknown }).sutToken;
+  if (typeof sutToken !== "string" || !sutToken.trim()) {
+    throw new Error("Telegram credential payload requires sutToken");
+  }
+  return { sutToken: sutToken.trim() };
+}
+
 function createWriter(options: TelegramRuntimeOptions) {
   return createQaScriptEvidenceWriter({
     artifactBase: options.artifactBase,
@@ -146,8 +190,9 @@ export async function runTelegramBotTokenRuntime(
   await fs.mkdir(options.artifactBase, { recursive: true });
   const writer = createWriter(options);
   const startedAt = Date.now();
-  const credential = resolveLeasedToken(env);
-  if (!credential) {
+  const directCredential = resolveLeasedToken(env);
+  const configuredSource = env.OPENCLAW_QA_CREDENTIAL_SOURCE?.trim().toLowerCase();
+  if (!directCredential && configuredSource !== "convex") {
     writer.appendLog(
       `telegram-startup-getme: blocked; none of ${TOKEN_ENV_KEYS.join(", ")} is set\n`,
     );
@@ -158,9 +203,15 @@ export async function runTelegramBotTokenRuntime(
     });
   }
 
-  writer.appendLog(`telegram-startup-getme: using leased credential from ${credential.key}\n`);
+  let credentialLease: TelegramCredentialLease | undefined;
+  let credentialHeartbeat: TelegramCredentialLeaseHeartbeat | undefined;
   let instance: TelegramProductStartupInstance | undefined;
   try {
+    credentialLease = await dependencies.acquireCredential(env);
+    credentialHeartbeat = dependencies.startCredentialHeartbeat(credentialLease);
+    const credentialLabel = directCredential?.key ?? `${credentialLease.source} credential lease`;
+    const token = credentialLease.payload.sutToken;
+    writer.appendLog(`telegram-startup-getme: using credential from ${credentialLabel}\n`);
     instance = await dependencies.createInstance({
       name: "qa-telegram-startup-getme",
       config: {
@@ -174,7 +225,7 @@ export async function runTelegramBotTokenRuntime(
             accounts: {
               [LIVE_ACCOUNT_ID]: {
                 enabled: true,
-                botToken: credential.token,
+                botToken: token,
               },
             },
           },
@@ -189,21 +240,27 @@ export async function runTelegramBotTokenRuntime(
     });
     await instance.startGateway();
     await waitForProductStartup(instance, options.startupTimeoutMs);
-    writer.appendLog(sanitizeRuntimeLogs(instance.logs(), credential.token));
+    writer.appendLog(sanitizeRuntimeLogs(instance.logs(), token));
     writer.appendLog(
       "telegram-startup-getme: product startAccount resolved getMe bot identity before polling\n",
     );
     await instance.cleanup();
     instance = undefined;
+    await credentialHeartbeat.stop();
+    credentialHeartbeat.throwIfFailed();
+    credentialHeartbeat = undefined;
+    await credentialLease.release();
+    credentialLease = undefined;
     return await writer.write({
-      details: `Telegram product-startup getMe completed with ${credential.key}`,
+      details: `Telegram product-startup getMe completed with ${credentialLabel}`,
       durationMs: Math.max(1, Date.now() - startedAt),
       status: "pass",
     });
   } catch (error) {
-    const details = sanitizeRuntimeLogs(formatErrorMessage(error), credential.token);
+    const token = credentialLease?.payload.sutToken ?? directCredential?.token ?? "";
+    const details = sanitizeRuntimeLogs(formatErrorMessage(error), token);
     if (instance) {
-      writer.appendLog(sanitizeRuntimeLogs(instance.logs(), credential.token));
+      writer.appendLog(sanitizeRuntimeLogs(instance.logs(), token));
     }
     writer.appendLog(`telegram-startup-getme: ${details}\n`);
     return await writer.write({
@@ -213,11 +270,17 @@ export async function runTelegramBotTokenRuntime(
     });
   } finally {
     await instance?.cleanup().catch(() => undefined);
+    try {
+      await credentialHeartbeat?.stop();
+    } finally {
+      await credentialLease?.release();
+    }
   }
 }
 
 export const testing = {
   parseOptions,
+  parseTelegramCredentialPayload,
   resolveLeasedToken,
   sanitizeRuntimeLogs,
   waitForProductStartup,
@@ -226,8 +289,15 @@ export const testing = {
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   runTelegramBotTokenRuntime(parseOptions(process.argv.slice(2)))
     .then((evidence) => {
-      const status = evidence.entries[0]?.result.status;
+      const result = evidence.entries[0]?.result;
+      if (!result) {
+        throw new Error("Telegram startup evidence did not contain a result");
+      }
+      const status = result.status;
       process.stdout.write(`telegram-startup-getme: ${status}\n`);
+      if (status === "fail") {
+        process.stderr.write(`telegram-startup-getme: ${result.failure?.reason ?? "failed"}\n`);
+      }
       process.exitCode = status === "fail" ? 1 : 0;
     })
     .catch((error: unknown) => {


### PR DESCRIPTION
## Summary

- acquire Telegram startup credentials through QA Lab shared leasing when the release profile selects Convex
- heartbeat and release the lease around the isolated Gateway lifecycle
- preserve dedicated environment-token behavior and blocked evidence when no usable source exists
- print sanitized failure details for script diagnostics
- keep the lease API narrow: no unused role field or duplicate inner runtime re-export

## Problem

The maturity workflow configures the existing shared credential broker, but the standalone Telegram startup producer only read dedicated token environment variables. It therefore reported blocked evidence before exercising product startup.

This adds no config option or credential system. It routes that producer through QA Lab's existing lease owner and lifecycle.

## Validation

- Blacksmith Testbox `tbx_01kyxvp94tm8ha01h5twzwdj6f`: Telegram runtime tests 6/6 and plugin SDK runtime tests 14/14 passed: https://github.com/openclaw/openclaw/actions/runs/30685335676
- The private-QA build passed previously; a live one-shot could not acquire because the standalone Testbox environment lacks `OPENCLAW_QA_CONVEX_SITE_URL`: https://github.com/openclaw/openclaw/actions/runs/30631865601
- `git diff --check`
- `oxfmt --check` on changed trim files
- Autoreview clean with no accepted/actionable findings

Related: https://github.com/openclaw/openclaw/actions/runs/30616797665

## AI assistance

AI-assisted implementation and review.
