### PR TITLE
fix(qa): bind Codex auth fixture to runtime version

### DIFF
--- a/extensions/codex/test-api.ts
+++ b/extensions/codex/test-api.ts
@@ -21,6 +21,8 @@ import {
   buildTurnStartParams,
 } from "./src/app-server/thread-lifecycle.js";
 
+export { CODEX_APP_SERVER_VERSION } from "./src/app-server/version.js";
+
 type CodexHarnessPromptSnapshot = {
   developerInstructions: string;
   threadStartParams: ReturnType<typeof buildThreadStartParams>;

--- a/test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs
+++ b/test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs
@@ -9,6 +9,10 @@ const requestLog = process.env.OPENCLAW_QA_CODEX_AUTH_APP_SERVER_LOG;
 if (!requestLog) {
   throw new Error("missing OPENCLAW_QA_CODEX_AUTH_APP_SERVER_LOG");
 }
+const appServerVersion = process.env.OPENCLAW_QA_CODEX_APP_SERVER_VERSION;
+if (!appServerVersion) {
+  throw new Error("missing OPENCLAW_QA_CODEX_APP_SERVER_VERSION");
+}
 
 runFakeCodexAppServer({
   requestLog,
@@ -18,8 +22,8 @@ runFakeCodexAppServer({
       sendResult(
         createFakeInitializeResponse({
           name: "openclaw-qa-codex-auth",
-          version: "0.146.0",
-          userAgent: "openclaw/0.146.0 (test)",
+          version: appServerVersion,
+          userAgent: `openclaw/${appServerVersion} (test)`,
         }),
       ),
     "account/login/start": ({ params, sendResult }) => sendResult({ type: params?.type }),
@@ -54,7 +58,7 @@ runFakeCodexAppServer({
           params,
           threadId: "thread-qa-codex-auth",
           sessionId: "session-qa-codex-auth",
-          version: "0.146.0",
+          version: appServerVersion,
         }),
       ),
     "turn/start": ({ notify, params, sendResult }) => {

--- a/test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs
+++ b/test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs
@@ -18,8 +18,8 @@ runFakeCodexAppServer({
       sendResult(
         createFakeInitializeResponse({
           name: "openclaw-qa-codex-auth",
-          version: "0.143.0",
-          userAgent: "openclaw/0.143.0 (test)",
+          version: "0.146.0",
+          userAgent: "openclaw/0.146.0 (test)",
         }),
       ),
     "account/login/start": ({ params, sendResult }) => sendResult({ type: params?.type }),
@@ -54,7 +54,7 @@ runFakeCodexAppServer({
           params,
           threadId: "thread-qa-codex-auth",
           sessionId: "session-qa-codex-auth",
-          version: "0.143.0",
+          version: "0.146.0",
         }),
       ),
     "turn/start": ({ notify, params, sendResult }) => {

--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
@@ -1,6 +1,7 @@
 // QA Lab Codex auth product proof exercises doctor, SQLite, Gateway, and app-server together.
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CODEX_APP_SERVER_VERSION } from "../../../../extensions/codex/test-api.js";
 import { createJsonlRequestTailer } from "../../../../scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs";
 import { closeOpenClawAgentDatabasesForTest } from "../../../../src/state/openclaw-agent-db.js";
 import { connectGatewayStatusClient, postJson } from "../../../helpers/gateway-e2e-harness.js";
@@ -116,6 +117,7 @@ describe("Codex auth product proof", () => {
         name: "qa-codex-auth-product-proof",
         env: {
           OPENCLAW_AGENT_HARNESS_FALLBACK: "none",
+          OPENCLAW_QA_CODEX_APP_SERVER_VERSION: CODEX_APP_SERVER_VERSION,
           OPENCLAW_SKIP_PROVIDERS: undefined,
         },
         config: {

--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
@@ -38,9 +38,15 @@ afterEach(async () => {
 function waitForRequest(requestLog: AppServerRequestLog, method: string) {
   return vi.waitFor(
     () => {
-      const request = requestLog.read().find((entry) => entry.method === method);
+      const entries = requestLog.read();
+      const request = entries.find((entry) => entry.method === method);
       if (!request) {
-        throw new Error(`waiting for Codex app-server method ${method}`);
+        const observedMethods = entries.flatMap((entry) =>
+          typeof entry.method === "string" ? [entry.method] : [],
+        );
+        throw new Error(
+          `waiting for Codex app-server method ${method}; observed ${observedMethods.join(", ") || "no methods"}`,
+        );
       }
       return request;
     },

--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
@@ -1,9 +1,9 @@
 // QA Lab Codex auth product proof exercises doctor, SQLite, Gateway, and app-server together.
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { CODEX_APP_SERVER_VERSION } from "../../../../extensions/codex/test-api.js";
 import { createJsonlRequestTailer } from "../../../../scripts/e2e/lib/codex-media-path/jsonl-request-tail.mjs";
 import { closeOpenClawAgentDatabasesForTest } from "../../../../src/state/openclaw-agent-db.js";
+import { loadBundledPluginPublicSurface } from "../../../../src/test-utils/bundled-plugin-public-surface.js";
 import { connectGatewayStatusClient, postJson } from "../../../helpers/gateway-e2e-harness.js";
 import {
   createOpenClawTestInstance,
@@ -110,6 +110,9 @@ describe("Codex auth product proof", () => {
     "repairs mixed legacy auth into SQLite and sends the selected OAuth profile to app-server",
     { timeout: 180_000 },
     async () => {
+      const { CODEX_APP_SERVER_VERSION } = await loadBundledPluginPublicSurface<{
+        CODEX_APP_SERVER_VERSION: string;
+      }>({ pluginId: "codex", artifactBasename: "test-api.js" });
       const appServerFixture = fileURLToPath(
         new URL("./codex-auth-app-server.fixture.mjs", import.meta.url),
       );


### PR DESCRIPTION
## What Problem This Solves

The release-profile Codex authentication proof could wait 60 seconds for `account/login/start` after its fake app-server was rejected during initialization.

## Why This Change Was Made

The managed Codex runtime requires an exact app-server version match. The fixture had copied that version as independent literals, so every future runtime pin update could recreate the same timeout.

This change exports the plugin's canonical `CODEX_APP_SERVER_VERSION` through its test-only API, loads that surface through the repository's generic bundled-plugin loader, passes the version through the proof-owned child-process environment, and uses it for every version advertised by the standalone fixture. Missing-request failures also report the methods actually observed.

The upstream method and initialize contracts were checked directly in sibling Codex source: `../codex/codex-rs/app-server-protocol/src/protocol/common.rs:909`, `../codex/codex-rs/app-server-protocol/src/protocol/v2/account.rs:66`, `../codex/codex-rs/app-server-protocol/src/protocol/v1.rs:61`, and `../codex/codex-rs/app-server/src/request_processors/initialize_processor.rs:140`.

## User Impact

No production behavior, product config, or operator environment surface changes. Release maturity validation now follows the runtime's canonical version instead of manually synchronizing a test fixture.

## Evidence

- Blacksmith Testbox `tbx_01kyxw3zbqs2zj06s5raan0p6q`: extension boundary 11/11 and focused product proof 1/1 passed: https://github.com/openclaw/openclaw/actions/runs/30685573676
- `git diff --check`
- `oxfmt --check` on all changed files
- Autoreview clean with no accepted/actionable findings
