### PR TITLE
ci: accept direct maintainer release heads

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -308,7 +308,7 @@ jobs:
           repository_name="${GITHUB_REPOSITORY#*/}"
           candidate_metadata_json="$(
             gh_with_retry api graphql \
-              -f query='query($owner:String!,$name:String!,$oid:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$oid){... on Commit{oid signature{isValid state signer{login}} associatedPullRequests(first:100){nodes{state headRefOid headRepository{nameWithOwner} baseRefName baseRepository{nameWithOwner} mergeCommit{oid} mergedBy{login}}}}}}}' \
+              -f query='query($owner:String!,$name:String!,$oid:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$oid){... on Commit{oid committer{user{login}} signature{isValid state signer{login}} associatedPullRequests(first:100){nodes{state headRefOid headRepository{nameWithOwner} baseRefName baseRepository{nameWithOwner} mergeCommit{oid} mergedBy{login}}}}}}}' \
               -f owner="$repository_owner" \
               -f name="$repository_name" \
               -f oid="$candidate_sha"
@@ -417,9 +417,18 @@ jobs:
                   '[.data.repository.object.associatedPullRequests.nodes[] |
                     select(.state == "MERGED" and .baseRefName == $base and
                       .baseRepository.nameWithOwner == $repo and .mergeCommit.oid == $sha) |
-                    .mergedBy.login] | unique | select(length == 1) | .[0]' \
+                    .mergedBy.login] | unique | if length == 0 then "" elif length == 1 then .[0] else error("ambiguous release merge actor") end' \
                   <<<"$signature_json"
               )"
+              if [[ -z "$permission_actor" ]]; then
+                # Direct release commits have no merged PR. The exact canonical
+                # branch head still requires a current maintainer as committer.
+                permission_actor="$(jq -er '.data.repository.object.committer.user.login // empty' <<<"$signature_json")"
+              fi
+              if [[ -z "$permission_actor" ]]; then
+                echo "Unsigned direct release candidate ${candidate_sha} has no GitHub committer." >&2
+                exit 1
+              fi
             fi
             permission_json="$(
               gh_with_retry api \
@@ -1050,7 +1059,7 @@ jobs:
           repository_name="${GITHUB_REPOSITORY#*/}"
           candidate_metadata_json="$(
             gh_with_retry api graphql \
-              -f query='query($owner:String!,$name:String!,$oid:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$oid){... on Commit{oid signature{isValid state signer{login}} associatedPullRequests(first:100){nodes{state headRefOid headRepository{nameWithOwner} baseRefName baseRepository{nameWithOwner} mergeCommit{oid} mergedBy{login}}}}}}}' \
+              -f query='query($owner:String!,$name:String!,$oid:GitObjectID!){repository(owner:$owner,name:$name){object(oid:$oid){... on Commit{oid committer{user{login}} signature{isValid state signer{login}} associatedPullRequests(first:100){nodes{state headRefOid headRepository{nameWithOwner} baseRefName baseRepository{nameWithOwner} mergeCommit{oid} mergedBy{login}}}}}}}' \
               -f owner="$repository_owner" \
               -f name="$repository_name" \
               -f oid="$candidate_sha"
@@ -1152,9 +1161,18 @@ jobs:
                   '[.data.repository.object.associatedPullRequests.nodes[] |
                     select(.state == "MERGED" and .baseRefName == $base and
                       .baseRepository.nameWithOwner == $repo and .mergeCommit.oid == $sha) |
-                    .mergedBy.login] | unique | select(length == 1) | .[0]' \
+                    .mergedBy.login] | unique | if length == 0 then "" elif length == 1 then .[0] else error("ambiguous release merge actor") end' \
                   <<<"$signature_json"
               )"
+              if [[ -z "$permission_actor" ]]; then
+                # Direct release commits have no merged PR. The exact canonical
+                # branch head still requires a current maintainer as committer.
+                permission_actor="$(jq -er '.data.repository.object.committer.user.login // empty' <<<"$signature_json")"
+              fi
+              if [[ -z "$permission_actor" ]]; then
+                echo "Unsigned direct release candidate ${candidate_sha} has no GitHub committer." >&2
+                exit 1
+              fi
             fi
             permission_json="$(
               gh_with_retry api \

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -423,7 +423,7 @@ jobs:
               if [[ -z "$permission_actor" ]]; then
                 # Direct release commits have no merged PR. The exact canonical
                 # branch head still requires a current maintainer as committer.
-                permission_actor="$(jq -er '.data.repository.object.committer.user.login // empty' <<<"$signature_json")"
+                permission_actor="$(jq -r '.data.repository.object.committer.user.login // empty' <<<"$signature_json")"
               fi
               if [[ -z "$permission_actor" ]]; then
                 echo "Unsigned direct release candidate ${candidate_sha} has no GitHub committer." >&2
