### PR TITLE
fix(mcp): bound catalog pagination

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -75,14 +75,18 @@ async function writeListToolsMcpServer(params: {
   exitOnListCall?: number;
   listToolsMethodNotFound?: boolean;
   listToolsJsonRpcErrorMessage?: string;
+  toolPageCursors?: Array<string | null>;
   callToolIsError?: boolean;
   callToolJsonRpcError?: boolean;
   callToolJsonRpcErrorCode?: number;
   callToolResult?: CallToolResult;
   resourcePageDelayMs?: number;
   resourcePageCount?: number;
+  resourcePageCursors?: Array<string | null>;
   resourceListJsonRpcError?: boolean;
   resourceReadJsonRpcError?: boolean;
+  promptPageDelayMs?: number;
+  promptPageCursors?: Array<string | null>;
 }): Promise<void> {
   await writeExecutable(
     params.filePath,
@@ -104,6 +108,7 @@ const notifyListChangedAfterFirstList = ${params.notifyListChangedAfterFirstList
 const exitOnListCall = ${params.exitOnListCall ?? 0};
 const listToolsMethodNotFound = ${params.listToolsMethodNotFound === true};
 const listToolsJsonRpcErrorMessage = ${JSON.stringify(params.listToolsJsonRpcErrorMessage)};
+const toolPageCursors = ${JSON.stringify(params.toolPageCursors)};
 const tools = ${JSON.stringify(
       params.tools ?? [
         {
@@ -119,12 +124,16 @@ const callToolJsonRpcErrorCode = ${params.callToolJsonRpcErrorCode ?? -32000};
 const callToolResult = ${JSON.stringify(params.callToolResult)};
 const resourcePageDelayMs = ${params.resourcePageDelayMs ?? 0};
 const resourcePageCount = ${params.resourcePageCount ?? 1};
+const resourcePageCursors = ${JSON.stringify(params.resourcePageCursors)};
 const resourceListJsonRpcError = ${params.resourceListJsonRpcError === true};
 const resourceReadJsonRpcError = ${params.resourceReadJsonRpcError === true};
+const promptPageDelayMs = ${params.promptPageDelayMs ?? 0};
+const promptPageCursors = ${JSON.stringify(params.promptPageCursors)};
 
 let buffer = "";
 let listCount = 0;
 let resourceListCount = 0;
+let promptListCount = 0;
 let pendingTimer;
 let keepAlive;
 let database;
@@ -183,6 +192,7 @@ function handle(message) {
   }
   if (message.method === "tools/list") {
     listCount += 1;
+    log("tools/list cursor " + JSON.stringify(message.params?.cursor));
     if (listCount === exitOnListCall) {
       log("exit tools/list " + listCount);
       process.exit(1);
@@ -211,13 +221,19 @@ function handle(message) {
       return;
     }
     const currentListCount = listCount;
+    const toolPageCursor = toolPageCursors?.[currentListCount - 1];
     log("delay tools/list " + delayMs);
     pendingTimer = setTimeout(() => {
       send({
         jsonrpc: "2.0",
         id: message.id,
         result: {
-          tools,
+          tools: toolPageCursors
+            ? tools.map((tool) => ({ ...tool, name: tool.name + "-" + currentListCount }))
+            : tools,
+          ...(toolPageCursor !== undefined && toolPageCursor !== null
+            ? { nextCursor: toolPageCursor }
+            : {}),
         },
       });
       if (notifyListChangedAfterFirstList && currentListCount === 1) {
@@ -253,6 +269,7 @@ function handle(message) {
   }
   if (message.method === "resources/list") {
     resourceListCount += 1;
+    log("resources/list cursor " + JSON.stringify(message.params?.cursor));
     if (resourceListJsonRpcError) {
       send({
         jsonrpc: "2.0",
@@ -262,17 +279,40 @@ function handle(message) {
       return;
     }
     setTimeout(() => {
+      const resourcePageCursor = resourcePageCursors?.[resourceListCount - 1];
       send({
         jsonrpc: "2.0",
         id: message.id,
         result: {
-          resources: [],
-          ...(resourceListCount < resourcePageCount
-            ? { nextCursor: String(resourceListCount) }
-            : {}),
+          resources: resourcePageCursors
+            ? [{ uri: "memo://page-" + resourceListCount, name: "page-" + resourceListCount }]
+            : [],
+          ...(resourcePageCursor !== undefined && resourcePageCursor !== null
+            ? { nextCursor: resourcePageCursor }
+            : resourceListCount < resourcePageCount
+              ? { nextCursor: String(resourceListCount) }
+              : {}),
         },
       });
     }, resourcePageDelayMs);
+    return;
+  }
+  if (message.method === "prompts/list") {
+    promptListCount += 1;
+    log("prompts/list cursor " + JSON.stringify(message.params?.cursor));
+    setTimeout(() => {
+      const promptPageCursor = promptPageCursors?.[promptListCount - 1];
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          prompts: [{ name: "prompt-" + promptListCount }],
+          ...(promptPageCursor !== undefined && promptPageCursor !== null
+            ? { nextCursor: promptPageCursor }
+            : {}),
+        },
+      });
+    }, promptPageDelayMs);
     return;
   }
   if (message.method === "resources/read") {
@@ -2172,7 +2212,115 @@ process.on("SIGINT", shutdown);`,
     }
   });
 
-  it("gives each paginated resource request its own timeout", async () => {
+  it("loads tool pages after an empty opaque cursor", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-tool-empty-cursor-");
+    const serverPath = path.join(tempDir, "tool-pages.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      toolPageCursors: ["", null],
+    });
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-tool-empty-cursor",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: { servers: { paged: { command: process.execPath, args: [serverPath] } } },
+      },
+    });
+
+    try {
+      await expect(runtime.getCatalog()).resolves.toMatchObject({
+        tools: [{ toolName: "slow_tool-1" }, { toolName: "slow_tool-2" }],
+      });
+      await waitForFileText(logPath, 'tools/list cursor ""', LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("isolates a cyclic tool catalog while a healthy bundle MCP sibling survives", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-tool-cycle-");
+    const loopingPath = path.join(tempDir, "looping.mjs");
+    const loopingLogPath = path.join(tempDir, "looping.log");
+    const healthyPath = path.join(tempDir, "healthy.mjs");
+    const healthyLogPath = path.join(tempDir, "healthy.log");
+    await writeListToolsMcpServer({
+      filePath: loopingPath,
+      logPath: loopingLogPath,
+      toolPageCursors: ["same", "same"],
+    });
+    await writeListToolsMcpServer({ filePath: healthyPath, logPath: healthyLogPath });
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-tool-cycle",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            looping: { command: process.execPath, args: [loopingPath] },
+            healthy: { command: process.execPath, args: [healthyPath] },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools.map((tool) => `${tool.serverName}:${tool.toolName}`)).toEqual([
+        "healthy:slow_tool",
+      ]);
+      expect(
+        catalog.diagnostics?.find((entry) => entry.serverName === "looping")?.message,
+      ).toContain("repeated pagination cursor");
+      await waitForFileText(healthyLogPath, "recv tools/list", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("loads resource and prompt pages after empty opaque cursors", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-utility-empty-cursor-");
+    const serverPath = path.join(tempDir, "utility-pages.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { resources: {}, prompts: {} },
+      listToolsMethodNotFound: true,
+      resourcePageCursors: ["", null],
+      promptPageCursors: ["", null],
+    });
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-utility-empty-cursor",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: { servers: { paged: { command: process.execPath, args: [serverPath] } } },
+      },
+    });
+
+    try {
+      await runtime.getCatalog();
+      const listResources = runtime.listResources;
+      const listPrompts = runtime.listPrompts;
+      if (!listResources || !listPrompts) {
+        throw new Error("Expected test runtime to expose resource and prompt utilities");
+      }
+      await expect(listResources("paged")).resolves.toMatchObject([
+        { uri: "memo://page-1" },
+        { uri: "memo://page-2" },
+      ]);
+      await expect(listPrompts("paged")).resolves.toMatchObject([
+        { name: "prompt-1" },
+        { name: "prompt-2" },
+      ]);
+      await waitForFileText(logPath, 'resources/list cursor ""', LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+      await waitForFileText(logPath, 'prompts/list cursor ""', LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("bounds the complete paginated resource listing by one absolute timeout", async () => {
     const tempDir = tempDirTracker.make("bundle-mcp-resource-pages-");
     const serverPath = path.join(tempDir, "resource-pages.mjs");
     const logPath = path.join(tempDir, "server.log");
@@ -2206,7 +2354,9 @@ process.on("SIGINT", shutdown);`,
       if (!runtime.listResources) {
         throw new Error("Expected test runtime to expose resource utilities");
       }
-      await expect(runtime.listResources("paged")).resolves.toEqual([]);
+      await expect(runtime.listResources("paged")).rejects.toThrow(
+        "MCP resource listing timed out after 150ms",
+      );
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -61,6 +61,7 @@ import {
 } from "./mcp-connection-resolver.js";
 import { createMcpJsonSchemaValidator } from "./mcp-json-schema-validator.js";
 import { sanitizeMcpMetadataText } from "./mcp-metadata.js";
+import { collectMcpPaginatedItems } from "./mcp-pagination.js";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
 
@@ -89,6 +90,9 @@ const BUNDLE_MCP_CATALOG_FAILURE_RETRY_MS = 5_000;
 const BUNDLE_MCP_CATALOG_LIST_TIMEOUT_MS = 1_500;
 const BUNDLE_MCP_DISPOSE_TIMEOUT_MS = 5_000;
 const BUNDLE_MCP_CATALOG_CONNECT_CONCURRENCY = 6;
+const BUNDLE_MCP_MAX_LIST_PAGES = 128;
+const BUNDLE_MCP_MAX_LIST_ITEMS = 16_384;
+const BUNDLE_MCP_MAX_LIST_BYTES = 10 * 1024 * 1024;
 let bundleMcpCatalogListTimeoutMs: number | undefined;
 const BUNDLE_MCP_TEST_STATE_KEY = Symbol.for("openclaw.bundleMcpTestState");
 type BundleMcpTestState = { disposeTimeoutMs?: number };
@@ -170,16 +174,24 @@ function redactMcpDiagnosticError(error: unknown): string {
   return redactToolPayloadText(redactSensitiveUrlLikeString(String(error)));
 }
 
-async function listAllTools(client: Client, timeoutMs: number) {
-  const tools: ListedTool[] = [];
-  let cursor: string | undefined;
-  do {
-    const params = cursor ? { cursor } : undefined;
-    const page = await client.listTools(params, { timeout: timeoutMs });
-    tools.push(...page.tools);
-    cursor = page.nextCursor;
-  } while (cursor);
-  return tools;
+async function listAllTools(client: Client, timeoutMs: number, signal: AbortSignal) {
+  return await collectMcpPaginatedItems({
+    label: "MCP tool listing",
+    itemLabel: "tools",
+    timeoutMs,
+    maxPages: BUNDLE_MCP_MAX_LIST_PAGES,
+    maxItems: BUNDLE_MCP_MAX_LIST_ITEMS,
+    maxBytes: BUNDLE_MCP_MAX_LIST_BYTES,
+    signal,
+    loadPage: async ({ cursor, timeoutMs: remainingTimeoutMs, signal: requestSignal }) => {
+      const page = await client.listTools(cursor === undefined ? undefined : { cursor }, {
+        timeout: remainingTimeoutMs,
+        maxTotalTimeout: remainingTimeoutMs,
+        signal: requestSignal,
+      });
+      return { items: page.tools, nextCursor: page.nextCursor, serializedValue: page };
+    },
+  });
 }
 
 function isMcpMethodNotFoundError(error: unknown): boolean {
@@ -193,10 +205,11 @@ function isMcpMethodNotFoundError(error: unknown): boolean {
 async function listAllToolsBestEffort(params: {
   client: Client;
   timeoutMs: number;
+  signal: AbortSignal;
   suppressUnsupported: boolean;
 }): Promise<ListedTool[]> {
   try {
-    return await listAllTools(params.client, params.timeoutMs);
+    return await listAllTools(params.client, params.timeoutMs, params.signal);
   } catch (error) {
     if (params.suppressUnsupported && isMcpMethodNotFoundError(error)) {
       return [];
@@ -258,31 +271,8 @@ function buildMcpClientOptions(mcpAppsEnabled: boolean): ClientOptions {
   return { capabilities: buildMcpClientCapabilities(mcpAppsEnabled) };
 }
 
-async function listAllResources(
-  loadPage: (cursor: string | undefined) => ReturnType<Client["listResources"]>,
-) {
-  const resources: unknown[] = [];
-  let cursor: string | undefined;
-  do {
-    const page = await loadPage(cursor);
-    resources.push(...page.resources);
-    cursor = page.nextCursor;
-  } while (cursor);
-  return resources;
-}
-
-async function listAllPrompts(
-  loadPage: (cursor: string | undefined) => ReturnType<Client["listPrompts"]>,
-) {
-  const prompts: unknown[] = [];
-  let cursor: string | undefined;
-  do {
-    const page = await loadPage(cursor);
-    prompts.push(...page.prompts);
-    cursor = page.nextCursor;
-  } while (cursor);
-  return prompts;
-}
+type ListedResource = Awaited<ReturnType<Client["listResources"]>>["resources"][number];
+type ListedPrompt = Awaited<ReturnType<Client["listPrompts"]>>["prompts"][number];
 
 function normalizeStringList(value: unknown): string[] | undefined {
   if (!Array.isArray(value)) {
@@ -426,6 +416,7 @@ export function createSessionMcpRuntime(params: {
   let lastUsedAt = createdAt;
   let activeLeases = 0;
   let disposed = false;
+  const lifecycleAbortController = new AbortController();
   let catalog: McpToolCatalog | null = null;
   let catalogRetryAfterMs: number | undefined;
   let catalogInFlight: Promise<McpToolCatalog> | undefined;
@@ -548,6 +539,7 @@ export function createSessionMcpRuntime(params: {
   const runMcpRequest = async <T>(
     session: BundleMcpSession,
     request: (signal: AbortSignal) => Promise<T>,
+    parentSignal?: AbortSignal,
   ): Promise<T> => {
     const abortController = new AbortController();
     const timeoutError = new McpError(ErrorCode.RequestTimeout, "Request timed out", {
@@ -559,7 +551,11 @@ export function createSessionMcpRuntime(params: {
     }, session.requestTimeoutMs);
     timeout.unref?.();
     try {
-      return await request(abortController.signal);
+      const signal = parentSignal
+        ? AbortSignal.any([parentSignal, abortController.signal])
+        : abortController.signal;
+      signal.throwIfAborted();
+      return await request(signal);
     } finally {
       clearTimeout(timeout);
     }
@@ -825,6 +821,7 @@ export function createSessionMcpRuntime(params: {
                 const listedTools = await listAllToolsBestEffort({
                   client: session.client,
                   timeoutMs: getCatalogListTimeoutMs(rawServer, resolved.requestTimeoutMs),
+                  signal: lifecycleAbortController.signal,
                   suppressUnsupported: Boolean(
                     !capabilities.tools && (capabilities.resources || capabilities.prompts),
                   ),
@@ -1108,14 +1105,39 @@ export function createSessionMcpRuntime(params: {
         serverName,
         session,
         async () =>
-          listAllResources((cursor) =>
-            runMcpRequest(session, async (signal) =>
-              session.client.listResources(cursor ? { cursor } : undefined, {
-                timeout: session.requestTimeoutMs,
-                signal,
-              }),
-            ),
-          ),
+          collectMcpPaginatedItems<ListedResource>({
+            label: "MCP resource listing",
+            itemLabel: "resources",
+            timeoutMs: session.requestTimeoutMs,
+            maxPages: BUNDLE_MCP_MAX_LIST_PAGES,
+            maxItems: BUNDLE_MCP_MAX_LIST_ITEMS,
+            maxBytes: BUNDLE_MCP_MAX_LIST_BYTES,
+            signal: lifecycleAbortController.signal,
+            loadPage: async ({
+              cursor,
+              timeoutMs: remainingTimeoutMs,
+              signal: paginationSignal,
+            }) => {
+              const page = await runMcpRequest(
+                session,
+                async (signal) =>
+                  await session.client.listResources(
+                    cursor === undefined ? undefined : { cursor },
+                    {
+                      timeout: remainingTimeoutMs,
+                      maxTotalTimeout: remainingTimeoutMs,
+                      signal,
+                    },
+                  ),
+                paginationSignal,
+              );
+              return {
+                items: page.resources,
+                nextCursor: page.nextCursor,
+                serializedValue: page,
+              };
+            },
+          }),
         options,
       );
     },
@@ -1151,14 +1173,28 @@ export function createSessionMcpRuntime(params: {
       await getCatalog();
       const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(serverName, session, async () =>
-        listAllPrompts((cursor) =>
-          runMcpRequest(session, async (signal) =>
-            session.client.listPrompts(cursor ? { cursor } : undefined, {
-              timeout: session.requestTimeoutMs,
-              signal,
-            }),
-          ),
-        ),
+        collectMcpPaginatedItems<ListedPrompt>({
+          label: "MCP prompt listing",
+          itemLabel: "prompts",
+          timeoutMs: session.requestTimeoutMs,
+          maxPages: BUNDLE_MCP_MAX_LIST_PAGES,
+          maxItems: BUNDLE_MCP_MAX_LIST_ITEMS,
+          maxBytes: BUNDLE_MCP_MAX_LIST_BYTES,
+          signal: lifecycleAbortController.signal,
+          loadPage: async ({ cursor, timeoutMs: remainingTimeoutMs, signal: paginationSignal }) => {
+            const page = await runMcpRequest(
+              session,
+              async (signal) =>
+                await session.client.listPrompts(cursor === undefined ? undefined : { cursor }, {
+                  timeout: remainingTimeoutMs,
+                  maxTotalTimeout: remainingTimeoutMs,
+                  signal,
+                }),
+              paginationSignal,
+            );
+            return { items: page.prompts, nextCursor: page.nextCursor, serializedValue: page };
+          },
+        }),
       );
     },
     async getPrompt(serverName, name, args) {
@@ -1179,6 +1215,7 @@ export function createSessionMcpRuntime(params: {
         return;
       }
       disposed = true;
+      lifecycleAbortController.abort(createDisposedError(params.sessionId));
       catalog = null;
       catalogRetryAfterMs = undefined;
       catalogInFlight = undefined;

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -183,10 +183,10 @@ async function listAllTools(client: Client, timeoutMs: number, signal: AbortSign
     maxItems: BUNDLE_MCP_MAX_LIST_ITEMS,
     maxBytes: BUNDLE_MCP_MAX_LIST_BYTES,
     signal,
-    loadPage: async ({ cursor, timeoutMs: remainingTimeoutMs, signal: requestSignal }) => {
+    loadPage: async ({ cursor, requestTimeoutMs, signal: requestSignal }) => {
       const page = await client.listTools(cursor === undefined ? undefined : { cursor }, {
-        timeout: remainingTimeoutMs,
-        maxTotalTimeout: remainingTimeoutMs,
+        timeout: requestTimeoutMs,
+        maxTotalTimeout: requestTimeoutMs,
         signal: requestSignal,
       });
       return { items: page.tools, nextCursor: page.nextCursor, serializedValue: page };
@@ -1113,19 +1113,15 @@ export function createSessionMcpRuntime(params: {
             maxItems: BUNDLE_MCP_MAX_LIST_ITEMS,
             maxBytes: BUNDLE_MCP_MAX_LIST_BYTES,
             signal: lifecycleAbortController.signal,
-            loadPage: async ({
-              cursor,
-              timeoutMs: remainingTimeoutMs,
-              signal: paginationSignal,
-            }) => {
+            loadPage: async ({ cursor, requestTimeoutMs, signal: paginationSignal }) => {
               const page = await runMcpRequest(
                 session,
                 async (signal) =>
                   await session.client.listResources(
                     cursor === undefined ? undefined : { cursor },
                     {
-                      timeout: remainingTimeoutMs,
-                      maxTotalTimeout: remainingTimeoutMs,
+                      timeout: requestTimeoutMs,
+                      maxTotalTimeout: requestTimeoutMs,
                       signal,
                     },
                   ),
@@ -1181,13 +1177,13 @@ export function createSessionMcpRuntime(params: {
           maxItems: BUNDLE_MCP_MAX_LIST_ITEMS,
           maxBytes: BUNDLE_MCP_MAX_LIST_BYTES,
           signal: lifecycleAbortController.signal,
-          loadPage: async ({ cursor, timeoutMs: remainingTimeoutMs, signal: paginationSignal }) => {
+          loadPage: async ({ cursor, requestTimeoutMs, signal: paginationSignal }) => {
             const page = await runMcpRequest(
               session,
               async (signal) =>
                 await session.client.listPrompts(cursor === undefined ? undefined : { cursor }, {
-                  timeout: remainingTimeoutMs,
-                  maxTotalTimeout: remainingTimeoutMs,
+                  timeout: requestTimeoutMs,
+                  maxTotalTimeout: requestTimeoutMs,
                   signal,
                 }),
               paginationSignal,

--- a/src/agents/mcp-pagination.test.ts
+++ b/src/agents/mcp-pagination.test.ts
@@ -86,7 +86,7 @@ describe("collectMcpPaginatedItems", () => {
     ).rejects.toThrow("exceeded 64 bytes");
   });
 
-  it("gives every page only the remaining absolute deadline", async () => {
+  it("keeps the per-request safety budget behind one absolute deadline", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
     const requestTimeouts: number[] = [];
@@ -96,8 +96,8 @@ describe("collectMcpPaginatedItems", () => {
       itemLabel: "tools",
       ...limits,
       timeoutMs: 50,
-      loadPage: async ({ timeoutMs }) => {
-        requestTimeouts.push(timeoutMs);
+      loadPage: async ({ requestTimeoutMs }) => {
+        requestTimeouts.push(requestTimeoutMs);
         await new Promise<void>((resolve) => {
           setTimeout(resolve, 30);
         });
@@ -109,7 +109,25 @@ describe("collectMcpPaginatedItems", () => {
 
     await vi.advanceTimersByTimeAsync(50);
     await rejected;
-    expect(requestTimeouts).toEqual([50, 20]);
+    expect(requestTimeouts).toEqual([50, 50]);
+  });
+
+  it("reports the collector deadline before a nested request timeout", async () => {
+    vi.useFakeTimers();
+    const listing = collectMcpPaginatedItems({
+      label: "MCP resource listing",
+      itemLabel: "resources",
+      ...limits,
+      timeoutMs: 50,
+      loadPage: async ({ requestTimeoutMs }) =>
+        await new Promise<never>((_resolve, reject) => {
+          setTimeout(() => reject(new Error("nested request timed out")), requestTimeoutMs);
+        }),
+    });
+    const rejected = expect(listing).rejects.toThrow("MCP resource listing timed out after 50ms");
+
+    await vi.advanceTimersByTimeAsync(50);
+    await rejected;
   });
 
   it("rejects a final page when synchronous processing crosses the deadline", async () => {

--- a/src/agents/mcp-pagination.test.ts
+++ b/src/agents/mcp-pagination.test.ts
@@ -121,7 +121,16 @@ describe("collectMcpPaginatedItems", () => {
       signal: controller.signal,
       loadPage: async ({ signal }) =>
         await new Promise<never>((_resolve, reject) => {
-          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+          signal.addEventListener(
+            "abort",
+            () =>
+              reject(
+                signal.reason instanceof Error
+                  ? signal.reason
+                  : new Error("MCP prompt listing aborted"),
+              ),
+            { once: true },
+          );
         }),
     });
 

--- a/src/agents/mcp-pagination.test.ts
+++ b/src/agents/mcp-pagination.test.ts
@@ -112,6 +112,54 @@ describe("collectMcpPaginatedItems", () => {
     expect(requestTimeouts).toEqual([50, 20]);
   });
 
+  it("rejects a final page when synchronous processing crosses the deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    let mappedItems = 0;
+    const listing = collectMcpPaginatedItems({
+      label: "MCP resource listing",
+      itemLabel: "resources",
+      ...limits,
+      timeoutMs: 50,
+      loadPage: async () => ({ items: ["resource"] }),
+      mapItem: (item) => {
+        mappedItems += 1;
+        vi.setSystemTime(1_050);
+        return item;
+      },
+    });
+
+    await expect(listing).rejects.toThrow("timed out after 50ms");
+    expect(mappedItems).toBe(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects when a page loader synchronously aborts its caller before resolving", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    let mappedItems = 0;
+    const listing = collectMcpPaginatedItems({
+      label: "MCP prompt listing",
+      itemLabel: "prompts",
+      ...limits,
+      signal: controller.signal,
+      loadPage: async () => {
+        controller.abort("runtime disposed");
+        return { items: ["must-not-return"] };
+      },
+      mapItem: (item) => {
+        mappedItems += 1;
+        return item;
+      },
+    });
+
+    const failure = await listing.catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure).toMatchObject({ message: "MCP prompt listing aborted" });
+    expect(mappedItems).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("aborts an in-flight page through the caller signal", async () => {
     const controller = new AbortController();
     const listing = collectMcpPaginatedItems({

--- a/src/agents/mcp-pagination.test.ts
+++ b/src/agents/mcp-pagination.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectMcpPaginatedItems } from "./mcp-pagination.js";
+
+const limits = {
+  timeoutMs: 1_000,
+  maxPages: 4,
+  maxItems: 8,
+  maxBytes: 1_024,
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("collectMcpPaginatedItems", () => {
+  it.each(["tool", "resource", "prompt"])(
+    "preserves normal %s ordering and treats an empty cursor as present",
+    async (operation) => {
+      const cursors: Array<string | undefined> = [];
+      const result = await collectMcpPaginatedItems({
+        label: `MCP ${operation} listing`,
+        itemLabel: `${operation}s`,
+        ...limits,
+        loadPage: async ({ cursor }) => {
+          cursors.push(cursor);
+          return cursor === undefined
+            ? { items: [`${operation}-one`], nextCursor: "" }
+            : { items: [`${operation}-two`] };
+        },
+      });
+
+      expect(cursors).toEqual([undefined, ""]);
+      expect(result).toEqual([`${operation}-one`, `${operation}-two`]);
+    },
+  );
+
+  it("rejects repeated and cyclic cursors", async () => {
+    await expect(
+      collectMcpPaginatedItems({
+        label: "MCP tool listing",
+        itemLabel: "tools",
+        ...limits,
+        loadPage: async ({ cursor }) => ({
+          items: [cursor ?? "first"],
+          nextCursor: cursor === undefined ? "a" : cursor === "a" ? "b" : "a",
+        }),
+      }),
+    ).rejects.toThrow("repeated pagination cursor");
+  });
+
+  it("bounds endless pages, retained items, and aggregate serialized bytes", async () => {
+    await expect(
+      collectMcpPaginatedItems({
+        label: "MCP tool listing",
+        itemLabel: "tools",
+        ...limits,
+        maxPages: 2,
+        loadPage: async ({ cursor }) => ({
+          items: [cursor ?? "first"],
+          nextCursor: `${cursor ?? "cursor"}-next`,
+        }),
+      }),
+    ).rejects.toThrow("exceeded 2 pages");
+
+    await expect(
+      collectMcpPaginatedItems({
+        label: "MCP resource listing",
+        itemLabel: "resources",
+        ...limits,
+        maxItems: 2,
+        loadPage: async () => ({ items: ["one", "two", "three"] }),
+      }),
+    ).rejects.toThrow("exceeded 2 resources");
+
+    await expect(
+      collectMcpPaginatedItems({
+        label: "MCP prompt listing",
+        itemLabel: "prompts",
+        ...limits,
+        maxBytes: 64,
+        loadPage: async () => ({
+          items: ["prompt"],
+          serializedValue: { prompts: [{ description: "x".repeat(128) }] },
+        }),
+      }),
+    ).rejects.toThrow("exceeded 64 bytes");
+  });
+
+  it("gives every page only the remaining absolute deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const requestTimeouts: number[] = [];
+    let page = 0;
+    const listing = collectMcpPaginatedItems({
+      label: "MCP tool listing",
+      itemLabel: "tools",
+      ...limits,
+      timeoutMs: 50,
+      loadPage: async ({ timeoutMs }) => {
+        requestTimeouts.push(timeoutMs);
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 30);
+        });
+        page += 1;
+        return { items: [`tool-${page}`], nextCursor: `cursor-${page}` };
+      },
+    });
+    const rejected = expect(listing).rejects.toThrow("timed out after 50ms");
+
+    await vi.advanceTimersByTimeAsync(50);
+    await rejected;
+    expect(requestTimeouts).toEqual([50, 20]);
+  });
+
+  it("aborts an in-flight page through the caller signal", async () => {
+    const controller = new AbortController();
+    const listing = collectMcpPaginatedItems({
+      label: "MCP prompt listing",
+      itemLabel: "prompts",
+      ...limits,
+      signal: controller.signal,
+      loadPage: async ({ signal }) =>
+        await new Promise<never>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    });
+
+    controller.abort(new Error("runtime disposed"));
+    await expect(listing).rejects.toThrow("runtime disposed");
+  });
+});

--- a/src/agents/mcp-pagination.ts
+++ b/src/agents/mcp-pagination.ts
@@ -2,14 +2,14 @@
 import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { boundedJsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 
-export type McpPaginationPage<T> = {
+type McpPaginationPage<T> = {
   items: readonly T[];
   nextCursor?: string;
   /** Original SDK page used for the aggregate serialized-byte budget. */
   serializedValue?: unknown;
 };
 
-export type McpPaginationRequest = {
+type McpPaginationRequest = {
   cursor: string | undefined;
   timeoutMs: number;
   signal: AbortSignal;

--- a/src/agents/mcp-pagination.ts
+++ b/src/agents/mcp-pagination.ts
@@ -1,0 +1,124 @@
+/** Shared bounded pagination for MCP list operations. */
+import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { boundedJsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+
+export type McpPaginationPage<T> = {
+  items: readonly T[];
+  nextCursor?: string;
+  /** Original SDK page used for the aggregate serialized-byte budget. */
+  serializedValue?: unknown;
+};
+
+export type McpPaginationRequest = {
+  cursor: string | undefined;
+  timeoutMs: number;
+  signal: AbortSignal;
+};
+
+type CollectMcpPaginatedItemsParams<TInput, TOutput = TInput> = {
+  label: string;
+  itemLabel: string;
+  timeoutMs: number;
+  maxPages: number;
+  maxItems: number;
+  maxBytes: number;
+  signal?: AbortSignal;
+  loadPage: (request: McpPaginationRequest) => Promise<McpPaginationPage<TInput>>;
+  mapItem?: (item: TInput) => TOutput | undefined;
+};
+
+function positiveInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function abortError(signal: AbortSignal, label: string): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error(`${label} aborted`);
+}
+
+/** Collects one complete MCP list under a single bounded lifecycle. */
+export async function collectMcpPaginatedItems<TInput, TOutput = TInput>(
+  params: CollectMcpPaginatedItemsParams<TInput, TOutput>,
+): Promise<TOutput[]> {
+  const timeoutMs = clampPositiveTimerTimeoutMs(params.timeoutMs);
+  if (timeoutMs === undefined) {
+    throw new Error(`${params.label} requires a positive timeout`);
+  }
+  const maxPages = positiveInteger(params.maxPages, `${params.label} maxPages`);
+  const maxItems = positiveInteger(params.maxItems, `${params.label} maxItems`);
+  const maxBytes = positiveInteger(params.maxBytes, `${params.label} maxBytes`);
+
+  const deadlineController = new AbortController();
+  const signal = params.signal
+    ? AbortSignal.any([params.signal, deadlineController.signal])
+    : deadlineController.signal;
+  if (signal.aborted) {
+    throw abortError(signal, params.label);
+  }
+  const deadlineAtMs = Date.now() + timeoutMs;
+  const timeoutError = new Error(`${params.label} timed out after ${timeoutMs}ms`);
+  const deadlineTimer = setTimeout(() => deadlineController.abort(timeoutError), timeoutMs);
+  deadlineTimer.unref?.();
+
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(abortError(signal, params.label));
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  const items: TOutput[] = [];
+  const seenCursors = new Set<string>();
+  let collectedBytes = 0;
+  let cursor: string | undefined;
+
+  try {
+    for (let pageNumber = 0; pageNumber < maxPages; pageNumber += 1) {
+      signal.throwIfAborted();
+      const remainingTimeoutMs = clampPositiveTimerTimeoutMs(deadlineAtMs - Date.now());
+      if (remainingTimeoutMs === undefined) {
+        throw timeoutError;
+      }
+      const page = await Promise.race([
+        params.loadPage({ cursor, timeoutMs: remainingTimeoutMs, signal }),
+        aborted,
+      ]);
+      const measured = boundedJsonUtf8Bytes(
+        page.serializedValue ?? { items: page.items, nextCursor: page.nextCursor },
+        maxBytes - collectedBytes,
+      );
+      if (!measured.complete || collectedBytes + measured.bytes > maxBytes) {
+        throw new Error(`${params.label} exceeded ${maxBytes} bytes`);
+      }
+      collectedBytes += measured.bytes;
+
+      for (const item of page.items) {
+        const mapped = params.mapItem ? params.mapItem(item) : (item as unknown as TOutput);
+        if (mapped === undefined) {
+          continue;
+        }
+        if (items.length >= maxItems) {
+          throw new Error(`${params.label} exceeded ${maxItems} ${params.itemLabel}`);
+        }
+        items.push(mapped);
+      }
+
+      const nextCursor = page.nextCursor;
+      if (nextCursor === undefined) {
+        return items;
+      }
+      if (seenCursors.has(nextCursor)) {
+        throw new Error(`${params.label} returned a repeated pagination cursor`);
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
+    }
+    throw new Error(`${params.label} exceeded ${maxPages} pages`);
+  } finally {
+    clearTimeout(deadlineTimer);
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+}

--- a/src/agents/mcp-pagination.ts
+++ b/src/agents/mcp-pagination.ts
@@ -11,7 +11,11 @@ type McpPaginationPage<T> = {
 
 type McpPaginationRequest = {
   cursor: string | undefined;
-  timeoutMs: number;
+  /**
+   * Full per-request safety budget. The collector signal owns the absolute list deadline,
+   * so nested transport timers cannot replace its canonical timeout error.
+   */
+  requestTimeoutMs: number;
   signal: AbortSignal;
 };
 
@@ -85,12 +89,8 @@ export async function collectMcpPaginatedItems<TInput, TOutput = TInput>(
   try {
     for (let pageNumber = 0; pageNumber < maxPages; pageNumber += 1) {
       assertActive();
-      const remainingTimeoutMs = clampPositiveTimerTimeoutMs(deadlineAtMs - Date.now());
-      if (remainingTimeoutMs === undefined) {
-        throw timeoutError;
-      }
       const page = await Promise.race([
-        params.loadPage({ cursor, timeoutMs: remainingTimeoutMs, signal }),
+        params.loadPage({ cursor, requestTimeoutMs: timeoutMs, signal }),
         aborted,
       ]);
       assertActive();

--- a/src/agents/mcp-pagination.ts
+++ b/src/agents/mcp-pagination.ts
@@ -61,6 +61,15 @@ export async function collectMcpPaginatedItems<TInput, TOutput = TInput>(
   const timeoutError = new Error(`${params.label} timed out after ${timeoutMs}ms`);
   const deadlineTimer = setTimeout(() => deadlineController.abort(timeoutError), timeoutMs);
   deadlineTimer.unref?.();
+  const assertActive = () => {
+    if (signal.aborted) {
+      throw abortError(signal, params.label);
+    }
+    if (Date.now() >= deadlineAtMs) {
+      deadlineController.abort(timeoutError);
+      throw timeoutError;
+    }
+  };
 
   let onAbort: (() => void) | undefined;
   const aborted = new Promise<never>((_resolve, reject) => {
@@ -75,7 +84,7 @@ export async function collectMcpPaginatedItems<TInput, TOutput = TInput>(
 
   try {
     for (let pageNumber = 0; pageNumber < maxPages; pageNumber += 1) {
-      signal.throwIfAborted();
+      assertActive();
       const remainingTimeoutMs = clampPositiveTimerTimeoutMs(deadlineAtMs - Date.now());
       if (remainingTimeoutMs === undefined) {
         throw timeoutError;
@@ -84,6 +93,7 @@ export async function collectMcpPaginatedItems<TInput, TOutput = TInput>(
         params.loadPage({ cursor, timeoutMs: remainingTimeoutMs, signal }),
         aborted,
       ]);
+      assertActive();
       const measured = boundedJsonUtf8Bytes(
         page.serializedValue ?? { items: page.items, nextCursor: page.nextCursor },
         maxBytes - collectedBytes,
@@ -104,7 +114,10 @@ export async function collectMcpPaginatedItems<TInput, TOutput = TInput>(
         items.push(mapped);
       }
 
+      // Synchronous page projection can consume the deadline or abort its caller.
+      // Never accept either a terminal page or its continuation after ownership ends.
       const nextCursor = page.nextCursor;
+      assertActive();
       if (nextCursor === undefined) {
         return items;
       }

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -18,6 +18,7 @@ function tool(name: string, description?: string): Tool {
 function createClient(params?: {
   connectError?: Error;
   tools?: Tool[];
+  list?: (params?: { cursor?: string }) => Promise<{ tools: Tool[]; nextCursor?: string }>;
   call?: (options?: { timeout?: number; signal?: AbortSignal }) => Promise<CallToolResult>;
 }) {
   return {
@@ -27,7 +28,9 @@ function createClient(params?: {
         throw params.connectError;
       }
     }),
-    listTools: vi.fn(async () => ({ tools: params?.tools ?? [] })),
+    listTools: vi.fn(async (input?: { cursor?: string }) =>
+      params?.list ? await params.list(input) : { tools: params?.tools ?? [] },
+    ),
     callTool: vi.fn(
       async (
         _input: unknown,
@@ -205,6 +208,164 @@ describe("node host MCP manager", () => {
     );
     expect(Buffer.byteLength(JSON.stringify(manager.descriptors))).toBeLessThan(10 * 1024 * 1024);
     await manager.close();
+  });
+
+  it("keeps global descriptor ordering across catalog pages", async () => {
+    const firstPage = Array.from({ length: 128 }, (_, index) =>
+      tool(`z-${String(index).padStart(3, "0")}`),
+    );
+    const client = createClient({
+      list: async (params) =>
+        params?.cursor
+          ? { tools: [tool("a-later-page")] }
+          : { tools: firstPage, nextCursor: "next" },
+    });
+    const warn = vi.fn();
+    const manager = await startNodeHostMcpManager(
+      { docs: { command: "docs" } },
+      { createClient: () => client, resolveTransport: () => transport, warn },
+    );
+
+    expect(manager.descriptors).toHaveLength(128);
+    expect(manager.descriptors[0]?.mcp?.tool).toBe("a-later-page");
+    expect(manager.descriptors.some((descriptor) => descriptor.mcp?.tool === "z-127")).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("published 128 of 129 tools"));
+
+    await manager.close();
+  });
+
+  it("isolates a repeated pagination cursor while a sibling server survives", async () => {
+    const looping = createClient({
+      list: async () => ({ tools: [tool("loop")], nextCursor: "same" }),
+    });
+    const healthy = createClient({ tools: [tool("search")] });
+    const warn = vi.fn();
+    const manager = await startNodeHostMcpManager(
+      { looping: { command: "looping" }, healthy: { command: "healthy" } },
+      {
+        createClient: (serverName) => (serverName === "looping" ? looping : healthy),
+        resolveTransport: () => transport,
+        warn,
+      },
+    );
+
+    expect(looping.listTools).toHaveBeenCalledTimes(2);
+    expect(looping.close).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("repeated pagination cursor"));
+    expect(manager.descriptors.map((descriptor) => descriptor.name)).toEqual(["healthy_search"]);
+    await expect(manager.callMcpTool({ server: "healthy", tool: "search" })).resolves.toEqual({
+      content: [{ type: "text", text: "ok" }],
+    });
+
+    await manager.close();
+    expect(looping.close).toHaveBeenCalledOnce();
+    expect(healthy.close).toHaveBeenCalledOnce();
+  });
+
+  it("isolates endless unique-cursor pagination at the page ceiling", async () => {
+    let page = 0;
+    const endless = createClient({
+      list: async () => {
+        page += 1;
+        return { tools: [tool(`tool-${page}`)], nextCursor: `cursor-${page}` };
+      },
+    });
+    const healthy = createClient({ tools: [tool("search")] });
+    const warn = vi.fn();
+    const manager = await startNodeHostMcpManager(
+      { endless: { command: "endless" }, healthy: { command: "healthy" } },
+      {
+        createClient: (serverName) => (serverName === "endless" ? endless : healthy),
+        resolveTransport: () => transport,
+        warn,
+      },
+    );
+
+    expect(endless.listTools).toHaveBeenCalledTimes(128);
+    expect(endless.close).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("exceeded 128 pages"));
+    expect(manager.descriptors.map((descriptor) => descriptor.name)).toEqual(["healthy_search"]);
+
+    await manager.close();
+  });
+
+  it("isolates an oversized multi-page catalog at the accumulated byte ceiling", async () => {
+    const largeTool = {
+      ...tool("large"),
+      inputSchema: { type: "object" as const, description: "x".repeat(6 * 1024 * 1024) },
+    };
+    const oversized = createClient({
+      list: async (params) =>
+        params?.cursor ? { tools: [largeTool] } : { tools: [largeTool], nextCursor: "next" },
+    });
+    const healthy = createClient({ tools: [tool("search")] });
+    const warn = vi.fn();
+    const manager = await startNodeHostMcpManager(
+      { oversized: { command: "oversized" }, healthy: { command: "healthy" } },
+      {
+        createClient: (serverName) => (serverName === "oversized" ? oversized : healthy),
+        resolveTransport: () => transport,
+        warn,
+      },
+    );
+
+    expect(oversized.listTools).toHaveBeenCalledTimes(2);
+    expect(oversized.close).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/listing exceeded \d+ bytes/u));
+    expect(manager.descriptors.map((descriptor) => descriptor.name)).toEqual(["healthy_search"]);
+
+    await manager.close();
+  });
+
+  it("isolates a listing that exceeds the retained candidate ceiling", async () => {
+    const overflowing = createClient({
+      tools: Array.from({ length: 16_385 }, (_, index) => tool(`tool-${index}`)),
+    });
+    const warn = vi.fn();
+    const manager = await startNodeHostMcpManager(
+      { overflowing: { command: "overflowing" } },
+      { createClient: () => overflowing, resolveTransport: () => transport, warn },
+    );
+
+    expect(overflowing.close).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("exceeded 16384 tools"));
+    expect(manager.descriptors).toEqual([]);
+
+    await manager.close();
+  });
+
+  it("closes a server when startup is aborted during paginated listing", async () => {
+    const controller = new AbortController();
+    const client = createClient({
+      list: async () =>
+        await new Promise<{ tools: Tool[] }>(() => {
+          // The startup abort owns closing the client behind this pending SDK request.
+        }),
+    });
+    const warn = vi.fn();
+    const starting = startNodeHostMcpManager(
+      { docs: { command: "docs" } },
+      {
+        createClient: () => client,
+        resolveTransport: () => transport,
+        signal: controller.signal,
+        warn,
+      },
+    );
+    await vi.waitFor(() => expect(client.listTools).toHaveBeenCalledOnce());
+
+    controller.abort();
+    const manager = await starting;
+
+    expect(client.close).toHaveBeenCalledOnce();
+    expect(manager.descriptors).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+    await manager.close();
+    expect(client.close).toHaveBeenCalledOnce();
   });
 
   it("cancels an in-flight MCP tool when its node invocation is aborted", async () => {

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -348,7 +348,7 @@ describe("node host MCP manager", () => {
       const manager = await starting;
 
       expect(slow.listTools).toHaveBeenCalledTimes(2);
-      expect(slow.listTools.mock.calls.map((call) => call[1]?.timeout)).toEqual([50, 20]);
+      expect(slow.listTools.mock.calls.map((call) => call[1]?.timeout)).toEqual([50, 50]);
       expect(slow.close).toHaveBeenCalledOnce();
       expect(warn).toHaveBeenCalledOnce();
       expect(warn).toHaveBeenCalledWith(expect.stringContaining("timed out after 50ms"));

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -18,7 +18,10 @@ function tool(name: string, description?: string): Tool {
 function createClient(params?: {
   connectError?: Error;
   tools?: Tool[];
-  list?: (params?: { cursor?: string }) => Promise<{ tools: Tool[]; nextCursor?: string }>;
+  list?: (
+    params?: { cursor?: string },
+    options?: { timeout?: number },
+  ) => Promise<{ tools: Tool[]; nextCursor?: string }>;
   call?: (options?: { timeout?: number; signal?: AbortSignal }) => Promise<CallToolResult>;
 }) {
   return {
@@ -28,8 +31,8 @@ function createClient(params?: {
         throw params.connectError;
       }
     }),
-    listTools: vi.fn(async (input?: { cursor?: string }) =>
-      params?.list ? await params.list(input) : { tools: params?.tools ?? [] },
+    listTools: vi.fn(async (input?: { cursor?: string }, options?: { timeout?: number }) =>
+      params?.list ? await params.list(input, options) : { tools: params?.tools ?? [] },
     ),
     callTool: vi.fn(
       async (
@@ -234,6 +237,34 @@ describe("node host MCP manager", () => {
     await manager.close();
   });
 
+  it("requests a second page when the opaque cursor is an empty string", async () => {
+    const client = createClient({
+      list: async (params) => {
+        if (params === undefined) {
+          return { tools: [tool("first")], nextCursor: "" };
+        }
+        expect(params).toEqual({ cursor: "" });
+        return { tools: [tool("second")] };
+      },
+    });
+    const manager = await startNodeHostMcpManager(
+      { docs: { command: "docs" } },
+      { createClient: () => client, resolveTransport: () => transport, warn: vi.fn() },
+    );
+
+    expect(client.listTools).toHaveBeenCalledTimes(2);
+    expect(client.listTools.mock.calls.map((call) => call[0])).toEqual([
+      undefined,
+      { cursor: "" },
+    ]);
+    expect(manager.descriptors.map((descriptor) => descriptor.mcp?.tool)).toEqual([
+      "first",
+      "second",
+    ]);
+
+    await manager.close();
+  });
+
   it("isolates a repeated pagination cursor while a sibling server survives", async () => {
     const looping = createClient({
       list: async () => ({ tools: [tool("loop")], nextCursor: "same" }),
@@ -289,6 +320,52 @@ describe("node host MCP manager", () => {
     expect(manager.descriptors.map((descriptor) => descriptor.name)).toEqual(["healthy_search"]);
 
     await manager.close();
+  });
+
+  it("isolates slow unique-cursor pagination at one catalog deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    try {
+      let page = 0;
+      const slow = createClient({
+        list: async () => {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 30);
+          });
+          page += 1;
+          return { tools: [tool(`tool-${page}`)], nextCursor: `cursor-${page}` };
+        },
+      });
+      const healthy = createClient({ tools: [tool("search")] });
+      const warn = vi.fn();
+      const starting = startNodeHostMcpManager(
+        { slow: { command: "slow" }, healthy: { command: "healthy" } },
+        {
+          createClient: (serverName) => (serverName === "slow" ? slow : healthy),
+          resolveTransport: () => ({ ...transport, requestTimeoutMs: 50 }),
+          warn,
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(50);
+      const manager = await starting;
+
+      expect(slow.listTools).toHaveBeenCalledTimes(2);
+      expect(slow.listTools.mock.calls.map((call) => call[1]?.timeout)).toEqual([50, 20]);
+      expect(slow.close).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("timed out after 50ms"));
+      expect(manager.descriptors.map((descriptor) => descriptor.name)).toEqual(["healthy_search"]);
+      await expect(manager.callMcpTool({ server: "healthy", tool: "search" })).resolves.toEqual({
+        content: [{ type: "text", text: "ok" }],
+      });
+
+      await vi.advanceTimersByTimeAsync(10);
+      await manager.close();
+      expect(healthy.close).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("isolates an oversized multi-page catalog at the accumulated byte ceiling", async () => {

--- a/src/node-host/mcp.test.ts
+++ b/src/node-host/mcp.test.ts
@@ -253,10 +253,7 @@ describe("node host MCP manager", () => {
     );
 
     expect(client.listTools).toHaveBeenCalledTimes(2);
-    expect(client.listTools.mock.calls.map((call) => call[0])).toEqual([
-      undefined,
-      { cursor: "" },
-    ]);
+    expect(client.listTools.mock.calls.map((call) => call[0])).toEqual([undefined, { cursor: "" }]);
     expect(manager.descriptors.map((descriptor) => descriptor.mcp?.tool)).toEqual([
       "first",
       "second",

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -275,10 +275,10 @@ async function listAllTools(
     maxItems: NODE_MCP_MAX_LISTED_TOOLS,
     maxBytes: NODE_MCP_MAX_CATALOG_BYTES,
     signal,
-    loadPage: async ({ cursor, timeoutMs: remainingTimeoutMs, signal: requestSignal }) => {
+    loadPage: async ({ cursor, requestTimeoutMs, signal: requestSignal }) => {
       const page = await client.listTools(cursor === undefined ? undefined : { cursor }, {
-        timeout: remainingTimeoutMs,
-        maxTotalTimeout: remainingTimeoutMs,
+        timeout: requestTimeoutMs,
+        maxTotalTimeout: requestTimeoutMs,
         signal: requestSignal,
       });
       return { items: page.tools, nextCursor: page.nextCursor, serializedValue: page };

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -10,6 +10,7 @@ import type { NodePluginToolDescriptor } from "../../packages/gateway-protocol/s
 import { matchesMcpToolFilterPattern } from "../agents/agent-bundle-mcp-filter.js";
 import { createMcpJsonSchemaValidator } from "../agents/mcp-json-schema-validator.js";
 import { sanitizeMcpMetadataText } from "../agents/mcp-metadata.js";
+import { collectMcpPaginatedItems } from "../agents/mcp-pagination.js";
 import { resolveMcpRequestTimeoutMs } from "../agents/mcp-transport-config.js";
 import { resolveMcpTransport } from "../agents/mcp-transport.js";
 import { normalizeConfiguredMcpServers } from "../config/mcp-config-normalize.js";
@@ -38,7 +39,7 @@ type NodeHostMcpClient = {
   connect(transport: Transport): Promise<void>;
   listTools(
     params?: { cursor?: string },
-    options?: { timeout?: number },
+    options?: { timeout?: number; maxTotalTimeout?: number; signal?: AbortSignal },
   ): Promise<{ tools: Tool[]; nextCursor?: string }>;
   callTool(
     params: { name: string; arguments?: Record<string, unknown> },
@@ -266,74 +267,30 @@ async function listAllTools(
   shouldInclude: (toolName: string) => boolean,
   signal?: AbortSignal,
 ): Promise<Tool[]> {
-  const listingTimeoutMs = clampPositiveTimerTimeoutMs(timeoutMs);
-  if (listingTimeoutMs === undefined) {
-    throw new Error("MCP tool listing requires a positive timeout");
-  }
-  const tools: Tool[] = [];
-  const seenCursors = new Set<string>();
-  let listingBytes = 0;
-  let cursor: string | undefined;
-  // One absolute deadline owns the complete catalog; each SDK request receives
-  // only the remaining budget so pagination cannot multiply requestTimeoutMs.
-  const deadlineAtMs = Date.now() + listingTimeoutMs;
-  let deadlineTimer: NodeJS.Timeout | undefined;
-  const deadline = new Promise<never>((_, reject) => {
-    deadlineTimer = setTimeout(
-      () => reject(new Error(`MCP tool listing timed out after ${listingTimeoutMs}ms`)),
-      listingTimeoutMs,
-    );
-    deadlineTimer.unref?.();
+  return await collectMcpPaginatedItems({
+    label: "MCP tool listing",
+    itemLabel: "tools",
+    timeoutMs,
+    maxPages: NODE_MCP_MAX_LIST_PAGES,
+    maxItems: NODE_MCP_MAX_LISTED_TOOLS,
+    maxBytes: NODE_MCP_MAX_CATALOG_BYTES,
+    signal,
+    loadPage: async ({ cursor, timeoutMs: remainingTimeoutMs, signal: requestSignal }) => {
+      const page = await client.listTools(cursor === undefined ? undefined : { cursor }, {
+        timeout: remainingTimeoutMs,
+        maxTotalTimeout: remainingTimeoutMs,
+        signal: requestSignal,
+      });
+      return { items: page.tools, nextCursor: page.nextCursor, serializedValue: page };
+    },
+    mapItem: (tool) => {
+      const toolName = tool.name.trim();
+      if (!toolName || !shouldInclude(toolName)) {
+        return undefined;
+      }
+      return { ...tool, name: toolName };
+    },
   });
-
-  try {
-    for (let pageNumber = 0; pageNumber < NODE_MCP_MAX_LIST_PAGES; pageNumber += 1) {
-      const remainingTimeoutMs = clampPositiveTimerTimeoutMs(deadlineAtMs - Date.now());
-      if (remainingTimeoutMs === undefined) {
-        throw new Error(`MCP tool listing timed out after ${listingTimeoutMs}ms`);
-      }
-      const page = await withAbort(
-        Promise.race([
-          client.listTools(cursor === undefined ? undefined : { cursor }, {
-            timeout: remainingTimeoutMs,
-          }),
-          deadline,
-        ]),
-        signal,
-      );
-      listingBytes += Buffer.byteLength(JSON.stringify(page));
-      if (listingBytes > NODE_MCP_MAX_CATALOG_BYTES) {
-        throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_CATALOG_BYTES} bytes`);
-      }
-
-      for (const tool of page.tools) {
-        const toolName = tool.name.trim();
-        if (!toolName || !shouldInclude(toolName)) {
-          continue;
-        }
-        if (tools.length >= NODE_MCP_MAX_LISTED_TOOLS) {
-          throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_LISTED_TOOLS} tools`);
-        }
-        tools.push({ ...tool, name: toolName });
-      }
-
-      const nextCursor = page.nextCursor;
-      if (nextCursor === undefined) {
-        return tools;
-      }
-      if (seenCursors.has(nextCursor)) {
-        throw new Error("MCP tool listing returned a repeated pagination cursor");
-      }
-      seenCursors.add(nextCursor);
-      cursor = nextCursor;
-    }
-
-    throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_LIST_PAGES} pages`);
-  } finally {
-    if (deadlineTimer) {
-      clearTimeout(deadlineTimer);
-    }
-  }
 }
 
 function resolveCallTimeoutMs(value: number | undefined): number {

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -266,44 +266,74 @@ async function listAllTools(
   shouldInclude: (toolName: string) => boolean,
   signal?: AbortSignal,
 ): Promise<Tool[]> {
+  const listingTimeoutMs = clampPositiveTimerTimeoutMs(timeoutMs);
+  if (listingTimeoutMs === undefined) {
+    throw new Error("MCP tool listing requires a positive timeout");
+  }
   const tools: Tool[] = [];
   const seenCursors = new Set<string>();
   let listingBytes = 0;
   let cursor: string | undefined;
-
-  for (let pageNumber = 0; pageNumber < NODE_MCP_MAX_LIST_PAGES; pageNumber += 1) {
-    const page = await withAbort(
-      client.listTools(cursor ? { cursor } : undefined, { timeout: timeoutMs }),
-      signal,
+  // One absolute deadline owns the complete catalog; each SDK request receives
+  // only the remaining budget so pagination cannot multiply requestTimeoutMs.
+  const deadlineAtMs = Date.now() + listingTimeoutMs;
+  let deadlineTimer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    deadlineTimer = setTimeout(
+      () => reject(new Error(`MCP tool listing timed out after ${listingTimeoutMs}ms`)),
+      listingTimeoutMs,
     );
-    listingBytes += Buffer.byteLength(JSON.stringify(page));
-    if (listingBytes > NODE_MCP_MAX_CATALOG_BYTES) {
-      throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_CATALOG_BYTES} bytes`);
+    deadlineTimer.unref?.();
+  });
+
+  try {
+    for (let pageNumber = 0; pageNumber < NODE_MCP_MAX_LIST_PAGES; pageNumber += 1) {
+      const remainingTimeoutMs = clampPositiveTimerTimeoutMs(deadlineAtMs - Date.now());
+      if (remainingTimeoutMs === undefined) {
+        throw new Error(`MCP tool listing timed out after ${listingTimeoutMs}ms`);
+      }
+      const page = await withAbort(
+        Promise.race([
+          client.listTools(cursor === undefined ? undefined : { cursor }, {
+            timeout: remainingTimeoutMs,
+          }),
+          deadline,
+        ]),
+        signal,
+      );
+      listingBytes += Buffer.byteLength(JSON.stringify(page));
+      if (listingBytes > NODE_MCP_MAX_CATALOG_BYTES) {
+        throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_CATALOG_BYTES} bytes`);
+      }
+
+      for (const tool of page.tools) {
+        const toolName = tool.name.trim();
+        if (!toolName || !shouldInclude(toolName)) {
+          continue;
+        }
+        if (tools.length >= NODE_MCP_MAX_LISTED_TOOLS) {
+          throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_LISTED_TOOLS} tools`);
+        }
+        tools.push({ ...tool, name: toolName });
+      }
+
+      const nextCursor = page.nextCursor;
+      if (nextCursor === undefined) {
+        return tools;
+      }
+      if (seenCursors.has(nextCursor)) {
+        throw new Error("MCP tool listing returned a repeated pagination cursor");
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
     }
 
-    for (const tool of page.tools) {
-      const toolName = tool.name.trim();
-      if (!toolName || !shouldInclude(toolName)) {
-        continue;
-      }
-      if (tools.length >= NODE_MCP_MAX_LISTED_TOOLS) {
-        throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_LISTED_TOOLS} tools`);
-      }
-      tools.push({ ...tool, name: toolName });
+    throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_LIST_PAGES} pages`);
+  } finally {
+    if (deadlineTimer) {
+      clearTimeout(deadlineTimer);
     }
-
-    const nextCursor = page.nextCursor;
-    if (!nextCursor) {
-      return tools;
-    }
-    if (seenCursors.has(nextCursor)) {
-      throw new Error("MCP tool listing returned a repeated pagination cursor");
-    }
-    seenCursors.add(nextCursor);
-    cursor = nextCursor;
   }
-
-  throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_LIST_PAGES} pages`);
 }
 
 function resolveCallTimeoutMs(value: number | undefined): number {

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -29,6 +29,9 @@ const NODE_MCP_ERROR_MAX_CHARS = 1_024;
 const NODE_MCP_MAX_DESCRIPTORS = 128;
 const NODE_MCP_MAX_DESCRIPTOR_BYTES = 1024 * 1024;
 const NODE_MCP_MAX_CATALOG_BYTES = 10 * 1024 * 1024;
+const NODE_MCP_MAX_LIST_PAGES = NODE_MCP_MAX_DESCRIPTORS;
+// The byte cap charges every response; this separately bounds retained tiny-tool object overhead.
+const NODE_MCP_MAX_LISTED_TOOLS = NODE_MCP_MAX_DESCRIPTORS * NODE_MCP_MAX_LIST_PAGES;
 
 type NodeHostMcpClient = {
   onclose?: () => void;
@@ -260,19 +263,47 @@ async function withAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined
 async function listAllTools(
   client: NodeHostMcpClient,
   timeoutMs: number,
+  shouldInclude: (toolName: string) => boolean,
   signal?: AbortSignal,
 ): Promise<Tool[]> {
   const tools: Tool[] = [];
+  const seenCursors = new Set<string>();
+  let listingBytes = 0;
   let cursor: string | undefined;
-  do {
+
+  for (let pageNumber = 0; pageNumber < NODE_MCP_MAX_LIST_PAGES; pageNumber += 1) {
     const page = await withAbort(
       client.listTools(cursor ? { cursor } : undefined, { timeout: timeoutMs }),
       signal,
     );
-    tools.push(...page.tools);
-    cursor = page.nextCursor;
-  } while (cursor);
-  return tools;
+    listingBytes += Buffer.byteLength(JSON.stringify(page));
+    if (listingBytes > NODE_MCP_MAX_CATALOG_BYTES) {
+      throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_CATALOG_BYTES} bytes`);
+    }
+
+    for (const tool of page.tools) {
+      const toolName = tool.name.trim();
+      if (!toolName || !shouldInclude(toolName)) {
+        continue;
+      }
+      if (tools.length >= NODE_MCP_MAX_LISTED_TOOLS) {
+        throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_LISTED_TOOLS} tools`);
+      }
+      tools.push({ ...tool, name: toolName });
+    }
+
+    const nextCursor = page.nextCursor;
+    if (!nextCursor) {
+      return tools;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error("MCP tool listing returned a repeated pagination cursor");
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+
+  throw new Error(`MCP tool listing exceeded ${NODE_MCP_MAX_LIST_PAGES} pages`);
 }
 
 function resolveCallTimeoutMs(value: number | undefined): number {
@@ -341,16 +372,15 @@ export async function startNodeHostMcpManager(
           deps.signal,
         );
         session.connected = true;
-        const tools = (await listAllTools(client, resolved.requestTimeoutMs, deps.signal)).filter(
-          (tool) => {
-            const toolName = tool.name.trim();
-            return Boolean(toolName) && shouldExposeTool(config, toolName);
-          },
+        const tools = await listAllTools(
+          client,
+          resolved.requestTimeoutMs,
+          (toolName) => shouldExposeTool(config, toolName),
+          deps.signal,
         );
         for (const tool of tools) {
-          const toolName = tool.name.trim();
-          session.tools.add(toolName);
-          listedTools.push({ serverName, tool: { ...tool, name: toolName } });
+          session.tools.add(tool.name);
+          listedTools.push({ serverName, tool });
         }
         sessions.set(serverName, session);
       } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an MCP server could keep node-host or agent-session catalog loading alive indefinitely with repeated or endless pagination cursors, multiply the configured timeout per page, grow retained results without bound, or silently lose later pages when the valid opaque cursor was an empty string.

## Why This Change Was Made

One shared MCP pagination owner now governs node-host tools and session-bundle tools, resources, and prompts. It preserves opaque cursors, detects cursor cycles, caps pages/items/serialized bytes, applies one absolute deadline with remaining per-page budgets, composes caller cancellation, and rechecks cancellation/deadline after synchronous final-page processing. Each runtime keeps its existing filtering and ordering behavior and isolates only the offending MCP server.

## User Impact

A malformed or unresponsive MCP server can no longer hang catalog startup or utility listing indefinitely, starve healthy sibling servers, or force unbounded catalog accumulation. Normal multi-page servers continue to return complete ordered results within their configured budget.

## Evidence

- Exact-head Testbox proof passed 116/116 focused tests across the shared paginator, node-host manager, and real session-bundle MCP runtime on `tbx_01kyw39g39ng77pbnpvdmr1b4g`, run `30631751241`.
- The complete changed gate passed on the same exact head, including core/core-test typechecks, lint, formatting, Knip, Plugin SDK/API boundaries, database-first, sidecar, cycle, webhook, and pairing guards.
- Direct pinned `@modelcontextprotocol/sdk` 1.30.0 source/types confirm that cursors are arbitrary strings (including empty), `nextCursor` is optional, and request timeout/`maxTotalTimeout` are per SDK request; OpenClaw therefore owns the multi-page deadline.
- Tests cover normal multi-page tool/resource/prompt results, empty cursors, repeated and cyclic cursors, endless unique cursors, page/item/byte caps, remaining absolute deadlines, caller abort, runtime disposal, final-page synchronous deadline crossing, synchronous abort with a resolved page, healthy sibling survival, and global node descriptor ordering.
- Final autoreview was clean at 0.96. Independent final review was clean at 0.99 after confirming the empty-cursor, aggregate-deadline, and post-final-page timing findings were resolved.

No protocol, configuration, dependency, persisted-state, or MCP output-shape changes.
