### PR TITLE
fix(cli): keep logs startup read-only

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -759,6 +759,7 @@ describe("argv helpers", () => {
 
   it.each([
     { argv: ["node", "openclaw", "status"], expected: true },
+    { argv: ["node", "openclaw", "logs", "--plain"], expected: false },
     { argv: ["node", "openclaw", "health"], expected: false },
     { argv: ["node", "openclaw", "sessions"], expected: false },
     { argv: ["node", "openclaw", "--profile", "work", "status"], expected: true },
@@ -784,6 +785,7 @@ describe("argv helpers", () => {
 
   it.each([
     { path: ["status"], expected: true },
+    { path: ["logs"], expected: false },
     { path: ["update", "status"], expected: false },
     { path: ["gateway", "call"], expected: false },
     { path: ["gateway", "health"], expected: true },

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -615,7 +615,7 @@ export function shouldMigrateStateFromPath(path: string[]): boolean {
     return true;
   }
   const [primary, secondary] = path;
-  if (primary === "health" || primary === "sessions") {
+  if (primary === "health" || primary === "logs" || primary === "sessions") {
     return false;
   }
   // Remote RPC clients must not migrate state owned by the running gateway.

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -211,10 +211,13 @@ describe("ensureConfigReady", () => {
     expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ observe: false });
   });
 
-  it("keeps logs config guard reads non-observing", async () => {
+  it("keeps logs config guard reads non-observing and independent of plugin state", async () => {
     await runEnsureConfigReady(["logs"]);
 
-    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ observe: false });
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({
+      observe: false,
+      skipPluginValidation: true,
+    });
   });
 
   it("keeps remote gateway call config reads non-observing", async () => {

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -169,6 +169,11 @@ describe("ensureConfigReady", () => {
       expectedDoctorCalls: 0,
     },
     {
+      name: "skips doctor flow for logs",
+      commandPath: ["logs"],
+      expectedDoctorCalls: 0,
+    },
+    {
       name: "skips doctor flow for remote gateway calls",
       commandPath: ["gateway", "call"],
       expectedDoctorCalls: 0,
@@ -206,6 +211,12 @@ describe("ensureConfigReady", () => {
     expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ observe: false });
   });
 
+  it("keeps logs config guard reads non-observing", async () => {
+    await runEnsureConfigReady(["logs"]);
+
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ observe: false });
+  });
+
   it("keeps remote gateway call config reads non-observing", async () => {
     await runEnsureConfigReady(["gateway", "call"]);
 
@@ -233,6 +244,16 @@ describe("ensureConfigReady", () => {
     await runEnsureConfigReady(["gateway", "call"]);
 
     expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps logs from migrating existing local legacy state", async () => {
+    const root = useTempOpenClawHome();
+    writeStateMarker(root, "cron/runs/legacy-job.jsonl");
+
+    await runEnsureConfigReady(["logs"]);
+
+    expect(loadAndMaybeMigrateDoctorConfigMock).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(root, ".openclaw", "cron/runs/legacy-job.jsonl"))).toBe(true);
   });
 
   it.each(["restart-sentinel.json", "restart-sentinel.json.doctor-importing"])(

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -268,10 +268,12 @@ export async function ensureConfigReady(
     preflightSnapshot = await runStateMigrationPreflight();
   }
 
-  // Status reads its materialized/source pair; remote Gateway calls must not
-  // record config health in the state owned by the Gateway being queried.
+  // Read-only diagnostics must not record config health; remote Gateway calls
+  // must not write into the state owned by the Gateway being queried.
   const configSnapshotOptions =
-    commandName === "status" || (commandName === "gateway" && subcommandName === "call")
+    commandName === "logs" ||
+    commandName === "status" ||
+    (commandName === "gateway" && subcommandName === "call")
       ? ({ observe: false } as const)
       : undefined;
   let snapshot = preflightSnapshot ?? (await getConfigSnapshot(configSnapshotOptions));

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -189,7 +189,7 @@ function isGatewayStartupCommand(commandPath: string[]): boolean {
   );
 }
 
-async function getConfigSnapshot(options?: { observe: false }) {
+async function getConfigSnapshot(options?: { observe: false; skipPluginValidation?: true }) {
   if (options?.observe === false) {
     return readConfigFileSnapshot(options);
   }
@@ -268,14 +268,14 @@ export async function ensureConfigReady(
     preflightSnapshot = await runStateMigrationPreflight();
   }
 
-  // Read-only diagnostics must not record config health; remote Gateway calls
-  // must not write into the state owned by the Gateway being queried.
+  // Read-only diagnostics must not record config health; logs also skips plugin
+  // metadata discovery because opening the shared state DB creates SQLite sidecars.
   const configSnapshotOptions =
-    commandName === "logs" ||
-    commandName === "status" ||
-    (commandName === "gateway" && subcommandName === "call")
-      ? ({ observe: false } as const)
-      : undefined;
+    commandName === "logs"
+      ? ({ observe: false, skipPluginValidation: true } as const)
+      : commandName === "status" || (commandName === "gateway" && subcommandName === "call")
+        ? ({ observe: false } as const)
+        : undefined;
   let snapshot = preflightSnapshot ?? (await getConfigSnapshot(configSnapshotOptions));
   if (
     !preflightSnapshot &&


### PR DESCRIPTION
## What Problem This Solves

`openclaw logs` is an observation command, but CLI startup classified it as migration-capable. Before collecting logs, `ensureConfigReady()` could run Doctor state migrations, import legacy cron run logs into shared SQLite, archive their source files, record config-health state, and open plugin metadata SQLite state.

That made incident evidence collection mutate the system being inspected.

Fixes #116853.

## Why This Change Was Made

The CLI already owns these decisions at central startup boundaries. This change classifies `logs` as read-only at all three:

1. `shouldMigrateStateFromPath(["logs"])` returns `false`, so Doctor state migration cannot run before log collection.
2. The config guard reads with `observe: false`, so it does not record config-health state.
3. The same read uses `skipPluginValidation: true`, so a passive log request does not discover plugin metadata through the shared state database.

Core config schema validation remains enabled. Gateway RPC tailing plus local file and systemd-journal fallback behavior are unchanged. Explicit `openclaw doctor --fix` remains the migration owner.

## User Impact

Operators and monitoring can run `openclaw logs` without importing or archiving legacy state, updating config-health history, or creating SQLite WAL/SHM files in the inspected state root.

## Scope

This PR intentionally does not add a new "migration pending" warning to `logs`. A reliable warning needs a separate read-only Doctor migration-preview contract; adding legacy-state discovery to this passive command would widen the fix and risk recreating the state-access problem. Operators can continue to run `openclaw doctor --fix` explicitly.

## Evidence

Validated base: `80bbdeda1ce9591859cd7e80e22eea8bcdadf136`

Validated head: `99c4030c1df410d07a33e55292b71b69ccf9bce1`

### Focused tests

- `node scripts/run-vitest.mjs src/cli/argv.test.ts src/cli/program/config-guard.test.ts src/cli/logs-cli.test.ts src/commands/doctor/cron/index.test.ts`
  - 294 tests passed across three Vitest shards.
- `node scripts/run-vitest.mjs src/config/config.model-ref-validation.test.ts`
  - Confirms core config validation still rejects malformed model-policy references when plugin validation is skipped.
- Oxfmt, Oxlint, and `git diff --check` passed on the changed files.
- Exact-head `pnpm build` passed on Blacksmith Testbox.

### Final-head real CLI proof

The built top-level CLI ran against:

- a real isolated Gateway containing `PROOF_LOG_LINE_116869`;
- a separate isolated target state containing a canonical SQLite database, legacy `logs/config-health.json`, legacy `cron/runs/legacy-job.jsonl`, and the active config.

Before and after `node openclaw.mjs logs --limit 200 --plain`, the proof compared:

- the entire target tree by path, entry type, mode, size, and SHA-256 for every file;
- individual SHA-256 values for the config, config-health JSON, cron JSONL, and SQLite database;
- the presence of any SQLite `-wal`, `-shm`, or `-journal` sidecar.

Result:

```text
LOGS_OUTPUT=PROOF_LOG_LINE_116869
LOGS_FULL_TREE_IMMUTABLE=PASS
LOGS_CONFIG_HASH_STABLE=PASS
LOGS_CONFIG_HEALTH_HASH_STABLE=PASS
LOGS_CRON_JSONL_HASH_STABLE=PASS
LOGS_SQLITE_HASH_STABLE=PASS
LOGS_SQLITE_SIDECARS_ABSENT=PASS
```

The first version of this proof caught `openclaw.sqlite-wal` and `openclaw.sqlite-shm` creation from plugin metadata validation. The final maintainer commit closes that exact gap.

### Explicit Doctor migration proof

The same untouched target then ran `node openclaw.mjs doctor --fix --yes`. Doctor archived both legacy files, imported one config-health row and one cron task row into SQLite, and preserved a pre-existing sentinel row:

```text
DOCTOR_CONFIG_HEALTH_ROWS=1
DOCTOR_CRON_TASK_ROWS=1
DOCTOR_SQLITE_SENTINEL=unchanged
DOCTOR_FIX_MIGRATION=PASS
```

This proves the passive `logs` path is mutation-free while the explicit repair path still performs the intended migrations.

## Authorship

The contributor's fix remains the first commit. The follow-up maintainer commit narrows the config-read boundary after hard runtime validation exposed the SQLite sidecar write.