### PR TITLE
feat(plugins): externalize Volcengine provider

### DIFF
--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-63 plugins
+62 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -167,8 +167,6 @@ Each entry lists the package, distribution route, and description.
 
 - **[vllm](/plugins/reference/vllm)** (`@openclaw/vllm-provider`) - included in OpenClaw. Adds vLLM model provider support to OpenClaw.
 
-- **[volcengine](/plugins/reference/volcengine)** (`@openclaw/volcengine-provider`) - included in OpenClaw. Adds Volcengine, Volcengine Plan model provider support to OpenClaw.
-
 - **[web-readability](/plugins/reference/web-readability)** (`@openclaw/web-readability-plugin`) - included in OpenClaw. Extract readable article content from local HTML web fetch responses.
 
 - **[webhooks](/plugins/reference/webhooks)** (`@openclaw/webhooks`) - included in OpenClaw. Authenticated inbound webhooks that bind external automation to OpenClaw TaskFlows.
@@ -181,7 +179,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-82 plugins
+83 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -332,6 +330,8 @@ Each entry lists the package, distribution route, and description.
 - **[vercel-ai-gateway](/plugins/reference/vercel-ai-gateway)** (`@openclaw/vercel-ai-gateway-provider`) - npm; ClawHub: `clawhub:@openclaw/vercel-ai-gateway-provider`. Adds Vercel AI Gateway model provider support to OpenClaw.
 
 - **[voice-call](/plugins/reference/voice-call)** (`@openclaw/voice-call`) - npm; ClawHub. OpenClaw voice-call plugin for Twilio, Telnyx, and Plivo phone calls.
+
+- **[volcengine](/plugins/reference/volcengine)** (`@openclaw/volcengine-provider`) - npm; ClawHub: `clawhub:@openclaw/volcengine-provider`. Adds Volcengine, Volcengine Plan model provider support to OpenClaw.
 
 - **[voyage](/plugins/reference/voyage)** (`@openclaw/voyage-provider`) - npm; ClawHub: `clawhub:@openclaw/voyage-provider`. Adds memory embedding provider support.
 

--- a/docs/plugins/reference/volcengine.md
+++ b/docs/plugins/reference/volcengine.md
@@ -12,7 +12,7 @@ Adds Volcengine, Volcengine Plan model provider support to OpenClaw.
 ## Distribution
 
 - Package: `@openclaw/volcengine-provider`
-- Install route: included in OpenClaw
+- Install route: npm; ClawHub: `clawhub:@openclaw/volcengine-provider`
 
 ## Surface
 

--- a/docs/providers/volcengine.md
+++ b/docs/providers/volcengine.md
@@ -7,7 +7,7 @@ read_when:
   - You want to use Volcengine Speech text-to-speech
 ---
 
-The Volcengine provider gives access to Doubao models and third-party models hosted on Volcano Engine, with separate endpoints for general and coding workloads. The same bundled plugin also registers Volcengine Speech as a TTS provider.
+The Volcengine provider gives access to Doubao models and third-party models hosted on Volcano Engine, with separate endpoints for general and coding workloads. The same official plugin also registers Volcengine Speech as a TTS provider.
 
 | Detail     | Value                                                      |
 | ---------- | ---------------------------------------------------------- |
@@ -19,6 +19,12 @@ The Volcengine provider gives access to Doubao models and third-party models hos
 ## Getting started
 
 <Steps>
+  <Step title="Install the plugin">
+    ```bash
+    openclaw plugins install @openclaw/volcengine-provider
+    openclaw gateway restart
+    ```
+  </Step>
   <Step title="Set the API key">
     Run interactive onboarding:
 

--- a/extensions/volcengine/README.md
+++ b/extensions/volcengine/README.md
@@ -1,0 +1,13 @@
+# OpenClaw Volcengine Provider
+
+Official OpenClaw provider plugin for Volcengine models, the Volcengine coding
+plan, and Volcengine Speech text-to-speech.
+
+Install from OpenClaw:
+
+```bash
+openclaw plugins install @openclaw/volcengine-provider
+openclaw gateway restart
+```
+
+See <https://docs.openclaw.ai/providers/volcengine> for model and speech setup.

--- a/extensions/volcengine/package.json
+++ b/extensions/volcengine/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@openclaw/volcengine-provider",
   "version": "2026.7.2",
-  "private": true,
-  "description": "OpenClaw Volcengine provider plugin",
+  "description": "OpenClaw Volcengine provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
@@ -10,6 +13,23 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/volcengine-provider",
+      "npmSpec": "@openclaw/volcengine-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.7.2"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -316,6 +316,7 @@
     "!dist/extensions/venice/**",
     "!dist/extensions/vercel-ai-gateway/**",
     "!dist/extensions/voice-call/**",
