### PR TITLE
fix: preserve structured tool finality for cron

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -13972,6 +13972,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let error: String?
     public let errorreason: AnyCodable?
     public let summary: String?
+    public let assistantcompletion: [String: AnyCodable]?
     public let diagnostics: [String: AnyCodable]?
     public let delivered: Bool?
     public let deliverystatus: AnyCodable?
@@ -13997,6 +13998,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         error: String? = nil,
         errorreason: AnyCodable? = nil,
         summary: String? = nil,
+        assistantcompletion: [String: AnyCodable]? = nil,
         diagnostics: [String: AnyCodable]? = nil,
         delivered: Bool? = nil,
         deliverystatus: AnyCodable? = nil,
@@ -14021,6 +14023,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.error = error
         self.errorreason = errorreason
         self.summary = summary
+        self.assistantcompletion = assistantcompletion
         self.diagnostics = diagnostics
         self.delivered = delivered
         self.deliverystatus = deliverystatus
@@ -14047,6 +14050,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         case error
         case errorreason = "errorReason"
         case summary
+        case assistantcompletion = "assistantCompletion"
         case diagnostics
         case delivered
         case deliverystatus = "deliveryStatus"

--- a/packages/ai/src/transports/deepseek-text-filter.ts
+++ b/packages/ai/src/transports/deepseek-text-filter.ts
@@ -4,13 +4,13 @@
  * across streamed chunks.
  */
 const DSML_KINDS = ["tool_use_error", "tool_calls", "tool_call", "function_calls"] as const;
-const DSML_BARS = ["|", "｜"] as const;
+const DSML_DELIMITERS = ["|", "||", "｜", "｜｜"] as const;
 
