### PR TITLE
fix(mcp): accept probe names in tool filters

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -372,8 +372,8 @@ Those saved definitions are for runtimes that OpenClaw launches or configures la
     - `supportsParallelToolCalls: true` marks servers that adapters can call concurrently
     - HTTP servers can use static headers, OAuth login, TLS verification control, and mTLS certificate/key paths
     - embedded OpenClaw exposes configured MCP tools in normal `coding` and `messaging` tool profiles; `minimal` still hides them, and `tools.deny: ["bundle-mcp"]` disables them explicitly
-    - per-server `toolFilter.include` and `toolFilter.exclude` filter discovered MCP tools before they become OpenClaw tools
-    - servers that advertise resources or prompts also expose utility tools for listing/reading resources and listing/fetching prompts; those generated utility names (`resources_list`, `resources_read`, `prompts_list`, `prompts_get`) use the same include/exclude filter
+    - per-server `toolFilter.include` and `toolFilter.exclude` filter discovered MCP tools before they become OpenClaw tools; entries can use raw MCP names or exact projected names printed by `mcp probe`
+    - servers that advertise resources or prompts also expose utility tools for listing/reading resources and listing/fetching prompts; those generated utility names (`resources_list`, `resources_read`, `prompts_list`, `prompts_get`) and their projected forms use the same include/exclude filter
     - dynamic MCP tool-list changes invalidate the cached catalog for that session; the next discovery/use refreshes from the server
     - repeated MCP tool request/protocol failures pause that server briefly so one broken server does not consume the whole turn
     - session-scoped bundled MCP runtimes are reaped after 10 minutes of idle time and one-shot embedded runs clean them up at run end
@@ -422,7 +422,7 @@ Notes:
 - `add` accepts stdio flags such as `--command`, `--arg`, `--env`, and `--cwd`, or HTTP flags such as `--url`, `--transport`, `--header`, `--auth oauth`, TLS, timeout, and tool-selection flags.
 - `set` expects one JSON object value on the command line.
 - `configure` updates enablement, tool filters, timeouts, OAuth, TLS, and parallel-tool-call hints without replacing the whole server definition. Add `--probe` to verify the updated server before saving.
-- `tools` updates per-server tool filters. Include/exclude entries are MCP tool names and simple `*` globs.
+- `tools` updates per-server tool filters. Include/exclude entries are MCP tool names and simple `*` globs. Filters accept either the raw name reported by the MCP server (for example `query`) or the exact projected name printed by `mcp probe` (for example `motherduck__query`), including sanitized, truncated, or collision-suffixed names. Generated resource and prompt utility tools follow the same rule.
 - `login` runs the OAuth flow for HTTP servers configured with `auth: "oauth"`. The first run prints an authorization URL; rerun with `--code` after approval.
 - `logout` clears stored OAuth credentials for the named server without removing the saved server definition.
 - `reload` disposes cached in-process MCP runtimes for the current CLI process only. Gateway or agent processes in another process still need their own reload or restart path.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -159,11 +159,12 @@ target server during config edits.
   for private endpoints and mutual TLS.
 - `mcp.servers.<name>.toolFilter`: optional per-server tool selection. `include`
   limits the discovered MCP tools to matching names; `exclude` hides matching
-  names. Entries can use the raw MCP tool name or the exact projected name
-  printed by `openclaw mcp probe`, with simple `*` globs supported for either.
+  names. Entries can use raw MCP tool names and simple `*` globs, or exact
+  projected names printed by `openclaw mcp probe`. Globs match raw names only,
+  preserving the meaning of existing filters.
   Servers with resources or prompts also generate utility tool names
   (`resources_list`, `resources_read`, `prompts_list`, `prompts_get`), and those
-  raw or projected names use the same filter.
+  raw names or exact projected names use the same filter.
 - `mcp.servers.<name>.codex`: optional Codex app-server projection controls.
   This block is OpenClaw metadata for Codex app-server threads only; it does not
   affect ACP sessions, generic Codex harness config, or other runtime adapters.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -159,10 +159,11 @@ target server during config edits.
   for private endpoints and mutual TLS.
 - `mcp.servers.<name>.toolFilter`: optional per-server tool selection. `include`
   limits the discovered MCP tools to matching names; `exclude` hides matching
-  names. Entries are exact MCP tool names or simple `*` globs. Servers with
-  resources or prompts also generate utility tool names (`resources_list`,
-  `resources_read`, `prompts_list`, `prompts_get`), and those names use the
-  same filter.
+  names. Entries can use the raw MCP tool name or the exact projected name
+  printed by `openclaw mcp probe`, with simple `*` globs supported for either.
+  Servers with resources or prompts also generate utility tool names
+  (`resources_list`, `resources_read`, `prompts_list`, `prompts_get`), and those
+  raw or projected names use the same filter.
 - `mcp.servers.<name>.codex`: optional Codex app-server projection controls.
   This block is OpenClaw metadata for Codex app-server threads only; it does not
   affect ACP sessions, generic Codex harness config, or other runtime adapters.

