### PR TITLE
fix(qa): isolate Slack MPIM dedupe from streaming

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.config.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.config.ts
@@ -286,21 +286,23 @@ export function buildSlackQaConfig(
               ? { dm: { enabled: true, groupEnabled: true } }
               : {}),
             replyToMode: params.overrides?.replyToMode ?? "off",
-            ...(progressOverrides
-              ? {
-                  streaming: {
-                    mode: "progress" as const,
-                    progress: {
-                      label: false,
-                      maxLines: 4,
-                      toolProgress: progressOverrides.toolProgress,
-                      ...(progressOverrides.commentary === undefined
-                        ? {}
-                        : { commentary: progressOverrides.commentary }),
+            ...(params.overrides?.streamingMode
+              ? { streaming: { mode: params.overrides.streamingMode } }
+              : progressOverrides
+                ? {
+                    streaming: {
+                      mode: "progress" as const,
+                      progress: {
+                        label: false,
+                        maxLines: 4,
+                        toolProgress: progressOverrides.toolProgress,
+                        ...(progressOverrides.commentary === undefined
+                          ? {}
+                          : { commentary: progressOverrides.commentary }),
+                      },
                     },
-                  },
-                }
-              : {}),
+                  }
+                : {}),
             ...(execApprovalsConfig ? { execApprovals: execApprovalsConfig } : {}),
             channels: {
               [params.channelId]: {

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
@@ -195,6 +195,7 @@ export type SlackQaConfigOverrides = {
     verboseDefault?: "off" | "on" | "full";
   };
   replyToMode?: "all" | "off";
+  streamingMode?: "off";
   users?: string[];
 };
 

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -605,6 +605,10 @@ describe("Slack live QA runtime helpers", () => {
     expect(
       buildScenarioConfig("slack-progress-commentary-false").agents?.defaults?.verboseDefault,
     ).toBe("off");
+    expect(
+      buildScenarioConfig("slack-mpim-app-mention-dedupe").channels?.slack?.accounts?.sut
+        ?.streaming,
+    ).toEqual({ mode: "off" });
     const omitted = progressConfig("slack-progress-commentary-omitted");
     expect(omitted).toMatchObject({ toolProgress: true });
     expect(Object.hasOwn(omitted ?? {}, "commentary")).toBe(false);

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
@@ -48,7 +48,9 @@ export const slackQaMentionGatingScenario: SlackQaScenarioImplementation = {
 };
 
 export const slackQaMpimAppMentionDedupeScenario: SlackQaScenarioImplementation = {
-  configOverrides: { groupDmEnabled: true, replyToMode: "all" },
+  // Keep the event-dedupe assertion independent from Slack's separate
+  // streaming preview/final message lifecycle.
+  configOverrides: { groupDmEnabled: true, replyToMode: "all", streamingMode: "off" },
   buildRun: (sutUserId) => {
     const suffix = randomUUID().slice(0, 8).toUpperCase();
     const seedMarker = `SLACK_QA_MPIM_SEED_${suffix}`;


### PR DESCRIPTION
## Summary

- disable Slack streaming only for the MPIM message/app_mention dedupe scenario
- keep the dedupe assertion focused on one inbound post producing one final reply
- make the explicit streaming override take precedence over progress configuration

## Problem

Slack defaults to streaming, whose preview/final lifecycle can produce multiple observed message identities containing the final marker. The MPIM scenario interpreted those transport messages as duplicate inbound dispatches even though the Gateway logged one inbound turn and one delivered reply.

## Validation

- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts` (43 passed)
- autoreview clean

Related: https://github.com/openclaw/openclaw/actions/runs/30616797665

## AI assistance

AI-assisted implementation and review.