### PR TITLE
fix(ai): normalize Moonshot/Kimi tool schemas with parent-level anyOf (#113130)

### DIFF
--- a/packages/ai/src/internal/openai.ts
+++ b/packages/ai/src/internal/openai.ts
@@ -3,6 +3,7 @@ export * from "../providers/azure-deployment-map.js";
 export * from "../providers/azure-openai-responses-client-compat.js";
 export * from "../providers/clean-for-gemini.js";
 export * from "../providers/clean-for-llamacpp-gbnf.js";
+export * from "../providers/clean-for-moonshot.js";
 export * from "../providers/openai-completions.js";
 export * from "../providers/openai-prompt-cache.js";
 export * from "../providers/openai-reasoning-effort.js";

--- a/packages/ai/src/providers/agent-tools-parameter-schema.ts
+++ b/packages/ai/src/providers/agent-tools-parameter-schema.ts
@@ -12,6 +12,7 @@ import {
 import type { TSchema } from "typebox";
 import { cleanSchemaForGemini } from "./clean-for-gemini.js";
 import { cleanSchemaForLlamacppGbnf } from "./clean-for-llamacpp-gbnf.js";
+import { cleanSchemaForMoonshot } from "./clean-for-moonshot.js";
 import { stripUnsupportedSchemaKeywords } from "./schema-keyword-strip.js";
 
 /**
@@ -106,6 +107,10 @@ function rememberCachedToolParameterSchema(schema: object, key: string, value: T
 
 function isGeminiModelId(modelId: string): boolean {
   return /(?:^|[/:])gemini(?:$|[-/:.])/.test(modelId);
+}
+
+function isKimiModelId(modelId: string): boolean {
+  return /(?:^|[/:])kimi(?:$|[-/:.])/.test(modelId);
 }
 
 function extractEnumValues(schema: unknown): unknown[] | undefined {
@@ -817,6 +822,8 @@ function normalizeToolParameterSchemaUncached(
   //   (TypeBox root unions compile to `{ anyOf: [...] }` without `type`).
   // - Anthropic expects full JSON Schema draft 2020-12 compliance.
   // - xAI's documented tool-schema contract rejects contains-count bounds.
+  // - Moonshot's "flavored" schema validator rejects `type` declared next to
+  //   anyOf/oneOf/allOf; every branch must declare its own `type`.
   //
   // Normalize once here so callers can always pass `tools` through unchanged.
   const normalizedProvider = normalizeLowercaseStringOrEmpty(options?.modelProvider);
@@ -829,6 +836,11 @@ function normalizeToolParameterSchemaUncached(
     normalizedProvider.includes("gemini") ||
     isGeminiModelId(normalizedModelId) ||
     normalizedToolSchemaProfile === "gemini";
+  const isMoonshotProvider =
+    normalizedProvider.includes("moonshot") ||
+    normalizedProvider.includes("kimi") ||
+    isKimiModelId(normalizedModelId) ||
+    normalizedToolSchemaProfile === "moonshot";
   const isAnthropicProvider = normalizedProvider.includes("anthropic");
   const unsupportedToolSchemaKeywords = resolveUnsupportedToolSchemaKeywords(options?.modelCompat);
   const omitEmptyArrayItems = shouldOmitEmptyArrayItems(options?.modelCompat);
@@ -841,6 +853,9 @@ function normalizeToolParameterSchemaUncached(
       : normalizedSchema;
     if (isLlamacppGbnfProfile) {
       arrayItemsCompatibleSchema = cleanSchemaForLlamacppGbnf(arrayItemsCompatibleSchema);
+    }
+    if (isMoonshotProvider) {
+      arrayItemsCompatibleSchema = cleanSchemaForMoonshot(arrayItemsCompatibleSchema);
     }
     if (isGeminiProvider && !isAnthropicProvider) {
       const geminiCompatibleSchema = cleanSchemaForGemini(arrayItemsCompatibleSchema);

--- a/packages/ai/src/providers/clean-for-moonshot.test.ts
+++ b/packages/ai/src/providers/clean-for-moonshot.test.ts
@@ -1,0 +1,168 @@
+// Verifies Moonshot flavored JSON schema normalization for tool parameters.
+import { describe, expect, it } from "vitest";
+import { normalizeToolParameterSchema } from "./agent-tools-parameter-schema.js";
+import { cleanSchemaForMoonshot } from "./clean-for-moonshot.js";
+
+describe("cleanSchemaForMoonshot", () => {
+  it("pushes parent type into anyOf branches and drops the parent type", () => {
+    const schema = {
+      type: "object",
+      required: ["user_id", "type"],
+      anyOf: [
+        { required: ["contact_id"] },
+        { required: ["account_id"] },
+        { required: ["opportunity_id"] },
+      ],
+      properties: {
+        user_id: { type: "string" },
+        type: { type: "string" },
+      },
+    };
+
+    expect(cleanSchemaForMoonshot(schema)).toEqual({
+      anyOf: [
+        { required: ["contact_id"], type: "object" },
+        { required: ["account_id"], type: "object" },
+        { required: ["opportunity_id"], type: "object" },
+      ],
+      required: ["user_id", "type"],
+      properties: {
+        user_id: { type: "string" },
+        type: { type: "string" },
+      },
+    });
+  });
+
+  it("recurses into nested anyOf (properties.tasks_attributes.items)", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        tasks_attributes: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["user_id", "type"],
+            anyOf: [{ required: ["contact_id"] }, { required: ["account_id"] }],
+            properties: {
+              user_id: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+
+    const cleaned = cleanSchemaForMoonshot(schema) as {
+      properties: {
+        tasks_attributes: {
+          items: { anyOf: Array<Record<string, unknown>>; type?: string };
+        };
+      };
+    };
+
+    expect(cleaned.properties?.tasks_attributes.items).not.toHaveProperty("type");
+    expect(cleaned.properties?.tasks_attributes.items.anyOf).toEqual([
+      { required: ["contact_id"], type: "object" },
+      { required: ["account_id"], type: "object" },
+    ]);
+  });
+
+  it("preserves branches that already declare their own type", () => {
+    const schema = {
+      type: "object",
+      anyOf: [{ type: "object", properties: { a: { type: "string" } } }, { required: ["b"] }],
+    };
+
+    expect(cleanSchemaForMoonshot(schema)).toEqual({
+      anyOf: [
+        { type: "object", properties: { a: { type: "string" } } },
+        { required: ["b"], type: "object" },
+      ],
+    });
+  });
+
+  it("handles oneOf and allOf the same way", () => {
+    const oneOfSchema = {
+      type: "object",
+      oneOf: [{ required: ["a"] }],
+    };
+    const allOfSchema = {
+      type: "object",
+      allOf: [{ required: ["a"] }],
+    };
+
+    expect(cleanSchemaForMoonshot(oneOfSchema)).toEqual({
+      oneOf: [{ required: ["a"], type: "object" }],
+    });
+    expect(cleanSchemaForMoonshot(allOfSchema)).toEqual({
+      allOf: [{ required: ["a"], type: "object" }],
+    });
+  });
+
+  it("leaves schemas without a parent type unchanged", () => {
+    const schema = {
+      anyOf: [{ required: ["a"] }, { required: ["b"] }],
+    };
+
+    expect(cleanSchemaForMoonshot(schema)).toEqual(schema);
+  });
+
+  it("returns the same reference when nothing changed", () => {
+    const schema = {
+      type: "object",
+      properties: { a: { type: "string" } },
+    };
+
+    expect(cleanSchemaForMoonshot(schema)).toBe(schema);
+  });
+});
+
+describe("normalizeToolParameterSchema moonshot profile", () => {
+  it("rewrites nested anyOf only for moonshot/kimi providers", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        tasks_attributes: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["user_id", "type"],
+            anyOf: [{ required: ["contact_id"] }, { required: ["account_id"] }],
+            properties: {
+              user_id: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+
+    const moonshot = normalizeToolParameterSchema(schema, {
+      modelProvider: "moonshot",
+    }) as {
+      properties: {
+        tasks_attributes: {
+          items: { anyOf: Array<Record<string, unknown>>; type?: string };
+        };
+      };
+    };
+    expect(moonshot.properties?.tasks_attributes.items).not.toHaveProperty("type");
+    expect(moonshot.properties?.tasks_attributes.items.anyOf).toEqual([
+      { required: ["contact_id"], type: "object" },
+      { required: ["account_id"], type: "object" },
+    ]);
+
+    const openai = normalizeToolParameterSchema(schema, {
+      modelProvider: "openai",
+    }) as {
+      properties: {
+        tasks_attributes: {
+          items: { anyOf: Array<Record<string, unknown>>; type?: string };
+        };
+      };
+    };
+    expect(openai.properties?.tasks_attributes.items).toHaveProperty("type", "object");
+    expect(openai.properties?.tasks_attributes.items.anyOf).toEqual([
+      { required: ["contact_id"] },
+      { required: ["account_id"] },
+    ]);
+  });
+});

--- a/packages/ai/src/providers/clean-for-moonshot.ts
+++ b/packages/ai/src/providers/clean-for-moonshot.ts
@@ -1,0 +1,110 @@
+/** Moonshot flavored JSON schema requires `type` inside anyOf/oneOf/allOf branches. */
+
+const SCHEMA_MAP_KEYS = new Set([
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+]);
+
+const SCHEMA_CHILD_KEYS = new Set([
+  "additionalItems",
+  "additionalProperties",
+  "contains",
+  "else",
+  "if",
+  "items",
+  "not",
+  "prefixItems",
+  "propertyNames",
+  "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+]);
+
+const COMBINATOR_KEYS = ["allOf", "anyOf", "oneOf"] as const;
+
+function isSchemaRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasNonEmptyCombinator(node: Record<string, unknown>): boolean {
+  return COMBINATOR_KEYS.some((key) => {
+    const value = node[key];
+    return Array.isArray(value) && value.length > 0;
+  });
+}
+
+function cleanSchemaNode(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    let changed = false;
+    const entries = node.map((entry) => {
+      const next = cleanSchemaNode(entry);
+      changed ||= next !== entry;
+      return next;
+    });
+    return changed ? entries : node;
+  }
+  if (!isSchemaRecord(node)) {
+    return node;
+  }
+
+  let changed = false;
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node)) {
+    let next = value;
+    if (SCHEMA_MAP_KEYS.has(key) && isSchemaRecord(value)) {
+      let mapChanged = false;
+      next = Object.fromEntries(
+        Object.entries(value).map(([childKey, childValue]) => {
+          const cleanedChild = cleanSchemaNode(childValue);
+          mapChanged ||= cleanedChild !== childValue;
+          return [childKey, cleanedChild];
+        }),
+      );
+      if (!mapChanged) {
+        next = value;
+      }
+    } else if (SCHEMA_CHILD_KEYS.has(key)) {
+      next = cleanSchemaNode(value);
+    } else if (
+      COMBINATOR_KEYS.includes(key as (typeof COMBINATOR_KEYS)[number]) &&
+      Array.isArray(value)
+    ) {
+      next = value.map((entry) => cleanSchemaNode(entry));
+    }
+    cleaned[key] = next;
+    changed ||= next !== value;
+  }
+
+  // Moonshot rejects a `type` declared next to anyOf/oneOf/allOf; it must live
+  // inside each branch instead. Distribute the parent `type` into branches that
+  // lack their own, then drop it from the parent.
+  if ("type" in cleaned && hasNonEmptyCombinator(cleaned)) {
+    for (const key of COMBINATOR_KEYS) {
+      const branches = cleaned[key];
+      if (!Array.isArray(branches)) {
+        continue;
+      }
+      const nextBranches: unknown[] = [];
+      for (const branch of branches) {
+        if (isSchemaRecord(branch) && !("type" in branch)) {
+          nextBranches.push({ ...branch, type: cleaned.type });
+        } else {
+          nextBranches.push(branch);
+        }
+      }
+      cleaned[key] = nextBranches;
+    }
+    delete cleaned.type;
+    changed = true;
+  }
+
+  return changed ? cleaned : node;
+}
+
+/** Rewrites Moonshot-flavored schemas so every anyOf/oneOf/allOf branch declares its own `type`. */
+export function cleanSchemaForMoonshot(schema: unknown): unknown {
+  return cleanSchemaNode(schema);
+}


### PR DESCRIPTION
Closes #113130

## What Problem This Solves

Fixes an issue where users running a Moonshot/Kimi model (e.g. `moonshot/kimi-k2.6`) with any in-scope agent tool whose parameter schema declares `type` at the parent of an `anyOf`/`oneOf`/`allOf` would get an HTTP 400 from Moonshot and always fail over to another provider — so Kimi effectively never served those turns. The `openai-completions` provider path forwards tool parameter schemas to the model verbatim, without the combinator normalization the Google and OpenAI-Responses paths already apply. Moonshot's "flavored" JSON Schema validator requires every branch of a combinator to declare its own `type`.

Reported error (from a real run with the Apollo.io MCP server's `apollo_tasks_bulk_create` tool):

```
400 Invalid request: tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'properties.tasks_attributes.items': when using anyOf,
         type should be defined in anyOf items instead of the parent schema>
```

## Why This Change Was Made

Every agent tool schema passes through the shared `normalizeToolParameterSchema` gate (`packages/ai/src/providers/agent-tools-parameter-schema.ts`) before any provider builds a request, and that gate already has provider-specific cleaning for `gemini` and `llamacpp` — but had no Moonshot/Kimi profile. This adds one:

- A new `cleanSchemaForMoonshot` cleaner (mirroring `clean-for-gemini`/`clean-for-llamacpp-gbnf`) recursively walks the schema and, for any node with a `type` plus a non-empty `anyOf`/`oneOf`/`allOf`, pushes the parent `type` into each branch that lacks its own and removes it from the parent — exactly what Moonshot's MFJS validator demands. It returns the same reference when nothing changed.
- The gate detects Moonshot/Kimi via provider string (`moonshot`/`kimi`), `kimi` model ids, or `toolSchemaProfile === "moonshot"`, and applies the cleaner in `applyProviderCleaning`. The existing cache key already includes provider/modelId/profile, so other providers never receive Moonshot-normalized output.
- The cleaner is re-exported from `packages/ai/src/internal/openai.ts` alongside its siblings. The `openai-completions` provider itself needs no change since the shared gate covers all agent tools.

Non-goal: this does not alter the strict-mode normalizer in `openai-tool-schema.ts` or `convertTools()`; the fix is placed at the shared normalization gate where all providers converge.

## User Impact

Users with Moonshot/Kimi models can now serve turns that include tools with parent-level `anyOf`/`oneOf`/`allOf` in their parameter schemas. The offending `tasks_attributes.items` shape is rewritten so every branch declares its own `type`, Moonshot accepts the request, and the ~50s failover-per-turn cost plus Kimi-only hard errors are eliminated.

## Evidence

Focused regression tests all pass locally (via `node scripts/run-vitest.mjs`):

- `packages/ai/src/providers/clean-for-moonshot.test.ts`: 7/7 — includes the exact `properties.tasks_attributes.items` nested-anyOf shape from the report, `oneOf`/`allOf`, branch preservation, identity-preserving no-ops, and provider gating via `normalizeToolParameterSchema` (Moonshot rewrites; OpenAI untouched).
- Sibling provider suites: `openai-tool-schema`, `clean-for-gemini`, `schema-keyword-strip`, `openai-completions` + `.compat`, `openai-tool-projection` — 169/169.
- `extensions/moonshot` suite: 31/31.

Static checks: `oxfmt` and `oxlint` clean on all changed files; `tsgo --project packages/ai/tsconfig.json` reports no errors in changed files.

The rewritten schema (before → after):

```json
{
  "type": "object",
  "required": ["user_id", "type"],
  "anyOf": [
    { "required": ["contact_id"] },
    { "required": ["account_id"] },
    { "required": ["opportunity_id"] }
  ],
  "properties": {}
}
```
→
```json
{
  "required": ["user_id", "type"],
  "anyOf": [
    { "type": "object", "required": ["contact_id"] },
    { "type": "object", "required": ["account_id"] },
    { "type": "object", "required": ["opportunity_id"] }
  ],
  "properties": {}
}
```