+    "!dist/extensions/volcengine/**",
     "!dist/extensions/voyage/**",
     "!dist/extensions/vydra/**",
     "!dist/extensions/whatsapp/**",

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -1805,6 +1805,75 @@
       }
     },
     {
+      "name": "@openclaw/volcengine-provider",
+      "description": "OpenClaw Volcengine provider plugin.",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "volcengine",
+          "label": "Volcengine"
+        },
+        "providers": [
+          {
+            "id": "volcengine",
+            "aliases": [
+              "volcengine-plan"
+            ],
+            "name": "Volcengine",
+            "docs": "/providers/volcengine",
+            "categories": [
+              "cloud",
+              "llm"
+            ],
+            "envVars": [
+              "VOLCANO_ENGINE_API_KEY"
+            ],
+            "authChoices": [
+              {
+                "method": "api-key",
+                "choiceId": "volcengine-api-key",
+                "choiceLabel": "Volcano Engine API key",
+                "groupId": "volcengine",
+                "groupLabel": "Volcano Engine",
+                "groupHint": "API key",
+                "optionKey": "volcengineApiKey",
+                "cliFlag": "--volcengine-api-key",
+                "cliOption": "--volcengine-api-key <key>",
+                "cliDescription": "Volcano Engine API key",
+                "onboardingScopes": [
+                  "text-inference"
+                ]
+              }
+            ]
+          },
+          {
+            "id": "volcengine-plan",
+            "name": "Volcengine Plan",
+            "docs": "/providers/volcengine",
+            "categories": [
+              "cloud",
+              "llm"
+            ],
+            "envVars": [
+              "VOLCANO_ENGINE_API_KEY"
+            ]
+          }
+        ],
+        "contracts": {
+          "speechProviders": [
+            "volcengine"
+          ]
+        },
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/volcengine-provider",
+          "npmSpec": "@openclaw/volcengine-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.7.2"
+        }
+      }
+    },
+    {
       "name": "@openclaw/stepfun-provider",
       "description": "OpenClaw StepFun provider plugin.",
       "source": "official",

--- a/src/cli/plugins-location-bridges.test.ts
+++ b/src/cli/plugins-location-bridges.test.ts
@@ -168,6 +168,7 @@ describe("listPersistedBundledPluginLocationBridges", () => {
     ["duckduckgo", "@openclaw/duckduckgo-plugin", false],
     ["synthetic", "@openclaw/synthetic-provider", true],
     ["teams-meetings", "@openclaw/teams-meetings", true],
+    ["volcengine", "@openclaw/volcengine-provider", true],
     ["voyage", "@openclaw/voyage-provider", true],
     ["vydra", "@openclaw/vydra-provider", true],
     ["zoom-meetings", "@openclaw/zoom-meetings", true],

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -2039,6 +2039,32 @@ describe("official external plugin catalog", () => {
     });
   });
 
+  it("lists Volcengine model and speech providers as one official external plugin", () => {
+    const entry = expectCatalogEntry("volcengine");
+    const manifest = getOfficialExternalPluginCatalogManifest(entry);
+    const volcengine = manifest?.providers?.find((provider) => provider.id === "volcengine");
+
+    expect(resolveOfficialExternalPluginId(entry)).toBe("volcengine");
+    expect(getOfficialExternalPluginCatalogEntry("volcengine-plan")).toBe(entry);
+    expect(resolveOfficialExternalPluginInstall(entry)).toEqual({
+      clawhubSpec: "clawhub:@openclaw/volcengine-provider",
+      npmSpec: "@openclaw/volcengine-provider",
+      defaultChoice: "npm",
+      minHostVersion: ">=2026.7.2",
+    });
+    expect(volcengine?.aliases).toEqual(["volcengine-plan"]);
+    expect(volcengine?.authChoices?.[0]).toMatchObject({
+      choiceId: "volcengine-api-key",
+      optionKey: "volcengineApiKey",
+      onboardingScopes: ["text-inference"],
+    });
+    expect(manifest?.providers?.map((provider) => provider.id)).toEqual([
+      "volcengine",
+      "volcengine-plan",
+    ]);
+    expect(manifest?.contracts?.speechProviders).toEqual(["volcengine"]);
+  });
+
   it.each([
     ["teams-meetings", "@openclaw/teams-meetings", "teams_meetings", "teams"],
     ["zoom-meetings", "@openclaw/zoom-meetings", "zoom_meetings", "zoom"],

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -391,6 +391,14 @@ describe("bundled plugin build entries", () => {
     expect(artifacts).not.toContain("dist/extensions/voyage/package.json");
   });
 
+  it("excludes the externalized Volcengine provider from bundled artifacts", () => {
+    const artifacts = listBundledPluginPackArtifacts();
+
+    expect(artifacts).not.toContain("dist/extensions/volcengine/index.js");
+    expect(artifacts).not.toContain("dist/extensions/volcengine/openclaw.plugin.json");
+    expect(artifacts).not.toContain("dist/extensions/volcengine/package.json");
+  });
+
   it("keeps bundled channel secret contracts on packed top-level sidecars", () => {
     const artifacts = listBundledPluginPackArtifacts();
     const excludedPackageDirs = collectRootPackageExcludedExtensionDirs();


### PR DESCRIPTION
## What Problem This Solves

Volcengine is still bundled into the core OpenClaw npm package even though its
model, coding-plan, and speech surfaces are fully plugin-owned. That increases
the default distribution and leaves Volcengine on a different installation
lifecycle from other official providers.

## Why This Change Was Made

This publishes Volcengine as the official external
`@openclaw/volcengine-provider` package and excludes it from core artifacts.
The official catalog preserves `volcengine`, `volcengine-plan`, their shared
auth choice/alias, and the `speechProviders` contract. The persisted bundled
location bridge keeps upgrades installable through the official npm route.

## User Impact

New installations can install Volcengine independently from npm or ClawHub.
Existing installations that recorded the bundled plugin retain default
enablement while converging to the external package. Model, coding-plan, and
Volcengine TTS behavior are unchanged.

## Evidence

- Exact reviewed head: `dac6ec8148a8722fc28fd198de2bda1e36adc630`
- 133 focused tests passed across Volcengine runtime, official catalog,
  location bridging, and bundled artifact generation.
- Plugin inventory generation/check passed with 62 core and 83 official
  external packages.
- Plugin npm release metadata check passed for
  `@openclaw/volcengine-provider@2026.7.2`.
- Core build-entry and pack-artifact probes confirm no
  `dist/extensions/volcengine/**` output remains.
- Exact-head Codex autoreview: clean, no accepted/actionable findings,
  confidence 0.91.

AI-assisted: yes. The implementation and generated surfaces were reviewed and
validated as described above.