@@ -1167,7 +1167,7 @@ jobs:
               if [[ -z "$permission_actor" ]]; then
                 # Direct release commits have no merged PR. The exact canonical
                 # branch head still requires a current maintainer as committer.
-                permission_actor="$(jq -er '.data.repository.object.committer.user.login // empty' <<<"$signature_json")"
+                permission_actor="$(jq -r '.data.repository.object.committer.user.login // empty' <<<"$signature_json")"
               fi
               if [[ -z "$permission_actor" ]]; then
                 echo "Unsigned direct release candidate ${candidate_sha} has no GitHub committer." >&2

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -210,7 +210,14 @@ function runAdvisoryStatus(overrides: Record<string, string> = {}) {
   };
 }
 
-function runCandidateProvenance(params: { openPr?: boolean; unsignedWebFlow?: boolean } = {}) {
+function runCandidateProvenance(
+  params: {
+    openPr?: boolean;
+    unsignedDirect?: boolean;
+    unsignedNoActor?: boolean;
+    unsignedWebFlow?: boolean;
+  } = {},
+) {
   const candidateSha = "a".repeat(40);
   const workdir = tempDirs.make("openclaw-telegram-provenance-");
   const fakeBin = join(workdir, "bin");
@@ -220,7 +227,8 @@ function runCandidateProvenance(params: { openPr?: boolean; unsignedWebFlow?: bo
       repository: {
         object: {
           oid: candidateSha,
-          signature: params.unsignedWebFlow
+          committer: params.unsignedDirect ? { user: { login: "release-maintainer" } } : null,
+          signature: params.unsignedWebFlow || params.unsignedDirect || params.unsignedNoActor
             ? null
             : { isValid: true, state: "VALID", signer: { login: "release-maintainer" } },
           associatedPullRequests: {
@@ -351,6 +359,13 @@ describe("release Telegram QA workflow", () => {
 
     const unsignedWebFlow = runCandidateProvenance({ unsignedWebFlow: true });
     expect(unsignedWebFlow.status, unsignedWebFlow.stderr).toBe(0);
+
+    const unsignedDirect = runCandidateProvenance({ unsignedDirect: true });
+    expect(unsignedDirect.status, unsignedDirect.stderr).toBe(0);
+
+    const unsignedNoActor = runCandidateProvenance({ unsignedNoActor: true });
+    expect(unsignedNoActor.status).toBe(1);
+    expect(unsignedNoActor.stderr).toContain("has no GitHub committer");
 
     const openPr = runCandidateProvenance({ openPr: true });
     expect(openPr.status).toBe(1);

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -228,9 +228,10 @@ function runCandidateProvenance(
         object: {
           oid: candidateSha,
           committer: params.unsignedDirect ? { user: { login: "release-maintainer" } } : null,
-          signature: params.unsignedWebFlow || params.unsignedDirect || params.unsignedNoActor
-            ? null
-            : { isValid: true, state: "VALID", signer: { login: "release-maintainer" } },
+          signature:
+            params.unsignedWebFlow || params.unsignedDirect || params.unsignedNoActor
+              ? null
+              : { isValid: true, state: "VALID", signer: { login: "release-maintainer" } },
           associatedPullRequests: {
             nodes: [
               ...(params.openPr


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation rejects an unsigned direct maintainer commit at the exact extended-stable release branch head before Telegram QA starts.

## Why This Change Was Made

Keep the existing fail-closed candidate rules. For an unsigned exact release-branch head, use its one exact merged PR actor when present; otherwise require the GitHub-resolved direct committer to retain maintain/admin access. Invalid signatures, open PR heads, arbitrary SHAs, tags, and unresolvable direct committers remain rejected.

## User Impact

Maintainers can validate direct extended-stable release backports without creating a synthetic PR solely for Telegram provenance. No product runtime behavior changes.

## Evidence

- Reproduced against candidate `7e8c0158f3fe8574bd45d98b5530def80f1bfe23`: its exact extended-stable branch head is unsigned, has no merged PR, and GitHub resolves its committer to a current maintainer.
- Regression coverage exercises signed, unsigned merged-PR, unsigned direct-maintainer, unsigned-no-actor, and open-PR-head cases for the candidate-build provenance gate.
- `actionlint .github/workflows/openclaw-release-telegram-qa.yml`
- `git diff --check`
- Fresh autoreview: no accepted/actionable findings.
- Focused Vitest is pending CI because this clean worktree intentionally has no installed dependencies (`p-map` is unavailable to the test launcher).