-const DSML_OPEN_TOKENS = DSML_BARS.flatMap((bar) =>
-  DSML_KINDS.map((kind) => `<${bar}DSML${bar}${kind}>`),
+const DSML_OPEN_TOKENS = DSML_DELIMITERS.flatMap((delimiter) =>
+  DSML_KINDS.map((kind) => `<${delimiter}DSML${delimiter}${kind}>`),
 );
-const DSML_CLOSE_TOKENS = DSML_BARS.flatMap((bar) =>
-  DSML_KINDS.map((kind) => `</${bar}DSML${bar}${kind}>`),
+const DSML_CLOSE_TOKENS = DSML_DELIMITERS.flatMap((delimiter) =>
+  DSML_KINDS.map((kind) => `</${delimiter}DSML${delimiter}${kind}>`),
 );
 const MAX_OPEN_TOKEN_LEN = Math.max(...DSML_OPEN_TOKENS.map((token) => token.length));
 const MAX_CLOSE_TOKEN_LEN = Math.max(...DSML_CLOSE_TOKENS.map((token) => token.length));

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -866,13 +866,13 @@ type RecoveredDeepSeekDsmlToolCall = {
 
 type DeepSeekDsmlRecoveredPart = { kind: "text"; text: string } | RecoveredDeepSeekDsmlToolCall;
 
-const DEEPSEEK_DSML_BARS = ["|", "｜"] as const;
+const DEEPSEEK_DSML_DELIMITERS = ["|", "||", "｜", "｜｜"] as const;
 const DEEPSEEK_DSML_TOOL_KINDS = ["tool_calls", "tool_call", "function_calls"] as const;
-const DEEPSEEK_DSML_TOOL_OPEN_TOKENS = DEEPSEEK_DSML_BARS.flatMap((bar) =>
-  DEEPSEEK_DSML_TOOL_KINDS.map((kind) => `<${bar}DSML${bar}${kind}>`),
+const DEEPSEEK_DSML_TOOL_OPEN_TOKENS = DEEPSEEK_DSML_DELIMITERS.flatMap((delimiter) =>
+  DEEPSEEK_DSML_TOOL_KINDS.map((kind) => `<${delimiter}DSML${delimiter}${kind}>`),
 );
-const DEEPSEEK_DSML_TOOL_CLOSE_TOKENS = DEEPSEEK_DSML_BARS.flatMap((bar) =>
-  DEEPSEEK_DSML_TOOL_KINDS.map((kind) => `</${bar}DSML${bar}${kind}>`),
+const DEEPSEEK_DSML_TOOL_CLOSE_TOKENS = DEEPSEEK_DSML_DELIMITERS.flatMap((delimiter) =>
+  DEEPSEEK_DSML_TOOL_KINDS.map((kind) => `</${delimiter}DSML${delimiter}${kind}>`),
 );
 const DEEPSEEK_DSML_TOOL_MAX_OPEN_TOKEN_LEN = Math.max(
   ...DEEPSEEK_DSML_TOOL_OPEN_TOKENS.map((token) => token.length),
@@ -941,7 +941,7 @@ function createDeepSeekDsmlToolCallRecoverer() {
 
 function parseDeepSeekDsmlToolCallBlock(body: string): RecoveredDeepSeekDsmlToolCall[] {
   const toolCalls: RecoveredDeepSeekDsmlToolCall[] = [];
-  const invokeOpenRegex = /<[|｜]DSML[|｜]invoke\b([^>]*)>/g;
+  const invokeOpenRegex = /<(?:\|\||\||｜｜|｜)DSML(?:\|\||\||｜｜|｜)invoke\b([^>]*)>/g;
   let openMatch: RegExpExecArray | null;
   while ((openMatch = invokeOpenRegex.exec(body)) !== null) {
     const invokeName = parseXmlAttribute(openMatch[1] ?? "", "name");
@@ -951,7 +951,9 @@ function parseDeepSeekDsmlToolCallBlock(body: string): RecoveredDeepSeekDsmlTool
     const invokeBodyStart = openMatch.index + openMatch[0].length;
     const invokeClose = findEarliestStringToken(body.slice(invokeBodyStart), [
       "</|DSML|invoke>",
+      "</||DSML||invoke>",
       "</｜DSML｜invoke>",
+      "</｜｜DSML｜｜invoke>",
     ]);
     if (!invokeClose) {
       continue;
@@ -974,7 +976,8 @@ function parseDeepSeekDsmlToolCallBlock(body: string): RecoveredDeepSeekDsmlTool
 
 function parseDeepSeekDsmlInvokeArguments(body: string): Record<string, unknown> | null {
   const args: Record<string, unknown> = {};
-  const parameterRegex = /<[|｜]DSML[|｜]parameter\b([^>]*)>([\s\S]*?)<\/[|｜]DSML[|｜]parameter>/g;
+  const parameterRegex =
+    /<(?:\|\||\||｜｜|｜)DSML(?:\|\||\||｜｜|｜)parameter\b([^>]*)>([\s\S]*?)<\/(?:\|\||\||｜｜|｜)DSML(?:\|\||\||｜｜|｜)parameter>/g;
   let parameterMatch: RegExpExecArray | null;
   while ((parameterMatch = parameterRegex.exec(body)) !== null) {
     const name = parseXmlAttribute(parameterMatch[1] ?? "", "name");

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -703,6 +703,17 @@ export const CronRunLogEntrySchema = closedObject({
   error: Type.Optional(Type.String()),
   errorReason: Type.Optional(CronFailoverReasonSchema),
   summary: Type.Optional(Type.String()),
+  assistantCompletion: Type.Optional(
+    closedObject({
+      contractVersion: Type.Literal("openclaw.cron-assistant-completion.v1"),
+      toolCallDetected: Type.Boolean(),
+      toolResultAccepted: Type.Boolean(),
+      finalAssistantVisible: Type.Boolean(),
+      finalUserVisibleResult: Type.Boolean(),
+      toolCallCount: Type.Integer({ minimum: 0 }),
+      toolFailureCount: Type.Integer({ minimum: 0 }),
+    }),
+  ),
   diagnostics: Type.Optional(CronRunDiagnosticsSchema),
   delivered: Type.Optional(Type.Boolean()),
   deliveryStatus: Type.Optional(CronDeliveryStatusSchema),

--- a/src/agents/deepseek-text-filter.test.ts
+++ b/src/agents/deepseek-text-filter.test.ts
@@ -46,6 +46,16 @@ describe("createDeepSeekTextFilter", () => {
       ],
       expected: "abc",
     },
+    {
+      name: "double full-width bars",
+      chunks: ["before <｜｜DSML｜｜tool_calls>body</｜｜DSML｜｜tool_calls> after"],
+      expected: "before  after",
+    },
+    {
+      name: "split double ASCII bars",
+      chunks: ["before <||DSM", "L||tool_calls>body</||DSML||tool_calls> after"],
+      expected: "before  after",
+    },
   ])("drops DSML: $name", ({ chunks, expected }) => {
     const text = filteredText(chunks);
     expect(text).toBe(expected);

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -280,6 +280,39 @@ describe("openai transport stream", () => {
     expect(JSON.stringify(events)).not.toContain("DSML");
   });
 
+  it("recovers double-bar DeepSeek DSML tool calls emitted as text", async () => {
+    const model = createDeepSeekCompletionsModel();
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        makeCompletionsChunk(
+          {
+            content:
+              '<｜｜DSML｜｜tool_calls><｜｜DSML｜｜invoke name="session_status"><｜｜DSML｜｜parameter name="sessionKey">current</｜｜DSML｜｜parameter></｜｜DSML｜｜invoke></｜｜DSML｜｜tool_calls>',
+          },
+          "stop",
+        ),
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    expect(output.stopReason).toBe("toolUse");
+    expect(output.content).toEqual([
+      {
+        type: "toolCall",
+        id: expect.stringMatching(/^call_[0-9a-f]{24}$/),
+        name: "session_status",
+        arguments: { sessionKey: "current" },
+        partialArgs: '{"sessionKey":"current"}',
+      },
+    ]);
+    expect(JSON.stringify(events)).not.toContain("DSML");
+  });
+
   it.each([
     { finishReason: "length", stopReason: "length" },
     { finishReason: "content_filter", stopReason: "error" },

--- a/src/cron/isolated-agent/assistant-completion.ts
+++ b/src/cron/isolated-agent/assistant-completion.ts
@@ -1,0 +1,64 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
+import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
+import type { CronAssistantCompletion } from "../types.js";
+
+const NON_FINAL_ASSISTANT_STOP_REASONS = new Set([
+  "aborted",
+  "error",
+  "length",
+  "restart",
+  "timeout",
+  "tool_calls",
+  "tooluse",
+]);
+
+/** Builds the content-free public proof consumed by cron observers. */
+export function buildCronAssistantCompletion(
+  result: Pick<EmbeddedAgentRunResult, "meta" | "payloads">,
+): CronAssistantCompletion {
+  const calls = result.meta.toolSummary?.calls;
+  const failures = result.meta.toolSummary?.failures;
+  const observedToolCallCount =
+    Number.isSafeInteger(calls) && (calls ?? -1) >= 0 ? (calls ?? 0) : 0;
+  const toolFailureCount =
+    Number.isSafeInteger(failures) && (failures ?? -1) >= 0 ? (failures ?? 0) : 0;
+  const pendingToolCallCount = Array.isArray(result.meta.pendingToolCalls)
+    ? result.meta.pendingToolCalls.length
+    : 0;
+  const toolCallCount = Math.max(observedToolCallCount, pendingToolCallCount);
+  const stopReason = normalizeOptionalString(
+    result.meta.stopReason ?? result.meta.completion?.stopReason,
+  )?.toLowerCase();
+  const finalAssistantText = normalizeOptionalString(result.meta.finalAssistantVisibleText);
+  const finalAssistantVisible =
+    finalAssistantText !== undefined && !isSilentReplyPayloadText(finalAssistantText);
+  const hasStructuredError = (result.payloads ?? []).some((payload) => payload.isError === true);
+  const stoppedBeforeFinal = stopReason ? NON_FINAL_ASSISTANT_STOP_REASONS.has(stopReason) : false;
+  const toolCallDetected = toolCallCount > 0 || pendingToolCallCount > 0;
+  const toolResultAccepted =
+    toolCallDetected &&
+    toolCallCount > 0 &&
+    toolFailureCount === 0 &&
+    pendingToolCallCount === 0 &&
+    !hasStructuredError &&
+    !stoppedBeforeFinal &&
+    finalAssistantVisible;
+  const finalUserVisibleResult =
+    finalAssistantVisible &&
+    !hasStructuredError &&
+    !stoppedBeforeFinal &&
+    pendingToolCallCount === 0 &&
+    toolFailureCount === 0 &&
+    (!toolCallDetected || toolResultAccepted);
+
+  return {
+    contractVersion: "openclaw.cron-assistant-completion.v1",
+    toolCallDetected,
+    toolResultAccepted,
+    finalAssistantVisible,
+    finalUserVisibleResult,
+    toolCallCount,
+    toolFailureCount,
+  };
+}

--- a/src/cron/isolated-agent/run-finalize.assistant-completion.test.ts
+++ b/src/cron/isolated-agent/run-finalize.assistant-completion.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildCronAssistantCompletion } from "./run-finalize.js";
+
+function buildResult(params: {
+  text?: string;
+  stopReason?: string;
+  calls?: number;
+  failures?: number;
+  pending?: number;
+  isError?: boolean;
+}) {
+  return {
+    payloads: params.text === undefined ? [] : [{ text: params.text, isError: params.isError }],
+    meta: {
+      durationMs: 1,
+      finalAssistantVisibleText: params.text,
+      stopReason: params.stopReason,
+      toolSummary: {
+        calls: params.calls ?? 0,
+        tools: params.calls ? ["exec"] : [],
+        failures: params.failures ?? 0,
+      },
+      pendingToolCalls: Array.from({ length: params.pending ?? 0 }, (_, index) => ({
+        id: `call-${index}`,
+        name: "exec",
+        arguments: "sensitive fixture argument",
+      })),
+    },
+  };
+}
+
+describe("buildCronAssistantCompletion", () => {
+  it("admits ordinary final assistant text without tool activity", () => {
+    expect(
+      buildCronAssistantCompletion(buildResult({ text: "Public summary", stopReason: "stop" })),
+    ).toEqual({
+      contractVersion: "openclaw.cron-assistant-completion.v1",
+      toolCallDetected: false,
+      toolResultAccepted: false,
+      finalAssistantVisible: true,
+      finalUserVisibleResult: true,
+      toolCallCount: 0,
+      toolFailureCount: 0,
+    });
+  });
+
+  it("proves a completed tool result followed by final assistant text", () => {
+    const completion = buildCronAssistantCompletion(
+      buildResult({ text: "Final summary", stopReason: "stop", calls: 1 }),
+    );
+    expect(completion).toMatchObject({
+      toolCallDetected: true,
+      toolResultAccepted: true,
+      finalAssistantVisible: true,
+      finalUserVisibleResult: true,
+      toolCallCount: 1,
+      toolFailureCount: 0,
+    });
+  });
+
+  it("rejects a failed tool even when a misleading non-empty text payload exists", () => {
+    const completion = buildCronAssistantCompletion(
+      buildResult({ text: "Misleading completion", stopReason: "stop", calls: 1, failures: 1 }),
+    );
+    expect(completion).toMatchObject({
+      toolCallDetected: true,
+      toolResultAccepted: false,
+      finalAssistantVisible: true,
+      finalUserVisibleResult: false,
+      toolFailureCount: 1,
+    });
+  });
+
+  it("rejects a pending tool call without a final continuation and emits no tool details", () => {
+    const completion = buildCronAssistantCompletion(
+      buildResult({ text: "intermediate", stopReason: "tool_calls", calls: 1, pending: 1 }),
+    );
+    expect(completion.finalUserVisibleResult).toBe(false);
+    expect(completion.toolResultAccepted).toBe(false);
+    expect(JSON.stringify(completion)).not.toContain("sensitive fixture argument");
+    expect(JSON.stringify(completion)).not.toContain("call-0");
+  });
+
+  it("admits a final assistant turn after earlier completed tool activity", () => {
+    const completion = buildCronAssistantCompletion(
+      buildResult({ text: "Final user-visible answer", stopReason: "stop", calls: 2 }),
+    );
+    expect(completion.finalUserVisibleResult).toBe(true);
+    expect(completion.toolResultAccepted).toBe(true);
+    expect(completion.toolCallCount).toBe(2);
+  });
+
+  it("rejects structured error payloads without inspecting warning text", () => {
+    const completion = buildCronAssistantCompletion(
+      buildResult({ text: "ordinary-looking text", stopReason: "stop", calls: 1, isError: true }),
+    );
+    expect(completion.finalUserVisibleResult).toBe(false);
+    expect(completion.toolResultAccepted).toBe(false);
+  });
+});

--- a/src/cron/isolated-agent/run-finalize.assistant-completion.test.ts
+++ b/src/cron/isolated-agent/run-finalize.assistant-completion.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCronAssistantCompletion } from "./run-finalize.js";
+import { buildCronAssistantCompletion } from "./assistant-completion.js";
 
 function buildResult(params: {
   text?: string;

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import { hasCommittedMessagingToolDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
 import { deriveContextPromptTokens } from "../../agents/usage.js";
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
 import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
@@ -17,7 +18,7 @@ import {
   createCronRunDiagnosticsFromError,
   mergeCronRunDiagnostics,
 } from "../run-diagnostics.js";
-import type { CronDeliveryTrace, CronRunTelemetry } from "../types.js";
+import type { CronAssistantCompletion, CronDeliveryTrace, CronRunTelemetry } from "../types.js";
 import { resolveCronChannelOutputPolicy } from "./channel-output-policy.js";
 import {
   isHeartbeatOnlyResponse,
@@ -57,6 +58,66 @@ async function loadUsageFormatRuntime() {
   return await import("../../utils/usage-format.js");
 }
 
+const NON_FINAL_ASSISTANT_STOP_REASONS = new Set([
+  "aborted",
+  "error",
+  "length",
+  "restart",
+  "timeout",
+  "tool_calls",
+  "tooluse",
+]);
+
+/** Builds the content-free public proof consumed by cron observers. */
+export function buildCronAssistantCompletion(
+  result: Pick<EmbeddedAgentRunResult, "meta" | "payloads">,
+): CronAssistantCompletion {
+  const calls = result.meta.toolSummary?.calls;
+  const failures = result.meta.toolSummary?.failures;
+  const observedToolCallCount =
+    Number.isSafeInteger(calls) && (calls ?? -1) >= 0 ? (calls ?? 0) : 0;
+  const toolFailureCount =
+    Number.isSafeInteger(failures) && (failures ?? -1) >= 0 ? (failures ?? 0) : 0;
+  const pendingToolCallCount = Array.isArray(result.meta.pendingToolCalls)
+    ? result.meta.pendingToolCalls.length
+    : 0;
+  const toolCallCount = Math.max(observedToolCallCount, pendingToolCallCount);
+  const stopReason = normalizeOptionalString(
+    result.meta.stopReason ?? result.meta.completion?.stopReason,
+  )?.toLowerCase();
+  const finalAssistantText = normalizeOptionalString(result.meta.finalAssistantVisibleText);
+  const finalAssistantVisible =
+    finalAssistantText !== undefined && !isSilentReplyPayloadText(finalAssistantText);
+  const hasStructuredError = (result.payloads ?? []).some((payload) => payload.isError === true);
+  const stoppedBeforeFinal = stopReason ? NON_FINAL_ASSISTANT_STOP_REASONS.has(stopReason) : false;
+  const toolCallDetected = toolCallCount > 0 || pendingToolCallCount > 0;
+  const toolResultAccepted =
+    toolCallDetected &&
+    toolCallCount > 0 &&
+    toolFailureCount === 0 &&
+    pendingToolCallCount === 0 &&
+    !hasStructuredError &&
+    !stoppedBeforeFinal &&
+    finalAssistantVisible;
+  const finalUserVisibleResult =
+    finalAssistantVisible &&
+    !hasStructuredError &&
+    !stoppedBeforeFinal &&
+    pendingToolCallCount === 0 &&
+    toolFailureCount === 0 &&
+    (!toolCallDetected || toolResultAccepted);
+
+  return {
+    contractVersion: "openclaw.cron-assistant-completion.v1",
+    toolCallDetected,
+    toolResultAccepted,
+    finalAssistantVisible,
+    finalUserVisibleResult,
+    toolCallCount,
+    toolFailureCount,
+  };
+}
+
 export async function finalizeCronRun(params: {
   prepared: PreparedCronRunContext;
   execution: CronExecutionResult;
@@ -68,6 +129,7 @@ export async function finalizeCronRun(params: {
   const { prepared, execution } = params;
   const finalRunResult = execution.runResult;
   const payloads = finalRunResult.payloads ?? [];
+  const assistantCompletion = buildCronAssistantCompletion(finalRunResult);
   let telemetry: CronRunTelemetry | undefined;
 
   // Late aborted results may still contain billable usage. Recheck before each
@@ -312,6 +374,7 @@ export async function finalizeCronRun(params: {
       deliveryAttempted: result?.deliveryAttempted,
       deliveryError: result?.deliveryError,
       delivery: result?.delivery,
+      assistantCompletion,
       diagnostics: mergeCronRunDiagnostics(
         runDiagnostics,
         hasFatalErrorPayload
@@ -379,6 +442,7 @@ export async function finalizeCronRun(params: {
       outputText: error,
       delivered: false,
       deliveryAttempted: false,
+      assistantCompletion,
       diagnostics: mergeCronRunDiagnostics(
         runDiagnostics,
         createCronRunDiagnosticsFromError("agent-run", error),
@@ -471,6 +535,7 @@ export async function finalizeCronRun(params: {
         deliveryResult.result.deliveryAttempted ?? deliveryResult.deliveryAttempted,
       deliveryError,
       delivery: deliveryTrace,
+      assistantCompletion,
       diagnostics: mergeCronRunDiagnostics(
         runDiagnostics,
         deliveryResult.result.diagnostics,

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -2,7 +2,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import { hasCommittedMessagingToolDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
-import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
 import { deriveContextPromptTokens } from "../../agents/usage.js";
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
 import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
@@ -18,7 +17,8 @@ import {
   createCronRunDiagnosticsFromError,
   mergeCronRunDiagnostics,
 } from "../run-diagnostics.js";
-import type { CronAssistantCompletion, CronDeliveryTrace, CronRunTelemetry } from "../types.js";
+import type { CronDeliveryTrace, CronRunTelemetry } from "../types.js";
+import { buildCronAssistantCompletion } from "./assistant-completion.js";
 import { resolveCronChannelOutputPolicy } from "./channel-output-policy.js";
 import {
   isHeartbeatOnlyResponse,
@@ -56,66 +56,6 @@ async function loadCliRunnerRuntime() {
 
 async function loadUsageFormatRuntime() {
   return await import("../../utils/usage-format.js");
-}
-
-const NON_FINAL_ASSISTANT_STOP_REASONS = new Set([
-  "aborted",
-  "error",
-  "length",
-  "restart",
-  "timeout",
-  "tool_calls",
-  "tooluse",
-]);
-
-/** Builds the content-free public proof consumed by cron observers. */
-export function buildCronAssistantCompletion(
-  result: Pick<EmbeddedAgentRunResult, "meta" | "payloads">,
-): CronAssistantCompletion {
-  const calls = result.meta.toolSummary?.calls;
-  const failures = result.meta.toolSummary?.failures;
-  const observedToolCallCount =
-    Number.isSafeInteger(calls) && (calls ?? -1) >= 0 ? (calls ?? 0) : 0;
-  const toolFailureCount =
-    Number.isSafeInteger(failures) && (failures ?? -1) >= 0 ? (failures ?? 0) : 0;
-  const pendingToolCallCount = Array.isArray(result.meta.pendingToolCalls)
-    ? result.meta.pendingToolCalls.length
-    : 0;
-  const toolCallCount = Math.max(observedToolCallCount, pendingToolCallCount);
-  const stopReason = normalizeOptionalString(
-    result.meta.stopReason ?? result.meta.completion?.stopReason,
-  )?.toLowerCase();
-  const finalAssistantText = normalizeOptionalString(result.meta.finalAssistantVisibleText);
-  const finalAssistantVisible =
-    finalAssistantText !== undefined && !isSilentReplyPayloadText(finalAssistantText);
-  const hasStructuredError = (result.payloads ?? []).some((payload) => payload.isError === true);
-  const stoppedBeforeFinal = stopReason ? NON_FINAL_ASSISTANT_STOP_REASONS.has(stopReason) : false;
-  const toolCallDetected = toolCallCount > 0 || pendingToolCallCount > 0;
-  const toolResultAccepted =
-    toolCallDetected &&
-    toolCallCount > 0 &&
-    toolFailureCount === 0 &&
-    pendingToolCallCount === 0 &&
-    !hasStructuredError &&
-    !stoppedBeforeFinal &&
-    finalAssistantVisible;
-  const finalUserVisibleResult =
-    finalAssistantVisible &&
-    !hasStructuredError &&
-    !stoppedBeforeFinal &&
-    pendingToolCallCount === 0 &&
-    toolFailureCount === 0 &&
-    (!toolCallDetected || toolResultAccepted);
-
-  return {
-    contractVersion: "openclaw.cron-assistant-completion.v1",
-    toolCallDetected,
-    toolResultAccepted,
-    finalAssistantVisible,
-    finalUserVisibleResult,
-    toolCallCount,
-    toolFailureCount,
-  };
 }
 
 export async function finalizeCronRun(params: {

--- a/src/cron/run-log-types.ts
+++ b/src/cron/run-log-types.ts
@@ -5,6 +5,7 @@ import type {
   CronDeliveryTrace,
   CronFailureNotificationDelivery,
   CronRunDiagnostics,
+  CronAssistantCompletion,
   CronRunStatus,
   CronRunTelemetry,
 } from "./types.js";
@@ -19,6 +20,7 @@ export type CronRunLogEntry = {
   errorReason?: FailoverReason;
   summary?: string;
   diagnostics?: CronRunDiagnostics;
+  assistantCompletion?: CronAssistantCompletion;
   delivered?: boolean;
   deliveryStatus?: CronDeliveryStatus;
   deliveryError?: string;

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -19,6 +19,7 @@ import type {
   CronJobCreate,
   CronJobPatch,
   CronRunDiagnostics,
+  CronAssistantCompletion,
   CronMessageChannel,
   CronRunOutcome,
   CronRunStatus,
@@ -38,6 +39,7 @@ export type CronEvent = {
   error?: string;
   summary?: string;
   diagnostics?: CronRunDiagnostics;
+  assistantCompletion?: CronAssistantCompletion;
   delivered?: boolean;
   deliveryStatus?: CronDeliveryStatus;
   deliveryError?: string;

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -628,6 +628,7 @@ function emitJobFinished(
     status: result.status,
     error: result.error,
     summary: result.summary,
+    assistantCompletion: result.assistantCompletion,
     diagnostics: result.diagnostics,
     delivered: job.state.lastDelivered,
     deliveryStatus: job.state.lastDeliveryStatus,

--- a/src/cron/task-run-detail.ts
+++ b/src/cron/task-run-detail.ts
@@ -51,6 +51,36 @@ function normalizeCronRunLogErrorReason(value: unknown): FailoverReason | undefi
     : undefined;
 }
 
+function normalizeCronAssistantCompletion(value: unknown): CronRunLogEntry["assistantCompletion"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const entry = value as Record<string, unknown>;
+  if (
+    entry.contractVersion !== "openclaw.cron-assistant-completion.v1" ||
+    typeof entry.toolCallDetected !== "boolean" ||
+    typeof entry.toolResultAccepted !== "boolean" ||
+    typeof entry.finalAssistantVisible !== "boolean" ||
+    typeof entry.finalUserVisibleResult !== "boolean" ||
+    !Number.isSafeInteger(entry.toolCallCount) ||
+    (entry.toolCallCount as number) < 0 ||
+    !Number.isSafeInteger(entry.toolFailureCount) ||
+    (entry.toolFailureCount as number) < 0 ||
+    (entry.toolFailureCount as number) > (entry.toolCallCount as number)
+  ) {
+    return undefined;
+  }
+  return {
+    contractVersion: "openclaw.cron-assistant-completion.v1",
+    toolCallDetected: entry.toolCallDetected,
+    toolResultAccepted: entry.toolResultAccepted,
+    finalAssistantVisible: entry.finalAssistantVisible,
+    finalUserVisibleResult: entry.finalUserVisibleResult,
+    toolCallCount: entry.toolCallCount as number,
+    toolFailureCount: entry.toolFailureCount as number,
+  };
+}
+
 /** Parses stored or migrated cron history while preserving the stable wire shape. */
 export function parseCronRunLogEntryObject(
   obj: unknown,
@@ -92,6 +122,7 @@ export function parseCronRunLogEntryObject(
     error: normalizedError,
     errorReason: normalizeCronRunLogErrorReason(entryObj.errorReason) ?? undefined,
     summary: entryObj.summary,
+    assistantCompletion: normalizeCronAssistantCompletion(entryObj.assistantCompletion),
     runId: typeof entryObj.runId === "string" && entryObj.runId.trim() ? entryObj.runId : undefined,
     diagnostics: normalizeCronRunDiagnostics(entryObj.diagnostics),
     runAtMs: entryObj.runAtMs,
@@ -179,6 +210,7 @@ export function cronRunLogEntryToTaskDetail(
     storeKey: options.storeKey,
     errorReason: entry.errorReason,
     diagnostics: entry.diagnostics,
+    assistantCompletion: entry.assistantCompletion,
     delivered: entry.delivered,
     deliveryStatus: entry.deliveryStatus,
     deliveryError: entry.deliveryError,

--- a/src/cron/task-run-event-codec.test.ts
+++ b/src/cron/task-run-event-codec.test.ts
@@ -2,6 +2,29 @@ import { describe, expect, it } from "vitest";
 import { cronRunLogEntryFromEvent } from "./task-run-event-codec.js";
 
 describe("cronRunLogEntryFromEvent", () => {
+  it("preserves sanitized assistant completion evidence in run history", () => {
+    const assistantCompletion = {
+      contractVersion: "openclaw.cron-assistant-completion.v1" as const,
+      toolCallDetected: true,
+      toolResultAccepted: true,
+      finalAssistantVisible: true,
+      finalUserVisibleResult: true,
+      toolCallCount: 1,
+      toolFailureCount: 0,
+    };
+    const entry = cronRunLogEntryFromEvent(
+      {
+        jobId: "cron-job",
+        action: "finished",
+        status: "ok",
+        assistantCompletion,
+      },
+      1,
+    );
+
+    expect(entry.assistantCompletion).toEqual(assistantCompletion);
+  });
+
   it("keeps permanent script failures out of run-history timeout classification", () => {
     const entry = cronRunLogEntryFromEvent(
       {

--- a/src/cron/task-run-event-codec.ts
+++ b/src/cron/task-run-event-codec.ts
@@ -36,6 +36,7 @@ export function cronRunLogEntryFromEvent(
     error: event.error,
     errorReason,
     summary: event.summary,
+    assistantCompletion: event.assistantCompletion,
     diagnostics: event.diagnostics,
     delivered: event.delivered,
     deliveryStatus: event.deliveryStatus,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -202,6 +202,17 @@ export type CronRunErrorClassification =
   | { kind: "reason"; reason: FailoverReason }
   | { kind: "permanent" };
 
+/** Sanitized public proof that an agent run reached a user-visible terminal assistant turn. */
+export type CronAssistantCompletion = {
+  contractVersion: "openclaw.cron-assistant-completion.v1";
+  toolCallDetected: boolean;
+  toolResultAccepted: boolean;
+  finalAssistantVisible: boolean;
+  finalUserVisibleResult: boolean;
+  toolCallCount: number;
+  toolFailureCount: number;
+};
+
 /** Execution result persisted on cron state, run logs, and isolated turn results. */
 export type CronRunOutcome = {
   status: CronRunStatus;
@@ -215,6 +226,7 @@ export type CronRunOutcome = {
   sessionId?: string;
   sessionKey?: string;
   diagnostics?: CronRunDiagnostics;
+  assistantCompletion?: CronAssistantCompletion;
 };
 
 /** One run's requested delay before the same paced job runs again. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where DeepSeek-compatible responses using double-bar DSML delimiters could leave a cron run with serialized tool protocol text instead of a final user-visible assistant result.

## Why This Change Was Made

The DeepSeek stream recovery now recognizes single- and double-bar ASCII/fullwidth DSML delimiters. Cron public run results also publish a content-free `openclaw.cron-assistant-completion.v1` proof so consumers can distinguish a completed final assistant result from a pending, failed, or uncontinued tool turn without reading private session state.

The completion proof contains only booleans and counts. It does not expose prompts, tool arguments, tool output, message text, identities, credentials, or private paths.

## User Impact

Valid recovered tool calls continue through the normal OpenClaw tool state machine, while public cron observers can fail closed when a run has no proven final user-visible assistant completion.

## Evidence

- `src/agents/openai-transport-stream.deepseek-and-shaping.test.ts`: double-bar DSML recovery passed in both configured project variants.
- DeepSeek filter plus cron completion/codec tests: 19 passed.
- `tsgo` core typecheck passed.
- Formatting and diff checks passed.

AI-assisted: yes. I reviewed the complete diff and understand the parser, finalization, public schema, and codec changes.
