### PR TITLE
feat(plugins): externalize BytePlus provider

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -442,10 +442,18 @@ In onboarding/configure model pickers, the Volcengine auth choice prefers both `
 
 BytePlus ARK provides access to the same models as Volcano Engine for international users.
 
+- Plugin: `@openclaw/byteplus-provider`
 - Provider: `byteplus` (coding: `byteplus-plan`)
 - Auth: `BYTEPLUS_API_KEY`
 - Example model: `byteplus-plan/ark-code-latest`
 - CLI: `openclaw onboard --auth-choice byteplus-api-key`
+
+Install the official plugin and restart the Gateway:
+
+```bash
+openclaw plugins install @openclaw/byteplus-provider
+openclaw gateway restart
+```
 
 ```json5
 {

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-61 plugins
+60 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -66,8 +66,6 @@ Each entry lists the package, distribution route, and description.
 - **[bonjour](/plugins/reference/bonjour)** (`@openclaw/bonjour`) - included in OpenClaw. Advertise the local OpenClaw gateway over Bonjour/mDNS.
 
 - **[browser](/plugins/reference/browser)** (`@openclaw/browser-plugin`) - included in OpenClaw. Adds agent-callable tools.
-
-- **[byteplus](/plugins/reference/byteplus)** (`@openclaw/byteplus-provider`) - included in OpenClaw. Adds BytePlus, BytePlus Plan model provider support to OpenClaw.
 
 - **[canvas](/plugins/reference/canvas)** (`@openclaw/canvas-plugin`) - included in OpenClaw. Experimental Canvas control and A2UI rendering surfaces for paired nodes.
 
@@ -177,7 +175,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-84 plugins
+85 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -194,6 +192,8 @@ Each entry lists the package, distribution route, and description.
 - **[brave](/plugins/reference/brave)** (`@openclaw/brave-plugin`) - npm; ClawHub. OpenClaw Brave Search provider plugin for web search.
 
 - **[buzz](/plugins/reference/buzz)** (`@openclaw/buzz`) - npm; ClawHub: `clawhub:@openclaw/buzz`. Connect OpenClaw agents to Buzz rooms.
+
+- **[byteplus](/plugins/reference/byteplus)** (`@openclaw/byteplus-provider`) - npm; ClawHub: `clawhub:@openclaw/byteplus-provider`. Adds BytePlus, BytePlus Plan model provider support to OpenClaw.
 
 - **[cerebras](/plugins/reference/cerebras)** (`@openclaw/cerebras-provider`) - npm; ClawHub: `clawhub:@openclaw/cerebras-provider`. Adds Cerebras model provider support to OpenClaw.
 

--- a/docs/plugins/reference/byteplus.md
+++ b/docs/plugins/reference/byteplus.md
@@ -12,7 +12,7 @@ Adds BytePlus, BytePlus Plan model provider support to OpenClaw.
 ## Distribution
 
 - Package: `@openclaw/byteplus-provider`
-- Install route: included in OpenClaw
+- Install route: npm; ClawHub: `clawhub:@openclaw/byteplus-provider`
 
 ## Surface
 

--- a/docs/tools/video-generation.md
+++ b/docs/tools/video-generation.md
@@ -105,7 +105,7 @@ openclaw tasks cancel <lookup>
 | Provider              | Default model                   | Text | Image ref                                            | Video ref                                       | Auth                                     |
 | --------------------- | ------------------------------- | :--: | ---------------------------------------------------- | ----------------------------------------------- | ---------------------------------------- |
 | Alibaba               | `wan2.6-t2v`                    |  ✓   | Yes (remote URL)                                     | Yes (remote URL)                                | `MODELSTUDIO_API_KEY`                    |
-| BytePlus (bundled)    | `seedance-1-0-pro-250528`       |  ✓   | Up to 2 images (first + last frame)                  | -                                               | `BYTEPLUS_API_KEY`                       |
+| BytePlus plugin       | `seedance-1-0-pro-250528`       |  ✓   | Up to 2 images (first + last frame)                  | -                                               | `BYTEPLUS_API_KEY`                       |
 | BytePlus 1.5 plugin   | `seedance-1-5-pro-251215`       |  ✓   | Up to 2 images (first + last frame via role)         | -                                               | `BYTEPLUS_API_KEY`                       |
 | BytePlus Seedance 2.0 | `dreamina-seedance-2-0-260128`  |  ✓   | Up to 9 reference images                             | Up to 3 videos                                  | `BYTEPLUS_API_KEY`                       |
 | ComfyUI               | `workflow`                      |  ✓   | 1 image                                              | -                                               | `COMFY_API_KEY` or `COMFY_CLOUD_API_KEY` |
@@ -322,7 +322,8 @@ Automatic fallback across authenticated providers is always enabled. A per-call
     Uses DashScope / Model Studio async endpoint. Reference images and
     videos must be remote `http(s)` URLs.
   </Accordion>
-  <Accordion title="BytePlus (bundled)">
+  <Accordion title="BytePlus plugin">
+    Requires the official `@openclaw/byteplus-provider` plugin.
     Provider id: `byteplus`.
 
     Models: `seedance-1-0-pro-250528` (default),

--- a/extensions/byteplus/README.md
+++ b/extensions/byteplus/README.md
@@ -1,0 +1,17 @@
+# OpenClaw BytePlus Provider
+
+Official OpenClaw provider plugin for BytePlus model inference and Seedance
+video generation.
+
+Install from OpenClaw:
+
+```bash
+openclaw plugins install @openclaw/byteplus-provider
+openclaw gateway restart
+```
+
+Set `BYTEPLUS_API_KEY`, then select a `byteplus/*` or `byteplus-plan/*` model.
+
+See <https://docs.openclaw.ai/concepts/model-providers#byteplus-international>
+for model setup and <https://docs.openclaw.ai/tools/video-generation> for
+Seedance video generation.

--- a/extensions/byteplus/index.ts
+++ b/extensions/byteplus/index.ts
@@ -15,7 +15,7 @@ const BYTEPLUS_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(manifest,
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "BytePlus Provider",
-  description: "Bundled BytePlus provider plugin",
+  description: "BytePlus provider plugin",
   manifest,
   provider: {
     label: "BytePlus",

--- a/extensions/byteplus/package.json
+++ b/extensions/byteplus/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@openclaw/byteplus-provider",
   "version": "2026.7.2",
-  "private": true,
-  "description": "OpenClaw BytePlus provider plugin",
+  "description": "OpenClaw BytePlus provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
@@ -10,6 +13,23 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/byteplus-provider",
+      "npmSpec": "@openclaw/byteplus-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.7.2"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -246,6 +246,7 @@
     "!dist/extensions/arcee/**",
     "!dist/extensions/baseten/**",
     "!dist/extensions/brave/**",
+    "!dist/extensions/byteplus/**",
     "!dist/extensions/buzz/**",
     "!dist/extensions/cerebras/**",
     "!dist/extensions/chutes/**",

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -191,6 +191,63 @@
       }
     },
     {
+      "name": "@openclaw/byteplus-provider",
+      "description": "OpenClaw BytePlus provider plugin.",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "byteplus",
+          "label": "BytePlus"
+        },
+        "providers": [
+          {
+            "id": "byteplus",
+            "aliases": [
+              "byteplus-plan"
+            ],
+            "name": "BytePlus",
+            "docs": "/concepts/model-providers#byteplus-international",
+            "categories": [
+              "cloud",
+              "llm"
+            ],
+            "envVars": [
+              "BYTEPLUS_API_KEY"
+            ],
+            "authChoices": [
+              {
+                "method": "api-key",
+                "choiceId": "byteplus-api-key",
+                "choiceLabel": "BytePlus API key",
+                "groupId": "byteplus",
+                "groupLabel": "BytePlus",
+                "groupHint": "API key",
+                "optionKey": "byteplusApiKey",
+                "cliFlag": "--byteplus-api-key",
+                "cliOption": "--byteplus-api-key <key>",
+                "cliDescription": "BytePlus API key",
+                "onboardingScopes": [
+                  "text-inference"
+                ]
+              }
+            ]
+          }
+        ],
+        "contracts": {
+          "videoGenerationProviders": [
+            "byteplus"
+          ]
+        },
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/byteplus-provider",
+          "npmSpec": "@openclaw/byteplus-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.7.2"
+        }
+      }
+    },
+    {
       "name": "@openclaw/cerebras-provider",
       "description": "OpenClaw Cerebras provider plugin.",
       "source": "official",

--- a/src/cli/plugins-location-bridges.test.ts
+++ b/src/cli/plugins-location-bridges.test.ts
@@ -165,6 +165,7 @@ describe("listPersistedBundledPluginLocationBridges", () => {
   });
 
   it.each([
+    ["byteplus", "@openclaw/byteplus-provider", true],
     ["duckduckgo", "@openclaw/duckduckgo-plugin", false],
     ["synthetic", "@openclaw/synthetic-provider", true],
     ["teams-meetings", "@openclaw/teams-meetings", true],

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -2106,6 +2106,29 @@ describe("official external plugin catalog", () => {
     ]);
   });
 
+  it("lists BytePlus and its paired plan route as an official external provider", () => {
+    const byteplus = expectCatalogEntry("byteplus");
+    const manifest = getOfficialExternalPluginCatalogManifest(byteplus);
+
+    expect(getOfficialExternalPluginCatalogEntry("byteplus-plan")).toBe(byteplus);
+    expect(resolveOfficialExternalPluginInstall(byteplus)).toEqual({
+      clawhubSpec: "clawhub:@openclaw/byteplus-provider",
+      npmSpec: "@openclaw/byteplus-provider",
+      defaultChoice: "npm",
+      minHostVersion: ">=2026.7.2",
+    });
+    expect(manifest?.contracts?.videoGenerationProviders).toEqual(["byteplus"]);
+    expect(manifest?.providers?.[0]?.aliases).toEqual(["byteplus-plan"]);
+    expect(
+      resolveOfficialExternalProviderPluginIds({
+        providerIds: new Set(["byteplus-plan"]),
+      }),
+    ).toEqual(["byteplus"]);
+    expect(resolveOfficialExternalProviderPluginIdsForEnv({ BYTEPLUS_API_KEY: "key" })).toEqual([
+      "byteplus",
+    ]);
+  });
+
   it.each([
     ["teams-meetings", "@openclaw/teams-meetings", "teams_meetings", "teams"],
     ["zoom-meetings", "@openclaw/zoom-meetings", "zoom_meetings", "zoom"],

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -339,10 +339,10 @@ describe("bundled plugin build entries", () => {
     }
   });
 
-  it("excludes externalized Cohere, Meta, and Xiaomi providers from bundled artifacts", () => {
+  it("excludes externalized model providers from bundled artifacts", () => {
     const artifacts = listBundledPluginPackArtifacts();
 
-    for (const pluginId of ["cohere", "meta", "xiaomi"]) {
+    for (const pluginId of ["byteplus", "cohere", "meta", "xiaomi"]) {
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/index.js`);
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/openclaw.plugin.json`);
       expect(artifacts).not.toContain(`dist/extensions/${pluginId}/package.json`);


### PR DESCRIPTION
## What Problem This Solves

BytePlus is an optional provider, but OpenClaw still shipped it inside the core distribution. That kept provider-specific code and dependencies on the bundled path instead of the official plugin install path.

## Why This Change Was Made

Externalizes BytePlus as the official `@openclaw/byteplus-provider` package and excludes it from core artifacts. The official catalog preserves the `byteplus` and `byteplus-plan` provider routes, API-key onboarding, video-generation capability, and automatic relocation of previously bundled installs.

## User Impact

Existing BytePlus users retain their enabled provider and authentication flow during upgrade. New users install the official plugin through npm or ClawHub, while the core package no longer bundles BytePlus.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/bundled-plugin-build-entries.test.ts src/cli/plugins-location-bridges.test.ts src/plugins/official-external-plugin-catalog.test.ts extensions/byteplus/index.test.ts` - 119 tests passed across 4 shards
- `node scripts/generate-npm-package-lock.mjs --package-dir "$PWD" --package-dir "$PWD/extensions/byteplus"` - both package locks validated
- `node scripts/generate-plugin-inventory-doc.mjs --check`
- targeted `oxfmt --check` and `git diff --check`
- exact-head autoreview: no accepted or actionable findings; patch correct at 0.87 confidence

AI-assisted: yes. The implementation and generated metadata were manually inspected, and the focused proof above passed on commit `4693684a510d1ef36f405a443e5203d6fee66e2d`.
