### PR TITLE
fix(google): restore image generation with blank base URL

### DIFF
--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -255,6 +255,21 @@ describe("google generative ai helpers", () => {
     expect(apiKeyHeaders["x-goog-api-client"]).toMatch(/^openclaw\//u);
   });
 
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])("defaults a %s shared request base URL", (_label, baseUrl) => {
+    const config = resolveGoogleGenerativeAiHttpRequestConfig({
+      apiKey: "api-key-123",
+      baseUrl,
+      capability: "video",
+      transport: "media-understanding",
+    });
+
+    expect(config.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta");
+    expect(new Headers(config.headers).get("x-goog-api-client")).toMatch(/^openclaw\//u);
+  });
+
   it("preserves explicit OpenAI-compatible Google endpoints during provider normalization", () => {
     expect(
       resolveGoogleGenerativeAiTransport({

--- a/extensions/google/api.test.ts
+++ b/extensions/google/api.test.ts
@@ -40,6 +40,8 @@ describe("google generative ai helpers", () => {
     expect(normalizeGoogleGenerativeAiBaseUrl("https://xgenerativelanguage.googleapis.com")).toBe(
       "https://xgenerativelanguage.googleapis.com",
     );
+    expect(normalizeGoogleGenerativeAiBaseUrl("")).toBeUndefined();
+    expect(normalizeGoogleGenerativeAiBaseUrl("   ")).toBeUndefined();
     expect(normalizeGoogleGenerativeAiBaseUrl()).toBeUndefined();
   });
 

--- a/extensions/google/api.ts
+++ b/extensions/google/api.ts
@@ -50,9 +50,9 @@ type GoogleGenerativeAiRequestOverrides = ProviderRequestTransportOverrides & {
 };
 
 function resolveTrustedGoogleGenerativeAiBaseUrl(baseUrl?: string): string {
-  const normalized =
-    normalizeGoogleGenerativeAiBaseUrl(baseUrl ?? DEFAULT_GOOGLE_API_BASE_URL) ??
-    DEFAULT_GOOGLE_API_BASE_URL;
+  // Config validation can materialize an absent provider URL as an empty string.
+  // Native Google HTTP callers must still use the canonical Gemini endpoint.
+  const normalized = normalizeGoogleGenerativeAiBaseUrl(baseUrl) || DEFAULT_GOOGLE_API_BASE_URL;
   let url: URL;
   try {
     url = new URL(normalized);

--- a/extensions/google/api.ts
+++ b/extensions/google/api.ts
@@ -80,8 +80,9 @@ export function resolveGoogleGenerativeAiHttpRequestConfig(params: {
   capability: "image" | "audio" | "video";
   transport: "http" | "media-understanding";
 }) {
+  const baseUrl = resolveTrustedGoogleGenerativeAiBaseUrl(params.baseUrl);
   return resolveProviderHttpRequestConfig({
-    baseUrl: resolveTrustedGoogleGenerativeAiBaseUrl(params.baseUrl),
+    baseUrl,
     defaultBaseUrl: DEFAULT_GOOGLE_API_BASE_URL,
     allowPrivateNetwork: params.request?.allowPrivateNetwork,
     headers: params.headers,
@@ -89,7 +90,7 @@ export function resolveGoogleGenerativeAiHttpRequestConfig(params: {
     defaultHeaders: {
       ...parseGeminiAuth(params.apiKey).headers,
       ...resolveGoogleApiClientHeaders({
-        baseUrl: params.baseUrl,
+        baseUrl,
         api: "google-generative-ai",
         capability: params.capability,
         transport: params.transport,

--- a/extensions/google/api.ts
+++ b/extensions/google/api.ts
@@ -50,9 +50,7 @@ type GoogleGenerativeAiRequestOverrides = ProviderRequestTransportOverrides & {
 };
 
 function resolveTrustedGoogleGenerativeAiBaseUrl(baseUrl?: string): string {
-  // Config validation can materialize an absent provider URL as an empty string.
-  // Native Google HTTP callers must still use the canonical Gemini endpoint.
-  const normalized = normalizeGoogleGenerativeAiBaseUrl(baseUrl) || DEFAULT_GOOGLE_API_BASE_URL;
+  const normalized = normalizeGoogleGenerativeAiBaseUrl(baseUrl) ?? DEFAULT_GOOGLE_API_BASE_URL;
   let url: URL;
   try {
     url = new URL(normalized);

--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -168,6 +168,38 @@ describe("Google image-generation provider", () => {
     });
   });
 
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])(
+    "uses the default Gemini API root when the configured base URL is %s",
+    async (_label, baseUrl) => {
+      mockGoogleApiKeyAuth();
+      const fetchMock = installGoogleFetchMock();
+
+      const provider = buildGoogleImageGenerationProvider();
+      await provider.generateImage({
+        provider: "google",
+        model: "gemini-3.1-flash-image",
+        prompt: "draw a cat",
+        cfg: {
+          models: {
+            providers: {
+              google: {
+                baseUrl,
+                models: [],
+              },
+            },
+          },
+        },
+      });
+
+      expect(fetchRequest(fetchMock).url).toBe(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent",
+      );
+    },
+  );
+
   it("passes request SSRF policy to the provider HTTP helper", async () => {
     mockGoogleApiKeyAuth();
     const postJsonRequest = vi.spyOn(providerHttp, "postJsonRequest").mockResolvedValue({

--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -194,9 +194,11 @@ describe("Google image-generation provider", () => {
         },
       });
 
-      expect(fetchRequest(fetchMock).url).toBe(
+      const request = fetchRequest(fetchMock);
+      expect(request.url).toBe(
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent",
       );
+      expect(new Headers(request.headers).get("x-goog-api-client")).toMatch(/^openclaw\//u);
     },
   );
 

--- a/extensions/google/media-understanding-provider.video.test.ts
+++ b/extensions/google/media-understanding-provider.video.test.ts
@@ -179,6 +179,27 @@ describe("describeGeminiVideo", () => {
     expect(new Headers(init?.headers).get("x-goog-api-client")).toMatch(/^openclaw\//u);
   });
 
+  it("uses the canonical endpoint for blank audio base URLs", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({
+      candidates: [{ content: { parts: [{ text: "audio ok" }] } }],
+    });
+
+    await transcribeGeminiAudio({
+      buffer: Buffer.from("audio-bytes"),
+      fileName: "clip.wav",
+      apiKey: "test-key",
+      baseUrl: "   ",
+      timeoutMs: 1500,
+      fetchFn,
+    });
+
+    const { url, init } = getRequest();
+    expect(url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent",
+    );
+    expect(new Headers(init?.headers).get("x-goog-api-client")).toMatch(/^openclaw\//u);
+  });
+
   it("bounds oversized video JSON responses and closes the stream early", async () => {
     const { server, closed } = createOversizedJsonServer();
     const port = await listenLoopbackServer(server);

--- a/extensions/google/media-understanding-provider.video.test.ts
+++ b/extensions/google/media-understanding-provider.video.test.ts
@@ -158,6 +158,27 @@ describe("describeGeminiVideo", () => {
     );
   });
 
+  it("uses the canonical endpoint for an empty configured base URL", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({
+      candidates: [{ content: { parts: [{ text: "video ok" }] } }],
+    });
+
+    await describeGeminiVideo({
+      buffer: Buffer.from("video-bytes"),
+      fileName: "clip.mp4",
+      apiKey: "test-key",
+      baseUrl: "",
+      timeoutMs: 1500,
+      fetchFn,
+    });
+
+    const { url, init } = getRequest();
+    expect(url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent",
+    );
+    expect(new Headers(init?.headers).get("x-goog-api-client")).toMatch(/^openclaw\//u);
+  });
+
   it("bounds oversized video JSON responses and closes the stream early", async () => {
     const { server, closed } = createOversizedJsonServer();
     const port = await listenLoopbackServer(server);

--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -452,6 +452,39 @@ describe("Google speech provider", () => {
     expect(new Headers(request.headers).get("x-goog-api-key")).toBe("env-google-key");
   });
 
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])(
+    "uses the canonical endpoint for a %s Google model-provider base URL",
+    async (_label, baseUrl) => {
+      const requestMock = installGoogleTtsRequestMock();
+      const provider = buildGoogleSpeechProvider();
+
+      await provider.synthesize({
+        text: "Read this plainly.",
+        cfg: {
+          models: {
+            providers: {
+              google: {
+                baseUrl,
+                models: [],
+              },
+            },
+          },
+        },
+        providerConfig: { apiKey: "google-test-key" },
+        target: "audio-file",
+        timeoutMs: 10_000,
+      });
+
+      const request = expectRecordFields(requireFirstRecordArg(requestMock, "Google TTS request"), {
+        url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent",
+      }) as { headers?: HeadersInit };
+      expect(new Headers(request.headers).get("x-goog-api-client")).toMatch(/^openclaw\//u);
+    },
+  );
+
   it("can reuse a configured Google model-provider API key without auth profiles", async () => {
     const requestMock = installGoogleTtsRequestMock();
     const provider = buildGoogleSpeechProvider();

--- a/extensions/google/src/google-api-base-url.ts
+++ b/extensions/google/src/google-api-base-url.ts
@@ -75,11 +75,12 @@ export function isGoogleGenerativeAiApi(api?: string | null): boolean {
 }
 
 export function normalizeGoogleGenerativeAiBaseUrl(baseUrl?: string): string | undefined {
-  if (!baseUrl) {
-    return baseUrl;
+  const raw = normalizeOptionalString(baseUrl);
+  if (!raw) {
+    return undefined;
   }
 
-  const normalized = normalizeGoogleApiBaseUrl(baseUrl);
+  const normalized = normalizeGoogleApiBaseUrl(raw);
   try {
     const url = new URL(normalized);
     stripUrlUserInfo(url);


### PR DESCRIPTION
Closes #111550

## What Problem This Solves

Fixes an issue where operators using the bundled Google provider could not generate images, transcribe audio, describe video, or synthesize speech when an absent provider `baseUrl` reached runtime as an empty or whitespace-only string.

This is a maintainer replacement for the closed, uneditable contribution at https://github.com/openclaw/openclaw/pull/112380. The two original implementation commits retain Ted Li as their author.

## Why This Change Was Made

Blank URL semantics now live in the shared Google Generative AI URL normalizer: empty and whitespace-only inputs normalize to "absent", while the native HTTP request resolver remains the single HTTPS and exact-`generativelanguage.googleapis.com` trust gate. The resolver reuses its validated canonical URL for both request dispatch and OpenClaw client attribution.

The graph-confirmed native HTTP callers all share this contract:

- image generation;
- media understanding for audio and video;
- Google TTS.

Explicit malformed URLs, non-HTTPS URLs, and non-Google hosts remain rejected before credentials are sent. SDK-backed Google media paths already omit blank overrides and therefore continue to use the SDK default.

Official contract checks:

- Google documents `generativelanguage.googleapis.com/v1beta/models/*:generateContent` as the Gemini API route: https://ai.google.dev/api
- `@google/genai` 2.13.0 treats a falsy `httpOptions.baseUrl` as absent before client initialization: https://github.com/googleapis/js-genai/blob/main/src/_base_url.ts

## User Impact

Direct Google image generation and the sibling audio, video, and speech capabilities now use the canonical Gemini endpoint when provider configuration supplies a blank URL. Operators no longer need to add the default endpoint manually or fall back to another provider.

## Evidence

- Exact head: `6731a88f153e990930bf007c567dbb947ae8fb5a`
- Rebased onto: `978a449968a2378096d84f73d6b02d16c32582b3`
- The prior manual CI failure was an unrelated protocol-since guard on the ancient merge-base snapshot. The rebased patch is unchanged, and its exact-merge focused suite passed again.
- Production delta: `+8/-8` across two files, net zero.
- Test delta: `+126/-0` across four files.
- Focused Node 24.18 proof, run twice on the final implementation:
  - `node scripts/run-vitest.mjs extensions/google/api.test.ts extensions/google/image-generation-provider.test.ts extensions/google/media-understanding-provider.video.test.ts extensions/google/speech-provider.test.ts`
  - 4 files passed, 64 tests passed.
- Targeted `oxfmt --check`: passed.
- Targeted type-aware `oxlint` with `config/tsconfig/oxlint.extensions.json`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Autoreview cycle 1: clean, no accepted or actionable findings.
- Secret scan in autoreview: clean.

The broader local extension typecheck could not complete because the shared local dependency install is stale: current `main` requires `string-width` 8.2.2 for `packages/terminal-core`, but the package-local dependency link is absent and TypeScript resolves an incompatible one-argument declaration at `packages/terminal-core/src/ansi.ts:194`. The changed Google files pass targeted type-aware lint. Remote changed-gate fallback was unavailable because the configured Crabbox providers lack broker authentication; exact-head GitHub CI is running.

Quota-backed image-generation proof is externally blocked on this machine: no `GEMINI_API_KEY` or `GOOGLE_API_KEY` is present, and the local OpenClaw configuration has neither a Google provider entry nor a Google auth profile. No credential was invented, copied, or exposed.

## Credit

Implementation originally authored by Ted Li (@MonkeyLeeT) in https://github.com/openclaw/openclaw/pull/112380. This replacement preserves Ted's authorship and adds maintainer-owned shared-normalizer and sibling-consumer coverage.
