### PR TITLE
fix(qa): keep memory context proof on the QA channel

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -50,6 +50,10 @@ describe("qa scenario catalog channel contracts", () => {
     }
   });
 
+  it("keeps the memory channel-context proof on the internal QA channel", () => {
+    expect(readQaScenarioById("memory-tools-channel-context").execution.channel).toBe("qa-channel");
+  });
+
   it("marks live transport modules as live-driver-only", () => {
     for (const scenarioId of [
       "matrix-approval-exec-metadata-single-event",

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -579,6 +579,10 @@ describe("qa scenario catalog", () => {
     });
   });
 
+  it("keeps the memory channel-context proof on the internal QA channel", () => {
+    expect(readQaScenarioById("memory-tools-channel-context").execution.channel).toBe("qa-channel");
+  });
+
   it("loads live gateway sentinel scenarios for harness self-health", () => {
     const scenarioIds = [
       "plugin-hook-health-sentinel",

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -579,10 +579,6 @@ describe("qa scenario catalog", () => {
     });
   });
 
-  it("keeps the memory channel-context proof on the internal QA channel", () => {
-    expect(readQaScenarioById("memory-tools-channel-context").execution.channel).toBe("qa-channel");
-  });
-
   it("loads live gateway sentinel scenarios for harness self-health", () => {
     const scenarioIds = [
       "plugin-hook-health-sentinel",

--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -20,6 +20,7 @@ scenario:
     - extensions/qa-lab/src/suite.ts
   execution:
     kind: flow
+    channel: qa-channel
     summary: Verify the agent uses memory tools in a shared channel when the answer lives only in memory files, not the live transcript.
     config:
       channelId: qa-memory-room


### PR DESCRIPTION
## What Problem This Solves

The memory channel-context scenario is an internal QA Channel proof, but without an explicit channel it can be selected by live-channel release lanes as though it were channel-agnostic.

## Why This Change Was Made

Declare the scenario's existing execution channel as `qa-channel` and cover that catalog contract. The earlier Codex watchdog changes in this branch are now superseded by main's canonical suite-level runtime selection and were removed during rebase.

## User Impact

No shipped product behavior or configuration changes. Release QA no longer routes this internal memory proof into unrelated live-channel lanes.

## Evidence

- Focused Testbox proof passed: `pnpm test extensions/qa-lab/src/scenario-catalog-channels.test.ts -- -t 'keeps the memory channel-context proof on the internal QA channel'`
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/30684331174
- `git diff --check` passed
- Fresh autoreview clean (0.99)
- The full catalog file currently also exposes the unrelated stale subagent-fanout assertion fixed by #117202