--- a/src/agents/agent-bundle-mcp-filter.test.ts
+++ b/src/agents/agent-bundle-mcp-filter.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { matchesMcpToolFilterPattern } from "./agent-bundle-mcp-filter.js";
+import {
+  findAmbiguousExactMcpToolFilterPatterns,
+  isMcpToolAllowedByFilter,
+  matchesMcpToolFilterPattern,
+} from "./agent-bundle-mcp-filter.js";
 
 describe("matchesMcpToolFilterPattern", () => {
   it.each([
@@ -18,5 +22,34 @@ describe("matchesMcpToolFilterPattern", () => {
     const pattern = `${"*a".repeat(128)}*b`;
     const value = `${"a".repeat(10_000)}c`;
     expect(matchesMcpToolFilterPattern(pattern, value)).toBe(false);
+  });
+
+  it("fails closed when an exact include matches raw and projected names of different tools", () => {
+    const candidateGroups = [
+      ["query", "demo__query"],
+      ["demo__query", "demo__demo__query"],
+    ];
+    const ambiguousIncludePatterns = findAmbiguousExactMcpToolFilterPatterns({
+      patterns: ["demo__query", "query", "demo__*"],
+      candidateGroups,
+    });
+
+    expect([...ambiguousIncludePatterns]).toEqual(["demo__query"]);
+    expect(
+      candidateGroups.map((candidateNames) =>
+        isMcpToolAllowedByFilter({
+          include: ["demo__query"],
+          candidateNames,
+          ambiguousIncludePatterns,
+        }),
+      ),
+    ).toEqual([false, false]);
+    expect(
+      isMcpToolAllowedByFilter({
+        include: ["query"],
+        candidateNames: candidateGroups[0]!,
+        ambiguousIncludePatterns,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/agents/agent-bundle-mcp-filter.test.ts
+++ b/src/agents/agent-bundle-mcp-filter.test.ts
@@ -52,4 +52,13 @@ describe("matchesMcpToolFilterPattern", () => {
       }),
     ).toBe(true);
   });
+
+  it("keeps wildcard matching raw-only while accepting exact projected names", () => {
+    const candidateNames = ["query", "demo__query-2"];
+
+    expect(isMcpToolAllowedByFilter({ include: ["demo__*"], candidateNames })).toBe(false);
+    expect(isMcpToolAllowedByFilter({ include: ["demo__query-2"], candidateNames })).toBe(true);
+    expect(isMcpToolAllowedByFilter({ exclude: ["demo__*"], candidateNames })).toBe(true);
+    expect(isMcpToolAllowedByFilter({ exclude: ["demo__query-2"], candidateNames })).toBe(false);
+  });
 });

--- a/src/agents/agent-bundle-mcp-filter.ts
+++ b/src/agents/agent-bundle-mcp-filter.ts
@@ -41,16 +41,50 @@ export function isMcpToolAllowedByFilter(params: {
   include?: readonly string[];
   exclude?: readonly string[];
   candidateNames: readonly string[];
+  ambiguousIncludePatterns?: ReadonlySet<string>;
 }): boolean {
-  const matchesAny = (patterns: readonly string[]): boolean =>
-    patterns.some((pattern) =>
-      params.candidateNames.some((name) => matchesMcpToolFilterPattern(pattern, name)),
-    );
+  const matchesAny = (patterns: readonly string[], skipAmbiguousExact: boolean): boolean =>
+    patterns.some((pattern) => {
+      const trimmed = pattern.trim();
+      if (
+        skipAmbiguousExact &&
+        !trimmed.includes("*") &&
+        params.ambiguousIncludePatterns?.has(trimmed)
+      ) {
+        return false;
+      }
+      return params.candidateNames.some((name) => matchesMcpToolFilterPattern(pattern, name));
+    });
   const include = params.include ?? [];
-  if (include.length > 0 && !matchesAny(include)) {
+  if (include.length > 0 && !matchesAny(include, true)) {
     return false;
   }
-  return !matchesAny(params.exclude ?? []);
+  return !matchesAny(params.exclude ?? [], false);
+}
+
+/** Find exact include patterns that identify more than one advertised MCP tool. */
+export function findAmbiguousExactMcpToolFilterPatterns(params: {
+  patterns: readonly string[];
+  candidateGroups: readonly (readonly string[])[];
+}): Set<string> {
+  const ambiguous = new Set<string>();
+  for (const pattern of params.patterns) {
+    const trimmed = pattern.trim();
+    if (!trimmed || trimmed.includes("*")) {
+      continue;
+    }
+    let matchingGroups = 0;
+    for (const candidateNames of params.candidateGroups) {
+      if (candidateNames.some((name) => matchesMcpToolFilterPattern(trimmed, name))) {
+        matchingGroups += 1;
+        if (matchingGroups > 1) {
+          ambiguous.add(trimmed);
+          break;
+        }
+      }
+    }
+  }
+  return ambiguous;
 }
 
 /** Return whether any pattern matches any supported name for an MCP tool. */

--- a/src/agents/agent-bundle-mcp-filter.ts
+++ b/src/agents/agent-bundle-mcp-filter.ts
@@ -35,3 +35,30 @@ export function matchesMcpToolFilterPattern(pattern: string, value: string): boo
   }
   return true;
 }
+
+/** Match include/exclude patterns against every supported name for one MCP tool. */
+export function isMcpToolAllowedByFilter(params: {
+  include?: readonly string[];
+  exclude?: readonly string[];
+  candidateNames: readonly string[];
+}): boolean {
+  const matchesAny = (patterns: readonly string[]): boolean =>
+    patterns.some((pattern) =>
+      params.candidateNames.some((name) => matchesMcpToolFilterPattern(pattern, name)),
+    );
+  const include = params.include ?? [];
+  if (include.length > 0 && !matchesAny(include)) {
+    return false;
+  }
+  return !matchesAny(params.exclude ?? []);
+}
+
+/** Return whether any pattern matches any supported name for an MCP tool. */
+export function matchesAnyMcpToolFilterCandidate(
+  patterns: readonly string[],
+  candidateNames: readonly string[],
+): boolean {
+  return patterns.some((pattern) =>
+    candidateNames.some((name) => matchesMcpToolFilterPattern(pattern, name)),
+  );
+}

--- a/src/agents/agent-bundle-mcp-filter.ts
+++ b/src/agents/agent-bundle-mcp-filter.ts
@@ -36,7 +36,21 @@ export function matchesMcpToolFilterPattern(pattern: string, value: string): boo
   return true;
 }
 
-/** Match include/exclude patterns against every supported name for one MCP tool. */
+function matchesMcpToolFilterCandidate(
+  pattern: string,
+  candidateNames: readonly string[],
+): boolean {
+  const trimmed = pattern.trim();
+  // The first candidate is always the raw MCP name. Preserve the shipped
+  // raw-only glob contract; projected probe names are accepted only exactly.
+  if (trimmed.includes("*")) {
+    const rawName = candidateNames[0];
+    return rawName ? matchesMcpToolFilterPattern(trimmed, rawName) : false;
+  }
+  return candidateNames.some((name) => matchesMcpToolFilterPattern(trimmed, name));
+}
+
+/** Match raw names/globs and exact projected names for one MCP tool. */
 export function isMcpToolAllowedByFilter(params: {
   include?: readonly string[];
   exclude?: readonly string[];
@@ -53,7 +67,7 @@ export function isMcpToolAllowedByFilter(params: {
       ) {
         return false;
       }
-      return params.candidateNames.some((name) => matchesMcpToolFilterPattern(pattern, name));
+      return matchesMcpToolFilterCandidate(trimmed, params.candidateNames);
     });
   const include = params.include ?? [];
   if (include.length > 0 && !matchesAny(include, true)) {
@@ -75,7 +89,7 @@ export function findAmbiguousExactMcpToolFilterPatterns(params: {
     }
     let matchingGroups = 0;
     for (const candidateNames of params.candidateGroups) {
-      if (candidateNames.some((name) => matchesMcpToolFilterPattern(trimmed, name))) {
+      if (matchesMcpToolFilterCandidate(trimmed, candidateNames)) {
         matchingGroups += 1;
         if (matchingGroups > 1) {
           ambiguous.add(trimmed);
@@ -92,7 +106,5 @@ export function matchesAnyMcpToolFilterCandidate(
   patterns: readonly string[],
   candidateNames: readonly string[],
 ): boolean {
-  return patterns.some((pattern) =>
-    candidateNames.some((name) => matchesMcpToolFilterPattern(pattern, name)),
-  );
+  return patterns.some((pattern) => matchesMcpToolFilterCandidate(pattern, candidateNames));
 }

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -2,20 +2,21 @@
 import crypto from "node:crypto";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { normalizeToolParameterSchema } from "@openclaw/ai/internal/openai";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
-import { getPluginToolMeta, setPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
-import { matchesMcpToolFilterPattern } from "./agent-bundle-mcp-filter.js";
+import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tools.js";
+import { isMcpToolAllowedByFilter } from "./agent-bundle-mcp-filter.js";
 import {
   buildSafeToolName,
   normalizeReservedToolNames,
+  reserveProjectedMcpToolName,
   TOOL_NAME_SEPARATOR,
 } from "./agent-bundle-mcp-names.js";
 import type {
   BundleMcpToolRuntime,
   McpCatalogTool,
   McpToolCatalog,
+  McpUtilityToolOperation,
   SessionMcpRuntime,
 } from "./agent-bundle-mcp-types.js";
 import { mcpContentBlockToAgentContent } from "./mcp-content.js";
@@ -57,12 +58,12 @@ function buildAppToolPolicyProjections(params: {
     return serverOrder || a.toolName.localeCompare(b.toolName);
   });
   for (const tool of appOnlyTools) {
-    const name = buildSafeToolName({
+    const name = reserveProjectedMcpToolName({
       serverName: tool.safeServerName,
       toolName: tool.toolName,
+      projectedName: tool.projectedName,
       reservedNames,
     });
-    reservedNames.add(normalizeLowercaseStringOrEmpty(name));
     const projection: AnyAgentTool = {
       name,
       label: tool.title ?? tool.toolName,
@@ -193,7 +194,8 @@ function optionalStringRecordArg(input: unknown, key: string): Record<string, st
 
 function serverAllowsUtilityTool(
   server: McpToolCatalog["servers"][string],
-  operation: string,
+  operation: McpUtilityToolOperation,
+  projectedName: string,
   sessionDeniedOnly: boolean,
 ): boolean {
   // Two disjoint passes share this gate: the executable pass (sessionDeniedOnly=false)
@@ -202,15 +204,11 @@ function serverAllowsUtilityTool(
   if ((server.deniedToolNames?.includes(operation) === true) !== sessionDeniedOnly) {
     return false;
   }
-  const include = server.toolFilter?.include ?? [];
-  const exclude = server.toolFilter?.exclude ?? [];
-  if (
-    include.length > 0 &&
-    !include.some((pattern) => matchesMcpToolFilterPattern(pattern, operation))
-  ) {
-    return false;
-  }
-  return !exclude.some((pattern) => matchesMcpToolFilterPattern(pattern, operation));
+  return isMcpToolAllowedByFilter({
+    include: server.toolFilter?.include,
+    exclude: server.toolFilter?.exclude,
+    candidateNames: [operation, projectedName],
+  });
 }
 
 function addMcpUtilityTool(params: {
@@ -218,20 +216,38 @@ function addMcpUtilityTool(params: {
   reservedNames: Set<string>;
   serverName: string;
   safeServerName: string;
+  server: McpToolCatalog["servers"][string];
   executionMode: AnyAgentTool["executionMode"];
-  operation: Exclude<PluginToolMcpMeta["operation"], "tool">;
+  operation: McpUtilityToolOperation;
   label: string;
   description: string;
   parameters: Record<string, unknown>;
   deniedBySession?: true;
   execute?: AnyAgentTool["execute"];
 }) {
-  const name = buildSafeToolName({
+  const projectedName =
+    params.server.projectedUtilityToolNames?.[params.operation] ??
+    buildSafeToolName({
+      serverName: params.safeServerName,
+      toolName: params.operation,
+      reservedNames: params.reservedNames,
+    });
+  if (
+    !serverAllowsUtilityTool(
+      params.server,
+      params.operation,
+      projectedName,
+      params.deniedBySession === true,
+    )
+  ) {
+    return;
+  }
+  const name = reserveProjectedMcpToolName({
     serverName: params.safeServerName,
     toolName: params.operation,
+    projectedName,
     reservedNames: params.reservedNames,
   });
-  params.reservedNames.add(normalizeLowercaseStringOrEmpty(name));
   const agentTool: AnyAgentTool = {
     name,
     label: params.label,
@@ -312,9 +328,10 @@ export function buildBundleMcpToolsFromCatalog(params: {
     const server = params.catalog.servers[tool.serverName];
     const executionMode: AnyAgentTool["executionMode"] =
       server?.supportsParallelToolCalls === true ? "parallel" : "sequential";
-    const safeToolName = buildSafeToolName({
+    const safeToolName = reserveProjectedMcpToolName({
       serverName: tool.safeServerName,
       toolName: originalName,
+      projectedName: tool.projectedName,
       reservedNames,
     });
     if (safeToolName !== `${tool.safeServerName}${TOOL_NAME_SEPARATOR}${originalName}`) {
@@ -322,7 +339,6 @@ export function buildBundleMcpToolsFromCatalog(params: {
         `bundle-mcp: tool "${tool.toolName}" from server "${tool.serverName}" registered as "${safeToolName}" to keep the tool name provider-safe.`,
       );
     }
-    reservedNames.add(normalizeLowercaseStringOrEmpty(safeToolName));
     const agentTool: AnyAgentTool = {
       name: safeToolName,
       label: tool.title ?? tool.toolName,
@@ -356,12 +372,13 @@ export function buildBundleMcpToolsFromCatalog(params: {
     const executionMode: AnyAgentTool["executionMode"] = server.supportsParallelToolCalls
       ? "parallel"
       : "sequential";
-    if (server.resources && serverAllowsUtilityTool(server, "resources_list", sessionDeniedOnly)) {
+    if (server.resources) {
       addMcpUtilityTool({
         tools,
         reservedNames,
         serverName: server.serverName,
         safeServerName,
+        server,
         executionMode,
         operation: "resources_list",
         label: "List MCP resources",
@@ -373,12 +390,13 @@ export function buildBundleMcpToolsFromCatalog(params: {
           : undefined,
       });
     }
-    if (server.resources && serverAllowsUtilityTool(server, "resources_read", sessionDeniedOnly)) {
+    if (server.resources) {
       addMcpUtilityTool({
         tools,
         reservedNames,
         serverName: server.serverName,
         safeServerName,
+        server,
         executionMode,
         operation: "resources_read",
         label: "Read MCP resource",
@@ -395,12 +413,13 @@ export function buildBundleMcpToolsFromCatalog(params: {
           : undefined,
       });
     }
-    if (server.prompts && serverAllowsUtilityTool(server, "prompts_list", sessionDeniedOnly)) {
+    if (server.prompts) {
       addMcpUtilityTool({
         tools,
         reservedNames,
         serverName: server.serverName,
         safeServerName,
+        server,
         executionMode,
         operation: "prompts_list",
         label: "List MCP prompts",
@@ -412,12 +431,13 @@ export function buildBundleMcpToolsFromCatalog(params: {
           : undefined,
       });
     }
-    if (server.prompts && serverAllowsUtilityTool(server, "prompts_get", sessionDeniedOnly)) {
+    if (server.prompts) {
       addMcpUtilityTool({
         tools,
         reservedNames,
         serverName: server.serverName,
         safeServerName,
+        server,
         executionMode,
         operation: "prompts_get",
         label: "Get MCP prompt",

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -208,6 +208,7 @@ function serverAllowsUtilityTool(
     include: server.toolFilter?.include,
     exclude: server.toolFilter?.exclude,
     candidateNames: [operation, projectedName],
+    ambiguousIncludePatterns: new Set(server.ambiguousToolFilterIncludes ?? []),
   });
 }
 

--- a/src/agents/agent-bundle-mcp-names.test.ts
+++ b/src/agents/agent-bundle-mcp-names.test.ts
@@ -1,6 +1,7 @@
 /** Tests MCP server/tool name sanitization, truncation, and collision handling. */
 import { describe, expect, it } from "vitest";
 import {
+  buildProjectedMcpToolNames,
   buildSafeToolName,
   normalizeReservedToolNames,
   sanitizeServerName,
@@ -69,5 +70,20 @@ describe("agent bundle MCP names", () => {
 
     expect(safeToolName.startsWith(`memory${TOOL_NAME_SEPARATOR}`)).toBe(true);
     expect(safeToolName.length).toBeLessThanOrEqual(64);
+  });
+
+  it("precomputes the exact filtered-name candidates used by MCP probe", () => {
+    const sharedPrefix = "x".repeat(80);
+    const names = buildProjectedMcpToolNames({
+      serverName: "duck-data",
+      toolNames: [`${sharedPrefix}-b`, "resources_list", `${sharedPrefix}-a`],
+      utilityNames: ["resources_list", "resources_read"],
+    });
+
+    expect(names.tools.get(`${sharedPrefix}-a`)).toBe(`duck-data__${"x".repeat(53)}`);
+    expect(names.tools.get(`${sharedPrefix}-b`)).toBe(`duck-data__${"x".repeat(51)}-2`);
+    expect(names.tools.get("resources_list")).toBe("duck-data__resources_list");
+    expect(names.utilities.get("resources_list")).toBe("duck-data__resources_list-2");
+    expect(names.utilities.get("resources_read")).toBe("duck-data__resources_read");
   });
 });

--- a/src/agents/agent-bundle-mcp-names.test.ts
+++ b/src/agents/agent-bundle-mcp-names.test.ts
@@ -86,4 +86,17 @@ describe("agent bundle MCP names", () => {
     expect(names.utilities.get("resources_list")).toBe("duck-data__resources_list-2");
     expect(names.utilities.get("resources_read")).toBe("duck-data__resources_read");
   });
+
+  it("keeps projected names distinct from every raw tool and utility name", () => {
+    const names = buildProjectedMcpToolNames({
+      serverName: "demo",
+      toolNames: ["query", "demo__query", "demo__resources_list"],
+      utilityNames: ["resources_list"],
+    });
+
+    expect(names.tools.get("query")).toBe("demo__query-2");
+    expect(names.tools.get("demo__query")).toBe("demo__demo__query");
+    expect(names.tools.get("demo__resources_list")).toBe("demo__demo__resources_list");
+    expect(names.utilities.get("resources_list")).toBe("demo__resources_list-2");
+  });
 });

--- a/src/agents/agent-bundle-mcp-names.ts
+++ b/src/agents/agent-bundle-mcp-names.ts
@@ -88,3 +88,60 @@ export function buildSafeToolName(params: {
   }
   return candidate;
 }
+
+/** Reserve a precomputed projected name, falling back to normal collision handling when needed. */
+export function reserveProjectedMcpToolName(params: {
+  serverName: string;
+  toolName: string;
+  projectedName?: string;
+  reservedNames: Set<string>;
+}): string {
+  const projectedName = params.projectedName?.trim();
+  if (projectedName && !params.reservedNames.has(normalizeLowercaseStringOrEmpty(projectedName))) {
+    params.reservedNames.add(normalizeLowercaseStringOrEmpty(projectedName));
+    return projectedName;
+  }
+  const name = buildSafeToolName(params);
+  params.reservedNames.add(normalizeLowercaseStringOrEmpty(name));
+  return name;
+}
+
+/**
+ * Precompute the provider-safe names that an unfiltered MCP probe exposes.
+ * Tool filters can then accept the exact names operators copy from probe output.
+ */
+export function buildProjectedMcpToolNames(params: {
+  serverName: string;
+  toolNames: readonly string[];
+  utilityNames?: readonly string[];
+}): {
+  tools: ReadonlyMap<string, string>;
+  utilities: ReadonlyMap<string, string>;
+} {
+  const reservedNames = new Set<string>();
+  const tools = new Map<string, string>();
+  for (const toolName of [
+    ...new Set(params.toolNames.map((name) => name.trim()).filter(Boolean)),
+  ].toSorted((left, right) => left.localeCompare(right))) {
+    tools.set(
+      toolName,
+      reserveProjectedMcpToolName({
+        serverName: params.serverName,
+        toolName,
+        reservedNames,
+      }),
+    );
+  }
+  const utilities = new Map<string, string>();
+  for (const utilityName of params.utilityNames ?? []) {
+    utilities.set(
+      utilityName,
+      reserveProjectedMcpToolName({
+        serverName: params.serverName,
+        toolName: utilityName,
+        reservedNames,
+      }),
+    );
+  }
+  return { tools, utilities };
+}

--- a/src/agents/agent-bundle-mcp-names.ts
+++ b/src/agents/agent-bundle-mcp-names.ts
@@ -118,11 +118,13 @@ export function buildProjectedMcpToolNames(params: {
   tools: ReadonlyMap<string, string>;
   utilities: ReadonlyMap<string, string>;
 } {
-  const reservedNames = new Set<string>();
+  const toolNames = [...new Set(params.toolNames.map((name) => name.trim()).filter(Boolean))];
+  const utilityNames = [...new Set(params.utilityNames ?? [])];
+  // Raw names remain valid filter inputs. Reserve them before projection so a
+  // projected name can never identify a different raw tool or utility.
+  const reservedNames = normalizeReservedToolNames([...toolNames, ...utilityNames]);
   const tools = new Map<string, string>();
-  for (const toolName of [
-    ...new Set(params.toolNames.map((name) => name.trim()).filter(Boolean)),
-  ].toSorted((left, right) => left.localeCompare(right))) {
+  for (const toolName of toolNames.toSorted((left, right) => left.localeCompare(right))) {
     tools.set(
       toolName,
       reserveProjectedMcpToolName({
@@ -133,7 +135,7 @@ export function buildProjectedMcpToolNames(params: {
     );
   }
   const utilities = new Map<string, string>();
-  for (const utilityName of params.utilityNames ?? []) {
+  for (const utilityName of utilityNames) {
     utilities.set(
       utilityName,
       reserveProjectedMcpToolName({

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { getPluginToolMeta } from "../plugins/tools.js";
 import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
 import {
   completeDeferredSessionMcpRuntimeRetirement,
@@ -1344,6 +1345,74 @@ describe("session MCP runtime", () => {
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts exact projected probe names for sanitized collisions and utility tools", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-projected-tool-filter-");
+    const serverPath = path.join(tempDir, "projected-tool-filter.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    const sharedPrefix = "x".repeat(80);
+    const firstCollidingName = `${sharedPrefix}-a`;
+    const secondCollidingName = `${sharedPrefix}-b`;
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { tools: {}, resources: {} },
+      tools: [
+        { name: secondCollidingName, inputSchema: { type: "object", properties: {} } },
+        { name: "resources_list", inputSchema: { type: "object", properties: {} } },
+        { name: firstCollidingName, inputSchema: { type: "object", properties: {} } },
+      ],
+    });
+
+    const createRuntime = (include?: string[]) =>
+      createSessionMcpRuntime({
+        sessionId: include ? "session-projected-filter" : "session-projected-probe",
+        workspaceDir: tempDir,
+        cfg: {
+          mcp: {
+            servers: {
+              "duck:data": {
+                command: process.execPath,
+                args: [serverPath],
+                ...(include ? { toolFilter: { include } } : {}),
+              },
+            },
+          },
+        },
+      });
+
+    const probeRuntime = createRuntime();
+    const probeTools = await materializeBundleMcpToolsForRun({ runtime: probeRuntime });
+    const projectedCollisionName = expectDefined(
+      probeTools.tools.find(
+        (tool) => getPluginToolMeta(tool)?.mcp?.toolName === secondCollidingName,
+      )?.name,
+      "projected colliding tool name",
+    );
+    const projectedUtilityName = expectDefined(
+      probeTools.tools.find((tool) => getPluginToolMeta(tool)?.mcp?.operation === "resources_list")
+        ?.name,
+      "projected resource utility name",
+    );
+    await probeTools.dispose();
+    await probeRuntime.dispose();
+
+    const filteredRuntime = createRuntime([projectedCollisionName, projectedUtilityName]);
+    try {
+      const catalog = await filteredRuntime.getCatalog();
+      expect(catalog.tools.map((tool) => tool.toolName)).toEqual([secondCollidingName]);
+      expect(catalog.servers["duck:data"]?.toolCount).toBe(1);
+      expect(catalog.servers["duck:data"]?.tools?.filteredCount).toBe(2);
+
+      const filteredTools = await materializeBundleMcpToolsForRun({ runtime: filteredRuntime });
+      expect(filteredTools.tools.map((tool) => tool.name).toSorted()).toEqual(
+        [projectedCollisionName, projectedUtilityName].toSorted(),
+      );
+      await filteredTools.dispose();
+    } finally {
+      await filteredRuntime.dispose();
     }
   });
 

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1521,6 +1521,26 @@ describe("session MCP runtime", () => {
     } finally {
       await projectedFilterRuntime.dispose();
     }
+
+    const wildcardFilterRuntime = createRuntime("session-raw-wildcard-filter", ["demo__*"]);
+    try {
+      const catalog = await wildcardFilterRuntime.getCatalog();
+      expect(catalog.tools.map((tool) => tool.toolName).toSorted()).toEqual([
+        "demo__query",
+        "demo__resources_list",
+      ]);
+      expect(catalog.servers.demo?.toolCount).toBe(2);
+      expect(catalog.servers.demo?.tools?.filteredCount).toBe(1);
+      const materialized = await materializeBundleMcpToolsForRun({
+        runtime: wildcardFilterRuntime,
+      });
+      expect(materialized.tools.map((tool) => tool.name).toSorted()).toEqual(
+        [projectedRawCollisionName, projectedRawUtilityCollisionName].toSorted(),
+      );
+      await materialized.dispose();
+    } finally {
+      await wildcardFilterRuntime.dispose();
+    }
   });
 
   it("applies session tool denials to listed and synthetic MCP tools", async () => {

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1416,7 +1416,7 @@ describe("session MCP runtime", () => {
     }
   });
 
-  it("fails closed when an exact include identifies different raw and projected tools", async () => {
+  it("preserves exact raw filters while projected names avoid cross-tool collisions", async () => {
     const tempDir = tempDirTracker.make("bundle-mcp-ambiguous-tool-filter-");
     const serverPath = path.join(tempDir, "ambiguous-tool-filter.mjs");
     const logPath = path.join(tempDir, "server.log");
@@ -1434,36 +1434,92 @@ describe("session MCP runtime", () => {
       ],
     });
 
-    const runtime = createSessionMcpRuntime({
-      sessionId: "session-ambiguous-filter",
-      workspaceDir: tempDir,
-      cfg: {
-        mcp: {
-          servers: {
-            demo: {
-              command: process.execPath,
-              args: [serverPath],
-              toolFilter: { include: ["demo__query", "demo__resources_list"] },
+    const createRuntime = (sessionId: string, include?: string[]) =>
+      createSessionMcpRuntime({
+        sessionId,
+        workspaceDir: tempDir,
+        cfg: {
+          mcp: {
+            servers: {
+              demo: {
+                command: process.execPath,
+                args: [serverPath],
+                ...(include ? { toolFilter: { include } } : {}),
+              },
             },
           },
         },
-      },
-    });
+      });
+
+    const probeRuntime = createRuntime("session-collision-probe");
+    const probeTools = await materializeBundleMcpToolsForRun({ runtime: probeRuntime });
+    const projectedQueryName = expectDefined(
+      probeTools.tools.find((tool) => getPluginToolMeta(tool)?.mcp?.toolName === "query")?.name,
+      "projected query tool name",
+    );
+    const projectedRawCollisionName = expectDefined(
+      probeTools.tools.find((tool) => getPluginToolMeta(tool)?.mcp?.toolName === "demo__query")
+        ?.name,
+      "projected raw collision tool name",
+    );
+    const projectedRawUtilityCollisionName = expectDefined(
+      probeTools.tools.find(
+        (tool) => getPluginToolMeta(tool)?.mcp?.toolName === "demo__resources_list",
+      )?.name,
+      "projected raw utility collision tool name",
+    );
+    const projectedUtilityName = expectDefined(
+      probeTools.tools.find((tool) => getPluginToolMeta(tool)?.mcp?.operation === "resources_list")
+        ?.name,
+      "projected resource utility name",
+    );
+    expect(projectedQueryName).not.toBe("demo__query");
+    expect(projectedUtilityName).not.toBe("demo__resources_list");
+    await probeTools.dispose();
+    await probeRuntime.dispose();
+
+    const rawFilterRuntime = createRuntime("session-raw-collision-filter", [
+      "demo__query",
+      "demo__resources_list",
+    ]);
 
     try {
-      const catalog = await runtime.getCatalog();
-      expect(catalog.tools).toEqual([]);
-      expect(catalog.servers.demo?.toolCount).toBe(0);
-      expect(catalog.servers.demo?.tools?.filteredCount).toBe(3);
-      expect(catalog.servers.demo?.ambiguousToolFilterIncludes).toEqual([
+      const catalog = await rawFilterRuntime.getCatalog();
+      expect(catalog.tools.map((tool) => tool.toolName).toSorted()).toEqual([
         "demo__query",
         "demo__resources_list",
       ]);
-      const materialized = await materializeBundleMcpToolsForRun({ runtime });
-      expect(materialized.tools).toEqual([]);
+      expect(catalog.servers.demo?.toolCount).toBe(2);
+      expect(catalog.servers.demo?.tools?.filteredCount).toBe(1);
+      expect(catalog.servers.demo?.ambiguousToolFilterIncludes).toBeUndefined();
+      const materialized = await materializeBundleMcpToolsForRun({ runtime: rawFilterRuntime });
+      expect(materialized.tools.map((tool) => tool.name).toSorted()).toEqual(
+        [projectedRawCollisionName, projectedRawUtilityCollisionName].toSorted(),
+      );
       await materialized.dispose();
     } finally {
-      await runtime.dispose();
+      await rawFilterRuntime.dispose();
+    }
+
+    const projectedFilterRuntime = createRuntime("session-projected-collision-filter", [
+      projectedQueryName,
+      projectedUtilityName,
+    ]);
+    try {
+      const catalog = await projectedFilterRuntime.getCatalog();
+      expect(catalog.tools.map((tool) => tool.toolName)).toEqual(["query"]);
+      expect(catalog.servers.demo?.toolCount).toBe(1);
+      expect(catalog.servers.demo?.tools?.filteredCount).toBe(2);
+      expect(catalog.servers.demo?.ambiguousToolFilterIncludes).toBeUndefined();
+      const materialized = await materializeBundleMcpToolsForRun({
+        runtime: projectedFilterRuntime,
+      });
+      expect(materialized.tools.map((tool) => tool.name).toSorted()).toEqual(
+        [projectedQueryName, projectedUtilityName].toSorted(),
+      );
+      await materialized.dispose();
+    } finally {
+      await projectedFilterRuntime.dispose();
     }
   });
 

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1416,6 +1416,57 @@ describe("session MCP runtime", () => {
     }
   });
 
+  it("fails closed when an exact include identifies different raw and projected tools", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-ambiguous-tool-filter-");
+    const serverPath = path.join(tempDir, "ambiguous-tool-filter.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { tools: {}, resources: {} },
+      tools: [
+        { name: "query", inputSchema: { type: "object", properties: {} } },
+        { name: "demo__query", inputSchema: { type: "object", properties: {} } },
+        {
+          name: "demo__resources_list",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    });
+
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-ambiguous-filter",
+      workspaceDir: tempDir,
+      cfg: {
+        mcp: {
+          servers: {
+            demo: {
+              command: process.execPath,
+              args: [serverPath],
+              toolFilter: { include: ["demo__query", "demo__resources_list"] },
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools).toEqual([]);
+      expect(catalog.servers.demo?.toolCount).toBe(0);
+      expect(catalog.servers.demo?.tools?.filteredCount).toBe(3);
+      expect(catalog.servers.demo?.ambiguousToolFilterIncludes).toEqual([
+        "demo__query",
+        "demo__resources_list",
+      ]);
+      const materialized = await materializeBundleMcpToolsForRun({ runtime });
+      expect(materialized.tools).toEqual([]);
+      await materialized.dispose();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
   it("applies session tool denials to listed and synthetic MCP tools", async () => {
     const tempDir = tempDirTracker.make("bundle-mcp-session-deny-");
     const serverPath = path.join(tempDir, "session-deny.mjs");

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -21,7 +21,10 @@ import { redactToolPayloadText } from "../logging/redact.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { mergeMcpToolCatalogs } from "./agent-bundle-mcp-combined.js";
-import { matchesMcpToolFilterPattern } from "./agent-bundle-mcp-filter.js";
+import {
+  isMcpToolAllowedByFilter,
+  matchesAnyMcpToolFilterCandidate,
+} from "./agent-bundle-mcp-filter.js";
 import {
   completeDeferredSessionMcpRuntimeRetirement,
   disposeAllSessionMcpRuntimes,
@@ -38,7 +41,11 @@ import {
   createSessionMcpRuntimeManager,
   setDefaultCreateSessionMcpRuntime,
 } from "./agent-bundle-mcp-manager.js";
-import { assignSafeServerNames, sanitizeServerName } from "./agent-bundle-mcp-names.js";
+import {
+  assignSafeServerNames,
+  buildProjectedMcpToolNames,
+  sanitizeServerName,
+} from "./agent-bundle-mcp-names.js";
 import {
   loadSessionMcpConfig,
   resolveSessionMcpConfigSummary,
@@ -50,6 +57,7 @@ import type {
   McpServerCatalog,
   McpToolCatalog,
   McpToolCatalogDiagnostic,
+  McpUtilityToolOperation,
   SessionMcpRequesterScope,
   SessionMcpRuntime,
   SessionMcpRuntimeManager,
@@ -302,16 +310,15 @@ function getMcpToolSelection(rawServer: unknown): McpToolSelection {
   };
 }
 
-function shouldExposeMcpTool(selection: McpToolSelection, toolName: string): boolean {
-  const include = selection.include ?? [];
-  const exclude = selection.exclude ?? [];
-  if (
-    include.length > 0 &&
-    !include.some((pattern) => matchesMcpToolFilterPattern(pattern, toolName))
-  ) {
-    return false;
-  }
-  return !exclude.some((pattern) => matchesMcpToolFilterPattern(pattern, toolName));
+function shouldExposeMcpTool(
+  selection: McpToolSelection,
+  candidateNames: readonly string[],
+): boolean {
+  return isMcpToolAllowedByFilter({
+    include: selection.include,
+    exclude: selection.exclude,
+    candidateNames,
+  });
 }
 
 function summarizeServerCapabilities(capabilities: ServerCapabilities | undefined) {
@@ -828,12 +835,52 @@ export function createSessionMcpRuntime(params: {
                 });
                 failIfDisposed();
                 const selection = getMcpToolSelection(rawServer);
+                const utilityOperations: McpUtilityToolOperation[] = [
+                  ...(capabilities.resources
+                    ? (["resources_list", "resources_read"] as const)
+                    : []),
+                  ...(capabilities.prompts ? (["prompts_list", "prompts_get"] as const) : []),
+                ];
+                const rawToolNames = listedTools.map((tool) => tool.name.trim()).filter(Boolean);
+                const projectedNames = buildProjectedMcpToolNames({
+                  serverName: safeServerName,
+                  toolNames: rawToolNames,
+                  utilityNames: utilityOperations,
+                });
+                const candidateNamesForTool = (toolName: string): string[] => [
+                  toolName,
+                  ...(projectedNames.tools.get(toolName)
+                    ? [projectedNames.tools.get(toolName)!]
+                    : []),
+                ];
+                const includePatterns = selection.include ?? [];
+                const advertisedCandidateGroups = [
+                  ...rawToolNames.map(candidateNamesForTool),
+                  ...utilityOperations.map((operation) => [
+                    operation,
+                    ...(projectedNames.utilities.get(operation)
+                      ? [projectedNames.utilities.get(operation)!]
+                      : []),
+                  ]),
+                ];
+                if (
+                  includePatterns.length > 0 &&
+                  advertisedCandidateGroups.length > 0 &&
+                  !advertisedCandidateGroups.some((candidateNames) =>
+                    matchesAnyMcpToolFilterCandidate(includePatterns, candidateNames),
+                  )
+                ) {
+                  const sampleNames = advertisedCandidateGroups[0]!;
+                  logWarn(
+                    `bundle-mcp: server "${serverName}": toolFilter include matched 0 of ${advertisedCandidateGroups.length} advertised tool(s); the server will expose no tools. Filter names accept the raw form (for example "${sampleNames[0]}") or the projected form printed by mcp probe (for example "${sampleNames.at(-1)}").`,
+                  );
+                }
                 const denialMap = params.toolOverrides?.mcpToolsDeny;
                 const deniedToolNames = new Set(
                   denialMap && Object.hasOwn(denialMap, serverName) ? denialMap[serverName] : [],
                 );
                 const policyEligibleTools = listedTools.filter((tool) =>
-                  shouldExposeMcpTool(selection, tool.name.trim()),
+                  shouldExposeMcpTool(selection, candidateNamesForTool(tool.name.trim())),
                 );
                 const exposedTools = policyEligibleTools.filter((tool) => {
                   const toolName = tool.name.trim();
@@ -866,6 +913,13 @@ export function createSessionMcpRuntime(params: {
                         },
                       }
                     : {}),
+                  ...(projectedNames.utilities.size > 0
+                    ? {
+                        projectedUtilityToolNames: Object.fromEntries(
+                          projectedNames.utilities,
+                        ) as Partial<Record<McpUtilityToolOperation, string>>,
+                      }
+                    : {}),
                   ...(deniedToolNames.size > 0
                     ? { deniedToolNames: [...deniedToolNames].toSorted() }
                     : {}),
@@ -891,6 +945,9 @@ export function createSessionMcpRuntime(params: {
                     serverName,
                     safeServerName,
                     toolName,
+                    ...(projectedNames.tools.get(toolName)
+                      ? { projectedName: projectedNames.tools.get(toolName) }
+                      : {}),
                     title: tool.title,
                     description: sanitizeMcpMetadataText(tool.description),
                     inputSchema: tool.inputSchema,

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -22,6 +22,7 @@ import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { mergeMcpToolCatalogs } from "./agent-bundle-mcp-combined.js";
 import {
+  findAmbiguousExactMcpToolFilterPatterns,
   isMcpToolAllowedByFilter,
   matchesAnyMcpToolFilterCandidate,
 } from "./agent-bundle-mcp-filter.js";
@@ -313,11 +314,13 @@ function getMcpToolSelection(rawServer: unknown): McpToolSelection {
 function shouldExposeMcpTool(
   selection: McpToolSelection,
   candidateNames: readonly string[],
+  ambiguousIncludePatterns?: ReadonlySet<string>,
 ): boolean {
   return isMcpToolAllowedByFilter({
     include: selection.include,
     exclude: selection.exclude,
     candidateNames,
+    ambiguousIncludePatterns,
   });
 }
 
@@ -847,27 +850,35 @@ export function createSessionMcpRuntime(params: {
                   toolNames: rawToolNames,
                   utilityNames: utilityOperations,
                 });
-                const candidateNamesForTool = (toolName: string): string[] => [
-                  toolName,
-                  ...(projectedNames.tools.get(toolName)
-                    ? [projectedNames.tools.get(toolName)!]
-                    : []),
-                ];
+                const candidateNamesForTool = (toolName: string): string[] => {
+                  const projectedName = projectedNames.tools.get(toolName);
+                  return projectedName ? [toolName, projectedName] : [toolName];
+                };
                 const includePatterns = selection.include ?? [];
-                const advertisedCandidateGroups = [
-                  ...rawToolNames.map(candidateNamesForTool),
-                  ...utilityOperations.map((operation) => [
-                    operation,
-                    ...(projectedNames.utilities.get(operation)
-                      ? [projectedNames.utilities.get(operation)!]
-                      : []),
-                  ]),
-                ];
+                const advertisedCandidateGroups = rawToolNames.map(candidateNamesForTool);
+                for (const operation of utilityOperations) {
+                  const projectedName = projectedNames.utilities.get(operation);
+                  advertisedCandidateGroups.push(
+                    projectedName ? [operation, projectedName] : [operation],
+                  );
+                }
+                const ambiguousIncludePatterns = findAmbiguousExactMcpToolFilterPatterns({
+                  patterns: includePatterns,
+                  candidateGroups: advertisedCandidateGroups,
+                });
+                if (ambiguousIncludePatterns.size > 0) {
+                  logWarn(
+                    `bundle-mcp: server "${serverName}": toolFilter exact include name(s) ${JSON.stringify([...ambiguousIncludePatterns].toSorted())} matched multiple advertised tools and were ignored to keep the allowlist fail-closed; use an unambiguous raw or projected name.`,
+                  );
+                }
+                const effectiveIncludePatterns = includePatterns.filter(
+                  (pattern) => !ambiguousIncludePatterns.has(pattern.trim()),
+                );
                 if (
                   includePatterns.length > 0 &&
                   advertisedCandidateGroups.length > 0 &&
                   !advertisedCandidateGroups.some((candidateNames) =>
-                    matchesAnyMcpToolFilterCandidate(includePatterns, candidateNames),
+                    matchesAnyMcpToolFilterCandidate(effectiveIncludePatterns, candidateNames),
                   )
                 ) {
                   const sampleNames = advertisedCandidateGroups[0]!;
@@ -880,7 +891,11 @@ export function createSessionMcpRuntime(params: {
                   denialMap && Object.hasOwn(denialMap, serverName) ? denialMap[serverName] : [],
                 );
                 const policyEligibleTools = listedTools.filter((tool) =>
-                  shouldExposeMcpTool(selection, candidateNamesForTool(tool.name.trim())),
+                  shouldExposeMcpTool(
+                    selection,
+                    candidateNamesForTool(tool.name.trim()),
+                    ambiguousIncludePatterns,
+                  ),
                 );
                 const exposedTools = policyEligibleTools.filter((tool) => {
                   const toolName = tool.name.trim();
@@ -918,6 +933,11 @@ export function createSessionMcpRuntime(params: {
                         projectedUtilityToolNames: Object.fromEntries(
                           projectedNames.utilities,
                         ) as Partial<Record<McpUtilityToolOperation, string>>,
+                      }
+                    : {}),
+                  ...(ambiguousIncludePatterns.size > 0
+                    ? {
+                        ambiguousToolFilterIncludes: [...ambiguousIncludePatterns].toSorted(),
                       }
                     : {}),
                   ...(deniedToolNames.size > 0

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -50,6 +50,8 @@ export type McpServerCatalog = {
   };
   /** Provider-safe utility names assigned before filtering, matching `mcp probe` output. */
   projectedUtilityToolNames?: Partial<Record<McpUtilityToolOperation, string>>;
+  /** Exact includes ignored because they identify multiple advertised tools. */
+  ambiguousToolFilterIncludes?: string[];
   deniedToolNames?: string[];
 };
 

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -10,6 +10,12 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
+export type McpUtilityToolOperation =
+  | "resources_list"
+  | "resources_read"
+  | "prompts_list"
+  | "prompts_get";
+
 /** Materialized MCP tools plus diagnostics and cleanup handle for one run. */
 export type BundleMcpToolRuntime = {
   tools: AnyAgentTool[];
@@ -42,6 +48,8 @@ export type McpServerCatalog = {
     include?: string[];
     exclude?: string[];
   };
+  /** Provider-safe utility names assigned before filtering, matching `mcp probe` output. */
+  projectedUtilityToolNames?: Partial<Record<McpUtilityToolOperation, string>>;
   deniedToolNames?: string[];
 };
 
@@ -50,6 +58,8 @@ export type McpCatalogTool = {
   serverName: string;
   safeServerName: string;
   toolName: string;
+  /** Provider-safe name assigned before filtering, matching `mcp probe` output. */
+  projectedName?: string;
   title?: string;
   description?: string;
   inputSchema: TSchema;

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -1024,6 +1024,35 @@ describe("mcp cli", () => {
     });
   });
 
+  it.each([
+    { firstEnabled: true, expectedTool: "duck-data-2__ping" },
+    { firstEnabled: false, expectedTool: "duck-data__ping" },
+  ])(
+    "preserves full-runtime safe server names in a named probe (first collider enabled: $firstEnabled)",
+    async ({ firstEnabled, expectedTool }) => {
+      await withTempHome("openclaw-cli-mcp-home-", async () => {
+        const workspaceDir = await createWorkspace();
+        const serverPath = path.join(workspaceDir, "probe-server.mjs");
+        await writeProbeMcpServer(serverPath);
+        vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+        const server = { command: process.execPath, args: [serverPath] };
+
+        await runMcpCommand([
+          "mcp",
+          "set",
+          "duck:data",
+          JSON.stringify({ ...server, enabled: firstEnabled }),
+        ]);
+        await runMcpCommand(["mcp", "set", "duck-data", JSON.stringify(server)]);
+
+        mockLog.mockClear();
+        await runMcpCommand(["mcp", "probe", "duck-data", "--json"]);
+
+        expect(JSON.parse(lastLogLine()).tools).toEqual([expectedTool]);
+      });
+    },
+  );
+
   it("fails when removing an unknown MCP server", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async (home) => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -11,6 +11,8 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { Command } from "commander";
 import { buildBundleMcpToolsFromCatalog } from "../agents/agent-bundle-mcp-materialize.js";
+import { assignSafeServerNames } from "../agents/agent-bundle-mcp-names.js";
+import { loadSessionMcpConfig } from "../agents/agent-bundle-mcp-runtime-config.js";
 import { createSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
 import {
   buildMcpHttpFetch,
@@ -415,14 +417,10 @@ async function probeMcpServerIssue(params: {
   name: string;
   server: Record<string, unknown>;
 }): Promise<McpDoctorIssue | null> {
-  const runtime = createSessionMcpRuntime({
+  const runtime = createMcpProbeRuntime({
     sessionId: "openclaw-cli-mcp-doctor",
-    workspaceDir: process.cwd(),
-    cfg: buildMcpProbeConfig({
-      config: params.config,
-      servers: { [params.name]: params.server },
-    }),
-    manifestRegistry: { plugins: [] },
+    config: params.config,
+    servers: { [params.name]: params.server },
   });
   try {
     const result = formatMcpProbeResult(await runtime.getCatalog());
@@ -543,6 +541,28 @@ function buildMcpProbeConfig(params: {
   };
 }
 
+function createMcpProbeRuntime(params: {
+  sessionId: string;
+  config: OpenClawConfig;
+  servers: Record<string, Record<string, unknown>>;
+}) {
+  const workspaceDir = process.cwd();
+  const manifestRegistry = { plugins: [] };
+  const fullConfig = loadSessionMcpConfig({
+    workspaceDir,
+    cfg: params.config,
+    manifestRegistry,
+    logDiagnostics: false,
+  });
+  return createSessionMcpRuntime({
+    sessionId: params.sessionId,
+    workspaceDir,
+    cfg: buildMcpProbeConfig({ config: params.config, servers: params.servers }),
+    manifestRegistry,
+    safeServerNamesByServer: assignSafeServerNames(Object.keys(fullConfig.loaded.mcpServers)),
+  });
+}
+
 const DEFAULT_MCP_PROBE_INITIALIZE_TIMEOUT_MS = 5_000;
 
 function applyMcpProbeInitializeTimeout(server: Record<string, unknown>): Record<string, unknown> {
@@ -594,11 +614,10 @@ async function probeMcpServersOrFail(params: {
       applyMcpProbeInitializeTimeout(server),
     ]),
   );
-  const runtime = createSessionMcpRuntime({
+  const runtime = createMcpProbeRuntime({
     sessionId: "openclaw-cli-mcp-probe",
-    workspaceDir: process.cwd(),
-    cfg: buildMcpProbeConfig({ config: params.config, servers: probeServers }),
-    manifestRegistry: { plugins: [] },
+    config: params.config,
+    servers: probeServers,
   });
   try {
     const result = formatMcpProbeResult(await runtime.getCatalog());
@@ -789,11 +808,10 @@ export function registerMcpCli(program: Command) {
           `MCP server "${name}" is disabled in ${loaded.path}. Run ${formatCliCommand(`openclaw mcp configure ${name} --enable`)} before probing it.`,
         );
       }
-      const runtime = createSessionMcpRuntime({
+      const runtime = createMcpProbeRuntime({
         sessionId: "openclaw-cli-mcp-probe",
-        workspaceDir: process.cwd(),
-        cfg: buildMcpProbeConfig({ config: loaded.config, servers }),
-        manifestRegistry: { plugins: [] },
+        config: loaded.config,
+        servers,
       });
       try {
         const result = formatMcpProbeResult(await runtime.getCatalog());

--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -216,11 +216,11 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
   "mcp.servers.*.codex":
     "OpenClaw projection metadata for Codex app-server threads only. It does not affect ACP sessions or generic Codex harness config. Omit this block to keep the server available to every Codex app-server agent with Codex's default MCP approval behavior.",
   "mcp.servers.*.toolFilter":
-    "Per-server MCP tool selection. Use include to expose only selected MCP tools, or exclude to hide selected MCP tools. Entries accept raw MCP names or exact projected names printed by 'openclaw mcp probe', with simple '*' globs supported for either.",
+    "Per-server MCP tool selection. Use include to expose only selected MCP tools, or exclude to hide selected MCP tools. Entries accept raw MCP names and simple '*' globs, or exact projected names printed by 'openclaw mcp probe'.",
   "mcp.servers.*.toolFilter.include":
-    "Raw MCP tool names, exact projected names printed by 'openclaw mcp probe', or simple '*' globs to expose from this server. When omitted, all server tools remain eligible unless excluded.",
+    "Raw MCP tool names and simple '*' globs, or exact projected names printed by 'openclaw mcp probe', to expose from this server. Globs match raw names only. When omitted, all server tools remain eligible unless excluded.",
   "mcp.servers.*.toolFilter.exclude":
-    "Raw MCP tool names, exact projected names printed by 'openclaw mcp probe', or simple '*' globs to hide from this server.",
+    "Raw MCP tool names and simple '*' globs, or exact projected names printed by 'openclaw mcp probe', to hide from this server. Globs match raw names only.",
   "mcp.servers.*.oauth.authProfileId":
     "Refresh-capable auth profile id used to inject the current bearer token into this remote MCP server. When set, OpenClaw resolves and refreshes the profile at runtime and does not project refresh material downstream.",
   "mcp.servers.*.codex.agents":

--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -216,11 +216,11 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
   "mcp.servers.*.codex":
     "OpenClaw projection metadata for Codex app-server threads only. It does not affect ACP sessions or generic Codex harness config. Omit this block to keep the server available to every Codex app-server agent with Codex's default MCP approval behavior.",
   "mcp.servers.*.toolFilter":
-    "Per-server MCP tool selection. Use include to expose only selected MCP tool names, or exclude to hide selected MCP tool names. Entries accept exact names and simple '*' globs.",
+    "Per-server MCP tool selection. Use include to expose only selected MCP tools, or exclude to hide selected MCP tools. Entries accept raw MCP names or exact projected names printed by 'openclaw mcp probe', with simple '*' globs supported for either.",
   "mcp.servers.*.toolFilter.include":
-    "Exact MCP tool names or simple '*' globs to expose from this server. When omitted, all server tools remain eligible unless excluded.",
+    "Raw MCP tool names, exact projected names printed by 'openclaw mcp probe', or simple '*' globs to expose from this server. When omitted, all server tools remain eligible unless excluded.",
   "mcp.servers.*.toolFilter.exclude":
-    "Exact MCP tool names or simple '*' globs to hide from this server.",
+    "Raw MCP tool names, exact projected names printed by 'openclaw mcp probe', or simple '*' globs to hide from this server.",
   "mcp.servers.*.oauth.authProfileId":
     "Refresh-capable auth profile id used to inject the current bearer token into this remote MCP server. When set, OpenClaw resolves and refreshes the profile at runtime and does not project refresh material downstream.",
   "mcp.servers.*.codex.agents":


### PR DESCRIPTION
Closes #98193

## What Problem This Solves

Fixes an issue where users who copied names from `openclaw mcp probe` into a per-server `toolFilter.include` or `toolFilter.exclude` could silently lose every tool from that server.

## Why This Change Was Made

The MCP runtime now computes the same provider-safe projected names that probe and materialization expose, accepts exact filters against both raw and projected names, and preserves raw-only matching for existing wildcard filters. Raw tool and synthetic utility names are reserved before projection, which keeps existing exact raw filters compatible while ensuring copied projected names identify only their intended tool. Residual exact include ambiguities fail closed, and single-server probes preserve the full runtime server-name assignment. The runtime also warns when a non-empty include filter matches no advertised tool and documents the accepted forms in the CLI, configuration reference, and schema help.

## User Impact

Operators can use raw MCP names and raw-name `*` globs, or the exact names printed by `mcp probe`, including sanitized, truncated, collision-suffixed, resource, and prompt utility names. Existing raw-name exact and wildcard filters continue to work unchanged. Projected names are disambiguated away from advertised raw names instead of changing a stored raw allowlist's meaning.

## Evidence

- [Exact-head raw-wildcard compatibility proof](https://github.com/openclaw/openclaw/pull/116872#issuecomment-5145684858) on `a33b2d60b2`: with raw `query` and `demo__query`, the real CLI and production materializer show that `include: ["demo__*"]` selects only raw `demo__query`; raw `query` is not admitted through projected `demo__query-2`.
- [Exact-head compatibility and live MCP stdio proof](https://github.com/openclaw/openclaw/pull/116872#issuecomment-5145487638) on `a487221b1e`: the real CLI and production materializer show that exact raw `demo__query` still selects raw `demo__query`, while the probe emits distinct `demo__query-2` for raw `query` and that copied projected include selects only `query`.
- [Earlier live MCP stdio behavior proof](https://github.com/openclaw/openclaw/pull/116872#issuecomment-5145147404) on `2283525c20`: the real CLI preserves server-name collision suffixes and a copied projected include exposes only the intended raw tool.
- `pnpm vitest run src/agents/agent-bundle-mcp-filter.test.ts src/agents/agent-bundle-mcp-names.test.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts src/agents/agent-bundle-mcp-runtime.test.ts` — initial focused suite: 5 test files, 215 tests passed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-names.test.ts` — 7 tests passed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-filter.test.ts` — 10 tests passed, including raw-only wildcard and exact projected include/exclude coverage.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts -t 'preserves exact raw filters while projected names avoid cross-tool collisions'` — 2 focused tests passed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-tools.materialize.test.ts` — 19 tests passed.
- `node scripts/run-vitest.mjs src/cli/mcp-cli.test.ts -t 'preserves full-runtime safe server names'` — 2 focused tests passed, covering enabled and disabled colliders.
- Targeted `oxfmt --threads=1`, `oxlint --threads=1 --deny-warnings`, and `git diff --check` passed.
- `pnpm format:docs:check` — 748 documentation files clean.
- Direct read-only Grok 4.5 reviews of the exact-name and wildcard compatibility follow-ups both returned `CLEAN`.
- Full-repository tests and typecheck were not run locally because of workstation resource limits; CI remains the broader validation gate.

## AI Assistance

AI-assisted: Codex was used for issue triage, implementation, and focused validation. Grok 4.5 performed the independent pre-PR and compatibility reviews described above.
