### PR TITLE
fix(models): expose runtime provider catalogs in browse views

### DIFF
--- a/src/agents/model-catalog-browse.test.ts
+++ b/src/agents/model-catalog-browse.test.ts
@@ -26,8 +26,8 @@ function config(params: { providerWildcard?: boolean } = {}): OpenClawConfig {
     agents: params.providerWildcard
       ? {
           defaults: {
-            models: {
-              "openai/*": {},
+            modelPolicy: {
+              allow: ["openai/*"],
             },
           },
         }
@@ -70,7 +70,7 @@ describe("loadPreparedModelCatalogSnapshotForBrowse", () => {
     expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
   });
 
-  it("uses the read-only catalog when configured visibility has provider wildcards", async () => {
+  it("uses the full catalog for default views with provider wildcards", async () => {
     const loadCatalog = vi.fn(async ({ readOnly }: { readOnly: boolean }) =>
       readOnly ? readOnlyCatalog : fullCatalog,
     );
@@ -80,9 +80,9 @@ describe("loadPreparedModelCatalogSnapshotForBrowse", () => {
         cfg: config({ providerWildcard: true }),
         loadCatalog,
       }),
-    ).resolves.toBe(readOnlyCatalog);
+    ).resolves.toBe(fullCatalog);
 
-    expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: true });
+    expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
   });
 
   it("uses the full catalog for configured views with provider wildcards", async () => {
@@ -101,17 +101,78 @@ describe("loadPreparedModelCatalogSnapshotForBrowse", () => {
     expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
   });
 
-  it.each([
-    ["without picker allowlists", config()],
-    ["with provider wildcards", config({ providerWildcard: true })],
-  ])("uses the read-only catalog for provider-config views %s", async (_label, cfg) => {
+  it("uses the read-only catalog for provider-config views without picker allowlists", async () => {
     const loadCatalog = vi.fn(async ({ readOnly }: { readOnly: boolean }) =>
       readOnly ? readOnlyCatalog : fullCatalog,
     );
 
     await expect(
-      loadPreparedModelCatalogSnapshotForBrowse({ cfg, view: "provider-config", loadCatalog }),
+      loadPreparedModelCatalogSnapshotForBrowse({
+        cfg: config(),
+        view: "provider-config",
+        loadCatalog,
+      }),
     ).resolves.toBe(readOnlyCatalog);
+
+    expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: true });
+  });
+
+  it("uses the full catalog for provider-config views with provider wildcards", async () => {
+    const loadCatalog = vi.fn(async ({ readOnly }: { readOnly: boolean }) =>
+      readOnly ? readOnlyCatalog : fullCatalog,
+    );
+
+    await expect(
+      loadPreparedModelCatalogSnapshotForBrowse({
+        cfg: config({ providerWildcard: true }),
+        view: "provider-config",
+        loadCatalog,
+      }),
+    ).resolves.toBe(fullCatalog);
+
+    expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
+  });
+
+  it("uses the selected agent's provider wildcard", async () => {
+    const loadCatalog = vi.fn(async ({ readOnly }: { readOnly: boolean }) =>
+      readOnly ? readOnlyCatalog : fullCatalog,
+    );
+    const cfg = {
+      agents: {
+        defaults: { modelPolicy: { allow: ["openai/gpt-5.6"] } },
+        list: [{ id: "research", modelPolicy: { allow: ["litellm/*"] } }],
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      loadPreparedModelCatalogSnapshotForBrowse({
+        cfg,
+        agentId: "research",
+        view: "provider-config",
+        loadCatalog,
+      }),
+    ).resolves.toBe(fullCatalog);
+
+    expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
+  });
+
+  it("keeps the read-only catalog for default views with legacy models wildcards", async () => {
+    const loadCatalog = vi.fn(async ({ readOnly }: { readOnly: boolean }) =>
+      readOnly ? readOnlyCatalog : fullCatalog,
+    );
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/*": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(loadPreparedModelCatalogSnapshotForBrowse({ cfg, loadCatalog })).resolves.toBe(
+      readOnlyCatalog,
+    );
 
     expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: true });
   });
@@ -143,13 +204,13 @@ describe("loadPreparedModelCatalogSnapshotForBrowse", () => {
     ]);
   });
 
-  it("returns an empty catalog when read-only catalog loading times out with provider wildcards", async () => {
+  it("returns an empty catalog when read-only catalog loading times out", async () => {
     vi.useFakeTimers();
     const onTimeout = vi.fn();
     const loadCatalog = vi.fn(() => new Promise<ModelCatalogSnapshot>(() => {}));
 
     const resultPromise = loadPreparedModelCatalogSnapshotForBrowse({
-      cfg: config({ providerWildcard: true }),
+      cfg: config(),
       loadCatalog,
       timeoutMs: 5,
       onTimeout,
@@ -179,6 +240,28 @@ describe("loadPreparedModelCatalogSnapshotForBrowse", () => {
     expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
     expect(onTimeout).toHaveBeenCalledExactlyOnceWith(5);
   });
+
+  it.each(["default", "provider-config"] as const)(
+    "bounds implicit full discovery for %s wildcard views",
+    async (view) => {
+      vi.useFakeTimers();
+      const onTimeout = vi.fn();
+      const loadCatalog = vi.fn(() => new Promise<ModelCatalogSnapshot>(() => {}));
+
+      const resultPromise = loadPreparedModelCatalogSnapshotForBrowse({
+        cfg: config({ providerWildcard: true }),
+        view,
+        loadCatalog,
+        timeoutMs: 5,
+        onTimeout,
+      });
+
+      await vi.advanceTimersByTimeAsync(5);
+      await expect(resultPromise).resolves.toEqual({ entries: [], routeVariants: [] });
+      expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
+      expect(onTimeout).toHaveBeenCalledExactlyOnceWith(5);
+    },
+  );
 
   it("uses the default timeout when timeoutMs is non-finite", async () => {
     const onTimeout = vi.fn();

--- a/src/agents/model-catalog-browse.ts
+++ b/src/agents/model-catalog-browse.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
   buildConfiguredModelCatalog,
+  LEGACY_MODEL_POLICY_ALLOW_CONFIG_PATH,
   parseConfiguredModelVisibilityEntries,
 } from "./model-selection-shared.js";
 
@@ -37,14 +38,30 @@ export function buildProviderConfigModelCatalogForBrowse(params: {
 /** True when a browse view requires the full published catalog generation. */
 export function modelCatalogBrowseRequiresFullDiscovery(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   view?: ModelCatalogBrowseView;
 }): boolean {
   const view = params.view ?? "default";
-  return (
-    view === "all" ||
-    (view === "configured" &&
-      parseConfiguredModelVisibilityEntries({ cfg: params.cfg }).providerWildcards.size > 0)
-  );
+  if (view === "all") {
+    return true;
+  }
+  const visibility = parseConfiguredModelVisibilityEntries({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+  if (visibility.providerWildcards.size === 0) {
+    return false;
+  }
+  // An explicit modelPolicy.allow provider wildcard makes model pickers,
+  // configured views, and provider-config inventory resolve against the
+  // discovered catalog so key-scoped runtime rows appear without an explicit
+  // allowlist entry (see openclaw#115953). Legacy agents.defaults.models
+  // wildcard entries keep the historical read-only default path and only
+  // escalate the configured view, as before.
+  if (visibility.configPath === LEGACY_MODEL_POLICY_ALLOW_CONFIG_PATH) {
+    return view === "configured";
+  }
+  return true;
 }
 
 function resolveModelCatalogBrowseTimeoutMs(value: number | undefined): number {
@@ -56,6 +73,7 @@ function resolveModelCatalogBrowseTimeoutMs(value: number | undefined): number {
 
 async function loadCatalogForBrowse<T>(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   view?: ModelCatalogBrowseView;
   loadCatalog: (params: { readOnly: boolean }) => Promise<T>;
   empty: T;
@@ -64,8 +82,18 @@ async function loadCatalogForBrowse<T>(params: {
   onTimeout?: (timeoutMs: number) => void;
 }): Promise<T> {
   const view = params.view ?? "default";
-  const requiresFullDiscovery = modelCatalogBrowseRequiresFullDiscovery({ cfg: params.cfg, view });
-  if (requiresFullDiscovery && !params.timeoutFullDiscovery) {
+  const requiresFullDiscovery = modelCatalogBrowseRequiresFullDiscovery({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    view,
+  });
+  // Provider-policy wildcards newly escalate ordinary inventory views to live discovery.
+  // Keep those implicit loads within the browse deadline; explicit all/configured loads retain
+  // their existing completion semantics unless the caller requests a timeout.
+  const shouldTimeoutFullDiscovery =
+    params.timeoutFullDiscovery ||
+    (requiresFullDiscovery && (view === "default" || view === "provider-config"));
+  if (requiresFullDiscovery && !shouldTimeoutFullDiscovery) {
     return await params.loadCatalog({ readOnly: false });
   }
 
@@ -97,6 +125,7 @@ async function loadCatalogForBrowse<T>(params: {
 /** Loads an explicit logical/physical catalog snapshot for route-aware browse surfaces. */
 export function loadPreparedModelCatalogSnapshotForBrowse(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   view?: ModelCatalogBrowseView;
   loadCatalog: (params: { readOnly: boolean }) => Promise<ModelCatalogSnapshot>;
   timeoutFullDiscovery?: boolean;

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -1515,6 +1515,7 @@ export function normalizeModelSelection(value: unknown): string | undefined {
 
 const DEFAULT_MODEL_POLICY_ALLOW_CONFIG_PATH = "agents.defaults.modelPolicy.allow";
 const AGENT_MODEL_POLICY_ALLOW_CONFIG_PATH = "agents.entries.*.modelPolicy.allow";
+export const LEGACY_MODEL_POLICY_ALLOW_CONFIG_PATH = "agents.defaults.models";
 
 function resolvePolicyAliasAgentId(
   configPath: string | null,
@@ -1554,7 +1555,7 @@ export function resolveConfiguredModelPolicyAllow(params: {
   if (legacyDefaultRefs) {
     return {
       refs: legacyDefaultRefs,
-      configPath: "agents.defaults.models",
+      configPath: LEGACY_MODEL_POLICY_ALLOW_CONFIG_PATH,
       repairConfigPath: DEFAULT_MODEL_POLICY_ALLOW_CONFIG_PATH,
     };
   }

--- a/src/agents/models-config.plan.test-support.ts
+++ b/src/agents/models-config.plan.test-support.ts
@@ -6,6 +6,7 @@ import type { ProviderConfig } from "./models-config.providers.secrets.js";
 type ResolveImplicitProvidersForModelsJson = (params: {
   agentDir: string;
   config: OpenClawConfig;
+  discoveryAuthConfig?: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   workspaceDir?: string;
   explicitProviders: Record<string, ProviderConfig>;
@@ -21,6 +22,7 @@ type PlanResult = Awaited<
 >;
 type ResolveProvidersParams = {
   cfg: OpenClawConfig;
+  discoveryAuthConfig?: OpenClawConfig;
   agentDir: string;
   env: NodeJS.ProcessEnv;
   workspaceDir?: string;

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -32,6 +32,7 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 type ResolveImplicitProvidersForModelsJson = (params: {
   agentDir: string;
   config: OpenClawConfig;
+  discoveryAuthConfig?: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   workspaceDir?: string;
   explicitProviders: Record<string, ProviderConfig>;
@@ -100,6 +101,7 @@ function buildPluginCatalogWrites(
 async function resolveProvidersForModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
+    discoveryAuthConfig?: OpenClawConfig;
     agentDir: string;
     env: NodeJS.ProcessEnv;
     workspaceDir?: string;
@@ -128,6 +130,7 @@ async function resolveProvidersForModelsJsonWithDeps(
   const implicitProviders = await resolveImplicitProvidersImpl({
     agentDir,
     config: cfg,
+    ...(params.discoveryAuthConfig ? { discoveryAuthConfig: params.discoveryAuthConfig } : {}),
     env,
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     explicitProviders,
@@ -212,6 +215,7 @@ function filterWritableProviders(
 async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
+    discoveryAuthConfig?: OpenClawConfig;
     sourceConfigForSecrets?: OpenClawConfig;
     agentDir: string;
     env: NodeJS.ProcessEnv;
@@ -232,6 +236,7 @@ async function planOpenClawModelsJsonWithDeps(
   const providers = await resolveProvidersForModelsJsonWithDeps(
     {
       cfg,
+      ...(params.discoveryAuthConfig ? { discoveryAuthConfig: params.discoveryAuthConfig } : {}),
       agentDir,
       env,
       ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),

--- a/src/agents/models-config.providers.auth-provenance.test.ts
+++ b/src/agents/models-config.providers.auth-provenance.test.ts
@@ -352,4 +352,31 @@ describe("models-config provider auth provenance", () => {
       source: "none",
     });
   });
+
+  it("keeps non-env SecretRef markers discovery-key-free when unresolved", () => {
+    const auth = createProviderApiKeyResolver(
+      {} as NodeJS.ProcessEnv,
+      {
+        version: 1,
+        profiles: {},
+      },
+      {
+        models: {
+          providers: {
+            vllm: {
+              baseUrl: "http://127.0.0.1:8000/v1",
+              apiKey: { source: "file", provider: "mounted-json", id: "/providers/vllm/apiKey" },
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(auth("vllm")).toEqual({
+      apiKey: NON_ENV_SECRETREF_MARKER,
+      discoveryApiKey: undefined,
+    });
+  });
 });

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -58,6 +58,7 @@ type ImplicitProviderParams = {
   agentDir: string;
   authStore?: AuthProfileStore;
   config?: OpenClawConfig;
+  discoveryAuthConfig?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   workspaceDir?: string;
   explicitProviders?: Record<string, ProviderConfig> | null;
@@ -600,15 +601,6 @@ export async function resolveImplicitProviders(
       allowKeychainPrompt: false,
       externalCliProviderIds: params.providerDiscoveryProviderIds,
     }));
-  const context: ImplicitProviderContext = {
-    ...params,
-    get authStore() {
-      return getAuthStore();
-    },
-    env,
-    resolveProviderApiKey: createProviderApiKeyResolver(env, getAuthStore, params.config),
-    resolveProviderAuth: createProviderAuthResolver(env, getAuthStore, params.config),
-  };
   const discoveryPluginIds = resolveProviderDiscoveryFilter({
     config: params.config,
     workspaceDir: params.workspaceDir,
@@ -618,6 +610,18 @@ export async function resolveImplicitProviders(
       : undefined,
     providerIds: params.providerDiscoveryProviderIds,
   });
+  // The runtime config has already resolved SecretRefs at its owning boundary.
+  // Re-resolving source refs here would execute unrelated file/exec providers on catalog reads.
+  const discoveryAuthConfig = params.discoveryAuthConfig ?? params.config;
+  const context: ImplicitProviderContext = {
+    ...params,
+    get authStore() {
+      return getAuthStore();
+    },
+    env,
+    resolveProviderApiKey: createProviderApiKeyResolver(env, getAuthStore, discoveryAuthConfig),
+    resolveProviderAuth: createProviderAuthResolver(env, getAuthStore, discoveryAuthConfig),
+  };
   const preparedStaticEntries = params.preparedStaticProviderCatalog
     ? params.preparedStaticProviderCatalog.entries.filter(
         ({ provider }) =>

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -338,7 +338,6 @@ function resolveConfigBackedProviderAuth(params: {
     }
     return {
       apiKey: resolveNonEnvSecretRefApiKeyMarker(configuredApiKeyRef.source),
-      discoveryApiKey: undefined,
       mode: "api_key",
       source: "config",
     };

--- a/src/agents/models-config.replace-mode-skip-implicit-discovery.test.ts
+++ b/src/agents/models-config.replace-mode-skip-implicit-discovery.test.ts
@@ -118,4 +118,53 @@ describe("models-config plan: replace mode skips implicit discovery", () => {
 
     expect(resolveImplicitSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("forwards resolved runtime config separately from source config", async () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          explicit: {
+            ...createExplicitProvider(),
+            apiKey: { source: "exec", provider: "must-not-run", id: "explicit" },
+          },
+        },
+      },
+    };
+    const discoveryAuthConfig: OpenClawConfig = {
+      models: {
+        providers: {
+          explicit: {
+            ...createExplicitProvider(),
+            apiKey: "resolved-runtime-key",
+          },
+        },
+      },
+    };
+    const resolveImplicitSpy = vi.fn(async () => ({}));
+
+    await resolveProvidersForModelsJsonWithDeps(
+      {
+        cfg,
+        discoveryAuthConfig,
+        agentDir: "/tmp/openclaw-models-config-auth-test",
+        env: {},
+      },
+      { resolveImplicitProviders: resolveImplicitSpy },
+    );
+
+    expect(resolveImplicitSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          models: expect.objectContaining({
+            providers: expect.objectContaining({
+              explicit: expect.objectContaining({
+                apiKey: { source: "exec", provider: "must-not-run", id: "explicit" },
+              }),
+            }),
+          }),
+        }),
+        discoveryAuthConfig,
+      }),
+    );
+  });
 });

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -88,6 +88,7 @@ async function readFileMtimeMs(pathname: string): Promise<number | null> {
 
 async function buildModelsJsonFingerprint(params: {
   config: OpenClawConfig;
+  discoveryAuthConfig: OpenClawConfig;
   sourceConfigForSecrets: OpenClawConfig;
   agentDir: string;
   workspaceDir?: string;
@@ -110,6 +111,7 @@ async function buildModelsJsonFingerprint(params: {
     : undefined;
   return stableStringify({
     config: params.config,
+    discoveryAuthConfigHash: hashRuntimeConfigValue(params.discoveryAuthConfig),
     sourceConfigForSecrets: params.sourceConfigForSecrets,
     envShape: params.env ? hashRuntimeConfigValue(envShape) : envShape,
     authProfilesMtimeMs,
@@ -250,6 +252,7 @@ function writePluginCatalogsForModelsJson(params: {
 
 function resolveModelsConfigInput(config?: OpenClawConfig): {
   config: OpenClawConfig;
+  discoveryAuthConfig: OpenClawConfig;
   sourceConfigForSecrets: OpenClawConfig;
 } {
   const runtimeSource = getRuntimeConfigSourceSnapshot();
@@ -257,18 +260,21 @@ function resolveModelsConfigInput(config?: OpenClawConfig): {
     const loaded = getRuntimeConfig();
     return {
       config: runtimeSource ?? loaded,
+      discoveryAuthConfig: loaded,
       sourceConfigForSecrets: runtimeSource ?? loaded,
     };
   }
   if (!runtimeSource) {
     return {
       config,
+      discoveryAuthConfig: config,
       sourceConfigForSecrets: config,
     };
   }
   const projected = projectConfigOntoRuntimeSourceSnapshot(config);
   return {
     config: projected,
+    discoveryAuthConfig: config,
     // If projection is skipped (for example incompatible top-level shape),
     // keep managed secret persistence anchored to the active source snapshot.
     sourceConfigForSecrets: projected === config ? runtimeSource : projected,
@@ -307,6 +313,7 @@ async function buildModelsJsonSourceFingerprint(
   const agentDir = agentDirOverride?.trim() ? agentDirOverride.trim() : resolveDefaultAgentDir(cfg);
   const fingerprint = await buildModelsJsonFingerprint({
     config: cfg,
+    discoveryAuthConfig: resolved.discoveryAuthConfig,
     sourceConfigForSecrets: resolved.sourceConfigForSecrets,
     agentDir,
     ...(workspaceDir ? { workspaceDir } : {}),
@@ -382,6 +389,7 @@ async function prepareOpenClawModelsJsonSource(
     });
     const plan = await planOpenClawModelsJson({
       cfg,
+      discoveryAuthConfig: resolved.discoveryAuthConfig,
       sourceConfigForSecrets: resolved.sourceConfigForSecrets,
       agentDir,
       env,
@@ -438,6 +446,7 @@ async function prepareOpenClawModelsJsonSource(
     const settled = await pending;
     const refreshedFingerprint = await buildModelsJsonFingerprint({
       config: cfg,
+      discoveryAuthConfig: resolved.discoveryAuthConfig,
       sourceConfigForSecrets: resolved.sourceConfigForSecrets,
       agentDir,
       ...(workspaceDir ? { workspaceDir } : {}),
@@ -511,6 +520,7 @@ export async function planOpenClawModelsJsonSource(
   const env = createConfigRuntimeEnv(cfg, options.env);
   const plan = await planOpenClawModelsJson({
     cfg,
+    discoveryAuthConfig: resolved.discoveryAuthConfig,
     sourceConfigForSecrets: resolved.sourceConfigForSecrets,
     agentDir,
     env,

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -673,7 +673,9 @@ export async function prepareAgentCatalogSource(
           providerDiscoveryEntriesOnly: true as const,
           providerDiscoveryProviderIds: providerIds,
         }
-      : { providerDiscoveryTimeoutMs: MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS }),
+      : {
+          providerDiscoveryTimeoutMs: MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS,
+        }),
   };
   if (!persist) {
     const source = await planOpenClawModelsJsonSource(input.config, input.agentDir, options);

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -49,11 +49,13 @@ const mocks = vi.hoisted(() => {
         wrote: false,
       }),
     ),
-    planOpenClawModelsJsonSource: vi.fn(async (_config: unknown, agentDir: unknown) => ({
-      agentDir: String(agentDir),
-      modelsJsonContents: null,
-      pluginCatalogs: [],
-    })),
+    planOpenClawModelsJsonSource: vi.fn(
+      async (_config: unknown, agentDir: unknown, _options?: unknown) => ({
+        agentDir: String(agentDir),
+        modelsJsonContents: null,
+        pluginCatalogs: [],
+      }),
+    ),
     buildPreparedModelCatalogSnapshot: vi.fn(async () => ({ entries: [], routeVariants: [] })),
     ensureRuntimePluginsLoaded: vi.fn(),
     loadStaticCatalog: vi.fn(async () => []),
@@ -298,6 +300,8 @@ describe("prepared model runtime Gateway catalog mode", () => {
         providerDiscoveryTimeoutMs: 5_000,
       }),
     );
+    const fullCatalogOptions = mocks.planOpenClawModelsJsonSource.mock.calls[0]?.[2];
+    expect(fullCatalogOptions).not.toHaveProperty("providerDiscoveryProviderIds");
     expect(mocks.buildPreparedModelCatalogSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({ includeProviderPluginAugmentation: true }),
     );

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -626,6 +626,7 @@ describe("prepared model runtime snapshots", () => {
     );
     expect(mocks.discoverModels).toHaveBeenCalledOnce();
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+    expect(mocks.planOpenClawModelsJsonSource).not.toHaveBeenCalled();
     expect(mocks.ensureRuntimePluginsLoaded).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -170,6 +170,7 @@ export async function buildModelsProviderData(
 
   const snapshot = await loadPreparedModelCatalogSnapshotForBrowse({
     cfg,
+    agentId,
     view: options.view ?? "default",
     loadCatalog: ({ readOnly }) =>
       loadPreparedModelCatalogSnapshot({

--- a/src/gateway/server-methods/chat-startup-projection-memo.ts
+++ b/src/gateway/server-methods/chat-startup-projection-memo.ts
@@ -112,7 +112,13 @@ async function buildChatStartupMetadataResult(params: {
   if (!params.modelCatalog) {
     return undefined;
   }
-  if (modelCatalogBrowseRequiresFullDiscovery({ cfg: params.cfg, view: "configured" })) {
+  if (
+    modelCatalogBrowseRequiresFullDiscovery({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      view: "configured",
+    })
+  ) {
     return undefined;
   }
   try {

--- a/src/gateway/server-methods/models-list-result.openai-routes.test.ts
+++ b/src/gateway/server-methods/models-list-result.openai-routes.test.ts
@@ -22,9 +22,14 @@ function catalogEntry(id: string, api: ModelCatalogEntry["api"]): ModelCatalogEn
   return { id, name: id, provider: "openai", api };
 }
 
+function providerCatalogEntry(provider: string, id: string): ModelCatalogEntry {
+  return { ...catalogEntry(id, "openai-completions"), provider };
+}
+
 async function listModels(params: {
   catalog: ModelCatalogEntry[];
   cfg?: OpenClawConfig;
+  discoveryModes?: Record<string, "refreshable" | "runtime" | "static">;
   routeResolverFactory?: typeof createOpenAIModelRoutesResolver;
   view?: "all" | "configured" | "provider-config" | "default";
 }) {
@@ -46,6 +51,22 @@ async function listModels(params: {
   return await buildModelsListResult({
     context,
     params: { view: params.view ?? "all" },
+    ...(params.discoveryModes
+      ? {
+          preloadedCatalog: {
+            agentId: "main",
+            config,
+            snapshot: { entries: params.catalog, routeVariants: params.catalog },
+          },
+          catalogProjector: {
+            metadataSnapshot: {
+              plugins: [
+                { id: "test-provider", modelCatalog: { discovery: params.discoveryModes } },
+              ],
+            },
+          } as never,
+        }
+      : {}),
     ...(params.routeResolverFactory ? { routeResolverFactory: params.routeResolverFactory } : {}),
   });
 }
@@ -846,6 +867,62 @@ describe("models.list OpenAI routes", () => {
           },
         ],
       });
+    });
+  });
+
+  it("includes runtime-discovered rows for configured providers without explicit models", async () => {
+    await withEnvAsync(WITHOUT_OPENAI_ENV_AUTH, async () => {
+      const cfg = {
+        models: {
+          providers: {
+            litellm: {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:14004",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      await expect(
+        listModels({
+          cfg,
+          discoveryModes: { litellm: "runtime" },
+          view: "provider-config",
+          catalog: [
+            providerCatalogEntry("litellm", "model-a"),
+            providerCatalogEntry("litellm", "model-b"),
+          ],
+        }),
+      ).resolves.toEqual({
+        models: [
+          expect.objectContaining({ id: "model-a", provider: "litellm" }),
+          expect.objectContaining({ id: "model-b", provider: "litellm" }),
+        ],
+      });
+    });
+  });
+
+  it("does not infer runtime inventory for static providers without explicit models", async () => {
+    await withEnvAsync(WITHOUT_OPENAI_ENV_AUTH, async () => {
+      const cfg = {
+        models: {
+          providers: {
+            kimi: {
+              api: "openai-completions",
+              baseUrl: "https://api.kimi.com/coding/v1",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      await expect(
+        listModels({
+          cfg,
+          discoveryModes: { kimi: "static" },
+          view: "provider-config",
+          catalog: [providerCatalogEntry("kimi", "kimi-for-coding")],
+        }),
+      ).resolves.toEqual({ models: [] });
     });
   });
 

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -260,9 +260,38 @@ function resolveGatewayModelCatalogRouteKey(entry: ModelCatalogEntry): string {
   );
 }
 
+/** Configured dynamic-catalog providers that omit explicit model inventory. */
+function listConfiguredRuntimeDiscoveryProviderIds(
+  cfg: OpenClawConfig,
+  metadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">,
+): Set<string> {
+  const ids = new Set<string>();
+  const providers = cfg.models?.providers;
+  if (!providers || typeof providers !== "object" || !metadataSnapshot) {
+    return ids;
+  }
+  const dynamicProviders = new Set<string>();
+  for (const plugin of metadataSnapshot.plugins) {
+    for (const [providerRaw, mode] of Object.entries(plugin.modelCatalog?.discovery ?? {})) {
+      const providerId = normalizeProviderId(providerRaw);
+      if (providerId && (mode === "runtime" || mode === "refreshable")) {
+        dynamicProviders.add(providerId);
+      }
+    }
+  }
+  for (const [providerRaw, provider] of Object.entries(providers)) {
+    const providerId = normalizeProviderId(providerRaw);
+    if (providerId && dynamicProviders.has(providerId) && !Array.isArray(provider?.models)) {
+      ids.add(providerId);
+    }
+  }
+  return ids;
+}
+
 function resolveProviderConfigInventoryEntries(params: {
   authoredEntries: readonly ModelCatalogEntry[];
   canonicalEntries: readonly ModelCatalogEntry[];
+  discoveryOnlyProviderIds?: ReadonlySet<string>;
 }): ModelCatalogEntry[] {
   const canonicalByKey = new Map<string, ModelCatalogEntry>();
   for (const entry of params.canonicalEntries) {
@@ -282,6 +311,21 @@ function resolveProviderConfigInventoryEntries(params: {
     // Authored config owns inventory membership. Canonical catalog rows own
     // route metadata; configured logical overrides are applied by the projector.
     inventory.push(canonicalByKey.get(key) ?? authoredEntry);
+  }
+  if (params.discoveryOnlyProviderIds) {
+    // Providers configured without explicit model lists (for example litellm)
+    // surface their key-scoped discovered rows as the configured inventory.
+    for (const canonicalEntry of params.canonicalEntries) {
+      const key = resolveGatewayModelCatalogRouteKey(canonicalEntry);
+      if (seen.has(key)) {
+        continue;
+      }
+      if (!params.discoveryOnlyProviderIds.has(normalizeProviderId(canonicalEntry.provider))) {
+        continue;
+      }
+      seen.add(key);
+      inventory.push(canonicalEntry);
+    }
   }
   return inventory;
 }
@@ -510,6 +554,7 @@ export async function buildModelsListResult(
   };
   let snapshot = await loadPreparedModelCatalogSnapshotForBrowse({
     cfg: initialConfig,
+    agentId: initialAgentId,
     view,
     loadCatalog: async (loadParams) => {
       loadedReadOnly = loadParams.readOnly ?? true;
@@ -531,13 +576,18 @@ export async function buildModelsListResult(
   if (
     loadedSnapshot &&
     loadedReadOnly &&
-    modelCatalogBrowseRequiresFullDiscovery({ cfg: loadedSnapshot.config, view })
+    modelCatalogBrowseRequiresFullDiscovery({
+      cfg: loadedSnapshot.config,
+      agentId: loadedSnapshot.agentId,
+      view,
+    })
   ) {
     const escalationAgentId = loadedSnapshot.agentId;
     let escalationTimedOut = false;
     let fullSnapshot: typeof loadedSnapshot | undefined;
     const escalatedCatalog = await loadPreparedModelCatalogSnapshotForBrowse({
       cfg: loadedSnapshot.config,
+      agentId: escalationAgentId,
       view,
       loadCatalog: async ({ readOnly }) => {
         fullSnapshot = await params.context.loadGatewayModelCatalogSnapshot({
@@ -595,6 +645,10 @@ export async function buildModelsListResult(
       entries: resolveProviderConfigInventoryEntries({
         authoredEntries,
         canonicalEntries: catalog,
+        discoveryOnlyProviderIds: listConfiguredRuntimeDiscoveryProviderIds(
+          sourceConfig,
+          metadataSnapshot,
+        ),
       }),
       routeVariants,
     };

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -420,6 +420,59 @@ describe("models.list", () => {
     });
   });
 
+  it("does not block wildcard provider inventory on slow full discovery", async () => {
+    const catalog = createDeferred<never>();
+    const loadGatewayModelCatalog = vi.fn(() => catalog.promise);
+    const runtimeConfig = {
+      agents: {
+        defaults: {
+          modelPolicy: { allow: ["vllm/*"] },
+        },
+      },
+      models: {
+        providers: {
+          vllm: {
+            baseUrl: "https://vllm.example/v1",
+            models: [{ id: "llama-local", name: "Llama Local" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const { request, respond } = requestModelsList({
+        view: "provider-config",
+        runtimeConfig,
+        loadGatewayModelCatalog,
+        reqId: "req-models-list-wildcard-provider-timeout",
+      });
+
+      await vi.advanceTimersByTimeAsync(800);
+      await vi.runOnlyPendingTimersAsync();
+      await request;
+
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        {
+          models: [
+            {
+              id: "llama-local",
+              name: "Llama Local",
+              provider: "vllm",
+            },
+          ],
+        },
+        undefined,
+      );
+      expect(loadGatewayModelCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({ readOnly: false }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps SecretRef configured fallback rows unknown when catalog discovery times out", async () => {
     const catalog = createDeferred<never>();
     const loadGatewayModelCatalog = vi.fn(() => catalog.promise);


### PR DESCRIPTION
## What Problem This Solves

Runtime-discovered provider models, such as LiteLLM `/v1/models`, were missing from CLI and Gateway browse views on clean instances. The regression came from #116261: startup catalog preparation was bounded correctly, but browse-time catalog projection reused the static/read-only snapshot and never materialized the runtime provider inventory.

This revision keeps startup static and makes browse-time discovery explicit:

- full catalog browse loads use the live, unscoped discovery path;
- provider-wildcard browse requests are agent-aware;
- runtime discovery uses the already-resolved runtime config for authentication while persisted/source projections retain SecretRef markers;
- configured providers inherit discovery-only rows only when their manifest declares `runtime` or `refreshable` discovery;
- static providers do not inherit unrelated canonical catalog rows;
- read-only persisted snapshots remain capture-only and do not acquire live planning side effects.

## Change Type

- [x] Bug fix
- [x] Refactor required for the fix
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [x] Auth / tokens
- [x] Integrations
- [ ] Skills / tool execution
- [ ] Memory / storage
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #115953
- Regression source: #116261 (`a67ad03eea4b9953af9ccac89173a67d396413b1`)

## Implementation

- Thread `agentId` through catalog browse, command, Gateway, and chat-startup projection callers so wildcard policy is resolved for the correct agent.
- Return both source-projected config and the already-resolved runtime config from model-config input resolution.
- Include a runtime-auth config hash in the prepared catalog fingerprint without persisting raw secret material.
- Pass runtime auth config into implicit provider discovery while continuing to serialize source SecretRef markers.
- Keep full-catalog discovery unscoped; keep startup/static discovery provider-scoped.
- Restrict configured-provider discovery inheritance to manifest-declared dynamic providers.

## Root Cause

`prepareAgentCatalogSource` after #116261 correctly stopped startup from doing broad runtime discovery, but browse views shared the resulting static/read-only path. A provider wildcard therefore had no route to a live full catalog on a clean home, and configured providers without explicit model rows had no inventory to project.

## Evidence

Exact reviewed head: `e644d217c88186e1ea1c7bc6845068e5a1c94760`

- Focused agents and Gateway suites: 205 tests green across model-config auth/source projection, implicit discovery, prepared-runtime lifecycle/static startup, browse policy, and `models.list` routes.
- Late timeout regression reruns: 18/18 agent tests and 50/50 Gateway route tests green, including pending-provider fallback for wildcard default and provider-config views./
- `git diff --check`: clean.
- `oxfmt`: clean on all changed files.
- Native-ghx Blacksmith Testbox changed gate: exit 0, including core and core-test `tsgo`, changed-file oxlint, plugin boundaries, dead exports, import cycles, schema/storage guards, and repository policy guards.
  - https://github.com/openclaw/openclaw/actions/runs/30674596502
- Autoreview through P1: no findings, patch correct, confidence 0.86.
- TruffleHog exact-bundle scan: clean.

Contributor-supplied behavior evidence on the original branch used a clean `OPENCLAW_HOME`, a mock LiteLLM `/v1/models` endpoint, env-key and file-SecretRef authentication, CLI `models list`, and all four Gateway `models.list` views. The rewritten tests preserve those invariants without adding eager SecretRef execution to catalog reads.

## Regression Test Plan

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/models-config.replace-mode-skip-implicit-discovery.test.ts src/agents/models-config.providers.auth-provenance.test.ts src/agents/model-catalog-browse.test.ts src/agents/prepared-model-runtime.startup-static.test.ts src/agents/prepared-model-runtime.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-methods.config.ts src/gateway/server-methods/models-list-result.openai-routes.test.ts src/gateway/server-methods/models.test.ts`
- `node scripts/check-changed.mjs`

## User-visible / Behavior Changes

CLI and Gateway model browse views can include runtime-discovered rows for configured dynamic providers on clean instances. Gateway startup remains discovery-free, and static providers do not gain inferred runtime inventory.

## Security Impact

- [x] New permissions/capabilities? No.
- [x] Secrets/tokens handling changed? Yes. Discovery consumes the already-resolved runtime config; source and persisted projections retain SecretRef markers. Catalog reads do not introduce a second eager file/exec SecretRef resolution path.
- [x] New/changed network calls? Browse-time full discovery can execute existing provider discovery hooks. Startup remains static.
- [x] Command/tool execution surface changed? No new surface.
- [x] Data access scope changed? No.

## Compatibility / Migration

- [x] Backward compatible.
- [x] No config or environment-variable changes.
- [x] No migration required.

## Best-fix Verdict

Yes. The fix preserves the startup latency boundary introduced by #116261 while restoring runtime discovery at the browse owner boundary. It avoids broadening read-only persistence, avoids duplicate secret resolution, honors per-agent policy, and prevents static providers from inheriting dynamic inventory.

## Risks and Mitigations

- Runtime browse may wait for provider discovery. Implicit wildcard default and provider-config loads use the 750 ms browse fallback; explicit all/configured loads retain their existing semantics./
- Secret-backed discovery could regress source persistence. Auth-provenance and source-marker tests pin the split between runtime credentials and persisted config.
- Provider inventory could leak across provider classes. Positive LiteLLM and negative static-provider tests pin manifest-gated inheritance.

## AI Assistance

- AI-assisted: yes.
- Human maintainer review, focused tests, exact changed-gate proof, and external autoreview completed.